### PR TITLE
fix: register all datasource dual write modes based on single config section

### DIFF
--- a/pkg/registry/apis/datasource/register.go
+++ b/pkg/registry/apis/datasource/register.go
@@ -28,6 +28,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/apiserver/builder"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/unified/apistore"
 	"github.com/grafana/grafana/pkg/tsdb/grafana-testdata-datasource/kinds"
 )
@@ -258,6 +259,7 @@ func (b *DataSourceAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver
 	}
 
 	if b.cfg.UseDualWriter {
+		b.applyDefaultStorageConfig(opts, ds)
 		legacyStore := &legacyStorage{
 			datasources:                     b.datasources,
 			resourceInfo:                    &ds,
@@ -298,6 +300,30 @@ func (b *DataSourceAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver
 
 	apiGroupInfo.VersionedResourcesStorageMap[ds.GroupVersion().Version] = storage
 	return err
+}
+
+// applyDefaultStorageConfig injects a unified storage config entry for this plugin's
+// datasource resource when no plugin-specific config exists, copying from the shared
+// "all datasources" key (setting.DataSourceResources). This allows operators to set a
+// single DualWriter mode for every datasource plugin via:
+//
+//	[unified_storage.datasources.datasource.grafana.app]
+//	dualWriterMode = 1
+func (b *DataSourceAPIBuilder) applyDefaultStorageConfig(opts builder.APIGroupOptions, ri utils.ResourceInfo) {
+	if opts.StorageOpts == nil {
+		return
+	}
+	key := ri.GroupResource().String()
+	if _, exists := opts.StorageOpts.UnifiedStorageConfig[key]; exists {
+		return
+	}
+	fallback, hasFallback := opts.StorageOpts.UnifiedStorageConfig[setting.DataSourceResources]
+	if !hasFallback {
+		return
+	}
+	opts.StorageOpts.UnifiedStorageConfig[key] = setting.UnifiedStorageConfig{
+		DualWriterMode: fallback.DualWriterMode,
+	}
 }
 
 func (b *DataSourceAPIBuilder) getPluginContext(ctx context.Context, uid string) (backend.PluginContext, error) {

--- a/pkg/registry/apis/datasource/register_test.go
+++ b/pkg/registry/apis/datasource/register_test.go
@@ -1,0 +1,94 @@
+package datasource
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	datasourceV0 "github.com/grafana/grafana/pkg/apis/datasource/v0alpha1"
+	"github.com/grafana/grafana/pkg/apiserver/rest"
+	"github.com/grafana/grafana/pkg/services/apiserver/builder"
+	"github.com/grafana/grafana/pkg/services/apiserver/options"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+func TestApplyDefaultStorageConfig(t *testing.T) {
+	newRI := func(pluginID string) utils.ResourceInfo {
+		return datasourceV0.DataSourceResourceInfo.WithGroupAndShortName(
+			pluginID+".datasource.grafana.app", pluginID,
+		)
+	}
+
+	t.Run("no-op when StorageOpts is nil", func(t *testing.T) {
+		b := &DataSourceAPIBuilder{}
+		opts := builder.APIGroupOptions{StorageOpts: nil}
+		b.applyDefaultStorageConfig(opts, newRI("testdata"))
+	})
+
+	t.Run("no-op when no fallback and no specific config", func(t *testing.T) {
+		b := &DataSourceAPIBuilder{}
+		storageOpts := &options.StorageOptions{
+			UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{},
+		}
+		opts := builder.APIGroupOptions{StorageOpts: storageOpts}
+
+		b.applyDefaultStorageConfig(opts, newRI("testdata"))
+
+		_, exists := storageOpts.UnifiedStorageConfig["datasources.testdata.datasource.grafana.app"]
+		require.False(t, exists)
+	})
+
+	t.Run("fallback is applied when no specific config exists", func(t *testing.T) {
+		b := &DataSourceAPIBuilder{}
+		storageOpts := &options.StorageOptions{
+			UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
+				setting.DataSourceResources: {DualWriterMode: rest.Mode1},
+			},
+		}
+		opts := builder.APIGroupOptions{StorageOpts: storageOpts}
+
+		b.applyDefaultStorageConfig(opts, newRI("testdata"))
+
+		cfg, exists := storageOpts.UnifiedStorageConfig["datasources.testdata.datasource.grafana.app"]
+		require.True(t, exists)
+		require.Equal(t, rest.Mode1, cfg.DualWriterMode)
+	})
+
+	t.Run("specific config takes precedence over fallback", func(t *testing.T) {
+		b := &DataSourceAPIBuilder{}
+		storageOpts := &options.StorageOptions{
+			UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
+				setting.DataSourceResources: {DualWriterMode: rest.Mode1},
+				"datasources.testdata.datasource.grafana.app": {DualWriterMode: rest.Mode4},
+			},
+		}
+		opts := builder.APIGroupOptions{StorageOpts: storageOpts}
+
+		b.applyDefaultStorageConfig(opts, newRI("testdata"))
+
+		cfg := storageOpts.UnifiedStorageConfig["datasources.testdata.datasource.grafana.app"]
+		require.Equal(t, rest.Mode4, cfg.DualWriterMode)
+	})
+
+	t.Run("fallback applies independently per plugin", func(t *testing.T) {
+		storageOpts := &options.StorageOptions{
+			UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
+				setting.DataSourceResources: {DualWriterMode: rest.Mode1},
+			},
+		}
+		opts := builder.APIGroupOptions{StorageOpts: storageOpts}
+
+		for _, pluginID := range []string{"testdata", "prometheus", "loki"} {
+			b := &DataSourceAPIBuilder{}
+			b.applyDefaultStorageConfig(opts, newRI(pluginID))
+		}
+
+		for _, pluginID := range []string{"testdata", "prometheus", "loki"} {
+			key := "datasources." + pluginID + ".datasource.grafana.app"
+			cfg, exists := storageOpts.UnifiedStorageConfig[key]
+			require.True(t, exists, "expected config for %s", pluginID)
+			require.Equal(t, rest.Mode1, cfg.DualWriterMode)
+		}
+	})
+}

--- a/pkg/registry/apis/datasource/register_test.go
+++ b/pkg/registry/apis/datasource/register_test.go
@@ -59,7 +59,7 @@ func TestApplyDefaultStorageConfig(t *testing.T) {
 		b := &DataSourceAPIBuilder{}
 		storageOpts := &options.StorageOptions{
 			UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
-				setting.DataSourceResources: {DualWriterMode: rest.Mode1},
+				setting.DataSourceResources:                   {DualWriterMode: rest.Mode1},
 				"datasources.testdata.datasource.grafana.app": {DualWriterMode: rest.Mode4},
 			},
 		}


### PR DESCRIPTION
We need specific handling for the datasource resource when it comes to dual writer mode management:

- We need to have a single config section handling all datasource groups/apis.
- We **can not** have a `*` in the config section due to the mt settings service constraint in cloud.

Thus, I suggested the `unified_storage.datasources.datasource.grafana.app` section in order to manage all datasource apis (for dual write modes). But, we need to handle this particular case when we register the datasource apis.

`http://localhost:3000/metrics`:
```ini
# HELP grafana_unified_storage_dual_writer_current_mode Unified storage dual writer current mode
# TYPE grafana_unified_storage_dual_writer_current_mode gauge
grafana_unified_storage_dual_writer_current_mode{group="alertmanager.datasource.grafana.app",resource="datasources"} 1
grafana_unified_storage_dual_writer_current_mode{group="cloudwatch.datasource.grafana.app",resource="datasources"} 1
grafana_unified_storage_dual_writer_current_mode{group="correlations.grafana.app",resource="correlations"} 1
grafana_unified_storage_dual_writer_current_mode{group="dashboard.datasource.grafana.app",resource="datasources"} 1
grafana_unified_storage_dual_writer_current_mode{group="elasticsearch.datasource.grafana.app",resource="datasources"} 1
grafana_unified_storage_dual_writer_current_mode{group="grafana-azure-monitor-datasource.datasource.grafana.app",resource="datasources"} 1
grafana_unified_storage_dual_writer_current_mode{group="grafana-postgresql-datasource.datasource.grafana.app",resource="datasources"} 1
grafana_unified_storage_dual_writer_current_mode{group="grafana-pyroscope-datasource.datasource.grafana.app",resource="datasources"} 1
grafana_unified_storage_dual_writer_current_mode{group="grafana-testdata-datasource.datasource.grafana.app",resource="datasources"} 1
grafana_unified_storage_dual_writer_current_mode{group="grafana.datasource.grafana.app",resource="datasources"} 1
grafana_unified_storage_dual_writer_current_mode{group="graphite.datasource.grafana.app",resource="datasources"} 1
grafana_unified_storage_dual_writer_current_mode{group="influxdb.datasource.grafana.app",resource="datasources"} 1
grafana_unified_storage_dual_writer_current_mode{group="jaeger.datasource.grafana.app",resource="datasources"} 1
grafana_unified_storage_dual_writer_current_mode{group="loki.datasource.grafana.app",resource="datasources"} 1
grafana_unified_storage_dual_writer_current_mode{group="mixed.datasource.grafana.app",resource="datasources"} 1
grafana_unified_storage_dual_writer_current_mode{group="mssql.datasource.grafana.app",resource="datasources"} 1
grafana_unified_storage_dual_writer_current_mode{group="mysql.datasource.grafana.app",resource="datasources"} 1
grafana_unified_storage_dual_writer_current_mode{group="opentsdb.datasource.grafana.app",resource="datasources"} 1
grafana_unified_storage_dual_writer_current_mode{group="parca.datasource.grafana.app",resource="datasources"} 1
grafana_unified_storage_dual_writer_current_mode{group="prometheus.datasource.grafana.app",resource="datasources"} 1
grafana_unified_storage_dual_writer_current_mode{group="shorturl.grafana.app",resource="shorturls"} 5
grafana_unified_storage_dual_writer_current_mode{group="stackdriver.datasource.grafana.app",resource="datasources"} 1
grafana_unified_storage_dual_writer_current_mode{group="tempo.datasource.grafana.app",resource="datasources"} 1
grafana_unified_storage_dual_writer_current_mode{group="zipkin.datasource.grafana.app",resource="datasources"} 1
```