### PR TITLE
Explore: Fix link between `Content outline` button and section

### DIFF
--- a/e2e-playwright/smoke-tests-suite/accessibility.spec.ts
+++ b/e2e-playwright/smoke-tests-suite/accessibility.spec.ts
@@ -22,6 +22,7 @@ test.describe(
         // Misc
         { url: '/?orgId=1' },
         { url: '/dashboards', ignoredRules: ['label'] },
+        { url: '/explore' },
         { url: '/d/O6f11TZWk/panel-tests-bar-gauge' },
         { url: '/alerting/list', ignoredRules: ['button-name', 'aria-required-parent'] },
 

--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -216,7 +216,7 @@ export function ExploreToolbar({ exploreId, onChangeTime, onContentOutlineToogle
             iconOnly={splitted}
             onClick={onContentOutlineToogle}
             aria-expanded={isContentOutlineOpen}
-            aria-controls={isContentOutlineOpen ? 'content-outline-container' : undefined}
+            aria-controls={isContentOutlineOpen ? `content-outline-container-${exploreId}` : undefined}
             className={styles.toolbarButton}
           >
             <Trans i18nKey="explore.explore-toolbar.outline">Outline</Trans>


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- uses the correct id for the `aria-owns` attribute on the `Content outline` button
- this properly links the relevant section to the button for screenreaders
- also adds the `/explore` route to the playwright accessibility tests to prevent regressions in the future

**Why do we need this feature?**

- better a11y

**Who is this feature for?**

- everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana/issues/118762

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
