### PR TITLE
fix: links within docs 

### DIFF
--- a/docs/sources/administration/roles-and-permissions/access-control/_index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/_index.md
@@ -103,7 +103,7 @@ refs:
 # Role-based access control (RBAC) overview
 
 {{< admonition type="note" >}}
-Available in [Grafana Enterprise](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/introduction/grafana-enterprise/) and [Grafana Cloud](https://grafana.com//docs/grafana-cloud).
+Available in [Grafana Enterprise](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/introduction/grafana-enterprise/) and [Grafana Cloud](https://grafana.com/docs/grafana-cloud).
 {{< /admonition >}}
 
 Role-based access control (RBAC) provides a standardized way of granting, changing, and revoking access so that users can view and modify Grafana resources such as dashboards, reports, and administrative settings. RBAC extends the permissions of basic roles included in Grafana OSS, and enables more granular control of users’ actions.

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -21,7 +21,7 @@ Grafana has default and custom configuration files.
 
 You can customize your Grafana instance by modifying the custom configuration file or by using environment variables.
 
-- To see the list of settings for a Grafana instance, refer to [View server settings](https://grafana.com//docs/grafana/<GRAFANA_VERSION>/administration/stats-and-license#view-server-settings).
+- To see the list of settings for a Grafana instance, refer to [View server settings](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/stats-and-license#view-server-settings).
 - After you add custom options, [uncomment](#remove-comments-in-the-ini-files) the relevant sections of the configuration file and restart Grafana for your changes to take effect.
 
 {{< admonition type="note" >}}


### PR DESCRIPTION
I removed the PR template fields since they're not really related to this simple docs change.

I came across it [here](https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/#customize-your-grafana-instance) (click "View Server Settings")

I checked and [these](https://github.com/search?q=repo%3Agrafana%2Fgrafana%20%22https%3A%2F%2Fgrafana.com%2F%2Fdocs%22&type=code) are the only two occurrences:

<img width="1041" height="325" alt="image" src="https://github.com/user-attachments/assets/a9981a0d-8e1f-469f-b719-79f2cd2e6e53" />

 Perhaps something a linter could catch automatically in the future.

https://grafana.com//docs/grafana-cloud resolves fine as its own URL, but when the HTML maps it to a local path `//docs/grafana-cloud` it does not open properly:

<img width="1492" height="649" alt="image" src="https://github.com/user-attachments/assets/20385fdd-9d41-4e2b-9c7f-f77e4b3dc2da" />
