### PR TITLE
Dashboards: Show v2 changes for provisioned save modal

### DIFF
--- a/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.tsx
@@ -20,11 +20,11 @@ import {
 import { QueryOperationRow } from 'app/core/components/QueryOperationRow/QueryOperationRow';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
 import { ExportFormat } from 'app/features/dashboard/api/types';
+import { isDashboardV2Spec } from 'app/features/dashboard/api/utils';
 
 import { type DashboardScene } from '../scene/DashboardScene';
 import { convertSpecToWireFormat } from '../serialization/transformationCompat';
 
-import { isDashboardV2Spec } from './DetectChangesWorker';
 import { type SaveDashboardDrawer } from './SaveDashboardDrawer';
 import { SaveDashboardFormCommonOptions } from './SaveDashboardForm';
 import { type DashboardChangeInfo } from './shared';

--- a/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.tsx
+++ b/public/app/features/dashboard-scene/saving/SaveProvisionedDashboardForm.tsx
@@ -22,7 +22,9 @@ import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
 import { ExportFormat } from 'app/features/dashboard/api/types';
 
 import { type DashboardScene } from '../scene/DashboardScene';
+import { convertSpecToWireFormat } from '../serialization/transformationCompat';
 
+import { isDashboardV2Spec } from './DetectChangesWorker';
 import { type SaveDashboardDrawer } from './SaveDashboardDrawer';
 import { SaveDashboardFormCommonOptions } from './SaveDashboardForm';
 import { type DashboardChangeInfo } from './shared';
@@ -40,7 +42,8 @@ export function SaveProvisionedDashboardForm({ dashboard, drawer, changeInfo }: 
   );
   const uid = dashboard.state.uid;
 
-  const classicJson = useMemo(() => JSON.stringify(changeInfo.changedSaveModel, null, 2), [changeInfo]);
+  const { changedSaveModel } = changeInfo;
+  const classicJson = useMemo(() => JSON.stringify(changedSaveModel, null, 2), [changedSaveModel]);
 
   const k8sResource = useAsync(async () => {
     if (exportFormat !== ExportFormat.V2Resource || !uid) {
@@ -48,17 +51,21 @@ export function SaveProvisionedDashboardForm({ dashboard, drawer, changeInfo }: 
     }
     const api = await getDashboardAPI('v2');
     const resource = await api.getDashboardDTO(uid);
+
+    // if the local edits are already in v2 form, reflect them in the displayed resource
+    const spec = isDashboardV2Spec(changedSaveModel) ? convertSpecToWireFormat(changedSaveModel) : resource.spec;
+
     return JSON.stringify(
       {
         apiVersion: resource.apiVersion,
         kind: 'Dashboard',
         metadata: omit(resource.metadata, 'managedFields'),
-        spec: resource.spec,
+        spec,
       },
       null,
       2
     );
-  }, [exportFormat, uid]);
+  }, [exportFormat, uid, changedSaveModel]);
 
   const isK8sMode = exportFormat === ExportFormat.V2Resource && hasK8sMeta;
   const displayJson = isK8sMode ? (k8sResource.value ?? '') : classicJson;


### PR DESCRIPTION
This PR fixes https://github.com/grafana/grafana/issues/123132 - and ensures the v2 changes propagate to the save modal in the provisioned dashboard save
