### PR TITLE
Alerting: Fix race condition in time interval Create/Update operations

### DIFF
--- a/pkg/services/ngalert/provisioning/mute_timings.go
+++ b/pkg/services/ngalert/provisioning/mute_timings.go
@@ -263,7 +263,7 @@ func (svc *MuteTimingService) UpdateMuteTiming(ctx context.Context, mt definitio
 		} else {
 			updateTimeInterval(revision, mt.MuteTimeInterval)
 		}
-		
+
 		// Verify the time interval appears exactly once in the config before saving
 		count := 0
 		for _, ti := range revision.Config.AlertmanagerConfig.MuteTimeIntervals {
@@ -279,7 +279,7 @@ func (svc *MuteTimingService) UpdateMuteTiming(ctx context.Context, mt definitio
 		if count != 1 {
 			return fmt.Errorf("expected time interval %q to appear exactly once after update, but found %d occurrences", mt.Name, count)
 		}
-		
+
 		if err := svc.configStore.Save(ctx, revision, orgID); err != nil {
 			return err
 		}

--- a/pkg/services/ngalert/provisioning/mute_timings.go
+++ b/pkg/services/ngalert/provisioning/mute_timings.go
@@ -175,18 +175,18 @@ func (svc *MuteTimingService) CreateMuteTiming(ctx context.Context, mt definitio
 		return definitions.MuteTimeInterval{}, err
 	}
 
-	revision, err := svc.configStore.Get(ctx, orgID)
-	if err != nil {
-		return definitions.MuteTimeInterval{}, err
-	}
+	err := svc.xact.InTransaction(ctx, func(ctx context.Context) error {
+		revision, err := svc.configStore.Get(ctx, orgID)
+		if err != nil {
+			return err
+		}
 
-	if grafanaTimeIntervalExists(revision, mt.Name) {
-		return definitions.MuteTimeInterval{}, ErrTimeIntervalExists.Errorf("")
-	}
+		if grafanaTimeIntervalExists(revision, mt.Name) {
+			return ErrTimeIntervalExists.Errorf("")
+		}
 
-	revision.Config.AlertmanagerConfig.TimeIntervals = append(revision.Config.AlertmanagerConfig.TimeIntervals, definitions.TimeInterval(mt.MuteTimeInterval))
+		revision.Config.AlertmanagerConfig.TimeIntervals = append(revision.Config.AlertmanagerConfig.TimeIntervals, definitions.TimeInterval(mt.MuteTimeInterval))
 
-	err = svc.xact.InTransaction(ctx, func(ctx context.Context) error {
 		if err := svc.configStore.Save(ctx, revision, orgID); err != nil {
 			return err
 		}
@@ -205,48 +205,47 @@ func (svc *MuteTimingService) UpdateMuteTiming(ctx context.Context, mt definitio
 		return definitions.MuteTimeInterval{}, MakeErrTimeIntervalInvalid(err)
 	}
 
-	revision, err := svc.configStore.Get(ctx, orgID)
-	if err != nil {
-		return definitions.MuteTimeInterval{}, err
-	}
-
-	var found bool
-	var existing definitions.MuteTimeInterval
-	if mt.UID != "" {
-		existing, found, err = svc.getMuteTimingByUID(ctx, revision, orgID, mt.UID)
-	} else {
-		existing, found, err = svc.getMuteTimingByName(ctx, revision, orgID, mt.Name)
-	}
-	if err != nil {
-		return definitions.MuteTimeInterval{}, err
-	} else if !found {
-		return definitions.MuteTimeInterval{}, ErrTimeIntervalNotFound.Errorf("")
-	}
-
-	if existing.Name != mt.Name { // if mute timing is renamed, check if this name is already taken
-		if grafanaTimeIntervalExists(revision, mt.Name) {
-			return definitions.MuteTimeInterval{}, ErrTimeIntervalExists.Errorf("")
-		}
-	}
-
-	if existing.Provenance == definitions.Provenance(models.ProvenanceConvertedPrometheus) {
-		return definitions.MuteTimeInterval{}, makeErrMuteTimeIntervalOrigin(existing, "update")
-	}
-
-	// check that provenance is not changed in an invalid way
-	if err := svc.validator(ctx, models.Provenance(existing.Provenance), models.Provenance(mt.Provenance)); err != nil {
-		return definitions.MuteTimeInterval{}, err
-	}
-
-	existingInterval := existing.MuteTimeInterval
-
-	// check optimistic concurrency
-	if err = svc.checkOptimisticConcurrency(existingInterval, models.Provenance(mt.Provenance), mt.Version, "update"); err != nil {
-		return definitions.MuteTimeInterval{}, err
-	}
-
 	// TODO add diff and noop detection
-	err = svc.xact.InTransaction(ctx, func(ctx context.Context) error {
+	err := svc.xact.InTransaction(ctx, func(ctx context.Context) error {
+		revision, err := svc.configStore.Get(ctx, orgID)
+		if err != nil {
+			return err
+		}
+
+		var found bool
+		var existing definitions.MuteTimeInterval
+		if mt.UID != "" {
+			existing, found, err = svc.getMuteTimingByUID(ctx, revision, orgID, mt.UID)
+		} else {
+			existing, found, err = svc.getMuteTimingByName(ctx, revision, orgID, mt.Name)
+		}
+		if err != nil {
+			return err
+		} else if !found {
+			return ErrTimeIntervalNotFound.Errorf("")
+		}
+
+		if existing.Name != mt.Name { // if mute timing is renamed, check if this name is already taken
+			if grafanaTimeIntervalExists(revision, mt.Name) {
+				return ErrTimeIntervalExists.Errorf("")
+			}
+		}
+
+		if existing.Provenance == definitions.Provenance(models.ProvenanceConvertedPrometheus) {
+			return makeErrMuteTimeIntervalOrigin(existing, "update")
+		}
+
+		// check that provenance is not changed in an invalid way
+		if err := svc.validator(ctx, models.Provenance(existing.Provenance), models.Provenance(mt.Provenance)); err != nil {
+			return err
+		}
+
+		existingInterval := existing.MuteTimeInterval
+
+		// check optimistic concurrency
+		if err = svc.checkOptimisticConcurrency(existingInterval, models.Provenance(mt.Provenance), mt.Version, "update"); err != nil {
+			return err
+		}
 		// if the name of the time interval changed
 		if existingInterval.Name != mt.Name {
 			deleteTimeInterval(revision, existingInterval)
@@ -264,6 +263,23 @@ func (svc *MuteTimingService) UpdateMuteTiming(ctx context.Context, mt definitio
 		} else {
 			updateTimeInterval(revision, mt.MuteTimeInterval)
 		}
+		
+		// Verify the time interval appears exactly once in the config before saving
+		count := 0
+		for _, ti := range revision.Config.AlertmanagerConfig.MuteTimeIntervals {
+			if ti.Name == mt.Name {
+				count++
+			}
+		}
+		for _, ti := range revision.Config.AlertmanagerConfig.TimeIntervals {
+			if ti.Name == mt.Name {
+				count++
+			}
+		}
+		if count != 1 {
+			return fmt.Errorf("expected time interval %q to appear exactly once after update, but found %d occurrences", mt.Name, count)
+		}
+		
 		if err := svc.configStore.Save(ctx, revision, orgID); err != nil {
 			return err
 		}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What is this feature?

Fixes a flaky test `TestIntegrationTimeIntervalReferentialIntegrity` that was intermittently failing with the error: `time interval "test-interval-new" is not unique`.

## Why do we need this feature?

The test failure indicated a race condition in the time interval management code that could lead to duplicate time intervals being created in the alertmanager configuration.

## Root Cause

Both `CreateMuteTiming` and `UpdateMuteTiming` methods had race conditions where critical operations happened outside the database transaction:

1. **Before the fix**: Config was fetched, uniqueness was checked, and the config was modified - all **outside** the transaction
2. This allowed concurrent operations to:
   - Both pass the uniqueness check (seeing the same state)
   - Both modify the config (potentially creating duplicates) 
   - Both save their changes successfully

The optimistic concurrency control (using `FetchedConfigurationHash`) would catch some conflicts, but not all - specifically when two operations modify different parts of the config but both add an interval with the same name.

## Changes

### 1. Move operations inside transactions (CreateMuteTiming)
- Moved `configStore.Get()`, `grafanaTimeIntervalExists()` check, and config modification **inside** the transaction
- Ensures atomic read-check-modify-write sequence

### 2. Move operations inside transactions (UpdateMuteTiming)  
- Moved `configStore.Get()`, lookup of existing interval, uniqueness check, provenance validation, and config modification **inside** the transaction
- Ensures atomic read-check-modify-write sequence for updates/renames

### 3. Add defensive validation (UpdateMuteTiming)
- Added a final check before saving to ensure the renamed interval appears exactly once in the combined `MuteTimeIntervals` + `TimeIntervals` arrays
- Provides early detection and clearer error messages if duplicates are somehow created

## Testing

- All existing tests pass: `pkg/tests/apis/alerting/notifications/timeinterval/`
- The flaky test `TestIntegrationTimeIntervalReferentialIntegrity` now passes consistently

## Which issue(s) does this PR fix?

Fixes the flaky test reported in https://github.com/grafana/grafana/actions/runs/24686077014/job/72195722097
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://raintank-corp.slack.com/archives/C028MCV4R7C/p1776776503436239?thread_ts=1776776503.436239&cid=C028MCV4R7C)

<div><a href="https://cursor.com/agents/bc-b69f181f-389b-58e2-825e-4d5d2df59988"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b69f181f-389b-58e2-825e-4d5d2df59988"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

