### PR TITLE
Alerting: POC evaluation step V2 with recording rule chain detection

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.test.tsx
@@ -1,0 +1,74 @@
+import * as React from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { Provider } from 'react-redux';
+import { render, screen } from 'test/test-utils';
+
+import { config } from '@grafana/runtime';
+import { configureStore } from 'app/store/configureStore';
+import { GrafanaAlertStateDecision } from 'app/types/unified-alerting-dto';
+
+import { setupMswServer } from '../../mockApi';
+import { RuleFormType, type RuleFormValues } from '../../types/rule-form';
+
+import { GrafanaEvaluationBehaviorStep } from './GrafanaEvaluationBehavior';
+
+setupMswServer();
+
+function makeWrapper(featureEnabled = false) {
+  const store = configureStore();
+  return ({ children }: React.PropsWithChildren<{}>) => {
+    const methods = useForm<RuleFormValues>({
+      defaultValues: {
+        evaluateEvery: '1m',
+        evaluateFor: '0s',
+        type: RuleFormType.grafana,
+        group: 'default-group',
+        noDataState: GrafanaAlertStateDecision.NoData,
+        execErrState: GrafanaAlertStateDecision.Error,
+        queries: [],
+        folder: { uid: 'test-folder', title: 'Test Folder' },
+      },
+    });
+
+    // Override featureToggles for this test
+    config.featureToggles = {
+      ...config.featureToggles,
+      ['alerting.rulesAPIV2']: featureEnabled,
+    };
+
+    return (
+      <Provider store={store}>
+        <FormProvider {...methods}>{children}</FormProvider>
+      </Provider>
+    );
+  };
+}
+
+afterEach(() => {
+  // Reset feature flag
+  config.featureToggles = {
+    ...config.featureToggles,
+    ['alerting.rulesAPIV2']: false,
+  };
+});
+
+describe('GrafanaEvaluationBehaviorStep — feature flag branching', () => {
+  it('renders legacy evaluation behavior when alertingRulesAPIV2 flag is disabled', () => {
+    render(<GrafanaEvaluationBehaviorStep existing={false} enableProvisionedGroups={false} />, {
+      wrapper: makeWrapper(false),
+    });
+
+    // Legacy behavior shows group selector
+    expect(screen.getByTestId('group-picker')).toBeInTheDocument();
+  });
+
+  it('renders EvaluationBehaviorV2 when alertingRulesAPIV2 flag is enabled', async () => {
+    render(<GrafanaEvaluationBehaviorStep existing={false} enableProvisionedGroups={false} />, {
+      wrapper: makeWrapper(true),
+    });
+
+    // V2 shows interval picker without group selector
+    expect(await screen.findByRole('textbox', { name: /evaluation interval/i })).toBeInTheDocument();
+    expect(screen.queryByTestId('group-picker')).not.toBeInTheDocument();
+  });
+});

--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.test.tsx
@@ -53,13 +53,13 @@ afterEach(() => {
 });
 
 describe('GrafanaEvaluationBehaviorStep — feature flag branching', () => {
-  it('renders legacy evaluation behavior when alertingRulesAPIV2 flag is disabled', () => {
+  it('renders legacy evaluation behavior when alertingRulesAPIV2 flag is disabled', async () => {
     render(<GrafanaEvaluationBehaviorStep existing={false} enableProvisionedGroups={false} />, {
       wrapper: makeWrapper(false),
     });
 
     // Legacy behavior shows group selector
-    expect(screen.getByTestId('group-picker')).toBeInTheDocument();
+    expect(await screen.findByTestId('group-picker')).toBeInTheDocument();
   });
 
   it('renders EvaluationBehaviorV2 when alertingRulesAPIV2 flag is enabled', async () => {

--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
@@ -25,6 +25,7 @@ import {
 } from '@grafana/ui';
 import { type RulerRulesConfigDTO } from 'app/types/unified-alerting-dto';
 
+import { shouldUseRulesAPIV2 } from '../../featureToggles';
 import { evaluateEveryValidationOptions } from '../../group-details/validation';
 import { useFetchGroupsForFolder } from '../../hooks/useFetchGroupsForFolder';
 import { DEFAULT_GROUP_EVALUATION_INTERVAL } from '../../rule-editor/formDefaults';
@@ -49,6 +50,7 @@ import { EvaluationGroupQuickPick } from './EvaluationGroupQuickPick';
 import { GrafanaAlertStatePicker } from './GrafanaAlertStatePicker';
 import { NeedHelpInfo } from './NeedHelpInfo';
 import { RuleEditorSection } from './RuleEditorSection';
+import { EvaluationBehaviorV2 } from './evaluation-v2/EvaluationBehaviorV2';
 
 const namespaceToGroupOptions = (rulerNamespace: RulerRulesConfigDTO, enableProvisionedGroups: boolean) => {
   const folderGroups = Object.values(rulerNamespace).flat();
@@ -115,6 +117,20 @@ const forValidationOptions = (getEvaluateEvery: () => string): RegisterOptions<{
 });
 
 export function GrafanaEvaluationBehaviorStep({
+  existing,
+  enableProvisionedGroups,
+}: {
+  existing: boolean;
+  enableProvisionedGroups: boolean;
+}) {
+  if (shouldUseRulesAPIV2()) {
+    return <EvaluationBehaviorV2 existing={existing} />;
+  }
+
+  return <LegacyEvaluationBehavior existing={existing} enableProvisionedGroups={enableProvisionedGroups} />;
+}
+
+function LegacyEvaluationBehavior({
   existing,
   enableProvisionedGroups,
 }: {

--- a/public/app/features/alerting/unified/components/rule-editor/evaluation-v2/ChainRecommendation.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/evaluation-v2/ChainRecommendation.test.tsx
@@ -1,0 +1,90 @@
+import userEvent from '@testing-library/user-event';
+import * as React from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { render, screen } from 'test/test-utils';
+
+import { type RecordingRuleDetectionResult } from '../../../hooks/useDetectRecordingRuleReferences';
+import { type EvaluationChain, EvaluationScenario } from '../../../types/evaluation-chain';
+import { type RuleFormValues } from '../../../types/rule-form';
+
+import { ChainRecommendation } from './ChainRecommendation';
+
+const mockChain: EvaluationChain = {
+  uid: 'chain-1',
+  name: 'My Evaluation Chain',
+  interval: '1m',
+  intervalSeconds: 60,
+  recordingRuleRefs: ['rec-rule-1'],
+  alertRuleRefs: [],
+};
+
+const mockDetection: RecordingRuleDetectionResult = {
+  scenario: EvaluationScenario.SingleChain,
+  referencedRecordingRules: [
+    {
+      uid: 'rec-rule-1',
+      name: 'CPU Recording Rule',
+      metric: 'cpu_usage',
+      chainUid: 'chain-1',
+      chainName: 'My Evaluation Chain',
+    },
+  ],
+  chains: [mockChain],
+  recommendedChainUid: 'chain-1',
+  warnings: [],
+  isLoading: false,
+};
+
+function makeWrapper(defaultValues: Partial<RuleFormValues> = {}) {
+  return ({ children }: React.PropsWithChildren<{}>) => {
+    const methods = useForm<RuleFormValues>({
+      defaultValues: { evaluateEvery: '1m', ...defaultValues } as RuleFormValues,
+    });
+    return <FormProvider {...methods}>{children}</FormProvider>;
+  };
+}
+
+describe('ChainRecommendation', () => {
+  it('renders info alert about recording rule dependency', () => {
+    render(<ChainRecommendation detection={mockDetection} onOptOut={jest.fn()} />, {
+      wrapper: makeWrapper(),
+    });
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText(/recording rule dependency detected/i)).toBeInTheDocument();
+  });
+
+  it('renders chain info card with name and interval', () => {
+    render(<ChainRecommendation detection={mockDetection} onOptOut={jest.fn()} />, {
+      wrapper: makeWrapper(),
+    });
+
+    expect(screen.getByText('My Evaluation Chain')).toBeInTheDocument();
+    expect(screen.getByText(/interval: 1m/i)).toBeInTheDocument();
+  });
+
+  it('calls onOptOut when opt-out link is clicked', async () => {
+    const user = userEvent.setup();
+    const onOptOut = jest.fn();
+    render(<ChainRecommendation detection={mockDetection} onOptOut={onOptOut} />, {
+      wrapper: makeWrapper(),
+    });
+
+    await user.click(
+      screen.getByRole('button', { name: /I don't want to use a chain, let me configure evaluation manually/i })
+    );
+
+    expect(onOptOut).toHaveBeenCalledTimes(1);
+  });
+
+  it('auto-selects the recommended chain when none is selected', () => {
+    // The auto-selection is tested indirectly via the form state
+    // We verify the component renders without error when a recommended chain is available
+    render(<ChainRecommendation detection={mockDetection} onOptOut={jest.fn()} />, {
+      wrapper: makeWrapper({ evaluationChainUid: undefined }),
+    });
+
+    // Chain info card should appear, meaning the recommended chain was detected
+    expect(screen.getByText('My Evaluation Chain')).toBeInTheDocument();
+  });
+});

--- a/public/app/features/alerting/unified/components/rule-editor/evaluation-v2/ChainRecommendation.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/evaluation-v2/ChainRecommendation.test.tsx
@@ -50,7 +50,7 @@ describe('ChainRecommendation', () => {
       wrapper: makeWrapper(),
     });
 
-    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByRole('status', { name: /recording rule dependency detected/i })).toBeInTheDocument();
     expect(screen.getByText(/recording rule dependency detected/i)).toBeInTheDocument();
   });
 

--- a/public/app/features/alerting/unified/components/rule-editor/evaluation-v2/ChainRecommendation.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/evaluation-v2/ChainRecommendation.tsx
@@ -1,0 +1,54 @@
+import { useEffect } from 'react';
+import { useFormContext } from 'react-hook-form';
+
+import { Trans, t } from '@grafana/i18n';
+import { Alert, Button, Stack } from '@grafana/ui';
+
+import { type RecordingRuleDetectionResult } from '../../../hooks/useDetectRecordingRuleReferences';
+import { type RuleFormValues } from '../../../types/rule-form';
+
+import { EvaluationChainInfoCard } from './EvaluationChainInfoCard';
+
+interface ChainRecommendationProps {
+  detection: RecordingRuleDetectionResult;
+  onOptOut: () => void;
+}
+
+export function ChainRecommendation({ detection, onOptOut }: ChainRecommendationProps) {
+  const { setValue, watch } = useFormContext<RuleFormValues>();
+  const currentChainUid = watch('evaluationChainUid');
+  const recommendedChain = detection.chains[0];
+
+  // Auto-select the recommended chain if none is selected
+  useEffect(() => {
+    if (recommendedChain && !currentChainUid) {
+      setValue('evaluationChainUid', recommendedChain.uid);
+      setValue('evaluationChainName', recommendedChain.name);
+      if (recommendedChain.interval) {
+        setValue('evaluateEvery', recommendedChain.interval);
+      }
+    }
+  }, [recommendedChain, currentChainUid, setValue]);
+
+  return (
+    <Stack direction="column" gap={2}>
+      <Alert
+        severity="info"
+        title={t('alerting.evaluation-v2.chain-recommendation.title', 'Recording rule dependency detected')}
+      >
+        <Trans i18nKey="alerting.evaluation-v2.chain-recommendation.message">
+          This alert rule queries a recording rule that belongs to an evaluation chain. We recommend adding this alert
+          rule to the same chain to ensure the recording rule always evaluates first.
+        </Trans>
+      </Alert>
+
+      {recommendedChain && <EvaluationChainInfoCard chain={recommendedChain} />}
+
+      <Button variant="secondary" fill="text" size="sm" onClick={onOptOut}>
+        <Trans i18nKey="alerting.evaluation-v2.chain-recommendation.opt-out">
+          I don&apos;t want to use a chain, let me configure evaluation manually
+        </Trans>
+      </Button>
+    </Stack>
+  );
+}

--- a/public/app/features/alerting/unified/components/rule-editor/evaluation-v2/CommonEvaluationFields.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/evaluation-v2/CommonEvaluationFields.tsx
@@ -1,0 +1,256 @@
+import { useEffect, useState } from 'react';
+import { Controller, type RegisterOptions, useFormContext } from 'react-hook-form';
+import { useFirstMountState } from 'react-use';
+
+import { Trans, t } from '@grafana/i18n';
+import { Divider, Field, Icon, Input, Label, Stack, Switch, Tooltip } from '@grafana/ui';
+
+import { type RuleFormValues } from '../../../types/rule-form';
+import { parsePrometheusDuration } from '../../../utils/time';
+import { CollapseToggle } from '../../CollapseToggle';
+import { DurationQuickPick } from '../DurationQuickPick';
+import { GrafanaAlertStatePicker } from '../GrafanaAlertStatePicker';
+
+interface CommonEvaluationFieldsProps {
+  existing: boolean;
+  isAlertingRule: boolean;
+}
+
+const forValidationOptions = (getEvaluateEvery: () => string): RegisterOptions<{ evaluateFor: string }> => ({
+  required: {
+    value: true,
+    message: t('alerting.for-validation-options.message.required', 'Required.'),
+  },
+  validate: (value) => {
+    if (value === '0') {
+      return true;
+    }
+    try {
+      const millisFor = parsePrometheusDuration(value);
+      if (millisFor === 0) {
+        return true;
+      }
+      try {
+        const millisEvery = parsePrometheusDuration(getEvaluateEvery());
+        return millisFor >= millisEvery
+          ? true
+          : t(
+              'alerting.rule-form.evaluation-behaviour-for.validation',
+              'Pending period must be greater than or equal to the evaluation interval.'
+            );
+      } catch {
+        return true;
+      }
+    } catch (error) {
+      return error instanceof Error
+        ? error.message
+        : t('alerting.rule-form.evaluation-behaviour-for.error-parsing', 'Failed to parse duration');
+    }
+  },
+});
+
+function PendingPeriodInput({ evaluateEvery }: { evaluateEvery: string }) {
+  const {
+    register,
+    formState: { errors },
+    setValue,
+    getValues,
+    watch,
+    trigger,
+  } = useFormContext<RuleFormValues>();
+
+  const evaluateForId = 'eval-for-input';
+  const currentPendingPeriod = watch('evaluateFor');
+
+  const isFirstMount = useFirstMountState();
+  useEffect(() => {
+    if (isFirstMount) {
+      return;
+    }
+    trigger('evaluateFor');
+  }, [evaluateEvery, currentPendingPeriod, trigger, isFirstMount]);
+
+  const setPendingPeriod = (pendingPeriod: string) => {
+    setValue('evaluateFor', pendingPeriod);
+  };
+
+  return (
+    <Stack direction="column" gap={2}>
+      <Field
+        noMargin
+        label={
+          <Label
+            htmlFor={evaluateForId}
+            description={t(
+              'alerting.for-input.description-pending',
+              'Period during which the threshold condition must be met to trigger an alert. Selecting "None" triggers the alert immediately once the condition is met.'
+            )}
+          >
+            <Trans i18nKey="alerting.rule-form.evaluation-behaviour.pending-period">Pending period</Trans>
+          </Label>
+        }
+        error={errors.evaluateFor?.message}
+        invalid={Boolean(errors.evaluateFor?.message) ? true : undefined}
+        validationMessageHorizontalOverflow={true}
+      >
+        <Input
+          id={evaluateForId}
+          width={8}
+          {...register(
+            'evaluateFor',
+            forValidationOptions(() => getValues('evaluateEvery'))
+          )}
+        />
+      </Field>
+      <DurationQuickPick
+        selectedDuration={currentPendingPeriod}
+        groupEvaluationInterval={evaluateEvery}
+        onSelect={setPendingPeriod}
+      />
+    </Stack>
+  );
+}
+
+function KeepFiringForInput({ evaluateEvery }: { evaluateEvery: string }) {
+  const {
+    register,
+    formState: { errors },
+    setValue,
+    watch,
+  } = useFormContext<RuleFormValues>();
+
+  const currentKeepFiringFor = watch('keepFiringFor');
+  const keepFiringForId = 'keep-firing-for-input';
+
+  const setKeepFiringFor = (keepFiringFor: string) => {
+    setValue('keepFiringFor', keepFiringFor);
+  };
+
+  return (
+    <Stack direction="column" gap={2}>
+      <Field
+        noMargin
+        label={
+          <Label
+            htmlFor={keepFiringForId}
+            description={t(
+              'alerting.rule-form.evaluation-behaviour.keep-firing-for.label-description',
+              'Period during which the alert will continue to show up as firing even though the threshold condition is no longer breached. Selecting "None" means the alert will be back to normal immediately.'
+            )}
+          >
+            <Trans i18nKey="alerting.rule-form.evaluation-behaviour.keep-firing-for.label-text">Keep firing for</Trans>
+          </Label>
+        }
+        error={errors.keepFiringFor?.message}
+        invalid={Boolean(errors.keepFiringFor?.message) ? true : undefined}
+        validationMessageHorizontalOverflow={true}
+      >
+        <Input id={keepFiringForId} width={8} {...register('keepFiringFor')} />
+      </Field>
+      <DurationQuickPick
+        selectedDuration={currentKeepFiringFor}
+        groupEvaluationInterval={evaluateEvery}
+        onSelect={setKeepFiringFor}
+      />
+    </Stack>
+  );
+}
+
+export function CommonEvaluationFields({ existing, isAlertingRule }: CommonEvaluationFieldsProps) {
+  const [showErrorHandling, setShowErrorHandling] = useState(false);
+  const { watch, setValue } = useFormContext<RuleFormValues>();
+
+  const [isPaused, evaluateEvery] = watch(['isPaused', 'evaluateEvery']);
+
+  const pauseContentText = isAlertingRule
+    ? t('alerting.rule-form.evaluation.pause.alerting', 'Turn on to pause evaluation for this alert rule.')
+    : t('alerting.rule-form.evaluation.pause.recording', 'Turn on to pause evaluation for this recording rule.');
+
+  return (
+    <Stack direction="column" gap={2}>
+      {isAlertingRule && <PendingPeriodInput evaluateEvery={evaluateEvery} />}
+      <Divider />
+      {isAlertingRule && <KeepFiringForInput evaluateEvery={evaluateEvery} />}
+
+      {existing && (
+        <Field noMargin htmlFor="pause-alert-switch">
+          <Controller
+            render={() => (
+              <Stack gap={1} direction="row" alignItems="center">
+                <Switch
+                  id="pause-alert"
+                  onChange={(value) => {
+                    setValue('isPaused', value.currentTarget.checked);
+                  }}
+                  value={Boolean(isPaused)}
+                />
+                <label htmlFor="pause-alert">
+                  <Trans i18nKey="alerting.rule-form.pause.label">Pause evaluation</Trans>
+                  <Tooltip placement="top" content={pauseContentText} theme={'info'}>
+                    <Icon tabIndex={0} name="info-circle" size="sm" />
+                  </Tooltip>
+                </label>
+              </Stack>
+            )}
+            name="isPaused"
+          />
+        </Field>
+      )}
+
+      {isAlertingRule && (
+        <>
+          <CollapseToggle
+            isCollapsed={!showErrorHandling}
+            onToggle={(collapsed) => setShowErrorHandling(!collapsed)}
+            text={t(
+              'alerting.grafana-evaluation-behavior-step.text-configure-no-data-and-error-handling',
+              'Configure no data and error handling'
+            )}
+          />
+          {showErrorHandling && (
+            <Stack direction="column" gap={2}>
+              <Field
+                noMargin
+                htmlFor="no-data-state-input"
+                label={t('alerting.alert.state-no-data', 'Alert state if no data or all values are null')}
+              >
+                <Controller
+                  render={({ field: { onChange, ref, ...field } }) => (
+                    <GrafanaAlertStatePicker
+                      {...field}
+                      inputId="no-data-state-input"
+                      width={42}
+                      includeNoData={true}
+                      includeError={false}
+                      onChange={(value) => onChange(value?.value)}
+                    />
+                  )}
+                  name="noDataState"
+                />
+              </Field>
+              <Field
+                noMargin
+                htmlFor="exec-err-state-input"
+                label={t('alerting.alert.state-error-timeout', 'Alert state if execution error or timeout')}
+              >
+                <Controller
+                  render={({ field: { onChange, ref, ...field } }) => (
+                    <GrafanaAlertStatePicker
+                      {...field}
+                      inputId="exec-err-state-input"
+                      width={42}
+                      includeNoData={false}
+                      includeError={true}
+                      onChange={(value) => onChange(value?.value)}
+                    />
+                  )}
+                  name="execErrState"
+                />
+              </Field>
+            </Stack>
+          )}
+        </>
+      )}
+    </Stack>
+  );
+}

--- a/public/app/features/alerting/unified/components/rule-editor/evaluation-v2/CreateChainRecommendation.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/evaluation-v2/CreateChainRecommendation.test.tsx
@@ -35,7 +35,7 @@ describe('CreateChainRecommendation', () => {
       wrapper: makeWrapper(),
     });
 
-    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByRole('status', { name: /recording rule dependency detected/i })).toBeInTheDocument();
     expect(screen.getByText(/recording rule dependency detected/i)).toBeInTheDocument();
     expect(screen.getByText(/CPU Recording Rule/)).toBeInTheDocument();
     expect(screen.getByText(/Memory Recording Rule/)).toBeInTheDocument();

--- a/public/app/features/alerting/unified/components/rule-editor/evaluation-v2/CreateChainRecommendation.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/evaluation-v2/CreateChainRecommendation.test.tsx
@@ -1,0 +1,69 @@
+import userEvent from '@testing-library/user-event';
+import * as React from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { render, screen } from 'test/test-utils';
+
+import { type RecordingRuleDetectionResult } from '../../../hooks/useDetectRecordingRuleReferences';
+import { EvaluationScenario } from '../../../types/evaluation-chain';
+import { type RuleFormValues } from '../../../types/rule-form';
+
+import { CreateChainRecommendation } from './CreateChainRecommendation';
+
+const mockDetection: RecordingRuleDetectionResult = {
+  scenario: EvaluationScenario.UnchainedRecordingRules,
+  referencedRecordingRules: [
+    { uid: 'rec-rule-1', name: 'CPU Recording Rule', metric: 'cpu_usage' },
+    { uid: 'rec-rule-2', name: 'Memory Recording Rule', metric: 'memory_usage' },
+  ],
+  chains: [],
+  warnings: [],
+  isLoading: false,
+};
+
+function makeWrapper() {
+  return ({ children }: React.PropsWithChildren<{}>) => {
+    const methods = useForm<RuleFormValues>({
+      defaultValues: { evaluateEvery: '1m' } as RuleFormValues,
+    });
+    return <FormProvider {...methods}>{children}</FormProvider>;
+  };
+}
+
+describe('CreateChainRecommendation', () => {
+  it('renders info alert listing referenced recording rules', () => {
+    render(<CreateChainRecommendation detection={mockDetection} onOptOut={jest.fn()} />, {
+      wrapper: makeWrapper(),
+    });
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText(/recording rule dependency detected/i)).toBeInTheDocument();
+    expect(screen.getByText(/CPU Recording Rule/)).toBeInTheDocument();
+    expect(screen.getByText(/Memory Recording Rule/)).toBeInTheDocument();
+  });
+
+  it('opens creation modal when create button is clicked', async () => {
+    const user = userEvent.setup();
+    render(<CreateChainRecommendation detection={mockDetection} onOptOut={jest.fn()} />, {
+      wrapper: makeWrapper(),
+    });
+
+    await user.click(screen.getByRole('button', { name: /create evaluation chain/i }));
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText(/new evaluation chain/i)).toBeInTheDocument();
+  });
+
+  it('calls onOptOut when opt-out link is clicked', async () => {
+    const user = userEvent.setup();
+    const onOptOut = jest.fn();
+    render(<CreateChainRecommendation detection={mockDetection} onOptOut={onOptOut} />, {
+      wrapper: makeWrapper(),
+    });
+
+    await user.click(
+      screen.getByRole('button', { name: /I don't want to use a chain, let me configure evaluation manually/i })
+    );
+
+    expect(onOptOut).toHaveBeenCalledTimes(1);
+  });
+});

--- a/public/app/features/alerting/unified/components/rule-editor/evaluation-v2/CreateChainRecommendation.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/evaluation-v2/CreateChainRecommendation.tsx
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+
+import { Trans, t } from '@grafana/i18n';
+import { Alert, Button, Stack } from '@grafana/ui';
+
+import { type RecordingRuleDetectionResult } from '../../../hooks/useDetectRecordingRuleReferences';
+
+import { EvaluationChainCreationModal } from './EvaluationChainCreationModal';
+
+interface CreateChainRecommendationProps {
+  detection: RecordingRuleDetectionResult;
+  onOptOut: () => void;
+  onChainCreated?: () => void;
+}
+
+export function CreateChainRecommendation({ detection, onOptOut, onChainCreated }: CreateChainRecommendationProps) {
+  const [showModal, setShowModal] = useState(false);
+  const ruleNames = detection.referencedRecordingRules.map((r) => r.name).join(', ');
+
+  return (
+    <Stack direction="column" gap={2}>
+      <Alert
+        severity="info"
+        title={t('alerting.evaluation-v2.create-chain.title', 'Recording rule dependency detected')}
+      >
+        <Trans i18nKey="alerting.evaluation-v2.create-chain.message" values={{ ruleNames }}>
+          This alert rule queries recording rules ({ruleNames}) that don&apos;t belong to any evaluation chain. We
+          recommend creating a new chain to ensure the recording rules always evaluate first.
+        </Trans>
+      </Alert>
+
+      <Button variant="secondary" icon="plus" onClick={() => setShowModal(true)}>
+        <Trans i18nKey="alerting.evaluation-v2.create-chain.create-button">Create evaluation chain</Trans>
+      </Button>
+
+      <Button variant="secondary" fill="text" size="sm" onClick={onOptOut}>
+        <Trans i18nKey="alerting.evaluation-v2.create-chain.opt-out">
+          I don&apos;t want to use a chain, let me configure evaluation manually
+        </Trans>
+      </Button>
+
+      {showModal && (
+        <EvaluationChainCreationModal
+          recordingRuleRefs={detection.referencedRecordingRules.map((r) => r.uid)}
+          onClose={() => setShowModal(false)}
+          onCreated={onChainCreated}
+        />
+      )}
+    </Stack>
+  );
+}

--- a/public/app/features/alerting/unified/components/rule-editor/evaluation-v2/EvaluationBehaviorV2.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/evaluation-v2/EvaluationBehaviorV2.test.tsx
@@ -1,4 +1,3 @@
-import userEvent from '@testing-library/user-event';
 import * as React from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { Provider } from 'react-redux';
@@ -8,7 +7,6 @@ import { configureStore } from 'app/store/configureStore';
 import { GrafanaAlertStateDecision } from 'app/types/unified-alerting-dto';
 
 import { setupMswServer } from '../../../mockApi';
-import { EvaluationScenario } from '../../../types/evaluation-chain';
 import { RuleFormType, type RuleFormValues } from '../../../types/rule-form';
 
 import { EvaluationBehaviorV2 } from './EvaluationBehaviorV2';
@@ -46,10 +44,10 @@ describe('EvaluationBehaviorV2', () => {
     expect(await screen.findByRole('textbox', { name: /evaluation interval/i })).toBeInTheDocument();
   });
 
-  it('renders section with correct title', () => {
+  it('renders section with correct title', async () => {
     render(<EvaluationBehaviorV2 existing={false} />, { wrapper: makeWrapper() });
 
-    expect(screen.getByText(/set evaluation behavior/i)).toBeInTheDocument();
+    expect(await screen.findByText(/set evaluation behavior/i)).toBeInTheDocument();
   });
 
   it('always renders CommonEvaluationFields regardless of scenario', async () => {
@@ -60,8 +58,6 @@ describe('EvaluationBehaviorV2', () => {
   });
 
   it('switches to manual mode when user clicks opt-out link', async () => {
-    const user = userEvent.setup();
-
     // Render with a scenario that shows an opt-out link
     // Since the mock API returns no recording rules, we start with NoRecordingRules/StandaloneEvaluation
     // We can't easily test opt-out without mocking the detection hook, so we test

--- a/public/app/features/alerting/unified/components/rule-editor/evaluation-v2/EvaluationBehaviorV2.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/evaluation-v2/EvaluationBehaviorV2.test.tsx
@@ -1,0 +1,91 @@
+import userEvent from '@testing-library/user-event';
+import * as React from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { Provider } from 'react-redux';
+import { render, screen } from 'test/test-utils';
+
+import { configureStore } from 'app/store/configureStore';
+import { GrafanaAlertStateDecision } from 'app/types/unified-alerting-dto';
+
+import { setupMswServer } from '../../../mockApi';
+import { EvaluationScenario } from '../../../types/evaluation-chain';
+import { RuleFormType, type RuleFormValues } from '../../../types/rule-form';
+
+import { EvaluationBehaviorV2 } from './EvaluationBehaviorV2';
+
+// MSW server returns empty recording rules list by default
+setupMswServer();
+
+function makeWrapper(defaultValues: Partial<RuleFormValues> = {}) {
+  const store = configureStore();
+  return ({ children }: React.PropsWithChildren<{}>) => {
+    const methods = useForm<RuleFormValues>({
+      defaultValues: {
+        evaluateEvery: '1m',
+        evaluateFor: '0s',
+        type: RuleFormType.grafana,
+        noDataState: GrafanaAlertStateDecision.NoData,
+        execErrState: GrafanaAlertStateDecision.Error,
+        queries: [],
+        ...defaultValues,
+      } as RuleFormValues,
+    });
+    return (
+      <Provider store={store}>
+        <FormProvider {...methods}>{children}</FormProvider>
+      </Provider>
+    );
+  };
+}
+
+describe('EvaluationBehaviorV2', () => {
+  it('renders StandaloneEvaluation when no recording rules are detected', async () => {
+    render(<EvaluationBehaviorV2 existing={false} />, { wrapper: makeWrapper() });
+
+    // Interval input is the key indicator of StandaloneEvaluation
+    expect(await screen.findByRole('textbox', { name: /evaluation interval/i })).toBeInTheDocument();
+  });
+
+  it('renders section with correct title', () => {
+    render(<EvaluationBehaviorV2 existing={false} />, { wrapper: makeWrapper() });
+
+    expect(screen.getByText(/set evaluation behavior/i)).toBeInTheDocument();
+  });
+
+  it('always renders CommonEvaluationFields regardless of scenario', async () => {
+    render(<EvaluationBehaviorV2 existing={false} />, { wrapper: makeWrapper() });
+
+    // The pending period field is part of CommonEvaluationFields
+    expect(await screen.findByText(/pending period/i)).toBeInTheDocument();
+  });
+
+  it('switches to manual mode when user clicks opt-out link', async () => {
+    const user = userEvent.setup();
+
+    // Render with a scenario that shows an opt-out link
+    // Since the mock API returns no recording rules, we start with NoRecordingRules/StandaloneEvaluation
+    // We can't easily test opt-out without mocking the detection hook, so we test
+    // that the StandaloneEvaluation renders in the default state
+    render(<EvaluationBehaviorV2 existing={false} />, {
+      wrapper: makeWrapper({ queries: [] }),
+    });
+
+    // In NoRecordingRules scenario, StandaloneEvaluation renders without opt-in link
+    expect(await screen.findByRole('textbox', { name: /evaluation interval/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /I want to add to an evaluation chain/i })).not.toBeInTheDocument();
+  });
+
+  it('does not show pause switch when not editing existing rule', async () => {
+    render(<EvaluationBehaviorV2 existing={false} />, { wrapper: makeWrapper() });
+
+    await screen.findByText(/set evaluation behavior/i);
+
+    expect(screen.queryByRole('switch', { name: /pause evaluation/i })).not.toBeInTheDocument();
+  });
+
+  it('shows pause switch when editing existing rule', async () => {
+    render(<EvaluationBehaviorV2 existing={true} />, { wrapper: makeWrapper() });
+
+    expect(await screen.findByText(/pause evaluation/i)).toBeInTheDocument();
+  });
+});

--- a/public/app/features/alerting/unified/components/rule-editor/evaluation-v2/EvaluationBehaviorV2.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/evaluation-v2/EvaluationBehaviorV2.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useState } from 'react';
+import { useFormContext } from 'react-hook-form';
+
+import { t } from '@grafana/i18n';
+import { Stack } from '@grafana/ui';
+
+import { useDetectRecordingRuleReferences } from '../../../hooks/useDetectRecordingRuleReferences';
+import { EvaluationScenario } from '../../../types/evaluation-chain';
+import { type RuleFormValues } from '../../../types/rule-form';
+import { isGrafanaAlertingRuleByType } from '../../../utils/rules';
+import { RuleEditorSection } from '../RuleEditorSection';
+
+import { ChainRecommendation } from './ChainRecommendation';
+import { CommonEvaluationFields } from './CommonEvaluationFields';
+import { CreateChainRecommendation } from './CreateChainRecommendation';
+import { MultiChainWarning } from './MultiChainWarning';
+import { StandaloneEvaluation } from './StandaloneEvaluation';
+
+interface EvaluationBehaviorV2Props {
+  existing: boolean;
+}
+
+export function EvaluationBehaviorV2({ existing }: EvaluationBehaviorV2Props) {
+  const { watch, setValue } = useFormContext<RuleFormValues>();
+  const [type, evaluateEvery] = watch(['type', 'evaluateEvery']);
+  const isAlertingRule = isGrafanaAlertingRuleByType(type);
+
+  const [userOptedOut, setUserOptedOut] = useState(false);
+  const [chainCreated, setChainCreated] = useState(false);
+  const detection = useDetectRecordingRuleReferences();
+
+  // The ruler API still requires a group name. Synthesise one from the
+  // evaluation interval so rules sharing the same cadence land in the same
+  // group. This is a POC workaround until the v2 save path is wired up.
+  useEffect(() => {
+    setValue('group', evaluateEvery || '1m');
+  }, [evaluateEvery, setValue]);
+
+  const handleOptOut = () => setUserOptedOut(true);
+  const handleOptIn = () => setUserOptedOut(false);
+
+  function renderScenario(scenario: EvaluationScenario, optedOut: boolean) {
+    if (chainCreated || optedOut) {
+      return (
+        <StandaloneEvaluation
+          onOptIn={chainCreated ? undefined : handleOptIn}
+          showOptInLink={!chainCreated && scenario !== EvaluationScenario.NoRecordingRules}
+        />
+      );
+    }
+
+    switch (scenario) {
+      case EvaluationScenario.NoRecordingRules:
+        return <StandaloneEvaluation />;
+      case EvaluationScenario.SingleChain:
+        return <ChainRecommendation detection={detection} onOptOut={handleOptOut} />;
+      case EvaluationScenario.UnchainedRecordingRules:
+        return (
+          <CreateChainRecommendation
+            detection={detection}
+            onOptOut={handleOptOut}
+            onChainCreated={() => setChainCreated(true)}
+          />
+        );
+      case EvaluationScenario.MultipleChains:
+        return <MultiChainWarning detection={detection} onOptOut={handleOptOut} />;
+    }
+  }
+
+  return (
+    <RuleEditorSection stepNo={4} title={t('alerting.evaluation-v2.section-title', 'Set evaluation behavior')}>
+      <Stack direction="column" gap={2}>
+        {renderScenario(detection.scenario, userOptedOut)}
+        <CommonEvaluationFields existing={existing} isAlertingRule={isAlertingRule} />
+      </Stack>
+    </RuleEditorSection>
+  );
+}

--- a/public/app/features/alerting/unified/components/rule-editor/evaluation-v2/EvaluationChainCreationModal.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/evaluation-v2/EvaluationChainCreationModal.test.tsx
@@ -26,8 +26,7 @@ describe('EvaluationChainCreationModal', () => {
     expect(screen.getByRole('textbox', { name: /evaluation interval/i })).toBeInTheDocument();
   });
 
-  it('validates name is required', async () => {
-    const user = userEvent.setup();
+  it('validates name is required', () => {
     render(<EvaluationChainCreationModal recordingRuleRefs={['rule-1']} onClose={jest.fn()} />, {
       wrapper: makeWrapper(),
     });

--- a/public/app/features/alerting/unified/components/rule-editor/evaluation-v2/EvaluationChainCreationModal.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/evaluation-v2/EvaluationChainCreationModal.test.tsx
@@ -1,0 +1,71 @@
+import userEvent from '@testing-library/user-event';
+import * as React from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { render, screen } from 'test/test-utils';
+
+import { type RuleFormValues } from '../../../types/rule-form';
+
+import { EvaluationChainCreationModal } from './EvaluationChainCreationModal';
+
+function makeWrapper() {
+  return ({ children }: React.PropsWithChildren<{}>) => {
+    const methods = useForm<RuleFormValues>({
+      defaultValues: { evaluateEvery: '1m' } as RuleFormValues,
+    });
+    return <FormProvider {...methods}>{children}</FormProvider>;
+  };
+}
+
+describe('EvaluationChainCreationModal', () => {
+  it('renders name and interval fields', () => {
+    render(<EvaluationChainCreationModal recordingRuleRefs={['rule-1']} onClose={jest.fn()} />, {
+      wrapper: makeWrapper(),
+    });
+
+    expect(screen.getByRole('textbox', { name: /evaluation chain name/i })).toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: /evaluation interval/i })).toBeInTheDocument();
+  });
+
+  it('validates name is required', async () => {
+    const user = userEvent.setup();
+    render(<EvaluationChainCreationModal recordingRuleRefs={['rule-1']} onClose={jest.fn()} />, {
+      wrapper: makeWrapper(),
+    });
+
+    // The Create button should be disabled when name is empty (form starts invalid due to required name)
+    const createButton = screen.getByRole('button', { name: /create/i });
+    expect(createButton).toBeDisabled();
+  });
+
+  it('enables create button when name is provided', async () => {
+    const user = userEvent.setup();
+    render(<EvaluationChainCreationModal recordingRuleRefs={['rule-1']} onClose={jest.fn()} />, {
+      wrapper: makeWrapper(),
+    });
+
+    await user.type(screen.getByRole('textbox', { name: /evaluation chain name/i }), 'My Chain');
+
+    expect(screen.getByRole('button', { name: /create/i })).toBeEnabled();
+  });
+
+  it('closes modal on cancel', async () => {
+    const user = userEvent.setup();
+    const onClose = jest.fn();
+    render(<EvaluationChainCreationModal recordingRuleRefs={['rule-1']} onClose={onClose} />, {
+      wrapper: makeWrapper(),
+    });
+
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders modal with correct title', () => {
+    render(<EvaluationChainCreationModal recordingRuleRefs={['rule-1']} onClose={jest.fn()} />, {
+      wrapper: makeWrapper(),
+    });
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText(/new evaluation chain/i)).toBeInTheDocument();
+  });
+});

--- a/public/app/features/alerting/unified/components/rule-editor/evaluation-v2/EvaluationChainCreationModal.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/evaluation-v2/EvaluationChainCreationModal.tsx
@@ -1,0 +1,113 @@
+import { FormProvider, useForm, useFormContext } from 'react-hook-form';
+
+import { Trans, t } from '@grafana/i18n';
+import { Button, Field, Input, Label, Modal, Stack } from '@grafana/ui';
+
+import { evaluateEveryValidationOptions } from '../../../group-details/validation';
+import { useCreateEvaluationChain } from '../../../hooks/useEvaluationChains';
+import { DEFAULT_GROUP_EVALUATION_INTERVAL } from '../../../rule-editor/formDefaults';
+import { type RuleFormValues } from '../../../types/rule-form';
+import { EvaluationGroupQuickPick } from '../EvaluationGroupQuickPick';
+
+interface EvaluationChainCreationModalProps {
+  recordingRuleRefs: string[];
+  onClose: () => void;
+  onCreated?: () => void;
+}
+
+export function EvaluationChainCreationModal({
+  recordingRuleRefs,
+  onClose,
+  onCreated,
+}: EvaluationChainCreationModalProps) {
+  const parentForm = useFormContext<RuleFormValues>();
+  const { createChain, isLoading } = useCreateEvaluationChain();
+
+  const formAPI = useForm({
+    defaultValues: { name: '', interval: DEFAULT_GROUP_EVALUATION_INTERVAL },
+    mode: 'onChange',
+  });
+
+  const { register, handleSubmit, formState, setValue, watch } = formAPI;
+  const currentInterval = watch('interval');
+
+  const onSubmit = handleSubmit(async (values) => {
+    const result = await createChain({
+      name: values.name,
+      interval: values.interval,
+      recordingRuleRefs,
+    });
+    parentForm.setValue('evaluationChainUid', result.uid);
+    parentForm.setValue('evaluationChainName', values.name);
+    parentForm.setValue('evaluateEvery', values.interval);
+    onClose();
+    onCreated?.();
+  });
+
+  return (
+    <Modal
+      isOpen
+      title={t('alerting.evaluation-v2.create-chain-modal.title', 'New evaluation chain')}
+      onDismiss={onClose}
+    >
+      <FormProvider {...formAPI}>
+        <form onSubmit={onSubmit}>
+          <Stack direction="column" gap={2}>
+            <Field
+              noMargin
+              label={
+                <Label htmlFor="chain-name">
+                  <Trans i18nKey="alerting.evaluation-v2.create-chain-modal.name-label">Evaluation chain name</Trans>
+                </Label>
+              }
+              error={formState.errors.name?.message}
+              invalid={Boolean(formState.errors.name)}
+            >
+              <Input
+                id="chain-name"
+                autoFocus
+                {...register('name', {
+                  required: {
+                    value: true,
+                    message: t('alerting.evaluation-v2.create-chain-modal.name-required', 'Required.'),
+                  },
+                })}
+              />
+            </Field>
+
+            <Field
+              noMargin
+              label={
+                <Label htmlFor="chain-interval">
+                  <Trans i18nKey="alerting.evaluation-v2.create-chain-modal.interval-label">Evaluation interval</Trans>
+                </Label>
+              }
+              error={formState.errors.interval?.message}
+              invalid={Boolean(formState.errors.interval)}
+            >
+              <Input
+                id="chain-interval"
+                placeholder={DEFAULT_GROUP_EVALUATION_INTERVAL}
+                {...register('interval', evaluateEveryValidationOptions([]))}
+              />
+            </Field>
+
+            <EvaluationGroupQuickPick
+              currentInterval={currentInterval}
+              onSelect={(interval) => setValue('interval', interval, { shouldValidate: true })}
+            />
+          </Stack>
+
+          <Modal.ButtonRow>
+            <Button variant="secondary" type="button" onClick={onClose}>
+              <Trans i18nKey="alerting.evaluation-v2.create-chain-modal.cancel">Cancel</Trans>
+            </Button>
+            <Button type="submit" disabled={!formState.isValid || isLoading}>
+              <Trans i18nKey="alerting.evaluation-v2.create-chain-modal.create">Create</Trans>
+            </Button>
+          </Modal.ButtonRow>
+        </form>
+      </FormProvider>
+    </Modal>
+  );
+}

--- a/public/app/features/alerting/unified/components/rule-editor/evaluation-v2/EvaluationChainInfoCard.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/evaluation-v2/EvaluationChainInfoCard.tsx
@@ -1,0 +1,32 @@
+import { Trans } from '@grafana/i18n';
+import { Box, Stack, Text } from '@grafana/ui';
+
+import { type EvaluationChain } from '../../../types/evaluation-chain';
+
+interface EvaluationChainInfoCardProps {
+  chain: EvaluationChain;
+}
+
+export function EvaluationChainInfoCard({ chain }: EvaluationChainInfoCardProps) {
+  const memberCount = chain.recordingRuleRefs.length + chain.alertRuleRefs.length;
+
+  return (
+    <Box borderColor="medium" borderStyle="solid" padding={2} borderRadius="default">
+      <Stack direction="column" gap={1}>
+        <Text variant="bodySmall" weight="bold">
+          {chain.name}
+        </Text>
+        <Stack direction="row" gap={2}>
+          <Text variant="bodySmall" color="secondary">
+            <Trans i18nKey="alerting.evaluation-v2.chain-info.interval">Interval: {chain.interval}</Trans>
+          </Text>
+          <Text variant="bodySmall" color="secondary">
+            <Trans i18nKey="alerting.evaluation-v2.chain-info.members" values={{ count: memberCount }}>
+              {'{{count}}'} members
+            </Trans>
+          </Text>
+        </Stack>
+      </Stack>
+    </Box>
+  );
+}

--- a/public/app/features/alerting/unified/components/rule-editor/evaluation-v2/MultiChainWarning.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/evaluation-v2/MultiChainWarning.test.tsx
@@ -1,0 +1,81 @@
+import userEvent from '@testing-library/user-event';
+import * as React from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { render, screen } from 'test/test-utils';
+
+import { type RecordingRuleDetectionResult } from '../../../hooks/useDetectRecordingRuleReferences';
+import { EvaluationScenario } from '../../../types/evaluation-chain';
+import { type RuleFormValues } from '../../../types/rule-form';
+
+import { MultiChainWarning } from './MultiChainWarning';
+
+const mockDetection: RecordingRuleDetectionResult = {
+  scenario: EvaluationScenario.MultipleChains,
+  referencedRecordingRules: [
+    { uid: 'rec-1', name: 'Rule 1', metric: 'cpu_usage', chainUid: 'chain-a', chainName: 'Chain A' },
+    { uid: 'rec-2', name: 'Rule 2', metric: 'memory_usage', chainUid: 'chain-b', chainName: 'Chain B' },
+  ],
+  chains: [
+    {
+      uid: 'chain-a',
+      name: 'Chain A',
+      interval: '1m',
+      intervalSeconds: 60,
+      recordingRuleRefs: ['rec-1'],
+      alertRuleRefs: [],
+    },
+    {
+      uid: 'chain-b',
+      name: 'Chain B',
+      interval: '5m',
+      intervalSeconds: 300,
+      recordingRuleRefs: ['rec-2'],
+      alertRuleRefs: [],
+    },
+  ],
+  warnings: ['Multiple chains detected'],
+  isLoading: false,
+};
+
+function makeWrapper() {
+  return ({ children }: React.PropsWithChildren<{}>) => {
+    const methods = useForm<RuleFormValues>({
+      defaultValues: { evaluateEvery: '1m' } as RuleFormValues,
+    });
+    return <FormProvider {...methods}>{children}</FormProvider>;
+  };
+}
+
+describe('MultiChainWarning', () => {
+  it('renders warning alert about multiple chains', () => {
+    render(<MultiChainWarning detection={mockDetection} onOptOut={jest.fn()} />, {
+      wrapper: makeWrapper(),
+    });
+
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText(/multiple evaluation chains detected/i)).toBeInTheDocument();
+  });
+
+  it('renders chain selector with detected chains as options', () => {
+    render(<MultiChainWarning detection={mockDetection} onOptOut={jest.fn()} />, {
+      wrapper: makeWrapper(),
+    });
+
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
+    expect(screen.getByText(/select evaluation chain/i)).toBeInTheDocument();
+  });
+
+  it('calls onOptOut when opt-out link is clicked', async () => {
+    const user = userEvent.setup();
+    const onOptOut = jest.fn();
+    render(<MultiChainWarning detection={mockDetection} onOptOut={onOptOut} />, {
+      wrapper: makeWrapper(),
+    });
+
+    await user.click(
+      screen.getByRole('button', { name: /I don't want to use a chain, let me configure evaluation manually/i })
+    );
+
+    expect(onOptOut).toHaveBeenCalledTimes(1);
+  });
+});

--- a/public/app/features/alerting/unified/components/rule-editor/evaluation-v2/MultiChainWarning.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/evaluation-v2/MultiChainWarning.tsx
@@ -1,0 +1,57 @@
+import { Controller, useFormContext } from 'react-hook-form';
+
+import { Trans, t } from '@grafana/i18n';
+import { Alert, Button, Field, Select, Stack } from '@grafana/ui';
+
+import { type RecordingRuleDetectionResult } from '../../../hooks/useDetectRecordingRuleReferences';
+import { type RuleFormValues } from '../../../types/rule-form';
+
+interface MultiChainWarningProps {
+  detection: RecordingRuleDetectionResult;
+  onOptOut: () => void;
+}
+
+export function MultiChainWarning({ detection, onOptOut }: MultiChainWarningProps) {
+  const { control } = useFormContext<RuleFormValues>();
+
+  const chainOptions = detection.chains.map((chain) => ({
+    label: `${chain.name} (${chain.interval || 'unknown interval'})`,
+    value: chain.uid,
+  }));
+
+  return (
+    <Stack direction="column" gap={2}>
+      <Alert
+        severity="warning"
+        title={t('alerting.evaluation-v2.multi-chain.title', 'Multiple evaluation chains detected')}
+      >
+        <Trans i18nKey="alerting.evaluation-v2.multi-chain.message">
+          This alert rule queries recording rules from different evaluation chains. Sequential execution of the entire
+          chain cannot be guaranteed. You can choose one of the chains or set a custom evaluation interval.
+        </Trans>
+      </Alert>
+
+      <Field noMargin label={t('alerting.evaluation-v2.multi-chain.select-label', 'Select evaluation chain')}>
+        <Controller
+          name="evaluationChainUid"
+          control={control}
+          render={({ field: { ref, ...field } }) => (
+            <Select
+              {...field}
+              options={chainOptions}
+              onChange={(option) => field.onChange(option.value)}
+              placeholder={t('alerting.evaluation-v2.multi-chain.select-placeholder', 'Choose a chain...')}
+              width={40}
+            />
+          )}
+        />
+      </Field>
+
+      <Button variant="secondary" fill="text" size="sm" onClick={onOptOut}>
+        <Trans i18nKey="alerting.evaluation-v2.multi-chain.opt-out">
+          I don&apos;t want to use a chain, let me configure evaluation manually
+        </Trans>
+      </Button>
+    </Stack>
+  );
+}

--- a/public/app/features/alerting/unified/components/rule-editor/evaluation-v2/StandaloneEvaluation.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/evaluation-v2/StandaloneEvaluation.test.tsx
@@ -1,0 +1,67 @@
+import userEvent from '@testing-library/user-event';
+import * as React from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { render, screen } from 'test/test-utils';
+
+import { RuleFormType, type RuleFormValues } from '../../../types/rule-form';
+
+import { StandaloneEvaluation } from './StandaloneEvaluation';
+
+function makeWrapper(defaultValues: Partial<RuleFormValues> = {}) {
+  return ({ children }: React.PropsWithChildren<{}>) => {
+    const methods = useForm<RuleFormValues>({
+      defaultValues: {
+        evaluateEvery: '1m',
+        type: RuleFormType.grafana,
+        ...defaultValues,
+      } as RuleFormValues,
+    });
+    return <FormProvider {...methods}>{children}</FormProvider>;
+  };
+}
+
+describe('StandaloneEvaluation', () => {
+  it('renders interval input with validation', () => {
+    render(<StandaloneEvaluation />, { wrapper: makeWrapper() });
+
+    expect(screen.getByRole('textbox', { name: /evaluation interval/i })).toBeInTheDocument();
+  });
+
+  it('renders quick-pick buttons', () => {
+    render(<StandaloneEvaluation />, { wrapper: makeWrapper() });
+
+    // EvaluationGroupQuickPick renders buttons for common intervals
+    const buttons = screen.getAllByRole('option');
+    expect(buttons.length).toBeGreaterThan(0);
+  });
+
+  it('does not show opt-in link when showOptInLink is false', () => {
+    render(<StandaloneEvaluation showOptInLink={false} />, { wrapper: makeWrapper() });
+
+    expect(screen.queryByRole('button', { name: /I want to add to an evaluation chain/i })).not.toBeInTheDocument();
+  });
+
+  it('does not show opt-in link when onOptIn is not provided', () => {
+    render(<StandaloneEvaluation showOptInLink={true} />, { wrapper: makeWrapper() });
+
+    // showOptInLink=true but no onOptIn callback — link should not render
+    expect(screen.queryByRole('button', { name: /I want to add to an evaluation chain/i })).not.toBeInTheDocument();
+  });
+
+  it('shows opt-in link when showOptInLink is true and onOptIn is provided', () => {
+    const onOptIn = jest.fn();
+    render(<StandaloneEvaluation showOptInLink onOptIn={onOptIn} />, { wrapper: makeWrapper() });
+
+    expect(screen.getByRole('button', { name: /I want to add to an evaluation chain/i })).toBeInTheDocument();
+  });
+
+  it('calls onOptIn when opt-in link is clicked', async () => {
+    const user = userEvent.setup();
+    const onOptIn = jest.fn();
+    render(<StandaloneEvaluation showOptInLink onOptIn={onOptIn} />, { wrapper: makeWrapper() });
+
+    await user.click(screen.getByRole('button', { name: /I want to add to an evaluation chain/i }));
+
+    expect(onOptIn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/public/app/features/alerting/unified/components/rule-editor/evaluation-v2/StandaloneEvaluation.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/evaluation-v2/StandaloneEvaluation.tsx
@@ -1,0 +1,58 @@
+import { useFormContext } from 'react-hook-form';
+
+import { Trans, t } from '@grafana/i18n';
+import { Button, Field, Input, Stack } from '@grafana/ui';
+
+import { evaluateEveryValidationOptions } from '../../../group-details/validation';
+import { DEFAULT_GROUP_EVALUATION_INTERVAL } from '../../../rule-editor/formDefaults';
+import { type RuleFormValues } from '../../../types/rule-form';
+import { EvaluationGroupQuickPick } from '../EvaluationGroupQuickPick';
+
+interface StandaloneEvaluationProps {
+  onOptIn?: () => void;
+  showOptInLink?: boolean;
+}
+
+export function StandaloneEvaluation({ onOptIn, showOptInLink }: StandaloneEvaluationProps) {
+  const {
+    register,
+    watch,
+    setValue,
+    formState: { errors },
+  } = useFormContext<RuleFormValues>();
+
+  const evaluateEvery = watch('evaluateEvery');
+
+  const setEvaluationInterval = (interval: string) => {
+    setValue('evaluateEvery', interval, { shouldValidate: true });
+    // Keep group in sync: the ruler API requires a non-empty group name.
+    // In the v2 path we derive it from the evaluation interval so that rules
+    // sharing the same cadence land in the same ruler group.
+    setValue('group', interval);
+  };
+
+  return (
+    <Stack direction="column" gap={2}>
+      <Field
+        noMargin
+        label={t('alerting.evaluation-v2.standalone.interval-label', 'Evaluation interval')}
+        description={t('alerting.evaluation-v2.standalone.interval-description', 'How often this rule is evaluated.')}
+        error={errors.evaluateEvery?.message}
+        invalid={Boolean(errors.evaluateEvery)}
+      >
+        <Input
+          id="evaluate-every-input"
+          width={16}
+          placeholder={DEFAULT_GROUP_EVALUATION_INTERVAL}
+          {...register('evaluateEvery', evaluateEveryValidationOptions([]))}
+        />
+      </Field>
+      <EvaluationGroupQuickPick currentInterval={evaluateEvery} onSelect={setEvaluationInterval} />
+      {showOptInLink && onOptIn && (
+        <Button variant="secondary" fill="text" size="sm" onClick={onOptIn}>
+          <Trans i18nKey="alerting.evaluation-v2.standalone.opt-in">I want to add to an evaluation chain</Trans>
+        </Button>
+      )}
+    </Stack>
+  );
+}

--- a/public/app/features/alerting/unified/components/rule-editor/evaluation-v2/StandaloneEvaluation.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/evaluation-v2/StandaloneEvaluation.tsx
@@ -44,7 +44,7 @@ export function StandaloneEvaluation({ onOptIn, showOptInLink }: StandaloneEvalu
           id="evaluate-every-input"
           width={16}
           placeholder={DEFAULT_GROUP_EVALUATION_INTERVAL}
-          {...register('evaluateEvery', evaluateEveryValidationOptions([]))}
+          {...register('evaluateEvery', evaluateEveryValidationOptions<Pick<RuleFormValues, 'evaluateEvery'>>([]))}
         />
       </Field>
       <EvaluationGroupQuickPick currentInterval={evaluateEvery} onSelect={setEvaluationInterval} />

--- a/public/app/features/alerting/unified/featureToggles.ts
+++ b/public/app/features/alerting/unified/featureToggles.ts
@@ -37,3 +37,5 @@ export const shouldUseFullyCompatibleBackendFilters = () =>
  */
 export const shouldShowAlertsActivityBanner = () =>
   (config.featureToggles.alertingAlertsActivityBanner && config.featureToggles.alertingTriage) ?? false;
+
+export const shouldUseRulesAPIV2 = () => config.featureToggles['alerting.rulesAPIV2'] ?? false;

--- a/public/app/features/alerting/unified/hooks/useDetectRecordingRuleReferences.test.ts
+++ b/public/app/features/alerting/unified/hooks/useDetectRecordingRuleReferences.test.ts
@@ -1,0 +1,91 @@
+import { renderHook } from '@testing-library/react';
+import React from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { Provider } from 'react-redux';
+
+import { configureStore } from 'app/store/configureStore';
+
+import { setupMswServer } from '../mockApi';
+import { EvaluationScenario } from '../types/evaluation-chain';
+import { type RuleFormValues } from '../types/rule-form';
+
+import { useDetectRecordingRuleReferences } from './useDetectRecordingRuleReferences';
+
+// Ensure no recording rules come back from the API for most tests
+setupMswServer();
+
+function makeWrapper(defaultValues: Partial<RuleFormValues> = {}) {
+  const store = configureStore();
+  return ({ children }: React.PropsWithChildren<{}>) => {
+    const formMethods = useForm<RuleFormValues>({ defaultValues: defaultValues as RuleFormValues });
+    return React.createElement(Provider, { store }, React.createElement(FormProvider, { ...formMethods }, children));
+  };
+}
+
+describe('useDetectRecordingRuleReferences', () => {
+  it('returns NoRecordingRules when queries have no recording rule references', () => {
+    const { result } = renderHook(() => useDetectRecordingRuleReferences(), {
+      wrapper: makeWrapper({ queries: [] }),
+    });
+
+    expect(result.current.scenario).toBe(EvaluationScenario.NoRecordingRules);
+    expect(result.current.referencedRecordingRules).toHaveLength(0);
+    expect(result.current.chains).toHaveLength(0);
+  });
+
+  it('handles empty queries array', () => {
+    const { result } = renderHook(() => useDetectRecordingRuleReferences(), {
+      wrapper: makeWrapper({ queries: [] }),
+    });
+
+    expect(result.current.scenario).toBe(EvaluationScenario.NoRecordingRules);
+    expect(result.current.warnings).toHaveLength(0);
+  });
+
+  it('handles loading state correctly', () => {
+    const { result } = renderHook(() => useDetectRecordingRuleReferences(), {
+      wrapper: makeWrapper({ queries: [{ refId: 'A', queryType: '', datasourceUid: 'ds-1', model: {} }] }),
+    });
+
+    // Initially loading while the API call resolves
+    expect(result.current.isLoading).toBe(true);
+    // When loading, scenario defaults to NoRecordingRules
+    expect(result.current.scenario).toBe(EvaluationScenario.NoRecordingRules);
+  });
+
+  it('returns NoRecordingRules for expression queries (non-data queries)', () => {
+    const { result } = renderHook(() => useDetectRecordingRuleReferences(), {
+      wrapper: makeWrapper({
+        queries: [
+          // Expression query with special datasource uid
+          { refId: 'B', queryType: '', datasourceUid: '__expr__', model: { type: 'reduce', refId: 'B' } },
+        ],
+      }),
+    });
+
+    // Expression queries are filtered out, so no recording rules detected
+    expect(result.current.scenario).toBe(EvaluationScenario.NoRecordingRules);
+  });
+
+  it('matches recording rules by datasource UID and metric name from expr field', () => {
+    // This test verifies the metric extraction logic for Prometheus-style queries
+    // When a data query has expr = 'simple_metric_name' (a simple identifier),
+    // it should be looked up in the recording rule index
+    const { result } = renderHook(() => useDetectRecordingRuleReferences(), {
+      wrapper: makeWrapper({
+        queries: [
+          {
+            refId: 'A',
+            queryType: '',
+            datasourceUid: 'ds-prom-1',
+            model: { expr: 'cpu_usage' }, // Simple metric name
+          },
+        ],
+      }),
+    });
+
+    // Since the mock API returns no recording rules, scenario is NoRecordingRules
+    // In a real test with MSW providing recording rules, this would match
+    expect(result.current.scenario).toBe(EvaluationScenario.NoRecordingRules);
+  });
+});

--- a/public/app/features/alerting/unified/hooks/useDetectRecordingRuleReferences.test.tsx
+++ b/public/app/features/alerting/unified/hooks/useDetectRecordingRuleReferences.test.tsx
@@ -1,9 +1,11 @@
 import { renderHook } from '@testing-library/react';
-import React from 'react';
+import * as React from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { Provider } from 'react-redux';
 
+import { ExpressionDatasourceUID, ExpressionQueryType } from 'app/features/expressions/types';
 import { configureStore } from 'app/store/configureStore';
+import { type AlertDataQuery, type AlertQuery } from 'app/types/unified-alerting-dto';
 
 import { setupMswServer } from '../mockApi';
 import { EvaluationScenario } from '../types/evaluation-chain';
@@ -16,9 +18,13 @@ setupMswServer();
 
 function makeWrapper(defaultValues: Partial<RuleFormValues> = {}) {
   const store = configureStore();
-  return ({ children }: React.PropsWithChildren<{}>) => {
+  return function Wrapper({ children }: React.PropsWithChildren<{}>) {
     const formMethods = useForm<RuleFormValues>({ defaultValues: defaultValues as RuleFormValues });
-    return React.createElement(Provider, { store }, React.createElement(FormProvider, { ...formMethods }, children));
+    return (
+      <Provider store={store}>
+        <FormProvider {...formMethods}>{children}</FormProvider>
+      </Provider>
+    );
   };
 }
 
@@ -43,8 +49,15 @@ describe('useDetectRecordingRuleReferences', () => {
   });
 
   it('handles loading state correctly', () => {
+    const loadingQuery: AlertQuery<AlertDataQuery> = {
+      refId: 'A',
+      queryType: '',
+      datasourceUid: 'ds-1',
+      model: { refId: 'A' },
+    };
+
     const { result } = renderHook(() => useDetectRecordingRuleReferences(), {
-      wrapper: makeWrapper({ queries: [{ refId: 'A', queryType: '', datasourceUid: 'ds-1', model: {} }] }),
+      wrapper: makeWrapper({ queries: [loadingQuery] }),
     });
 
     // Initially loading while the API call resolves
@@ -54,13 +67,15 @@ describe('useDetectRecordingRuleReferences', () => {
   });
 
   it('returns NoRecordingRules for expression queries (non-data queries)', () => {
+    const expressionQuery: AlertQuery = {
+      refId: 'B',
+      queryType: '',
+      datasourceUid: ExpressionDatasourceUID,
+      model: { type: ExpressionQueryType.reduce, refId: 'B' },
+    };
+
     const { result } = renderHook(() => useDetectRecordingRuleReferences(), {
-      wrapper: makeWrapper({
-        queries: [
-          // Expression query with special datasource uid
-          { refId: 'B', queryType: '', datasourceUid: '__expr__', model: { type: 'reduce', refId: 'B' } },
-        ],
-      }),
+      wrapper: makeWrapper({ queries: [expressionQuery] }),
     });
 
     // Expression queries are filtered out, so no recording rules detected
@@ -68,24 +83,22 @@ describe('useDetectRecordingRuleReferences', () => {
   });
 
   it('matches recording rules by datasource UID and metric name from expr field', () => {
-    // This test verifies the metric extraction logic for Prometheus-style queries
-    // When a data query has expr = 'simple_metric_name' (a simple identifier),
-    // it should be looked up in the recording rule index
+    // Verifies the metric extraction logic for Prometheus-style queries: when a
+    // data query has expr = 'simple_metric_name', it should be looked up in the
+    // recording rule index.
+    const promQuery: AlertQuery<AlertDataQuery & { expr: string }> = {
+      refId: 'A',
+      queryType: '',
+      datasourceUid: 'ds-prom-1',
+      model: { refId: 'A', expr: 'cpu_usage' },
+    };
+
     const { result } = renderHook(() => useDetectRecordingRuleReferences(), {
-      wrapper: makeWrapper({
-        queries: [
-          {
-            refId: 'A',
-            queryType: '',
-            datasourceUid: 'ds-prom-1',
-            model: { expr: 'cpu_usage' }, // Simple metric name
-          },
-        ],
-      }),
+      wrapper: makeWrapper({ queries: [promQuery] }),
     });
 
-    // Since the mock API returns no recording rules, scenario is NoRecordingRules
-    // In a real test with MSW providing recording rules, this would match
+    // Since the mock API returns no recording rules, scenario is NoRecordingRules.
+    // In a real test with MSW providing recording rules, this would match.
     expect(result.current.scenario).toBe(EvaluationScenario.NoRecordingRules);
   });
 });

--- a/public/app/features/alerting/unified/hooks/useDetectRecordingRuleReferences.ts
+++ b/public/app/features/alerting/unified/hooks/useDetectRecordingRuleReferences.ts
@@ -1,0 +1,155 @@
+import { useMemo } from 'react';
+import { useFormContext } from 'react-hook-form';
+
+import { type AlertQuery } from 'app/types/unified-alerting-dto';
+
+import { type EvaluationChain, EvaluationScenario, type RecordingRuleReference } from '../types/evaluation-chain';
+import { type RuleFormValues } from '../types/rule-form';
+
+import { useEvaluationChains } from './useEvaluationChains';
+import { useRecordingRulesByMetric } from './useRecordingRulesByMetric';
+
+export interface RecordingRuleDetectionResult {
+  scenario: EvaluationScenario;
+  referencedRecordingRules: RecordingRuleReference[];
+  chains: EvaluationChain[];
+  recommendedChainUid?: string;
+  warnings: string[];
+  isLoading: boolean;
+}
+
+export function useDetectRecordingRuleReferences(): RecordingRuleDetectionResult {
+  const { watch } = useFormContext<RuleFormValues>();
+  const queries = watch('queries');
+
+  const { byDatasourceAndMetric, isLoading: loadingRecordingRules } = useRecordingRulesByMetric();
+  const { getChainsForRuleUid, isLoading: loadingChains } = useEvaluationChains();
+
+  return useMemo(() => {
+    const isLoading = loadingRecordingRules || loadingChains;
+
+    if (isLoading || !queries?.length) {
+      return {
+        scenario: EvaluationScenario.NoRecordingRules,
+        referencedRecordingRules: [],
+        chains: [],
+        warnings: [],
+        isLoading,
+      };
+    }
+
+    // Step 1: Find data queries (non-expression queries) by checking datasourceUid
+    // Expression queries have a special datasource uid like "__expr__"
+    const dataQueries = queries.filter((q: AlertQuery) => {
+      const uid = q.datasourceUid;
+      return uid !== '__expr__' && uid !== '-100';
+    });
+
+    // Step 2: Match against known recording rules by datasource + metric
+    const matchedRules: RecordingRuleReference[] = [];
+    for (const query of dataQueries) {
+      const metric = extractMetricFromQuery(query);
+      if (!metric) {
+        continue;
+      }
+      const key = `${query.datasourceUid}::${metric}`;
+      const recordingRule = byDatasourceAndMetric.get(key);
+      if (recordingRule) {
+        // Resolve chain membership
+        const chains = getChainsForRuleUid(recordingRule.uid);
+        matchedRules.push({
+          ...recordingRule,
+          chainUid: chains[0]?.uid,
+          chainName: chains[0]?.name,
+        });
+      }
+    }
+
+    // Step 3: Classify scenario
+    if (matchedRules.length === 0) {
+      return {
+        scenario: EvaluationScenario.NoRecordingRules,
+        referencedRecordingRules: [],
+        chains: [],
+        warnings: [],
+        isLoading: false,
+      };
+    }
+
+    const uniqueChainUids = new Set(matchedRules.map((r) => r.chainUid).filter(Boolean));
+    const unchainedRules = matchedRules.filter((r) => !r.chainUid);
+    const allChains: EvaluationChain[] = [...uniqueChainUids]
+      .map((uid): EvaluationChain | undefined => {
+        const rule = matchedRules.find((r) => r.chainUid === uid);
+        return rule && uid
+          ? {
+              uid,
+              name: rule.chainName ?? '',
+              interval: '',
+              intervalSeconds: 0,
+              recordingRuleRefs: [],
+              alertRuleRefs: [],
+            }
+          : undefined;
+      })
+      .filter((chain): chain is EvaluationChain => chain !== undefined);
+
+    // All referenced rules are unchained
+    if (uniqueChainUids.size === 0) {
+      return {
+        scenario: EvaluationScenario.UnchainedRecordingRules,
+        referencedRecordingRules: matchedRules,
+        chains: [],
+        warnings: [],
+        isLoading: false,
+      };
+    }
+
+    // All referenced rules belong to the same chain (some may be unchained too)
+    if (uniqueChainUids.size === 1 && unchainedRules.length === 0) {
+      const chainUid = [...uniqueChainUids][0]!;
+      return {
+        scenario: EvaluationScenario.SingleChain,
+        referencedRecordingRules: matchedRules,
+        chains: allChains,
+        recommendedChainUid: chainUid,
+        warnings: [],
+        isLoading: false,
+      };
+    }
+
+    // Multiple chains or mix of chained + unchained
+    return {
+      scenario: EvaluationScenario.MultipleChains,
+      referencedRecordingRules: matchedRules,
+      chains: allChains,
+      warnings: [
+        'This alert rule queries recording rules from different evaluation chains. Sequential execution cannot be guaranteed.',
+      ],
+      isLoading: false,
+    };
+  }, [queries, byDatasourceAndMetric, getChainsForRuleUid, loadingRecordingRules, loadingChains]);
+}
+
+/**
+ * Extract metric name from a data query model.
+ * This is a heuristic — different data sources store the metric differently.
+ */
+function extractMetricFromQuery(query: AlertQuery): string | undefined {
+  // query.model is a loose data-source-specific shape; access fields dynamically.
+  const expr: unknown = Reflect.get(query.model, 'expr');
+  // Prometheus-style: expr field contains the metric or PromQL
+  if (typeof expr === 'string') {
+    // Simple metric reference (no operators/functions) — most recording rule queries
+    const trimmed = expr.trim();
+    if (/^[a-zA-Z_:][a-zA-Z0-9_:]*$/.test(trimmed)) {
+      return trimmed;
+    }
+  }
+  // Grafana recording rule metric field
+  const metric: unknown = Reflect.get(query.model, 'metric');
+  if (typeof metric === 'string') {
+    return metric;
+  }
+  return undefined;
+}

--- a/public/app/features/alerting/unified/hooks/useEvaluationChains.ts
+++ b/public/app/features/alerting/unified/hooks/useEvaluationChains.ts
@@ -1,0 +1,43 @@
+import { useMemo } from 'react';
+
+import { type EvaluationChain } from '../types/evaluation-chain';
+
+/**
+ * Mock hook for fetching evaluation chains.
+ * TODO: Replace with real API call when EvaluationChain K8s kind is available.
+ * Use auto-generated client from @grafana/api-clients when ready.
+ */
+export function useEvaluationChains(): {
+  chains: EvaluationChain[];
+  isLoading: boolean;
+  getChainByUid: (uid: string) => EvaluationChain | undefined;
+  getChainsForRuleUid: (ruleUid: string) => EvaluationChain[];
+} {
+  // Mock: no chains exist until backend API is available
+  const chains: EvaluationChain[] = useMemo(() => [], []);
+
+  const getChainByUid = useMemo(() => {
+    const map = new Map(chains.map((c) => [c.uid, c]));
+    return (uid: string) => map.get(uid);
+  }, [chains]);
+
+  const getChainsForRuleUid = useMemo(() => {
+    return (ruleUid: string) =>
+      chains.filter((c) => c.recordingRuleRefs.includes(ruleUid) || c.alertRuleRefs.includes(ruleUid));
+  }, [chains]);
+
+  return { chains, isLoading: false, getChainByUid, getChainsForRuleUid };
+}
+
+/**
+ * Mock hook for creating an evaluation chain.
+ * TODO: Replace with real mutation when EvaluationChain K8s kind is available.
+ */
+export function useCreateEvaluationChain() {
+  const createChain = async (_spec: { name: string; interval: string; recordingRuleRefs: string[] }) => {
+    // Mock: return a fake UID. In production, this calls the chain API.
+    return { uid: `mock-chain-${Date.now()}` };
+  };
+
+  return { createChain, isLoading: false };
+}

--- a/public/app/features/alerting/unified/hooks/useRecordingRulesByMetric.test.ts
+++ b/public/app/features/alerting/unified/hooks/useRecordingRulesByMetric.test.ts
@@ -1,0 +1,127 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { HttpResponse, http } from 'msw';
+import React from 'react';
+import { Provider } from 'react-redux';
+
+import { configureStore } from 'app/store/configureStore';
+
+import { setupMswServer } from '../mockApi';
+
+import { useRecordingRulesByMetric } from './useRecordingRulesByMetric';
+
+const server = setupMswServer();
+
+function getWrapper() {
+  const store = configureStore();
+  return ({ children }: React.PropsWithChildren<{}>) => React.createElement(Provider, { store }, children);
+}
+
+describe('useRecordingRulesByMetric', () => {
+  it('returns empty map when no recording rules exist', async () => {
+    server.use(
+      http.get('/apis/rules.alerting.grafana.app/v0alpha1/namespaces/default/recordingrules', () =>
+        HttpResponse.json({ items: [], metadata: {}, apiVersion: 'v1', kind: 'RecordingRuleList' })
+      )
+    );
+
+    const { result } = renderHook(() => useRecordingRulesByMetric(), { wrapper: getWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.byDatasourceAndMetric.size).toBe(0);
+    expect(result.current.error).toBeUndefined();
+  });
+
+  it('indexes recording rules by datasource UID and metric name', async () => {
+    server.use(
+      http.get('/apis/rules.alerting.grafana.app/v0alpha1/namespaces/default/recordingrules', () =>
+        HttpResponse.json({
+          items: [
+            {
+              apiVersion: 'rules.alerting.grafana.app/v0alpha1',
+              kind: 'RecordingRule',
+              metadata: { name: 'rule-uid-1' },
+              spec: {
+                title: 'CPU Usage Rule',
+                metric: 'cpu_usage',
+                targetDatasourceUID: 'ds-prom-1',
+                expressions: {},
+                trigger: {},
+              },
+            },
+            {
+              apiVersion: 'rules.alerting.grafana.app/v0alpha1',
+              kind: 'RecordingRule',
+              metadata: { name: 'rule-uid-2' },
+              spec: {
+                title: 'Memory Usage Rule',
+                metric: 'memory_usage',
+                targetDatasourceUID: 'ds-prom-1',
+                expressions: {},
+                trigger: {},
+              },
+            },
+          ],
+          metadata: {},
+          apiVersion: 'v1',
+          kind: 'RecordingRuleList',
+        })
+      )
+    );
+
+    const { result } = renderHook(() => useRecordingRulesByMetric(), { wrapper: getWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.byDatasourceAndMetric.size).toBe(2);
+    expect(result.current.byDatasourceAndMetric.get('ds-prom-1::cpu_usage')).toMatchObject({
+      uid: 'rule-uid-1',
+      name: 'CPU Usage Rule',
+      metric: 'cpu_usage',
+    });
+    expect(result.current.byDatasourceAndMetric.get('ds-prom-1::memory_usage')).toMatchObject({
+      uid: 'rule-uid-2',
+      name: 'Memory Usage Rule',
+      metric: 'memory_usage',
+    });
+  });
+
+  it('handles duplicate metric names across different datasources', async () => {
+    server.use(
+      http.get('/apis/rules.alerting.grafana.app/v0alpha1/namespaces/default/recordingrules', () =>
+        HttpResponse.json({
+          items: [
+            {
+              metadata: { name: 'rule-a' },
+              spec: { title: 'Rule A', metric: 'cpu_usage', targetDatasourceUID: 'ds-1', expressions: {}, trigger: {} },
+            },
+            {
+              metadata: { name: 'rule-b' },
+              spec: { title: 'Rule B', metric: 'cpu_usage', targetDatasourceUID: 'ds-2', expressions: {}, trigger: {} },
+            },
+          ],
+          metadata: {},
+        })
+      )
+    );
+
+    const { result } = renderHook(() => useRecordingRulesByMetric(), { wrapper: getWrapper() });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.byDatasourceAndMetric.size).toBe(2);
+    expect(result.current.byDatasourceAndMetric.get('ds-1::cpu_usage')?.uid).toBe('rule-a');
+    expect(result.current.byDatasourceAndMetric.get('ds-2::cpu_usage')?.uid).toBe('rule-b');
+  });
+
+  it('returns loading state while fetching', () => {
+    const { result } = renderHook(() => useRecordingRulesByMetric(), { wrapper: getWrapper() });
+    expect(result.current.isLoading).toBe(true);
+  });
+});

--- a/public/app/features/alerting/unified/hooks/useRecordingRulesByMetric.test.tsx
+++ b/public/app/features/alerting/unified/hooks/useRecordingRulesByMetric.test.tsx
@@ -1,6 +1,6 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { HttpResponse, http } from 'msw';
-import React from 'react';
+import * as React from 'react';
 import { Provider } from 'react-redux';
 
 import { configureStore } from 'app/store/configureStore';
@@ -13,7 +13,9 @@ const server = setupMswServer();
 
 function getWrapper() {
   const store = configureStore();
-  return ({ children }: React.PropsWithChildren<{}>) => React.createElement(Provider, { store }, children);
+  return function Wrapper({ children }: React.PropsWithChildren<{}>) {
+    return <Provider store={store}>{children}</Provider>;
+  };
 }
 
 describe('useRecordingRulesByMetric', () => {

--- a/public/app/features/alerting/unified/hooks/useRecordingRulesByMetric.ts
+++ b/public/app/features/alerting/unified/hooks/useRecordingRulesByMetric.ts
@@ -1,0 +1,37 @@
+import { useMemo } from 'react';
+
+import { generatedAPI } from '@grafana/api-clients/rtkq/rules.alerting/v0alpha1';
+
+import { type RecordingRuleReference } from '../types/evaluation-chain';
+
+interface RecordingRuleIndex {
+  /** Map key is `${targetDatasourceUID}::${metric}` */
+  byDatasourceAndMetric: Map<string, RecordingRuleReference>;
+  isLoading: boolean;
+  error: unknown;
+}
+
+export function useRecordingRulesByMetric(): RecordingRuleIndex {
+  const { data, isLoading, error } = generatedAPI.useListRecordingRuleQuery({});
+
+  const byDatasourceAndMetric = useMemo(() => {
+    const map = new Map<string, RecordingRuleReference>();
+    if (!data?.items) {
+      return map;
+    }
+    for (const rule of data.items) {
+      const key = `${rule.spec.targetDatasourceUID}::${rule.spec.metric}`;
+      map.set(key, {
+        uid: rule.metadata.name ?? '',
+        name: rule.spec.title,
+        metric: rule.spec.metric,
+        // Chain membership resolved separately — undefined for now
+        chainUid: undefined,
+        chainName: undefined,
+      });
+    }
+    return map;
+  }, [data]);
+
+  return { byDatasourceAndMetric, isLoading, error };
+}

--- a/public/app/features/alerting/unified/mocks/server/all-handlers.ts
+++ b/public/app/features/alerting/unified/mocks/server/all-handlers.ts
@@ -13,6 +13,7 @@ import historianHandlers from 'app/features/alerting/unified/mocks/server/handle
 import inhibitionRulesK8sHandlers from 'app/features/alerting/unified/mocks/server/handlers/k8s/inhibitionRules.k8s';
 import integrationTypeSchemasK8sHandlers from 'app/features/alerting/unified/mocks/server/handlers/k8s/integrationTypeSchemas.k8s';
 import receiverK8sHandlers from 'app/features/alerting/unified/mocks/server/handlers/k8s/receivers.k8s';
+import recordingRulesK8sHandlers from 'app/features/alerting/unified/mocks/server/handlers/k8s/recordingRules.k8s';
 import routingTreeK8sHandlers from 'app/features/alerting/unified/mocks/server/handlers/k8s/routingtrees.k8s';
 import templatesK8sHandlers from 'app/features/alerting/unified/mocks/server/handlers/k8s/templates.k8s';
 import timeIntervalK8sHandlers from 'app/features/alerting/unified/mocks/server/handlers/k8s/timeIntervals.k8s';
@@ -46,6 +47,7 @@ export const alertingHandlers = [
   ...receiverTestK8sHandlers,
   ...templatesK8sHandlers,
   ...routingTreeK8sHandlers,
+  ...recordingRulesK8sHandlers,
 ];
 
 /**

--- a/public/app/features/alerting/unified/mocks/server/handlers/k8s/recordingRules.k8s.ts
+++ b/public/app/features/alerting/unified/mocks/server/handlers/k8s/recordingRules.k8s.ts
@@ -1,0 +1,20 @@
+import { HttpResponse, http } from 'msw';
+
+import { type RecordingRuleList } from '@grafana/api-clients/rtkq/rules.alerting/v0alpha1';
+
+const RULES_ALERTING_API_SERVER_BASE_URL = '/apis/rules.alerting.grafana.app/v0alpha1';
+
+const emptyRecordingRuleList: RecordingRuleList = {
+  apiVersion: 'rules.alerting.grafana.app/v0alpha1',
+  kind: 'RecordingRuleList',
+  items: [],
+  metadata: {},
+};
+
+const listNamespacedRecordingRuleHandler = () =>
+  http.get<{ namespace: string }>(`${RULES_ALERTING_API_SERVER_BASE_URL}/namespaces/:namespace/recordingrules`, () =>
+    HttpResponse.json(emptyRecordingRuleList)
+  );
+
+const handlers = [listNamespacedRecordingRuleHandler()];
+export default handlers;

--- a/public/app/features/alerting/unified/types/evaluation-chain.ts
+++ b/public/app/features/alerting/unified/types/evaluation-chain.ts
@@ -1,0 +1,24 @@
+export interface EvaluationChain {
+  uid: string;
+  name: string;
+  intervalSeconds: number;
+  interval: string; // Formatted PromDuration e.g. "1m"
+  recordingRuleRefs: string[]; // Rule UIDs
+  alertRuleRefs: string[]; // Rule UIDs
+  folderUid?: string;
+}
+
+export interface RecordingRuleReference {
+  uid: string;
+  name: string;
+  metric: string;
+  chainUid?: string; // undefined if not in any chain
+  chainName?: string;
+}
+
+export enum EvaluationScenario {
+  NoRecordingRules = 'no-recording-rules',
+  SingleChain = 'single-chain',
+  UnchainedRecordingRules = 'unchained-recording-rules',
+  MultipleChains = 'multiple-chains',
+}

--- a/public/app/features/alerting/unified/types/rule-form.ts
+++ b/public/app/features/alerting/unified/types/rule-form.ts
@@ -59,6 +59,11 @@ export interface RuleFormValues {
   editorSettings?: SimplifiedEditor;
   metric?: string;
   targetDatasourceUid?: string;
+
+  // Evaluation chain fields (only used when alerting.rulesAPIV2 flag is on)
+  evaluationChainUid?: string;
+  evaluationChainName?: string;
+
   // cortex / loki rules
   namespace: string;
   forTime: number;

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1197,6 +1197,45 @@
       "body-minimum-interval": "A minimum evaluation interval of <strong>{{minInterval}}</strong> has been configured in Grafana.<br/>Please contact the administrator to configure a lower interval.",
       "title-global-evaluation-interval-limit-exceeded": "Global evaluation interval limit exceeded"
     },
+    "evaluation-v2": {
+      "chain-info": {
+        "interval": "Interval: <1></1>",
+        "members_one": "{{count}} members",
+        "members_other": "{{count}} members"
+      },
+      "chain-recommendation": {
+        "message": "This alert rule queries a recording rule that belongs to an evaluation chain. We recommend adding this alert rule to the same chain to ensure the recording rule always evaluates first.",
+        "opt-out": "I don't want to use a chain, let me configure evaluation manually",
+        "title": "Recording rule dependency detected"
+      },
+      "create-chain": {
+        "create-button": "Create evaluation chain",
+        "message": "This alert rule queries recording rules ({{ruleNames}}) that don't belong to any evaluation chain. We recommend creating a new chain to ensure the recording rules always evaluate first.",
+        "opt-out": "I don't want to use a chain, let me configure evaluation manually",
+        "title": "Recording rule dependency detected"
+      },
+      "create-chain-modal": {
+        "cancel": "Cancel",
+        "create": "Create",
+        "interval-label": "Evaluation interval",
+        "name-label": "Evaluation chain name",
+        "name-required": "Required.",
+        "title": "New evaluation chain"
+      },
+      "multi-chain": {
+        "message": "This alert rule queries recording rules from different evaluation chains. Sequential execution of the entire chain cannot be guaranteed. You can choose one of the chains or set a custom evaluation interval.",
+        "opt-out": "I don't want to use a chain, let me configure evaluation manually",
+        "select-label": "Select evaluation chain",
+        "select-placeholder": "Choose a chain...",
+        "title": "Multiple evaluation chains detected"
+      },
+      "section-title": "Set evaluation behavior",
+      "standalone": {
+        "interval-description": "How often this rule is evaluated.",
+        "interval-label": "Evaluation interval",
+        "opt-in": "I want to add to an evaluation chain"
+      }
+    },
     "existing-rule-editor": {
       "sorry-permission": "Sorry! You do not have permission to edit this rule.",
       "sorry-this-rule-does-not-exist": "Sorry! This rule does not exist.",


### PR DESCRIPTION
**What is this feature?**

A new evaluation step UI for Grafana managed alert rules, activated by the alerting.rulesAPIV2 feature flag. When the flag is on, the group selector is replaced by a direct interval picker. It also detects when the rule's queries reference recording rules and surfaces contextual recommendations, adding the rule to an existing evaluation chain, creating a new chain, or warning when recording rules span multiple chains.

https://github.com/user-attachments/assets/89f40fae-b2a1-4d00-b0f6-ab4f6bffe5cf

**What to test**
 1. V2 evaluation UI (no recording rules)
    i. Go to Alerting → Alert rules → + New alert rule
    ii. Navigate to step 4
    iii. Check: Interval input + quick-picks instead of group selector dropdown.

  2. Opt-out / opt-in toggle
    i. From Scenario 1, with a recording rule already created (see Scenario 3 setup), create an alert rule whose query references cpu_idle_avg on gdev-prometheus. Go to step 4.
    ii. Check: Blue banner shown. Click "I don't want to use a chain, let me configure evaluation manually".
    iii. Check: Banner disappears, interval picker shown with "I want to add to an evaluation chain" link at the bottom.
    iv. Click that link.
    v. Check: Banner reappears
