### PR TITLE
Dashboards: Separate filters from variables in section-level outline

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/DashboardOutline.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardOutline.tsx
@@ -10,6 +10,7 @@ import { Box, Icon, ScrollContainer, Sidebar, Text, useElementSelection, useStyl
 import { DashboardLinksSet } from '../settings/links/DashboardLinksSet';
 import { LinkEdit } from '../settings/links/LinkAddEditableElement';
 import { DashboardFiltersSet } from '../settings/variables/DashboardFiltersSet';
+import { SectionFiltersSet } from '../settings/variables/SectionFiltersSet';
 import { isRepeatCloneOrChildOf } from '../utils/clone';
 import { DashboardInteractions } from '../utils/interactions';
 import { getDashboardSceneFor } from '../utils/utils';
@@ -76,7 +77,8 @@ function DashboardOutlineNode({ sceneObject, editPane, isEditing, depth, index }
       if (
         sceneObject instanceof LinkEdit ||
         sceneObject instanceof DashboardLinksSet ||
-        sceneObject instanceof DashboardFiltersSet
+        sceneObject instanceof DashboardFiltersSet ||
+        sceneObject instanceof SectionFiltersSet
       ) {
         // Select directly via editPane.selectObject because these objects are not
         // in the scene graph, so sceneGraph.findByKey (used by onSelect) can't find them.

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { store } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { logWarning } from '@grafana/runtime';
+import { config, logWarning } from '@grafana/runtime';
 import { getFeatureFlagClient } from '@grafana/runtime/internal';
 import {
   NewSceneObjectAddedEvent,
@@ -24,6 +24,7 @@ import { ConditionalRenderingGroup } from '../../conditional-rendering/group/Con
 import { dashboardEditActions } from '../../edit-pane/shared';
 import { serializeRow } from '../../serialization/layoutSerializers/RowsLayoutSerializer';
 import { getElements } from '../../serialization/layoutSerializers/utils';
+import { SectionFiltersSet } from '../../settings/variables/SectionFiltersSet';
 import { removeRepeatLocalVariableFromSet } from '../../utils/clone';
 import { type PanelIdGenerator } from '../../utils/dashboardSceneGraph';
 import { trackDropItemCrossLayout } from '../../utils/tracking';
@@ -73,6 +74,7 @@ export class RowItem
   public readonly isEditableDashboardElement = true;
   public readonly isDashboardDropTarget = true;
   public containerRef: React.MutableRefObject<HTMLDivElement | null> = React.createRef<HTMLDivElement>();
+  private _filtersSet?: SectionFiltersSet;
 
   public constructor(state?: Partial<RowItemState>) {
     super({
@@ -105,6 +107,13 @@ export class RowItem
     };
   }
 
+  private getFiltersSet(): SectionFiltersSet {
+    if (!this._filtersSet) {
+      this._filtersSet = new SectionFiltersSet({ sectionRef: this.getRef() });
+    }
+    return this._filtersSet;
+  }
+
   public getOutlineChildren(isEditing?: boolean): SceneObject[] {
     const layoutChildren = this.state.layout.getOutlineChildren();
     if (
@@ -112,7 +121,11 @@ export class RowItem
       getFeatureFlagClient().getBooleanValue('dashboardSectionVariables', false) &&
       this.state.$variables
     ) {
-      return [this.state.$variables, ...layoutChildren];
+      return [
+        ...(config.featureToggles.dashboardUnifiedDrilldownControls ? [this.getFiltersSet()] : []),
+        this.state.$variables,
+        ...layoutChildren,
+      ];
     }
     return layoutChildren;
   }

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { store } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { logWarning } from '@grafana/runtime';
+import { config, logWarning } from '@grafana/runtime';
 import { getFeatureFlagClient } from '@grafana/runtime/internal';
 import {
   NewSceneObjectAddedEvent,
@@ -24,6 +24,7 @@ import { ConditionalRenderingGroup } from '../../conditional-rendering/group/Con
 import { dashboardEditActions } from '../../edit-pane/shared';
 import { serializeTab } from '../../serialization/layoutSerializers/TabsLayoutSerializer';
 import { getElements } from '../../serialization/layoutSerializers/utils';
+import { SectionFiltersSet } from '../../settings/variables/SectionFiltersSet';
 import { removeRepeatLocalVariableFromSet } from '../../utils/clone';
 import { type PanelIdGenerator } from '../../utils/dashboardSceneGraph';
 import { trackDropItemCrossLayout } from '../../utils/tracking';
@@ -71,6 +72,7 @@ export class TabItem
 
   public readonly isEditableDashboardElement = true;
   public readonly isDashboardDropTarget = true;
+  private _filtersSet?: SectionFiltersSet;
 
   public containerRef = React.createRef<HTMLDivElement>();
 
@@ -105,6 +107,13 @@ export class TabItem
     };
   }
 
+  private getFiltersSet(): SectionFiltersSet {
+    if (!this._filtersSet) {
+      this._filtersSet = new SectionFiltersSet({ sectionRef: this.getRef() });
+    }
+    return this._filtersSet;
+  }
+
   public getOutlineChildren(isEditing?: boolean): SceneObject[] {
     const layoutChildren = this.state.layout.getOutlineChildren();
     if (
@@ -112,7 +121,11 @@ export class TabItem
       getFeatureFlagClient().getBooleanValue('dashboardSectionVariables', false) &&
       this.state.$variables
     ) {
-      return [this.state.$variables, ...layoutChildren];
+      return [
+        ...(config.featureToggles.dashboardUnifiedDrilldownControls ? [this.getFiltersSet()] : []),
+        this.state.$variables,
+        ...layoutChildren,
+      ];
     }
     return layoutChildren;
   }

--- a/public/app/features/dashboard-scene/settings/links/DashboardLinksSet.tsx
+++ b/public/app/features/dashboard-scene/settings/links/DashboardLinksSet.tsx
@@ -51,13 +51,10 @@ export class DashboardLinksSet extends SceneObjectBase<DashboardLinksSetState> i
   }
 
   public getEditableElementInfo(): EditableDashboardElementInfo {
-    const dashboard = this.state.dashboardRef.resolve();
-    const links = dashboard.state.links ?? [];
     return {
       typeName: t('dashboard.edit-pane.elements.link-set', 'Links'),
       icon: 'link',
       instanceName: t('dashboard.edit-pane.elements.link-set', 'Links'),
-      isHidden: links.length === 0,
     };
   }
 

--- a/public/app/features/dashboard-scene/settings/variables/DashboardFiltersSet.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/DashboardFiltersSet.tsx
@@ -72,12 +72,10 @@ export class DashboardFiltersSet extends SceneObjectBase<DashboardFiltersSetStat
   }
 
   public getEditableElementInfo(): EditableDashboardElementInfo {
-    const filters = this.getAdhocVariables();
     return {
       typeName: t('dashboard.edit-pane.elements.filters-set', 'Filters'),
       icon: 'filter',
       instanceName: t('dashboard.edit-pane.elements.filters-set', 'Filters'),
-      isHidden: filters.length === 0,
     };
   }
 

--- a/public/app/features/dashboard-scene/settings/variables/SectionFiltersSet.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/SectionFiltersSet.test.tsx
@@ -1,0 +1,136 @@
+import { VariableHide } from '@grafana/data';
+import { AdHocFiltersVariable, CustomVariable, SceneVariableSet } from '@grafana/scenes';
+
+import { DashboardScene } from '../../scene/DashboardScene';
+import { AutoGridLayoutManager } from '../../scene/layout-auto-grid/AutoGridLayoutManager';
+import { RowItem } from '../../scene/layout-rows/RowItem';
+import { RowsLayoutManager } from '../../scene/layout-rows/RowsLayoutManager';
+
+import { SectionFiltersSet } from './SectionFiltersSet';
+
+function buildRow({
+  includeFilter = false,
+  includeCustom = false,
+  filterHide = VariableHide.dontHide,
+}: { includeFilter?: boolean; includeCustom?: boolean; filterHide?: VariableHide } = {}) {
+  const variables = [
+    ...(includeFilter ? [new AdHocFiltersVariable({ name: 'filter0', type: 'adhoc', hide: filterHide })] : []),
+    ...(includeCustom ? [new CustomVariable({ name: 'custom0', query: 'a,b', value: ['a'], text: ['a'] })] : []),
+  ];
+
+  const row = new RowItem({
+    $variables: new SceneVariableSet({ variables }),
+    layout: AutoGridLayoutManager.createEmpty(),
+  });
+
+  new DashboardScene({
+    body: new RowsLayoutManager({ rows: [row] }),
+  });
+
+  return row;
+}
+
+describe('SectionFiltersSet', () => {
+  describe('getEditableElementInfo', () => {
+    it('returns Filters label and filter icon', () => {
+      const row = buildRow({ includeFilter: true });
+      const filtersSet = new SectionFiltersSet({ sectionRef: row.getRef() });
+
+      const info = filtersSet.getEditableElementInfo();
+
+      expect(info.typeName).toBe('Filters');
+      expect(info.instanceName).toBe('Filters');
+      expect(info.icon).toBe('filter');
+    });
+
+    it('is hidden when no adhoc variables exist', () => {
+      const row = buildRow({ includeCustom: true });
+      const filtersSet = new SectionFiltersSet({ sectionRef: row.getRef() });
+
+      const info = filtersSet.getEditableElementInfo();
+
+      expect(info.isHidden).toBe(true);
+    });
+
+    it('is not hidden when adhoc variables exist', () => {
+      const row = buildRow({ includeFilter: true });
+      const filtersSet = new SectionFiltersSet({ sectionRef: row.getRef() });
+
+      const info = filtersSet.getEditableElementInfo();
+
+      expect(info.isHidden).toBe(false);
+    });
+
+    it('is hidden when section has no variables at all', () => {
+      const row = buildRow();
+      const filtersSet = new SectionFiltersSet({ sectionRef: row.getRef() });
+
+      const info = filtersSet.getEditableElementInfo();
+
+      expect(info.isHidden).toBe(true);
+    });
+  });
+
+  describe('getOutlineChildren', () => {
+    it('returns only adhoc variables', () => {
+      const row = buildRow({ includeFilter: true, includeCustom: true });
+      const filtersSet = new SectionFiltersSet({ sectionRef: row.getRef() });
+
+      const children = filtersSet.getOutlineChildren();
+
+      expect(children).toHaveLength(1);
+      expect(children[0].state.name).toBe('filter0');
+    });
+
+    it('returns empty array when no adhoc variables exist', () => {
+      const row = buildRow({ includeCustom: true });
+      const filtersSet = new SectionFiltersSet({ sectionRef: row.getRef() });
+
+      const children = filtersSet.getOutlineChildren();
+
+      expect(children).toHaveLength(0);
+    });
+
+    it('partitions variables by display mode', () => {
+      const visibleFilter = new AdHocFiltersVariable({
+        name: 'visibleFilter',
+        type: 'adhoc',
+        hide: VariableHide.dontHide,
+      });
+      const hiddenFilter = new AdHocFiltersVariable({
+        name: 'hiddenFilter',
+        type: 'adhoc',
+        hide: VariableHide.hideVariable,
+      });
+      const controlsMenuFilter = new AdHocFiltersVariable({
+        name: 'controlsFilter',
+        type: 'adhoc',
+        hide: VariableHide.inControlsMenu,
+      });
+
+      const row = new RowItem({
+        $variables: new SceneVariableSet({ variables: [hiddenFilter, controlsMenuFilter, visibleFilter] }),
+        layout: AutoGridLayoutManager.createEmpty(),
+      });
+
+      new DashboardScene({
+        body: new RowsLayoutManager({ rows: [row] }),
+      });
+
+      const filtersSet = new SectionFiltersSet({ sectionRef: row.getRef() });
+      const children = filtersSet.getOutlineChildren();
+
+      expect(children.map((c) => c.state.name)).toEqual(['visibleFilter', 'controlsFilter', 'hiddenFilter']);
+    });
+  });
+
+  describe('key', () => {
+    it('includes the section key for uniqueness', () => {
+      const row = buildRow({ includeFilter: true });
+      const filtersSet = new SectionFiltersSet({ sectionRef: row.getRef() });
+
+      expect(filtersSet.state.key).toContain('section-filters-set-');
+      expect(filtersSet.state.key).toContain(row.state.key!);
+    });
+  });
+});

--- a/public/app/features/dashboard-scene/settings/variables/SectionFiltersSet.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/SectionFiltersSet.test.tsx
@@ -1,5 +1,5 @@
 import { VariableHide } from '@grafana/data';
-import { AdHocFiltersVariable, CustomVariable, SceneVariableSet } from '@grafana/scenes';
+import { AdHocFiltersVariable, CustomVariable, type SceneVariable, SceneVariableSet } from '@grafana/scenes';
 
 import { DashboardScene } from '../../scene/DashboardScene';
 import { AutoGridLayoutManager } from '../../scene/layout-auto-grid/AutoGridLayoutManager';
@@ -43,31 +43,13 @@ describe('SectionFiltersSet', () => {
       expect(info.icon).toBe('filter');
     });
 
-    it('is hidden when no adhoc variables exist', () => {
-      const row = buildRow({ includeCustom: true });
-      const filtersSet = new SectionFiltersSet({ sectionRef: row.getRef() });
-
-      const info = filtersSet.getEditableElementInfo();
-
-      expect(info.isHidden).toBe(true);
-    });
-
-    it('is not hidden when adhoc variables exist', () => {
-      const row = buildRow({ includeFilter: true });
-      const filtersSet = new SectionFiltersSet({ sectionRef: row.getRef() });
-
-      const info = filtersSet.getEditableElementInfo();
-
-      expect(info.isHidden).toBe(false);
-    });
-
-    it('is hidden when section has no variables at all', () => {
+    it('does not set isHidden so the node always shows in the outline', () => {
       const row = buildRow();
       const filtersSet = new SectionFiltersSet({ sectionRef: row.getRef() });
 
       const info = filtersSet.getEditableElementInfo();
 
-      expect(info.isHidden).toBe(true);
+      expect(info.isHidden).toBeUndefined();
     });
   });
 
@@ -79,7 +61,7 @@ describe('SectionFiltersSet', () => {
       const children = filtersSet.getOutlineChildren();
 
       expect(children).toHaveLength(1);
-      expect(children[0].state.name).toBe('filter0');
+      expect((children[0] as SceneVariable).state.name).toBe('filter0');
     });
 
     it('returns empty array when no adhoc variables exist', () => {
@@ -89,48 +71,6 @@ describe('SectionFiltersSet', () => {
       const children = filtersSet.getOutlineChildren();
 
       expect(children).toHaveLength(0);
-    });
-
-    it('partitions variables by display mode', () => {
-      const visibleFilter = new AdHocFiltersVariable({
-        name: 'visibleFilter',
-        type: 'adhoc',
-        hide: VariableHide.dontHide,
-      });
-      const hiddenFilter = new AdHocFiltersVariable({
-        name: 'hiddenFilter',
-        type: 'adhoc',
-        hide: VariableHide.hideVariable,
-      });
-      const controlsMenuFilter = new AdHocFiltersVariable({
-        name: 'controlsFilter',
-        type: 'adhoc',
-        hide: VariableHide.inControlsMenu,
-      });
-
-      const row = new RowItem({
-        $variables: new SceneVariableSet({ variables: [hiddenFilter, controlsMenuFilter, visibleFilter] }),
-        layout: AutoGridLayoutManager.createEmpty(),
-      });
-
-      new DashboardScene({
-        body: new RowsLayoutManager({ rows: [row] }),
-      });
-
-      const filtersSet = new SectionFiltersSet({ sectionRef: row.getRef() });
-      const children = filtersSet.getOutlineChildren();
-
-      expect(children.map((c) => c.state.name)).toEqual(['visibleFilter', 'controlsFilter', 'hiddenFilter']);
-    });
-  });
-
-  describe('key', () => {
-    it('includes the section key for uniqueness', () => {
-      const row = buildRow({ includeFilter: true });
-      const filtersSet = new SectionFiltersSet({ sectionRef: row.getRef() });
-
-      expect(filtersSet.state.key).toContain('section-filters-set-');
-      expect(filtersSet.state.key).toContain(row.state.key!);
     });
   });
 });

--- a/public/app/features/dashboard-scene/settings/variables/SectionFiltersSet.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/SectionFiltersSet.tsx
@@ -1,0 +1,88 @@
+import { useId, useMemo } from 'react';
+
+import { t } from '@grafana/i18n';
+import {
+  type SceneObject,
+  SceneObjectBase,
+  type SceneObjectRef,
+  type SceneObjectState,
+  type SceneVariable,
+  SceneVariableSet,
+  sceneUtils,
+} from '@grafana/scenes';
+import { OptionsPaneCategoryDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneCategoryDescriptor';
+import { OptionsPaneItemDescriptor } from 'app/features/dashboard/components/PanelEditor/OptionsPaneItemDescriptor';
+
+import { SectionFiltersList } from '../../edit-pane/SectionFiltersList';
+import { partitionVariablesByDisplay } from '../../edit-pane/dashboard/DashboardVariablesList';
+import {
+  type EditableDashboardElement,
+  type EditableDashboardElementInfo,
+} from '../../scene/types/EditableDashboardElement';
+import { filterSectionRepeatLocalVariables } from '../../variables/utils';
+
+export interface SectionFiltersSetState extends SceneObjectState {
+  sectionRef: SceneObjectRef<SceneObject>;
+}
+
+function useEditPaneOptions(
+  this: SectionFiltersSet,
+  sectionRef: SceneObjectRef<SceneObject>
+): OptionsPaneCategoryDescriptor[] {
+  const filterListId = useId();
+  const sectionOwner = sectionRef.resolve();
+
+  const options = useMemo(() => {
+    const category = new OptionsPaneCategoryDescriptor({ title: '', id: 'section-filters' });
+
+    category.addItem(
+      new OptionsPaneItemDescriptor({
+        title: '',
+        id: filterListId,
+        skipField: true,
+        render: () => <SectionFiltersList sectionOwner={sectionOwner} />,
+      })
+    );
+
+    return category;
+  }, [filterListId, sectionOwner]);
+
+  return [options];
+}
+
+export class SectionFiltersSet extends SceneObjectBase<SectionFiltersSetState> implements EditableDashboardElement {
+  public readonly isEditableDashboardElement = true;
+
+  public constructor(state: SectionFiltersSetState) {
+    const sectionKey = state.sectionRef.resolve().state.key ?? 'unknown';
+    super({ ...state, key: `section-filters-set-${sectionKey}` });
+  }
+
+  public getEditableElementInfo(): EditableDashboardElementInfo {
+    const filters = this.getAdhocVariables();
+    return {
+      typeName: t('dashboard.edit-pane.elements.section-filters-set', 'Filters'),
+      icon: 'filter',
+      instanceName: t('dashboard.edit-pane.elements.section-filters-set', 'Filters'),
+      isHidden: filters.length === 0,
+    };
+  }
+
+  public getOutlineChildren(): SceneObject[] {
+    const { visible, controlsMenu, hidden } = partitionVariablesByDisplay(this.getAdhocVariables());
+    return [...visible, ...controlsMenu, ...hidden];
+  }
+
+  private getAdhocVariables(): SceneVariable[] {
+    const sectionOwner = this.state.sectionRef.resolve();
+    const variableSet = sectionOwner.state.$variables;
+    if (!(variableSet instanceof SceneVariableSet)) {
+      return [];
+    }
+    return filterSectionRepeatLocalVariables(variableSet.state.variables, variableSet).filter(
+      sceneUtils.isAdHocVariable
+    );
+  }
+
+  public useEditPaneOptions = useEditPaneOptions.bind(this, this.state.sectionRef);
+}

--- a/public/app/features/dashboard-scene/settings/variables/SectionFiltersSet.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/SectionFiltersSet.tsx
@@ -54,8 +54,10 @@ export class SectionFiltersSet extends SceneObjectBase<SectionFiltersSetState> i
   public readonly isEditableDashboardElement = true;
 
   public constructor(state: SectionFiltersSetState) {
-    const sectionKey = state.sectionRef.resolve().state.key ?? 'unknown';
-    super({ ...state, key: `section-filters-set-${sectionKey}` });
+    super({
+      ...state,
+      key: `section-filters-set-${state.sectionRef.resolve().state.key}`,
+    });
   }
 
   public getEditableElementInfo(): EditableDashboardElementInfo {

--- a/public/app/features/dashboard-scene/settings/variables/SectionFiltersSet.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/SectionFiltersSet.tsx
@@ -61,12 +61,10 @@ export class SectionFiltersSet extends SceneObjectBase<SectionFiltersSetState> i
   }
 
   public getEditableElementInfo(): EditableDashboardElementInfo {
-    const filters = this.getAdhocVariables();
     return {
       typeName: t('dashboard.edit-pane.elements.section-filters-set', 'Filters'),
       icon: 'filter',
       instanceName: t('dashboard.edit-pane.elements.section-filters-set', 'Filters'),
-      isHidden: filters.length === 0,
     };
   }
 

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -5636,6 +5636,7 @@
         "panels": "Panels",
         "row": "Row",
         "rows": "Rows",
+        "section-filters-set": "Filters",
         "tab": "Tab",
         "tabs": "Tabs",
         "variable": "{{type}} variable",


### PR DESCRIPTION
**What is this feature?**

When `dashboardUnifiedDrilldownControls` is enabled, adhoc filter variables are shown under a dedicated "Filters" node in the section-level (row/tab) content outline, instead of being mixed in with regular variables.

<img width="1286" height="719" alt="image" src="https://github.com/user-attachments/assets/196cccf6-4832-45ca-b6d1-f583a5ce77a7" />


**Which issue(s) does this PR fix?**:

Fixes #123157