### PR TITLE
Dynamic dashboards: Remove share button label, instrument sharing options

### DIFF
--- a/public/app/features/dashboard-scene/scene/new-toolbar/actions/ShareDashboardButton.tsx
+++ b/public/app/features/dashboard-scene/scene/new-toolbar/actions/ShareDashboardButton.tsx
@@ -41,14 +41,12 @@ export const ShareDashboardButton = ({ dashboard }: ToolbarActionProps) => {
         }
       }}
       groupTestId={newShareButtonSelector.shareLink}
-      buttonLabel={t('dashboard.toolbar.new.share.title', 'Share')}
       buttonTooltip={t('dashboard.toolbar.new.share.tooltip', 'Copy link')}
       buttonTestId={newShareButtonSelector.container}
       onButtonClick={onPrimaryShareClick}
       arrowLabel={t('dashboard.toolbar.new.share.arrow', 'Share')}
       arrowTestId={newShareButtonSelector.arrowMenu}
       dashboard={dashboard}
-      variant={!dashboard.state.isEditing ? 'primary' : 'canvas'}
       loading={loading}
     />
   );

--- a/public/app/features/dashboard-scene/scene/new-toolbar/actions/ShareExportDashboardButton.tsx
+++ b/public/app/features/dashboard-scene/scene/new-toolbar/actions/ShareExportDashboardButton.tsx
@@ -3,33 +3,29 @@ import { type ReactElement, useState } from 'react';
 import { ButtonGroup, Dropdown, ToolbarButton } from '@grafana/ui';
 
 import { type ToolbarActionProps } from '../types';
+import { DashboardInteractions } from 'app/features/dashboard-scene/utils/interactions';
 
 interface Props extends ToolbarActionProps {
   menu: ReactElement | (() => ReactElement);
   onMenuVisibilityChange?: (isOpen: boolean) => void;
   groupTestId: string;
-  buttonLabel: string;
   buttonTooltip: string;
   buttonTestId: string;
   onButtonClick?: () => void;
   arrowLabel: string;
   arrowTestId: string;
-  variant?: 'primary' | 'canvas';
   loading?: boolean;
 }
 
 export const ShareExportDashboardButton = ({
-  dashboard,
   menu,
   onMenuVisibilityChange,
   groupTestId,
-  buttonLabel,
   buttonTooltip,
   buttonTestId,
   onButtonClick,
   arrowLabel,
   arrowTestId,
-  variant = 'canvas',
   loading,
 }: Props) => {
   const [isOpen, setIsOpen] = useState(false);
@@ -39,12 +35,10 @@ export const ShareExportDashboardButton = ({
       <ToolbarButton
         data-testid={buttonTestId}
         tooltip={buttonTooltip}
-        variant={variant}
+        variant="canvas"
         onClick={loading ? undefined : onButtonClick}
         icon={loading ? 'spinner' : 'share-alt'}
-      >
-        {buttonLabel}
-      </ToolbarButton>
+      />
       <Dropdown
         overlay={menu}
         placement="bottom-end"
@@ -58,7 +52,7 @@ export const ShareExportDashboardButton = ({
           aria-label={arrowLabel}
           data-testid={arrowTestId}
           icon={isOpen ? 'angle-up' : 'angle-down'}
-          variant={variant}
+          variant="canvas"
         />
       </Dropdown>
     </ButtonGroup>

--- a/public/app/features/dashboard-scene/scene/new-toolbar/actions/ShareExportDashboardButton.tsx
+++ b/public/app/features/dashboard-scene/scene/new-toolbar/actions/ShareExportDashboardButton.tsx
@@ -3,7 +3,6 @@ import { type ReactElement, useState } from 'react';
 import { ButtonGroup, Dropdown, ToolbarButton } from '@grafana/ui';
 
 import { type ToolbarActionProps } from '../types';
-import { DashboardInteractions } from 'app/features/dashboard-scene/utils/interactions';
 
 interface Props extends ToolbarActionProps {
   menu: ReactElement | (() => ReactElement);

--- a/public/app/features/dashboard-scene/sharing/ShareButton/ShareMenu.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareButton/ShareMenu.tsx
@@ -56,7 +56,10 @@ export default function ShareMenu({ dashboard, panel }: { dashboard: DashboardSc
       icon: 'building',
       label: t('share-dashboard.menu.share-internally-title', 'Share internally'),
       renderCondition: true,
-      onClick: () => onMenuItemClick(shareDashboardType.link),
+      onClick: () => {
+        DashboardInteractions.toolbarShareDropdownOptionClick('internally');
+        onMenuItemClick(shareDashboardType.link);
+      },
     });
 
     menuItems.push({
@@ -66,6 +69,7 @@ export default function ShareMenu({ dashboard, panel }: { dashboard: DashboardSc
       label: t('share-dashboard.menu.share-externally-title', 'Share externally'),
       renderCondition: !panel && isPublicDashboardsEnabled(),
       onClick: () => {
+        DashboardInteractions.toolbarShareDropdownOptionClick('externally');
         onMenuItemClick(shareDashboardType.publicDashboard);
       },
     });
@@ -80,6 +84,7 @@ export default function ShareMenu({ dashboard, panel }: { dashboard: DashboardSc
         config.snapshotEnabled &&
         contextSrv.hasPermission(AccessControlAction.SnapshotsCreate),
       onClick: () => {
+        DashboardInteractions.toolbarShareDropdownOptionClick('snapshot');
         onMenuItemClick(shareDashboardType.snapshot);
       },
     });

--- a/public/app/features/dashboard-scene/utils/interactions.ts
+++ b/public/app/features/dashboard-scene/utils/interactions.ts
@@ -210,14 +210,17 @@ export const DashboardInteractions = {
   toolbarShareClick: () => {
     reportDashboardInteraction('toolbar_actions_clicked', { item: 'share' });
   },
-  toolbarShareDropdownClick: () => {
-    reportDashboardInteraction('toolbar_actions_clicked', { item: 'share_dropdown' });
-  },
   toolbarAddClick: () => {
     reportDashboardInteraction('toolbar_actions_clicked', { item: 'add' });
   },
-
   // Sharing interactions:
+  toolbarShareDropdownClick: () => {
+    reportDashboardInteraction('toolbar_actions_clicked', { item: 'share_dropdown' });
+  },
+  // clicking on a specific share option in the toolbar share button dropdown
+  toolbarShareDropdownOptionClick: (option: string) => {
+    reportDashboardInteraction('toolbar_share_option_clicked', { item: 'share_dropdown_option', option });
+  },
   sharingCategoryClicked: (properties?: Record<string, unknown>) => {
     reportSharingInteraction('sharing_category_clicked', properties);
   },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -6443,7 +6443,6 @@
         "save-library-panel": "Save library panel",
         "share": {
           "arrow": "Share",
-          "title": "Share",
           "tooltip": "Copy link"
         },
         "unlink-library-panel": "Unlink library panel"


### PR DESCRIPTION
After talking to @Ijin08, we decided to reduce the prominence by making it a canvas button + removing the label, since the icon is self explanatory. 

For purposes of investigating placement of other dropdown options, we're instrumenting them and creating a panel to track usage (compared to just the share button click)

Fixes https://github.com/grafana/grafana/issues/122398


<img width="300" alt="Screenshot 2026-04-21 at 20 20 55" src="https://github.com/user-attachments/assets/38a5e087-e295-48a2-bcd6-e49bee47d796" />

<img width="300" alt="Screenshot 2026-04-21 at 20 20 52" src="https://github.com/user-attachments/assets/ee3e5370-8431-4120-9cdf-1bc152a2d556" />
