### PR TITLE
fix: react to URL theme param changes without page reload #123153

### DIFF
--- a/public/app/app.ts
+++ b/public/app/app.ts
@@ -83,7 +83,9 @@ import { backendSrv } from './core/services/backend_srv';
 import { contextSrv, RedirectToUrlKey } from './core/services/context_srv';
 import { initEchoSrv } from './core/services/echo/init';
 import { KeybindingSrv } from './core/services/keybindingSrv';
+import { changeTheme } from './core/services/theme';
 import { startMeasure, stopMeasure } from './core/utils/metrics';
+import { getSelectableThemes } from './core/components/ThemeSelector/getSelectableThemes';
 import { initAlerting } from './features/alerting/unified/initAlerting';
 import { getTimeSrv } from './features/dashboard/services/TimeSrv';
 import { EmbeddedDashboardLazy } from './features/dashboard-scene/embedding/EmbeddedDashboardLazy';
@@ -131,6 +133,10 @@ const extensionsExports = extensionsIndex.keys().map((key) => {
 
 export class GrafanaApp {
   context!: GrafanaContextType;
+  private currentUrlTheme = this.getThemeFromUrl();
+  private hasAppliedUrlTheme = false;
+  private readonly validThemeIds = new Set(getSelectableThemes().map((theme) => theme.id));
+  private readonly fallbackThemeId = contextSrv.user.theme || config.defaultTheme;
 
   async init() {
     try {
@@ -280,6 +286,8 @@ export class GrafanaApp {
 
       // Read initial kiosk mode from url at app startup
       chromeService.setKioskModeFromUrl(queryParams.kiosk);
+      this.syncThemeWithUrl();
+      locationService.getHistory().listen(() => this.syncThemeWithUrl());
 
       // Clean up old search local storage values
       try {
@@ -320,6 +328,35 @@ export class GrafanaApp {
     } finally {
       stopMeasure('frontend_app_init');
     }
+  }
+
+  private syncThemeWithUrl() {
+    const nextUrlTheme = this.getThemeFromUrl();
+    if (nextUrlTheme === this.currentUrlTheme) {
+      return;
+    }
+
+    this.currentUrlTheme = nextUrlTheme;
+
+    if (!nextUrlTheme) {
+      if (this.hasAppliedUrlTheme) {
+        this.hasAppliedUrlTheme = false;
+        changeTheme(this.fallbackThemeId, true);
+      }
+      return;
+    }
+
+    if (!this.validThemeIds.has(nextUrlTheme)) {
+      return;
+    }
+
+    this.hasAppliedUrlTheme = true;
+    changeTheme(nextUrlTheme, true);
+  }
+
+  private getThemeFromUrl() {
+    const urlTheme = locationService.getSearchObject().theme;
+    return typeof urlTheme === 'string' ? urlTheme : undefined;
   }
 }
 


### PR DESCRIPTION
## Summary

- Make Grafana react to `theme` query parameter changes at runtime, without requiring a full page reload.
- Add URL-driven theme sync in app bootstrap flow so embedded/iframe use cases can switch theme dynamically.
- Keep behavior safe by applying URL theme changes as runtime-only (no user preference persistence).
- Validate URL theme values and ignore invalid ones to avoid unstable UI state.
- Restore fallback theme (user/default) when `theme` is removed from the URL after a URL-driven override.

Closes #123153

## Why

Grafana currently applies URL theme at initial load, but does not consistently react when `?theme=` changes while the app is already running. This is especially problematic for iframe embedding scenarios where host applications update the URL dynamically.

This change ensures theme changes from the URL are reflected immediately in the running app.

## Implementation Details

- Hook into route/history updates with `locationService.getHistory().listen(...)`.
- On each navigation event:
  - Read `theme` from `locationService.getSearchObject()`.
  - If changed and valid, call `changeTheme(theme, true)`.
  - If `theme` is removed and an override was previously applied, switch back to fallback user/default theme.
- Track last URL theme value to prevent redundant theme updates.

## Scope / Non-Goals

- No backend API changes.
- No reload-based behavior changes.
- No persistence of URL-driven theme changes to user preferences.

## Test Plan

- [ ] Open Grafana with `?theme=light` and verify light theme is applied.
- [ ] Change URL to `?theme=dark` (without reload) and verify theme switches immediately.
- [ ] In an iframe embedding scenario, update iframe URL theme query param and verify live theme update.
- [ ] Set `?theme=<invalid>` and verify current theme remains unchanged.
- [ ] Remove `theme` query param after applying URL theme and verify fallback to user/default theme.
- [ ] Verify no full-page refresh occurs during any of the above transitions.

## Risk Assessment

- Low-to-moderate frontend risk: change is localized to app initialization/runtime URL sync path.
- Main risk is unintended theme toggles on navigation; mitigated by:
  - comparing with previously seen URL theme,
  - validating allowed theme ids,
  - using existing `changeTheme` flow.
