### PR TITLE
Alerting: Fix 500 on external Alertmanager config GET when upstream returns empty config

### DIFF
--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
@@ -1133,6 +1133,13 @@ func (c *ExternalAlertmanagerConfig) UnmarshalJSON(b []byte) error {
 	}
 	// store the map[string]interface{} variant for re-encoding later without redaction
 	c.amSimple = tmp.AlertmanagerConfig
+	// Upstream Mimir/Cortex-compat AMs may return an empty, null, or missing
+	// alertmanager_config when no config has been saved yet. Guarantee amSimple
+	// is non-nil on success so the nil-check in Marshal{JSON,YAML} still catches
+	// undecoded structs without rejecting legitimately empty upstream configs.
+	if c.amSimple == nil {
+		c.amSimple = map[string]interface{}{}
+	}
 
 	return nil
 }
@@ -1180,6 +1187,14 @@ func (c *ExternalAlertmanagerConfig) UnmarshalYAML(value *yaml.Node) error {
 	// store the map[string]interface{} variant for re-encoding later without redaction
 	if err := yaml.Unmarshal([]byte(tmp.AlertmanagerConfig), &c.amSimple); err != nil {
 		return err
+	}
+	// yaml.Unmarshal on empty bytes is a no-op and leaves amSimple nil. Upstream
+	// Mimir/Cortex-compat AMs return alertmanager_config as an empty/null/missing
+	// string when no config has been saved. Guarantee amSimple is non-nil on
+	// success so Marshal{JSON,YAML} still catches undecoded structs without
+	// rejecting legitimately empty upstream configs.
+	if c.amSimple == nil {
+		c.amSimple = map[string]interface{}{}
 	}
 
 	c.TemplateFiles = tmp.TemplateFiles

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager_test.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager_test.go
@@ -712,3 +712,95 @@ receivers:
 		})
 	}
 }
+
+// Regression test: upstream Mimir/Cortex-compat Alertmanagers return an empty,
+// null, or missing `alertmanager_config` when no config has been saved. Before
+// the fix, UnmarshalYAML/UnmarshalJSON left amSimple nil, which made the
+// subsequent MarshalJSON return a 500 on GET config requests.
+func Test_ExternalAlertmanagerConfig_EmptyUpstreamConfig_RoundTrip(t *testing.T) {
+	t.Run("YAML", func(t *testing.T) {
+		for _, tc := range []struct {
+			desc  string
+			input string
+		}{
+			{
+				desc: "empty string",
+				input: `
+template_files: {}
+alertmanager_config: ""
+`,
+			},
+			{
+				desc: "null",
+				input: `
+template_files: {}
+alertmanager_config: null
+`,
+			},
+			{
+				desc: "missing",
+				input: `
+template_files: {}
+`,
+			},
+		} {
+			t.Run(tc.desc, func(t *testing.T) {
+				var cfg ExternalAlertmanagerConfig
+				require.NoError(t, yaml.Unmarshal([]byte(tc.input), &cfg))
+				require.NotNil(t, cfg.amSimple, "amSimple must be non-nil so Marshal does not error")
+
+				out, err := yaml.Marshal(&cfg)
+				require.NoError(t, err, "YAML round-trip must not error for empty upstream config")
+				require.NotEmpty(t, out)
+
+				jsonOut, err := json.Marshal(&cfg)
+				require.NoError(t, err, "JSON re-encode must not error for empty upstream config")
+				require.NotEmpty(t, jsonOut)
+			})
+		}
+	})
+
+	t.Run("JSON", func(t *testing.T) {
+		for _, tc := range []struct {
+			desc  string
+			input string
+		}{
+			{
+				desc:  "null",
+				input: `{"template_files":{},"alertmanager_config":null}`,
+			},
+			{
+				desc:  "missing",
+				input: `{"template_files":{}}`,
+			},
+			{
+				desc:  "empty object",
+				input: `{"template_files":{},"alertmanager_config":{}}`,
+			},
+		} {
+			t.Run(tc.desc, func(t *testing.T) {
+				var cfg ExternalAlertmanagerConfig
+				require.NoError(t, json.Unmarshal([]byte(tc.input), &cfg))
+				require.NotNil(t, cfg.amSimple, "amSimple must be non-nil so Marshal does not error")
+
+				jsonOut, err := json.Marshal(&cfg)
+				require.NoError(t, err, "JSON round-trip must not error for empty upstream config")
+				require.NotEmpty(t, jsonOut)
+
+				yamlOut, err := yaml.Marshal(&cfg)
+				require.NoError(t, err, "YAML re-encode must not error for empty upstream config")
+				require.NotEmpty(t, yamlOut)
+			})
+		}
+	})
+
+	// Guard against accidental removal of the nil-check in Marshal: a
+	// zero-value struct that was never decoded must still error out.
+	t.Run("undecoded struct still errors on marshal", func(t *testing.T) {
+		var cfg ExternalAlertmanagerConfig
+		_, err := json.Marshal(&cfg)
+		require.Error(t, err)
+		_, err = yaml.Marshal(&cfg)
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
## Summary

ExternalAlertmanagerConfig.UnmarshalYAML/UnmarshalJSON left the unexported amSimple field as nil when the upstream Mimir/Cortex-compat AM returned an empty, null, or missing alertmanager_config — yaml/json unmarshal on empty input is a no-op and does not populate the target map. MarshalJSON/YAML then errored because amSimple == nil, returning a 500 on GET /api/alertmanager/{dsUID}/config/api/v1/alerts and blocking customers from creating contact points on freshly provisioned stacks where no AM config has ever been saved upstream.

Initialize amSimple to an empty map if still nil after unmarshal so legitimately empty upstream configs round-trip, while preserving the Marshal nil-check that catches zero-value structs that were never decoded.

Regression from #121484.