### PR TITLE
Provisioning: Enforce folder version in finalizer handler

### DIFF
--- a/pkg/operators/provisioning/repo_operator.go
+++ b/pkg/operators/provisioning/repo_operator.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-app-sdk/logging"
+	folderv1beta1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	appcontroller "github.com/grafana/grafana/apps/provisioning/pkg/controller"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"k8s.io/client-go/tools/cache"
@@ -123,6 +124,7 @@ func RunRepoController(deps server.OperatorDependencies) error {
 		controllerCfg.DrainTimeout(),
 		quotaGetter,
 		resources.IsFolderMetadataEnabled(controllerCfg.Settings),
+		controllerCfg.Settings.SectionWithEnvOverrides("operator").Key("folders_api_version").MustString(folderv1beta1.APIVersion),
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create repository controller: %w", err)

--- a/pkg/registry/apis/provisioning/controller/finalizers.go
+++ b/pkg/registry/apis/provisioning/controller/finalizers.go
@@ -22,10 +22,11 @@ import (
 )
 
 type finalizer struct {
-	lister        resources.ResourceLister
-	clientFactory resources.ClientFactory
-	metrics       *finalizerMetrics
-	maxWorkers    int
+	lister           resources.ResourceLister
+	clientFactory    resources.ClientFactory
+	metrics          *finalizerMetrics
+	maxWorkers       int
+	folderAPIVersion string
 }
 
 func (f *finalizer) process(ctx context.Context,
@@ -103,9 +104,17 @@ func (f *finalizer) newItemProcessor(
 ) itemProcessor {
 	logger := logging.FromContext(ctx)
 	return func(jobCtx context.Context, item *provisioning.ResourceListItem) error {
+		// If the item is a folder, use the configured folder API version.
+		var version string
+		if item.Group == resources.FolderResource.Group && item.Resource == resources.FolderResource.Resource {
+			version = f.folderAPIVersion
+			logger = logger.With("version", version)
+		}
+
 		res, _, err := clients.ForResource(jobCtx, schema.GroupVersionResource{
 			Group:    item.Group,
 			Resource: item.Resource,
+			Version:  version,
 		})
 		if err != nil {
 			logger.Error("error getting client for resource", "resource", item.Resource, "error", err)

--- a/pkg/registry/apis/provisioning/controller/finalizers_test.go
+++ b/pkg/registry/apis/provisioning/controller/finalizers_test.go
@@ -494,9 +494,10 @@ func TestFinalizer_process(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			metrics := registerFinalizerMetrics(prometheus.NewRegistry())
 			f := &finalizer{
-				lister:        tc.lister,
-				clientFactory: tc.clientFactory,
-				metrics:       &metrics,
+				lister:           tc.lister,
+				clientFactory:    tc.clientFactory,
+				metrics:          &metrics,
+				folderAPIVersion: "v1",
 			}
 			err := f.process(context.Background(), tc.repo, tc.finalizers)
 			if tc.expectedErr == "" {
@@ -673,13 +674,22 @@ func TestDeleteExistingItems_ResourcesBeforeFolders(t *testing.T) {
 			return nil
 		},
 	}
-	clients.On("ForResource", mock.Anything, mock.Anything).Return(client, schema.GroupVersionKind{}, nil)
+	clients.On("ForResource", mock.Anything, schema.GroupVersionResource{
+		Group:    "dashboard.grafana.app",
+		Resource: "dashboards",
+	}).Return(client, schema.GroupVersionKind{}, nil).Twice()
+	clients.On("ForResource", mock.Anything, schema.GroupVersionResource{
+		Group:    "folder.grafana.app",
+		Resource: "folders",
+		Version:  "v1",
+	}).Return(client, schema.GroupVersionKind{}, nil).Twice()
 
 	f := &finalizer{
-		lister:        resourceLister,
-		clientFactory: clientFactory,
-		metrics:       func() *finalizerMetrics { m := registerFinalizerMetrics(prometheus.NewRegistry()); return &m }(),
-		maxWorkers:    1,
+		lister:           resourceLister,
+		clientFactory:    clientFactory,
+		metrics:          func() *finalizerMetrics { m := registerFinalizerMetrics(prometheus.NewRegistry()); return &m }(),
+		maxWorkers:       1,
+		folderAPIVersion: "v1",
 	}
 
 	repo := &provisioning.Repository{ObjectMeta: metav1.ObjectMeta{Name: "my-repo", Namespace: "default"}}
@@ -721,13 +731,22 @@ func TestReleaseExistingItems_FoldersBeforeResources(t *testing.T) {
 			return nil, nil
 		},
 	}
-	clients.On("ForResource", mock.Anything, mock.Anything).Return(client, schema.GroupVersionKind{}, nil)
+	clients.On("ForResource", mock.Anything, schema.GroupVersionResource{
+		Group:    "dashboard.grafana.app",
+		Resource: "dashboards",
+	}).Return(client, schema.GroupVersionKind{}, nil).Twice()
+	clients.On("ForResource", mock.Anything, schema.GroupVersionResource{
+		Group:    "folder.grafana.app",
+		Resource: "folders",
+		Version:  "v1",
+	}).Return(client, schema.GroupVersionKind{}, nil).Twice()
 
 	f := &finalizer{
-		lister:        resourceLister,
-		clientFactory: clientFactory,
-		metrics:       func() *finalizerMetrics { m := registerFinalizerMetrics(prometheus.NewRegistry()); return &m }(),
-		maxWorkers:    1,
+		lister:           resourceLister,
+		clientFactory:    clientFactory,
+		metrics:          func() *finalizerMetrics { m := registerFinalizerMetrics(prometheus.NewRegistry()); return &m }(),
+		maxWorkers:       1,
+		folderAPIVersion: "v1",
 	}
 
 	repo := &provisioning.Repository{ObjectMeta: metav1.ObjectMeta{Name: "my-repo", Namespace: "default"}}
@@ -738,6 +757,122 @@ func TestReleaseExistingItems_FoldersBeforeResources(t *testing.T) {
 	// Folders should be released shallowest-first, before any non-folder resources.
 	assert.Equal(t, []string{"folder-root", "folder-nested"}, order[:2], "folders should be released shallowest first")
 	assert.Equal(t, []string{"dash-2", "dash-1"}, order[2:], "non-folder resources should be released after folders")
+}
+
+func TestFinalizer_FolderAPIVersion_RoutesFolderItemsToFolderClient(t *testing.T) {
+	testCases := []struct {
+		name             string
+		folderAPIVersion string
+	}{
+		{name: "v1beta1 folder client (cloud default)", folderAPIVersion: "v1beta1"},
+		{name: "v1 folder client (on-prem default)", folderAPIVersion: "v1"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Run("release path", func(t *testing.T) {
+				items := provisioning.ResourceList{
+					Items: []provisioning.ResourceListItem{
+						{Group: folders.GroupVersion.Group, Resource: "folders", Name: "folder-a", Path: "a"},
+						{Group: "dashboard.grafana.app", Resource: "dashboards", Name: "dash-a", Path: "dash.json"},
+					},
+				}
+
+				resourceLister := resources.NewMockResourceLister(t)
+				resourceLister.On("List", mock.Anything, "default", "my-repo").Return(&items, nil)
+
+				clientFactory := resources.NewMockClientFactory(t)
+				clients := resources.NewMockResourceClients(t)
+				clientFactory.On("Clients", mock.Anything, "default").Return(clients, nil)
+
+				folderClient := &mockDynamicClient{
+					patchFunc: func(ctx context.Context, name string, pt types.PatchType, data []byte, options metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error) {
+						return nil, nil
+					},
+				}
+				dashboardClient := &mockDynamicClient{
+					patchFunc: func(ctx context.Context, name string, pt types.PatchType, data []byte, options metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error) {
+						return nil, nil
+					},
+				}
+
+				clients.On("ForResource", mock.Anything, schema.GroupVersionResource{
+					Group:    "folder.grafana.app",
+					Resource: "folders",
+					Version:  tc.folderAPIVersion,
+				}).Return(folderClient, schema.GroupVersionKind{}, nil).Once()
+				clients.On("ForResource", mock.Anything, schema.GroupVersionResource{
+					Group:    "dashboard.grafana.app",
+					Resource: "dashboards",
+				}).Return(dashboardClient, schema.GroupVersionKind{}, nil).Once()
+
+				f := &finalizer{
+					lister:           resourceLister,
+					clientFactory:    clientFactory,
+					metrics:          func() *finalizerMetrics { m := registerFinalizerMetrics(prometheus.NewRegistry()); return &m }(),
+					maxWorkers:       1,
+					folderAPIVersion: tc.folderAPIVersion,
+				}
+
+				repo := &provisioning.Repository{ObjectMeta: metav1.ObjectMeta{Name: "my-repo", Namespace: "default"}}
+				count, err := f.releaseExistingItems(context.Background(), repo)
+				assert.NoError(t, err)
+				assert.Equal(t, 2, count)
+				clients.AssertExpectations(t)
+			})
+
+			t.Run("delete path", func(t *testing.T) {
+				items := provisioning.ResourceList{
+					Items: []provisioning.ResourceListItem{
+						{Group: folders.GroupVersion.Group, Resource: "folders", Name: "folder-a", Path: "a"},
+						{Group: "dashboard.grafana.app", Resource: "dashboards", Name: "dash-a", Path: "dash.json"},
+					},
+				}
+
+				resourceLister := resources.NewMockResourceLister(t)
+				resourceLister.On("List", mock.Anything, "default", "my-repo").Return(&items, nil)
+
+				clientFactory := resources.NewMockClientFactory(t)
+				clients := resources.NewMockResourceClients(t)
+				clientFactory.On("Clients", mock.Anything, "default").Return(clients, nil)
+
+				folderClient := &mockDynamicClient{
+					deleteFunc: func(ctx context.Context, name string, options metav1.DeleteOptions, subresources ...string) error {
+						return nil
+					},
+				}
+				dashboardClient := &mockDynamicClient{
+					deleteFunc: func(ctx context.Context, name string, options metav1.DeleteOptions, subresources ...string) error {
+						return nil
+					},
+				}
+
+				clients.On("ForResource", mock.Anything, schema.GroupVersionResource{
+					Group:    "folder.grafana.app",
+					Resource: "folders",
+					Version:  tc.folderAPIVersion,
+				}).Return(folderClient, schema.GroupVersionKind{}, nil).Once()
+				clients.On("ForResource", mock.Anything, schema.GroupVersionResource{
+					Group:    "dashboard.grafana.app",
+					Resource: "dashboards",
+				}).Return(dashboardClient, schema.GroupVersionKind{}, nil).Once()
+
+				f := &finalizer{
+					lister:           resourceLister,
+					clientFactory:    clientFactory,
+					metrics:          func() *finalizerMetrics { m := registerFinalizerMetrics(prometheus.NewRegistry()); return &m }(),
+					maxWorkers:       1,
+					folderAPIVersion: tc.folderAPIVersion,
+				}
+
+				repo := &provisioning.Repository{ObjectMeta: metav1.ObjectMeta{Name: "my-repo", Namespace: "default"}}
+				count, err := f.deleteExistingItems(context.Background(), repo)
+				assert.NoError(t, err)
+				assert.Equal(t, 2, count)
+				clients.AssertExpectations(t)
+			})
+		})
+	}
 }
 
 func TestReleaseExistingItems_ResourcesConcurrent(t *testing.T) {
@@ -780,10 +915,11 @@ func TestReleaseExistingItems_ResourcesConcurrent(t *testing.T) {
 	clients.On("ForResource", mock.Anything, mock.Anything).Return(client, schema.GroupVersionKind{}, nil)
 
 	f := &finalizer{
-		lister:        resourceLister,
-		clientFactory: clientFactory,
-		metrics:       func() *finalizerMetrics { m := registerFinalizerMetrics(prometheus.NewRegistry()); return &m }(),
-		maxWorkers:    5,
+		lister:           resourceLister,
+		clientFactory:    clientFactory,
+		metrics:          func() *finalizerMetrics { m := registerFinalizerMetrics(prometheus.NewRegistry()); return &m }(),
+		maxWorkers:       5,
+		folderAPIVersion: "v1",
 	}
 
 	repo := &provisioning.Repository{ObjectMeta: metav1.ObjectMeta{Name: "my-repo", Namespace: "default"}}
@@ -892,14 +1028,20 @@ func TestFinalizer_processExistingItems_Concurrency(t *testing.T) {
 
 			clients.
 				On("ForResource", mock.Anything, mock.Anything).
-				Return(client, schema.GroupVersionKind{}, nil)
+				Return(client, schema.GroupVersionKind{}, nil).
+				Maybe()
+			clients.
+				On("Folder", mock.Anything, "v1").
+				Return(client, schema.GroupVersionKind{}, nil).
+				Maybe()
 
 			metrics := registerFinalizerMetrics(prometheus.NewRegistry())
 			f := &finalizer{
-				lister:        resourceLister,
-				clientFactory: clientFactory,
-				metrics:       &metrics,
-				maxWorkers:    tc.maxWorkers,
+				lister:           resourceLister,
+				clientFactory:    clientFactory,
+				metrics:          &metrics,
+				maxWorkers:       tc.maxWorkers,
+				folderAPIVersion: "v1",
 			}
 
 			repo := &provisioning.Repository{

--- a/pkg/registry/apis/provisioning/controller/repository.go
+++ b/pkg/registry/apis/provisioning/controller/repository.go
@@ -107,6 +107,7 @@ func NewRepositoryController(
 	drainTimeout time.Duration,
 	quotaGetter quotas.QuotaGetter,
 	folderMetadataEnabled bool,
+	folderAPIVersion string,
 ) (*RepositoryController, error) {
 	finalizerMetrics := registerFinalizerMetrics(registry)
 	repoTokenMetrics := registerRepositoryTokenMetrics(registry)
@@ -127,10 +128,11 @@ func NewRepositoryController(
 		quotaChecker:      NewRepositoryQuotaChecker(repoInformer.Lister()),
 		statusPatcher:     statusPatcher,
 		finalizer: &finalizer{
-			lister:        resourceLister,
-			clientFactory: clients,
-			metrics:       &finalizerMetrics,
-			maxWorkers:    parallelOperations,
+			lister:           resourceLister,
+			clientFactory:    clients,
+			metrics:          &finalizerMetrics,
+			maxWorkers:       parallelOperations,
+			folderAPIVersion: folderAPIVersion,
 		},
 		jobs:                  jobs,
 		logger:                logging.DefaultLogger.With("logger", loggerName),

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -1019,6 +1019,7 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 				30*time.Second,
 				b.quotaGetter,
 				b.folderMetadataEnabled,
+				b.folderAPIVersion,
 			)
 			if err != nil {
 				return err


### PR DESCRIPTION
**What is this feature?**

The Repository controller's finalizer (`ReleaseOrphanResources` / `RemoveOrphanResources`) now honours the configured folder API version when patching/deleting folder items, instead of relying on the dynamic client's preferred-version resolution.

The version is threaded through `NewRepositoryController` the same way the Jobs controller already does:
- Main Grafana binary reads `cfg.ProvisioningFolderAPIVersion` (defaults to `v1`, for on-prem).
- Cloud operator reads `operator.folders_api_version` (defaults to `v1beta1`), matching `jobs_operator` / `jobqueue_operator`.

When the finalizer processes a folder item, the GVR passed to `clients.ForResource` now includes the configured version; non-folder items are unchanged.

**Why do we need this feature?**

`finalizer.newItemProcessor` was building a GVR with no `Version`, so the dynamic client resolved to the API's preferred version — `v1` — regardless of environment. In cloud, where `v1beta1` is the intended folder API, this caused the finalizer to patch/delete folders against the wrong version. The Jobs controller already enforces the version via config; the Repository controller was the remaining gap.

**Who is this feature for?**

Operators running Grafana with provisioning enabled. This is an internal correctness fix — no user-visible behaviour change on on-prem (still `v1` by default). Cloud deployments get correctly-versioned folder API calls from the finalizer.

Please check that:
- [ ] It works as expected from a user's perspective.
- [x] No feature toggle needed — this is a correctness fix behind existing config.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/c
  ontribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's
  New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.