### PR TITLE
Zanzana: Fix mt-reconciler Unauthenticated error by adding internal ReadTuples

### DIFF
--- a/pkg/services/authz/zanzana/server.go
+++ b/pkg/services/authz/zanzana/server.go
@@ -35,5 +35,6 @@ type ServerInternal interface {
 	DeleteStore(ctx context.Context, namespace string) error
 	ListAllStores(ctx context.Context) ([]StoreInfo, error)
 	WriteTuples(ctx context.Context, store *StoreInfo, writeTuples []*openfgav1.TupleKey, deleteTuples []*openfgav1.TupleKeyWithoutCondition) error
+	ReadTuples(ctx context.Context, store *StoreInfo, req *openfgav1.ReadRequest) (*openfgav1.ReadResponse, error)
 	GetOpenFGAServer() openfgav1.OpenFGAServiceServer
 }

--- a/pkg/services/authz/zanzana/server/reconciler/namespace.go
+++ b/pkg/services/authz/zanzana/server/reconciler/namespace.go
@@ -19,7 +19,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	authzextv1 "github.com/grafana/grafana/pkg/services/authz/proto/v1"
 	"github.com/grafana/grafana/pkg/services/authz/zanzana"
-	"github.com/grafana/grafana/pkg/services/authz/zanzana/common"
 )
 
 // tupleKey generates a unique string key for a tuple based on user, relation, and object.
@@ -265,26 +264,32 @@ func (r *Reconciler) computeDiffStreaming(
 	))
 	defer span.End()
 
+	// Get store info for the namespace. The reconciler runs as a background
+	// worker without end-user claims, so it calls the internal ReadTuples helper
+	// (mirroring WriteTuples) to bypass the public-API authorization check.
+	storeInfo, err := r.server.GetOrCreateStore(ctx, namespace)
+	if err != nil {
+		return nil, nil, tracing.Errorf(span, "failed to get store info: %w", err)
+	}
+
 	pagesRead := 0
 	var continuationToken string
 
 	// Read current tuples page-by-page and diff against expected
 	for {
-		req := &authzextv1.ReadRequest{
-			Namespace:         namespace,
+		req := &openfgav1.ReadRequest{
 			PageSize:          wrapperspb.Int32(r.cfg.zanzanaReadPageSize()),
 			ContinuationToken: continuationToken,
 		}
 
-		resp, err := r.server.Read(ctx, req)
+		resp, err := r.server.ReadTuples(ctx, storeInfo, req)
 		if err != nil {
 			return nil, nil, tracing.Errorf(span, "failed to read tuples: %w", err)
 		}
 
 		pagesRead++
 
-		for _, authzTuple := range resp.GetTuples() {
-			tuple := common.ToOpenFGATuple(authzTuple)
+		for _, tuple := range resp.GetTuples() {
 			key := tupleKey(tuple.GetKey())
 			if expected, exists := expectedMap[key]; exists {
 				if proto.Equal(expected.GetCondition(), tuple.GetKey().GetCondition()) {

--- a/pkg/services/authz/zanzana/server/reconciler/namespace_test.go
+++ b/pkg/services/authz/zanzana/server/reconciler/namespace_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	authzextv1 "github.com/grafana/grafana/pkg/services/authz/proto/v1"
 	"github.com/grafana/grafana/pkg/services/authz/zanzana"
-	"github.com/grafana/grafana/pkg/services/authz/zanzana/common"
 )
 
 // mockServerInternal satisfies zanzana.ServerInternal for computeDiffStreaming tests.
@@ -43,13 +42,9 @@ func (m *mockServerInternal) ListAllStores(context.Context) ([]zanzana.StoreInfo
 func (m *mockServerInternal) WriteTuples(context.Context, *zanzana.StoreInfo, []*openfgav1.TupleKey, []*openfgav1.TupleKeyWithoutCondition) error {
 	return nil
 }
-func (m *mockServerInternal) GetOpenFGAServer() openfgav1.OpenFGAServiceServer {
-	return nil
-}
-
-func (m *mockServerInternal) Read(_ context.Context, _ *authzextv1.ReadRequest) (*authzextv1.ReadResponse, error) {
+func (m *mockServerInternal) ReadTuples(_ context.Context, _ *zanzana.StoreInfo, _ *openfgav1.ReadRequest) (*openfgav1.ReadResponse, error) {
 	if len(m.pages) == 0 {
-		return &authzextv1.ReadResponse{}, nil
+		return &openfgav1.ReadResponse{}, nil
 	}
 	page := m.pages[0]
 	m.pages = m.pages[1:]
@@ -59,17 +54,13 @@ func (m *mockServerInternal) Read(_ context.Context, _ *authzextv1.ReadRequest) 
 		token = "next"
 	}
 
-	pageTuples := make([]*authzextv1.Tuple, 0)
-	for _, t := range page {
-		pageTuples = append(pageTuples, &authzextv1.Tuple{
-			Key:       common.ToAuthzExtTupleKey(t.GetKey()),
-			Timestamp: t.GetTimestamp(),
-		})
-	}
-	return &authzextv1.ReadResponse{
-		Tuples:            pageTuples,
+	return &openfgav1.ReadResponse{
+		Tuples:            page,
 		ContinuationToken: token,
 	}, nil
+}
+func (m *mockServerInternal) GetOpenFGAServer() openfgav1.OpenFGAServiceServer {
+	return nil
 }
 
 func makeTuple(user, relation, object string) *openfgav1.TupleKey {

--- a/pkg/services/authz/zanzana/server/reconciler/reconciler_test.go
+++ b/pkg/services/authz/zanzana/server/reconciler/reconciler_test.go
@@ -44,6 +44,9 @@ func (s *stubServer) ListAllStores(context.Context) ([]zanzana.StoreInfo, error)
 func (s *stubServer) WriteTuples(context.Context, *zanzana.StoreInfo, []*openfgav1.TupleKey, []*openfgav1.TupleKeyWithoutCondition) error {
 	return nil
 }
+func (s *stubServer) ReadTuples(context.Context, *zanzana.StoreInfo, *openfgav1.ReadRequest) (*openfgav1.ReadResponse, error) {
+	return &openfgav1.ReadResponse{}, nil
+}
 func (s *stubServer) GetOpenFGAServer() openfgav1.OpenFGAServiceServer {
 	return nil
 }

--- a/pkg/services/authz/zanzana/server/server_read.go
+++ b/pkg/services/authz/zanzana/server/server_read.go
@@ -10,6 +10,7 @@ import (
 	"go.opentelemetry.io/otel/codes"
 
 	authzextv1 "github.com/grafana/grafana/pkg/services/authz/proto/v1"
+	"github.com/grafana/grafana/pkg/services/authz/zanzana"
 	"github.com/grafana/grafana/pkg/services/authz/zanzana/common"
 )
 
@@ -74,4 +75,20 @@ func (s *Server) read(ctx context.Context, req *authzextv1.ReadRequest) (*authze
 		Tuples:            tuples,
 		ContinuationToken: res.GetContinuationToken(),
 	}, nil
+}
+
+// ReadTuples reads tuples from the provided store, skipping the public-API
+// authorization check that Server.Read performs. Intended for internal callers
+// (such as the mt-reconciler) that already have a resolved StoreInfo and run
+// under a background context without end-user claims.
+func (s *Server) ReadTuples(ctx context.Context, store *zanzana.StoreInfo, req *openfgav1.ReadRequest) (*openfgav1.ReadResponse, error) {
+	ctx, span := s.tracer.Start(ctx, "server.ReadTuples")
+	defer span.End()
+
+	defer func(t time.Time) {
+		s.metrics.requestDurationSeconds.WithLabelValues("ReadTuples").Observe(time.Since(t).Seconds())
+	}(time.Now())
+
+	req.StoreId = store.ID
+	return s.openFGAClient.Read(ctx, req)
 }


### PR DESCRIPTION
## Summary

Fixes a regression in #123030 that broke the mt-reconciler with:

```
logger=zanzana.server level=error msg="failed to perform read request"
  error="rpc error: code = Unauthenticated desc = unauthenticated"
  namespace=stacks-XXXX
```

### Root cause

#123030 routed the reconciler's read path through the public `Server.Read` API instead of calling OpenFGA directly. `Server.Read` calls `authorize(ctx, req.GetNamespace(), s.cfg)` (`server/auth.go:16`), which requires `claims.AuthInfoFrom(ctx)` and returns `codes.Unauthenticated` when absent. The mt-reconciler runs as a background worker with no end-user claims in its context, so the check fails every reconcile.

Note the asymmetry before this PR: the reconciler's **write** path still uses `Server.WriteTuples(ctx, storeInfo, ...)` — an internal helper that takes a pre-resolved `StoreInfo` and bypasses `authorizeWrite`. Only reads were switched to the public API.

### Fix

Mirror the `WriteTuples` pattern:

- Add `ReadTuples(ctx, store *StoreInfo, req *openfgav1.ReadRequest)` to `ServerInternal`.
- Implement it as a thin wrapper around `s.openFGAClient.Read(...)` that uses the caller-supplied `StoreInfo`, records the `ReadTuples` latency metric, and **does not call `authorize`**.
- `computeDiffStreaming` now resolves the store once via `GetOrCreateStore` (same as `writeTuplesToZanzana`) and iterates via `ReadTuples` using `openfgav1` types directly. This also drops the `authzextv1` ↔ `openfgav1` conversion that #123030 introduced.

Auth was chosen over bypass because adding authentication to the reconciler context would add extra per-read latency on a hot path that already fans out page-by-page per namespace.

## Test plan

- [x] `go build ./pkg/services/authz/zanzana/...`
- [x] `go test ./pkg/services/authz/zanzana/...` — all pass
- [x] `make lint-go` — 0 issues
- [ ] Verify in dev cluster that mt-reconciler errors stop after deploy