### PR TITLE
feat(timepicker): add support for ISO 8601 week strings (YYYY-Www)

### DIFF
--- a/packages/grafana-data/src/datetime/datemath.test.ts
+++ b/packages/grafana-data/src/datetime/datemath.test.ts
@@ -52,6 +52,27 @@ describe('DateMath', () => {
     expect(startOfDay).toBe(expected.getTime());
   });
 
+  describe('ISO Week parsing', () => {
+    it('should parse ISO week string 2026-W15 as start of week', () => {
+      const result = dateMath.parse('2026-W15', false);
+      expect(result?.isValid()).toBe(true);
+      // ISO Week 15 in 2026 starts on Monday, April 6th
+      expect(result?.format('YYYY-MM-DD')).toBe('2026-04-06');
+    });
+
+    it('should parse ISO week string 2026-W15 as end of week when roundUp is true', () => {
+      const result = dateMath.parse('2026-W15', true);
+      expect(result?.isValid()).toBe(true);
+      // Sunday of that week
+      expect(result?.format('YYYY-MM-DD')).toBe('2026-04-12');
+    });
+
+    it('should still parse standard ISO dates correctly', () => {
+      const result = dateMath.parse('2026-04-06', false);
+      expect(result?.format('YYYY-MM-DD')).toBe('2026-04-06');
+    });
+  });
+
   describe('with fiscal quarters', () => {
     beforeEach(() => {
       const fixedTime = dateTime('2023-07-05T06:06:06.666Z').valueOf();

--- a/packages/grafana-data/src/datetime/datemath.ts
+++ b/packages/grafana-data/src/datetime/datemath.ts
@@ -11,10 +11,12 @@ import {
   type DurationUnit,
   isDateTime,
   ISO_8601,
+  ISO_8601_WEEK,
 } from './moment_wrapper';
 
 const units: string[] = ['y', 'M', 'w', 'd', 'h', 'm', 's', 'Q'] satisfies DurationUnit[];
 const MAX_MATH_TOKEN_DIGITS = 5;
+const ISO_WEEK_REGEXP = /^\d{4}-W\d{2}$/;
 
 export const isDurationUnit = (value: string): value is DurationUnit => {
   return units.includes(value);
@@ -110,8 +112,18 @@ export function toDateTime(dateTimeRep: string | DateTime | Date, options: Conve
         parseString = dateTimeRep.substring(0, index);
         mathString = dateTimeRep.substring(index + 2);
       }
-      // We're going to just require ISO8601 timestamps, k?
-      time = dateTime(parseString, ISO_8601);
+      // Handle ISO 8601 week strings (e.g. 2026-W15)
+      if (ISO_WEEK_REGEXP.test(parseString)) {
+        time = dateTime(parseString, ISO_8601_WEEK);
+
+        if (options.roundUp) {
+          time.endOf('isoWeek');
+        } else {
+          time.startOf('isoWeek');
+        }
+      } else {
+        time = dateTime(parseString, ISO_8601);
+      }
     }
 
     if (!mathString.length) {

--- a/packages/grafana-data/src/datetime/moment_wrapper.ts
+++ b/packages/grafana-data/src/datetime/moment_wrapper.ts
@@ -7,6 +7,7 @@ export interface DateTimeBuiltinFormat {
   __momentBuiltinFormatBrand: any;
 }
 export const ISO_8601: DateTimeBuiltinFormat = moment.ISO_8601;
+export const ISO_8601_WEEK = 'GGGG-[W]WW';
 export type DateTimeInput = Date | string | number | Array<string | number> | DateTime | null; // | undefined;
 export type FormatInput = string | DateTimeBuiltinFormat | undefined;
 export type DurationInput = string | number | DateTimeDuration;

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker/TimeRangeContent.tsx
@@ -3,6 +3,7 @@ import { type KeyboardEvent, useCallback, useEffect, useId, useState } from 'rea
 import { useForm } from 'react-hook-form';
 
 import {
+  dateMath,
   type DateTime,
   dateTimeFormat,
   dateTimeParse,
@@ -100,9 +101,26 @@ export const TimeRangeContent = (props: Props) => {
 
   const onApply = useCallback(() => {
     handleSubmit((data) => {
-      const raw: RawTimeRange = { from: data.from, to: data.to };
-      const timeRange = rangeUtil.convertRawToRange(raw, timeZone, fiscalYearStartMonth, commonFormat);
-      onApplyFromProps(timeRange);
+      /**
+       * ARCHITECTURAL NOTE:
+       * We bypass rangeUtil.convertRawToRange to utilize the upgraded dateMath.parse
+       * engine directly. This ensures that ISO 8601 week strings (YYYY-Www) are
+       * parsed correctly with proper boundary resolution (Monday-Sunday).
+       * * We pass 'fiscalYearStartMonth' and 'timeZone' to ensure no regression in
+       * existing fiscal or timezone-specific math logic.
+       */
+      const from = dateMath.parse(data.from, false, timeZone, fiscalYearStartMonth);
+      const to = dateMath.parse(data.to, true, timeZone, fiscalYearStartMonth);
+
+      if (from && to) {
+        onApplyFromProps({
+          from,
+          to,
+          // We pass back the raw input strings so the UI retains the 'YYYY-Www'
+          // format in the input fields instead of being replaced by timestamps.
+          raw: { from: data.from, to: data.to },
+        });
+      }
     })();
   }, [handleSubmit, timeZone, fiscalYearStartMonth, onApplyFromProps]);
 
@@ -272,12 +290,27 @@ export const TimeRangeContent = (props: Props) => {
   );
 };
 
+/**
+ * Validates that the 'from' date is chronologically before or equal to the 'to' date.
+ * We use dateMath.parse directly to ensure the 'to' field correctly respects
+ * the roundUp boundary (e.g., Sunday for ISO weeks), preventing false positives
+ * when the same week is entered in both fields.
+ */
 function isRangeInvalid(from: string, to: string, timezone?: string): boolean {
-  const raw: RawTimeRange = { from, to };
-  const timeRange = rangeUtil.convertRawToRange(raw, timezone, undefined, commonFormat);
-  const valid = timeRange.from.isSame(timeRange.to) || timeRange.from.isBefore(timeRange.to);
+  // Parse both ends of the range.
+  // 'from' is parsed to the start of the period, 'to' is parsed to the end.
+  const fromDate = dateMath.parse(from, false, timezone);
+  const toDate = dateMath.parse(to, true, timezone);
 
-  return !valid;
+  // If either string is currently unparseable, we let the individual
+  // field validators handle the "Invalid Date" UI feedback.
+  if (!fromDate || !toDate || !fromDate.isValid() || !toDate.isValid()) {
+    return false;
+  }
+
+  // The range is invalid ONLY if 'from' is strictly after 'to'.
+  // Using .valueOf() is the safest way to compare timestamps in TS.
+  return fromDate.valueOf() > toDate.valueOf();
 }
 
 function valueAsString(value: DateTime | string, timeZone?: TimeZone): string {

--- a/packages/grafana-ui/src/components/DateTimePickers/utils.ts
+++ b/packages/grafana-ui/src/components/DateTimePickers/utils.ts
@@ -7,9 +7,10 @@ export function isValid(value: string, roundUp?: boolean, timeZone?: TimeZone): 
     return value.isValid();
   }
 
-  // handles `now` math
-  if (dateMath.isMathString(value)) {
-    return dateMath.isValid(value);
+  // handles `now` math AND ISO week logic
+  // dateMath.isValid calls dateMath.parse internally!
+  if (dateMath.isValid(value)) {
+    return true;
   }
 
   const parsed = dateTimeParse(value, { roundUp, timeZone, format: commonFormat });


### PR DESCRIPTION
<img width="475" height="383" alt="timepicker" src="https://github.com/user-attachments/assets/b8301982-1d99-4672-888b-e930cd36f253" />

This PR implements support for ISO 8601 week strings (e.g., 2026-W15) across the grafana-data parsing engine and the grafana-ui TimePicker components. Previously, these strings were rejected by the UI validator and ignored by the dateMath engine.

Why is this needed?
As noted in #122887, users currently receive an "Enter a date..." validation error when attempting to use standard ISO week formats, even though these are technically valid date strings.

Key Changes

- Engine Support: Updated dateMath.parse to recognize the YYYY-Www pattern using dateTimeParse.
- Boundary Handling: Implemented roundUp logic for weeks, ensuring the to field correctly resolves to the end of the week (Sunday 23:59:59).
- UI Validation: Updated isValid and isRangeInvalid in TimePicker to allow these strings and ensure chronological consistency.
- State Integrity: Updated TimeRangeContent to parse these strings directly via dateMath, preserving the raw user input in the UI state.

Fixed Issue
Closes #122887

How to test
1) Open the TimePicker.
2) Enter a week string like 2026-W15 in the "From" or "To" field.
3) Observe that the validation error no longer appears.

Apply the range and verify the resulting time window covers the full week (Monday to Sunday).