### PR TITLE
chore: getCachedPromise always logs and invalidates on error

### DIFF
--- a/packages/grafana-runtime/src/utils/getCachedPromise.test.ts
+++ b/packages/grafana-runtime/src/utils/getCachedPromise.test.ts
@@ -177,15 +177,49 @@ describe('cached promises', () => {
         expect(promise).toHaveBeenCalledTimes(1);
       });
 
-      test('should not invalidate cache on errors', async () => {
+      test('should invalidate cache on errors', async () => {
         const promise = jest.fn(simulateErrorRequest);
         const promise2 = jest.fn(simulateOkRequest);
 
         await expect(getCachedPromise(promise)).rejects.toThrow('Network Error');
-        await expect(getCachedPromise(promise2)).rejects.toThrow('Network Error');
 
+        const actual = await getCachedPromise(promise2);
+
+        expect(actual).toStrictEqual({ ok: true, status: 200, statusText: 'ok' });
         expect(promise).toHaveBeenCalledTimes(1);
-        expect(promise2).toHaveBeenCalledTimes(0);
+        expect(promise2).toHaveBeenCalledTimes(1);
+      });
+
+      test('should log errors', async () => {
+        const promise = jest.fn(simulateErrorRequest);
+
+        await expect(getCachedPromise(promise)).rejects.toThrow('Network Error');
+
+        const logErrorMock = getLogger('grafana/runtime.utils.getCachedPromise').logError as jest.Mock;
+        expect(logErrorMock).toHaveBeenCalledTimes(1);
+        expect(logErrorMock).toHaveBeenCalledWith(
+          new Error(`getCachedPromise: Something failed while resolving a cached promise`),
+          {
+            stack: expect.any(String),
+            message: 'Network Error',
+            key: 'mockConstructor',
+          }
+        );
+        expect(logErrorMock.mock.calls[0][0].cause).toStrictEqual(new Error('Network Error'));
+      });
+
+      test('should log non-Error thrown values', async () => {
+        const promise = jest.fn(() => Promise.reject('string error'));
+
+        await expect(getCachedPromise(promise)).rejects.toBe('string error');
+
+        const logErrorMock = getLogger('grafana/runtime.utils.getCachedPromise').logError as jest.Mock;
+        expect(logErrorMock).toHaveBeenCalledTimes(1);
+        expect(logErrorMock).toHaveBeenCalledWith(
+          expect.any(Error),
+          expect.objectContaining({ message: 'string error', key: 'mockConstructor' })
+        );
+        expect(logErrorMock.mock.calls[0][0].cause).toBe('string error');
       });
     });
 
@@ -229,8 +263,9 @@ describe('cached promises', () => {
 
         expect(actual).toStrictEqual({ ok: false, status: 500, statusText: 'Internal Server Error' });
         expect(promise).toHaveBeenCalledTimes(1);
-        expect(getLogger('grafana/runtime.utils.getCachedPromise').logError).toHaveBeenCalledTimes(1);
-        expect(getLogger('grafana/runtime.utils.getCachedPromise').logError).toHaveBeenCalledWith(
+        const logErrorMock = getLogger('grafana/runtime.utils.getCachedPromise').logError as jest.Mock;
+        expect(logErrorMock).toHaveBeenCalledTimes(1);
+        expect(logErrorMock).toHaveBeenCalledWith(
           new Error(`getCachedPromise: Something failed while resolving a cached promise`),
           {
             stack: expect.any(String),
@@ -238,6 +273,7 @@ describe('cached promises', () => {
             key: 'mockConstructor',
           }
         );
+        expect(logErrorMock.mock.calls[0][0].cause).toStrictEqual(new Error('Network Error'));
       });
 
       test('should invalidate cache when something errors', async () => {
@@ -297,30 +333,10 @@ describe('cached promises', () => {
         expect(actual).toStrictEqual({ ok: false, status: 500, statusText: 'Internal Server Error' });
         expect(promise).toHaveBeenCalledTimes(1);
         expect(onError).toHaveBeenCalledTimes(1);
-        expect(onError).toHaveBeenCalledWith({ error: new Error('Network Error'), invalidate: expect.any(Function) });
+        expect(onError).toHaveBeenCalledWith({ error: new Error('Network Error') });
       });
 
-      test('should invalidate cache when calling invalidate function', async () => {
-        const promise = jest.fn(simulateErrorRequest);
-        const promise2 = jest.fn(simulateOkRequest);
-
-        const actual1 = await getCachedPromise(promise, {
-          onError: async ({ error, invalidate }) => {
-            expect(error).toStrictEqual(new Error('Network Error'));
-            invalidate();
-            return { ok: false, status: 500, statusText: 'Network Error' };
-          },
-        });
-
-        const actual2 = await getCachedPromise(promise2);
-
-        expect(actual1).toStrictEqual({ ok: false, status: 500, statusText: 'Network Error' });
-        expect(actual2).toStrictEqual({ ok: true, status: 200, statusText: 'ok' });
-        expect(promise).toHaveBeenCalledTimes(1);
-        expect(promise2).toHaveBeenCalledTimes(1); // because the cache is invalidated on error then promise2 is called
-      });
-
-      test('should not invalidate cache if invalidate function is not called', async () => {
+      test('should always invalidate cache on error', async () => {
         const promise = jest.fn(simulateErrorRequest);
         const promise2 = jest.fn(simulateOkRequest);
 
@@ -334,9 +350,51 @@ describe('cached promises', () => {
         const actual2 = await getCachedPromise(promise2);
 
         expect(actual1).toStrictEqual({ ok: false, status: 500, statusText: 'Network Error' });
-        expect(actual2).toBe(actual1);
+        expect(actual2).toStrictEqual({ ok: true, status: 200, statusText: 'ok' });
         expect(promise).toHaveBeenCalledTimes(1);
-        expect(promise2).toHaveBeenCalledTimes(0); // because the cache is not invalidated on error
+        expect(promise2).toHaveBeenCalledTimes(1); // cache is always invalidated on error
+      });
+
+      test('should log errors', async () => {
+        const promise = jest.fn(simulateErrorRequest);
+
+        await getCachedPromise(promise, {
+          onError: async () => ({ ok: false, status: 500, statusText: 'Internal Server Error' }),
+        });
+
+        const logErrorMock = getLogger('grafana/runtime.utils.getCachedPromise').logError as jest.Mock;
+        expect(logErrorMock).toHaveBeenCalledTimes(1);
+        expect(logErrorMock).toHaveBeenCalledWith(
+          new Error(`getCachedPromise: Something failed while resolving a cached promise`),
+          {
+            stack: expect.any(String),
+            message: 'Network Error',
+            key: 'mockConstructor',
+          }
+        );
+        expect(logErrorMock.mock.calls[0][0].cause).toStrictEqual(new Error('Network Error'));
+      });
+
+      test('should propagate error when onError callback throws', async () => {
+        const promise = jest.fn(simulateErrorRequest);
+
+        await expect(
+          getCachedPromise(promise, {
+            onError: async () => {
+              throw new Error('onError failed');
+            },
+          })
+        ).rejects.toThrow('onError failed');
+
+        // Error should still be logged
+        const logErrorMock = getLogger('grafana/runtime.utils.getCachedPromise').logError as jest.Mock;
+        expect(logErrorMock).toHaveBeenCalledTimes(1);
+
+        // Cache should still be invalidated
+        const promise2 = jest.fn(simulateOkRequest);
+        const actual = await getCachedPromise(promise2);
+        expect(actual).toStrictEqual({ ok: true, status: 200, statusText: 'ok' });
+        expect(promise2).toHaveBeenCalledTimes(1);
       });
     });
   });
@@ -436,7 +494,7 @@ describe('cached promises', () => {
 
       expect(actual).toBe('recovered');
       expect(onError).toHaveBeenCalledTimes(1);
-      expect(onError).toHaveBeenCalledWith({ error: new Error('fail'), invalidate: expect.any(Function) });
+      expect(onError).toHaveBeenCalledWith({ error: new Error('fail') });
     });
 
     test('should support invalidate option', async () => {
@@ -616,19 +674,16 @@ describe('cached promises', () => {
         const fn = jest.fn(async (_id: string): Promise<string> => {
           throw new Error('fail');
         });
-        const onError = jest.fn(async ({ invalidate }: { invalidate: () => void }) => {
-          invalidate();
-          return 'recovered';
-        });
+        const onError = jest.fn(async () => 'recovered');
         const cached = getCachedPromiseWithArgs(fn, { onError }, (id) => `custom:${id}`);
 
         const actual = await cached('a');
 
         expect(actual).toBe('recovered');
         expect(onError).toHaveBeenCalledTimes(1);
-        expect(onError).toHaveBeenCalledWith({ error: new Error('fail'), invalidate: expect.any(Function) });
+        expect(onError).toHaveBeenCalledWith({ error: new Error('fail') });
 
-        // After invalidation via onError, a new call should re-fetch
+        // Cache is always invalidated on error, so a new call should re-fetch
         fn.mockResolvedValueOnce('fresh');
         const actual2 = await cached('a');
         expect(actual2).toBe('fresh');

--- a/packages/grafana-runtime/src/utils/getCachedPromise.ts
+++ b/packages/grafana-runtime/src/utils/getCachedPromise.ts
@@ -10,7 +10,6 @@ export const MAX_CACHE_SIZE = 500;
 
 interface OnErrorArgs {
   error: unknown;
-  invalidate: () => void;
 }
 
 type PromiseFunction<T> = () => Promise<T>;
@@ -22,7 +21,7 @@ interface CachedPromiseOptions<T> {
   onError?: (args: OnErrorArgs) => Promise<T>;
 }
 
-interface CachePromiseWithoutCatchArgs<T> {
+interface CachePromiseThatPropagatesError<T> {
   key: string;
   promise: PromiseFunction<T>;
 }
@@ -45,17 +44,21 @@ interface LogErrorArgs {
 }
 
 function logError({ error, key }: LogErrorArgs): void {
-  const err = error instanceof Error ? error : new Error(String(error));
+  try {
+    const err = error instanceof Error ? error : new Error(String(error));
 
-  const context: LogContext = { message: err.message, key };
-  if (err.stack) {
-    context.stack = err.stack;
+    const context: LogContext = { message: err.message, key };
+    if (err.stack) {
+      context.stack = err.stack;
+    }
+
+    getLogger('grafana/runtime.utils.getCachedPromise').logError(
+      new Error(`getCachedPromise: Something failed while resolving a cached promise`, { cause: error }),
+      context
+    );
+  } catch (error) {
+    console.error(error);
   }
-
-  getLogger('grafana/runtime.utils.getCachedPromise').logError(
-    new Error(`getCachedPromise: Something failed while resolving a cached promise`),
-    context
-  );
 }
 
 function checkCacheSize() {
@@ -70,8 +73,12 @@ function addToCache<T>(key: string, cached: Promise<T>) {
   cache.set(key, cached);
 }
 
-function cachePromiseWithoutCatch<T>({ key, promise }: CachePromiseWithoutCatchArgs<T>): Promise<T> {
-  const cached = promise();
+function cachePromiseThatPropagatesError<T>({ key, promise }: CachePromiseThatPropagatesError<T>): Promise<T> {
+  const cached = promise().catch((error) => {
+    logError({ error, key });
+    cache.delete(key);
+    throw error;
+  });
   addToCache(key, cached);
 
   return cached;
@@ -89,8 +96,11 @@ function cachePromiseWithDefaultValue<T>({ defaultValue, key, promise }: CachePr
 }
 
 function cachePromiseWithCallback<T>({ key, promise, onError }: CachePromiseWithCallbackArgs<T>): Promise<T> {
-  const invalidate = () => cache.delete(key);
-  const cached = promise().catch((error) => onError({ error, invalidate }));
+  const cached = promise().catch((error) => {
+    logError({ error, key });
+    cache.delete(key);
+    return onError({ error });
+  });
   addToCache(key, cached);
 
   return cached;
@@ -100,8 +110,11 @@ function cachePromiseWithCallback<T>({ key, promise, onError }: CachePromiseWith
  * This utility function will safely handle concurrent requests for the same resource by caching the promise.
  * Caches the result of a promise based on the name of the promise function or cacheKey. If a cached promise exists for the given key,
  * it returns the cached promise. Otherwise, it executes the promise function and caches the result.
- * It also provides options for handling errors, including returning a defaultValue value or invoking a custom error handler.
- * If neither defaultValue nor onError is provided, errors will propagate as usual.
+ *
+ * On error, the cache entry is always invalidated and the error is always logged.
+ * If a `defaultValue` is provided, it is returned instead of throwing.
+ * If an `onError` callback is provided, its return value is used instead of throwing.
+ * If neither is provided, the error propagates after logging and cache invalidation.
  *
  * @template T - The type of the resolved promise value
  * @param promise - Function that returns the promise to be cached
@@ -109,7 +122,7 @@ function cachePromiseWithCallback<T>({ key, promise, onError }: CachePromiseWith
  * @param options.cacheKey - Optional cache key to use as key instead of the function name
  * @param options.defaultValue - Optional default value to return if the promise rejects
  * @param options.invalidate - Optionally invalidates the cache for the given function name or cacheKey
- * @param options.onError - Optional error handler that receives the error and an invalidate function
+ * @param options.onError - Optional error handler that receives the error and returns a fallback value
  * @returns A promise that resolves to the cached or newly computed value
  */
 export function getCachedPromise<T>(promise: PromiseFunction<T>, options?: CachedPromiseOptions<T>): Promise<T> {
@@ -138,7 +151,7 @@ export function getCachedPromise<T>(promise: PromiseFunction<T>, options?: Cache
     return cachePromiseWithDefaultValue({ defaultValue, key, promise });
   }
 
-  return cachePromiseWithoutCatch({ key, promise });
+  return cachePromiseThatPropagatesError({ key, promise });
 }
 
 export function invalidateCache() {
@@ -195,7 +208,7 @@ export function serializeArg(value: unknown, baseKey: string): string {
  * @param options - Options for error handling and cache invalidation (defaultValue, invalidate, onError)
  * @param options.defaultValue - Optional default value to return if the promise rejects
  * @param options.invalidate - Optionally invalidates the cache for the given function name or cacheKey
- * @param options.onError - Optional error handler that receives the error and an invalidate function
+ * @param options.onError - Optional error handler that receives the error and returns a fallback value
  * @param cacheKeyFn - Optional function that receives the same arguments as `fn` and returns a
  *   cache key string. **Required** when `fn` accepts arguments that are not plain POJOs.
  * @returns A wrapper function with the same signature as `fn` that returns cached promises


### PR DESCRIPTION
**What is this feature?**                                                                                                                                                
                                                                                                                                                                           
Simplifies `getCachedPromise` error handling so that all code paths consistently log errors and invalidate the cache on failure. Removes the `invalidate` callback from `onError` since invalidation now always happens automatically. 

We could potentially introduce an `invalidateOnError` option if someone wants to keep their rejected promise in cache, but leaving that for the future to decide 👍                                                                                               
                                                           
**Why do we need this feature?**
                                                                                                                                                                           
The previous error handling behavior was inconsistent across the three code paths: the no-options path silently swallowed errors without logging or invalidating, the `defaultValue` path logged and invalidated, and the `onError` path delegated invalidation to the caller. Since no callers use `getCachedPromise` without options or rely on the `onError` `invalidate` callback, this simplifies the API by making the behavior uniform, errors are always logged and the cache is always invalidated, reducing the surface area for stale cached errors.

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
