### PR TITLE
Revert "Zanzana: Refactor read in reconciler"

### DIFF
--- a/pkg/services/authz/zanzana/server/reconciler/namespace.go
+++ b/pkg/services/authz/zanzana/server/reconciler/namespace.go
@@ -19,7 +19,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	authzextv1 "github.com/grafana/grafana/pkg/services/authz/proto/v1"
 	"github.com/grafana/grafana/pkg/services/authz/zanzana"
-	"github.com/grafana/grafana/pkg/services/authz/zanzana/common"
 )
 
 // tupleKey generates a unique string key for a tuple based on user, relation, and object.
@@ -266,25 +265,31 @@ func (r *Reconciler) computeDiffStreaming(
 	defer span.End()
 
 	pagesRead := 0
+
+	// Get store info for the namespace
+	storeInfo, err := r.server.GetOrCreateStore(ctx, namespace)
+	if err != nil {
+		return nil, nil, tracing.Errorf(span, "failed to get store info: %w", err)
+	}
+
 	var continuationToken string
 
 	// Read current tuples page-by-page and diff against expected
 	for {
-		req := &authzextv1.ReadRequest{
-			Namespace:         namespace,
+		req := &openfgav1.ReadRequest{
+			StoreId:           storeInfo.ID,
 			PageSize:          wrapperspb.Int32(r.cfg.zanzanaReadPageSize()),
 			ContinuationToken: continuationToken,
 		}
 
-		resp, err := r.server.Read(ctx, req)
+		resp, err := r.server.GetOpenFGAServer().Read(ctx, req)
 		if err != nil {
 			return nil, nil, tracing.Errorf(span, "failed to read tuples: %w", err)
 		}
 
 		pagesRead++
 
-		for _, authzTuple := range resp.GetTuples() {
-			tuple := common.ToOpenFGATuple(authzTuple)
+		for _, tuple := range resp.GetTuples() {
 			key := tupleKey(tuple.GetKey())
 			if expected, exists := expectedMap[key]; exists {
 				if proto.Equal(expected.GetCondition(), tuple.GetKey().GetCondition()) {

--- a/pkg/services/authz/zanzana/server/reconciler/namespace_test.go
+++ b/pkg/services/authz/zanzana/server/reconciler/namespace_test.go
@@ -16,14 +16,37 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	authzextv1 "github.com/grafana/grafana/pkg/services/authz/proto/v1"
 	"github.com/grafana/grafana/pkg/services/authz/zanzana"
-	"github.com/grafana/grafana/pkg/services/authz/zanzana/common"
 )
+
+// mockOpenFGAServer implements only the Read method; all others panic via the embedded Unimplemented.
+type mockOpenFGAServer struct {
+	openfgav1.UnimplementedOpenFGAServiceServer
+	// pages is a list of tuple pages to return on successive Read calls.
+	pages [][]*openfgav1.Tuple
+}
+
+func (m *mockOpenFGAServer) Read(_ context.Context, _ *openfgav1.ReadRequest) (*openfgav1.ReadResponse, error) {
+	if len(m.pages) == 0 {
+		return &openfgav1.ReadResponse{}, nil
+	}
+	page := m.pages[0]
+	m.pages = m.pages[1:]
+
+	token := ""
+	if len(m.pages) > 0 {
+		token = "next"
+	}
+	return &openfgav1.ReadResponse{
+		Tuples:            page,
+		ContinuationToken: token,
+	}, nil
+}
 
 // mockServerInternal satisfies zanzana.ServerInternal for computeDiffStreaming tests.
 type mockServerInternal struct {
 	authzv1.UnimplementedAuthzServiceServer
 	authzextv1.UnimplementedAuthzExtentionServiceServer
-	pages [][]*openfgav1.Tuple
+	fga *mockOpenFGAServer
 }
 
 func (m *mockServerInternal) Close()                              {}
@@ -44,32 +67,7 @@ func (m *mockServerInternal) WriteTuples(context.Context, *zanzana.StoreInfo, []
 	return nil
 }
 func (m *mockServerInternal) GetOpenFGAServer() openfgav1.OpenFGAServiceServer {
-	return nil
-}
-
-func (m *mockServerInternal) Read(_ context.Context, _ *authzextv1.ReadRequest) (*authzextv1.ReadResponse, error) {
-	if len(m.pages) == 0 {
-		return &authzextv1.ReadResponse{}, nil
-	}
-	page := m.pages[0]
-	m.pages = m.pages[1:]
-
-	token := ""
-	if len(m.pages) > 0 {
-		token = "next"
-	}
-
-	pageTuples := make([]*authzextv1.Tuple, 0)
-	for _, t := range page {
-		pageTuples = append(pageTuples, &authzextv1.Tuple{
-			Key:       common.ToAuthzExtTupleKey(t.GetKey()),
-			Timestamp: t.GetTimestamp(),
-		})
-	}
-	return &authzextv1.ReadResponse{
-		Tuples:            pageTuples,
-		ContinuationToken: token,
-	}, nil
+	return m.fga
 }
 
 func makeTuple(user, relation, object string) *openfgav1.TupleKey {
@@ -120,7 +118,7 @@ func toTuple(tk *openfgav1.TupleKey) *openfgav1.Tuple {
 
 func newTestReconciler(pages [][]*openfgav1.Tuple) *Reconciler {
 	return &Reconciler{
-		server:  &mockServerInternal{pages: pages},
+		server:  &mockServerInternal{fga: &mockOpenFGAServer{pages: pages}},
 		cfg:     Config{CRDs: DefaultCRDs},
 		logger:  log.NewNopLogger(),
 		tracer:  tracing.NewNoopTracerService(),

--- a/pkg/services/authz/zanzana/server/reconciler/reconciler_test.go
+++ b/pkg/services/authz/zanzana/server/reconciler/reconciler_test.go
@@ -45,7 +45,7 @@ func (s *stubServer) WriteTuples(context.Context, *zanzana.StoreInfo, []*openfga
 	return nil
 }
 func (s *stubServer) GetOpenFGAServer() openfgav1.OpenFGAServiceServer {
-	return nil
+	return &mockOpenFGAServer{}
 }
 func (s *stubServer) GetOrCreateStore(_ context.Context, ns string) (*zanzana.StoreInfo, error) {
 	s.getOrCreateCalls.Add(1)

--- a/pkg/services/authz/zanzana/server/server_store.go
+++ b/pkg/services/authz/zanzana/server/server_store.go
@@ -186,7 +186,7 @@ func (s *Server) ListAllStores(ctx context.Context) ([]zanzana.StoreInfo, error)
 	var continuationToken string
 
 	for {
-		res, err := s.openFGAClient.ListStores(ctx, &openfgav1.ListStoresRequest{
+		res, err := s.GetOpenFGAServer().ListStores(ctx, &openfgav1.ListStoresRequest{
 			ContinuationToken: continuationToken,
 		})
 		if err != nil {


### PR DESCRIPTION
Reverts grafana/grafana#123030
It breaks tuples read since Read() method designed to use externaly and have authorization required token with correct audience (namespace).