### PR TITLE
chore: fix usagestats flaky test

### DIFF
--- a/pkg/infra/usagestats/service/usage_stats_test.go
+++ b/pkg/infra/usagestats/service/usage_stats_test.go
@@ -116,9 +116,13 @@ func TestMetrics(t *testing.T) {
 		})
 		usageStatsURL = ts.URL
 
+		var wg sync.WaitGroup
+		wg.Add(1)
+		t.Cleanup(wg.Wait)
 		go func() {
+			defer wg.Done()
 			_, err := uss.sendUsageStats(context.Background())
-			require.NoError(t, err)
+			assert.NoError(t, err)
 		}()
 
 		// Wait for fake HTTP server to receive a request


### PR DESCRIPTION
this one was tricky. the test spawns a goroutine to call `sendUsageStats` and reads from a channel once the fake HTTP handler fires, then the subtest returns, which triggers `ts.Close()` via cleanup, which closes active server connections while the goroutine's HTTP client is still reading the response. This causes the "CloseIdleConnections called" error on the client side.

the fix is to register `wg.Wait` as a cleanup after `ts.Close`, so it runs first and blocks until the goroutine finishes before the server tears down.