### PR TITLE
chore: use token broker in integration tests

### DIFF
--- a/.github/actions/setup-enterprise/action.yml
+++ b/.github/actions/setup-enterprise/action.yml
@@ -3,15 +3,19 @@ description: 'Clones and sets up Grafana Enterprise repository for testing'
 
 inputs:
   github-app-name:
-    description: 'Name of the GitHub App in Vault'
+    description: 'Name of the GitHub App in Vault (unused when token is provided)'
     required: false
     default: 'grafana-ci-bot'
+  token:
+    description: 'GitHub token for cloning grafana-enterprise (when provided, skips vault and token generation)'
+    required: false
 
 runs:
   using: "composite"
   steps:
     - name: Retrieve GitHub App secrets
       id: get-secrets
+      if: ${{ inputs.token == '' }}
       uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.0.1 # zizmor: ignore[unpinned-uses]
       with:
         repo_secrets: |
@@ -21,6 +25,7 @@ runs:
 
     - name: Generate GitHub App token
       id: generate_token
+      if: ${{ inputs.token == '' }}
       uses: actions/create-github-app-token@v1
       with:
         app-id: ${{ env.APP_ID }}
@@ -31,7 +36,7 @@ runs:
     - name: Setup Enterprise
       shell: bash
       env:
-        GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+        GH_TOKEN: ${{ inputs.token || steps.generate_token.outputs.token }}
       run: |
         RETRIES="5"
         grafana_root="$PWD"

--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -197,10 +197,15 @@ jobs:
         uses: actions/checkout@v5
         with:
           persist-credentials: false
+      - name: Get GitHub App token
+        id: get-github-app-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@e5b7989c92b55fe3ac6dd006d6de49082ba8c507 # create-github-app-token (github-script/v9)
+        with:
+          github_app: grafana-ci-bot
       - name: Setup Enterprise
         uses: ./.github/actions/setup-enterprise
         with:
-          github-app-name: 'grafana-ci-bot'
+          token: ${{ steps.get-github-app-token.outputs.token }}
       # Enterprise must be cloned before setup-go so that enterprise
       # modules are visible when the Go cache key is computed.
       - name: Setup Go
@@ -252,10 +257,15 @@ jobs:
         uses: actions/checkout@v5
         with:
           persist-credentials: false
+      - name: Get GitHub App token
+        id: get-github-app-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@e5b7989c92b55fe3ac6dd006d6de49082ba8c507 # create-github-app-token (github-script/v9)
+        with:
+          github_app: grafana-ci-bot
       - name: Setup Enterprise
         uses: ./.github/actions/setup-enterprise
         with:
-          github-app-name: 'grafana-ci-bot'
+          token: ${{ steps.get-github-app-token.outputs.token }}
       # Enterprise must be cloned before setup-go so that enterprise
       # modules are visible when the Go cache key is computed.
       - name: Setup Go
@@ -304,10 +314,15 @@ jobs:
       - name: Start Postgres via docker compose
         run: |
           make devenv sources=postgres_tests
+      - name: Get GitHub App token
+        id: get-github-app-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@e5b7989c92b55fe3ac6dd006d6de49082ba8c507 # create-github-app-token (github-script/v9)
+        with:
+          github_app: grafana-ci-bot
       - name: Setup Enterprise
         uses: ./.github/actions/setup-enterprise
         with:
-          github-app-name: 'grafana-ci-bot'
+          token: ${{ steps.get-github-app-token.outputs.token }}
       # Enterprise must be cloned before setup-go so that enterprise
       # modules are visible when the Go cache key is computed.
       - name: Setup Go


### PR DESCRIPTION
This should hopefully cut down on the number of vault pull failures in our integration tests.