### PR TITLE
Alerting: Fix flake TestIntegrationTimeIntervalReferentialIntegrity

### DIFF
--- a/pkg/tests/apis/alerting/notifications/timeinterval/timeinterval_test.go
+++ b/pkg/tests/apis/alerting/notifications/timeinterval/timeinterval_test.go
@@ -819,7 +819,9 @@ func TestIntegrationTimeIntervalReferentialIntegrity(t *testing.T) {
 	t.Run("Update", func(t *testing.T) {
 		t.Run("should rename all references if name changes", func(t *testing.T) {
 			renamed := interval.Copy().(*v1beta1.TimeInterval)
-			renamed.Spec.Name += "-new"
+			// Use a unique suffix so the target name cannot collide with any
+			// leftover state in the stored Alertmanager configuration.
+			renamed.Spec.Name += "-" + util.GenerateShortUID()
 
 			actual, err := adminClient.Update(ctx, renamed, resource.UpdateOptions{})
 			require.NoError(t, err)


### PR DESCRIPTION
## Summary
- The `should rename all references if name changes` subtest renames the fixture interval to a hardcoded `"-new"` target. When the stored Alertmanager configuration carries any leftover entry with that exact name, the subsequent GET fails the upstream Alertmanager validator with `time interval "test-interval-new" is not unique`, surfacing as `alerting.notification.configCorrupted` (500).
- Generates the rename suffix with `util.GenerateShortUID()` so the target name cannot collide.

## Test plan
- [x] `go test -count=5 -run TestIntegrationTimeIntervalReferentialIntegrity ./pkg/tests/apis/alerting/notifications/timeinterval/...` passes locally.