### PR TITLE
fix: force index for shorturl migration query

### DIFF
--- a/pkg/registry/apps/shorturl/migrator/query_shorturls.sql
+++ b/pkg/registry/apps/shorturl/migrator/query_shorturls.sql
@@ -7,7 +7,7 @@ SELECT
     s.created_at,
     s.last_seen_at
 FROM
-    {{ .Ident .ShortURLTable }} as s
+    {{ .Ident .ShortURLTable }} as s{{ if eq .DialectName "mysql" }} FORCE INDEX (IDX_short_url_org_id_id){{ end }}
 WHERE
     s.org_id = {{ .Arg .Query.OrgID }}
     {{ if .Query.LastID }}

--- a/pkg/registry/apps/shorturl/migrator/testdata/mysql--query_shorturls-all.sql
+++ b/pkg/registry/apps/shorturl/migrator/testdata/mysql--query_shorturls-all.sql
@@ -7,7 +7,7 @@ SELECT
     s.created_at,
     s.last_seen_at
 FROM
-    `grafana`.`short_url` as s
+    `grafana`.`short_url` as s FORCE INDEX (IDX_short_url_org_id_id)
 WHERE
     s.org_id = 1
     AND s.id > 5

--- a/pkg/registry/apps/shorturl/migrator/testdata/mysql--query_shorturls-last-id.sql
+++ b/pkg/registry/apps/shorturl/migrator/testdata/mysql--query_shorturls-last-id.sql
@@ -7,7 +7,7 @@ SELECT
     s.created_at,
     s.last_seen_at
 FROM
-    `grafana`.`short_url` as s
+    `grafana`.`short_url` as s FORCE INDEX (IDX_short_url_org_id_id)
 WHERE
     s.org_id = 1
     AND s.id > 5

--- a/pkg/registry/apps/shorturl/migrator/testdata/mysql--query_shorturls-limit.sql
+++ b/pkg/registry/apps/shorturl/migrator/testdata/mysql--query_shorturls-limit.sql
@@ -7,7 +7,7 @@ SELECT
     s.created_at,
     s.last_seen_at
 FROM
-    `grafana`.`short_url` as s
+    `grafana`.`short_url` as s FORCE INDEX (IDX_short_url_org_id_id)
 WHERE
     s.org_id = 1
 ORDER BY

--- a/pkg/registry/apps/shorturl/migrator/testdata/mysql--query_shorturls-list.sql
+++ b/pkg/registry/apps/shorturl/migrator/testdata/mysql--query_shorturls-list.sql
@@ -7,7 +7,7 @@ SELECT
     s.created_at,
     s.last_seen_at
 FROM
-    `grafana`.`short_url` as s
+    `grafana`.`short_url` as s FORCE INDEX (IDX_short_url_org_id_id)
 WHERE
     s.org_id = 1
 ORDER BY


### PR DESCRIPTION
Force using the newly added query in order to fix the below error faced while migrating `latamairlines`:
```log
ts=2026-04-22T08:19:59.276214666Z level=error caller=migrator.go:572 job=migration msg="error during migration" instance=latamairlines migration_id=shorturls err="migration failed for org 1 (stacks-179330): Error 1038 (HY001): Out of sort memory, consider increasing server sort buffer size"
```

Below are the explained queries with and without the force index hint (`FORCE INDEX (IDX_short_url_org_id_id)`); we can clearly see that the mysql planner is not using the newly added index and with the addition of the force index, it drops the sort operation:
```sql

MySQL [hg_latamairlines]> EXPLAIN SELECT
    ->     s.id, s.org_id, s.uid, s.path, s.created_by, s.created_at, s.last_seen_at
    -> FROM short_url AS s FORCE INDEX (IDX_short_url_org_id_id)
    -> WHERE s.org_id = 1 AND id > 0
    -> ORDER BY s.id ASC
    -> LIMIT 1000\G
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: s
   partitions: NULL
         type: range
possible_keys: IDX_short_url_org_id_id
          key: IDX_short_url_org_id_id
      key_len: 16
          ref: NULL
         rows: 6987
     filtered: 100.00
        Extra: Using index condition
1 row in set, 1 warning (0.005 sec)

MySQL [hg_latamairlines]> EXPLAIN SELECT
    ->     s.id, s.org_id, s.uid, s.path, s.created_by, s.created_at, s.last_seen_at
    -> FROM short_url s
    -> WHERE s.org_id = 1 AND id > 0
    -> ORDER BY s.id ASC
    -> LIMIT 1000\G
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: s
   partitions: NULL
         type: ref
possible_keys: PRIMARY,UQE_short_url_org_id_uid,IDX_short_url_org_id_id
          key: UQE_short_url_org_id_uid
      key_len: 8
          ref: const
         rows: 6987
     filtered: 50.00
        Extra: Using index condition; Using filesort
1 row in set, 1 warning (0.003 sec)
```