### PR TITLE
chore: typo sweep (recieved, seperate, publically, creataed, recieve)

### DIFF
--- a/contribute/feature-toggles.md
+++ b/contribute/feature-toggles.md
@@ -159,7 +159,7 @@ If using non-boolean flags (a unique feature of the new feature flag system), ex
 
 For advanced, non-React contexts (utilities, class methods, callbacks), you can use the OpenFeature client directly.
 
-However, because this is seperate from the React render loop there are important caveats you must be aware of:
+However, because this is separate from the React render loop there are important caveats you must be aware of:
 
 - Flag values are loaded asynchronously, so you cannot call `getBooleanValue()` just at the top-level of a module. You must wait until `app.ts` has initialised until you call a flag otherwise you will only get the default value
 - Flag values can change over the lifetime of the session, so do not store or cache the result. Always evaluate flags just in time when you use them, preferably in the if statement, for example.

--- a/contribute/merge-pull-request.md
+++ b/contribute/merge-pull-request.md
@@ -120,7 +120,7 @@ Backporting is the process of copying the pull request into the version branch o
 
 Backporting should be a rare exception, reserved only for critical bug fixes, and must be initiated by a Grafana Labs employee. We generally avoid automatic backports, as these changes carry some risk: they typically receive less manual testing than changes included in regular point releases.
 
-If a pull request addresses a critical bug and backporting is warranted, a Grafana Labs team member can apply the appropriate `backport vx.x` labels for the relevant release branches. The team will review and approve the backport before proceeding. When the pull request is merged, seperate backport PRs will automatically be creataed.
+If a pull request addresses a critical bug and backporting is warranted, a Grafana Labs team member can apply the appropriate `backport vx.x` labels for the relevant release branches. The team will review and approve the backport before proceeding. When the pull request is merged, separate backport PRs will automatically be created.
 
 #### Required labels
 

--- a/e2e-playwright/utils/RequestsRecorder.ts
+++ b/e2e-playwright/utils/RequestsRecorder.ts
@@ -73,7 +73,7 @@ export class RequestsRecorder {
   async #handleRequest(request: Request) {
     const type = request.resourceType();
 
-    // Once we've recieved a document response, create a list of requests that we'll count the responses of.
+    // Once we've received a document response, create a list of requests that we'll count the responses of.
     // We also want to count the document request itself.
     if (this.#documentUrl || type === 'document') {
       this.#currentRequests.add(request);
@@ -98,7 +98,7 @@ export class RequestsRecorder {
     // Record when a document response comes in so we can keep track of future requests
     if (type === 'document') {
       if (this.#documentUrl) {
-        console.warn('recieved additional document response', url);
+        console.warn('received additional document response', url);
       }
 
       this.#documentUrl = url;

--- a/packages/grafana-ui/src/components/Select/types.ts
+++ b/packages/grafana-ui/src/components/Select/types.ts
@@ -184,7 +184,7 @@ export type SelectOptions<T = any> =
 
 export type FormatOptionLabelMeta<T> = { context: string; inputValue: string; selectValue: Array<SelectableValue<T>> };
 
-// This is the type of `selectProps` our custom components (like SelectContainer, etc) recieve
+// This is the type of `selectProps` our custom components (like SelectContainer, etc) receive
 // It's slightly different to the base react select props because we pass in additional props directly to
 // react select
 export type ReactSelectProps<Option, IsMulti extends boolean, Group extends GroupBase<Option>> = ReactSelectCommonProps<

--- a/public/app/features/browse-dashboards/types.ts
+++ b/public/app/features/browse-dashboards/types.ts
@@ -27,7 +27,7 @@ export interface BrowseDashboardsState {
   childrenByParentUID: Record<string, DashboardViewItemCollection | undefined>;
   selectedItems: DashboardTreeSelection;
 
-  // Only folders can ever be open or closed, so no need to seperate this by kind
+  // Only folders can ever be open or closed, so no need to separate this by kind
   openFolders: Record<string, boolean>;
 }
 

--- a/public/app/features/connections/mocks/store.navIndex.mock.ts
+++ b/public/app/features/connections/mocks/store.navIndex.mock.ts
@@ -40,7 +40,7 @@ export const navIndex: NavIndex = {
       {
         id: 'dashboards/snapshots',
         text: 'Snapshots',
-        subTitle: 'Interactive, publically available, point-in-time representations of dashboards',
+        subTitle: 'Interactive, publicly available, point-in-time representations of dashboards',
         icon: 'camera',
         url: '/dashboard/snapshots',
       },
@@ -70,7 +70,7 @@ export const navIndex: NavIndex = {
   'dashboards/snapshots': {
     id: 'dashboards/snapshots',
     text: 'Snapshots',
-    subTitle: 'Interactive, publically available, point-in-time representations of dashboards',
+    subTitle: 'Interactive, publicly available, point-in-time representations of dashboards',
     icon: 'camera',
     url: '/dashboard/snapshots',
   },

--- a/public/app/initApp.ts
+++ b/public/app/initApp.ts
@@ -1,4 +1,4 @@
-// See ./index.ts for why this is in a seperate file
+// See ./index.ts for why this is in a separate file
 
 // Trusted types must be initialised before the rest of the world is imported
 import './core/trustedTypePolicies';


### PR DESCRIPTION
Small sweep of prose/comment typos across frontend/docs/helpers, no functional change:

- `e2e-playwright/utils/RequestsRecorder.ts:76,101`, two `recieved` -> `received`
- `contribute/feature-toggles.md:162`, `seperate` -> `separate`
- `contribute/merge-pull-request.md:123`, `seperate backport PRs will automatically be creataed` -> `separate backport PRs will automatically be created`
- `public/app/initApp.ts:1`, `in a seperate file` -> `in a separate file`
- `public/app/features/browse-dashboards/types.ts:30`, `seperate` -> `separate`
- `packages/grafana-ui/src/components/Select/types.ts:187`, `recieve` -> `receive`
- `public/app/features/connections/mocks/store.navIndex.mock.ts:43,73`, two `publically available` -> `publicly available`