### PR TITLE
fix: remove trivy from policy-bot

### DIFF
--- a/.policy.yml
+++ b/.policy.yml
@@ -44,7 +44,6 @@ policy:
             - Workflow .github/workflows/shellcheck.yml succeeded or skipped
             - Workflow .github/workflows/storybook-a11y.yml succeeded or skipped
             - Workflow .github/workflows/swagger-gen.yml succeeded or skipped
-            - Workflow .github/workflows/trivy-scan.yml succeeded or skipped
             - Workflow .github/workflows/trufflehog.yml succeeded or skipped
             - default to approval
         - override policies

--- a/Makefile
+++ b/Makefile
@@ -783,3 +783,5 @@ GENERATE_POLICY_BOT_CONFIG_SHA := sha256:d05ff5c7d4247da155c85f8c6f1f9f7c6d013d1
 		.
 # We don't want the patch workflow to be run. This is exclusively useful for the security-mirror. It won't work in OSS.
 	sed -i.bak '/- Workflow \.github\/workflows\/create-security-patch-from-security-mirror/d' .policy.yml; rm -f .policy.yml.bak
+# Trivy was disabled in March, 2026. We'll unrequire it while we wait for it to be reenabled at org-level.
+	sed -i.bak '/- Workflow \.github\/workflows\/trivy-scan/d' .policy.yml; rm -f .policy.yml.bak


### PR DESCRIPTION
The Trivy action is currently disabled org-wide and will not work. Therefore, we should also not require it.