### PR TITLE
Alerting: Surface contact point save errors in the UI

### DIFF
--- a/public/app/features/alerting/unified/components/receivers/NewReceiverView.test.tsx
+++ b/public/app/features/alerting/unified/components/receivers/NewReceiverView.test.tsx
@@ -2,6 +2,7 @@ import { Route, Routes } from 'react-router-dom-v5-compat';
 import { render, screen } from 'test/test-utils';
 import { byPlaceholderText, byRole, byTestId } from 'testing-library-selector';
 
+import { AppNotificationList } from 'app/core/components/AppNotifications/AppNotificationList';
 import { captureRequests } from 'app/features/alerting/unified/mocks/server/events';
 import { AccessControlAction } from 'app/types/accessControl';
 
@@ -19,10 +20,13 @@ const Index = () => {
 
 const renderForm = () =>
   render(
-    <Routes>
-      <Route path="/alerting/notifications" element={<Index />} />
-      <Route path="/alerting/notifications/new" element={<NewReceiverView />} />
-    </Routes>,
+    <>
+      <AppNotificationList />
+      <Routes>
+        <Route path="/alerting/notifications" element={<Index />} />
+        <Route path="/alerting/notifications/new" element={<NewReceiverView />} />
+      </Routes>
+    </>,
     {
       historyOptions: { initialEntries: ['/alerting/notifications/new'] },
     }
@@ -112,6 +116,26 @@ describe('new receiver', () => {
     await user.click(ui.saveContactButton.get());
 
     expect(screen.queryByText(/redirected/i)).not.toBeInTheDocument();
+  });
+
+  it('shows the backend error message when contact point creation fails', async () => {
+    const { user } = renderForm();
+
+    await user.type(await ui.inputs.name.find(), 'receiver that should fail');
+    const email = ui.inputs.email.addresses.get();
+    await user.clear(email);
+    await user.type(email, 'test@test.com');
+
+    makeAllK8sEndpointsFail(
+      'alerting.notifications.receivers.invalid',
+      'Invalid receiver: \'invalid email integration[0]: failed to check if email address "test@test.com" exists: user not found\'',
+      400
+    );
+
+    await user.click(ui.saveContactButton.get());
+
+    expect(await screen.findByText(/failed to save the contact point/i)).toBeInTheDocument();
+    expect(await screen.findByText(/user not found/i)).toBeInTheDocument();
   });
 });
 

--- a/public/app/features/alerting/unified/components/receivers/form/CloudReceiverForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/CloudReceiverForm.tsx
@@ -56,16 +56,12 @@ export const CloudReceiverForm = ({ contactPoint, alertManagerSourceName, readOn
   const onSubmit = async (values: ReceiverFormValues<CloudChannelValues>) => {
     const newReceiver = formValuesToCloudReceiver(values, defaultChannelValues);
 
-    try {
-      if (editMode && contactPoint) {
-        await updateContactPoint.execute({ contactPoint: newReceiver, originalName: contactPoint.name });
-      } else {
-        await createContactPoint.execute({ contactPoint: newReceiver });
-      }
-      locationService.push('/alerting/notifications');
-    } catch (error) {
-      // React form validation will handle this for us
+    if (editMode && contactPoint) {
+      await updateContactPoint.execute({ contactPoint: newReceiver, originalName: contactPoint.name });
+    } else {
+      await createContactPoint.execute({ contactPoint: newReceiver });
     }
+    locationService.push('/alerting/notifications');
   };
 
   // this basically checks if we can manage the selected alert manager data source, either because it's a Grafana Managed one

--- a/public/app/features/alerting/unified/components/receivers/form/GrafanaReceiverForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/GrafanaReceiverForm.tsx
@@ -100,27 +100,23 @@ export const GrafanaReceiverForm = ({ contactPoint, readOnly = false, editMode }
   const onSubmit = async (values: ReceiverFormValues<GrafanaChannelValues>) => {
     const newReceiver = formValuesToGrafanaReceiver(values, id2original, defaultChannelValues);
 
-    try {
-      if (editMode) {
-        if (contactPoint && contactPoint.id) {
-          await updateContactPoint.execute({
-            contactPoint: newReceiver,
-            id: contactPoint.id,
-            resourceVersion: contactPoint?.metadata?.resourceVersion,
-          });
-        } else if (contactPoint) {
-          await updateContactPoint.execute({
-            contactPoint: newReceiver,
-            originalName: contactPoint.name,
-          });
-        }
-      } else {
-        await createContactPoint.execute({ contactPoint: newReceiver });
+    if (editMode) {
+      if (contactPoint && contactPoint.id) {
+        await updateContactPoint.execute({
+          contactPoint: newReceiver,
+          id: contactPoint.id,
+          resourceVersion: contactPoint?.metadata?.resourceVersion,
+        });
+      } else if (contactPoint) {
+        await updateContactPoint.execute({
+          contactPoint: newReceiver,
+          originalName: contactPoint.name,
+        });
       }
-      locationService.push('/alerting/notifications');
-    } catch (error) {
-      // React form validation will handle this for us
+    } else {
+      await createContactPoint.execute({ contactPoint: newReceiver });
     }
+    locationService.push('/alerting/notifications');
   };
 
   const onTestChannel = (values: GrafanaChannelValues) => {

--- a/public/app/features/alerting/unified/components/receivers/form/ReceiverForm.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/ReceiverForm.tsx
@@ -113,7 +113,6 @@ export function ReceiverForm<R extends ChannelValues>({
         error.cause = e;
         logError(error);
       }
-      throw e;
     }
   };
 


### PR DESCRIPTION
## Summary

When the contact point create/update mutation rejects, nothing surfaces in the UI — the save silently fails. Root cause is a pair of swallowed try/catches:

- `GrafanaReceiverForm.onSubmit` and `CloudReceiverForm.onSubmit` wrap the `execute()` awaits in a try/catch with an empty body and the comment "React form validation will handle this for us." That comment is wrong — react-hook-form doesn't turn a rejected `onValid` promise into a toast or field error. The outer `ReceiverForm.submitCallback` already handles this correctly (`notifyApp.error('Failed to save the contact point', getErrorMessage(e))` + `logError`), but only if the rejection propagates to it.
- `ReceiverForm.submitCallback` additionally re-throws after notifying/logging. Nothing downstream (in RHF or the DOM event handler) consumes that rejection, so it just becomes an unhandled rejection at the form boundary. Dropping the `throw` also fixes latent test flakiness that had been masked by the inner swallow.

`getErrorMessage` → `getMessageFromError` already reads `err.data.message` off the `FetchError`, so backend error bodies display correctly once the error is allowed through — no new error-shape-specific code required.

## Test plan

- [x] `yarn test --watchAll=false public/app/features/alerting/unified/components/receivers` — 123/123 pass, including a new regression test in `NewReceiverView.test.tsx` that mocks a k8s `Status` 400 and asserts both the "Failed to save the contact point" title and the BE message body render via `AppNotificationList`.
- [ ] Manual: trigger a backend error while saving a Grafana-managed contact point; expect a red toast with the BE message and the form stays put. On success, expect redirect as before.
- [ ] Manual: repeat on a Mimir/cloud alertmanager to confirm `CloudReceiverForm` surfaces errors the same way.