### PR TITLE
feat(policy): require changelog label

### DIFF
--- a/.policy.yml
+++ b/.policy.yml
@@ -47,6 +47,9 @@ policy:
             - Workflow .github/workflows/trivy-scan.yml succeeded or skipped
             - Workflow .github/workflows/trufflehog.yml succeeded or skipped
             - default to approval
+        - or:
+            - has no-changelog label
+            - has add to changelog label
         - override policies
     - policy bot config is valid when modified
 approval_rules:
@@ -666,6 +669,18 @@ approval_rules:
       conditions:
         has_successful_status:
           - Check .policy.yml is valid
+  - name: has no-changelog label
+    description: |
+      Requires you to add a "no-changelog" OR "add to changelog" label on all PRs.
+    if:
+      has_labels:
+        - no-changelog
+  - name: has add to changelog label
+    description: |
+      Requires you to add a "no-changelog" OR "add to changelog" label on all PRs.
+    if:
+      has_labels:
+        - add to changelog
   - name: override policies
     description: |
       Policy-bot can be overridden in emergency situations.

--- a/.policy.yml.tmpl
+++ b/.policy.yml.tmpl
@@ -7,6 +7,9 @@ policy:
   approval:
     - or:
         - MERGE_WITH_GENERATED
+        - or:
+          - has no-changelog label
+          - has add to changelog label
         - override policies
     - policy bot config is valid when modified
 
@@ -20,6 +23,23 @@ approval_rules:
       conditions:
         has_successful_status:
           - Check .policy.yml is valid
+
+  - name: has no-changelog label
+    description: |
+      Requires you to add a "no-changelog" OR "add to changelog" label on all PRs.
+    if:
+      has_labels:
+        - no-changelog
+    requires:
+      count: 0
+  - name: has add to changelog label
+    description: |
+      Requires you to add a "no-changelog" OR "add to changelog" label on all PRs.
+    if:
+      has_labels:
+        - add to changelog
+    requires:
+      count: 0
 
   - name: override policies
     description: |


### PR DESCRIPTION
This lets us retire the changelog check we currently have on PRs. The check often fails or is behind. policy-bot should be able to handle this case better.