### PR TITLE
Revert "ToolbarButton: fix text overflow causing overlap with adjacent elements"

### DIFF
--- a/packages/grafana-ui/src/components/ToolbarButton/ToolbarButton.tsx
+++ b/packages/grafana-ui/src/components/ToolbarButton/ToolbarButton.tsx
@@ -252,9 +252,6 @@ const getStyles = (theme: GrafanaTheme2) => {
     contentWithIcon: css({
       display: 'none',
       paddingLeft: theme.spacing(1),
-      overflow: 'hidden',
-      textOverflow: 'ellipsis',
-      minWidth: 0,
 
       [`@media ${mediaUp(theme.v1.breakpoints.md)}`]: {
         display: 'block',


### PR DESCRIPTION
Reverts grafana/grafana#121269 due to the Explore button overflowing in English :(


<img width="211" height="95" alt="Screenshot 2026-04-22 at 1 36 56 pm" src="https://github.com/user-attachments/assets/cd288fb7-413d-4312-80e0-694399932ff3" />
