### PR TITLE
Transformations: Promote "Time series to table" to GA

### DIFF
--- a/docs/sources/visualizations/panels-visualizations/query-transform-data/transform-data/index.md
+++ b/docs/sources/visualizations/panels-visualizations/query-transform-data/transform-data/index.md
@@ -1465,8 +1465,6 @@ For each generated **Trend** field value, a calculation function can be selected
 
 {{< figure src="/static/img/docs/transformations/timeseries-table-select-stat.png" class="docs-image--no-shadow" max-width= "1100px" alt="A select box showing available statistics that can be calculated." >}}
 
-> **Note:** This transformation is available in Grafana 9.5+ as an opt-in beta feature. Modify the Grafana [configuration file][] to use it.
-
 ### Transpose
 
 Use this transformation to pivot the data frame, converting rows into columns and columns into rows. This transformation is particularly useful when you want to switch the orientation of your data to better suit your visualization needs.
@@ -1547,7 +1545,6 @@ The transformation preserves all original time points while reducing noise, resu
 [Table panel]: ref:table-panel
 [Calculation types]: ref:calculation-types
 [sparkline cell type]: ref:sparkline-cell-type
-[configuration file]: ref:configuration-file
 [Time series panel]: ref:time-series-panel
 [feature toggle]: ref:feature-toggle
 [dashboard variable]: ref:dashboard-variable

--- a/public/app/features/transformers/docs/content.ts
+++ b/public/app/features/transformers/docs/content.ts
@@ -1542,19 +1542,12 @@ ${buildImageContent(
   imageRenderType,
   'A select box showing available statistics that can be calculated.'
 )}
-
-
-> **Note:** This transformation is available in Grafana 9.5+ as an opt-in beta feature. Modify the Grafana [configuration file][] to use it.
   `;
     },
     links: [
       {
         title: 'sparkline cell type',
         url: 'https://grafana.com/docs/grafana/latest/panels-visualizations/visualizations/table/#sparkline',
-      },
-      {
-        title: 'configuration file',
-        url: 'https://grafana.com/docs/grafana/latest/setup-grafana/configure-grafana/',
       },
     ],
   },

--- a/public/app/features/transformers/timeSeriesTable/TimeSeriesTableTransformEditor.tsx
+++ b/public/app/features/transformers/timeSeriesTable/TimeSeriesTableTransformEditor.tsx
@@ -1,7 +1,6 @@
 import { useCallback } from 'react';
 
 import {
-  PluginState,
   type TransformerRegistryItem,
   type TransformerUIProps,
   ReducerID,
@@ -133,7 +132,6 @@ export const getTimeSeriesTableTransformRegistryItem: () => TransformerRegistryI
       transformation: timeSeriesTableTransformer,
       name: timeSeriesTableTransformer.name,
       description: timeSeriesTableTransformer.description,
-      state: PluginState.beta,
       imageDark: darkImage,
       imageLight: lightImage,
     };


### PR DESCRIPTION
## What

Resolves https://github.com/grafana/grafana/issues/123220
For Linear ↓
Fixes DPRO-32

Removes the `Beta` badge from the **Time series to table** transform and drops the stale "opt-in beta feature" note from the docs.

## Why

The transform has been enabled by default since Grafana 10.2 (feature toggle removed in #76125, Oct 2023).
## Risk

Minimal — frontend-only, no feature toggle, no schema/migration, no behavioral change. UI label + docs only.

## Follow-up

What's New entry will be added separately via the `grafana/writers-toolkit` repo.