### PR TITLE
Alerting: Fix flaky TestValidateRuleGroupFailures misalignment case

### DIFF
--- a/pkg/services/ngalert/api/api_ruler_validation_test.go
+++ b/pkg/services/ngalert/api/api_ruler_validation_test.go
@@ -282,7 +282,8 @@ func TestValidateRuleGroupFailures(t *testing.T) {
 			name: "fail if interval is not aligned with base interval",
 			group: func() *apimodels.PostableRuleGroupConfig {
 				g := validGroup(cfg)
-				g.Interval = model.Duration(cfg.BaseInterval + time.Duration(rand.IntN(10)+1)*time.Second)
+				// Offset must be in [1, BaseInterval-1) seconds to guarantee misalignment with BaseInterval.
+				g.Interval = model.Duration(cfg.BaseInterval + time.Duration(rand.Int64N(int64(cfg.BaseInterval.Seconds())-2)+1)*time.Second)
 				return &g
 			},
 		},


### PR DESCRIPTION
## What

Fixes a ~1% flake in `TestValidateRuleGroupFailures/fail_if_interval_is_not_aligned_with_base_interval`.

Observed failure: https://github.com/grafana/grafana/actions/runs/24726017288/job/72327204225
```
--- FAIL: TestValidateRuleGroupFailures/fail_if_interval_is_not_aligned_with_base_interval (0.00s)
    api_ruler_validation_test.go:340: Error: An error is expected but got nil.
```

## Why

The `config()` helper generates `BaseInterval` in the `[3, 99]`s range. The subtest then added a random `[1, 10]`s offset to `BaseInterval`, expecting misalignment. When `BaseInterval` ≤ 10 and the offset happened to be a multiple of it (e.g. `BaseInterval=5, offset=10` → `15s`, still a multiple of `5s`), the resulting interval _was_ aligned, validation passed, and `require.Error` failed.

## How

Constrain the offset to `[1, BaseInterval-1)` seconds — guaranteed misalignment regardless of `BaseInterval`. Mirrors the existing pattern already used at [`api_ruler_validation_test.go:967`](https://github.com/grafana/grafana/blob/main/pkg/services/ngalert/api/api_ruler_validation_test.go#L967).

## How to test

```bash
go test -count=2000 -run 'TestValidateRuleGroupFailures/fail_if_interval_is_not_aligned_with_base_interval' ./pkg/services/ngalert/api/
```
2000 iterations pass consistently.