### PR TITLE
Alerting: Log-only validation of expression models on save

### DIFF
--- a/pkg/expr/validate.go
+++ b/pkg/expr/validate.go
@@ -1,0 +1,94 @@
+package expr
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/grafana/grafana/pkg/expr/classic"
+	"github.com/grafana/grafana/pkg/expr/mathexp"
+)
+
+// ErrUnknownExpressionType is returned by ValidateExpressionModel when the
+// expression command type cannot be determined from the model JSON.
+var ErrUnknownExpressionType = errors.New("unknown expression command type")
+
+// ValidateExpressionModel performs a parse-only validation of an expression
+// query model. It is designed to be called from write paths (for example,
+// AlertQuery.PreSave) to detect malformed expression models before they land
+// in storage. It does not execute the expression and does not depend on
+// runtime-only configuration such as memory limits or feature toggles.
+//
+// Returns:
+//   - (nil, nil) when modelRaw is not a recognised expression model
+//   - (CommandType, nil) on successful parse
+//   - (CommandType, err) when the model is recognised but fails to parse;
+//     in this case CommandType may be TypeUnknown if the type itself was invalid
+//
+// SQL expressions are intentionally skipped because their unmarshaler requires
+// a context, cfg, and feature toggles; callers that need SQL validation
+// should invoke UnmarshalSQLCommand directly at a later stage.
+func ValidateExpressionModel(refID string, modelRaw json.RawMessage) (CommandType, error) {
+	if len(modelRaw) == 0 {
+		return TypeUnknown, nil
+	}
+
+	rawQuery := make(map[string]any)
+	if err := json.Unmarshal(modelRaw, &rawQuery); err != nil {
+		return TypeUnknown, fmt.Errorf("failed to unmarshal expression model: %w", err)
+	}
+
+	commandType, err := GetExpressionCommandType(rawQuery)
+	if err != nil {
+		return TypeUnknown, fmt.Errorf("%w: %w", ErrUnknownExpressionType, err)
+	}
+
+	rn := &rawNode{
+		RefID:    refID,
+		Query:    rawQuery,
+		QueryRaw: modelRaw,
+	}
+
+	switch commandType {
+	case TypeMath:
+		return commandType, validateMathModel(rawQuery)
+	case TypeReduce:
+		_, err := UnmarshalReduceCommand(rn)
+		return commandType, err
+	case TypeResample:
+		// UnmarshalResampleCommand requires a TimeRange. Supply a zero-value
+		// range here so that structural parsing can proceed; the TimeRange is
+		// only meaningful at execute time.
+		rn.TimeRange = RelativeTimeRange{}
+		_, err := UnmarshalResampleCommand(rn)
+		return commandType, err
+	case TypeClassicConditions:
+		_, err := classic.UnmarshalConditionsCmd(rawQuery, refID)
+		return commandType, err
+	case TypeThreshold:
+		_, err := UnmarshalThresholdCommand(rn)
+		return commandType, err
+	case TypeSQL:
+		// SQL validation requires runtime cfg/toggles; skip.
+		return commandType, nil
+	default:
+		return commandType, fmt.Errorf("expression command type %q not supported for pre-save validation", commandType)
+	}
+}
+
+// validateMathModel reuses the parse step of NewMathCommand without requiring
+// a *setting.Cfg. The memory limit from Cfg is an execute-time concern.
+func validateMathModel(rawQuery map[string]any) error {
+	rawExpr, ok := rawQuery["expression"]
+	if !ok {
+		return errors.New("command is missing an expression")
+	}
+	exprString, ok := rawExpr.(string)
+	if !ok {
+		return fmt.Errorf("math expression is expected to be a string, got %T", rawExpr)
+	}
+	if _, err := mathexp.New(exprString); err != nil {
+		return fmt.Errorf("invalid math command: %w", err)
+	}
+	return nil
+}

--- a/pkg/expr/validate_test.go
+++ b/pkg/expr/validate_test.go
@@ -1,0 +1,92 @@
+package expr
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateExpressionModel(t *testing.T) {
+	testCases := []struct {
+		name         string
+		model        string
+		expectType   CommandType
+		expectErr    bool
+		expectUnknow bool // expect ErrUnknownExpressionType
+	}{
+		{
+			name:       "empty model is a no-op",
+			model:      ``,
+			expectType: TypeUnknown,
+		},
+		{
+			name:         "missing type is unknown",
+			model:        `{"refId":"A"}`,
+			expectType:   TypeUnknown,
+			expectErr:    true,
+			expectUnknow: true,
+		},
+		{
+			name: "valid classic_conditions",
+			model: `{
+				"type":"classic_conditions",
+				"conditions":[{"type":"query","evaluator":{"params":[0],"type":"gt"},"query":{"params":["A"]},"reducer":{"type":"last","params":[]}}]
+			}`,
+			expectType: TypeClassicConditions,
+		},
+		{
+			name: "malformed classic_conditions missing query.params fails",
+			model: `{
+				"type":"classic_conditions",
+				"conditions":[{"type":"query","evaluator":{"params":[0],"type":"gt"},"query":{},"reducer":{"type":"last","params":[]}}]
+			}`,
+			expectType: TypeClassicConditions,
+			expectErr:  true,
+		},
+		{
+			name:       "valid math",
+			model:      `{"type":"math","expression":"$A + 1"}`,
+			expectType: TypeMath,
+		},
+		{
+			name:       "malformed math missing expression fails",
+			model:      `{"type":"math"}`,
+			expectType: TypeMath,
+			expectErr:  true,
+		},
+		{
+			name:       "valid threshold",
+			model:      `{"type":"threshold","expression":"A","conditions":[{"evaluator":{"type":"gt","params":[0]}}]}`,
+			expectType: TypeThreshold,
+		},
+		{
+			name:       "malformed threshold without expression fails",
+			model:      `{"type":"threshold","conditions":[]}`,
+			expectType: TypeThreshold,
+			expectErr:  true,
+		},
+		{
+			name:       "sql is skipped (no cfg/toggles available at validate time)",
+			model:      `{"type":"sql","expression":"SELECT * FROM A"}`,
+			expectType: TypeSQL,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotType, err := ValidateExpressionModel("A", json.RawMessage(tc.model))
+			assert.Equal(t, tc.expectType, gotType)
+			if tc.expectErr {
+				require.Error(t, err)
+				if tc.expectUnknow {
+					assert.True(t, errors.Is(err, ErrUnknownExpressionType))
+				}
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/services/ngalert/models/alert_query.go
+++ b/pkg/services/ngalert/models/alert_query.go
@@ -9,7 +9,10 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 
 	"github.com/grafana/grafana/pkg/expr"
+	"github.com/grafana/grafana/pkg/infra/log"
 )
+
+var alertQueryLogger = log.New("ngalert.models.alert_query")
 
 const defaultMaxDataPoints float64 = 43200 // 12 hours at 1sec interval
 const defaultIntervalMS float64 = 1000
@@ -335,7 +338,38 @@ func (aq *AlertQuery) PreSave() error {
 	if ok := isExpression || aq.RelativeTimeRange.isValid(); !ok {
 		return ErrInvalidRelativeTimeRange(aq.RefID, aq.RelativeTimeRange)
 	}
+
+	if isExpression {
+		aq.logInvalidExpressionModel()
+	}
 	return nil
+}
+
+// logInvalidExpressionModel performs a parse-only validation of the expression
+// model and emits a warning log + counter increment when it fails. It never
+// returns an error: the goal is observability, not rejection. Strict Ruler API
+// validation continues to run before PreSave via buildPipeline; this covers
+// provisioning, file, and legacy-migration write paths where that earlier
+// check does not run.
+func (aq *AlertQuery) logInvalidExpressionModel() {
+	commandType, err := expr.ValidateExpressionModel(aq.RefID, aq.Model)
+	if err == nil {
+		return
+	}
+
+	reason := "unmarshal"
+	if errors.Is(err, expr.ErrUnknownExpressionType) {
+		reason = "unknown_type"
+	}
+
+	invalidExpressionModelSaves.WithLabelValues(commandType.String(), reason).Inc()
+	alertQueryLogger.Warn(
+		"alert rule saved with invalid expression model",
+		"refId", aq.RefID,
+		"expressionType", commandType.String(),
+		"reason", reason,
+		"error", err,
+	)
 }
 
 // InitDefaults ensures all default parameters are set in the query model.

--- a/pkg/services/ngalert/models/alert_query_test.go
+++ b/pkg/services/ngalert/models/alert_query_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/data"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -371,6 +372,66 @@ func TestAlertQuery_PreSave(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestAlertQuery_PreSave_logsInvalidExpressionModel(t *testing.T) {
+	const (
+		malformedClassic = `{
+			"refId": "B",
+			"datasourceUid": "__expr__",
+			"model": {
+				"refId": "B",
+				"type": "classic_conditions",
+				"conditions": [
+					{
+						"type": "query",
+						"evaluator": {"params": [0], "type": "gt"},
+						"query": {}
+					}
+				]
+			}
+		}`
+		validClassic = `{
+			"refId": "B",
+			"datasourceUid": "__expr__",
+			"model": {
+				"refId": "B",
+				"type": "classic_conditions",
+				"conditions": [
+					{
+						"type": "query",
+						"evaluator": {"params": [0], "type": "gt"},
+						"query": {"params": ["A"]},
+						"reducer": {"type": "last", "params": []}
+					}
+				]
+			}
+		}`
+	)
+
+	t.Run("does not reject a malformed expression model", func(t *testing.T) {
+		invalidExpressionModelSaves.Reset()
+
+		var aq AlertQuery
+		require.NoError(t, json.Unmarshal([]byte(malformedClassic), &aq))
+
+		require.NoError(t, aq.PreSave())
+		require.Equal(t, 1.0, testutil.ToFloat64(
+			invalidExpressionModelSaves.WithLabelValues("classic_conditions", "unmarshal"),
+		))
+	})
+
+	t.Run("does not increment the counter for a valid expression model", func(t *testing.T) {
+		invalidExpressionModelSaves.Reset()
+
+		var aq AlertQuery
+		require.NoError(t, json.Unmarshal([]byte(validClassic), &aq))
+
+		require.NoError(t, aq.PreSave())
+		require.Equal(t, 0.0, testutil.ToFloat64(
+			invalidExpressionModelSaves.WithLabelValues("classic_conditions", "unmarshal"),
+		))
+	})
 }
 
 func TestAlertQuery_GetQuery(t *testing.T) {

--- a/pkg/services/ngalert/models/metrics.go
+++ b/pkg/services/ngalert/models/metrics.go
@@ -1,0 +1,22 @@
+package models
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// invalidExpressionModelSaves counts alert rule save attempts whose expression
+// model failed a parse-only validation. Increments are advisory only: the save
+// still proceeds. Labels allow slicing by expression command type (e.g.
+// "classic_conditions") and a short reason (e.g. "unmarshal"). Used to measure
+// prevalence of malformed expression data flowing through provisioning, file,
+// and legacy-migration write paths.
+var invalidExpressionModelSaves = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: "grafana",
+		Subsystem: "alerting",
+		Name:      "invalid_expression_model_saves_total",
+		Help:      "Number of alert rule save attempts whose expression model failed parse validation. Advisory only; saves still proceed.",
+	},
+	[]string{"expression_type", "reason"},
+)


### PR DESCRIPTION
## Summary
- Calls parse-only validators from `AlertQuery.PreSave` for `math`, `reduce`, `resample`, `classic_conditions`, and `threshold` expressions. On failure, logs a warning and increments a new counter metric; the save still proceeds.
- Closes the gap for provisioning, file, and legacy-migration write paths that currently bypass the Ruler API's strict validation, so malformed expression models (for example `classic_conditions` conditions missing `query.params`) become observable before we decide whether to reject them outright.
- SQL expressions are intentionally skipped — their unmarshaler needs a context, cfg, and feature toggles that are not available at `PreSave` time.

### New metric

```
grafana_alerting_invalid_expression_model_saves_total{expression_type, reason}
```

Advisory only; saves still proceed. Labels allow slicing by expression type and error reason.

### Context

Companion frontend PR makes `ClassicCondition.query.params` optional so the rule view page stops crashing on already-persisted malformed data.

## Test plan
- [x] `go test ./pkg/expr/ ./pkg/services/ngalert/models/` passes locally
- [ ] Verify counter fires once per malformed save via log grep in dev
- [ ] Dashboard the new metric to size the population before any rejection change