### PR TITLE
NPM: Publish nightlies instead of canaries

### DIFF
--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -38,13 +38,13 @@ on:
 permissions: {}
 
 jobs:
-  # If called with version_type 'canary' or 'stable', build + publish to NPM
-  # If called with version_type 'nightly', do nothing (we're not yet tagging them with the nightly tag)
+  # If called with version_type 'nightly' or 'stable', build + publish to NPM
+  # If called with version_type 'canary', do nothing (temporarily stopping canary releases)
 
   publish:
     name: Publish NPM packages
     runs-on: github-hosted-ubuntu-x64-small
-    if: inputs.version_type == 'canary' || inputs.version_type == 'stable'
+    if: inputs.version_type == 'nightly' || inputs.version_type == 'stable'
     # Required for this workflow to have permission to publish NPM packages
     environment: npm-publish
     permissions:


### PR DESCRIPTION
Due to new versions of `@grafana/ui` being blocked from publishing because of too many versions, we're stopping publishing of canary versions, and instead just publish nightly to coincide with the nightly docker release.