### PR TITLE
Storage: Move lock package into search package

### DIFF
--- a/pkg/storage/unified/search/lock_cdk_backend.go
+++ b/pkg/storage/unified/search/lock_cdk_backend.go
@@ -1,4 +1,4 @@
-package lock
+package search
 
 import (
 	"bytes"

--- a/pkg/storage/unified/search/lock_cdk_backend_options.go
+++ b/pkg/storage/unified/search/lock_cdk_backend_options.go
@@ -1,4 +1,4 @@
-package lock
+package search
 
 import (
 	"context"

--- a/pkg/storage/unified/search/lock_cdk_backend_test.go
+++ b/pkg/storage/unified/search/lock_cdk_backend_test.go
@@ -1,4 +1,4 @@
-package lock
+package search
 
 import (
 	"context"
@@ -28,9 +28,9 @@ import (
 // Uses conditionalBucket (fake ETag tracking) by default.
 // Set CDK_TEST_BUCKET_URL to run against a real provider:
 //
-//	CDK_TEST_BUCKET_URL=s3://bucket?region=us-east-1 go test ./pkg/storage/unified/search/lock/... -v
-//	CDK_TEST_BUCKET_URL=gs://bucket go test ./pkg/storage/unified/search/lock/... -v
-//	CDK_TEST_BUCKET_URL=azblob://container go test ./pkg/storage/unified/search/lock/... -v
+//	CDK_TEST_BUCKET_URL=s3://bucket?region=us-east-1 go test ./pkg/storage/unified/search/... -v
+//	CDK_TEST_BUCKET_URL=gs://bucket go test ./pkg/storage/unified/search/... -v
+//	CDK_TEST_BUCKET_URL=azblob://container go test ./pkg/storage/unified/search/... -v
 
 func testBackend(t *testing.T, opts ...func(*cdkLockBackendOptions)) *cdkLockBackend {
 	t.Helper()

--- a/pkg/storage/unified/search/lock_objstore.go
+++ b/pkg/storage/unified/search/lock_objstore.go
@@ -1,4 +1,4 @@
-package lock
+package search
 
 import (
 	"context"

--- a/pkg/storage/unified/search/lock_objstore_test.go
+++ b/pkg/storage/unified/search/lock_objstore_test.go
@@ -1,4 +1,4 @@
-package lock
+package search
 
 import (
 	"context"


### PR DESCRIPTION
## What this PR does

Moves the `lock` package under `pkg/storage/unified/search/lock/` into the parent `search` package.

All identifiers in the `lock` package are unexported, the package has no external importers, and there are no name collisions with the `search` package. This is a mechanical move:

- Rename the 5 files with a `lock_` prefix so they group together in `search/`.
- Change `package lock` → `package search`.
- Update the three `go test ./pkg/storage/unified/search/lock/...` test-comment paths.

`git mv` was used so history is preserved.

## Why

Precursor to exposing distributed locking via `RemoteIndexStore`. Keeping the lock primitives in a sibling package would force awkward re-exports; co-locating them lets `RemoteIndexStore` expose locking naturally (see the three `TODO: caller must hold ... lock` comments in `remote_index_store.go`).

Exporting the lock API and adding `RemoteIndexStore` methods will happen in a follow-up PR.

## Verification

- `go build ./pkg/storage/unified/search/...` — clean
- `go vet ./pkg/storage/unified/search/...` — clean
- `go test ./pkg/storage/unified/search/` — passes (all relocated lock tests included)
