### PR TITLE
Live: Resolve channel id from legacy `namespace` field in plugin addresses

### DIFF
--- a/public/app/features/live/centrifuge/service.test.ts
+++ b/public/app/features/live/centrifuge/service.test.ts
@@ -126,4 +126,29 @@ describe('CentrifugeService', () => {
     expect(mockCentrifuge.newSubscription).toHaveBeenCalled();
     expect(mockSubscription.subscribe).toHaveBeenCalled();
   });
+
+  it('resolves channel id when the address uses the legacy `namespace` field', async () => {
+    mockCentrifugeState = State.Connected;
+
+    const service = new CentrifugeService(makeDeps());
+
+    // Older plugin builds (e.g. @grafana/llm <=1.0.2) still construct
+    // addresses with `namespace` instead of `stream`. The subscription id
+    // must resolve without an `undefined` segment so the backend can route
+    // the subscription.
+    const legacyAddr = {
+      scope: LiveChannelScope.Plugin,
+      namespace: 'grafana-llm-app',
+      path: 'stream/chat-completions',
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    service.getStream(legacyAddr).subscribe();
+
+    expect(mockCentrifuge.newSubscription).toHaveBeenCalledTimes(1);
+    expect(mockCentrifuge.newSubscription).toHaveBeenCalledWith(
+      'default/plugin/grafana-llm-app/stream/chat-completions',
+      expect.anything()
+    );
+  });
 });

--- a/public/app/features/live/centrifuge/service.ts
+++ b/public/app/features/live/centrifuge/service.ts
@@ -155,7 +155,11 @@ export class CentrifugeService implements CentrifugeSrv {
    * channel will be returned with an error state indicated in its status
    */
   private getChannel<TMessage>(addr: LiveChannelAddress): CentrifugeLiveChannel<TMessage> {
-    const id = `${this.deps.namespace}/${addr.scope}/${addr.stream}/${addr.path}`;
+    // Use toLiveChannelId so addresses from plugins still using the legacy
+    // `namespace` field (pre-rename) resolve to the same channel id as ones
+    // using `stream`. Without this, subscriptions get an id with `undefined`
+    // in place of the stream segment and silently never receive data.
+    const id = `${this.deps.namespace}/${toLiveChannelId(addr)}`;
     let channel = this.open.get(id);
     if (channel != null) {
       return channel;


### PR DESCRIPTION
## What is this feature?

Fix a regression in Grafana 12.4 where plugins that still construct
`LiveChannelAddress` with the pre-rename `namespace` field get subscribed
to a malformed centrifuge channel id — the middle segment is the literal
string `undefined` — so the backend never routes data to them.

Before:
```
default/plugin/undefined/stream/chat-completions
```

After:
```
default/plugin/grafana-llm-app/stream/chat-completions
```

## Why do we need this feature?

#117275 renamed `LiveChannelAddress.namespace` → `.stream`. #119108
added the back-compat fallback in `toLiveChannelId` and
`isValidLiveChannelAddress`, but `CentrifugeService.getChannel` was
still building the subscription id by hand — it read `addr.stream`
directly and missed the fallback.

User-visible fallout of this gap in 12.4:
- LLM: Dashboard/Panel Title/Description/Changes generation silently
  does nothing (no request over the Live websocket).
- Pyroscope FlameGraph streaming fails with the same root cause.

Both are reproduced and explained in #119781.

The concrete plugin versions that still ship the legacy field:
`@grafana/llm` up to and including v1.0.2 (the version pinned in 12.4)
still emits `namespace: LLM_PLUGIN_ID` when constructing the live
address.

## Reproduction

Self-contained Docker reproduction on Grafana 13.0.1 + `grafana-llm-app`
1.0.8 + a local Ollama model (no external API key needed):

https://github.com/tobiasworkstech/grafana-issue-119781-repro

`docker compose up`, then press `e` on a panel and click ✨ Auto-generate —
times out with "Failed to generate content using LLM". DevTools → Network
→ WS shows the subscribe frame going to a channel id containing the
literal string `undefined`.

## Which issue(s) does this PR fix?

Fixes #119781

## Special notes for your reviewer

- This is a surgical follow-up to #119108. Only `getChannel` in the
  centrifuge service was left out of the back-compat fix.
- Added a regression test that reproduces the malformed id on the old
  line and asserts the correct id with the new line.
- 12.4.x is affected and should probably also get a backport of
  #119108 + this fix together.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.