### PR TITLE
fix: Respect rules of hooks

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/ElementEditPane.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/ElementEditPane.tsx
@@ -18,17 +18,19 @@ export class ElementEditPane extends SceneObjectBase {
 }
 
 export function ElementEditPaneRenderer({ model }: SceneComponentProps<ElementEditPane>) {
-  const editPane = sceneGraph.getAncestor(model, DashboardEditPane);
   const styles = useStyles2(getStyles);
+
+  const editPane = sceneGraph.getAncestor(model, DashboardEditPane);
+
   const element = useMemo(() => {
     return getEditableElementForSelection(editPane, editPane.state.selectionContext.selected);
   }, [editPane]);
 
+  const categories = element?.useEditPaneOptions ? element.useEditPaneOptions(editPane.state.isNewElement) : [];
+
   if (!element) {
     return null;
   }
-
-  const categories = element.useEditPaneOptions ? element.useEditPaneOptions(editPane.state.isNewElement) : [];
 
   return (
     <div className={styles.wrapper}>


### PR DESCRIPTION
Encountered today in local dev:

<img width="1812" height="522" alt="image" src="https://github.com/user-attachments/assets/aad0fda0-30a9-4048-af7e-e8eca1418ab5" />

---

See https://github.com/facebook/react/issues/24391