### PR TITLE
[release-13.0.2] PostgreSQL: Allow sql_engine to return results for EXPLAIN queries

### DIFF
--- a/pkg/tsdb/grafana-postgresql-datasource/sqleng/sql_engine.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/sqleng/sql_engine.go
@@ -534,16 +534,18 @@ func convertSQLTimeColumnsToEpochMS(frame *data.Frame, qm *dataQueryModel) error
 func convertResultsToFrame(results []*pgconn.Result, rowLimit int64) (*data.Frame, error) {
 	m := pgtype.NewMap()
 
-	// Find the first SELECT result to establish the frame structure
+	// Find the first result that returns rows (has field descriptions).
+	// We check FieldDescriptions rather than CommandTag.Select() because commands
+	// like EXPLAIN and EXPLAIN ANALYZE return rows but have a non-SELECT command tag.
 	var firstSelectResult *pgconn.Result
 	for _, result := range results {
-		if result.CommandTag.Select() {
+		if len(result.FieldDescriptions) > 0 {
 			firstSelectResult = result
 			break
 		}
 	}
 
-	// If no SELECT results found, return empty frame
+	// If no row-returning results found, return empty frame
 	if firstSelectResult == nil {
 		return data.NewFrame(""), nil
 	}
@@ -561,10 +563,10 @@ func convertResultsToFrame(results []*pgconn.Result, rowLimit int64) (*data.Fram
 	}
 	frame := *data.NewFrame("", fields...)
 
-	// Process all SELECT results, but validate column compatibility
+	// Process all row-returning results, but validate column compatibility
 	for _, result := range results {
-		// Skip non-select statements
-		if !result.CommandTag.Select() {
+		// Skip statements that don't return rows (e.g. INSERT, UPDATE, DELETE)
+		if len(result.FieldDescriptions) == 0 {
 			continue
 		}
 

--- a/pkg/tsdb/grafana-postgresql-datasource/sqleng/sql_engine_test.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/sqleng/sql_engine_test.go
@@ -568,8 +568,8 @@ func TestConvertResultsToFrame(t *testing.T) {
 		require.Equal(t, 1, frame.Rows())
 	})
 
-	t.Run("convertResultsToFrame with no SELECT results", func(t *testing.T) {
-		// Create only non-SELECT results
+	t.Run("convertResultsToFrame with no row-returning results", func(t *testing.T) {
+		// UPDATE and INSERT have no FieldDescriptions, so should return an empty frame
 		result1 := &pgconn.Result{}
 		result1.CommandTag = pgconn.NewCommandTag("UPDATE 1")
 
@@ -583,6 +583,31 @@ func TestConvertResultsToFrame(t *testing.T) {
 		require.NotNil(t, frame)
 		require.Equal(t, 0, len(frame.Fields))
 		require.Equal(t, 0, frame.Rows())
+	})
+
+	t.Run("convertResultsToFrame with EXPLAIN ANALYZE result", func(t *testing.T) {
+		// EXPLAIN ANALYZE returns rows with a non-SELECT command tag ("EXPLAIN"),
+		// but has FieldDescriptions and should not be filtered out.
+		fieldDescs := []pgconn.FieldDescription{
+			{Name: "QUERY PLAN", DataTypeOID: pgtype.TextOID},
+		}
+		mockRows := [][][]byte{
+			{[]byte("Seq Scan on t  (cost=0.00..1.01 rows=1 width=4) (actual time=0.010..0.011 rows=1 loops=1)")},
+			{[]byte("Planning Time: 0.1 ms")},
+			{[]byte("Execution Time: 0.2 ms")},
+		}
+		result := &pgconn.Result{
+			FieldDescriptions: fieldDescs,
+			Rows:              mockRows,
+		}
+		result.CommandTag = pgconn.NewCommandTag("EXPLAIN")
+
+		frame, err := convertResultsToFrame([]*pgconn.Result{result}, 1000)
+		require.NoError(t, err)
+		require.NotNil(t, frame)
+		require.Equal(t, 1, len(frame.Fields))
+		require.Equal(t, "QUERY PLAN", frame.Fields[0].Name)
+		require.Equal(t, 3, frame.Rows())
 	})
 
 	t.Run("convertResultsToFrame with multiple results and row limit per result", func(t *testing.T) {


### PR DESCRIPTION
Backport 659db278c57047cfa8a22e64b844621f40fa46c5 from #122739

Manual backport: the original PR was opened from a fork (sdague/grafana), so the automated backport workflow skipped it.

---
**Original author:** @sdague