### PR TITLE
Dashboard: expose `enableGroupBy` and `groupBy` operator in mutation API schemas

### DIFF
--- a/public/app/features/dashboard-scene/mutation-api/README.md
+++ b/public/app/features/dashboard-scene/mutation-api/README.md
@@ -774,6 +774,52 @@ Same `{ element, layoutItem }` shape as ADD_PANEL and UPDATE_PANEL. When moving 
 }
 ```
 
+**Add an AdhocVariable with group-by enabled:**
+
+```json
+{
+  "type": "ADD_VARIABLE",
+  "payload": {
+    "variable": {
+      "kind": "AdhocVariable",
+      "group": "prometheus",
+      "datasource": { "name": "My Prometheus" },
+      "spec": {
+        "name": "filters",
+        "label": "Filters",
+        "enableGroupBy": true
+      }
+    }
+  }
+}
+```
+
+With `enableGroupBy: true`, users can add group-by dimensions to the filter bar. A group-by row uses `operator: "groupBy"` in the `filters` array:
+
+```json
+{
+  "type": "UPDATE_VARIABLE",
+  "payload": {
+    "name": "filters",
+    "variable": {
+      "kind": "AdhocVariable",
+      "group": "prometheus",
+      "datasource": { "name": "My Prometheus" },
+      "spec": {
+        "name": "filters",
+        "enableGroupBy": true,
+        "filters": [
+          { "key": "job", "operator": "=", "value": "api-server" },
+          { "key": "namespace", "operator": "groupBy", "value": "" }
+        ]
+      }
+    }
+  }
+}
+```
+
+The `"groupBy"` operator on a filter row tells Grafana to group query results by that dimension rather than filter by it.
+
 ### `UPDATE_VARIABLE`
 
 **Request:**

--- a/public/app/features/dashboard-scene/mutation-api/README.md
+++ b/public/app/features/dashboard-scene/mutation-api/README.md
@@ -774,52 +774,6 @@ Same `{ element, layoutItem }` shape as ADD_PANEL and UPDATE_PANEL. When moving 
 }
 ```
 
-**Add an AdhocVariable with group-by enabled:**
-
-```json
-{
-  "type": "ADD_VARIABLE",
-  "payload": {
-    "variable": {
-      "kind": "AdhocVariable",
-      "group": "prometheus",
-      "datasource": { "name": "My Prometheus" },
-      "spec": {
-        "name": "filters",
-        "label": "Filters",
-        "enableGroupBy": true
-      }
-    }
-  }
-}
-```
-
-With `enableGroupBy: true`, users can add group-by dimensions to the filter bar. A group-by row uses `operator: "groupBy"` in the `filters` array:
-
-```json
-{
-  "type": "UPDATE_VARIABLE",
-  "payload": {
-    "name": "filters",
-    "variable": {
-      "kind": "AdhocVariable",
-      "group": "prometheus",
-      "datasource": { "name": "My Prometheus" },
-      "spec": {
-        "name": "filters",
-        "enableGroupBy": true,
-        "filters": [
-          { "key": "job", "operator": "=", "value": "api-server" },
-          { "key": "namespace", "operator": "groupBy", "value": "" }
-        ]
-      }
-    }
-  }
-}
-```
-
-The `"groupBy"` operator on a filter row tells Grafana to group query results by that dimension rather than filter by it.
-
 ### `UPDATE_VARIABLE`
 
 **Request:**

--- a/public/app/features/dashboard-scene/mutation-api/commands/schemas.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/schemas.ts
@@ -97,7 +97,11 @@ const variableSortSchema = z
 
 const adHocFilterSchema = z.object({
   key: z.string().describe('Filter key (dimension name)'),
-  operator: z.string().describe('Comparison operator (e.g., "=", "!=", "=~")'),
+  operator: z
+    .string()
+    .describe(
+      'Comparison operator (e.g., "=", "!=", "=~"). Use "groupBy" to add a group-by dimension (only valid when the parent AdhocVariable has enableGroupBy: true).'
+    ),
   value: z.string().describe('Filter value'),
   values: z.array(z.string()).optional().describe('Multiple filter values'),
   keyLabel: z.string().optional().describe('Display label for the key'),
@@ -373,6 +377,15 @@ export const adhocVariableKindSchema = z
         .optional()
         .default(true)
         .describe('Flag indicating if custom filter values can be entered'),
+      enableGroupBy: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe(
+          'When true, enables "Group by" functionality on this ad-hoc filter variable. ' +
+            'Requires the dashboardUnifiedDrilldownControls feature flag. ' +
+            'Users can then add group-by dimensions alongside regular filters using operator "groupBy".'
+        ),
     }),
   })
   .describe(


### PR DESCRIPTION
**What is this feature?**


Add two missing things to mutation api for the assistant to support it:
- `enableGroupBy` field on `AdhocVariable` spec — controls whether the "Group by" UI is shown alongside filters
-  The `"groupBy"` operator value on `adHocFilterSchema.operator` 
