### PR TITLE
Mutation API: add UPDATE_DASHBOARD_SETTINGS command

### DIFF
--- a/public/app/features/dashboard-scene/mutation-api/commands/commands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/commands.test.ts
@@ -66,6 +66,7 @@ describe('Command consistency', () => {
       'REMOVE_ROW',
       'REMOVE_TAB',
       'REMOVE_VARIABLE',
+      'UPDATE_DASHBOARD_SETTINGS',
       'UPDATE_LAYOUT',
       'UPDATE_PANEL',
       'UPDATE_ROW',

--- a/public/app/features/dashboard-scene/mutation-api/commands/registry.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/registry.ts
@@ -22,6 +22,7 @@ import { removeRowCommand } from './removeRow';
 import { removeTabCommand } from './removeTab';
 import { removeVariableCommand } from './removeVariable';
 import type { MutationCommand } from './types';
+import { updateDashboardSettingsCommand } from './updateDashboardSettings';
 import { updateLayoutCommand } from './updateLayout';
 import { updatePanelCommand } from './updatePanel';
 import { updateRowCommand } from './updateRow';
@@ -51,6 +52,7 @@ export const ALL_COMMANDS: Array<MutationCommand<any>> = [
   removePanelCommand,
   listPanelsCommand,
   getDashboardInfoCommand,
+  updateDashboardSettingsCommand,
 ];
 
 /** All valid command names. */

--- a/public/app/features/dashboard-scene/mutation-api/commands/schemas.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/schemas.ts
@@ -905,6 +905,25 @@ export const movePanelPayloadSchema = z.object({
   position: gridPositionSchema.optional().describe('DEPRECATED: Use layoutItem instead.'),
 });
 
+export const updateDashboardSettingsPayloadSchema = z.object({
+  title: z.string().optional().describe('Dashboard title'),
+  description: z.string().optional().describe('Dashboard description'),
+  tags: z.array(z.string()).optional().describe('Dashboard tags'),
+  refresh: z
+    .string()
+    .optional()
+    .describe('Auto-refresh interval (e.g. "5s", "1m", "5m", "15m", "30m", "1h", "2h", "1d", "" to disable)'),
+  timeRange: z
+    .object({
+      from: z.string().describe('Start of time range (e.g. "now-6h")'),
+      to: z.string().describe('End of time range (e.g. "now")'),
+    })
+    .optional()
+    .describe('Dashboard time range'),
+  timezone: z.string().optional().describe('Timezone ("browser", "utc", or IANA timezone)'),
+  editable: z.boolean().optional().describe('Whether the dashboard is editable'),
+});
+
 /**
  * Per-command payload schemas, accessible via DashboardMutationAPI.getPayloadSchema().
  *
@@ -937,4 +956,7 @@ export const payloads = {
     'Move a panel to a different group or reposition within the current group'
   ),
   getDashboardInfo: emptyPayloadSchema.describe('Get dashboard metadata (title, description, uid, tags, folder info)'),
+  updateDashboardSettings: updateDashboardSettingsPayloadSchema.describe(
+    'Update dashboard settings (title, description, tags, refresh, time range, timezone, editable)'
+  ),
 };

--- a/public/app/features/dashboard-scene/mutation-api/commands/updateDashboardSettings.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updateDashboardSettings.test.ts
@@ -1,0 +1,223 @@
+import { sceneGraph } from '@grafana/scenes';
+
+import type { DashboardControls } from '../../scene/DashboardControls';
+import type { DashboardScene } from '../../scene/DashboardScene';
+
+import { updateDashboardSettingsCommand } from './updateDashboardSettings';
+
+jest.mock('@grafana/scenes', () => ({
+  sceneGraph: {
+    getTimeRange: jest.fn(),
+  },
+}));
+
+function buildTestScene(
+  overrides: Partial<{
+    title: string;
+    description: string;
+    tags: string[];
+    editable: boolean;
+    isEditing: boolean;
+  }> = {}
+) {
+  const timeRangeState: Record<string, unknown> = {
+    from: 'now-6h',
+    to: 'now',
+    timeZone: '',
+  };
+
+  const timeRange = {
+    state: timeRangeState,
+    setState: jest.fn((partial: Record<string, unknown>) => {
+      Object.assign(timeRangeState, partial);
+    }),
+  };
+
+  const refreshPickerState: Record<string, unknown> = { refresh: '' };
+  const refreshPicker = {
+    state: refreshPickerState,
+    setState: jest.fn((partial: Record<string, unknown>) => {
+      Object.assign(refreshPickerState, partial);
+    }),
+  };
+
+  const controlsState = { refreshPicker };
+  const controls = { state: controlsState } as unknown as DashboardControls;
+
+  const state: Record<string, unknown> = {
+    title: 'Test Dashboard',
+    description: '',
+    tags: [],
+    editable: true,
+    isEditing: false,
+    $timeRange: timeRange,
+    controls,
+    ...overrides,
+  };
+
+  const scene = {
+    state,
+    canEditDashboard: jest.fn(() => true),
+    onEnterEditMode: jest.fn(() => {
+      state.isEditing = true;
+    }),
+    forceRender: jest.fn(),
+    setState: jest.fn((partial: Record<string, unknown>) => {
+      Object.assign(state, partial);
+    }),
+  };
+
+  (sceneGraph.getTimeRange as jest.Mock).mockReturnValue(timeRange);
+
+  return { scene: scene as unknown as DashboardScene, timeRange, refreshPicker };
+}
+
+describe('UPDATE_DASHBOARD_SETTINGS', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('updates title only', async () => {
+    const { scene } = buildTestScene();
+    const result = await updateDashboardSettingsCommand.handler({ title: 'New Title' }, { scene });
+
+    expect(result.success).toBe(true);
+    expect(scene.setState).toHaveBeenCalledWith({ title: 'New Title' });
+    expect(result.data).toMatchObject({ title: 'New Title' });
+    expect(result.changes[0].previousValue).toMatchObject({ title: 'Test Dashboard' });
+  });
+
+  it('updates description', async () => {
+    const { scene } = buildTestScene();
+    const result = await updateDashboardSettingsCommand.handler({ description: 'A great dashboard' }, { scene });
+
+    expect(result.success).toBe(true);
+    expect(scene.setState).toHaveBeenCalledWith({ description: 'A great dashboard' });
+    expect(result.data).toMatchObject({ description: 'A great dashboard' });
+  });
+
+  it('updates tags', async () => {
+    const { scene } = buildTestScene({ tags: ['old'] });
+    const result = await updateDashboardSettingsCommand.handler({ tags: ['sales', 'ops'] }, { scene });
+
+    expect(result.success).toBe(true);
+    expect(scene.setState).toHaveBeenCalledWith({ tags: ['sales', 'ops'] });
+    expect(result.data).toMatchObject({ tags: ['sales', 'ops'] });
+    expect(result.changes[0].previousValue).toMatchObject({ tags: ['old'] });
+  });
+
+  it('updates editable', async () => {
+    const { scene } = buildTestScene();
+    const result = await updateDashboardSettingsCommand.handler({ editable: false }, { scene });
+
+    expect(result.success).toBe(true);
+    expect(scene.setState).toHaveBeenCalledWith({ editable: false });
+    expect(result.data).toMatchObject({ editable: false });
+  });
+
+  it('updates refresh interval', async () => {
+    const { scene, refreshPicker } = buildTestScene();
+    const result = await updateDashboardSettingsCommand.handler({ refresh: '5m' }, { scene });
+
+    expect(result.success).toBe(true);
+    expect(refreshPicker.setState).toHaveBeenCalledWith({ refresh: '5m' });
+    expect(result.data).toMatchObject({ refresh: '5m' });
+  });
+
+  it('disables refresh with empty string', async () => {
+    const { scene, refreshPicker } = buildTestScene();
+    refreshPicker.state.refresh = '1m';
+
+    const result = await updateDashboardSettingsCommand.handler({ refresh: '' }, { scene });
+
+    expect(result.success).toBe(true);
+    expect(refreshPicker.setState).toHaveBeenCalledWith({ refresh: '' });
+    expect(result.data).toMatchObject({ refresh: '' });
+  });
+
+  it('updates time range', async () => {
+    const { scene, timeRange } = buildTestScene();
+    const result = await updateDashboardSettingsCommand.handler(
+      { timeRange: { from: 'now-1h', to: 'now' } },
+      { scene }
+    );
+
+    expect(result.success).toBe(true);
+    expect(timeRange.setState).toHaveBeenCalledWith({ from: 'now-1h', to: 'now' });
+    expect(result.data).toMatchObject({ timeRange: { from: 'now-1h', to: 'now' } });
+  });
+
+  it('updates timezone', async () => {
+    const { scene, timeRange } = buildTestScene();
+    const result = await updateDashboardSettingsCommand.handler({ timezone: 'utc' }, { scene });
+
+    expect(result.success).toBe(true);
+    expect(timeRange.setState).toHaveBeenCalledWith({ timeZone: 'utc' });
+    expect(result.data).toMatchObject({ timezone: 'utc' });
+  });
+
+  it('updates timezone with IANA string', async () => {
+    const { scene, timeRange } = buildTestScene();
+    const result = await updateDashboardSettingsCommand.handler({ timezone: 'America/New_York' }, { scene });
+
+    expect(result.success).toBe(true);
+    expect(timeRange.setState).toHaveBeenCalledWith({ timeZone: 'America/New_York' });
+    expect(result.data).toMatchObject({ timezone: 'America/New_York' });
+  });
+
+  it('applies multiple settings at once', async () => {
+    const { scene, timeRange, refreshPicker } = buildTestScene();
+    const result = await updateDashboardSettingsCommand.handler(
+      {
+        title: 'Sales Overview',
+        tags: ['sales'],
+        refresh: '5m',
+        timeRange: { from: 'now-24h', to: 'now' },
+        timezone: 'utc',
+      },
+      { scene }
+    );
+
+    expect(result.success).toBe(true);
+    expect(scene.setState).toHaveBeenCalledWith({ title: 'Sales Overview', tags: ['sales'] });
+    expect(timeRange.setState).toHaveBeenCalledWith({ from: 'now-24h', to: 'now', timeZone: 'utc' });
+    expect(refreshPicker.setState).toHaveBeenCalledWith({ refresh: '5m' });
+  });
+
+  it('empty payload is a no-op', async () => {
+    const { scene, timeRange, refreshPicker } = buildTestScene();
+    const result = await updateDashboardSettingsCommand.handler({}, { scene });
+
+    expect(result.success).toBe(true);
+    expect(scene.setState).not.toHaveBeenCalled();
+    expect(timeRange.setState).not.toHaveBeenCalled();
+    expect(refreshPicker.setState).not.toHaveBeenCalled();
+  });
+
+  it('enters edit mode if not already editing', async () => {
+    const { scene } = buildTestScene({ isEditing: false });
+    await updateDashboardSettingsCommand.handler({ title: 'X' }, { scene });
+
+    expect(scene.onEnterEditMode).toHaveBeenCalled();
+  });
+
+  it('does not re-enter edit mode if already editing', async () => {
+    const { scene } = buildTestScene({ isEditing: true });
+    await updateDashboardSettingsCommand.handler({ title: 'X' }, { scene });
+
+    expect(scene.onEnterEditMode).not.toHaveBeenCalled();
+  });
+
+  it('records previous and new values in changes', async () => {
+    const { scene } = buildTestScene({ title: 'Old Title', description: 'Old Desc' });
+    const result = await updateDashboardSettingsCommand.handler(
+      { title: 'New Title', description: 'New Desc' },
+      { scene }
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.changes).toHaveLength(1);
+    expect(result.changes[0].previousValue).toMatchObject({ title: 'Old Title', description: 'Old Desc' });
+    expect(result.changes[0].newValue).toMatchObject({ title: 'New Title', description: 'New Desc' });
+  });
+});

--- a/public/app/features/dashboard-scene/mutation-api/commands/updateDashboardSettings.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updateDashboardSettings.test.ts
@@ -187,7 +187,7 @@ describe('UPDATE_DASHBOARD_SETTINGS', () => {
   it('warns when refresh is requested but refreshPicker is not present', async () => {
     const { scene } = buildTestScene();
     // Remove refreshPicker from scene controls
-    (scene.state as Record<string, unknown>).controls = undefined;
+    (scene.state as unknown as Record<string, unknown>).controls = undefined;
 
     const result = await updateDashboardSettingsCommand.handler({ refresh: '5m' }, { scene });
 

--- a/public/app/features/dashboard-scene/mutation-api/commands/updateDashboardSettings.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updateDashboardSettings.test.ts
@@ -184,6 +184,17 @@ describe('UPDATE_DASHBOARD_SETTINGS', () => {
     expect(refreshPicker.setState).toHaveBeenCalledWith({ refresh: '5m' });
   });
 
+  it('warns when refresh is requested but refreshPicker is not present', async () => {
+    const { scene } = buildTestScene();
+    // Remove refreshPicker from scene controls
+    (scene.state as Record<string, unknown>).controls = undefined;
+
+    const result = await updateDashboardSettingsCommand.handler({ refresh: '5m' }, { scene });
+
+    expect(result.success).toBe(true);
+    expect(result.warnings).toContain('refresh interval could not be set: refresh picker not found in scene controls');
+  });
+
   it('empty payload is a no-op', async () => {
     const { scene, timeRange, refreshPicker } = buildTestScene();
     const result = await updateDashboardSettingsCommand.handler({}, { scene });

--- a/public/app/features/dashboard-scene/mutation-api/commands/updateDashboardSettings.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updateDashboardSettings.ts
@@ -51,6 +51,7 @@ export const updateDashboardSettingsCommand: MutationCommand<UpdateDashboardSett
 
     try {
       const previousValue = readCurrentSettings(scene);
+      const warnings: string[] = [];
 
       const sceneUpdates: Record<string, unknown> = {};
       if (payload.title !== undefined) {
@@ -88,6 +89,8 @@ export const updateDashboardSettingsCommand: MutationCommand<UpdateDashboardSett
         const refreshPicker = scene.state.controls?.state.refreshPicker;
         if (refreshPicker) {
           refreshPicker.setState({ refresh: payload.refresh });
+        } else {
+          warnings.push('refresh interval could not be set: refresh picker not found in scene controls');
         }
       }
 
@@ -97,6 +100,7 @@ export const updateDashboardSettingsCommand: MutationCommand<UpdateDashboardSett
         success: true,
         data: newValue,
         changes: [{ previousValue, newValue }],
+        warnings: warnings.length > 0 ? warnings : undefined,
       };
     } catch (error) {
       return {

--- a/public/app/features/dashboard-scene/mutation-api/commands/updateDashboardSettings.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updateDashboardSettings.ts
@@ -99,7 +99,7 @@ export const updateDashboardSettingsCommand: MutationCommand<UpdateDashboardSett
       return {
         success: true,
         data: newValue,
-        changes: [{ previousValue, newValue }],
+        changes: [{ path: '', previousValue, newValue }],
         warnings: warnings.length > 0 ? warnings : undefined,
       };
     } catch (error) {

--- a/public/app/features/dashboard-scene/mutation-api/commands/updateDashboardSettings.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updateDashboardSettings.ts
@@ -1,0 +1,109 @@
+import { type z } from 'zod';
+
+import { sceneGraph } from '@grafana/scenes';
+
+import { payloads } from './schemas';
+import { enterEditModeIfNeeded, requiresEdit, type MutationCommand } from './types';
+
+export const updateDashboardSettingsPayloadSchema = payloads.updateDashboardSettings;
+
+export type UpdateDashboardSettingsPayload = z.infer<typeof updateDashboardSettingsPayloadSchema>;
+
+interface DashboardSettings {
+  title: string;
+  description: string;
+  tags: string[];
+  editable: boolean;
+  refresh: string;
+  timeRange: { from: string; to: string };
+  timezone: string;
+}
+
+function readCurrentSettings(scene: Parameters<MutationCommand['handler']>[1]['scene']): DashboardSettings {
+  const timeRange = sceneGraph.getTimeRange(scene);
+  const refreshPicker = scene.state.controls?.state.refreshPicker;
+
+  return {
+    title: scene.state.title ?? '',
+    description: scene.state.description ?? '',
+    tags: scene.state.tags ?? [],
+    editable: scene.state.editable ?? true,
+    refresh: refreshPicker?.state.refresh ?? '',
+    timeRange: {
+      from: timeRange.state.from,
+      to: timeRange.state.to,
+    },
+    timezone: timeRange.state.timeZone ?? '',
+  };
+}
+
+export const updateDashboardSettingsCommand: MutationCommand<UpdateDashboardSettingsPayload> = {
+  name: 'UPDATE_DASHBOARD_SETTINGS',
+  description: payloads.updateDashboardSettings.description ?? '',
+
+  payloadSchema: payloads.updateDashboardSettings,
+  permission: requiresEdit,
+  readOnly: false,
+
+  handler: async (payload, context) => {
+    const { scene } = context;
+    enterEditModeIfNeeded(scene);
+
+    try {
+      const previousValue = readCurrentSettings(scene);
+
+      const sceneUpdates: Record<string, unknown> = {};
+      if (payload.title !== undefined) {
+        sceneUpdates.title = payload.title;
+      }
+      if (payload.description !== undefined) {
+        sceneUpdates.description = payload.description;
+      }
+      if (payload.tags !== undefined) {
+        sceneUpdates.tags = payload.tags;
+      }
+      if (payload.editable !== undefined) {
+        sceneUpdates.editable = payload.editable;
+      }
+
+      if (Object.keys(sceneUpdates).length > 0) {
+        scene.setState(sceneUpdates);
+      }
+
+      const timeRange = sceneGraph.getTimeRange(scene);
+      const timeRangeUpdates: Record<string, unknown> = {};
+      if (payload.timeRange !== undefined) {
+        timeRangeUpdates.from = payload.timeRange.from;
+        timeRangeUpdates.to = payload.timeRange.to;
+      }
+      if (payload.timezone !== undefined) {
+        timeRangeUpdates.timeZone = payload.timezone;
+      }
+
+      if (Object.keys(timeRangeUpdates).length > 0) {
+        timeRange.setState(timeRangeUpdates);
+      }
+
+      if (payload.refresh !== undefined) {
+        const refreshPicker = scene.state.controls?.state.refreshPicker;
+        if (refreshPicker) {
+          refreshPicker.setState({ refresh: payload.refresh });
+        }
+      }
+
+      const newValue = readCurrentSettings(scene);
+
+      return {
+        success: true,
+        data: newValue,
+        changes: [{ previousValue, newValue }],
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+        changes: [],
+      };
+    }
+  },
+};


### PR DESCRIPTION
## Summary
- Adds `UPDATE_DASHBOARD_SETTINGS` mutation command for partial updates to dashboard title, description, tags, refresh interval, time range, timezone, and editable flag
- Uses `sceneGraph.getTimeRange()` for time/timezone and `controls.refreshPicker` for refresh, matching `GeneralSettingsEditView` patterns
- 14 unit tests covering all settings, partial updates, no-ops, and edit mode entry

## Test plan
- [x] Unit tests pass (`updateDashboardSettings.test.ts` - 14 tests)
- [ ] Manual: open a dashboard, send "set dashboard title to Sales Overview and refresh every 5 minutes" via Assistant