### PR TITLE
Logs: Add optional download support for dashboards

### DIFF
--- a/packages/grafana-schema/src/raw/composable/logs/panelcfg/x/types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/logs/panelcfg/x/types.gen.ts
@@ -15,6 +15,7 @@ import * as common from '@grafana/schema';
 export const pluginVersion = "13.1.0-pre";
 
 export interface Options {
+  allowDownload?: boolean;
   controlsStorageKey?: string;
   dedupStrategy: common.LogsDedupStrategy;
   detailsMode?: ('inline' | 'sidebar');

--- a/packages/grafana-schema/src/raw/composable/logstable/panelcfg/x/types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/logstable/panelcfg/x/types.gen.ts
@@ -15,6 +15,7 @@ import * as common from '@grafana/schema';
 export const pluginVersion = "13.1.0-pre";
 
 export interface Options {
+  allowDownload?: boolean;
   buildLinkToLogLine?: unknown;
   displayedFields?: Array<string>;
   enableLogDetails?: boolean;

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -41,6 +41,7 @@ import { usePopoverMenu } from './usePopoverMenu';
 import { LogLineVirtualization, getLogLineSize, type LogFieldDimension, ScrollToLogsEvent } from './virtualization';
 
 export interface Props {
+  allowDownload?: boolean;
   app: CoreApp;
   containerElement: HTMLDivElement;
   dedupStrategy: LogsDedupStrategy;
@@ -123,6 +124,7 @@ type LogListComponentProps = Omit<
 
 export const LogList = ({
   app,
+  allowDownload,
   displayedFields,
   dataFrames,
   containerElement,
@@ -179,6 +181,7 @@ export const LogList = ({
 }: Props) => {
   return (
     <LogListContextProvider
+      allowDownload={allowDownload}
       app={app}
       containerElement={containerElement}
       dedupStrategy={dedupStrategy}

--- a/public/app/features/logs/components/panel/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.tsx
@@ -73,6 +73,7 @@ export interface LogListContextData
 
 export const LogListContext = createContext<LogListContextData>({
   app: CoreApp.Unknown,
+  allowDownload: true,
   controlsExpanded: false,
   dedupStrategy: LogsDedupStrategy.none,
   displayedFields: [],
@@ -144,6 +145,7 @@ export type LogListState = Pick<
 
 export interface Props {
   app: CoreApp;
+  allowDownload?: boolean;
   children?: ReactNode;
   // Only ControlledLogRows can send an undefined containerElement. See LogList.tsx
   containerElement?: HTMLDivElement;
@@ -191,6 +193,7 @@ export interface Props {
 
 export const LogListContextProvider = ({
   app,
+  allowDownload,
   children,
   containerElement,
   logOptionsStorageKey,
@@ -594,6 +597,7 @@ export const LogListContextProvider = ({
     <LogListContext.Provider
       value={{
         app,
+        allowDownload,
         controlsExpanded,
         dedupStrategy: logListState.dedupStrategy,
         displayedFields,

--- a/public/app/features/logs/components/panel/LogListControls.test.tsx
+++ b/public/app/features/logs/components/panel/LogListControls.test.tsx
@@ -154,6 +154,19 @@ describe('LogListControls', () => {
       expect(screen.queryByLabelText(SHOW_TIMESTAMP_LABEL_COPY)).not.toBeInTheDocument();
       expect(screen.queryByLabelText(WRAP_LINES_LABEL_COPY)).not.toBeInTheDocument();
       expect(screen.queryByLabelText(ENABLE_HIGHLIGHTING_LABEL_COPY)).not.toBeInTheDocument();
+      expect(screen.queryByLabelText(DOWNLOAD_LOGS_LABEL_COPY)).not.toBeInTheDocument();
+    }
+  );
+
+  test.each([CoreApp.Dashboard, CoreApp.PanelEditor, CoreApp.PanelViewer])(
+    'Allows download in Dashboards when enabled',
+    (app: CoreApp) => {
+      render(
+        <LogListContextProvider {...contextProps} app={app} allowDownload>
+          <LogListControls eventBus={new EventBusSrv()} />
+        </LogListContextProvider>
+      );
+      expect(screen.getByLabelText(DOWNLOAD_LOGS_LABEL_COPY)).toBeInTheDocument();
     }
   );
 

--- a/public/app/features/logs/components/panel/LogListControls.tsx
+++ b/public/app/features/logs/components/panel/LogListControls.tsx
@@ -52,6 +52,7 @@ export const LogListControls = ({ eventBus, logLevels = FILTER_LEVELS, visualisa
   const newLogsPanelEnabled = useBooleanFlagValue('newLogsPanel', true);
   const {
     app,
+    allowDownload,
     controlsExpanded,
     dedupStrategy,
     downloadLogs,
@@ -598,6 +599,21 @@ export const LogListControls = ({ eventBus, logLevels = FILTER_LEVELS, visualisa
               }
               size="lg"
             />
+          )}
+          {allowDownload === true && (
+            <>
+              <div className={styles.divider} />
+              <Dropdown overlay={downloadMenu} placement="auto-end">
+                <LogListControlsOption
+                  expanded={controlsExpanded}
+                  name="download-alt"
+                  className={styles.controlButton}
+                  label={t('logs.logs-controls.download', 'Download logs')}
+                  tooltip={t('logs.logs-controls.tooltip.download', 'Download')}
+                  size="lg"
+                />
+              </Dropdown>
+            </>
           )}
         </>
       )}

--- a/public/app/features/logs/components/panel/LogTableControls.test.tsx
+++ b/public/app/features/logs/components/panel/LogTableControls.test.tsx
@@ -2,11 +2,11 @@ import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { CoreApp, EventBusSrv, LogsSortOrder } from '@grafana/data';
+import { PanelContextProvider } from '@grafana/ui';
 
 import { DownloadFormat, downloadLogs } from '../../utils';
 
 import { LogTableControls } from './LogTableControls';
-import { PanelContextProvider } from '@grafana/ui';
 
 const DOWNLOAD_LOGS_LABEL_COPY = 'Download logs';
 

--- a/public/app/features/logs/components/panel/LogTableControls.test.tsx
+++ b/public/app/features/logs/components/panel/LogTableControls.test.tsx
@@ -1,11 +1,12 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { LogsSortOrder } from '@grafana/data';
+import { CoreApp, EventBusSrv, LogsSortOrder } from '@grafana/data';
 
 import { DownloadFormat, downloadLogs } from '../../utils';
 
 import { LogTableControls } from './LogTableControls';
+import { PanelContextProvider } from '@grafana/ui';
 
 const DOWNLOAD_LOGS_LABEL_COPY = 'Download logs';
 
@@ -121,23 +122,88 @@ describe('LogTableControls', () => {
     ['txt', DownloadFormat.Text],
     ['json', DownloadFormat.Json],
     ['csv', DownloadFormat.CSV],
-  ])('Allows to download logs', async (label: string, format: DownloadFormat) => {
+  ])('Allows to download logs in plugins and Explore', async (label: string, format: DownloadFormat) => {
     jest.mocked(downloadLogs).mockClear();
     render(
-      <LogTableControls
-        logOptionsStorageKey={''}
-        controlsExpanded={false}
-        setControlsExpanded={jest.fn()}
-        sortOrder={LogsSortOrder.Ascending}
-        setSortOrder={jest.fn()}
-        downloadLogs={downloadLogs as unknown as (f: DownloadFormat) => void}
-        wrapText={false}
-        onWrapTextClick={jest.fn()}
-      />
+      <PanelContextProvider
+        value={{
+          app: CoreApp.Explore,
+          eventsScope: 'test',
+          eventBus: new EventBusSrv(),
+        }}
+      >
+        <LogTableControls
+          logOptionsStorageKey={''}
+          controlsExpanded={false}
+          setControlsExpanded={jest.fn()}
+          sortOrder={LogsSortOrder.Ascending}
+          setSortOrder={jest.fn()}
+          downloadLogs={downloadLogs as unknown as (f: DownloadFormat) => void}
+          wrapText={false}
+          onWrapTextClick={jest.fn()}
+        />
+      </PanelContextProvider>
     );
     await userEvent.click(screen.getByLabelText(DOWNLOAD_LOGS_LABEL_COPY));
     await userEvent.click(await screen.findByText(label));
     expect(downloadLogs).toHaveBeenCalledTimes(1);
     expect(downloadLogs).toHaveBeenCalledWith(format);
+  });
+
+  test.each([
+    ['txt', DownloadFormat.Text],
+    ['json', DownloadFormat.Json],
+    ['csv', DownloadFormat.CSV],
+  ])('Allows to download logs in Dashboards when enabled', async (label: string, format: DownloadFormat) => {
+    jest.mocked(downloadLogs).mockClear();
+    render(
+      <PanelContextProvider
+        value={{
+          app: CoreApp.Dashboard,
+          eventsScope: 'test',
+          eventBus: new EventBusSrv(),
+        }}
+      >
+        <LogTableControls
+          allowDownload
+          logOptionsStorageKey={''}
+          controlsExpanded={false}
+          setControlsExpanded={jest.fn()}
+          sortOrder={LogsSortOrder.Ascending}
+          setSortOrder={jest.fn()}
+          downloadLogs={downloadLogs as unknown as (f: DownloadFormat) => void}
+          wrapText={false}
+          onWrapTextClick={jest.fn()}
+        />
+      </PanelContextProvider>
+    );
+    await userEvent.click(screen.getByLabelText(DOWNLOAD_LOGS_LABEL_COPY));
+    await userEvent.click(await screen.findByText(label));
+    expect(downloadLogs).toHaveBeenCalledTimes(1);
+    expect(downloadLogs).toHaveBeenCalledWith(format);
+  });
+
+  it('Does not allow to download when disabled', async () => {
+    render(
+      <PanelContextProvider
+        value={{
+          app: CoreApp.Dashboard,
+          eventsScope: 'test',
+          eventBus: new EventBusSrv(),
+        }}
+      >
+        <LogTableControls
+          logOptionsStorageKey={''}
+          controlsExpanded={false}
+          setControlsExpanded={jest.fn()}
+          sortOrder={LogsSortOrder.Ascending}
+          setSortOrder={jest.fn()}
+          downloadLogs={downloadLogs as unknown as (f: DownloadFormat) => void}
+          wrapText={false}
+          onWrapTextClick={jest.fn()}
+        />
+      </PanelContextProvider>
+    );
+    expect(screen.queryByLabelText(DOWNLOAD_LOGS_LABEL_COPY)).not.toBeInTheDocument();
   });
 });

--- a/public/app/features/logs/components/panel/LogTableControls.tsx
+++ b/public/app/features/logs/components/panel/LogTableControls.tsx
@@ -1,10 +1,10 @@
 import { css, cx } from '@emotion/css';
 import { useCallback, useMemo } from 'react';
 
-import { type GrafanaTheme2, LogsSortOrder, store } from '@grafana/data';
+import { CoreApp, type GrafanaTheme2, LogsSortOrder, store } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, reportInteraction } from '@grafana/runtime';
-import { Dropdown, Menu, useStyles2 } from '@grafana/ui';
+import { Dropdown, Menu, usePanelContext, useStyles2 } from '@grafana/ui';
 
 import { DownloadFormat } from '../../utils';
 
@@ -13,6 +13,7 @@ import { LogListControlsOption } from './LogListControlsOption';
 import { LOG_LIST_CONTROLS_WIDTH } from './virtualization';
 
 type Props = {
+  allowDownload?: boolean;
   controlsExpanded: boolean;
   setControlsExpanded: (expanded: boolean) => void;
   setSortOrder: (sortOrder: LogsSortOrder) => void;
@@ -24,6 +25,7 @@ type Props = {
 };
 
 export const LogTableControls = ({
+  allowDownload,
   controlsExpanded,
   logOptionsStorageKey,
   setControlsExpanded,
@@ -34,6 +36,7 @@ export const LogTableControls = ({
   wrapText,
 }: Props) => {
   const styles = useStyles2(getStyles, controlsExpanded);
+  const { app } = usePanelContext();
 
   const onExpandControlsClick = useCallback(() => {
     reportInteraction('logs_log_list_controls_expand_controls_clicked');
@@ -82,6 +85,9 @@ export const LogTableControls = ({
     ),
     [downloadLogs]
   );
+
+  const inDashboard = app === CoreApp.Dashboard || app === CoreApp.PanelEditor || app === CoreApp.PanelViewer;
+  const canDownload = (inDashboard && allowDownload === true) || (!inDashboard && !config.exploreHideLogsDownload);
 
   return (
     <div className={styles.navContainer}>
@@ -138,7 +144,7 @@ export const LogTableControls = ({
         }
       />
 
-      {!config.exploreHideLogsDownload && (
+      {canDownload && (
         <>
           <div className={styles.divider} />
           <Dropdown overlay={downloadMenu} placement="auto-end">

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -144,8 +144,11 @@ interface LogsPanelProps extends PanelProps<Options> {
 }
 const noCommonLabels: Labels = {};
 
+const dashboardApps = [CoreApp.Dashboard, CoreApp.PanelEditor, CoreApp.PanelViewer];
+
 export const LogsPanel = ({ data, timeZone, fieldConfig, options, onOptionsChange, height, id }: LogsPanelProps) => {
   const {
+    allowDownload,
     showControls,
     showFieldSelector,
     controlsStorageKey,
@@ -590,6 +593,7 @@ export const LogsPanel = ({ data, timeZone, fieldConfig, options, onOptionsChang
         >
           {deduplicatedRows.length > 0 && scrollElement && (
             <LogList
+              allowDownload={allowDownload}
               app={isCoreApp(app) ? app : CoreApp.Dashboard}
               containerElement={scrollElement}
               dataFrames={panelData.series}

--- a/public/app/plugins/panel/logs/LogsPanel.tsx
+++ b/public/app/plugins/panel/logs/LogsPanel.tsx
@@ -144,8 +144,6 @@ interface LogsPanelProps extends PanelProps<Options> {
 }
 const noCommonLabels: Labels = {};
 
-const dashboardApps = [CoreApp.Dashboard, CoreApp.PanelEditor, CoreApp.PanelViewer];
-
 export const LogsPanel = ({ data, timeZone, fieldConfig, options, onOptionsChange, height, id }: LogsPanelProps) => {
   const {
     allowDownload,

--- a/public/app/plugins/panel/logs/module.tsx
+++ b/public/app/plugins/panel/logs/module.tsx
@@ -179,25 +179,27 @@ export const plugin = new PanelPlugin<Options>(LogsPanel)
     }
 
     if (config.featureToggles.newLogsPanel) {
-      builder.addBooleanSwitch({
-        path: 'showControls',
-        name: t('logs.name-show-controls', 'Show controls'),
-        category,
-        description: t(
-          'logs.description-show-controls',
-          'Display controls to jump to the last or first log line, and filters by log level.'
-        ),
-        defaultValue: false,
-      }).addBooleanSwitch({
-        path: 'allowDownload',
-        name: t('logs.name-allow-download', 'Display download control'),
-        category,
-        description: t(
-          'logs.description-allow-download',
-          'When controls are enabled, show an option to download the logs on display.'
-        ),
-        showIf: (currentOptions) => Boolean(currentOptions.showControls),
-      });
+      builder
+        .addBooleanSwitch({
+          path: 'showControls',
+          name: t('logs.name-show-controls', 'Show controls'),
+          category,
+          description: t(
+            'logs.description-show-controls',
+            'Display controls to jump to the last or first log line, and filters by log level.'
+          ),
+          defaultValue: false,
+        })
+        .addBooleanSwitch({
+          path: 'allowDownload',
+          name: t('logs.name-allow-download', 'Display download control'),
+          category,
+          description: t(
+            'logs.description-allow-download',
+            'When controls are enabled, show an option to download the logs on display.'
+          ),
+          showIf: (currentOptions) => Boolean(currentOptions.showControls),
+        });
     }
 
     builder.addBooleanSwitch({

--- a/public/app/plugins/panel/logs/module.tsx
+++ b/public/app/plugins/panel/logs/module.tsx
@@ -188,6 +188,15 @@ export const plugin = new PanelPlugin<Options>(LogsPanel)
           'Display controls to jump to the last or first log line, and filters by log level.'
         ),
         defaultValue: false,
+      }).addBooleanSwitch({
+        path: 'allowDownload',
+        name: t('logs.name-allow-download', 'Display download control'),
+        category,
+        description: t(
+          'logs.description-allow-download',
+          'When controls are enabled, show an option to download the logs on display.'
+        ),
+        showIf: (currentOptions) => Boolean(currentOptions.showControls),
       });
     }
 

--- a/public/app/plugins/panel/logs/panelcfg.cue
+++ b/public/app/plugins/panel/logs/panelcfg.cue
@@ -63,6 +63,7 @@ composableKinds: PanelCfg: {
 					displayedFields?: [...string]
 					setDisplayedFields?: _
 					grammar?:            _
+					allowDownload?:      bool
 				} @cuetsy(kind="interface")
 			}
 		}]

--- a/public/app/plugins/panel/logs/panelcfg.gen.ts
+++ b/public/app/plugins/panel/logs/panelcfg.gen.ts
@@ -13,6 +13,7 @@
 import * as common from '@grafana/schema';
 
 export interface Options {
+  allowDownload?: boolean;
   controlsStorageKey?: string;
   dedupStrategy: common.LogsDedupStrategy;
   detailsMode?: ('inline' | 'sidebar');

--- a/public/app/plugins/panel/logstable/TableNGWrap.tsx
+++ b/public/app/plugins/panel/logstable/TableNGWrap.tsx
@@ -96,6 +96,7 @@ export function TableNGWrap({
       {showControls && (
         <div className={styles.listControlsWrapper}>
           <LogTableControls
+            allowDownload={options.allowDownload}
             logOptionsStorageKey={logOptionsStorageKey}
             controlsExpanded={controlsExpanded}
             setControlsExpanded={setControlsExpanded}

--- a/public/app/plugins/panel/logstable/module.tsx
+++ b/public/app/plugins/panel/logstable/module.tsx
@@ -38,7 +38,8 @@ export const plugin = new PanelPlugin<Options & TableOptions, TableFieldConfig>(
         category: logsTableCategory,
         description: t('logstable.description-show-controls', 'Display table controls'),
         defaultValue: defaultOptions.showControls ?? false,
-      }).addBooleanSwitch({
+      })
+      .addBooleanSwitch({
         path: 'allowDownload',
         name: t('logs.name-allow-download', 'Display download control'),
         category: logsTableCategory,
@@ -47,6 +48,6 @@ export const plugin = new PanelPlugin<Options & TableOptions, TableFieldConfig>(
           'When controls are enabled, show an option to download the logs on display.'
         ),
         showIf: (currentOptions) => Boolean(currentOptions.showControls),
-      })
+      });
   })
   .setSuggestionsSupplier(logstableSuggestionsSupplier);

--- a/public/app/plugins/panel/logstable/module.tsx
+++ b/public/app/plugins/panel/logstable/module.tsx
@@ -38,6 +38,15 @@ export const plugin = new PanelPlugin<Options & TableOptions, TableFieldConfig>(
         category: logsTableCategory,
         description: t('logstable.description-show-controls', 'Display table controls'),
         defaultValue: defaultOptions.showControls ?? false,
-      });
+      }).addBooleanSwitch({
+        path: 'allowDownload',
+        name: t('logs.name-allow-download', 'Display download control'),
+        category: logsTableCategory,
+        description: t(
+          'logs.description-allow-download',
+          'When controls are enabled, show an option to download the logs on display.'
+        ),
+        showIf: (currentOptions) => Boolean(currentOptions.showControls),
+      })
   })
   .setSuggestionsSupplier(logstableSuggestionsSupplier);

--- a/public/app/plugins/panel/logstable/panelcfg.cue
+++ b/public/app/plugins/panel/logstable/panelcfg.cue
@@ -36,6 +36,7 @@ composableKinds: PanelCfg: {
 					displayedFields?: [...string]
 					buildLinkToLogLine?: _
 					wrapText?:           bool
+					allowDownload?:      bool
 				} @cuetsy(kind="interface")
 			}
 		}]

--- a/public/app/plugins/panel/logstable/panelcfg.gen.ts
+++ b/public/app/plugins/panel/logstable/panelcfg.gen.ts
@@ -13,6 +13,7 @@
 import * as common from '@grafana/schema';
 
 export interface Options {
+  allowDownload?: boolean;
   buildLinkToLogLine?: unknown;
   displayedFields?: Array<string>;
   enableLogDetails?: boolean;

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11220,6 +11220,7 @@
       "label-numbers": "Numbers",
       "label-signature": "Signature"
     },
+    "description-allow-download": "When controls are enabled, show an option to download the logs on display.",
     "description-enable-field-selector": "Experimental. Show a component to manage the displayed fields from the logs.",
     "description-enable-infinite-scrolling": "Experimental. Request more results by scrolling to the bottom of the logs list.",
     "description-enable-logs-highlighting": "Use a predefined coloring scheme to highlight relevant parts of the log lines.",
@@ -11517,6 +11518,7 @@
         "common-labels": "Common labels:"
       }
     },
+    "name-allow-download": "Display download control",
     "name-common-labels": "Common labels",
     "name-deduplication": "Deduplication",
     "name-details-mode": "Log details panel mode",


### PR DESCRIPTION
Closes https://github.com/grafana/grafana/issues/120605

Adds a new option to allow to download logs from Dashboards. It should be optional in both visualizations, in dashboards, because there's precedent of some users needing to disable this option.

In other contexts, such as plugins and Explore, it works as follows:

- Explore: can be disabled by configuration (hide_logs_download). https://github.com/grafana/grafana/pull/99512
- Plugins: the option is available, unless strictly disabled by passing `false` to the `allowDownload` prop

<img width="311" height="173" alt="imagen" src="https://github.com/user-attachments/assets/833f1c06-e019-4ff5-9295-b93f9cff6f1d" />

<img width="1259" height="545" alt="imagen" src="https://github.com/user-attachments/assets/b03a2cdc-311f-4ab1-9481-bf103f6f24b6" />

<img width="1262" height="1079" alt="imagen" src="https://github.com/user-attachments/assets/d0a9c656-6fcd-453c-b8d6-8b13390583ab" />
