### PR TITLE
[release-12.4.4] Docs: Updates to main data source landing page

### DIFF
--- a/docs/sources/datasources/_index.md
+++ b/docs/sources/datasources/_index.md
@@ -3,13 +3,23 @@ aliases:
   - data-sources/
   - overview/
   - ./features/datasources/
+description: Learn how to manage, configure, and query built-in and plugin data sources in Grafana.
+keywords:
+  - grafana
+  - data source
+  - datasource
+  - query
+  - plugin
+  - configure
 labels:
   products:
     - cloud
     - enterprise
     - oss
+menuTitle: Data sources
 title: Data sources
 weight: 60
+review_date: 2026-03-10
 refs:
   query-transform-data:
     - pattern: /docs/grafana/
@@ -44,22 +54,57 @@ refs:
   plugin-management:
     - pattern: /docs/grafana/
       destination: /docs/grafana/<GRAFANA_VERSION>/administration/plugin-management/
-    - pattern: /docs/grafana-cloud
+    - pattern: /docs/grafana-cloud/
       destination: /docs/grafana/<GRAFANA_VERSION>/administration/plugin-management/
   panels:
     - pattern: /docs/grafana/
       destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana/<GRAFANA_VERSION>/panels-visualizations/
+  provisioning-data-sources:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/administration/provisioning/#data-sources
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana/<GRAFANA_VERSION>/administration/provisioning/#data-sources
+  template-variables:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/dashboards/variables/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana/<GRAFANA_VERSION>/dashboards/variables/
+  query-caching:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/administration/data-source-management/#query-and-resource-caching
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana/<GRAFANA_VERSION>/administration/data-source-management/#query-and-resource-caching
+  annotate-visualizations:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/dashboards/build-dashboards/annotate-visualizations/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana/<GRAFANA_VERSION>/dashboards/build-dashboards/annotate-visualizations/
+  correlations:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/administration/correlations/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana/<GRAFANA_VERSION>/administration/correlations/
+  troubleshoot-data-sources:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/datasources/troubleshooting/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana/<GRAFANA_VERSION>/datasources/troubleshooting/
+  create-dashboards-from-suggestions:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/dashboards/build-dashboards/create-template-dashboards/#create-dashboards-from-suggestions
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana/<GRAFANA_VERSION>/dashboards/build-dashboards/create-template-dashboards/#create-dashboards-from-suggestions
 ---
 
-# Grafana data sources
+# Data sources
 
-Grafana comes with built-in support for many _data sources_.
+A _data source_ in Grafana is a connection to a storage backend that holds your data, such as a Prometheus server, a Loki instance, a SQL database, or a cloud monitoring service. Grafana queries data sources to retrieve the stored data (e.g. metrics, logs, traces, and profiles) that it then visualizes in dashboards and Explore.
+
+Grafana comes with built-in support for many data sources.
 If you need other data sources, you can also install one of the many data source plugins.
 If the plugin you need doesn't exist, you can develop a custom plugin.
-
-{{< youtube id="cqHO0oYW6Ic" >}}
 
 Each data source comes with a _query editor_,
 which formulates custom queries according to the source's structure.
@@ -74,12 +119,18 @@ and how to configure or query the built-in data sources.
 
 For other available plugins, refer to the list of [documented plugins](https://grafana.com/docs/plugins/) or browse the [Plugin catalog](/grafana/plugins/). To develop a custom plugin, refer to [Create a data source plugin](#create-a-data-source-plugin).
 
+{{< admonition type="note" >}}
+Grafana Cloud includes pre-configured data sources for Prometheus, Loki, and Tempo, so you can start querying without additional setup. Refer to [Grafana Cloud documentation](https://grafana.com/docs/grafana-cloud/) for details.
+{{< /admonition >}}
+
 ## Manage data sources
 
 Only users with the [organization administrator role](ref:organization-roles) can add or remove data sources.
-To access data source management tools in Grafana as an administrator, navigate to **Configuration > Data Sources** in the Grafana sidebar.
+To access data source management tools in Grafana as an administrator, navigate to **Connections > Data sources** in the left-side menu.
 
-For details on data source management, including instructions on how configure user permissions for queries, refer to the [administration documentation](ref:data-source-management).
+For details on data source management, including instructions on how to configure user permissions for queries, refer to the [administration documentation](ref:data-source-management).
+
+By default, any user in an organization can query any data source in that organization. With [Grafana Enterprise](ref:grafana-enterprise) or Grafana Cloud, you can configure **data source permissions** to restrict query, edit, and admin access to specific users, teams, or roles. Refer to the [data source management documentation](ref:data-source-management) for details.
 
 ## Add a data source
 
@@ -96,9 +147,9 @@ Only users with the organization admin role can add data sources.
 1. Click the data source you want to add.
 1. Configure the data source following instructions specific to that data source.
 
-## Use query editors
+You can mark one data source as the **Default** by toggling the option on its configuration page. The default data source is pre-selected when you create new panels, navigate to Explore, or create alert rules.
 
-{{< figure src="/static/img/docs/queries/influxdb-query-editor-7-2.png" class="docs-image--no-shadow" max-width="1000px" caption="The InfluxDB query editor" >}}
+## Query editors
 
 Each data source's **query editor** provides a customized user interface that helps you write queries that take advantage of its unique capabilities.
 You use a data source's query editor when you create queries in [dashboard panels](ref:query-transform-data) or [Explore](ref:explore).
@@ -106,17 +157,13 @@ You use a data source's query editor when you create queries in [dashboard panel
 Because of the differences between query languages, each data source query editor looks and functions differently.
 Depending on your data source, the query editor might provide auto-completion features, metric names, variable suggestions, or a visual query-building interface.
 
-For example, this video demonstrates the visual Prometheus query builder:
-
-{{< vimeo 720004179 >}}
-
 For general information about querying in Grafana, and common options and user interface elements across all query editors, refer to [Query and transform data](ref:query-transform-data).
 
-## Build a dashboard from the data source
+## Provision data sources
 
-After you've configured a data source, you can start creating a dashboard directly from it, by clicking the **Build a dashboard** button.
+You can define and manage data sources as code using the Grafana provisioning system. This lets you configure data sources through YAML files or Terraform instead of the Grafana UI, which is useful for automated deployments and version-controlled configuration.
 
-For more information, refer to [Begin dashboard creation from data source configuration](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/dashboards/build-dashboards/create-dashboard/#begin-dashboard-creation-from-connections).
+For more information, refer to [Provision data sources](ref:provisioning-data-sources).
 
 ## Special data sources
 
@@ -124,7 +171,7 @@ Grafana includes three special data sources:
 
 ### Grafana
 
-A built-in data source that generates random walk data and can poll the [Testdata](testdata/) data source. Additionally, it can list files and get other data from a Grafana installation. This can be helpful for testing visualizations and running experiments.
+A built-in data source that generates random walk data and can poll the [TestData](testdata/) data source. Additionally, it can list files and get other data from a Grafana installation. This can be helpful for testing visualizations and running experiments.
 
 ### Mixed
 
@@ -143,35 +190,51 @@ A data source that uses the result set from another panel in the same dashboard.
 
 ## Built-in core data sources
 
-These built-in core data sources are also included in the Grafana documentation:
+Grafana ships with the following core data sources, organized by their primary use case.
 
-{{< column-list >}}
+### Metrics and time series
 
-- [Alertmanager](alertmanager/)
 - [AWS CloudWatch](aws-cloudwatch/)
 - [Azure Monitor](azure-monitor/)
-- [Elasticsearch](elasticsearch/)
 - [Google Cloud Monitoring](google-cloud-monitoring/)
 - [Graphite](graphite/)
 - [InfluxDB](influxdb/)
-- [Jaeger](jaeger/)
-- [Loki](loki/)
-- [Microsoft SQL Server (MSSQL)](mssql/)
-- [MySQL](mysql/)
 - [OpenTSDB](opentsdb/)
-- [Parca](parca/)
-- [PostgreSQL](postgres/)
 - [Prometheus](prometheus/)
-- [Pyroscope](pyroscope/)
+
+### Logs
+
+- [Elasticsearch](elasticsearch/)
+- [Loki](loki/)
+
+### Traces
+
+- [Jaeger](jaeger/)
 - [Tempo](tempo/)
-- [Testdata](testdata/)
 - [Zipkin](zipkin/)
 
-{{< /column-list >}}
+### Profiles
+
+- [Parca](parca/)
+- [Pyroscope](pyroscope/)
+
+### SQL databases
+
+- [Microsoft SQL Server (MSSQL)](mssql/)
+- [MySQL](mysql/)
+- [PostgreSQL](postgres/)
+
+### Alerting
+
+- [Alertmanager](alertmanager/)
+
+### Testing and debugging
+
+- [TestData](testdata/)
 
 ## Add additional data source plugins
 
-You can add additional data sources as plugins (that are not available in core Grafana), which you can install or create yourself.
+You can add additional data sources as plugins (that aren't available in core Grafana), which you can install or create yourself.
 
 ### Find data source plugins in the plugin catalog
 
@@ -186,3 +249,30 @@ For more documentation on a specific data source plugin's features, including it
 ### Create a data source plugin
 
 To build your own data source plugin, refer to the [Build a data source plugin](/developers/plugin-tools/tutorials/build-a-data-source-plugin) tutorial and [Plugin tools](/developers/plugin-tools).
+
+## Correlate data across data sources
+
+Grafana lets you link related data across different data sources so you can jump from one signal to another during investigations. For example, you can navigate from a trace span to related logs, or from a log line to metrics for the same service.
+
+You can set up these links in two ways:
+
+- **Data source configuration:** Tracing data sources like Tempo, Jaeger, and Zipkin include built-in settings for trace-to-logs, trace-to-metrics, and trace-to-profiles links.
+- **Correlations:** A more flexible, general-purpose feature that lets you define rules to link data between any data sources. Refer to [Correlations](ref:correlations) for details.
+
+## Troubleshoot data sources
+
+If you run into issues with a data source, refer to [Troubleshoot data sources](ref:troubleshoot-data-sources) for solutions to common problems like connection errors, authentication failures, and empty query results.
+
+Each built-in data source also has its own troubleshooting page with guidance specific to that data source.
+
+## Next steps
+
+After you've configured a data source, you can:
+
+- **Build a dashboard:** Click the **Build a dashboard** drop-down list on the data source configuration page and select **From suggestions** to open a dialog box with suggested dashboards based on the data source type. For more information, refer to [Create dashboards from suggestions](ref:create-dashboards-from-suggestions) or [Create a dashboard](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/build-dashboards/create-dashboard/).
+- **Explore your data:** Use [Explore](ref:explore) to run free-form queries without creating a dashboard.
+- **Set up alerts:** Create [alert rules](ref:alerts) to get notified when your data meets certain conditions.
+- **Use template variables:** Create dynamic, reusable dashboards with [template variables](ref:template-variables).
+- **Add annotations:** Overlay [annotations](ref:annotate-visualizations) on your graphs to mark events and correlate them with metrics.
+- **Transform query results:** Apply [transformations](ref:query-transform-data) to manipulate and combine data from multiple sources.
+- **Enable query caching:** Improve dashboard performance and reduce backend load with [query and resource caching](ref:query-caching) (available in Grafana Enterprise and Grafana Cloud).

--- a/docs/sources/datasources/troubleshooting.md
+++ b/docs/sources/datasources/troubleshooting.md
@@ -1,0 +1,192 @@
+---
+description: Solutions to common issues when configuring and querying data sources in Grafana.
+keywords:
+  - grafana
+  - data source
+  - troubleshooting
+  - connection
+  - authentication
+  - query
+  - errors
+labels:
+  products:
+    - cloud
+    - enterprise
+    - oss
+menuTitle: Troubleshooting
+title: Troubleshoot general data sources
+weight: 900
+review_date: 2026-03-10
+refs:
+  data-source-management:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/administration/data-source-management/
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana/<GRAFANA_VERSION>/administration/data-source-management/
+  provisioning-data-sources:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/administration/provisioning/#data-sources
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana/<GRAFANA_VERSION>/administration/provisioning/#data-sources
+  private-data-source-connect:
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/
+    - pattern: /docs/grafana/
+      destination: /docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/
+---
+
+# Troubleshoot general data source issues
+
+This page provides solutions to common issues that apply across data sources in Grafana. For troubleshooting specific to a data source, refer to the troubleshooting page within each data source's documentation.
+
+## Connection errors
+
+These errors occur when Grafana can't reach the data source backend.
+
+### "Connection refused" or timeout errors
+
+**Symptoms:**
+
+- **Save & test** fails with a connection error or timeout
+- Panels show "error" or fail to load data
+- Intermittent connectivity issues
+
+**Possible causes and solutions:**
+
+| Cause                     | Solution                                                                                                                                             |
+| ------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Incorrect URL             | Verify the data source URL is correct, including the protocol (`http://` or `https://`) and port number.                                             |
+| Network or firewall rules | Ensure the Grafana server can reach the data source endpoint. Check that firewall rules allow outbound traffic on the required port.                 |
+| Data source is down       | Verify the data source service is running and accepting connections.                                                                                 |
+| DNS resolution failure    | Confirm the hostname resolves correctly from the Grafana server.                                                                                     |
+| Private network access    | If the data source is on a private network and you're using Grafana Cloud, configure [Private data source connect](ref:private-data-source-connect). |
+
+### TLS/SSL errors
+
+**Symptoms:**
+
+- Errors mentioning "certificate," "TLS handshake," or "x509"
+- **Save & test** fails with SSL-related messages
+
+**Solutions:**
+
+1. Verify the data source is using a valid TLS certificate.
+1. If you're using a self-signed certificate, enable **Skip TLS Verify** in the data source configuration (not recommended for production) or add the CA certificate to the list of trusted certificates in Grafana.
+1. Ensure the certificate hasn't expired.
+1. Confirm the certificate's Common Name or Subject Alternative Name matches the hostname in the data source URL.
+
+## Authentication errors
+
+These errors occur when credentials are invalid, missing, or lack the required permissions.
+
+### "Unauthorized" or "Access denied"
+
+**Symptoms:**
+
+- **Save & test** fails with `401 Unauthorized` or `403 Forbidden`
+- Queries return access denied messages
+- Drop-down menus don't populate
+
+**Possible causes and solutions:**
+
+| Cause                       | Solution                                                                                                                                                   |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Invalid credentials         | Double-check the username, password, API key, or token. Regenerate credentials if necessary.                                                               |
+| Expired credentials         | Create new credentials and update the data source configuration.                                                                                           |
+| Insufficient permissions    | Ensure the account or API key has the permissions required by the data source. Refer to the specific data source's documentation for required permissions. |
+| Wrong authentication method | Verify you've selected the correct authentication type for your setup.                                                                                     |
+
+## Query errors
+
+These errors occur when executing queries against a properly connected data source.
+
+### "No data" or empty results
+
+**Symptoms:**
+
+- Queries execute without error but return no data
+- Panels show "No data"
+- Graphs are empty
+
+**Possible causes and solutions:**
+
+| Cause                           | Solution                                                                                          |
+| ------------------------------- | ------------------------------------------------------------------------------------------------- |
+| Time range doesn't contain data | Expand the dashboard time range or verify data exists in the data source for the selected period. |
+| Incorrect query                 | Review the query syntax. Use the data source's query editor to build or validate the query.       |
+| Wrong data source selected      | Verify you've selected the correct data source in the panel or Explore.                           |
+| Permissions issue               | Ensure the credentials have read access to the specific resource or index being queried.          |
+
+### Query timeout
+
+**Symptoms:**
+
+- Queries run for a long time then fail
+- Error messages mention timeout or query limits
+
+**Solutions:**
+
+1. Narrow the dashboard time range to reduce the volume of data.
+1. Add filters to the query to reduce the result set.
+1. Break complex queries into smaller parts.
+1. Increase the data source timeout setting if your data source legitimately needs more time.
+
+## Data source configuration errors
+
+### "Save & test" fails after provisioning
+
+**Symptoms:**
+
+- Provisioned data sources fail the connection test
+- Errors appear after deploying provisioning YAML files
+
+**Solutions:**
+
+1. Verify the provisioning YAML syntax is correct. Refer to [Provision data sources](ref:provisioning-data-sources) for the expected format.
+1. Ensure `secureJsonData` values (such as passwords, API keys, and tokens) are set correctly. These values can't be read back after being saved.
+1. Check that the provisioning file is in the correct directory and that Grafana has read access.
+1. Restart Grafana after making changes to provisioning files.
+
+### Data source disappears or resets
+
+**Symptoms:**
+
+- Data source changes revert after Grafana restarts
+- Data source configuration can't be saved through the UI
+
+**Solutions:**
+
+1. Provisioned data sources can't be edited through the UI. Make changes in the provisioning YAML file instead.
+1. Verify no other provisioning file is overwriting your data source configuration.
+
+## Enable debug logging
+
+To capture detailed error information for troubleshooting:
+
+1. Set the Grafana log level to `debug` in the configuration file:
+
+   ```ini
+   [log]
+   level = debug
+   ```
+
+1. Restart Grafana for the change to take effect.
+1. Reproduce the issue and review logs at `/var/log/grafana/grafana.log` (or your configured log location).
+1. Look for entries related to your data source that include request and response details.
+1. Reset the log level to `info` after troubleshooting to avoid excessive log volume.
+
+## Get additional help
+
+If the solutions on this page don't resolve your issue:
+
+1. Check the troubleshooting page for your specific data source.
+1. Search the [Grafana community forums](https://community.grafana.com/) for similar issues.
+1. Review [Grafana GitHub issues](https://github.com/grafana/grafana/issues) for known bugs.
+1. Contact [Grafana Support](https://grafana.com/support/) if you're a Grafana Enterprise, Cloud Pro, or Cloud Advanced user.
+
+When reporting issues, include:
+
+- Grafana version and data source plugin version
+- Exact error messages (redact sensitive information)
+- Steps to reproduce the issue
+- Relevant configuration (redact credentials)


### PR DESCRIPTION
Backport cecdccd409ed85e7107378af01daa51068dfb903 from #119994

---

**What is this feature?**

Summary
Updated the data sources landing page (docs/sources/datasources/_index.md) to improve completeness, accuracy, and usability for users arriving at Grafana's most-viewed data source doc.

Content additions

* Data source definition: Added a clear definition of what a data source is in Grafana as the opening sentence.
* Grafana Cloud note: Added admonition about pre-configured data sources in Grafana Cloud.
* Data source permissions: Added note in "Manage" section about restricting access with Enterprise/Cloud permissions.
* Default data source: Added note explaining the Default toggle and what it does.
* Provisioning section: New section covering YAML and Terraform provisioning with link to docs.
* Categorized data source list: Reorganized the flat alphabetical list into signal-type categories (Metrics, Logs, Traces, Profiles, SQL, Alerting, Testing).
* Added Parca: Was missing from the built-in data sources list despite having docs.
* Correlations section: New section explaining cross-data-source linking (trace-to-logs, trace-to-metrics, and general Correlations feature).
* Troubleshooting section: Added link to new general troubleshooting page.
* Next steps section: Replaced the thin "Build a dashboard" section with a comprehensive list: dashboards, Explore, alerting, template variables, annotations, transformations, and query caching.

Fixes

* Updated outdated nav path ("Configuration > Data Sources" to "Connections > Data sources").
* Fixed typo ("how configure" to "how to configure").
* Removed outdated v7.2 InfluxDB screenshot and stale embedded videos.
* Renamed "Use query editors" heading to "Query editors."

New file

* Created docs/sources/datasources/troubleshooting.md -- a general troubleshooting page covering connection errors, authentication failures, query issues, provisioning problems, debug logging, and how to get help.

**Backport conflict resolution:**

The cherry-pick had a merge conflict in `docs/sources/datasources/_index.md` because the "Build a dashboard" section differed between `main` and `release-12.4.4`. The old section content was replaced with the new "Provision data sources" section (matching the intended change from the original PR).

Made with [Cursor](https://cursor.com)