### PR TITLE
ci: pin grafana-github-actions and shared-workflows to commit SHAs

### DIFF
--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -1,16 +1,12 @@
 name: Run commands when issues are labeled or comments added
-
 on:
   issues:
     types: [labeled, unlabeled]
   issue_comment:
     types: [created]
-
 concurrency:
   group: issue-commands-${{ github.event.issue.number }}
-
 permissions: {}
-
 jobs:
   config:
     runs-on: "ubuntu-latest"
@@ -24,7 +20,6 @@ jobs:
           if [ "${{ github.repository }}" == "grafana/grafana" ]; then
             echo "has-secrets=1" >> "$GITHUB_OUTPUT"
           fi
-
   main:
     needs: config
     if: needs.config.outputs.has-secrets
@@ -35,21 +30,19 @@ jobs:
     steps:
       - name: Get vault secrets
         id: vault-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
+        uses: grafana/shared-workflows/actions/get-vault-secrets@10c9e32a5db1e4795e06f0590accf5ca27e2b915 # main
         with:
           repo_secrets: |
             GITHUB_APP_ID=grafana_pr_automation_app:app_id
             GITHUB_APP_PRIVATE_KEY=grafana_pr_automation_app:app_pem
-
       - name: Generate token
         id: generate_token
         uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
         with:
           app-id: ${{ env.GITHUB_APP_ID }}
           private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
-
       - name: Run commands
-        uses: grafana/grafana-github-actions/commands@main
+        uses: grafana/grafana-github-actions/commands@6606a86307be7d0f4249bc38a19a5f5818d2cd55 # main
         with:
           metricsWriteAPIKey: ""
           token: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -2,25 +2,22 @@ name: PR Checks
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
-
 concurrency:
   group: pr-checks-${{ github.event.number }}-new
   cancel-in-progress: true
-
 permissions:
   statuses: write
   checks: write
   actions: write
   contents: read
   pull-requests: read
-
 jobs:
   main:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == false
     steps:
       - name: Run PR Checks
-        uses: grafana/grafana-github-actions/pr-checks@main
+        uses: grafana/grafana-github-actions/pr-checks@6606a86307be7d0f4249bc38a19a5f5818d2cd55 # main
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           configPath: pr-checks

--- a/.github/workflows/pr-commands.yml
+++ b/.github/workflows/pr-commands.yml
@@ -5,12 +5,9 @@ on:
       - labeled
       - opened
       - synchronize
-
 concurrency:
   group: pr-commands-${{ github.event.number }}
-
 permissions: {}
-
 jobs:
   main:
     permissions:
@@ -20,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run PR Commands
-        uses: grafana/grafana-github-actions/commands@main
+        uses: grafana/grafana-github-actions/commands@6606a86307be7d0f4249bc38a19a5f5818d2cd55 # main
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           configPath: pr-commands


### PR DESCRIPTION
Three workflows reference internal actions at `@main` with no SHA pin:

- `pr-commands.yml` — uses `grafana-github-actions/commands@main` with `pull_request_target` (runs with base repo permissions)
- `pr-checks.yml` — uses `grafana-github-actions/pr-checks@main`
- `commands.yml` — uses both `shared-workflows/get-vault-secrets@main` and `grafana-github-actions/commands@main`, with `id-token: write` and a GitHub App private key fetch

With `@main`, the code that runs is whatever is at HEAD of those repos at execution time, not what was reviewed when the workflow was last touched. A bad commit to either action repo would silently affect these workflows on the next trigger.

Pinned all four references to the current HEAD SHA with a `# main` comment. No functional change. Same pattern already used in this repo for `tibdex/github-app-token` and `actions/stale`.

**Special notes for reviewer:** four lines changed across three files, behavior is identical.