### PR TITLE
Azure Monitor: Refactor `fetchInitialRows` to improve async utilisation

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.test.ts
+++ b/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.test.ts
@@ -748,6 +748,30 @@ describe('AzureMonitor resourcePickerData', () => {
       expect(resourcePickerData.getResourceGroupsBySubscriptionId).toBeCalledTimes(1);
       expect(resourcePickerData.getResourcesForResourceGroup).toBeCalledTimes(1);
     });
+
+    it('fetches resource groups for distinct subscriptions in parallel', async () => {
+      const { resourcePickerData } = createResourcePickerData([createMockARGSubscriptionResponse()]);
+
+      let inFlight = 0;
+      let maxInFlight = 0;
+      resourcePickerData.getResourceGroupsBySubscriptionId = jest.fn().mockImplementation(async (subId: string) => {
+        inFlight++;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        inFlight--;
+        return [{ id: `rg-${subId}`, uri: `/subscriptions/${subId}/resourceGroups/rg-${subId}` }];
+      });
+      resourcePickerData.getResourcesForResourceGroup = jest.fn().mockResolvedValue([]);
+
+      await resourcePickerData.fetchInitialRows('logs', [
+        { subscription: '1', resourceGroup: 'rg-1', metricNamespace: 'Microsoft.Compute/virtualMachines' },
+        { subscription: '2', resourceGroup: 'rg-2', metricNamespace: 'Microsoft.Compute/virtualMachines' },
+        { subscription: '3', resourceGroup: 'rg-3', metricNamespace: 'Microsoft.Compute/virtualMachines' },
+      ]);
+
+      expect(resourcePickerData.getResourceGroupsBySubscriptionId).toBeCalledTimes(3);
+      expect(maxInFlight).toBeGreaterThan(1);
+    });
   });
 
   describe('parseRows', () => {

--- a/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.ts
+++ b/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.ts
@@ -9,7 +9,6 @@ import type AzureResourceGraphDatasource from '../azure_resource_graph/azure_res
 import { type ResourceRow, type ResourceRowGroup, ResourceRowType } from '../components/ResourcePicker/types';
 import {
   addResources,
-  findRow,
   parseMultipleResourceDetails,
   parseResourceDetails,
   parseResourceURI,
@@ -62,32 +61,28 @@ export default class ResourcePickerData extends DataSourceWithBackend<
 
       const rgUriOf = (s: AzureMonitorResource) => `/subscriptions/${s.subscription}/resourceGroups/${s.resourceGroup}`;
 
-      const resUriOf = (s: AzureMonitorResource) => resourceToString(s);
-
       const hasSubAndRG = (
         s: AzureMonitorResource
       ): s is AzureMonitorResource & { subscription: string; resourceGroup: string } =>
         Boolean(s.subscription && s.resourceGroup);
 
-      const subsToFetch = uniq(
-        currentSelection
-          .filter(hasSubAndRG)
-          .filter((s) => !findRow(subscriptions, rgUriOf(s)))
-          .map(({ subscription }) => subscription)
-      );
+      const hasResource = (
+        s: AzureMonitorResource
+      ): s is AzureMonitorResource & { subscription: string; resourceGroup: string; resourceName: string } =>
+        hasSubAndRG(s) && Boolean(s.resourceName);
 
-      const rgUrisToFetch = uniq(
-        currentSelection
-          .filter((s) => s.subscription && s.resourceGroup && s.resourceName && !findRow(subscriptions, resUriOf(s)))
-          .map((s) => rgUriOf(s))
-      );
+      const subsToFetch = uniq(currentSelection.filter(hasSubAndRG).map(({ subscription }) => subscription));
+
+      const rgUrisToFetch = uniq(currentSelection.filter(hasResource).map(rgUriOf));
 
       const [groupsResults, resourcesResults] = await Promise.all([
         Promise.all(
-          subsToFetch.map(async (sub) => [sub, await this.getResourceGroupsBySubscriptionId(sub, type)] as const)
+          subsToFetch.map((sub) => this.getResourceGroupsBySubscriptionId(sub, type).then((rgs) => [sub, rgs] as const))
         ),
         Promise.all(
-          rgUrisToFetch.map(async (rgUri) => [rgUri, await this.getResourcesForResourceGroup(rgUri, type)] as const)
+          rgUrisToFetch.map((rgUri) =>
+            this.getResourcesForResourceGroup(rgUri, type).then((res) => [rgUri, res] as const)
+          )
         ),
       ]);
 
@@ -262,7 +257,7 @@ export default class ResourcePickerData extends DataSourceWithBackend<
     | project subscriptionName=name, subscriptionId
 
     | join kind=leftouter (
-      resourcecontainers
+      resourcecontainers            
             | where type == "microsoft.resources/subscriptions/resourcegroups"
             | where id =~ "${resourceGroupURI}"
             | project resourceGroupName=name, resourceGroup, subscriptionId

--- a/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.ts
+++ b/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.ts
@@ -1,3 +1,5 @@
+import { uniq } from 'lodash';
+
 import { DataSourceWithBackend, reportInteraction } from '@grafana/runtime';
 
 import { logsResourceTypes } from '../azureMetadata/logsResourceTypes';
@@ -58,31 +60,46 @@ export default class ResourcePickerData extends DataSourceWithBackend<
         return subscriptions;
       }
 
-      let resources = subscriptions;
-      const promises = currentSelection.map((selection) => async () => {
-        if (selection.subscription) {
-          const resourceGroupURI = `/subscriptions/${selection.subscription}/resourceGroups/${selection.resourceGroup}`;
+      const rgUriOf = (s: AzureMonitorResource) => `/subscriptions/${s.subscription}/resourceGroups/${s.resourceGroup}`;
 
-          if (selection.resourceGroup && !findRow(resources, resourceGroupURI)) {
-            const resourceGroups = await this.getResourceGroupsBySubscriptionId(selection.subscription, type);
-            resources = addResources(resources, `/subscriptions/${selection.subscription}`, resourceGroups);
-          }
+      const resUriOf = (s: AzureMonitorResource) => resourceToString(s);
 
-          const resourceURI = resourceToString(selection);
-          if (selection.resourceName && !findRow(resources, resourceURI)) {
-            const resourcesForResourceGroup = await this.getResourcesForResourceGroup(resourceGroupURI, type);
-            resources = addResources(resources, resourceGroupURI, resourcesForResourceGroup);
-          }
-        }
-      });
+      const hasSubAndRG = (
+        s: AzureMonitorResource
+      ): s is AzureMonitorResource & { subscription: string; resourceGroup: string } =>
+        Boolean(s.subscription && s.resourceGroup);
 
-      for (const promise of promises) {
-        // Fetch resources one by one, avoiding re-fetching the same resource
-        // and race conditions updating the resources array
-        await promise();
-      }
+      const subsToFetch = uniq(
+        currentSelection
+          .filter(hasSubAndRG)
+          .filter((s) => !findRow(subscriptions, rgUriOf(s)))
+          .map(({ subscription }) => subscription)
+      );
 
-      return resources;
+      const rgUrisToFetch = uniq(
+        currentSelection
+          .filter((s) => s.subscription && s.resourceGroup && s.resourceName && !findRow(subscriptions, resUriOf(s)))
+          .map((s) => rgUriOf(s))
+      );
+
+      const [groupsResults, resourcesResults] = await Promise.all([
+        Promise.all(
+          subsToFetch.map(async (sub) => [sub, await this.getResourceGroupsBySubscriptionId(sub, type)] as const)
+        ),
+        Promise.all(
+          rgUrisToFetch.map(async (rgUri) => [rgUri, await this.getResourcesForResourceGroup(rgUri, type)] as const)
+        ),
+      ]);
+
+      const withGroups = groupsResults.reduce<ResourceRowGroup>(
+        (acc, [sub, rgs]) => addResources(acc, `/subscriptions/${sub}`, rgs),
+        subscriptions
+      );
+
+      return resourcesResults.reduce<ResourceRowGroup>(
+        (acc, [rgUri, res]) => addResources(acc, rgUri, res),
+        withGroups
+      );
     } catch (err) {
       if (err instanceof Error) {
         if (err.message !== 'No subscriptions were found') {
@@ -245,7 +262,7 @@ export default class ResourcePickerData extends DataSourceWithBackend<
     | project subscriptionName=name, subscriptionId
 
     | join kind=leftouter (
-      resourcecontainers            
+      resourcecontainers
             | where type == "microsoft.resources/subscriptions/resourcegroups"
             | where id =~ "${resourceGroupURI}"
             | project resourceGroupName=name, resourceGroup, subscriptionId


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/110416. Reopens https://github.com/grafana/grafana/pull/110474 (auto-closed as stale).

## Summary

`fetchInitialRows` previously executed its HTTP requests serially because each iteration mutated a shared `resources` array and subsequent iterations read from it via `findRow`. In practice the shared state was defensive — `getSubscriptions` returns rows with empty children, so `findRow` never matched — but the serialisation cost was real.

This PR:

- Collects the set of subscription IDs that need resource groups and the set of resource-group URIs that need resources up-front, deduped.
- Fans both sets out in parallel via nested `Promise.all`, then folds the results into the tree with `addResources`.
- Removes the shared mutable `resources` variable.

## Correctness notes

- Dedup guarantees: two selections sharing a subscription issue one `getResourceGroupsBySubscriptionId` call; two sharing a resource group issue one `getResourcesForResourceGroup` call. The existing "fetches resource groups and resources" test covers this.
- Error semantics are unchanged — `Promise.all` fail-fast matches the original serial throw, since the original also discarded partially-added rows on error.