### PR TITLE
Explore: remove stray console.log in scanning loop

### DIFF
--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -657,7 +657,6 @@ export const runQueries = createAsyncThunk<void, RunQueriesOptions>(
 
           // Keep scanning for results if this was the last scanning transaction
           if (exploreState!.scanning) {
-            console.log(data.series);
             if (data.state === LoadingState.Done && data.series.length === 0) {
               const range = getShiftedTimeRange(-1, exploreState!.range);
               dispatch(updateTime({ exploreId, absoluteRange: range }));


### PR DESCRIPTION
**What this PR does / why we need it:**

Removes a debug `console.log(data.series)` statement that was accidentally left in production code inside the Explore scanning loop (`public/app/features/explore/state/query.ts`).

When Explore is in scanning mode (e.g. "Scan for older logs"), this `console.log` fires on **every single query response**, dumping the entire `data.series` array to the browser console. For large data frames this adds measurable serialization overhead and makes the console unusable during extended scanning sessions.

**Which issue(s) this PR fixes:**

Fixes #123274

**Special notes for your reviewer:**

- One-line deletion; no functional changes.
- The surrounding scan-stop logic remains intact.
