### PR TITLE
Templating: fix LegacyVariableWrapper.getValue() type-check and remove debug log

### DIFF
--- a/public/app/features/templating/LegacyVariableWrapper.ts
+++ b/public/app/features/templating/LegacyVariableWrapper.ts
@@ -13,11 +13,11 @@ export class LegacyVariableWrapper implements FormatVariable {
   getValue(_fieldPath: string): VariableValue {
     let { value } = this.state;
 
-    if (value === 'string' || value === 'number' || value === 'boolean') {
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
       return value;
     }
 
-    return String(value);
+    return value;
   }
 
   getValueText(): string {
@@ -31,7 +31,6 @@ export class LegacyVariableWrapper implements FormatVariable {
       return text.join(' + ');
     }
 
-    console.log('value', text);
     return String(text);
   }
 }


### PR DESCRIPTION
**What this PR does / why we need it:**

Fixes two issues in `LegacyVariableWrapper.getValue()` (`public/app/features/templating/LegacyVariableWrapper.ts`):

1. **Wrong type-check:** The guard condition was comparing the *value itself* against the string literals `'string'`, `'number'`, and `'boolean'` instead of using `typeof`:
   ```ts
   // Before (broken)
   if (value === 'string' || value === 'number' || value === 'boolean') { ... }

   // After (fixed)
   if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') { ... }
   ```
   Because the old condition was essentially always false for real variable values, multi-value arrays were passed through `String(value)`, which coerced them to a comma-separated string. This broke any downstream code (custom formatters, plugins) that expected to receive an array from multi-value variables.

2. **Debug console.log:** Removes a stray `console.log('value', text)` in `getValueText()` that was leaking output to the browser console in production.

**Which issue(s) this PR fixes:**

Fixes #123273

**Special notes for your reviewer:**

- No behavioural change for single string/number/boolean values (they were returned correctly before by coincidence).
- Arrays are now returned as-is instead of being stringified, matching the expected contract for multi-value variables.
