### PR TITLE
BarChart: add e2e tests

### DIFF
--- a/apps/dashboard/pkg/migration/testdata/golden_checksums.json
+++ b/apps/dashboard/pkg/migration/testdata/golden_checksums.json
@@ -53,7 +53,7 @@
   "dev-dashboards-output/panel-barchart/barchart-series-toggle.v42.json": "87088d19f2529d083c9a4e8aec9287350605465d8445defaa53161be1e77fc33",
   "dev-dashboards-output/panel-barchart/barchart-thresholds-mappings.v42.json": "2e226012ed274749148f89a6ea2aa16382c39f1bbdc22c90382cebcead94f2b3",
   "dev-dashboards-output/panel-barchart/barchart-tooltips-legends.v42.json": "1c036fe05070c4193b3c474fb63f3a97fe45314f6a4c63a1bf3400b800c7d5b1",
-  "dev-dashboards-output/panel-barchart/barchart_tests.v42.json": "7c5d3f80f6d08c16258354304c4dbe1803677a944eeb53b506d2b18e8a5908c1",
+  "dev-dashboards-output/panel-barchart/barchart_tests.v42.json": "14a47f2e78601b9558c83f897eb7693743833a1b05106b8760dbdfac37c2b62f",
   "dev-dashboards-output/panel-bargauge/bar_gauge_demo.v42.json": "96465e48df0b503567bea5871a793c4154a11449f1ec2bc63685264939debbf5",
   "dev-dashboards-output/panel-bargauge/panel_tests_bar_gauge.v42.json": "47d818d21f4559fb40bc0e4c05c074a5271af63debe540e9927019e9889c5b73",
   "dev-dashboards-output/panel-bargauge/panel_tests_bar_gauge2.v42.json": "f714bb0d054f3139ee7a9bc0550d202e02e5b49fcd4432ef09495092f44c5813",

--- a/apps/dashboard/pkg/migration/testdata/golden_checksums.json
+++ b/apps/dashboard/pkg/migration/testdata/golden_checksums.json
@@ -53,6 +53,7 @@
   "dev-dashboards-output/panel-barchart/barchart-series-toggle.v42.json": "87088d19f2529d083c9a4e8aec9287350605465d8445defaa53161be1e77fc33",
   "dev-dashboards-output/panel-barchart/barchart-thresholds-mappings.v42.json": "2e226012ed274749148f89a6ea2aa16382c39f1bbdc22c90382cebcead94f2b3",
   "dev-dashboards-output/panel-barchart/barchart-tooltips-legends.v42.json": "1c036fe05070c4193b3c474fb63f3a97fe45314f6a4c63a1bf3400b800c7d5b1",
+  "dev-dashboards-output/panel-barchart/barchart_tests.v42.json": "7c5d3f80f6d08c16258354304c4dbe1803677a944eeb53b506d2b18e8a5908c1",
   "dev-dashboards-output/panel-bargauge/bar_gauge_demo.v42.json": "96465e48df0b503567bea5871a793c4154a11449f1ec2bc63685264939debbf5",
   "dev-dashboards-output/panel-bargauge/panel_tests_bar_gauge.v42.json": "47d818d21f4559fb40bc0e4c05c074a5271af63debe540e9927019e9889c5b73",
   "dev-dashboards-output/panel-bargauge/panel_tests_bar_gauge2.v42.json": "f714bb0d054f3139ee7a9bc0550d202e02e5b49fcd4432ef09495092f44c5813",

--- a/devenv/dev-dashboards/panel-barchart/barchart_tests.json
+++ b/devenv/dev-dashboards/panel-barchart/barchart_tests.json
@@ -247,6 +247,123 @@
       ],
       "title": "No Data",
       "type": "barchart"
+    },
+    {
+      "datasource": { "type": "grafana-testdata-datasource" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineWidth": 1
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 10, "w": 12, "x": 0, "y": 30 },
+      "id": 7,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "orientation": "auto",
+        "showValue": "always",
+        "stacking": "none",
+        "tooltip": { "mode": "single", "sort": "none" },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "targets": [
+        {
+          "csvContent": "month,sales\nJan,10\nFeb,20\nMar,15\nApr,25\nMay,18",
+          "refId": "A",
+          "scenarioId": "csv_content"
+        }
+      ],
+      "title": "Show Values Always",
+      "type": "barchart"
+    },
+    {
+      "datasource": { "type": "grafana-testdata-datasource" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineWidth": 1
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 10, "w": 12, "x": 12, "y": 30 },
+      "id": 8,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "orientation": "auto",
+        "showValue": "auto",
+        "stacking": "percent",
+        "tooltip": { "mode": "single", "sort": "none" },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "targets": [
+        {
+          "csvContent": "month,sales,expenses\nJan,10,5\nFeb,20,12\nMar,15,8\nApr,25,14\nMay,18,9",
+          "refId": "A",
+          "scenarioId": "csv_content"
+        }
+      ],
+      "title": "Stacked 100 Percent",
+      "type": "barchart"
+    },
+    {
+      "datasource": { "type": "grafana-testdata-datasource" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineWidth": 1
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 10, "w": 12, "x": 0, "y": 40 },
+      "id": 9,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": true,
+        "groupWidth": 0.7,
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "orientation": "auto",
+        "showValue": "auto",
+        "stacking": "none",
+        "tooltip": { "mode": "single", "sort": "none" },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "targets": [
+        {
+          "csvContent": "month,sales\nJan,10\nFeb,20\nMar,15\nApr,25\nMay,18",
+          "refId": "A",
+          "scenarioId": "csv_content"
+        }
+      ],
+      "title": "Full Highlight",
+      "type": "barchart"
     }
   ],
   "schemaVersion": 36,

--- a/devenv/dev-dashboards/panel-barchart/barchart_tests.json
+++ b/devenv/dev-dashboards/panel-barchart/barchart_tests.json
@@ -1,0 +1,263 @@
+{
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "datasource": { "type": "grafana-testdata-datasource" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineWidth": 1
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 10, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "orientation": "auto",
+        "showValue": "auto",
+        "stacking": "none",
+        "tooltip": { "mode": "single", "sort": "none" },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "targets": [
+        {
+          "csvContent": "month,sales\nJan,10\nFeb,20\nMar,15\nApr,25\nMay,18",
+          "refId": "A",
+          "scenarioId": "csv_content"
+        }
+      ],
+      "title": "Single Series",
+      "type": "barchart"
+    },
+    {
+      "datasource": { "type": "grafana-testdata-datasource" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineWidth": 1
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 10, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "orientation": "auto",
+        "showValue": "auto",
+        "stacking": "none",
+        "tooltip": { "mode": "all", "sort": "none" },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "targets": [
+        {
+          "csvContent": "month,sales,expenses\nJan,10,5\nFeb,20,12\nMar,15,8\nApr,25,14\nMay,18,9",
+          "refId": "A",
+          "scenarioId": "csv_content"
+        }
+      ],
+      "title": "Multi Series",
+      "type": "barchart"
+    },
+    {
+      "datasource": { "type": "grafana-testdata-datasource" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineWidth": 1
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 10, "w": 12, "x": 0, "y": 10 },
+      "id": 3,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "orientation": "auto",
+        "showValue": "auto",
+        "stacking": "normal",
+        "tooltip": { "mode": "single", "sort": "none" },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "targets": [
+        {
+          "csvContent": "month,sales,expenses\nJan,10,5\nFeb,20,12\nMar,15,8\nApr,25,14\nMay,18,9",
+          "refId": "A",
+          "scenarioId": "csv_content"
+        }
+      ],
+      "title": "Stacked",
+      "type": "barchart"
+    },
+    {
+      "datasource": { "type": "grafana-testdata-datasource" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineWidth": 1
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 10, "w": 12, "x": 12, "y": 10 },
+      "id": 4,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "orientation": "horizontal",
+        "showValue": "auto",
+        "stacking": "none",
+        "tooltip": { "mode": "single", "sort": "none" },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "targets": [
+        {
+          "csvContent": "month,sales\nJan,10\nFeb,20\nMar,15\nApr,25\nMay,18",
+          "refId": "A",
+          "scenarioId": "csv_content"
+        }
+      ],
+      "title": "Horizontal",
+      "type": "barchart"
+    },
+    {
+      "datasource": { "type": "grafana-testdata-datasource" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": {
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": { "legend": false, "tooltip": false, "viz": false },
+            "lineWidth": 1
+          },
+          "links": [
+            {
+              "title": "Example Data Link",
+              "url": "https://grafana.com/docs"
+            }
+          ],
+          "actions": [
+            {
+              "fetch": {
+                "body": "{}",
+                "headers": [["Content-Type", "application/json"]],
+                "method": "GET",
+                "queryParams": [],
+                "url": "https://grafana.com"
+              },
+              "title": "Example Action",
+              "type": "fetch"
+            }
+          ]
+        },
+        "overrides": []
+      },
+      "gridPos": { "h": 10, "w": 12, "x": 0, "y": 20 },
+      "id": 5,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "orientation": "auto",
+        "showValue": "auto",
+        "stacking": "none",
+        "tooltip": { "mode": "single", "sort": "none" },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "targets": [
+        {
+          "csvContent": "month,sales\nJan,10\nFeb,20\nMar,15\nApr,25\nMay,18",
+          "refId": "A",
+          "scenarioId": "csv_content"
+        }
+      ],
+      "title": "With Data Link",
+      "type": "barchart"
+    },
+    {
+      "datasource": { "type": "grafana-testdata-datasource" },
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "gridPos": { "h": 10, "w": 12, "x": 12, "y": 20 },
+      "id": 6,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": { "calcs": [], "displayMode": "list", "placement": "bottom", "showLegend": true },
+        "orientation": "auto",
+        "showValue": "auto",
+        "stacking": "none",
+        "tooltip": { "mode": "single", "sort": "none" },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "scenarioId": "no_data_points"
+        }
+      ],
+      "title": "No Data",
+      "type": "barchart"
+    }
+  ],
+  "schemaVersion": 36,
+  "tags": ["gdev", "panel-tests", "barchart"],
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Bar Chart Tests",
+  "uid": "panel-tests-barchart",
+  "version": 1
+}

--- a/devenv/jsonnet/dev-dashboards.libsonnet
+++ b/devenv/jsonnet/dev-dashboards.libsonnet
@@ -21,6 +21,7 @@
     "barchart-series-toggle": (import '../dev-dashboards/panel-barchart/barchart-series-toggle.json'),
     "barchart-thresholds-mappings": (import '../dev-dashboards/panel-barchart/barchart-thresholds-mappings.json'),
     "barchart-tooltips-legends": (import '../dev-dashboards/panel-barchart/barchart-tooltips-legends.json'),
+    "barchart_tests": (import '../dev-dashboards/panel-barchart/barchart_tests.json'),
     "candlestick": (import '../dev-dashboards/panel-candlestick/candlestick.json'),
     "candlestick_tests": (import '../dev-dashboards/panel-candlestick/candlestick_tests.json'),
     "canvas-connection-examples": (import '../dev-dashboards/panel-canvas/canvas-connection-examples.json'),

--- a/e2e-playwright/panels-suite/barchart-datalinks.spec.ts
+++ b/e2e-playwright/panels-suite/barchart-datalinks.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from '@grafana/plugin-e2e';
+
+const DASHBOARD_UID = 'panel-tests-barchart';
+
+test.use({
+  viewport: { width: 1280, height: 2000 },
+});
+
+test.describe('Panels test: BarChart data links', { tag: ['@panels', '@barchart'] }, () => {
+  test('shows data links in pinned tooltip', async ({ gotoDashboardPage, selectors, page }) => {
+    const dashboardPage = await gotoDashboardPage({
+      uid: DASHBOARD_UID,
+      queryParams: new URLSearchParams({ editPanel: '5' }),
+    });
+
+    // wait for chart to render
+    const barchartUplot = page.locator('.uplot').first();
+    await expect(barchartUplot, 'uplot is rendered').toBeVisible();
+
+    // compute position from the data overlay area
+    const uOver = barchartUplot.locator('.u-over');
+    const box = await uOver.boundingBox();
+    if (!box) {
+      throw new Error('u-over bounding box not found');
+    }
+    const center = { x: Math.round(box.width / 2), y: Math.round(box.height / 2) };
+
+    const tooltip = dashboardPage.getByGrafanaSelector(selectors.components.Panels.Visualization.Tooltip.Wrapper);
+
+    // pin tooltip on a data point
+    await barchartUplot.hover({ position: center, force: true });
+    await expect(tooltip, 'tooltip shown on hover').toBeVisible();
+    await barchartUplot.click({ position: center, force: true });
+    await expect(
+      page.getByTestId(selectors.components.Portal.container).getByRole('button', { name: 'Close' }),
+      'tooltip pinned on click'
+    ).toBeVisible();
+
+    // pinned tooltip should contain the configured data link
+    await expect(tooltip.getByText('Example Data Link'), 'data link visible in tooltip').toBeVisible();
+
+    // pinned tooltip should contain the configured action button
+    await expect(
+      tooltip.getByRole('button', { name: 'Example Action' }),
+      'action button visible in tooltip'
+    ).toBeVisible();
+  });
+});

--- a/e2e-playwright/panels-suite/barchart-datalinks.spec.ts
+++ b/e2e-playwright/panels-suite/barchart-datalinks.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect } from '@grafana/plugin-e2e';
 
+import { getUPlotCenterPosition } from './barchart-utils';
+
 const DASHBOARD_UID = 'panel-tests-barchart';
 
 test.use({
@@ -17,13 +19,7 @@ test.describe('Panels test: BarChart data links', { tag: ['@panels', '@barchart'
     const barchartUplot = page.locator('.uplot').first();
     await expect(barchartUplot, 'uplot is rendered').toBeVisible();
 
-    // compute position from the data overlay area
-    const uOver = barchartUplot.locator('.u-over');
-    const box = await uOver.boundingBox();
-    if (!box) {
-      throw new Error('u-over bounding box not found');
-    }
-    const center = { x: Math.round(box.width / 2), y: Math.round(box.height / 2) };
+    const center = await getUPlotCenterPosition(barchartUplot);
 
     const tooltip = dashboardPage.getByGrafanaSelector(selectors.components.Panels.Visualization.Tooltip.Wrapper);
 

--- a/e2e-playwright/panels-suite/barchart-legend.spec.ts
+++ b/e2e-playwright/panels-suite/barchart-legend.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from '@grafana/plugin-e2e';
+
+const DASHBOARD_UID = 'panel-tests-barchart';
+
+test.use({
+  viewport: { width: 1280, height: 2000 },
+});
+
+test.describe('Panels test: BarChart legend', { tag: ['@panels', '@barchart'] }, () => {
+  test('legend visibility toggle', async ({ gotoDashboardPage, selectors, page }) => {
+    const dashboardPage = await gotoDashboardPage({
+      uid: DASHBOARD_UID,
+      queryParams: new URLSearchParams({ editPanel: '1' }),
+    });
+
+    // verify legend is visible by default
+    const legend = dashboardPage.getByGrafanaSelector(selectors.components.VizLayout.legend);
+    await expect(legend, 'legend is rendered').toBeVisible();
+
+    // find the visibility toggle in the Legend options group
+    const panelOptionsLegendGroup = page.getByTestId(selectors.components.OptionsGroup.group('Legend'));
+    const legendVisibilityClickableLabel = panelOptionsLegendGroup.getByText('Visibility');
+    const legendVisibilitySwitch = panelOptionsLegendGroup.getByLabel('Visibility');
+
+    // toggle visibility off and verify legend disappears
+    await expect(legendVisibilitySwitch, 'legend is enabled by default').toBeChecked();
+    await legendVisibilityClickableLabel.click();
+    await expect(legendVisibilitySwitch).not.toBeChecked({ timeout: 400 });
+    await expect(legend, 'legend is no longer visible').not.toBeVisible();
+  });
+
+  test('legend mode and placement toggles', async ({ gotoDashboardPage, selectors, page }) => {
+    const dashboardPage = await gotoDashboardPage({
+      uid: DASHBOARD_UID,
+      queryParams: new URLSearchParams({ editPanel: '1' }),
+    });
+
+    // verify legend is visible before toggling options
+    const legend = dashboardPage.getByGrafanaSelector(selectors.components.VizLayout.legend);
+    await expect(legend, 'legend is rendered').toBeVisible();
+
+    // switch mode from List to Table
+    const modeOption = dashboardPage.getByGrafanaSelector(
+      selectors.components.PanelEditor.OptionsPane.fieldLabel('Legend Mode')
+    );
+    await modeOption.getByLabel('Table').click();
+    await expect(legend, 'legend still visible after mode switch').toBeVisible();
+
+    // switch back to List
+    await modeOption.getByLabel('List').click();
+    await expect(legend, 'legend still visible after switching back').toBeVisible();
+
+    // switch placement from Bottom to Right
+    const placementOption = dashboardPage.getByGrafanaSelector(
+      selectors.components.PanelEditor.OptionsPane.fieldLabel('Legend Placement')
+    );
+    await placementOption.getByLabel('Right').click();
+    await expect(legend, 'legend still visible after placement switch').toBeVisible();
+
+    // switch back to Bottom
+    await placementOption.getByLabel('Bottom').click();
+    await expect(legend, 'legend still visible after switching back').toBeVisible();
+  });
+});

--- a/e2e-playwright/panels-suite/barchart-nodata.spec.ts
+++ b/e2e-playwright/panels-suite/barchart-nodata.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@grafana/plugin-e2e';
+
+const DASHBOARD_UID = 'panel-tests-barchart';
+
+test.use({
+  viewport: { width: 1280, height: 2000 },
+});
+
+test.describe('Panels test: BarChart no data', { tag: ['@panels', '@barchart'] }, () => {
+  test('handles no data', async ({ gotoDashboardPage, selectors }) => {
+    const dashboardPage = await gotoDashboardPage({
+      uid: DASHBOARD_UID,
+      queryParams: new URLSearchParams({ editPanel: '6' }),
+    });
+
+    // locate the panel by its title
+    const panel = dashboardPage.getByGrafanaSelector(selectors.components.Panels.Panel.title('No Data'));
+
+    // no chart should render inside this panel
+    await expect(panel.locator('.uplot'), 'no chart rendered').toHaveCount(0);
+
+    // panel should show "No data" message
+    await expect(panel.getByText('No data', { exact: true }), 'no data message visible').toBeVisible();
+  });
+});

--- a/e2e-playwright/panels-suite/barchart-options.spec.ts
+++ b/e2e-playwright/panels-suite/barchart-options.spec.ts
@@ -44,7 +44,7 @@ test.describe('Panels test: BarChart options', { tag: ['@panels', '@barchart'] }
     const barchartUplot = page.locator('.uplot').first();
     await expect(barchartUplot, 'uplot renders with stacking=percent').toBeVisible();
 
-    // stacking toggle: Normal → None → back to 100%
+    // stacking toggle: Normal → Off → back to 100%
     const stackingOption = dashboardPage.getByGrafanaSelector(
       selectors.components.PanelEditor.OptionsPane.fieldLabel('Bar chart Stacking')
     );

--- a/e2e-playwright/panels-suite/barchart-options.spec.ts
+++ b/e2e-playwright/panels-suite/barchart-options.spec.ts
@@ -1,0 +1,134 @@
+import { test, expect } from '@grafana/plugin-e2e';
+
+const DASHBOARD_UID = 'panel-tests-barchart';
+
+test.use({
+  viewport: { width: 1280, height: 2000 },
+});
+
+test.describe('Panels test: BarChart options', { tag: ['@panels', '@barchart'] }, () => {
+  test('show values - toggle always/never/auto', async ({ gotoDashboardPage, selectors, page }) => {
+    const dashboardPage = await gotoDashboardPage({
+      uid: DASHBOARD_UID,
+      queryParams: new URLSearchParams({ editPanel: '7' }),
+    });
+
+    const barchartUplot = page.locator('.uplot').first();
+    await expect(barchartUplot, 'uplot renders with showValue=always').toBeVisible();
+
+    const showValuesOption = dashboardPage.getByGrafanaSelector(
+      selectors.components.PanelEditor.OptionsPane.fieldLabel('Bar chart Show values')
+    );
+    await showValuesOption.scrollIntoViewIfNeeded();
+
+    // switch to Never — panel still renders
+    await showValuesOption.getByLabel('Never').click();
+    await expect(barchartUplot, 'uplot renders after switching to Never').toBeVisible();
+
+    // switch to Auto — panel still renders
+    await showValuesOption.getByLabel('Auto').click();
+    await expect(barchartUplot, 'uplot renders after switching to Auto').toBeVisible();
+
+    const errorInfo = dashboardPage.getByGrafanaSelector(selectors.components.Panels.Panel.headerCornerInfo('error'));
+    await expect(errorInfo, 'no errors after toggling show values').toBeHidden();
+  });
+
+  test('stacking 100 percent - renders and shows tooltip', async ({ gotoDashboardPage, selectors, page }) => {
+    const dashboardPage = await gotoDashboardPage({
+      uid: DASHBOARD_UID,
+      queryParams: new URLSearchParams({ editPanel: '8' }),
+    });
+
+    const barchartUplot = page.locator('.uplot').first();
+    await expect(barchartUplot, 'uplot renders with stacking=percent').toBeVisible();
+
+    // stacking toggle: Normal → None → back to 100%
+    const stackingOption = dashboardPage.getByGrafanaSelector(
+      selectors.components.PanelEditor.OptionsPane.fieldLabel('Bar chart Stacking')
+    );
+    await stackingOption.scrollIntoViewIfNeeded();
+
+    await stackingOption.getByLabel('Normal').click();
+    await expect(barchartUplot, 'uplot renders with Normal stacking').toBeVisible();
+
+    await stackingOption.scrollIntoViewIfNeeded();
+    await stackingOption.getByLabel('Off').click();
+    await expect(barchartUplot, 'uplot renders with None stacking').toBeVisible();
+
+    await stackingOption.scrollIntoViewIfNeeded();
+    await stackingOption.getByLabel('100%').click();
+    await expect(barchartUplot, 'uplot renders with 100% stacking').toBeVisible();
+
+    const errorInfo = dashboardPage.getByGrafanaSelector(selectors.components.Panels.Panel.headerCornerInfo('error'));
+    await expect(errorInfo, 'no errors after toggling stacking').toBeHidden();
+
+    // tooltip works in 100% stacking mode — do this last so Escape doesn't exit editor
+    const uOver = barchartUplot.locator('.u-over');
+    const box = await uOver.boundingBox();
+    if (!box) {
+      throw new Error('u-over bounding box not found');
+    }
+    const center = { x: Math.round(box.width / 2), y: Math.round(box.height / 2) };
+    const tooltip = dashboardPage.getByGrafanaSelector(selectors.components.Panels.Visualization.Tooltip.Wrapper);
+    await barchartUplot.hover({ position: center, force: true });
+    await expect(tooltip, 'tooltip appears on hover with stacking 100%').toBeVisible();
+  });
+
+  test('full highlight - tooltip appears across bar column', async ({ gotoDashboardPage, selectors, page }) => {
+    const dashboardPage = await gotoDashboardPage({
+      uid: DASHBOARD_UID,
+      queryParams: new URLSearchParams({ editPanel: '9' }),
+    });
+
+    const barchartUplot = page.locator('.uplot').first();
+    await expect(barchartUplot, 'uplot renders with fullHighlight=true').toBeVisible();
+
+    // full highlight toggle visible in pane (only shown when stacking=none)
+    const fullHighlightField = dashboardPage.getByGrafanaSelector(
+      selectors.components.PanelEditor.OptionsPane.fieldLabel('Bar chart Highlight full area on hover')
+    );
+    await fullHighlightField.scrollIntoViewIfNeeded();
+    const fullHighlightSwitch = fullHighlightField.getByRole('switch');
+    await expect(fullHighlightSwitch, 'full highlight toggle is visible').toBeVisible();
+    await expect(fullHighlightSwitch, 'full highlight is enabled').toBeChecked();
+
+    // tooltip appears when hovering
+    const uOver = barchartUplot.locator('.u-over');
+    const box = await uOver.boundingBox();
+    if (!box) {
+      throw new Error('u-over bounding box not found');
+    }
+    const center = { x: Math.round(box.width / 2), y: Math.round(box.height / 2) };
+
+    // tooltip works with full highlight — do this last so Escape doesn't exit editor
+    const tooltip = dashboardPage.getByGrafanaSelector(selectors.components.Panels.Visualization.Tooltip.Wrapper);
+    await barchartUplot.hover({ position: center, force: true });
+    await expect(tooltip, 'tooltip appears on hover with full highlight enabled').toBeVisible();
+  });
+
+  test('orientation - toggle vertical and horizontal', async ({ gotoDashboardPage, selectors, page }) => {
+    const dashboardPage = await gotoDashboardPage({
+      uid: DASHBOARD_UID,
+      queryParams: new URLSearchParams({ editPanel: '1' }),
+    });
+
+    const barchartUplot = page.locator('.uplot').first();
+    await expect(barchartUplot, 'uplot renders in auto orientation').toBeVisible();
+
+    const orientationOption = dashboardPage.getByGrafanaSelector(
+      selectors.components.PanelEditor.OptionsPane.fieldLabel('Bar chart Orientation')
+    );
+
+    await orientationOption.getByLabel('Horizontal').click();
+    await expect(barchartUplot, 'uplot renders in horizontal orientation').toBeVisible();
+
+    await orientationOption.getByLabel('Vertical').click();
+    await expect(barchartUplot, 'uplot renders in vertical orientation').toBeVisible();
+
+    await orientationOption.getByLabel('Auto').click();
+    await expect(barchartUplot, 'uplot renders back in auto orientation').toBeVisible();
+
+    const errorInfo = dashboardPage.getByGrafanaSelector(selectors.components.Panels.Panel.headerCornerInfo('error'));
+    await expect(errorInfo, 'no errors after toggling orientation').toBeHidden();
+  });
+});

--- a/e2e-playwright/panels-suite/barchart-options.spec.ts
+++ b/e2e-playwright/panels-suite/barchart-options.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect } from '@grafana/plugin-e2e';
 
+import { getUPlotCenterPosition } from './barchart-utils';
+
 const DASHBOARD_UID = 'panel-tests-barchart';
 
 test.use({
@@ -63,12 +65,7 @@ test.describe('Panels test: BarChart options', { tag: ['@panels', '@barchart'] }
     await expect(errorInfo, 'no errors after toggling stacking').toBeHidden();
 
     // tooltip works in 100% stacking mode — do this last so Escape doesn't exit editor
-    const uOver = barchartUplot.locator('.u-over');
-    const box = await uOver.boundingBox();
-    if (!box) {
-      throw new Error('u-over bounding box not found');
-    }
-    const center = { x: Math.round(box.width / 2), y: Math.round(box.height / 2) };
+    const center = await getUPlotCenterPosition(barchartUplot);
     const tooltip = dashboardPage.getByGrafanaSelector(selectors.components.Panels.Visualization.Tooltip.Wrapper);
     await barchartUplot.hover({ position: center, force: true });
     await expect(tooltip, 'tooltip appears on hover with stacking 100%').toBeVisible();
@@ -92,15 +89,8 @@ test.describe('Panels test: BarChart options', { tag: ['@panels', '@barchart'] }
     await expect(fullHighlightSwitch, 'full highlight toggle is visible').toBeVisible();
     await expect(fullHighlightSwitch, 'full highlight is enabled').toBeChecked();
 
-    // tooltip appears when hovering
-    const uOver = barchartUplot.locator('.u-over');
-    const box = await uOver.boundingBox();
-    if (!box) {
-      throw new Error('u-over bounding box not found');
-    }
-    const center = { x: Math.round(box.width / 2), y: Math.round(box.height / 2) };
-
     // tooltip works with full highlight — do this last so Escape doesn't exit editor
+    const center = await getUPlotCenterPosition(barchartUplot);
     const tooltip = dashboardPage.getByGrafanaSelector(selectors.components.Panels.Visualization.Tooltip.Wrapper);
     await barchartUplot.hover({ position: center, force: true });
     await expect(tooltip, 'tooltip appears on hover with full highlight enabled').toBeVisible();

--- a/e2e-playwright/panels-suite/barchart-render.spec.ts
+++ b/e2e-playwright/panels-suite/barchart-render.spec.ts
@@ -10,9 +10,9 @@ test.describe('Panels test: BarChart render', { tag: ['@panels', '@barchart'] },
   test('renders successfully', async ({ gotoDashboardPage, selectors, page }) => {
     const dashboardPage = await gotoDashboardPage({ uid: DASHBOARD_UID });
 
-    // 5 panels with data render uplot; the no-data panel does not
+    // 8 panels with data render uplot; the no-data panel does not
     const uplotElements = page.locator('.uplot');
-    await expect(uplotElements, 'panels are rendered').toHaveCount(5);
+    await expect(uplotElements, 'panels are rendered').toHaveCount(8);
 
     // no panel should show an error icon
     const errorInfo = dashboardPage.getByGrafanaSelector(selectors.components.Panels.Panel.headerCornerInfo('error'));

--- a/e2e-playwright/panels-suite/barchart-render.spec.ts
+++ b/e2e-playwright/panels-suite/barchart-render.spec.ts
@@ -1,0 +1,21 @@
+import { test, expect } from '@grafana/plugin-e2e';
+
+const DASHBOARD_UID = 'panel-tests-barchart';
+
+test.use({
+  viewport: { width: 1280, height: 2000 },
+});
+
+test.describe('Panels test: BarChart render', { tag: ['@panels', '@barchart'] }, () => {
+  test('renders successfully', async ({ gotoDashboardPage, selectors, page }) => {
+    const dashboardPage = await gotoDashboardPage({ uid: DASHBOARD_UID });
+
+    // 5 panels with data render uplot; the no-data panel does not
+    const uplotElements = page.locator('.uplot');
+    await expect(uplotElements, 'panels are rendered').toHaveCount(5);
+
+    // no panel should show an error icon
+    const errorInfo = dashboardPage.getByGrafanaSelector(selectors.components.Panels.Panel.headerCornerInfo('error'));
+    await expect(errorInfo, 'no errors in the panels').toBeHidden();
+  });
+});

--- a/e2e-playwright/panels-suite/barchart-tooltips.spec.ts
+++ b/e2e-playwright/panels-suite/barchart-tooltips.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect } from '@grafana/plugin-e2e';
 
+import { getUPlotCenterPosition } from './barchart-utils';
+
 const DASHBOARD_UID = 'panel-tests-barchart';
 
 test.use({
@@ -16,14 +18,8 @@ test.describe('Panels test: BarChart tooltips', { tag: ['@panels', '@barchart'] 
     const barchartUplot = page.locator('.uplot').first();
     await expect(barchartUplot, 'uplot is rendered').toBeVisible();
 
-    // compute positions from the data overlay area
-    const uOver = barchartUplot.locator('.u-over');
-    const box = await uOver.boundingBox();
-    if (!box) {
-      throw new Error('u-over bounding box not found');
-    }
-    const center = { x: Math.round(box.width / 2), y: Math.round(box.height / 2) };
-    const alt = { x: Math.round(box.width / 4), y: center.y };
+    const center = await getUPlotCenterPosition(barchartUplot);
+    const alt = { x: Math.round(center.x / 2), y: center.y };
 
     const tooltip = dashboardPage.getByGrafanaSelector(selectors.components.Panels.Visualization.Tooltip.Wrapper);
 

--- a/e2e-playwright/panels-suite/barchart-tooltips.spec.ts
+++ b/e2e-playwright/panels-suite/barchart-tooltips.spec.ts
@@ -1,0 +1,76 @@
+import { test, expect } from '@grafana/plugin-e2e';
+
+const DASHBOARD_UID = 'panel-tests-barchart';
+
+test.use({
+  viewport: { width: 1280, height: 2000 },
+});
+
+test.describe('Panels test: BarChart tooltips', { tag: ['@panels', '@barchart'] }, () => {
+  test('tooltip interactions', async ({ gotoDashboardPage, page, selectors }) => {
+    const dashboardPage = await gotoDashboardPage({
+      uid: DASHBOARD_UID,
+      queryParams: new URLSearchParams({ editPanel: '1' }),
+    });
+
+    const barchartUplot = page.locator('.uplot').first();
+    await expect(barchartUplot, 'uplot is rendered').toBeVisible();
+
+    // compute positions from the data overlay area
+    const uOver = barchartUplot.locator('.u-over');
+    const box = await uOver.boundingBox();
+    if (!box) {
+      throw new Error('u-over bounding box not found');
+    }
+    const center = { x: Math.round(box.width / 2), y: Math.round(box.height / 2) };
+    const alt = { x: Math.round(box.width / 4), y: center.y };
+
+    const tooltip = dashboardPage.getByGrafanaSelector(selectors.components.Panels.Visualization.Tooltip.Wrapper);
+
+    // hover to trigger tooltip — force bypasses any overlay elements
+    await barchartUplot.hover({ position: center, force: true });
+    await expect(tooltip, 'tooltip appears on hover').toBeVisible();
+
+    // click to pin, hover away to verify pinning
+    await barchartUplot.click({ position: center, force: true });
+    await barchartUplot.hover({ position: alt, force: true });
+    await expect(tooltip, 'tooltip pinned on click').toBeVisible();
+
+    // unpin by clicking elsewhere
+    await barchartUplot.click({ position: alt, force: true });
+    await barchartUplot.blur();
+    await expect(tooltip, 'tooltip closed after unpinning').toBeHidden();
+
+    // close via X button
+    await barchartUplot.click({ position: center, force: true });
+    await expect(tooltip, 'tooltip appears on click').toBeVisible();
+    await dashboardPage.getByGrafanaSelector(selectors.components.Portal.container).getByLabel('Close').click();
+    await expect(tooltip, 'tooltip closed on X click').toBeHidden();
+
+    // CMD/CTRL+C does not dismiss
+    await barchartUplot.click({ position: center, force: true });
+    await expect(tooltip, 'tooltip appears on click').toBeVisible();
+    await page.keyboard.press('ControlOrMeta+C');
+    await expect(tooltip, 'tooltip persists after CMD/CTRL+C').toBeVisible();
+
+    // Escape key dismisses
+    await page.keyboard.press('Escape');
+    await expect(tooltip, 'tooltip closed on Escape').toBeHidden();
+
+    // switch to All mode — tooltip should still appear
+    const tooltipModeOption = dashboardPage.getByGrafanaSelector(
+      selectors.components.PanelEditor.OptionsPane.fieldLabel('Tooltip Tooltip mode')
+    );
+    await tooltipModeOption.getByLabel('All').click();
+    await barchartUplot.hover({ position: center, force: true });
+    await expect(tooltip, 'tooltip appears in All mode').toBeVisible();
+
+    // dismiss tooltip before switching mode
+    await page.keyboard.press('Escape');
+
+    // switch to Hidden — tooltip should not appear
+    await tooltipModeOption.getByLabel('Hidden').click();
+    await barchartUplot.hover({ position: center, force: true });
+    await expect(tooltip, 'tooltip not shown when disabled').toBeHidden();
+  });
+});

--- a/e2e-playwright/panels-suite/barchart-utils.ts
+++ b/e2e-playwright/panels-suite/barchart-utils.ts
@@ -1,0 +1,10 @@
+import { type Locator } from '@playwright/test';
+
+export async function getUPlotCenterPosition(uplotLocator: Locator): Promise<{ x: number; y: number }> {
+  const uOver = uplotLocator.locator('.u-over');
+  const box = await uOver.boundingBox();
+  if (!box) {
+    throw new Error('u-over bounding box not found');
+  }
+  return { x: Math.round(box.width / 2), y: Math.round(box.height / 2) };
+}

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -3375,6 +3375,16 @@
       "count": 1
     }
   },
+  "public/app/plugins/datasource/prometheus/configuration/AzureAuthSettings.tsx": {
+    "@grafana/no-gf-form": {
+      "count": 1
+    }
+  },
+  "public/app/plugins/datasource/prometheus/configuration/AzureCredentialsForm.tsx": {
+    "@grafana/no-gf-form": {
+      "count": 15
+    }
+  },
   "public/app/plugins/datasource/tempo/QueryField.tsx": {
     "react-prefer-function-component/react-prefer-function-component": {
       "count": 1

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -3375,16 +3375,6 @@
       "count": 1
     }
   },
-  "public/app/plugins/datasource/prometheus/configuration/AzureAuthSettings.tsx": {
-    "@grafana/no-gf-form": {
-      "count": 1
-    }
-  },
-  "public/app/plugins/datasource/prometheus/configuration/AzureCredentialsForm.tsx": {
-    "@grafana/no-gf-form": {
-      "count": 15
-    }
-  },
   "public/app/plugins/datasource/tempo/QueryField.tsx": {
     "react-prefer-function-component/react-prefer-function-component": {
       "count": 1


### PR DESCRIPTION
Add E2E test coverage for the Bar chart panel plugin.

Ref #112986

## Summary

### Tests
- 11 new E2E tests across 6 spec files
- Covers rendering, no-data, tooltips, legend, data links and actions, and panel options (show values, stacking, full highlight, orientation)

### Dashboard
- New test dashboard `devenv/dev-dashboards/panel-barchart/barchart_tests.json` with 9 panels
- Each panel exercises a different bar chart configuration (series count, stacking, orientation, data links, no data, show values, full highlight)

### Stability
- Hover positions computed from `.u-over` boundingBox instead of hardcoded offsets
- Shared `getUPlotCenterPosition` helper in `barchart-utils.ts` removes duplication across specs
- Uses `ControlOrMeta+C` for cross-platform keyboard shortcuts (candlestick, state-timeline, and status-history still use `Meta+C` — follow-up)
- `scrollIntoViewIfNeeded` before toggling options below the viewport fold
- Options toggles ordered before tooltip interactions so `Escape` dismissing tooltip does not also exit the panel editor

### Infrastructure
- `apps/dashboard/pkg/migration/testdata/golden_checksums.json` — migration checksum for `barchart_tests.v42.json`
- `devenv/jsonnet/dev-dashboards.libsonnet` — register dashboard for backend config validation

### E2E test specs (new)
| File | Test | Panel | What it verifies |
|------|------|-------|-----------------|
| `barchart-datalinks.spec.ts` | shows data links in pinned tooltip | 5 - With Data Link | Data link text and action button visible |
| `barchart-legend.spec.ts` | legend visibility toggle | 1 - Single Series | Toggle on/off via options pane |
| `barchart-legend.spec.ts` | legend mode and placement toggles | 1 - Single Series | List/Table mode, Bottom/Right placement |
| `barchart-nodata.spec.ts` | handles no data | 6 - No Data | No chart rendered, "No data" message visible |
| `barchart-options.spec.ts` | show values - toggle always/never/auto | 7 - Show Values Always | Show values radio Never/Auto toggle, panel still renders |
| `barchart-options.spec.ts` | stacking 100 percent - renders and shows tooltip | 8 - Stacked 100 Percent | Normal/Off/100% stacking toggle, tooltip in 100% mode |
| `barchart-options.spec.ts` | full highlight - tooltip appears across bar column | 9 - Full Highlight | Switch enabled, tooltip appears on hover |
| `barchart-options.spec.ts` | orientation - toggle vertical and horizontal | 1 - Single Series | Horizontal/Vertical/Auto orientation toggle |
| `barchart-render.spec.ts` | renders successfully | All 9 | 8 uplot charts render, no error icons |
| `barchart-tooltips.spec.ts` | tooltip interactions | 1 - Single Series | Hover, pin/unpin, X close, Escape, Cmd+C persist, All mode, Hidden mode |

### Test dashboard (`panel-tests-barchart`)
| ID | Title | Series | Stacking | Orientation | Show values | Full Highlight | Data Links | Actions |
|----|-------|--------|----------|-------------|-------------|----------------|------------|---------|
| 1 | Single Series | 1 | none | auto | auto | no | no | no |
| 2 | Multi Series | 2 | none | auto | auto | no | no | no |
| 3 | Stacked | 2 | normal | auto | auto | no | no | no |
| 4 | Horizontal | 1 | none | horizontal | auto | no | no | no |
| 5 | With Data Link | 1 | none | auto | auto | no | yes | yes |
| 6 | No Data | — | none | auto | auto | no | no | no |
| 7 | Show Values Always | 1 | none | auto | always | no | no | no |
| 8 | Stacked 100 Percent | 2 | percent | auto | auto | no | no | no |
| 9 | Full Highlight | 1 | none | auto | auto | yes | no | no |

## Test plan
- [x] All 11 bar chart E2E tests pass locally against Grafana on \`localhost:3001\`
- [ ] Golden file checksum validates (migration)
- [ ] Jsonnet backend config validation passes
- [ ] Lint passes
- [ ] No regressions in other panel E2E tests
- [ ] Dashboard loads correctly in dev environment