### PR TITLE
Dashboards: fix type-check in LegacyVariableWrapper.getValue() to preserve multi-value arrays

### DIFF
--- a/public/app/features/templating/LegacyVariableWrapper.test.ts
+++ b/public/app/features/templating/LegacyVariableWrapper.test.ts
@@ -1,0 +1,62 @@
+import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from '../variables/constants';
+
+import { LegacyVariableWrapper } from './LegacyVariableWrapper';
+
+const makeVariable = (name = 'test', type = 'query') => ({ name, type } as any);
+
+describe('LegacyVariableWrapper', () => {
+  describe('getValue', () => {
+    it('returns a string value as-is', () => {
+      const wrapper = new LegacyVariableWrapper(makeVariable(), 'server1', 'server1');
+      expect(wrapper.getValue('')).toBe('server1');
+    });
+
+    it('returns a number value as-is', () => {
+      const wrapper = new LegacyVariableWrapper(makeVariable(), 42, '42');
+      expect(wrapper.getValue('')).toBe(42);
+    });
+
+    it('returns a boolean value as-is', () => {
+      const wrapper = new LegacyVariableWrapper(makeVariable(), true, 'true');
+      expect(wrapper.getValue('')).toBe(true);
+    });
+
+    it('returns an array as-is without coercing to string', () => {
+      const value = ['server1', 'server2'];
+      const wrapper = new LegacyVariableWrapper(makeVariable(), value, value);
+      expect(wrapper.getValue('')).toEqual(['server1', 'server2']);
+      expect(Array.isArray(wrapper.getValue(''))).toBe(true);
+    });
+
+    it('does not join array values into a comma-separated string', () => {
+      const value = ['a', 'b', 'c'];
+      const wrapper = new LegacyVariableWrapper(makeVariable(), value, value);
+      expect(wrapper.getValue('')).not.toBe('a,b,c');
+    });
+  });
+
+  describe('getValueText', () => {
+    it('returns text when text is a string', () => {
+      const wrapper = new LegacyVariableWrapper(makeVariable(), 'server1', 'Server 1');
+      expect(wrapper.getValueText()).toBe('Server 1');
+    });
+
+    it('returns ALL_VARIABLE_TEXT when value is ALL_VARIABLE_VALUE', () => {
+      const wrapper = new LegacyVariableWrapper(makeVariable(), ALL_VARIABLE_VALUE, 'All');
+      expect(wrapper.getValueText()).toBe(ALL_VARIABLE_TEXT);
+    });
+
+    it('joins array text values with " + "', () => {
+      const wrapper = new LegacyVariableWrapper(makeVariable(), ['s1', 's2'], ['Server 1', 'Server 2']);
+      expect(wrapper.getValueText()).toBe('Server 1 + Server 2');
+    });
+
+    it('falls back to String() for non-string non-array text without logging', () => {
+      const spy = jest.spyOn(console, 'log');
+      const wrapper = new LegacyVariableWrapper(makeVariable(), 99, 99 as any);
+      expect(wrapper.getValueText()).toBe('99');
+      expect(spy).not.toHaveBeenCalled();
+      spy.mockRestore();
+    });
+  });
+});

--- a/public/app/features/templating/LegacyVariableWrapper.test.ts
+++ b/public/app/features/templating/LegacyVariableWrapper.test.ts
@@ -1,8 +1,10 @@
+import { type VariableModel } from '@grafana/schema';
+
 import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from '../variables/constants';
 
 import { LegacyVariableWrapper } from './LegacyVariableWrapper';
 
-const makeVariable = (name = 'test', type = 'query') => ({ name, type }) as any;
+const makeVariable = (name = 'test', type = 'query') => ({ name, type }) as unknown as VariableModel;
 
 describe('LegacyVariableWrapper', () => {
   describe('getValue', () => {
@@ -53,7 +55,7 @@ describe('LegacyVariableWrapper', () => {
 
     it('falls back to String() for non-string non-array text without logging', () => {
       const spy = jest.spyOn(console, 'log');
-      const wrapper = new LegacyVariableWrapper(makeVariable(), 99, 99 as any);
+      const wrapper = new LegacyVariableWrapper(makeVariable(), 99, 99 as unknown as string);
       expect(wrapper.getValueText()).toBe('99');
       expect(spy).not.toHaveBeenCalled();
       spy.mockRestore();

--- a/public/app/features/templating/LegacyVariableWrapper.test.ts
+++ b/public/app/features/templating/LegacyVariableWrapper.test.ts
@@ -2,7 +2,7 @@ import { ALL_VARIABLE_TEXT, ALL_VARIABLE_VALUE } from '../variables/constants';
 
 import { LegacyVariableWrapper } from './LegacyVariableWrapper';
 
-const makeVariable = (name = 'test', type = 'query') => ({ name, type } as any);
+const makeVariable = (name = 'test', type = 'query') => ({ name, type }) as any;
 
 describe('LegacyVariableWrapper', () => {
   describe('getValue', () => {

--- a/public/app/features/templating/LegacyVariableWrapper.ts
+++ b/public/app/features/templating/LegacyVariableWrapper.ts
@@ -11,13 +11,13 @@ export class LegacyVariableWrapper implements FormatVariable {
   }
 
   getValue(_fieldPath: string): VariableValue {
-    let { value } = this.state;
+    const { value } = this.state;
 
-    if (value === 'string' || value === 'number' || value === 'boolean') {
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
       return value;
     }
 
-    return String(value);
+    return value;
   }
 
   getValueText(): string {
@@ -31,7 +31,6 @@ export class LegacyVariableWrapper implements FormatVariable {
       return text.join(' + ');
     }
 
-    console.log('value', text);
     return String(text);
   }
 }

--- a/public/app/features/templating/LegacyVariableWrapper.ts
+++ b/public/app/features/templating/LegacyVariableWrapper.ts
@@ -11,13 +11,7 @@ export class LegacyVariableWrapper implements FormatVariable {
   }
 
   getValue(_fieldPath: string): VariableValue {
-    const { value } = this.state;
-
-    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
-      return value;
-    }
-
-    return value;
+    return this.state.value;
   }
 
   getValueText(): string {


### PR DESCRIPTION
**What is this feature?**

This is a bug fix. `LegacyVariableWrapper.getValue()` had a guard condition that compared `value` against the string literals `'string'`, `'number'`, and `'boolean'` instead of using `typeof`. The condition was effectively dead code, causing every value to fall through to `String(value)`. For multi-value variables where `value` is an array, this silently coerced `['server1', 'server2']` into `'server1,server2'`.

Also removes a stray `console.log` from `getValueText()` that fired in production whenever `text` was not a string or array.

**Why do we need this feature?**

Multi-value variables passed through `getValue()` were being returned as comma-joined strings instead of arrays. Any custom formatter or data source plugin that calls `getValue()` and expects an array for multi-value variables would silently receive a string instead, causing queries to produce wrong results without any visible error. This class also had zero test coverage, which is why the bug went undetected.

**Who is this feature for?**

Anyone using multi-value dashboard variables with custom formatters or data source plugins that rely on the Scenes `FormatVariable` interface.

**Which issue(s) does this PR fix?**

Fixes #123273

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.

Two files changed:
- `public/app/features/templating/LegacyVariableWrapper.ts` — the fix
- `public/app/features/templating/LegacyVariableWrapper.test.ts` — new test file, 8 test cases, all passing. This class had no tests before this PR.
