### PR TITLE
Explore: remove debug console.log from query scanning loop

### DIFF
--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -657,7 +657,6 @@ export const runQueries = createAsyncThunk<void, RunQueriesOptions>(
 
           // Keep scanning for results if this was the last scanning transaction
           if (exploreState!.scanning) {
-            console.log(data.series);
             if (data.state === LoadingState.Done && data.series.length === 0) {
               const range = getShiftedTimeRange(-1, exploreState!.range);
               dispatch(updateTime({ exploreId, absoluteRange: range }));


### PR DESCRIPTION
**What is this feature?**

Bug fix. A `console.log(data.series)` statement was left in the Explore scanning loop inside `runQueries`. It fired on every query response tick while scanning mode was active, dumping the full data series array to the browser console.

**Why do we need this feature?**

During an Explore scanning session, queries run in a continuous loop shifting the time range backwards. The debug log fired on every single response, flooding the browser console and adding unnecessary serialization overhead for potentially large data frames. Any developer debugging Explore would have their console unusable during scanning.

**Who is this feature for?**

Anyone using the Explore log scanning feature. Also affects developers debugging Explore query behavior.

**Which issue(s) does this PR fix?**

Fixes #123274

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.

One line removed from `public/app/features/explore/state/query.ts`. The surrounding scan logic — checking `data.state` and `data.series.length` to decide whether to continue or stop scanning — is completely untouched.
