### PR TITLE
Folders: Remove redundant RBAC check from FolderService.Get()

### DIFF
--- a/pkg/services/folder/folderimpl/folder.go
+++ b/pkg/services/folder/folderimpl/folder.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel/trace"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	dashboardv1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
 	folderv1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
@@ -296,6 +297,10 @@ func SplitFullpath(s string) []string {
 }
 
 func toFolderError(err error) error {
+	if apierrors.IsForbidden(err) {
+		return folder.ErrAccessDenied
+	}
+
 	if errors.Is(err, dashboards.ErrDashboardTitleEmpty) {
 		return folder.ErrTitleEmpty
 	}

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage.go
@@ -116,14 +116,6 @@ func (s *Service) Get(ctx context.Context, q *folder.GetFolderQuery) (*folder.Fo
 		return dashFolder, nil
 	}
 
-	evaluator := accesscontrol.EvalPermission(folder.ActionFoldersRead, folder.ScopeFoldersProvider.GetResourceScopeUID(dashFolder.UID))
-	if canView, err := s.accessControl.Evaluate(ctx, q.SignedInUser, evaluator); err != nil || !canView {
-		if err != nil {
-			return nil, toFolderError(err)
-		}
-		return nil, folder.ErrAccessDenied
-	}
-
 	// nolint:staticcheck
 	if q.ID != nil {
 		q.ID = nil

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage.go
@@ -124,7 +124,6 @@ func (s *Service) Get(ctx context.Context, q *folder.GetFolderQuery) (*folder.Fo
 		return nil, folder.ErrAccessDenied
 	}
 
-	metrics.MFolderIDsServiceCount.WithLabelValues(metrics.Folder).Inc()
 	// nolint:staticcheck
 	if q.ID != nil {
 		q.ID = nil

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
@@ -163,14 +163,13 @@ func TestIntegrationFolderServiceViaUnifiedStorage(t *testing.T) {
 	mux.HandleFunc("GET /apis/folder.grafana.app/v1/namespaces/default/folders/forbidden", func(w http.ResponseWriter, req *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(http.StatusForbidden)
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"kind":       "Status",
-			"apiVersion": "v1",
-			"status":     "Failure",
-			"message":    `folders "forbidden" is forbidden: access denied`,
-			"reason":     "Forbidden",
-			"code":       403,
-		})
+		_ = json.NewEncoder(w).Encode(`{
+										"kind": "Status",
+										"apiVersion": "v1",
+										"metadata": {},
+										"status": "Failure",
+										"code": 403
+										}`)
 	})
 
 	mux.HandleFunc("GET /apis/folder.grafana.app/v1/namespaces/default/folders/not-foo", func(w http.ResponseWriter, req *http.Request) {

--- a/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
+++ b/pkg/services/folder/folderimpl/folder_unifiedstorage_test.go
@@ -160,6 +160,19 @@ func TestIntegrationFolderServiceViaUnifiedStorage(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	mux.HandleFunc("GET /apis/folder.grafana.app/v1/namespaces/default/folders/forbidden", func(w http.ResponseWriter, req *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusForbidden)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"kind":       "Status",
+			"apiVersion": "v1",
+			"status":     "Failure",
+			"message":    `folders "forbidden" is forbidden: access denied`,
+			"reason":     "Forbidden",
+			"code":       403,
+		})
+	})
+
 	mux.HandleFunc("GET /apis/folder.grafana.app/v1/namespaces/default/folders/not-foo", func(w http.ResponseWriter, req *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		namespacer := func(_ int64) string { return "1" }
@@ -300,7 +313,7 @@ func TestIntegrationFolderServiceViaUnifiedStorage(t *testing.T) {
 			ctx = identity.WithRequester(context.Background(), noPermUsr)
 
 			f := folder.NewFolder("Folder", "")
-			f.UID = "foo"
+			f.UID = "forbidden"
 
 			t.Run("When get folder by id should return access denied error", func(t *testing.T) {
 				_, err := folderService.Get(ctx, &folder.GetFolderQuery{

--- a/pkg/services/libraryelements/libraryelements_permissions_test.go
+++ b/pkg/services/libraryelements/libraryelements_permissions_test.go
@@ -195,7 +195,7 @@ func TestIntegrationLibraryElementGranularPermissions(t *testing.T) {
 		})
 
 		t.Run("When viewer doesn't have read access to folder2, they cannot move library element to folder2", func(t *testing.T) {
-			patchLibraryElement(t, grafanaListedAddr, "granular-viewer", "granular-viewer", uid, folder2UID, http.StatusBadRequest)
+			patchLibraryElement(t, grafanaListedAddr, "granular-viewer", "granular-viewer", uid, folder2UID, http.StatusForbidden)
 		})
 	})
 

--- a/pkg/storage/unified/resource/server_test.go
+++ b/pkg/storage/unified/resource/server_test.go
@@ -1511,4 +1511,59 @@ func TestNewEventPermissionChecks(t *testing.T) {
 		require.NoError(t, err)
 		require.Nil(t, rsp.Error)
 	})
+
+	t.Run("read is denied when user lacks get permission", func(t *testing.T) {
+		ac := &callbackAccessClient{}
+		srv := createThenSwitch(t, makeValue(""), ac)
+
+		ac.fn = func(_ authlib.CheckRequest, _ string) (authlib.CheckResponse, error) { return deny() }
+
+		rsp, err := srv.Read(ctx, &resourcepb.ReadRequest{Key: key})
+		require.NoError(t, err)
+		require.NotNil(t, rsp.Error)
+		require.Equal(t, int32(http.StatusForbidden), rsp.Error.Code)
+	})
+
+	t.Run("read is allowed when user has get permission", func(t *testing.T) {
+		ac := &callbackAccessClient{}
+		srv := createThenSwitch(t, makeValue(""), ac)
+
+		ac.fn = func(_ authlib.CheckRequest, _ string) (authlib.CheckResponse, error) { return allow() }
+
+		rsp, err := srv.Read(ctx, &resourcepb.ReadRequest{Key: key})
+		require.NoError(t, err)
+		require.Nil(t, rsp.Error)
+		require.NotNil(t, rsp.Value)
+	})
+
+	t.Run("read passes the resource folder to the access check", func(t *testing.T) {
+		ac := &callbackAccessClient{}
+		srv := createThenSwitch(t, makeValue(folderA), ac)
+
+		var capturedFolder string
+		ac.fn = func(req authlib.CheckRequest, folder string) (authlib.CheckResponse, error) {
+			if req.Verb == "get" {
+				capturedFolder = folder
+			}
+			return allow()
+		}
+
+		rsp, err := srv.Read(ctx, &resourcepb.ReadRequest{Key: key})
+		require.NoError(t, err)
+		require.Nil(t, rsp.Error)
+		require.Equal(t, folderA, capturedFolder)
+	})
+
+	t.Run("read returns error when access check fails", func(t *testing.T) {
+		ac := &callbackAccessClient{}
+		srv := createThenSwitch(t, makeValue(""), ac)
+
+		ac.fn = func(_ authlib.CheckRequest, _ string) (authlib.CheckResponse, error) {
+			return authlib.CheckResponse{}, errors.New("authz service unavailable")
+		}
+
+		rsp, err := srv.Read(ctx, &resourcepb.ReadRequest{Key: key})
+		require.NoError(t, err)
+		require.NotNil(t, rsp.Error)
+	})
 }

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/blevesearch/bleve/v2"
+	authlib "github.com/grafana/authlib/types"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
@@ -793,4 +794,127 @@ func selectableFieldQuery(key *resourcepb.ResourceKey, field, value string) *res
 		},
 		Limit: 100000,
 	}
+}
+
+// testAccessClient is a simple access client for testing that allows access
+// only to resources in the specified folders. An empty allowedFolders set
+// means access is denied to everything.
+type testAccessClient struct {
+	allowedFolders map[string]bool
+}
+
+func (c *testAccessClient) Check(_ context.Context, _ authlib.AuthInfo, req authlib.CheckRequest, folder string) (authlib.CheckResponse, error) {
+	return authlib.CheckResponse{Allowed: c.allowedFolders[folder], Zookie: authlib.NoopZookie{}}, nil
+}
+
+func (c *testAccessClient) Compile(_ context.Context, _ authlib.AuthInfo, _ authlib.ListRequest) (authlib.ItemChecker, authlib.Zookie, error) {
+	return func(name, folder string) bool { return c.allowedFolders[folder] }, authlib.NoopZookie{}, nil
+}
+
+func (c *testAccessClient) BatchCheck(_ context.Context, _ authlib.AuthInfo, req authlib.BatchCheckRequest) (authlib.BatchCheckResponse, error) {
+	results := make(map[string]authlib.BatchCheckResult, len(req.Checks))
+	for _, item := range req.Checks {
+		results[item.CorrelationID] = authlib.BatchCheckResult{Allowed: c.allowedFolders[item.Folder]}
+	}
+	return authlib.BatchCheckResponse{Results: results}, nil
+}
+
+func checkSearchQueryWithAccess(t *testing.T, index resource.ResourceIndex, ac authlib.AccessClient, query *resourcepb.ResourceSearchRequest, expectedNames []string) {
+	t.Helper()
+	user := &identity.StaticRequester{
+		Type:      authlib.TypeUser,
+		UserID:    1,
+		Namespace: query.Options.Key.Namespace,
+	}
+	ctx := authlib.WithAuthInfo(context.Background(), user)
+	res, err := index.Search(ctx, ac, query, nil, nil)
+	require.NoError(t, err)
+	names := make([]string, 0, len(res.Results.GetRows()))
+	for _, row := range res.Results.GetRows() {
+		names = append(names, row.Key.Name)
+	}
+	require.ElementsMatch(t, expectedNames, names)
+}
+
+func TestSearchPermissionFiltering(t *testing.T) {
+	key := resource.NamespacedResource{
+		Namespace: "default",
+		Group:     "dashboard.grafana.app",
+		Resource:  "dashboards",
+	}
+
+	indexDocumentsWithFolders := func(t *testing.T, index resource.ResourceIndex, docs map[string]string) {
+		t.Helper()
+		items := make([]*resource.BulkIndexItem, 0, len(docs))
+		for name, folder := range docs {
+			items = append(items, &resource.BulkIndexItem{
+				Action: resource.ActionIndex,
+				Doc: &resource.IndexableDocument{
+					RV:    1,
+					Name:  name,
+					Title: name,
+					Key: &resourcepb.ResourceKey{
+						Name:      name,
+						Namespace: key.Namespace,
+						Group:     key.Group,
+						Resource:  key.Resource,
+					},
+					Folder: folder,
+				},
+			})
+		}
+		require.NoError(t, index.BulkIndex(&resource.BulkIndexRequest{Items: items}))
+	}
+
+	query := &resourcepb.ResourceSearchRequest{
+		Options: &resourcepb.ListOptions{
+			Key: &resourcepb.ResourceKey{
+				Namespace: key.Namespace,
+				Group:     key.Group,
+				Resource:  key.Resource,
+			},
+		},
+		Limit: 100000,
+	}
+
+	t.Run("returns all documents when access client is nil", func(t *testing.T) {
+		index := newTestDashboardsIndex(t, threshold, 2, noop)
+		indexDocumentsWithFolders(t, index, map[string]string{
+			"doc-a": "folder-a",
+			"doc-b": "folder-b",
+		})
+		checkSearchQueryWithAccess(t, index, nil, query, []string{"doc-a", "doc-b"})
+	})
+
+	t.Run("returns only documents in allowed folders", func(t *testing.T) {
+		index := newTestDashboardsIndex(t, threshold, 2, noop)
+		indexDocumentsWithFolders(t, index, map[string]string{
+			"doc-a": "folder-a",
+			"doc-b": "folder-b",
+			"doc-c": "folder-a",
+		})
+		ac := &testAccessClient{allowedFolders: map[string]bool{"folder-a": true}}
+		checkSearchQueryWithAccess(t, index, ac, query, []string{"doc-a", "doc-c"})
+	})
+
+	t.Run("returns no documents when user has no folder access", func(t *testing.T) {
+		index := newTestDashboardsIndex(t, threshold, 2, noop)
+		indexDocumentsWithFolders(t, index, map[string]string{
+			"doc-a": "folder-a",
+			"doc-b": "folder-b",
+		})
+		ac := &testAccessClient{allowedFolders: map[string]bool{}}
+		checkSearchQueryWithAccess(t, index, ac, query, []string{})
+	})
+
+	t.Run("returns documents from multiple allowed folders", func(t *testing.T) {
+		index := newTestDashboardsIndex(t, threshold, 2, noop)
+		indexDocumentsWithFolders(t, index, map[string]string{
+			"doc-a": "folder-a",
+			"doc-b": "folder-b",
+			"doc-c": "folder-c",
+		})
+		ac := &testAccessClient{allowedFolders: map[string]bool{"folder-a": true, "folder-b": true}}
+		checkSearchQueryWithAccess(t, index, ac, query, []string{"doc-a", "doc-b"})
+	})
 }


### PR DESCRIPTION
This PR removes a redundant service-layer RBAC check from `FolderService.Get()` and hardens the authorization path across the unified storage stack.

Changes:
- **Remove `accesscontrol.Evaluate()` from `Get()`** — user-level RBAC is already enforced in `server.read()` via `authzLimitedClient`; keeping it at the service layer was redundant and the wrong place for it
- **Remove duplicate metric increment** in `folder_unifiedstorage.go` (copy-paste bug)
- **Fix `toFolderError()`** to translate K8s `403 Forbidden` responses into `folder.ErrAccessDenied`, so the unified storage denial surfaces correctly through the service layer
- **Add tests for `server.read()` permission checks** — previously the denial path had no unit test coverage
- **Add tests for Bleve search permission filtering** (`permissionScopedQuery`) — previously untested

Related to https://github.com/grafana/search-and-storage-team/issues/748