### PR TITLE
Alerting: Make ClassicCondition.query.params optional

### DIFF
--- a/public/app/features/alerting/unified/GrafanaRuleQueryViewer.test.tsx
+++ b/public/app/features/alerting/unified/GrafanaRuleQueryViewer.test.tsx
@@ -16,6 +16,18 @@ describe('GrafanaRuleQueryViewer', () => {
     expect(screen.getByTestId('expressions-container')).toHaveStyle('flex-wrap: wrap');
   });
 
+  it('renders classic_conditions with missing query.params without crashing', async () => {
+    const rule = mockCombinedRule();
+
+    const malformedExpression = getExpression('F', undefined);
+
+    render(
+      <GrafanaRuleQueryViewer queries={[...queries, malformedExpression]} condition="A" rule={rule} />
+    );
+
+    await waitFor(() => expect(screen.getByTestId('expressions-container')).toBeInTheDocument());
+  });
+
   it('should catch cyclical references', async () => {
     const rule = mockCombinedRule();
 
@@ -53,7 +65,7 @@ const queries = [
   getDataSourceQuery('E'),
 ];
 
-function getExpression(refId: string) {
+function getExpression(refId: string, queryParams: string[] | undefined = ['A']) {
   const expr = {
     refId: refId,
     datasourceUid: '__expr__',
@@ -73,7 +85,7 @@ function getExpression(refId: string) {
             type: 'and',
           },
           query: {
-            params: ['A'],
+            params: queryParams,
           },
           reducer: {
             params: [],

--- a/public/app/features/alerting/unified/GrafanaRuleQueryViewer.tsx
+++ b/public/app/features/alerting/unified/GrafanaRuleQueryViewer.tsx
@@ -357,7 +357,7 @@ function ClassicConditionViewer({ model }: { model: ExpressionQuery }) {
             <div className={styles.blue}>
               <Trans i18nKey="alerting.classic-condition-viewer.of">OF</Trans>
             </div>
-            <div className={styles.bold}>{query.params[0]}</div>
+            <div className={styles.bold}>{query.params?.[0]}</div>
             <div className={styles.blue}>{evalFunctions[evaluator.type].text}</div>
             <div className={styles.bold}>
               {isRange ? `(${evaluator.params[0]}; ${evaluator.params[1]})` : evaluator.params[0]}

--- a/public/app/features/alerting/unified/components/rule-editor/dag.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/dag.ts
@@ -96,7 +96,7 @@ export function getTargets(model: ExpressionQuery) {
     return parseRefsFromMathExpression(model.expression ?? '');
   }
   if (isClassicCondition) {
-    return model.conditions?.map((c) => c.query.params[0]) ?? [];
+    return model.conditions?.flatMap((c) => (c.query.params?.[0] ? [c.query.params[0]] : [])) ?? [];
   }
   if (isSqlExpression) {
     return parseRefsFromSqlExpression(model.expression ?? '');

--- a/public/app/features/alerting/unified/components/rule-editor/util.test.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/util.test.ts
@@ -1,4 +1,5 @@
 import { ExpressionDatasourceRef } from '@grafana/runtime/internal';
+import { EvalFunction } from 'app/features/alerting/state/alertDef';
 import { type ClassicCondition, type ExpressionQuery } from 'app/features/expressions/types';
 import { type AlertQuery } from 'app/types/unified-alerting-dto';
 
@@ -185,6 +186,26 @@ describe('rule-editor', () => {
       expect(rewiredQueries[0]).toEqual(queries[0]);
       expect(rewiredQueries[1]).toEqual(queries[1]);
       expect(rewiredQueries[2]).toEqual(queries[2]);
+    });
+
+    it('should not crash on classic conditions with missing query.params', () => {
+      const malformedClassicCondition: ClassicCondition = {
+        type: 'query',
+        evaluator: { params: [3], type: EvalFunction.IsAbove },
+        operator: { type: 'and' },
+        query: {},
+        reducer: { params: [], type: 'last' },
+      };
+      const malformedCondition: AlertQuery = {
+        ...classicCondition,
+        model: {
+          ...classicCondition.model,
+          conditions: [malformedClassicCondition],
+        },
+      };
+
+      const queries: AlertQuery[] = [dataSource, malformedCondition];
+      expect(() => queriesWithUpdatedReferences(queries, 'A', 'C')).not.toThrow();
     });
 
     it('should not rewire non-referencing expressions', () => {

--- a/public/app/features/alerting/unified/components/rule-editor/util.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/util.ts
@@ -64,7 +64,7 @@ export function queriesWithUpdatedReferences(
         ...condition,
         query: {
           ...condition.query,
-          params: condition.query.params.map((param: string) => (param === previousRefId ? newRefId : param)),
+          params: (condition.query.params ?? []).map((param: string) => (param === previousRefId ? newRefId : param)),
         },
       }));
 
@@ -166,7 +166,7 @@ export function getThresholdsForQueries(queries: AlertQuery[], condition: string
       const threshold = condition.evaluator.params;
 
       // "classic_conditions" use `condition.query.params[]` and "threshold" uses `query.model.expression`
-      const refId = condition.query?.params[0] ?? query.model.expression;
+      const refId = condition.query?.params?.[0] ?? query.model.expression;
 
       // if an expression hasn't been linked to a data query yet, it won't have a refId
       if (!refId) {

--- a/public/app/features/alerting/unified/utils/timeRange.ts
+++ b/public/app/features/alerting/unified/utils/timeRange.ts
@@ -39,8 +39,9 @@ const getReferencedIds = (model: ExpressionQuery, queries: AlertQuery[]): string
 };
 
 const getReferencedIdsForClassicCondition = (model: ExpressionQuery) => {
-  return model.conditions?.map((condition) => {
-    return condition.query.params[0];
+  return model.conditions?.flatMap((condition) => {
+    const refId = condition.query.params?.[0];
+    return refId ? [refId] : [];
   });
 };
 

--- a/public/app/features/expressions/components/Condition.tsx
+++ b/public/app/features/expressions/components/Condition.tsx
@@ -104,7 +104,7 @@ export const Condition = ({ condition, index, onChange, onRemoveCondition, refId
             onChange={onRefIdChange}
             options={refIds}
             width={'auto'}
-            value={refIds.find((r) => r.value === condition.query.params[0])}
+            value={refIds.find((r) => r.value === condition.query.params?.[0])}
           />
         </InlineFieldRow>
         <InlineFieldRow>

--- a/public/app/features/expressions/types.ts
+++ b/public/app/features/expressions/types.ts
@@ -177,7 +177,7 @@ export interface ClassicCondition {
     type: string;
   };
   query: {
-    params: string[];
+    params?: string[];
   };
   reducer?: {
     params: [];


### PR DESCRIPTION
## Summary
- Stops the rule view page (\`/alerting/grafana/*/view\`) from crashing on alert rules whose \`classic_conditions\` expression is missing \`query.params\` (e.g. \`{query: {}}\`). Production Faro reports show this happening in the wild for rules saved via provisioning / file / legacy-migration, which bypass the Ruler API's strict validation.
- Relaxes \`ClassicCondition.query.params\` from required to optional and fixes every access site to tolerate \`undefined\`: \`util.ts\`, \`dag.ts\`, \`timeRange.ts\`, \`GrafanaRuleQueryViewer.tsx\`, \`Condition.tsx\`.
- Adds regression tests in \`util.test.ts\` and \`GrafanaRuleQueryViewer.test.tsx\` covering the missing-\`params\` shape.

### Why types, not runtime validation
We considered a Zod + RTKQ \`transformResponse\` pipeline to coerce the shape centrally, but chose to make the type honest about the data instead — fewer transforms on every response and the fix lives next to the code that uses the field. A companion backend PR makes malformed saves observable so we can decide whether to tighten to rejection later.

### Companion
Backend: #123229 — log-only validation of expression models in \`AlertQuery.PreSave\` + new \`grafana_alerting_invalid_expression_model_saves_total\` counter.

## Test plan
- [x] \`yarn test --watchAll=false\` passes for the modified files (util, dag, timeRange, GrafanaRuleQueryViewer)
- [x] \`yarn typecheck\` clean
- [ ] Manually load an alert rule with \`{query: {}}\` in a \`classic_conditions\` expression and confirm the view page renders