### PR TITLE
E2E: fix perf-test flakiness caused by unhandled response.body() error

### DIFF
--- a/e2e-playwright/utils/RequestsRecorder.ts
+++ b/e2e-playwright/utils/RequestsRecorder.ts
@@ -122,20 +122,24 @@ export class RequestsRecorder {
       labels.plugin_name = plugin_name;
     }
 
-    if (!noBodyStatusCode) {
-      const body = await response.body();
-      this.#inflatedSizeBytesCounter.inc(labels, body.length);
-    }
+    try {
+      if (!noBodyStatusCode) {
+        const body = await response.body();
+        this.#inflatedSizeBytesCounter.inc(labels, body.length);
+      }
 
-    const sizes = await response.request().sizes();
+      const sizes = await response.request().sizes();
 
-    this.#transferSizeBytesCounter.inc(labels, sizes.responseBodySize + sizes.responseHeadersSize);
-    this.#requestCountCounter.inc(labels);
+      this.#transferSizeBytesCounter.inc(labels, sizes.responseBodySize + sizes.responseHeadersSize);
+      this.#requestCountCounter.inc(labels);
+    } catch (e) {
+      console.warn('Failed to record metrics for response', response.url(), e);
+    } finally {
+      this.#requestsInFlight -= 1;
 
-    this.#requestsInFlight -= 1;
-
-    if (this.#requestsInFlight === 0 && this.#resolve) {
-      this.#resolve();
+      if (this.#requestsInFlight === 0 && this.#resolve) {
+        this.#resolve();
+      }
     }
   }
 

--- a/e2e-playwright/various-suite/perf-test.spec.ts
+++ b/e2e-playwright/various-suite/perf-test.spec.ts
@@ -39,6 +39,8 @@ test('payload-size', { tag: '@performance' }, async ({ page }) => {
   await client.send('HeapProfiler.collectGarbage');
   let usedJSHeapSize = (await client.send('Runtime.getHeapUsage')).usedSize;
 
+  await stopListening();
+
   const responseMetrics = recorder.getMetrics();
   for (const metric of responseMetrics) {
     promRegistry.registerMetric(metric);
@@ -53,6 +55,5 @@ test('payload-size', { tag: '@performance' }, async ({ page }) => {
   console.log(metricsText);
   fs.writeFileSync(process.env.METRICS_OUTPUT_PATH || '/tmp/asset-metrics.txt', metricsText);
 
-  await stopListening();
-  page.close();
+  await page.close();
 });

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -3375,16 +3375,6 @@
       "count": 1
     }
   },
-  "public/app/plugins/datasource/prometheus/configuration/AzureAuthSettings.tsx": {
-    "@grafana/no-gf-form": {
-      "count": 1
-    }
-  },
-  "public/app/plugins/datasource/prometheus/configuration/AzureCredentialsForm.tsx": {
-    "@grafana/no-gf-form": {
-      "count": 15
-    }
-  },
   "public/app/plugins/datasource/tempo/QueryField.tsx": {
     "react-prefer-function-component/react-prefer-function-component": {
       "count": 1


### PR DESCRIPTION
## Summary

Fixes `e2e-playwright/various-suite/perf-test.spec.ts` which has been failing x5 in CI (tracked in [daily CI report](https://raintank-corp.slack.com/archives/C01BKPAV1EZ/p1776862807849119)).

Root cause: `RequestsRecorder.#handleResponse` reads `response.body()` which throws `Protocol error (Network.getResponseBody): No data found for resource with given identifier` for certain responses (cached resources, redirects, etc.). This error was unhandled, so `#requestsInFlight` was never decremented via `finally`, causing `stopListening()` to wait indefinitely and the test to time out.

Changes:
- Wrap the `response.body()` and `response.request().sizes()` calls in a `try/catch/finally` in `RequestsRecorder.ts` so `#requestsInFlight` is always decremented even on error
- Move `await stopListening()` before `recorder.getMetrics()` in the test so all in-flight responses are settled before metrics are collected
- Add missing `await` on `page.close()`

## Test plan
- [ ] Verify the test passes in CI without flaking
- [ ] Check that perf metrics are still emitted correctly (the `console.warn` for failed responses is expected for some CDN/redirect responses)

<!-- add to changelog -->