### PR TITLE
chore: make sure circular deps only runs for PRs to main

### DIFF
--- a/.github/workflows/frontend-lint.yml
+++ b/.github/workflows/frontend-lint.yml
@@ -244,7 +244,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    if: github.event_name == 'pull_request' && needs.detect-changes.outputs.changed == 'true'
+    if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && needs.detect-changes.outputs.changed == 'true'
     name: Check circular dependencies
     runs-on: ubuntu-x64-small
     steps:


### PR DESCRIPTION
**What is this feature?**

This pull request makes a small update to the `frontend-lint.yml` workflow. The change ensures that the "Check circular dependencies" job only runs on pull requests targeting the `main` branch, in addition to the previous conditions.

See dummy run on `release-13.0.2` branch here: https://github.com/grafana/grafana/actions/runs/24826489296/job/72663731728?pr=123328

**Why do we need this feature?**

So we don't run "Check circular dependencies" job on release branches for instance

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
