### PR TITLE
Provisioning: Fix flaky TestIntegrationProvisioning_CreatingGitHubRepository delete wait

### DIFF
--- a/pkg/tests/apis/provisioning/repository/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository/repository_test.go
@@ -820,11 +820,14 @@ func TestIntegrationProvisioning_CreatingGitHubRepository(t *testing.T) {
 		assert.Equal(collect, 0, len(found.Items), "expected dashboards to be deleted")
 	}, time.Second*20, time.Millisecond*10, "Expected dashboards to be deleted")
 
-	// Wait for repository to be fully deleted before subtests run
+	// Wait for repository to be fully deleted before subtests run.
+	// Use the package-wide default timeout: finalizer processing (webhook
+	// cleanup, releasing and removing orphan resources) runs asynchronously
+	// and can exceed a shorter bound on loaded CI runners.
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		_, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{})
 		assert.True(collect, apierrors.IsNotFound(err), "repository should be deleted")
-	}, time.Second*10, time.Millisecond*50, "repository should be deleted before subtests")
+	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "repository should be deleted before subtests")
 
 	t.Run("github url cleanup", func(t *testing.T) {
 		tests := []struct {


### PR DESCRIPTION
## Summary

- Fixes a flake in `TestIntegrationProvisioning_CreatingGitHubRepository` where the post-`Delete()` wait for the repository to become `NotFound` used a 10s / 50ms `EventuallyWithT` bound.
- The controller must drive three finalizers before the API object disappears (`CleanFinalizer` → `ReleaseOrphanResourcesFinalizer` → `RemoveOrphanResourcesFinalizer`, see `pkg/registry/apis/provisioning/controller/finalizers.go`). On loaded CI runners the chain can exceed 10s, so the test times out and — because the repo is still around — the next test (`TestIntegrationProvisioning_ReadOnlyRepositoryNoWebhook`) also fails in `CleanupAllResources(repositories)`.
- Switch the wait to the suite-wide defaults (`common.WaitTimeoutDefault` = 60s, `common.WaitIntervalDefault` = 100ms), matching every other `EventuallyWithT` in the package.

Fixes grafana/git-ui-sync-project#1104

## Test plan

- [ ] CI green on the provisioning integration suite (Sqlite Enterprise sharded jobs in particular)
- [ ] Re-run the affected test locally a few times to confirm no regression:
  `go test -run TestIntegrationProvisioning_CreatingGitHubRepository ./pkg/tests/apis/provisioning/repository/ -count=5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)