### PR TITLE
Provisioning: Use default wait timeouts for finalizer-driven deletions

### DIFF
--- a/pkg/tests/apis/provisioning/folderownerrefs_test.go
+++ b/pkg/tests/apis/provisioning/folderownerrefs_test.go
@@ -2,7 +2,6 @@ package provisioning
 
 import (
 	"testing"
-	"time"
 
 	foldersV1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
@@ -99,7 +98,7 @@ func TestIntegrationFolderOwnerRefs_UnprovisionedFolders(t *testing.T) {
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			_, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{})
 			assert.True(collect, apierrors.IsNotFound(err), "repository should be deleted")
-		}, time.Second*10, time.Millisecond*50, "repository should be deleted")
+		}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "repository should be deleted")
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			foundFolders, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
 			require.NoError(t, err, "can list values")
@@ -109,7 +108,7 @@ func TestIntegrationFolderOwnerRefs_UnprovisionedFolders(t *testing.T) {
 				assert.NotContains(t, v.GetAnnotations(), utils.AnnoKeySourcePath)
 				assert.NotContains(t, v.GetAnnotations(), utils.AnnoKeySourceChecksum)
 			}
-		}, time.Second*20, time.Millisecond*10, "Expected folders to be released")
+		}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "Expected folders to be released")
 
 		_, err = helper.Folders.Resource.Patch(t.Context(), managedFolderName, types.JSONPatchType, ownerRefsPatch, metav1.PatchOptions{})
 		require.NoError(t, err, "should set ownerReferences on released folder")

--- a/pkg/tests/apis/provisioning/folderpermissions_test.go
+++ b/pkg/tests/apis/provisioning/folderpermissions_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
-	"time"
 
 	foldersV1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
@@ -99,7 +98,7 @@ func TestIntegrationFolderPermissions_UnprovisionedFolders(t *testing.T) {
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			_, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{})
 			assert.True(collect, apierrors.IsNotFound(err), "repository should be deleted")
-		}, time.Second*10, time.Millisecond*50, "repository should be deleted")
+		}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "repository should be deleted")
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			foundFolders, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
 			require.NoError(t, err, "can list values")
@@ -109,7 +108,7 @@ func TestIntegrationFolderPermissions_UnprovisionedFolders(t *testing.T) {
 				assert.NotContains(t, v.GetAnnotations(), utils.AnnoKeySourcePath)
 				assert.NotContains(t, v.GetAnnotations(), utils.AnnoKeySourceChecksum)
 			}
-		}, time.Second*20, time.Millisecond*10, "Expected folders to be released")
+		}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "Expected folders to be released")
 
 		permissionsPayload := map[string]interface{}{
 			"items": []map[string]interface{}{

--- a/pkg/tests/apis/provisioning/jobs/movejob_test.go
+++ b/pkg/tests/apis/provisioning/jobs/movejob_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -210,7 +209,7 @@ func TestIntegrationProvisioning_MoveJob(t *testing.T) {
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			_, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{})
 			assert.True(collect, apierrors.IsNotFound(err), "repository should be deleted")
-		}, time.Second*5, time.Millisecond*50, "repository should be deleted before creating new one")
+		}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "repository should be deleted before creating new one")
 
 		// Create modified test files with unique UIDs for ResourceRef testing
 		allPanelsContent := helper.LoadFile("../testdata/all-panels.json")

--- a/pkg/tests/apis/provisioning/librarypanels_test.go
+++ b/pkg/tests/apis/provisioning/librarypanels_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"testing"
-	"time"
 
 	foldersV1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
@@ -147,7 +146,7 @@ func TestIntegrationLibraryPanels_UnprovisionedFolders(t *testing.T) {
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			_, err := helper.Repositories.Resource.Get(t.Context(), repo, metav1.GetOptions{})
 			assert.True(collect, apierrors.IsNotFound(err), "repository should be deleted")
-		}, time.Second*10, time.Millisecond*50, "repository should be deleted")
+		}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "repository should be deleted")
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			foundFolders, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
 			require.NoError(t, err, "can list values")
@@ -157,7 +156,7 @@ func TestIntegrationLibraryPanels_UnprovisionedFolders(t *testing.T) {
 				assert.NotContains(t, v.GetAnnotations(), utils.AnnoKeySourcePath)
 				assert.NotContains(t, v.GetAnnotations(), utils.AnnoKeySourceChecksum)
 			}
-		}, time.Second*20, time.Millisecond*10, "Expected folders to be released")
+		}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "Expected folders to be released")
 
 		libraryElement := map[string]interface{}{
 			"kind":      1,

--- a/pkg/tests/apis/provisioning/repository/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository/repository_test.go
@@ -818,7 +818,7 @@ func TestIntegrationProvisioning_CreatingGitHubRepository(t *testing.T) {
 		found, err := helper.DashboardsV1.Resource.List(ctx, metav1.ListOptions{})
 		assert.NoError(t, err, "can list values")
 		assert.Equal(collect, 0, len(found.Items), "expected dashboards to be deleted")
-	}, time.Second*20, time.Millisecond*10, "Expected dashboards to be deleted")
+	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "Expected dashboards to be deleted")
 
 	// Wait for repository to be fully deleted before subtests run
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
@@ -1449,7 +1449,7 @@ func TestIntegrationProvisioning_DeleteRepositoryAndReleaseResources(t *testing.
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		_, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{})
 		assert.True(collect, apierrors.IsNotFound(err), "repository should be deleted")
-	}, time.Second*10, time.Millisecond*50, "repository should be deleted")
+	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "repository should be deleted")
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		foundDashboards, err := helper.DashboardsV1.Resource.List(ctx, metav1.ListOptions{})
@@ -1460,7 +1460,7 @@ func TestIntegrationProvisioning_DeleteRepositoryAndReleaseResources(t *testing.
 			assert.NotContains(t, v.GetAnnotations(), utils.AnnoKeySourcePath)
 			assert.NotContains(t, v.GetAnnotations(), utils.AnnoKeySourceChecksum)
 		}
-	}, time.Second*20, time.Millisecond*10, "Expected dashboards to be released")
+	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "Expected dashboards to be released")
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		foundFolders, err := helper.Folders.Resource.List(ctx, metav1.ListOptions{})
@@ -1471,7 +1471,7 @@ func TestIntegrationProvisioning_DeleteRepositoryAndReleaseResources(t *testing.
 			assert.NotContains(t, v.GetAnnotations(), utils.AnnoKeySourcePath)
 			assert.NotContains(t, v.GetAnnotations(), utils.AnnoKeySourceChecksum)
 		}
-	}, time.Second*20, time.Millisecond*10, "Expected folders to be released")
+	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "Expected folders to be released")
 }
 
 func TestIntegrationProvisioning_DeleteRepositoryAndCleanupClassicDashboards(t *testing.T) {
@@ -1513,7 +1513,7 @@ func TestIntegrationProvisioning_DeleteRepositoryAndCleanupClassicDashboards(t *
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			_, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{})
 			assert.True(collect, apierrors.IsNotFound(err), "repository should be deleted")
-		}, time.Second*20, time.Millisecond*50, "repository should be deleted")
+		}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "repository should be deleted")
 
 		_, err = helper.DashboardsV1.Resource.Get(ctx, "finalizer-remove-classic-uid", metav1.GetOptions{})
 		require.Error(t, err, "classic dashboard should be deleted by remove-orphan-resources finalizer")
@@ -1560,7 +1560,7 @@ func TestIntegrationProvisioning_DeleteRepositoryAndCleanupClassicDashboards(t *
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			_, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{})
 			assert.True(collect, apierrors.IsNotFound(err), "repository should be deleted")
-		}, time.Second*20, time.Millisecond*50, "repository should be deleted")
+		}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "repository should be deleted")
 
 		dashboard, err = helper.DashboardsV1.Resource.Get(ctx, "finalizer-release-classic-uid", metav1.GetOptions{})
 		require.NoError(t, err, "classic dashboard should still exist after release")

--- a/pkg/tests/apis/provisioning/secrets_test.go
+++ b/pkg/tests/apis/provisioning/secrets_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -91,7 +90,7 @@ func TestIntegrationProvisioning_InlineSecrets(t *testing.T) {
 			require.Eventually(t, func() bool {
 				_, err := helper.Repositories.Resource.Get(ctx, obj.GetName(), metav1.GetOptions{})
 				return apierrors.IsNotFound(err)
-			}, time.Second*15, time.Millisecond*300, "should be removed")
+			}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "should be removed")
 
 			// now check that we can no longer decrypt the requested values
 			results, err := decryptService.Decrypt(ctx, "provisioning.grafana.app", obj.GetNamespace(), created...)


### PR DESCRIPTION
## Summary

Follow-up to #123334 that broadens the same fix across the provisioning integration tests.

All of the bespoke `EventuallyWithT` / `Eventually` timeouts in these tests are poll loops that run **after** `Repositories.Resource.Delete(...)` and wait for the finalizer chain (`CleanFinalizer` → `ReleaseOrphanResourcesFinalizer` → `RemoveOrphanResourcesFinalizer`, see `pkg/registry/apis/provisioning/controller/finalizers.go`) to drain. On loaded CI runners that chain can exceed the old 5s–20s bounds, causing the next test to fail in `CleanupAllResources`.

This PR swaps those custom bounds for the package-wide defaults (`common.WaitTimeoutDefault` = 60s, `common.WaitIntervalDefault` = 100ms) that every other wait in the suite already uses.

### Call sites touched

- `librarypanels_test.go` — repository delete + folders released
- `folderpermissions_test.go` — repository delete + folders released
- `folderownerrefs_test.go` — repository delete + folders released
- `repository/repository_test.go` — dashboards deleted, `DeleteRepositoryAndReleaseResources` waits, `finalizer-remove-classic` / `finalizer-release-classic` waits
- `jobs/movejob_test.go` — pre-create repository delete wait (was 5s — the shortest bound in the suite)
- `secrets_test.go` — inline-secrets post-delete wait

The line already addressed by #123334 is left alone to avoid a conflict.

## Test plan

- [ ] CI green on the provisioning integration suite (Sqlite Enterprise sharded jobs in particular)
- [ ] Re-run the affected tests a few times locally:
  `go test -count=5 ./pkg/tests/apis/provisioning/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)