### PR TITLE
Provisioning: Fix v1beta1 CRUD test flake by disabling sync

### DIFF
--- a/pkg/tests/apis/provisioning/v1beta1/repository_test.go
+++ b/pkg/tests/apis/provisioning/v1beta1/repository_test.go
@@ -40,9 +40,9 @@ func TestIntegrationV1Beta1RepositoryCRUD(t *testing.T) {
 				},
 				"workflows": []string{"write"},
 				"sync": map[string]interface{}{
-					"enabled":         true,
+					"enabled":         false,
 					"target":          "folder",
-					"intervalSeconds": 10,
+					"intervalSeconds": 60,
 				},
 			},
 		}


### PR DESCRIPTION
## Summary

Fixes https://github.com/grafana/git-ui-sync-project/issues/1103
Fixes the flake in `TestIntegrationV1Beta1APIAvailable` and `TestIntegrationV1Beta1OpenAPISchema` reported in https://github.com/grafana/git-ui-sync-project/issues/1103.

## Root cause

`TestIntegrationV1Beta1RepositoryCRUD` creates a repo with `sync.enabled: true` and `sync.target: "folder"`. The background sync calls `EnsureFolderExists` (`pkg/registry/apis/provisioning/jobs/sync/full.go:53`) for the repository root folder with `Path: ""`. `SetSourceProperties` (`pkg/apimachinery/utils/meta.go:787`) *deletes* the `AnnoKeySourcePath` annotation when the path is empty — so the root folder ends up with a manager annotation but no source path.

There's then a race between the sync creating/indexing the root folder and the repo's `remove-orphan-resources` finalizer listing managed resources to delete. If the folder isn't yet visible to the lister, the finalizer misses it and the folder is leaked past repo deletion.

The next test runs `CleanupAllResources` as admin. Admin isn't the provisioning identity, so the folder delete routes through `handleManagedResourceRouting` (`pkg/storage/unified/apistore/managed.go:244`) which requires a non-empty source path — hence:

```
CleanupAllResources(folders): deleteAndWait: timed out with 1 items remaining
(first delete error: deleteAndWait: delete "test-v1beta1-repo":
managed resource is missing source path annotation)
```

## Fix

The test only exercises v1beta1 API CRUD serialization; it does not need sync. Disable sync to match the pattern used in `pkg/tests/apis/provisioning/apiversion/version_test.go:38`. No sync -> no root folder -> no race.

## Follow-up (out of scope)

The underlying issue — orphaned root folders (with empty source paths) being un-deletable by admin — still affects any repo using `sync.target: folder`. Worth a separate investigation.

## Test plan

- [ ] CI on `pkg/tests/apis/provisioning/v1beta1/...` passes
- [ ] Flake no longer reproduces on the affected test matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)