### PR TITLE
Explore: return insert error from QueryHistoryDetails session callback in createQuery

### DIFF
--- a/pkg/services/queryhistory/database.go
+++ b/pkg/services/queryhistory/database.go
@@ -51,7 +51,9 @@ func (s QueryHistoryService) createQuery(ctx context.Context, user *user.SignedI
 
 		err = s.store.WithDbSession(ctx, func(session *db.Session) error {
 			for _, queryHistoryDetailsItem := range queryHistoryDetailsItems {
-				_, err = session.Insert(queryHistoryDetailsItem)
+				if _, err = session.Insert(queryHistoryDetailsItem); err != nil {
+					return err
+				}
 			}
 			return nil
 		})


### PR DESCRIPTION
**What is this feature?**

Bug fix. In `pkg/services/queryhistory/database.go`, the `WithDbSession` callback in `createQuery` always returned `nil` regardless of whether the `QueryHistoryDetails` inserts succeeded. Database errors were silently swallowed, leaving the `query_history_details` table partially populated with no indication to the caller.

**Why do we need this feature?**

When a `QueryHistoryDetails` insert fails, the caller receives a successful `QueryHistoryDTO` as if nothing went wrong. The affected query won't be filterable by datasource in the query history UI. No error is logged, no error is returned. This runs on every query execution in Explore when query history is enabled.

**Who is this feature for?**

All Grafana users with query history enabled who use Explore.

**Which issue(s) does this PR fix?**

Fixes #123275

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.

One file changed: `pkg/services/queryhistory/database.go`. The fix adds an early return on insert error inside the loop. The rest of the function is untouched.
