### PR TITLE
Search: trigger background rebuild for indexes built by newer Grafana version

### DIFF
--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -154,6 +154,7 @@ type searchServer struct {
 	dashboardIndexMaxAge time.Duration
 	maxIndexAge          time.Duration
 	minBuildVersion      *semver.Version
+	buildVersion         *semver.Version
 	selectableFields     map[string][]string
 
 	bgTaskWg     sync.WaitGroup
@@ -218,6 +219,7 @@ func newSearchServer(opts SearchOptions, storage StorageBackend, access types.Ac
 		dashboardIndexMaxAge:      opts.DashboardIndexMaxAge,
 		maxIndexAge:               opts.MaxIndexAge,
 		minBuildVersion:           opts.MinBuildVersion,
+		buildVersion:              opts.BuildVersion,
 		selectableFields:          opts.SelectableFieldsForKinds,
 		injectFailuresPercent:     opts.InjectFailuresPercent,
 		indexModificationCacheTTL: opts.IndexModificationCacheTTL,
@@ -823,7 +825,7 @@ func (s *searchServer) findIndexesToRebuild(lastImportTimes map[NamespacedResour
 		sfKey := fmt.Sprintf("%s/%s", strings.ToLower(key.Group), strings.ToLower(key.Resource))
 		sfields := s.selectableFields[sfKey]
 
-		if shouldRebuildIndex(bi, s.minBuildVersion, minBuildTime, lastImportTime, sfields, nil) {
+		if shouldRebuildIndex(bi, s.minBuildVersion, s.buildVersion, minBuildTime, lastImportTime, sfields, nil) {
 			completeCh := make(chan struct{})
 			completeChs = append(completeChs, completeCh)
 			rebuildReq := newRebuildRequest(key, minBuildTime, lastImportTime, s.minBuildVersion, sfields, completeCh)
@@ -894,7 +896,7 @@ func (s *searchServer) rebuildIndex(ctx context.Context, req rebuildRequest) {
 		l.Error("failed to get build info for index to rebuild", "error", err)
 	}
 
-	rebuild := shouldRebuildIndex(bi, req.minBuildVersion, req.minBuildTime, req.lastImportTime, req.selectableFields, l)
+	rebuild := shouldRebuildIndex(bi, req.minBuildVersion, s.buildVersion, req.minBuildTime, req.lastImportTime, req.selectableFields, l)
 	if !rebuild {
 		span.AddEvent("index not rebuilt")
 		l.Info("index doesn't need to be rebuilt")
@@ -936,7 +938,7 @@ func (s *searchServer) rebuildIndex(ctx context.Context, req rebuildRequest) {
 	}
 }
 
-func shouldRebuildIndex(buildInfo IndexBuildInfo, minBuildVersion *semver.Version, minBuildTime time.Time, lastImportTime time.Time, selectableFields []string, rebuildLogger log.Logger) bool {
+func shouldRebuildIndex(buildInfo IndexBuildInfo, minBuildVersion, maxBuildVersion *semver.Version, minBuildTime time.Time, lastImportTime time.Time, selectableFields []string, rebuildLogger log.Logger) bool {
 	if !minBuildTime.IsZero() {
 		if buildInfo.BuildTime.IsZero() || buildInfo.BuildTime.Before(minBuildTime) {
 			if rebuildLogger != nil {
@@ -960,6 +962,16 @@ func shouldRebuildIndex(buildInfo IndexBuildInfo, minBuildVersion *semver.Versio
 		if buildInfo.BuildVersion == nil || buildInfo.BuildVersion.Compare(minBuildVersion) < 0 {
 			if rebuildLogger != nil {
 				rebuildLogger.Info("index build version is before minBuildVersion, rebuilding the index", "indexBuildVersion", buildInfo.BuildVersion, "minBuildVersion", minBuildVersion)
+			}
+			return true
+		}
+	}
+
+	// If index was built by a newer Grafana version than currently running, rebuild to ensure compatibility.
+	if maxBuildVersion != nil && buildInfo.BuildVersion != nil {
+		if buildInfo.BuildVersion.Compare(maxBuildVersion) > 0 {
+			if rebuildLogger != nil {
+				rebuildLogger.Info("index build version is after maxBuildVersion (running version), rebuilding the index", "indexBuildVersion", buildInfo.BuildVersion, "maxBuildVersion", maxBuildVersion)
 			}
 			return true
 		}

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -445,6 +445,7 @@ func TestShouldRebuildIndex(t *testing.T) {
 		minTime          time.Time
 		lastImportTime   time.Time
 		minBuildVersion  *semver.Version
+		maxBuildVersion  *semver.Version
 		selectableFields []string
 
 		expected bool
@@ -502,6 +503,26 @@ func TestShouldRebuildIndex(t *testing.T) {
 			minBuildVersion: semver.MustParse("10.15.20"),
 			expected:        false,
 		},
+		"build version newer than running version": {
+			buildInfo:       IndexBuildInfo{BuildVersion: semver.MustParse("12.0.0")},
+			maxBuildVersion: semver.MustParse("11.0.0"),
+			expected:        true,
+		},
+		"build version same as running version": {
+			buildInfo:       IndexBuildInfo{BuildVersion: semver.MustParse("11.0.0")},
+			maxBuildVersion: semver.MustParse("11.0.0"),
+			expected:        false,
+		},
+		"build version older than running version": {
+			buildInfo:       IndexBuildInfo{BuildVersion: semver.MustParse("10.0.0")},
+			maxBuildVersion: semver.MustParse("11.0.0"),
+			expected:        false,
+		},
+		"no index build version with maxBuildVersion set": {
+			buildInfo:       IndexBuildInfo{},
+			maxBuildVersion: semver.MustParse("11.0.0"),
+			expected:        false,
+		},
 		"index with no previous selectable fields, and no new selectable fields": {
 			buildInfo:        IndexBuildInfo{},
 			selectableFields: nil,
@@ -539,7 +560,7 @@ func TestShouldRebuildIndex(t *testing.T) {
 		},
 	} {
 		t.Run(name, func(t *testing.T) {
-			res := shouldRebuildIndex(tc.buildInfo, tc.minBuildVersion, tc.minTime, tc.lastImportTime, tc.selectableFields, nil)
+			res := shouldRebuildIndex(tc.buildInfo, tc.minBuildVersion, tc.maxBuildVersion, tc.minTime, tc.lastImportTime, tc.selectableFields, nil)
 			require.Equal(t, tc.expected, res)
 		})
 	}
@@ -565,6 +586,7 @@ func TestFindIndexesForRebuild(t *testing.T) {
 			{Namespace: "resource-2h-v5", Group: "group", Resource: dashboardv1.DASHBOARD_RESOURCE},
 			{Namespace: "resource-2h-v6", Group: "group", Resource: dashboardv1.DASHBOARD_RESOURCE},
 			{Namespace: "resource-recently-imported", Group: "group", Resource: dashboardv1.DASHBOARD_RESOURCE},
+			{Namespace: "resource-newer-version", Group: "group", Resource: "folder"},
 
 			// We report this index as open, but it's really not. This can happen if index expires between the call
 			// to GetOpenIndexes and the call to GetIndex.
@@ -616,6 +638,11 @@ func TestFindIndexesForRebuild(t *testing.T) {
 			{Namespace: "resource-recently-imported", Group: "group", Resource: dashboardv1.DASHBOARD_RESOURCE}: &MockResourceIndex{
 				buildInfo: IndexBuildInfo{BuildTime: now.Add(-30 * time.Minute), BuildVersion: semver.MustParse("6.0.0")},
 			},
+
+			// To be rebuilt because of version newer than running (7.0.0 > 6.5.0)
+			{Namespace: "resource-newer-version", Group: "group", Resource: "folder"}: &MockResourceIndex{
+				buildInfo: IndexBuildInfo{BuildTime: now, BuildVersion: semver.MustParse("7.0.0")},
+			},
 		},
 	}
 
@@ -632,6 +659,7 @@ func TestFindIndexesForRebuild(t *testing.T) {
 		DashboardIndexMaxAge: 1 * time.Hour,
 		MaxIndexAge:          5 * time.Hour,
 		MinBuildVersion:      semver.MustParse("5.5.5"),
+		BuildVersion:         semver.MustParse("6.5.0"), // Running version
 	}
 
 	support, err := newSearchServer(opts, storage, nil, nil, nil, nil)
@@ -647,14 +675,14 @@ func TestFindIndexesForRebuild(t *testing.T) {
 	}
 
 	support.findIndexesToRebuild(importTimes, nil, now, false)
-	require.Equal(t, 7, support.rebuildQueue.Len())
+	require.Equal(t, 8, support.rebuildQueue.Len())
 
 	now5m := now.Add(5 * time.Minute)
 
 	// Running findIndexesToRebuild again should not add any new indexes to the rebuild queue, and all existing
 	// ones should be "combined" with new ones (this will "bump" minBuildTime)
 	support.findIndexesToRebuild(importTimes, nil, now5m, false)
-	require.Equal(t, 7, support.rebuildQueue.Len())
+	require.Equal(t, 8, support.rebuildQueue.Len())
 
 	// Values that we expect to find in rebuild requests.
 	minBuildVersion := semver.MustParse("5.5.5")
@@ -672,6 +700,9 @@ func TestFindIndexesForRebuild(t *testing.T) {
 		{NamespacedResource: NamespacedResource{Namespace: "resource-2h-v6", Group: "group", Resource: dashboardv1.DASHBOARD_RESOURCE}, minBuildVersion: minBuildVersion, minBuildTime: minBuildTimeDashboard},
 
 		{NamespacedResource: NamespacedResource{Namespace: "resource-recently-imported", Group: "group", Resource: dashboardv1.DASHBOARD_RESOURCE}, minBuildVersion: minBuildVersion, minBuildTime: minBuildTimeDashboard, lastImportTime: lastImportTime},
+
+		// Index built by newer version than running (7.0.0 > 6.5.0)
+		{NamespacedResource: NamespacedResource{Namespace: "resource-newer-version", Group: "group", Resource: "folder"}, minBuildVersion: minBuildVersion, minBuildTime: minBuildTime},
 	}
 	if diff := cmp.Diff(expected, vals, cmpopts.IgnoreFields(rebuildRequest{}, "completeChannels"), cmp.AllowUnexported(rebuildRequest{})); diff != "" {
 		t.Errorf("rebuildQueue mismatch (-want +got):\n%s", diff)

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -238,6 +238,9 @@ type SearchOptions struct {
 	// Minimum build version for reusing file-based indexes. Ignored if nil.
 	MinBuildVersion *semver.Version
 
+	// Running Grafana build version. Used to detect if index was built by a newer version.
+	BuildVersion *semver.Version
+
 	// Number of workers to use for index rebuilds.
 	IndexRebuildWorkers int
 

--- a/pkg/storage/unified/search/options.go
+++ b/pkg/storage/unified/search/options.go
@@ -59,6 +59,16 @@ func NewSearchOptions(
 			}
 		}
 
+		var buildVersion *semver.Version
+		if cfg.BuildVersion != "" {
+			v, err := semver.NewVersion(cfg.BuildVersion)
+			if err != nil {
+				cfg.Logger.Error("Failed to parse build_version, ignoring it.", "version", cfg.BuildVersion, "err", err)
+			} else {
+				buildVersion = v
+			}
+		}
+
 		snapshot, err := buildSnapshotOptions(cfg, minVersion)
 		if err != nil {
 			return resource.SearchOptions{}, err
@@ -88,6 +98,7 @@ func NewSearchOptions(
 			DashboardIndexMaxAge:      cfg.IndexRebuildInterval,
 			MaxIndexAge:               cfg.MaxFileIndexAge,
 			MinBuildVersion:           minVersion,
+			BuildVersion:              buildVersion,
 			IndexMinUpdateInterval:    cfg.IndexMinUpdateInterval,
 			IndexModificationCacheTTL: cfg.IndexModificationCacheTTL,
 			InjectFailuresPercent:     cfg.SearchInjectFailuresPercent,


### PR DESCRIPTION
When the periodic index scan detects an index that was built by a Grafana version newer than the currently running one, enqueue a background rebuild. This ensures indexes converge to match the running version after a downgrade scenario.

Follow-up to #123238 (point 1 from [this comment](https://github.com/grafana/grafana/pull/123238#issuecomment-4297820723)).