### PR TITLE
Extensions: Fix enterprise imports file

### DIFF
--- a/pkg/extensions/enterprise_imports.go
+++ b/pkg/extensions/enterprise_imports.go
@@ -28,6 +28,7 @@ import (
 	_ "github.com/googleapis/gax-go/v2"
 	_ "github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus"
 	_ "github.com/grpc-ecosystem/go-grpc-middleware/v2"
+	_ "github.com/hashicorp/go-hclog"
 	_ "github.com/hashicorp/go-multierror"
 	_ "github.com/hashicorp/go-plugin"
 	_ "github.com/hashicorp/golang-lru/v2"


### PR DESCRIPTION
`github.com/hashicorp/go-hclog` was added as an Enterprise dependency but not declared here.

This should have been caught :( 