### PR TITLE
search: add distributed build lock API to remote index store

### DIFF
--- a/pkg/storage/unified/search/bleve_snapshot_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_test.go
@@ -39,6 +39,18 @@ type fakeRemoteIndexStore struct {
 	downloadCalls atomic.Int32
 }
 
+type noopIndexStoreLock struct {
+	lost chan struct{}
+}
+
+func (l *noopIndexStoreLock) Release() error {
+	return nil
+}
+
+func (l *noopIndexStoreLock) Lost() <-chan struct{} {
+	return l.lost
+}
+
 func (f *fakeRemoteIndexStore) put(key ulid.ULID, meta *IndexMeta) {
 	if f.data == nil {
 		f.data = map[ulid.ULID]*IndexMeta{}
@@ -68,6 +80,10 @@ func (f *fakeRemoteIndexStore) DownloadIndex(_ context.Context, _ resource.Names
 		return nil, fmt.Errorf("not found")
 	}
 	return meta, writeFakeSnapshot(destDir, meta)
+}
+
+func (f *fakeRemoteIndexStore) LockBuildIndex(context.Context, resource.NamespacedResource) (IndexStoreLock, error) {
+	return &noopIndexStoreLock{lost: make(chan struct{})}, nil
 }
 
 func (f *fakeRemoteIndexStore) UploadIndex(context.Context, resource.NamespacedResource, string, IndexMeta) (ulid.ULID, error) {
@@ -406,7 +422,7 @@ func TestIntegrationBleveSnapshotRoundTrip(t *testing.T) {
 	bucket := memblob.OpenBucket(nil)
 	t.Cleanup(func() { _ = bucket.Close() })
 
-	store := NewBucketRemoteIndexStore(bucket)
+	store := NewBucketRemoteIndexStore(bucket, newFakeBackend(newConditionalBucket()), "test-owner", 5*time.Second, 500*time.Millisecond)
 	key := newTestNsResource()
 	meta := IndexMeta{
 		GrafanaBuildVersion:   "11.5.0",

--- a/pkg/storage/unified/search/options.go
+++ b/pkg/storage/unified/search/options.go
@@ -2,12 +2,14 @@ package search
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
 	"os"
 	"path/filepath"
 	"time"
 
 	"github.com/Masterminds/semver"
+	"github.com/oklog/ulid/v2"
 	"gocloud.dev/blob"
 
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -135,8 +137,34 @@ func buildSnapshotOptions(cfg *setting.Cfg, minBuildVersion *semver.Version) (Sn
 		return SnapshotOptions{}, fmt.Errorf("opening snapshot bucket %q: %w", cfg.IndexSnapshotBucketURL, err)
 	}
 
+	lockOpts, err := cdkLockOptionsFromBucket(bucket, cfg.IndexSnapshotBucketURL)
+	if err != nil {
+		return SnapshotOptions{}, fmt.Errorf("snapshot lock backend options: %w", err)
+	}
+	lockBackend := newCDKLockBackend(bucket, lockOpts)
+
+	ownerBase := cfg.InstanceID
+	if ownerBase == "" {
+		ownerBase = cfg.InstanceName
+	}
+	if ownerBase == "" {
+		ownerBase = "unknown-instance"
+	}
+	// Include a per-process ULID suffix to avoid owner collisions across instances
+	// that share the same configured instance_id/instance_name.
+	owner := fmt.Sprintf("%s/%s", ownerBase, ulid.MustNew(ulid.Now(), rand.Reader).String())
+
+	lockTTL := DefaultSnapshotLockTTL
+	lockHeartbeat := lockTTL / 3
+	if lockHeartbeat <= 0 || lockHeartbeat*2 > lockTTL {
+		lockHeartbeat = lockTTL / 2
+	}
+	if lockHeartbeat <= 0 {
+		lockHeartbeat = time.Second
+	}
+
 	return SnapshotOptions{
-		Store:           NewBucketRemoteIndexStore(bucket),
+		Store:           NewBucketRemoteIndexStore(bucket, lockBackend, owner, lockTTL, lockHeartbeat),
 		MinDocCount:     int64(cfg.IndexSnapshotThreshold),
 		MaxIndexAge:     cfg.IndexSnapshotMaxAge,
 		MinBuildVersion: minBuildVersion,

--- a/pkg/storage/unified/search/options.go
+++ b/pkg/storage/unified/search/options.go
@@ -124,6 +124,17 @@ func NewSearchOptions(
 	}, nil
 }
 
+func snapshotLockHeartbeat(ttl time.Duration) time.Duration {
+	hb := ttl / 3
+	if hb <= 0 || hb*2 > ttl {
+		hb = ttl / 2
+	}
+	if hb <= 0 {
+		hb = time.Second
+	}
+	return hb
+}
+
 // buildSnapshotOptions opens the configured object-storage bucket and wraps it
 // as a RemoteIndexStore. Returns a zero SnapshotOptions (Store==nil) when the
 // feature is not enabled, so the backend short-circuits all new paths.
@@ -150,18 +161,16 @@ func buildSnapshotOptions(cfg *setting.Cfg, minBuildVersion *semver.Version) (Sn
 	if ownerBase == "" {
 		ownerBase = "unknown-instance"
 	}
+	lockOwnerSuffix, err := ulid.New(ulid.Now(), rand.Reader)
+	if err != nil {
+		return SnapshotOptions{}, fmt.Errorf("creating lock owner suffix: %w", err)
+	}
 	// Include a per-process ULID suffix to avoid owner collisions across instances
 	// that share the same configured instance_id/instance_name.
-	owner := fmt.Sprintf("%s/%s", ownerBase, ulid.MustNew(ulid.Now(), rand.Reader).String())
+	owner := fmt.Sprintf("%s/%s", ownerBase, lockOwnerSuffix.String())
 
 	lockTTL := DefaultSnapshotLockTTL
-	lockHeartbeat := lockTTL / 3
-	if lockHeartbeat <= 0 || lockHeartbeat*2 > lockTTL {
-		lockHeartbeat = lockTTL / 2
-	}
-	if lockHeartbeat <= 0 {
-		lockHeartbeat = time.Second
-	}
+	lockHeartbeat := snapshotLockHeartbeat(lockTTL)
 
 	return SnapshotOptions{
 		Store:           NewBucketRemoteIndexStore(bucket, lockBackend, owner, lockTTL, lockHeartbeat),

--- a/pkg/storage/unified/search/options_test.go
+++ b/pkg/storage/unified/search/options_test.go
@@ -1,0 +1,35 @@
+package search
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSnapshotLockHeartbeat(t *testing.T) {
+	tests := []struct {
+		name string
+		ttl  time.Duration
+	}{
+		{name: "default TTL", ttl: DefaultSnapshotLockTTL},
+		{name: "one second", ttl: time.Second},
+		{name: "five seconds", ttl: 5 * time.Second},
+		{name: "non-divisible", ttl: 1300 * time.Millisecond},
+		{name: "tiny positive", ttl: 1 * time.Nanosecond},
+		{name: "zero", ttl: 0},
+		{name: "negative", ttl: -1 * time.Second},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			hb := snapshotLockHeartbeat(tc.ttl)
+
+			assert.Greater(t, hb, time.Duration(0), "heartbeat must always be positive")
+
+			if tc.ttl >= 2*time.Second {
+				assert.LessOrEqual(t, 2*hb, tc.ttl, "heartbeat must satisfy lock validation (TTL >= 2x heartbeat)")
+			}
+		})
+	}
+}

--- a/pkg/storage/unified/search/remote_index_store.go
+++ b/pkg/storage/unified/search/remote_index_store.go
@@ -43,9 +43,18 @@ type IndexMeta struct {
 	Files map[string]int64 `json:"files"`
 }
 
+// IndexStoreLock represents a distributed lock used to coordinate index store operations.
+type IndexStoreLock interface {
+	Release() error
+	Lost() <-chan struct{}
+}
+
 // RemoteIndexStore manages index snapshots on remote storage.
 // Index keys are immutable: each snapshot uses a unique ULID key.
 type RemoteIndexStore interface {
+	// LockBuildIndex acquires a distributed build lock for namespace/group/resource.
+	LockBuildIndex(ctx context.Context, nsResource resource.NamespacedResource) (IndexStoreLock, error)
+
 	// UploadIndex uploads a local index directory to remote storage.
 	// It generates a unique, lexicographically sortable ULID key and returns it.
 	UploadIndex(ctx context.Context, nsResource resource.NamespacedResource, localDir string, meta IndexMeta) (ulid.ULID, error)
@@ -78,15 +87,23 @@ type RemoteIndexStore interface {
 // meta.json is uploaded last during upload and deleted first during delete,
 // serving as the completion signal.
 type BucketRemoteIndexStore struct {
-	bucket resource.CDKBucket
-	log    log.Logger
+	bucket                resource.CDKBucket
+	lockBackend           lockBackend
+	lockOwner             string
+	lockTTL               time.Duration
+	lockHeartbeatInterval time.Duration
+	log                   log.Logger
 }
 
 // NewBucketRemoteIndexStore creates a new RemoteIndexStore backed by the given bucket.
-func NewBucketRemoteIndexStore(bucket resource.CDKBucket) *BucketRemoteIndexStore {
+func NewBucketRemoteIndexStore(bucket resource.CDKBucket, lockBackend lockBackend, lockOwner string, lockTTL, lockHeartbeatInterval time.Duration) *BucketRemoteIndexStore {
 	return &BucketRemoteIndexStore{
-		bucket: bucket,
-		log:    log.New("bucket-remote-index-store"),
+		bucket:                bucket,
+		lockBackend:           lockBackend,
+		lockOwner:             lockOwner,
+		lockTTL:               lockTTL,
+		lockHeartbeatInterval: lockHeartbeatInterval,
+		log:                   log.New("bucket-remote-index-store"),
 	}
 }
 
@@ -98,6 +115,27 @@ func indexPrefix(ns resource.NamespacedResource, indexKey string) string {
 // nsPrefix returns the object storage prefix for a namespaced resource (without index key).
 func nsPrefix(ns resource.NamespacedResource) string {
 	return fmt.Sprintf("%s/%s.%s/", ns.Namespace, ns.Group, ns.Resource)
+}
+
+func buildIndexLockKey(ns resource.NamespacedResource) string {
+	return fmt.Sprintf("%s/%s.%s/locks/build", ns.Namespace, ns.Group, ns.Resource)
+}
+
+func (s *BucketRemoteIndexStore) LockBuildIndex(ctx context.Context, nsResource resource.NamespacedResource) (IndexStoreLock, error) {
+	l, err := newObjectStorageLock(objectStorageLockConfig{
+		Backend:           s.lockBackend,
+		Key:               buildIndexLockKey(nsResource),
+		Owner:             s.lockOwner,
+		TTL:               s.lockTTL,
+		HeartbeatInterval: s.lockHeartbeatInterval,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating build lock: %w", err)
+	}
+	if err := l.Acquire(ctx); err != nil {
+		return nil, err
+	}
+	return l, nil
 }
 
 // TODO: caller must hold a namespace/group/resource build lock.

--- a/pkg/storage/unified/search/remote_index_store_test.go
+++ b/pkg/storage/unified/search/remote_index_store_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -53,6 +54,16 @@ func newTestNsResource() resource.NamespacedResource {
 	}
 }
 
+func newTestRemoteIndexStore(t *testing.T, bucket resource.CDKBucket) *BucketRemoteIndexStore {
+	t.Helper()
+	return newTestRemoteIndexStoreWithLockOwner(t, bucket, newFakeBackend(newConditionalBucket()), "test-owner")
+}
+
+func newTestRemoteIndexStoreWithLockOwner(t *testing.T, bucket resource.CDKBucket, backend lockBackend, owner string) *BucketRemoteIndexStore {
+	t.Helper()
+	return NewBucketRemoteIndexStore(bucket, backend, owner, 5*time.Second, 500*time.Millisecond)
+}
+
 // createTestBleveIndex creates a real bleve index with sample documents.
 func createTestBleveIndex(t *testing.T) string {
 	t.Helper()
@@ -72,7 +83,7 @@ func createTestBleveIndex(t *testing.T) string {
 }
 
 func TestRemoteIndexStore_UploadDownloadBleveIndex(t *testing.T) {
-	store := NewBucketRemoteIndexStore(testBucket(t))
+	store := newTestRemoteIndexStore(t, testBucket(t))
 	ctx := context.Background()
 	ns := newTestNsResource()
 
@@ -113,7 +124,7 @@ func TestRemoteIndexStore_UploadDownloadBleveIndex(t *testing.T) {
 }
 
 func TestRemoteIndexStore_ListAndDeleteIndexes(t *testing.T) {
-	store := NewBucketRemoteIndexStore(testBucket(t))
+	store := newTestRemoteIndexStore(t, testBucket(t))
 	ctx := context.Background()
 	ns := newTestNsResource()
 
@@ -178,7 +189,7 @@ func TestRemoteIndexStore_UploadRejectsNonRegularFiles(t *testing.T) {
 	ctx := context.Background()
 	bucket := memblob.OpenBucket(nil)
 	defer func() { _ = bucket.Close() }()
-	store := NewBucketRemoteIndexStore(bucket)
+	store := newTestRemoteIndexStore(t, bucket)
 	ns := newTestNsResource()
 
 	srcDir := createTestBleveIndex(t)
@@ -198,7 +209,7 @@ func TestRemoteIndexStore_DownloadRejectsCorruptMetaJSON(t *testing.T) {
 	ctx := context.Background()
 	bucket := memblob.OpenBucket(nil)
 	defer func() { _ = bucket.Close() }()
-	store := NewBucketRemoteIndexStore(bucket)
+	store := newTestRemoteIndexStore(t, bucket)
 	ns := newTestNsResource()
 	key := ulid.Make()
 	pfx := indexPrefix(ns, key.String())
@@ -263,7 +274,7 @@ func TestRemoteIndexStore_DownloadValidatesCompleteness(t *testing.T) {
 	ctx := context.Background()
 	bucket := memblob.OpenBucket(nil)
 	defer func() { _ = bucket.Close() }()
-	store := NewBucketRemoteIndexStore(bucket)
+	store := newTestRemoteIndexStore(t, bucket)
 	ns := newTestNsResource()
 
 	srcDir := createTestBleveIndex(t)
@@ -290,7 +301,7 @@ func TestRemoteIndexStore_UploadRejectsEmptyDirectory(t *testing.T) {
 	ctx := context.Background()
 	bucket := memblob.OpenBucket(nil)
 	defer func() { _ = bucket.Close() }()
-	store := NewBucketRemoteIndexStore(bucket)
+	store := newTestRemoteIndexStore(t, bucket)
 	ns := newTestNsResource()
 
 	emptyDir := t.TempDir()
@@ -304,7 +315,7 @@ func TestRemoteIndexStore_UploadExcludesMetaJSON(t *testing.T) {
 	ctx := context.Background()
 	bucket := memblob.OpenBucket(nil)
 	defer func() { _ = bucket.Close() }()
-	store := NewBucketRemoteIndexStore(bucket)
+	store := newTestRemoteIndexStore(t, bucket)
 	ns := newTestNsResource()
 
 	srcDir := createTestBleveIndex(t)
@@ -380,7 +391,7 @@ func TestRemoteIndexStore_BucketErrors(t *testing.T) {
 
 	uploadSnapshot := func(t *testing.T, bucket *blob.Bucket) ulid.ULID {
 		t.Helper()
-		store := NewBucketRemoteIndexStore(bucket)
+		store := newTestRemoteIndexStore(t, bucket)
 		srcDir := createTestBleveIndex(t)
 		meta := IndexMeta{GrafanaBuildVersion: "11.0.0", LatestResourceVersion: 10}
 		key, err := store.UploadIndex(ctx, ns, srcDir, meta)
@@ -391,7 +402,7 @@ func TestRemoteIndexStore_BucketErrors(t *testing.T) {
 	t.Run("upload file error", func(t *testing.T) {
 		real := memblob.OpenBucket(nil)
 		defer func() { _ = real.Close() }()
-		store := NewBucketRemoteIndexStore(&errorBucket{CDKBucket: real, uploadErr: fmt.Errorf("upload network timeout")})
+		store := newTestRemoteIndexStore(t, &errorBucket{CDKBucket: real, uploadErr: fmt.Errorf("upload network timeout")})
 
 		_, err := store.UploadIndex(ctx, ns, createTestBleveIndex(t),
 			IndexMeta{GrafanaBuildVersion: "11.0.0", LatestResourceVersion: 10})
@@ -402,7 +413,7 @@ func TestRemoteIndexStore_BucketErrors(t *testing.T) {
 	t.Run("meta.json write error", func(t *testing.T) {
 		real := memblob.OpenBucket(nil)
 		defer func() { _ = real.Close() }()
-		store := NewBucketRemoteIndexStore(&errorBucket{CDKBucket: real, writeAllErr: fmt.Errorf("write quota exceeded")})
+		store := newTestRemoteIndexStore(t, &errorBucket{CDKBucket: real, writeAllErr: fmt.Errorf("write quota exceeded")})
 
 		_, err := store.UploadIndex(ctx, ns, createTestBleveIndex(t),
 			IndexMeta{GrafanaBuildVersion: "11.0.0", LatestResourceVersion: 10})
@@ -413,7 +424,7 @@ func TestRemoteIndexStore_BucketErrors(t *testing.T) {
 	t.Run("meta.json download error", func(t *testing.T) {
 		real := memblob.OpenBucket(nil)
 		defer func() { _ = real.Close() }()
-		store := NewBucketRemoteIndexStore(&errorBucket{
+		store := newTestRemoteIndexStore(t, &errorBucket{
 			CDKBucket: real,
 			downloadFn: func(key string) error {
 				if strings.HasSuffix(key, "/meta.json") {
@@ -432,7 +443,7 @@ func TestRemoteIndexStore_BucketErrors(t *testing.T) {
 		real := memblob.OpenBucket(nil)
 		defer func() { _ = real.Close() }()
 		key := uploadSnapshot(t, real)
-		store := NewBucketRemoteIndexStore(&errorBucket{CDKBucket: real, downloadErr: fmt.Errorf("connection reset")})
+		store := newTestRemoteIndexStore(t, &errorBucket{CDKBucket: real, downloadErr: fmt.Errorf("connection reset")})
 
 		parentDir := t.TempDir()
 		destDir := filepath.Join(parentDir, "downloaded")
@@ -454,7 +465,7 @@ func TestRemoteIndexStore_BucketErrors(t *testing.T) {
 		real := memblob.OpenBucket(nil)
 		defer func() { _ = real.Close() }()
 		key := uploadSnapshot(t, real)
-		store := NewBucketRemoteIndexStore(real)
+		store := newTestRemoteIndexStore(t, real)
 
 		destDir := t.TempDir() // already exists
 		_, err := store.DownloadIndex(ctx, ns, key, destDir)
@@ -466,7 +477,7 @@ func TestRemoteIndexStore_BucketErrors(t *testing.T) {
 		real := memblob.OpenBucket(nil)
 		defer func() { _ = real.Close() }()
 		key := uploadSnapshot(t, real)
-		store := NewBucketRemoteIndexStore(&errorBucket{CDKBucket: real, deleteErr: fmt.Errorf("permission denied")})
+		store := newTestRemoteIndexStore(t, &errorBucket{CDKBucket: real, deleteErr: fmt.Errorf("permission denied")})
 
 		err := store.DeleteIndex(ctx, ns, key)
 		require.Error(t, err)
@@ -478,7 +489,7 @@ func TestRemoteIndexStore_CleanupIncompleteUploads(t *testing.T) {
 	ctx := context.Background()
 	bucket := memblob.OpenBucket(nil)
 	defer func() { _ = bucket.Close() }()
-	store := NewBucketRemoteIndexStore(bucket)
+	store := newTestRemoteIndexStore(t, bucket)
 	ns := newTestNsResource()
 
 	// Upload a complete index (has meta.json)
@@ -514,7 +525,7 @@ func TestRemoteIndexStore_CleanupIncompleteUploads_NoneFound(t *testing.T) {
 	ctx := context.Background()
 	bucket := memblob.OpenBucket(nil)
 	defer func() { _ = bucket.Close() }()
-	store := NewBucketRemoteIndexStore(bucket)
+	store := newTestRemoteIndexStore(t, bucket)
 	ns := newTestNsResource()
 
 	// Upload a complete index
@@ -533,7 +544,7 @@ func TestRemoteIndexStore_CleanupIncompleteUploads_CorruptManifest(t *testing.T)
 	ctx := context.Background()
 	bucket := memblob.OpenBucket(nil)
 	defer func() { _ = bucket.Close() }()
-	store := NewBucketRemoteIndexStore(bucket)
+	store := newTestRemoteIndexStore(t, bucket)
 	ns := newTestNsResource()
 
 	// Upload a valid complete index
@@ -575,7 +586,7 @@ func TestRemoteIndexStore_CleanupIncompleteUploads_MinAge(t *testing.T) {
 	ctx := context.Background()
 	bucket := memblob.OpenBucket(nil)
 	defer func() { _ = bucket.Close() }()
-	store := NewBucketRemoteIndexStore(bucket)
+	store := newTestRemoteIndexStore(t, bucket)
 	ns := newTestNsResource()
 
 	// Create an incomplete prefix with a ULID from 2 hours ago.
@@ -605,4 +616,71 @@ func TestRemoteIndexStore_CleanupIncompleteUploads_MinAge(t *testing.T) {
 	obj, err = iter.Next(ctx)
 	require.NoError(t, err)
 	assert.NotNil(t, obj)
+}
+
+func TestRemoteIndexStore_LockBuildIndex_AcquireRelease(t *testing.T) {
+	ctx := context.Background()
+	ns := newTestNsResource()
+	backend := newFakeBackend(newConditionalBucket())
+	bucket := memblob.OpenBucket(nil)
+	defer func() { _ = bucket.Close() }()
+	store := newTestRemoteIndexStoreWithLockOwner(t, bucket, backend, "instance-1")
+
+	lock, err := store.LockBuildIndex(ctx, ns)
+	require.NoError(t, err)
+
+	select {
+	case <-lock.Lost():
+		t.Fatal("lock should not be lost")
+	default:
+	}
+
+	require.NoError(t, lock.Release())
+}
+
+func TestRemoteIndexStore_LockBuildIndex_Contention(t *testing.T) {
+	ctx := context.Background()
+	ns := newTestNsResource()
+	backend := newFakeBackend(newConditionalBucket())
+	bucket := memblob.OpenBucket(nil)
+	defer func() { _ = bucket.Close() }()
+
+	store1 := newTestRemoteIndexStoreWithLockOwner(t, bucket, backend, "instance-1")
+	store2 := newTestRemoteIndexStoreWithLockOwner(t, bucket, backend, "instance-2")
+
+	lock1, err := store1.LockBuildIndex(ctx, ns)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = lock1.Release() })
+
+	_, err = store2.LockBuildIndex(ctx, ns)
+	require.ErrorIs(t, err, errLockHeld)
+
+	require.NoError(t, lock1.Release())
+	lock2, err := store2.LockBuildIndex(ctx, ns)
+	require.NoError(t, err)
+	require.NoError(t, lock2.Release())
+}
+
+func TestRemoteIndexStore_LockBuildIndex_LostAndReleaseAfterLoss(t *testing.T) {
+	ctx := context.Background()
+	ns := newTestNsResource()
+	backend := newFakeBackend(newConditionalBucket())
+	bucket := memblob.OpenBucket(nil)
+	defer func() { _ = bucket.Close() }()
+	store := newTestRemoteIndexStoreWithLockOwner(t, bucket, backend, "instance-1")
+
+	lock, err := store.LockBuildIndex(ctx, ns)
+	require.NoError(t, err)
+
+	require.NoError(t, backend.Delete(ctx, buildIndexLockKey(ns), "instance-1"))
+
+	select {
+	case <-lock.Lost():
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected lock loss to be detected")
+	}
+
+	err = lock.Release()
+	require.True(t, err == nil || errors.Is(err, errLockNotFound), "expected nil or errLockNotFound, got %v", err)
+	require.NoError(t, lock.Release())
 }


### PR DESCRIPTION
## Summary
This PR adds distributed build-lock acquisition to `RemoteIndexStore` and implements it in `BucketRemoteIndexStore` using the existing object-storage lock primitives. It also wires lock backend/owner configuration into snapshot store construction and updates tests accordingly (including lock contention/loss coverage).