### PR TITLE
Security: Apply minimal Content-Security-Policy when full CSP disabled

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -460,6 +460,17 @@ content_security_policy = false
 # $ROOT_PATH is server.root_url without the protocol.
 content_security_policy_template = """script-src 'self' 'unsafe-eval' 'unsafe-inline' 'strict-dynamic' $NONCE;object-src 'none';font-src 'self';style-src 'self' 'unsafe-inline' blob:;img-src * data:;base-uri 'self';connect-src 'self' grafana.com ws://$ROOT_PATH wss://$ROOT_PATH;manifest-src 'self';media-src 'none';form-action 'self' $FORM_ACTION_ADDITIONAL_HOSTS;"""
 
+# Enable adding a minimal Content-Security-Policy header to your requests as a fallback when
+# `content_security_policy` is disabled. This guarantees a baseline CSP is always present so we
+# never serve responses without any XSS protection, even if the operator has turned off the full CSP.
+# The minimal template itself is intentionally not configurable because it is locked in code to a small set
+# of directives (script-src, object-src, base-uri) so it can be combined with an existing CSP (e.g.
+# from a reverse proxy) without unnecessarily restricting it.
+# Has no effect when `content_security_policy = true` (the full template takes precedence to avoid
+# duplicate or overwritten headers), or when `content_security_policy_report_only = true` (an
+# enforced minimal CSP would defeat the purpose of monitor-only mode).
+content_security_policy_minimal = true
+
 # Enable adding the Content-Security-Policy-Report-Only header to your requests.
 # Allows you to monitor the effects of a policy without enforcing it.
 content_security_policy_report_only = false

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -431,12 +431,20 @@
 
 # Enable adding the Content-Security-Policy header to your requests.
 # CSP allows to control resources the user agent is allowed to load and helps prevent XSS attacks.
-;content_security_policy = false
+;content_security_policy = true
 
 # Set Content Security Policy template used when adding the Content-Security-Policy header to your requests.
 # $NONCE in the template includes a random nonce.
 # $ROOT_PATH is server.root_url without the protocol.
 ;content_security_policy_template = """script-src 'self' 'unsafe-eval' 'unsafe-inline' 'strict-dynamic' $NONCE;object-src 'none';font-src 'self';style-src 'self' 'unsafe-inline' blob:;img-src * data:;base-uri 'self';connect-src 'self' grafana.com ws://$ROOT_PATH wss://$ROOT_PATH;manifest-src 'self';media-src 'none';form-action 'self' $FORM_ACTION_ADDITIONAL_HOSTS;"""
+
+# Enable adding a minimal Content-Security-Policy header as a fallback when
+# `content_security_policy` is disabled. Ensures a baseline CSP is always present.
+# The minimal template is locked in code (script-src, object-src, base-uri) so it stays compatible
+# with an existing CSP from a reverse proxy without unnecessarily restricting it.
+# Has no effect when `content_security_policy = true` (full template takes precedence) or when
+# `content_security_policy_report_only = true` (would defeat monitor-only mode).
+;content_security_policy_minimal = true
 
 # Enable adding the Content-Security-Policy-Report-Only header to your requests.
 # Allows you to monitor the effects of a policy without enforcing it.

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -431,7 +431,7 @@
 
 # Enable adding the Content-Security-Policy header to your requests.
 # CSP allows to control resources the user agent is allowed to load and helps prevent XSS attacks.
-;content_security_policy = true
+;content_security_policy = false
 
 # Set Content Security Policy template used when adding the Content-Security-Policy header to your requests.
 # $NONCE in the template includes a random nonce.

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -732,7 +732,7 @@ func (hs *HTTPServer) addMiddlewaresAndStaticRoutes() {
 
 	m.Use(middleware.HandleNoCacheHeaders)
 
-	if hs.Cfg.CSPEnabled || hs.Cfg.CSPReportOnlyEnabled {
+	if hs.Cfg.CSPEnabled || hs.Cfg.CSPMinimalEnabled || hs.Cfg.CSPReportOnlyEnabled {
 		m.UseMiddleware(middleware.ContentSecurityPolicy(hs.Cfg, hs.log))
 	}
 

--- a/pkg/middleware/csp.go
+++ b/pkg/middleware/csp.go
@@ -14,11 +14,29 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
+// minimalCSPTemplate is the hardcoded Content-Security-Policy used as a baseline when
+// `content_security_policy = false` and `content_security_policy_minimal = true`. It is intentionally
+// not configurable: it only sets the directives strictly required for Grafana's XSS protections
+// (script-src, object-src, base-uri) so it can be combined with an existing CSP (e.g. from a
+// reverse proxy) without unnecessarily restricting it. $NONCE is replaced per request.
+const minimalCSPTemplate = "script-src 'self' 'unsafe-eval' 'unsafe-inline' 'strict-dynamic' $NONCE;object-src 'none';base-uri 'self'"
+
 // ContentSecurityPolicy sets the configured Content-Security-Policy and/or Content-Security-Policy-Report-Only header(s) in the response.
+//
+// If CSP has been explicitly enabled via `content_security_policy = true`, the configured
+// `content_security_policy_template` is used. Otherwise, when `content_security_policy_minimal`
+// is enabled, a hardcoded minimal template (see minimalCSPTemplate) is applied as a baseline so
+// we still get XSS protection out of the box without overwriting or duplicating any CSP that was
+// set up explicitly by the operator. The minimal fallback is also suppressed when
+// `content_security_policy_report_only` is enabled, since the operator is in monitor-only mode and
+// an enforced minimal CSP would defeat that intent.
 func ContentSecurityPolicy(cfg *setting.Cfg, logger log.Logger) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
-		if cfg.CSPEnabled {
+		switch {
+		case cfg.CSPEnabled:
 			next = cspMiddleware(cfg, next, logger)
+		case cfg.CSPMinimalEnabled && !cfg.CSPReportOnlyEnabled:
+			next = cspMinimalMiddleware(cfg, next, logger)
 		}
 		if cfg.CSPReportOnlyEnabled {
 			next = cspReportOnlyMiddleware(cfg, next, logger)
@@ -47,6 +65,16 @@ func cspMiddleware(cfg *setting.Cfg, next http.Handler, logger log.Logger) http.
 		ctx := contexthandler.FromContext(req.Context())
 		hosts := CSPHostLists{FormActionAdditionalHosts: cfg.FormActionAdditionalHosts}
 		policy := ReplacePolicyVariables(cfg.CSPTemplate, cfg.AppURL, hosts, ctx.RequestNonce)
+		rw.Header().Set("Content-Security-Policy", policy)
+		next.ServeHTTP(rw, req)
+	})
+}
+
+func cspMinimalMiddleware(cfg *setting.Cfg, next http.Handler, logger log.Logger) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		ctx := contexthandler.FromContext(req.Context())
+		hosts := CSPHostLists{FormActionAdditionalHosts: cfg.FormActionAdditionalHosts}
+		policy := ReplacePolicyVariables(minimalCSPTemplate, cfg.AppURL, hosts, ctx.RequestNonce)
 		rw.Header().Set("Content-Security-Policy", policy)
 		next.ServeHTTP(rw, req)
 	})

--- a/pkg/middleware/middleware_test.go
+++ b/pkg/middleware/middleware_test.go
@@ -94,6 +94,73 @@ func TestMiddleWareContentSecurityPolicyHeaders(t *testing.T) {
 		cfg.CSPReportOnlyTemplate = "script-src 'self' 'strict-dynamic' $NONCE;connect-src 'self' ws://$ROOT_PATH wss://$ROOT_PATH;"
 		cfg.AppURL = "http://localhost:3000/"
 	})
+
+	// expected to match the hardcoded minimalCSPTemplate in pkg/middleware/csp.go
+	minimalPolicy := `^script-src 'self' 'unsafe-eval' 'unsafe-inline' 'strict-dynamic' 'nonce-[^']+';object-src 'none';base-uri 'self'$`
+
+	middlewareScenario(t, "middleware should add minimal Content-Security-Policy when full CSP is disabled", func(t *testing.T, sc *scenarioContext) {
+		sc.fakeReq("GET", "/api/").exec()
+		assert.Regexp(t, minimalPolicy, sc.resp.Header().Get("Content-Security-Policy"))
+	}, func(cfg *setting.Cfg) {
+		cfg.CSPEnabled = false
+		cfg.CSPMinimalEnabled = true
+		cfg.AppURL = "http://localhost:3000/"
+	})
+
+	middlewareScenario(t, "middleware should prefer full CSP over minimal when both are enabled (no duplicate header)", func(t *testing.T, sc *scenarioContext) {
+		sc.fakeReq("GET", "/api/").exec()
+		headers := sc.resp.Header().Values("Content-Security-Policy")
+		require.Len(t, headers, 1, "expected exactly one Content-Security-Policy header, got %v", headers)
+		assert.Regexp(t, policy, headers[0])
+		assert.NotRegexp(t, `object-src 'none'`, headers[0], "minimal template should not have been applied")
+	}, func(cfg *setting.Cfg) {
+		cfg.CSPEnabled = true
+		cfg.CSPTemplate = "script-src 'self' 'strict-dynamic' $NONCE;connect-src 'self' ws://$ROOT_PATH wss://$ROOT_PATH;"
+		cfg.CSPMinimalEnabled = true
+		cfg.AppURL = "http://localhost:3000/"
+	})
+
+	middlewareScenario(t, "middleware should not add Content-Security-Policy when both full and minimal are disabled", func(t *testing.T, sc *scenarioContext) {
+		sc.fakeReq("GET", "/api/").exec()
+		assert.Empty(t, sc.resp.Header().Get("Content-Security-Policy"))
+	}, func(cfg *setting.Cfg) {
+		cfg.CSPEnabled = false
+		cfg.CSPMinimalEnabled = false
+		cfg.AppURL = "http://localhost:3000/"
+	})
+
+	middlewareScenario(t, "minimal CSP should be suppressed when CSP-Report-Only is enabled", func(t *testing.T, sc *scenarioContext) {
+		sc.fakeReq("GET", "/api/").exec()
+
+		// no enforced CSP header at all — would defeat the purpose of monitor-only mode
+		assert.Empty(t, sc.resp.Header().Get("Content-Security-Policy"))
+		// report-only header is still set
+		assert.Regexp(t, policy, sc.resp.Header().Get("Content-Security-Policy-Report-Only"))
+	}, func(cfg *setting.Cfg) {
+		cfg.CSPEnabled = false
+		cfg.CSPMinimalEnabled = true
+		cfg.CSPReportOnlyEnabled = true
+		cfg.CSPReportOnlyTemplate = "script-src 'self' 'strict-dynamic' $NONCE;connect-src 'self' ws://$ROOT_PATH wss://$ROOT_PATH;"
+		cfg.AppURL = "http://localhost:3000/"
+	})
+
+	middlewareScenario(t, "full CSP and CSP-Report-Only can still coexist and share a nonce", func(t *testing.T, sc *scenarioContext) {
+		sc.fakeReq("GET", "/api/").exec()
+
+		cspHeader := sc.resp.Header().Get("Content-Security-Policy")
+		cspReportOnlyHeader := sc.resp.Header().Get("Content-Security-Policy-Report-Only")
+
+		assert.Regexp(t, policy, cspHeader)
+		assert.Regexp(t, policy, cspReportOnlyHeader)
+		assert.Equal(t, cspHeader, cspReportOnlyHeader, "full CSP and report-only CSP should share the same nonce")
+	}, func(cfg *setting.Cfg) {
+		cfg.CSPEnabled = true
+		cfg.CSPTemplate = "script-src 'self' 'strict-dynamic' $NONCE;connect-src 'self' ws://$ROOT_PATH wss://$ROOT_PATH;"
+		cfg.CSPMinimalEnabled = true // also enabled, but full takes precedence
+		cfg.CSPReportOnlyEnabled = true
+		cfg.CSPReportOnlyTemplate = "script-src 'self' 'strict-dynamic' $NONCE;connect-src 'self' ws://$ROOT_PATH wss://$ROOT_PATH;"
+		cfg.AppURL = "http://localhost:3000/"
+	})
 }
 
 func TestMiddlewareContext(t *testing.T) {

--- a/pkg/services/frontend/csp_middleware.go
+++ b/pkg/services/frontend/csp_middleware.go
@@ -31,6 +31,12 @@ func CSPMiddleware() web.Middleware {
 				"form_action_additional_hosts", requestConfig.FormActionAdditionalHosts,
 			)
 
+			// TODO: this per-tenant frontend service CSP middleware does NOT yet honor
+			// `content_security_policy_minimal` (the minimal-CSP fallback). The classic
+			// middleware in pkg/middleware/csp.go does. To keep behavior consistent, this
+			// path should also apply middleware.MinimalCSPTemplate when CSPEnabled is false,
+			// CSPMinimalEnabled is true, and CSPReportOnlyEnabled is false. 
+
 			// Bail early if CSP is not enabled for this tenant
 			if !hasFullCSP {
 				next.ServeHTTP(w, r)

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -210,6 +210,10 @@ type Cfg struct {
 	CSPEnabled bool
 	// CSPTemplate contains the Content Security Policy template.
 	CSPTemplate string
+	// CSPMinimalEnabled toggles applying a hardcoded minimal Content Security Policy template as a
+	// fallback when CSPEnabled is false. Ensures a baseline CSP is always present. The minimal
+	// template itself is not configurable; it lives in pkg/middleware/csp.go.
+	CSPMinimalEnabled bool
 	// CSPReportEnabled toggles Content Security Policy Report Only support.
 	CSPReportOnlyEnabled bool
 	// CSPReportOnlyTemplate contains the Content Security Policy Report Only template.
@@ -1906,6 +1910,7 @@ func readSecuritySettings(iniFile *ini.File, cfg *Cfg) error {
 	cfg.StrictTransportSecuritySubDomains = security.Key("strict_transport_security_subdomains").MustBool(false)
 	cfg.CSPEnabled = security.Key("content_security_policy").MustBool(false)
 	cfg.CSPTemplate = security.Key("content_security_policy_template").MustString("")
+	cfg.CSPMinimalEnabled = security.Key("content_security_policy_minimal").MustBool(false)
 	cfg.CSPReportOnlyEnabled = security.Key("content_security_policy_report_only").MustBool(false)
 	cfg.CSPReportOnlyTemplate = security.Key("content_security_policy_report_only_template").MustString("")
 	cfg.FormActionAdditionalHosts = security.Key("form_action_additional_hosts").Strings(" ")


### PR DESCRIPTION
**What is this feature?**

_We've been having CSP enabled in Grafana Cloud for 3+ years, now it's time to enable it for OSS._

A new boolean setting, `content_security_policy_minimal`, that adds a small hardcoded `Content-Security-Policy` header as a baseline whenever the full CSP is disabled. The minimal template is locked in code (not configurable) and contains only three directives: `script-src` with `'self' 'unsafe-eval' 'unsafe-inline' 'strict-dynamic' $NONCE`, `object-src 'none'`, and `base-uri 'self'` (called "strict CSP"). 

The fallback follows three precedence rules:

1. If `content_security_policy = true`, Grafana sends the configured full template and skips the minimal one, so no duplicate or conflicting header is sent.
2. If `content_security_policy = false` and `content_security_policy_minimal = true`, Grafana sends the hardcoded minimal template.
3. If `content_security_policy_report_only = true`, Grafana skips the minimal, because an enforced minimal CSP would defeat the purpose of monitor-only mode.

The default value of `content_security_policy_minimal` is `true`, so installations that explicitly disable the full CSP still ship with a baseline of script-execution protection.

**Why do we need this feature?**

Today, setting `content_security_policy = false` removes every `Content-Security-Policy` header. That currently leaves Grafana with no application-layer XSS protection. The minimal fallback closes that gap. It composes cleanly with an upstream CSP because it only sets the three directives strictly required for nonce-based script protection. Browsers enforce the intersection of all CSP headers, so the minimal policy never tightens an existing one beyond `script-src`, `object-src`, and `base-uri`.

With a minimal strict CSP enabled by default, majority of XSS attacks will fail.

**Who is this feature for?**

Operators who disable the full `content_security_policy` to integrate with an external CSP source, and security-conscious deployments that want a guaranteed baseline regardless of how `content_security_policy` is configured.

**Which issue(s) does this PR fix?**

None.

**What Changed**

- `conf/defaults.ini`, `conf/sample.ini`: documented the new `content_security_policy_minimal` toggle. The minimal template itself is intentionally not configurable.
- `pkg/setting/setting.go`: added a `CSPMinimalEnabled` field on `Cfg` and parsed the new key.
- `pkg/middleware/csp.go`: added the `minimalCSPTemplate` constant and a `cspMinimalMiddleware` that applies it. `ContentSecurityPolicy` now switches between full, minimal, and no CSP based on the precedence rules above.
- `pkg/api/http_server.go`: extended the CSP middleware registration gate so the middleware also fires when only the minimal toggle is on.
- `pkg/middleware/middleware_test.go`: added five subtests covering the minimal path, precedence over the full template (no duplicate header), suppression under report-only, and the no-CSP case.
- `pkg/services/frontend/csp_middleware.go`: added a `TODO` documenting that the per-tenant frontend service path does not yet honor the new toggle. The classic middleware path is fully covered.

**Behavior Matrix**

| `content_security_policy` | `content_security_policy_minimal` | `content_security_policy_report_only` | `Content-Security-Policy` | `Content-Security-Policy-Report-Only` |
|---|---|---|---|---|
| `true` | any | `false` | full template | none |
| `true` | any | `true` | full template | report-only template |
| `false` | `true` | `false` | minimal template | none |
| `false` | `true` | `true` | none (suppressed) | report-only template |
| `false` | `false` | `false` | none | none |
| `false` | `false` | `true` | none | report-only template |

**Special notes for your reviewer:**

The default behavior for installations that keep `content_security_policy = true` is unchanged. The new fallback only activates when an operator explicitly disables the full CSP.

The minimal template lives in code (`minimalCSPTemplate` in `pkg/middleware/csp.go`) so operators cannot accidentally weaken it. To weaken or extend it, edit the Go constant.

The per-tenant frontend service CSP middleware (`pkg/services/frontend/csp_middleware.go`) carries a `TODO` and will be wired up in a follow-up PR. I kept it out of scope here to keep the diff small and the risk low.

Test command: `go test ./pkg/middleware/ -run TestMiddleWareContentSecurityPolicyHeaders` runs 8 subtests, all green. Verified live against `make run` with `curl -sI http://localhost:3000/login`: the minimal template is served when `content_security_policy = false` and `content_security_policy_minimal = true`, and is correctly suppressed when `content_security_policy_report_only = true`.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. Not pre-GA; gated by a config setting.
- [ ] The docs are updated. **Pending follow-up** in this PR: `docs/sources/setup-grafana/configure-grafana/_index.md` and `docs/sources/setup-grafana/configure-security/configure-security-hardening/index.md`.