### PR TITLE
Provisioning: fix memory leak in repository controller work queue

### DIFF
--- a/pkg/registry/apis/provisioning/controller/repository.go
+++ b/pkg/registry/apis/provisioning/controller/repository.go
@@ -39,12 +39,6 @@ const (
 	maxAttempts = 3
 )
 
-type queueItem struct {
-	key      string
-	obj      interface{}
-	attempts int
-}
-
 //go:generate mockery --name finalizerProcessor --structname MockFinalizerProcessor --inpackage --filename finalizer_mock.go --with-expecter
 type finalizerProcessor interface {
 	process(ctx context.Context, repo repository.Repository, finalizers []string) error
@@ -69,11 +63,11 @@ type RepositoryController struct {
 	healthChecker     *RepositoryHealthChecker
 	quotaChecker      *RepositoryQuotaChecker
 	// To allow injection for testing.
-	processFn         func(item *queueItem) error
+	processFn         func(key string) error
 	enqueueRepository func(obj any)
 	keyFunc           func(obj any) (string, error)
 
-	queue           workqueue.TypedRateLimitingInterface[*queueItem]
+	queue           workqueue.TypedRateLimitingInterface[string]
 	resyncInterval  time.Duration
 	minSyncInterval time.Duration
 	drainTimeout    time.Duration
@@ -121,8 +115,8 @@ func NewRepositoryController(
 		repoLister: repoInformer.Lister(),
 		repoSynced: repoInformer.Informer().HasSynced,
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
-			workqueue.DefaultTypedControllerRateLimiter[*queueItem](),
-			workqueue.TypedRateLimitingQueueConfig[*queueItem]{
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{
 				Name: "provisioningRepositoryController",
 			},
 		),
@@ -236,50 +230,49 @@ func (rc *RepositoryController) enqueue(obj interface{}) {
 		utilruntime.HandleError(fmt.Errorf("couldn't get key for object: %v", err))
 		return
 	}
-
-	item := queueItem{key: key, obj: obj}
-	rc.queue.Add(&item)
+	rc.queue.Add(key)
 }
 
 // processNextWorkItem deals with one key off the queue.
 // It returns false when it's time to quit.
 func (rc *RepositoryController) processNextWorkItem(ctx context.Context) bool {
-	item, quit := rc.queue.Get()
+	key, quit := rc.queue.Get()
 	if quit {
 		return false
 	}
-	defer rc.queue.Done(item)
+	defer rc.queue.Done(key)
 
-	namespace, name, _ := cache.SplitMetaNamespaceKey(item.key)
-	logger := logging.FromContext(ctx).With("work_key", item.key, "namespace", namespace, "repository", name)
+	namespace, name, _ := cache.SplitMetaNamespaceKey(key)
+	logger := logging.FromContext(ctx).With("work_key", key, "namespace", namespace, "repository", name)
 	logger.Info("RepositoryController processing key")
 
-	err := rc.processFn(item)
+	err := rc.processFn(key)
 	if err == nil {
-		rc.queue.Forget(item)
+		rc.queue.Forget(key)
 		return true
 	}
 
-	item.attempts++
-	logger = logger.With("error", err, "attempts", item.attempts)
+	// NumRequeues counts prior AddRateLimited calls; add 1 for the current attempt.
+	attempts := rc.queue.NumRequeues(key) + 1
+	logger = logger.With("error", err, "attempts", attempts)
 	logger.Error("RepositoryController failed to process key")
 
-	if item.attempts >= maxAttempts {
+	if attempts >= maxAttempts {
 		logger.Error("RepositoryController failed too many times")
-		rc.queue.Forget(item)
+		rc.queue.Forget(key)
 		return true
 	}
 
 	if !apierrors.IsServiceUnavailable(err) {
 		logger.Info("RepositoryController will not retry")
-		rc.queue.Forget(item)
+		rc.queue.Forget(key)
 		return true
 	} else {
 		logger.Info("RepositoryController will retry as service is unavailable")
 	}
 
-	utilruntime.HandleError(fmt.Errorf("%v failed with: %v", item, err))
-	rc.queue.AddRateLimited(item)
+	utilruntime.HandleError(fmt.Errorf("%v failed with: %v", key, err))
+	rc.queue.AddRateLimited(key)
 
 	return true
 }
@@ -569,11 +562,11 @@ func (rc *RepositoryController) determineSyncStatusOps(obj *provisioning.Reposit
 }
 
 //nolint:gocyclo
-func (rc *RepositoryController) process(item *queueItem) error {
-	logger := rc.logger.With("key", item.key)
+func (rc *RepositoryController) process(key string) error {
+	logger := rc.logger.With("key", key)
 	ctx := logging.Context(context.Background(), logger)
 
-	namespace, name, err := cache.SplitMetaNamespaceKey(item.key)
+	namespace, name, err := cache.SplitMetaNamespaceKey(key)
 	if err != nil {
 		return err
 	}

--- a/pkg/registry/apis/provisioning/controller/repository_test.go
+++ b/pkg/registry/apis/provisioning/controller/repository_test.go
@@ -1413,7 +1413,7 @@ func TestRepositoryController_process_HookFailureCooldownSuppressesRetry(t *test
 		tracer:        tracing.InitializeTracerForTest(),
 	}
 
-	err := rc.process(&queueItem{key: namespace + "/" + repoName})
+	err := rc.process(namespace + "/" + repoName)
 	require.NoError(t, err)
 
 	assert.Equal(t, int32(0), stub.onUpdateCalls.Load(),
@@ -1519,7 +1519,7 @@ func TestRepositoryController_process_HookFailureRecoveryAfterWorkflowsRemoved(t
 	}
 	rc, patcher := newRecoveryController(t, repo, stub)
 
-	require.NoError(t, rc.process(&queueItem{key: namespace + "/" + repoName}))
+	require.NoError(t, rc.process(namespace + "/" + repoName))
 
 	assert.Equal(t, int32(1), stub.testCalls.Load(),
 		"health refresh must run after workflows are removed even during the previous cooldown")
@@ -1581,7 +1581,7 @@ func TestRepositoryController_process_HookFailureRecoveryAfterCooldownExpires(t 
 	stub := &hookRepoStub{cfg: repo}
 	rc, patcher := newRecoveryController(t, repo, stub)
 
-	require.NoError(t, rc.process(&queueItem{key: namespace + "/" + repoName}))
+	require.NoError(t, rc.process(namespace + "/" + repoName))
 
 	assert.Equal(t, int32(0), stub.onCreateCalls.Load(),
 		"hooks must not run when the spec is observed and the webhook already exists")

--- a/pkg/registry/apis/provisioning/controller/repository_test.go
+++ b/pkg/registry/apis/provisioning/controller/repository_test.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"sync/atomic"
 	"testing"
@@ -15,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/workqueue"
 
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/controller/mocks"
@@ -954,7 +956,7 @@ func TestRepositoryController_process_QuotaUpdateTriggersReconciliation(t *testi
 				tracer:        tracing.InitializeTracerForTest(),
 			}
 
-			err := rc.process(&queueItem{key: namespace + "/" + repoName})
+			err := rc.process(namespace + "/" + repoName)
 			assert.NoError(t, err)
 
 			if tc.expectReconcile {
@@ -1049,7 +1051,7 @@ func TestRepositoryController_process_ConditionsNotOverwritten(t *testing.T) {
 		logger:        logging.DefaultLogger,
 	}
 
-	err := rc.process(&queueItem{key: "default/test-repo"})
+	err := rc.process("default/test-repo")
 	require.NoError(t, err)
 
 	// Find the last /status/conditions patch operation — if there are multiple
@@ -1201,7 +1203,7 @@ func TestRepositoryController_process_TokenRefreshedWhileOverQuota(t *testing.T)
 		logger:            logging.DefaultLogger.With("logger", loggerName),
 	}
 
-	err := rc.process(&queueItem{key: namespace + "/" + repoName})
+	err := rc.process(namespace + "/" + repoName)
 	require.NoError(t, err)
 
 	// The token patch must be present even though the repository is currently over quota.
@@ -1597,4 +1599,190 @@ func TestRepositoryController_process_HookFailureRecoveryAfterCooldownExpires(t 
 		"repository must recover after the hook-failure cooldown elapses")
 	assert.Empty(t, healthStatus.Error,
 		"recovered health status must clear HealthFailureHook")
+}
+
+// TestRepositoryController_DeduplicatesEnqueueWhileProcessing verifies that multiple enqueue
+// calls for the same key while it is being processed result in exactly one additional processing
+// round, not one per enqueue call. This guards against memory and CPU growth from status-update
+// feedback loops where every reconciliation triggers a new status patch which re-enqueues the
+// same key.
+func TestRepositoryController_DeduplicatesEnqueueWhileProcessing(t *testing.T) {
+	var processCount atomic.Int32
+	firstProcessingStarted := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	secondProcessingDone := make(chan struct{})
+
+	rc := &RepositoryController{
+		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Name: "test-dedup",
+			},
+		),
+		repoSynced:   func() bool { return true },
+		logger:       logging.DefaultLogger.With("logger", "test"),
+		drainTimeout: 5 * time.Second,
+	}
+
+	rc.processFn = func(key string) error {
+		switch processCount.Add(1) {
+		case 1:
+			close(firstProcessingStarted)
+			<-releaseFirst
+		case 2:
+			close(secondProcessingDone)
+		}
+		return nil
+	}
+
+	rc.queue.Add("test/repo")
+
+	ctx, cancel := context.WithCancel(t.Context())
+	runDone := make(chan struct{})
+	go func() {
+		rc.Run(ctx, 1, func() {}, func() {})
+		close(runDone)
+	}()
+
+	// Wait for the first processing round to start, then enqueue the same key several times.
+	<-firstProcessingStarted
+	for range 5 {
+		rc.queue.Add("test/repo")
+	}
+	close(releaseFirst)
+
+	// Wait for the second round to finish, then shut down. Once Run returns no further
+	// calls to processFn are possible, so the count is final.
+	<-secondProcessingDone
+	cancel()
+	<-runDone
+	assert.Equal(t, int32(2), processCount.Load(), "5 enqueues while processing must collapse to 1 additional round")
+}
+
+// TestRepositoryController_DeduplicatesEnqueueBeforeProcessing verifies that adding
+// the same key multiple times before any worker picks it up results in exactly one
+// processing round. This is the complement to the while-processing dedup test and
+// directly tests the dirty-set no-op path in Add() (queue.go:233).
+func TestRepositoryController_DeduplicatesEnqueueBeforeProcessing(t *testing.T) {
+	var processCount atomic.Int32
+	processingDone := make(chan struct{})
+
+	rc := &RepositoryController{
+		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Name: "test-dedup-before",
+			},
+		),
+		repoSynced:   func() bool { return true },
+		logger:       logging.DefaultLogger.With("logger", "test"),
+		drainTimeout: 5 * time.Second,
+	}
+
+	rc.processFn = func(key string) error {
+		processCount.Add(1)
+		close(processingDone)
+		return nil
+	}
+
+	// Enqueue the same key several times before any worker starts.
+	for range 5 {
+		rc.queue.Add("test/repo")
+	}
+
+	ctx, cancel := context.WithCancel(t.Context())
+	runDone := make(chan struct{})
+	go func() {
+		rc.Run(ctx, 1, func() {}, func() {})
+		close(runDone)
+	}()
+
+	// Wait for the one expected round, then shut down. Once Run returns the count is final.
+	<-processingDone
+	cancel()
+	<-runDone
+	assert.Equal(t, int32(1), processCount.Load(), "5 enqueues before pickup must collapse to 1 processing round")
+}
+
+// TestRepositoryController_ServiceUnavailableRetriesUpToMaxAttempts verifies that a
+// ServiceUnavailable error causes the key to be re-queued with backoff, and that
+// processing stops after maxAttempts total attempts. This tests the NumRequeues-based
+// attempt counting that replaced the old item.attempts field on queueItem.
+func TestRepositoryController_ServiceUnavailableRetriesUpToMaxAttempts(t *testing.T) {
+	var processCount atomic.Int32
+	allAttemptsDone := make(chan struct{})
+
+	rc := &RepositoryController{
+		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Name: "test-retry",
+			},
+		),
+		repoSynced:   func() bool { return true },
+		logger:       logging.DefaultLogger.With("logger", "test"),
+		drainTimeout: 5 * time.Second,
+	}
+
+	rc.processFn = func(key string) error {
+		if processCount.Add(1) == maxAttempts {
+			close(allAttemptsDone)
+		}
+		return apierrors.NewServiceUnavailable("test")
+	}
+
+	rc.queue.Add("test/repo")
+
+	ctx, cancel := context.WithCancel(t.Context())
+	runDone := make(chan struct{})
+	go func() {
+		rc.Run(ctx, 1, func() {}, func() {})
+		close(runDone)
+	}()
+
+	// Wait for the final attempt, then shut down. Once Run returns the count is final.
+	<-allAttemptsDone
+	cancel()
+	<-runDone
+	assert.Equal(t, int32(maxAttempts), processCount.Load(), "ServiceUnavailable should retry exactly maxAttempts times then give up")
+}
+
+// TestRepositoryController_NonRetryableErrorIsNotRetried verifies that errors other
+// than ServiceUnavailable are dropped after a single attempt with no re-queue.
+func TestRepositoryController_NonRetryableErrorIsNotRetried(t *testing.T) {
+	var processCount atomic.Int32
+	processingDone := make(chan struct{})
+
+	rc := &RepositoryController{
+		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{
+				Name: "test-no-retry",
+			},
+		),
+		repoSynced:   func() bool { return true },
+		logger:       logging.DefaultLogger.With("logger", "test"),
+		drainTimeout: 5 * time.Second,
+	}
+
+	rc.processFn = func(key string) error {
+		processCount.Add(1)
+		close(processingDone)
+		return errors.New("some non-retryable error")
+	}
+
+	rc.queue.Add("test/repo")
+
+	ctx, cancel := context.WithCancel(t.Context())
+	runDone := make(chan struct{})
+	go func() {
+		rc.Run(ctx, 1, func() {}, func() {})
+		close(runDone)
+	}()
+
+	// Wait for the one expected attempt, then shut down. Once Run returns the count is final.
+	<-processingDone
+	cancel()
+	<-runDone
+	assert.Equal(t, int32(1), processCount.Load(), "non-retryable errors must not be retried")
 }

--- a/pkg/registry/apis/provisioning/controller/repository_test.go
+++ b/pkg/registry/apis/provisioning/controller/repository_test.go
@@ -1519,7 +1519,7 @@ func TestRepositoryController_process_HookFailureRecoveryAfterWorkflowsRemoved(t
 	}
 	rc, patcher := newRecoveryController(t, repo, stub)
 
-	require.NoError(t, rc.process(namespace + "/" + repoName))
+	require.NoError(t, rc.process(namespace+"/"+repoName))
 
 	assert.Equal(t, int32(1), stub.testCalls.Load(),
 		"health refresh must run after workflows are removed even during the previous cooldown")
@@ -1581,7 +1581,7 @@ func TestRepositoryController_process_HookFailureRecoveryAfterCooldownExpires(t 
 	stub := &hookRepoStub{cfg: repo}
 	rc, patcher := newRecoveryController(t, repo, stub)
 
-	require.NoError(t, rc.process(namespace + "/" + repoName))
+	require.NoError(t, rc.process(namespace+"/"+repoName))
 
 	assert.Equal(t, int32(0), stub.onCreateCalls.Load(),
 		"hooks must not run when the spec is observed and the webhook already exists")

--- a/pkg/registry/apis/provisioning/controller/shutdown_test.go
+++ b/pkg/registry/apis/provisioning/controller/shutdown_test.go
@@ -19,8 +19,8 @@ func TestRepositoryController_Run_DrainWaitsForInFlight(t *testing.T) {
 
 	rc := &RepositoryController{
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
-			workqueue.DefaultTypedControllerRateLimiter[*queueItem](),
-			workqueue.TypedRateLimitingQueueConfig[*queueItem]{
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{
 				Name: "test-drain",
 			},
 		),
@@ -29,14 +29,14 @@ func TestRepositoryController_Run_DrainWaitsForInFlight(t *testing.T) {
 		drainTimeout: 5 * time.Second,
 	}
 
-	rc.processFn = func(item *queueItem) error {
+	rc.processFn = func(key string) error {
 		close(processingStarted)
 		<-processCh
 		processed.Store(true)
 		return nil
 	}
 
-	rc.queue.Add(&queueItem{key: "test/repo"})
+	rc.queue.Add("test/repo")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	runDone := make(chan struct{})
@@ -76,8 +76,8 @@ func TestRepositoryController_Run_DrainTimeoutForcesShutdown(t *testing.T) {
 
 	rc := &RepositoryController{
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
-			workqueue.DefaultTypedControllerRateLimiter[*queueItem](),
-			workqueue.TypedRateLimitingQueueConfig[*queueItem]{
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{
 				Name: "test-drain-timeout",
 			},
 		),
@@ -87,12 +87,12 @@ func TestRepositoryController_Run_DrainTimeoutForcesShutdown(t *testing.T) {
 	}
 
 	// processFn blocks forever to simulate a stuck reconciliation
-	rc.processFn = func(item *queueItem) error {
+	rc.processFn = func(key string) error {
 		close(processingStarted)
 		select {}
 	}
 
-	rc.queue.Add(&queueItem{key: "test/stuck"})
+	rc.queue.Add("test/stuck")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	runDone := make(chan struct{})
@@ -123,8 +123,8 @@ func TestRepositoryController_Run_OnShutdownCalledBeforeDrain(t *testing.T) {
 
 	rc := &RepositoryController{
 		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
-			workqueue.DefaultTypedControllerRateLimiter[*queueItem](),
-			workqueue.TypedRateLimitingQueueConfig[*queueItem]{
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{
 				Name: "test-shutdown-ordering",
 			},
 		),
@@ -133,13 +133,13 @@ func TestRepositoryController_Run_OnShutdownCalledBeforeDrain(t *testing.T) {
 		drainTimeout: 5 * time.Second,
 	}
 
-	rc.processFn = func(item *queueItem) error {
+	rc.processFn = func(key string) error {
 		close(processingStarted)
 		<-processCh
 		return nil
 	}
 
-	rc.queue.Add(&queueItem{key: "test/ordering"})
+	rc.queue.Add("test/ordering")
 
 	ctx, cancel := context.WithCancel(context.Background())
 	runDone := make(chan struct{})


### PR DESCRIPTION
## Summary

Fix a memory leak in `provisioning-repo-operator` that was causing OOM crashes in `prod-us-east-2` ([git-ui-sync-project#1088](https://github.com/grafana/git-ui-sync-project/issues/1088)). The leak is caused by the repository controller's work queue accumulating unbounded items — each holding a reference to a full `Repository` object — due to a missing deduplication mechanism. This PR fixes the deduplication by switching the queue item type from a pointer struct to a string key.

Fixes https://github.com/grafana/git-ui-sync-project/issues/1088

## What

- Remove `queueItem` struct and replace the queue type from `TypedRateLimitingInterface[*queueItem]` to `TypedRateLimitingInterface[string]`, using the namespace/name key as the queue item.
- `obj interface{}` on `queueItem` is removed — it was never read in `process`, which always fetches the latest object from the lister. `attempts int` is replaced by `queue.NumRequeues(key) + 1`, which the rate-limiting queue already tracks per key.

## Why

The `provisioning-repo-operator` reconciles repositories by processing items from a work queue. When the informer fires `UpdateFunc` (on any object update, including status patches written by the controller itself), `enqueue` was called:

```go
item := queueItem{key: key, obj: obj}
rc.queue.Add(&item)
```

The k8s workqueue deduplicates items using a `dirty` set with Go's `==` operator. Because each call allocated a **new** `*queueItem` pointer, two items for the same repository key were never equal — every `Add` bypassed deduplication and pushed a distinct item into the queue, each holding a full `*Repository` reference.

The queue internally maintains three sets:
- **Q (queue)**: keys waiting to be picked up by a worker.
- **P (processing)**: keys currently held by a worker, between `Get()` and `Done()`. At most one worker holds any given key at a time, preventing concurrent reconciliations of the same resource.
- **D (dirty)**: keys re-enqueued while already in P. An item in D is not yet in Q — it is a deferred signal that says "this key needs another reconciliation round once the current one finishes". When `Done(key)` is called, any D entry is automatically moved to Q.

`Done` is always called via `defer` in `processNextWorkItem` regardless of whether `processFn` succeeds or fails, so the key is always removed from P. On error, `AddRateLimited` or `Forget` is called before `Done` to handle the retry decision, but `Done` itself is unconditional.

### Example: what happens when `processFn` returns an error

Consider `default/my-repo` whose webhook setup keeps failing. Each call to `processFn` writes a status patch (via `RecordFailure`), which triggers `UpdateFunc`, which calls `enqueue`. Then `processFn` returns an error.

**Old (`*queueItem` — no deduplication):**

| Step | Event | Q | P | D |
|------|-------|---|---|---|
| 1 | Initial enqueue | `[ptr1]` | — | — |
| 2 | `Get()` — worker picks up `ptr1` | — | `{ptr1}` | — |
| 3 | `processFn` writes status → `UpdateFunc` → `enqueue` | `[ptr2]` | `{ptr1}` | — |
| 4 | `processFn` writes status again → `enqueue` (×N) | `[ptr2…ptrN]` | `{ptr1}` | — |
| 5 | `processFn` returns error → `AddRateLimited(ptr1)` schedules delayed retry | `[ptr2…ptrN]` | `{ptr1}` | — |
| 6 | `defer Done(ptr1)` → removes `ptr1` from P; D is empty → nothing pushed to Q | `[ptr2…ptrN]` | — | — |
| 7 | After delay: `ptr1` re-added to Q | `[ptr2…ptrN, ptr1]` | — | — |

Each new pointer bypasses `dirty.Has` — items accumulate in Q unboundedly. At step 7, Q holds N+1 independent items, each pinning a stale `*Repository` snapshot that cannot be GC'd until processed.

**New (`string` — deduplication by value):**

| Step | Event | Q | P | D |
|------|-------|---|---|---|
| 1 | Initial enqueue | `["default/my-repo"]` | — | — |
| 2 | `Get()` — worker picks up key; D cleared | — | `{"default/my-repo"}` | — |
| 3 | `processFn` writes status → `UpdateFunc` → `enqueue` | — | `{"default/my-repo"}` | `{"default/my-repo"}` |
| 4 | `processFn` writes status again → `enqueue` (×N) | — | `{"default/my-repo"}` | `{"default/my-repo"}` |
| 5 | `processFn` returns error → `AddRateLimited("default/my-repo")` schedules delayed retry | — | `{"default/my-repo"}` | `{"default/my-repo"}` |
| 6 | `defer Done("default/my-repo")` → removes key from P; D has key → pushed to Q | `["default/my-repo"]` | — | `{"default/my-repo"}` |
| 7 | Worker `Get()` picks up key for next round; D cleared | — | `{"default/my-repo"}` | — |
| 8 | After delay: `AddRateLimited` fires → `Add("default/my-repo")` → key in P → goes to D | — | `{"default/my-repo"}` | `{"default/my-repo"}` |

Steps 3 and 4 are identical regardless of N: `dirty.Has("default/my-repo")` returns true after the first enqueue, so all subsequent calls are no-ops. `Done` at step 6 moves the single D entry to Q — exactly one immediate retry. The delayed `AddRateLimited` at step 8 lands back in D (key is in P again), so it becomes one more deferred round rather than a new independent item. Queue depth never exceeds 1.

### Connection to the reconciliation loop

A feedback loop was introduced in [grafana#122725](https://github.com/grafana/grafana/pull/122725): when a webhook setup fails, the controller writes `HealthFailureHook` to `status.health`. The next reconciliation (triggered by that status patch) runs a health check that overwrites `status.health` with `HealthFailureHealth`, resetting the hook retry suppression. The hook runs again, fails, and the cycle repeats — generating at least one status patch per reconciliation cycle.

Under the old pointer queue, each cycle added a new `*queueItem` to the queue, which grew without bound and caused the pod to OOM. **This PR does not fix the reconciliation loop itself** — that is tracked in [git-ui-sync-project#1087](https://github.com/grafana/git-ui-sync-project/issues/1087). It fixes the memory growth mechanism: with string-keyed deduplication, queue depth is bounded at O(number of repositories) regardless of how frequently status patches fire.

## Test Plan

Four new tests in `repository_test.go` verify the behaviour of `processNextWorkItem` directly:

| Test | What it verifies |
|------|-----------------|
| `TestRepositoryController_DeduplicatesEnqueueWhileProcessing` | N enqueues while key is in P → exactly one additional processing round, not N |
| `TestRepositoryController_DeduplicatesEnqueueBeforeProcessing` | N enqueues before key is picked up → single processing round |
| `TestRepositoryController_ServiceUnavailableRetriesUpToMaxAttempts` | `ServiceUnavailable` errors retry exactly `maxAttempts` times using `NumRequeues`-based counting, then give up |
| `TestRepositoryController_NonRetryableErrorIsNotRetried` | Any other error is forgotten after one attempt with no re-queue |

All tests use channel-based synchronisation — no sleeps — and shut down `Run` after the expected rounds complete, so the final assertion on `processCount` is provably final rather than a race.