### PR TITLE
Provisioning: Fix flaky RequireRepoDashboardCount test helper

### DIFF
--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -963,20 +963,29 @@ func (h *ProvisioningTestHelper) WaitForConditionReason(t *testing.T, repoName s
 	}, WaitTimeoutDefault, WaitIntervalDefault, "%s condition should have reason %s", conditionType, expectedReason)
 }
 
-// RequireRepoDashboardCount performs a one-off check that the number of dashboards managed by the given repo matches the expected count.
+// RequireRepoDashboardCount polls the dashboards list until the number of
+// dashboards managed by the given repo matches the expected count, or the
+// default wait timeout elapses. Polling is required because SyncAndWait only
+// waits for the sync job resource to complete; the dashboards-list API may
+// not yet reflect newly-created/deleted resources at that instant.
 func (h *ProvisioningTestHelper) RequireRepoDashboardCount(t *testing.T, repoName string, expectedCount int) {
 	t.Helper()
-	dashboards, err := h.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
-	require.NoError(t, err, "failed to list dashboards")
-
-	var count int
-	for _, d := range dashboards.Items {
-		managerID, _, _ := unstructured.NestedString(d.Object, "metadata", "annotations", "grafana.app/managerId")
-		if managerID == repoName {
-			count++
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		dashboards, err := h.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
+		if !assert.NoError(c, err, "failed to list dashboards") {
+			return
 		}
-	}
-	require.Equal(t, expectedCount, count, "unexpected number of dashboards managed by repo %s", repoName)
+
+		var count int
+		for _, d := range dashboards.Items {
+			managerID, _, _ := unstructured.NestedString(d.Object, "metadata", "annotations", "grafana.app/managerId")
+			if managerID == repoName {
+				count++
+			}
+		}
+		assert.Equal(c, expectedCount, count, "unexpected number of dashboards managed by repo %s", repoName)
+	}, WaitTimeoutDefault, WaitIntervalDefault,
+		"expected %d dashboard(s) managed by repo %s", expectedCount, repoName)
 }
 
 // TriggerConnectionReconciliation forces the controller to re-process a connection


### PR DESCRIPTION
**What is this feature?**

Wrap the list+count logic in `ProvisioningTestHelper.RequireRepoDashboardCount` in `require.EventuallyWithT` instead of a one-shot `require.Equal`.

**Why do we need this feature?**

The helper did a synchronous check immediately after `SyncAndWait`. `SyncAndWait`/`AwaitJobs` waits for the sync job resource to complete but not for the dashboards-list API to index newly-created or deleted resources, so the one-off check raced with eventual consistency and intermittently failed with `expected: N, actual: 0`. Mirrors the already-working `GitTestHelper` sibling at line 2742.

**Who is this feature for?**

Provisioning engineers — removes a shared source of flakes across ~50 call sites.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/1096
Fixes https://github.com/grafana/git-ui-sync-project/issues/1097
Fixes https://github.com/grafana/git-ui-sync-project/issues/1100

**Special notes for your reviewer:**

Verified locally: `go test -run '^(TestIntegrationProvisioning_SyncQuotaHandling|TestIntegrationProvisioning_QuotaCondition)$' -count=20 ./pkg/tests/apis/provisioning/quota/` → 20/20 pass.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.