### PR TITLE
Provisioning: Dump full job on HasState mismatch for flake triage

### DIFF
--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -2189,13 +2189,27 @@ func (h *ProvisioningTestHelper) GetRepositories() *apis.K8sResourceClient {
 type JobMatcher func(t *testing.T, job *unstructured.Unstructured)
 
 // HasState returns a matcher that asserts the job finished in the given state.
+// On mismatch it dumps the full job (spec + status) so the top-level error
+// message, errors list, summary counts, and warnings are visible in CI logs.
 func HasState(expected provisioning.JobState) JobMatcher {
 	return func(t *testing.T, job *unstructured.Unstructured) {
 		t.Helper()
 		actual := MustNestedString(job.Object, "status", "state")
 		require.Equal(t, string(expected), actual,
-			"job %q should have state %s", job.GetName(), expected)
+			"job %q should have state %s; full job:\n%s",
+			job.GetName(), expected, jobDump(job))
 	}
+}
+
+// jobDump renders a job as indented JSON for failure messages. Falls back to
+// the default formatter if marshalling fails (which should not happen for a
+// server-returned object).
+func jobDump(job *unstructured.Unstructured) string {
+	b, err := json.MarshalIndent(job.Object, "", "  ")
+	if err != nil {
+		return fmt.Sprintf("%+v (marshal error: %v)", job.Object, err)
+	}
+	return string(b)
 }
 
 // HasNoErrors returns a matcher that asserts the job completed without errors.


### PR DESCRIPTION
## Summary

- When a provisioning sync test asserts `HasState(success)` and the job is actually in `error`, the current failure message only prints the expected/actual state — not the error message, per-item errors, or summary from the job status.
- This makes flakes like [git-ui-sync#1105](https://github.com/grafana/git-ui-sync-project/issues/1105) hard to diagnose from CI logs alone: we see `expected: "success" / actual: "error"` but not *why* the job errored.
- This PR makes `HasState` dump the full job (spec + status) as indented JSON on mismatch so `status.message` (top-level error), `status.errors[]`, `status.summary`, and `status.warnings` are visible in CI.

No behavior change outside of test failure messages.

Fixes https://github.com/grafana/git-ui-sync-project/issues/1105 (will reopen if faced again)

## Test plan

- [ ] `go build ./pkg/tests/apis/provisioning/...`
- [ ] Manually force a provisioning sync test to fail (e.g. by expecting the wrong state) and confirm the failure message now includes the full job JSON