### PR TITLE
Restore dashboards: Show warning when deleted dashboards reach the retention limit

### DIFF
--- a/public/app/features/browse-dashboards/RecentlyDeletedPage.test.tsx
+++ b/public/app/features/browse-dashboards/RecentlyDeletedPage.test.tsx
@@ -1,0 +1,185 @@
+import { act, type ComponentProps, useEffect, useState } from 'react';
+import type AutoSizer from 'react-virtualized-auto-sizer';
+import { render as testRender, screen, waitFor } from 'test/test-utils';
+
+import { store } from '@grafana/data';
+import { config, setBackendSrv } from '@grafana/runtime';
+import { setupMockServer } from '@grafana/test-utils/server';
+import { backendSrv } from 'app/core/services/backend_srv';
+import { type ListMeta, type ResourceList } from 'app/features/apiserver/types';
+import { type SearchState, SearchLayout } from 'app/features/search/types';
+import { type DashboardDataDTO } from 'app/types/dashboard';
+
+import { deletedDashboardsCache } from '../search/service/deletedDashboardsCache';
+
+import RecentlyDeletedPage from './RecentlyDeletedPage';
+import { useRecentlyDeletedStateManager, type TrashStateManager } from './api/useRecentlyDeletedStateManager';
+import { DISMISS_STORAGE_KEY } from './components/DeletedDashboardsLimitBanner';
+
+setBackendSrv(backendSrv);
+setupMockServer();
+
+jest.mock('./api/useRecentlyDeletedStateManager');
+jest.mock('../search/service/deletedDashboardsCache', () => ({
+  deletedDashboardsCache: {
+    getAsResourceList: jest.fn(),
+  },
+}));
+
+jest.mock('react-virtualized-auto-sizer', () => ({
+  __esModule: true,
+  default(props: ComponentProps<typeof AutoSizer>) {
+    return <div>{props.children({ width: 800, height: 600, scaledWidth: 800, scaledHeight: 600 })}</div>;
+  },
+}));
+
+const mockUseRecentlyDeletedStateManager = useRecentlyDeletedStateManager as jest.MockedFunction<
+  typeof useRecentlyDeletedStateManager
+>;
+const mockGetAsResourceList = deletedDashboardsCache.getAsResourceList as jest.MockedFunction<
+  typeof deletedDashboardsCache.getAsResourceList
+>;
+
+function buildList(count: number, metadata: Partial<ListMeta> = {}): ResourceList<DashboardDataDTO> {
+  return {
+    apiVersion: 'v1',
+    kind: 'List',
+    metadata: { resourceVersion: '0', ...metadata },
+    items: Array.from({ length: count }, (_, i) => ({
+      apiVersion: 'dashboard.grafana.app/v1beta1',
+      kind: 'Dashboard',
+      metadata: { name: `d-${i}`, resourceVersion: '0', creationTimestamp: '2024-01-01T00:00:00Z' },
+      spec: {} as DashboardDataDTO,
+    })),
+  };
+}
+
+function buildSearchResult(seed: number) {
+  return { totalRows: 0, __seed: seed } as unknown as NonNullable<SearchState['result']>;
+}
+
+function defaultSearchState(result?: SearchState['result']): SearchState {
+  return {
+    query: '',
+    tag: [],
+    starred: false,
+    layout: SearchLayout.List,
+    deleted: true,
+    eventTrackingNamespace: 'manage_dashboards',
+    result,
+  };
+}
+
+// Reactive mock state so we can simulate `stateManager.useState` emitting new
+// values (the real hook subscribes to a BehaviorSubject; a static jest.fn()
+// mock plus React.memo on the page would otherwise swallow re-renders).
+let currentSearchState: SearchState = defaultSearchState();
+const stateSubscribers = new Set<() => void>();
+
+function publishSearchState(next: SearchState) {
+  currentSearchState = next;
+  stateSubscribers.forEach((notify) => notify());
+}
+
+const mockStateManager = {
+  initStateFromUrl: jest.fn(),
+  onQueryChange: jest.fn(),
+  onLayoutChange: jest.fn(),
+  onSortChange: jest.fn(),
+  onTagFilterChange: jest.fn(),
+  onDatasourceChange: jest.fn(),
+  onPanelTypeChange: jest.fn(),
+  onSetIncludePanels: jest.fn(),
+  getTagOptions: jest.fn().mockResolvedValue([]),
+  getSortOptions: jest.fn().mockResolvedValue([]),
+} as unknown as TrashStateManager;
+
+function render() {
+  return testRender(<RecentlyDeletedPage />, {
+    preloadedState: {
+      navIndex: {
+        'dashboards/recently-deleted': {
+          id: 'dashboards/recently-deleted',
+          text: 'Recently deleted',
+        },
+      },
+    },
+  });
+}
+
+const atLimitAlert = { name: /deleted dashboards limit reached/i };
+
+describe('RecentlyDeletedPage banner integration', () => {
+  let previousFlag: boolean | undefined;
+
+  beforeEach(() => {
+    previousFlag = config.featureToggles.restoreDashboards;
+    store.delete(DISMISS_STORAGE_KEY);
+    mockGetAsResourceList.mockReset();
+    currentSearchState = defaultSearchState();
+    stateSubscribers.clear();
+
+    mockUseRecentlyDeletedStateManager.mockImplementation(() => {
+      const [, setTick] = useState(0);
+      useEffect(() => {
+        const notify = () => setTick((n) => n + 1);
+        stateSubscribers.add(notify);
+        return () => {
+          stateSubscribers.delete(notify);
+        };
+      }, []);
+      return [currentSearchState, mockStateManager];
+    });
+  });
+
+  afterEach(() => {
+    config.featureToggles.restoreDashboards = previousFlag;
+    jest.clearAllMocks();
+  });
+
+  it('does not render the banner when the restoreDashboards feature flag is off', async () => {
+    config.featureToggles.restoreDashboards = false;
+    mockGetAsResourceList.mockResolvedValue(buildList(1000, { continue: 'next' }));
+
+    render();
+
+    // Let any pending effects settle so we can assert the banner genuinely never appears.
+    await waitFor(() => {
+      expect(screen.getByPlaceholderText('Search for dashboards')).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    expect(mockGetAsResourceList).not.toHaveBeenCalled();
+  });
+
+  it('renders the at_limit banner when the flag is on and the cache reports an overage', async () => {
+    config.featureToggles.restoreDashboards = true;
+    mockGetAsResourceList.mockResolvedValue(buildList(1000, { continue: 'next' }));
+
+    render();
+
+    expect(await screen.findByRole('alert', atLimitAlert)).toBeInTheDocument();
+  });
+
+  it('updates the banner when searchState.result changes (post-mutation reactivity)', async () => {
+    config.featureToggles.restoreDashboards = true;
+    mockGetAsResourceList.mockResolvedValue(buildList(500));
+
+    render();
+
+    await waitFor(() => {
+      expect(mockGetAsResourceList).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+
+    // Simulate the state manager finishing a new search after a delete/restore
+    // mutation: cache was invalidated, now repopulated with 1000 items, and
+    // `setState({ result, loading: false })` hands callers a fresh reference.
+    mockGetAsResourceList.mockResolvedValue(buildList(1000));
+    await act(async () => {
+      publishSearchState(defaultSearchState(buildSearchResult(2)));
+    });
+
+    expect(await screen.findByRole('alert', atLimitAlert)).toBeInTheDocument();
+    expect(mockGetAsResourceList).toHaveBeenCalledTimes(2);
+  });
+});

--- a/public/app/features/browse-dashboards/RecentlyDeletedPage.tsx
+++ b/public/app/features/browse-dashboards/RecentlyDeletedPage.tsx
@@ -4,6 +4,7 @@ import AutoSizer, { type Size } from 'react-virtualized-auto-sizer';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
 import { FilterInput, useStyles2 } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import { ActionRow } from 'app/features/search/page/components/ActionRow';
@@ -11,6 +12,7 @@ import { getGrafanaSearcher } from 'app/features/search/service/searcher';
 import { useDispatch } from 'app/types/store';
 
 import { useRecentlyDeletedStateManager } from './api/useRecentlyDeletedStateManager';
+import { DeletedDashboardsLimitBanner } from './components/DeletedDashboardsLimitBanner';
 import { RecentlyDeletedActions } from './components/RecentlyDeletedActions';
 import { RecentlyDeletedEmptyState } from './components/RecentlyDeletedEmptyState';
 import { SearchView } from './components/SearchView';
@@ -43,6 +45,7 @@ const RecentlyDeletedPage = memo(() => {
   return (
     <Page navId="dashboards/recently-deleted">
       <Page.Contents className={styles.pageContents}>
+        {config.featureToggles.restoreDashboards && <DeletedDashboardsLimitBanner resultToken={searchState.result} />}
         <div>
           <FilterInput
             placeholder={t('recentlyDeleted.filter.placeholder', 'Search for dashboards')}

--- a/public/app/features/browse-dashboards/components/DeletedDashboardsLimitBanner.test.tsx
+++ b/public/app/features/browse-dashboards/components/DeletedDashboardsLimitBanner.test.tsx
@@ -1,0 +1,151 @@
+import { render, screen, waitFor } from 'test/test-utils';
+
+import { store } from '@grafana/data';
+import { type ListMeta, type ResourceList } from 'app/features/apiserver/types';
+import { type DashboardDataDTO } from 'app/types/dashboard';
+
+import { deletedDashboardsCache } from '../../search/service/deletedDashboardsCache';
+
+import { DISMISS_STORAGE_KEY, DeletedDashboardsLimitBanner } from './DeletedDashboardsLimitBanner';
+
+jest.mock('../../search/service/deletedDashboardsCache', () => ({
+  deletedDashboardsCache: {
+    getAsResourceList: jest.fn(),
+  },
+}));
+
+const mockGetAsResourceList = deletedDashboardsCache.getAsResourceList as jest.MockedFunction<
+  typeof deletedDashboardsCache.getAsResourceList
+>;
+
+function buildList(count: number, metadata: Partial<ListMeta> = {}): ResourceList<DashboardDataDTO> {
+  return {
+    apiVersion: 'v1',
+    kind: 'List',
+    metadata: { resourceVersion: '0', ...metadata },
+    items: Array.from({ length: count }, (_, i) => ({
+      apiVersion: 'dashboard.grafana.app/v1beta1',
+      kind: 'Dashboard',
+      metadata: { name: `d-${i}`, resourceVersion: '0', creationTimestamp: '2024-01-01T00:00:00Z' },
+      spec: {} as DashboardDataDTO,
+    })),
+  };
+}
+
+function mockCache(list: ResourceList<DashboardDataDTO>) {
+  mockGetAsResourceList.mockResolvedValue(list);
+}
+
+const atLimitAlert = { name: /deleted dashboards limit reached/i };
+
+describe('DeletedDashboardsLimitBanner', () => {
+  beforeEach(() => {
+    store.delete(DISMISS_STORAGE_KEY);
+    mockGetAsResourceList.mockReset();
+  });
+
+  describe('does not render', () => {
+    it('when count is below the limit', async () => {
+      mockCache(buildList(999));
+      render(<DeletedDashboardsLimitBanner resultToken={1} />);
+      await waitFor(() => {
+        expect(mockGetAsResourceList).toHaveBeenCalled();
+      });
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
+    it('when the cache returns an empty list (fetch failed)', async () => {
+      mockCache(buildList(0));
+      render(<DeletedDashboardsLimitBanner resultToken={1} />);
+      await waitFor(() => {
+        expect(mockGetAsResourceList).toHaveBeenCalled();
+      });
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+
+    it('when continue is set but count + 1 stays below the limit', async () => {
+      // listFromTrash cuts pages when pageBytes >= maxPageBytes (default 2 MiB), so a small page
+      // with `continue` set is a legitimate shape that must not trigger at_limit.
+      mockCache(buildList(998, { continue: 'next-page-token' }));
+      render(<DeletedDashboardsLimitBanner resultToken={1} />);
+      await waitFor(() => {
+        expect(mockGetAsResourceList).toHaveBeenCalled();
+      });
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('at_limit state', () => {
+    it('renders when count === 1000 with no continuation token (future-proof path)', async () => {
+      mockCache(buildList(1000));
+      render(<DeletedDashboardsLimitBanner resultToken={1} />);
+
+      const alert = await screen.findByRole('alert', atLimitAlert);
+      expect(alert).toHaveTextContent(/Grafana retains up to 1000 recently deleted dashboards/i);
+    });
+
+    it("renders when count === 1000 and continue is set (today's overage path)", async () => {
+      mockCache(buildList(1000, { continue: 'next-page-token' }));
+      render(<DeletedDashboardsLimitBanner resultToken={1} />);
+
+      expect(await screen.findByRole('alert', atLimitAlert)).toBeInTheDocument();
+    });
+
+    it('renders when count === 999 and continue is set (backend chunked below the limit)', async () => {
+      mockCache(buildList(999, { continue: 'next-page-token' }));
+      render(<DeletedDashboardsLimitBanner resultToken={1} />);
+
+      expect(await screen.findByRole('alert', atLimitAlert)).toBeInTheDocument();
+    });
+
+    it('renders when remainingItemCount > 0 and continue is absent', async () => {
+      mockCache(buildList(500, { remainingItemCount: 600 }));
+      render(<DeletedDashboardsLimitBanner resultToken={1} />);
+
+      expect(await screen.findByRole('alert', atLimitAlert)).toBeInTheDocument();
+    });
+  });
+
+  describe('dismiss', () => {
+    it('hides the banner when the dismiss button is clicked and persists `true` in localStorage', async () => {
+      mockCache(buildList(1000));
+      const { user } = render(<DeletedDashboardsLimitBanner resultToken={1} />);
+
+      expect(await screen.findByRole('alert', atLimitAlert)).toBeInTheDocument();
+
+      await user.click(screen.getByRole('button', { name: /close alert/i }));
+
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+      expect(store.getObject(DISMISS_STORAGE_KEY)).toBe(true);
+    });
+
+    it('stays hidden across mounts when storage has `true`', async () => {
+      store.setObject(DISMISS_STORAGE_KEY, true);
+      mockCache(buildList(1000));
+      render(<DeletedDashboardsLimitBanner resultToken={1} />);
+
+      await waitFor(() => {
+        expect(mockGetAsResourceList).toHaveBeenCalled();
+      });
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('reactivity', () => {
+    it('re-reads the cache when resultToken changes', async () => {
+      mockCache(buildList(500));
+      const { rerender } = render(<DeletedDashboardsLimitBanner resultToken={1} />);
+
+      await waitFor(() => {
+        expect(mockGetAsResourceList).toHaveBeenCalledTimes(1);
+      });
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+
+      mockCache(buildList(1000));
+      rerender(<DeletedDashboardsLimitBanner resultToken={2} />);
+
+      expect(await screen.findByRole('alert', atLimitAlert)).toBeInTheDocument();
+      expect(mockGetAsResourceList).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/public/app/features/browse-dashboards/components/DeletedDashboardsLimitBanner.tsx
+++ b/public/app/features/browse-dashboards/components/DeletedDashboardsLimitBanner.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react';
+import { useAsync } from 'react-use';
+
+import { store } from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
+import { Alert } from '@grafana/ui';
+
+import { deletedDashboardsCache } from '../../search/service/deletedDashboardsCache';
+
+export const DELETED_DASHBOARDS_LIMIT = 1000;
+export const DISMISS_STORAGE_KEY = 'grafana.recently-deleted-limit-banner.dismissed';
+
+interface Props {
+  /**
+   * Trigger used to re-read the cache after mutations. Pass the page's
+   * `searchState.result` so the banner refreshes whenever a completed
+   * search replaces the reference (which happens after every delete / restore
+   * cycle that invalidates the cache).
+   */
+  resultToken: unknown;
+}
+
+export function DeletedDashboardsLimitBanner({ resultToken }: Props) {
+  const { value: data } = useAsync(() => deletedDashboardsCache.getAsResourceList(), [resultToken]);
+  const [dismissed, setDismissed] = useState<boolean>(() => store.getObject(DISMISS_STORAGE_KEY) === true);
+
+  if (!data || dismissed) {
+    return null;
+  }
+
+  const count = data.items.length;
+  const lowerBoundOfMissing = data.metadata.remainingItemCount ?? (data.metadata.continue ? 1 : 0);
+  const atLimit = count + lowerBoundOfMissing >= DELETED_DASHBOARDS_LIMIT;
+
+  if (!atLimit) {
+    return null;
+  }
+
+  const handleDismiss = () => {
+    store.setObject(DISMISS_STORAGE_KEY, true);
+    setDismissed(true);
+  };
+
+  return (
+    <Alert
+      severity="warning"
+      title={t('recently-deleted.limit-banner.at-limit-title', 'Deleted dashboards limit reached')}
+      onRemove={handleDismiss}
+    >
+      <Trans i18nKey="recently-deleted.limit-banner.at-limit-body" values={{ limit: DELETED_DASHBOARDS_LIMIT }}>
+        Grafana retains up to {'{{limit}}'} recently deleted dashboards. Older entries are permanently removed.
+      </Trans>
+    </Alert>
+  );
+}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -14206,6 +14206,10 @@
     "buttons": {
       "restore": "Restore"
     },
+    "limit-banner": {
+      "at-limit-body": "Grafana retains up to {{limit}} recently deleted dashboards. Older entries are permanently removed.",
+      "at-limit-title": "Deleted dashboards limit reached"
+    },
     "page": {
       "no-deleted-dashboards": "You haven't deleted any dashboards recently.",
       "no-deleted-dashboards-text": "When you delete a dashboard, it will be kept in the history for up to 12 months before being permanently deleted. Users with delete permissions can restore the dashboards they deleted, and admins can restore dashboards deleted by any user.",


### PR DESCRIPTION
**What is this feature?**

Adds a dismissible warning banner on the Recently Deleted dashboards page that surfaces once Grafana's 1000-item retention cap for soft-deleted dashboards is reached. 



**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/113571

<img width="1015" height="550" alt="Screenshot 2026-04-24 at 13 13 54" src="https://github.com/user-attachments/assets/62840117-de62-4606-8114-3b2d8bedcb73" />
