### PR TITLE
Provisioning: Fix flaky inline secrets test by polling for secret cleanup

### DIFF
--- a/pkg/tests/apis/provisioning/secrets_test.go
+++ b/pkg/tests/apis/provisioning/secrets_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -87,12 +88,19 @@ func TestIntegrationProvisioning_InlineSecrets(t *testing.T) {
 
 			helper.WaitForRepositoryDeleted(t, ctx, obj.GetName())
 
-			// now check that we can no longer decrypt the requested values
-			results, err := decryptService.Decrypt(ctx, "provisioning.grafana.app", obj.GetNamespace(), created...)
-			require.NoError(t, err, "failed to execute decrypt with removed secrets")
-			for k, v := range results {
-				require.ErrorContains(t, v.Error(), "not found", "expecting not found error for all secrets: %s", k)
-			}
+			// Inline secrets are cleaned up asynchronously (owner-reference GC
+			// and the secret garbage-collection worker) after the repository
+			// finalizer chain completes, so poll until every secret reports
+			// not found rather than asserting once.
+			require.EventuallyWithT(t, func(collect *assert.CollectT) {
+				results, err := decryptService.Decrypt(ctx, "provisioning.grafana.app", obj.GetNamespace(), created...)
+				if !assert.NoError(collect, err, "failed to execute decrypt with removed secrets") {
+					return
+				}
+				for k, v := range results {
+					assert.ErrorContains(collect, v.Error(), "not found", "expecting not found error for all secrets: %s", k)
+				}
+			}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "inline secrets should be removed after repository deletion")
 		})
 	}
 }


### PR DESCRIPTION
**What is this feature?**

Fixes a flake in `TestIntegrationProvisioning_InlineSecrets/inline_github_token_encrypted`. After `WaitForRepositoryDeleted` returns, inline `SecureValue` resources are still cleaned up asynchronously (owner-reference GC and the secret garbage-collection worker), so the test could race the cleanup and still successfully decrypt a secret. The post-deletion decrypt check is now wrapped in `require.EventuallyWithT` (using the shared `WaitTimeoutDefault` / `WaitIntervalDefault`) so it polls until every secret reports not found.

**Why do we need this feature?**

The provisioning finalizer chain (`Clean` → `ReleaseOrphanResources` → `RemoveOrphanResources`) does not explicitly delete inline `SecureValue` resources, so their removal is eventually consistent relative to repository deletion — the test's one-shot assertion was racing that cleanup on loaded CI runners.

**Who is this feature for?**

Grafana developers — stabilizes CI for the provisioning integration tests.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

- Verified locally with 5 consecutive passing runs of the test.