### PR TITLE
Provisioning: Fix TestIntegrationProvisioning_BlockManagerChange flake

### DIFF
--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -203,19 +203,27 @@ func (h *ProvisioningTestHelper) SyncAndWait(t *testing.T, repo string, options 
 		Pull:   options,
 	})
 
-	result := h.AdminREST.Post().
-		Namespace(h.Namespace).
-		Resource("repositories").
-		Name(repo).
-		SubResource("jobs").
-		Body(body).
-		SetHeader("Content-Type", "application/json").
-		Do(t.Context())
+	post := func() rest.Result {
+		return h.AdminREST.Post().
+			Namespace(h.Namespace).
+			Resource("repositories").
+			Name(repo).
+			SubResource("jobs").
+			Body(body).
+			SetHeader("Content-Type", "application/json").
+			Do(t.Context())
+	}
 
-	if apierrors.IsAlreadyExists(result.Error()) {
-		// Wait for all jobs to finish as we don't have the name.
+	// A controller-triggered sync (e.g. the auto-resync when a repo first
+	// becomes healthy) may already be in flight when the caller invokes us.
+	// That sync may not observe state changes the caller just made (e.g.
+	// files copied to the provisioning path), so we drain any in-flight
+	// jobs and retry the POST to guarantee a sync runs against current state.
+	result := post()
+	const maxRetries = 3
+	for i := 0; apierrors.IsAlreadyExists(result.Error()) && i < maxRetries; i++ {
 		h.AwaitJobs(t, repo)
-		return
+		result = post()
 	}
 
 	obj, err := result.Get()


### PR DESCRIPTION
## Summary

Fixes flaky `TestIntegrationProvisioning_BlockManagerChange` (grafana/git-ui-sync-project#1110).

When a repository first becomes healthy, the repository controller auto-triggers a full resync (see `determineSyncStrategy` at `pkg/registry/apis/provisioning/controller/repository.go:434`). In the flake window, that auto-sync is still in flight when `CreateLocalRepo` returns from `WaitForHealthyRepository`, copies files onto disk, and calls `SyncAndWait`.

The old `SyncAndWait` handled `IsAlreadyExists` by waiting for existing jobs to drain — but those existing jobs had started **before** the file copy, so the test observed the root folder (created by the auto-sync) without the dashboard.

## Changes

- `SyncAndWait` now drains in-flight jobs and retries the POST (up to 3×) when `IsAlreadyExists` is returned, guaranteeing that a sync runs against the caller's post-setup state.

## Testing

- Ran the flaky test 10× locally without failures.
- Ran the full `TestIntegrationProvisioning_*` suite — all passing.

Closes grafana/git-ui-sync-project#1110

🤖 Generated with [Claude Code](https://claude.com/claude-code)