### PR TITLE
Transformations: Add smoke tests for dashboard transformations

### DIFF
--- a/apps/dashboard/pkg/migration/testdata/golden_checksums.json
+++ b/apps/dashboard/pkg/migration/testdata/golden_checksums.json
@@ -146,6 +146,7 @@
   "dev-dashboards-output/transforms/regression-analysis.v42.json": "e91acc1f6ac61ac21b9405c6db6a1de75f0a1232f6aa75e7e535c048be11dc2f",
   "dev-dashboards-output/transforms/reuse.v42.json": "596dc084f29bdbffdf85d17061f4d832da2c3e567d144241da2f0aa3b3779047",
   "dev-dashboards-output/transforms/rows-to-fields.v42.json": "c75bdb93aef097345930bb9ddde41debffaa7279843437bffbc02eb3497cf298",
+  "dev-dashboards-output/transforms/smoke.v42.json": "6f78e8c47a3bdf0be65f7a08011a6b211dcc3330c94f42a1df9cea2731003499",
   "output/latest_version/v10.table_thresholds.v42.json": "7f4448ea616bfdc3c64cccb8c679273432d0a5440dd1ed6f4192cd8280dae464",
   "output/latest_version/v11.no-op-migration.v42.json": "183e5bf1b794e533d990f3059d889d0d3083b639320fbbb1c489ecb27fafa6da",
   "output/latest_version/v12.template-variables.v42.json": "7a038ac84ca3e2d9830b542f6aa4870cd271ee1a94422af55913eb454ed400cb",

--- a/devenv/dev-dashboards/transforms/smoke.json
+++ b/devenv/dev-dashboards/transforms/smoke.json
@@ -1,0 +1,280 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "target": {
+          "limit": 100,
+          "matchAny": false,
+          "tags": [],
+          "type": "dashboard"
+        },
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "grafana-testdata-datasource"
+      },
+      "description": "Three-field frame (time, value, category). Used by editor-mount smoke tests; also drives the Merge applicability check because a single frame is not mergeable.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": ["sum"],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "targets": [
+        {
+          "csvContent": "time,value,category\n2024-01-01T00:00:00Z,10,alpha\n2024-01-01T01:00:00Z,20,beta\n2024-01-01T02:00:00Z,30,gamma",
+          "datasource": {
+            "type": "grafana-testdata-datasource"
+          },
+          "refId": "A",
+          "scenarioId": "csv_content"
+        }
+      ],
+      "title": "Multi-field time series",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "grafana-testdata-datasource"
+      },
+      "description": "Frame without a time field. Used to assert the Format time transformation appears disabled in the picker.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": ["sum"],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "targets": [
+        {
+          "csvContent": "name,value\nalpha,1\nbeta,2\ngamma,3",
+          "datasource": {
+            "type": "grafana-testdata-datasource"
+          },
+          "refId": "A",
+          "scenarioId": "csv_content"
+        }
+      ],
+      "title": "No time field",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "grafana-testdata-datasource"
+      },
+      "description": "Two-field frame (time, value). Total field count is below the three fields required by Grouping to matrix, so its card should be disabled in the picker.",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 3,
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": ["sum"],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "targets": [
+        {
+          "csvContent": "time,value\n2024-01-01T00:00:00Z,10\n2024-01-01T01:00:00Z,20\n2024-01-01T02:00:00Z,30",
+          "datasource": {
+            "type": "grafana-testdata-datasource"
+          },
+          "refId": "A",
+          "scenarioId": "csv_content"
+        }
+      ],
+      "title": "Two fields (time, value)",
+      "type": "table"
+    },
+    {
+      "datasource": {
+        "type": "grafana-testdata-datasource"
+      },
+      "description": "Single-field frame. Used to assert Group to nested tables is disabled in the picker (it requires at least two fields on a single series).",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green"
+              }
+            ]
+          },
+          "color": {
+            "mode": "thresholds"
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": ["sum"],
+          "countRows": false,
+          "fields": ""
+        }
+      },
+      "targets": [
+        {
+          "csvContent": "value\n1\n2\n3",
+          "datasource": {
+            "type": "grafana-testdata-datasource"
+          },
+          "refId": "A",
+          "scenarioId": "csv_content"
+        }
+      ],
+      "title": "Single field (value)",
+      "type": "table"
+    }
+  ],
+  "schemaVersion": 41,
+  "tags": ["gdev", "transform", "e2e"],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Transforms - Smoke",
+  "uid": "transforms-smoke"
+}

--- a/e2e-playwright/panels-suite/panelEdit_transforms.spec.ts
+++ b/e2e-playwright/panels-suite/panelEdit_transforms.spec.ts
@@ -1,5 +1,8 @@
 import { test, expect } from '@grafana/plugin-e2e';
 
+const SMOKE_DASHBOARD_UID = 'transforms-smoke';
+const PANEL_MULTI_FIELD_TIME_SERIES = '1';
+
 test.describe(
   'Panels test: Transformations',
   {
@@ -39,6 +42,46 @@ test.describe(
       await expect(
         dashboardPage.getByGrafanaSelector(selectors.components.Panels.Panel.PanelDataErrorMessage)
       ).toBeHidden();
+    });
+
+    test('Group by editor mounts in the legacy panel edit flow', async ({ selectors, gotoDashboardPage }) => {
+      const dashboardPage = await gotoDashboardPage({
+        uid: SMOKE_DASHBOARD_UID,
+        queryParams: new URLSearchParams({ editPanel: PANEL_MULTI_FIELD_TIME_SERIES }),
+      });
+
+      await dashboardPage.getByGrafanaSelector(selectors.components.Tab.title('Transformations')).click();
+      await dashboardPage.getByGrafanaSelector(selectors.components.Transforms.addTransformationButton).click();
+      await dashboardPage.getByGrafanaSelector(selectors.components.TransformTab.newTransform('Group by')).click();
+
+      await expect(
+        dashboardPage.getByGrafanaSelector(selectors.components.TransformTab.transformationEditor('Group by'))
+      ).toBeVisible();
+      await expect(
+        dashboardPage.getByGrafanaSelector(selectors.components.Panels.Panel.PanelDataErrorMessage)
+      ).toBeHidden();
+    });
+
+    test('Merge series/tables is flagged as not applicable in the legacy picker', async ({
+      selectors,
+      gotoDashboardPage,
+    }) => {
+      const dashboardPage = await gotoDashboardPage({
+        uid: SMOKE_DASHBOARD_UID,
+        queryParams: new URLSearchParams({ editPanel: PANEL_MULTI_FIELD_TIME_SERIES }),
+      });
+
+      await dashboardPage.getByGrafanaSelector(selectors.components.Tab.title('Transformations')).click();
+      await dashboardPage.getByGrafanaSelector(selectors.components.Transforms.addTransformationButton).click();
+
+      const card = dashboardPage.getByGrafanaSelector(
+        selectors.components.TransformTab.newTransform('Merge series/tables')
+      );
+      await expect(card).toBeVisible();
+
+      const applicabilityInfo = card.getByTestId(selectors.components.Transforms.applicabilityInfo);
+      await expect(applicabilityInfo).toBeVisible();
+      await expect(applicabilityInfo).toHaveAttribute('aria-label', /at least 2 data series/);
     });
   }
 );

--- a/e2e-playwright/panels-suite/panelEdit_transforms.spec.ts
+++ b/e2e-playwright/panels-suite/panelEdit_transforms.spec.ts
@@ -54,12 +54,11 @@ test.describe(
       await dashboardPage.getByGrafanaSelector(selectors.components.Transforms.addTransformationButton).click();
       await dashboardPage.getByGrafanaSelector(selectors.components.TransformTab.newTransform('Group by')).click();
 
-      await expect(
-        dashboardPage.getByGrafanaSelector(selectors.components.TransformTab.transformationEditor('Group by'))
-      ).toBeVisible();
-      await expect(
-        dashboardPage.getByGrafanaSelector(selectors.components.Panels.Panel.PanelDataErrorMessage)
-      ).toBeHidden();
+      const editor = dashboardPage.getByGrafanaSelector(
+        selectors.components.TransformTab.transformationEditor('Group by')
+      );
+      await expect(editor).toBeVisible();
+      await expect(editor.getByRole('alert', { name: 'An unexpected error happened' })).toBeHidden();
     });
 
     test('Merge series/tables is flagged as not applicable in the legacy picker', async ({

--- a/e2e-playwright/panels-suite/panelEdit_transformsSmoke.spec.ts
+++ b/e2e-playwright/panels-suite/panelEdit_transformsSmoke.spec.ts
@@ -1,0 +1,191 @@
+import { type Page } from '@playwright/test';
+
+import { test, expect, type E2ESelectorGroups } from '@grafana/plugin-e2e';
+
+// High-signal smoke coverage for dashboard transformations under the Query Editor Next
+// surface. Tests here are deliberately small and canary-focused:
+//
+//   1. Editor-mount smokes: click-through the picker for a representative set of
+//      transformations whose `defaultOptions` shapes differ, asserting each editor
+//      renders without an inline panel error. These guard against regressions in the
+//      registry/editor contract exposed by lazy-loaded editors.
+//
+//   2. Picker applicability: for data shapes that make specific transformations
+//      unapplicable, assert the card still exposes the applicability info affordance.
+//      The substring match on the tooltip text is intentional because the full
+//      description includes a runtime number (like the current field count);
+//      matching only a stable part keeps the test focused on the applicability
+//      behavior and won't break when the count changes.
+
+test.use({
+  openFeature: {
+    flags: {
+      queryEditorNext: true,
+    },
+  },
+});
+
+const DASHBOARD_UID = 'transforms-smoke';
+const PANEL_MULTI_FIELD_TIME_SERIES = '1';
+const PANEL_NO_TIME_FIELD = '2';
+const PANEL_TWO_FIELDS = '3';
+const PANEL_SINGLE_FIELD = '4';
+
+function editPanelUrl(panelId: string) {
+  return new URLSearchParams({ editPanel: panelId });
+}
+
+function addTransformationButton(page: Page) {
+  return page.getByLabel('Add transformation');
+}
+
+async function openTransformationPicker(page: Page, selectors: E2ESelectorGroups) {
+  await addTransformationButton(page).click();
+
+  const searchInput = page.getByTestId(selectors.components.Transforms.searchInput);
+  await expect(searchInput).toBeVisible();
+  return searchInput;
+}
+
+async function pickTransformationCard(page: Page, selectors: E2ESelectorGroups, name: string) {
+  const searchInput = await openTransformationPicker(page, selectors);
+  // Narrow the grid down to the target card so the click can't land on an
+  // adjacent tile from the virtualized grid.
+  await searchInput.fill(name);
+
+  const card = page.getByTestId(selectors.components.TransformTab.newTransform(name));
+  await expect(card).toBeVisible();
+  return card;
+}
+
+async function assertEditorMountsFor(page: Page, selectors: E2ESelectorGroups, name: string) {
+  const card = await pickTransformationCard(page, selectors, name);
+  await card.click();
+
+  await expect(page.getByTestId(selectors.components.TransformTab.transformationEditor(name))).toBeVisible();
+  await expect(page.getByTestId(selectors.components.Panels.Panel.PanelDataErrorMessage)).toBeHidden();
+}
+
+async function assertTransformationPickerDisabled(
+  page: Page,
+  selectors: E2ESelectorGroups,
+  name: string,
+  descriptionSubstring: string
+) {
+  const card = await pickTransformationCard(page, selectors, name);
+
+  // TransformationCard renders the applicability info button only when the
+  // transformation reports itself as not applicable for the current input data.
+  // Scoping the locator inside the card's data-testid isolates the assertion
+  // from other disabled cards that might appear in the picker.
+  const applicabilityInfo = card.getByTestId(selectors.components.Transforms.applicabilityInfo);
+  await expect(applicabilityInfo).toBeVisible();
+  await expect(applicabilityInfo).toHaveAttribute('aria-label', new RegExp(descriptionSubstring));
+}
+
+// ---------------------------------------------------------------------------
+// Editor-mount smokes
+// ---------------------------------------------------------------------------
+//
+// All mount assertions run against the multi-field time-series panel, which has
+// three fields including a time column — enough to satisfy every transformation's
+// applicability check so the picker click lands on an enabled card.
+test.describe('Query Editor Next: Transformation editor mount smoke', { tag: ['@panels', '@queryEditorNext'] }, () => {
+  test.beforeEach(async ({ gotoDashboardPage, selectors }) => {
+    const dashboardPage = await gotoDashboardPage({
+      uid: DASHBOARD_UID,
+      queryParams: editPanelUrl(PANEL_MULTI_FIELD_TIME_SERIES),
+    });
+    await expect(dashboardPage.getByGrafanaSelector(selectors.components.PanelEditor.General.content)).toBeVisible();
+  });
+
+  test('Reduce editor mounts with default options', async ({ page, selectors }) => {
+    await assertEditorMountsFor(page, selectors, 'Reduce');
+  });
+
+  test('Convert field type editor mounts with default options', async ({ page, selectors }) => {
+    await assertEditorMountsFor(page, selectors, 'Convert field type');
+  });
+
+  test('Group by editor mounts with default options', async ({ page, selectors }) => {
+    await assertEditorMountsFor(page, selectors, 'Group by');
+  });
+
+  test('Group to nested tables editor mounts with default options', async ({ page, selectors }) => {
+    await assertEditorMountsFor(page, selectors, 'Group to nested tables');
+  });
+
+  test('Format time editor mounts with default options', async ({ page, selectors }) => {
+    await assertEditorMountsFor(page, selectors, 'Format time');
+  });
+
+  test('Grouping to matrix editor mounts with default options', async ({ page, selectors }) => {
+    await assertEditorMountsFor(page, selectors, 'Grouping to matrix');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Picker applicability
+// ---------------------------------------------------------------------------
+//
+// Each row targets a panel whose data shape makes exactly one transformation
+// unapplicable. The applicability info affordance is the signal that the picker
+// still recognises the unsupported input — it is intentionally not an assertion
+// on click-blocking behaviour, since the card remains clickable by design.
+interface ApplicabilityCase {
+  panelId: string;
+  transformationName: string;
+  inputDescription: string;
+  tooltipSubstring: string;
+}
+
+const applicabilityCases: ApplicabilityCase[] = [
+  {
+    panelId: PANEL_MULTI_FIELD_TIME_SERIES,
+    transformationName: 'Merge series/tables',
+    inputDescription: 'a single-series input',
+    tooltipSubstring: 'at least 2 data series',
+  },
+  {
+    panelId: PANEL_NO_TIME_FIELD,
+    transformationName: 'Format time',
+    inputDescription: 'an input without a time field',
+    tooltipSubstring: 'requires a time field',
+  },
+  {
+    panelId: PANEL_TWO_FIELDS,
+    transformationName: 'Grouping to matrix',
+    inputDescription: 'an input with fewer than three fields',
+    tooltipSubstring: 'at least 3 fields',
+  },
+  {
+    panelId: PANEL_SINGLE_FIELD,
+    transformationName: 'Group to nested tables',
+    inputDescription: 'an input with a single field',
+    tooltipSubstring: 'at least 2 fields',
+  },
+];
+
+test.describe(
+  'Query Editor Next: Transformation picker applicability',
+  { tag: ['@panels', '@queryEditorNext'] },
+  () => {
+    for (const { panelId, transformationName, inputDescription, tooltipSubstring } of applicabilityCases) {
+      test(`${transformationName} is flagged as not applicable for ${inputDescription}`, async ({
+        gotoDashboardPage,
+        selectors,
+        page,
+      }) => {
+        const dashboardPage = await gotoDashboardPage({
+          uid: DASHBOARD_UID,
+          queryParams: editPanelUrl(panelId),
+        });
+        await expect(
+          dashboardPage.getByGrafanaSelector(selectors.components.PanelEditor.General.content)
+        ).toBeVisible();
+
+        await assertTransformationPickerDisabled(page, selectors, transformationName, tooltipSubstring);
+      });
+    }
+  }
+);

--- a/e2e-playwright/panels-suite/panelEdit_transformsSmoke.spec.ts
+++ b/e2e-playwright/panels-suite/panelEdit_transformsSmoke.spec.ts
@@ -62,8 +62,9 @@ async function assertEditorMountsFor(page: Page, selectors: E2ESelectorGroups, n
   const card = await pickTransformationCard(page, selectors, name);
   await card.click();
 
-  await expect(page.getByTestId(selectors.components.TransformTab.transformationEditor(name))).toBeVisible();
-  await expect(page.getByTestId(selectors.components.Panels.Panel.PanelDataErrorMessage)).toBeHidden();
+  const editor = page.getByTestId(selectors.components.TransformTab.transformationEditor(name));
+  await expect(editor).toBeVisible();
+  await expect(editor.getByRole('alert', { name: 'An unexpected error happened' })).toBeHidden();
 }
 
 async function assertTransformationPickerDisabled(
@@ -90,6 +91,15 @@ async function assertTransformationPickerDisabled(
 // All mount assertions run against the multi-field time-series panel, which has
 // three fields including a time column — enough to satisfy every transformation's
 // applicability check so the picker click lands on an enabled card.
+const mountSmokeTransformations = [
+  'Reduce',
+  'Convert field type',
+  'Group by',
+  'Group to nested tables',
+  'Format time',
+  'Grouping to matrix',
+];
+
 test.describe('Query Editor Next: Transformation editor mount smoke', { tag: ['@panels', '@queryEditorNext'] }, () => {
   test.beforeEach(async ({ gotoDashboardPage, selectors }) => {
     const dashboardPage = await gotoDashboardPage({
@@ -99,29 +109,11 @@ test.describe('Query Editor Next: Transformation editor mount smoke', { tag: ['@
     await expect(dashboardPage.getByGrafanaSelector(selectors.components.PanelEditor.General.content)).toBeVisible();
   });
 
-  test('Reduce editor mounts with default options', async ({ page, selectors }) => {
-    await assertEditorMountsFor(page, selectors, 'Reduce');
-  });
-
-  test('Convert field type editor mounts with default options', async ({ page, selectors }) => {
-    await assertEditorMountsFor(page, selectors, 'Convert field type');
-  });
-
-  test('Group by editor mounts with default options', async ({ page, selectors }) => {
-    await assertEditorMountsFor(page, selectors, 'Group by');
-  });
-
-  test('Group to nested tables editor mounts with default options', async ({ page, selectors }) => {
-    await assertEditorMountsFor(page, selectors, 'Group to nested tables');
-  });
-
-  test('Format time editor mounts with default options', async ({ page, selectors }) => {
-    await assertEditorMountsFor(page, selectors, 'Format time');
-  });
-
-  test('Grouping to matrix editor mounts with default options', async ({ page, selectors }) => {
-    await assertEditorMountsFor(page, selectors, 'Grouping to matrix');
-  });
+  for (const name of mountSmokeTransformations) {
+    test(`${name} editor mounts with default options`, async ({ page, selectors }) => {
+      await assertEditorMountsFor(page, selectors, name);
+    });
+  }
 });
 
 // ---------------------------------------------------------------------------

--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -3375,16 +3375,6 @@
       "count": 1
     }
   },
-  "public/app/plugins/datasource/prometheus/configuration/AzureAuthSettings.tsx": {
-    "@grafana/no-gf-form": {
-      "count": 1
-    }
-  },
-  "public/app/plugins/datasource/prometheus/configuration/AzureCredentialsForm.tsx": {
-    "@grafana/no-gf-form": {
-      "count": 15
-    }
-  },
   "public/app/plugins/datasource/tempo/QueryField.tsx": {
     "react-prefer-function-component/react-prefer-function-component": {
       "count": 1

--- a/packages/grafana-e2e-selectors/src/selectors/components.ts
+++ b/packages/grafana-e2e-selectors/src/selectors/components.ts
@@ -963,6 +963,9 @@ export const versionedComponents = {
     card: {
       '10.1.0': (name: string) => `data-testid New transform ${name}`,
     },
+    applicabilityInfo: {
+      '13.1.0': 'data-testid Transformation applicability info',
+    },
     disableTransformationButton: {
       '10.4.0': 'data-testid Disable transformation button',
     },

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationCard.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationCard.tsx
@@ -78,7 +78,12 @@ export function TransformationCard({
         <Text variant="bodySmall">{description || ''}</Text>
         {showIllustrations && imageUrl && <img className={styles.image} src={imageUrl} alt={transform.name} />}
         {!isApplicable && applicabilityDescription !== null && (
-          <IconButton className={styles.applicableInfoButton} name="info-circle" tooltip={applicabilityDescription} />
+          <IconButton
+            className={styles.applicableInfoButton}
+            name="info-circle"
+            tooltip={applicabilityDescription}
+            data-testid={selectors.components.Transforms.applicabilityInfo}
+          />
         )}
       </Card.Description>
     </Card>


### PR DESCRIPTION
## What

Adds Playwright smoke tests for a small canary set of dashboard transformations. Two things are checked:

1. **Editor mount** - after picking a transformation, its editor renders and the panel shows no error. Covers Reduce, Convert field type, Group by, Group to nested tables, Format time, Grouping to matrix.
2. **Picker applicability** - for input data where a transformation is not applicable, the card still shows the info affordance. Covers Merge, Format time, Grouping to matrix, Group to nested tables.

Most tests run under Query Editor Next. Two extra smoke tests run under the legacy panel edit flow.

## Why

PR #122326 lazy-loaded transformation editors and surfaced two classes of regressions that our current tests don't catch: missing default options breaking editor mount, and picker losing applicability behavior. See #123259.

## Changes

- New fixture: `devenv/dev-dashboards/transforms/smoke.json` with four `csv_content` panels, one per required data shape.
- New spec: `panelEdit_transformsSmoke.spec.ts` (Query Editor Next).
- Extended spec: `panelEdit_transforms.spec.ts` with two legacy smokes.
- Added `Transforms.applicabilityInfo` selector and wired a `data-testid` into the shared `TransformationCard` info button.

## Test plan

- [ ] `yarn e2e:pw panelEdit_transformsSmoke` passes locally
- [ ] `yarn e2e:pw panelEdit_transforms` passes locally

Closes #123259
Closes DPRO-38