### PR TITLE
Provisioning: Fix Bitbucket Server URL validation to accept /scm/project/repo paths

### DIFF
--- a/public/app/features/provisioning/Wizard/fields.test.ts
+++ b/public/app/features/provisioning/Wizard/fields.test.ts
@@ -79,19 +79,30 @@ describe('URL validation patterns', () => {
     });
 
     it.each([
+      // Bitbucket Cloud
       ['https://bitbucket.org/workspace/repo', true],
       ['https://bitbucket.org/workspace/repo/', true],
       ['https://bitbucket.example.com/workspace/repo', true],
+      // Bitbucket Server / Data Center (3-segment /scm/ paths)
+      ['https://bitbucket.example.com/scm/project/repo', true],
+      ['https://bitbucket.example.com/scm/project/repo/', true],
+      // Multi-segment paths
+      ['https://bitbucket.org/workspace/repo/extra', true],
     ])('%s → %s', (url, expected) => {
       expect(pattern.test(url)).toBe(expected);
     });
 
     it.each([
-      ['https://bitbucket.org/workspace/repo/extra', false],
+      // Must have at least 2 path segments
       ['https://bitbucket.org/workspace', false],
+      // No http
       ['http://bitbucket.org/workspace/repo', false],
+      // No path
       ['https://bitbucket.org/', false],
+      // Empty segments
       ['https://bitbucket.org/workspace//repo', false],
+      // Bare hostname
+      ['https://bitbucket.org', false],
     ])('rejects %s', (url, expected) => {
       expect(pattern.test(url)).toBe(expected);
     });

--- a/public/app/features/provisioning/Wizard/fields.ts
+++ b/public/app/features/provisioning/Wizard/fields.ts
@@ -175,8 +175,14 @@ const getProviderConfigs = (): Record<RepoType, Record<string, FieldConfig>> => 
         placeholder: 'https://bitbucket.org/owner/repository',
         required: true,
         validation: {
-          ...shared.url.validation,
           required: t('provisioning.bitbucket.url-required', 'Repository URL is required'),
+          pattern: {
+            value: /^https:\/\/[^\/]+\/[^\/]+(\/[^\/]+)+\/?$/,
+            message: t(
+              'provisioning.bitbucket.url-pattern',
+              'Must be a valid repository URL (https://hostname/owner/repo or https://hostname/scm/project/repo)'
+            ),
+          },
         },
       },
       branch: {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13150,6 +13150,7 @@
       "token-user-description": "The username that will be used to access the repository with the API token",
       "token-user-required": "Username is required",
       "url-description": "The Bitbucket repository URL",
+      "url-pattern": "Must be a valid repository URL (https://hostname/owner/repo or https://hostname/scm/project/repo)",
       "url-required": "Repository URL is required"
     },
     "bootstrap-step": {


### PR DESCRIPTION
**What is this feature?**

- Override the shared URL validation regex for Bitbucket with a multi-segment pattern (`/^https:\/\/[^\/]+\/[^\/]+(\/[^\/]+)+\/?$/`) that accepts 2+ path segments
- Add a Bitbucket-specific error message mentioning both Cloud and Server URL formats
- Add test cases for Bitbucket Server URLs (`/scm/project/repo`) and update expectations for multi-segment paths
- Extract new `provisioning.bitbucket.url-pattern` i18n translation key

**Why do we need this feature?**

- Bitbucket Server/Data Center uses 3-segment URLs (`https://hostname/scm/project/repo`) which the existing 2-segment-only regex rejected with "Must be a valid repository URL"
- - This follows the same approach used for GitLab subgroup URLs (PR #122232)

**Who is this feature for?**

Git sync users

**Which issue(s) does this PR fix?**:

Fixes N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
