### PR TITLE
Alerting: POC Folder-first rule list 

### DIFF
--- a/public/app/features/alerting/unified/RuleList.tsx
+++ b/public/app/features/alerting/unified/RuleList.tsx
@@ -1,22 +1,32 @@
 import { Suspense, lazy, useEffect, useRef } from 'react';
 
 import { trackRuleListPageView } from './Analytics';
-import { shouldUseAlertingListViewV2 } from './featureToggles';
+import { shouldUseAlertingListViewV2, shouldUseAlertingRulesAPIV2 } from './featureToggles';
 import RuleListV1 from './rule-list/RuleList.v1';
 import { withPageErrorBoundary } from './withPageErrorBoundary';
 
 const RuleListV2 = lazy(() => import('./rule-list/RuleList.v2'));
+const RuleListAPIV2 = lazy(() => import('./rule-list/api-v2/RuleListAPIV2Page'));
 
 const RuleList = () => {
+  const apiV2 = shouldUseAlertingRulesAPIV2();
   const newView = shouldUseAlertingListViewV2();
   const tracked = useRef(false);
 
   useEffect(() => {
     if (!tracked.current) {
-      trackRuleListPageView({ view: newView ? 'v2' : 'v1' });
+      trackRuleListPageView({ view: apiV2 || newView ? 'v2' : 'v1' });
       tracked.current = true;
     }
-  }, [newView]);
+  }, [apiV2, newView]);
+
+  if (apiV2) {
+    return (
+      <Suspense>
+        <RuleListAPIV2 />
+      </Suspense>
+    );
+  }
 
   return <Suspense>{newView ? <RuleListV2 /> : <RuleListV1 />}</Suspense>;
 };

--- a/public/app/features/alerting/unified/featureToggles.ts
+++ b/public/app/features/alerting/unified/featureToggles.ts
@@ -5,6 +5,8 @@ import { isAdmin } from './utils/misc';
 
 export const shouldUsePrometheusRulesPrimary = () => config.featureToggles.alertingPrometheusRulesPrimary ?? false;
 
+export const shouldUseAlertingRulesAPIV2 = () => config.featureToggles['alerting.rulesAPIV2'] ?? false;
+
 export const shouldUseAlertingListViewV2 = () => {
   const previewToggleValue = getPreviewToggle('alertingListViewV2');
 

--- a/public/app/features/alerting/unified/rule-list/api-v2/RuleListAPIV2Body.tsx
+++ b/public/app/features/alerting/unified/rule-list/api-v2/RuleListAPIV2Body.tsx
@@ -1,0 +1,146 @@
+import { css } from '@emotion/css';
+import { useMemo, useState } from 'react';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { Trans } from '@grafana/i18n';
+import { Stack, useStyles2 } from '@grafana/ui';
+
+import { useRulesFilter } from '../../hooks/useFilteredRules';
+
+import { ExternalSourceFetcher } from './components/ExternalSourceFetcher';
+import { FilterPanel } from './components/FilterPanel';
+import { FolderDetail } from './components/FolderDetail';
+import { FolderRail } from './components/FolderRail';
+import { PageHeader } from './components/PageHeader';
+import { RecentlyDeletedView } from './components/RecentlyDeletedView';
+import { SearchRow } from './components/SearchRow';
+import { useRuleTree } from './hooks/useRuleTree';
+import { useSelectedFolder } from './hooks/useSelectedFolder';
+import { useStateChipFilter } from './hooks/useStateChipFilter';
+import { findDataSource, findFolder } from './lib/treeModel';
+
+export function RuleListAPIV2Body() {
+  const styles = useStyles2(getStyles);
+  const [filtersOpen, setFiltersOpen] = useState(true);
+
+  const { filteredTree, preStateTree, externalDataSources, publishExternalResult } = useRuleTree();
+  const chip = useStateChipFilter(preStateTree);
+  const displayedTree = chip.applyToTree(filteredTree);
+
+  const { view, selectFolder, selectDeleted } = useSelectedFolder();
+  const { activeFilters } = useRulesFilter();
+  const filterCount = activeFilters.length + (chip.hasActiveChips ? 1 : 0);
+
+  const defaultFolder = useMemo(() => {
+    const firstDs = displayedTree.dataSources.find((d) => d.folders.length > 0);
+    if (!firstDs) {
+      return undefined;
+    }
+    return { dataSourceUid: firstDs.uid, folderKey: firstDs.folders[0].key };
+  }, [displayedTree]);
+
+  const effectiveView =
+    view.kind === 'empty' && defaultFolder ? ({ kind: 'folder', folder: defaultFolder } as const) : view;
+
+  return (
+    <div className={styles.wrapper}>
+      {externalDataSources.map((ds) => (
+        <ExternalSourceFetcher key={ds.uid} uid={ds.uid} name={ds.name} onResult={publishExternalResult} />
+      ))}
+
+      <PageHeader />
+
+      <div className={styles.filterRegion}>
+        <SearchRow
+          filterCount={filterCount}
+          filtersOpen={filtersOpen}
+          onToggleFilters={() => setFiltersOpen((prev) => !prev)}
+        />
+        {filtersOpen && (
+          <div id="rule-list-v2-filter-panel">
+            <FilterPanel
+              counts={chip.counts}
+              activeChips={chip.active}
+              onToggleChip={chip.toggle}
+              hasAnyActive={chip.hasActiveChips}
+              onClearAll={chip.clear}
+            />
+          </div>
+        )}
+      </div>
+
+      <div className={styles.splitWrapper}>
+        <Stack direction="row" gap={0} alignItems="stretch">
+          <FolderRail
+            tree={displayedTree}
+            view={effectiveView}
+            onSelectFolder={selectFolder}
+            onSelectDeleted={selectDeleted}
+          />
+          <main className={styles.main}>{renderMain(effectiveView, displayedTree, styles.empty)}</main>
+        </Stack>
+      </div>
+    </div>
+  );
+}
+
+function renderMain(
+  view: ReturnType<typeof useSelectedFolder>['view'],
+  tree: ReturnType<typeof useRuleTree>['filteredTree'],
+  emptyClass: string
+) {
+  if (view.kind === 'deleted') {
+    return <RecentlyDeletedView />;
+  }
+  if (view.kind === 'folder') {
+    return renderFolderDetail(tree, view.folder);
+  }
+  return (
+    <div className={emptyClass}>
+      <Trans i18nKey="alerting.rule-list-v2.select-folder">Select a folder from the left to see its rules.</Trans>
+    </div>
+  );
+}
+
+function renderFolderDetail(
+  tree: ReturnType<typeof useRuleTree>['filteredTree'],
+  folder: { dataSourceUid: string; folderKey: string }
+) {
+  const ds = findDataSource(tree, folder.dataSourceUid);
+  const fld = findFolder(tree, folder.dataSourceUid, folder.folderKey);
+  if (!ds || !fld) {
+    return (
+      <div>
+        <Trans i18nKey="alerting.rule-list-v2.no-matching-folder">No matching folder.</Trans>
+      </div>
+    );
+  }
+  return <FolderDetail dataSource={ds} folder={fld} />;
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    wrapper: css({
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(2),
+    }),
+    filterRegion: css({
+      padding: theme.spacing(0, 2),
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(1),
+    }),
+    splitWrapper: css({
+      padding: theme.spacing(0, 2),
+    }),
+    main: css({
+      flex: 1,
+      minWidth: 0,
+    }),
+    empty: css({
+      padding: theme.spacing(4),
+      color: theme.colors.text.secondary,
+    }),
+  };
+}

--- a/public/app/features/alerting/unified/rule-list/api-v2/RuleListAPIV2Page.tsx
+++ b/public/app/features/alerting/unified/rule-list/api-v2/RuleListAPIV2Page.tsx
@@ -1,0 +1,19 @@
+import { AlertingPageWrapper } from '../../components/AlertingPageWrapper';
+import { useAlertRulesNav } from '../../navigation/useAlertRulesNav';
+
+import { RuleListAPIV2Body } from './RuleListAPIV2Body';
+
+export default function RuleListAPIV2Page() {
+  const { navId, pageNav } = useAlertRulesNav();
+
+  // The APIV2 layout owns its own header + rail + recently-deleted affordance, so we strip
+  // the tabbed children (Alert rules / Recently deleted) off the shared pageNav before
+  // passing it to the wrapper.
+  const pageNavWithoutTabs = pageNav ? { ...pageNav, children: undefined } : undefined;
+
+  return (
+    <AlertingPageWrapper navId={navId} pageNav={pageNavWithoutTabs}>
+      <RuleListAPIV2Body />
+    </AlertingPageWrapper>
+  );
+}

--- a/public/app/features/alerting/unified/rule-list/api-v2/RuleListAPIV2Page.tsx
+++ b/public/app/features/alerting/unified/rule-list/api-v2/RuleListAPIV2Page.tsx
@@ -7,12 +7,13 @@ export default function RuleListAPIV2Page() {
   const { navId, pageNav } = useAlertRulesNav();
 
   // The APIV2 layout owns its own header + rail + recently-deleted affordance, so we strip
-  // the tabbed children (Alert rules / Recently deleted) off the shared pageNav before
-  // passing it to the wrapper.
-  const pageNavWithoutTabs = pageNav ? { ...pageNav, children: undefined } : undefined;
+  // the tabbed children (Alert rules / Recently deleted) and the subtitle off the shared
+  // pageNav before passing it to the wrapper — our body renders its own header.
+  const pageNavWithoutTabs = pageNav ? { ...pageNav, children: undefined, subTitle: undefined } : undefined;
 
+  // Suppress the default Grafana page title — the body renders its own PageHeader.
   return (
-    <AlertingPageWrapper navId={navId} pageNav={pageNavWithoutTabs}>
+    <AlertingPageWrapper navId={navId} pageNav={pageNavWithoutTabs} renderTitle={() => null}>
       <RuleListAPIV2Body />
     </AlertingPageWrapper>
   );

--- a/public/app/features/alerting/unified/rule-list/api-v2/components/ChainView.tsx
+++ b/public/app/features/alerting/unified/rule-list/api-v2/components/ChainView.tsx
@@ -1,0 +1,175 @@
+import { css } from '@emotion/css';
+import { useRef } from 'react';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
+import { Icon, useStyles2 } from '@grafana/ui';
+import { type Rule, type RuleGroupIdentifierV2 } from 'app/types/unified-alerting';
+import { PromRuleType } from 'app/types/unified-alerting-dto';
+
+import { type ChainInfo } from '../lib/types';
+
+import { DependencyOverlay } from './DependencyOverlay';
+import { RuleCard } from './RuleCard';
+
+interface Props {
+  rules: Rule[];
+  chain: ChainInfo;
+  groupIdentifier: RuleGroupIdentifierV2;
+}
+
+export function ChainView({ rules, chain, groupIdentifier }: Props) {
+  const styles = useStyles2(getStyles);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const recordingRefs = useRef<Map<string, HTMLDivElement | null>>(new Map());
+  const alertRefs = useRef<Map<string, HTMLDivElement | null>>(new Map());
+
+  const recordings = rules.filter((r) => r.type === PromRuleType.Recording);
+  const alerts = rules.filter((r) => r.type === PromRuleType.Alerting);
+
+  const description = describeChain(chain);
+
+  return (
+    <div ref={containerRef} className={styles.grid}>
+      <div className={styles.column}>
+        <div className={styles.colHeader}>
+          <Icon name="record-audio" />
+          <span>
+            <Trans i18nKey="alerting.rule-list-v2.chain.recordings-first">RECORDING RULES EVALUATE FIRST</Trans>
+          </span>
+        </div>
+        {recordings.map((rule) => (
+          <div
+            key={rule.name}
+            ref={(el) => {
+              recordingRefs.current.set(rule.name, el);
+            }}
+          >
+            <RuleCard
+              rule={rule}
+              instanceCount={undefined}
+              contactPoint={undefined}
+              showStateChip={false}
+              groupIdentifier={groupIdentifier}
+            />
+          </div>
+        ))}
+      </div>
+
+      <div className={styles.middle} aria-hidden="true" />
+
+      <div className={styles.column}>
+        <div className={styles.colHeaderAlert}>
+          <Icon name="bell" />
+          <span>
+            <Trans i18nKey="alerting.rule-list-v2.chain.alerts-after">THEN ALERT RULES FIRE ON THEM</Trans>
+          </span>
+        </div>
+        {alerts.map((rule) => (
+          <div
+            key={rule.name}
+            ref={(el) => {
+              alertRefs.current.set(rule.name, el);
+            }}
+          >
+            <RuleCard
+              rule={rule}
+              instanceCount={countInstances(rule)}
+              contactPoint={undefined}
+              groupIdentifier={groupIdentifier}
+            />
+          </div>
+        ))}
+      </div>
+
+      <DependencyOverlay
+        containerRef={containerRef}
+        recordingRefs={recordingRefs}
+        alertRefs={alertRefs}
+        dependencies={chain.dependencies}
+        description={description}
+      />
+
+      <span className={styles.visuallyHidden}>{description}</span>
+    </div>
+  );
+}
+
+function describeChain(chain: ChainInfo): string {
+  if (chain.dependencies.size === 0) {
+    return t(
+      'alerting.rule-list-v2.chain.description-empty',
+      'No dependencies between recording and alert rules in this group.'
+    );
+  }
+  const parts: string[] = [];
+  chain.dependencies.forEach((recordings, alertName) => {
+    parts.push(
+      t('alerting.rule-list-v2.chain.description-item', '{{alert}} depends on {{recordings}}', {
+        alert: alertName,
+        recordings: recordings.join(', '),
+      })
+    );
+  });
+  return parts.join('. ');
+}
+
+function countInstances(rule: Rule): number | undefined {
+  if (rule.type !== PromRuleType.Alerting) {
+    return undefined;
+  }
+  return rule.alerts?.length ?? 0;
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    grid: css({
+      position: 'relative',
+      display: 'grid',
+      gridTemplateColumns: '1fr 80px 1fr',
+      gap: theme.spacing(1),
+      padding: theme.spacing(1),
+    }),
+    column: css({
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(1),
+    }),
+    colHeader: css({
+      display: 'flex',
+      alignItems: 'center',
+      gap: theme.spacing(0.5),
+      color: theme.colors.info.text,
+      textTransform: 'uppercase',
+      fontSize: theme.typography.bodySmall.fontSize,
+      fontWeight: theme.typography.fontWeightBold,
+      letterSpacing: '0.05em',
+      marginBottom: theme.spacing(0.5),
+    }),
+    colHeaderAlert: css({
+      display: 'flex',
+      alignItems: 'center',
+      gap: theme.spacing(0.5),
+      color: theme.colors.warning.text,
+      textTransform: 'uppercase',
+      fontSize: theme.typography.bodySmall.fontSize,
+      fontWeight: theme.typography.fontWeightBold,
+      letterSpacing: '0.05em',
+      marginBottom: theme.spacing(0.5),
+    }),
+    middle: css({
+      position: 'relative',
+    }),
+    visuallyHidden: css({
+      position: 'absolute',
+      width: 1,
+      height: 1,
+      padding: 0,
+      margin: -1,
+      overflow: 'hidden',
+      clip: 'rect(0, 0, 0, 0)',
+      whiteSpace: 'nowrap',
+      border: 0,
+    }),
+  };
+}

--- a/public/app/features/alerting/unified/rule-list/api-v2/components/DependencyOverlay.tsx
+++ b/public/app/features/alerting/unified/rule-list/api-v2/components/DependencyOverlay.tsx
@@ -1,0 +1,124 @@
+import { css } from '@emotion/css';
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { useStyles2, useTheme2 } from '@grafana/ui';
+
+import { buildArrowPath, centerOf } from '../lib/chainGeometry';
+
+interface Props {
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  recordingRefs: React.MutableRefObject<Map<string, HTMLDivElement | null>>;
+  alertRefs: React.MutableRefObject<Map<string, HTMLDivElement | null>>;
+  dependencies: Map<string, string[]>;
+  description: string;
+}
+
+interface Path {
+  key: string;
+  d: string;
+}
+
+export function DependencyOverlay({ containerRef, recordingRefs, alertRefs, dependencies, description }: Props) {
+  const styles = useStyles2(getStyles);
+  const theme = useTheme2();
+  const svgRef = useRef<SVGSVGElement>(null);
+  const [size, setSize] = useState({ width: 0, height: 0 });
+  const [paths, setPaths] = useState<Path[]>([]);
+
+  const recompute = useCallback(() => {
+    const container = containerRef.current;
+    if (!container) {
+      return;
+    }
+    const containerRect = container.getBoundingClientRect();
+    setSize({ width: containerRect.width, height: containerRect.height });
+
+    const nextPaths: Path[] = [];
+    dependencies.forEach((recordings, alertName) => {
+      const alertEl = alertRefs.current.get(alertName);
+      if (!alertEl) {
+        return;
+      }
+      const alertRect = alertEl.getBoundingClientRect();
+      const alertPoint = centerOf(alertRect, containerRect, 'left');
+      for (const recordingName of recordings) {
+        const recEl = recordingRefs.current.get(recordingName);
+        if (!recEl) {
+          continue;
+        }
+        const recRect = recEl.getBoundingClientRect();
+        const recPoint = centerOf(recRect, containerRect, 'right');
+        nextPaths.push({
+          key: `${recordingName}→${alertName}`,
+          d: buildArrowPath(recPoint, alertPoint),
+        });
+      }
+    });
+    setPaths(nextPaths);
+  }, [containerRef, recordingRefs, alertRefs, dependencies]);
+
+  useLayoutEffect(() => {
+    recompute();
+
+    const container = containerRef.current;
+    if (!container || typeof ResizeObserver === 'undefined') {
+      return;
+    }
+    const observer = new ResizeObserver(recompute);
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [containerRef, recompute]);
+
+  // On initial mount of a chain panel (e.g. when navigating back to a folder)
+  // child ref callbacks and layout may not have fully settled by the time the
+  // layout effect above runs — this frame-delayed pass ensures we re-measure
+  // after the paint cycle completes so arrows render reliably.
+  useEffect(() => {
+    const handle = requestAnimationFrame(recompute);
+    return () => cancelAnimationFrame(handle);
+  }, [recompute]);
+
+  return (
+    <svg
+      ref={svgRef}
+      role="img"
+      aria-label={t(
+        'alerting.rule-list-v2.dependency-overlay.label',
+        'Dependencies between recording rules and alert rules'
+      )}
+      className={styles.svg}
+      width={size.width}
+      height={size.height}
+    >
+      <desc>{description}</desc>
+      <defs>
+        <marker id="arrowhead" viewBox="0 0 8 8" refX="6" refY="4" markerWidth="6" markerHeight="6" orient="auto">
+          <path d="M 0 0 L 8 4 L 0 8 z" fill={theme.colors.warning.main} />
+        </marker>
+      </defs>
+      {paths.map((p) => (
+        <path
+          key={p.key}
+          d={p.d}
+          stroke={theme.colors.warning.main}
+          strokeWidth={1.5}
+          opacity={0.7}
+          fill="none"
+          markerEnd="url(#arrowhead)"
+        />
+      ))}
+    </svg>
+  );
+}
+
+function getStyles(_theme: GrafanaTheme2) {
+  return {
+    svg: css({
+      position: 'absolute',
+      inset: 0,
+      pointerEvents: 'none',
+    }),
+  };
+}

--- a/public/app/features/alerting/unified/rule-list/api-v2/components/EmptyFolderState.tsx
+++ b/public/app/features/alerting/unified/rule-list/api-v2/components/EmptyFolderState.tsx
@@ -1,0 +1,38 @@
+import { css } from '@emotion/css';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { useStyles2 } from '@grafana/ui';
+
+interface Props {
+  title?: string;
+  message?: string;
+}
+
+export function EmptyFolderState({ title = 'No rules', message = 'No rules match the current filters.' }: Props) {
+  const styles = useStyles2(getStyles);
+  return (
+    <div className={styles.wrapper}>
+      <h3 className={styles.title}>{title}</h3>
+      <p className={styles.message}>{message}</p>
+    </div>
+  );
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    wrapper: css({
+      padding: theme.spacing(4, 2),
+      textAlign: 'center',
+      color: theme.colors.text.secondary,
+    }),
+    title: css({
+      margin: 0,
+      marginBottom: theme.spacing(1),
+      fontSize: theme.typography.h4.fontSize,
+      color: theme.colors.text.primary,
+    }),
+    message: css({
+      margin: 0,
+    }),
+  };
+}

--- a/public/app/features/alerting/unified/rule-list/api-v2/components/EvaluationChainCard.tsx
+++ b/public/app/features/alerting/unified/rule-list/api-v2/components/EvaluationChainCard.tsx
@@ -1,0 +1,76 @@
+import { css } from '@emotion/css';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { Trans } from '@grafana/i18n';
+import { Icon, useStyles2 } from '@grafana/ui';
+import { type RuleGroup, type RuleGroupIdentifierV2 } from 'app/types/unified-alerting';
+
+import { type ChainInfo } from '../lib/types';
+
+import { ChainView } from './ChainView';
+import { FlatView } from './FlatView';
+
+interface Props {
+  group: RuleGroup;
+  groupIdentifier: RuleGroupIdentifierV2;
+  chain: ChainInfo;
+  showArrows: boolean;
+}
+
+/**
+ * Outer card for an evaluation chain. Unlike the legacy `EvaluationGroupPanel`,
+ * this card has no group-name header, no interval chip, and no Edit-group / ⋮
+ * actions — rules don't have groups anymore in the new rules API (only virtual
+ * groups for chain evaluation). The card only exists to visually bind
+ * recording rules with the alerts that feed on them.
+ */
+export function EvaluationChainCard({ group, groupIdentifier, chain, showArrows }: Props) {
+  const styles = useStyles2(getStyles);
+  const useChain = chain.isChain && showArrows;
+
+  return (
+    <section className={styles.panel}>
+      <div className={styles.badgeRow}>
+        <span className={styles.chainBadge}>
+          <Icon name="link" size="sm" />
+          <Trans i18nKey="alerting.rule-list-v2.evaluation-chain-badge">evaluation chain</Trans>
+        </span>
+      </div>
+      <div className={styles.body}>
+        {useChain ? (
+          <ChainView rules={group.rules} chain={chain} groupIdentifier={groupIdentifier} />
+        ) : (
+          <FlatView rules={group.rules} groupIdentifier={groupIdentifier} />
+        )}
+      </div>
+    </section>
+  );
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    panel: css({
+      border: `1px solid ${theme.colors.border.weak}`,
+      borderRadius: theme.shape.radius.default,
+      background: theme.colors.background.primary,
+      overflow: 'hidden',
+    }),
+    badgeRow: css({
+      display: 'flex',
+      alignItems: 'center',
+      padding: theme.spacing(1, 1, 0, 1),
+    }),
+    chainBadge: css({
+      display: 'inline-flex',
+      alignItems: 'center',
+      gap: theme.spacing(0.5),
+      padding: theme.spacing(0.25, 0.75),
+      borderRadius: theme.shape.radius.pill,
+      background: 'rgba(240, 90, 40, 0.1)',
+      border: `1px solid ${theme.colors.warning.border}`,
+      color: theme.colors.warning.text,
+      fontSize: theme.typography.bodySmall.fontSize,
+    }),
+    body: css({}),
+  };
+}

--- a/public/app/features/alerting/unified/rule-list/api-v2/components/ExternalSourceFetcher.tsx
+++ b/public/app/features/alerting/unified/rule-list/api-v2/components/ExternalSourceFetcher.tsx
@@ -1,0 +1,44 @@
+import { useEffect } from 'react';
+
+import { alertRuleApi } from '../../../api/alertRuleApi';
+import { type ExternalSourceResult } from '../hooks/useRuleTree';
+
+interface Props {
+  uid: string;
+  name: string;
+  onResult: (uid: string, result: ExternalSourceResult) => void;
+}
+
+export function ExternalSourceFetcher({ uid, name, onResult }: Props) {
+  const { data, isError, error } = alertRuleApi.endpoints.prometheusRuleNamespaces.useQuery(
+    { ruleSourceName: name, limitAlerts: 0 },
+    { pollingInterval: 120_000 }
+  );
+
+  useEffect(() => {
+    onResult(uid, {
+      namespaces: data,
+      error: isError ? formatError(error) : undefined,
+    });
+  }, [uid, data, isError, error, onResult]);
+
+  return null;
+}
+
+function formatError(err: unknown): string {
+  const status = extractStatus(err);
+  if (status === 'FETCH_ERROR') {
+    return 'Failed to load rules: connection refused';
+  }
+  if (typeof status === 'number') {
+    return `Failed to load rules: ${status}`;
+  }
+  return 'Failed to load rules';
+}
+
+function extractStatus(err: unknown): unknown {
+  if (err && typeof err === 'object' && 'status' in err) {
+    return err.status;
+  }
+  return undefined;
+}

--- a/public/app/features/alerting/unified/rule-list/api-v2/components/FilterPanel.tsx
+++ b/public/app/features/alerting/unified/rule-list/api-v2/components/FilterPanel.tsx
@@ -1,0 +1,209 @@
+import { css } from '@emotion/css';
+import { produce } from 'immer';
+
+import { ContactPointSelector } from '@grafana/alerting/unstable';
+import { type GrafanaTheme2 } from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
+import { Button, Input, Label, MultiCombobox, Select, useStyles2 } from '@grafana/ui';
+import { PromRuleType } from 'app/types/unified-alerting-dto';
+
+import {
+  useAlertingDataSourceOptions,
+  useLabelOptions,
+} from '../../../components/rules/Filter/useRuleFilterAutocomplete';
+import { useRulesFilter } from '../../../hooks/useFilteredRules';
+import { RuleHealth, RuleSource } from '../../../search/rulesSearchParser';
+import { usePluginsFilterStatus } from '../../filter/utils';
+import { type StateChip, type StateChipCounts } from '../lib/types';
+
+import { StateChipRow } from './StateChipRow';
+
+interface Props {
+  counts: StateChipCounts;
+  activeChips: Set<StateChip>;
+  onToggleChip: (chip: StateChip) => void;
+  hasAnyActive: boolean;
+  onClearAll: () => void;
+}
+
+function getHealthOptions() {
+  return [
+    { label: t('alerting.rule-list-v2.health-all', 'All'), value: undefined },
+    { label: t('alerting.rule-list-v2.health-ok', 'OK'), value: RuleHealth.Ok },
+    { label: t('alerting.rule-list-v2.health-nodata', 'No data'), value: RuleHealth.NoData },
+    { label: t('alerting.rule-list-v2.health-error', 'Error'), value: RuleHealth.Error },
+  ];
+}
+
+function getSourceOptions() {
+  return [
+    { label: t('alerting.rule-list-v2.source-all', 'All'), value: undefined },
+    { label: t('alerting.rule-list-v2.source-grafana', 'Grafana managed'), value: RuleSource.Grafana },
+    { label: t('alerting.rule-list-v2.source-datasource', 'Data source managed'), value: RuleSource.DataSource },
+  ];
+}
+
+function getTypeOptions() {
+  return [
+    { label: t('alerting.rule-list-v2.type-all', 'All'), value: undefined },
+    { label: t('alerting.rule-list-v2.type-alert', 'Alert rule'), value: PromRuleType.Alerting },
+    { label: t('alerting.rule-list-v2.type-recording', 'Recording rule'), value: PromRuleType.Recording },
+  ];
+}
+
+function getPluginOptions() {
+  return [
+    { label: t('alerting.rule-list-v2.plugin-show', 'Show'), value: undefined },
+    { label: t('alerting.rule-list-v2.plugin-hide', 'Hide'), value: 'hide' as const },
+  ];
+}
+
+export function FilterPanel({ counts, activeChips, onToggleChip, hasAnyActive, onClearAll }: Props) {
+  const styles = useStyles2(getStyles);
+  const { filterState, updateFilters, hasActiveFilters, clearAll: clearSearchFilters } = useRulesFilter();
+  const { labelOptions } = useLabelOptions();
+  const dataSourceOptions = useAlertingDataSourceOptions();
+  const { pluginsFilterEnabled } = usePluginsFilterStatus();
+
+  const canClear = hasActiveFilters || hasAnyActive;
+
+  function apply(updater: (draft: typeof filterState) => void) {
+    updateFilters(produce(filterState, updater));
+  }
+
+  function handleClearAll() {
+    clearSearchFilters();
+    onClearAll();
+  }
+
+  return (
+    <div className={styles.panel}>
+      <div className={styles.headerRow}>
+        <StateChipRow counts={counts} active={activeChips} onToggle={onToggleChip} />
+        <Button size="sm" variant="secondary" fill="text" icon="times" onClick={handleClearAll} disabled={!canClear}>
+          <Trans i18nKey="alerting.rule-list-v2.clear-filters">Clear filters</Trans>
+        </Button>
+      </div>
+
+      <div className={styles.grid}>
+        <Field label={t('alerting.rule-list-v2.field.rule-name', 'Rule name')}>
+          <Input
+            placeholder={t('alerting.rule-list-v2.field.rule-name-placeholder', 'Filter by name...')}
+            defaultValue={filterState.ruleName ?? ''}
+            onBlur={(e) => apply((d) => void (d.ruleName = e.currentTarget.value || undefined))}
+          />
+        </Field>
+
+        <Field label={t('alerting.rule-list-v2.field.labels', 'Labels')}>
+          <MultiCombobox
+            options={labelOptions}
+            value={filterState.labels}
+            onChange={(selections) => apply((d) => void (d.labels = selections.map((s) => s.value)))}
+            placeholder={t('alerting.rule-list-v2.field.labels-placeholder', 'env=prod, team=...')}
+          />
+        </Field>
+
+        <Field label={t('alerting.rule-list-v2.field.rule-source', 'Rule source')}>
+          <Select
+            options={getSourceOptions()}
+            value={filterState.ruleSource}
+            onChange={(option) => apply((d) => void (d.ruleSource = option?.value))}
+          />
+        </Field>
+
+        <Field label={t('alerting.rule-list-v2.field.data-source', 'Data source')}>
+          <MultiCombobox
+            options={dataSourceOptions}
+            value={filterState.dataSourceNames}
+            onChange={(selections) => apply((d) => void (d.dataSourceNames = selections.map((s) => s.value)))}
+            placeholder={t('alerting.rule-list-v2.field.data-source-placeholder', 'Select data sources')}
+          />
+        </Field>
+
+        <Field label={t('alerting.rule-list-v2.field.contact-point', 'Contact point')}>
+          <ContactPointSelector
+            placeholder={t('alerting.rule-list-v2.field.contact-point-placeholder', 'Select contact point')}
+            value={'contactPoint' in filterState ? (filterState.contactPoint ?? null) : null}
+            isClearable
+            onChange={(cp) => {
+              const name = cp?.spec.title ?? null;
+              apply((d) => {
+                if (name) {
+                  Object.assign(d, { contactPoint: name, policy: undefined });
+                } else {
+                  Object.assign(d, { contactPoint: undefined });
+                }
+              });
+            }}
+          />
+        </Field>
+
+        <Field label={t('alerting.rule-list-v2.field.health', 'Health')}>
+          <Select
+            options={getHealthOptions()}
+            value={filterState.ruleHealth}
+            onChange={(option) => apply((d) => void (d.ruleHealth = option?.value))}
+          />
+        </Field>
+
+        <Field label={t('alerting.rule-list-v2.field.rule-type', 'Type')}>
+          <Select
+            options={getTypeOptions()}
+            value={filterState.ruleType}
+            onChange={(option) => apply((d) => void (d.ruleType = option?.value))}
+          />
+        </Field>
+
+        {pluginsFilterEnabled && (
+          <Field label={t('alerting.rule-list-v2.field.plugin-rules', 'Plugin rules')}>
+            <Select
+              options={getPluginOptions()}
+              value={filterState.plugins}
+              onChange={(option) => apply((d) => void (d.plugins = option?.value))}
+            />
+          </Field>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  const styles = useStyles2(getStyles);
+  return (
+    <div className={styles.field}>
+      <Label>{label}</Label>
+      {children}
+    </div>
+  );
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    panel: css({
+      padding: theme.spacing(1.5, 2),
+      background: theme.colors.background.secondary,
+      border: `1px solid ${theme.colors.border.weak}`,
+      borderRadius: theme.shape.radius.default,
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(1),
+    }),
+    headerRow: css({
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      gap: theme.spacing(1),
+    }),
+    grid: css({
+      display: 'grid',
+      gridTemplateColumns: 'repeat(4, 1fr)',
+      gap: theme.spacing(1),
+    }),
+    field: css({
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(0.5),
+    }),
+  };
+}

--- a/public/app/features/alerting/unified/rule-list/api-v2/components/FlatView.tsx
+++ b/public/app/features/alerting/unified/rule-list/api-v2/components/FlatView.tsx
@@ -1,0 +1,48 @@
+import { css } from '@emotion/css';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { useStyles2 } from '@grafana/ui';
+import { type Rule, type RuleGroupIdentifierV2 } from 'app/types/unified-alerting';
+import { PromRuleType } from 'app/types/unified-alerting-dto';
+
+import { RuleCard } from './RuleCard';
+
+interface Props {
+  rules: Rule[];
+  groupIdentifier: RuleGroupIdentifierV2;
+}
+
+export function FlatView({ rules, groupIdentifier }: Props) {
+  const styles = useStyles2(getStyles);
+  return (
+    <div className={styles.list}>
+      {rules.map((rule, idx) => (
+        <RuleCard
+          key={rule.name}
+          rule={rule}
+          index={idx}
+          instanceCount={instanceCount(rule)}
+          groupIdentifier={groupIdentifier}
+        />
+      ))}
+    </div>
+  );
+}
+
+function instanceCount(rule: Rule): number | undefined {
+  if (rule.type !== PromRuleType.Alerting) {
+    return undefined;
+  }
+  return rule.alerts?.length ?? 0;
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    list: css({
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(0.5),
+      padding: theme.spacing(1),
+    }),
+  };
+}

--- a/public/app/features/alerting/unified/rule-list/api-v2/components/FolderDetail.tsx
+++ b/public/app/features/alerting/unified/rule-list/api-v2/components/FolderDetail.tsx
@@ -1,0 +1,117 @@
+import { css } from '@emotion/css';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { Checkbox, Icon, Stack, useStyles2 } from '@grafana/ui';
+
+import { useShowDependencyArrowsPref } from '../hooks/useShowDependencyArrowsPref';
+import { detectDependencies } from '../lib/detectDependencies';
+import { buildGroupIdentifier } from '../lib/groupIdentifier';
+import { type TreeDataSource, type TreeFolder } from '../lib/types';
+
+import { EmptyFolderState } from './EmptyFolderState';
+import { EvaluationChainCard } from './EvaluationChainCard';
+import { RuleCard } from './RuleCard';
+
+interface Props {
+  dataSource: TreeDataSource;
+  folder: TreeFolder;
+}
+
+export function FolderDetail({ dataSource, folder }: Props) {
+  const styles = useStyles2(getStyles);
+  const [showArrows, setShowArrows] = useShowDependencyArrowsPref();
+
+  return (
+    <div className={styles.wrapper}>
+      <div className={styles.breadcrumb}>
+        <Icon name="database" className={styles.dsIcon} />
+        <span>{dataSource.name}</span>
+        <span>›</span>
+      </div>
+      <div className={styles.headerRow}>
+        <h2 className={styles.folderTitle}>
+          <Icon name="folder-open" />
+          <span>{folder.title}</span>
+        </h2>
+        <Checkbox
+          label={t('alerting.rule-list-v2.show-dependency-arrows', 'Show dependency arrows')}
+          value={showArrows}
+          onChange={(e) => setShowArrows(e.currentTarget.checked)}
+        />
+      </div>
+      {folder.groups.length === 0 ? (
+        <EmptyFolderState />
+      ) : (
+        <Stack direction="column" gap={1}>
+          {folder.groups.map((group) => {
+            const chain = detectDependencies(group);
+            const groupIdentifier = buildGroupIdentifier(dataSource, folder, group);
+            if (chain.isChain) {
+              return (
+                <EvaluationChainCard
+                  key={group.name}
+                  group={group}
+                  chain={chain}
+                  groupIdentifier={groupIdentifier}
+                  showArrows={showArrows}
+                />
+              );
+            }
+            return group.rules.map((rule) => (
+              <RuleCard
+                key={`${group.name}-${rule.name}`}
+                rule={rule}
+                instanceCount={instanceCount(rule)}
+                groupIdentifier={groupIdentifier}
+              />
+            ));
+          })}
+        </Stack>
+      )}
+    </div>
+  );
+}
+
+function instanceCount(rule: { type: string; alerts?: unknown[] }): number | undefined {
+  if (rule.type !== 'alerting') {
+    return undefined;
+  }
+  return rule.alerts?.length ?? 0;
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    wrapper: css({
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(2),
+      flex: 1,
+      minWidth: 0,
+      padding: theme.spacing(1, 2),
+    }),
+    breadcrumb: css({
+      display: 'flex',
+      alignItems: 'center',
+      gap: theme.spacing(0.5),
+      color: theme.colors.text.secondary,
+      fontSize: theme.typography.bodySmall.fontSize,
+    }),
+    dsIcon: css({
+      color: theme.colors.text.secondary,
+    }),
+    headerRow: css({
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      gap: theme.spacing(2),
+    }),
+    folderTitle: css({
+      display: 'flex',
+      alignItems: 'center',
+      gap: theme.spacing(1),
+      margin: 0,
+      fontSize: theme.typography.h3.fontSize,
+    }),
+  };
+}

--- a/public/app/features/alerting/unified/rule-list/api-v2/components/FolderList.tsx
+++ b/public/app/features/alerting/unified/rule-list/api-v2/components/FolderList.tsx
@@ -1,0 +1,167 @@
+import { css } from '@emotion/css';
+import { useMemo, useState } from 'react';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
+import { useStyles2 } from '@grafana/ui';
+
+import { useFolderListKeyboard } from '../hooks/useFolderListKeyboard';
+import { type SelectedFolder, type TreeDataSource } from '../lib/types';
+
+import { FolderListRow } from './FolderListRow';
+
+interface Props {
+  dataSources: TreeDataSource[];
+  selected?: SelectedFolder;
+  filterText: string;
+  onSelect: (dataSourceUid: string, folderKey: string) => void;
+  firingCounts: Map<string, number>;
+}
+
+export function FolderList({ dataSources, selected, filterText, onSelect, firingCounts }: Props) {
+  const styles = useStyles2(getStyles);
+
+  const flatKeys = useMemo(() => {
+    const keys: string[] = [];
+    for (const ds of dataSources) {
+      for (const folder of ds.folders) {
+        if (matchesFilter(folder.title, filterText)) {
+          keys.push(`${ds.uid}:${folder.key}`);
+        }
+      }
+    }
+    return keys;
+  }, [dataSources, filterText]);
+
+  const activeKey = selected ? `${selected.dataSourceUid}:${selected.folderKey}` : undefined;
+  const [focusKey, setFocusKey] = useState<string | undefined>(activeKey);
+  const effectiveFocusKey = focusKey && flatKeys.includes(focusKey) ? focusKey : (activeKey ?? flatKeys[0]);
+
+  const { onKeyDown } = useFolderListKeyboard({
+    flatKeys,
+    activeKey: effectiveFocusKey,
+    onActivate: (key) => {
+      setFocusKey(key);
+      const [dsUid, folderKey] = splitKey(key);
+      onSelect(dsUid, folderKey);
+    },
+  });
+
+  return (
+    <div
+      role="tree"
+      aria-label={t('alerting.rule-list-v2.folders-tree', 'Folders')}
+      className={styles.tree}
+      onKeyDown={onKeyDown}
+      tabIndex={0}
+    >
+      {dataSources.map((ds) => (
+        <DataSourceSection
+          key={ds.uid}
+          ds={ds}
+          filterText={filterText}
+          activeKey={activeKey}
+          focusKey={effectiveFocusKey}
+          onSelect={onSelect}
+          firingCounts={firingCounts}
+        />
+      ))}
+    </div>
+  );
+}
+
+interface SectionProps {
+  ds: TreeDataSource;
+  filterText: string;
+  activeKey?: string;
+  focusKey?: string;
+  onSelect: (dataSourceUid: string, folderKey: string) => void;
+  firingCounts: Map<string, number>;
+}
+
+function DataSourceSection({ ds, filterText, activeKey, focusKey, onSelect, firingCounts }: SectionProps) {
+  const styles = useStyles2(getStyles);
+  const folders = ds.folders.filter((f) => matchesFilter(f.title, filterText));
+
+  return (
+    <div className={styles.section}>
+      <div className={styles.sectionHeader}>
+        <span className={styles.sectionTitle}>{ds.name}</span>
+        {ds.error && (
+          <span className={styles.errorTag}>
+            <Trans i18nKey="alerting.rule-list-v2.ds-error-tag">Error</Trans>
+          </span>
+        )}
+      </div>
+      {ds.error && <div className={styles.errorRow}>{ds.error}</div>}
+      {!ds.error &&
+        folders.map((folder) => {
+          const key = `${ds.uid}:${folder.key}`;
+          const active = key === activeKey;
+          const focused = key === focusKey;
+          return (
+            <FolderListRow
+              key={folder.key}
+              rowId={`folder-row-${key}`}
+              title={folder.title}
+              groupCount={folder.groups.length}
+              firingCount={firingCounts.get(key) ?? 0}
+              active={active}
+              tabIndex={focused ? 0 : -1}
+              onSelect={() => onSelect(ds.uid, folder.key)}
+            />
+          );
+        })}
+    </div>
+  );
+}
+
+function matchesFilter(title: string, filterText: string): boolean {
+  if (!filterText.trim()) {
+    return true;
+  }
+  return title.toLowerCase().includes(filterText.toLowerCase());
+}
+
+function splitKey(key: string): [string, string] {
+  const colon = key.indexOf(':');
+  return [key.slice(0, colon), key.slice(colon + 1)];
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    tree: css({
+      display: 'flex',
+      flexDirection: 'column',
+    }),
+    section: css({
+      display: 'flex',
+      flexDirection: 'column',
+      marginBottom: theme.spacing(1),
+    }),
+    sectionHeader: css({
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
+      padding: theme.spacing(0.5, 1),
+      textTransform: 'uppercase',
+      fontSize: theme.typography.bodySmall.fontSize,
+      fontWeight: theme.typography.fontWeightBold,
+      color: theme.colors.text.secondary,
+      letterSpacing: '0.05em',
+    }),
+    sectionTitle: css({
+      fontSize: theme.typography.bodySmall.fontSize,
+    }),
+    errorTag: css({
+      color: theme.colors.error.text,
+      fontSize: theme.typography.bodySmall.fontSize,
+      textTransform: 'none',
+    }),
+    errorRow: css({
+      padding: theme.spacing(0.5, 1),
+      color: theme.colors.error.text,
+      fontSize: theme.typography.bodySmall.fontSize,
+    }),
+  };
+}

--- a/public/app/features/alerting/unified/rule-list/api-v2/components/FolderListRow.tsx
+++ b/public/app/features/alerting/unified/rule-list/api-v2/components/FolderListRow.tsx
@@ -1,0 +1,91 @@
+import { css, cx } from '@emotion/css';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { Icon, useStyles2 } from '@grafana/ui';
+
+interface Props {
+  title: string;
+  firingCount: number;
+  groupCount: number;
+  active: boolean;
+  onSelect: () => void;
+  rowId: string;
+  tabIndex: number;
+}
+
+export function FolderListRow({ title, firingCount, groupCount, active, onSelect, rowId, tabIndex }: Props) {
+  const styles = useStyles2(getStyles);
+  return (
+    <div
+      id={rowId}
+      role="treeitem"
+      aria-selected={active}
+      tabIndex={tabIndex}
+      className={cx(styles.row, active && styles.active)}
+      onClick={onSelect}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onSelect();
+        }
+      }}
+    >
+      <Icon name={active ? 'folder-open' : 'folder'} className={styles.icon} aria-hidden="true" />
+      <span className={styles.title} title={title}>
+        {title}
+      </span>
+      {firingCount > 0 && <span className={styles.firing}>{firingCount}</span>}
+      <span className={styles.group}>{groupCount}</span>
+    </div>
+  );
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    row: css({
+      display: 'flex',
+      alignItems: 'center',
+      gap: theme.spacing(0.75),
+      padding: theme.spacing(0.5, 1),
+      cursor: 'pointer',
+      borderLeft: '2px solid transparent',
+      color: theme.colors.text.primary,
+      fontSize: theme.typography.bodySmall.fontSize,
+      '&:hover': {
+        background: theme.colors.action.hover,
+      },
+      '&:focus-visible': {
+        outline: `2px solid ${theme.colors.primary.border}`,
+        outlineOffset: -2,
+      },
+    }),
+    active: css({
+      background: theme.colors.background.secondary,
+      borderLeftColor: theme.colors.primary.main,
+    }),
+    icon: css({
+      color: theme.colors.text.secondary,
+      flexShrink: 0,
+    }),
+    title: css({
+      flex: 1,
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+    }),
+    firing: css({
+      color: theme.colors.error.text,
+      fontVariantNumeric: 'tabular-nums',
+      fontFamily: theme.typography.fontFamilyMonospace,
+      minWidth: theme.spacing(2),
+      textAlign: 'right',
+    }),
+    group: css({
+      color: theme.colors.text.secondary,
+      fontVariantNumeric: 'tabular-nums',
+      fontFamily: theme.typography.fontFamilyMonospace,
+      minWidth: theme.spacing(2),
+      textAlign: 'right',
+    }),
+  };
+}

--- a/public/app/features/alerting/unified/rule-list/api-v2/components/FolderRail.tsx
+++ b/public/app/features/alerting/unified/rule-list/api-v2/components/FolderRail.tsx
@@ -1,0 +1,133 @@
+import { css } from '@emotion/css';
+import { useMemo, useState } from 'react';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
+import { Icon, Input, useStyles2 } from '@grafana/ui';
+
+import { shouldAllowRecoveringDeletedRules } from '../../../featureToggles';
+import { type SelectedView, type TreeModel } from '../lib/types';
+
+import { FolderList } from './FolderList';
+
+interface Props {
+  tree: TreeModel;
+  view: SelectedView;
+  onSelectFolder: (dataSourceUid: string, folderKey: string) => void;
+  onSelectDeleted: () => void;
+}
+
+const RAIL_WIDTH = 260;
+
+export function FolderRail({ tree, view, onSelectFolder, onSelectDeleted }: Props) {
+  const styles = useStyles2(getStyles);
+  const [filterText, setFilterText] = useState('');
+
+  const firingCounts = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const ds of tree.dataSources) {
+      for (const folder of ds.folders) {
+        let firing = 0;
+        for (const group of folder.groups) {
+          for (const rule of group.rules) {
+            if (rule.type === 'alerting' && rule.state === 'firing') {
+              firing += 1;
+            }
+          }
+        }
+        counts.set(`${ds.uid}:${folder.key}`, firing);
+      }
+    }
+    return counts;
+  }, [tree]);
+
+  const deletedAllowed = shouldAllowRecoveringDeletedRules();
+
+  return (
+    <aside className={styles.rail} style={{ width: RAIL_WIDTH }}>
+      <div className={styles.filterInputWrap}>
+        <Input
+          placeholder={t('alerting.rule-list-v2.filter-folders', 'Filter folders...')}
+          value={filterText}
+          onChange={(e) => setFilterText(e.currentTarget.value)}
+          prefix={<Icon name="search" />}
+        />
+      </div>
+      <div className={styles.treeWrap}>
+        <FolderList
+          dataSources={tree.dataSources}
+          selected={view.kind === 'folder' ? view.folder : undefined}
+          filterText={filterText}
+          onSelect={onSelectFolder}
+          firingCounts={firingCounts}
+        />
+      </div>
+      {deletedAllowed && (
+        <>
+          <div className={styles.divider} />
+          <button
+            type="button"
+            onClick={onSelectDeleted}
+            className={styles.deletedRow}
+            aria-pressed={view.kind === 'deleted'}
+          >
+            <Icon name="trash-alt" />
+            <span>
+              <Trans i18nKey="alerting.rule-list-v2.recently-deleted">Recently deleted</Trans>
+            </span>
+          </button>
+        </>
+      )}
+    </aside>
+  );
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    rail: css({
+      position: 'sticky',
+      top: 0,
+      display: 'flex',
+      flexDirection: 'column',
+      background: theme.colors.background.secondary,
+      border: `1px solid ${theme.colors.border.weak}`,
+      borderRadius: theme.shape.radius.default,
+      padding: theme.spacing(1, 0),
+      flexShrink: 0,
+      alignSelf: 'flex-start',
+      maxHeight: '100vh',
+      marginRight: theme.spacing(2),
+    }),
+    filterInputWrap: css({
+      padding: theme.spacing(1),
+    }),
+    treeWrap: css({
+      overflowY: 'auto',
+      flex: 1,
+    }),
+    divider: css({
+      borderTop: `1px solid ${theme.colors.border.weak}`,
+      margin: theme.spacing(1, 0),
+    }),
+    deletedRow: css({
+      display: 'flex',
+      alignItems: 'center',
+      gap: theme.spacing(1),
+      padding: theme.spacing(0.5, 1),
+      background: 'transparent',
+      border: 'none',
+      cursor: 'pointer',
+      color: theme.colors.text.primary,
+      textAlign: 'left',
+      borderLeft: '2px solid transparent',
+      fontSize: theme.typography.bodySmall.fontSize,
+      '&[aria-pressed="true"]': {
+        background: theme.colors.background.secondary,
+        borderLeftColor: theme.colors.primary.main,
+      },
+      '&:hover': {
+        background: theme.colors.action.hover,
+      },
+    }),
+  };
+}

--- a/public/app/features/alerting/unified/rule-list/api-v2/components/PageHeader.tsx
+++ b/public/app/features/alerting/unified/rule-list/api-v2/components/PageHeader.tsx
@@ -1,0 +1,52 @@
+import { css } from '@emotion/css';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { Trans } from '@grafana/i18n';
+import { LinkButton, Stack, useStyles2 } from '@grafana/ui';
+
+export function PageHeader() {
+  const styles = useStyles2(getStyles);
+  return (
+    <div className={styles.wrapper}>
+      <div>
+        <h1 className={styles.title}>
+          <Trans i18nKey="alerting.rule-list-v2.title">Alert rules</Trans>
+        </h1>
+        <p className={styles.subtitle}>
+          <Trans i18nKey="alerting.rule-list-v2.subtitle">
+            Organized by folder and evaluation group — the way rules actually evaluate
+          </Trans>
+        </p>
+      </div>
+      <Stack direction="row" gap={1}>
+        <LinkButton variant="secondary" icon="import" href="#">
+          <Trans i18nKey="alerting.rule-list-v2.import-export">Import / export</Trans>
+        </LinkButton>
+        <LinkButton variant="primary" icon="plus" href="/alerting/new/alerting">
+          <Trans i18nKey="alerting.rule-list-v2.new-rule">New rule in folder</Trans>
+        </LinkButton>
+      </Stack>
+    </div>
+  );
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    wrapper: css({
+      display: 'flex',
+      alignItems: 'flex-start',
+      justifyContent: 'space-between',
+      gap: theme.spacing(2),
+      padding: theme.spacing(2, 2, 1, 2),
+    }),
+    title: css({
+      margin: 0,
+      marginBottom: theme.spacing(0.5),
+      fontSize: theme.typography.h1.fontSize,
+    }),
+    subtitle: css({
+      margin: 0,
+      color: theme.colors.text.secondary,
+    }),
+  };
+}

--- a/public/app/features/alerting/unified/rule-list/api-v2/components/PageHeader.tsx
+++ b/public/app/features/alerting/unified/rule-list/api-v2/components/PageHeader.tsx
@@ -10,12 +10,10 @@ export function PageHeader() {
     <div className={styles.wrapper}>
       <div>
         <h1 className={styles.title}>
-          <Trans i18nKey="alerting.rule-list-v2.title">Alert rules</Trans>
+          <Trans i18nKey="alerting.rule-list-v2.title">Rules</Trans>
         </h1>
         <p className={styles.subtitle}>
-          <Trans i18nKey="alerting.rule-list-v2.subtitle">
-            Organized by folder and evaluation group — the way rules actually evaluate
-          </Trans>
+          <Trans i18nKey="alerting.rule-list-v2.subtitle">Rules that determine whether an alert will fire</Trans>
         </p>
       </div>
       <Stack direction="row" gap={1}>

--- a/public/app/features/alerting/unified/rule-list/api-v2/components/RecentlyDeletedView.tsx
+++ b/public/app/features/alerting/unified/rule-list/api-v2/components/RecentlyDeletedView.tsx
@@ -1,0 +1,161 @@
+import { css } from '@emotion/css';
+import { useState } from 'react';
+
+import { type GrafanaTheme2, dateTimeFormat } from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
+import { Button, type Column, EmptyState, Icon, InteractiveTable, Stack, useStyles2 } from '@grafana/ui';
+import { type GrafanaRuleDefinition, type RulerGrafanaRuleDTO } from 'app/types/unified-alerting-dto';
+
+import { trackDeletedRuleRestoreFail, trackDeletedRuleRestoreSuccess } from '../../../Analytics';
+import { alertRuleApi } from '../../../api/alertRuleApi';
+import { UpdatedByUser } from '../../../components/rule-viewer/tabs/version-history/UpdatedBy';
+import { ConfirmDeletedPermanentlyModal } from '../../../components/rules/deleted-rules/ConfirmDeletePermanantlyModal';
+import { ConfirmRestoreDeletedRuleModal } from '../../../components/rules/deleted-rules/ConfirmRestoreDeletedRuleModal';
+import { shouldAllowPermanentlyDeletingRules } from '../../../featureToggles';
+
+type DeletedRule = RulerGrafanaRuleDTO<GrafanaRuleDefinition>;
+
+const PAGE_SIZE = 30;
+
+export function RecentlyDeletedView() {
+  const styles = useStyles2(getStyles);
+  const { data, isLoading } = alertRuleApi.endpoints.getDeletedRules.useQuery({});
+
+  const [restoreRule, setRestoreRule] = useState<DeletedRule | undefined>();
+  const [guidToDelete, setGuidToDelete] = useState<string | undefined>();
+
+  const allowPermanent = shouldAllowPermanentlyDeletingRules();
+
+  if (isLoading) {
+    return (
+      <div className={styles.wrapper}>
+        <Trans i18nKey="alerting.rule-list-v2.loading">Loading…</Trans>
+      </div>
+    );
+  }
+
+  const rules = data ?? [];
+
+  return (
+    <div className={styles.wrapper}>
+      <h2 className={styles.title}>
+        <Trans i18nKey="alerting.rule-list-v2.deleted.title">Recently deleted</Trans>
+      </h2>
+      <p className={styles.subtitle}>
+        <Trans i18nKey="alerting.rule-list-v2.deleted.subtitle">Soft-deleted rules. Restore within 30 days.</Trans>
+      </p>
+
+      {rules.length === 0 ? (
+        <EmptyState
+          message={t('alerting.rule-list-v2.deleted.empty', 'No recently deleted rules found')}
+          variant="not-found"
+        />
+      ) : (
+        <InteractiveTable
+          pageSize={PAGE_SIZE}
+          columns={buildColumns(allowPermanent, setRestoreRule, setGuidToDelete)}
+          data={rules}
+          getRowId={(row) => row.grafana_alert.guid || row.grafana_alert.uid}
+        />
+      )}
+
+      <ConfirmRestoreDeletedRuleModal
+        ruleToRestore={restoreRule}
+        isOpen={Boolean(restoreRule)}
+        onDismiss={() => setRestoreRule(undefined)}
+        onRestoreSucess={trackDeletedRuleRestoreSuccess}
+        onRestoreError={trackDeletedRuleRestoreFail}
+      />
+      <ConfirmDeletedPermanentlyModal
+        guid={guidToDelete}
+        isOpen={guidToDelete !== undefined}
+        onDismiss={() => setGuidToDelete(undefined)}
+      />
+    </div>
+  );
+}
+
+function buildColumns(
+  allowPermanent: boolean,
+  setRestoreRule: (r: DeletedRule) => void,
+  setGuidToDelete: (g: string) => void
+): Array<Column<DeletedRule>> {
+  return [
+    {
+      id: 'name',
+      header: t('alerting.rule-list-v2.deleted.column-name', 'NAME'),
+      cell: ({ row }) => (
+        <Stack direction="row" alignItems="center" gap={0.5}>
+          <Icon name="bell" />
+          <code>{row.original.grafana_alert.title}</code>
+        </Stack>
+      ),
+    },
+    {
+      id: 'location',
+      header: t('alerting.rule-list-v2.deleted.column-location', 'LOCATION'),
+      cell: ({ row }) =>
+        `${row.original.grafana_alert.namespace_uid ?? '—'} / ${row.original.grafana_alert.rule_group ?? '—'}`,
+    },
+    {
+      id: 'deletedAt',
+      header: t('alerting.rule-list-v2.deleted.column-deleted-at', 'DELETED AT'),
+      cell: ({ row }) => {
+        const value = row.original.grafana_alert.updated;
+        return value ? dateTimeFormat(value) : '—';
+      },
+    },
+    {
+      id: 'deletedBy',
+      header: t('alerting.rule-list-v2.deleted.column-deleted-by', 'DELETED BY'),
+      cell: ({ row }) => <UpdatedByUser user={row.original.grafana_alert.updated_by} />,
+    },
+    {
+      id: 'actions',
+      header: '',
+      disableGrow: true,
+      cell: ({ row }) => (
+        <Stack direction="row" alignItems="center" justifyContent="flex-end" gap={0.5}>
+          <Button size="sm" variant="secondary" icon="history" onClick={() => setRestoreRule(row.original)}>
+            <Trans i18nKey="alerting.rule-list-v2.deleted.restore">Restore</Trans>
+          </Button>
+          {allowPermanent && (
+            <Button
+              size="sm"
+              variant="destructive"
+              icon="trash-alt"
+              onClick={() => {
+                const guid = row.original.grafana_alert.guid;
+                if (guid) {
+                  setGuidToDelete(guid);
+                }
+              }}
+            >
+              <Trans i18nKey="alerting.rule-list-v2.deleted.delete-permanently">Delete permanently</Trans>
+            </Button>
+          )}
+        </Stack>
+      ),
+    },
+  ];
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    wrapper: css({
+      padding: theme.spacing(1, 2),
+      flex: 1,
+      minWidth: 0,
+    }),
+    title: css({
+      margin: 0,
+      marginBottom: theme.spacing(0.5),
+      fontSize: theme.typography.h3.fontSize,
+    }),
+    subtitle: css({
+      margin: 0,
+      marginBottom: theme.spacing(2),
+      color: theme.colors.text.secondary,
+    }),
+  };
+}

--- a/public/app/features/alerting/unified/rule-list/api-v2/components/RuleCard.tsx
+++ b/public/app/features/alerting/unified/rule-list/api-v2/components/RuleCard.tsx
@@ -1,0 +1,172 @@
+import { css, cx } from '@emotion/css';
+import { forwardRef } from 'react';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { Trans } from '@grafana/i18n';
+import { Icon, Stack, Text, useStyles2 } from '@grafana/ui';
+import { type Rule, type RuleGroupIdentifierV2 } from 'app/types/unified-alerting';
+import { PromRuleType } from 'app/types/unified-alerting-dto';
+
+import { RuleActionsButtons } from '../../components/RuleActionsButtons.V2';
+import { normalizeState } from '../../components/util';
+
+interface Props {
+  rule: Rule;
+  index?: number;
+  contactPoint?: string;
+  instanceCount?: number;
+  showStateChip?: boolean;
+  groupIdentifier?: RuleGroupIdentifierV2;
+}
+
+export const RuleCard = forwardRef<HTMLDivElement, Props>(function RuleCard(
+  { rule, index, contactPoint, instanceCount, showStateChip = true, groupIdentifier },
+  ref
+) {
+  const styles = useStyles2(getStyles);
+  const isRecording = rule.type === PromRuleType.Recording;
+
+  return (
+    <div ref={ref} className={cx(styles.card, isRecording ? styles.recording : styles.alert)}>
+      {typeof index === 'number' && <span className={styles.index}>{index + 1}.</span>}
+      <Icon name={isRecording ? 'record-audio' : 'bell'} className={styles.typeIcon} />
+      <div className={styles.body}>
+        <Text variant="body" weight="medium" color={isRecording ? 'info' : 'primary'}>
+          <code className={styles.name}>{rule.name}</code>
+        </Text>
+        {typeof instanceCount === 'number' && (
+          <span className={styles.meta}>
+            <Trans i18nKey="alerting.rule-list-v2.instance-count" values={{ count: instanceCount }}>
+              {'{{count}} inst.'}
+            </Trans>
+            <MetaContactPoint contactPoint={contactPoint} isRecording={isRecording} />
+          </span>
+        )}
+      </div>
+      <Stack direction="row" alignItems="center" gap={1}>
+        {showStateChip && !isRecording && 'state' in rule && <MiniStateBadge state={normalizeState(rule.state)} />}
+        {contactPoint && typeof instanceCount !== 'number' && (
+          <Text variant="bodySmall" color="secondary">
+            → {contactPoint}
+          </Text>
+        )}
+        {!contactPoint && !isRecording && typeof instanceCount !== 'number' && (
+          <Text variant="bodySmall" color="warning">
+            <Trans i18nKey="alerting.rule-list-v2.no-contact">no contact</Trans>
+          </Text>
+        )}
+        {groupIdentifier && <RuleActionsButtons compact promRule={rule} groupIdentifier={groupIdentifier} />}
+      </Stack>
+    </div>
+  );
+});
+
+function MetaContactPoint({ contactPoint, isRecording }: { contactPoint?: string; isRecording: boolean }) {
+  if (contactPoint) {
+    return (
+      <>
+        {' · '}→ {contactPoint}
+      </>
+    );
+  }
+  if (!isRecording) {
+    return (
+      <>
+        {' · '}
+        <Text color="warning">
+          <Trans i18nKey="alerting.rule-list-v2.no-contact-warning">⚠ no contact</Trans>
+        </Text>
+      </>
+    );
+  }
+  return null;
+}
+
+function MiniStateBadge({ state }: { state: ReturnType<typeof normalizeState> }) {
+  const styles = useStyles2(getStyles);
+  if (!state || state === 'unknown') {
+    return null;
+  }
+  return <span className={cx(styles.stateBadge, styles[`state_${state}`])}>{label(state)}</span>;
+}
+
+function label(state: string): string {
+  return state.charAt(0).toUpperCase() + state.slice(1);
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    card: css({
+      display: 'flex',
+      alignItems: 'center',
+      gap: theme.spacing(1),
+      padding: theme.spacing(1),
+      borderRadius: theme.shape.radius.default,
+      background: theme.colors.background.secondary,
+      border: `1px solid ${theme.colors.border.weak}`,
+      borderLeft: `2px solid transparent`,
+    }),
+    alert: css({
+      borderLeftColor: theme.colors.warning.main,
+    }),
+    recording: css({
+      borderLeftColor: theme.colors.info.main,
+    }),
+    index: css({
+      color: theme.colors.text.secondary,
+      fontSize: theme.typography.bodySmall.fontSize,
+      minWidth: theme.spacing(2),
+    }),
+    typeIcon: css({
+      color: theme.colors.text.secondary,
+      flexShrink: 0,
+    }),
+    body: css({
+      display: 'flex',
+      flexDirection: 'column',
+      flex: 1,
+      minWidth: 0,
+    }),
+    name: css({
+      fontFamily: theme.typography.fontFamilyMonospace,
+      fontSize: theme.typography.body.fontSize,
+      background: 'none',
+      padding: 0,
+    }),
+    meta: css({
+      color: theme.colors.text.secondary,
+      fontSize: theme.typography.bodySmall.fontSize,
+    }),
+    stateBadge: css({
+      padding: theme.spacing(0.25, 0.75),
+      borderRadius: theme.shape.radius.pill,
+      fontSize: theme.typography.bodySmall.fontSize,
+      fontWeight: theme.typography.fontWeightMedium,
+    }),
+    state_firing: css({
+      background: theme.colors.error.transparent,
+      color: theme.colors.error.text,
+      border: `1px solid ${theme.colors.error.border}`,
+    }),
+    state_pending: css({
+      background: theme.colors.warning.transparent,
+      color: theme.colors.warning.text,
+      border: `1px solid ${theme.colors.warning.border}`,
+    }),
+    state_recovering: css({
+      background: theme.colors.info.transparent,
+      color: theme.colors.info.text,
+      border: `1px solid ${theme.colors.info.border}`,
+    }),
+    state_normal: css({
+      background: theme.colors.success.transparent,
+      color: theme.colors.success.text,
+      border: `1px solid ${theme.colors.success.border}`,
+    }),
+    state_inhibited: css({
+      background: theme.colors.secondary.transparent,
+      color: theme.colors.text.secondary,
+      border: `1px solid ${theme.colors.border.weak}`,
+    }),
+  };
+}

--- a/public/app/features/alerting/unified/rule-list/api-v2/components/SearchRow.tsx
+++ b/public/app/features/alerting/unified/rule-list/api-v2/components/SearchRow.tsx
@@ -1,0 +1,88 @@
+import { css } from '@emotion/css';
+import { useEffect, useState } from 'react';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
+import { Button, Icon, Input, useStyles2 } from '@grafana/ui';
+
+import { useRulesFilter } from '../../../hooks/useFilteredRules';
+
+interface Props {
+  filterCount: number;
+  filtersOpen: boolean;
+  onToggleFilters: () => void;
+}
+
+export function SearchRow({ filterCount, filtersOpen, onToggleFilters }: Props) {
+  const styles = useStyles2(getStyles);
+  const { searchQuery, setSearchQuery } = useRulesFilter();
+  const [localValue, setLocalValue] = useState(searchQuery);
+
+  // Keep the local input value in sync when the URL/filter panel writes a new search string.
+  useEffect(() => {
+    setLocalValue(searchQuery);
+  }, [searchQuery]);
+
+  function commit(next: string) {
+    setSearchQuery(next || undefined);
+  }
+
+  return (
+    <div className={styles.row}>
+      <div className={styles.searchWrap}>
+        <Input
+          placeholder={t('alerting.rule-list-v2.search-placeholder', 'Search by name or enter filter query...')}
+          prefix={<Icon name="search" />}
+          value={localValue}
+          onChange={(e) => setLocalValue(e.currentTarget.value)}
+          onBlur={(e) => commit(e.currentTarget.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' && e.currentTarget instanceof HTMLInputElement) {
+              commit(e.currentTarget.value);
+            }
+          }}
+        />
+      </div>
+      <Button variant="secondary" icon="bookmark">
+        <Trans i18nKey="alerting.rule-list-v2.saved-searches">Saved searches</Trans>
+      </Button>
+      <Button
+        variant="secondary"
+        icon="filter"
+        aria-expanded={filtersOpen}
+        aria-controls="rule-list-v2-filter-panel"
+        onClick={onToggleFilters}
+      >
+        <Trans i18nKey="alerting.rule-list-v2.filters">Filters</Trans>
+        {filterCount > 0 && <span className={styles.badge}>{filterCount}</span>}
+      </Button>
+    </div>
+  );
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    row: css({
+      display: 'flex',
+      alignItems: 'center',
+      gap: theme.spacing(1),
+    }),
+    searchWrap: css({
+      flex: 1,
+    }),
+    badge: css({
+      marginLeft: theme.spacing(0.5),
+      display: 'inline-flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      width: theme.spacing(2.25),
+      height: theme.spacing(2.25),
+      borderRadius: theme.shape.radius.circle,
+      background: theme.colors.primary.main,
+      color: theme.colors.primary.contrastText,
+      fontSize: theme.typography.bodySmall.fontSize,
+      fontWeight: theme.typography.fontWeightMedium,
+      lineHeight: 1,
+    }),
+  };
+}

--- a/public/app/features/alerting/unified/rule-list/api-v2/components/StateChip.tsx
+++ b/public/app/features/alerting/unified/rule-list/api-v2/components/StateChip.tsx
@@ -1,0 +1,87 @@
+import { css, cx } from '@emotion/css';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { useStyles2 } from '@grafana/ui';
+
+import { type StateChip as StateChipKind } from '../lib/types';
+
+interface Props {
+  kind: StateChipKind;
+  count: number;
+  active: boolean;
+  onToggle: () => void;
+}
+
+export function StateChip({ kind, count, active, onToggle }: Props) {
+  const styles = useStyles2(getStyles);
+  return (
+    <button
+      type="button"
+      aria-pressed={active}
+      onClick={onToggle}
+      className={cx(styles.chip, active && styles.active, styles[kind])}
+    >
+      <span className={cx(styles.dot, styles[`${kind}Dot`])} aria-hidden="true" />
+      <span className={styles.label}>{labelFor(kind)}</span>
+      <span className={styles.count}>{count}</span>
+    </button>
+  );
+}
+
+function labelFor(kind: StateChipKind): string {
+  switch (kind) {
+    case 'firing':
+      return t('alerting.rule-list-v2.state.firing', 'Firing');
+    case 'pending':
+      return t('alerting.rule-list-v2.state.pending', 'Pending');
+    case 'recovering':
+      return t('alerting.rule-list-v2.state.recovering', 'Recovering');
+    case 'normal':
+      return t('alerting.rule-list-v2.state.normal', 'Normal');
+  }
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    chip: css({
+      display: 'inline-flex',
+      alignItems: 'center',
+      gap: theme.spacing(0.5),
+      padding: theme.spacing(0.25, 1),
+      background: 'transparent',
+      border: `1px solid ${theme.colors.border.weak}`,
+      borderRadius: theme.shape.radius.pill,
+      cursor: 'pointer',
+      fontSize: theme.typography.bodySmall.fontSize,
+      color: theme.colors.text.primary,
+      '&:hover': {
+        background: theme.colors.action.hover,
+      },
+    }),
+    active: css({
+      borderColor: theme.colors.primary.border,
+      background: theme.colors.action.selected,
+    }),
+    dot: css({
+      width: 8,
+      height: 8,
+      borderRadius: theme.shape.radius.circle,
+    }),
+    firing: css({}),
+    pending: css({}),
+    recovering: css({}),
+    normal: css({}),
+    firingDot: css({ background: theme.colors.error.main }),
+    pendingDot: css({ background: theme.colors.warning.main }),
+    recoveringDot: css({ background: theme.colors.info.main }),
+    normalDot: css({ background: theme.colors.success.main }),
+    label: css({
+      fontWeight: theme.typography.fontWeightMedium,
+    }),
+    count: css({
+      color: theme.colors.text.secondary,
+      fontVariantNumeric: 'tabular-nums',
+    }),
+  };
+}

--- a/public/app/features/alerting/unified/rule-list/api-v2/components/StateChipRow.tsx
+++ b/public/app/features/alerting/unified/rule-list/api-v2/components/StateChipRow.tsx
@@ -1,0 +1,56 @@
+import { css } from '@emotion/css';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { Trans } from '@grafana/i18n';
+import { Stack, useStyles2 } from '@grafana/ui';
+
+import { type StateChipCounts, type StateChip as StateChipKind } from '../lib/types';
+
+import { StateChip } from './StateChip';
+
+interface Props {
+  counts: StateChipCounts;
+  active: Set<StateChipKind>;
+  onToggle: (chip: StateChipKind) => void;
+}
+
+const CHIPS: StateChipKind[] = ['firing', 'pending', 'recovering', 'normal'];
+
+export function StateChipRow({ counts, active, onToggle }: Props) {
+  const styles = useStyles2(getStyles);
+  return (
+    <div className={styles.row}>
+      <span className={styles.label}>
+        <Trans i18nKey="alerting.rule-list-v2.state-label">STATE</Trans>
+      </span>
+      <Stack direction="row" gap={0.5}>
+        {CHIPS.map((chip) => (
+          <StateChip
+            key={chip}
+            kind={chip}
+            count={counts[chip]}
+            active={active.has(chip)}
+            onToggle={() => onToggle(chip)}
+          />
+        ))}
+      </Stack>
+    </div>
+  );
+}
+
+function getStyles(theme: GrafanaTheme2) {
+  return {
+    row: css({
+      display: 'flex',
+      alignItems: 'center',
+      gap: theme.spacing(1),
+      padding: theme.spacing(0.5, 0),
+    }),
+    label: css({
+      color: theme.colors.text.secondary,
+      fontSize: theme.typography.bodySmall.fontSize,
+      fontWeight: theme.typography.fontWeightBold,
+      letterSpacing: '0.05em',
+    }),
+  };
+}

--- a/public/app/features/alerting/unified/rule-list/api-v2/hooks/useFolderListKeyboard.ts
+++ b/public/app/features/alerting/unified/rule-list/api-v2/hooks/useFolderListKeyboard.ts
@@ -1,0 +1,62 @@
+import { type KeyboardEvent, useCallback } from 'react';
+
+export interface FolderListKeyboardHandlers {
+  onKeyDown: (event: KeyboardEvent<HTMLElement>) => void;
+}
+
+export interface UseFolderListKeyboardOptions {
+  flatKeys: string[];
+  activeKey?: string;
+  onActivate: (key: string) => void;
+}
+
+export function useFolderListKeyboard({
+  flatKeys,
+  activeKey,
+  onActivate,
+}: UseFolderListKeyboardOptions): FolderListKeyboardHandlers {
+  const onKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLElement>) => {
+      if (flatKeys.length === 0) {
+        return;
+      }
+      const currentIndex = activeKey ? flatKeys.indexOf(activeKey) : -1;
+
+      switch (event.key) {
+        case 'ArrowDown': {
+          event.preventDefault();
+          const next = currentIndex < 0 ? 0 : Math.min(currentIndex + 1, flatKeys.length - 1);
+          onActivate(flatKeys[next]);
+          break;
+        }
+        case 'ArrowUp': {
+          event.preventDefault();
+          const next = currentIndex <= 0 ? 0 : currentIndex - 1;
+          onActivate(flatKeys[next]);
+          break;
+        }
+        case 'Home': {
+          event.preventDefault();
+          onActivate(flatKeys[0]);
+          break;
+        }
+        case 'End': {
+          event.preventDefault();
+          onActivate(flatKeys[flatKeys.length - 1]);
+          break;
+        }
+        case 'Enter':
+        case ' ': {
+          if (activeKey) {
+            event.preventDefault();
+            onActivate(activeKey);
+          }
+          break;
+        }
+      }
+    },
+    [flatKeys, activeKey, onActivate]
+  );
+
+  return { onKeyDown };
+}

--- a/public/app/features/alerting/unified/rule-list/api-v2/hooks/useRuleDependencies.ts
+++ b/public/app/features/alerting/unified/rule-list/api-v2/hooks/useRuleDependencies.ts
@@ -1,0 +1,10 @@
+import { useMemo } from 'react';
+
+import { type RuleGroup } from 'app/types/unified-alerting';
+
+import { detectDependencies } from '../lib/detectDependencies';
+import { type ChainInfo } from '../lib/types';
+
+export function useRuleDependencies(group: RuleGroup): ChainInfo {
+  return useMemo(() => detectDependencies(group), [group]);
+}

--- a/public/app/features/alerting/unified/rule-list/api-v2/hooks/useRuleTree.ts
+++ b/public/app/features/alerting/unified/rule-list/api-v2/hooks/useRuleTree.ts
@@ -1,0 +1,119 @@
+import { useCallback, useMemo, useReducer } from 'react';
+
+import { type RuleNamespace } from 'app/types/unified-alerting';
+
+import { alertRuleApi } from '../../../api/alertRuleApi';
+import { useRulesFilter } from '../../../hooks/useFilteredRules';
+import { GRAFANA_RULES_SOURCE_NAME, getRulesDataSources } from '../../../utils/datasource';
+import { applyRulesFilterToTree } from '../lib/applyRulesFilterToTree';
+import { type DataSourceInput, buildTreeModel } from '../lib/treeModel';
+import { type TreeModel } from '../lib/types';
+
+const POLL_INTERVAL_MS = 120_000;
+
+export interface ExternalSourceResult {
+  namespaces?: RuleNamespace[];
+  error?: string;
+}
+
+export interface UseRuleTreeResult {
+  filteredTree: TreeModel;
+  preStateTree: TreeModel;
+  isLoading: boolean;
+  externalDataSources: Array<{ uid: string; name: string }>;
+  publishExternalResult: (uid: string, result: ExternalSourceResult) => void;
+}
+
+type Action = { type: 'set'; uid: string; result: ExternalSourceResult };
+
+function reducer(state: Record<string, ExternalSourceResult>, action: Action): Record<string, ExternalSourceResult> {
+  if (action.type === 'set') {
+    const prev = state[action.uid];
+    if (prev && prev.namespaces === action.result.namespaces && prev.error === action.result.error) {
+      return state;
+    }
+    return { ...state, [action.uid]: action.result };
+  }
+  return state;
+}
+
+export function useRuleTree(): UseRuleTreeResult {
+  const { filterState } = useRulesFilter();
+
+  const externalDataSources = useMemo(
+    () =>
+      getRulesDataSources().map((ds) => ({
+        uid: ds.uid,
+        name: ds.name,
+      })),
+    []
+  );
+
+  const grafanaQuery = alertRuleApi.endpoints.prometheusRulesByNamespace.useQuery(
+    { limitAlerts: 0 },
+    { pollingInterval: POLL_INTERVAL_MS }
+  );
+
+  const [externalResults, dispatch] = useReducer(reducer, {});
+
+  const publishExternalResult = useCallback((uid: string, result: ExternalSourceResult) => {
+    dispatch({ type: 'set', uid, result });
+  }, []);
+
+  const rawTree = useMemo<TreeModel>(() => {
+    const inputs: DataSourceInput[] = [];
+
+    inputs.push({
+      uid: GRAFANA_RULES_SOURCE_NAME,
+      name: 'Grafana-managed',
+      isGrafana: true,
+      namespaces: grafanaQuery.data,
+      error: grafanaQuery.isError ? errorMessage(grafanaQuery.error) : undefined,
+    });
+
+    for (const ds of externalDataSources) {
+      const result = externalResults[ds.uid];
+      inputs.push({
+        uid: ds.uid,
+        name: ds.name,
+        isGrafana: false,
+        namespaces: result?.namespaces,
+        error: result?.error,
+      });
+    }
+
+    return buildTreeModel(inputs);
+  }, [grafanaQuery.data, grafanaQuery.isError, grafanaQuery.error, externalDataSources, externalResults]);
+
+  const filteredTree = useMemo(() => applyRulesFilterToTree(rawTree, filterState), [rawTree, filterState]);
+  const preStateTree = useMemo(
+    () => applyRulesFilterToTree(rawTree, filterState, { ignoreRuleState: true }),
+    [rawTree, filterState]
+  );
+
+  return {
+    filteredTree,
+    preStateTree,
+    isLoading: grafanaQuery.isLoading,
+    externalDataSources,
+    publishExternalResult,
+  };
+}
+
+function errorMessage(err: unknown): string {
+  const status = extractStatus(err);
+  if (status === 'FETCH_ERROR') {
+    return 'Failed to load rules: connection refused';
+  }
+  if (typeof status === 'number') {
+    return `Failed to load rules: ${status}`;
+  }
+  return 'Failed to load rules';
+}
+
+function extractStatus(err: unknown): unknown {
+  if (err && typeof err === 'object' && 'status' in err) {
+    return err.status;
+  }
+  return undefined;
+}

--- a/public/app/features/alerting/unified/rule-list/api-v2/hooks/useSelectedFolder.ts
+++ b/public/app/features/alerting/unified/rule-list/api-v2/hooks/useSelectedFolder.ts
@@ -1,0 +1,61 @@
+import { useCallback, useMemo } from 'react';
+
+import { useURLSearchParams } from '../../../hooks/useURLSearchParams';
+import { type SelectedView } from '../lib/types';
+
+const PARAM = 'folder';
+
+export interface UseSelectedFolderResult {
+  view: SelectedView;
+  selectFolder: (dataSourceUid: string, folderKey: string) => void;
+  selectDeleted: () => void;
+  clear: () => void;
+}
+
+export function useSelectedFolder(): UseSelectedFolderResult {
+  const [params, update] = useURLSearchParams();
+  const raw = params.get(PARAM);
+
+  const view = useMemo<SelectedView>(() => parseParam(raw), [raw]);
+
+  const selectFolder = useCallback(
+    (dataSourceUid: string, folderKey: string) => {
+      update({ [PARAM]: `ds:${encodeURIComponent(dataSourceUid)}/${encodeURIComponent(folderKey)}` });
+    },
+    [update]
+  );
+
+  const selectDeleted = useCallback(() => {
+    update({ [PARAM]: 'deleted' });
+  }, [update]);
+
+  const clear = useCallback(() => {
+    update({ [PARAM]: undefined });
+  }, [update]);
+
+  return { view, selectFolder, selectDeleted, clear };
+}
+
+function parseParam(raw: string | null): SelectedView {
+  if (!raw) {
+    return { kind: 'empty' };
+  }
+  if (raw === 'deleted') {
+    return { kind: 'deleted' };
+  }
+  if (raw.startsWith('ds:')) {
+    const rest = raw.slice(3);
+    const slash = rest.indexOf('/');
+    if (slash === -1) {
+      return { kind: 'empty' };
+    }
+    return {
+      kind: 'folder',
+      folder: {
+        dataSourceUid: decodeURIComponent(rest.slice(0, slash)),
+        folderKey: decodeURIComponent(rest.slice(slash + 1)),
+      },
+    };
+  }
+  return { kind: 'empty' };
+}

--- a/public/app/features/alerting/unified/rule-list/api-v2/hooks/useShowDependencyArrowsPref.ts
+++ b/public/app/features/alerting/unified/rule-list/api-v2/hooks/useShowDependencyArrowsPref.ts
@@ -1,0 +1,16 @@
+import { useCallback, useState } from 'react';
+
+import { store } from '@grafana/data';
+
+const STORAGE_KEY = 'grafana.alerting.rulesAPIV2.showDependencyArrows';
+
+export function useShowDependencyArrowsPref(): [boolean, (next: boolean) => void] {
+  const [value, setValue] = useState<boolean>(() => store.getBool(STORAGE_KEY, true));
+
+  const update = useCallback((next: boolean) => {
+    store.set(STORAGE_KEY, String(next));
+    setValue(next);
+  }, []);
+
+  return [value, update];
+}

--- a/public/app/features/alerting/unified/rule-list/api-v2/hooks/useStateChipFilter.ts
+++ b/public/app/features/alerting/unified/rule-list/api-v2/hooks/useStateChipFilter.ts
@@ -1,0 +1,108 @@
+import { useCallback, useMemo, useState } from 'react';
+
+import { PromAlertingRuleState } from 'app/types/unified-alerting-dto';
+
+import { type StateChip, type StateChipCounts, type TreeModel, getStateBucket } from '../lib/types';
+
+export interface UseStateChipFilterResult {
+  active: Set<StateChip>;
+  counts: StateChipCounts;
+  toggle: (chip: StateChip) => void;
+  clear: () => void;
+  applyToTree: (tree: TreeModel) => TreeModel;
+  hasActiveChips: boolean;
+}
+
+const EMPTY_COUNTS: StateChipCounts = { firing: 0, pending: 0, recovering: 0, normal: 0 };
+
+export function useStateChipFilter(preStateTree: TreeModel): UseStateChipFilterResult {
+  const [active, setActive] = useState<Set<StateChip>>(() => new Set());
+
+  const counts = useMemo<StateChipCounts>(() => {
+    const next: StateChipCounts = { ...EMPTY_COUNTS };
+    for (const ds of preStateTree.dataSources) {
+      for (const folder of ds.folders) {
+        for (const group of folder.groups) {
+          for (const rule of group.rules) {
+            if (rule.type !== 'alerting') {
+              continue;
+            }
+            const bucket = getStateBucket(rule.state);
+            if (bucket) {
+              next[bucket] += 1;
+            }
+          }
+        }
+      }
+    }
+    return next;
+  }, [preStateTree]);
+
+  const toggle = useCallback((chip: StateChip) => {
+    setActive((prev) => {
+      const next = new Set(prev);
+      if (next.has(chip)) {
+        next.delete(chip);
+      } else {
+        next.add(chip);
+      }
+      return next;
+    });
+  }, []);
+
+  const clear = useCallback(() => setActive(new Set()), []);
+
+  const applyToTree = useCallback(
+    (tree: TreeModel): TreeModel => {
+      if (active.size === 0) {
+        return tree;
+      }
+      const wanted: PromAlertingRuleState[] = [];
+      active.forEach((chip) => {
+        const state = chipToState(chip);
+        if (state) {
+          wanted.push(state);
+        }
+      });
+      return {
+        dataSources: tree.dataSources.map((ds) => ({
+          ...ds,
+          folders: ds.folders
+            .map((folder) => ({
+              ...folder,
+              groups: folder.groups
+                .map((group) => ({
+                  ...group,
+                  rules: group.rules.filter((rule) => {
+                    if (rule.type !== 'alerting') {
+                      return false;
+                    }
+                    return wanted.includes(rule.state);
+                  }),
+                }))
+                .filter((g) => g.rules.length > 0),
+            }))
+            .filter((f) => f.groups.length > 0 || Boolean(ds.error)),
+        })),
+      };
+    },
+    [active]
+  );
+
+  return { active, counts, toggle, clear, applyToTree, hasActiveChips: active.size > 0 };
+}
+
+function chipToState(chip: StateChip): PromAlertingRuleState | undefined {
+  switch (chip) {
+    case 'firing':
+      return PromAlertingRuleState.Firing;
+    case 'pending':
+      return PromAlertingRuleState.Pending;
+    case 'recovering':
+      return PromAlertingRuleState.Recovering;
+    case 'normal':
+      return PromAlertingRuleState.Inactive;
+    default:
+      return undefined;
+  }
+}

--- a/public/app/features/alerting/unified/rule-list/api-v2/lib/applyRulesFilterToTree.ts
+++ b/public/app/features/alerting/unified/rule-list/api-v2/lib/applyRulesFilterToTree.ts
@@ -1,0 +1,144 @@
+import { type Rule, type RuleGroup } from 'app/types/unified-alerting';
+import { PromRuleType } from 'app/types/unified-alerting-dto';
+
+import { RuleSource, type RulesFilter } from '../../../search/rulesSearchParser';
+import { getRuleHealth, prometheusRuleType } from '../../../utils/rules';
+
+import { type TreeDataSource, type TreeFolder, type TreeModel } from './types';
+
+export interface ApplyFilterOptions {
+  ignoreRuleState?: boolean;
+}
+
+export function applyRulesFilterToTree(
+  model: TreeModel,
+  filter: RulesFilter,
+  options: ApplyFilterOptions = {}
+): TreeModel {
+  const effective = options.ignoreRuleState ? { ...filter, ruleState: undefined } : filter;
+
+  const dataSources = model.dataSources.map((ds) => filterDataSource(ds, effective)).filter(hasContent);
+
+  return { dataSources };
+}
+
+function filterDataSource(ds: TreeDataSource, filter: RulesFilter): TreeDataSource {
+  if (ds.error) {
+    return ds;
+  }
+
+  if (filter.ruleSource === RuleSource.Grafana && !ds.isGrafana) {
+    return { ...ds, folders: [] };
+  }
+  if (filter.ruleSource === RuleSource.DataSource && ds.isGrafana) {
+    return { ...ds, folders: [] };
+  }
+
+  if (filter.dataSourceNames?.length) {
+    if (!ds.isGrafana && !filter.dataSourceNames.includes(ds.name)) {
+      return { ...ds, folders: [] };
+    }
+  }
+
+  const folders = ds.folders.map((f) => filterFolder(f, filter)).filter((f): f is TreeFolder => f !== null);
+  return { ...ds, folders };
+}
+
+function filterFolder(folder: TreeFolder, filter: RulesFilter): TreeFolder | null {
+  if (filter.namespace && !folder.title.toLowerCase().includes(filter.namespace.toLowerCase())) {
+    return null;
+  }
+
+  const groups = folder.groups.map((g) => filterGroup(g, filter)).filter((g): g is RuleGroup => g !== null);
+  if (groups.length === 0) {
+    return null;
+  }
+  return { ...folder, groups };
+}
+
+function filterGroup(group: RuleGroup, filter: RulesFilter): RuleGroup | null {
+  if (filter.groupName && !group.name.toLowerCase().includes(filter.groupName.toLowerCase())) {
+    return null;
+  }
+  const rules = group.rules.filter((r) => matchesRule(r, filter));
+  if (rules.length === 0) {
+    return null;
+  }
+  return { ...group, rules };
+}
+
+function matchesRule(rule: Rule, filter: RulesFilter): boolean {
+  if (filter.ruleName && !rule.name.toLowerCase().includes(filter.ruleName.toLowerCase())) {
+    return false;
+  }
+
+  if (filter.ruleType && rule.type !== filter.ruleType) {
+    return false;
+  }
+
+  if (filter.ruleState) {
+    if (!prometheusRuleType.alertingRule(rule)) {
+      return false;
+    }
+    if (rule.state !== filter.ruleState) {
+      return false;
+    }
+  }
+
+  if (filter.ruleHealth) {
+    const health = getRuleHealth(rule.health);
+    if (health !== filter.ruleHealth) {
+      return false;
+    }
+  }
+
+  if (filter.labels?.length) {
+    const ruleLabels = rule.labels ?? {};
+    for (const matcher of filter.labels) {
+      if (!matchesLabel(ruleLabels, matcher)) {
+        return false;
+      }
+    }
+  }
+
+  // Free-form words: match alert name or label values loosely.
+  if (filter.freeFormWords?.length) {
+    const haystack = ruleSearchableText(rule);
+    for (const word of filter.freeFormWords) {
+      if (!haystack.includes(word.toLowerCase())) {
+        return false;
+      }
+    }
+  }
+
+  return true;
+}
+
+function matchesLabel(labels: Record<string, string>, matcher: string): boolean {
+  const eq = matcher.split('=');
+  if (eq.length !== 2) {
+    return true;
+  }
+  const [key, rawValue] = eq;
+  const value = rawValue.replace(/^"|"$/g, '');
+  return labels[key] === value;
+}
+
+function ruleSearchableText(rule: Rule): string {
+  const parts: string[] = [rule.name];
+  if (rule.labels) {
+    for (const [k, v] of Object.entries(rule.labels)) {
+      parts.push(k, v);
+    }
+  }
+  if (rule.type === PromRuleType.Alerting && rule.annotations) {
+    for (const v of Object.values(rule.annotations)) {
+      parts.push(v);
+    }
+  }
+  return parts.join(' ').toLowerCase();
+}
+
+function hasContent(ds: TreeDataSource): boolean {
+  return ds.folders.length > 0 || Boolean(ds.error);
+}

--- a/public/app/features/alerting/unified/rule-list/api-v2/lib/chainGeometry.ts
+++ b/public/app/features/alerting/unified/rule-list/api-v2/lib/chainGeometry.ts
@@ -1,0 +1,24 @@
+export interface ArrowEndpoint {
+  x: number;
+  y: number;
+}
+
+export interface ArrowPath {
+  key: string;
+  d: string;
+  from: ArrowEndpoint;
+  to: ArrowEndpoint;
+}
+
+export function buildArrowPath(from: ArrowEndpoint, to: ArrowEndpoint): string {
+  const dx = to.x - from.x;
+  const cp1x = from.x + dx * 0.5;
+  const cp2x = to.x - dx * 0.5;
+  return `M ${from.x},${from.y} C ${cp1x},${from.y} ${cp2x},${to.y} ${to.x},${to.y}`;
+}
+
+export function centerOf(rect: DOMRect, containerRect: DOMRect, side: 'left' | 'right'): ArrowEndpoint {
+  const y = rect.top + rect.height / 2 - containerRect.top;
+  const x = side === 'left' ? rect.left - containerRect.left : rect.right - containerRect.left;
+  return { x, y };
+}

--- a/public/app/features/alerting/unified/rule-list/api-v2/lib/detectDependencies.ts
+++ b/public/app/features/alerting/unified/rule-list/api-v2/lib/detectDependencies.ts
@@ -1,0 +1,42 @@
+import { type RuleGroup } from 'app/types/unified-alerting';
+
+import { prometheusRuleType } from '../../../utils/rules';
+
+import { type ChainInfo } from './types';
+
+// NOTE: string-match heuristic. Can produce false positives when a recording-metric
+// name collides with a label value or free text. Follow-up: PromQL AST parse via
+// @grafana/prometheus. Deferred for PoC.
+export function detectDependencies(group: RuleGroup): ChainInfo {
+  const recordings = group.rules.filter(prometheusRuleType.recordingRule);
+  const alerts = group.rules.filter(prometheusRuleType.alertingRule);
+
+  if (recordings.length === 0 || alerts.length === 0) {
+    return { isChain: false, dependencies: new Map() };
+  }
+
+  const recordingNames = recordings.map((r) => r.name).filter(Boolean);
+  const dependencies = new Map<string, string[]>();
+
+  for (const alert of alerts) {
+    const matches: string[] = [];
+    for (const name of recordingNames) {
+      if (!name) {
+        continue;
+      }
+      const pattern = new RegExp(`\\b${escapeRegExp(name)}\\b`);
+      if (pattern.test(alert.query)) {
+        matches.push(name);
+      }
+    }
+    if (matches.length > 0) {
+      dependencies.set(alert.name, matches);
+    }
+  }
+
+  return { isChain: dependencies.size > 0, dependencies };
+}
+
+function escapeRegExp(input: string): string {
+  return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/public/app/features/alerting/unified/rule-list/api-v2/lib/groupIdentifier.ts
+++ b/public/app/features/alerting/unified/rule-list/api-v2/lib/groupIdentifier.ts
@@ -1,0 +1,27 @@
+import { type RuleGroup, type RuleGroupIdentifierV2 } from 'app/types/unified-alerting';
+
+import { type TreeDataSource, type TreeFolder } from './types';
+
+export function buildGroupIdentifier(
+  dataSource: TreeDataSource,
+  folder: TreeFolder,
+  group: RuleGroup
+): RuleGroupIdentifierV2 {
+  if (dataSource.isGrafana) {
+    return {
+      groupName: group.name,
+      namespace: { uid: folder.key },
+      groupOrigin: 'grafana',
+    };
+  }
+  return {
+    rulesSource: {
+      uid: dataSource.uid,
+      name: dataSource.name,
+      ruleSourceType: 'datasource',
+    },
+    groupName: group.name,
+    namespace: { name: folder.title },
+    groupOrigin: 'datasource',
+  };
+}

--- a/public/app/features/alerting/unified/rule-list/api-v2/lib/treeModel.ts
+++ b/public/app/features/alerting/unified/rule-list/api-v2/lib/treeModel.ts
@@ -1,0 +1,52 @@
+import { type RuleNamespace } from 'app/types/unified-alerting';
+
+import { type TreeDataSource, type TreeFolder, type TreeModel } from './types';
+
+export interface DataSourceInput {
+  uid: string;
+  name: string;
+  isGrafana: boolean;
+  namespaces?: RuleNamespace[];
+  error?: string;
+}
+
+export function buildTreeModel(inputs: DataSourceInput[]): TreeModel {
+  const dataSources: TreeDataSource[] = inputs.map((input) => ({
+    uid: input.uid,
+    name: input.name,
+    isGrafana: input.isGrafana,
+    error: input.error,
+    folders: toFolders(input.namespaces ?? []),
+  }));
+
+  return { dataSources };
+}
+
+function toFolders(namespaces: RuleNamespace[]): TreeFolder[] {
+  const folders = namespaces.map<TreeFolder>((namespace) => ({
+    key: folderKeyFromNamespace(namespace),
+    title: namespace.name,
+    groups: namespace.groups,
+  }));
+
+  // eslint-disable-next-line @grafana/no-locale-compare -- folder lists are small and user-facing
+  folders.sort((a, b) => a.title.localeCompare(b.title));
+  return folders;
+}
+
+export function folderKeyFromNamespace(namespace: RuleNamespace): string {
+  const firstRule = namespace.groups[0]?.rules[0];
+  if (firstRule && 'folderUid' in firstRule && firstRule.folderUid) {
+    return firstRule.folderUid;
+  }
+  return namespace.name;
+}
+
+export function findFolder(model: TreeModel, dataSourceUid: string, folderKey: string): TreeFolder | undefined {
+  const ds = model.dataSources.find((d) => d.uid === dataSourceUid);
+  return ds?.folders.find((f) => f.key === folderKey);
+}
+
+export function findDataSource(model: TreeModel, dataSourceUid: string): TreeDataSource | undefined {
+  return model.dataSources.find((d) => d.uid === dataSourceUid);
+}

--- a/public/app/features/alerting/unified/rule-list/api-v2/lib/types.ts
+++ b/public/app/features/alerting/unified/rule-list/api-v2/lib/types.ts
@@ -1,0 +1,59 @@
+import { type Rule, type RuleGroup } from 'app/types/unified-alerting';
+import { type PromAlertingRuleState } from 'app/types/unified-alerting-dto';
+
+export type StateChip = 'firing' | 'pending' | 'recovering' | 'normal';
+
+export type StateChipCounts = Record<StateChip, number>;
+
+export interface TreeFolder {
+  key: string;
+  title: string;
+  groups: RuleGroup[];
+}
+
+export interface TreeDataSource {
+  uid: string;
+  name: string;
+  isGrafana: boolean;
+  error?: string;
+  folders: TreeFolder[];
+}
+
+export interface TreeModel {
+  dataSources: TreeDataSource[];
+}
+
+export interface ChainInfo {
+  isChain: boolean;
+  dependencies: Map<string, string[]>;
+}
+
+export interface SelectedFolder {
+  dataSourceUid: string;
+  folderKey: string;
+}
+
+export type SelectedView = { kind: 'folder'; folder: SelectedFolder } | { kind: 'deleted' } | { kind: 'empty' };
+
+export function isAlertRule(rule: Rule): boolean {
+  return rule.type === 'alerting';
+}
+
+export function isRecordingRule(rule: Rule): boolean {
+  return rule.type === 'recording';
+}
+
+export function getStateBucket(state: PromAlertingRuleState | undefined): StateChip | undefined {
+  switch (state) {
+    case 'firing':
+      return 'firing';
+    case 'pending':
+      return 'pending';
+    case 'recovering':
+      return 'recovering';
+    case 'inactive':
+      return 'normal';
+    default:
+      return undefined;
+  }
+}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3021,8 +3021,82 @@
       "expand-all": "Expand all"
     },
     "rule-list-v2": {
+      "chain": {
+        "alerts-after": "THEN ALERT RULES FIRE ON THEM",
+        "description-empty": "No dependencies between recording and alert rules in this group.",
+        "description-item": "{{alert}} depends on {{recordings}}",
+        "recordings-first": "RECORDING RULES EVALUATE FIRST"
+      },
+      "clear-filters": "Clear filters",
+      "deleted": {
+        "column-deleted-at": "DELETED AT",
+        "column-deleted-by": "DELETED BY",
+        "column-location": "LOCATION",
+        "column-name": "NAME",
+        "delete-permanently": "Delete permanently",
+        "empty": "No recently deleted rules found",
+        "restore": "Restore",
+        "subtitle": "Soft-deleted rules. Restore within 30 days.",
+        "title": "Recently deleted"
+      },
+      "dependency-overlay": {
+        "label": "Dependencies between recording rules and alert rules"
+      },
+      "ds-error-tag": "Error",
+      "evaluation-chain-badge": "evaluation chain",
+      "field": {
+        "contact-point": "Contact point",
+        "contact-point-placeholder": "Select contact point",
+        "data-source": "Data source",
+        "data-source-placeholder": "Select data sources",
+        "health": "Health",
+        "labels": "Labels",
+        "labels-placeholder": "env=prod, team=...",
+        "plugin-rules": "Plugin rules",
+        "rule-name": "Rule name",
+        "rule-name-placeholder": "Filter by name...",
+        "rule-source": "Rule source",
+        "rule-type": "Type"
+      },
+      "filter-folders": "Filter folders...",
+      "filters": "Filters",
+      "folders-tree": "Folders",
+      "health-all": "All",
+      "health-error": "Error",
+      "health-nodata": "No data",
+      "health-ok": "OK",
+      "import-export": "Import / export",
       "import-to-gma": "Import alert rules",
-      "import-to-gma-tool": "Import to Grafana Alerting"
+      "import-to-gma-tool": "Import to Grafana Alerting",
+      "instance-count_one": "{{count}} inst.",
+      "instance-count_other": "{{count}} inst.",
+      "loading": "Loading…",
+      "new-rule": "New rule in folder",
+      "no-contact": "no contact",
+      "no-contact-warning": "⚠ no contact",
+      "no-matching-folder": "No matching folder.",
+      "plugin-hide": "Hide",
+      "plugin-show": "Show",
+      "recently-deleted": "Recently deleted",
+      "saved-searches": "Saved searches",
+      "search-placeholder": "Search by name or enter filter query...",
+      "select-folder": "Select a folder from the left to see its rules.",
+      "show-dependency-arrows": "Show dependency arrows",
+      "source-all": "All",
+      "source-datasource": "Data source managed",
+      "source-grafana": "Grafana managed",
+      "state": {
+        "firing": "Firing",
+        "normal": "Normal",
+        "pending": "Pending",
+        "recovering": "Recovering"
+      },
+      "state-label": "STATE",
+      "subtitle": "Rules that determine whether an alert will fire",
+      "title": "Rules",
+      "type-alert": "Alert rule",
+      "type-all": "All",
+      "type-recording": "Recording rule"
     },
     "rule-modify-export": {
       "text-loading-the-rule": "Loading the rule...",


### PR DESCRIPTION
**Changes**

A folder-first redesign of the alert rules list page, rendered when the `alerting.rulesAPIV2` feature toggle is enabled. All existing V1/V2 pages are untouched — the new page is gated behind the flag and supersedes them only when it is on.

  The new layout:
  - **Page header** with a "Rules" title, subtitle, and Import / export + New rule actions.
  - **Filter strip** (search row + collapsible filter panel) that reuses the existing `useRulesFilter` hook and `AdvancedFilters` types from the current V2 sidebar, so filter state still lives in the `?search=…` query param. Adds a four-chip multi-select state filter (Firing / Pending / Recovering / Normal) as a client-side layer with live counts.
  - **Two-column split** with a sticky left rail grouped by data source, a Recently-deleted row at the bottom (gated by `shouldAllowRecoveringDeletedRules`), and a folder detail on the right.
  - **Evaluation chain card** — a single card per group that contains at least one recording rule and an alert rule whose PromQL references it. Chain detection is a word-boundary string match on the alert's query (documented in-file as a TODO for a proper PromQL AST pass). Optional SVG dependency arrows between recording and alert cards, toggled by a user preference stored in `localStorage`.
  - **Non-chain rules** render as individual `RuleCard`s at folder level — no virtual group wrapper, in anticipation of the new rules API where non-chain rules no longer belong to a group.
  - **RuleCard** shows name, instance count, contact point (or "no contact" in warning), state chip, and reuses the existing `RuleActionsButtons` V2 component for Edit + the ⋮ menu (silence, clone, delete, export, etc.).
  - **Recently deleted view** renders a dedicated table (`NAME / LOCATION / DELETED AT / DELETED BY / ACTIONS`) using `alertRuleApi.getDeletedRules` and the existing restore / permanent-delete confirm modals.

  All new code lives under `public/app/features/alerting/unified/rule-list/api-v2/`. Files touched outside that subtree:
  - `RuleList.tsx` — adds a third branch that lazy-loads the new page when the flag is on.
  - `featureToggles.ts` — adds the `shouldUseAlertingRulesAPIV2()` helper.


https://github.com/user-attachments/assets/68218136-6f92-4fbc-97ea-49bcc0a1d46a

