### PR TITLE
Provisioning: Use full sync instead of incremental if diff size exceeds threshold in Webhook handler

### DIFF
--- a/apps/provisioning/pkg/repository/github/extra.go
+++ b/apps/provisioning/pkg/repository/github/extra.go
@@ -20,18 +20,18 @@ type WebhookURLBuilder interface {
 }
 
 type extra struct {
-	factory               *Factory
-	decrypter             repository.Decrypter
-	webhookBuilder        WebhookURLBuilder
-	folderMetadataEnabled bool
+	factory           *Factory
+	decrypter         repository.Decrypter
+	webhookBuilder    WebhookURLBuilder
+	incrementalPolicy repository.IncrementalSyncPolicy
 }
 
-func Extra(decrypter repository.Decrypter, factory *Factory, webhookBuilder WebhookURLBuilder, folderMetadataEnabled bool) repository.Extra {
+func Extra(decrypter repository.Decrypter, factory *Factory, webhookBuilder WebhookURLBuilder, incrementalPolicy repository.IncrementalSyncPolicy) repository.Extra {
 	return &extra{
-		decrypter:             decrypter,
-		factory:               factory,
-		webhookBuilder:        webhookBuilder,
-		folderMetadataEnabled: folderMetadataEnabled,
+		decrypter:         decrypter,
+		factory:           factory,
+		webhookBuilder:    webhookBuilder,
+		incrementalPolicy: incrementalPolicy,
 	}
 }
 
@@ -82,7 +82,7 @@ func (e *extra) Build(ctx context.Context, r *provisioning.Repository) (reposito
 		return nil, fmt.Errorf("decrypt webhookSecret: %w", err)
 	}
 
-	return NewGithubWebhookRepository(ghRepo, webhookURL, webhookSecret, e.folderMetadataEnabled), nil
+	return NewGithubWebhookRepository(ghRepo, webhookURL, webhookSecret, e.incrementalPolicy), nil
 }
 
 func (e *extra) Mutate(ctx context.Context, obj runtime.Object) error {

--- a/apps/provisioning/pkg/repository/github/extra_test.go
+++ b/apps/provisioning/pkg/repository/github/extra_test.go
@@ -32,7 +32,7 @@ func (m *mockSecureValues) WebhookSecret(_ context.Context) (common.RawSecureVal
 }
 
 func TestExtra_Type(t *testing.T) {
-	e := github.Extra(nil, nil, nil, false)
+	e := github.Extra(nil, nil, nil, repository.IncrementalSyncPolicy{})
 	assert.Equal(t, provisioning.GitHubRepositoryType, e.Type())
 }
 
@@ -263,7 +263,7 @@ func TestExtra_Build(t *testing.T) {
 			webhookBuilder := tt.setupWebhook(t, tt.repo)
 			factory := github.ProvideFactory()
 
-			e := github.Extra(decrypter, factory, webhookBuilder, false)
+			e := github.Extra(decrypter, factory, webhookBuilder, repository.IncrementalSyncPolicy{})
 
 			result, err := e.Build(ctx, tt.repo)
 
@@ -393,7 +393,7 @@ func TestExtra_Mutate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 
-			e := github.Extra(nil, nil, nil, false)
+			e := github.Extra(nil, nil, nil, repository.IncrementalSyncPolicy{})
 
 			err := e.Mutate(ctx, tt.obj)
 

--- a/apps/provisioning/pkg/repository/github/testdata/webhook-push-large_diff.json
+++ b/apps/provisioning/pkg/repository/github/testdata/webhook-push-large_diff.json
@@ -1,0 +1,59 @@
+{
+  "ref": "refs/heads/main",
+  "commits": [
+    {
+      "message": "Bulk import dashboards",
+      "author": {
+        "name": "Test User",
+        "email": "test@example.com",
+        "username": "testuser"
+      },
+      "url": "https://github.com/grafana/git-ui-sync-demo/commit/abc123",
+      "distinct": true,
+      "id": "abc123def456",
+      "tree_id": "tree123",
+      "timestamp": "2024-12-09T08:58:00+03:00",
+      "committer": {
+        "name": "GitHub",
+        "email": "noreply@github.com",
+        "username": "web-flow"
+      },
+      "added": [
+        "dashboards/d-001.json",
+        "dashboards/d-002.json",
+        "dashboards/d-003.json",
+        "dashboards/d-004.json",
+        "dashboards/d-005.json",
+        "dashboards/d-006.json"
+      ],
+      "modified": [
+        "README.md"
+      ]
+    }
+  ],
+  "before": "6c86a0cdfd220c2fe3518cfaa4a4babf030d9a7a",
+  "after": "abc123def456",
+  "created": false,
+  "deleted": false,
+  "forced": false,
+  "compare": "https://github.com/grafana/git-ui-sync-demo/compare/6c86a0cdfd22...abc123def456",
+  "repository": {
+    "id": 888020043,
+    "node_id": "R_kgDONO4cSw",
+    "name": "git-ui-sync-demo",
+    "full_name": "grafana/git-ui-sync-demo",
+    "owner": {
+      "login": "grafana",
+      "id": 7195757
+    },
+    "private": true
+  },
+  "head_commit": {
+    "message": "Bulk import dashboards",
+    "id": "abc123def456"
+  },
+  "pusher": {
+    "name": "testuser",
+    "email": "test@example.com"
+  }
+}

--- a/apps/provisioning/pkg/repository/github/webhook.go
+++ b/apps/provisioning/pkg/repository/github/webhook.go
@@ -34,30 +34,30 @@ type GithubWebhookRepository interface {
 
 type githubWebhookRepository struct {
 	GithubRepository
-	config                *provisioning.Repository
-	owner                 string
-	repo                  string
-	secret                common.RawSecureValue
-	gh                    Client
-	webhookURL            string
-	folderMetadataEnabled bool
+	config            *provisioning.Repository
+	owner             string
+	repo              string
+	secret            common.RawSecureValue
+	gh                Client
+	webhookURL        string
+	incrementalPolicy repository.IncrementalSyncPolicy
 }
 
 func NewGithubWebhookRepository(
 	basic GithubRepository,
 	webhookURL string,
 	secret common.RawSecureValue,
-	folderMetadataEnabled bool,
+	incrementalPolicy repository.IncrementalSyncPolicy,
 ) GithubWebhookRepository {
 	return &githubWebhookRepository{
-		GithubRepository:      basic,
-		config:                basic.Config(),
-		owner:                 basic.Owner(),
-		repo:                  basic.Repo(),
-		gh:                    basic.Client(),
-		webhookURL:            webhookURL,
-		secret:                secret,
-		folderMetadataEnabled: folderMetadataEnabled,
+		GithubRepository:  basic,
+		config:            basic.Config(),
+		owner:             basic.Owner(),
+		repo:              basic.Repo(),
+		gh:                basic.Client(),
+		webhookURL:        webhookURL,
+		secret:            secret,
+		incrementalPolicy: incrementalPolicy,
 	}
 }
 
@@ -123,16 +123,14 @@ func (r *githubWebhookRepository) parsePushEvent(event *github.PushEvent) (*prov
 		return &provisioning.WebhookResponse{Code: http.StatusOK}, nil
 	}
 
-	// whenever possible, we want to do incremental syncs to keep things performant.
-	// however, if we get an event where just a .keep file is being deleted, and no other files in the folder
-	// are being deleted, the folder could be gone from git, but not from grafana and we do not have a way
-	// to get the grafana uid to delete the folder. so, instead, we will queue a full sync to clean things up.
 	var deletedPaths []string
+	var totalChanges int
 	for _, change := range event.GetCommits() {
+		totalChanges += len(change.Added) + len(change.Modified) + len(change.Removed)
 		deletedPaths = append(deletedPaths, change.Removed...)
 	}
 
-	incremental := repository.CanUseIncrementalSyncInWebhook(deletedPaths, r.folderMetadataEnabled)
+	incremental := r.incrementalPolicy.CanUseIncrementalSync(deletedPaths, totalChanges)
 
 	return &provisioning.WebhookResponse{
 		Code: http.StatusAccepted,

--- a/apps/provisioning/pkg/repository/github/webhook_test.go
+++ b/apps/provisioning/pkg/repository/github/webhook_test.go
@@ -142,6 +142,40 @@ func TestParseWebhooks(t *testing.T) {
 	}
 }
 
+func TestParsePushEvent_LargeDiffForcesFullSync(t *testing.T) {
+	gh := &githubWebhookRepository{
+		config: &provisioning.Repository{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "unit-test-repo",
+			},
+			Spec: provisioning.RepositorySpec{
+				Sync: provisioning.SyncOptions{
+					Enabled: true,
+				},
+				GitHub: &provisioning.GitHubRepositoryConfig{
+					URL:    "https://github.com/grafana/git-ui-sync-demo",
+					Branch: "main",
+				},
+			},
+		},
+		owner:             "grafana",
+		repo:              "git-ui-sync-demo",
+		incrementalPolicy: repo.NewIncrementalSyncPolicy(false, 5),
+	}
+
+	// nolint:gosec
+	payload, err := os.ReadFile(path.Join("testdata", "webhook-push-large_diff.json"))
+	require.NoError(t, err)
+
+	rsp, err := gh.parseWebhook("push", payload)
+	require.NoError(t, err)
+
+	require.Equal(t, http.StatusAccepted, rsp.Code)
+	require.NotNil(t, rsp.Job)
+	require.NotNil(t, rsp.Job.Pull)
+	require.False(t, rsp.Job.Pull.Incremental, "large diff should force full sync when above threshold")
+}
+
 func TestGitHubRepository_Webhook(t *testing.T) {
 	tests := []struct {
 		name          string

--- a/apps/provisioning/pkg/repository/workflows.go
+++ b/apps/provisioning/pkg/repository/workflows.go
@@ -45,63 +45,38 @@ func IsWriteAllowed(repo *provisioning.Repository, ref string) error {
 	}
 }
 
-// CanUseIncrementalSyncInController determines if an incremental sync is permitted in the controller, based on the given file changes,
-// the folder metadata feature flag, and the maximum allowed changes. It returns false to require a full sync if:
-//   - The number of changes exceeds maxIncrementalChanges,
+// IncrementalSyncPolicy holds config-level settings for the incremental-vs-full sync decision.
+// Initialised once at startup and shared by both the controller and webhook paths.
+type IncrementalSyncPolicy struct {
+	folderMetadataEnabled bool
+	maxIncrementalChanges int
+}
+
+func NewIncrementalSyncPolicy(folderMetadataEnabled bool, maxIncrementalChanges int) IncrementalSyncPolicy {
+	return IncrementalSyncPolicy{
+		folderMetadataEnabled: folderMetadataEnabled,
+		maxIncrementalChanges: maxIncrementalChanges,
+	}
+}
+
+// CanUseIncrementalSync determines if an incremental sync is permitted, based on the given deleted paths
+// and total change count. It returns false to require a full sync if:
+//   - The total number of changes exceeds maxIncrementalChanges (when maxIncrementalChanges > 0),
 //   - Any directory only has its folder-metadata file removed (.keep, or _folder.json if folderMetadataEnabled) without
 //     any Grafana resources in that directory being deleted. In such cases, a full sync is needed because the incremental
 //     sync cannot determine whether an entire folder (not just its metadata) was deleted, and these metadata files do not
 //     represent Grafana resources themselves. Returning false ensures deleted directories are properly cleaned up by a full sync.
-func CanUseIncrementalSyncInController(
-	changes []VersionedFileChange,
-	folderMetadataEnabled bool,
-	maxIncrementalChanges int,
-) bool {
-	if maxIncrementalChanges > 0 && len(changes) > maxIncrementalChanges {
+func (p IncrementalSyncPolicy) CanUseIncrementalSync(deletedPaths []string, totalChanges int) bool {
+	if p.maxIncrementalChanges > 0 && totalChanges > p.maxIncrementalChanges {
 		return false
 	}
 
-	var deletedPaths []string
-	for _, change := range changes {
-		if change.Action == FileActionDeleted {
-			deletedPaths = append(deletedPaths, change.Path)
-		}
-	}
-
 	dirsWithMetadataDeletes := make(map[string]struct{})
 	dirsWithOtherDeletes := make(map[string]struct{})
 
 	for _, path := range deletedPaths {
 		dir := safepath.Dir(path)
-		if isFolderMetadataFile(path, folderMetadataEnabled) {
-			dirsWithMetadataDeletes[dir] = struct{}{}
-		} else {
-			dirsWithOtherDeletes[dir] = struct{}{}
-		}
-	}
-
-	for dir := range dirsWithMetadataDeletes {
-		if _, exists := dirsWithOtherDeletes[dir]; !exists {
-			return false
-		}
-	}
-
-	return true
-}
-
-// CanUseIncrementalSyncInWebhook determines if an incremental sync is permitted in the webhook, based on the given deleted paths,
-// and the folder metadata feature flag. It returns false to require a full sync if:
-//   - Any directory only has its folder-metadata file removed (.keep, or _folder.json if folderMetadataEnabled) without
-//     any Grafana resources in that directory being deleted. In such cases, a full sync is needed because the incremental
-//     sync cannot determine whether an entire folder (not just its metadata) was deleted, and these metadata files do not
-//     represent Grafana resources themselves. Returning false ensures deleted directories are properly cleaned up by a full sync.
-func CanUseIncrementalSyncInWebhook(deletedPaths []string, folderMetadataEnabled bool) bool {
-	dirsWithMetadataDeletes := make(map[string]struct{})
-	dirsWithOtherDeletes := make(map[string]struct{})
-
-	for _, path := range deletedPaths {
-		dir := safepath.Dir(path)
-		if isFolderMetadataFile(path, folderMetadataEnabled) {
+		if isFolderMetadataFile(path, p.folderMetadataEnabled) {
 			dirsWithMetadataDeletes[dir] = struct{}{}
 		} else {
 			dirsWithOtherDeletes[dir] = struct{}{}

--- a/apps/provisioning/pkg/repository/workflows_test.go
+++ b/apps/provisioning/pkg/repository/workflows_test.go
@@ -2,7 +2,6 @@ package repository
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 	"testing"
 
@@ -347,13 +346,80 @@ func TestIsWriteAllowed(t *testing.T) {
 	}
 }
 
-func TestCanUseIncrementalSyncInWebhook(t *testing.T) {
+func TestCanUseIncrementalSync(t *testing.T) {
 	tests := []struct {
 		name                  string
 		deletedPaths          []string
 		folderMetadataEnabled bool
+		totalChanges          int
+		maxIncrementalChanges int
 		want                  bool
 	}{
+		// ─── size-threshold boundary cases ─────────────────────────────────────
+		{
+			name:                  "empty diff stays incremental",
+			deletedPaths:          nil,
+			totalChanges:          0,
+			maxIncrementalChanges: 100,
+			want:                  true,
+		},
+		{
+			name:                  "diff one-under threshold stays incremental",
+			deletedPaths:          nil,
+			totalChanges:          99,
+			maxIncrementalChanges: 100,
+			want:                  true,
+		},
+		{
+			name:                  "diff at threshold stays incremental (strict greater-than)",
+			deletedPaths:          nil,
+			totalChanges:          100,
+			maxIncrementalChanges: 100,
+			want:                  true,
+		},
+		{
+			name:                  "diff above threshold forces full sync",
+			deletedPaths:          nil,
+			totalChanges:          101,
+			maxIncrementalChanges: 100,
+			want:                  false,
+		},
+		{
+			name:                  "diff far above threshold forces full sync",
+			deletedPaths:          nil,
+			totalChanges:          1000,
+			maxIncrementalChanges: 100,
+			want:                  false,
+		},
+		{
+			name:                  "threshold of 0 disables size check",
+			deletedPaths:          nil,
+			totalChanges:          1000,
+			maxIncrementalChanges: 0,
+			want:                  true,
+		},
+		{
+			name:                  "negative threshold disables size check",
+			deletedPaths:          nil,
+			totalChanges:          1000,
+			maxIncrementalChanges: -1,
+			want:                  true,
+		},
+		{
+			name:                  "threshold of 0 with empty diff stays incremental",
+			deletedPaths:          nil,
+			totalChanges:          0,
+			maxIncrementalChanges: 0,
+			want:                  true,
+		},
+		{
+			name:                  "threshold of 0 with folder-metadata-only-delete still forces full",
+			deletedPaths:          []string{"folder1/.keep"},
+			totalChanges:          1,
+			maxIncrementalChanges: 0,
+			want:                  false,
+		},
+		// ─── folder-metadata-only deletion cases ───────────────────────────────
 		{
 			name:         "no deleted paths",
 			deletedPaths: []string{},
@@ -362,235 +428,114 @@ func TestCanUseIncrementalSyncInWebhook(t *testing.T) {
 		{
 			name:         "no keep file deletions",
 			deletedPaths: []string{"test.json"},
+			totalChanges: 1,
 			want:         true,
 		},
 		{
 			name:         "keep file deletion at root without other deletions",
 			deletedPaths: []string{".keep"},
+			totalChanges: 1,
 			want:         false,
 		},
 		{
 			name:         "keep file deletion with other deletions in same folder",
 			deletedPaths: []string{"test/.keep", "test/test.json"},
+			totalChanges: 2,
 			want:         true,
 		},
 		{
 			name:         "multiple keep files in different folders without other deletions",
 			deletedPaths: []string{"folder1/.keep", "folder2/.keep"},
+			totalChanges: 2,
 			want:         false,
 		},
 		{
 			name:         "nested folder with only keep file deleted",
 			deletedPaths: []string{"parent/child/.keep"},
+			totalChanges: 1,
 			want:         false,
 		},
 		{
 			name:         "some folders with only keep, some with other files",
 			deletedPaths: []string{"folder1/.keep", "folder2/.keep", "folder2/dashboard.json"},
+			totalChanges: 3,
 			want:         false,
 		},
 		{
 			name:         "only regular files deleted from multiple folders",
 			deletedPaths: []string{"folder1/file1.json", "folder2/file2.json", "folder3/file3.json"},
+			totalChanges: 3,
 			want:         true,
 		},
 		{
 			name:                  "folder metadata file deleted alone - flag on",
 			deletedPaths:          []string{"folder1/_folder.json"},
 			folderMetadataEnabled: true,
+			totalChanges:          1,
 			want:                  false,
 		},
 		{
 			name:                  "folder metadata file deleted alone - flag off",
 			deletedPaths:          []string{"folder1/_folder.json"},
 			folderMetadataEnabled: false,
+			totalChanges:          1,
 			want:                  true,
 		},
 		{
 			name:                  "folder metadata file deleted with other files in same folder - flag on",
 			deletedPaths:          []string{"folder1/_folder.json", "folder1/dashboard.json"},
 			folderMetadataEnabled: true,
+			totalChanges:          2,
 			want:                  true,
 		},
 		{
 			name:                  "folder metadata and keep file deleted together without other files - flag on",
 			deletedPaths:          []string{"folder1/.keep", "folder1/_folder.json"},
 			folderMetadataEnabled: true,
+			totalChanges:          2,
 			want:                  false,
 		},
 		{
 			name:                  "folder metadata at root deleted alone - flag on",
 			deletedPaths:          []string{"_folder.json"},
 			folderMetadataEnabled: true,
+			totalChanges:          1,
 			want:                  false,
 		},
 		{
 			name:                  "nested folder metadata deleted alone - flag on",
 			deletedPaths:          []string{"parent/child/_folder.json"},
 			folderMetadataEnabled: true,
+			totalChanges:          1,
 			want:                  false,
 		},
 		{
 			name:                  "mixed: folder metadata alone in one dir, other files in another - flag on",
 			deletedPaths:          []string{"folder1/_folder.json", "folder2/dashboard.json"},
 			folderMetadataEnabled: true,
+			totalChanges:          2,
 			want:                  false,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := CanUseIncrementalSyncInWebhook(tt.deletedPaths, tt.folderMetadataEnabled)
-			require.Equal(t, tt.want, got)
-		})
-	}
-}
-
-// deletedChanges builds a []VersionedFileChange whose every entry is a
-// FileActionDeleted at the given path — convenient for reusing the webhook-style
-// path list shape inside the controller-variant tests.
-func deletedChanges(paths ...string) []VersionedFileChange {
-	out := make([]VersionedFileChange, 0, len(paths))
-	for _, p := range paths {
-		out = append(out, VersionedFileChange{Action: FileActionDeleted, Path: p})
-	}
-	return out
-}
-
-// createdChanges builds a []VersionedFileChange of `count` Created entries.
-// Used for exercising the size threshold without caring about per-entry
-// semantics.
-func createdChanges(count int) []VersionedFileChange {
-	out := make([]VersionedFileChange, count)
-	for i := range out {
-		out[i] = VersionedFileChange{
-			Action: FileActionCreated,
-			Path:   fmt.Sprintf("dashboards/d-%04d.json", i),
-			Ref:    "new-ref",
-		}
-	}
-	return out
-}
-
-func TestCanUseIncrementalSyncInController(t *testing.T) {
-	tests := []struct {
-		name                  string
-		changes               []VersionedFileChange
-		folderMetadataEnabled bool
-		maxIncrementalChanges int
-		want                  bool
-	}{
-		// ─── size-threshold boundary cases (the new behaviour added by FD-007) ──
-		{
-			name:                  "empty diff stays incremental",
-			changes:               nil,
-			maxIncrementalChanges: 100,
-			want:                  true,
-		},
-		{
-			name:                  "diff one-under threshold stays incremental",
-			changes:               createdChanges(99),
-			maxIncrementalChanges: 100,
-			want:                  true,
-		},
-		{
-			name:                  "diff at threshold stays incremental (strict greater-than)",
-			changes:               createdChanges(100),
-			maxIncrementalChanges: 100,
-			want:                  true,
-		},
-		{
-			name:                  "diff above threshold forces full sync",
-			changes:               createdChanges(101),
-			maxIncrementalChanges: 100,
-			want:                  false,
-		},
-		{
-			name:                  "diff far above threshold forces full sync",
-			changes:               createdChanges(1000),
-			maxIncrementalChanges: 100,
-			want:                  false,
-		},
-		{
-			name:                  "threshold of 0 disables size check - falls through to folder-metadata guard",
-			changes:               createdChanges(1000),
-			maxIncrementalChanges: 0,
-			want:                  true,
-		},
-		{
-			name:                  "negative threshold disables size check - falls through to folder-metadata guard",
-			changes:               createdChanges(1000),
-			maxIncrementalChanges: -1,
-			want:                  true,
-		},
-		{
-			name:                  "threshold of 0 with empty diff stays incremental",
-			changes:               nil,
-			maxIncrementalChanges: 0,
-			want:                  true,
-		},
-		{
-			name:                  "threshold of 0 with folder-metadata-only-delete still forces full",
-			changes:               deletedChanges("folder1/.keep"),
-			maxIncrementalChanges: 0,
-			want:                  false,
-		},
-		// ─── pre-existing folder-metadata-only deletion cases (preserved) ──────
-		{
-			name:                  "no keep-file deletions",
-			changes:               deletedChanges("test.json"),
-			maxIncrementalChanges: 100,
-			want:                  true,
-		},
-		{
-			name:                  "keep file deletion alone forces full sync",
-			changes:               deletedChanges(".keep"),
-			maxIncrementalChanges: 100,
-			want:                  false,
-		},
-		{
-			name:                  "keep file with sibling deletion stays incremental",
-			changes:               deletedChanges("test/.keep", "test/test.json"),
-			maxIncrementalChanges: 100,
-			want:                  true,
-		},
-		{
-			name:                  "_folder.json alone forces full sync - flag on",
-			changes:               deletedChanges("folder1/_folder.json"),
-			folderMetadataEnabled: true,
-			maxIncrementalChanges: 100,
-			want:                  false,
-		},
-		{
-			name:                  "_folder.json alone stays incremental - flag off",
-			changes:               deletedChanges("folder1/_folder.json"),
-			folderMetadataEnabled: false,
-			maxIncrementalChanges: 100,
-			want:                  true,
-		},
-		{
-			name:                  "_folder.json with sibling deletion stays incremental - flag on",
-			changes:               deletedChanges("folder1/_folder.json", "folder1/dashboard.json"),
-			folderMetadataEnabled: true,
-			maxIncrementalChanges: 100,
-			want:                  true,
 		},
 		// ─── size check is evaluated before the folder-metadata guard ──────────
 		{
 			name:                  "above threshold overrides folder-metadata guard",
-			changes:               append(createdChanges(200), VersionedFileChange{Action: FileActionDeleted, Path: "folder1/.keep"}),
+			deletedPaths:          []string{"folder1/.keep"},
+			totalChanges:          201,
 			maxIncrementalChanges: 100,
 			want:                  false,
 		},
 		{
 			name:                  "created-only diff above threshold forces full sync",
-			changes:               createdChanges(150),
+			deletedPaths:          nil,
+			totalChanges:          150,
 			maxIncrementalChanges: 100,
 			want:                  false,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := CanUseIncrementalSyncInController(tt.changes, tt.folderMetadataEnabled, tt.maxIncrementalChanges)
+			policy := NewIncrementalSyncPolicy(tt.folderMetadataEnabled, tt.maxIncrementalChanges)
+			got := policy.CanUseIncrementalSync(tt.deletedPaths, tt.totalChanges)
 			require.Equal(t, tt.want, got)
 		})
 	}

--- a/pkg/operators/provisioning/config.go
+++ b/pkg/operators/provisioning/config.go
@@ -555,7 +555,10 @@ func (c *ControllerConfig) RepositoryExtras() ([]repository.Extra, error) {
 			if provisioningAppURL != "" {
 				webhook = webhooks.ProvideWebhooks(provisioningAppURL, c.Registry())
 			}
-			extras = append(extras, githubrepo.Extra(decrypter, githubrepo.ProvideFactory(), webhook, resources.IsFolderMetadataEnabled(c.Settings)))
+			extras = append(extras, githubrepo.Extra(decrypter, githubrepo.ProvideFactory(), webhook, repository.NewIncrementalSyncPolicy(
+				resources.IsFolderMetadataEnabled(c.Settings),
+				provisioningSec.Key("max_incremental_changes").MustInt(100),
+			)))
 		case provisioning.LocalRepositoryType:
 			homePath := operatorSec.Key("home_path").String()
 			if homePath == "" {

--- a/pkg/operators/provisioning/repo_operator.go
+++ b/pkg/operators/provisioning/repo_operator.go
@@ -123,9 +123,11 @@ func RunRepoController(deps server.OperatorDependencies) error {
 		controllerCfg.Settings.SectionWithEnvOverrides("provisioning").Key("min_sync_interval").MustDuration(1*time.Minute),
 		controllerCfg.DrainTimeout(),
 		quotaGetter,
-		resources.IsFolderMetadataEnabled(controllerCfg.Settings),
+		repository.NewIncrementalSyncPolicy(
+			resources.IsFolderMetadataEnabled(controllerCfg.Settings),
+			controllerCfg.Settings.SectionWithEnvOverrides("provisioning").Key("max_incremental_changes").MustInt(100),
+		),
 		controllerCfg.Settings.SectionWithEnvOverrides("operator").Key("folders_api_version").MustString(folderv1beta1.APIVersion),
-		controllerCfg.Settings.SectionWithEnvOverrides("provisioning").Key("max_incremental_changes").MustInt(100),
 		controllerCfg.Settings.SectionWithEnvOverrides("provisioning").Key("webhook_secret_rotation_interval").MustDuration(30*24*time.Hour),
 	)
 	if err != nil {

--- a/pkg/registry/apis/provisioning/controller/repository.go
+++ b/pkg/registry/apis/provisioning/controller/repository.go
@@ -77,8 +77,7 @@ type RepositoryController struct {
 	tracer                        tracing.Tracer
 	quotaGetter                   quotas.QuotaGetter
 	tokenMetrics                  *repositoryTokenMetrics
-	folderMetadataEnabled         bool
-	maxIncrementalChanges         int
+	incrementalPolicy             repository.IncrementalSyncPolicy
 	webhookSecretRotationInterval time.Duration
 }
 
@@ -103,9 +102,8 @@ func NewRepositoryController(
 	minSyncInterval time.Duration,
 	drainTimeout time.Duration,
 	quotaGetter quotas.QuotaGetter,
-	folderMetadataEnabled bool,
+	incrementalPolicy repository.IncrementalSyncPolicy,
 	folderAPIVersion string,
-	maxIncrementalChanges int,
 	webhookSecretRotationInterval time.Duration,
 ) (*RepositoryController, error) {
 	finalizerMetrics := registerFinalizerMetrics(registry)
@@ -142,8 +140,7 @@ func NewRepositoryController(
 		drainTimeout:                  drainTimeout,
 		quotaGetter:                   quotaGetter,
 		tokenMetrics:                  repoTokenMetrics,
-		folderMetadataEnabled:         folderMetadataEnabled,
-		maxIncrementalChanges:         maxIncrementalChanges,
+		incrementalPolicy:             incrementalPolicy,
 		webhookSecretRotationInterval: webhookSecretRotationInterval,
 	}
 
@@ -468,7 +465,7 @@ func (rc *RepositoryController) determineSyncStrategy(
 		// However, we fall back to a full sync when incremental diffing cannot safely represent the change,
 		// such as .keep file deletions inside a folder with no other deletions (to detect whether the folder
 		// was deleted in git) or when the diff size reaches/exceeds max_incremental_changes.
-		incremental, err := shouldUseIncrementalSync(ctx, versioned, obj, latestRef, rc.folderMetadataEnabled, rc.maxIncrementalChanges)
+		incremental, err := shouldUseIncrementalSync(ctx, versioned, obj, latestRef, rc.incrementalPolicy)
 		if err != nil {
 			logger.Warn("unable to compare files for incremental sync, doing full sync", "error", err)
 			return &provisioning.SyncJobOptions{}
@@ -486,15 +483,21 @@ func shouldUseIncrementalSync(
 	versioned repository.Versioned,
 	obj *provisioning.Repository,
 	latestRef string,
-	folderMetadataEnabled bool,
-	maxIncrementalChanges int,
+	policy repository.IncrementalSyncPolicy,
 ) (bool, error) {
 	changes, err := versioned.CompareFiles(ctx, obj.Status.Sync.LastRef, latestRef)
 	if err != nil {
 		return false, err
 	}
 
-	return repository.CanUseIncrementalSyncInController(changes, folderMetadataEnabled, maxIncrementalChanges), nil
+	var deletedPaths []string
+	for _, change := range changes {
+		if change.Action == repository.FileActionDeleted {
+			deletedPaths = append(deletedPaths, change.Path)
+		}
+	}
+
+	return policy.CanUseIncrementalSync(deletedPaths, len(changes)), nil
 }
 
 func (rc *RepositoryController) addSyncJob(ctx context.Context, obj *provisioning.Repository, syncOptions *provisioning.SyncJobOptions) error {

--- a/pkg/registry/apis/provisioning/controller/repository_test.go
+++ b/pkg/registry/apis/provisioning/controller/repository_test.go
@@ -481,9 +481,7 @@ func TestShouldUseIncrementalSync(t *testing.T) {
 	}
 	latestRef := "456"
 
-	// Large max so the size-threshold branch does not interfere with the
-	// pre-existing folder-metadata-guard assertions.
-	const largeMax = 1000
+	largePolicy := repository.NewIncrementalSyncPolicy(false, 1000)
 
 	t.Run("should use incremental sync", func(t *testing.T) {
 		versioned.On("CompareFiles", context.Background(), obj.Status.Sync.LastRef, latestRef).Return([]repository.VersionedFileChange{
@@ -492,7 +490,7 @@ func TestShouldUseIncrementalSync(t *testing.T) {
 				Path:   "test.json",
 			},
 		}, nil).Once()
-		got, err := shouldUseIncrementalSync(context.Background(), versioned, obj, latestRef, false, largeMax)
+		got, err := shouldUseIncrementalSync(context.Background(), versioned, obj, latestRef, largePolicy)
 		assert.NoError(t, err)
 		assert.True(t, got)
 	})
@@ -504,61 +502,62 @@ func TestShouldUseIncrementalSync(t *testing.T) {
 				Path:   "test/.keep",
 			},
 		}, nil).Once()
-		got, err := shouldUseIncrementalSync(context.Background(), versioned, obj, latestRef, false, largeMax)
+		got, err := shouldUseIncrementalSync(context.Background(), versioned, obj, latestRef, largePolicy)
 		assert.NoError(t, err)
 		assert.False(t, got)
 	})
 
 	t.Run("should use incremental sync when diff is one under the max size", func(t *testing.T) {
-		const max = 100
-		changes := make([]repository.VersionedFileChange, max-1)
+		policy := repository.NewIncrementalSyncPolicy(false, 100)
+		changes := make([]repository.VersionedFileChange, 99)
 		for i := range changes {
 			changes[i] = repository.VersionedFileChange{Action: repository.FileActionCreated, Path: "dashboards/d.json"}
 		}
 		versioned.On("CompareFiles", context.Background(), obj.Status.Sync.LastRef, latestRef).Return(changes, nil).Once()
-		got, err := shouldUseIncrementalSync(context.Background(), versioned, obj, latestRef, false, max)
+		got, err := shouldUseIncrementalSync(context.Background(), versioned, obj, latestRef, policy)
 		assert.NoError(t, err)
 		assert.True(t, got, "diff one under threshold must stay incremental")
 	})
 
 	t.Run("should use incremental sync when diff is at the max size", func(t *testing.T) {
-		const max = 100
-		changes := make([]repository.VersionedFileChange, max)
+		policy := repository.NewIncrementalSyncPolicy(false, 100)
+		changes := make([]repository.VersionedFileChange, 100)
 		for i := range changes {
 			changes[i] = repository.VersionedFileChange{Action: repository.FileActionCreated, Path: "dashboards/d.json"}
 		}
 		versioned.On("CompareFiles", context.Background(), obj.Status.Sync.LastRef, latestRef).Return(changes, nil).Once()
-		got, err := shouldUseIncrementalSync(context.Background(), versioned, obj, latestRef, false, max)
+		got, err := shouldUseIncrementalSync(context.Background(), versioned, obj, latestRef, policy)
 		assert.NoError(t, err)
 		assert.True(t, got, "diff at threshold must stay incremental (strict >)")
 	})
 
 	t.Run("should not use incremental sync when diff exceeds max size", func(t *testing.T) {
-		const max = 100
-		changes := make([]repository.VersionedFileChange, max+1)
+		policy := repository.NewIncrementalSyncPolicy(false, 100)
+		changes := make([]repository.VersionedFileChange, 101)
 		for i := range changes {
 			changes[i] = repository.VersionedFileChange{Action: repository.FileActionCreated, Path: "dashboards/d.json"}
 		}
 		versioned.On("CompareFiles", context.Background(), obj.Status.Sync.LastRef, latestRef).Return(changes, nil).Once()
-		got, err := shouldUseIncrementalSync(context.Background(), versioned, obj, latestRef, false, max)
+		got, err := shouldUseIncrementalSync(context.Background(), versioned, obj, latestRef, policy)
 		assert.NoError(t, err)
 		assert.False(t, got, "diff above threshold must force a full sync")
 	})
 
 	t.Run("should use incremental sync when max is zero (unlimited)", func(t *testing.T) {
+		policy := repository.NewIncrementalSyncPolicy(false, 0)
 		changes := make([]repository.VersionedFileChange, 1000)
 		for i := range changes {
 			changes[i] = repository.VersionedFileChange{Action: repository.FileActionCreated, Path: "dashboards/d.json"}
 		}
 		versioned.On("CompareFiles", context.Background(), obj.Status.Sync.LastRef, latestRef).Return(changes, nil).Once()
-		got, err := shouldUseIncrementalSync(context.Background(), versioned, obj, latestRef, false, 0)
+		got, err := shouldUseIncrementalSync(context.Background(), versioned, obj, latestRef, policy)
 		assert.NoError(t, err)
 		assert.True(t, got, "max_incremental_changes=0 disables the size check (unlimited)")
 	})
 
 	t.Run("propagates CompareFiles error without deciding", func(t *testing.T) {
 		versioned.On("CompareFiles", context.Background(), obj.Status.Sync.LastRef, latestRef).Return(nil, assert.AnError).Once()
-		got, err := shouldUseIncrementalSync(context.Background(), versioned, obj, latestRef, false, largeMax)
+		got, err := shouldUseIncrementalSync(context.Background(), versioned, obj, latestRef, largePolicy)
 		assert.Error(t, err)
 		assert.False(t, got, "on CompareFiles error the decision defaults to full sync (returned as false)")
 	})

--- a/pkg/registry/apis/provisioning/extras/register.go
+++ b/pkg/registry/apis/provisioning/extras/register.go
@@ -46,7 +46,7 @@ func ProvideProvisioningOSSRepositoryExtras(
 			decrypter,
 			ghFactory,
 			webhooksBuilder,
-			folderMetadataEnabled,
+			repository.NewIncrementalSyncPolicy(folderMetadataEnabled, cfg.ProvisioningMaxIncrementalChanges),
 		),
 	}
 }

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -139,7 +139,7 @@ type APIBuilder struct {
 	registry                      prometheus.Registerer
 	quotaGetter                   quotas.QuotaGetter
 	folderMetadataEnabled         bool
-	maxIncrementalChanges         int
+	incrementalPolicy             repository.IncrementalSyncPolicy
 	folderAPIVersion              string
 	webhookSecretRotationInterval time.Duration
 }
@@ -188,7 +188,7 @@ func NewAPIBuilder(
 	quotaGetter quotas.QuotaGetter,
 	folderMetadataEnabled bool,
 	folderAPIVersion string,
-	maxIncrementalChanges int,
+	incrementalPolicy repository.IncrementalSyncPolicy,
 ) (*APIBuilder, error) {
 	var clients resources.ClientFactory
 	if newStandaloneClientFactoryFunc != nil {
@@ -240,7 +240,7 @@ func NewAPIBuilder(
 		quotaGetter:                         quotaGetter,
 		folderMetadataEnabled:               folderMetadataEnabled,
 		folderAPIVersion:                    folderAPIVersion,
-		maxIncrementalChanges:               maxIncrementalChanges,
+		incrementalPolicy:                   incrementalPolicy,
 	}
 
 	for _, builder := range extraBuilders {
@@ -315,7 +315,7 @@ func RegisterAPIService(
 	jobHistoryConfig := createJobHistoryConfigFromSettings(cfg)
 	folderMetadataEnabled := features.IsEnabledGlobally(featuremgmt.FlagProvisioningFolderMetadata) //nolint:staticcheck
 	folderAPIVersion := cfg.ProvisioningFolderAPIVersion
-	maxIncrementalChanges := cfg.ProvisioningMaxIncrementalChanges
+	incrementalPolicy := repository.NewIncrementalSyncPolicy(folderMetadataEnabled, cfg.ProvisioningMaxIncrementalChanges)
 
 	// Register v0alpha1 (preferred version)
 	builder, err := NewAPIBuilder(
@@ -347,7 +347,7 @@ func RegisterAPIService(
 		quotaGetter,
 		folderMetadataEnabled,
 		folderAPIVersion,
-		maxIncrementalChanges,
+		incrementalPolicy,
 	)
 	if err != nil {
 		return nil, err
@@ -385,7 +385,7 @@ func RegisterAPIService(
 		quotaGetter,
 		folderMetadataEnabled,
 		folderAPIVersion,
-		maxIncrementalChanges,
+		incrementalPolicy,
 	)
 	if err != nil {
 		return nil, err
@@ -1042,9 +1042,8 @@ func (b *APIBuilder) GetPostStartHooks() (map[string]genericapiserver.PostStartH
 				b.minSyncInterval,
 				30*time.Second,
 				b.quotaGetter,
-				b.folderMetadataEnabled,
+				b.incrementalPolicy,
 				b.folderAPIVersion,
-				b.maxIncrementalChanges,
 				webhookSecretRotationInterval,
 			)
 			if err != nil {

--- a/pkg/tests/apis/provisioning/git/incrementaldiffthreshold/incremental_diff_threshold_test.go
+++ b/pkg/tests/apis/provisioning/git/incrementaldiffthreshold/incremental_diff_threshold_test.go
@@ -44,7 +44,7 @@ func TestIntegrationProvisioning_IncrementalDiffThreshold_AboveThreshold_Schedul
 	seenJobs := snapshotPullJobNames(t, h, repoName)
 
 	// Push (threshold + 1) files in a single commit. CompareFiles will report
-	// `len(changes) > maxIncrementalChanges`, so CanUseIncrementalSyncInController
+	// `len(changes) > maxIncrementalChanges`, so CanUseIncrementalSync
 	// must return false.
 	const fileCount = testMaxIncrementalChanges + 1
 	addDashboardFiles(t, local, "above", fileCount)


### PR DESCRIPTION
## Summary

Extend the `max_incremental_changes` threshold to the webhook push-event path and unify the incremental sync decision into a single `IncrementalSyncPolicy` struct shared by both controller and webhook.

Fixes https://github.com/grafana/git-ui-sync-project/issues/1092

## What

- `parsePushEvent` now counts all changed files (`Added + Modified + Removed`) across commits from the push event payload
- `CanUseIncrementalSyncInController` and `CanUseIncrementalSyncInWebhook` are replaced by a single `IncrementalSyncPolicy.CanUseIncrementalSync` method, eliminating ~30 lines of duplicated logic
- `IncrementalSyncPolicy` bundles `folderMetadataEnabled` and `maxIncrementalChanges` with unexported fields and a `NewIncrementalSyncPolicy` constructor — constructed once at startup, threaded as a single value through both paths
- No new config keys — reuses `provisioning.max_incremental_changes` (default 100, 0 = disabled)

## Why

The previous PR (#123392) added a size guard to the controller's interval-scheduled sync, but left the webhook handler unchanged. GitHub push events include `added`, `modified`, and `removed` arrays per commit — the data was available but unused. A large push (bulk dashboard import, mass rename, fast-forward merge) would still take the incremental path through the webhook, producing slow per-file writes and tripping error ceilings that full sync handles cleanly.

The change count is approximate — duplicates across commits overcount (biases toward full sync, the safe direction), and GitHub truncates at ~20 commits (but pushes that large are inherently big diffs).

## Test plan

- [ ] `go test ./apps/provisioning/pkg/repository/...` — unified `CanUseIncrementalSync` tests (threshold boundary, disabled, metadata guard)
- [ ] `go test ./apps/provisioning/pkg/repository/github/...` — `TestParsePushEvent_LargeDiffForcesFullSync` + all existing webhook tests pass unchanged
- [ ] `go test ./pkg/registry/apis/provisioning/controller/...` — `TestShouldUseIncrementalSync` with policy struct
- [ ] `grep -r "CanUseIncrementalSyncInController\|CanUseIncrementalSyncInWebhook" --include="*.go"` returns zero results

Relates to grafana/git-ui-sync-project#1092