### PR TITLE
Logs: Add keyboard navigation support for Log Details

### DIFF
--- a/public/app/features/logs/components/panel/LogDetailsContext.test.tsx
+++ b/public/app/features/logs/components/panel/LogDetailsContext.test.tsx
@@ -1,9 +1,10 @@
-import { renderHook } from '@testing-library/react';
+import { act, renderHook } from '@testing-library/react';
 import { type ReactNode } from 'react';
 
 import { createLogLine } from '../mocks/logRow';
 
 import {
+  LogDetailsContextProvider,
   useLogDetailsContextData,
   useLogDetailsContext,
   LogDetailsContext,
@@ -18,6 +19,7 @@ const contextValue: LogDetailsContextData = {
   detailsMode: 'sidebar',
   detailsWidth: 1337,
   enableLogDetails: false,
+  replaceDetails: () => {},
   setCurrentLog: () => {},
   setDetailsMode: () => {},
   setDetailsWidth: () => {},
@@ -38,4 +40,90 @@ test('Allows to access context attributes', () => {
   const { result } = renderHook(() => useLogDetailsContextData('detailsWidth'), { wrapper });
 
   expect(result.current).toEqual(contextValue.detailsWidth);
+});
+
+describe('replaceDetails', () => {
+  const logA = createLogLine({ rowId: 'row-a', uid: 'log-a' });
+  const logB = createLogLine({ rowId: 'row-b', uid: 'log-b' });
+  const logs = [logA, logB];
+
+  function providerWrapper(enableLogDetails: boolean) {
+    return function Wrapper({ children }: { children: ReactNode }) {
+      return (
+        <LogDetailsContextProvider
+          detailsMode="sidebar"
+          enableLogDetails={enableLogDetails}
+          logs={logs}
+          showControls={false}
+        >
+          {children}
+        </LogDetailsContextProvider>
+      );
+    };
+  }
+
+  test('does nothing when log details are disabled', () => {
+    const { result } = renderHook(() => useLogDetailsContext(), {
+      wrapper: providerWrapper(false),
+    });
+
+    act(() => {
+      result.current.replaceDetails(logB);
+    });
+
+    expect(result.current.currentLog).toBeUndefined();
+    expect(result.current.showDetails).toEqual([]);
+  });
+
+  test('does nothing when no log details are open', () => {
+    const { result } = renderHook(() => useLogDetailsContext(), {
+      wrapper: providerWrapper(true),
+    });
+
+    act(() => {
+      result.current.replaceDetails(logB);
+    });
+
+    expect(result.current.currentLog).toBeUndefined();
+    expect(result.current.showDetails).toEqual([]);
+  });
+
+  test('replaces the open log when switching to a different row', () => {
+    const { result } = renderHook(() => useLogDetailsContext(), {
+      wrapper: providerWrapper(true),
+    });
+
+    act(() => {
+      result.current.toggleDetails(logA);
+    });
+    expect(result.current.currentLog).toBe(logA);
+    expect(result.current.showDetails).toEqual([logA]);
+
+    act(() => {
+      result.current.replaceDetails(logB);
+    });
+
+    expect(result.current.currentLog).toBe(logB);
+    expect(result.current.showDetails).toEqual([logB]);
+  });
+
+  test('when the target uid is already expanded, updates currentLog without changing expanded list length', () => {
+    const logARefreshed = createLogLine({ rowId: 'row-a-new', uid: 'log-a', timeEpochMs: 99_000 });
+    const { result } = renderHook(() => useLogDetailsContext(), {
+      wrapper: providerWrapper(true),
+    });
+
+    act(() => {
+      result.current.toggleDetails(logA);
+    });
+    expect(result.current.showDetails).toEqual([logA]);
+
+    act(() => {
+      result.current.replaceDetails(logARefreshed);
+    });
+
+    expect(result.current.currentLog).toBe(logARefreshed);
+    expect(result.current.showDetails).toEqual([logA]);
+    expect(result.current.detailsDisplayed(logARefreshed)).toBe(true);
+  });
 });

--- a/public/app/features/logs/components/panel/LogDetailsContext.tsx
+++ b/public/app/features/logs/components/panel/LogDetailsContext.tsx
@@ -16,7 +16,8 @@ export interface LogDetailsContextData {
   detailsMode: LogLineDetailsMode;
   detailsWidth: number;
   enableLogDetails: boolean;
-  setCurrentLog(log: LogListModel): void;
+  replaceDetails: (log: LogListModel) => void;
+  setCurrentLog: (log: LogListModel) => void;
   setDetailsMode: (mode: LogLineDetailsMode) => void;
   setDetailsWidth: (width: number) => void;
   showDetails: LogListModel[];
@@ -30,6 +31,7 @@ export const emptyContextData: LogDetailsContextData = {
   detailsMode: 'sidebar',
   detailsWidth: 0,
   enableLogDetails: false,
+  replaceDetails: () => {},
   setCurrentLog: () => {},
   setDetailsMode: () => {},
   setDetailsWidth: () => {},
@@ -163,6 +165,23 @@ export const LogDetailsContextProvider = ({
     [currentLog, enableLogDetails, showDetails]
   );
 
+  const replaceDetails = useCallback(
+    (log: LogListModel) => {
+      if (!enableLogDetails || !currentLog) {
+        return;
+      }
+      if (showDetails.find((stateLog) => stateLog.uid === log.uid)) {
+        setCurrentLog(log);
+        return;
+      }
+      removeDetailsScrollPosition(currentLog);
+      const newShowDetails = showDetails.filter((stateLog) => stateLog.uid !== currentLog.uid);
+      setShowDetails([...newShowDetails, log]);
+      setCurrentLog(log);
+    },
+    [currentLog, enableLogDetails, showDetails]
+  );
+
   const setDetailsWidth = useCallback(
     (width: number) => {
       if (!logOptionsStorageKey || !containerElement) {
@@ -192,6 +211,7 @@ export const LogDetailsContextProvider = ({
         detailsMode,
         detailsWidth,
         enableLogDetails,
+        replaceDetails,
         setCurrentLog,
         setDetailsMode,
         setDetailsWidth,

--- a/public/app/features/logs/components/panel/LogLineDetails.test.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.test.tsx
@@ -752,16 +752,11 @@ describe('LogLineDetails', () => {
       const replaceDetails = jest.fn();
       const focusLogLine = jest.fn();
 
-      await setup(
-        { logs, focusLogLine },
-        undefined,
-        undefined,
-        {
-          showDetails: logs,
-          currentLog: logs[0],
-          replaceDetails,
-        }
-      );
+      await setup({ logs, focusLogLine }, undefined, undefined, {
+        showDetails: logs,
+        currentLog: logs[0],
+        replaceDetails,
+      });
 
       fireEvent.keyDown(document, { key: 'ArrowDown' });
 
@@ -774,16 +769,11 @@ describe('LogLineDetails', () => {
       const replaceDetails = jest.fn();
       const focusLogLine = jest.fn();
 
-      await setup(
-        { logs, focusLogLine },
-        undefined,
-        undefined,
-        {
-          showDetails: logs,
-          currentLog: logs[1],
-          replaceDetails,
-        }
-      );
+      await setup({ logs, focusLogLine }, undefined, undefined, {
+        showDetails: logs,
+        currentLog: logs[1],
+        replaceDetails,
+      });
 
       fireEvent.keyDown(document, { key: 'ArrowUp' });
 

--- a/public/app/features/logs/components/panel/LogLineDetails.test.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.test.tsx
@@ -762,7 +762,7 @@ describe('LogLineDetails', () => {
 
       expect(replaceDetails).toHaveBeenCalledTimes(1);
       expect(replaceDetails).toHaveBeenCalledWith(logs[1]);
-      expect(focusLogLine).toHaveBeenCalledWith(logs[1]);
+      expect(focusLogLine).toHaveBeenCalledWith(logs[1], 'auto');
     });
 
     test('Can be keyboard navigated up', async () => {
@@ -779,7 +779,7 @@ describe('LogLineDetails', () => {
 
       expect(replaceDetails).toHaveBeenCalledTimes(1);
       expect(replaceDetails).toHaveBeenCalledWith(logs[0]);
-      expect(focusLogLine).toHaveBeenCalledWith(logs[0]);
+      expect(focusLogLine).toHaveBeenCalledWith(logs[0], 'auto');
     });
   });
 

--- a/public/app/features/logs/components/panel/LogLineDetails.test.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { of } from 'rxjs';
 
@@ -732,11 +732,12 @@ describe('LogLineDetails', () => {
       expect(screen.queryAllByRole('tab')).toHaveLength(0);
     });
 
+    const logs = [
+      createLogLine({ uid: '1', logLevel: LogLevel.error, timeEpochMs: 1546297200000, entry: 'First log' }),
+      createLogLine({ uid: '2', logLevel: LogLevel.error, timeEpochMs: 1546297200000, entry: 'Second log' }),
+    ];
+
     test('Renders multiple log details', async () => {
-      const logs = [
-        createLogLine({ uid: '1', logLevel: LogLevel.error, timeEpochMs: 1546297200000, entry: 'First log' }),
-        createLogLine({ uid: '2', logLevel: LogLevel.error, timeEpochMs: 1546297200000, entry: 'Second log' }),
-      ];
       await setup({ logs }, undefined, undefined, { showDetails: logs, currentLog: logs[1] }, 'No fields to display.');
 
       expect(screen.queryAllByRole('tab')).toHaveLength(2);
@@ -745,6 +746,50 @@ describe('LogLineDetails', () => {
 
       expect(screen.getAllByText('First log')).toHaveLength(1);
       expect(screen.getAllByText('Second log')).toHaveLength(2);
+    });
+
+    test('Can be keyboard navigated down', async () => {
+      const replaceDetails = jest.fn();
+      const focusLogLine = jest.fn();
+
+      await setup(
+        { logs, focusLogLine },
+        undefined,
+        undefined,
+        {
+          showDetails: logs,
+          currentLog: logs[0],
+          replaceDetails,
+        }
+      );
+
+      fireEvent.keyDown(document, { key: 'ArrowDown' });
+
+      expect(replaceDetails).toHaveBeenCalledTimes(1);
+      expect(replaceDetails).toHaveBeenCalledWith(logs[1]);
+      expect(focusLogLine).toHaveBeenCalledWith(logs[1]);
+    });
+
+    test('Can be keyboard navigated up', async () => {
+      const replaceDetails = jest.fn();
+      const focusLogLine = jest.fn();
+
+      await setup(
+        { logs, focusLogLine },
+        undefined,
+        undefined,
+        {
+          showDetails: logs,
+          currentLog: logs[1],
+          replaceDetails,
+        }
+      );
+
+      fireEvent.keyDown(document, { key: 'ArrowUp' });
+
+      expect(replaceDetails).toHaveBeenCalledTimes(1);
+      expect(replaceDetails).toHaveBeenCalledWith(logs[0]);
+      expect(focusLogLine).toHaveBeenCalledWith(logs[0]);
     });
   });
 

--- a/public/app/features/logs/components/panel/LogLineDetails.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.tsx
@@ -2,6 +2,7 @@ import { css } from '@emotion/css';
 import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { Resizable } from 're-resizable';
 import { memo, startTransition, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { type Align } from 'react-window';
 
 import { store, type GrafanaTheme2, type TimeRange } from '@grafana/data';
 import { t } from '@grafana/i18n';
@@ -20,7 +21,7 @@ import { LOG_LIST_MIN_WIDTH } from './virtualization';
 
 export interface Props {
   containerElement: HTMLDivElement;
-  focusLogLine: (log: LogListModel) => void;
+  focusLogLine: (log: LogListModel, align?: Align) => void;
   logs: LogListModel[];
   timeRange: TimeRange;
   timeZone: string;
@@ -130,7 +131,7 @@ const LogLineDetailsTabs = memo(
           return;
         }
         replaceDetails(nextLog);
-        focusLogLine(nextLog);
+        focusLogLine(nextLog, 'auto');
       }
       document.addEventListener('keydown', handleKeydown);
       return () => document.removeEventListener('keydown', handleKeydown);

--- a/public/app/features/logs/components/panel/LogLineDetails.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.tsx
@@ -122,7 +122,6 @@ const LogLineDetailsTabs = memo(
         } else {
           return;
         }
-        e.preventDefault();
         if (!currentLog || !logs.find((log) => log.uid === currentLog.uid)) {
           return;
         }
@@ -130,6 +129,7 @@ const LogLineDetailsTabs = memo(
         if (!nextLog) {
           return;
         }
+        e.preventDefault();
         replaceDetails(nextLog);
         focusLogLine(nextLog, 'auto');
       }

--- a/public/app/features/logs/components/panel/LogLineDetails.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.tsx
@@ -80,8 +80,16 @@ LogLineDetails.displayName = 'LogLineDetails';
 const LogLineDetailsTabs = memo(
   ({ focusLogLine, logs, timeRange, timeZone }: Pick<Props, 'focusLogLine' | 'logs' | 'timeRange' | 'timeZone'>) => {
     const { app, fontSize, noInteractions, wrapLogMessage } = useLogListContext();
-    const { currentLog, closeDetails, detailsMode, setCurrentLog, showDetails, setDetailsMode, toggleDetails } =
-      useLogDetailsContext();
+    const {
+      currentLog,
+      closeDetails,
+      detailsMode,
+      replaceDetails,
+      setCurrentLog,
+      showDetails,
+      setDetailsMode,
+      toggleDetails,
+    } = useLogDetailsContext();
     const [search, setSearch] = useState('');
     const inputRef = useRef('');
 
@@ -102,6 +110,30 @@ const LogLineDetailsTabs = memo(
       // Once
       // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
+
+    useEffect(() => {
+      function handleKeydown(e: KeyboardEvent) {
+        let delta: number;
+        if (e.key === 'ArrowDown') {
+          delta = 1;
+        } else if (e.key === 'ArrowUp') {
+          delta = -1;
+        } else {
+          return;
+        }
+        e.preventDefault();
+        if (!currentLog || logs.indexOf(currentLog) < 0) {
+          return;
+        }
+        const nextLog = logs[logs.indexOf(currentLog) + delta];
+        if (!nextLog) {
+          return;
+        }
+        replaceDetails(nextLog);
+      }
+      document.addEventListener('keydown', handleKeydown);
+      return () => document.removeEventListener('keydown', handleKeydown);
+    }, [currentLog, logs, replaceDetails]);
 
     const handleSearch = useCallback((newSearch: string) => {
       inputRef.current = newSearch;

--- a/public/app/features/logs/components/panel/LogLineDetails.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.tsx
@@ -131,8 +131,8 @@ const LogLineDetailsTabs = memo(
         }
         replaceDetails(nextLog);
       }
-      document.addEventListener('keydown', handleKeydown);
-      return () => document.removeEventListener('keydown', handleKeydown);
+      document.addEventListener('keyup', handleKeydown);
+      return () => document.removeEventListener('keyup', handleKeydown);
     }, [currentLog, logs, replaceDetails]);
 
     const handleSearch = useCallback((newSearch: string) => {

--- a/public/app/features/logs/components/panel/LogLineDetails.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.tsx
@@ -70,7 +70,13 @@ export const LogLineDetails = memo(
         maxWidth={maxWidth}
       >
         <div className={styles.container} ref={containerRef}>
-          <LogLineDetailsTabs focusLogLine={focusLogLine} logs={logs} timeRange={timeRange} timeZone={timeZone} />
+          <LogLineDetailsTabs
+            containerElement={containerElement}
+            focusLogLine={focusLogLine}
+            logs={logs}
+            timeRange={timeRange}
+            timeZone={timeZone}
+          />
         </div>
       </Resizable>
     );
@@ -79,7 +85,13 @@ export const LogLineDetails = memo(
 LogLineDetails.displayName = 'LogLineDetails';
 
 const LogLineDetailsTabs = memo(
-  ({ focusLogLine, logs, timeRange, timeZone }: Pick<Props, 'focusLogLine' | 'logs' | 'timeRange' | 'timeZone'>) => {
+  ({
+    containerElement,
+    focusLogLine,
+    logs,
+    timeRange,
+    timeZone,
+  }: Pick<Props, 'containerElement' | 'focusLogLine' | 'logs' | 'timeRange' | 'timeZone'>) => {
     const { app, fontSize, noInteractions, wrapLogMessage } = useLogListContext();
     const {
       currentLog,
@@ -114,6 +126,13 @@ const LogLineDetailsTabs = memo(
 
     useEffect(() => {
       function handleKeydown(e: KeyboardEvent) {
+        if (
+          e.target instanceof Element &&
+          e.target.contains(containerElement) === false &&
+          containerElement.contains(e.target) === false
+        ) {
+          return;
+        }
         let delta: number;
         if (e.key === 'ArrowDown') {
           delta = 1;
@@ -135,7 +154,7 @@ const LogLineDetailsTabs = memo(
       }
       document.addEventListener('keydown', handleKeydown);
       return () => document.removeEventListener('keydown', handleKeydown);
-    }, [currentLog, focusLogLine, logs, replaceDetails]);
+    }, [containerElement, currentLog, focusLogLine, logs, replaceDetails]);
 
     const handleSearch = useCallback((newSearch: string) => {
       inputRef.current = newSearch;

--- a/public/app/features/logs/components/panel/LogLineDetails.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.tsx
@@ -122,18 +122,19 @@ const LogLineDetailsTabs = memo(
           return;
         }
         e.preventDefault();
-        if (!currentLog || logs.indexOf(currentLog) < 0) {
+        if (!currentLog || !logs.find((log) => log.uid === currentLog.uid)) {
           return;
         }
-        const nextLog = logs[logs.indexOf(currentLog) + delta];
+        const nextLog = logs[logs.findIndex((log) => log.uid === currentLog.uid) + delta];
         if (!nextLog) {
           return;
         }
         replaceDetails(nextLog);
+        focusLogLine(nextLog);
       }
-      document.addEventListener('keyup', handleKeydown);
-      return () => document.removeEventListener('keyup', handleKeydown);
-    }, [currentLog, logs, replaceDetails]);
+      document.addEventListener('keydown', handleKeydown);
+      return () => document.removeEventListener('keydown', handleKeydown);
+    }, [currentLog, focusLogLine, logs, replaceDetails]);
 
     const handleSearch = useCallback((newSearch: string) => {
       inputRef.current = newSearch;

--- a/public/app/features/logs/components/panel/LogList.tsx
+++ b/public/app/features/logs/components/panel/LogList.tsx
@@ -468,10 +468,10 @@ const LogListComponent = ({
   );
 
   const focusLogLine = useCallback(
-    (log: LogListModel) => {
+    (log: LogListModel, align: Align = 'start') => {
       const index = filteredLogs.findIndex((filteredLog) => filteredLog.uid === log.uid);
       if (index >= 0) {
-        debouncedScrollToItem(index, 'start');
+        debouncedScrollToItem(index, align);
       }
     },
     [debouncedScrollToItem, filteredLogs]

--- a/public/app/plugins/panel/logstable/LogDetailsContext.test.tsx
+++ b/public/app/plugins/panel/logstable/LogDetailsContext.test.tsx
@@ -15,6 +15,7 @@ import {
 
 const log1 = createLogLine({ uid: 'uid-1', rowId: 'row-1' });
 const log2 = createLogLine({ uid: 'uid-2', rowId: 'row-2' });
+const log3 = createLogLine({ uid: 'uid-3', rowId: 'row-3' });
 
 const contextValue: LogDetailsContextData = {
   ...emptyContextData,
@@ -153,6 +154,85 @@ describe('LogDetailsContextProvider', () => {
 
     await waitFor(() => {
       expect(result.current.showDetails).toEqual([]);
+    });
+  });
+
+  describe('replaceDetails', () => {
+    test('does nothing when log details are disabled', () => {
+      const { result, setProviderProps } = renderLogDetailsProviderHook([log1, log2, log3]);
+
+      act(() => {
+        result.current.toggleDetails(0);
+      });
+      setProviderProps({ enableLogDetails: false });
+      act(() => {
+        result.current.replaceDetails(log2);
+      });
+
+      expect(result.current.showDetails.map((l) => l.uid)).toEqual([log1.uid]);
+      expect(result.current.currentLog?.uid).toBe(log1.uid);
+    });
+
+    test('does nothing when there is no current expanded log', () => {
+      const { result } = renderLogDetailsProviderHook([log1, log2, log3]);
+
+      act(() => {
+        result.current.replaceDetails(log2);
+      });
+
+      expect(result.current.showDetails).toEqual([]);
+      expect(result.current.currentLog).toBeUndefined();
+    });
+
+    test('replaces the current row details with another log and updates currentLog', () => {
+      const { result } = renderLogDetailsProviderHook([log1, log2, log3]);
+
+      act(() => {
+        result.current.toggleDetails(0);
+      });
+      act(() => {
+        result.current.replaceDetails(log2);
+      });
+
+      expect(result.current.showDetails.map((l) => l.uid)).toEqual([log2.uid]);
+      expect(result.current.currentLog?.uid).toBe(log2.uid);
+    });
+
+    test('when multiple rows are expanded, removes only the previous current log and appends the replacement', () => {
+      const { result } = renderLogDetailsProviderHook([log1, log2, log3]);
+
+      act(() => {
+        result.current.toggleDetails(0);
+      });
+      act(() => {
+        result.current.toggleDetails(1);
+      });
+      expect(result.current.currentLog?.uid).toBe(log2.uid);
+
+      act(() => {
+        result.current.replaceDetails(log3);
+      });
+
+      expect(result.current.showDetails.map((l) => l.uid)).toEqual([log1.uid, log3.uid]);
+      expect(result.current.currentLog?.uid).toBe(log3.uid);
+    });
+
+    test('when the target log is already expanded, only switches currentLog without changing expanded rows', () => {
+      const { result } = renderLogDetailsProviderHook([log1, log2, log3]);
+
+      act(() => {
+        result.current.toggleDetails(0);
+      });
+      act(() => {
+        result.current.toggleDetails(1);
+      });
+
+      act(() => {
+        result.current.replaceDetails(log1);
+      });
+
+      expect(result.current.showDetails.map((l) => l.uid)).toEqual([log1.uid, log2.uid]);
+      expect(result.current.currentLog?.uid).toBe(log1.uid);
     });
   });
 });

--- a/public/app/plugins/panel/logstable/LogDetailsContext.tsx
+++ b/public/app/plugins/panel/logstable/LogDetailsContext.tsx
@@ -8,7 +8,8 @@ export interface LogDetailsContextData {
   detailsDisplayed: (rowIndex: number) => boolean;
   enableLogDetails: boolean;
   logs: LogListModel[];
-  setCurrentLog(log: LogListModel): void;
+  replaceDetails: (log: LogListModel) => void;
+  setCurrentLog: (log: LogListModel) => void;
   showDetails: LogListModel[];
   toggleDetails: (log: number | LogListModel) => void;
 }
@@ -19,6 +20,7 @@ export const emptyContextData: LogDetailsContextData = {
   detailsDisplayed: () => false,
   enableLogDetails: false,
   logs: [],
+  replaceDetails: () => {},
   setCurrentLog: () => {},
   showDetails: [],
   toggleDetails: () => {},
@@ -98,6 +100,22 @@ export const LogDetailsContextProvider = ({ children, enableLogDetails, logs }: 
     [currentLog, enableLogDetails, logs, showDetails]
   );
 
+  const replaceDetails = useCallback(
+    (log: LogListModel) => {
+      if (!enableLogDetails || !currentLog) {
+        return;
+      }
+      if (showDetails.find((stateLog) => stateLog.uid === log.uid)) {
+        setCurrentLog(log);
+        return;
+      }
+      const newShowDetails = showDetails.filter((stateLog) => stateLog.uid !== currentLog.uid);
+      setShowDetails([...newShowDetails, log]);
+      setCurrentLog(log);
+    },
+    [currentLog, enableLogDetails, showDetails]
+  );
+
   return (
     <LogDetailsContext.Provider
       value={{
@@ -106,6 +124,7 @@ export const LogDetailsContextProvider = ({ children, enableLogDetails, logs }: 
         detailsDisplayed,
         enableLogDetails,
         logs,
+        replaceDetails,
         setCurrentLog,
         showDetails,
         toggleDetails,

--- a/public/app/plugins/panel/logstable/LogsTable.tsx
+++ b/public/app/plugins/panel/logstable/LogsTable.tsx
@@ -327,6 +327,7 @@ export const LogsTable = ({
           />
 
           <LogsTableDetails
+            containerElement={containerElement}
             options={tableOptions}
             onOptionsChange={handleTableOptionsChange}
             timeRange={data.timeRange}

--- a/public/app/plugins/panel/logstable/LogsTableDetails.test.tsx
+++ b/public/app/plugins/panel/logstable/LogsTableDetails.test.tsx
@@ -296,13 +296,7 @@ describe('LogsTableDetails', () => {
     const allLogs = [logA, logB, logC];
     const replaceDetails = jest.fn();
 
-    setup(
-      { currentLog: logB, showDetails: allLogs, replaceDetails },
-      undefined,
-      undefined,
-      jest.fn(),
-      allLogs
-    );
+    setup({ currentLog: logB, showDetails: allLogs, replaceDetails }, undefined, undefined, jest.fn(), allLogs);
 
     await waitFor(() => {
       expect(screen.getByText('Log line')).toBeInTheDocument();

--- a/public/app/plugins/panel/logstable/LogsTableDetails.test.tsx
+++ b/public/app/plugins/panel/logstable/LogsTableDetails.test.tsx
@@ -274,6 +274,53 @@ describe('LogsTableDetails', () => {
     expect(closeDetails).toHaveBeenCalledTimes(1);
   });
 
+  test('calls replaceDetails when ArrowDown and ArrowUp navigate the log list', async () => {
+    const logA = createLogLine({
+      uid: 'a',
+      logLevel: LogLevel.info,
+      timeEpochMs: 1546297200000,
+      datasourceUid: lokiDS.uid,
+    });
+    const logB = createLogLine({
+      uid: 'b',
+      logLevel: LogLevel.warn,
+      timeEpochMs: 1546297200001,
+      datasourceUid: lokiDS.uid,
+    });
+    const logC = createLogLine({
+      uid: 'c',
+      logLevel: LogLevel.error,
+      timeEpochMs: 1546297200002,
+      datasourceUid: lokiDS.uid,
+    });
+    const allLogs = [logA, logB, logC];
+    const replaceDetails = jest.fn();
+
+    setup(
+      { currentLog: logB, showDetails: allLogs, replaceDetails },
+      undefined,
+      undefined,
+      jest.fn(),
+      allLogs
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText('Log line')).toBeInTheDocument();
+    });
+
+    await userEvent.keyboard('{ArrowDown}');
+
+    expect(replaceDetails).toHaveBeenCalledTimes(1);
+    expect(replaceDetails).toHaveBeenCalledWith(logC);
+
+    replaceDetails.mockClear();
+
+    await userEvent.keyboard('{ArrowUp}');
+
+    expect(replaceDetails).toHaveBeenCalledTimes(1);
+    expect(replaceDetails).toHaveBeenCalledWith(logA);
+  });
+
   test('forwards label filters to the panel ad-hoc filter handler', async () => {
     const onAddAdHocFilter = jest.fn();
     const labeledLog = createLogLine({

--- a/public/app/plugins/panel/logstable/LogsTableDetails.test.tsx
+++ b/public/app/plugins/panel/logstable/LogsTableDetails.test.tsx
@@ -103,6 +103,7 @@ const setup = (
     >
       <LogDetailsContext.Provider value={detailsData}>
         <LogsTableDetails
+          containerElement={null}
           options={{ ...baseOptions, ...optionsOverrides }}
           onOptionsChange={onOptionsChange}
           timeRange={timeRange}
@@ -194,7 +195,13 @@ describe('LogsTableDetails', () => {
     render(
       <PanelContextProvider value={{ eventsScope: 'test', eventBus: new EventBusSrv(), app: CoreApp.Dashboard }}>
         <LogDetailsContext.Provider value={detailsData}>
-          <LogsTableDetails options={baseOptions} onOptionsChange={jest.fn()} timeRange={timeRange} timeZone="UTC" />
+          <LogsTableDetails
+            containerElement={null}
+            options={baseOptions}
+            onOptionsChange={jest.fn()}
+            timeRange={timeRange}
+            timeZone="UTC"
+          />
         </LogDetailsContext.Provider>
       </PanelContextProvider>
     );
@@ -244,7 +251,13 @@ describe('LogsTableDetails', () => {
     render(
       <PanelContextProvider value={{ eventsScope: 'test', eventBus: new EventBusSrv(), app: CoreApp.Dashboard }}>
         <LogDetailsContext.Provider value={detailsData}>
-          <LogsTableDetails options={baseOptions} onOptionsChange={jest.fn()} timeRange={timeRange} timeZone="UTC" />
+          <LogsTableDetails
+            containerElement={null}
+            options={baseOptions}
+            onOptionsChange={jest.fn()}
+            timeRange={timeRange}
+            timeZone="UTC"
+          />
         </LogDetailsContext.Provider>
       </PanelContextProvider>
     );

--- a/public/app/plugins/panel/logstable/LogsTableDetails.tsx
+++ b/public/app/plugins/panel/logstable/LogsTableDetails.tsx
@@ -59,7 +59,7 @@ export const LogsTableDetails = ({ options, onOptionsChange, timeRange, timeZone
   }, [closeDetails, showDetails.length]);
 
   useEffect(() => {
-    function handleKeydown(e: KeyboardEvent) {
+    function handleKeyup(e: KeyboardEvent) {
       let delta: number;
       if (e.key === 'ArrowDown') {
         delta = 1;
@@ -78,8 +78,8 @@ export const LogsTableDetails = ({ options, onOptionsChange, timeRange, timeZone
       }
       replaceDetails(nextLog);
     }
-    document.addEventListener('keyup', handleKeydown);
-    return () => document.removeEventListener('keyup', handleKeydown);
+    document.addEventListener('keyup', handleKeyup);
+    return () => document.removeEventListener('keyup', handleKeyup);
   }, [currentLog, logs, replaceDetails]);
 
   const handleSearch = useCallback((newSearch: string) => {

--- a/public/app/plugins/panel/logstable/LogsTableDetails.tsx
+++ b/public/app/plugins/panel/logstable/LogsTableDetails.tsx
@@ -60,7 +60,7 @@ export const LogsTableDetails = ({ containerElement, options, onOptionsChange, t
   }, [closeDetails, showDetails.length]);
 
   useEffect(() => {
-    function handleKeyup(e: KeyboardEvent) {
+    function handleKeydown(e: KeyboardEvent) {
       if (
         containerElement &&
         e.target instanceof Element &&
@@ -87,8 +87,8 @@ export const LogsTableDetails = ({ containerElement, options, onOptionsChange, t
       e.preventDefault();
       replaceDetails(nextLog);
     }
-    document.addEventListener('keyup', handleKeyup);
-    return () => document.removeEventListener('keyup', handleKeyup);
+    document.addEventListener('keydown', handleKeydown);
+    return () => document.removeEventListener('keydown', handleKeydown);
   }, [containerElement, currentLog, logs, replaceDetails]);
 
   const handleSearch = useCallback((newSearch: string) => {

--- a/public/app/plugins/panel/logstable/LogsTableDetails.tsx
+++ b/public/app/plugins/panel/logstable/LogsTableDetails.tsx
@@ -68,7 +68,6 @@ export const LogsTableDetails = ({ options, onOptionsChange, timeRange, timeZone
       } else {
         return;
       }
-      e.preventDefault();
       if (!currentLog || logs.indexOf(currentLog) < 0) {
         return;
       }
@@ -76,6 +75,7 @@ export const LogsTableDetails = ({ options, onOptionsChange, timeRange, timeZone
       if (!nextLog) {
         return;
       }
+      e.preventDefault();
       replaceDetails(nextLog);
     }
     document.addEventListener('keyup', handleKeyup);

--- a/public/app/plugins/panel/logstable/LogsTableDetails.tsx
+++ b/public/app/plugins/panel/logstable/LogsTableDetails.tsx
@@ -176,6 +176,7 @@ export const LogsTableDetails = ({ options, onOptionsChange, timeRange, timeZone
             displayedFields={[]}
             fontSize={store.get(`${SETTING_KEY_ROOT}.fontSize`) ?? 'default'}
             logs={logs}
+            logOptionsStorageKey={SETTING_KEY_ROOT}
             showControls={false}
             showTime={false}
             sortOrder={LogsSortOrder.Ascending}

--- a/public/app/plugins/panel/logstable/LogsTableDetails.tsx
+++ b/public/app/plugins/panel/logstable/LogsTableDetails.tsx
@@ -29,8 +29,16 @@ interface Props extends Pick<PanelProps<Options>, 'onOptionsChange'> {
 }
 
 export const LogsTableDetails = ({ options, onOptionsChange, timeRange, timeZone }: Props) => {
-  const { currentLog, closeDetails, enableLogDetails, logs, setCurrentLog, showDetails, toggleDetails } =
-    useLogDetailsContext();
+  const {
+    currentLog,
+    closeDetails,
+    enableLogDetails,
+    logs,
+    replaceDetails,
+    setCurrentLog,
+    showDetails,
+    toggleDetails,
+  } = useLogDetailsContext();
   const [search, setSearch] = useState('');
   const [detailsWidth, setDetailsWidth] = useState(options.logDetailsWidth ?? getDefaultLogDetailsWidth());
   const { onAddAdHocFilter, app } = usePanelContext();
@@ -49,6 +57,30 @@ export const LogsTableDetails = ({ options, onOptionsChange, timeRange, timeZone
       document.removeEventListener('keyup', handleClose);
     };
   }, [closeDetails, showDetails.length]);
+
+  useEffect(() => {
+    function handleKeydown(e: KeyboardEvent) {
+      let delta: number;
+      if (e.key === 'ArrowDown') {
+        delta = 1;
+      } else if (e.key === 'ArrowUp') {
+        delta = -1;
+      } else {
+        return;
+      }
+      e.preventDefault();
+      if (!currentLog || logs.indexOf(currentLog) < 0) {
+        return;
+      }
+      const nextLog = logs[logs.indexOf(currentLog) + delta];
+      if (!nextLog) {
+        return;
+      }
+      replaceDetails(nextLog);
+    }
+    document.addEventListener('keyup', handleKeydown);
+    return () => document.removeEventListener('keyup', handleKeydown);
+  }, [currentLog, logs, replaceDetails]);
 
   const handleSearch = useCallback((newSearch: string) => {
     inputRef.current = newSearch;

--- a/public/app/plugins/panel/logstable/LogsTableDetails.tsx
+++ b/public/app/plugins/panel/logstable/LogsTableDetails.tsx
@@ -23,12 +23,13 @@ import { type Options } from './options/types';
 import { isCoreApp, isIsLabelFilterActive } from './types';
 
 interface Props extends Pick<PanelProps<Options>, 'onOptionsChange'> {
+  containerElement: HTMLDivElement | null;
   options: Options;
   timeRange: TimeRange;
   timeZone: string;
 }
 
-export const LogsTableDetails = ({ options, onOptionsChange, timeRange, timeZone }: Props) => {
+export const LogsTableDetails = ({ containerElement, options, onOptionsChange, timeRange, timeZone }: Props) => {
   const {
     currentLog,
     closeDetails,
@@ -60,6 +61,14 @@ export const LogsTableDetails = ({ options, onOptionsChange, timeRange, timeZone
 
   useEffect(() => {
     function handleKeyup(e: KeyboardEvent) {
+      if (
+        containerElement &&
+        e.target instanceof Element &&
+        e.target.contains(containerElement) === false &&
+        containerElement.contains(e.target) === false
+      ) {
+        return;
+      }
       let delta: number;
       if (e.key === 'ArrowDown') {
         delta = 1;
@@ -80,7 +89,7 @@ export const LogsTableDetails = ({ options, onOptionsChange, timeRange, timeZone
     }
     document.addEventListener('keyup', handleKeyup);
     return () => document.removeEventListener('keyup', handleKeyup);
-  }, [currentLog, logs, replaceDetails]);
+  }, [containerElement, currentLog, logs, replaceDetails]);
 
   const handleSearch = useCallback((newSearch: string) => {
     inputRef.current = newSearch;

--- a/public/app/plugins/panel/logstable/LogsTableDetails.tsx
+++ b/public/app/plugins/panel/logstable/LogsTableDetails.tsx
@@ -77,10 +77,10 @@ export const LogsTableDetails = ({ containerElement, options, onOptionsChange, t
       } else {
         return;
       }
-      if (!currentLog || logs.indexOf(currentLog) < 0) {
+      if (!currentLog || logs.findIndex((log) => log.uid === currentLog.uid) < 0) {
         return;
       }
-      const nextLog = logs[logs.indexOf(currentLog) + delta];
+      const nextLog = logs[logs.findIndex((log) => log.uid === currentLog.uid) + delta];
       if (!nextLog) {
         return;
       }


### PR DESCRIPTION
This PR adds keyboard navigation to Log Details, for both TableNG and Logs visualizations.

Closes https://github.com/grafana/grafana/issues/121199

Demo:

https://github.com/user-attachments/assets/5e23bfa0-e424-4a37-b7b8-d138f4136218