### PR TITLE
LibraryPanels: Return 403 instead of 500 for insufficient permissions

### DIFF
--- a/pkg/services/dashboardimport/api/api.go
+++ b/pkg/services/dashboardimport/api/api.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/dashboardimport/utils"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	libraryelementsmodel "github.com/grafana/grafana/pkg/services/libraryelements/model"
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginstore"
 	"github.com/grafana/grafana/pkg/services/quota"
 	"github.com/grafana/grafana/pkg/web"
@@ -124,6 +125,9 @@ func (api *ImportDashboardAPI) ImportDashboard(c *contextmodel.ReqContext) respo
 	if err != nil {
 		if errors.Is(err, utils.ErrDashboardInputMissing) {
 			return response.Error(http.StatusBadRequest, err.Error(), err)
+		}
+		if errors.Is(err, libraryelementsmodel.ErrLibraryElementInsufficientPermissions) {
+			return response.Error(http.StatusForbidden, err.Error(), err)
 		}
 		return apierrors.ToDashboardErrorResponse(c.Req.Context(), api.pluginStore, err)
 	}

--- a/pkg/services/dashboardimport/api/api_test.go
+++ b/pkg/services/dashboardimport/api/api_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -163,7 +164,7 @@ func TestImportDashboardAPI(t *testing.T) {
 	t.Run("Import service returns a library panel permission error", func(t *testing.T) {
 		service := &serviceMock{
 			importDashboardFunc: func(ctx context.Context, req *dashboardimport.ImportDashboardRequest) (*dashboardimport.ImportDashboardResponse, error) {
-				return nil, libraryelementsmodel.ErrLibraryElementInsufficientPermissions.Errorf("insufficient permissions for creating library panel in folder with UID: 'abc'")
+				return nil, fmt.Errorf("%w: folder UID 'abc'", libraryelementsmodel.ErrLibraryElementInsufficientPermissions)
 			},
 		}
 		importDashboardAPI := New(service, quotaServiceFunc(quotaNotReached), nil, actest.FakeAccessControl{ExpectedEvaluate: true}, featuremgmt.WithFeatures())

--- a/pkg/services/dashboardimport/api/api_test.go
+++ b/pkg/services/dashboardimport/api/api_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/dashboardimport"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	libraryelementsmodel "github.com/grafana/grafana/pkg/services/libraryelements/model"
 	"github.com/grafana/grafana/pkg/services/quota"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/web/webtest"
@@ -157,6 +158,35 @@ func TestImportDashboardAPI(t *testing.T) {
 			require.NoError(t, resp.Body.Close())
 			require.Equal(t, http.StatusForbidden, resp.StatusCode)
 		})
+	})
+
+	t.Run("Import service returns a library panel permission error", func(t *testing.T) {
+		service := &serviceMock{
+			importDashboardFunc: func(ctx context.Context, req *dashboardimport.ImportDashboardRequest) (*dashboardimport.ImportDashboardResponse, error) {
+				return nil, libraryelementsmodel.ErrLibraryElementInsufficientPermissions.Errorf("insufficient permissions for creating library panel in folder with UID: 'abc'")
+			},
+		}
+		importDashboardAPI := New(service, quotaServiceFunc(quotaNotReached), nil, actest.FakeAccessControl{ExpectedEvaluate: true}, featuremgmt.WithFeatures())
+		routeRegister := routing.NewRouteRegister()
+		importDashboardAPI.RegisterAPIEndpoints(routeRegister)
+		s := webtest.NewServer(t, routeRegister)
+
+		cmd := &dashboardimport.ImportDashboardRequest{
+			Dashboard: simplejson.New(),
+		}
+		jsonBytes, err := json.Marshal(cmd)
+		require.NoError(t, err)
+		req := s.NewPostRequest("/api/dashboards/import", bytes.NewReader(jsonBytes))
+		webtest.RequestWithSignedInUser(req, &user.SignedInUser{
+			UserID: 1,
+			Permissions: map[int64]map[string][]string{
+				1: {dashboards.ActionDashboardsCreate: {}},
+			},
+		})
+		resp, err := s.SendJSON(req)
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+		require.Equal(t, http.StatusForbidden, resp.StatusCode)
 	})
 }
 

--- a/pkg/services/libraryelements/api.go
+++ b/pkg/services/libraryelements/api.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"hash/fnv"
 	"net/http"
-	"strings"
 
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -421,7 +420,7 @@ func (l *LibraryElementService) toLibraryElementError(err error, message string)
 	if errors.Is(err, model.ErrLibraryElementProvisionedFolder) {
 		return response.Error(http.StatusConflict, model.ErrLibraryElementProvisionedFolder.Error(), err)
 	}
-	if err != nil && strings.Contains(err.Error(), "insufficient permissions") {
+	if errors.Is(err, model.ErrLibraryElementInsufficientPermissions) {
 		return response.Error(http.StatusForbidden, err.Error(), err)
 	}
 

--- a/pkg/services/libraryelements/database.go
+++ b/pkg/services/libraryelements/database.go
@@ -182,7 +182,7 @@ func (l *LibraryElementService) CreateElement(c context.Context, signedInUser id
 	err = l.SQLStore.WithTransactionalDbSession(c, func(session *db.Session) error {
 		allowed, err := l.AccessControl.Evaluate(c, signedInUser, ac.EvalPermission(ActionLibraryPanelsCreate, folder.ScopeFoldersProvider.GetResourceScopeUID(folderUID)))
 		if !allowed {
-			return fmt.Errorf("insufficient permissions for creating library panel in folder with UID: '%s'", folderUID)
+			return model.ErrLibraryElementInsufficientPermissions.Errorf("insufficient permissions for creating library panel in folder with UID: '%s'", folderUID)
 		}
 		if err != nil {
 			return err

--- a/pkg/services/libraryelements/database.go
+++ b/pkg/services/libraryelements/database.go
@@ -182,7 +182,7 @@ func (l *LibraryElementService) CreateElement(c context.Context, signedInUser id
 	err = l.SQLStore.WithTransactionalDbSession(c, func(session *db.Session) error {
 		allowed, err := l.AccessControl.Evaluate(c, signedInUser, ac.EvalPermission(ActionLibraryPanelsCreate, folder.ScopeFoldersProvider.GetResourceScopeUID(folderUID)))
 		if !allowed {
-			return model.ErrLibraryElementInsufficientPermissions.Errorf("insufficient permissions for creating library panel in folder with UID: '%s'", folderUID)
+			return fmt.Errorf("%w: folder UID '%s'", model.ErrLibraryElementInsufficientPermissions, folderUID)
 		}
 		if err != nil {
 			return err

--- a/pkg/services/libraryelements/database.go
+++ b/pkg/services/libraryelements/database.go
@@ -181,11 +181,11 @@ func (l *LibraryElementService) CreateElement(c context.Context, signedInUser id
 
 	err = l.SQLStore.WithTransactionalDbSession(c, func(session *db.Session) error {
 		allowed, err := l.AccessControl.Evaluate(c, signedInUser, ac.EvalPermission(ActionLibraryPanelsCreate, folder.ScopeFoldersProvider.GetResourceScopeUID(folderUID)))
-		if !allowed {
-			return fmt.Errorf("%w: folder UID '%s'", model.ErrLibraryElementInsufficientPermissions, folderUID)
-		}
 		if err != nil {
 			return err
+		}
+		if !allowed {
+			return fmt.Errorf("%w: folder UID '%s'", model.ErrLibraryElementInsufficientPermissions, folderUID)
 		}
 		if _, err := session.Insert(&element); err != nil {
 			if l.SQLStore.GetDialect().IsUniqueConstraintViolation(err) {

--- a/pkg/services/libraryelements/model/model.go
+++ b/pkg/services/libraryelements/model/model.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"time"
-
-	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 )
 
 // LibraryElement is the model for library element definitions.
@@ -137,7 +135,7 @@ var (
 	// ErrLibraryElementProvisionedFolder indicates that a library element cannot be created on a provisioned folder.
 	ErrLibraryElementProvisionedFolder = errors.New("resource type not supported in repository-managed folders")
 	// ErrLibraryElementInsufficientPermissions is returned when the caller lacks permission to modify a library element in a folder.
-	ErrLibraryElementInsufficientPermissions = errutil.Forbidden("libraryelements.insufficientPermissions")
+	ErrLibraryElementInsufficientPermissions = errors.New("insufficient permissions for modifying library element")
 )
 
 // Commands

--- a/pkg/services/libraryelements/model/model.go
+++ b/pkg/services/libraryelements/model/model.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"errors"
 	"time"
+
+	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 )
 
 // LibraryElement is the model for library element definitions.
@@ -134,6 +136,8 @@ var (
 	ErrLibraryElementUIDTooLong = errors.New("uid too long, max 40 characters")
 	// ErrLibraryElementProvisionedFolder indicates that a library element cannot be created on a provisioned folder.
 	ErrLibraryElementProvisionedFolder = errors.New("resource type not supported in repository-managed folders")
+	// ErrLibraryElementInsufficientPermissions is returned when the caller lacks permission to modify a library element in a folder.
+	ErrLibraryElementInsufficientPermissions = errutil.Forbidden("libraryelements.insufficientPermissions")
 )
 
 // Commands

--- a/pkg/services/libraryelements/model/model.go
+++ b/pkg/services/libraryelements/model/model.go
@@ -134,8 +134,8 @@ var (
 	ErrLibraryElementUIDTooLong = errors.New("uid too long, max 40 characters")
 	// ErrLibraryElementProvisionedFolder indicates that a library element cannot be created on a provisioned folder.
 	ErrLibraryElementProvisionedFolder = errors.New("resource type not supported in repository-managed folders")
-	// ErrLibraryElementInsufficientPermissions is returned when the caller lacks permission to modify a library element in a folder.
-	ErrLibraryElementInsufficientPermissions = errors.New("insufficient permissions for modifying library element")
+	// ErrLibraryElementInsufficientPermissions is returned when the caller lacks permission to perform a library element operation in a folder.
+	ErrLibraryElementInsufficientPermissions = errors.New("insufficient permissions for library element operation")
 )
 
 // Commands


### PR DESCRIPTION
## Summary

`POST /api/dashboards/import` returned HTTP 500 when the caller lacked permission to create library panels in the target folder. It should have returned 403.

https://github.com/grafana/support-escalations/issues/21936

## Root cause

`libraryelements.LibraryElementService.CreateElement` returned an untyped `fmt.Errorf("insufficient permissions for creating library panel in folder with UID: '%s'", folderUID)`.

- The library elements API handler (`libraryelements/api.go:toLibraryElementError`) mapped this to 403 by string-matching `err.Error()`, so direct library-element endpoints happened to return the correct status.
- Any other caller — in particular `dashboardimport/service.ImportDashboard` → `apierrors.ToDashboardErrorResponse` → `response.ErrOrFallback` — could only recognise typed sentinels. The untyped error fell through to the generic 500 branch.

## Fix

- Introduce `model.ErrLibraryElementInsufficientPermissions`, a plain `errors.New` sentinel that sits alongside the other library element sentinels in `pkg/services/libraryelements/model/model.go`.
- `CreateElement` wraps it with `fmt.Errorf("%w: folder UID '%s'", ..., folderUID)` so `errors.Is` still matches while the folder UID is preserved in the message. Also swap the order so the `Evaluate` error is returned before the `!allowed` branch, matching the convention used elsewhere in the package.
- Library elements API handler uses `errors.Is(..., ErrLibraryElementInsufficientPermissions)` instead of `strings.Contains(err.Error(), "insufficient permissions")`.
- Dashboard import API handler gets the same `errors.Is` check next to its existing `errors.Is(err, utils.ErrDashboardInputMissing)`, mapping the sentinel to 403.
- Added a test case to `TestImportDashboardAPI` that wires a library-panel permission error through the import handler and asserts it surfaces as 403.

## Testing

- `go test ./pkg/services/dashboardimport/api/ -run TestImportDashboardAPI` — passes, including the new `Import service returns a library panel permission error` case.
- `go test ./pkg/services/libraryelements/ -run TestIntegration.*Permission|TestCreate` — passes.
- `go vet ./pkg/services/libraryelements/... ./pkg/services/dashboardimport/...` — clean.

## Checklist

- [x] Tests added for the new behaviour
- [x] No behaviour change for other error paths (sentinel replacement of a string match)
- [x] No schema / migration / feature-flag changes

Fixes gz#225599