### PR TITLE
Alerting: support AWS and Azure Managed Prometheus in alert rule import/conversion

### DIFF
--- a/pkg/services/ngalert/prom/convert.go
+++ b/pkg/services/ngalert/prom/convert.go
@@ -69,6 +69,16 @@ type RulesConfig struct {
 	IsPaused bool
 }
 
+// isValidPrometheusDatasourceType returns true for native Prometheus and Prometheus-compatible managed datasources.
+func isValidPrometheusDatasourceType(dsType string) bool {
+	return dsType == datasources.DS_PROMETHEUS || dsType == datasources.DS_AMAZON_PROMETHEUS || dsType == datasources.DS_AZURE_PROMETHEUS
+}
+
+// isValidPrometheusOrLokiDatasourceType returns true for Prometheus, Prometheus-compatible managed datasources, and Loki.
+func isValidPrometheusOrLokiDatasourceType(dsType string) bool {
+	return isValidPrometheusDatasourceType(dsType) || dsType == datasources.DS_LOKI
+}
+
 var (
 	defaultTimeRange        = 600 * time.Second
 	defaultEvaluationOffset = 0 * time.Minute
@@ -118,7 +128,7 @@ func NewConverter(cfg Config) (*Converter, error) {
 	if cfg.KeepOriginalRuleDefinition == nil {
 		cfg.KeepOriginalRuleDefinition = defaultConfig.KeepOriginalRuleDefinition
 	}
-	if cfg.DatasourceType != datasources.DS_PROMETHEUS && cfg.DatasourceType != datasources.DS_LOKI {
+	if !isValidPrometheusOrLokiDatasourceType(cfg.DatasourceType) {
 		return nil, ErrInvalidDatasourceType.Errorf("invalid datasource type: %s, must be prometheus or loki", cfg.DatasourceType)
 	}
 
@@ -218,7 +228,7 @@ func (p *Converter) convertRule(orgID int64, namespaceUID string, promGroup Prom
 	}
 
 	if isRecordingRule {
-		if p.cfg.TargetDatasourceType != datasources.DS_PROMETHEUS {
+		if !isValidPrometheusDatasourceType(p.cfg.TargetDatasourceType) {
 			return models.AlertRule{}, ErrInvalidTargetDatasourceType.Errorf("invalid target datasource type: %s, must be prometheus", p.cfg.TargetDatasourceType)
 		}
 

--- a/pkg/services/ngalert/prom/convert_test.go
+++ b/pkg/services/ngalert/prom/convert_test.go
@@ -1013,3 +1013,119 @@ func withInternalLabel(l map[string]string) map[string]string {
 
 	return result
 }
+
+func TestNewConverter_SupportedDatasourceTypes(t *testing.T) {
+	testCases := []struct {
+		name        string
+		dsType      string
+		expectError bool
+	}{
+		{
+			name:        "native prometheus datasource",
+			dsType:      datasources.DS_PROMETHEUS,
+			expectError: false,
+		},
+		{
+			name:        "loki datasource",
+			dsType:      datasources.DS_LOKI,
+			expectError: false,
+		},
+		{
+			name:        "amazon managed prometheus datasource",
+			dsType:      datasources.DS_AMAZON_PROMETHEUS,
+			expectError: false,
+		},
+		{
+			name:        "azure managed prometheus datasource",
+			dsType:      datasources.DS_AZURE_PROMETHEUS,
+			expectError: false,
+		},
+		{
+			name:        "unsupported datasource type",
+			dsType:      "unsupported-datasource",
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := Config{
+				DatasourceUID:   "datasource-uid",
+				DatasourceType:  tc.dsType,
+				DefaultInterval: 1 * time.Minute,
+			}
+			_, err := NewConverter(cfg)
+			if tc.expectError {
+				require.Error(t, err)
+				require.ErrorIs(t, err, ErrInvalidDatasourceType)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestPrometheusRulesToGrafana_ManagedPrometheusRecordingRules(t *testing.T) {
+	testCases := []struct {
+		name            string
+		targetDsType    string
+		expectError     bool
+	}{
+		{
+			name:         "recording rule with native prometheus target",
+			targetDsType: datasources.DS_PROMETHEUS,
+			expectError:  false,
+		},
+		{
+			name:         "recording rule with amazon managed prometheus target",
+			targetDsType: datasources.DS_AMAZON_PROMETHEUS,
+			expectError:  false,
+		},
+		{
+			name:         "recording rule with azure managed prometheus target",
+			targetDsType: datasources.DS_AZURE_PROMETHEUS,
+			expectError:  false,
+		},
+		{
+			name:         "recording rule with unsupported target datasource",
+			targetDsType: "mysql",
+			expectError:  true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := Config{
+				DatasourceUID:        "datasource-uid",
+				DatasourceType:       datasources.DS_PROMETHEUS,
+				TargetDatasourceUID:  "target-datasource-uid",
+				TargetDatasourceType: tc.targetDsType,
+				DefaultInterval:      1 * time.Minute,
+			}
+			converter, err := NewConverter(cfg)
+			require.NoError(t, err)
+
+			promGroup := PrometheusRuleGroup{
+				Name: "test-group",
+				Rules: []PrometheusRule{
+					{
+						Record: "some_metric",
+						Expr:   "sum(rate(http_requests_total[5m]))",
+					},
+				},
+			}
+
+			grafanaGroup, err := converter.PrometheusRulesToGrafana(1, "namespace", promGroup)
+			if tc.expectError {
+				require.Error(t, err)
+				require.ErrorIs(t, err, ErrInvalidTargetDatasourceType)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, grafanaGroup)
+				require.Len(t, grafanaGroup.Rules, 1)
+				require.NotNil(t, grafanaGroup.Rules[0].Record)
+				require.Equal(t, "target-datasource-uid", grafanaGroup.Rules[0].Record.TargetDatasourceUID)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What this PR does / why we need it:**

Expands the datasource type allowlist in the Prometheus-to-Grafana alert rule converter to accept AWS Managed Prometheus () and Azure Managed Prometheus ().

These are Prometheus-compatible managed services that expose the identical rule format as native Prometheus. Previously, attempting to import rules from either datasource failed with:



**Which issue(s) this PR fixes:**

Fixes #123144

**Special notes for your reviewer:**

- Extracts validation into  and  helpers for clarity.
- Allows Amazon and Azure Managed Prometheus as **source** datasources for both alerting and recording rules.
- Allows Amazon and Azure Managed Prometheus as **target** datasources for recording rules (they support remote-write).
- Adds unit tests covering all supported and unsupported datasource types.
