### PR TITLE
Connections: redirect /datasources/:id/new to generic new-datasource page

### DIFF
--- a/public/app/features/connections/Connections.tsx
+++ b/public/app/features/connections/Connections.tsx
@@ -74,6 +74,14 @@ export default function Connections() {
         element={<DataSourceDashboardsPage />}
       />
 
+      {/* Redirect /connections/datasources/:id/new to the generic new-datasource page.
+          Some plugin pages or older links may reference plugin-specific /new URLs. */}
+      <Route
+        caseSensitive
+        path={`${ROUTES.DataSourcesDetails.replace(ROUTES.Base, '')}/new`}
+        element={<Navigate replace to={ROUTES.DataSourcesNew} />}
+      />
+
       {/* "Add new connection" page - we don't register a route in case a plugin already registers a standalone page for it */}
       {!isAddNewConnectionPageOverridden && (
         <Route


### PR DESCRIPTION
**What this PR does / why we need it:**

Adds a redirect route so that plugin-specific `/new` URLs (e.g. `/connections/datasources/grafana-testdata-datasource/new`) are handled gracefully instead of falling through to the not-found catch-all and showing a blank/404 page.

**Which issue(s) this PR fixes:**

Fixes #123100

**Special notes for your reviewer:**

- The redirect sends users to the generic `NewDataSourcePage` where they can choose any datasource type.
- This is a defensive fix for URLs that may be generated by plugin readmes, external links, or legacy navigation patterns.
