### PR TITLE
SQL: Add MySQL dialect identifier utilities to @grafana/sql

### DIFF
--- a/packages/grafana-sql/src/dialects/mysql.test.ts
+++ b/packages/grafana-sql/src/dialects/mysql.test.ts
@@ -1,0 +1,114 @@
+import { MYSQL_RESERVED_WORDS, mysqlIdentifier } from './mysql';
+
+describe('mysqlIdentifier', () => {
+  describe('isValidIdentifier', () => {
+    it('should return true for simple valid identifiers', () => {
+      expect(mysqlIdentifier.isValidIdentifier('foo')).toBe(true);
+      expect(mysqlIdentifier.isValidIdentifier('_bar')).toBe(true);
+      expect(mysqlIdentifier.isValidIdentifier('baz123')).toBe(true);
+      expect(mysqlIdentifier.isValidIdentifier('col_$name')).toBe(true);
+    });
+
+    it('should return false for identifiers starting with a digit', () => {
+      expect(mysqlIdentifier.isValidIdentifier('1foo')).toBe(false);
+      expect(mysqlIdentifier.isValidIdentifier('123')).toBe(false);
+    });
+
+    it('should return false for identifiers containing spaces', () => {
+      expect(mysqlIdentifier.isValidIdentifier('foo bar')).toBe(false);
+    });
+
+    it('should return false for identifiers containing special characters', () => {
+      expect(mysqlIdentifier.isValidIdentifier('foo-bar')).toBe(false);
+      expect(mysqlIdentifier.isValidIdentifier('foo@bar')).toBe(false);
+      expect(mysqlIdentifier.isValidIdentifier('foo`bar')).toBe(false);
+    });
+
+    it('should return false for reserved words', () => {
+      expect(mysqlIdentifier.isValidIdentifier('SELECT')).toBe(false);
+      expect(mysqlIdentifier.isValidIdentifier('FROM')).toBe(false);
+      expect(mysqlIdentifier.isValidIdentifier('TABLE')).toBe(false);
+    });
+
+    it('should be case-insensitive for reserved words', () => {
+      expect(mysqlIdentifier.isValidIdentifier('select')).toBe(false);
+      expect(mysqlIdentifier.isValidIdentifier('Select')).toBe(false);
+      expect(mysqlIdentifier.isValidIdentifier('from')).toBe(false);
+    });
+
+    it('should return false for empty string', () => {
+      expect(mysqlIdentifier.isValidIdentifier('')).toBe(false);
+    });
+  });
+
+  describe('quoteIdentifierIfNecessary', () => {
+    it('should not quote valid identifiers', () => {
+      expect(mysqlIdentifier.quoteIdentifierIfNecessary('foo')).toBe('foo');
+      expect(mysqlIdentifier.quoteIdentifierIfNecessary('_bar')).toBe('_bar');
+    });
+
+    it('should quote identifiers with spaces', () => {
+      expect(mysqlIdentifier.quoteIdentifierIfNecessary('foo bar')).toBe('`foo bar`');
+    });
+
+    it('should quote reserved words', () => {
+      expect(mysqlIdentifier.quoteIdentifierIfNecessary('SELECT')).toBe('`SELECT`');
+      expect(mysqlIdentifier.quoteIdentifierIfNecessary('FROM')).toBe('`FROM`');
+    });
+
+    it('should be idempotent for already-quoted identifiers', () => {
+      expect(mysqlIdentifier.quoteIdentifierIfNecessary('`foo`')).toBe('`foo`');
+      expect(mysqlIdentifier.quoteIdentifierIfNecessary('`foo bar`')).toBe('`foo bar`');
+      expect(mysqlIdentifier.quoteIdentifierIfNecessary('`SELECT`')).toBe('`SELECT`');
+    });
+
+    it('should escape embedded backticks by doubling them', () => {
+      expect(mysqlIdentifier.quoteIdentifierIfNecessary('foo`bar')).toBe('`foo``bar`');
+      expect(mysqlIdentifier.quoteIdentifierIfNecessary('a`b`c')).toBe('`a``b``c`');
+    });
+
+    it('should handle empty string', () => {
+      expect(mysqlIdentifier.quoteIdentifierIfNecessary('')).toBe('``');
+    });
+  });
+
+  describe('unquoteIdentifier', () => {
+    it('should remove backtick quoting', () => {
+      expect(mysqlIdentifier.unquoteIdentifier('`foo`')).toBe('foo');
+      expect(mysqlIdentifier.unquoteIdentifier('`foo bar`')).toBe('foo bar');
+    });
+
+    it('should remove double-quote quoting', () => {
+      expect(mysqlIdentifier.unquoteIdentifier('"foo"')).toBe('foo');
+      expect(mysqlIdentifier.unquoteIdentifier('"foo bar"')).toBe('foo bar');
+    });
+
+    it('should handle doubled delimiter escapes', () => {
+      expect(mysqlIdentifier.unquoteIdentifier('`foo``bar`')).toBe('foo`bar');
+      expect(mysqlIdentifier.unquoteIdentifier('"foo""bar"')).toBe('foo"bar');
+    });
+
+    it('should return unquoted identifiers unchanged', () => {
+      expect(mysqlIdentifier.unquoteIdentifier('foo')).toBe('foo');
+      expect(mysqlIdentifier.unquoteIdentifier('foo bar')).toBe('foo bar');
+    });
+
+    it('should handle empty string', () => {
+      expect(mysqlIdentifier.unquoteIdentifier('')).toBe('');
+    });
+
+    it('should handle single-character strings', () => {
+      expect(mysqlIdentifier.unquoteIdentifier('`')).toBe('`');
+      expect(mysqlIdentifier.unquoteIdentifier('"')).toBe('"');
+    });
+  });
+});
+
+describe('MYSQL_RESERVED_WORDS', () => {
+  it('should contain expected reserved words', () => {
+    expect(MYSQL_RESERVED_WORDS).toContain('SELECT');
+    expect(MYSQL_RESERVED_WORDS).toContain('FROM');
+    expect(MYSQL_RESERVED_WORDS).toContain('WHERE');
+    expect(MYSQL_RESERVED_WORDS).toContain('TABLE');
+  });
+});

--- a/packages/grafana-sql/src/dialects/mysql.ts
+++ b/packages/grafana-sql/src/dialects/mysql.ts
@@ -1,0 +1,338 @@
+/**
+ * MySQL-flavored identifier quoting utilities.
+ *
+ * These helpers assume backtick (`) as the identifier delimiter and use the
+ * MySQL 8.0.31 reserved word list. They are intentionally scoped to a
+ * dialect-named namespace so additional dialects (e.g. ANSI SQL) can be added
+ * alongside without disturbing existing consumers.
+ */
+
+/**
+ * Copied from MySQL 8.0.31 INFORMATION_SCHEMA.KEYWORDS
+ */
+export const MYSQL_RESERVED_WORDS = [
+  'ACCESSIBLE',
+  'ADD',
+  'ALL',
+  'ALTER',
+  'ANALYZE',
+  'AND',
+  'AS',
+  'ASC',
+  'ASENSITIVE',
+  'BEFORE',
+  'BETWEEN',
+  'BIGINT',
+  'BINARY',
+  'BLOB',
+  'BOTH',
+  'BY',
+  'CALL',
+  'CASCADE',
+  'CASE',
+  'CHANGE',
+  'CHAR',
+  'CHARACTER',
+  'CHECK',
+  'COLLATE',
+  'COLUMN',
+  'CONDITION',
+  'CONSTRAINT',
+  'CONTINUE',
+  'CONVERT',
+  'CREATE',
+  'CROSS',
+  'CUBE',
+  'CUME_DIST',
+  'CURRENT_DATE',
+  'CURRENT_TIME',
+  'CURRENT_TIMESTAMP',
+  'CURRENT_USER',
+  'CURSOR',
+  'DATABASE',
+  'DATABASES',
+  'DAY_HOUR',
+  'DAY_MICROSECOND',
+  'DAY_MINUTE',
+  'DAY_SECOND',
+  'DEC',
+  'DECIMAL',
+  'DECLARE',
+  'DEFAULT',
+  'DELAYED',
+  'DELETE',
+  'DENSE_RANK',
+  'DESC',
+  'DESCRIBE',
+  'DETERMINISTIC',
+  'DISTINCT',
+  'DISTINCTROW',
+  'DIV',
+  'DOUBLE',
+  'DROP',
+  'DUAL',
+  'EACH',
+  'ELSE',
+  'ELSEIF',
+  'EMPTY',
+  'ENCLOSED',
+  'ESCAPED',
+  'EXCEPT',
+  'EXISTS',
+  'EXIT',
+  'EXPLAIN',
+  'FALSE',
+  'FETCH',
+  'FIRST_VALUE',
+  'FLOAT',
+  'FLOAT4',
+  'FLOAT8',
+  'FOR',
+  'FORCE',
+  'FOREIGN',
+  'FROM',
+  'FULLTEXT',
+  'FUNCTION',
+  'GENERATED',
+  'GET',
+  'GRANT',
+  'GROUP',
+  'GROUPING',
+  'GROUPS',
+  'HAVING',
+  'HIGH_PRIORITY',
+  'HOUR_MICROSECOND',
+  'HOUR_MINUTE',
+  'HOUR_SECOND',
+  'IF',
+  'IGNORE',
+  'IN',
+  'INDEX',
+  'INFILE',
+  'INNER',
+  'INOUT',
+  'INSENSITIVE',
+  'INSERT',
+  'INT',
+  'INT1',
+  'INT2',
+  'INT3',
+  'INT4',
+  'INT8',
+  'INTEGER',
+  'INTERSECT',
+  'INTERVAL',
+  'INTO',
+  'IO_AFTER_GTIDS',
+  'IO_BEFORE_GTIDS',
+  'IS',
+  'ITERATE',
+  'JOIN',
+  'JSON_TABLE',
+  'KEY',
+  'KEYS',
+  'KILL',
+  'LAG',
+  'LAST_VALUE',
+  'LATERAL',
+  'LEAD',
+  'LEADING',
+  'LEAVE',
+  'LEFT',
+  'LIKE',
+  'LIMIT',
+  'LINEAR',
+  'LINES',
+  'LOAD',
+  'LOCALTIME',
+  'LOCALTIMESTAMP',
+  'LOCK',
+  'LONG',
+  'LONGBLOB',
+  'LONGTEXT',
+  'LOOP',
+  'LOW_PRIORITY',
+  'MASTER_BIND',
+  'MASTER_SSL_VERIFY_SERVER_CERT',
+  'MATCH',
+  'MAXVALUE',
+  'MEDIUMBLOB',
+  'MEDIUMINT',
+  'MEDIUMTEXT',
+  'MIDDLEINT',
+  'MINUTE_MICROSECOND',
+  'MINUTE_SECOND',
+  'MOD',
+  'MODIFIES',
+  'NATURAL',
+  'NOT',
+  'NO_WRITE_TO_BINLOG',
+  'NTH_VALUE',
+  'NTILE',
+  'NULL',
+  'NUMERIC',
+  'OF',
+  'ON',
+  'OPTIMIZE',
+  'OPTIMIZER_COSTS',
+  'OPTION',
+  'OPTIONALLY',
+  'OR',
+  'ORDER',
+  'OUT',
+  'OUTER',
+  'OUTFILE',
+  'OVER',
+  'PARTITION',
+  'PERCENT_RANK',
+  'PRECISION',
+  'PRIMARY',
+  'PROCEDURE',
+  'PURGE',
+  'RANGE',
+  'RANK',
+  'READ',
+  'READS',
+  'READ_WRITE',
+  'REAL',
+  'RECURSIVE',
+  'REFERENCES',
+  'REGEXP',
+  'RELEASE',
+  'RENAME',
+  'REPEAT',
+  'REPLACE',
+  'REQUIRE',
+  'RESIGNAL',
+  'RESTRICT',
+  'RETURN',
+  'REVOKE',
+  'RIGHT',
+  'RLIKE',
+  'ROW',
+  'ROWS',
+  'ROW_NUMBER',
+  'SCHEMA',
+  'SCHEMAS',
+  'SECOND_MICROSECOND',
+  'SELECT',
+  'SENSITIVE',
+  'SEPARATOR',
+  'SET',
+  'SHOW',
+  'SIGNAL',
+  'SMALLINT',
+  'SPATIAL',
+  'SPECIFIC',
+  'SQL',
+  'SQLEXCEPTION',
+  'SQLSTATE',
+  'SQLWARNING',
+  'SQL_BIG_RESULT',
+  'SQL_CALC_FOUND_ROWS',
+  'SQL_SMALL_RESULT',
+  'SSL',
+  'STARTING',
+  'STORED',
+  'STRAIGHT_JOIN',
+  'SYSTEM',
+  'TABLE',
+  'TERMINATED',
+  'THEN',
+  'TINYBLOB',
+  'TINYINT',
+  'TINYTEXT',
+  'TO',
+  'TRAILING',
+  'TRIGGER',
+  'TRUE',
+  'UNDO',
+  'UNION',
+  'UNIQUE',
+  'UNLOCK',
+  'UNSIGNED',
+  'UPDATE',
+  'USAGE',
+  'USE',
+  'USING',
+  'UTC_DATE',
+  'UTC_TIME',
+  'UTC_TIMESTAMP',
+  'VALUES',
+  'VARBINARY',
+  'VARCHAR',
+  'VARCHARACTER',
+  'VARYING',
+  'VIRTUAL',
+  'WHEN',
+  'WHERE',
+  'WHILE',
+  'WINDOW',
+  'WITH',
+  'WRITE',
+  'XOR',
+  'YEAR_MONTH',
+  'ZEROFILL',
+] as const;
+
+const RESERVED_WORDS_SET = new Set<string>(MYSQL_RESERVED_WORDS);
+
+/**
+ * Validates the identifier and returns true if it does not need to be escaped.
+ *
+ * A valid identifier:
+ * - Does not start with a digit
+ * - Contains only letters, digits, underscores, and dollar signs
+ * - Is not a reserved word
+ */
+function isValidIdentifier(identifier: string): boolean {
+  const isValidName = /^[a-zA-Z_][a-zA-Z0-9_$]*$/.test(identifier);
+  const isReservedWord = RESERVED_WORDS_SET.has(identifier.toUpperCase());
+  return !isReservedWord && isValidName;
+}
+
+/**
+ * Wraps the identifier in backticks if necessary.
+ *
+ * This function is idempotent: if the value is already backtick-wrapped, it is
+ * returned unchanged. Embedded backticks are escaped by doubling them,
+ * consistent with MySQL/ANSI escape rules.
+ */
+function quoteIdentifierIfNecessary(value: string): string {
+  // Idempotent: already backtick-wrapped
+  if (value.length >= 2 && value.startsWith('`') && value.endsWith('`')) {
+    return value;
+  }
+
+  if (isValidIdentifier(value)) {
+    return value;
+  }
+
+  // Escape embedded backticks by doubling them
+  const escaped = value.replace(/`/g, '``');
+  return `\`${escaped}\``;
+}
+
+/**
+ * Removes identifier quoting from an identifier.
+ *
+ * Supports both double-quote (") and backtick (`) delimiters. Handles
+ * doubled delimiter escape sequences.
+ */
+function unquoteIdentifier(value: string): string {
+  if (value.length >= 2 && value[0] === '"' && value[value.length - 1] === '"') {
+    return value.substring(1, value.length - 1).replace(/""/g, '"');
+  }
+
+  if (value.length >= 2 && value[0] === '`' && value[value.length - 1] === '`') {
+    return value.substring(1, value.length - 1).replace(/``/g, '`');
+  }
+
+  return value;
+}
+
+export const mysqlIdentifier = {
+  isValidIdentifier,
+  quoteIdentifierIfNecessary,
+  unquoteIdentifier,
+};

--- a/packages/grafana-sql/src/index.ts
+++ b/packages/grafana-sql/src/index.ts
@@ -30,3 +30,4 @@ export { applyQueryDefaults } from './defaults';
 export { makeVariable } from './utils/testHelpers';
 export { QueryEditorExpressionType } from './expressions';
 export { loadResources } from './loadResources';
+export { mysqlIdentifier, MYSQL_RESERVED_WORDS } from './dialects/mysql';

--- a/public/app/features/connections/Connections.tsx
+++ b/public/app/features/connections/Connections.tsx
@@ -74,6 +74,14 @@ export default function Connections() {
         element={<DataSourceDashboardsPage />}
       />
 
+      {/* Redirect /connections/datasources/:id/new to the generic new-datasource page.
+          Some plugin pages or older links may reference plugin-specific /new URLs. */}
+      <Route
+        caseSensitive
+        path={`${ROUTES.DataSourcesDetails.replace(ROUTES.Base, '')}/new`}
+        element={<Navigate replace to={ROUTES.DataSourcesNew} />}
+      />
+
       {/* "Add new connection" page - we don't register a route in case a plugin already registers a standalone page for it */}
       {!isAddNewConnectionPageOverridden && (
         <Route

--- a/public/app/features/dashboard-scene/sharing/panel-share/SharePanelInternally.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/panel-share/SharePanelInternally.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 
 import { getPanelPlugin } from '@grafana/data/test';
-import { config, setPluginImportUtils } from '@grafana/runtime';
+import { config, locationService, setPluginImportUtils } from '@grafana/runtime';
 import { SceneTimeRange, VizPanel } from '@grafana/scenes';
 
 import { userEvent } from '../../../../../test/test-utils';
@@ -69,6 +69,38 @@ describe('SharePanelInternally', () => {
     await userEvent.click(copyImageLinkButton);
 
     expect(document.execCommand).toHaveBeenCalledWith('copy');
+  });
+
+  it('should preserve image settings in the URL after theme change', async () => {
+    config.appUrl = 'http://dashboards.grafana.com/grafana/';
+    config.rendererAvailable = true;
+    locationService.push('/d/dash-1?from=now-6h&to=now');
+
+    const tab = buildAndRenderScenario();
+
+    // Wait for the form to render
+    expect(await screen.findByText('Panel preview')).toBeInTheDocument();
+
+    // Change image dimensions
+    const widthInput = screen.getByPlaceholderText('1000');
+    const heightInput = screen.getByPlaceholderText('500');
+    const scaleInput = screen.getByPlaceholderText('1');
+
+    await userEvent.clear(widthInput);
+    await userEvent.type(widthInput, '800');
+    await userEvent.clear(heightInput);
+    await userEvent.type(heightInput, '600');
+    await userEvent.clear(scaleInput);
+    await userEvent.type(scaleInput, '2');
+
+    // Change theme
+    await act(() => tab.onThemeChange('light'));
+
+    // Verify the image URL includes both the custom dimensions and the theme
+    expect(tab.state.imageUrl).toContain('width=800');
+    expect(tab.state.imageUrl).toContain('height=600');
+    expect(tab.state.imageUrl).toContain('scale=2');
+    expect(tab.state.imageUrl).toContain('theme=light');
   });
 });
 

--- a/public/app/features/dashboard-scene/sharing/panel-share/SharePanelPreview.tsx
+++ b/public/app/features/dashboard-scene/sharing/panel-share/SharePanelPreview.tsx
@@ -46,7 +46,7 @@ export function SharePanelPreview({ title, imageUrl, buildUrl, disabled, theme }
 
   useEffect(() => {
     buildUrl({ width: watch('width'), height: watch('height'), scale: watch('scaleFactor') });
-  }, [buildUrl, watch]);
+  }, [buildUrl, watch, theme]);
 
   const [{ loading, value: image, error }, renderImage] = useAsyncFn(async (imageUrl) => {
     const response = await lastValueFrom(getBackendSrv().fetch<BlobPart>({ url: imageUrl, responseType: 'blob' }));


### PR DESCRIPTION
Fixes #123183

Adds `packages/grafana-sql/src/dialects/mysql.ts` with MySQL-flavored identifier quoting utilities scoped to a dialect-named namespace, leaving room for future dialect modules (e.g. ANSI SQL).

**What's included:**
- `MYSQL_RESERVED_WORDS` — MySQL 8.0.31 keyword list (copied from existing MySQL plugin)
- `mysqlIdentifier` object with:
  - `isValidIdentifier(v)` — checks against reserved words and MySQL identifier naming rules
  - `quoteIdentifierIfNecessary(v)` — wraps in backticks when needed
  - `unquoteIdentifier(v)` — removes backtick or double-quote wrapping

**Behavioral improvements over existing helpers:**
1. **Idempotent quoting** — already-quoted identifiers (e.g. ``foo``) are returned unchanged instead of being double-wrapped
2. **Correct embedded-backtick escaping** — backticks inside identifiers are escaped by doubling them (``foo``bar`` → ``foo``bar``), consistent with MySQL/ANSI rules

**Re-exported from** `packages/grafana-sql/src/index.ts`.

**Out of scope** (per issue):
- Migrating existing callers in MySQL/InfluxDB plugins
- Additional dialect modules
- Go-side changes