### PR TITLE
Alerting: fix UpdateAdminConfiguration updating wrong rows when multiple orgs exist

### DIFF
--- a/pkg/services/ngalert/store/admin_configuration.go
+++ b/pkg/services/ngalert/store/admin_configuration.go
@@ -77,7 +77,8 @@ func (st DBstore) DeleteAdminConfiguration(orgID int64) error {
 
 func (st DBstore) UpdateAdminConfiguration(cmd UpdateAdminConfigurationCmd) error {
 	return st.SQLStore.WithTransactionalDbSession(context.Background(), func(sess *db.Session) error {
-		has, err := sess.Table("ngalert_configuration").Where("org_id = ?", cmd.AdminConfiguration.OrgID).Exist()
+		existing := &ngmodels.AdminConfiguration{}
+		has, err := sess.Table("ngalert_configuration").Where("org_id = ?", cmd.AdminConfiguration.OrgID).Get(existing)
 		if err != nil {
 			return err
 		}
@@ -87,9 +88,11 @@ func (st DBstore) UpdateAdminConfiguration(cmd UpdateAdminConfigurationCmd) erro
 			return err
 		}
 
-		_, err = sess.Table("ngalert_configuration").Where("org_id = ?", cmd.AdminConfiguration.OrgID).Cols(
-			buildUpdateCols(cmd.AdminConfiguration)...,
-		).Update(cmd.AdminConfiguration)
+		cols := buildUpdateCols(cmd.AdminConfiguration)
+		if len(cols) == 0 {
+			return nil
+		}
+		_, err = sess.Table("ngalert_configuration").ID(existing.ID).Cols(cols...).Update(cmd.AdminConfiguration)
 		return err
 	})
 }

--- a/pkg/services/ngalert/store/admin_configuration_test.go
+++ b/pkg/services/ngalert/store/admin_configuration_test.go
@@ -1,0 +1,75 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/infra/log"
+	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/util/testutil"
+)
+
+func TestIntegrationUpdateAdminConfiguration(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	sqlStore := db.InitTestDB(t)
+	store := &DBstore{
+		SQLStore: sqlStore,
+		Logger:   log.NewNopLogger(),
+	}
+
+	sendTo := ngmodels.ExternalAlertmanagers
+
+	t.Run("insert when no config exists", func(t *testing.T) {
+		err := store.UpdateAdminConfiguration(UpdateAdminConfigurationCmd{
+			AdminConfiguration: &ngmodels.AdminConfiguration{
+				OrgID:        1,
+				SendAlertsTo: &sendTo,
+			},
+		})
+		require.NoError(t, err)
+
+		cfg, err := store.GetAdminConfiguration(1)
+		require.NoError(t, err)
+		require.Equal(t, ngmodels.ExternalAlertmanagers, *cfg.SendAlertsTo)
+	})
+
+	t.Run("update existing config does not affect other orgs", func(t *testing.T) {
+		// Create configs for two more orgs.
+		for _, orgID := range []int64{2, 3} {
+			err := store.UpdateAdminConfiguration(UpdateAdminConfigurationCmd{
+				AdminConfiguration: &ngmodels.AdminConfiguration{
+					OrgID:        orgID,
+					SendAlertsTo: &sendTo,
+				},
+			})
+			require.NoError(t, err)
+		}
+
+		// Update org 2 — this triggered the missing-WHERE bug when multiple orgs existed.
+		internal := ngmodels.InternalAlertmanager
+		err := store.UpdateAdminConfiguration(UpdateAdminConfigurationCmd{
+			AdminConfiguration: &ngmodels.AdminConfiguration{
+				OrgID:        2,
+				SendAlertsTo: &internal,
+			},
+		})
+		require.NoError(t, err)
+
+		// Org 2 should reflect the update.
+		cfg2, err := store.GetAdminConfiguration(2)
+		require.NoError(t, err)
+		require.Equal(t, ngmodels.InternalAlertmanager, *cfg2.SendAlertsTo)
+
+		// Org 1 and 3 must be untouched.
+		cfg1, err := store.GetAdminConfiguration(1)
+		require.NoError(t, err)
+		require.Equal(t, ngmodels.ExternalAlertmanagers, *cfg1.SendAlertsTo)
+
+		cfg3, err := store.GetAdminConfiguration(3)
+		require.NoError(t, err)
+		require.Equal(t, ngmodels.ExternalAlertmanagers, *cfg3.SendAlertsTo)
+	})
+}


### PR DESCRIPTION
## Summary

- `UpdateAdminConfiguration` used xorm's fluent `Where` + `Update(struct)` pattern, but xorm resolves the target row by primary key when a struct is passed — the `WHERE org_id = ?` clause was silently ignored, causing all rows to be updated when multiple orgs had a configuration
- Fix: fetch the existing row first to get its PK, then use `.ID(existing.ID)` so the UPDATE is scoped to exactly that one record
- Added a guard for the no-op case when `buildUpdateCols` returns no columns
- Added an integration test (`TestIntegrationUpdateAdminConfiguration`) that verifies updating one org's config does not affect other orgs

## Test plan

- [ ] Run integration test: `go test -run TestIntegrationUpdateAdminConfiguration ./pkg/services/ngalert/store/`
- [ ] Verify CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)