### PR TITLE
Alerting: Small improvements to instance drawer drilldown silence flow

### DIFF
--- a/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawer.tsx
+++ b/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawer.tsx
@@ -4,7 +4,7 @@ import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'rea
 import { useMeasure } from 'react-use';
 
 import { type GrafanaTheme2, type Labels } from '@grafana/data';
-import { t } from '@grafana/i18n';
+import { Trans, t } from '@grafana/i18n';
 import { config, isFetchError } from '@grafana/runtime';
 import { TimeRangePicker, useTimeRange } from '@grafana/scenes-react';
 import {
@@ -323,9 +323,8 @@ export function InstanceDetailsDrawer({ ruleUID, instanceLabels, commonLabels, o
             <InstanceDetailsDrawerTitle
               {...sharedTitleProps}
               rule={rule.grafana_alert}
-              titleText={t('alerting.triage.instance-details-drawer.silence-title-with-name', 'Silence {{name}}', {
-                name: rule.grafana_alert.title,
-              })}
+              sectionLabel={<Trans i18nKey="alerting.triage.instance-details-drawer.section-silence">Silence</Trans>}
+              titleText={rule.grafana_alert.title}
               hideActions
               showAlertState={false}
               titleSection={<DrawerBackButton onClick={handleBack} />}

--- a/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawerTitle.tsx
+++ b/public/app/features/alerting/unified/triage/instance-details/InstanceDetailsDrawerTitle.tsx
@@ -49,6 +49,8 @@ interface InstanceDetailsDrawerTitleProps {
   rule?: GrafanaRuleDefinition;
   onOpenSilence?: () => void;
   titleText?: string;
+  /** Overrides the muted label above the title (defaults to Alert Instance). */
+  sectionLabel?: ReactNode;
   hideActions?: boolean;
   titleSection?: ReactNode;
   showAlertState?: boolean;
@@ -61,6 +63,7 @@ export function InstanceDetailsDrawerTitle({
   rule,
   onOpenSilence,
   titleText,
+  sectionLabel,
   hideActions = false,
   titleSection,
   showAlertState = true,
@@ -100,7 +103,9 @@ export function InstanceDetailsDrawerTitle({
       )}
       <Stack direction="column" gap={0.5}>
         <Text variant="bodySmall" color="secondary">
-          <Trans i18nKey="alerting.triage.instance-details-drawer.alert-instance-label">Alert Instance</Trans>
+          {sectionLabel ?? (
+            <Trans i18nKey="alerting.triage.instance-details-drawer.alert-instance-label">Alert Instance</Trans>
+          )}
         </Text>
         <Stack direction="row" alignItems="center" justifyContent="space-between" gap={1}>
           <Stack direction="row" alignItems="center" gap={1} minWidth={0}>

--- a/public/app/features/alerting/unified/triage/instance-details/InstanceSilenceForm.tsx
+++ b/public/app/features/alerting/unified/triage/instance-details/InstanceSilenceForm.tsx
@@ -34,7 +34,6 @@ export function InstanceSilenceForm({ ruleUid, instanceLabels, onClose }: Instan
         alertManagerSourceName={GRAFANA_RULES_SOURCE_NAME}
         onSilenceCreated={onClose}
         onCancel={onClose}
-        showCancelButton={false}
       />
     </AlertmanagerProvider>
   );

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3589,9 +3589,9 @@
         "declare-incident": "Declare incident",
         "declare-incident-no-permission": "You do not have permission to access Incident",
         "instance-details": "Instance details",
+        "section-silence": "Silence",
         "silence-button": "Silence",
-        "silence-no-permission": "You do not have permission to create silences",
-        "silence-title-with-name": "Silence {{name}}"
+        "silence-no-permission": "You do not have permission to create silences"
       },
       "labels-column-title": "Labels",
       "no-firing-or-pending-instances": "You have no alert instances in a firing or pending state for the selected time range.",


### PR DESCRIPTION
This PR makes minor improvements to the silence instance drawer in Alerts Activity
- Restores Cancel button in the silence form drawer
- Sets the section label to 'Silence' on the silence drawer instead of Alert Instance
- Sets the drawer title to the instance name

<img width="1255" height="826" alt="image" src="https://github.com/user-attachments/assets/694edf0a-49e7-43bc-a265-7644d8f9d658" />
