### PR TITLE
Authz: Add concurrency limiter to zanzana gRPC server

### DIFF
--- a/pkg/services/authz/zanzana/server/admission.go
+++ b/pkg/services/authz/zanzana/server/admission.go
@@ -1,0 +1,60 @@
+package server
+
+import (
+	"sync"
+
+	"golang.org/x/sync/semaphore"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+func (s *Server) acquireSlot(method, namespace string) (release func(), err error) {
+	var nl *semaphore.Weighted
+
+	if s.globalSem != nil {
+		if !s.globalSem.TryAcquire(1) {
+			s.metrics.rejectedRequests.WithLabelValues(method, "global").Inc()
+			return nil, status.Error(codes.ResourceExhausted, "server concurrency limit reached")
+		}
+		defer func() {
+			if err != nil {
+				s.globalSem.Release(1)
+			}
+		}()
+	}
+
+	if s.nsLimiterSize > 0 {
+		nl = s.getOrCreateNamespaceLimiter(namespace)
+		if !nl.TryAcquire(1) {
+			s.metrics.rejectedRequests.WithLabelValues(method, "namespace").Inc()
+			return nil, status.Error(codes.ResourceExhausted, "namespace concurrency limit reached")
+		}
+	}
+
+	s.metrics.inflightRequests.WithLabelValues(method).Inc()
+
+	var once sync.Once
+	release = func() {
+		once.Do(func() {
+			s.metrics.inflightRequests.WithLabelValues(method).Dec()
+			if nl != nil {
+				nl.Release(1)
+			}
+			if s.globalSem != nil {
+				s.globalSem.Release(1)
+			}
+		})
+	}
+
+	return release, nil
+}
+
+func (s *Server) getOrCreateNamespaceLimiter(namespace string) *semaphore.Weighted {
+	if v, ok := s.namespaceLimiters.Load(namespace); ok {
+		return v.(*semaphore.Weighted)
+	}
+
+	sem := semaphore.NewWeighted(s.nsLimiterSize)
+	actual, _ := s.namespaceLimiters.LoadOrStore(namespace, sem)
+	return actual.(*semaphore.Weighted)
+}

--- a/pkg/services/authz/zanzana/server/admission_test.go
+++ b/pkg/services/authz/zanzana/server/admission_test.go
@@ -1,0 +1,167 @@
+package server
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sync/semaphore"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+func newTestServerWithLimits(maxGlobal, maxPerNS int) *Server {
+	cfg := setting.ZanzanaServerSettings{
+		MaxConcurrentRequests:             maxGlobal,
+		MaxConcurrentRequestsPerNamespace: maxPerNS,
+	}
+
+	s := &Server{
+		cfg:           cfg,
+		metrics:       newZanzanaServerMetrics(prometheus.NewRegistry()),
+		nsLimiterSize: int64(maxPerNS),
+	}
+
+	if maxGlobal > 0 {
+		s.globalSem = semaphore.NewWeighted(int64(maxGlobal))
+	}
+
+	return s
+}
+
+func TestAcquireSlot_Disabled(t *testing.T) {
+	s := newTestServerWithLimits(0, 0)
+
+	for i := 0; i < 100; i++ {
+		release, err := s.acquireSlot("Check", "ns-a")
+		require.NoError(t, err)
+		defer release()
+	}
+}
+
+func TestAcquireSlot_GlobalLimit(t *testing.T) {
+	s := newTestServerWithLimits(2, 0)
+
+	r1, err := s.acquireSlot("Check", "ns-a")
+	require.NoError(t, err)
+
+	r2, err := s.acquireSlot("Check", "ns-b")
+	require.NoError(t, err)
+
+	// 3rd should fail
+	_, err = s.acquireSlot("Check", "ns-c")
+	require.Error(t, err)
+	assert.Equal(t, codes.ResourceExhausted, status.Code(err))
+	assert.Contains(t, err.Error(), "server concurrency limit reached")
+
+	// Release one, next should succeed
+	r1()
+	r3, err := s.acquireSlot("Check", "ns-c")
+	require.NoError(t, err)
+	r2()
+	r3()
+}
+
+func TestAcquireSlot_NamespaceLimit(t *testing.T) {
+	s := newTestServerWithLimits(10, 1)
+
+	r1, err := s.acquireSlot("Check", "ns-a")
+	require.NoError(t, err)
+
+	// 2nd for same namespace should fail
+	_, err = s.acquireSlot("Check", "ns-a")
+	require.Error(t, err)
+	assert.Equal(t, codes.ResourceExhausted, status.Code(err))
+	assert.Contains(t, err.Error(), "namespace concurrency limit reached")
+
+	// Different namespace should succeed
+	r2, err := s.acquireSlot("Check", "ns-b")
+	require.NoError(t, err)
+
+	r1()
+	r2()
+}
+
+func TestAcquireSlot_GlobalBeforeNamespace(t *testing.T) {
+	s := newTestServerWithLimits(1, 5)
+
+	r1, err := s.acquireSlot("Check", "ns-a")
+	require.NoError(t, err)
+
+	// Different namespace also fails — global is full
+	_, err = s.acquireSlot("Check", "ns-b")
+	require.Error(t, err)
+	assert.Equal(t, codes.ResourceExhausted, status.Code(err))
+	assert.Contains(t, err.Error(), "server concurrency limit reached")
+
+	r1()
+}
+
+func TestAcquireSlot_ReleaseRestoresBoth(t *testing.T) {
+	s := newTestServerWithLimits(1, 1)
+
+	release, err := s.acquireSlot("Check", "ns-a")
+	require.NoError(t, err)
+
+	// Both global and namespace are full
+	_, err = s.acquireSlot("Check", "ns-a")
+	require.Error(t, err)
+
+	_, err = s.acquireSlot("Check", "ns-b")
+	require.Error(t, err)
+
+	// After release, both should be available again
+	release()
+
+	r1, err := s.acquireSlot("Check", "ns-a")
+	require.NoError(t, err)
+	r1()
+}
+
+func TestAcquireSlot_ReleaseIsIdempotent(t *testing.T) {
+	s := newTestServerWithLimits(1, 1)
+
+	release, err := s.acquireSlot("Check", "ns-a")
+	require.NoError(t, err)
+
+	// Calling release multiple times should not panic or double-release
+	release()
+	release()
+	release()
+
+	// Should still be able to acquire
+	r, err := s.acquireSlot("Check", "ns-a")
+	require.NoError(t, err)
+	r()
+}
+
+func TestAcquireSlot_MetricsIncDec(t *testing.T) {
+	s := newTestServerWithLimits(10, 0)
+
+	release, err := s.acquireSlot("Check", "ns-a")
+	require.NoError(t, err)
+
+	assert.Equal(t, 1.0, testutil.ToFloat64(s.metrics.inflightRequests.WithLabelValues("Check")))
+
+	release()
+
+	assert.Equal(t, 0.0, testutil.ToFloat64(s.metrics.inflightRequests.WithLabelValues("Check")))
+}
+
+func TestAcquireSlot_RejectionMetrics(t *testing.T) {
+	s := newTestServerWithLimits(1, 0)
+
+	r, err := s.acquireSlot("Check", "ns-a")
+	require.NoError(t, err)
+
+	_, err = s.acquireSlot("Check", "ns-b")
+	require.Error(t, err)
+
+	assert.Equal(t, 1.0, testutil.ToFloat64(s.metrics.rejectedRequests.WithLabelValues("Check", "global")))
+
+	r()
+}

--- a/pkg/services/authz/zanzana/server/metrics.go
+++ b/pkg/services/authz/zanzana/server/metrics.go
@@ -15,6 +15,10 @@ type metrics struct {
 	requestDurationSeconds *prometheus.HistogramVec
 	// batchCheckPhaseDurationSeconds measures the duration of each batch check phase
 	batchCheckPhaseDurationSeconds *prometheus.HistogramVec
+	// inflightRequests tracks current in-flight requests by method
+	inflightRequests *prometheus.GaugeVec
+	// rejectedRequests counts requests rejected by the concurrency limiter
+	rejectedRequests *prometheus.CounterVec
 }
 
 func newZanzanaServerMetrics(reg prometheus.Registerer) *metrics {
@@ -38,6 +42,24 @@ func newZanzanaServerMetrics(reg prometheus.Registerer) *metrics {
 				Buckets:   prometheus.ExponentialBuckets(0.00001, 4, 10),
 			},
 			[]string{"phase"},
+		),
+		inflightRequests: promauto.With(reg).NewGaugeVec(
+			prometheus.GaugeOpts{
+				Name:      "inflight_requests",
+				Help:      "Current number of in-flight requests",
+				Namespace: metricsNamespace,
+				Subsystem: metricsSubSystem,
+			},
+			[]string{"method"},
+		),
+		rejectedRequests: promauto.With(reg).NewCounterVec(
+			prometheus.CounterOpts{
+				Name:      "rejected_requests_total",
+				Help:      "Total requests rejected by the concurrency limiter",
+				Namespace: metricsNamespace,
+				Subsystem: metricsSubSystem,
+			},
+			[]string{"method", "limiter"},
 		),
 	}
 }

--- a/pkg/services/authz/zanzana/server/server.go
+++ b/pkg/services/authz/zanzana/server/server.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/sync/semaphore"
 	"golang.org/x/sync/singleflight"
 
 	"github.com/fullstorydev/grpchan/inprocgrpc"
@@ -65,6 +66,10 @@ type Server struct {
 	logger  log.Logger
 	tracer  tracing.Tracer
 	metrics *metrics
+
+	globalSem         *semaphore.Weighted
+	namespaceLimiters sync.Map
+	nsLimiterSize     int64
 }
 
 func NewEmbeddedZanzanaServer(cfg *setting.Cfg, store storage.OpenFGADatastore, logger log.Logger, tracer tracing.Tracer, reg prometheus.Registerer, restConfig apiserver.RestConfigProvider, reconcileCRDs []schema.GroupVersionResource) (*Server, error) {
@@ -102,6 +107,11 @@ func newServer(cfg *setting.Cfg, openfga OpenFGAServer, store storage.OpenFGADat
 		logger:        logger,
 		tracer:        tracer,
 		metrics:       newZanzanaServerMetrics(reg),
+		nsLimiterSize: int64(zanzanaCfg.MaxConcurrentRequestsPerNamespace),
+	}
+
+	if zanzanaCfg.MaxConcurrentRequests > 0 {
+		s.globalSem = semaphore.NewWeighted(int64(zanzanaCfg.MaxConcurrentRequests))
 	}
 
 	var clientFactory resources.ClientFactory

--- a/pkg/services/authz/zanzana/server/server_batch_check.go
+++ b/pkg/services/authz/zanzana/server/server_batch_check.go
@@ -31,6 +31,12 @@ type batchCheckItem struct {
 }
 
 func (s *Server) BatchCheck(ctx context.Context, r *authzv1.BatchCheckRequest) (*authzv1.BatchCheckResponse, error) {
+	release, err := s.acquireSlot("BatchCheck", r.GetNamespace())
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+
 	ctx, span := s.tracer.Start(ctx, "server.BatchCheck")
 	defer span.End()
 	span.SetAttributes(

--- a/pkg/services/authz/zanzana/server/server_check.go
+++ b/pkg/services/authz/zanzana/server/server_check.go
@@ -17,6 +17,12 @@ import (
 )
 
 func (s *Server) Check(ctx context.Context, r *authzv1.CheckRequest) (*authzv1.CheckResponse, error) {
+	release, err := s.acquireSlot("Check", r.GetNamespace())
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+
 	ctx, span := s.tracer.Start(ctx, "server.Check")
 	defer span.End()
 	span.SetAttributes(attribute.String("namespace", r.GetNamespace()))

--- a/pkg/services/authz/zanzana/server/server_check.go
+++ b/pkg/services/authz/zanzana/server/server_check.go
@@ -218,9 +218,7 @@ func (s *Server) openfgaCheck(ctx context.Context, store *zanzana.StoreInfo, sub
 	})
 
 	if err != nil {
-		// error is decorated by openfga with a public-facing error message, so we need to unwrap it to get the actual error and log it server-side,
-		// but we want to return wrapped error to the client to prevent leaking internal error details
-		s.logger.Error("failed to perform check", "error", errors.Unwrap(err), "subject", subject, "relation", relation, "object", object)
+		s.logger.Error("failed to perform check", "error", err, "subject", subject, "relation", relation, "object", object)
 		return nil, fmt.Errorf("failed to perform openfga Check request: %w", err)
 	}
 

--- a/pkg/services/authz/zanzana/server/server_list.go
+++ b/pkg/services/authz/zanzana/server/server_list.go
@@ -21,6 +21,12 @@ import (
 )
 
 func (s *Server) List(ctx context.Context, r *authzv1.ListRequest) (*authzv1.ListResponse, error) {
+	release, err := s.acquireSlot("List", r.GetNamespace())
+	if err != nil {
+		return nil, err
+	}
+	defer release()
+
 	ctx, span := s.tracer.Start(ctx, "server.List")
 	defer span.End()
 	span.SetAttributes(attribute.String("namespace", r.GetNamespace()))

--- a/pkg/setting/settings_zanzana.go
+++ b/pkg/setting/settings_zanzana.go
@@ -121,6 +121,12 @@ type ZanzanaServerSettings struct {
 	// Max unique folder checks per batch-check phase before switching from OpenFGA BatchCheck
 	// to ListObjects. Reduces graph exploration when many distinct folders are checked. Default 20.
 	FolderCheckBatchThreshold int
+	// Max number of concurrent in-flight Check/BatchCheck/List requests.
+	// 0 means no limit (default). When reached, new requests are rejected with ResourceExhausted.
+	MaxConcurrentRequests int
+	// Max number of concurrent in-flight requests per namespace (tenant).
+	// 0 means no limit (default). Prevents a single noisy tenant from starving others.
+	MaxConcurrentRequestsPerNamespace int
 }
 
 type OpenFgaServerSettings struct {
@@ -321,6 +327,8 @@ func (cfg *Cfg) readZanzanaSettings() {
 	zs.AllowInsecure = serverSec.Key("allow_insecure").MustBool(false)
 	zs.ReadPageSize = int32(serverSec.Key("read_page_size").MustInt(defaultReadPageSize))
 	zs.FolderCheckBatchThreshold = serverSec.Key("folder_check_batch_threshold").MustInt(20)
+	zs.MaxConcurrentRequests = serverSec.Key("max_concurrent_requests").MustInt(0)
+	zs.MaxConcurrentRequestsPerNamespace = serverSec.Key("max_concurrent_requests_per_namespace").MustInt(0)
 
 	// Cache settings
 	zs.CacheSettings.CheckCacheLimit = uint32(serverSec.Key("check_cache_limit").MustUint(10000))


### PR DESCRIPTION
## Why

Zanzana was getting OOM-killed after memory grew from 250MB to 9.4GB in ~15 minutes. A single namespace flooded `Check`/`BatchCheck` gRPC calls while OpenFGA became unresponsive, and each request held a goroutine for the full 30s gRPC timeout with no upper bound on concurrency. There is currently zero backpressure at the zanzana gRPC handler level.

## Summary

- Add two-layer semaphore-based admission control: a **global** limit across all tenants, and a **per-namespace** limit to prevent a single noisy tenant from starving others
- When either limit is reached, requests are immediately rejected with `codes.ResourceExhausted` (no blocking/queuing) — gRPC clients already retry on this code
- Applied to `Check`, `BatchCheck`, and `List` handlers (the hot path); internal/reconciler RPCs are unaffected
- New Prometheus metrics: `iam_authz_zanzana_server_inflight_requests` (gauge) and `iam_authz_zanzana_server_rejected_requests_total` (counter)
- Both limits default to `0` (disabled), configured via `[zanzana.server]` settings `max_concurrent_requests` and `max_concurrent_requests_per_namespace`
- Fix `error=null` in openfga check logs — `errors.Unwrap(err)` returns nil when the error doesn't implement `Unwrap()`, now logs the error directly

## Known tradeoffs

**Admission runs before auth/validation.** The slot is acquired at the top of `Check`/`BatchCheck`/`List`, before `authorize()` or `EnsureNamespace()`. This means requests that would fail auth still consume a slot briefly. In practice this is low risk — the zanzana gRPC server is internal-only (callers are Grafana instances with valid credentials), and the OOM was caused by a legitimate tenant, not invalid traffic. Moving admission after auth would require restructuring the handler chain since auth happens inside the inner methods.

**Per-namespace semaphores are never evicted.** `getOrCreateNamespaceLimiter` stores a `*semaphore.Weighted` (~64 bytes) per namespace in a `sync.Map`, with no cleanup. In practice, namespaces are a fixed set of tenant stacks — not arbitrary strings. Even 10k stale entries would be ~640KB. If this becomes a concern, cleanup can be added as a follow-up.

## Test plan

- [x] 8 unit tests covering: disabled mode, global limit, namespace limit, global-before-namespace ordering, release restores both, idempotent release, inflight gauge inc/dec, rejection counter
- [ ] Existing integration tests pass (`go test -run TestIntegration ./pkg/services/authz/zanzana/server/`) — limits default to 0 so admission is disabled
- [ ] Deploy with initial limits and monitor `inflight_requests` + `rejected_requests_total` metrics