### PR TITLE
Unified Storage: Add histogram to track US operations with resource key

### DIFF
--- a/pkg/storage/unified/resource/client.go
+++ b/pkg/storage/unified/resource/client.go
@@ -99,12 +99,18 @@ func NewLegacyResourceClient(channel grpc.ClientConnInterface, indexChannel grpc
 	return newResourceClient(cc, cci)
 }
 
-func NewLocalResourceClient(server ResourceServer) ResourceClient {
+func NewLocalResourceClient(srv ResourceServer) ResourceClient {
 	// scenario: local in-proc
 	channel := &inprocgrpc.Channel{}
 	tracer := otel.Tracer("github.com/grafana/grafana/pkg/storage/unified/resource")
 
 	grpcAuthInt := grpcutils.NewUnsafeAuthenticator(tracer)
+
+	var metricsInt grpc.UnaryServerInterceptor
+	if s, ok := srv.(*server); ok {
+		metricsInt = UnaryRequestDurationInterceptor(s.storageMetrics)
+	}
+
 	for _, desc := range []*grpc.ServiceDesc{
 		&resourcepb.ResourceStore_ServiceDesc,
 		&resourcepb.ResourceIndex_ServiceDesc,
@@ -114,13 +120,17 @@ func NewLocalResourceClient(server ResourceServer) ResourceClient {
 		&resourcepb.Diagnostics_ServiceDesc,
 		&resourcepb.Quotas_ServiceDesc,
 	} {
+		wrapped := desc
+		if metricsInt != nil {
+			wrapped = grpchan.InterceptServer(wrapped, metricsInt, nil)
+		}
 		channel.RegisterService(
 			grpchan.InterceptServer(
-				desc,
+				wrapped,
 				grpcAuth.UnaryServerInterceptor(grpcAuthInt),
 				grpcAuth.StreamServerInterceptor(grpcAuthInt),
 			),
-			server,
+			srv,
 		)
 	}
 

--- a/pkg/storage/unified/resource/client.go
+++ b/pkg/storage/unified/resource/client.go
@@ -121,7 +121,7 @@ func NewLocalResourceClient(srv ResourceServer) ResourceClient {
 		&resourcepb.Quotas_ServiceDesc,
 	} {
 		wrapped := desc
-		if metricsInt != nil {
+		if metricsInt != nil && desc == &resourcepb.ResourceStore_ServiceDesc {
 			wrapped = grpchan.InterceptServer(wrapped, metricsInt, nil)
 		}
 		channel.RegisterService(

--- a/pkg/storage/unified/resource/grpc_interceptor.go
+++ b/pkg/storage/unified/resource/grpc_interceptor.go
@@ -1,0 +1,64 @@
+package resource
+
+import (
+	"context"
+	"path"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/status"
+
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+)
+
+// UnaryRequestDurationInterceptor records storage_server_grpc_request_duration_seconds
+// for unified-storage RPCs. Returns a pass-through if metrics is nil or RequestDuration
+// is unset, so it is safe to apply unconditionally.
+func UnaryRequestDurationInterceptor(metrics *StorageMetrics) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, info *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		if metrics == nil || metrics.RequestDuration == nil {
+			return handler(ctx, req)
+		}
+		start := time.Now()
+		resp, err := handler(ctx, req)
+		group, resource := requestKeyLabels(req)
+		metrics.RequestDuration.
+			WithLabelValues(path.Base(info.FullMethod), group, resource, status.Code(err).String()).
+			Observe(time.Since(start).Seconds())
+		return resp, err
+	}
+}
+
+func requestKeyLabels(req any) (group, resource string) {
+	group, resource = "unknown", "unknown"
+	var key *resourcepb.ResourceKey
+	switch r := req.(type) {
+	case *resourcepb.CreateRequest:
+		key = r.GetKey()
+	case *resourcepb.UpdateRequest:
+		key = r.GetKey()
+	case *resourcepb.DeleteRequest:
+		key = r.GetKey()
+	case *resourcepb.ReadRequest:
+		key = r.GetKey()
+	case *resourcepb.ListRequest:
+		key = r.GetOptions().GetKey()
+	case *resourcepb.ResourceSearchRequest:
+		key = r.GetOptions().GetKey()
+	case *resourcepb.PutBlobRequest:
+		key = r.GetResource()
+	case *resourcepb.GetBlobRequest:
+		key = r.GetResource()
+	case *resourcepb.QuotaUsageRequest:
+		key = r.GetKey()
+	}
+	if key != nil {
+		if g := key.GetGroup(); g != "" {
+			group = g
+		}
+		if rr := key.GetResource(); rr != "" {
+			resource = rr
+		}
+	}
+	return
+}

--- a/pkg/storage/unified/resource/grpc_interceptor.go
+++ b/pkg/storage/unified/resource/grpc_interceptor.go
@@ -43,14 +43,6 @@ func requestKeyLabels(req any) (group, resource string) {
 		key = r.GetKey()
 	case *resourcepb.ListRequest:
 		key = r.GetOptions().GetKey()
-	case *resourcepb.ResourceSearchRequest:
-		key = r.GetOptions().GetKey()
-	case *resourcepb.PutBlobRequest:
-		key = r.GetResource()
-	case *resourcepb.GetBlobRequest:
-		key = r.GetResource()
-	case *resourcepb.QuotaUsageRequest:
-		key = r.GetKey()
 	}
 	if key != nil {
 		if g := key.GetGroup(); g != "" {

--- a/pkg/storage/unified/resource/metrics.go
+++ b/pkg/storage/unified/resource/metrics.go
@@ -12,6 +12,7 @@ type StorageMetrics struct {
 	WatchEventLatency      *prometheus.HistogramVec
 	PollerLatency          prometheus.Histogram
 	ListWithFieldSelectors *prometheus.CounterVec
+	RequestDuration        *prometheus.HistogramVec
 	Broadcaster            *BroadcasterMetrics
 }
 
@@ -39,6 +40,15 @@ func ProvideStorageMetrics(reg prometheus.Registerer) *StorageMetrics {
 			Name: "storage_server_field_selector_search_count",
 			Help: "number of times List was served by field selector search",
 		}, []string{"resource", "served_by"}),
+		RequestDuration: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+			Namespace:                       "storage_server",
+			Name:                            "grpc_request_duration_seconds",
+			Help:                            "Time (in seconds) spent serving unified storage gRPC requests, labeled by group and resource.",
+			Buckets:                         instrument.DefBuckets,
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  160,
+			NativeHistogramMinResetDuration: time.Hour,
+		}, []string{"method", "group", "resource", "status_code"}),
 		Broadcaster: newBroadcasterMetrics(reg),
 	}
 }

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -569,6 +569,28 @@ type server struct {
 	bookmarkFrequency time.Duration
 }
 
+// observeRequest records a sample into storage_server_grpc_request_duration_seconds.
+// Safe to call with a nil key or nil storageMetrics. Intended for use with defer.
+func (s *server) observeRequest(method string, key *resourcepb.ResourceKey, start time.Time, err error) {
+	if s.storageMetrics == nil || s.storageMetrics.RequestDuration == nil {
+		return
+	}
+	group, resource := "unknown", "unknown"
+	if key != nil {
+		if g := key.GetGroup(); g != "" {
+			group = g
+		}
+		if r := key.GetResource(); r != "" {
+			resource = r
+		}
+	}
+	code := "OK"
+	if err != nil {
+		code = status.Code(err).String()
+	}
+	s.storageMetrics.RequestDuration.WithLabelValues(method, group, resource, code).Observe(time.Since(start).Seconds())
+}
+
 // Init implements ResourceServer.
 func (s *server) Init(ctx context.Context) error {
 	s.once.Do(func() {
@@ -850,16 +872,18 @@ func (s *server) checkFolderMovePermissions(ctx context.Context, user claims.Aut
 	return nil
 }
 
-func (s *server) Create(ctx context.Context, req *resourcepb.CreateRequest) (*resourcepb.CreateResponse, error) {
+func (s *server) Create(ctx context.Context, req *resourcepb.CreateRequest) (resp *resourcepb.CreateResponse, err error) {
 	ctx, span := tracer.Start(ctx, "resource.server.Create")
 	defer span.End()
+	start := time.Now()
+	defer func() { s.observeRequest("Create", req.GetKey(), start, err) }()
 
 	if !s.trackWrite() {
 		return nil, errStopping
 	}
 	defer s.inflight.Done()
 
-	err := s.checkQuota(ctx, NamespacedResource{
+	err = s.checkQuota(ctx, NamespacedResource{
 		Namespace: req.Key.Namespace,
 		Group:     req.Key.Group,
 		Resource:  req.Key.Resource,
@@ -975,9 +999,11 @@ func (s *server) sleepAfterSuccessfulWriteOperation(ctx context.Context, operati
 	return true
 }
 
-func (s *server) Update(ctx context.Context, req *resourcepb.UpdateRequest) (*resourcepb.UpdateResponse, error) {
+func (s *server) Update(ctx context.Context, req *resourcepb.UpdateRequest) (resp *resourcepb.UpdateResponse, err error) {
 	ctx, span := tracer.Start(ctx, "resource.server.Update")
 	defer span.End()
+	start := time.Now()
+	defer func() { s.observeRequest("Update", req.GetKey(), start, err) }()
 
 	if !s.trackWrite() {
 		return nil, errStopping
@@ -994,10 +1020,7 @@ func (s *server) Update(ctx context.Context, req *resourcepb.UpdateRequest) (*re
 		return rsp, nil
 	}
 
-	var (
-		res *resourcepb.UpdateResponse
-		err error
-	)
+	var res *resourcepb.UpdateResponse
 	runErr := s.runInQueue(ctx, req.Key.Namespace, func(queueCtx context.Context) {
 		res, err = s.update(queueCtx, user, req)
 	})
@@ -1040,9 +1063,11 @@ func (s *server) update(ctx context.Context, user claims.AuthInfo, req *resource
 	return rsp, nil
 }
 
-func (s *server) Delete(ctx context.Context, req *resourcepb.DeleteRequest) (*resourcepb.DeleteResponse, error) {
+func (s *server) Delete(ctx context.Context, req *resourcepb.DeleteRequest) (resp *resourcepb.DeleteResponse, err error) {
 	ctx, span := tracer.Start(ctx, "resource.server.Delete")
 	defer span.End()
+	start := time.Now()
+	defer func() { s.observeRequest("Delete", req.GetKey(), start, err) }()
 
 	if !s.trackWrite() {
 		return nil, errStopping
@@ -1059,11 +1084,7 @@ func (s *server) Delete(ctx context.Context, req *resourcepb.DeleteRequest) (*re
 		return rsp, nil
 	}
 
-	var (
-		res *resourcepb.DeleteResponse
-		err error
-	)
-
+	var res *resourcepb.DeleteResponse
 	runErr := s.runInQueue(ctx, req.Key.Namespace, func(queueCtx context.Context) {
 		res, err = s.delete(queueCtx, user, req)
 	})
@@ -1150,7 +1171,10 @@ func (s *server) delete(ctx context.Context, user claims.AuthInfo, req *resource
 	return rsp, nil
 }
 
-func (s *server) Read(ctx context.Context, req *resourcepb.ReadRequest) (*resourcepb.ReadResponse, error) {
+func (s *server) Read(ctx context.Context, req *resourcepb.ReadRequest) (resp *resourcepb.ReadResponse, err error) {
+	start := time.Now()
+	defer func() { s.observeRequest("Read", req.GetKey(), start, err) }()
+
 	user, ok := claims.AuthInfoFrom(ctx)
 	if !ok || user == nil {
 		return &resourcepb.ReadResponse{
@@ -1164,10 +1188,7 @@ func (s *server) Read(ctx context.Context, req *resourcepb.ReadRequest) (*resour
 		return &resourcepb.ReadResponse{Error: NewBadRequestError("missing resource")}, nil
 	}
 
-	var (
-		res *resourcepb.ReadResponse
-		err error
-	)
+	var res *resourcepb.ReadResponse
 	runErr := s.runInQueue(ctx, req.Key.Namespace, func(queueCtx context.Context) {
 		res, err = s.read(queueCtx, user, req)
 	})
@@ -1209,10 +1230,12 @@ func (s *server) read(ctx context.Context, user claims.AuthInfo, req *resourcepb
 	}, nil
 }
 
-func (s *server) List(ctx context.Context, req *resourcepb.ListRequest) (*resourcepb.ListResponse, error) {
+func (s *server) List(ctx context.Context, req *resourcepb.ListRequest) (resp *resourcepb.ListResponse, err error) {
 	ctx, span := tracer.Start(ctx, "resource.server.List")
 	span.SetAttributes(attribute.String("group", req.Options.Key.Group), attribute.String("resource", req.Options.Key.Resource))
 	defer span.End()
+	start := time.Now()
+	defer func() { s.observeRequest("List", req.GetOptions().GetKey(), start, err) }()
 
 	// The history + trash queries do not yet support additional filters
 	if req.Source != resourcepb.ListRequest_STORE {
@@ -1721,7 +1744,10 @@ func (s *server) Watch(req *resourcepb.WatchRequest, srv resourcepb.ResourceStor
 	}
 }
 
-func (s *server) Search(ctx context.Context, req *resourcepb.ResourceSearchRequest) (*resourcepb.ResourceSearchResponse, error) {
+func (s *server) Search(ctx context.Context, req *resourcepb.ResourceSearchRequest) (resp *resourcepb.ResourceSearchResponse, err error) {
+	start := time.Now()
+	defer func() { s.observeRequest("Search", req.GetOptions().GetKey(), start, err) }()
+
 	if s.search == nil {
 		return nil, fmt.Errorf("search index not configured")
 	}
@@ -1735,7 +1761,10 @@ type StatsGetter interface {
 }
 
 // GetStats implements ResourceServer.
-func (s *server) GetStats(ctx context.Context, req *resourcepb.ResourceStatsRequest) (*resourcepb.ResourceStatsResponse, error) {
+func (s *server) GetStats(ctx context.Context, req *resourcepb.ResourceStatsRequest) (resp *resourcepb.ResourceStatsResponse, err error) {
+	start := time.Now()
+	defer func() { s.observeRequest("GetStats", nil, start, err) }()
+
 	if err := s.Init(ctx); err != nil {
 		return nil, err
 	}
@@ -1751,7 +1780,10 @@ func (s *server) GetStats(ctx context.Context, req *resourcepb.ResourceStatsRequ
 	return s.search.GetStats(ctx, req)
 }
 
-func (s *server) ListManagedObjects(ctx context.Context, req *resourcepb.ListManagedObjectsRequest) (*resourcepb.ListManagedObjectsResponse, error) {
+func (s *server) ListManagedObjects(ctx context.Context, req *resourcepb.ListManagedObjectsRequest) (resp *resourcepb.ListManagedObjectsResponse, err error) {
+	start := time.Now()
+	defer func() { s.observeRequest("ListManagedObjects", nil, start, err) }()
+
 	if s.search == nil {
 		return nil, fmt.Errorf("search index not configured")
 	}
@@ -1759,7 +1791,10 @@ func (s *server) ListManagedObjects(ctx context.Context, req *resourcepb.ListMan
 	return s.search.ListManagedObjects(ctx, req)
 }
 
-func (s *server) CountManagedObjects(ctx context.Context, req *resourcepb.CountManagedObjectsRequest) (*resourcepb.CountManagedObjectsResponse, error) {
+func (s *server) CountManagedObjects(ctx context.Context, req *resourcepb.CountManagedObjectsRequest) (resp *resourcepb.CountManagedObjectsResponse, err error) {
+	start := time.Now()
+	defer func() { s.observeRequest("CountManagedObjects", nil, start, err) }()
+
 	if s.search == nil {
 		return nil, fmt.Errorf("search index not configured")
 	}
@@ -1773,7 +1808,10 @@ func (s *server) IsHealthy(ctx context.Context, req *resourcepb.HealthCheckReque
 }
 
 // GetBlob implements BlobStore.
-func (s *server) PutBlob(ctx context.Context, req *resourcepb.PutBlobRequest) (*resourcepb.PutBlobResponse, error) {
+func (s *server) PutBlob(ctx context.Context, req *resourcepb.PutBlobRequest) (resp *resourcepb.PutBlobResponse, err error) {
+	start := time.Now()
+	defer func() { s.observeRequest("PutBlob", req.GetResource(), start, err) }()
+
 	if s.blob == nil {
 		return &resourcepb.PutBlobResponse{Error: &resourcepb.ErrorResult{
 			Message: "blob store not configured",
@@ -1788,7 +1826,10 @@ func (s *server) PutBlob(ctx context.Context, req *resourcepb.PutBlobRequest) (*
 	return rsp, nil
 }
 
-func (s *server) GetQuotaUsage(ctx context.Context, req *resourcepb.QuotaUsageRequest) (*resourcepb.QuotaUsageResponse, error) {
+func (s *server) GetQuotaUsage(ctx context.Context, req *resourcepb.QuotaUsageRequest) (resp *resourcepb.QuotaUsageResponse, err error) {
+	start := time.Now()
+	defer func() { s.observeRequest("GetQuotaUsage", req.GetKey(), start, err) }()
+
 	if s.overridesService == nil {
 		return &resourcepb.QuotaUsageResponse{Error: &resourcepb.ErrorResult{
 			Message: "overrides service not configured on resource server",
@@ -1846,7 +1887,10 @@ func (s *server) getPartialObject(ctx context.Context, key *resourcepb.ResourceK
 }
 
 // GetBlob implements BlobStore.
-func (s *server) GetBlob(ctx context.Context, req *resourcepb.GetBlobRequest) (*resourcepb.GetBlobResponse, error) {
+func (s *server) GetBlob(ctx context.Context, req *resourcepb.GetBlobRequest) (resp *resourcepb.GetBlobResponse, err error) {
+	start := time.Now()
+	defer func() { s.observeRequest("GetBlob", req.GetResource(), start, err) }()
+
 	if s.blob == nil {
 		return &resourcepb.GetBlobResponse{Error: &resourcepb.ErrorResult{
 			Message: "blob store not configured",

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -569,28 +569,6 @@ type server struct {
 	bookmarkFrequency time.Duration
 }
 
-// observeRequest records a sample into storage_server_grpc_request_duration_seconds.
-// Safe to call with a nil key or nil storageMetrics. Intended for use with defer.
-func (s *server) observeRequest(method string, key *resourcepb.ResourceKey, start time.Time, err error) {
-	if s.storageMetrics == nil || s.storageMetrics.RequestDuration == nil {
-		return
-	}
-	group, resource := "unknown", "unknown"
-	if key != nil {
-		if g := key.GetGroup(); g != "" {
-			group = g
-		}
-		if r := key.GetResource(); r != "" {
-			resource = r
-		}
-	}
-	code := "OK"
-	if err != nil {
-		code = status.Code(err).String()
-	}
-	s.storageMetrics.RequestDuration.WithLabelValues(method, group, resource, code).Observe(time.Since(start).Seconds())
-}
-
 // Init implements ResourceServer.
 func (s *server) Init(ctx context.Context) error {
 	s.once.Do(func() {
@@ -872,18 +850,16 @@ func (s *server) checkFolderMovePermissions(ctx context.Context, user claims.Aut
 	return nil
 }
 
-func (s *server) Create(ctx context.Context, req *resourcepb.CreateRequest) (resp *resourcepb.CreateResponse, err error) {
+func (s *server) Create(ctx context.Context, req *resourcepb.CreateRequest) (*resourcepb.CreateResponse, error) {
 	ctx, span := tracer.Start(ctx, "resource.server.Create")
 	defer span.End()
-	start := time.Now()
-	defer func() { s.observeRequest("Create", req.GetKey(), start, err) }()
 
 	if !s.trackWrite() {
 		return nil, errStopping
 	}
 	defer s.inflight.Done()
 
-	err = s.checkQuota(ctx, NamespacedResource{
+	err := s.checkQuota(ctx, NamespacedResource{
 		Namespace: req.Key.Namespace,
 		Group:     req.Key.Group,
 		Resource:  req.Key.Resource,
@@ -999,11 +975,9 @@ func (s *server) sleepAfterSuccessfulWriteOperation(ctx context.Context, operati
 	return true
 }
 
-func (s *server) Update(ctx context.Context, req *resourcepb.UpdateRequest) (resp *resourcepb.UpdateResponse, err error) {
+func (s *server) Update(ctx context.Context, req *resourcepb.UpdateRequest) (*resourcepb.UpdateResponse, error) {
 	ctx, span := tracer.Start(ctx, "resource.server.Update")
 	defer span.End()
-	start := time.Now()
-	defer func() { s.observeRequest("Update", req.GetKey(), start, err) }()
 
 	if !s.trackWrite() {
 		return nil, errStopping
@@ -1020,7 +994,10 @@ func (s *server) Update(ctx context.Context, req *resourcepb.UpdateRequest) (res
 		return rsp, nil
 	}
 
-	var res *resourcepb.UpdateResponse
+	var (
+		res *resourcepb.UpdateResponse
+		err error
+	)
 	runErr := s.runInQueue(ctx, req.Key.Namespace, func(queueCtx context.Context) {
 		res, err = s.update(queueCtx, user, req)
 	})
@@ -1063,11 +1040,9 @@ func (s *server) update(ctx context.Context, user claims.AuthInfo, req *resource
 	return rsp, nil
 }
 
-func (s *server) Delete(ctx context.Context, req *resourcepb.DeleteRequest) (resp *resourcepb.DeleteResponse, err error) {
+func (s *server) Delete(ctx context.Context, req *resourcepb.DeleteRequest) (*resourcepb.DeleteResponse, error) {
 	ctx, span := tracer.Start(ctx, "resource.server.Delete")
 	defer span.End()
-	start := time.Now()
-	defer func() { s.observeRequest("Delete", req.GetKey(), start, err) }()
 
 	if !s.trackWrite() {
 		return nil, errStopping
@@ -1084,7 +1059,11 @@ func (s *server) Delete(ctx context.Context, req *resourcepb.DeleteRequest) (res
 		return rsp, nil
 	}
 
-	var res *resourcepb.DeleteResponse
+	var (
+		res *resourcepb.DeleteResponse
+		err error
+	)
+
 	runErr := s.runInQueue(ctx, req.Key.Namespace, func(queueCtx context.Context) {
 		res, err = s.delete(queueCtx, user, req)
 	})
@@ -1171,10 +1150,7 @@ func (s *server) delete(ctx context.Context, user claims.AuthInfo, req *resource
 	return rsp, nil
 }
 
-func (s *server) Read(ctx context.Context, req *resourcepb.ReadRequest) (resp *resourcepb.ReadResponse, err error) {
-	start := time.Now()
-	defer func() { s.observeRequest("Read", req.GetKey(), start, err) }()
-
+func (s *server) Read(ctx context.Context, req *resourcepb.ReadRequest) (*resourcepb.ReadResponse, error) {
 	user, ok := claims.AuthInfoFrom(ctx)
 	if !ok || user == nil {
 		return &resourcepb.ReadResponse{
@@ -1188,7 +1164,10 @@ func (s *server) Read(ctx context.Context, req *resourcepb.ReadRequest) (resp *r
 		return &resourcepb.ReadResponse{Error: NewBadRequestError("missing resource")}, nil
 	}
 
-	var res *resourcepb.ReadResponse
+	var (
+		res *resourcepb.ReadResponse
+		err error
+	)
 	runErr := s.runInQueue(ctx, req.Key.Namespace, func(queueCtx context.Context) {
 		res, err = s.read(queueCtx, user, req)
 	})
@@ -1230,12 +1209,10 @@ func (s *server) read(ctx context.Context, user claims.AuthInfo, req *resourcepb
 	}, nil
 }
 
-func (s *server) List(ctx context.Context, req *resourcepb.ListRequest) (resp *resourcepb.ListResponse, err error) {
+func (s *server) List(ctx context.Context, req *resourcepb.ListRequest) (*resourcepb.ListResponse, error) {
 	ctx, span := tracer.Start(ctx, "resource.server.List")
 	span.SetAttributes(attribute.String("group", req.Options.Key.Group), attribute.String("resource", req.Options.Key.Resource))
 	defer span.End()
-	start := time.Now()
-	defer func() { s.observeRequest("List", req.GetOptions().GetKey(), start, err) }()
 
 	// The history + trash queries do not yet support additional filters
 	if req.Source != resourcepb.ListRequest_STORE {
@@ -1744,10 +1721,7 @@ func (s *server) Watch(req *resourcepb.WatchRequest, srv resourcepb.ResourceStor
 	}
 }
 
-func (s *server) Search(ctx context.Context, req *resourcepb.ResourceSearchRequest) (resp *resourcepb.ResourceSearchResponse, err error) {
-	start := time.Now()
-	defer func() { s.observeRequest("Search", req.GetOptions().GetKey(), start, err) }()
-
+func (s *server) Search(ctx context.Context, req *resourcepb.ResourceSearchRequest) (*resourcepb.ResourceSearchResponse, error) {
 	if s.search == nil {
 		return nil, fmt.Errorf("search index not configured")
 	}
@@ -1761,10 +1735,7 @@ type StatsGetter interface {
 }
 
 // GetStats implements ResourceServer.
-func (s *server) GetStats(ctx context.Context, req *resourcepb.ResourceStatsRequest) (resp *resourcepb.ResourceStatsResponse, err error) {
-	start := time.Now()
-	defer func() { s.observeRequest("GetStats", nil, start, err) }()
-
+func (s *server) GetStats(ctx context.Context, req *resourcepb.ResourceStatsRequest) (*resourcepb.ResourceStatsResponse, error) {
 	if err := s.Init(ctx); err != nil {
 		return nil, err
 	}
@@ -1780,10 +1751,7 @@ func (s *server) GetStats(ctx context.Context, req *resourcepb.ResourceStatsRequ
 	return s.search.GetStats(ctx, req)
 }
 
-func (s *server) ListManagedObjects(ctx context.Context, req *resourcepb.ListManagedObjectsRequest) (resp *resourcepb.ListManagedObjectsResponse, err error) {
-	start := time.Now()
-	defer func() { s.observeRequest("ListManagedObjects", nil, start, err) }()
-
+func (s *server) ListManagedObjects(ctx context.Context, req *resourcepb.ListManagedObjectsRequest) (*resourcepb.ListManagedObjectsResponse, error) {
 	if s.search == nil {
 		return nil, fmt.Errorf("search index not configured")
 	}
@@ -1791,10 +1759,7 @@ func (s *server) ListManagedObjects(ctx context.Context, req *resourcepb.ListMan
 	return s.search.ListManagedObjects(ctx, req)
 }
 
-func (s *server) CountManagedObjects(ctx context.Context, req *resourcepb.CountManagedObjectsRequest) (resp *resourcepb.CountManagedObjectsResponse, err error) {
-	start := time.Now()
-	defer func() { s.observeRequest("CountManagedObjects", nil, start, err) }()
-
+func (s *server) CountManagedObjects(ctx context.Context, req *resourcepb.CountManagedObjectsRequest) (*resourcepb.CountManagedObjectsResponse, error) {
 	if s.search == nil {
 		return nil, fmt.Errorf("search index not configured")
 	}
@@ -1808,10 +1773,7 @@ func (s *server) IsHealthy(ctx context.Context, req *resourcepb.HealthCheckReque
 }
 
 // GetBlob implements BlobStore.
-func (s *server) PutBlob(ctx context.Context, req *resourcepb.PutBlobRequest) (resp *resourcepb.PutBlobResponse, err error) {
-	start := time.Now()
-	defer func() { s.observeRequest("PutBlob", req.GetResource(), start, err) }()
-
+func (s *server) PutBlob(ctx context.Context, req *resourcepb.PutBlobRequest) (*resourcepb.PutBlobResponse, error) {
 	if s.blob == nil {
 		return &resourcepb.PutBlobResponse{Error: &resourcepb.ErrorResult{
 			Message: "blob store not configured",
@@ -1826,10 +1788,7 @@ func (s *server) PutBlob(ctx context.Context, req *resourcepb.PutBlobRequest) (r
 	return rsp, nil
 }
 
-func (s *server) GetQuotaUsage(ctx context.Context, req *resourcepb.QuotaUsageRequest) (resp *resourcepb.QuotaUsageResponse, err error) {
-	start := time.Now()
-	defer func() { s.observeRequest("GetQuotaUsage", req.GetKey(), start, err) }()
-
+func (s *server) GetQuotaUsage(ctx context.Context, req *resourcepb.QuotaUsageRequest) (*resourcepb.QuotaUsageResponse, error) {
 	if s.overridesService == nil {
 		return &resourcepb.QuotaUsageResponse{Error: &resourcepb.ErrorResult{
 			Message: "overrides service not configured on resource server",
@@ -1887,10 +1846,7 @@ func (s *server) getPartialObject(ctx context.Context, key *resourcepb.ResourceK
 }
 
 // GetBlob implements BlobStore.
-func (s *server) GetBlob(ctx context.Context, req *resourcepb.GetBlobRequest) (resp *resourcepb.GetBlobResponse, err error) {
-	start := time.Now()
-	defer func() { s.observeRequest("GetBlob", req.GetResource(), start, err) }()
-
+func (s *server) GetBlob(ctx context.Context, req *resourcepb.GetBlobRequest) (*resourcepb.GetBlobResponse, error) {
 	if s.blob == nil {
 		return &resourcepb.GetBlobResponse{Error: &resourcepb.ErrorResult{
 			Message: "blob store not configured",

--- a/pkg/storage/unified/sql/service.go
+++ b/pkg/storage/unified/sql/service.go
@@ -10,11 +10,13 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/fullstorydev/grpchan"
 	"github.com/gorilla/mux"
 	grpcauth "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/auth"
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
+	"google.golang.org/grpc"
 
 	"github.com/grafana/authlib/grpcutils"
 	"github.com/grafana/dskit/kv"
@@ -513,9 +515,14 @@ func (s *service) registerSearchServer(provider grpcserver.Provider, server reso
 		handler = &searchServerWithAuth{SearchServer: server, ServiceWithAuth: sa}
 	}
 	srv := provider.GetServer()
-	resourcepb.RegisterResourceIndexServer(srv, handler)
-	resourcepb.RegisterManagedObjectIndexServer(srv, handler)
-	resourcepb.RegisterDiagnosticsServer(srv, handler)
+	metricsInt := resource.UnaryRequestDurationInterceptor(s.storageMetrics)
+	for _, desc := range []*grpc.ServiceDesc{
+		&resourcepb.ResourceIndex_ServiceDesc,
+		&resourcepb.ManagedObjectIndex_ServiceDesc,
+		&resourcepb.Diagnostics_ServiceDesc,
+	} {
+		srv.RegisterService(grpchan.InterceptServer(desc, metricsInt, nil), handler)
+	}
 	_, _ = grpcserver.ProvideReflectionService(s.cfg, provider)
 	return nil
 }
@@ -533,15 +540,20 @@ func (s *service) registerUnifiedResourceServer(provider grpcserver.Provider, se
 	if sa := interceptors.NewServiceAuth(s.authenticator); sa != nil {
 		handler = &resourceServerWithAuth{ResourceServer: server, ServiceWithAuth: sa}
 	}
-	// Register storage services
 	srv := provider.GetServer()
-	resourcepb.RegisterResourceStoreServer(srv, handler)
-	resourcepb.RegisterBulkStoreServer(srv, handler)
-	resourcepb.RegisterBlobStoreServer(srv, handler)
-	resourcepb.RegisterDiagnosticsServer(srv, handler)
-	resourcepb.RegisterQuotasServer(srv, handler)
-	// Register search services
-	resourcepb.RegisterResourceIndexServer(srv, handler)
-	resourcepb.RegisterManagedObjectIndexServer(srv, handler)
+	metricsInt := resource.UnaryRequestDurationInterceptor(s.storageMetrics)
+	for _, desc := range []*grpc.ServiceDesc{
+		// Storage services
+		&resourcepb.ResourceStore_ServiceDesc,
+		&resourcepb.BulkStore_ServiceDesc,
+		&resourcepb.BlobStore_ServiceDesc,
+		&resourcepb.Diagnostics_ServiceDesc,
+		&resourcepb.Quotas_ServiceDesc,
+		// Search services
+		&resourcepb.ResourceIndex_ServiceDesc,
+		&resourcepb.ManagedObjectIndex_ServiceDesc,
+	} {
+		srv.RegisterService(grpchan.InterceptServer(desc, metricsInt, nil), handler)
+	}
 	_, _ = grpcserver.ProvideReflectionService(s.cfg, provider)
 }

--- a/pkg/storage/unified/sql/service.go
+++ b/pkg/storage/unified/sql/service.go
@@ -16,7 +16,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/trace"
-	"google.golang.org/grpc"
 
 	"github.com/grafana/authlib/grpcutils"
 	"github.com/grafana/dskit/kv"
@@ -515,14 +514,9 @@ func (s *service) registerSearchServer(provider grpcserver.Provider, server reso
 		handler = &searchServerWithAuth{SearchServer: server, ServiceWithAuth: sa}
 	}
 	srv := provider.GetServer()
-	metricsInt := resource.UnaryRequestDurationInterceptor(s.storageMetrics)
-	for _, desc := range []*grpc.ServiceDesc{
-		&resourcepb.ResourceIndex_ServiceDesc,
-		&resourcepb.ManagedObjectIndex_ServiceDesc,
-		&resourcepb.Diagnostics_ServiceDesc,
-	} {
-		srv.RegisterService(grpchan.InterceptServer(desc, metricsInt, nil), handler)
-	}
+	resourcepb.RegisterResourceIndexServer(srv, handler)
+	resourcepb.RegisterManagedObjectIndexServer(srv, handler)
+	resourcepb.RegisterDiagnosticsServer(srv, handler)
 	_, _ = grpcserver.ProvideReflectionService(s.cfg, provider)
 	return nil
 }
@@ -541,19 +535,16 @@ func (s *service) registerUnifiedResourceServer(provider grpcserver.Provider, se
 		handler = &resourceServerWithAuth{ResourceServer: server, ServiceWithAuth: sa}
 	}
 	srv := provider.GetServer()
+	// Storage services. ResourceStore is wrapped with the request-duration interceptor
+	// so we get group/resource-labeled metrics for Read/Create/Update/Delete/List.
 	metricsInt := resource.UnaryRequestDurationInterceptor(s.storageMetrics)
-	for _, desc := range []*grpc.ServiceDesc{
-		// Storage services
-		&resourcepb.ResourceStore_ServiceDesc,
-		&resourcepb.BulkStore_ServiceDesc,
-		&resourcepb.BlobStore_ServiceDesc,
-		&resourcepb.Diagnostics_ServiceDesc,
-		&resourcepb.Quotas_ServiceDesc,
-		// Search services
-		&resourcepb.ResourceIndex_ServiceDesc,
-		&resourcepb.ManagedObjectIndex_ServiceDesc,
-	} {
-		srv.RegisterService(grpchan.InterceptServer(desc, metricsInt, nil), handler)
-	}
+	srv.RegisterService(grpchan.InterceptServer(&resourcepb.ResourceStore_ServiceDesc, metricsInt, nil), handler)
+	resourcepb.RegisterBulkStoreServer(srv, handler)
+	resourcepb.RegisterBlobStoreServer(srv, handler)
+	resourcepb.RegisterDiagnosticsServer(srv, handler)
+	resourcepb.RegisterQuotasServer(srv, handler)
+	// Search services
+	resourcepb.RegisterResourceIndexServer(srv, handler)
+	resourcepb.RegisterManagedObjectIndexServer(srv, handler)
 	_, _ = grpcserver.ProvideReflectionService(s.cfg, provider)
 }


### PR DESCRIPTION
Add a unary gRPC server interceptor that records storage_server_grpc_request_duration_seconds for only the storage grpc service, labeled by method, group, resource, and status_code.

Gives us metrics that look like this:
```
grafana_storage_server_grpc_request_duration_seconds_bucket{group="folder.grafana.app",method="Create",resource="folders",status_code="OK",le="0.005"} 0
grafana_storage_server_grpc_request_duration_seconds_bucket{group="folder.grafana.app",method="Create",resource="folders",status_code="OK",le="0.01"} 0
grafana_storage_server_grpc_request_duration_seconds_bucket{group="folder.grafana.app",method="Create",resource="folders",status_code="OK",le="0.025"} 1
grafana_storage_server_grpc_request_duration_seconds_bucket{group="folder.grafana.app",method="Create",resource="folders",status_code="OK",le="0.05"} 1
grafana_storage_server_grpc_request_duration_seconds_bucket{group="folder.grafana.app",method="Create",resource="folders",status_code="OK",le="0.1"} 1
grafana_storage_server_grpc_request_duration_seconds_bucket{group="folder.grafana.app",method="Create",resource="folders",status_code="OK",le="0.25"} 1
grafana_storage_server_grpc_request_duration_seconds_bucket{group="folder.grafana.app",method="Create",resource="folders",status_code="OK",le="0.5"} 1
grafana_storage_server_grpc_request_duration_seconds_bucket{group="folder.grafana.app",method="Create",resource="folders",status_code="OK",le="1"} 1
grafana_storage_server_grpc_request_duration_seconds_bucket{group="folder.grafana.app",method="Create",resource="folders",status_code="OK",le="2.5"} 1
grafana_storage_server_grpc_request_duration_seconds_bucket{group="folder.grafana.app",method="Create",resource="folders",status_code="OK",le="5"} 1
grafana_storage_server_grpc_request_duration_seconds_bucket{group="folder.grafana.app",method="Create",resource="folders",status_code="OK",le="10"} 1
grafana_storage_server_grpc_request_duration_seconds_bucket{group="folder.grafana.app",method="Create",resource="folders",status_code="OK",le="25"} 1
grafana_storage_server_grpc_request_duration_seconds_bucket{group="folder.grafana.app",method="Create",resource="folders",status_code="OK",le="50"} 1
grafana_storage_server_grpc_request_duration_seconds_bucket{group="folder.grafana.app",method="Create",resource="folders",status_code="OK",le="100"} 1
grafana_storage_server_grpc_request_duration_seconds_bucket{group="folder.grafana.app",method="Create",resource="folders",status_code="OK",le="+Inf"} 1
grafana_storage_server_grpc_request_duration_seconds_sum{group="folder.grafana.app",method="Create",resource="folders",status_code="OK"} 0.023887375
grafana_storage_server_grpc_request_duration_seconds_count{group="folder.grafana.app",method="Create",resource="folders",status_code="OK"} 1
```

**Notes for reviewer**
Yes this will increase the volume of metrics we generate due to all the new label dims here, but imo its worth it for us.