### PR TITLE
Feature: Add localStorage provider w/ feature control UI for flag overrides

### DIFF
--- a/packages/grafana-runtime/package.json
+++ b/packages/grafana-runtime/package.json
@@ -59,6 +59,7 @@
     "@grafana/schema": "13.1.0-pre",
     "@grafana/ui": "13.1.0-pre",
     "@openfeature/core": "^1.10.0",
+    "@openfeature/localstorage-provider": "^0.1.2",
     "@openfeature/ofrep-web-provider": "^0.3.6",
     "@openfeature/react-sdk": "^1.3.0",
     "@openfeature/web-sdk": "^1.8.0",

--- a/packages/grafana-runtime/package.json
+++ b/packages/grafana-runtime/package.json
@@ -59,6 +59,7 @@
     "@grafana/schema": "13.1.0-pre",
     "@grafana/ui": "13.1.0-pre",
     "@openfeature/core": "^1.10.0",
+    "@openfeature/localstorage-provider": "^0.1.2",
     "@openfeature/ofrep-web-provider": "^0.4.1",
     "@openfeature/react-sdk": "^1.3.0",
     "@openfeature/web-sdk": "^1.8.0",

--- a/packages/grafana-runtime/src/internal/index.ts
+++ b/packages/grafana-runtime/src/internal/index.ts
@@ -28,7 +28,12 @@ export {
 
 export { UserStorage, useUserStorage } from '../utils/userStorage';
 
-export { initOpenFeature, getFeatureFlagClient, getLocalStorageProvider } from '../internal/openFeature';
+export {
+  initOpenFeature,
+  getFeatureFlagClient,
+  getLocalStorageProvider,
+  getOFREPWebProvider,
+} from '../internal/openFeature';
 export * from '../internal/openFeature/openfeature.gen';
 
 export { getAppPluginMeta, getAppPluginMetas, setAppPluginMetas } from '../services/pluginMeta/apps';

--- a/packages/grafana-runtime/src/internal/index.ts
+++ b/packages/grafana-runtime/src/internal/index.ts
@@ -28,7 +28,7 @@ export {
 
 export { UserStorage, useUserStorage } from '../utils/userStorage';
 
-export { initOpenFeature, getFeatureFlagClient } from '../internal/openFeature';
+export { initOpenFeature, getFeatureFlagClient, getLocalStorageProvider } from '../internal/openFeature';
 export * from '../internal/openFeature/openfeature.gen';
 
 export { getAppPluginMeta, getAppPluginMetas, setAppPluginMetas } from '../services/pluginMeta/apps';

--- a/packages/grafana-runtime/src/internal/openFeature/index.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/index.ts
@@ -49,19 +49,23 @@ export function getLocalStorageProvider() {
   }));
 }
 
+// Allow direct access to a singleton OFREP provider,
+//  to allow the feature control developer UI to discover flags from the provider
+let ofrepWebProvider: OFREPWebProvider;
+export function getOFREPWebProvider() {
+  return (ofrepWebProvider ??= new OFREPWebProvider({
+    baseUrl: `${config.appSubUrl || ''}/apis/features.grafana.app/v0alpha1/namespaces/${config.namespace}`,
+    pollInterval: -1, // disable polling
+    timeoutMs: 5_000,
+  }));
+}
+
 export async function initOpenFeature() {
   OpenFeature.addHandler(ProviderEvents.Ready, checkDefaultProvider);
   OpenFeature.addHandler(ProviderEvents.Error, checkDefaultProvider);
 
-  const subPath = config.appSubUrl || '';
-  const baseUrl = `${subPath}/apis/features.grafana.app/v0alpha1/namespaces/${config.namespace}`;
-
   const lsProvider = getLocalStorageProvider();
-  const ofProvider = new OFREPWebProvider({
-    baseUrl: baseUrl,
-    pollInterval: -1, // disable polling
-    timeoutMs: 5_000,
-  });
+  const ofProvider = getOFREPWebProvider();
 
   await OpenFeature.setProviderAndWait(
     GRAFANA_CORE_OPEN_FEATURE_DOMAIN,

--- a/packages/grafana-runtime/src/internal/openFeature/index.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/index.ts
@@ -1,5 +1,6 @@
+import { LocalStorageProvider } from '@openfeature/localstorage-provider';
 import { OFREPWebProvider } from '@openfeature/ofrep-web-provider';
-import { OpenFeature, ProviderEvents, NOOP_PROVIDER, type EventDetails } from '@openfeature/react-sdk';
+import { OpenFeature, ProviderEvents, NOOP_PROVIDER, type EventDetails, MultiProvider } from '@openfeature/react-sdk';
 
 import { type FeatureToggles } from '@grafana/data';
 
@@ -37,6 +38,17 @@ export type FeatureFlagName = keyof FeatureToggles;
 // to ensure tests work correctly.
 export const GRAFANA_CORE_OPEN_FEATURE_DOMAIN = 'internal-grafana-core';
 
+export const GRAFANA_OPEN_FEATURE_LOCALSTORAGE_PREFIX = 'grafana.openfeature.';
+
+// Allow direct access to a singleton localStorage provider,
+//  to allow the feature control developer UI to override flags via the provider
+let localStorageProvider: LocalStorageProvider;
+export function getLocalStorageProvider() {
+  return (localStorageProvider ??= new LocalStorageProvider({
+    prefix: GRAFANA_OPEN_FEATURE_LOCALSTORAGE_PREFIX,
+  }));
+}
+
 export async function initOpenFeature() {
   OpenFeature.addHandler(ProviderEvents.Ready, checkDefaultProvider);
   OpenFeature.addHandler(ProviderEvents.Error, checkDefaultProvider);
@@ -44,16 +56,21 @@ export async function initOpenFeature() {
   const subPath = config.appSubUrl || '';
   const baseUrl = `${subPath}/apis/features.grafana.app/v0alpha1/namespaces/${config.namespace}`;
 
+  const lsProvider = getLocalStorageProvider();
   const ofProvider = new OFREPWebProvider({
     baseUrl: baseUrl,
     pollInterval: -1, // disable polling
     timeoutMs: 5_000,
   });
 
-  await OpenFeature.setProviderAndWait(GRAFANA_CORE_OPEN_FEATURE_DOMAIN, ofProvider, {
-    targetingKey: config.namespace,
-    ...config.openFeatureContext,
-  });
+  await OpenFeature.setProviderAndWait(
+    GRAFANA_CORE_OPEN_FEATURE_DOMAIN,
+    new MultiProvider([{ provider: lsProvider }, { provider: ofProvider }]),
+    {
+      targetingKey: config.namespace,
+      ...config.openFeatureContext,
+    }
+  );
 }
 
 /**

--- a/packages/grafana-runtime/src/internal/openFeature/index.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/index.ts
@@ -1,5 +1,6 @@
+import { LocalStorageProvider } from '@openfeature/localstorage-provider';
 import { OFREPWebProvider } from '@openfeature/ofrep-web-provider';
-import { OpenFeature, ProviderEvents, NOOP_PROVIDER, type EventDetails } from '@openfeature/react-sdk';
+import { OpenFeature, ProviderEvents, NOOP_PROVIDER, type EventDetails, MultiProvider } from '@openfeature/react-sdk';
 
 import { config } from '../../config';
 import { logError } from '../../utils/logging';
@@ -32,6 +33,16 @@ function checkDefaultProvider(event?: EventDetails) {
 // If changing this, you MUST also update the same constant in packages/grafana-test-utils/src/utilities/featureFlags.ts
 // to ensure tests work correctly.
 const GRAFANA_CORE_OPEN_FEATURE_DOMAIN = 'internal-grafana-core';
+const GRAFANA_OPEN_FEATURE_LOCALSTORAGE_PREFIX = 'grafana.openfeature.';
+
+// Allow direct access to a singleton localStorage provider,
+//  to allow the feature control developer UI to override flags via the provider
+let localStorageProvider: LocalStorageProvider;
+export function getLocalStorageProvider() {
+  return (localStorageProvider ??= new LocalStorageProvider({
+    prefix: GRAFANA_OPEN_FEATURE_LOCALSTORAGE_PREFIX,
+  }));
+}
 
 export async function initOpenFeature() {
   OpenFeature.addHandler(ProviderEvents.Ready, checkDefaultProvider);
@@ -40,6 +51,7 @@ export async function initOpenFeature() {
   const subPath = config.appSubUrl || '';
   const baseUrl = `${subPath}/apis/features.grafana.app/v0alpha1/namespaces/${config.namespace}`;
 
+  const lsProvider = getLocalStorageProvider();
   const ofProvider = new OFREPWebProvider({
     baseUrl: baseUrl,
     disableVisibilityRefresh: true, // Do not refresh
@@ -47,10 +59,14 @@ export async function initOpenFeature() {
     timeoutMs: 5_000,
   });
 
-  await OpenFeature.setProviderAndWait(GRAFANA_CORE_OPEN_FEATURE_DOMAIN, ofProvider, {
-    targetingKey: config.namespace,
-    ...config.openFeatureContext,
-  });
+  await OpenFeature.setProviderAndWait(
+    GRAFANA_CORE_OPEN_FEATURE_DOMAIN,
+    new MultiProvider([{ provider: lsProvider }, { provider: ofProvider }]),
+    {
+      targetingKey: config.namespace,
+      ...config.openFeatureContext,
+    }
+  );
 }
 
 /**

--- a/packages/grafana-runtime/src/internal/openFeature/index.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/index.ts
@@ -44,20 +44,24 @@ export function getLocalStorageProvider() {
   }));
 }
 
+// Allow direct access to a singleton OFREP provider,
+//  to allow the feature control developer UI to discover flags from the provider
+let ofrepWebProvider: OFREPWebProvider;
+export function getOFREPWebProvider() {
+  return (ofrepWebProvider ??= new OFREPWebProvider({
+    baseUrl: `${config.appSubUrl || ''}/apis/features.grafana.app/v0alpha1/namespaces/${config.namespace}`,
+    disableVisibilityRefresh: true, // Do not refresh
+    cacheMode: 'disabled', // Do not write to localStorage
+    timeoutMs: 5_000,
+  }));
+}
+
 export async function initOpenFeature() {
   OpenFeature.addHandler(ProviderEvents.Ready, checkDefaultProvider);
   OpenFeature.addHandler(ProviderEvents.Error, checkDefaultProvider);
 
-  const subPath = config.appSubUrl || '';
-  const baseUrl = `${subPath}/apis/features.grafana.app/v0alpha1/namespaces/${config.namespace}`;
-
   const lsProvider = getLocalStorageProvider();
-  const ofProvider = new OFREPWebProvider({
-    baseUrl: baseUrl,
-    disableVisibilityRefresh: true, // Do not refresh
-    cacheMode: 'disabled', // Do not write to localStorage
-    timeoutMs: 5_000,
-  });
+  const ofProvider = getOFREPWebProvider();
 
   await OpenFeature.setProviderAndWait(
     GRAFANA_CORE_OPEN_FEATURE_DOMAIN,

--- a/public/app/AppWrapper.tsx
+++ b/public/app/AppWrapper.tsx
@@ -13,6 +13,7 @@ import { getAppRoutes } from 'app/routes/routes';
 import { store } from 'app/store/store';
 
 import { ExtensionSidebarContextProvider } from './core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider';
+import { FeatureControlContextProvider } from './core/components/AppChrome/FeatureControl/FeatureControlProvider';
 import { GrafanaContext, type GrafanaContextType } from './core/context/GrafanaContext';
 import { GrafanaRouteWrapper } from './core/navigation/GrafanaRoute';
 import { type RouteDescriptor } from './core/navigation/types';
@@ -132,14 +133,16 @@ export function AppWrapper({ context }: AppWrapperProps) {
                     <ScopesContextProvider>
                       <ExtensionRegistriesProvider registries={registries}>
                         <ExtensionsSidebarProvider>
-                          <UNSAFE_PortalProvider getContainer={getPortalContainer}>
-                            <GlobalStyles />
-                            <div className="grafana-app">
-                              <RouterWrapper {...routerWrapperProps} />
-                              <LiveConnectionWarning />
-                              <PortalContainer />
-                            </div>
-                          </UNSAFE_PortalProvider>
+                          <FeatureControlContextProvider>
+                            <UNSAFE_PortalProvider getContainer={getPortalContainer}>
+                              <GlobalStyles />
+                              <div className="grafana-app">
+                                <RouterWrapper {...routerWrapperProps} />
+                                <LiveConnectionWarning />
+                                <PortalContainer />
+                              </div>
+                            </UNSAFE_PortalProvider>
+                          </FeatureControlContextProvider>
                         </ExtensionsSidebarProvider>
                       </ExtensionRegistriesProvider>
                     </ScopesContextProvider>

--- a/public/app/AppWrapper.tsx
+++ b/public/app/AppWrapper.tsx
@@ -13,6 +13,7 @@ import { getAppRoutes } from 'app/routes/routes';
 import { store } from 'app/store/store';
 
 import { ExtensionSidebarContextProvider } from './core/components/AppChrome/ExtensionSidebar/ExtensionSidebarProvider';
+import { FeatureControlContextProvider } from './core/components/AppChrome/FeatureControl/FeatureControlProvider';
 import { GrafanaContext, type GrafanaContextType } from './core/context/GrafanaContext';
 import { GrafanaRouteWrapper } from './core/navigation/GrafanaRoute';
 import { type RouteDescriptor } from './core/navigation/types';
@@ -125,16 +126,18 @@ export function AppWrapper({ context }: AppWrapperProps) {
                   <MaybeTimeRangeProvider>
                     <ScopesContextProvider>
                       <ExtensionRegistriesProvider registries={registries}>
-                        <ExtensionSidebarContextProvider>
-                          <UNSAFE_PortalProvider getContainer={getPortalContainer}>
-                            <GlobalStyles />
-                            <div className="grafana-app">
-                              <RouterWrapper {...routerWrapperProps} />
-                              <LiveConnectionWarning />
-                              <PortalContainer />
-                            </div>
-                          </UNSAFE_PortalProvider>
-                        </ExtensionSidebarContextProvider>
+                        <FeatureControlContextProvider>
+                          <ExtensionSidebarContextProvider>
+                            <UNSAFE_PortalProvider getContainer={getPortalContainer}>
+                              <GlobalStyles />
+                              <div className="grafana-app">
+                                <RouterWrapper {...routerWrapperProps} />
+                                <LiveConnectionWarning />
+                                <PortalContainer />
+                              </div>
+                            </UNSAFE_PortalProvider>
+                          </ExtensionSidebarContextProvider>
+                        </FeatureControlContextProvider>
                       </ExtensionRegistriesProvider>
                     </ScopesContextProvider>
                   </MaybeTimeRangeProvider>

--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -22,6 +22,7 @@ import {
   MIN_EXTENSION_SIDEBAR_WIDTH,
 } from './ExtensionSidebar/ExtensionSidebar';
 import { useExtensionSidebarContext } from './ExtensionSidebar/ExtensionSidebarProvider';
+import { FeatureControlFloating } from './FeatureControl/FeatureControlFloating';
 import { MegaMenu, MENU_WIDTH } from './MegaMenu/MegaMenu';
 import { useMegaMenuFocusHelper } from './MegaMenu/utils';
 import { ReturnToPrevious } from './ReturnToPrevious/ReturnToPrevious';
@@ -165,6 +166,7 @@ export function AppChrome({ children }: Props) {
       {!state.chromeless && !state.megaMenuDocked && <AppChromeMenu />}
       {!state.chromeless && <CommandPalette />}
       {!state.chromeless && isSplashScreenEnabled && <SplashScreenModal />}
+      {!state.chromeless && <FeatureControlFloating />}
       {shouldShowReturnToPrevious && state.returnToPrevious && (
         <ReturnToPrevious href={state.returnToPrevious.href} title={state.returnToPrevious.title} />
       )}

--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -23,6 +23,7 @@ import {
   MIN_EXTENSION_SIDEBAR_WIDTH,
 } from './ExtensionSidebar/ExtensionSidebar';
 import { useExtensionSidebarContext } from './ExtensionSidebar/ExtensionSidebarProvider';
+import { FeatureControlFloating } from './FeatureControl/FeatureControlFloating';
 import { MegaMenu, MENU_WIDTH } from './MegaMenu/MegaMenu';
 import { useMegaMenuFocusHelper } from './MegaMenu/utils';
 import { ReturnToPrevious } from './ReturnToPrevious/ReturnToPrevious';
@@ -167,6 +168,7 @@ export function AppChrome({ children }: Props) {
       {!state.chromeless && !state.megaMenuDocked && <AppChromeMenu />}
       {!state.chromeless && <CommandPalette />}
       {!state.chromeless && isSplashScreenEnabled && <SplashScreenModal />}
+      {!state.chromeless && <FeatureControlFloating />}
       {shouldShowReturnToPrevious && state.returnToPrevious && (
         <ReturnToPrevious href={state.returnToPrevious.href} title={state.returnToPrevious.title} />
       )}

--- a/public/app/core/components/AppChrome/FeatureControl/FeatureControlButton.test.tsx
+++ b/public/app/core/components/AppChrome/FeatureControl/FeatureControlButton.test.tsx
@@ -1,0 +1,91 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ComponentPropsWithoutRef } from 'react';
+
+import { FeatureControlButton } from './FeatureControlButton';
+import { type FeatureControlContextType, useFeatureControlContext } from './FeatureControlProvider';
+
+type MockToolbarButtonProps = ComponentPropsWithoutRef<'button'> & {
+  icon?: string;
+  iconOnly?: boolean;
+  tooltip?: string;
+  variant?: string;
+};
+
+const setIsAccessible = jest.fn();
+const setIsOpen = jest.fn();
+
+const buildContext = (overrides: Partial<FeatureControlContextType> = {}): FeatureControlContextType => ({
+  isAccessible: true,
+  setIsAccessible,
+  isOpen: false,
+  setIsOpen,
+  ...overrides,
+});
+
+jest.mock('@grafana/ui', () => ({
+  ToolbarButton: ({
+    icon: _icon,
+    iconOnly: _iconOnly,
+    onClick,
+    tooltip,
+    variant,
+    ...props
+  }: MockToolbarButtonProps) => (
+    <button {...props} data-tooltip={tooltip} data-variant={variant} onClick={onClick}>
+      {props['aria-label']}
+    </button>
+  ),
+}));
+
+jest.mock('./FeatureControlProvider', () => ({
+  useFeatureControlContext: jest.fn(),
+}));
+
+describe('FeatureControlButton', () => {
+  const useFeatureControlContextMock = jest.mocked(useFeatureControlContext);
+  const getButton = () => screen.getByRole('button', { name: 'Feature control' });
+
+  const expectButton = ({ expanded, tooltip, variant }: { expanded: string; tooltip: string; variant: string }) => {
+    const button = getButton();
+    expect(button).toHaveAttribute('aria-expanded', expanded);
+    expect(button).toHaveAttribute('data-tooltip', tooltip);
+    expect(button).toHaveAttribute('data-variant', variant);
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    useFeatureControlContextMock.mockReturnValue(buildContext());
+  });
+
+  it('does not render when feature control is not accessible', () => {
+    useFeatureControlContextMock.mockReturnValue(buildContext({ isAccessible: false }));
+
+    render(<FeatureControlButton />);
+
+    expect(screen.queryByRole('button', { name: 'Feature control' })).not.toBeInTheDocument();
+  });
+
+  it('renders a collapsed button when feature control is closed', () => {
+    render(<FeatureControlButton />);
+
+    expectButton({ expanded: 'false', tooltip: 'Open feature control', variant: 'default' });
+  });
+
+  it('renders an expanded button when feature control is open', () => {
+    useFeatureControlContextMock.mockReturnValue(buildContext({ isOpen: true }));
+
+    render(<FeatureControlButton />);
+
+    expectButton({ expanded: 'true', tooltip: 'Close feature control', variant: 'active' });
+  });
+
+  it('toggles the open state when clicked', async () => {
+    render(<FeatureControlButton />);
+
+    await userEvent.click(getButton());
+
+    expect(setIsOpen).toHaveBeenCalledWith(true);
+  });
+});

--- a/public/app/core/components/AppChrome/FeatureControl/FeatureControlButton.test.tsx
+++ b/public/app/core/components/AppChrome/FeatureControl/FeatureControlButton.test.tsx
@@ -1,0 +1,96 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ComponentPropsWithoutRef } from 'react';
+
+import { FeatureControlButton } from './FeatureControlButton';
+import { type FeatureControlContextType, useFeatureControlContext } from './FeatureControlProvider';
+
+type MockToolbarButtonProps = ComponentPropsWithoutRef<'button'> & {
+  icon?: string;
+  iconOnly?: boolean;
+  tooltip?: string;
+  variant?: string;
+};
+
+const setIsAccessible = jest.fn();
+const setIsOpen = jest.fn();
+const setCorner = jest.fn();
+
+const buildContext = (overrides: Partial<FeatureControlContextType> = {}): FeatureControlContextType => ({
+  isAccessible: true,
+  setIsAccessible,
+  isOpen: false,
+  setIsOpen,
+  corner: 'bottom-right',
+  setCorner,
+  ...overrides,
+});
+
+jest.mock('@grafana/ui', () => ({
+  ToolbarButton: ({
+    icon: _icon,
+    iconOnly: _iconOnly,
+    onClick,
+    tooltip,
+    variant,
+    ...props
+  }: MockToolbarButtonProps) => (
+    <button {...props} data-tooltip={tooltip} data-variant={variant} onClick={onClick}>
+      {props['aria-label']}
+    </button>
+  ),
+}));
+
+jest.mock('./FeatureControlProvider', () => ({
+  useFeatureControlContext: jest.fn(),
+}));
+
+describe('FeatureControlButton', () => {
+  const useFeatureControlContextMock = jest.mocked(useFeatureControlContext);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    useFeatureControlContextMock.mockReturnValue(buildContext());
+  });
+
+  it('does not render when feature control is not accessible', () => {
+    useFeatureControlContextMock.mockReturnValue(buildContext({ isAccessible: false }));
+
+    render(<FeatureControlButton />);
+
+    expect(screen.queryByRole('button', { name: 'Feature control' })).not.toBeInTheDocument();
+  });
+
+  it('renders a collapsed button when feature control is closed', () => {
+    render(<FeatureControlButton />);
+
+    expect(screen.getByRole('button', { name: 'Feature control' })).toHaveAttribute('aria-expanded', 'false');
+    expect(screen.getByRole('button', { name: 'Feature control' })).toHaveAttribute(
+      'data-tooltip',
+      'Open feature control'
+    );
+    expect(screen.getByRole('button', { name: 'Feature control' })).toHaveAttribute('data-variant', 'default');
+  });
+
+  it('renders an expanded button when feature control is open', () => {
+    useFeatureControlContextMock.mockReturnValue(buildContext({ isOpen: true }));
+
+    render(<FeatureControlButton />);
+
+    expect(screen.getByRole('button', { name: 'Feature control' })).toHaveAttribute('aria-expanded', 'true');
+    expect(screen.getByRole('button', { name: 'Feature control' })).toHaveAttribute(
+      'data-tooltip',
+      'Close feature control'
+    );
+    expect(screen.getByRole('button', { name: 'Feature control' })).toHaveAttribute('data-variant', 'active');
+  });
+
+  it('toggles the open state when clicked', async () => {
+    render(<FeatureControlButton />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Feature control' }));
+
+    expect(setIsOpen).toHaveBeenCalledWith(true);
+  });
+});

--- a/public/app/core/components/AppChrome/FeatureControl/FeatureControlButton.tsx
+++ b/public/app/core/components/AppChrome/FeatureControl/FeatureControlButton.tsx
@@ -1,0 +1,30 @@
+import { memo } from 'react';
+
+import { t } from '@grafana/i18n';
+import { ToolbarButton } from '@grafana/ui';
+
+import { useFeatureControlContext } from './FeatureControlProvider';
+
+export const FeatureControlButton = memo(function FeatureControlButton() {
+  const { isAccessible, isOpen, setIsOpen } = useFeatureControlContext();
+
+  if (!isAccessible) {
+    return null;
+  }
+
+  return (
+    <ToolbarButton
+      iconOnly
+      icon="flask"
+      aria-label={t('feature-control.button.aria-label', 'Feature control')}
+      aria-expanded={isOpen}
+      variant={isOpen ? 'active' : 'default'}
+      tooltip={
+        isOpen
+          ? t('feature-control.button.close-tooltip', 'Close feature control')
+          : t('feature-control.button.open-tooltip', 'Open feature control')
+      }
+      onClick={() => setIsOpen(!isOpen)}
+    />
+  );
+});

--- a/public/app/core/components/AppChrome/FeatureControl/FeatureControlFlag.test.tsx
+++ b/public/app/core/components/AppChrome/FeatureControl/FeatureControlFlag.test.tsx
@@ -2,6 +2,7 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { ComponentProps } from 'react';
 
+import * as runtimeInternal from '@grafana/runtime/internal';
 import { getLocalStorageProvider } from '@grafana/runtime/internal';
 import { mockComboboxRect } from '@grafana/test-utils';
 import type { CodeEditor } from '@grafana/ui';
@@ -78,7 +79,7 @@ describe('FeatureControlFlag', () => {
         renderComponent();
         await expandFlag('new-flag-override');
 
-        await userEvent.type(screen.getByRole('textbox', { name: 'Flag key' }), 'alpha');
+        await userEvent.type(screen.getByRole('combobox', { name: 'Flag key' }), 'alpha[Enter]');
         await changeType(type);
         await changeValue(after.input, type);
 
@@ -126,5 +127,20 @@ describe('FeatureControlFlag', () => {
     await waitFor(() => {
       expect(window.localStorage.getItem(getStorageKey('alpha'))).toBeNull();
     });
+  });
+
+  it('shows known flag names in the flag key combobox', async () => {
+    const mockOFREPProvider = {
+      flagCache: { 'feature-alpha': true, 'feature-beta': false } as Record<string, unknown>,
+      events: { addHandler: jest.fn(), removeHandler: jest.fn() },
+    };
+    jest.spyOn(runtimeInternal, 'getOFREPWebProvider').mockReturnValue(mockOFREPProvider as never);
+
+    renderComponent();
+    await expandFlag('new-flag-override');
+
+    await userEvent.click(screen.getByRole('combobox', { name: 'Flag key' }));
+    expect(screen.getByRole('option', { name: 'feature-alpha' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'feature-beta' })).toBeInTheDocument();
   });
 });

--- a/public/app/core/components/AppChrome/FeatureControl/FeatureControlFlag.test.tsx
+++ b/public/app/core/components/AppChrome/FeatureControl/FeatureControlFlag.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { getLocalStorageProvider } from '@grafana/runtime/internal';
+
+import { FeatureControlFlag, type FeatureControlFlagProps } from './FeatureControlFlag';
+
+type Flag = NonNullable<FeatureControlFlagProps['flag']>;
+
+const renderComponent = (flag?: Flag) => render(<FeatureControlFlag flag={flag} />);
+
+const getStorageKey = (flagName: string) => `grafana.openfeature.${flagName}`;
+
+const expandFlag = async (flagName: string) => {
+  await userEvent.click(screen.getByText(flagName));
+
+  await waitFor(() => {
+    expect(screen.getByLabelText('Flag value')).toBeVisible();
+  });
+};
+
+describe('FeatureControlFlag', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    window.localStorage.clear();
+    getLocalStorageProvider().clearFlags();
+  });
+
+  it('adds a new flag', async () => {
+    renderComponent();
+    await expandFlag('new-flag-override');
+
+    await userEvent.type(screen.getByLabelText('Flag key'), 'alpha');
+    await userEvent.type(screen.getByLabelText('Flag value'), 'true');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Save override' }));
+    await waitFor(() => {
+      expect(window.localStorage.getItem(getStorageKey('alpha'))).toBe('true');
+    });
+  });
+
+  it('updates an existing flag', async () => {
+    getLocalStorageProvider().setFlags({ alpha: true });
+
+    renderComponent({ key: 'alpha', value: 'true' });
+    await expandFlag('alpha');
+
+    await userEvent.clear(screen.getByLabelText('Flag value'));
+    await userEvent.type(screen.getByLabelText('Flag value'), 'false');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Save override' }));
+    await waitFor(() => {
+      expect(window.localStorage.getItem(getStorageKey('alpha'))).toBe('false');
+    });
+  });
+
+  it('removes an existing flag', async () => {
+    getLocalStorageProvider().setFlags({ alpha: true });
+
+    renderComponent({ key: 'alpha', value: 'true' });
+    await expandFlag('alpha');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Delete override' }));
+    await waitFor(() => {
+      expect(window.localStorage.getItem(getStorageKey('alpha'))).toBeNull();
+    });
+  });
+});

--- a/public/app/core/components/AppChrome/FeatureControl/FeatureControlFlag.test.tsx
+++ b/public/app/core/components/AppChrome/FeatureControl/FeatureControlFlag.test.tsx
@@ -1,9 +1,21 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { ComponentProps } from 'react';
 
 import { getLocalStorageProvider } from '@grafana/runtime/internal';
+import { mockComboboxRect } from '@grafana/test-utils';
+import type { CodeEditor } from '@grafana/ui';
 
 import { FeatureControlFlag, type FeatureControlFlagProps } from './FeatureControlFlag';
+
+type CodeEditorProps = ComponentProps<typeof CodeEditor>;
+
+jest.mock('@grafana/ui', () => ({
+  ...jest.requireActual('@grafana/ui'),
+  CodeEditor: ({ value, onChange }: CodeEditorProps) => (
+    <textarea aria-label="Flag value" value={value} onChange={(e) => onChange?.(e.target.value)} />
+  ),
+}));
 
 type Flag = NonNullable<FeatureControlFlagProps['flag']>;
 
@@ -15,42 +27,92 @@ const expandFlag = async (flagName: string) => {
   await userEvent.click(screen.getByText(flagName));
 
   await waitFor(() => {
-    expect(screen.getByLabelText('Flag value')).toBeVisible();
+    expect(screen.getByRole('button', { name: 'Save' })).toBeVisible();
   });
 };
 
+const changeType = async (type: string) => {
+  await userEvent.click(screen.getByRole('combobox', { name: 'Flag type' }));
+  await userEvent.click(screen.getByRole('option', { name: type }));
+};
+
+const changeValue = async (input: string, type: string) => {
+  if (type === 'boolean') {
+    await userEvent.click(screen.getByRole('radio', { name: input }));
+  } else {
+    const elm = screen.getByRole(type === 'number' ? 'spinbutton' : 'textbox', { name: 'Flag value' });
+    await userEvent.clear(elm);
+    await userEvent.type(elm, input);
+  }
+};
+
 describe('FeatureControlFlag', () => {
+  beforeAll(() => {
+    mockComboboxRect();
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
     window.localStorage.clear();
     getLocalStorageProvider().clearFlags();
   });
 
-  it('adds a new flag', async () => {
-    renderComponent();
-    await expandFlag('new-flag-override');
+  [
+    { type: 'boolean', before: { storage: 'true', expected: 'true' }, after: { input: 'true', expected: 'true' } },
+    { type: 'number', before: { storage: '42', expected: '42' }, after: { input: '42', expected: '42' } },
+    {
+      type: 'string',
+      before: { storage: 'hello world', expected: 'hello world' },
+      after: { input: 'hello world', expected: 'hello world' },
+    },
+    {
+      type: 'object',
+      before: { storage: '{"key":"value"}', expected: '{\n  "key": "value"\n}' },
+      after: { input: '{{"key": "value"}}', expected: '{"key":"value"}' },
+    },
+  ].map(({ type, before, after }) => {
+    describe(`${type} flags`, () => {
+      it('adds a new flag', async () => {
+        expect(window.localStorage.getItem(getStorageKey('alpha'))).toBeNull();
 
-    await userEvent.type(screen.getByLabelText('Flag key'), 'alpha');
-    await userEvent.type(screen.getByLabelText('Flag value'), 'true');
+        renderComponent();
+        await expandFlag('new-flag-override');
 
-    await userEvent.click(screen.getByRole('button', { name: 'Save override' }));
-    await waitFor(() => {
-      expect(window.localStorage.getItem(getStorageKey('alpha'))).toBe('true');
-    });
-  });
+        await userEvent.type(screen.getByRole('textbox', { name: 'Flag key' }), 'alpha');
+        await changeType(type);
+        await changeValue(after.input, type);
 
-  it('updates an existing flag', async () => {
-    getLocalStorageProvider().setFlags({ alpha: true });
+        await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+        await waitFor(() => {
+          expect(window.localStorage.getItem(getStorageKey('alpha'))).toBe(after.expected);
+        });
+      });
 
-    renderComponent({ key: 'alpha', value: 'true' });
-    await expandFlag('alpha');
+      it('updates an existing flag', async () => {
+        getLocalStorageProvider().setFlags({ alpha: before.storage });
 
-    await userEvent.clear(screen.getByLabelText('Flag value'));
-    await userEvent.type(screen.getByLabelText('Flag value'), 'false');
+        renderComponent({ key: 'alpha', value: before.storage });
+        await expandFlag('alpha');
 
-    await userEvent.click(screen.getByRole('button', { name: 'Save override' }));
-    await waitFor(() => {
-      expect(window.localStorage.getItem(getStorageKey('alpha'))).toBe('false');
+        expect(screen.getByRole('textbox', { name: 'Flag key' })).toHaveValue('alpha');
+        expect(screen.getByRole('combobox', { name: 'Flag type' })).toHaveValue(type);
+
+        if (type === 'boolean') {
+          expect(screen.getByRole('radio', { name: before.expected })).toBeChecked();
+          expect(screen.getByRole('radio', { name: before.expected === 'true' ? 'false' : 'true' })).not.toBeChecked();
+        } else {
+          expect(screen.getByRole(type === 'number' ? 'spinbutton' : 'textbox', { name: 'Flag value' })).toHaveValue(
+            type === 'number' ? Number(before.expected) : before.expected
+          );
+        }
+
+        await changeValue(after.input, type);
+
+        await userEvent.click(screen.getByRole('button', { name: 'Save' }));
+        await waitFor(() => {
+          expect(window.localStorage.getItem(getStorageKey('alpha'))).toBe(after.expected);
+        });
+      });
     });
   });
 
@@ -60,7 +122,7 @@ describe('FeatureControlFlag', () => {
     renderComponent({ key: 'alpha', value: 'true' });
     await expandFlag('alpha');
 
-    await userEvent.click(screen.getByRole('button', { name: 'Delete override' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
     await waitFor(() => {
       expect(window.localStorage.getItem(getStorageKey('alpha'))).toBeNull();
     });

--- a/public/app/core/components/AppChrome/FeatureControl/FeatureControlFlag.tsx
+++ b/public/app/core/components/AppChrome/FeatureControl/FeatureControlFlag.tsx
@@ -1,0 +1,158 @@
+import { css } from '@emotion/css';
+import { useEffect, useState } from 'react';
+
+import type { GrafanaTheme2 } from '@grafana/data';
+import { t, Trans } from '@grafana/i18n';
+import { getLocalStorageProvider } from '@grafana/runtime/internal';
+import { Badge, Field, IconButton, Input, Stack, Text, useStyles2 } from '@grafana/ui';
+
+export type FeatureControlFlagProps = {
+  flag?: {
+    key: string;
+    value: string;
+  };
+};
+
+const getBadgeColor = (value: string) => {
+  if (value === 'true') {
+    return 'green';
+  }
+  if (value === 'false') {
+    return 'red';
+  }
+  return 'blue';
+};
+
+export const FeatureControlFlag = ({ flag }: FeatureControlFlagProps) => {
+  const styles = useStyles2(getStyles);
+  const [key, setKey] = useState(flag?.key ?? '');
+  const [value, setValue] = useState(flag?.value ?? '');
+
+  useEffect(() => {
+    setValue(flag?.key ?? '');
+  }, [flag?.key]);
+
+  useEffect(() => {
+    setValue(flag?.value ?? '');
+  }, [flag?.value]);
+
+  return (
+    <details className={styles.details}>
+      <summary>
+        <Stack direction="row" gap={1} alignItems="center" justifyContent="space-between">
+          {flag ? (
+            <>
+              <Text variant="code" truncate>
+                {flag.key}
+              </Text>
+              <Badge
+                color={getBadgeColor(flag.value)}
+                text={
+                  <Text variant="code" truncate>
+                    {flag.value}
+                  </Text>
+                }
+              />
+            </>
+          ) : (
+            <>
+              <Text variant="code" color="secondary" truncate>
+                <Trans i18nKey="feature-control.new-flag">new-flag-override</Trans>
+              </Text>
+              <Badge icon="plus" color="darkgrey" />
+            </>
+          )}
+        </Stack>
+      </summary>
+
+      <div className={styles.fields}>
+        <Field noMargin disabled={!!flag}>
+          <Input
+            value={key}
+            aria-label={t('feature-control.flag-key', 'Flag key')}
+            placeholder={t('feature-control.flag-key-placeholder', 'my-component.my-flag')}
+            onChange={(e) => setKey(e.currentTarget.value)}
+          />
+        </Field>
+
+        <Field noMargin>
+          <Input
+            value={value}
+            aria-label={t('feature-control.flag-value', 'Flag value')}
+            placeholder={t('feature-control.flag-value-placeholder', 'true, false, a string, number, or JSON')}
+            onChange={(e) => setValue(e.currentTarget.value)}
+          />
+        </Field>
+
+        <Stack direction="row" gap={1}>
+          <IconButton
+            name="save"
+            size="lg"
+            tooltip={t('feature-control.save-flag', 'Save override')}
+            onClick={() => {
+              getLocalStorageProvider().setFlags({ [key]: value });
+              if (!flag) {
+                setKey('');
+                setValue('');
+              }
+            }}
+            disabled={value === flag?.value || !value.trim() || !key.trim()}
+            variant="primary"
+          />
+
+          <IconButton
+            name="trash-alt"
+            size="lg"
+            tooltip={t('feature-control.delete-flag', 'Delete override')}
+            onClick={() => {
+              getLocalStorageProvider().setFlags({ [key]: undefined });
+            }}
+            disabled={!flag}
+            variant="destructive"
+          />
+        </Stack>
+      </div>
+    </details>
+  );
+};
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  details: css({
+    '&[open]': {
+      display: 'flex',
+      flexDirection: 'column',
+      gap: theme.spacing(1),
+    },
+
+    '> summary': {
+      listStyle: 'none',
+      cursor: 'pointer',
+      padding: theme.spacing(1),
+      margin: theme.spacing(-0.5, -1),
+      borderRadius: theme.shape.radius.sm,
+
+      '&:hover': {
+        backgroundColor: theme.colors.background.primary,
+      },
+
+      '&::-webkit-details-marker': {
+        display: 'none',
+      },
+
+      span: {
+        lineHeight: 1.5,
+      },
+    },
+  }),
+  fields: css({
+    boxSizing: 'border-box',
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1),
+
+    input: {
+      fontFamily: theme.typography.code.fontFamily,
+      fontSize: theme.typography.code.fontSize,
+    },
+  }),
+});

--- a/public/app/core/components/AppChrome/FeatureControl/FeatureControlFlag.tsx
+++ b/public/app/core/components/AppChrome/FeatureControl/FeatureControlFlag.tsx
@@ -1,10 +1,22 @@
 import { css } from '@emotion/css';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
 
 import type { GrafanaTheme2 } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 import { getLocalStorageProvider } from '@grafana/runtime/internal';
-import { Badge, Field, IconButton, Input, Stack, Text, useStyles2 } from '@grafana/ui';
+import {
+  Badge,
+  type BadgeColor,
+  Button,
+  CodeEditor,
+  Combobox,
+  Field,
+  Input,
+  RadioButtonGroup,
+  Stack,
+  Text,
+  useStyles2,
+} from '@grafana/ui';
 
 export type FeatureControlFlagProps = {
   flag?: {
@@ -13,32 +25,121 @@ export type FeatureControlFlagProps = {
   };
 };
 
-const getBadgeColor = (value: string) => {
-  if (value === 'true') {
-    return 'green';
+const types = ['boolean', 'number', 'string', 'object'] as const;
+type FeatureControlFlagType = (typeof types)[number];
+
+const getFlagType = (value: string): FeatureControlFlagType => {
+  if (value === 'true' || value === 'false') {
+    return 'boolean';
   }
-  if (value === 'false') {
-    return 'red';
+
+  const number = Number.parseFloat(value);
+  if (!Number.isNaN(number)) {
+    return 'number';
   }
-  return 'blue';
+
+  try {
+    JSON.parse(value);
+    return 'object';
+  } catch {}
+
+  return 'string';
+};
+
+const getBadgeText = (value: string): string => {
+  const type = getFlagType(value);
+
+  switch (type) {
+    case 'boolean':
+    case 'number':
+    case 'string':
+      return value;
+    case 'object':
+      return '{...}';
+  }
+};
+
+const getBadgeColor = (value: string): BadgeColor => {
+  const type = getFlagType(value);
+
+  switch (type) {
+    case 'boolean':
+      return value === 'true' ? 'green' : 'red';
+    case 'number':
+      return 'orange';
+    case 'string':
+      return 'purple';
+    case 'object':
+      return 'blue';
+  }
 };
 
 export const FeatureControlFlag = ({ flag }: FeatureControlFlagProps) => {
   const styles = useStyles2(getStyles);
-  const [key, setKey] = useState(flag?.key ?? '');
-  const [value, setValue] = useState(flag?.value ?? '');
+  const ref = useRef<HTMLDetailsElement>(null);
+  const [key, setKey] = useState('');
+  const [value, setValue] = useState('true');
+  const [json, setJson] = useState('true');
+  const [type, setType] = useState<FeatureControlFlagType>('boolean');
+  const [error, setError] = useState<string>();
+  const id = useId();
+
+  const reset = useCallback(() => {
+    setKey(flag?.key ?? '');
+    setValue(flag?.value ?? 'true');
+    setJson(() => {
+      try {
+        return JSON.stringify(JSON.parse(flag?.value ?? 'true'), null, 2);
+      } catch {
+        return flag?.value ?? 'true';
+      }
+    });
+    setType(flag ? getFlagType(flag.value) : 'boolean');
+    setError(undefined);
+  }, [flag]);
 
   useEffect(() => {
-    setValue(flag?.key ?? '');
-  }, [flag?.key]);
+    reset();
+  }, [reset]);
 
-  useEffect(() => {
-    setValue(flag?.value ?? '');
-  }, [flag?.value]);
+  const changeType = (newType: FeatureControlFlagType) => {
+    setType(newType);
+
+    const newValue = (() => {
+      switch (newType) {
+        case 'boolean':
+          return ['false', '0', ''].includes(value) ? 'false' : 'true';
+        case 'number':
+          return !Number.isNaN(Number.parseFloat(value)) ? value : '0';
+        case 'string':
+          return value;
+        case 'object':
+          try {
+            return JSON.stringify(JSON.parse(value), null, 2);
+          } catch {
+            return JSON.stringify(value, null, 2);
+          }
+      }
+    })();
+
+    setValue(newValue);
+    setJson(newValue);
+  };
+
+  const changeJson = (newJson: string) => {
+    setJson(newJson);
+
+    try {
+      setValue(JSON.stringify(JSON.parse(newJson)));
+      setError(undefined);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    }
+  };
 
   return (
-    <details className={styles.details}>
-      <summary>
+    <details ref={ref} className={styles.details}>
+      <summary onClick={reset}>
         <Stack direction="row" gap={1} alignItems="center" justifyContent="space-between">
           {flag ? (
             <>
@@ -49,7 +150,7 @@ export const FeatureControlFlag = ({ flag }: FeatureControlFlagProps) => {
                 color={getBadgeColor(flag.value)}
                 text={
                   <Text variant="code" truncate>
-                    {flag.value}
+                    {getBadgeText(flag.value)}
                   </Text>
                 }
               />
@@ -75,42 +176,96 @@ export const FeatureControlFlag = ({ flag }: FeatureControlFlagProps) => {
           />
         </Field>
 
-        <Field noMargin>
-          <Input
-            value={value}
-            aria-label={t('feature-control.flag-value', 'Flag value')}
-            placeholder={t('feature-control.flag-value-placeholder', 'true, false, a string, number, or JSON')}
-            onChange={(e) => setValue(e.currentTarget.value)}
-          />
-        </Field>
+        <Stack direction="row" gap={1} alignItems="center">
+          <Field
+            label={
+              <label htmlFor={`${id}-type`} className="sr-only">
+                <Trans i18nKey="feature-control.flag-type">Flag type</Trans>
+              </label>
+            }
+            noMargin
+          >
+            <Combobox
+              id={`${id}-type`}
+              options={types.map((t) => ({ label: t, value: t }))}
+              value={type}
+              onChange={(v) => changeType(v.value)}
+            />
+          </Field>
 
-        <Stack direction="row" gap={1}>
-          <IconButton
-            name="save"
-            size="lg"
-            tooltip={t('feature-control.save-flag', 'Save override')}
+          <Button
+            icon="save"
             onClick={() => {
               getLocalStorageProvider().setFlags({ [key]: value });
               if (!flag) {
-                setKey('');
-                setValue('');
+                reset();
+                if (ref.current) {
+                  ref.current.open = false;
+                }
               }
             }}
-            disabled={value === flag?.value || !value.trim() || !key.trim()}
-            variant="primary"
-          />
+            disabled={flag?.value === value || !key.trim()}
+          >
+            <Trans i18nKey="feature-control.save-flag">Save</Trans>
+          </Button>
 
-          <IconButton
-            name="trash-alt"
-            size="lg"
-            tooltip={t('feature-control.delete-flag', 'Delete override')}
+          <Button
+            icon="trash-alt"
+            variant="destructive"
             onClick={() => {
               getLocalStorageProvider().setFlags({ [key]: undefined });
             }}
             disabled={!flag}
-            variant="destructive"
-          />
+          >
+            <Trans i18nKey="feature-control.delete-flag">Delete</Trans>
+          </Button>
         </Stack>
+
+        {type === 'boolean' && (
+          <Field
+            label={
+              <span className="sr-only">
+                <Trans i18nKey="feature-control.flag-value">Flag value</Trans>
+              </span>
+            }
+            noMargin
+          >
+            <RadioButtonGroup
+              options={[
+                { label: 'true', value: 'true' },
+                { label: 'false', value: 'false' },
+              ]}
+              value={value}
+              onChange={setValue}
+              fullWidth
+            />
+          </Field>
+        )}
+
+        {(type === 'number' || type === 'string') && (
+          <Field
+            label={
+              <label htmlFor={`${id}-value`} className="sr-only">
+                <Trans i18nKey="feature-control.flag-value">Flag value</Trans>
+              </label>
+            }
+            noMargin
+          >
+            <Input
+              id={`${id}-value`}
+              type={type === 'number' ? 'number' : 'text'}
+              value={value}
+              aria-label={t('feature-control.flag-value', 'Flag value')}
+              onChange={(e) => setValue(e.currentTarget.value)}
+            />
+          </Field>
+        )}
+
+        {type === 'object' && (
+          <Field noMargin error={error} invalid={!!error}>
+            <CodeEditor value={json} onChange={changeJson} language="json" height={80} />
+          </Field>
+        )}
       </div>
     </details>
   );

--- a/public/app/core/components/AppChrome/FeatureControl/FeatureControlFlag.tsx
+++ b/public/app/core/components/AppChrome/FeatureControl/FeatureControlFlag.tsx
@@ -1,15 +1,17 @@
 import { css } from '@emotion/css';
+import { ClientProviderEvents } from '@openfeature/web-sdk';
 import { useCallback, useEffect, useId, useRef, useState } from 'react';
 
 import type { GrafanaTheme2 } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
-import { getLocalStorageProvider } from '@grafana/runtime/internal';
+import { getLocalStorageProvider, getOFREPWebProvider } from '@grafana/runtime/internal';
 import {
   Badge,
   type BadgeColor,
   Button,
   CodeEditor,
   Combobox,
+  type ComboboxOption,
   Field,
   Input,
   RadioButtonGroup,
@@ -17,6 +19,8 @@ import {
   Text,
   useStyles2,
 } from '@grafana/ui';
+
+const compare = new Intl.Collator('en', { sensitivity: 'base', numeric: true }).compare;
 
 export type FeatureControlFlagProps = {
   flag?: {
@@ -72,6 +76,47 @@ const getBadgeColor = (value: string): BadgeColor => {
     case 'object':
       return 'blue';
   }
+};
+
+const FeatureControlKey = ({ value, onChange }: { value: string; onChange: (value: string) => void }) => {
+  const [keys, setKeys] = useState<Array<ComboboxOption<string>>>([]);
+  const id = useId();
+
+  useEffect(() => {
+    const loadKeys = () => {
+      setKeys(
+        Object.keys(getOFREPWebProvider().flagCache)
+          .sort((a, b) => compare(a, b))
+          .map((k) => ({ label: k, value: k }))
+      );
+    };
+    loadKeys();
+
+    getOFREPWebProvider().events.addHandler(ClientProviderEvents.ConfigurationChanged, loadKeys);
+    return () => {
+      getOFREPWebProvider().events.removeHandler(ClientProviderEvents.ConfigurationChanged, loadKeys);
+    };
+  }, []);
+
+  return (
+    <Field
+      label={
+        <label htmlFor={`${id}-key`} className="sr-only">
+          <Trans i18nKey="feature-control.flag-key">Flag key</Trans>
+        </label>
+      }
+      noMargin
+    >
+      <Combobox
+        id={`${id}-key`}
+        options={keys}
+        value={value}
+        placeholder={t('feature-control.flag-key-placeholder', 'my-component.my-flag')}
+        onChange={(v) => onChange(v.value)}
+        createCustomValue
+      />
+    </Field>
+  );
 };
 
 export const FeatureControlFlag = ({ flag }: FeatureControlFlagProps) => {
@@ -167,14 +212,17 @@ export const FeatureControlFlag = ({ flag }: FeatureControlFlagProps) => {
       </summary>
 
       <div className={styles.fields}>
-        <Field noMargin disabled={!!flag}>
-          <Input
-            value={key}
-            aria-label={t('feature-control.flag-key', 'Flag key')}
-            placeholder={t('feature-control.flag-key-placeholder', 'my-component.my-flag')}
-            onChange={(e) => setKey(e.currentTarget.value)}
-          />
-        </Field>
+        {flag ? (
+          <Field noMargin disabled>
+            <Input
+              value={key}
+              aria-label={t('feature-control.flag-key', 'Flag key')}
+              placeholder={t('feature-control.flag-key-placeholder', 'my-component.my-flag')}
+            />
+          </Field>
+        ) : (
+          <FeatureControlKey value={key} onChange={setKey} />
+        )}
 
         <Stack direction="row" gap={1} alignItems="center">
           <Field

--- a/public/app/core/components/AppChrome/FeatureControl/FeatureControlFlags.test.tsx
+++ b/public/app/core/components/AppChrome/FeatureControl/FeatureControlFlags.test.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { getLocalStorageProvider } from '@grafana/runtime/internal';
+
+import { FeatureControlFlags } from './FeatureControlFlags';
+import { FeatureControlContext } from './FeatureControlProvider';
+
+const setIsAccessible = jest.fn();
+const setIsOpen = jest.fn();
+
+const renderComponent = () => {
+  return render(
+    <FeatureControlContext.Provider
+      value={{
+        isAccessible: true,
+        setIsAccessible,
+        isOpen: true,
+        setIsOpen,
+      }}
+    >
+      <FeatureControlFlags />
+    </FeatureControlContext.Provider>
+  );
+};
+
+const getStorageKey = (flagName: string) => `grafana.openfeature.${flagName}`;
+
+describe('FeatureControlFlags', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    window.localStorage.clear();
+    getLocalStorageProvider().clearFlags();
+  });
+
+  it('renders flags from local storage', async () => {
+    getLocalStorageProvider().setFlags({ alpha: true, beta: 'custom-value' });
+
+    renderComponent();
+
+    expect(await screen.findByText('alpha')).toBeInTheDocument();
+    expect(screen.getByText('beta')).toBeInTheDocument();
+    expect(screen.getByText('custom-value')).toBeInTheDocument();
+  });
+
+  it('dismisses feature control', async () => {
+    getLocalStorageProvider().setFlags({ alpha: true });
+
+    renderComponent();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+    await userEvent.click(screen.getByRole('menuitem', { name: /Remove UI and toolbar button/ }));
+
+    expect(setIsOpen).toHaveBeenCalledWith(false);
+    expect(setIsAccessible).toHaveBeenCalledWith(false);
+    expect(window.localStorage.getItem(getStorageKey('alpha'))).toBe('true');
+  });
+});

--- a/public/app/core/components/AppChrome/FeatureControl/FeatureControlFlags.test.tsx
+++ b/public/app/core/components/AppChrome/FeatureControl/FeatureControlFlags.test.tsx
@@ -51,10 +51,41 @@ describe('FeatureControlFlags', () => {
 
     renderComponent();
 
-    await userEvent.click(screen.getByRole('button', { name: 'Dismiss feature control' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+    await userEvent.click(screen.getByRole('menuitem', { name: /Remove UI and toolbar button/ }));
 
     expect(setIsOpen).toHaveBeenCalledWith(false);
     expect(setIsAccessible).toHaveBeenCalledWith(false);
     expect(window.localStorage.getItem(getStorageKey('alpha'))).toBe('true');
+  });
+
+  it('updates position when menu item is clicked', async () => {
+    getLocalStorageProvider().setFlags({ alpha: true });
+
+    renderComponent();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+    await userEvent.click(screen.getByRole('menuitem', { name: 'Top left' }));
+
+    expect(setCorner).toHaveBeenCalledWith('top-left');
+  });
+
+  it('changes position between different corners', async () => {
+    getLocalStorageProvider().setFlags({ alpha: true });
+
+    renderComponent();
+
+    const corners = [
+      { name: 'Top right', value: 'top-right' },
+      { name: 'Bottom left', value: 'bottom-left' },
+      { name: 'Bottom right', value: 'bottom-right' },
+    ];
+
+    for (const corner of corners) {
+      jest.clearAllMocks();
+      await userEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+      await userEvent.click(screen.getByRole('menuitem', { name: corner.name }));
+      expect(setCorner).toHaveBeenCalledWith(corner.value);
+    }
   });
 });

--- a/public/app/core/components/AppChrome/FeatureControl/FeatureControlFlags.test.tsx
+++ b/public/app/core/components/AppChrome/FeatureControl/FeatureControlFlags.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { getLocalStorageProvider } from '@grafana/runtime/internal';
+
+import { FeatureControlFlags } from './FeatureControlFlags';
+import { FeatureControlContext } from './FeatureControlProvider';
+
+const setIsAccessible = jest.fn();
+const setIsOpen = jest.fn();
+const setCorner = jest.fn();
+
+const renderComponent = () => {
+  return render(
+    <FeatureControlContext.Provider
+      value={{
+        isAccessible: true,
+        setIsAccessible,
+        isOpen: true,
+        setIsOpen,
+        corner: 'bottom-right',
+        setCorner,
+      }}
+    >
+      <FeatureControlFlags />
+    </FeatureControlContext.Provider>
+  );
+};
+
+const getStorageKey = (flagName: string) => `grafana.openfeature.${flagName}`;
+
+describe('FeatureControlFlags', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    window.localStorage.clear();
+    getLocalStorageProvider().clearFlags();
+  });
+
+  it('renders flags from local storage', async () => {
+    getLocalStorageProvider().setFlags({ alpha: true, beta: 'custom-value' });
+
+    renderComponent();
+
+    expect(await screen.findByText('alpha')).toBeInTheDocument();
+    expect(screen.getByText('beta')).toBeInTheDocument();
+    expect(screen.getByText('custom-value')).toBeInTheDocument();
+  });
+
+  it('dismisses feature control', async () => {
+    getLocalStorageProvider().setFlags({ alpha: true });
+
+    renderComponent();
+
+    await userEvent.click(screen.getByRole('button', { name: 'Dismiss feature control' }));
+
+    expect(setIsOpen).toHaveBeenCalledWith(false);
+    expect(setIsAccessible).toHaveBeenCalledWith(false);
+    expect(window.localStorage.getItem(getStorageKey('alpha'))).toBe('true');
+  });
+});

--- a/public/app/core/components/AppChrome/FeatureControl/FeatureControlFlags.tsx
+++ b/public/app/core/components/AppChrome/FeatureControl/FeatureControlFlags.tsx
@@ -1,0 +1,113 @@
+import { css } from '@emotion/css';
+import { ClientProviderEvents } from '@openfeature/web-sdk';
+import { useEffect, useState } from 'react';
+
+import type { GrafanaTheme2 } from '@grafana/data';
+import { t, Trans } from '@grafana/i18n';
+import { getLocalStorageProvider } from '@grafana/runtime/internal';
+import { Card, Dropdown, Icon, IconButton, Menu, MenuItem, Stack, Text, useStyles2 } from '@grafana/ui';
+
+import { FeatureControlFlag, type FeatureControlFlagProps } from './FeatureControlFlag';
+import { useFeatureControlContext } from './FeatureControlProvider';
+
+const compare = new Intl.Collator('en', { sensitivity: 'base', numeric: true }).compare;
+
+type Flag = NonNullable<FeatureControlFlagProps['flag']>;
+
+export const FeatureControlFlags = () => {
+  const { setIsOpen, setIsAccessible } = useFeatureControlContext();
+  const [flags, setFlags] = useState<Flag[]>([]);
+  const styles = useStyles2(getStyles);
+
+  useEffect(() => {
+    const loadFlags = () => {
+      setFlags(
+        Object.entries(getLocalStorageProvider().getFlags())
+          .map(([key, value]) => ({ key, value }))
+          .sort((a, b) => compare(a.key, b.key))
+      );
+    };
+    loadFlags();
+
+    getLocalStorageProvider().events.addHandler(ClientProviderEvents.ConfigurationChanged, loadFlags);
+    return () => {
+      getLocalStorageProvider().events.removeHandler(ClientProviderEvents.ConfigurationChanged, loadFlags);
+    };
+  }, []);
+
+  return (
+    <Card noMargin className={styles.card}>
+      <Stack direction="row" alignItems="center">
+        <Icon name="flask" size="xl" />
+        <Text variant="h4">
+          <Trans i18nKey="feature-control.title">Feature control</Trans>
+        </Text>
+
+        <Dropdown
+          overlay={
+            <Menu onOpen={(focusOnItem) => focusOnItem(-1)}>
+              <MenuItem
+                onClick={() => {
+                  setIsOpen(false);
+                  setIsAccessible(false);
+                }}
+                destructive
+                icon="times"
+                label={t('feature-control.dismiss.label', 'Remove UI and toolbar button')}
+                component={() => (
+                  <Text color="secondary" variant="bodySmall" textAlignment="start">
+                    <Trans i18nKey="feature-control.dismiss.tooltip" values={{ param: '?featureControl=true' }}>
+                      Any feature flag overrides defined will remain active.
+                      <br /> Use <code>{'{{ param }}'}</code> in the URL to enable UI again.
+                    </Trans>
+                  </Text>
+                )}
+              />
+            </Menu>
+          }
+          placement="bottom-start"
+        >
+          <IconButton
+            tooltip={t('feature-control.menu', 'Open menu')}
+            variant="secondary"
+            name="bars"
+            className={styles.menu}
+          />
+        </Dropdown>
+      </Stack>
+      <Text variant="body" color="secondary">
+        <Trans i18nKey="feature-control.description">
+          Override frontend feature flags locally for testing and development purposes.
+        </Trans>
+      </Text>
+
+      <div className={styles.list}>
+        {flags.map((flag) => (
+          <FeatureControlFlag key={flag.key} flag={flag} />
+        ))}
+        <FeatureControlFlag />
+      </div>
+    </Card>
+  );
+};
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  card: css({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1),
+    width: theme.spacing(50),
+    boxShadow: theme.shadows.z2,
+    border: `1px solid ${theme.colors.border.medium}`,
+  }),
+  menu: css({
+    marginLeft: 'auto',
+  }),
+  list: css({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1),
+    margin: theme.spacing(0, 0, 1),
+    width: '100%',
+  }),
+});

--- a/public/app/core/components/AppChrome/FeatureControl/FeatureControlFlags.tsx
+++ b/public/app/core/components/AppChrome/FeatureControl/FeatureControlFlags.tsx
@@ -1,0 +1,97 @@
+import { css } from '@emotion/css';
+import { ClientProviderEvents } from '@openfeature/web-sdk';
+import { useEffect, useState } from 'react';
+
+import type { GrafanaTheme2 } from '@grafana/data';
+import { Trans } from '@grafana/i18n';
+import { getLocalStorageProvider } from '@grafana/runtime/internal';
+import { Button, Card, Icon, Stack, Text, useStyles2 } from '@grafana/ui';
+
+import { FeatureControlFlag, type FeatureControlFlagProps } from './FeatureControlFlag';
+import { useFeatureControlContext } from './FeatureControlProvider';
+
+const compare = new Intl.Collator('en', { sensitivity: 'base', numeric: true }).compare;
+
+type Flag = NonNullable<FeatureControlFlagProps['flag']>;
+
+export const FeatureControlFlags = () => {
+  const { setIsOpen, setIsAccessible } = useFeatureControlContext();
+  const [flags, setFlags] = useState<Flag[]>([]);
+  const styles = useStyles2(getStyles);
+
+  useEffect(() => {
+    const loadFlags = () => {
+      setFlags(
+        Object.entries(getLocalStorageProvider().getFlags())
+          .map(([key, value]) => ({ key, value }))
+          .sort((a, b) => compare(a.key, b.key))
+      );
+    };
+    loadFlags();
+
+    getLocalStorageProvider().events.addHandler(ClientProviderEvents.ConfigurationChanged, loadFlags);
+    return () => {
+      getLocalStorageProvider().events.removeHandler(ClientProviderEvents.ConfigurationChanged, loadFlags);
+    };
+  }, []);
+
+  return (
+    <Card noMargin className={styles.card}>
+      <Stack direction="row" alignItems="center">
+        <Icon name="flask" size="xl" />
+        <Text variant="h4">
+          <Trans i18nKey="feature-control.title">Feature control</Trans>
+        </Text>
+      </Stack>
+      <Text variant="body" color="secondary">
+        <Trans i18nKey="feature-control.description">
+          Override frontend feature flags locally for testing and development purposes.
+        </Trans>
+      </Text>
+
+      <div className={styles.list}>
+        {flags.map((flag) => (
+          <FeatureControlFlag key={flag.key} flag={flag} />
+        ))}
+        <FeatureControlFlag />
+      </div>
+
+      <Button
+        size="sm"
+        variant="destructive"
+        fill="outline"
+        fullWidth
+        onClick={() => {
+          setIsOpen(false);
+          setIsAccessible(false);
+        }}
+        tooltip={
+          <Trans i18nKey="feature-control.dismiss-tooltip" values={{ param: '?featureControl=true' }}>
+            Removes the feature control UI and toolbar button. Use <code>{'{{ param }}'}</code> in the URL to enable it
+            again. Any overrides defined will remain active.
+          </Trans>
+        }
+      >
+        <Trans i18nKey="feature-control.dismiss">Dismiss feature control</Trans>
+      </Button>
+    </Card>
+  );
+};
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  card: css({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1),
+    width: theme.spacing(50),
+    boxShadow: theme.shadows.z2,
+    border: `1px solid ${theme.colors.border.medium}`,
+  }),
+  list: css({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1),
+    margin: theme.spacing(0, 0, 1),
+    width: '100%',
+  }),
+});

--- a/public/app/core/components/AppChrome/FeatureControl/FeatureControlFlags.tsx
+++ b/public/app/core/components/AppChrome/FeatureControl/FeatureControlFlags.tsx
@@ -1,6 +1,6 @@
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import { ClientProviderEvents } from '@openfeature/web-sdk';
-import { useEffect, useState } from 'react';
+import { type PointerEventHandler, useEffect, useState } from 'react';
 
 import type { GrafanaTheme2 } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
@@ -14,7 +14,12 @@ const compare = new Intl.Collator('en', { sensitivity: 'base', numeric: true }).
 
 type Flag = NonNullable<FeatureControlFlagProps['flag']>;
 
-export const FeatureControlFlags = () => {
+type FeatureControlFlagsProps = {
+  className?: string;
+  onPointerDown?: PointerEventHandler<HTMLDivElement>;
+};
+
+export const FeatureControlFlags = ({ className, onPointerDown }: FeatureControlFlagsProps) => {
   const { setIsOpen, setIsAccessible } = useFeatureControlContext();
   const [flags, setFlags] = useState<Flag[]>([]);
   const styles = useStyles2(getStyles);
@@ -36,18 +41,20 @@ export const FeatureControlFlags = () => {
   }, []);
 
   return (
-    <Card noMargin className={styles.card}>
-      <Stack direction="row" alignItems="center">
-        <Icon name="flask" size="xl" />
-        <Text variant="h4">
-          <Trans i18nKey="feature-control.title">Feature control</Trans>
+    <Card noMargin className={cx(styles.card, className)} onPointerDown={onPointerDown}>
+      <div className={styles.header}>
+        <Stack direction="row" alignItems="center">
+          <Icon name="flask" size="xl" />
+          <Text variant="h4">
+            <Trans i18nKey="feature-control.title">Feature control</Trans>
+          </Text>
+        </Stack>
+        <Text variant="body" color="secondary">
+          <Trans i18nKey="feature-control.description">
+            Override frontend feature flags locally for testing and development purposes.
+          </Trans>
         </Text>
-      </Stack>
-      <Text variant="body" color="secondary">
-        <Trans i18nKey="feature-control.description">
-          Override frontend feature flags locally for testing and development purposes.
-        </Trans>
-      </Text>
+      </div>
 
       <div className={styles.list}>
         {flags.map((flag) => (
@@ -83,9 +90,14 @@ const getStyles = (theme: GrafanaTheme2) => ({
     display: 'flex',
     flexDirection: 'column',
     gap: theme.spacing(1),
-    width: theme.spacing(50),
     boxShadow: theme.shadows.z2,
     border: `1px solid ${theme.colors.border.medium}`,
+  }),
+  header: css({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(1),
+    pointerEvents: 'none',
   }),
   list: css({
     display: 'flex',

--- a/public/app/core/components/AppChrome/FeatureControl/FeatureControlFlags.tsx
+++ b/public/app/core/components/AppChrome/FeatureControl/FeatureControlFlags.tsx
@@ -1,14 +1,14 @@
 import { css, cx } from '@emotion/css';
 import { ClientProviderEvents } from '@openfeature/web-sdk';
-import { type PointerEventHandler, useEffect, useState } from 'react';
+import { type CSSProperties, useEffect, useMemo, useState } from 'react';
 
-import type { GrafanaTheme2 } from '@grafana/data';
-import { Trans } from '@grafana/i18n';
+import type { GrafanaTheme2, IconName } from '@grafana/data';
+import { t, Trans } from '@grafana/i18n';
 import { getLocalStorageProvider } from '@grafana/runtime/internal';
-import { Button, Card, Icon, Stack, Text, useStyles2 } from '@grafana/ui';
+import { Card, Dropdown, Icon, IconButton, Menu, MenuGroup, MenuItem, Stack, Text, useStyles2 } from '@grafana/ui';
 
 import { FeatureControlFlag, type FeatureControlFlagProps } from './FeatureControlFlag';
-import { useFeatureControlContext } from './FeatureControlProvider';
+import { type FeatureControlCorner, useFeatureControlContext } from './FeatureControlProvider';
 
 const compare = new Intl.Collator('en', { sensitivity: 'base', numeric: true }).compare;
 
@@ -16,11 +16,11 @@ type Flag = NonNullable<FeatureControlFlagProps['flag']>;
 
 type FeatureControlFlagsProps = {
   className?: string;
-  onPointerDown?: PointerEventHandler<HTMLDivElement>;
+  style?: CSSProperties;
 };
 
-export const FeatureControlFlags = ({ className, onPointerDown }: FeatureControlFlagsProps) => {
-  const { setIsOpen, setIsAccessible } = useFeatureControlContext();
+export const FeatureControlFlags = ({ className, style }: FeatureControlFlagsProps) => {
+  const { setIsOpen, setIsAccessible, corner, setCorner } = useFeatureControlContext();
   const [flags, setFlags] = useState<Flag[]>([]);
   const styles = useStyles2(getStyles);
 
@@ -40,14 +40,94 @@ export const FeatureControlFlags = ({ className, onPointerDown }: FeatureControl
     };
   }, []);
 
+  const menu = useMemo(() => {
+    const corners: Array<{ value: FeatureControlCorner; label: string; icon: IconName; transform: string }> = [
+      {
+        value: 'top-left',
+        label: t('feature-control.position.top-left', 'Top left'),
+        icon: 'arrow-up',
+        transform: 'rotate(-45deg)',
+      },
+      {
+        value: 'top-right',
+        label: t('feature-control.position.top-right', 'Top right'),
+        icon: 'arrow-up',
+        transform: 'rotate(45deg)',
+      },
+      {
+        value: 'bottom-left',
+        label: t('feature-control.position.bottom-left', 'Bottom left'),
+        icon: 'arrow-down',
+        transform: 'rotate(45deg)',
+      },
+      {
+        value: 'bottom-right',
+        label: t('feature-control.position.bottom-right', 'Bottom right'),
+        icon: 'arrow-down',
+        transform: 'rotate(-45deg)',
+      },
+    ];
+
+    return (
+      <Menu>
+        <MenuGroup label={t('feature-control.position.header', 'Position')}>
+          {corners.map((item) => (
+            <MenuItem
+              key={item.value}
+              active={item.value === corner}
+              ariaChecked={item.value === corner}
+              onClick={() => setCorner(item.value)}
+              label=""
+              component={() => (
+                <Stack direction="row" alignItems="center">
+                  <Icon name={item.icon} style={{ transform: item.transform }} />
+                  <Text color="primary">{item.label}</Text>
+                </Stack>
+              )}
+            />
+          ))}
+        </MenuGroup>
+
+        <MenuGroup label={t('feature-control.dismiss.header', 'Dismiss')}>
+          <MenuItem
+            onClick={() => {
+              setIsOpen(false);
+              setIsAccessible(false);
+            }}
+            destructive
+            icon="times"
+            label={t('feature-control.dismiss.label', 'Remove UI and toolbar button')}
+            component={() => (
+              <Text color="secondary" variant="bodySmall" textAlignment="start">
+                <Trans i18nKey="feature-control.dismiss.tooltip" values={{ param: '?featureControl=true' }}>
+                  Any feature flag overrides defined will remain active.
+                  <br /> Use <code>{'{{ param }}'}</code> in the URL to enable UI again.
+                </Trans>
+              </Text>
+            )}
+          />
+        </MenuGroup>
+      </Menu>
+    );
+  }, [corner, setCorner, setIsOpen, setIsAccessible]);
+
   return (
-    <Card noMargin className={cx(styles.card, className)} onPointerDown={onPointerDown}>
+    <Card noMargin className={cx(styles.card, className)} style={style}>
       <div className={styles.header}>
         <Stack direction="row" alignItems="center">
           <Icon name="flask" size="xl" />
           <Text variant="h4">
             <Trans i18nKey="feature-control.title">Feature control</Trans>
           </Text>
+
+          <Dropdown overlay={menu} placement="bottom-start">
+            <IconButton
+              tooltip={t('feature-control.menu', 'Open menu')}
+              variant="secondary"
+              name="bars"
+              className={styles.menu}
+            />
+          </Dropdown>
         </Stack>
         <Text variant="body" color="secondary">
           <Trans i18nKey="feature-control.description">
@@ -62,25 +142,6 @@ export const FeatureControlFlags = ({ className, onPointerDown }: FeatureControl
         ))}
         <FeatureControlFlag />
       </div>
-
-      <Button
-        size="sm"
-        variant="destructive"
-        fill="outline"
-        fullWidth
-        onClick={() => {
-          setIsOpen(false);
-          setIsAccessible(false);
-        }}
-        tooltip={
-          <Trans i18nKey="feature-control.dismiss-tooltip" values={{ param: '?featureControl=true' }}>
-            Removes the feature control UI and toolbar button. Use <code>{'{{ param }}'}</code> in the URL to enable it
-            again. Any overrides defined will remain active.
-          </Trans>
-        }
-      >
-        <Trans i18nKey="feature-control.dismiss">Dismiss feature control</Trans>
-      </Button>
     </Card>
   );
 };
@@ -97,7 +158,9 @@ const getStyles = (theme: GrafanaTheme2) => ({
     display: 'flex',
     flexDirection: 'column',
     gap: theme.spacing(1),
-    pointerEvents: 'none',
+  }),
+  menu: css({
+    marginLeft: 'auto',
   }),
   list: css({
     display: 'flex',

--- a/public/app/core/components/AppChrome/FeatureControl/FeatureControlFloating.tsx
+++ b/public/app/core/components/AppChrome/FeatureControl/FeatureControlFloating.tsx
@@ -1,0 +1,33 @@
+import { css } from '@emotion/css';
+
+import type { GrafanaTheme2 } from '@grafana/data';
+import { Portal, useStyles2, useTheme2 } from '@grafana/ui';
+
+import { FeatureControlFlags } from './FeatureControlFlags';
+import { useFeatureControlContext } from './FeatureControlProvider';
+
+export const FeatureControlFloating = () => {
+  const { isOpen } = useFeatureControlContext();
+  const theme = useTheme2();
+  const styles = useStyles2(getStyles);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <Portal zIndex={theme.zIndex.modal}>
+      <div className={styles.portal}>
+        <FeatureControlFlags />
+      </div>
+    </Portal>
+  );
+};
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  portal: css({
+    position: 'fixed',
+    bottom: theme.spacing(3),
+    right: theme.spacing(3),
+  }),
+});

--- a/public/app/core/components/AppChrome/FeatureControl/FeatureControlFloating.tsx
+++ b/public/app/core/components/AppChrome/FeatureControl/FeatureControlFloating.tsx
@@ -1,33 +1,201 @@
 import { css } from '@emotion/css';
+import {
+  type CSSProperties,
+  type PointerEvent as ReactPointerEvent,
+  type RefObject,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 
 import type { GrafanaTheme2 } from '@grafana/data';
 import { Portal, useStyles2, useTheme2 } from '@grafana/ui';
 
+import { useChromeHeaderHeight } from '../TopBar/useChromeHeaderHeight';
+
 import { FeatureControlFlags } from './FeatureControlFlags';
-import { useFeatureControlContext } from './FeatureControlProvider';
+import { type FeatureControlCorner, useFeatureControlContext } from './FeatureControlProvider';
+
+type DragPosition = {
+  x: number;
+  y: number;
+};
+
+const getRects = (boundsRef: RefObject<HTMLDivElement>, wrapperRef: RefObject<HTMLDivElement>) => ({
+  bounds: boundsRef.current?.getBoundingClientRect(),
+  wrapper: wrapperRef.current?.getBoundingClientRect(),
+});
+
+const getClosestCorner = (
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  containerWidth: number,
+  containerHeight: number
+): FeatureControlCorner => {
+  const centerX = x + width / 2;
+  const centerY = y + height / 2;
+  const vertical = centerY <= containerHeight / 2 ? 'top' : 'bottom';
+  const horizontal = centerX <= containerWidth / 2 ? 'left' : 'right';
+
+  if (vertical === 'top') {
+    return horizontal === 'left' ? 'top-left' : 'top-right';
+  }
+  return horizontal === 'left' ? 'bottom-left' : 'bottom-right';
+};
+
+const CORNER_POSITIONS: Record<FeatureControlCorner, CSSProperties> = {
+  'top-left': { top: 0, right: 'auto', bottom: 'auto', left: 0 },
+  'top-right': { top: 0, right: 0, bottom: 'auto', left: 'auto' },
+  'bottom-left': { top: 'auto', right: 'auto', bottom: 0, left: 0 },
+  'bottom-right': { top: 'auto', right: 0, bottom: 0, left: 'auto' },
+};
 
 export const FeatureControlFloating = () => {
-  const { isOpen } = useFeatureControlContext();
+  const { corner, isOpen, setCorner } = useFeatureControlContext();
   const theme = useTheme2();
   const styles = useStyles2(getStyles);
+  const headerHeight = useChromeHeaderHeight();
+  const boundsRef = useRef<HTMLDivElement>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const dragOffsetRef = useRef<DragPosition>({ x: 0, y: 0 });
+  const lastDragPositionRef = useRef<DragPosition | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [dragPosition, setDragPosition] = useState<DragPosition | null>(null);
+
+  useEffect(() => {
+    if (!isDragging) {
+      return;
+    }
+
+    document.body.style.userSelect = 'none';
+
+    const handlePointerMove = (event: PointerEvent) => {
+      const { bounds: boundsRect, wrapper: wrapperRect } = getRects(boundsRef, wrapperRef);
+      if (!wrapperRect || !boundsRect) {
+        return;
+      }
+
+      const maxX = Math.max(0, boundsRect.width - wrapperRect.width);
+      const maxY = Math.max(0, boundsRect.height - wrapperRect.height);
+
+      const nextPosition = {
+        x: Math.min(Math.max(0, event.clientX - boundsRect.left - dragOffsetRef.current.x), maxX),
+        y: Math.min(Math.max(0, event.clientY - boundsRect.top - dragOffsetRef.current.y), maxY),
+      };
+
+      lastDragPositionRef.current = nextPosition;
+      setDragPosition(nextPosition);
+    };
+
+    const handlePointerUp = () => {
+      const { bounds: boundsRect, wrapper: wrapperRect } = getRects(boundsRef, wrapperRef);
+      if (wrapperRect && boundsRect && lastDragPositionRef.current) {
+        const nextCorner = getClosestCorner(
+          lastDragPositionRef.current.x,
+          lastDragPositionRef.current.y,
+          wrapperRect.width,
+          wrapperRect.height,
+          boundsRect.width,
+          boundsRect.height
+        );
+        setCorner(nextCorner);
+      }
+
+      setIsDragging(false);
+      setDragPosition(null);
+      lastDragPositionRef.current = null;
+    };
+
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', handlePointerUp);
+
+    return () => {
+      document.body.style.userSelect = '';
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', handlePointerUp);
+    };
+  }, [isDragging, setCorner]);
+
+  const onPointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
+    if (event.target !== event.currentTarget) {
+      return;
+    }
+
+    event.preventDefault();
+
+    const { bounds: boundsRect, wrapper: wrapperRect } = getRects(boundsRef, wrapperRef);
+    if (!wrapperRect || !boundsRect) {
+      return;
+    }
+
+    dragOffsetRef.current = {
+      x: event.clientX - wrapperRect.left,
+      y: event.clientY - wrapperRect.top,
+    };
+
+    lastDragPositionRef.current = {
+      x: wrapperRect.left - boundsRect.left,
+      y: wrapperRect.top - boundsRect.top,
+    };
+    setDragPosition(lastDragPositionRef.current);
+    setIsDragging(true);
+  };
 
   if (!isOpen) {
     return null;
   }
 
+  const portalStyle = dragPosition
+    ? {
+        ...CORNER_POSITIONS['top-left'],
+        transform: `translate(${dragPosition.x}px, ${dragPosition.y}px)`,
+        cursor: 'grabbing' as const,
+      }
+    : CORNER_POSITIONS[corner];
+
   return (
     <Portal zIndex={theme.zIndex.modal}>
-      <div className={styles.portal}>
-        <FeatureControlFlags />
+      <div
+        ref={boundsRef}
+        className={styles.bounds}
+        style={{ marginTop: `calc(${headerHeight}px + ${theme.spacing(3)})` }}
+      >
+        <div ref={wrapperRef} className={styles.portal} style={portalStyle}>
+          <FeatureControlFlags className={styles.card} onPointerDown={onPointerDown} />
+        </div>
       </div>
     </Portal>
   );
 };
 
 const getStyles = (theme: GrafanaTheme2) => ({
-  portal: css({
+  bounds: css({
     position: 'fixed',
-    bottom: theme.spacing(3),
-    right: theme.spacing(3),
+    inset: 0,
+    margin: theme.spacing(3),
+    boxSizing: 'border-box',
+    pointerEvents: 'none',
+  }),
+  portal: css({
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    maxHeight: '100%',
+    display: 'flex',
+    flexDirection: 'column',
+    pointerEvents: 'auto',
+    touchAction: 'none',
+  }),
+  card: css({
+    width: theme.spacing(50),
+    maxHeight: '100%',
+    overflowY: 'auto',
+    cursor: 'grab',
+
+    '> *': {
+      cursor: 'auto',
+    },
   }),
 });

--- a/public/app/core/components/AppChrome/FeatureControl/FeatureControlFloating.tsx
+++ b/public/app/core/components/AppChrome/FeatureControl/FeatureControlFloating.tsx
@@ -1,12 +1,5 @@
 import { css } from '@emotion/css';
-import {
-  type CSSProperties,
-  type PointerEvent as ReactPointerEvent,
-  type RefObject,
-  useEffect,
-  useRef,
-  useState,
-} from 'react';
+import type { CSSProperties } from 'react';
 
 import type { GrafanaTheme2 } from '@grafana/data';
 import { Portal, useStyles2, useTheme2 } from '@grafana/ui';
@@ -16,36 +9,7 @@ import { useChromeHeaderHeight } from '../TopBar/useChromeHeaderHeight';
 import { FeatureControlFlags } from './FeatureControlFlags';
 import { type FeatureControlCorner, useFeatureControlContext } from './FeatureControlProvider';
 
-type DragPosition = {
-  x: number;
-  y: number;
-};
-
-const getRects = (boundsRef: RefObject<HTMLDivElement>, wrapperRef: RefObject<HTMLDivElement>) => ({
-  bounds: boundsRef.current?.getBoundingClientRect(),
-  wrapper: wrapperRef.current?.getBoundingClientRect(),
-});
-
-const getClosestCorner = (
-  x: number,
-  y: number,
-  width: number,
-  height: number,
-  containerWidth: number,
-  containerHeight: number
-): FeatureControlCorner => {
-  const centerX = x + width / 2;
-  const centerY = y + height / 2;
-  const vertical = centerY <= containerHeight / 2 ? 'top' : 'bottom';
-  const horizontal = centerX <= containerWidth / 2 ? 'left' : 'right';
-
-  if (vertical === 'top') {
-    return horizontal === 'left' ? 'top-left' : 'top-right';
-  }
-  return horizontal === 'left' ? 'bottom-left' : 'bottom-right';
-};
-
-const CORNER_POSITIONS: Record<FeatureControlCorner, CSSProperties> = {
+const corners: Record<FeatureControlCorner, CSSProperties> = {
   'top-left': { top: 0, right: 'auto', bottom: 'auto', left: 0 },
   'top-right': { top: 0, right: 0, bottom: 'auto', left: 'auto' },
   'bottom-left': { top: 'auto', right: 'auto', bottom: 0, left: 0 },
@@ -53,118 +17,19 @@ const CORNER_POSITIONS: Record<FeatureControlCorner, CSSProperties> = {
 };
 
 export const FeatureControlFloating = () => {
-  const { corner, isOpen, setCorner } = useFeatureControlContext();
+  const { corner, isOpen } = useFeatureControlContext();
   const theme = useTheme2();
   const styles = useStyles2(getStyles);
   const headerHeight = useChromeHeaderHeight();
-  const boundsRef = useRef<HTMLDivElement>(null);
-  const wrapperRef = useRef<HTMLDivElement>(null);
-  const dragOffsetRef = useRef<DragPosition>({ x: 0, y: 0 });
-  const lastDragPositionRef = useRef<DragPosition | null>(null);
-  const [isDragging, setIsDragging] = useState(false);
-  const [dragPosition, setDragPosition] = useState<DragPosition | null>(null);
-
-  useEffect(() => {
-    if (!isDragging) {
-      return;
-    }
-
-    document.body.style.userSelect = 'none';
-
-    const handlePointerMove = (event: PointerEvent) => {
-      const { bounds: boundsRect, wrapper: wrapperRect } = getRects(boundsRef, wrapperRef);
-      if (!wrapperRect || !boundsRect) {
-        return;
-      }
-
-      const maxX = Math.max(0, boundsRect.width - wrapperRect.width);
-      const maxY = Math.max(0, boundsRect.height - wrapperRect.height);
-
-      const nextPosition = {
-        x: Math.min(Math.max(0, event.clientX - boundsRect.left - dragOffsetRef.current.x), maxX),
-        y: Math.min(Math.max(0, event.clientY - boundsRect.top - dragOffsetRef.current.y), maxY),
-      };
-
-      lastDragPositionRef.current = nextPosition;
-      setDragPosition(nextPosition);
-    };
-
-    const handlePointerUp = () => {
-      const { bounds: boundsRect, wrapper: wrapperRect } = getRects(boundsRef, wrapperRef);
-      if (wrapperRect && boundsRect && lastDragPositionRef.current) {
-        const nextCorner = getClosestCorner(
-          lastDragPositionRef.current.x,
-          lastDragPositionRef.current.y,
-          wrapperRect.width,
-          wrapperRect.height,
-          boundsRect.width,
-          boundsRect.height
-        );
-        setCorner(nextCorner);
-      }
-
-      setIsDragging(false);
-      setDragPosition(null);
-      lastDragPositionRef.current = null;
-    };
-
-    window.addEventListener('pointermove', handlePointerMove);
-    window.addEventListener('pointerup', handlePointerUp);
-
-    return () => {
-      document.body.style.userSelect = '';
-      window.removeEventListener('pointermove', handlePointerMove);
-      window.removeEventListener('pointerup', handlePointerUp);
-    };
-  }, [isDragging, setCorner]);
-
-  const onPointerDown = (event: ReactPointerEvent<HTMLDivElement>) => {
-    if (event.target !== event.currentTarget) {
-      return;
-    }
-
-    event.preventDefault();
-
-    const { bounds: boundsRect, wrapper: wrapperRect } = getRects(boundsRef, wrapperRef);
-    if (!wrapperRect || !boundsRect) {
-      return;
-    }
-
-    dragOffsetRef.current = {
-      x: event.clientX - wrapperRect.left,
-      y: event.clientY - wrapperRect.top,
-    };
-
-    lastDragPositionRef.current = {
-      x: wrapperRect.left - boundsRect.left,
-      y: wrapperRect.top - boundsRect.top,
-    };
-    setDragPosition(lastDragPositionRef.current);
-    setIsDragging(true);
-  };
 
   if (!isOpen) {
     return null;
   }
 
-  const portalStyle = dragPosition
-    ? {
-        ...CORNER_POSITIONS['top-left'],
-        transform: `translate(${dragPosition.x}px, ${dragPosition.y}px)`,
-        cursor: 'grabbing' as const,
-      }
-    : CORNER_POSITIONS[corner];
-
   return (
     <Portal zIndex={theme.zIndex.modal}>
-      <div
-        ref={boundsRef}
-        className={styles.bounds}
-        style={{ marginTop: `calc(${headerHeight}px + ${theme.spacing(3)})` }}
-      >
-        <div ref={wrapperRef} className={styles.portal} style={portalStyle}>
-          <FeatureControlFlags className={styles.card} onPointerDown={onPointerDown} />
-        </div>
+      <div className={styles.bounds} style={{ marginTop: `calc(${headerHeight}px + ${theme.spacing(3)})` }}>
+        <FeatureControlFlags className={styles.card} style={corners[corner]} />
       </div>
     </Portal>
   );
@@ -178,24 +43,11 @@ const getStyles = (theme: GrafanaTheme2) => ({
     boxSizing: 'border-box',
     pointerEvents: 'none',
   }),
-  portal: css({
-    position: 'absolute',
-    top: 0,
-    left: 0,
-    maxHeight: '100%',
-    display: 'flex',
-    flexDirection: 'column',
-    pointerEvents: 'auto',
-    touchAction: 'none',
-  }),
   card: css({
+    position: 'absolute',
     width: theme.spacing(50),
     maxHeight: '100%',
     overflowY: 'auto',
-    cursor: 'grab',
-
-    '> *': {
-      cursor: 'auto',
-    },
+    pointerEvents: 'auto',
   }),
 });

--- a/public/app/core/components/AppChrome/FeatureControl/FeatureControlProvider.test.tsx
+++ b/public/app/core/components/AppChrome/FeatureControl/FeatureControlProvider.test.tsx
@@ -1,0 +1,101 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { locationService } from '@grafana/runtime';
+
+import { FeatureControlContextProvider, useFeatureControlContext } from './FeatureControlProvider';
+
+const STORAGE_KEYS = {
+  accessible: 'grafana.feature-control.accessible',
+  open: 'grafana.feature-control.open',
+} as const;
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  locationService: {
+    getSearchObject: jest.fn(),
+    getLocationObservable: jest.fn(),
+  },
+}));
+
+describe('FeatureControlProvider', () => {
+  const locationServiceMock = jest.mocked(locationService);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    window.localStorage.clear();
+    locationServiceMock.getSearchObject.mockReturnValue({});
+    locationServiceMock.getLocationObservable.mockReturnValue({
+      subscribe: jest.fn().mockReturnValue({
+        unsubscribe: jest.fn(),
+      }),
+    } as never);
+  });
+
+  const TestComponent = () => {
+    const { isAccessible, setIsAccessible, isOpen, setIsOpen } = useFeatureControlContext();
+
+    return (
+      <div>
+        <div data-testid="is-accessible">{isAccessible.toString()}</div>
+        <div data-testid="is-open">{isOpen.toString()}</div>
+        <button onClick={() => setIsAccessible(true)}>Enable accessibility</button>
+        <button onClick={() => setIsOpen(true)}>Open feature control</button>
+      </div>
+    );
+  };
+
+  const renderProvider = () =>
+    render(
+      <FeatureControlContextProvider>
+        <TestComponent />
+      </FeatureControlContextProvider>
+    );
+
+  const expectState = ({ isAccessible, isOpen }: { isAccessible: boolean; isOpen: boolean }) => {
+    expect(screen.getByTestId('is-accessible')).toHaveTextContent(isAccessible.toString());
+    expect(screen.getByTestId('is-open')).toHaveTextContent(isOpen.toString());
+  };
+
+  const expectStorage = ({ isAccessible, isOpen }: { isAccessible: string | null; isOpen: string | null }) => {
+    expect(window.localStorage.getItem(STORAGE_KEYS.accessible)).toBe(isAccessible);
+    expect(window.localStorage.getItem(STORAGE_KEYS.open)).toBe(isOpen);
+  };
+
+  it('should provide default context values', () => {
+    renderProvider();
+
+    expectState({ isAccessible: false, isOpen: false });
+  });
+
+  it.each([
+    ['accessibility', STORAGE_KEYS.accessible, 'true', { isAccessible: true, isOpen: false }],
+    ['open state', STORAGE_KEYS.open, 'true', { isAccessible: false, isOpen: true }],
+    ['accessibility with invalid value', STORAGE_KEYS.accessible, 'invalid', { isAccessible: false, isOpen: false }],
+    ['open state with invalid value', STORAGE_KEYS.open, 'invalid', { isAccessible: false, isOpen: false }],
+  ])('should load %s from local storage', (_name, key, value, expectedState) => {
+    window.localStorage.setItem(key, value);
+    renderProvider();
+
+    expectState(expectedState);
+  });
+
+  it('should force accessibility and open state when featureControl query param is true', () => {
+    locationServiceMock.getSearchObject.mockReturnValue({ featureControl: true });
+    renderProvider();
+
+    expectState({ isAccessible: true, isOpen: true });
+    expectStorage({ isAccessible: 'true', isOpen: 'true' });
+  });
+
+  it('should update accessibility and open state', async () => {
+    renderProvider();
+
+    await userEvent.click(screen.getByText('Enable accessibility'));
+    await userEvent.click(screen.getByText('Open feature control'));
+
+    expectState({ isAccessible: true, isOpen: true });
+    expectStorage({ isAccessible: 'true', isOpen: 'true' });
+  });
+});

--- a/public/app/core/components/AppChrome/FeatureControl/FeatureControlProvider.test.tsx
+++ b/public/app/core/components/AppChrome/FeatureControl/FeatureControlProvider.test.tsx
@@ -1,0 +1,177 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { locationService } from '@grafana/runtime';
+
+import { FeatureControlContextProvider, useFeatureControlContext } from './FeatureControlProvider';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  locationService: {
+    getSearchObject: jest.fn(),
+    getLocationObservable: jest.fn(),
+  },
+}));
+
+describe('FeatureControlProvider', () => {
+  const locationServiceMock = jest.mocked(locationService);
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    window.localStorage.clear();
+    locationServiceMock.getSearchObject.mockReturnValue({});
+    locationServiceMock.getLocationObservable.mockReturnValue({
+      subscribe: jest.fn().mockReturnValue({
+        unsubscribe: jest.fn(),
+      }),
+    } as never);
+  });
+
+  const TestComponent = () => {
+    const { corner, isAccessible, isOpen, setCorner, setIsAccessible, setIsOpen } = useFeatureControlContext();
+
+    return (
+      <div>
+        <div data-testid="is-accessible">{isAccessible.toString()}</div>
+        <div data-testid="is-open">{isOpen.toString()}</div>
+        <div data-testid="corner">{corner}</div>
+        <button onClick={() => setIsAccessible(true)}>Enable accessibility</button>
+        <button onClick={() => setIsOpen(true)}>Open feature control</button>
+        <button onClick={() => setCorner('top-left')}>Move feature control</button>
+      </div>
+    );
+  };
+
+  it('should provide default context values', () => {
+    render(
+      <FeatureControlContextProvider>
+        <TestComponent />
+      </FeatureControlContextProvider>
+    );
+
+    expect(screen.getByTestId('is-accessible')).toHaveTextContent('false');
+    expect(screen.getByTestId('is-open')).toHaveTextContent('false');
+    expect(screen.getByTestId('corner')).toHaveTextContent('bottom-right');
+  });
+
+  it('should load corner from local storage', () => {
+    window.localStorage.setItem('grafana.feature-control.corner', 'top-left');
+
+    render(
+      <FeatureControlContextProvider>
+        <TestComponent />
+      </FeatureControlContextProvider>
+    );
+
+    expect(screen.getByTestId('corner')).toHaveTextContent('top-left');
+  });
+
+  it('should load accessibility from local storage', () => {
+    window.localStorage.setItem('grafana.feature-control.accessible', 'true');
+
+    render(
+      <FeatureControlContextProvider>
+        <TestComponent />
+      </FeatureControlContextProvider>
+    );
+
+    expect(screen.getByTestId('is-accessible')).toHaveTextContent('true');
+  });
+
+  it('should load open state from local storage', () => {
+    window.localStorage.setItem('grafana.feature-control.open', 'true');
+
+    render(
+      <FeatureControlContextProvider>
+        <TestComponent />
+      </FeatureControlContextProvider>
+    );
+
+    expect(screen.getByTestId('is-open')).toHaveTextContent('true');
+  });
+
+  it('should fallback to default accessibility when local storage value is invalid', () => {
+    window.localStorage.setItem('grafana.feature-control.accessible', 'invalid');
+
+    render(
+      <FeatureControlContextProvider>
+        <TestComponent />
+      </FeatureControlContextProvider>
+    );
+
+    expect(screen.getByTestId('is-accessible')).toHaveTextContent('false');
+  });
+
+  it('should fallback to default open state when local storage value is invalid', () => {
+    window.localStorage.setItem('grafana.feature-control.open', '123');
+
+    render(
+      <FeatureControlContextProvider>
+        <TestComponent />
+      </FeatureControlContextProvider>
+    );
+
+    expect(screen.getByTestId('is-open')).toHaveTextContent('false');
+  });
+
+  it('should fallback to default corner when local storage value is invalid', () => {
+    window.localStorage.setItem('grafana.feature-control.corner', 'middle');
+
+    render(
+      <FeatureControlContextProvider>
+        <TestComponent />
+      </FeatureControlContextProvider>
+    );
+
+    expect(screen.getByTestId('corner')).toHaveTextContent('bottom-right');
+  });
+
+  it('should force accessibility and open state when featureControl query param is true', () => {
+    locationServiceMock.getSearchObject.mockReturnValue({ featureControl: true });
+
+    render(
+      <FeatureControlContextProvider>
+        <TestComponent />
+      </FeatureControlContextProvider>
+    );
+
+    expect(screen.getByTestId('is-accessible')).toHaveTextContent('true');
+    expect(screen.getByTestId('is-open')).toHaveTextContent('true');
+    expect(window.localStorage.getItem('grafana.feature-control.accessible')).toBe('true');
+    expect(window.localStorage.getItem('grafana.feature-control.open')).toBe('true');
+  });
+
+  it('should update accessibility and open state', async () => {
+    render(
+      <FeatureControlContextProvider>
+        <TestComponent />
+      </FeatureControlContextProvider>
+    );
+
+    await userEvent.click(screen.getByText('Enable accessibility'));
+    await userEvent.click(screen.getByText('Open feature control'));
+
+    expect(screen.getByTestId('is-accessible')).toHaveTextContent('true');
+    expect(screen.getByTestId('is-open')).toHaveTextContent('true');
+    await waitFor(() => {
+      expect(window.localStorage.getItem('grafana.feature-control.accessible')).toBe('true');
+      expect(window.localStorage.getItem('grafana.feature-control.open')).toBe('true');
+    });
+  });
+
+  it('should update corner state', async () => {
+    render(
+      <FeatureControlContextProvider>
+        <TestComponent />
+      </FeatureControlContextProvider>
+    );
+
+    await userEvent.click(screen.getByText('Move feature control'));
+
+    expect(screen.getByTestId('corner')).toHaveTextContent('top-left');
+    await waitFor(() => {
+      expect(window.localStorage.getItem('grafana.feature-control.corner')).toBe('top-left');
+    });
+  });
+});

--- a/public/app/core/components/AppChrome/FeatureControl/FeatureControlProvider.tsx
+++ b/public/app/core/components/AppChrome/FeatureControl/FeatureControlProvider.tsx
@@ -1,0 +1,140 @@
+import { createContext, type ReactNode, useCallback, useContext, useEffect, useMemo } from 'react';
+import { useLocalStorage } from 'react-use';
+
+import { locationService } from '@grafana/runtime';
+
+const FEATURE_CONTROL_ACCESSIBLE_LOCAL_STORAGE_KEY = 'grafana.feature-control.accessible';
+const FEATURE_CONTROL_OPEN_LOCAL_STORAGE_KEY = 'grafana.feature-control.open';
+const FEATURE_CONTROL_CORNER_LOCAL_STORAGE_KEY = 'grafana.feature-control.corner';
+
+const corners = ['top-left', 'top-right', 'bottom-left', 'bottom-right'] as const;
+export type FeatureControlCorner = (typeof corners)[number];
+
+const isCorner = (value: string): value is FeatureControlCorner => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  return corners.includes(value as FeatureControlCorner);
+};
+
+export type FeatureControlContextType = {
+  isAccessible: boolean;
+  setIsAccessible: (isAccessible: boolean) => void;
+  isOpen: boolean;
+  setIsOpen: (isOpen: boolean) => void;
+  corner: FeatureControlCorner;
+  setCorner: (corner: FeatureControlCorner) => void;
+};
+
+export const FeatureControlContext = createContext<FeatureControlContextType>({
+  isAccessible: false,
+  setIsAccessible: () => {},
+  isOpen: false,
+  setIsOpen: () => {},
+  corner: 'bottom-right',
+  setCorner: () => {},
+});
+
+export function useFeatureControlContext() {
+  return useContext(FeatureControlContext);
+}
+
+interface FeatureControlContextProviderProps {
+  children: ReactNode;
+  initialIsAccessible?: boolean;
+  initialIsOpen?: boolean;
+  initialCorner?: FeatureControlCorner;
+}
+
+export const FeatureControlContextProvider = ({
+  children,
+  initialIsAccessible = false,
+  initialIsOpen = false,
+  initialCorner = 'bottom-right',
+}: FeatureControlContextProviderProps) => {
+  const [storedIsAccessible, setStoredIsAccessible] = useLocalStorage<boolean>(
+    FEATURE_CONTROL_ACCESSIBLE_LOCAL_STORAGE_KEY,
+    initialIsAccessible,
+    {
+      raw: false,
+      serializer: (value) => value.toString(),
+      deserializer: (value) => value === 'true',
+    }
+  );
+  const [storedIsOpen, setStoredIsOpen] = useLocalStorage<boolean>(
+    FEATURE_CONTROL_OPEN_LOCAL_STORAGE_KEY,
+    initialIsOpen,
+    {
+      raw: false,
+      serializer: (value) => value.toString(),
+      deserializer: (value) => value === 'true',
+    }
+  );
+  const [storedCorner, setStoredCorner] = useLocalStorage<FeatureControlCorner>(
+    FEATURE_CONTROL_CORNER_LOCAL_STORAGE_KEY,
+    initialCorner,
+    {
+      raw: false,
+      serializer: (value) => value,
+      deserializer: (value) => (isCorner(value) ? value : 'bottom-right'),
+    }
+  );
+  const isAccessible = storedIsAccessible ?? false;
+  const isOpen = storedIsOpen ?? false;
+  const corner = storedCorner ?? 'bottom-right';
+
+  const setIsAccessible = useCallback(
+    (value: boolean) => {
+      setStoredIsAccessible(value);
+    },
+    [setStoredIsAccessible]
+  );
+
+  const setIsOpen = useCallback(
+    (value: boolean) => {
+      setStoredIsOpen(value);
+    },
+    [setStoredIsOpen]
+  );
+
+  const setCorner = useCallback(
+    (value: FeatureControlCorner) => {
+      setStoredCorner(value);
+    },
+    [setStoredCorner]
+  );
+
+  useEffect(() => {
+    const syncAccessibleState = () => {
+      const queryParams = locationService.getSearchObject();
+      const isForcedOn = queryParams.featureControl === true;
+
+      if (isForcedOn) {
+        setIsAccessible(true);
+        setIsOpen(true);
+      }
+    };
+
+    syncAccessibleState();
+
+    const subscription = locationService.getLocationObservable().subscribe(() => {
+      syncAccessibleState();
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, [setIsAccessible, setIsOpen]);
+
+  const value = useMemo(
+    () => ({
+      isAccessible,
+      setIsAccessible,
+      isOpen,
+      setIsOpen,
+      corner,
+      setCorner,
+    }),
+    [corner, isAccessible, isOpen, setCorner, setIsAccessible, setIsOpen]
+  );
+
+  return <FeatureControlContext.Provider value={value}>{children}</FeatureControlContext.Provider>;
+};

--- a/public/app/core/components/AppChrome/FeatureControl/FeatureControlProvider.tsx
+++ b/public/app/core/components/AppChrome/FeatureControl/FeatureControlProvider.tsx
@@ -1,0 +1,64 @@
+import { createContext, type ReactNode, useCallback, useContext, useEffect, useMemo } from 'react';
+import { useLocalStorage } from 'react-use';
+
+import { locationService } from '@grafana/runtime';
+
+const FEATURE_CONTROL_ACCESSIBLE_LOCAL_STORAGE_KEY = 'grafana.feature-control.accessible';
+const FEATURE_CONTROL_OPEN_LOCAL_STORAGE_KEY = 'grafana.feature-control.open';
+
+const useStoredBoolean = (key: string, initialValue: boolean): [boolean, (value: boolean) => void] => {
+  const [value, setValue] = useLocalStorage<boolean>(key, initialValue, {
+    raw: false,
+    serializer: (value: boolean) => value.toString(),
+    deserializer: (value: string) => value === 'true',
+  });
+  return [value ?? false, useCallback((nextValue: boolean) => setValue(nextValue), [setValue])];
+};
+
+export type FeatureControlContextType = {
+  /** Whether the feature control button is in the toolbar */
+  isAccessible: boolean;
+  setIsAccessible: (isAccessible: boolean) => void;
+  /** Whether the feature control panel itself is open */
+  isOpen: boolean;
+  setIsOpen: (isOpen: boolean) => void;
+};
+
+export const FeatureControlContext = createContext<FeatureControlContextType>({
+  isAccessible: false,
+  setIsAccessible: () => {},
+  isOpen: false,
+  setIsOpen: () => {},
+});
+
+export const useFeatureControlContext = () => useContext(FeatureControlContext);
+
+export const FeatureControlContextProvider = ({ children }: { children: ReactNode }) => {
+  const [isAccessible, setIsAccessible] = useStoredBoolean(FEATURE_CONTROL_ACCESSIBLE_LOCAL_STORAGE_KEY, false);
+  const [isOpen, setIsOpen] = useStoredBoolean(FEATURE_CONTROL_OPEN_LOCAL_STORAGE_KEY, false);
+
+  useEffect(() => {
+    const syncForcedState = () => {
+      if (locationService.getSearchObject().featureControl === true) {
+        setIsAccessible(true);
+        setIsOpen(true);
+      }
+    };
+    syncForcedState();
+
+    const subscription = locationService.getLocationObservable().subscribe(syncForcedState);
+    return () => subscription.unsubscribe();
+  }, [setIsAccessible, setIsOpen]);
+
+  const value = useMemo(
+    () => ({
+      isAccessible,
+      setIsAccessible,
+      isOpen,
+      setIsOpen,
+    }),
+    [isAccessible, setIsAccessible, isOpen, setIsOpen]
+  );
+
+  return <FeatureControlContext.Provider value={value}>{children}</FeatureControlContext.Provider>;
+};

--- a/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
+++ b/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
@@ -18,6 +18,7 @@ import { HomeLink } from '../../Branding/Branding';
 import { Breadcrumbs } from '../../Breadcrumbs/Breadcrumbs';
 import { buildBreadcrumbs } from '../../Breadcrumbs/utils';
 import { ExtensionToolbarItem } from '../ExtensionSidebar/ExtensionToolbarItem';
+import { FeatureControlButton } from '../FeatureControl/FeatureControlButton';
 import { NavToolbarSeparator } from '../NavToolbar/NavToolbarSeparator';
 import { QuickAdd } from '../QuickAdd/QuickAdd';
 
@@ -95,6 +96,7 @@ export const SingleTopBar = memo(function SingleTopBar({
           <TopBarExtensionPoint />
           <TopSearchBarCommandPaletteTrigger />
           {!isSmallScreen && <QuickAdd />}
+          <FeatureControlButton />
           <HelpTopBarButton isSmallScreen={isSmallScreen} />
           <NavToolbarSeparator />
           {!isSmallScreen && <ExtensionToolbarItem compact={isSmallScreen} />}

--- a/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
+++ b/public/app/core/components/AppChrome/TopBar/SingleTopBar.tsx
@@ -19,6 +19,7 @@ import { HomeLink } from '../../Branding/Branding';
 import { Breadcrumbs } from '../../Breadcrumbs/Breadcrumbs';
 import { buildBreadcrumbs } from '../../Breadcrumbs/utils';
 import { ExtensionToolbarItem } from '../ExtensionSidebar/ExtensionToolbarItem';
+import { FeatureControlButton } from '../FeatureControl/FeatureControlButton';
 import { NavToolbarSeparator } from '../NavToolbar/NavToolbarSeparator';
 import { QuickAdd } from '../QuickAdd/QuickAdd';
 
@@ -97,6 +98,7 @@ export const SingleTopBar = memo(function SingleTopBar({
           <TopBarExtensionPoint />
           <TopSearchBarCommandPaletteTrigger />
           {!isSmallScreen && <QuickAdd />}
+          <FeatureControlButton />
           <HelpTopBarButton isSmallScreen={isSmallScreen} />
           <NavToolbarSeparator />
           {!isSmallScreen && <ExtensionToolbarItem compact={isSmallScreen} />}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8832,6 +8832,13 @@
       "label-input": "Input"
     }
   },
+  "feature-control": {
+    "button": {
+      "aria-label": "Feature control",
+      "close-tooltip": "Close feature control",
+      "open-tooltip": "Open feature control"
+    }
+  },
   "folder-filter": {
     "select-aria-label": "Folder filter",
     "select-placeholder": "Filter by folder"

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8838,7 +8838,7 @@
       "close-tooltip": "Close feature control",
       "open-tooltip": "Open feature control"
     },
-    "delete-flag": "Delete override",
+    "delete-flag": "Delete",
     "description": "Override frontend feature flags locally for testing and development purposes.",
     "dismiss": {
       "label": "Remove UI and toolbar button",
@@ -8846,11 +8846,11 @@
     },
     "flag-key": "Flag key",
     "flag-key-placeholder": "my-component.my-flag",
+    "flag-type": "Flag type",
     "flag-value": "Flag value",
-    "flag-value-placeholder": "true, false, a string, number, or JSON",
     "menu": "Open menu",
     "new-flag": "new-flag-override",
-    "save-flag": "Save override",
+    "save-flag": "Save",
     "title": "Feature control"
   },
   "folder-filter": {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8837,7 +8837,21 @@
       "aria-label": "Feature control",
       "close-tooltip": "Close feature control",
       "open-tooltip": "Open feature control"
-    }
+    },
+    "delete-flag": "Delete override",
+    "description": "Override frontend feature flags locally for testing and development purposes.",
+    "dismiss": {
+      "label": "Remove UI and toolbar button",
+      "tooltip": "Any feature flag overrides defined will remain active.<br/> Use <3>{{ param }}</3> in the URL to enable UI again."
+    },
+    "flag-key": "Flag key",
+    "flag-key-placeholder": "my-component.my-flag",
+    "flag-value": "Flag value",
+    "flag-value-placeholder": "true, false, a string, number, or JSON",
+    "menu": "Open menu",
+    "new-flag": "new-flag-override",
+    "save-flag": "Save override",
+    "title": "Feature control"
   },
   "folder-filter": {
     "select-aria-label": "Folder filter",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -9122,16 +9122,16 @@
       "close-tooltip": "Close feature control",
       "open-tooltip": "Open feature control"
     },
-    "delete-flag": "Delete override",
+    "delete-flag": "Delete",
     "description": "Override frontend feature flags locally for testing and development purposes.",
     "dismiss": "Dismiss feature control",
     "dismiss-tooltip": "Removes the feature control UI and toolbar button. Use <1>{{ param }}</1> in the URL to enable it again. Any overrides defined will remain active.",
     "flag-key": "Flag key",
     "flag-key-placeholder": "my-component.my-flag",
+    "flag-type": "Flag type",
     "flag-value": "Flag value",
-    "flag-value-placeholder": "true, false, a string, number, or JSON",
     "new-flag": "new-flag-override",
-    "save-flag": "Save override",
+    "save-flag": "Save",
     "title": "Feature control"
   },
   "folder-filter": {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -9124,13 +9124,24 @@
     },
     "delete-flag": "Delete",
     "description": "Override frontend feature flags locally for testing and development purposes.",
-    "dismiss": "Dismiss feature control",
-    "dismiss-tooltip": "Removes the feature control UI and toolbar button. Use <1>{{ param }}</1> in the URL to enable it again. Any overrides defined will remain active.",
+    "dismiss": {
+      "header": "Dismiss",
+      "label": "Remove UI and toolbar button",
+      "tooltip": "Any feature flag overrides defined will remain active.<br/> Use <3>{{ param }}</3> in the URL to enable UI again."
+    },
     "flag-key": "Flag key",
     "flag-key-placeholder": "my-component.my-flag",
     "flag-type": "Flag type",
     "flag-value": "Flag value",
+    "menu": "Open menu",
     "new-flag": "new-flag-override",
+    "position": {
+      "bottom-left": "Bottom left",
+      "bottom-right": "Bottom right",
+      "header": "Position",
+      "top-left": "Top left",
+      "top-right": "Top right"
+    },
     "save-flag": "Save",
     "title": "Feature control"
   },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -9116,6 +9116,13 @@
       "label-input": "Input"
     }
   },
+  "feature-control": {
+    "button": {
+      "aria-label": "Feature control",
+      "close-tooltip": "Close feature control",
+      "open-tooltip": "Open feature control"
+    }
+  },
   "folder-filter": {
     "select-aria-label": "Folder filter",
     "select-placeholder": "Filter by folder"

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -9121,7 +9121,18 @@
       "aria-label": "Feature control",
       "close-tooltip": "Close feature control",
       "open-tooltip": "Open feature control"
-    }
+    },
+    "delete-flag": "Delete override",
+    "description": "Override frontend feature flags locally for testing and development purposes.",
+    "dismiss": "Dismiss feature control",
+    "dismiss-tooltip": "Removes the feature control UI and toolbar button. Use <1>{{ param }}</1> in the URL to enable it again. Any overrides defined will remain active.",
+    "flag-key": "Flag key",
+    "flag-key-placeholder": "my-component.my-flag",
+    "flag-value": "Flag value",
+    "flag-value-placeholder": "true, false, a string, number, or JSON",
+    "new-flag": "new-flag-override",
+    "save-flag": "Save override",
+    "title": "Feature control"
   },
   "folder-filter": {
     "select-aria-label": "Folder filter",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2895,6 +2895,7 @@ __metadata:
     "@grafana/schema": "npm:13.1.0-pre"
     "@grafana/ui": "npm:13.1.0-pre"
     "@openfeature/core": "npm:^1.10.0"
+    "@openfeature/localstorage-provider": "npm:^0.1.2"
     "@openfeature/ofrep-web-provider": "npm:^0.4.1"
     "@openfeature/react-sdk": "npm:^1.3.0"
     "@openfeature/web-sdk": "npm:^1.8.0"
@@ -5763,6 +5764,17 @@ __metadata:
   version: 1.10.0
   resolution: "@openfeature/core@npm:1.10.0"
   checksum: 10/62e0289b9e9e86fcc56e6ee972ffb2e0de9511e58fdc6d01f4f9c2dc312b4c43a95ad266984f63b89f7faacfc5ece214e484c308edbd491be0053a94f60bd6b7
+  languageName: node
+  linkType: hard
+
+"@openfeature/localstorage-provider@npm:^0.1.2":
+  version: 0.1.2
+  resolution: "@openfeature/localstorage-provider@npm:0.1.2"
+  dependencies:
+    tslib: "npm:^2.3.0"
+  peerDependencies:
+    "@openfeature/web-sdk": ^1.6.0
+  checksum: 10/32213139053cbd748c2a08bd12d0a664cfec4a6323a79c53072685399502a4a37d28604fba3394d191d758a9c33329d3d840c6be8611675c45a3251b3d00fc35
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4177,6 +4177,7 @@ __metadata:
     "@grafana/schema": "npm:13.1.0-pre"
     "@grafana/ui": "npm:13.1.0-pre"
     "@openfeature/core": "npm:^1.10.0"
+    "@openfeature/localstorage-provider": "npm:^0.1.2"
     "@openfeature/ofrep-web-provider": "npm:^0.3.6"
     "@openfeature/react-sdk": "npm:^1.3.0"
     "@openfeature/web-sdk": "npm:^1.8.0"
@@ -7080,6 +7081,17 @@ __metadata:
   version: 1.10.0
   resolution: "@openfeature/core@npm:1.10.0"
   checksum: 10/62e0289b9e9e86fcc56e6ee972ffb2e0de9511e58fdc6d01f4f9c2dc312b4c43a95ad266984f63b89f7faacfc5ece214e484c308edbd491be0053a94f60bd6b7
+  languageName: node
+  linkType: hard
+
+"@openfeature/localstorage-provider@npm:^0.1.2":
+  version: 0.1.2
+  resolution: "@openfeature/localstorage-provider@npm:0.1.2"
+  dependencies:
+    tslib: "npm:^2.3.0"
+  peerDependencies:
+    "@openfeature/web-sdk": ^1.6.0
+  checksum: 10/32213139053cbd748c2a08bd12d0a664cfec4a6323a79c53072685399502a4a37d28604fba3394d191d758a9c33329d3d840c6be8611675c45a3251b3d00fc35
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**What is this feature?**

With https://github.com/open-feature/js-sdk-contrib/pull/1518 landed upstream, there is now an OpenFeature provider that uses localStorage, which when combined with MultiProvider, allows it to act as an override system for local frontend development. On top of that, I've then introduced a minimal floating UI that is driven from localStorage and the LocalStorageProvider, to control these flag overrides.

https://github.com/user-attachments/assets/53815ec1-c372-4744-9993-99047fb37e5d

**Why do we need this feature?**

To aid in ease of local development and then testing of new features in deployed environments with stakeholders, as it provides a way for anyone who knows the query param to enable the feature control UI, and the relevant feature flag names, to quickly test out frontend feature-flagged code in their own browser.

**Who is this feature for?**

Developers et al.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Use the `?featureControl=true` query param on any page to enable the UI. This is only hooked up to grafana/grafana's frontend OpenFeature usage, not any plugins, currently.

Future extension of this would be to not only allow overriding feature flags from this UI, but also showing all the current evaluated values for flags, to allow folks to more easily understand what is happening with feature flag without needing to open up the network inspector and poke through the ofrep response.

Should this be documented anywhere, or keep it as an undocumented secret UI?

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
