### PR TITLE
Preserve string datasource refs during V1 to V2 panel migration

### DIFF
--- a/public/app/features/dashboard/api/ResponseTransformers.test.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.test.ts
@@ -28,6 +28,7 @@ import {
 import { type DashboardDataDTO, type DashboardDTO } from 'app/types/dashboard';
 
 import {
+  buildPanelKind,
   getDefaultDatasource,
   getPanelQueries,
   ResponseTransformers,
@@ -1075,6 +1076,85 @@ describe('ResponseTransformers', () => {
           expect(query.spec.query.datasource?.name).toEqual('theoretical-uid');
           expect(query.spec.query.kind).toBe('DataQuery');
         });
+      });
+    });
+
+    describe('buildPanelKind', () => {
+      it('preserves variable datasource expression when panel datasource is a string', () => {
+        const panel: Panel = {
+          id: 1,
+          type: 'timeseries',
+          title: 'Test',
+          datasource: '$DataSource' as any,
+          targets: [{ refId: 'A' }],
+          fieldConfig: { defaults: {}, overrides: [] },
+          options: {},
+          gridPos: { x: 0, y: 0, w: 12, h: 8 },
+          transformations: [],
+        };
+
+        const result = buildPanelKind(panel);
+        const query = result.spec.data.spec.queries[0];
+
+        expect(query.spec.query.datasource?.name).toBe('$DataSource');
+      });
+
+      it('preserves legacy datasource name string so lookup-by-name can succeed at runtime', () => {
+        const panel: Panel = {
+          id: 2,
+          type: 'timeseries',
+          title: 'Test',
+          datasource: 'My Prometheus' as any,
+          targets: [{ refId: 'A' }],
+          fieldConfig: { defaults: {}, overrides: [] },
+          options: {},
+          gridPos: { x: 0, y: 0, w: 12, h: 8 },
+          transformations: [],
+        };
+
+        const result = buildPanelKind(panel);
+        const query = result.spec.data.spec.queries[0];
+
+        expect(query.spec.query.datasource?.name).toBe('My Prometheus');
+      });
+
+      it('leaves object datasource untouched', () => {
+        const panel: Panel = {
+          id: 3,
+          type: 'timeseries',
+          title: 'Test',
+          datasource: { uid: 'abc123', type: 'mysql' },
+          targets: [{ refId: 'A' }],
+          fieldConfig: { defaults: {}, overrides: [] },
+          options: {},
+          gridPos: { x: 0, y: 0, w: 12, h: 8 },
+          transformations: [],
+        };
+
+        const result = buildPanelKind(panel);
+        const query = result.spec.data.spec.queries[0];
+
+        expect(query.spec.query.datasource?.name).toBe('abc123');
+        expect(query.spec.query.group).toBe('mysql');
+      });
+
+      it('preserves string datasource on individual targets', () => {
+        const panel: Panel = {
+          id: 4,
+          type: 'timeseries',
+          title: 'Test',
+          datasource: { uid: 'panel-ds', type: 'mysql' },
+          targets: [{ refId: 'A', datasource: '$TargetDS' as any }],
+          fieldConfig: { defaults: {}, overrides: [] },
+          options: {},
+          gridPos: { x: 0, y: 0, w: 12, h: 8 },
+          transformations: [],
+        };
+
+        const result = buildPanelKind(panel);
+        const query = result.spec.data.spec.queries[0];
+
+        expect(query.spec.query.datasource?.name).toBe('$TargetDS');
       });
     });
   });

--- a/public/app/features/dashboard/api/ResponseTransformers.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.ts
@@ -587,9 +587,7 @@ export function buildPanelKind(p: Panel): PanelKind {
   // V1 panels can store datasource as a plain string (variable expression or legacy name).
   // Normalize to DataSourceRef so the uid is preserved through V1→V2 conversion.
   const panelDatasource =
-    typeof p.datasource === 'string'
-      ? { uid: p.datasource, type: '' }
-      : (p.datasource ?? { type: '', uid: '' });
+    typeof p.datasource === 'string' ? { uid: p.datasource, type: '' } : (p.datasource ?? { type: '', uid: '' });
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/consistent-type-assertions
   const queries = getPanelQueries((p.targets as any) || [], panelDatasource);
 

--- a/public/app/features/dashboard/api/ResponseTransformers.ts
+++ b/public/app/features/dashboard/api/ResponseTransformers.ts
@@ -506,7 +506,9 @@ export function getPanelQueries(targets: DataQuery[], panelDatasource: DataSourc
     // and fall through to use panel datasource (matches backend behavior)
     const targetDs = t.datasource;
     const isEmptyDatasourceObject = targetDs && typeof targetDs === 'object' && Object.keys(targetDs).length === 0;
-    const ds = isEmptyDatasourceObject ? panelDatasource : targetDs || panelDatasource;
+    // V1 targets can also store datasource as a plain string (variable or legacy name) — normalize to DataSourceRef
+    const normalizedTargetDs = typeof targetDs === 'string' ? { uid: targetDs, type: '' } : targetDs;
+    const ds = isEmptyDatasourceObject ? panelDatasource : normalizedTargetDs || panelDatasource;
     const q: PanelQueryKind = {
       kind: 'PanelQuery',
       spec: {
@@ -582,8 +584,14 @@ function extractAngularOptions(panel: Panel): Record<string, unknown> {
 }
 
 export function buildPanelKind(p: Panel): PanelKind {
+  // V1 panels can store datasource as a plain string (variable expression or legacy name).
+  // Normalize to DataSourceRef so the uid is preserved through V1→V2 conversion.
+  const panelDatasource =
+    typeof p.datasource === 'string'
+      ? { uid: p.datasource, type: '' }
+      : (p.datasource ?? { type: '', uid: '' });
   // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/consistent-type-assertions
-  const queries = getPanelQueries((p.targets as any) || [], p.datasource ?? { type: '', uid: '' });
+  const queries = getPanelQueries((p.targets as any) || [], panelDatasource);
 
   const transformations = getPanelTransformations(p.transformations || []);
 


### PR DESCRIPTION
### Problem

Old dashboards sometimes store the panel datasource as a plain string, either a variable like $DataSource or a legacy name. When we convert V1 to V2, that string gets passed into getPanelQueries as if it were a DataSourceRef object. Since strings don't have .uid or .type, the query ends up with group: '' and no datasource, so SceneQueryRunner has nothing to query against and panels show "No Data" on load.
This regressed in [#109037](https://github.com/grafana/grafana/issues/109037) which changed p.datasource || getDefaultDatasource() to p.datasource ?? { type: '', uid: '' }. The ?? doesn't catch strings so they slip through. Didn't surface until the V2 API went live in March.

### Fix

Normalize string datasources to { uid: string, type: '' } before passing them into getPanelQueries, at both panel and target level. The uid gets preserved through the conversion and variable expressions like $DataSource get interpolated at query time as normal.