### PR TITLE
Tracing: Fix span duration handling in tracing loops for grafana queries

### DIFF
--- a/pkg/expr/graph.go
+++ b/pkg/expr/graph.go
@@ -147,10 +147,10 @@ func (dp *DataPipeline) execute(c context.Context, now time.Time, s *Service) (m
 			inputRefIDs := node.NeedsVars()
 			span.SetAttributes(attribute.StringSlice("node.inputRefIDs", inputRefIDs))
 		}
-		defer span.End()
 
 		execNode, ok := node.(ExecutableNode)
 		if !ok {
+			span.End()
 			return vars, makeUnexpectedNodeTypeError(node.RefID(), node.NodeType().String())
 		}
 
@@ -160,6 +160,7 @@ func (dp *DataPipeline) execute(c context.Context, now time.Time, s *Service) (m
 		}
 
 		vars[node.RefID()] = res
+		span.End()
 	}
 	return vars, nil
 }

--- a/pkg/tsdb/graphite/query.go
+++ b/pkg/tsdb/graphite/query.go
@@ -71,7 +71,6 @@ func (s *Service) RunQuery(ctx context.Context, req *backend.QueryDataRequest, d
 
 	for refId, graphiteReq := range graphiteQueries {
 		_, span := tracing.DefaultTracer().Start(ctx, "graphite query")
-		defer span.End()
 		targetStr := strings.Join(graphiteReq.formData["target"], ",")
 		span.SetAttributes(
 			attribute.String("refId", refId),
@@ -88,6 +87,7 @@ func (s *Service) RunQuery(ctx context.Context, req *backend.QueryDataRequest, d
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
+			span.End()
 			result.Responses[refId] = backend.ErrorResponseWithErrorSource(backend.DownstreamError(err))
 			return result, nil
 		}
@@ -103,11 +103,13 @@ func (s *Service) RunQuery(ctx context.Context, req *backend.QueryDataRequest, d
 		if err != nil {
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
+			span.End()
 			result.Responses[refId] = backend.ErrorResponseWithErrorSource(err)
 			return result, nil
 		}
 
 		frames = append(frames, queryFrames...)
+		span.End()
 	}
 
 	for _, f := range frames {


### PR DESCRIPTION
**What is this feature?**

Bug fix. `defer span.End()` was used inside loops in two places. In Go, `defer` executes when the enclosing function returns, not at the end of a loop iteration. This caused all spans created across loop iterations to close at the same timestamp, making per-node execution times completely wrong in distributed tracing.

**Why do we need this feature?**

The expression pipeline (`pkg/expr/graph.go`) runs on every alert rule evaluation. With `defer span.End()` inside the node execution loop, every `SSE.ExecuteNode` span reported the same end time regardless of when each node actually finished. This makes tracing data for alerting useless you cannot tell which expression node was slow. The same issue existed in the Graphite datasource query loop.

**Who is this feature for?**

Anyone using Grafana with a tracing backend (Tempo, Jaeger) who wants accurate per-node execution times for alert rule evaluation or Graphite queries.

**Which issue(s) does this PR fix?**

Fixes #123419

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.

Two files changed:
- `pkg/expr/graph.go`  `defer span.End()` replaced with direct `span.End()` calls, including the early-return error path
- `pkg/tsdb/graphite/query.go` 
This pull request updates the way tracing spans are managed in the `DataPipeline` execution and Graphite query code. The main change is replacing the use of `defer span.End()` with explicit calls to `span.End()` at appropriate points in the code. This ensures that spans are closed as soon as their associated work is complete, improving trace accuracy and preventing spans from remaining open longer than necessary.

**Tracing span management improvements:**

* [`pkg/expr/graph.go`](diffhunk://#diff-9852c58960376692798327dbe2462d2cf75d93ed41aa837c5908ee2a031dd050L150-R153): Removed `defer span.End()` and added explicit `span.End()` calls before returning from the `execute` method, ensuring spans are closed immediately after node execution or upon encountering an unexpected node type. [[1]](diffhunk://#diff-9852c58960376692798327dbe2462d2cf75d93ed41aa837c5908ee2a031dd050L150-R153) [[2]](diffhunk://#diff-9852c58960376692798327dbe2462d2cf75d93ed41aa837c5908ee2a031dd050R163)
* [`pkg/tsdb/graphite/query.go`](diffhunk://#diff-d97ed3a19dd85b3480d98de05015c3ff0a820e558f3d063141ef88c2ba55ff3cL74): Removed `defer span.End()` and replaced it with explicit `span.End()` calls after error handling and after successful frame processing in the `RunQuery` method, ensuring spans are closed at the correct time in all code paths. [[1]](diffhunk://#diff-d97ed3a19dd85b3480d98de05015c3ff0a820e558f3d063141ef88c2ba55ff3cL74) [[2]](diffhunk://#diff-d97ed3a19dd85b3480d98de05015c3ff0a820e558f3d063141ef88c2ba55ff3cR90) [[3]](diffhunk://#diff-d97ed3a19dd85b3480d98de05015c3ff0a820e558f3d063141ef88c2ba55ff3cR106-R112) same fix, with `span.End()` added to both the error paths and the successful iteration end
