### PR TITLE
Authz: Split IAM integration tests into sub-packages for CI shard distribution

### DIFF
--- a/pkg/tests/apis/iam/iam_test.go
+++ b/pkg/tests/apis/iam/iam_test.go
@@ -27,12 +27,6 @@ var gvrUsers = schema.GroupVersionResource{
 	Resource: "users",
 }
 
-var gvrTeamBindings = schema.GroupVersionResource{
-	Group:    "iam.grafana.app",
-	Version:  "v0alpha1",
-	Resource: "teambindings",
-}
-
 func TestMain(m *testing.M) {
 	testsuite.Run(m)
 }

--- a/pkg/tests/apis/iam/resourcepermission/resource_permissions_integration_test.go
+++ b/pkg/tests/apis/iam/resourcepermission/resource_permissions_integration_test.go
@@ -1,4 +1,4 @@
-package identity
+package resourcepermission
 
 import (
 	"context"
@@ -18,7 +18,7 @@ import (
 	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/apiserver/rest"
-	"github.com/grafana/grafana/pkg/registry/apis/iam/resourcepermission"
+	rp "github.com/grafana/grafana/pkg/registry/apis/iam/resourcepermission"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tests/apis"
@@ -690,7 +690,7 @@ func TestIntegrationResourcePermissionSearch(t *testing.T) {
 		// Admin has get_permissions on the folder -> should see Editor's direct permission for this folder.
 		rawAdmin, err := restClientAdmin.Get().
 			AbsPath("apis", iamv0.GROUP, iamv0.VERSION, "namespaces", ns, "resourcepermissions", "search").
-			Param(resourcepermission.SearchParamUserUID, editorUID).
+			Param(rp.SearchParamUserUID, editorUID).
 			Do(ctx).
 			Raw()
 		require.NoError(t, err)
@@ -708,7 +708,7 @@ func TestIntegrationResourcePermissionSearch(t *testing.T) {
 		// Viewer does not have get_permissions on this folder -> should NOT see Editor's direct permission for it.
 		rawViewer, err := restClientViewer.Get().
 			AbsPath("apis", iamv0.GROUP, iamv0.VERSION, "namespaces", ns, "resourcepermissions", "search").
-			Param(resourcepermission.SearchParamUserUID, editorUID).
+			Param(rp.SearchParamUserUID, editorUID).
 			Do(ctx).
 			Raw()
 		require.NoError(t, err)
@@ -735,7 +735,7 @@ func TestIntegrationResourcePermissionSearch(t *testing.T) {
 
 		raw, err := restClientAdmin.Get().
 			AbsPath("apis", iamv0.GROUP, iamv0.VERSION, "namespaces", ns, "resourcepermissions", "search").
-			Param(resourcepermission.SearchParamUserUID, editorUID).
+			Param(rp.SearchParamUserUID, editorUID).
 			Do(ctx).
 			Raw()
 		require.NoError(t, err)
@@ -769,7 +769,7 @@ func TestIntegrationResourcePermissionSearch(t *testing.T) {
 
 		raw, err := restClientAdmin.Get().
 			AbsPath("apis", iamv0.GROUP, iamv0.VERSION, "namespaces", ns, "resourcepermissions", "search").
-			Param(resourcepermission.SearchParamTeamUID, teamUID).
+			Param(rp.SearchParamTeamUID, teamUID).
 			Do(ctx).
 			Raw()
 		require.NoError(t, err)
@@ -804,7 +804,7 @@ func TestIntegrationResourcePermissionSearch(t *testing.T) {
 		// Admin has get_permissions on the folder -> should see Staff team's direct permission for this folder.
 		rawAdmin, err := restClientAdmin.Get().
 			AbsPath("apis", iamv0.GROUP, iamv0.VERSION, "namespaces", ns, "resourcepermissions", "search").
-			Param(resourcepermission.SearchParamTeamUID, teamUID).
+			Param(rp.SearchParamTeamUID, teamUID).
 			Do(ctx).
 			Raw()
 		require.NoError(t, err)
@@ -822,7 +822,7 @@ func TestIntegrationResourcePermissionSearch(t *testing.T) {
 		// Viewer does not have get_permissions on this folder -> should NOT see Staff team's direct permission for it.
 		rawViewer, err := restClientViewer.Get().
 			AbsPath("apis", iamv0.GROUP, iamv0.VERSION, "namespaces", ns, "resourcepermissions", "search").
-			Param(resourcepermission.SearchParamTeamUID, teamUID).
+			Param(rp.SearchParamTeamUID, teamUID).
 			Do(ctx).
 			Raw()
 		require.NoError(t, err)
@@ -849,7 +849,7 @@ func TestIntegrationResourcePermissionSearch(t *testing.T) {
 
 		raw, err := restClientAdmin.Get().
 			AbsPath("apis", iamv0.GROUP, iamv0.VERSION, "namespaces", ns, "resourcepermissions", "search").
-			Param(resourcepermission.SearchParamBasicRole, "Editor").
+			Param(rp.SearchParamBasicRole, "Editor").
 			Do(ctx).
 			Raw()
 		require.NoError(t, err)
@@ -882,7 +882,7 @@ func TestIntegrationResourcePermissionSearch(t *testing.T) {
 		// Admin has get_permissions on the folder -> should see Viewer basic role's direct permission for this folder.
 		rawAdmin, err := restClientAdmin.Get().
 			AbsPath("apis", iamv0.GROUP, iamv0.VERSION, "namespaces", ns, "resourcepermissions", "search").
-			Param(resourcepermission.SearchParamBasicRole, "Viewer").
+			Param(rp.SearchParamBasicRole, "Viewer").
 			Do(ctx).
 			Raw()
 		require.NoError(t, err)
@@ -900,7 +900,7 @@ func TestIntegrationResourcePermissionSearch(t *testing.T) {
 		// Viewer does not have get_permissions on this folder -> should NOT see Viewer basic role's direct permission for it.
 		rawViewer, err := restClientViewer.Get().
 			AbsPath("apis", iamv0.GROUP, iamv0.VERSION, "namespaces", ns, "resourcepermissions", "search").
-			Param(resourcepermission.SearchParamBasicRole, "Viewer").
+			Param(rp.SearchParamBasicRole, "Viewer").
 			Do(ctx).
 			Raw()
 		require.NoError(t, err)

--- a/pkg/tests/apis/iam/resourcepermission/resourcepermission_test.go
+++ b/pkg/tests/apis/iam/resourcepermission/resourcepermission_test.go
@@ -1,0 +1,11 @@
+package resourcepermission
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana/pkg/tests/testsuite"
+)
+
+func TestMain(m *testing.M) {
+	testsuite.Run(m)
+}

--- a/pkg/tests/apis/iam/serviceaccount/service_account_integration_test.go
+++ b/pkg/tests/apis/iam/serviceaccount/service_account_integration_test.go
@@ -1,4 +1,4 @@
-package identity
+package serviceaccount
 
 import (
 	"context"
@@ -66,7 +66,7 @@ func doServiceAccountCRUDTestsUsingTheNewAPIs(t *testing.T, helper *apis.K8sTest
 			GVR:       gvrServiceAccounts,
 		})
 
-		created, err := saClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("testdata/serviceaccount-test-create-v0.yaml"), metav1.CreateOptions{})
+		created, err := saClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("../testdata/serviceaccount-test-create-v0.yaml"), metav1.CreateOptions{})
 		require.NoError(t, err)
 		require.NotNil(t, created)
 
@@ -116,7 +116,7 @@ func doServiceAccountCRUDTestsUsingTheNewAPIs(t *testing.T, helper *apis.K8sTest
 					GVR:       gvrServiceAccounts,
 				})
 
-				_, err := saClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("testdata/serviceaccount-test-create-v0.yaml"), metav1.CreateOptions{})
+				_, err := saClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("../testdata/serviceaccount-test-create-v0.yaml"), metav1.CreateOptions{})
 				require.Error(t, err)
 				var statusErr *errors.StatusError
 				require.ErrorAs(t, err, &statusErr)
@@ -133,7 +133,7 @@ func doServiceAccountCRUDTestsUsingTheNewAPIs(t *testing.T, helper *apis.K8sTest
 			GVR:       gvrServiceAccounts,
 		})
 
-		saToCreate := helper.LoadYAMLOrJSONFile("testdata/serviceaccount-test-invalid-role-v0.yaml")
+		saToCreate := helper.LoadYAMLOrJSONFile("../testdata/serviceaccount-test-invalid-role-v0.yaml")
 
 		_, err := saClient.Resource.Create(ctx, saToCreate, metav1.CreateOptions{})
 		require.Error(t, err)
@@ -151,7 +151,7 @@ func doServiceAccountCRUDTestsUsingTheNewAPIs(t *testing.T, helper *apis.K8sTest
 			GVR:       gvrServiceAccounts,
 		})
 
-		saToCreate := helper.LoadYAMLOrJSONFile("testdata/serviceaccount-test-no-title-v0.yaml")
+		saToCreate := helper.LoadYAMLOrJSONFile("../testdata/serviceaccount-test-no-title-v0.yaml")
 
 		_, err := saClient.Resource.Create(ctx, saToCreate, metav1.CreateOptions{})
 		require.Error(t, err)
@@ -169,7 +169,7 @@ func doServiceAccountCRUDTestsUsingTheNewAPIs(t *testing.T, helper *apis.K8sTest
 			GVR:       gvrServiceAccounts,
 		})
 
-		saToCreate := helper.LoadYAMLOrJSONFile("testdata/serviceaccount-test-external-v0.yaml")
+		saToCreate := helper.LoadYAMLOrJSONFile("../testdata/serviceaccount-test-external-v0.yaml")
 
 		_, err := saClient.Resource.Create(ctx, saToCreate, metav1.CreateOptions{})
 		require.Error(t, err)
@@ -188,7 +188,7 @@ func doServiceAccountCRUDTestsUsingTheNewAPIs(t *testing.T, helper *apis.K8sTest
 			GVR:       gvrServiceAccounts,
 		})
 
-		created, err := saClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("testdata/serviceaccount-test-generate-name-v0.yaml"), metav1.CreateOptions{})
+		created, err := saClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("../testdata/serviceaccount-test-generate-name-v0.yaml"), metav1.CreateOptions{})
 		require.NoError(t, err)
 		require.NotNil(t, created)
 

--- a/pkg/tests/apis/iam/serviceaccount/service_account_token_integration_test.go
+++ b/pkg/tests/apis/iam/serviceaccount/service_account_token_integration_test.go
@@ -1,4 +1,4 @@
-package identity
+package serviceaccount
 
 import (
 	"context"
@@ -90,7 +90,7 @@ func createServiceAccount(t *testing.T, helper *apis.K8sTestHelper) string {
 		GVR:       gvrServiceAccounts,
 	})
 
-	created, err := saClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("testdata/serviceaccount-test-create-v0.yaml"), metav1.CreateOptions{})
+	created, err := saClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("../testdata/serviceaccount-test-create-v0.yaml"), metav1.CreateOptions{})
 	require.NoError(t, err)
 	require.NotNil(t, created)
 

--- a/pkg/tests/apis/iam/serviceaccount/serviceaccount_test.go
+++ b/pkg/tests/apis/iam/serviceaccount/serviceaccount_test.go
@@ -1,0 +1,11 @@
+package serviceaccount
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana/pkg/tests/testsuite"
+)
+
+func TestMain(m *testing.M) {
+	testsuite.Run(m)
+}

--- a/pkg/tests/apis/iam/team/helpers_test.go
+++ b/pkg/tests/apis/iam/team/helpers_test.go
@@ -1,0 +1,23 @@
+package team
+
+import (
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/grafana/grafana/pkg/tests/apis"
+)
+
+func createTeamObject(helper *apis.K8sTestHelper, teamName string, title string, email string) *unstructured.Unstructured {
+	teamObj := helper.LoadYAMLOrJSONFile("../testdata/team-test-create-v0.yaml")
+	teamObj.Object["metadata"].(map[string]any)["name"] = teamName
+	teamObj.Object["spec"].(map[string]any)["title"] = title
+	teamObj.Object["spec"].(map[string]any)["email"] = email
+
+	return teamObj
+}
+
+func createTeamBindingObject(helper *apis.K8sTestHelper, userName, teamName string) *unstructured.Unstructured {
+	obj := helper.LoadYAMLOrJSONFile("../testdata/teambinding-test-create-v0.yaml")
+	obj.Object["spec"].(map[string]interface{})["subject"].(map[string]interface{})["name"] = userName
+	obj.Object["spec"].(map[string]interface{})["teamRef"].(map[string]interface{})["name"] = teamName
+	return obj
+}

--- a/pkg/tests/apis/iam/team/team_integration_test.go
+++ b/pkg/tests/apis/iam/team/team_integration_test.go
@@ -1,4 +1,4 @@
-package identity
+package team
 
 import (
 	"context"
@@ -60,7 +60,7 @@ func doTeamCRUDTestsUsingTheNewAPIs(t *testing.T, helper *apis.K8sTestHelper) {
 		})
 
 		// Create the team
-		created, err := teamClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("testdata/team-test-create-v0.yaml"), metav1.CreateOptions{})
+		created, err := teamClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("../testdata/team-test-create-v0.yaml"), metav1.CreateOptions{})
 		require.NoError(t, err)
 		require.NotNil(t, created)
 
@@ -86,7 +86,7 @@ func doTeamCRUDTestsUsingTheNewAPIs(t *testing.T, helper *apis.K8sTestHelper) {
 		require.Equal(t, "default", fetched.GetNamespace())
 
 		// Update the team
-		updatedTeam, err := teamClient.Resource.Update(ctx, helper.LoadYAMLOrJSONFile("testdata/team-test-update-v0.yaml"), metav1.UpdateOptions{})
+		updatedTeam, err := teamClient.Resource.Update(ctx, helper.LoadYAMLOrJSONFile("../testdata/team-test-update-v0.yaml"), metav1.UpdateOptions{})
 		require.NoError(t, err)
 		require.NotNil(t, updatedTeam)
 
@@ -129,7 +129,7 @@ func doTeamCRUDTestsUsingTheNewAPIs(t *testing.T, helper *apis.K8sTestHelper) {
 					GVR:       gvrTeams,
 				})
 
-				_, err := teamClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("testdata/team-test-create-v0.yaml"), metav1.CreateOptions{})
+				_, err := teamClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("../testdata/team-test-create-v0.yaml"), metav1.CreateOptions{})
 				require.Error(t, err)
 				var statusErr *errors.StatusError
 				require.ErrorAs(t, err, &statusErr)
@@ -146,7 +146,7 @@ func doTeamCRUDTestsUsingTheNewAPIs(t *testing.T, helper *apis.K8sTestHelper) {
 			GVR:       gvrTeams,
 		})
 
-		toCreate := helper.LoadYAMLOrJSONFile("testdata/team-test-no-title-v0.yaml")
+		toCreate := helper.LoadYAMLOrJSONFile("../testdata/team-test-no-title-v0.yaml")
 
 		_, err := teamClient.Resource.Create(ctx, toCreate, metav1.CreateOptions{})
 		require.Error(t, err)
@@ -164,7 +164,7 @@ func doTeamCRUDTestsUsingTheNewAPIs(t *testing.T, helper *apis.K8sTestHelper) {
 			GVR:       gvrTeams,
 		})
 
-		toCreate := helper.LoadYAMLOrJSONFile("testdata/team-test-provisioned-v0.yaml")
+		toCreate := helper.LoadYAMLOrJSONFile("../testdata/team-test-provisioned-v0.yaml")
 
 		_, err := teamClient.Resource.Create(ctx, toCreate, metav1.CreateOptions{})
 		require.Error(t, err)
@@ -182,7 +182,7 @@ func doTeamCRUDTestsUsingTheNewAPIs(t *testing.T, helper *apis.K8sTestHelper) {
 			GVR:       gvrTeams,
 		})
 
-		toCreate := helper.LoadYAMLOrJSONFile("testdata/team-test-external-uid-without-provisioned-v0.yaml")
+		toCreate := helper.LoadYAMLOrJSONFile("../testdata/team-test-external-uid-without-provisioned-v0.yaml")
 
 		_, err := teamClient.Resource.Create(ctx, toCreate, metav1.CreateOptions{})
 		require.Error(t, err)
@@ -201,7 +201,7 @@ func doTeamCRUDTestsUsingTheNewAPIs(t *testing.T, helper *apis.K8sTestHelper) {
 			GVR:       gvrTeams,
 		})
 
-		created, err := teamClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("testdata/team-test-generate-name-v0.yaml"), metav1.CreateOptions{})
+		created, err := teamClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("../testdata/team-test-generate-name-v0.yaml"), metav1.CreateOptions{})
 		require.NoError(t, err)
 		require.NotNil(t, created)
 

--- a/pkg/tests/apis/iam/team/team_members_search_integration_test.go
+++ b/pkg/tests/apis/iam/team/team_members_search_integration_test.go
@@ -1,4 +1,4 @@
-package identity
+package team
 
 import (
 	"context"
@@ -100,7 +100,7 @@ func doTeamMembersTests(t *testing.T, helper *apis.K8sTestHelper) {
 	// Create 5 users
 	users := make([]*unstructured.Unstructured, 0, 5)
 	for i := 1; i <= 5; i++ {
-		uObj := helper.LoadYAMLOrJSONFile("testdata/user-test-create-v0.yaml")
+		uObj := helper.LoadYAMLOrJSONFile("../testdata/user-test-create-v0.yaml")
 		uObj.Object["metadata"].(map[string]any)["name"] = fmt.Sprintf("user-member-%d", i)
 		uObj.Object["spec"].(map[string]any)["login"] = fmt.Sprintf("user-member-%d", i)
 		uObj.Object["spec"].(map[string]any)["email"] = fmt.Sprintf("user-member-%d@example.com", i)

--- a/pkg/tests/apis/iam/team/team_redirect_integration_test.go
+++ b/pkg/tests/apis/iam/team/team_redirect_integration_test.go
@@ -1,4 +1,4 @@
-package identity
+package team
 
 import (
 	"context"

--- a/pkg/tests/apis/iam/team/team_search_integration_test.go
+++ b/pkg/tests/apis/iam/team/team_search_integration_test.go
@@ -1,4 +1,4 @@
-package identity
+package team
 
 import (
 	"context"
@@ -59,11 +59,11 @@ func doTeamSearchTests(t *testing.T, helper *apis.K8sTestHelper, mode rest.DualW
 		GVR:       gvrTeams,
 	})
 
-	team1, err := teamClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("testdata/team-test-create-v0.yaml"), metav1.CreateOptions{})
+	team1, err := teamClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("../testdata/team-test-create-v0.yaml"), metav1.CreateOptions{})
 	require.NoError(t, err)
 	require.NotNil(t, team1)
 
-	team2YAML := helper.LoadYAMLOrJSONFile("testdata/team-test-create-v0.yaml")
+	team2YAML := helper.LoadYAMLOrJSONFile("../testdata/team-test-create-v0.yaml")
 	team2YAML.Object["metadata"].(map[string]interface{})["name"] = "testteam2"
 	team2YAML.Object["spec"].(map[string]interface{})["title"] = "Another Team"
 	team2YAML.Object["spec"].(map[string]interface{})["email"] = "anotherteam@example.com"
@@ -500,7 +500,7 @@ func doTeamSearchMemberCountTests(t *testing.T, helper *apis.K8sTestHelper) {
 
 	// Create 3 users and bind them to teamA
 	for i := 1; i <= 3; i++ {
-		uObj := helper.LoadYAMLOrJSONFile("testdata/user-test-create-v0.yaml")
+		uObj := helper.LoadYAMLOrJSONFile("../testdata/user-test-create-v0.yaml")
 		uObj.Object["metadata"].(map[string]any)["name"] = fmt.Sprintf("mc-user-%d", i)
 		uObj.Object["spec"].(map[string]any)["login"] = fmt.Sprintf("mc-user-%d", i)
 		uObj.Object["spec"].(map[string]any)["email"] = fmt.Sprintf("mc-user-%d@example.com", i)
@@ -611,7 +611,7 @@ func TestIntegrationTeamSearch_AccessControl(t *testing.T) {
 				GVR:       gvrTeams,
 			})
 
-			team1, err := teamClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("testdata/team-test-create-v0.yaml"), metav1.CreateOptions{})
+			team1, err := teamClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("../testdata/team-test-create-v0.yaml"), metav1.CreateOptions{})
 			require.NoError(t, err)
 			require.NotNil(t, team1)
 

--- a/pkg/tests/apis/iam/team/team_service_integration_test.go
+++ b/pkg/tests/apis/iam/team/team_service_integration_test.go
@@ -1,4 +1,4 @@
-package identity
+package team
 
 import (
 	"context"

--- a/pkg/tests/apis/iam/team/team_test.go
+++ b/pkg/tests/apis/iam/team/team_test.go
@@ -1,0 +1,31 @@
+package team
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/grafana/grafana/pkg/tests/testsuite"
+)
+
+var gvrTeams = schema.GroupVersionResource{
+	Group:    "iam.grafana.app",
+	Version:  "v0alpha1",
+	Resource: "teams",
+}
+
+var gvrUsers = schema.GroupVersionResource{
+	Group:    "iam.grafana.app",
+	Version:  "v0alpha1",
+	Resource: "users",
+}
+
+var gvrTeamBindings = schema.GroupVersionResource{
+	Group:    "iam.grafana.app",
+	Version:  "v0alpha1",
+	Resource: "teambindings",
+}
+
+func TestMain(m *testing.M) {
+	testsuite.Run(m)
+}

--- a/pkg/tests/apis/iam/teambinding/team_binding_integration_test.go
+++ b/pkg/tests/apis/iam/teambinding/team_binding_integration_test.go
@@ -1,4 +1,4 @@
-package identity
+package teambinding
 
 import (
 	"context"
@@ -58,7 +58,7 @@ func TestIntegrationTeamBindings(t *testing.T) {
 				GVR:       gvrTeams,
 			})
 
-			team, err := teamClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("testdata/team-test-create-v0.yaml"), metav1.CreateOptions{})
+			team, err := teamClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("../testdata/team-test-create-v0.yaml"), metav1.CreateOptions{})
 			require.NoError(t, err)
 			require.NotNil(t, team)
 
@@ -69,7 +69,7 @@ func TestIntegrationTeamBindings(t *testing.T) {
 				GVR:       gvrUsers,
 			})
 
-			user, err := userClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("testdata/user-test-create-v0.yaml"), metav1.CreateOptions{})
+			user, err := userClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("../testdata/user-test-create-v0.yaml"), metav1.CreateOptions{})
 			require.NoError(t, err)
 			require.NotNil(t, user)
 
@@ -601,7 +601,7 @@ func doTeamBindingFieldSelectionTests(t *testing.T, helper *apis.K8sTestHelper) 
 		})
 
 		createTeam := func(name string, email string) *unstructured.Unstructured {
-			obj := helper.LoadYAMLOrJSONFile("testdata/team-test-create-v0.yaml")
+			obj := helper.LoadYAMLOrJSONFile("../testdata/team-test-create-v0.yaml")
 			obj.SetName(name)
 
 			spec := obj.Object["spec"].(map[string]interface{})
@@ -615,7 +615,7 @@ func doTeamBindingFieldSelectionTests(t *testing.T, helper *apis.K8sTestHelper) 
 		}
 
 		createUser := func(name string, email string, login string) *unstructured.Unstructured {
-			obj := helper.LoadYAMLOrJSONFile("testdata/user-test-create-v0.yaml")
+			obj := helper.LoadYAMLOrJSONFile("../testdata/user-test-create-v0.yaml")
 			obj.SetName(name)
 
 			spec := obj.Object["spec"].(map[string]interface{})
@@ -634,7 +634,7 @@ func doTeamBindingFieldSelectionTests(t *testing.T, helper *apis.K8sTestHelper) 
 		user2 := createUser("tb-user-2", "tb-user2@example.com", "tb-user2")
 
 		createBinding := func(user *unstructured.Unstructured, team *unstructured.Unstructured, external bool) {
-			toCreate := helper.LoadYAMLOrJSONFile("testdata/teambinding-test-create-v0.yaml")
+			toCreate := helper.LoadYAMLOrJSONFile("../testdata/teambinding-test-create-v0.yaml")
 			toCreate.SetName("")
 			toCreate.SetGenerateName("binding-")
 			toCreate.Object["spec"].(map[string]interface{})["subject"].(map[string]interface{})["name"] = user.GetName()
@@ -705,7 +705,7 @@ func doTeamBindingFieldSelectionTests(t *testing.T, helper *apis.K8sTestHelper) 
 }
 
 func createTeamBindingObject(helper *apis.K8sTestHelper, userName, teamName string) *unstructured.Unstructured {
-	obj := helper.LoadYAMLOrJSONFile("testdata/teambinding-test-create-v0.yaml")
+	obj := helper.LoadYAMLOrJSONFile("../testdata/teambinding-test-create-v0.yaml")
 	obj.Object["spec"].(map[string]interface{})["subject"].(map[string]interface{})["name"] = userName
 	obj.Object["spec"].(map[string]interface{})["teamRef"].(map[string]interface{})["name"] = teamName
 	return obj

--- a/pkg/tests/apis/iam/teambinding/teambinding_test.go
+++ b/pkg/tests/apis/iam/teambinding/teambinding_test.go
@@ -1,0 +1,31 @@
+package teambinding
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/grafana/grafana/pkg/tests/testsuite"
+)
+
+var gvrTeams = schema.GroupVersionResource{
+	Group:    "iam.grafana.app",
+	Version:  "v0alpha1",
+	Resource: "teams",
+}
+
+var gvrUsers = schema.GroupVersionResource{
+	Group:    "iam.grafana.app",
+	Version:  "v0alpha1",
+	Resource: "users",
+}
+
+var gvrTeamBindings = schema.GroupVersionResource{
+	Group:    "iam.grafana.app",
+	Version:  "v0alpha1",
+	Resource: "teambindings",
+}
+
+func TestMain(m *testing.M) {
+	testsuite.Run(m)
+}

--- a/pkg/tests/apis/iam/user/user_integration_test.go
+++ b/pkg/tests/apis/iam/user/user_integration_test.go
@@ -1,4 +1,4 @@
-package identity
+package user
 
 import (
 	"context"
@@ -67,7 +67,7 @@ func doUserCRUDTestsUsingTheNewAPIs(t *testing.T, helper *apis.K8sTestHelper) {
 		})
 
 		// Create the user
-		created, err := userClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("testdata/user-test-create-v0.yaml"), metav1.CreateOptions{})
+		created, err := userClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("../testdata/user-test-create-v0.yaml"), metav1.CreateOptions{})
 		require.NoError(t, err)
 		require.NotNil(t, created)
 
@@ -119,7 +119,7 @@ func doUserCRUDTestsUsingTheNewAPIs(t *testing.T, helper *apis.K8sTestHelper) {
 		})
 
 		// Create the user
-		created, err := userClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("testdata/user-test-create-v1.yaml"), metav1.CreateOptions{})
+		created, err := userClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("../testdata/user-test-create-v1.yaml"), metav1.CreateOptions{})
 		require.NoError(t, err)
 		require.NotNil(t, created)
 		t.Cleanup(func() {
@@ -174,7 +174,7 @@ func doUserCRUDTestsUsingTheNewAPIs(t *testing.T, helper *apis.K8sTestHelper) {
 				})
 
 				// Create the user
-				_, err := userClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("testdata/user-test-create-v0.yaml"), metav1.CreateOptions{})
+				_, err := userClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("../testdata/user-test-create-v0.yaml"), metav1.CreateOptions{})
 				require.Error(t, err)
 				var statusErr *errors.StatusError
 				require.ErrorAs(t, err, &statusErr)
@@ -192,12 +192,12 @@ func doUserCRUDTestsUsingTheNewAPIs(t *testing.T, helper *apis.K8sTestHelper) {
 		})
 
 		// Create the first user
-		created, err := userClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("testdata/user-test-create-duplicate-email-v0.yaml"), metav1.CreateOptions{})
+		created, err := userClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("../testdata/user-test-create-duplicate-email-v0.yaml"), metav1.CreateOptions{})
 		require.NoError(t, err)
 		require.NotNil(t, created)
 
 		// Attempt to create another user with the same email
-		_, err = userClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("testdata/user-test-create-duplicate-email-other.yaml"), metav1.CreateOptions{})
+		_, err = userClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("../testdata/user-test-create-duplicate-email-other.yaml"), metav1.CreateOptions{})
 		require.Error(t, err)
 		var statusErr *errors.StatusError
 		require.ErrorAs(t, err, &statusErr)
@@ -218,12 +218,12 @@ func doUserCRUDTestsUsingTheNewAPIs(t *testing.T, helper *apis.K8sTestHelper) {
 		})
 
 		// Create the first user
-		created, err := userClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("testdata/user-test-create-duplicate-login-v0.yaml"), metav1.CreateOptions{})
+		created, err := userClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("../testdata/user-test-create-duplicate-login-v0.yaml"), metav1.CreateOptions{})
 		require.NoError(t, err)
 		require.NotNil(t, created)
 
 		// Attempt to create a second user with the same login
-		_, err = userClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("testdata/user-test-create-duplicate-login-other.yaml"), metav1.CreateOptions{})
+		_, err = userClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("../testdata/user-test-create-duplicate-login-other.yaml"), metav1.CreateOptions{})
 		require.Error(t, err)
 		var statusErr *errors.StatusError
 		require.ErrorAs(t, err, &statusErr)
@@ -244,12 +244,12 @@ func doUserCRUDTestsUsingTheNewAPIs(t *testing.T, helper *apis.K8sTestHelper) {
 		})
 
 		// Create the first user
-		user1, err := userClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("testdata/user-test-create-v0.yaml"), metav1.CreateOptions{})
+		user1, err := userClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("../testdata/user-test-create-v0.yaml"), metav1.CreateOptions{})
 		require.NoError(t, err)
 		require.NotNil(t, user1)
 
 		// Create the second user
-		user2, err := userClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("testdata/user-test-create-v1.yaml"), metav1.CreateOptions{})
+		user2, err := userClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("../testdata/user-test-create-v1.yaml"), metav1.CreateOptions{})
 		require.NoError(t, err)
 		require.NotNil(t, user2)
 
@@ -287,12 +287,12 @@ func doUserCRUDTestsUsingTheNewAPIs(t *testing.T, helper *apis.K8sTestHelper) {
 		})
 
 		// Create the first user
-		user1, err := userClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("testdata/user-test-create-v0.yaml"), metav1.CreateOptions{})
+		user1, err := userClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("../testdata/user-test-create-v0.yaml"), metav1.CreateOptions{})
 		require.NoError(t, err)
 		require.NotNil(t, user1)
 
 		// Create the second user
-		user2, err := userClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("testdata/user-test-create-v1.yaml"), metav1.CreateOptions{})
+		user2, err := userClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("../testdata/user-test-create-v1.yaml"), metav1.CreateOptions{})
 		require.NoError(t, err)
 		require.NotNil(t, user2)
 
@@ -392,7 +392,7 @@ func doHiddenUsersTests(t *testing.T, helper *apis.K8sTestHelper) {
 		})
 
 		// Create the user before marking it as hidden so BeforeCreate does not block it.
-		obj := helper.LoadYAMLOrJSONFile("testdata/user-test-create-v0.yaml")
+		obj := helper.LoadYAMLOrJSONFile("../testdata/user-test-create-v0.yaml")
 		spec := obj.Object["spec"].(map[string]interface{})
 		spec["login"] = hiddenLogin
 		spec["email"] = hiddenLogin + "@example.com"
@@ -460,7 +460,7 @@ func doHiddenUsersTests(t *testing.T, helper *apis.K8sTestHelper) {
 			delete(helper.GetEnv().Cfg.HiddenUsers, hiddenLogin)
 		})
 
-		obj := helper.LoadYAMLOrJSONFile("testdata/user-test-create-v0.yaml")
+		obj := helper.LoadYAMLOrJSONFile("../testdata/user-test-create-v0.yaml")
 		spec := obj.Object["spec"].(map[string]interface{})
 		spec["login"] = hiddenLogin
 		spec["email"] = hiddenLogin + "@example.com"
@@ -488,7 +488,7 @@ func doUserFieldSelectorTests(t *testing.T, helper *apis.K8sTestHelper) {
 		})
 
 		createUser := func(name string, email string, login string) {
-			obj := helper.LoadYAMLOrJSONFile("testdata/user-test-create-v0.yaml")
+			obj := helper.LoadYAMLOrJSONFile("../testdata/user-test-create-v0.yaml")
 			obj.SetName(name)
 
 			spec := obj.Object["spec"].(map[string]interface{})
@@ -551,7 +551,7 @@ func doUserStatusUpdateTests(t *testing.T, helper *apis.K8sTestHelper) {
 		})
 
 		// Create a user
-		created, err := userClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("testdata/user-test-create-v0.yaml"), metav1.CreateOptions{})
+		created, err := userClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("../testdata/user-test-create-v0.yaml"), metav1.CreateOptions{})
 		require.NoError(t, err)
 		require.NotNil(t, created)
 		createdUID := created.GetName()

--- a/pkg/tests/apis/iam/user/user_search_integration_test.go
+++ b/pkg/tests/apis/iam/user/user_search_integration_test.go
@@ -1,4 +1,4 @@
-package identity
+package user
 
 import (
 	"context"

--- a/pkg/tests/apis/iam/user/user_service_integration_test.go
+++ b/pkg/tests/apis/iam/user/user_service_integration_test.go
@@ -1,4 +1,4 @@
-package identity
+package user
 
 import (
 	"context"

--- a/pkg/tests/apis/iam/user/user_teams_search_integration_test.go
+++ b/pkg/tests/apis/iam/user/user_teams_search_integration_test.go
@@ -1,4 +1,4 @@
-package identity
+package user
 
 import (
 	"context"
@@ -88,12 +88,12 @@ func doUserTeamsTests(t *testing.T, helper *apis.K8sTestHelper) {
 	})
 
 	// Create u1 - will be bound to all 5 teams
-	u1, err := userClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("testdata/user-test-create-v0.yaml"), metav1.CreateOptions{})
+	u1, err := userClient.Resource.Create(ctx, helper.LoadYAMLOrJSONFile("../testdata/user-test-create-v0.yaml"), metav1.CreateOptions{})
 	require.NoError(t, err)
 	require.NotNil(t, u1)
 
 	// Create u2 - no bindings
-	u2Obj := helper.LoadYAMLOrJSONFile("testdata/user-test-create-v0.yaml")
+	u2Obj := helper.LoadYAMLOrJSONFile("../testdata/user-test-create-v0.yaml")
 	u2Obj.Object["metadata"].(map[string]any)["name"] = "user-no-binding"
 	u2Obj.Object["spec"].(map[string]any)["login"] = "user-no-binding"
 	u2Obj.Object["spec"].(map[string]any)["email"] = "user-no-binding@example.com"
@@ -223,7 +223,7 @@ func doUserTeamsTests(t *testing.T, helper *apis.K8sTestHelper) {
 }
 
 func createTeamObject(helper *apis.K8sTestHelper, teamName string, title string, email string) *unstructured.Unstructured {
-	teamObj := helper.LoadYAMLOrJSONFile("testdata/team-test-create-v0.yaml")
+	teamObj := helper.LoadYAMLOrJSONFile("../testdata/team-test-create-v0.yaml")
 	teamObj.Object["metadata"].(map[string]any)["name"] = teamName
 	teamObj.Object["spec"].(map[string]any)["title"] = title
 	teamObj.Object["spec"].(map[string]any)["email"] = email
@@ -266,6 +266,13 @@ func getUserTeamsWithPaging(t *testing.T, helper *apis.K8sTestHelper, userName s
 
 	require.Equal(t, http.StatusOK, rsp.Response.StatusCode)
 	return res
+}
+
+func createTeamBindingObject(helper *apis.K8sTestHelper, userName, teamName string) *unstructured.Unstructured {
+	obj := helper.LoadYAMLOrJSONFile("../testdata/teambinding-test-create-v0.yaml")
+	obj.Object["spec"].(map[string]interface{})["subject"].(map[string]interface{})["name"] = userName
+	obj.Object["spec"].(map[string]interface{})["teamRef"].(map[string]interface{})["name"] = teamName
+	return obj
 }
 
 func getUserTeamsWithOffset(t *testing.T, helper *apis.K8sTestHelper, userName string, offset, limit int) userTeamsResponse {

--- a/pkg/tests/apis/iam/user/user_test.go
+++ b/pkg/tests/apis/iam/user/user_test.go
@@ -1,0 +1,31 @@
+package user
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/grafana/grafana/pkg/tests/testsuite"
+)
+
+var gvrUsers = schema.GroupVersionResource{
+	Group:    "iam.grafana.app",
+	Version:  "v0alpha1",
+	Resource: "users",
+}
+
+var gvrTeams = schema.GroupVersionResource{
+	Group:    "iam.grafana.app",
+	Version:  "v0alpha1",
+	Resource: "teams",
+}
+
+var gvrTeamBindings = schema.GroupVersionResource{
+	Group:    "iam.grafana.app",
+	Version:  "v0alpha1",
+	Resource: "teambindings",
+}
+
+func TestMain(m *testing.M) {
+	testsuite.Run(m)
+}


### PR DESCRIPTION
## Summary
- Split IAM integration tests from 1 Go package into 6 sub-packages (`team/`, `teambinding/`, `user/`, `serviceaccount/`, `resourcepermission/`, plus root)
- CI sharding distributes packages across runners — this change enables parallel execution of IAM tests that previously all ran on a single shard
- Follows the same pattern used by provisioning tests (`pkg/tests/apis/provisioning/`)

## Details
- Each sub-package has its own `TestMain` calling `testsuite.Run(m)`
- GVR variables are duplicated where needed (small constants, avoids shared package coupling)
- Testdata stays centralized in `iam/testdata/`, referenced via `../testdata/`
- Helper functions (`createTeamObject`, `createTeamBindingObject`) duplicated in packages that need them since `_test.go` functions can't be exported

## Test plan
- [ ] CI integration tests pass across all 6 packages
- [ ] Shard distribution includes the new packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)