### PR TITLE
Docs: Updates to Git Sync limits

### DIFF
--- a/docs/sources/as-code/observability-as-code/git-sync/usage-limits.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/usage-limits.md
@@ -45,11 +45,11 @@ The following Git Sync per-tier limits apply:
 
 | Tier                                      | **Cloud - Free** | **Cloud - Other** | **On-prem OSS** | **On-prem Enterprise** |
 | ----------------------------------------- | ---------------- | ----------------- | --------------- | ---------------------- |
-| Amount of repositories                    | 1                | 10                | 10              | 10                     |
-| Amount of synced resources per repository | 20               | Grafana limit (1) | No limit (2)    | No limit (2)           |
+| Amount of repositories                    | 1                | 10 (1)            | 10 (2)          | 10 (2)                 |
+| Amount of synced resources per repository | 20               | Grafana limit     | No limit        | No limit               |
 
-- (1) If you're a Cloud user, contact Support to modify your limits.
-- (2) If you're an on-prem user, you can customize your limit using the `max_repositories` configuration setting. Refer to [`max_repositories`](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#max_repositories) in the Configure Grafana section to learn more.
+- (1) If you're a Cloud user, contact Support to modify the amount of repostories you can sync.
+- (2) If you're an on-prem user, you can customize the amount of repostories you can sync using the `max_repositories` configuration setting. Refer to [`max_repositories`](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#max_repositories) in the Configure Grafana section to learn more.
 
 ## Compatible Git providers
 

--- a/docs/sources/as-code/observability-as-code/git-sync/usage-limits.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/usage-limits.md
@@ -45,11 +45,19 @@ The following Git Sync per-tier limits apply:
 
 | Tier                                      | **Cloud - Free** | **Cloud - Other** | **On-prem OSS** | **On-prem Enterprise** |
 | ----------------------------------------- | ---------------- | ----------------- | --------------- | ---------------------- |
-| Amount of repositories                    | 1                | 10 (1)            | 10 (2)          | 10 (2)                 |
-| Amount of synced resources per repository | 20               | Grafana limit     | No limit        | No limit               |
+| Amount of repositories                    | 1                | 10                | 10              | 10                     |
+| Amount of synced resources per repository | 20               | 1,000             | No limit        | No limit               |
 
-- (1) If you're a Cloud user, contact Support to modify the amount of repostories you can sync.
-- (2) If you're an on-prem user, you can customize the amount of repostories you can sync using the `max_repositories` configuration setting. Refer to [`max_repositories`](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#max_repositories) in the Configure Grafana section to learn more.
+### Modify your usage limits
+
+Before changing your usage limits, study your specific use case. Define the governance you'd like to set when you design the repository structure and how many repositories and how many resources you can support. For example, setting over 1,000 resources per repository may impact your system's performance.
+
+If you're a Cloud user, contact Support to modify the amount of repositories you can sync.
+
+If you're an on-prem user, you can customize your limits via configuration settings:
+
+- Use `max_repositories` to set the amount of repositories you can sync. Refer to [`max_repositories`](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#max_repositories) in the Configure Grafana section to learn more.
+- Use `max_resources_per_repository` to set the amount of resources per repository to sync. Refer to [`max_resources_per_repository`](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#max_resources_per_repository) in the Configure Grafana section to learn more.
 
 ## Compatible Git providers
 

--- a/docs/sources/as-code/observability-as-code/git-sync/usage-limits.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/usage-limits.md
@@ -46,7 +46,10 @@ The following Git Sync per-tier limits apply:
 | Tier                                      | **Cloud - Free** | **Cloud - Other** | **On-prem OSS** | **On-prem Enterprise** |
 | ----------------------------------------- | ---------------- | ----------------- | --------------- | ---------------------- |
 | Amount of repositories                    | 1                | 10                | 10              | 10                     |
-| Amount of synced resources per repository | 20               | 1,000             | 1,000           | 1,000                  |
+| Amount of synced resources per repository | 20               | Grafana limit (1) | No limit (2)    | No limit (2)           |
+
+- (1) If you're a Cloud user, contact Support to modify your limits.
+- (2) If you're an on-prem user, you can customize your limit using the `max_repositories` configuration setting. Refer to [`max_repositories`](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#max_repositories) in the Configure Grafana section to learn more.
 
 ## Compatible Git providers
 


### PR DESCRIPTION
As requested via Slack.
Replaces https://github.com/grafana/grafana/pull/123400.

Preview - https://deploy-preview-grafana-123460-zb444pucvq-vp.a.run.app/docs/grafana/latest/as-code/observability-as-code/git-sync/usage-limits/