### PR TITLE
Stars: Fix silent data loss from colliding synthetic dashboard_id values

### DIFF
--- a/pkg/services/star/starimpl/xorm_store.go
+++ b/pkg/services/star/starimpl/xorm_store.go
@@ -2,12 +2,21 @@ package starimpl
 
 import (
 	"context"
-	"math/rand"
+	"sync/atomic"
 	"time"
 
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/services/star"
 )
+
+// dashboardIDCounter provides a monotonic per-process offset used to generate
+// a synthetic unique dashboard_id value for new star rows. The dashboard_id
+// column is no longer used by the star service, but the legacy
+// UNIQUE (user_id, dashboard_id) index is still present (see star_mig.go).
+// Combining time.Now().UnixMicro() with an atomic counter guarantees uniqueness
+// for every Insert within a process, avoiding silent unique-constraint
+// violations when Add() is called in quick succession.
+var dashboardIDCounter atomic.Int64
 
 type sqlStore struct {
 	db db.DB
@@ -33,7 +42,12 @@ func (s *sqlStore) Insert(ctx context.Context, cmd *star.StarDashboardCommand) e
 	return s.db.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
 		// nolint:staticcheck
 		if cmd.DashboardID == 0 {
-			cmd.DashboardID = time.Now().UnixMicro() + rand.Int63n(5000) // random unique value
+			// Use UnixMicro plus a monotonic counter so the generated value is
+			// guaranteed unique within this process, even for calls that happen
+			// in the same microsecond. This avoids hitting the legacy
+			// UNIQUE (user_id, dashboard_id) index, which would otherwise be
+			// silently swallowed by Add() and cause data loss.
+			cmd.DashboardID = time.Now().UnixMicro() + dashboardIDCounter.Add(1)
 		}
 
 		entity := star.Star{

--- a/pkg/storage/unified/migrations/testcases/stars.go
+++ b/pkg/storage/unified/migrations/testcases/stars.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -80,15 +79,12 @@ func (tc *starsTestCase) Setup(t *testing.T, helper *apis.K8sTestHelper) bool {
 		})
 		require.NoError(t, err)
 
-		// Use Eventually to handle potential read-your-own-writes delay with connection pooling.
-		// Each Add uses its own transaction, and GetByUser may run on a different connection
-		// that doesn't immediately see the committed data.
-		require.Eventually(t, func() bool {
-			res, err := stars.GetByUser(context.Background(), &star.GetUserStarsQuery{
-				UserID: userID,
-			})
-			return err == nil && res != nil && len(res.UserStars) == 2
-		}, 5*time.Second, 100*time.Millisecond, "expected 2 stars for user %d", userID)
+		res, err := stars.GetByUser(context.Background(), &star.GetUserStarsQuery{
+			UserID: userID,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, res)
+		require.Len(t, res.UserStars, 2)
 	}
 
 	return true // will exist in mode0


### PR DESCRIPTION
## What this does

Replaces the `time.Now().UnixMicro() + rand.Int63n(5000)` synthetic `dashboard_id` generator in `starimpl.Insert` with `time.Now().UnixMicro() + atomic counter`, guaranteeing uniqueness within a process.

Also reverts the `require.Eventually` workaround from #123383 — with the real bug fixed, the test can go back to its original synchronous assertion.

## Why

The `star` table has two unique indexes:

1. `UNIQUE (user_id, dashboard_id)` — legacy, kept for rollback (see `star_mig.go`)
2. `UNIQUE (user_id, dashboard_uid, org_id)` — current

When the caller doesn't supply a `DashboardID`, `Insert` synthesizes one. The old formula `UnixMicro() + rand.Int63n(5000)` is not actually unique: two back-to-back `Add` calls for the same user can produce the same value (~0.01% per pair at realistic timings).

When that happens:
- The second `INSERT` violates the `(user_id, dashboard_id)` unique index.
- `starService.Add` silently swallows all unique-constraint violations (by design, to make re-starring idempotent).
- The second row is silently dropped. No error is returned anywhere, `require.NoError` is happy, but the star is gone.

This was the actual cause of the intermittent `TestIntegrationEnterpriseMigrations/…/stars` failures (e.g. [run 24824149235](https://github.com/grafana/grafana/actions/runs/24824149235/job/72658095916)): `"map[dash-1:true]" should have 2 item(s), but has 1`.

`require.Eventually` (#123383) doesn't actually fix this — when the collision hits, the row is never inserted, so retrying the `SELECT` just times out. That PR passed CI because the collision is rare, not because retrying helps.

## Follow-up

A follow-up issue will propose dropping the legacy `UNIQUE (user_id, dashboard_id)` index entirely, since `dashboard_id` is no longer used. Larger change, out of scope here.

## Which issue(s) this PR fixes

Fixes the flake in [actions/runs/24824149235](https://github.com/grafana/grafana/actions/runs/24824149235/job/72658095916) and supersedes #123383.
