### PR TITLE
add some tracing to request flow for dataosurce api servers

### DIFF
--- a/pkg/registry/apis/datasource/register.go
+++ b/pkg/registry/apis/datasource/register.go
@@ -10,6 +10,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	openapi "k8s.io/kube-openapi/pkg/common"
@@ -336,6 +337,7 @@ func (b *DataSourceAPIBuilder) applyDefaultStorageConfig(opts builder.APIGroupOp
 
 func (b *DataSourceAPIBuilder) getPluginContext(ctx context.Context, uid string) (backend.PluginContext, error) {
 	ctx, span := tracing.Start(ctx, "datasource.getPluginContext",
+		attribute.String("namespace", request.NamespaceValue(ctx)),
 		attribute.String("plugin_id", b.pluginJSON.ID),
 		attribute.String("datasource_uid", uid),
 	)

--- a/pkg/registry/apis/datasource/register.go
+++ b/pkg/registry/apis/datasource/register.go
@@ -31,7 +31,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/unified/apistore"
-	"github.com/grafana/grafana/pkg/tsdb/grafana-testdata-datasource/kinds"
 	"go.opentelemetry.io/otel/attribute"
 )
 

--- a/pkg/registry/apis/datasource/register.go
+++ b/pkg/registry/apis/datasource/register.go
@@ -21,6 +21,7 @@ import (
 	grafanaregistry "github.com/grafana/grafana/pkg/apiserver/registry/generic"
 	"github.com/grafana/grafana/pkg/infra/metrics"
 	"github.com/grafana/grafana/pkg/infra/metrics/metricutil"
+	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/plugins/manager/sources"
 	pluginspec "github.com/grafana/grafana/pkg/plugins/openapi"
@@ -30,6 +31,8 @@ import (
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/unified/apistore"
+	"github.com/grafana/grafana/pkg/tsdb/grafana-testdata-datasource/kinds"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 var (
@@ -333,11 +336,28 @@ func (b *DataSourceAPIBuilder) applyDefaultStorageConfig(opts builder.APIGroupOp
 }
 
 func (b *DataSourceAPIBuilder) getPluginContext(ctx context.Context, uid string) (backend.PluginContext, error) {
-	instance, err := b.datasources.GetInstanceSettings(ctx, uid)
+	ctx, span := tracing.Start(ctx, "datasource.getPluginContext",
+		attribute.String("plugin_id", b.pluginJSON.ID),
+		attribute.String("datasource_uid", uid),
+	)
+	defer span.End()
+
+	getInstanceCtx, getInstanceSpan := tracing.Start(ctx, "datasource.getPluginContext.getInstanceSettings")
+	instance, err := b.datasources.GetInstanceSettings(getInstanceCtx, uid)
+	getInstanceSpan.End()
 	if err != nil {
+		err = tracing.Error(span, err)
 		return backend.PluginContext{}, err
 	}
-	return b.contextProvider.PluginContextForDataSource(ctx, instance)
+
+	buildContextCtx, buildContextSpan := tracing.Start(ctx, "datasource.getPluginContext.buildPluginContext")
+	pluginCtx, err := b.contextProvider.PluginContextForDataSource(buildContextCtx, instance)
+	buildContextSpan.End()
+	if err != nil {
+		err = tracing.Error(span, err)
+		return backend.PluginContext{}, err
+	}
+	return pluginCtx, nil
 }
 
 func (b *DataSourceAPIBuilder) GetOpenAPIDefinitions() openapi.GetOpenAPIDefinitions {

--- a/pkg/registry/apis/datasource/sub_health.go
+++ b/pkg/registry/apis/datasource/sub_health.go
@@ -12,7 +12,9 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/config"
 	datasource "github.com/grafana/grafana/pkg/apis/datasource/v0alpha1"
+	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/datasources"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 type subHealthREST struct {
@@ -48,10 +50,17 @@ func (r *subHealthREST) NewConnectOptions() (runtime.Object, bool, string) {
 }
 
 func (r *subHealthREST) Connect(ctx context.Context, name string, opts runtime.Object, responder rest.Responder) (http.Handler, error) {
+	ctx, connectSpan := tracing.Start(ctx, "datasource.health.connect",
+		attribute.String("plugin_id", r.builder.pluginJSON.ID),
+		attribute.String("datasource_uid", name),
+	)
+	defer connectSpan.End()
+
 	m := newConnectMetric("health", r.builder.pluginJSON.ID)
 
 	pluginCtx, err := r.builder.getPluginContext(ctx, name)
 	if err != nil {
+		err = tracing.Error(connectSpan, err)
 		if errors.Is(err, datasources.ErrDataSourceNotFound) {
 			m.SetNotFound()
 			m.Record()
@@ -64,10 +73,13 @@ func (r *subHealthREST) Connect(ctx context.Context, name string, opts runtime.O
 	ctx = config.WithGrafanaConfig(ctx, pluginCtx.GrafanaConfig)
 	ctx = contextualMiddlewares(ctx)
 
-	healthResponse, err := r.builder.client.CheckHealth(ctx, &backend.CheckHealthRequest{
+	checkHealthCtx, checkHealthSpan := tracing.Start(ctx, "datasource.health.pluginClient.CheckHealth")
+	healthResponse, err := r.builder.client.CheckHealth(checkHealthCtx, &backend.CheckHealthRequest{
 		PluginContext: pluginCtx,
 	})
+	checkHealthSpan.End()
 	if err != nil {
+		err = tracing.Error(connectSpan, err)
 		m.SetError()
 		m.Record()
 		return nil, err
@@ -76,14 +88,21 @@ func (r *subHealthREST) Connect(ctx context.Context, name string, opts runtime.O
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		defer m.Record()
 
+		_, reqSpan := tracing.Start(req.Context(), "datasource.health.request",
+			attribute.String("plugin_id", r.builder.pluginJSON.ID),
+			attribute.String("datasource_uid", name),
+		)
+		defer reqSpan.End()
+
 		rsp := &datasource.HealthCheckResult{}
 		rsp.Code = int(healthResponse.Status)
 		rsp.Status = healthResponse.Status.String()
 		rsp.Message = healthResponse.Message
 
 		if len(healthResponse.JSONDetails) > 0 {
-			err = json.Unmarshal(healthResponse.JSONDetails, &rsp.Details)
+			err := json.Unmarshal(healthResponse.JSONDetails, &rsp.Details)
 			if err != nil {
+				_ = tracing.Error(reqSpan, err)
 				m.SetError()
 				responder.Error(err)
 				return

--- a/pkg/registry/apis/datasource/sub_health.go
+++ b/pkg/registry/apis/datasource/sub_health.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -50,7 +51,9 @@ func (r *subHealthREST) NewConnectOptions() (runtime.Object, bool, string) {
 }
 
 func (r *subHealthREST) Connect(ctx context.Context, name string, opts runtime.Object, responder rest.Responder) (http.Handler, error) {
+	namespace := request.NamespaceValue(ctx)
 	ctx, connectSpan := tracing.Start(ctx, "datasource.health.connect",
+		attribute.String("namespace", namespace),
 		attribute.String("plugin_id", r.builder.pluginJSON.ID),
 		attribute.String("datasource_uid", name),
 	)
@@ -89,6 +92,7 @@ func (r *subHealthREST) Connect(ctx context.Context, name string, opts runtime.O
 		defer m.Record()
 
 		_, reqSpan := tracing.Start(req.Context(), "datasource.health.request",
+			attribute.String("namespace", namespace),
 			attribute.String("plugin_id", r.builder.pluginJSON.ID),
 			attribute.String("datasource_uid", name),
 		)

--- a/pkg/registry/apis/datasource/sub_query.go
+++ b/pkg/registry/apis/datasource/sub_query.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -59,7 +60,9 @@ func (r *subQueryREST) NewConnectOptions() (runtime.Object, bool, string) {
 }
 
 func (r *subQueryREST) Connect(ctx context.Context, name string, opts runtime.Object, responder rest.Responder) (http.Handler, error) {
+	namespace := request.NamespaceValue(ctx)
 	ctx, connectSpan := tracing.Start(ctx, "datasource.query.connect",
+		attribute.String("namespace", namespace),
 		attribute.String("plugin_id", r.builder.pluginJSON.ID),
 		attribute.String("datasource_uid", name),
 	)
@@ -84,6 +87,7 @@ func (r *subQueryREST) Connect(ctx context.Context, name string, opts runtime.Ob
 		defer m.Record()
 
 		reqCtx, reqSpan := tracing.Start(ctx, "datasource.query.request",
+			attribute.String("namespace", namespace),
 			attribute.String("plugin_id", r.builder.pluginJSON.ID),
 			attribute.String("datasource_uid", name),
 		)

--- a/pkg/registry/apis/datasource/sub_query.go
+++ b/pkg/registry/apis/datasource/sub_query.go
@@ -14,8 +14,10 @@ import (
 	data "github.com/grafana/grafana-plugin-sdk-go/experimental/apis/datasource/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	dsV0 "github.com/grafana/grafana/pkg/apis/datasource/v0alpha1"
+	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/web"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 type subQueryREST struct {
@@ -57,10 +59,17 @@ func (r *subQueryREST) NewConnectOptions() (runtime.Object, bool, string) {
 }
 
 func (r *subQueryREST) Connect(ctx context.Context, name string, opts runtime.Object, responder rest.Responder) (http.Handler, error) {
+	ctx, connectSpan := tracing.Start(ctx, "datasource.query.connect",
+		attribute.String("plugin_id", r.builder.pluginJSON.ID),
+		attribute.String("datasource_uid", name),
+	)
+	defer connectSpan.End()
+
 	m := newConnectMetric("query", r.builder.pluginJSON.ID)
 
 	pluginCtx, err := r.builder.getPluginContext(ctx, name)
 	if err != nil {
+		err = tracing.Error(connectSpan, err)
 		if errors.Is(err, datasources.ErrDataSourceNotFound) {
 			m.SetNotFound()
 			m.Record()
@@ -74,38 +83,57 @@ func (r *subQueryREST) Connect(ctx context.Context, name string, opts runtime.Ob
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		defer m.Record()
 
+		reqCtx, reqSpan := tracing.Start(req.Context(), "datasource.query.request",
+			attribute.String("plugin_id", r.builder.pluginJSON.ID),
+			attribute.String("datasource_uid", name),
+		)
+		defer reqSpan.End()
+
 		dqr := data.QueryDataRequest{}
+		_, bindSpan := tracing.Start(reqCtx, "datasource.query.bindRequest")
 		err := web.Bind(req, &dqr)
+		bindSpan.End()
 		if err != nil {
+			_ = tracing.Error(reqSpan, err)
 			m.SetError()
 			responder.Error(err)
 			return
 		}
 
+		_, convertSpan := tracing.Start(reqCtx, "datasource.query.convertQueries")
 		queries, dsRef, err := data.ToDataSourceQueries(dqr)
+		convertSpan.End()
 		if err != nil {
+			_ = tracing.Error(reqSpan, err)
 			m.SetError()
 			responder.Error(err)
 			return
 		}
 		if dsRef != nil && dsRef.UID != name {
+			err := fmt.Errorf("expected query body datasource and request to match")
+			_ = tracing.Error(reqSpan, err)
 			m.SetError()
-			responder.Error(fmt.Errorf("expected query body datasource and request to match"))
+			responder.Error(err)
 			return
 		}
 
-		ctx = config.WithGrafanaConfig(ctx, pluginCtx.GrafanaConfig)
-		ctx = contextualMiddlewares(ctx)
+		callCtx := config.WithGrafanaConfig(reqCtx, pluginCtx.GrafanaConfig)
+		callCtx = contextualMiddlewares(callCtx)
 
-		rsp, err := r.builder.client.QueryData(ctx, &backend.QueryDataRequest{
+		queryCtx, querySpan := tracing.Start(callCtx, "datasource.query.pluginClient.QueryData",
+			attribute.Int("queries_count", len(queries)),
+		)
+		rsp, err := r.builder.client.QueryData(queryCtx, &backend.QueryDataRequest{
 			Queries:       queries,
 			PluginContext: pluginCtx,
 			Headers:       map[string]string{},
 		})
+		querySpan.End()
 
 		// all errors get converted into k8s errors when sent in responder.Error and lose important context like downstream info
 		var e errutil.Error
 		if errors.As(err, &e) && e.Source == errutil.SourceDownstream {
+			_ = tracing.Error(reqSpan, err)
 			m.SetError()
 			responder.Object(int(backend.StatusBadRequest),
 				&dsV0.QueryDataResponse{QueryDataResponse: backend.QueryDataResponse{Responses: map[string]backend.DataResponse{
@@ -120,6 +148,7 @@ func (r *subQueryREST) Connect(ctx context.Context, name string, opts runtime.Ob
 		}
 
 		if err != nil {
+			_ = tracing.Error(reqSpan, err)
 			m.SetError()
 			responder.Error(err)
 			return

--- a/pkg/registry/apis/datasource/sub_query.go
+++ b/pkg/registry/apis/datasource/sub_query.go
@@ -83,7 +83,7 @@ func (r *subQueryREST) Connect(ctx context.Context, name string, opts runtime.Ob
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		defer m.Record()
 
-		reqCtx, reqSpan := tracing.Start(req.Context(), "datasource.query.request",
+		reqCtx, reqSpan := tracing.Start(ctx, "datasource.query.request",
 			attribute.String("plugin_id", r.builder.pluginJSON.ID),
 			attribute.String("datasource_uid", name),
 		)

--- a/pkg/registry/apis/datasource/sub_resource.go
+++ b/pkg/registry/apis/datasource/sub_resource.go
@@ -15,8 +15,10 @@ import (
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/config"
+	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/plugins/httpresponsesender"
 	"github.com/grafana/grafana/pkg/services/datasources"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 type subResourceREST struct {
@@ -50,10 +52,17 @@ func (r *subResourceREST) NewConnectOptions() (runtime.Object, bool, string) {
 }
 
 func (r *subResourceREST) Connect(ctx context.Context, name string, opts runtime.Object, responder rest.Responder) (http.Handler, error) {
+	ctx, connectSpan := tracing.Start(ctx, "datasource.resource.connect",
+		attribute.String("plugin_id", r.builder.pluginJSON.ID),
+		attribute.String("datasource_uid", name),
+	)
+	defer connectSpan.End()
+
 	m := newConnectMetric("resource", r.builder.pluginJSON.ID)
 
 	pluginCtx, err := r.builder.getPluginContext(ctx, name)
 	if err != nil {
+		err = tracing.Error(connectSpan, err)
 		backend.Logger.Error("failed to get plugin context for datasource in resource handler", "name", name, "error", err)
 		if errors.Is(err, datasources.ErrDataSourceNotFound) {
 			m.SetNotFound()
@@ -65,29 +74,45 @@ func (r *subResourceREST) Connect(ctx context.Context, name string, opts runtime
 		return nil, err
 	}
 
-	ctx = config.WithGrafanaConfig(ctx, pluginCtx.GrafanaConfig)
-	ctx = contextualMiddlewares(ctx)
-
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		defer m.Record()
 
+		reqCtx, reqSpan := tracing.Start(req.Context(), "datasource.resource.request",
+			attribute.String("plugin_id", r.builder.pluginJSON.ID),
+			attribute.String("datasource_uid", name),
+			attribute.String("http_method", req.Method),
+		)
+		defer reqSpan.End()
+
+		callCtx := config.WithGrafanaConfig(reqCtx, pluginCtx.GrafanaConfig)
+		callCtx = contextualMiddlewares(callCtx)
+
+		_, cloneSpan := tracing.Start(reqCtx, "datasource.resource.normalizeRequest")
 		clonedReq, err := resourceRequest(req)
+		cloneSpan.End()
 		if err != nil {
+			_ = tracing.Error(reqSpan, err)
 			backend.Logger.Error("failed to create resource request", "error", err)
 			m.SetError()
 			responder.Error(err)
 			return
 		}
 
+		_, readBodySpan := tracing.Start(reqCtx, "datasource.resource.readRequestBody")
 		body, err := io.ReadAll(req.Body)
+		readBodySpan.End()
 		if err != nil {
+			_ = tracing.Error(reqSpan, err)
 			backend.Logger.Error("failed to read request body", "error", err)
 			m.SetError()
 			responder.Error(err)
 			return
 		}
 
-		err = r.builder.client.CallResource(ctx, &backend.CallResourceRequest{
+		resourceCtx, resourceSpan := tracing.Start(callCtx, "datasource.resource.pluginClient.CallResource",
+			attribute.String("plugin_resource_path", clonedReq.URL.Path),
+		)
+		err = r.builder.client.CallResource(resourceCtx, &backend.CallResourceRequest{
 			PluginContext: pluginCtx,
 			Path:          clonedReq.URL.Path,
 			Method:        req.Method,
@@ -95,8 +120,10 @@ func (r *subResourceREST) Connect(ctx context.Context, name string, opts runtime
 			Body:          body,
 			Headers:       req.Header,
 		}, httpresponsesender.New(w))
+		resourceSpan.End()
 
 		if err != nil {
+			_ = tracing.Error(reqSpan, err)
 			backend.Logger.Error("plugin resource request failed", "error", err)
 			m.SetError()
 			responder.Error(err)

--- a/pkg/registry/apis/datasource/sub_resource.go
+++ b/pkg/registry/apis/datasource/sub_resource.go
@@ -11,6 +11,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -52,7 +53,9 @@ func (r *subResourceREST) NewConnectOptions() (runtime.Object, bool, string) {
 }
 
 func (r *subResourceREST) Connect(ctx context.Context, name string, opts runtime.Object, responder rest.Responder) (http.Handler, error) {
+	namespace := request.NamespaceValue(ctx)
 	ctx, connectSpan := tracing.Start(ctx, "datasource.resource.connect",
+		attribute.String("namespace", namespace),
 		attribute.String("plugin_id", r.builder.pluginJSON.ID),
 		attribute.String("datasource_uid", name),
 	)
@@ -78,6 +81,7 @@ func (r *subResourceREST) Connect(ctx context.Context, name string, opts runtime
 		defer m.Record()
 
 		reqCtx, reqSpan := tracing.Start(ctx, "datasource.resource.request",
+			attribute.String("namespace", namespace),
 			attribute.String("plugin_id", r.builder.pluginJSON.ID),
 			attribute.String("datasource_uid", name),
 			attribute.String("http_method", req.Method),

--- a/pkg/registry/apis/datasource/sub_resource.go
+++ b/pkg/registry/apis/datasource/sub_resource.go
@@ -77,7 +77,7 @@ func (r *subResourceREST) Connect(ctx context.Context, name string, opts runtime
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		defer m.Record()
 
-		reqCtx, reqSpan := tracing.Start(req.Context(), "datasource.resource.request",
+		reqCtx, reqSpan := tracing.Start(ctx, "datasource.resource.request",
 			attribute.String("plugin_id", r.builder.pluginJSON.ID),
 			attribute.String("datasource_uid", name),
 			attribute.String("http_method", req.Method),


### PR DESCRIPTION
We are losing alot of details on investigating timeouts around the new http endpoints for datasources. This PR introduces some instrumentation to tempo so we can potentially investigate when we have issues on the new http endpoints [for example](https://raintank-corp.slack.com/archives/C06TNNEKAHL/p1776971828141489)