### PR TITLE
Storage: Fix flaky SQL/KV compatibility tests on SQLite

### DIFF
--- a/pkg/storage/unified/testing/storage_backend_sql_compatibility.go
+++ b/pkg/storage/unified/testing/storage_backend_sql_compatibility.go
@@ -122,13 +122,13 @@ func newIntegrationTestContext(t *testing.T) context.Context {
 func runTestIntegrationBackendKeyPathGeneration(t *testing.T, sqlBackend, kvBackend resource.StorageBackend, nsPrefix string, db sqldb.DB) {
 	// Test SQL backend with 3 writes, 3 updates, 3 deletes
 	t.Run("SQL Backend Operations", func(t *testing.T) {
-		ctx := testutil.NewDefaultTestContext(t)
+		ctx := newIntegrationTestContext(t)
 		runKeyPathTest(t, sqlBackend, nsPrefix+"-sql", db, ctx)
 	})
 
 	// Test SQL KV backend with 3 writes, 3 updates, 3 deletes
 	t.Run("SQL KV Backend Operations", func(t *testing.T) {
-		ctx := testutil.NewDefaultTestContext(t)
+		ctx := newIntegrationTestContext(t)
 		runKeyPathTest(t, kvBackend, nsPrefix+"-kv", db, ctx)
 	})
 }
@@ -295,13 +295,13 @@ func runTestSQLBackendFieldsCompatibility(t *testing.T, sqlBackend, kvBackend re
 
 	// Test SQL backend with 3 resources through complete lifecycle
 	t.Run("SQL Backend Operations", func(t *testing.T) {
-		ctx := testutil.NewDefaultTestContext(t)
+		ctx := newIntegrationTestContext(t)
 		runSQLBackendFieldsTest(t, sqlBackend, namespace+"-sql", db, ctx)
 	})
 
 	// Test KV backend with 3 resources through complete lifecycle
 	t.Run("KV Backend Operations", func(t *testing.T) {
-		ctx := testutil.NewDefaultTestContext(t)
+		ctx := newIntegrationTestContext(t)
 		runSQLBackendFieldsTest(t, kvBackend, namespace+"-kv", db, ctx)
 	})
 }


### PR DESCRIPTION
**What is this feature?**

Fixes a flaky subtest in `TestIntegrationSQLStorageAndSQLKVCompatibilityTests` by widening the per-subtest context deadline on the two heavy-workload subtest pairs (`sql_backend_fields_compatibility` and `key_path_generation`) from the 1s `testutil.NewDefaultTestContext` to the 30s `newIntegrationTestContext` already used by the other heavy tests in the same file.

**Why do we need this feature?**

[Run 24872553687](https://github.com/grafana/grafana/actions/runs/24872553687/job/72821922002) failed with `failed to write data: context deadline exceeded` after the KV subtest ran exactly 1.00s. Each subtest performs 3 creates + 3 updates + 2 deletes through the RV manager, SQLite writer, and channel notifier — too much work to reliably finish inside 1s on a loaded CI runner. The flake was latent since #121811 split the shared parent context into per-subtest contexts without widening the budget.

**Who is this feature for?**

Grafana contributors — reduces CI noise for the unified-storage suite.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Verified locally on SQLite:
- 10× loop of `sql_backend_fields_compatibility` subtests → all pass
- 10× loop of `key_path_generation` subtests → all pass
- Full `TestIntegrationSQLStorageAndSQLKVCompatibilityTests` suite → pass