### PR TITLE
BugFix: RandomWalk multi-query key collision

### DIFF
--- a/public/app/plugins/datasource/grafana/datasource.test.ts
+++ b/public/app/plugins/datasource/grafana/datasource.test.ts
@@ -1,8 +1,13 @@
-import { type AnnotationQueryRequest, type DataSourceInstanceSettings, dateTime } from '@grafana/data';
+import {
+  type AnnotationQueryRequest,
+  type DataQueryRequest,
+  type DataSourceInstanceSettings,
+  dateTime,
+} from '@grafana/data';
 import { backendSrv } from 'app/core/services/backend_srv'; // will use the version in __mocks__
 
 import { GrafanaDatasource } from './datasource';
-import { type GrafanaAnnotationQuery, GrafanaAnnotationType, type GrafanaQuery } from './types';
+import { type GrafanaAnnotationQuery, GrafanaAnnotationType, type GrafanaQuery, GrafanaQueryType } from './types';
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
@@ -13,6 +18,45 @@ jest.mock('@grafana/runtime', () => ({
     },
   }),
 }));
+
+describe('RandomWalk query', () => {
+  it('each query emits a response with a distinct key matching its refId', (done) => {
+    const ds = new GrafanaDatasource({} as DataSourceInstanceSettings);
+    const request = {
+      targets: [
+        { refId: 'A', queryType: GrafanaQueryType.RandomWalk },
+        { refId: 'B', queryType: GrafanaQueryType.RandomWalk },
+      ],
+      range: {
+        from: dateTime('2024-01-01T00:00:00Z'),
+        to: dateTime('2024-01-01T01:00:00Z'),
+        raw: { from: 'now-1h', to: 'now' },
+      },
+      intervalMs: 60000,
+      maxDataPoints: 60,
+      requestId: 'test',
+      interval: '1m',
+      scopedVars: {},
+      timezone: 'browser',
+      app: 'dashboard',
+      startTime: 0,
+    } as unknown as DataQueryRequest<GrafanaQuery>;
+
+    const keys: string[] = [];
+    ds.query(request).subscribe({
+      next: (response) => {
+        expect(response.key).toBeDefined();
+        keys.push(response.key!);
+      },
+      complete: () => {
+        expect(keys).toHaveLength(2);
+        expect(keys).toContain('A');
+        expect(keys).toContain('B');
+        done();
+      },
+    });
+  });
+});
 
 describe('grafana data source', () => {
   const getMock = jest.spyOn(backendSrv, 'get');

--- a/public/app/plugins/datasource/grafana/datasource.ts
+++ b/public/app/plugins/datasource/grafana/datasource.ts
@@ -146,6 +146,7 @@ export class GrafanaDatasource extends DataSourceWithBackend<GrafanaQuery> {
       } else if (target.queryType === GrafanaQueryType.RandomWalk || !target.queryType) {
         results.push(
           of({
+            key: target.refId,
             data: randomWalk(target, request),
             state: LoadingState.Done,
           })

--- a/public/app/plugins/datasource/grafana/randomWalk.test.ts
+++ b/public/app/plugins/datasource/grafana/randomWalk.test.ts
@@ -52,6 +52,7 @@ describe('randomWalk', () => {
     expect(frame.fields[1].name).toBe('A-series');
     expect(frame.fields[1].type).toBe(FieldType.number);
     expect(frame.meta?.type).toBe(DataFrameType.TimeSeriesMulti);
+    expect(frame.refId).toBe('A');
     expect(frame.length).toBe(frame.fields[0].values.length);
   });
 

--- a/public/app/plugins/datasource/grafana/randomWalk.ts
+++ b/public/app/plugins/datasource/grafana/randomWalk.ts
@@ -66,6 +66,7 @@ export function randomWalk(query: GrafanaQuery, request: DataQueryRequest<Grafan
         { name: seriesName, type: FieldType.number, values: floatValues, config: {} },
       ],
       length: timeValues.length,
+      refId: query.refId,
       meta: { type: DataFrameType.TimeSeriesMulti },
     });
   }


### PR DESCRIPTION
**What is this feature?**

Fix a bug where using the -- Grafana -- datasource with multiple RandomWalk queries only displayed the last query's data.

**Why do we need this feature?**

When multiple RandomWalk queries run concurrently via `merge()`, each emits a separate response packet. `processResponsePacket` in `runRequest.ts` keys packets by `packet.key ?? packet.data?.[0]?.refId ?? 'A'`. Since `randomWalk.ts` never set `refId` on frames and `datasource.ts` never set `key` on packets, all queries collapsed to key `'A'` and overwrote each other.

**Who is this feature for?**

Users of the -- Grafana -- datasource with multiple RandomWalk queries on the same panel.

**Which issue(s) does this PR fix?**:

Fixes #123388

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.