### PR TITLE
Provisioning: retry finalizer ops on RV conflict

### DIFF
--- a/pkg/registry/apis/provisioning/controller/finalizers.go
+++ b/pkg/registry/apis/provisioning/controller/finalizers.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/util/retry"
 
 	"github.com/grafana/grafana-app-sdk/logging"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
@@ -102,13 +103,15 @@ func (f *finalizer) newItemProcessor(
 	clients resources.ResourceClients,
 	cb func(client dynamic.ResourceInterface, item *provisioning.ResourceListItem) error,
 ) itemProcessor {
-	logger := logging.FromContext(ctx)
+	baseLogger := logging.FromContext(ctx)
 	return func(jobCtx context.Context, item *provisioning.ResourceListItem) error {
 		// If the item is a folder, use the configured folder API version.
+		// Use a per-item logger so fields don't accumulate across items.
+		itemLogger := baseLogger
 		var version string
 		if item.Group == resources.FolderResource.Group && item.Resource == resources.FolderResource.Resource {
 			version = f.folderAPIVersion
-			logger = logger.With("version", version)
+			itemLogger = baseLogger.With("version", version)
 		}
 
 		res, _, err := clients.ForResource(jobCtx, schema.GroupVersionResource{
@@ -117,17 +120,23 @@ func (f *finalizer) newItemProcessor(
 			Version:  version,
 		})
 		if err != nil {
-			logger.Error("error getting client for resource", "resource", item.Resource, "error", err)
+			itemLogger.Error("error getting client for resource", "resource", item.Resource, "error", err)
 			return err
 		}
 
-		err = cb(res, item)
+		// Retry on optimistic-concurrency conflicts from the unified storage
+		// layer ("requested RV does not match current RV"). The finalizer races
+		// with other reconciles/syncs that may mutate the same resource, and a
+		// transient RV mismatch should not fail the whole finalizer run.
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			return cb(res, item)
+		})
 		if err != nil {
 			if errors.IsNotFound(err) {
-				logger.Info("resource not found, skipping", "name", item.Name, "group", item.Group, "resource", item.Resource)
+				itemLogger.Info("resource not found, skipping", "name", item.Name, "group", item.Group, "resource", item.Resource)
 				return nil
 			}
-			logger.Error("error processing item", "name", item.Name, "error", err)
+			itemLogger.Error("error processing item", "name", item.Name, "error", err)
 			return fmt.Errorf("processing item: %w", err)
 		}
 		return nil

--- a/pkg/registry/apis/provisioning/controller/finalizers.go
+++ b/pkg/registry/apis/provisioning/controller/finalizers.go
@@ -103,15 +103,13 @@ func (f *finalizer) newItemProcessor(
 	clients resources.ResourceClients,
 	cb func(client dynamic.ResourceInterface, item *provisioning.ResourceListItem) error,
 ) itemProcessor {
-	baseLogger := logging.FromContext(ctx)
+	logger := logging.FromContext(ctx)
 	return func(jobCtx context.Context, item *provisioning.ResourceListItem) error {
 		// If the item is a folder, use the configured folder API version.
-		// Use a per-item logger so fields don't accumulate across items.
-		itemLogger := baseLogger
 		var version string
 		if item.Group == resources.FolderResource.Group && item.Resource == resources.FolderResource.Resource {
 			version = f.folderAPIVersion
-			itemLogger = baseLogger.With("version", version)
+			logger = logger.With("version", version)
 		}
 
 		res, _, err := clients.ForResource(jobCtx, schema.GroupVersionResource{
@@ -120,7 +118,7 @@ func (f *finalizer) newItemProcessor(
 			Version:  version,
 		})
 		if err != nil {
-			itemLogger.Error("error getting client for resource", "resource", item.Resource, "error", err)
+			logger.Error("error getting client for resource", "resource", item.Resource, "error", err)
 			return err
 		}
 
@@ -133,10 +131,10 @@ func (f *finalizer) newItemProcessor(
 		})
 		if err != nil {
 			if errors.IsNotFound(err) {
-				itemLogger.Info("resource not found, skipping", "name", item.Name, "group", item.Group, "resource", item.Resource)
+				logger.Info("resource not found, skipping", "name", item.Name, "group", item.Group, "resource", item.Resource)
 				return nil
 			}
-			itemLogger.Error("error processing item", "name", item.Name, "error", err)
+			logger.Error("error processing item", "name", item.Name, "error", err)
 			return fmt.Errorf("processing item: %w", err)
 		}
 		return nil

--- a/pkg/registry/apis/provisioning/controller/finalizers_test.go
+++ b/pkg/registry/apis/provisioning/controller/finalizers_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	mock "github.com/stretchr/testify/mock"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -1072,4 +1073,145 @@ func TestFinalizer_processExistingItems_Concurrency(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestReleaseExistingItems_RetriesOnConflict verifies that a transient
+// ResourceVersion conflict from the storage backend is retried rather than
+// failing the finalizer run.
+func TestReleaseExistingItems_RetriesOnConflict(t *testing.T) {
+	items := provisioning.ResourceList{
+		Items: []provisioning.ResourceListItem{
+			{Group: folders.GroupVersion.Group, Resource: "folders", Name: "folder-a", Path: "a"},
+		},
+	}
+
+	resourceLister := resources.NewMockResourceLister(t)
+	resourceLister.On("List", mock.Anything, "default", "my-repo").Return(&items, nil)
+
+	clientFactory := resources.NewMockClientFactory(t)
+	clients := resources.NewMockResourceClients(t)
+	clientFactory.On("Clients", mock.Anything, "default").Return(clients, nil)
+
+	var calls int32
+	client := &mockDynamicClient{
+		patchFunc: func(ctx context.Context, name string, pt types.PatchType, data []byte, options metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error) {
+			n := atomic.AddInt32(&calls, 1)
+			if n == 1 {
+				// Mirror the error returned by the unified storage backend when
+				// a Write is rejected because of RV mismatch.
+				return nil, apierrors.NewConflict(
+					schema.GroupResource{Group: folders.GroupVersion.Group, Resource: "folders"},
+					name,
+					fmt.Errorf("requested RV does not match current RV"),
+				)
+			}
+			return nil, nil
+		},
+	}
+	clients.On("ForResource", mock.Anything, mock.Anything).Return(client, schema.GroupVersionKind{}, nil)
+
+	f := &finalizer{
+		lister:           resourceLister,
+		clientFactory:    clientFactory,
+		metrics:          func() *finalizerMetrics { m := registerFinalizerMetrics(prometheus.NewRegistry()); return &m }(),
+		maxWorkers:       1,
+		folderAPIVersion: "v1",
+	}
+
+	repo := &provisioning.Repository{ObjectMeta: metav1.ObjectMeta{Name: "my-repo", Namespace: "default"}}
+	count, err := f.releaseExistingItems(context.Background(), repo)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, count)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls), "patch should have been retried once after the initial conflict")
+}
+
+// TestDeleteExistingItems_RetriesOnConflict mirrors the release-path test for
+// the delete path so both cb invocations are covered by retry.
+func TestDeleteExistingItems_RetriesOnConflict(t *testing.T) {
+	items := provisioning.ResourceList{
+		Items: []provisioning.ResourceListItem{
+			{Group: folders.GroupVersion.Group, Resource: "folders", Name: "folder-a", Path: "a"},
+		},
+	}
+
+	resourceLister := resources.NewMockResourceLister(t)
+	resourceLister.On("List", mock.Anything, "default", "my-repo").Return(&items, nil)
+
+	clientFactory := resources.NewMockClientFactory(t)
+	clients := resources.NewMockResourceClients(t)
+	clientFactory.On("Clients", mock.Anything, "default").Return(clients, nil)
+
+	var calls int32
+	client := &mockDynamicClient{
+		deleteFunc: func(ctx context.Context, name string, options metav1.DeleteOptions, subresources ...string) error {
+			n := atomic.AddInt32(&calls, 1)
+			if n == 1 {
+				return apierrors.NewConflict(
+					schema.GroupResource{Group: folders.GroupVersion.Group, Resource: "folders"},
+					name,
+					fmt.Errorf("requested RV does not match current RV"),
+				)
+			}
+			return nil
+		},
+	}
+	clients.On("ForResource", mock.Anything, mock.Anything).Return(client, schema.GroupVersionKind{}, nil)
+
+	f := &finalizer{
+		lister:           resourceLister,
+		clientFactory:    clientFactory,
+		metrics:          func() *finalizerMetrics { m := registerFinalizerMetrics(prometheus.NewRegistry()); return &m }(),
+		maxWorkers:       1,
+		folderAPIVersion: "v1",
+	}
+
+	repo := &provisioning.Repository{ObjectMeta: metav1.ObjectMeta{Name: "my-repo", Namespace: "default"}}
+	count, err := f.deleteExistingItems(context.Background(), repo)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, count)
+	assert.Equal(t, int32(2), atomic.LoadInt32(&calls), "delete should have been retried once after the initial conflict")
+}
+
+// TestReleaseExistingItems_ReturnsErrorWhenConflictPersists ensures the retry
+// budget is bounded: if every attempt returns Conflict, the finalizer surfaces
+// the error rather than looping forever.
+func TestReleaseExistingItems_ReturnsErrorWhenConflictPersists(t *testing.T) {
+	items := provisioning.ResourceList{
+		Items: []provisioning.ResourceListItem{
+			{Group: folders.GroupVersion.Group, Resource: "folders", Name: "folder-a", Path: "a"},
+		},
+	}
+
+	resourceLister := resources.NewMockResourceLister(t)
+	resourceLister.On("List", mock.Anything, "default", "my-repo").Return(&items, nil)
+
+	clientFactory := resources.NewMockClientFactory(t)
+	clients := resources.NewMockResourceClients(t)
+	clientFactory.On("Clients", mock.Anything, "default").Return(clients, nil)
+
+	var calls int32
+	client := &mockDynamicClient{
+		patchFunc: func(ctx context.Context, name string, pt types.PatchType, data []byte, options metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error) {
+			atomic.AddInt32(&calls, 1)
+			return nil, apierrors.NewConflict(
+				schema.GroupResource{Group: folders.GroupVersion.Group, Resource: "folders"},
+				name,
+				fmt.Errorf("requested RV does not match current RV"),
+			)
+		},
+	}
+	clients.On("ForResource", mock.Anything, mock.Anything).Return(client, schema.GroupVersionKind{}, nil)
+
+	f := &finalizer{
+		lister:           resourceLister,
+		clientFactory:    clientFactory,
+		metrics:          func() *finalizerMetrics { m := registerFinalizerMetrics(prometheus.NewRegistry()); return &m }(),
+		maxWorkers:       1,
+		folderAPIVersion: "v1",
+	}
+
+	repo := &provisioning.Repository{ObjectMeta: metav1.ObjectMeta{Name: "my-repo", Namespace: "default"}}
+	_, err := f.releaseExistingItems(context.Background(), repo)
+	assert.Error(t, err)
+	assert.Greater(t, atomic.LoadInt32(&calls), int32(1), "finalizer should have retried at least once before giving up")
 }


### PR DESCRIPTION
## Summary

Wrap the per-item finalizer callback in `retry.RetryOnConflict` so transient optimistic-concurrency errors from the unified storage backend (`requested RV does not match current RV`) don't fail the whole repository finalizer run.

## Context

Observed in production:

```
logger=provisioning-repository-controller repositoryType=gitlab ...
error="Operation cannot be fulfilled on folders.folder.grafana.app \"features-...\": requested RV does not match current RV"
```

The error originates from the unified storage backend at `pkg/storage/unified/resource/storage_backend.go:761` when `event.PreviousRV` doesn't match the current RV at write time.

Note that even a bare `client.Delete(name, DeleteOptions{})` — with no preconditions set on the caller side — can produce this error. The unified storage layer **always** carries an RV precondition on writes:

1. `pkg/storage/unified/apistore/store.go:312` — `Storage.Delete` reads the current object and sets `cmd.ResourceVersion = meta.GetResourceVersionInt64()`.
2. `pkg/storage/unified/resource/server.go:1081` — `server.delete` converts the delete into a `WriteEvent` with `Type = DELETED` and `PreviousRV = req.ResourceVersion`.
3. `pkg/storage/unified/resource/storage_backend.go:759-761` — `WriteEvent` rejects the write if anything modified the object between step 1 and step 3.

So every write on unified storage (Delete, Patch, Update) is implicitly optimistic-concurrency, and the finalizer races with other reconciles/syncs that legitimately mutate the same folder/dashboard. A transient conflict on one item should be retried, not abort the whole cleanup run.

## Changes

- `pkg/registry/apis/provisioning/controller/finalizers.go` — wrap `cb(res, item)` in `retry.RetryOnConflict(retry.DefaultRetry, ...)`. `IsNotFound` handling remains intact (non-conflict errors pass through unchanged). Default backoff is 5 steps at ~10ms each, so worst-case added latency is tens of ms per item.
- `pkg/registry/apis/provisioning/controller/finalizers_test.go`
  - `TestReleaseExistingItems_RetriesOnConflict` — first `Patch` returns the unified-storage conflict error, second succeeds.
  - `TestDeleteExistingItems_RetriesOnConflict` — same shape for the delete path (the one we actually observe).
  - `TestReleaseExistingItems_ReturnsErrorWhenConflictPersists` — ensures the retry budget is bounded.

## Test plan

- [x] `go test ./pkg/registry/apis/provisioning/controller/...` passes locally
- [ ] CI green
- [ ] Watch staging logs after rollout for the `process finalizers: remove resources: processing item:` pattern

## Follow-ups (not in this PR)

The same root cause affects other writes on `repositories.provisioning.grafana.app`:

- `apps/provisioning/pkg/controller/status.go:30-31` — `RepositoryStatusPatcher.Patch` (status patch operations / hook failure updates).
- `pkg/registry/apis/provisioning/controller/repository.go:307-312` — direct finalizer-removal Patch.
- `pkg/registry/apis/provisioning/resources/folders.go:281` — `EnsureFolderExists` Get-then-Update on the sync path.

Those need the same `RetryOnConflict` treatment and will be addressed in separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)