### PR TITLE
Chore: Migrate DES and release-guild ownership to grafana-backend-services-squad

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,8 +12,8 @@
 # This should make it easy to add new rules without breaking existing ones.
 
 # Documentation
-/.changelog-archive @grafana/grafana-developer-enablement-squad
-/CHANGELOG.md @grafana/grafana-developer-enablement-squad
+/.changelog-archive @grafana/grafana-backend-services-squad
+/CHANGELOG.md @grafana/grafana-backend-services-squad
 /CODE_OF_CONDUCT.md @grafana/grafana-community-support
 /CONTRIBUTING.md @grafana/grafana-community-support
 /GOVERNANCE.md @RichiH
@@ -69,7 +69,7 @@
 /go.sum @grafana/grafana-backend-group
 /go.work @grafana/grafana-app-platform-squad
 /go.work.sum @grafana/grafana-app-platform-squad
-/.citools @grafana/grafana-backend-servicdes-squad
+/.citools @grafana/grafana-backend-services-squad
 /pkg/README.md @grafana/grafana-backend-group
 /pkg/ruleguard.rules.go @grafana/grafana-backend-group
 /.golangci.yml @grafana/grafana-backend-group
@@ -356,12 +356,12 @@
 
 
 # Continuous Integration
-/pkg/build/ @grafana/grafana-developer-enablement-squad
-/.dockerignore @grafana/grafana-developer-enablement-squad
-/Dockerfile @grafana/grafana-developer-enablement-squad
-/Makefile @grafana/grafana-developer-enablement-squad
-/scripts/build/ @grafana/grafana-developer-enablement-squad
-/scripts/list-release-artifacts.sh @grafana/grafana-developer-enablement-squad
+/pkg/build/ @grafana/grafana-backend-services-squad
+/.dockerignore @grafana/grafana-backend-services-squad
+/Dockerfile @grafana/grafana-backend-services-squad
+/Makefile @grafana/grafana-backend-services-squad
+/scripts/build/ @grafana/grafana-backend-services-squad
+/scripts/list-release-artifacts.sh @grafana/grafana-backend-services-squad
 /scripts/releasefinder.sh @baldm0mma
 
 # OSS Plugin Partnerships backend code
@@ -1081,9 +1081,9 @@ playwright.storybook.config.ts @grafana/grafana-frontend-platform
 /scripts/build-targz.sh @grafana/grafana-backend-services-squad
 scripts/verify-pkg-stig.sh @grafana/grafana-backend-services-squad
 /scripts/check-breaking-changes.sh @grafana/grafana-frontend-platform
-/scripts/ci-* @grafana/grafana-developer-enablement-squad
-/scripts/publish-npm-packages.sh @grafana/grafana-developer-enablement-squad @grafana/grafana-frontend-platform
-/scripts/validate-npm-packages.sh @grafana/grafana-developer-enablement-squad @grafana/grafana-frontend-platform
+/scripts/ci-* @grafana/grafana-backend-services-squad
+/scripts/publish-npm-packages.sh @grafana/grafana-backend-services-squad @grafana/grafana-frontend-platform
+/scripts/validate-npm-packages.sh @grafana/grafana-backend-services-squad @grafana/grafana-frontend-platform
 /scripts/ci-frontend-metrics.sh @grafana/grafana-frontend-platform @grafana/frontend-ops
 /scripts/cli/ @grafana/grafana-frontend-platform
 /scripts/clean-git-or-error.sh @grafana/grafana-as-code
@@ -1091,18 +1091,18 @@ scripts/verify-pkg-stig.sh @grafana/grafana-backend-services-squad
 /scripts/check-frontend-dev.sh @grafana/grafana-frontend-platform
 /scripts/check-codeowner-affected.js @grafana/dataviz-squad
 /scripts/compare-coverage-by-codeowner.js @grafana/dataviz-squad
-/scripts/helpers/ @grafana/grafana-developer-enablement-squad
+/scripts/helpers/ @grafana/grafana-backend-services-squad
 /scripts/import_many_dashboards.sh @torkelo
 /scripts/mixin-check.sh @bergquist
 /scripts/openapi3/ @grafana/grafana-operator-experience-squad
 /scripts/prepare-npm-package.js @grafana/frontend-ops
 /scripts/protobuf-check.sh @grafana/plugins-platform-backend
 /scripts/stripnulls.sh @grafana/grafana-as-code
-/scripts/tag_release.sh @grafana/grafana-developer-enablement-squad
-/scripts/trigger_docker_build.sh @grafana/grafana-developer-enablement-squad
-/scripts/trigger_grafana_packer.sh @grafana/grafana-developer-enablement-squad
-/scripts/trigger_windows_build.sh @grafana/grafana-developer-enablement-squad
-/scripts/verify-repo-update/ @grafana/grafana-developer-enablement-squad
+/scripts/tag_release.sh @grafana/grafana-backend-services-squad
+/scripts/trigger_docker_build.sh @grafana/grafana-backend-services-squad
+/scripts/trigger_grafana_packer.sh @grafana/grafana-backend-services-squad
+/scripts/trigger_windows_build.sh @grafana/grafana-backend-services-squad
+/scripts/verify-repo-update/ @grafana/grafana-backend-services-squad
 /scripts/generate-alerting-rtk-apis.ts @grafana/alerting-frontend
 /scripts/levitate-parse-json-report.js @grafana/grafana-frontend-platform
 /scripts/levitate-show-affected-plugins.js @grafana/grafana-frontend-platform
@@ -1251,39 +1251,39 @@ embed.go @grafana/grafana-as-code
 /.github/actions/setup-go/action.yml @grafana/grafana-backend-group
 /.github/actions/report-go-cache-sizes/ @grafana/grafana-backend-group
 /.github/actions/setup-grafana-bench/ @Proximyst
-/.github/actions/build-package @grafana/grafana-developer-enablement-squad
-/.github/actions/change-detection @grafana/grafana-developer-enablement-squad
+/.github/actions/build-package @grafana/grafana-backend-services-squad
+/.github/actions/change-detection @grafana/grafana-backend-services-squad
 /.github/actions/setup-fpm @grafana/grafana-backend-services-squad
 /.github/actions/setup-node @grafana/grafana-frontend-platform
 /.github/actions/yarn-install/action.yml @grafana/grafana-frontend-platform
-/.github/workflows/actionlint-format.txt @grafana/grafana-developer-enablement-squad
-/.github/workflows/actionlint.yml @grafana/grafana-developer-enablement-squad
+/.github/workflows/actionlint-format.txt @grafana/grafana-backend-services-squad
+/.github/workflows/actionlint.yml @grafana/grafana-backend-services-squad
 /.github/workflows/add-to-whats-new.yml @grafana/docs-tooling
 /.github/workflows/auto-triager/ @grafana/plugins-platform-frontend
 /.github/workflows/alerting-swagger-gen.yml @grafana/alerting-backend
 /.github/workflows/alerting-update-module.yml @grafana/alerting-backend
-/.github/workflows/auto-milestone.yml @grafana/grafana-developer-enablement-squad
+/.github/workflows/auto-milestone.yml @grafana/grafana-backend-services-squad
 /.github/workflows/backend-code-checks.yml @grafana/grafana-backend-group
 /.github/workflows/backend-unit-tests.yml @grafana/grafana-backend-group
-/.github/workflows/backport-trigger.yml @grafana/grafana-developer-enablement-squad
+/.github/workflows/backport-trigger.yml @grafana/grafana-backend-services-squad
 /.github/workflows/build-go-matrix.yml @grafana/grafana-backend-services-squad
-/.github/workflows/backport-workflow.yml @grafana/grafana-developer-enablement-squad
-/.github/workflows/bump-version.yml @grafana/grafana-developer-enablement-squad
-/.github/workflows/release-pr.yml @grafana/grafana-developer-enablement-squad
-/.github/workflows/release-comms.yml @grafana/grafana-developer-enablement-squad
-/.github/workflows/migrate-prs.yml @grafana/grafana-developer-enablement-squad
-/.github/workflows/create-next-release-branch.yml @grafana/grafana-developer-enablement-squad
-/.github/workflows/create-security-branch.yml @grafana/grafana-developer-enablement-squad
+/.github/workflows/backport-workflow.yml @grafana/grafana-backend-services-squad
+/.github/workflows/bump-version.yml @grafana/grafana-backend-services-squad
+/.github/workflows/release-pr.yml @grafana/grafana-backend-services-squad
+/.github/workflows/release-comms.yml @grafana/grafana-backend-services-squad
+/.github/workflows/migrate-prs.yml @grafana/grafana-backend-services-squad
+/.github/workflows/create-next-release-branch.yml @grafana/grafana-backend-services-squad
+/.github/workflows/create-security-branch.yml @grafana/grafana-backend-services-squad
 /.github/workflows/codeowners-validator.yml @tolzhabayev
 /.github/workflows/codeql-analysis.yml @DanCech
 /.github/workflows/commands.yml @torkelo
-/.github/workflows/community-release.yml @grafana/grafana-developer-enablement-squad
+/.github/workflows/community-release.yml @grafana/grafana-backend-services-squad
 /.github/workflows/detect-breaking-changes-* @grafana/grafana-frontend-platform
 /.github/workflows/documentation-ci.yml @grafana/docs-tooling
 /.github/workflows/deploy-pr-preview.yml @grafana/docs-tooling
 /.github/workflows/externalized-datasources-reminder.yml @grafana/data-sources
 /.github/workflows/feature-toggles-ci.yml @grafana/docs-tooling
-/.github/workflows/github-release.yml @grafana/grafana-developer-enablement-squad
+/.github/workflows/github-release.yml @grafana/grafana-backend-services-squad
 /.github/workflows/external-fr-notify.yml @grafana/grafana-community-support
 /.github/workflows/external-fr-weekly-digest.yml @grafana/grafana-community-support
 /.github/workflows/external-pr-notify-handler.yml @grafana/grafana-community-support
@@ -1298,11 +1298,11 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/pr-codeql-analysis-python.yml @DanCech
 /.github/workflows/pr-commands.yml @tolzhabayev
 /.github/workflows/pr-external-labelling.yml @Proximyst
-/.github/workflows/pr-patch-check-event.yml @grafana/grafana-developer-enablement-squad
-/.github/workflows/pr-patch-check.yml @grafana/grafana-developer-enablement-squad
+/.github/workflows/pr-patch-check-event.yml @grafana/grafana-backend-services-squad
+/.github/workflows/pr-patch-check.yml @grafana/grafana-backend-services-squad
 /.github/workflows/pr-test-integration.yml @grafana/grafana-backend-group
-/.github/workflows/reject-gh-secrets.yml @grafana/grafana-developer-enablement-squad
-/.github/workflows/sync-mirror-event.yml @grafana/grafana-developer-enablement-squad
+/.github/workflows/reject-gh-secrets.yml @grafana/grafana-backend-services-squad
+/.github/workflows/sync-mirror-event.yml @grafana/grafana-backend-services-squad
 /.github/workflows/publish-technical-documentation-next.yml @grafana/docs-tooling
 /.github/workflows/publish-technical-documentation-release.yml @grafana/docs-tooling
 /.github/workflows/scripts/fr-digest.mts @grafana/grafana-community-support
@@ -1311,13 +1311,13 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/scripts/pr-notify.mts @grafana/grafana-community-support
 /.github/workflows/scripts/utils.mts @grafana/grafana-community-support
 /.github/workflows/scripts/json-file-to-job-output.js @grafana/grafana-frontend-platform
-/.github/workflows/stale.yml @grafana/grafana-developer-enablement-squad
+/.github/workflows/stale.yml @grafana/grafana-backend-services-squad
 /.github/workflows/storybook-a11y.yml @grafana/grafana-frontend-platform
-/.github/workflows/scripts/create-security-branch/create-security-branch.sh @grafana/grafana-developer-enablement-squad
+/.github/workflows/scripts/create-security-branch/create-security-branch.sh @grafana/grafana-backend-services-squad
 /.github/workflows/dashboards-issue-add-label.yml @grafana/dashboards-squad
 /.github/workflows/run-schema-v2-e2e.yml  @grafana/dashboards-squad
 /.github/workflows/ephemeral-instances-pr-comment.yml @grafana/grafana-operator-experience-squad
-/.github/workflows/create-security-patch-from-security-mirror.yml @grafana/grafana-developer-enablement-squad
+/.github/workflows/create-security-patch-from-security-mirror.yml @grafana/grafana-backend-services-squad
 /.github/workflows/i18n-crowdin-upload.yml @grafana/grafana-frontend-platform
 /.github/workflows/i18n-crowdin-download.yml @grafana/grafana-frontend-platform
 /.github/workflows/i18n-crowdin-create-tasks.yml @grafana/grafana-frontend-platform
@@ -1333,12 +1333,12 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/govulncheck.yml @grafana/grafana-backend-services-squad
 /.github/workflows/trufflehog.yml @Proximyst
 /.github/workflows/changelog.yml @zserge
-/.github/workflows/shellcheck.yml @grafana/grafana-developer-enablement-squad
-/.github/workflows/release-build.yml @grafana/grafana-developer-enablement-squad
+/.github/workflows/shellcheck.yml @grafana/grafana-backend-services-squad
+/.github/workflows/release-build.yml @grafana/grafana-backend-services-squad
 /.github/workflows/release-verify.yml @grafana/grafana-backend-services-squad
 /.github/workflows/release-verify-packages.yml @grafana/grafana-backend-services-squad
-/.github/workflows/cleanup-branches.yml @grafana/grafana-developer-enablement-squad
-/.github/workflows/publish-artifact.yml @grafana/grafana-developer-enablement-squad
+/.github/workflows/cleanup-branches.yml @grafana/grafana-backend-services-squad
+/.github/workflows/publish-artifact.yml @grafana/grafana-backend-services-squad
 /.github/actions/changelog @zserge
 /.github/workflows/check-frontend-test-coverage.yml @grafana/dataviz-squad
 /.github/workflows/report-frontend-coverage-to-bench.yaml @grafana/dataviz-squad
@@ -1346,20 +1346,20 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/pr-frontend-unit-tests.yml @grafana/grafana-frontend-platform
 /.github/workflows/frontend-lint.yml @grafana/grafana-frontend-platform
 /.github/workflows/analytics-events-report.yml @grafana/grafana-frontend-platform
-/.github/workflows/pr-e2e-tests.yml @grafana/grafana-developer-enablement-squad
+/.github/workflows/pr-e2e-tests.yml @grafana/grafana-backend-services-squad
 /.github/workflows/skye-add-to-project.yml @grafana/grafana-frontend-platform
 /.github/workflows/frontend-perf-tests.yaml @grafana/grafana-frontend-platform
 /.github/workflows/release-npm.yml @grafana/grafana-frontend-platform
 /.github/workflows/scripts/determine-npm-tag.sh @grafana/grafana-frontend-platform
 /.github/workflows/scripts/validate-commit-in-head.sh @grafana/grafana-frontend-platform
 /.github/workflows/scripts/test-endpoint-migration-check.sh @grafana/alerting-frontend
-/.github/zizmor.yml @grafana/grafana-developer-enablement-squad
+/.github/zizmor.yml @grafana/grafana-backend-services-squad
 /.github/license_finder.yaml @bergquist
-/.github/actionlint.yaml @grafana/grafana-developer-enablement-squad
-/.github/workflows/pr-test-docker.yml @grafana/grafana-developer-enablement-squad
+/.github/actionlint.yaml @grafana/grafana-backend-services-squad
+/.github/workflows/pr-test-docker.yml @grafana/grafana-backend-services-squad
 /.github/workflows/update-schema-types.yml @grafana/grafana-frontend-platform
 /.github/workflows/defaults-ini-docs-reminder.yml @grafana/docs-tooling @jtvdez
-/.github/workflows/pr-build-grafana.yml @grafana/grafana-developer-enablement-squad
+/.github/workflows/pr-build-grafana.yml @grafana/grafana-backend-services-squad
 
 # Generated files not requiring owner approval
 /packages/grafana-data/src/types/featureToggles.gen.ts @grafanabot

--- a/.github/workflows/create-security-patch-from-security-mirror.yml
+++ b/.github/workflows/create-security-patch-from-security-mirror.yml
@@ -1,4 +1,4 @@
-# Owned by grafana-release-guild
+# Owned by grafana-backend-services-squad
 # Intended to be dropped into the base repo (Ex: grafana/grafana) for use in the security mirror.
 name: Create security patch
 run-name: create-security-patch

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/BurntSushi/toml v1.5.0 // @grafana/identity-access-team
 	github.com/DATA-DOG/go-sqlmock v1.5.2 // @grafana/grafana-search-and-storage
 	github.com/Masterminds/semver v1.5.0 // @grafana/grafana-backend-group
-	github.com/Masterminds/semver/v3 v3.4.0 // @grafana/grafana-developer-enablement-squad
+	github.com/Masterminds/semver/v3 v3.4.0 // @grafana/grafana-backend-services-squad
 	github.com/Masterminds/sprig/v3 v3.3.0 // @grafana/grafana-backend-group
 	github.com/VividCortex/mysqlerr v1.0.0 // @grafana/grafana-backend-group
 	github.com/alicebob/miniredis/v2 v2.34.0 // @grafana/alerting-backend

--- a/scripts/modowners/README.md
+++ b/scripts/modowners/README.md
@@ -35,7 +35,7 @@ Example CLI command to get a list of all owners with a count of the number of de
 Example output:
 
 ```
-@grafana/grafana-release-guild 5
+@grafana/grafana-backend-services-squad 5
 @grafana/grafana-bi-squad 2
 @grafana/grafana-app-platform-squad 13
 @grafana/observability-metrics 4
@@ -64,9 +64,9 @@ Example output:
 
 List all dependencies of given owner(s).
 
-Example CLI command to list all direct dependencies owned by Delivery and Authnz:
+Example CLI command to list all direct dependencies owned by Backend Services and Authnz:
 
-`go run scripts/modowners/modowners.go modules -o @grafana/grafana-release-guild,@grafana/identity-access-team go.mod`
+`go run scripts/modowners/modowners.go modules -o @grafana/grafana-backend-services-squad,@grafana/identity-access-team go.mod`
 
 Example output:
 

--- a/scripts/modowners/modowners.go
+++ b/scripts/modowners/modowners.go
@@ -129,7 +129,7 @@ func owners(fileSystem fs.FS, logger *log.Logger, args []string) error {
 }
 
 // Print dependencies for a given owner. Can specify one or more owners.
-// An example CLI command to list all direct dependencies owned by Delivery and Authnz `go run scripts/modowners/modowners.go modules -o @grafana/grafana-release-guild,@grafana/identity-access-team go.mod`
+// An example CLI command to list all direct dependencies owned by Backend Services and Authnz `go run scripts/modowners/modowners.go modules -o @grafana/grafana-backend-services-squad,@grafana/identity-access-team go.mod`
 func modules(fileSystem fs.FS, logger *log.Logger, args []string) error {
 	fs := flag.NewFlagSet("modules", flag.ExitOnError)
 	indirect := fs.Bool("i", false, "print indirect dependencies")


### PR DESCRIPTION
## Summary

The DES (Developer Enablement Squad) and GBS (Grafana Backend Services Squad) teams merged. This PR migrates GitHub ownership references from the old team names to `@grafana/grafana-backend-services-squad`.

**Scope (grafana/grafana only):**
- \`.github/CODEOWNERS\` — all DES entries (~48 lines) now point to GBS
- \`go.mod\` — single DES annotation on \`semver/v3\`
- \`.github/workflows/create-security-patch-from-security-mirror.yml\` — ownership comment updated
- \`scripts/modowners/README.md\` and \`modowners.go\` — stale release-guild example updated to a GBS example

No functional change. The DES and release-guild GitHub teams still exist (out-of-scope to delete), so nothing breaks if something was missed.

Part of a broader cleanup effort across the org. Follow-up PRs will cover grafana-enterprise, deployment_tools, and the release pipeline repos.

## Test plan

- [x] \`grep -rn \"grafana-developer-enablement-squad\\|grafana-release-guild\"\` in the repo returns no matches
- [ ] CI passes
- [ ] GitHub's CODEOWNERS validation shows required reviewers resolve to GBS on a touched path