### PR TITLE
Provisioning: retry Repository patches on RV conflict

### DIFF
--- a/apps/provisioning/pkg/controller/status.go
+++ b/apps/provisioning/pkg/controller/status.go
@@ -9,6 +9,7 @@ import (
 	client "github.com/grafana/grafana/apps/provisioning/pkg/generated/clientset/versioned/typed/provisioning/v0alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 )
 
 type RepositoryStatusPatcher struct {
@@ -27,8 +28,15 @@ func (r *RepositoryStatusPatcher) Patch(ctx context.Context, repo *provisioning.
 		return fmt.Errorf("unable to marshal patch data: %w", err)
 	}
 
-	_, err = r.client.Repositories(repo.Namespace).
-		Patch(ctx, repo.Name, types.JSONPatchType, patch, metav1.PatchOptions{}, "status")
+	// Retry on optimistic-concurrency conflicts from the unified storage
+	// layer ("requested RV does not match current RV"). The apiserver
+	// translates a JSON Patch into a read-modify-write with the just-read
+	// RV as PreviousRV, so concurrent status updates race with this call.
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		_, err := r.client.Repositories(repo.Namespace).
+			Patch(ctx, repo.Name, types.JSONPatchType, patch, metav1.PatchOptions{}, "status")
+		return err
+	})
 	if err != nil {
 		return fmt.Errorf("unable to update repo with job status: %w", err)
 	}

--- a/apps/provisioning/pkg/controller/status_test.go
+++ b/apps/provisioning/pkg/controller/status_test.go
@@ -4,13 +4,16 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sync/atomic"
 	"testing"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/generated/clientset/versioned/typed/provisioning/v0alpha1/fake"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	k8testing "k8s.io/client-go/testing"
 )
 
@@ -127,4 +130,64 @@ func TestRepositoryStatusPatcher_Patch(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRepositoryStatusPatcher_Patch_RetriesOnConflict(t *testing.T) {
+	repo := &provisioning.Repository{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-repo", Namespace: "test-namespace"},
+	}
+	ops := []map[string]interface{}{
+		{"op": "replace", "path": "/status/health", "value": map[string]interface{}{"healthy": true}},
+	}
+
+	t.Run("transient conflict is retried and succeeds", func(t *testing.T) {
+		var calls int32
+		c := fake.FakeProvisioningV0alpha1{Fake: &k8testing.Fake{}}
+		c.AddReactor("patch", "repositories", func(action k8testing.Action) (bool, runtime.Object, error) {
+			n := atomic.AddInt32(&calls, 1)
+			if n == 1 {
+				return true, nil, apierrors.NewConflict(
+					schema.GroupResource{Group: provisioning.GROUP, Resource: "repositories"},
+					"test-repo",
+					fmt.Errorf("requested RV does not match current RV"),
+				)
+			}
+			return true, &provisioning.Repository{}, nil
+		})
+
+		err := NewRepositoryStatusPatcher(&c).Patch(context.Background(), repo, ops...)
+		require.NoError(t, err)
+		require.Equal(t, int32(2), atomic.LoadInt32(&calls), "patch should retry once after conflict")
+	})
+
+	t.Run("persistent conflict surfaces the error", func(t *testing.T) {
+		var calls int32
+		c := fake.FakeProvisioningV0alpha1{Fake: &k8testing.Fake{}}
+		c.AddReactor("patch", "repositories", func(action k8testing.Action) (bool, runtime.Object, error) {
+			atomic.AddInt32(&calls, 1)
+			return true, nil, apierrors.NewConflict(
+				schema.GroupResource{Group: provisioning.GROUP, Resource: "repositories"},
+				"test-repo",
+				fmt.Errorf("requested RV does not match current RV"),
+			)
+		})
+
+		err := NewRepositoryStatusPatcher(&c).Patch(context.Background(), repo, ops...)
+		require.Error(t, err)
+		require.ErrorContains(t, err, "unable to update repo with job status")
+		require.Greater(t, atomic.LoadInt32(&calls), int32(1), "patch should retry at least once before giving up")
+	})
+
+	t.Run("non-conflict errors are not retried", func(t *testing.T) {
+		var calls int32
+		c := fake.FakeProvisioningV0alpha1{Fake: &k8testing.Fake{}}
+		c.AddReactor("patch", "repositories", func(action k8testing.Action) (bool, runtime.Object, error) {
+			atomic.AddInt32(&calls, 1)
+			return true, nil, fmt.Errorf("boom")
+		})
+
+		err := NewRepositoryStatusPatcher(&c).Patch(context.Background(), repo, ops...)
+		require.Error(t, err)
+		require.Equal(t, int32(1), atomic.LoadInt32(&calls), "non-conflict errors should not be retried")
+	})
 }

--- a/pkg/registry/apis/provisioning/controller/repository.go
+++ b/pkg/registry/apis/provisioning/controller/repository.go
@@ -16,6 +16,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/client-go/tools/cache"
+	"k8s.io/client-go/util/retry"
 	"k8s.io/client-go/util/workqueue"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
@@ -296,13 +297,19 @@ func (rc *RepositoryController) handleDelete(ctx context.Context, obj *provision
 			return fmt.Errorf("process finalizers: %w", err)
 		}
 
-		// remove the finalizers
-		_, err = rc.client.Repositories(obj.GetNamespace()).
-			Patch(ctx, obj.Name, types.JSONPatchType, []byte(`[
+		// remove the finalizers. Retry on optimistic-concurrency conflicts:
+		// the apiserver translates this JSON Patch into a read-modify-write
+		// with PreviousRV set, so concurrent writes on the repository race
+		// with this call and legitimately succeed on retry.
+		err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+			_, err := rc.client.Repositories(obj.GetNamespace()).
+				Patch(ctx, obj.Name, types.JSONPatchType, []byte(`[
 					{ "op": "remove", "path": "/metadata/finalizers" }
 				]`), v1.PatchOptions{
-				FieldManager: "provisioning-controller",
-			})
+					FieldManager: "provisioning-controller",
+				})
+			return err
+		})
 		if err != nil {
 			return fmt.Errorf("remove finalizers: %w", err)
 		}

--- a/pkg/registry/apis/provisioning/controller/repository_test.go
+++ b/pkg/registry/apis/provisioning/controller/repository_test.go
@@ -381,6 +381,95 @@ func TestRepositoryController_handleDelete(t *testing.T) {
 	}
 }
 
+// TestRepositoryController_handleDelete_RetriesOnConflict verifies that a
+// transient RV conflict from the unified storage backend when removing
+// finalizers is retried rather than failing the deletion flow. The apiserver
+// translates this JSON Patch into a read-modify-write with PreviousRV set, so
+// concurrent writes on the same Repository object legitimately race with it.
+func TestRepositoryController_handleDelete_RetriesOnConflict(t *testing.T) {
+	finalizer := NewMockFinalizerProcessor(t)
+	finalizer.
+		On("process", context.Background(), nil, []string{repository.RemoveOrphanResourcesFinalizer}).
+		Once().
+		Return(nil)
+
+	factory := repository.NewMockFactory(t)
+	factory.On("Build", context.Background(), mock.Anything).Once().Return(nil, nil)
+
+	var calls int32
+	repoClient := &mockRepoInterface{
+		patchFunc: func(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (*provisioning.Repository, error) {
+			n := atomic.AddInt32(&calls, 1)
+			if n == 1 {
+				return nil, apierrors.NewConflict(
+					schema.GroupResource{Group: provisioning.GROUP, Resource: "repositories"},
+					name,
+					errors.New("requested RV does not match current RV"),
+				)
+			}
+			return &provisioning.Repository{}, nil
+		},
+	}
+
+	c := &RepositoryController{
+		repoFactory: factory,
+		finalizer:   finalizer,
+		client: &mockProvisioningV0alpha1Interface{
+			repositoriesFunc: func(string) client.RepositoryInterface { return repoClient },
+		},
+	}
+
+	repo := &provisioning.Repository{
+		ObjectMeta: metav1.ObjectMeta{
+			Finalizers: []string{repository.RemoveOrphanResourcesFinalizer},
+		},
+	}
+	err := c.handleDelete(context.Background(), repo)
+	require.NoError(t, err)
+	require.Equal(t, int32(2), atomic.LoadInt32(&calls), "finalizer-removal patch should retry once after a conflict")
+}
+
+func TestRepositoryController_handleDelete_ReturnsErrorWhenConflictPersists(t *testing.T) {
+	finalizer := NewMockFinalizerProcessor(t)
+	finalizer.
+		On("process", context.Background(), nil, []string{repository.RemoveOrphanResourcesFinalizer}).
+		Once().
+		Return(nil)
+
+	factory := repository.NewMockFactory(t)
+	factory.On("Build", context.Background(), mock.Anything).Once().Return(nil, nil)
+
+	var calls int32
+	repoClient := &mockRepoInterface{
+		patchFunc: func(ctx context.Context, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (*provisioning.Repository, error) {
+			atomic.AddInt32(&calls, 1)
+			return nil, apierrors.NewConflict(
+				schema.GroupResource{Group: provisioning.GROUP, Resource: "repositories"},
+				name,
+				errors.New("requested RV does not match current RV"),
+			)
+		},
+	}
+
+	c := &RepositoryController{
+		repoFactory: factory,
+		finalizer:   finalizer,
+		client: &mockProvisioningV0alpha1Interface{
+			repositoriesFunc: func(string) client.RepositoryInterface { return repoClient },
+		},
+	}
+
+	repo := &provisioning.Repository{
+		ObjectMeta: metav1.ObjectMeta{
+			Finalizers: []string{repository.RemoveOrphanResourcesFinalizer},
+		},
+	}
+	err := c.handleDelete(context.Background(), repo)
+	require.Error(t, err)
+	require.ErrorContains(t, err, "remove finalizers")
+	require.Greater(t, atomic.LoadInt32(&calls), int32(1), "should retry at least once before giving up")
+}
+
 func TestShouldUseIncrementalSync(t *testing.T) {
 	versioned := repository.NewMockVersioned(t)
 	obj := &provisioning.Repository{


### PR DESCRIPTION
## Summary

Follow-up to #123493 (finalizer item retry). Same root cause, different call sites.

The unified storage layer translates every JSON Patch into a read-modify-write with `PreviousRV` set to the value it just read (`pkg/storage/unified/apistore/store.go` → `pkg/storage/unified/resource/server.go` → `pkg/storage/unified/resource/storage_backend.go:761`). Any concurrent write on the same object races with the patch and surfaces as:

```
Operation cannot be fulfilled on repositories.provisioning.grafana.app "...": requested RV does not match current RV
```

Two call sites on the Repository object have no retry and fail outright today:

- **`RepositoryStatusPatcher.Patch`** (`apps/provisioning/pkg/controller/status.go`) — the shared helper behind every status patch. Three callers in the repository controller all hit it: `status patch operations`, post-hook status updates, and the delete-status path. This is the source of the `unable to update repo with job status: ...` errors observed in prod logs across `prod-us-east-2`, `prod-us-east-0`, `prod-us-central-0`.
- **`handleDelete` finalizer strip** (`pkg/registry/apis/provisioning/controller/repository.go:307`) — the JSON Patch that removes `/metadata/finalizers` after finalizer processing completes. Source of the `remove finalizers: Operation cannot be fulfilled on repositories...` error observed on `prod-au-southeast-1`.

Both are wrapped in `retry.RetryOnConflict(retry.DefaultRetry, ...)` (5 steps, ~50ms). Conflicts are transient — the next attempt re-reads the current RV and almost always succeeds — and the retry budget is bounded so persistent conflicts still surface the error.

## Test plan

- [x] `go test ./apps/provisioning/pkg/controller/ -run TestRepositoryStatusPatcher -count=1`
- [x] `go test ./pkg/registry/apis/provisioning/controller/ -run TestRepositoryController_handleDelete -count=1`
- [x] Full packages: `go test ./apps/provisioning/pkg/controller/ ./pkg/registry/apis/provisioning/controller/ -count=1`
- [x] New tests:
  - `TestRepositoryStatusPatcher_Patch_RetriesOnConflict` — transient conflict retried; persistent conflict surfaces error; non-conflict errors not retried
  - `TestRepositoryController_handleDelete_RetriesOnConflict` — finalizer-removal patch retries on conflict
  - `TestRepositoryController_handleDelete_ReturnsErrorWhenConflictPersists` — bounded retry budget
- [ ] Production verification: watch for the disappearance of `unable to update repo with job status: ... requested RV does not match current RV` errors after rollout

🤖 Generated with [Claude Code](https://claude.com/claude-code)