### PR TITLE
Provisioning: Scope repository uniqueness by (URL, branch, path)

### DIFF
--- a/apps/provisioning/pkg/repository/verify.go
+++ b/apps/provisioning/pkg/repository/verify.go
@@ -3,7 +3,6 @@ package repository
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -11,6 +10,7 @@ import (
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/quotas"
+	"github.com/grafana/grafana/apps/provisioning/pkg/safepath"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 )
 
@@ -70,33 +70,28 @@ func (v *VerifyAgainstExistingRepositoriesValidator) Validate(ctx context.Contex
 		}
 	}
 
-	// If repo is git and sync is enabled, ensure no other repository is defined with a conflicting path.
-	// Path checks are skipped when sync is disabled to allow the onboarding wizard to create repositories
-	// in multiple steps (first with empty path, then configure path, then enable sync).
-	if cfg.Spec.Type.IsGit() && cfg.Spec.Sync.Enabled {
+	// Duplicate repository locations are rejected once branch is configured.
+	// Parent folder conflict checks stay gated by sync.Enabled to support multi-step onboarding.
+	if cfg.Spec.Type.IsGit() && cfg.URL() != "" && (cfg.Spec.Sync.Enabled || cfg.Branch() != "") {
 		for _, v := range all {
 			// skip itself
 			if cfg.Name == v.Name {
 				continue
 			}
 			if v.URL() == cfg.URL() && v.Branch() == cfg.Branch() {
-				if v.Path() == cfg.Path() {
+				if normalizeRepositoryPath(v.Path()) == normalizeRepositoryPath(cfg.Path()) {
 					return field.ErrorList{field.Invalid(field.NewPath("spec", string(cfg.Spec.Type), "path"),
 						cfg.Path(),
 						fmt.Sprintf("%s: %s", ErrRepositoryDuplicatePath.Error(), v.Name))}
 				}
 
-				if v.Path() != "" || cfg.Path() != "" {
-					relPath, err := filepath.Rel(v.Path(), cfg.Path())
-					if err != nil {
-						return field.ErrorList{field.Invalid(field.NewPath("spec", string(cfg.Spec.Type), "path"), cfg.Path(), "failed to evaluate path: "+err.Error())}
-					}
-					// https://pkg.go.dev/path/filepath#Rel
-					// Rel will return "../" if the relative paths are not related
-					if !strings.HasPrefix(relPath, "../") {
-						return field.ErrorList{field.Invalid(field.NewPath("spec", string(cfg.Spec.Type), "path"), cfg.Path(),
-							fmt.Sprintf("%s: %s", ErrRepositoryParentFolderConflict.Error(), v.Name))}
-					}
+				if !cfg.Spec.Sync.Enabled {
+					continue
+				}
+
+				if repositoryPathsOverlap(v.Path(), cfg.Path()) {
+					return field.ErrorList{field.Invalid(field.NewPath("spec", string(cfg.Spec.Type), "path"), cfg.Path(),
+						fmt.Sprintf("%s: %s", ErrRepositoryParentFolderConflict.Error(), v.Name))}
 				}
 			}
 		}
@@ -132,4 +127,23 @@ func (v *VerifyAgainstExistingRepositoriesValidator) Validate(ctx context.Contex
 	}
 
 	return nil
+}
+
+// repositoryPathsOverlap reports whether two repository-relative paths target the
+// same tree or one tree contains the other. An empty path represents the repository root.
+func repositoryPathsOverlap(existingPath, newPath string) bool {
+	existingPath = normalizeRepositoryPath(existingPath)
+	newPath = normalizeRepositoryPath(newPath)
+
+	if existingPath == "" || newPath == "" {
+		return true
+	}
+
+	return strings.HasPrefix(newPath, existingPath+"/") || strings.HasPrefix(existingPath, newPath+"/")
+}
+
+// normalizeRepositoryPath canonicalizes configured repository paths before comparing them.
+// Repository paths are relative, so leading and trailing slashes are ignored.
+func normalizeRepositoryPath(p string) string {
+	return strings.Trim(safepath.Clean(strings.TrimSpace(p)), "/")
 }

--- a/apps/provisioning/pkg/repository/verify.go
+++ b/apps/provisioning/pkg/repository/verify.go
@@ -79,15 +79,13 @@ func (v *VerifyAgainstExistingRepositoriesValidator) Validate(ctx context.Contex
 			if cfg.Name == v.Name {
 				continue
 			}
-			if v.URL() == cfg.URL() {
-				// Allow duplicate paths only when both paths are empty (repository root)
-				if v.Path() == cfg.Path() && cfg.Path() != "" {
+			if v.URL() == cfg.URL() && v.Branch() == cfg.Branch() {
+				if v.Path() == cfg.Path() {
 					return field.ErrorList{field.Invalid(field.NewPath("spec", string(cfg.Spec.Type), "path"),
 						cfg.Path(),
 						fmt.Sprintf("%s: %s", ErrRepositoryDuplicatePath.Error(), v.Name))}
 				}
 
-				// Skip parent/child conflict check when both paths are empty (both at repository root)
 				if v.Path() != "" || cfg.Path() != "" {
 					relPath, err := filepath.Rel(v.Path(), cfg.Path())
 					if err != nil {

--- a/apps/provisioning/pkg/repository/verify.go
+++ b/apps/provisioning/pkg/repository/verify.go
@@ -70,7 +70,9 @@ func (v *VerifyAgainstExistingRepositoriesValidator) Validate(ctx context.Contex
 		}
 	}
 
-	// When sync is enabled, repository locations must be unique by URL, branch, and path.
+	// If repo is git and sync is enabled, ensure no other repository is defined with a conflicting path.
+	// Path checks are skipped when sync is disabled to allow the onboarding wizard to create repositories
+	// in multiple steps (first with empty path, then configure path, then enable sync).
 	if cfg.Spec.Type.IsGit() && cfg.Spec.Sync.Enabled {
 		for _, v := range all {
 			// skip itself
@@ -84,12 +86,14 @@ func (v *VerifyAgainstExistingRepositoriesValidator) Validate(ctx context.Contex
 						fmt.Sprintf("%s: %s", ErrRepositoryDuplicatePath.Error(), v.Name))}
 				}
 
+				// Skip parent/child conflict check when both paths are empty (both at repository root)
 				if v.Path() != "" || cfg.Path() != "" {
 					relPath, err := filepath.Rel(v.Path(), cfg.Path())
 					if err != nil {
 						return field.ErrorList{field.Invalid(field.NewPath("spec", string(cfg.Spec.Type), "path"), cfg.Path(), "failed to evaluate path: "+err.Error())}
 					}
-					// Rel returns "../" when relative paths are not related.
+					// https://pkg.go.dev/path/filepath#Rel
+					// Rel will return "../" if the relative paths are not related
 					if !strings.HasPrefix(relPath, "../") {
 						return field.ErrorList{field.Invalid(field.NewPath("spec", string(cfg.Spec.Type), "path"), cfg.Path(),
 							fmt.Sprintf("%s: %s", ErrRepositoryParentFolderConflict.Error(), v.Name))}

--- a/apps/provisioning/pkg/repository/verify.go
+++ b/apps/provisioning/pkg/repository/verify.go
@@ -70,9 +70,8 @@ func (v *VerifyAgainstExistingRepositoriesValidator) Validate(ctx context.Contex
 		}
 	}
 
-	// Duplicate repository locations are rejected once branch is configured.
-	// Parent folder conflict checks stay gated by sync.Enabled to support multi-step onboarding.
-	if cfg.Spec.Type.IsGit() && cfg.URL() != "" && (cfg.Spec.Sync.Enabled || cfg.Branch() != "") {
+	// When sync is enabled, repository locations must be unique by URL, branch, and normalized path.
+	if cfg.Spec.Type.IsGit() && cfg.Spec.Sync.Enabled {
 		for _, v := range all {
 			// skip itself
 			if cfg.Name == v.Name {
@@ -83,10 +82,6 @@ func (v *VerifyAgainstExistingRepositoriesValidator) Validate(ctx context.Contex
 					return field.ErrorList{field.Invalid(field.NewPath("spec", string(cfg.Spec.Type), "path"),
 						cfg.Path(),
 						fmt.Sprintf("%s: %s", ErrRepositoryDuplicatePath.Error(), v.Name))}
-				}
-
-				if !cfg.Spec.Sync.Enabled {
-					continue
 				}
 
 				if repositoryPathsOverlap(v.Path(), cfg.Path()) {

--- a/apps/provisioning/pkg/repository/verify.go
+++ b/apps/provisioning/pkg/repository/verify.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	"k8s.io/apimachinery/pkg/util/validation/field"
@@ -10,7 +11,6 @@ import (
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/quotas"
-	"github.com/grafana/grafana/apps/provisioning/pkg/safepath"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 )
 
@@ -70,7 +70,7 @@ func (v *VerifyAgainstExistingRepositoriesValidator) Validate(ctx context.Contex
 		}
 	}
 
-	// When sync is enabled, repository locations must be unique by URL, branch, and normalized path.
+	// When sync is enabled, repository locations must be unique by URL, branch, and path.
 	if cfg.Spec.Type.IsGit() && cfg.Spec.Sync.Enabled {
 		for _, v := range all {
 			// skip itself
@@ -78,15 +78,22 @@ func (v *VerifyAgainstExistingRepositoriesValidator) Validate(ctx context.Contex
 				continue
 			}
 			if v.URL() == cfg.URL() && v.Branch() == cfg.Branch() {
-				if normalizeRepositoryPath(v.Path()) == normalizeRepositoryPath(cfg.Path()) {
+				if v.Path() == cfg.Path() {
 					return field.ErrorList{field.Invalid(field.NewPath("spec", string(cfg.Spec.Type), "path"),
 						cfg.Path(),
 						fmt.Sprintf("%s: %s", ErrRepositoryDuplicatePath.Error(), v.Name))}
 				}
 
-				if repositoryPathsOverlap(v.Path(), cfg.Path()) {
-					return field.ErrorList{field.Invalid(field.NewPath("spec", string(cfg.Spec.Type), "path"), cfg.Path(),
-						fmt.Sprintf("%s: %s", ErrRepositoryParentFolderConflict.Error(), v.Name))}
+				if v.Path() != "" || cfg.Path() != "" {
+					relPath, err := filepath.Rel(v.Path(), cfg.Path())
+					if err != nil {
+						return field.ErrorList{field.Invalid(field.NewPath("spec", string(cfg.Spec.Type), "path"), cfg.Path(), "failed to evaluate path: "+err.Error())}
+					}
+					// Rel returns "../" when relative paths are not related.
+					if !strings.HasPrefix(relPath, "../") {
+						return field.ErrorList{field.Invalid(field.NewPath("spec", string(cfg.Spec.Type), "path"), cfg.Path(),
+							fmt.Sprintf("%s: %s", ErrRepositoryParentFolderConflict.Error(), v.Name))}
+					}
 				}
 			}
 		}
@@ -122,23 +129,4 @@ func (v *VerifyAgainstExistingRepositoriesValidator) Validate(ctx context.Contex
 	}
 
 	return nil
-}
-
-// repositoryPathsOverlap reports whether two repository-relative paths target the
-// same tree or one tree contains the other. An empty path represents the repository root.
-func repositoryPathsOverlap(existingPath, newPath string) bool {
-	existingPath = normalizeRepositoryPath(existingPath)
-	newPath = normalizeRepositoryPath(newPath)
-
-	if existingPath == "" || newPath == "" {
-		return true
-	}
-
-	return strings.HasPrefix(newPath, existingPath+"/") || strings.HasPrefix(existingPath, newPath+"/")
-}
-
-// normalizeRepositoryPath canonicalizes configured repository paths before comparing them.
-// Repository paths are relative, so leading and trailing slashes are ignored.
-func normalizeRepositoryPath(p string) string {
-	return strings.Trim(safepath.Clean(strings.TrimSpace(p)), "/")
 }

--- a/apps/provisioning/pkg/repository/verify_test.go
+++ b/apps/provisioning/pkg/repository/verify_test.go
@@ -156,7 +156,7 @@ func TestVerifyAgainstExistingRepositoriesValidator_Validate(t *testing.T) {
 			maxRepositories: 10,
 		},
 		{
-			name: "allows duplicate empty paths in same repo",
+			name: "forbids duplicate empty paths when sync is enabled",
 			cfg: &provisioning.Repository{
 				ObjectMeta: metav1.ObjectMeta{Name: "new-repo", Namespace: "default"},
 				Spec: provisioning.RepositorySpec{
@@ -180,7 +180,273 @@ func TestVerifyAgainstExistingRepositoriesValidator_Validate(t *testing.T) {
 					},
 				},
 			},
-			wantErr: false,
+			wantErr:         true,
+			wantErrContains: ErrRepositoryDuplicatePath.Error(),
+			maxRepositories: 10,
+		},
+		{
+			name: "allows duplicate empty paths when sync is disabled",
+			cfg: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{Name: "new-repo", Namespace: "default"},
+				Spec: provisioning.RepositorySpec{
+					Type: provisioning.GitHubRepositoryType,
+					Sync: provisioning.SyncOptions{Enabled: false},
+					GitHub: &provisioning.GitHubRepositoryConfig{
+						URL:  "https://github.com/org/repo",
+						Path: "",
+					},
+				},
+			},
+			existingRepos: []provisioning.Repository{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "existing-repo"},
+					Spec: provisioning.RepositorySpec{
+						Type: provisioning.GitHubRepositoryType,
+						GitHub: &provisioning.GitHubRepositoryConfig{
+							URL:  "https://github.com/org/repo",
+							Path: "",
+						},
+					},
+				},
+			},
+			wantErr:         false,
+			maxRepositories: 10,
+		},
+		{
+			name: "allows empty paths with different URLs when sync is enabled",
+			cfg: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{Name: "new-repo", Namespace: "default"},
+				Spec: provisioning.RepositorySpec{
+					Type: provisioning.GitHubRepositoryType,
+					Sync: provisioning.SyncOptions{Enabled: true},
+					GitHub: &provisioning.GitHubRepositoryConfig{
+						URL:  "https://github.com/org/repo2",
+						Path: "",
+					},
+				},
+			},
+			existingRepos: []provisioning.Repository{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "existing-repo"},
+					Spec: provisioning.RepositorySpec{
+						Type: provisioning.GitHubRepositoryType,
+						GitHub: &provisioning.GitHubRepositoryConfig{
+							URL:  "https://github.com/org/repo1",
+							Path: "",
+						},
+					},
+				},
+			},
+			wantErr:         false,
+			maxRepositories: 10,
+		},
+		{
+			name: "forbids duplicate non-empty paths on same branch when sync is enabled",
+			cfg: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{Name: "new-repo", Namespace: "default"},
+				Spec: provisioning.RepositorySpec{
+					Type: provisioning.GitHubRepositoryType,
+					Sync: provisioning.SyncOptions{Enabled: true},
+					GitHub: &provisioning.GitHubRepositoryConfig{
+						URL:    "https://github.com/org/repo",
+						Branch: "main",
+						Path:   "grafana/",
+					},
+				},
+			},
+			existingRepos: []provisioning.Repository{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "existing-repo"},
+					Spec: provisioning.RepositorySpec{
+						Type: provisioning.GitHubRepositoryType,
+						GitHub: &provisioning.GitHubRepositoryConfig{
+							URL:    "https://github.com/org/repo",
+							Branch: "main",
+							Path:   "grafana/",
+						},
+					},
+				},
+			},
+			wantErr:         true,
+			wantErrContains: ErrRepositoryDuplicatePath.Error(),
+			maxRepositories: 10,
+		},
+		{
+			name: "allows same path on different branches when sync is enabled",
+			cfg: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{Name: "new-repo", Namespace: "default"},
+				Spec: provisioning.RepositorySpec{
+					Type: provisioning.GitHubRepositoryType,
+					Sync: provisioning.SyncOptions{Enabled: true},
+					GitHub: &provisioning.GitHubRepositoryConfig{
+						URL:    "https://github.com/org/repo",
+						Branch: "develop",
+						Path:   "grafana/",
+					},
+				},
+			},
+			existingRepos: []provisioning.Repository{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "existing-repo"},
+					Spec: provisioning.RepositorySpec{
+						Type: provisioning.GitHubRepositoryType,
+						GitHub: &provisioning.GitHubRepositoryConfig{
+							URL:    "https://github.com/org/repo",
+							Branch: "main",
+							Path:   "grafana/",
+						},
+					},
+				},
+			},
+			wantErr:         false,
+			maxRepositories: 10,
+		},
+		{
+			name: "allows empty path on different branches when sync is enabled",
+			cfg: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{Name: "new-repo", Namespace: "default"},
+				Spec: provisioning.RepositorySpec{
+					Type: provisioning.GitHubRepositoryType,
+					Sync: provisioning.SyncOptions{Enabled: true},
+					GitHub: &provisioning.GitHubRepositoryConfig{
+						URL:    "https://github.com/org/repo",
+						Branch: "develop",
+						Path:   "",
+					},
+				},
+			},
+			existingRepos: []provisioning.Repository{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "existing-repo"},
+					Spec: provisioning.RepositorySpec{
+						Type: provisioning.GitHubRepositoryType,
+						GitHub: &provisioning.GitHubRepositoryConfig{
+							URL:    "https://github.com/org/repo",
+							Branch: "main",
+							Path:   "",
+						},
+					},
+				},
+			},
+			wantErr:         false,
+			maxRepositories: 10,
+		},
+		{
+			name: "allows overlapping paths on different branches",
+			cfg: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{Name: "new-repo", Namespace: "default"},
+				Spec: provisioning.RepositorySpec{
+					Type: provisioning.GitHubRepositoryType,
+					Sync: provisioning.SyncOptions{Enabled: true},
+					GitHub: &provisioning.GitHubRepositoryConfig{
+						URL:    "https://github.com/org/repo",
+						Branch: "develop",
+						Path:   "grafana/dashboards/",
+					},
+				},
+			},
+			existingRepos: []provisioning.Repository{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "existing-repo"},
+					Spec: provisioning.RepositorySpec{
+						Type: provisioning.GitHubRepositoryType,
+						GitHub: &provisioning.GitHubRepositoryConfig{
+							URL:    "https://github.com/org/repo",
+							Branch: "main",
+							Path:   "grafana/",
+						},
+					},
+				},
+			},
+			wantErr:         false,
+			maxRepositories: 10,
+		},
+		{
+			name: "forbids overlapping paths on same branch",
+			cfg: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{Name: "new-repo", Namespace: "default"},
+				Spec: provisioning.RepositorySpec{
+					Type: provisioning.GitHubRepositoryType,
+					Sync: provisioning.SyncOptions{Enabled: true},
+					GitHub: &provisioning.GitHubRepositoryConfig{
+						URL:    "https://github.com/org/repo",
+						Branch: "main",
+						Path:   "grafana/dashboards/",
+					},
+				},
+			},
+			existingRepos: []provisioning.Repository{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "existing-repo"},
+					Spec: provisioning.RepositorySpec{
+						Type: provisioning.GitHubRepositoryType,
+						GitHub: &provisioning.GitHubRepositoryConfig{
+							URL:    "https://github.com/org/repo",
+							Branch: "main",
+							Path:   "grafana/",
+						},
+					},
+				},
+			},
+			wantErr:         true,
+			wantErrContains: ErrRepositoryParentFolderConflict.Error(),
+			maxRepositories: 10,
+		},
+		{
+			name: "allows self-update with identical URL branch and path",
+			cfg: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{Name: "same-repo", Namespace: "default"},
+				Spec: provisioning.RepositorySpec{
+					Type: provisioning.GitHubRepositoryType,
+					Sync: provisioning.SyncOptions{Enabled: true},
+					GitHub: &provisioning.GitHubRepositoryConfig{
+						URL:    "https://github.com/org/repo",
+						Branch: "main",
+						Path:   "grafana/",
+					},
+				},
+			},
+			existingRepos: []provisioning.Repository{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "same-repo"},
+					Spec: provisioning.RepositorySpec{
+						Type: provisioning.GitHubRepositoryType,
+						GitHub: &provisioning.GitHubRepositoryConfig{
+							URL:    "https://github.com/org/repo",
+							Branch: "main",
+							Path:   "grafana/",
+						},
+					},
+				},
+			},
+			wantErr:         false,
+			maxRepositories: 10,
+		},
+		{
+			name: "allows duplicate local repository paths (not checked by git validator)",
+			cfg: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{Name: "new-local", Namespace: "default"},
+				Spec: provisioning.RepositorySpec{
+					Type: provisioning.LocalRepositoryType,
+					Sync: provisioning.SyncOptions{Enabled: true},
+					Local: &provisioning.LocalRepositoryConfig{
+						Path: "/data/grafana",
+					},
+				},
+			},
+			existingRepos: []provisioning.Repository{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "existing-local"},
+					Spec: provisioning.RepositorySpec{
+						Type: provisioning.LocalRepositoryType,
+						Local: &provisioning.LocalRepositoryConfig{
+							Path: "/data/grafana",
+						},
+					},
+				},
+			},
+			wantErr:         false,
+			maxRepositories: 10,
 		},
 		{
 			name: "forbids parent folder conflict when sync is enabled",

--- a/apps/provisioning/pkg/repository/verify_test.go
+++ b/apps/provisioning/pkg/repository/verify_test.go
@@ -128,15 +128,16 @@ func TestVerifyAgainstExistingRepositoriesValidator_Validate(t *testing.T) {
 			maxRepositories: 10,
 		},
 		{
-			name: "allows duplicate git path when sync is disabled",
+			name: "forbids duplicate git path when sync is disabled",
 			cfg: &provisioning.Repository{
 				ObjectMeta: metav1.ObjectMeta{Name: "new-repo", Namespace: "default"},
 				Spec: provisioning.RepositorySpec{
 					Type: provisioning.GitHubRepositoryType,
 					Sync: provisioning.SyncOptions{Enabled: false},
 					GitHub: &provisioning.GitHubRepositoryConfig{
-						URL:  "https://github.com/org/repo",
-						Path: "grafana/",
+						URL:    "https://github.com/org/repo",
+						Branch: "main",
+						Path:   "grafana/",
 					},
 				},
 			},
@@ -146,13 +147,75 @@ func TestVerifyAgainstExistingRepositoriesValidator_Validate(t *testing.T) {
 					Spec: provisioning.RepositorySpec{
 						Type: provisioning.GitHubRepositoryType,
 						GitHub: &provisioning.GitHubRepositoryConfig{
-							URL:  "https://github.com/org/repo",
-							Path: "grafana/",
+							URL:    "https://github.com/org/repo",
+							Branch: "main",
+							Path:   "grafana/",
+						},
+					},
+				},
+			},
+			wantErr:         true,
+			wantErrContains: ErrRepositoryDuplicatePath.Error(),
+			maxRepositories: 10,
+		},
+		{
+			name: "allows duplicate URL before branch is configured when sync is disabled",
+			cfg: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{Name: "new-repo", Namespace: "default"},
+				Spec: provisioning.RepositorySpec{
+					Type: provisioning.GitHubRepositoryType,
+					Sync: provisioning.SyncOptions{Enabled: false},
+					GitHub: &provisioning.GitHubRepositoryConfig{
+						URL:  "https://github.com/org/repo",
+						Path: "",
+					},
+				},
+			},
+			existingRepos: []provisioning.Repository{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "existing-repo"},
+					Spec: provisioning.RepositorySpec{
+						Type: provisioning.GitHubRepositoryType,
+						GitHub: &provisioning.GitHubRepositoryConfig{
+							URL:    "https://github.com/org/repo",
+							Branch: "main",
+							Path:   "",
 						},
 					},
 				},
 			},
 			wantErr:         false,
+			maxRepositories: 10,
+		},
+		{
+			name: "forbids duplicate normalized path when sync is disabled",
+			cfg: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{Name: "new-repo", Namespace: "default"},
+				Spec: provisioning.RepositorySpec{
+					Type: provisioning.GitHubRepositoryType,
+					Sync: provisioning.SyncOptions{Enabled: false},
+					GitHub: &provisioning.GitHubRepositoryConfig{
+						URL:    "https://github.com/org/repo",
+						Branch: "main",
+						Path:   "grafana/",
+					},
+				},
+			},
+			existingRepos: []provisioning.Repository{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "existing-repo"},
+					Spec: provisioning.RepositorySpec{
+						Type: provisioning.GitHubRepositoryType,
+						GitHub: &provisioning.GitHubRepositoryConfig{
+							URL:    "https://github.com/org/repo",
+							Branch: "main",
+							Path:   "grafana",
+						},
+					},
+				},
+			},
+			wantErr:         true,
+			wantErrContains: ErrRepositoryDuplicatePath.Error(),
 			maxRepositories: 10,
 		},
 		{
@@ -185,15 +248,16 @@ func TestVerifyAgainstExistingRepositoriesValidator_Validate(t *testing.T) {
 			maxRepositories: 10,
 		},
 		{
-			name: "allows duplicate empty paths when sync is disabled",
+			name: "forbids duplicate empty paths when sync is disabled",
 			cfg: &provisioning.Repository{
 				ObjectMeta: metav1.ObjectMeta{Name: "new-repo", Namespace: "default"},
 				Spec: provisioning.RepositorySpec{
 					Type: provisioning.GitHubRepositoryType,
 					Sync: provisioning.SyncOptions{Enabled: false},
 					GitHub: &provisioning.GitHubRepositoryConfig{
-						URL:  "https://github.com/org/repo",
-						Path: "",
+						URL:    "https://github.com/org/repo",
+						Branch: "main",
+						Path:   "",
 					},
 				},
 			},
@@ -203,13 +267,15 @@ func TestVerifyAgainstExistingRepositoriesValidator_Validate(t *testing.T) {
 					Spec: provisioning.RepositorySpec{
 						Type: provisioning.GitHubRepositoryType,
 						GitHub: &provisioning.GitHubRepositoryConfig{
-							URL:  "https://github.com/org/repo",
-							Path: "",
+							URL:    "https://github.com/org/repo",
+							Branch: "main",
+							Path:   "",
 						},
 					},
 				},
 			},
-			wantErr:         false,
+			wantErr:         true,
+			wantErrContains: ErrRepositoryDuplicatePath.Error(),
 			maxRepositories: 10,
 		},
 		{
@@ -384,6 +450,37 @@ func TestVerifyAgainstExistingRepositoriesValidator_Validate(t *testing.T) {
 							URL:    "https://github.com/org/repo",
 							Branch: "main",
 							Path:   "grafana/",
+						},
+					},
+				},
+			},
+			wantErr:         true,
+			wantErrContains: ErrRepositoryParentFolderConflict.Error(),
+			maxRepositories: 10,
+		},
+		{
+			name: "forbids overlapping base path on same branch when sync is enabled",
+			cfg: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{Name: "new-repo", Namespace: "default"},
+				Spec: provisioning.RepositorySpec{
+					Type: provisioning.GitHubRepositoryType,
+					Sync: provisioning.SyncOptions{Enabled: true},
+					GitHub: &provisioning.GitHubRepositoryConfig{
+						URL:    "https://github.com/org/repo",
+						Branch: "main",
+						Path:   "grafana/",
+					},
+				},
+			},
+			existingRepos: []provisioning.Repository{
+				{
+					ObjectMeta: metav1.ObjectMeta{Name: "existing-repo"},
+					Spec: provisioning.RepositorySpec{
+						Type: provisioning.GitHubRepositoryType,
+						GitHub: &provisioning.GitHubRepositoryConfig{
+							URL:    "https://github.com/org/repo",
+							Branch: "main",
+							Path:   "",
 						},
 					},
 				},

--- a/apps/provisioning/pkg/repository/verify_test.go
+++ b/apps/provisioning/pkg/repository/verify_test.go
@@ -187,37 +187,6 @@ func TestVerifyAgainstExistingRepositoriesValidator_Validate(t *testing.T) {
 			maxRepositories: 10,
 		},
 		{
-			name: "forbids duplicate normalized path when sync is enabled",
-			cfg: &provisioning.Repository{
-				ObjectMeta: metav1.ObjectMeta{Name: "new-repo", Namespace: "default"},
-				Spec: provisioning.RepositorySpec{
-					Type: provisioning.GitHubRepositoryType,
-					Sync: provisioning.SyncOptions{Enabled: true},
-					GitHub: &provisioning.GitHubRepositoryConfig{
-						URL:    "https://github.com/org/repo",
-						Branch: "main",
-						Path:   "grafana/",
-					},
-				},
-			},
-			existingRepos: []provisioning.Repository{
-				{
-					ObjectMeta: metav1.ObjectMeta{Name: "existing-repo"},
-					Spec: provisioning.RepositorySpec{
-						Type: provisioning.GitHubRepositoryType,
-						GitHub: &provisioning.GitHubRepositoryConfig{
-							URL:    "https://github.com/org/repo",
-							Branch: "main",
-							Path:   "grafana",
-						},
-					},
-				},
-			},
-			wantErr:         true,
-			wantErrContains: ErrRepositoryDuplicatePath.Error(),
-			maxRepositories: 10,
-		},
-		{
 			name: "forbids duplicate empty paths when sync is enabled",
 			cfg: &provisioning.Repository{
 				ObjectMeta: metav1.ObjectMeta{Name: "new-repo", Namespace: "default"},

--- a/apps/provisioning/pkg/repository/verify_test.go
+++ b/apps/provisioning/pkg/repository/verify_test.go
@@ -128,7 +128,7 @@ func TestVerifyAgainstExistingRepositoriesValidator_Validate(t *testing.T) {
 			maxRepositories: 10,
 		},
 		{
-			name: "forbids duplicate git path when sync is disabled",
+			name: "allows duplicate git path when sync is disabled",
 			cfg: &provisioning.Repository{
 				ObjectMeta: metav1.ObjectMeta{Name: "new-repo", Namespace: "default"},
 				Spec: provisioning.RepositorySpec{
@@ -154,8 +154,7 @@ func TestVerifyAgainstExistingRepositoriesValidator_Validate(t *testing.T) {
 					},
 				},
 			},
-			wantErr:         true,
-			wantErrContains: ErrRepositoryDuplicatePath.Error(),
+			wantErr:         false,
 			maxRepositories: 10,
 		},
 		{
@@ -188,12 +187,12 @@ func TestVerifyAgainstExistingRepositoriesValidator_Validate(t *testing.T) {
 			maxRepositories: 10,
 		},
 		{
-			name: "forbids duplicate normalized path when sync is disabled",
+			name: "forbids duplicate normalized path when sync is enabled",
 			cfg: &provisioning.Repository{
 				ObjectMeta: metav1.ObjectMeta{Name: "new-repo", Namespace: "default"},
 				Spec: provisioning.RepositorySpec{
 					Type: provisioning.GitHubRepositoryType,
-					Sync: provisioning.SyncOptions{Enabled: false},
+					Sync: provisioning.SyncOptions{Enabled: true},
 					GitHub: &provisioning.GitHubRepositoryConfig{
 						URL:    "https://github.com/org/repo",
 						Branch: "main",
@@ -248,7 +247,7 @@ func TestVerifyAgainstExistingRepositoriesValidator_Validate(t *testing.T) {
 			maxRepositories: 10,
 		},
 		{
-			name: "forbids duplicate empty paths when sync is disabled",
+			name: "allows duplicate empty paths when sync is disabled",
 			cfg: &provisioning.Repository{
 				ObjectMeta: metav1.ObjectMeta{Name: "new-repo", Namespace: "default"},
 				Spec: provisioning.RepositorySpec{
@@ -274,8 +273,7 @@ func TestVerifyAgainstExistingRepositoriesValidator_Validate(t *testing.T) {
 					},
 				},
 			},
-			wantErr:         true,
-			wantErrContains: ErrRepositoryDuplicatePath.Error(),
+			wantErr:         false,
 			maxRepositories: 10,
 		},
 		{

--- a/pkg/tests/apis/provisioning/repository/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository/repository_test.go
@@ -637,6 +637,163 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 		require.ErrorContains(t, err, provisioningAPIServer.ErrRepositoryParentFolderConflict.Error())
 	})
 
+	t.Run("Git repository branch-scoped path validation with sync enabled", func(t *testing.T) {
+		baseURL := "https://github.com/grafana/test-repo-branch-validation"
+
+		branchTests := []struct {
+			name        string
+			branch      string
+			path        string
+			expectError error
+		}{
+			{
+				name:        "first repo with branch main and path grafana should succeed",
+				branch:      "main",
+				path:        "grafana/",
+				expectError: nil,
+			},
+			{
+				name:        "second repo with branch develop and same path grafana should succeed",
+				branch:      "develop",
+				path:        "grafana/",
+				expectError: nil,
+			},
+			{
+				name:        "third repo with branch main and duplicate path grafana should fail",
+				branch:      "main",
+				path:        "grafana/",
+				expectError: provisioningAPIServer.ErrRepositoryDuplicatePath,
+			},
+			{
+				name:        "fourth repo with branch develop and child path should succeed",
+				branch:      "develop",
+				path:        "grafana/dashboards/",
+				expectError: nil,
+			},
+			{
+				name:        "fifth repo with branch main and child path should fail",
+				branch:      "main",
+				path:        "grafana/dashboards/",
+				expectError: provisioningAPIServer.ErrRepositoryParentFolderConflict,
+			},
+		}
+
+		for i, test := range branchTests {
+			t.Run(test.name, func(t *testing.T) {
+				repoName := fmt.Sprintf("git-branch-test-%d", i+1)
+				gitRepo := helper.RenderObject(t, common.TestdataPath("github.json.tmpl"), map[string]any{
+					"Name":          repoName,
+					"URL":           baseURL,
+					"Branch":        test.branch,
+					"Path":          test.path,
+					"SyncEnabled":   true,
+					"SyncTarget":    "folder",
+					"WorkflowsJSON": `[]`,
+				})
+
+				_, err := helper.Repositories.Resource.Create(ctx, gitRepo, metav1.CreateOptions{FieldValidation: "Strict"})
+
+				if test.expectError != nil {
+					require.Error(t, err, "Expected error for repo branch=%s path=%s", test.branch, test.path)
+					require.ErrorContains(t, err, test.expectError.Error(), "Error should contain expected message for branch=%s path=%s", test.branch, test.path)
+					var statusError *apierrors.StatusError
+					if errors.As(err, &statusError) {
+						require.Equal(t, metav1.StatusReasonInvalid, statusError.ErrStatus.Reason, "Should be a validation error")
+						require.Equal(t, http.StatusUnprocessableEntity, int(statusError.ErrStatus.Code), "Should return 422 status code")
+					}
+				} else {
+					require.NoError(t, err, "Expected success for repo branch=%s path=%s", test.branch, test.path)
+				}
+			})
+		}
+	})
+
+	t.Run("Git repository rejects duplicate empty paths on same branch when sync is enabled", func(t *testing.T) {
+		baseURL := "https://github.com/grafana/test-repo-empty-path-branch"
+
+		firstRepo := helper.RenderObject(t, common.TestdataPath("github.json.tmpl"), map[string]any{
+			"Name":          "git-empty-branch-1",
+			"URL":           baseURL,
+			"Branch":        "main",
+			"Path":          "",
+			"SyncEnabled":   true,
+			"SyncTarget":    "folder",
+			"WorkflowsJSON": `[]`,
+		})
+		_, err := helper.Repositories.Resource.Create(ctx, firstRepo, metav1.CreateOptions{FieldValidation: "Strict"})
+		require.NoError(t, err, "First repository with empty path should succeed")
+
+		secondRepo := helper.RenderObject(t, common.TestdataPath("github.json.tmpl"), map[string]any{
+			"Name":          "git-empty-branch-2",
+			"URL":           baseURL,
+			"Branch":        "main",
+			"Path":          "",
+			"SyncEnabled":   true,
+			"SyncTarget":    "folder",
+			"WorkflowsJSON": `[]`,
+		})
+		_, err = helper.Repositories.Resource.Create(ctx, secondRepo, metav1.CreateOptions{FieldValidation: "Strict"})
+		require.Error(t, err, "Second repository with same URL, branch, and empty path should fail")
+		require.ErrorContains(t, err, provisioningAPIServer.ErrRepositoryDuplicatePath.Error())
+		var statusError *apierrors.StatusError
+		if errors.As(err, &statusError) {
+			require.Equal(t, metav1.StatusReasonInvalid, statusError.ErrStatus.Reason, "Should be a validation error")
+			require.Equal(t, http.StatusUnprocessableEntity, int(statusError.ErrStatus.Code), "Should return 422 status code")
+		}
+
+		thirdRepo := helper.RenderObject(t, common.TestdataPath("github.json.tmpl"), map[string]any{
+			"Name":          "git-empty-branch-3",
+			"URL":           baseURL,
+			"Branch":        "develop",
+			"Path":          "",
+			"SyncEnabled":   true,
+			"SyncTarget":    "folder",
+			"WorkflowsJSON": `[]`,
+		})
+		_, err = helper.Repositories.Resource.Create(ctx, thirdRepo, metav1.CreateOptions{FieldValidation: "Strict"})
+		require.NoError(t, err, "Third repository with different branch and empty path should succeed")
+	})
+
+	t.Run("Git repository allows conflicting paths on different branches when sync is disabled", func(t *testing.T) {
+		baseURL := "https://github.com/grafana/test-repo-branch-sync-disabled"
+
+		firstRepo := helper.RenderObject(t, common.TestdataPath("github.json.tmpl"), map[string]any{
+			"Name":          "git-branch-disabled-1",
+			"URL":           baseURL,
+			"Branch":        "main",
+			"Path":          "demo/",
+			"SyncEnabled":   false,
+			"SyncTarget":    "folder",
+			"WorkflowsJSON": `[]`,
+		})
+		_, err := helper.Repositories.Resource.Create(ctx, firstRepo, metav1.CreateOptions{FieldValidation: "Strict"})
+		require.NoError(t, err, "First repository with sync disabled should succeed")
+
+		secondRepo := helper.RenderObject(t, common.TestdataPath("github.json.tmpl"), map[string]any{
+			"Name":          "git-branch-disabled-2",
+			"URL":           baseURL,
+			"Branch":        "main",
+			"Path":          "demo/",
+			"SyncEnabled":   false,
+			"SyncTarget":    "folder",
+			"WorkflowsJSON": `[]`,
+		})
+		_, err = helper.Repositories.Resource.Create(ctx, secondRepo, metav1.CreateOptions{FieldValidation: "Strict"})
+		require.NoError(t, err, "Second repository with duplicate path should succeed when sync is disabled")
+
+		thirdRepo := helper.RenderObject(t, common.TestdataPath("github.json.tmpl"), map[string]any{
+			"Name":          "git-branch-disabled-3",
+			"URL":           baseURL,
+			"Branch":        "develop",
+			"Path":          "demo/",
+			"SyncEnabled":   false,
+			"SyncTarget":    "folder",
+			"WorkflowsJSON": `[]`,
+		})
+		_, err = helper.Repositories.Resource.Create(ctx, thirdRepo, metav1.CreateOptions{FieldValidation: "Strict"})
+		require.NoError(t, err, "Third repository with different branch should succeed when sync is disabled")
+	})
+
 	t.Run("should update sync interval", func(t *testing.T) {
 		r := helper.RenderObject(t, common.TestdataPath("local.json.tmpl"), map[string]any{
 			"Name":                "valid-repo-testinterval",

--- a/pkg/tests/apis/provisioning/repository/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository/repository_test.go
@@ -754,7 +754,7 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 		require.NoError(t, err, "Third repository with different branch and empty path should succeed")
 	})
 
-	t.Run("Git repository allows conflicting paths on different branches when sync is disabled", func(t *testing.T) {
+	t.Run("Git repository rejects exact duplicates but allows overlaps when sync is disabled", func(t *testing.T) {
 		baseURL := "https://github.com/grafana/test-repo-branch-sync-disabled"
 
 		firstRepo := helper.RenderObject(t, common.TestdataPath("github.json.tmpl"), map[string]any{
@@ -779,7 +779,8 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 			"WorkflowsJSON": `[]`,
 		})
 		_, err = helper.Repositories.Resource.Create(ctx, secondRepo, metav1.CreateOptions{FieldValidation: "Strict"})
-		require.NoError(t, err, "Second repository with duplicate path should succeed when sync is disabled")
+		require.Error(t, err, "Second repository with duplicate path should fail even when sync is disabled")
+		require.ErrorContains(t, err, provisioningAPIServer.ErrRepositoryDuplicatePath.Error())
 
 		thirdRepo := helper.RenderObject(t, common.TestdataPath("github.json.tmpl"), map[string]any{
 			"Name":          "git-branch-disabled-3",
@@ -792,6 +793,18 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 		})
 		_, err = helper.Repositories.Resource.Create(ctx, thirdRepo, metav1.CreateOptions{FieldValidation: "Strict"})
 		require.NoError(t, err, "Third repository with different branch should succeed when sync is disabled")
+
+		fourthRepo := helper.RenderObject(t, common.TestdataPath("github.json.tmpl"), map[string]any{
+			"Name":          "git-branch-disabled-4",
+			"URL":           baseURL,
+			"Branch":        "main",
+			"Path":          "demo/dashboards/",
+			"SyncEnabled":   false,
+			"SyncTarget":    "folder",
+			"WorkflowsJSON": `[]`,
+		})
+		_, err = helper.Repositories.Resource.Create(ctx, fourthRepo, metav1.CreateOptions{FieldValidation: "Strict"})
+		require.NoError(t, err, "Fourth repository with parent-child path should succeed when sync is disabled")
 	})
 
 	t.Run("should update sync interval", func(t *testing.T) {

--- a/pkg/tests/apis/provisioning/repository/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository/repository_test.go
@@ -665,10 +665,10 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 				expectError: provisioningAPIServer.ErrRepositoryDuplicatePath,
 			},
 			{
-				name:        "fourth repo with branch develop and child path should succeed",
+				name:        "fourth repo with branch develop and child path should fail",
 				branch:      "develop",
 				path:        "grafana/dashboards/",
-				expectError: nil,
+				expectError: provisioningAPIServer.ErrRepositoryParentFolderConflict,
 			},
 			{
 				name:        "fifth repo with branch main and child path should fail",

--- a/pkg/tests/apis/provisioning/repository/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository/repository_test.go
@@ -754,7 +754,7 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 		require.NoError(t, err, "Third repository with different branch and empty path should succeed")
 	})
 
-	t.Run("Git repository rejects exact duplicates but allows overlaps when sync is disabled", func(t *testing.T) {
+	t.Run("Git repository allows conflicting paths when sync is disabled", func(t *testing.T) {
 		baseURL := "https://github.com/grafana/test-repo-branch-sync-disabled"
 
 		firstRepo := helper.RenderObject(t, common.TestdataPath("github.json.tmpl"), map[string]any{
@@ -779,8 +779,7 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 			"WorkflowsJSON": `[]`,
 		})
 		_, err = helper.Repositories.Resource.Create(ctx, secondRepo, metav1.CreateOptions{FieldValidation: "Strict"})
-		require.Error(t, err, "Second repository with duplicate path should fail even when sync is disabled")
-		require.ErrorContains(t, err, provisioningAPIServer.ErrRepositoryDuplicatePath.Error())
+		require.NoError(t, err, "Second repository with duplicate path should succeed when sync is disabled")
 
 		thirdRepo := helper.RenderObject(t, common.TestdataPath("github.json.tmpl"), map[string]any{
 			"Name":          "git-branch-disabled-3",

--- a/pkg/tests/apis/provisioning/repository/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository/repository_test.go
@@ -1951,9 +1951,10 @@ func TestIntegrationProvisioning_EmptyPath(t *testing.T) {
 		// Clean up
 		err = helper.Repositories.Resource.Delete(ctx, repo, metav1.DeleteOptions{})
 		require.NoError(t, err)
+		helper.WaitForRepositoryDeleted(t, ctx, repo)
 	})
 
-	t.Run("multiple repositories with empty path - creation succeeds but sync warns on ownership conflicts", func(t *testing.T) {
+	t.Run("multiple repositories with empty path - duplicate sync-enabled root path is rejected", func(t *testing.T) {
 		const repo1 = "empty-path-repo-1"
 		const repo2 = "empty-path-repo-2"
 
@@ -1968,57 +1969,28 @@ func TestIntegrationProvisioning_EmptyPath(t *testing.T) {
 		}
 		helper.CreateLocalRepo(t, testRepo1)
 
-		// Step 2: Create second repository with same empty path
-		// Creation should succeed (no duplicate path validation error)
-		// but sync should warn because dashboards are owned by repo1
-		testRepo2 := common.TestRepo{
-			Name:                   repo2,
-			Template:               common.TestdataPath("github.json.tmpl"),
-			SyncTarget:             "folder",
-			Workflows:              []string{},
-			SkipResourceAssertions: true, // Skip because we can't easily count per-repo resources
-		}
-		helper.CreateLocalRepo(t, testRepo2)
+		// Step 2: Create second repository with same URL, branch, and empty path.
+		// Empty path represents the repository root, so this is a duplicate path.
+		secondRepo := helper.RenderObject(t, common.TestdataPath("github.json.tmpl"), map[string]any{
+			"Name":          repo2,
+			"SyncEnabled":   true,
+			"SyncTarget":    "folder",
+			"WorkflowsJSON": `[]`,
+		})
+		_, err := helper.Repositories.Resource.Create(ctx, secondRepo, metav1.CreateOptions{})
+		require.Error(t, err, "Second repository with same URL, branch, and empty path should fail")
+		require.ErrorContains(t, err, provisioningAPIServer.ErrRepositoryDuplicatePath.Error())
 
-		// Verify both repositories have empty paths
+		// Verify first repository has empty path
 		repo1Obj, err := helper.Repositories.Resource.Get(ctx, repo1, metav1.GetOptions{})
 		require.NoError(t, err)
 		path1, _, _ := unstructured.NestedString(repo1Obj.Object, "spec", "github", "path")
 		require.Equal(t, "", path1, "repo1 should have empty path")
 
-		repo2Obj, err := helper.Repositories.Resource.Get(ctx, repo2, metav1.GetOptions{})
-		require.NoError(t, err)
-		path2, _, _ := unstructured.NestedString(repo2Obj.Object, "spec", "github", "path")
-		require.Equal(t, "", path2, "repo2 should have empty path")
-
-		// Verify repo2 sync completed with warning state (ownership conflicts)
-		syncState, _, _ := unstructured.NestedString(repo2Obj.Object, "status", "sync", "state")
-		require.Equal(t, "warning", syncState, "repo2 sync should complete with warning state due to ownership conflicts")
-
-		// Verify global resource counts:
-		// - Folders: 12 total (6 from repo1 + 6 from repo2) - folders are duplicated per repository
-		// - Dashboards: 3 total (only from repo1) - repo2's dashboards fail with ownership conflicts
-		// Poll because repo2's sync job can return before the folder/dashboard
-		// list endpoints have observed all of the newly-created resources.
-		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			dashboards, err := helper.DashboardsV1.Resource.List(ctx, metav1.ListOptions{})
-			if !assert.NoError(collect, err) {
-				return
-			}
-			assert.Len(collect, dashboards.Items, 3, "should have 3 dashboards (only from repo1)")
-
-			folders, err := helper.Folders.Resource.List(ctx, metav1.ListOptions{})
-			if !assert.NoError(collect, err) {
-				return
-			}
-			assert.Len(collect, folders.Items, 12, "should have 12 folders (6 from repo1 + 6 from repo2)")
-		}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "should observe all dashboards and folders after both repos sync")
-
 		// Clean up
 		err = helper.Repositories.Resource.Delete(ctx, repo1, metav1.DeleteOptions{})
 		require.NoError(t, err)
-		err = helper.Repositories.Resource.Delete(ctx, repo2, metav1.DeleteOptions{})
-		require.NoError(t, err)
+		helper.WaitForRepositoryDeleted(t, ctx, repo1)
 	})
 }
 


### PR DESCRIPTION
## Summary

- Scope repository uniqueness by `(URL, branch, path)` when repository sync is enabled.
- Treat empty path as repository root.
- Keep duplicate and parent/child path conflict checks behind `sync.enabled` to preserve onboarding behavior.

## Problem

The `VerifyAgainstExistingRepositoriesValidator` had related edge cases:

1. Empty path (`""`) means repository root, but duplicate empty paths could pass as non-duplicates.
2. Branch was not part of the identity key, so same URL/path on different branches could be rejected incorrectly.

## Changes

### `apps/provisioning/pkg/repository/verify.go`
- Keep git repository path conflict validation behind `cfg.Spec.Sync.Enabled`.
- Compare repositories by URL and branch before checking path conflicts.
- Reject exact duplicate paths when sync is enabled.
- Keep parent/child path conflict checks when sync is enabled.

### `apps/provisioning/pkg/repository/verify_test.go`
- Cover sync-disabled onboarding behavior: duplicate and overlapping paths are allowed while sync is disabled.
- Cover empty path as repository root.
- Cover branch-scoped duplicate and overlap behavior.

### `pkg/tests/apis/provisioning/repository/repository_test.go`
- Add integration coverage for branch-scoped path validation.
- Add integration coverage for duplicate empty root paths.
- Keep sync-disabled integration coverage confirming conflicting paths are allowed until sync is enabled.

## Invariants preserved

- Wizard/onboarding flow: `sync.enabled=false` skips cross-repo path conflict checks.
- Self-update: `cfg.Name == v.Name` skip remains unchanged.
- Error shape: `ErrRepositoryDuplicatePath` and `ErrRepositoryParentFolderConflict` still use field path `spec.<type>.path`.
- Different branches can use the same URL/path.
- Local repositories are not checked by this git-specific validator.

## Test plan

- [x] `go test ./apps/provisioning/pkg/repository -run '^TestVerifyAgainstExistingRepositoriesValidator_Validate$'`
- [x] `go test -tags enterprise ./pkg/tests/apis/provisioning/repository -run '^TestIntegrationProvisioning_RepositoryValidation/Git_repository_allows_conflicting_paths_when_sync_is_disabled$'`
- [ ] `go test -tags enterprise ./pkg/tests/apis/provisioning/repository/... -run TestIntegrationProvisioning_RepositoryValidation`

Closes https://github.com/grafana/git-ui-sync-project/issues/1080
Closes https://github.com/grafana/git-ui-sync-project/issues/1081
Closes https://github.com/grafana/grafana/issues/122744
