### PR TITLE
Provisioning: Enrich worker logs and fix finalizer version field duplication

### DIFF
--- a/pkg/registry/apis/provisioning/controller/connection.go
+++ b/pkg/registry/apis/provisioning/controller/connection.go
@@ -127,8 +127,9 @@ func (cc *ConnectionController) Run(ctx context.Context, workerCount int, onStar
 	defer logger.Info("Shutting down ConnectionController")
 
 	logger.Info("Starting workers", "count", workerCount)
-	for range workerCount {
-		go wait.UntilWithContext(ctx, cc.runWorker, time.Second)
+	for i := range workerCount {
+		workerCtx := logging.Context(ctx, logger.With("worker_id", i))
+		go wait.UntilWithContext(workerCtx, cc.runWorker, time.Second)
 	}
 
 	logger.Info("Started workers")

--- a/pkg/registry/apis/provisioning/controller/finalizers.go
+++ b/pkg/registry/apis/provisioning/controller/finalizers.go
@@ -102,9 +102,10 @@ func (f *finalizer) newItemProcessor(
 	clients resources.ResourceClients,
 	cb func(client dynamic.ResourceInterface, item *provisioning.ResourceListItem) error,
 ) itemProcessor {
-	logger := logging.FromContext(ctx)
+	baseLogger := logging.FromContext(ctx)
 	return func(jobCtx context.Context, item *provisioning.ResourceListItem) error {
 		// If the item is a folder, use the configured folder API version.
+		logger := baseLogger
 		var version string
 		if item.Group == resources.FolderResource.Group && item.Resource == resources.FolderResource.Resource {
 			version = f.folderAPIVersion

--- a/pkg/registry/apis/provisioning/controller/repository.go
+++ b/pkg/registry/apis/provisioning/controller/repository.go
@@ -194,7 +194,8 @@ func (rc *RepositoryController) Run(ctx context.Context, workerCount int, onStar
 
 	logger.Info("Starting workers", "count", workerCount)
 	for i := 0; i < workerCount; i++ {
-		go wait.UntilWithContext(ctx, rc.runWorker, time.Second)
+		workerCtx := logging.Context(ctx, logger.With("worker_id", i))
+		go wait.UntilWithContext(workerCtx, rc.runWorker, time.Second)
 	}
 
 	logger.Info("Started workers")


### PR DESCRIPTION
## Summary

Two small logging fixes in the provisioning controllers.

### 1. Attach `worker_id` to per-worker logger context

`RepositoryController.Run` and `ConnectionController.Run` spawn N goroutines that all share the same logger context, so logs from `runWorker` / `processNextWorkItem` / `processFn` don't indicate which worker handled a given queue item. This change wraps the context per goroutine with `logging.Context(ctx, logger.With(\"worker_id\", i))` so every log line downstream carries the worker index. The third provisioning controller, `ConcurrentJobDriver`, already logs `driver_id` using the same pattern.

### 2. Fix duplicated `version=v1beta1` fields in finalizer logs

`finalizer.newItemProcessor` closed over a `logger` variable from its outer scope and reassigned it on every folder item via `logger = logger.With(\"version\", version)`. Each subsequent invocation appended another `version` field, producing error lines like:

```
msg=\"error processing item\" ... version=v1beta1 version=v1beta1 version=v1beta1 ...
```

Because `processResourceItems` runs this closure from multiple goroutines, the shared reassignment was also a data race. The fix copies the base logger into a local per-invocation variable.

## Test plan

- [ ] `go build ./pkg/registry/apis/provisioning/controller/`
- [ ] `go vet ./pkg/registry/apis/provisioning/controller/`
- [ ] `go test -run TestFinalizer ./pkg/registry/apis/provisioning/controller/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)