### PR TITLE
feat(mutation-api): variable UI pilot - route editor through Mutation API

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -379,6 +379,11 @@ export interface FeatureToggles {
   */
   dashboardUndoRedo?: boolean;
   /**
+  * Routes variable editor add/update/delete through the Dashboard Mutation API instead of direct Scenes mutations
+  * @default false
+  */
+  dashboardMutationApiVariablePilot?: boolean;
+  /**
   * Enables unlimited dashboard panel grouping
   * @default false
   */

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -661,6 +661,14 @@ var (
 			Expression:  "false",
 		},
 		{
+			Name:        "dashboardMutationApiVariablePilot",
+			Description: "Routes variable editor add/update/delete through the Dashboard Mutation API instead of direct Scenes mutations",
+			Stage:       FeatureStageExperimental,
+			Generate:    Generate{LegacyFrontend: true},
+			Owner:       grafanaDashboardsSquad,
+			Expression:  "false",
+		},
+		{
 			Name:        "unlimitedLayoutsNesting",
 			Description: "Enables unlimited dashboard panel grouping",
 			Stage:       FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -75,6 +75,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-03-19,dashboardDefaultLayoutSelector,GA,@grafana/dashboards-squad,false,false,true
 2026-03-10,dashboardAssistantPopover,experimental,@grafana/dashboards-squad,false,false,true
 2025-08-29,dashboardUndoRedo,experimental,@grafana/dashboards-squad,false,false,true
+2026-04-28,dashboardMutationApiVariablePilot,experimental,@grafana/dashboards-squad,false,false,true
 2025-10-10,unlimitedLayoutsNesting,experimental,@grafana/dashboards-squad,false,false,true
 2026-02-11,sceneCsvExport,GA,@grafana/dashboards-squad,false,false,false
 2025-12-17,drilldownRecommendations,experimental,@grafana/dashboards-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -235,10 +235,6 @@ const (
 	// Enables new dashboard layouts
 	FlagDashboardNewLayouts = "dashboardNewLayouts"
 
-	// FlagDashboardMutationApiVariablePilot
-	// Routes variable editor add/update/delete through the Dashboard Mutation API instead of direct Scenes mutations
-	FlagDashboardMutationApiVariablePilot = "dashboardMutationApiVariablePilot"
-
 	// FlagSceneCsvExport
 	// Enables CSV export using scenes dashboard architecture
 	FlagSceneCsvExport = "sceneCsvExport"

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -235,6 +235,10 @@ const (
 	// Enables new dashboard layouts
 	FlagDashboardNewLayouts = "dashboardNewLayouts"
 
+	// FlagDashboardMutationApiVariablePilot
+	// Routes variable editor add/update/delete through the Dashboard Mutation API instead of direct Scenes mutations
+	FlagDashboardMutationApiVariablePilot = "dashboardMutationApiVariablePilot"
+
 	// FlagSceneCsvExport
 	// Enables CSV export using scenes dashboard architecture
 	FlagSceneCsvExport = "sceneCsvExport"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1578,6 +1578,20 @@
     },
     {
       "metadata": {
+        "name": "dashboardMutationApiVariablePilot",
+        "resourceVersion": "1777379752461",
+        "creationTimestamp": "2026-04-28T12:35:52Z"
+      },
+      "spec": {
+        "description": "Routes variable editor add/update/delete through the Dashboard Mutation API instead of direct Scenes mutations",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "dashboardNewLayouts",
         "resourceVersion": "1775209187023",
         "creationTimestamp": "2024-10-23T08:55:45Z",

--- a/public/app/features/dashboard-scene/edit-pane/shared.ts
+++ b/public/app/features/dashboard-scene/edit-pane/shared.ts
@@ -14,6 +14,7 @@ import {
 } from '@grafana/scenes';
 import { type ElementSelectionContextItem } from '@grafana/ui';
 
+import { cmd } from '../mutation-api/cmd';
 import { DashboardDataLayerSet } from '../scene/DashboardDataLayerSet';
 import { DashboardScene } from '../scene/DashboardScene';
 import { SceneGridRowEditableElement } from '../scene/layout-default/SceneGridRowEditableElement';
@@ -26,6 +27,7 @@ import { LocalVariableEditableElement } from '../settings/variables/LocalVariabl
 import { VariableEditableElement } from '../settings/variables/VariableEditableElement';
 import { VariableSetEditableElement } from '../settings/variables/VariableSetEditableElement';
 import { isSceneVariable } from '../settings/variables/utils';
+import { getDashboardSceneFor } from '../utils/utils';
 
 import { type DashboardEditPane } from './DashboardEditPane';
 import { MultiSelectedObjectsEditableElement } from './MultiSelectedObjectsEditableElement';
@@ -250,32 +252,14 @@ export const dashboardEditActions = {
   }),
 
   addVariable({ source, addedObject }: AddVariableActionHelperProps) {
-    const varsBeforeAddition = [...(source.state.variables ?? [])];
-
-    dashboardEditActions.addElement({
-      source,
-      addedObject,
-      perform() {
-        source.setState({ variables: [...varsBeforeAddition, addedObject] });
-      },
-      undo() {
-        source.setState({ variables: [...varsBeforeAddition] });
-      },
-    });
+    const dashboard = getDashboardSceneFor(source);
+    // UI path: SceneVariable goes through the Scenes-native overload of cmd.addVariable.
+    // The Mutation API routes it via __scenesPayload, no Zod, snapshot undo registered automatically.
+    dashboard.mutationClient.execute(cmd.addVariable(addedObject));
   },
   removeVariable({ source, removedObject }: RemoveVariableActionHelperProps) {
-    const varsBeforeRemoval = [...source.state.variables];
-
-    dashboardEditActions.removeElement({
-      source,
-      removedObject,
-      perform() {
-        source.setState({ variables: varsBeforeRemoval.filter((v) => v !== removedObject) });
-      },
-      undo() {
-        source.setState({ variables: varsBeforeRemoval });
-      },
-    });
+    const dashboard = getDashboardSceneFor(source);
+    dashboard.mutationClient.execute(cmd.removeVariable(removedObject));
   },
   changeVariableType({ source, oldVariable, newVariable }: ChangeVariableTypeActionHelperProps) {
     const varsBeforeChange = [...source.state.variables];

--- a/public/app/features/dashboard-scene/edit-pane/shared.ts
+++ b/public/app/features/dashboard-scene/edit-pane/shared.ts
@@ -255,11 +255,20 @@ export const dashboardEditActions = {
     const dashboard = getDashboardSceneFor(source);
     // UI path: SceneVariable goes through the Scenes-native overload of cmd.addVariable.
     // The Mutation API routes it via __scenesPayload, no Zod, snapshot undo registered automatically.
-    dashboard.mutationClient.execute(cmd.addVariable(addedObject));
+    dashboard.mutationClient.execute(cmd.addVariable(addedObject)).then((result) => {
+      if (!result.success) {
+        // TODO(POC): surface to UI as toast/banner. For now, log so the failure isn't silent.
+        console.warn('addVariable failed', { error: result.error, locked: result.locked });
+      }
+    });
   },
   removeVariable({ source, removedObject }: RemoveVariableActionHelperProps) {
     const dashboard = getDashboardSceneFor(source);
-    dashboard.mutationClient.execute(cmd.removeVariable(removedObject));
+    dashboard.mutationClient.execute(cmd.removeVariable(removedObject)).then((result) => {
+      if (!result.success) {
+        console.warn('removeVariable failed', { error: result.error, locked: result.locked });
+      }
+    });
   },
   changeVariableType({ source, oldVariable, newVariable }: ChangeVariableTypeActionHelperProps) {
     const varsBeforeChange = [...source.state.variables];

--- a/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
+++ b/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
@@ -63,55 +63,47 @@ export class DashboardMutationClient implements MutationClient {
 
     const context: MutationContext = { scene: this.scene };
 
+    // Snapshot variable state before the mutation for undo/redo wiring.
+    // This follows the same snapshot pattern used by dashboardEditActions in shared.ts.
+    const varsBefore = this.scene.state.$variables?.state.variables.slice() ?? [];
+    const varSetBefore = this.scene.state.$variables;
+
     try {
       const result = await registration.handler(payload, context);
 
       if (result.success && !registration.readOnly) {
         this.scene.forceRender();
+
+        // Wire into the DashboardEditPane undo/redo history system when the variable
+        // set changed. Mutation was already applied inside the handler, so perform()
+        // skips its first call and re-applies on subsequent redo calls.
+        const varSetAfter = this.scene.state.$variables;
+        if (varSetAfter !== varSetBefore && typeof this.scene.publishEvent === 'function') {
+          const varsAfter = varSetAfter!.state.variables.slice();
+          const scene = this.scene;
+          let alreadyPerformed = true;
+
+          this.scene.publishEvent(
+            new DashboardEditActionEvent({
+              source: this.scene,
+              description: type,
+              perform() {
+                if (alreadyPerformed) {
+                  alreadyPerformed = false;
+                  return;
+                }
+                scene.state.$variables?.setState({ variables: varsAfter });
+              },
+              undo() {
+                scene.state.$variables?.setState({ variables: varsBefore });
+              },
+            }),
+            true
+          );
+        }
       }
 
-      // Wire undo/redo into the DashboardEditPane event system when the command
-      // provides an _undo callback. The mutation has already been applied at this
-      // point, so perform() is a no-op for the initial registration. The DashboardEditPane
-      // handleEditAction calls perform() immediately then pushes to undoStack.
-      // When redo is invoked, performAction calls perform() again -- at that point
-      // the _undo has already restored the previous state, so perform() must
-      // re-apply the mutation. We capture the current variables state here to
-      // use as the "redo" snapshot (state after the mutation).
-      if (result.success && result._undo && typeof this.scene.publishEvent === 'function') {
-        const undoFn = result._undo;
-        const description = result._description ?? mutation.type;
-        // Capture the post-mutation variable state for redo.
-        const varSet = this.scene.state.$variables;
-        const variablesAfterMutation = varSet ? varSet.state.variables.slice() : [];
-        const scene = this.scene;
-
-        let alreadyPerformed = true;
-
-        this.scene.publishEvent(
-          new DashboardEditActionEvent({
-            source: this.scene,
-            description,
-            perform: () => {
-              // First call is a no-op because mutation was already applied.
-              if (alreadyPerformed) {
-                alreadyPerformed = false;
-                return;
-              }
-              // Subsequent calls (redo): restore the post-mutation state.
-              if (scene.state.$variables) {
-                scene.state.$variables.setState({ variables: variablesAfterMutation });
-              }
-            },
-            undo: undoFn,
-          }),
-          true
-        );
-      }
-
-      // Strip internal fields before returning to callers.
-      const { _undo: _u, _description: _d, ...publicResult } = result;
-      return publicResult;
+      return result;
     } catch (error) {
       return {
         success: false,

--- a/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
+++ b/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
@@ -52,14 +52,19 @@ export class DashboardMutationClient implements MutationClient {
       return { success: false, error: permissionResult.error, changes: [] };
     }
 
-    const validationResult = validatePayload(type, mutation.payload);
-    if (!validationResult.success) {
-      return { success: false, error: validationResult.error, changes: [] };
+    let payload: unknown;
+    if ('__scenesPayload' in mutation) {
+      // UI path: SceneObject passed directly — skip Zod validation and forward transformer.
+      payload = { __scenesPayload: mutation.__scenesPayload };
+    } else {
+      const validationResult = validatePayload(type, mutation.payload);
+      if (!validationResult.success) {
+        return { success: false, error: validationResult.error, changes: [] };
+      }
+      // Zod may return frozen or shared default objects. Deep-clone write payloads
+      // so downstream code (e.g. getPanelOptionsWithDefaults) can mutate in-place.
+      payload = registration.readOnly ? validationResult.data : structuredClone(validationResult.data);
     }
-
-    // Zod may return frozen or shared default objects. Deep-clone write payloads
-    // so downstream code (e.g. getPanelOptionsWithDefaults) can mutate in-place.
-    const payload = registration.readOnly ? validationResult.data : structuredClone(validationResult.data);
 
     const context: MutationContext = { scene: this.scene };
 

--- a/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
+++ b/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
@@ -18,6 +18,7 @@ import type { DashboardScene } from '../scene/DashboardScene';
 
 import { ALL_COMMANDS, validatePayload } from './commands/registry';
 import type { MutationCommand, MutationContext } from './commands/types';
+import { replaceVariableSet } from './commands/variableUtils';
 import type { MutationClient, MutationRequest, MutationResult } from './types';
 
 type MutationHandler = (payload: unknown, context: MutationContext) => Promise<MutationResult>;
@@ -68,10 +69,11 @@ export class DashboardMutationClient implements MutationClient {
 
     const context: MutationContext = { scene: this.scene };
 
-    // Snapshot variable state before the mutation for undo/redo wiring.
-    // This follows the same snapshot pattern used by dashboardEditActions in shared.ts.
-    const varsBefore = this.scene.state.$variables?.state.variables.slice() ?? [];
+    // Capture the variable set reference and variable array before the handler runs.
+    // replaceVariableSet (used by all variable commands) always creates a new
+    // SceneVariableSet instance, so identity comparison detects any variable mutation.
     const varSetBefore = this.scene.state.$variables;
+    const varsBefore = varSetBefore?.state.variables.slice() ?? [];
 
     try {
       const result = await registration.handler(payload, context);
@@ -79,28 +81,29 @@ export class DashboardMutationClient implements MutationClient {
       if (result.success && !registration.readOnly) {
         this.scene.forceRender();
 
-        // Wire into the DashboardEditPane undo/redo history system when the variable
-        // set changed. Mutation was already applied inside the handler, so perform()
-        // skips its first call and re-applies on subsequent redo calls.
+        // Register undo/redo when the variable set was replaced by the handler.
+        // Both callbacks use replaceVariableSet to ensure proper SceneVariableSet
+        // lifecycle (child variable activation) on each undo/redo cycle.
         const varSetAfter = this.scene.state.$variables;
         if (varSetAfter !== varSetBefore && typeof this.scene.publishEvent === 'function') {
           const varsAfter = varSetAfter!.state.variables.slice();
           const scene = this.scene;
-          let alreadyPerformed = true;
+          // The mutation is already applied; skip the first perform() call from handleEditAction.
+          let firstPerform = true;
 
           this.scene.publishEvent(
             new DashboardEditActionEvent({
               source: this.scene,
               description: type,
               perform() {
-                if (alreadyPerformed) {
-                  alreadyPerformed = false;
+                if (firstPerform) {
+                  firstPerform = false;
                   return;
                 }
-                scene.state.$variables?.setState({ variables: varsAfter });
+                replaceVariableSet(scene, varsAfter);
               },
               undo() {
-                scene.state.$variables?.setState({ variables: varsBefore });
+                replaceVariableSet(scene, varsBefore);
               },
             }),
             true

--- a/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
+++ b/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
@@ -13,11 +13,13 @@
  * 3. Payload validation (does the payload match the Zod schema?)
  */
 
+import { type SceneVariable } from '@grafana/scenes';
+
 import { DashboardEditActionEvent } from '../edit-pane/events';
 import type { DashboardScene } from '../scene/DashboardScene';
 
 import { ALL_COMMANDS, validatePayload } from './commands/registry';
-import type { MutationCommand, MutationContext } from './commands/types';
+import type { MutationCommand, MutationContext, UndoDomain } from './commands/types';
 import { replaceVariableSet } from './commands/variableUtils';
 import type { MutationClient, MutationRequest, MutationResult } from './types';
 
@@ -27,6 +29,7 @@ interface CommandRegistration {
   handler: MutationHandler;
   canExecute: (scene: DashboardScene) => { allowed: true } | { allowed: false; error: string };
   readOnly: boolean;
+  undoDomain?: UndoDomain;
 }
 
 export class DashboardMutationClient implements MutationClient {
@@ -69,11 +72,9 @@ export class DashboardMutationClient implements MutationClient {
 
     const context: MutationContext = { scene: this.scene };
 
-    // Capture the variable set reference and variable array before the handler runs.
-    // replaceVariableSet (used by all variable commands) always creates a new
-    // SceneVariableSet instance, so identity comparison detects any variable mutation.
-    const varSetBefore = this.scene.state.$variables;
-    const varsBefore = varSetBefore?.state.variables.slice() ?? [];
+    // Snapshot the declared domain before the handler runs.
+    const { undoDomain } = registration;
+    const beforeSnapshot = undoDomain ? this.snapshotDomain(undoDomain) : undefined;
 
     try {
       const result = await registration.handler(payload, context);
@@ -81,30 +82,25 @@ export class DashboardMutationClient implements MutationClient {
       if (result.success && !registration.readOnly) {
         this.scene.forceRender();
 
-        // Register undo/redo when the variable set was replaced by the handler.
-        // Both callbacks use replaceVariableSet to ensure proper SceneVariableSet
-        // lifecycle (child variable activation) on each undo/redo cycle.
-        const varSetAfter = this.scene.state.$variables;
-        if (varSetAfter !== varSetBefore && typeof this.scene.publishEvent === 'function') {
-          const varsAfter = varSetAfter!.state.variables.slice();
-          const scene = this.scene;
-          // The mutation is already applied; skip the first perform() call from handleEditAction.
+        // Register undo/redo entry when the command declared a snapshot domain.
+        // perform() is called immediately by DashboardEditPane.handleEditAction —
+        // the mutation is already applied so we skip that first call.
+        if (undoDomain && beforeSnapshot && typeof this.scene.publishEvent === 'function') {
+          const afterSnapshot = this.snapshotDomain(undoDomain);
           let firstPerform = true;
 
           this.scene.publishEvent(
             new DashboardEditActionEvent({
               source: this.scene,
               description: type,
-              perform() {
+              perform: () => {
                 if (firstPerform) {
                   firstPerform = false;
                   return;
                 }
-                replaceVariableSet(scene, varsAfter);
+                this.restoreDomain(undoDomain, afterSnapshot);
               },
-              undo() {
-                replaceVariableSet(scene, varsBefore);
-              },
+              undo: () => this.restoreDomain(undoDomain, beforeSnapshot),
             }),
             true
           );
@@ -125,12 +121,26 @@ export class DashboardMutationClient implements MutationClient {
     return Array.from(this.commands.keys());
   }
 
+  private snapshotDomain(domain: UndoDomain): SceneVariable[] {
+    if (domain === 'variables') {
+      return this.scene.state.$variables?.state.variables.slice() ?? [];
+    }
+    return [];
+  }
+
+  private restoreDomain(domain: UndoDomain, snapshot: SceneVariable[]): void {
+    if (domain === 'variables') {
+      replaceVariableSet(this.scene, snapshot);
+    }
+  }
+
   private registerCommand(cmd: MutationCommand): void {
     this.commands.set(cmd.name, {
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- safe: client validates with Zod before dispatch
       handler: cmd.handler as MutationHandler,
       canExecute: cmd.permission,
       readOnly: cmd.readOnly ?? false,
+      undoDomain: cmd.undoDomain,
     });
   }
 }

--- a/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
+++ b/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
@@ -13,6 +13,7 @@
  * 3. Payload validation (does the payload match the Zod schema?)
  */
 
+import { DashboardEditActionEvent } from '../edit-pane/events';
 import type { DashboardScene } from '../scene/DashboardScene';
 
 import { ALL_COMMANDS, validatePayload } from './commands/registry';
@@ -69,7 +70,48 @@ export class DashboardMutationClient implements MutationClient {
         this.scene.forceRender();
       }
 
-      return result;
+      // Wire undo/redo into the DashboardEditPane event system when the command
+      // provides an _undo callback. The mutation has already been applied at this
+      // point, so perform() is a no-op for the initial registration. The DashboardEditPane
+      // handleEditAction calls perform() immediately then pushes to undoStack.
+      // When redo is invoked, performAction calls perform() again -- at that point
+      // the _undo has already restored the previous state, so perform() must
+      // re-apply the mutation. We capture the current variables state here to
+      // use as the "redo" snapshot (state after the mutation).
+      if (result.success && result._undo && typeof this.scene.publishEvent === 'function') {
+        const undoFn = result._undo;
+        const description = result._description ?? mutation.type;
+        // Capture the post-mutation variable state for redo.
+        const varSet = this.scene.state.$variables;
+        const variablesAfterMutation = varSet ? varSet.state.variables.slice() : [];
+        const scene = this.scene;
+
+        let alreadyPerformed = true;
+
+        this.scene.publishEvent(
+          new DashboardEditActionEvent({
+            source: this.scene,
+            description,
+            perform: () => {
+              // First call is a no-op because mutation was already applied.
+              if (alreadyPerformed) {
+                alreadyPerformed = false;
+                return;
+              }
+              // Subsequent calls (redo): restore the post-mutation state.
+              if (scene.state.$variables) {
+                scene.state.$variables.setState({ variables: variablesAfterMutation });
+              }
+            },
+            undo: undoFn,
+          }),
+          true
+        );
+      }
+
+      // Strip internal fields before returning to callers.
+      const { _undo: _u, _description: _d, ...publicResult } = result;
+      return publicResult;
     } catch (error) {
       return {
         success: false,

--- a/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
+++ b/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
@@ -52,6 +52,11 @@ export class DashboardMutationClient implements MutationClient {
       return { success: false, error: `Unknown command type: ${type}`, changes: [] };
     }
 
+    const permissionResult = registration.canExecute(this.scene);
+    if (!permissionResult.allowed) {
+      return { success: false, error: permissionResult.error, changes: [] };
+    }
+
     if (registration.lockTarget && this.scene.isWriteLocked(registration.lockTarget)) {
       return {
         success: false,
@@ -59,11 +64,6 @@ export class DashboardMutationClient implements MutationClient {
         error: `Target '${registration.lockTarget}' is locked`,
         changes: [],
       };
-    }
-
-    const permissionResult = registration.canExecute(this.scene);
-    if (!permissionResult.allowed) {
-      return { success: false, error: permissionResult.error, changes: [] };
     }
 
     let payload: unknown;

--- a/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
+++ b/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
@@ -30,6 +30,7 @@ interface CommandRegistration {
   canExecute: (scene: DashboardScene) => { allowed: true } | { allowed: false; error: string };
   readOnly: boolean;
   undoDomain?: UndoDomain;
+  lockTarget?: string;
 }
 
 export class DashboardMutationClient implements MutationClient {
@@ -49,6 +50,15 @@ export class DashboardMutationClient implements MutationClient {
     const registration = this.commands.get(type);
     if (!registration) {
       return { success: false, error: `Unknown command type: ${type}`, changes: [] };
+    }
+
+    if (registration.lockTarget && this.scene.isWriteLocked(registration.lockTarget)) {
+      return {
+        success: false,
+        locked: true,
+        error: `Target '${registration.lockTarget}' is locked`,
+        changes: [],
+      };
     }
 
     const permissionResult = registration.canExecute(this.scene);
@@ -141,6 +151,7 @@ export class DashboardMutationClient implements MutationClient {
       canExecute: cmd.permission,
       readOnly: cmd.readOnly ?? false,
       undoDomain: cmd.undoDomain,
+      lockTarget: cmd.lockTarget,
     });
   }
 }

--- a/public/app/features/dashboard-scene/mutation-api/cmd.ts
+++ b/public/app/features/dashboard-scene/mutation-api/cmd.ts
@@ -14,6 +14,8 @@
 
 import { type z } from 'zod';
 
+import { isSceneObject, type SceneVariable } from '@grafana/scenes';
+
 import { payloads } from './commands/schemas';
 import type { MutationRequest } from './types';
 
@@ -21,6 +23,16 @@ import type { MutationRequest } from './types';
 type CmdBuilders = {
   [K in keyof typeof payloads]: (payload: z.input<(typeof payloads)[K]>) => MutationRequest;
 };
+
+// Scenes-native overloads for variable commands: UI callers pass SceneVariable directly.
+export interface SceneNativeCmdBuilders {
+  addVariable(sceneVar: SceneVariable): MutationRequest;
+  addVariable(payload: z.input<(typeof payloads)['addVariable']>): MutationRequest;
+  updateVariable(sceneVar: SceneVariable): MutationRequest;
+  updateVariable(payload: z.input<(typeof payloads)['updateVariable']>): MutationRequest;
+  removeVariable(sceneVar: SceneVariable): MutationRequest;
+  removeVariable(payload: z.input<(typeof payloads)['removeVariable']>): MutationRequest;
+}
 
 /**
  * Convert a camelCase command key to UPPER_SNAKE_CASE for use as the MutationRequest type.
@@ -30,17 +42,30 @@ function toCommandType(key: string): string {
   return key.replace(/([A-Z])/g, '_$1').toUpperCase();
 }
 
-function buildCmd(): CmdBuilders {
+function buildCmd(): CmdBuilders & SceneNativeCmdBuilders {
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- building the record generically; type safety is ensured by CmdBuilders return type
-  const result = {} as CmdBuilders;
+  const result = {} as CmdBuilders & SceneNativeCmdBuilders;
 
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- narrowing key iteration to the known keyof type
   for (const key of Object.keys(payloads) as Array<keyof typeof payloads>) {
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- generic indexing requires cast; each entry is validated by CmdBuilders
-    (result as Record<string, (payload: unknown) => MutationRequest>)[key] = (payload: unknown) => ({
+    (result as unknown as Record<string, (payload: unknown) => MutationRequest>)[key] = (payload: unknown) => ({
       type: toCommandType(key),
       payload,
     });
+  }
+
+  // Scenes-native overloads: detect SceneVariable instance and bypass Zod roundtrip.
+  const variableCommands = ['addVariable', 'updateVariable', 'removeVariable'] as const;
+  for (const key of variableCommands) {
+    const commandType = toCommandType(key);
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- overriding generated builder with overloaded version
+    (result as unknown as Record<string, (arg: unknown) => MutationRequest>)[key] = (arg: unknown) => {
+      if (isSceneObject(arg)) {
+        return { type: commandType, __scenesPayload: arg };
+      }
+      return { type: commandType, payload: arg };
+    };
   }
 
   return result;
@@ -49,5 +74,8 @@ function buildCmd(): CmdBuilders {
 /**
  * Type-safe command builder. Each property corresponds to a command in the
  * `payloads` record and produces a fully typed MutationRequest.
+ *
+ * Variable commands (addVariable, updateVariable, removeVariable) also accept
+ * a SceneVariable directly for UI callers, bypassing the Zod roundtrip.
  */
-export const cmd: CmdBuilders = buildCmd();
+export const cmd: CmdBuilders & SceneNativeCmdBuilders = buildCmd();

--- a/public/app/features/dashboard-scene/mutation-api/cmd.ts
+++ b/public/app/features/dashboard-scene/mutation-api/cmd.ts
@@ -1,0 +1,53 @@
+/**
+ * Typed command builder for the Dashboard Mutation API.
+ *
+ * Provides one type-safe factory function per command, derived from the
+ * `payloads` record in schemas.ts. Each function produces a MutationRequest
+ * ready to pass to DashboardMutationClient.execute() or any MutationClient.
+ *
+ * Key naming: camelCase payload key -> UPPER_SNAKE_CASE type string.
+ *
+ * Usage:
+ *   import { cmd } from './cmd';
+ *   const result = await client.execute(cmd.addVariable({ variable: myVar }));
+ */
+
+import { type z } from 'zod';
+
+import { payloads } from './commands/schemas';
+import type { MutationRequest } from './types';
+
+// Build the type for the cmd object: one function per payload key.
+type CmdBuilders = {
+  [K in keyof typeof payloads]: (payload: z.infer<(typeof payloads)[K]>) => MutationRequest;
+};
+
+/**
+ * Convert a camelCase command key to UPPER_SNAKE_CASE for use as the MutationRequest type.
+ * Example: "addVariable" -> "ADD_VARIABLE"
+ */
+function toCommandType(key: string): string {
+  return key.replace(/([A-Z])/g, '_$1').toUpperCase();
+}
+
+function buildCmd(): CmdBuilders {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- building the record generically; type safety is ensured by CmdBuilders return type
+  const result = {} as CmdBuilders;
+
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- narrowing key iteration to the known keyof type
+  for (const key of Object.keys(payloads) as Array<keyof typeof payloads>) {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- generic indexing requires cast; each entry is validated by CmdBuilders
+    (result as Record<string, (payload: unknown) => MutationRequest>)[key] = (payload: unknown) => ({
+      type: toCommandType(key),
+      payload,
+    });
+  }
+
+  return result;
+}
+
+/**
+ * Type-safe command builder. Each property corresponds to a command in the
+ * `payloads` record and produces a fully typed MutationRequest.
+ */
+export const cmd: CmdBuilders = buildCmd();

--- a/public/app/features/dashboard-scene/mutation-api/cmd.ts
+++ b/public/app/features/dashboard-scene/mutation-api/cmd.ts
@@ -19,7 +19,7 @@ import type { MutationRequest } from './types';
 
 // Build the type for the cmd object: one function per payload key.
 type CmdBuilders = {
-  [K in keyof typeof payloads]: (payload: z.infer<(typeof payloads)[K]>) => MutationRequest;
+  [K in keyof typeof payloads]: (payload: z.input<(typeof payloads)[K]>) => MutationRequest;
 };
 
 /**

--- a/public/app/features/dashboard-scene/mutation-api/commands/addVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/addVariable.ts
@@ -47,8 +47,7 @@ export const addVariableCommand: MutationCommand<AddVariablePayload> = {
       const sceneVariable = createSceneVariableFromVariableModel(variableKind as VariableKind);
 
       const varSet = sceneGraph.getVariables(scene);
-      const variablesBeforeAdd = varSet.state.variables.slice();
-      const currentVariables = [...variablesBeforeAdd];
+      const currentVariables = [...varSet.state.variables];
 
       if (position !== undefined && position >= 0 && position < currentVariables.length) {
         currentVariables.splice(position, 0, sceneVariable);
@@ -62,10 +61,6 @@ export const addVariableCommand: MutationCommand<AddVariablePayload> = {
         success: true,
         data: { variable: variableKind },
         changes: [{ path: `/variables/${name}`, previousValue: null, newValue: variableKind }],
-        _description: `Add variable '${name}'`,
-        _undo: () => {
-          replaceVariableSet(scene, variablesBeforeAdd);
-        },
       };
     } catch (error) {
       return {

--- a/public/app/features/dashboard-scene/mutation-api/commands/addVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/addVariable.ts
@@ -26,6 +26,7 @@ export const addVariableCommand: MutationCommand<AddVariablePayload> = {
   payloadSchema: payloads.addVariable,
   permission: requiresEdit,
   readOnly: false,
+  undoDomain: 'variables',
 
   handler: async (payload, context) => {
     const { scene } = context;

--- a/public/app/features/dashboard-scene/mutation-api/commands/addVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/addVariable.ts
@@ -47,7 +47,8 @@ export const addVariableCommand: MutationCommand<AddVariablePayload> = {
       const sceneVariable = createSceneVariableFromVariableModel(variableKind as VariableKind);
 
       const varSet = sceneGraph.getVariables(scene);
-      const currentVariables = [...varSet.state.variables];
+      const variablesBeforeAdd = varSet.state.variables.slice();
+      const currentVariables = [...variablesBeforeAdd];
 
       if (position !== undefined && position >= 0 && position < currentVariables.length) {
         currentVariables.splice(position, 0, sceneVariable);
@@ -61,6 +62,10 @@ export const addVariableCommand: MutationCommand<AddVariablePayload> = {
         success: true,
         data: { variable: variableKind },
         changes: [{ path: `/variables/${name}`, previousValue: null, newValue: variableKind }],
+        _description: `Add variable '${name}'`,
+        _undo: () => {
+          replaceVariableSet(scene, variablesBeforeAdd);
+        },
       };
     } catch (error) {
       return {

--- a/public/app/features/dashboard-scene/mutation-api/commands/addVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/addVariable.ts
@@ -6,14 +6,14 @@
 
 import { type z } from 'zod';
 
-import { sceneGraph } from '@grafana/scenes';
+import { sceneGraph, type SceneVariable } from '@grafana/scenes';
 import type { VariableKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 
 import { createSceneVariableFromVariableModel } from '../../serialization/transformSaveModelSchemaV2ToScene';
 
 import { payloads } from './schemas';
 import { enterEditModeIfNeeded, requiresEdit, type MutationCommand } from './types';
-import { replaceVariableSet } from './variableUtils';
+import { isSceneNativeVariablePayload, replaceVariableSet } from './variableUtils';
 
 export const addVariablePayloadSchema = payloads.addVariable;
 
@@ -32,8 +32,23 @@ export const addVariableCommand: MutationCommand<AddVariablePayload> = {
     enterEditModeIfNeeded(scene);
 
     try {
-      const { variable: variableKind, position } = payload;
-      const name = variableKind.spec.name;
+      let sceneVariable: SceneVariable;
+      let name: string;
+      let position: number | undefined;
+
+      if (isSceneNativeVariablePayload(payload)) {
+        sceneVariable = payload.__scenesPayload;
+        name = sceneVariable.state.name;
+        position = undefined;
+      } else {
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- validated by Zod in DashboardMutationClient
+        const typedPayload = payload as AddVariablePayload;
+        const variableKind = typedPayload.variable;
+        name = variableKind.spec.name;
+        position = typedPayload.position;
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Zod output is structurally compatible with VariableKind
+        sceneVariable = createSceneVariableFromVariableModel(variableKind as VariableKind);
+      }
 
       const existingVariables = scene.state.$variables;
       if (existingVariables) {
@@ -42,9 +57,6 @@ export const addVariableCommand: MutationCommand<AddVariablePayload> = {
           throw new Error(`Variable '${name}' already exists`);
         }
       }
-
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Zod output is structurally compatible with VariableKind
-      const sceneVariable = createSceneVariableFromVariableModel(variableKind as VariableKind);
 
       const varSet = sceneGraph.getVariables(scene);
       const currentVariables = [...varSet.state.variables];
@@ -59,8 +71,8 @@ export const addVariableCommand: MutationCommand<AddVariablePayload> = {
 
       return {
         success: true,
-        data: { variable: variableKind },
-        changes: [{ path: `/variables/${name}`, previousValue: null, newValue: variableKind }],
+        data: { name },
+        changes: [{ path: `/variables/${name}`, previousValue: null, newValue: name }],
       };
     } catch (error) {
       return {

--- a/public/app/features/dashboard-scene/mutation-api/commands/addVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/addVariable.ts
@@ -27,6 +27,7 @@ export const addVariableCommand: MutationCommand<AddVariablePayload> = {
   permission: requiresEdit,
   readOnly: false,
   undoDomain: 'variables',
+  lockTarget: 'variables',
 
   handler: async (payload, context) => {
     const { scene } = context;

--- a/public/app/features/dashboard-scene/mutation-api/commands/removeVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/removeVariable.ts
@@ -8,7 +8,7 @@ import { type z } from 'zod';
 
 import { payloads } from './schemas';
 import { enterEditModeIfNeeded, requiresEdit, type MutationCommand } from './types';
-import { replaceVariableSet } from './variableUtils';
+import { isSceneNativeVariablePayload, replaceVariableSet } from './variableUtils';
 
 export const removeVariablePayloadSchema = payloads.removeVariable;
 
@@ -24,8 +24,15 @@ export const removeVariableCommand: MutationCommand<RemoveVariablePayload> = {
 
   handler: async (payload, context) => {
     const { scene } = context;
-    const { name } = payload;
     enterEditModeIfNeeded(scene);
+
+    let name: string;
+    if (isSceneNativeVariablePayload(payload)) {
+      name = payload.__scenesPayload.state.name;
+    } else {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- validated by Zod in DashboardMutationClient
+      name = (payload as RemoveVariablePayload).name;
+    }
 
     try {
       const variables = scene.state.$variables;

--- a/public/app/features/dashboard-scene/mutation-api/commands/removeVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/removeVariable.ts
@@ -21,6 +21,7 @@ export const removeVariableCommand: MutationCommand<RemoveVariablePayload> = {
   payloadSchema: payloads.removeVariable,
   permission: requiresEdit,
   readOnly: false,
+  undoDomain: 'variables',
 
   handler: async (payload, context) => {
     const { scene } = context;

--- a/public/app/features/dashboard-scene/mutation-api/commands/removeVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/removeVariable.ts
@@ -39,14 +39,18 @@ export const removeVariableCommand: MutationCommand<RemoveVariablePayload> = {
       }
 
       const previousState = variable.state;
-
-      const updatedVariables = variables.state.variables.filter((v) => v.state.name !== name);
+      const variablesBeforeRemove = variables.state.variables.slice();
+      const updatedVariables = variablesBeforeRemove.filter((v) => v.state.name !== name);
       replaceVariableSet(scene, updatedVariables);
 
       return {
         success: true,
         data: { name },
         changes: [{ path: `/variables/${name}`, previousValue: previousState, newValue: null }],
+        _description: `Remove variable '${name}'`,
+        _undo: () => {
+          replaceVariableSet(scene, variablesBeforeRemove);
+        },
       };
     } catch (error) {
       return {

--- a/public/app/features/dashboard-scene/mutation-api/commands/removeVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/removeVariable.ts
@@ -39,18 +39,13 @@ export const removeVariableCommand: MutationCommand<RemoveVariablePayload> = {
       }
 
       const previousState = variable.state;
-      const variablesBeforeRemove = variables.state.variables.slice();
-      const updatedVariables = variablesBeforeRemove.filter((v) => v.state.name !== name);
+      const updatedVariables = variables.state.variables.filter((v) => v.state.name !== name);
       replaceVariableSet(scene, updatedVariables);
 
       return {
         success: true,
         data: { name },
         changes: [{ path: `/variables/${name}`, previousValue: previousState, newValue: null }],
-        _description: `Remove variable '${name}'`,
-        _undo: () => {
-          replaceVariableSet(scene, variablesBeforeRemove);
-        },
       };
     } catch (error) {
       return {

--- a/public/app/features/dashboard-scene/mutation-api/commands/removeVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/removeVariable.ts
@@ -22,6 +22,7 @@ export const removeVariableCommand: MutationCommand<RemoveVariablePayload> = {
   permission: requiresEdit,
   readOnly: false,
   undoDomain: 'variables',
+  lockTarget: 'variables',
 
   handler: async (payload, context) => {
     const { scene } = context;

--- a/public/app/features/dashboard-scene/mutation-api/commands/types.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/types.ts
@@ -26,6 +26,14 @@ export type PermissionCheck = (scene: DashboardScene) => PermissionCheckResult;
  * Each command file exports a single MutationCommand. The registry collects
  * them and the DashboardMutationClient iterates over them generically.
  */
+/**
+ * Declares which state slice a command modifies.
+ * DashboardMutationClient snapshots this slice before execution and registers
+ * perform/undo callbacks automatically — no per-handler undo logic required.
+ * Extend with new literals as new command domains are wired up.
+ */
+export type UndoDomain = 'variables';
+
 export interface MutationCommand<T = unknown> {
   /** Command name -- must be UPPER_CASE. Used as the MutationType value. */
   name: string;
@@ -37,6 +45,9 @@ export interface MutationCommand<T = unknown> {
   permission: PermissionCheck;
   /** When true, the command only reads state and will not trigger a forceRender. */
   readOnly?: boolean;
+  /** Declares which state slice this command modifies. When set, the client automatically
+   *  snapshots the domain before execution and registers an undo/redo history entry. */
+  undoDomain?: UndoDomain;
   /** The handler function. */
   handler: (payload: T, context: MutationContext) => Promise<MutationResult>;
 }

--- a/public/app/features/dashboard-scene/mutation-api/commands/types.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/types.ts
@@ -48,6 +48,10 @@ export interface MutationCommand<T = unknown> {
   /** Declares which state slice this command modifies. When set, the client automatically
    *  snapshots the domain before execution and registers an undo/redo history entry. */
   undoDomain?: UndoDomain;
+  /** Optional write-lock target this command operates against (e.g. 'variables').
+   *  If the target is locked at execute() time, DashboardMutationClient short-circuits
+   *  with { success: false, locked: true } without running the handler. */
+  lockTarget?: string;
   /** The handler function. */
   handler: (payload: T, context: MutationContext) => Promise<MutationResult>;
 }

--- a/public/app/features/dashboard-scene/mutation-api/commands/updateVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updateVariable.ts
@@ -26,6 +26,7 @@ export const updateVariableCommand: MutationCommand<UpdateVariablePayload> = {
   payloadSchema: payloads.updateVariable,
   permission: requiresEdit,
   readOnly: false,
+  undoDomain: 'variables',
 
   handler: async (payload, context) => {
     const { scene } = context;

--- a/public/app/features/dashboard-scene/mutation-api/commands/updateVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updateVariable.ts
@@ -35,7 +35,8 @@ export const updateVariableCommand: MutationCommand<UpdateVariablePayload> = {
       const { name, variable: variableKind } = payload;
 
       const varSet = sceneGraph.getVariables(scene);
-      const currentVariables = [...varSet.state.variables];
+      const variablesBeforeUpdate = varSet.state.variables.slice();
+      const currentVariables = [...variablesBeforeUpdate];
 
       const existingIndex = currentVariables.findIndex((v) => v.state.name === name);
       if (existingIndex === -1) {
@@ -60,6 +61,10 @@ export const updateVariableCommand: MutationCommand<UpdateVariablePayload> = {
             newValue: variableKind,
           },
         ],
+        _description: `Update variable '${name}'`,
+        _undo: () => {
+          replaceVariableSet(scene, variablesBeforeUpdate);
+        },
       };
     } catch (error) {
       return {

--- a/public/app/features/dashboard-scene/mutation-api/commands/updateVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updateVariable.ts
@@ -35,8 +35,7 @@ export const updateVariableCommand: MutationCommand<UpdateVariablePayload> = {
       const { name, variable: variableKind } = payload;
 
       const varSet = sceneGraph.getVariables(scene);
-      const variablesBeforeUpdate = varSet.state.variables.slice();
-      const currentVariables = [...variablesBeforeUpdate];
+      const currentVariables = [...varSet.state.variables];
 
       const existingIndex = currentVariables.findIndex((v) => v.state.name === name);
       if (existingIndex === -1) {
@@ -54,17 +53,7 @@ export const updateVariableCommand: MutationCommand<UpdateVariablePayload> = {
       return {
         success: true,
         data: { variable: variableKind },
-        changes: [
-          {
-            path: `/variables/${name}`,
-            previousValue: previousState,
-            newValue: variableKind,
-          },
-        ],
-        _description: `Update variable '${name}'`,
-        _undo: () => {
-          replaceVariableSet(scene, variablesBeforeUpdate);
-        },
+        changes: [{ path: `/variables/${name}`, previousValue: previousState, newValue: variableKind }],
       };
     } catch (error) {
       return {

--- a/public/app/features/dashboard-scene/mutation-api/commands/updateVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updateVariable.ts
@@ -6,14 +6,14 @@
 
 import { type z } from 'zod';
 
-import { sceneGraph } from '@grafana/scenes';
+import { sceneGraph, type SceneVariable } from '@grafana/scenes';
 import type { VariableKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 
 import { createSceneVariableFromVariableModel } from '../../serialization/transformSaveModelSchemaV2ToScene';
 
 import { payloads } from './schemas';
 import { enterEditModeIfNeeded, requiresEdit, type MutationCommand } from './types';
-import { replaceVariableSet } from './variableUtils';
+import { isSceneNativeVariablePayload, replaceVariableSet } from './variableUtils';
 
 export const updateVariablePayloadSchema = payloads.updateVariable;
 
@@ -32,7 +32,20 @@ export const updateVariableCommand: MutationCommand<UpdateVariablePayload> = {
     enterEditModeIfNeeded(scene);
 
     try {
-      const { name, variable: variableKind } = payload;
+      let newSceneVariable: SceneVariable;
+      let name: string;
+
+      if (isSceneNativeVariablePayload(payload)) {
+        newSceneVariable = payload.__scenesPayload;
+        name = newSceneVariable.state.name;
+      } else {
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- validated by Zod in DashboardMutationClient
+        const typedPayload = payload as UpdateVariablePayload;
+        name = typedPayload.name;
+        const variableKind = typedPayload.variable;
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Zod output is structurally compatible with VariableKind
+        newSceneVariable = createSceneVariableFromVariableModel(variableKind as VariableKind);
+      }
 
       const varSet = sceneGraph.getVariables(scene);
       const currentVariables = [...varSet.state.variables];
@@ -43,17 +56,14 @@ export const updateVariableCommand: MutationCommand<UpdateVariablePayload> = {
       }
 
       const previousState = currentVariables[existingIndex].state;
-
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Zod output is structurally compatible with VariableKind
-      const newSceneVariable = createSceneVariableFromVariableModel(variableKind as VariableKind);
       currentVariables[existingIndex] = newSceneVariable;
 
       replaceVariableSet(scene, currentVariables);
 
       return {
         success: true,
-        data: { variable: variableKind },
-        changes: [{ path: `/variables/${name}`, previousValue: previousState, newValue: variableKind }],
+        data: { name },
+        changes: [{ path: `/variables/${name}`, previousValue: previousState, newValue: name }],
       };
     } catch (error) {
       return {

--- a/public/app/features/dashboard-scene/mutation-api/commands/updateVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updateVariable.ts
@@ -27,6 +27,7 @@ export const updateVariableCommand: MutationCommand<UpdateVariablePayload> = {
   permission: requiresEdit,
   readOnly: false,
   undoDomain: 'variables',
+  lockTarget: 'variables',
 
   handler: async (payload, context) => {
     const { scene } = context;

--- a/public/app/features/dashboard-scene/mutation-api/commands/variableCommands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/variableCommands.test.ts
@@ -1,4 +1,4 @@
-import { type CustomVariable, type QueryVariable, SceneVariableSet } from '@grafana/scenes';
+import { CustomVariable, type QueryVariable, SceneVariableSet } from '@grafana/scenes';
 
 import { DashboardEditActionEvent } from '../../edit-pane/events';
 import type { DashboardScene } from '../../scene/DashboardScene';
@@ -448,6 +448,58 @@ describe('Variable mutation commands', () => {
 
       perform();
       expect(sceneWithEvents.state.$variables?.state.variables.find((v) => v.state.name === 'redoable')).toBeDefined();
+    });
+  });
+
+  // --- Scenes-native path (cmd.addVariable/updateVariable/removeVariable with SceneVariable) ---
+
+  describe('Scenes-native path', () => {
+    it('cmd.addVariable with SceneVariable adds it to the dashboard', async () => {
+      const sceneVar = new CustomVariable({ name: 'native', query: 'x,y,z' });
+      const result = await client.execute(cmd.addVariable(sceneVar));
+
+      expect(result.success).toBe(true);
+      expect(result.changes[0].path).toBe('/variables/native');
+      expect(scene.state.$variables?.state.variables.find((v) => v.state.name === 'native')).toBeDefined();
+    });
+
+    it('cmd.updateVariable with SceneVariable updates the existing variable', async () => {
+      await client.execute(
+        cmd.addVariable({ variable: { kind: 'CustomVariable', spec: { name: 'updateme', query: 'before' } } })
+      );
+
+      const updatedVar = new CustomVariable({ name: 'updateme', query: 'after' });
+      const result = await client.execute(cmd.updateVariable(updatedVar));
+
+      expect(result.success).toBe(true);
+      expect(result.changes[0].path).toBe('/variables/updateme');
+      const stored = scene.state.$variables?.state.variables.find((v) => v.state.name === 'updateme');
+      expect((stored as CustomVariable | undefined)?.state.query).toBe('after');
+    });
+
+    it('cmd.removeVariable with SceneVariable removes it from the dashboard', async () => {
+      await client.execute(
+        cmd.addVariable({ variable: { kind: 'CustomVariable', spec: { name: 'removeme', query: 'a,b' } } })
+      );
+
+      const sceneVar = new CustomVariable({ name: 'removeme', query: 'a,b' });
+      const result = await client.execute(cmd.removeVariable(sceneVar));
+
+      expect(result.success).toBe(true);
+      expect(scene.state.$variables?.state.variables.find((v) => v.state.name === 'removeme')).toBeUndefined();
+    });
+
+    it('cmd.addVariable Scenes-native path produces __scenesPayload request', () => {
+      const sceneVar = new CustomVariable({ name: 'check', query: 'a' });
+      const request = cmd.addVariable(sceneVar);
+      expect(request.type).toBe('ADD_VARIABLE');
+      expect('__scenesPayload' in request).toBe(true);
+    });
+
+    it('cmd.addVariable payload path still produces payload request', () => {
+      const request = cmd.addVariable({ variable: { kind: 'CustomVariable', spec: { name: 'x', query: 'a' } } });
+      expect(request.type).toBe('ADD_VARIABLE');
+      expect('payload' in request).toBe(true);
     });
   });
 

--- a/public/app/features/dashboard-scene/mutation-api/commands/variableCommands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/variableCommands.test.ts
@@ -242,6 +242,36 @@ describe('Variable mutation commands', () => {
     expect(result.error).toContain('Validation failed');
   });
 
+  it('ADD_VARIABLE Zod rejects unknown variable kind', async () => {
+    const result = await client.execute({
+      type: 'ADD_VARIABLE',
+      payload: { variable: { kind: 'WeirdVariable', spec: { name: 'x' } } },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Validation failed');
+  });
+
+  it('ADD_VARIABLE Zod rejects CustomVariable with missing query field', async () => {
+    const result = await client.execute({
+      type: 'ADD_VARIABLE',
+      payload: { variable: { kind: 'CustomVariable', spec: {} } },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Validation failed');
+  });
+
+  it('UPDATE_VARIABLE Zod rejects missing name field', async () => {
+    const result = await client.execute({
+      type: 'UPDATE_VARIABLE',
+      payload: { variable: { kind: 'CustomVariable', spec: { name: 'x', query: 'a' } } },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Validation failed');
+  });
+
   it('rejects unknown command types', async () => {
     const result = await client.execute({
       type: 'NONEXISTENT_COMMAND',
@@ -398,12 +428,26 @@ describe('Variable mutation commands', () => {
       expect((restoredVar as CustomVariable | undefined)?.state.query).toBe('before');
     });
 
-    it('internal _undo/_description fields are stripped from the returned result', async () => {
-      const result = await clientWithEvents.execute(
-        cmd.addVariable({ variable: { kind: 'CustomVariable', spec: { name: 'check', query: 'x' } } })
+    it('ADD_VARIABLE redo re-applies the mutation after undo', async () => {
+      await clientWithEvents.execute(
+        cmd.addVariable({ variable: { kind: 'CustomVariable', spec: { name: 'redoable', query: 'a,b' } } })
       );
-      expect(result).not.toHaveProperty('_undo');
-      expect(result).not.toHaveProperty('_description');
+
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- mock scene has publishEvent as jest.Mock
+      const publishMock = (sceneWithEvents as unknown as { publishEvent: jest.Mock }).publishEvent;
+      const event: DashboardEditActionEvent = publishMock.mock.calls[0][0];
+      const { perform, undo } = event.payload;
+
+      // Trigger the initial no-op (simulates DashboardEditPane.handleEditAction)
+      perform();
+
+      undo();
+      expect(
+        sceneWithEvents.state.$variables?.state.variables.find((v) => v.state.name === 'redoable')
+      ).toBeUndefined();
+
+      perform();
+      expect(sceneWithEvents.state.$variables?.state.variables.find((v) => v.state.name === 'redoable')).toBeDefined();
     });
   });
 

--- a/public/app/features/dashboard-scene/mutation-api/commands/variableCommands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/variableCommands.test.ts
@@ -1,11 +1,18 @@
-import { SceneVariableSet } from '@grafana/scenes';
+import { type CustomVariable, type QueryVariable, SceneVariableSet } from '@grafana/scenes';
 
+import { DashboardEditActionEvent } from '../../edit-pane/events';
 import type { DashboardScene } from '../../scene/DashboardScene';
+import { createSceneVariableFromVariableModel } from '../../serialization/transformSaveModelSchemaV2ToScene';
 import { DashboardMutationClient } from '../DashboardMutationClient';
+import { cmd } from '../cmd';
 import type { MutationResult } from '../types';
 
-function buildMockScene(options: { editable?: boolean; isEditing?: boolean } = {}): DashboardScene {
-  const { editable = true, isEditing = false } = options;
+import { createVariableKindFromSceneVariable } from './variableUtils';
+
+function buildMockScene(
+  options: { editable?: boolean; isEditing?: boolean; withEventBus?: boolean } = {}
+): DashboardScene {
+  const { editable = true, isEditing = false, withEventBus = false } = options;
   const state: Record<string, unknown> = {
     uid: 'test-dash',
     isEditing,
@@ -18,6 +25,7 @@ function buildMockScene(options: { editable?: boolean; isEditing?: boolean } = {
       state.isEditing = true;
     }),
     forceRender: jest.fn(),
+    publishEvent: withEventBus ? jest.fn() : undefined,
     setState: jest.fn((partial: Record<string, unknown>) => {
       Object.assign(state, partial);
       // Activate new variable set if provided
@@ -260,5 +268,190 @@ describe('Variable mutation commands', () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toContain('Cannot edit dashboard');
+  });
+
+  // --- cmd builder ---
+
+  it('cmd builder produces correct MutationRequest type strings', () => {
+    expect(cmd.addVariable({ variable: { kind: 'CustomVariable', spec: { name: 'x', query: 'a' } } }).type).toBe(
+      'ADD_VARIABLE'
+    );
+    expect(
+      cmd.updateVariable({ name: 'x', variable: { kind: 'CustomVariable', spec: { name: 'x', query: 'a' } } }).type
+    ).toBe('UPDATE_VARIABLE');
+    expect(cmd.removeVariable({ name: 'x' }).type).toBe('REMOVE_VARIABLE');
+    expect(cmd.listVariables({}).type).toBe('LIST_VARIABLES');
+    expect(
+      cmd.addPanel({
+        panel: {
+          kind: 'Panel',
+          spec: {
+            title: 'T',
+            data: { kind: 'QueryGroup', spec: { queries: [] } },
+            vizConfig: { kind: 'VizConfig', group: 'timeseries', spec: {} },
+          },
+        },
+        parentPath: '/',
+      }).type
+    ).toBe('ADD_PANEL');
+    expect(cmd.updateDashboardSettings({}).type).toBe('UPDATE_DASHBOARD_SETTINGS');
+  });
+
+  it('cmd builder payloads round-trip through execute', async () => {
+    const result = await client.execute(
+      cmd.addVariable({ variable: { kind: 'CustomVariable', spec: { name: 'built', query: 'x,y' } } })
+    );
+    expect(result.success).toBe(true);
+    expect(result.changes[0].path).toBe('/variables/built');
+  });
+
+  // --- Undo/redo integration ---
+
+  describe('undo/redo wiring', () => {
+    let sceneWithEvents: DashboardScene;
+    let clientWithEvents: DashboardMutationClient;
+
+    beforeEach(() => {
+      sceneWithEvents = buildMockScene({ editable: true, withEventBus: true });
+      clientWithEvents = new DashboardMutationClient(sceneWithEvents);
+    });
+
+    it('ADD_VARIABLE publishes DashboardEditActionEvent', async () => {
+      await clientWithEvents.execute(
+        cmd.addVariable({ variable: { kind: 'CustomVariable', spec: { name: 'toAdd', query: 'a,b' } } })
+      );
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- mock scene has publishEvent as jest.Mock
+      expect((sceneWithEvents as unknown as { publishEvent: jest.Mock }).publishEvent).toHaveBeenCalledWith(
+        expect.any(DashboardEditActionEvent),
+        true
+      );
+    });
+
+    it('ADD_VARIABLE undo removes the variable', async () => {
+      await clientWithEvents.execute(
+        cmd.addVariable({ variable: { kind: 'CustomVariable', spec: { name: 'willUndo', query: 'a,b' } } })
+      );
+
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- mock scene has publishEvent as jest.Mock
+      const publishMock = (sceneWithEvents as unknown as { publishEvent: jest.Mock }).publishEvent;
+      const event: DashboardEditActionEvent = publishMock.mock.calls[0][0];
+      const { undo } = event.payload;
+
+      // Variable should be present before undo
+      expect(sceneWithEvents.state.$variables?.state.variables.find((v) => v.state.name === 'willUndo')).toBeDefined();
+
+      undo();
+
+      // Variable should be gone after undo
+      expect(
+        sceneWithEvents.state.$variables?.state.variables.find((v) => v.state.name === 'willUndo')
+      ).toBeUndefined();
+    });
+
+    it('REMOVE_VARIABLE undo restores the variable', async () => {
+      await clientWithEvents.execute(
+        cmd.addVariable({ variable: { kind: 'CustomVariable', spec: { name: 'willRestore', query: 'a,b' } } })
+      );
+
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- mock scene has publishEvent as jest.Mock
+      const publishMock = (sceneWithEvents as unknown as { publishEvent: jest.Mock }).publishEvent;
+      publishMock.mockClear();
+
+      await clientWithEvents.execute(cmd.removeVariable({ name: 'willRestore' }));
+
+      expect(
+        sceneWithEvents.state.$variables?.state.variables.find((v) => v.state.name === 'willRestore')
+      ).toBeUndefined();
+
+      const removeEvent: DashboardEditActionEvent = publishMock.mock.calls[0][0];
+      removeEvent.payload.undo();
+
+      expect(
+        sceneWithEvents.state.$variables?.state.variables.find((v) => v.state.name === 'willRestore')
+      ).toBeDefined();
+    });
+
+    it('UPDATE_VARIABLE undo restores the previous variable state', async () => {
+      await clientWithEvents.execute(
+        cmd.addVariable({ variable: { kind: 'CustomVariable', spec: { name: 'mutable', query: 'before' } } })
+      );
+
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- mock scene has publishEvent as jest.Mock
+      const publishMock = (sceneWithEvents as unknown as { publishEvent: jest.Mock }).publishEvent;
+      publishMock.mockClear();
+
+      await clientWithEvents.execute(
+        cmd.updateVariable({
+          name: 'mutable',
+          variable: { kind: 'CustomVariable', spec: { name: 'mutable', query: 'after' } },
+        })
+      );
+
+      // After update the variable should reflect the new query
+      const updatedVar = sceneWithEvents.state.$variables?.state.variables.find((v) => v.state.name === 'mutable');
+      expect((updatedVar as CustomVariable | undefined)?.state.query).toBe('after');
+
+      const updateEvent: DashboardEditActionEvent = publishMock.mock.calls[0][0];
+      updateEvent.payload.undo();
+
+      const restoredVar = sceneWithEvents.state.$variables?.state.variables.find((v) => v.state.name === 'mutable');
+      expect((restoredVar as CustomVariable | undefined)?.state.query).toBe('before');
+    });
+
+    it('internal _undo/_description fields are stripped from the returned result', async () => {
+      const result = await clientWithEvents.execute(
+        cmd.addVariable({ variable: { kind: 'CustomVariable', spec: { name: 'check', query: 'x' } } })
+      );
+      expect(result).not.toHaveProperty('_undo');
+      expect(result).not.toHaveProperty('_description');
+    });
+  });
+
+  // --- Reverse transformer (createVariableKindFromSceneVariable) ---
+
+  describe('createVariableKindFromSceneVariable round-trip', () => {
+    it('CustomVariable survives SceneVariable -> VariableKind -> SceneVariable round-trip', () => {
+      const original: Parameters<typeof createSceneVariableFromVariableModel>[0] = {
+        kind: 'CustomVariable',
+        spec: {
+          name: 'env',
+          query: 'dev,staging,prod',
+          multi: true,
+          includeAll: false,
+          skipUrlSync: false,
+          hide: 'dontHide',
+        },
+      };
+      const sceneVar = createSceneVariableFromVariableModel(original);
+      const variableKind = createVariableKindFromSceneVariable(sceneVar);
+      const roundTripped = createSceneVariableFromVariableModel(variableKind as typeof original);
+
+      expect(roundTripped.state.name).toBe('env');
+      expect((roundTripped as CustomVariable).state.query).toBe('dev,staging,prod');
+      expect((roundTripped as CustomVariable).state.isMulti).toBe(true);
+    });
+
+    it('QueryVariable preserves core fields through round-trip', () => {
+      const original: Parameters<typeof createSceneVariableFromVariableModel>[0] = {
+        kind: 'QueryVariable',
+        spec: {
+          name: 'qvar',
+          query: { kind: 'DataQuery', group: 'prometheus', version: 'v0', spec: { expr: 'up' } },
+          refresh: 'onDashboardLoad',
+          regex: '.*',
+          sort: 'alphabeticalAsc',
+          multi: false,
+          includeAll: false,
+          skipUrlSync: false,
+          hide: 'dontHide',
+        },
+      };
+      const sceneVar = createSceneVariableFromVariableModel(original);
+      const variableKind = createVariableKindFromSceneVariable(sceneVar);
+      const roundTripped = createSceneVariableFromVariableModel(variableKind as typeof original);
+
+      expect(roundTripped.state.name).toBe('qvar');
+      expect((roundTripped as QueryVariable).state.regex).toBe('.*');
+    });
   });
 });

--- a/public/app/features/dashboard-scene/mutation-api/commands/variableCommands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/variableCommands.test.ts
@@ -464,6 +464,9 @@ describe('Variable mutation commands', () => {
           includeAll: false,
           skipUrlSync: false,
           hide: 'dontHide',
+          current: { text: '', value: '' },
+          options: [],
+          allowCustomValue: true,
         },
       };
       const sceneVar = createSceneVariableFromVariableModel(original);
@@ -488,6 +491,9 @@ describe('Variable mutation commands', () => {
           includeAll: false,
           skipUrlSync: false,
           hide: 'dontHide',
+          current: { text: '', value: '' },
+          options: [],
+          allowCustomValue: true,
         },
       };
       const sceneVar = createSceneVariableFromVariableModel(original);

--- a/public/app/features/dashboard-scene/mutation-api/commands/variableCommands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/variableCommands.test.ts
@@ -18,6 +18,7 @@ function buildMockScene(
     isEditing,
     $variables: new SceneVariableSet({ variables: [] }),
   };
+  const writeLocks = new Set<string>();
   const scene = {
     state,
     canEditDashboard: jest.fn(() => editable),
@@ -26,6 +27,9 @@ function buildMockScene(
     }),
     forceRender: jest.fn(),
     publishEvent: withEventBus ? jest.fn() : undefined,
+    acquireWriteLock: (t: string) => writeLocks.add(t),
+    releaseWriteLock: (t: string) => writeLocks.delete(t),
+    isWriteLocked: (t: string) => writeLocks.has(t),
     setState: jest.fn((partial: Record<string, unknown>) => {
       Object.assign(state, partial);
       // Activate new variable set if provided
@@ -554,6 +558,81 @@ describe('Variable mutation commands', () => {
 
       expect(roundTripped.state.name).toBe('qvar');
       expect((roundTripped as QueryVariable).state.regex).toBe('.*');
+    });
+  });
+
+  describe('canonical undo: add three, remove middle, undo restores at the right index', () => {
+    it('add [a,b,c], remove b, undo -> [a,b,c], redo -> [a,c]', async () => {
+      const sceneWithBus = buildMockScene({ editable: true, withEventBus: true });
+      const c = new DashboardMutationClient(sceneWithBus);
+
+      // Capture the published events so we can drive undo/redo deterministically
+      const events: Array<{ perform: () => void; undo: () => void }> = [];
+      (sceneWithBus.publishEvent as jest.Mock).mockImplementation((event: DashboardEditActionEvent) => {
+        events.push({ perform: event.payload.perform, undo: event.payload.undo });
+        // DashboardEditPane calls perform() once on subscribe; emulate that here.
+        event.payload.perform();
+      });
+
+      const mkVar = (name: string) => ({ kind: 'CustomVariable' as const, spec: { name, query: 'x,y' } });
+      await c.execute({ type: 'ADD_VARIABLE', payload: { variable: mkVar('a') } });
+      await c.execute({ type: 'ADD_VARIABLE', payload: { variable: mkVar('b') } });
+      await c.execute({ type: 'ADD_VARIABLE', payload: { variable: mkVar('c') } });
+
+      const namesAfterAdds = sceneWithBus.state.$variables!.state.variables.map((v) => v.state.name);
+      expect(namesAfterAdds).toEqual(['a', 'b', 'c']);
+
+      // Remove the middle one
+      await c.execute({ type: 'REMOVE_VARIABLE', payload: { name: 'b' } });
+      expect(sceneWithBus.state.$variables!.state.variables.map((v) => v.state.name)).toEqual(['a', 'c']);
+
+      // Undo the remove -> b should be restored at index 1
+      events[events.length - 1].undo();
+      expect(sceneWithBus.state.$variables!.state.variables.map((v) => v.state.name)).toEqual(['a', 'b', 'c']);
+
+      // Redo the remove -> b should be gone again
+      events[events.length - 1].perform();
+      expect(sceneWithBus.state.$variables!.state.variables.map((v) => v.state.name)).toEqual(['a', 'c']);
+    });
+  });
+
+  describe('multiplayer composition: each mutation reads latest state', () => {
+    it('two sequential add commands accumulate, second sees state from first', async () => {
+      await client.execute({
+        type: 'ADD_VARIABLE',
+        payload: { variable: { kind: 'CustomVariable', spec: { name: 'first', query: 'a,b' } } },
+      });
+      await client.execute({
+        type: 'ADD_VARIABLE',
+        payload: { variable: { kind: 'CustomVariable', spec: { name: 'second', query: 'c,d' } } },
+      });
+
+      expect(scene.state.$variables!.state.variables.map((v) => v.state.name)).toEqual(['first', 'second']);
+    });
+  });
+
+  describe('lock mechanism', () => {
+    it('returns locked:true when the target is write-locked, then succeeds after release', async () => {
+      scene.acquireWriteLock('variables');
+
+      const blocked = await client.execute({
+        type: 'ADD_VARIABLE',
+        payload: { variable: { kind: 'CustomVariable', spec: { name: 'env', query: 'dev,prod' } } },
+      });
+
+      expect(blocked.success).toBe(false);
+      expect(blocked.locked).toBe(true);
+      expect(blocked.error).toMatch(/locked/);
+      expect(scene.state.$variables!.state.variables.map((v) => v.state.name)).toEqual([]);
+
+      scene.releaseWriteLock('variables');
+      const ok = await client.execute({
+        type: 'ADD_VARIABLE',
+        payload: { variable: { kind: 'CustomVariable', spec: { name: 'env', query: 'dev,prod' } } },
+      });
+      expect(ok.success).toBe(true);
+      expect(ok.locked).toBeFalsy();
+      expect(scene.state.$variables!.state.variables.map((v) => v.state.name)).toEqual(['env']);
     });
   });
 });

--- a/public/app/features/dashboard-scene/mutation-api/commands/variableUtils.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/variableUtils.ts
@@ -4,7 +4,37 @@
  * Contains helpers used across add/remove/update variable commands.
  */
 
-import { type sceneGraph, SceneVariableSet } from '@grafana/scenes';
+import { config } from '@grafana/runtime';
+import { type sceneGraph, SceneVariableSet, sceneUtils, type SceneVariable } from '@grafana/scenes';
+import {
+  type AdhocVariableKind,
+  type ConstantVariableKind,
+  type CustomVariableKind,
+  type DataQueryKind,
+  type DatasourceVariableKind,
+  type GroupByVariableKind,
+  type IntervalVariableKind,
+  type QueryVariableKind,
+  type SwitchVariableKind,
+  type TextVariableKind,
+  type VariableKind,
+  type VariableOption,
+  defaultDataQueryKind,
+  defaultIntervalVariableSpec,
+  defaultVariableHide,
+} from '@grafana/schema/apis/dashboard.grafana.app/v2';
+import { getDefaultDatasource } from 'app/features/dashboard/api/ResponseTransformers';
+
+import { getDataSourceForQuery } from '../../serialization/layoutSerializers/utils';
+import { validateFiltersOrigin } from '../../serialization/sceneVariablesSetToVariables';
+import { getDataQueryKind, getElementDatasource } from '../../serialization/transformSceneToSaveModelSchemaV2';
+import {
+  LEGACY_STRING_VALUE_KEY,
+  transformSortVariableToEnum,
+  transformVariableHideToEnum,
+  transformVariableRefreshToEnum,
+} from '../../serialization/transformToV2TypesUtils';
+import { getIntervalsQueryFromNewIntervalModel } from '../../utils/utils';
 
 /**
  * Replace the dashboard's variable set with a new set containing the given variables.
@@ -18,4 +48,262 @@ export function replaceVariableSet(
   scene.setState({ $variables: newVarSet });
   newVarSet.activate();
   return newVarSet;
+}
+
+/**
+ * Convert a single SceneVariable into a v2beta1 VariableKind.
+ *
+ * This is the reverse of createSceneVariableFromVariableModel. It extracts
+ * the current runtime state of one variable and returns the schema representation
+ * suitable for passing to ADD_VARIABLE or UPDATE_VARIABLE commands.
+ *
+ * The parent set is optional -- when provided, it is used to resolve datasource
+ * references for QueryVariable. When omitted, datasource resolution is skipped.
+ */
+export function createVariableKindFromSceneVariable(
+  variable: SceneVariable,
+  parentSet?: Parameters<typeof sceneGraph.getVariables>[0]
+): VariableKind {
+  const commonProperties = {
+    name: variable.state.name,
+    label: variable.state.label,
+    description: variable.state.description ?? undefined,
+    skipUrlSync: Boolean(variable.state.skipUrlSync),
+    hide: transformVariableHideToEnum(variable.state.hide) || defaultVariableHide(),
+  };
+
+  const currentVariableOption: VariableOption = {
+    // @ts-expect-error -- SceneVariable value/text not typed on base state
+    value: variable.state.value,
+    // @ts-expect-error
+    text: variable.state.text,
+  };
+
+  if (sceneUtils.isQueryVariable(variable)) {
+    const query = variable.state.query;
+    let dataQuery: DataQueryKind | string;
+
+    const datasource = parentSet
+      ? getElementDatasource(
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+          parentSet as Parameters<typeof getElementDatasource>[0],
+          variable,
+          'variable'
+        )
+      : undefined;
+
+    if (typeof query !== 'string') {
+      dataQuery = {
+        kind: 'DataQuery',
+        version: defaultDataQueryKind().version,
+        group: datasource?.type || getDataQueryKind(query),
+        ...(datasource?.uid && { datasource: { name: datasource.uid } }),
+        spec: query,
+      };
+    } else {
+      const spec: Record<string, string> = {};
+      if (query) {
+        spec[LEGACY_STRING_VALUE_KEY] = query;
+      }
+      dataQuery = {
+        kind: 'DataQuery',
+        version: defaultDataQueryKind().version,
+        group: datasource?.type || getDataQueryKind(query),
+        ...(datasource?.uid && { datasource: { name: datasource.uid } }),
+        spec,
+      };
+    }
+
+    const result: QueryVariableKind = {
+      kind: 'QueryVariable',
+      spec: {
+        ...commonProperties,
+        current: currentVariableOption,
+        options: [],
+        query: dataQuery,
+        definition: variable.state.definition,
+        sort: transformSortVariableToEnum(variable.state.sort),
+        refresh: transformVariableRefreshToEnum(variable.state.refresh),
+        regex: variable.state.regex ?? '',
+        allValue: variable.state.allValue,
+        includeAll: variable.state.includeAll || false,
+        multi: variable.state.isMulti || false,
+        skipUrlSync: variable.state.skipUrlSync || false,
+        allowCustomValue: variable.state.allowCustomValue ?? true,
+      },
+    };
+    return result;
+  }
+
+  if (sceneUtils.isCustomVariable(variable)) {
+    const result: CustomVariableKind = {
+      kind: 'CustomVariable',
+      spec: {
+        ...commonProperties,
+        current: currentVariableOption,
+        options: [],
+        query: variable.state.query,
+        multi: variable.state.isMulti || false,
+        allValue: variable.state.allValue,
+        includeAll: variable.state.includeAll ?? false,
+        allowCustomValue: variable.state.allowCustomValue ?? true,
+        valuesFormat: variable.state.valuesFormat ?? 'csv',
+      },
+    };
+    return result;
+  }
+
+  if (sceneUtils.isDataSourceVariable(variable)) {
+    const result: DatasourceVariableKind = {
+      kind: 'DatasourceVariable',
+      spec: {
+        ...commonProperties,
+        current: currentVariableOption,
+        options: [],
+        regex: variable.state.regex ?? '',
+        refresh: 'onDashboardLoad',
+        pluginId: variable.state.pluginId ?? getDefaultDatasource().type,
+        multi: variable.state.isMulti || false,
+        includeAll: variable.state.includeAll || false,
+        allowCustomValue: variable.state.allowCustomValue ?? true,
+        ...(variable.state.allValue !== undefined && { allValue: variable.state.allValue }),
+      },
+    };
+    return result;
+  }
+
+  if (sceneUtils.isConstantVariable(variable)) {
+    const value = variable.state.value ? String(variable.state.value) : '';
+    const result: ConstantVariableKind = {
+      kind: 'ConstantVariable',
+      spec: {
+        ...commonProperties,
+        current: { text: value, value },
+        query: value,
+      },
+    };
+    return result;
+  }
+
+  if (sceneUtils.isIntervalVariable(variable)) {
+    const intervals = getIntervalsQueryFromNewIntervalModel(variable.state.intervals);
+    const result: IntervalVariableKind = {
+      kind: 'IntervalVariable',
+      spec: {
+        ...commonProperties,
+        current: {
+          ...currentVariableOption,
+          text: variable.state.value,
+        },
+        query: intervals,
+        refresh: defaultIntervalVariableSpec().refresh,
+        options: variable.state.intervals.map((interval) => ({
+          value: interval,
+          text: interval,
+          selected: interval === variable.state.value,
+        })),
+        auto: variable.state.autoEnabled ?? defaultIntervalVariableSpec().auto,
+        auto_min: variable.state.autoMinInterval ?? defaultIntervalVariableSpec().auto_min,
+        auto_count: variable.state.autoStepCount ?? defaultIntervalVariableSpec().auto_count,
+      },
+    };
+    return result;
+  }
+
+  if (sceneUtils.isTextBoxVariable(variable)) {
+    const current = {
+      text: variable.state.value ?? '',
+      value: variable.state.value ?? '',
+    };
+    const result: TextVariableKind = {
+      kind: 'TextVariable',
+      spec: {
+        ...commonProperties,
+        current,
+        query: variable.state.value ?? '',
+      },
+    };
+    return result;
+  }
+
+  if (sceneUtils.isGroupByVariable(variable) && config.featureToggles.groupByVariable) {
+    // @ts-expect-error
+    const defaultVariableOptionValue: VariableOption | undefined = variable.state.defaultValue
+      ? {
+          value: variable.state.defaultValue.value,
+          text: variable.state.defaultValue.text,
+        }
+      : undefined;
+
+    const ds = getDataSourceForQuery(
+      variable.state.datasource,
+      variable.state.datasource?.type || getDefaultDatasource().type!
+    );
+
+    const result: GroupByVariableKind = {
+      kind: 'GroupByVariable',
+      group: ds.type!,
+      datasource: { name: ds.uid },
+      spec: {
+        ...commonProperties,
+        options:
+          variable.state.defaultOptions?.map((option) => ({
+            text: option.text,
+            value: String(option.value),
+          })) || [],
+        current: currentVariableOption,
+        defaultValue: defaultVariableOptionValue,
+        multi: variable.state.isMulti || false,
+      },
+    };
+    return result;
+  }
+
+  if (sceneUtils.isAdHocVariable(variable)) {
+    const ds = getDataSourceForQuery(
+      variable.state.datasource,
+      variable.state.datasource?.type || getDefaultDatasource().type!
+    );
+    const result: AdhocVariableKind = {
+      kind: 'AdhocVariable',
+      group: ds.type!,
+      datasource: { name: ds.uid },
+      spec: {
+        ...commonProperties,
+        baseFilters: validateFiltersOrigin(variable.state.baseFilters) || [],
+        filters: [
+          ...validateFiltersOrigin(variable.getOriginalFilters()).map(
+            ({ key, operator, value, values, keyLabel, valueLabels, origin }) => ({
+              key,
+              origin,
+              value,
+              values,
+              valueLabels,
+              keyLabel,
+              operator,
+            })
+          ),
+          ...validateFiltersOrigin(variable.state.filters),
+        ],
+        defaultKeys: variable.state.defaultKeys || [],
+        allowCustomValue: variable.state.allowCustomValue ?? true,
+      },
+    };
+    return result;
+  }
+
+  if (sceneUtils.isSwitchVariable(variable)) {
+    const result: SwitchVariableKind = {
+      kind: 'SwitchVariable',
+      spec: {
+        ...commonProperties,
+        current: variable.state.value,
+        enabledValue: variable.state.enabledValue,
+        disabledValue: variable.state.disabledValue,
+      },
+    };
+    return result;
+  }
+
+  throw new Error(`Unsupported variable type: ${variable.state.type}`);
 }

--- a/public/app/features/dashboard-scene/mutation-api/commands/variableUtils.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/variableUtils.ts
@@ -307,3 +307,7 @@ export function createVariableKindFromSceneVariable(
 
   throw new Error(`Unsupported variable type: ${variable.state.type}`);
 }
+
+export function isSceneNativeVariablePayload(payload: unknown): payload is { __scenesPayload: SceneVariable } {
+  return typeof payload === 'object' && payload !== null && '__scenesPayload' in payload;
+}

--- a/public/app/features/dashboard-scene/mutation-api/index.ts
+++ b/public/app/features/dashboard-scene/mutation-api/index.ts
@@ -25,3 +25,7 @@ export type {
 export { ALL_COMMANDS, MUTATION_TYPES, validatePayload } from './commands/registry';
 
 export type { MutationCommand } from './commands/types';
+
+export { cmd } from './cmd';
+
+export { createVariableKindFromSceneVariable } from './commands/variableUtils';

--- a/public/app/features/dashboard-scene/mutation-api/types.ts
+++ b/public/app/features/dashboard-scene/mutation-api/types.ts
@@ -6,6 +6,7 @@
  * and inferred from Zod schemas.
  */
 
+import type { SceneObject } from '@grafana/scenes';
 import type {
   AutoGridLayoutItemKind,
   Element,
@@ -13,10 +14,9 @@ import type {
   VariableKind,
 } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 
-export interface MutationRequest {
-  type: string;
-  payload: unknown;
-}
+// The __scenesPayload variant signals the execute() path to skip Zod
+// validation and pass the SceneObject directly to the handler.
+export type MutationRequest = { type: string; payload: unknown } | { type: string; __scenesPayload: SceneObject };
 
 export interface MutationResult {
   success: boolean;

--- a/public/app/features/dashboard-scene/mutation-api/types.ts
+++ b/public/app/features/dashboard-scene/mutation-api/types.ts
@@ -24,18 +24,6 @@ export interface MutationResult {
   changes: MutationChange[];
   warnings?: string[];
   data?: unknown;
-  /**
-   * Internal: callback to undo this mutation. Set by variable commands to wire
-   * into the DashboardEditActionEvent undo/redo system. Underscore prefix signals
-   * that this field is for internal infrastructure use only and must not be
-   * forwarded to external callers.
-   */
-  _undo?: () => void;
-  /**
-   * Internal: human-readable description shown in the undo history UI.
-   * Set alongside _undo by commands that support undo/redo.
-   */
-  _description?: string;
 }
 
 export interface MutationChange {

--- a/public/app/features/dashboard-scene/mutation-api/types.ts
+++ b/public/app/features/dashboard-scene/mutation-api/types.ts
@@ -24,6 +24,18 @@ export interface MutationResult {
   changes: MutationChange[];
   warnings?: string[];
   data?: unknown;
+  /**
+   * Internal: callback to undo this mutation. Set by variable commands to wire
+   * into the DashboardEditActionEvent undo/redo system. Underscore prefix signals
+   * that this field is for internal infrastructure use only and must not be
+   * forwarded to external callers.
+   */
+  _undo?: () => void;
+  /**
+   * Internal: human-readable description shown in the undo history UI.
+   * Set alongside _undo by commands that support undo/redo.
+   */
+  _description?: string;
 }
 
 export interface MutationChange {

--- a/public/app/features/dashboard-scene/mutation-api/types.ts
+++ b/public/app/features/dashboard-scene/mutation-api/types.ts
@@ -24,6 +24,12 @@ export interface MutationResult {
   changes: MutationChange[];
   warnings?: string[];
   data?: unknown;
+  /**
+   * True when the targeted object is currently write-locked. The agent should
+   * wait and retry. Absent / false means the mutation was either applied or
+   * failed for a non-lock reason.
+   */
+  locked?: boolean;
 }
 
 export interface MutationChange {

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -62,6 +62,7 @@ import {
 } from '../../apiserver/types';
 import { DashboardEditPane } from '../edit-pane/DashboardEditPane';
 import { dashboardEditActions } from '../edit-pane/shared';
+import { DashboardMutationClient } from '../mutation-api/DashboardMutationClient';
 import { type PanelEditor } from '../panel-edit/PanelEditor';
 import { DashboardSceneChangeTracker } from '../saving/DashboardSceneChangeTracker';
 import { SaveDashboardDrawer } from '../saving/SaveDashboardDrawer';
@@ -240,6 +241,37 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
    * Dashboard changes tracker
    */
   private _changeTracker: DashboardSceneChangeTracker;
+  private _mutationClient?: DashboardMutationClient;
+  private _writeLocks = new Set<string>();
+
+  /**
+   * Lazy-initialized Mutation API client. UI components can call
+   * `dashboard.mutationClient.execute(cmd.addVariable(...))` to route writes
+   * through the API the same way the Assistant does.
+   */
+  public get mutationClient(): DashboardMutationClient {
+    if (!this._mutationClient) {
+      this._mutationClient = new DashboardMutationClient(this);
+    }
+    return this._mutationClient;
+  }
+
+  /**
+   * Acquire a write lock for the given target identifier (e.g. 'variables').
+   * Subsequent mutations against the same target return locked:true until released.
+   * Reads via Scenes subscriptions are unaffected.
+   */
+  public acquireWriteLock(target: string): void {
+    this._writeLocks.add(target);
+  }
+
+  public releaseWriteLock(target: string): void {
+    this._writeLocks.delete(target);
+  }
+
+  public isWriteLocked(target: string): boolean {
+    return this._writeLocks.has(target);
+  }
 
   /**
    * Remember scroll position when going into panel edit

--- a/public/app/features/dashboard-scene/settings/VariablesEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VariablesEditView.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
 import { type NavModel, type NavModelItem, PageLayoutType } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import {
   type SceneComponentProps,
   SceneObjectBase,
@@ -11,6 +12,9 @@ import {
 } from '@grafana/scenes';
 import { Page } from 'app/core/components/Page/Page';
 
+import { DashboardMutationClient } from '../mutation-api/DashboardMutationClient';
+import { cmd } from '../mutation-api/cmd';
+import { createVariableKindFromSceneVariable } from '../mutation-api/commands/variableUtils';
 import { type DashboardScene } from '../scene/DashboardScene';
 import { NavToolbarActions } from '../scene/NavToolbarActions';
 import { transformSceneToSaveModel } from '../serialization/transformSceneToSaveModel';
@@ -27,6 +31,7 @@ import {
   type EditableVariableType,
   RESERVED_GLOBAL_VARIABLE_NAME_REGEX,
   WORD_CHARACTERS_REGEX,
+  getNextAvailableId,
   getVariableDefault,
   getVariableScene,
   isVariableEditable,
@@ -76,7 +81,14 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
     this.getVariableSet().setState({ variables: updatedVariables });
   };
 
-  public onDelete = (identifier: string) => {
+  public onDelete = async (identifier: string) => {
+    if (config.featureToggles.dashboardMutationApiVariablePilot) {
+      const client = new DashboardMutationClient(this.getDashboard());
+      await client.execute(cmd.removeVariable({ name: identifier }));
+      this.setState({ editIndex: undefined });
+      return;
+    }
+
     // Find the index of the variable to be deleted
     const variableIndex = this.getVariableIndex(identifier);
     const { variables } = this.getVariableSet().state;
@@ -157,12 +169,47 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
     this.setState({ editIndex: variableIndex });
   };
 
-  public onAdd = () => {
+  public onAdd = async () => {
     const variables = this.getVariables();
     const variableIndex = variables.length;
-    //add the new variable to the end of the array
-    const defaultNewVariable = getVariableDefault(variables);
 
+    if (config.featureToggles.dashboardMutationApiVariablePilot) {
+      // Build a default QueryVariable as a VariableKind for the Mutation API.
+      const nextName = getNextAvailableId('query', variables);
+      const defaultVariableKind = {
+        kind: 'QueryVariable' as const,
+        spec: {
+          name: nextName,
+          query: {
+            kind: 'DataQuery' as const,
+            version: 'v0',
+            group: '',
+            spec: {},
+          },
+          refresh: 'onDashboardLoad' as const,
+          regex: '',
+          sort: 'disabled' as const,
+          multi: false,
+          includeAll: false,
+          allowCustomValue: true,
+          current: { text: '', value: '' },
+          options: [],
+          skipUrlSync: false,
+          hide: 'dontHide' as const,
+        },
+      };
+
+      const client = new DashboardMutationClient(this.getDashboard());
+      const result = await client.execute(cmd.addVariable({ variable: defaultVariableKind }));
+
+      if (result.success) {
+        this.setState({ editIndex: variableIndex });
+      }
+      return;
+    }
+
+    // Fallback: direct Scenes mutation.
+    const defaultNewVariable = getVariableDefault(variables);
     this.getVariableSet().setState({ variables: [...this.getVariables(), defaultNewVariable] });
     this.setState({ editIndex: variableIndex });
   };
@@ -184,7 +231,31 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
     this.replaceEditVariable(newVariable);
   };
 
-  public onGoBack = () => {
+  public onGoBack = async () => {
+    if (config.featureToggles.dashboardMutationApiVariablePilot) {
+      const editIndex = this.state.editIndex;
+
+      // Only call UPDATE_VARIABLE when going back from an existing variable.
+      // New variables added via onAdd already have their state registered via ADD_VARIABLE.
+      if (editIndex !== undefined) {
+        const variables = this.getVariables();
+        const variable = variables[editIndex];
+        if (variable) {
+          try {
+            const variableKind = createVariableKindFromSceneVariable(variable, this.getDashboard());
+            const client = new DashboardMutationClient(this.getDashboard());
+            await client.execute(cmd.updateVariable({ name: variable.state.name, variable: variableKind }));
+          } catch (error) {
+            // Non-fatal: if serialization fails, fall through to navigation.
+            console.error('Failed to call UPDATE_VARIABLE on goBack:', error);
+          }
+        }
+      }
+
+      this.setState({ editIndex: undefined });
+      return;
+    }
+
     this.setState({ editIndex: undefined });
   };
 

--- a/public/app/features/dashboard-scene/settings/VariablesEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VariablesEditView.tsx
@@ -12,9 +12,6 @@ import {
 } from '@grafana/scenes';
 import { Page } from 'app/core/components/Page/Page';
 
-import { DashboardMutationClient } from '../mutation-api/DashboardMutationClient';
-import { cmd } from '../mutation-api/cmd';
-import { createVariableKindFromSceneVariable } from '../mutation-api/commands/variableUtils';
 import { type DashboardScene } from '../scene/DashboardScene';
 import { NavToolbarActions } from '../scene/NavToolbarActions';
 import { transformSceneToSaveModel } from '../serialization/transformSceneToSaveModel';
@@ -83,6 +80,8 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
 
   public onDelete = async (identifier: string) => {
     if (config.featureToggles.dashboardMutationApiVariablePilot) {
+      const { DashboardMutationClient } = await import('../mutation-api/DashboardMutationClient');
+      const { cmd } = await import('../mutation-api/cmd');
       const client = new DashboardMutationClient(this.getDashboard());
       await client.execute(cmd.removeVariable({ name: identifier }));
       this.setState({ editIndex: undefined });
@@ -199,6 +198,8 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
         },
       };
 
+      const { DashboardMutationClient } = await import('../mutation-api/DashboardMutationClient');
+      const { cmd } = await import('../mutation-api/cmd');
       const client = new DashboardMutationClient(this.getDashboard());
       const result = await client.execute(cmd.addVariable({ variable: defaultVariableKind }));
 
@@ -242,6 +243,9 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
         const variable = variables[editIndex];
         if (variable) {
           try {
+            const { createVariableKindFromSceneVariable } = await import('../mutation-api/commands/variableUtils');
+            const { DashboardMutationClient } = await import('../mutation-api/DashboardMutationClient');
+            const { cmd } = await import('../mutation-api/cmd');
             const variableKind = createVariableKindFromSceneVariable(variable, this.getDashboard());
             const client = new DashboardMutationClient(this.getDashboard());
             await client.execute(cmd.updateVariable({ name: variable.state.name, variable: variableKind }));

--- a/public/app/features/dashboard-scene/settings/VariablesEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VariablesEditView.tsx
@@ -28,7 +28,6 @@ import {
   type EditableVariableType,
   RESERVED_GLOBAL_VARIABLE_NAME_REGEX,
   WORD_CHARACTERS_REGEX,
-  getNextAvailableId,
   getVariableDefault,
   getVariableScene,
   isVariableEditable,
@@ -80,10 +79,14 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
 
   public onDelete = async (identifier: string) => {
     if (config.featureToggles.dashboardMutationApiVariablePilot) {
-      const { DashboardMutationClient } = await import('../mutation-api/DashboardMutationClient');
-      const { cmd } = await import('../mutation-api/cmd');
-      const client = new DashboardMutationClient(this.getDashboard());
-      await client.execute(cmd.removeVariable({ name: identifier }));
+      const variables = this.getVariables();
+      const sceneVar = variables.find((v) => v.state.name === identifier);
+      if (sceneVar) {
+        const { DashboardMutationClient } = await import('../mutation-api/DashboardMutationClient');
+        const { cmd } = await import('../mutation-api/cmd');
+        const client = new DashboardMutationClient(this.getDashboard());
+        await client.execute(cmd.removeVariable(sceneVar));
+      }
       this.setState({ editIndex: undefined });
       return;
     }
@@ -173,35 +176,11 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
     const variableIndex = variables.length;
 
     if (config.featureToggles.dashboardMutationApiVariablePilot) {
-      // Build a default QueryVariable as a VariableKind for the Mutation API.
-      const nextName = getNextAvailableId('query', variables);
-      const defaultVariableKind = {
-        kind: 'QueryVariable' as const,
-        spec: {
-          name: nextName,
-          query: {
-            kind: 'DataQuery' as const,
-            version: 'v0',
-            group: '',
-            spec: {},
-          },
-          refresh: 'onDashboardLoad' as const,
-          regex: '',
-          sort: 'disabled' as const,
-          multi: false,
-          includeAll: false,
-          allowCustomValue: true,
-          current: { text: '', value: '' },
-          options: [],
-          skipUrlSync: false,
-          hide: 'dontHide' as const,
-        },
-      };
-
+      const defaultNewVariable = getVariableDefault(variables);
       const { DashboardMutationClient } = await import('../mutation-api/DashboardMutationClient');
       const { cmd } = await import('../mutation-api/cmd');
       const client = new DashboardMutationClient(this.getDashboard());
-      const result = await client.execute(cmd.addVariable({ variable: defaultVariableKind }));
+      const result = await client.execute(cmd.addVariable(defaultNewVariable));
 
       if (result.success) {
         this.setState({ editIndex: variableIndex });
@@ -243,14 +222,12 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
         const variable = variables[editIndex];
         if (variable) {
           try {
-            const { createVariableKindFromSceneVariable } = await import('../mutation-api/commands/variableUtils');
             const { DashboardMutationClient } = await import('../mutation-api/DashboardMutationClient');
             const { cmd } = await import('../mutation-api/cmd');
-            const variableKind = createVariableKindFromSceneVariable(variable, this.getDashboard());
             const client = new DashboardMutationClient(this.getDashboard());
-            await client.execute(cmd.updateVariable({ name: variable.state.name, variable: variableKind }));
+            await client.execute(cmd.updateVariable(variable));
           } catch (error) {
-            // Non-fatal: if serialization fails, fall through to navigation.
+            // Non-fatal: fall through to navigation.
             console.error('Failed to call UPDATE_VARIABLE on goBack:', error);
           }
         }

--- a/public/app/features/dashboard-scene/settings/VariablesEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VariablesEditView.tsx
@@ -2,7 +2,6 @@ import { useMemo } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
 import { type NavModel, type NavModelItem, PageLayoutType } from '@grafana/data';
-import { config } from '@grafana/runtime';
 import {
   type SceneComponentProps,
   SceneObjectBase,
@@ -12,6 +11,7 @@ import {
 } from '@grafana/scenes';
 import { Page } from 'app/core/components/Page/Page';
 
+import { cmd } from '../mutation-api/cmd';
 import { type DashboardScene } from '../scene/DashboardScene';
 import { NavToolbarActions } from '../scene/NavToolbarActions';
 import { transformSceneToSaveModel } from '../serialization/transformSceneToSaveModel';
@@ -77,34 +77,13 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
     this.getVariableSet().setState({ variables: updatedVariables });
   };
 
-  public onDelete = async (identifier: string) => {
-    if (config.featureToggles.dashboardMutationApiVariablePilot) {
-      const variables = this.getVariables();
-      const sceneVar = variables.find((v) => v.state.name === identifier);
-      if (sceneVar) {
-        const { DashboardMutationClient } = await import('../mutation-api/DashboardMutationClient');
-        const { cmd } = await import('../mutation-api/cmd');
-        const client = new DashboardMutationClient(this.getDashboard());
-        await client.execute(cmd.removeVariable(sceneVar));
-      }
-      this.setState({ editIndex: undefined });
-      return;
-    }
-
-    // Find the index of the variable to be deleted
-    const variableIndex = this.getVariableIndex(identifier);
-    const { variables } = this.getVariableSet().state;
-    if (variableIndex === -1) {
-      // Handle the case where the variable is not found
+  public onDelete = (identifier: string) => {
+    const sceneVar = this.getVariables().find((v) => v.state.name === identifier);
+    if (!sceneVar) {
       console.error('Variable not found');
       return;
     }
-
-    // Create a new array excluding the variable to be deleted
-    const updatedVariables = [...variables.slice(0, variableIndex), ...variables.slice(variableIndex + 1)];
-
-    // Update the state or the variables array
-    this.getVariableSet().setState({ variables: updatedVariables });
+    this.getDashboard().mutationClient.execute(cmd.removeVariable(sceneVar));
     // Remove editIndex otherwise switches to next variable in list
     this.setState({ editIndex: undefined });
   };
@@ -171,26 +150,11 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
     this.setState({ editIndex: variableIndex });
   };
 
-  public onAdd = async () => {
+  public onAdd = () => {
     const variables = this.getVariables();
     const variableIndex = variables.length;
-
-    if (config.featureToggles.dashboardMutationApiVariablePilot) {
-      const defaultNewVariable = getVariableDefault(variables);
-      const { DashboardMutationClient } = await import('../mutation-api/DashboardMutationClient');
-      const { cmd } = await import('../mutation-api/cmd');
-      const client = new DashboardMutationClient(this.getDashboard());
-      const result = await client.execute(cmd.addVariable(defaultNewVariable));
-
-      if (result.success) {
-        this.setState({ editIndex: variableIndex });
-      }
-      return;
-    }
-
-    // Fallback: direct Scenes mutation.
     const defaultNewVariable = getVariableDefault(variables);
-    this.getVariableSet().setState({ variables: [...this.getVariables(), defaultNewVariable] });
+    this.getDashboard().mutationClient.execute(cmd.addVariable(defaultNewVariable));
     this.setState({ editIndex: variableIndex });
   };
 
@@ -211,32 +175,17 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
     this.replaceEditVariable(newVariable);
   };
 
-  public onGoBack = async () => {
-    if (config.featureToggles.dashboardMutationApiVariablePilot) {
-      const editIndex = this.state.editIndex;
-
-      // Only call UPDATE_VARIABLE when going back from an existing variable.
-      // New variables added via onAdd already have their state registered via ADD_VARIABLE.
-      if (editIndex !== undefined) {
-        const variables = this.getVariables();
-        const variable = variables[editIndex];
-        if (variable) {
-          try {
-            const { DashboardMutationClient } = await import('../mutation-api/DashboardMutationClient');
-            const { cmd } = await import('../mutation-api/cmd');
-            const client = new DashboardMutationClient(this.getDashboard());
-            await client.execute(cmd.updateVariable(variable));
-          } catch (error) {
-            // Non-fatal: fall through to navigation.
-            console.error('Failed to call UPDATE_VARIABLE on goBack:', error);
-          }
-        }
+  public onGoBack = () => {
+    const editIndex = this.state.editIndex;
+    if (editIndex !== undefined) {
+      // Register the edit pass through the Mutation API so it joins the
+      // undo/redo stack. New variables already registered via ADD_VARIABLE
+      // in onAdd, but their edited state lands here.
+      const variable = this.getVariables()[editIndex];
+      if (variable) {
+        this.getDashboard().mutationClient.execute(cmd.updateVariable(variable));
       }
-
-      this.setState({ editIndex: undefined });
-      return;
     }
-
     this.setState({ editIndex: undefined });
   };
 


### PR DESCRIPTION
## POC for Proposal 1 in the [Mutation API design doc](https://docs.google.com/document/d/1N1t368pLLNhgpXPFITAPBy_4bwKLbcGazKzZrXI4yXQ/edit)

Architecture: Scenes-native `cmd.*` overload + discriminated union `MutationRequest` + snapshot-based undo via `undoDomain` declared on each command.

Paired with [grafana/grafana#125252](https://github.com/grafana/grafana/pull/125252) (Proposal 2, layered UserActionsService). Both PRs demonstrate identical acceptance criteria.

> **For trade-offs, differentiators, validated properties, and the side-by-side summary table, read [Proposal 1 + Summary in the design doc](https://docs.google.com/document/d/1N1t368pLLNhgpXPFITAPBy_4bwKLbcGazKzZrXI4yXQ/edit).** Below is PR-specific implementation detail only.

## Architecture

```mermaid
sequenceDiagram
    actor UI as Variable editor<br/>(shared.ts)
    actor Agent as Assistant
    participant Client as DashboardMutationClient
    participant Scene as DashboardScene
    participant Handler as addVariableCommand<br/>handler
    participant Pane as DashboardEditPane

    UI->>Client: execute(cmd.addVariable(sceneVar))
    Note right of UI: __scenesPayload, no Zod
    Agent->>Client: execute({ type, payload })
    Note right of Agent: Zod validates payload

    Client->>Scene: isWriteLocked(lockTarget)?
    Note over Client: if locked: return { success:false, locked:true }
    Client->>Scene: canEditDashboard()?
    Client->>Scene: snapshot $variables (undoDomain)
    Client->>Handler: handler(payload, context)
    Handler->>Scene: replaceVariableSet(...)
    Client->>Pane: publish DashboardEditActionEvent<br/>(perform: skip-first, undo: restore snapshot)
    Pane->>Pane: push to undoStack
    Client-->>UI: MutationResult
```

## Same 5 acceptance criteria as #125252

| | This PR (Proposal 1) |
|---|---|
| **1. UI add flow** | Variable editor calls `dashboard.mutationClient.execute(cmd.addVariable(sceneVar))`. Scenes-native overload routes via `__scenesPayload`, no Zod roundtrip. |
| **2. Toolbar undo** | `DashboardMutationClient` snapshots before the handler, publishes `DashboardEditActionEvent` with restore-from-snapshot. Existing toolbar undo button just works. |
| **3. Canonical undo unit test** | Add `[a, b, c]`, remove `b`, undo restores at index 1, redo removes again. |
| **4. Multiplayer composition unit test** | Two sequential `client.execute(cmd.addVariable(...))`; second sees the state from the first. |
| **5. Working lock mechanism** | `DashboardScene.acquireWriteLock('variables')` short-circuits mutations with `{ success: false, locked: true, error }`. Reads via Scenes `useState` unaffected. Release, retry, succeeds. |

## Files changed (POC scope: addVariable / removeVariable / updateVariable)

```
public/app/features/dashboard-scene/
  edit-pane/shared.ts                          UI wiring
  mutation-api/DashboardMutationClient.ts      lock check
  mutation-api/cmd.ts                          (already present) Scenes-native overload
  mutation-api/types.ts                        + locked?: boolean
  mutation-api/commands/types.ts               + lockTarget?: string
  mutation-api/commands/{add,remove,update}Variable.ts  + lockTarget: 'variables'
  mutation-api/commands/variableCommands.test.ts        canonical undo + multiplayer + lock tests
  scene/DashboardScene.tsx                     + mutationClient getter, lock state, lock methods
```

## Run

```bash
yarn jest public/app/features/dashboard-scene/mutation-api/commands/variableCommands.test.ts
```

## no-changelog