### PR TITLE
feat(dashboard-scene): add DashboardScene.addVariable(), delegate from ADD_VARIABLE handler

### DIFF
--- a/public/app/features/dashboard-scene/mutation-api/commands/addVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/addVariable.ts
@@ -7,9 +7,6 @@
 import { type z } from 'zod';
 
 import { sceneGraph } from '@grafana/scenes';
-import type { VariableKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
-
-import { createSceneVariableFromVariableModel } from '../../serialization/transformSaveModelSchemaV2ToScene';
 
 import { payloads } from './schemas';
 import { enterEditModeIfNeeded, requiresEdit, type MutationCommand } from './types';
@@ -35,32 +32,18 @@ export const addVariableCommand: MutationCommand<AddVariablePayload> = {
       const { variable: variableKind, position } = payload;
       const name = variableKind.spec.name;
 
-      const existingVariables = scene.state.$variables;
-      if (existingVariables) {
-        const existing = existingVariables.state.variables.find((v) => v.state.name === name);
-        if (existing) {
-          throw new Error(`Variable '${name}' already exists`);
-        }
-      }
+      const variablesBeforeAdd = sceneGraph.getVariables(scene).state.variables.slice();
 
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Zod output is structurally compatible with VariableKind
-      const sceneVariable = createSceneVariableFromVariableModel(variableKind as VariableKind);
-
-      const varSet = sceneGraph.getVariables(scene);
-      const currentVariables = [...varSet.state.variables];
-
-      if (position !== undefined && position >= 0 && position < currentVariables.length) {
-        currentVariables.splice(position, 0, sceneVariable);
-      } else {
-        currentVariables.push(sceneVariable);
-      }
-
-      replaceVariableSet(scene, currentVariables);
+      scene.addVariable(variableKind, position);
 
       return {
         success: true,
         data: { variable: variableKind },
         changes: [{ path: `/variables/${name}`, previousValue: null, newValue: variableKind }],
+        _description: `Add variable '${name}'`,
+        _undo: () => {
+          replaceVariableSet(scene, variablesBeforeAdd);
+        },
       };
     } catch (error) {
       return {

--- a/public/app/features/dashboard-scene/mutation-api/commands/removeVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/removeVariable.ts
@@ -6,6 +6,8 @@
 
 import { type z } from 'zod';
 
+import { sceneGraph } from '@grafana/scenes';
+
 import { payloads } from './schemas';
 import { enterEditModeIfNeeded, requiresEdit, type MutationCommand } from './types';
 import { replaceVariableSet } from './variableUtils';
@@ -28,25 +30,24 @@ export const removeVariableCommand: MutationCommand<RemoveVariablePayload> = {
     enterEditModeIfNeeded(scene);
 
     try {
-      const variables = scene.state.$variables;
-      if (!variables) {
-        throw new Error('Dashboard has no variable set');
-      }
-
-      const variable = variables.getByName(name);
-      if (!variable) {
+      const varSet = sceneGraph.getVariables(scene);
+      const existingVar = varSet.state.variables.find((v) => v.state.name === name);
+      if (!existingVar) {
         throw new Error(`Variable '${name}' not found`);
       }
+      const previousState = existingVar.state;
+      const variablesBeforeRemove = varSet.state.variables.slice();
 
-      const previousState = variable.state;
-
-      const updatedVariables = variables.state.variables.filter((v) => v.state.name !== name);
-      replaceVariableSet(scene, updatedVariables);
+      scene.removeVariable(name);
 
       return {
         success: true,
         data: { name },
         changes: [{ path: `/variables/${name}`, previousValue: previousState, newValue: null }],
+        _description: `Remove variable '${name}'`,
+        _undo: () => {
+          replaceVariableSet(scene, variablesBeforeRemove);
+        },
       };
     } catch (error) {
       return {

--- a/public/app/features/dashboard-scene/mutation-api/commands/updateVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updateVariable.ts
@@ -7,9 +7,6 @@
 import { type z } from 'zod';
 
 import { sceneGraph } from '@grafana/scenes';
-import type { VariableKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
-
-import { createSceneVariableFromVariableModel } from '../../serialization/transformSaveModelSchemaV2ToScene';
 
 import { payloads } from './schemas';
 import { enterEditModeIfNeeded, requiresEdit, type MutationCommand } from './types';
@@ -33,33 +30,24 @@ export const updateVariableCommand: MutationCommand<UpdateVariablePayload> = {
 
     try {
       const { name, variable: variableKind } = payload;
-
       const varSet = sceneGraph.getVariables(scene);
-      const currentVariables = [...varSet.state.variables];
-
-      const existingIndex = currentVariables.findIndex((v) => v.state.name === name);
-      if (existingIndex === -1) {
+      const existingVar = varSet.state.variables.find((v) => v.state.name === name);
+      if (!existingVar) {
         throw new Error(`Variable '${name}' not found`);
       }
+      const previousState = existingVar.state;
+      const variablesBeforeUpdate = varSet.state.variables.slice();
 
-      const previousState = currentVariables[existingIndex].state;
-
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Zod output is structurally compatible with VariableKind
-      const newSceneVariable = createSceneVariableFromVariableModel(variableKind as VariableKind);
-      currentVariables[existingIndex] = newSceneVariable;
-
-      replaceVariableSet(scene, currentVariables);
+      scene.updateVariable(name, variableKind);
 
       return {
         success: true,
         data: { variable: variableKind },
-        changes: [
-          {
-            path: `/variables/${name}`,
-            previousValue: previousState,
-            newValue: variableKind,
-          },
-        ],
+        changes: [{ path: `/variables/${name}`, previousValue: previousState, newValue: variableKind }],
+        _description: `Update variable '${name}'`,
+        _undo: () => {
+          replaceVariableSet(scene, variablesBeforeUpdate);
+        },
       };
     } catch (error) {
       return {

--- a/public/app/features/dashboard-scene/mutation-api/commands/variableCommands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/variableCommands.test.ts
@@ -1,8 +1,12 @@
-import { SceneVariableSet } from '@grafana/scenes';
+import { sceneGraph, SceneVariableSet } from '@grafana/scenes';
+import type { VariableKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 
 import type { DashboardScene } from '../../scene/DashboardScene';
+import { createSceneVariableFromVariableModel } from '../../serialization/transformSaveModelSchemaV2ToScene';
 import { DashboardMutationClient } from '../DashboardMutationClient';
 import type { MutationResult } from '../types';
+
+import { replaceVariableSet } from './variableUtils';
 
 function buildMockScene(options: { editable?: boolean; isEditing?: boolean } = {}): DashboardScene {
   const { editable = true, isEditing = false } = options;
@@ -11,7 +15,7 @@ function buildMockScene(options: { editable?: boolean; isEditing?: boolean } = {
     isEditing,
     $variables: new SceneVariableSet({ variables: [] }),
   };
-  const scene = {
+  const scene: Record<string, unknown> = {
     state,
     canEditDashboard: jest.fn(() => editable),
     onEnterEditMode: jest.fn(() => {
@@ -27,6 +31,49 @@ function buildMockScene(options: { editable?: boolean; isEditing?: boolean } = {
       }
     }),
   };
+
+  scene.addVariable = (variable: VariableKind, position?: number) => {
+    const name = variable.spec.name;
+    const varSet = sceneGraph.getVariables(scene as unknown as DashboardScene);
+    const existing = varSet.state.variables.find((v) => v.state.name === name);
+    if (existing) {
+      throw new Error(`Variable '${name}' already exists`);
+    }
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- structurally compatible
+    const sceneVar = createSceneVariableFromVariableModel(variable as VariableKind);
+    const current = [...varSet.state.variables];
+    if (position !== undefined && position >= 0 && position < current.length) {
+      current.splice(position, 0, sceneVar);
+    } else {
+      current.push(sceneVar);
+    }
+    replaceVariableSet(scene as unknown as DashboardScene, current);
+  };
+
+  scene.updateVariable = (name: string, variable: VariableKind) => {
+    const varSet = sceneGraph.getVariables(scene as unknown as DashboardScene);
+    const current = [...varSet.state.variables];
+    const idx = current.findIndex((v) => v.state.name === name);
+    if (idx === -1) {
+      throw new Error(`Variable '${name}' not found`);
+    }
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- structurally compatible
+    current[idx] = createSceneVariableFromVariableModel(variable as VariableKind);
+    replaceVariableSet(scene as unknown as DashboardScene, current);
+  };
+
+  scene.removeVariable = (name: string) => {
+    const varSet = sceneGraph.getVariables(scene as unknown as DashboardScene);
+    const existing = varSet.state.variables.find((v) => v.state.name === name);
+    if (!existing) {
+      throw new Error(`Variable '${name}' not found`);
+    }
+    replaceVariableSet(
+      scene as unknown as DashboardScene,
+      varSet.state.variables.filter((v) => v.state.name !== name)
+    );
+  };
+
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- mock scene satisfies DashboardScene at runtime
   return scene as unknown as DashboardScene;
 }

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -376,6 +376,30 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
     replaceVariableSet(this, currentVariables);
   }
 
+  public updateVariable(name: string, variable: VariableKind): void {
+    const varSet = sceneGraph.getVariables(this);
+    const currentVariables = [...varSet.state.variables];
+    const existingIndex = currentVariables.findIndex((v) => v.state.name === name);
+    if (existingIndex === -1) {
+      throw new Error(`Variable '${name}' not found`);
+    }
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Zod output is structurally compatible with VariableKind
+    currentVariables[existingIndex] = createSceneVariableFromVariableModelV2(variable);
+    replaceVariableSet(this, currentVariables);
+  }
+
+  public removeVariable(name: string): void {
+    const varSet = sceneGraph.getVariables(this);
+    const existing = varSet.state.variables.find((v) => v.state.name === name);
+    if (!existing) {
+      throw new Error(`Variable '${name}' not found`);
+    }
+    replaceVariableSet(
+      this,
+      varSet.state.variables.filter((v) => v.state.name !== name)
+    );
+  }
+
   public setDefaultLinks(defaultLinks: DashboardLink[]) {
     const userLinks = this.state.links.filter((l) => !l.origin);
     this.setState({ links: [...defaultLinks, ...userLinks] });

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -354,18 +354,15 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
 
   public addVariable(variable: VariableKind, position?: number): void {
     const name = variable.spec.name;
-    const existingVariables = this.state.$variables;
-    if (existingVariables) {
-      const existing = existingVariables.state.variables.find((v) => v.state.name === name);
-      if (existing) {
-        throw new Error(`Variable '${name}' already exists`);
-      }
-    }
-
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Zod output is structurally compatible with VariableKind
     const sceneVariable = createSceneVariableFromVariableModelV2(variable);
     const varSet = sceneGraph.getVariables(this);
     const currentVariables = [...varSet.state.variables];
+
+    const existing = currentVariables.find((v) => v.state.name === name);
+    if (existing) {
+      throw new Error(`Variable '${name}' already exists`);
+    }
 
     if (position !== undefined && position >= 0 && position < currentVariables.length) {
       currentVariables.splice(position, 0, sceneVariable);

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -62,6 +62,7 @@ import {
 } from '../../apiserver/types';
 import { DashboardEditPane } from '../edit-pane/DashboardEditPane';
 import { dashboardEditActions } from '../edit-pane/shared';
+import { replaceVariableSet } from '../mutation-api/commands/variableUtils';
 import { type PanelEditor } from '../panel-edit/PanelEditor';
 import { getUpdatedHoverHeader } from '../panel-edit/getPanelFrameOptions';
 import { DashboardSceneChangeTracker } from '../saving/DashboardSceneChangeTracker';
@@ -349,6 +350,30 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
       .filter((v): v is SceneVariable => Boolean(v));
 
     variableSet.setState({ variables: [...defaultVarObjects, ...userVars] });
+  }
+
+  public addVariable(variable: VariableKind, position?: number): void {
+    const name = variable.spec.name;
+    const existingVariables = this.state.$variables;
+    if (existingVariables) {
+      const existing = existingVariables.state.variables.find((v) => v.state.name === name);
+      if (existing) {
+        throw new Error(`Variable '${name}' already exists`);
+      }
+    }
+
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Zod output is structurally compatible with VariableKind
+    const sceneVariable = createSceneVariableFromVariableModelV2(variable);
+    const varSet = sceneGraph.getVariables(this);
+    const currentVariables = [...varSet.state.variables];
+
+    if (position !== undefined && position >= 0 && position < currentVariables.length) {
+      currentVariables.splice(position, 0, sceneVariable);
+    } else {
+      currentVariables.push(sceneVariable);
+    }
+
+    replaceVariableSet(this, currentVariables);
   }
 
   public setDefaultLinks(defaultLinks: DashboardLink[]) {


### PR DESCRIPTION
## Summary

- Adds `DashboardScene.addVariable(variable: VariableKind, position?)`, `updateVariable(name, variable)`, and `removeVariable(name)` instance methods that encapsulate v2-to-Scenes transformation internally.
- All three variable mutation API handlers (`ADD_VARIABLE`, `UPDATE_VARIABLE`, `REMOVE_VARIABLE`) now delegate to these scene methods instead of duplicating the transformation logic.
- Handlers retain pre-mutation snapshot capture and `_undo`/`_description` for undo/redo wiring.
- Test mock updated with implementations of all three scene methods so existing command tests exercise the full delegation path.
- Follows the existing pattern of `setDefaultVariables(variables: VariableKind[])` which already accepts v2 schema payloads and transforms them inside `DashboardScene`.

This is the proof-of-concept for [Proposal 2 in the Mutation API design doc](https://docs.google.com/document/d/1Pwpg4wiNl-T9XP0MCch1TP7AXfwibYSFxgYx_NHgtpI/edit): DashboardScene as the mutation interface, with API handlers as thin validators that delegate to scene methods. The v2 transformation lives in one place; both the API handler and future UI call sites use the same code path.

## What's in scope

- `ADD_VARIABLE` handler delegates to `scene.addVariable()`
- `UPDATE_VARIABLE` handler delegates to `scene.updateVariable()`
- `REMOVE_VARIABLE` handler delegates to `scene.removeVariable()`
- `LIST_VARIABLES` is read-only and stays as-is (no scene method needed)

## Test plan

- [ ] All existing variable command tests pass with the new delegation path
- [ ] Manually verify adding/updating/removing a variable via the Assistant still works end-to-end
- [ ] Verify a direct `scene.addVariable(variableKind)` call produces the same Scenes state as the previous handler path