### PR TITLE
Search: require BuildVersion when snapshot store is configured

### DIFF
--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -125,7 +125,8 @@ type bleveBackend struct {
 
 	selectableFields map[string][]string
 
-	// Parsed opts.BuildVersion for snapshot tier comparisons. Nil if BuildVersion is empty.
+	// Parsed opts.BuildVersion for snapshot tier comparisons. Nil if BuildVersion
+	// is empty. Guaranteed non-nil when opts.Snapshot.Store is set.
 	runningBuildVersion *semver.Version
 
 	bgTasksCancel func()
@@ -158,6 +159,13 @@ func NewBleveBackend(opts BleveOptions, indexMetrics *resource.BleveIndexMetrics
 			return nil, fmt.Errorf("cannot parse build version %s: %w", opts.BuildVersion, err)
 		}
 		runningBuildVersion = v
+	}
+
+	// Snapshot selection compares against runningBuildVersion, so we require it
+	// to be set when the feature is enabled. This keeps the snapshot code free
+	// of nil checks.
+	if opts.Snapshot.Store != nil && runningBuildVersion == nil {
+		return nil, fmt.Errorf("bleve backend requires non-empty BuildVersion when snapshot store is configured")
 	}
 
 	l := opts.Logger

--- a/pkg/storage/unified/search/bleve_snapshot.go
+++ b/pkg/storage/unified/search/bleve_snapshot.go
@@ -30,7 +30,7 @@ const (
 type snapshotCandidate struct {
 	key     ulid.ULID
 	meta    *IndexMeta
-	version *semver.Version // always non-nil; unparseable entries are dropped earlier
+	version *semver.Version // always non-nil; pickBestSnapshot drops unparseable entries
 	tier    int             // 0 = best, 2 = last resort
 }
 
@@ -129,15 +129,14 @@ func (b *bleveBackend) pickBestSnapshot(all map[ulid.ULID]*IndexMeta, now time.T
 	var droppedAge, droppedUnparseable int
 	candidates := make([]snapshotCandidate, 0, len(all))
 	for k, m := range all {
-		if m == nil {
-			continue
-		}
 		// Hard filter: age.
 		if maxAge > 0 && now.Sub(m.UploadTimestamp) > maxAge {
 			droppedAge++
 			continue
 		}
-		// Hard filter: unparseable version (we can't tier it).
+		// Hard filter: unparseable version (we can't tier it). Metadata validation
+		// lives here rather than in the store so we don't have to duplicate it
+		// across store implementations.
 		v, err := semver.NewVersion(m.GrafanaBuildVersion)
 		if err != nil {
 			droppedUnparseable++
@@ -189,8 +188,10 @@ func (b *bleveBackend) pickBestSnapshot(all map[ulid.ULID]*IndexMeta, now time.T
 
 // snapshotTier returns the preference tier of v relative to the configured
 // lower bound (minVersion) and the running Grafana version. Lower = better.
+// running must be non-nil; the caller (NewBleveBackend) enforces this when the
+// snapshot feature is enabled.
 func snapshotTier(v, minVersion, running *semver.Version) int {
-	if running != nil && v.Compare(running) > 0 {
+	if v.Compare(running) > 0 {
 		return 2 // newer than running Grafana: last resort
 	}
 	if minVersion != nil && v.Compare(minVersion) < 0 {

--- a/pkg/storage/unified/search/bleve_snapshot_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_test.go
@@ -162,9 +162,6 @@ func TestSnapshotTier(t *testing.T) {
 	t.Run("no min: below running is tier 0", func(t *testing.T) {
 		assert.Equal(t, 0, snapshotTier(semver.MustParse("9.0.0"), nil, running))
 	})
-	t.Run("no running: anything is tier 0 or 1", func(t *testing.T) {
-		assert.Equal(t, 0, snapshotTier(semver.MustParse("99.0.0"), minV, nil))
-	})
 }
 
 func TestPickBestSnapshot(t *testing.T) {


### PR DESCRIPTION
## Summary

Follow-ups from [#123238 (comment)](https://github.com/grafana/grafana/pull/123238#issuecomment-4313317632):

- Require `BuildVersion` when `Snapshot.Store` is configured. Lets `snapshotTier` drop its `running != nil` check.
- Drop the `m == nil` guard in `pickBestSnapshot` — the store returns non-nil `*IndexMeta`.

The `age` and `unparseable GrafanaBuildVersion` filters stay: the store doesn't validate metadata semantics (different Grafana versions may write different fields), so the consumer rejects entries it can't reason about.

Part of grafana/search-and-storage-team#720.