### PR TITLE
Provisioning: Fix flaky webhook rotation tests racing with reconciler

### DIFF
--- a/pkg/tests/apis/provisioning/git/webhook/webhook_test.go
+++ b/pkg/tests/apis/provisioning/git/webhook/webhook_test.go
@@ -131,10 +131,16 @@ func TestIntegrationProvisioning_GithubRepoWebhookRecreatedWhenMissing(t *testin
 
 	waitForWebhook(t, helper, repoName, 789)
 
-	// Clear Status.Webhook to simulate restart / state loss.
+	// Clear Status.Webhook to simulate restart / state loss. Retry to absorb a
+	// concurrent reconcile that rotates secure.webhookSecret between the
+	// apistore's optimistic read and the resource server's re-read — the stale
+	// secure name makes the server reject this status patch with
+	// "secure value not found" even though the patch itself doesn't touch secure.
 	patch := []byte(`{"status":{"webhook":null}}`)
-	_, err := helper.Repositories.Resource.Patch(ctx, repoName, types.MergePatchType, patch, metav1.PatchOptions{}, "status")
-	require.NoError(t, err, "failed to clear webhook status")
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		_, err := helper.Repositories.Resource.Patch(ctx, repoName, types.MergePatchType, patch, metav1.PatchOptions{}, "status")
+		assert.NoError(collect, err)
+	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "clear webhook status")
 
 	// Trigger reconciliation by updating the spec.
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
@@ -217,11 +223,17 @@ func TestIntegrationProvisioning_WebhookSecretRotatedWhenExpired(t *testing.T) {
 
 	waitForWebhook(t, helper, repoName, 200)
 
-	// Patch LastRotated to a past value to simulate expired rotation.
+	// Patch LastRotated to a past value to simulate expired rotation. Retry to
+	// absorb a concurrent reconcile that rotates secure.webhookSecret between
+	// the apistore's optimistic read and the resource server's re-read — the
+	// stale secure name makes the server reject this status patch with
+	// "secure value not found" even though the patch itself doesn't touch secure.
 	expiredTimestamp := int64(1)
 	patch := []byte(fmt.Sprintf(`{"status":{"webhook":{"id":200,"url":"https://grafana.example.com/hook","subscribedEvents":["pull_request","push"],"lastRotated":%d}}}`, expiredTimestamp))
-	_, err := helper.Repositories.Resource.Patch(ctx, repoName, types.MergePatchType, patch, metav1.PatchOptions{}, "status")
-	require.NoError(t, err)
+	require.EventuallyWithT(t, func(collect *assert.CollectT) {
+		_, err := helper.Repositories.Resource.Patch(ctx, repoName, types.MergePatchType, patch, metav1.PatchOptions{}, "status")
+		assert.NoError(collect, err)
+	}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "expire LastRotated")
 
 	// Trigger reconciliation.
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {


### PR DESCRIPTION
## Summary

Fixes https://github.com/grafana/git-ui-sync-project/issues/1112.

`TestIntegrationProvisioning_WebhookSecretRotatedWhenExpired` (and the closely related `TestIntegrationProvisioning_GithubRepoWebhookRecreatedWhenMissing`) occasionally fail on CI with:

```
--- FAIL: TestIntegrationProvisioning_WebhookSecretRotatedWhenExpired
    webhook_test.go:224:
        Error: Received unexpected error: secure value not found
```

### Root cause

The tests issue a merge patch on the `/status` subresource to simulate an expired rotation or restart. That patch never touches `secure`, but the apiserver still runs `canReferenceSecureValues` during the write. That check compares the incoming object's `secure.webhookSecret` to what was just re-read from storage. Because the apistore reads at T1 (optimistic lock) and the resource server re-reads at T2 just before the check, a concurrent reconcile that rotates the webhook secret between T1 and T2 leaves the test's in-flight patch referencing an inline secret that has already been deleted. The check then calls `CanReference(<old name>)` and gets `ErrSecureValueNotFound`.

The error is transient — once the rotation commits, a retry of the same patch reads the new state and validates fine.

### Fix

Wrap both racy status patches in `EventuallyWithT` to retry the transient error. This matches the existing pattern already used in the same tests for spec updates.

### Verification

- 10/10 passes of the previously-flaky test locally (previously ~1/5 failed).
- Full `pkg/tests/apis/provisioning/git/webhook` suite passes.

## Test plan

- [x] `go test -tags=integration -run TestIntegrationProvisioning_WebhookSecretRotatedWhenExpired -count=10 ./pkg/tests/apis/provisioning/git/webhook/`
- [x] `go test -tags=integration ./pkg/tests/apis/provisioning/git/webhook/`
- [ ] CI passes on Sqlite Enterprise shard 12/16 (the shard this flake was reported on)

🤖 Generated with [Claude Code](https://claude.com/claude-code)