### PR TITLE
Alerting: Migrate org email validation to bulk query

### DIFF
--- a/pkg/services/ngalert/notifier/org_email_validator.go
+++ b/pkg/services/ngalert/notifier/org_email_validator.go
@@ -2,6 +2,7 @@ package notifier
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/mail"
 	"strings"
@@ -19,7 +20,7 @@ import (
 // table, which is the source of truth for membership (distinct from
 // user.OrgID, which only tracks the user's default/current org).
 type OrgMembershipLookup interface {
-	SearchOrgUsers(ctx context.Context, query *org.SearchOrgUsersQuery) (*org.SearchOrgUsersQueryResult, error)
+	SearchOrgUsersByEmails(ctx context.Context, query *org.SearchOrgUsersByEmailsQuery) ([]*org.OrgUserDTO, error)
 }
 
 type EmailIntegrationValidator interface {
@@ -59,7 +60,11 @@ func (v *OrgUserEmailValidator) ValidateIntegrationConfig(ctx context.Context, r
 	if err != nil {
 		return fmt.Errorf("failed to parse email settings: %w", err)
 	}
-	checked := make(map[string]struct{}, len(cfg.Addresses))
+
+	// pending maps lowercase email to its original display form.
+	// It doubles as a dedup set and tracks which addresses haven't been matched yet.
+	pending := make(map[string]string, len(cfg.Addresses))
+	emails := make([]string, 0, len(cfg.Addresses))
 	for _, address := range cfg.Addresses {
 		if address == "" {
 			continue
@@ -71,40 +76,31 @@ func (v *OrgUserEmailValidator) ValidateIntegrationConfig(ctx context.Context, r
 		if err != nil {
 			return fmt.Errorf("failed to parse email address %q: %w", address, err)
 		}
-		lowerAddr := strings.ToLower(addr.Address)
-		if _, ok := checked[lowerAddr]; ok {
-			continue
+		lower := strings.ToLower(addr.Address)
+		if _, ok := pending[lower]; !ok {
+			pending[lower] = addr.Address
+			emails = append(emails, lower)
 		}
-
-		exists, err := v.addressExistsInOrg(ctx, requester, lowerAddr)
-		if err != nil {
-			return fmt.Errorf("failed to validate email address %q: %w", addr.Address, err)
-		}
-		if !exists {
-			return fmt.Errorf("email address %q is not an allowed recipient for this organization", addr.Address)
-		}
-		checked[lowerAddr] = struct{}{}
 	}
-	return nil
-}
 
-func (v *OrgUserEmailValidator) addressExistsInOrg(ctx context.Context, requester identity.Requester, address string) (bool, error) {
-	result, err := v.orgSvc.SearchOrgUsers(ctx, &org.SearchOrgUsersQuery{
-		Query:                    address,
-		User:                     requester,
-		OrgID:                    requester.GetOrgID(),
-		DontEnforceAccessControl: true,
-		ExcludeHiddenUsers:       true,
+	if len(emails) == 0 {
+		return nil
+	}
+	members, err := v.orgSvc.SearchOrgUsersByEmails(ctx, &org.SearchOrgUsersByEmailsQuery{
+		OrgID:              requester.GetOrgID(),
+		Emails:             emails,
+		ExcludeHiddenUsers: true,
 	})
 	if err != nil {
-		return false, err
+		return fmt.Errorf("failed to get email addresses from organization members: %w", err)
 	}
-	for _, u := range result.OrgUsers {
-		if strings.EqualFold(u.Email, address) {
-			return true, nil
-		}
+	for _, m := range members {
+		delete(pending, strings.ToLower(m.Email))
 	}
-	return false, nil
+	if len(pending) > 0 {
+		return errors.New("one or many email addresses specified in the integration are not members of this organization")
+	}
+	return nil
 }
 
 type NoopOrgEmailValidator struct{}

--- a/pkg/services/ngalert/notifier/org_email_validator.go
+++ b/pkg/services/ngalert/notifier/org_email_validator.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/alerting/receivers/schema"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/org"
 )
@@ -24,8 +25,8 @@ type OrgMembershipLookup interface {
 }
 
 type EmailIntegrationValidator interface {
-	ValidateIntegrationConfig(ctx context.Context, requester identity.Requester, integration alertingModels.IntegrationConfig) error
-	ValidateIntegration(ctx context.Context, requester identity.Requester, integration models.Integration) error
+	ValidateIntegrationConfig(ctx context.Context, requester identity.Requester, integration alertingModels.IntegrationConfig, logger log.Logger) error
+	ValidateIntegration(ctx context.Context, requester identity.Requester, integration models.Integration, logger log.Logger) error
 }
 
 // OrgUserEmailValidator gates email address validation against org membership.
@@ -41,7 +42,7 @@ func NewEmailValidator(orgSvc OrgMembershipLookup, enabled bool) EmailIntegratio
 	return &NoopOrgEmailValidator{}
 }
 
-func (v *OrgUserEmailValidator) ValidateIntegration(ctx context.Context, requester identity.Requester, integration models.Integration) error {
+func (v *OrgUserEmailValidator) ValidateIntegration(ctx context.Context, requester identity.Requester, integration models.Integration, logger log.Logger) error {
 	if integration.Config.Type() != schema.EmailType || integration.Config.Version != schema.V1 { // TODO: support v0
 		return nil
 	}
@@ -49,10 +50,10 @@ func (v *OrgUserEmailValidator) ValidateIntegration(ctx context.Context, request
 	if err != nil {
 		return fmt.Errorf("failed to convert integration to integration config: %w", err)
 	}
-	return v.ValidateIntegrationConfig(ctx, requester, cfg)
+	return v.ValidateIntegrationConfig(ctx, requester, cfg, logger)
 }
 
-func (v *OrgUserEmailValidator) ValidateIntegrationConfig(ctx context.Context, requester identity.Requester, integration alertingModels.IntegrationConfig) error {
+func (v *OrgUserEmailValidator) ValidateIntegrationConfig(ctx context.Context, requester identity.Requester, integration alertingModels.IntegrationConfig, logger log.Logger) error {
 	if integration.Type != schema.EmailType || integration.Version != schema.V1 { // TODO: support v0
 		return nil
 	}
@@ -86,6 +87,8 @@ func (v *OrgUserEmailValidator) ValidateIntegrationConfig(ctx context.Context, r
 	if len(emails) == 0 {
 		return nil
 	}
+	l := logger.New("component", "email-integration-validator")
+	l.Info("Validating email addresses against organization members", "emails", len(emails))
 	members, err := v.orgSvc.SearchOrgUsersByEmails(ctx, &org.SearchOrgUsersByEmailsQuery{
 		OrgID:              requester.GetOrgID(),
 		Emails:             emails,
@@ -94,6 +97,7 @@ func (v *OrgUserEmailValidator) ValidateIntegrationConfig(ctx context.Context, r
 	if err != nil {
 		return fmt.Errorf("failed to get email addresses from organization members: %w", err)
 	}
+	l.Debug("Found organization members by emails", "emails", len(emails), "members", len(members))
 	for _, m := range members {
 		delete(pending, strings.ToLower(m.Email))
 	}
@@ -105,10 +109,10 @@ func (v *OrgUserEmailValidator) ValidateIntegrationConfig(ctx context.Context, r
 
 type NoopOrgEmailValidator struct{}
 
-func (v *NoopOrgEmailValidator) ValidateIntegrationConfig(_ context.Context, _ identity.Requester, _ alertingModels.IntegrationConfig) error {
+func (v *NoopOrgEmailValidator) ValidateIntegrationConfig(_ context.Context, _ identity.Requester, _ alertingModels.IntegrationConfig, _ log.Logger) error {
 	return nil
 }
 
-func (v *NoopOrgEmailValidator) ValidateIntegration(_ context.Context, _ identity.Requester, _ models.Integration) error {
+func (v *NoopOrgEmailValidator) ValidateIntegration(_ context.Context, _ identity.Requester, _ models.Integration, _ log.Logger) error {
 	return nil
 }

--- a/pkg/services/ngalert/notifier/org_email_validator.go
+++ b/pkg/services/ngalert/notifier/org_email_validator.go
@@ -11,7 +11,6 @@ import (
 	emailv1 "github.com/grafana/alerting/receivers/email/v1"
 	"github.com/grafana/alerting/receivers/schema"
 
-	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/org"
@@ -25,8 +24,8 @@ type OrgMembershipLookup interface {
 }
 
 type EmailIntegrationValidator interface {
-	ValidateIntegrationConfig(ctx context.Context, requester identity.Requester, integration alertingModels.IntegrationConfig, logger log.Logger) error
-	ValidateIntegration(ctx context.Context, requester identity.Requester, integration models.Integration, logger log.Logger) error
+	ValidateIntegrationConfig(ctx context.Context, orgID int64, integration alertingModels.IntegrationConfig, logger log.Logger) error
+	ValidateIntegration(ctx context.Context, orgID int64, integration models.Integration, logger log.Logger) error
 }
 
 // OrgUserEmailValidator gates email address validation against org membership.
@@ -42,7 +41,7 @@ func NewEmailValidator(orgSvc OrgMembershipLookup, enabled bool) EmailIntegratio
 	return &NoopOrgEmailValidator{}
 }
 
-func (v *OrgUserEmailValidator) ValidateIntegration(ctx context.Context, requester identity.Requester, integration models.Integration, logger log.Logger) error {
+func (v *OrgUserEmailValidator) ValidateIntegration(ctx context.Context, orgID int64, integration models.Integration, logger log.Logger) error {
 	if integration.Config.Type() != schema.EmailType || integration.Config.Version != schema.V1 { // TODO: support v0
 		return nil
 	}
@@ -50,10 +49,10 @@ func (v *OrgUserEmailValidator) ValidateIntegration(ctx context.Context, request
 	if err != nil {
 		return fmt.Errorf("failed to convert integration to integration config: %w", err)
 	}
-	return v.ValidateIntegrationConfig(ctx, requester, cfg, logger)
+	return v.ValidateIntegrationConfig(ctx, orgID, cfg, logger)
 }
 
-func (v *OrgUserEmailValidator) ValidateIntegrationConfig(ctx context.Context, requester identity.Requester, integration alertingModels.IntegrationConfig, logger log.Logger) error {
+func (v *OrgUserEmailValidator) ValidateIntegrationConfig(ctx context.Context, orgID int64, integration alertingModels.IntegrationConfig, logger log.Logger) error {
 	if integration.Type != schema.EmailType || integration.Version != schema.V1 { // TODO: support v0
 		return nil
 	}
@@ -90,7 +89,7 @@ func (v *OrgUserEmailValidator) ValidateIntegrationConfig(ctx context.Context, r
 	l := logger.New("component", "email-integration-validator")
 	l.Info("Validating email addresses against organization members", "emails", len(emails))
 	members, err := v.orgSvc.SearchOrgUsersByEmails(ctx, &org.SearchOrgUsersByEmailsQuery{
-		OrgID:              requester.GetOrgID(),
+		OrgID:              orgID,
 		Emails:             emails,
 		ExcludeHiddenUsers: true,
 	})
@@ -109,10 +108,10 @@ func (v *OrgUserEmailValidator) ValidateIntegrationConfig(ctx context.Context, r
 
 type NoopOrgEmailValidator struct{}
 
-func (v *NoopOrgEmailValidator) ValidateIntegrationConfig(_ context.Context, _ identity.Requester, _ alertingModels.IntegrationConfig, _ log.Logger) error {
+func (v *NoopOrgEmailValidator) ValidateIntegrationConfig(_ context.Context, _ int64, _ alertingModels.IntegrationConfig, _ log.Logger) error {
 	return nil
 }
 
-func (v *NoopOrgEmailValidator) ValidateIntegration(_ context.Context, _ identity.Requester, _ models.Integration, _ log.Logger) error {
+func (v *NoopOrgEmailValidator) ValidateIntegration(_ context.Context, _ int64, _ models.Integration, _ log.Logger) error {
 	return nil
 }

--- a/pkg/services/ngalert/notifier/org_email_validator_test.go
+++ b/pkg/services/ngalert/notifier/org_email_validator_test.go
@@ -11,19 +11,13 @@ import (
 	"github.com/grafana/alerting/receivers/schema"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/org/orgtest"
-	"github.com/grafana/grafana/pkg/services/user"
 )
 
 const testValidatorOrgID int64 = 7
-
-func requesterWithOrg(orgID int64) identity.Requester {
-	return &user.SignedInUser{OrgID: orgID}
-}
 
 // emailConfig builds a minimal email V1 IntegrationConfig with the given address string.
 func emailConfig(addresses string) alertingModels.IntegrationConfig {
@@ -139,7 +133,7 @@ func TestOrgUserEmailValidator_ValidateIntegrationConfig(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			v := &OrgUserEmailValidator{orgSvc: tc.orgSvc}
-			err := v.ValidateIntegrationConfig(context.Background(), requesterWithOrg(testValidatorOrgID), tc.config, log.NewNopLogger())
+			err := v.ValidateIntegrationConfig(context.Background(), testValidatorOrgID, tc.config, log.NewNopLogger())
 			if tc.wantErr != "" {
 				require.ErrorContains(t, err, tc.wantErr)
 			} else {
@@ -160,26 +154,26 @@ func TestOrgUserEmailValidator_ValidateIntegrationConfig(t *testing.T) {
 			return result, nil
 		}
 		v := &OrgUserEmailValidator{orgSvc: svc}
-		err := v.ValidateIntegrationConfig(context.Background(), requesterWithOrg(testValidatorOrgID), emailConfig("alice@org.com;alice@org.com"), log.NewNopLogger())
+		err := v.ValidateIntegrationConfig(context.Background(), testValidatorOrgID, emailConfig("alice@org.com;alice@org.com"), log.NewNopLogger())
 		require.NoError(t, err)
 		require.Equal(t, 1, searchCalls)
 	})
 
 	t.Run("lookup is case-insensitive", func(t *testing.T) {
 		v := &OrgUserEmailValidator{orgSvc: orgHavingMember("alice@org.com")}
-		err := v.ValidateIntegrationConfig(context.Background(), requesterWithOrg(testValidatorOrgID), emailConfig("Alice@Org.Com"), log.NewNopLogger())
+		err := v.ValidateIntegrationConfig(context.Background(), testValidatorOrgID, emailConfig("Alice@Org.Com"), log.NewNopLogger())
 		require.NoError(t, err)
 	})
 
 	t.Run("display-name format is parsed correctly", func(t *testing.T) {
 		v := &OrgUserEmailValidator{orgSvc: orgHavingMember("alice@org.com")}
-		err := v.ValidateIntegrationConfig(context.Background(), requesterWithOrg(testValidatorOrgID), emailConfig("Alice <alice@org.com>"), log.NewNopLogger())
+		err := v.ValidateIntegrationConfig(context.Background(), testValidatorOrgID, emailConfig("Alice <alice@org.com>"), log.NewNopLogger())
 		require.NoError(t, err)
 	})
 
 	t.Run("first address valid second not in org returns error", func(t *testing.T) {
 		v := &OrgUserEmailValidator{orgSvc: orgHavingMember("alice@org.com")}
-		err := v.ValidateIntegrationConfig(context.Background(), requesterWithOrg(testValidatorOrgID), emailConfig("alice@org.com;outsider@evil.com"), log.NewNopLogger())
+		err := v.ValidateIntegrationConfig(context.Background(), testValidatorOrgID, emailConfig("alice@org.com;outsider@evil.com"), log.NewNopLogger())
 		require.ErrorContains(t, err, "are not members of this organization")
 	})
 }
@@ -188,7 +182,7 @@ func TestOrgUserEmailValidator_ValidateIntegration(t *testing.T) {
 	t.Run("non-email integration type is skipped", func(t *testing.T) {
 		v := &OrgUserEmailValidator{orgSvc: orgWithoutMember()}
 		integration := models.IntegrationGen(models.IntegrationMuts.WithValidConfig(schema.SlackType))()
-		require.NoError(t, v.ValidateIntegration(context.Background(), requesterWithOrg(testValidatorOrgID), integration, log.NewNopLogger()))
+		require.NoError(t, v.ValidateIntegration(context.Background(), testValidatorOrgID, integration, log.NewNopLogger()))
 	})
 
 	t.Run("email V1 with org member succeeds", func(t *testing.T) {
@@ -197,7 +191,7 @@ func TestOrgUserEmailValidator_ValidateIntegration(t *testing.T) {
 			models.IntegrationMuts.WithValidConfig(schema.EmailType),
 			models.IntegrationMuts.WithSettings(map[string]any{"addresses": "alice@org.com"}),
 		)()
-		require.NoError(t, v.ValidateIntegration(context.Background(), requesterWithOrg(testValidatorOrgID), integration, log.NewNopLogger()))
+		require.NoError(t, v.ValidateIntegration(context.Background(), testValidatorOrgID, integration, log.NewNopLogger()))
 	})
 
 	t.Run("email V1 with non-org address returns error", func(t *testing.T) {
@@ -206,7 +200,7 @@ func TestOrgUserEmailValidator_ValidateIntegration(t *testing.T) {
 			models.IntegrationMuts.WithValidConfig(schema.EmailType),
 			models.IntegrationMuts.WithSettings(map[string]any{"addresses": "outsider@evil.com"}),
 		)()
-		require.ErrorContains(t, v.ValidateIntegration(context.Background(), requesterWithOrg(testValidatorOrgID), integration, log.NewNopLogger()), "are not members of this organization")
+		require.ErrorContains(t, v.ValidateIntegration(context.Background(), testValidatorOrgID, integration, log.NewNopLogger()), "are not members of this organization")
 	})
 }
 

--- a/pkg/services/ngalert/notifier/org_email_validator_test.go
+++ b/pkg/services/ngalert/notifier/org_email_validator_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/org/orgtest"
@@ -34,36 +35,30 @@ func emailConfig(addresses string) alertingModels.IntegrationConfig {
 	}
 }
 
-// orgHavingMember returns a FakeOrgService whose SearchOrgUsers returns the given email as an org member.
+// orgHavingMember returns a FakeOrgService whose SearchOrgUsersByEmails returns the given email as an org member.
 func orgHavingMember(email string) *orgtest.FakeOrgService {
 	svc := orgtest.NewOrgServiceFake()
-	svc.SearchOrgUsersFn = func(_ context.Context, q *org.SearchOrgUsersQuery) (*org.SearchOrgUsersQueryResult, error) {
-		if strings.EqualFold(q.Query, email) {
-			return &org.SearchOrgUsersQueryResult{
-				TotalCount: 1,
-				OrgUsers:   []*org.OrgUserDTO{{Email: email}},
-			}, nil
+	svc.SearchOrgUsersByEmailsFn = func(_ context.Context, q *org.SearchOrgUsersByEmailsQuery) ([]*org.OrgUserDTO, error) {
+		for _, e := range q.Emails {
+			if strings.EqualFold(e, email) {
+				return []*org.OrgUserDTO{{Email: email}}, nil
+			}
 		}
-		return &org.SearchOrgUsersQueryResult{}, nil
+		return nil, nil
 	}
 	return svc
 }
 
 // orgWithoutMember returns a FakeOrgService that finds no members for any query.
 func orgWithoutMember() *orgtest.FakeOrgService {
-	return &orgtest.FakeOrgService{
-		ExpectedSearchOrgUsersResult: &org.SearchOrgUsersQueryResult{},
-	}
+	return orgtest.NewOrgServiceFake()
 }
 
 func TestOrgUserEmailValidator_ValidateIntegrationConfig(t *testing.T) {
 	disabledMember := func() *orgtest.FakeOrgService {
 		svc := orgtest.NewOrgServiceFake()
-		svc.SearchOrgUsersFn = func(_ context.Context, _ *org.SearchOrgUsersQuery) (*org.SearchOrgUsersQueryResult, error) {
-			return &org.SearchOrgUsersQueryResult{
-				TotalCount: 1,
-				OrgUsers:   []*org.OrgUserDTO{{Email: "alice@org.com", IsDisabled: true}},
-			}, nil
+		svc.SearchOrgUsersByEmailsFn = func(_ context.Context, _ *org.SearchOrgUsersByEmailsQuery) ([]*org.OrgUserDTO, error) {
+			return []*org.OrgUserDTO{{Email: "alice@org.com", IsDisabled: true}}, nil
 		}
 		return svc
 	}
@@ -95,7 +90,7 @@ func TestOrgUserEmailValidator_ValidateIntegrationConfig(t *testing.T) {
 			name:    "email not found in org returns not-allowed error",
 			config:  emailConfig("outsider@org.com"),
 			orgSvc:  orgWithoutMember(),
-			wantErr: "is not an allowed recipient for this organization",
+			wantErr: "are not members of this organization",
 		},
 		{
 			name:   "email belongs to disabled user is allowed",
@@ -118,23 +113,23 @@ func TestOrgUserEmailValidator_ValidateIntegrationConfig(t *testing.T) {
 			name:    "org search error is returned",
 			config:  emailConfig("alice@org.com"),
 			orgSvc:  searchFails,
-			wantErr: "failed to validate email address",
+			wantErr: "failed to get email addresses from organization members",
 		},
 		{
 			name:   "multiple valid addresses all pass",
 			config: emailConfig("alice@org.com;bob@org.com"),
 			orgSvc: func() *orgtest.FakeOrgService {
 				svc := orgtest.NewOrgServiceFake()
-				svc.SearchOrgUsersFn = func(_ context.Context, q *org.SearchOrgUsersQuery) (*org.SearchOrgUsersQueryResult, error) {
-					for _, email := range []string{"alice@org.com", "bob@org.com"} {
-						if strings.EqualFold(q.Query, email) {
-							return &org.SearchOrgUsersQueryResult{
-								TotalCount: 1,
-								OrgUsers:   []*org.OrgUserDTO{{Email: email}},
-							}, nil
+				svc.SearchOrgUsersByEmailsFn = func(_ context.Context, q *org.SearchOrgUsersByEmailsQuery) ([]*org.OrgUserDTO, error) {
+					var result []*org.OrgUserDTO
+					for _, e := range q.Emails {
+						for _, member := range []string{"alice@org.com", "bob@org.com"} {
+							if strings.EqualFold(e, member) {
+								result = append(result, &org.OrgUserDTO{Email: member})
+							}
 						}
 					}
-					return &org.SearchOrgUsersQueryResult{}, nil
+					return result, nil
 				}
 				return svc
 			}(),
@@ -144,7 +139,7 @@ func TestOrgUserEmailValidator_ValidateIntegrationConfig(t *testing.T) {
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			v := &OrgUserEmailValidator{orgSvc: tc.orgSvc}
-			err := v.ValidateIntegrationConfig(context.Background(), requesterWithOrg(testValidatorOrgID), tc.config)
+			err := v.ValidateIntegrationConfig(context.Background(), requesterWithOrg(testValidatorOrgID), tc.config, log.NewNopLogger())
 			if tc.wantErr != "" {
 				require.ErrorContains(t, err, tc.wantErr)
 			} else {
@@ -156,35 +151,36 @@ func TestOrgUserEmailValidator_ValidateIntegrationConfig(t *testing.T) {
 	t.Run("duplicate addresses are checked only once", func(t *testing.T) {
 		var searchCalls int
 		svc := orgtest.NewOrgServiceFake()
-		svc.SearchOrgUsersFn = func(_ context.Context, q *org.SearchOrgUsersQuery) (*org.SearchOrgUsersQueryResult, error) {
+		svc.SearchOrgUsersByEmailsFn = func(_ context.Context, q *org.SearchOrgUsersByEmailsQuery) ([]*org.OrgUserDTO, error) {
 			searchCalls++
-			return &org.SearchOrgUsersQueryResult{
-				TotalCount: 1,
-				OrgUsers:   []*org.OrgUserDTO{{Email: q.Query}},
-			}, nil
+			result := make([]*org.OrgUserDTO, 0, len(q.Emails))
+			for _, e := range q.Emails {
+				result = append(result, &org.OrgUserDTO{Email: e})
+			}
+			return result, nil
 		}
 		v := &OrgUserEmailValidator{orgSvc: svc}
-		err := v.ValidateIntegrationConfig(context.Background(), requesterWithOrg(testValidatorOrgID), emailConfig("alice@org.com;alice@org.com"))
+		err := v.ValidateIntegrationConfig(context.Background(), requesterWithOrg(testValidatorOrgID), emailConfig("alice@org.com;alice@org.com"), log.NewNopLogger())
 		require.NoError(t, err)
 		require.Equal(t, 1, searchCalls)
 	})
 
 	t.Run("lookup is case-insensitive", func(t *testing.T) {
 		v := &OrgUserEmailValidator{orgSvc: orgHavingMember("alice@org.com")}
-		err := v.ValidateIntegrationConfig(context.Background(), requesterWithOrg(testValidatorOrgID), emailConfig("Alice@Org.Com"))
+		err := v.ValidateIntegrationConfig(context.Background(), requesterWithOrg(testValidatorOrgID), emailConfig("Alice@Org.Com"), log.NewNopLogger())
 		require.NoError(t, err)
 	})
 
 	t.Run("display-name format is parsed correctly", func(t *testing.T) {
 		v := &OrgUserEmailValidator{orgSvc: orgHavingMember("alice@org.com")}
-		err := v.ValidateIntegrationConfig(context.Background(), requesterWithOrg(testValidatorOrgID), emailConfig("Alice <alice@org.com>"))
+		err := v.ValidateIntegrationConfig(context.Background(), requesterWithOrg(testValidatorOrgID), emailConfig("Alice <alice@org.com>"), log.NewNopLogger())
 		require.NoError(t, err)
 	})
 
 	t.Run("first address valid second not in org returns error", func(t *testing.T) {
 		v := &OrgUserEmailValidator{orgSvc: orgHavingMember("alice@org.com")}
-		err := v.ValidateIntegrationConfig(context.Background(), requesterWithOrg(testValidatorOrgID), emailConfig("alice@org.com;outsider@evil.com"))
-		require.ErrorContains(t, err, "is not an allowed recipient for this organization")
+		err := v.ValidateIntegrationConfig(context.Background(), requesterWithOrg(testValidatorOrgID), emailConfig("alice@org.com;outsider@evil.com"), log.NewNopLogger())
+		require.ErrorContains(t, err, "are not members of this organization")
 	})
 }
 
@@ -192,7 +188,7 @@ func TestOrgUserEmailValidator_ValidateIntegration(t *testing.T) {
 	t.Run("non-email integration type is skipped", func(t *testing.T) {
 		v := &OrgUserEmailValidator{orgSvc: orgWithoutMember()}
 		integration := models.IntegrationGen(models.IntegrationMuts.WithValidConfig(schema.SlackType))()
-		require.NoError(t, v.ValidateIntegration(context.Background(), requesterWithOrg(testValidatorOrgID), integration))
+		require.NoError(t, v.ValidateIntegration(context.Background(), requesterWithOrg(testValidatorOrgID), integration, log.NewNopLogger()))
 	})
 
 	t.Run("email V1 with org member succeeds", func(t *testing.T) {
@@ -201,7 +197,7 @@ func TestOrgUserEmailValidator_ValidateIntegration(t *testing.T) {
 			models.IntegrationMuts.WithValidConfig(schema.EmailType),
 			models.IntegrationMuts.WithSettings(map[string]any{"addresses": "alice@org.com"}),
 		)()
-		require.NoError(t, v.ValidateIntegration(context.Background(), requesterWithOrg(testValidatorOrgID), integration))
+		require.NoError(t, v.ValidateIntegration(context.Background(), requesterWithOrg(testValidatorOrgID), integration, log.NewNopLogger()))
 	})
 
 	t.Run("email V1 with non-org address returns error", func(t *testing.T) {
@@ -210,7 +206,7 @@ func TestOrgUserEmailValidator_ValidateIntegration(t *testing.T) {
 			models.IntegrationMuts.WithValidConfig(schema.EmailType),
 			models.IntegrationMuts.WithSettings(map[string]any{"addresses": "outsider@evil.com"}),
 		)()
-		require.ErrorContains(t, v.ValidateIntegration(context.Background(), requesterWithOrg(testValidatorOrgID), integration), "is not an allowed recipient for this organization")
+		require.ErrorContains(t, v.ValidateIntegration(context.Background(), requesterWithOrg(testValidatorOrgID), integration, log.NewNopLogger()), "are not members of this organization")
 	})
 }
 

--- a/pkg/services/ngalert/notifier/receiver_svc.go
+++ b/pkg/services/ngalert/notifier/receiver_svc.go
@@ -398,7 +398,7 @@ func (rs *ReceiverService) CreateReceiver(ctx context.Context, r *models.Receive
 		return nil, err
 	}
 
-	if err := rs.validateReceiver(ctx, user, createdReceiver, logger); err != nil {
+	if err := rs.validateReceiver(ctx, orgID, createdReceiver, logger); err != nil {
 		span.RecordError(err)
 		return nil, models.ErrReceiverInvalid(err)
 	}
@@ -527,7 +527,7 @@ func (rs *ReceiverService) UpdateReceiver(ctx context.Context, r *models.Receive
 		updatedReceiver.WithExistingSecureFields(existing, storedSecureFields)
 	}
 
-	if err := rs.validateReceiver(ctx, user, updatedReceiver, logger); err != nil {
+	if err := rs.validateReceiver(ctx, orgID, updatedReceiver, logger); err != nil {
 		return nil, models.ErrReceiverInvalid(err)
 	}
 
@@ -867,7 +867,7 @@ func (rs *ReceiverService) getImportedReceivers(ctx context.Context, span trace.
 	return result
 }
 
-func (rs *ReceiverService) validateReceiver(ctx context.Context, user identity.Requester, receiver models.Receiver, l log.Logger) error {
+func (rs *ReceiverService) validateReceiver(ctx context.Context, orgID int64, receiver models.Receiver, l log.Logger) error {
 	if err := receiver.Validate(rs.decryptor(ctx)); err != nil {
 		return err
 	}
@@ -875,7 +875,7 @@ func (rs *ReceiverService) validateReceiver(ctx context.Context, user identity.R
 		if integration == nil || integration.Config.Type() != schema.EmailType {
 			continue
 		}
-		if err := rs.emailValidator.ValidateIntegration(ctx, user, *integration, l); err != nil {
+		if err := rs.emailValidator.ValidateIntegration(ctx, orgID, *integration, l); err != nil {
 			return fmt.Errorf("invalid email integration[%d]: %w", idx, err)
 		}
 	}

--- a/pkg/services/ngalert/notifier/receiver_svc.go
+++ b/pkg/services/ngalert/notifier/receiver_svc.go
@@ -383,6 +383,8 @@ func (rs *ReceiverService) CreateReceiver(ctx context.Context, r *models.Receive
 		return nil, models.ErrReceiverInvalid(err)
 	}
 
+	logger := rs.log.FromContext(ctx).New("receiver", result.Name, "integrations", result.GetIntegrationTypes())
+
 	revision, err := rs.cfgStore.Get(ctx, orgID)
 	if err != nil {
 		return nil, err
@@ -396,7 +398,7 @@ func (rs *ReceiverService) CreateReceiver(ctx context.Context, r *models.Receive
 		return nil, err
 	}
 
-	if err := rs.validateReceiver(ctx, user, createdReceiver); err != nil {
+	if err := rs.validateReceiver(ctx, user, createdReceiver, logger); err != nil {
 		span.RecordError(err)
 		return nil, models.ErrReceiverInvalid(err)
 	}
@@ -425,7 +427,7 @@ func (rs *ReceiverService) CreateReceiver(ctx context.Context, r *models.Receive
 		attribute.String("uid", result.UID),
 		attribute.String("version", result.Version),
 	))
-	rs.log.FromContext(ctx).Info("Created a new receiver", "receiver", result.Name, "uid", result.UID, "fingerprint", result.Version, "integrations", result.GetIntegrationTypes())
+	logger.Info("Created a new receiver", "uid", result.UID, "fingerprint", result.Version)
 	return result, nil
 }
 
@@ -525,7 +527,7 @@ func (rs *ReceiverService) UpdateReceiver(ctx context.Context, r *models.Receive
 		updatedReceiver.WithExistingSecureFields(existing, storedSecureFields)
 	}
 
-	if err := rs.validateReceiver(ctx, user, updatedReceiver); err != nil {
+	if err := rs.validateReceiver(ctx, user, updatedReceiver, logger); err != nil {
 		return nil, models.ErrReceiverInvalid(err)
 	}
 
@@ -865,7 +867,7 @@ func (rs *ReceiverService) getImportedReceivers(ctx context.Context, span trace.
 	return result
 }
 
-func (rs *ReceiverService) validateReceiver(ctx context.Context, user identity.Requester, receiver models.Receiver) error {
+func (rs *ReceiverService) validateReceiver(ctx context.Context, user identity.Requester, receiver models.Receiver, l log.Logger) error {
 	if err := receiver.Validate(rs.decryptor(ctx)); err != nil {
 		return err
 	}
@@ -873,7 +875,7 @@ func (rs *ReceiverService) validateReceiver(ctx context.Context, user identity.R
 		if integration == nil || integration.Config.Type() != schema.EmailType {
 			continue
 		}
-		if err := rs.emailValidator.ValidateIntegration(ctx, user, *integration); err != nil {
+		if err := rs.emailValidator.ValidateIntegration(ctx, user, *integration, l); err != nil {
 			return fmt.Errorf("invalid email integration[%d]: %w", idx, err)
 		}
 	}

--- a/pkg/services/ngalert/notifier/receiver_svc.go
+++ b/pkg/services/ngalert/notifier/receiver_svc.go
@@ -383,7 +383,7 @@ func (rs *ReceiverService) CreateReceiver(ctx context.Context, r *models.Receive
 		return nil, models.ErrReceiverInvalid(err)
 	}
 
-	logger := rs.log.FromContext(ctx).New("receiver", result.Name, "integrations", result.GetIntegrationTypes())
+	logger := rs.log.FromContext(ctx).New("receiver", r.Name, "integrations", r.GetIntegrationTypes())
 
 	revision, err := rs.cfgStore.Get(ctx, orgID)
 	if err != nil {

--- a/pkg/services/ngalert/notifier/receiver_testing_svc.go
+++ b/pkg/services/ngalert/notifier/receiver_testing_svc.go
@@ -9,6 +9,7 @@ import (
 	"github.com/prometheus/common/model"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
@@ -154,7 +155,7 @@ func (t *ReceiverTestingService) testIntegration(ctx context.Context, user ident
 	}
 	orgID := user.GetOrgID()
 	if integration.Config.Type() == schema.EmailType {
-		if err := t.emailValidator.ValidateIntegration(ctx, user, integration); err != nil {
+		if err := t.emailValidator.ValidateIntegration(ctx, user, integration, log.New("ngalert", "component", "integration-testing").FromContext(ctx)); err != nil {
 			return IntegrationTestResult{}, models.ErrReceiverInvalid(err)
 		}
 	}

--- a/pkg/services/ngalert/notifier/receiver_testing_svc.go
+++ b/pkg/services/ngalert/notifier/receiver_testing_svc.go
@@ -155,7 +155,7 @@ func (t *ReceiverTestingService) testIntegration(ctx context.Context, user ident
 	}
 	orgID := user.GetOrgID()
 	if integration.Config.Type() == schema.EmailType {
-		if err := t.emailValidator.ValidateIntegration(ctx, user, integration, log.New("ngalert", "component", "integration-testing").FromContext(ctx)); err != nil {
+		if err := t.emailValidator.ValidateIntegration(ctx, orgID, integration, log.New("ngalert", "component", "integration-testing").FromContext(ctx)); err != nil {
 			return IntegrationTestResult{}, models.ErrReceiverInvalid(err)
 		}
 	}

--- a/pkg/services/ngalert/notifier/receiver_testing_svc_test.go
+++ b/pkg/services/ngalert/notifier/receiver_testing_svc_test.go
@@ -95,7 +95,7 @@ func TestReceiverTestingService_TestNewReceiverIntegration(t *testing.T) {
 	expectedAlert, err := convertToAlertParam(alert)
 	require.NoError(t, err)
 
-	emailValidator.ValidateIntegrationFunc = func(ctx context.Context, requester identity.Requester, integration models.Integration, logger log.Logger) error {
+	emailValidator.ValidateIntegrationFunc = func(ctx context.Context, orgID int64, integration models.Integration, logger log.Logger) error {
 		if integration.Name == validEmailIntegration.Name {
 			return nil
 		}

--- a/pkg/services/ngalert/notifier/receiver_testing_svc_test.go
+++ b/pkg/services/ngalert/notifier/receiver_testing_svc_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -94,7 +95,7 @@ func TestReceiverTestingService_TestNewReceiverIntegration(t *testing.T) {
 	expectedAlert, err := convertToAlertParam(alert)
 	require.NoError(t, err)
 
-	emailValidator.ValidateIntegrationFunc = func(ctx context.Context, requester identity.Requester, integration models.Integration) error {
+	emailValidator.ValidateIntegrationFunc = func(ctx context.Context, requester identity.Requester, integration models.Integration, logger log.Logger) error {
 		if integration.Name == validEmailIntegration.Name {
 			return nil
 		}
@@ -120,8 +121,9 @@ func TestReceiverTestingService_TestNewReceiverIntegration(t *testing.T) {
 			expectedErr: ac.ErrAuthorizationBase,
 		},
 		{
-			name: "integration is tested successfully (receiverUID empty)",
-			user: userAuthorizedToCreate,
+			name:        "integration is tested successfully (receiverUID empty)",
+			integration: &slackIntegration,
+			user:        userAuthorizedToCreate,
 		},
 		{
 			name:                "integration type in allowlist is permitted",

--- a/pkg/services/ngalert/notifier/testing.go
+++ b/pkg/services/ngalert/notifier/testing.go
@@ -701,32 +701,32 @@ type FakeReceiverService struct {
 }
 
 type FakeEmailValidator struct {
-	ValidateIntegrationFunc       func(ctx context.Context, requester identity.Requester, integration models.Integration) error
-	ValidateIntegrationConfigFunc func(ctx context.Context, requester identity.Requester, integration alertingModels.IntegrationConfig) error
+	ValidateIntegrationFunc       func(ctx context.Context, requester identity.Requester, integration models.Integration, logger log.Logger) error
+	ValidateIntegrationConfigFunc func(ctx context.Context, requester identity.Requester, integration alertingModels.IntegrationConfig, logger log.Logger) error
 }
 
 func NewFakeEmailValidator(t *testing.T, err error) *FakeEmailValidator {
 	t.Helper()
 	return &FakeEmailValidator{
-		ValidateIntegrationFunc: func(ctx context.Context, requester identity.Requester, integration models.Integration) error {
+		ValidateIntegrationFunc: func(ctx context.Context, requester identity.Requester, integration models.Integration, logger log.Logger) error {
 			return err
 		},
-		ValidateIntegrationConfigFunc: func(ctx context.Context, requester identity.Requester, integration alertingModels.IntegrationConfig) error {
+		ValidateIntegrationConfigFunc: func(ctx context.Context, requester identity.Requester, integration alertingModels.IntegrationConfig, logger log.Logger) error {
 			return err
 		},
 	}
 }
 
-func (f *FakeEmailValidator) ValidateIntegration(ctx context.Context, requester identity.Requester, integration models.Integration) error {
+func (f *FakeEmailValidator) ValidateIntegration(ctx context.Context, requester identity.Requester, integration models.Integration, logger log.Logger) error {
 	if f.ValidateIntegrationFunc != nil {
-		return f.ValidateIntegrationFunc(ctx, requester, integration)
+		return f.ValidateIntegrationFunc(ctx, requester, integration, logger)
 	}
 	return nil
 }
 
-func (f *FakeEmailValidator) ValidateIntegrationConfig(ctx context.Context, requester identity.Requester, integration alertingModels.IntegrationConfig) error {
+func (f *FakeEmailValidator) ValidateIntegrationConfig(ctx context.Context, requester identity.Requester, integration alertingModels.IntegrationConfig, logger log.Logger) error {
 	if f.ValidateIntegrationConfigFunc != nil {
-		return f.ValidateIntegrationConfigFunc(ctx, requester, integration)
+		return f.ValidateIntegrationConfigFunc(ctx, requester, integration, logger)
 	}
 	return nil
 }

--- a/pkg/services/ngalert/notifier/testing.go
+++ b/pkg/services/ngalert/notifier/testing.go
@@ -701,32 +701,32 @@ type FakeReceiverService struct {
 }
 
 type FakeEmailValidator struct {
-	ValidateIntegrationFunc       func(ctx context.Context, requester identity.Requester, integration models.Integration, logger log.Logger) error
-	ValidateIntegrationConfigFunc func(ctx context.Context, requester identity.Requester, integration alertingModels.IntegrationConfig, logger log.Logger) error
+	ValidateIntegrationFunc       func(ctx context.Context, orgID int64, integration models.Integration, logger log.Logger) error
+	ValidateIntegrationConfigFunc func(ctx context.Context, orgID int64, integration alertingModels.IntegrationConfig, logger log.Logger) error
 }
 
 func NewFakeEmailValidator(t *testing.T, err error) *FakeEmailValidator {
 	t.Helper()
 	return &FakeEmailValidator{
-		ValidateIntegrationFunc: func(ctx context.Context, requester identity.Requester, integration models.Integration, logger log.Logger) error {
+		ValidateIntegrationFunc: func(ctx context.Context, orgID int64, integration models.Integration, logger log.Logger) error {
 			return err
 		},
-		ValidateIntegrationConfigFunc: func(ctx context.Context, requester identity.Requester, integration alertingModels.IntegrationConfig, logger log.Logger) error {
+		ValidateIntegrationConfigFunc: func(ctx context.Context, orgID int64, integration alertingModels.IntegrationConfig, logger log.Logger) error {
 			return err
 		},
 	}
 }
 
-func (f *FakeEmailValidator) ValidateIntegration(ctx context.Context, requester identity.Requester, integration models.Integration, logger log.Logger) error {
+func (f *FakeEmailValidator) ValidateIntegration(ctx context.Context, orgID int64, integration models.Integration, logger log.Logger) error {
 	if f.ValidateIntegrationFunc != nil {
-		return f.ValidateIntegrationFunc(ctx, requester, integration, logger)
+		return f.ValidateIntegrationFunc(ctx, orgID, integration, logger)
 	}
 	return nil
 }
 
-func (f *FakeEmailValidator) ValidateIntegrationConfig(ctx context.Context, requester identity.Requester, integration alertingModels.IntegrationConfig, logger log.Logger) error {
+func (f *FakeEmailValidator) ValidateIntegrationConfig(ctx context.Context, orgID int64, integration alertingModels.IntegrationConfig, logger log.Logger) error {
 	if f.ValidateIntegrationConfigFunc != nil {
-		return f.ValidateIntegrationConfigFunc(ctx, requester, integration, logger)
+		return f.ValidateIntegrationConfigFunc(ctx, orgID, integration, logger)
 	}
 	return nil
 }

--- a/pkg/services/ngalert/provisioning/contactpoints.go
+++ b/pkg/services/ngalert/provisioning/contactpoints.go
@@ -43,7 +43,7 @@ type AlertRuleNotificationSettingsStore interface {
 }
 
 type emailIntegrationValidator interface {
-	ValidateIntegrationConfig(ctx context.Context, user identity.Requester, integration alertingModels.IntegrationConfig, logger log.Logger) error
+	ValidateIntegrationConfig(ctx context.Context, orgID int64, integration alertingModels.IntegrationConfig, logger log.Logger) error
 }
 
 type ContactPointService struct {
@@ -177,7 +177,7 @@ func (ecp *ContactPointService) CreateContactPoint(
 	contactPoint apimodels.EmbeddedContactPoint,
 	provenance models.Provenance,
 ) (apimodels.EmbeddedContactPoint, error) {
-	if err := ecp.validateContactPoint(ctx, user, &contactPoint); err != nil {
+	if err := ecp.validateContactPoint(ctx, orgID, &contactPoint); err != nil {
 		return apimodels.EmbeddedContactPoint{}, fmt.Errorf("%w: %s", ErrValidation, err.Error())
 	}
 
@@ -299,7 +299,7 @@ func (ecp *ContactPointService) UpdateContactPoint(ctx context.Context, orgID in
 	}
 
 	// validate merged values
-	if err := ecp.validateContactPoint(ctx, user, &contactPoint); err != nil {
+	if err := ecp.validateContactPoint(ctx, orgID, &contactPoint); err != nil {
 		return fmt.Errorf("%w: %s", ErrValidation, err.Error())
 	}
 
@@ -652,7 +652,7 @@ groupLoop:
 	return oldReceiverName, fullRemoval, newReceiverCreated
 }
 
-func (ecp *ContactPointService) validateContactPoint(ctx context.Context, user identity.Requester, e *apimodels.EmbeddedContactPoint) error {
+func (ecp *ContactPointService) validateContactPoint(ctx context.Context, orgID int64, e *apimodels.EmbeddedContactPoint) error {
 	if err := ValidateContactPoint(ctx, e, ecp.encryptionService.GetDecryptedValue, ecp.allowedIntegrations); err != nil {
 		return err
 	}
@@ -663,7 +663,7 @@ func (ecp *ContactPointService) validateContactPoint(ctx context.Context, user i
 	if err != nil {
 		return err
 	}
-	return ecp.emailValidator.ValidateIntegrationConfig(ctx, user, integration, ecp.log.FromContext(ctx))
+	return ecp.emailValidator.ValidateIntegrationConfig(ctx, orgID, integration, ecp.log.FromContext(ctx))
 }
 
 func ValidateContactPoint(ctx context.Context, e *apimodels.EmbeddedContactPoint, decryptFunc alertingNotify.GetDecryptedValueFn, allowedIntegrations map[schema.IntegrationType]struct{}) error {

--- a/pkg/services/ngalert/provisioning/contactpoints.go
+++ b/pkg/services/ngalert/provisioning/contactpoints.go
@@ -43,7 +43,7 @@ type AlertRuleNotificationSettingsStore interface {
 }
 
 type emailIntegrationValidator interface {
-	ValidateIntegrationConfig(ctx context.Context, user identity.Requester, integration alertingModels.IntegrationConfig) error
+	ValidateIntegrationConfig(ctx context.Context, user identity.Requester, integration alertingModels.IntegrationConfig, logger log.Logger) error
 }
 
 type ContactPointService struct {
@@ -663,7 +663,7 @@ func (ecp *ContactPointService) validateContactPoint(ctx context.Context, user i
 	if err != nil {
 		return err
 	}
-	return ecp.emailValidator.ValidateIntegrationConfig(ctx, user, integration)
+	return ecp.emailValidator.ValidateIntegrationConfig(ctx, user, integration, ecp.log.FromContext(ctx))
 }
 
 func ValidateContactPoint(ctx context.Context, e *apimodels.EmbeddedContactPoint, decryptFunc alertingNotify.GetDecryptedValueFn, allowedIntegrations map[schema.IntegrationType]struct{}) error {


### PR DESCRIPTION
This is a follow-up for https://github.com/grafana/grafana/pull/123173 that updates the email validator to use bulk queries  https://github.com/grafana/grafana/pull/123288

Additional changes: 
- refactor validator methods to accept orgID instead of user, and split validation methods in provisioning. 
- adds logging for a fact of the validation.  