### PR TITLE
Stat: Fix percent change E2E tests racing panel render

### DIFF
--- a/e2e-playwright/panels-suite/stat.spec.ts
+++ b/e2e-playwright/panels-suite/stat.spec.ts
@@ -160,24 +160,34 @@ test.describe('Panels test: Stat', { tag: ['@panels', '@stat'] }, () => {
     await expect(page.getByTestId('icon-arrow-up'), 'upward arrow is shown for positive percent change').toBeVisible();
   });
 
-  test('percent change: zero shows no directional arrow', async ({ gotoDashboardPage, page }) => {
-    await gotoDashboardPage({
+  test('percent change: zero shows no directional arrow', async ({ gotoDashboardPage, selectors, page }) => {
+    const dashboardPage = await gotoDashboardPage({
       uid: DASHBOARD_UID,
       queryParams: new URLSearchParams({ editPanel: '32' }),
     });
 
     // panel 32: fixed CSV data 50 → 100 → 50 (0% net change) — shows "0%" text but no arrow
+    // wait for the percent-change widget to render before asserting arrow absence, otherwise
+    // toBeHidden() passes instantly on not-yet-attached icons (false positive).
+    const panelContent = dashboardPage.getByGrafanaSelector(selectors.components.Panels.Panel.content);
+    await expect(panelContent, 'percent change widget rendered').toContainText('0%');
+
     await expect(page.getByTestId('icon-arrow-up'), 'no upward arrow for zero percent change').toBeHidden();
     await expect(page.getByTestId('icon-arrow-down'), 'no downward arrow for zero percent change').toBeHidden();
   });
 
-  test('percent change: NaN is not displayed', async ({ gotoDashboardPage, page }) => {
-    await gotoDashboardPage({
+  test('percent change: NaN is not displayed', async ({ gotoDashboardPage, selectors, page }) => {
+    const dashboardPage = await gotoDashboardPage({
       uid: DASHBOARD_UID,
       queryParams: new URLSearchParams({ editPanel: '30' }),
     });
 
     // panel 30: fixed CSV data 0 → 0 (0/0 = NaN percent change) — percent change widget is hidden
+    // wait for the stat value to render before asserting arrow absence, otherwise toBeHidden()
+    // passes instantly on not-yet-attached icons (false positive).
+    const panelContent = dashboardPage.getByGrafanaSelector(selectors.components.Panels.Panel.content);
+    await expect(panelContent, 'stat value rendered').toContainText('0');
+
     await expect(page.getByTestId('icon-arrow-up'), 'no upward arrow for NaN percent change').toBeHidden();
     await expect(page.getByTestId('icon-arrow-down'), 'no downward arrow for NaN percent change').toBeHidden();
   });


### PR DESCRIPTION
## Summary

Running E2E playwright tests interactively showed two tests that fast-passed.

The two percent-change E2E tests in the stat panel suite were passing without waiting for the panel to render, producing false positives that would not catch a regression adding a directional arrow.

Affected tests:

- `percent change: zero shows no directional arrow` (panel 32)
- `percent change: NaN is not displayed` (panel 30)

## Fix

Wait for a stable render in the panel content before asserting arrow absence:

- Panel 32: wait for the `0%` percent-change text.
- Panel 30: wait for the stat value text (`0`); the percent-change widget is fully hidden, so there is no `%` text to wait on.

## Related

Follow-up to #123525 (merged) and #123276 (original stat E2E suite). The timing bug fixed here predates both.

## Test plan

- [x] \`yarn playwright test e2e-playwright/panels-suite/stat.spec.ts -g \"percent change\" --workers=1\` passes locally against a dev Grafana on \`localhost:3001\`.
- [ ] CI passes.