### PR TITLE
Azure Monitor: Pool gzip writers in Log Analytics deep-link encoder

### DIFF
--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource.go
@@ -14,6 +14,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -883,10 +884,17 @@ type LogAnalyticsMeta struct {
 	AzurePortalLink string   `json:"azurePortalLink,omitempty"`
 }
 
+var gzipWriterPool = sync.Pool{
+	New: func() any { return gzip.NewWriter(io.Discard) },
+}
+
 // encodeQuery encodes the query in gzip so the frontend can build links.
 func encodeQuery(rawQuery string) (string, error) {
 	var b bytes.Buffer
-	gz := gzip.NewWriter(&b)
+	gz := gzipWriterPool.Get().(*gzip.Writer)
+	defer gzipWriterPool.Put(gz)
+	gz.Reset(&b)
+
 	if _, err := gz.Write([]byte(rawQuery)); err != nil {
 		return "", err
 	}

--- a/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/loganalytics/azure-log-analytics-datasource_test.go
@@ -1,7 +1,10 @@
 package loganalytics
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -9,6 +12,7 @@ import (
 	"net/http/httptest"
 	"regexp"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -898,5 +902,69 @@ func TestAddTraceDataLinksToFields_EmptyResources(t *testing.T) {
 			require.Error(t, err)
 			require.Contains(t, err.Error(), tt.expectedErrorString)
 		})
+	}
+}
+
+func decodeEncodedQuery(t *testing.T, encoded string) string {
+	t.Helper()
+	gzipped, err := base64.StdEncoding.DecodeString(encoded)
+	require.NoError(t, err)
+	r, err := gzip.NewReader(bytes.NewReader(gzipped))
+	require.NoError(t, err)
+	defer func() { require.NoError(t, r.Close()) }()
+	decoded, err := io.ReadAll(r)
+	require.NoError(t, err)
+	return string(decoded)
+}
+
+func TestEncodeQuery(t *testing.T) {
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{name: "empty", query: ""},
+		{name: "simple", query: "Heartbeat | take 10"},
+		{name: "multiline", query: "Heartbeat\n| where TimeGenerated > ago(1d)\n| summarize count() by Computer"},
+		{name: "large", query: strings.Repeat("Heartbeat | where TimeGenerated > ago(1d) | summarize count() by Computer ", 50)},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			encoded, err := encodeQuery(tc.query)
+			require.NoError(t, err)
+			require.Equal(t, tc.query, decodeEncodedQuery(t, encoded))
+		})
+	}
+}
+
+func TestEncodeQueryConcurrent(t *testing.T) {
+	// Exercises the gzip.Writer sync.Pool under contention: each goroutine
+	// must produce output that decodes back to its own input.
+	const goroutines = 64
+	const iterations = 32
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func(g int) {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				query := fmt.Sprintf("Heartbeat | where Computer == 'c-%d-%d' | take 10", g, i)
+				encoded, err := encodeQuery(query)
+				require.NoError(t, err)
+				require.Equal(t, query, decodeEncodedQuery(t, encoded))
+			}
+		}(g)
+	}
+	wg.Wait()
+}
+
+func BenchmarkEncodeQuery(b *testing.B) {
+	query := strings.Repeat("Heartbeat | where TimeGenerated > ago(1d) | summarize count() by Computer ", 20)
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		if _, err := encodeQuery(query); err != nil {
+			b.Fatal(err)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

`encodeQuery` in the Log Analytics datasource builds the gzip+base64-encoded `ChartDefinition` segment of the Azure Portal deep-link embedded in frame metadata. It allocated a fresh `*gzip.Writer` — with its ~32 KB internal flate state — on every call, even though the writer is discarded immediately after use.

This change introduces a package-level `sync.Pool` of `*gzip.Writer` and rebinds the output buffer with `Reset` on each call. Output is byte-identical and there is no API or behaviour change.

## Benchmark

`go test -run none -bench BenchmarkEncodeQuery -benchtime=2s -count=3 ./pkg/tsdb/azuremonitor/loganalytics/` on darwin/arm64 (M-series, `-cpu=10`):

| Metric          |     Before |    After | Delta    |
| :-------------- | ---------: | -------: | :------- |
| Bytes per op    |    815,953 |    2,144 | −99.7%   |
| Allocations/op  |         23 |        6 | −74%     |
| Time/op (ns)    |    ~108000 |   ~27900 | −74%     |

Raw output:

```
BEFORE
BenchmarkEncodeQuery-10    14331    147067 ns/op    815954 B/op    23 allocs/op
BenchmarkEncodeQuery-10    20947    108165 ns/op    815952 B/op    23 allocs/op
BenchmarkEncodeQuery-10    46809     67753 ns/op    815953 B/op    23 allocs/op

AFTER
BenchmarkEncodeQuery-10    83186     27929 ns/op      2126 B/op     6 allocs/op
BenchmarkEncodeQuery-10   115932     28590 ns/op      2139 B/op     6 allocs/op
BenchmarkEncodeQuery-10   115909     20307 ns/op      2167 B/op     6 allocs/op
```

The remaining 2 KB / 6 allocs are the output buffer growth and the base64 result string, which are inherent to the function's contract.