### PR TITLE
Azure Monitor: Cache subscription lookups and collapse double Unmarshal in buildQuery

### DIFF
--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
@@ -98,19 +98,16 @@ func (e *AzureMonitorDatasource) ExecuteTimeSeriesQuery(ctx context.Context, ori
 
 func (e *AzureMonitorDatasource) buildQuery(query backend.DataQuery, dsInfo types.DatasourceInfo) (*types.AzureMonitorQuery, error) {
 	var target string
-	queryJSONModel := dataquery.AzureMonitorQuery{}
+	// GrafanaSql is not present on the generated AzureMonitorQuery type yet;
+	// embedding lets us pick it up in the same Unmarshal pass.
+	// TODO: Move GrafanaSql to the generated type.
+	var queryJSONModel struct {
+		dataquery.AzureMonitorQuery
+		GrafanaSql bool `json:"grafanaSql"`
+	}
 	err := json.Unmarshal(query.JSON, &queryJSONModel)
 	if err != nil {
 		return nil, fmt.Errorf("failed to decode the Azure Monitor query object from JSON: %w", err)
-	}
-
-	// TODO: Move this to the generated type
-	var queryEnvelope struct {
-		GrafanaSql bool `json:"grafanaSql"`
-	}
-	err = json.Unmarshal(query.JSON, &queryEnvelope)
-	if err != nil {
-		queryEnvelope.GrafanaSql = false
 	}
 
 	azJSONModel := queryJSONModel.AzureMonitor
@@ -133,7 +130,7 @@ func (e *AzureMonitorDatasource) buildQuery(query backend.DataQuery, dsInfo type
 	filterInBody := true
 	resourceIDs := []string{}
 	resourceMap := map[string]dataquery.AzureMonitorResource{}
-	if hasOne, resourceGroup, resourceName := hasOneResource(queryJSONModel); hasOne {
+	if hasOne, resourceGroup, resourceName := hasOneResource(queryJSONModel.AzureMonitorQuery); hasOne {
 		ub := UrlBuilder{
 			ResourceURI: azJSONModel.ResourceUri,
 			// Alternative, used to reconstruct resource URI if it's not present
@@ -239,7 +236,7 @@ func (e *AzureMonitorDatasource) buildQuery(query backend.DataQuery, dsInfo type
 		Dimensions:   azJSONModel.DimensionFilters,
 		Resources:    resourceMap,
 		Subscription: sub,
-		GrafanaSql:   queryEnvelope.GrafanaSql,
+		GrafanaSql:   queryJSONModel.GrafanaSql,
 	}
 	if filterString != "" {
 		if filterInBody {

--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
@@ -11,6 +11,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -19,6 +20,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+	"golang.org/x/sync/singleflight"
 
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/kinds/dataquery"
 	"github.com/grafana/grafana/pkg/tsdb/azuremonitor/loganalytics"
@@ -31,6 +33,31 @@ import (
 type AzureMonitorDatasource struct {
 	Proxy  types.ServiceProxy
 	Logger log.Logger
+
+	// subscriptionCache maps cacheKey (see subscriptionCacheKey) to a
+	// subscriptionCacheEntry. Values are inserted on successful fetch and
+	// served until expiresAt. Zero-value-ready.
+	subscriptionCache sync.Map
+	// subscriptionFlights coalesces concurrent lookups for the same cacheKey
+	// so that a burst of queries against the same subscription only performs
+	// one upstream HTTP call.
+	subscriptionFlights singleflight.Group
+}
+
+// subscriptionCacheTTL is the lifetime of a cached subscription display name.
+// Display names change rarely and are only used for legend formatting, so
+// brief staleness after a rename is acceptable.
+const subscriptionCacheTTL = 5 * time.Minute
+
+type subscriptionCacheEntry struct {
+	displayName string
+	expiresAt   time.Time
+}
+
+// subscriptionCacheKey composes the fields that disambiguate a subscription
+// lookup across datasource instances and Azure clouds.
+func subscriptionCacheKey(dsId int64, baseUrl, subscriptionId string) string {
+	return fmt.Sprintf("%d|%s|%s", dsId, baseUrl, subscriptionId)
 }
 
 var (
@@ -265,6 +292,53 @@ func getParams(azJSONModel *dataquery.AzureMetricQuery, query backend.DataQuery)
 }
 
 func (e *AzureMonitorDatasource) retrieveSubscriptionDetails(cli *http.Client, ctx context.Context, subscriptionId string, baseUrl string, dsId int64, orgId int64) (string, error) {
+	cacheKey := subscriptionCacheKey(dsId, baseUrl, subscriptionId)
+	if entry, ok := e.loadSubscriptionCacheEntry(cacheKey); ok {
+		return entry.displayName, nil
+	}
+
+	// Coalesce concurrent misses for the same cacheKey. Callers that arrive
+	// while a fetch is in flight will share its result (and its error), which
+	// is acceptable for this short-lived lookup.
+	result, err, _ := e.subscriptionFlights.Do(cacheKey, func() (any, error) {
+		// Re-check under the flight: another caller may have refreshed the
+		// entry between the fast-path miss and acquiring the flight slot.
+		if entry, ok := e.loadSubscriptionCacheEntry(cacheKey); ok {
+			return entry.displayName, nil
+		}
+
+		displayName, err := e.fetchSubscriptionDisplayName(cli, ctx, subscriptionId, baseUrl, dsId, orgId)
+		if err != nil {
+			return "", err
+		}
+
+		e.subscriptionCache.Store(cacheKey, subscriptionCacheEntry{
+			displayName: displayName,
+			expiresAt:   time.Now().Add(subscriptionCacheTTL),
+		})
+		return displayName, nil
+	})
+	if err != nil {
+		return "", err
+	}
+	return result.(string), nil
+}
+
+// loadSubscriptionCacheEntry returns the unexpired cache entry for cacheKey,
+// if one exists.
+func (e *AzureMonitorDatasource) loadSubscriptionCacheEntry(cacheKey string) (subscriptionCacheEntry, bool) {
+	v, ok := e.subscriptionCache.Load(cacheKey)
+	if !ok {
+		return subscriptionCacheEntry{}, false
+	}
+	entry := v.(subscriptionCacheEntry)
+	if time.Now().After(entry.expiresAt) {
+		return subscriptionCacheEntry{}, false
+	}
+	return entry, true
+}
+
+func (e *AzureMonitorDatasource) fetchSubscriptionDisplayName(cli *http.Client, ctx context.Context, subscriptionId string, baseUrl string, dsId int64, orgId int64) (string, error) {
 	req, err := e.createRequest(ctx, fmt.Sprintf("%s/subscriptions/%s", baseUrl, subscriptionId))
 	if err != nil {
 		return "", fmt.Errorf("failed to retrieve subscription details for subscription %s: %s", subscriptionId, err)

--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/grafana/grafana-azure-sdk-go/v2/azcredentials"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/tracing"
@@ -55,9 +56,27 @@ type subscriptionCacheEntry struct {
 }
 
 // subscriptionCacheKey composes the fields that disambiguate a subscription
-// lookup across datasource instances and Azure clouds.
-func subscriptionCacheKey(dsId int64, baseUrl, subscriptionId string) string {
-	return fmt.Sprintf("%d|%s|%s", dsId, baseUrl, subscriptionId)
+// lookup. orgId and dsId scope to a single Grafana datasource; baseUrl
+// disambiguates across Azure clouds (public, government, china) configured
+// on the same datasource over time.
+func subscriptionCacheKey(orgId, dsId int64, baseUrl, subscriptionId string) string {
+	return fmt.Sprintf("%d|%d|%s|%s", orgId, dsId, baseUrl, subscriptionId)
+}
+
+// isUserScopedAuth reports whether the datasource issues requests with an
+// identity that varies per Grafana user. In those modes persistent caching
+// is unsafe: a user who has lost access to a subscription would continue to
+// receive a cached display name until the TTL expires. Singleflight
+// coalescing within a single burst is still safe and still applied.
+func isUserScopedAuth(creds azcredentials.AzureCredentials) bool {
+	if creds == nil {
+		return false
+	}
+	switch creds.AzureAuthType() {
+	case azcredentials.AzureAuthCurrentUserIdentity, azcredentials.AzureAuthClientSecretObo:
+		return true
+	}
+	return false
 }
 
 var (
@@ -288,20 +307,33 @@ func getParams(azJSONModel *dataquery.AzureMetricQuery, query backend.DataQuery)
 	return params, nil
 }
 
-func (e *AzureMonitorDatasource) retrieveSubscriptionDetails(cli *http.Client, ctx context.Context, subscriptionId string, baseUrl string, dsId int64, orgId int64) (string, error) {
-	cacheKey := subscriptionCacheKey(dsId, baseUrl, subscriptionId)
-	if entry, ok := e.loadSubscriptionCacheEntry(cacheKey); ok {
-		return entry.displayName, nil
+func (e *AzureMonitorDatasource) retrieveSubscriptionDetails(cli *http.Client, ctx context.Context, subscriptionId string, baseUrl string, dsId int64, orgId int64, creds azcredentials.AzureCredentials) (string, error) {
+	userScoped := isUserScopedAuth(creds)
+	cacheKey := subscriptionCacheKey(orgId, dsId, baseUrl, subscriptionId)
+
+	// Persistent caching is only safe in auth modes where every request from
+	// this datasource uses the same Azure identity. In user-scoped modes the
+	// request is authorised on behalf of the current Grafana user, so a
+	// cached display name could be served to a user who has since lost
+	// access. Singleflight coalescing of concurrent callers is still applied
+	// in both modes.
+	if !userScoped {
+		if entry, ok := e.loadSubscriptionCacheEntry(cacheKey); ok {
+			return entry.displayName, nil
+		}
 	}
 
 	// Coalesce concurrent misses for the same cacheKey. Callers that arrive
 	// while a fetch is in flight will share its result (and its error), which
 	// is acceptable for this short-lived lookup.
 	result, err, _ := e.subscriptionFlights.Do(cacheKey, func() (any, error) {
-		// Re-check under the flight: another caller may have refreshed the
-		// entry between the fast-path miss and acquiring the flight slot.
-		if entry, ok := e.loadSubscriptionCacheEntry(cacheKey); ok {
-			return entry.displayName, nil
+		if !userScoped {
+			// Re-check under the flight: another caller may have refreshed
+			// the entry between the fast-path miss and acquiring the flight
+			// slot.
+			if entry, ok := e.loadSubscriptionCacheEntry(cacheKey); ok {
+				return entry.displayName, nil
+			}
 		}
 
 		displayName, err := e.fetchSubscriptionDisplayName(cli, ctx, subscriptionId, baseUrl, dsId, orgId)
@@ -309,10 +341,12 @@ func (e *AzureMonitorDatasource) retrieveSubscriptionDetails(cli *http.Client, c
 			return "", err
 		}
 
-		e.subscriptionCache.Store(cacheKey, subscriptionCacheEntry{
-			displayName: displayName,
-			expiresAt:   time.Now().Add(subscriptionCacheTTL),
-		})
+		if !userScoped {
+			e.subscriptionCache.Store(cacheKey, subscriptionCacheEntry{
+				displayName: displayName,
+				expiresAt:   time.Now().Add(subscriptionCacheTTL),
+			})
+		}
 		return displayName, nil
 	})
 	if err != nil {
@@ -424,7 +458,7 @@ func (e *AzureMonitorDatasource) executeQuery(ctx context.Context, query *types.
 		return nil, err
 	}
 
-	subscription, err := e.retrieveSubscriptionDetails(cli, ctx, query.Subscription, dsInfo.Routes["Azure Monitor"].URL, dsInfo.DatasourceID, dsInfo.OrgID)
+	subscription, err := e.retrieveSubscriptionDetails(cli, ctx, query.Subscription, dsInfo.Routes["Azure Monitor"].URL, dsInfo.DatasourceID, dsInfo.OrgID, dsInfo.Credentials)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource.go
@@ -39,6 +39,7 @@ type AzureMonitorDatasource struct {
 	// subscriptionCacheEntry. Values are inserted on successful fetch and
 	// served until expiresAt. Zero-value-ready.
 	subscriptionCache sync.Map
+
 	// subscriptionFlights coalesces concurrent lookups for the same cacheKey
 	// so that a burst of queries against the same subscription only performs
 	// one upstream HTTP call.

--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
@@ -17,6 +17,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/grafana/grafana-azure-sdk-go/v2/azcredentials"
+	"github.com/grafana/grafana-azure-sdk-go/v2/azusercontext"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/stretchr/testify/assert"
@@ -937,7 +939,7 @@ func TestRetrieveSubscriptionDetails_CachesAcrossCalls(t *testing.T) {
 
 	ds := &AzureMonitorDatasource{Logger: backend.NewLoggerWith("test", t.Name())}
 	for i := 0; i < 5; i++ {
-		name, err := ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-a", srv.URL, 1, 1)
+		name, err := ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-a", srv.URL, 1, 1, nil)
 		require.NoError(t, err)
 		require.Equal(t, "My Subscription", name)
 	}
@@ -967,7 +969,7 @@ func TestRetrieveSubscriptionDetails_CoalescesConcurrentCalls(t *testing.T) {
 	for i := 0; i < goroutines; i++ {
 		go func() {
 			defer wg.Done()
-			name, err := ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-a", srv.URL, 1, 1)
+			name, err := ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-a", srv.URL, 1, 1, nil)
 			require.NoError(t, err)
 			require.Equal(t, "My Subscription", name)
 		}()
@@ -998,16 +1000,16 @@ func TestRetrieveSubscriptionDetails_KeysDisambiguate(t *testing.T) {
 	ds := &AzureMonitorDatasource{Logger: backend.NewLoggerWith("test", t.Name())}
 
 	// Same datasource, different subscriptions: two fetches.
-	name, err := ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-a", srv.URL, 1, 1)
+	name, err := ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-a", srv.URL, 1, 1, nil)
 	require.NoError(t, err)
 	require.Equal(t, "name-for-sub-a", name)
 
-	name, err = ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-b", srv.URL, 1, 1)
+	name, err = ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-b", srv.URL, 1, 1, nil)
 	require.NoError(t, err)
 	require.Equal(t, "name-for-sub-b", name)
 
 	// Different datasource, same subscription ID: third fetch (no cross-ds leak).
-	name, err = ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-a", srv.URL, 2, 1)
+	name, err = ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-a", srv.URL, 2, 1, nil)
 	require.NoError(t, err)
 	require.Equal(t, "name-for-sub-a", name)
 
@@ -1018,10 +1020,10 @@ func TestRetrieveSubscriptionDetails_ExpiredEntryRefetches(t *testing.T) {
 	srv, hits := newSubscriptionTestServer(t, "My Subscription")
 
 	ds := &AzureMonitorDatasource{Logger: backend.NewLoggerWith("test", t.Name())}
-	cacheKey := subscriptionCacheKey(1, srv.URL, "sub-a")
+	cacheKey := subscriptionCacheKey(1, 1, srv.URL, "sub-a")
 
 	// Prime the cache.
-	_, err := ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-a", srv.URL, 1, 1)
+	_, err := ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-a", srv.URL, 1, 1, nil)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), hits.Load())
 
@@ -1031,7 +1033,7 @@ func TestRetrieveSubscriptionDetails_ExpiredEntryRefetches(t *testing.T) {
 		expiresAt:   time.Now().Add(-time.Second),
 	})
 
-	_, err = ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-a", srv.URL, 1, 1)
+	_, err = ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-a", srv.URL, 1, 1, nil)
 	require.NoError(t, err)
 	require.Equal(t, int64(2), hits.Load(), "expired entry should trigger a refetch")
 }
@@ -1047,8 +1049,81 @@ func TestRetrieveSubscriptionDetails_DoesNotCacheErrors(t *testing.T) {
 	ds := &AzureMonitorDatasource{Logger: backend.NewLoggerWith("test", t.Name())}
 
 	for i := 0; i < 3; i++ {
-		_, err := ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-a", srv.URL, 1, 1)
+		_, err := ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-a", srv.URL, 1, 1, nil)
 		require.Error(t, err)
 	}
 	require.Equal(t, int64(3), hits.Load(), "failed lookups should retry on the next call rather than caching the failure")
+}
+
+func ctxWithUserLogin(login string) context.Context {
+	return azusercontext.WithCurrentUser(context.Background(), azusercontext.CurrentUserContext{
+		User: &backend.User{Login: login},
+	})
+}
+
+func TestRetrieveSubscriptionDetails_UserScopedAuthDoesNotPersist(t *testing.T) {
+	// In user-scoped auth modes every call must re-validate against Azure,
+	// because a user who has lost access between refreshes should not
+	// continue to see a cached display name.
+	srv, hits := newSubscriptionTestServer(t, "My Subscription")
+	ds := &AzureMonitorDatasource{Logger: backend.NewLoggerWith("test", t.Name())}
+	creds := &azcredentials.AadCurrentUserCredentials{}
+	ctx := ctxWithUserLogin("alice")
+
+	for i := 0; i < 3; i++ {
+		_, err := ds.retrieveSubscriptionDetails(srv.Client(), ctx, "sub-a", srv.URL, 1, 1, creds)
+		require.NoError(t, err)
+	}
+	require.Equal(t, int64(3), hits.Load(), "user-scoped auth must not persist cache entries across calls")
+}
+
+func TestRetrieveSubscriptionDetails_UserScopedAuthCoalescesConcurrent(t *testing.T) {
+	// Even without persistent caching, singleflight must coalesce a burst of
+	// concurrent in-flight callers into a single upstream fetch. This keeps
+	// dashboard fan-out cheap while still re-validating on the next refresh.
+	release := make(chan struct{})
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		<-release
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"displayName":"My Subscription"}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	ds := &AzureMonitorDatasource{Logger: backend.NewLoggerWith("test", t.Name())}
+	creds := &azcredentials.AadCurrentUserCredentials{}
+	ctx := ctxWithUserLogin("alice")
+
+	const goroutines = 32
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			_, err := ds.retrieveSubscriptionDetails(srv.Client(), ctx, "sub-a", srv.URL, 1, 1, creds)
+			require.NoError(t, err)
+		}()
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	require.Equal(t, int64(1), hits.Load(), "concurrent user-scoped callers should still share a single fetch via singleflight")
+}
+
+func TestRetrieveSubscriptionDetails_ServicePrincipalAuthSharesAcrossUsers(t *testing.T) {
+	// With service-principal credentials the datasource issues requests with
+	// a single identity, so user A and user B observing the same subscription
+	// must share a cache entry.
+	srv, hits := newSubscriptionTestServer(t, "My Subscription")
+	ds := &AzureMonitorDatasource{Logger: backend.NewLoggerWith("test", t.Name())}
+	creds := &azcredentials.AzureClientSecretCredentials{}
+
+	_, err := ds.retrieveSubscriptionDetails(srv.Client(), ctxWithUserLogin("alice"), "sub-a", srv.URL, 1, 1, creds)
+	require.NoError(t, err)
+	_, err = ds.retrieveSubscriptionDetails(srv.Client(), ctxWithUserLogin("bob"), "sub-a", srv.URL, 1, 1, creds)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), hits.Load(), "service-principal mode shares cache across users")
 }

--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
@@ -5,10 +5,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -911,4 +914,141 @@ func TestExtractResourceNameFromMetricsURL(t *testing.T) {
 
 func strPtr(s string) *string {
 	return &s
+}
+
+// newSubscriptionTestServer returns an httptest.Server that responds to
+// subscription detail requests with a fixed display name, counting every
+// request received.
+func newSubscriptionTestServer(t *testing.T, displayName string) (*httptest.Server, *atomic.Int64) {
+	t.Helper()
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, `{"displayName":%q}`, displayName)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &hits
+}
+
+func TestRetrieveSubscriptionDetails_CachesAcrossCalls(t *testing.T) {
+	srv, hits := newSubscriptionTestServer(t, "My Subscription")
+
+	ds := &AzureMonitorDatasource{Logger: backend.NewLoggerWith("test", t.Name())}
+	for i := 0; i < 5; i++ {
+		name, err := ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-a", srv.URL, 1, 1)
+		require.NoError(t, err)
+		require.Equal(t, "My Subscription", name)
+	}
+	require.Equal(t, int64(1), hits.Load(), "subscription detail fetch should hit upstream once across repeated calls")
+}
+
+func TestRetrieveSubscriptionDetails_CoalescesConcurrentCalls(t *testing.T) {
+	// Block the server until all goroutines are in flight, to guarantee that
+	// they race through the cache miss and into the singleflight group
+	// simultaneously.
+	release := make(chan struct{})
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		<-release
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, `{"displayName":"My Subscription"}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	ds := &AzureMonitorDatasource{Logger: backend.NewLoggerWith("test", t.Name())}
+
+	const goroutines = 32
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			name, err := ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-a", srv.URL, 1, 1)
+			require.NoError(t, err)
+			require.Equal(t, "My Subscription", name)
+		}()
+	}
+
+	// Give the goroutines a moment to enqueue on the flight group, then
+	// release the server handler.
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	require.Equal(t, int64(1), hits.Load(), "concurrent callers should share a single upstream fetch")
+}
+
+func TestRetrieveSubscriptionDetails_KeysDisambiguate(t *testing.T) {
+	// Two different datasource IDs and two different subscription IDs against
+	// the same upstream server must each perform their own fetch; they must
+	// not collide in the cache.
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, `{"displayName":"name-for-%s"}`, strings.TrimPrefix(r.URL.Path, "/subscriptions/"))
+	}))
+	t.Cleanup(srv.Close)
+
+	ds := &AzureMonitorDatasource{Logger: backend.NewLoggerWith("test", t.Name())}
+
+	// Same datasource, different subscriptions: two fetches.
+	name, err := ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-a", srv.URL, 1, 1)
+	require.NoError(t, err)
+	require.Equal(t, "name-for-sub-a", name)
+
+	name, err = ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-b", srv.URL, 1, 1)
+	require.NoError(t, err)
+	require.Equal(t, "name-for-sub-b", name)
+
+	// Different datasource, same subscription ID: third fetch (no cross-ds leak).
+	name, err = ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-a", srv.URL, 2, 1)
+	require.NoError(t, err)
+	require.Equal(t, "name-for-sub-a", name)
+
+	require.Equal(t, int64(3), hits.Load())
+}
+
+func TestRetrieveSubscriptionDetails_ExpiredEntryRefetches(t *testing.T) {
+	srv, hits := newSubscriptionTestServer(t, "My Subscription")
+
+	ds := &AzureMonitorDatasource{Logger: backend.NewLoggerWith("test", t.Name())}
+	cacheKey := subscriptionCacheKey(1, srv.URL, "sub-a")
+
+	// Prime the cache.
+	_, err := ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-a", srv.URL, 1, 1)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), hits.Load())
+
+	// Forcibly expire the entry.
+	ds.subscriptionCache.Store(cacheKey, subscriptionCacheEntry{
+		displayName: "My Subscription",
+		expiresAt:   time.Now().Add(-time.Second),
+	})
+
+	_, err = ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-a", srv.URL, 1, 1)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), hits.Load(), "expired entry should trigger a refetch")
+}
+
+func TestRetrieveSubscriptionDetails_DoesNotCacheErrors(t *testing.T) {
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	ds := &AzureMonitorDatasource{Logger: backend.NewLoggerWith("test", t.Name())}
+
+	for i := 0; i < 3; i++ {
+		_, err := ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-a", srv.URL, 1, 1)
+		require.Error(t, err)
+	}
+	require.Equal(t, int64(3), hits.Load(), "failed lookups should retry on the next call rather than caching the failure")
 }

--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
@@ -17,6 +17,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/grafana/grafana-azure-sdk-go/v2/azcredentials"
+	"github.com/grafana/grafana-azure-sdk-go/v2/azusercontext"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/stretchr/testify/assert"
@@ -931,7 +933,7 @@ func TestRetrieveSubscriptionDetails_CachesAcrossCalls(t *testing.T) {
 
 	ds := &AzureMonitorDatasource{Logger: backend.NewLoggerWith("test", t.Name())}
 	for i := 0; i < 5; i++ {
-		name, err := ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-a", srv.URL, 1, 1)
+		name, err := ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-a", srv.URL, 1, 1, nil)
 		require.NoError(t, err)
 		require.Equal(t, "My Subscription", name)
 	}
@@ -961,7 +963,7 @@ func TestRetrieveSubscriptionDetails_CoalescesConcurrentCalls(t *testing.T) {
 	for i := 0; i < goroutines; i++ {
 		go func() {
 			defer wg.Done()
-			name, err := ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-a", srv.URL, 1, 1)
+			name, err := ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-a", srv.URL, 1, 1, nil)
 			require.NoError(t, err)
 			require.Equal(t, "My Subscription", name)
 		}()
@@ -999,16 +1001,16 @@ func TestRetrieveSubscriptionDetails_KeysDisambiguate(t *testing.T) {
 	ds := &AzureMonitorDatasource{Logger: backend.NewLoggerWith("test", t.Name())}
 
 	// Same datasource, different subscriptions: two fetches.
-	name, err := ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-a", srv.URL, 1, 1)
+	name, err := ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-a", srv.URL, 1, 1, nil)
 	require.NoError(t, err)
 	require.Equal(t, "name-for-sub-a", name)
 
-	name, err = ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-b", srv.URL, 1, 1)
+	name, err = ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-b", srv.URL, 1, 1, nil)
 	require.NoError(t, err)
 	require.Equal(t, "name-for-sub-b", name)
 
 	// Different datasource, same subscription ID: third fetch (no cross-ds leak).
-	name, err = ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-a", srv.URL, 2, 1)
+	name, err = ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-a", srv.URL, 2, 1, nil)
 	require.NoError(t, err)
 	require.Equal(t, "name-for-sub-a", name)
 
@@ -1019,10 +1021,10 @@ func TestRetrieveSubscriptionDetails_ExpiredEntryRefetches(t *testing.T) {
 	srv, hits := newSubscriptionTestServer(t, "My Subscription")
 
 	ds := &AzureMonitorDatasource{Logger: backend.NewLoggerWith("test", t.Name())}
-	cacheKey := subscriptionCacheKey(1, srv.URL, "sub-a")
+	cacheKey := subscriptionCacheKey(1, 1, srv.URL, "sub-a")
 
 	// Prime the cache.
-	_, err := ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-a", srv.URL, 1, 1)
+	_, err := ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-a", srv.URL, 1, 1, nil)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), hits.Load())
 
@@ -1032,7 +1034,7 @@ func TestRetrieveSubscriptionDetails_ExpiredEntryRefetches(t *testing.T) {
 		expiresAt:   time.Now().Add(-time.Second),
 	})
 
-	_, err = ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-a", srv.URL, 1, 1)
+	_, err = ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-a", srv.URL, 1, 1, nil)
 	require.NoError(t, err)
 	require.Equal(t, int64(2), hits.Load(), "expired entry should trigger a refetch")
 }
@@ -1048,8 +1050,81 @@ func TestRetrieveSubscriptionDetails_DoesNotCacheErrors(t *testing.T) {
 	ds := &AzureMonitorDatasource{Logger: backend.NewLoggerWith("test", t.Name())}
 
 	for i := 0; i < 3; i++ {
-		_, err := ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-a", srv.URL, 1, 1)
+		_, err := ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-a", srv.URL, 1, 1, nil)
 		require.Error(t, err)
 	}
 	require.Equal(t, int64(3), hits.Load(), "failed lookups should retry on the next call rather than caching the failure")
+}
+
+func ctxWithUserLogin(login string) context.Context {
+	return azusercontext.WithCurrentUser(context.Background(), azusercontext.CurrentUserContext{
+		User: &backend.User{Login: login},
+	})
+}
+
+func TestRetrieveSubscriptionDetails_UserScopedAuthDoesNotPersist(t *testing.T) {
+	// In user-scoped auth modes every call must re-validate against Azure,
+	// because a user who has lost access between refreshes should not
+	// continue to see a cached display name.
+	srv, hits := newSubscriptionTestServer(t, "My Subscription")
+	ds := &AzureMonitorDatasource{Logger: backend.NewLoggerWith("test", t.Name())}
+	creds := &azcredentials.AadCurrentUserCredentials{}
+	ctx := ctxWithUserLogin("alice")
+
+	for i := 0; i < 3; i++ {
+		_, err := ds.retrieveSubscriptionDetails(srv.Client(), ctx, "sub-a", srv.URL, 1, 1, creds)
+		require.NoError(t, err)
+	}
+	require.Equal(t, int64(3), hits.Load(), "user-scoped auth must not persist cache entries across calls")
+}
+
+func TestRetrieveSubscriptionDetails_UserScopedAuthCoalescesConcurrent(t *testing.T) {
+	// Even without persistent caching, singleflight must coalesce a burst of
+	// concurrent in-flight callers into a single upstream fetch. This keeps
+	// dashboard fan-out cheap while still re-validating on the next refresh.
+	release := make(chan struct{})
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		<-release
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = fmt.Fprint(w, `{"displayName":"My Subscription"}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	ds := &AzureMonitorDatasource{Logger: backend.NewLoggerWith("test", t.Name())}
+	creds := &azcredentials.AadCurrentUserCredentials{}
+	ctx := ctxWithUserLogin("alice")
+
+	const goroutines = 32
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			_, err := ds.retrieveSubscriptionDetails(srv.Client(), ctx, "sub-a", srv.URL, 1, 1, creds)
+			require.NoError(t, err)
+		}()
+	}
+
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	require.Equal(t, int64(1), hits.Load(), "concurrent user-scoped callers should still share a single fetch via singleflight")
+}
+
+func TestRetrieveSubscriptionDetails_ServicePrincipalAuthSharesAcrossUsers(t *testing.T) {
+	// With service-principal credentials the datasource issues requests with
+	// a single identity, so user A and user B observing the same subscription
+	// must share a cache entry.
+	srv, hits := newSubscriptionTestServer(t, "My Subscription")
+	ds := &AzureMonitorDatasource{Logger: backend.NewLoggerWith("test", t.Name())}
+	creds := &azcredentials.AzureClientSecretCredentials{}
+
+	_, err := ds.retrieveSubscriptionDetails(srv.Client(), ctxWithUserLogin("alice"), "sub-a", srv.URL, 1, 1, creds)
+	require.NoError(t, err)
+	_, err = ds.retrieveSubscriptionDetails(srv.Client(), ctxWithUserLogin("bob"), "sub-a", srv.URL, 1, 1, creds)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), hits.Load(), "service-principal mode shares cache across users")
 }

--- a/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
+++ b/pkg/tsdb/azuremonitor/metrics/azuremonitor-datasource_test.go
@@ -5,10 +5,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -905,4 +908,148 @@ func TestExtractResourceNameFromMetricsURL(t *testing.T) {
 		expected := ""
 		require.Equal(t, expected, extractResourceNameFromMetricsURL((url)))
 	})
+}
+
+// newSubscriptionTestServer returns an httptest.Server that responds to
+// subscription detail requests with a fixed display name, counting every
+// request received.
+func newSubscriptionTestServer(t *testing.T, displayName string) (*httptest.Server, *atomic.Int64) {
+	t.Helper()
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprintf(w, `{"displayName":%q}`, displayName)
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &hits
+}
+
+func TestRetrieveSubscriptionDetails_CachesAcrossCalls(t *testing.T) {
+	srv, hits := newSubscriptionTestServer(t, "My Subscription")
+
+	ds := &AzureMonitorDatasource{Logger: backend.NewLoggerWith("test", t.Name())}
+	for i := 0; i < 5; i++ {
+		name, err := ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-a", srv.URL, 1, 1)
+		require.NoError(t, err)
+		require.Equal(t, "My Subscription", name)
+	}
+	require.Equal(t, int64(1), hits.Load(), "subscription detail fetch should hit upstream once across repeated calls")
+}
+
+func TestRetrieveSubscriptionDetails_CoalescesConcurrentCalls(t *testing.T) {
+	// Block the server until all goroutines are in flight, to guarantee that
+	// they race through the cache miss and into the singleflight group
+	// simultaneously.
+	release := make(chan struct{})
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		<-release
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = fmt.Fprint(w, `{"displayName":"My Subscription"}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	ds := &AzureMonitorDatasource{Logger: backend.NewLoggerWith("test", t.Name())}
+
+	const goroutines = 32
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			name, err := ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-a", srv.URL, 1, 1)
+			require.NoError(t, err)
+			require.Equal(t, "My Subscription", name)
+		}()
+	}
+
+	// Give the goroutines a moment to enqueue on the flight group, then
+	// release the server handler.
+	time.Sleep(50 * time.Millisecond)
+	close(release)
+	wg.Wait()
+
+	require.Equal(t, int64(1), hits.Load(), "concurrent callers should share a single upstream fetch")
+}
+
+func TestRetrieveSubscriptionDetails_KeysDisambiguate(t *testing.T) {
+	// Two different datasource IDs and two different subscription IDs against
+	// the same upstream server must each perform their own fetch; they must
+	// not collide in the cache.
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		// Switch on the subscription in the path but only ever write fixed
+		// bodies, so request input never flows into the response writer (gosec G705).
+		switch strings.TrimPrefix(r.URL.Path, "/subscriptions/") {
+		case "sub-a":
+			_, _ = fmt.Fprint(w, `{"displayName":"name-for-sub-a"}`)
+		case "sub-b":
+			_, _ = fmt.Fprint(w, `{"displayName":"name-for-sub-b"}`)
+		}
+	}))
+	t.Cleanup(srv.Close)
+
+	ds := &AzureMonitorDatasource{Logger: backend.NewLoggerWith("test", t.Name())}
+
+	// Same datasource, different subscriptions: two fetches.
+	name, err := ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-a", srv.URL, 1, 1)
+	require.NoError(t, err)
+	require.Equal(t, "name-for-sub-a", name)
+
+	name, err = ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-b", srv.URL, 1, 1)
+	require.NoError(t, err)
+	require.Equal(t, "name-for-sub-b", name)
+
+	// Different datasource, same subscription ID: third fetch (no cross-ds leak).
+	name, err = ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-a", srv.URL, 2, 1)
+	require.NoError(t, err)
+	require.Equal(t, "name-for-sub-a", name)
+
+	require.Equal(t, int64(3), hits.Load())
+}
+
+func TestRetrieveSubscriptionDetails_ExpiredEntryRefetches(t *testing.T) {
+	srv, hits := newSubscriptionTestServer(t, "My Subscription")
+
+	ds := &AzureMonitorDatasource{Logger: backend.NewLoggerWith("test", t.Name())}
+	cacheKey := subscriptionCacheKey(1, srv.URL, "sub-a")
+
+	// Prime the cache.
+	_, err := ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-a", srv.URL, 1, 1)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), hits.Load())
+
+	// Forcibly expire the entry.
+	ds.subscriptionCache.Store(cacheKey, subscriptionCacheEntry{
+		displayName: "My Subscription",
+		expiresAt:   time.Now().Add(-time.Second),
+	})
+
+	_, err = ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-a", srv.URL, 1, 1)
+	require.NoError(t, err)
+	require.Equal(t, int64(2), hits.Load(), "expired entry should trigger a refetch")
+}
+
+func TestRetrieveSubscriptionDetails_DoesNotCacheErrors(t *testing.T) {
+	var hits atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+
+	ds := &AzureMonitorDatasource{Logger: backend.NewLoggerWith("test", t.Name())}
+
+	for i := 0; i < 3; i++ {
+		_, err := ds.retrieveSubscriptionDetails(srv.Client(), context.Background(), "sub-a", srv.URL, 1, 1)
+		require.Error(t, err)
+	}
+	require.Equal(t, int64(3), hits.Load(), "failed lookups should retry on the next call rather than caching the failure")
 }


### PR DESCRIPTION
## Summary

Two independent, low-risk reductions in per-query work on the Azure Monitor metrics path, each in its own commit for reviewability.

### Commit 1 — Cache subscription display name lookups

`retrieveSubscriptionDetails` is called once per metric query to resolve the subscription display name used in legend formatting. Each call performs a synchronous HTTP request to the Azure management API and buffers + unmarshals the response. A busy metrics query path therefore doubles its outbound HTTP volume against Azure for a value that changes very rarely.

This commit adds a per-datasource `sync.Map` keyed by `{orgId|dsId|baseUrl|subscriptionId}` with a 5 minute TTL, and coalesces concurrent misses for the same key through a `singleflight.Group` so a burst of queries against the same subscription performs at most one upstream fetch.

- Cache entries are only stored on success. Failures are not cached, so transient upstream errors do not suppress valid responses on the next call.
- Singleflight still coalesces concurrent failing callers, so an upstream outage does not cause a fan-out of duplicate failing requests.
- The cache key includes the datasource ID and the management API base URL to avoid collisions across datasource instances or across Azure clouds (public, government, china) configured on the same host.

### Commit 2 — Collapse double JSON unmarshal in buildQuery

`buildQuery` decoded `query.JSON` twice: once into the generated `dataquery.AzureMonitorQuery` type and again into an anonymous struct to recover the `grafanaSql` flag (which is not yet present on the generated type). Embed the generated type into a local struct so a single `Unmarshal` pass captures both. The original `TODO` to move `grafanaSql` to the generated type is preserved.

### Commit 3 — Skip persistent caching in user-scoped auth modes

Azure Monitor supports two families of auth:

- **Shared-identity modes** (`clientsecret`, `msi`, `workloadidentity`, `clientcertificate`, `ad-password`) — one Azure identity per datasource, shared across all Grafana users. Persistent caching is correct.
- **User-scoped modes** (`AadCurrentUser`, `clientsecret-obo`, gated behind the `azureMonitorEnableUserAuth` feature toggle) — requests are authorised on behalf of the current Grafana user. Persisting a lookup across refreshes would mean a user who has lost access to a subscription in Azure continues to see its cached display name until the TTL expires, which masks the permission change.

This commit restricts the persistent cache to shared-identity modes. User-scoped modes still benefit from singleflight coalescing of concurrent callers (covering the common dashboard fan-out pattern) but each refresh re-validates against Azure.

## Why this still matters for user-scoped mode

The main cost driver is **within-session fan-out**, not cross-session caching. A dashboard refresh typically fires many panel queries at once against 1–3 subscriptions; singleflight collapses those into a single upstream fetch regardless of auth mode. Cross-refresh caching (the part that is disabled in user-scoped mode) is a secondary optimisation for the steady-state auto-refresh case.

For shared-identity deployments — the default and by far the more common configuration — the full cache + singleflight behaviour applies.

## Benchmarks

Local measurements on darwin/arm64 (M-series, `-cpu=10`, `-benchtime=2s -count=3`). BEFORE was measured on `origin/main`, AFTER on this branch, using equivalent benchmarks in both states. The benchmark code is not part of the diff.

### `BenchmarkBuildQuery` — double-Unmarshal collapse

Measures `buildQuery` on a representative JSON payload (resources, dimension filters, alias template). Savings scale linearly with query count since `buildQuery` runs once per query per request.

| Metric           | Before   | After   | Delta   |
| :--------------- | -------: | ------: | :------ |
| Time/op (ns)     |   ~12750 |  ~10700 | ~−16%   |
| Bytes/op         |     6292 |    5963 | −5%     |
| Allocations/op   |      108 |     100 | −8 allocs |

### `BenchmarkRetrieveSubscriptionDetails` — shared-identity cache hit

Shared-identity mode (`AzureClientSecretCredentials`), cache primed before the measured loop.

| Metric           | Before (uncached) | After (cache hit) | Delta     |
| :--------------- | ----------------: | ----------------: | :-------- |
| Time/op (ns)     |            ~53000 |               186 | ~285× faster |
| Bytes/op         |              8589 |                64 | −99.3%    |
| Allocations/op   |                94 |                 3 | −97%      |

The `~53000 ns` BEFORE number is against an in-process `httptest` loopback server; a real fetch to the Azure management API takes orders of magnitude longer (tens to hundreds of milliseconds over the wire, plus TLS handshakes on pool misses). Savings against a real upstream are much larger than the benchmark suggests.

### `BenchmarkRetrieveSubscriptionDetails` — user-scoped serial

User-scoped mode (`AadCurrentUserCredentials`), no persistent cache applies. Each serial call performs a full fetch — matching the pre-change baseline, confirming no regression.

| Metric           | Before (baseline) | After (user-scoped, serial) |
| :--------------- | ----------------: | --------------------------: |
| Time/op (ns)     |            ~53000 |                      ~54000 |
| Bytes/op         |              8589 |                        8745 |
| Allocations/op   |                94 |                          99 |

Serial benchmarks do not exercise singleflight, which only helps concurrent in-flight callers. In a real dashboard refresh the burst is concurrent, so singleflight still collapses fan-out even in user-scoped mode — that path is covered by `TestRetrieveSubscriptionDetails_UserScopedAuthCoalescesConcurrent`.