### PR TITLE
SQL Expressions: add structure-preserving query redactor for analytics (proposal)

### DIFF
--- a/pkg/expr/sql/redact.go
+++ b/pkg/expr/sql/redact.go
@@ -123,8 +123,8 @@ func (r *redactor) name(kind identKind, original string) string {
 func (r *redactor) redact(stmt sqlparser.SQLNode) {
 	_ = sqlparser.Walk(func(node sqlparser.SQLNode) (bool, error) {
 		if cte, ok := node.(*sqlparser.CommonTableExpr); ok && cte.AliasedTableExpr != nil {
-			if !cte.AliasedTableExpr.As.IsEmpty() {
-				_ = r.name(identKindTable, cte.AliasedTableExpr.As.String())
+			if !cte.As.IsEmpty() {
+				_ = r.name(identKindTable, cte.As.String())
 			}
 		}
 		return true, nil

--- a/pkg/expr/sql/redact.go
+++ b/pkg/expr/sql/redact.go
@@ -1,0 +1,254 @@
+package sql
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/dolthub/vitess/go/vt/sqlparser"
+)
+
+// RedactedQuery returns a structure-preserving, value/identifier-redacted version
+// of the supplied SQL Expression query. It is intended for usage analytics so we
+// can understand how SQL Expressions are being used (joins, aggregations,
+// subqueries, CTEs, window functions, etc.) without leaking any potentially
+// sensitive content from the query itself.
+//
+// All literal values are replaced with placeholders (`?` for strings, `0` for
+// numeric/hex/bit literals). All user-defined identifiers are replaced with
+// deterministic, monotonically numbered placeholders so that structural
+// relationships within the same query — for example, joining two tables on the
+// same column, referencing the same CTE from multiple places, or aliasing a
+// table and then qualifying columns by that alias — remain visible.
+//
+// Two identifier namespaces are used:
+//   - `t<n>` for table-like identifiers: real table names, table aliases,
+//     CTE names, and qualifiers in column references. They share a namespace
+//     so that `users u` followed by `u.id` redacts to `t2 as t1` / `t1.c1`,
+//     preserving the alias-to-table relationship.
+//   - `c<n>` for column-like identifiers: column names and SELECT-expression
+//     aliases. They share a namespace so that `COUNT(*) AS total ... ORDER BY
+//     total` redacts to `... as c1 ... order by c1`, preserving the alias
+//     reuse.
+//
+// The dialect used is whatever Vitess `sqlparser` accepts (which is also the
+// dialect used by SQL Expressions for parse/validate). If the query cannot be
+// parsed, the original error is returned and no fallback string is produced —
+// callers must NOT log the raw query in that case.
+func RedactedQuery(rawSQL string) (string, error) {
+	stmt, err := sqlparser.Parse(rawSQL)
+	if err != nil {
+		return "", fmt.Errorf("error parsing sql: %s", err.Error())
+	}
+
+	r := newRedactor()
+	r.redact(stmt)
+
+	return sqlparser.String(stmt), nil
+}
+
+// redactor walks a Vitess AST and rewrites identifier and literal nodes in
+// place so that the resulting SQL has the same structure but none of the
+// original names or values.
+type redactor struct {
+	// idents maps a (kind, original lower-cased value) tuple to its assigned
+	// placeholder so that all references to the same identifier within a
+	// single query share the same placeholder. ColIdent comparisons in
+	// Vitess are case-insensitive, and TableIdent comparisons are
+	// case-sensitive on the wire but case-insensitive in MySQL by default;
+	// we lowercase here for simplicity so that telemetry doesn't depend on
+	// casing differences across uses of the same identifier.
+	idents map[identKey]string
+	// counters tracks the next placeholder number per identifier kind.
+	counters map[identKind]int
+}
+
+type identKind int
+
+const (
+	// identKindTable covers real table names, table aliases, CTE names,
+	// and qualifiers used in column references.
+	identKindTable identKind = iota
+	// identKindColumn covers column names and SELECT-expression aliases.
+	identKindColumn
+)
+
+func (k identKind) prefix() string {
+	switch k {
+	case identKindTable:
+		return "t"
+	case identKindColumn:
+		return "c"
+	default:
+		return "id"
+	}
+}
+
+type identKey struct {
+	kind identKind
+	val  string
+}
+
+func newRedactor() *redactor {
+	return &redactor{
+		idents:   make(map[identKey]string),
+		counters: make(map[identKind]int),
+	}
+}
+
+func (r *redactor) name(kind identKind, original string) string {
+	if original == "" {
+		return ""
+	}
+	key := identKey{kind: kind, val: strings.ToLower(original)}
+	if name, ok := r.idents[key]; ok {
+		return name
+	}
+	r.counters[kind]++
+	name := fmt.Sprintf("%s%d", kind.prefix(), r.counters[kind])
+	r.idents[key] = name
+	return name
+}
+
+// redact mutates the supplied AST so that all identifiers and literal values
+// are replaced with placeholders. We rewrite during the pre-order traversal
+// because the Vitess AST stores values by pointer for some node types
+// (e.g. *SQLVal, *ColName, *AliasedExpr, *AliasedTableExpr) and by value for
+// others (TableName, ColIdent, TableIdent). For the by-value cases we use the
+// parent pointer to update the field in place.
+//
+// To make sure CTE definitions and references collapse to the same
+// placeholder, we pre-walk the AST once to populate the table-like namespace
+// with all CTE names. The main walk then naturally maps any reference matching
+// a known CTE to that same placeholder.
+func (r *redactor) redact(stmt sqlparser.SQLNode) {
+	_ = sqlparser.Walk(func(node sqlparser.SQLNode) (bool, error) {
+		if cte, ok := node.(*sqlparser.CommonTableExpr); ok && cte.AliasedTableExpr != nil {
+			if !cte.AliasedTableExpr.As.IsEmpty() {
+				_ = r.name(identKindTable, cte.AliasedTableExpr.As.String())
+			}
+		}
+		return true, nil
+	}, stmt)
+
+	_ = sqlparser.Walk(func(node sqlparser.SQLNode) (bool, error) {
+		switch v := node.(type) {
+		case *sqlparser.SQLVal:
+			r.redactSQLVal(v)
+
+		case *sqlparser.ColName:
+			r.redactColName(v)
+			return false, nil
+
+		case *sqlparser.AliasedExpr:
+			r.redactAliasedExpr(v)
+
+		case *sqlparser.AliasedTableExpr:
+			r.redactAliasedTableExpr(v)
+
+		case *sqlparser.CommonTableExpr:
+			// The CTE's name is on its embedded AliasedTableExpr and is
+			// handled by that case; we just need to redact its column
+			// list (e.g. `WITH foo(a, b) AS ...`).
+			for i, col := range v.Columns {
+				if col.IsEmpty() {
+					continue
+				}
+				v.Columns[i] = sqlparser.NewColIdent(r.name(identKindColumn, col.String()))
+			}
+
+		case *sqlparser.StarExpr:
+			r.redactStarExpr(v)
+			return false, nil
+
+		case *sqlparser.IndexHints:
+			r.redactIndexHints(v)
+			return false, nil
+		}
+		return true, nil
+	}, stmt)
+}
+
+func (r *redactor) redactSQLVal(v *sqlparser.SQLVal) {
+	switch v.Type {
+	case sqlparser.StrVal:
+		v.Val = []byte("?")
+	case sqlparser.IntVal, sqlparser.FloatVal, sqlparser.HexNum:
+		v.Val = []byte("0")
+	case sqlparser.HexVal:
+		v.Val = []byte("00")
+	case sqlparser.BitVal:
+		v.Val = []byte("0")
+	case sqlparser.ValArg:
+		// Already a placeholder — leave as-is so its name is preserved
+		// for any downstream binding logic. Callers do not pass values
+		// here today, but be defensive.
+	}
+}
+
+func (r *redactor) redactColName(c *sqlparser.ColName) {
+	if c == nil {
+		return
+	}
+	if !c.Qualifier.IsEmpty() {
+		c.Qualifier = r.redactTableName(c.Qualifier)
+	}
+	if !c.Name.IsEmpty() {
+		c.Name = sqlparser.NewColIdent(r.name(identKindColumn, c.Name.String()))
+	}
+}
+
+func (r *redactor) redactAliasedExpr(a *sqlparser.AliasedExpr) {
+	// Wipe the captured raw input expression — Vitess uses it verbatim
+	// when re-formatting a SELECT expression, which would re-introduce
+	// the original column name / value into the redacted output.
+	a.InputExpression = ""
+	if !a.As.IsEmpty() {
+		a.As = sqlparser.NewColIdent(r.name(identKindColumn, a.As.String()))
+	}
+}
+
+func (r *redactor) redactAliasedTableExpr(a *sqlparser.AliasedTableExpr) {
+	if !a.As.IsEmpty() {
+		a.As = sqlparser.NewTableIdent(r.name(identKindTable, a.As.String()))
+	}
+	if tn, ok := a.Expr.(sqlparser.TableName); ok {
+		a.Expr = r.redactTableName(tn)
+	}
+}
+
+func (r *redactor) redactStarExpr(s *sqlparser.StarExpr) {
+	if s == nil {
+		return
+	}
+	if !s.TableName.IsEmpty() {
+		s.TableName = r.redactTableName(s.TableName)
+	}
+}
+
+func (r *redactor) redactIndexHints(h *sqlparser.IndexHints) {
+	if h == nil {
+		return
+	}
+	for i, idx := range h.Indexes {
+		if idx.IsEmpty() {
+			continue
+		}
+		h.Indexes[i] = sqlparser.NewColIdent(r.name(identKindColumn, idx.String()))
+	}
+}
+
+// redactTableName returns a redacted TableName. It must be assigned back into
+// the parent because TableName is a value type, not a pointer.
+func (r *redactor) redactTableName(t sqlparser.TableName) sqlparser.TableName {
+	out := sqlparser.TableName{}
+	if !t.Name.IsEmpty() {
+		out.Name = sqlparser.NewTableIdent(r.name(identKindTable, t.Name.String()))
+	}
+	if !t.DbQualifier.IsEmpty() {
+		out.DbQualifier = sqlparser.NewTableIdent(r.name(identKindTable, t.DbQualifier.String()))
+	}
+	if !t.SchemaQualifier.IsEmpty() {
+		out.SchemaQualifier = sqlparser.NewTableIdent(r.name(identKindTable, t.SchemaQualifier.String()))
+	}
+	return out
+}

--- a/pkg/expr/sql/redact_demo_test.go
+++ b/pkg/expr/sql/redact_demo_test.go
@@ -1,0 +1,46 @@
+package sql
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestRedactedQuery_DemoOutput is here to make it easy for reviewers to see
+// what the redactor produces for a representative set of inputs. It always
+// passes — the goal is to print the before/after pairs so we can paste them
+// into the PR description and the analytics design doc.
+func TestRedactedQuery_DemoOutput(t *testing.T) {
+	queries := []string{
+		`SELECT email, ssn FROM customers WHERE country = 'US' AND age > 18`,
+		`SELECT u.country, COUNT(*) AS total
+			FROM users u
+			LEFT JOIN orders o ON u.id = o.user_id
+			WHERE u.email LIKE '%@example.com'
+			GROUP BY u.country
+			HAVING COUNT(*) > 10
+			ORDER BY total DESC LIMIT 5`,
+		`WITH top_products AS (
+			SELECT id, price FROM products WHERE price > 100
+			ORDER BY price DESC LIMIT 5
+		)
+		SELECT id FROM top_products`,
+		`SELECT user_id,
+			ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY ts DESC) AS rn
+			FROM events
+			WHERE region IN ('us-east', 'us-west', 'eu-west')`,
+		`SELECT CASE WHEN amount > 100 THEN 'high' ELSE 'low' END AS bucket
+			FROM transactions`,
+	}
+
+	for _, q := range queries {
+		out, err := RedactedQuery(q)
+		if err != nil {
+			t.Fatalf("redact failed: %v", err)
+		}
+		fmt.Println("--- ORIGINAL ---")
+		fmt.Println(q)
+		fmt.Println("--- REDACTED ---")
+		fmt.Println(out)
+		fmt.Println()
+	}
+}

--- a/pkg/expr/sql/redact_test.go
+++ b/pkg/expr/sql/redact_test.go
@@ -97,8 +97,8 @@ func TestRedactedQuery(t *testing.T) {
 			mustContain: []string{"row_number", "over", "partition by", "order by"},
 		},
 		{
-			name: "qualified column references collapse to same placeholder",
-			sql: `SELECT a.x, b.x FROM a JOIN b ON a.x = b.x`,
+			name:           "qualified column references collapse to same placeholder",
+			sql:            `SELECT a.x, b.x FROM a JOIN b ON a.x = b.x`,
 			mustNotContain: []string{
 				// don't assert "a", "b", or "x" individually because these
 				// short tokens occur in keywords and placeholders.

--- a/pkg/expr/sql/redact_test.go
+++ b/pkg/expr/sql/redact_test.go
@@ -1,0 +1,202 @@
+package sql
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestRedactedQuery(t *testing.T) {
+	// We don't assert on the exact stringified SQL because that is a
+	// product of Vitess's formatter and may shift over library upgrades.
+	// Instead we assert that:
+	//   - the query is still parseable as SQL after redaction
+	//   - the structural keywords (joins, aggregations, etc.) remain
+	//   - any potentially sensitive substring from the original query
+	//     does not appear in the redacted output.
+	tests := []struct {
+		name              string
+		sql               string
+		mustNotContain    []string
+		mustContain       []string
+		mustContainLowest []string
+	}{
+		{
+			name: "simple select",
+			sql:  "SELECT email, ssn FROM customers WHERE country = 'US'",
+			mustNotContain: []string{
+				"email", "ssn", "customers", "US",
+			},
+			mustContain: []string{
+				"select", "from", "where",
+			},
+			mustContainLowest: []string{"c1", "c2", "t1"},
+		},
+		{
+			name: "join + aggregation",
+			sql: `SELECT users.country, COUNT(*) AS total
+				FROM users
+				LEFT JOIN orders ON users.id = orders.user_id
+				WHERE users.email LIKE '%@example.com'
+				GROUP BY users.country
+				HAVING COUNT(*) > 10
+				ORDER BY total DESC
+				LIMIT 5`,
+			mustNotContain: []string{
+				"users", "orders", "country", "email",
+				"example.com", "user_id",
+				// "id" is a substring of "ident" / placeholders, so don't assert on it
+			},
+			mustContain: []string{
+				"left join", "group by", "having", "order by", "limit", "count(*)",
+			},
+		},
+		{
+			name: "subquery",
+			sql: `SELECT name FROM (
+				SELECT name FROM people WHERE age > 30
+			) AS adults`,
+			mustNotContain: []string{"people", "age", "name", "adults"},
+			mustContain:    []string{"select", "from", "where"},
+		},
+		{
+			name: "cte (with clause)",
+			sql: `WITH top_products AS (
+				SELECT id, price FROM products WHERE price > 100 ORDER BY price DESC LIMIT 5
+			)
+			SELECT id FROM top_products`,
+			mustNotContain: []string{"top_products", "products", "price"},
+			mustContain:    []string{"with", "select", "from", "limit"},
+		},
+		{
+			name: "in list",
+			sql:  `SELECT * FROM logs WHERE user_id IN ('abc', 'def', 'ghi')`,
+			mustNotContain: []string{
+				"abc", "def", "ghi", "logs", "user_id",
+			},
+			mustContain: []string{"in"},
+		},
+		{
+			name: "case expression",
+			sql: `SELECT CASE WHEN amount > 100 THEN 'high' ELSE 'low' END AS bucket
+				FROM transactions`,
+			mustNotContain: []string{
+				"high", "low", "amount", "bucket", "transactions",
+			},
+			mustContain: []string{"case", "when", "then", "else", "end"},
+		},
+		{
+			name: "window function",
+			sql: `SELECT user_id,
+				ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY ts DESC) AS rn
+				FROM events`,
+			mustNotContain: []string{
+				"user_id", "events", "rn",
+			},
+			mustContain: []string{"row_number", "over", "partition by", "order by"},
+		},
+		{
+			name: "qualified column references collapse to same placeholder",
+			sql: `SELECT a.x, b.x FROM a JOIN b ON a.x = b.x`,
+			mustNotContain: []string{
+				// don't assert "a", "b", or "x" individually because these
+				// short tokens occur in keywords and placeholders.
+			},
+			mustContain: []string{"join"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			redacted, err := RedactedQuery(tc.sql)
+			require.NoError(t, err, "redact failed for: %s", tc.sql)
+			require.NotEmpty(t, redacted)
+
+			lower := strings.ToLower(redacted)
+			for _, banned := range tc.mustNotContain {
+				require.NotContains(t, lower, strings.ToLower(banned),
+					"redacted query unexpectedly contains %q: %s", banned, redacted)
+			}
+			for _, must := range tc.mustContain {
+				require.Contains(t, lower, strings.ToLower(must),
+					"redacted query missing keyword %q: %s", must, redacted)
+			}
+			for _, must := range tc.mustContainLowest {
+				require.Contains(t, lower, must,
+					"redacted query missing placeholder %q: %s", must, redacted)
+			}
+		})
+	}
+}
+
+func TestRedactedQuery_StableForRepeatedIdentifiers(t *testing.T) {
+	const q = `SELECT u.email, u.email FROM users u WHERE u.email = 'x@y.z'`
+	out, err := RedactedQuery(q)
+	require.NoError(t, err)
+
+	// `u.email` appears twice in SELECT and once in WHERE; all three should
+	// reference the same column placeholder so analytics can see that the
+	// query references the same column multiple times.
+	lower := strings.ToLower(out)
+	require.NotContains(t, lower, "email")
+	require.NotContains(t, lower, "x@y.z")
+
+	require.Equal(t, 3, strings.Count(lower, "c1"),
+		"expected three references to c1, got: %s", out)
+}
+
+func TestRedactedQuery_CTEDeclarationAndReferenceShareName(t *testing.T) {
+	const q = `WITH top_products AS (
+		SELECT id FROM products WHERE price > 100
+	)
+	SELECT id FROM top_products`
+
+	out, err := RedactedQuery(q)
+	require.NoError(t, err)
+
+	lower := strings.ToLower(out)
+	// The CTE is registered first, so it gets t1. The outer FROM should
+	// reuse t1 (not introduce t3 or t2 — t2 is the inner table `products`).
+	require.Equal(t, 2, strings.Count(lower, "t1"),
+		"CTE declaration and outer reference should share t1, got: %s", out)
+}
+
+func TestRedactedQuery_TableAliasAndQualifierShareName(t *testing.T) {
+	const q = `SELECT u.id, u.email FROM users u WHERE u.id > 0`
+	out, err := RedactedQuery(q)
+	require.NoError(t, err)
+
+	lower := strings.ToLower(out)
+	// `u` (the alias) should match `u.id` / `u.email` qualifiers. The alias
+	// is t1 (the first table-like identifier seen in the FROM clause), and
+	// every qualifier reference should also be t1.
+	require.GreaterOrEqual(t, strings.Count(lower, "t1"), 3,
+		"alias and qualifiers should share t1, got: %s", out)
+}
+
+func TestRedactedQuery_PreservesJoinAndCteDistinction(t *testing.T) {
+	const q = `WITH t AS (SELECT 1)
+		SELECT * FROM t JOIN t AS u ON 1=1`
+	out, err := RedactedQuery(q)
+	require.NoError(t, err)
+
+	lower := strings.ToLower(out)
+	require.Contains(t, lower, "with")
+	require.Contains(t, lower, "join")
+
+	// Both literal `1` values must be redacted to `0`.
+	require.NotContains(t, lower, "1=1")
+}
+
+func TestRedactedQuery_InvalidSQL(t *testing.T) {
+	out, err := RedactedQuery("this is not sql")
+	require.Error(t, err)
+	require.Empty(t, out, "must return empty string on parse error to avoid leaking input")
+}
+
+func TestRedactedQuery_Empty(t *testing.T) {
+	out, err := RedactedQuery("")
+	require.Error(t, err)
+	require.Empty(t, out)
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

Adds a backend helper, `pkg/expr/sql.RedactedQuery`, that takes a SQL Expression query and returns a structure-preserving, value/identifier-redacted version of it that is safe to ship as an analytics event property.

It uses the same Vitess `sqlparser` we already use in `pkg/expr/sql/parser.go` (`TablesList`) and `parser_allow.go` (`AllowQuery`) to parse the query, then walks the AST to:

- replace literal values (`*sqlparser.SQLVal`) with placeholders — `'?'` for strings, `0` for numeric/hex/bit literals;
- replace user-defined identifiers with deterministic, monotonically numbered placeholders;
- keep aliases, qualifiers, and CTE references collapsed to the same placeholder so structural relationships within a single query (joins on the same column, repeated CTE references, alias-then-qualify patterns) remain visible in the telemetry.

Two namespaces are used:

- **`t<n>`** — table-like identifiers: real table names, table aliases, CTE names, and qualifiers in column references. They share a namespace so that `users u` followed by `u.id` redacts to `t2 as t1` / `t1.c1`.
- **`c<n>`** — column-like identifiers: column names and SELECT-expression aliases. They share a namespace so that `COUNT(*) AS total ... ORDER BY total` redacts to `... as c1 ... order by c1`.

This PR contains the helper + tests only. No telemetry call sites are wired up yet (see "Open question" below).

**Why do we need this feature?**

We already fire `dashboards_expression_interaction` RudderStack events for SQL Expressions on add / execute / remove (see `public/app/features/expressions/components/SqlExpressions/SqlExpr.tsx`, `PanelDataQueriesTab.tsx`, `TransformationTypePicker.tsx`, etc.), and `expression_counts` is included in `grafana_dashboard_saved` / `_created`. We deliberately did not ship the SQL text itself because filter values can contain PII.

We do, however, want to know whether people are using joins, aggregations, subqueries, CTEs, window functions, etc. — i.e. the **structure** of the query. The redactor in this PR gives us a SQL string that has only that structural information left in it, which is safe to attach to those events.

**Who is this feature for?**

The SQL Expressions team / anyone who needs to understand how SQL Expressions are being used in the wild without exposing customer query content.

**Example output**

(produced by `TestRedactedQuery_DemoOutput`, full log attached below)

| Original | Redacted |
|---|---|
| `SELECT email, ssn FROM customers WHERE country = 'US' AND age > 18` | `select c1, c2 from t1 where c3 = '?' and c4 > 0` |
| `SELECT u.country, COUNT(*) AS total FROM users u LEFT JOIN orders o ON u.id = o.user_id WHERE u.email LIKE '%@example.com' GROUP BY u.country HAVING COUNT(*) > 10 ORDER BY total DESC LIMIT 5` | `select t1.c1, COUNT(*) as c2 from t2 as t1 left join t4 as t3 on t1.c3 = t3.c4 where t1.c5 like '?' group by t1.c1 having COUNT(*) > 0 order by c2 desc limit 0` |
| `WITH top_products AS ( SELECT id, price FROM products WHERE price > 100 ORDER BY price DESC LIMIT 5 ) SELECT id FROM top_products` | `with t1 as (select c1, c2 from t2 where c2 > 0 order by c2 desc limit 0) select c1 from t1` |
| `SELECT user_id, ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY ts DESC) AS rn FROM events WHERE region IN ('us-east', 'us-west', 'eu-west')` | `select c1, ROW_NUMBER() over (partition by c1 order by c3 desc) as c2 from t1 where c4 in ('?', '?', '?')` |
| `SELECT CASE WHEN amount > 100 THEN 'high' ELSE 'low' END AS bucket FROM transactions` | `select case when c2 > 0 then '?' else '?' end as c1 from t1` |

Notice that:

- All values (`'US'`, `18`, `100`, `'us-east'`, `'high'`, …) are gone.
- All names (`email`, `customers`, `top_products`, …) are gone.
- Joins (`left join`), aggregations (`COUNT(*)`, `GROUP BY`, `HAVING`), CTEs (`with t1 as ...`), window functions (`ROW_NUMBER() OVER (PARTITION BY ... ORDER BY ...)`), `IN`-lists, `CASE`/`WHEN`/`THEN`/`ELSE`, `ORDER BY`, and `LIMIT` are all preserved.
- The CTE declared as `top_products` (`t1`) is the same `t1` referenced in the outer `FROM`.
- The alias `users u` reuses the same placeholder for every `u.<col>` qualifier.
- `COUNT(*) AS total ... ORDER BY total` keeps the alias reuse: `... as c2 ... order by c2`.

Logs:
[sql_redact_demo_output.log](https://cursor.com/agents/bc-79f0bc97-c6fb-4f22-a744-512d136edd62/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsql_redact_demo_output.log)

**Open question — where to wire this in**

I deliberately did **not** wire this into any analytics call site yet, because the right place depends on a small product/privacy decision I don't want to make unilaterally. The candidates are:

1. **Backend, on every evaluate** — easiest place to call (we already parse the query in `NewSQLCommand`), and it captures *all* SQL Expressions, not just the ones edited in the dashboard editor. Would require introducing a new backend RudderStack/usage-stats event because the existing events are frontend-only.
2. **Frontend, attach to existing `reportInteraction('dashboards_expression_interaction', …)` calls** for `add_expression` / `execute_expression`. We don't currently have a SQL parser on the frontend, so we'd either need to (a) add one (`node-sql-parser` etc., another dependency, possibly a different dialect), or (b) add a tiny backend endpoint that takes a query string and returns the redacted form. Both are doable but each has trade-offs.
3. **Save-time** — extend `getExpressionCounts` to also produce `expression_structures` and ship in `grafana_dashboard_saved` / `_created`. This would need the same backend round-trip as option 2.

My recommendation is **option 1**: it's lossless, requires no new dependencies, and avoids any frontend round-trip. Happy to do that wiring as a follow-up PR once we agree.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

- Helper lives at `pkg/expr/sql/redact.go`. Tests at `pkg/expr/sql/redact_test.go`. A demo-output test is included at `pkg/expr/sql/redact_demo_test.go` — it always passes and just prints before/after pairs so reviewers can eyeball the output without having to read the test fixtures.
- The redactor uses the AST in place via `sqlparser.Walk`, then re-formats it with `sqlparser.String`. We re-use the parser that `TablesList` and `AllowQuery` already use, so we don't take on any new dependency.
- On parse error the helper returns `("", err)` rather than falling back to the raw input, so callers cannot accidentally leak the original query text in the error path.
- `*AliasedExpr.InputExpression` is wiped before re-formatting because Vitess otherwise re-emits the captured raw SELECT-expression substring verbatim — which would defeat the redaction.

Please check that:
- [ ] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. _N/A — no user-facing surface yet, just the helper._
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-79f0bc97-c6fb-4f22-a744-512d136edd62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-79f0bc97-c6fb-4f22-a744-512d136edd62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

