### PR TITLE
Docs: Adds admonition about URL formats

### DIFF
--- a/docs/sources/as-code/infrastructure-as-code/terraform/terraform-cloud-provider-o11y.md
+++ b/docs/sources/as-code/infrastructure-as-code/terraform/terraform-cloud-provider-o11y.md
@@ -63,9 +63,14 @@ To configure authentication for the Grafana Provider:
 1. Obtain the regional Cloud Provider API endpoint.
    - To obtain the regional Cloud provider API endpoint, use your access policy token and the following command to return a list of all of the Grafana stacks you own, along with their respective Cloud Provider API hostnames:
    ```bash
-   curl -sH "Authorization: Bearer <Access Token from previous step>" "https://grafana.com/api/instances" | \
+   curl -sH "Authorization: Bearer @@@GRAFANA_CLOUD_ACCESS_POLICY_TOKEN@@@" "https://grafana.com/api/instances" | \
    jq '[.items[]|{stackName: .slug, clusterName:.clusterSlug, cloudProviderAPIURL: "https://cloud-provider-api-\(.clusterSlug).grafana.net"}]'
    ```
+    {{< admonition type="note" >}}
+    If this endpoint does not work, your Grafana Cloud Provider API endpoint may be using the new URL format.
+    For more information on Grafana Cloud URLs, refer to [Determine Grafana Cloud URLs based on region](/docs/grafana-cloud/security-and-account-management/region-url-formats/).
+    {{< /admonition >}}
+
 1. Create a file named `cloud-provider.tf` and add the following code block:
 
    ```tf
@@ -78,12 +83,12 @@ To configure authentication for the Grafana Provider:
    }
 
    provider "grafana" {
-       cloud_api_url      = "<CLOUD_PROVIDER_API_URL>"
-       cloud_access_policy_token     = "<CLOUD_ACCESS_POLICY_TOKEN>"
+       cloud_api_url      = "<@@@CLOUD_PROVIDER_API_URL@@@"
+       cloud_access_policy_token     = "@@@CLOUD_ACCESS_POLICY_TOKEN@@@>"
    }
    ```
 
-1. Create a `variables.tf` file and paste the `<CLOUD_ACCESS_POLICY_TOKEN>` and `<CLOUD_PROVIDER_API_URL` variables with your values.
+1. Create a `variables.tf` file and paste the `CLOUD_ACCESS_POLICY_TOKEN` and `CLOUD_PROVIDER_API_URL` variables with your values.
 1. Run the following Terraform command:
    ```tf
    terraform apply -var-file="variables.tf"

--- a/docs/sources/as-code/infrastructure-as-code/terraform/terraform-cloud-provider-o11y.md
+++ b/docs/sources/as-code/infrastructure-as-code/terraform/terraform-cloud-provider-o11y.md
@@ -62,14 +62,16 @@ To configure authentication for the Grafana Provider:
 
 1. Obtain the regional Cloud Provider API endpoint.
    - To obtain the regional Cloud provider API endpoint, use your access policy token and the following command to return a list of all of the Grafana stacks you own, along with their respective Cloud Provider API hostnames:
+
    ```bash
    curl -sH "Authorization: Bearer @@@GRAFANA_CLOUD_ACCESS_POLICY_TOKEN@@@" "https://grafana.com/api/instances" | \
    jq '[.items[]|{stackName: .slug, clusterName:.clusterSlug, cloudProviderAPIURL: "https://cloud-provider-api-\(.clusterSlug).grafana.net"}]'
    ```
-    {{< admonition type="note" >}}
-    If this endpoint does not work, your Grafana Cloud Provider API endpoint may be using the new URL format.
-    For more information on Grafana Cloud URLs, refer to [Determine Grafana Cloud URLs based on region](/docs/grafana-cloud/security-and-account-management/region-url-formats/).
-    {{< /admonition >}}
+
+   {{< admonition type="note" >}}
+   If this endpoint does not work, your Grafana Cloud Provider API endpoint may be using the new URL format.
+   For more information on Grafana Cloud URLs, refer to [Determine Grafana Cloud URLs based on region](/docs/grafana-cloud/security-and-account-management/region-url-formats/).
+   {{< /admonition >}}
 
 1. Create a file named `cloud-provider.tf` and add the following code block:
 


### PR DESCRIPTION
**What is this feature?**

It adds a note about the new URL formatting changes to the Cloud Provider Terraform docs.

**Why do we need this feature?**

We recently changed how our URLs for Grafana Cloud are formatted and it affects how users connect to the Cloud Provider API.

**Who is this feature for?**

Users who configure Cloud Provider Observability using Terraform.

**Which issue(s) does this PR fix?**:

Fixes:
https://github.com/grafana/grafana-csp-app/issues/1407
https://github.com/grafana/cloud-onboarding/issues/10767

**Special notes for your reviewer:**

Please check the following pages:

- [Manage Cloud Provider Observability with Terraform](https://deploy-preview-grafana-123561-zb444pucvq-vp.a.run.app/docs/grafana/latest/as-code/infrastructure-as-code/terraform/terraform-cloud-provider-o11y/)