### PR TITLE
Alerting: (POC) Add chain-rail layout to alert rules list 

### DIFF
--- a/public/app/features/alerting/unified/Analytics.ts
+++ b/public/app/features/alerting/unified/Analytics.ts
@@ -487,3 +487,10 @@ export function trackViewExperienceToggleConfirmed(
 export function trackRuleListPageView(payload: { view: 'v1' | 'v2' }) {
   reportInteraction('grafana_alerting_rule_list_page_view', payload);
 }
+
+/**
+ * Track clicks on the Edit / More buttons inside a chain header (v2 chain rail).
+ */
+export function trackChainHeaderActionClick(payload: { chainId: string; action: 'edit' | 'more' }) {
+  reportInteraction('grafana_alerting_chain_header_action_click', payload);
+}

--- a/public/app/features/alerting/unified/api/alertingApi.ts
+++ b/public/app/features/alerting/unified/api/alertingApi.ts
@@ -131,6 +131,7 @@ export const alertingApi = createApi({
     'Receiver',
     'DeletedRules',
     'GrafanaPrometheusGroups',
+    'RuleGroupChain',
   ],
   endpoints: () => ({}),
 });

--- a/public/app/features/alerting/unified/api/ruleGroupChainsApi.ts
+++ b/public/app/features/alerting/unified/api/ruleGroupChainsApi.ts
@@ -1,0 +1,73 @@
+import { type Chain, type ListRuleGroupChainsResponse } from '../rule-list/chainRail/types';
+
+import { alertingApi } from './alertingApi';
+
+interface ListRuleGroupChainsArg {
+  folderUid?: string;
+}
+
+// Sentinel folder + group used to demo the chain rail before the backend
+// endpoint ships. Only the synthetic demo folder section queries for these.
+export const DEV_DEMO_CHAIN_FOLDER_UID = 'chain-demo-folder';
+export const DEV_DEMO_CHAIN_GROUP_NAME = 'chain-rail-demo';
+export const DEV_DEMO_CHAIN_ID = 'dev-chain-demo';
+
+function buildDevChainsFixture(folderUid?: string): Chain[] {
+  if (folderUid !== DEV_DEMO_CHAIN_FOLDER_UID) {
+    return [];
+  }
+  return [
+    {
+      id: DEV_DEMO_CHAIN_ID,
+      name: 'Chain rail demo',
+      folderUid,
+      groupName: DEV_DEMO_CHAIN_GROUP_NAME,
+      mode: 'Sequential',
+      interval: '1m',
+      ruleUids: [],
+    },
+  ];
+}
+
+function isChain(value: unknown): value is Chain {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    'id' in value &&
+    'folderUid' in value &&
+    'groupName' in value &&
+    'ruleUids' in value
+  );
+}
+
+function parseChainsResponse(raw: unknown): ListRuleGroupChainsResponse {
+  if (raw && typeof raw === 'object' && 'chains' in raw && Array.isArray(raw.chains)) {
+    return { chains: raw.chains.filter(isChain) };
+  }
+  return { chains: [] };
+}
+
+export const ruleGroupChainsApi = alertingApi.injectEndpoints({
+  endpoints: (build) => ({
+    listRuleGroupChains: build.query<ListRuleGroupChainsResponse, ListRuleGroupChainsArg>({
+      // TODO(alerting.rulesAPIV2): replace queryFn with `query` once the backend chain endpoint ships.
+      // The dev branch returns a factory-shaped fixture so the UI can be demoed without a backend.
+      async queryFn(arg, _api, _extraOptions, fetchWithBQ) {
+        if (process.env.NODE_ENV === 'development') {
+          return { data: { chains: buildDevChainsFixture(arg.folderUid) } };
+        }
+        const result = await fetchWithBQ({
+          url: 'api/ruler/grafana/api/v1/chains',
+          params: { folder_uid: arg.folderUid },
+        });
+        if (result.error) {
+          return { error: result.error };
+        }
+        return { data: parseChainsResponse(result.data) };
+      },
+      providesTags: (_result, _error, { folderUid }) => [{ type: 'RuleGroupChain', id: folderUid ?? '__any__' }],
+    }),
+  }),
+});
+
+export const { useListRuleGroupChainsQuery } = ruleGroupChainsApi;

--- a/public/app/features/alerting/unified/featureToggles.ts
+++ b/public/app/features/alerting/unified/featureToggles.ts
@@ -16,6 +16,8 @@ export const shouldUseAlertingListViewV2 = () => {
   return config.featureToggles.alertingListViewV2 ?? false;
 };
 
+export const shouldUseAlertingRulesAPIV2 = () => config.featureToggles['alerting.rulesAPIV2'] ?? false;
+
 export const shouldAllowRecoveringDeletedRules = () =>
   (isAdmin() && config.featureToggles.alertingRuleRecoverDeleted && config.featureToggles.alertRuleRestore) ?? false;
 

--- a/public/app/features/alerting/unified/mocks/server/all-handlers.ts
+++ b/public/app/features/alerting/unified/mocks/server/all-handlers.ts
@@ -5,6 +5,7 @@
 import accessControlHandlers from 'app/features/alerting/unified/mocks/server/handlers/accessControl';
 import alertNotifierHandlers from 'app/features/alerting/unified/mocks/server/handlers/alertNotifiers';
 import alertmanagerHandlers from 'app/features/alerting/unified/mocks/server/handlers/alertmanagers';
+import chainHandlers from 'app/features/alerting/unified/mocks/server/handlers/chains';
 import datasourcesHandlers from 'app/features/alerting/unified/mocks/server/handlers/datasources';
 import evalHandlers from 'app/features/alerting/unified/mocks/server/handlers/eval';
 import folderHandlers from 'app/features/alerting/unified/mocks/server/handlers/folders';
@@ -32,6 +33,7 @@ import userStorageHandlers from 'app/features/alerting/unified/mocks/server/hand
 export const alertingHandlers = [
   ...alertNotifierHandlers,
   ...grafanaRulerHandlers,
+  ...chainHandlers,
   ...historianHandlers,
   ...mimirRulerHandlers,
   ...alertmanagerHandlers,

--- a/public/app/features/alerting/unified/mocks/server/db.ts
+++ b/public/app/features/alerting/unified/mocks/server/db.ts
@@ -24,6 +24,7 @@ import {
   type RulerRuleGroupDTO,
 } from 'app/types/unified-alerting-dto';
 
+import { type Chain } from '../../rule-list/chainRail/types';
 import { setupDataSources } from '../../testSetup/datasources';
 import { Annotation } from '../../utils/constants';
 import { DataSourceType } from '../../utils/datasource';
@@ -106,6 +107,16 @@ const rulerGrafanaGroupFactory = Factory.define<RulerGrafanaRuleGroupDTO>(({ seq
   name: `test-group-${sequence}`,
   interval: '1m',
   rules: grafanaAlertingRuleFactory.buildList(3),
+}));
+
+const chainFactory = Factory.define<Chain>(({ sequence }) => ({
+  id: `chain-${sequence}`,
+  name: `Chain ${sequence}`,
+  folderUid: 'test-folder',
+  groupName: `test-group-${sequence}`,
+  mode: 'Sequential',
+  interval: '1m',
+  ruleUids: [],
 }));
 
 class DataSourceFactory extends Factory<DataSourceInstanceSettings> {
@@ -327,4 +338,5 @@ export const alertingFactory = {
       receiver: grafanaReceiverConfigFactory,
     },
   },
+  chain: chainFactory,
 };

--- a/public/app/features/alerting/unified/mocks/server/handlers/chains.ts
+++ b/public/app/features/alerting/unified/mocks/server/handlers/chains.ts
@@ -1,0 +1,31 @@
+import { HttpResponse, http } from 'msw';
+
+import {
+  DEV_DEMO_CHAIN_FOLDER_UID,
+  DEV_DEMO_CHAIN_GROUP_NAME,
+  DEV_DEMO_CHAIN_ID,
+} from '../../../api/ruleGroupChainsApi';
+import { alertingFactory } from '../db';
+
+const listRuleGroupChainsHandler = () =>
+  http.get('/api/ruler/grafana/api/v1/chains', ({ request }) => {
+    const folderUid = new URL(request.url).searchParams.get('folder_uid') ?? DEV_DEMO_CHAIN_FOLDER_UID;
+    if (folderUid !== DEV_DEMO_CHAIN_FOLDER_UID) {
+      return HttpResponse.json({ chains: [] });
+    }
+    const chains = [
+      alertingFactory.chain.build({
+        id: DEV_DEMO_CHAIN_ID,
+        folderUid,
+        groupName: DEV_DEMO_CHAIN_GROUP_NAME,
+        name: 'Chain rail demo',
+        mode: 'Sequential',
+        interval: '1m',
+      }),
+    ];
+    return HttpResponse.json({ chains });
+  });
+
+const handlers = [listRuleGroupChainsHandler()];
+
+export default handlers;

--- a/public/app/features/alerting/unified/rule-list/GrafanaRuleListItem.tsx
+++ b/public/app/features/alerting/unified/rule-list/GrafanaRuleListItem.tsx
@@ -21,6 +21,8 @@ interface GrafanaRuleListItemProps {
   namespaceName: string;
   operation?: 'creating' | 'deleting';
   showLocation?: boolean;
+  inChain?: boolean;
+  className?: string;
 }
 
 export function GrafanaRuleListItem({
@@ -29,6 +31,8 @@ export function GrafanaRuleListItem({
   namespaceName,
   operation,
   showLocation = true,
+  inChain = false,
+  className,
 }: GrafanaRuleListItemProps) {
   const { name, uid, labels, provenance } = rule;
 
@@ -68,12 +72,14 @@ export function GrafanaRuleListItem({
         instancesCount={instancesCount}
         operation={operation}
         showLocation={showLocation}
+        inChain={inChain}
+        className={className}
       />
     );
   }
 
   if (prometheusRuleType.grafana.recordingRule(rule)) {
-    return <RecordingRuleListItem {...commonProps} showLocation={showLocation} />;
+    return <RecordingRuleListItem {...commonProps} showLocation={showLocation} className={className} />;
   }
 
   return <UnknownRuleListItem ruleName={name} groupIdentifier={groupIdentifier} ruleDefinition={rule} />;

--- a/public/app/features/alerting/unified/rule-list/RuleList.v2.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleList.v2.tsx
@@ -11,6 +11,7 @@ import { AlertingPageWrapper } from '../components/AlertingPageWrapper';
 import { GrafanaRulesExporter } from '../components/export/GrafanaRulesExporter';
 import { useListViewMode } from '../components/rules/Filter/RulesViewModeSelector';
 import { AIAlertRuleButtonComponent } from '../enterprise-components/AI/AIGenAlertRuleButton/addAIAlertRuleButton';
+import { shouldUseAlertingRulesAPIV2 } from '../featureToggles';
 import { AlertingAction, useAlertingAbility } from '../hooks/useAbilities';
 import { useRulesFilter } from '../hooks/useFilteredRules';
 import { useAlertRulesNav } from '../navigation/useAlertRulesNav';
@@ -21,6 +22,7 @@ import { AlertsActivityBanner } from './AlertsActivityBanner';
 import { FilterView } from './FilterView';
 import { GroupedView } from './GroupedView';
 import { RuleListPageTitle } from './RuleListPageTitle';
+import { ChainRailGroupedView } from './chainRail/ChainRailGroupedView';
 import RulesFilter from './filter/RulesFilter.v2';
 import { RulesFilterSidebar } from './filter/RulesFilterSidebar';
 import { useApplyDefaultSearch } from './filter/useApplyDefaultSearch';
@@ -28,6 +30,13 @@ import { useApplyDefaultSearch } from './filter/useApplyDefaultSearch';
 function RuleList() {
   const { filterState } = useRulesFilter();
   const { viewMode, handleViewChange } = useListViewMode();
+  const useChainRail = shouldUseAlertingRulesAPIV2();
+
+  const groupedBody = useChainRail ? (
+    <ChainRailGroupedView groupFilter={filterState.groupName} namespaceFilter={filterState.namespace} />
+  ) : (
+    <GroupedView groupFilter={filterState.groupName} namespaceFilter={filterState.namespace} />
+  );
 
   return (
     <Stack direction="column">
@@ -37,11 +46,7 @@ function RuleList() {
         <Stack direction="row" grow={1} minHeight={0}>
           <RulesFilterSidebar />
           <Box flex={1} minWidth={0} paddingLeft={2}>
-            {viewMode === 'list' ? (
-              <FilterView filterState={filterState} />
-            ) : (
-              <GroupedView groupFilter={filterState.groupName} namespaceFilter={filterState.namespace} />
-            )}
+            {viewMode === 'list' ? <FilterView filterState={filterState} /> : groupedBody}
           </Box>
         </Stack>
       </Stack>

--- a/public/app/features/alerting/unified/rule-list/chainRail/ChainFolderBody.tsx
+++ b/public/app/features/alerting/unified/rule-list/chainRail/ChainFolderBody.tsx
@@ -1,0 +1,48 @@
+import { useMemo } from 'react';
+
+import { Stack } from '@grafana/ui';
+import { type GrafanaPromRuleGroupDTO } from 'app/types/unified-alerting-dto';
+
+import { useListRuleGroupChainsQuery } from '../../api/ruleGroupChainsApi';
+
+import { ChainRuleCluster } from './ChainRuleCluster';
+import { FlatGroupRules } from './FlatGroupRules';
+import { getDevMockRulesFor } from './devMockRules';
+
+interface ChainFolderBodyProps {
+  folderUid: string;
+  folderName: string;
+  groups: GrafanaPromRuleGroupDTO[];
+}
+
+export function ChainFolderBody({ folderUid, folderName, groups }: ChainFolderBodyProps) {
+  const { data } = useListRuleGroupChainsQuery({ folderUid });
+  const chains = useMemo(() => data?.chains ?? [], [data]);
+
+  const claimedGroupNames = useMemo(() => {
+    const names = new Set<string>();
+    for (const chain of chains) {
+      names.add(chain.groupName);
+    }
+    return names;
+  }, [chains]);
+
+  return (
+    <Stack direction="column" gap={0}>
+      {chains.map((chain) => (
+        <ChainRuleCluster
+          key={chain.id}
+          chain={chain}
+          folderUid={folderUid}
+          namespaceName={folderName}
+          mockRules={getDevMockRulesFor(chain)}
+        />
+      ))}
+      {groups
+        .filter((group) => !claimedGroupNames.has(group.name))
+        .map((group) => (
+          <FlatGroupRules key={`grafana-ns-${folderUid}-${group.name}`} group={group} namespaceName={folderName} />
+        ))}
+    </Stack>
+  );
+}

--- a/public/app/features/alerting/unified/rule-list/chainRail/ChainGroup.tsx
+++ b/public/app/features/alerting/unified/rule-list/chainRail/ChainGroup.tsx
@@ -1,0 +1,19 @@
+import { type ReactNode } from 'react';
+
+import { useStyles2 } from '@grafana/ui';
+
+import { getChainRailStyles } from './styles';
+
+interface ChainGroupProps {
+  children: ReactNode;
+  'data-testid'?: string;
+}
+
+export function ChainGroup({ children, 'data-testid': testId }: ChainGroupProps) {
+  const styles = useStyles2(getChainRailStyles);
+  return (
+    <div role="group" className={styles.chainGroup} data-testid={testId}>
+      {children}
+    </div>
+  );
+}

--- a/public/app/features/alerting/unified/rule-list/chainRail/ChainHeader.tsx
+++ b/public/app/features/alerting/unified/rule-list/chainRail/ChainHeader.tsx
@@ -1,0 +1,54 @@
+import { Trans, t } from '@grafana/i18n';
+import { Button, Icon, useStyles2 } from '@grafana/ui';
+
+import { getChainRailStyles } from './styles';
+import { type Chain } from './types';
+
+interface ChainHeaderProps {
+  chain: Chain;
+  ruleCount: number;
+  onEdit?: () => void;
+  onMore?: () => void;
+}
+
+export function ChainHeader({ chain, ruleCount, onEdit, onMore }: ChainHeaderProps) {
+  const styles = useStyles2(getChainRailStyles);
+
+  return (
+    <div role="heading" aria-level={4} className={styles.chainHeader}>
+      <span className={styles.chainHeaderIcon} aria-hidden="true">
+        <Icon name="link" size="sm" />
+      </span>
+      <span className={styles.chainHeaderName}>{chain.name}</span>
+      <span className={styles.chainHeaderCount}>
+        {t('alerting.chain-rail.rule-count', '{{count}} rules', { count: ruleCount })}
+      </span>
+      <span className={styles.chainHeaderSpacer} />
+      <span className={styles.chainHeaderMeta}>
+        <span>
+          {chain.mode} · {chain.interval}
+        </span>
+      </span>
+      <div className={styles.chainHeaderActions}>
+        <Button
+          size="sm"
+          variant="secondary"
+          fill="text"
+          aria-label={t('alerting.chain-rail.edit-aria', 'Edit {{name}}', { name: chain.name })}
+          onClick={onEdit}
+        >
+          <Trans i18nKey="alerting.chain-rail.edit">Edit</Trans>
+        </Button>
+        <Button
+          size="sm"
+          variant="secondary"
+          fill="text"
+          aria-label={t('alerting.chain-rail.more-aria', 'More options for {{name}}', { name: chain.name })}
+          onClick={onMore}
+        >
+          <Trans i18nKey="alerting.chain-rail.more">More</Trans>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/public/app/features/alerting/unified/rule-list/chainRail/ChainRailGroupedView.tsx
+++ b/public/app/features/alerting/unified/rule-list/chainRail/ChainRailGroupedView.tsx
@@ -1,0 +1,223 @@
+import { groupBy, isEmpty } from 'lodash';
+import { useEffect, useMemo, useRef } from 'react';
+
+import { t } from '@grafana/i18n';
+import { Icon, Stack, TextLink } from '@grafana/ui';
+import { type DataSourceRulesSourceIdentifier, GrafanaRulesSourceSymbol } from 'app/types/unified-alerting';
+import { type PromRuleGroupDTO } from 'app/types/unified-alerting-dto';
+
+import { featureDiscoveryApi } from '../../api/featureDiscoveryApi';
+import { WithReturnButton } from '../../components/WithReturnButton';
+import { FolderActionsButton } from '../../components/folder-actions/FolderActionsButton';
+import { GrafanaNoRulesCTA } from '../../components/rules/NoRulesCTA';
+import { GRAFANA_RULES_SOURCE_NAME, GrafanaRulesSource, getExternalRulesSources } from '../../utils/datasource';
+import { makeFolderAlertsLink } from '../../utils/misc';
+import { PaginatedDataSourceLoader } from '../PaginatedDataSourceLoader';
+import { AlertRuleListItemSkeleton } from '../components/AlertRuleListItemLoader';
+import { DataSourceErrorBoundary } from '../components/DataSourceErrorBoundary';
+import { DataSourceSection } from '../components/DataSourceSection';
+import { ListSection } from '../components/ListSection';
+import { LoadMoreButton } from '../components/LoadMoreButton';
+import { NoRulesFound } from '../components/NoRulesFound';
+import { getGrafanaFilter, hasGrafanaClientSideFilters } from '../hooks/grafanaFilter';
+import { toIndividualRuleGroups, useGrafanaGroupsGenerator } from '../hooks/prometheusGroupsGenerator';
+import { useDataSourceLoadingReporter } from '../hooks/useDataSourceLoadingReporter';
+import { type DataSourceLoadState, useDataSourceLoadingStates } from '../hooks/useDataSourceLoadingStates';
+import { useLazyLoadPrometheusGroups } from '../hooks/useLazyLoadPrometheusGroups';
+import { FRONTED_GROUPED_PAGE_SIZE, getApiGroupPageSize } from '../paginationLimits';
+
+import { ChainFolderBody } from './ChainFolderBody';
+import { DemoFolderSection } from './DemoFolderSection';
+
+const { useDiscoverDsFeaturesQuery } = featureDiscoveryApi;
+
+interface ChainRailGroupedViewProps {
+  groupFilter?: string;
+  namespaceFilter?: string;
+}
+
+export function ChainRailGroupedView({ groupFilter, namespaceFilter }: ChainRailGroupedViewProps) {
+  const hasFilters = Boolean(groupFilter || namespaceFilter);
+  const externalRuleSources = useMemo(() => getExternalRulesSources(), []);
+  const { updateState, loadingDataSources } = useDataSourceLoadingStates();
+
+  return (
+    <Stack direction="column" gap={1} role="list">
+      <DataSourceErrorBoundary rulesSourceIdentifier={GrafanaRulesSource}>
+        <PaginatedChainAwareLoader
+          groupFilter={groupFilter}
+          namespaceFilter={namespaceFilter}
+          onLoadingStateChange={updateState}
+          key={`${groupFilter}-${namespaceFilter}`}
+        />
+      </DataSourceErrorBoundary>
+      {externalRuleSources.map((ruleSource) => (
+        <ExternalDataSourceLoader
+          key={ruleSource.uid}
+          rulesSourceIdentifier={ruleSource}
+          groupFilter={groupFilter}
+          namespaceFilter={namespaceFilter}
+          onLoadingStateChange={updateState}
+        />
+      ))}
+      {hasFilters && !isEmpty(loadingDataSources) && <AlertRuleListItemSkeleton />}
+    </Stack>
+  );
+}
+
+interface LoaderProps {
+  groupFilter?: string;
+  namespaceFilter?: string;
+  onLoadingStateChange?: (uid: string, state: DataSourceLoadState) => void;
+}
+
+function PaginatedChainAwareLoader({ groupFilter, namespaceFilter, onLoadingStateChange }: LoaderProps) {
+  const filterState = { namespace: namespaceFilter, groupName: groupFilter };
+  const { backendFilter } = getGrafanaFilter(filterState);
+
+  const hasFilters = Boolean(groupFilter || namespaceFilter);
+  const needsClientSideFiltering = hasGrafanaClientSideFilters(filterState);
+
+  const grafanaGroupsGenerator = useGrafanaGroupsGenerator({
+    populateCache: needsClientSideFiltering ? false : true,
+    limitAlerts: 0,
+  });
+
+  const apiGroupPageSize = getApiGroupPageSize(needsClientSideFiltering);
+
+  const groupsGenerator = useRef(
+    toIndividualRuleGroups(grafanaGroupsGenerator({ groupLimit: apiGroupPageSize }, backendFilter))
+  );
+
+  useEffect(() => {
+    const currentGenerator = groupsGenerator.current;
+    return () => {
+      currentGenerator.return();
+    };
+  }, []);
+
+  const filterFn = useMemo(() => {
+    const { frontendFilter } = getGrafanaFilter({
+      namespace: namespaceFilter,
+      groupName: groupFilter,
+      freeFormWords: [],
+      ruleName: '',
+      labels: [],
+      ruleType: undefined,
+      ruleState: undefined,
+      ruleHealth: undefined,
+      dashboardUid: undefined,
+      dataSourceNames: [],
+      plugins: undefined,
+      contactPoint: undefined,
+      ruleSource: undefined,
+    });
+    return (group: PromRuleGroupDTO) => frontendFilter.groupMatches(group);
+  }, [namespaceFilter, groupFilter]);
+
+  const { isLoading, groups, hasMoreGroups, fetchMoreGroups, error } = useLazyLoadPrometheusGroups(
+    groupsGenerator.current,
+    FRONTED_GROUPED_PAGE_SIZE,
+    filterFn
+  );
+
+  useDataSourceLoadingReporter(
+    GRAFANA_RULES_SOURCE_NAME,
+    { isLoading, rulesCount: groups.length, error },
+    onLoadingStateChange
+  );
+
+  const groupsByFolder = useMemo(() => groupBy(groups, 'folderUid'), [groups]);
+  const hasNoRules = isEmpty(groups) && !isLoading;
+
+  if (hasFilters && isEmpty(groups)) {
+    return null;
+  }
+
+  return (
+    <DataSourceSection
+      name="Grafana-managed"
+      application="grafana"
+      uid={GrafanaRulesSourceSymbol}
+      isLoading={isLoading}
+      error={error}
+    >
+      <Stack direction="column" gap={0}>
+        <DemoFolderSection />
+        {Object.entries(groupsByFolder).map(([folderUid, folderGroups]) => {
+          const folderName = folderGroups[0].file;
+          return (
+            <ListSection
+              key={folderUid}
+              title={
+                <Stack direction="row" gap={1} alignItems="center">
+                  <Icon name="folder" />{' '}
+                  <WithReturnButton
+                    title={t('alerting.rule-list.return-button.title', 'Alert rules')}
+                    component={
+                      <TextLink href={makeFolderAlertsLink(folderUid, folderName)} inline={false} color="primary">
+                        {folderName}
+                      </TextLink>
+                    }
+                  />
+                </Stack>
+              }
+              actions={<FolderActionsButton folderUID={folderUid} />}
+            >
+              <ChainFolderBody folderUid={folderUid} folderName={folderName} groups={folderGroups} />
+            </ListSection>
+          );
+        })}
+        {hasNoRules && !hasFilters && <GrafanaNoRulesCTA />}
+        {hasNoRules && hasFilters && <NoRulesFound />}
+        {hasMoreGroups && (
+          <div>
+            <LoadMoreButton loading={isLoading} onClick={fetchMoreGroups} />
+          </div>
+        )}
+      </Stack>
+    </DataSourceSection>
+  );
+}
+
+interface ExternalDataSourceLoaderProps {
+  rulesSourceIdentifier: DataSourceRulesSourceIdentifier;
+  groupFilter?: string;
+  namespaceFilter?: string;
+  onLoadingStateChange?: (uid: string, state: DataSourceLoadState) => void;
+}
+
+function ExternalDataSourceLoader({
+  rulesSourceIdentifier,
+  groupFilter,
+  namespaceFilter,
+  onLoadingStateChange,
+}: ExternalDataSourceLoaderProps) {
+  const hasFilters = Boolean(groupFilter || namespaceFilter);
+  const { data: dataSourceInfo, isLoading, error } = useDiscoverDsFeaturesQuery({ uid: rulesSourceIdentifier.uid });
+  const { uid, name } = rulesSourceIdentifier;
+
+  if (hasFilters && (isLoading || Boolean(error))) {
+    return null;
+  }
+
+  if (error) {
+    return <DataSourceSection error={error} uid={uid} name={name} />;
+  }
+
+  if (dataSourceInfo) {
+    return (
+      <DataSourceErrorBoundary rulesSourceIdentifier={rulesSourceIdentifier}>
+        <PaginatedDataSourceLoader
+          rulesSourceIdentifier={rulesSourceIdentifier}
+          application={dataSourceInfo.application}
+          groupFilter={groupFilter}
+          namespaceFilter={namespaceFilter}
+          onLoadingStateChange={onLoadingStateChange}
+        />
+      </DataSourceErrorBoundary>
+    );
+  }
+
+  return null;
+}

--- a/public/app/features/alerting/unified/rule-list/chainRail/ChainRuleCluster.tsx
+++ b/public/app/features/alerting/unified/rule-list/chainRail/ChainRuleCluster.tsx
@@ -1,0 +1,102 @@
+import { useMemo } from 'react';
+
+import { t } from '@grafana/i18n';
+import { Alert, Stack, useStyles2 } from '@grafana/ui';
+import { type GrafanaRuleGroupIdentifier } from 'app/types/unified-alerting';
+import { type GrafanaPromRuleDTO } from 'app/types/unified-alerting-dto';
+
+import { trackChainHeaderActionClick } from '../../Analytics';
+import { prometheusApi } from '../../api/prometheusApi';
+import { RULE_LIST_POLL_INTERVAL_MS } from '../../utils/constants';
+import { GrafanaRuleListItem } from '../GrafanaRuleListItem';
+import { AlertRuleListItemSkeleton } from '../components/AlertRuleListItemLoader';
+
+import { ChainGroup } from './ChainGroup';
+import { ChainHeader } from './ChainHeader';
+import { getChainRailStyles } from './styles';
+import { type Chain } from './types';
+
+const { useGetGrafanaGroupsQuery } = prometheusApi;
+
+interface ChainRuleClusterProps {
+  chain: Chain;
+  folderUid: string;
+  namespaceName: string;
+  onEdit?: (chain: Chain) => void;
+  onMore?: (chain: Chain) => void;
+  // Dev-only: when present, the cluster renders these instead of hitting the
+  // Prometheus rules endpoint. Used to demo the layout before the real chain
+  // API ships. See devMockRules.ts.
+  mockRules?: GrafanaPromRuleDTO[];
+}
+
+export function ChainRuleCluster({
+  chain,
+  folderUid,
+  namespaceName,
+  onEdit,
+  onMore,
+  mockRules,
+}: ChainRuleClusterProps) {
+  const styles = useStyles2(getChainRailStyles);
+  const skip = Boolean(mockRules);
+  const { data: promResponse, isLoading } = useGetGrafanaGroupsQuery(
+    {
+      folderUid,
+      groupName: chain.groupName,
+      limitAlerts: 0,
+    },
+    { pollingInterval: RULE_LIST_POLL_INTERVAL_MS, skip }
+  );
+
+  const rules = useMemo(() => mockRules ?? promResponse?.data.groups.at(0)?.rules ?? [], [mockRules, promResponse]);
+
+  const groupIdentifier: GrafanaRuleGroupIdentifier = useMemo(
+    () => ({
+      groupName: chain.groupName,
+      namespace: { uid: folderUid },
+      groupOrigin: 'grafana',
+    }),
+    [chain.groupName, folderUid]
+  );
+
+  const skeletonCount = chain.ruleUids.length > 0 ? chain.ruleUids.length : 3;
+
+  const handleEdit = () => {
+    trackChainHeaderActionClick({ chainId: chain.id, action: 'edit' });
+    onEdit?.(chain);
+  };
+  const handleMore = () => {
+    trackChainHeaderActionClick({ chainId: chain.id, action: 'more' });
+    onMore?.(chain);
+  };
+
+  return (
+    <ChainGroup data-testid={`chain-group-${chain.id}`}>
+      <ChainHeader
+        chain={chain}
+        ruleCount={rules.length || chain.ruleUids.length}
+        onEdit={handleEdit}
+        onMore={handleMore}
+      />
+      <Stack direction="column" gap={0}>
+        {isLoading && Array.from({ length: skeletonCount }).map((_, i) => <AlertRuleListItemSkeleton key={i} />)}
+        {!isLoading && rules.length === 0 && (
+          <Alert severity="info" title={t('alerting.chain-rail.no-rules', 'No rules found in this chain')} />
+        )}
+        {!isLoading &&
+          rules.map((rule) => (
+            <GrafanaRuleListItem
+              key={rule.uid}
+              rule={rule}
+              groupIdentifier={groupIdentifier}
+              namespaceName={namespaceName}
+              showLocation={false}
+              inChain
+              className={styles.chainRule}
+            />
+          ))}
+      </Stack>
+    </ChainGroup>
+  );
+}

--- a/public/app/features/alerting/unified/rule-list/chainRail/DemoFolderSection.tsx
+++ b/public/app/features/alerting/unified/rule-list/chainRail/DemoFolderSection.tsx
@@ -1,0 +1,48 @@
+import { Icon, Stack } from '@grafana/ui';
+
+import { DEV_DEMO_CHAIN_FOLDER_UID, DEV_DEMO_CHAIN_GROUP_NAME, DEV_DEMO_CHAIN_ID } from '../../api/ruleGroupChainsApi';
+import { ListSection } from '../components/ListSection';
+
+import { ChainRuleCluster } from './ChainRuleCluster';
+import { getDevMockRulesFor } from './devMockRules';
+import { type Chain } from './types';
+
+// Dev-only: renders a synthetic "ChainDemoFolder" at the top of the
+// Grafana-managed section so the chain rail is visible without any setup in
+// the user's local Grafana. Gated by NODE_ENV, so the whole module is
+// tree-shaken out of production bundles.
+const DEMO_FOLDER_NAME = 'ChainDemoFolder';
+
+const DEMO_CHAIN: Chain = {
+  id: DEV_DEMO_CHAIN_ID,
+  name: 'Chain rail demo',
+  folderUid: DEV_DEMO_CHAIN_FOLDER_UID,
+  groupName: DEV_DEMO_CHAIN_GROUP_NAME,
+  mode: 'Sequential',
+  interval: '1m',
+  ruleUids: [],
+};
+
+export function DemoFolderSection() {
+  if (process.env.NODE_ENV !== 'development') {
+    return null;
+  }
+  const mockRules = getDevMockRulesFor(DEMO_CHAIN);
+  return (
+    <ListSection
+      title={
+        <Stack direction="row" gap={1} alignItems="center">
+          <Icon name="folder" />
+          <span>{DEMO_FOLDER_NAME}</span>
+        </Stack>
+      }
+    >
+      <ChainRuleCluster
+        chain={DEMO_CHAIN}
+        folderUid={DEV_DEMO_CHAIN_FOLDER_UID}
+        namespaceName={DEMO_FOLDER_NAME}
+        mockRules={mockRules}
+      />
+    </ListSection>
+  );
+}

--- a/public/app/features/alerting/unified/rule-list/chainRail/FlatGroupRules.tsx
+++ b/public/app/features/alerting/unified/rule-list/chainRail/FlatGroupRules.tsx
@@ -1,0 +1,40 @@
+import { Fragment, useMemo } from 'react';
+
+import { type GrafanaRuleGroupIdentifier } from 'app/types/unified-alerting';
+import { type GrafanaPromRuleGroupDTO } from 'app/types/unified-alerting-dto';
+
+import { GrafanaRuleListItem } from '../GrafanaRuleListItem';
+
+interface FlatGroupRulesProps {
+  group: GrafanaPromRuleGroupDTO;
+  namespaceName: string;
+}
+
+// Renders every rule in an evaluation group as a standalone inline row. The
+// group header is not rendered — per the chain-rail spec the evaluation-group
+// level is removed, and rules live as equal siblings of chain clusters.
+export function FlatGroupRules({ group, namespaceName }: FlatGroupRulesProps) {
+  const groupIdentifier: GrafanaRuleGroupIdentifier = useMemo(
+    () => ({
+      groupName: group.name,
+      namespace: { uid: group.folderUid },
+      groupOrigin: 'grafana',
+    }),
+    [group.name, group.folderUid]
+  );
+
+  return (
+    <>
+      {group.rules.map((rule) => (
+        <Fragment key={rule.uid}>
+          <GrafanaRuleListItem
+            rule={rule}
+            groupIdentifier={groupIdentifier}
+            namespaceName={namespaceName}
+            showLocation={false}
+          />
+        </Fragment>
+      ))}
+    </>
+  );
+}

--- a/public/app/features/alerting/unified/rule-list/chainRail/adaptGroupedNamespace.ts
+++ b/public/app/features/alerting/unified/rule-list/chainRail/adaptGroupedNamespace.ts
@@ -1,0 +1,19 @@
+import { type GrafanaPromRuleGroupDTO } from 'app/types/unified-alerting-dto';
+
+import { type Chain } from './types';
+
+export type ChainsByKey = Map<string, Chain>;
+
+const keyOf = (folderUid: string, groupName: string) => `${folderUid}::${groupName}`;
+
+export function buildChainsByKey(chains: Chain[]): ChainsByKey {
+  const map = new Map<string, Chain>();
+  for (const chain of chains) {
+    map.set(keyOf(chain.folderUid, chain.groupName), chain);
+  }
+  return map;
+}
+
+export function getChainForGroup(chainsByKey: ChainsByKey, group: GrafanaPromRuleGroupDTO): Chain | undefined {
+  return chainsByKey.get(keyOf(group.folderUid, group.name));
+}

--- a/public/app/features/alerting/unified/rule-list/chainRail/devMockRules.ts
+++ b/public/app/features/alerting/unified/rule-list/chainRail/devMockRules.ts
@@ -1,0 +1,117 @@
+import { type GrafanaPromRuleDTO, PromAlertingRuleState, PromRuleType } from 'app/types/unified-alerting-dto';
+
+import { type Chain } from './types';
+
+// TODO(alerting.rulesAPIV2): remove this module once the backend chain endpoint
+// returns real rule data. It only exists so the chain rail can be demoed in
+// `yarn start` before the API ships.
+
+const DEV_CHAIN_ID_PREFIX = 'dev-chain-';
+
+function buildRecordingRule(folderUid: string): GrafanaPromRuleDTO {
+  return {
+    uid: `${folderUid}-dev-recording-1`,
+    folderUid,
+    isPaused: false,
+    name: 'hosted_grafana:pause_events:10m',
+    query: 'sum by (namespace) (rate(pause_events_total[10m]))',
+    type: PromRuleType.Recording,
+    health: 'ok',
+    labels: { team: 'billing' },
+    queriedDatasourceUIDs: ['grafanacloud-dev-logs'],
+  };
+}
+
+function buildAlertRule(params: {
+  folderUid: string;
+  uid: string;
+  name: string;
+  summary: string;
+  state: PromAlertingRuleState;
+  labels?: Record<string, string>;
+  datasourceUid?: string;
+  alertCount?: number;
+}): GrafanaPromRuleDTO {
+  const { folderUid, uid, name, summary, state, labels = {}, datasourceUid, alertCount = 0 } = params;
+  const alertInstances =
+    alertCount > 0 && state !== PromAlertingRuleState.Inactive
+      ? Array.from({ length: alertCount }, (_, i) => ({
+          labels: { instance: `host-${i + 1}` },
+          annotations: {},
+          state: PromAlertingRuleState.Firing as const,
+          activeAt: new Date(Date.now() - 60_000).toISOString(),
+          value: '1',
+        }))
+      : undefined;
+
+  return {
+    uid,
+    folderUid,
+    isPaused: false,
+    name,
+    query: 'sum by (namespace) (grafanacloud_instance_active_series)',
+    type: PromRuleType.Alerting,
+    state,
+    health: 'ok',
+    labels,
+    annotations: { summary },
+    alerts: alertInstances,
+    totals: alertInstances ? { alerting: alertInstances.length } : {},
+    totalsFiltered: alertInstances ? { alerting: alertInstances.length } : {},
+    queriedDatasourceUIDs: datasourceUid ? [datasourceUid] : undefined,
+  };
+}
+
+function buildDevMockChainRules(folderUid: string): GrafanaPromRuleDTO[] {
+  return [
+    buildRecordingRule(folderUid),
+    buildAlertRule({
+      folderUid,
+      uid: `${folderUid}-dev-alert-1`,
+      name: 'Attributed Metrics Usage [namespace=sum_by]: 10% over 12,000,000 series',
+      summary: 'This alert is provisioned by the Grafana Cloud Cost Management and Billing app.',
+      state: PromAlertingRuleState.Inactive,
+      labels: { severity: 'warning', team: 'billing', env: 'prod', region: 'us-east' },
+      datasourceUid: 'grafanacloud-usage',
+    }),
+    buildAlertRule({
+      folderUid,
+      uid: `${folderUid}-dev-alert-2`,
+      name: 'Attributed Metrics Usage [namespace=AWS/EC2]: 1% over 15,000 series',
+      summary: 'This alert is provisioned by the Grafana Cloud Cost Management and Billing app.',
+      state: PromAlertingRuleState.Pending,
+      labels: { severity: 'warning', team: 'billing', env: 'prod', region: 'us-east' },
+      datasourceUid: 'grafanacloud-usage',
+    }),
+    buildAlertRule({
+      folderUid,
+      uid: `${folderUid}-dev-alert-3`,
+      name: 'Attributed Logs Usage [namespace=prod]: 5% over 200 GiB',
+      summary: 'This alert is provisioned by the Grafana Cloud Cost Management and Billing app.',
+      state: PromAlertingRuleState.Firing,
+      labels: { severity: 'critical', team: 'billing', env: 'prod' },
+      datasourceUid: 'grafanacloud-usage',
+      alertCount: 3,
+    }),
+    buildAlertRule({
+      folderUid,
+      uid: `${folderUid}-dev-alert-4`,
+      name: 'Attributed Traces Usage [namespace=staging]: 20% over quota',
+      summary: 'This alert is provisioned by the Grafana Cloud Cost Management and Billing app.',
+      state: PromAlertingRuleState.Inactive,
+      labels: { severity: 'warning', team: 'billing', env: 'staging' },
+      datasourceUid: 'grafanacloud-usage',
+    }),
+  ];
+}
+
+export function isDevMockChain(chain: Chain): boolean {
+  return process.env.NODE_ENV === 'development' && chain.id.startsWith(DEV_CHAIN_ID_PREFIX);
+}
+
+export function getDevMockRulesFor(chain: Chain): GrafanaPromRuleDTO[] | undefined {
+  if (!isDevMockChain(chain)) {
+    return undefined;
+  }
+  return buildDevMockChainRules(chain.folderUid);
+}

--- a/public/app/features/alerting/unified/rule-list/chainRail/styles.ts
+++ b/public/app/features/alerting/unified/rule-list/chainRail/styles.ts
@@ -1,0 +1,108 @@
+import { css } from '@emotion/css';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+
+// Info-blue palette from v2-chain-rail-spec.md §6.
+// TODO(design): promote to theme tokens once the pattern stabilises.
+const CHAIN_BLUE = '#6E9FFF';
+const CHAIN_TEXT = '#8AB8FF';
+const CHAIN_BG_GROUP = 'rgba(110, 159, 255, 0.03)';
+const CHAIN_BG_HEADER = 'rgba(110, 159, 255, 0.06)';
+const CHAIN_ICON_BG = 'rgba(110, 159, 255, 0.12)';
+const CHAIN_BORDER = 'rgba(110, 159, 255, 0.25)';
+const CHAIN_ICON_BORDER = 'rgba(110, 159, 255, 0.45)';
+const CHAIN_RAIL_COLOR = 'rgba(110, 159, 255, 0.6)';
+
+export const getChainRailStyles = (theme: GrafanaTheme2) => ({
+  chainGroup: css({
+    position: 'relative',
+    background: CHAIN_BG_GROUP,
+    listStyle: 'none',
+    padding: 0,
+    margin: 0,
+
+    '&::before': {
+      content: '""',
+      position: 'absolute',
+      left: '18px',
+      top: '28px',
+      bottom: '12px',
+      width: '2px',
+      background: CHAIN_RAIL_COLOR,
+      pointerEvents: 'none',
+    },
+  }),
+  // `&&&` triples class specificity so we beat ListSection's
+  // `.groupItemsWrapper li[role=treeitem]::before` (specificity 0,2,2) which
+  // would otherwise override our dot's height / borderLeft and render a
+  // vertical pill instead of a circle.
+  chainRule: css({
+    '&&&': {
+      position: 'relative',
+      paddingLeft: theme.spacing(4),
+    },
+    '&&&::before': {
+      content: '""',
+      position: 'absolute',
+      boxSizing: 'border-box',
+      left: '13px',
+      top: '50%',
+      marginTop: '-6px',
+      marginLeft: 0,
+      width: '12px',
+      height: '12px',
+      borderRadius: theme.shape.radius.circle,
+      background: theme.colors.background.canvas,
+      border: `2px solid ${CHAIN_BLUE}`,
+      zIndex: 1,
+      pointerEvents: 'none',
+    },
+  }),
+  chainHeader: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1.25),
+    padding: theme.spacing(1, 1.5),
+    fontSize: theme.typography.size.sm,
+    color: CHAIN_TEXT,
+    background: CHAIN_BG_HEADER,
+    borderTop: `1px dashed ${CHAIN_BORDER}`,
+    borderBottom: `1px dashed ${CHAIN_BORDER}`,
+  }),
+  chainHeaderIcon: css({
+    width: '20px',
+    height: '20px',
+    borderRadius: theme.shape.radius.circle,
+    background: CHAIN_ICON_BG,
+    border: `1px solid ${CHAIN_ICON_BORDER}`,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    color: CHAIN_TEXT,
+    flex: '0 0 auto',
+  }),
+  chainHeaderName: css({
+    fontWeight: theme.typography.fontWeightMedium,
+    color: CHAIN_TEXT,
+  }),
+  chainHeaderCount: css({
+    fontFamily: theme.typography.fontFamilyMonospace,
+    color: theme.colors.text.secondary,
+    fontSize: '11px',
+  }),
+  chainHeaderSpacer: css({
+    flex: 1,
+  }),
+  chainHeaderMeta: css({
+    fontSize: '11px',
+    color: theme.colors.text.secondary,
+    fontFamily: theme.typography.fontFamilyMonospace,
+    display: 'flex',
+    gap: theme.spacing(1.5),
+    alignItems: 'center',
+  }),
+  chainHeaderActions: css({
+    display: 'flex',
+    gap: theme.spacing(0.25),
+  }),
+});

--- a/public/app/features/alerting/unified/rule-list/chainRail/styles.ts
+++ b/public/app/features/alerting/unified/rule-list/chainRail/styles.ts
@@ -46,8 +46,15 @@ export const getChainRailStyles = (theme: GrafanaTheme2) => ({
       position: 'absolute',
       boxSizing: 'border-box',
       left: '13px',
-      top: '50%',
-      marginTop: '-6px',
+      // Align the dot's centre with the status icon's centre.
+      // Derived from ListItem.tsx:
+      //   <li> padding-top theme.spacing(1) = 8px
+      // + .statusIcon marginTop theme.spacing(0.5) = 4px
+      // + half of the 16x16 status icon = 8px      → icon centre at 20px
+      // - half of the 12x12 dot = 6px              → dot top at 14px
+      // If ListItem's padding or .statusIcon's margin changes, update here.
+      top: '14px',
+      marginTop: 0,
       marginLeft: 0,
       width: '12px',
       height: '12px',

--- a/public/app/features/alerting/unified/rule-list/chainRail/types.ts
+++ b/public/app/features/alerting/unified/rule-list/chainRail/types.ts
@@ -1,0 +1,20 @@
+export type ChainMode = 'Sequential' | 'Parallel' | 'Conditional';
+
+export interface Chain {
+  id: string;
+  name: string;
+  folderUid: string;
+  groupName: string;
+  mode: ChainMode;
+  interval: string;
+  ruleUids: string[];
+}
+
+export interface ChainMembership {
+  id: string;
+  position: number;
+}
+
+export interface ListRuleGroupChainsResponse {
+  chains: Chain[];
+}

--- a/public/app/features/alerting/unified/rule-list/components/AlertRuleListItem.tsx
+++ b/public/app/features/alerting/unified/rule-list/components/AlertRuleListItem.tsx
@@ -60,6 +60,10 @@ export interface AlertRuleListItemProps {
   // the grouped view doesn't need to show the location again – it's redundant
   showLocation?: boolean;
   querySourceUIDs?: string[];
+  // When true, interval + next-evaluation metadata is suppressed because the
+  // chain header above this row owns chain-level timing.
+  inChain?: boolean;
+  className?: string;
 }
 
 export const AlertRuleListItem = (props: AlertRuleListItemProps) => {
@@ -87,6 +91,8 @@ export const AlertRuleListItem = (props: AlertRuleListItemProps) => {
     operation,
     showLocation = true,
     querySourceUIDs = [],
+    inChain = false,
+    className,
   } = props;
 
   const listItemAriaId = useId();
@@ -111,7 +117,7 @@ export const AlertRuleListItem = (props: AlertRuleListItemProps) => {
   }
 
   if (!isPaused) {
-    if (lastEvaluation && evaluationInterval) {
+    if (!inChain && lastEvaluation && evaluationInterval) {
       metadata.push(
         <EvaluationMetadata lastEvaluation={lastEvaluation} evaluationInterval={evaluationInterval} state={state} />
       );
@@ -158,6 +164,7 @@ export const AlertRuleListItem = (props: AlertRuleListItemProps) => {
   return (
     <ListItem
       aria-labelledby={listItemAriaId}
+      className={className}
       title={
         <Stack direction="row" alignItems="center">
           <TextLink href={href} color="primary" inline={false} id={listItemAriaId}>
@@ -201,7 +208,8 @@ export function RecordingRuleListItem({
   actions,
   showLocation = true,
   querySourceUIDs = [],
-}: RecordingRuleListItemProps) {
+  className,
+}: RecordingRuleListItemProps & { className?: string }) {
   const metadata: ReactNode[] = [];
   if (namespace && group && showLocation) {
     metadata.push(
@@ -225,6 +233,7 @@ export function RecordingRuleListItem({
 
   return (
     <ListItem
+      className={className}
       title={
         <Stack direction="row" alignItems="center">
           <TextLink color="primary" href={href} inline={false}>

--- a/public/app/features/alerting/unified/rule-list/components/ListItem.tsx
+++ b/public/app/features/alerting/unified/rule-list/components/ListItem.tsx
@@ -1,4 +1,4 @@
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import React, { type AriaAttributes, type ReactNode } from 'react';
 import Skeleton from 'react-loading-skeleton';
 
@@ -13,15 +13,26 @@ interface ListItemProps extends AriaAttributes {
   metaRight?: ReactNode[];
   actions?: ReactNode;
   'data-testid'?: string;
+  className?: string;
 }
 
 export const ListItem = (props: ListItemProps) => {
   const styles = useStyles2(getStyles);
-  const { icon = null, title, description, meta, metaRight, actions, 'data-testid': testId, ...ariaAttributes } = props;
+  const {
+    icon = null,
+    title,
+    description,
+    meta,
+    metaRight,
+    actions,
+    'data-testid': testId,
+    className,
+    ...ariaAttributes
+  } = props;
 
   return (
     <li
-      className={styles.alertListItemContainer}
+      className={cx(styles.alertListItemContainer, className)}
       role="treeitem"
       aria-selected="false"
       data-testid={testId}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -830,6 +830,15 @@
         }
       }
     },
+    "chain-rail": {
+      "edit": "Edit",
+      "edit-aria": "Edit {{name}}",
+      "more": "More",
+      "more-aria": "More options for {{name}}",
+      "no-rules": "No rules found in this chain",
+      "rule-count_one": "{{count}} rules",
+      "rule-count_other": "{{count}} rules"
+    },
     "channel-sub-form": {
       "badge-deprecated": "Deprecated",
       "delete": "Delete",


### PR DESCRIPTION
**Summary**
This PR implements a POC layout for the alert rules list, shown when the `alerting.rulesAPIV2` feature toggle is enabled (on top of the existing `alertingListViewV2`):

  - Groups consecutive rules that share an evaluation chain behind a thin vertical blue rail with a hollow dot per rule.
  - Renders a compact chain header (name, rule count, mode · interval, Edit / More actions) above each cluster — replacing the collapsible evaluation-group row.
  - Flattens non-chain evaluation groups so their rules appear as inline siblings of chain clusters, no more group-level expand/collapse.
  - When the toggle is off, the existing V2 grouped view renders unchanged.

Because the backend chain API is not ready yet, the RTK Query endpoint (`listRuleGroupChains`) has a dev-only short-circuit that returns a factory-shaped fixture. 
A mock **ChainDemoFolder** is injected at the top of the Grafana-managed section with a 5-rule cluster (1 recording rule + 4 alert rules across firing / pending / normal states) so the layout can be demoed without any setup. MSW handlers at `mocks/server/handlers/chains.ts` serve the same shape for tests. 

<img width="3386" height="4036" alt="image" src="https://github.com/user-attachments/assets/0f254e60-b442-4930-986e-8951d798793a" />
