### PR TITLE
BarChart and Table: pass keyLabel when adding ad hoc filters from panels

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/components/TableCellActions.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/components/TableCellActions.test.tsx
@@ -1,0 +1,117 @@
+import { render, screen } from '@testing-library/react';
+
+import { Field, FieldType } from '@grafana/data';
+
+import { FILTER_FOR_OPERATOR, FILTER_OUT_OPERATOR } from '../types';
+
+import { TableCellActions } from './TableCellActions';
+
+describe('TableCellActions', () => {
+  const setInspectCell = jest.fn();
+
+  beforeEach(() => {
+    setInspectCell.mockClear();
+  });
+
+  describe('filter actions', () => {
+    it('calls onCellFilterAdded with key, value, operator and keyLabel when "Filter for value" is clicked', () => {
+      const onCellFilterAdded = jest.fn();
+      const field: Field = {
+        name: 'Account.Owner.Name',
+        type: FieldType.string,
+        values: [],
+        config: {
+          displayNameFromDS: 'Account Owner Name',
+        },
+      };
+      const value = 'CA';
+
+      render(
+        <TableCellActions
+          field={field}
+          value={value}
+          displayName={field.config.displayNameFromDS ?? field.name}
+          cellInspect={false}
+          showFilters={true}
+          setInspectCell={setInspectCell}
+          onCellFilterAdded={onCellFilterAdded}
+        />
+      );
+
+      screen.getByRole('button', { name: 'Filter for value' }).click();
+
+      expect(onCellFilterAdded).toHaveBeenCalledTimes(1);
+      expect(onCellFilterAdded).toHaveBeenCalledWith({
+        key: 'Account.Owner.Name',
+        operator: FILTER_FOR_OPERATOR,
+        value: 'CA',
+        keyLabel: 'Account Owner Name',
+      });
+    });
+
+    it('calls onCellFilterAdded with keyLabel from field.name when displayNameFromDS is not set', () => {
+      const onCellFilterAdded = jest.fn();
+      const field: Field = {
+        name: 'orders.status',
+        type: FieldType.string,
+        values: [],
+        config: {},
+      };
+
+      render(
+        <TableCellActions
+          field={field}
+          value="completed"
+          displayName={field.name}
+          cellInspect={false}
+          showFilters={true}
+          setInspectCell={setInspectCell}
+          onCellFilterAdded={onCellFilterAdded}
+        />
+      );
+
+      screen.getByRole('button', { name: 'Filter for value' }).click();
+
+      expect(onCellFilterAdded).toHaveBeenCalledWith(
+        expect.objectContaining({
+          key: 'orders.status',
+          value: 'completed',
+          operator: FILTER_FOR_OPERATOR,
+          keyLabel: 'orders.status',
+        })
+      );
+    });
+
+    it('calls onCellFilterAdded with key, value, operator and keyLabel when "Filter out value" is clicked', () => {
+      const onCellFilterAdded = jest.fn();
+      const field: Field = {
+        name: 'status',
+        type: FieldType.string,
+        values: [],
+        config: { displayNameFromDS: 'Status' },
+      };
+
+      render(
+        <TableCellActions
+          field={field}
+          value="pending"
+          displayName={field.config.displayNameFromDS ?? field.name}
+          cellInspect={false}
+          showFilters={true}
+          setInspectCell={setInspectCell}
+          onCellFilterAdded={onCellFilterAdded}
+        />
+      );
+
+      screen.getByRole('button', { name: 'Filter out value' }).click();
+
+      expect(onCellFilterAdded).toHaveBeenCalledTimes(1);
+      expect(onCellFilterAdded).toHaveBeenCalledWith({
+        key: 'status',
+        operator: FILTER_OUT_OPERATOR,
+        value: 'pending',
+        keyLabel: 'Status',
+      });
+    });
+  });
+});

--- a/packages/grafana-ui/src/components/Table/TableNG/components/TableCellActions.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/components/TableCellActions.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 
-import { Field, FieldType } from '@grafana/data';
+import { type Field, FieldType } from '@grafana/data';
 
 import { FILTER_FOR_OPERATOR, FILTER_OUT_OPERATOR } from '../types';
 

--- a/packages/grafana-ui/src/components/Table/TableNG/components/TableCellActions.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/components/TableCellActions.tsx
@@ -32,10 +32,13 @@ export const TableCellActions = memo(
               name={'filter-plus'}
               aria-label={t('grafana-ui.table.cell-filter-on', 'Filter for value')}
               onClick={() => {
+                const val = String(value ?? '');
                 onCellFilterAdded?.({
                   key: field.name,
                   operator: FILTER_FOR_OPERATOR,
-                  value: String(value ?? ''),
+                  value: val,
+                  keyLabel: field.config.displayNameFromDS ?? field.state?.displayName ?? field.name,
+                  valueLabel: val,
                 });
               }}
             />
@@ -43,10 +46,13 @@ export const TableCellActions = memo(
               name={'filter-minus'}
               aria-label={t('grafana-ui.table.cell-filter-out', 'Filter out value')}
               onClick={() => {
+                const val = String(value ?? '');
                 onCellFilterAdded?.({
                   key: field.name,
                   operator: FILTER_OUT_OPERATOR,
-                  value: String(value ?? ''),
+                  value: val,
+                  keyLabel: field.config.displayNameFromDS ?? field.state?.displayName ?? field.name,
+                  valueLabel: val,
                 });
               }}
             />

--- a/packages/grafana-ui/src/components/Table/TableNG/components/TableCellActions.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/components/TableCellActions.tsx
@@ -38,7 +38,6 @@ export const TableCellActions = memo(
                   operator: FILTER_FOR_OPERATOR,
                   value: val,
                   keyLabel: field.config.displayNameFromDS ?? field.state?.displayName ?? field.name,
-                  valueLabel: val,
                 });
               }}
             />
@@ -52,7 +51,6 @@ export const TableCellActions = memo(
                   operator: FILTER_OUT_OPERATOR,
                   value: val,
                   keyLabel: field.config.displayNameFromDS ?? field.state?.displayName ?? field.name,
-                  valueLabel: val,
                 });
               }}
             />

--- a/packages/grafana-ui/src/components/Table/TableNG/types.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/types.ts
@@ -25,7 +25,15 @@ export const FILTER_FOR_OPERATOR = '=';
 export const FILTER_OUT_OPERATOR = '!=';
 
 export type AdHocFilterOperator = typeof FILTER_FOR_OPERATOR | typeof FILTER_OUT_OPERATOR;
-export type AdHocFilterItem = { key: string; value: string; operator: AdHocFilterOperator };
+export type AdHocFilterItem = {
+  key: string;
+  value: string;
+  operator: AdHocFilterOperator;
+  /** Human-readable label for the key (e.g. from DisplayNameFromDS). Falls back to key when absent. */
+  keyLabel?: string;
+  /** Human-readable label for the value. Falls back to value when absent. */
+  valueLabel?: string;
+};
 export type TableFilterActionCallback = (item: AdHocFilterItem) => void;
 export type TableColumnResizeActionCallback = (fieldDisplayName: string, width: number) => void;
 export type TableSortByActionCallback = (state: TableSortByFieldState[]) => void;

--- a/packages/grafana-ui/src/components/Table/TableNG/types.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/types.ts
@@ -29,10 +29,8 @@ export type AdHocFilterItem = {
   key: string;
   value: string;
   operator: AdHocFilterOperator;
-  /** Human-readable label for the key (e.g. from DisplayNameFromDS). Falls back to key when absent. */
+  /** Human-readable label for the key (e.g. from DisplayNameFromDS). Falls back to key when absent. Values are not given separate labels in scope. */
   keyLabel?: string;
-  /** Human-readable label for the value. Falls back to value when absent. */
-  valueLabel?: string;
 };
 export type TableFilterActionCallback = (item: AdHocFilterItem) => void;
 export type TableColumnResizeActionCallback = (fieldDisplayName: string, width: number) => void;

--- a/packages/grafana-ui/src/components/Table/types.ts
+++ b/packages/grafana-ui/src/components/Table/types.ts
@@ -39,7 +39,15 @@ export type InspectCell = { value: any; mode: TableCellInspectorMode };
 export const FILTER_FOR_OPERATOR = '=';
 export const FILTER_OUT_OPERATOR = '!=';
 export type AdHocFilterOperator = typeof FILTER_FOR_OPERATOR | typeof FILTER_OUT_OPERATOR;
-export type AdHocFilterItem = { key: string; value: string; operator: AdHocFilterOperator };
+export type AdHocFilterItem = {
+  key: string;
+  value: string;
+  operator: AdHocFilterOperator;
+  /** Human-readable label for the key (e.g. from DisplayNameFromDS). Falls back to key when absent. */
+  keyLabel?: string;
+  /** Human-readable label for the value. Falls back to value when absent. */
+  valueLabel?: string;
+};
 export type TableFilterActionCallback = (item: AdHocFilterItem) => void;
 export type TableColumnResizeActionCallback = (fieldDisplayName: string, width: number) => void;
 export type TableSortByActionCallback = (state: TableSortByFieldState[]) => void;

--- a/packages/grafana-ui/src/components/Table/types.ts
+++ b/packages/grafana-ui/src/components/Table/types.ts
@@ -43,10 +43,8 @@ export type AdHocFilterItem = {
   key: string;
   value: string;
   operator: AdHocFilterOperator;
-  /** Human-readable label for the key (e.g. from DisplayNameFromDS). Falls back to key when absent. */
+  /** Human-readable label for the key (e.g. from DisplayNameFromDS). Falls back to key when absent. Values are not given separate labels in scope. */
   keyLabel?: string;
-  /** Human-readable label for the value. Falls back to value when absent. */
-  valueLabel?: string;
 };
 export type TableFilterActionCallback = (item: AdHocFilterItem) => void;
 export type TableColumnResizeActionCallback = (fieldDisplayName: string, width: number) => void;

--- a/public/app/features/dashboard-scene/scene/setDashboardPanelContext.test.ts
+++ b/public/app/features/dashboard-scene/scene/setDashboardPanelContext.test.ts
@@ -139,7 +139,6 @@ describe('setDashboardPanelContext', () => {
       expect(variable.state.filters).toEqual([
         { key: 'hello', value: 'world', operator: '!=' },
         { key: 'hello', value: 'world2', operator: '!=' },
-        ,
       ]);
     });
 
@@ -175,6 +174,23 @@ describe('setDashboardPanelContext', () => {
       const variables = sceneGraph.getVariables(scene);
       const adhocVars = variables.state.variables.filter((v) => v.state.type === 'adhoc');
       expect(adhocVars.length).toBe(1);
+    });
+
+    it('should persist keyLabel and valueLabel when provided', () => {
+      const { scene, context } = buildTestScene({});
+
+      context.onAddAdHocFilter!({
+        key: 'Account.Owner.Name',
+        value: 'CA',
+        operator: '=',
+        keyLabel: 'Account Owner Name',
+        valueLabel: 'California',
+      });
+
+      const variable = getAdHocFilterVariableFor(scene, { uid: 'my-ds-uid' });
+      expect(variable.state.filters).toHaveLength(1);
+      expect(variable.state.filters[0].keyLabel).toBe('Account Owner Name');
+      expect(variable.state.filters[0].valueLabels).toEqual(['California']);
     });
   });
 

--- a/public/app/features/dashboard-scene/scene/setDashboardPanelContext.test.ts
+++ b/public/app/features/dashboard-scene/scene/setDashboardPanelContext.test.ts
@@ -176,7 +176,7 @@ describe('setDashboardPanelContext', () => {
       expect(adhocVars.length).toBe(1);
     });
 
-    it('should persist keyLabel and valueLabel when provided', () => {
+    it('should persist keyLabel when provided', () => {
       const { scene, context } = buildTestScene({});
 
       context.onAddAdHocFilter!({
@@ -184,13 +184,11 @@ describe('setDashboardPanelContext', () => {
         value: 'CA',
         operator: '=',
         keyLabel: 'Account Owner Name',
-        valueLabel: 'California',
       });
 
       const variable = getAdHocFilterVariableFor(scene, { uid: 'my-ds-uid' });
       expect(variable.state.filters).toHaveLength(1);
       expect(variable.state.filters[0].keyLabel).toBe('Account Owner Name');
-      expect(variable.state.filters[0].valueLabels).toEqual(['California']);
     });
   });
 

--- a/public/app/features/dashboard-scene/scene/setDashboardPanelContext.ts
+++ b/public/app/features/dashboard-scene/scene/setDashboardPanelContext.ts
@@ -277,15 +277,14 @@ export function getAdHocFilterVariableFor(scene: DashboardScene, ds: DataSourceR
   return newVariable;
 }
 
-/** Convert panel AdHocFilterItem to the shape expected by AdHocFiltersVariable (keyLabel, valueLabels). */
+/** Convert panel AdHocFilterItem to the shape expected by AdHocFiltersVariable. Only keyLabel is set from panels (values are just values; no valueLabels in scope). */
 function toAdHocFilterWithLabels(item: AdHocFilterItem) {
-  const { key, value, operator, keyLabel, valueLabel } = item;
+  const { key, value, operator, keyLabel } = item;
   return {
     key,
     value,
     operator,
     ...(keyLabel !== undefined && { keyLabel }),
-    ...(valueLabel !== undefined && { valueLabels: [valueLabel] }),
   };
 }
 

--- a/public/app/features/dashboard-scene/scene/setDashboardPanelContext.ts
+++ b/public/app/features/dashboard-scene/scene/setDashboardPanelContext.ts
@@ -277,6 +277,18 @@ export function getAdHocFilterVariableFor(scene: DashboardScene, ds: DataSourceR
   return newVariable;
 }
 
+/** Convert panel AdHocFilterItem to the shape expected by AdHocFiltersVariable (keyLabel, valueLabels). */
+function toAdHocFilterWithLabels(item: AdHocFilterItem) {
+  const { key, value, operator, keyLabel, valueLabel } = item;
+  return {
+    key,
+    value,
+    operator,
+    ...(keyLabel !== undefined && { keyLabel }),
+    ...(valueLabel !== undefined && { valueLabels: [valueLabel] }),
+  };
+}
+
 function bulkUpdateAdHocFiltersVariable(filterVar: AdHocFiltersVariable, newFilters: AdHocFilterItem[]) {
   if (!newFilters.length) {
     return;
@@ -286,18 +298,19 @@ function bulkUpdateAdHocFiltersVariable(filterVar: AdHocFiltersVariable, newFilt
   let hasChanges = false;
 
   for (const newFilter of newFilters) {
+    const filterWithLabels = toAdHocFilterWithLabels(newFilter);
     const filterToReplaceIndex = updatedFilters.findIndex(
       (filter) =>
         filter.key === newFilter.key && filter.value === newFilter.value && filter.operator !== newFilter.operator
     );
 
     if (filterToReplaceIndex >= 0) {
-      updatedFilters.splice(filterToReplaceIndex, 1, newFilter);
+      updatedFilters.splice(filterToReplaceIndex, 1, filterWithLabels);
       hasChanges = true;
       continue;
     }
 
-    updatedFilters.push(newFilter);
+    updatedFilters.push(filterWithLabels);
     hasChanges = true;
   }
 
@@ -310,6 +323,8 @@ function updateAdHocFilterVariable(filterVar: AdHocFiltersVariable, newFilter: A
   // This function handles 'Filter for value' and 'Filter out value' from table cell
   // We are allowing to add filters with the same key because elastic search ds supports that
 
+  const filterWithLabels = toAdHocFilterWithLabels(newFilter);
+
   // Update is only required when we change operator and keep key and value the same
   //   key1 = value1 -> key1 != value1
   const filterToReplaceIndex = filterVar.state.filters.findIndex(
@@ -319,11 +334,11 @@ function updateAdHocFilterVariable(filterVar: AdHocFiltersVariable, newFilter: A
 
   if (filterToReplaceIndex >= 0) {
     const updatedFilters = filterVar.state.filters.slice();
-    updatedFilters.splice(filterToReplaceIndex, 1, newFilter);
+    updatedFilters.splice(filterToReplaceIndex, 1, filterWithLabels);
     filterVar.updateFilters(updatedFilters);
     return;
   }
 
   // Add new filter
-  filterVar.updateFilters([...filterVar.state.filters, newFilter]);
+  filterVar.updateFilters([...filterVar.state.filters, filterWithLabels]);
 }

--- a/public/app/plugins/panel/barchart/BarChartPanel.tsx
+++ b/public/app/plugins/panel/barchart/BarChartPanel.tsx
@@ -175,10 +175,13 @@ export const BarChartPanel = (props: PanelProps<Options>) => {
                 // are derived from a data source, but are not present in the data source.
                 // We choose `xField` here because it contains the label-value pair, rather than `field` which is the numeric Value.
                 if (xField.config.filterable && onAddAdHocFilter != null) {
+                  const value = String(xField.values[dataIdx]);
                   const adHocFilterItem: AdHocFilterItem = {
                     key: xField.name,
                     operator: FILTER_FOR_OPERATOR,
-                    value: String(xField.values[dataIdx]),
+                    value,
+                    keyLabel: xField.config.displayNameFromDS ?? xField.state?.displayName ?? xField.name,
+                    valueLabel: value,
                   };
 
                   const adHocFilters: AdHocFilterModel[] = [

--- a/public/app/plugins/panel/barchart/BarChartPanel.tsx
+++ b/public/app/plugins/panel/barchart/BarChartPanel.tsx
@@ -181,7 +181,6 @@ export const BarChartPanel = (props: PanelProps<Options>) => {
                     operator: FILTER_FOR_OPERATOR,
                     value,
                     keyLabel: xField.config.displayNameFromDS ?? xField.state?.displayName ?? xField.name,
-                    valueLabel: value,
                   };
 
                   const adHocFilters: AdHocFilterModel[] = [

--- a/public/app/plugins/panel/barchart/BarChartPanel.tsx
+++ b/public/app/plugins/panel/barchart/BarChartPanel.tsx
@@ -19,7 +19,7 @@ import { TimeSeriesTooltip } from '../timeseries/TimeSeriesTooltip';
 
 import { BarChartLegend, hasVisibleLegendSeries } from './BarChartLegend';
 import { type Options } from './panelcfg.gen';
-import { prepConfig, prepSeries } from './utils';
+import { getFieldKeyLabel, prepConfig, prepSeries } from './utils';
 
 const charWidth = measureText('M', UPLOT_AXIS_FONT_SIZE).width;
 const toRads = Math.PI / 180;
@@ -180,7 +180,7 @@ export const BarChartPanel = (props: PanelProps<Options>) => {
                     key: xField.name,
                     operator: FILTER_FOR_OPERATOR,
                     value,
-                    keyLabel: xField.config.displayNameFromDS ?? xField.state?.displayName ?? xField.name,
+                    keyLabel: getFieldKeyLabel(xField),
                   };
 
                   const adHocFilters: AdHocFilterModel[] = [

--- a/public/app/plugins/panel/barchart/utils.test.ts
+++ b/public/app/plugins/panel/barchart/utils.test.ts
@@ -993,4 +993,12 @@ describe('getFieldKeyLabel', () => {
     };
     expect(getFieldKeyLabel(field)).toBe('orders.raw_customers_first_name');
   });
+
+  it('should not use config.displayName (panel-level overrides are not datasource keys)', () => {
+    const field: Field = {
+      ...baseField,
+      config: { displayName: 'Panel Override Name' },
+    };
+    expect(getFieldKeyLabel(field)).toBe('orders.raw_customers_first_name');
+  });
 });

--- a/public/app/plugins/panel/barchart/utils.test.ts
+++ b/public/app/plugins/panel/barchart/utils.test.ts
@@ -4,6 +4,7 @@ import {
   createDataFrame,
   createTheme,
   type DataFrame,
+  type Field,
   FieldColorModeId,
   type FieldConfigSource,
   FieldType,
@@ -28,7 +29,7 @@ import type { BarsOptions } from './bars';
 import * as barsModule from './bars';
 import type { Options } from './panelcfg.gen';
 import { applyBarChartFieldDefaults } from './test-helpers';
-import { prepConfig, type PrepConfigOpts, prepSeries } from './utils';
+import { getFieldKeyLabel, prepConfig, type PrepConfigOpts, prepSeries } from './utils';
 
 jest.mock('@grafana/data', () => ({
   ...jest.requireActual('@grafana/data'),
@@ -968,3 +969,48 @@ function withGetConfigSpy(capture: (opts: BarsOptions) => void, testFn: () => vo
     jest.restoreAllMocks();
   }
 }
+
+describe('getFieldKeyLabel', () => {
+  const baseField: Field = {
+    name: 'orders.raw_customers_first_name',
+    type: FieldType.string,
+    config: {},
+    values: [],
+  };
+
+  it('should return displayNameFromDS when set', () => {
+    const field: Field = {
+      ...baseField,
+      config: { displayNameFromDS: 'Orders Raw Customers First Name' },
+      state: { displayName: 'Some Calculated Name' },
+    };
+    expect(getFieldKeyLabel(field)).toBe('Orders Raw Customers First Name');
+  });
+
+  it('should fall back to state.displayName when displayNameFromDS is not set', () => {
+    const field: Field = {
+      ...baseField,
+      config: {},
+      state: { displayName: 'Some Calculated Name' },
+    };
+    expect(getFieldKeyLabel(field)).toBe('Some Calculated Name');
+  });
+
+  it('should fall back to field name when neither displayNameFromDS nor state.displayName is set', () => {
+    const field: Field = {
+      ...baseField,
+      config: {},
+      state: undefined,
+    };
+    expect(getFieldKeyLabel(field)).toBe('orders.raw_customers_first_name');
+  });
+
+  it('should fall back to field name when state exists but displayName is undefined', () => {
+    const field: Field = {
+      ...baseField,
+      config: {},
+      state: {},
+    };
+    expect(getFieldKeyLabel(field)).toBe('orders.raw_customers_first_name');
+  });
+});

--- a/public/app/plugins/panel/barchart/utils.test.ts
+++ b/public/app/plugins/panel/barchart/utils.test.ts
@@ -982,34 +982,14 @@ describe('getFieldKeyLabel', () => {
     const field: Field = {
       ...baseField,
       config: { displayNameFromDS: 'Orders Raw Customers First Name' },
-      state: { displayName: 'Some Calculated Name' },
     };
     expect(getFieldKeyLabel(field)).toBe('Orders Raw Customers First Name');
   });
 
-  it('should fall back to state.displayName when displayNameFromDS is not set', () => {
+  it('should fall back to field name when displayNameFromDS is not set', () => {
     const field: Field = {
       ...baseField,
       config: {},
-      state: { displayName: 'Some Calculated Name' },
-    };
-    expect(getFieldKeyLabel(field)).toBe('Some Calculated Name');
-  });
-
-  it('should fall back to field name when neither displayNameFromDS nor state.displayName is set', () => {
-    const field: Field = {
-      ...baseField,
-      config: {},
-      state: undefined,
-    };
-    expect(getFieldKeyLabel(field)).toBe('orders.raw_customers_first_name');
-  });
-
-  it('should fall back to field name when state exists but displayName is undefined', () => {
-    const field: Field = {
-      ...baseField,
-      config: {},
-      state: {},
     };
     expect(getFieldKeyLabel(field)).toBe('orders.raw_customers_first_name');
   });

--- a/public/app/plugins/panel/barchart/utils.ts
+++ b/public/app/plugins/panel/barchart/utils.ts
@@ -15,12 +15,11 @@ import {
 } from '@grafana/data';
 
 /**
- * Return the best human-readable label for a field, preferring the
- * datasource-provided display name, then the calculated display name,
- * and falling back to the raw field name.
+ * Return the best human-readable key label for a field, preferring the
+ * datasource-provided display name and falling back to the raw field name.
  */
 export function getFieldKeyLabel(field: Field): string {
-  return field.config.displayNameFromDS ?? field.state?.displayName ?? field.name;
+  return field.config.displayNameFromDS ?? field.name;
 }
 import { decoupleHideFromState } from '@grafana/data/internal';
 import { t } from '@grafana/i18n';

--- a/public/app/plugins/panel/barchart/utils.ts
+++ b/public/app/plugins/panel/barchart/utils.ts
@@ -13,6 +13,15 @@ import {
   getFieldSeriesColor,
   outerJoinDataFrames,
 } from '@grafana/data';
+
+/**
+ * Return the best human-readable label for a field, preferring the
+ * datasource-provided display name, then the calculated display name,
+ * and falling back to the raw field name.
+ */
+export function getFieldKeyLabel(field: Field): string {
+  return field.config.displayNameFromDS ?? field.state?.displayName ?? field.name;
+}
 import { decoupleHideFromState } from '@grafana/data/internal';
 import { t } from '@grafana/i18n';
 import {

--- a/public/app/plugins/panel/barchart/utils.ts
+++ b/public/app/plugins/panel/barchart/utils.ts
@@ -13,14 +13,6 @@ import {
   getFieldSeriesColor,
   outerJoinDataFrames,
 } from '@grafana/data';
-
-/**
- * Return the best human-readable key label for a field, preferring the
- * datasource-provided display name and falling back to the raw field name.
- */
-export function getFieldKeyLabel(field: Field): string {
-  return field.config.displayNameFromDS ?? field.name;
-}
 import { decoupleHideFromState } from '@grafana/data/internal';
 import { t } from '@grafana/i18n';
 import {
@@ -49,6 +41,14 @@ import { setClassicPaletteIdxs } from '../timeseries/utils';
 import { type BarsOptions, getConfig } from './bars';
 import { type FieldConfig, type Options, defaultFieldConfig } from './panelcfg.gen';
 // import { isLegendOrdered } from './utils';
+
+/**
+ * Return the best human-readable key label for a field, preferring the
+ * datasource-provided display name and falling back to the raw field name.
+ */
+export function getFieldKeyLabel(field: Field): string {
+  return field.config.displayNameFromDS ?? field.name;
+}
 
 interface BarSeries {
   series: DataFrame[];

--- a/public/app/plugins/panel/logstable/LogsTable.test.tsx
+++ b/public/app/plugins/panel/logstable/LogsTable.test.tsx
@@ -356,6 +356,7 @@ describe('LogsTable', () => {
       expect(onAddAdHocFilter).toHaveBeenCalledTimes(1);
       expect(onAddAdHocFilter).toHaveBeenCalledWith({
         key: 'level',
+        keyLabel: 'level',
         value: 'info',
         operator: '=',
       });
@@ -365,6 +366,7 @@ describe('LogsTable', () => {
       expect(onAddAdHocFilter).toHaveBeenCalledTimes(2);
       expect(onAddAdHocFilter).toHaveBeenCalledWith({
         key: 'level',
+        keyLabel: 'level',
         value: 'info',
         operator: '!=',
       });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

This PR combines the changes from the two previously-stale PRs #118135 (BarChart + variable layer + types) and #117641 (Table cell actions) into a single PR rebased onto current `main`. It allows panels to pass an optional human-readable **`keyLabel`** when adding ad hoc filters from panel interactions:

- Extends `AdHocFilterItem` (in `Table/types.ts` and `TableNG/types.ts`) with optional `keyLabel`.
- In `setDashboardPanelContext.ts`, adds `toAdHocFilterWithLabels()` so `updateAdHocFilterVariable()` and `bulkUpdateAdHocFiltersVariable()` persist `keyLabel` on the `AdHocFiltersVariable` state.
- BarChart tooltip "Filter for value" now passes `keyLabel`, derived via a new `getFieldKeyLabel(field)` util in `panel/barchart/utils.ts` that resolves to `field.config.displayNameFromDS ?? field.name`.
- Table cell "Filter for value" / "Filter out value" actions now pass `keyLabel`, derived from `field.config.displayNameFromDS ?? field.state?.displayName ?? field.name`.

Scope is intentionally **`keyLabel` only** — no `valueLabel` from panels.

**Why do we need this feature?**

Datasources that set `DisplayNameFromDS` on dimension fields (e.g. Salesforce, Cube) can now show friendly column/dimension names in ad hoc filter chips when users add filters via panel interactions, instead of only the technical field name.

**Who is this feature for?**

Users of datasources that provide human-readable field display names alongside technical names, who interact with ad hoc filters via the BarChart tooltip or the Table cell action menu.

**Which issue(s) does this PR fix?**

Ref: #117639

**Special notes for your reviewer:**

This is a **rebased combination** of two stale PRs that were auto-closed:

- #118135 — BarChart + variable layer + `AdHocFilterItem` types (8 commits)
- #117641 — Table cell actions + tests (3 commits, originally stacked on top of #118135)

The original PR descriptions mention an `adhocFilterLabelsFromPanels` feature toggle, but the final commit on #118135 (`d508cf4` "Ad hoc filter labels: scope to keyLabel only (no valueLabel)") removed the toggle and persists `keyLabel` unconditionally — a follow-up cleanup commit on #117641 (`4d44cf9`) confirms the same. This combined branch reflects that final state (no feature toggle).

**Outstanding reviewer feedback to address (not yet applied here, listed for visibility):**

From #118135 (`@gtk-grafana`):

- `public/app/plugins/panel/barchart/utils.test.ts`: questioned the test that asserts `config.displayName` is *not* used as the label ("This is the opposite of what I'd expect a UI display label test to assert").
- `public/app/plugins/panel/barchart/utils.ts`: suggested replacing `getFieldKeyLabel` with a `getDisplayName(field) => field.state?.displayName ?? field.name` helper to align with how other panels cache display names.

From #118135 (`@samjewell`):

- `public/app/plugins/panel/barchart/utils.ts`: noted that `getFieldKeyLabel` should probably not live in the BarChart folder since Table will reuse it; suggested moving it (and tests) when the Table follow-up lands.

From #117641 (`@gtk-grafana` and `@fastfrwrd`):

- `TableCellActions.tsx`: reviewers initially suggested `getFieldDisplayName(field)` from `@grafana/data`, but `@fastfrwrd` corrected that — inside TableNG we should use `getDisplayName` from `TableNG/utils` (not `getFieldDisplayName`) for performance reasons. There is now an ESLint rule (#117693) enforcing this.
- `TableCellActions.test.tsx`: requested adding a test case for a field with `displayName` set.

**Testing**

- ✅ `yarn jest --no-watch packages/grafana-ui/src/components/Table/TableNG/components/TableCellActions.test.tsx` (3 passed)
- ✅ `yarn jest --no-watch public/app/plugins/panel/barchart/utils.test.ts public/app/features/dashboard-scene/scene/setDashboardPanelContext.test.ts` (55 passed, 9 snapshots)
- ✅ `yarn typecheck` (14 projects)
- ✅ `yarn lint`

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle. *(N/A — final state of the source PRs intentionally removed the toggle.)*
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3cd1e9d3-b1a8-4a5c-909b-9ab7e3d32709"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3cd1e9d3-b1a8-4a5c-909b-9ab7e3d32709"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

