### PR TITLE
Plugins: update test snapshot for InfluxDB grafanaDependency

### DIFF
--- a/pkg/tests/api/plugins/data/expectedListResp.json
+++ b/pkg/tests/api/plugins/data/expectedListResp.json
@@ -1049,7 +1049,7 @@
       "keywords": null
     },
     "dependencies": {
-      "grafanaDependency": "",
+      "grafanaDependency": ">=12.3.0",
       "grafanaVersion": "*",
       "plugins": [],
       "extensions": {


### PR DESCRIPTION
## Summary

Fixes the failing `TestIntegrationPlugins/List/should_return_all_loaded_core_plugins` integration test in `pkg/tests/api/plugins`.

The InfluxDB `plugin.json` declares `"grafanaDependency": ">=12.3.0"`, but the test snapshot in `pkg/tests/api/plugins/data/expectedListResp.json` still expected an empty value, producing this diff:

```
Dependencies: plugins.Dependencies{
-     GrafanaDependency: "",
+     GrafanaDependency: ">=12.3.0",
      GrafanaVersion:    "*",
      ...
}
```

## Changes

- Update the InfluxDB entry in `expectedListResp.json` so `grafanaDependency` matches the value declared in `public/app/plugins/datasource/influxdb/plugin.json`.

## Testing

- Targeted integration test:
  ```
  go test -run TestIntegrationPlugins ./pkg/tests/api/plugins/
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)