### PR TITLE
Dynamic dashboards: Reinstrument outline button

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.test.tsx
@@ -1,5 +1,6 @@
 import { act, screen } from '@testing-library/react';
 import { render } from 'test/test-utils';
+import userEvent from '@testing-library/user-event';
 
 import { getPanelPlugin } from '@grafana/data/test';
 import { selectors } from '@grafana/e2e-selectors';
@@ -13,6 +14,8 @@ import { DefaultGridLayoutManager } from '../scene/layout-default/DefaultGridLay
 import { activateFullSceneTree } from '../utils/test-utils';
 
 import { DashboardEditPaneSplitter } from './DashboardEditPaneSplitter';
+import { DashboardEditPaneRenderer } from './DashboardEditPaneRenderer';
+import { DashboardInteractions } from '../utils/interactions';
 
 setPluginImportUtils({
   importPanelPlugin: (id: string) => Promise.resolve(getPanelPlugin({})),
@@ -110,14 +113,17 @@ describe('DashboardEditPaneRenderer', () => {
     expect(scene.state.editPane.state.isDocked).toBe(false);
   });
 
-  // describe('outline interactions tracking', () => {
-  //   it('should call DashboardInteractions.outlineClicked when clicking on dashboard outline', async () => {
-  //     const user = userEvent.setup();
-  //     const scene = buildTestScene();
-  //     render(<DashboardEditPaneRenderer editPane={scene.state.editPane} dashboard={scene} />);
-  //     const outlineButton = screen.getByTestId(selectors.components.PanelEditor.Outline.section);
-  //     await user.click(outlineButton);
-  //     expect(DashboardInteractions.dashboardOutlineClicked).toHaveBeenCalled();
-  //   });
-  // });
+  describe('outline interactions tracking', () => {
+    it('should call DashboardInteractions.outlineClicked when clicking on dashboard outline', async () => {
+      const user = userEvent.setup();
+      const scene = buildTestScene();
+
+      act(() => activateFullSceneTree(scene));
+
+      render(<DashboardEditPaneSplitter dashboard={scene} isEditing />);
+      const outlineButton = screen.getByTestId(selectors.pages.Dashboard.Sidebar.outlineButton);
+      await user.click(outlineButton);
+      expect(DashboardInteractions.dashboardOutlineClicked).toHaveBeenCalled();
+    });
+  });
 });

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.test.tsx
@@ -1,6 +1,6 @@
 import { act, screen } from '@testing-library/react';
-import { render } from 'test/test-utils';
 import userEvent from '@testing-library/user-event';
+import { render } from 'test/test-utils';
 
 import { getPanelPlugin } from '@grafana/data/test';
 import { selectors } from '@grafana/e2e-selectors';
@@ -11,11 +11,10 @@ import { DashboardDataLayerSet } from '../scene/DashboardDataLayerSet';
 import { DashboardScene } from '../scene/DashboardScene';
 import { DashboardGridItem } from '../scene/layout-default/DashboardGridItem';
 import { DefaultGridLayoutManager } from '../scene/layout-default/DefaultGridLayoutManager';
+import { DashboardInteractions } from '../utils/interactions';
 import { activateFullSceneTree } from '../utils/test-utils';
 
 import { DashboardEditPaneSplitter } from './DashboardEditPaneSplitter';
-import { DashboardEditPaneRenderer } from './DashboardEditPaneRenderer';
-import { DashboardInteractions } from '../utils/interactions';
 
 setPluginImportUtils({
   importPanelPlugin: (id: string) => Promise.resolve(getPanelPlugin({})),

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.tsx
@@ -15,6 +15,7 @@ import { onOpenSnapshotOriginalDashboard } from '../scene/GoToSnapshotOriginButt
 import { ManagedDashboardNavBarBadge } from '../scene/ManagedDashboardNavBarBadge';
 import { DashboardFiltersOverviewPane } from '../scene/dashboard-filters-overview/DashboardFiltersOverviewPane';
 import { type ToolbarActionProps } from '../scene/new-toolbar/types';
+import { DashboardInteractions } from '../utils/interactions';
 import { dynamicDashNavActions } from '../utils/registerDynamicDashNavAction';
 
 import { DashboardCodePane } from './DashboardCodePane';
@@ -23,7 +24,6 @@ import { ShareExportDashboardButton } from './DashboardExportButton';
 import { DashboardOutline } from './DashboardOutline';
 import { AddNewEditPane } from './add-new/AddNewEditPane';
 import { type DashboardSidebarPane } from './types';
-import { DashboardInteractions } from '../utils/interactions';
 
 export interface Props {
   editPane: DashboardEditPane;

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.tsx
@@ -23,6 +23,7 @@ import { ShareExportDashboardButton } from './DashboardExportButton';
 import { DashboardOutline } from './DashboardOutline';
 import { AddNewEditPane } from './add-new/AddNewEditPane';
 import { type DashboardSidebarPane } from './types';
+import { DashboardInteractions } from '../utils/interactions';
 
 export interface Props {
   editPane: DashboardEditPane;
@@ -126,7 +127,10 @@ export function DashboardEditPaneRenderer({ editPane, dashboard }: Props) {
           {hasUid && !isEmbedded && <ShareExportDashboardButton dashboard={dashboard} />}
           <Sidebar.Button
             icon="list-ui-alt"
-            onClick={() => editPane.openPane(new DashboardOutline({}))}
+            onClick={() => {
+              DashboardInteractions.dashboardOutlineClicked();
+              editPane.openPane(new DashboardOutline({}));
+            }}
             title={t('dashboard.sidebar.outline.title', 'Outline')}
             tooltip={t('dashboard.sidebar.outline.tooltip', 'Content outline')}
             data-testid={selectors.pages.Dashboard.Sidebar.outlineButton}


### PR DESCRIPTION
Looks like this was removed in https://github.com/grafana/grafana/pull/114245/changes#top for some reason, we need this instrumentation to track user activity in mobile