### PR TITLE
Add snapshot upload policy tracking

### DIFF
--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -306,11 +306,13 @@ func (b *bleveBackend) runEvictExpiredOrUnownedIndexes(now time.Time) {
 	}
 
 	for key, idx := range unowned {
+		b.clearUploadTracking(key)
 		b.log.Info("index evicted from cache", "reason", "unowned", "key", key, "storage", idx.indexStorage)
 		b.closeIndex(idx, key)
 	}
 
 	for key, idx := range expired {
+		b.clearUploadTracking(key)
 		b.log.Info("index evicted from cache", "reason", "expired", "key", key, "storage", idx.indexStorage)
 		b.closeIndex(idx, key)
 	}
@@ -357,6 +359,12 @@ func (b *bleveBackend) getUploadTracking(key resource.NamespacedResource) (time.
 		return time.Time{}, false
 	}
 	return t, true
+}
+
+func (b *bleveBackend) clearUploadTracking(key resource.NamespacedResource) {
+	b.uploadTrackingMu.Lock()
+	defer b.uploadTrackingMu.Unlock()
+	delete(b.lastUploadTime, key)
 }
 
 // updateIndexSizeMetric sets the total size of all file-based indices metric.
@@ -815,6 +823,7 @@ func (b *bleveBackend) closeAllIndexes() {
 	defer b.cacheMx.Unlock()
 
 	for key, idx := range b.cache {
+		b.clearUploadTracking(key)
 		if err := idx.stopUpdaterAndCloseIndex(); err != nil {
 			b.log.Error("Failed to close index", "err", err)
 		}

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -50,8 +50,9 @@ const (
 
 // Keys used to store internal data in index.
 const (
-	internalRVKey        = "rv"         // Encoded as big-endian int64
-	internalBuildInfoKey = "build_info" // Encoded as JSON of buildInfo struct
+	internalRVKey                    = "rv"                      // Encoded as big-endian int64
+	internalBuildInfoKey             = "build_info"              // Encoded as JSON of buildInfo struct
+	internalSnapshotMutationCountKey = "snapshot_mutation_count" // Encoded as big-endian int64
 )
 
 var tracer = otel.Tracer("github.com/grafana/grafana/pkg/storage/unified/search")
@@ -91,13 +92,14 @@ type BleveOptions struct {
 	Snapshot SnapshotOptions
 }
 
-// SnapshotOptions configures remote index snapshot handling in BuildIndex.
+// SnapshotOptions configures remote index snapshot handling in BuildIndex and
+// background upload scheduling.
 type SnapshotOptions struct {
 	// Store is the remote index store. When nil, the snapshot feature is disabled
-	// and no remote download is attempted.
+	// and no remote download/upload is attempted.
 	Store RemoteIndexStore
 
-	// MinDocCount is the minimum document count at which a remote snapshot download is attempted.
+	// MinDocCount is the minimum document count at which a remote snapshot download/upload is attempted.
 	// Must be >= FileThreshold to be meaningful; smaller resources are built in-process.
 	MinDocCount int64
 
@@ -109,6 +111,14 @@ type SnapshotOptions struct {
 	// build version of a remote snapshot. Snapshots with a lower version are
 	// considered only if no snapshot at or above this version is available.
 	MinBuildVersion *semver.Version
+
+	// UploadInterval is the minimum time between consecutive successful uploads
+	// for the same resource.
+	UploadInterval time.Duration
+
+	// MinDocChanges is the minimum resource version delta required before a new
+	// upload is attempted after a previous successful upload.
+	MinDocChanges int
 }
 
 type bleveBackend struct {
@@ -130,6 +140,9 @@ type bleveBackend struct {
 
 	bgTasksCancel func()
 	bgTasksWg     sync.WaitGroup
+
+	uploadTrackingMu sync.Mutex
+	lastUploadTime   map[resource.NamespacedResource]time.Time
 }
 
 func NewBleveBackend(opts BleveOptions, indexMetrics *resource.BleveIndexMetrics) (*bleveBackend, error) {
@@ -179,6 +192,7 @@ func NewBleveBackend(opts BleveOptions, indexMetrics *resource.BleveIndexMetrics
 		indexMetrics:        indexMetrics,
 		selectableFields:    opts.SelectableFieldsForKinds,
 		runningBuildVersion: runningBuildVersion,
+		lastUploadTime:      map[resource.NamespacedResource]time.Time{},
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -300,6 +314,49 @@ func (b *bleveBackend) runEvictExpiredOrUnownedIndexes(now time.Time) {
 		b.log.Info("index evicted from cache", "reason", "expired", "key", key, "storage", idx.indexStorage)
 		b.closeIndex(idx, key)
 	}
+}
+
+func (b *bleveBackend) shouldUpload(key resource.NamespacedResource, idx *bleveIndex, now time.Time) (bool, error) {
+	docCount, err := idx.index.DocCount()
+	if err != nil {
+		return false, fmt.Errorf("reading document count for %v: %w", key, err)
+	}
+	if int64(docCount) < b.opts.Snapshot.MinDocCount {
+		return false, nil
+	}
+
+	lastUploadTime, ok := b.getUploadTracking(key)
+	if !ok {
+		return true, nil
+	}
+	if b.opts.Snapshot.UploadInterval > 0 && now.Sub(lastUploadTime) < b.opts.Snapshot.UploadInterval {
+		return false, nil
+	}
+
+	mutationCount, err := getSnapshotMutationCount(idx.index)
+	if err != nil {
+		return false, fmt.Errorf("reading snapshot mutation count for %v: %w", key, err)
+	}
+	if mutationCount < int64(b.opts.Snapshot.MinDocChanges) {
+		return false, nil
+	}
+	return true, nil
+}
+
+func (b *bleveBackend) setUploadTracking(key resource.NamespacedResource, uploadedAt time.Time) {
+	b.uploadTrackingMu.Lock()
+	defer b.uploadTrackingMu.Unlock()
+	b.lastUploadTime[key] = uploadedAt
+}
+
+func (b *bleveBackend) getUploadTracking(key resource.NamespacedResource) (time.Time, bool) {
+	b.uploadTrackingMu.Lock()
+	defer b.uploadTrackingMu.Unlock()
+	t, ok := b.lastUploadTime[key]
+	if !ok {
+		return time.Time{}, false
+	}
+	return t, true
 }
 
 // updateIndexSizeMetric sets the total size of all file-based indices metric.
@@ -819,6 +876,10 @@ type bleveIndex struct {
 
 	// Used to detect if the index can be safely closed, if it no longer belongs to this instance. UnixMilli.
 	lastFetchedFromCache atomic.Int64
+
+	// Guards read-modify-write updates of the persisted snapshot mutation count
+	// stored in Bleve internal data, so concurrent BulkIndex calls don't lose increments.
+	snapshotMutationMu sync.Mutex
 }
 
 func (b *bleveBackend) newBleveIndex(
@@ -875,7 +936,10 @@ func (b *bleveIndex) BulkIndex(req *resource.BulkIndexRequest) error {
 		}
 	}
 
-	return b.index.Batch(batch)
+	if err := b.index.Batch(batch); err != nil {
+		return err
+	}
+	return b.addSnapshotMutationCount(int64(len(req.Items)))
 }
 
 func (b *bleveIndex) updateResourceVersion(rv int64) error {
@@ -897,6 +961,34 @@ func setRV(index bleve.Index, rv int64) error {
 	binary.BigEndian.PutUint64(buf, uint64(rv))
 
 	return index.SetInternal([]byte(internalRVKey), buf)
+}
+
+func setSnapshotMutationCount(index bleve.Index, count int64) error {
+	buf := make([]byte, 8)
+	binary.BigEndian.PutUint64(buf, uint64(count))
+	return index.SetInternal([]byte(internalSnapshotMutationCountKey), buf)
+}
+
+func getSnapshotMutationCount(index bleve.Index) (int64, error) {
+	raw, err := index.GetInternal([]byte(internalSnapshotMutationCountKey))
+	if err != nil {
+		return 0, err
+	}
+	if len(raw) < 8 {
+		return 0, nil
+	}
+	return int64(binary.BigEndian.Uint64(raw)), nil
+}
+
+func (b *bleveIndex) addSnapshotMutationCount(delta int64) error {
+	b.snapshotMutationMu.Lock()
+	defer b.snapshotMutationMu.Unlock()
+
+	current, err := getSnapshotMutationCount(b.index)
+	if err != nil {
+		return err
+	}
+	return setSnapshotMutationCount(b.index, current+delta)
 }
 
 // getRV will call index.GetInternal to retrieve the RV saved in the index. If index is closed, it will return a

--- a/pkg/storage/unified/search/bleve_snapshot.go
+++ b/pkg/storage/unified/search/bleve_snapshot.go
@@ -82,7 +82,8 @@ func (b *bleveBackend) tryDownloadRemoteSnapshot(
 	}
 
 	start := time.Now()
-	if _, err := store.DownloadIndex(ctx, key, candidate.key, destDir); err != nil {
+	downloadedMeta, err := store.DownloadIndex(ctx, key, candidate.key, destDir)
+	if err != nil {
 		_ = os.RemoveAll(destDir)
 		b.recordSnapshotDownloadStatus(snapshotStatusDownloadError)
 		return nil, "", 0, fmt.Errorf("downloading snapshot: %w", err)
@@ -108,6 +109,19 @@ func (b *bleveBackend) tryDownloadRemoteSnapshot(
 	if b.indexMetrics != nil {
 		b.indexMetrics.IndexSnapshotDownloadDuration.Observe(elapsed.Seconds())
 	}
+
+	uploadedAt := candidate.meta.UploadTimestamp
+	if downloadedMeta != nil && !downloadedMeta.UploadTimestamp.IsZero() {
+		uploadedAt = downloadedMeta.UploadTimestamp
+	}
+	// A downloaded snapshot becomes the new upload baseline for this index.
+	if err := setSnapshotMutationCount(idx, 0); err != nil {
+		_ = idx.Close()
+		_ = os.RemoveAll(destDir)
+		b.recordSnapshotDownloadStatus(snapshotStatusValidateError)
+		return nil, "", 0, fmt.Errorf("resetting snapshot mutation count: %w", err)
+	}
+	b.setUploadTracking(key, uploadedAt)
 
 	logger.Info("Downloaded remote index snapshot", "elapsed", elapsed, "rv", rv, "directory", destDir)
 	return idx, name, rv, nil

--- a/pkg/storage/unified/search/bleve_snapshot_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_test.go
@@ -513,6 +513,33 @@ func TestBulkIndexTracksSnapshotMutations(t *testing.T) {
 	assert.Equal(t, int64(2), count)
 }
 
+func TestEvictExpiredIndexClearsUploadTracking(t *testing.T) {
+	be, _ := newTestBleveBackend(t, SnapshotOptions{})
+	key := newTestNsResource()
+	resourceDir := be.getResourceDir(key)
+	require.NoError(t, os.MkdirAll(resourceDir, 0o750))
+
+	index, err := newBleveIndex(filepath.Join(resourceDir, formatIndexName(time.Now())), bleve.NewIndexMapping(), time.Now(), be.opts.BuildVersion, nil)
+	require.NoError(t, err)
+	require.NoError(t, index.Index("dash-1", map[string]string{"title": "Production Overview"}))
+	require.NoError(t, setRV(index, 42))
+
+	idx := be.newBleveIndex(key, index, indexStorageFile, nil, nil, nil, nil, be.log)
+	idx.resourceVersion.Store(42)
+	idx.expiration = time.Now().Add(-time.Minute)
+
+	be.cacheMx.Lock()
+	be.cache[key] = idx
+	be.cacheMx.Unlock()
+	be.setUploadTracking(key, time.Now())
+
+	be.runEvictExpiredOrUnownedIndexes(time.Now())
+
+	assert.Nil(t, be.getCachedIndex(key, time.Now()))
+	_, ok := be.getUploadTracking(key)
+	assert.False(t, ok)
+}
+
 func TestIntegrationBleveSnapshotRoundTrip(t *testing.T) {
 	ctx := identity.WithRequester(context.Background(), &user.SignedInUser{Namespace: "ns"})
 	bucket := memblob.OpenBucket(nil)

--- a/pkg/storage/unified/search/bleve_snapshot_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
 
 // fakeRemoteIndexStore is an in-memory RemoteIndexStore for unit tests.
@@ -417,6 +418,101 @@ func TestBuildIndex_SkipsDownloadBelowMinDocCount(t *testing.T) {
 // snapshot via store.UploadIndex, then verifies BuildIndex downloads it
 // instead of calling the builder. The round-trip of a real built index
 // through the store is covered separately in TestRemoteIndexStore_*.
+func TestShouldUpload(t *testing.T) {
+	key := newTestNsResource()
+
+	t.Run("uploads when no prior upload is tracked", func(t *testing.T) {
+		be, _ := newTestBleveBackend(t, SnapshotOptions{MinDocCount: 1, UploadInterval: time.Hour, MinDocChanges: 1000})
+		idx := newUploadTestIndex(t, be, key, 42)
+
+		should, err := be.shouldUpload(key, idx, time.Now())
+		require.NoError(t, err)
+		assert.True(t, should)
+	})
+
+	t.Run("skips below min doc count", func(t *testing.T) {
+		be, _ := newTestBleveBackend(t, SnapshotOptions{MinDocCount: 2, UploadInterval: time.Hour, MinDocChanges: 1000})
+		idx := newUploadTestIndex(t, be, key, 42)
+
+		should, err := be.shouldUpload(key, idx, time.Now())
+		require.NoError(t, err)
+		assert.False(t, should)
+	})
+
+	t.Run("skips when upload interval has not elapsed", func(t *testing.T) {
+		be, _ := newTestBleveBackend(t, SnapshotOptions{MinDocCount: 1, UploadInterval: time.Hour, MinDocChanges: 1})
+		idx := newUploadTestIndex(t, be, key, 42)
+		require.NoError(t, setSnapshotMutationCount(idx.index, 5))
+		be.setUploadTracking(key, time.Now().Add(-30*time.Minute))
+
+		should, err := be.shouldUpload(key, idx, time.Now())
+		require.NoError(t, err)
+		assert.False(t, should)
+	})
+
+	t.Run("skips when mutation count is below threshold", func(t *testing.T) {
+		be, _ := newTestBleveBackend(t, SnapshotOptions{MinDocCount: 1, UploadInterval: time.Minute, MinDocChanges: 100})
+		idx := newUploadTestIndex(t, be, key, 150)
+		require.NoError(t, setSnapshotMutationCount(idx.index, 50))
+		be.setUploadTracking(key, time.Now().Add(-2*time.Minute))
+
+		should, err := be.shouldUpload(key, idx, time.Now())
+		require.NoError(t, err)
+		assert.False(t, should)
+	})
+
+	t.Run("uploads when interval elapsed and mutation count is large enough", func(t *testing.T) {
+		be, _ := newTestBleveBackend(t, SnapshotOptions{MinDocCount: 1, UploadInterval: time.Minute, MinDocChanges: 25})
+		idx := newUploadTestIndex(t, be, key, 150)
+		require.NoError(t, setSnapshotMutationCount(idx.index, 30))
+		be.setUploadTracking(key, time.Now().Add(-2*time.Minute))
+
+		should, err := be.shouldUpload(key, idx, time.Now())
+		require.NoError(t, err)
+		assert.True(t, should)
+	})
+}
+
+func TestBulkIndexTracksSnapshotMutations(t *testing.T) {
+	be, _ := newTestBleveBackend(t, SnapshotOptions{})
+	key := newTestNsResource()
+	idx := newUploadTestIndex(t, be, key, 42)
+
+	count, err := getSnapshotMutationCount(idx.index)
+	require.NoError(t, err)
+	assert.Equal(t, int64(0), count)
+
+	err = idx.BulkIndex(&resource.BulkIndexRequest{Items: []*resource.BulkIndexItem{
+		{
+			Action: resource.ActionIndex,
+			Doc: &resource.IndexableDocument{
+				Name:  "dash-2",
+				Title: "dash-2",
+				Key: &resourcepb.ResourceKey{
+					Name:      "dash-2",
+					Namespace: key.Namespace,
+					Group:     key.Group,
+					Resource:  key.Resource,
+				},
+			},
+		},
+		{
+			Action: resource.ActionDelete,
+			Key: &resourcepb.ResourceKey{
+				Name:      "dash-1",
+				Namespace: key.Namespace,
+				Group:     key.Group,
+				Resource:  key.Resource,
+			},
+		},
+	}})
+	require.NoError(t, err)
+
+	count, err = getSnapshotMutationCount(idx.index)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), count)
+}
+
 func TestIntegrationBleveSnapshotRoundTrip(t *testing.T) {
 	ctx := identity.WithRequester(context.Background(), &user.SignedInUser{Namespace: "ns"})
 	bucket := memblob.OpenBucket(nil)
@@ -465,4 +561,12 @@ func TestIntegrationBleveSnapshotRoundTrip(t *testing.T) {
 	bi, ok := idx.(*bleveIndex)
 	require.True(t, ok)
 	assert.Equal(t, meta.LatestResourceVersion, bi.resourceVersion.Load())
+
+	trackedAt, tracked := be.getUploadTracking(key)
+	require.True(t, tracked)
+	assert.WithinDuration(t, meta.UploadTimestamp, trackedAt, time.Second)
+
+	mutationCount, err := getSnapshotMutationCount(bi.index)
+	require.NoError(t, err)
+	assert.Zero(t, mutationCount)
 }

--- a/pkg/storage/unified/search/options.go
+++ b/pkg/storage/unified/search/options.go
@@ -177,5 +177,7 @@ func buildSnapshotOptions(cfg *setting.Cfg, minBuildVersion *semver.Version) (Sn
 		MinDocCount:     int64(cfg.IndexSnapshotThreshold),
 		MaxIndexAge:     cfg.IndexSnapshotMaxAge,
 		MinBuildVersion: minBuildVersion,
+		UploadInterval:  DefaultSnapshotUploadInterval,
+		MinDocChanges:   DefaultSnapshotMinDocChanges,
 	}, nil
 }

--- a/pkg/storage/unified/search/remote_index_store.go
+++ b/pkg/storage/unified/search/remote_index_store.go
@@ -79,10 +79,10 @@ type RemoteIndexStore interface {
 //
 // Object storage layout:
 //
-//	/<namespace>/<group>.<resource>/<index-key>/index_meta.json
-//	/<namespace>/<group>.<resource>/<index-key>/store/root.bolt
-//	/<namespace>/<group>.<resource>/<index-key>/store/*.zap
-//	/<namespace>/<group>.<resource>/<index-key>/meta.json  <- uploaded last, signals complete upload
+//	/<namespace>/<resource>.<group>/<index-key>/index_meta.json
+//	/<namespace>/<resource>.<group>/<index-key>/store/root.bolt
+//	/<namespace>/<resource>.<group>/<index-key>/store/*.zap
+//	/<namespace>/<resource>.<group>/<index-key>/meta.json  <- uploaded last, signals complete upload
 //
 // meta.json is uploaded last during upload and deleted first during delete,
 // serving as the completion signal.


### PR DESCRIPTION
This adds the policy groundwork for periodic snapshot uploads.

It threads upload interval and minimum change settings through snapshot options, tracks upload timing in the backend, and stores per-index snapshot mutation counts in Bleve internal data.

A downloaded snapshot now becomes the new upload baseline by resetting the mutation counter and initializing upload tracking time.
