### PR TITLE
Scopes: Fix defaultPath race condition

### DIFF
--- a/devenv/scopes/scopes-config.yaml
+++ b/devenv/scopes/scopes-config.yaml
@@ -48,6 +48,22 @@ scopes:
         operator: equals
         value: kids
 
+  # A scope with a 4-level defaultPath for testing deep path resolution.
+  # Tests that resolvePathToRoot uses the live state tree (not a stale snapshot)
+  # when merging path nodes after async API calls.
+  deep-service:
+    title: Deep Service
+    # Path: gdev-scopes > production > eu-west > deep-service-prod  (4 levels)
+    defaultPath:
+      - gdev-scopes
+      - gdev-scopes-production
+      - gdev-scopes-production-eu-west
+      - gdev-scopes-production-eu-west-deep-service-prod
+    filters:
+      - key: service
+        operator: equals
+        value: deep
+
   # This scope appears in multiple places in the tree.
   # The defaultPath determines which path is shown when this scope is selected
   # (e.g., from a URL or programmatically), even if another path also links to it.
@@ -85,6 +101,16 @@ tree:
             nodeType: leaf
             linkId: app2
             linkType: scope
+          eu-west:
+            title: EU West
+            nodeType: container
+            disableMultiSelect: true
+            children:
+              deep-service-prod:
+                title: Deep Service
+                nodeType: leaf
+                linkId: deep-service
+                linkType: scope
           # This node links to 'shared-service' scope.
           # The scope's defaultPath points here (production > gdev-scopes).
           shared-service-prod:

--- a/public/app/features/scopes/ScopesService.test.ts
+++ b/public/app/features/scopes/ScopesService.test.ts
@@ -283,6 +283,47 @@ describe('ScopesService', () => {
       );
     });
 
+    it('should correctly call resolvePathToRoot for a deeply nested defaultPath without scope_node', async () => {
+      let changeScopesResolve: () => void;
+      const changeScopesPromise = new Promise<void>((resolve) => {
+        changeScopesResolve = resolve;
+      });
+
+      selectorService.changeScopes = jest.fn().mockImplementation(() => {
+        selectorService.state.appliedScopes = [{ scopeId: 'deep-scope' }];
+        selectorService.state.scopes = {
+          'deep-scope': {
+            metadata: { name: 'deep-scope' },
+            spec: {
+              title: 'Deep Scope',
+              defaultPath: ['', 'l1', 'l1-l2', 'l1-l2-l3', 'l1-l2-l3-leaf'],
+              filters: [],
+            },
+          },
+        };
+        changeScopesResolve();
+        return changeScopesPromise;
+      });
+
+      locationService.getLocation = jest.fn().mockReturnValue({
+        pathname: '/test',
+        search: '?scopes=deep-scope',
+      });
+
+      service = new ScopesService(selectorService, dashboardsService, locationService);
+
+      await changeScopesPromise;
+
+      // Should use last element of the 4-level defaultPath
+      expect(selectorService.resolvePathToRoot).toHaveBeenCalledWith('l1-l2-l3-leaf', expect.anything(), 'deep-scope');
+
+      // scope_node should NOT be written to URL — it is re-derived from defaultPath on load
+      expect(locationService.partial).not.toHaveBeenCalledWith(
+        expect.objectContaining({ scope_node: expect.any(String) }),
+        expect.anything()
+      );
+    });
+
     it('should not call resolvePathToRoot when scope_node is absent and no defaultPath exists', async () => {
       let changeScopesResolve: () => void;
       const changeScopesPromise = new Promise<void>((resolve) => {

--- a/public/app/features/scopes/selector/ScopesSelectorService.test.ts
+++ b/public/app/features/scopes/selector/ScopesSelectorService.test.ts
@@ -1581,6 +1581,39 @@ describe('ScopesSelectorService', () => {
         result.tree.children?.['region-us-west']?.children?.['country-usa']?.children?.['city-seattle']
       ).toBeDefined();
     });
+
+    it('should not overwrite concurrent tree updates made while awaiting the API', async () => {
+      (service as any).updateState({
+        scopes: { 'scope-sea-1': scopeWithDefaultPath },
+      });
+
+      // Hold the API response so we can inject a concurrent tree update in the gap
+      let resolveApiCall!: (nodes: ScopeNode[]) => void;
+      apiClient.fetchMultipleScopeNodes = jest
+        .fn()
+        .mockImplementation(() => new Promise<ScopeNode[]>((resolve) => (resolveApiCall = resolve)));
+
+      // The tree snapshot passed to resolvePathToRoot (stale by the time await resumes)
+      const staleSnapshot = { expanded: false, scopeNodeId: '', query: '', children: {} };
+      const resultPromise = service.resolvePathToRoot('datacenter-sea-1', staleSnapshot, 'scope-sea-1');
+
+      // Simulate a concurrent caller (e.g. open() → filterNode) writing a sibling node
+      // into this.state.tree while resolvePathToRoot is suspended at its internal await.
+      const concurrentNode = { expanded: false, scopeNodeId: 'region-eu-west', query: '', children: {} };
+      (service as any).updateState({
+        tree: { ...service.state.tree, children: { 'region-eu-west': concurrentNode } },
+      });
+
+      // Unblock the API — resolvePathToRoot resumes and must merge into this.state.tree,
+      // not the stale staleSnapshot which predates the concurrent update above.
+      resolveApiCall([regionNode, countryNode, cityNode, datacenterNode]);
+      const result = await resultPromise;
+
+      // The concurrent sibling must survive the merge
+      expect(result.tree.children?.['region-eu-west']).toBeDefined();
+      // The resolved path nodes must also be present
+      expect(result.tree.children?.['region-us-west']).toBeDefined();
+    });
   });
 
   describe('applyScopes with defaultPath pre-fetching', () => {

--- a/public/app/features/scopes/selector/ScopesSelectorService.ts
+++ b/public/app/features/scopes/selector/ScopesSelectorService.ts
@@ -184,7 +184,11 @@ export class ScopesSelectorService extends ScopesServiceBase<ScopesSelectorServi
       nodePath = await this.getNodePath(scopeNodeId);
     }
 
-    const newTree = insertPathNodesIntoTree(tree, nodePath);
+    // Use this.state.tree instead of the tree parameter: after the awaits above,
+    // concurrent calls (e.g. open() → filterNode) may have modified state. Reading
+    // this.state.tree here ensures we merge into the latest version rather than
+    // overwriting it with a stale snapshot captured at call time.
+    const newTree = insertPathNodesIntoTree(this.state.tree, nodePath);
 
     this.updateState({ tree: newTree });
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

When removing the scope_node URL sync for defaultPath, a race condition was exposed

**Why do we need this feature?**

The open state will sync with an outdated version of the tree

**Who is this feature for?**

Scopes users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related to https://github.com/grafana/hyperion-planning/issues/609

**Special notes for your reviewer:**

1. Setup devenv scopes
2. Select a scope
3. Reload
4. Verify that you are expanded in the correct place

For defaultPath, do this but try selecting `gdev-scopes -> Production -> EU West -> Deep Service`.


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
