### PR TITLE
Backend: Modify getProxyPath to normalize paths

### DIFF
--- a/pkg/api/plugin_proxy.go
+++ b/pkg/api/plugin_proxy.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 	"net"
 	"net/http"
+	"path"
 	"regexp"
 	"sync"
 	"time"

--- a/pkg/api/plugin_proxy.go
+++ b/pkg/api/plugin_proxy.go
@@ -67,5 +67,5 @@ func extractProxyPath(originalRawPath string) string {
 }
 
 func getProxyPath(c *contextmodel.ReqContext) string {
-	return extractProxyPath(c.Req.URL.EscapedPath())
+	return path.Join("/", extractProxyPath(c.Req.URL.EscapedPath()))
 }

--- a/pkg/api/plugin_proxy_test.go
+++ b/pkg/api/plugin_proxy_test.go
@@ -1,8 +1,11 @@
 package api
 
 import (
+	"net/http"
+	"net/url"
 	"testing"
 
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -35,6 +38,42 @@ func TestExtractPluginProxyPath(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run("Given raw path, should extract expected proxy path", func(t *testing.T) {
 			assert.Equal(t, tc.exp, extractProxyPath(tc.originalRawPath))
+		})
+	}
+}
+
+func TestGetProxyPath(t *testing.T) {
+	testCases := []struct {
+		rawPath string
+		exp     string
+	}{
+		{
+			"/api/plugin-proxy/test",
+			"/",
+		},
+		{
+			"/api/plugin-proxy/test/some/thing",
+			"/some/thing",
+		},
+		{
+			"/api/plugin-proxy/test2/api/services/afsd%2Fafsd/operations",
+			"/api/services/afsd%2Fafsd/operations",
+		},
+		{
+			"/api/plugin-proxy/cloudflare-app/with-token/api/v4/accounts",
+			"/with-token/api/v4/accounts",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run("Given raw path, getProxyPath should normalize with leading slash", func(t *testing.T) {
+			c := &contextmodel.ReqContext{
+				Context: &contextmodel.Context{
+					Req: &http.Request{
+						URL: &url.URL{RawPath: tc.rawPath},
+					},
+				},
+			}
+			assert.Equal(t, tc.exp, getProxyPath(c))
 		})
 	}
 }


### PR DESCRIPTION
This PR normlizes paths in the plugin-proxy to not cause confusion for certain plugin names.
