### PR TITLE
Provisioning: add public_root_url instance setting for external URLs

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2421,6 +2421,13 @@ folders_api_version = v1
 # Default is 100. If set to 0, the size check is disabled.
 max_incremental_changes = 100
 
+# Public-facing URL of this Grafana instance, used by provisioning to construct URLs that
+# must be reachable from external systems (e.g. GitHub PR-comment image fetchers and
+# GitHub webhook deliveries). When empty, falls back to [server] root_url. Set this when
+# root_url points at an internal/cluster URL but provisioning needs an externally-reachable
+# host. Analogous to [rendering] callback_url for the image renderer plugin.
+public_app_url =
+
 #################################### Unified Storage ####################################
 [unified_storage]
 # index_path is the path where unified storage can store its index files for search.

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2421,12 +2421,12 @@ folders_api_version = v1
 # Default is 100. If set to 0, the size check is disabled.
 max_incremental_changes = 100
 
-# Public-facing URL of this Grafana instance, used by provisioning to construct URLs that
-# must be reachable from external systems (e.g. GitHub PR-comment image fetchers and
+# Public-facing root URL of this Grafana instance, used by provisioning to construct URLs
+# that must be reachable from external systems (e.g. GitHub PR-comment image fetchers and
 # GitHub webhook deliveries). When empty, falls back to [server] root_url. Set this when
 # root_url points at an internal/cluster URL but provisioning needs an externally-reachable
 # host. Analogous to [rendering] callback_url for the image renderer plugin.
-public_app_url =
+public_root_url =
 
 #################################### Unified Storage ####################################
 [unified_storage]

--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-extend.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-extend.md
@@ -60,6 +60,22 @@ root_url = https://<PUBLIC_DOMAIN>
 
 To check the configured webhooks, go to **Administration > General > Provisioning** and click the **View** link for your GitHub repository.
 
+{{< admonition type="note" >}}
+
+If your `[server] root_url` must point at an internal address (for example, when Grafana runs behind a private ingress in a Kubernetes cluster), set the publicly-reachable URL with `[provisioning] public_app_url` instead. This URL is used both to register webhook callbacks with the Git provider and as the base for screenshot images embedded in pull-request comments, which the Git provider's servers fetch from the public internet.
+
+```ini
+[server]
+root_url = http://internal.cluster.local
+
+[provisioning]
+public_app_url = https://<PUBLIC_DOMAIN>
+```
+
+The per-repository `spec.webhook.baseUrl` field still overrides `public_app_url` for webhook registration; screenshot URLs always use `public_app_url` (or `root_url` when unset).
+
+{{< /admonition >}}
+
 ### Expose necessary paths only
 
 If your security setup doesn't permit publicly exposing the Grafana instance, you can either choose to allowlist the GitHub IP addresses, or expose only the necessary paths.

--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-extend.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-extend.md
@@ -62,17 +62,17 @@ To check the configured webhooks, go to **Administration > General > Provisionin
 
 {{< admonition type="note" >}}
 
-If your `[server] root_url` must point at an internal address (for example, when Grafana runs behind a private ingress in a Kubernetes cluster), set the publicly-reachable URL with `[provisioning] public_app_url` instead. This URL is used both to register webhook callbacks with the Git provider and as the base for screenshot images embedded in pull-request comments, which the Git provider's servers fetch from the public internet.
+If your `[server] root_url` must point at an internal address (for example, when Grafana runs behind a private ingress in a Kubernetes cluster), set the publicly-reachable URL with `[provisioning] public_root_url` instead. This URL is used both to register webhook callbacks with the Git provider and as the base for screenshot images embedded in pull-request comments, which the Git provider's servers fetch from the public internet.
 
 ```ini
 [server]
 root_url = http://internal.cluster.local
 
 [provisioning]
-public_app_url = https://<PUBLIC_DOMAIN>
+public_root_url = https://<PUBLIC_DOMAIN>
 ```
 
-The per-repository `spec.webhook.baseUrl` field still overrides `public_app_url` for webhook registration; screenshot URLs always use `public_app_url` (or `root_url` when unset).
+The per-repository `spec.webhook.baseUrl` field still overrides `public_root_url` for webhook registration; screenshot URLs always use `public_root_url` (or `root_url` when unset).
 
 {{< /admonition >}}
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -2816,6 +2816,17 @@ Maximum number of repositories allowed. Default is `10`. Set to `0` for unlimite
 
 Maximum number of resources (dashboards, folders, etc.) allowed per repository. Default is `0`, which means unlimited.
 
+#### `public_app_url`
+
+Public-facing URL of this Grafana instance, used by provisioning to construct URLs that must be reachable from external systems. When empty, falls back to `[server] root_url`.
+
+Two consumers honor this setting:
+
+- Webhook callbacks registered with the Git provider (for example, GitHub). The per-repository `spec.webhook.baseUrl`, when set, still wins.
+- Screenshot images embedded in pull-request comments. These are fetched by the Git provider's servers, so the URL must be reachable from the public internet.
+
+Set this when `[server] root_url` points at a cluster-internal address (for example, when Grafana runs behind a private ingress) but provisioning needs an externally-reachable host. This is analogous to `[rendering] callback_url`, which serves the same purpose for the image renderer plugin.
+
 <hr>
 
 ### `[plugin.plugin_id]`

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -2816,9 +2816,9 @@ Maximum number of repositories allowed. Default is `10`. Set to `0` for unlimite
 
 Maximum number of resources (dashboards, folders, etc.) allowed per repository. Default is `0`, which means unlimited.
 
-#### `public_app_url`
+#### `public_root_url`
 
-Public-facing URL of this Grafana instance, used by provisioning to construct URLs that must be reachable from external systems. When empty, falls back to `[server] root_url`.
+Public-facing root URL of this Grafana instance, used by provisioning to construct URLs that must be reachable from external systems. When empty, falls back to `[server] root_url`.
 
 Two consumers honor this setting:
 

--- a/pkg/operators/provisioning/config.go
+++ b/pkg/operators/provisioning/config.go
@@ -551,7 +551,16 @@ func (c *ControllerConfig) RepositoryExtras() ([]repository.Extra, error) {
 			extras = append(extras, gitrepo.Extra(decrypter))
 		case provisioning.GitHubRepositoryType:
 			var webhook *webhooks.WebhookExtraBuilder
+			// The operator runs as a separate process; webhook callbacks must
+			// be registered against an externally-reachable URL pointing at
+			// the main Grafana server. [operator] provisioning_server_public_url
+			// is the operator-specific knob; fall back to the instance-level
+			// [provisioning] public_root_url so a single setting drives both
+			// the in-process and operator deployments.
 			provisioningAppURL := operatorSec.Key("provisioning_server_public_url").String()
+			if provisioningAppURL == "" {
+				provisioningAppURL = c.Settings.ProvisioningPublicRootURL
+			}
 			if provisioningAppURL != "" {
 				webhook = webhooks.ProvideWebhooks(provisioningAppURL, c.Registry())
 			}

--- a/pkg/operators/provisioning/config.go
+++ b/pkg/operators/provisioning/config.go
@@ -551,16 +551,7 @@ func (c *ControllerConfig) RepositoryExtras() ([]repository.Extra, error) {
 			extras = append(extras, gitrepo.Extra(decrypter))
 		case provisioning.GitHubRepositoryType:
 			var webhook *webhooks.WebhookExtraBuilder
-			// The operator runs as a separate process; webhook callbacks must
-			// be registered against an externally-reachable URL pointing at
-			// the main Grafana server. [operator] provisioning_server_public_url
-			// is the operator-specific knob; fall back to the instance-level
-			// [provisioning] public_root_url so a single setting drives both
-			// the in-process and operator deployments.
 			provisioningAppURL := operatorSec.Key("provisioning_server_public_url").String()
-			if provisioningAppURL == "" {
-				provisioningAppURL = c.Settings.ProvisioningPublicRootURL
-			}
 			if provisioningAppURL != "" {
 				webhook = webhooks.ProvideWebhooks(provisioningAppURL, c.Registry())
 			}

--- a/pkg/operators/provisioning/jobs.go
+++ b/pkg/operators/provisioning/jobs.go
@@ -178,14 +178,11 @@ func buildWorkers(cfg *setting.Cfg, controllerCfg *ControllerConfig, registry pr
 
 	// PullRequest
 	renderer := pullrequest.NewNoOpRenderer()
-	// Operator path uses a NoOp renderer; screenshotBaseURL is plumbed for
-	// signature parity but unused at runtime. Prefer the instance-level
-	// provisioning public_root_url when set.
-	screenshotBaseURL := cfg.ProvisioningPublicRootURL
-	if screenshotBaseURL == "" {
-		screenshotBaseURL = cfg.AppURL
-	}
-	evaluator := pullrequest.NewEvaluator(renderer, parsers, urlProvider, screenshotBaseURL, registry)
+	// Operator uses a NoOp renderer, so screenshotBaseURL is plumbed for
+	// signature parity but never used at runtime. The on-prem-only
+	// [provisioning] public_root_url setting is intentionally not consulted
+	// here.
+	evaluator := pullrequest.NewEvaluator(renderer, parsers, urlProvider, cfg.AppURL, registry)
 	commenter := pullrequest.NewCommenter(false)
 	prWorker := pullrequest.NewPullRequestWorker(evaluator, commenter, registry)
 

--- a/pkg/operators/provisioning/jobs.go
+++ b/pkg/operators/provisioning/jobs.go
@@ -178,10 +178,6 @@ func buildWorkers(cfg *setting.Cfg, controllerCfg *ControllerConfig, registry pr
 
 	// PullRequest
 	renderer := pullrequest.NewNoOpRenderer()
-	// Operator uses a NoOp renderer, so screenshotBaseURL is plumbed for
-	// signature parity but never used at runtime. The on-prem-only
-	// [provisioning] public_root_url setting is intentionally not consulted
-	// here.
 	evaluator := pullrequest.NewEvaluator(renderer, parsers, urlProvider, cfg.AppURL, registry)
 	commenter := pullrequest.NewCommenter(false)
 	prWorker := pullrequest.NewPullRequestWorker(evaluator, commenter, registry)

--- a/pkg/operators/provisioning/jobs.go
+++ b/pkg/operators/provisioning/jobs.go
@@ -178,7 +178,10 @@ func buildWorkers(cfg *setting.Cfg, controllerCfg *ControllerConfig, registry pr
 
 	// PullRequest
 	renderer := pullrequest.NewNoOpRenderer()
-	evaluator := pullrequest.NewEvaluator(renderer, parsers, urlProvider, cfg.AppURL, registry)
+	evaluator := pullrequest.NewEvaluator(renderer, parsers, pullrequest.URLProvider{
+		Internal: urlProvider,
+		Public:   urlProvider,
+	}, registry)
 	commenter := pullrequest.NewCommenter(false)
 	prWorker := pullrequest.NewPullRequestWorker(evaluator, commenter, registry)
 

--- a/pkg/operators/provisioning/jobs.go
+++ b/pkg/operators/provisioning/jobs.go
@@ -178,7 +178,14 @@ func buildWorkers(cfg *setting.Cfg, controllerCfg *ControllerConfig, registry pr
 
 	// PullRequest
 	renderer := pullrequest.NewNoOpRenderer()
-	evaluator := pullrequest.NewEvaluator(renderer, parsers, urlProvider, registry)
+	// Operator path uses a NoOp renderer; screenshotBaseURL is plumbed for
+	// signature parity but unused at runtime. Prefer the instance-level
+	// provisioning public_app_url when set.
+	screenshotBaseURL := cfg.ProvisioningPublicAppURL
+	if screenshotBaseURL == "" {
+		screenshotBaseURL = cfg.AppURL
+	}
+	evaluator := pullrequest.NewEvaluator(renderer, parsers, urlProvider, screenshotBaseURL, registry)
 	commenter := pullrequest.NewCommenter(false)
 	prWorker := pullrequest.NewPullRequestWorker(evaluator, commenter, registry)
 

--- a/pkg/operators/provisioning/jobs.go
+++ b/pkg/operators/provisioning/jobs.go
@@ -180,8 +180,8 @@ func buildWorkers(cfg *setting.Cfg, controllerCfg *ControllerConfig, registry pr
 	renderer := pullrequest.NewNoOpRenderer()
 	// Operator path uses a NoOp renderer; screenshotBaseURL is plumbed for
 	// signature parity but unused at runtime. Prefer the instance-level
-	// provisioning public_app_url when set.
-	screenshotBaseURL := cfg.ProvisioningPublicAppURL
+	// provisioning public_root_url when set.
+	screenshotBaseURL := cfg.ProvisioningPublicRootURL
 	if screenshotBaseURL == "" {
 		screenshotBaseURL = cfg.AppURL
 	}

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/changes.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/changes.go
@@ -69,28 +69,37 @@ type fileChangeInfo struct {
 	HasRemovedMetadata bool
 }
 
-type evaluator struct {
-	render            ScreenshotRenderer
-	parsers           resources.ParserFactory
-	urlProvider       func(ctx context.Context, namespace string) string
-	screenshotBaseURL string
-	metrics           screenshotMetrics
+// URLProvider yields the two base URLs Grafana uses when referring to itself
+// from a PR comment. They split because consumers differ:
+//
+//   - Internal builds the dashboard view and preview URLs surfaced as
+//     clickable links. Reviewers click these from their own browsers — usually
+//     from inside the corp network — so the canonical AppURL works.
+//   - Public prefixes screenshot images embedded in the same comment. These
+//     images are fetched server-side by the Git provider's image proxy, so
+//     the URL must be reachable from the public internet.
+//
+// Operator deployments that don't need the split can set both fields to the
+// same closure.
+type URLProvider struct {
+	Internal func(ctx context.Context, namespace string) string
+	Public   func(ctx context.Context, namespace string) string
 }
 
-// NewEvaluator constructs an Evaluator. screenshotBaseURL is the base URL
-// used to prefix relative blob paths returned by the screenshot renderer when
-// embedding images in PR comments — these images are fetched by external
-// systems (e.g. GitHub) so the URL must be publicly reachable. It is
-// independent from urlProvider, which builds the dashboard view and preview
-// URLs surfaced as clickable links in the same comment.
-func NewEvaluator(render ScreenshotRenderer, parsers resources.ParserFactory, urlProvider func(ctx context.Context, namespace string) string, screenshotBaseURL string, registry prometheus.Registerer) Evaluator {
+type evaluator struct {
+	render  ScreenshotRenderer
+	parsers resources.ParserFactory
+	urls    URLProvider
+	metrics screenshotMetrics
+}
+
+func NewEvaluator(render ScreenshotRenderer, parsers resources.ParserFactory, urls URLProvider, registry prometheus.Registerer) Evaluator {
 	metrics := registerScreenshotMetrics(registry)
 	return &evaluator{
-		render:            render,
-		parsers:           parsers,
-		urlProvider:       urlProvider,
-		screenshotBaseURL: screenshotBaseURL,
-		metrics:           metrics,
+		render:  render,
+		parsers: parsers,
+		urls:    urls,
+		metrics: metrics,
 	}
 }
 
@@ -105,11 +114,12 @@ func (e *evaluator) Evaluate(ctx context.Context, repo repository.Reader, opts p
 	rendererAvailable := e.render.IsAvailable(ctx)
 	shouldRender := rendererAvailable && len(changes) == 1 && cfg.Spec.GitHub.GenerateDashboardPreviews
 	info := changeInfo{
-		GrafanaBaseURL:       e.urlProvider(ctx, cfg.Namespace),
+		GrafanaBaseURL:       e.urls.Internal(ctx, cfg.Namespace),
 		RepositoryName:       cfg.Name,
 		RepositoryTitle:      cfg.Spec.Title,
 		MissingImageRenderer: !rendererAvailable,
 	}
+	screenshotBaseURL := e.urls.Public(ctx, cfg.Namespace)
 
 	logger := logging.FromContext(ctx)
 
@@ -123,7 +133,7 @@ func (e *evaluator) Evaluate(ctx context.Context, repo repository.Reader, opts p
 
 		progress.SetMessage(ctx, fmt.Sprintf("process %s", change.Path))
 		logger.With("action", change.Action).With("path", change.Path)
-		info.Changes = append(info.Changes, e.evaluateFile(ctx, repo, info.GrafanaBaseURL, e.screenshotBaseURL, change, opts, parser, shouldRender))
+		info.Changes = append(info.Changes, e.evaluateFile(ctx, repo, info.GrafanaBaseURL, screenshotBaseURL, change, opts, parser, shouldRender))
 	}
 
 	return info, nil

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/changes.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/changes.go
@@ -70,19 +70,27 @@ type fileChangeInfo struct {
 }
 
 type evaluator struct {
-	render      ScreenshotRenderer
-	parsers     resources.ParserFactory
-	urlProvider func(ctx context.Context, namespace string) string
-	metrics     screenshotMetrics
+	render            ScreenshotRenderer
+	parsers           resources.ParserFactory
+	urlProvider       func(ctx context.Context, namespace string) string
+	screenshotBaseURL string
+	metrics           screenshotMetrics
 }
 
-func NewEvaluator(render ScreenshotRenderer, parsers resources.ParserFactory, urlProvider func(ctx context.Context, namespace string) string, registry prometheus.Registerer) Evaluator {
+// NewEvaluator constructs an Evaluator. screenshotBaseURL is the base URL
+// used to prefix relative blob paths returned by the screenshot renderer when
+// embedding images in PR comments — these images are fetched by external
+// systems (e.g. GitHub) so the URL must be publicly reachable. It is
+// independent from urlProvider, which builds the dashboard view and preview
+// URLs surfaced as clickable links in the same comment.
+func NewEvaluator(render ScreenshotRenderer, parsers resources.ParserFactory, urlProvider func(ctx context.Context, namespace string) string, screenshotBaseURL string, registry prometheus.Registerer) Evaluator {
 	metrics := registerScreenshotMetrics(registry)
 	return &evaluator{
-		render:      render,
-		parsers:     parsers,
-		urlProvider: urlProvider,
-		metrics:     metrics,
+		render:            render,
+		parsers:           parsers,
+		urlProvider:       urlProvider,
+		screenshotBaseURL: screenshotBaseURL,
+		metrics:           metrics,
 	}
 }
 
@@ -115,7 +123,7 @@ func (e *evaluator) Evaluate(ctx context.Context, repo repository.Reader, opts p
 
 		progress.SetMessage(ctx, fmt.Sprintf("process %s", change.Path))
 		logger.With("action", change.Action).With("path", change.Path)
-		info.Changes = append(info.Changes, e.evaluateFile(ctx, repo, info.GrafanaBaseURL, change, opts, parser, shouldRender))
+		info.Changes = append(info.Changes, e.evaluateFile(ctx, repo, info.GrafanaBaseURL, e.screenshotBaseURL, change, opts, parser, shouldRender))
 	}
 
 	return info, nil
@@ -123,7 +131,7 @@ func (e *evaluator) Evaluate(ctx context.Context, repo repository.Reader, opts p
 
 var dashboardKind = dashboard.DashboardResourceInfo.GroupVersionKind().Kind
 
-func (e *evaluator) evaluateFile(ctx context.Context, repo repository.Reader, baseURL string, change repository.VersionedFileChange, opts provisioning.PullRequestJobOptions, parser resources.Parser, shouldRender bool) fileChangeInfo {
+func (e *evaluator) evaluateFile(ctx context.Context, repo repository.Reader, baseURL string, screenshotBaseURL string, change repository.VersionedFileChange, opts provisioning.PullRequestJobOptions, parser resources.Parser, shouldRender bool) fileChangeInfo {
 	if change.Action == repository.FileActionDeleted {
 		return e.evaluateDeletedFile(ctx, repo, baseURL, change, parser)
 	}
@@ -195,14 +203,14 @@ func (e *evaluator) evaluateFile(ctx context.Context, repo repository.Reader, ba
 		info.PreviewURL += "?" + query.Encode()
 		if shouldRender {
 			if info.GrafanaURL != "" {
-				info.GrafanaScreenshotURL, err = renderScreenshotFromGrafanaURL(ctx, baseURL, e.render, info.Parsed.Repo, info.GrafanaURL, e.metrics)
+				info.GrafanaScreenshotURL, err = renderScreenshotFromGrafanaURL(ctx, screenshotBaseURL, e.render, info.Parsed.Repo, info.GrafanaURL, e.metrics)
 				if err != nil {
 					info.Error = err.Error()
 				}
 			}
 
 			if info.PreviewURL != "" {
-				info.PreviewScreenshotURL, err = renderScreenshotFromGrafanaURL(ctx, baseURL, e.render, info.Parsed.Repo, info.PreviewURL, e.metrics)
+				info.PreviewScreenshotURL, err = renderScreenshotFromGrafanaURL(ctx, screenshotBaseURL, e.render, info.Parsed.Repo, info.PreviewURL, e.metrics)
 				if err != nil {
 					info.Error = err.Error()
 				}

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/changes_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/changes_test.go
@@ -106,7 +106,7 @@ func TestCalculateChanges(t *testing.T) {
 			},
 		},
 		{
-			name:              "screenshot uses ProvisioningPublicAppURL when set",
+			name:              "screenshot uses ProvisioningPublicRootURL when set",
 			screenshotBaseURL: "https://public.example.com",
 			setupMocks: func(parser *resources.MockParser, reader *repository.MockReader, progress *jobs.MockJobProgressRecorder, renderer *MockScreenshotRenderer, parserFactory *resources.MockParserFactory) {
 				finfo := &repository.FileInfo{
@@ -181,7 +181,7 @@ func TestCalculateChanges(t *testing.T) {
 			},
 		},
 		{
-			name: "screenshot falls back to grafana base url when ProvisioningPublicAppURL empty",
+			name: "screenshot falls back to grafana base url when ProvisioningPublicRootURL empty",
 			setupMocks: func(parser *resources.MockParser, reader *repository.MockReader, progress *jobs.MockJobProgressRecorder, renderer *MockScreenshotRenderer, parserFactory *resources.MockParserFactory) {
 				finfo := &repository.FileInfo{
 					Path: "path/to/file.json",
@@ -256,9 +256,9 @@ func TestCalculateChanges(t *testing.T) {
 		},
 		{
 			// Proves the screenshot path does not silently inherit spec.webhook.baseUrl.
-			// The repo has webhook.baseUrl set, but ProvisioningPublicAppURL is empty,
+			// The repo has webhook.baseUrl set, but ProvisioningPublicRootURL is empty,
 			// so screenshots must use the grafana base URL — not the webhook URL.
-			name: "screenshot ignores spec.webhook.baseUrl when ProvisioningPublicAppURL empty",
+			name: "screenshot ignores spec.webhook.baseUrl when ProvisioningPublicRootURL empty",
 			setupMocks: func(parser *resources.MockParser, reader *repository.MockReader, progress *jobs.MockJobProgressRecorder, renderer *MockScreenshotRenderer, parserFactory *resources.MockParserFactory) {
 				finfo := &repository.FileInfo{
 					Path: "path/to/file.json",

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/changes_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/changes_test.go
@@ -23,12 +23,13 @@ import (
 
 func TestCalculateChanges(t *testing.T) {
 	tests := []struct {
-		name           string
-		setupMocks     func(parser *resources.MockParser, reader *repository.MockReader, progress *jobs.MockJobProgressRecorder, renderer *MockScreenshotRenderer, parserFactory *resources.MockParserFactory)
-		changes        []repository.VersionedFileChange
-		expectedInfo   changeInfo
-		expectedError  string
-		grafanaBaseURL string
+		name              string
+		setupMocks        func(parser *resources.MockParser, reader *repository.MockReader, progress *jobs.MockJobProgressRecorder, renderer *MockScreenshotRenderer, parserFactory *resources.MockParserFactory)
+		changes           []repository.VersionedFileChange
+		expectedInfo      changeInfo
+		expectedError     string
+		grafanaBaseURL    string
+		screenshotBaseURL string
 	}{
 		{
 			name: "with screenshot",
@@ -101,6 +102,235 @@ func TestCalculateChanges(t *testing.T) {
 					PreviewURL:           "http://host/admin/provisioning/y/dashboard/preview/path/to/file.json?pull_request_url=http%253A%252F%252Fgithub.com%252Fpr%252F&ref=ref",
 					GrafanaScreenshotURL: "https://cdn2.thecatapi.com/images/9e2.jpg",
 					PreviewScreenshotURL: "https://cdn2.thecatapi.com/images/9e2.jpg",
+				}},
+			},
+		},
+		{
+			name:              "screenshot uses ProvisioningPublicAppURL when set",
+			screenshotBaseURL: "https://public.example.com",
+			setupMocks: func(parser *resources.MockParser, reader *repository.MockReader, progress *jobs.MockJobProgressRecorder, renderer *MockScreenshotRenderer, parserFactory *resources.MockParserFactory) {
+				finfo := &repository.FileInfo{
+					Path: "path/to/file.json",
+					Ref:  "ref",
+					Data: []byte("xxxx"),
+				}
+				obj := &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": resources.DashboardResource.GroupVersion().String(),
+						"kind":       dashboardKind,
+						"metadata": map[string]interface{}{
+							"name": "the-uid",
+						},
+						"spec": map[string]interface{}{
+							"title": "hello world",
+						},
+					},
+				}
+				meta, _ := utils.MetaAccessor(obj)
+
+				progress.On("SetMessage", mock.Anything, "process path/to/file.json").Return()
+				reader.On("Read", mock.Anything, "path/to/file.json", "ref").Return(finfo, nil)
+				reader.On("Read", mock.Anything, "path/to/file.json", "").Maybe().Return(nil, repository.ErrFileNotFound)
+				reader.On("Config").Return(&provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-repo",
+						Namespace: "x",
+					},
+					Spec: provisioning.RepositorySpec{
+						GitHub: &provisioning.GitHubRepositoryConfig{
+							GenerateDashboardPreviews: true,
+						},
+					},
+				})
+				parser.On("Parse", mock.Anything, finfo).Return(&resources.ParsedResource{
+					Info: finfo,
+					Repo: provisioning.ResourceRepositoryInfo{
+						Namespace: "x",
+						Name:      "y",
+					},
+					GVK: schema.GroupVersionKind{
+						Kind: dashboardKind,
+					},
+					Obj:            obj,
+					Existing:       obj,
+					Meta:           meta,
+					DryRunResponse: obj,
+				}, nil)
+				renderer.On("IsAvailable", mock.Anything, mock.Anything).Return(true)
+				renderer.On("RenderScreenshot", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Return("screenshots/abc.png", nil)
+				parserFactory.On("GetParser", mock.Anything, mock.Anything).Return(parser, nil)
+			},
+			changes: []repository.VersionedFileChange{{
+				Action: repository.FileActionCreated,
+				Path:   "path/to/file.json",
+				Ref:    "ref",
+			}},
+			expectedInfo: changeInfo{
+				Changes: []fileChangeInfo{{
+					Change: repository.VersionedFileChange{
+						Action: repository.FileActionCreated,
+						Path:   "path/to/file.json",
+						Ref:    "ref",
+					},
+					GrafanaURL:           "http://host/d/the-uid/hello-world",
+					PreviewURL:           "http://host/admin/provisioning/y/dashboard/preview/path/to/file.json?pull_request_url=http%253A%252F%252Fgithub.com%252Fpr%252F&ref=ref",
+					GrafanaScreenshotURL: "https://public.example.com/screenshots/abc.png",
+					PreviewScreenshotURL: "https://public.example.com/screenshots/abc.png",
+				}},
+			},
+		},
+		{
+			name: "screenshot falls back to grafana base url when ProvisioningPublicAppURL empty",
+			setupMocks: func(parser *resources.MockParser, reader *repository.MockReader, progress *jobs.MockJobProgressRecorder, renderer *MockScreenshotRenderer, parserFactory *resources.MockParserFactory) {
+				finfo := &repository.FileInfo{
+					Path: "path/to/file.json",
+					Ref:  "ref",
+					Data: []byte("xxxx"),
+				}
+				obj := &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": resources.DashboardResource.GroupVersion().String(),
+						"kind":       dashboardKind,
+						"metadata": map[string]interface{}{
+							"name": "the-uid",
+						},
+						"spec": map[string]interface{}{
+							"title": "hello world",
+						},
+					},
+				}
+				meta, _ := utils.MetaAccessor(obj)
+
+				progress.On("SetMessage", mock.Anything, "process path/to/file.json").Return()
+				reader.On("Read", mock.Anything, "path/to/file.json", "ref").Return(finfo, nil)
+				reader.On("Read", mock.Anything, "path/to/file.json", "").Maybe().Return(nil, repository.ErrFileNotFound)
+				reader.On("Config").Return(&provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-repo",
+						Namespace: "x",
+					},
+					Spec: provisioning.RepositorySpec{
+						GitHub: &provisioning.GitHubRepositoryConfig{
+							GenerateDashboardPreviews: true,
+						},
+					},
+				})
+				parser.On("Parse", mock.Anything, finfo).Return(&resources.ParsedResource{
+					Info: finfo,
+					Repo: provisioning.ResourceRepositoryInfo{
+						Namespace: "x",
+						Name:      "y",
+					},
+					GVK: schema.GroupVersionKind{
+						Kind: dashboardKind,
+					},
+					Obj:            obj,
+					Existing:       obj,
+					Meta:           meta,
+					DryRunResponse: obj,
+				}, nil)
+				renderer.On("IsAvailable", mock.Anything, mock.Anything).Return(true)
+				renderer.On("RenderScreenshot", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Return("screenshots/abc.png", nil)
+				parserFactory.On("GetParser", mock.Anything, mock.Anything).Return(parser, nil)
+			},
+			changes: []repository.VersionedFileChange{{
+				Action: repository.FileActionCreated,
+				Path:   "path/to/file.json",
+				Ref:    "ref",
+			}},
+			expectedInfo: changeInfo{
+				Changes: []fileChangeInfo{{
+					Change: repository.VersionedFileChange{
+						Action: repository.FileActionCreated,
+						Path:   "path/to/file.json",
+						Ref:    "ref",
+					},
+					GrafanaURL:           "http://host/d/the-uid/hello-world",
+					PreviewURL:           "http://host/admin/provisioning/y/dashboard/preview/path/to/file.json?pull_request_url=http%253A%252F%252Fgithub.com%252Fpr%252F&ref=ref",
+					GrafanaScreenshotURL: "http://host/screenshots/abc.png",
+					PreviewScreenshotURL: "http://host/screenshots/abc.png",
+				}},
+			},
+		},
+		{
+			// Proves the screenshot path does not silently inherit spec.webhook.baseUrl.
+			// The repo has webhook.baseUrl set, but ProvisioningPublicAppURL is empty,
+			// so screenshots must use the grafana base URL — not the webhook URL.
+			name: "screenshot ignores spec.webhook.baseUrl when ProvisioningPublicAppURL empty",
+			setupMocks: func(parser *resources.MockParser, reader *repository.MockReader, progress *jobs.MockJobProgressRecorder, renderer *MockScreenshotRenderer, parserFactory *resources.MockParserFactory) {
+				finfo := &repository.FileInfo{
+					Path: "path/to/file.json",
+					Ref:  "ref",
+					Data: []byte("xxxx"),
+				}
+				obj := &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": resources.DashboardResource.GroupVersion().String(),
+						"kind":       dashboardKind,
+						"metadata": map[string]interface{}{
+							"name": "the-uid",
+						},
+						"spec": map[string]interface{}{
+							"title": "hello world",
+						},
+					},
+				}
+				meta, _ := utils.MetaAccessor(obj)
+
+				progress.On("SetMessage", mock.Anything, "process path/to/file.json").Return()
+				reader.On("Read", mock.Anything, "path/to/file.json", "ref").Return(finfo, nil)
+				reader.On("Read", mock.Anything, "path/to/file.json", "").Maybe().Return(nil, repository.ErrFileNotFound)
+				reader.On("Config").Return(&provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-repo",
+						Namespace: "x",
+					},
+					Spec: provisioning.RepositorySpec{
+						GitHub: &provisioning.GitHubRepositoryConfig{
+							GenerateDashboardPreviews: true,
+						},
+						Webhook: &provisioning.WebhookConfig{
+							BaseURL: "https://webhook-only.example.com",
+						},
+					},
+				})
+				parser.On("Parse", mock.Anything, finfo).Return(&resources.ParsedResource{
+					Info: finfo,
+					Repo: provisioning.ResourceRepositoryInfo{
+						Namespace: "x",
+						Name:      "y",
+					},
+					GVK: schema.GroupVersionKind{
+						Kind: dashboardKind,
+					},
+					Obj:            obj,
+					Existing:       obj,
+					Meta:           meta,
+					DryRunResponse: obj,
+				}, nil)
+				renderer.On("IsAvailable", mock.Anything, mock.Anything).Return(true)
+				renderer.On("RenderScreenshot", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Return("screenshots/abc.png", nil)
+				parserFactory.On("GetParser", mock.Anything, mock.Anything).Return(parser, nil)
+			},
+			changes: []repository.VersionedFileChange{{
+				Action: repository.FileActionCreated,
+				Path:   "path/to/file.json",
+				Ref:    "ref",
+			}},
+			expectedInfo: changeInfo{
+				Changes: []fileChangeInfo{{
+					Change: repository.VersionedFileChange{
+						Action: repository.FileActionCreated,
+						Path:   "path/to/file.json",
+						Ref:    "ref",
+					},
+					GrafanaURL:           "http://host/d/the-uid/hello-world",
+					PreviewURL:           "http://host/admin/provisioning/y/dashboard/preview/path/to/file.json?pull_request_url=http%253A%252F%252Fgithub.com%252Fpr%252F&ref=ref",
+					GrafanaScreenshotURL: "http://host/screenshots/abc.png",
+					PreviewScreenshotURL: "http://host/screenshots/abc.png",
 				}},
 			},
 		},
@@ -934,13 +1164,17 @@ func TestCalculateChanges(t *testing.T) {
 
 			tt.setupMocks(parser, reader, progress, renderer, parserFactory)
 
+			screenshotBaseURL := tt.screenshotBaseURL
+			if screenshotBaseURL == "" {
+				screenshotBaseURL = "http://host/"
+			}
 			evaluator := NewEvaluator(renderer, parserFactory, func(_ context.Context, _ string) string {
 				if tt.grafanaBaseURL != "" {
 					return tt.grafanaBaseURL
 				}
 
 				return "http://host/"
-			}, prometheus.NewPedanticRegistry())
+			}, screenshotBaseURL, prometheus.NewPedanticRegistry())
 
 			pullRequest := provisioning.PullRequestJobOptions{
 				Ref: "ref",

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/changes_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/changes_test.go
@@ -1168,13 +1168,14 @@ func TestCalculateChanges(t *testing.T) {
 			if screenshotBaseURL == "" {
 				screenshotBaseURL = "http://host/"
 			}
-			evaluator := NewEvaluator(renderer, parserFactory, func(_ context.Context, _ string) string {
-				if tt.grafanaBaseURL != "" {
-					return tt.grafanaBaseURL
-				}
-
-				return "http://host/"
-			}, screenshotBaseURL, prometheus.NewPedanticRegistry())
+			internalURL := "http://host/"
+			if tt.grafanaBaseURL != "" {
+				internalURL = tt.grafanaBaseURL
+			}
+			evaluator := NewEvaluator(renderer, parserFactory, URLProvider{
+				Internal: func(_ context.Context, _ string) string { return internalURL },
+				Public:   func(_ context.Context, _ string) string { return screenshotBaseURL },
+			}, prometheus.NewPedanticRegistry())
 
 			pullRequest := provisioning.PullRequestJobOptions{
 				Ref: "ref",

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/worker.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/worker.go
@@ -30,8 +30,12 @@ func ProvidePullRequestWorker(
 	configProvider apiserver.RestConfigProvider,
 	registry prometheus.Registerer,
 ) *PullRequestWorker {
+	publicURL := cfg.AppURL
+	if cfg.ProvisioningPublicAppURL != "" {
+		publicURL = cfg.ProvisioningPublicAppURL
+	}
 	urlProvider := func(_ context.Context, _ string) string {
-		return cfg.AppURL
+		return publicURL
 	}
 
 	// FIXME: we should create providers for client and parsers, so that we don't have
@@ -39,7 +43,7 @@ func ProvidePullRequestWorker(
 	clients := resources.NewClientFactory(configProvider)
 	parsers := resources.NewParserFactory(clients, resources.IsFolderMetadataEnabled(cfg))
 	screenshotRenderer := NewScreenshotRenderer(renderer, blobstore)
-	evaluator := NewEvaluator(screenshotRenderer, parsers, urlProvider, registry)
+	evaluator := NewEvaluator(screenshotRenderer, parsers, urlProvider, publicURL, registry)
 	commenter := NewCommenter(cfg.ProvisioningAllowImageRendering)
 
 	return NewPullRequestWorker(evaluator, commenter, registry)

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/worker.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/worker.go
@@ -31,8 +31,8 @@ func ProvidePullRequestWorker(
 	registry prometheus.Registerer,
 ) *PullRequestWorker {
 	publicURL := cfg.AppURL
-	if cfg.ProvisioningPublicAppURL != "" {
-		publicURL = cfg.ProvisioningPublicAppURL
+	if cfg.ProvisioningPublicRootURL != "" {
+		publicURL = cfg.ProvisioningPublicRootURL
 	}
 	urlProvider := func(_ context.Context, _ string) string {
 		return publicURL

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/worker.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/worker.go
@@ -30,18 +30,17 @@ func ProvidePullRequestWorker(
 	configProvider apiserver.RestConfigProvider,
 	registry prometheus.Registerer,
 ) *PullRequestWorker {
-	// Clickable links in PR comments resolve against AppURL so internal
-	// reviewers reach Grafana via the canonical (corp-network-friendly) URL.
-	internalURLProvider := func(_ context.Context, _ string) string {
-		return cfg.AppURL
-	}
-
 	// Screenshot images are fetched server-side by the Git provider's image
 	// proxy and must be reachable from the public internet — prefer
-	// public_root_url when set.
-	screenshotBaseURL := cfg.AppURL
+	// public_root_url when set. Clickable links stay on AppURL so internal
+	// reviewers reach Grafana via the canonical URL.
+	publicURL := cfg.AppURL
 	if cfg.ProvisioningPublicRootURL != "" {
-		screenshotBaseURL = cfg.ProvisioningPublicRootURL
+		publicURL = cfg.ProvisioningPublicRootURL
+	}
+	urls := URLProvider{
+		Internal: func(_ context.Context, _ string) string { return cfg.AppURL },
+		Public:   func(_ context.Context, _ string) string { return publicURL },
 	}
 
 	// FIXME: we should create providers for client and parsers, so that we don't have
@@ -49,7 +48,7 @@ func ProvidePullRequestWorker(
 	clients := resources.NewClientFactory(configProvider)
 	parsers := resources.NewParserFactory(clients, resources.IsFolderMetadataEnabled(cfg))
 	screenshotRenderer := NewScreenshotRenderer(renderer, blobstore)
-	evaluator := NewEvaluator(screenshotRenderer, parsers, internalURLProvider, screenshotBaseURL, registry)
+	evaluator := NewEvaluator(screenshotRenderer, parsers, urls, registry)
 	commenter := NewCommenter(cfg.ProvisioningAllowImageRendering)
 
 	return NewPullRequestWorker(evaluator, commenter, registry)

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/worker.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/worker.go
@@ -30,12 +30,18 @@ func ProvidePullRequestWorker(
 	configProvider apiserver.RestConfigProvider,
 	registry prometheus.Registerer,
 ) *PullRequestWorker {
-	publicURL := cfg.AppURL
-	if cfg.ProvisioningPublicRootURL != "" {
-		publicURL = cfg.ProvisioningPublicRootURL
+	// Clickable links in PR comments resolve against AppURL so internal
+	// reviewers reach Grafana via the canonical (corp-network-friendly) URL.
+	internalURLProvider := func(_ context.Context, _ string) string {
+		return cfg.AppURL
 	}
-	urlProvider := func(_ context.Context, _ string) string {
-		return publicURL
+
+	// Screenshot images are fetched server-side by the Git provider's image
+	// proxy and must be reachable from the public internet — prefer
+	// public_root_url when set.
+	screenshotBaseURL := cfg.AppURL
+	if cfg.ProvisioningPublicRootURL != "" {
+		screenshotBaseURL = cfg.ProvisioningPublicRootURL
 	}
 
 	// FIXME: we should create providers for client and parsers, so that we don't have
@@ -43,7 +49,7 @@ func ProvidePullRequestWorker(
 	clients := resources.NewClientFactory(configProvider)
 	parsers := resources.NewParserFactory(clients, resources.IsFolderMetadataEnabled(cfg))
 	screenshotRenderer := NewScreenshotRenderer(renderer, blobstore)
-	evaluator := NewEvaluator(screenshotRenderer, parsers, urlProvider, publicURL, registry)
+	evaluator := NewEvaluator(screenshotRenderer, parsers, internalURLProvider, screenshotBaseURL, registry)
 	commenter := NewCommenter(cfg.ProvisioningAllowImageRendering)
 
 	return NewPullRequestWorker(evaluator, commenter, registry)

--- a/pkg/registry/apis/provisioning/webhooks/register.go
+++ b/pkg/registry/apis/provisioning/webhooks/register.go
@@ -72,31 +72,24 @@ func ProvideWebhooksWithImages(
 	configProvider apiserver.RestConfigProvider,
 	registry prometheus.Registerer,
 ) *WebhookExtraBuilder {
-	// Clickable links embedded in PR comments (GrafanaURL, PreviewURL) point
-	// human reviewers back at Grafana for inspection. Reviewers typically click
-	// from inside the corp network, so these resolve against the canonical
-	// AppURL — flipping them to a firewalled public URL would 403 the very
-	// users who need them.
-	internalURLProvider := func(_ context.Context, _ string) string {
-		return cfg.AppURL
-	}
-
-	// Webhook callbacks (registered with the Git provider) and screenshot
-	// images (fetched server-side by the Git provider's image proxy) must both
-	// be reachable from the public internet. Prefer [provisioning]
-	// public_root_url when set, otherwise fall back to AppURL.
+	// Webhook callbacks and screenshot images embedded in PR comments must be
+	// reachable from the public internet (the Git provider fetches them
+	// server-side). Prefer [provisioning] public_root_url when set; fall back
+	// to AppURL. Clickable links stay on AppURL so internal reviewers reach
+	// Grafana via the canonical, corp-network-friendly URL.
 	publicURL := cfg.AppURL
 	if cfg.ProvisioningPublicRootURL != "" {
 		publicURL = cfg.ProvisioningPublicRootURL
 	}
-	publicURLProvider := func(_ context.Context, _ string) string {
-		return publicURL
+	urls := pullrequest.URLProvider{
+		Internal: func(_ context.Context, _ string) string { return cfg.AppURL },
+		Public:   func(_ context.Context, _ string) string { return publicURL },
 	}
 	isPublic := isPublicURL(publicURL)
 
 	return &WebhookExtraBuilder{
 		isPublic:    isPublic,
-		urlProvider: publicURLProvider,
+		urlProvider: urls.Public,
 		ExtraBuilder: func(b *provisioningapis.APIBuilder) provisioningapis.Extra {
 			clients := resources.NewClientFactory(configProvider)
 			parsers := resources.NewParserFactory(clients, resources.IsFolderMetadataEnabled(cfg))
@@ -110,14 +103,14 @@ func ProvideWebhooksWithImages(
 				registry,
 			)
 
-			evaluator := pullrequest.NewEvaluator(screenshotRenderer, parsers, internalURLProvider, publicURL, registry)
+			evaluator := pullrequest.NewEvaluator(screenshotRenderer, parsers, urls, registry)
 			commenter := pullrequest.NewCommenter(cfg.ProvisioningAllowImageRendering)
 			pullRequestWorker := pullrequest.NewPullRequestWorker(evaluator, commenter, registry)
 
 			return NewWebhookExtraWithImages(
 				render,
 				webhook,
-				publicURLProvider,
+				urls.Public,
 				[]jobs.Worker{pullRequestWorker},
 			)
 		},

--- a/pkg/registry/apis/provisioning/webhooks/register.go
+++ b/pkg/registry/apis/provisioning/webhooks/register.go
@@ -74,11 +74,11 @@ func ProvideWebhooksWithImages(
 ) *WebhookExtraBuilder {
 	// Webhooks registered with the git provider and screenshot images embedded in
 	// PR comments must both be reachable from the public internet. Prefer the
-	// instance-level [provisioning] public_app_url when set, otherwise fall back
-	// to the standard AppURL.
+	// instance-level [provisioning] public_root_url when set, otherwise fall
+	// back to the standard AppURL.
 	publicURL := cfg.AppURL
-	if cfg.ProvisioningPublicAppURL != "" {
-		publicURL = cfg.ProvisioningPublicAppURL
+	if cfg.ProvisioningPublicRootURL != "" {
+		publicURL = cfg.ProvisioningPublicRootURL
 	}
 	urlProvider := func(_ context.Context, _ string) string {
 		return publicURL

--- a/pkg/registry/apis/provisioning/webhooks/register.go
+++ b/pkg/registry/apis/provisioning/webhooks/register.go
@@ -72,10 +72,18 @@ func ProvideWebhooksWithImages(
 	configProvider apiserver.RestConfigProvider,
 	registry prometheus.Registerer,
 ) *WebhookExtraBuilder {
-	urlProvider := func(_ context.Context, _ string) string {
-		return cfg.AppURL
+	// Webhooks registered with the git provider and screenshot images embedded in
+	// PR comments must both be reachable from the public internet. Prefer the
+	// instance-level [provisioning] public_app_url when set, otherwise fall back
+	// to the standard AppURL.
+	publicURL := cfg.AppURL
+	if cfg.ProvisioningPublicAppURL != "" {
+		publicURL = cfg.ProvisioningPublicAppURL
 	}
-	isPublic := isPublicURL(urlProvider(context.Background(), ""))
+	urlProvider := func(_ context.Context, _ string) string {
+		return publicURL
+	}
+	isPublic := isPublicURL(publicURL)
 
 	return &WebhookExtraBuilder{
 		isPublic:    isPublic,
@@ -93,7 +101,7 @@ func ProvideWebhooksWithImages(
 				registry,
 			)
 
-			evaluator := pullrequest.NewEvaluator(screenshotRenderer, parsers, urlProvider, registry)
+			evaluator := pullrequest.NewEvaluator(screenshotRenderer, parsers, urlProvider, publicURL, registry)
 			commenter := pullrequest.NewCommenter(cfg.ProvisioningAllowImageRendering)
 			pullRequestWorker := pullrequest.NewPullRequestWorker(evaluator, commenter, registry)
 

--- a/pkg/registry/apis/provisioning/webhooks/register.go
+++ b/pkg/registry/apis/provisioning/webhooks/register.go
@@ -72,22 +72,31 @@ func ProvideWebhooksWithImages(
 	configProvider apiserver.RestConfigProvider,
 	registry prometheus.Registerer,
 ) *WebhookExtraBuilder {
-	// Webhooks registered with the git provider and screenshot images embedded in
-	// PR comments must both be reachable from the public internet. Prefer the
-	// instance-level [provisioning] public_root_url when set, otherwise fall
-	// back to the standard AppURL.
+	// Clickable links embedded in PR comments (GrafanaURL, PreviewURL) point
+	// human reviewers back at Grafana for inspection. Reviewers typically click
+	// from inside the corp network, so these resolve against the canonical
+	// AppURL — flipping them to a firewalled public URL would 403 the very
+	// users who need them.
+	internalURLProvider := func(_ context.Context, _ string) string {
+		return cfg.AppURL
+	}
+
+	// Webhook callbacks (registered with the Git provider) and screenshot
+	// images (fetched server-side by the Git provider's image proxy) must both
+	// be reachable from the public internet. Prefer [provisioning]
+	// public_root_url when set, otherwise fall back to AppURL.
 	publicURL := cfg.AppURL
 	if cfg.ProvisioningPublicRootURL != "" {
 		publicURL = cfg.ProvisioningPublicRootURL
 	}
-	urlProvider := func(_ context.Context, _ string) string {
+	publicURLProvider := func(_ context.Context, _ string) string {
 		return publicURL
 	}
 	isPublic := isPublicURL(publicURL)
 
 	return &WebhookExtraBuilder{
 		isPublic:    isPublic,
-		urlProvider: urlProvider,
+		urlProvider: publicURLProvider,
 		ExtraBuilder: func(b *provisioningapis.APIBuilder) provisioningapis.Extra {
 			clients := resources.NewClientFactory(configProvider)
 			parsers := resources.NewParserFactory(clients, resources.IsFolderMetadataEnabled(cfg))
@@ -101,14 +110,14 @@ func ProvideWebhooksWithImages(
 				registry,
 			)
 
-			evaluator := pullrequest.NewEvaluator(screenshotRenderer, parsers, urlProvider, publicURL, registry)
+			evaluator := pullrequest.NewEvaluator(screenshotRenderer, parsers, internalURLProvider, publicURL, registry)
 			commenter := pullrequest.NewCommenter(cfg.ProvisioningAllowImageRendering)
 			pullRequestWorker := pullrequest.NewPullRequestWorker(evaluator, commenter, registry)
 
 			return NewWebhookExtraWithImages(
 				render,
 				webhook,
-				urlProvider,
+				publicURLProvider,
 				[]jobs.Worker{pullRequestWorker},
 			)
 		},

--- a/pkg/registry/apis/provisioning/webhooks/register_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/register_test.go
@@ -8,6 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 func TestWebhookExtraBuilder_WebhookURL(t *testing.T) {
@@ -104,6 +105,56 @@ func TestWebhookExtraBuilder_WebhookURL(t *testing.T) {
 
 			result := builder.WebhookURL(context.Background(), tt.repo)
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestResolvePublicURL verifies the urlProvider resolution chain used by
+// ProvideWebhooksWithImages: spec.webhook.baseUrl wins when set on a repo;
+// otherwise the builder falls back to ProvisioningPublicAppURL when set, then
+// to AppURL.
+func TestResolvePublicURL(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         *setting.Cfg
+		repoWebhook *provisioning.WebhookConfig
+		expected    string
+	}{
+		{
+			name:     "uses ProvisioningPublicAppURL when set and no spec override",
+			cfg:      &setting.Cfg{AppURL: "http://internal.cluster.local/", ProvisioningPublicAppURL: "https://public.example.com"},
+			expected: "https://public.example.com/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/my-repo/webhook",
+		},
+		{
+			name:     "falls back to AppURL when ProvisioningPublicAppURL empty",
+			cfg:      &setting.Cfg{AppURL: "https://grafana.example.com/"},
+			expected: "https://grafana.example.com/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/my-repo/webhook",
+		},
+		{
+			name:        "spec.webhook.baseUrl still wins over ProvisioningPublicAppURL",
+			cfg:         &setting.Cfg{AppURL: "http://internal.cluster.local/", ProvisioningPublicAppURL: "https://public.example.com"},
+			repoWebhook: &provisioning.WebhookConfig{BaseURL: "https://repo-override.example.com"},
+			expected:    "https://repo-override.example.com/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/my-repo/webhook",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			publicURL := tt.cfg.AppURL
+			if tt.cfg.ProvisioningPublicAppURL != "" {
+				publicURL = tt.cfg.ProvisioningPublicAppURL
+			}
+			builder := &WebhookExtraBuilder{
+				isPublic: isPublicURL(publicURL),
+				urlProvider: func(_ context.Context, _ string) string {
+					return publicURL
+				},
+			}
+			repo := &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-repo", Namespace: "default"},
+				Spec:       provisioning.RepositorySpec{Webhook: tt.repoWebhook},
+			}
+			assert.Equal(t, tt.expected, builder.WebhookURL(context.Background(), repo))
 		})
 	}
 }

--- a/pkg/registry/apis/provisioning/webhooks/register_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/register_test.go
@@ -111,7 +111,7 @@ func TestWebhookExtraBuilder_WebhookURL(t *testing.T) {
 
 // TestResolvePublicURL verifies the urlProvider resolution chain used by
 // ProvideWebhooksWithImages: spec.webhook.baseUrl wins when set on a repo;
-// otherwise the builder falls back to ProvisioningPublicAppURL when set, then
+// otherwise the builder falls back to ProvisioningPublicRootURL when set, then
 // to AppURL.
 func TestResolvePublicURL(t *testing.T) {
 	tests := []struct {
@@ -121,18 +121,18 @@ func TestResolvePublicURL(t *testing.T) {
 		expected    string
 	}{
 		{
-			name:     "uses ProvisioningPublicAppURL when set and no spec override",
-			cfg:      &setting.Cfg{AppURL: "http://internal.cluster.local/", ProvisioningPublicAppURL: "https://public.example.com"},
+			name:     "uses ProvisioningPublicRootURL when set and no spec override",
+			cfg:      &setting.Cfg{AppURL: "http://internal.cluster.local/", ProvisioningPublicRootURL: "https://public.example.com"},
 			expected: "https://public.example.com/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/my-repo/webhook",
 		},
 		{
-			name:     "falls back to AppURL when ProvisioningPublicAppURL empty",
+			name:     "falls back to AppURL when ProvisioningPublicRootURL empty",
 			cfg:      &setting.Cfg{AppURL: "https://grafana.example.com/"},
 			expected: "https://grafana.example.com/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/my-repo/webhook",
 		},
 		{
-			name:        "spec.webhook.baseUrl still wins over ProvisioningPublicAppURL",
-			cfg:         &setting.Cfg{AppURL: "http://internal.cluster.local/", ProvisioningPublicAppURL: "https://public.example.com"},
+			name:        "spec.webhook.baseUrl still wins over ProvisioningPublicRootURL",
+			cfg:         &setting.Cfg{AppURL: "http://internal.cluster.local/", ProvisioningPublicRootURL: "https://public.example.com"},
 			repoWebhook: &provisioning.WebhookConfig{BaseURL: "https://repo-override.example.com"},
 			expected:    "https://repo-override.example.com/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/my-repo/webhook",
 		},
@@ -141,8 +141,8 @@ func TestResolvePublicURL(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			publicURL := tt.cfg.AppURL
-			if tt.cfg.ProvisioningPublicAppURL != "" {
-				publicURL = tt.cfg.ProvisioningPublicAppURL
+			if tt.cfg.ProvisioningPublicRootURL != "" {
+				publicURL = tt.cfg.ProvisioningPublicRootURL
 			}
 			builder := &WebhookExtraBuilder{
 				isPublic: isPublicURL(publicURL),

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -162,6 +162,7 @@ type Cfg struct {
 	ProvisioningFolderAPIVersion              string        // "v1" (default for on-prem) or "v1beta1"
 	ProvisioningMaxIncrementalChanges         int           // default 100, 0 in config = unlimited
 	ProvisioningWebhookSecretRotationInterval time.Duration // default 30 days
+	ProvisioningPublicAppURL                  string        // public-facing URL of this Grafana instance for provisioning consumers (webhooks, screenshots); falls back to AppURL when empty
 	DataPath                                  string
 	LogsPath                                  string
 	EnterpriseLicensePath                     string
@@ -2419,6 +2420,7 @@ func (cfg *Cfg) readProvisioningSettings(iniFile *ini.File) error {
 	cfg.ProvisioningFolderAPIVersion = iniFile.Section("provisioning").Key("folders_api_version").MustString("v1")
 	cfg.ProvisioningMaxIncrementalChanges = iniFile.Section("provisioning").Key("max_incremental_changes").MustInt(100)
 	cfg.ProvisioningWebhookSecretRotationInterval = iniFile.Section("provisioning").Key("webhook_secret_rotation_interval").MustDuration(30 * 24 * time.Hour)
+	cfg.ProvisioningPublicAppURL = strings.TrimRight(valueAsString(iniFile.Section("provisioning"), "public_app_url", ""), "/")
 
 	// Read job history configuration
 	cfg.ProvisioningLokiURL = valueAsString(iniFile.Section("provisioning"), "loki_url", "")

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -162,7 +162,7 @@ type Cfg struct {
 	ProvisioningFolderAPIVersion              string        // "v1" (default for on-prem) or "v1beta1"
 	ProvisioningMaxIncrementalChanges         int           // default 100, 0 in config = unlimited
 	ProvisioningWebhookSecretRotationInterval time.Duration // default 30 days
-	ProvisioningPublicAppURL                  string        // public-facing URL of this Grafana instance for provisioning consumers (webhooks, screenshots); falls back to AppURL when empty
+	ProvisioningPublicRootURL                 string        // public-facing root URL of this Grafana instance for provisioning consumers (webhooks, screenshots); falls back to AppURL when empty
 	DataPath                                  string
 	LogsPath                                  string
 	EnterpriseLicensePath                     string
@@ -2420,7 +2420,7 @@ func (cfg *Cfg) readProvisioningSettings(iniFile *ini.File) error {
 	cfg.ProvisioningFolderAPIVersion = iniFile.Section("provisioning").Key("folders_api_version").MustString("v1")
 	cfg.ProvisioningMaxIncrementalChanges = iniFile.Section("provisioning").Key("max_incremental_changes").MustInt(100)
 	cfg.ProvisioningWebhookSecretRotationInterval = iniFile.Section("provisioning").Key("webhook_secret_rotation_interval").MustDuration(30 * 24 * time.Hour)
-	cfg.ProvisioningPublicAppURL = strings.TrimRight(valueAsString(iniFile.Section("provisioning"), "public_app_url", ""), "/")
+	cfg.ProvisioningPublicRootURL = strings.TrimRight(valueAsString(iniFile.Section("provisioning"), "public_root_url", ""), "/")
 
 	// Read job history configuration
 	cfg.ProvisioningLokiURL = valueAsString(iniFile.Section("provisioning"), "loki_url", "")


### PR DESCRIPTION
## Summary

Adds a new instance-level `[provisioning] public_root_url` setting that drives the webhook callback URL registered with the Git provider and the screenshot images embedded in pull-request comments. Clickable Grafana/Preview links continue to resolve against `[server] root_url` so internal reviewers reach Grafana via the canonical (corp-network-friendly) URL. Alternative to #123004 — same bug, different layer.

(Supersedes the closed-by-rename #123609.)

### Why

When Grafana runs behind an internal ingress, `[server] root_url` points at a cluster-private host. GitHub's image fetcher cannot reach those URLs, so dashboard preview images embedded in PR comments come out broken (`![Preview](http://internal-grafana/...)`).

#123004 repurposes the per-repository `spec.webhook.baseUrl` field to also drive screenshot URLs. Two issues with that approach:

1. **Wrong contract scope.** `WebhookConfig.BaseURL` is documented narrowly as the URL of the *inbound* webhook endpoint (`/apis/.../webhook`). Screenshots are *outbound* image fetches at a different endpoint (`/apis/.../render/{guid}`). Overloading the field couples two unrelated concerns.
2. **Wrong layer.** The same Grafana instance serves every provisioning repo, so `webhook.baseUrl` ends up being identical for all repos on a given instance — it doesn't belong on a per-repo CRD. The root cause is instance-level: `root_url` points internal.

### What changes

A single instance-level setting:

```ini
[provisioning]
public_root_url =
```

Named to mirror `[server] root_url` (the value it falls back to), so operators searching docs for "root_url" land on the right knob.

### Three URLs, three reachability profiles

PR comments contain three different URLs that have *different* consumers and *different* reachability requirements:

| URL | Consumer | Where consumer runs | Reachability |
|---|---|---|---|
| Webhook URL (registered with the Git provider) | GitHub webhook delivery | GitHub's infra | **Public** |
| Screenshot URL (image embed `![preview](...)`) | GitHub's `camo` image proxy (server-side fetch) | GitHub's infra | **Public** |
| Clickable Grafana / Preview link | Reviewer's browser (direct, not proxied) | typically the corp network | **Internal-friendly** |

Conflating these under a single `root_url` is the source of the bug. The fix is to resolve each per-consumer:

| Consumer | Resolution order |
|---|---|
| Webhook URL | `spec.webhook.baseUrl` → `[provisioning] public_root_url` → `cfg.AppURL` |
| Screenshot URL | `[provisioning] public_root_url` → `cfg.AppURL` |
| Clickable Grafana / Preview link | `cfg.AppURL` only (always — internal-friendly) |

**Why clickable links stay on `AppURL`** even when `public_root_url` is set: the public host in the typical deployment shape (e.g., a separate ingress firewalled to GitHub's CIDR ranges) is *not* reachable by the corporate egress IPs of the very reviewers who'd click these links. Pointing them at the public URL would 403 internal users on every preview click. External viewers can't reach internal Grafana either way (it requires Grafana access regardless of URL), so flipping clickable links to public has no upside.

Screenshots intentionally do **not** consult `spec.webhook.baseUrl`. Per-repo webhook overrides remain a webhook-only concern. `webhook.baseUrl` stays as-is — no deprecation, no doc rewrite — its effective default just broadens (now `public_root_url` instead of `AppURL`).

Analogous to the existing `[rendering] callback_url` setting, which serves the same purpose for the image renderer plugin (a separate process that needs a callback URL distinct from `root_url`).

### Files changed

- **Settings:** New `Cfg.ProvisioningPublicRootURL` field, read from `[provisioning] public_root_url`. `defaults.ini` documents the key.
- **Webhook URL provider:** `ProvideWebhooksWithImages` and `ProvidePullRequestWorker` build two closures: `internalURLProvider` (returns `AppURL`, fed to the evaluator's `urlProvider` for clickable links) and `publicURLProvider` (returns `public_root_url` || `AppURL`, fed to the `WebhookExtraBuilder` for webhook URL registration). The same `publicURL` value is also passed as `screenshotBaseURL` to the evaluator.
- **Screenshot URL plumbing:** `pullrequest.NewEvaluator` takes a new `screenshotBaseURL` argument resolved at construction. `evaluateFile` is widened to receive it and feeds it to `renderScreenshotFromGrafanaURL`. The per-evaluation `cfg.Spec.Webhook.BaseURL` read introduced in #123004 is dropped — the contract is now resolved once at construction, not per-PR.
- **Tests:** New `changes_test.go` cases for the screenshot resolution chain (set / fallback / `webhook.baseUrl` doesn't leak in). The cases use distinct hostnames (`http://host/` for `urlProvider`, `https://public.example.com` for `screenshotBaseURL`) so the assertions explicitly verify that clickable URLs come out on the internal host while screenshots come out on the public one. New `register_test.go` case for the webhook URL fallback chain.
- **Docs:** Documents `public_root_url` in the configuration reference and adds a self-hosted setup note in the Git Sync setup guide.

### Backward compatibility

Existing repos relying on `spec.webhook.baseUrl` see no behavior change — the per-repo override still wins for webhook registration. Existing instances with no `public_root_url` set continue to use `[server] root_url` for everything (including the new screenshot path, which previously also used `root_url`).

### Design context

The broader design conversation around per-consumer outbound URLs (Twilio BYOC analogy, split-horizon DNS as an alternative, Enterprise licensing constraints, multi-CNAME serving, `root_url`-as-array proposals from internal Slack) is captured in a separate design doc for peer review.

## Test plan

- [x] `go test ./pkg/registry/apis/provisioning/webhooks/... ./pkg/setting/...`
- [x] `go vet ./pkg/setting/... ./pkg/registry/apis/provisioning/... ./pkg/operators/provisioning/...`
- [ ] Manual: configure `[server] root_url = http://internal.example` and `[provisioning] public_root_url = https://public.example`, verify:
  - Webhook registered on GitHub points at `https://public.example/apis/.../webhook`.
  - PR-comment markdown clickable link reads `[Open dashboard](http://internal.example/d/...)`.
  - PR-comment markdown image reads `![preview](https://public.example/apis/.../render/...)`.
- [ ] Manual: with `spec.webhook.baseUrl = https://webhook-only.example`, verify webhooks use `webhook-only.example` while screenshots still use `public_root_url` and clickable links still use `root_url`.
- [ ] Manual: with `public_root_url` unset and `spec.webhook.baseUrl` set, verify webhook uses `webhook.baseUrl` and screenshots fall back to `root_url` (proves no silent fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)