### PR TITLE
Docs: grafanactl archive date

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -3,3 +3,10 @@ MinAlertLevel = warning
 [*.md]
 BasedOnStyles = Grafana
 TokenIgnores = (<http[^\n]+>+?), \*\*[^\n]+\*\*
+
+# Canonical URLs in Hugo front matter sit outside Vale token ignores; host/path contain `grafana`
+# substrings that trigger Grafana.GrafanaCom and Grafana.WordList even though full URLs are required.
+[docs/sources/as-code/observability-as-code/grafana-cli/**/*.md]
+Grafana.GrafanaCom = NO
+Grafana.WordList = NO
+

--- a/.vale.ini
+++ b/.vale.ini
@@ -3,10 +3,3 @@ MinAlertLevel = warning
 [*.md]
 BasedOnStyles = Grafana
 TokenIgnores = (<http[^\n]+>+?), \*\*[^\n]+\*\*
-
-# Canonical URLs in Hugo front matter sit outside Vale token ignores; host/path contain `grafana`
-# substrings that trigger Grafana.GrafanaCom and Grafana.WordList even though full URLs are required.
-[docs/sources/as-code/observability-as-code/grafana-cli/**/*.md]
-Grafana.GrafanaCom = NO
-Grafana.WordList = NO
-

--- a/docs/sources/as-code/observability-as-code/grafana-cli/_index.md
+++ b/docs/sources/as-code/observability-as-code/grafana-cli/_index.md
@@ -35,7 +35,7 @@ aliases:
 
 # Introduction to the Grafana CLI
 
-Grafana command-line tools are designed to simplify interaction with Grafana instances. You can authenticate, manage multiple environments, and perform administrative tasks through the Grafana REST API, all from the terminal. Whether you're automating workflows in CI/CD pipelines or switching between staging and production environments, the Grafana CLI provides a flexible and efficient way to manage your Grafana setup as code.
+Grafana command-line tools are designed to simplify interaction with Grafana instances. You can authenticate, manage multiple environments, and perform administrative tasks through the Grafana REST API, all from the terminal. Whether you're automating workflows in CI/CD pipelines or switching between staging and production environments, the Grafana CLI tool provides a flexible and efficient way to manage your Grafana setup as code.
 
 `gcx` works across all environments for Grafana OSS, Enterprise, and Cloud. **Use `gcx` to work with AI agents**.
 

--- a/docs/sources/as-code/observability-as-code/grafana-cli/_index.md
+++ b/docs/sources/as-code/observability-as-code/grafana-cli/_index.md
@@ -37,7 +37,7 @@ aliases:
 
 Grafana command-line tools are designed to simplify interaction with Grafana instances. You can authenticate, manage multiple environments, and perform administrative tasks through the Grafana REST API, all from the terminal. Whether you're automating workflows in CI/CD pipelines or switching between staging and production environments, the Grafana CLI provides a flexible and efficient way to manage your Grafana setup as code.
 
-`gcx` work across all environments for Grafana OSS, Enterprise, and Cloud. **Use `gcx` to work with AI agents**.
+`gcx` works across all environments for Grafana OSS, Enterprise, and Cloud. **Use `gcx` to work with AI agents**.
 
 ## Explore
 

--- a/docs/sources/as-code/observability-as-code/grafana-cli/_index.md
+++ b/docs/sources/as-code/observability-as-code/grafana-cli/_index.md
@@ -35,7 +35,7 @@ aliases:
 
 # Introduction to the Grafana CLI
 
-Grafana command-line tools are designed to simplify interaction with Grafana instances. You can authenticate, manage multiple environments, and perform administrative tasks through Grafana’s REST API, all from the terminal. Whether you're automating workflows in CI/CD pipelines or switching between staging and production environments, the Grafana CLIs provide a flexible and scriptable way to manage your Grafana setup efficiently.
+Grafana command-line tools are designed to simplify interaction with Grafana instances. You can authenticate, manage multiple environments, and perform administrative tasks through the Grafana REST API, all from the terminal. Whether you're automating workflows in CI/CD pipelines or switching between staging and production environments, the Grafana CLIs provide a flexible and scriptable way to manage your Grafana setup efficiently.
 
 `gcx` work across all environments for Grafana OSS, Enterprise, and Cloud. **Use `gcx` to work with AI agents**.
 

--- a/docs/sources/as-code/observability-as-code/grafana-cli/_index.md
+++ b/docs/sources/as-code/observability-as-code/grafana-cli/_index.md
@@ -35,7 +35,7 @@ aliases:
 
 # Introduction to the Grafana CLI
 
-Grafana command-line tools are designed to simplify interaction with Grafana instances. You can authenticate, manage multiple environments, and perform administrative tasks through the Grafana REST API, all from the terminal. Whether you're automating workflows in CI/CD pipelines or switching between staging and production environments, the Grafana CLIs provide a flexible and scriptable way to manage your Grafana setup efficiently.
+Grafana command-line tools are designed to simplify interaction with Grafana instances. You can authenticate, manage multiple environments, and perform administrative tasks through the Grafana REST API, all from the terminal. Whether you're automating workflows in CI/CD pipelines or switching between staging and production environments, the Grafana CLI provides a flexible and efficient way to manage your Grafana setup as code.
 
 `gcx` work across all environments for Grafana OSS, Enterprise, and Cloud. **Use `gcx` to work with AI agents**.
 

--- a/docs/sources/as-code/observability-as-code/grafana-cli/gcx/_index.md
+++ b/docs/sources/as-code/observability-as-code/grafana-cli/gcx/_index.md
@@ -37,7 +37,7 @@ The Grafana Cloud CLI `gcx` is a single CLI that allows you to manage both Grafa
 
 Among other, the `gcx` CLI provides the following benefits:
 
-- **Manage Grafana on-prem and Grafana Cloud:** Use a single tool for dashboards, alerting, SLOs, on-call, synthetic checks, load testing, and more.
+- **Manage Grafana OSS/Enterprise and Grafana Cloud:** Use a single tool for dashboards, alerting, SLOs, on-call, synthetic checks, load testing, and more.
 - **AI agent friendly:** Agent mode auto-detected for Claude Code, Copilot, Cursor, and other.
 - **Automation:** `gcx` uses JSON/YAML output, structured errors, and predictable exit codes.
 - **GitOps**: Pull resources to files, version in Git, or push back with full round-trip fidelity.

--- a/docs/sources/as-code/observability-as-code/grafana-cli/grafanactl/_index.md
+++ b/docs/sources/as-code/observability-as-code/grafana-cli/grafanactl/_index.md
@@ -33,7 +33,7 @@ To migrate from `grafanactl` to `gcx`, search-and-replace `grafanactl` with `gcx
 
 {{< /admonition >}}
 
-The `grafanactl` command-line tool allows you to authenticate, manage multiple environments, and perform administrative tasks through Grafana’s REST API, all from the terminal. It is available for Grafana OSS, Enterprise, and Cloud.
+The `grafanactl` command-line tool allows you to authenticate, manage multiple environments, and perform administrative tasks through the Grafana REST API, all from the terminal. It is available for Grafana OSS, Enterprise, and Cloud.
 
 ## Install the Grafana CLI `grafanactl`
 

--- a/docs/sources/as-code/observability-as-code/grafana-cli/grafanactl/_index.md
+++ b/docs/sources/as-code/observability-as-code/grafana-cli/grafanactl/_index.md
@@ -101,11 +101,17 @@ By default, the CLI uses a context named `default`. To configure it use:
 ```bash
 grafanactl config set contexts.default.grafana.server http://localhost:3000
 grafanactl config set contexts.default.grafana.org-id 1
+```
 
-# Authenticate with a service account token
+Authenticate with a service account token:
+
+```bash
 grafanactl config set contexts.default.grafana.token service-account-token
+```
 
-# Or use basic authentication
+Or use basic authentication:
+
+```bash
 grafanactl config set contexts.default.grafana.user admin
 grafanactl config set contexts.default.grafana.password admin
 ```

--- a/docs/sources/as-code/observability-as-code/grafana-cli/grafanactl/_index.md
+++ b/docs/sources/as-code/observability-as-code/grafana-cli/grafanactl/_index.md
@@ -27,7 +27,7 @@ aliases:
 
 {{< admonition type="caution" >}}
 
-`grafanactl` is being deprecated, and we're bringing all our learnings and experience into the new, improved CLI tool [`gcx`](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/grafana-cli/gcx).
+`grafanactl` is being deprecated, and we're bringing all our learnings and experience into the new, improved CLI tool [`gcx`](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/grafana-cli/gcx). The `grafanactl` repository in GitHub will be archived on June 1st, 2026.
 
 To migrate from `grafanactl` to `gcx`, search-and-replace `grafanactl` with `gcx`. For `grafanactl resources serve`, use `gcx dev serve` instead.
 

--- a/docs/sources/as-code/observability-as-code/grafana-cli/grafanactl/_index.md
+++ b/docs/sources/as-code/observability-as-code/grafana-cli/grafanactl/_index.md
@@ -27,7 +27,7 @@ aliases:
 
 {{< admonition type="caution" >}}
 
-`grafanactl` is being deprecated, and we're bringing all our learnings and experience into the new, improved CLI tool [`gcx`](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/grafana-cli/gcx). The `grafanactl` repository in GitHub will be archived on June 1st, 2026.
+`grafanactl` is being deprecated, and we're bringing all our learnings and experience into the new, improved CLI tool [`gcx`](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/grafana-cli/gcx). The `grafanactl` repository in GitHub will be archived on June 1, 2026.
 
 To migrate from `grafanactl` to `gcx`, search-and-replace `grafanactl` with `gcx`. For `grafanactl resources serve`, use `gcx dev serve` instead.
 
@@ -72,7 +72,7 @@ You can configure `grafanactl` in two ways: using environment variables or throu
 - **Configuration files** can manage multiple contexts, making it easier to switch between different Grafana instances.
 
 {{< admonition type="note" >}}
-Configuration items may change depending on your set-up. For example, use `org-id` for Grafana on-prem, but use `stack-id` for Grafana Cloud.
+Configuration items may change depending on your set-up. For example, use `org-id` for self-managed Grafana, but use `stack-id` for Grafana Cloud.
 {{< /admonition >}}
 
 ### Configure Grafana CLI with environment variables

--- a/docs/sources/as-code/observability-as-code/grafana-cli/grafanactl/_index.md
+++ b/docs/sources/as-code/observability-as-code/grafana-cli/grafanactl/_index.md
@@ -27,7 +27,7 @@ aliases:
 
 {{< admonition type="caution" >}}
 
-`grafanactl` is being deprecated, and we're bringing all our learnings and experience into the new, improved CLI tool [`gcx`](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/grafana-cli/gcx). The `grafanactl` repository in GitHub will be archived on June 1, 2026.
+`grafanactl` is being deprecated, and we're bringing all our learning and experience into the new, improved CLI tool [`gcx`](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/grafana-cli/gcx). The `grafanactl` repository in GitHub will be archived on June 1, 2026.
 
 To migrate from `grafanactl` to `gcx`, search-and-replace `grafanactl` with `gcx`. For `grafanactl resources serve`, use `gcx dev serve` instead.
 

--- a/docs/sources/as-code/observability-as-code/grafana-cli/grafanactl/_index.md
+++ b/docs/sources/as-code/observability-as-code/grafana-cli/grafanactl/_index.md
@@ -33,7 +33,7 @@ To migrate from `grafanactl` to `gcx`, search-and-replace `grafanactl` with `gcx
 
 {{< /admonition >}}
 
-The `grafanactl` command-line tool allows you to authenticate, manage multiple environments, and perform administrative tasks through the Grafana REST API, all from the terminal. It is available for Grafana OSS, Enterprise, and Cloud.
+The `grafanactl` command-line tool allows you to authenticate, manage multiple environments, and perform administrative tasks through the Grafana REST API, all from the terminal. It's available for Grafana OSS, Enterprise, and Cloud.
 
 ## Install the Grafana CLI `grafanactl`
 
@@ -66,7 +66,7 @@ go install github.com/grafana/grafanactl/cmd/grafanactl@latest
 
 ## Configure `grafanactl`
 
-You can configure Grafana CLI in two ways: using environment variables or through a configuration file.
+You can configure `grafanactl` in two ways: using environment variables or through a configuration file.
 
 - **Environment variables** are ideal for CI environments and support a single context. A full list of supported environment variables is available in the [reference documentation](https://github.com/grafana/grafanactl/blob/main/docs/reference/environment-variables/index.md#environment-variables-reference).
 - **Configuration files** can manage multiple contexts, making it easier to switch between different Grafana instances.
@@ -77,7 +77,7 @@ Configuration items may change depending on your set-up. For example, use `org-i
 
 ### Configure Grafana CLI with environment variables
 
-Grafana CLI communicates with Grafana via its REST API, which requires authentication credentials.
+Grafana CLI communicates with Grafana via the REST API, which requires authentication credentials.
 
 At a minimum, set the URL of your Grafana instance and the organization ID:
 

--- a/docs/sources/as-code/observability-as-code/grafana-cli/grafanactl/grafanacli-workflows.md
+++ b/docs/sources/as-code/observability-as-code/grafana-cli/grafanactl/grafanacli-workflows.md
@@ -24,7 +24,7 @@ aliases:
 
 {{< admonition type="caution" >}}
 
-`grafanactl` is being deprecated, and we're bringing all our learnings and experience into the new, improved CLI tool [`gcx`](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/grafana-cli/gcx).
+`grafanactl` is being deprecated, and we're bringing all our learnings and experience into the new, improved CLI tool [`gcx`](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/grafana-cli/gcx).The `grafanactl` repository in GitHub will be archived on June 1st, 2026.
 
 To migrate from `grafanactl` to `gcx`, search-and-replace `grafanactl` with `gcx`. For `grafanactl resources serve`, use `gcx dev serve` instead.
 

--- a/docs/sources/as-code/observability-as-code/grafana-cli/grafanactl/grafanacli-workflows.md
+++ b/docs/sources/as-code/observability-as-code/grafana-cli/grafanactl/grafanacli-workflows.md
@@ -24,7 +24,7 @@ aliases:
 
 {{< admonition type="caution" >}}
 
-`grafanactl` is being deprecated, and we're bringing all our learnings and experience into the new, improved CLI tool [`gcx`](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/grafana-cli/gcx).The `grafanactl` repository in GitHub will be archived on June 1st, 2026.
+`grafanactl` is being deprecated, and we're bringing all our learnings and experience into the new, improved CLI tool [`gcx`](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/grafana-cli/gcx). The `grafanactl` repository in GitHub will be archived on June 1, 2026.
 
 To migrate from `grafanactl` to `gcx`, search-and-replace `grafanactl` with `gcx`. For `grafanactl resources serve`, use `gcx dev serve` instead.
 

--- a/docs/sources/as-code/observability-as-code/grafana-cli/grafanactl/grafanacli-workflows.md
+++ b/docs/sources/as-code/observability-as-code/grafana-cli/grafanactl/grafanacli-workflows.md
@@ -53,21 +53,21 @@ This can be configured with the `-p, --path` flags to specify custom paths on di
 1. Pull those resources from the development environment to your local machine:
 
    ```bash
-   grafanactl config use-context YOUR_CONTEXT  # for example "dev"
-   grafanactl resources pull --path ./resources/ -o yaml # or json
+   grafanactl config use-context YOUR_CONTEXT
+   grafanactl resources pull --path ./resources/ -o yaml
    ```
 
 1. (Optional) Preview the resources locally before pushing:
 
    ```bash
-   grafanactl config use-context YOUR_CONTEXT  # for example "prod"
+   grafanactl config use-context YOUR_CONTEXT
    grafanactl resources serve ./resources/
    ```
 
 1. Switch to the **production instance** and push the resources:
 
    ```bash
-   grafanactl config use-context YOUR_CONTEXT  # for example "prod"
+   grafanactl config use-context YOUR_CONTEXT
    grafanactl resources push -p ./resources/
    ```
 
@@ -78,8 +78,8 @@ This workflow helps you back up all Grafana resources from one instance and late
 1. Use `grafanactl` to pull all resources from your target environment:
 
    ```bash
-   grafanactl config use-context YOUR_CONTEXT  # for example "prod"
-   grafanactl resources pull --path ./resources/ -o yaml # or json
+   grafanactl config use-context YOUR_CONTEXT
+   grafanactl resources pull --path ./resources/ -o yaml
    ```
 
 1. Save the exported resources to version control or cloud storage.
@@ -89,14 +89,14 @@ This workflow helps you back up all Grafana resources from one instance and late
 1. (Optional) Preview the backup locally:
 
    ```bash
-   grafanactl config use-context YOUR_CONTEXT  # for example "prod"
+   grafanactl config use-context YOUR_CONTEXT
    grafanactl resources serve ./resources/
    ```
 
 1. To restore the resources later or restore them on another instance, push the saved resources:
 
    ```bash
-   grafanactl config use-context YOUR_CONTEXT  # for example "prod"
+   grafanactl config use-context YOUR_CONTEXT
    grafanactl resources push -p ./resources/
    ```
 
@@ -109,7 +109,7 @@ With this workflow, you can define and manage dashboards as code, saving them to
 1. Serve and preview the output of the dashboard generator locally:
 
    ```bash
-   grafanactl config use-context YOUR_CONTEXT  # for example "dev"
+   grafanactl config use-context YOUR_CONTEXT
    grafanactl resources serve --script 'go run scripts/generate-dashboard.go' --watch './scripts'
    ```
 
@@ -122,7 +122,7 @@ With this workflow, you can define and manage dashboards as code, saving them to
 1. Push the generated resources to your Grafana instance:
 
    ```bash
-   grafanactl config use-context YOUR_CONTEXT  # for example "dev"
+   grafanactl config use-context YOUR_CONTEXT
    grafanactl resources push -p ./resources/
    ```
 
@@ -137,7 +137,7 @@ Use this workflow to identify dashboards that reference incorrect or outdated da
 1. Set the context to the appropriate environment:
 
    ```bash
-   grafanactl config use-context YOUR_CONTEXT  # for example "prod"
+   grafanactl config use-context YOUR_CONTEXT
    ```
 
 1. Find dashboards using specific data sources:
@@ -185,7 +185,7 @@ Use this workflow to locate dashboards using a deprecated API version and mark t
 1. Set the context to the appropriate environment:
 
    ```bash
-   grafanactl config use-context YOUR_CONTEXT  # for example "prod"
+   grafanactl config use-context YOUR_CONTEXT
    ```
 
 1. List all available resources types and versions:

--- a/docs/sources/as-code/observability-as-code/grafana-cli/grafanactl/grafanacli-workflows.md
+++ b/docs/sources/as-code/observability-as-code/grafana-cli/grafanactl/grafanacli-workflows.md
@@ -24,7 +24,7 @@ aliases:
 
 {{< admonition type="caution" >}}
 
-`grafanactl` is being deprecated, and we're bringing all our learnings and experience into the new, improved CLI tool [`gcx`](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/grafana-cli/gcx). The `grafanactl` repository in GitHub will be archived on June 1, 2026.
+`grafanactl` is being deprecated, and we're bringing all our learning and experience into the new, improved CLI tool [`gcx`](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/grafana-cli/gcx). The `grafanactl` repository in GitHub will be archived on June 1, 2026.
 
 To migrate from `grafanactl` to `gcx`, search-and-replace `grafanactl` with `gcx`. For `grafanactl resources serve`, use `gcx dev serve` instead.
 


### PR DESCRIPTION
Replaces https://github.com/grafana/website/pull/30410.
