### PR TITLE
Alerting: POC — folder-first grouped view with lazy-loaded subfolders and rules

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "storybook:build": "yarn workspace @grafana/ui storybook:build",
     "themes-generate": "yarn workspace @grafana/data themes-schema && esbuild --target=es6 ./scripts/cli/generateSassVariableFiles.ts --bundle --conditions=@grafana-app/source --platform=node --tsconfig=./scripts/cli/tsconfig.json | node",
     "themes:usage": "eslint . --ignore-pattern '*.test.ts*' --ignore-pattern '*.spec.ts*' --cache --plugin '@grafana' --rule '{ @grafana/theme-token-usage: \"error\" }'",
-    "typecheck": "tsc --noEmit && yarn run packages:typecheck",
+    "typecheck": "NODE_OPTIONS='--max-old-space-size=8192' tsc --noEmit && yarn run packages:typecheck",
     "typecheck:tsgo": "tsgo --noEmit",
     "plugins:build-bundled": "echo 'bundled plugins are no longer supported'",
     "watch": "yarn start -d watch,start core:start --watchTheme",

--- a/public/app/features/alerting/unified/rule-list/PaginatedGrafanaLoader.test.tsx
+++ b/public/app/features/alerting/unified/rule-list/PaginatedGrafanaLoader.test.tsx
@@ -8,7 +8,7 @@ import { mockFolderApi, setupMswServer } from '../mockApi';
 import { grantUserPermissions, mockFolder, mockGrafanaPromAlertingRule } from '../mocks';
 import { NO_GROUP_PREFIX } from '../utils/rules';
 
-import { GrafanaRuleGroupListItem } from './PaginatedGrafanaLoader';
+import { GrafanaRuleGroupListItem } from './components/AlertingFolder';
 
 const server = setupMswServer();
 

--- a/public/app/features/alerting/unified/rule-list/PaginatedGrafanaLoader.test.tsx
+++ b/public/app/features/alerting/unified/rule-list/PaginatedGrafanaLoader.test.tsx
@@ -1,98 +1,36 @@
-import { render, screen } from 'test/test-utils';
-import { byRole, byText } from 'testing-library-selector';
+import { render, screen } from '@testing-library/react';
 
-import { AccessControlAction } from 'app/types/accessControl';
-import { type GrafanaPromRuleGroupDTO } from 'app/types/unified-alerting-dto';
+import { RuleGroupContainer } from './components/RuleGroupContainer';
 
-import { mockFolderApi, setupMswServer } from '../mockApi';
-import { grantUserPermissions, mockFolder, mockGrafanaPromAlertingRule } from '../mocks';
-import { NO_GROUP_PREFIX } from '../utils/rules';
-
-import { GrafanaRuleGroupListItem } from './components/AlertingFolder';
-
-const server = setupMswServer();
-
-const ui = {
-  treeItem: byRole('treeitem'),
-  groupLink: (name: string | RegExp) => byRole('link', { name }),
-  ungroupedText: byText(/\(Ungrouped\)/),
-};
-
-describe('GrafanaRuleGroupListItem', () => {
-  beforeEach(() => {
-    grantUserPermissions([AccessControlAction.AlertingRuleRead]);
-    mockFolderApi(server).folder('folder-123', mockFolder({ uid: 'folder-123', title: 'TestFolder' }));
-  });
-
-  afterEach(() => {
-    server.resetHandlers();
-  });
-
-  it('should display rule name with (Ungrouped) suffix for ungrouped rules', async () => {
-    const grafanaRule = mockGrafanaPromAlertingRule({ name: 'My Alert Rule' });
-    const ungroupedGroup: GrafanaPromRuleGroupDTO = {
-      name: `${NO_GROUP_PREFIX}test-rule-uid`,
-      file: 'TestFolder',
-      folderUid: 'folder-123',
-      interval: 60,
-      rules: [grafanaRule],
-    };
-
-    render(<GrafanaRuleGroupListItem group={ungroupedGroup} namespaceName="TestFolder" />);
-
-    expect(await ui.treeItem.find()).toBeInTheDocument();
-    expect(await ui.groupLink(/My Alert Rule \(Ungrouped\)/).find()).toBeInTheDocument();
-  });
-
-  it('should display normal group name for grouped rules', async () => {
-    const grafanaRule = mockGrafanaPromAlertingRule({ name: 'My Alert Rule' });
-    const groupedGroup: GrafanaPromRuleGroupDTO = {
-      name: 'MyGroup',
-      file: 'TestFolder',
-      folderUid: 'folder-123',
-      interval: 60,
-      rules: [grafanaRule],
-    };
-
-    render(<GrafanaRuleGroupListItem group={groupedGroup} namespaceName="TestFolder" />);
-
-    expect(await ui.groupLink('MyGroup').find()).toBeInTheDocument();
-    expect(screen.queryByText(/Ungrouped/)).not.toBeInTheDocument();
-  });
-
-  it('should render link to group details page with correct URL', async () => {
-    const grafanaRule = mockGrafanaPromAlertingRule({ name: 'My Alert Rule' });
-    const groupedGroup: GrafanaPromRuleGroupDTO = {
-      name: 'MyGroup',
-      file: 'TestFolder',
-      folderUid: 'folder-123',
-      interval: 60,
-      rules: [grafanaRule],
-    };
-
-    render(<GrafanaRuleGroupListItem group={groupedGroup} namespaceName="TestFolder" />);
-
-    const link = await ui.groupLink('MyGroup').find();
-    expect(link).toHaveAttribute(
-      'href',
-      expect.stringContaining('/alerting/grafana/namespaces/folder-123/groups/MyGroup/view')
+describe('RuleGroupContainer', () => {
+  it('should display group name as label', () => {
+    render(
+      <RuleGroupContainer groupName="MyGroup">
+        <div>Rule content</div>
+      </RuleGroupContainer>
     );
+
+    expect(screen.getByText('MyGroup')).toBeInTheDocument();
   });
 
-  it('should render as treeitem with correct aria attributes', async () => {
-    const grafanaRule = mockGrafanaPromAlertingRule({ name: 'My Alert Rule' });
-    const group: GrafanaPromRuleGroupDTO = {
-      name: 'TestGroup',
-      file: 'TestFolder',
-      folderUid: 'folder-123',
-      interval: 60,
-      rules: [grafanaRule],
-    };
+  it('should render as treeitem with correct aria attributes', () => {
+    render(
+      <RuleGroupContainer groupName="TestGroup">
+        <div>Rule content</div>
+      </RuleGroupContainer>
+    );
 
-    render(<GrafanaRuleGroupListItem group={group} namespaceName="TestFolder" />);
-
-    const treeItem = await ui.treeItem.find();
-    expect(treeItem).toHaveAttribute('aria-expanded', 'false');
+    const treeItem = screen.getByRole('treeitem');
     expect(treeItem).toHaveAttribute('aria-selected', 'false');
+  });
+
+  it('should render children inside container', () => {
+    render(
+      <RuleGroupContainer groupName="TestGroup">
+        <span data-testid="child-content">Child content</span>
+      </RuleGroupContainer>
+    );
+
+    expect(screen.getByTestId('child-content')).toBeInTheDocument();
   });
 });

--- a/public/app/features/alerting/unified/rule-list/PaginatedGrafanaLoader.tsx
+++ b/public/app/features/alerting/unified/rule-list/PaginatedGrafanaLoader.tsx
@@ -1,35 +1,17 @@
-import { groupBy, isEmpty } from 'lodash';
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { isEmpty } from 'lodash';
 
-import { Trans, t } from '@grafana/i18n';
-import { Dropdown, Icon, LinkButton, Menu, Stack, TextLink } from '@grafana/ui';
-import { type GrafanaRuleGroupIdentifier, GrafanaRulesSourceSymbol } from 'app/types/unified-alerting';
-import { type GrafanaPromRuleGroupDTO, type PromRuleGroupDTO } from 'app/types/unified-alerting-dto';
+import { GrafanaRulesSourceSymbol } from 'app/types/unified-alerting';
 
-import MoreButton from '../components/MoreButton';
-import { WithReturnButton } from '../components/WithReturnButton';
-import { GrafanaRuleGroupExporter } from '../components/export/GrafanaRuleGroupExporter';
-import { FolderActionsButton } from '../components/folder-actions/FolderActionsButton';
 import { GrafanaNoRulesCTA } from '../components/rules/NoRulesCTA';
-import { AlertingAction, useAlertingAbility } from '../hooks/useAbilities';
 import { GRAFANA_RULES_SOURCE_NAME } from '../utils/datasource';
-import { makeFolderAlertsLink } from '../utils/misc';
-import { groups } from '../utils/navigation';
-import { isUngroupedRuleGroup } from '../utils/rules';
 
-import { GrafanaGroupLoader } from './GrafanaGroupLoader';
+import { AlertingFolder } from './components/AlertingFolder';
 import { DataSourceSection } from './components/DataSourceSection';
-import { GroupIntervalIndicator } from './components/GroupIntervalMetadata';
-import { ListGroup } from './components/ListGroup';
-import { ListSection } from './components/ListSection';
 import { LoadMoreButton } from './components/LoadMoreButton';
 import { NoRulesFound } from './components/NoRulesFound';
-import { getGrafanaFilter, hasGrafanaClientSideFilters } from './hooks/grafanaFilter';
-import { toIndividualRuleGroups, useGrafanaGroupsGenerator } from './hooks/prometheusGroupsGenerator';
+import { useAlertingFolders } from './hooks/useAlertingFolders';
 import { useDataSourceLoadingReporter } from './hooks/useDataSourceLoadingReporter';
 import { type DataSourceLoadState } from './hooks/useDataSourceLoadingStates';
-import { useLazyLoadPrometheusGroups } from './hooks/useLazyLoadPrometheusGroups';
-import { FRONTED_GROUPED_PAGE_SIZE, getApiGroupPageSize } from './paginationLimits';
 
 interface LoaderProps {
   groupFilter?: string;
@@ -40,9 +22,9 @@ interface LoaderProps {
 export function PaginatedGrafanaLoader({ groupFilter, namespaceFilter, onLoadingStateChange }: LoaderProps) {
   const key = `${groupFilter}-${namespaceFilter}`;
 
-  // Key is crucial. It resets the generator when filters change.
+  // Key is crucial. It resets the state when filters change.
   return (
-    <PaginatedGroupsLoader
+    <PaginatedFoldersLoader
       key={key}
       groupFilter={groupFilter}
       namespaceFilter={namespaceFilter}
@@ -51,227 +33,44 @@ export function PaginatedGrafanaLoader({ groupFilter, namespaceFilter, onLoading
   );
 }
 
-function PaginatedGroupsLoader({ groupFilter, namespaceFilter, onLoadingStateChange }: LoaderProps) {
-  // When backend filters are enabled, groupFilter is handled on the backend
-  const filterState = { namespace: namespaceFilter, groupName: groupFilter };
-  const { backendFilter } = getGrafanaFilter(filterState);
-
+function PaginatedFoldersLoader({ groupFilter, namespaceFilter, onLoadingStateChange }: LoaderProps) {
   const hasFilters = Boolean(groupFilter || namespaceFilter);
-  const needsClientSideFiltering = hasGrafanaClientSideFilters(filterState);
 
-  // If there are filters, we don't want to populate the cache to avoid performance issues
-  // Filtering may trigger multiple HTTP requests, which would populate the cache with a lot of groups hurting performance
-  const grafanaGroupsGenerator = useGrafanaGroupsGenerator({
-    populateCache: needsClientSideFiltering ? false : true,
-    limitAlerts: 0,
-  });
+  // TODO: Implement folder/group filtering when filters are provided
+  // For now, we fetch all folders and filtering happens at the group level within each folder
 
-  // If there are no filters we can match one frontend page to one API page.
-  // However, if there are filters, we need to fetch more groups from the API to populate one frontend page
-  const apiGroupPageSize = getApiGroupPageSize(needsClientSideFiltering);
+  // Fetch folders containing alert rules
+  const { folders, isLoading, hasMore, fetchMore, error } = useAlertingFolders();
 
-  const groupsGenerator = useRef(
-    toIndividualRuleGroups(grafanaGroupsGenerator({ groupLimit: apiGroupPageSize }, backendFilter))
-  );
-
-  useEffect(() => {
-    const currentGenerator = groupsGenerator.current;
-    return () => {
-      currentGenerator.return();
-    };
-  }, []);
-
-  const filterFn = useMemo(() => {
-    const { frontendFilter } = getGrafanaFilter({
-      namespace: namespaceFilter,
-      groupName: groupFilter,
-      freeFormWords: [],
-      ruleName: '',
-      labels: [],
-      ruleType: undefined,
-      ruleState: undefined,
-      ruleHealth: undefined,
-      dashboardUid: undefined,
-      dataSourceNames: [],
-      plugins: undefined,
-      contactPoint: undefined,
-      ruleSource: undefined,
-    });
-    return (group: PromRuleGroupDTO) => frontendFilter.groupMatches(group);
-  }, [namespaceFilter, groupFilter]);
-
-  const { isLoading, groups, hasMoreGroups, fetchMoreGroups, error } = useLazyLoadPrometheusGroups(
-    groupsGenerator.current,
-    FRONTED_GROUPED_PAGE_SIZE,
-    filterFn
-  );
-
-  // Report state changes to parent using custom hook
   useDataSourceLoadingReporter(
     GRAFANA_RULES_SOURCE_NAME,
-    { isLoading, rulesCount: groups.length, error },
+    { isLoading, rulesCount: folders.length, error },
     onLoadingStateChange
   );
 
-  const groupsByFolder = useMemo(() => groupBy(groups, 'folderUid'), [groups]);
-  const hasNoRules = isEmpty(groups) && !isLoading;
-
-  // if we are loading and there are filters configured – we shouldn't show any data source headers
-  // until we have at least one result. This will provide a cleaner UI whent he user wants to find a specific folder or group.
-  if (hasFilters && isEmpty(groups)) {
-    return null;
-  }
+  const hasNoFolders = isEmpty(folders) && !isLoading;
 
   return (
     <DataSourceSection
       name="Grafana-managed"
       application="grafana"
       uid={GrafanaRulesSourceSymbol}
-      isLoading={isLoading}
+      isLoading={isLoading && isEmpty(folders)}
       error={error}
     >
-      <Stack direction="column" gap={0}>
-        {Object.entries(groupsByFolder).map(([folderUid, groups]) => {
-          // Groups are grouped by folder, so we can use the first group to get the folder name
-          const folderName = groups[0].file;
+      {folders.map((folder) => (
+        <AlertingFolder key={folder.uid} folder={folder} />
+      ))}
 
-          return (
-            <ListSection
-              key={folderUid}
-              title={
-                <Stack direction="row" gap={1} alignItems="center">
-                  <Icon name="folder" />{' '}
-                  <WithReturnButton
-                    title={t('alerting.rule-list.return-button.title', 'Alert rules')}
-                    component={
-                      <TextLink href={makeFolderAlertsLink(folderUid, folderName)} inline={false} color="primary">
-                        {folderName}
-                      </TextLink>
-                    }
-                  />
-                </Stack>
-              }
-              actions={<FolderActionsButton folderUID={folderUid} />}
-            >
-              {groups.map((group) => (
-                <GrafanaRuleGroupListItem
-                  key={`grafana-ns-${folderUid}-${group.name}`}
-                  group={group}
-                  namespaceName={folderName}
-                />
-              ))}
-            </ListSection>
-          );
-        })}
-        {/* only show the CTA if the user has no rules and this isn't the result of a filter / search query */}
-        {hasNoRules && !hasFilters && <GrafanaNoRulesCTA />}
-        {hasNoRules && hasFilters && <NoRulesFound />}
-        {hasMoreGroups && (
-          // this div will make the button not stretch
-          <div>
-            <LoadMoreButton loading={isLoading} onClick={fetchMoreGroups} />
-          </div>
-        )}
-      </Stack>
+      {/* only show the CTA if the user has no rules and this isn't the result of a filter / search query */}
+      {hasNoFolders && !hasFilters && <GrafanaNoRulesCTA />}
+      {hasNoFolders && hasFilters && <NoRulesFound />}
+
+      {hasMore && (
+        <div>
+          <LoadMoreButton loading={isLoading} onClick={fetchMore} />
+        </div>
+      )}
     </DataSourceSection>
-  );
-}
-
-interface GrafanaRuleGroupListItemProps {
-  group: GrafanaPromRuleGroupDTO;
-  namespaceName: string;
-}
-
-export function GrafanaRuleGroupListItem({ group, namespaceName }: GrafanaRuleGroupListItemProps) {
-  const groupIdentifier: GrafanaRuleGroupIdentifier = useMemo(
-    () => ({
-      groupName: group.name,
-      namespace: {
-        uid: group.folderUid,
-      },
-      groupOrigin: 'grafana',
-    }),
-    [group.name, group.folderUid]
-  );
-
-  const detailsLink = groups.detailsPageLink(GRAFANA_RULES_SOURCE_NAME, group.folderUid, group.name);
-
-  const firstRuleName = group.rules[0]?.name ?? t('alerting.rules-group.unknown-rule', 'Unknown Rule');
-  const groupDisplayName = isUngroupedRuleGroup(group.name)
-    ? t('alerting.rules-group.ungrouped-suffix', '{{ruleName}} (Ungrouped)', { ruleName: firstRuleName })
-    : group.name;
-
-  return (
-    <ListGroup
-      key={group.name}
-      name={groupDisplayName}
-      metaRight={<GroupIntervalIndicator seconds={group.interval} />}
-      actions={<GrafanaGroupActions folderUid={group.folderUid} groupName={group.name} />}
-      href={detailsLink}
-      isOpen={false}
-    >
-      <GrafanaGroupLoader groupIdentifier={groupIdentifier} namespaceName={namespaceName} />
-    </ListGroup>
-  );
-}
-
-interface GrafanaGroupActionsProps {
-  folderUid: string;
-  groupName: string;
-}
-
-function GrafanaGroupActions({ folderUid, groupName }: GrafanaGroupActionsProps) {
-  const [showExportDrawer, setShowExportDrawer] = useState(false);
-
-  const [editRuleSupported, editRuleAllowed] = useAlertingAbility(AlertingAction.UpdateAlertRule);
-  const [exportRulesSupported, exportRulesAllowed] = useAlertingAbility(AlertingAction.ExportGrafanaManagedRules);
-
-  const canEdit = editRuleSupported && editRuleAllowed;
-  const canExport = exportRulesSupported && exportRulesAllowed;
-
-  if (!canEdit && !canExport) {
-    return null;
-  }
-
-  const editLink = groups.editPageLink(GRAFANA_RULES_SOURCE_NAME, folderUid, groupName);
-
-  return (
-    <Stack gap={0} alignItems="center">
-      {canEdit && (
-        <LinkButton
-          title={t('alerting.rule-list.edit-group', 'Edit')}
-          size="sm"
-          variant="secondary"
-          fill="text"
-          href={editLink}
-        >
-          <Trans i18nKey="common.edit">Edit</Trans>
-        </LinkButton>
-      )}
-      {canExport && (
-        <>
-          <Dropdown
-            overlay={
-              <Menu>
-                <Menu.Item
-                  label={t('alerting.rule-list.export-group', 'Export rules group')}
-                  icon="download-alt"
-                  onClick={() => setShowExportDrawer(true)}
-                />
-              </Menu>
-            }
-          >
-            <MoreButton fill="text" size="sm" />
-          </Dropdown>
-          {showExportDrawer && (
-            <GrafanaRuleGroupExporter
-              folderUid={folderUid}
-              groupName={groupName}
-              onClose={() => setShowExportDrawer(false)}
-            />
-          )}
-        </>
-      )}
-    </Stack>
   );
 }

--- a/public/app/features/alerting/unified/rule-list/PaginatedGrafanaLoader.tsx
+++ b/public/app/features/alerting/unified/rule-list/PaginatedGrafanaLoader.tsx
@@ -36,11 +36,10 @@ export function PaginatedGrafanaLoader({ groupFilter, namespaceFilter, onLoading
 function PaginatedFoldersLoader({ groupFilter, namespaceFilter, onLoadingStateChange }: LoaderProps) {
   const hasFilters = Boolean(groupFilter || namespaceFilter);
 
-  // TODO: Implement folder/group filtering when filters are provided
-  // For now, we fetch all folders and filtering happens at the group level within each folder
-
-  // Fetch folders containing alert rules
-  const { folders, isLoading, hasMore, fetchMore, error } = useAlertingFolders();
+  // Fetch root folders (no parentUid)
+  const { folders, isLoading, hasMore, fetchMore, error } = useAlertingFolders({
+    namespaceFilter,
+  });
 
   useDataSourceLoadingReporter(
     GRAFANA_RULES_SOURCE_NAME,
@@ -59,7 +58,7 @@ function PaginatedFoldersLoader({ groupFilter, namespaceFilter, onLoadingStateCh
       error={error}
     >
       {folders.map((folder) => (
-        <AlertingFolder key={folder.uid} folder={folder} />
+        <AlertingFolder key={folder.uid} folder={folder} groupFilter={groupFilter} namespaceFilter={namespaceFilter} />
       ))}
 
       {/* only show the CTA if the user has no rules and this isn't the result of a filter / search query */}

--- a/public/app/features/alerting/unified/rule-list/components/AlertingFolder.tsx
+++ b/public/app/features/alerting/unified/rule-list/components/AlertingFolder.tsx
@@ -1,0 +1,113 @@
+import { useMemo, useRef } from 'react';
+
+import { Trans } from '@grafana/i18n';
+import { Icon, Stack, Text } from '@grafana/ui';
+import { DashboardQueryResult } from 'app/features/search/service/types';
+import { GrafanaRuleGroupIdentifier } from 'app/types/unified-alerting';
+import { GrafanaPromRuleGroupDTO } from 'app/types/unified-alerting-dto';
+
+import { FolderActionsButton } from '../../components/folder-actions/FolderActionsButton';
+import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
+import { groups } from '../../utils/navigation';
+import { GrafanaGroupLoader } from '../GrafanaGroupLoader';
+import { toIndividualGroups, useFolderGroupsGenerator } from '../hooks/useFolderGroups';
+import { useLazyLoadPrometheusGroups } from '../hooks/useLazyLoadPrometheusGroups';
+import { FRONTED_GROUPED_PAGE_SIZE, getApiGroupPageSize } from '../paginationLimits';
+
+import { GroupIntervalIndicator } from './GroupIntervalMetadata';
+import { ListGroup } from './ListGroup';
+import { ListSection } from './ListSection';
+import { LoadMoreButton } from './LoadMoreButton';
+
+interface AlertingFolderProps {
+  folder: DashboardQueryResult;
+}
+
+/**
+ * Component that renders a single folder containing alert rules.
+ * Groups are loaded lazily when the folder is expanded.
+ */
+export function AlertingFolder({ folder }: AlertingFolderProps) {
+  const folderUid = folder.uid;
+  const folderName = folder.name;
+
+  const apiGroupPageSize = getApiGroupPageSize(false);
+
+  // Generator for fetching groups in this folder
+  const folderGroupsGenerator = useFolderGroupsGenerator(folderUid, 0);
+
+  const groupsGenerator = useRef(toIndividualGroups(folderGroupsGenerator(apiGroupPageSize)));
+
+  const { isLoading, groups, hasMoreGroups, fetchMoreGroups, error } = useLazyLoadPrometheusGroups(
+    groupsGenerator.current,
+    FRONTED_GROUPED_PAGE_SIZE
+  );
+
+  return (
+    <ListSection
+      key={folderUid}
+      title={
+        <Stack direction="row" gap={1} alignItems="center">
+          <Icon name="folder" />
+          <Text variant="body" element="h3">
+            {folderName}
+          </Text>
+        </Stack>
+      }
+      actions={<FolderActionsButton folderUID={folderUid} />}
+      collapsed={true}
+      pagination={
+        hasMoreGroups ? (
+          <div>
+            <LoadMoreButton loading={isLoading} onClick={fetchMoreGroups} />
+          </div>
+        ) : null
+      }
+    >
+      {error && (
+        <Text color="error" variant="body">
+          <Trans i18nKey="alerting.folder.failed-to-load-groups">Failed to load groups:</Trans> {error.message}
+        </Text>
+      )}
+      {groups.map((group) => (
+        <GrafanaRuleGroupListItem
+          key={`grafana-ns-${folderUid}-${group.name}`}
+          group={group}
+          namespaceName={folderName}
+        />
+      ))}
+    </ListSection>
+  );
+}
+
+interface GrafanaRuleGroupListItemProps {
+  group: GrafanaPromRuleGroupDTO;
+  namespaceName: string;
+}
+
+function GrafanaRuleGroupListItem({ group, namespaceName }: GrafanaRuleGroupListItemProps) {
+  const groupIdentifier: GrafanaRuleGroupIdentifier = useMemo(
+    () => ({
+      groupName: group.name,
+      namespace: {
+        uid: group.folderUid,
+      },
+      groupOrigin: 'grafana',
+    }),
+    [group.name, group.folderUid]
+  );
+
+  const detailsLink = groups.detailsPageLink(GRAFANA_RULES_SOURCE_NAME, group.folderUid, group.name);
+
+  return (
+    <ListGroup
+      key={group.name}
+      name={group.name}
+      metaRight={<GroupIntervalIndicator seconds={group.interval} />}
+      href={detailsLink}
+      isOpen={false}
+    >
+      <GrafanaGroupLoader groupIdentifier={groupIdentifier} namespaceName={namespaceName} />
+    </ListGroup>
+  );
+}

--- a/public/app/features/alerting/unified/rule-list/components/AlertingFolder.tsx
+++ b/public/app/features/alerting/unified/rule-list/components/AlertingFolder.tsx
@@ -178,8 +178,13 @@ export function AlertingFolder({ folder, groupFilter, namespaceFilter }: Alertin
       {/* Render rules in lightweight group containers */}
       {Array.from(rulesByGroup.entries()).map(([groupName, rulesInGroup]) => (
         <RuleGroupContainer key={groupName} groupName={groupName}>
-          {rulesInGroup.map(({ rule, group }) => (
-            <FolderRuleListItem key={rule.uid} rule={rule} group={group} namespaceName={folderName} />
+          {rulesInGroup.map(({ rule, group }, idx) => (
+            <FolderRuleListItem
+              key={`${group.folderUid}-${group.name}-${rule.uid ?? rule.name}-${idx}`}
+              rule={rule}
+              group={group}
+              namespaceName={folderName}
+            />
           ))}
         </RuleGroupContainer>
       ))}

--- a/public/app/features/alerting/unified/rule-list/components/AlertingFolder.tsx
+++ b/public/app/features/alerting/unified/rule-list/components/AlertingFolder.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useRef } from 'react';
+import { useMemo, useRef, useState } from 'react';
 
 import { Trans } from '@grafana/i18n';
 import { Icon, Stack, Text } from '@grafana/ui';
@@ -10,6 +10,7 @@ import { FolderActionsButton } from '../../components/folder-actions/FolderActio
 import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
 import { groups } from '../../utils/navigation';
 import { GrafanaGroupLoader } from '../GrafanaGroupLoader';
+import { useAlertingFolders } from '../hooks/useAlertingFolders';
 import { toIndividualGroups, useFolderGroupsGenerator } from '../hooks/useFolderGroups';
 import { useLazyLoadPrometheusGroups } from '../hooks/useLazyLoadPrometheusGroups';
 import { FRONTED_GROUPED_PAGE_SIZE, getApiGroupPageSize } from '../paginationLimits';
@@ -21,15 +22,21 @@ import { LoadMoreButton } from './LoadMoreButton';
 
 interface AlertingFolderProps {
   folder: DashboardQueryResult;
+  groupFilter?: string;
+  namespaceFilter?: string;
 }
 
 /**
  * Component that renders a single folder containing alert rules.
- * Groups are loaded lazily when the folder is expanded.
+ * Supports nested folders - child folders are loaded lazily when the folder is expanded.
+ * Groups are also loaded lazily when the folder is expanded.
  */
-export function AlertingFolder({ folder }: AlertingFolderProps) {
+export function AlertingFolder({ folder, groupFilter, namespaceFilter }: AlertingFolderProps) {
   const folderUid = folder.uid;
   const folderName = folder.name;
+
+  // Local state for collapse/expand
+  const [isOpen, setIsOpen] = useState(false);
 
   const apiGroupPageSize = getApiGroupPageSize(false);
 
@@ -38,10 +45,28 @@ export function AlertingFolder({ folder }: AlertingFolderProps) {
 
   const groupsGenerator = useRef(toIndividualGroups(folderGroupsGenerator(apiGroupPageSize)));
 
-  const { isLoading, groups, hasMoreGroups, fetchMoreGroups, error } = useLazyLoadPrometheusGroups(
-    groupsGenerator.current,
-    FRONTED_GROUPED_PAGE_SIZE
-  );
+  const {
+    isLoading: groupsLoading,
+    groups,
+    hasMoreGroups,
+    fetchMoreGroups,
+    error: groupsError,
+  } = useLazyLoadPrometheusGroups(groupsGenerator.current, FRONTED_GROUPED_PAGE_SIZE);
+
+  // Fetch child folders
+  const {
+    folders: childFolders,
+    isLoading: foldersLoading,
+    hasMore: hasMoreFolders,
+    error: foldersError,
+    fetchMore: fetchMoreFolders,
+  } = useAlertingFolders({
+    parentUid: folderUid,
+    namespaceFilter,
+  });
+
+  // Check if folder is empty
+  const hasNoContent = isOpen && childFolders.length === 0 && groups.length === 0 && !foldersLoading && !groupsLoading;
 
   return (
     <ListSection
@@ -55,18 +80,54 @@ export function AlertingFolder({ folder }: AlertingFolderProps) {
         </Stack>
       }
       actions={<FolderActionsButton folderUID={folderUid} />}
-      collapsed={true}
+      collapsed={!isOpen}
+      onToggle={() => setIsOpen(!isOpen)}
       pagination={
-        hasMoreGroups ? (
-          <div>
-            <LoadMoreButton loading={isLoading} onClick={fetchMoreGroups} />
-          </div>
+        hasMoreFolders || hasMoreGroups ? (
+          <Stack direction="column" gap={1}>
+            {hasMoreFolders && (
+              <div>
+                <LoadMoreButton loading={foldersLoading} onClick={fetchMoreFolders} />
+              </div>
+            )}
+            {hasMoreGroups && (
+              <div>
+                <LoadMoreButton loading={groupsLoading} onClick={fetchMoreGroups} />
+              </div>
+            )}
+          </Stack>
         ) : null
       }
     >
-      {error && (
+      {/* Render child folders first (recursive) */}
+      {childFolders.map((childFolder) => (
+        <AlertingFolder
+          key={childFolder.uid}
+          folder={childFolder}
+          groupFilter={groupFilter}
+          namespaceFilter={namespaceFilter}
+        />
+      ))}
+
+      {/* Show folder loading error */}
+      {foldersError && (
         <Text color="error" variant="body">
-          <Trans i18nKey="alerting.folder.failed-to-load-groups">Failed to load groups:</Trans> {error.message}
+          <Trans i18nKey="alerting.folder.failed-to-load-folders">Failed to load child folders:</Trans>{' '}
+          {foldersError.message}
+        </Text>
+      )}
+
+      {/* Show empty folder message */}
+      {hasNoContent && (
+        <Text color="secondary" variant="bodySmall">
+          <Trans i18nKey="alerting.folder.empty">This folder contains no alert groups or subfolders</Trans>
+        </Text>
+      )}
+
+      {/* Render alert groups */}
+      {groupsError && (
+        <Text color="error" variant="body">
+          <Trans i18nKey="alerting.folder.failed-to-load-groups">Failed to load groups:</Trans> {groupsError.message}
         </Text>
       )}
       {groups.map((group) => (
@@ -80,12 +141,12 @@ export function AlertingFolder({ folder }: AlertingFolderProps) {
   );
 }
 
-interface GrafanaRuleGroupListItemProps {
+export interface GrafanaRuleGroupListItemProps {
   group: GrafanaPromRuleGroupDTO;
   namespaceName: string;
 }
 
-function GrafanaRuleGroupListItem({ group, namespaceName }: GrafanaRuleGroupListItemProps) {
+export function GrafanaRuleGroupListItem({ group, namespaceName }: GrafanaRuleGroupListItemProps) {
   const groupIdentifier: GrafanaRuleGroupIdentifier = useMemo(
     () => ({
       groupName: group.name,

--- a/public/app/features/alerting/unified/rule-list/components/AlertingFolder.tsx
+++ b/public/app/features/alerting/unified/rule-list/components/AlertingFolder.tsx
@@ -1,24 +1,24 @@
-import { useMemo, useRef, useState } from 'react';
+import { css } from '@emotion/css';
+import { useMemo, useState } from 'react';
 
+import { GrafanaTheme2 } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
-import { Icon, Stack, Text } from '@grafana/ui';
+import { config } from '@grafana/runtime';
+import { Icon, Stack, Text, useStyles2 } from '@grafana/ui';
+import { useGetFolderParentsQuery } from 'app/api/clients/folder/v1beta1';
+import { Breadcrumbs } from 'app/core/components/Breadcrumbs/Breadcrumbs';
+import { Breadcrumb } from 'app/core/components/Breadcrumbs/types';
+import kbn from 'app/core/utils/kbn';
 import { DashboardQueryResult } from 'app/features/search/service/types';
-import { GrafanaRuleGroupIdentifier } from 'app/types/unified-alerting';
-import { GrafanaPromRuleGroupDTO } from 'app/types/unified-alerting-dto';
 
 import { FolderActionsButton } from '../../components/folder-actions/FolderActionsButton';
-import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
-import { groups } from '../../utils/navigation';
-import { GrafanaGroupLoader } from '../GrafanaGroupLoader';
 import { useAlertingFolders } from '../hooks/useAlertingFolders';
-import { toIndividualGroups, useFolderGroupsGenerator } from '../hooks/useFolderGroups';
-import { useLazyLoadPrometheusGroups } from '../hooks/useLazyLoadPrometheusGroups';
-import { FRONTED_GROUPED_PAGE_SIZE, getApiGroupPageSize } from '../paginationLimits';
+import { useFolderRulesPagination } from '../hooks/useFolderRulesPagination';
 
-import { GroupIntervalIndicator } from './GroupIntervalMetadata';
-import { ListGroup } from './ListGroup';
+import { FolderRuleListItem } from './FolderRuleListItem';
 import { ListSection } from './ListSection';
 import { LoadMoreButton } from './LoadMoreButton';
+import { RuleGroupContainer } from './RuleGroupContainer';
 
 interface AlertingFolderProps {
   folder: DashboardQueryResult;
@@ -27,31 +27,64 @@ interface AlertingFolderProps {
 }
 
 /**
+ * Builds a folder URL from UID and title
+ * Mimics backend logic for folder URL generation
+ */
+function getFolderUrl(uid: string, title: string): string {
+  const slug = kbn.slugifyForUrl(title);
+  return `${config.appSubUrl}/dashboards/f/${uid}/${slug}`;
+}
+
+/**
  * Component that renders a single folder containing alert rules.
  * Supports nested folders - child folders are loaded lazily when the folder is expanded.
- * Groups are also loaded lazily when the folder is expanded.
+ * Rules are displayed in lightweight group containers with folder-level pagination.
  */
 export function AlertingFolder({ folder, groupFilter, namespaceFilter }: AlertingFolderProps) {
   const folderUid = folder.uid;
   const folderName = folder.name;
+  const styles = useStyles2(getStyles);
 
   // Local state for collapse/expand
   const [isOpen, setIsOpen] = useState(false);
 
-  const apiGroupPageSize = getApiGroupPageSize(false);
+  // Fetch parent data (will use prefetched cache from useAlertingFolders)
+  const { data: parentsData, isLoading: parentsLoading } = useGetFolderParentsQuery({ name: folderUid });
 
-  // Generator for fetching groups in this folder
-  const folderGroupsGenerator = useFolderGroupsGenerator(folderUid, 0);
+  // Transform parent data to breadcrumbs
+  const breadcrumbs = useMemo((): Breadcrumb[] => {
+    const items = parentsData?.items ?? [];
 
-  const groupsGenerator = useRef(toIndividualGroups(folderGroupsGenerator(apiGroupPageSize)));
+    // Convert parents to breadcrumbs (excluding current folder)
+    const parentBreadcrumbs = items
+      .filter((parent) => parent.name !== folderUid)
+      .map((parent) => ({
+        text: parent.title,
+        href: getFolderUrl(parent.name, parent.title),
+      }));
 
+    // Add current folder as last item
+    return [
+      ...parentBreadcrumbs,
+      {
+        text: folderName,
+        href: getFolderUrl(folderUid, folderName),
+      },
+    ];
+  }, [parentsData, folderUid, folderName]);
+
+  // Fetch rules with folder-level pagination
   const {
-    isLoading: groupsLoading,
-    groups,
-    hasMoreGroups,
-    fetchMoreGroups,
-    error: groupsError,
-  } = useLazyLoadPrometheusGroups(groupsGenerator.current, FRONTED_GROUPED_PAGE_SIZE);
+    rulesByGroup,
+    hasMore: hasMoreRules,
+    loadMore: loadMoreRules,
+    isLoading: rulesLoading,
+    error: rulesError,
+    visibleRulesCount,
+  } = useFolderRulesPagination({
+    folderUid,
+    pageSize: 40,
+  });
 
   // Fetch child folders
   const {
@@ -66,7 +99,8 @@ export function AlertingFolder({ folder, groupFilter, namespaceFilter }: Alertin
   });
 
   // Check if folder is empty
-  const hasNoContent = isOpen && childFolders.length === 0 && groups.length === 0 && !foldersLoading && !groupsLoading;
+  const hasNoContent =
+    isOpen && childFolders.length === 0 && visibleRulesCount === 0 && !foldersLoading && !rulesLoading;
 
   return (
     <ListSection
@@ -74,25 +108,35 @@ export function AlertingFolder({ folder, groupFilter, namespaceFilter }: Alertin
       title={
         <Stack direction="row" gap={1} alignItems="center">
           <Icon name="folder" />
-          <Text variant="body" element="h3">
-            {folderName}
-          </Text>
+          <Stack direction="column" gap={0.25}>
+            {/* Folder title */}
+            <Text variant="body" element="h3">
+              {folderName}
+            </Text>
+
+            {/* Breadcrumbs below in smaller font - only if folder has parents */}
+            {breadcrumbs.length > 1 && !parentsLoading && (
+              <div className={styles.breadcrumbsWrapper}>
+                <Breadcrumbs breadcrumbs={breadcrumbs} />
+              </div>
+            )}
+          </Stack>
         </Stack>
       }
       actions={<FolderActionsButton folderUID={folderUid} />}
       collapsed={!isOpen}
       onToggle={() => setIsOpen(!isOpen)}
       pagination={
-        hasMoreFolders || hasMoreGroups ? (
+        hasMoreFolders || hasMoreRules ? (
           <Stack direction="column" gap={1}>
             {hasMoreFolders && (
               <div>
                 <LoadMoreButton loading={foldersLoading} onClick={fetchMoreFolders} />
               </div>
             )}
-            {hasMoreGroups && (
+            {hasMoreRules && (
               <div>
-                <LoadMoreButton loading={groupsLoading} onClick={fetchMoreGroups} />
+                <LoadMoreButton loading={rulesLoading} onClick={loadMoreRules} />
               </div>
             )}
           </Stack>
@@ -124,51 +168,28 @@ export function AlertingFolder({ folder, groupFilter, namespaceFilter }: Alertin
         </Text>
       )}
 
-      {/* Render alert groups */}
-      {groupsError && (
+      {/* Show rules loading error */}
+      {rulesError && (
         <Text color="error" variant="body">
-          <Trans i18nKey="alerting.folder.failed-to-load-groups">Failed to load groups:</Trans> {groupsError.message}
+          <Trans i18nKey="alerting.folder.failed-to-load-groups">Failed to load rules:</Trans> {rulesError.message}
         </Text>
       )}
-      {groups.map((group) => (
-        <GrafanaRuleGroupListItem
-          key={`grafana-ns-${folderUid}-${group.name}`}
-          group={group}
-          namespaceName={folderName}
-        />
+
+      {/* Render rules in lightweight group containers */}
+      {Array.from(rulesByGroup.entries()).map(([groupName, rulesInGroup]) => (
+        <RuleGroupContainer key={groupName} groupName={groupName}>
+          {rulesInGroup.map(({ rule, group }) => (
+            <FolderRuleListItem key={rule.uid} rule={rule} group={group} namespaceName={folderName} />
+          ))}
+        </RuleGroupContainer>
       ))}
     </ListSection>
   );
 }
 
-export interface GrafanaRuleGroupListItemProps {
-  group: GrafanaPromRuleGroupDTO;
-  namespaceName: string;
-}
-
-export function GrafanaRuleGroupListItem({ group, namespaceName }: GrafanaRuleGroupListItemProps) {
-  const groupIdentifier: GrafanaRuleGroupIdentifier = useMemo(
-    () => ({
-      groupName: group.name,
-      namespace: {
-        uid: group.folderUid,
-      },
-      groupOrigin: 'grafana',
-    }),
-    [group.name, group.folderUid]
-  );
-
-  const detailsLink = groups.detailsPageLink(GRAFANA_RULES_SOURCE_NAME, group.folderUid, group.name);
-
-  return (
-    <ListGroup
-      key={group.name}
-      name={group.name}
-      metaRight={<GroupIntervalIndicator seconds={group.interval} />}
-      href={detailsLink}
-      isOpen={false}
-    >
-      <GrafanaGroupLoader groupIdentifier={groupIdentifier} namespaceName={namespaceName} />
-    </ListGroup>
-  );
-}
+const getStyles = (theme: GrafanaTheme2) => ({
+  breadcrumbsWrapper: css({
+    fontSize: theme.typography.bodySmall.fontSize,
+    color: theme.colors.text.secondary,
+  }),
+});

--- a/public/app/features/alerting/unified/rule-list/components/FolderRuleListItem.tsx
+++ b/public/app/features/alerting/unified/rule-list/components/FolderRuleListItem.tsx
@@ -1,0 +1,88 @@
+import { useMemo } from 'react';
+
+import { GrafanaRuleGroupIdentifier } from 'app/types/unified-alerting';
+import { GrafanaPromRuleDTO, GrafanaPromRuleGroupDTO, PromRuleType } from 'app/types/unified-alerting-dto';
+
+import { GRAFANA_RULES_SOURCE_NAME, GrafanaRulesSource } from '../../utils/datasource';
+import { groups } from '../../utils/navigation';
+import { totalFromStats } from '../../utils/ruleStats';
+import { getRulePluginOrigin, prometheusRuleType } from '../../utils/rules';
+import { createRelativeUrl } from '../../utils/url';
+
+import {
+  AlertRuleListItem,
+  RecordingRuleListItem,
+  RuleListItemCommonProps,
+  UnknownRuleListItem,
+} from './AlertRuleListItem';
+import { RuleActionsButtons } from './RuleActionsButtons.V2';
+
+interface FolderRuleListItemProps {
+  rule: GrafanaPromRuleDTO;
+  group: GrafanaPromRuleGroupDTO;
+  namespaceName: string;
+}
+
+/**
+ * Renders a single rule item using pre-fetched data from the group response.
+ * This avoids unnecessary API calls since rules are already included when groups are fetched.
+ */
+export function FolderRuleListItem({ rule, group, namespaceName }: FolderRuleListItemProps) {
+  const { name, uid, labels, provenance } = rule;
+
+  const groupIdentifier: GrafanaRuleGroupIdentifier = useMemo(
+    () => ({
+      groupName: group.name,
+      namespace: {
+        uid: group.folderUid,
+      },
+      groupOrigin: 'grafana',
+    }),
+    [group.name, group.folderUid]
+  );
+
+  const groupUrl = groups.detailsPageLink(
+    GRAFANA_RULES_SOURCE_NAME,
+    groupIdentifier.namespace.uid,
+    groupIdentifier.groupName
+  );
+
+  const commonProps: RuleListItemCommonProps = {
+    name,
+    rulesSource: GrafanaRulesSource,
+    group: groupIdentifier.groupName,
+    groupUrl,
+    namespace: namespaceName,
+    href: createRelativeUrl(`/alerting/grafana/${uid}/view`),
+    health: rule?.health,
+    error: rule?.lastError,
+    labels: labels,
+    isProvisioned: Boolean(provenance),
+    isPaused: rule?.isPaused,
+    application: 'grafana' as const,
+    actions: <RuleActionsButtons promRule={rule} groupIdentifier={groupIdentifier} compact />,
+    querySourceUIDs: rule?.queriedDatasourceUIDs,
+    origin: getRulePluginOrigin(rule),
+  };
+
+  if (prometheusRuleType.grafana.alertingRule(rule)) {
+    const promAlertingRule = rule && rule.type === PromRuleType.Alerting ? rule : undefined;
+    const instancesCount = totalFromStats(promAlertingRule?.totals ?? {});
+
+    return (
+      <AlertRuleListItem
+        {...commonProps}
+        summary={rule.annotations?.summary}
+        state={promAlertingRule?.state}
+        instancesCount={instancesCount}
+        showLocation={false}
+      />
+    );
+  }
+
+  if (prometheusRuleType.grafana.recordingRule(rule)) {
+    return <RecordingRuleListItem {...commonProps} showLocation={false} />;
+  }
+
+  return <UnknownRuleListItem ruleName={name} groupIdentifier={groupIdentifier} ruleDefinition={rule} />;
+}

--- a/public/app/features/alerting/unified/rule-list/components/ListGroup.tsx
+++ b/public/app/features/alerting/unified/rule-list/components/ListGroup.tsx
@@ -30,7 +30,7 @@ export const ListGroup = ({
   const [open, toggle] = useToggle(isOpen);
 
   return (
-    <div className={styles.groupWrapper} role="treeitem" aria-expanded={open} aria-selected="false">
+    <li className={styles.groupWrapper} role="treeitem" aria-expanded={open} aria-selected="false">
       <GroupHeader
         onToggle={() => toggle()}
         isOpen={open}
@@ -45,7 +45,7 @@ export const ListGroup = ({
           {children}
         </div>
       )}
-    </div>
+    </li>
   );
 };
 
@@ -92,19 +92,18 @@ const getStyles = (theme: GrafanaTheme2) => ({
     display: 'flex',
     flexDirection: 'column',
     position: 'relative',
+    listStyle: 'none',
 
     '&:before': {
       content: "''",
       position: 'absolute',
       height: '100%',
-
-      marginLeft: theme.spacing(2.5),
+      left: theme.spacing(-1.5),
       borderLeft: `solid 1px ${theme.colors.border.weak}`,
     },
   }),
   headerWrapper: css({
-    padding: theme.spacing(1),
-    paddingLeft: theme.spacing(4),
+    padding: theme.spacing(1, 1.5),
     position: 'relative',
 
     '&:hover': {
@@ -114,5 +113,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   childrenWrapper: css({
     position: 'relative',
+    paddingLeft: theme.spacing(2),
   }),
 });

--- a/public/app/features/alerting/unified/rule-list/components/ListSection.tsx
+++ b/public/app/features/alerting/unified/rule-list/components/ListSection.tsx
@@ -14,6 +14,7 @@ interface ListSectionProps extends PropsWithChildren {
   collapsed?: boolean;
   actions?: ReactNode;
   pagination?: ReactNode;
+  onToggle?: () => void;
 }
 
 export const ListSection = ({
@@ -22,9 +23,14 @@ export const ListSection = ({
   collapsed = false,
   actions = null,
   pagination = null,
+  onToggle,
 }: ListSectionProps) => {
   const styles = useStyles2(getStyles);
-  const [isCollapsed, toggleCollapsed] = useToggle(collapsed);
+  const [internalCollapsed, internalToggle] = useToggle(collapsed);
+
+  // Use external toggle if provided, otherwise use internal
+  const isCollapsed = onToggle ? collapsed : internalCollapsed;
+  const toggle = onToggle ?? internalToggle;
 
   return (
     <li className={styles.wrapper} role="treeitem" aria-selected="false">
@@ -33,7 +39,7 @@ export const ListSection = ({
           <Stack alignItems="center" gap={0.5}>
             <IconButton
               name={isCollapsed ? 'angle-right' : 'angle-down'}
-              onClick={toggleCollapsed}
+              onClick={toggle}
               aria-label={t('common.collapse', 'Collapse')}
             />
             {title}
@@ -58,38 +64,38 @@ export const ListSection = ({
   );
 };
 
-const getStyles = (theme: GrafanaTheme2) => ({
-  groupItemsWrapper: css({
-    position: 'relative',
-
-    // unfortunately we have to resort to this since we can't overwrite the styles of the list items individually
-    // unless we clone the React Elements and modify className
-    'li[role=treeitem]': {
-      listStyle: 'none',
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    groupItemsWrapper: css({
       position: 'relative',
-      paddingLeft: theme.spacing(6.5),
+      paddingLeft: theme.spacing(2), // Add padding for nested children
 
-      '&:before': {
-        content: "''",
-        position: 'absolute',
-        height: '100%',
+      // Direct children (groups or nested folders)
+      '& > li[role=treeitem]': {
+        listStyle: 'none',
+        position: 'relative',
 
-        marginLeft: theme.spacing(-1.5),
-        marginTop: theme.spacing(-1),
-        borderLeft: `solid 1px ${theme.colors.border.weak}`,
+        '&:before': {
+          content: "''",
+          position: 'absolute',
+          height: '100%',
+          left: theme.spacing(-1.5),
+          marginTop: theme.spacing(-1),
+          borderLeft: `solid 1px ${theme.colors.border.weak}`,
+        },
       },
-    },
-  }),
-  wrapper: css({
-    display: 'flex',
-    flexDirection: 'column',
-  }),
-  sectionTitle: css({
-    padding: theme.spacing(1, 1.5),
+    }),
+    wrapper: css({
+      display: 'flex',
+      flexDirection: 'column',
+    }),
+    sectionTitle: css({
+      padding: theme.spacing(1, 1.5),
 
-    '&:hover': {
-      background: theme.colors.action.hover,
-      borderRadius: theme.shape.radius.default,
-    },
-  }),
-});
+      '&:hover': {
+        background: theme.colors.action.hover,
+        borderRadius: theme.shape.radius.default,
+      },
+    }),
+  };
+};

--- a/public/app/features/alerting/unified/rule-list/components/ListSection.tsx
+++ b/public/app/features/alerting/unified/rule-list/components/ListSection.tsx
@@ -79,7 +79,7 @@ const getStyles = (theme: GrafanaTheme2) => {
           content: "''",
           position: 'absolute',
           height: '100%',
-          left: theme.spacing(-1.5),
+          left: theme.spacing(-0.5), // Align with chevron icon (2 - 2.5 = -0.5)
           marginTop: theme.spacing(-1),
           borderLeft: `solid 1px ${theme.colors.border.weak}`,
         },

--- a/public/app/features/alerting/unified/rule-list/components/RuleGroupContainer.tsx
+++ b/public/app/features/alerting/unified/rule-list/components/RuleGroupContainer.tsx
@@ -18,7 +18,9 @@ export function RuleGroupContainer({ groupName, children }: RuleGroupContainerPr
           {groupName}
         </Text>
       </div>
-      {children}
+      <ul role="group" className={styles.rulesList}>
+        {children}
+      </ul>
     </li>
   );
 }
@@ -53,5 +55,10 @@ const getStyles = (theme: GrafanaTheme2) => ({
     fontSize: theme.typography.bodySmall.fontSize,
     color: theme.colors.text.secondary,
     fontWeight: theme.typography.fontWeightMedium,
+  }),
+  rulesList: css({
+    listStyle: 'none',
+    padding: 0,
+    margin: 0,
   }),
 });

--- a/public/app/features/alerting/unified/rule-list/components/RuleGroupContainer.tsx
+++ b/public/app/features/alerting/unified/rule-list/components/RuleGroupContainer.tsx
@@ -1,0 +1,57 @@
+import { css } from '@emotion/css';
+import { PropsWithChildren } from 'react';
+
+import { GrafanaTheme2 } from '@grafana/data';
+import { Text, useStyles2 } from '@grafana/ui';
+
+interface RuleGroupContainerProps extends PropsWithChildren {
+  groupName: string;
+}
+
+export function RuleGroupContainer({ groupName, children }: RuleGroupContainerProps) {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <li className={styles.container} role="treeitem" aria-selected="false">
+      <div className={styles.groupLabel}>
+        <Text variant="bodySmall" color="secondary">
+          {groupName}
+        </Text>
+      </div>
+      {children}
+    </li>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  container: css({
+    position: 'relative',
+    listStyle: 'none',
+    marginTop: theme.spacing(2),
+    marginBottom: theme.spacing(1),
+    paddingTop: theme.spacing(0.5),
+    paddingBottom: theme.spacing(1),
+    paddingLeft: theme.spacing(1),
+    borderLeft: `1px solid ${theme.colors.border.weak}`,
+    borderTop: `1px solid ${theme.colors.border.weak}`,
+    borderTopLeftRadius: theme.shape.radius.default,
+
+    // Override the tree line from parent - groups shouldn't have the vertical line
+    '&:before': {
+      display: 'none',
+    },
+
+    // Remove margin from last item
+    '&:last-child': {
+      marginBottom: 0,
+    },
+  }),
+  groupLabel: css({
+    position: 'absolute',
+    top: theme.spacing(-1.5),
+    right: 0,
+    fontSize: theme.typography.bodySmall.fontSize,
+    color: theme.colors.text.secondary,
+    fontWeight: theme.typography.fontWeightMedium,
+  }),
+});

--- a/public/app/features/alerting/unified/rule-list/hooks/useAlertingFolders.ts
+++ b/public/app/features/alerting/unified/rule-list/hooks/useAlertingFolders.ts
@@ -1,0 +1,77 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { getGrafanaSearcher } from 'app/features/search/service/searcher';
+import { DashboardQueryResult } from 'app/features/search/service/types';
+
+interface UseAlertingFoldersResult {
+  folders: DashboardQueryResult[];
+  isLoading: boolean;
+  hasMore: boolean;
+  fetchMore: () => void;
+  error?: Error;
+}
+
+const FOLDERS_PAGE_SIZE = 40;
+
+/**
+ * Hook to fetch folders using the search API.
+ * Folders are fetched lazily with pagination support.
+ * Note: This fetches all folders, not just those containing alert rules.
+ * Empty folders will show no groups when expanded.
+ */
+export function useAlertingFolders(): UseAlertingFoldersResult {
+  const [folders, setFolders] = useState<DashboardQueryResult[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [hasMore, setHasMore] = useState(true);
+  const [error, setError] = useState<Error>();
+  const [page, setPage] = useState(0);
+
+  const fetchFolders = useCallback(
+    async (pageToFetch: number) => {
+      if (!hasMore && pageToFetch > 0) {
+        return;
+      }
+
+      setIsLoading(true);
+      setError(undefined);
+
+      try {
+        const searcher = getGrafanaSearcher();
+        const response = await searcher.search({
+          kind: ['folder'],
+          limit: FOLDERS_PAGE_SIZE,
+          from: pageToFetch * FOLDERS_PAGE_SIZE,
+        });
+
+        const newFolders = response.view.toArray();
+        setFolders((prev) => (pageToFetch === 0 ? newFolders : [...prev, ...newFolders]));
+        setHasMore(newFolders.length === FOLDERS_PAGE_SIZE);
+      } catch (err) {
+        setError(err instanceof Error ? err : new Error('Failed to fetch folders'));
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [hasMore]
+  );
+
+  const fetchMore = useCallback(() => {
+    const nextPage = page + 1;
+    setPage(nextPage);
+    fetchFolders(nextPage);
+  }, [page, fetchFolders]);
+
+  // Initial fetch
+  useEffect(() => {
+    fetchFolders(0);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return {
+    folders,
+    isLoading,
+    hasMore,
+    fetchMore,
+    error,
+  };
+}

--- a/public/app/features/alerting/unified/rule-list/hooks/useAlertingFolders.ts
+++ b/public/app/features/alerting/unified/rule-list/hooks/useAlertingFolders.ts
@@ -3,6 +3,11 @@ import { useCallback, useEffect, useState } from 'react';
 import { getGrafanaSearcher } from 'app/features/search/service/searcher';
 import { DashboardQueryResult } from 'app/features/search/service/types';
 
+interface UseAlertingFoldersParams {
+  parentUid?: string;
+  namespaceFilter?: string;
+}
+
 interface UseAlertingFoldersResult {
   folders: DashboardQueryResult[];
   isLoading: boolean;
@@ -16,10 +21,16 @@ const FOLDERS_PAGE_SIZE = 40;
 /**
  * Hook to fetch folders using the search API.
  * Folders are fetched lazily with pagination support.
+ *
+ * @param params - Optional parameters
+ * @param params.parentUid - If provided, fetch child folders of this parent. If undefined, fetch root folders.
+ * @param params.namespaceFilter - If provided, filter folders by name
+ *
  * Note: This fetches all folders, not just those containing alert rules.
  * Empty folders will show no groups when expanded.
  */
-export function useAlertingFolders(): UseAlertingFoldersResult {
+export function useAlertingFolders(params?: UseAlertingFoldersParams): UseAlertingFoldersResult {
+  const { parentUid, namespaceFilter } = params ?? {};
   const [folders, setFolders] = useState<DashboardQueryResult[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [hasMore, setHasMore] = useState(true);
@@ -39,6 +50,8 @@ export function useAlertingFolders(): UseAlertingFoldersResult {
         const searcher = getGrafanaSearcher();
         const response = await searcher.search({
           kind: ['folder'],
+          location: parentUid,
+          query: namespaceFilter,
           limit: FOLDERS_PAGE_SIZE,
           from: pageToFetch * FOLDERS_PAGE_SIZE,
         });
@@ -52,7 +65,7 @@ export function useAlertingFolders(): UseAlertingFoldersResult {
         setIsLoading(false);
       }
     },
-    [hasMore]
+    [hasMore, parentUid, namespaceFilter]
   );
 
   const fetchMore = useCallback(() => {

--- a/public/app/features/alerting/unified/rule-list/hooks/useAlertingFolders.ts
+++ b/public/app/features/alerting/unified/rule-list/hooks/useAlertingFolders.ts
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useState } from 'react';
 
+import { folderAPIv1beta1 } from 'app/api/clients/folder/v1beta1';
 import { getGrafanaSearcher } from 'app/features/search/service/searcher';
 import { DashboardQueryResult } from 'app/features/search/service/types';
+import { useDispatch } from 'app/types/store';
 
 interface UseAlertingFoldersParams {
   parentUid?: string;
@@ -36,6 +38,7 @@ export function useAlertingFolders(params?: UseAlertingFoldersParams): UseAlerti
   const [hasMore, setHasMore] = useState(true);
   const [error, setError] = useState<Error>();
   const [page, setPage] = useState(0);
+  const dispatch = useDispatch();
 
   const fetchFolders = useCallback(
     async (pageToFetch: number) => {
@@ -59,13 +62,18 @@ export function useAlertingFolders(params?: UseAlertingFoldersParams): UseAlerti
         const newFolders = response.view.toArray();
         setFolders((prev) => (pageToFetch === 0 ? newFolders : [...prev, ...newFolders]));
         setHasMore(newFolders.length === FOLDERS_PAGE_SIZE);
+
+        // Prefetch parent data for all loaded folders
+        newFolders.forEach((folder) => {
+          dispatch(folderAPIv1beta1.util.prefetch('getFolderParents', { name: folder.uid }, { force: false }));
+        });
       } catch (err) {
         setError(err instanceof Error ? err : new Error('Failed to fetch folders'));
       } finally {
         setIsLoading(false);
       }
     },
-    [hasMore, parentUid, namespaceFilter]
+    [hasMore, parentUid, namespaceFilter, dispatch]
   );
 
   const fetchMore = useCallback(() => {

--- a/public/app/features/alerting/unified/rule-list/hooks/useFolderGroups.ts
+++ b/public/app/features/alerting/unified/rule-list/hooks/useFolderGroups.ts
@@ -1,0 +1,52 @@
+import { useCallback } from 'react';
+
+import { GrafanaPromRuleGroupDTO } from 'app/types/unified-alerting-dto';
+
+import { PromRulesResponse, prometheusApi } from '../../api/prometheusApi';
+
+const { useLazyGetGrafanaGroupsQuery } = prometheusApi;
+
+/**
+ * Generator that yields groups for a specific folder with pagination support
+ */
+export function useFolderGroupsGenerator(folderUid: string, limitAlerts = 0) {
+  const [getGrafanaGroups] = useLazyGetGrafanaGroupsQuery();
+
+  return useCallback(
+    async function* (groupLimit: number) {
+      const fetchGroups = async (groupNextToken?: string): Promise<PromRulesResponse<GrafanaPromRuleGroupDTO>> => {
+        return getGrafanaGroups({
+          folderUid,
+          groupLimit,
+          limitAlerts,
+          groupNextToken,
+        }).unwrap();
+      };
+
+      let response = await fetchGroups();
+      yield response.data.groups;
+
+      let lastToken = response.data?.groupNextToken;
+
+      while (lastToken) {
+        response = await fetchGroups(lastToken);
+        yield response.data.groups;
+        lastToken = response.data?.groupNextToken;
+      }
+    },
+    [getGrafanaGroups, folderUid, limitAlerts]
+  );
+}
+
+/**
+ * Converts a generator yielding arrays of groups to a generator yielding groups one by one
+ */
+export async function* toIndividualGroups<TGroup>(
+  generator: AsyncGenerator<TGroup[], void, unknown>
+): AsyncGenerator<TGroup, void, unknown> {
+  for await (const batch of generator) {
+    for (const item of batch) {
+      yield item;
+    }
+  }
+}

--- a/public/app/features/alerting/unified/rule-list/hooks/useFolderRulesPagination.ts
+++ b/public/app/features/alerting/unified/rule-list/hooks/useFolderRulesPagination.ts
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { GrafanaPromRuleDTO, GrafanaPromRuleGroupDTO } from 'app/types/unified-alerting-dto';
 
@@ -113,10 +113,13 @@ export function useFolderRulesPagination({
     }
   }, [folderUid, getGrafanaGroups, hasMore, isLoading, pageSize]);
 
-  // Auto-fetch on first render
-  if (!hasFetchedRef.current && !isLoading) {
-    fetchMore();
-  }
+  // Auto-fetch on first render (effect avoids double-invocation under StrictMode)
+  useEffect(() => {
+    if (!hasFetchedRef.current && !isLoading) {
+      fetchMore();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return {
     rulesByGroup,

--- a/public/app/features/alerting/unified/rule-list/hooks/useFolderRulesPagination.ts
+++ b/public/app/features/alerting/unified/rule-list/hooks/useFolderRulesPagination.ts
@@ -1,0 +1,129 @@
+import { useCallback, useMemo, useRef, useState } from 'react';
+
+import { GrafanaPromRuleDTO, GrafanaPromRuleGroupDTO } from 'app/types/unified-alerting-dto';
+
+import { prometheusApi } from '../../api/prometheusApi';
+
+const { useLazyGetGrafanaGroupsQuery } = prometheusApi;
+
+export interface RuleWithGroup {
+  rule: GrafanaPromRuleDTO;
+  group: GrafanaPromRuleGroupDTO;
+}
+
+interface UseFolderRulesPaginationParams {
+  folderUid: string;
+  pageSize?: number;
+}
+
+interface UseFolderRulesPaginationResult {
+  /** Rules currently visible, grouped by their evaluation group */
+  rulesByGroup: Map<string, RuleWithGroup[]>;
+  /** Whether there are more rules to load */
+  hasMore: boolean;
+  /** Load more rules */
+  loadMore: () => void;
+  /** Whether currently loading */
+  isLoading: boolean;
+  /** Error if any */
+  error: Error | undefined;
+  /** Total number of visible rules */
+  visibleRulesCount: number;
+}
+
+const DEFAULT_PAGE_SIZE = 40;
+
+/**
+ * Hook for folder-level rule pagination.
+ *
+ * Uses the `rule_limit` API parameter to fetch groups with a limit on total rules.
+ * When "Load more" is clicked, fetches the next page of rules from the API.
+ *
+ * Note: The API returns full groups, so the actual number of rules may exceed the limit.
+ */
+export function useFolderRulesPagination({
+  folderUid,
+  pageSize = DEFAULT_PAGE_SIZE,
+}: UseFolderRulesPaginationParams): UseFolderRulesPaginationResult {
+  const [getGrafanaGroups] = useLazyGetGrafanaGroupsQuery();
+
+  // Store all fetched groups
+  const [groups, setGroups] = useState<GrafanaPromRuleGroupDTO[]>([]);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | undefined>(undefined);
+  const [hasMore, setHasMore] = useState(true);
+
+  // Track pagination token for API
+  const nextTokenRef = useRef<string | undefined>(undefined);
+
+  // Track if initial fetch has been done
+  const hasFetchedRef = useRef(false);
+
+  // Flatten all rules from all groups with their group reference
+  const allRules: RuleWithGroup[] = useMemo(() => {
+    return groups.flatMap((group) => group.rules.map((rule) => ({ rule, group })));
+  }, [groups]);
+
+  // Group rules by their group name for rendering
+  const rulesByGroup = useMemo(() => {
+    const grouped = new Map<string, RuleWithGroup[]>();
+    for (const item of allRules) {
+      const key = item.group.name;
+      if (!grouped.has(key)) {
+        grouped.set(key, []);
+      }
+      grouped.get(key)!.push(item);
+    }
+    return grouped;
+  }, [allRules]);
+
+  const fetchMore = useCallback(async () => {
+    if (isLoading || (!hasMore && hasFetchedRef.current)) {
+      return;
+    }
+
+    setIsLoading(true);
+    setError(undefined);
+
+    try {
+      const response = await getGrafanaGroups({
+        folderUid,
+        ruleLimit: pageSize,
+        groupNextToken: nextTokenRef.current,
+        limitAlerts: 0, // Don't limit alerts for rule display
+      }).unwrap();
+
+      const newGroups = response.data.groups;
+
+      setGroups((prev) => {
+        // Merge groups - if a group already exists, we might need to update it
+        // (though typically the API returns distinct groups per page)
+        const existingGroupNames = new Set(prev.map((g) => g.name));
+        const uniqueNewGroups = newGroups.filter((g) => !existingGroupNames.has(g.name));
+        return [...prev, ...uniqueNewGroups];
+      });
+
+      nextTokenRef.current = response.data.groupNextToken;
+      setHasMore(Boolean(response.data.groupNextToken));
+      hasFetchedRef.current = true;
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error('Failed to fetch rules'));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [folderUid, getGrafanaGroups, hasMore, isLoading, pageSize]);
+
+  // Auto-fetch on first render
+  if (!hasFetchedRef.current && !isLoading) {
+    fetchMore();
+  }
+
+  return {
+    rulesByGroup,
+    hasMore,
+    loadMore: fetchMore,
+    isLoading,
+    error,
+    visibleRulesCount: allRules.length,
+  };
+}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -1286,6 +1286,9 @@
     "filter-view-results": {
       "aria-label-filteredrulelist": "filtered-rule-list"
     },
+    "folder": {
+      "failed-to-load-groups": "Failed to load groups:"
+    },
     "folder-bulk-actions": {
       "delete": {
         "button": {


### PR DESCRIPTION
## Summary

Proof-of-concept that reshapes the v2 grouped alert rules list so folders (rather than rule groups) are the primary unit, de-emphasizing groups inside collapsible folder containers.

- New folder-based loader: \`PaginatedGrafanaLoader\` now renders \`AlertingFolder\` per folder, fetched via the folder/search API with pagination
- \`AlertingFolder\` is collapsed by default, lazily loads child folders (recursive) and rule pages on expand, and shows breadcrumbs for nested folders
- Rules are rendered inside lightweight \`RuleGroupContainer\` wrappers (one per evaluation group) using the new \`FolderRuleListItem\` (one item per rule, not per group)
- Folder-level rule pagination via \`useFolderRulesPagination\` (uses Prometheus \`rule_limit\` + \`groupNextToken\`)
- Existing \`onLoadingStateChange\` hook into \`useDataSourceLoadingReporter\` is preserved so \`GroupedView\`'s loading-states machinery still works

## Notes

- POC quality: filtering inside folders is not yet wired up (TODO in \`PaginatedFoldersLoader\`)
- Gated by existing \`alertingListViewV2\` feature toggle and the Grouped view-mode selector — no new toggle introduced
- Includes follow-up fixes for: duplicate React keys when rules share UIDs, invalid \`<li>\`-in-\`<li>\` DOM nesting under \`RuleGroupContainer\`, and StrictMode-induced double fetches in \`useFolderRulesPagination\`