### PR TITLE
Docs: Fix malformed hyperlink syntax in contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thank you for your interest in contributing to Grafana! We welcome all people who want to contribute in a healthy and constructive manner within our community. To help us create a safe and positive community experience for all, we require all participants to adhere to the [Code of Conduct](CODE_OF_CONDUCT.md).
 
-This document is a guide to help you through the process of contributing to Grafana. Be sure to check out the [Grafana Champions program]([https://grafana.com/community/champions/?src=github&camp=community-cross-platform-engagement](https://grafana.com/community/champions/) as you start to contribute. It's designed to recognize and empower individuals who are actively contributing to the growth and success of the Grafana ecosystem.
+This document is a guide to help you through the process of contributing to Grafana. Be sure to check out the [Grafana Champions program]([https://grafana.com/community/champions/?src=github&camp=community-cross-platform-engagement](https://grafana.com/community/champions/)) as you start to contribute. It's designed to recognize and empower individuals who are actively contributing to the growth and success of the Grafana ecosystem.
 
 > **Help us improve!** We'd love to hear about your contributor experience. Take a moment to share your feedback in our [Open Source Contributor Experience Survey](https://gra.fan/ome). Your input helps us make contributing to Grafana better for everyone.
 


### PR DESCRIPTION
**What is this feature?**

Noticed a syntax error in the CONTRIBUTING.md where a nested Markdown link was preventing the "Grafana Champions program" link from rendering correctly.

**Why do we need this feature?**

Fixed malformed hyperlink syntax so formatting works.

Also preserved original UTM tracking parameters for community engagement analytics.

**Who is this feature for?**

Contributors for Grafana

**Which issue(s) does this PR fix?**:

n/a

**Special notes for your reviewer:**

Completed an 'audit' for any other broken links and everything came back clean.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
