### PR TITLE
Revert "Scopes: Remove scope_node from URL when using defaultPath"

### DIFF
--- a/public/app/features/scopes/ScopesService.test.ts
+++ b/public/app/features/scopes/ScopesService.test.ts
@@ -534,7 +534,7 @@ describe('ScopesService', () => {
     });
 
     describe('defaultPath support', () => {
-      it('should not write scope_node to URL when defaultPath is available', () => {
+      it('should extract scope_node from defaultPath when available', () => {
         if (!selectorStateSubscription) {
           throw new Error('selectorStateSubscription not set');
         }
@@ -559,12 +559,11 @@ describe('ScopesService', () => {
           }
         );
 
-        // When defaultPath is available, scope_node is redundant (it is re-derived
-        // from defaultPath on load), so the URL param is cleared.
+        // Should use 'correct-node' from defaultPath, not 'old-node' from appliedScopes
         expect(locationService.partial).toHaveBeenCalledWith(
           {
             scopes: ['scope1'],
-            scope_node: null,
+            scope_node: 'correct-node',
             scope_parent: null,
           },
           true
@@ -642,12 +641,10 @@ describe('ScopesService', () => {
         );
       });
 
-      it('should not update URL when only defaultPath changes and scopes are unchanged', () => {
+      it('should detect changes in defaultPath-derived scopeNodeId', () => {
         if (!selectorStateSubscription) {
           throw new Error('selectorStateSubscription not set');
         }
-
-        jest.clearAllMocks();
 
         selectorStateSubscription(
           {
@@ -678,9 +675,15 @@ describe('ScopesService', () => {
           }
         );
 
-        // scope_node is no longer synced when defaultPath is present, so a
-        // defaultPath-only change does not trigger a URL update.
-        expect(locationService.partial).not.toHaveBeenCalled();
+        // Should detect the change in defaultPath-derived scopeNodeId
+        expect(locationService.partial).toHaveBeenCalledWith(
+          {
+            scopes: ['scope1'],
+            scope_node: 'new-node',
+            scope_parent: null,
+          },
+          true
+        );
       });
     });
 
@@ -928,7 +931,7 @@ describe('ScopesService', () => {
       );
     });
 
-    it('should clear scope_node when enabling scopes for a scope with defaultPath', () => {
+    it('should use defaultPath for scope_node when enabling scopes', () => {
       selectorService.state.appliedScopes = [{ scopeId: 'scope1', scopeNodeId: 'old-node' }];
       selectorService.state.scopes = {
         scope1: {
@@ -943,11 +946,10 @@ describe('ScopesService', () => {
 
       service.setEnabled(true);
 
-      // When defaultPath is available, scope_node is redundant and should be
-      // cleared from the URL (passing null removes any stale value).
+      // Should use defaultPath instead of scopeNodeId from appliedScopes
       expect(locationService.partial).toHaveBeenCalledWith(
         expect.objectContaining({
-          scope_node: null,
+          scope_node: 'correct-node-from-defaultPath',
         }),
         true
       );

--- a/public/app/features/scopes/ScopesService.ts
+++ b/public/app/features/scopes/ScopesService.ts
@@ -7,7 +7,6 @@ import { type LocationService, type ScopesContextValue, type ScopesContextValueS
 import { type ScopesDashboardsService } from './dashboards/ScopesDashboardsService';
 import { deserializeFolderPath, serializeFolderPath } from './dashboards/scopeNavgiationUtils';
 import { type ScopesSelectorService } from './selector/ScopesSelectorService';
-import { type ScopesMap, type SelectedScope } from './selector/types';
 
 export interface State {
   enabled: boolean;
@@ -171,8 +170,22 @@ export class ScopesService implements ScopesContextValue {
         const oldScopeNames = prevState.appliedScopes.map((scope) => scope.scopeId);
         const newScopeNames = state.appliedScopes.map((scope) => scope.scopeId);
 
-        const oldScopeNodeId = this.getScopeNodeIdForUrl(prevState.appliedScopes, prevState.scopes);
-        const newScopeNodeId = this.getScopeNodeIdForUrl(state.appliedScopes, state.scopes);
+        // Extract scopeNodeId from defaultPath when available
+        const getScopeNodeId = (appliedScopes: typeof state.appliedScopes, scopes: typeof state.scopes) => {
+          const firstScope = appliedScopes[0];
+          if (!firstScope) {
+            return undefined;
+          }
+          const scope = scopes[firstScope.scopeId];
+          // Prefer defaultPath when available
+          if (scope?.spec.defaultPath && scope.spec.defaultPath.length > 0) {
+            return scope.spec.defaultPath[scope.spec.defaultPath.length - 1];
+          }
+          return firstScope.scopeNodeId;
+        };
+
+        const oldScopeNodeId = getScopeNodeId(prevState.appliedScopes, prevState.scopes);
+        const newScopeNodeId = getScopeNodeId(state.appliedScopes, state.scopes);
 
         const scopesChanged = !isEqual(oldScopeNames, newScopeNames);
         const scopeNodeChanged = oldScopeNodeId !== newScopeNodeId;
@@ -247,12 +260,11 @@ export class ScopesService implements ScopesContextValue {
     if (this.state.enabled !== enabled) {
       this.updateState({ enabled });
       if (enabled) {
-        const { appliedScopes, scopes } = this.selectorService.state;
-        const scopeNodeId = this.getScopeNodeIdForUrl(appliedScopes, scopes);
+        const scopeNodeId = this.getScopeNodeIdForUrl();
         this.locationService.partial(
           {
-            scopes: appliedScopes.map((s) => s.scopeId),
-            scope_node: scopeNodeId ?? null,
+            scopes: this.selectorService.state.appliedScopes.map((s) => s.scopeId),
+            scope_node: scopeNodeId,
             scope_parent: null,
           },
           true
@@ -262,27 +274,25 @@ export class ScopesService implements ScopesContextValue {
   };
 
   /**
-   * Returns the scope node id to sync with the URL, or `undefined` when the
-   * URL should not carry `scope_node` at all.
-   *
-   * We skip writing `scope_node` when the scope has a non-empty `defaultPath`,
-   * since that value is redundant — it is re-derived from `defaultPath` on load
-   * and kept in sync by the selector service. Bookmarked URLs that still carry
-   * `scope_node=...` continue to work via the read path.
+   * Extracts the scopeNodeId for URL syncing, preferring defaultPath when available.
+   * When a scope has defaultPath, that is the source of truth for the node ID.
    * @private
    */
-  private getScopeNodeIdForUrl(appliedScopes: SelectedScope[], scopes: ScopesMap): string | undefined {
-    const firstScope = appliedScopes[0];
+  private getScopeNodeIdForUrl(): string | undefined {
+    const firstScope = this.selectorService.state.appliedScopes[0];
     if (!firstScope) {
       return undefined;
     }
 
-    const scope = scopes[firstScope.scopeId];
+    const scope = this.selectorService.state.scopes[firstScope.scopeId];
 
+    // Prefer scopeNodeId from defaultPath if available (most reliable source)
     if (scope?.spec.defaultPath && scope.spec.defaultPath.length > 0) {
-      return undefined;
+      // Extract scopeNodeId from the last element of defaultPath
+      return scope.spec.defaultPath[scope.spec.defaultPath.length - 1];
     }
 
+    // Fallback to next in priority order: scopeNodeId from appliedScopes
     return firstScope.scopeNodeId;
   }
 


### PR DESCRIPTION
Reverts grafana/grafana#123130 as it broke the selector path resolution https://github.com/grafana/hyperion-planning/issues/609