### PR TITLE
AuthN: Fix overridden Groups on Identity

### DIFF
--- a/pkg/services/authn/authnimpl/sync/user_sync.go
+++ b/pkg/services/authn/authnimpl/sync/user_sync.go
@@ -745,6 +745,8 @@ func syncUserToIdentity(ctx context.Context, usr *user.User, id *authn.Identity)
 }
 
 // syncSignedInUserToIdentity syncs a user to an identity.
+// id.Groups must not be overridden as part of this function as it is used to store group information from the auth module
+// which is needed for role mapping in the case of SAML or for team sync.
 func syncSignedInUserToIdentity(usr *user.SignedInUser, id *authn.Identity) {
 	id.UID = usr.UserUID
 	id.Name = usr.Name
@@ -755,7 +757,6 @@ func syncSignedInUserToIdentity(usr *user.SignedInUser, id *authn.Identity) {
 	id.OrgRoles = map[int64]org.RoleType{id.OrgID: usr.OrgRole}
 	id.HelpFlags1 = usr.HelpFlags1
 	id.TeamIDs = usr.TeamIDs // nolint:staticcheck
-	id.Groups = usr.TeamUIDs
 	id.LastSeenAt = usr.LastSeenAt
 	id.IsDisabled = usr.IsDisabled
 	id.IsGrafanaAdmin = &usr.IsGrafanaAdmin


### PR DESCRIPTION
## Summary

- `syncSignedInUserToIdentity` was overwriting `id.Groups` with `usr.TeamUIDs`, clobbering the group information populated by the auth module (e.g. SAML).
- Removing the assignment preserves the upstream group claims that role mapping and team sync rely on.
- Adds a comment on the function documenting why `id.Groups` must not be overridden here.

Fixing an issue introduced by https://github.com/grafana/grafana/pull/123228.

## Test plan

- [ ] Verify SAML login still maps roles based on group claims
- [ ] Verify team sync continues to function for SAML/LDAP users
- [ ] Backend unit tests in `pkg/services/authn/authnimpl/sync/` pass