### PR TITLE
fix(explore): remove debug console.log left in scanning loop

### DIFF
--- a/public/app/features/explore/state/query.ts
+++ b/public/app/features/explore/state/query.ts
@@ -657,7 +657,6 @@ export const runQueries = createAsyncThunk<void, RunQueriesOptions>(
 
           // Keep scanning for results if this was the last scanning transaction
           if (exploreState!.scanning) {
-            console.log(data.series);
             if (data.state === LoadingState.Done && data.series.length === 0) {
               const range = getShiftedTimeRange(-1, exploreState!.range);
               dispatch(updateTime({ exploreId, absoluteRange: range }));


### PR DESCRIPTION
Closes #123274

Removes `console.log(data.series)` that fires on every query response while Explore is in scanning mode. This is a debug statement that was not removed before merge.

**What changed:** One line deleted from `public/app/features/explore/state/query.ts`.