### PR TITLE
fix(templating): use typeof check in LegacyVariableWrapper.getValue() and remove debug console.log

### DIFF
--- a/public/app/features/templating/LegacyVariableWrapper.ts
+++ b/public/app/features/templating/LegacyVariableWrapper.ts
@@ -13,7 +13,7 @@ export class LegacyVariableWrapper implements FormatVariable {
   getValue(_fieldPath: string): VariableValue {
     let { value } = this.state;
 
-    if (value === 'string' || value === 'number' || value === 'boolean') {
+    if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
       return value;
     }
 
@@ -31,7 +31,6 @@ export class LegacyVariableWrapper implements FormatVariable {
       return text.join(' + ');
     }
 
-    console.log('value', text);
     return String(text);
   }
 }


### PR DESCRIPTION
Closes #123273

Two fixes in `public/app/features/templating/LegacyVariableWrapper.ts`:

1. `getValue()` compared the value itself against the string literals `"string"`, `"number"`, and `"boolean"` instead of using `typeof`. This caused all primitive values to fall through to `String(value)`, corrupting multi-value variable interpolation.

2. Removes `console.log('value', text)` in `getValueText()` that fires in production for non-string, non-array text values.

**Before:** `if (value === 'string' || value === 'number' || value === 'boolean')`
**After:** `if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean')`