### PR TITLE
fix(expressions): end tracing spans per iteration instead of deferring

### DIFF
--- a/pkg/expr/graph.go
+++ b/pkg/expr/graph.go
@@ -147,10 +147,10 @@ func (dp *DataPipeline) execute(c context.Context, now time.Time, s *Service) (m
 			inputRefIDs := node.NeedsVars()
 			span.SetAttributes(attribute.StringSlice("node.inputRefIDs", inputRefIDs))
 		}
-		defer span.End()
 
 		execNode, ok := node.(ExecutableNode)
 		if !ok {
+			span.End()
 			return vars, makeUnexpectedNodeTypeError(node.RefID(), node.NodeType().String())
 		}
 
@@ -160,6 +160,7 @@ func (dp *DataPipeline) execute(c context.Context, now time.Time, s *Service) (m
 		}
 
 		vars[node.RefID()] = res
+		span.End()
 	}
 	return vars, nil
 }


### PR DESCRIPTION
Closes #123419

`defer span.End()` inside the `execute()` loop in `pkg/expr/graph.go` causes all tracing spans to accumulate and close simultaneously when the function returns. Each node's span should end when that node's execution completes, so downstream tracing tools see accurate per-node timing.

**What changed:** Replaced `defer span.End()` with explicit `span.End()` calls at the end of the loop body and before the early return path.

In Go, `defer` executes when the enclosing function returns, not at the end of a loop iteration. This is a common Go gotcha documented in [Effective Go](https://go.dev/doc/effective_go#defer).