### PR TITLE
Alerting: Fix slug in alerting nested folder URL

### DIFF
--- a/public/app/features/alerting/unified/utils/misc.test.ts
+++ b/public/app/features/alerting/unified/utils/misc.test.ts
@@ -108,7 +108,13 @@ describe('create links', () => {
   });
 
   it('should make folder alerts link', () => {
-    expect(makeFolderAlertsLink('abc123', 'my-title')).toBe('/dashboards/f/abc123/my-title/alerting');
+    expect(makeFolderAlertsLink('abc123', 'My Title')).toBe('/dashboards/f/abc123/my-title/alerting');
+  });
+
+  it('should slugify nested folder paths for folder alerts link', () => {
+    expect(makeFolderAlertsLink('abc123', 'MainFolder/Subfolder1')).toBe(
+      '/dashboards/f/abc123/mainfoldersubfolder1/alerting'
+    );
   });
 
   it('should make folder settings link', () => {

--- a/public/app/features/alerting/unified/utils/misc.ts
+++ b/public/app/features/alerting/unified/utils/misc.ts
@@ -7,6 +7,7 @@ import { config, isFetchError } from '@grafana/runtime';
 import { type DataSourceRef } from '@grafana/schema';
 import { contextSrv } from 'app/core/services/context_srv';
 import { getMessageFromError, getRequestConfigFromError, getStatusFromError } from 'app/core/utils/errors';
+import kbn from 'app/core/utils/kbn';
 import { escapePathSeparators } from 'app/features/alerting/unified/utils/rule-id';
 import {
   alertInstanceKey,
@@ -185,7 +186,8 @@ export function makeFolderLink(folderUID: string): string {
 }
 
 export function makeFolderAlertsLink(folderUID: string, title: string): string {
-  return createRelativeUrl(`/dashboards/f/${folderUID}/${title}/alerting`);
+  const slug = kbn.slugifyForUrl(title).replace(/^-+|-+$/g, '') || folderUID;
+  return createRelativeUrl(`/dashboards/f/${folderUID}/${slug}/alerting`);
 }
 
 export function makeFolderSettingsLink(uid: string): string {


### PR DESCRIPTION
Related issue: https://github.com/grafana/support-escalations/issues/21987

Grafana-managed rules in nested dashboard folders expose a namespace file value that includes / (full folder path). The alert rules list linked to /dashboards/f/:uid/:slug/alerting by inserting that string unchanged, which added extra path segments and broke the route (404).

Change: build slug the same way as getFolderUrl: kbn.slugifyForUrl(title), trim edge hyphens, fall back to folderUID if empty, then append /alerting.

Before fix:
<img width="1512" height="902" alt="Kapture 2026-04-27 at 17 23 10" src="https://github.com/user-attachments/assets/f7b6a9b0-a0b0-4835-91c9-b94e53a9e145" />

After fix:
<img width="1510" height="902" alt="Kapture 2026-04-27 at 17 20 52" src="https://github.com/user-attachments/assets/d3122372-4be2-4282-8d07-8bdb398a561e" />
