### PR TITLE
Alerting: Add INFO-level logging for rule evaluation state machine

### DIFF
--- a/pkg/services/ngalert/schedule/alert_rule.go
+++ b/pkg/services/ngalert/schedule/alert_rule.go
@@ -304,7 +304,6 @@ func (a *alertRule) Run() error {
 
 					var needReset bool
 					if a.currentFingerprint != f {
-						logger.Debug("Got a new version of alert rule. Clear up the state", "current_fingerprint", a.currentFingerprint, "fingerprint", f)
 						needReset = true
 					}
 					// We need to reset state if the loop has started and the alert is already paused. It can happen,
@@ -352,7 +351,6 @@ func (a *alertRule) Run() error {
 					// we return nil - so technically, this is meaningless to know whether the evaluation has errors or not.
 					span.End()
 					if err == nil {
-						logger.Debug("Tick processed", "attempt", attempt, "duration", a.clock.Now().Sub(evalStart))
 						return
 					}
 
@@ -369,7 +367,6 @@ func (a *alertRule) Run() error {
 				}
 			}()
 			if ctx.afterEval != nil {
-				logger.Debug("Calling afterEval")
 				ctx.afterEval()
 			}
 		case <-grafanaCtx.Done():
@@ -463,17 +460,16 @@ func (a *alertRule) evaluate(ctx context.Context, e *Evaluation, span trace.Span
 			err = results.Error()
 		}
 
-		logger.Debug("Alert rule evaluated", "error", err, "duration", dur)
 		span.SetStatus(codes.Error, "rule evaluation failed")
 		span.RecordError(err)
 	} else {
-		logger.Debug("Alert rule evaluated", "results", len(results), "duration", dur)
 		span.AddEvent("rule evaluated", trace.WithAttributes(
 			attribute.Int64("results", int64(len(results))),
 		))
 	}
 	start = a.clock.Now()
-	_ = a.stateManager.ProcessEvalResults(
+	var alertsSent int
+	allChanges := a.stateManager.ProcessEvalResults(
 		ctx,
 		e.scheduledAt,
 		e.rule,
@@ -482,13 +478,33 @@ func (a *alertRule) evaluate(ctx context.Context, e *Evaluation, span trace.Span
 		func(ctx context.Context, statesToSend state.StateTransitions) {
 			start := a.clock.Now()
 			alerts := a.send(ctx, logger, statesToSend)
+			alertsSent = len(alerts.PostableAlerts)
 			span.AddEvent("results sent", trace.WithAttributes(
-				attribute.Int64("alerts_sent", int64(len(alerts.PostableAlerts))),
+				attribute.Int64("alerts_sent", int64(alertsSent)),
 			))
 			sendDuration.Observe(a.clock.Now().Sub(start).Seconds())
 		},
 	)
 	processDuration.Observe(a.clock.Now().Sub(start).Seconds())
+
+	stateTransitionCount := 0
+	for _, t := range allChanges {
+		if t.Changed() {
+			stateTransitionCount++
+		}
+	}
+
+	logCtx := []any{
+		"source", "eval",
+		"results", len(results),
+		"duration", dur,
+		"state_transitions", stateTransitionCount,
+		"alerts_sent", alertsSent,
+	}
+	if err != nil {
+		logCtx = append(logCtx, "error", err)
+	}
+	logger.Info("Alert rule evaluation completed", logCtx...)
 
 	return nil
 }
@@ -498,19 +514,34 @@ func (a *alertRule) send(ctx context.Context, logger log.Logger, states state.St
 	alerts := definitions.PostableAlerts{PostableAlerts: make([]models.PostableAlert, 0, len(states))}
 	for _, alertState := range states {
 		alerts.PostableAlerts = append(alerts.PostableAlerts, *state.StateToPostableAlert(alertState, a.appURL, a.featureToggles))
+
+		if alertState.Changed() {
+			status := "firing"
+			if alertState.State.State == eval.Normal {
+				status = "resolved"
+			}
+			logger.Info("Dispatching alert to notifier",
+				"source", "eval",
+				"status", status,
+				"state", state.FormatStateAndReason(alertState.State.State, alertState.StateReason),
+				"labels", alertState.Labels,
+				"starts_at", alertState.StartsAt,
+				"ends_at", alertState.EndsAt,
+			)
+		}
 	}
 
 	if len(alerts.PostableAlerts) > 0 {
-		logger.Debug("Sending transitions to notifier", "transitions", len(alerts.PostableAlerts))
 		a.sender.Send(ctx, a.key.AlertRuleKey, alerts)
 	}
 	return alerts
 }
 
-// sendExpire sends alerts to expire all previously firing alerts in the provided state transitions.
+// expireAndSend sends alerts to expire all previously firing alerts in the provided state transitions.
 func (a *alertRule) expireAndSend(ctx context.Context, states []state.StateTransition) {
 	expiredAlerts := state.FromAlertsStateToStoppedAlert(states, a.appURL, a.clock, a.featureToggles)
 	if len(expiredAlerts.PostableAlerts) > 0 {
+		a.logger.Info("Dispatching expired alerts to notifier", "source", "eval", "count", len(expiredAlerts.PostableAlerts))
 		a.sender.Send(ctx, a.key.AlertRuleKey, expiredAlerts)
 	}
 }

--- a/pkg/services/ngalert/schedule/schedule.go
+++ b/pkg/services/ngalert/schedule/schedule.go
@@ -433,7 +433,12 @@ func (sch *schedule) processTick(ctx context.Context, dispatcherGroup *errgroup.
 func (sch *schedule) runJobFn(next readyToRunItem, prev ...readyToRunItem) func() {
 	return func() {
 		if len(prev) > 0 {
-			sch.log.Debug("Rule evaluation triggered by previous rule", append(next.rule.GetKey().LogContext(), "previousRule", prev[0].rule.UID)...)
+			sch.log.Info("Rule evaluation triggered by previous rule",
+				"source", "eval",
+				"rule_uid", next.rule.UID,
+				"org_id", next.rule.OrgID,
+				"previous_rule", prev[0].rule.UID,
+			)
 		}
 		key := next.rule.GetKey()
 		success, dropped := next.ruleRoutine.Eval(&next.Evaluation)

--- a/pkg/services/ngalert/schedule/sequence.go
+++ b/pkg/services/ngalert/schedule/sequence.go
@@ -97,7 +97,7 @@ func (sch *schedule) buildSequence(groupKey groupKey, groupItems []readyToRunIte
 	for _, item := range groupItems {
 		uids = append(uids, item.rule.UID)
 	}
-	sch.log.Debug("Sequence created", "folder", groupKey.folderTitle, "group", groupKey.groupName, "sequence", strings.Join(uids, "->"))
+	sch.log.Debug("Sequence created", "folder", groupKey.folderTitle, "group", groupKey.groupName, "rules", len(groupItems), "sequence", strings.Join(uids, "->"))
 
 	return sequence(groupItems[0])
 }

--- a/pkg/services/ngalert/state/manager.go
+++ b/pkg/services/ngalert/state/manager.go
@@ -218,8 +218,6 @@ func (st *Manager) Get(orgID int64, alertRuleUID string, stateId data.Fingerprin
 // DeleteStateByRuleUID removes the rule instances from cache and instanceStore.
 func (st *Manager) DeleteStateByRuleUID(ctx context.Context, ruleKey ngModels.AlertRuleKeyWithGroup, reason string) []StateTransition {
 	logger := st.log.FromContext(ctx)
-	logger.Debug("Resetting state of the rule")
-
 	states := st.ForgetStateByRuleUID(ctx, ruleKey)
 
 	if len(states) == 0 {
@@ -258,7 +256,7 @@ func (st *Manager) DeleteStateByRuleUID(ctx context.Context, ruleKey ngModels.Al
 		}
 	}
 
-	logger.Info("Rules state was reset", "states", len(states))
+	logger.Info("Rules state was reset", "reason", reason, "states", len(states))
 
 	return transitions
 }
@@ -341,7 +339,6 @@ func (st *Manager) ProcessEvalResults(
 		}
 	}
 
-	logger.Debug("State manager processing evaluation results", "resultCount", len(results))
 	states := st.setNextStateForRule(ctx, alertRule, results, extraLabels, logger, fn, evaluatedAt)
 
 	missingSeriesStates, staleCount := st.processMissingSeriesStates(logger, evaluatedAt, alertRule, fn)

--- a/pkg/services/ngalert/state/state.go
+++ b/pkg/services/ngalert/state/state.go
@@ -340,25 +340,15 @@ func NewEvaluationValues(m map[string]eval.NumberValueCapture) map[string]float6
 	return result
 }
 
-func resultNormal(state *State, rule *models.AlertRule, result eval.Result, logger log.Logger, reason string) {
+func resultNormal(state *State, rule *models.AlertRule, result eval.Result, reason string) {
 	switch {
 	case state.State == eval.Normal:
-		logger.Debug("Keeping state", "state", state.State)
+		// Already Normal, nothing to do.
 	case state.State == eval.Recovering:
 		// If the previous state is Recovering then check if the KeepFiringFor duration has been observed,
 		// and if so, transition to Normal.
 		if result.EvaluatedAt.Sub(state.StartsAt) >= rule.KeepFiringFor {
 			nextEndsAt := result.EvaluatedAt
-			logger.Debug("Changing state",
-				"previous_state",
-				state.State,
-				"next_state",
-				eval.Normal,
-				"previous_ends_at",
-				state.EndsAt,
-				"next_ends_at",
-				nextEndsAt,
-			)
 			state.SetNormal(reason, nextEndsAt, nextEndsAt)
 		} else {
 			// If the KeepFiringFor duration has not been observed then the state is kept as Recovering.
@@ -372,61 +362,24 @@ func resultNormal(state *State, rule *models.AlertRule, result eval.Result, logg
 		//
 		// EndsAt must be set to a future time for the Alertmanager, the same as for Alerting states.
 		nextEndsAt := nextEndsTime(rule.IntervalSeconds, result.EvaluatedAt)
-		logger.Debug("Changing state",
-			"previous_state",
-			state.State,
-			"next_state",
-			eval.Recovering,
-			"previous_ends_at",
-			state.EndsAt,
-			"next_ends_at",
-			nextEndsAt,
-		)
 		state.SetRecovering(reason, result.EvaluatedAt, nextEndsAt)
 	default:
 		nextEndsAt := result.EvaluatedAt
-		logger.Debug("Changing state",
-			"previous_state",
-			state.State,
-			"next_state",
-			eval.Normal,
-			"previous_ends_at",
-			state.EndsAt,
-			"next_ends_at",
-			nextEndsAt,
-		)
 		// Normal states have the same start and end timestamps
 		state.SetNormal(reason, nextEndsAt, nextEndsAt)
 	}
 }
 
-func resultAlerting(state *State, rule *models.AlertRule, result eval.Result, logger log.Logger, reason string) {
+func resultAlerting(state *State, rule *models.AlertRule, result eval.Result, reason string) {
 	switch state.State {
 	case eval.Alerting:
-		prevEndsAt := state.EndsAt
 		state.Maintain(rule.IntervalSeconds, result.EvaluatedAt)
 		// explicitly clear errors
 		state.Error = nil
-		logger.Debug("Keeping state",
-			"state",
-			state.State,
-			"previous_ends_at",
-			prevEndsAt,
-			"next_ends_at",
-			state.EndsAt)
 	case eval.Pending:
 		// If the previous state is Pending then check if the For duration has been observed
 		if result.EvaluatedAt.Sub(state.StartsAt) >= rule.For {
 			nextEndsAt := nextEndsTime(rule.IntervalSeconds, result.EvaluatedAt)
-			logger.Debug("Changing state",
-				"previous_state",
-				state.State,
-				"next_state",
-				eval.Alerting,
-				"previous_ends_at",
-				state.EndsAt,
-				"next_ends_at",
-				nextEndsAt)
 			state.SetAlerting(reason, result.EvaluatedAt, nextEndsAt)
 		}
 	default:
@@ -434,38 +387,17 @@ func resultAlerting(state *State, rule *models.AlertRule, result eval.Result, lo
 		if state.State != eval.Recovering && rule.For > 0 {
 			// If the alert rule has a For duration that should be observed then the state should be set to Pending.
 			// If the alert is currently in the Recovering state then we skip Pending and set it directly to Alerting.
-			logger.Debug("Changing state",
-				"previous_state",
-				state.State,
-				"next_state",
-				eval.Pending,
-				"previous_ends_at",
-				state.EndsAt,
-				"next_ends_at",
-				nextEndsAt)
 			state.SetPending(reason, result.EvaluatedAt, nextEndsAt)
 		} else {
-			logger.Debug("Changing state",
-				"previous_state",
-				state.State,
-				"next_state",
-				eval.Alerting,
-				"previous_ends_at",
-				state.EndsAt,
-				"next_ends_at",
-				nextEndsAt)
 			state.SetAlerting(reason, result.EvaluatedAt, nextEndsAt)
 		}
 	}
 }
 
-func resultError(state *State, rule *models.AlertRule, result eval.Result, logger log.Logger, ignorePending bool) {
-	handlerStr := "resultError"
-
+func resultError(state *State, rule *models.AlertRule, result eval.Result, ignorePending bool) {
 	switch rule.ExecErrState {
 	case models.AlertingErrState:
-		logger.Debug("Execution error state is Alerting", "handler", "resultAlerting", "previous_handler", handlerStr)
-		resultAlerting(state, rule, result, logger, models.StateReasonError)
+		resultAlerting(state, rule, result, models.StateReasonError)
 		// This is a special case where Alerting and Pending should also have an error and reason
 		state.Error = result.Error
 		state.addErrorInfoToAnnotations(result.Error, rule)
@@ -473,35 +405,27 @@ func resultError(state *State, rule *models.AlertRule, result eval.Result, logge
 		switch state.State {
 		case eval.Error:
 			// Already in Error state, maintain it.
-			prevEndsAt := state.EndsAt
 			state.Error = result.Error
 			state.Maintain(rule.IntervalSeconds, result.EvaluatedAt)
-			logger.Debug("Keeping state", "state", state.State, "previous_ends_at", prevEndsAt, "next_ends_at", state.EndsAt)
-
 		case eval.Pending:
 			if result.EvaluatedAt.Sub(state.StartsAt) >= rule.For {
 				// 'For' duration exceeded. Transition to Error.
 				nextEndsAt := nextEndsTime(rule.IntervalSeconds, result.EvaluatedAt)
-				logger.Debug("Changing state", "previous_state", state.State, "next_state", eval.Error, "previous_ends_at", state.EndsAt, "next_ends_at", nextEndsAt)
 				state.SetError(result.Error, result.EvaluatedAt, nextEndsAt)
 			} else {
 				// Still pending. Maintain and update the Error field.
-				prevEndsAt := state.EndsAt
 				state.Error = result.Error
 				state.Maintain(rule.IntervalSeconds, result.EvaluatedAt)
-				logger.Debug("Keeping state", "state", state.State, "previous_ends_at", prevEndsAt, "next_ends_at", state.EndsAt)
 			}
 		default:
 			// First occurrence of Error.
 			nextEndsAt := nextEndsTime(rule.IntervalSeconds, result.EvaluatedAt)
 			if !ignorePending && state.State != eval.Recovering && rule.For > 0 {
 				// Set to Pending if there's a 'for' duration specified. Skip if Recovering.
-				logger.Debug("Changing state", "previous_state", state.State, "next_state", eval.Pending, "previous_ends_at", state.EndsAt, "next_ends_at", nextEndsAt)
 				state.SetPending(models.StateReasonError, result.EvaluatedAt, nextEndsAt)
 				state.Error = result.Error
 			} else {
 				// No 'for' duration or Recovering. Transition directly to Error.
-				logger.Debug("Changing state", "previous_state", state.State, "next_state", eval.Error, "previous_ends_at", state.EndsAt, "next_ends_at", nextEndsAt)
 				state.SetError(result.Error, result.EvaluatedAt, nextEndsAt)
 			}
 		}
@@ -510,12 +434,10 @@ func resultError(state *State, rule *models.AlertRule, result eval.Result, logge
 			state.Annotations["Error"] = result.Error.Error()
 		}
 	case models.OkErrState:
-		logger.Debug("Execution error state is Normal", "handler", "resultNormal", "previous_handler", handlerStr)
-		resultNormal(state, rule, result, logger, "") // TODO: Should we add a reason?
+		resultNormal(state, rule, result, "") // TODO: Should we add a reason?
 		state.addErrorInfoToAnnotations(result.Error, rule)
 	case models.KeepLastErrState:
-		logger := logger.New("previous_handler", handlerStr)
-		resultKeepLast(state, rule, result, logger)
+		resultKeepLast(state, rule, result)
 		state.addErrorInfoToAnnotations(result.Error, rule)
 	default:
 		err := fmt.Errorf("unsupported execution error state: %s", rule.ExecErrState)
@@ -524,58 +446,40 @@ func resultError(state *State, rule *models.AlertRule, result eval.Result, logge
 	}
 }
 
-func resultNoData(state *State, rule *models.AlertRule, result eval.Result, logger log.Logger, ignorePending bool) {
-	handlerStr := "resultNoData"
-
+func resultNoData(state *State, rule *models.AlertRule, result eval.Result, ignorePending bool) {
 	switch rule.NoDataState {
 	case models.Alerting:
-		logger.Debug("Execution no data state is Alerting", "handler", "resultAlerting", "previous_handler", handlerStr)
-		resultAlerting(state, rule, result, logger, models.StateReasonNoData)
+		resultAlerting(state, rule, result, models.StateReasonNoData)
 	case models.NoData:
 		switch state.State {
 		case eval.NoData:
 			// Already in NoData state. Maintain it.
-			prevEndsAt := state.EndsAt
 			state.Maintain(rule.IntervalSeconds, result.EvaluatedAt)
-			logger.Debug("Keeping state",
-				"state",
-				state.State,
-				"previous_ends_at",
-				prevEndsAt,
-				"next_ends_at",
-				state.EndsAt)
 		case eval.Pending:
 			if result.EvaluatedAt.Sub(state.StartsAt) >= rule.For {
 				// 'For' duration exceeded. Transition to NoData.
 				nextEndsAt := nextEndsTime(rule.IntervalSeconds, result.EvaluatedAt)
-				logger.Debug("Changing state", "previous_state", state.State, "next_state", eval.NoData, "previous_ends_at", state.EndsAt, "next_ends_at", nextEndsAt)
 				state.SetNoData("", result.EvaluatedAt, nextEndsAt)
 			} else {
 				// Still pending, maintain.
-				prevEndsAt := state.EndsAt
 				state.Error = nil
 				state.Maintain(rule.IntervalSeconds, result.EvaluatedAt)
-				logger.Debug("Keeping state", "state", state.State, "previous_ends_at", prevEndsAt, "next_ends_at", state.EndsAt)
 			}
 		default:
 			// First occurrence of NoData.
 			nextEndsAt := nextEndsTime(rule.IntervalSeconds, result.EvaluatedAt)
 			if !ignorePending && state.State != eval.Recovering && rule.For > 0 {
 				// Set to Pending if there's a 'for' duration specified. Skip if Recovering.
-				logger.Debug("Changing state", "previous_state", state.State, "next_state", eval.Pending, "previous_ends_at", state.EndsAt, "next_ends_at", nextEndsAt)
 				state.SetPending(models.StateReasonNoData, result.EvaluatedAt, nextEndsAt)
 			} else {
 				// No 'for' duration or Recovering. Transition directly to NoData.
-				logger.Debug("Changing state", "previous_state", state.State, "next_state", eval.NoData, "previous_ends_at", state.EndsAt, "next_ends_at", nextEndsAt)
 				state.SetNoData("", result.EvaluatedAt, nextEndsAt)
 			}
 		}
 	case models.OK:
-		logger.Debug("Execution no data state is Normal", "handler", "resultNormal", "previous_handler", handlerStr)
-		resultNormal(state, rule, result, logger, models.StateReasonNoData)
+		resultNormal(state, rule, result, models.StateReasonNoData)
 	case models.KeepLast:
-		logger := logger.New("previous_handler", handlerStr)
-		resultKeepLast(state, rule, result, logger)
+		resultKeepLast(state, rule, result)
 	default:
 		err := fmt.Errorf("unsupported no data state: %s", rule.NoDataState)
 		state.SetError(err, state.StartsAt, nextEndsTime(rule.IntervalSeconds, result.EvaluatedAt))
@@ -583,28 +487,23 @@ func resultNoData(state *State, rule *models.AlertRule, result eval.Result, logg
 	}
 }
 
-func resultKeepLast(state *State, rule *models.AlertRule, result eval.Result, logger log.Logger) {
+func resultKeepLast(state *State, rule *models.AlertRule, result eval.Result) {
 	reason := models.ConcatReasons(result.State.String(), models.StateReasonKeepLast)
 
 	switch state.State {
 	case eval.Alerting:
-		logger.Debug("Execution keep last state is Alerting", "handler", "resultAlerting")
-		resultAlerting(state, rule, result, logger, reason)
+		resultAlerting(state, rule, result, reason)
 	case eval.Pending:
 		// respect 'for' setting on rule
 		if result.EvaluatedAt.Sub(state.StartsAt) >= rule.For {
-			logger.Debug("Execution keep last state is Pending", "handler", "resultAlerting")
-			resultAlerting(state, rule, result, logger, reason)
-		} else {
-			logger.Debug("Ignoring set next state to pending")
+			resultAlerting(state, rule, result, reason)
 		}
+		// Otherwise keep Pending (For duration not yet met).
 	case eval.Normal:
-		logger.Debug("Execution keep last state is Normal", "handler", "resultNormal")
-		resultNormal(state, rule, result, logger, reason)
+		resultNormal(state, rule, result, reason)
 	default:
 		// this should not happen, add as failsafe
-		logger.Debug("Reverting invalid state to normal", "handler", "resultNormal")
-		resultNormal(state, rule, result, logger, reason)
+		resultNormal(state, rule, result, reason)
 	}
 }
 
@@ -845,20 +744,15 @@ func (a *State) transition(alertRule *models.AlertRule, result eval.Result, extr
 
 	switch result.State {
 	case eval.Normal:
-		logger.Debug("Setting next state", "handler", "resultNormal")
-		resultNormal(a, alertRule, result, logger, "")
+		resultNormal(a, alertRule, result, "")
 	case eval.Alerting:
-		logger.Debug("Setting next state", "handler", "resultAlerting")
-		resultAlerting(a, alertRule, result, logger, "")
+		resultAlerting(a, alertRule, result, "")
 	case eval.Error:
-		logger.Debug("Setting next state", "handler", "resultError")
-		resultError(a, alertRule, result, logger, ignorePendingForNoDataAndError)
+		resultError(a, alertRule, result, ignorePendingForNoDataAndError)
 	case eval.NoData:
-		logger.Debug("Setting next state", "handler", "resultNoData")
-		resultNoData(a, alertRule, result, logger, ignorePendingForNoDataAndError)
+		resultNoData(a, alertRule, result, ignorePendingForNoDataAndError)
 	case eval.Pending,
 		eval.Recovering: // we do not emit results with these states
-		logger.Debug("Ignoring set next state", "state", result.State)
 	}
 
 	// Set reason iff: result and state are different, reason is not Alerting or Normal
@@ -889,6 +783,15 @@ func (a *State) transition(alertRule *models.AlertRule, result eval.Result, extr
 
 	for key, val := range extraAnnotations {
 		a.Annotations[key] = val
+	}
+
+	if oldState != a.State || oldReason != a.StateReason {
+		logger.Info("State transition",
+			"source", "eval",
+			"result_state", result.State,
+			"previous_state", FormatStateAndReason(oldState, oldReason),
+			"computed_state", FormatStateAndReason(a.State, a.StateReason),
+		)
 	}
 
 	nextState := StateTransition{


### PR DESCRIPTION
**What is this feature?**

Adds structured INFO-level logs to track the ngalert rule evaluation lifecycle. All new logs are tagged with `source="eval"` for easy filtering.

New INFO logs:
- **Evaluation summary** (1 per rule per tick): result count, query duration, state transition count, alerts sent, and error if present
- **State transition** (per instance, only on actual change): `result_state`, `previous_state`, `computed_state` showing the full conversion from evaluation result to state machine output
- **Alert dispatch** (per alert, only on state change): status (firing/resolved), state, labels, starts_at, ends_at
- **Expired alert dispatch**: count of resolved alerts sent on rule deletion/update
- **Chain trigger**: which rule triggered which in a sequential evaluation chain

Also consolidates ~30 DEBUG logs in state handler functions into the single State transition INFO log, which fires after all mutations (reason, resolved, image, annotations) are complete.

Includes `reason` field in the existing "Rules state was reset" INFO log.

**Why do we need this feature?**

With INFO-only logging (the production default), the evaluation state machine was largely invisible. An on-call engineer had no way to trace evaluation flow, state transitions, or Alertmanager dispatch without enabling DEBUG logging, which is too noisy for production.

**Who is this feature for?**

On-call engineers and operators debugging alerting behavior in production.

**Which issue(s) does this PR fix?**:

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.