### PR TITLE
Dashboards: Update display labels for section variables

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
@@ -73,6 +73,7 @@ export class RowItem
 
   public readonly isEditableDashboardElement = true;
   public readonly isDashboardDropTarget = true;
+  public readonly sectionType = 'row' as const;
   public containerRef: React.MutableRefObject<HTMLDivElement | null> = React.createRef<HTMLDivElement>();
   private _filtersSet?: SectionFiltersSet;
 

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
@@ -72,6 +72,7 @@ export class TabItem
 
   public readonly isEditableDashboardElement = true;
   public readonly isDashboardDropTarget = true;
+  public readonly sectionType = 'tab' as const;
   private _filtersSet?: SectionFiltersSet;
 
   public containerRef = React.createRef<HTMLDivElement>();

--- a/public/app/features/dashboard-scene/settings/variables/VariableEditableElement.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariableEditableElement.test.tsx
@@ -11,11 +11,13 @@ import { DashboardEditPaneRenderer } from '../../edit-pane/DashboardEditPaneRend
 import { DashboardScene } from '../../scene/DashboardScene';
 import { AutoGridLayoutManager } from '../../scene/layout-auto-grid/AutoGridLayoutManager';
 import { RowItem } from '../../scene/layout-rows/RowItem';
+import { TabItem } from '../../scene/layout-tabs/TabItem';
 import { DashboardInteractions } from '../../utils/interactions';
 import { activateFullSceneTree } from '../../utils/test-utils';
 
 import { shouldHideControlsMenuOption, VariableEditableElement } from './VariableEditableElement';
 import { VariableTypeChangePane } from './VariableTypeSelectionPane';
+import { getVariableSectionType } from './variableSectionType';
 
 jest.mock('../../utils/interactions', () => ({
   DashboardInteractions: {
@@ -133,6 +135,46 @@ describe('VariableEditableElement', () => {
       const variable = new CustomVariable({ name: 'env', query: 'prod,dev', value: 'prod', text: 'prod' });
 
       expect(shouldHideControlsMenuOption(variable)).toBe(true);
+    });
+  });
+
+  describe('getVariableSectionType', () => {
+    it('returns dashboard for dashboard-level variables', () => {
+      const variable = new CustomVariable({ name: 'env', query: 'prod,dev', value: 'prod', text: 'prod' });
+      const variableSet = new SceneVariableSet({ variables: [variable] });
+
+      new DashboardScene({
+        $variables: variableSet,
+        $timeRange: new SceneTimeRange({ from: 'now-6h', to: 'now' }),
+        body: AutoGridLayoutManager.createEmpty(),
+        isEditing: true,
+      });
+
+      expect(getVariableSectionType(variable)).toBe('dashboard');
+    });
+
+    it('returns row for row-level variables', () => {
+      const variable = new CustomVariable({ name: 'env', query: 'prod,dev', value: 'prod', text: 'prod' });
+      const variableSet = new SceneVariableSet({ variables: [variable] });
+
+      new RowItem({ $variables: variableSet });
+
+      expect(getVariableSectionType(variable)).toBe('row');
+    });
+
+    it('returns tab for tab-level variables', () => {
+      const variable = new CustomVariable({ name: 'env', query: 'prod,dev', value: 'prod', text: 'prod' });
+      const variableSet = new SceneVariableSet({ variables: [variable] });
+
+      new TabItem({ $variables: variableSet });
+
+      expect(getVariableSectionType(variable)).toBe('tab');
+    });
+
+    it('returns dashboard when variable parent is not a SceneVariableSet', () => {
+      const variable = new CustomVariable({ name: 'env', query: 'prod,dev', value: 'prod', text: 'prod' });
+
+      expect(getVariableSectionType(variable)).toBe('dashboard');
     });
   });
 });

--- a/public/app/features/dashboard-scene/settings/variables/VariableEditableElement.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariableEditableElement.tsx
@@ -34,6 +34,7 @@ import { DashboardInteractions } from '../../utils/interactions';
 
 import { openChangeVariableTypePane } from './VariableTypeSelectionPane';
 import { useVariableSelectionOptionsCategory } from './useVariableSelectionOptionsCategory';
+import { getVariableSectionType } from './variableSectionType';
 
 // TODO fix conditional hook usage here...
 function useEditPaneOptions(this: VariableEditableElement, isNewElement: boolean): OptionsPaneCategoryDescriptor[] {
@@ -382,6 +383,7 @@ function VariableDisplayInput({ variable }: VariableInputProps) {
     <VariableDisplaySelect
       display={display}
       type={variable.state.type}
+      sectionType={getVariableSectionType(variable)}
       hideControlsMenuOption={shouldHideControlsMenuOption(variable)}
       onChange={onChange}
     />

--- a/public/app/features/dashboard-scene/settings/variables/VariableEditorForm.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariableEditorForm.tsx
@@ -28,6 +28,7 @@ import {
   isEditableVariableType,
   validateVariableName,
 } from './utils';
+import { getVariableSectionType } from './variableSectionType';
 
 interface VariableEditorFormProps {
   variable: SceneVariable;
@@ -129,7 +130,12 @@ export function VariableEditorForm({ variable, onTypeChange, onGoBack, onDelete 
         width={52}
       />
 
-      <VariableDisplaySelect onChange={onDisplayChange} display={display || defaultVariableModel.hide!} type={type} />
+      <VariableDisplaySelect
+        onChange={onDisplayChange}
+        display={display || defaultVariableModel.hide!}
+        type={type}
+        sectionType={getVariableSectionType(variable)}
+      />
 
       {EditorToRender && <EditorToRender variable={variable} onRunQuery={onRunQuery} />}
 

--- a/public/app/features/dashboard-scene/settings/variables/components/VariableDisplaySelect.test.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/VariableDisplaySelect.test.tsx
@@ -57,6 +57,50 @@ describe('VariableDisplaySelect', () => {
     expect(screen.getByText('Hidden')).toBeInTheDocument();
   });
 
+  it('should render row display labels for row variables', async () => {
+    const onChange = jest.fn();
+    const user = userEvent.setup();
+    render(
+      <VariableDisplaySelect
+        onChange={onChange}
+        display={VariableHide.dontHide}
+        type="query"
+        sectionType="row"
+        hideControlsMenuOption={true}
+      />
+    );
+
+    const combobox = screen.getByRole('combobox');
+    await user.click(combobox);
+
+    expect(await screen.findByText('Top of row')).toBeInTheDocument();
+    expect(screen.getByText('Top of row, label hidden')).toBeInTheDocument();
+    expect(screen.queryByText('Above dashboard')).not.toBeInTheDocument();
+    expect(screen.getByText('Hidden')).toBeInTheDocument();
+  });
+
+  it('should render tab display labels for tab variables', async () => {
+    const onChange = jest.fn();
+    const user = userEvent.setup();
+    render(
+      <VariableDisplaySelect
+        onChange={onChange}
+        display={VariableHide.dontHide}
+        type="query"
+        sectionType="tab"
+        hideControlsMenuOption={true}
+      />
+    );
+
+    const combobox = screen.getByRole('combobox');
+    await user.click(combobox);
+
+    expect(await screen.findByText('Top of tab')).toBeInTheDocument();
+    expect(screen.getByText('Top of tab, label hidden')).toBeInTheDocument();
+    expect(screen.queryByText('Above dashboard')).not.toBeInTheDocument();
+    expect(screen.getByText('Hidden')).toBeInTheDocument();
+  });
+
   it('should call onChange() with the selected value', async () => {
     const onChange = jest.fn();
     const user = userEvent.setup();

--- a/public/app/features/dashboard-scene/settings/variables/components/VariableDisplaySelect.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/VariableDisplaySelect.tsx
@@ -5,10 +5,13 @@ import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { Combobox, Field } from '@grafana/ui';
 
+import { type VariableSectionType } from '../variableSectionType';
+
 interface Props {
   onChange: (option: VariableHide) => void;
   display: VariableHide;
   type: VariableType;
+  sectionType?: VariableSectionType;
   hideControlsMenuOption?: boolean;
   minWidth?: number;
 }
@@ -17,23 +20,23 @@ export function VariableDisplaySelect({
   onChange,
   display,
   type,
+  sectionType = 'dashboard',
   hideControlsMenuOption = false,
   minWidth = 52,
 }: PropsWithChildren<Props>) {
   const displayId = useId();
-  const OPTIONS = useMemo(
-    () => [
+  const OPTIONS = useMemo(() => {
+    const labels = getDisplayLabels(sectionType);
+
+    return [
       {
         value: VariableHide.dontHide,
-        label: t('dashboard-scene.variable-display-select.options.above-dashboard.label', 'Above dashboard'),
+        label: labels.visibleLabel,
       },
       {
         value: VariableHide.hideLabel,
-        label: t('dashboard-scene.variable-display-select.options.hidden-label.label', 'Above dashboard, label hidden'),
-        description: t(
-          'dashboard-scene.variable-display-select.options.hidden-label.description',
-          'Above the dashboard, but without showing the name of variable'
-        ),
+        label: labels.hiddenLabel,
+        description: labels.hiddenLabelDescription,
       },
       ...(!hideControlsMenuOption
         ? [
@@ -55,9 +58,8 @@ export function VariableDisplaySelect({
           'Only visible in edit mode'
         ),
       },
-    ],
-    [hideControlsMenuOption]
-  );
+    ];
+  }, [hideControlsMenuOption, sectionType]);
   const value = useMemo(() => OPTIONS.find((o) => o.value === display)?.value ?? OPTIONS[0].value, [display, OPTIONS]);
 
   // Constant variables don't support display options
@@ -78,4 +80,45 @@ export function VariableDisplaySelect({
       />
     </Field>
   );
+}
+
+function getDisplayLabels(sectionType: VariableSectionType) {
+  switch (sectionType) {
+    case 'row':
+      return {
+        visibleLabel: t('dashboard-scene.variable-display-select.options.top-of-row.label', 'Top of row'),
+        hiddenLabel: t(
+          'dashboard-scene.variable-display-select.options.top-of-row-hidden-label.label',
+          'Top of row, label hidden'
+        ),
+        hiddenLabelDescription: t(
+          'dashboard-scene.variable-display-select.options.top-of-row-hidden-label.description',
+          'Top of row, but without showing the name of variable'
+        ),
+      };
+    case 'tab':
+      return {
+        visibleLabel: t('dashboard-scene.variable-display-select.options.top-of-tab.label', 'Top of tab'),
+        hiddenLabel: t(
+          'dashboard-scene.variable-display-select.options.top-of-tab-hidden-label.label',
+          'Top of tab, label hidden'
+        ),
+        hiddenLabelDescription: t(
+          'dashboard-scene.variable-display-select.options.top-of-tab-hidden-label.description',
+          'Top of tab, but without showing the name of variable'
+        ),
+      };
+    case 'dashboard':
+      return {
+        visibleLabel: t('dashboard-scene.variable-display-select.options.above-dashboard.label', 'Above dashboard'),
+        hiddenLabel: t(
+          'dashboard-scene.variable-display-select.options.hidden-label.label',
+          'Above dashboard, label hidden'
+        ),
+        hiddenLabelDescription: t(
+          'dashboard-scene.variable-display-select.options.hidden-label.description',
+          'Above the dashboard, but without showing the name of variable'
+        ),
+      };
+  }
 }

--- a/public/app/features/dashboard-scene/settings/variables/variableSectionType.ts
+++ b/public/app/features/dashboard-scene/settings/variables/variableSectionType.ts
@@ -1,0 +1,17 @@
+import { type SceneVariable, SceneVariableSet } from '@grafana/scenes';
+
+export type VariableSectionType = 'dashboard' | 'row' | 'tab';
+
+export function getVariableSectionType(variable: SceneVariable): VariableSectionType {
+  const set = variable.parent;
+  if (!(set instanceof SceneVariableSet)) {
+    return 'dashboard';
+  }
+
+  const sectionType = hasSectionType(set.parent) ? set.parent.sectionType : undefined;
+  return sectionType === 'row' || sectionType === 'tab' ? sectionType : 'dashboard';
+}
+
+function hasSectionType(value: unknown): value is { sectionType: unknown } {
+  return typeof value === 'object' && value !== null && 'sectionType' in value;
+}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -7730,6 +7730,20 @@
         "hidden-label": {
           "description": "Above the dashboard, but without showing the name of variable",
           "label": "Above dashboard, label hidden"
+        },
+        "top-of-row": {
+          "label": "Top of row"
+        },
+        "top-of-row-hidden-label": {
+          "description": "Top of row, but without showing the name of variable",
+          "label": "Top of row, label hidden"
+        },
+        "top-of-tab": {
+          "label": "Top of tab"
+        },
+        "top-of-tab-hidden-label": {
+          "description": "Top of tab, but without showing the name of variable",
+          "label": "Top of tab, label hidden"
         }
       }
     },


### PR DESCRIPTION
## Summary
- Updates variable Display labels to reflect dashboard, row, or tab context.
- Adds lightweight row/tab section markers and derives section context without importing row/tab classes into the variable display path.
- Covers row/tab label rendering and section type detection with tests.

## Problem
Row-scoped variables rendered at the top of a row, but the variable editor still described visible variables as "Above dashboard". A previous approach tried to determine row/tab context via direct `RowItem`/`TabItem` class imports and `instanceof` checks, but that introduces new circular dependency paths through the dashboard edit-pane modules.

## Circular dependency context
The initial implementation I tried was to have `VariableDisplaySelect` or `VariableEditableElement` to import `RowItem` and `TabItem`, then do something like `set.parent instanceof RowItem` / `set.parent instanceof TabItem`.

That added a runtime import edge from the variable editor/display path back to the section scene classes. Those section classes already depend on edit-pane code for dashboard edit actions, so the graph becomes cyclic:

```text
VariableDisplaySelect.tsx / VariableEditableElement.tsx
  -> RowItem.tsx or TabItem.tsx
  -> edit-pane/shared.ts
  -> VariableEditableElement.tsx
  -> VariableDisplaySelect.tsx
```

To avoid the new runtime import edge, the PR uses a small marker property on the section owner (`sectionType = 'row' | 'tab'`) and derives context from the variable's owning `SceneVariableSet`. This keeps the scene graph as the source of truth while avoiding duplicated persisted variable state and avoiding new circular imports.

## Solution
- Added `sectionType` markers to `RowItem` and `TabItem`.
- Added `getVariableSectionType()` to derive dashboard/row/tab context from the variable's owning `SceneVariableSet` without importing row/tab classes.
- Updated `VariableDisplaySelect` labels:
  - Dashboard: "Above dashboard"
  - Row: "Top of row"
  - Tab: "Top of tab"
- Threaded the derived section type through both the edit pane and legacy variable editor paths.

Closes https://github.com/grafana/grafana/issues/123557

## Test plan
- [x] Verified locally that row/tab labels appear correctly in the UI.
- [x] `yarn jest --no-watch public/app/features/dashboard-scene/settings/variables/components/VariableDisplaySelect.test.tsx public/app/features/dashboard-scene/settings/variables/VariableEditableElement.test.tsx`
- [x] `yarn eslint <changed TS files> --no-error-on-unmatched-pattern`
- [x] `yarn typecheck`
- [x] `yarn lint:circular` reports 446 circular dependencies, unchanged from baseline.
- [x] `make i18n-extract`