### PR TITLE
Alerting: Surface save and bulk-delete errors to the user

### DIFF
--- a/public/app/features/alerting/unified/components/folder-actions/DeleteModal.test.tsx
+++ b/public/app/features/alerting/unified/components/folder-actions/DeleteModal.test.tsx
@@ -1,0 +1,73 @@
+import { type UserEvent } from '@testing-library/user-event';
+import { render, screen, waitFor } from 'test/test-utils';
+
+import { selectors } from '@grafana/e2e-selectors';
+import { AppNotificationList } from 'app/core/components/AppNotifications/AppNotificationList';
+
+import { DeleteModal, type Props } from './DeleteModal';
+
+const mockTrackSuccess = jest.fn();
+const mockTrackFail = jest.fn();
+jest.mock('../../Analytics', () => ({
+  trackFolderBulkActionsDeleteSuccess: () => mockTrackSuccess(),
+  trackFolderBulkActionsDeleteFail: () => mockTrackFail(),
+}));
+
+const defaultProps: Props = {
+  isOpen: true,
+  folderName: 'My folder',
+  onConfirm: jest.fn(),
+  onDismiss: jest.fn(),
+};
+
+const renderModal = (props: Partial<Props> = {}) => {
+  const view = render(
+    <>
+      <AppNotificationList />
+      <DeleteModal {...defaultProps} {...props} />
+    </>
+  );
+  return view;
+};
+
+const confirmDelete = async (user: UserEvent) => {
+  await user.type(screen.getByTestId(selectors.pages.ConfirmModal.input), 'Delete');
+  await user.click(screen.getByTestId(selectors.pages.ConfirmModal.delete));
+};
+
+describe('DeleteModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows an error notification, dismisses, and tracks failure when onConfirm rejects', async () => {
+    const onConfirm = jest.fn().mockRejectedValue(new Error('cannot delete'));
+    const onDismiss = jest.fn();
+    const { user } = renderModal({ onConfirm, onDismiss });
+
+    await confirmDelete(user);
+
+    expect(await screen.findByText(/Failed to delete folder rules/i)).toBeInTheDocument();
+    expect(await screen.findByText(/cannot delete/i)).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mockTrackFail).toHaveBeenCalledTimes(1);
+    });
+    expect(mockTrackSuccess).not.toHaveBeenCalled();
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it('dismisses and tracks success when onConfirm resolves', async () => {
+    const onConfirm = jest.fn().mockResolvedValue(undefined);
+    const onDismiss = jest.fn();
+    const { user } = renderModal({ onConfirm, onDismiss });
+
+    await confirmDelete(user);
+
+    await waitFor(() => {
+      expect(mockTrackSuccess).toHaveBeenCalledTimes(1);
+    });
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+    expect(mockTrackFail).not.toHaveBeenCalled();
+    expect(screen.queryByText(/Failed to delete folder rules/i)).not.toBeInTheDocument();
+  });
+});

--- a/public/app/features/alerting/unified/components/folder-actions/DeleteModal.tsx
+++ b/public/app/features/alerting/unified/components/folder-actions/DeleteModal.tsx
@@ -2,8 +2,10 @@ import React, { useState } from 'react';
 
 import { Trans, t } from '@grafana/i18n';
 import { ConfirmModal, Space, Text } from '@grafana/ui';
+import { useAppNotification } from 'app/core/copy/appNotification';
 
 import { trackFolderBulkActionsDeleteFail, trackFolderBulkActionsDeleteSuccess } from '../../Analytics';
+import { stringifyErrorLike } from '../../utils/misc';
 
 export interface Props {
   isOpen: boolean;
@@ -14,6 +16,7 @@ export interface Props {
 
 export const DeleteModal = React.memo(({ onConfirm, onDismiss, isOpen, folderName }: Props) => {
   const [isDeleting, setIsDeleting] = useState(false);
+  const notifyApp = useAppNotification();
 
   const onDeleteConfirm = async () => {
     setIsDeleting(true);
@@ -21,8 +24,13 @@ export const DeleteModal = React.memo(({ onConfirm, onDismiss, isOpen, folderNam
       await onConfirm();
       trackFolderBulkActionsDeleteSuccess();
       onDismiss();
-    } catch {
+    } catch (error) {
       trackFolderBulkActionsDeleteFail();
+      notifyApp.error(
+        t('alerting.folder-bulk-actions.delete.error', 'Failed to delete folder rules'),
+        stringifyErrorLike(error)
+      );
+      onDismiss();
     } finally {
       setIsDeleting(false);
     }

--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/AlertRuleForm.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/AlertRuleForm.test.tsx
@@ -1,0 +1,94 @@
+import { HttpResponse } from 'msw';
+import * as React from 'react';
+import { renderRuleEditor, ui } from 'test/helpers/alertingRuleEditor';
+import { clickSelectOption } from 'test/helpers/selectOptionInTest';
+import { screen, waitFor } from 'test/test-utils';
+import { byRole } from 'testing-library-selector';
+
+import { locationService, setPluginLinksHook } from '@grafana/runtime';
+import { contextSrv } from 'app/core/services/context_srv';
+import { setupMswServer } from 'app/features/alerting/unified/mockApi';
+import { PROMETHEUS_DATASOURCE_UID } from 'app/features/alerting/unified/mocks/server/constants';
+import { AccessControlAction } from 'app/types/accessControl';
+
+import { grantUserPermissions, mockDataSource } from '../../../mocks';
+import { grafanaRulerGroup, mockPreviewApiResponse } from '../../../mocks/grafanaRulerApi';
+import { setUpdateGrafanaRulerRuleNamespaceResolver } from '../../../mocks/server/configure';
+import { setupDataSources } from '../../../testSetup/datasources';
+
+jest.mock('app/core/components/AppChrome/AppChromeUpdate', () => ({
+  AppChromeUpdate: ({ actions }: { actions: React.ReactNode }) => <div>{actions}</div>,
+}));
+
+jest.setTimeout(60 * 1000);
+
+const server = setupMswServer();
+
+const dataSources = {
+  default: mockDataSource(
+    {
+      type: 'prometheus',
+      name: 'Prom',
+      uid: PROMETHEUS_DATASOURCE_UID,
+      isDefault: true,
+    },
+    { alerting: true, module: 'core:plugin/prometheus' }
+  ),
+};
+
+setupDataSources(dataSources.default);
+
+setPluginLinksHook(() => ({ links: [], isLoading: false }));
+
+const fillNewGrafanaRule = async (user: ReturnType<typeof renderRuleEditor>['user']) => {
+  await user.type(await ui.inputs.name.find(), 'my new rule');
+  await user.click(await screen.findByRole('button', { name: /select folder/i }));
+  await user.click(await screen.findByLabelText('Folder A'));
+  const groupInput = await ui.inputs.group.find();
+  await user.click(await byRole('combobox').find(groupInput));
+  await clickSelectOption(groupInput, grafanaRulerGroup.name);
+  await user.type(ui.inputs.annotationValue(1).get(), 'some description');
+};
+
+describe('AlertRuleForm submit failure handling', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    contextSrv.isEditor = true;
+    contextSrv.hasEditPermissionInFolders = true;
+    grantUserPermissions([
+      AccessControlAction.AlertingRuleRead,
+      AccessControlAction.AlertingRuleUpdate,
+      AccessControlAction.AlertingRuleDelete,
+      AccessControlAction.AlertingRuleCreate,
+      AccessControlAction.DataSourcesRead,
+      AccessControlAction.DataSourcesWrite,
+      AccessControlAction.DataSourcesCreate,
+      AccessControlAction.FoldersWrite,
+      AccessControlAction.FoldersRead,
+      AccessControlAction.AlertingRuleExternalRead,
+      AccessControlAction.AlertingRuleExternalWrite,
+    ]);
+
+    mockPreviewApiResponse(server, []);
+  });
+
+  it('surfaces a form-level error notification when creating a rule fails and does not redirect', async () => {
+    setUpdateGrafanaRulerRuleNamespaceResolver(async () =>
+      HttpResponse.json({ message: 'boom from the api' }, { status: 500 })
+    );
+    const replaceSpy = jest.spyOn(locationService, 'replace');
+
+    const { user } = renderRuleEditor();
+
+    await fillNewGrafanaRule(user);
+    await user.click(ui.buttons.save.get());
+
+    expect(await screen.findByText(/Failed to save alert rule/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Rule added successfully/i)).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(ui.buttons.save.get()).toBeEnabled();
+    });
+    expect(replaceSpy).not.toHaveBeenCalled();
+  });
+});

--- a/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/AlertRuleForm.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/alert-rule-form/AlertRuleForm.tsx
@@ -52,6 +52,7 @@ import {
   isExpressionQueryInAlert,
 } from '../../../rule-editor/formProcessing';
 import { RuleFormType, type RuleFormValues } from '../../../types/rule-form';
+import { stringifyErrorLike } from '../../../utils/misc';
 import { rulesNav } from '../../../utils/navigation';
 import {
   MANUAL_ROUTING_KEY,
@@ -143,7 +144,6 @@ export const AlertRuleForm = ({ existing, prefill, isManualRestore }: Props) => 
     setConditionErrorMsg(msg);
   };
 
-  // @todo why is error not propagated to form?
   const submit = async (values: RuleFormValues): Promise<void> => {
     const { type, evaluateEvery } = values;
 
@@ -166,37 +166,41 @@ export const AlertRuleForm = ({ existing, prefill, isManualRestore }: Props) => 
 
     const targetRuleGroupIdentifier = getRuleGroupLocationFromFormValues(values);
 
-    let saveResult: RulerGroupUpdatedResponse;
-    // @TODO move this to a hook too to make sure the logic here is tested for regressions?
-    if (!existing) {
-      // when creating a new rule, we save the manual routing setting , and editorSettings.simplifiedQueryEditor to the local storage
-      storeInLocalStorageValues(values);
-      // save the rule to the rule group
-      saveResult = await addRuleToRuleGroup.execute(ruleGroupIdentifier, ruleDefinition, evaluateEvery);
-      // track the new Grafana-managed rule creation in the analytics
-      if (grafanaTypeRule) {
-        const dataQueries = values.queries.filter((query) => !isExpressionQuery(query.model));
-        const expressionQueries = values.queries.filter((query) => isExpressionQueryInAlert(query));
-        trackNewGrafanaAlertRuleFormSavedSuccess({
-          simplifiedQueryEditor: values.editorSettings?.simplifiedQueryEditor ?? false,
-          simplifiedNotificationEditor: values.editorSettings?.simplifiedNotificationEditor ?? false,
-          canBeTransformedToSimpleQuery: areQueriesTransformableToSimpleCondition(dataQueries, expressionQueries),
-        });
-      }
-    } else {
-      // when updating an existing rule
-      const ruleIdentifier = fromRulerRuleAndRuleGroupIdentifier(ruleGroupIdentifier, existing.rule);
-      saveResult = await updateRuleInRuleGroup.execute(
-        ruleGroupIdentifier,
-        ruleIdentifier,
-        ruleDefinition,
-        targetRuleGroupIdentifier,
-        evaluateEvery
-      );
-    }
+    const errorTitle = t('alerting.alert-rule-form.error-title', 'Failed to save alert rule');
 
-    redirectToDetailsPage(ruleDefinition, targetRuleGroupIdentifier, saveResult);
-    return;
+    let saveResult: RulerGroupUpdatedResponse;
+    try {
+      if (!existing) {
+        // when creating a new rule, we save the manual routing setting , and editorSettings.simplifiedQueryEditor to the local storage
+        storeInLocalStorageValues(values);
+        // save the rule to the rule group
+        saveResult = await addRuleToRuleGroup.execute(ruleGroupIdentifier, ruleDefinition, evaluateEvery);
+        // track the new Grafana-managed rule creation in the analytics
+        if (grafanaTypeRule) {
+          const dataQueries = values.queries.filter((query) => !isExpressionQuery(query.model));
+          const expressionQueries = values.queries.filter((query) => isExpressionQueryInAlert(query));
+          trackNewGrafanaAlertRuleFormSavedSuccess({
+            simplifiedQueryEditor: values.editorSettings?.simplifiedQueryEditor ?? false,
+            simplifiedNotificationEditor: values.editorSettings?.simplifiedNotificationEditor ?? false,
+            canBeTransformedToSimpleQuery: areQueriesTransformableToSimpleCondition(dataQueries, expressionQueries),
+          });
+        }
+      } else {
+        // when updating an existing rule
+        const ruleIdentifier = fromRulerRuleAndRuleGroupIdentifier(ruleGroupIdentifier, existing.rule);
+        saveResult = await updateRuleInRuleGroup.execute(
+          ruleGroupIdentifier,
+          ruleIdentifier,
+          ruleDefinition,
+          targetRuleGroupIdentifier,
+          evaluateEvery
+        );
+      }
+
+      redirectToDetailsPage(ruleDefinition, targetRuleGroupIdentifier, saveResult);
+    } catch (err) {
+      notifyApp.error(errorTitle, stringifyErrorLike(err));
+    }
   };
 
   const onInvalid: SubmitErrorHandler<RuleFormValues> = (errors): void => {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -514,7 +514,8 @@
       "action-buttons": {
         "edit-yaml": "Edit YAML",
         "save": "Save"
-      }
+      },
+      "error-title": "Failed to save alert rule"
     },
     "alert-rule-name-and-metric": {
       "aria-label-name": "name",
@@ -1290,7 +1291,8 @@
       "delete": {
         "button": {
           "label": "Delete all rules"
-        }
+        },
+        "error": "Failed to delete folder rules"
       },
       "delete-modal-confirmation-text": "Delete",
       "delete-modal-delete-button": "Delete",


### PR DESCRIPTION
**Changes**

Two operations (rule create/update, folder delete) were silently swallowing errors:

  - **AlertRuleForm**: the submit method awaited the upsert hooks but never validated the result. With useAsync swallowing rejections, a failed save produced no toast and the form fell through to a silent logWarning. 
    - **Fix**: The submit body is now wrapped in try/catch and a "Failed to save alert rule" notification is surfaced via getMessageFromError before returning early, so redirectToDetailsPage only runs on a real response.

  - **DeleteModal**: The catch block called only `trackFolderBulkActionsDeleteFail`, so the modal stayed open with no error UI after a failed bulk delete. 
    - **Fix**: It now surfaces a notifyApp.error and dismisses the modal, following the PauseUnpauseActionMenuItem precedent in the same folder.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
