### PR TITLE
QueryHistory: propagate insert errors from QueryHistoryDetails

### DIFF
--- a/pkg/services/queryhistory/database.go
+++ b/pkg/services/queryhistory/database.go
@@ -51,10 +51,15 @@ func (s QueryHistoryService) createQuery(ctx context.Context, user *user.SignedI
 
 		err = s.store.WithDbSession(ctx, func(session *db.Session) error {
 			for _, queryHistoryDetailsItem := range queryHistoryDetailsItems {
-				_, err = session.Insert(queryHistoryDetailsItem)
+				if _, insertErr := session.Insert(queryHistoryDetailsItem); insertErr != nil {
+					return insertErr
+				}
 			}
 			return nil
 		})
+		if err != nil {
+			return QueryHistoryDTO{}, err
+		}
 	}
 
 	dto := QueryHistoryDTO{


### PR DESCRIPTION
## What is this PR about?

Fixes silent data loss in Explore query history. The `createQuery` function in `pkg/services/queryhistory/database.go` has two bugs:

1. **The `WithDbSession` callback always returns `nil`**, discarding any `session.Insert` errors for `QueryHistoryDetails` rows.
2. **The error from `WithDbSession` is assigned but never checked** before the function returns success.

The result: database failures during detail inserts (constraint violations, connection errors, etc.) are invisible. Affected queries appear in query history but are missing from `query_history_details`, so they can't be filtered by datasource in the Explore UI.

## Changes

In `pkg/services/queryhistory/database.go`, `createQuery` function:

- Return insert errors from the session callback on first failure (using a distinct `insertErr` to avoid shadowing the outer `err`)
- Check the `WithDbSession` error and return early if details insert failed

This matches the error handling pattern used throughout the rest of the file (e.g., `searchQueries`, `deleteQuery`, `patchQueryComment`).

Closes #123331