### PR TITLE
Alerting: Support AWS and Azure Managed Prometheus datasource types in rule converter

### DIFF
--- a/pkg/services/ngalert/prom/convert.go
+++ b/pkg/services/ngalert/prom/convert.go
@@ -28,7 +28,7 @@ const (
 var (
 	ErrInvalidDatasourceType = errutil.ValidationFailed(
 		"alerting.invalidDatasourceType",
-		errutil.WithPublicMessage("Datasource type must be Prometheus or Loki to import rules."),
+		errutil.WithPublicMessage("Datasource type must be Prometheus, Loki, AWS Managed Prometheus, or Azure Managed Prometheus to import rules."),
 	)
 	ErrInvalidTargetDatasourceType = errutil.ValidationFailed(
 		"alerting.invalidTargetDatasourceType",
@@ -118,8 +118,18 @@ func NewConverter(cfg Config) (*Converter, error) {
 	if cfg.KeepOriginalRuleDefinition == nil {
 		cfg.KeepOriginalRuleDefinition = defaultConfig.KeepOriginalRuleDefinition
 	}
-	if cfg.DatasourceType != datasources.DS_PROMETHEUS && cfg.DatasourceType != datasources.DS_LOKI {
-		return nil, ErrInvalidDatasourceType.Errorf("invalid datasource type: %s, must be prometheus or loki", cfg.DatasourceType)
+	switch cfg.DatasourceType {
+	case datasources.DS_PROMETHEUS, datasources.DS_LOKI, datasources.DS_AMAZON_PROMETHEUS, datasources.DS_AZURE_PROMETHEUS:
+		// supported
+	default:
+		return nil, ErrInvalidDatasourceType.Errorf(
+			"invalid datasource type: %s, must be one of %s, %s, %s, or %s",
+			cfg.DatasourceType,
+			datasources.DS_PROMETHEUS,
+			datasources.DS_LOKI,
+			datasources.DS_AMAZON_PROMETHEUS,
+			datasources.DS_AZURE_PROMETHEUS,
+		)
 	}
 
 	return &Converter{

--- a/pkg/services/ngalert/prom/convert_test.go
+++ b/pkg/services/ngalert/prom/convert_test.go
@@ -19,6 +19,36 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 )
 
+func TestNewConverter_DatasourceTypeValidation(t *testing.T) {
+	base := Config{
+		DatasourceUID:   "uid",
+		DefaultInterval: 2 * time.Minute,
+	}
+
+	t.Run("accepts prometheus, loki, and managed prometheus types", func(t *testing.T) {
+		for _, dsType := range []string{
+			datasources.DS_PROMETHEUS,
+			datasources.DS_LOKI,
+			datasources.DS_AMAZON_PROMETHEUS,
+			datasources.DS_AZURE_PROMETHEUS,
+		} {
+			cfg := base
+			cfg.DatasourceType = dsType
+			_, err := NewConverter(cfg)
+			require.NoError(t, err, "datasource type %q should be accepted", dsType)
+		}
+	})
+
+	t.Run("rejects unsupported datasource type", func(t *testing.T) {
+		cfg := base
+		cfg.DatasourceType = datasources.DS_GRAPHITE
+		_, err := NewConverter(cfg)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid datasource type")
+		require.Contains(t, err.Error(), datasources.DS_GRAPHITE)
+	})
+}
+
 func TestPrometheusRulesToGrafana(t *testing.T) {
 	defaultInterval := 2 * time.Minute
 


### PR DESCRIPTION
<!--
Thanks for sending a PR! Filling in the boilerplate so reviewers have what they need.
-->

## What this PR does / why we need it

The Prometheus → Grafana alert rule converter currently rejects AWS Managed Prometheus (`grafana-amazonprometheus-datasource`) and Azure Managed Prometheus (`grafana-azureprometheus-datasource`) datasources, even though both expose the same Prometheus-compatible rule format as the native `prometheus` datasource type. Importing rules from a managed Prometheus datasource fails with:

```
[alerting.invalidDatasourceType] invalid datasource type: grafana-amazonprometheus-datasource, must be prometheus or loki
```

This PR extends the validation allowlist in `NewConverter` to accept both managed Prometheus datasource types.

The two constants (`DS_AMAZON_PROMETHEUS`, `DS_AZURE_PROMETHEUS`) already exist in `pkg/services/datasources/models.go`, so no new constants are introduced — only the converter's allowlist is extended. The validation is reshaped from an `if`-chain into a `switch` so adding further Prometheus-compatible datasource types in the future is a one-line change.

## Which issue(s) this PR fixes

Fixes #123144

## Special notes for your reviewer

- Added `TestNewConverter_DatasourceTypeValidation` covering all four accepted datasource types plus an unsupported-type rejection case. This was previously not covered by a dedicated unit test (the validation was only exercised indirectly via `TestPrometheusRulesToGrafana` setting `DS_PROMETHEUS`).
- Updated the public error message and the developer-facing error to enumerate all four accepted types.

## Does this PR introduce a user-facing change?

```release-note
Alerting: data-source-managed → Grafana-managed alert rule import now supports AWS Managed Prometheus and Azure Managed Prometheus datasources in addition to native Prometheus and Loki.
```

/area alerting
