### PR TITLE
Plugins: add docsPath to plugin.json schema

### DIFF
--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -249,6 +249,10 @@
       "type": "string",
       "description": "Plugin category used on the Add new connection page. Can be one from the list: \"tsdb\", \"logging\", \"cloud\", \"tracing\", \"profiling\", \"sql\", \"enterprise\", \"iot\", \"other\", empty string or custom string"
     },
+    "docsPath": {
+      "type": "string",
+      "description": "Path to the directory containing plugin documentation."
+    },
     "enterpriseFeatures": {
       "type": "object",
       "description": "Grafana Enterprise specific features",


### PR DESCRIPTION
**What is this feature?**

Adds `docsPath` as an allowed property in the plugin.json JSON schema.

**Why do we need this feature?**

The field is already implemented in the GCOM API, plugin-validator and TypeScript types but was missing from the schema, causing uploads to fail with "data must NOT have additional properties".

**Who is this feature for?**

Plugin authors who want to enable multi-page documentation on their plugin's catalog page.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.