### PR TITLE
Folder: Wrap validation errors in metav1.Status

### DIFF
--- a/pkg/api/apierrors/folder.go
+++ b/pkg/api/apierrors/folder.go
@@ -10,11 +10,19 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/grafana/grafana/pkg/api/response"
+	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/dashboards/dashboardaccess"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/util"
 )
+
+// stableFolderErrSentinels are folder errors whose legacy /api/folders message are kept stable.
+var stableFolderErrSentinels = []error{
+	folder.ErrTitleEmpty,
+	folder.ErrInvalidUID,
+	folder.ErrFolderCannotBeParentOfItself,
+}
 
 // ToFolderErrorResponse returns a different response status according to the folder error type
 func ToFolderErrorResponse(err error) response.Response {
@@ -32,6 +40,14 @@ func ToFolderErrorResponse(err error) response.Response {
 		errors.Is(err, folder.ErrFolderCannotBeParentOfItself) ||
 		errors.Is(err, folder.ErrMaximumDepthReached) ||
 		errors.Is(err, folder.ErrInvalidUID) {
+		var grafanaErr errutil.Error
+		if errors.As(err, &grafanaErr) {
+			for _, s := range stableFolderErrSentinels {
+				if errors.Is(err, s) {
+					return response.Error(http.StatusBadRequest, s.Error(), nil)
+				}
+			}
+		}
 		return response.Error(http.StatusBadRequest, err.Error(), nil)
 	}
 

--- a/pkg/api/apierrors/folder.go
+++ b/pkg/api/apierrors/folder.go
@@ -30,7 +30,8 @@ func ToFolderErrorResponse(err error) response.Response {
 		errors.Is(err, dashboards.ErrDashboardInvalidUid) ||
 		errors.Is(err, dashboards.ErrDashboardUidTooLong) ||
 		errors.Is(err, folder.ErrFolderCannotBeParentOfItself) ||
-		errors.Is(err, folder.ErrMaximumDepthReached) {
+		errors.Is(err, folder.ErrMaximumDepthReached) ||
+		errors.Is(err, folder.ErrInvalidUID) {
 		return response.Error(http.StatusBadRequest, err.Error(), nil)
 	}
 

--- a/pkg/api/apierrors/folder_test.go
+++ b/pkg/api/apierrors/folder_test.go
@@ -59,6 +59,13 @@ func TestToFolderErrorResponse(t *testing.T) {
 			want:  response.Error(http.StatusBadRequest, "folder title cannot be empty", nil),
 		},
 		{
+			// Apiserver-wrapped form. errors.Is matches via Unwrap so it
+			// routes to the same 400 branch; message has the errutil prefix.
+			name:  "folder title empty (apiserver wrapped)",
+			input: folder.ErrAPITitleEmpty,
+			want:  response.Error(http.StatusBadRequest, folder.ErrAPITitleEmpty.Error(), nil),
+		},
+		{
 			name:  "dashboard type mismatch",
 			input: dashboards.ErrDashboardTypeMismatch,
 			want:  response.Error(http.StatusBadRequest, "Dashboard cannot be changed to a folder", dashboards.ErrDashboardTypeMismatch),
@@ -75,8 +82,8 @@ func TestToFolderErrorResponse(t *testing.T) {
 		},
 		{
 			name:  "folder cannot be parent of itself",
-			input: folder.ErrFolderCannotBeParentOfItself,
-			want:  response.Error(http.StatusBadRequest, folder.ErrFolderCannotBeParentOfItself.Error(), nil),
+			input: folder.ErrFolderCannotBeParentOfItself.Errorf("folder cannot be parent of itself"),
+			want:  response.Error(http.StatusBadRequest, "[folder.cannot-be-parent-of-itself] folder cannot be parent of itself", nil),
 		},
 		// --- 403 Forbidden ---
 		{
@@ -204,6 +211,24 @@ func TestToFolderErrorResponse(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			resp := ToFolderErrorResponse(tt.input)
 			require.Equal(t, tt.want, resp)
+		})
+	}
+}
+
+// TestErrorsIs_UnwrapsAPIWrappers tests that errors.Is matches the legacy sentinel via
+// the Unwrap chain.
+func TestErrorsIs_UnwrapsAPIWrappers(t *testing.T) {
+	cases := []struct {
+		name    string
+		wrapped error
+		legacy  error
+	}{
+		{"title empty", folder.ErrAPITitleEmpty, folder.ErrTitleEmpty},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			require.True(t, errors.Is(c.wrapped, c.legacy),
+				"errors.Is must walk Unwrap to match the legacy sentinel; got %v", c.wrapped)
 		})
 	}
 }

--- a/pkg/api/apierrors/folder_test.go
+++ b/pkg/api/apierrors/folder_test.go
@@ -2,6 +2,7 @@ package apierrors
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -59,11 +60,9 @@ func TestToFolderErrorResponse(t *testing.T) {
 			want:  response.Error(http.StatusBadRequest, "folder title cannot be empty", nil),
 		},
 		{
-			// Apiserver-wrapped form. errors.Is matches via Unwrap so it
-			// routes to the same 400 branch; message has the errutil prefix.
 			name:  "folder title empty (apiserver wrapped)",
 			input: folder.ErrAPITitleEmpty,
-			want:  response.Error(http.StatusBadRequest, folder.ErrAPITitleEmpty.Error(), nil),
+			want:  response.Error(http.StatusBadRequest, "folder title cannot be empty", nil),
 		},
 		{
 			name:  "dashboard type mismatch",
@@ -82,8 +81,29 @@ func TestToFolderErrorResponse(t *testing.T) {
 		},
 		{
 			name:  "folder cannot be parent of itself",
-			input: folder.ErrFolderCannotBeParentOfItself.Errorf("folder cannot be parent of itself"),
-			want:  response.Error(http.StatusBadRequest, "[folder.cannot-be-parent-of-itself] folder cannot be parent of itself", nil),
+			input: folder.ErrFolderCannotBeParentOfItself,
+			want:  response.Error(http.StatusBadRequest, "folder cannot be parent of itself", nil),
+		},
+		{
+			name:  "folder cannot be parent of itself (apiserver wrapped)",
+			input: folder.ErrAPIFolderCannotBeParentOfItself,
+			want:  response.Error(http.StatusBadRequest, "folder cannot be parent of itself", nil),
+		},
+		{
+			name:  "invalid uid",
+			input: folder.ErrInvalidUID,
+			want:  response.Error(http.StatusBadRequest, "invalid uid for folder provided", nil),
+		},
+		{
+			name:  "invalid uid (apiserver wrapped)",
+			input: folder.ErrAPIInvalidUID,
+			want:  response.Error(http.StatusBadRequest, "invalid uid for folder provided", nil),
+		},
+		{
+			// Custom-context wrappers (non-errutil) keep their added context.
+			name:  "folder title empty wrapped with custom context",
+			input: fmt.Errorf("save folder: %w", folder.ErrTitleEmpty),
+			want:  response.Error(http.StatusBadRequest, "save folder: folder title cannot be empty", nil),
 		},
 		// --- 403 Forbidden ---
 		{
@@ -224,6 +244,8 @@ func TestErrorsIs_UnwrapsAPIWrappers(t *testing.T) {
 		legacy  error
 	}{
 		{"title empty", folder.ErrAPITitleEmpty, folder.ErrTitleEmpty},
+		{"invalid uid", folder.ErrAPIInvalidUID, folder.ErrInvalidUID},
+		{"folder cannot be parent of itself", folder.ErrAPIFolderCannotBeParentOfItself, folder.ErrFolderCannotBeParentOfItself},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/pkg/registry/apis/folders/parents.go
+++ b/pkg/registry/apis/folders/parents.go
@@ -49,7 +49,7 @@ func newParentsGetter(getter rest.Getter, maxDepth int) parentsGetter {
 			}
 
 			if found[item.Parent] {
-				return nil, fmt.Errorf("cyclic folder references found: %s", item.Parent)
+				return nil, folderLegacy.ErrCyclicReference.Errorf("cyclic folder references found: %s", item.Parent)
 			}
 
 			obj, e2 := getter.Get(ctx, item.Parent, &metav1.GetOptions{})

--- a/pkg/registry/apis/folders/validate.go
+++ b/pkg/registry/apis/folders/validate.go
@@ -65,7 +65,7 @@ func validateOnCreate(ctx context.Context, f *folders.Folder, getter parentsGett
 		folder.GeneralFolderUID,
 		folder.SharedWithMeFolderUID,
 	}, id) {
-		return folder.ErrInvalidUID
+		return folder.ErrInvalidUID.Errorf("reserved UID %q cannot be used", id)
 	}
 
 	meta, err := utils.MetaAccessor(f)
@@ -87,7 +87,7 @@ func validateOnCreate(ctx context.Context, f *folders.Folder, getter parentsGett
 	f.Spec.Title = strings.TrimSpace(f.Spec.Title)
 
 	if f.Spec.Title == "" {
-		return folder.ErrTitleEmpty
+		return folder.ErrAPITitleEmpty
 	}
 
 	if strings.EqualFold(f.Spec.Title, dashboards.RootFolderName) {
@@ -100,7 +100,7 @@ func validateOnCreate(ctx context.Context, f *folders.Folder, getter parentsGett
 	}
 
 	if parentName == f.Name {
-		return folder.ErrFolderCannotBeParentOfItself
+		return folder.ErrFolderCannotBeParentOfItself.Errorf("folder cannot be parent of itself")
 	}
 
 	// note: `parents` will include itself as the last item
@@ -112,7 +112,7 @@ func validateOnCreate(ctx context.Context, f *folders.Folder, getter parentsGett
 	// Can not create a folder that will be too deep.
 	// We need to add +1 as we also have the root folder as part of the parents.
 	if len(parents.Items) > maxDepth+1 {
-		return fmt.Errorf("folder max depth exceeded, max depth is %d", maxDepth)
+		return folder.ErrMaximumDepthReached.Errorf("folder max depth exceeded, max depth is %d", maxDepth)
 	}
 
 	return nil
@@ -138,7 +138,7 @@ func validateOnUpdate(ctx context.Context,
 	obj.Spec.Title = strings.TrimSpace(obj.Spec.Title)
 
 	if obj.Spec.Title == "" {
-		return folder.ErrTitleEmpty
+		return folder.ErrAPITitleEmpty
 	}
 
 	if strings.EqualFold(obj.Spec.Title, dashboards.RootFolderName) {

--- a/pkg/registry/apis/folders/validate.go
+++ b/pkg/registry/apis/folders/validate.go
@@ -65,7 +65,7 @@ func validateOnCreate(ctx context.Context, f *folders.Folder, getter parentsGett
 		folder.GeneralFolderUID,
 		folder.SharedWithMeFolderUID,
 	}, id) {
-		return folder.ErrInvalidUID.Errorf("reserved UID %q cannot be used", id)
+		return folder.ErrAPIInvalidUID
 	}
 
 	meta, err := utils.MetaAccessor(f)
@@ -100,7 +100,7 @@ func validateOnCreate(ctx context.Context, f *folders.Folder, getter parentsGett
 	}
 
 	if parentName == f.Name {
-		return folder.ErrFolderCannotBeParentOfItself.Errorf("folder cannot be parent of itself")
+		return folder.ErrAPIFolderCannotBeParentOfItself
 	}
 
 	// note: `parents` will include itself as the last item

--- a/pkg/registry/apis/folders/validate_test.go
+++ b/pkg/registry/apis/folders/validate_test.go
@@ -12,6 +12,7 @@ import (
 	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
+	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
@@ -22,7 +23,7 @@ func TestValidateCreate(t *testing.T) {
 		name        string
 		folder      *folders.Folder
 		mockFolders map[string]*folders.Folder
-		expectedErr string
+		expectedErr error
 		maxDepth    int // defaults to 5 unless set
 	}{
 		{
@@ -63,7 +64,7 @@ func TestValidateCreate(t *testing.T) {
 					Name: folder.GeneralFolderUID,
 				},
 			},
-			expectedErr: "invalid uid for folder provided",
+			expectedErr: folder.ErrInvalidUID,
 		},
 		{
 			name: "reserved name - sharedwithme",
@@ -72,7 +73,7 @@ func TestValidateCreate(t *testing.T) {
 					Name: folder.SharedWithMeFolderUID,
 				},
 			},
-			expectedErr: "invalid uid for folder provided",
+			expectedErr: folder.ErrInvalidUID,
 		},
 		{
 			name: "too long",
@@ -81,7 +82,7 @@ func TestValidateCreate(t *testing.T) {
 					Name: "a0123456789012345678901234567890123456789", // longer than 40
 				},
 			},
-			expectedErr: "uid too long, max 40 characters",
+			expectedErr: dashboards.ErrDashboardUidTooLong,
 		},
 		{
 			name: "bad name",
@@ -90,7 +91,7 @@ func TestValidateCreate(t *testing.T) {
 					Name: "hello world", // not a-z|0-9,
 				},
 			},
-			expectedErr: "uid contains illegal characters",
+			expectedErr: dashboards.ErrDashboardInvalidUid,
 		},
 		{
 			name: "can not be a parent of yourself",
@@ -103,7 +104,7 @@ func TestValidateCreate(t *testing.T) {
 					Title: "some title",
 				},
 			},
-			expectedErr: "folder cannot be parent of itself",
+			expectedErr: folder.ErrFolderCannotBeParentOfItself,
 		},
 		{
 			name: "can not create a tree that is too deep",
@@ -154,7 +155,7 @@ func TestValidateCreate(t *testing.T) {
 				},
 			},
 			maxDepth:    2,
-			expectedErr: "folder max depth exceeded",
+			expectedErr: folder.ErrMaximumDepthReached,
 		},
 		{
 			name: "can create a folder in max depth",
@@ -216,7 +217,7 @@ func TestValidateCreate(t *testing.T) {
 					Title: "General",
 				},
 			},
-			expectedErr: "folder.name-exists",
+			expectedErr: folder.ErrNameExists,
 		},
 		{
 			name: "title is reserved name General case insensitive",
@@ -228,7 +229,7 @@ func TestValidateCreate(t *testing.T) {
 					Title: "GENERAL",
 				},
 			},
-			expectedErr: "folder.name-exists",
+			expectedErr: folder.ErrNameExists,
 		},
 		{
 			name: "title is reserved name General with surrounding whitespace",
@@ -240,7 +241,7 @@ func TestValidateCreate(t *testing.T) {
 					Title: "  General  ",
 				},
 			},
-			expectedErr: "folder.name-exists",
+			expectedErr: folder.ErrNameExists,
 		},
 		{
 			name: "cannot create a circular reference",
@@ -253,7 +254,7 @@ func TestValidateCreate(t *testing.T) {
 					Title: "some title",
 				},
 			},
-			expectedErr: "cyclic folder references found",
+			expectedErr: folder.ErrCyclicReference,
 			mockFolders: map[string]*folders.Folder{
 				"2": {
 					ObjectMeta: metav1.ObjectMeta{
@@ -311,11 +312,11 @@ func TestValidateCreate(t *testing.T) {
 
 			err := validateOnCreate(context.Background(), tt.folder, getter, maxDepth)
 
-			if tt.expectedErr == "" {
+			if tt.expectedErr == nil {
 				require.NoError(t, err)
 			} else {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), tt.expectedErr)
+				require.ErrorIs(t, err, tt.expectedErr)
+				require.Contains(t, err.Error(), tt.expectedErr.Error())
 			}
 		})
 	}

--- a/pkg/services/folder/model.go
+++ b/pkg/services/folder/model.go
@@ -14,7 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-var ErrMaximumDepthReached = errutil.BadRequest("folder.maximum-depth-reached", errutil.WithPublicMessage("Maximum nested folder depth reached"))
+var ErrMaximumDepthReached = errutil.BadRequest("folder.maximum-depth-reached", errutil.WithPublicMessage("Maximum nested folder depth reached")) // Important: keep error msgID stable for other services to consume (provisioning)
 var ErrBadRequest = errutil.BadRequest("folder.bad-request")
 var ErrDatabaseError = errutil.Internal("folder.database-error")
 var ErrConflict = errutil.Conflict("folder.conflict")
@@ -22,13 +22,20 @@ var ErrInternal = errutil.Internal("folder.internal")
 var ErrCircularReference = errutil.BadRequest("folder.circular-reference", errutil.WithPublicMessage("Circular reference detected"))
 var ErrTargetRegistrySrvConflict = errutil.Internal("folder.target-registry-srv-conflict")
 var ErrFolderNotEmpty = errutil.BadRequest("folder.not-empty", errutil.WithPublicMessage("Folder cannot be deleted: folder is not empty"))
-var ErrFolderCannotBeParentOfItself = errors.New("folder cannot be parent of itself")
+var ErrCyclicReference = errutil.Internal("folder.cyclic-reference", errutil.WithPublicMessage("Cyclic folder references found"))
+var ErrFolderCannotBeParentOfItself = errutil.BadRequest("folder.cannot-be-parent-of-itself", errutil.WithPublicMessage("Folder cannot be parent of itself"))
+var ErrInvalidUID = errutil.BadRequest("folder.invalid-uid", errutil.WithPublicMessage("Invalid uid for folder provided"))
 
+// TODO: evaluate if we can remove legacy errors and only have wrapped k8s errors
 var ErrVersionMismatch = errors.New("the folder has been changed by someone else")
-var ErrTitleEmpty = errors.New("folder title cannot be empty")
 var ErrSameUIDExists = errors.New("a folder/dashboard with the same uid already exists")
-var ErrInvalidUID = errors.New("invalid uid for folder provided")
 var ErrAccessDenied = errors.New("access denied to folder")
+
+// ErrAPITitleEmpty wraps the legacy ErrTitleEmpty error (/api) into an apiserver (/apis) error for it to be handled as 400.
+var ErrAPITitleEmpty = errutil.BadRequest("folder.title-empty", errutil.WithPublicMessage("Folder title cannot be empty")).
+	Errorf("%w", ErrTitleEmpty)
+var ErrTitleEmpty = errors.New("folder title cannot be empty")
+
 var ErrMoveAccessDenied = errutil.Forbidden("folders.forbiddenMove", errutil.WithPublicMessage("Access denied to the destination folder"))
 var ErrAccessEscalation = errutil.Forbidden("folders.accessEscalation", errutil.WithPublicMessage("Cannot move a folder to a folder where you have higher permissions"))
 var ErrCreationAccessDenied = errutil.Forbidden("folders.forbiddenCreation", errutil.WithPublicMessage("not enough permissions to create a folder in the selected location"))

--- a/pkg/services/folder/model.go
+++ b/pkg/services/folder/model.go
@@ -23,18 +23,22 @@ var ErrCircularReference = errutil.BadRequest("folder.circular-reference", errut
 var ErrTargetRegistrySrvConflict = errutil.Internal("folder.target-registry-srv-conflict")
 var ErrFolderNotEmpty = errutil.BadRequest("folder.not-empty", errutil.WithPublicMessage("Folder cannot be deleted: folder is not empty"))
 var ErrCyclicReference = errutil.Internal("folder.cyclic-reference", errutil.WithPublicMessage("Cyclic folder references found"))
-var ErrFolderCannotBeParentOfItself = errutil.BadRequest("folder.cannot-be-parent-of-itself", errutil.WithPublicMessage("Folder cannot be parent of itself"))
-var ErrInvalidUID = errutil.BadRequest("folder.invalid-uid", errutil.WithPublicMessage("Invalid uid for folder provided"))
 
-// TODO: evaluate if we can remove legacy errors and only have wrapped k8s errors
+// TODO: evaluate if we can remove legacy errors and only have k8s ones
+var ErrTitleEmpty = errors.New("folder title cannot be empty")
+var ErrInvalidUID = errors.New("invalid uid for folder provided")
+var ErrFolderCannotBeParentOfItself = errors.New("folder cannot be parent of itself")
 var ErrVersionMismatch = errors.New("the folder has been changed by someone else")
 var ErrSameUIDExists = errors.New("a folder/dashboard with the same uid already exists")
 var ErrAccessDenied = errors.New("access denied to folder")
 
-// ErrAPITitleEmpty wraps the legacy ErrTitleEmpty error (/api) into an apiserver (/apis) error for it to be handled as 400.
+// Wraps legacy errors (/api) into an apiserver (/apis) error for them to be handled as 400.
 var ErrAPITitleEmpty = errutil.BadRequest("folder.title-empty", errutil.WithPublicMessage("Folder title cannot be empty")).
 	Errorf("%w", ErrTitleEmpty)
-var ErrTitleEmpty = errors.New("folder title cannot be empty")
+var ErrAPIInvalidUID = errutil.BadRequest("folder.invalid-uid", errutil.WithPublicMessage("Invalid uid for folder provided")).
+	Errorf("%w", ErrInvalidUID)
+var ErrAPIFolderCannotBeParentOfItself = errutil.BadRequest("folder.cannot-be-parent-of-itself", errutil.WithPublicMessage("Folder cannot be parent of itself")).
+	Errorf("%w", ErrFolderCannotBeParentOfItself)
 
 var ErrMoveAccessDenied = errutil.Forbidden("folders.forbiddenMove", errutil.WithPublicMessage("Access denied to the destination folder"))
 var ErrAccessEscalation = errutil.Forbidden("folders.accessEscalation", errutil.WithPublicMessage("Cannot move a folder to a folder where you have higher permissions"))

--- a/pkg/services/provisioning/dashboards/file_reader.go
+++ b/pkg/services/provisioning/dashboards/file_reader.go
@@ -444,7 +444,7 @@ func (fr *FileReader) getOrCreateFolderInternal(ctx context.Context, orgID int64
 
 	// do not allow the creation of folder with uid "general"
 	if result != nil && result.UID == accesscontrol.GeneralFolderUID {
-		return 0, "", folder.ErrInvalidUID.Errorf("reserved UID %q cannot be used", result.UID)
+		return 0, "", folder.ErrInvalidUID
 	}
 
 	// When we expect folders in unified storage, they should have a manager indicated.

--- a/pkg/services/provisioning/dashboards/file_reader.go
+++ b/pkg/services/provisioning/dashboards/file_reader.go
@@ -444,7 +444,7 @@ func (fr *FileReader) getOrCreateFolderInternal(ctx context.Context, orgID int64
 
 	// do not allow the creation of folder with uid "general"
 	if result != nil && result.UID == accesscontrol.GeneralFolderUID {
-		return 0, "", folder.ErrInvalidUID
+		return 0, "", folder.ErrInvalidUID.Errorf("reserved UID %q cannot be used", result.UID)
 	}
 
 	// When we expect folders in unified storage, they should have a manager indicated.

--- a/pkg/tests/apis/folder/folders_test.go
+++ b/pkg/tests/apis/folder/folders_test.go
@@ -1161,7 +1161,7 @@ func TestIntegrationFoldersCreateAPIEndpointK8S(t *testing.T) {
 			description:            "folder creation fails given folder service error %s",
 			input:                  folderWithTitleEmpty,
 			expectedCode:           http.StatusBadRequest,
-			expectedMessage:        folder.ErrAPITitleEmpty.Error(),
+			expectedMessage:        folder.ErrTitleEmpty.Error(),
 			expectedFolderSvcError: folder.ErrTitleEmpty,
 			permissions:            folderCreatePermission,
 		},
@@ -2474,17 +2474,17 @@ func TestIntegrationFolderValidationReturns400(t *testing.T) {
 		{
 			name:        "title empty",
 			folder:      func(string) *unstructured.Unstructured { return makeFolder("title-empty-test", "", "") },
-			expectedMsg: "[folder.title-empty] folder title cannot be empty",
+			expectedMsg: "folder title cannot be empty",
 		},
 		{
 			name:        "reserved uid",
 			folder:      func(string) *unstructured.Unstructured { return makeFolder(folder.GeneralFolderUID, "Some title", "") },
-			expectedMsg: "[folder.invalid-uid] reserved UID \"general\" cannot be used",
+			expectedMsg: "invalid uid for folder provided",
 		},
 		{
 			name:        "parent of itself",
 			folder:      func(string) *unstructured.Unstructured { return makeFolder("self-parent", "Some title", "self-parent") },
-			expectedMsg: "[folder.cannot-be-parent-of-itself] folder cannot be parent of itself",
+			expectedMsg: "folder cannot be parent of itself",
 		},
 		{
 			name: "max depth exceeded",

--- a/pkg/tests/apis/folder/folders_test.go
+++ b/pkg/tests/apis/folder/folders_test.go
@@ -1161,7 +1161,7 @@ func TestIntegrationFoldersCreateAPIEndpointK8S(t *testing.T) {
 			description:            "folder creation fails given folder service error %s",
 			input:                  folderWithTitleEmpty,
 			expectedCode:           http.StatusBadRequest,
-			expectedMessage:        folder.ErrTitleEmpty.Error(),
+			expectedMessage:        folder.ErrAPITitleEmpty.Error(),
 			expectedFolderSvcError: folder.ErrTitleEmpty,
 			permissions:            folderCreatePermission,
 		},
@@ -2435,8 +2435,10 @@ func TestIntegrationFolderDryRun(t *testing.T) {
 	}
 }
 
-// TestIntegrationFolderMaxDepthReturns400 asserts k8s apiserver can convert error to a metav1.Status
-func TestIntegrationFolderMaxDepthReturns400(t *testing.T) {
+// TestIntegrationFolderValidationReturns400 asserts the folder admission
+// validator surfaces structured 4xx responses (and stable messages consumed
+// by provisioning) rather than "Unhandled Error" 500s.
+func TestIntegrationFolderValidationReturns400(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 	if !db.IsTestDbSQLite() {
 		t.Skip("test only on sqlite for now")
@@ -2447,54 +2449,81 @@ func TestIntegrationFolderMaxDepthReturns400(t *testing.T) {
 		DisableAnonymous:     true,
 		APIServerStorageType: "unified",
 	})
-
 	client := helper.GetResourceClient(apis.ResourceClientArgs{
 		User: helper.Org1.Admin,
 		GVR:  gvr,
 	})
 
-	// Default MaxNestedFolderDepth is 4 — five levels of nesting are allowed.
-	parentUID := ""
-	for i := 1; i <= 5; i++ {
-		md := map[string]any{
-			"name": fmt.Sprintf("max-depth-%d", i),
-		}
+	makeFolder := func(name, title, parentUID string) *unstructured.Unstructured {
+		md := map[string]any{"name": name}
 		if parentUID != "" {
 			md["annotations"] = map[string]any{utils.AnnoKeyFolder: parentUID}
 		}
-		f := &unstructured.Unstructured{
-			Object: map[string]any{
-				"metadata": md,
-				"spec":     map[string]any{"title": fmt.Sprintf("Max depth %d", i)},
-			},
-		}
-		out, err := client.Resource.Create(context.Background(), f, metav1.CreateOptions{})
-		require.NoErrorf(t, err, "creating folder at depth %d should succeed", i)
-		parentUID = out.GetName()
+		return &unstructured.Unstructured{Object: map[string]any{
+			"metadata": md,
+			"spec":     map[string]any{"title": title},
+		}}
 	}
 
-	// Sixth level exceeds the limit and must fail with HTTP 400, not 500.
-	overflow := &unstructured.Unstructured{
-		Object: map[string]any{
-			"metadata": map[string]any{
-				"name":        "max-depth-6",
-				"annotations": map[string]any{utils.AnnoKeyFolder: parentUID},
+	cases := []struct {
+		name        string
+		setup       func(t *testing.T) string
+		folder      func(parentUID string) *unstructured.Unstructured
+		expectedMsg string
+	}{
+		{
+			name:        "title empty",
+			folder:      func(string) *unstructured.Unstructured { return makeFolder("title-empty-test", "", "") },
+			expectedMsg: "[folder.title-empty] folder title cannot be empty",
+		},
+		{
+			name:        "reserved uid",
+			folder:      func(string) *unstructured.Unstructured { return makeFolder(folder.GeneralFolderUID, "Some title", "") },
+			expectedMsg: "[folder.invalid-uid] reserved UID \"general\" cannot be used",
+		},
+		{
+			name:        "parent of itself",
+			folder:      func(string) *unstructured.Unstructured { return makeFolder("self-parent", "Some title", "self-parent") },
+			expectedMsg: "[folder.cannot-be-parent-of-itself] folder cannot be parent of itself",
+		},
+		{
+			name: "max depth exceeded",
+			setup: func(t *testing.T) string {
+				parentUID := ""
+				for i := 1; i <= 5; i++ {
+					out, err := client.Resource.Create(context.Background(),
+						makeFolder(fmt.Sprintf("max-depth-%d", i), fmt.Sprintf("Max depth %d", i), parentUID),
+						metav1.CreateOptions{})
+					require.NoErrorf(t, err, "creating folder at depth %d should succeed", i)
+					parentUID = out.GetName()
+				}
+				return parentUID
 			},
-			"spec": map[string]any{"title": "Max depth 6"},
+			folder: func(parentUID string) *unstructured.Unstructured {
+				return makeFolder("max-depth-6", "Max depth 6", parentUID)
+			},
+			expectedMsg: "[folder.maximum-depth-reached] folder max depth exceeded, max depth is 4",
 		},
 	}
-	_, err := client.Resource.Create(context.Background(), overflow, metav1.CreateOptions{})
-	require.Error(t, err, "creating folder beyond max depth must error")
-	require.Falsef(t, apierrors.IsInternalError(err),
-		"apiserver surfaced max-depth error as HTTP 500 (regression of alert #1782995): %v", err)
-	require.Truef(t, apierrors.IsBadRequest(err),
-		"expected HTTP 400 BadRequest from max-depth violation; got: %v (%T)", err, err)
 
-	// Provisioning parses this message — keep format stable.
-	const expectedMsg = "[folder.maximum-depth-reached] folder max depth exceeded, max depth is 4"
-	var statusErr *apierrors.StatusError
-	require.True(t, errors.As(err, &statusErr), "expected *apierrors.StatusError; got %T", err)
-	require.Equal(t, int32(http.StatusBadRequest), statusErr.ErrStatus.Code)
-	require.Equal(t, expectedMsg, statusErr.ErrStatus.Message)
-	require.Equal(t, expectedMsg, err.Error())
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var parentUID string
+			if tc.setup != nil {
+				parentUID = tc.setup(t)
+			}
+			_, err := client.Resource.Create(context.Background(), tc.folder(parentUID), metav1.CreateOptions{})
+			require.Error(t, err)
+			require.Falsef(t, apierrors.IsInternalError(err),
+				"apiserver surfaced as HTTP 500 (regression of alert #1782995): %v", err)
+			require.Truef(t, apierrors.IsBadRequest(err),
+				"expected HTTP 400 BadRequest; got: %v (%T)", err, err)
+
+			var statusErr *apierrors.StatusError
+			require.True(t, errors.As(err, &statusErr), "expected *apierrors.StatusError; got %T", err)
+			require.Equal(t, int32(http.StatusBadRequest), statusErr.ErrStatus.Code)
+			require.Equal(t, tc.expectedMsg, statusErr.ErrStatus.Message)
+			require.Equal(t, tc.expectedMsg, err.Error())
+		})
+	}
 }

--- a/pkg/tests/apis/folder/folders_test.go
+++ b/pkg/tests/apis/folder/folders_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -397,7 +398,7 @@ func getFromBothAPIs(t *testing.T,
 	helper *apis.K8sTestHelper,
 	client *apis.K8sResourceClient,
 	uid string,
-	// Optionally match some expect some values
+// Optionally match some expect some values
 	expect *folder.Folder,
 ) *unstructured.Unstructured {
 	t.Helper()
@@ -2434,12 +2435,7 @@ func TestIntegrationFolderDryRun(t *testing.T) {
 	}
 }
 
-// TestIntegrationFolderMaxDepthReturns400 guards against the regression that
-// fired alert #1782995: the folder admission validator returned a bare Go
-// error for the max-depth check, which the k8s apiserver could not convert
-// to a metav1.Status, so it surfaced as HTTP 500 instead of 400. The test
-// creates the maximum allowed nesting and then attempts one folder beyond
-// it; the response must be HTTP 400 BadRequest, not 500 InternalError.
+// TestIntegrationFolderMaxDepthReturns400 asserts k8s apiserver can convert error to a metav1.Status
 func TestIntegrationFolderMaxDepthReturns400(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 	if !db.IsTestDbSQLite() {
@@ -2493,4 +2489,12 @@ func TestIntegrationFolderMaxDepthReturns400(t *testing.T) {
 		"apiserver surfaced max-depth error as HTTP 500 (regression of alert #1782995): %v", err)
 	require.Truef(t, apierrors.IsBadRequest(err),
 		"expected HTTP 400 BadRequest from max-depth violation; got: %v (%T)", err, err)
+
+	// Provisioning parses this message — keep format stable.
+	const expectedMsg = "[folder.maximum-depth-reached] folder max depth exceeded, max depth is 4"
+	var statusErr *apierrors.StatusError
+	require.True(t, errors.As(err, &statusErr), "expected *apierrors.StatusError; got %T", err)
+	require.Equal(t, int32(http.StatusBadRequest), statusErr.ErrStatus.Code)
+	require.Equal(t, expectedMsg, statusErr.ErrStatus.Message)
+	require.Equal(t, expectedMsg, err.Error())
 }

--- a/pkg/tests/apis/folder/folders_test.go
+++ b/pkg/tests/apis/folder/folders_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -2431,4 +2432,65 @@ func TestIntegrationFolderDryRun(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+// TestIntegrationFolderMaxDepthReturns400 guards against the regression that
+// fired alert #1782995: the folder admission validator returned a bare Go
+// error for the max-depth check, which the k8s apiserver could not convert
+// to a metav1.Status, so it surfaced as HTTP 500 instead of 400. The test
+// creates the maximum allowed nesting and then attempts one folder beyond
+// it; the response must be HTTP 400 BadRequest, not 500 InternalError.
+func TestIntegrationFolderMaxDepthReturns400(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+	if !db.IsTestDbSQLite() {
+		t.Skip("test only on sqlite for now")
+	}
+
+	helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
+		AppModeProduction:    true,
+		DisableAnonymous:     true,
+		APIServerStorageType: "unified",
+	})
+
+	client := helper.GetResourceClient(apis.ResourceClientArgs{
+		User: helper.Org1.Admin,
+		GVR:  gvr,
+	})
+
+	// Default MaxNestedFolderDepth is 4 — five levels of nesting are allowed.
+	parentUID := ""
+	for i := 1; i <= 5; i++ {
+		md := map[string]any{
+			"name": fmt.Sprintf("max-depth-%d", i),
+		}
+		if parentUID != "" {
+			md["annotations"] = map[string]any{utils.AnnoKeyFolder: parentUID}
+		}
+		f := &unstructured.Unstructured{
+			Object: map[string]any{
+				"metadata": md,
+				"spec":     map[string]any{"title": fmt.Sprintf("Max depth %d", i)},
+			},
+		}
+		out, err := client.Resource.Create(context.Background(), f, metav1.CreateOptions{})
+		require.NoErrorf(t, err, "creating folder at depth %d should succeed", i)
+		parentUID = out.GetName()
+	}
+
+	// Sixth level exceeds the limit and must fail with HTTP 400, not 500.
+	overflow := &unstructured.Unstructured{
+		Object: map[string]any{
+			"metadata": map[string]any{
+				"name":        "max-depth-6",
+				"annotations": map[string]any{utils.AnnoKeyFolder: parentUID},
+			},
+			"spec": map[string]any{"title": "Max depth 6"},
+		},
+	}
+	_, err := client.Resource.Create(context.Background(), overflow, metav1.CreateOptions{})
+	require.Error(t, err, "creating folder beyond max depth must error")
+	require.Falsef(t, apierrors.IsInternalError(err),
+		"apiserver surfaced max-depth error as HTTP 500 (regression of alert #1782995): %v", err)
+	require.Truef(t, apierrors.IsBadRequest(err),
+		"expected HTTP 400 BadRequest from max-depth violation; got: %v (%T)", err, err)
 }

--- a/pkg/tests/apis/folder/folders_test.go
+++ b/pkg/tests/apis/folder/folders_test.go
@@ -398,7 +398,7 @@ func getFromBothAPIs(t *testing.T,
 	helper *apis.K8sTestHelper,
 	client *apis.K8sResourceClient,
 	uid string,
-// Optionally match some expect some values
+	// Optionally match some expect some values
 	expect *folder.Folder,
 ) *unstructured.Unstructured {
 	t.Helper()


### PR DESCRIPTION
**What is this feature?**

Wraps validation errors returned by the folder admission validator with `errutil` so they implement the k8s `APIStatus` interface and surface as proper 4xx responses instead of bare 500s. Affects:

- `ErrMaximumDepthReached` (the original fire) — call site at `pkg/registry/apis/folders/validate.go` now uses `.Errorf("folder max depth exceeded, max depth is %d", maxDepth)` instead of a bare `fmt.Errorf`.
- `ErrTitleEmpty`, `ErrInvalidUID`, `ErrFolderCannotBeParentOfItself` — kept as legacy `errors.New` sentinels for byte-stable `/api/folders` messages, plus new `ErrAPIxxx` variants in `pkg/services/folder/model.go` that wrap each via `%w`. Validate.go returns the `ErrAPIxxx` variants so the apiserver gets `APIStatus`; `errors.Is` still matches the legacy sentinels through Unwrap.
- `ErrCyclicReference` — promoted from a local `errors.New` in `parents.go` to an exported errutil error in `model.go`.
- `ToFolderErrorResponse` (`pkg/api/apierrors/folder.go`) — when the error chain contains an `errutil.Error` and matches one of the three stable folder sentinels, responds with `sentinel.Error()` instead of `err.Error()`. This strips the `[messageID] ...` errutil prefix only for the apiserver-wrapped path; `fmt.Errorf("ctx: %w", folder.ErrTitleEmpty)` style wrappers keep their context.
- Tests: retyped `TestValidateCreate.expectedErr` from substring to typed `error` so assertions go through `errors.Is`. Added `TestErrorsIs_UnwrapsAPIWrappers` documenting that `errors.Is(ErrAPIxxx, ErrXxx)` matches via `Unwrap`. New integration test `TestIntegrationFolderValidationReturns400` boots a real apiserver, drives all four validation errors, asserts HTTP 400 (not 500) and the exact response message.

**Why do we need this feature?**

Production alert (`folder-grafana-app-main`) was burning SLO budget on 5xx responses. Sift identified ~98% of the errors as bare `fmt.Errorf("folder max depth exceeded, max depth is 4")` returns from the admission validator — the k8s apiserver couldn't convert them to a `metav1.Status`, so they logged as "Unhandled Error" and surfaced as HTTP 500. Clients should get a 4xx here so they fail fast instead of retrying and burning more budget.

**Who is this feature for?**

Folder API consumers, the SLO owners (search_storage team), and clients that retry 5xx but not 4xx. The `"folder max depth exceeded"` substring contract is matched by https://github.com/grafana/grafana/pull/123726 (`resources.IsFolderDepthExceededAPIError`).

**Which issue(s) does this PR fix?**:

Fixes the SLO-burn alert on the folder service.

**Special notes for your reviewer:**

- Legacy `/api/folders` consumers (e.g., Terraform provider, downstream HTTP clients) see byte-identical messages to before this PR. The `errAs(err, &errutil.Error)` gate in `ToFolderErrorResponse` ensures we only strip the `[messageID]` prefix when the wrapping is the apiserver-path `errutil.Error`; generic `fmt.Errorf("ctx: %w", ...)` wrappers preserve their custom context (covered by `TestToFolderErrorResponse/folder_title_empty_wrapped_with_custom_context`).
- The `"folder max depth exceeded, max depth is %d"` log message format is consumed by provisioning in PR #123726 (substring match) — comment at the call site flags this.