### PR TITLE
datasources: querier: remove feature-flag test

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -309,11 +309,6 @@ export interface FeatureToggles {
   */
   datasourcesApiserverEnableResourceEndpointRedirect?: boolean;
   /**
-  * use raw output mode for the data source querier
-  * @default false
-  */
-  datasourcesQuerierRawOutput?: boolean;
-  /**
   * Runs CloudWatch metrics queries as separate batches
   * @default false
   */

--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -31,12 +31,10 @@ import (
 	"github.com/grafana/grafana/pkg/services/datasources"
 	ds_service "github.com/grafana/grafana/pkg/services/datasources/service"
 	"github.com/grafana/grafana/pkg/services/dsquerierclient"
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	service "github.com/grafana/grafana/pkg/services/query"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util/errhttp"
 	"github.com/grafana/grafana/pkg/web"
-	"github.com/open-feature/go-sdk/openfeature"
 )
 
 type queryREST struct {
@@ -194,19 +192,7 @@ func (r *queryREST) Connect(connectCtx context.Context, name string, _ runtime.O
 			b.reportStatus(ctx, statusCode)
 		}
 
-		var responder rest.Responder
-		rawOutputMode := openfeature.NewDefaultClient().Boolean(
-			ctx,
-			featuremgmt.FlagDatasourcesQuerierRawOutput,
-			false,
-			openfeature.TransactionContext(ctx),
-		)
-		connectLogger.Debug("raw-mode-feature-flag evaluated", "result", rawOutputMode)
-		if rawOutputMode {
-			responder = newRawResponderWrapper(ctx, w, responderOnObjectFn, responderOnErrorFn)
-		} else {
-			responder = newConnectResponderWrapper(incomingResponder, responderOnObjectFn, responderOnErrorFn)
-		}
+		responder := newRawResponderWrapper(ctx, w, responderOnObjectFn, responderOnErrorFn)
 
 		raw := &query.QueryDataRequest{}
 		err := web.Bind(httpreq, raw)
@@ -411,36 +397,6 @@ func handleQuery(
 		return nil, err
 	}
 	return handlePreparedQuery(ctx, pq, b.concurrentQueryLimit)
-}
-
-type connectResponderWrapper struct {
-	wrapped    rest.Responder
-	onObjectFn func(statusCode *int, obj runtime.Object)
-	onErrorFn  func(err error)
-}
-
-func newConnectResponderWrapper(responder rest.Responder, onObjectFn func(statusCode *int, obj runtime.Object), onErrorFn func(err error)) rest.Responder {
-	return &connectResponderWrapper{
-		wrapped:    responder,
-		onObjectFn: onObjectFn,
-		onErrorFn:  onErrorFn,
-	}
-}
-
-func (r connectResponderWrapper) Object(statusCode int, obj runtime.Object) {
-	if r.onObjectFn != nil {
-		r.onObjectFn(&statusCode, obj)
-	}
-
-	r.wrapped.Object(statusCode, obj)
-}
-
-func (r connectResponderWrapper) Error(err error) {
-	if r.onErrorFn != nil {
-		r.onErrorFn(err)
-	}
-
-	r.wrapped.Error(err)
 }
 
 type rawResponderWrapper struct {

--- a/pkg/registry/apis/query/query_test.go
+++ b/pkg/registry/apis/query/query_test.go
@@ -27,9 +27,6 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/registry/apis/query/clientapi"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
-	"github.com/open-feature/go-sdk/openfeature"
-	"github.com/open-feature/go-sdk/openfeature/memprovider"
-	oftesting "github.com/open-feature/go-sdk/openfeature/testing"
 )
 
 func loadTestdataFrames(t *testing.T, filename string) *backend.QueryDataResponse {
@@ -170,116 +167,8 @@ func TestQueryAPI(t *testing.T) {
 		},
 	}
 
-	testProvider := oftesting.NewTestProvider()
-	err := openfeature.SetProviderAndWait(testProvider)
-	if err != nil {
-		t.Errorf("unable to set openfeature provider")
-	}
-
-	// first we test the responder-based output mode
 	for _, tc := range testCases {
-		t.Run(tc.name+"-responder", func(t *testing.T) {
-			defer testProvider.Cleanup()
-			testProvider.UsingFlags(t, map[string]memprovider.InMemoryFlag{
-				featuremgmt.FlagDatasourcesQuerierRawOutput: {
-					State:          memprovider.Enabled,
-					DefaultVariant: "disabled",
-					Variants: map[string]any{
-						"disabled": false,
-					},
-				},
-			})
-
-			builder := &QueryAPIBuilder{
-				converter: &expr.ResultConverter{
-					Features: featuremgmt.WithFeatures(featuremgmt.FlagSqlExpressions),
-					Tracer:   tracing.InitializeTracerForTest(),
-				},
-				instanceProvider: mockClient{
-					stubbedFrame: tc.stubbedFrame,
-				},
-				tracer:                 tracing.InitializeTracerForTest(),
-				log:                    log.New("test"),
-				legacyDatasourceLookup: &mockLegacyDataSourceLookup{},
-				reportStatus:           func(context.Context, int) {},
-			}
-
-			reqCtx := claims.WithAuthInfo(identity.WithRequester(context.Background(), mockUser{}), &mockAuthInfo{})
-
-			req := httptest.NewRequestWithContext(reqCtx, http.MethodPost, "/some-path", bytes.NewReader([]byte(tc.queryJSON)))
-			req.Header.Set("Content-Type", "application/json")
-
-			// Set optional headers
-			for key, value := range tc.headers {
-				req.Header.Set(key, value)
-			}
-
-			ctx := context.Background()
-			mr := &mockResponder{}
-			qr := newQueryREST(builder)
-
-			handler, err := qr.Connect(ctx, "name", nil, mr)
-			require.NoError(t, err)
-			rr := httptest.NewRecorder()
-			handler.ServeHTTP(rr, req)
-
-			require.NoError(t, mr.err, "Should not have error in responder")
-			require.Equal(t, tc.expectedStatus, mr.statusCode, "Should return expected status code")
-			require.NotNil(t, mr.response, "Should have a response object")
-
-			// Verify the response is the expected type
-			qdr, ok := mr.response.(*queryapi.QueryDataResponse)
-			require.True(t, ok, "Response should be QueryDataResponse type")
-			require.NotNil(t, qdr.Responses, "Should have responses")
-
-			// Load expected frames from testdata if provided
-			if tc.testdataFile != "" {
-				expectedResponse := loadTestdataFrames(t, tc.testdataFile)
-
-				// get refids from expected response
-				expectedRefIds := make([]string, 0, len(expectedResponse.Responses))
-				for refID := range expectedResponse.Responses {
-					expectedRefIds = append(expectedRefIds, refID)
-				}
-
-				// Verify all expected refIDs are present
-				for _, refID := range expectedRefIds {
-					require.Contains(t, qdr.Responses, refID, "Should contain response for refId %s", refID)
-
-					actualResponse := qdr.Responses[refID]
-					expectedFrameResponse := expectedResponse.Responses[refID]
-
-					// Verify frame structure matches testdata
-					require.Len(t, actualResponse.Frames, len(expectedFrameResponse.Frames), "Frame count should match testdata for refId %s", refID)
-
-					for i, actualFrame := range actualResponse.Frames {
-						expectedFrame := expectedFrameResponse.Frames[i]
-						if diff := cmp.Diff(expectedFrame, actualFrame, data.FrameTestCompareOptions()...); diff != "" {
-							require.FailNowf(t, "Result mismatch (-want +got):%s", diff)
-						}
-					}
-				}
-			} else {
-				t.Fatalf("No testdata file provided for test case %s", tc.name)
-			}
-
-			t.Logf("Test case '%s' completed successfully", tc.name)
-		})
-	}
-
-	// next we test the raw output mode
-	for _, tc := range testCases {
-		t.Run(tc.name+"raw-output", func(t *testing.T) {
-			defer testProvider.Cleanup()
-			testProvider.UsingFlags(t, map[string]memprovider.InMemoryFlag{
-				featuremgmt.FlagDatasourcesQuerierRawOutput: {
-					State:          memprovider.Enabled,
-					DefaultVariant: "enabled",
-					Variants: map[string]any{
-						"enabled": true,
-					},
-				},
-			})
+		t.Run(tc.name, func(t *testing.T) {
 			builder := &QueryAPIBuilder{
 				converter: &expr.ResultConverter{
 					Features: featuremgmt.WithFeatures(featuremgmt.FlagSqlExpressions),

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -545,15 +545,6 @@ var (
 			Generate:        Generate{LegacyGo: true, LegacyFrontend: true},
 		},
 		{
-			Name:            "datasourcesQuerierRawOutput",
-			Description:     "use raw output mode for the data source querier",
-			Stage:           FeatureStageExperimental,
-			Owner:           grafanaDatasourcesCoreServicesSquad,
-			RequiresRestart: false,
-			Expression:      "false",
-			Generate:        Generate{LegacyGo: true, LegacyFrontend: true},
-		},
-		{
 			Name:        "cloudWatchBatchQueries",
 			Description: "Runs CloudWatch metrics queries as separate batches",
 			Stage:       FeatureStageGeneralAvailability,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -61,7 +61,6 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-02-18,datasourcesRerouteLegacyCRUDAPIs,experimental,@grafana/grafana-datasources-core-services,false,false,false
 2026-02-18,datasourcesApiServerEnableResourceEndpoint,experimental,@grafana/grafana-datasources-core-services,false,false,false
 2026-03-16,datasourcesApiserverEnableResourceEndpointRedirect,experimental,@grafana/grafana-datasources-core-services,false,false,false
-2026-03-30,datasourcesQuerierRawOutput,experimental,@grafana/grafana-datasources-core-services,false,false,false
 2023-10-20,cloudWatchBatchQueries,GA,@grafana/data-sources-plugins,false,false,false
 2023-10-12,cachingOptimizeSerializationMemoryUsage,experimental,@grafana/grafana-operator-experience-squad,false,false,false
 2023-10-30,alertmanagerRemoteSecondary,experimental,@grafana/alerting-squad,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -199,10 +199,6 @@ const (
 	// redirect datasource resource requests from the legacy API routes to the new datasource api group endpoints.
 	FlagDatasourcesApiserverEnableResourceEndpointRedirect = "datasourcesApiserverEnableResourceEndpointRedirect"
 
-	// FlagDatasourcesQuerierRawOutput
-	// use raw output mode for the data source querier
-	FlagDatasourcesQuerierRawOutput = "datasourcesQuerierRawOutput"
-
 	// FlagCloudWatchBatchQueries
 	// Runs CloudWatch metrics queries as separate batches
 	FlagCloudWatchBatchQueries = "cloudWatchBatchQueries"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2004,7 +2004,8 @@
       "metadata": {
         "name": "datasourcesQuerierRawOutput",
         "resourceVersion": "1774855676428",
-        "creationTimestamp": "2026-03-30T07:27:56Z"
+        "creationTimestamp": "2026-03-30T07:27:56Z",
+        "deletionTimestamp": "2026-04-28T09:16:40Z"
       },
       "spec": {
         "description": "use raw output mode for the data source querier",


### PR DESCRIPTION
in https://github.com/grafana/grafana/pull/121114 we added a new output mode (raw output mode), and a feature-flag that allowed switching between the old mode and the new mode.

this has been tested in production, and it is working fine, this PR makes the new mode the only mode (removes the old mode), and removes the feature-flag too.