### PR TITLE
Unified Storage: don't skip migration when legacy SQL has edits since dualwrite stamp

### DIFF
--- a/pkg/storage/unified/migrations/resource_migration.go
+++ b/pkg/storage/unified/migrations/resource_migration.go
@@ -371,13 +371,21 @@ func (s dualwriteStorageStatus) migratedToUnified() bool {
 
 // isAlreadyOnUnifiedStorage checks persisted dualwrite state used by prior versions of Grafana.
 // Returns true when all resources in the definition were already migrated to unified storage
-// (read_unified=true, write_unified=true, write_legacy=false, and migrated>0).
+// (read_unified=true, write_unified=true, write_legacy=false, and migrated>0) AND legacy SQL
+// has not been touched since the migration was recorded.
 // This is to prevent data loss, as otherwise unified storage will be wiped and repopulated
 // from sql, destroying resources that only exist in unified storage.
 //
 // Two historical locations are checked:
 //   - kv_store table with namespace "unified.dualwrite" (12.1.0+)
 //   - <data_path>/dualwrite.json file containing a map[string]StorageStatus (12.0.0)
+//
+// The dualwrite state is necessary but not sufficient: feature flags (e.g. kubernetesDashboards,
+// provisioning) can route the API around the dualwriter without touching the persisted state.
+// In that case writes silently resume against legacy SQL while the dualwrite row becomes a
+// stale fossil. We therefore also verify that legacy has not been edited after the recorded
+// "migrated" timestamp; if it has, unified is not currently authoritative and the migration
+// must run to bring legacy edits into unified.
 //
 // This legacy path was only ever exposed for folders/dashboards, so this check is skipped
 // for every other migration definition.
@@ -396,24 +404,73 @@ func (r *MigrationRunner) isAlreadyOnUnifiedStorage(sess *xorm.Session) (bool, e
 		return false, fmt.Errorf("failed to read dualwrite state file: %w", err)
 	}
 
+	var earliestMigrated int64
 	for _, key := range configResources {
-		if status, ok := fileStatuses[key]; ok {
-			if !status.migratedToUnified() {
-				return false, nil
+		var (
+			status dualwriteStorageStatus
+			found  bool
+		)
+		if s, ok := fileStatuses[key]; ok {
+			status, found = s, true
+		} else {
+			kvStatus, kvFound, err := r.readDualwriteKVState(sess, key)
+			if err != nil {
+				return false, err
 			}
-			continue
-		}
-
-		status, found, err := r.readDualwriteKVState(sess, key)
-		if err != nil {
-			return false, err
+			status, found = kvStatus, kvFound
 		}
 		if !found || !status.migratedToUnified() {
 			return false, nil
 		}
+		if earliestMigrated == 0 || status.Migrated < earliestMigrated {
+			earliestMigrated = status.Migrated
+		}
+	}
+
+	legacyTouched, err := r.legacyEditedAfter(sess, earliestMigrated)
+	if err != nil {
+		return false, fmt.Errorf("failed to check legacy edits since dualwrite stamp: %w", err)
+	}
+	if legacyTouched {
+		r.log.Warn(
+			"dualwrite state shows folders/dashboards migrated to unified, but legacy SQL has edits since — running migration to bring legacy edits into unified",
+			"migrated_at", time.UnixMilli(earliestMigrated).UTC().Format(time.RFC3339))
+		return false, nil
 	}
 
 	return true, nil
+}
+
+// legacyEditedAfter reports whether the legacy "dashboard" or "folder" tables contain any
+// rows with `updated` after the given Unix-millis timestamp. Both tables are scanned because
+// folders are stored in `dashboard` (with is_folder=1) on older instances and in `folder` on
+// newer ones; one or the other may carry the post-stamp activity. Missing tables are treated
+// as empty so the check is a no-op on installs that never ran the legacy schema.
+func (r *MigrationRunner) legacyEditedAfter(sess *xorm.Session, migratedMillis int64) (bool, error) {
+	if migratedMillis <= 0 {
+		return false, nil
+	}
+	threshold := time.UnixMilli(migratedMillis).UTC()
+
+	for _, table := range []string{"dashboard", "folder"} {
+		exists, err := sess.IsTableExist(table)
+		if err != nil {
+			return false, fmt.Errorf("failed to check legacy table %s: %w", table, err)
+		}
+		if !exists {
+			continue
+		}
+		var present int
+		// SELECT 1 ... LIMIT 1 is supported on Postgres, MySQL and SQLite.
+		ok, err := sess.SQL(fmt.Sprintf("SELECT 1 FROM %s WHERE updated > ? LIMIT 1", table), threshold).Get(&present)
+		if err != nil {
+			return false, fmt.Errorf("failed to check legacy edits in %s: %w", table, err)
+		}
+		if ok {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 // readDualwriteKVState loads dualwrite state for the given resource key from kv_store.

--- a/pkg/storage/unified/migrations/resource_migration_test.go
+++ b/pkg/storage/unified/migrations/resource_migration_test.go
@@ -876,6 +876,42 @@ func TestIntegrationIsAlreadyOnUnifiedStorage(t *testing.T) {
 		},
 	}
 
+	cleanLegacyTables := func(t *testing.T) {
+		t.Helper()
+		sess := env.engine.NewSession()
+		defer sess.Close()
+		_, err := sess.Exec("DELETE FROM dashboard")
+		require.NoError(t, err)
+		_, err = sess.Exec("DELETE FROM folder")
+		require.NoError(t, err)
+	}
+
+	// Use raw SQL inserts so xorm's auto-`updated`/`created` magic doesn't overwrite
+	// the timestamps we are deliberately setting for the test.
+	insertDashboard := func(t *testing.T, uid string, updated time.Time) {
+		t.Helper()
+		sess := env.engine.NewSession()
+		defer sess.Close()
+		_, err := sess.Exec(
+			`INSERT INTO dashboard (version, slug, title, data, org_id, created, updated, folder_id, is_folder, has_acl, is_public, uid)
+			 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			1, uid, "test "+uid, "{}", 1, updated.UTC(), updated.UTC(), 0, false, false, false, uid,
+		)
+		require.NoError(t, err)
+	}
+
+	insertFolder := func(t *testing.T, uid string, updated time.Time) {
+		t.Helper()
+		sess := env.engine.NewSession()
+		defer sess.Close()
+		_, err := sess.Exec(
+			`INSERT INTO folder (uid, org_id, title, created, updated)
+			 VALUES (?, ?, ?, ?, ?)`,
+			uid, 1, "folder "+uid, updated.UTC(), updated.UTC(),
+		)
+		require.NoError(t, err)
+	}
+
 	insertKVState := func(t *testing.T, key string, status dualwriteStorageStatus) {
 		t.Helper()
 		orgID := int64(0)
@@ -1071,6 +1107,7 @@ func TestIntegrationIsAlreadyOnUnifiedStorage(t *testing.T) {
 	})
 
 	t.Run("Run skips migration when already on unified storage", func(t *testing.T) {
+		cleanLegacyTables(t)
 		insertKVState(t, configKey, migratedStatus)
 		runner2, fake := newRunner(t, noopLocker(), &transactionalTableRenamer{log: logger}, def)
 		runMigration(t, env.engine, runner2, migrator.SQLite)
@@ -1078,9 +1115,57 @@ func TestIntegrationIsAlreadyOnUnifiedStorage(t *testing.T) {
 	})
 
 	t.Run("Run proceeds with migration when not on unified storage", func(t *testing.T) {
+		cleanLegacyTables(t)
 		insertKVState(t, configKey, dualwriteStorageStatus{ReadUnified: false, WriteUnified: false, Migrated: 0})
 		runner2, fake := newRunner(t, noopLocker(), &transactionalTableRenamer{log: logger}, def)
 		runMigration(t, env.engine, runner2, migrator.SQLite)
 		require.Equal(t, 1, fake.migrateCalled, "Migrate should be called when not on unified storage")
+	})
+
+	t.Run("returns false when legacy dashboard has edits after migrated stamp", func(t *testing.T) {
+		cleanLegacyTables(t)
+		insertKVState(t, configKey, migratedStatus)
+		insertDashboard(t, "dash-after", time.UnixMilli(migratedStatus.Migrated).Add(time.Hour))
+
+		sess := newSession()
+		defer sess.Close()
+		got, err := runner.isAlreadyOnUnifiedStorage(sess)
+		require.NoError(t, err)
+		require.False(t, got, "should not skip migration when legacy dashboard has edits after the dualwrite stamp")
+	})
+
+	t.Run("returns false when legacy folder has edits after migrated stamp", func(t *testing.T) {
+		cleanLegacyTables(t)
+		insertKVState(t, configKey, migratedStatus)
+		insertFolder(t, "folder-after", time.UnixMilli(migratedStatus.Migrated).Add(time.Hour))
+
+		sess := newSession()
+		defer sess.Close()
+		got, err := runner.isAlreadyOnUnifiedStorage(sess)
+		require.NoError(t, err)
+		require.False(t, got, "should not skip migration when legacy folder has edits after the dualwrite stamp")
+	})
+
+	t.Run("returns true when legacy edits all predate migrated stamp", func(t *testing.T) {
+		cleanLegacyTables(t)
+		insertKVState(t, configKey, migratedStatus)
+		insertDashboard(t, "dash-before", time.UnixMilli(migratedStatus.Migrated).Add(-time.Hour))
+		insertFolder(t, "folder-before", time.UnixMilli(migratedStatus.Migrated).Add(-time.Hour))
+
+		sess := newSession()
+		defer sess.Close()
+		got, err := runner.isAlreadyOnUnifiedStorage(sess)
+		require.NoError(t, err)
+		require.True(t, got, "should skip migration when all legacy edits predate the dualwrite stamp")
+	})
+
+	t.Run("Run proceeds with migration when legacy has edits after migrated stamp", func(t *testing.T) {
+		cleanLegacyTables(t)
+		insertKVState(t, configKey, migratedStatus)
+		insertDashboard(t, "dash-postmigrate", time.UnixMilli(migratedStatus.Migrated).Add(time.Hour))
+
+		runner2, fake := newRunner(t, noopLocker(), &transactionalTableRenamer{log: logger}, def)
+		runMigration(t, env.engine, runner2, migrator.SQLite)
+		require.Equal(t, 1, fake.migrateCalled, "Migrate should be called when legacy has post-stamp edits")
 	})
 }


### PR DESCRIPTION
## Summary

Refs #123616.

#122866 added a skip-check to the v13 unified-storage migration: if the historical dualwrite KV row (`namespace=unified.dualwrite`, written by the 12.1.0+ dualwriter service) records that folders/dashboards reached `WriteUnified=true, WriteLegacy=false, Migrated>0`, the migration's wipe-and-repopulate-from-legacy is skipped. That covers users who trialed git-sync and stayed on unified storage.

It does **not** cover the inverse: a user who trialed git-sync (the dualwriter stamped the row), then disabled the unified feature flags (`kubernetesDashboards`, `kubernetesClientDashboardsFolders`, `provisioning`), and kept editing dashboards. With the flags off, the API routes around the dualwriter and writes resume against legacy SQL — but the dualwrite row is never updated, so it ages into a fossil that says "we're on unified" while reality is "we've been on legacy for months". On v13 upgrade, the skip-check trusts the stamp, the migration is silently skipped, and post-upgrade reads serve the trial-era unified snapshot instead of the user's current legacy state. From the user's perspective, dashboards "revert to where we tested git sync".

This is the failure mode reported in #123616. Confirmed against the user's `kv_store` row (stamped 2025-09-01 on Grafana 12.1.1) plus an 8-month gap of edits the user has been making on legacy SQL.

### Fix

Verify the stamp against legacy SQL before trusting it: in `isAlreadyOnUnifiedStorage`, after collecting the earliest `Migrated` timestamp across config resources, check whether any row in the legacy `dashboard` or `folder` tables has been updated since. If yes, unified is not currently authoritative and the migration must run rather than skip.

| dualwrite row says migrated? | Legacy edits after `Migrated`? | Action |
|---|---|---|
| no / missing | n/a | run migration *(unchanged)* |
| yes | no | skip *(unchanged — what #122866 was for)* |
| yes | **yes** | **run migration** *(new — fixes this issue)* |

The legacy-edits check uses a single `SELECT 1 ... WHERE updated > ? LIMIT 1` per table, runs only when the dualwrite row already says "migrated", and is skipped entirely for any migration definition other than `folders-dashboards`. Tables that don't exist are treated as empty, so the check is a no-op on installs that never ran the legacy schema.

### Recovery for users already affected

For users who already hit this on 13.0.x: roll back to 12.x, delete the dualwrite kv_store rows so the next upgrade attempt won't skip:

```sql
DELETE FROM kv_store
 WHERE namespace = 'unified.dualwrite'
   AND key IN ('folders.folder.grafana.app', 'dashboards.dashboard.grafana.app');
```

Then re-attempt the v13 upgrade. With the rows above gone, the skip-check returns false, the migration wipes the stale unified contents, and re-populates from legacy SQL (which is the user's current authoritative state).

### Follow-ups (out of scope here)

- **Divergence error.** When *both* unified and legacy have edits after `Migrated`, current behavior (after this fix) is to overwrite unified with legacy, silently dropping unified-only writes. A loud error in that case is preferable; punting until product/runbook sign-off.
- **Stop relying on the kv_store row as the load-bearing skip signal.** Its producer was deleted in v13 (#121738); this fix continues to read it but the long-term goal is to anchor "is unified currently authoritative" to direct evidence in unified itself rather than a fossil row.
- **Backport.** This needs to land on `release-13.0` (and any newer point releases in flight) so the next user's upgrade does the right thing.

## Test plan

- [x] `TestIntegrationIsAlreadyOnUnifiedStorage` extended with cases covering legacy edits before/after the stamp on dashboards and folders, plus an end-to-end `Run` test that validates the migrator is invoked when legacy has post-stamp edits.
- [ ] Manual repro on 12.4.x → 13.0.x with the affected user's kv_store layout once a backport branch exists.
- [ ] Reviewer eyes on: cross-dialect correctness of `SELECT 1 FROM dashboard WHERE updated > ? LIMIT 1` (raw `time.Time` parameter binding under Postgres / MySQL / SQLite via xorm). Tests run on SQLite via `db.InitTestDB`; the integration test suite covers Postgres / MySQL when `GRAFANA_TEST_DB` is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)