### PR TITLE
[release-12.4.4] SigV4: fix AWS auth settings not getting forwarded to data proxy HTTP client

### DIFF
--- a/pkg/infra/httpclient/httpclientprovider/http_client_provider.go
+++ b/pkg/infra/httpclient/httpclientprovider/http_client_provider.go
@@ -2,10 +2,15 @@ package httpclientprovider
 
 import (
 	"net/http"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/grafana/grafana-aws-sdk/pkg/awsauth"
+	"github.com/grafana/grafana-aws-sdk/pkg/awsds"
+	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
+	"github.com/grafana/grafana-plugin-sdk-go/backend/proxy"
 	"github.com/mwitkow/go-conntrack"
 
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -44,7 +49,27 @@ func New(cfg *setting.Cfg, validator validations.DataSourceRequestURLValidator, 
 
 	// SigV4 signing should be performed after all headers are added
 	if cfg.SigV4AuthEnabled {
-		middlewares = append(middlewares, awsauth.NewSigV4Middleware())
+		awsCfg := backend.NewGrafanaCfg(map[string]string{
+			awsds.AllowedAuthProvidersEnvVarKeyName:          strings.Join(cfg.AWSAllowedAuthProviders, ","),
+			awsds.AssumeRoleEnabledEnvVarKeyName:             strconv.FormatBool(cfg.AWSAssumeRoleEnabled),
+			awsds.GrafanaAssumeRoleExternalIdKeyName:         cfg.AWSExternalId,
+			awsds.ListMetricsPageLimitKeyName:                strconv.Itoa(cfg.AWSListMetricsPageLimit),
+			awsds.SessionDurationEnvVarKeyName:               cfg.AWSSessionDuration,
+			awsds.PerDatasourceHTTPProxyEnabledEnvVarKeyName: strconv.FormatBool(cfg.AWSPerDatasourceHTTPProxyEnabled),
+			proxy.PluginSecureSocksProxyEnabled:              strconv.FormatBool(cfg.SecureSocksDSProxy.Enabled),
+		})
+		middlewares = append(middlewares, sdkhttpclient.NamedMiddlewareFunc("sigv4-aws-config", func(opts sdkhttpclient.Options, next http.RoundTripper) http.RoundTripper {
+			sigv4 := awsauth.NewSigV4Middleware().CreateMiddleware(opts, next)
+			return sdkhttpclient.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+				ctx := req.Context()
+				// Normally the sigv4 middleware would read auth settings from ctx. But for frontend-only datasources using the data proxy,
+				// GrafanaConfig is never injected into the request context. In this case fall back to cfg values
+				if _, exists := awsds.ReadAuthSettingsFromContext(ctx); !exists {
+					ctx = backend.WithGrafanaConfig(ctx, awsCfg)
+				}
+				return sigv4.RoundTrip(req.WithContext(ctx))
+			})
+		}))
 	}
 
 	setDefaultTimeoutOptions(cfg)

--- a/pkg/infra/httpclient/httpclientprovider/http_client_provider_test.go
+++ b/pkg/infra/httpclient/httpclientprovider/http_client_provider_test.go
@@ -3,7 +3,6 @@ package httpclientprovider
 import (
 	"testing"
 
-	"github.com/grafana/grafana-aws-sdk/pkg/awsauth"
 	sdkhttpclient "github.com/grafana/grafana-plugin-sdk-go/backend/httpclient"
 	"github.com/stretchr/testify/require"
 
@@ -64,7 +63,7 @@ func TestHTTPClientProvider(t *testing.T) {
 		require.Equal(t, sdkhttpclient.ResponseLimitMiddlewareName, o.Middlewares[6].(sdkhttpclient.MiddlewareName).MiddlewareName())
 		require.Equal(t, HostRedirectValidationMiddlewareName, o.Middlewares[7].(sdkhttpclient.MiddlewareName).MiddlewareName())
 		require.Equal(t, sdkhttpclient.ErrorSourceMiddlewareName, o.Middlewares[8].(sdkhttpclient.MiddlewareName).MiddlewareName())
-		require.Equal(t, awsauth.NewSigV4Middleware().(sdkhttpclient.MiddlewareName).MiddlewareName(), o.Middlewares[9].(sdkhttpclient.MiddlewareName).MiddlewareName())
+		require.Equal(t, "sigv4-aws-config", o.Middlewares[9].(sdkhttpclient.MiddlewareName).MiddlewareName())
 	})
 
 	t.Run("When creating new provider and http logging is enabled for one plugin, it should apply expected middleware", func(t *testing.T) {


### PR DESCRIPTION
Backport 04a13f996af7e8387fc58ef314f8e2650d2db99a from #120767

---

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

After https://github.com/grafana/grafana/pull/107522 we no longer pass in aws auth settings as the middleware would read the auth settings from ctx. But for frontend-only datasources using the data proxy (like `alertmanager`), GrafanaConfig is never injected into the request context. This causes them to no longer respect the aws auth settings

The fix here is to pass the grafana cfg as a fallback when the context's auth settings are not found

**Why do we need this feature?**

Fixes regression

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #120766

**Special notes for your reviewer:**

Previously

1. Set ini `allowed_auth_providers = ec2_iam_role,keys,default`
2. Set up prometheus data source with sigv4 + AWS IAM auth. Confirmed it works
3. Set up alertmanager data source with same setup. Confirmed it fails health check

<img width="628" height="382" alt="image" src="https://github.com/user-attachments/assets/2858af45-0711-4343-a8cf-2017931c41c9" />

Now

1. Set ini `allowed_auth_providers = ec2_iam_role,keys,default`
2. Set up prometheus data source with sigv4 + AWS IAM auth. Confirmed it works
3. Set up alertmanager data source with same setup. Confirmed it works

<img width="793" height="358" alt="image" src="https://github.com/user-attachments/assets/6d5fd2ba-1394-45ed-a099-31078d6f6852" />


Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.