### PR TITLE
fix: publish current dualwriter mode based on storage mode reader

### DIFF
--- a/pkg/services/apiserver/appinstaller/storage.go
+++ b/pkg/services/apiserver/appinstaller/storage.go
@@ -20,7 +20,7 @@ func NewDualWriter(
 ) (grafanarest.Storage, error) {
 	key := gr.String()
 	if resourceConfig, ok := storageOpts.UnifiedStorageConfig[key]; ok {
-		builderMetrics.RecordDualWriterModes(gr.Resource, gr.Group, resourceConfig.DualWriterMode)
+		builderMetrics.RecordDualWriterTargetMode(gr.Resource, gr.Group, resourceConfig.DualWriterMode)
 	}
 
 	return dualWriteService.NewStorage(gr, legacy, storage)

--- a/pkg/services/apiserver/builder/helper.go
+++ b/pkg/services/apiserver/builder/helper.go
@@ -297,7 +297,7 @@ func InstallAPIs(
 		dualWrite = func(gr schema.GroupResource, legacy grafanarest.Storage, storage grafanarest.Storage) (grafanarest.Storage, error) {
 			key := gr.String()
 			if resourceConfig, ok := storageOpts.UnifiedStorageConfig[key]; ok {
-				builderMetrics.RecordDualWriterModes(gr.Resource, gr.Group, resourceConfig.DualWriterMode)
+				builderMetrics.RecordDualWriterTargetMode(gr.Resource, gr.Group, resourceConfig.DualWriterMode)
 			}
 			return dualWriteService.NewStorage(gr, legacy, storage)
 		}

--- a/pkg/services/apiserver/builder/metrics.go
+++ b/pkg/services/apiserver/builder/metrics.go
@@ -7,24 +7,21 @@ import (
 )
 
 type BuilderMetrics struct {
-	dualWriterTargetMode  *prometheus.GaugeVec
-	dualWriterCurrentMode *prometheus.GaugeVec
+	dualWriterTargetMode *prometheus.GaugeVec
 }
 
 func ProvideBuilderMetrics(reg prometheus.Registerer) *BuilderMetrics {
 	return &BuilderMetrics{
 		dualWriterTargetMode: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
 			Name: "unified_storage_dual_writer_target_mode",
-			Help: "Unified Storage dual writer target mode",
-		}, []string{"resource", "group"}),
-		dualWriterCurrentMode: promauto.With(reg).NewGaugeVec(prometheus.GaugeOpts{
-			Name: "unified_storage_dual_writer_current_mode",
-			Help: "Unified storage dual writer current mode",
+			Help: "Unified storage dual writer target mode from static config (0=legacy/Mode0, 1-3=dual-write/Mode1-3, 4-5=unified/Mode4-5)",
 		}, []string{"resource", "group"}),
 	}
 }
 
-func (m *BuilderMetrics) RecordDualWriterModes(resource, group string, mode grafanarest.DualWriterMode) {
+// RecordDualWriterTargetMode records the configured target dual writer mode for a resource.
+// The current mode (which may differ due to migration log state) is tracked separately
+// by the dualwrite service as unified_storage_dual_writer_current_mode.
+func (m *BuilderMetrics) RecordDualWriterTargetMode(resource, group string, mode grafanarest.DualWriterMode) {
 	m.dualWriterTargetMode.WithLabelValues(resource, group).Set(float64(mode))
-	m.dualWriterCurrentMode.WithLabelValues(resource, group).Set(float64(mode))
 }

--- a/pkg/storage/legacysql/dualwrite/metrics.go
+++ b/pkg/storage/legacysql/dualwrite/metrics.go
@@ -24,6 +24,11 @@ var (
 		Help: "Total number of errors from the status reader when resolving storage mode",
 	}, []string{"resource"})
 
+	currentModeMetric = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "unified_storage_dual_writer_current_mode",
+		Help: "Unified storage current storage mode, resolved dynamically from migration log (0=legacy, 1=dual-write, 5=unified)",
+	}, []string{"resource", "group"})
+
 	backgroundErrorMethods = []string{"GET", "LIST", "CREATE", "DELETE", "UPDATE", "DELETE_COLLECTION"}
 )
 
@@ -31,12 +36,13 @@ type dualWriterMetrics struct {
 	backgroundErrors   *prometheus.CounterVec
 	statusReaderNull   *prometheus.CounterVec
 	statusReaderErrors *prometheus.CounterVec
+	currentMode        *prometheus.GaugeVec
 }
 
 func provideDualWriterMetrics(reg prometheus.Registerer) *dualWriterMetrics {
 	registerMetricsOnce.Do(func() {
 		if reg != nil {
-			for _, m := range []prometheus.Collector{backgroundErrorsMetric, statusReaderNullMetric, statusReaderErrorsMetric} {
+			for _, m := range []prometheus.Collector{backgroundErrorsMetric, statusReaderNullMetric, statusReaderErrorsMetric, currentModeMetric} {
 				if err := reg.Register(m); err != nil {
 					log.New("dualwrite").Warn("failed to register dualwriter metrics", "error", err)
 				}
@@ -47,6 +53,7 @@ func provideDualWriterMetrics(reg prometheus.Registerer) *dualWriterMetrics {
 		backgroundErrors:   backgroundErrorsMetric,
 		statusReaderNull:   statusReaderNullMetric,
 		statusReaderErrors: statusReaderErrorsMetric,
+		currentMode:        currentModeMetric,
 	}
 }
 

--- a/pkg/storage/legacysql/dualwrite/service_test.go
+++ b/pkg/storage/legacysql/dualwrite/service_test.go
@@ -359,6 +359,71 @@ func TestServiceMetrics_HappyPath(t *testing.T) {
 	require.Equal(t, float64(0), testutil.ToFloat64(metrics.statusReaderErrors.WithLabelValues(gr.String())))
 }
 
+func TestCurrentModeMetric(t *testing.T) {
+	gr := schema.GroupResource{Group: "test.grafana.app", Resource: "widgets"}
+	ls := (rest.Storage)(nil)
+	us := (rest.Storage)(nil)
+
+	t.Run("storageModeToDualWriterMode mapping", func(t *testing.T) {
+		for _, tt := range []struct {
+			mode     unifiedmigrations.StorageMode
+			expected rest.DualWriterMode
+		}{
+			{unifiedmigrations.StorageModeLegacy, rest.Mode0},
+			{unifiedmigrations.StorageModeDualWrite, rest.Mode1},
+			{unifiedmigrations.StorageModeUnified, rest.Mode5},
+		} {
+			require.Equalf(t, tt.expected, storageModeToDualWriterMode(tt.mode), "StorageMode %d", tt.mode)
+		}
+	})
+
+	t.Run("NewStorage initializes metric from status reader", func(t *testing.T) {
+		for _, tt := range []struct {
+			name          string
+			mode          unifiedmigrations.StorageMode
+			wantMetricVal float64
+		}{
+			{"Legacy", unifiedmigrations.StorageModeLegacy, float64(rest.Mode0)},
+			{"DualWrite", unifiedmigrations.StorageModeDualWrite, float64(rest.Mode1)},
+			{"Unified", unifiedmigrations.StorageModeUnified, float64(rest.Mode5)},
+		} {
+			t.Run(tt.name, func(t *testing.T) {
+				metrics := newTestDualWriterMetrics()
+				svc := &storageService{
+					cfg:          &setting.Cfg{},
+					statusReader: NewFakeMigrationStatusReader(gr.String(), tt.mode),
+					metrics:      metrics,
+				}
+				_, err := svc.NewStorage(gr, ls, us)
+				require.NoError(t, err)
+				require.Equal(t, tt.wantMetricVal, testutil.ToFloat64(metrics.currentMode.WithLabelValues(gr.Resource, gr.Group)))
+			})
+		}
+	})
+
+	t.Run("metric updates dynamically when migration completes at runtime", func(t *testing.T) {
+		reader := &switchableStatusReader{mode: unifiedmigrations.StorageModeDualWrite}
+		metrics := newTestDualWriterMetrics()
+		svc := &storageService{
+			cfg:          &setting.Cfg{},
+			statusReader: reader,
+			metrics:      metrics,
+		}
+
+		storage, err := svc.NewStorage(gr, ls, us)
+		require.NoError(t, err)
+		dw, ok := storage.(*dualWriter)
+		require.True(t, ok, "expected a *dualWriter for DualWrite mode")
+		require.Equal(t, float64(rest.Mode1), testutil.ToFloat64(metrics.currentMode.WithLabelValues(gr.Resource, gr.Group)))
+
+		// Simulate a remote migration completing: status reader now returns Unified.
+		reader.mode = unifiedmigrations.StorageModeUnified
+		dw.getMode(context.Background())
+
+		require.Equal(t, float64(rest.Mode5), testutil.ToFloat64(metrics.currentMode.WithLabelValues(gr.Resource, gr.Group)))
+	})
+}
+
 // --- test helpers ---
 
 // newTestDualWriterMetrics creates isolated metrics for test assertions.
@@ -373,6 +438,9 @@ func newTestDualWriterMetrics() *dualWriterMetrics {
 		statusReaderErrors: prometheus.NewCounterVec(prometheus.CounterOpts{
 			Name: "test_reader_errors",
 		}, []string{"resource"}),
+		currentMode: prometheus.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "test_current_mode",
+		}, []string{"resource", "group"}),
 	}
 }
 
@@ -384,4 +452,13 @@ type failingStatusReader struct {
 
 func (f *failingStatusReader) GetStorageMode(_ context.Context, _ schema.GroupResource) (unifiedmigrations.StorageMode, error) {
 	return f.mode, f.err
+}
+
+// switchableStatusReader returns the current mode field, allowing tests to simulate runtime mode changes.
+type switchableStatusReader struct {
+	mode unifiedmigrations.StorageMode
+}
+
+func (s *switchableStatusReader) GetStorageMode(_ context.Context, _ schema.GroupResource) (unifiedmigrations.StorageMode, error) {
+	return s.mode, nil
 }

--- a/pkg/storage/legacysql/dualwrite/storage_service.go
+++ b/pkg/storage/legacysql/dualwrite/storage_service.go
@@ -33,12 +33,28 @@ func (m *storageService) getStorageMode(ctx context.Context, gr schema.GroupReso
 	return mode
 }
 
+// storageModeToLegacyMode maps a StorageMode to a representative DualWriterMode value
+// for metric consistency: Legacy→Mode0, DualWrite→Mode1, Unified→Mode5.
+func storageModeToLegacyMode(mode unifiedmigrations.StorageMode) rest.DualWriterMode {
+	switch mode {
+	case unifiedmigrations.StorageModeUnified:
+		return rest.Mode5
+	case unifiedmigrations.StorageModeDualWrite:
+		return rest.Mode1
+	default:
+		return rest.Mode0
+	}
+}
+
 // NewStorage creates a storage instance based on the 3-mode concept:
 //   - ModeLegacy    → return legacy
 //   - ModeDualWrite → dualWriter that checks mode dynamically on every request
 //   - ModeUnified   → return unified
 func (m *storageService) NewStorage(gr schema.GroupResource, legacy rest.Storage, unified rest.Storage) (rest.Storage, error) {
-	switch m.getStorageMode(context.Background(), gr) {
+	initialMode := m.getStorageMode(context.Background(), gr)
+	m.metrics.currentMode.WithLabelValues(gr.Resource, gr.Group).Set(float64(storageModeToLegacyMode(initialMode)))
+
+	switch initialMode {
 	case unifiedmigrations.StorageModeUnified:
 		return unified, nil
 	case unifiedmigrations.StorageModeDualWrite:
@@ -48,6 +64,7 @@ func (m *storageService) NewStorage(gr schema.GroupResource, legacy rest.Storage
 			unified: unified,
 			getMode: func(ctx context.Context) (bool, bool) {
 				mode := m.getStorageMode(ctx, gr)
+				m.metrics.currentMode.WithLabelValues(gr.Resource, gr.Group).Set(float64(storageModeToLegacyMode(mode)))
 				return mode == unifiedmigrations.StorageModeUnified,
 					mode == unifiedmigrations.StorageModeDualWrite
 			},

--- a/pkg/storage/legacysql/dualwrite/storage_service.go
+++ b/pkg/storage/legacysql/dualwrite/storage_service.go
@@ -33,9 +33,9 @@ func (m *storageService) getStorageMode(ctx context.Context, gr schema.GroupReso
 	return mode
 }
 
-// storageModeToLegacyMode maps a StorageMode to a representative DualWriterMode value
+// storageModeToDualWriterMode maps a StorageMode to a representative DualWriterMode value
 // for metric consistency: Legacy→Mode0, DualWrite→Mode1, Unified→Mode5.
-func storageModeToLegacyMode(mode unifiedmigrations.StorageMode) rest.DualWriterMode {
+func storageModeToDualWriterMode(mode unifiedmigrations.StorageMode) rest.DualWriterMode {
 	switch mode {
 	case unifiedmigrations.StorageModeUnified:
 		return rest.Mode5
@@ -52,7 +52,7 @@ func storageModeToLegacyMode(mode unifiedmigrations.StorageMode) rest.DualWriter
 //   - ModeUnified   → return unified
 func (m *storageService) NewStorage(gr schema.GroupResource, legacy rest.Storage, unified rest.Storage) (rest.Storage, error) {
 	initialMode := m.getStorageMode(context.Background(), gr)
-	m.metrics.currentMode.WithLabelValues(gr.Resource, gr.Group).Set(float64(storageModeToLegacyMode(initialMode)))
+	m.metrics.currentMode.WithLabelValues(gr.Resource, gr.Group).Set(float64(storageModeToDualWriterMode(initialMode)))
 
 	switch initialMode {
 	case unifiedmigrations.StorageModeUnified:
@@ -64,7 +64,7 @@ func (m *storageService) NewStorage(gr schema.GroupResource, legacy rest.Storage
 			unified: unified,
 			getMode: func(ctx context.Context) (bool, bool) {
 				mode := m.getStorageMode(ctx, gr)
-				m.metrics.currentMode.WithLabelValues(gr.Resource, gr.Group).Set(float64(storageModeToLegacyMode(mode)))
+				m.metrics.currentMode.WithLabelValues(gr.Resource, gr.Group).Set(float64(storageModeToDualWriterMode(mode)))
 				return mode == unifiedmigrations.StorageModeUnified,
 					mode == unifiedmigrations.StorageModeDualWrite
 			},


### PR DESCRIPTION
We will start to `finalize` the migrations, ie. start serving from unified only (mode5). I realized that we were not properly capturing the correct current mode metric after the finalizations have been completed. I observed this in dev with a test instance. (https://ops.grafana-ops.net/goto/bfkg16ry8zqbka?orgId=stacks-27821 and https://ops.grafana-ops.net/goto/efkg17wtwxloga?orgId=stacks-27821)

Update the current mode metric to accommodate the new storage status reader. As we will move on and update the storage status based on the migration status captured in the migration log table, we would need to dynamically detect and publish the correct current mode.