### PR TITLE
Add periodic snapshot upload background task

### DIFF
--- a/pkg/storage/unified/resource/bleve_index_metrics.go
+++ b/pkg/storage/unified/resource/bleve_index_metrics.go
@@ -25,6 +25,8 @@ type BleveIndexMetrics struct {
 
 	IndexSnapshotDownloads        *prometheus.CounterVec
 	IndexSnapshotDownloadDuration prometheus.Histogram
+	IndexSnapshotUploads          *prometheus.CounterVec
+	IndexSnapshotUploadDuration   prometheus.Histogram
 }
 
 var IndexCreationBuckets = []float64{1, 5, 10, 25, 50, 75, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000}
@@ -109,10 +111,26 @@ func ProvideIndexMetrics(reg prometheus.Registerer) *BleveIndexMetrics {
 			NativeHistogramMaxBucketNumber:  160,
 			NativeHistogramMinResetDuration: time.Hour,
 		}),
+		IndexSnapshotUploads: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "index_server_snapshot_uploads_total",
+			Help: "Number of remote index snapshot upload attempts, by outcome.",
+		}, []string{"status"}), // status: success, skip_no_changes, skip_lock_contention, error
+		IndexSnapshotUploadDuration: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+			Name:                            "index_server_snapshot_upload_duration_seconds",
+			Help:                            "Duration of successful remote index snapshot uploads, including snapshot creation.",
+			Buckets:                         IndexCreationBuckets,
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  160,
+			NativeHistogramMinResetDuration: time.Hour,
+		}),
 	}
 
 	// Initialize labels.
 	m.OpenIndexes.WithLabelValues("file").Set(0)
 	m.OpenIndexes.WithLabelValues("memory").Set(0)
+	m.IndexSnapshotUploads.WithLabelValues("success").Add(0)
+	m.IndexSnapshotUploads.WithLabelValues("skip_no_changes").Add(0)
+	m.IndexSnapshotUploads.WithLabelValues("skip_lock_contention").Add(0)
+	m.IndexSnapshotUploads.WithLabelValues("error").Add(0)
 	return m
 }

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -116,7 +116,7 @@ type SnapshotOptions struct {
 	// for the same resource.
 	UploadInterval time.Duration
 
-	// MinDocChanges is the minimum resource version delta required before a new
+	// MinDocChanges is the minimum persisted mutation count required before a new
 	// upload is attempted after a previous successful upload.
 	MinDocChanges int
 }
@@ -208,6 +208,11 @@ func NewBleveBackend(opts BleveOptions, indexMetrics *resource.BleveIndexMetrics
 
 	be.bgTasksWg.Add(1)
 	go be.evictExpiredOrUnownedIndexesPeriodically(ctx)
+
+	if opts.Snapshot.Store != nil {
+		be.bgTasksWg.Add(1)
+		go be.uploadSnapshotsPeriodically(ctx)
+	}
 
 	if be.indexMetrics != nil {
 		be.bgTasksWg.Add(1)
@@ -343,7 +348,7 @@ func (b *bleveBackend) shouldUpload(key resource.NamespacedResource, idx *bleveI
 		return false, nil
 	}
 
-	mutationCount, err := getSnapshotMutationCount(idx.index)
+	mutationCount, err := idx.getSnapshotMutationCount()
 	if err != nil {
 		return false, fmt.Errorf("reading snapshot mutation count for %v: %w", key, err)
 	}
@@ -373,6 +378,87 @@ func (b *bleveBackend) clearUploadTracking(key resource.NamespacedResource) {
 	b.uploadTrackingMu.Lock()
 	defer b.uploadTrackingMu.Unlock()
 	delete(b.lastUploadTime, key)
+}
+
+const (
+	snapshotUploadCheckInterval       = 5 * time.Minute
+	snapshotUploadStatusSuccess       = "success"
+	snapshotUploadStatusSkipNoChanges = "skip_no_changes"
+	snapshotUploadStatusSkipLockHeld  = "skip_lock_contention"
+	snapshotUploadStatusError         = "error"
+)
+
+func (b *bleveBackend) uploadSnapshotsPeriodically(ctx context.Context) {
+	defer b.bgTasksWg.Done()
+
+	t := time.NewTicker(snapshotUploadCheckInterval)
+	defer t.Stop()
+
+	for ctx.Err() == nil {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			b.runUploadSnapshots(ctx)
+		}
+	}
+}
+
+func (b *bleveBackend) runUploadSnapshots(ctx context.Context) {
+	now := time.Now()
+	for _, key := range b.GetOpenIndexes() {
+		idx := b.getCachedIndex(key, now)
+		if idx == nil || idx.indexStorage != indexStorageFile {
+			continue
+		}
+
+		shouldUpload, err := b.shouldUpload(key, idx, now)
+		if err != nil {
+			b.recordSnapshotUploadStatus(snapshotUploadStatusError)
+			b.log.Warn("failed to evaluate snapshot upload eligibility", "key", key, "err", err)
+			continue
+		}
+		if !shouldUpload {
+			b.recordSnapshotUploadStatus(snapshotUploadStatusSkipNoChanges)
+			continue
+		}
+
+		baselineMutations, err := idx.getSnapshotMutationCount()
+		if err != nil {
+			b.recordSnapshotUploadStatus(snapshotUploadStatusError)
+			b.log.Warn("failed to read snapshot mutation baseline", "key", key, "err", err)
+			continue
+		}
+
+		start := time.Now()
+		if err := b.uploadSnapshot(ctx, key, idx); err != nil {
+			if errors.Is(err, errLockHeld) {
+				b.recordSnapshotUploadStatus(snapshotUploadStatusSkipLockHeld)
+			} else {
+				b.recordSnapshotUploadStatus(snapshotUploadStatusError)
+				b.log.Warn("snapshot upload failed", "key", key, "err", err)
+			}
+			continue
+		}
+
+		if err := idx.subtractSnapshotMutationCount(baselineMutations); err != nil {
+			b.recordSnapshotUploadStatus(snapshotUploadStatusError)
+			b.log.Warn("failed to advance snapshot mutation baseline", "key", key, "err", err)
+			continue
+		}
+		b.setUploadTracking(key, time.Now())
+		b.recordSnapshotUploadStatus(snapshotUploadStatusSuccess)
+		if b.indexMetrics != nil {
+			b.indexMetrics.IndexSnapshotUploadDuration.Observe(time.Since(start).Seconds())
+		}
+	}
+}
+
+func (b *bleveBackend) recordSnapshotUploadStatus(status string) {
+	if b.indexMetrics == nil {
+		return
+	}
+	b.indexMetrics.IndexSnapshotUploads.WithLabelValues(status).Inc()
 }
 
 // updateIndexSizeMetric sets the total size of all file-based indices metric.
@@ -980,13 +1066,13 @@ func setRV(index bleve.Index, rv int64) error {
 	return index.SetInternal([]byte(internalRVKey), buf)
 }
 
-func setSnapshotMutationCount(index bleve.Index, count int64) error {
+func writeSnapshotMutationCount(index bleve.Index, count int64) error {
 	buf := make([]byte, 8)
 	binary.BigEndian.PutUint64(buf, uint64(count))
 	return index.SetInternal([]byte(internalSnapshotMutationCountKey), buf)
 }
 
-func getSnapshotMutationCount(index bleve.Index) (int64, error) {
+func readSnapshotMutationCount(index bleve.Index) (int64, error) {
 	raw, err := index.GetInternal([]byte(internalSnapshotMutationCountKey))
 	if err != nil {
 		return 0, err
@@ -997,15 +1083,36 @@ func getSnapshotMutationCount(index bleve.Index) (int64, error) {
 	return int64(binary.BigEndian.Uint64(raw)), nil
 }
 
+func (b *bleveIndex) getSnapshotMutationCount() (int64, error) {
+	b.snapshotMutationMu.Lock()
+	defer b.snapshotMutationMu.Unlock()
+	return readSnapshotMutationCount(b.index)
+}
+
 func (b *bleveIndex) addSnapshotMutationCount(delta int64) error {
 	b.snapshotMutationMu.Lock()
 	defer b.snapshotMutationMu.Unlock()
 
-	current, err := getSnapshotMutationCount(b.index)
+	current, err := readSnapshotMutationCount(b.index)
 	if err != nil {
 		return err
 	}
-	return setSnapshotMutationCount(b.index, current+delta)
+	return writeSnapshotMutationCount(b.index, current+delta)
+}
+
+func (b *bleveIndex) subtractSnapshotMutationCount(delta int64) error {
+	b.snapshotMutationMu.Lock()
+	defer b.snapshotMutationMu.Unlock()
+
+	current, err := readSnapshotMutationCount(b.index)
+	if err != nil {
+		return err
+	}
+	remaining := current - delta
+	if remaining < 0 {
+		remaining = 0
+	}
+	return writeSnapshotMutationCount(b.index, remaining)
 }
 
 // getRV will call index.GetInternal to retrieve the RV saved in the index. If index is closed, it will return a

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -244,17 +244,21 @@ func (b *bleveBackend) GetOpenIndexes() []resource.NamespacedResource {
 }
 
 func (b *bleveBackend) getCachedIndex(key resource.NamespacedResource, now time.Time) *bleveIndex {
-	// Check index with read-lock first.
-	b.cacheMx.RLock()
-	idx := b.cache[key]
-	b.cacheMx.RUnlock()
-
+	idx := b.peekCachedIndex(key)
 	if idx == nil {
 		return nil
 	}
-
 	idx.lastFetchedFromCache.Store(now.UnixMilli())
 	return idx
+}
+
+// peekCachedIndex returns the cached index for key without refreshing its last-fetched
+// timestamp. Use this from background scans that should not keep unowned indexes alive
+// against eviction in runEvictExpiredOrUnownedIndexes.
+func (b *bleveBackend) peekCachedIndex(key resource.NamespacedResource) *bleveIndex {
+	b.cacheMx.RLock()
+	defer b.cacheMx.RUnlock()
+	return b.cache[key]
 }
 
 func (b *bleveBackend) closeIndex(idx *bleveIndex, key resource.NamespacedResource) {
@@ -405,14 +409,13 @@ func (b *bleveBackend) uploadSnapshotsPeriodically(ctx context.Context) {
 }
 
 func (b *bleveBackend) runUploadSnapshots(ctx context.Context) {
-	now := time.Now()
 	for _, key := range b.GetOpenIndexes() {
-		idx := b.getCachedIndex(key, now)
+		idx := b.peekCachedIndex(key)
 		if idx == nil || idx.indexStorage != indexStorageFile {
 			continue
 		}
 
-		shouldUpload, err := b.shouldUpload(key, idx, now)
+		shouldUpload, err := b.shouldUpload(key, idx, time.Now())
 		if err != nil {
 			b.recordSnapshotUploadStatus(snapshotUploadStatusError)
 			b.log.Warn("failed to evaluate snapshot upload eligibility", "key", key, "err", err)

--- a/pkg/storage/unified/search/bleve_snapshot.go
+++ b/pkg/storage/unified/search/bleve_snapshot.go
@@ -115,7 +115,7 @@ func (b *bleveBackend) tryDownloadRemoteSnapshot(
 		uploadedAt = downloadedMeta.UploadTimestamp
 	}
 	// A downloaded snapshot becomes the new upload baseline for this index.
-	if err := setSnapshotMutationCount(idx, 0); err != nil {
+	if err := writeSnapshotMutationCount(idx, 0); err != nil {
 		_ = idx.Close()
 		_ = os.RemoveAll(destDir)
 		b.recordSnapshotDownloadStatus(snapshotStatusValidateError)

--- a/pkg/storage/unified/search/bleve_snapshot_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_test.go
@@ -439,7 +439,7 @@ func TestShouldUpload(t *testing.T) {
 	t.Run("skips when upload interval has not elapsed", func(t *testing.T) {
 		be, _ := newTestBleveBackend(t, SnapshotOptions{MinDocCount: 1, UploadInterval: time.Hour, MinDocChanges: 1})
 		idx := newUploadTestIndex(t, be, key, 42)
-		require.NoError(t, setSnapshotMutationCount(idx.index, 5))
+		require.NoError(t, writeSnapshotMutationCount(idx.index, 5))
 		be.setUploadTracking(key, time.Now().Add(-30*time.Minute))
 
 		should, err := be.shouldUpload(key, idx, time.Now())
@@ -450,7 +450,7 @@ func TestShouldUpload(t *testing.T) {
 	t.Run("skips when mutation count is below threshold", func(t *testing.T) {
 		be, _ := newTestBleveBackend(t, SnapshotOptions{MinDocCount: 1, UploadInterval: time.Minute, MinDocChanges: 100})
 		idx := newUploadTestIndex(t, be, key, 150)
-		require.NoError(t, setSnapshotMutationCount(idx.index, 50))
+		require.NoError(t, writeSnapshotMutationCount(idx.index, 50))
 		be.setUploadTracking(key, time.Now().Add(-2*time.Minute))
 
 		should, err := be.shouldUpload(key, idx, time.Now())
@@ -461,7 +461,7 @@ func TestShouldUpload(t *testing.T) {
 	t.Run("uploads when interval elapsed and mutation count is large enough", func(t *testing.T) {
 		be, _ := newTestBleveBackend(t, SnapshotOptions{MinDocCount: 1, UploadInterval: time.Minute, MinDocChanges: 25})
 		idx := newUploadTestIndex(t, be, key, 150)
-		require.NoError(t, setSnapshotMutationCount(idx.index, 30))
+		require.NoError(t, writeSnapshotMutationCount(idx.index, 30))
 		be.setUploadTracking(key, time.Now().Add(-2*time.Minute))
 
 		should, err := be.shouldUpload(key, idx, time.Now())
@@ -475,7 +475,7 @@ func TestBulkIndexTracksSnapshotMutations(t *testing.T) {
 	key := newTestNsResource()
 	idx := newUploadTestIndex(t, be, key, 42)
 
-	count, err := getSnapshotMutationCount(idx.index)
+	count, err := readSnapshotMutationCount(idx.index)
 	require.NoError(t, err)
 	assert.Equal(t, int64(0), count)
 
@@ -505,7 +505,7 @@ func TestBulkIndexTracksSnapshotMutations(t *testing.T) {
 	}})
 	require.NoError(t, err)
 
-	count, err = getSnapshotMutationCount(idx.index)
+	count, err = readSnapshotMutationCount(idx.index)
 	require.NoError(t, err)
 	assert.Equal(t, int64(2), count)
 }
@@ -590,7 +590,7 @@ func TestIntegrationBleveSnapshotRoundTrip(t *testing.T) {
 	require.True(t, tracked)
 	assert.WithinDuration(t, meta.UploadTimestamp, trackedAt, time.Second)
 
-	mutationCount, err := getSnapshotMutationCount(bi.index)
+	mutationCount, err := readSnapshotMutationCount(bi.index)
 	require.NoError(t, err)
 	assert.Zero(t, mutationCount)
 }

--- a/pkg/storage/unified/search/bleve_snapshot_upload_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_upload_test.go
@@ -12,10 +12,13 @@ import (
 
 	"github.com/blevesearch/bleve/v2"
 	"github.com/oklog/ulid/v2"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
 
 type uploadTestStore struct {
@@ -25,6 +28,7 @@ type uploadTestStore struct {
 	uploadCalls atomic.Int32
 	uploadMeta  IndexMeta
 	uploaded    []string
+	onUpload    func() error
 }
 
 func (s *uploadTestStore) LockBuildIndex(context.Context, resource.NamespacedResource) (IndexStoreLock, error) {
@@ -54,6 +58,11 @@ func (s *uploadTestStore) UploadIndex(_ context.Context, _ resource.NamespacedRe
 	})
 	if err != nil {
 		return ulid.ULID{}, err
+	}
+	if s.onUpload != nil {
+		if err := s.onUpload(); err != nil {
+			return ulid.ULID{}, err
+		}
 	}
 	if s.uploadErr != nil {
 		return ulid.ULID{}, s.uploadErr
@@ -91,6 +100,26 @@ func newUploadTestIndex(t *testing.T, be *bleveBackend, key resource.NamespacedR
 
 	wrapped := be.newBleveIndex(key, idx, indexStorageFile, nil, nil, nil, nil, be.log)
 	wrapped.resourceVersion.Store(rv)
+	return wrapped
+}
+
+func newCachedUploadTestIndex(t *testing.T, be *bleveBackend, key resource.NamespacedResource, rv int64) *bleveIndex {
+	t.Helper()
+	resourceDir := be.getResourceDir(key)
+	require.NoError(t, os.MkdirAll(resourceDir, 0o750))
+
+	idx, err := newBleveIndex(filepath.Join(resourceDir, formatIndexName(time.Now())), bleve.NewIndexMapping(), time.Now(), be.opts.BuildVersion, nil)
+	require.NoError(t, err)
+
+	require.NoError(t, idx.Index("dash-1", map[string]string{"title": "Production Overview"}))
+	require.NoError(t, setRV(idx, rv))
+
+	wrapped := be.newBleveIndex(key, idx, indexStorageFile, nil, nil, nil, nil, be.log)
+	wrapped.resourceVersion.Store(rv)
+
+	be.cacheMx.Lock()
+	be.cache[key] = wrapped
+	be.cacheMx.Unlock()
 	return wrapped
 }
 
@@ -157,4 +186,85 @@ func TestUploadSnapshot_UploadErrorCleansStagingDir(t *testing.T) {
 	entries, readErr := os.ReadDir(snapshotParent)
 	require.NoError(t, readErr)
 	assert.Empty(t, entries)
+}
+
+func TestRunUploadSnapshots_Success(t *testing.T) {
+	store := &uploadTestStore{}
+	be, metrics := newTestBleveBackend(t, SnapshotOptions{Store: store, MinDocCount: 1, UploadInterval: time.Hour, MinDocChanges: 1})
+	key := newTestNsResource()
+	idx := newCachedUploadTestIndex(t, be, key, 42)
+	require.NoError(t, writeSnapshotMutationCount(idx.index, 3))
+
+	be.runUploadSnapshots(context.Background())
+
+	assert.Equal(t, int32(1), store.uploadCalls.Load())
+	trackedAt, ok := be.getUploadTracking(key)
+	require.True(t, ok)
+	assert.False(t, trackedAt.IsZero())
+
+	count, err := readSnapshotMutationCount(idx.index)
+	require.NoError(t, err)
+	assert.Zero(t, count)
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotUploads.WithLabelValues(snapshotUploadStatusSuccess)))
+
+	m := &dto.Metric{}
+	require.NoError(t, metrics.IndexSnapshotUploadDuration.Write(m))
+	assert.Equal(t, uint64(1), m.GetHistogram().GetSampleCount())
+}
+
+func TestRunUploadSnapshots_SkipNoChanges(t *testing.T) {
+	store := &uploadTestStore{}
+	be, metrics := newTestBleveBackend(t, SnapshotOptions{Store: store, MinDocCount: 1, UploadInterval: time.Hour, MinDocChanges: 10})
+	key := newTestNsResource()
+	idx := newCachedUploadTestIndex(t, be, key, 42)
+	require.NoError(t, writeSnapshotMutationCount(idx.index, 5))
+	be.setUploadTracking(key, time.Now().Add(-2*time.Hour))
+
+	be.runUploadSnapshots(context.Background())
+
+	assert.Zero(t, store.uploadCalls.Load())
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotUploads.WithLabelValues(snapshotUploadStatusSkipNoChanges)))
+}
+
+func TestRunUploadSnapshots_SkipLockContention(t *testing.T) {
+	store := &uploadTestStore{lockErr: errLockHeld}
+	be, metrics := newTestBleveBackend(t, SnapshotOptions{Store: store, MinDocCount: 1, UploadInterval: time.Hour, MinDocChanges: 1})
+	key := newTestNsResource()
+	idx := newCachedUploadTestIndex(t, be, key, 42)
+	require.NoError(t, writeSnapshotMutationCount(idx.index, 5))
+	be.setUploadTracking(key, time.Now().Add(-2*time.Hour))
+
+	be.runUploadSnapshots(context.Background())
+
+	assert.Zero(t, store.uploadCalls.Load())
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotUploads.WithLabelValues(snapshotUploadStatusSkipLockHeld)))
+}
+
+func TestRunUploadSnapshots_PreservesConcurrentMutations(t *testing.T) {
+	store := &uploadTestStore{}
+	be, _ := newTestBleveBackend(t, SnapshotOptions{Store: store, MinDocCount: 1, UploadInterval: time.Hour, MinDocChanges: 1})
+	key := newTestNsResource()
+	idx := newCachedUploadTestIndex(t, be, key, 42)
+	require.NoError(t, writeSnapshotMutationCount(idx.index, 3))
+	store.onUpload = func() error {
+		return idx.BulkIndex(&resource.BulkIndexRequest{Items: []*resource.BulkIndexItem{{
+			Action: resource.ActionIndex,
+			Doc: &resource.IndexableDocument{
+				Name:  "dash-2",
+				Title: "dash-2",
+				Key: &resourcepb.ResourceKey{
+					Name:      "dash-2",
+					Namespace: key.Namespace,
+					Group:     key.Group,
+					Resource:  key.Resource,
+				},
+			},
+		}}})
+	}
+
+	be.runUploadSnapshots(context.Background())
+
+	count, err := readSnapshotMutationCount(idx.index)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), count)
 }


### PR DESCRIPTION
This adds the background runner that drives periodic Bleve snapshot uploads.

A goroutine ticks every 5 minutes, walks the open file-based indexes, and for each one consults the upload policy added in #123605. Eligible indexes are uploaded under the distributed build lock using the primitive added in #123474.

After a successful upload, the persisted mutation count is advanced by subtracting the value read before the upload, so any mutations that arrived while the upload was in flight are preserved as the next baseline. Upload timing is updated only on success; lock contention and policy skips leave both the timing and mutation count untouched.

Adds `index_server_snapshot_uploads_total` with `success`, `skip_no_changes`, `skip_lock_contention`, and `error` outcomes, and `index_server_snapshot_upload_duration_seconds` for successful upload duration.

Part of https://github.com/grafana/search-and-storage-team/issues/721.