### PR TITLE
Provisioning: Return test results instead of HTTP 500 when GetDefaultBranch fails

### DIFF
--- a/apps/provisioning/pkg/repository/github/repository.go
+++ b/apps/provisioning/pkg/repository/github/repository.go
@@ -125,7 +125,7 @@ func (r *githubRepository) Test(ctx context.Context) (*provisioning.TestResults,
 	if r.GetCurrentBranch() == "" {
 		branch, err := r.GetDefaultBranch(ctx)
 		if err != nil {
-			return nil, err
+			return testResultFromGetDefaultBranchError(url, err), nil
 		}
 
 		r.SetBranch(branch)
@@ -141,6 +141,44 @@ func (r *githubRepository) Test(ctx context.Context) (*provisioning.TestResults,
 	}
 
 	return results, nil
+}
+
+// testResultFromGetDefaultBranchError converts a GetDefaultBranch failure into a
+// user-facing TestResults. The /test endpoint is the onboarding entry point; surfacing
+// these as bare Go errors turns recoverable conditions (wrong URL, missing token scope,
+// transient GitHub outage) into opaque HTTP 500s.
+func testResultFromGetDefaultBranchError(url string, err error) *provisioning.TestResults {
+	path := field.NewPath("spec", "github", "url")
+	code := http.StatusBadRequest
+	var detail string
+
+	switch {
+	case errors.Is(err, repository.ErrFileNotFound):
+		detail = fmt.Sprintf("repository %q not found, or the configured token does not have access to it", url)
+	case errors.Is(err, repository.ErrUnauthorized):
+		path = field.NewPath("spec", "github", "token")
+		code = http.StatusUnauthorized
+		detail = "authentication failed: the configured token is invalid or expired"
+	case errors.Is(err, repository.ErrPermissionDenied):
+		path = field.NewPath("spec", "github", "token")
+		code = http.StatusForbidden
+		detail = fmt.Sprintf("the configured token lacks permission to access %q", url)
+	case errors.Is(err, repository.ErrServerUnavailable):
+		code = http.StatusServiceUnavailable
+		detail = "GitHub is currently unavailable, please try again later"
+	default:
+		detail = err.Error()
+	}
+
+	return &provisioning.TestResults{
+		Code:    code,
+		Success: false,
+		Errors: []provisioning.ErrorDetails{{
+			Type:   metav1.CauseTypeFieldValueInvalid,
+			Field:  path.String(),
+			Detail: detail,
+		}},
+	}
 }
 
 // checkBranchProtection validates that branch protection rules and repository rulesets

--- a/apps/provisioning/pkg/repository/github/repository_test.go
+++ b/apps/provisioning/pkg/repository/github/repository_test.go
@@ -1755,7 +1755,7 @@ func TestGitHubRepository_Test_EmptyBranch(t *testing.T) {
 		gitTestError   error
 		expectGetRepo  bool
 		expectedBranch string
-		expectedError  bool
+		expectedResult *provisioning.TestResults
 	}{
 		{
 			name:          "empty branch triggers GetDefaultBranch and sets default branch",
@@ -1766,7 +1766,6 @@ func TestGitHubRepository_Test_EmptyBranch(t *testing.T) {
 			},
 			expectGetRepo:  true,
 			expectedBranch: "develop",
-			expectedError:  false,
 		},
 		{
 			name:          "non-empty branch does not trigger GetDefaultBranch",
@@ -1776,14 +1775,81 @@ func TestGitHubRepository_Test_EmptyBranch(t *testing.T) {
 			},
 			expectGetRepo:  false,
 			expectedBranch: "feature-branch",
-			expectedError:  false,
 		},
 		{
-			name:          "GetDefaultBranch failure returns error",
+			name:          "GetDefaultBranch returns ErrFileNotFound (404) → URL field error",
+			initialBranch: "",
+			getRepoError:  repo.ErrFileNotFound,
+			expectGetRepo: true,
+			expectedResult: &provisioning.TestResults{
+				Code:    http.StatusBadRequest,
+				Success: false,
+				Errors: []provisioning.ErrorDetails{{
+					Type:   metav1.CauseTypeFieldValueInvalid,
+					Field:  "spec.github.url",
+					Detail: `repository "https://github.com/grafana/grafana" not found, or the configured token does not have access to it`,
+				}},
+			},
+		},
+		{
+			name:          "GetDefaultBranch returns ErrUnauthorized (401) → token field error",
+			initialBranch: "",
+			getRepoError:  repo.ErrUnauthorized,
+			expectGetRepo: true,
+			expectedResult: &provisioning.TestResults{
+				Code:    http.StatusUnauthorized,
+				Success: false,
+				Errors: []provisioning.ErrorDetails{{
+					Type:   metav1.CauseTypeFieldValueInvalid,
+					Field:  "spec.github.token",
+					Detail: "authentication failed: the configured token is invalid or expired",
+				}},
+			},
+		},
+		{
+			name:          "GetDefaultBranch returns ErrPermissionDenied (403) → token field error",
+			initialBranch: "",
+			getRepoError:  repo.ErrPermissionDenied,
+			expectGetRepo: true,
+			expectedResult: &provisioning.TestResults{
+				Code:    http.StatusForbidden,
+				Success: false,
+				Errors: []provisioning.ErrorDetails{{
+					Type:   metav1.CauseTypeFieldValueInvalid,
+					Field:  "spec.github.token",
+					Detail: `the configured token lacks permission to access "https://github.com/grafana/grafana"`,
+				}},
+			},
+		},
+		{
+			name:          "GetDefaultBranch returns ErrServerUnavailable → 503 result",
+			initialBranch: "",
+			getRepoError:  repo.ErrServerUnavailable,
+			expectGetRepo: true,
+			expectedResult: &provisioning.TestResults{
+				Code:    http.StatusServiceUnavailable,
+				Success: false,
+				Errors: []provisioning.ErrorDetails{{
+					Type:   metav1.CauseTypeFieldValueInvalid,
+					Field:  "spec.github.url",
+					Detail: "GitHub is currently unavailable, please try again later",
+				}},
+			},
+		},
+		{
+			name:          "GetDefaultBranch returns unclassified error → generic 400 result",
 			initialBranch: "",
 			getRepoError:  errors.New("API rate limit exceeded"),
 			expectGetRepo: true,
-			expectedError: true, // Error is returned as error, not in TestResults
+			expectedResult: &provisioning.TestResults{
+				Code:    http.StatusBadRequest,
+				Success: false,
+				Errors: []provisioning.ErrorDetails{{
+					Type:   metav1.CauseTypeFieldValueInvalid,
+					Field:  "spec.github.url",
+					Detail: "failed to get repository metadata: API rate limit exceeded",
+				}},
+			},
 		},
 		{
 			name:          "empty branch with git test failure after branch detection",
@@ -1800,7 +1866,6 @@ func TestGitHubRepository_Test_EmptyBranch(t *testing.T) {
 			},
 			expectGetRepo:  true,
 			expectedBranch: "main",
-			expectedError:  false,
 		},
 	}
 
@@ -1864,20 +1929,20 @@ func TestGitHubRepository_Test_EmptyBranch(t *testing.T) {
 			result, err := githubRepo.Test(context.Background())
 
 			// Verify
-			if tt.expectedError {
-				require.Error(t, err)
-				if tt.getRepoError != nil {
-					assert.Contains(t, err.Error(), "failed to get repository metadata")
-				}
-			} else {
-				require.NoError(t, err)
-				if tt.expectedBranch != "" {
-					// Verify branch was updated in config
-					assert.Equal(t, tt.expectedBranch, config.Spec.GitHub.Branch)
+			require.NoError(t, err, "Test() must surface failures via TestResults, not Go errors")
 
-					if result != nil {
-						assert.Equal(t, tt.gitTestResults.Success, result.Success)
-					}
+			if tt.expectedResult != nil {
+				require.NotNil(t, result)
+				assert.Equal(t, tt.expectedResult, result)
+				return
+			}
+
+			if tt.expectedBranch != "" {
+				// Verify branch was updated in config
+				assert.Equal(t, tt.expectedBranch, config.Spec.GitHub.Branch)
+
+				if result != nil {
+					assert.Equal(t, tt.gitTestResults.Success, result.Success)
 				}
 			}
 		})


### PR DESCRIPTION
## Summary

The `/test` subresource on `provisioning.grafana.app` repositories is the onboarding entry point — the frontend calls it before persisting the configuration to surface validation errors. When the request body specified a GitHub repository with an empty branch, the temporary repository's `Test()` called `GetDefaultBranch`, and any failure there was propagated as a Go error → `responder.Error(err)` → HTTP 500 with `"failed to get repository metadata: file not found"`. Users hitting this during onboarding had no way to know whether their URL was wrong, their token expired, or they lacked permissions.

This change classifies the underlying error from `GetDefaultBranch` and returns a `TestResults` with a field-targeted `ErrorDetails`, mirroring the existing URL-parse and branch-protection handling in the same method.

## Behavior

| GitHub response | Before | After |
| --- | --- | --- |
| 404 (repo missing or token has no access) | 500 `"failed to get repository metadata: file not found"` | 400 on `spec.github.url` |
| 401 (invalid/expired token) | 500 | 401 on `spec.github.token` |
| 403 (no permission) | 500 | 403 on `spec.github.token` |
| 5xx (GitHub down) | 500 | 503 on `spec.github.url` |
| Anything else | 500 with raw error | 400 on `spec.github.url` with raw error in `Detail` |

## Files

- `apps/provisioning/pkg/repository/github/repository.go`: `Test()` now calls a new `testResultFromGetDefaultBranchError` helper instead of returning the bare error.
- `apps/provisioning/pkg/repository/github/repository_test.go`: replaced the single "GetDefaultBranch failure returns error" case with one case per classified error type.

## Test plan

- [x] `go test ./apps/provisioning/pkg/repository/github/... -count=1`
- [ ] Manual: hit `POST /apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/new/test` with a wrong URL / no-access token and confirm the response is a structured `TestResults` rather than HTTP 500.