### PR TITLE
IAM: Inject DefaultOrgID in User.Create method

### DIFF
--- a/pkg/services/user/userimpl/user.go
+++ b/pkg/services/user/userimpl/user.go
@@ -60,7 +60,11 @@ func ProvideService(db db.DB,
 
 func (s *Service) Create(ctx context.Context, cmd *user.CreateUserCommand) (*user.User, error) {
 	if s.isKubernetesUserServiceEnabled(ctx) {
-		return s.k8sService.Create(ctx, cmd)
+		k8sCtx := ctx
+		if !hasOrgID(ctx) {
+			k8sCtx = identity.WithOrgID(ctx, s.cfg.DefaultOrgID())
+		}
+		return s.k8sService.Create(k8sCtx, cmd)
 	}
 
 	return s.legacyService.Create(ctx, cmd)

--- a/pkg/services/user/userk8s/user.go
+++ b/pkg/services/user/userk8s/user.go
@@ -61,7 +61,7 @@ func (s *UserK8sService) Create(ctx context.Context, cmd *user.CreateUserCommand
 
 	orgID, err := s.getOrgID(ctx, ctxLogger)
 	if err != nil {
-		ctxLogger.Error("failed to get orgID from context", "err", err)
+		ctxLogger.Error("failed to get orgID from context in Create", "err", err)
 		return nil, err
 	}
 
@@ -133,7 +133,7 @@ func (s *UserK8sService) GetByID(ctx context.Context, cmd *user.GetUserByIDQuery
 
 	orgID, err := s.getOrgID(ctx, ctxLogger)
 	if err != nil {
-		ctxLogger.Error("failed to get orgID from context", "err", err)
+		ctxLogger.Error("failed to get orgID from context in GetByID", "err", err)
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		return nil, err
@@ -184,7 +184,7 @@ func (s *UserK8sService) GetByLogin(ctx context.Context, cmd *user.GetUserByLogi
 
 	orgID, err := s.getOrgID(ctx, ctxLogger)
 	if err != nil {
-		ctxLogger.Error("failed to get orgID from context", "err", err)
+		ctxLogger.Error("failed to get orgID from context in GetByLogin", "err", err)
 		return nil, err
 	}
 
@@ -227,7 +227,7 @@ func (s *UserK8sService) GetByEmail(ctx context.Context, cmd *user.GetUserByEmai
 
 	orgID, err := s.getOrgID(ctx, ctxLogger)
 	if err != nil {
-		ctxLogger.Error("failed to get orgID from context", "err", err)
+		ctxLogger.Error("failed to get orgID from context in GetByEmail", "err", err)
 		return nil, err
 	}
 
@@ -259,7 +259,7 @@ func (s *UserK8sService) Update(ctx context.Context, cmd *user.UpdateUserCommand
 
 	orgID, err := s.getOrgID(ctx, ctxLogger)
 	if err != nil {
-		ctxLogger.Error("failed to get orgID from context", "err", err)
+		ctxLogger.Error("failed to get orgID from context in Update", "err", err)
 		span.RecordError(err)
 		span.SetStatus(codes.Error, err.Error())
 		return err
@@ -379,7 +379,7 @@ func (s *UserK8sService) GetSignedInUser(ctx context.Context, cmd *user.GetSigne
 		var err error
 		orgID, err = s.getOrgID(ctx, ctxLogger)
 		if err != nil {
-			ctxLogger.Error("failed to get orgID from context", "err", err)
+			ctxLogger.Error("failed to get orgID from context in GetSignedInUser", "err", err)
 			span.RecordError(err)
 			span.SetStatus(codes.Error, err.Error())
 			return nil, err


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Update the User service to inject the DefaultOrgID in the `Create` method in case there is no orgID in context. It's the same pattern used by the other methods in the User service.

Related to https://github.com/grafana/grafana/pull/123636.

**Why do we need this feature?**

During an OAuth login, the request goes through `authn.Login`, which does not call `identity.WithOrgID` on the context.  So by the time `SyncUserHook` runs, there is neither a Requester nor an OrgID in the context. `getOrgID` in the k8s service fails with `no requester or orgID in context`.

**Who is this feature for?**

all users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
