### PR TITLE
Folders: Remove unused FolderUnifiedStoreImpl.GetHeight

### DIFF
--- a/pkg/services/folder/folderimpl/unifiedstore.go
+++ b/pkg/services/folder/folderimpl/unifiedstore.go
@@ -303,37 +303,6 @@ func (ss *FolderUnifiedStoreImpl) GetChildren(ctx context.Context, q folder.GetC
 	return hits, nil
 }
 
-// TODO use a single query to get the height of a folder
-func (ss *FolderUnifiedStoreImpl) GetHeight(ctx context.Context, foldrUID string, orgID int64, parentUID *string) (int, error) {
-	ctx, span := ss.tracer.Start(ctx, tracePrefix+"GetHeight")
-	defer span.End()
-
-	height := -1
-	queue := []string{foldrUID}
-	for len(queue) > 0 && height <= ss.maxDepth {
-		length := len(queue)
-		height++
-		for i := 0; i < length; i++ {
-			ele := queue[0]
-			queue = queue[1:]
-			if parentUID != nil && *parentUID == ele {
-				return 0, folder.ErrCircularReference.Errorf("circular reference detected")
-			}
-			folders, err := ss.GetChildren(ctx, folder.GetChildrenQuery{UID: ele, OrgID: orgID})
-			if err != nil {
-				return 0, err
-			}
-			for _, f := range folders {
-				queue = append(queue, f.UID)
-			}
-		}
-	}
-	if height > ss.maxDepth {
-		ss.log.Warn("folder height exceeds the maximum allowed depth, You might have a circular reference", "uid", foldrUID, "orgId", orgID, "maxDepth", ss.maxDepth)
-	}
-	return height, nil
-}
-
 // GetFolders returns org folders by their UIDs.
 // If UIDs is empty, it returns all folders in the org.
 // If WithFullpath is true it computes also the full path of a folder.

--- a/pkg/services/folder/store.go
+++ b/pkg/services/folder/store.go
@@ -40,10 +40,6 @@ type Store interface {
 	// given folder.
 	GetChildren(ctx context.Context, q GetChildrenQuery) ([]*FolderReference, error)
 
-	// GetHeight returns the height of the folder tree. When parentUID is set, the function would
-	// verify in the meanwhile that parentUID is not present in the subtree of the folder with the given UID.
-	GetHeight(ctx context.Context, foldrUID string, orgID int64, parentUID *string) (int, error)
-
 	// GetFolders returns folders with given uids
 	GetFolders(ctx context.Context, q GetFoldersFromStoreQuery) ([]*Folder, error)
 	// GetDescendants returns all descendants of a folder (with no guaranteed order)

--- a/pkg/services/folder/store_fake.go
+++ b/pkg/services/folder/store_fake.go
@@ -10,7 +10,6 @@ type fakeStore struct {
 	ExpectedFolders       []*Folder
 	ExpectedFolder        *Folder
 	ExpectedError         error
-	ExpectedFolderHeight  int
 	CreateCalled          bool
 	DeleteCalled          bool
 }
@@ -45,10 +44,6 @@ func (f *fakeStore) GetParents(ctx context.Context, q GetParentsQuery) ([]*Folde
 
 func (f *fakeStore) GetChildren(ctx context.Context, cmd GetChildrenQuery) ([]*FolderReference, error) {
 	return f.ExpectedChildFolders, f.ExpectedError
-}
-
-func (f *fakeStore) GetHeight(ctx context.Context, folderUID string, orgID int64, parentUID *string) (int, error) {
-	return f.ExpectedFolderHeight, f.ExpectedError
 }
 
 func (f *fakeStore) GetFolders(ctx context.Context, q GetFoldersFromStoreQuery) ([]*Folder, error) {


### PR DESCRIPTION
Removes `GetHeight` from the folder store. The method has no callers anywhere in the codebase — only the interface declaration and two implementations existed.

Identified as dead code while reviewing #123663. Removing it shrinks the `folder.Store` surface area and avoids future maintenance of code nobody uses.

The `log` and `maxDepth` fields on `FolderUnifiedStoreImpl`, and the `cfg *setting.Cfg` parameter on `ProvideUnifiedStore`, become unused on `main` after this PR — but #123663 reuses them in the rewritten `GetDescendants`, so they are intentionally retained here to avoid pointless churn / merge conflicts between the two PRs.

No behaviour change. No changelog entry needed.