### PR TITLE
SplashScreen: Persist dismissal on CTA click without closing modal

### DIFF
--- a/public/app/core/components/SplashScreenModal/SplashScreenModal.tsx
+++ b/public/app/core/components/SplashScreenModal/SplashScreenModal.tsx
@@ -26,7 +26,7 @@ export function SplashScreenModal() {
   const [activeIndex, setActiveIndex] = useState(0);
   const styles = useStyles2(getStyles);
   const config = getSplashScreenConfig();
-  const { shouldShow, dismiss } = useShouldShowSplash(config.version);
+  const { shouldShow, dismiss, markEngaged } = useShouldShowSplash(config.version);
 
   const total = config.features.length;
   const goToPrev = useCallback(() => setActiveIndex((i) => (i - 1 + total) % total), [total]);
@@ -69,6 +69,7 @@ export function SplashScreenModal() {
           variant="secondary"
           fill="outline"
           size="md"
+          onClick={markEngaged}
         >
           {cta.text}
         </LinkButton>

--- a/public/app/core/components/SplashScreenModal/useShouldShowSplash.ts
+++ b/public/app/core/components/SplashScreenModal/useShouldShowSplash.ts
@@ -3,51 +3,14 @@ import { useCallback, useEffect, useState } from 'react';
 import { useUserStorage } from '@grafana/runtime/internal';
 
 const STORAGE_KEY = 'dismissedVersion';
-const SESSION_KEY_PREFIX = 'grafana-splash-active-';
-
-// Per-tab flag that survives reloads but not tab close. Lets the modal stay
-// available after the user clicks a CTA (which persists the dismissal in
-// userStorage) so they can still browse the remaining slides in this tab,
-// while new tabs / future sessions correctly skip the splash.
-const sessionKey = (version: string) => `${SESSION_KEY_PREFIX}${version}`;
-
-const readSessionFlag = (version: string): boolean => {
-  try {
-    return window.sessionStorage.getItem(sessionKey(version)) !== null;
-  } catch {
-    return false;
-  }
-};
-
-const writeSessionFlag = (version: string) => {
-  try {
-    window.sessionStorage.setItem(sessionKey(version), '1');
-  } catch {
-    // sessionStorage may be unavailable (e.g. locked-down browser settings);
-    // splash will still work, it just won't survive a reload after engaging.
-  }
-};
-
-const clearSessionFlag = (version: string) => {
-  try {
-    window.sessionStorage.removeItem(sessionKey(version));
-  } catch {
-    // ignore
-  }
-};
 
 export function useShouldShowSplash(version: string) {
   const [shouldShow, setShouldShow] = useState(false);
   const splashStorage = useUserStorage('grafana-splash-screen');
 
   useEffect(() => {
-    if (readSessionFlag(version)) {
-      setShouldShow(true);
-      return;
-    }
     splashStorage.getItem(STORAGE_KEY).then((dismissedVersion) => {
       if (dismissedVersion !== version) {
-        writeSessionFlag(version);
         setShouldShow(true);
       }
     });
@@ -63,7 +26,6 @@ export function useShouldShowSplash(version: string) {
 
   const dismiss = useCallback(() => {
     splashStorage.setItem(STORAGE_KEY, version);
-    clearSessionFlag(version);
     setShouldShow(false);
   }, [version, splashStorage]);
 

--- a/public/app/core/components/SplashScreenModal/useShouldShowSplash.ts
+++ b/public/app/core/components/SplashScreenModal/useShouldShowSplash.ts
@@ -3,23 +3,69 @@ import { useCallback, useEffect, useState } from 'react';
 import { useUserStorage } from '@grafana/runtime/internal';
 
 const STORAGE_KEY = 'dismissedVersion';
+const SESSION_KEY_PREFIX = 'grafana-splash-active-';
+
+// Per-tab flag that survives reloads but not tab close. Lets the modal stay
+// available after the user clicks a CTA (which persists the dismissal in
+// userStorage) so they can still browse the remaining slides in this tab,
+// while new tabs / future sessions correctly skip the splash.
+const sessionKey = (version: string) => `${SESSION_KEY_PREFIX}${version}`;
+
+const readSessionFlag = (version: string): boolean => {
+  try {
+    return window.sessionStorage.getItem(sessionKey(version)) !== null;
+  } catch {
+    return false;
+  }
+};
+
+const writeSessionFlag = (version: string) => {
+  try {
+    window.sessionStorage.setItem(sessionKey(version), '1');
+  } catch {
+    // sessionStorage may be unavailable (e.g. locked-down browser settings);
+    // splash will still work, it just won't survive a reload after engaging.
+  }
+};
+
+const clearSessionFlag = (version: string) => {
+  try {
+    window.sessionStorage.removeItem(sessionKey(version));
+  } catch {
+    // ignore
+  }
+};
 
 export function useShouldShowSplash(version: string) {
   const [shouldShow, setShouldShow] = useState(false);
   const splashStorage = useUserStorage('grafana-splash-screen');
 
   useEffect(() => {
+    if (readSessionFlag(version)) {
+      setShouldShow(true);
+      return;
+    }
     splashStorage.getItem(STORAGE_KEY).then((dismissedVersion) => {
       if (dismissedVersion !== version) {
+        writeSessionFlag(version);
         setShouldShow(true);
       }
     });
   }, [version, splashStorage]);
 
+  // Persist the dismissal but keep the modal open so the user can continue
+  // navigating slides. Used when the user clicks a CTA that opens an external
+  // page in a new tab - we treat that as "user has seen the splash" without
+  // unmounting the current tab's modal.
+  const markEngaged = useCallback(() => {
+    splashStorage.setItem(STORAGE_KEY, version);
+  }, [version, splashStorage]);
+
   const dismiss = useCallback(() => {
     splashStorage.setItem(STORAGE_KEY, version);
+    clearSessionFlag(version);
     setShouldShow(false);
   }, [version, splashStorage]);
 
-  return { shouldShow, dismiss };
+  return { shouldShow, dismiss, markEngaged };
 }


### PR DESCRIPTION
## What

When a user clicks a "Show me" CTA on the splash screen, persist the dismissal in `userStorage` immediately, but keep the modal open so the user can continue browsing the remaining slides in the current tab. New tabs and future sessions correctly skip the splash.

A per-tab `sessionStorage` flag is used so that reloading the current tab after engaging keeps the modal visible - without it, a stray refresh would silently destroy the rest of the slides for that user.

## Why

Today, clicking a CTA opens the target page in a new tab while the original tab still shows the splash screen. The new tab also re-shows the splash, which is confusing - the user has clearly already engaged with it. We want:

- New tab / next session: splash is gone (CTA click counts as "seen").
- Current tab: modal stays open so the user can read the remaining slides.
- Hard close (X): splash is gone everywhere on next load.

## Behavior

| Action | Result |
| --- | --- |
| First load | Splash shows |
| Click "Show me" | Dismissal persisted, current modal stays open |
| Reload current tab after engaging | Splash still shows (sessionStorage) |
| Open new tab after engaging | Splash skipped |
| Click X | Splash closes, future loads skip |
| Close tab and reopen Grafana | Splash skipped |