### PR TITLE
Transformations: Add copy to clipboard button in debug view

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/TransformationDebugDisplay.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/TransformationDebugDisplay.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
-import { Drawer, Icon, JSONFormatter, Stack, useStyles2 } from '@grafana/ui';
+import { ClipboardButton, Drawer, Icon, JSONFormatter, Stack, useStyles2 } from '@grafana/ui';
 
 import { usePanelContext, useQueryEditorUIContext, useQueryRunnerContext } from './QueryEditorContext';
 import { useTransformationDebugData } from './hooks/useTransformationDebugData';
@@ -38,6 +38,15 @@ export function TransformationDebugDisplay() {
         <div className={styles.debug}>
           <div className={styles.debugTitle}>
             <Trans i18nKey="query-editor-next.transformation-debug.input-data">Input data</Trans>
+            <ClipboardButton
+              icon="copy"
+              variant="secondary"
+              fill="text"
+              size="sm"
+              getText={() => JSON.stringify(input, null, 2)}
+            >
+              <Trans i18nKey="query-editor-next.transformation-debug.copy-input-data">Copy</Trans>
+            </ClipboardButton>
           </div>
           <div className={styles.debugJson}>
             <JSONFormatter json={input} />
@@ -49,6 +58,15 @@ export function TransformationDebugDisplay() {
         <div className={styles.debug}>
           <div className={styles.debugTitle}>
             <Trans i18nKey="query-editor-next.transformation-debug.output-data">Output data</Trans>
+            <ClipboardButton
+              icon="copy"
+              variant="secondary"
+              fill="text"
+              size="sm"
+              getText={() => JSON.stringify(output, null, 2)}
+            >
+              <Trans i18nKey="query-editor-next.transformation-debug.copy-output-data">Copy</Trans>
+            </ClipboardButton>
           </div>
           <div className={styles.debugJson}>
             <JSONFormatter json={output} />
@@ -72,6 +90,9 @@ const getStyles = (theme: GrafanaTheme2) => {
       color: theme.colors.primary.text,
     }),
     debugTitle: css({
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
       padding: `${theme.spacing(1)} ${theme.spacing(0.25)}`,
       fontFamily: theme.typography.fontFamilyMonospace,
       fontSize: theme.typography.bodySmall.fontSize,

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationEditor.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationEditor.tsx
@@ -9,7 +9,7 @@ import {
 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
-import { Icon, JSONFormatter, LoadingPlaceholder, useStyles2, Drawer } from '@grafana/ui';
+import { ClipboardButton, Icon, JSONFormatter, LoadingPlaceholder, useStyles2, Drawer } from '@grafana/ui';
 
 import { type TransformationsEditorTransformation } from './types';
 
@@ -72,6 +72,15 @@ export const TransformationEditor = ({
             <div className={styles.debug}>
               <div className={styles.debugTitle}>
                 <Trans i18nKey="dashboard.transformation-editor.input-data">Input data</Trans>
+                <ClipboardButton
+                  icon="copy"
+                  variant="secondary"
+                  fill="text"
+                  size="sm"
+                  getText={() => JSON.stringify(input, null, 2)}
+                >
+                  <Trans i18nKey="dashboard.transformation-editor.copy-input-data">Copy</Trans>
+                </ClipboardButton>
               </div>
               <div className={styles.debugJson}>
                 <JSONFormatter json={input} />
@@ -83,6 +92,15 @@ export const TransformationEditor = ({
             <div className={styles.debug}>
               <div className={styles.debugTitle}>
                 <Trans i18nKey="dashboard.transformation-editor.output-data">Output data</Trans>
+                <ClipboardButton
+                  icon="copy"
+                  variant="secondary"
+                  fill="text"
+                  size="sm"
+                  getText={() => JSON.stringify(output, null, 2)}
+                >
+                  <Trans i18nKey="dashboard.transformation-editor.copy-output-data">Copy</Trans>
+                </ClipboardButton>
               </div>
               <div className={styles.debugJson}>{output && <JSONFormatter json={output} />}</div>
             </div>
@@ -110,6 +128,9 @@ const getStyles = (theme: GrafanaTheme2) => {
       color: theme.colors.primary.text,
     }),
     debugTitle: css({
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'space-between',
       padding: `${theme.spacing(1)} ${theme.spacing(0.25)}`,
       fontFamily: theme.typography.fontFamilyMonospace,
       fontSize: theme.typography.bodySmall.fontSize,

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -6489,6 +6489,8 @@
       "unlink-library-panel": "Unlink library panel"
     },
     "transformation-editor": {
+      "copy-input-data": "Copy",
+      "copy-output-data": "Copy",
       "input-data": "Input data",
       "loading": "Loading editor...",
       "output-data": "Output data",
@@ -14246,6 +14248,8 @@
       "view-toggle": "View"
     },
     "transformation-debug": {
+      "copy-input-data": "Copy",
+      "copy-output-data": "Copy",
       "input-data": "Input data",
       "output-data": "Output data",
       "title": "Debug transformation"


### PR DESCRIPTION
## Summary

- Adds a **Copy** button next to the "Input data" and "Output data" headers in the Debug transformation drawer
- Uses the existing `ClipboardButton` component from `@grafana/ui` with `JSON.stringify(data, null, 2)` for readable output
- Applied to both the legacy `TransformationEditor` and the new `TransformationDebugDisplay` components

Closes #115711

## Test plan

- [ ] Open a panel with transformations applied
- [ ] Click the debug icon to open the Debug transformation drawer
- [ ] Verify "Copy" buttons appear next to "Input data" and "Output data"
- [ ] Click Copy on input data — paste into an editor and verify valid JSON
- [ ] Click Copy on output data — paste into an editor and verify valid JSON
- [ ] Verify the button briefly shows a success state after copying