### PR TITLE
Provisioning: Block credentials embedded in repository URL

### DIFF
--- a/public/app/features/provisioning/Config/ConfigForm.tsx
+++ b/public/app/features/provisioning/Config/ConfigForm.tsx
@@ -286,6 +286,7 @@ export function ConfigForm({ data }: ConfigFormProps) {
                 {...register('url', {
                   required: gitFields.urlConfig.validation?.required,
                   pattern: gitFields.urlConfig.validation?.pattern,
+                  validate: gitFields.urlConfig.validation?.validate,
                 })}
                 placeholder={gitFields.urlConfig.placeholder}
               />

--- a/public/app/features/provisioning/Wizard/fields.ts
+++ b/public/app/features/provisioning/Wizard/fields.ts
@@ -1,5 +1,7 @@
 import { t } from '@grafana/i18n';
 
+import { validateNoUserInfoInUrl } from '../utils/validators';
+
 import { type RepoType } from './types';
 
 export interface FieldConfig {
@@ -13,6 +15,7 @@ export interface FieldConfig {
       value: RegExp;
       message: string;
     };
+    validate?: (value: string | undefined) => string | true;
   };
 }
 
@@ -42,6 +45,7 @@ const getProviderConfigs = (): Record<RepoType, Record<string, FieldConfig>> => 
           value: /^https:\/\/[^\/]+\/[^\/]+\/[^\/]+\/?$/,
           message: t('provisioning.shared.url-pattern', 'Must be a valid repository URL (https://hostname/owner/repo)'),
         },
+        validate: validateNoUserInfoInUrl,
       },
     },
     tokenUser: {
@@ -125,6 +129,7 @@ const getProviderConfigs = (): Record<RepoType, Record<string, FieldConfig>> => 
               'Must be a valid repository URL (https://hostname/group/repository or https://hostname/group/subgroup/repository)'
             ),
           },
+          validate: validateNoUserInfoInUrl,
         },
       },
       branch: {
@@ -183,6 +188,7 @@ const getProviderConfigs = (): Record<RepoType, Record<string, FieldConfig>> => 
               'Must be a valid repository URL (https://hostname/owner/repo or https://hostname/scm/project/repo)'
             ),
           },
+          validate: validateNoUserInfoInUrl,
         },
       },
       branch: {
@@ -238,6 +244,7 @@ const getProviderConfigs = (): Record<RepoType, Record<string, FieldConfig>> => 
             value: /^https?:\/\/.+/,
             message: t('provisioning.git.url-pattern', 'Must be a valid Git repository URL'),
           },
+          validate: validateNoUserInfoInUrl,
         },
       },
       branch: {

--- a/public/app/features/provisioning/utils/validators.test.ts
+++ b/public/app/features/provisioning/utils/validators.test.ts
@@ -111,30 +111,35 @@ describe('validateNoUserInfoInUrl', () => {
   // Invalid inputs
   it('returns error for URL with username and password', () => {
     expect(validateNoUserInfoInUrl('https://user:token@github.com/owner/repo')).toEqual(
+      // trufflehog:ignore
       expect.stringContaining('must not include a username or password')
     );
   });
 
   it('returns error for URL with username only', () => {
     expect(validateNoUserInfoInUrl('https://user@github.com/owner/repo')).toEqual(
+      // trufflehog:ignore
       expect.stringContaining('must not include a username or password')
     );
   });
 
   it('returns error for URL with password only (empty username)', () => {
     expect(validateNoUserInfoInUrl('https://:token@github.com/owner/repo')).toEqual(
+      // trufflehog:ignore
       expect.stringContaining('must not include a username or password')
     );
   });
 
   it('returns error for URL-encoded credentials', () => {
     expect(validateNoUserInfoInUrl('https://user:%24TOKEN@github.com/owner/repo')).toEqual(
+      // trufflehog:ignore
       expect.stringContaining('must not include a username or password')
     );
   });
 
   it('returns error for URL with leading/trailing whitespace around credentials', () => {
     expect(validateNoUserInfoInUrl('  https://user:token@github.com/owner/repo  ')).toEqual(
+      // trufflehog:ignore
       expect.stringContaining('must not include a username or password')
     );
   });

--- a/public/app/features/provisioning/utils/validators.test.ts
+++ b/public/app/features/provisioning/utils/validators.test.ts
@@ -1,4 +1,4 @@
-import { validateNoHiddenCharacters } from './validators';
+import { validateNoHiddenCharacters, validateNoUserInfoInUrl } from './validators';
 
 describe('validateNoHiddenCharacters', () => {
   // Should pass for valid inputs
@@ -79,5 +79,63 @@ describe('validateNoHiddenCharacters', () => {
 
   it('returns error for en space (U+2002)', () => {
     expect(validateNoHiddenCharacters('abc\u2002def')).toEqual(expect.stringContaining('hidden'));
+  });
+});
+
+describe('validateNoUserInfoInUrl', () => {
+  // Valid inputs
+  it('returns true for a clean HTTPS URL', () => {
+    expect(validateNoUserInfoInUrl('https://github.com/owner/repo')).toBe(true);
+  });
+
+  it('returns true for a URL with @ in the path (not userinfo)', () => {
+    expect(validateNoUserInfoInUrl('https://github.com/owner@scope/repo')).toBe(true);
+  });
+
+  it('returns true for empty string', () => {
+    expect(validateNoUserInfoInUrl('')).toBe(true);
+  });
+
+  it('returns true for undefined', () => {
+    expect(validateNoUserInfoInUrl(undefined)).toBe(true);
+  });
+
+  it('returns true for malformed URL (defers to pattern)', () => {
+    expect(validateNoUserInfoInUrl('not a url')).toBe(true);
+  });
+
+  it('returns true for whitespace-only string', () => {
+    expect(validateNoUserInfoInUrl('   ')).toBe(true);
+  });
+
+  // Invalid inputs
+  it('returns error for URL with username and password', () => {
+    expect(validateNoUserInfoInUrl('https://user:token@github.com/owner/repo')).toEqual(
+      expect.stringContaining('must not include a username or password')
+    );
+  });
+
+  it('returns error for URL with username only', () => {
+    expect(validateNoUserInfoInUrl('https://user@github.com/owner/repo')).toEqual(
+      expect.stringContaining('must not include a username or password')
+    );
+  });
+
+  it('returns error for URL with password only (empty username)', () => {
+    expect(validateNoUserInfoInUrl('https://:token@github.com/owner/repo')).toEqual(
+      expect.stringContaining('must not include a username or password')
+    );
+  });
+
+  it('returns error for URL-encoded credentials', () => {
+    expect(validateNoUserInfoInUrl('https://user:%24TOKEN@github.com/owner/repo')).toEqual(
+      expect.stringContaining('must not include a username or password')
+    );
+  });
+
+  it('returns error for URL with leading/trailing whitespace around credentials', () => {
+    expect(validateNoUserInfoInUrl('  https://user:token@github.com/owner/repo  ')).toEqual(
+      expect.stringContaining('must not include a username or password')
+    );
   });
 });

--- a/public/app/features/provisioning/utils/validators.ts
+++ b/public/app/features/provisioning/utils/validators.ts
@@ -26,3 +26,30 @@ export function validateNoHiddenCharacters(value: string | undefined): string | 
     'This field contains hidden characters that may have been introduced by copying and pasting. Please retype or clean the value and try again.'
   );
 }
+
+/**
+ * react-hook-form `validate` function.
+ * Rejects URLs that embed credentials in the userinfo component (e.g. https://user:token@host/...).
+ * Returns `true` when valid, or an error message string when credentials are detected.
+ */
+export function validateNoUserInfoInUrl(value: string | undefined): string | true {
+  const trimmed = value?.trim();
+  if (!trimmed) {
+    return true;
+  }
+
+  try {
+    const parsed = new URL(trimmed);
+    if (parsed.username !== '' || parsed.password !== '') {
+      return t(
+        'provisioning.validation.url-with-credentials',
+        'Repository URL must not include a username or password. Remove credentials from the URL and use the token field instead.'
+      );
+    }
+  } catch {
+    // Malformed URL — defer to the per-provider regex pattern for the format error.
+    return true;
+  }
+
+  return true;
+}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13825,7 +13825,8 @@
       "make-sure": "Create a token with these permissions"
     },
     "validation": {
-      "hidden-characters": "This field contains hidden characters that may have been introduced by copying and pasting. Please retype or clean the value and try again."
+      "hidden-characters": "This field contains hidden characters that may have been introduced by copying and pasting. Please retype or clean the value and try again.",
+      "url-with-credentials": "Repository URL must not include a username or password. Remove credentials from the URL and use the token field instead."
     },
     "warning-title-default": "Warning",
     "watch-stream": {


### PR DESCRIPTION
**What is this feature?**

Adds a frontend validation gate that prevents saving a provisioning repository URL containing embedded credentials (e.g. `https://user:token@github.com/owner/repo`). The new `validateNoUserInfoInUrl` validator uses the `URL` parser to detect `username` or `password` in the userinfo component and surfaces a clear error message directing users to the token field instead.

**Why do we need this feature?**

The `url` field in provisioning repository settings is not treated as a secret — it is returned verbatim by the settings API, meaning any authenticated Viewer can read credentials embedded in the URL. While `secure.token` is correctly redacted, there is no guard preventing customers from accidentally putting credentials in the URL itself. This frontend gate prevents new misconfigurations from being saved.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/1119

<img width="988" height="244" alt="Screenshot 2026-04-28 at 18 38 46" src="https://github.com/user-attachments/assets/eda7d62f-1060-44da-bc6e-ae810f199225" />
