### PR TITLE
Provisioning: Add raw .md read support to the files API

### DIFF
--- a/pkg/registry/apis/provisioning/files.go
+++ b/pkg/registry/apis/provisioning/files.go
@@ -18,6 +18,7 @@ import (
 	"github.com/grafana/grafana/apps/provisioning/pkg/quotas"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/grafana/grafana/apps/provisioning/pkg/safepath"
+	"github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
 )
@@ -105,7 +106,7 @@ func (c *filesConnector) handleRequest(ctx context.Context, name string, r *http
 		return
 	}
 
-	dualReadWriter, err := c.createDualReadWriter(ctx, repo, readWriter)
+	dualReadWriter, authorizer, err := c.createDualReadWriter(ctx, repo, readWriter)
 	if err != nil {
 		responder.Error(err)
 		return
@@ -142,7 +143,7 @@ func (c *filesConnector) handleRequest(ctx context.Context, name string, r *http
 		}
 	}
 
-	obj, err := c.handleMethodRequest(ctx, r, opts, isDir, dualReadWriter)
+	obj, err := c.handleMethodRequest(ctx, r, opts, isDir, dualReadWriter, readWriter, authorizer)
 	if err != nil {
 		logger.Debug("got an error after processing request", "error", err)
 		respondWithError(responder, err)
@@ -159,25 +160,27 @@ func (c *filesConnector) handleRequest(ctx context.Context, name string, r *http
 }
 
 // createDualReadWriter sets up the dual read writer with all required dependencies.
-func (c *filesConnector) createDualReadWriter(ctx context.Context, repo repository.Repository, readWriter repository.ReaderWriter) (*resources.DualReadWriter, error) {
+// It also returns the authorizer so callers that bypass the dual read/write path
+// (raw file reads, etc.) can run their own authorization checks.
+func (c *filesConnector) createDualReadWriter(ctx context.Context, repo repository.Repository, readWriter repository.ReaderWriter) (*resources.DualReadWriter, resources.Authorizer, error) {
 	parser, err := c.parsers.GetParser(ctx, readWriter)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get parser: %w", err)
+		return nil, nil, fmt.Errorf("failed to get parser: %w", err)
 	}
 
 	clients, err := c.clients.Clients(ctx, repo.Config().Namespace)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get clients: %w", err)
+		return nil, nil, fmt.Errorf("failed to get clients: %w", err)
 	}
 
 	folderClient, folderGVK, err := clients.Folder(ctx, c.folderAPIVersion)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get folder client: %w", err)
+		return nil, nil, fmt.Errorf("failed to get folder client: %w", err)
 	}
 
 	folders := resources.NewFolderManager(readWriter, folderClient, resources.NewEmptyFolderTree(), folderGVK, resources.WithFolderMetadataEnabled(c.folderMetadataEnabled))
 	authorizer := resources.NewAuthorizer(repo.Config(), readWriter, c.access, c.folderMetadataEnabled)
-	return resources.NewDualReadWriter(readWriter, parser, folders, authorizer, c.folderMetadataEnabled), nil
+	return resources.NewDualReadWriter(readWriter, parser, folders, authorizer, c.folderMetadataEnabled), authorizer, nil
 }
 
 // parseRequestOptions extracts options from the HTTP request.
@@ -197,8 +200,16 @@ func (c *filesConnector) parseRequestOptions(r *http.Request, name string, repo 
 	}
 	opts.Path = path
 
-	if err := resources.IsPathSupported(opts.Path); err != nil {
-		return opts, err
+	// GET requests can read raw files (such as README.md) in addition to k8s
+	// resources. Write operations remain restricted to resource files.
+	if r.Method == http.MethodGet {
+		if err := resources.IsReadablePath(opts.Path); err != nil {
+			return opts, err
+		}
+	} else {
+		if err := resources.IsPathSupported(opts.Path); err != nil {
+			return opts, err
+		}
 	}
 
 	return opts, nil
@@ -221,7 +232,7 @@ func (c *filesConnector) handleDirectoryListing(ctx context.Context, name string
 }
 
 // handleMethodRequest routes the request to the appropriate handler based on HTTP method.
-func (c *filesConnector) handleMethodRequest(ctx context.Context, r *http.Request, opts resources.DualWriteOptions, isDir bool, dualReadWriter *resources.DualReadWriter) (*provisioning.ResourceWrapper, error) {
+func (c *filesConnector) handleMethodRequest(ctx context.Context, r *http.Request, opts resources.DualWriteOptions, isDir bool, dualReadWriter *resources.DualReadWriter, readWriter repository.ReaderWriter, authorizer resources.Authorizer) (*provisioning.ResourceWrapper, error) {
 	if c.folderMetadataEnabled && r.Method != http.MethodGet && resources.IsFolderMetadataFile(opts.Path) {
 		return nil, apierrors.NewForbidden(
 			provisioning.RepositoryResourceInfo.GroupResource(),
@@ -231,7 +242,7 @@ func (c *filesConnector) handleMethodRequest(ctx context.Context, r *http.Reques
 	}
 	switch r.Method {
 	case http.MethodGet:
-		return c.handleGet(ctx, opts, dualReadWriter)
+		return c.handleGet(ctx, opts, dualReadWriter, readWriter, authorizer)
 	case http.MethodPost:
 		return c.handlePost(ctx, r, opts, isDir, dualReadWriter)
 	case http.MethodPut:
@@ -243,12 +254,50 @@ func (c *filesConnector) handleMethodRequest(ctx context.Context, r *http.Reques
 	}
 }
 
-func (c *filesConnector) handleGet(ctx context.Context, opts resources.DualWriteOptions, dualReadWriter *resources.DualReadWriter) (*provisioning.ResourceWrapper, error) {
+func (c *filesConnector) handleGet(ctx context.Context, opts resources.DualWriteOptions, dualReadWriter *resources.DualReadWriter, readWriter repository.ReaderWriter, authorizer resources.Authorizer) (*provisioning.ResourceWrapper, error) {
+	// Raw files (e.g. README.md) are returned without parsing as a k8s resource.
+	if resources.IsRawFile(opts.Path) {
+		return c.handleGetRawFile(ctx, opts, readWriter, authorizer)
+	}
+
 	resource, err := dualReadWriter.Read(ctx, opts.Path, opts.Ref)
 	if err != nil {
 		return nil, err
 	}
 	return resource.AsResourceWrapper(), nil
+}
+
+// handleGetRawFile reads a raw file (such as README.md) and returns its bytes
+// inside ResourceWrapper.Resource.File under the "content" key.
+//
+// Authorization is checked at folder scope: the caller needs read permission
+// on the folder containing the file, mirroring how parsed-resource reads
+// inherit folder-level permissions.
+func (c *filesConnector) handleGetRawFile(ctx context.Context, opts resources.DualWriteOptions, readWriter repository.ReaderWriter, authorizer resources.Authorizer) (*provisioning.ResourceWrapper, error) {
+	if err := authorizer.AuthorizeReadRawFile(ctx, opts.Path); err != nil {
+		return nil, err
+	}
+
+	info, err := readWriter.Read(ctx, opts.Path, opts.Ref)
+	if err != nil {
+		if errors.Is(err, repository.ErrFileNotFound) {
+			return nil, apierrors.NewNotFound(provisioning.RepositoryResourceInfo.GroupResource(), opts.Path)
+		}
+		return nil, fmt.Errorf("read raw file: %w", err)
+	}
+
+	return &provisioning.ResourceWrapper{
+		Path: info.Path,
+		Ref:  info.Ref,
+		Hash: info.Hash,
+		Resource: provisioning.ResourceObjects{
+			File: v0alpha1.Unstructured{
+				Object: map[string]any{
+					"content": string(info.Data),
+				},
+			},
+		},
+	}, nil
 }
 
 func (c *filesConnector) handlePost(ctx context.Context, r *http.Request, opts resources.DualWriteOptions, isDir bool, dualReadWriter *resources.DualReadWriter) (*provisioning.ResourceWrapper, error) {

--- a/pkg/registry/apis/provisioning/files_test.go
+++ b/pkg/registry/apis/provisioning/files_test.go
@@ -2,15 +2,18 @@ package provisioning
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/grafana/grafana/apps/provisioning/pkg/apis/auth"
 	provisioningapi "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -213,7 +216,7 @@ func TestHandleMethodRequest_FolderMetadataGuard(t *testing.T) {
 			opts := resources.DualWriteOptions{Path: tc.path}
 
 			if tc.expectForbidden {
-				_, err := connector.handleMethodRequest(context.Background(), req, opts, false, nil)
+				_, err := connector.handleMethodRequest(context.Background(), req, opts, false, nil, nil, nil)
 				require.Error(t, err)
 				assert.True(t, apierrors.IsForbidden(err))
 			} else {
@@ -221,7 +224,7 @@ func TestHandleMethodRequest_FolderMetadataGuard(t *testing.T) {
 				// This is intentional: we only test the guard logic here, not the downstream handlers.
 				require.Panics(t, func() {
 					//nolint:errcheck
-					_, _ = connector.handleMethodRequest(context.Background(), req, opts, false, nil)
+					_, _ = connector.handleMethodRequest(context.Background(), req, opts, false, nil, nil, nil)
 				}, "guard must not intercept; code should proceed past the guard")
 			}
 		})
@@ -296,7 +299,7 @@ func TestHandleMethodRequest_PutDirectoryRouting(t *testing.T) {
 
 		require.Panics(t, func() {
 			//nolint:errcheck
-			_, _ = connector.handleMethodRequest(context.Background(), req, opts, true, nil)
+			_, _ = connector.handleMethodRequest(context.Background(), req, opts, true, nil, nil, nil)
 		})
 	})
 
@@ -306,7 +309,7 @@ func TestHandleMethodRequest_PutDirectoryRouting(t *testing.T) {
 		req := httptest.NewRequest(http.MethodPut, "/", body)
 		opts := resources.DualWriteOptions{Path: "myfolder/"}
 
-		_, err := connector.handleMethodRequest(context.Background(), req, opts, true, nil)
+		_, err := connector.handleMethodRequest(context.Background(), req, opts, true, nil, nil, nil)
 		require.Error(t, err)
 		assert.True(t, apierrors.IsMethodNotSupported(err))
 	})
@@ -321,4 +324,254 @@ func TestHandleMethodRequest_PutDirectoryRouting(t *testing.T) {
 		require.Error(t, err)
 		assert.True(t, apierrors.IsMethodNotSupported(err), "expected MethodNotSupported, got: %v", err)
 	})
+}
+
+func TestParseRequestOptionsPathValidation(t *testing.T) {
+	tests := []struct {
+		name        string
+		method      string
+		path        string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:   "GET json file allowed",
+			method: http.MethodGet,
+			path:   "dashboard.json",
+		},
+		{
+			name:   "GET yaml file allowed",
+			method: http.MethodGet,
+			path:   "dashboard.yaml",
+		},
+		{
+			name:   "GET yml file allowed",
+			method: http.MethodGet,
+			path:   "dashboard.yml",
+		},
+		{
+			name:   "GET markdown file allowed",
+			method: http.MethodGet,
+			path:   "README.md",
+		},
+		{
+			name:   "GET nested markdown file allowed",
+			method: http.MethodGet,
+			path:   "folder/subfolder/README.md",
+		},
+		{
+			name:        "GET txt file not allowed",
+			method:      http.MethodGet,
+			path:        "file.txt",
+			wantErr:     true,
+			errContains: "unsupported file extension",
+		},
+		{
+			name:   "POST json file allowed",
+			method: http.MethodPost,
+			path:   "dashboard.json",
+		},
+		{
+			name:        "POST markdown file not allowed",
+			method:      http.MethodPost,
+			path:        "README.md",
+			wantErr:     true,
+			errContains: "unsupported file extension",
+		},
+		{
+			name:        "PUT markdown file not allowed",
+			method:      http.MethodPut,
+			path:        "README.md",
+			wantErr:     true,
+			errContains: "unsupported file extension",
+		},
+		{
+			name:        "DELETE markdown file not allowed",
+			method:      http.MethodDelete,
+			path:        "README.md",
+			wantErr:     true,
+			errContains: "unsupported file extension",
+		},
+		{
+			name:   "GET directory allowed",
+			method: http.MethodGet,
+			path:   "dashboards/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockRepo := repository.NewMockRepository(t)
+			mockRepo.On("Config").Return(&provisioningapi.Repository{
+				Spec: provisioningapi.RepositorySpec{
+					Title: "test-repo",
+				},
+			}).Maybe()
+
+			connector := &filesConnector{}
+			r := httptest.NewRequest(tt.method, "/test-repo/files/"+tt.path, nil)
+
+			opts, err := connector.parseRequestOptions(r, "test-repo", mockRepo)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errContains)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.path, opts.Path)
+			}
+		})
+	}
+}
+
+func TestHandleGetRawFile(t *testing.T) {
+	tests := []struct {
+		name           string
+		path           string
+		fileContent    string
+		readError      error
+		wantErr        bool
+		errContains    string
+		expectedResult string
+	}{
+		{
+			name:           "successful readme read",
+			path:           "README.md",
+			fileContent:    "# Hello World\n\nThis is a test.",
+			expectedResult: "# Hello World\n\nThis is a test.",
+		},
+		{
+			name:           "nested readme read",
+			path:           "folder/README.md",
+			fileContent:    "# Folder Readme",
+			expectedResult: "# Folder Readme",
+		},
+		{
+			name:        "file not found",
+			path:        "README.md",
+			readError:   repository.ErrFileNotFound,
+			wantErr:     true,
+			errContains: "not found",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockReadWriter := repository.NewMockReaderWriter(t)
+			mockAccess := auth.NewMockAccessChecker(t)
+			mockAccess.EXPECT().Check(mock.Anything, mock.Anything, mock.Anything).Return(nil).Maybe()
+
+			repo := &provisioningapi.Repository{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-repo"},
+				Spec: provisioningapi.RepositorySpec{
+					Sync: provisioningapi.SyncOptions{Target: provisioningapi.SyncTargetTypeFolder},
+				},
+			}
+			mockReadWriter.EXPECT().Config().Return(repo).Maybe()
+			authorizer := resources.NewAuthorizer(repo, mockReadWriter, mockAccess, false)
+
+			if tt.readError != nil {
+				mockReadWriter.EXPECT().Read(mock.Anything, tt.path, "").Return(nil, tt.readError)
+			} else {
+				mockReadWriter.EXPECT().Read(mock.Anything, tt.path, "").Return(&repository.FileInfo{
+					Path: tt.path,
+					Data: []byte(tt.fileContent),
+					Ref:  "main",
+					Hash: "abc123",
+				}, nil)
+			}
+
+			connector := &filesConnector{access: mockAccess}
+
+			opts := resources.DualWriteOptions{Path: tt.path}
+
+			result, err := connector.handleGetRawFile(context.Background(), opts, mockReadWriter, authorizer)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.errContains)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, result)
+				require.Equal(t, tt.path, result.Path)
+
+				content, ok := result.Resource.File.Object["content"]
+				require.True(t, ok, "content field should exist")
+				require.Equal(t, tt.expectedResult, content)
+			}
+		})
+	}
+}
+
+func TestHandleGetRawFile_FolderScopedAuth(t *testing.T) {
+	t.Run("denies the read when the user lacks folder read permission", func(t *testing.T) {
+		mockReadWriter := repository.NewMockReaderWriter(t)
+		mockAccess := auth.NewMockAccessChecker(t)
+
+		repo := &provisioningapi.Repository{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-repo"},
+			Spec: provisioningapi.RepositorySpec{
+				Sync: provisioningapi.SyncOptions{Target: provisioningapi.SyncTargetTypeFolder},
+			},
+		}
+		mockReadWriter.EXPECT().Config().Return(repo).Maybe()
+
+		// Folder check is denied — readWriter.Read on the file must never be called.
+		mockAccess.EXPECT().
+			Check(mock.Anything, mock.Anything, mock.Anything).
+			Return(apierrors.NewForbidden(provisioningapi.RepositoryResourceInfo.GroupResource(), "team-a", errors.New("denied")))
+
+		authorizer := resources.NewAuthorizer(repo, mockReadWriter, mockAccess, false)
+		connector := &filesConnector{access: mockAccess}
+
+		_, err := connector.handleGetRawFile(
+			context.Background(),
+			resources.DualWriteOptions{Path: "team-a/README.md"},
+			mockReadWriter,
+			authorizer,
+		)
+
+		require.Error(t, err)
+		require.True(t, apierrors.IsForbidden(err), "expected Forbidden, got %v", err)
+	})
+}
+
+func TestIsRawFileIntegration(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{
+			name:     "README.md is raw",
+			path:     "README.md",
+			expected: true,
+		},
+		{
+			name:     "nested README.md is raw",
+			path:     "folder/subfolder/README.md",
+			expected: true,
+		},
+		{
+			name:     "dashboard.json is not raw",
+			path:     "dashboard.json",
+			expected: false,
+		},
+		{
+			name:     "dashboard.yaml is not raw",
+			path:     "dashboard.yaml",
+			expected: false,
+		},
+		{
+			name:     "directory is not raw",
+			path:     "folder/",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, resources.IsRawFile(tt.path))
+		})
+	}
 }

--- a/pkg/registry/apis/provisioning/resources/authorizer.go
+++ b/pkg/registry/apis/provisioning/resources/authorizer.go
@@ -114,6 +114,19 @@ type Authorizer interface {
 	// AuthorizeWrite checks if writes are allowed to the specified ref.
 	// This ensures operations on the configured branch are properly authorized.
 	AuthorizeWrite(ctx context.Context, ref string) error
+
+	// AuthorizeReadRawFile checks if the user has permission to read a raw
+	// (non-resource) file at the given path.
+	//
+	// Raw files such as README.md are returned as bytes rather than parsed as
+	// k8s resources, so we cannot derive a per-resource verb. We instead gate
+	// access on the read permission of the file's containing folder. For files
+	// at the repository root, the check uses the repository's root folder.
+	//
+	// Permissions on a parent folder grant at least that level of access to
+	// all children, so a user who can read the parent folder can read raw
+	// files inside it.
+	AuthorizeReadRawFile(ctx context.Context, path string) error
 }
 
 // ProvisioningAuthorizer implements Authorizer for provisioning operations.
@@ -493,4 +506,32 @@ func (a *ProvisioningAuthorizer) AuthorizeCreateAllSupported(ctx context.Context
 // This delegates to the repository's write authorization logic.
 func (a *ProvisioningAuthorizer) AuthorizeWrite(ctx context.Context, ref string) error {
 	return repository.IsWriteAllowed(a.repo, ref)
+}
+
+// AuthorizeReadRawFile checks if the user has read permission on the folder
+// containing a raw (non-resource) file.
+//
+// Folder IDs are resolved from the configured branch (ref="") for the same
+// reasons documented on the Authorizer interface — caller-supplied refs can
+// be used to spoof folder UIDs.
+func (a *ProvisioningAuthorizer) AuthorizeReadRawFile(ctx context.Context, path string) error {
+	parentPath := safepath.Dir(path)
+
+	var folderID string
+	if parentPath == "" {
+		folderID = RootFolder(a.repo)
+	} else {
+		id, err := a.getFolderID(ctx, parentPath)
+		if err != nil {
+			return fmt.Errorf("get parent folder ID for %q: %w", path, err)
+		}
+		folderID = id
+	}
+
+	return a.access.Check(ctx, authlib.CheckRequest{
+		Group:    FolderResource.Group,
+		Resource: FolderResource.Resource,
+		Name:     folderID,
+		Verb:     utils.VerbGet,
+	}, folderID)
 }

--- a/pkg/registry/apis/provisioning/resources/filepath.go
+++ b/pkg/registry/apis/provisioning/resources/filepath.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"errors"
 	"path"
+	"strings"
 
 	"github.com/grafana/grafana/apps/provisioning/pkg/safepath"
 )
@@ -15,10 +16,63 @@ var (
 
 const maxPathDepth = 8
 
-// IsPathSupported checks if the file path is supported by the provisioning API.
-// it also validates if the path is safe and if the file extension is supported.
+// resourceExtensions are file extensions that contain k8s resources and can be parsed.
+var resourceExtensions = map[string]bool{
+	".yml":  true,
+	".yaml": true,
+	".json": true,
+}
+
+// readOnlyExtensions are file extensions that can be read as raw content (read-only).
+var readOnlyExtensions = map[string]bool{
+	".md": true,
+}
+
+// IsPathSupported checks if the file path is supported by the provisioning API for write operations.
+// It validates the path is safe and that the file extension is one of the resource types
+// (yml, yaml, json).
 func IsPathSupported(filePath string) error {
-	// Validate the path for any traversal attempts first
+	if err := validatePathBasics(filePath); err != nil {
+		return err
+	}
+
+	if !safepath.IsDir(filePath) {
+		ext := strings.ToLower(path.Ext(filePath))
+		if !resourceExtensions[ext] {
+			return ErrUnsupportedFileExtension
+		}
+	}
+
+	return nil
+}
+
+// IsReadablePath checks if the file path is supported for read operations. This includes resource
+// files (yml, yaml, json) and read-only files (md).
+func IsReadablePath(filePath string) error {
+	if err := validatePathBasics(filePath); err != nil {
+		return err
+	}
+
+	if !safepath.IsDir(filePath) {
+		ext := strings.ToLower(path.Ext(filePath))
+		if !resourceExtensions[ext] && !readOnlyExtensions[ext] {
+			return ErrUnsupportedFileExtension
+		}
+	}
+
+	return nil
+}
+
+// IsRawFile reports whether the file path points at a read-only raw file (not a k8s resource).
+func IsRawFile(filePath string) bool {
+	if safepath.IsDir(filePath) {
+		return false
+	}
+	ext := strings.ToLower(path.Ext(filePath))
+	return readOnlyExtensions[ext]
+}
+
+func validatePathBasics(filePath string) error {
 	if err := safepath.IsSafe(filePath); err != nil {
 		return err
 	}
@@ -29,13 +83,6 @@ func IsPathSupported(filePath string) error {
 
 	if safepath.IsAbs(filePath) {
 		return ErrNotRelative
-	}
-
-	// Only check file extension if it's not a folder path
-	if !safepath.IsDir(filePath) {
-		if ext := path.Ext(filePath); ext != ".yml" && ext != ".yaml" && ext != ".json" {
-			return ErrUnsupportedFileExtension
-		}
 	}
 
 	return nil

--- a/pkg/registry/apis/provisioning/resources/filepath_test.go
+++ b/pkg/registry/apis/provisioning/resources/filepath_test.go
@@ -39,6 +39,11 @@ func TestIsPathSupported(t *testing.T) {
 			expectedErr: ErrUnsupportedFileExtension,
 		},
 		{
+			name:        "markdown file not supported for write",
+			path:        "dashboards/README.md",
+			expectedErr: ErrUnsupportedFileExtension,
+		},
+		{
 			name:        "path traversal attempt",
 			path:        "../dashboards/my-dashboard.yaml",
 			expectedErr: safepath.ErrPathTraversalAttempt,
@@ -67,6 +72,129 @@ func TestIsPathSupported(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestIsReadablePath(t *testing.T) {
+	tests := []struct {
+		name        string
+		path        string
+		expectedErr error
+	}{
+		{
+			name: "valid yaml file",
+			path: "dashboards/my-dashboard.yaml",
+		},
+		{
+			name: "valid yml file",
+			path: "dashboards/my-dashboard.yml",
+		},
+		{
+			name: "valid json file",
+			path: "dashboards/my-dashboard.json",
+		},
+		{
+			name: "valid markdown file",
+			path: "dashboards/README.md",
+		},
+		{
+			name: "markdown file in nested path",
+			path: "dashboards/folder1/folder2/README.md",
+		},
+		{
+			name: "valid directory path",
+			path: "dashboards/folder1/",
+		},
+		{
+			name:        "unsupported file extension",
+			path:        "dashboards/my-dashboard.txt",
+			expectedErr: ErrUnsupportedFileExtension,
+		},
+		{
+			name:        "path traversal attempt",
+			path:        "../dashboards/README.md",
+			expectedErr: safepath.ErrPathTraversalAttempt,
+		},
+		{
+			name:        "path too deep",
+			path:        "level1/level2/level3/level4/level5/level6/level7/level8/level9/README.md",
+			expectedErr: ErrPathTooDeep,
+		},
+		{
+			name:        "absolute path",
+			path:        "/etc/dashboards/README.md",
+			expectedErr: ErrNotRelative,
+		},
+		{
+			name: "empty directory path",
+			path: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := IsReadablePath(tt.path)
+			if tt.expectedErr != nil {
+				require.ErrorIs(t, err, tt.expectedErr)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestIsRawFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected bool
+	}{
+		{
+			name:     "markdown file is raw",
+			path:     "README.md",
+			expected: true,
+		},
+		{
+			name:     "nested markdown file is raw",
+			path:     "dashboards/folder/README.md",
+			expected: true,
+		},
+		{
+			name:     "uppercase MD extension",
+			path:     "README.MD",
+			expected: true,
+		},
+		{
+			name:     "yaml file is not raw",
+			path:     "dashboard.yaml",
+			expected: false,
+		},
+		{
+			name:     "json file is not raw",
+			path:     "dashboard.json",
+			expected: false,
+		},
+		{
+			name:     "yml file is not raw",
+			path:     "dashboard.yml",
+			expected: false,
+		},
+		{
+			name:     "directory is not raw",
+			path:     "dashboards/",
+			expected: false,
+		},
+		{
+			name:     "empty path is not raw",
+			path:     "",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, IsRawFile(tt.path))
 		})
 	}
 }

--- a/pkg/tests/apis/provisioning/files_test.go
+++ b/pkg/tests/apis/provisioning/files_test.go
@@ -605,6 +605,244 @@ func TestIntegrationProvisioning_FilesOwnershipProtection(t *testing.T) {
 	})
 }
 
+func TestIntegrationProvisioning_ReadmeFiles(t *testing.T) {
+	helper := sharedHelper(t)
+	ctx := context.Background()
+
+	const repo = "readme-test-repo"
+	const readmeContent = "# Test Repository\n\nThis is a test README for the provisioning API."
+
+	helper.CreateLocalRepo(t, common.TestRepo{
+		Name:               repo,
+		LocalPath:          helper.ProvisioningPath,
+		SyncTarget:         "instance",
+		Workflows:          []string{"write"},
+		ExpectedDashboards: 0,
+		ExpectedFolders:    0,
+	})
+
+	helper.WriteToProvisioningPath(t, "README.md", []byte(readmeContent))
+
+	t.Run("GET README.md file should succeed", func(t *testing.T) {
+		addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
+		url := fmt.Sprintf("http://admin:admin@%s/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/%s/files/README.md", addr, repo)
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		// nolint:errcheck
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode, "should return 200 OK for README.md")
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		var result map[string]interface{}
+		require.NoError(t, json.Unmarshal(body, &result))
+
+		resource, ok := result["resource"].(map[string]interface{})
+		require.True(t, ok, "response should have resource field")
+
+		file, ok := resource["file"].(map[string]interface{})
+		require.True(t, ok, "resource should have file field")
+
+		content, ok := file["content"].(string)
+		require.True(t, ok, "file should have content field")
+		require.Equal(t, readmeContent, content, "content should match the README")
+	})
+
+	t.Run("GET nested README.md should succeed", func(t *testing.T) {
+		nestedReadmeContent := "# Nested Folder README\n\nThis is inside a folder."
+		helper.WriteToProvisioningPath(t, "folder/README.md", []byte(nestedReadmeContent))
+
+		addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
+		url := fmt.Sprintf("http://admin:admin@%s/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/%s/files/folder/README.md", addr, repo)
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		// nolint:errcheck
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode, "should return 200 OK for nested README.md")
+
+		body, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		var result map[string]interface{}
+		require.NoError(t, json.Unmarshal(body, &result))
+
+		resource := result["resource"].(map[string]interface{})
+		file := resource["file"].(map[string]interface{})
+		content := file["content"].(string)
+		require.Equal(t, nestedReadmeContent, content, "nested README content should match")
+	})
+
+	t.Run("GET non-existent README.md should return 404", func(t *testing.T) {
+		addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
+		url := fmt.Sprintf("http://admin:admin@%s/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/%s/files/nonexistent/README.md", addr, repo)
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		// nolint:errcheck
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusNotFound, resp.StatusCode, "should return 404 for non-existent README.md")
+	})
+
+	t.Run("POST README.md should be rejected", func(t *testing.T) {
+		addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
+		url := fmt.Sprintf("http://admin:admin@%s/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/%s/files/new-readme.md", addr, repo)
+		req, err := http.NewRequest(http.MethodPost, url, bytes.NewBufferString("# New README"))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "text/plain")
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		// nolint:errcheck
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode, "should return 400 for POST .md files")
+	})
+
+	t.Run("PUT README.md should be rejected", func(t *testing.T) {
+		addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
+		url := fmt.Sprintf("http://admin:admin@%s/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/%s/files/README.md", addr, repo)
+		req, err := http.NewRequest(http.MethodPut, url, bytes.NewBufferString("# Updated README"))
+		require.NoError(t, err)
+		req.Header.Set("Content-Type", "text/plain")
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		// nolint:errcheck
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode, "should return 400 for PUT .md files")
+	})
+
+	t.Run("DELETE README.md should be rejected", func(t *testing.T) {
+		addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
+		url := fmt.Sprintf("http://admin:admin@%s/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/%s/files/README.md", addr, repo)
+		req, err := http.NewRequest(http.MethodDelete, url, nil)
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		// nolint:errcheck
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusBadRequest, resp.StatusCode, "should return 400 for DELETE .md files")
+	})
+
+	// The folder-scoped auth check resolves the file's parent folder ID and
+	// requires folders:get on it. The default Viewer/Editor roles include
+	// folders:read, so reads at the repo root should succeed.
+	t.Run("viewer can GET README.md at the repo root", func(t *testing.T) {
+		addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
+		url := fmt.Sprintf("http://viewer:viewer@%s/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/%s/files/README.md", addr, repo)
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		// nolint:errcheck
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode, "viewer should be able to GET README.md")
+	})
+
+	t.Run("editor can GET README.md at the repo root", func(t *testing.T) {
+		addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
+		url := fmt.Sprintf("http://editor:editor@%s/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/%s/files/README.md", addr, repo)
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		// nolint:errcheck
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode, "editor should be able to GET README.md")
+	})
+
+	// Negative case for the folder-scoped check: the nested 'folder/' directory
+	// exists in the repo file tree but has not been synced into Grafana, so the
+	// viewer has no permission grant on its hash-based folder UID. Admins still
+	// pass thanks to wildcard access.
+	t.Run("viewer is denied for README in an unsynced subfolder", func(t *testing.T) {
+		addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
+		url := fmt.Sprintf("http://viewer:viewer@%s/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/%s/files/folder/README.md", addr, repo)
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		// nolint:errcheck
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusForbidden, resp.StatusCode,
+			"viewer without folders:get on the parent folder should be denied")
+	})
+
+	t.Run("admin can GET README in an unsynced subfolder", func(t *testing.T) {
+		addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
+		url := fmt.Sprintf("http://admin:admin@%s/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/%s/files/folder/README.md", addr, repo)
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		// nolint:errcheck
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode, "admin should be able to GET README in any folder")
+	})
+
+	_ = ctx
+}
+
+// TestIntegrationProvisioning_ReadmeFiles_FolderTarget exercises the folder-scoped
+// auth check on a folder-target repository, where RootFolder() resolves to the
+// repo's name as the folder UID. This is the path that proved the new authorizer
+// resolves the synced folder rather than always falling back to the empty root.
+func TestIntegrationProvisioning_ReadmeFiles_FolderTarget(t *testing.T) {
+	helper := sharedHelper(t)
+
+	const repo = "readme-folder-target-repo"
+	const readmeContent = "# Folder-target README"
+
+	helper.CreateLocalRepo(t, common.TestRepo{
+		Name:                   repo,
+		LocalPath:              helper.ProvisioningPath,
+		SyncTarget:             "folder",
+		Workflows:              []string{"write"},
+		SkipResourceAssertions: true,
+	})
+
+	helper.WriteToProvisioningPath(t, "README.md", []byte(readmeContent))
+
+	t.Run("admin can GET README.md", func(t *testing.T) {
+		addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
+		url := fmt.Sprintf("http://admin:admin@%s/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/%s/files/README.md", addr, repo)
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		// nolint:errcheck
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode, "admin should be able to GET README.md on folder-target repo")
+	})
+
+	t.Run("viewer can GET README.md when they have folders:read on the synced folder", func(t *testing.T) {
+		addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
+		url := fmt.Sprintf("http://viewer:viewer@%s/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/%s/files/README.md", addr, repo)
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		// nolint:errcheck
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode, "viewer should be able to GET README.md on folder-target repo")
+	})
+}
+
 func TestIntegrationProvisioning_FilesAuthorization(t *testing.T) {
 	helper := sharedHelper(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

Backend half of the README-on-folders feature: lets the provisioning files API serve raw `.md` files from a Git Sync repository so the frontend can render a folder's `README.md`. Splits cleanly from the UI work (separate PR) and is safe to ship on its own — no UI consumer until the frontend lands.

## Changes

### `pkg/registry/apis/provisioning/resources/filepath.go`
- Split path validation into:
  - `IsPathSupported` (write paths: `.yml` / `.yaml` / `.json`)
  - `IsReadablePath` (read paths: resource files **plus** `.md`)
- New `IsRawFile()` to detect read-only raw extensions.

### `pkg/registry/apis/provisioning/files.go`
- `parseRequestOptions` now allows `.md` paths only on `GET`. Writes (POST/PUT/DELETE) on `.md` are still rejected with 400.
- `handleGet` short-circuits raw files into `handleGetRawFile`, which:
  - Calls `Authorizer.AuthorizeReadRawFile` (see below).
  - Reads the file bytes via `repository.ReaderWriter.Read`.
  - Returns the content under `ResourceWrapper.Resource.File.Object["content"]`.
  - Maps `repository.ErrFileNotFound` to a Kubernetes `NotFound` 404.

### `pkg/registry/apis/provisioning/resources/authorizer.go`
- New `AuthorizeReadRawFile(ctx, path)` on the `Authorizer` interface.
- Resolves the file's containing folder (via `safepath.Dir` + `getFolderID`, reading folder metadata from the configured branch — same security pattern used elsewhere in the authorizer to prevent caller-supplied refs from spoofing folder UIDs).
- Checks `folders:get` against that folder ID. For files at the repo root, the check uses `RootFolder(repo)`.

## Authorization model

| Repository scope | Caller permission required |
| --- | --- |
| Instance-target repo | `folders:get` on the root folder (default for Viewer/Editor) |
| Folder-target repo | `folders:get` on the synced folder |
| Nested README in a sub-folder | `folders:get` on the parent folder |

Admins always pass via wildcard. Viewers/Editors with default Grafana RBAC pass on already-synced folders. A user with no permission on the parent folder gets `403`.

## Tests

### Unit
- `TestIsPathSupported` extended with the markdown-write rejection case.
- New `TestIsReadablePath` and `TestIsRawFile` in `filepath_test.go`.
- New `TestParseRequestOptionsPathValidation` for the GET-vs-write path gating.
- `TestHandleGetRawFile` covers the success/nested/not-found paths.
- New `TestHandleGetRawFile_FolderScopedAuth` asserts a denied `folders:get` rejects the read with `Forbidden` and never calls `readWriter.Read`.

### Integration (`pkg/tests/apis/provisioning/files_test.go`)
- `TestIntegrationProvisioning_ReadmeFiles`:
  - GET README.md success at root, nested.
  - GET non-existent README.md → 404.
  - POST/PUT/DELETE on `.md` → 400.
  - Viewer + Editor at the repo root → 200 (default `folders:read`).
  - Viewer denied for an unsynced subfolder → 403 (folder-scoped check rejects when there's no permission grant).
  - Admin still passes the unsynced subfolder via wildcard.
- `TestIntegrationProvisioning_ReadmeFiles_FolderTarget` exercises the folder-target case where `RootFolder()` resolves to the synced folder UID.

## Test plan

- [ ] `go test ./pkg/registry/apis/provisioning/... ./pkg/registry/apis/provisioning/resources/...`
- [ ] `go test -timeout 5m -run TestIntegrationProvisioning_ReadmeFiles ./pkg/tests/apis/provisioning/`
- [ ] Manual: `curl -u admin:admin /apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/{repo}/files/README.md` returns the file content
- [ ] Manual: same request as a viewer on a folder they don't own → 403

🤖 Generated with [Claude Code](https://claude.com/claude-code)