### PR TITLE
Add RemoteIndexStore primitives for snapshot cleanup

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -662,6 +662,7 @@ type Cfg struct {
 	IndexSnapshotBucketURL                     string        // Go CDK bucket URL for snapshot storage (s3://, gs://, azblob://, mem://, file:///)
 	IndexSnapshotThreshold                     int           // Min doc count to use remote snapshots (must be >= IndexFileThreshold, default: 5000)
 	IndexSnapshotMaxAge                        time.Duration // Max snapshot age before deletion (must be >= MaxFileIndexAge, default: 7d)
+	IndexSnapshotCleanupGracePeriod            time.Duration // Time a new snapshot must exist before its predecessor in the same Grafana-version group is eligible for cleanup (default: 30m)
 	EnableSharding                             bool
 	QOSEnabled                                 bool
 	QOSNumberWorker                            int

--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -263,6 +263,7 @@ func (cfg *Cfg) setUnifiedStorageConfig() {
 		cfg.Logger.Warn("index_snapshot_max_age is smaller than max_file_index_age, overriding", "configured", cfg.IndexSnapshotMaxAge, "max_file_index_age", cfg.MaxFileIndexAge)
 		cfg.IndexSnapshotMaxAge = cfg.MaxFileIndexAge
 	}
+	cfg.IndexSnapshotCleanupGracePeriod = section.Key("index_snapshot_cleanup_grace_period").MustDuration(30 * time.Minute)
 
 	// Vector storage (separate pgvector database)
 	vectorSection := cfg.Raw.Section("database_vector")

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -274,10 +274,12 @@ type SearchOptions struct {
 	IndexSnapshotUploadInterval time.Duration
 	// IndexSnapshotLockTTL is the TTL for the distributed lock used to coordinate uploads/cleanup.
 	IndexSnapshotLockTTL time.Duration
-	// IndexSnapshotMinKeep is the minimum number of snapshots to retain regardless of age.
-	IndexSnapshotMinKeep int
 	// IndexSnapshotCleanupInterval is how often snapshot cleanup runs.
 	IndexSnapshotCleanupInterval time.Duration
+	// IndexSnapshotCleanupGracePeriod is the time a newly uploaded snapshot must
+	// have existed before its predecessor in the same Grafana-version group is
+	// considered eligible for cleanup.
+	IndexSnapshotCleanupGracePeriod time.Duration
 }
 
 type ResourceServerOptions struct {

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -119,6 +119,11 @@ type SnapshotOptions struct {
 	// MinDocChanges is the minimum persisted mutation count required before a new
 	// upload is attempted after a previous successful upload.
 	MinDocChanges int
+
+	// CleanupGracePeriod is the time a newly uploaded snapshot must have existed
+	// before its predecessor in the same Grafana-version group is eligible for
+	// cleanup. Consumed by the cleanup loop only; no effect on upload/download.
+	CleanupGracePeriod time.Duration
 }
 
 type bleveBackend struct {

--- a/pkg/storage/unified/search/bleve_snapshot_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_test.go
@@ -96,6 +96,15 @@ func (f *fakeRemoteIndexStore) DeleteIndex(context.Context, resource.NamespacedR
 func (f *fakeRemoteIndexStore) CleanupIncompleteUploads(context.Context, resource.NamespacedResource, time.Duration) (int, error) {
 	panic("CleanupIncompleteUploads not implemented for fakeRemoteIndexStore")
 }
+func (f *fakeRemoteIndexStore) ListNamespaces(context.Context) ([]string, error) {
+	panic("ListNamespaces not implemented for fakeRemoteIndexStore")
+}
+func (f *fakeRemoteIndexStore) ListNamespaceIndexes(context.Context, string) ([]resource.NamespacedResource, error) {
+	panic("ListNamespaceIndexes not implemented for fakeRemoteIndexStore")
+}
+func (f *fakeRemoteIndexStore) LockNamespaceForCleanup(context.Context, string) (IndexStoreLock, error) {
+	panic("LockNamespaceForCleanup not implemented for fakeRemoteIndexStore")
+}
 
 // writeFakeSnapshot creates an empty bleve index at dir with RV and build info
 // matching meta. validateDownloadedIndex reads these back.

--- a/pkg/storage/unified/search/bleve_snapshot_upload_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_upload_test.go
@@ -86,6 +86,18 @@ func (s *uploadTestStore) CleanupIncompleteUploads(context.Context, resource.Nam
 	panic("CleanupIncompleteUploads not implemented for uploadTestStore")
 }
 
+func (s *uploadTestStore) ListNamespaces(context.Context) ([]string, error) {
+	panic("ListNamespaces not implemented for uploadTestStore")
+}
+
+func (s *uploadTestStore) ListNamespaceIndexes(context.Context, string) ([]resource.NamespacedResource, error) {
+	panic("ListNamespaceIndexes not implemented for uploadTestStore")
+}
+
+func (s *uploadTestStore) LockNamespaceForCleanup(context.Context, string) (IndexStoreLock, error) {
+	panic("LockNamespaceForCleanup not implemented for uploadTestStore")
+}
+
 func newUploadTestIndex(t *testing.T, be *bleveBackend, key resource.NamespacedResource, rv int64) *bleveIndex {
 	t.Helper()
 	resourceDir := be.getResourceDir(key)

--- a/pkg/storage/unified/search/options.go
+++ b/pkg/storage/unified/search/options.go
@@ -29,8 +29,11 @@ const (
 	DefaultSnapshotCleanupInterval = 6 * time.Hour
 	// DefaultSnapshotLockTTL is the TTL for the distributed lock used during upload/cleanup.
 	DefaultSnapshotLockTTL = 3 * time.Minute
-	// DefaultSnapshotMinKeep is the minimum number of snapshots retained regardless of age.
-	DefaultSnapshotMinKeep = 3
+	// DefaultSnapshotCleanupGracePeriod is the time a newly uploaded snapshot must
+	// have existed before its predecessor in the same Grafana-version group is
+	// considered eligible for cleanup. Gives in-flight downloads time to converge
+	// on the new snapshot before its predecessor disappears.
+	DefaultSnapshotCleanupGracePeriod = 30 * time.Minute
 )
 
 func NewSearchOptions(
@@ -105,15 +108,15 @@ func NewSearchOptions(
 			IndexModificationCacheTTL: cfg.IndexModificationCacheTTL,
 			InjectFailuresPercent:     cfg.SearchInjectFailuresPercent,
 
-			IndexSnapshotEnabled:         cfg.IndexSnapshotEnabled,
-			IndexSnapshotBucketURL:       cfg.IndexSnapshotBucketURL,
-			IndexSnapshotThreshold:       cfg.IndexSnapshotThreshold,
-			IndexSnapshotMaxAge:          cfg.IndexSnapshotMaxAge,
-			IndexSnapshotMinDocChanges:   DefaultSnapshotMinDocChanges,
-			IndexSnapshotUploadInterval:  DefaultSnapshotUploadInterval,
-			IndexSnapshotLockTTL:         DefaultSnapshotLockTTL,
-			IndexSnapshotMinKeep:         DefaultSnapshotMinKeep,
-			IndexSnapshotCleanupInterval: DefaultSnapshotCleanupInterval,
+			IndexSnapshotEnabled:            cfg.IndexSnapshotEnabled,
+			IndexSnapshotBucketURL:          cfg.IndexSnapshotBucketURL,
+			IndexSnapshotThreshold:          cfg.IndexSnapshotThreshold,
+			IndexSnapshotMaxAge:             cfg.IndexSnapshotMaxAge,
+			IndexSnapshotMinDocChanges:      DefaultSnapshotMinDocChanges,
+			IndexSnapshotUploadInterval:     DefaultSnapshotUploadInterval,
+			IndexSnapshotLockTTL:            DefaultSnapshotLockTTL,
+			IndexSnapshotCleanupInterval:    DefaultSnapshotCleanupInterval,
+			IndexSnapshotCleanupGracePeriod: cleanupGracePeriodOrDefault(cfg.IndexSnapshotCleanupGracePeriod),
 		}, nil
 	}
 	return resource.SearchOptions{
@@ -173,11 +176,22 @@ func buildSnapshotOptions(cfg *setting.Cfg, minBuildVersion *semver.Version) (Sn
 	lockHeartbeat := snapshotLockHeartbeat(lockTTL)
 
 	return SnapshotOptions{
-		Store:           NewBucketRemoteIndexStore(bucket, lockBackend, owner, lockTTL, lockHeartbeat),
-		MinDocCount:     int64(cfg.IndexSnapshotThreshold),
-		MaxIndexAge:     cfg.IndexSnapshotMaxAge,
-		MinBuildVersion: minBuildVersion,
-		UploadInterval:  DefaultSnapshotUploadInterval,
-		MinDocChanges:   DefaultSnapshotMinDocChanges,
+		Store:              NewBucketRemoteIndexStore(bucket, lockBackend, owner, lockTTL, lockHeartbeat),
+		MinDocCount:        int64(cfg.IndexSnapshotThreshold),
+		MaxIndexAge:        cfg.IndexSnapshotMaxAge,
+		MinBuildVersion:    minBuildVersion,
+		UploadInterval:     DefaultSnapshotUploadInterval,
+		MinDocChanges:      DefaultSnapshotMinDocChanges,
+		CleanupGracePeriod: cleanupGracePeriodOrDefault(cfg.IndexSnapshotCleanupGracePeriod),
 	}, nil
+}
+
+// cleanupGracePeriodOrDefault returns d if positive, otherwise the default.
+// Lets a zero value in setting.Cfg fall back to the documented default rather
+// than disabling the grace window entirely.
+func cleanupGracePeriodOrDefault(d time.Duration) time.Duration {
+	if d <= 0 {
+		return DefaultSnapshotCleanupGracePeriod
+	}
+	return d
 }

--- a/pkg/storage/unified/search/remote_index_store.go
+++ b/pkg/storage/unified/search/remote_index_store.go
@@ -159,9 +159,6 @@ func (s *BucketRemoteIndexStore) LockBuildIndex(ctx context.Context, nsResource 
 }
 
 func (s *BucketRemoteIndexStore) LockNamespaceForCleanup(ctx context.Context, namespace string) (IndexStoreLock, error) {
-	if namespace == "" {
-		return nil, fmt.Errorf("namespace must not be empty")
-	}
 	l, err := newObjectStorageLock(objectStorageLockConfig{
 		Backend:           s.lockBackend,
 		Key:               cleanupLockKey(namespace),
@@ -468,9 +465,6 @@ func (s *BucketRemoteIndexStore) ListNamespaces(ctx context.Context) ([]string, 
 // ListNamespaceIndexes returns the resources currently known under the given
 // namespace.
 func (s *BucketRemoteIndexStore) ListNamespaceIndexes(ctx context.Context, namespace string) ([]resource.NamespacedResource, error) {
-	if namespace == "" {
-		return nil, fmt.Errorf("namespace must not be empty")
-	}
 	pfx := cleanFileSegment(namespace) + "/"
 	iter := s.bucket.List(&blob.ListOptions{Prefix: pfx, Delimiter: "/"})
 	var resources []resource.NamespacedResource
@@ -502,7 +496,6 @@ func (s *BucketRemoteIndexStore) ListNamespaceIndexes(ctx context.Context, names
 	return resources, nil
 }
 
-// TODO: caller must hold a namespace-level cleanup lock.
 func (s *BucketRemoteIndexStore) DeleteIndex(ctx context.Context, nsResource resource.NamespacedResource, indexKey ulid.ULID) error {
 	pfx := indexPrefix(nsResource, indexKey.String())
 

--- a/pkg/storage/unified/search/remote_index_store.go
+++ b/pkg/storage/unified/search/remote_index_store.go
@@ -55,6 +55,11 @@ type RemoteIndexStore interface {
 	// LockBuildIndex acquires a distributed build lock for namespace/group/resource.
 	LockBuildIndex(ctx context.Context, nsResource resource.NamespacedResource) (IndexStoreLock, error)
 
+	// LockNamespaceForCleanup acquires a distributed cleanup lock for a namespace.
+	// Uses a different lock key than LockBuildIndex so cleanup never blocks an
+	// in-flight upload for any resource in the namespace.
+	LockNamespaceForCleanup(ctx context.Context, namespace string) (IndexStoreLock, error)
+
 	// UploadIndex uploads a local index directory to remote storage.
 	// It generates a unique, lexicographically sortable ULID key and returns it.
 	UploadIndex(ctx context.Context, nsResource resource.NamespacedResource, localDir string, meta IndexMeta) (ulid.ULID, error)
@@ -62,6 +67,14 @@ type RemoteIndexStore interface {
 	// DownloadIndex downloads a remote index to a local directory.
 	// destDir must not exist; it will be created atomically on success.
 	DownloadIndex(ctx context.Context, nsResource resource.NamespacedResource, indexKey ulid.ULID, destDir string) (*IndexMeta, error)
+
+	// ListNamespaces returns the namespaces currently known to the store.
+	ListNamespaces(ctx context.Context) ([]string, error)
+
+	// ListNamespaceIndexes returns the resources currently known under the given
+	// namespace. It does not list the snapshots themselves; callers follow up
+	// with ListIndexes for each returned NamespacedResource.
+	ListNamespaceIndexes(ctx context.Context, namespace string) ([]resource.NamespacedResource, error)
 
 	// ListIndexes lists all complete index snapshots for a namespaced resource.
 	// Note: indexes may be deleted between listing and subsequent operations.
@@ -121,6 +134,13 @@ func buildIndexLockKey(ns resource.NamespacedResource) string {
 	return fmt.Sprintf("%s/locks/build", resourceSubPath(ns))
 }
 
+// cleanupLockKey returns the object-storage lock key used to serialise cleanup
+// passes within a namespace. It is intentionally distinct from
+// buildIndexLockKey so cleanup never blocks ongoing uploads.
+func cleanupLockKey(namespace string) string {
+	return fmt.Sprintf("%s/locks/cleanup", cleanFileSegment(namespace))
+}
+
 func (s *BucketRemoteIndexStore) LockBuildIndex(ctx context.Context, nsResource resource.NamespacedResource) (IndexStoreLock, error) {
 	l, err := newObjectStorageLock(objectStorageLockConfig{
 		Backend:           s.lockBackend,
@@ -131,6 +151,26 @@ func (s *BucketRemoteIndexStore) LockBuildIndex(ctx context.Context, nsResource 
 	})
 	if err != nil {
 		return nil, fmt.Errorf("creating build lock: %w", err)
+	}
+	if err := l.Acquire(ctx); err != nil {
+		return nil, err
+	}
+	return l, nil
+}
+
+func (s *BucketRemoteIndexStore) LockNamespaceForCleanup(ctx context.Context, namespace string) (IndexStoreLock, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace must not be empty")
+	}
+	l, err := newObjectStorageLock(objectStorageLockConfig{
+		Backend:           s.lockBackend,
+		Key:               cleanupLockKey(namespace),
+		Owner:             s.lockOwner,
+		TTL:               s.lockTTL,
+		HeartbeatInterval: s.lockHeartbeatInterval,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating cleanup lock: %w", err)
 	}
 	if err := l.Acquire(ctx); err != nil {
 		return nil, err
@@ -399,6 +439,67 @@ func (s *BucketRemoteIndexStore) ListIndexes(ctx context.Context, nsResource res
 	}
 
 	return result, nil
+}
+
+// ListNamespaces returns the namespaces currently known to the store.
+func (s *BucketRemoteIndexStore) ListNamespaces(ctx context.Context) ([]string, error) {
+	iter := s.bucket.List(&blob.ListOptions{Delimiter: "/"})
+	var namespaces []string
+	for {
+		obj, err := iter.Next(ctx)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("listing namespaces: %w", err)
+		}
+		if !obj.IsDir {
+			continue
+		}
+		ns := strings.TrimSuffix(obj.Key, "/")
+		if ns == "" {
+			continue
+		}
+		namespaces = append(namespaces, ns)
+	}
+	return namespaces, nil
+}
+
+// ListNamespaceIndexes returns the resources currently known under the given
+// namespace.
+func (s *BucketRemoteIndexStore) ListNamespaceIndexes(ctx context.Context, namespace string) ([]resource.NamespacedResource, error) {
+	if namespace == "" {
+		return nil, fmt.Errorf("namespace must not be empty")
+	}
+	pfx := cleanFileSegment(namespace) + "/"
+	iter := s.bucket.List(&blob.ListOptions{Prefix: pfx, Delimiter: "/"})
+	var resources []resource.NamespacedResource
+	for {
+		obj, err := iter.Next(ctx)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("listing namespace indexes: %w", err)
+		}
+		if !obj.IsDir {
+			continue
+		}
+		rel := strings.TrimSuffix(strings.TrimPrefix(obj.Key, pfx), "/")
+		// `<resource>.<group>` — split on the first dot only; group may contain
+		// further dots (e.g. `dashboard.grafana.app`). Anything without a dot
+		// (e.g. the `locks` sibling) is not a resource directory.
+		dot := strings.Index(rel, ".")
+		if dot <= 0 || dot == len(rel)-1 {
+			continue
+		}
+		resources = append(resources, resource.NamespacedResource{
+			Namespace: namespace,
+			Resource:  rel[:dot],
+			Group:     rel[dot+1:],
+		})
+	}
+	return resources, nil
 }
 
 // TODO: caller must hold a namespace-level cleanup lock.

--- a/pkg/storage/unified/search/remote_index_store_test.go
+++ b/pkg/storage/unified/search/remote_index_store_test.go
@@ -778,6 +778,28 @@ func TestRemoteIndexStore_ListNamespaceIndexes_Empty(t *testing.T) {
 	assert.Empty(t, got)
 }
 
+func TestRemoteIndexStore_ListIndexes_SkipsLockSibling(t *testing.T) {
+	ctx := context.Background()
+	bucket := memblob.OpenBucket(nil)
+	defer func() { _ = bucket.Close() }()
+	store := newTestRemoteIndexStore(t, bucket)
+	ns := newTestNsResource()
+
+	indexKey, err := store.UploadIndex(ctx, ns, createTestBleveIndex(t),
+		IndexMeta{GrafanaBuildVersion: "11.0.0", LatestResourceVersion: 1})
+	require.NoError(t, err)
+
+	// Plant a `<resource-group>/locks/build` object directly in the data bucket.
+	// In production the lock backend shares the snapshot bucket, so this prefix
+	// is observable alongside index-key directories. ListIndexes must skip it.
+	require.NoError(t, bucket.WriteAll(ctx, buildIndexLockKey(ns), []byte("{}"), nil))
+
+	indexes, err := store.ListIndexes(ctx, ns)
+	require.NoError(t, err)
+	require.Len(t, indexes, 1)
+	assert.Contains(t, indexes, indexKey)
+}
+
 func TestRemoteIndexStore_ListNamespaceIndexes_SkipsLockSibling(t *testing.T) {
 	ctx := context.Background()
 	bucket := memblob.OpenBucket(nil)

--- a/pkg/storage/unified/search/remote_index_store_test.go
+++ b/pkg/storage/unified/search/remote_index_store_test.go
@@ -782,32 +782,21 @@ func TestRemoteIndexStore_ListNamespaceIndexes_SkipsLockSibling(t *testing.T) {
 	ctx := context.Background()
 	bucket := memblob.OpenBucket(nil)
 	defer func() { _ = bucket.Close() }()
-	backend := newFakeBackend(newConditionalBucket())
-	store := newTestRemoteIndexStoreWithLockOwner(t, bucket, backend, "instance-1")
+	store := newTestRemoteIndexStore(t, bucket)
 
 	nsRes := resource.NamespacedResource{Namespace: "stack-1", Group: "dashboard.grafana.app", Resource: "dashboards"}
 	_, err := store.UploadIndex(ctx, nsRes, createTestBleveIndex(t),
 		IndexMeta{GrafanaBuildVersion: "11.0.0", LatestResourceVersion: 1})
 	require.NoError(t, err)
 
-	// Acquire the cleanup lock so a `stack-1/locks/cleanup` object exists.
-	cleanupLock, err := store.LockNamespaceForCleanup(ctx, "stack-1")
-	require.NoError(t, err)
-	t.Cleanup(func() { _ = cleanupLock.Release() })
+	// Plant a `stack-1/locks/...` object directly in the data bucket. In production
+	// the lock backend shares the snapshot bucket, so this prefix is observable
+	// alongside resource directories. ListNamespaceIndexes must skip it.
+	require.NoError(t, bucket.WriteAll(ctx, "stack-1/locks/cleanup", []byte("{}"), nil))
 
 	got, err := store.ListNamespaceIndexes(ctx, "stack-1")
 	require.NoError(t, err)
 	assert.Equal(t, []resource.NamespacedResource{nsRes}, got)
-}
-
-func TestRemoteIndexStore_ListNamespaceIndexes_RejectsEmptyNamespace(t *testing.T) {
-	ctx := context.Background()
-	bucket := memblob.OpenBucket(nil)
-	defer func() { _ = bucket.Close() }()
-	store := newTestRemoteIndexStore(t, bucket)
-
-	_, err := store.ListNamespaceIndexes(ctx, "")
-	require.Error(t, err)
 }
 
 func TestRemoteIndexStore_LockNamespaceForCleanup_AcquireRelease(t *testing.T) {
@@ -870,15 +859,4 @@ func TestRemoteIndexStore_LockNamespaceForCleanup_DistinctFromBuildLock(t *testi
 	require.NoError(t, buildLock.Release())
 
 	require.NotEqual(t, cleanupLockKey(ns.Namespace), buildIndexLockKey(ns))
-}
-
-func TestRemoteIndexStore_LockNamespaceForCleanup_RejectsEmptyNamespace(t *testing.T) {
-	ctx := context.Background()
-	backend := newFakeBackend(newConditionalBucket())
-	bucket := memblob.OpenBucket(nil)
-	defer func() { _ = bucket.Close() }()
-	store := newTestRemoteIndexStoreWithLockOwner(t, bucket, backend, "instance-1")
-
-	_, err := store.LockNamespaceForCleanup(ctx, "")
-	require.Error(t, err)
 }

--- a/pkg/storage/unified/search/remote_index_store_test.go
+++ b/pkg/storage/unified/search/remote_index_store_test.go
@@ -684,3 +684,201 @@ func TestRemoteIndexStore_LockBuildIndex_LostAndReleaseAfterLoss(t *testing.T) {
 	require.True(t, err == nil || errors.Is(err, errLockNotFound), "expected nil or errLockNotFound, got %v", err)
 	require.NoError(t, lock.Release())
 }
+
+// --- ListNamespaces / ListNamespaceIndexes / LockNamespaceForCleanup ---
+
+func TestRemoteIndexStore_ListNamespaces_Empty(t *testing.T) {
+	ctx := context.Background()
+	bucket := memblob.OpenBucket(nil)
+	defer func() { _ = bucket.Close() }()
+	store := newTestRemoteIndexStore(t, bucket)
+
+	got, err := store.ListNamespaces(ctx)
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestRemoteIndexStore_ListNamespaces(t *testing.T) {
+	ctx := context.Background()
+	bucket := memblob.OpenBucket(nil)
+	defer func() { _ = bucket.Close() }()
+	store := newTestRemoteIndexStore(t, bucket)
+
+	// Seed snapshots in three distinct namespaces.
+	for _, ns := range []string{"stack-1", "stack-2", "stack-3"} {
+		nsRes := resource.NamespacedResource{Namespace: ns, Group: "dashboard.grafana.app", Resource: "dashboards"}
+		_, err := store.UploadIndex(ctx, nsRes, createTestBleveIndex(t),
+			IndexMeta{GrafanaBuildVersion: "11.0.0", LatestResourceVersion: 1})
+		require.NoError(t, err)
+	}
+
+	got, err := store.ListNamespaces(ctx)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"stack-1", "stack-2", "stack-3"}, got)
+}
+
+func TestRemoteIndexStore_ListNamespaces_IgnoresStrayObjects(t *testing.T) {
+	ctx := context.Background()
+	bucket := memblob.OpenBucket(nil)
+	defer func() { _ = bucket.Close() }()
+	store := newTestRemoteIndexStore(t, bucket)
+
+	// A bare object at the bucket root must not be reported as a namespace.
+	require.NoError(t, bucket.WriteAll(ctx, "stray.txt", []byte("hi"), nil))
+
+	nsRes := resource.NamespacedResource{Namespace: "stack-1", Group: "dashboard.grafana.app", Resource: "dashboards"}
+	_, err := store.UploadIndex(ctx, nsRes, createTestBleveIndex(t),
+		IndexMeta{GrafanaBuildVersion: "11.0.0", LatestResourceVersion: 1})
+	require.NoError(t, err)
+
+	got, err := store.ListNamespaces(ctx)
+	require.NoError(t, err)
+	assert.Equal(t, []string{"stack-1"}, got)
+}
+
+func TestRemoteIndexStore_ListNamespaceIndexes(t *testing.T) {
+	ctx := context.Background()
+	bucket := memblob.OpenBucket(nil)
+	defer func() { _ = bucket.Close() }()
+	store := newTestRemoteIndexStore(t, bucket)
+
+	resources := []resource.NamespacedResource{
+		{Namespace: "stack-1", Group: "dashboard.grafana.app", Resource: "dashboards"},
+		{Namespace: "stack-1", Group: "folder.grafana.app", Resource: "folders"},
+		{Namespace: "stack-2", Group: "dashboard.grafana.app", Resource: "dashboards"},
+	}
+	for _, r := range resources {
+		_, err := store.UploadIndex(ctx, r, createTestBleveIndex(t),
+			IndexMeta{GrafanaBuildVersion: "11.0.0", LatestResourceVersion: 1})
+		require.NoError(t, err)
+	}
+
+	got, err := store.ListNamespaceIndexes(ctx, "stack-1")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []resource.NamespacedResource{
+		{Namespace: "stack-1", Group: "dashboard.grafana.app", Resource: "dashboards"},
+		{Namespace: "stack-1", Group: "folder.grafana.app", Resource: "folders"},
+	}, got)
+
+	got, err = store.ListNamespaceIndexes(ctx, "stack-2")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []resource.NamespacedResource{
+		{Namespace: "stack-2", Group: "dashboard.grafana.app", Resource: "dashboards"},
+	}, got)
+}
+
+func TestRemoteIndexStore_ListNamespaceIndexes_Empty(t *testing.T) {
+	ctx := context.Background()
+	bucket := memblob.OpenBucket(nil)
+	defer func() { _ = bucket.Close() }()
+	store := newTestRemoteIndexStore(t, bucket)
+
+	got, err := store.ListNamespaceIndexes(ctx, "stack-1")
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestRemoteIndexStore_ListNamespaceIndexes_SkipsLockSibling(t *testing.T) {
+	ctx := context.Background()
+	bucket := memblob.OpenBucket(nil)
+	defer func() { _ = bucket.Close() }()
+	backend := newFakeBackend(newConditionalBucket())
+	store := newTestRemoteIndexStoreWithLockOwner(t, bucket, backend, "instance-1")
+
+	nsRes := resource.NamespacedResource{Namespace: "stack-1", Group: "dashboard.grafana.app", Resource: "dashboards"}
+	_, err := store.UploadIndex(ctx, nsRes, createTestBleveIndex(t),
+		IndexMeta{GrafanaBuildVersion: "11.0.0", LatestResourceVersion: 1})
+	require.NoError(t, err)
+
+	// Acquire the cleanup lock so a `stack-1/locks/cleanup` object exists.
+	cleanupLock, err := store.LockNamespaceForCleanup(ctx, "stack-1")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cleanupLock.Release() })
+
+	got, err := store.ListNamespaceIndexes(ctx, "stack-1")
+	require.NoError(t, err)
+	assert.Equal(t, []resource.NamespacedResource{nsRes}, got)
+}
+
+func TestRemoteIndexStore_ListNamespaceIndexes_RejectsEmptyNamespace(t *testing.T) {
+	ctx := context.Background()
+	bucket := memblob.OpenBucket(nil)
+	defer func() { _ = bucket.Close() }()
+	store := newTestRemoteIndexStore(t, bucket)
+
+	_, err := store.ListNamespaceIndexes(ctx, "")
+	require.Error(t, err)
+}
+
+func TestRemoteIndexStore_LockNamespaceForCleanup_AcquireRelease(t *testing.T) {
+	ctx := context.Background()
+	backend := newFakeBackend(newConditionalBucket())
+	bucket := memblob.OpenBucket(nil)
+	defer func() { _ = bucket.Close() }()
+	store := newTestRemoteIndexStoreWithLockOwner(t, bucket, backend, "instance-1")
+
+	lock, err := store.LockNamespaceForCleanup(ctx, "stack-1")
+	require.NoError(t, err)
+	select {
+	case <-lock.Lost():
+		t.Fatal("lock should not be lost")
+	default:
+	}
+	require.NoError(t, lock.Release())
+}
+
+func TestRemoteIndexStore_LockNamespaceForCleanup_Contention(t *testing.T) {
+	ctx := context.Background()
+	backend := newFakeBackend(newConditionalBucket())
+	bucket := memblob.OpenBucket(nil)
+	defer func() { _ = bucket.Close() }()
+
+	store1 := newTestRemoteIndexStoreWithLockOwner(t, bucket, backend, "instance-1")
+	store2 := newTestRemoteIndexStoreWithLockOwner(t, bucket, backend, "instance-2")
+
+	lock1, err := store1.LockNamespaceForCleanup(ctx, "stack-1")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = lock1.Release() })
+
+	_, err = store2.LockNamespaceForCleanup(ctx, "stack-1")
+	require.ErrorIs(t, err, errLockHeld)
+
+	// Different namespace must be acquirable independently.
+	lock2, err := store2.LockNamespaceForCleanup(ctx, "stack-2")
+	require.NoError(t, err)
+	require.NoError(t, lock2.Release())
+
+	require.NoError(t, lock1.Release())
+}
+
+func TestRemoteIndexStore_LockNamespaceForCleanup_DistinctFromBuildLock(t *testing.T) {
+	// The cleanup lock must not block the build lock for a resource in the same namespace,
+	// nor vice versa. Both are independently acquirable.
+	ctx := context.Background()
+	backend := newFakeBackend(newConditionalBucket())
+	bucket := memblob.OpenBucket(nil)
+	defer func() { _ = bucket.Close() }()
+	store := newTestRemoteIndexStoreWithLockOwner(t, bucket, backend, "instance-1")
+	ns := newTestNsResource()
+
+	cleanupLock, err := store.LockNamespaceForCleanup(ctx, ns.Namespace)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cleanupLock.Release() })
+
+	buildLock, err := store.LockBuildIndex(ctx, ns)
+	require.NoError(t, err)
+	require.NoError(t, buildLock.Release())
+
+	require.NotEqual(t, cleanupLockKey(ns.Namespace), buildIndexLockKey(ns))
+}
+
+func TestRemoteIndexStore_LockNamespaceForCleanup_RejectsEmptyNamespace(t *testing.T) {
+	ctx := context.Background()
+	backend := newFakeBackend(newConditionalBucket())
+	bucket := memblob.OpenBucket(nil)
+	defer func() { _ = bucket.Close() }()
+	store := newTestRemoteIndexStoreWithLockOwner(t, bucket, backend, "instance-1")
+
+	_, err := store.LockNamespaceForCleanup(ctx, "")
+	require.Error(t, err)
+}


### PR DESCRIPTION
**Add `RemoteIndexStore` primitives needed by the upcoming snapshot cleanup loop**

Purely additive. No production behaviour changes — the new methods have no callers in the merged tree yet.

Part of grafana/search-and-storage-team#715. Implements the primitives half of grafana/search-and-storage-team#722.

The new cleanup lock uses key `<namespace>/locks/cleanup`, distinct from `buildIndexLockKey` so cleanup never blocks in-flight uploads. `BucketRemoteIndexStore` implements all three new methods; the two existing test fakes get panicking stubs.

## `MinKeep` → `CleanupGracePeriod`

The unused `MinKeep` knob from #719 is replaced by a grace-period rule before any cleanup logic ships. Safe to remove without deprecation: feature is disabled by default and `MinKeep` had no consumer.

- Removed: `DefaultSnapshotMinKeep`, `SearchOptions.IndexSnapshotMinKeep`.
- Added: `DefaultSnapshotCleanupGracePeriod = 30m`, `SearchOptions.IndexSnapshotCleanupGracePeriod`, `SnapshotOptions.CleanupGracePeriod`.
- Added config: `index_snapshot_cleanup_grace_period` (default 30m), plumbed through `NewSearchOptions` / `buildSnapshotOptions`.
