### PR TITLE
Storage: make badgerKV Keys/BatchGet/BatchDelete honor ctx cancellation

### DIFF
--- a/pkg/storage/unified/resource/kv/kv.go
+++ b/pkg/storage/unified/resource/kv/kv.go
@@ -182,12 +182,6 @@ func (k *badgerKV) Get(ctx context.Context, section string, key string) (io.Read
 }
 
 func (k *badgerKV) BatchGet(ctx context.Context, section string, keys []string) iter.Seq2[KeyValue, error] {
-	if k.db.IsClosed() {
-		return func(yield func(KeyValue, error) bool) {
-			yield(KeyValue{}, fmt.Errorf("database is closed"))
-		}
-	}
-
 	if section == "" {
 		return func(yield func(KeyValue, error) bool) {
 			yield(KeyValue{}, fmt.Errorf("section is required"))
@@ -195,10 +189,26 @@ func (k *badgerKV) BatchGet(ctx context.Context, section string, keys []string) 
 	}
 
 	return func(yield func(KeyValue, error) bool) {
+		// Re-check at iteration time, not just when BatchGet() was called.
+		// The closure can be invoked much later, after ctx has been
+		// cancelled (e.g. gRPC Stop) or the DB has been closed.
+		if err := ctx.Err(); err != nil {
+			yield(KeyValue{}, err)
+			return
+		}
+		if k.db.IsClosed() {
+			yield(KeyValue{}, fmt.Errorf("database is closed"))
+			return
+		}
+
 		txn := k.db.NewTransaction(false)
 		defer txn.Discard()
 
 		for _, key := range keys {
+			if err := ctx.Err(); err != nil {
+				yield(KeyValue{}, err)
+				return
+			}
 			keyWithSection := section + "/" + key
 
 			item, err := txn.Get([]byte(keyWithSection))
@@ -319,11 +329,6 @@ func (k *badgerKV) Delete(ctx context.Context, section string, key string) error
 }
 
 func (k *badgerKV) Keys(ctx context.Context, section string, opt ListOptions) iter.Seq2[string, error] {
-	if k.db.IsClosed() {
-		return func(yield func(string, error) bool) {
-			yield("", fmt.Errorf("database is closed"))
-		}
-	}
 	if section == "" {
 		return func(yield func(string, error) bool) {
 			yield("", fmt.Errorf("section is required"))
@@ -353,12 +358,28 @@ func (k *badgerKV) Keys(ctx context.Context, section string, opt ListOptions) it
 	count := int64(0)
 
 	return func(yield func(string, error) bool) {
+		// Re-check at iteration time, not just when Keys() was called.
+		// The closure can be invoked much later, after ctx has been
+		// cancelled (e.g. gRPC Stop) or the DB has been closed.
+		if err := ctx.Err(); err != nil {
+			yield("", err)
+			return
+		}
+		if k.db.IsClosed() {
+			yield("", fmt.Errorf("database is closed"))
+			return
+		}
+
 		txn := k.db.NewTransaction(false)
 		iter := txn.NewIterator(opts)
 		defer txn.Discard()
 		defer iter.Close()
 
 		for iter.Seek([]byte(start)); iter.Valid(); iter.Next() {
+			if err := ctx.Err(); err != nil {
+				yield("", err)
+				return
+			}
 			item := iter.Item()
 			if opt.Limit > 0 && count >= opt.Limit {
 				break
@@ -420,6 +441,9 @@ func (k *badgerKV) BatchDelete(ctx context.Context, section string, keys []strin
 	defer txn.Discard()
 
 	for _, key := range keys {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		keyWithSection := section + "/" + key
 
 		// Delete the key (BadgerDB's Delete is idempotent - succeeds even if key doesn't exist)

--- a/pkg/storage/unified/resource/kv/kv_test.go
+++ b/pkg/storage/unified/resource/kv/kv_test.go
@@ -3,6 +3,7 @@ package kv
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"strings"
 	"sync"
@@ -499,6 +500,155 @@ func TestBadgerKV_Batch(t *testing.T) {
 				}
 			}
 			require.Equal(t, 1, successes, "only one writer should succeed")
+		}
+	})
+}
+
+func TestBadgerKV_ContextCancellation(t *testing.T) {
+	const section = "test-section"
+
+	seed := func(t *testing.T, kv KV, n int) []string {
+		t.Helper()
+		keys := make([]string, n)
+		for i := range n {
+			k := fmt.Sprintf("key-%03d", i)
+			keys[i] = k
+			saveKVHelper(t, kv, context.Background(), section, k, strings.NewReader("value"))
+		}
+		return keys
+	}
+
+	t.Run("Keys: pre-cancelled ctx yields error before any keys", func(t *testing.T) {
+		kv := setupTestKV(t)
+		seed(t, kv, 5)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		var got []string
+		var gotErr error
+		for k, err := range kv.Keys(ctx, section, ListOptions{}) {
+			if err != nil {
+				gotErr = err
+				break
+			}
+			got = append(got, k)
+		}
+		require.ErrorIs(t, gotErr, context.Canceled)
+		require.Empty(t, got)
+	})
+
+	t.Run("Keys: cancellation mid-iteration stops scan", func(t *testing.T) {
+		kv := setupTestKV(t)
+		seed(t, kv, 100)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		var got []string
+		var gotErr error
+		for k, err := range kv.Keys(ctx, section, ListOptions{}) {
+			if err != nil {
+				gotErr = err
+				break
+			}
+			got = append(got, k)
+			if len(got) == 3 {
+				cancel()
+			}
+		}
+		require.ErrorIs(t, gotErr, context.Canceled)
+		require.GreaterOrEqual(t, len(got), 3)
+		require.Less(t, len(got), 100, "iteration should have stopped before draining all keys")
+	})
+
+	t.Run("BatchGet: pre-cancelled ctx yields error before any keys", func(t *testing.T) {
+		kv := setupTestKV(t)
+		keys := seed(t, kv, 5)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		var got int
+		var gotErr error
+		for _, err := range kv.BatchGet(ctx, section, keys) {
+			if err != nil {
+				gotErr = err
+				break
+			}
+			got++
+		}
+		require.ErrorIs(t, gotErr, context.Canceled)
+		require.Equal(t, 0, got)
+	})
+
+	t.Run("BatchGet: cancellation mid-iteration stops scan", func(t *testing.T) {
+		kv := setupTestKV(t)
+		keys := seed(t, kv, 50)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		var got int
+		var gotErr error
+		for entry, err := range kv.BatchGet(ctx, section, keys) {
+			if err != nil {
+				gotErr = err
+				break
+			}
+			require.NoError(t, entry.Value.Close())
+			got++
+			if got == 3 {
+				cancel()
+			}
+		}
+		require.ErrorIs(t, gotErr, context.Canceled)
+		require.GreaterOrEqual(t, got, 3)
+		require.Less(t, got, 50, "iteration should have stopped before draining all keys")
+	})
+
+	t.Run("BatchDelete: pre-cancelled ctx returns error and deletes nothing", func(t *testing.T) {
+		kv := setupTestKV(t)
+		keys := seed(t, kv, 5)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		err := kv.BatchDelete(ctx, section, keys)
+		require.ErrorIs(t, err, context.Canceled)
+
+		// Transaction should have been discarded; all keys still present.
+		for _, k := range keys {
+			_, err := kv.Get(context.Background(), section, k)
+			require.NoError(t, err, "key %q should still exist", k)
+		}
+	})
+
+	t.Run("BatchDelete: empty keys with cancelled ctx is a no-op", func(t *testing.T) {
+		// BatchDelete is eager and only checks ctx per-iteration, so an empty
+		// keys slice short-circuits to a successful empty Commit even when
+		// ctx is already cancelled. Documenting that behavior here.
+		kv := setupTestKV(t)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		err := kv.BatchDelete(ctx, section, nil)
+		require.NoError(t, err)
+	})
+
+	t.Run("sanity: errors.Is matches context.Canceled", func(t *testing.T) {
+		// Guards against a future change wrapping ctx.Err() into an opaque
+		// error type that breaks errors.Is for callers (e.g. retry logic).
+		kv := setupTestKV(t)
+		seed(t, kv, 1)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		for _, err := range kv.Keys(ctx, section, ListOptions{}) {
+			require.True(t, errors.Is(err, context.Canceled))
+			break
 		}
 	})
 }


### PR DESCRIPTION
## What this PR does

Makes `badgerKV.Keys`, `badgerKV.BatchGet`, and `badgerKV.BatchDelete` in `pkg/storage/unified/resource/kv/kv.go` actually honor the `context.Context` they're passed. Previously the `ctx` parameter was effectively unused for cancellation: the iter.Seq2 closures and the BatchDelete loop ran to completion regardless of cancellation.

## Why

Investigating a flaky `TestKVGRPC` failure (https://github.com/grafana/grafana/actions/runs/25041595286/job/73345999559):

```
panic: DB Closed
github.com/dgraph-io/badger/v4.(*Txn).NewIterator(...)
github.com/grafana/grafana/pkg/storage/unified/resource/kv.(*badgerKV).Keys.func4(...)
    pkg/storage/unified/resource/kv/kv.go:356
github.com/grafana/grafana/pkg/extensions/storage/unified/kv.(*BadgerKVServer).Keys(...)
    pkg/extensions/storage/unified/kv/server.go:58
```

The earlier test-only fix in https://github.com/grafana/grafana-enterprise/pull/11798 (use `GracefulStop` with a 5s timeout) didn't fully eliminate the race: when `GracefulStop` times out it falls back to `Stop()`, which cancels stream contexts but doesn't wait for handler goroutines. The handler then races `db.Close()` and panics inside `NewIterator`.

Root cause on the grafana side: `badgerKV.Keys` ignored its `ctx`, so cancelling the gRPC stream context didn't actually stop the badger scan — `GracefulStop` had nothing to drain quickly. Same gap in `BatchGet` and `BatchDelete`.

## Cost

`ctx.Err()` per iteration on a cancellable context is ~15–30 ns (mutex + read). Negligible vs. one badger iterator step. For a million-key scan that's ~15–30 ms total overhead, which is small compared to the iteration itself.

## References

- Failing run: https://github.com/grafana/grafana/actions/runs/25041595286/job/73345999559
- Earlier test-only fix: https://github.com/grafana/grafana-enterprise/pull/11798
