### PR TITLE
Unified Storage: Capture panel query expressions in dashboard parser

### DIFF
--- a/pkg/services/store/kind/dashboard/dashboard.go
+++ b/pkg/services/store/kind/dashboard/dashboard.go
@@ -550,7 +550,7 @@ func readpanelInfo(iter *jsoniter.Iterator, lookup DatasourceLookup, jsonPath st
 	for field := iter.ReadObject(); field != ""; field = iter.ReadObject() {
 		if iter.WhatIsNext() == jsoniter.NilValue {
 			if field == "datasource" {
-				targets.addDatasource(iter, jsonPath+".datasource", lc)
+				_ = targets.addDatasource(iter, jsonPath+".datasource", lc)
 				continue
 			}
 
@@ -816,54 +816,34 @@ func readV2PanelSpec(iter *jsoniter.Iterator, lookup DatasourceLookup, jsonPath 
 	return panel
 }
 
-// readV2QueryExpression pulls the refId, datasource, and expression out of
-// one v2 queries[] entry. Tries three path shapes in order — schema-correct
-// (m.spec.query.spec.<expr> with refId on m.spec and datasource at
-// m.spec.query.datasource), nested-spec variant (m.spec.<expr>,
-// m.spec.datasource), and flat fallback (m.<expr> with refId/datasource at
-// root). Datasource extraction is shared with readV2QueryDatasourceRef so
-// the per-query DatasourceUID and the panel-level Datasource aggregation
-// always agree.
+// readV2QueryExpression extracts refId, datasource, and expression from one
+// v2 queries[] entry using the schema-correct path: refId at m.spec.refId,
+// datasource via readV2QueryDatasourceRef, expression at m.spec.query.spec.<expr>.
 func readV2QueryExpression(m map[string]any) PanelQueryInfo {
 	q := PanelQueryInfo{}
 	if ds := readV2QueryDatasourceRef(m); ds != nil {
 		q.DatasourceUID = ds.UID
 	}
-
-	if specMap, _ := m["spec"].(map[string]any); specMap != nil {
-		if rid, _ := specMap["refId"].(string); rid != "" {
-			q.RefID = rid
-		}
-		// Schema path: m.spec.query.spec.<expr>.
-		if query, _ := specMap["query"].(map[string]any); query != nil {
-			if qspec, _ := query["spec"].(map[string]any); qspec != nil {
-				if expr := pickExpression(qspec); expr != "" {
-					q.Expression = expr
-					return q
-				}
-			}
-		}
-		// Variant: m.spec.<expr>.
-		if expr := pickExpression(specMap); expr != "" {
-			q.Expression = expr
-			return q
-		}
+	specMap, _ := m["spec"].(map[string]any)
+	if specMap == nil {
+		return q
 	}
-	// Flat: m.<expr> with refId at root.
-	q.Expression = pickExpression(m)
-	if q.RefID == "" {
-		if rid, _ := m["refId"].(string); rid != "" {
-			q.RefID = rid
-		}
+	if refId, _ := specMap["refId"].(string); refId != "" {
+		q.RefID = refId
 	}
+	query, _ := specMap["query"].(map[string]any)
+	if query == nil {
+		return q
+	}
+	qspec, _ := query["spec"].(map[string]any)
+	if qspec == nil {
+		return q
+	}
+	q.Expression = pickExpression(qspec)
 	return q
 }
 
-// readV2QueryDatasourceRef walks the same path priority as
-// readV2QueryExpression to find a v2 query's datasource. Returns nil when
-// no datasource is referenced. UID holds whichever identifier was present
-// (uid or name); Type may be empty for v2 schema-correct refs which only
-// declare name.
+// dashboard can exist at m.spec.query.datasource or m.datasource in v2 schema
 func readV2QueryDatasourceRef(m map[string]any) *DataSourceRef {
 	// Schema path: m.spec.query.datasource.
 	if specMap, _ := m["spec"].(map[string]any); specMap != nil {
@@ -872,12 +852,7 @@ func readV2QueryDatasourceRef(m map[string]any) *DataSourceRef {
 				return dsRefFromMap(ds)
 			}
 		}
-		// Variant: m.spec.datasource.
-		if ds, _ := specMap["datasource"].(map[string]any); ds != nil {
-			return dsRefFromMap(ds)
-		}
 	}
-	// Flat: m.datasource.
 	if ds, _ := m["datasource"].(map[string]any); ds != nil {
 		return dsRefFromMap(ds)
 	}

--- a/pkg/services/store/kind/dashboard/dashboard.go
+++ b/pkg/services/store/kind/dashboard/dashboard.go
@@ -826,18 +826,25 @@ func readV2PanelSpec(iter *jsoniter.Iterator, lookup DatasourceLookup, jsonPath 
 	return panel
 }
 
-// readV2QueryExpression pulls the query expression and refId out of one v2
-// queries[] entry. The v2 schema (matching what grafana-assistant-app's
-// extractor reads) puts the expression at m.spec.query.spec.<expr> with
-// refId on m.spec. Falls back to m.spec.<expr> and m.<expr> for variants.
+// readV2QueryExpression pulls the query expression, refId, and datasource
+// reference out of one v2 queries[] entry. The v2 schema (matching what
+// grafana-assistant-app's extractor reads) puts the expression at
+// m.spec.query.spec.<expr> with refId on m.spec and datasource at
+// m.spec.query.datasource. The datasource ref carries `name` (v2 references
+// datasources by name); we put whatever identifier is present into
+// DatasourceUID so consumers can map each query back to its datasource.
+// Falls back to m.spec.<expr> / m.<expr> with corresponding datasource paths.
 func readV2QueryExpression(m map[string]any) PanelQueryInfo {
 	if specMap, _ := m["spec"].(map[string]any); specMap != nil {
 		var q PanelQueryInfo
 		if rid, _ := specMap["refId"].(string); rid != "" {
 			q.RefID = rid
 		}
-		// Schema path: m.spec.query.spec.<expr>
+		// Schema path: m.spec.query.spec.<expr>, datasource at m.spec.query.datasource.
 		if query, _ := specMap["query"].(map[string]any); query != nil {
+			if ds, _ := query["datasource"].(map[string]any); ds != nil {
+				q.DatasourceUID = pickDatasourceRef(ds)
+			}
 			if qspec, _ := query["spec"].(map[string]any); qspec != nil {
 				if expr := pickExpression(qspec); expr != "" {
 					q.Expression = expr
@@ -845,14 +852,35 @@ func readV2QueryExpression(m map[string]any) PanelQueryInfo {
 				}
 			}
 		}
-		// Variant: m.spec.<expr>
+		// Variant: m.spec.<expr> with datasource at m.spec.datasource.
+		if q.DatasourceUID == "" {
+			if ds, _ := specMap["datasource"].(map[string]any); ds != nil {
+				q.DatasourceUID = pickDatasourceRef(ds)
+			}
+		}
 		if expr := pickExpression(specMap); expr != "" {
 			q.Expression = expr
 			return q
 		}
 	}
-	// Flat fallback: m.<expr>
-	return PanelQueryInfo{Expression: pickExpression(m)}
+	// Flat fallback: m.<expr> with datasource at m.datasource.
+	q := PanelQueryInfo{Expression: pickExpression(m)}
+	if ds, _ := m["datasource"].(map[string]any); ds != nil {
+		q.DatasourceUID = pickDatasourceRef(ds)
+	}
+	return q
+}
+
+// pickDatasourceRef returns whichever identifier a datasource ref carries,
+// preferring `uid` (v1-style or denormalized) over `name` (schema-correct v2).
+func pickDatasourceRef(ds map[string]any) string {
+	if uid, _ := ds["uid"].(string); uid != "" {
+		return uid
+	}
+	if name, _ := ds["name"].(string); name != "" {
+		return name
+	}
+	return ""
 }
 
 func pickExpression(m map[string]any) string {

--- a/pkg/services/store/kind/dashboard/dashboard.go
+++ b/pkg/services/store/kind/dashboard/dashboard.go
@@ -790,11 +790,6 @@ func readV2PanelSpec(iter *jsoniter.Iterator, lookup DatasourceLookup, jsonPath 
 							if !ok {
 								continue
 							}
-							// Pull the datasource ref using the same path
-							// priority readV2QueryExpression uses, so the
-							// per-query DatasourceUID and the panel-level
-							// aggregation always agree on which datasource
-							// the query references.
 							if ds := readV2QueryDatasourceRef(m); ds != nil {
 								panel.Datasource = append(panel.Datasource, *ds)
 							}

--- a/pkg/services/store/kind/dashboard/dashboard.go
+++ b/pkg/services/store/kind/dashboard/dashboard.go
@@ -790,23 +790,13 @@ func readV2PanelSpec(iter *jsoniter.Iterator, lookup DatasourceLookup, jsonPath 
 							if !ok {
 								continue
 							}
-							// Datasource lives at queries[].spec.datasource in
-							// the v2 fixtures we've seen. (Older flat form
-							// queries[].datasource is preserved for backward
-							// compat with whatever the existing parser was
-							// targeting.)
-							ds, _ := m["datasource"].(map[string]any)
-							if ds == nil {
-								if specMap, _ := m["spec"].(map[string]any); specMap != nil {
-									ds, _ = specMap["datasource"].(map[string]any)
-								}
-							}
-							if ds != nil {
-								uid, _ := ds["uid"].(string)
-								typ, _ := ds["type"].(string)
-								if uid != "" {
-									panel.Datasource = append(panel.Datasource, DataSourceRef{UID: uid, Type: typ})
-								}
+							// Pull the datasource ref using the same path
+							// priority readV2QueryExpression uses, so the
+							// per-query DatasourceUID and the panel-level
+							// aggregation always agree on which datasource
+							// the query references.
+							if ds := readV2QueryDatasourceRef(m); ds != nil {
+								panel.Datasource = append(panel.Datasource, *ds)
 							}
 
 							if qe := readV2QueryExpression(m); qe.Expression != "" {
@@ -826,24 +816,26 @@ func readV2PanelSpec(iter *jsoniter.Iterator, lookup DatasourceLookup, jsonPath 
 	return panel
 }
 
-// readV2QueryExpression pulls the query expression, refId, and datasource
-// reference out of one v2 queries[] entry. The v2 schema puts the expression at
-// m.spec.query.spec.<expr> with refId on m.spec and datasource at
-// m.spec.query.datasource. The datasource ref carries `name` (v2 references
-// datasources by name); we put whatever identifier is present into
-// DatasourceUID so consumers can map each query back to its datasource.
-// Falls back to m.spec.<expr> / m.<expr> with corresponding datasource paths.
+// readV2QueryExpression pulls the refId, datasource, and expression out of
+// one v2 queries[] entry. Tries three path shapes in order — schema-correct
+// (m.spec.query.spec.<expr> with refId on m.spec and datasource at
+// m.spec.query.datasource), nested-spec variant (m.spec.<expr>,
+// m.spec.datasource), and flat fallback (m.<expr> with refId/datasource at
+// root). Datasource extraction is shared with readV2QueryDatasourceRef so
+// the per-query DatasourceUID and the panel-level Datasource aggregation
+// always agree.
 func readV2QueryExpression(m map[string]any) PanelQueryInfo {
+	q := PanelQueryInfo{}
+	if ds := readV2QueryDatasourceRef(m); ds != nil {
+		q.DatasourceUID = ds.UID
+	}
+
 	if specMap, _ := m["spec"].(map[string]any); specMap != nil {
-		var q PanelQueryInfo
 		if rid, _ := specMap["refId"].(string); rid != "" {
 			q.RefID = rid
 		}
-		// Schema path: m.spec.query.spec.<expr>, datasource at m.spec.query.datasource.
+		// Schema path: m.spec.query.spec.<expr>.
 		if query, _ := specMap["query"].(map[string]any); query != nil {
-			if ds, _ := query["datasource"].(map[string]any); ds != nil {
-				q.DatasourceUID = pickDatasourceRef(ds)
-			}
 			if qspec, _ := query["spec"].(map[string]any); qspec != nil {
 				if expr := pickExpression(qspec); expr != "" {
 					q.Expression = expr
@@ -851,38 +843,61 @@ func readV2QueryExpression(m map[string]any) PanelQueryInfo {
 				}
 			}
 		}
-		// Variant: m.spec.<expr> with datasource at m.spec.datasource.
-		if q.DatasourceUID == "" {
-			if ds, _ := specMap["datasource"].(map[string]any); ds != nil {
-				q.DatasourceUID = pickDatasourceRef(ds)
-			}
-		}
+		// Variant: m.spec.<expr>.
 		if expr := pickExpression(specMap); expr != "" {
 			q.Expression = expr
 			return q
 		}
 	}
-	// Flat fallback: m.<expr> with refId/datasource at the root.
-	q := PanelQueryInfo{Expression: pickExpression(m)}
-	if rid, _ := m["refId"].(string); rid != "" {
-		q.RefID = rid
-	}
-	if ds, _ := m["datasource"].(map[string]any); ds != nil {
-		q.DatasourceUID = pickDatasourceRef(ds)
+	// Flat: m.<expr> with refId at root.
+	q.Expression = pickExpression(m)
+	if q.RefID == "" {
+		if rid, _ := m["refId"].(string); rid != "" {
+			q.RefID = rid
+		}
 	}
 	return q
 }
 
-// pickDatasourceRef returns whichever identifier a datasource ref carries,
-// preferring `uid` (v1-style or denormalized) over `name` (schema-correct v2).
-func pickDatasourceRef(ds map[string]any) string {
-	if uid, _ := ds["uid"].(string); uid != "" {
-		return uid
+// readV2QueryDatasourceRef walks the same path priority as
+// readV2QueryExpression to find a v2 query's datasource. Returns nil when
+// no datasource is referenced. UID holds whichever identifier was present
+// (uid or name); Type may be empty for v2 schema-correct refs which only
+// declare name.
+func readV2QueryDatasourceRef(m map[string]any) *DataSourceRef {
+	// Schema path: m.spec.query.datasource.
+	if specMap, _ := m["spec"].(map[string]any); specMap != nil {
+		if query, _ := specMap["query"].(map[string]any); query != nil {
+			if ds, _ := query["datasource"].(map[string]any); ds != nil {
+				return dsRefFromMap(ds)
+			}
+		}
+		// Variant: m.spec.datasource.
+		if ds, _ := specMap["datasource"].(map[string]any); ds != nil {
+			return dsRefFromMap(ds)
+		}
 	}
-	if name, _ := ds["name"].(string); name != "" {
-		return name
+	// Flat: m.datasource.
+	if ds, _ := m["datasource"].(map[string]any); ds != nil {
+		return dsRefFromMap(ds)
 	}
-	return ""
+	return nil
+}
+
+// dsRefFromMap pulls a DataSourceRef from a {uid?, name?, type?} map. Prefers
+// `uid` (v1-style or denormalized) over `name` (schema-correct v2). Returns
+// nil when neither identifier is present.
+func dsRefFromMap(ds map[string]any) *DataSourceRef {
+	uid, _ := ds["uid"].(string)
+	name, _ := ds["name"].(string)
+	typ, _ := ds["type"].(string)
+	if uid == "" {
+		uid = name
+	}
+	if uid == "" {
+		return nil
+	}
+	return &DataSourceRef{UID: uid, Type: typ}
 }
 
 func pickExpression(m map[string]any) string {

--- a/pkg/services/store/kind/dashboard/dashboard.go
+++ b/pkg/services/store/kind/dashboard/dashboard.go
@@ -622,11 +622,17 @@ func readpanelInfo(iter *jsoniter.Iterator, lookup DatasourceLookup, jsonPath st
 			switch iter.WhatIsNext() {
 			case jsoniter.ArrayValue:
 				for ix := 0; iter.ReadArray(); ix++ {
-					targets.addTarget(iter, fmt.Sprintf("%s.targets[%d]", jsonPath, ix), lc)
+					q := targets.addTarget(iter, fmt.Sprintf("%s.targets[%d]", jsonPath, ix), lc)
+					if q.Expression != "" {
+						panel.Queries = append(panel.Queries, q)
+					}
 				}
 			case jsoniter.ObjectValue:
 				for fn := iter.ReadObject(); fn != ""; fn = iter.ReadObject() {
-					targets.addTarget(iter, jsonPath+".targets."+fn, lc)
+					q := targets.addTarget(iter, jsonPath+".targets."+fn, lc)
+					if q.Expression != "" {
+						panel.Queries = append(panel.Queries, q)
+					}
 				}
 			default:
 				iter.Skip()
@@ -738,6 +744,17 @@ func readV2PanelSpec(iter *jsoniter.Iterator, lookup DatasourceLookup, jsonPath 
 			continue
 		}
 		switch field {
+		case "id":
+			if !checkAndSkipUnexpectedElement(iter, jsonPath+".id", lc, jsoniter.NumberValue, jsoniter.StringValue) {
+				continue
+			}
+			if iter.WhatIsNext() == jsoniter.StringValue {
+				if id, err := strconv.ParseInt(iter.ReadString(), 10, 64); err == nil {
+					panel.ID = id
+				}
+			} else {
+				panel.ID = iter.ReadInt64()
+			}
 		case "title":
 			if checkAndSkipUnexpectedElement(iter, jsonPath+".title", lc, jsoniter.StringValue) {
 				panel.Title = iter.ReadString()
@@ -769,14 +786,37 @@ func readV2PanelSpec(iter *jsoniter.Iterator, lookup DatasourceLookup, jsonPath 
 					}
 					if queries, _ := spec["queries"].([]any); queries != nil {
 						for _, q := range queries {
-							if m, ok := q.(map[string]any); ok {
-								if ds, ok := m["datasource"].(map[string]any); ok {
-									uid, _ := ds["uid"].(string)
-									typ, _ := ds["type"].(string)
-									if uid != "" {
-										panel.Datasource = append(panel.Datasource, DataSourceRef{UID: uid, Type: typ})
+							m, ok := q.(map[string]any)
+							if !ok {
+								continue
+							}
+							// Datasource may live at the queries[] item level
+							// (`m.datasource`) or nested under `m.spec.datasource`.
+							// The schema-correct form is `m.spec.query.datasource`.
+							ds, _ := m["datasource"].(map[string]any)
+							if ds == nil {
+								if specMap, _ := m["spec"].(map[string]any); specMap != nil {
+									ds, _ = specMap["datasource"].(map[string]any)
+									if ds == nil {
+										if query, _ := specMap["query"].(map[string]any); query != nil {
+											ds, _ = query["datasource"].(map[string]any)
+										}
 									}
 								}
+							}
+							if ds != nil {
+								uid, _ := ds["uid"].(string)
+								typ, _ := ds["type"].(string)
+								if uid != "" {
+									panel.Datasource = append(panel.Datasource, DataSourceRef{UID: uid, Type: typ})
+								}
+							}
+
+							// Capture the query expression. Try the same depths
+							// in priority order: schema-correct `m.spec.query.spec.<expr>`,
+							// then `m.spec.<expr>`, then flat `m.<expr>`.
+							if qe := readV2QueryExpression(m); qe.Expression != "" {
+								panel.Queries = append(panel.Queries, qe)
 							}
 						}
 					}
@@ -790,6 +830,50 @@ func readV2PanelSpec(iter *jsoniter.Iterator, lookup DatasourceLookup, jsonPath 
 	}
 	panel.Datasource = filterSpecialDatasourcesFromRefs(panel.Datasource)
 	return panel
+}
+
+// readV2QueryExpression pulls the query expression and refId out of one v2
+// queries[] entry. V2 schema variants put the expression at different
+// depths; we try each in priority order.
+func readV2QueryExpression(m map[string]any) PanelQueryInfo {
+	// Schema-correct: m.spec.query.spec.<expr> with m.spec.refId
+	if specMap, _ := m["spec"].(map[string]any); specMap != nil {
+		var q PanelQueryInfo
+		if rid, _ := specMap["refId"].(string); rid != "" {
+			q.RefID = rid
+		}
+		if query, _ := specMap["query"].(map[string]any); query != nil {
+			if qspec, _ := query["spec"].(map[string]any); qspec != nil {
+				if expr := pickExpression(qspec); expr != "" {
+					q.Expression = expr
+					return q
+				}
+			}
+		}
+		// Fallback: m.spec.<expr> directly
+		if expr := pickExpression(specMap); expr != "" {
+			q.Expression = expr
+			return q
+		}
+	}
+	// Flat fallback: m.<expr> (matches some legacy fixtures)
+	return PanelQueryInfo{Expression: pickExpression(m)}
+}
+
+func pickExpression(m map[string]any) string {
+	if s, _ := m["expr"].(string); s != "" {
+		return s
+	}
+	if s, _ := m["rawSql"].(string); s != "" {
+		return s
+	}
+	if s, _ := m["rawQuery"].(string); s != "" {
+		return s
+	}
+	if s, _ := m["query"].(string); s != "" {
+		return s
+	}
+	return ""
 }
 
 func readV2LibraryPanelSpec(iter *jsoniter.Iterator, jsonPath string, lc map[string]any) PanelSummaryInfo {

--- a/pkg/services/store/kind/dashboard/dashboard.go
+++ b/pkg/services/store/kind/dashboard/dashboard.go
@@ -827,8 +827,7 @@ func readV2PanelSpec(iter *jsoniter.Iterator, lookup DatasourceLookup, jsonPath 
 }
 
 // readV2QueryExpression pulls the query expression, refId, and datasource
-// reference out of one v2 queries[] entry. The v2 schema (matching what
-// grafana-assistant-app's extractor reads) puts the expression at
+// reference out of one v2 queries[] entry. The v2 schema puts the expression at
 // m.spec.query.spec.<expr> with refId on m.spec and datasource at
 // m.spec.query.datasource. The datasource ref carries `name` (v2 references
 // datasources by name); we put whatever identifier is present into

--- a/pkg/services/store/kind/dashboard/dashboard.go
+++ b/pkg/services/store/kind/dashboard/dashboard.go
@@ -790,18 +790,15 @@ func readV2PanelSpec(iter *jsoniter.Iterator, lookup DatasourceLookup, jsonPath 
 							if !ok {
 								continue
 							}
-							// Datasource may live at the queries[] item level
-							// (`m.datasource`) or nested under `m.spec.datasource`.
-							// The schema-correct form is `m.spec.query.datasource`.
+							// Datasource lives at queries[].spec.datasource in
+							// the v2 fixtures we've seen. (Older flat form
+							// queries[].datasource is preserved for backward
+							// compat with whatever the existing parser was
+							// targeting.)
 							ds, _ := m["datasource"].(map[string]any)
 							if ds == nil {
 								if specMap, _ := m["spec"].(map[string]any); specMap != nil {
 									ds, _ = specMap["datasource"].(map[string]any)
-									if ds == nil {
-										if query, _ := specMap["query"].(map[string]any); query != nil {
-											ds, _ = query["datasource"].(map[string]any)
-										}
-									}
 								}
 							}
 							if ds != nil {
@@ -812,9 +809,6 @@ func readV2PanelSpec(iter *jsoniter.Iterator, lookup DatasourceLookup, jsonPath 
 								}
 							}
 
-							// Capture the query expression. Try the same depths
-							// in priority order: schema-correct `m.spec.query.spec.<expr>`,
-							// then `m.spec.<expr>`, then flat `m.<expr>`.
 							if qe := readV2QueryExpression(m); qe.Expression != "" {
 								panel.Queries = append(panel.Queries, qe)
 							}
@@ -833,15 +827,16 @@ func readV2PanelSpec(iter *jsoniter.Iterator, lookup DatasourceLookup, jsonPath 
 }
 
 // readV2QueryExpression pulls the query expression and refId out of one v2
-// queries[] entry. V2 schema variants put the expression at different
-// depths; we try each in priority order.
+// queries[] entry. The v2 schema (matching what grafana-assistant-app's
+// extractor reads) puts the expression at m.spec.query.spec.<expr> with
+// refId on m.spec. Falls back to m.spec.<expr> and m.<expr> for variants.
 func readV2QueryExpression(m map[string]any) PanelQueryInfo {
-	// Schema-correct: m.spec.query.spec.<expr> with m.spec.refId
 	if specMap, _ := m["spec"].(map[string]any); specMap != nil {
 		var q PanelQueryInfo
 		if rid, _ := specMap["refId"].(string); rid != "" {
 			q.RefID = rid
 		}
+		// Schema path: m.spec.query.spec.<expr>
 		if query, _ := specMap["query"].(map[string]any); query != nil {
 			if qspec, _ := query["spec"].(map[string]any); qspec != nil {
 				if expr := pickExpression(qspec); expr != "" {
@@ -850,13 +845,13 @@ func readV2QueryExpression(m map[string]any) PanelQueryInfo {
 				}
 			}
 		}
-		// Fallback: m.spec.<expr> directly
+		// Variant: m.spec.<expr>
 		if expr := pickExpression(specMap); expr != "" {
 			q.Expression = expr
 			return q
 		}
 	}
-	// Flat fallback: m.<expr> (matches some legacy fixtures)
+	// Flat fallback: m.<expr>
 	return PanelQueryInfo{Expression: pickExpression(m)}
 }
 

--- a/pkg/services/store/kind/dashboard/dashboard.go
+++ b/pkg/services/store/kind/dashboard/dashboard.go
@@ -862,8 +862,11 @@ func readV2QueryExpression(m map[string]any) PanelQueryInfo {
 			return q
 		}
 	}
-	// Flat fallback: m.<expr> with datasource at m.datasource.
+	// Flat fallback: m.<expr> with refId/datasource at the root.
 	q := PanelQueryInfo{Expression: pickExpression(m)}
+	if rid, _ := m["refId"].(string); rid != "" {
+		q.RefID = rid
+	}
 	if ds, _ := m["datasource"].(map[string]any); ds != nil {
 		q.DatasourceUID = pickDatasourceRef(ds)
 	}

--- a/pkg/services/store/kind/dashboard/dashboard_test.go
+++ b/pkg/services/store/kind/dashboard/dashboard_test.go
@@ -77,6 +77,7 @@ func TestReadDashboard(t *testing.T) {
 		"k8s-wrapper-tags-string",
 		"k8s-wrapper-with-parsing-errors",
 		"v2-elements",
+		"panel-queries",
 		"scenarios/all-colapsed-rows-public",
 	}
 

--- a/pkg/services/store/kind/dashboard/dashboard_test.go
+++ b/pkg/services/store/kind/dashboard/dashboard_test.go
@@ -78,6 +78,7 @@ func TestReadDashboard(t *testing.T) {
 		"k8s-wrapper-with-parsing-errors",
 		"v2-elements",
 		"panel-queries",
+		"v2-panel-queries",
 		"scenarios/all-colapsed-rows-public",
 	}
 

--- a/pkg/services/store/kind/dashboard/targets.go
+++ b/pkg/services/store/kind/dashboard/targets.go
@@ -89,14 +89,15 @@ func (s *targetInfo) addTarget(iter *jsoniter.Iterator, jsonPath string, lc map[
 	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "datasource":
-			// Null means "inherit from the panel" — skip addDatasource
-			// entirely so we don't pollute the panel-level aggregation
-			// (s.uids → panel.Datasource) with the org default. Consumers
-			// fall back to panel.Datasource, which then accurately reflects
-			// only datasources the panel actually references.
-			if iter.WhatIsNext() == jsoniter.NilValue {
-				iter.Skip()
-			} else if ref := s.addDatasource(iter, jsonPath+".datasource", lc); ref != nil && ref.UID != "" {
+			// Null targets resolve to the org default at runtime in this
+			// codebase's interpretation, and the panel-level aggregation
+			// records that dependency via addDatasource. Don't propagate
+			// the resolved default into q.DatasourceUID though — leaving
+			// it empty signals "no explicit per-query datasource", and
+			// consumers should not assume a single fallback.
+			isNil := iter.WhatIsNext() == jsoniter.NilValue
+			ref := s.addDatasource(iter, jsonPath+".datasource", lc)
+			if !isNil && ref != nil && ref.UID != "" {
 				q.DatasourceUID = ref.UID
 			}
 

--- a/pkg/services/store/kind/dashboard/targets.go
+++ b/pkg/services/store/kind/dashboard/targets.go
@@ -26,10 +26,12 @@ func (s *targetInfo) GetDatasourceInfo() []DataSourceRef {
 	return keys
 }
 
-// the node will either be string (name|uid) OR ref
-func (s *targetInfo) addDatasource(iter *jsoniter.Iterator, jsonPath string, lc map[string]any) {
+// addDatasource accumulates the datasource reference into targetInfo and
+// returns the resolved ref (may be nil). The node may be a string (uid),
+// nil (default), or an object ref.
+func (s *targetInfo) addDatasource(iter *jsoniter.Iterator, jsonPath string, lc map[string]any) *DataSourceRef {
 	if !checkAndSkipUnexpectedElement(iter, jsonPath, lc, jsoniter.StringValue, jsoniter.NilValue, jsoniter.ObjectValue) {
-		return
+		return nil
 	}
 
 	switch iter.WhatIsNext() {
@@ -40,26 +42,32 @@ func (s *targetInfo) addDatasource(iter *jsoniter.Iterator, jsonPath string, lc 
 		if !isVariableRef(dsRef.UID) && !isSpecialDatasource(dsRef.UID) {
 			ds := s.lookup.ByRef(dsRef)
 			s.addRef(ds)
-		} else {
-			s.addRef(dsRef)
+			return ds
 		}
+		s.addRef(dsRef)
+		return dsRef
 
 	case jsoniter.NilValue:
-		s.addRef(s.lookup.ByRef(nil))
+		ds := s.lookup.ByRef(nil)
+		s.addRef(ds)
 		iter.Skip()
+		return ds
 
 	case jsoniter.ObjectValue:
 		ref := &DataSourceRef{}
 		iter.ReadVal(ref)
 
 		if !isVariableRef(ref.UID) && !isSpecialDatasource(ref.UID) {
-			s.addRef(s.lookup.ByRef(ref))
-		} else {
-			s.addRef(ref)
+			resolved := s.lookup.ByRef(ref)
+			s.addRef(resolved)
+			return resolved
 		}
+		s.addRef(ref)
+		return ref
 
 	default:
 		iter.Skip()
+		return nil
 	}
 }
 
@@ -69,23 +77,57 @@ func (s *targetInfo) addRef(ref *DataSourceRef) {
 	}
 }
 
-func (s *targetInfo) addTarget(iter *jsoniter.Iterator, jsonPath string, lc map[string]any) {
+// addTarget walks one target object, accumulates its datasource into
+// targetInfo, and returns the captured query info. Empty Expression means
+// the target had no expression we recognise.
+func (s *targetInfo) addTarget(iter *jsoniter.Iterator, jsonPath string, lc map[string]any) PanelQueryInfo {
+	var q PanelQueryInfo
 	if !checkAndSkipUnexpectedElement(iter, jsonPath, lc, jsoniter.ObjectValue) {
-		return
+		return q
 	}
 
 	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "datasource":
-			s.addDatasource(iter, jsonPath+".datasource", lc)
+			if ref := s.addDatasource(iter, jsonPath+".datasource", lc); ref != nil && ref.UID != "" {
+				q.DatasourceUID = ref.UID
+			}
 
 		case "refId":
-			iter.Skip()
+			if iter.WhatIsNext() == jsoniter.StringValue {
+				q.RefID = iter.ReadString()
+			} else {
+				iter.Skip()
+			}
+
+		case "expr":
+			if iter.WhatIsNext() == jsoniter.StringValue && q.Expression == "" {
+				q.Expression = iter.ReadString()
+			} else {
+				iter.Skip()
+			}
+
+		case "rawSql", "rawQuery":
+			if iter.WhatIsNext() == jsoniter.StringValue && q.Expression == "" {
+				q.Expression = iter.ReadString()
+			} else {
+				iter.Skip()
+			}
+
+		case "query":
+			// TraceQL: only treat the string form as an expression. The
+			// object form appears in templating-variable contexts.
+			if iter.WhatIsNext() == jsoniter.StringValue && q.Expression == "" {
+				q.Expression = iter.ReadString()
+			} else {
+				iter.Skip()
+			}
 
 		default:
 			iter.Skip()
 		}
 	}
+	return q
 }
 
 func (s *targetInfo) addPanel(panel PanelSummaryInfo) {

--- a/pkg/services/store/kind/dashboard/targets.go
+++ b/pkg/services/store/kind/dashboard/targets.go
@@ -89,13 +89,14 @@ func (s *targetInfo) addTarget(iter *jsoniter.Iterator, jsonPath string, lc map[
 	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "datasource":
-			// Null means "inherit from the panel" — addDatasource resolves
-			// it to the org default for the panel-level aggregation, but we
-			// don't want to record that as the per-query datasource. Leave
-			// q.DatasourceUID empty so consumers fall back to panel.Datasource.
-			isNil := iter.WhatIsNext() == jsoniter.NilValue
-			ref := s.addDatasource(iter, jsonPath+".datasource", lc)
-			if !isNil && ref != nil && ref.UID != "" {
+			// Null means "inherit from the panel" — skip addDatasource
+			// entirely so we don't pollute the panel-level aggregation
+			// (s.uids → panel.Datasource) with the org default. Consumers
+			// fall back to panel.Datasource, which then accurately reflects
+			// only datasources the panel actually references.
+			if iter.WhatIsNext() == jsoniter.NilValue {
+				iter.Skip()
+			} else if ref := s.addDatasource(iter, jsonPath+".datasource", lc); ref != nil && ref.UID != "" {
 				q.DatasourceUID = ref.UID
 			}
 

--- a/pkg/services/store/kind/dashboard/targets.go
+++ b/pkg/services/store/kind/dashboard/targets.go
@@ -89,15 +89,8 @@ func (s *targetInfo) addTarget(iter *jsoniter.Iterator, jsonPath string, lc map[
 	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "datasource":
-			// Null targets resolve to the org default at runtime in this
-			// codebase's interpretation, and the panel-level aggregation
-			// records that dependency via addDatasource. Don't propagate
-			// the resolved default into q.DatasourceUID though — leaving
-			// it empty signals "no explicit per-query datasource", and
-			// consumers should not assume a single fallback.
-			isNil := iter.WhatIsNext() == jsoniter.NilValue
 			ref := s.addDatasource(iter, jsonPath+".datasource", lc)
-			if !isNil && ref != nil && ref.UID != "" {
+			if ref != nil && ref.UID != "" {
 				q.DatasourceUID = ref.UID
 			}
 

--- a/pkg/services/store/kind/dashboard/targets.go
+++ b/pkg/services/store/kind/dashboard/targets.go
@@ -89,7 +89,13 @@ func (s *targetInfo) addTarget(iter *jsoniter.Iterator, jsonPath string, lc map[
 	for f := iter.ReadObject(); f != ""; f = iter.ReadObject() {
 		switch f {
 		case "datasource":
-			if ref := s.addDatasource(iter, jsonPath+".datasource", lc); ref != nil && ref.UID != "" {
+			// Null means "inherit from the panel" — addDatasource resolves
+			// it to the org default for the panel-level aggregation, but we
+			// don't want to record that as the per-query datasource. Leave
+			// q.DatasourceUID empty so consumers fall back to panel.Datasource.
+			isNil := iter.WhatIsNext() == jsoniter.NilValue
+			ref := s.addDatasource(iter, jsonPath+".datasource", lc)
+			if !isNil && ref != nil && ref.UID != "" {
 				q.DatasourceUID = ref.UID
 			}
 

--- a/pkg/services/store/kind/dashboard/testdata/panel-queries-info.json
+++ b/pkg/services/store/kind/dashboard/testdata/panel-queries-info.json
@@ -15,6 +15,10 @@
     {
       "uid": "pg-1",
       "type": "postgres"
+    },
+    {
+      "uid": "default.uid",
+      "type": "default.type"
     }
   ],
   "panels": [
@@ -86,6 +90,26 @@
         {
           "refId": "B",
           "expression": "rate(errors_total[1m])"
+        }
+      ]
+    },
+    {
+      "id": 5,
+      "title": "Target with null datasource inherits panel",
+      "datasource": [
+        {
+          "uid": "prom-1",
+          "type": "prometheus"
+        },
+        {
+          "uid": "default.uid",
+          "type": "default.type"
+        }
+      ],
+      "queries": [
+        {
+          "refId": "A",
+          "expression": "up{job=\"api\"}"
         }
       ]
     }

--- a/pkg/services/store/kind/dashboard/testdata/panel-queries-info.json
+++ b/pkg/services/store/kind/dashboard/testdata/panel-queries-info.json
@@ -15,10 +15,6 @@
     {
       "uid": "pg-1",
       "type": "postgres"
-    },
-    {
-      "uid": "default.uid",
-      "type": "default.type"
     }
   ],
   "panels": [
@@ -100,10 +96,6 @@
         {
           "uid": "prom-1",
           "type": "prometheus"
-        },
-        {
-          "uid": "default.uid",
-          "type": "default.type"
         }
       ],
       "queries": [

--- a/pkg/services/store/kind/dashboard/testdata/panel-queries-info.json
+++ b/pkg/services/store/kind/dashboard/testdata/panel-queries-info.json
@@ -1,0 +1,98 @@
+{
+  "title": "Panel queries fixture",
+  "tags": [
+    "queries"
+  ],
+  "datasource": [
+    {
+      "uid": "tempo-1",
+      "type": "tempo"
+    },
+    {
+      "uid": "prom-1",
+      "type": "prometheus"
+    },
+    {
+      "uid": "pg-1",
+      "type": "postgres"
+    }
+  ],
+  "panels": [
+    {
+      "id": 1,
+      "title": "PromQL panel",
+      "datasource": [
+        {
+          "uid": "prom-1",
+          "type": "prometheus"
+        }
+      ],
+      "queries": [
+        {
+          "refId": "A",
+          "datasourceUid": "prom-1",
+          "expression": "rate(http_requests_total[5m])"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "SQL panel",
+      "datasource": [
+        {
+          "uid": "pg-1",
+          "type": "postgres"
+        }
+      ],
+      "queries": [
+        {
+          "refId": "A",
+          "datasourceUid": "pg-1",
+          "expression": "SELECT 1"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Tempo panel",
+      "datasource": [
+        {
+          "uid": "tempo-1",
+          "type": "tempo"
+        }
+      ],
+      "queries": [
+        {
+          "refId": "A",
+          "datasourceUid": "tempo-1",
+          "expression": "{ duration \u003e 1s }"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Multi-target panel",
+      "datasource": [
+        {
+          "uid": "prom-1",
+          "type": "prometheus"
+        }
+      ],
+      "queries": [
+        {
+          "refId": "A",
+          "expression": "up"
+        },
+        {
+          "refId": "B",
+          "expression": "rate(errors_total[1m])"
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 0,
+  "linkCount": 0,
+  "timeFrom": "",
+  "timeTo": "",
+  "timezone": ""
+}

--- a/pkg/services/store/kind/dashboard/testdata/panel-queries-info.json
+++ b/pkg/services/store/kind/dashboard/testdata/panel-queries-info.json
@@ -15,6 +15,10 @@
     {
       "uid": "pg-1",
       "type": "postgres"
+    },
+    {
+      "uid": "default.uid",
+      "type": "default.type"
     }
   ],
   "panels": [
@@ -91,11 +95,15 @@
     },
     {
       "id": 5,
-      "title": "Target with null datasource inherits panel",
+      "title": "Target with null datasource",
       "datasource": [
         {
           "uid": "prom-1",
           "type": "prometheus"
+        },
+        {
+          "uid": "default.uid",
+          "type": "default.type"
         }
       ],
       "queries": [

--- a/pkg/services/store/kind/dashboard/testdata/panel-queries.json
+++ b/pkg/services/store/kind/dashboard/testdata/panel-queries.json
@@ -52,7 +52,7 @@
     },
     {
       "id": 5,
-      "title": "Target with null datasource inherits panel",
+      "title": "Target with null datasource",
       "datasource": { "uid": "prom-1", "type": "prometheus" },
       "targets": [
         { "refId": "A", "datasource": null, "expr": "up{job=\"api\"}" }

--- a/pkg/services/store/kind/dashboard/testdata/panel-queries.json
+++ b/pkg/services/store/kind/dashboard/testdata/panel-queries.json
@@ -49,6 +49,14 @@
         { "refId": "A", "expr": "up" },
         { "refId": "B", "expr": "rate(errors_total[1m])" }
       ]
+    },
+    {
+      "id": 5,
+      "title": "Target with null datasource inherits panel",
+      "datasource": { "uid": "prom-1", "type": "prometheus" },
+      "targets": [
+        { "refId": "A", "datasource": null, "expr": "up{job=\"api\"}" }
+      ]
     }
   ]
 }

--- a/pkg/services/store/kind/dashboard/testdata/panel-queries.json
+++ b/pkg/services/store/kind/dashboard/testdata/panel-queries.json
@@ -1,0 +1,54 @@
+{
+  "uid": "panel-queries-uid",
+  "title": "Panel queries fixture",
+  "tags": ["queries"],
+  "schemaVersion": 0,
+  "linkCount": 0,
+  "panels": [
+    {
+      "id": 1,
+      "title": "PromQL panel",
+      "datasource": { "uid": "prom-1", "type": "prometheus" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "uid": "prom-1", "type": "prometheus" },
+          "expr": "rate(http_requests_total[5m])"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "SQL panel",
+      "datasource": { "uid": "pg-1", "type": "postgres" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "uid": "pg-1", "type": "postgres" },
+          "rawSql": "SELECT 1"
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Tempo panel",
+      "datasource": { "uid": "tempo-1", "type": "tempo" },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": { "uid": "tempo-1", "type": "tempo" },
+          "query": "{ duration > 1s }"
+        }
+      ]
+    },
+    {
+      "id": 4,
+      "title": "Multi-target panel",
+      "datasource": { "uid": "prom-1", "type": "prometheus" },
+      "targets": [
+        { "refId": "A", "expr": "up" },
+        { "refId": "B", "expr": "rate(errors_total[1m])" }
+      ]
+    }
+  ]
+}

--- a/pkg/services/store/kind/dashboard/testdata/v2-elements-info.json
+++ b/pkg/services/store/kind/dashboard/testdata/v2-elements-info.json
@@ -1,6 +1,9 @@
 {
   "title": "V2 dashboard with elements",
-  "tags": ["v2", "elements"],
+  "tags": [
+    "v2",
+    "elements"
+  ],
   "datasource": [
     {
       "uid": "default.uid",
@@ -9,7 +12,7 @@
   ],
   "panels": [
     {
-      "id": 0,
+      "id": 1,
       "title": "Timeseries panel",
       "description": "A v2 panel",
       "type": "TimeseriesPanel",
@@ -19,7 +22,10 @@
           "type": "default.type"
         }
       ],
-      "transformer": ["merge", "groupBy"]
+      "transformer": [
+        "merge",
+        "groupBy"
+      ]
     },
     {
       "id": 0,

--- a/pkg/services/store/kind/dashboard/testdata/v2-panel-queries-info.json
+++ b/pkg/services/store/kind/dashboard/testdata/v2-panel-queries-info.json
@@ -6,10 +6,6 @@
   ],
   "datasource": [
     {
-      "uid": "prom-flat",
-      "type": "prometheus"
-    },
-    {
       "uid": "my-prom"
     },
     {
@@ -48,24 +44,6 @@
           "refId": "A",
           "datasourceUid": "my-loki",
           "expression": "{app=\"api\"} |= \"error\""
-        }
-      ]
-    },
-    {
-      "id": 3,
-      "title": "Flat-shape query (legacy)",
-      "type": "TimeseriesPanel",
-      "datasource": [
-        {
-          "uid": "prom-flat",
-          "type": "prometheus"
-        }
-      ],
-      "queries": [
-        {
-          "refId": "B",
-          "datasourceUid": "prom-flat",
-          "expression": "up"
         }
       ]
     }

--- a/pkg/services/store/kind/dashboard/testdata/v2-panel-queries-info.json
+++ b/pkg/services/store/kind/dashboard/testdata/v2-panel-queries-info.json
@@ -10,8 +10,10 @@
       "type": "prometheus"
     },
     {
-      "uid": "default.uid",
-      "type": "default.type"
+      "uid": "my-prom"
+    },
+    {
+      "uid": "my-loki"
     }
   ],
   "panels": [
@@ -21,8 +23,7 @@
       "type": "TimeseriesPanel",
       "datasource": [
         {
-          "uid": "default.uid",
-          "type": "default.type"
+          "uid": "my-prom"
         }
       ],
       "queries": [
@@ -39,8 +40,7 @@
       "type": "LogsPanel",
       "datasource": [
         {
-          "uid": "default.uid",
-          "type": "default.type"
+          "uid": "my-loki"
         }
       ],
       "queries": [

--- a/pkg/services/store/kind/dashboard/testdata/v2-panel-queries-info.json
+++ b/pkg/services/store/kind/dashboard/testdata/v2-panel-queries-info.json
@@ -1,0 +1,54 @@
+{
+  "title": "V2 dashboard with query expressions",
+  "tags": [
+    "v2",
+    "queries"
+  ],
+  "datasource": [
+    {
+      "uid": "default.uid",
+      "type": "default.type"
+    }
+  ],
+  "panels": [
+    {
+      "id": 1,
+      "title": "Request rate",
+      "type": "TimeseriesPanel",
+      "datasource": [
+        {
+          "uid": "default.uid",
+          "type": "default.type"
+        }
+      ],
+      "queries": [
+        {
+          "refId": "A",
+          "expression": "rate(http_requests_total[5m])"
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "title": "Recent errors",
+      "type": "LogsPanel",
+      "datasource": [
+        {
+          "uid": "default.uid",
+          "type": "default.type"
+        }
+      ],
+      "queries": [
+        {
+          "refId": "A",
+          "expression": "{app=\"api\"} |= \"error\""
+        }
+      ]
+    }
+  ],
+  "schemaVersion": 0,
+  "linkCount": 0,
+  "timeFrom": "",
+  "timeTo": "",
+  "timezone": ""
+}

--- a/pkg/services/store/kind/dashboard/testdata/v2-panel-queries-info.json
+++ b/pkg/services/store/kind/dashboard/testdata/v2-panel-queries-info.json
@@ -24,6 +24,7 @@
       "queries": [
         {
           "refId": "A",
+          "datasourceUid": "my-prom",
           "expression": "rate(http_requests_total[5m])"
         }
       ]
@@ -41,6 +42,7 @@
       "queries": [
         {
           "refId": "A",
+          "datasourceUid": "my-loki",
           "expression": "{app=\"api\"} |= \"error\""
         }
       ]

--- a/pkg/services/store/kind/dashboard/testdata/v2-panel-queries-info.json
+++ b/pkg/services/store/kind/dashboard/testdata/v2-panel-queries-info.json
@@ -6,6 +6,10 @@
   ],
   "datasource": [
     {
+      "uid": "prom-flat",
+      "type": "prometheus"
+    },
+    {
       "uid": "default.uid",
       "type": "default.type"
     }
@@ -44,6 +48,24 @@
           "refId": "A",
           "datasourceUid": "my-loki",
           "expression": "{app=\"api\"} |= \"error\""
+        }
+      ]
+    },
+    {
+      "id": 3,
+      "title": "Flat-shape query (legacy)",
+      "type": "TimeseriesPanel",
+      "datasource": [
+        {
+          "uid": "prom-flat",
+          "type": "prometheus"
+        }
+      ],
+      "queries": [
+        {
+          "refId": "B",
+          "datasourceUid": "prom-flat",
+          "expression": "up"
         }
       ]
     }

--- a/pkg/services/store/kind/dashboard/testdata/v2-panel-queries.json
+++ b/pkg/services/store/kind/dashboard/testdata/v2-panel-queries.json
@@ -59,26 +59,6 @@
             }
           }
         }
-      },
-      "panel-c": {
-        "kind": "Panel",
-        "spec": {
-          "id": 3,
-          "title": "Flat-shape query (legacy)",
-          "vizConfig": { "kind": "TimeseriesPanel", "spec": {} },
-          "data": {
-            "kind": "QueryGroup",
-            "spec": {
-              "queries": [
-                {
-                  "refId": "B",
-                  "datasource": { "uid": "prom-flat", "type": "prometheus" },
-                  "expr": "up"
-                }
-              ]
-            }
-          }
-        }
       }
     },
     "layout": { "kind": "GridLayout", "spec": {} }

--- a/pkg/services/store/kind/dashboard/testdata/v2-panel-queries.json
+++ b/pkg/services/store/kind/dashboard/testdata/v2-panel-queries.json
@@ -1,0 +1,66 @@
+{
+  "apiVersion": "dashboard.grafana.app/v2beta1",
+  "kind": "Dashboard",
+  "metadata": { "name": "v2-panel-queries-uid" },
+  "spec": {
+    "title": "V2 dashboard with query expressions",
+    "tags": ["v2", "queries"],
+    "elements": {
+      "panel-a": {
+        "kind": "Panel",
+        "spec": {
+          "id": 1,
+          "title": "Request rate",
+          "vizConfig": { "kind": "TimeseriesPanel", "spec": {} },
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "refId": "A",
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "prometheus.grafana.app",
+                      "datasource": { "name": "my-prom" },
+                      "spec": { "expr": "rate(http_requests_total[5m])" }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "panel-b": {
+        "kind": "Panel",
+        "spec": {
+          "id": 2,
+          "title": "Recent errors",
+          "vizConfig": { "kind": "LogsPanel", "spec": {} },
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "refId": "A",
+                    "query": {
+                      "kind": "DataQuery",
+                      "group": "loki.grafana.app",
+                      "datasource": { "name": "my-loki" },
+                      "spec": { "expr": "{app=\"api\"} |= \"error\"" }
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      }
+    },
+    "layout": { "kind": "GridLayout", "spec": {} }
+  }
+}

--- a/pkg/services/store/kind/dashboard/testdata/v2-panel-queries.json
+++ b/pkg/services/store/kind/dashboard/testdata/v2-panel-queries.json
@@ -59,6 +59,26 @@
             }
           }
         }
+      },
+      "panel-c": {
+        "kind": "Panel",
+        "spec": {
+          "id": 3,
+          "title": "Flat-shape query (legacy)",
+          "vizConfig": { "kind": "TimeseriesPanel", "spec": {} },
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "refId": "B",
+                  "datasource": { "uid": "prom-flat", "type": "prometheus" },
+                  "expr": "up"
+                }
+              ]
+            }
+          }
+        }
       }
     },
     "layout": { "kind": "GridLayout", "spec": {} }

--- a/pkg/services/store/kind/dashboard/types.go
+++ b/pkg/services/store/kind/dashboard/types.go
@@ -3,15 +3,15 @@ package dashboard
 import "iter"
 
 type PanelSummaryInfo struct {
-	ID            int64           `json:"id"`
-	Title         string          `json:"title"`
-	Description   string          `json:"description,omitempty"`
-	Type          string          `json:"type,omitempty"` // PluginID
-	PluginVersion string          `json:"pluginVersion,omitempty"`
-	LibraryPanel  string          `json:"libraryPanel,omitempty"` // UID of referenced library panel
-	Datasource    []DataSourceRef `json:"datasource,omitempty"`   // UIDs
-	Transformer   []string        `json:"transformer,omitempty"`  // ids of the transformation steps
-	Queries       []PanelQueryInfo `json:"queries,omitempty"`     // per-target query expressions
+	ID            int64            `json:"id"`
+	Title         string           `json:"title"`
+	Description   string           `json:"description,omitempty"`
+	Type          string           `json:"type,omitempty"` // PluginID
+	PluginVersion string           `json:"pluginVersion,omitempty"`
+	LibraryPanel  string           `json:"libraryPanel,omitempty"` // UID of referenced library panel
+	Datasource    []DataSourceRef  `json:"datasource,omitempty"`   // UIDs
+	Transformer   []string         `json:"transformer,omitempty"`  // ids of the transformation steps
+	Queries       []PanelQueryInfo `json:"queries,omitempty"`      // per-target query expressions
 	// Rows define panels as sub objects
 	Collapsed []PanelSummaryInfo `json:"collapsed,omitempty"`
 }

--- a/pkg/services/store/kind/dashboard/types.go
+++ b/pkg/services/store/kind/dashboard/types.go
@@ -17,8 +17,13 @@ type PanelSummaryInfo struct {
 }
 
 // PanelQueryInfo is the captured form of one query target on a panel.
-// Language inference is left to consumers since it depends on the panel's
-// datasource type (PanelSummaryInfo.Datasource).
+//
+// DatasourceUID holds the explicit datasource identifier the target
+// referenced (uid or, for v2 schema-correct refs, name). Empty means the
+// target had a null/missing datasource at parse time — consumers should
+// not assume a fallback; runtime semantics for inheritance are not
+// preserved here. Language inference is also left to consumers since it
+// depends on the panel's datasource type (PanelSummaryInfo.Datasource).
 type PanelQueryInfo struct {
 	RefID         string `json:"refId,omitempty"`
 	DatasourceUID string `json:"datasourceUid,omitempty"`

--- a/pkg/services/store/kind/dashboard/types.go
+++ b/pkg/services/store/kind/dashboard/types.go
@@ -11,8 +11,18 @@ type PanelSummaryInfo struct {
 	LibraryPanel  string          `json:"libraryPanel,omitempty"` // UID of referenced library panel
 	Datasource    []DataSourceRef `json:"datasource,omitempty"`   // UIDs
 	Transformer   []string        `json:"transformer,omitempty"`  // ids of the transformation steps
+	Queries       []PanelQueryInfo `json:"queries,omitempty"`     // per-target query expressions
 	// Rows define panels as sub objects
 	Collapsed []PanelSummaryInfo `json:"collapsed,omitempty"`
+}
+
+// PanelQueryInfo is the captured form of one query target on a panel.
+// Language inference is left to consumers since it depends on the panel's
+// datasource type (PanelSummaryInfo.Datasource).
+type PanelQueryInfo struct {
+	RefID         string `json:"refId,omitempty"`
+	DatasourceUID string `json:"datasourceUid,omitempty"`
+	Expression    string `json:"expression,omitempty"`
 }
 
 type DashboardSummaryInfo struct {


### PR DESCRIPTION
**Summary**
Adds `Queries []PanelQueryInfo` to `PanelSummaryInfo` so consumers can read per-panel query content (`expr`, `rawSql`, `rawQuery`, TraceQL `query`) plus `refId` and `datasourceUid`.

**Why**
For the unified vector search MVP we need to know the queries on the panels. Makes sense to add it here. Purely additive so I don't see an issue.

**Notes for reviewer**
Its tough to tell the actual path for query expressions looking at the panel query [cue def](https://github.com/grafana/grafana/blob/718716e76c851c03dc2f04a20101bed36d470d9f/apps/dashboard/kinds/v2beta1/dashboard_spec.cue#L516). But I can see from others querying it, that on the query it is `spec.query.spec.<expr>.`, with the full path being `data.spec.queries[*].spec.query.spec.<expr>`.