### PR TITLE
Remote Alertmanager: Stop replicating silences internally and skip clustering in remote primary

### DIFF
--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -248,6 +248,7 @@ func (ng *AlertNG) init() error {
 		if remotePrimary {
 			ng.Log.Debug("Starting Grafana with remote primary mode enabled")
 			m.Info.WithLabelValues(metrics.ModeRemotePrimary).Set(1)
+			ng.Cfg.UnifiedAlerting.SkipClustering = true
 			override = remote.NewRemotePrimaryFactory(cfg, ng.KVStore, crypto, m, ng.tracer, ng.FeatureToggles)
 		} else {
 			ng.Log.Debug("Starting Grafana with remote secondary mode enabled")

--- a/pkg/services/ngalert/ngalert.go
+++ b/pkg/services/ngalert/ngalert.go
@@ -206,6 +206,7 @@ func (ng *AlertNG) init() error {
 	// Configure the remote Alertmanager.
 	// If toggles for both modes are enabled, remote primary takes precedence.
 	var opts []notifier.Option
+	var skipClustering bool
 	moaLogger := log.New("ngalert.multiorg.alertmanager")
 	crypto := notifier.NewCrypto(ng.SecretsService, ng.store, moaLogger)
 	//nolint:staticcheck // not yet migrated to OpenFeature
@@ -248,8 +249,8 @@ func (ng *AlertNG) init() error {
 		if remotePrimary {
 			ng.Log.Debug("Starting Grafana with remote primary mode enabled")
 			m.Info.WithLabelValues(metrics.ModeRemotePrimary).Set(1)
-			ng.Cfg.UnifiedAlerting.SkipClustering = true
 			override = remote.NewRemotePrimaryFactory(cfg, ng.KVStore, crypto, m, ng.tracer, ng.FeatureToggles)
+			skipClustering = true
 		} else {
 			ng.Log.Debug("Starting Grafana with remote secondary mode enabled")
 			m.Info.WithLabelValues(metrics.ModeRemoteSecondary).Set(1)
@@ -297,6 +298,7 @@ func (ng *AlertNG) init() error {
 		ng.SecretsService,
 		ng.FeatureToggles,
 		notificationHistorian,
+		skipClustering,
 		opts...,
 	)
 	if err != nil {

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -62,8 +62,8 @@ type Alertmanager interface {
 	GetSilence(context.Context, string) (apimodels.GettableSilence, error)
 	ListSilences(context.Context, []string) (apimodels.GettableSilences, error)
 
-	// SilenceState returns the current state of silences in the Alertmanager.
-	// This is used to persist the state to the kvstore.
+	// SilenceState returns the current state of silences in the Alertmanager. This is used to persist the state
+	// to the kvstore.
 	SilenceState(context.Context) (alertingNotify.SilenceState, error)
 
 	// Alerts

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -62,8 +62,8 @@ type Alertmanager interface {
 	GetSilence(context.Context, string) (apimodels.GettableSilence, error)
 	ListSilences(context.Context, []string) (apimodels.GettableSilences, error)
 
-	// SilenceState returns the current state of silences in the Alertmanager. This is used to persist the state
-	// to the kvstore.
+	// SilenceState returns the current state of silences in the Alertmanager.
+	// This is used to persist the state to the kvstore.
 	SilenceState(context.Context) (alertingNotify.SilenceState, error)
 
 	// Alerts
@@ -649,10 +649,9 @@ func (moa *MultiOrgAlertmanager) DeleteSilence(ctx context.Context, orgID int64,
 // the state has persisted. This can happen, for example, in a rolling deployment scenario.
 func (moa *MultiOrgAlertmanager) updateSilenceState(ctx context.Context, orgAM Alertmanager, orgID int64) error {
 	// Collect the internal silence state from the AM.
-	// TODO: Currently, we rely on the AM itself for the persisted silence state representation. Preferably, we would
-	//  define the state ourselves and persist it in a format that is easy to guarantee consistency for writes to
-	//  individual silences. In addition to the consistency benefits, this would also allow us to avoid the need for
-	//  a network request to the AM to get the state in the case of remote alertmanagers.
+	// TODO: Currently, we rely on the AM itself for the persisted silence state representation.
+	// Preferably, we would define the state ourselves and persist it in a format that is easy to
+	// guarantee consistency for writes to individual silences.
 	silences, err := orgAM.SilenceState(ctx)
 	if err != nil {
 		return err

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -149,6 +149,7 @@ func NewMultiOrgAlertmanager(
 	s secrets.Service,
 	featureManager featuremgmt.FeatureToggles,
 	notificationHistorian nfstatus.NotificationHistorian,
+	skipClustering bool,
 	opts ...Option,
 ) (*MultiOrgAlertmanager, error) {
 	moa := &MultiOrgAlertmanager{
@@ -170,8 +171,12 @@ func NewMultiOrgAlertmanager(
 		peer:                        &NilPeer{},
 	}
 
-	if err := moa.setupClustering(cfg); err != nil {
-		return nil, err
+	if skipClustering {
+		moa.logger.Info("Not setting up clustering for the multi-org Alertmanager")
+	} else {
+		if err := moa.setupClustering(cfg); err != nil {
+			return nil, err
+		}
 	}
 
 	moa.initAlertBroadcast()
@@ -201,11 +206,6 @@ func NewMultiOrgAlertmanager(
 }
 
 func (moa *MultiOrgAlertmanager) setupClustering(cfg *setting.Cfg) error {
-	if cfg.UnifiedAlerting.SkipClustering {
-		moa.logger.Info("Not setting up clustering for the multi-org Alertmanager")
-		return nil
-	}
-
 	clusterLogger := moa.logger.New("component", "clustering")
 	// We set the settlement timeout to be a multiple of the gossip interval,
 	// ensuring that a sufficient number of broadcasts have occurred, thereby

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager.go
@@ -201,6 +201,11 @@ func NewMultiOrgAlertmanager(
 }
 
 func (moa *MultiOrgAlertmanager) setupClustering(cfg *setting.Cfg) error {
+	if cfg.UnifiedAlerting.SkipClustering {
+		moa.logger.Info("Not setting up clustering for the multi-org Alertmanager")
+		return nil
+	}
+
 	clusterLogger := moa.logger.New("component", "clustering")
 	// We set the settlement timeout to be a multiple of the gossip interval,
 	// ensuring that a sufficient number of broadcasts have occurred, thereby

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager_remote_test.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager_remote_test.go
@@ -92,6 +92,7 @@ func TestMultiorgAlertmanager_RemoteSecondaryMode(t *testing.T) {
 		secretsService,
 		featuremgmt.WithFeatures(),
 		nil,
+		false,
 		notifier.WithAlertmanagerOverride(override),
 	)
 	require.NoError(t, err)

--- a/pkg/services/ngalert/notifier/multiorg_alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/multiorg_alertmanager_test.go
@@ -395,6 +395,7 @@ func setupMam(t *testing.T, cfg *setting.Cfg) *MultiOrgAlertmanager {
 		secretsService,
 		featuremgmt.WithFeatures(),
 		nil,
+		false,
 	)
 	require.NoError(t, err)
 	return mam

--- a/pkg/services/ngalert/notifier/testing.go
+++ b/pkg/services/ngalert/notifier/testing.go
@@ -645,6 +645,7 @@ func NewTestMultiOrgAlertmanager(t *testing.T, opts ...TestMultiOrgAlertmanagerO
 		secretsService,
 		options.featureToggles,
 		nil,
+		false,
 		moaOpts...,
 	)
 	require.NoError(t, err)

--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -681,30 +681,21 @@ func (am *Alertmanager) Ready() bool {
 	return am.ready
 }
 
-// SilenceState returns the Alertmanager's silence state as a SilenceState. Currently, does not retrieve the state
-// remotely and instead uses the value from the state store.
+// SilenceState returns an empty SilenceState and no error.
+// The source of truth for state should be the remote Alertmanager.
 func (am *Alertmanager) SilenceState(ctx context.Context) (alertingNotify.SilenceState, error) {
-	silences, err := am.state.GetSilences(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("error getting silences: %w", err)
-	}
-
-	return alertingNotify.DecodeState(strings.NewReader(silences))
+	return alertingNotify.SilenceState{}, nil
 }
 
 // getFullState returns a base64-encoded protobuf message representing the Alertmanager's internal state.
 func (am *Alertmanager) getFullState(ctx context.Context) (string, error) {
 	var parts []alertingClusterPB.Part
 
-	state, err := am.SilenceState(ctx)
+	silences, err := am.state.GetSilences(ctx)
 	if err != nil {
 		return "", fmt.Errorf("error getting silences: %w", err)
 	}
-	b, err := state.MarshalBinary()
-	if err != nil {
-		return "", fmt.Errorf("error marshalling silences: %w", err)
-	}
-	parts = append(parts, alertingClusterPB.Part{Key: notifier.SilencesFilename, Data: b})
+	parts = append(parts, alertingClusterPB.Part{Key: notifier.SilencesFilename, Data: []byte(silences)})
 
 	notificationLog, err := am.state.GetNotificationLog(ctx)
 	if err != nil {
@@ -721,7 +712,7 @@ func (am *Alertmanager) getFullState(ctx context.Context) (string, error) {
 	fs := alertingClusterPB.FullState{
 		Parts: parts,
 	}
-	b, err = fs.Marshal()
+	b, err := fs.Marshal()
 	if err != nil {
 		return "", fmt.Errorf("error marshaling full state: %w", err)
 	}

--- a/pkg/services/ngalert/remote/forked_alertmanager_test.go
+++ b/pkg/services/ngalert/remote/forked_alertmanager_test.go
@@ -3,7 +3,6 @@ package remote
 import (
 	"context"
 	"errors"
-	"fmt"
 	"testing"
 	"time"
 
@@ -534,16 +533,14 @@ func TestForkedAlertmanager_ModeRemotePrimary(t *testing.T) {
 	})
 
 	t.Run("CreateSilence", func(tt *testing.T) {
-		// We should create the silence in both Alertmanagers using the same uid.
+		// We should create the silence in the remote Alertmanager.
 		testSilence := &apimodels.PostableSilence{}
 		expID := "test-id"
 
-		internal, remote, forked := genTestAlertmanagers(tt, modeRemotePrimary)
+		_, remote, forked := genTestAlertmanagers(tt, modeRemotePrimary)
 		remote.EXPECT().CreateSilence(mock.Anything, testSilence).Return(expID, nil).Once()
-		internal.EXPECT().CreateSilence(mock.Anything, testSilence).Return(testSilence.ID, nil).Once()
 		id, err := forked.CreateSilence(ctx, testSilence)
 		require.NoError(tt, err)
-		require.Equal(tt, expID, testSilence.ID)
 		require.Equal(tt, expID, id)
 
 		// If there's an error in the remote Alertmanager, the error should be returned.
@@ -551,60 +548,19 @@ func TestForkedAlertmanager_ModeRemotePrimary(t *testing.T) {
 		remote.EXPECT().CreateSilence(mock.Anything, mock.Anything).Return("", expErr).Once()
 		_, err = forked.CreateSilence(ctx, testSilence)
 		require.ErrorIs(tt, expErr, err)
-
-		// An error in the internal Alertmanager should not be returned.
-		internal, remote, forked = genTestAlertmanagers(tt, modeRemotePrimary)
-		remote.EXPECT().CreateSilence(mock.Anything, mock.Anything).Return(expID, nil).Once()
-		internal.EXPECT().CreateSilence(mock.Anything, mock.Anything).Return("", expErr).Once()
-		id, err = forked.CreateSilence(ctx, testSilence)
-		require.NoError(tt, err)
-		require.Equal(tt, expID, id)
-
-		// If the silence ID changes, the internal Alertmanager should attempt to expire the old silence.
-		newID := "new"
-		internal, remote, forked = genTestAlertmanagers(tt, modeRemotePrimary)
-		remote.EXPECT().CreateSilence(mock.Anything, mock.Anything).Return(newID, nil).Once()
-		internal.EXPECT().DeleteSilence(mock.Anything, mock.Anything).Return(nil).Once()
-		// If internal.CreateSilence() returns a new id, it should be ignored.
-		internal.EXPECT().CreateSilence(mock.Anything, mock.Anything).Return("random-id", nil).Once()
-		id, err = forked.CreateSilence(ctx, testSilence)
-		require.NoError(tt, err)
-		require.Equal(tt, newID, testSilence.ID)
-		require.Equal(tt, newID, id)
-
-		// Restore original ID.
-		testSilence.ID = expID
-
-		// An error attempting to delete a silence in the internal Alertmanager not be returned.
-		internal, remote, forked = genTestAlertmanagers(tt, modeRemotePrimary)
-		remote.EXPECT().CreateSilence(mock.Anything, mock.Anything).Return(newID, nil).Once()
-		internal.EXPECT().DeleteSilence(mock.Anything, mock.Anything).Return(fmt.Errorf("test error")).Once()
-		// If internal.CreateSilence() returns a new id, it should be ignored.
-		internal.EXPECT().CreateSilence(mock.Anything, mock.Anything).Return("random-id", nil).Once()
-		id, err = forked.CreateSilence(ctx, testSilence)
-		require.NoError(tt, err)
-		require.Equal(tt, newID, testSilence.ID)
-		require.Equal(tt, newID, id)
 	})
 
 	t.Run("DeleteSilence", func(tt *testing.T) {
-		// We should delete the silence in both Alertmanagers.
+		// We should delete the silence in the remote Alertmanager.
 		testID := "test-id"
-		internal, remote, forked := genTestAlertmanagers(tt, modeRemotePrimary)
+		_, remote, forked := genTestAlertmanagers(tt, modeRemotePrimary)
 		remote.EXPECT().DeleteSilence(mock.Anything, testID).Return(nil).Once()
-		internal.EXPECT().DeleteSilence(mock.Anything, testID).Return(nil).Once()
 		require.NoError(tt, forked.DeleteSilence(ctx, testID))
 
 		// If there's an error in the remote Alertmanager, the error should be returned.
 		_, remote, forked = genTestAlertmanagers(tt, modeRemotePrimary)
-		remote.EXPECT().DeleteSilence(mock.Anything, testID).Return(expErr).Maybe()
+		remote.EXPECT().DeleteSilence(mock.Anything, testID).Return(expErr).Once()
 		require.ErrorIs(tt, expErr, forked.DeleteSilence(ctx, testID))
-
-		// An error in the internal Alertmanager should not be returned.
-		internal, remote, forked = genTestAlertmanagers(tt, modeRemotePrimary)
-		remote.EXPECT().DeleteSilence(mock.Anything, testID).Return(nil).Maybe()
-		internal.EXPECT().DeleteSilence(mock.Anything, testID).Return(nil).Maybe()
-		require.NoError(tt, forked.DeleteSilence(ctx, testID))
 	})
 
 	t.Run("GetSilence", func(tt *testing.T) {

--- a/pkg/services/ngalert/remote/remote_primary_forked_alertmanager.go
+++ b/pkg/services/ngalert/remote/remote_primary_forked_alertmanager.go
@@ -86,40 +86,11 @@ func (fam *RemotePrimaryForkedAlertmanager) GetStatus(ctx context.Context) (apim
 }
 
 func (fam *RemotePrimaryForkedAlertmanager) CreateSilence(ctx context.Context, silence *apimodels.PostableSilence) (string, error) {
-	originalID := silence.ID
-	id, err := fam.remote.CreateSilence(ctx, silence)
-	if err != nil {
-		return "", err
-	}
-
-	if originalID != "" && originalID != id {
-		// ID has changed, expire the old silence before creating a new one.
-		if err := fam.internal.DeleteSilence(ctx, originalID); err != nil {
-			if errors.Is(err, alertingNotify.ErrSilenceNotFound) {
-				// This can happen if the silence was created in the remote AM without using the Grafana UI
-				// in remote primary mode, or if the silence failed to be replicated in the internal AM.
-				fam.log.Warn("Failed to delete silence in the internal Alertmanager", "err", err, "id", originalID)
-			} else {
-				fam.log.Error("Failed to delete silence in the internal Alertmanager", "err", err, "id", originalID)
-			}
-		}
-	}
-
-	silence.ID = id
-	if _, err := fam.internal.CreateSilence(ctx, silence); err != nil {
-		fam.log.Error("Error creating silence in the internal Alertmanager", "err", err, "silence", silence)
-	}
-	return id, nil
+	return fam.remote.CreateSilence(ctx, silence)
 }
 
 func (fam *RemotePrimaryForkedAlertmanager) DeleteSilence(ctx context.Context, id string) error {
-	if err := fam.remote.DeleteSilence(ctx, id); err != nil {
-		return err
-	}
-	if err := fam.internal.DeleteSilence(ctx, id); err != nil {
-		fam.log.Error("Error deleting silence in the internal Alertmanager", "err", err, "id", id)
-	}
-	return nil
+	return fam.remote.DeleteSilence(ctx, id)
 }
 
 func (fam *RemotePrimaryForkedAlertmanager) GetSilence(ctx context.Context, id string) (apimodels.GettableSilence, error) {

--- a/pkg/services/ngalert/remote/remote_primary_forked_alertmanager.go
+++ b/pkg/services/ngalert/remote/remote_primary_forked_alertmanager.go
@@ -2,7 +2,6 @@ package remote
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	alertingModels "github.com/grafana/alerting/models"

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -124,7 +124,6 @@ type UnifiedAlertingSettings struct {
 	// DefaultRuleEvaluationInterval default interval between evaluations of a rule.
 	DefaultRuleEvaluationInterval time.Duration
 	Screenshots                   UnifiedAlertingScreenshotSettings
-	SkipClustering                bool
 	ReservedLabels                UnifiedAlertingReservedLabelSettings
 	StateHistory                  UnifiedAlertingStateHistorySettings
 	NotificationHistory           UnifiedAlertingNotificationHistorySettings

--- a/pkg/setting/setting_unified_alerting.go
+++ b/pkg/setting/setting_unified_alerting.go
@@ -124,6 +124,7 @@ type UnifiedAlertingSettings struct {
 	// DefaultRuleEvaluationInterval default interval between evaluations of a rule.
 	DefaultRuleEvaluationInterval time.Duration
 	Screenshots                   UnifiedAlertingScreenshotSettings
+	SkipClustering                bool
 	ReservedLabels                UnifiedAlertingReservedLabelSettings
 	StateHistory                  UnifiedAlertingStateHistorySettings
 	NotificationHistory           UnifiedAlertingNotificationHistorySettings


### PR DESCRIPTION
### Description

This PR removes the need for clustering in _remote primary_ mode by not replicating silences in the internal Alertmanager.

#### Context

In _remote primary_ mode, silences are created, updated, and deleted in both Alertmanagers: first in the remote, then in the internal. The original purpose of replicating silences internally was to be able to disable _remote primary_ mode without losing silences and notification log entries. This was solved by introducing [remote state merge](https://github.com/grafana/grafana/pull/107710).

When deleting a silence, the Grafana instance proxies the request to the Alertmanager and then expires the silence locally. All Grafana instances that are part of the cluster receive this change, and the resulting state is persisted in the database when the next [maintenance routine](https://github.com/grafana/grafana/blob/aa2dc5319e443c26426afa49a6aab69fc100f481/pkg/services/ngalert/notifier/alertmanager.go#L113-L121)  runs.

When Grafana starts, it fetches the Alertmanager state from the database (`kv_store` table) and forwards it to the Alertmanager., who then merges entries for nflog and silences with its own internal state.

#### Problem

We still need to enable clustering to run Grafana in _remote primary_ mode is to avoid issues with silences when Grafana instances restart. Without clustering, other Grafana instances are not aware of changes in silences, and can overwrite the database state with their own stale state during the next maintenance (either periodically or during shutdown).

Because of how the merge works, missing silences are not a problem. However, silences that were previously expired will be recreated if the Alertmanager receives an entry for that UID.

Consider the following scenario:
- Two Grafana instances using the same remote Alertmanager, silence `"foo"` is active
- Instance 1 gets a request to delete silence `"foo"`
    - It forwards the request to the Alertmanager
    - The Alertmanager marks silence `"foo"` as expired
 - Instance 2 restarts
     - It fetches the state in the database and sends it to the Alertmanager
     - The Alertmanager marks silence `"foo"` as active again

<details><summary>Diagram</summary>

```mermaid
sequenceDiagram
actor u as User
participant g1 as Grafana 1
participant g2 as Grafana 2
participant gdb@{ "type" : "database" } as Grafana DB
participant am as Alertmanager
u->>g1: Delete silence "foo"
activate g1
g1->>am: Delete silence "foo"
am-->>g1: OK (silence "foo" deleted)
g1-->>g1: Delete silence "foo"
g1-->>u: OK
deactivate g1
g2-->>g2: Shutdown!
activate g2
g2->>gdb: Save state
gdb-->>g2: OK (silence "foo" active again)
deactivate g2
g2-->>g2: Restart!
activate g2
g2->>gdb: Fetch state
gdb-->>g2: OK
g2->>am: Send state
am-->>g2: OK (silence "foo" active again)
deactivate g2
```
</details>

#### Fix

Stop replicating changes in silences internally. Use the Alertmanager as the single source of truth for silences. Enable clustering when running in _remote primary_ mode.

Returning a blank state from `SilenceState` will delete the state from the Grafana database. The Alertmanager merges external state entries one by one, incorporating those that are not yet there. Sending an empty state will have no effect.

### Note for reviewers

`SilenceState` is essentially a no-op in _remote primary_. We [pull the silences from the database](https://github.com/grafana/grafana/blob/baa428a6b4bf471301079df6ea43a44536ba3036/pkg/services/ngalert/remote/alertmanager.go#L684-L693) and [store them back again](https://github.com/grafana/grafana/blob/baa428a6b4bf471301079df6ea43a44536ba3036/pkg/services/ngalert/notifier/multiorg_alertmanager.go#L647-L665). There's no save-after-write guarantee.