### PR TITLE
Meticulous: Add frontend handling

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -896,6 +896,7 @@ playwright.storybook.config.ts @grafana/grafana-frontend-platform
 /public/app/core/services/impression_srv.ts @grafana/grafana-frontend-platform
 /public/app/core/services/KeybindingSet* @grafana/grafana-frontend-platform
 /public/app/core/services/keybindingSrv.ts @grafana/grafana-frontend-platform
+/public/app/core/services/meticulous.ts @grafana/dataviz-squad
 /public/app/core/services/mocks/subscribeTester.ts @grafana/grafana-frontend-platform
 /public/app/core/services/mousetrap/ @grafana/grafana-frontend-platform
 /public/app/core/services/NewFrontendAssetsChecker* @grafana/grafana-frontend-platform

--- a/devenv/frontend-service/goff-flags.yaml
+++ b/devenv/frontend-service/goff-flags.yaml
@@ -31,4 +31,4 @@ grafana.meticulousAIRecorder:
     enabled: true
     disabled: false
   defaultRule:
-    variation: disabled
+    variation: enabled

--- a/devenv/frontend-service/goff-flags.yaml
+++ b/devenv/frontend-service/goff-flags.yaml
@@ -31,4 +31,4 @@ grafana.meticulousAIRecorder:
     enabled: true
     disabled: false
   defaultRule:
-    variation: enabled
+    variation: disabled

--- a/public/app/core/navigation/GrafanaRoute.tsx
+++ b/public/app/core/navigation/GrafanaRoute.tsx
@@ -3,16 +3,18 @@ import { Navigate, useLocation, useParams } from 'react-router-dom-v5-compat';
 
 import { config, locationSearchToObject, navigationLogger, reportPageview } from '@grafana/runtime';
 import { ErrorBoundary } from '@grafana/ui';
+import { updateMeticulousRecording } from 'app/core/services/meticulous';
 import { isFrontendService } from 'app/core/utils/isFrontendService';
 
 import { useGrafana } from '../context/GrafanaContext';
 import { contextSrv } from '../services/context_srv';
 
+
 import { GrafanaRouteError } from './GrafanaRouteError';
 import { GrafanaRouteLoading } from './GrafanaRouteLoading';
 import { type GrafanaRouteComponentProps, type RouteDescriptor } from './types';
 
-export interface Props extends Pick<GrafanaRouteComponentProps, 'route' | 'location'> {}
+export interface Props extends Pick<GrafanaRouteComponentProps, 'route' | 'location'> { }
 
 export function GrafanaRoute(props: Props) {
   const { chrome, keybindings } = useGrafana();
@@ -40,6 +42,7 @@ export function GrafanaRoute(props: Props) {
     cleanupDOM();
     reportPageview();
     navigationLogger('GrafanaRoute', false, 'Updated', props);
+    updateMeticulousRecording(props.location.pathname);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [props.location.pathname, props.location.search, props.location.hash]);
 

--- a/public/app/core/navigation/GrafanaRoute.tsx
+++ b/public/app/core/navigation/GrafanaRoute.tsx
@@ -9,12 +9,11 @@ import { isFrontendService } from 'app/core/utils/isFrontendService';
 import { useGrafana } from '../context/GrafanaContext';
 import { contextSrv } from '../services/context_srv';
 
-
 import { GrafanaRouteError } from './GrafanaRouteError';
 import { GrafanaRouteLoading } from './GrafanaRouteLoading';
 import { type GrafanaRouteComponentProps, type RouteDescriptor } from './types';
 
-export interface Props extends Pick<GrafanaRouteComponentProps, 'route' | 'location'> { }
+export interface Props extends Pick<GrafanaRouteComponentProps, 'route' | 'location'> {}
 
 export function GrafanaRoute(props: Props) {
   const { chrome, keybindings } = useGrafana();

--- a/public/app/core/services/meticulous.ts
+++ b/public/app/core/services/meticulous.ts
@@ -6,7 +6,7 @@ function isAuthPath(pathname: string): boolean {
 
 // if we ever hit an auth path, stop recording and never restart it.
 export async function updateMeticulousRecording(pathname: string): Promise<void> {
-  if (window.__meticulous == undefined) {
+  if (window.Meticulous == undefined) {
     return;
   }
 

--- a/public/app/core/services/meticulous.ts
+++ b/public/app/core/services/meticulous.ts
@@ -1,0 +1,23 @@
+const AUTH_PATH_PREFIXES = ['/login', '/signup', '/invite/', '/verify', '/user/password/'];
+
+function isAuthPath(pathname: string): boolean {
+  return AUTH_PATH_PREFIXES.some((prefix) => pathname.startsWith(prefix));
+}
+
+// if we ever hit an auth path, stop recording and never restart it.
+export async function updateMeticulousRecording(pathname: string): Promise<void> {
+  if (window.__meticulous == undefined) {
+    return;
+  }
+
+  // we assume the recorder was enabled by default
+  if (!isAuthPath(pathname)) {
+    return;
+  }
+
+  try {
+    window.__meticulous.stopRecording();
+  } catch (error) {
+    console.error('Error stopping Meticulous recording:', error);
+  }
+}

--- a/public/app/core/services/meticulous.ts
+++ b/public/app/core/services/meticulous.ts
@@ -1,4 +1,4 @@
-const AUTH_PATH_PREFIXES = ['/login', '/signup', '/invite/', '/verify', '/user/password/'];
+const AUTH_PATH_PREFIXES = ['/login', '/signup', '/invite/', '/verify', '/user/password/', '/profile/password'];
 
 function isAuthPath(pathname: string): boolean {
   return AUTH_PATH_PREFIXES.some((prefix) => pathname.startsWith(prefix));

--- a/public/app/core/services/meticulous.ts
+++ b/public/app/core/services/meticulous.ts
@@ -6,7 +6,7 @@ function isAuthPath(pathname: string): boolean {
 
 // if we ever hit an auth path, stop recording and never restart it.
 export async function updateMeticulousRecording(pathname: string): Promise<void> {
-  if (window.Meticulous == undefined) {
+  if (window.Meticulous == null || window.__meticulous == null) {
     return;
   }
 


### PR DESCRIPTION
To test:

- you can use https://github.com/grafana/grafana/blob/main/devenv/frontend-service/goff-flags.yaml and `make frontend-service` to run the app with frontend-service and enable meticulous, and then navigate to an auth page and see what happens.

Decoupled from #123758 for multi-tenancy reasons, this would add handling to the frontend to disable the recorder whenever we are in the "auth part" of Grafana.