### PR TITLE
[release-13.0.2] Provisioning: Folder max depth problems should be surface as warnings

### DIFF
--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/health.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/health.go
@@ -75,6 +75,11 @@ const (
 	// ReasonFolderMetadataConflict indicates a conflict between folder metadata in the
 	// repository and the actual folder state in Grafana (e.g., ID mismatch, deleted folder).
 	ReasonFolderMetadataConflict = "FolderMetadataConflict"
+	// ReasonFolderDepthExceeded indicates that creating the folder would exceed
+	// the maximum folder depth enforced by the folder API. The repository
+	// owner must shorten the offending path; provisioning cannot recover
+	// automatically and will not retry the failed write.
+	ReasonFolderDepthExceeded = "FolderDepthExceeded"
 )
 
 // Condition reasons for the Quota condition

--- a/pkg/registry/apis/provisioning/jobs/job_resource_result.go
+++ b/pkg/registry/apis/provisioning/jobs/job_resource_result.go
@@ -57,6 +57,7 @@ func classifyWarning(err error) (string, bool) {
 	var quotaExceededErr *quotas.QuotaExceededError
 	var missingMetaErr *resources.MissingFolderMetadata
 	var metaConflictErr *resources.FolderMetadataConflict
+	var depthExceededErr *resources.FolderDepthExceededError
 
 	switch {
 	case errors.As(err, &quotaExceededErr):
@@ -71,6 +72,8 @@ func classifyWarning(err error) (string, bool) {
 		return provisioning.ReasonMissingFolderMetadata, true
 	case errors.As(err, &metaConflictErr):
 		return provisioning.ReasonFolderMetadataConflict, true
+	case errors.As(err, &depthExceededErr):
+		return provisioning.ReasonFolderDepthExceeded, true
 	default:
 		return "", false
 	}

--- a/pkg/registry/apis/provisioning/jobs/job_resource_result_test.go
+++ b/pkg/registry/apis/provisioning/jobs/job_resource_result_test.go
@@ -381,6 +381,29 @@ func TestJobResourceResult_WarningReason(t *testing.T) {
 
 		assert.Equal(t, provisioning.ReasonFolderMetadataConflict, result.WarningReason())
 	})
+
+	t.Run("FolderDepthExceededError classifies as ReasonFolderDepthExceeded", func(t *testing.T) {
+		depthErr := resources.NewFolderDepthExceededError("a/b/c/d/e/", errors.New("folder max depth exceeded, max depth is 4"))
+		result := NewResourceResult().WithError(depthErr).Build()
+
+		assert.Equal(t, provisioning.ReasonFolderDepthExceeded, result.WarningReason())
+		assert.Nil(t, result.Error(), "depth-exceeded should be a warning, not an error")
+		assert.NotNil(t, result.Warning(), "depth-exceeded should populate the warning slot")
+	})
+
+	t.Run("PathCreationError wrapping FolderDepthExceededError classifies as ReasonFolderDepthExceeded", func(t *testing.T) {
+		depthErr := resources.NewFolderDepthExceededError("a/b/c/d/e/", errors.New("folder max depth exceeded, max depth is 4"))
+		pathErr := &resources.PathCreationError{
+			Path: "a/b/c/d/e/",
+			Err:  fmt.Errorf("ensure folder exists: %w", depthErr),
+		}
+		wrapped := fmt.Errorf("ensuring folder exists at path %s: %w", "a/b/c/d/e/", pathErr)
+		result := NewResourceResult().WithError(wrapped).Build()
+
+		assert.Equal(t, provisioning.ReasonFolderDepthExceeded, result.WarningReason())
+		assert.Nil(t, result.Error(), "depth-exceeded should be a warning even when wrapped through PathCreationError")
+		assert.NotNil(t, result.Warning())
+	})
 }
 
 func TestIsNonFailingWarning(t *testing.T) {

--- a/pkg/registry/apis/provisioning/jobs/progress.go
+++ b/pkg/registry/apis/provisioning/jobs/progress.go
@@ -133,6 +133,12 @@ func (r *jobProgressRecorder) Record(ctx context.Context, result JobResourceResu
 					r.failedUpdates = append(r.failedUpdates, result.PreviousPath())
 				}
 			}
+
+			// Folder creation failures may be surfaced as warnings.
+			var pathErr *resources.PathCreationError
+			if errors.As(result.Warning(), &pathErr) {
+				r.failedCreations = append(r.failedCreations, pathErr.Path)
+			}
 		}
 
 		if reason := result.WarningReason(); reason != "" {

--- a/pkg/registry/apis/provisioning/jobs/progress_test.go
+++ b/pkg/registry/apis/provisioning/jobs/progress_test.go
@@ -416,6 +416,39 @@ func TestJobProgressRecorderFolderFailureTracking(t *testing.T) {
 	recorder.mu.RUnlock()
 }
 
+func TestJobProgressRecorderFolderFailureTrackingFromWarning(t *testing.T) {
+	ctx := context.Background()
+
+	mockProgressFn := func(ctx context.Context, status provisioning.JobStatus) error {
+		return nil
+	}
+	recorder := newJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
+
+	// Folder depth violations are surfaced as warnings instead of errors so
+	// the job is not retried in a loop. They must still populate
+	// failedCreations so that descendant resources are short-circuited
+	// instead of generating duplicate bad requests for the same offending
+	// path.
+	depthErr := resources.NewFolderDepthExceededError(
+		"too/deep/folder/",
+		errors.New("folder max depth exceeded, max depth is 4"),
+	)
+	pathErr := &resources.PathCreationError{
+		Path: "too/deep/folder/",
+		Err:  depthErr,
+	}
+	recorder.Record(ctx, NewFolderResult("too/deep/folder/").
+		WithAction(repository.FileActionCreated).
+		WithError(pathErr).
+		Build())
+
+	recorder.mu.RLock()
+	defer recorder.mu.RUnlock()
+	assert.Contains(t, recorder.failedCreations, "too/deep/folder/", "depth-exceeded warning should still mark the path as a failed creation")
+	assert.Empty(t, recorder.errors, "depth-exceeded warning should not contribute to the error list")
+	assert.Equal(t, 0, recorder.errorCount, "depth-exceeded warning should not increment error count")
+}
+
 func TestJobProgressRecorderHasDirPathFailedCreation(t *testing.T) {
 	ctx := context.Background()
 

--- a/pkg/registry/apis/provisioning/resources/errors.go
+++ b/pkg/registry/apis/provisioning/resources/errors.go
@@ -3,10 +3,12 @@ package resources
 import (
 	"errors"
 	"fmt"
+	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	foldermodel "github.com/grafana/grafana/pkg/services/folder"
 )
 
 // ResourceOwnershipConflictError represents an error that occurred when a resource
@@ -128,4 +130,91 @@ func NewResourceValidationError(err error) *ResourceValidationError {
 	return &ResourceValidationError{
 		Err: combinedError,
 	}
+}
+
+// ErrFolderDepthExceeded is a sentinel for any depth-exceeded violation
+// surfaced by the folder API, regardless of whether it came from a Create
+// or an Update/move.
+var ErrFolderDepthExceeded = errors.New("folder depth exceeded")
+
+// Substrings used to recognise the two human-readable forms of the depth
+// violation. They fall into two buckets that map onto the two validation
+// paths in pkg/registry/apis/folders/validate.go:
+//   - validateOnCreate returns a plain fmt.Errorf with "folder max depth exceeded"
+//   - validateOnUpdate returns folder.ErrMaximumDepthReached, whose public
+//     message is "Maximum nested folder depth reached"
+//
+// Both substrings have been stable for long enough that matching on them
+// is the most reliable cross-process signal we have today; the structured
+// message ID below is preferred when the error chain still carries it.
+const (
+	folderDepthExceededCreateMsg = "folder max depth exceeded"
+	folderDepthExceededUpdateMsg = "maximum nested folder depth reached"
+
+	// folderDepthExceededMessageID is the errutil message ID for the
+	// move/update form. It survives the round-trip through the K8s API
+	// inside Status.Details.UID, so it gives us a stable contract that
+	// does not depend on the human-readable message.
+	folderDepthExceededMessageID = "folder.maximum-depth-reached"
+)
+
+// FolderDepthExceededError wraps a folder-API depth violation.
+type FolderDepthExceededError struct {
+	Path string
+	Err  error
+}
+
+func (e *FolderDepthExceededError) Error() string {
+	if e.Err == nil {
+		return fmt.Sprintf("folder %q exceeds the maximum folder depth allowed by the folder API", e.Path)
+	}
+	return fmt.Sprintf("folder %q exceeds the maximum folder depth allowed by the folder API: %v", e.Path, e.Err)
+}
+
+// Unwrap exposes both the sentinel and the underlying API error
+func (e *FolderDepthExceededError) Unwrap() []error {
+	if e.Err == nil {
+		return []error{ErrFolderDepthExceeded}
+	}
+	return []error{ErrFolderDepthExceeded, e.Err}
+}
+
+// NewFolderDepthExceededError wraps the original folder-API error so callers
+// can detect the depth violation via errors.As.
+func NewFolderDepthExceededError(path string, err error) *FolderDepthExceededError {
+	return &FolderDepthExceededError{Path: path, Err: err}
+}
+
+// IsFolderDepthExceededAPIError reports whether err originates from the
+// folder API rejecting a write because the maximum folder depth was
+// exceeded — either on Create (the new path is too deep) or on Update
+// (a move would push the folder or its descendants past the limit).
+func IsFolderDepthExceededAPIError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// In-process: the original sentinel or the structured errutil base
+	// error are still in the chain.
+	if errors.Is(err, ErrFolderDepthExceeded) || errors.Is(err, foldermodel.ErrMaximumDepthReached) {
+		return true
+	}
+
+	// Through the K8s API the structured message ID is propagated in
+	// Status.Details.UID, which is the most reliable signal we get on
+	// the client side.
+	var statusErr apierrors.APIStatus
+	if errors.As(err, &statusErr) {
+		if details := statusErr.Status().Details; details != nil && string(details.UID) == folderDepthExceededMessageID {
+			return true
+		}
+	}
+
+	// Fallback: substring match on the known human-readable forms and on
+	// the message ID itself, which appears in errutil.Error.Error() output
+	// and therefore in any fmt.Errorf chain wrapping the in-process error.
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, folderDepthExceededCreateMsg) ||
+		strings.Contains(msg, folderDepthExceededUpdateMsg) ||
+		strings.Contains(msg, folderDepthExceededMessageID)
 }

--- a/pkg/registry/apis/provisioning/resources/errors_test.go
+++ b/pkg/registry/apis/provisioning/resources/errors_test.go
@@ -2,12 +2,15 @@ package resources
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	foldermodel "github.com/grafana/grafana/pkg/services/folder"
 )
 
 func TestResourceValidationError(t *testing.T) {
@@ -366,5 +369,102 @@ func TestResourceOwnershipConflictError(t *testing.T) {
 		require.Contains(t, errMsg, "plugin")
 		require.Contains(t, errMsg, "plugin-instance-1")
 		require.Contains(t, errMsg, "cannot be modified")
+	})
+}
+
+func TestFolderDepthExceededError(t *testing.T) {
+	t.Run("Error includes path and underlying message", func(t *testing.T) {
+		underlying := errors.New("folder max depth exceeded, max depth is 4")
+		err := NewFolderDepthExceededError("a/b/c/d/e/", underlying)
+
+		require.Contains(t, err.Error(), "a/b/c/d/e/")
+		require.Contains(t, err.Error(), "max depth")
+	})
+
+	t.Run("Unwrap exposes both sentinel and underlying error", func(t *testing.T) {
+		underlying := errors.New("folder max depth exceeded, max depth is 4")
+		err := NewFolderDepthExceededError("a/b/", underlying)
+
+		require.True(t, errors.Is(err, ErrFolderDepthExceeded), "should match sentinel via errors.Is")
+		require.True(t, errors.Is(err, underlying), "should preserve underlying error in chain")
+	})
+
+	t.Run("errors.As extracts FolderDepthExceededError through wrapping", func(t *testing.T) {
+		underlying := errors.New("folder max depth exceeded, max depth is 4")
+		err := NewFolderDepthExceededError("a/b/", underlying)
+		wrapped := fmt.Errorf("ensure folder exists: %w", err)
+
+		var depthErr *FolderDepthExceededError
+		require.True(t, errors.As(wrapped, &depthErr))
+		require.Equal(t, "a/b/", depthErr.Path)
+	})
+}
+
+func TestIsFolderDepthExceededAPIError(t *testing.T) {
+	t.Run("nil returns false", func(t *testing.T) {
+		require.False(t, IsFolderDepthExceededAPIError(nil))
+	})
+
+	t.Run("matches the create-path substring", func(t *testing.T) {
+		err := errors.New("folder max depth exceeded, max depth is 4")
+		require.True(t, IsFolderDepthExceededAPIError(err))
+	})
+
+	t.Run("matches the update/move public message substring", func(t *testing.T) {
+		// This is the PublicMessage on folder.ErrMaximumDepthReached, which
+		// is what surfaces to the dynamic client when validateOnUpdate
+		// rejects a move.
+		err := apierrors.NewBadRequest("Maximum nested folder depth reached")
+		require.True(t, IsFolderDepthExceededAPIError(err))
+	})
+
+	t.Run("matches the update/move log message substring (case-insensitive)", func(t *testing.T) {
+		err := errors.New("[folder.maximum-depth-reached] maximum folder depth reached")
+		require.True(t, IsFolderDepthExceededAPIError(err))
+	})
+
+	t.Run("matches BadRequest status error from create path", func(t *testing.T) {
+		err := apierrors.NewBadRequest("folder max depth exceeded, max depth is 4")
+		require.True(t, IsFolderDepthExceededAPIError(err))
+	})
+
+	t.Run("matches the structured errutil error via errors.Is", func(t *testing.T) {
+		// The in-process error returned by validateOnUpdate.
+		err := foldermodel.ErrMaximumDepthReached.Errorf("maximum folder depth reached")
+		require.True(t, IsFolderDepthExceededAPIError(err))
+	})
+
+	t.Run("matches when status details carry the structured message ID", func(t *testing.T) {
+		// Simulates a StatusError that survived a round-trip through the
+		// K8s API: the human-readable message is generic but the structured
+		// message ID is preserved in Status.Details.UID.
+		statusErr := &apierrors.StatusError{
+			ErrStatus: metav1.Status{
+				Status:  metav1.StatusFailure,
+				Code:    400,
+				Message: "Bad Request",
+				Details: &metav1.StatusDetails{
+					UID: "folder.maximum-depth-reached",
+				},
+			},
+		}
+		require.True(t, IsFolderDepthExceededAPIError(statusErr))
+	})
+
+	t.Run("matches sentinel error via errors.Is", func(t *testing.T) {
+		require.True(t, IsFolderDepthExceededAPIError(ErrFolderDepthExceeded))
+	})
+
+	t.Run("matches sentinel through wrapping", func(t *testing.T) {
+		wrapped := fmt.Errorf("update folder: %w", ErrFolderDepthExceeded)
+		require.True(t, IsFolderDepthExceededAPIError(wrapped))
+	})
+
+	t.Run("does not match unrelated errors", func(t *testing.T) {
+		require.False(t, IsFolderDepthExceededAPIError(errors.New("something else")))
+	})
+
+	t.Run("does not match unrelated bad-request status errors", func(t *testing.T) {
+		require.False(t, IsFolderDepthExceededAPIError(apierrors.NewBadRequest("title cannot be empty")))
 	})
 }

--- a/pkg/registry/apis/provisioning/resources/folders.go
+++ b/pkg/registry/apis/provisioning/resources/folders.go
@@ -279,6 +279,13 @@ func (fm *FolderManager) EnsureFolderExists(ctx context.Context, folder Folder, 
 				return fmt.Errorf("unable to use provisioning identity %w", err)
 			}
 			if _, err := fm.client.Update(ctx, obj, metav1.UpdateOptions{}); err != nil {
+				// A managed folder being moved into a path that exceeds the
+				// folder API's max depth is the same user-side problem as a
+				// fresh create: surface it as a typed warning so the sync is
+				// not retried in a loop.
+				if IsFolderDepthExceededAPIError(err) {
+					return NewFolderDepthExceededError(folder.Path, err)
+				}
 				return fmt.Errorf("update folder: %w", err)
 			}
 		}
@@ -351,6 +358,15 @@ func (fm *FolderManager) EnsureFolderExists(ctx context.Context, folder Folder, 
 			}
 
 			return nil
+		}
+
+		// The folder API enforces a global maximum folder depth that
+		// provisioning cannot influence. Repositories containing paths
+		// deeper than this limit will fail forever, so surface it as a
+		// typed warning instead of a retryable error and let the sync
+		// keep going for the rest of the tree.
+		if IsFolderDepthExceededAPIError(err) {
+			return NewFolderDepthExceededError(folder.Path, err)
 		}
 
 		return fmt.Errorf("failed to create folder: %w", err)

--- a/pkg/registry/apis/provisioning/resources/folders_test.go
+++ b/pkg/registry/apis/provisioning/resources/folders_test.go
@@ -410,6 +410,65 @@ func TestEnsureFolderExists_TitleUpdate(t *testing.T) {
 		require.ErrorContains(t, err, "managed by a different repository (other-repo)")
 		require.Empty(t, client.updateCalls)
 	})
+
+	t.Run("wraps folder depth API error as FolderDepthExceededError", func(t *testing.T) {
+		repo, _ := newRepo(t)
+		tree := NewEmptyFolderTree()
+
+		client := &fakeDynamicResourceClient{
+			getFn: func(name string) (*unstructured.Unstructured, error) {
+				return nil, apierrors.NewNotFound(schema.GroupResource{Group: "folder.grafana.app", Resource: "folders"}, name)
+			},
+			createFn: func(_ *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+				return nil, apierrors.NewBadRequest("folder max depth exceeded, max depth is 4")
+			},
+		}
+
+		fm := NewFolderManager(repo, client, tree, FolderKind)
+		err := fm.EnsureFolderExists(ctx, Folder{
+			ID:    "folder-id",
+			Title: "New Title",
+			Path:  "a/b/c/d/e/",
+		}, "")
+
+		require.Error(t, err)
+		var depthErr *FolderDepthExceededError
+		require.True(t, errors.As(err, &depthErr), "should return FolderDepthExceededError")
+		require.Equal(t, "a/b/c/d/e/", depthErr.Path)
+		require.NotEmpty(t, client.createCalls)
+	})
+
+	t.Run("wraps folder depth API error from Update (move) as FolderDepthExceededError", func(t *testing.T) {
+		// When a managed folder already exists and provisioning tries to
+		// move it (via Update) into a path that exceeds the folder API's
+		// max depth, the resulting error must also be classified as a
+		// depth violation so the sync surfaces it as a warning instead
+		// of looping retries.
+		repo, cfg := newRepo(t)
+		tree := NewEmptyFolderTree()
+
+		client := &fakeDynamicResourceClient{
+			getFn: func(name string) (*unstructured.Unstructured, error) {
+				return managedFolder(name, "Old Title", cfg.Name), nil
+			},
+			updateFn: func(_ *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+				return nil, apierrors.NewBadRequest("Maximum nested folder depth reached")
+			},
+		}
+
+		fm := NewFolderManager(repo, client, tree, FolderKind)
+		err := fm.EnsureFolderExists(ctx, Folder{
+			ID:    "folder-id",
+			Title: "New Title",
+			Path:  "deep/path/that/exceeds/limit/",
+		}, "")
+
+		require.Error(t, err)
+		var depthErr *FolderDepthExceededError
+		require.True(t, errors.As(err, &depthErr), "Update path should also return FolderDepthExceededError")
+		require.Equal(t, "deep/path/that/exceeds/limit/", depthErr.Path)
+		require.NotEmpty(t, client.updateCalls)
+	})
 }
 
 type fakeDynamicResourceClient struct {

--- a/pkg/tests/apis/provisioning/jobs/pulljob_folder_depth_test.go
+++ b/pkg/tests/apis/provisioning/jobs/pulljob_folder_depth_test.go
@@ -1,0 +1,197 @@
+package jobs
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+)
+
+// TestIntegrationProvisioning_PullJobFolderDepthExceeded verifies that paths
+// deeper than the folder API's maximum folder depth surface as warnings on the
+// sync job (so the job is not requeued forever) and that descendant resources
+// are short-circuited instead of producing a burst of identical bad requests.
+//
+// The default DefaultMaxNestedFolderDepth is 4 and the hard ceiling
+// (maxNestedFolderDepth) is 7, so the deep path here uses 8 nested directories
+// to guarantee a depth violation regardless of configuration.
+func TestIntegrationProvisioning_PullJobFolderDepthExceeded(t *testing.T) {
+	helper := sharedHelper(t)
+
+	const repo = "folder-depth-exceeded-repo"
+	const deepDir = "level1/level2/level3/level4/level5/level6/level7/level8"
+
+	repoPath := filepath.Join(helper.ProvisioningPath, repo)
+	helper.CreateRepo(t, common.TestRepo{
+		Name:   repo,
+		Path:   repoPath,
+		Target: "folder",
+		Copies: map[string]string{
+			"../testdata/all-panels.json":    "shallow/dashboard1.json",
+			"../testdata/text-options.json":  deepDir + "/dashboard2.json",
+			"../testdata/timeline-demo.json": deepDir + "/dashboard3.json",
+		},
+		SkipSync:               true,
+		SkipResourceAssertions: true,
+	})
+
+	job := helper.TriggerJobAndWaitForComplete(t, repo, provisioning.JobSpec{
+		Action: provisioning.JobActionPull,
+		Pull:   &provisioning.SyncJobOptions{},
+	})
+
+	jobObj := &provisioning.Job{}
+	err := runtime.DefaultUnstructuredConverter.FromUnstructured(job.Object, jobObj)
+	require.NoError(t, err)
+
+	t.Logf("Job state: %s", jobObj.Status.State)
+	t.Logf("Job message: %s", jobObj.Status.Message)
+	t.Logf("Job warnings: %v", jobObj.Status.Warnings)
+	t.Logf("Job errors: %v", jobObj.Status.Errors)
+	for _, s := range jobObj.Status.Summary {
+		t.Logf("Summary: group=%s kind=%s create=%d warning=%d error=%d warnings=%v",
+			s.Group, s.Kind, s.Create, s.Warning, s.Error, s.Warnings)
+	}
+
+	require.Equal(t, provisioning.JobStateWarning, jobObj.Status.State,
+		"depth-exceeded folders must be reported as warnings so the job queue does not retry the sync forever")
+	require.Empty(t, jobObj.Status.Errors,
+		"depth-exceeded folders must not contribute to Status.Errors; treating them as errors triggers a 5-minute retry loop")
+	require.NotEmpty(t, jobObj.Status.Warnings, "expected at least one warning describing the depth violation")
+
+	// Exactly one folder-depth warning is expected: the offending leaf folder.
+	// Deeper descendants would also violate the limit but must be suppressed by
+	// the failedCreations short-circuit so we don't burst-write identical bad
+	// requests against the folder API.
+	depthWarnings := 0
+	for _, w := range jobObj.Status.Warnings {
+		if strings.Contains(w, "folder max depth exceeded") {
+			depthWarnings++
+		}
+	}
+	require.Equal(t, 1, depthWarnings,
+		"expected exactly one folder-depth warning; saw %d. Warnings: %v",
+		depthWarnings, jobObj.Status.Warnings)
+
+	// Sibling dashboards under the depth-violating folder must not produce
+	// their own retryable errors — they should be silently skipped because the
+	// parent path already failed.
+	for _, e := range jobObj.Status.Errors {
+		require.NotContains(t, e, deepDir,
+			"resources under a depth-violating folder must not surface as errors")
+	}
+
+	// The shallow dashboard (outside the depth-violating subtree) must still
+	// be created — a depth violation in one branch must not block the rest of
+	// the sync.
+	helper.RequireRepoDashboardCount(t, repo, 1)
+
+	// Resources under the depth-violating folder must not exist in Grafana,
+	// but the legal ancestors up to the depth limit are created normally.
+	// `grafana.app/sourcePath` stores folder paths without a trailing slash,
+	// e.g. "shallow", "level1/level2".
+	folders, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
+	require.NoError(t, err)
+
+	managedSourcePaths := make(map[string]struct{})
+	for _, f := range folders.Items {
+		managerID, _, _ := unstructured.NestedString(f.Object, "metadata", "annotations", "grafana.app/managerId")
+		if managerID != repo {
+			continue
+		}
+		sourcePath, _, _ := unstructured.NestedString(f.Object, "metadata", "annotations", "grafana.app/sourcePath")
+		managedSourcePaths[sourcePath] = struct{}{}
+	}
+
+	// The shallow folder must be created normally despite the depth violation
+	// in another branch.
+	assert.Contains(t, managedSourcePaths, "shallow",
+		"the shallow folder must be created normally despite the depth violation in another branch; got managed paths: %v",
+		managedSourcePaths)
+
+	// The deepest folder in the test tree must not exist. The folder API's
+	// hard ceiling for max depth is 7, so the 8th nested folder is guaranteed
+	// to fail under any valid configuration. This keeps the test stable
+	// without coupling to the runtime value of MaxNestedFolderDepth.
+	assert.NotContains(t, managedSourcePaths,
+		"level1/level2/level3/level4/level5/level6/level7/level8",
+		"the deepest folder must not be created — it exceeds the maximum folder depth allowed by the folder API")
+
+	// Pull condition must be a warning state, not Failure. The condition
+	// reason currently buckets generic warnings under ReasonCompletedWithWarnings;
+	// we assert that explicitly so a future change to surface
+	// ReasonFolderDepthExceeded on the condition has to update this assertion
+	// intentionally.
+	helper.WaitForConditionReason(t, repo,
+		provisioning.ConditionTypePullStatus,
+		provisioning.ReasonCompletedWithWarnings)
+
+	// Re-running the sync must reproduce the same outcome (warning, not error)
+	// without crashing or losing the previously-synced shallow dashboard. This
+	// guards against regressions where a depth-exceeded result poisons the
+	// repository state on the second pull.
+	rerun := helper.TriggerJobAndWaitForComplete(t, repo, provisioning.JobSpec{
+		Action: provisioning.JobActionPull,
+		Pull:   &provisioning.SyncJobOptions{},
+	})
+	rerunObj := &provisioning.Job{}
+	require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(rerun.Object, rerunObj))
+	require.Equal(t, provisioning.JobStateWarning, rerunObj.Status.State,
+		"second pull should also surface the depth violation as a warning, not an error")
+	require.Empty(t, rerunObj.Status.Errors)
+	helper.RequireRepoDashboardCount(t, repo, 1)
+}
+
+// TestIntegrationProvisioning_PullJobFolderDepthExceeded_RecoversAfterFix
+// verifies that once the offending deep path is removed from the repository,
+// a subsequent sync recovers cleanly to a Success state without any leftover
+// depth warning.
+func TestIntegrationProvisioning_PullJobFolderDepthExceeded_RecoversAfterFix(t *testing.T) {
+	helper := sharedHelper(t)
+
+	const repo = "folder-depth-recovery-repo"
+	const deepDir = "a/b/c/d/e/f/g/h"
+	deepDashboardRel := deepDir + "/dashboard.json"
+
+	repoPath := filepath.Join(helper.ProvisioningPath, repo)
+	helper.CreateRepo(t, common.TestRepo{
+		Name:   repo,
+		Path:   repoPath,
+		Target: "folder",
+		Copies: map[string]string{
+			"../testdata/all-panels.json":   "ok/dashboard.json",
+			"../testdata/text-options.json": deepDashboardRel,
+		},
+		SkipSync:               true,
+		SkipResourceAssertions: true,
+	})
+
+	job := helper.TriggerJobAndWaitForComplete(t, repo, provisioning.JobSpec{
+		Action: provisioning.JobActionPull,
+		Pull:   &provisioning.SyncJobOptions{},
+	})
+	jobObj := &provisioning.Job{}
+	require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(job.Object, jobObj))
+	require.Equal(t, provisioning.JobStateWarning, jobObj.Status.State)
+	require.Empty(t, jobObj.Status.Errors)
+
+	// Remove the offending dashboard (and its now-empty parent directory tree)
+	// to simulate the user fixing the repository. The shallow dashboard stays.
+	require.NoError(t, os.Remove(filepath.Join(repoPath, deepDashboardRel)))
+	require.NoError(t, os.RemoveAll(filepath.Join(repoPath, "a")))
+
+	helper.SyncAndWait(t, repo, nil)
+	helper.WaitForConditionReason(t, repo,
+		provisioning.ConditionTypePullStatus,
+		provisioning.ReasonSuccess)
+	helper.RequireRepoDashboardCount(t, repo, 1)
+}

--- a/pkg/tests/apis/provisioning/quota/sync_quota_test.go
+++ b/pkg/tests/apis/provisioning/quota/sync_quota_test.go
@@ -333,14 +333,19 @@ func TestIntegrationProvisioning_SyncQuotaHandling(t *testing.T) {
 		quotaWarningCount := 0
 		for _, w := range jobObj.Status.Warnings {
 			// TODO: Using contains for now, this will be easier once jobs contain top-level warning reasons.
-			if strings.Contains(w, "resource quota exceeded") {
+			// A nested resource whose parent folder failed quota check is recorded with the generic
+			// "parent folder could not be created" wording, so it counts toward the quota cascade as well.
+			if strings.Contains(w, "resource quota exceeded") ||
+				strings.Contains(w, "parent folder could not be created") {
 				quotaWarningCount++
 			}
 		}
 		require.Equal(t, 3, quotaWarningCount,
-			"should have 3 quota warnings: 1 skipped folder + 2 skipped dashboards")
+			"should have 3 quota-related warnings: 1 skipped folder + 1 dashboard skipped by quota + 1 dashboard skipped due to failed parent folder")
 
-		// Step 5: Verify no new dashboards were created (both skipped because the new folder consumed the last quota slot)
+		// Step 5: Verify no new dashboards were created. One new folder consumes the last quota slot,
+		// so its sibling dashboard is skipped due to quota. The other folder fails creation,
+		// so its child dashboard is skipped because the parent folder could not be created.
 		require.EventuallyWithT(t, func(collect *assert.CollectT) {
 			dashboards, err := helper.DashboardsV1.Resource.List(t.Context(), metav1.ListOptions{})
 			if !assert.NoError(collect, err) {


### PR DESCRIPTION
Backport cbf6bd6c000bae3ee873026f2d1cd3019012b9d2 from #123726

---

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Folder max depth API errors should be classify as provisioning jobs warnings as they are user-side problems that need their action to be solved.

**Why do we need this feature?**

Without it, this kind of API errors will fail the jobs and trigger retries for problems that are not retryable.

**Who is this feature for?**

Provisioning feature customers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/git-ui-sync-project/issues/1120

**Special notes for your reviewer:**

Please check that:
- [ x ] It works as expected from a user's perspective.
- [ x ] If this is a pre-GA feature, it is behind a feature toggle.
- [ x ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
