### PR TITLE
LibraryPanels: Set hoverHeader when there is no title

### DIFF
--- a/public/app/features/dashboard-scene/mutation-api/commands/panelCommands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/panelCommands.test.ts
@@ -1,12 +1,12 @@
 import { config } from '@grafana/runtime';
 import { sceneGraph, type VizPanel } from '@grafana/scenes';
 
-import { getUpdatedHoverHeader } from '../../panel-edit/getPanelFrameOptions';
 import type { DashboardScene } from '../../scene/DashboardScene';
 import { type AutoGridItem } from '../../scene/layout-auto-grid/AutoGridItem';
 import { AutoGridLayoutManager } from '../../scene/layout-auto-grid/AutoGridLayoutManager';
 import { DefaultGridLayoutManager } from '../../scene/layout-default/DefaultGridLayoutManager';
 import { PanelTimeRange } from '../../scene/panel-timerange/PanelTimeRange';
+import { getUpdatedHoverHeader } from '../../scene/panel-timerange/utils';
 import { getQueryRunnerFor } from '../../utils/utils';
 import { DashboardMutationClient } from '../DashboardMutationClient';
 import type { PanelElementEntry, PanelElementsData, MutationResult } from '../types';
@@ -98,7 +98,7 @@ function buildPanelScene(panels: VizPanel[] = [], elementMap: Record<string, num
       Object.assign(state, partial);
     }),
     updatePanelTitle: jest.fn((panel: VizPanel, title: string) => {
-      panel.setState({ title, hoverHeader: getUpdatedHoverHeader(title, panel.state.$timeRange) });
+      panel.setState({ title, hoverHeader: getUpdatedHoverHeader(title, panel.state.$timeRange?.state) });
     }),
     changePanelPlugin: jest.fn(),
   };
@@ -129,7 +129,7 @@ function buildAutoGridPanelScene(panels: VizPanel[] = [], elementMap: Record<str
       Object.assign(state, partial);
     }),
     updatePanelTitle: jest.fn((panel: VizPanel, title: string) => {
-      panel.setState({ title, hoverHeader: getUpdatedHoverHeader(title, panel.state.$timeRange) });
+      panel.setState({ title, hoverHeader: getUpdatedHoverHeader(title, panel.state.$timeRange?.state) });
     }),
     changePanelPlugin: jest.fn(),
   };

--- a/public/app/features/dashboard-scene/mutation-api/commands/updatePanel.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updatePanel.ts
@@ -13,9 +13,9 @@ import { type z } from 'zod';
 import { type FieldConfigSource } from '@grafana/data';
 
 import { ConditionalRenderingGroup } from '../../conditional-rendering/group/ConditionalRenderingGroup';
-import { getUpdatedHoverHeader } from '../../panel-edit/getPanelFrameOptions';
 import { AutoGridItem } from '../../scene/layout-auto-grid/AutoGridItem';
 import { PanelTimeRange } from '../../scene/panel-timerange/PanelTimeRange';
+import { getUpdatedHoverHeader } from '../../scene/panel-timerange/utils';
 import { getElements, panelQueryKindToSceneQuery } from '../../serialization/layoutSerializers/utils';
 import { getQueryRunnerFor, getVizPanelKeyForPanelId } from '../../utils/utils';
 
@@ -205,7 +205,7 @@ export const updatePanelCommand: MutationCommand<UpdatePanelPayload> = {
               });
               vizPanel.setState({
                 $timeRange: timeRange,
-                hoverHeader: getUpdatedHoverHeader(vizPanel.state.title, timeRange),
+                hoverHeader: getUpdatedHoverHeader(vizPanel.state.title, timeRange.state),
               });
             }
           }

--- a/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelDataPane/PanelDataQueriesTab.tsx
@@ -40,8 +40,8 @@ import { ExpressionDatasourceUID } from '../../../expressions/types';
 import { getDatasourceSrv } from '../../../plugins/datasource_srv';
 import { PanelInspectDrawer } from '../../inspect/PanelInspectDrawer';
 import { PanelTimeRange } from '../../scene/panel-timerange/PanelTimeRange';
+import { getUpdatedHoverHeader } from '../../scene/panel-timerange/utils';
 import { getDashboardSceneFor, getQueryRunnerFor } from '../../utils/utils';
-import { getUpdatedHoverHeader } from '../getPanelFrameOptions';
 
 import { type PanelDataPaneTab, type PanelDataTabHeaderProps, TabId } from './types';
 import { hasBackendDatasource } from './utils';
@@ -251,7 +251,7 @@ export class PanelDataQueriesTab extends SceneObjectBase<PanelDataQueriesTabStat
 
     if (timeFrom !== undefined || timeShift !== undefined) {
       panelStateUpdate.$timeRange = new PanelTimeRange({ timeFrom, timeShift, hideTimeOverride });
-      panelStateUpdate.hoverHeader = getUpdatedHoverHeader(panel.state.title, panelStateUpdate.$timeRange);
+      panelStateUpdate.hoverHeader = getUpdatedHoverHeader(panel.state.title, panelStateUpdate.$timeRange?.state);
     } else {
       panelStateUpdate.$timeRange = undefined;
       panelStateUpdate.hoverHeader = getUpdatedHoverHeader(panel.state.title, undefined);

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.test.tsx
@@ -63,10 +63,6 @@ jest.mock('../../utils/utils', () => ({
   getDashboardSceneFor: (sceneObject: unknown) => mockGetDashboardSceneFor(sceneObject),
 }));
 
-jest.mock('../getPanelFrameOptions', () => ({
-  getUpdatedHoverHeader: jest.fn(() => false),
-}));
-
 // Mock sceneGraph.getTimeRange
 jest.spyOn(sceneGraph, 'getTimeRange').mockReturnValue({} as ReturnType<typeof sceneGraph.getTimeRange>);
 

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/PanelDataPaneNext.tsx
@@ -25,8 +25,8 @@ import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSou
 import { type QueryGroupOptions } from 'app/types/query';
 
 import { PanelTimeRange } from '../../scene/panel-timerange/PanelTimeRange';
+import { getUpdatedHoverHeader } from '../../scene/panel-timerange/utils';
 import { getDashboardSceneFor, getQueryRunnerFor } from '../../utils/utils';
-import { getUpdatedHoverHeader } from '../getPanelFrameOptions';
 
 import { QueryEditorContent } from './QueryEditor/QueryEditorContent';
 import { filterDataTransformerConfigs } from './QueryEditor/utils';
@@ -679,7 +679,7 @@ export class PanelDataPaneNext extends SceneObjectBase<PanelDataPaneNextState> {
 
     if (timeFrom !== undefined || timeShift !== undefined) {
       panelStateUpdate.$timeRange = new PanelTimeRange({ timeFrom, timeShift, hideTimeOverride });
-      panelStateUpdate.hoverHeader = getUpdatedHoverHeader(panel.state.title, panelStateUpdate.$timeRange);
+      panelStateUpdate.hoverHeader = getUpdatedHoverHeader(panel.state.title, panelStateUpdate.$timeRange?.state);
     } else {
       panelStateUpdate.$timeRange = undefined;
       panelStateUpdate.hoverHeader = getUpdatedHoverHeader(panel.state.title, undefined);

--- a/public/app/features/dashboard-scene/panel-edit/getPanelFrameOptions.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/getPanelFrameOptions.tsx
@@ -257,4 +257,3 @@ export function editPanelTitleAction(panel: VizPanel, title: string, prevTitle: 
     undo: () => updatePanelTitleState(panel, prevTitle),
   });
 }
-

--- a/public/app/features/dashboard-scene/panel-edit/getPanelFrameOptions.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/getPanelFrameOptions.tsx
@@ -4,7 +4,7 @@ import { CoreApp, type FieldConfigSource, type PanelPluginVisualizationSuggestio
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
-import { type SceneTimeRangeLike, type VizPanel } from '@grafana/scenes';
+import { type VizPanel } from '@grafana/scenes';
 import { DataLinksInlineEditor, Input, TextArea, Switch } from '@grafana/ui';
 import { GenAIPanelDescriptionButton } from 'app/features/dashboard/components/GenAI/GenAIPanelDescriptionButton';
 import { GenAIPanelTitleButton } from 'app/features/dashboard/components/GenAI/GenAIPanelTitleButton';
@@ -15,7 +15,6 @@ import { getPanelLinksVariableSuggestions } from 'app/features/panel/panellinks/
 import { dashboardEditActions } from '../edit-pane/shared';
 import { type VizPanelLinks } from '../scene/PanelLinks';
 import { useEditPaneInputAutoFocus } from '../scene/layouts-shared/utils';
-import { PanelTimeRange } from '../scene/panel-timerange/PanelTimeRange';
 import { isDashboardLayoutItem } from '../scene/types/DashboardLayoutItem';
 import { vizPanelToPanel, transformSceneToSaveModel } from '../serialization/transformSceneToSaveModel';
 import { dashboardSceneGraph } from '../utils/dashboardSceneGraph';
@@ -259,16 +258,3 @@ export function editPanelTitleAction(panel: VizPanel, title: string, prevTitle: 
   });
 }
 
-export function getUpdatedHoverHeader(title: string, timeRange: SceneTimeRangeLike | undefined): boolean {
-  if (title !== '') {
-    return false;
-  }
-
-  if (timeRange instanceof PanelTimeRange && !timeRange.state.hideTimeOverride) {
-    if (timeRange.state.timeFrom || timeRange.state.timeShift) {
-      return false;
-    }
-  }
-
-  return true;
-}

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -63,7 +63,6 @@ import {
 import { DashboardEditPane } from '../edit-pane/DashboardEditPane';
 import { dashboardEditActions } from '../edit-pane/shared';
 import { type PanelEditor } from '../panel-edit/PanelEditor';
-import { getUpdatedHoverHeader } from './panel-timerange/utils';
 import { DashboardSceneChangeTracker } from '../saving/DashboardSceneChangeTracker';
 import { SaveDashboardDrawer } from '../saving/SaveDashboardDrawer';
 import { type DashboardChangeInfo } from '../saving/shared';
@@ -114,6 +113,7 @@ import { DashboardGridItem } from './layout-default/DashboardGridItem';
 import { DefaultGridLayoutManager } from './layout-default/DefaultGridLayoutManager';
 import { addNewRowTo } from './layouts-shared/addNew';
 import { clearClipboard } from './layouts-shared/paste';
+import { getUpdatedHoverHeader } from './panel-timerange/utils';
 import { type DashboardLayoutManager } from './types/DashboardLayoutManager';
 import { type LayoutParent } from './types/LayoutParent';
 

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -63,7 +63,7 @@ import {
 import { DashboardEditPane } from '../edit-pane/DashboardEditPane';
 import { dashboardEditActions } from '../edit-pane/shared';
 import { type PanelEditor } from '../panel-edit/PanelEditor';
-import { getUpdatedHoverHeader } from '../panel-edit/getPanelFrameOptions';
+import { getUpdatedHoverHeader } from './panel-timerange/utils';
 import { DashboardSceneChangeTracker } from '../saving/DashboardSceneChangeTracker';
 import { SaveDashboardDrawer } from '../saving/SaveDashboardDrawer';
 import { type DashboardChangeInfo } from '../saving/shared';
@@ -901,7 +901,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
   }
 
   public updatePanelTitle(panel: VizPanel, title: string) {
-    panel.setState({ title, hoverHeader: getUpdatedHoverHeader(title, panel.state.$timeRange) });
+    panel.setState({ title, hoverHeader: getUpdatedHoverHeader(title, panel.state.$timeRange?.state) });
   }
 
   public async changePanelPlugin(

--- a/public/app/features/dashboard-scene/scene/LibraryPanelBehavior.test.tsx
+++ b/public/app/features/dashboard-scene/scene/LibraryPanelBehavior.test.tsx
@@ -188,6 +188,33 @@ describe('LibraryPanelBehavior', () => {
     expect(behaviorClone.state._loadedPanel?.uid).toBe('111');
   });
 
+  describe('hoverHeader', () => {
+    it('should set hoverHeader to false when library panel has a title', async () => {
+      const { gridItem } = await buildTestSceneWithLibraryPanel();
+
+      expect(gridItem.state.body.state.hoverHeader).toBe(false);
+    });
+
+    it('should set hoverHeader to true when library panel has no title', async () => {
+      const { gridItem } = await buildTestSceneWithLibraryPanel({
+        vizPanelTitle: '',
+        libPanelModelTitle: '',
+      });
+
+      expect(gridItem.state.body.state.hoverHeader).toBe(true);
+    });
+
+    it('should set hoverHeader to false when library panel has a time override', async () => {
+      const { gridItem } = await buildTestSceneWithLibraryPanel({
+        vizPanelTitle: '',
+        libPanelModelTitle: '',
+        timeFrom: '2h',
+      });
+
+      expect(gridItem.state.body.state.hoverHeader).toBe(false);
+    });
+  });
+
   it('should use dashboard panel ID for data provider filtering', async () => {
     const { gridItem } = await buildTestSceneWithLibraryPanel();
 
@@ -207,11 +234,19 @@ describe('LibraryPanelBehavior', () => {
   });
 });
 
-async function buildTestSceneWithLibraryPanel() {
+interface BuildTestSceneOptions {
+  vizPanelTitle?: string;
+  libPanelModelTitle?: string;
+  timeFrom?: string;
+}
+
+async function buildTestSceneWithLibraryPanel(options: BuildTestSceneOptions = {}) {
+  const { vizPanelTitle = 'Panel A', libPanelModelTitle = 'LibraryPanel A title', timeFrom } = options;
+
   const behavior = new LibraryPanelBehavior({ name: 'LibraryPanel A', uid: '111' });
 
   const vizPanel = new VizPanel({
-    title: 'Panel A',
+    title: vizPanelTitle,
     pluginId: 'lib-panel-loading',
     key: 'panel-1',
     $behaviors: [behavior],
@@ -222,13 +257,14 @@ async function buildTestSceneWithLibraryPanel() {
     uid: '111',
     type: 'table',
     model: {
-      title: 'LibraryPanel A title',
+      title: libPanelModelTitle,
       type: 'table',
       links: [{ ...NEW_LINK, title: 'link1' }],
       options: { showHeader: true },
       fieldConfig: { defaults: {}, overrides: [] },
       datasource: { uid: 'abcdef' },
       targets: [{ refId: 'A' }],
+      ...(timeFrom ? { timeFrom } : {}),
     },
     version: 1,
   };

--- a/public/app/features/dashboard-scene/scene/LibraryPanelBehavior.tsx
+++ b/public/app/features/dashboard-scene/scene/LibraryPanelBehavior.tsx
@@ -14,7 +14,6 @@ import { Stack } from '@grafana/ui';
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
 import { getLibraryPanel } from 'app/features/library-panels/state/api';
 
-import { getUpdatedHoverHeader } from '../panel-edit/getPanelFrameOptions';
 import { createPanelDataProvider } from '../utils/createPanelDataProvider';
 import { getDashboardSceneFor, getPanelIdForVizPanel } from '../utils/utils';
 
@@ -23,6 +22,7 @@ import { panelLinksBehavior } from './PanelMenuBehavior';
 import { PanelNotices } from './PanelNotices';
 import { DashboardGridItem } from './layout-default/DashboardGridItem';
 import { PanelTimeRange } from './panel-timerange/PanelTimeRange';
+import { getUpdatedHoverHeader } from './panel-timerange/utils';
 
 export interface LibraryPanelBehaviorState extends SceneObjectState {
   uid: string;
@@ -91,7 +91,7 @@ export class LibraryPanelBehavior extends SceneObjectBase<LibraryPanelBehaviorSt
 
     const vizPanelState: VizPanelState = {
       title,
-      hoverHeader: getUpdatedHoverHeader(title ?? '', timeRange),
+      hoverHeader: getUpdatedHoverHeader(title ?? '', timeRange?.state),
       options: libPanelModel.options ?? {},
       fieldConfig: libPanelModel.fieldConfig,
       pluginId: libPanelModel.type,

--- a/public/app/features/dashboard-scene/scene/LibraryPanelBehavior.tsx
+++ b/public/app/features/dashboard-scene/scene/LibraryPanelBehavior.tsx
@@ -14,8 +14,8 @@ import { Stack } from '@grafana/ui';
 import { PanelModel } from 'app/features/dashboard/state/PanelModel';
 import { getLibraryPanel } from 'app/features/library-panels/state/api';
 
-import { createPanelDataProvider } from '../utils/createPanelDataProvider';
 import { getUpdatedHoverHeader } from '../panel-edit/getPanelFrameOptions';
+import { createPanelDataProvider } from '../utils/createPanelDataProvider';
 import { getDashboardSceneFor, getPanelIdForVizPanel } from '../utils/utils';
 
 import { VizPanelLinks, VizPanelLinksMenu } from './PanelLinks';

--- a/public/app/features/dashboard-scene/scene/LibraryPanelBehavior.tsx
+++ b/public/app/features/dashboard-scene/scene/LibraryPanelBehavior.tsx
@@ -15,6 +15,7 @@ import { PanelModel } from 'app/features/dashboard/state/PanelModel';
 import { getLibraryPanel } from 'app/features/library-panels/state/api';
 
 import { createPanelDataProvider } from '../utils/createPanelDataProvider';
+import { getUpdatedHoverHeader } from '../panel-edit/getPanelFrameOptions';
 import { getDashboardSceneFor, getPanelIdForVizPanel } from '../utils/utils';
 
 import { VizPanelLinks, VizPanelLinksMenu } from './PanelLinks';
@@ -79,8 +80,18 @@ export class LibraryPanelBehavior extends SceneObjectBase<LibraryPanelBehaviorSt
       title = vizPanel.state.title ?? libPanelModel.title;
     }
 
+    const timeRange =
+      libPanelModel.timeFrom || libPanelModel.timeShift
+        ? new PanelTimeRange({
+            timeFrom: libPanelModel.timeFrom,
+            timeShift: libPanelModel.timeShift,
+            hideTimeOverride: libPanelModel.hideTimeOverride,
+          })
+        : undefined;
+
     const vizPanelState: VizPanelState = {
       title,
+      hoverHeader: getUpdatedHoverHeader(title ?? '', timeRange),
       options: libPanelModel.options ?? {},
       fieldConfig: libPanelModel.fieldConfig,
       pluginId: libPanelModel.type,
@@ -91,12 +102,8 @@ export class LibraryPanelBehavior extends SceneObjectBase<LibraryPanelBehaviorSt
       $data: createPanelDataProvider(libPanelModel),
     };
 
-    if (libPanelModel.timeFrom || libPanelModel.timeShift) {
-      vizPanelState.$timeRange = new PanelTimeRange({
-        timeFrom: libPanelModel.timeFrom,
-        timeShift: libPanelModel.timeShift,
-        hideTimeOverride: libPanelModel.hideTimeOverride,
-      });
+    if (timeRange) {
+      vizPanelState.$timeRange = timeRange;
     }
 
     vizPanel.setState(vizPanelState);

--- a/public/app/features/dashboard-scene/scene/panel-timerange/utils.ts
+++ b/public/app/features/dashboard-scene/scene/panel-timerange/utils.ts
@@ -7,6 +7,8 @@ import { of } from 'rxjs';
 import { dateTime, type DateTime, rangeUtil, type TimeRange } from '@grafana/data';
 import { type ExtraQueryDataProcessor } from '@grafana/scenes';
 
+import type { PanelTimeRangeState } from './PanelTimeRange';
+
 // rendered appropriately.
 export const timeShiftAlignmentProcessor: ExtraQueryDataProcessor = (primary, secondary) => {
   const diff = secondary.timeRange.from.diff(primary.timeRange.from);
@@ -25,6 +27,20 @@ export const timeShiftAlignmentProcessor: ExtraQueryDataProcessor = (primary, se
 };
 
 export const getCompareSeriesRefId = (refId: string) => `${refId}-compare`;
+
+export function getUpdatedHoverHeader(title: string, timeOverride?: Partial<PanelTimeRangeState>): boolean {
+  if (title !== '') {
+    return false;
+  }
+
+  if (timeOverride && !timeOverride.hideTimeOverride) {
+    if (timeOverride.timeFrom || timeOverride.timeShift) {
+      return false;
+    }
+  }
+
+  return true;
+}
 
 const PREVIOUS_PERIOD_VALUE = '__previousPeriod';
 

--- a/public/app/features/dashboard-scene/scene/panel-timerange/utils.ts
+++ b/public/app/features/dashboard-scene/scene/panel-timerange/utils.ts
@@ -28,6 +28,11 @@ export const timeShiftAlignmentProcessor: ExtraQueryDataProcessor = (primary, se
 
 export const getCompareSeriesRefId = (refId: string) => `${refId}-compare`;
 
+/**
+ * Whether a panel should use a hover header, used when there's
+ * nothing always-visible to display in it (no title, no visible time override).
+ * return true hides the header, return false displays the header
+ */
 export function getUpdatedHoverHeader(title: string, timeOverride?: Partial<PanelTimeRangeState>): boolean {
   if (title !== '') {
     return false;

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/utils.ts
@@ -156,6 +156,8 @@ export function buildLibraryPanel(panel: LibraryPanelKind, id?: number): VizPane
     }),
     pluginId: LibraryPanelBehavior.LOADING_VIZ_PANEL_PLUGIN_ID,
     title: panel.spec.title,
+    hoverHeader: !panel.spec.title,
+    hoverHeaderOffset: 0,
     options: {},
     fieldConfig: {
       defaults: {},


### PR DESCRIPTION
**What is this feature?**

The library panel was always displaying the header even when no title was present. 
This PR removes the header when there is no title and/or time override to display, and uses `hoverHeader` like regular panels.

**Before** (library panel on the left, regular panel on the right)
<img width="1400" height="277" alt="Screenshot 2026-04-28 at 15 32 02" src="https://github.com/user-attachments/assets/8a6eb848-6433-43b5-ae28-7c198ade630f" />

**After** (library panel on the left, regular panel on the right)
<img width="1383" height="272" alt="Screenshot 2026-04-28 at 15 32 35" src="https://github.com/user-attachments/assets/d4d41825-dcba-493a-b08e-3dca9085a301" />

Also supports time shift and override
<img width="1390" height="266" alt="Screenshot 2026-04-28 at 15 45 15" src="https://github.com/user-attachments/assets/7b4ab285-741b-4a3d-8c15-9f230c117281" />

Fixes https://github.com/grafana/support-escalations/issues/22020
Fixes https://github.com/grafana/grafana/issues/123036

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
