### PR TITLE
Dashboards: Fix panel editor crash on malformed override matcher options

### DIFF
--- a/packages/grafana-data/src/field/fieldOverrides.test.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.test.ts
@@ -476,6 +476,43 @@ describe('applyFieldOverrides', () => {
     warnSpy.mockRestore();
   });
 
+  it('should skip byName overrides whose options shape is invalid', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+
+    const data = applyFieldOverrides({
+      data: [f0],
+      fieldConfig: {
+        defaults: {},
+        overrides: [
+          // Invalid: byName expects a string, not an object.
+          {
+            matcher: { id: FieldMatcherID.byName, options: { name: 'value' } as unknown as string },
+            properties: [{ id: 'decimals', value: 5 }],
+          },
+          // Valid sibling — must still apply to its target.
+          {
+            matcher: { id: FieldMatcherID.byName, options: 'value2' },
+            properties: [{ id: 'decimals', value: 1 }],
+          },
+        ],
+      },
+      replaceVariables: (value) => value,
+      theme: createTheme(),
+      fieldConfigRegistry: customFieldRegistry,
+    });
+
+    expect(data).toHaveLength(1);
+    expect(data[0].fields[1].name).toEqual('value');
+    expect(data[0].fields[1].config.decimals).toEqual(6);
+    expect(data[0].fields[2].name).toEqual('value2');
+    expect(data[0].fields[2].config.decimals).toEqual(1);
+    expect(warnSpy).toHaveBeenCalledWith('Invalid options for field matcher "byName", skipping override rule', {
+      name: 'value',
+    });
+
+    warnSpy.mockRestore();
+  });
+
   it('displayName should be able to reference itself', () => {
     const data = applyFieldOverrides({
       data: [f0], // the frame

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -10,7 +10,7 @@ import { createDataFrame, guessFieldTypeForField } from '../dataframe/processDat
 import { type PanelPlugin } from '../panel/PanelPlugin';
 import { asHexString } from '../themes/colorManipulator';
 import { type GrafanaTheme2 } from '../themes/types';
-import { fieldMatchers } from '../transformations/matchers';
+import { areMatcherOptionsValid, fieldMatchers } from '../transformations/matchers';
 import { type ScopedVars, type DataContextScopedVar } from '../types/ScopedVars';
 import {
   type DataFrame,
@@ -121,10 +121,19 @@ export function applyFieldOverrides(
       if ((rule.matcher.scope ?? 'series') !== scope) {
         continue;
       }
+
       const info = fieldMatchers.getIfExists(rule.matcher.id);
 
       if (!info) {
         console.warn(`Unknown field matcher id: "${rule.matcher.id}", skipping override rule`);
+        continue;
+      }
+
+      if (!areMatcherOptionsValid(info, rule.matcher.options)) {
+        console.warn(
+          `Invalid options for field matcher "${rule.matcher.id}", skipping override rule`,
+          rule.matcher.options
+        );
         continue;
       }
 

--- a/packages/grafana-data/src/index.ts
+++ b/packages/grafana-data/src/index.ts
@@ -284,6 +284,7 @@ export {
   getFieldMatcher,
   getFrameMatchers,
   getValueMatcher,
+  areMatcherOptionsValid,
 } from './transformations/matchers';
 export { type FieldValueMatcherConfig } from './transformations/matchers/fieldValueMatcher';
 export { DataTransformerID } from './transformations/transformers/ids';

--- a/packages/grafana-data/src/transformations/matchers.ts
+++ b/packages/grafana-data/src/transformations/matchers.ts
@@ -102,3 +102,10 @@ export function getValueMatcher(config: MatcherConfig): ValueMatcher {
   }
   return info.get(config.options);
 }
+
+export function areMatcherOptionsValid<TOptions>(
+  matcher: FieldMatcherInfo<TOptions> | FrameMatcherInfo<TOptions>,
+  options: unknown
+): options is TOptions {
+  return matcher.validateOptions ? matcher.validateOptions(options) : true;
+}

--- a/packages/grafana-data/src/transformations/matchers/matchers.test.ts
+++ b/packages/grafana-data/src/transformations/matchers/matchers.test.ts
@@ -1,4 +1,5 @@
-import { fieldMatchers } from '../matchers';
+import { type FieldMatcherInfo } from '../../types/transformations';
+import { areMatcherOptionsValid, fieldMatchers } from '../matchers';
 
 import { FieldMatcherID } from './ids';
 
@@ -8,5 +9,26 @@ describe('Matchers', () => {
       const matcher = fieldMatchers.get(name);
       expect(matcher.id).toBe(name);
     }
+  });
+});
+
+describe('areMatcherOptionsValid', () => {
+  const noValidator = {} as FieldMatcherInfo<unknown>;
+  const stringValidator = {
+    validateOptions: (o: unknown): o is string => typeof o === 'string',
+  } as FieldMatcherInfo<string>;
+
+  it('accepts any options when the matcher declares no validateOptions', () => {
+    expect(areMatcherOptionsValid(noValidator, 'a')).toBe(true);
+    expect(areMatcherOptionsValid(noValidator, { foo: 'bar' })).toBe(true);
+    expect(areMatcherOptionsValid(noValidator, null)).toBe(true);
+    expect(areMatcherOptionsValid(noValidator, undefined)).toBe(true);
+  });
+
+  it('delegates entirely to validateOptions when present', () => {
+    expect(areMatcherOptionsValid(stringValidator, 'a')).toBe(true);
+    expect(areMatcherOptionsValid(stringValidator, { foo: 'bar' })).toBe(false);
+    expect(areMatcherOptionsValid(stringValidator, 1)).toBe(false);
+    expect(areMatcherOptionsValid(stringValidator, null)).toBe(false);
   });
 });

--- a/packages/grafana-data/src/transformations/matchers/nameMatcher.test.ts
+++ b/packages/grafana-data/src/transformations/matchers/nameMatcher.test.ts
@@ -501,4 +501,14 @@ describe('Field Name matcher with malformed options (pre-validation behavior)', 
       expect(matchFn(field, frame, [frame])).toBe(false);
     }
   });
+
+  it('byName.validateOptions accepts strings and rejects everything else', () => {
+    const info = fieldMatchers.get(FieldMatcherID.byName);
+    expect(info.validateOptions?.('value')).toBe(true);
+    expect(info.validateOptions?.('')).toBe(true);
+    expect(info.validateOptions?.({ name: 'value' })).toBe(false);
+    expect(info.validateOptions?.(123)).toBe(false);
+    expect(info.validateOptions?.(null)).toBe(false);
+    expect(info.validateOptions?.(undefined)).toBe(false);
+  });
 });

--- a/packages/grafana-data/src/transformations/matchers/nameMatcher.test.ts
+++ b/packages/grafana-data/src/transformations/matchers/nameMatcher.test.ts
@@ -1,6 +1,6 @@
 import { toDataFrame } from '../../dataframe/processDataFrame';
 import { type DataFrame, FieldType } from '../../types/dataFrame';
-import { getFieldMatcher } from '../matchers';
+import { fieldMatchers, getFieldMatcher } from '../matchers';
 
 import { FieldMatcherID } from './ids';
 import { ByNamesMatcherMode } from './nameMatcher';
@@ -481,5 +481,24 @@ describe('Fields returned by query with refId', () => {
     const frameB = data[1];
     expect(matcher(frameB.fields[0], frameB, data)).toBe(false);
     expect(matcher(frameB.fields[1], frameB, data)).toBe(false);
+  });
+});
+
+describe('Field Name matcher with malformed options (pre-validation behavior)', () => {
+  const frame = toDataFrame({
+    fields: [
+      { name: 'value', type: FieldType.number, values: [1, 2] },
+      { name: 'value2', type: FieldType.number, values: [3, 4] },
+    ],
+    name: 'A',
+  });
+
+  it('byName with object options matches no field (silent no-op)', () => {
+    const info = fieldMatchers.get(FieldMatcherID.byName);
+    const matchFn = info.get({ name: 'value' } as unknown as string);
+
+    for (const field of frame.fields) {
+      expect(matchFn(field, frame, [frame])).toBe(false);
+    }
   });
 });

--- a/packages/grafana-data/src/transformations/matchers/nameMatcher.ts
+++ b/packages/grafana-data/src/transformations/matchers/nameMatcher.ts
@@ -40,6 +40,8 @@ const fieldNameMatcher: FieldMatcherInfo<string> = {
   description: 'match the field name',
   defaultOptions: '',
 
+  validateOptions: (options): options is string => typeof options === 'string',
+
   get: (name: string): FieldMatcher => {
     const uniqueNames = new Set<string>([name]);
 

--- a/packages/grafana-data/src/utils/Registry.ts
+++ b/packages/grafana-data/src/utils/Registry.ts
@@ -29,6 +29,14 @@ export interface RegistryItemWithOptions<TOptions = any> extends RegistryItem {
    * Default options used if nothing else is specified
    */
   defaultOptions?: TOptions;
+
+  /**
+   * Optional runtime type guard for `options`. Used by `areMatcherOptionsValid`
+   * to drop malformed configs (wrong shape from old/foreign authors, schema
+   * drift, etc.). Implement only when `get(options)` would crash or silently
+   * misbehave on a bad shape; otherwise leave undefined and accept anything.
+   */
+  validateOptions?: (options: unknown) => options is TOptions;
 }
 
 interface RegistrySelectInfo {

--- a/packages/grafana-data/src/utils/Registry.ts
+++ b/packages/grafana-data/src/utils/Registry.ts
@@ -31,10 +31,7 @@ export interface RegistryItemWithOptions<TOptions = any> extends RegistryItem {
   defaultOptions?: TOptions;
 
   /**
-   * Optional runtime type guard for `options`. Used by `areMatcherOptionsValid`
-   * to drop malformed configs (wrong shape from old/foreign authors, schema
-   * drift, etc.). Implement only when `get(options)` would crash or silently
-   * misbehave on a bad shape; otherwise leave undefined and accept anything.
+   * Optional runtime type guard for `options`.
    */
   validateOptions?: (options: unknown) => options is TOptions;
 }

--- a/public/app/features/dashboard/components/PanelEditor/getFieldOverrideElements.test.ts
+++ b/public/app/features/dashboard/components/PanelEditor/getFieldOverrideElements.test.ts
@@ -4,6 +4,7 @@ import {
   type FieldConfigSource,
   Registry,
 } from '@grafana/data';
+import { fieldMatchersUI } from '@grafana/ui';
 
 import { getFieldOverrideCategories } from './getFieldOverrideElements';
 
@@ -20,17 +21,26 @@ jest.mock('@grafana/runtime', () => ({
   },
 }));
 
-jest.mock('@grafana/ui', () => ({
-  ...jest.requireActual('@grafana/ui'),
-  fieldMatchersUI: {
-    get: jest.fn().mockReturnValue({
-      name: 'By Name',
-      matcher: {},
-      component: () => null,
-    }),
-    selectOptions: jest.fn().mockReturnValue({ options: [] }),
-  },
-}));
+jest.mock('@grafana/ui', () => {
+  const mockMatcherUi = {
+    name: 'By Name',
+    matcher: {
+      validateOptions: (o: unknown): o is string => typeof o === 'string',
+    },
+    component: () => null,
+  };
+  return {
+    ...jest.requireActual('@grafana/ui'),
+    fieldMatchersUI: {
+      getIfExists: jest.fn().mockReturnValue(mockMatcherUi),
+      get: jest.fn().mockReturnValue(mockMatcherUi),
+      selectOptions: jest.fn().mockReturnValue({ options: [] }),
+    },
+  };
+});
+
+const getIfExistsMock = fieldMatchersUI.getIfExists as jest.Mock;
+const defaultMatcherUi = getIfExistsMock();
 
 function makeRegistry(items: FieldConfigPropertyItem[]): FieldConfigOptionsRegistry {
   return new Registry<FieldConfigPropertyItem>(() => items);
@@ -102,5 +112,35 @@ describe('getFieldOverrideCategories', () => {
 
       expect(element.props.options).toHaveLength(3);
     });
+  });
+
+  it('drops overrides with unknown matcher id or invalid options shape, keeps valid siblings', () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation();
+    getIfExistsMock.mockReturnValueOnce(undefined);
+
+    const registry = makeRegistry([makeItem('custom.a')]);
+    const fieldConfig: FieldConfigSource = {
+      defaults: {},
+      overrides: [
+        { matcher: { id: 'invalidMatcher', options: 'foo' }, properties: [] },
+        {
+          matcher: { id: 'byName', options: { name: 'value' } as unknown as string },
+          properties: [],
+        },
+        { matcher: { id: 'byName', options: 'value' }, properties: [] },
+      ],
+    };
+
+    const categories = getFieldOverrideCategories(fieldConfig, registry, [], '', jest.fn());
+
+    expect(categories).toHaveLength(2);
+    expect(categories[0].props.title).toBe('Override 3');
+    expect(warnSpy).toHaveBeenCalledWith('Unknown field matcher id: "invalidMatcher", skipping override rule');
+    expect(warnSpy).toHaveBeenCalledWith('Invalid options for field matcher "byName", skipping override rule', {
+      name: 'value',
+    });
+
+    warnSpy.mockRestore();
+    getIfExistsMock.mockReturnValue(defaultMatcherUi);
   });
 });

--- a/public/app/features/dashboard/components/PanelEditor/getFieldOverrideElements.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/getFieldOverrideElements.tsx
@@ -8,6 +8,7 @@ import {
   type VariableSuggestionsScope,
   type DynamicConfigValue,
   type ConfigOverrideRule,
+  areMatcherOptionsValid,
   fieldMatchers,
   type FieldConfigSource,
   type DataFrame,
@@ -96,7 +97,21 @@ export function getFieldOverrideCategories(
       overrideNum: idx + 1,
     });
     const overrideId = `panel-options-override-${idx}`;
-    const matcherUi = fieldMatchersUI.get(override.matcher.id);
+    const matcherUi = fieldMatchersUI.getIfExists(override.matcher.id);
+
+    if (!matcherUi) {
+      console.warn(`Unknown field matcher id: "${override.matcher.id}", skipping override rule`);
+      continue;
+    }
+
+    if (!areMatcherOptionsValid(matcherUi.matcher, override.matcher.options)) {
+      console.warn(
+        `Invalid options for field matcher "${override.matcher.id}", skipping override rule`,
+        override.matcher.options
+      );
+      continue;
+    }
+
     const configPropertiesOptions = registry.selectOptions(
       undefined,
       (item) => !item.hideFromOverrides,


### PR DESCRIPTION
**What is this feature?**

Adds an opt-in `validateOptions` runtime guard to `RegistryItemWithOptions` and uses it to drop field overrides whose `matcher.options` shape is invalid, instead of letting the bad value reach the renderer. 

**Why do we need this feature?**
The panel editor crashes with React error ("Objects are not valid as a React child") when a dashboard contains a `byName` override whose `options` is an object like `{ name: "value" }` instead of the expected `string`. 

The crash happens in [OverrideCategoryTitle.tsx](https://github.com/grafana/grafana/blob/main/public/app/features/dashboard/components/PanelEditor/OverrideCategoryTitle.tsx#L46)