### PR TITLE
UPlotCompare: Improvements

### DIFF
--- a/packages/grafana-test-utils/src/matchers/toMatchUPlotSnapshot.ts
+++ b/packages/grafana-test-utils/src/matchers/toMatchUPlotSnapshot.ts
@@ -43,10 +43,14 @@ export function toMatchUPlotSnapshot(
   }
   const result = baseResult as SnapshotMismatch;
 
-  if (!process.env.CI && !result.pass && result.expected != null) {
+  if (!process.env.CI && ((!result.pass && result.expected != null) || process.env.GEN_CANVAS_OUTPUT_ON_FAIL)) {
+    let expected = result.expected;
+    if (!expected) {
+      expected = JSON.stringify(received);
+    }
     let parsedExpected;
     try {
-      parsedExpected = parseSnapshotJson(result.expected) as CanvasRenderingContext2DEvent[];
+      parsedExpected = parseSnapshotJson(expected) as CanvasRenderingContext2DEvent[];
     } catch (e) {
       console.error('toMatchUPlotSnapshot: failed to parse expected snapshot JSON', e);
       return result;

--- a/packages/grafana-test-utils/src/matchers/toMatchUPlotSnapshot.ts
+++ b/packages/grafana-test-utils/src/matchers/toMatchUPlotSnapshot.ts
@@ -64,6 +64,7 @@ export function toMatchUPlotSnapshot(
       uPlotCanvasEvents: uPlotCanvasEvents,
       width: payloadWidth,
       height: payloadHeight,
+      snapshotAssertionPassed: result.pass,
     };
 
     const { fullPath, publicBasename } = resolveUPlotComparePayloadWriteTarget(testName);

--- a/scripts/uplot-compare/src/components/AssertionStatusBadge.tsx
+++ b/scripts/uplot-compare/src/components/AssertionStatusBadge.tsx
@@ -1,0 +1,10 @@
+export function AssertionStatusBadge({ passed, compact }: { passed: boolean; compact?: boolean }) {
+  return (
+    <span
+      className={`compare-snapshot-status${passed ? ' is-pass' : ' is-fail'}${compact ? ' is-compact' : ''}`}
+      title="Whether the test passed when this payload was written"
+    >
+      {passed ? 'passed' : 'failed'}
+    </span>
+  );
+}

--- a/scripts/uplot-compare/src/components/ComparePlots.tsx
+++ b/scripts/uplot-compare/src/components/ComparePlots.tsx
@@ -4,6 +4,7 @@ import { useCanvasEventsEffect } from '../hooks/useCanvasEventsEffect.ts';
 import { useDiffImageData } from '../hooks/useDiffImageData.ts';
 import type { ComparePlotsProps } from '../types.ts';
 
+import { AssertionStatusBadge } from './AssertionStatusBadge.tsx';
 import { CanvasStack } from './CanvasStack.tsx';
 import { DiffCanvas } from './DiffCanvas.tsx';
 import { PlotHeader } from './PlotHeader.tsx';
@@ -52,29 +53,38 @@ export function ComparePlots({ defaultWidth, defaultHeight, payload }: ComparePl
     }
   }, [diffImageData, height, showOverlay, width]);
 
+  const showActualOnly = payload.snapshotAssertionPassed === true;
+
   return (
     <>
-      <h3 className="compare-title">Test: {payload.testName}</h3>
-      <div className="wrap">
-        <div className="plot-panel expected">
-          <PlotHeader
-            title={'Expected'}
-            onClick={() => setRenderExpectedSetupEvents((prev) => !prev)}
-            renderSetupEvents={renderExpectedSetupEvents}
-            mixBlendMode={blendMode}
-            onChangeBlendMode={setBlendMode}
-            showBlend={showOverlay && hasDiff}
-          />
-          <CanvasStack
-            uPlotRef={expectedUPlotRef}
-            width={width}
-            height={height}
-            overlayRef={expectedOverlayRef}
-            showOverlay={showOverlay}
-            hasDiff={hasDiff}
-            mixBlendMode={blendMode}
-          />
-        </div>
+      <div className="compare-title-row">
+        <h3 className="compare-title">Test: {payload.testName}</h3>
+        {payload.snapshotAssertionPassed !== undefined ? (
+          <AssertionStatusBadge passed={payload.snapshotAssertionPassed} />
+        ) : null}
+      </div>
+      <div className={`wrap${showActualOnly ? ' wrap--actual-only' : ''}`}>
+        {!showActualOnly ? (
+          <div className="plot-panel expected">
+            <PlotHeader
+              title={'Expected'}
+              onClick={() => setRenderExpectedSetupEvents((prev) => !prev)}
+              renderSetupEvents={renderExpectedSetupEvents}
+              mixBlendMode={blendMode}
+              onChangeBlendMode={setBlendMode}
+              showBlend={showOverlay && hasDiff}
+            />
+            <CanvasStack
+              uPlotRef={expectedUPlotRef}
+              width={width}
+              height={height}
+              overlayRef={expectedOverlayRef}
+              showOverlay={showOverlay}
+              hasDiff={hasDiff}
+              mixBlendMode={blendMode}
+            />
+          </div>
+        ) : null}
 
         <div className="plot-panel actual">
           <PlotHeader
@@ -95,18 +105,20 @@ export function ComparePlots({ defaultWidth, defaultHeight, payload }: ComparePl
             mixBlendMode={blendMode}
           />
         </div>
-        <div className="diff-panel-wrap">
-          <DiffCanvas
-            width={width}
-            height={height}
-            hasDiff={hasDiff}
-            diffImageData={diffImageData}
-            showOverlay={showOverlay}
-            onToggleOverlay={() => setShowOverlay((prev) => !prev)}
-            renderDiffSetupEvents={renderDiffSetupEvents}
-            onToggleDiffSetupEvents={() => setRenderDiffSetupEvents((prev) => !prev)}
-          />
-        </div>
+        {!showActualOnly ? (
+          <div className="diff-panel-wrap">
+            <DiffCanvas
+              width={width}
+              height={height}
+              hasDiff={hasDiff}
+              diffImageData={diffImageData}
+              showOverlay={showOverlay}
+              onToggleOverlay={() => setShowOverlay((prev) => !prev)}
+              renderDiffSetupEvents={renderDiffSetupEvents}
+              onToggleDiffSetupEvents={() => setRenderDiffSetupEvents((prev) => !prev)}
+            />
+          </div>
+        ) : null}
       </div>
     </>
   );

--- a/scripts/uplot-compare/src/components/CompareUPlotCanvases.tsx
+++ b/scripts/uplot-compare/src/components/CompareUPlotCanvases.tsx
@@ -1,8 +1,9 @@
 import * as React from 'react';
 
-import { isUPlotComparePayload } from '../testUtils.ts';
+import { isUPlotComparePayload, readSnapshotAssertionPassed } from '../testUtils.ts';
 import type { ResolvedPayload, UPlotComparePayload } from '../types.ts';
 
+import { AssertionStatusBadge } from './AssertionStatusBadge.tsx';
 import { ComparePlots } from './ComparePlots.tsx';
 
 /** When payload JSON has no `width`/`height` (older files), uplot-compare still needs a canvas size for replay. */
@@ -53,6 +54,9 @@ export const CompareUPlotCanvases = ({
   const [view, setView] = React.useState<ViewState>({ kind: 'loading' });
   const [selectedFile, setSelectedFile] = React.useState<string | null>(null);
   const [fileModifiedLabels, setFileModifiedLabels] = React.useState<Record<string, string>>({});
+  const [fileSnapshotAssertionPassed, setFileSnapshotAssertionPassed] = React.useState<
+    Record<string, boolean | undefined>
+  >({});
 
   /**
    * @todo route with links instead so folks can open each in a new tab
@@ -85,6 +89,7 @@ export const CompareUPlotCanvases = ({
         actual: raw.actual,
         uPlotCanvasEvents: Array.isArray(raw.uPlotCanvasEvents) ? raw.uPlotCanvasEvents : [],
         ...readPayloadDimensions(raw),
+        snapshotAssertionPassed: raw.snapshotAssertionPassed,
       },
     });
   }, []);
@@ -162,6 +167,34 @@ export const CompareUPlotCanvases = ({
 
   React.useEffect(() => {
     let cancelled = false;
+    const loadSnapshotAssertionFlags = async () => {
+      const entries = await Promise.all(
+        PUBLIC_PAYLOAD_FILES.map(async (basename): Promise<[string, boolean | undefined]> => {
+          try {
+            const res = await fetch(payloadFetchUrl(basename));
+            if (!res.ok) {
+              return [basename, undefined];
+            }
+            const data: unknown = await res.json();
+            return [basename, readSnapshotAssertionPassed(data)];
+          } catch {
+            return [basename, undefined];
+          }
+        })
+      );
+      if (!cancelled) {
+        setFileSnapshotAssertionPassed(Object.fromEntries(entries));
+      }
+    };
+
+    void loadSnapshotAssertionFlags();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  React.useEffect(() => {
+    let cancelled = false;
     const loadFileModifiedDates = async () => {
       const entries = await Promise.all(
         PUBLIC_PAYLOAD_FILES.map(async (basename): Promise<[string, string]> => {
@@ -227,7 +260,12 @@ export const CompareUPlotCanvases = ({
                 className={`compare-file-item${selectedFile === basename ? ' is-selected' : ''}`}
                 onClick={() => loadPayloadFromPublicFile(basename, 'push')}
               >
-                <span>{basename}</span>
+                <span className="compare-file-item-header">
+                  <span className="compare-file-name">{basename}</span>
+                  {typeof fileSnapshotAssertionPassed[basename] === 'boolean' ? (
+                    <AssertionStatusBadge passed={fileSnapshotAssertionPassed[basename]} compact />
+                  ) : null}
+                </span>
                 <span className="compare-file-modified">
                   {fileModifiedLabels[basename] ? `Modified: ${fileModifiedLabels[basename]}` : 'Modified: unknown'}
                 </span>

--- a/scripts/uplot-compare/src/exportedTypes.ts
+++ b/scripts/uplot-compare/src/exportedTypes.ts
@@ -9,4 +9,6 @@ export interface UPlotComparePayload {
   /** uPlot `width` / `height` (CSS px) for the test canvas; used by uplot-compare to size replay canvases */
   width: number;
   height: number;
+  /** Present on payloads from newer matchers: whether the Jest snapshot assertion passed when this file was written. */
+  snapshotAssertionPassed?: boolean;
 }

--- a/scripts/uplot-compare/src/index.css
+++ b/scripts/uplot-compare/src/index.css
@@ -20,6 +20,10 @@
   row-gap: var(--compare-gap);
 }
 
+.wrap.wrap--actual-only {
+  flex-wrap: nowrap;
+}
+
 .compare-blocked {
   max-width: 56rem;
   padding: 1rem;
@@ -80,6 +84,18 @@
   cursor: pointer;
 }
 
+.compare-file-item-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.compare-file-name {
+  word-break: break-all;
+  min-width: 0;
+}
+
 .compare-file-modified {
   font-size: 11px;
   color: #5f6b7d;
@@ -90,10 +106,48 @@
   background: #eef4ff;
 }
 
+.compare-title-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 0.65rem 1rem;
+  margin-bottom: 0.75rem;
+}
+
 .compare-title {
-  margin: 0 0 0.75rem;
+  margin: 0;
   font-size: 1rem;
   font-weight: 600;
+}
+
+.compare-snapshot-status {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  padding: 0.2rem 0.5rem;
+  border-radius: 4px;
+  border: 1px solid #c8d1df;
+  background: #f1f5f9;
+  color: #475569;
+}
+
+.compare-snapshot-status.is-pass {
+  border-color: #86efac;
+  background: #ecfdf5;
+  color: #166534;
+}
+
+.compare-snapshot-status.is-fail {
+  border-color: #fca5a5;
+  background: #fef2f2;
+  color: #991b1b;
+}
+
+.compare-snapshot-status.is-compact {
+  font-size: 10px;
+  padding: 0.12rem 0.35rem;
+  flex-shrink: 0;
 }
 
 .plot-panel {

--- a/scripts/uplot-compare/src/testUtils.ts
+++ b/scripts/uplot-compare/src/testUtils.ts
@@ -12,3 +12,15 @@ export function isUPlotComparePayload(value: unknown): value is UPlotComparePayl
   const o = value as Record<string, unknown>;
   return typeof o.testName === 'string' && 'expected' in o && 'actual' in o;
 }
+
+/** Reads `snapshotAssertionPassed` from parsed payload JSON when present. */
+export function readSnapshotAssertionPassed(data: unknown): boolean | undefined {
+  if (!data || typeof data !== 'object') {
+    return undefined;
+  }
+  if (!('snapshotAssertionPassed' in data)) {
+    return undefined;
+  }
+  const v = data.snapshotAssertionPassed;
+  return typeof v === 'boolean' ? v : undefined;
+}

--- a/scripts/uplot-compare/src/types.ts
+++ b/scripts/uplot-compare/src/types.ts
@@ -13,6 +13,7 @@ export type ResolvedPayload = {
   uPlotCanvasEvents: CanvasRenderingContext2DEvent[];
   width?: number;
   height?: number;
+  snapshotAssertionPassed?: boolean;
 };
 
 export interface ComparePlotsProps {


### PR DESCRIPTION


**What is this feature?**

Add sort by date, status flag, and `GEN_CANVAS_OUTPUT_ON_PASS` env variable to provide visual output for passing tests.

<img width="1030" height="373" alt="image" src="https://github.com/user-attachments/assets/64c64f78-818b-4dca-a528-27bccd894b37" />


**Why do we need this feature?**

GEN_CANVAS_OUTPUT_ON_PASS: Make it easier to review and debug noop changes
Sort by date: so recent executions aren't buried
Status flag: so you can more easily jump to failed output when `GEN_CANVAS_OUTPUT_ON_PASS` is set

**Who is this feature for?**
Me, mostly

**Special notes for your reviewer:**
https://github.com/grafana/grafana/issues/123686

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
