### PR TITLE
docs: fix relative aliases in api docs

### DIFF
--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/access_control.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/access_control.md
@@ -1,8 +1,8 @@
 ---
 aliases:
-  - ../../../../http_api/access_control/ # /docs/grafana/<GRAFANA_VERSION>/http_api/access_control/
-  - ../../../../http_api/accesscontrol/ # /docs/grafana/<GRAFANA_VERSION>/http_api/accesscontrol/
-  - ../../../../developers/http_api/access_control/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/access_control/
+  - ../../../../http_api/access_control/ # /docs/grafana/next/http_api/access_control/
+  - ../../../../http_api/accesscontrol/ # /docs/grafana/next/http_api/accesscontrol/
+  - ../../../../developers/http_api/access_control/ # /docs/grafana/next/developers/http_api/access_control/
   - ../../../../developer-resources/api-reference/http-api/access-control/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/access_control/
 description: ''

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/access_control.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/access_control.md
@@ -1,8 +1,8 @@
 ---
 aliases:
-  - ../../../http_api/access_control/ # /docs/grafana/next/http_api/access_control/
-  - ../../../http_api/accesscontrol/ # /docs/grafana/next/http_api/accesscontrol/
-  - ../../../developers/http_api/access_control/ # /docs/grafana/next/developers/http_api/access_control/
+  - ../../../../http_api/access_control/ # /docs/grafana/<GRAFANA_VERSION>/http_api/access_control/
+  - ../../../../http_api/accesscontrol/ # /docs/grafana/<GRAFANA_VERSION>/http_api/accesscontrol/
+  - ../../../../developers/http_api/access_control/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/access_control/
   - ../../../../developer-resources/api-reference/http-api/access-control/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/access_control/
 description: ''

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/admin.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/admin.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - ../../../../http_api/admin/ # /docs/grafana/<GRAFANA_VERSION>/http_api/admin/
-  - ../../../../developers/http_api/admin/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/admin/
+  - ../../../../http_api/admin/ # /docs/grafana/next/http_api/admin/
+  - ../../../../developers/http_api/admin/ # /docs/grafana/next/developers/http_api/admin/
   - ../../../../developer-resources/api-reference/http-api/admin/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/admin/
 description: Grafana Admin HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/admin.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/admin.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - ../../../http-api/admin/ # /docs/grafana/next/http_api/admin/
-  - ../../../developers/http-api/admin/ # /docs/grafana/next/developers/http_api/admin/
+  - ../../../../http_api/admin/ # /docs/grafana/<GRAFANA_VERSION>/http_api/admin/
+  - ../../../../developers/http_api/admin/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/admin/
   - ../../../../developer-resources/api-reference/http-api/admin/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/admin/
 description: Grafana Admin HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/alerting_provisioning.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/alerting_provisioning.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - ../../../../http_api/alerting_provisioning/ # /docs/grafana/<GRAFANA_VERSION>/http_api/alerting_provisioning/
-  - ../../../../developers/http_api/alerting_provisioning/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/alerting_provisioning/
+  - ../../../../http_api/alerting_provisioning/ # /docs/grafana/next/http_api/alerting_provisioning/
+  - ../../../../developers/http_api/alerting_provisioning/ # /docs/grafana/next/developers/http_api/alerting_provisioning/
   - ../../../../developer-resources/api-reference/http-api/alerting_provisioning/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/alerting_provisioning/
 description: Grafana Alerts HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/alerting_provisioning.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/alerting_provisioning.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - ../../../http_api/alerting_provisioning/ # /docs/grafana/next/http_api/alerting_provisioning/
-  - ../../../developers/http_api/alerting_provisioning/ # /docs/grafana/next/developers/http_api/alerting_provisioning/
+  - ../../../../http_api/alerting_provisioning/ # /docs/grafana/<GRAFANA_VERSION>/http_api/alerting_provisioning/
+  - ../../../../developers/http_api/alerting_provisioning/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/alerting_provisioning/
   - ../../../../developer-resources/api-reference/http-api/alerting_provisioning/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/alerting_provisioning/
 description: Grafana Alerts HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/annotations.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/annotations.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - ../../../http_api/annotations/ # /docs/grafana/next/http_api/annotations/
-  - ../../../developers/http_api/annotations/ # /docs/grafana/next/developers/http_api/annotations/
+  - ../../../../http_api/annotations/ # /docs/grafana/<GRAFANA_VERSION>/http_api/annotations/
+  - ../../../../developers/http_api/annotations/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/annotations/
   - ../../../../developer-resources/api-reference/http-api/api-legacy/annotations/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/annotations/
 description: Grafana Annotations HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/annotations.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/annotations.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - ../../../../http_api/annotations/ # /docs/grafana/<GRAFANA_VERSION>/http_api/annotations/
-  - ../../../../developers/http_api/annotations/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/annotations/
+  - ../../../../http_api/annotations/ # /docs/grafana/next/http_api/annotations/
+  - ../../../../developers/http_api/annotations/ # /docs/grafana/next/developers/http_api/annotations/
   - ../../../../developer-resources/api-reference/http-api/api-legacy/annotations/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/annotations/
 description: Grafana Annotations HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/authentication.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/authentication.md
@@ -17,7 +17,7 @@ title: Authentication options for the HTTP API
 menuTitle: Authentication
 weight: 110
 aliases:
-  - ../../../developers/http_api/authentication/ # /docs/grafana/next/developers/http_api/authentication/
+  - ../../../../developers/http_api/authentication/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/authentication/
   - ../../../../developer-resources/api-reference/http-api/api-legacy/authentication/ #legacy folder
 ---
 

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/authentication.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/authentication.md
@@ -17,7 +17,7 @@ title: Authentication options for the HTTP API
 menuTitle: Authentication
 weight: 110
 aliases:
-  - ../../../../developers/http_api/authentication/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/authentication/
+  - ../../../../developers/http_api/authentication/ # /docs/grafana/next/developers/http_api/authentication/
   - ../../../../developer-resources/api-reference/http-api/api-legacy/authentication/ #legacy folder
 ---
 

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/correlations.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/correlations.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - ../../../http_api/correlations/ # /docs/grafana/next/http_api/correlations/
-  - ../../../developers/http_api/correlations/ # /docs/grafana/next/developers/http_api/correlations/
+  - ../../../../http_api/correlations/ # /docs/grafana/<GRAFANA_VERSION>/http_api/correlations/
+  - ../../../../developers/http_api/correlations/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/correlations/
   - ../../../../developer-resources/api-reference/http-api/correlations/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/correlations/
 description: Grafana Correlations HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/correlations.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/correlations.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - ../../../../http_api/correlations/ # /docs/grafana/<GRAFANA_VERSION>/http_api/correlations/
-  - ../../../../developers/http_api/correlations/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/correlations/
+  - ../../../../http_api/correlations/ # /docs/grafana/next/http_api/correlations/
+  - ../../../../developers/http_api/correlations/ # /docs/grafana/next/developers/http_api/correlations/
   - ../../../../developer-resources/api-reference/http-api/correlations/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/correlations/
 description: Grafana Correlations HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/dashboard_permissions.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/dashboard_permissions.md
@@ -1,8 +1,8 @@
 ---
 aliases:
-  - ../../../http_api/dashboard_permissions/ # /docs/grafana/next/http_api/dashboard_permissions/
-  - ../../../http_api/dashboardpermissions/ # /docs/grafana/next/http_api/dashboardpermissions/
-  - ../../../developers/http_api/dashboard_permissions/ # /docs/grafana/next/developers/http_api/dashboard_permissions/
+  - ../../../../http_api/dashboard_permissions/ # /docs/grafana/<GRAFANA_VERSION>/http_api/dashboard_permissions/
+  - ../../../../http_api/dashboardpermissions/ # /docs/grafana/<GRAFANA_VERSION>/http_api/dashboardpermissions/
+  - ../../../../developers/http_api/dashboard_permissions/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/dashboard_permissions/
   - ../../../../developer-resources/api-reference/http-api/dashboard_permissions/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/dashboard_permissions/
 description: Grafana Dashboard Permissions HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/dashboard_permissions.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/dashboard_permissions.md
@@ -1,8 +1,8 @@
 ---
 aliases:
-  - ../../../../http_api/dashboard_permissions/ # /docs/grafana/<GRAFANA_VERSION>/http_api/dashboard_permissions/
-  - ../../../../http_api/dashboardpermissions/ # /docs/grafana/<GRAFANA_VERSION>/http_api/dashboardpermissions/
-  - ../../../../developers/http_api/dashboard_permissions/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/dashboard_permissions/
+  - ../../../../http_api/dashboard_permissions/ # /docs/grafana/next/http_api/dashboard_permissions/
+  - ../../../../http_api/dashboardpermissions/ # /docs/grafana/next/http_api/dashboardpermissions/
+  - ../../../../developers/http_api/dashboard_permissions/ # /docs/grafana/next/developers/http_api/dashboard_permissions/
   - ../../../../developer-resources/api-reference/http-api/dashboard_permissions/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/dashboard_permissions/
 description: Grafana Dashboard Permissions HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/dashboard_public.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/dashboard_public.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - ../../../../http_api/dashboard_public/ # /docs/grafana/<GRAFANA_VERSION>/http_api/dashboard_public/
-  - ../../../../developers/http_api/dashboard_public/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/dashboard_public/
+  - ../../../../http_api/dashboard_public/ # /docs/grafana/next/http_api/dashboard_public/
+  - ../../../../developers/http_api/dashboard_public/ # /docs/grafana/next/developers/http_api/dashboard_public/
   - ../../../../developer-resources/api-reference/http-api/dashboard_public/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/dashboard_public/
 description: Grafana Shared Dashboards HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/dashboard_public.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/dashboard_public.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - ../../../http_api/dashboard_public/ # /docs/grafana/next/http_api/dashboard_public/
-  - ../../../developers/http_api/dashboard_public/ # /docs/grafana/next/developers/http_api/dashboard_public/
+  - ../../../../http_api/dashboard_public/ # /docs/grafana/<GRAFANA_VERSION>/http_api/dashboard_public/
+  - ../../../../developers/http_api/dashboard_public/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/dashboard_public/
   - ../../../../developer-resources/api-reference/http-api/dashboard_public/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/dashboard_public/
 description: Grafana Shared Dashboards HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/dashboard_versions.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/dashboard_versions.md
@@ -1,8 +1,8 @@
 ---
 aliases:
-  - ../../../../http_api/dashboard_versions/ # /docs/grafana/<GRAFANA_VERSION>/http_api/dashboard_versions/
-  - ../../../../http_api/dashboardversions/ # /docs/grafana/<GRAFANA_VERSION>/http_api/dashboardversions/
-  - ../../../../developers/http_api/dashboard_versions/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/dashboard_versions/
+  - ../../../../http_api/dashboard_versions/ # /docs/grafana/next/http_api/dashboard_versions/
+  - ../../../../http_api/dashboardversions/ # /docs/grafana/next/http_api/dashboardversions/
+  - ../../../../developers/http_api/dashboard_versions/ # /docs/grafana/next/developers/http_api/dashboard_versions/
   - ../../../../developer-resources/api-reference/http-api/dashboard_versions/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/dashboard_versions/
 description: Grafana Dashboard Versions HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/dashboard_versions.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/dashboard_versions.md
@@ -1,8 +1,8 @@
 ---
 aliases:
-  - ../../../http_api/dashboard_versions/ # /docs/grafana/next/http_api/dashboard_versions/
-  - ../../../http_api/dashboardversions/ # /docs/grafana/next/http_api/dashboardversions/
-  - ../../../developers/http_api/dashboard_versions/ # /docs/grafana/next/developers/http_api/dashboard_versions/
+  - ../../../../http_api/dashboard_versions/ # /docs/grafana/<GRAFANA_VERSION>/http_api/dashboard_versions/
+  - ../../../../http_api/dashboardversions/ # /docs/grafana/<GRAFANA_VERSION>/http_api/dashboardversions/
+  - ../../../../developers/http_api/dashboard_versions/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/dashboard_versions/
   - ../../../../developer-resources/api-reference/http-api/dashboard_versions/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/dashboard_versions/
 description: Grafana Dashboard Versions HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/data_source.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/data_source.md
@@ -1,8 +1,8 @@
 ---
 aliases:
-  - ../../../../http_api/data_source/ # /docs/grafana/<GRAFANA_VERSION>/http_api/data_source/
-  - ../../../../http_api/datasource/ # /docs/grafana/<GRAFANA_VERSION>/http_api/datasource/
-  - ../../../../developers/http_api/data_source/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/data_source/
+  - ../../../../http_api/data_source/ # /docs/grafana/next/http_api/data_source/
+  - ../../../../http_api/datasource/ # /docs/grafana/next/http_api/datasource/
+  - ../../../../developers/http_api/data_source/ # /docs/grafana/next/developers/http_api/data_source/
   - ../../../../developer-resources/api-reference/http-api/data_source/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/data_source/
 description: Grafana Data source HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/data_source.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/data_source.md
@@ -1,8 +1,8 @@
 ---
 aliases:
-  - ../../../http_api/data_source/ # /docs/grafana/next/http_api/data_source/
-  - ../../../http_api/datasource/ # /docs/grafana/next/http_api/datasource/
-  - ../../../developers/http_api/data_source/ # /docs/grafana/next/developers/http_api/data_source/
+  - ../../../../http_api/data_source/ # /docs/grafana/<GRAFANA_VERSION>/http_api/data_source/
+  - ../../../../http_api/datasource/ # /docs/grafana/<GRAFANA_VERSION>/http_api/datasource/
+  - ../../../../developers/http_api/data_source/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/data_source/
   - ../../../../developer-resources/api-reference/http-api/data_source/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/data_source/
 description: Grafana Data source HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/datasource_lbac_rules.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/datasource_lbac_rules.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - ../../../http_api/datasource_lbac_rules/ # /docs/grafana/next/http_api/datasource_lbac_rules/
-  - ../../../developers/http_api/datasource_lbac_rules/ # /docs/grafana/next/developers/http_api/datasource_lbac_rules/
+  - ../../../../http_api/datasource_lbac_rules/ # /docs/grafana/<GRAFANA_VERSION>/http_api/datasource_lbac_rules/
+  - ../../../../developers/http_api/datasource_lbac_rules/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/datasource_lbac_rules/
   - ../../../../developer-resources/api-reference/http-api/datasource_lbac_rules/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/datasource_lbac_rules/
 description: Data Source LBAC rules API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/datasource_lbac_rules.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/datasource_lbac_rules.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - ../../../../http_api/datasource_lbac_rules/ # /docs/grafana/<GRAFANA_VERSION>/http_api/datasource_lbac_rules/
-  - ../../../../developers/http_api/datasource_lbac_rules/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/datasource_lbac_rules/
+  - ../../../../http_api/datasource_lbac_rules/ # /docs/grafana/next/http_api/datasource_lbac_rules/
+  - ../../../../developers/http_api/datasource_lbac_rules/ # /docs/grafana/next/developers/http_api/datasource_lbac_rules/
   - ../../../../developer-resources/api-reference/http-api/datasource_lbac_rules/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/datasource_lbac_rules/
 description: Data Source LBAC rules API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/datasource_permissions.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/datasource_permissions.md
@@ -1,8 +1,8 @@
 ---
 aliases:
-  - ../../../../http_api/datasource_permissions/ # /docs/grafana/<GRAFANA_VERSION>/http_api/datasource_permissions/
-  - ../../../../http_api/datasourcepermissions/ # /docs/grafana/<GRAFANA_VERSION>/http_api/datasourcepermissions/
-  - ../../../../developers/http_api/datasource_permissions/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/datasource_permissions/
+  - ../../../../http_api/datasource_permissions/ # /docs/grafana/next/http_api/datasource_permissions/
+  - ../../../../http_api/datasourcepermissions/ # /docs/grafana/next/http_api/datasourcepermissions/
+  - ../../../../developers/http_api/datasource_permissions/ # /docs/grafana/next/developers/http_api/datasource_permissions/
   - ../../../../developer-resources/api-reference/http-api/datasource_permissions/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/datasource_permissions/
 description: Data Source Permissions API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/datasource_permissions.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/datasource_permissions.md
@@ -1,8 +1,8 @@
 ---
 aliases:
-  - ../../../http_api/datasource_permissions/ # /docs/grafana/next/http_api/datasource_permissions/
-  - ../../../http_api/datasourcepermissions/ # /docs/grafana/next/http_api/datasourcepermissions/
-  - ../../../developers/http_api/datasource_permissions/ # /docs/grafana/next/developers/http_api/datasource_permissions/
+  - ../../../../http_api/datasource_permissions/ # /docs/grafana/<GRAFANA_VERSION>/http_api/datasource_permissions/
+  - ../../../../http_api/datasourcepermissions/ # /docs/grafana/<GRAFANA_VERSION>/http_api/datasourcepermissions/
+  - ../../../../developers/http_api/datasource_permissions/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/datasource_permissions/
   - ../../../../developer-resources/api-reference/http-api/datasource_permissions/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/datasource_permissions/
 description: Data Source Permissions API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/folder_dashboard_search.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/folder_dashboard_search.md
@@ -1,8 +1,7 @@
 ---
 aliases:
-  - ../../../http_api/folder_dashboard_search/ # /docs/grafana/next/http_api/folder_dashboard_search/
-  - ../../../developers/http_api/folder_dashboard_search/ # /docs/grafana/next/developers/http_api/folder_dashboard_search/
-  - ../../../../developers/http_api/folder_dashboard_search/ # /docs/grafana/next/developers/http_api/folder_dashboard_search/
+  - ../../../../http_api/folder_dashboard_search/ # /docs/grafana/<GRAFANA_VERSION>/http_api/folder_dashboard_search/
+  - ../../../../developers/http_api/folder_dashboard_search/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/folder_dashboard_search/
   - ../../../../developer-resources/api-reference/http-api/folder_dashboard_search/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/folder_dashboard_search/
 description: Grafana Folder/Dashboard Search HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/folder_dashboard_search.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/folder_dashboard_search.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - ../../../../http_api/folder_dashboard_search/ # /docs/grafana/<GRAFANA_VERSION>/http_api/folder_dashboard_search/
-  - ../../../../developers/http_api/folder_dashboard_search/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/folder_dashboard_search/
+  - ../../../../http_api/folder_dashboard_search/ # /docs/grafana/next/http_api/folder_dashboard_search/
+  - ../../../../developers/http_api/folder_dashboard_search/ # /docs/grafana/next/developers/http_api/folder_dashboard_search/
   - ../../../../developer-resources/api-reference/http-api/folder_dashboard_search/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/folder_dashboard_search/
 description: Grafana Folder/Dashboard Search HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/folder_permissions.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/folder_permissions.md
@@ -1,8 +1,8 @@
 ---
 aliases:
-  - ../../../http_api/dashboardpermissions/ # /docs/grafana/next/http_api/dashboardpermissions/
-  - ../../../http_api/folder_permissions/ # /docs/grafana/next/http_api/folder_permissions/
-  - ../../../developers/http_api/folder_permissions/ # /docs/grafana/next/developers/http_api/folder_permissions/
+  - ../../../../http_api/dashboardpermissions/ # /docs/grafana/<GRAFANA_VERSION>/http_api/dashboardpermissions/
+  - ../../../../http_api/folder_permissions/ # /docs/grafana/<GRAFANA_VERSION>/http_api/folder_permissions/
+  - ../../../../developers/http_api/folder_permissions/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/folder_permissions/
   - ../../../../developer-resources/api-reference/http-api/folder_permissions/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/folder_permissions/
 description: Grafana Folder Permissions HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/folder_permissions.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/folder_permissions.md
@@ -1,8 +1,8 @@
 ---
 aliases:
-  - ../../../../http_api/dashboardpermissions/ # /docs/grafana/<GRAFANA_VERSION>/http_api/dashboardpermissions/
-  - ../../../../http_api/folder_permissions/ # /docs/grafana/<GRAFANA_VERSION>/http_api/folder_permissions/
-  - ../../../../developers/http_api/folder_permissions/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/folder_permissions/
+  - ../../../../http_api/dashboardpermissions/ # /docs/grafana/next/http_api/dashboardpermissions/
+  - ../../../../http_api/folder_permissions/ # /docs/grafana/next/http_api/folder_permissions/
+  - ../../../../developers/http_api/folder_permissions/ # /docs/grafana/next/developers/http_api/folder_permissions/
   - ../../../../developer-resources/api-reference/http-api/folder_permissions/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/folder_permissions/
 description: Grafana Folder Permissions HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/library_element.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/library_element.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - ../../../../http_api/library_element/ # /docs/grafana/<GRAFANA_VERSION>/http_api/library_element/
-  - ../../../../developers/http_api/library_element/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/library_element/
+  - ../../../../http_api/library_element/ # /docs/grafana/next/http_api/library_element/
+  - ../../../../developers/http_api/library_element/ # /docs/grafana/next/developers/http_api/library_element/
   - ../../../../developer-resources/api-reference/http-api/library_element/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/library_element/
 description: Grafana Library Element HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/library_element.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/library_element.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - ../../../http_api/library_element/ # /docs/grafana/next/http_api/library_element/
-  - ../../../developers/http_api/library_element/ # /docs/grafana/next/developers/http_api/library_element/
+  - ../../../../http_api/library_element/ # /docs/grafana/<GRAFANA_VERSION>/http_api/library_element/
+  - ../../../../developers/http_api/library_element/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/library_element/
   - ../../../../developer-resources/api-reference/http-api/library_element/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/library_element/
 description: Grafana Library Element HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/licensing.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/licensing.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - ../../../http_api/licensing/ # /docs/grafana/next/http_api/licensing/
-  - ../../../developers/http_api/licensing/ # /docs/grafana/next/developers/http_api/licensing/
+  - ../../../../http_api/licensing/ # /docs/grafana/<GRAFANA_VERSION>/http_api/licensing/
+  - ../../../../developers/http_api/licensing/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/licensing/
   - ../../../../developer-resources/api-reference/http-api/licensing/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/licensing/
 description: Enterprise Licensing HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/licensing.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/licensing.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - ../../../../http_api/licensing/ # /docs/grafana/<GRAFANA_VERSION>/http_api/licensing/
-  - ../../../../developers/http_api/licensing/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/licensing/
+  - ../../../../http_api/licensing/ # /docs/grafana/next/http_api/licensing/
+  - ../../../../developers/http_api/licensing/ # /docs/grafana/next/developers/http_api/licensing/
   - ../../../../developer-resources/api-reference/http-api/licensing/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/licensing/
 description: Enterprise Licensing HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/org.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/org.md
@@ -1,8 +1,8 @@
 ---
 aliases:
-  - ../../../../http_api/org/ # /docs/grafana/<GRAFANA_VERSION>/http_api/org/
-  - ../../../../http_api/organization/ # /docs/grafana/<GRAFANA_VERSION>/http_api/organization/
-  - ../../../../developers/http_api/org/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/org/
+  - ../../../../http_api/org/ # /docs/grafana/next/http_api/org/
+  - ../../../../http_api/organization/ # /docs/grafana/next/http_api/organization/
+  - ../../../../developers/http_api/org/ # /docs/grafana/next/developers/http_api/org/
   - ../../../../developer-resources/api-reference/http-api/org/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/org/
 description: Grafana Organization HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/org.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/org.md
@@ -1,8 +1,8 @@
 ---
 aliases:
-  - ../../../http_api/org/ # /docs/grafana/next/http_api/org/
-  - ../../../http_api/organization/ # /docs/grafana/next/http_api/organization/
-  - ../../../developers/http_api/org/ # /docs/grafana/next/developers/http_api/org/
+  - ../../../../http_api/org/ # /docs/grafana/<GRAFANA_VERSION>/http_api/org/
+  - ../../../../http_api/organization/ # /docs/grafana/<GRAFANA_VERSION>/http_api/organization/
+  - ../../../../developers/http_api/org/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/org/
   - ../../../../developer-resources/api-reference/http-api/org/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/org/
 description: Grafana Organization HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/other.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/other.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - ../../../http_api/other/ # /docs/grafana/next/http_api/other/
-  - ../../../developers/http_api/other/ # /docs/grafana/next/developers/http_api/other/
+  - ../../../../http_api/other/ # /docs/grafana/<GRAFANA_VERSION>/http_api/other/
+  - ../../../../developers/http_api/other/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/other/
   - ../../../../developer-resources/api-reference/http-api/other/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/other/
 description: Grafana Other HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/other.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/other.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - ../../../../http_api/other/ # /docs/grafana/<GRAFANA_VERSION>/http_api/other/
-  - ../../../../developers/http_api/other/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/other/
+  - ../../../../http_api/other/ # /docs/grafana/next/http_api/other/
+  - ../../../../developers/http_api/other/ # /docs/grafana/next/developers/http_api/other/
   - ../../../../developer-resources/api-reference/http-api/other/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/other/
 description: Grafana Other HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/preferences.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/preferences.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - ../../../../http_api/preferences/ # /docs/grafana/<GRAFANA_VERSION>/http_api/preferences/
-  - ../../../../developers/http_api/preferences/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/preferences/
+  - ../../../../http_api/preferences/ # /docs/grafana/next/http_api/preferences/
+  - ../../../../developers/http_api/preferences/ # /docs/grafana/next/developers/http_api/preferences/
   - ../../../../developer-resources/api-reference/http-api/preferences/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/preferences/
 description: Grafana HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/preferences.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/preferences.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - ../../../http_api/preferences/ # /docs/grafana/next/http_api/preferences/
-  - ../../../developers/http_api/preferences/ # /docs/grafana/next/developers/http_api/preferences/
+  - ../../../../http_api/preferences/ # /docs/grafana/<GRAFANA_VERSION>/http_api/preferences/
+  - ../../../../developers/http_api/preferences/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/preferences/
   - ../../../../developer-resources/api-reference/http-api/preferences/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/preferences/
 description: Grafana HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/query_and_resource_caching.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/query_and_resource_caching.md
@@ -1,9 +1,9 @@
 ---
 aliases:
-  - ../../../http_api/query_caching/ # /docs/grafana/next/http_api/query_caching/
-  - ../../../http_api/resource_caching/ # /docs/grafana/next/http_api/resource_caching/
-  - ../../../http_api/caching/ # /docs/grafana/next/http_api/caching/
-  - ../../../developers/http_api/query_and_resource_caching/ # /docs/grafana/next/developers/http_api/query_and_resource_caching/
+  - ../../../../http_api/query_caching/ # /docs/grafana/<GRAFANA_VERSION>/http_api/query_caching/
+  - ../../../../http_api/resource_caching/ # /docs/grafana/<GRAFANA_VERSION>/http_api/resource_caching/
+  - ../../../../http_api/caching/ # /docs/grafana/<GRAFANA_VERSION>/http_api/caching/
+  - ../../../../developers/http_api/query_and_resource_caching/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/query_and_resource_caching/
   - ../../../../developer-resources/api-reference/http-api/query_and_resource_caching/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/query_and_resource_caching/
 description: Grafana Enterprise Query and Resource Caching HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/query_and_resource_caching.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/query_and_resource_caching.md
@@ -1,9 +1,9 @@
 ---
 aliases:
-  - ../../../../http_api/query_caching/ # /docs/grafana/<GRAFANA_VERSION>/http_api/query_caching/
-  - ../../../../http_api/resource_caching/ # /docs/grafana/<GRAFANA_VERSION>/http_api/resource_caching/
-  - ../../../../http_api/caching/ # /docs/grafana/<GRAFANA_VERSION>/http_api/caching/
-  - ../../../../developers/http_api/query_and_resource_caching/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/query_and_resource_caching/
+  - ../../../../http_api/query_caching/ # /docs/grafana/next/http_api/query_caching/
+  - ../../../../http_api/resource_caching/ # /docs/grafana/next/http_api/resource_caching/
+  - ../../../../http_api/caching/ # /docs/grafana/next/http_api/caching/
+  - ../../../../developers/http_api/query_and_resource_caching/ # /docs/grafana/next/developers/http_api/query_and_resource_caching/
   - ../../../../developer-resources/api-reference/http-api/query_and_resource_caching/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/query_and_resource_caching/
 description: Grafana Enterprise Query and Resource Caching HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/query_history.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/query_history.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - ../../../../http_api/query_history/ # /docs/grafana/<GRAFANA_VERSION>/http_api/query_history/
-  - ../../../../developers/http_api/query_history/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/query_history/
+  - ../../../../http_api/query_history/ # /docs/grafana/next/http_api/query_history/
+  - ../../../../developers/http_api/query_history/ # /docs/grafana/next/developers/http_api/query_history/
   - ../../../../developer-resources/api-reference/http-api/query_history/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/query_history/
 description: Grafana Query History HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/query_history.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/query_history.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - ../../../http_api/query_history/ # /docs/grafana/next/http_api/query_history/
-  - ../../../developers/http_api/query_history/ # /docs/grafana/next/developers/http_api/query_history/
+  - ../../../../http_api/query_history/ # /docs/grafana/<GRAFANA_VERSION>/http_api/query_history/
+  - ../../../../developers/http_api/query_history/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/query_history/
   - ../../../../developer-resources/api-reference/http-api/query_history/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/query_history/
 description: Grafana Query History HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/reporting.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/reporting.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - ../../../http_api/reporting/ # /docs/grafana/next/http_api/reporting/
-  - ../../../developers/http_api/reporting/ # /docs/grafana/next/developers/http_api/reporting/
+  - ../../../../http_api/reporting/ # /docs/grafana/<GRAFANA_VERSION>/http_api/reporting/
+  - ../../../../developers/http_api/reporting/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/reporting/
   - ../../../../developer-resources/api-reference/http-api/reporting/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/reporting/
 description: Grafana Enterprise APIs

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/reporting.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/reporting.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - ../../../../http_api/reporting/ # /docs/grafana/<GRAFANA_VERSION>/http_api/reporting/
-  - ../../../../developers/http_api/reporting/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/reporting/
+  - ../../../../http_api/reporting/ # /docs/grafana/next/http_api/reporting/
+  - ../../../../developers/http_api/reporting/ # /docs/grafana/next/developers/http_api/reporting/
   - ../../../../developer-resources/api-reference/http-api/reporting/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/reporting/
 description: Grafana Enterprise APIs

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/serviceaccount.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/serviceaccount.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - ../../../../http_api/serviceaccount/ # /docs/grafana/<GRAFANA_VERSION>/http_api/serviceaccount/
-  - ../../../../developers/http_api/serviceaccount/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/serviceaccount/
+  - ../../../../http_api/serviceaccount/ # /docs/grafana/next/http_api/serviceaccount/
+  - ../../../../developers/http_api/serviceaccount/ # /docs/grafana/next/developers/http_api/serviceaccount/
   - ../../../../developer-resources/api-reference/http-api/serviceaccount/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/serviceaccount/
 description: Grafana service account HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/serviceaccount.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/serviceaccount.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - ../../../http_api/serviceaccount/ # /docs/grafana/next/http_api/serviceaccount/
-  - ../../../developers/http_api/serviceaccount/ # /docs/grafana/next/developers/http_api/serviceaccount/
+  - ../../../../http_api/serviceaccount/ # /docs/grafana/<GRAFANA_VERSION>/http_api/serviceaccount/
+  - ../../../../developers/http_api/serviceaccount/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/serviceaccount/
   - ../../../../developer-resources/api-reference/http-api/serviceaccount/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/serviceaccount/
 description: Grafana service account HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/short_url.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/short_url.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - ../../../../http_api/short_url/ # /docs/grafana/<GRAFANA_VERSION>/http_api/short_url/
-  - ../../../../developers/http_api/short_url/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/short_url/
+  - ../../../../http_api/short_url/ # /docs/grafana/next/http_api/short_url/
+  - ../../../../developers/http_api/short_url/ # /docs/grafana/next/developers/http_api/short_url/
   - ../../../../developer-resources/api-reference/http-api/short_url/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/short_url/
 description: Grafana Short URL HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/short_url.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/short_url.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - ../../../http_api/short_url/ # /docs/grafana/next/http_api/short_url/
-  - ../../../developers/http_api/short_url/ # /docs/grafana/next/developers/http_api/short_url/
+  - ../../../../http_api/short_url/ # /docs/grafana/<GRAFANA_VERSION>/http_api/short_url/
+  - ../../../../developers/http_api/short_url/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/short_url/
   - ../../../../developer-resources/api-reference/http-api/short_url/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/short_url/
 description: Grafana Short URL HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/snapshot.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/snapshot.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - ../../../../http_api/snapshot/ # /docs/grafana/<GRAFANA_VERSION>/http_api/snapshot/
-  - ../../../../developers/http_api/snapshot/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/snapshot/
+  - ../../../../http_api/snapshot/ # /docs/grafana/next/http_api/snapshot/
+  - ../../../../developers/http_api/snapshot/ # /docs/grafana/next/developers/http_api/snapshot/
   - ../../../../developer-resources/api-reference/http-api/snapshot/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/snapshot/
 description: Grafana HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/snapshot.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/snapshot.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - ../../../http_api/snapshot/ # /docs/grafana/next/http_api/snapshot/
-  - ../../../developers/http_api/snapshot/ # /docs/grafana/next/developers/http_api/snapshot/
+  - ../../../../http_api/snapshot/ # /docs/grafana/<GRAFANA_VERSION>/http_api/snapshot/
+  - ../../../../developers/http_api/snapshot/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/snapshot/
   - ../../../../developer-resources/api-reference/http-api/snapshot/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/snapshot/
 description: Grafana HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/sso-settings.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/sso-settings.md
@@ -1,8 +1,8 @@
 ---
 aliases:
-  - ../../../http_api/sso-settings/ # /docs/grafana/next/http_api/sso-settings/
-  - ../../../http_api/ssosettings/ # /docs/grafana/next/http_api/ssosettings/
-  - ../../../developers/http_api/sso-settings/ # /docs/grafana/next/developers/http_api/sso-settings/
+  - ../../../../http_api/sso-settings/ # /docs/grafana/<GRAFANA_VERSION>/http_api/sso-settings/
+  - ../../../../http_api/ssosettings/ # /docs/grafana/<GRAFANA_VERSION>/http_api/ssosettings/
+  - ../../../../developers/http_api/sso-settings/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/sso-settings/
   - ../../../../developer-resources/api-reference/http-api/sso-settings/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/sso-settings/
 description: Grafana SSO Settings API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/sso-settings.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/sso-settings.md
@@ -1,8 +1,8 @@
 ---
 aliases:
-  - ../../../../http_api/sso-settings/ # /docs/grafana/<GRAFANA_VERSION>/http_api/sso-settings/
-  - ../../../../http_api/ssosettings/ # /docs/grafana/<GRAFANA_VERSION>/http_api/ssosettings/
-  - ../../../../developers/http_api/sso-settings/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/sso-settings/
+  - ../../../../http_api/sso-settings/ # /docs/grafana/next/http_api/sso-settings/
+  - ../../../../http_api/ssosettings/ # /docs/grafana/next/http_api/ssosettings/
+  - ../../../../developers/http_api/sso-settings/ # /docs/grafana/next/developers/http_api/sso-settings/
   - ../../../../developer-resources/api-reference/http-api/sso-settings/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/sso-settings/
 description: Grafana SSO Settings API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/team.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/team.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - ../../../http_api/team/ # /docs/grafana/next/http_api/team/
-  - ../../../developers/http_api/team/ # /docs/grafana/next/developers/http_api/team/
+  - ../../../../http_api/team/ # /docs/grafana/<GRAFANA_VERSION>/http_api/team/
+  - ../../../../developers/http_api/team/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/team/
   - ../../../../developer-resources/api-reference/http-api/team/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/team/
 description: Grafana Team HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/team.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/team.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - ../../../../http_api/team/ # /docs/grafana/<GRAFANA_VERSION>/http_api/team/
-  - ../../../../developers/http_api/team/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/team/
+  - ../../../../http_api/team/ # /docs/grafana/next/http_api/team/
+  - ../../../../developers/http_api/team/ # /docs/grafana/next/developers/http_api/team/
   - ../../../../developer-resources/api-reference/http-api/team/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/team/
 description: Grafana Team HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/team_sync.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/team_sync.md
@@ -1,8 +1,8 @@
 ---
 aliases:
-  - ../../../../http_api/external_group_sync/ # /docs/grafana/<GRAFANA_VERSION>/http_api/external_group_sync/
-  - ../../../../developers/http_api/external_group_sync/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/external_group_sync/
-  - ../../../../developers/http_api/team_sync/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/team_sync/
+  - ../../../../http_api/external_group_sync/ # /docs/grafana/next/http_api/external_group_sync/
+  - ../../../../developers/http_api/external_group_sync/ # /docs/grafana/next/developers/http_api/external_group_sync/
+  - ../../../../developers/http_api/team_sync/ # /docs/grafana/next/developers/http_api/team_sync/
   - ../../../../developer-resources/api-reference/http-api/team_sync/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/team_sync/
 description: Grafana Team Sync HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/team_sync.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/team_sync.md
@@ -1,8 +1,8 @@
 ---
 aliases:
-  - ../../../http_api/external_group_sync/ # /docs/grafana/next/http_api/external_group_sync/
-  - ../../../developers/http_api/external_group_sync/ # /docs/grafana/next/developers/http_api/external_group_sync/
-  - ../../../developers/http_api/team_sync/ # /docs/grafana/next/developers/http_api/team_sync/
+  - ../../../../http_api/external_group_sync/ # /docs/grafana/<GRAFANA_VERSION>/http_api/external_group_sync/
+  - ../../../../developers/http_api/external_group_sync/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/external_group_sync/
+  - ../../../../developers/http_api/team_sync/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/team_sync/
   - ../../../../developer-resources/api-reference/http-api/team_sync/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/team_sync/
 description: Grafana Team Sync HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/user.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/user.md
@@ -1,7 +1,7 @@
 ---
 aliases:
-  - ../../../../http_api/user/ # /docs/grafana/<GRAFANA_VERSION>/http_api/user/
-  - ../../../../developers/http_api/user/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/user/
+  - ../../../../http_api/user/ # /docs/grafana/next/http_api/user/
+  - ../../../../developers/http_api/user/ # /docs/grafana/next/developers/http_api/user/
   - ../../../../developer-resources/api-reference/http-api/user/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/user/
 description: Grafana User HTTP API

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/user.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/user.md
@@ -1,8 +1,8 @@
 ---
 aliases:
-  - ../../../http_api/user/ # /docs/grafana/next/http_api/user/
-  - ../../../developers/http_api/user/ # /docs/grafana/next/developers/http_api/user/
-  - ../../../../developer-resources/api-reference/http-api/user #legacy folder
+  - ../../../../http_api/user/ # /docs/grafana/<GRAFANA_VERSION>/http_api/user/
+  - ../../../../developers/http_api/user/ # /docs/grafana/<GRAFANA_VERSION>/developers/http_api/user/
+  - ../../../../developer-resources/api-reference/http-api/user/ #legacy folder
 canonical: https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/api-legacy/user/
 description: Grafana User HTTP API
 keywords:


### PR DESCRIPTION
**What is this feature?**

Adjusts relative aliases across API docs that broke when they were moved to `api-legacy`

**Why do we need this feature?**

So links resolve correctly

**Who is this feature for?**

All users of Grafana API docs