### PR TITLE
unified-storage: retry on conflicts in Badger KV

### DIFF
--- a/pkg/storage/unified/resource/kv/kv.go
+++ b/pkg/storage/unified/resource/kv/kv.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"iter"
+	"math/rand"
 	"regexp"
 	"time"
 
@@ -444,6 +445,31 @@ func (k *badgerKV) Batch(ctx context.Context, section string, ops []BatchOp) err
 		return fmt.Errorf("too many operations: %d > %d", len(ops), MaxBatchOps)
 	}
 
+	// Retry the batch operation up to `maxAttempts` times in case of conflict, with a
+	// random delay between retries to increase the chances of success. Badger will
+	// fail the `Commit()` call on the transaction if a conflict is detected internally,
+	// which can happen if multiple callers are trying to apply a similar batch of
+	// operations at the same time.
+	const maxAttempts = 5
+	const maxRetryJitter = 100 * time.Millisecond
+	var lastConflict error
+	for attempt := range maxAttempts {
+		err := k.batchOnce(section, ops)
+		if errors.Is(err, badger.ErrConflict) {
+			lastConflict = err
+			if attempt < maxAttempts-1 {
+				if err := sleepWithJitter(ctx, maxRetryJitter); err != nil {
+					return err
+				}
+			}
+			continue
+		}
+		return err
+	}
+	return fmt.Errorf("after %d attempts: %w", maxAttempts, lastConflict)
+}
+
+func (k *badgerKV) batchOnce(section string, ops []BatchOp) error {
 	txn := k.db.NewTransaction(true)
 	defer txn.Discard()
 
@@ -504,4 +530,17 @@ func (k *badgerKV) Batch(ctx context.Context, section string, ops []BatchOp) err
 	}
 
 	return txn.Commit()
+}
+
+func sleepWithJitter(ctx context.Context, max time.Duration) error {
+	delay := time.Duration(rand.Int63n(int64(max) + 1))
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		return nil
+	}
 }

--- a/pkg/storage/unified/resource/kv/kv_test.go
+++ b/pkg/storage/unified/resource/kv/kv_test.go
@@ -2,8 +2,10 @@ package kv
 
 import (
 	"context"
+	"errors"
 	"io"
 	"strings"
+	"sync"
 	"testing"
 
 	badger "github.com/dgraph-io/badger/v4"
@@ -459,6 +461,45 @@ func TestBadgerKV_Batch(t *testing.T) {
 		require.NoError(t, err)
 		b, _ := io.ReadAll(val)
 		require.Equal(t, "v2", string(b))
+	})
+
+	t.Run("concurrent create reports key exists instead of badger conflict", func(t *testing.T) {
+		const rounds = 5
+		const goroutines = 10
+
+		for round := range rounds {
+			key := "create-race-" + string(rune('a'+round))
+
+			var wg sync.WaitGroup
+			start := make(chan struct{})
+			errs := make(chan error, goroutines)
+
+			for range goroutines {
+				wg.Go(func() {
+					<-start
+					errs <- kv.Batch(ctx, section, []BatchOp{
+						{Mode: BatchOpCreate, Key: key, Value: []byte("created")},
+					})
+				})
+			}
+
+			close(start)
+			wg.Wait()
+			close(errs)
+
+			var successes int
+			for err := range errs {
+				switch {
+				case err == nil:
+					successes++
+				case errors.Is(err, ErrKeyAlreadyExists):
+					// expected
+				default:
+					require.NoError(t, err, "unexpected error from concurrent Batch")
+				}
+			}
+			require.Equal(t, 1, successes, "only one writer should succeed")
+		}
 	})
 }
 


### PR DESCRIPTION
Adds an internal retry mechanism on Badger's `Batch` implementation to handle conflicts. With the randomized delay between retries, this eliminates (with high probability) the need for caller retries, not specified in the KV interface.