### PR TITLE
Provisioning: Hide stepper on onboarding wizard when screen is smaller

### DIFF
--- a/public/app/features/provisioning/Wizard/ProvisioningWizard.tsx
+++ b/public/app/features/provisioning/Wizard/ProvisioningWizard.tsx
@@ -198,10 +198,10 @@ export const ProvisioningWizard = memo(function ProvisioningWizard({
   return (
     <FormProvider {...methods}>
       <Stack gap={6} direction="row" alignItems="flex-start">
-        <>
+        <div className={styles.stepperWrapper}>
           <Stepper steps={wizardSteps} activeStep={activeStep} visitedSteps={completedSteps} />
           <div className={styles.divider} />
-        </>
+        </div>
         <form onSubmit={handleSubmit(onFormSubmit)} className={styles.form}>
           <FormPrompt
             onDiscard={onDiscard}
@@ -268,6 +268,14 @@ const getStyles = (theme: GrafanaTheme2) => ({
   form: css({
     maxWidth: '900px',
     flexGrow: 1,
+  }),
+  stepperWrapper: css({
+    display: 'flex',
+    flexDirection: 'row',
+    alignItems: 'flex-start',
+    [theme.breakpoints.down('md')]: {
+      display: 'none',
+    },
   }),
   divider: css({
     width: 1,

--- a/public/app/features/provisioning/Wizard/ProvisioningWizard.tsx
+++ b/public/app/features/provisioning/Wizard/ProvisioningWizard.tsx
@@ -270,9 +270,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
     flexGrow: 1,
   }),
   stepperWrapper: css({
-    display: 'flex',
-    flexDirection: 'row',
-    alignItems: 'flex-start',
     [theme.breakpoints.down('md')]: {
       display: 'none',
     },

--- a/public/app/features/provisioning/Wizard/ProvisioningWizard.tsx
+++ b/public/app/features/provisioning/Wizard/ProvisioningWizard.tsx
@@ -268,6 +268,10 @@ const getStyles = (theme: GrafanaTheme2) => ({
   form: css({
     maxWidth: '900px',
     flexGrow: 1,
+    [theme.breakpoints.down('md')]: {
+      maxWidth: '100%',
+      minWidth: 0,
+    },
   }),
   stepperWrapper: css({
     [theme.breakpoints.down('md')]: {
@@ -288,5 +292,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
     borderBottom: `1px solid ${theme.colors.border.weak}`,
     paddingBottom: theme.spacing(4),
     marginBottom: theme.spacing(4),
+    overflowX: 'auto',
   }),
 });


### PR DESCRIPTION
**What is this feature?**

Provisioning: Hide onboarding wizard stepper on smaller screen 
<img width="400" height="843" alt="image" src="https://github.com/user-attachments/assets/65c2b4d2-8cbb-441e-a875-a095fbf23645" />


**Why do we need this feature?**

Fix smaller screen stepper is taking up too much space issue

**Who is this feature for?**

git sync users on small screens

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/974

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
