### PR TITLE
SqlExpressions: Interpolate variables in schema queries

### DIFF
--- a/public/app/features/expressions/components/SqlExpressions/SqlExpr.test.tsx
+++ b/public/app/features/expressions/components/SqlExpressions/SqlExpr.test.tsx
@@ -1,8 +1,21 @@
 import { render, testWithFeatureToggles, userEvent, waitFor } from 'test/test-utils';
 
+import { type AdHocVariableFilter, type DataFrame, type DataQueryRequest, type ScopedVars } from '@grafana/data';
+
+import { dataSource } from '../../ExpressionDatasource';
 import { type ExpressionQuery, ExpressionQueryType } from '../../types';
+import { fetchSQLFields } from '../../utils/metaSqlExpr';
 
 import { SqlExpr, type SqlExprProps } from './SqlExpr';
+
+function mockMetadata(request: Partial<DataQueryRequest<ExpressionQuery>>): SqlExprProps['metadata'] {
+  return {
+    data: {
+      series: [],
+      request,
+    },
+  } as unknown as SqlExprProps['metadata'];
+}
 
 jest.mock('@grafana/ui', () => ({
   ...jest.requireActual('@grafana/ui'),
@@ -10,6 +23,9 @@ jest.mock('@grafana/ui', () => ({
 }));
 
 jest.mock('@grafana/plugin-ui', () => ({
+  QueryFormat: {
+    Table: 'table',
+  },
   SQLEditor: () => <div data-testid="sql-editor">SQL Editor Mock</div>,
 }));
 
@@ -90,10 +106,14 @@ describe('Schema Inspector feature toggle', () => {
 
     afterEach(() => {
       localStorage.removeItem('grafana.sql-expression.schema-inspector-open');
+      jest.clearAllMocks();
       mockBackendSrv.post.mockResolvedValue({
         kind: 'SQLSchemaResponse',
         apiVersion: 'query.grafana.app/v0alpha1',
         sqlSchemas: {},
+      });
+      mockDataSourceSrv.get.mockResolvedValue({
+        getRef: () => ({ uid: 'mock-ds-uid', type: 'mock-ds-type' }),
       });
     });
 
@@ -151,6 +171,70 @@ describe('Schema Inspector feature toggle', () => {
       expect(await findByRole('tab', { name: 'B' })).toBeInTheDocument();
       expect(await findByRole('tab', { name: 'C' })).toBeInTheDocument();
     });
+
+    it('sends interpolated source queries to sqlschemas', async () => {
+      const sourceQuery = {
+        refId: 'A',
+        datasource: { uid: 'prometheus-uid', type: 'prometheus' },
+        expr: 'up{job="$job"}',
+      };
+      const interpolatedQuery = {
+        ...sourceQuery,
+        expr: 'up{job="api"}',
+      };
+      const scopedVars: ScopedVars = {
+        job: { text: 'api', value: 'api' },
+      };
+      const filters: AdHocVariableFilter[] = [{ key: 'cluster', operator: '=', value: 'prod' }];
+      const interpolateVariablesInQueries = jest.fn().mockReturnValue([interpolatedQuery]);
+
+      mockDataSourceSrv.get.mockResolvedValueOnce({ interpolateVariablesInQueries });
+
+      render(<SqlExpr {...defaultProps} queries={[sourceQuery]} metadata={mockMetadata({ scopedVars, filters })} />);
+
+      await waitFor(() => {
+        expect(mockBackendSrv.post).toHaveBeenCalled();
+      });
+
+      expect(interpolateVariablesInQueries).toHaveBeenCalledWith([sourceQuery], scopedVars, filters);
+
+      const calls = mockBackendSrv.post.mock.calls;
+      expect(calls[calls.length - 1][1].queries).toEqual([interpolatedQuery]);
+    });
+
+    it('refetches sqlschemas when interpolation context arrives after mount', async () => {
+      const sourceQuery = {
+        refId: 'A',
+        datasource: { uid: 'prometheus-uid', type: 'prometheus' },
+        expr: 'up{job="$job"}',
+      };
+      const scopedVars: ScopedVars = {
+        job: { text: 'api', value: 'api' },
+      };
+      const interpolateVariablesInQueries = jest.fn(([query], vars) => [
+        {
+          ...query,
+          expr: vars.job ? 'up{job="api"}' : query.expr,
+        },
+      ]);
+
+      mockDataSourceSrv.get.mockResolvedValue({ interpolateVariablesInQueries });
+
+      const { rerender } = render(<SqlExpr {...defaultProps} queries={[sourceQuery]} />);
+
+      await waitFor(() => {
+        expect(mockBackendSrv.post).toHaveBeenCalledTimes(1);
+      });
+
+      rerender(<SqlExpr {...defaultProps} queries={[sourceQuery]} metadata={mockMetadata({ scopedVars })} />);
+
+      await waitFor(() => {
+        expect(mockBackendSrv.post).toHaveBeenCalledTimes(2);
+      });
+
+      expect(mockBackendSrv.post.mock.calls[0][1].queries).toEqual([sourceQuery]);
+      expect(mockBackendSrv.post.mock.calls[1][1].queries).toEqual([{ ...sourceQuery, expr: 'up{job="api"}' }]);
+    });
   });
 
   describe('when feature disabled', () => {
@@ -162,5 +246,42 @@ describe('Schema Inspector feature toggle', () => {
       expect(queryByText('Schema inspector')).not.toBeInTheDocument();
       expect(queryByText('No schema information available')).not.toBeInTheDocument();
     });
+  });
+});
+
+describe('fetchSQLFields', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+    mockDataSourceSrv.get.mockResolvedValue({
+      getRef: () => ({ uid: 'mock-ds-uid', type: 'mock-ds-type' }),
+    });
+  });
+
+  it('uses interpolated source queries for autocomplete metadata queries', async () => {
+    const sourceQuery = {
+      refId: 'A',
+      datasource: { uid: 'prometheus-uid', type: 'prometheus' },
+      expr: 'up{job="$job"}',
+    };
+    const interpolatedQuery = {
+      ...sourceQuery,
+      expr: 'up{job="api"}',
+    };
+    const scopedVars = {
+      job: { text: 'api', value: 'api' },
+    };
+    const filters: AdHocVariableFilter[] = [{ key: 'cluster', operator: '=', value: 'prod' }];
+    const interpolateVariablesInQueries = jest.fn().mockReturnValue([interpolatedQuery]);
+    const runMetaSQLExprQuery = jest
+      .spyOn(dataSource, 'runMetaSQLExprQuery')
+      .mockResolvedValue({ fields: [], length: 0 } as DataFrame);
+
+    mockDataSourceSrv.get.mockResolvedValueOnce({ interpolateVariablesInQueries });
+
+    await fetchSQLFields({ table: 'A' }, [sourceQuery], { scopedVars, filters });
+
+    expect(interpolateVariablesInQueries).toHaveBeenCalledWith([sourceQuery], scopedVars, filters);
+    expect(runMetaSQLExprQuery.mock.calls[0][2]).toEqual([interpolatedQuery]);
   });
 });

--- a/public/app/features/expressions/components/SqlExpressions/SqlExpr.tsx
+++ b/public/app/features/expressions/components/SqlExpressions/SqlExpr.tsx
@@ -13,7 +13,7 @@ import { Button, Stack, useStyles2 } from '@grafana/ui';
 
 import { type ExpressionQueryEditorProps } from '../../ExpressionQueryEditor';
 import { type SqlExpressionQuery } from '../../types';
-import { fetchSQLFields } from '../../utils/metaSqlExpr';
+import { fetchSQLFields, type FetchSQLFieldsOptions } from '../../utils/metaSqlExpr';
 import { QueryToolbox } from '../QueryToolbox';
 
 import { getSqlCompletionProvider } from './CompletionProvider/sqlCompletionProvider';
@@ -44,13 +44,21 @@ export interface SqlExprProps {
 
 export const SqlExpr = ({ onChange, refIds, query, alerting = false, queries, metadata, onRunQuery }: SqlExprProps) => {
   const vars = useMemo(() => refIds.map((v) => v.value!), [refIds]);
+  const interpolationScopedVars = metadata?.data?.request?.scopedVars;
+  const interpolationFilters = metadata?.data?.request?.filters;
+  const interpolationRange = metadata?.range;
   const completionProvider = useMemo(
     () =>
       getSqlCompletionProvider({
-        getFields: (identifier: TableIdentifier) => fetchFields(identifier, queries || []),
+        getFields: (identifier: TableIdentifier) =>
+          fetchFields(identifier, queries || [], {
+            range: interpolationRange,
+            scopedVars: interpolationScopedVars,
+            filters: interpolationFilters,
+          }),
         refIds,
       }),
-    [queries, refIds]
+    [interpolationFilters, interpolationRange, interpolationScopedVars, queries, refIds]
   );
 
   // Define the language definition for MySQL syntax highlighting and autocomplete
@@ -81,7 +89,9 @@ LIMIT
   } = useSQLSchemas({
     queries,
     enabled: true,
-    timeRange: metadata?.range,
+    timeRange: interpolationRange,
+    scopedVars: interpolationScopedVars,
+    filters: interpolationFilters,
   });
 
   const queryContext = useMemo(
@@ -279,7 +289,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
 });
 
-async function fetchFields(identifier: TableIdentifier, queries: DataQuery[]) {
-  const fields = await fetchSQLFields({ table: identifier.table }, queries);
+async function fetchFields(identifier: TableIdentifier, queries: DataQuery[], options: FetchSQLFieldsOptions) {
+  const fields = await fetchSQLFields({ table: identifier.table }, queries, options);
   return fields.map((t) => ({ name: t.name, completion: t.value, kind: CompletionItemKind.Field }));
 }

--- a/public/app/features/expressions/components/SqlExpressions/hooks/useSQLSchemas.ts
+++ b/public/app/features/expressions/components/SqlExpressions/hooks/useSQLSchemas.ts
@@ -1,10 +1,13 @@
-import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+import { useState, useRef, useCallback, useMemo } from 'react';
+import { useDeepCompareEffect } from 'react-use';
 
 import { getAPINamespace } from '@grafana/api-clients';
-import { getDefaultTimeRange, type TimeRange } from '@grafana/data';
+import { type AdHocVariableFilter, getDefaultTimeRange, type ScopedVars, type TimeRange } from '@grafana/data';
 import { config, getBackendSrv, getDataSourceSrv } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
 import { SHARED_DASHBOARD_QUERY } from 'app/plugins/datasource/dashboard/constants';
+
+import { interpolateSourceQueries } from '../../../utils/interpolateSourceQueries';
 
 export function isDashboardDatasource(query: DataQuery): boolean {
   return query.datasource?.uid === SHARED_DASHBOARD_QUERY;
@@ -35,9 +38,11 @@ interface UseSQLSchemasOptions {
   queries?: DataQuery[];
   enabled: boolean;
   timeRange?: TimeRange;
+  scopedVars?: ScopedVars;
+  filters?: AdHocVariableFilter[];
 }
 
-export function useSQLSchemas({ queries, enabled, timeRange }: UseSQLSchemasOptions) {
+export function useSQLSchemas({ queries, enabled, timeRange, scopedVars, filters }: UseSQLSchemasOptions) {
   const isFeatureEnabled = useMemo(
     () => config.featureToggles.queryService || config.featureToggles.grafanaAPIServerWithExperimentalAPIs || false,
     []
@@ -48,9 +53,14 @@ export function useSQLSchemas({ queries, enabled, timeRange }: UseSQLSchemasOpti
   const [loading, setLoading] = useState(enabled && isFeatureEnabled && Boolean(queries));
   const [error, setError] = useState<Error | null>(null);
 
-  // Store queries in ref so we can access current value without triggering effect
+  // Store queries/scopedVars/filters in refs so we can access current values
+  // without triggering the fetch effect on every parent render.
   const queriesRef = useRef(queries);
   queriesRef.current = queries;
+  const scopedVarsRef = useRef(scopedVars);
+  scopedVarsRef.current = scopedVars;
+  const filtersRef = useRef(filters);
+  filtersRef.current = filters;
 
   const fetchSchemas = useCallback(async () => {
     if (!enabled || !isFeatureEnabled) {
@@ -82,13 +92,23 @@ export function useSQLSchemas({ queries, enabled, timeRange }: UseSQLSchemasOpti
         return query;
       });
 
+      // Interpolate dashboard variables in source queries so the schema
+      // request mirrors what the panel execution path actually sends. Without
+      // this, datasources like Prometheus can reject raw `$var` / `$__macro`
+      // syntax and datasources like Loki silently return empty data.
+      const interpolatedQueries = await interpolateSourceQueries(
+        resolvedQueries,
+        scopedVarsRef.current ?? {},
+        filtersRef.current
+      );
+
       const namespace = getAPINamespace();
       const currentTimeRange = timeRange || getDefaultTimeRange();
 
       const response = await getBackendSrv().post<SQLSchemasResponse>(
         `/apis/query.grafana.app/v0alpha1/namespaces/${namespace}/sqlschemas`,
         {
-          queries: resolvedQueries,
+          queries: interpolatedQueries,
           from: currentTimeRange.from.toISOString(),
           to: currentTimeRange.to.toISOString(),
         }
@@ -102,9 +122,13 @@ export function useSQLSchemas({ queries, enabled, timeRange }: UseSQLSchemasOpti
     }
   }, [enabled, isFeatureEnabled, timeRange]);
 
-  useEffect(() => {
+  // Refetch on mount, when fetchSchemas identity changes (enabled/feature/timeRange),
+  // and when scopedVars/filters change by value. Identity-based comparison would
+  // refetch on every parent render that creates new context objects with the same
+  // contents; deep comparison avoids that.
+  useDeepCompareEffect(() => {
     fetchSchemas();
-  }, [fetchSchemas]);
+  }, [fetchSchemas, scopedVars ?? {}, filters ?? []]);
 
   return { schemas, loading, error, isFeatureEnabled, refetch: fetchSchemas };
 }

--- a/public/app/features/expressions/utils/interpolateSourceQueries.ts
+++ b/public/app/features/expressions/utils/interpolateSourceQueries.ts
@@ -1,0 +1,38 @@
+import { type AdHocVariableFilter, type ScopedVars } from '@grafana/data';
+import { getDataSourceSrv } from '@grafana/runtime';
+import { type DataQuery } from '@grafana/schema';
+
+/**
+ * Runs each data source query through its own `interpolateVariablesInQueries`
+ * implementation when available, so downstream callers (e.g. the SQL Expressions
+ * schema inspector and field autocomplete) send the same interpolated queries the
+ * panel execution path would.
+ *
+ * - Resolves each query's datasource via `getDataSourceSrv().get()`.
+ * - Delegates interpolation to the datasource; falls back to the original query
+ *   when the datasource is unavailable or does not implement `interpolateVariablesInQueries`.
+ * - Intentionally generic: no per-datasource logic.
+ */
+export async function interpolateSourceQueries(
+  queries: DataQuery[],
+  scopedVars: ScopedVars,
+  filters?: AdHocVariableFilter[]
+): Promise<DataQuery[]> {
+  return Promise.all(
+    queries.map(async (query) => {
+      let ds;
+      try {
+        ds = await getDataSourceSrv().get(query.datasource);
+      } catch {
+        return query;
+      }
+
+      if (typeof ds.interpolateVariablesInQueries !== 'function') {
+        return query;
+      }
+
+      const [interpolated] = ds.interpolateVariablesInQueries([query], scopedVars, filters);
+      return interpolated ?? query;
+    })
+  );
+}

--- a/public/app/features/expressions/utils/metaSqlExpr.ts
+++ b/public/app/features/expressions/utils/metaSqlExpr.ts
@@ -1,23 +1,47 @@
 import { v4 as uuidv4 } from 'uuid';
 
-import { getDefaultTimeRange, DataFrameView } from '@grafana/data';
+import {
+  type AdHocVariableFilter,
+  DataFrameView,
+  getDefaultTimeRange,
+  type ScopedVars,
+  type TimeRange,
+} from '@grafana/data';
 import { QueryFormat, type SQLQuery, type SQLSelectableValue } from '@grafana/plugin-ui';
 import { type DataQuery } from '@grafana/schema';
 
 import { dataSource } from '../ExpressionDatasource';
 
-export async function fetchSQLFields(query: Partial<SQLQuery>, queries: DataQuery[]): Promise<SQLSelectableValue[]> {
+import { interpolateSourceQueries } from './interpolateSourceQueries';
+
+export interface FetchSQLFieldsOptions {
+  range?: TimeRange;
+  scopedVars?: ScopedVars;
+  filters?: AdHocVariableFilter[];
+}
+
+export async function fetchSQLFields(
+  query: Partial<SQLQuery>,
+  queries: DataQuery[],
+  options: FetchSQLFieldsOptions = {}
+): Promise<SQLSelectableValue[]> {
   const datasource = dataSource;
   if (!query.table) {
     return [];
   }
 
   const queryString = `SELECT * FROM ${query.table} LIMIT 1`;
+  const sourceQueries = queries.filter((q) => q.refId === query.table);
+  const interpolatedSourceQueries = await interpolateSourceQueries(
+    sourceQueries,
+    options.scopedVars ?? {},
+    options.filters
+  );
 
   const queryResponse = await datasource.runMetaSQLExprQuery(
     { rawSql: queryString, format: QueryFormat.Table, refId: `fields-${uuidv4()}` },
-    getDefaultTimeRange(),
-    queries.filter((q) => q.refId === query.table)
+    options.range ?? getDefaultTimeRange(),
+    interpolatedSourceQueries
   );
   const frame = new DataFrameView<string[]>(queryResponse);
 


### PR DESCRIPTION
## Description

This PR fixes [DPRO-46](https://linear.app/grafana/issue/DPRO-46/sql-expressions-sqlschemas-sends-uninterpolated-source-queries) / https://github.com/grafana/grafana/issues/123575.

SQL Expressions were sending un-interpolated queries to the `/sqlschemas` endpoint and the field-autocomplete metadata path. Anything with a template variable (`$job`, `$__rate_interval`, ad-hoc filters, etc.) would either fail outright or return schemas/columns that didn't match what the panel actually executed, so the schema tree and autocomplete drifted out of sync with reality the moment a variable was involved.

## Changes
<!--- Describe your changes in detail -->

Added a small generic helper, `interpolateSourceQueries(queries, scopedVars, filters)`, that resolves each query's datasource and delegates to its own `interpolateVariablesInQueries`, with a graceful fallback when the datasource is unavailable or doesn't implement it. The schema hook (`useSQLSchemas`) and the autocomplete path (`fetchSQLFields` -> `runMetaSQLExprQuery`) now both pipe their source queries through it.

`useSQLSchemas` also picks up `scopedVars`/`filters` plumbed in from `SqlExpr`'s `metadata.data.request`, and uses `useDeepCompareEffect` to refetch when their content changes (rather than every render that hands us new identity-equal objects).

## Risks
<!--- Describe what risks you've considered i.e. what features are most likely to break -->

Low. Tests have been added, and locally I'm seeing all the expected results with variable interpolation when using SQL Expressions with the following data sources:
- Prometheus (this wasn't working before)
- Loki (this was already working, still works)
- TestData (this was already working, still works)

## Demo
<!--- Attach a demo gif/video or screenshots of the changes if applicable -->

Consider a panel that uses a Prometheus data source query and a SQL Expression that transforms that query. In the PromQL, we reference a [query-type](https://grafana.com/docs/grafana/latest/visualizations/dashboards/variables/add-template-variables/#add-a-query-variable) dashboard variable that contains label values associated with the label we're filtering by:

<img width="1687" height="953" alt="demo-prometheus-interpolation-query" src="https://github.com/user-attachments/assets/e4e64088-19fb-4c0c-b935-9c0ec29b4fa6" />

### Before

On `main`, the schema doesn't load for the table associated with our Prometheus data source query:

<img width="1687" height="953" alt="demo-missing-schema-before" src="https://github.com/user-attachments/assets/5681e356-e7db-41af-85e4-bfb25c643024" />

### After

On `nickrichmond/dpro-46`, the schema loads as expected:

<img width="1687" height="953" alt="demo-prometheus-interpolation-query-in-sql-expression" src="https://github.com/user-attachments/assets/aa86706f-9224-460c-aaab-4655f8568158" />

## Testing Instructions
<!--- Provide step by step instructions and the dashboard if applicable -->

To test locally, pull down the `nickrichmond/dpro-46` branch, build the front end, and run the server.

Next, run `make devenv sources=prometheus,loki` from the project root to scaffold `gdev-prometheus` and `gdev-loki` data sources.

You can use this dashboard to validate the variable interpolation behavior in Prometheus, Loki, and TestData data sources:

[dashboard-sqlexp-var-interpolation-1777430016312.json](https://github.com/user-attachments/files/27187748/dashboard-sqlexp-var-interpolation-1777430016312.json)

Here's what that looks like:

<img width="1687" height="446" alt="demo-var-interpolation-with-testdata-loki-prometheus" src="https://github.com/user-attachments/assets/fb9e6003-9eff-4c72-a229-9a6a67894138" />

## Reviewer Checklist
<!--- The reviewer should make sure the following has been done -->
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable