### PR TITLE
chore: Add updated OpenAPI specs for enterprise reporting API changes

### DIFF
--- a/packages/grafana-api-clients/src/clients/rtkq/legacy/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/legacy/endpoints.gen.ts
@@ -4788,6 +4788,10 @@ export type ReportSchedule = {
   workdaysOnly?: boolean;
 };
 export type State = string;
+export type ReportUrlItem = {
+  title?: string;
+  url?: string;
+};
 export type Report = {
   created?: string;
   dashboards?: ReportDashboard[];
@@ -4807,6 +4811,7 @@ export type Report = {
   subject?: string;
   uid?: string;
   updated?: string;
+  urls?: ReportUrlItem[];
   userId?: number;
 };
 export type CreateOrUpdateReport = {
@@ -4823,6 +4828,7 @@ export type CreateOrUpdateReport = {
   schedule?: ReportSchedule;
   state?: State;
   subject?: string;
+  urls?: ReportUrlItem[];
 };
 export type ReportEmail = {
   /** Comma-separated list of emails to which to send the report to. */

--- a/packages/grafana-openapi/src/api/openapi3.json
+++ b/packages/grafana-openapi/src/api/openapi3.json
@@ -4225,6 +4225,12 @@
           },
           "subject": {
             "type": "string"
+          },
+          "urls": {
+            "items": {
+              "$ref": "#/components/schemas/ReportURLItem"
+            },
+            "type": "array"
           }
         },
         "type": "object"
@@ -9781,6 +9787,12 @@
             "format": "date-time",
             "type": "string"
           },
+          "urls": {
+            "items": {
+              "$ref": "#/components/schemas/ReportURLItem"
+            },
+            "type": "array"
+          },
           "userId": {
             "format": "int64",
             "type": "integer"
@@ -9960,6 +9972,17 @@
             "type": "string"
           },
           "to": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ReportURLItem": {
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "url": {
             "type": "string"
           }
         },

--- a/public/api-enterprise-spec.json
+++ b/public/api-enterprise-spec.json
@@ -3872,6 +3872,12 @@
         },
         "subject": {
           "type": "string"
+        },
+        "urls": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ReportURLItem"
+          }
         }
       }
     },
@@ -6941,6 +6947,12 @@
           "type": "string",
           "format": "date-time"
         },
+        "urls": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ReportURLItem"
+          }
+        },
         "userId": {
           "type": "integer",
           "format": "int64"
@@ -7120,6 +7132,17 @@
           "type": "string"
         },
         "to": {
+          "type": "string"
+        }
+      }
+    },
+    "ReportURLItem": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
           "type": "string"
         }
       }

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -14557,6 +14557,12 @@
         },
         "subject": {
           "type": "string"
+        },
+        "urls": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ReportURLItem"
+          }
         }
       }
     },
@@ -20212,6 +20218,12 @@
           "type": "string",
           "format": "date-time"
         },
+        "urls": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ReportURLItem"
+          }
+        },
         "userId": {
           "type": "integer",
           "format": "int64"
@@ -20391,6 +20403,17 @@
           "type": "string"
         },
         "to": {
+          "type": "string"
+        }
+      }
+    },
+    "ReportURLItem": {
+      "type": "object",
+      "properties": {
+        "title": {
+          "type": "string"
+        },
+        "url": {
           "type": "string"
         }
       }

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -4325,6 +4325,12 @@
           },
           "subject": {
             "type": "string"
+          },
+          "urls": {
+            "items": {
+              "$ref": "#/components/schemas/ReportURLItem"
+            },
+            "type": "array"
           }
         },
         "type": "object"
@@ -9980,6 +9986,12 @@
             "format": "date-time",
             "type": "string"
           },
+          "urls": {
+            "items": {
+              "$ref": "#/components/schemas/ReportURLItem"
+            },
+            "type": "array"
+          },
           "userId": {
             "format": "int64",
             "type": "integer"
@@ -10159,6 +10171,17 @@
             "type": "string"
           },
           "to": {
+            "type": "string"
+          }
+        },
+        "type": "object"
+      },
+      "ReportURLItem": {
+        "properties": {
+          "title": {
+            "type": "string"
+          },
+          "url": {
             "type": "string"
           }
         },


### PR DESCRIPTION
Adds a new "urls" array of ReportURLItem to the grafana enterprise reporting OpenAPI definition.