### PR TITLE
Docs: Git Sync - Note PAT must belong to a repo admin for webhooks

### DIFF
--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/_index.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/_index.md
@@ -81,6 +81,12 @@ If you want to configure Git Sync for GitHub and authenticate with a Personal Ac
 - **Pull requests**: Read and write permission
 - **Webhooks**: Read and write permission
 
+{{< admonition type="note" >}}
+
+The Personal Access Token must belong to a user with the **Admin** role on the repository. GitHub only grants the **Webhooks: Read and write** permission to repository admins, so tokens created by non-admin users can't manage the webhooks Git Sync relies on for instantaneous updates and pull request previews.
+
+{{< /admonition >}}
+
 Refer to [Managing your personal access tokens](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens) for instructions.
 
 Return to Grafana and fill in the following fields:


### PR DESCRIPTION
## Summary

- Adds a note in the Git Sync setup docs clarifying that the GitHub Personal Access Token must belong to a user with the **Admin** role on the repository.
- GitHub only grants the **Webhooks: Read and write** fine-grained permission to repository admins, so tokens issued by non-admins can't manage the webhooks Git Sync uses for instantaneous updates and PR previews. Users hitting this end up with a working Git Sync connection that silently fails to react to repo events.

## Test plan

- [ ] Render the page locally (`make docs` / Hugo preview) and confirm the admonition shows up under **Connect with a GitHub Personal Access Token**.
- [ ] Confirm there are no broken links and the note reads cleanly alongside the surrounding permissions list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)