### PR TITLE
Add background cleanup of obsolete remote index snapshots

### DIFF
--- a/pkg/storage/unified/resource/bleve_index_metrics.go
+++ b/pkg/storage/unified/resource/bleve_index_metrics.go
@@ -27,6 +27,8 @@ type BleveIndexMetrics struct {
 	IndexSnapshotDownloadDuration prometheus.Histogram
 	IndexSnapshotUploads          *prometheus.CounterVec
 	IndexSnapshotUploadDuration   prometheus.Histogram
+	IndexSnapshotCleanups         *prometheus.CounterVec
+	IndexSnapshotDeleted          *prometheus.CounterVec
 }
 
 var IndexCreationBuckets = []float64{1, 5, 10, 25, 50, 75, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000}
@@ -123,14 +125,45 @@ func ProvideIndexMetrics(reg prometheus.Registerer) *BleveIndexMetrics {
 			NativeHistogramMaxBucketNumber:  160,
 			NativeHistogramMinResetDuration: time.Hour,
 		}),
+		IndexSnapshotCleanups: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "index_server_snapshot_cleanups_total",
+			Help: "Number of remote index snapshot cleanup attempts per namespace, by outcome.",
+		}, []string{"status"}), // status: success, error, skip_lock_held, skip_unowned
+		IndexSnapshotDeleted: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "index_server_snapshot_deleted_total",
+			Help: "Number of remote index snapshot objects deleted by cleanup, by kind.",
+		}, []string{"kind"}), // kind: snapshot, incomplete
 	}
 
-	// Initialize labels.
+	// Always-on label series. Snapshot-specific series are initialised separately
+	// in InitSnapshotMetrics so they don't appear on instances where the feature
+	// is disabled — see InitSnapshotMetrics for rationale.
 	m.OpenIndexes.WithLabelValues("file").Set(0)
 	m.OpenIndexes.WithLabelValues("memory").Set(0)
+	return m
+}
+
+// InitSnapshotMetrics zero-initialises the per-status label series of the
+// snapshot-related counters. Call once at startup only when the snapshot
+// feature is configured to run on this instance, so disabled instances don't
+// emit permanently-zero `index_server_snapshot_*` series. Registration of
+// the CounterVecs themselves stays unconditional in ProvideIndexMetrics.
+func (m *BleveIndexMetrics) InitSnapshotMetrics() {
+	if m == nil {
+		return
+	}
+	m.IndexSnapshotDownloads.WithLabelValues("success").Add(0)
+	m.IndexSnapshotDownloads.WithLabelValues("empty").Add(0)
+	m.IndexSnapshotDownloads.WithLabelValues("download_error").Add(0)
+	m.IndexSnapshotDownloads.WithLabelValues("validate_error").Add(0)
 	m.IndexSnapshotUploads.WithLabelValues("success").Add(0)
 	m.IndexSnapshotUploads.WithLabelValues("skip_no_changes").Add(0)
 	m.IndexSnapshotUploads.WithLabelValues("skip_lock_contention").Add(0)
 	m.IndexSnapshotUploads.WithLabelValues("error").Add(0)
-	return m
+	m.IndexSnapshotCleanups.WithLabelValues("success").Add(0)
+	m.IndexSnapshotCleanups.WithLabelValues("error").Add(0)
+	m.IndexSnapshotCleanups.WithLabelValues("skip_lock_held").Add(0)
+	m.IndexSnapshotCleanups.WithLabelValues("skip_unowned").Add(0)
+	m.IndexSnapshotDeleted.WithLabelValues("snapshot").Add(0)
+	m.IndexSnapshotDeleted.WithLabelValues("incomplete").Add(0)
 }

--- a/pkg/storage/unified/resource/bleve_index_metrics.go
+++ b/pkg/storage/unified/resource/bleve_index_metrics.go
@@ -127,7 +127,7 @@ func ProvideIndexMetrics(reg prometheus.Registerer) *BleveIndexMetrics {
 		}),
 		IndexSnapshotCleanups: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "index_server_snapshot_cleanups_total",
-			Help: "Number of remote index snapshot cleanup attempts per namespace, by outcome.",
+			Help: "Number of remote index snapshot cleanup attempts by outcome.",
 		}, []string{"status"}), // status: success, error, skip_lock_held, skip_unowned
 		IndexSnapshotDeleted: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "index_server_snapshot_deleted_total",

--- a/pkg/storage/unified/resource/bleve_index_metrics.go
+++ b/pkg/storage/unified/resource/bleve_index_metrics.go
@@ -23,12 +23,13 @@ type BleveIndexMetrics struct {
 	RebuildQueueLength      prometheus.Gauge
 	SearchLegacyQueryFields prometheus.Counter
 
-	IndexSnapshotDownloads        *prometheus.CounterVec
-	IndexSnapshotDownloadDuration prometheus.Histogram
-	IndexSnapshotUploads          *prometheus.CounterVec
-	IndexSnapshotUploadDuration   prometheus.Histogram
-	IndexSnapshotCleanups         *prometheus.CounterVec
-	IndexSnapshotDeleted          *prometheus.CounterVec
+	IndexSnapshotDownloads                *prometheus.CounterVec
+	IndexSnapshotDownloadDuration         prometheus.Histogram
+	IndexSnapshotUploads                  *prometheus.CounterVec
+	IndexSnapshotUploadDuration           prometheus.Histogram
+	IndexSnapshotNamespaceCleanups        *prometheus.CounterVec
+	IndexSnapshotDeleted                  *prometheus.CounterVec
+	IndexSnapshotIncompleteUploadsCleaned prometheus.Counter
 }
 
 var IndexCreationBuckets = []float64{1, 5, 10, 25, 50, 75, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000}
@@ -125,14 +126,18 @@ func ProvideIndexMetrics(reg prometheus.Registerer) *BleveIndexMetrics {
 			NativeHistogramMaxBucketNumber:  160,
 			NativeHistogramMinResetDuration: time.Hour,
 		}),
-		IndexSnapshotCleanups: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-			Name: "index_server_snapshot_cleanups_total",
-			Help: "Number of remote index snapshot cleanup attempts by outcome.",
+		IndexSnapshotNamespaceCleanups: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "index_server_snapshot_namespace_cleanups_total",
+			Help: "Number of namespace-level remote index snapshot cleanup attempts, by outcome.",
 		}, []string{"status"}), // status: success, error, skip_lock_held, skip_unowned
 		IndexSnapshotDeleted: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "index_server_snapshot_deleted_total",
-			Help: "Number of remote index snapshot objects deleted by cleanup, by kind.",
-		}, []string{"kind"}), // kind: snapshot, incomplete
+			Help: "Number of remote index snapshot delete attempts by cleanup, by outcome.",
+		}, []string{"outcome"}), // outcome: success, error
+		IndexSnapshotIncompleteUploadsCleaned: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Name: "index_server_snapshot_incomplete_uploads_cleaned_total",
+			Help: "Number of incomplete (partial) index snapshots deleted by cleanup.",
+		}),
 	}
 
 	// Always-on label series. Snapshot-specific series are initialised separately
@@ -160,10 +165,11 @@ func (m *BleveIndexMetrics) InitSnapshotMetrics() {
 	m.IndexSnapshotUploads.WithLabelValues("skip_no_changes").Add(0)
 	m.IndexSnapshotUploads.WithLabelValues("skip_lock_contention").Add(0)
 	m.IndexSnapshotUploads.WithLabelValues("error").Add(0)
-	m.IndexSnapshotCleanups.WithLabelValues("success").Add(0)
-	m.IndexSnapshotCleanups.WithLabelValues("error").Add(0)
-	m.IndexSnapshotCleanups.WithLabelValues("skip_lock_held").Add(0)
-	m.IndexSnapshotCleanups.WithLabelValues("skip_unowned").Add(0)
-	m.IndexSnapshotDeleted.WithLabelValues("snapshot").Add(0)
-	m.IndexSnapshotDeleted.WithLabelValues("incomplete").Add(0)
+	m.IndexSnapshotNamespaceCleanups.WithLabelValues("success").Add(0)
+	m.IndexSnapshotNamespaceCleanups.WithLabelValues("error").Add(0)
+	m.IndexSnapshotNamespaceCleanups.WithLabelValues("skip_lock_held").Add(0)
+	m.IndexSnapshotNamespaceCleanups.WithLabelValues("skip_unowned").Add(0)
+	m.IndexSnapshotDeleted.WithLabelValues("success").Add(0)
+	m.IndexSnapshotDeleted.WithLabelValues("error").Add(0)
+	m.IndexSnapshotIncompleteUploadsCleaned.Add(0)
 }

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -124,6 +124,12 @@ type SnapshotOptions struct {
 	// before its predecessor in the same Grafana-version group is eligible for
 	// cleanup. Consumed by the cleanup loop only; no effect on upload/download.
 	CleanupGracePeriod time.Duration
+
+	// CleanupInterval is how often the background cleanup pass runs. The first
+	// run after start is jittered uniformly in [0, CleanupInterval) to spread
+	// listings across replicas deployed together. Zero disables periodic cleanup
+	// (the loop is not started).
+	CleanupInterval time.Duration
 }
 
 type bleveBackend struct {
@@ -215,8 +221,19 @@ func NewBleveBackend(opts BleveOptions, indexMetrics *resource.BleveIndexMetrics
 	go be.evictExpiredOrUnownedIndexesPeriodically(ctx)
 
 	if opts.Snapshot.Store != nil {
+		// Initialise snapshot metric label series only on instances where the
+		// feature is actually wired up; ProvideIndexMetrics deliberately skips
+		// this so disabled instances stay quiet. See InitSnapshotMetrics for the
+		// full rationale.
+		be.indexMetrics.InitSnapshotMetrics()
+
 		be.bgTasksWg.Add(1)
 		go be.uploadSnapshotsPeriodically(ctx)
+
+		if opts.Snapshot.CleanupInterval > 0 {
+			be.bgTasksWg.Add(1)
+			go be.cleanupSnapshotsPeriodically(ctx)
+		}
 	}
 
 	if be.indexMetrics != nil {

--- a/pkg/storage/unified/search/options.go
+++ b/pkg/storage/unified/search/options.go
@@ -183,6 +183,7 @@ func buildSnapshotOptions(cfg *setting.Cfg, minBuildVersion *semver.Version) (Sn
 		UploadInterval:     DefaultSnapshotUploadInterval,
 		MinDocChanges:      DefaultSnapshotMinDocChanges,
 		CleanupGracePeriod: cleanupGracePeriodOrDefault(cfg.IndexSnapshotCleanupGracePeriod),
+		CleanupInterval:    DefaultSnapshotCleanupInterval,
 	}, nil
 }
 

--- a/pkg/storage/unified/search/remote_index_cleanup.go
+++ b/pkg/storage/unified/search/remote_index_cleanup.go
@@ -51,12 +51,8 @@ var errCleanupLockLost = errors.New("cleanup lock lost")
 func (b *bleveBackend) cleanupSnapshotsPeriodically(ctx context.Context) {
 	defer b.bgTasksWg.Done()
 
+	// Caller (NewBleveBackend) only starts this goroutine when CleanupInterval > 0.
 	interval := b.opts.Snapshot.CleanupInterval
-	if interval <= 0 {
-		// Caller (NewBleveBackend) only starts this goroutine when CleanupInterval > 0.
-		return
-	}
-
 	initialDelay := time.Duration(rand.Int64N(int64(interval)))
 	select {
 	case <-ctx.Done():
@@ -113,7 +109,7 @@ func (b *bleveBackend) runNamespaceCleanup(ctx context.Context, namespace string
 	// Ownership is checked at namespace granularity. The production OwnsIndex
 	// implementation hashes on Namespace alone, so calling it with an empty
 	// Group/Resource is the contract. A future change to that semantics will
-	// trip the assertion in Test_RunCleanup_OwnershipFilter_NamespaceLevel.
+	// trip the assertion in TestRunCleanup_OwnershipFilter_NamespaceLevel.
 	owned, err := b.ownsIndexFn(resource.NamespacedResource{Namespace: namespace})
 	if err != nil {
 		b.recordSnapshotCleanupStatus(snapshotCleanupStatusError)
@@ -231,12 +227,15 @@ func (b *bleveBackend) runResourceCleanup(ctx context.Context, res resource.Name
 		b.recordSnapshotDeleted(snapshotDeletedKindSnapshot)
 	}
 
+	// CleanupIncompleteUploads returns a partial cleaned count even on error;
+	// record those before propagating so metrics don't undercount on transient
+	// bucket failures.
 	cleaned, err := store.CleanupIncompleteUploads(ctx, res, cleanupIncompleteUploadsMinAge)
-	if err != nil {
-		return fmt.Errorf("cleaning up incomplete uploads: %w", err)
-	}
 	for range cleaned {
 		b.recordSnapshotDeleted(snapshotDeletedKindIncomplete)
+	}
+	if err != nil {
+		return fmt.Errorf("cleaning up incomplete uploads: %w", err)
 	}
 
 	return nil
@@ -282,7 +281,8 @@ func selectSnapshotsToDelete(metas map[ulid.ULID]*IndexMeta, now time.Time, maxA
 		}
 		// Group by normalised version string so "11.5.0" and "v11.5.0" land in
 		// the same bucket.
-		groups[v.String()] = append(groups[v.String()], entry{key: k, meta: m, v: v})
+		version := v.String()
+		groups[version] = append(groups[version], entry{key: k, meta: m, v: v})
 	}
 
 	for _, g := range groups {

--- a/pkg/storage/unified/search/remote_index_cleanup.go
+++ b/pkg/storage/unified/search/remote_index_cleanup.go
@@ -1,0 +1,327 @@
+package search
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/rand/v2"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/Masterminds/semver"
+	"github.com/oklog/ulid/v2"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
+)
+
+// snapshotCleanupStatus labels for the index_server_snapshot_cleanups_total counter.
+// One increment per (namespace, outcome) tuple.
+const (
+	snapshotCleanupStatusSuccess      = "success"
+	snapshotCleanupStatusError        = "error"
+	snapshotCleanupStatusSkipLockHeld = "skip_lock_held"
+	snapshotCleanupStatusSkipUnowned  = "skip_unowned"
+)
+
+// snapshotDeletedKind labels for the index_server_snapshot_deleted_total counter.
+const (
+	snapshotDeletedKindSnapshot   = "snapshot"
+	snapshotDeletedKindIncomplete = "incomplete"
+)
+
+// cleanupIncompleteUploadsMinAge is the minimum age of a partial upload prefix
+// before CleanupIncompleteUploads will delete it. Set generously above the
+// realistic upper bound for snapshot upload duration so a slow but live upload
+// is never killed mid-flight by cleanup.
+const cleanupIncompleteUploadsMinAge = 24 * time.Hour
+
+// errCleanupLockLost is used as the cancellation cause for the per-namespace
+// context when the cleanup lock's Lost() channel fires. Surfacing it via
+// context.Cause lets the namespace loop tell "parent shutdown" apart from
+// "lock lost" after the fact, without an extra channel.
+var errCleanupLockLost = errors.New("cleanup lock lost")
+
+// cleanupSnapshotsPeriodically runs runCleanup on a fixed CleanupInterval, with
+// a uniformly jittered initial delay in [0, CleanupInterval). The jitter spreads
+// the first cleanup pass across replicas deployed together so they don't all
+// hammer the bucket on the same 6h boundary, and brings the average first-run
+// latency down from one full interval to half.
+func (b *bleveBackend) cleanupSnapshotsPeriodically(ctx context.Context) {
+	defer b.bgTasksWg.Done()
+
+	interval := b.opts.Snapshot.CleanupInterval
+	if interval <= 0 {
+		// Caller (NewBleveBackend) only starts this goroutine when CleanupInterval > 0.
+		return
+	}
+
+	initialDelay := time.Duration(rand.Int64N(int64(interval)))
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(initialDelay):
+	}
+
+	b.runCleanup(ctx)
+
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			b.runCleanup(ctx)
+		}
+	}
+}
+
+// runCleanup lists every namespace currently holding remote snapshots and runs
+// runNamespaceCleanup against each. Namespace order is randomised so two
+// replicas sharing ownership are unlikely to contend on the same namespace's
+// cleanup lock at the same instant.
+func (b *bleveBackend) runCleanup(ctx context.Context) {
+	store := b.opts.Snapshot.Store
+	namespaces, err := store.ListNamespaces(ctx)
+	if err != nil {
+		// We can't attribute this error to any single namespace, so it shows up
+		// as a single "error" cleanup. Logged at warn so operators see it.
+		b.recordSnapshotCleanupStatus(snapshotCleanupStatusError)
+		b.log.Warn("listing namespaces for snapshot cleanup", "err", err)
+		return
+	}
+	rand.Shuffle(len(namespaces), func(i, j int) {
+		namespaces[i], namespaces[j] = namespaces[j], namespaces[i]
+	})
+	for _, ns := range namespaces {
+		if ctx.Err() != nil {
+			return
+		}
+		b.runNamespaceCleanup(ctx, ns)
+	}
+}
+
+// runNamespaceCleanup applies the retention rules to every resource under one
+// namespace. Errors in one namespace must not abort the rest of the cleanup
+// pass, so all error paths return without panicking.
+func (b *bleveBackend) runNamespaceCleanup(ctx context.Context, namespace string) {
+	store := b.opts.Snapshot.Store
+	logger := b.log.New("namespace", namespace)
+
+	// Ownership is checked at namespace granularity. The production OwnsIndex
+	// implementation hashes on Namespace alone, so calling it with an empty
+	// Group/Resource is the contract. A future change to that semantics will
+	// trip the assertion in Test_RunCleanup_OwnershipFilter_NamespaceLevel.
+	owned, err := b.ownsIndexFn(resource.NamespacedResource{Namespace: namespace})
+	if err != nil {
+		b.recordSnapshotCleanupStatus(snapshotCleanupStatusError)
+		logger.Warn("ownership check failed during cleanup", "err", err)
+		return
+	}
+	if !owned {
+		b.recordSnapshotCleanupStatus(snapshotCleanupStatusSkipUnowned)
+		return
+	}
+
+	lock, err := store.LockNamespaceForCleanup(ctx, namespace)
+	if errors.Is(err, errLockHeld) {
+		b.recordSnapshotCleanupStatus(snapshotCleanupStatusSkipLockHeld)
+		return
+	}
+	if err != nil {
+		b.recordSnapshotCleanupStatus(snapshotCleanupStatusError)
+		logger.Warn("acquiring cleanup lock", "err", err)
+		return
+	}
+	// Tie a per-namespace context to the cleanup lock: if the lock is lost
+	// mid-run, cancel the context so any in-flight bucket operation
+	// (List/Delete) aborts immediately rather than waiting for the next
+	// resource boundary. The cause carries the reason so the post-loop check
+	// can distinguish lock loss from parent shutdown.
+	nsCtx, cancelNs := context.WithCancelCause(ctx)
+	var watcher sync.WaitGroup
+	watcher.Go(func() {
+		select {
+		case <-lock.Lost():
+			cancelNs(errCleanupLockLost)
+		case <-nsCtx.Done():
+		}
+	})
+	// Order matters: cancel + wait for the watcher first, so it can't fire
+	// against a stale lock; then release the lock.
+	defer func() {
+		cancelNs(nil)
+		watcher.Wait()
+		if releaseErr := lock.Release(); releaseErr != nil {
+			logger.Warn("releasing cleanup lock", "err", releaseErr)
+		}
+	}()
+
+	resources, err := store.ListNamespaceIndexes(nsCtx, namespace)
+	if err != nil {
+		b.recordSnapshotCleanupStatus(snapshotCleanupStatusError)
+		logger.Warn("listing namespace indexes", "err", err)
+		return
+	}
+	// Resource order is randomised so a single misbehaving resource (panic,
+	// slow listing, lock loss before this point in the run) doesn't permanently
+	// starve the resources after it. Unlike namespace shuffling above, this is
+	// not about cross-replica contention — we hold the cleanup lock here, so no
+	// other replica is processing this namespace.
+	rand.Shuffle(len(resources), func(i, j int) {
+		resources[i], resources[j] = resources[j], resources[i]
+	})
+
+	hadResourceError := false
+	for _, res := range resources {
+		// nsCtx covers both cancellation paths: lock loss (cause =
+		// errCleanupLockLost) and parent shutdown (parent ctx cancelled,
+		// propagated to nsCtx). The post-loop block decides which it was.
+		if nsCtx.Err() != nil {
+			break
+		}
+		if err := b.runResourceCleanup(nsCtx, res, logger); err != nil {
+			if errors.Is(err, context.Canceled) {
+				// Cancellation propagated from lock loss or parent shutdown;
+				// not a resource-level failure.
+				break
+			}
+			hadResourceError = true
+			logger.Warn("resource cleanup failed", "resource", res, "err", err)
+		}
+	}
+
+	if errors.Is(context.Cause(nsCtx), errCleanupLockLost) {
+		logger.Warn("cleanup lock lost mid-run, aborted namespace")
+		b.recordSnapshotCleanupStatus(snapshotCleanupStatusError)
+		return
+	}
+	if ctx.Err() != nil {
+		return
+	}
+	if hadResourceError {
+		b.recordSnapshotCleanupStatus(snapshotCleanupStatusError)
+		return
+	}
+	b.recordSnapshotCleanupStatus(snapshotCleanupStatusSuccess)
+}
+
+// runResourceCleanup applies the retention rules to one resource and sweeps any
+// stale partial uploads. Returns the first error encountered; per-snapshot
+// delete failures are logged but do not abort the resource (best effort).
+func (b *bleveBackend) runResourceCleanup(ctx context.Context, res resource.NamespacedResource, logger log.Logger) error {
+	store := b.opts.Snapshot.Store
+
+	metas, err := store.ListIndexes(ctx, res)
+	if err != nil {
+		return fmt.Errorf("listing snapshots: %w", err)
+	}
+
+	toDelete := selectSnapshotsToDelete(metas, time.Now(), b.opts.Snapshot.MaxIndexAge, b.opts.Snapshot.CleanupGracePeriod)
+	for _, key := range toDelete {
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		if err := store.DeleteIndex(ctx, res, key); err != nil {
+			logger.Warn("deleting snapshot", "resource", res, "snapshot", key.String(), "err", err)
+			continue
+		}
+		b.recordSnapshotDeleted(snapshotDeletedKindSnapshot)
+	}
+
+	cleaned, err := store.CleanupIncompleteUploads(ctx, res, cleanupIncompleteUploadsMinAge)
+	if err != nil {
+		return fmt.Errorf("cleaning up incomplete uploads: %w", err)
+	}
+	for range cleaned {
+		b.recordSnapshotDeleted(snapshotDeletedKindIncomplete)
+	}
+
+	return nil
+}
+
+// selectSnapshotsToDelete applies the retention policy and returns the keys
+// that should be deleted. Two independent rules; a snapshot is deletable if
+// either fires:
+//
+//	A. Age cutoff: anything older than maxAge, regardless of group/successor.
+//	B. Superseded with stable replacement: within a Grafana-version group, all
+//	   snapshots except the newest are deletable once the newest has lived
+//	   beyond gracePeriod.
+//
+// Snapshots with an unparseable GrafanaBuildVersion are excluded from any
+// version group; rule A still applies, but otherwise they are left untouched.
+// CleanupIncompleteUploads does NOT pick them up — it only targets prefixes
+// with missing or syntactically invalid meta.json, and an unparseable version
+// string lives inside a structurally valid manifest. Rule A's age cutoff is
+// therefore the only mechanism that bounds their lifetime.
+//
+// The function is deliberately pure (no I/O, no metrics, no clock) to make
+// retention semantics directly unit-testable.
+func selectSnapshotsToDelete(metas map[ulid.ULID]*IndexMeta, now time.Time, maxAge, gracePeriod time.Duration) []ulid.ULID {
+	type entry struct {
+		key  ulid.ULID
+		meta *IndexMeta
+		v    *semver.Version
+	}
+
+	var toDelete []ulid.ULID
+	groups := map[string][]entry{}
+
+	for k, m := range metas {
+		// Rule A first — applies regardless of version parseability.
+		if maxAge > 0 && now.Sub(m.UploadTimestamp) > maxAge {
+			toDelete = append(toDelete, k)
+			continue
+		}
+		v, err := semver.NewVersion(m.GrafanaBuildVersion)
+		if err != nil {
+			continue
+		}
+		// Group by normalised version string so "11.5.0" and "v11.5.0" land in
+		// the same bucket.
+		groups[v.String()] = append(groups[v.String()], entry{key: k, meta: m, v: v})
+	}
+
+	for _, g := range groups {
+		// Newest first: highest LatestResourceVersion wins, ties broken by
+		// UploadTimestamp desc. Mirrors download-side selection so cleanup keeps
+		// what the download path would prefer.
+		sort.Slice(g, func(i, j int) bool {
+			if g[i].meta.LatestResourceVersion != g[j].meta.LatestResourceVersion {
+				return g[i].meta.LatestResourceVersion > g[j].meta.LatestResourceVersion
+			}
+			return g[i].meta.UploadTimestamp.After(g[j].meta.UploadTimestamp)
+		})
+
+		if len(g) <= 1 {
+			continue
+		}
+		if now.Sub(g[0].meta.UploadTimestamp) < gracePeriod {
+			// Newest in group hasn't stabilised yet — keep its predecessors so
+			// in-flight downloaders that picked an older one can still find it.
+			continue
+		}
+		for _, e := range g[1:] {
+			toDelete = append(toDelete, e.key)
+		}
+	}
+
+	return toDelete
+}
+
+func (b *bleveBackend) recordSnapshotCleanupStatus(status string) {
+	if b.indexMetrics == nil {
+		return
+	}
+	b.indexMetrics.IndexSnapshotCleanups.WithLabelValues(status).Inc()
+}
+
+func (b *bleveBackend) recordSnapshotDeleted(kind string) {
+	if b.indexMetrics == nil {
+		return
+	}
+	b.indexMetrics.IndexSnapshotDeleted.WithLabelValues(kind).Inc()
+}

--- a/pkg/storage/unified/search/remote_index_cleanup.go
+++ b/pkg/storage/unified/search/remote_index_cleanup.go
@@ -16,19 +16,24 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 )
 
-// snapshotCleanupStatus labels for the index_server_snapshot_cleanups_total counter.
-// One increment per (namespace, outcome) tuple.
+// snapshotNamespaceCleanupStatus labels for the
+// index_server_snapshot_namespace_cleanups_total counter. One increment per
+// (namespace, outcome) tuple per cleanup pass.
 const (
-	snapshotCleanupStatusSuccess      = "success"
-	snapshotCleanupStatusError        = "error"
-	snapshotCleanupStatusSkipLockHeld = "skip_lock_held"
-	snapshotCleanupStatusSkipUnowned  = "skip_unowned"
+	snapshotNamespaceCleanupStatusSuccess      = "success"
+	snapshotNamespaceCleanupStatusError        = "error"
+	snapshotNamespaceCleanupStatusSkipLockHeld = "skip_lock_held"
+	snapshotNamespaceCleanupStatusSkipUnowned  = "skip_unowned"
 )
 
-// snapshotDeletedKind labels for the index_server_snapshot_deleted_total counter.
+// snapshotDeleteOutcome labels for the index_server_snapshot_deleted_total
+// counter. Cleaned-up incomplete-upload prefixes are tracked in a separate
+// metric (IndexSnapshotIncompleteUploadsCleaned) since they have no
+// outcome=error series — CleanupIncompleteUploads short-circuits on internal
+// errors and only reports successful prefix deletes.
 const (
-	snapshotDeletedKindSnapshot   = "snapshot"
-	snapshotDeletedKindIncomplete = "incomplete"
+	snapshotDeleteOutcomeSuccess = "success"
+	snapshotDeleteOutcomeError   = "error"
 )
 
 // cleanupIncompleteUploadsMinAge is the minimum age of a partial upload prefix
@@ -84,7 +89,7 @@ func (b *bleveBackend) runCleanup(ctx context.Context) {
 	if err != nil {
 		// We can't attribute this error to any single namespace, so it shows up
 		// as a single "error" cleanup. Logged at warn so operators see it.
-		b.recordSnapshotCleanupStatus(snapshotCleanupStatusError)
+		b.recordSnapshotNamespaceCleanupStatus(snapshotNamespaceCleanupStatusError)
 		b.log.Warn("listing namespaces for snapshot cleanup", "err", err)
 		return
 	}
@@ -112,22 +117,22 @@ func (b *bleveBackend) runNamespaceCleanup(ctx context.Context, namespace string
 	// trip the assertion in TestRunCleanup_OwnershipFilter_NamespaceLevel.
 	owned, err := b.ownsIndexFn(resource.NamespacedResource{Namespace: namespace})
 	if err != nil {
-		b.recordSnapshotCleanupStatus(snapshotCleanupStatusError)
+		b.recordSnapshotNamespaceCleanupStatus(snapshotNamespaceCleanupStatusError)
 		logger.Warn("ownership check failed during cleanup", "err", err)
 		return
 	}
 	if !owned {
-		b.recordSnapshotCleanupStatus(snapshotCleanupStatusSkipUnowned)
+		b.recordSnapshotNamespaceCleanupStatus(snapshotNamespaceCleanupStatusSkipUnowned)
 		return
 	}
 
 	lock, err := store.LockNamespaceForCleanup(ctx, namespace)
 	if errors.Is(err, errLockHeld) {
-		b.recordSnapshotCleanupStatus(snapshotCleanupStatusSkipLockHeld)
+		b.recordSnapshotNamespaceCleanupStatus(snapshotNamespaceCleanupStatusSkipLockHeld)
 		return
 	}
 	if err != nil {
-		b.recordSnapshotCleanupStatus(snapshotCleanupStatusError)
+		b.recordSnapshotNamespaceCleanupStatus(snapshotNamespaceCleanupStatusError)
 		logger.Warn("acquiring cleanup lock", "err", err)
 		return
 	}
@@ -157,7 +162,7 @@ func (b *bleveBackend) runNamespaceCleanup(ctx context.Context, namespace string
 
 	resources, err := store.ListNamespaceIndexes(nsCtx, namespace)
 	if err != nil {
-		b.recordSnapshotCleanupStatus(snapshotCleanupStatusError)
+		b.recordSnapshotNamespaceCleanupStatus(snapshotNamespaceCleanupStatusError)
 		logger.Warn("listing namespace indexes", "err", err)
 		return
 	}
@@ -191,17 +196,17 @@ func (b *bleveBackend) runNamespaceCleanup(ctx context.Context, namespace string
 
 	if errors.Is(context.Cause(nsCtx), errCleanupLockLost) {
 		logger.Warn("cleanup lock lost mid-run, aborted namespace")
-		b.recordSnapshotCleanupStatus(snapshotCleanupStatusError)
+		b.recordSnapshotNamespaceCleanupStatus(snapshotNamespaceCleanupStatusError)
 		return
 	}
 	if ctx.Err() != nil {
 		return
 	}
 	if hadResourceError {
-		b.recordSnapshotCleanupStatus(snapshotCleanupStatusError)
+		b.recordSnapshotNamespaceCleanupStatus(snapshotNamespaceCleanupStatusError)
 		return
 	}
-	b.recordSnapshotCleanupStatus(snapshotCleanupStatusSuccess)
+	b.recordSnapshotNamespaceCleanupStatus(snapshotNamespaceCleanupStatusSuccess)
 }
 
 // runResourceCleanup applies the retention rules to one resource and sweeps any
@@ -216,29 +221,43 @@ func (b *bleveBackend) runResourceCleanup(ctx context.Context, res resource.Name
 	}
 
 	toDelete := selectSnapshotsToDelete(metas, time.Now(), b.opts.Snapshot.MaxIndexAge, b.opts.Snapshot.CleanupGracePeriod)
+	deleteFailures := 0
 	for _, key := range toDelete {
 		if ctx.Err() != nil {
 			return ctx.Err()
 		}
 		if err := store.DeleteIndex(ctx, res, key); err != nil {
 			logger.Warn("deleting snapshot", "resource", res, "snapshot", key.String(), "err", err)
+			b.recordSnapshotDeleted(snapshotDeleteOutcomeError)
+			deleteFailures++
 			continue
 		}
-		b.recordSnapshotDeleted(snapshotDeletedKindSnapshot)
+		b.recordSnapshotDeleted(snapshotDeleteOutcomeSuccess)
 	}
 
 	// CleanupIncompleteUploads returns a partial cleaned count even on error;
-	// record those before propagating so metrics don't undercount on transient
-	// bucket failures.
-	cleaned, err := store.CleanupIncompleteUploads(ctx, res, cleanupIncompleteUploadsMinAge)
+	// record successes before checking the error so metrics don't undercount
+	// on transient bucket failures. Treated symmetrically with the per-snapshot
+	// delete loop above: log, flag, continue — don't short-circuit the resource.
+	cleaned, incompleteErr := store.CleanupIncompleteUploads(ctx, res, cleanupIncompleteUploadsMinAge)
 	for range cleaned {
-		b.recordSnapshotDeleted(snapshotDeletedKindIncomplete)
+		b.recordIncompleteUploadCleaned()
 	}
-	if err != nil {
-		return fmt.Errorf("cleaning up incomplete uploads: %w", err)
+	if incompleteErr != nil {
+		logger.Warn("cleaning up incomplete uploads", "resource", res, "err", incompleteErr)
 	}
 
-	return nil
+	// Surface failures so the namespace-level cleanup status flips to "error"
+	// instead of being recorded as success. Per-snapshot detail is already in
+	// the metrics above; this is the aggregate signal.
+	var errs []error
+	if deleteFailures > 0 {
+		errs = append(errs, fmt.Errorf("%d snapshot delete(s) failed", deleteFailures))
+	}
+	if incompleteErr != nil {
+		errs = append(errs, fmt.Errorf("cleaning up incomplete uploads: %w", incompleteErr))
+	}
+	return errors.Join(errs...)
 }
 
 // selectSnapshotsToDelete applies the retention policy and returns the keys
@@ -312,16 +331,23 @@ func selectSnapshotsToDelete(metas map[ulid.ULID]*IndexMeta, now time.Time, maxA
 	return toDelete
 }
 
-func (b *bleveBackend) recordSnapshotCleanupStatus(status string) {
+func (b *bleveBackend) recordSnapshotNamespaceCleanupStatus(status string) {
 	if b.indexMetrics == nil {
 		return
 	}
-	b.indexMetrics.IndexSnapshotCleanups.WithLabelValues(status).Inc()
+	b.indexMetrics.IndexSnapshotNamespaceCleanups.WithLabelValues(status).Inc()
 }
 
-func (b *bleveBackend) recordSnapshotDeleted(kind string) {
+func (b *bleveBackend) recordSnapshotDeleted(outcome string) {
 	if b.indexMetrics == nil {
 		return
 	}
-	b.indexMetrics.IndexSnapshotDeleted.WithLabelValues(kind).Inc()
+	b.indexMetrics.IndexSnapshotDeleted.WithLabelValues(outcome).Inc()
+}
+
+func (b *bleveBackend) recordIncompleteUploadCleaned() {
+	if b.indexMetrics == nil {
+		return
+	}
+	b.indexMetrics.IndexSnapshotIncompleteUploadsCleaned.Inc()
 }

--- a/pkg/storage/unified/search/remote_index_cleanup_test.go
+++ b/pkg/storage/unified/search/remote_index_cleanup_test.go
@@ -232,13 +232,7 @@ func TestSelectSnapshotsToDelete_NeverDeletesDownloadPick(t *testing.T) {
 				runningBuildVersion: running,
 			}
 			picked, ok := be.pickBestSnapshot(metas, now)
-			if !ok {
-				// Empty input or everything dropped by hard filters — invariant
-				// vacuously holds. We still call cleanup to make sure it doesn't
-				// blow up.
-				_ = selectSnapshotsToDelete(metas, now, testCleanupMaxAge, testCleanupGrace)
-				return
-			}
+			require.Truef(t, ok, "test case must yield a pickable snapshot — if a no-pick scenario is needed, add a dedicated test case rather than letting this one short-circuit")
 
 			deleted := selectSnapshotsToDelete(metas, now, testCleanupMaxAge, testCleanupGrace)
 			for _, k := range deleted {
@@ -259,11 +253,10 @@ func TestSelectSnapshotsToDelete_NeverDeletesDownloadPick(t *testing.T) {
 // versa).
 //
 // The test drives the full runCleanup path (which reads b.runningBuildVersion
-// indirectly through the snapshot wiring) rather than calling
-// selectSnapshotsToDelete directly. selectSnapshotsToDelete takes no version
-// parameter, so a unit test on it would be a tautology; the regression we
-// want to catch is "someone introduces tier logic into the cleanup path",
-// which only the end-to-end form notices.
+// indirectly through the snapshot wiring) instead of calling
+// selectSnapshotsToDelete directly since it takes no version
+// parameter; the regression we want to catch is "someone introduces
+// tier logic into the cleanup path", which only the end-to-end form notices.
 func TestRunCleanup_ReplicaVersionAgnostic(t *testing.T) {
 	now := time.Now()
 	ns := newTestNsResource()

--- a/pkg/storage/unified/search/remote_index_cleanup_test.go
+++ b/pkg/storage/unified/search/remote_index_cleanup_test.go
@@ -1,0 +1,754 @@
+package search
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Masterminds/semver"
+	"github.com/oklog/ulid/v2"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gocloud.dev/blob"
+	"gocloud.dev/blob/memblob"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
+)
+
+// Default retention values used by the pure tests below. Tests that need a
+// different threshold (e.g. rule-A age cutoff) inline their own.
+const (
+	testCleanupMaxAge = 7 * 24 * time.Hour
+	testCleanupGrace  = 30 * time.Minute
+)
+
+// --- selectSnapshotsToDelete (pure retention rules) ---
+//
+// These tests cover retention semantics in isolation, without involving any
+// bucket or lock backend. selectSnapshotsToDelete deliberately takes a clock
+// and is pure, so the whole policy is exercisable as a unit.
+
+func mkMeta(version string, rv int64, uploadedAt time.Time) *IndexMeta {
+	return &IndexMeta{
+		GrafanaBuildVersion:   version,
+		LatestResourceVersion: rv,
+		UploadTimestamp:       uploadedAt,
+	}
+}
+
+// newCleanupTestBucket returns an in-memory bucket and a store backed by it,
+// with the bucket's Close registered as test cleanup. Used by the end-to-end
+// runCleanup tests.
+func newCleanupTestBucket(t *testing.T) (*blob.Bucket, *BucketRemoteIndexStore) {
+	t.Helper()
+	bucket := memblob.OpenBucket(nil)
+	t.Cleanup(func() { _ = bucket.Close() })
+	return bucket, newTestRemoteIndexStore(t, bucket)
+}
+
+func TestSelectSnapshotsToDelete_AgeCutoff(t *testing.T) {
+	now := time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC)
+
+	old := makeULID(t, now.Add(-10*24*time.Hour))
+	mid := makeULID(t, now.Add(-3*24*time.Hour))
+	fresh := makeULID(t, now.Add(-time.Hour))
+
+	metas := map[ulid.ULID]*IndexMeta{
+		old:   mkMeta("11.5.0", 100, now.Add(-10*24*time.Hour)),
+		mid:   mkMeta("11.5.0", 200, now.Add(-3*24*time.Hour)),
+		fresh: mkMeta("11.5.0", 300, now.Add(-time.Hour)),
+	}
+
+	got := selectSnapshotsToDelete(metas, now, testCleanupMaxAge, testCleanupGrace)
+	// Expect: old deleted by rule A; mid deleted by rule B (fresh is the newest
+	// and stable beyond grace); fresh kept (newest in group).
+	assert.ElementsMatch(t, []ulid.ULID{old, mid}, got)
+}
+
+func TestSelectSnapshotsToDelete_NewestInGroupAlwaysKept(t *testing.T) {
+	now := time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC)
+
+	keys := make([]ulid.ULID, 5)
+	metas := map[ulid.ULID]*IndexMeta{}
+	for i := range keys {
+		keys[i] = makeULID(t, now.Add(-time.Duration(i)*time.Minute))
+		metas[keys[i]] = mkMeta("11.5.0", int64(100+i*10), now.Add(-time.Duration(i+60)*time.Minute))
+	}
+	// Make the highest-RV (i=4 -> rv=140) the newest by upload time, well past grace.
+	metas[keys[4]].UploadTimestamp = now.Add(-2 * time.Hour)
+
+	got := selectSnapshotsToDelete(metas, now, testCleanupMaxAge, testCleanupGrace)
+	// All except keys[4] must be deleted.
+	assert.NotContains(t, got, keys[4])
+	assert.Len(t, got, 4)
+}
+
+func TestSelectSnapshotsToDelete_OlderKeptWhileSuccessorStabilising(t *testing.T) {
+	now := time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC)
+
+	s1 := makeULID(t, now.Add(-2*time.Hour))
+	s2 := makeULID(t, now.Add(-time.Minute))
+
+	metas := map[ulid.ULID]*IndexMeta{
+		s1: mkMeta("11.5.0", 100, now.Add(-2*time.Hour)),
+		s2: mkMeta("11.5.0", 200, now.Add(-time.Minute)),
+	}
+
+	got := selectSnapshotsToDelete(metas, now, testCleanupMaxAge, testCleanupGrace)
+	assert.Empty(t, got, "successor still inside grace window — predecessor must be retained")
+}
+
+func TestSelectSnapshotsToDelete_OlderDeletedOnceSuccessorStabilises(t *testing.T) {
+	now := time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC)
+
+	s1 := makeULID(t, now.Add(-2*time.Hour))
+	s2 := makeULID(t, now.Add(-testCleanupGrace-time.Minute))
+
+	metas := map[ulid.ULID]*IndexMeta{
+		s1: mkMeta("11.5.0", 100, now.Add(-2*time.Hour)),
+		s2: mkMeta("11.5.0", 200, now.Add(-testCleanupGrace-time.Minute)),
+	}
+
+	got := selectSnapshotsToDelete(metas, now, testCleanupMaxAge, testCleanupGrace)
+	assert.Equal(t, []ulid.ULID{s1}, got)
+}
+
+func TestSelectSnapshotsToDelete_RuleAWinsOnLoneOldSnapshot(t *testing.T) {
+	now := time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC)
+	maxAge := 24 * time.Hour
+
+	only := makeULID(t, now.Add(-2*maxAge))
+	metas := map[ulid.ULID]*IndexMeta{
+		only: mkMeta("11.5.0", 100, now.Add(-2*maxAge)),
+	}
+
+	got := selectSnapshotsToDelete(metas, now, maxAge, testCleanupGrace)
+	assert.Equal(t, []ulid.ULID{only}, got)
+}
+
+func TestSelectSnapshotsToDelete_PerVersionIsolation(t *testing.T) {
+	now := time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC)
+
+	old15 := makeULID(t, now.Add(-3*time.Hour))
+	new15 := makeULID(t, now.Add(-2*time.Hour))
+	old16 := makeULID(t, now.Add(-3*time.Hour))
+	new16 := makeULID(t, now.Add(-2*time.Hour))
+
+	metas := map[ulid.ULID]*IndexMeta{
+		old15: mkMeta("11.5.0", 100, now.Add(-3*time.Hour)),
+		new15: mkMeta("11.5.0", 200, now.Add(-2*time.Hour)),
+		old16: mkMeta("11.6.0", 100, now.Add(-3*time.Hour)),
+		new16: mkMeta("11.6.0", 200, now.Add(-2*time.Hour)),
+	}
+
+	got := selectSnapshotsToDelete(metas, now, testCleanupMaxAge, testCleanupGrace)
+	// One predecessor per group is deletable; both newest are kept.
+	assert.ElementsMatch(t, []ulid.ULID{old15, old16}, got)
+}
+
+func TestSelectSnapshotsToDelete_UnparseableVersionLeftAlone(t *testing.T) {
+	now := time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC)
+
+	garbage := makeULID(t, now.Add(-time.Hour))
+	metas := map[ulid.ULID]*IndexMeta{
+		garbage: mkMeta("garbage", 100, now.Add(-time.Hour)),
+	}
+
+	got := selectSnapshotsToDelete(metas, now, testCleanupMaxAge, testCleanupGrace)
+	assert.Empty(t, got, "unparseable version must be skipped, not deleted by rule B")
+}
+
+// TestSelectSnapshotsToDelete_NeverDeletesDownloadPick pins the cross-package
+// invariant that cleanup must never delete a snapshot the download path would
+// prefer. selectSnapshotsToDelete and pickBestSnapshot have independent sort
+// orders today (cleanup: per-group RV desc, upload desc; download:
+// tier-asc/version-desc/RV-desc/upload-desc) and a future change to either
+// could make them disagree. This test runs both over the same input across a
+// few representative shapes and asserts the picked snapshot is always in the
+// keep set.
+//
+// We considered factoring the shared within-version-group comparator into a
+// single helper called from both sites, which would make the invariant
+// structurally true and let this test go away. We deferred that: the only
+// genuinely shared logic is a five-line comparator, and the rest of each
+// function (tier classification on the download side, grouping + grace-period
+// rule on the cleanup side) is intentionally distinct. The shared helper
+// would be small enough that the indirection costs more than it saves, while
+// this test catches the same drift directly. Revisit if more selection logic
+// ends up duplicated.
+func TestSelectSnapshotsToDelete_NeverDeletesDownloadPick(t *testing.T) {
+	now := time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC)
+	minV := semver.MustParse("11.0.0")
+	running := semver.MustParse("11.5.0")
+
+	cases := map[string]map[ulid.ULID]*IndexMeta{
+		"single version, multiple RVs": {
+			makeULID(t, now.Add(-3*time.Hour)): mkMeta("11.5.0", 100, now.Add(-3*time.Hour)),
+			makeULID(t, now.Add(-2*time.Hour)): mkMeta("11.5.0", 200, now.Add(-2*time.Hour)),
+			makeULID(t, now.Add(-time.Hour)):   mkMeta("11.5.0", 150, now.Add(-time.Hour)),
+		},
+		"single version, RV ties broken by upload time": {
+			makeULID(t, now.Add(-3*time.Hour)): mkMeta("11.5.0", 200, now.Add(-3*time.Hour)),
+			makeULID(t, now.Add(-2*time.Hour)): mkMeta("11.5.0", 200, now.Add(-2*time.Hour)),
+		},
+		"two version groups, both stable, both tier 0": {
+			makeULID(t, now.Add(-3*time.Hour)): mkMeta("11.4.0", 200, now.Add(-3*time.Hour)),
+			makeULID(t, now.Add(-2*time.Hour)): mkMeta("11.4.0", 100, now.Add(-2*time.Hour)),
+			makeULID(t, now.Add(-time.Hour)):   mkMeta("11.5.0", 100, now.Add(-time.Hour)),
+		},
+		"mixed tiers: tier 2 newer than running, tier 0 stable": {
+			makeULID(t, now.Add(-3*time.Hour)): mkMeta("11.5.0", 200, now.Add(-3*time.Hour)),
+			makeULID(t, now.Add(-2*time.Hour)): mkMeta("11.5.0", 100, now.Add(-2*time.Hour)),
+			makeULID(t, now.Add(-time.Hour)):   mkMeta("11.6.0", 300, now.Add(-time.Hour)),
+		},
+		"successor still inside grace window": {
+			makeULID(t, now.Add(-3*time.Hour)):   mkMeta("11.5.0", 100, now.Add(-3*time.Hour)),
+			makeULID(t, now.Add(-5*time.Minute)): mkMeta("11.5.0", 200, now.Add(-5*time.Minute)),
+		},
+		"some snapshots dropped by age": {
+			makeULID(t, now.Add(-30*24*time.Hour)): mkMeta("11.5.0", 50, now.Add(-30*24*time.Hour)),
+			makeULID(t, now.Add(-2*time.Hour)):     mkMeta("11.5.0", 200, now.Add(-2*time.Hour)),
+			makeULID(t, now.Add(-time.Hour)):       mkMeta("11.5.0", 150, now.Add(-time.Hour)),
+		},
+	}
+
+	for name, metas := range cases {
+		t.Run(name, func(t *testing.T) {
+			be := &bleveBackend{
+				log: log.New("cleanup-vs-download-test"),
+				opts: BleveOptions{Snapshot: SnapshotOptions{
+					MaxIndexAge:     testCleanupMaxAge,
+					MinBuildVersion: minV,
+				}},
+				runningBuildVersion: running,
+			}
+			picked, ok := be.pickBestSnapshot(metas, now)
+			if !ok {
+				// Empty input or everything dropped by hard filters — invariant
+				// vacuously holds. We still call cleanup to make sure it doesn't
+				// blow up.
+				_ = selectSnapshotsToDelete(metas, now, testCleanupMaxAge, testCleanupGrace)
+				return
+			}
+
+			deleted := selectSnapshotsToDelete(metas, now, testCleanupMaxAge, testCleanupGrace)
+			for _, k := range deleted {
+				assert.NotEqualf(t, picked.key, k,
+					"cleanup deleted snapshot %s but download would pick it (version=%s rv=%d uploaded=%s)",
+					k, picked.version, picked.meta.LatestResourceVersion, picked.meta.UploadTimestamp)
+			}
+		})
+	}
+}
+
+// TestRunCleanup_ReplicaVersionAgnostic verifies that cleanup decisions do not
+// depend on the running Grafana build version of the replica that runs them.
+// A v11.5.0 replica and a v11.6.0 replica must produce the same delete set
+// over the same input — each applies the same per-version-group rules to
+// every group, rather than the download-side tier preference that would
+// otherwise skew a v11.5.0 replica toward deleting v11.6.0 snapshots (or vice
+// versa).
+//
+// The test drives the full runCleanup path (which reads b.runningBuildVersion
+// indirectly through the snapshot wiring) rather than calling
+// selectSnapshotsToDelete directly. selectSnapshotsToDelete takes no version
+// parameter, so a unit test on it would be a tautology; the regression we
+// want to catch is "someone introduces tier logic into the cleanup path",
+// which only the end-to-end form notices.
+func TestRunCleanup_ReplicaVersionAgnostic(t *testing.T) {
+	now := time.Now()
+	ns := newTestNsResource()
+
+	// Pre-compute ULIDs so both runs operate on identical input keys; if we
+	// minted fresh ULIDs inside each run, ElementsMatch would be comparing
+	// disjoint key sets and pass for the wrong reason.
+	old15 := makeULID(t, now.Add(-3*time.Hour))
+	new15 := makeULID(t, now.Add(-2*time.Hour))
+	old16 := makeULID(t, now.Add(-3*time.Hour))
+	new16 := makeULID(t, now.Add(-2*time.Hour))
+
+	seed := func(ctx context.Context, bucket *blob.Bucket) {
+		seedSnapshot(t, ctx, bucket, ns, old15, mkMeta("11.5.0", 100, now.Add(-3*time.Hour)))
+		seedSnapshot(t, ctx, bucket, ns, new15, mkMeta("11.5.0", 200, now.Add(-2*time.Hour)))
+		seedSnapshot(t, ctx, bucket, ns, old16, mkMeta("11.6.0", 100, now.Add(-3*time.Hour)))
+		seedSnapshot(t, ctx, bucket, ns, new16, mkMeta("11.6.0", 200, now.Add(-2*time.Hour)))
+	}
+
+	runForVersion := func(version string) []ulid.ULID {
+		ctx := context.Background()
+		bucket, store := newCleanupTestBucket(t)
+		seed(ctx, bucket)
+
+		be, err := NewBleveBackend(BleveOptions{
+			Root:          t.TempDir(),
+			FileThreshold: 5,
+			BuildVersion:  version,
+			Snapshot: SnapshotOptions{
+				Store:              store,
+				MaxIndexAge:        7 * 24 * time.Hour,
+				CleanupGracePeriod: 30 * time.Minute,
+			},
+		}, resource.ProvideIndexMetrics(prometheus.NewRegistry()))
+		require.NoError(t, err)
+		t.Cleanup(be.Stop)
+
+		be.runCleanup(ctx)
+		return listSeededIndexKeys(t, ctx, store, ns)
+	}
+
+	keptByV15 := runForVersion("11.5.0")
+	keptByV16 := runForVersion("11.6.0")
+
+	assert.ElementsMatch(t, keptByV15, keptByV16,
+		"cleanup must produce the same delete set regardless of running version")
+	// Belt-and-braces: assert cleanup actually deleted something. A no-op
+	// cleanup would satisfy the equality above trivially.
+	assert.ElementsMatch(t, []ulid.ULID{new15, new16}, keptByV15)
+}
+
+// --- end-to-end runCleanup tests against a memblob bucket ---
+
+// seedSnapshot writes a minimal but valid snapshot at indexKey under ns,
+// matching the layout BucketRemoteIndexStore expects: a single placeholder file
+// plus meta.json declaring it. Bypasses store.UploadIndex so tests can pin
+// arbitrary UploadTimestamps without being tied to wall-clock or ULID.Time().
+// Takes *IndexMeta so callers can use mkMeta directly.
+func seedSnapshot(t *testing.T, ctx context.Context, bucket *blob.Bucket, ns resource.NamespacedResource, indexKey ulid.ULID, meta *IndexMeta) {
+	t.Helper()
+	pfx := indexPrefix(ns, indexKey.String())
+	require.NoError(t, bucket.WriteAll(ctx, pfx+"store/data.bin", []byte("x"), nil))
+	if meta.Files == nil {
+		meta.Files = map[string]int64{"store/data.bin": 1}
+	}
+	metaBytes, err := json.Marshal(meta)
+	require.NoError(t, err)
+	require.NoError(t, bucket.WriteAll(ctx, pfx+metaJSONFile, metaBytes, nil))
+}
+
+// listSeededIndexKeys returns the index keys still present at ns in the bucket.
+func listSeededIndexKeys(t *testing.T, ctx context.Context, store *BucketRemoteIndexStore, ns resource.NamespacedResource) []ulid.ULID {
+	t.Helper()
+	got, err := store.ListIndexes(ctx, ns)
+	require.NoError(t, err)
+	keys := make([]ulid.ULID, 0, len(got))
+	for k := range got {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+func newCleanupTestBackend(t *testing.T, store RemoteIndexStore, ownsFn func(resource.NamespacedResource) (bool, error)) (*bleveBackend, *resource.BleveIndexMetrics) {
+	t.Helper()
+	be, metrics := newTestBleveBackend(t, SnapshotOptions{
+		Store:              store,
+		MaxIndexAge:        7 * 24 * time.Hour,
+		CleanupGracePeriod: 30 * time.Minute,
+		// CleanupInterval intentionally left zero: tests drive runCleanup
+		// directly so we don't depend on the background goroutine timing.
+	})
+	if ownsFn != nil {
+		be.ownsIndexFn = ownsFn
+	}
+	return be, metrics
+}
+
+func TestRunCleanup_LockContentionSkipsNamespace(t *testing.T) {
+	ctx := context.Background()
+	bucket := memblob.OpenBucket(nil)
+	t.Cleanup(func() { _ = bucket.Close() })
+
+	// Two storeA/storeB instances share the same bucket and lock backend so
+	// that a lock acquired by storeA is observable by storeB. Constructed
+	// directly rather than via newCleanupTestBucket because we need distinct
+	// lock owners.
+	backend := newFakeBackend(newConditionalBucket())
+	storeA := NewBucketRemoteIndexStore(bucket, backend, "instance-A", 5*time.Second, 500*time.Millisecond)
+	storeB := NewBucketRemoteIndexStore(bucket, backend, "instance-B", 5*time.Second, 500*time.Millisecond)
+
+	nsA := resource.NamespacedResource{Namespace: "stack-1", Group: "dashboard.grafana.app", Resource: "dashboards"}
+	nsB := resource.NamespacedResource{Namespace: "stack-2", Group: "dashboard.grafana.app", Resource: "dashboards"}
+
+	now := time.Now()
+	old := makeULID(t, now.Add(-2*time.Hour))
+	fresh := makeULID(t, now.Add(-time.Hour))
+	for _, ns := range []resource.NamespacedResource{nsA, nsB} {
+		seedSnapshot(t, ctx, bucket, ns, old, mkMeta("11.5.0", 100, now.Add(-2*time.Hour)))
+		seedSnapshot(t, ctx, bucket, ns, fresh, mkMeta("11.5.0", 200, now.Add(-time.Hour)))
+	}
+
+	// instance-A pre-acquires the cleanup lock for stack-1; instance-B's runCleanup
+	// must see the lock as held and skip it, but still process stack-2.
+	heldLock, err := storeA.LockNamespaceForCleanup(ctx, nsA.Namespace)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = heldLock.Release() })
+
+	be, metrics := newCleanupTestBackend(t, storeB, nil)
+	be.runCleanup(ctx)
+
+	keysA := listSeededIndexKeys(t, ctx, storeB, nsA)
+	assert.ElementsMatch(t, []ulid.ULID{old, fresh}, keysA, "stack-1 must be untouched while its cleanup lock is held by another instance")
+
+	keysB := listSeededIndexKeys(t, ctx, storeB, nsB)
+	assert.Equal(t, []ulid.ULID{fresh}, keysB, "stack-2 must have its older snapshot cleaned up")
+
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotCleanups.WithLabelValues(snapshotCleanupStatusSkipLockHeld)))
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotCleanups.WithLabelValues(snapshotCleanupStatusSuccess)))
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotDeleted.WithLabelValues(snapshotDeletedKindSnapshot)))
+}
+
+func TestRunCleanup_IncompleteUploadsCounted(t *testing.T) {
+	ctx := context.Background()
+	bucket, store := newCleanupTestBucket(t)
+
+	ns := newTestNsResource()
+	old := makeULID(t, time.Now().Add(-48*time.Hour))
+	pfx := indexPrefix(ns, old.String())
+	// Stale prefix without meta.json — older than CleanupIncompleteUploads' minAge.
+	require.NoError(t, bucket.WriteAll(ctx, pfx+"store/data.bin", []byte("partial"), nil))
+
+	be, metrics := newCleanupTestBackend(t, store, nil)
+	be.runCleanup(ctx)
+
+	iter := bucket.List(&blob.ListOptions{Prefix: pfx})
+	_, err := iter.Next(ctx)
+	require.Error(t, err, "incomplete upload prefix must be removed")
+
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotDeleted.WithLabelValues(snapshotDeletedKindIncomplete)))
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotCleanups.WithLabelValues(snapshotCleanupStatusSuccess)))
+}
+
+func TestRunCleanup_DeletesPerRetentionRules(t *testing.T) {
+	ctx := context.Background()
+	bucket, store := newCleanupTestBucket(t)
+	ns := newTestNsResource()
+
+	now := time.Now()
+	keep := makeULID(t, now.Add(-2*time.Hour))
+	supersededOld := makeULID(t, now.Add(-3*time.Hour))
+	tooOld := makeULID(t, now.Add(-10*24*time.Hour))
+
+	seedSnapshot(t, ctx, bucket, ns, keep, mkMeta("11.5.0", 200, now.Add(-2*time.Hour)))
+	seedSnapshot(t, ctx, bucket, ns, supersededOld, mkMeta("11.5.0", 100, now.Add(-3*time.Hour)))
+	seedSnapshot(t, ctx, bucket, ns, tooOld, mkMeta("11.5.0", 50, now.Add(-10*24*time.Hour)))
+
+	be, metrics := newCleanupTestBackend(t, store, nil)
+	be.runCleanup(ctx)
+
+	keys := listSeededIndexKeys(t, ctx, store, ns)
+	assert.Equal(t, []ulid.ULID{keep}, keys)
+	assert.Equal(t, 2.0, testutil.ToFloat64(metrics.IndexSnapshotDeleted.WithLabelValues(snapshotDeletedKindSnapshot)))
+}
+
+// --- ownership filter ---
+//
+// recordingStore wraps an inner RemoteIndexStore and counts every method call
+// it sees, so tests can assert "this method was never called for that
+// namespace". Used to pin down the namespace-only ownership assumption.
+type recordingStore struct {
+	inner RemoteIndexStore
+
+	mu sync.Mutex
+	// per-method counters
+	listNamespaces       int
+	listNamespaceIndexes map[string]int
+	lockNamespaceCleanup map[string]int
+	listIndexes          map[string]int // keyed by Namespace
+	deleteIndex          map[string]int
+	cleanupIncomplete    map[string]int
+}
+
+func newRecordingStore(inner RemoteIndexStore) *recordingStore {
+	return &recordingStore{
+		inner:                inner,
+		listNamespaceIndexes: map[string]int{},
+		lockNamespaceCleanup: map[string]int{},
+		listIndexes:          map[string]int{},
+		deleteIndex:          map[string]int{},
+		cleanupIncomplete:    map[string]int{},
+	}
+}
+
+func (s *recordingStore) ListNamespaces(ctx context.Context) ([]string, error) {
+	s.mu.Lock()
+	s.listNamespaces++
+	s.mu.Unlock()
+	return s.inner.ListNamespaces(ctx)
+}
+func (s *recordingStore) ListNamespaceIndexes(ctx context.Context, ns string) ([]resource.NamespacedResource, error) {
+	s.mu.Lock()
+	s.listNamespaceIndexes[ns]++
+	s.mu.Unlock()
+	return s.inner.ListNamespaceIndexes(ctx, ns)
+}
+func (s *recordingStore) LockNamespaceForCleanup(ctx context.Context, ns string) (IndexStoreLock, error) {
+	s.mu.Lock()
+	s.lockNamespaceCleanup[ns]++
+	s.mu.Unlock()
+	return s.inner.LockNamespaceForCleanup(ctx, ns)
+}
+func (s *recordingStore) ListIndexes(ctx context.Context, r resource.NamespacedResource) (map[ulid.ULID]*IndexMeta, error) {
+	s.mu.Lock()
+	s.listIndexes[r.Namespace]++
+	s.mu.Unlock()
+	return s.inner.ListIndexes(ctx, r)
+}
+func (s *recordingStore) DeleteIndex(ctx context.Context, r resource.NamespacedResource, k ulid.ULID) error {
+	s.mu.Lock()
+	s.deleteIndex[r.Namespace]++
+	s.mu.Unlock()
+	return s.inner.DeleteIndex(ctx, r, k)
+}
+func (s *recordingStore) CleanupIncompleteUploads(ctx context.Context, r resource.NamespacedResource, minAge time.Duration) (int, error) {
+	s.mu.Lock()
+	s.cleanupIncomplete[r.Namespace]++
+	s.mu.Unlock()
+	return s.inner.CleanupIncompleteUploads(ctx, r, minAge)
+}
+func (s *recordingStore) LockBuildIndex(ctx context.Context, r resource.NamespacedResource) (IndexStoreLock, error) {
+	return s.inner.LockBuildIndex(ctx, r)
+}
+func (s *recordingStore) UploadIndex(ctx context.Context, r resource.NamespacedResource, dir string, m IndexMeta) (ulid.ULID, error) {
+	return s.inner.UploadIndex(ctx, r, dir, m)
+}
+func (s *recordingStore) DownloadIndex(ctx context.Context, r resource.NamespacedResource, k ulid.ULID, dest string) (*IndexMeta, error) {
+	return s.inner.DownloadIndex(ctx, r, k, dest)
+}
+
+func TestRunCleanup_OwnershipFilter_NamespaceLevel(t *testing.T) {
+	ctx := context.Background()
+	bucket, inner := newCleanupTestBucket(t)
+	store := newRecordingStore(inner)
+
+	ownedNs := resource.NamespacedResource{Namespace: "ownedNs", Group: "dashboard.grafana.app", Resource: "dashboards"}
+	unownedNs := resource.NamespacedResource{Namespace: "unownedNs", Group: "dashboard.grafana.app", Resource: "dashboards"}
+
+	now := time.Now()
+	old := makeULID(t, now.Add(-3*time.Hour))
+	fresh := makeULID(t, now.Add(-2*time.Hour))
+	for _, ns := range []resource.NamespacedResource{ownedNs, unownedNs} {
+		seedSnapshot(t, ctx, bucket, ns, old, mkMeta("11.5.0", 100, now.Add(-3*time.Hour)))
+		seedSnapshot(t, ctx, bucket, ns, fresh, mkMeta("11.5.0", 200, now.Add(-2*time.Hour)))
+	}
+
+	var ownsCalls atomic.Int32
+	ownsFn := func(key resource.NamespacedResource) (bool, error) {
+		ownsCalls.Add(1)
+		// Pin down the contract: cleanup must call OwnsIndex with empty group/resource
+		// because the production implementation hashes on Namespace alone. If a
+		// future change to OwnsIndex starts considering Group/Resource, this
+		// assertion will fire and force this code to be redesigned.
+		assert.Empty(t, key.Group, "ownership probe must pass empty group")
+		assert.Empty(t, key.Resource, "ownership probe must pass empty resource")
+		return key.Namespace == "ownedNs", nil
+	}
+
+	be, metrics := newCleanupTestBackend(t, store, ownsFn)
+	be.runCleanup(ctx)
+
+	// Owned namespace: predecessor deleted; fresh kept.
+	ownedKeys := listSeededIndexKeys(t, ctx, inner, ownedNs)
+	assert.Equal(t, []ulid.ULID{fresh}, ownedKeys)
+	// Unowned namespace: untouched.
+	unownedKeys := listSeededIndexKeys(t, ctx, inner, unownedNs)
+	assert.ElementsMatch(t, []ulid.ULID{old, fresh}, unownedKeys)
+
+	// Both namespaces probed via ownsIndexFn.
+	assert.Equal(t, int32(2), ownsCalls.Load())
+	// Skip path for unowned namespace: zero of every store call beyond ListNamespaces.
+	assert.Zero(t, store.listNamespaceIndexes["unownedNs"])
+	assert.Zero(t, store.lockNamespaceCleanup["unownedNs"])
+	assert.Zero(t, store.listIndexes["unownedNs"])
+	assert.Zero(t, store.deleteIndex["unownedNs"])
+	assert.Zero(t, store.cleanupIncomplete["unownedNs"])
+	// And owned namespace is processed normally.
+	assert.Equal(t, 1, store.listNamespaceIndexes["ownedNs"])
+	assert.Equal(t, 1, store.lockNamespaceCleanup["ownedNs"])
+
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotCleanups.WithLabelValues(snapshotCleanupStatusSkipUnowned)))
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotCleanups.WithLabelValues(snapshotCleanupStatusSuccess)))
+}
+
+// --- lock loss mid-run ---
+//
+// controllableLockStore returns locks whose Lost() channel can be closed by the
+// test, simulating a heartbeat-detected lock loss without depending on the real
+// objectStorageLock TTL/heartbeat timing.
+type controllableLock struct {
+	lost chan struct{}
+}
+
+func (l *controllableLock) Release() error        { return nil }
+func (l *controllableLock) Lost() <-chan struct{} { return l.lost }
+func (l *controllableLock) loseLock()             { close(l.lost) }
+
+type controllableLockStore struct {
+	inner RemoteIndexStore
+	mu    sync.Mutex
+	locks map[string]*controllableLock
+	// onCleanupIncomplete fires after each CleanupIncompleteUploads call, with
+	// the same context the inner store was invoked with. CleanupIncompleteUploads
+	// is the last operation in runResourceCleanup, so this hook fires after a
+	// resource has been fully cleaned — a deterministic point at which to
+	// trigger lock loss so the next resource (rather than this one mid-flight)
+	// is the one that observes the cancellation.
+	onCleanupIncomplete func(ctx context.Context, r resource.NamespacedResource)
+}
+
+func (s *controllableLockStore) ListNamespaces(ctx context.Context) ([]string, error) {
+	return s.inner.ListNamespaces(ctx)
+}
+func (s *controllableLockStore) ListNamespaceIndexes(ctx context.Context, ns string) ([]resource.NamespacedResource, error) {
+	return s.inner.ListNamespaceIndexes(ctx, ns)
+}
+func (s *controllableLockStore) LockNamespaceForCleanup(_ context.Context, ns string) (IndexStoreLock, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.locks == nil {
+		s.locks = map[string]*controllableLock{}
+	}
+	l := &controllableLock{lost: make(chan struct{})}
+	s.locks[ns] = l
+	return l, nil
+}
+func (s *controllableLockStore) ListIndexes(ctx context.Context, r resource.NamespacedResource) (map[ulid.ULID]*IndexMeta, error) {
+	return s.inner.ListIndexes(ctx, r)
+}
+func (s *controllableLockStore) DeleteIndex(ctx context.Context, r resource.NamespacedResource, k ulid.ULID) error {
+	return s.inner.DeleteIndex(ctx, r, k)
+}
+func (s *controllableLockStore) CleanupIncompleteUploads(ctx context.Context, r resource.NamespacedResource, minAge time.Duration) (int, error) {
+	out, err := s.inner.CleanupIncompleteUploads(ctx, r, minAge)
+	if s.onCleanupIncomplete != nil {
+		s.onCleanupIncomplete(ctx, r)
+	}
+	return out, err
+}
+func (s *controllableLockStore) LockBuildIndex(ctx context.Context, r resource.NamespacedResource) (IndexStoreLock, error) {
+	return s.inner.LockBuildIndex(ctx, r)
+}
+func (s *controllableLockStore) UploadIndex(ctx context.Context, r resource.NamespacedResource, dir string, m IndexMeta) (ulid.ULID, error) {
+	return s.inner.UploadIndex(ctx, r, dir, m)
+}
+func (s *controllableLockStore) DownloadIndex(ctx context.Context, r resource.NamespacedResource, k ulid.ULID, dest string) (*IndexMeta, error) {
+	return s.inner.DownloadIndex(ctx, r, k, dest)
+}
+
+func TestRunCleanup_LockLossAbortsNamespace(t *testing.T) {
+	ctx := context.Background()
+	bucket, inner := newCleanupTestBucket(t)
+
+	// Two resources in one namespace. Lose the lock after the first ListIndexes
+	// call; the second resource must be untouched.
+	ns := "stack-1"
+	resA := resource.NamespacedResource{Namespace: ns, Group: "dashboard.grafana.app", Resource: "dashboards"}
+	resB := resource.NamespacedResource{Namespace: ns, Group: "folder.grafana.app", Resource: "folders"}
+
+	now := time.Now()
+	oldA := makeULID(t, now.Add(-3*time.Hour))
+	freshA := makeULID(t, now.Add(-2*time.Hour))
+	oldB := makeULID(t, now.Add(-3*time.Hour))
+	freshB := makeULID(t, now.Add(-2*time.Hour))
+
+	for _, r := range []resource.NamespacedResource{resA, resB} {
+		var oldKey, freshKey ulid.ULID
+		if r == resA {
+			oldKey, freshKey = oldA, freshA
+		} else {
+			oldKey, freshKey = oldB, freshB
+		}
+		seedSnapshot(t, ctx, bucket, r, oldKey, mkMeta("11.5.0", 100, now.Add(-3*time.Hour)))
+		seedSnapshot(t, ctx, bucket, r, freshKey, mkMeta("11.5.0", 200, now.Add(-2*time.Hour)))
+	}
+
+	store := &controllableLockStore{inner: inner}
+	var processed atomic.Int32
+	store.onCleanupIncomplete = func(hookCtx context.Context, r resource.NamespacedResource) {
+		// Fire lock loss after the first resource has fully completed. Then wait
+		// for the watcher goroutine to propagate cancellation through nsCtx, so
+		// the next resource deterministically observes a cancelled context
+		// rather than racing the watcher.
+		if processed.Add(1) != 1 {
+			return
+		}
+		store.mu.Lock()
+		l := store.locks[ns]
+		store.mu.Unlock()
+		l.loseLock()
+		select {
+		case <-hookCtx.Done():
+		case <-time.After(2 * time.Second):
+			t.Fatal("per-namespace ctx was not cancelled within 2s of lock loss")
+		}
+	}
+
+	be, metrics := newCleanupTestBackend(t, store, nil)
+	be.runCleanup(ctx)
+
+	// Exactly one of {resA, resB} should have been cleaned (the first one
+	// processed in random order); the other must be untouched.
+	keysA := listSeededIndexKeys(t, ctx, inner, resA)
+	keysB := listSeededIndexKeys(t, ctx, inner, resB)
+	totalSurviving := len(keysA) + len(keysB)
+	assert.Equal(t, 3, totalSurviving, "lock loss must abort processing of remaining resources")
+
+	// Only one Delete fired; lock loss is reported as an error.
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotDeleted.WithLabelValues(snapshotDeletedKindSnapshot)))
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotCleanups.WithLabelValues(snapshotCleanupStatusError)))
+}
+
+// --- lifecycle ---
+
+func TestCleanupSnapshotsPeriodically_LifecycleExitsOnContextCancel(t *testing.T) {
+	_, store := newCleanupTestBucket(t)
+
+	// CleanupInterval > 0 makes NewBleveBackend start the cleanup goroutine.
+	// 1h is long enough that the initial jittered delay parks the goroutine in
+	// its select; we then verify Stop unblocks it via bgTasksCancel/Wait.
+	be, _ := newTestBleveBackend(t, SnapshotOptions{
+		Store:           store,
+		MaxIndexAge:     7 * 24 * time.Hour,
+		CleanupInterval: time.Hour,
+	})
+
+	done := make(chan struct{})
+	go func() {
+		be.Stop()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("bleveBackend.Stop did not return — cleanup goroutine likely leaking")
+	}
+}
+
+// --- error paths ---
+
+// listNamespacesErrStore returns an error from ListNamespaces. We use it to
+// verify that runCleanup attributes the failure to a single "error" cleanup
+// counter increment.
+type listNamespacesErrStore struct {
+	RemoteIndexStore
+	err error
+}
+
+func (s *listNamespacesErrStore) ListNamespaces(context.Context) ([]string, error) {
+	return nil, s.err
+}
+
+func TestRunCleanup_ListNamespacesErrorRecorded(t *testing.T) {
+	_, inner := newCleanupTestBucket(t)
+
+	store := &listNamespacesErrStore{RemoteIndexStore: inner, err: errors.New("network down")}
+	be, metrics := newCleanupTestBackend(t, store, nil)
+	be.runCleanup(context.Background())
+
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotCleanups.WithLabelValues(snapshotCleanupStatusError)))
+}

--- a/pkg/storage/unified/search/remote_index_cleanup_test.go
+++ b/pkg/storage/unified/search/remote_index_cleanup_test.go
@@ -81,7 +81,9 @@ func TestSelectSnapshotsToDelete_NewestInGroupAlwaysKept(t *testing.T) {
 		keys[i] = makeULID(t, now.Add(-time.Duration(i)*time.Minute))
 		metas[keys[i]] = mkMeta("11.5.0", int64(100+i*10), now.Add(-time.Duration(i+60)*time.Minute))
 	}
-	// Make the highest-RV (i=4 -> rv=140) the newest by upload time, well past grace.
+	// Make the highest-RV (i=4 -> rv=140) the oldest by upload time, well past
+	// grace. RV-desc beats UploadTimestamp-desc in the per-group sort, so this
+	// snapshot still wins as the per-group keep.
 	metas[keys[4]].UploadTimestamp = now.Add(-2 * time.Hour)
 
 	got := selectSnapshotsToDelete(metas, now, testCleanupMaxAge, testCleanupGrace)

--- a/pkg/storage/unified/search/remote_index_cleanup_test.go
+++ b/pkg/storage/unified/search/remote_index_cleanup_test.go
@@ -400,9 +400,9 @@ func TestRunCleanup_LockContentionSkipsNamespace(t *testing.T) {
 	keysB := listSeededIndexKeys(t, ctx, storeB, nsB)
 	assert.Equal(t, []ulid.ULID{fresh}, keysB, "stack-2 must have its older snapshot cleaned up")
 
-	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotCleanups.WithLabelValues(snapshotCleanupStatusSkipLockHeld)))
-	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotCleanups.WithLabelValues(snapshotCleanupStatusSuccess)))
-	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotDeleted.WithLabelValues(snapshotDeletedKindSnapshot)))
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotNamespaceCleanups.WithLabelValues(snapshotNamespaceCleanupStatusSkipLockHeld)))
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotNamespaceCleanups.WithLabelValues(snapshotNamespaceCleanupStatusSuccess)))
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotDeleted.WithLabelValues(snapshotDeleteOutcomeSuccess)))
 }
 
 func TestRunCleanup_IncompleteUploadsCounted(t *testing.T) {
@@ -422,8 +422,8 @@ func TestRunCleanup_IncompleteUploadsCounted(t *testing.T) {
 	_, err := iter.Next(ctx)
 	require.Error(t, err, "incomplete upload prefix must be removed")
 
-	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotDeleted.WithLabelValues(snapshotDeletedKindIncomplete)))
-	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotCleanups.WithLabelValues(snapshotCleanupStatusSuccess)))
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotIncompleteUploadsCleaned))
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotNamespaceCleanups.WithLabelValues(snapshotNamespaceCleanupStatusSuccess)))
 }
 
 func TestRunCleanup_DeletesPerRetentionRules(t *testing.T) {
@@ -445,7 +445,7 @@ func TestRunCleanup_DeletesPerRetentionRules(t *testing.T) {
 
 	keys := listSeededIndexKeys(t, ctx, store, ns)
 	assert.Equal(t, []ulid.ULID{keep}, keys)
-	assert.Equal(t, 2.0, testutil.ToFloat64(metrics.IndexSnapshotDeleted.WithLabelValues(snapshotDeletedKindSnapshot)))
+	assert.Equal(t, 2.0, testutil.ToFloat64(metrics.IndexSnapshotDeleted.WithLabelValues(snapshotDeleteOutcomeSuccess)))
 }
 
 // --- ownership filter ---
@@ -573,8 +573,8 @@ func TestRunCleanup_OwnershipFilter_NamespaceLevel(t *testing.T) {
 	assert.Equal(t, 1, store.listNamespaceIndexes["ownedNs"])
 	assert.Equal(t, 1, store.lockNamespaceCleanup["ownedNs"])
 
-	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotCleanups.WithLabelValues(snapshotCleanupStatusSkipUnowned)))
-	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotCleanups.WithLabelValues(snapshotCleanupStatusSuccess)))
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotNamespaceCleanups.WithLabelValues(snapshotNamespaceCleanupStatusSkipUnowned)))
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotNamespaceCleanups.WithLabelValues(snapshotNamespaceCleanupStatusSuccess)))
 }
 
 // --- lock loss mid-run ---
@@ -701,8 +701,8 @@ func TestRunCleanup_LockLossAbortsNamespace(t *testing.T) {
 	assert.Equal(t, 3, totalSurviving, "lock loss must abort processing of remaining resources")
 
 	// Only one Delete fired; lock loss is reported as an error.
-	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotDeleted.WithLabelValues(snapshotDeletedKindSnapshot)))
-	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotCleanups.WithLabelValues(snapshotCleanupStatusError)))
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotDeleted.WithLabelValues(snapshotDeleteOutcomeSuccess)))
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotNamespaceCleanups.WithLabelValues(snapshotNamespaceCleanupStatusError)))
 }
 
 // --- lifecycle ---
@@ -752,5 +752,45 @@ func TestRunCleanup_ListNamespacesErrorRecorded(t *testing.T) {
 	be, metrics := newCleanupTestBackend(t, store, nil)
 	be.runCleanup(context.Background())
 
-	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotCleanups.WithLabelValues(snapshotCleanupStatusError)))
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotNamespaceCleanups.WithLabelValues(snapshotNamespaceCleanupStatusError)))
+}
+
+// deleteFailingStore wraps an inner store and forces every DeleteIndex call to
+// return an error, so we can exercise the per-snapshot failure path without
+// depending on bucket internals.
+type deleteFailingStore struct {
+	RemoteIndexStore
+	err error
+}
+
+func (s *deleteFailingStore) DeleteIndex(context.Context, resource.NamespacedResource, ulid.ULID) error {
+	return s.err
+}
+
+func TestRunCleanup_DeleteFailureRecordedAndFlipsNamespaceStatus(t *testing.T) {
+	ctx := context.Background()
+	bucket, inner := newCleanupTestBucket(t)
+	ns := newTestNsResource()
+
+	now := time.Now()
+	old := makeULID(t, now.Add(-3*time.Hour))
+	fresh := makeULID(t, now.Add(-2*time.Hour))
+	seedSnapshot(t, ctx, bucket, ns, old, mkMeta("11.5.0", 100, now.Add(-3*time.Hour)))
+	seedSnapshot(t, ctx, bucket, ns, fresh, mkMeta("11.5.0", 200, now.Add(-2*time.Hour)))
+
+	store := &deleteFailingStore{RemoteIndexStore: inner, err: errors.New("bucket 5xx")}
+	be, metrics := newCleanupTestBackend(t, store, nil)
+	be.runCleanup(ctx)
+
+	// Per-snapshot failure recorded under outcome=error; nothing under success.
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotDeleted.WithLabelValues(snapshotDeleteOutcomeError)))
+	assert.Equal(t, 0.0, testutil.ToFloat64(metrics.IndexSnapshotDeleted.WithLabelValues(snapshotDeleteOutcomeSuccess)))
+
+	// Namespace status flips to error — cleanup ran to completion but the
+	// delete that should have succeeded didn't, so this isn't a "success".
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotNamespaceCleanups.WithLabelValues(snapshotNamespaceCleanupStatusError)))
+	assert.Equal(t, 0.0, testutil.ToFloat64(metrics.IndexSnapshotNamespaceCleanups.WithLabelValues(snapshotNamespaceCleanupStatusSuccess)))
+
+	// Bucket state confirms the delete didn't actually happen.
+	assert.ElementsMatch(t, []ulid.ULID{old, fresh}, listSeededIndexKeys(t, ctx, inner, ns))
 }

--- a/pkg/storage/unified/search/remote_index_store.go
+++ b/pkg/storage/unified/search/remote_index_store.go
@@ -62,6 +62,7 @@ type RemoteIndexStore interface {
 
 	// UploadIndex uploads a local index directory to remote storage.
 	// It generates a unique, lexicographically sortable ULID key and returns it.
+	// Caller should hold LockBuildIndex to avoid concurrent build and upload of the index.
 	UploadIndex(ctx context.Context, nsResource resource.NamespacedResource, localDir string, meta IndexMeta) (ulid.ULID, error)
 
 	// DownloadIndex downloads a remote index to a local directory.
@@ -85,6 +86,7 @@ type RemoteIndexStore interface {
 
 	// CleanupIncompleteUploads removes incomplete uploads older than minAge.
 	// Returns the number of cleaned prefixes.
+	// Caller should hold a namespace-level cleanup lock to avoid concurrent cleanup by diferent instances.
 	CleanupIncompleteUploads(ctx context.Context, nsResource resource.NamespacedResource, minAge time.Duration) (int, error)
 }
 
@@ -175,7 +177,6 @@ func (s *BucketRemoteIndexStore) LockNamespaceForCleanup(ctx context.Context, na
 	return l, nil
 }
 
-// TODO: caller must hold a namespace/group/resource build lock.
 func (s *BucketRemoteIndexStore) UploadIndex(ctx context.Context, nsResource resource.NamespacedResource, localDir string, meta IndexMeta) (_ ulid.ULID, retErr error) {
 	indexKey, err := ulid.New(ulid.Timestamp(time.Now()), rand.Reader)
 	if err != nil {
@@ -522,7 +523,6 @@ func (s *BucketRemoteIndexStore) DeleteIndex(ctx context.Context, nsResource res
 	return nil
 }
 
-// TODO: caller must hold a namespace-level cleanup lock.
 func (s *BucketRemoteIndexStore) CleanupIncompleteUploads(ctx context.Context, nsResource resource.NamespacedResource, minAge time.Duration) (int, error) {
 	nsPfx := nsPrefix(nsResource)
 

--- a/pkg/storage/unified/search/remote_index_store.go
+++ b/pkg/storage/unified/search/remote_index_store.go
@@ -86,7 +86,7 @@ type RemoteIndexStore interface {
 
 	// CleanupIncompleteUploads removes incomplete uploads older than minAge.
 	// Returns the number of cleaned prefixes.
-	// Caller should hold a namespace-level cleanup lock to avoid concurrent cleanup by diferent instances.
+	// Caller should hold a namespace-level cleanup lock to avoid concurrent cleanup by different instances.
 	CleanupIncompleteUploads(ctx context.Context, nsResource resource.NamespacedResource, minAge time.Duration) (int, error)
 }
 


### PR DESCRIPTION
Adds a background goroutine that periodically deletes obsolete remote index snapshots and stale partial uploads from object storage, so the bucket doesn't grow unboundedly as #123745's primitives keep accumulating uploads.

Builds on #123745. Part of grafana/search-and-storage-team#722.

## Retention policy

Two independent rules; a snapshot is deletable if either fires:

- **A. Age cutoff** — anything older than `IndexSnapshotMaxAge` (default 7d), the same threshold the download path uses as a hard filter.
- **B. Superseded with stable replacement** — within a Grafana-version group, the newest is always kept; older snapshots are deletable only once the newest has been stable for `CleanupGracePeriod` (default 30m).

The policy is replica-version-agnostic, so v11.5.0 and v11.6.0 replicas produce the same delete set.

## Concurrency

- Cleanup uses a per-namespace lock at `<namespace>/locks/cleanup`, distinct from the build lock, so it never blocks in-flight uploads.
- A watcher tied to a `context.WithCancelCause` aborts in-flight bucket operations the moment the cleanup lock is lost, rather than waiting for the next resource boundary.
- First run is jittered in `[0, CleanupInterval)` to avoid replicas hammering the bucket on the same 6h boundary.

## Metrics

- `index_server_snapshot_cleanups_total{status="success|error|skip_lock_held|skip_unowned"}`
- `index_server_snapshot_deleted_total{kind="snapshot|incomplete"}`

Snapshot metric label series are now zero-initialised in `NewBleveBackend` rather than unconditionally in `ProvideIndexMetrics`, so instances that never enable the feature don't emit permanently-zero `index_server_snapshot_*` series.