### PR TITLE
Provisioning: Surface folder uid-too-long and other validation 4xx as sync warnings

### DIFF
--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/health.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/health.go
@@ -95,6 +95,12 @@ const (
 	// owner must shorten the offending path; provisioning cannot recover
 	// automatically and will not retry the failed write.
 	ReasonFolderDepthExceeded = "FolderDepthExceeded"
+	// ReasonFolderUIDTooLong indicates that a folder UID derived from a
+	// repository path or _folder.json metadata exceeds the 40-character
+	// limit enforced by the folder API. The repository owner must shorten
+	// the offending path/UID; provisioning cannot recover automatically and
+	// will not retry the failed write.
+	ReasonFolderUIDTooLong = "FolderUIDTooLong"
 )
 
 // Condition reasons for the Quota condition

--- a/apps/provisioning/pkg/apis/provisioning/v0alpha1/health.go
+++ b/apps/provisioning/pkg/apis/provisioning/v0alpha1/health.go
@@ -101,6 +101,13 @@ const (
 	// the offending path/UID; provisioning cannot recover automatically and
 	// will not retry the failed write.
 	ReasonFolderUIDTooLong = "FolderUIDTooLong"
+	// ReasonFolderValidationFailed indicates that the folder API rejected a
+	// write with a validation 4xx the more specific reasons above did not
+	// claim (illegal-uid-chars, reserved-uid, future folder validations).
+	// Like the more specific folder reasons, the rejection is permanent
+	// without user action, so provisioning surfaces it as a warning rather
+	// than retrying the failed write.
+	ReasonFolderValidationFailed = "FolderValidationFailed"
 )
 
 // Condition reasons for the Quota condition

--- a/pkg/registry/apis/provisioning/jobs/job_resource_result.go
+++ b/pkg/registry/apis/provisioning/jobs/job_resource_result.go
@@ -60,7 +60,11 @@ func classifyWarning(err error) (string, bool) {
 	var invalidMetaErr *resources.InvalidFolderMetadata
 	var depthExceededErr *resources.FolderDepthExceededError
 	var uidTooLongErr *resources.FolderUIDTooLongError
+	var folderValidationErr *resources.FolderValidationError
 
+	// Order matters: the more specific folder reasons must be checked
+	// before the generic FolderValidationError fallback so the user-facing
+	// reason stays as descriptive as possible.
 	switch {
 	case errors.As(err, &quotaExceededErr):
 		return provisioning.ReasonQuotaExceeded, true
@@ -80,6 +84,8 @@ func classifyWarning(err error) (string, bool) {
 		return provisioning.ReasonFolderDepthExceeded, true
 	case errors.As(err, &uidTooLongErr):
 		return provisioning.ReasonFolderUIDTooLong, true
+	case errors.As(err, &folderValidationErr):
+		return provisioning.ReasonFolderValidationFailed, true
 	default:
 		return "", false
 	}

--- a/pkg/registry/apis/provisioning/jobs/job_resource_result.go
+++ b/pkg/registry/apis/provisioning/jobs/job_resource_result.go
@@ -59,6 +59,7 @@ func classifyWarning(err error) (string, bool) {
 	var metaConflictErr *resources.FolderMetadataConflict
 	var invalidMetaErr *resources.InvalidFolderMetadata
 	var depthExceededErr *resources.FolderDepthExceededError
+	var uidTooLongErr *resources.FolderUIDTooLongError
 
 	switch {
 	case errors.As(err, &quotaExceededErr):
@@ -77,6 +78,8 @@ func classifyWarning(err error) (string, bool) {
 		return provisioning.ReasonInvalidFolderMetadata, true
 	case errors.As(err, &depthExceededErr):
 		return provisioning.ReasonFolderDepthExceeded, true
+	case errors.As(err, &uidTooLongErr):
+		return provisioning.ReasonFolderUIDTooLong, true
 	default:
 		return "", false
 	}

--- a/pkg/registry/apis/provisioning/jobs/job_resource_result_test.go
+++ b/pkg/registry/apis/provisioning/jobs/job_resource_result_test.go
@@ -427,6 +427,48 @@ func TestJobResourceResult_WarningReason(t *testing.T) {
 		assert.Nil(t, result.Error(), "uid-too-long should be a warning even when wrapped through PathCreationError")
 		assert.NotNil(t, result.Warning())
 	})
+
+	t.Run("FolderValidationError classifies as ReasonFolderValidationFailed", func(t *testing.T) {
+		validationErr := resources.NewFolderValidationError("bad-folder/", errors.New("uid contains illegal characters"))
+		result := NewResourceResult().WithError(validationErr).Build()
+
+		assert.Equal(t, provisioning.ReasonFolderValidationFailed, result.WarningReason())
+		assert.Nil(t, result.Error(), "folder validation should be a warning, not an error")
+		assert.NotNil(t, result.Warning(), "folder validation should populate the warning slot")
+	})
+
+	t.Run("PathCreationError wrapping FolderValidationError classifies as ReasonFolderValidationFailed", func(t *testing.T) {
+		validationErr := resources.NewFolderValidationError("bad-folder/", errors.New("uid contains illegal characters"))
+		pathErr := &resources.PathCreationError{
+			Path: "bad-folder/",
+			Err:  fmt.Errorf("ensure folder exists: %w", validationErr),
+		}
+		wrapped := fmt.Errorf("ensuring folder exists at path %s: %w", "bad-folder/", pathErr)
+		result := NewResourceResult().WithError(wrapped).Build()
+
+		assert.Equal(t, provisioning.ReasonFolderValidationFailed, result.WarningReason())
+		assert.Nil(t, result.Error(), "folder validation should be a warning even when wrapped through PathCreationError")
+		assert.NotNil(t, result.Warning())
+	})
+
+	t.Run("FolderDepthExceededError keeps its specific reason over the generic FolderValidationFailed", func(t *testing.T) {
+		// Guards the classifier's switch order: more specific reasons must
+		// be checked before the catch-all so user-facing reasons stay as
+		// descriptive as possible.
+		depthErr := resources.NewFolderDepthExceededError("deep/", errors.New("folder max depth exceeded, max depth is 4"))
+		result := NewResourceResult().WithError(depthErr).Build()
+
+		assert.Equal(t, provisioning.ReasonFolderDepthExceeded, result.WarningReason(),
+			"depth-exceeded must keep its specific reason; the generic FolderValidationFailed must not shadow it")
+	})
+
+	t.Run("FolderUIDTooLongError keeps its specific reason over the generic FolderValidationFailed", func(t *testing.T) {
+		uidErr := resources.NewFolderUIDTooLongError("path/", "uid", errors.New("uid too long, max 40 characters"))
+		result := NewResourceResult().WithError(uidErr).Build()
+
+		assert.Equal(t, provisioning.ReasonFolderUIDTooLong, result.WarningReason(),
+			"uid-too-long must keep its specific reason; the generic FolderValidationFailed must not shadow it")
+	})
 }
 
 func TestIsNonFailingWarning(t *testing.T) {

--- a/pkg/registry/apis/provisioning/jobs/job_resource_result_test.go
+++ b/pkg/registry/apis/provisioning/jobs/job_resource_result_test.go
@@ -404,6 +404,29 @@ func TestJobResourceResult_WarningReason(t *testing.T) {
 		assert.Nil(t, result.Error(), "depth-exceeded should be a warning even when wrapped through PathCreationError")
 		assert.NotNil(t, result.Warning())
 	})
+
+	t.Run("FolderUIDTooLongError classifies as ReasonFolderUIDTooLong", func(t *testing.T) {
+		uidErr := resources.NewFolderUIDTooLongError("GMPO/bare-metal-services-engineering/", "a0123456789012345678901234567890123456789", errors.New("uid too long, max 40 characters"))
+		result := NewResourceResult().WithError(uidErr).Build()
+
+		assert.Equal(t, provisioning.ReasonFolderUIDTooLong, result.WarningReason())
+		assert.Nil(t, result.Error(), "uid-too-long should be a warning, not an error")
+		assert.NotNil(t, result.Warning(), "uid-too-long should populate the warning slot")
+	})
+
+	t.Run("PathCreationError wrapping FolderUIDTooLongError classifies as ReasonFolderUIDTooLong", func(t *testing.T) {
+		uidErr := resources.NewFolderUIDTooLongError("GMPO/bare-metal-services-engineering/", "a0123456789012345678901234567890123456789", errors.New("uid too long, max 40 characters"))
+		pathErr := &resources.PathCreationError{
+			Path: "GMPO/bare-metal-services-engineering/",
+			Err:  fmt.Errorf("ensure folder exists: %w", uidErr),
+		}
+		wrapped := fmt.Errorf("ensuring folder exists at path %s: %w", "GMPO/bare-metal-services-engineering/", pathErr)
+		result := NewResourceResult().WithError(wrapped).Build()
+
+		assert.Equal(t, provisioning.ReasonFolderUIDTooLong, result.WarningReason())
+		assert.Nil(t, result.Error(), "uid-too-long should be a warning even when wrapped through PathCreationError")
+		assert.NotNil(t, result.Warning())
+	})
 }
 
 func TestIsNonFailingWarning(t *testing.T) {

--- a/pkg/registry/apis/provisioning/jobs/progress_test.go
+++ b/pkg/registry/apis/provisioning/jobs/progress_test.go
@@ -450,6 +450,40 @@ func TestJobProgressRecorderFolderFailureTrackingFromWarning(t *testing.T) {
 	assert.Equal(t, 0, recorder.errorCount, "depth-exceeded warning should not increment error count")
 }
 
+func TestJobProgressRecorderFolderUIDTooLongFailureTrackingFromWarning(t *testing.T) {
+	ctx := context.Background()
+
+	mockProgressFn := func(ctx context.Context, status provisioning.JobStatus) error {
+		return nil
+	}
+	recorder := newJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
+
+	// Folder UID-length violations are surfaced as warnings instead of
+	// errors so the job is not retried in a loop. They must still populate
+	// failedCreations so that descendant resources are short-circuited
+	// instead of generating duplicate bad requests for the same offending
+	// path.
+	uidErr := resources.NewFolderUIDTooLongError(
+		"GMPO/bare-metal-services-engineering/",
+		"a0123456789012345678901234567890123456789",
+		errors.New("uid too long, max 40 characters"),
+	)
+	pathErr := &resources.PathCreationError{
+		Path: "GMPO/bare-metal-services-engineering/",
+		Err:  uidErr,
+	}
+	recorder.Record(ctx, NewFolderResult("GMPO/bare-metal-services-engineering/").
+		WithAction(repository.FileActionCreated).
+		WithError(pathErr).
+		Build())
+
+	recorder.mu.RLock()
+	defer recorder.mu.RUnlock()
+	assert.Contains(t, recorder.failedCreations, "GMPO/bare-metal-services-engineering/", "uid-too-long warning should still mark the path as a failed creation")
+	assert.Empty(t, recorder.errors, "uid-too-long warning should not contribute to the error list")
+	assert.Equal(t, 0, recorder.errorCount, "uid-too-long warning should not increment error count")
+}
+
 func TestJobProgressRecorderHasDirPathFailedCreation(t *testing.T) {
 	ctx := context.Background()
 

--- a/pkg/registry/apis/provisioning/jobs/progress_test.go
+++ b/pkg/registry/apis/provisioning/jobs/progress_test.go
@@ -484,6 +484,39 @@ func TestJobProgressRecorderFolderUIDTooLongFailureTrackingFromWarning(t *testin
 	assert.Equal(t, 0, recorder.errorCount, "uid-too-long warning should not increment error count")
 }
 
+func TestJobProgressRecorderFolderValidationFailureTrackingFromWarning(t *testing.T) {
+	ctx := context.Background()
+
+	mockProgressFn := func(ctx context.Context, status provisioning.JobStatus) error {
+		return nil
+	}
+	recorder := newJobProgressRecorder(mockProgressFn, nil, "").(*jobProgressRecorder)
+
+	// Generic folder-API validation rejections (illegal-uid-chars,
+	// reserved-uid, future folder validations) must follow the same
+	// failed-creations short-circuit as the more specific depth/UID
+	// cases so descendant resources don't burst-write identical bad
+	// requests against the folder API.
+	validationErr := resources.NewFolderValidationError(
+		"bad-folder/",
+		errors.New("uid contains illegal characters"),
+	)
+	pathErr := &resources.PathCreationError{
+		Path: "bad-folder/",
+		Err:  validationErr,
+	}
+	recorder.Record(ctx, NewFolderResult("bad-folder/").
+		WithAction(repository.FileActionCreated).
+		WithError(pathErr).
+		Build())
+
+	recorder.mu.RLock()
+	defer recorder.mu.RUnlock()
+	assert.Contains(t, recorder.failedCreations, "bad-folder/", "folder validation warning should still mark the path as a failed creation")
+	assert.Empty(t, recorder.errors, "folder validation warning should not contribute to the error list")
+	assert.Equal(t, 0, recorder.errorCount, "folder validation warning should not increment error count")
+}
+
 func TestJobProgressRecorderHasDirPathFailedCreation(t *testing.T) {
 	ctx := context.Background()
 

--- a/pkg/registry/apis/provisioning/resources/errors.go
+++ b/pkg/registry/apis/provisioning/resources/errors.go
@@ -302,3 +302,93 @@ func IsFolderUIDTooLongAPIError(err error) bool {
 	return strings.Contains(msg, folderUIDTooLongLegacyMsg) ||
 		strings.Contains(msg, folderUIDTooLongMessageID)
 }
+
+// folderMessageIDPrefix matches every errutil base declared in
+// pkg/services/folder/model.go and pkg/registry/apis/folders/errors.go. Any
+// message ID with this prefix is, by construction, a folder-API validation
+// rejection that the sync cannot fix by retrying.
+const folderMessageIDPrefix = "folder."
+
+// ErrFolderValidation is a sentinel for any user-actionable 4xx rejection
+// from the folder API that does not match a more specific sentinel above
+// (e.g. an invalid-uid-chars or reserved-uid rejection coming from a
+// _folder.json UID the user controls). Like the depth and uid-too-long
+// sentinels, it is surfaced as a job warning so the sync is not retried.
+var ErrFolderValidation = errors.New("folder validation failed")
+
+// FolderValidationError wraps a generic folder-API validation rejection.
+// More specific wrappers — FolderDepthExceededError, FolderUIDTooLongError —
+// take precedence in EnsureFolderExists; this type is the catch-all for any
+// remaining folder-API 4xx that the sync cannot recover from automatically.
+type FolderValidationError struct {
+	Path string
+	Err  error
+}
+
+func (e *FolderValidationError) Error() string {
+	if e.Err == nil {
+		return fmt.Sprintf("folder API rejected %q with a validation error", e.Path)
+	}
+	return fmt.Sprintf("folder API rejected %q with a validation error: %v", e.Path, e.Err)
+}
+
+// Unwrap exposes both the sentinel and the underlying API error so callers
+// can match either via errors.Is/errors.As.
+func (e *FolderValidationError) Unwrap() []error {
+	if e.Err == nil {
+		return []error{ErrFolderValidation}
+	}
+	return []error{ErrFolderValidation, e.Err}
+}
+
+// NewFolderValidationError wraps the original folder-API error so callers
+// can detect the validation rejection via errors.As.
+func NewFolderValidationError(path string, err error) *FolderValidationError {
+	return &FolderValidationError{Path: path, Err: err}
+}
+
+// IsFolderValidationAPIError reports whether err is a 4xx rejection from the
+// folder API caused by a validation rule the sync cannot fix by retrying.
+//
+// It returns true for:
+//   - any of the more specific sentinels (depth, uid-too-long), so callers
+//     can use a single check when they don't care about the subtype;
+//   - any K8s StatusError whose code is 400 and whose Details.UID has the
+//     "folder." messageID prefix — covers every existing and future folder
+//     errutil sentinel post-#123709;
+//   - the in-process errutil.Error itself (it implements APIStatus and the
+//     above branch matches it via errors.As).
+//
+// It does NOT match:
+//   - 5xx errors (genuinely retryable transient failures);
+//   - 4xx errors with no folder messageID (likely caller bugs we want to
+//     keep visible so we can debug them);
+//   - 401/403/404, where retry semantics differ and the existing
+//     ResourceOwnershipConflictError / ResourceUnmanagedConflictError
+//     paths handle the meaningful cases.
+func IsFolderValidationAPIError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if IsFolderDepthExceededAPIError(err) || IsFolderUIDTooLongAPIError(err) {
+		return true
+	}
+
+	if errors.Is(err, ErrFolderValidation) {
+		return true
+	}
+
+	// Structured 400 from a folder errutil error. errutil.Error implements
+	// APIStatus, so errors.As matches both an in-process error and one that
+	// has round-tripped through the K8s API as a *StatusError.
+	var statusErr apierrors.APIStatus
+	if errors.As(err, &statusErr) {
+		s := statusErr.Status()
+		if s.Code == 400 && s.Details != nil && strings.HasPrefix(string(s.Details.UID), folderMessageIDPrefix) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/pkg/registry/apis/provisioning/resources/errors.go
+++ b/pkg/registry/apis/provisioning/resources/errors.go
@@ -218,3 +218,87 @@ func IsFolderDepthExceededAPIError(err error) bool {
 		strings.Contains(msg, folderDepthExceededUpdateMsg) ||
 		strings.Contains(msg, folderDepthExceededMessageID)
 }
+
+// ErrFolderUIDTooLong is a sentinel for folder-API rejections caused by a
+// UID exceeding the 40-character limit. Triggered by the typed error below
+// or by the legacy "uid too long, max 40 characters" message form, which
+// older Grafanas surface as a 500 (the structured 400 response was added in
+// pkg/registry/apis/folders/errors.go, but provisioning may run against a
+// Grafana that hasn't picked it up yet).
+var ErrFolderUIDTooLong = errors.New("folder uid too long")
+
+const (
+	// folderUIDTooLongLegacyMsg is the message the dashboards.ErrDashboardUidTooLong
+	// sentinel returns. Pre-fix grafanas surface it as the body of a 500;
+	// post-fix grafanas surface it as the public message of a structured 400.
+	folderUIDTooLongLegacyMsg = "uid too long, max 40 characters"
+
+	// folderUIDTooLongMessageID is the errutil message ID set on
+	// pkg/registry/apis/folders.ErrAPIUIDTooLong. It survives the round-trip
+	// through the K8s API inside Status.Details.UID and through any fmt.Errorf
+	// chain that retains err.Error().
+	folderUIDTooLongMessageID = "folder.uid-too-long"
+)
+
+// FolderUIDTooLongError wraps a folder-API "uid too long" rejection. The
+// repository owner must shorten the offending path or _folder.json UID;
+// provisioning cannot recover automatically and must not retry the write.
+type FolderUIDTooLongError struct {
+	Path string
+	UID  string
+	Err  error
+}
+
+func (e *FolderUIDTooLongError) Error() string {
+	if e.Err == nil {
+		return fmt.Sprintf("folder UID %q at %q exceeds the 40-character limit enforced by the folder API", e.UID, e.Path)
+	}
+	return fmt.Sprintf("folder UID %q at %q exceeds the 40-character limit enforced by the folder API: %v", e.UID, e.Path, e.Err)
+}
+
+// Unwrap exposes both the sentinel and the underlying API error so callers
+// can match either via errors.Is/errors.As.
+func (e *FolderUIDTooLongError) Unwrap() []error {
+	if e.Err == nil {
+		return []error{ErrFolderUIDTooLong}
+	}
+	return []error{ErrFolderUIDTooLong, e.Err}
+}
+
+// NewFolderUIDTooLongError wraps the original folder-API error so callers
+// can detect the UID-length violation via errors.As.
+func NewFolderUIDTooLongError(path, uid string, err error) *FolderUIDTooLongError {
+	return &FolderUIDTooLongError{Path: path, UID: uid, Err: err}
+}
+
+// IsFolderUIDTooLongAPIError reports whether err originates from the folder
+// API rejecting a write because the UID exceeded the 40-character limit.
+func IsFolderUIDTooLongAPIError(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// In-process: the sentinel is still in the chain.
+	if errors.Is(err, ErrFolderUIDTooLong) {
+		return true
+	}
+
+	// Through the K8s API the structured message ID is propagated in
+	// Status.Details.UID, which is the most reliable signal we get on
+	// the client side once pkg/registry/apis/folders.ErrAPIUIDTooLong has
+	// rolled out.
+	var statusErr apierrors.APIStatus
+	if errors.As(err, &statusErr) {
+		if details := statusErr.Status().Details; details != nil && string(details.UID) == folderUIDTooLongMessageID {
+			return true
+		}
+	}
+
+	// Fallback: substring match on the legacy human-readable form (which
+	// appears in pre-fix 500 responses and in dashboards.ErrDashboardUidTooLong)
+	// and on the structured message ID, which appears in errutil.Error.Error()
+	// output and therefore in any fmt.Errorf chain wrapping the in-process error.
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, folderUIDTooLongLegacyMsg) ||
+		strings.Contains(msg, folderUIDTooLongMessageID)
+}

--- a/pkg/registry/apis/provisioning/resources/errors.go
+++ b/pkg/registry/apis/provisioning/resources/errors.go
@@ -303,11 +303,34 @@ func IsFolderUIDTooLongAPIError(err error) bool {
 		strings.Contains(msg, folderUIDTooLongMessageID)
 }
 
-// folderMessageIDPrefix matches every errutil base declared in
-// pkg/services/folder/model.go and pkg/registry/apis/folders/errors.go. Any
-// message ID with this prefix is, by construction, a folder-API validation
-// rejection that the sync cannot fix by retrying.
-const folderMessageIDPrefix = "folder."
+// folderValidationMessageIDs is the explicit allow-list of folder.* errutil
+// message IDs that represent user-fixable validation rejections from the
+// folder API. Errors with these IDs come from a user-controlled input
+// (path, _folder.json, dashboard parent annotation) and re-running the
+// sync without the user fixing the input will fail again — the warning
+// classification is what stops the retry loop.
+//
+// We deliberately allow-list rather than match every "folder." prefix so
+// internal-only errutil errors that happen to live in the folder package —
+// notably folder.ErrBadRequest ("folder.bad-request"), raised on
+// programmer faults like a missing signed-in user — are NOT silently
+// downgraded to sync warnings. Those are real bugs that must surface as
+// errors so they get noticed.
+//
+// When new user-fixable folder validations are added, extend this map.
+// New folder.* errutil errors that are server-side faults must NOT be
+// added here.
+var folderValidationMessageIDs = map[string]struct{}{
+	"folder.title-empty":                {},
+	"folder.invalid-uid":                {},
+	"folder.invalid-uid-chars":          {},
+	"folder.uid-too-long":               {},
+	"folder.cannot-be-parent-of-itself": {},
+	"folder.maximum-depth-reached":      {},
+	"folder.cannot-be-moved-to-k6":      {},
+	"folder.name-exists":                {},
+	"folder.circular-reference":         {},
+}
 
 // ErrFolderValidation is a sentinel for any user-actionable 4xx rejection
 // from the folder API that does not match a more specific sentinel above
@@ -348,20 +371,24 @@ func NewFolderValidationError(path string, err error) *FolderValidationError {
 }
 
 // IsFolderValidationAPIError reports whether err is a 4xx rejection from the
-// folder API caused by a validation rule the sync cannot fix by retrying.
+// folder API caused by a user-fixable validation rule.
 //
 // It returns true for:
 //   - any of the more specific sentinels (depth, uid-too-long), so callers
 //     can use a single check when they don't care about the subtype;
-//   - any K8s StatusError whose code is 400 and whose Details.UID has the
-//     "folder." messageID prefix — covers every existing and future folder
-//     errutil sentinel post-#123709;
+//   - any K8s StatusError whose code is 400 and whose Details.UID is on
+//     the folderValidationMessageIDs allow-list — covers every folder
+//     errutil sentinel landed via #123709 / #123843 that represents a
+//     user-fixable repository-side input problem;
 //   - the in-process errutil.Error itself (it implements APIStatus and the
 //     above branch matches it via errors.As).
 //
 // It does NOT match:
 //   - 5xx errors (genuinely retryable transient failures);
-//   - 4xx errors with no folder messageID (likely caller bugs we want to
+//   - 4xx errors with a folder.* message ID that is NOT user-fixable
+//     (e.g. folder.bad-request raised on programmer faults like a missing
+//     signed-in user) — those must keep surfacing as hard errors;
+//   - 4xx errors with no message ID at all (likely caller bugs we want to
 //     keep visible so we can debug them);
 //   - 401/403/404, where retry semantics differ and the existing
 //     ResourceOwnershipConflictError / ResourceUnmanagedConflictError
@@ -385,8 +412,10 @@ func IsFolderValidationAPIError(err error) bool {
 	var statusErr apierrors.APIStatus
 	if errors.As(err, &statusErr) {
 		s := statusErr.Status()
-		if s.Code == 400 && s.Details != nil && strings.HasPrefix(string(s.Details.UID), folderMessageIDPrefix) {
-			return true
+		if s.Code == 400 && s.Details != nil {
+			if _, ok := folderValidationMessageIDs[string(s.Details.UID)]; ok {
+				return true
+			}
 		}
 	}
 

--- a/pkg/registry/apis/provisioning/resources/errors_test.go
+++ b/pkg/registry/apis/provisioning/resources/errors_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	foldermodel "github.com/grafana/grafana/pkg/services/folder"
@@ -654,6 +655,65 @@ func TestIsFolderValidationAPIError(t *testing.T) {
 			},
 		}
 		require.False(t, IsFolderValidationAPIError(statusErr))
+	})
+
+	t.Run("does not match folder.bad-request (internal request-context fault)", func(t *testing.T) {
+		// folder.ErrBadRequest is the errutil base used for programmer
+		// faults like a missing signed-in user in folder service Create/
+		// Update. It is a 400 with a folder.* message ID, but it is NOT
+		// user-fixable from the repository content. Treating it as a
+		// warning would hide real provisioning bugs as
+		// "CompletedWithWarnings". The allow-list keeps these surfacing
+		// as hard errors.
+		statusErr := &apierrors.StatusError{
+			ErrStatus: metav1.Status{
+				Status:  metav1.StatusFailure,
+				Code:    400,
+				Message: "missing signed in user",
+				Details: &metav1.StatusDetails{
+					UID: "folder.bad-request",
+				},
+			},
+		}
+		require.False(t, IsFolderValidationAPIError(statusErr))
+	})
+
+	t.Run("does not match an unknown folder.* message ID", func(t *testing.T) {
+		// Future folder.* errutil errors must not be auto-classified as
+		// warnings: each new validation must be explicitly added to
+		// folderValidationMessageIDs after the team confirms the failure
+		// is user-fixable. This guards the allow-list contract.
+		statusErr := &apierrors.StatusError{
+			ErrStatus: metav1.Status{
+				Status:  metav1.StatusFailure,
+				Code:    400,
+				Message: "Bad Request",
+				Details: &metav1.StatusDetails{
+					UID: "folder.future-validation-error-not-yet-classified",
+				},
+			},
+		}
+		require.False(t, IsFolderValidationAPIError(statusErr))
+	})
+
+	t.Run("matches every entry in the allow-list", func(t *testing.T) {
+		// Guards drift between folderValidationMessageIDs and the matcher.
+		for id := range folderValidationMessageIDs {
+			id := id
+			t.Run(id, func(t *testing.T) {
+				statusErr := &apierrors.StatusError{
+					ErrStatus: metav1.Status{
+						Status:  metav1.StatusFailure,
+						Code:    400,
+						Message: "validation failed",
+						Details: &metav1.StatusDetails{
+							UID: types.UID(id),
+						},
+					},
+				}
+				require.True(t, IsFolderValidationAPIError(statusErr), "matcher must accept %q", id)
+			})
+		}
 	})
 
 	t.Run("does not match a 5xx with a folder message ID", func(t *testing.T) {

--- a/pkg/registry/apis/provisioning/resources/errors_test.go
+++ b/pkg/registry/apis/provisioning/resources/errors_test.go
@@ -468,3 +468,99 @@ func TestIsFolderDepthExceededAPIError(t *testing.T) {
 		require.False(t, IsFolderDepthExceededAPIError(apierrors.NewBadRequest("title cannot be empty")))
 	})
 }
+
+func TestFolderUIDTooLongError(t *testing.T) {
+	t.Run("Error includes path, uid, and underlying message", func(t *testing.T) {
+		underlying := errors.New("uid too long, max 40 characters")
+		err := NewFolderUIDTooLongError("GMPO/bare-metal-services-engineering/", "a0123456789012345678901234567890123456789", underlying)
+
+		require.Contains(t, err.Error(), "GMPO/bare-metal-services-engineering/")
+		require.Contains(t, err.Error(), "a0123456789012345678901234567890123456789")
+		require.Contains(t, err.Error(), "40-character")
+	})
+
+	t.Run("Unwrap exposes both sentinel and underlying error", func(t *testing.T) {
+		underlying := errors.New("uid too long, max 40 characters")
+		err := NewFolderUIDTooLongError("a/b/", "uid", underlying)
+
+		require.True(t, errors.Is(err, ErrFolderUIDTooLong), "should match sentinel via errors.Is")
+		require.True(t, errors.Is(err, underlying), "should preserve underlying error in chain")
+	})
+
+	t.Run("errors.As extracts FolderUIDTooLongError through wrapping", func(t *testing.T) {
+		underlying := errors.New("uid too long, max 40 characters")
+		err := NewFolderUIDTooLongError("a/b/", "uid", underlying)
+		wrapped := fmt.Errorf("ensure folder exists: %w", err)
+
+		var uidErr *FolderUIDTooLongError
+		require.True(t, errors.As(wrapped, &uidErr))
+		require.Equal(t, "a/b/", uidErr.Path)
+		require.Equal(t, "uid", uidErr.UID)
+	})
+}
+
+func TestIsFolderUIDTooLongAPIError(t *testing.T) {
+	t.Run("nil returns false", func(t *testing.T) {
+		require.False(t, IsFolderUIDTooLongAPIError(nil))
+	})
+
+	t.Run("matches the legacy 500-form substring (pre-fix grafana)", func(t *testing.T) {
+		// Older Grafanas surface the dashboards.ErrDashboardUidTooLong
+		// sentinel as the body of a 500 because the validator returned a
+		// bare DashboardErr. Provisioning still needs to recognise it.
+		err := errors.New("failed to create folder: uid too long, max 40 characters")
+		require.True(t, IsFolderUIDTooLongAPIError(err))
+	})
+
+	t.Run("matches BadRequest with the legacy public message", func(t *testing.T) {
+		// Post-fix Grafanas surface ErrAPIUIDTooLong's PublicMessage
+		// in the StatusError body.
+		err := apierrors.NewBadRequest("uid too long, max 40 characters")
+		require.True(t, IsFolderUIDTooLongAPIError(err))
+	})
+
+	t.Run("matches the structured message ID substring", func(t *testing.T) {
+		// errutil.Error.Error() embeds "[folder.uid-too-long] ...", and any
+		// fmt.Errorf chain wrapping the in-process error preserves it.
+		err := errors.New("[folder.uid-too-long] uid too long, max 40 characters")
+		require.True(t, IsFolderUIDTooLongAPIError(err))
+	})
+
+	t.Run("matches when status details carry the structured message ID", func(t *testing.T) {
+		// Simulates a StatusError that survived a round-trip through the
+		// K8s API: the message is generic but the message ID is preserved
+		// in Status.Details.UID.
+		statusErr := &apierrors.StatusError{
+			ErrStatus: metav1.Status{
+				Status:  metav1.StatusFailure,
+				Code:    400,
+				Message: "Bad Request",
+				Details: &metav1.StatusDetails{
+					UID: "folder.uid-too-long",
+				},
+			},
+		}
+		require.True(t, IsFolderUIDTooLongAPIError(statusErr))
+	})
+
+	t.Run("matches sentinel error via errors.Is", func(t *testing.T) {
+		require.True(t, IsFolderUIDTooLongAPIError(ErrFolderUIDTooLong))
+	})
+
+	t.Run("matches sentinel through wrapping", func(t *testing.T) {
+		wrapped := fmt.Errorf("create folder: %w", ErrFolderUIDTooLong)
+		require.True(t, IsFolderUIDTooLongAPIError(wrapped))
+	})
+
+	t.Run("does not match unrelated errors", func(t *testing.T) {
+		require.False(t, IsFolderUIDTooLongAPIError(errors.New("something else")))
+	})
+
+	t.Run("does not match unrelated bad-request status errors", func(t *testing.T) {
+		require.False(t, IsFolderUIDTooLongAPIError(apierrors.NewBadRequest("title cannot be empty")))
+	})
+
+	t.Run("does not match the depth-exceeded error", func(t *testing.T) {
+		require.False(t, IsFolderUIDTooLongAPIError(ErrFolderDepthExceeded))
+	})
+}

--- a/pkg/registry/apis/provisioning/resources/errors_test.go
+++ b/pkg/registry/apis/provisioning/resources/errors_test.go
@@ -564,3 +564,133 @@ func TestIsFolderUIDTooLongAPIError(t *testing.T) {
 		require.False(t, IsFolderUIDTooLongAPIError(ErrFolderDepthExceeded))
 	})
 }
+
+func TestFolderValidationError(t *testing.T) {
+	t.Run("Error includes path and underlying message", func(t *testing.T) {
+		underlying := errors.New("uid contains illegal characters")
+		err := NewFolderValidationError("bad path/", underlying)
+
+		require.Contains(t, err.Error(), "bad path/")
+		require.Contains(t, err.Error(), "uid contains illegal characters")
+	})
+
+	t.Run("Unwrap exposes both sentinel and underlying error", func(t *testing.T) {
+		underlying := errors.New("uid contains illegal characters")
+		err := NewFolderValidationError("a/b/", underlying)
+
+		require.True(t, errors.Is(err, ErrFolderValidation), "should match sentinel via errors.Is")
+		require.True(t, errors.Is(err, underlying), "should preserve underlying error in chain")
+	})
+
+	t.Run("errors.As extracts FolderValidationError through wrapping", func(t *testing.T) {
+		underlying := errors.New("uid contains illegal characters")
+		err := NewFolderValidationError("a/b/", underlying)
+		wrapped := fmt.Errorf("ensure folder exists: %w", err)
+
+		var validationErr *FolderValidationError
+		require.True(t, errors.As(wrapped, &validationErr))
+		require.Equal(t, "a/b/", validationErr.Path)
+	})
+}
+
+func TestIsFolderValidationAPIError(t *testing.T) {
+	t.Run("nil returns false", func(t *testing.T) {
+		require.False(t, IsFolderValidationAPIError(nil))
+	})
+
+	t.Run("matches structured 400 with folder.* message ID", func(t *testing.T) {
+		// Simulates a StatusError that rolled out of pkg/registry/apis/folders.
+		// e.g. ErrAPIInvalidUIDChars (illegal chars in a _folder.json UID).
+		statusErr := &apierrors.StatusError{
+			ErrStatus: metav1.Status{
+				Status:  metav1.StatusFailure,
+				Code:    400,
+				Message: "uid contains illegal characters",
+				Details: &metav1.StatusDetails{
+					UID: "folder.invalid-uid-chars",
+				},
+			},
+		}
+		require.True(t, IsFolderValidationAPIError(statusErr))
+	})
+
+	t.Run("matches the depth-exceeded specific sentinel", func(t *testing.T) {
+		require.True(t, IsFolderValidationAPIError(ErrFolderDepthExceeded))
+	})
+
+	t.Run("matches the uid-too-long specific sentinel", func(t *testing.T) {
+		require.True(t, IsFolderValidationAPIError(ErrFolderUIDTooLong))
+	})
+
+	t.Run("matches the generic sentinel via errors.Is", func(t *testing.T) {
+		require.True(t, IsFolderValidationAPIError(ErrFolderValidation))
+	})
+
+	t.Run("matches FolderValidationError through fmt.Errorf wrapping", func(t *testing.T) {
+		err := NewFolderValidationError("p/", errors.New("title cannot be empty"))
+		wrapped := fmt.Errorf("ensure folder exists: %w", err)
+		require.True(t, IsFolderValidationAPIError(wrapped))
+	})
+
+	t.Run("does not match 4xx without a folder message ID", func(t *testing.T) {
+		// A 400 with no Details.UID — likely a caller bug in our request,
+		// not a folder-API validation. Keep it visible as an error so we
+		// can debug it instead of silently treating it as a warning.
+		require.False(t, IsFolderValidationAPIError(apierrors.NewBadRequest("malformed JSON")))
+	})
+
+	t.Run("does not match a 400 from a non-folder errutil error", func(t *testing.T) {
+		// Simulates a structured 400 from a different apiserver, e.g.
+		// "dashboard.invalid-something". We must not classify it as a
+		// folder-API validation rejection.
+		statusErr := &apierrors.StatusError{
+			ErrStatus: metav1.Status{
+				Status:  metav1.StatusFailure,
+				Code:    400,
+				Message: "Bad Request",
+				Details: &metav1.StatusDetails{
+					UID: "dashboard.invalid-uid",
+				},
+			},
+		}
+		require.False(t, IsFolderValidationAPIError(statusErr))
+	})
+
+	t.Run("does not match a 5xx with a folder message ID", func(t *testing.T) {
+		// Server-side errors (database-error, internal, etc.) are
+		// genuinely retryable transient failures and must not be
+		// converted into warnings.
+		statusErr := &apierrors.StatusError{
+			ErrStatus: metav1.Status{
+				Status:  metav1.StatusFailure,
+				Code:    500,
+				Message: "internal error",
+				Details: &metav1.StatusDetails{
+					UID: "folder.internal",
+				},
+			},
+		}
+		require.False(t, IsFolderValidationAPIError(statusErr))
+	})
+
+	t.Run("does not match a 403 with a folder message ID", func(t *testing.T) {
+		// Forbidden is the existing ResourceOwnershipConflictError /
+		// ResourceUnmanagedConflictError territory; we don't want to
+		// double-classify.
+		statusErr := &apierrors.StatusError{
+			ErrStatus: metav1.Status{
+				Status:  metav1.StatusFailure,
+				Code:    403,
+				Message: "forbidden",
+				Details: &metav1.StatusDetails{
+					UID: "folders.forbiddenMove",
+				},
+			},
+		}
+		require.False(t, IsFolderValidationAPIError(statusErr))
+	})
+
+	t.Run("does not match unrelated errors", func(t *testing.T) {
+		require.False(t, IsFolderValidationAPIError(errors.New("something else")))
+	})
+}

--- a/pkg/registry/apis/provisioning/resources/folders.go
+++ b/pkg/registry/apis/provisioning/resources/folders.go
@@ -388,8 +388,10 @@ func (fm *FolderManager) EnsureFolderExists(ctx context.Context, folder Folder, 
 			return NewFolderDepthExceededError(folder.Path, err)
 		}
 		// Same reasoning as depth above: a UID longer than the folder
-		// API's 40-character limit (typically a _folder.json stable UID
-		// or a path segment that overflowed) is a permanent rejection.
+		// API's 40-character limit is a permanent rejection. Path-derived
+		// UIDs are always truncated to <=40 by appendHashSuffix, so this
+		// only fires for user-supplied UIDs (typically a _folder.json
+		// stable UID, but also any future caller-provided UID source).
 		// Surface it as a typed warning so the sync moves on.
 		if IsFolderUIDTooLongAPIError(err) {
 			return NewFolderUIDTooLongError(folder.Path, folder.ID, err)

--- a/pkg/registry/apis/provisioning/resources/folders.go
+++ b/pkg/registry/apis/provisioning/resources/folders.go
@@ -295,6 +295,13 @@ func (fm *FolderManager) EnsureFolderExists(ctx context.Context, folder Folder, 
 				if IsFolderUIDTooLongAPIError(err) {
 					return NewFolderUIDTooLongError(folder.Path, folder.ID, err)
 				}
+				// Catch-all for any other folder-API validation 4xx
+				// (illegal-uid-chars, reserved-uid, etc.). The repository
+				// owner must fix the offending input; retrying produces
+				// the same rejection.
+				if IsFolderValidationAPIError(err) {
+					return NewFolderValidationError(folder.Path, err)
+				}
 				return fmt.Errorf("update folder: %w", err)
 			}
 		}
@@ -386,6 +393,14 @@ func (fm *FolderManager) EnsureFolderExists(ctx context.Context, folder Folder, 
 		// Surface it as a typed warning so the sync moves on.
 		if IsFolderUIDTooLongAPIError(err) {
 			return NewFolderUIDTooLongError(folder.Path, folder.ID, err)
+		}
+		// Catch-all for any other folder-API validation 4xx the more
+		// specific matchers above did not claim (illegal-uid-chars,
+		// reserved-uid, future folder validations). The repository owner
+		// must fix the offending input; retrying produces the same
+		// rejection.
+		if IsFolderValidationAPIError(err) {
+			return NewFolderValidationError(folder.Path, err)
 		}
 
 		return fmt.Errorf("failed to create folder: %w", err)

--- a/pkg/registry/apis/provisioning/resources/folders.go
+++ b/pkg/registry/apis/provisioning/resources/folders.go
@@ -289,6 +289,12 @@ func (fm *FolderManager) EnsureFolderExists(ctx context.Context, folder Folder, 
 				if IsFolderDepthExceededAPIError(err) {
 					return NewFolderDepthExceededError(folder.Path, err)
 				}
+				// A managed folder ending up with a UID longer than 40 chars
+				// (typically via _folder.json metadata) cannot be repaired by
+				// a retry; surface it as a typed warning instead.
+				if IsFolderUIDTooLongAPIError(err) {
+					return NewFolderUIDTooLongError(folder.Path, folder.ID, err)
+				}
 				return fmt.Errorf("update folder: %w", err)
 			}
 		}
@@ -373,6 +379,13 @@ func (fm *FolderManager) EnsureFolderExists(ctx context.Context, folder Folder, 
 		// keep going for the rest of the tree.
 		if IsFolderDepthExceededAPIError(err) {
 			return NewFolderDepthExceededError(folder.Path, err)
+		}
+		// Same reasoning as depth above: a UID longer than the folder
+		// API's 40-character limit (typically a _folder.json stable UID
+		// or a path segment that overflowed) is a permanent rejection.
+		// Surface it as a typed warning so the sync moves on.
+		if IsFolderUIDTooLongAPIError(err) {
+			return NewFolderUIDTooLongError(folder.Path, folder.ID, err)
 		}
 
 		return fmt.Errorf("failed to create folder: %w", err)

--- a/pkg/registry/apis/provisioning/resources/folders_test.go
+++ b/pkg/registry/apis/provisioning/resources/folders_test.go
@@ -472,6 +472,69 @@ func TestEnsureFolderExists_TitleUpdate(t *testing.T) {
 		require.Equal(t, "deep/path/that/exceeds/limit/", depthErr.Path)
 		require.NotEmpty(t, client.updateCalls)
 	})
+
+	t.Run("wraps folder UID-too-long API error as FolderUIDTooLongError", func(t *testing.T) {
+		repo, _ := newRepo(t)
+		tree := NewEmptyFolderTree()
+
+		client := &fakeDynamicResourceClient{
+			getFn: func(name string) (*unstructured.Unstructured, error) {
+				return nil, apierrors.NewNotFound(schema.GroupResource{Group: "folder.grafana.app", Resource: "folders"}, name)
+			},
+			createFn: func(_ *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+				// Pre-fix Grafanas surface this as a 500 with "uid too long, max 40 characters"
+				// in the body. Post-fix Grafanas surface it as a structured 400 with the same
+				// public message; either form should classify as UID-too-long.
+				return nil, apierrors.NewBadRequest("uid too long, max 40 characters")
+			},
+		}
+
+		fm := NewFolderManager(repo, client, tree, FolderKind)
+		err := fm.EnsureFolderExists(ctx, Folder{
+			ID:    "a0123456789012345678901234567890123456789",
+			Title: "Bare metal services engineering",
+			Path:  "GMPO/bare-metal-services-engineering/",
+		}, "")
+
+		require.Error(t, err)
+		var uidErr *FolderUIDTooLongError
+		require.True(t, errors.As(err, &uidErr), "should return FolderUIDTooLongError")
+		require.Equal(t, "GMPO/bare-metal-services-engineering/", uidErr.Path)
+		require.Equal(t, "a0123456789012345678901234567890123456789", uidErr.UID)
+		require.NotEmpty(t, client.createCalls)
+	})
+
+	t.Run("wraps folder UID-too-long API error from Update (move) as FolderUIDTooLongError", func(t *testing.T) {
+		// Symmetric with the depth-exceeded Update case above: a managed
+		// folder being moved into a path whose derived UID overflows must
+		// also be classified as UID-too-long so the sync surfaces it as a
+		// warning instead of looping retries.
+		repo, cfg := newRepo(t)
+		tree := NewEmptyFolderTree()
+
+		client := &fakeDynamicResourceClient{
+			getFn: func(name string) (*unstructured.Unstructured, error) {
+				return managedFolder(name, "Old Title", cfg.Name), nil
+			},
+			updateFn: func(_ *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+				return nil, apierrors.NewBadRequest("uid too long, max 40 characters")
+			},
+		}
+
+		fm := NewFolderManager(repo, client, tree, FolderKind)
+		err := fm.EnsureFolderExists(ctx, Folder{
+			ID:    "a0123456789012345678901234567890123456789",
+			Title: "New Title",
+			Path:  "GMPO/bare-metal-services-engineering/",
+		}, "")
+
+		require.Error(t, err)
+		var uidErr *FolderUIDTooLongError
+		require.True(t, errors.As(err, &uidErr), "Update path should also return FolderUIDTooLongError")
+		require.Equal(t, "GMPO/bare-metal-services-engineering/", uidErr.Path)
+		require.Equal(t, "a0123456789012345678901234567890123456789", uidErr.UID)
+		require.NotEmpty(t, client.updateCalls)
+	})
 }
 
 type fakeDynamicResourceClient struct {

--- a/pkg/registry/apis/provisioning/resources/folders_test.go
+++ b/pkg/registry/apis/provisioning/resources/folders_test.go
@@ -482,9 +482,11 @@ func TestEnsureFolderExists_TitleUpdate(t *testing.T) {
 				return nil, apierrors.NewNotFound(schema.GroupResource{Group: "folder.grafana.app", Resource: "folders"}, name)
 			},
 			createFn: func(_ *unstructured.Unstructured) (*unstructured.Unstructured, error) {
-				// Pre-fix Grafanas surface this as a 500 with "uid too long, max 40 characters"
-				// in the body. Post-fix Grafanas surface it as a structured 400 with the same
-				// public message; either form should classify as UID-too-long.
+				// Simulates the post-#123843 form: a structured 400 from
+				// the folder apiserver carrying the legacy public message.
+				// IsFolderUIDTooLongAPIError's substring fallbacks cover
+				// the pre-fix legacy 500 form too; that's covered by the
+				// matcher unit tests in errors_test.go.
 				return nil, apierrors.NewBadRequest("uid too long, max 40 characters")
 			},
 		}

--- a/pkg/registry/apis/provisioning/resources/folders_test.go
+++ b/pkg/registry/apis/provisioning/resources/folders_test.go
@@ -535,6 +535,95 @@ func TestEnsureFolderExists_TitleUpdate(t *testing.T) {
 		require.Equal(t, "a0123456789012345678901234567890123456789", uidErr.UID)
 		require.NotEmpty(t, client.updateCalls)
 	})
+
+	t.Run("wraps generic folder validation 4xx as FolderValidationError", func(t *testing.T) {
+		// Any folder-API 400 with a structured "folder.*" message ID that
+		// is not one of the more specific cases above must be wrapped as
+		// FolderValidationError so the sync surfaces it as a warning
+		// rather than retrying. This case simulates the illegal-uid-chars
+		// rejection (e.g. a _folder.json with a UID containing a space).
+		repo, _ := newRepo(t)
+		tree := NewEmptyFolderTree()
+
+		genericValidation := &apierrors.StatusError{
+			ErrStatus: metav1.Status{
+				Status:  metav1.StatusFailure,
+				Code:    400,
+				Message: "uid contains illegal characters",
+				Details: &metav1.StatusDetails{
+					UID: "folder.invalid-uid-chars",
+				},
+			},
+		}
+
+		client := &fakeDynamicResourceClient{
+			getFn: func(name string) (*unstructured.Unstructured, error) {
+				return nil, apierrors.NewNotFound(schema.GroupResource{Group: "folder.grafana.app", Resource: "folders"}, name)
+			},
+			createFn: func(_ *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+				return nil, genericValidation
+			},
+		}
+
+		fm := NewFolderManager(repo, client, tree, FolderKind)
+		err := fm.EnsureFolderExists(ctx, Folder{
+			ID:    "hello world",
+			Title: "Bad title",
+			Path:  "bad-folder/",
+		}, "")
+
+		require.Error(t, err)
+		var validationErr *FolderValidationError
+		require.True(t, errors.As(err, &validationErr), "should return FolderValidationError")
+		require.Equal(t, "bad-folder/", validationErr.Path)
+		// The more-specific wrappers must NOT claim this error.
+		var depthErr *FolderDepthExceededError
+		require.False(t, errors.As(err, &depthErr), "must not be classified as depth-exceeded")
+		var uidErr *FolderUIDTooLongError
+		require.False(t, errors.As(err, &uidErr), "must not be classified as uid-too-long")
+		require.NotEmpty(t, client.createCalls)
+	})
+
+	t.Run("wraps generic folder validation 4xx from Update (move) as FolderValidationError", func(t *testing.T) {
+		// Symmetric with the depth/uid-too-long Update cases above: a
+		// generic folder validation rejection on the Update path must
+		// also be classified as a warning instead of looping retries.
+		repo, cfg := newRepo(t)
+		tree := NewEmptyFolderTree()
+
+		genericValidation := &apierrors.StatusError{
+			ErrStatus: metav1.Status{
+				Status:  metav1.StatusFailure,
+				Code:    400,
+				Message: "uid contains illegal characters",
+				Details: &metav1.StatusDetails{
+					UID: "folder.invalid-uid-chars",
+				},
+			},
+		}
+
+		client := &fakeDynamicResourceClient{
+			getFn: func(name string) (*unstructured.Unstructured, error) {
+				return managedFolder(name, "Old Title", cfg.Name), nil
+			},
+			updateFn: func(_ *unstructured.Unstructured) (*unstructured.Unstructured, error) {
+				return nil, genericValidation
+			},
+		}
+
+		fm := NewFolderManager(repo, client, tree, FolderKind)
+		err := fm.EnsureFolderExists(ctx, Folder{
+			ID:    "hello world",
+			Title: "New Title",
+			Path:  "bad-folder/",
+		}, "")
+
+		require.Error(t, err)
+		var validationErr *FolderValidationError
+		require.True(t, errors.As(err, &validationErr), "Update path should also return FolderValidationError")
+		require.Equal(t, "bad-folder/", validationErr.Path)
+		require.NotEmpty(t, client.updateCalls)
+	})
 }
 
 type fakeDynamicResourceClient struct {

--- a/pkg/tests/apis/provisioning/foldermetadata/full_sync_invalid_uid_chars_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/full_sync_invalid_uid_chars_test.go
@@ -85,14 +85,6 @@ func TestIntegrationProvisioning_FullSync_FolderInvalidUIDChars(t *testing.T) {
 		"expected exactly one folder-validation warning; saw %d. Warnings: %v",
 		validationWarnings, jobObj.Status.Warnings)
 
-	// The dashboard inside the offending folder must not surface as an
-	// error — it should be silently skipped because the parent folder
-	// creation already failed.
-	for _, e := range jobObj.Status.Errors {
-		require.NotContains(t, e, "bad-folder/dashboard2.json",
-			"resources under a rejected folder must not surface as errors")
-	}
-
 	// The shallow folder (outside the failing subtree) must still be
 	// created — a validation rejection in one branch must not block the
 	// rest of the sync.

--- a/pkg/tests/apis/provisioning/foldermetadata/full_sync_invalid_uid_chars_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/full_sync_invalid_uid_chars_test.go
@@ -1,0 +1,140 @@
+package foldermetadata
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+)
+
+// TestIntegrationProvisioning_FullSync_FolderInvalidUIDChars verifies that a
+// repository whose _folder.json declares a UID containing illegal characters
+// surfaces the rejection as a generic FolderValidationFailed warning. This
+// exercises the catch-all path in IsFolderValidationAPIError — the rejection
+// is neither depth-exceeded nor uid-too-long, but it is a folder-API
+// validation 4xx the sync cannot fix by retrying.
+//
+// The folder API validates that names match the DNS subdomain rules
+// (a-z, 0-9, -, .). A name containing a space therefore triggers
+// pkg/registry/apis/folders.ErrAPIInvalidUIDChars, which carries the
+// "folder.invalid-uid-chars" message ID.
+func TestIntegrationProvisioning_FullSync_FolderInvalidUIDChars(t *testing.T) {
+	helper := sharedHelper(t)
+
+	const repo = "folder-invalid-uid-chars-repo"
+	// Contains a space — illegal per the folder API's DNS-name validation.
+	const illegalUID = "hello world"
+
+	helper.CreateLocalRepo(t, common.TestRepo{
+		Name:                   repo,
+		SyncTarget:             "folder",
+		SkipSync:               true,
+		SkipResourceAssertions: true,
+	})
+
+	// Shallow folder with a valid UID — must be created normally despite
+	// the bad sibling branch.
+	writeToProvisioningPath(t, helper, "shallow/_folder.json", folderMetadataJSON("shallow-uid", "Shallow"))
+	writeToProvisioningPath(t, helper, "shallow/dashboard1.json", common.DashboardJSON("shallow-dash", "Shallow Dashboard", 1))
+
+	// Folder with an illegal UID — the folder API must reject it; the
+	// sync must surface the rejection as a warning, not an error.
+	writeToProvisioningPath(t, helper, "bad-folder/_folder.json", folderMetadataJSON(illegalUID, "Bad folder"))
+	writeToProvisioningPath(t, helper, "bad-folder/dashboard2.json", common.DashboardJSON("bad-folder-dash", "Bad Folder Dashboard", 1))
+
+	job := helper.TriggerJobAndWaitForComplete(t, repo, provisioning.JobSpec{
+		Action: provisioning.JobActionPull,
+		Pull:   &provisioning.SyncJobOptions{},
+	})
+
+	jobObj := &provisioning.Job{}
+	require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(job.Object, jobObj))
+
+	t.Logf("Job state: %s", jobObj.Status.State)
+	t.Logf("Job message: %s", jobObj.Status.Message)
+	t.Logf("Job warnings: %v", jobObj.Status.Warnings)
+	t.Logf("Job errors: %v", jobObj.Status.Errors)
+
+	require.Equal(t, provisioning.JobStateWarning, jobObj.Status.State,
+		"folder validation rejections must be reported as warnings so the job queue does not retry the sync forever")
+	require.Empty(t, jobObj.Status.Errors,
+		"folder validation rejections must not contribute to Status.Errors; treating them as errors triggers a retry loop")
+	require.NotEmpty(t, jobObj.Status.Warnings, "expected at least one warning describing the validation rejection")
+
+	// Exactly one validation warning is expected: the offending folder
+	// itself. Sibling resources under the same folder must be suppressed
+	// by the failedCreations short-circuit.
+	validationWarnings := 0
+	for _, w := range jobObj.Status.Warnings {
+		// Match either the legacy human-readable message or the structured
+		// errutil messageID embedded in the wrapped error.
+		if strings.Contains(w, "uid contains illegal characters") ||
+			strings.Contains(w, "folder.invalid-uid-chars") ||
+			strings.Contains(w, "validation error") {
+			validationWarnings++
+		}
+	}
+	require.Equal(t, 1, validationWarnings,
+		"expected exactly one folder-validation warning; saw %d. Warnings: %v",
+		validationWarnings, jobObj.Status.Warnings)
+
+	// The dashboard inside the offending folder must not surface as an
+	// error — it should be silently skipped because the parent folder
+	// creation already failed.
+	for _, e := range jobObj.Status.Errors {
+		require.NotContains(t, e, "bad-folder/dashboard2.json",
+			"resources under a rejected folder must not surface as errors")
+	}
+
+	// The shallow folder (outside the failing subtree) must still be
+	// created — a validation rejection in one branch must not block the
+	// rest of the sync.
+	helper.RequireRepoDashboardCount(t, repo, 1)
+
+	folders, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
+	require.NoError(t, err)
+
+	managedSourcePaths := make(map[string]struct{})
+	for _, f := range folders.Items {
+		managerID, _, _ := unstructured.NestedString(f.Object, "metadata", "annotations", "grafana.app/managerId")
+		if managerID != repo {
+			continue
+		}
+		sourcePath, _, _ := unstructured.NestedString(f.Object, "metadata", "annotations", "grafana.app/sourcePath")
+		managedSourcePaths[sourcePath] = struct{}{}
+	}
+
+	assert.Contains(t, managedSourcePaths, "shallow",
+		"the shallow folder must be created normally despite the validation rejection in another branch; got managed paths: %v",
+		managedSourcePaths)
+
+	// Pull condition must be a warning state, not Failure. The condition
+	// reason currently buckets generic warnings under
+	// ReasonCompletedWithWarnings; we assert that explicitly so a future
+	// change to surface ReasonFolderValidationFailed on the condition has
+	// to update this assertion intentionally.
+	helper.WaitForConditionReason(t, repo,
+		provisioning.ConditionTypePullStatus,
+		provisioning.ReasonCompletedWithWarnings)
+
+	// Re-running the sync must reproduce the same outcome (warning, not
+	// error) without crashing or losing the previously-synced shallow
+	// dashboard.
+	rerun := helper.TriggerJobAndWaitForComplete(t, repo, provisioning.JobSpec{
+		Action: provisioning.JobActionPull,
+		Pull:   &provisioning.SyncJobOptions{},
+	})
+	rerunObj := &provisioning.Job{}
+	require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(rerun.Object, rerunObj))
+	require.Equal(t, provisioning.JobStateWarning, rerunObj.Status.State,
+		"second pull should also surface the validation rejection as a warning, not an error")
+	require.Empty(t, rerunObj.Status.Errors)
+	helper.RequireRepoDashboardCount(t, repo, 1)
+}

--- a/pkg/tests/apis/provisioning/foldermetadata/full_sync_uid_too_long_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/full_sync_uid_too_long_test.go
@@ -91,14 +91,6 @@ func TestIntegrationProvisioning_FullSync_FolderUIDTooLong(t *testing.T) {
 		"expected exactly one uid-too-long warning; saw %d. Warnings: %v",
 		uidTooLongWarnings, jobObj.Status.Warnings)
 
-	// The dashboard inside the offending folder must not surface as a
-	// retryable error — it should be silently skipped because the parent
-	// folder creation already failed.
-	for _, e := range jobObj.Status.Errors {
-		require.NotContains(t, e, "bare-metal/dashboard2.json",
-			"resources under a uid-too-long folder must not surface as errors")
-	}
-
 	// The shallow folder (outside the failing subtree) must still be
 	// created — a UID violation in one branch must not block the rest of
 	// the sync.

--- a/pkg/tests/apis/provisioning/foldermetadata/full_sync_uid_too_long_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/full_sync_uid_too_long_test.go
@@ -1,0 +1,147 @@
+package foldermetadata
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+)
+
+// TestIntegrationProvisioning_FullSync_FolderUIDTooLong verifies that a
+// repository whose _folder.json declares a UID longer than the folder API's
+// 40-character limit surfaces the rejection as a warning on the sync job
+// (so the job is not requeued forever) instead of as a hard error.
+//
+// Path-derived UIDs are always truncated to <=40 characters by
+// resources.appendHashSuffix, so the only way a too-long UID reaches the
+// folder API is via _folder.json metadata. This test sets that up
+// explicitly and checks the same end-to-end contract that exists for
+// FolderDepthExceeded:
+//   - JobStateWarning, not Error
+//   - Status.Warnings mentions the offending path and the legacy
+//     "uid too long, max 40 characters" message
+//   - the condition reason for ConditionTypePullStatus is
+//     CompletedWithWarnings (current bucket; flips to FolderUIDTooLong if
+//     a future change surfaces it on the condition)
+//   - reruns produce the same warning state without state corruption
+func TestIntegrationProvisioning_FullSync_FolderUIDTooLong(t *testing.T) {
+	helper := sharedHelper(t)
+
+	const repo = "folder-uid-too-long-repo"
+	// 41 characters — one over the 40-char ceiling enforced by the folder API.
+	const tooLongUID = "a0123456789012345678901234567890123456789"
+	require.Equal(t, 41, len(tooLongUID), "test fixture must be exactly one over the 40-char limit")
+
+	helper.CreateLocalRepo(t, common.TestRepo{
+		Name:                   repo,
+		SyncTarget:             "folder",
+		SkipSync:               true,
+		SkipResourceAssertions: true,
+	})
+
+	// Shallow folder with a valid UID — must be created normally to prove
+	// that one bad branch does not block the rest of the sync.
+	writeToProvisioningPath(t, helper, "shallow/_folder.json", folderMetadataJSON("shallow-uid", "Shallow"))
+	writeToProvisioningPath(t, helper, "shallow/dashboard1.json", common.DashboardJSON("shallow-dash", "Shallow Dashboard", 1))
+
+	// Deep folder with a 41-char UID — the folder API must reject it; the
+	// sync must surface the rejection as a warning, not an error.
+	writeToProvisioningPath(t, helper, "bare-metal/_folder.json", folderMetadataJSON(tooLongUID, "Bare metal services engineering"))
+	writeToProvisioningPath(t, helper, "bare-metal/dashboard2.json", common.DashboardJSON("bare-metal-dash", "Bare Metal Dashboard", 1))
+
+	job := helper.TriggerJobAndWaitForComplete(t, repo, provisioning.JobSpec{
+		Action: provisioning.JobActionPull,
+		Pull:   &provisioning.SyncJobOptions{},
+	})
+
+	jobObj := &provisioning.Job{}
+	require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(job.Object, jobObj))
+
+	t.Logf("Job state: %s", jobObj.Status.State)
+	t.Logf("Job message: %s", jobObj.Status.Message)
+	t.Logf("Job warnings: %v", jobObj.Status.Warnings)
+	t.Logf("Job errors: %v", jobObj.Status.Errors)
+
+	require.Equal(t, provisioning.JobStateWarning, jobObj.Status.State,
+		"uid-too-long folders must be reported as warnings so the job queue does not retry the sync forever")
+	require.Empty(t, jobObj.Status.Errors,
+		"uid-too-long folders must not contribute to Status.Errors; treating them as errors triggers a retry loop")
+	require.NotEmpty(t, jobObj.Status.Warnings, "expected at least one warning describing the UID-length violation")
+
+	// Exactly one uid-too-long warning is expected: the offending folder
+	// itself. Sibling resources under the same folder must be suppressed by
+	// the failedCreations short-circuit so we don't burst-write identical
+	// bad requests against the folder API.
+	uidTooLongWarnings := 0
+	for _, w := range jobObj.Status.Warnings {
+		if strings.Contains(w, "uid too long, max 40 characters") ||
+			strings.Contains(w, "folder.uid-too-long") ||
+			strings.Contains(w, "40-character") {
+			uidTooLongWarnings++
+		}
+	}
+	require.Equal(t, 1, uidTooLongWarnings,
+		"expected exactly one uid-too-long warning; saw %d. Warnings: %v",
+		uidTooLongWarnings, jobObj.Status.Warnings)
+
+	// The dashboard inside the offending folder must not surface as a
+	// retryable error — it should be silently skipped because the parent
+	// folder creation already failed.
+	for _, e := range jobObj.Status.Errors {
+		require.NotContains(t, e, "bare-metal/dashboard2.json",
+			"resources under a uid-too-long folder must not surface as errors")
+	}
+
+	// The shallow folder (outside the failing subtree) must still be
+	// created — a UID violation in one branch must not block the rest of
+	// the sync.
+	helper.RequireRepoDashboardCount(t, repo, 1)
+
+	folders, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
+	require.NoError(t, err)
+
+	managedSourcePaths := make(map[string]struct{})
+	for _, f := range folders.Items {
+		managerID, _, _ := unstructured.NestedString(f.Object, "metadata", "annotations", "grafana.app/managerId")
+		if managerID != repo {
+			continue
+		}
+		sourcePath, _, _ := unstructured.NestedString(f.Object, "metadata", "annotations", "grafana.app/sourcePath")
+		managedSourcePaths[sourcePath] = struct{}{}
+	}
+
+	assert.Contains(t, managedSourcePaths, "shallow",
+		"the shallow folder must be created normally despite the UID violation in another branch; got managed paths: %v",
+		managedSourcePaths)
+
+	// Pull condition must be a warning state, not Failure. The condition
+	// reason currently buckets generic warnings under
+	// ReasonCompletedWithWarnings; we assert that explicitly so a future
+	// change to surface ReasonFolderUIDTooLong on the condition has to
+	// update this assertion intentionally.
+	helper.WaitForConditionReason(t, repo,
+		provisioning.ConditionTypePullStatus,
+		provisioning.ReasonCompletedWithWarnings)
+
+	// Re-running the sync must reproduce the same outcome (warning, not
+	// error) without crashing or losing the previously-synced shallow
+	// dashboard. This guards against regressions where a uid-too-long
+	// result poisons the repository state on the second pull.
+	rerun := helper.TriggerJobAndWaitForComplete(t, repo, provisioning.JobSpec{
+		Action: provisioning.JobActionPull,
+		Pull:   &provisioning.SyncJobOptions{},
+	})
+	rerunObj := &provisioning.Job{}
+	require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(rerun.Object, rerunObj))
+	require.Equal(t, provisioning.JobStateWarning, rerunObj.Status.State,
+		"second pull should also surface the UID violation as a warning, not an error")
+	require.Empty(t, rerunObj.Status.Errors)
+	helper.RequireRepoDashboardCount(t, repo, 1)
+}


### PR DESCRIPTION
## Summary

A user provisioning a Git repo hits this terminal sync error today:

```
ensuring folder exists at path GMPO/bare-metal-services-engineering/:
  failed to create path GMPO/bare-metal-services-engineering:
    ensure folder exists: failed to create folder: uid too long, max 40 characters
```

The folder API rejection is permanent — the user must shorten the offending `_folder.json` UID — but provisioning treats it as a retryable hard error and the sync job is requeued every 5 minutes. Same retry-loop bug #123726 fixed for max-depth, applied to the remaining folder validation 4xx surface area.

The folder apiserver side of this — wrapping `dashboards.ErrDashboardInvalidUid` / `ErrDashboardUidTooLong` in errutil so they render as structured 400s with stable `folder.invalid-uid-chars` / `folder.uid-too-long` message IDs — is already on main via #123843. This PR is the provisioning-side follow-up.

Path-derived UIDs always fit (`resources.appendHashSuffix` truncates to 40), so these rejections only fire when `_folder.json` declares a stable UID over the limit or with bad chars; the user must fix the repository, not wait for a retry.

## Changes

**Commit 1 — `FolderUIDTooLongError` (specific)**
- `apps/provisioning/pkg/apis/provisioning/v0alpha1/health.go`: `ReasonFolderUIDTooLong`.
- `pkg/registry/apis/provisioning/resources/errors.go`: `ErrFolderUIDTooLong` sentinel, `FolderUIDTooLongError` type, `IsFolderUIDTooLongAPIError` matcher (sentinel + `Status.Details.UID == "folder.uid-too-long"` + substring fallback for both pre-fix legacy 500-form and post-fix bracketed form).
- `pkg/registry/apis/provisioning/resources/folders.go`: `EnsureFolderExists` wraps the rejection on both Create and Update/move paths.
- `pkg/registry/apis/provisioning/jobs/job_resource_result.go`: `classifyWarning` maps it to `ReasonFolderUIDTooLong`.
- Unit tests at every layer mirror the existing `FolderDepthExceeded` coverage.
- `pkg/tests/apis/provisioning/foldermetadata/full_sync_uid_too_long_test.go`: integration test (env has folder metadata enabled) that writes a `_folder.json` with a 41-char UID, runs a pull job, asserts `JobStateWarning` (no errors), exactly one uid-too-long warning, the dashboard under the bad folder is silently skipped, the shallow folder still gets created, condition reason is `CompletedWithWarnings`, and a re-run reproduces the same warning state.

**Commit 2 — `FolderValidationError` (generic catch-all)**
- `apps/provisioning/pkg/apis/provisioning/v0alpha1/health.go`: `ReasonFolderValidationFailed`.
- `pkg/registry/apis/provisioning/resources/errors.go`: `ErrFolderValidation` sentinel, `FolderValidationError` type, `IsFolderValidationAPIError` matcher. Catches any K8s `StatusError` whose code is 400 and whose `Status.Details.UID` has the `folder.` messageID prefix — covers every existing folder errutil sentinel (now landed via #123843) and any new ones that follow the same pattern. Restricted to 400 (not all 4xx) so 401/403/404 stay in their existing `ResourceOwnership`/`Unmanaged` conflict territory; restricted to known message IDs so unknown 400s (likely caller bugs) keep surfacing as errors we can debug.
- `pkg/registry/apis/provisioning/resources/folders.go`: `EnsureFolderExists` wraps the rejection on both Create and Update/move paths *after* the more specific depth/uid-too-long checks.
- `pkg/registry/apis/provisioning/jobs/job_resource_result.go`: `classifyWarning` order guarantees `FolderDepthExceeded`/`FolderUIDTooLong` win over the generic `FolderValidationFailed` when both apply.
- `pkg/tests/apis/provisioning/foldermetadata/full_sync_invalid_uid_chars_test.go`: integration test exercising the catch-all path with an illegal-chars `_folder.json` UID (a `metadata.name` containing a space).

## Test plan

- [x] `go build` clean across all changed packages
- [x] `go vet` clean
- [x] `gofmt -l` clean
- [x] Unit tests pass: `pkg/registry/apis/provisioning/resources/`, `pkg/registry/apis/provisioning/jobs/`
- [x] Provisioning integration tests pass: `TestIntegrationProvisioning_FullSync_FolderUIDTooLong` (specific path), `TestIntegrationProvisioning_FullSync_FolderInvalidUIDChars` (generic catch-all path)

## Out of scope

- Hardening `resources.appendHashSuffix` itself — the existing 40-char truncation is correct; the rejection only reaches the folder API via `_folder.json` stable UIDs (or a future external-UID code path), both of which are user-actionable.
- Folder apiserver wrapping of UID validation errors — already merged in #123843.

## Related

- Builds on #123843 (folder validation errutil wrapping)
- Mirrors #123726 (folder depth → sync warning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)