### PR TITLE
fix: name generation for datasource dual writer

### DIFF
--- a/pkg/registry/apis/datasource/register.go
+++ b/pkg/registry/apis/datasource/register.go
@@ -256,13 +256,16 @@ func (b *DataSourceAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver
 		if err != nil {
 			return err
 		}
-		storage[ds.StoragePath()], err = opts.DualWriteBuilder(ds.GroupResource(), legacyStore, unified)
+		dualStore, err := opts.DualWriteBuilder(ds.GroupResource(), legacyStore, unified)
+		if err != nil {
+			return err
+		}
+		// generatedNameStorage assigns a server-generated name when the client
+		// sends none, which is the normal datasource create flow.
+		storage[ds.StoragePath()] = &generatedNameStorage{Storage: dualStore}
 		storage[ds.StoragePath("access")] = &subAccessREST{
 			builder: b,
 			getter:  legacyStore,
-		}
-		if err != nil {
-			return err
 		}
 	} else {
 		storage[ds.StoragePath()] = &connectionAccess{

--- a/pkg/registry/apis/datasource/storage.go
+++ b/pkg/registry/apis/datasource/storage.go
@@ -1,0 +1,31 @@
+package datasource
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/registry/rest"
+
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
+	"github.com/grafana/grafana/pkg/util"
+)
+
+// generatedNameStorage wraps a Storage to assign a server-generated name when
+// the incoming object has neither name nor generateName set. Datasource
+// creation relies on server-side UID generation: the frontend sends no name
+// and expects the legacy SQL store to assign one. The dualwriter requires a
+// name before calling the legacy store, so this wrapper generates one upfront
+// using the same short-UID format that the SQL store would use.
+type generatedNameStorage struct {
+	grafanarest.Storage
+}
+
+func (s *generatedNameStorage) Create(ctx context.Context, in runtime.Object, createValidation rest.ValidateObjectFunc, options *metav1.CreateOptions) (runtime.Object, error) {
+	acc, err := utils.MetaAccessor(in)
+	if err == nil && acc.GetName() == "" && acc.GetGenerateName() == "" {
+		acc.SetName(util.GenerateShortUID())
+	}
+	return s.Storage.Create(ctx, in, createValidation, options)
+}


### PR DESCRIPTION
Name generation for datasources is done in the backend, thus the guardrails put into the dual writer are breaking the datasource case. Here, I introduce a wrapper storage which covers the datasource specific logic prior to running dualwriter creation.