### PR TITLE
QueryEditor: Add feature toggle for multi-select

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1477,6 +1477,11 @@ export interface FeatureToggles {
   */
   queryEditorNext?: boolean;
   /**
+  * Enables multi-select UX (card checkboxes and bulk-actions footer) in the next query editor
+  * @default false
+  */
+  queryEditorNextMultiSelect?: boolean;
+  /**
   * Enables search for team bindings in the app platform API
   * @default false
   */

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
@@ -26,6 +26,7 @@ declare module "@openfeature/core" {
     | "useMTPlugins"
     | "dashboardSectionVariables"
     | "queryEditorNext"
+    | "queryEditorNextMultiSelect"
     | "managedPluginsV2"
     | "analyticsFramework"
     | "datasourcesApiServerEnableHealthEndpointFrontend"

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -55,6 +55,8 @@ export const FlagKeys = {
   ProvisioningFolderMetadata: "provisioningFolderMetadata",
   /** Enables next generation query editor experience */
   QueryEditorNext: "queryEditorNext",
+  /** Enables multi-select UX (card checkboxes and bulk-actions footer) in the next query editor */
+  QueryEditorNextMultiSelect: "queryEditorNextMultiSelect",
   /** Enables recently viewed dashboards section in the browsing dashboard page */
   RecentlyViewedDashboards: "recentlyViewedDashboards",
   /** Enables reporting for any page in Grafana */
@@ -298,6 +300,17 @@ export const useFlagProvisioningFolderMetadata = (options?: ReactFlagEvaluationO
  */
 export const useFlagQueryEditorNext = (options?: ReactFlagEvaluationOptions): boolean => {
   return useFlag("queryEditorNext", false, options).value;
+};
+
+/**
+ * Enables multi-select UX (card checkboxes and bulk-actions footer) in the next query editor
+ *
+ * **Details:**
+ * - flag key: `queryEditorNextMultiSelect`
+ * - default value: `false`
+ */
+export const useFlagQueryEditorNextMultiSelect = (options?: ReactFlagEvaluationOptions): boolean => {
+  return useFlag("queryEditorNextMultiSelect", false, options).value;
 };
 
 /**

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2551,6 +2551,14 @@ var (
 			Expression:  "false",
 		},
 		{
+			Name:        "queryEditorNextMultiSelect",
+			Description: "Enables multi-select UX (card checkboxes and bulk-actions footer) in the next query editor",
+			Stage:       FeatureStageExperimental,
+			Generate:    Generate{LegacyFrontend: true, React: true},
+			Owner:       grafanaDataProSquad,
+			Expression:  "false",
+		},
+		{
 			Name:         "kubernetesTeamBindings",
 			Description:  "Enables search for team bindings in the app platform API",
 			Stage:        FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -298,6 +298,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-01-14,alertingSyncDispatchTimer,experimental,@grafana/alerting-squad,false,true,false
 2026-02-18,queryWithAssistant,experimental,@grafana/data-sources-plugins,false,false,true
 2026-02-18,queryEditorNext,privatePreview,@grafana/datapro,false,false,true
+2026-04-29,queryEditorNextMultiSelect,experimental,@grafana/datapro,false,false,true
 2026-02-18,kubernetesTeamBindings,experimental,@grafana/identity-access-team,false,false,false
 2026-03-10,kubernetesTeamsApi,experimental,@grafana/identity-access-team,false,false,false
 2026-03-16,kubernetesTeamsRedirect,experimental,@grafana/identity-access-team,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -4724,6 +4724,20 @@
     },
     {
       "metadata": {
+        "name": "queryEditorNextMultiSelect",
+        "resourceVersion": "1777462601515",
+        "creationTimestamp": "2026-04-29T11:36:41Z"
+      },
+      "spec": {
+        "description": "Enables multi-select UX (card checkboxes and bulk-actions footer) in the next query editor",
+        "stage": "experimental",
+        "codeowner": "@grafana/datapro",
+        "frontend": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "queryFetchConfigFromSettingsService",
         "resourceVersion": "1773659793759",
         "creationTimestamp": "2026-03-16T11:16:33Z"

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Cards/SidebarCard.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Cards/SidebarCard.tsx
@@ -1,4 +1,5 @@
 import { css, cx } from '@emotion/css';
+import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { useCallback, useState } from 'react';
 
 import { colorManipulator, type GrafanaTheme2 } from '@grafana/data';
@@ -54,6 +55,7 @@ export const SidebarCard = ({
   const addVariant = item.type === QueryEditorType.Transformation ? 'transformation' : 'query';
   const hasActions = onDelete || onDuplicate || onToggleHide;
   const [hasFocusWithin, setHasFocusWithin] = useState(false);
+  const isMultiSelectEnabled = useBooleanFlagValue('queryEditorNextMultiSelect', false);
 
   const styles = useStyles2(getStyles, { isSelected, isPartOfSelection, item });
 
@@ -120,7 +122,13 @@ export const SidebarCard = ({
         aria-label={t('query-editor-next.sidebar.card-click', 'Select card {{id}}', { id })}
         aria-pressed={isSelected || isPartOfSelection}
       >
-        <div className={styles.cardContent}>{children}</div>
+        <div className={styles.cardContent}>
+          {isMultiSelectEnabled && (
+            // TODO(queryEditorNextMultiSelect): checkbox goes here
+            <></>
+          )}
+          {children}
+        </div>
         {/** Alerts don't have actions and cannot be hidden so we don't need to show the hidden icon or hover actions. */}
         {/** hasActions is indicating if this is an alert card or a query/transformation card. */}
         {hasActions && (

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Footer/SidebarFooter.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Footer/SidebarFooter.tsx
@@ -1,5 +1,4 @@
 import { css } from '@emotion/css';
-import { useBooleanFlagValue } from '@openfeature/react-sdk';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
@@ -19,14 +18,8 @@ export function SidebarFooter() {
   const { alertRules } = useAlertingContext();
   const { cardType } = useQueryEditorUIContext();
   const styles = useStyles2(getStyles);
-  const isMultiSelectEnabled = useBooleanFlagValue('queryEditorNextMultiSelect', false);
 
   const isAlertView = cardType === QueryEditorType.Alert;
-
-  if (isMultiSelectEnabled && !isAlertView) {
-    return <div className={styles.footer}>{/* TODO(queryEditorNextMultiSelect): new footer goes here */}</div>;
-  }
-
   const total = isAlertView ? alertRules.length : queries.length + transformations.length;
   const hidden = isAlertView
     ? 0

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Footer/SidebarFooter.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Footer/SidebarFooter.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/css';
+import { useBooleanFlagValue } from '@openfeature/react-sdk';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
@@ -18,8 +19,14 @@ export function SidebarFooter() {
   const { alertRules } = useAlertingContext();
   const { cardType } = useQueryEditorUIContext();
   const styles = useStyles2(getStyles);
+  const isMultiSelectEnabled = useBooleanFlagValue('queryEditorNextMultiSelect', false);
 
   const isAlertView = cardType === QueryEditorType.Alert;
+
+  if (isMultiSelectEnabled && !isAlertView) {
+    return <div className={styles.footer}>{/* TODO(queryEditorNextMultiSelect): new footer goes here */}</div>;
+  }
+
   const total = isAlertView ? alertRules.length : queries.length + transformations.length;
   const hidden = isAlertView
     ? 0

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Sidebar.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Sidebar.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/css';
+import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { memo } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
@@ -26,6 +27,7 @@ export const Sidebar = memo(function Sidebar({ sidebarSize, setSidebarSize }: Si
   const styles = useStyles2(getStyles);
   const { setSelectedAlert, cardType } = useQueryEditorUIContext();
   const { alertRules, loading } = useAlertingContext();
+  const isMultiSelectEnabled = useBooleanFlagValue('queryEditorNextMultiSelect', false);
 
   const handleViewChange = (view: QueryEditorType) => {
     trackSidebarViewChange(view);
@@ -54,7 +56,7 @@ export const Sidebar = memo(function Sidebar({ sidebarSize, setSidebarSize }: Si
           showBackground={false}
         />
       </SidebarHeaderActions>
-      <BulkActionsBar />
+      {!isMultiSelectEnabled && <BulkActionsBar />}
       {/** The translateX property of the hoverActions in SidebarCard causes the scroll container to overflow by 8px. */}
       <ScrollContainer overflowX="hidden">
         <div className={styles.content}>

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/testUtils.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/testUtils.tsx
@@ -1,3 +1,4 @@
+import { OpenFeatureProvider } from '@openfeature/react-sdk';
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { type ReactElement } from 'react';
@@ -5,6 +6,7 @@ import { type ReactElement } from 'react';
 import { type DataSourceInstanceSettings, getDefaultTimeRange, LoadingState, PluginType } from '@grafana/data';
 import { VizPanel } from '@grafana/scenes';
 import { type DataQuery } from '@grafana/schema';
+import { getTestFeatureFlagClient } from '@grafana/test-utils/unstable';
 import { type QueryGroupOptions } from 'app/types/query';
 
 import { QueryEditorType } from '../constants';
@@ -287,17 +289,19 @@ export function renderWithQueryEditorProvider(children: ReactElement, options: C
   return {
     user: userEvent.setup({ pointerEventsCheck: 0 }),
     ...render(
-      <QueryEditorProvider
-        dsState={defaultDsState}
-        qrState={defaultQrState}
-        panelState={defaultPanelState}
-        uiState={defaultUiState}
-        actions={defaultActions}
-        alertingState={defaultAlertingState}
-        typeConfig={mockTypeConfig}
-      >
-        {children}
-      </QueryEditorProvider>
+      <OpenFeatureProvider client={getTestFeatureFlagClient()}>
+        <QueryEditorProvider
+          dsState={defaultDsState}
+          qrState={defaultQrState}
+          panelState={defaultPanelState}
+          uiState={defaultUiState}
+          actions={defaultActions}
+          alertingState={defaultAlertingState}
+          typeConfig={mockTypeConfig}
+        >
+          {children}
+        </QueryEditorProvider>
+      </OpenFeatureProvider>
     ),
   };
 }


### PR DESCRIPTION
**What is this feature?**

Adds a new `queryEditorNextMultiSelect` feature toggle for the next query editor and wires it into the three sidebar components that will host the upcoming multi-select UX:

- `SidebarCard` - empty placeholder slot inside `cardContent` for the future checkbox.
- `SidebarFooter` - early-return empty footer when the flag is on (non-alert view), where the new `Select…` / bulk-actions UI will live.
- `Sidebar` - legacy `<BulkActionsBar />` is hidden when the flag is on, freeing the layout for the footer-based bulk actions.

Closes DPRO-53