### PR TITLE
ValueMappings: Align icon size with color picker size

### DIFF
--- a/public/app/features/dimensions/editors/ResourcePicker.tsx
+++ b/public/app/features/dimensions/editors/ResourcePicker.tsx
@@ -164,6 +164,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
     verticalAlign: 'middle',
     display: 'inline-block',
     fill: 'currentColor',
-    width: '25px',
+    width: '20px',
   }),
 });


### PR DESCRIPTION
Before:

<img width="331" height="202" alt="Screenshot 2026-04-29 at 15 45 30" src="https://github.com/user-attachments/assets/d0321644-dbe1-4bff-a0d0-146f6926e1d6" />


After: 

<img width="341" height="191" alt="Screenshot 2026-04-29 at 15 45 19" src="https://github.com/user-attachments/assets/4913ca05-4335-498d-a7b8-987419c9c9fd" />
