### PR TITLE
Search: scale retry budget for streaming index builds

### DIFF
--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -678,7 +678,8 @@ func (s *searchServer) buildIndexes(ctx context.Context) (int, error) {
 
 			s.log.Debug("building index", "namespace", info.Namespace, "group", info.Group, "resource", info.Resource)
 			reason := "init"
-			_, err := s.build(ctx, info.NamespacedResource, info.Count, reason, false, time.Time{})
+			// Use WithIndexBuildRetryBudget so it can retry based on number of keys.
+			_, err := s.build(WithIndexBuildRetryBudget(ctx), info.NamespacedResource, info.Count, reason, false, time.Time{})
 			return err
 		})
 	}
@@ -933,8 +934,9 @@ func (s *searchServer) rebuildIndex(ctx context.Context, req rebuildRequest) {
 		}
 	}
 
-	// Pass rebuild=true to force rebuild of any existing file-based index
-	_, err = s.build(ctx, req.NamespacedResource, size, "rebuild", true, time.Time{})
+	// Pass rebuild=true to force rebuild of any existing file-based index.
+	// Use WithIndexBuildRetryBudget so it can retry based on number of keys.
+	_, err = s.build(WithIndexBuildRetryBudget(ctx), req.NamespacedResource, size, "rebuild", true, time.Time{})
 	if err != nil {
 		span.RecordError(err)
 		l.Error("failed to rebuild index", "error", err)

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -1103,7 +1103,12 @@ func (k *kvStorageBackend) ListIterator(ctx context.Context, req *resourcepb.Lis
 		listRV = listOptions.ResourceVersion
 	}
 
-	// Fetch the latest objects
+	// Fetch the latest objects.
+	// TODO: stream keys into BatchGet instead of materializing the whole list.
+	// For unbounded list calls (e.g. index build with req.Limit == 0) at 1M
+	// rows this allocates ~250 MB of DataKey before any reads start. Pipe
+	// ListResourceKeysAtRevision through a bounded channel into BatchGet so
+	// memory is O(chunk), not O(N).
 	keys := make([]DataKey, 0, min(defaultListBufferSize, req.Limit+1))
 	for dataKey, err := range k.dataStore.ListResourceKeysAtRevision(ctx, listOptions) {
 		if err != nil {
@@ -1116,7 +1121,7 @@ func (k *kvStorageBackend) ListIterator(ctx context.Context, req *resourcepb.Lis
 			break
 		}
 	}
-	iter := newKvListIterator(ctx, k.dataStore, keys, listRV, req.Options.Key.Namespace == "")
+	iter := newKvListIterator(ctx, k.dataStore, keys, listRV, req.Options.Key.Namespace == "", k.retryPolicyFor(ctx))
 	defer iter.stop()
 
 	err := cb(iter)
@@ -1127,14 +1132,59 @@ func (k *kvStorageBackend) ListIterator(ctx context.Context, req *resourcepb.Lis
 	return listRV, nil
 }
 
-const (
-	// maxKvListIteratorConsecutiveFailures caps back-to-back retries with zero
-	// progress; the counter resets when an attempt yields a key.
-	maxKvListIteratorConsecutiveFailures = 3
-	// maxKvListIteratorTotalAttempts bounds total retryable failures to stop
-	// slow-drip loops (1 key per attempt, always fails) from hanging.
-	maxKvListIteratorTotalAttempts = 10
-)
+// BatchGetRetryPolicy bounds how many retryable BatchGet failures the
+// streaming list iterator absorbs before giving up.
+type BatchGetRetryPolicy struct {
+	// MaxConsecutiveFailures resets each time a key is yielded.
+	MaxConsecutiveFailures int
+	MaxTotalFailureRate    float64
+	// FailureBudgetFloor keeps tiny key sets from failing on the first hiccup.
+	FailureBudgetFloor int
+}
+
+func (p BatchGetRetryPolicy) totalBudget(numKeys int) int {
+	scaled := int(float64(numKeys) * p.MaxTotalFailureRate)
+	if scaled < p.FailureBudgetFloor {
+		return p.FailureBudgetFloor
+	}
+	return scaled
+}
+
+// defaultBatchGetRetryPolicy keeps a stuck KV from blocking sync requests
+// for more than ~5s under the 500ms minimum backoff.
+var defaultBatchGetRetryPolicy = BatchGetRetryPolicy{
+	MaxConsecutiveFailures: 3,
+	FailureBudgetFloor:     10,
+}
+
+// defaultRebuildBatchGetRetryPolicy absorbs a sustained ~5% failure rate on
+// million-key rebuilds with 2x headroom.
+var defaultRebuildBatchGetRetryPolicy = BatchGetRetryPolicy{
+	MaxConsecutiveFailures: 3,
+	MaxTotalFailureRate:    0.10,
+	FailureBudgetFloor:     20,
+}
+
+type indexBuildRetryBudgetCtxKey struct{}
+
+// WithIndexBuildRetryBudget opts the caller into the dataset-size-scaled
+// retry budget. Use only on long-running background reads — synchronous
+// API paths must not call it or transient KV issues turn into minutes-long
+// client waits.
+func WithIndexBuildRetryBudget(ctx context.Context) context.Context {
+	return context.WithValue(ctx, indexBuildRetryBudgetCtxKey{}, struct{}{})
+}
+
+func isIndexBuildRetryBudget(ctx context.Context) bool {
+	return ctx.Value(indexBuildRetryBudgetCtxKey{}) != nil
+}
+
+func (k *kvStorageBackend) retryPolicyFor(ctx context.Context) BatchGetRetryPolicy {
+	if isIndexBuildRetryBudget(ctx) {
+		return defaultRebuildBatchGetRetryPolicy
+	}
+	return defaultBatchGetRetryPolicy
+}
 
 // kvListIteratorBackoff is the default backoff config used between retry attempts.
 var kvListIteratorBackoff = backoff.Config{
@@ -1151,6 +1201,7 @@ type batchGetRetryPull struct {
 	nextIdx   int // next not-yet-yielded position in keys
 	stopFn    func()
 	retryBo   *backoff.Backoff
+	policy    BatchGetRetryPolicy
 
 	consecutiveFailures int
 	totalFailures       int
@@ -1160,12 +1211,13 @@ type batchGetRetryPull struct {
 
 // newBatchGetRetryPull builds a pull-style iterator over dataStore.BatchGet
 // that retries on kv.ErrRetryable failures.
-func newBatchGetRetryPull(ctx context.Context, ds *dataStore, keys []DataKey) *batchGetRetryPull {
+func newBatchGetRetryPull(ctx context.Context, ds *dataStore, keys []DataKey, policy BatchGetRetryPolicy) *batchGetRetryPull {
 	p := &batchGetRetryPull{
 		ctx:       ctx,
 		dataStore: ds,
 		keys:      keys,
 		retryBo:   backoff.New(ctx, kvListIteratorBackoff),
+		policy:    policy,
 	}
 	p.next, p.stopFn = iter.Pull2(p.dataStore.BatchGet(p.ctx, keys))
 	return p
@@ -1199,18 +1251,20 @@ func (p *batchGetRetryPull) tryRetry(err error) (bool, error) {
 	}
 	p.totalFailures++
 	p.consecutiveFailures++
+	totalBudget := p.policy.totalBudget(len(p.keys))
 	logArgs := []any{
 		"next_idx", p.nextIdx,
 		"remaining_keys", len(p.keys) - p.nextIdx,
 		"total_failures", p.totalFailures,
 		"consecutive_failures", p.consecutiveFailures,
+		"total_budget", totalBudget,
 		"error", err,
 	}
-	if p.totalFailures >= maxKvListIteratorTotalAttempts {
+	if p.totalFailures >= totalBudget {
 		batchGetRetryLogger.Warn("kv BatchGet retry budget exhausted (total attempts)", logArgs...)
 		return false, nil
 	}
-	if p.consecutiveFailures >= maxKvListIteratorConsecutiveFailures {
+	if p.consecutiveFailures >= p.policy.MaxConsecutiveFailures {
 		batchGetRetryLogger.Warn("kv BatchGet retry budget exhausted (consecutive failures)", logArgs...)
 		return false, nil
 	}
@@ -1245,11 +1299,11 @@ func (p *batchGetRetryPull) stop() {
 }
 
 // newKvListIterator builds a kvListIterator over dataStore.BatchGet(keys).
-func newKvListIterator(ctx context.Context, ds *dataStore, keys []DataKey, listRV int64, isCrossNamespace bool) *kvListIterator {
+func newKvListIterator(ctx context.Context, ds *dataStore, keys []DataKey, listRV int64, isCrossNamespace bool, policy BatchGetRetryPolicy) *kvListIterator {
 	return &kvListIterator{
 		listRV:           listRV,
 		isCrossNamespace: isCrossNamespace,
-		pull:             newBatchGetRetryPull(ctx, ds, keys),
+		pull:             newBatchGetRetryPull(ctx, ds, keys, policy),
 	}
 }
 
@@ -1736,7 +1790,7 @@ func (k *kvStorageBackend) ListHistory(ctx context.Context, req *resourcepb.List
 	// Pagination: filter out items up to and including lastSeenRV
 	pagedKeys := applyPagination(filteredKeys, lastSeenRV)
 
-	iter := newKvHistoryIterator(ctx, k.dataStore, pagedKeys, listRV, false)
+	iter := newKvHistoryIterator(ctx, k.dataStore, pagedKeys, listRV, false, k.retryPolicyFor(ctx))
 	defer iter.stop()
 
 	if err := fn(iter); err != nil {
@@ -1816,7 +1870,7 @@ func (k *kvStorageBackend) processTrashEntries(
 	// Apply RV-based pagination: skip candidates already seen on previous pages.
 	candidates = applyPagination(candidates, lastSeenRV)
 
-	iter := newKvHistoryIterator(ctx, k.dataStore, candidates, listRV, true)
+	iter := newKvHistoryIterator(ctx, k.dataStore, candidates, listRV, true, k.retryPolicyFor(ctx))
 	defer iter.stop()
 
 	if err := fn(iter); err != nil {
@@ -1840,11 +1894,11 @@ func matchesTrashVersionFilter(req *resourcepb.ListRequest, key DataKey) bool {
 }
 
 // newKvHistoryIterator builds a kvHistoryIterator over dataStore.BatchGet(keys).
-func newKvHistoryIterator(ctx context.Context, ds *dataStore, keys []DataKey, listRV int64, skipProvisioned bool) *kvHistoryIterator {
+func newKvHistoryIterator(ctx context.Context, ds *dataStore, keys []DataKey, listRV int64, skipProvisioned bool, policy BatchGetRetryPolicy) *kvHistoryIterator {
 	return &kvHistoryIterator{
 		listRV:          listRV,
 		skipProvisioned: skipProvisioned,
-		pull:            newBatchGetRetryPull(ctx, ds, keys),
+		pull:            newBatchGetRetryPull(ctx, ds, keys, policy),
 	}
 }
 

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -1137,13 +1137,15 @@ func (k *kvStorageBackend) ListIterator(ctx context.Context, req *resourcepb.Lis
 type BatchGetRetryPolicy struct {
 	// MaxConsecutiveFailures resets each time a key is yielded.
 	MaxConsecutiveFailures int
-	MaxTotalFailureRate    float64
+	// MaxTotalFailureRate scales the budget by the number of BatchGet chunks
+	MaxTotalFailureRate float64
 	// FailureBudgetFloor keeps tiny key sets from failing on the first hiccup.
 	FailureBudgetFloor int
 }
 
 func (p BatchGetRetryPolicy) totalBudget(numKeys int) int {
-	scaled := int(float64(numKeys) * p.MaxTotalFailureRate)
+	chunks := (numKeys + dataBatchSize - 1) / dataBatchSize
+	scaled := int(float64(chunks) * p.MaxTotalFailureRate)
 	if scaled < p.FailureBudgetFloor {
 		return p.FailureBudgetFloor
 	}

--- a/pkg/storage/unified/resource/storage_backend_list_retry_test.go
+++ b/pkg/storage/unified/resource/storage_backend_list_retry_test.go
@@ -6,10 +6,12 @@ import (
 	"errors"
 	"fmt"
 	"iter"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/grafana/dskit/backoff"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -103,6 +105,12 @@ func swapListBackoff(t *testing.T) {
 	t.Cleanup(func() { kvListIteratorBackoff = orig })
 }
 
+var testRetryPolicy = BatchGetRetryPolicy{
+	MaxConsecutiveFailures: 3,
+	MaxTotalFailureRate:    0,  // rely solely on FailureBudgetFloor
+	FailureBudgetFloor:     10, // legacy maxKvListIteratorTotalAttempts
+}
+
 func makeTestDataKey(name string) DataKey {
 	return DataKey{
 		Group:           "testgroup",
@@ -129,7 +137,7 @@ func seedKeys(t *testing.T, ds *dataStore, n int, body func(i int) string) []Dat
 	ctx := context.Background()
 	out := make([]DataKey, 0, n)
 	for i := 0; i < n; i++ {
-		dk := makeTestDataKey("obj-" + string(rune('a'+i)))
+		dk := makeTestDataKey(fmt.Sprintf("obj-%06d", i))
 		require.NoError(t, ds.Save(ctx, dk, bytes.NewReader([]byte(body(i)))))
 		out = append(out, dk)
 	}
@@ -159,26 +167,26 @@ func collectNames(it ListIterator) ([]string, error) {
 // setupListRetryTest wires a flakyBatchGetKV around a fresh Badger store,
 // seeds n list-style keys, and returns an attached kvListIterator along
 // with the seeded keys and the flaky wrapper for assertions.
-func setupListRetryTest(t *testing.T, n int, plan []flakyStep) (*kvListIterator, []DataKey, *flakyBatchGetKV) {
+func setupListRetryTest(t *testing.T, n int, plan []flakyStep, policy BatchGetRetryPolicy) (*kvListIterator, []DataKey, *flakyBatchGetKV) {
 	t.Helper()
 	realKV := setupBadgerKV(t)
 	ds := newDataStore(realKV, nil)
 	keys := seedKeys(t, ds, n, func(int) string { return "v" })
 	flaky := &flakyBatchGetKV{KV: realKV, plan: plan}
-	it := newKvListIterator(context.Background(), newDataStore(flaky, nil), keys, 0, false)
+	it := newKvListIterator(context.Background(), newDataStore(flaky, nil), keys, 0, false, policy)
 	t.Cleanup(it.stop)
 	return it, keys, flaky
 }
 
 // setupHistoryRetryTest is the history analogue of setupListRetryTest.
 // manager is the per-index provisioned-kind annotation; pass nil for none.
-func setupHistoryRetryTest(t *testing.T, n int, manager []string, skipProvisioned bool, plan []flakyStep) (*kvHistoryIterator, []DataKey, *flakyBatchGetKV) {
+func setupHistoryRetryTest(t *testing.T, n int, manager []string, skipProvisioned bool, plan []flakyStep, policy BatchGetRetryPolicy) (*kvHistoryIterator, []DataKey, *flakyBatchGetKV) {
 	t.Helper()
 	realKV := setupBadgerKV(t)
 	ds := newDataStore(realKV, nil)
 	keys := seedKeys(t, ds, n, historyBody(manager))
 	flaky := &flakyBatchGetKV{KV: realKV, plan: plan}
-	it := newKvHistoryIterator(context.Background(), newDataStore(flaky, nil), keys, 0, skipProvisioned)
+	it := newKvHistoryIterator(context.Background(), newDataStore(flaky, nil), keys, 0, skipProvisioned, policy)
 	t.Cleanup(it.stop)
 	return it, keys, flaky
 }
@@ -192,14 +200,14 @@ var iteratorFlavors = []iteratorFlavor{
 	{
 		name: "list",
 		setup: func(t *testing.T, n int, plan []flakyStep) (ListIterator, []DataKey, *flakyBatchGetKV) {
-			it, keys, flaky := setupListRetryTest(t, n, plan)
+			it, keys, flaky := setupListRetryTest(t, n, plan, testRetryPolicy)
 			return it, keys, flaky
 		},
 	},
 	{
 		name: "history",
 		setup: func(t *testing.T, n int, plan []flakyStep) (ListIterator, []DataKey, *flakyBatchGetKV) {
-			it, keys, flaky := setupHistoryRetryTest(t, n, nil, false, plan)
+			it, keys, flaky := setupHistoryRetryTest(t, n, nil, false, plan, testRetryPolicy)
 			return it, keys, flaky
 		},
 	},
@@ -262,12 +270,12 @@ func TestKvIterator_Retry(t *testing.T) {
 
 			t.Run("exhausts consecutive-failure budget", func(t *testing.T) {
 				it, _, flaky := f.setup(t, 3,
-					failAt(0, maxKvListIteratorConsecutiveFailures, retryableErr(errors.New("down"))))
+					failAt(0, testRetryPolicy.MaxConsecutiveFailures, retryableErr(errors.New("down"))))
 				names, err := collectNames(it)
 				require.Error(t, err)
 				assert.ErrorIs(t, err, kv.ErrRetryable)
 				assert.Empty(t, names)
-				assert.Equal(t, maxKvListIteratorConsecutiveFailures, flaky.injected)
+				assert.Equal(t, testRetryPolicy.MaxConsecutiveFailures, flaky.injected)
 			})
 
 			t.Run("exhausts total-attempt budget despite progress", func(t *testing.T) {
@@ -275,11 +283,12 @@ func TestKvIterator_Retry(t *testing.T) {
 				// the consecutive counter resets between failures. Total
 				// attempts must still cap the retries.
 				retry := retryableErr(errors.New("flap"))
-				plan := make([]flakyStep, maxKvListIteratorTotalAttempts)
+				totalCap := testRetryPolicy.totalBudget(testRetryPolicy.FailureBudgetFloor + 2)
+				plan := make([]flakyStep, totalCap)
 				for i := range plan {
 					plan[i] = flakyStep{at: i + 1, err: retry}
 				}
-				it, keys, flaky := f.setup(t, maxKvListIteratorTotalAttempts+2, plan)
+				it, keys, flaky := f.setup(t, totalCap+2, plan)
 				names, err := collectNames(it)
 				require.Error(t, err)
 				assert.ErrorIs(t, err, kv.ErrRetryable)
@@ -287,7 +296,7 @@ func TestKvIterator_Retry(t *testing.T) {
 				// was yielded, but not all of them.
 				assert.NotEmpty(t, names)
 				assert.Less(t, len(names), len(keys))
-				assert.Equal(t, maxKvListIteratorTotalAttempts, flaky.injected)
+				assert.Equal(t, totalCap, flaky.injected)
 			})
 
 			t.Run("ContinueToken is non-empty across retryable recoveries", func(t *testing.T) {
@@ -316,14 +325,63 @@ func TestKvIterator_Retry(t *testing.T) {
 		})
 	}
 
+	// spreadFailures returns a plan with `failures` retryable errors
+	// distributed evenly across `n` yields, each at the midpoint of its
+	// stride window so every failure is preceded by successful yields.
+	// That keeps offsets in [0, n) and stops the consecutive-failure cap
+	// from tripping for low failure rates.
+	spreadFailures := func(n, failures int, err error) []flakyStep {
+		plan := make([]flakyStep, failures)
+		stride := n / failures
+		for i := range plan {
+			plan[i] = flakyStep{at: i*stride + stride/2, err: err}
+		}
+		return plan
+	}
+
+	scaledPolicy := BatchGetRetryPolicy{
+		MaxConsecutiveFailures: 3,
+		MaxTotalFailureRate:    0.10,
+		FailureBudgetFloor:     20,
+	}
+
+	t.Run("scaled budget tolerates spread-out failures across large key set", func(t *testing.T) {
+		// 500 keys with 5% failures. Scaled budget is max(20, 0.10*500) = 50.
+		const n = 500
+		const failures = n / 20
+		it, keys, flaky := setupListRetryTest(t, n,
+			spreadFailures(n, failures, retryableErr(errors.New("noise"))),
+			scaledPolicy)
+		names, err := collectNames(it)
+		require.NoError(t, err)
+		assert.Equal(t, keyNames(keys), names)
+		assert.Equal(t, failures, flaky.injected)
+	})
+
+	t.Run("scaled budget still trips on excessive failure rate", func(t *testing.T) {
+		// 200 keys with 25% failures (50 errors) exceeds the budget of
+		// max(20, 0.10*200) = 20.
+		const n = 200
+		const failures = 50
+		it, _, flaky := setupListRetryTest(t, n,
+			spreadFailures(n, failures, retryableErr(errors.New("flood"))),
+			scaledPolicy)
+		names, err := collectNames(it)
+		require.Error(t, err)
+		assert.ErrorIs(t, err, kv.ErrRetryable)
+		assert.NotEmpty(t, names)
+		assert.Less(t, len(names), n)
+		assert.Equal(t, scaledPolicy.totalBudget(n), flaky.injected)
+	})
+
 	// kvListIterator specific behavior
 	t.Run("ContinueToken sees valid next key after retryable prefetch failure", func(t *testing.T) {
 		it, keys, _ := setupListRetryTest(t, 3,
-			failAt(1, 1, retryableErr(errors.New("prefetch flap"))))
+			failAt(1, 1, retryableErr(errors.New("prefetch flap"))),
+			testRetryPolicy)
 
 		require.True(t, it.Next())
 		require.Equal(t, keys[0].Name, it.Name())
-		// The continue token is the next key (obj-b)
 		assert.NotEmpty(t, it.ContinueToken(), "ContinueToken must not be empty right after a retryable prefetch failure was resolved")
 		assert.Equal(t, keys[1].Name, it.nextDataObj.Key.Name)
 
@@ -339,13 +397,127 @@ func TestKvIterator_Retry(t *testing.T) {
 		// manager kind). With skipProvisioned=true the iterator must yield
 		// only the two unmanaged items — AND if a retryable error fires
 		// after a skipped item, the retry must not re-fetch it.
-		it, _, flaky := setupHistoryRetryTest(t, 4,
+		it, keys, flaky := setupHistoryRetryTest(t, 4,
 			[]string{"", "git", "", "git"}, true,
-			failAt(2, 1, retryableErr(errors.New("flap"))))
+			failAt(2, 1, retryableErr(errors.New("flap"))),
+			testRetryPolicy)
 		names, err := collectNames(it)
 		require.NoError(t, err)
-		// obj-a (idx 0, unmanaged) and obj-c (idx 2, unmanaged) survive.
-		assert.Equal(t, []string{"obj-a", "obj-c"}, names)
+		// idx 0 and idx 2 are unmanaged and survive.
+		assert.Equal(t, []string{keys[0].Name, keys[2].Name}, names)
 		assert.Equal(t, 1, flaky.injected)
 	})
+}
+
+func TestKvStorageBackend_retryPolicyFor(t *testing.T) {
+	k := &kvStorageBackend{}
+
+	t.Run("untagged ctx picks the fixed sync default", func(t *testing.T) {
+		assert.Equal(t, defaultBatchGetRetryPolicy, k.retryPolicyFor(context.Background()))
+	})
+
+	t.Run("WithIndexBuildRetryBudget picks the fixed rebuild default", func(t *testing.T) {
+		ctx := WithIndexBuildRetryBudget(context.Background())
+		assert.Equal(t, defaultRebuildBatchGetRetryPolicy, k.retryPolicyFor(ctx))
+	})
+}
+
+func TestBatchGetRetryPolicy_TotalBudget(t *testing.T) {
+	t.Run("rate=0 makes the budget exactly the floor", func(t *testing.T) {
+		p := BatchGetRetryPolicy{
+			MaxConsecutiveFailures: 3,
+			MaxTotalFailureRate:    0,
+			FailureBudgetFloor:     50,
+		}
+		assert.Equal(t, 50, p.totalBudget(1_000_000),
+			"with rate=0, budget must be the floor regardless of key count")
+	})
+
+	t.Run("rate>0 scales above the floor", func(t *testing.T) {
+		p := BatchGetRetryPolicy{
+			MaxConsecutiveFailures: 3,
+			MaxTotalFailureRate:    0.05,
+			FailureBudgetFloor:     20,
+		}
+		assert.Equal(t, 20, p.totalBudget(100),
+			"100 keys × 5%% = 5 < floor 20 → budget is the floor")
+		assert.Equal(t, 5000, p.totalBudget(100_000),
+			"100k keys × 5%% = 5000 > floor 20 → budget is the rate")
+	})
+}
+
+// ctxCapturingStorage wraps mockStorageBackend and records the ctx passed
+// to ListIterator. Tests use this to assert that the right callers tag ctx
+// with WithIndexBuildRetryBudget.
+type ctxCapturingStorage struct {
+	mockStorageBackend
+	mu           sync.Mutex
+	listIterCtxs []context.Context
+}
+
+func (c *ctxCapturingStorage) ListIterator(ctx context.Context, _ *resourcepb.ListRequest, _ func(ListIterator) error) (int64, error) {
+	c.mu.Lock()
+	c.listIterCtxs = append(c.listIterCtxs, ctx)
+	c.mu.Unlock()
+	return 0, nil
+}
+
+func newRetryBudgetTestServer(t *testing.T, storage StorageBackend) *searchServer {
+	t.Helper()
+	opts := SearchOptions{
+		Backend: &mockSearchBackend{},
+		Resources: &TestDocumentBuilderSupplier{
+			GroupsResources: map[string]string{"g": "r"},
+		},
+		InitMinCount: 1,
+	}
+	s, err := newSearchServer(opts, storage, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+	require.NotNil(t, s)
+	return s
+}
+
+// TestSearchServer_InitTagsCtxForRebuildBudget pins the wiring that
+// resolved the original startup failure: when init runs s.buildIndexes,
+// the ctx that reaches the storage backend must carry the
+// WithIndexBuildRetryBudget marker.
+func TestSearchServer_InitTagsCtxForRebuildBudget(t *testing.T) {
+	storage := &ctxCapturingStorage{
+		mockStorageBackend: mockStorageBackend{
+			resourceStats: []ResourceStats{
+				{NamespacedResource: NamespacedResource{Namespace: "ns", Group: "g", Resource: "r"}, Count: 50, ResourceVersion: 1},
+			},
+		},
+	}
+	s := newRetryBudgetTestServer(t, storage)
+
+	_, err := s.buildIndexes(context.Background())
+	require.NoError(t, err)
+
+	require.Len(t, storage.listIterCtxs, 1, "init must call ListIterator once for the seeded resource")
+	assert.True(t, isIndexBuildRetryBudget(storage.listIterCtxs[0]),
+		"init's call to s.build must tag ctx with WithIndexBuildRetryBudget")
+}
+
+// TestSearchServer_GetOrCreateIndexDoesNotTagCtx guards against the
+// reviewer's concern: under context.WithoutCancel a flaky build at request
+// time could otherwise consume a budget proportional to the full key
+// count, stalling search requests for hours.
+func TestSearchServer_GetOrCreateIndexDoesNotTagCtx(t *testing.T) {
+	storage := &ctxCapturingStorage{
+		mockStorageBackend: mockStorageBackend{
+			resourceStats: []ResourceStats{
+				{NamespacedResource: NamespacedResource{Namespace: "ns", Group: "g", Resource: "r"}, Count: 50, ResourceVersion: 1},
+			},
+		},
+	}
+	s := newRetryBudgetTestServer(t, storage)
+
+	_, err := s.getOrCreateIndex(context.Background(), nil,
+		NamespacedResource{Namespace: "ns", Group: "g", Resource: "r"}, "test")
+	require.NoError(t, err)
+
+	require.Len(t, storage.listIterCtxs, 1, "getOrCreateIndex must call ListIterator once")
+	assert.False(t, isIndexBuildRetryBudget(storage.listIterCtxs[0]),
+		"getOrCreateIndex must NOT tag ctx with the rebuild retry budget")
 }

--- a/pkg/storage/unified/resource/storage_backend_list_retry_test.go
+++ b/pkg/storage/unified/resource/storage_backend_list_retry_test.go
@@ -345,10 +345,12 @@ func TestKvIterator_Retry(t *testing.T) {
 		FailureBudgetFloor:     20,
 	}
 
-	t.Run("scaled budget tolerates spread-out failures across large key set", func(t *testing.T) {
-		// 500 keys with 5% failures. Scaled budget is max(20, 0.10*500) = 50.
+	t.Run("scaled budget tolerates failures up to the floor", func(t *testing.T) {
+		// 500 keys / 50-key chunks = 10 chunks. With rate 0.10 the
+		// scaled term is 1, so the floor (20) wins. 15 spread chunk
+		// failures fit comfortably under the budget.
 		const n = 500
-		const failures = n / 20
+		const failures = 15
 		it, keys, flaky := setupListRetryTest(t, n,
 			spreadFailures(n, failures, retryableErr(errors.New("noise"))),
 			scaledPolicy)
@@ -358,9 +360,9 @@ func TestKvIterator_Retry(t *testing.T) {
 		assert.Equal(t, failures, flaky.injected)
 	})
 
-	t.Run("scaled budget still trips on excessive failure rate", func(t *testing.T) {
-		// 200 keys with 25% failures (50 errors) exceeds the budget of
-		// max(20, 0.10*200) = 20.
+	t.Run("scaled budget trips when failures exceed the budget", func(t *testing.T) {
+		// 200 keys / 50-key chunks = 4 chunks. Budget = max(20, 4*0.10)
+		// = 20. 50 injected failures exhaust the budget at 20.
 		const n = 200
 		const failures = 50
 		it, _, flaky := setupListRetryTest(t, n,
@@ -433,16 +435,16 @@ func TestBatchGetRetryPolicy_TotalBudget(t *testing.T) {
 			"with rate=0, budget must be the floor regardless of key count")
 	})
 
-	t.Run("rate>0 scales above the floor", func(t *testing.T) {
+	t.Run("rate scales by BatchGet chunks, not raw keys", func(t *testing.T) {
 		p := BatchGetRetryPolicy{
 			MaxConsecutiveFailures: 3,
-			MaxTotalFailureRate:    0.05,
+			MaxTotalFailureRate:    0.10,
 			FailureBudgetFloor:     20,
 		}
-		assert.Equal(t, 20, p.totalBudget(100),
-			"100 keys × 5%% = 5 < floor 20 → budget is the floor")
-		assert.Equal(t, 5000, p.totalBudget(100_000),
-			"100k keys × 5%% = 5000 > floor 20 → budget is the rate")
+		// 100 keys = ceil(100/50) = 2 chunks; 2 * 0.10 = 0.2 → floor wins.
+		assert.Equal(t, 20, p.totalBudget(100))
+		// 1M keys = 20000 chunks; 20000 * 0.10 = 2000 → rate wins.
+		assert.Equal(t, 2000, p.totalBudget(1_000_000))
 	})
 }
 

--- a/pkg/storage/unified/search/bleve_snapshot.go
+++ b/pkg/storage/unified/search/bleve_snapshot.go
@@ -82,6 +82,10 @@ func (b *bleveBackend) tryDownloadRemoteSnapshot(
 	}
 
 	start := time.Now()
+	// TODO: retry DownloadIndex on transient errors before falling through to a
+	// from-scratch KV rebuild. The object store is its own fault domain;
+	// a single failed download shouldn't force a full rebuild for large
+	// indexes (e.g. a 1M-doc dashboard index would re-pay every read).
 	downloadedMeta, err := store.DownloadIndex(ctx, key, candidate.key, destDir)
 	if err != nil {
 		_ = os.RemoveAll(destDir)


### PR DESCRIPTION
## Summary

The hardcoded 10-failure cap in the streaming `BatchGet` retry pull aborts a 1M-row index build at ~1% in under realistic transient KV noise (5% read failure rate). Replace the constants with a `BatchGetRetryPolicy` whose total-failures budget scales with the number of `BatchGet` chunks (not raw keys), since `totalFailures` increments once per chunk-level error.

Two policies are hardcoded:

- `defaultBatchGetRetryPolicy` — sync `list`/`history`/`trash` paths. `floor = 10`, no rate scaling. A stuck KV surfaces as a quick error in ~5 s under the 500 ms minimum backoff.
- `defaultRebuildBatchGetRetryPolicy` — `floor = 20`, `rate = 0.10`. For 1M keys (≈ 20 000 chunks) this yields a budget of **2 000** chunk failures, which absorbs ~5 % chunk-level noise (≈ 1 000 expected failures) with 2x headroom, while bounding the worst case to roughly tens of minutes rather than hours.

Callers opt into the rebuild budget via `WithIndexBuildRetryBudget(ctx)`. Only `init` (`buildIndexes`) and the background rebuilder (`runIndexRebuilder`) opt in. `getOrCreateIndex` deliberately does not, so a flaky build at request time can't stall search requests for hours under `context.WithoutCancel`.

`MaxConsecutiveFailures = 3` still trips fast when a stream is genuinely wedged regardless of dataset size.

`TODO` markers are added for two follow-ups discussed during review: snapshot-download retry on object-store hiccups, and streaming key listing in `ListIterator` instead of materializing all keys upfront.

## Test plan

- [x] `go build ./pkg/storage/unified/... ./pkg/setting/...`
- [x] `go vet ./pkg/storage/unified/... ./pkg/setting/...`
- [x] `go test ./pkg/storage/unified/resource/ ./pkg/storage/unified/search/ ./pkg/storage/unified/sql/ ./pkg/setting/ -count=1 -short`
- [x] `TestBatchGetRetryPolicy_TotalBudget` — `rate = 0` → floor; `rate > 0` → ceil-chunks math (100 keys → floor 20; 1M keys → 2 000).
- [x] `TestKvIterator_Retry/scaled_budget_*` — completion below the budget; exhaustion above it.
- [x] `TestKvStorageBackend_retryPolicyFor` — untagged ctx → sync default; `WithIndexBuildRetryBudget` ctx → rebuild default.
- [x] `TestSearchServer_InitTagsCtxForRebuildBudget` — pins the wiring that fixes the original startup failure.
- [x] `TestSearchServer_GetOrCreateIndexDoesNotTagCtx` — guards the safety boundary the reviewer flagged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)