### PR TITLE
Search: support file snapshot buckets

### DIFF
--- a/pkg/storage/unified/search/bleve_snapshot_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
@@ -544,6 +545,108 @@ func TestEvictExpiredIndexClearsUploadTracking(t *testing.T) {
 	assert.Nil(t, be.getCachedIndex(key, time.Now()))
 	_, ok := be.getUploadTracking(key)
 	assert.False(t, ok)
+}
+
+func TestBleveSnapshotLifecycleWithFileBucket(t *testing.T) {
+	ctx := identity.WithRequester(context.Background(), &user.SignedInUser{Namespace: "default"})
+	bucketURL := fileBucketURL(t, t.TempDir())
+	key := newTestNsResource()
+
+	beA, metricsA := newConfiguredSnapshotBackend(t, bucketURL)
+	beAStopped := false
+	t.Cleanup(func() {
+		if !beAStopped {
+			beA.Stop()
+		}
+	})
+	idxA, err := beA.BuildIndex(ctx, key, 10, nil, "startup", func(index resource.ResourceIndex) (int64, error) {
+		require.NoError(t, index.BulkIndex(&resource.BulkIndexRequest{Items: []*resource.BulkIndexItem{
+			{
+				Action: resource.ActionIndex,
+				Doc: &resource.IndexableDocument{
+					RV:    1,
+					Name:  "dash-prod",
+					Title: "Production Overview",
+					Key: &resourcepb.ResourceKey{
+						Name:      "dash-prod",
+						Namespace: key.Namespace,
+						Group:     key.Group,
+						Resource:  key.Resource,
+					},
+				},
+			},
+			{
+				Action: resource.ActionIndex,
+				Doc: &resource.IndexableDocument{
+					RV:    2,
+					Name:  "dash-api",
+					Title: "API Latency",
+					Key: &resourcepb.ResourceKey{
+						Name:      "dash-api",
+						Namespace: key.Namespace,
+						Group:     key.Group,
+						Resource:  key.Resource,
+					},
+				},
+			},
+		}}))
+		return 2, nil
+	}, nil, false, time.Time{})
+	require.NoError(t, err)
+	require.NotNil(t, idxA)
+
+	beA.runUploadSnapshots(ctx)
+	assert.Equal(t, 1.0, testutil.ToFloat64(metricsA.IndexSnapshotUploads.WithLabelValues(snapshotUploadStatusSuccess)))
+
+	indexes, err := beA.opts.Snapshot.Store.ListIndexes(ctx, key)
+	require.NoError(t, err)
+	require.Len(t, indexes, 1)
+
+	beA.Stop()
+	beAStopped = true
+
+	beB, metricsB := newConfiguredSnapshotBackend(t, bucketURL)
+	t.Cleanup(beB.Stop)
+	var builderCalled atomic.Bool
+	idxB, err := beB.BuildIndex(ctx, key, 10, nil, "startup", func(resource.ResourceIndex) (int64, error) {
+		builderCalled.Store(true)
+		return 0, fmt.Errorf("builder should not be called when a remote snapshot is available")
+	}, nil, false, time.Time{})
+	require.NoError(t, err)
+	require.NotNil(t, idxB)
+
+	assert.False(t, builderCalled.Load())
+	assert.Equal(t, 1.0, testutil.ToFloat64(metricsB.IndexSnapshotDownloads.WithLabelValues(snapshotStatusSuccess)))
+
+	res, err := idxB.Search(ctx, nil, &resourcepb.ResourceSearchRequest{
+		Options: &resourcepb.ListOptions{Key: &resourcepb.ResourceKey{
+			Namespace: key.Namespace,
+			Group:     key.Group,
+			Resource:  key.Resource,
+		}},
+		Query: "Production",
+		Limit: 100,
+	}, nil, nil)
+	require.NoError(t, err)
+	require.Equal(t, int64(1), res.TotalHits)
+	require.Equal(t, "dash-prod", res.Results.Rows[0].Key.Name)
+}
+
+func newConfiguredSnapshotBackend(t *testing.T, bucketURL string) (*bleveBackend, *resource.BleveIndexMetrics) {
+	t.Helper()
+	cfg := snapshotOptionsTestCfg(t)
+	cfg.EnableSearch = true
+	cfg.BuildVersion = "11.5.0"
+	cfg.IndexSnapshotEnabled = true
+	cfg.IndexSnapshotBucketURL = bucketURL
+
+	metrics := resource.ProvideIndexMetrics(prometheus.NewRegistry())
+	opts, err := NewSearchOptions(featuremgmt.WithFeatures(), cfg, nil, metrics, nil)
+	require.NoError(t, err)
+	be, ok := opts.Backend.(*bleveBackend)
+	require.True(t, ok)
+	be.opts.Snapshot.MinDocChanges = 1
+	return be, metrics
 }
 
 func TestIntegrationBleveSnapshotRoundTrip(t *testing.T) {

--- a/pkg/storage/unified/search/lock_local_backend.go
+++ b/pkg/storage/unified/search/lock_local_backend.go
@@ -10,34 +10,14 @@ import (
 // It is intended for local development and integration tests only: locks are not
 // persisted and are not coordinated across processes or hosts.
 type localLockBackend struct {
-	state *localLockState
+	mu    sync.Mutex
+	locks map[string]lockInfo
 	now   func() time.Time
 }
 
-type localLockState struct {
-	mu    sync.Mutex
-	locks map[string]lockInfo
-}
-
-var localLockRegistry = struct {
-	mu      sync.Mutex
-	buckets map[string]*localLockState
-}{
-	buckets: map[string]*localLockState{},
-}
-
-func newLocalLockBackend(registryKey string) *localLockBackend {
-	localLockRegistry.mu.Lock()
-	defer localLockRegistry.mu.Unlock()
-
-	state := localLockRegistry.buckets[registryKey]
-	if state == nil {
-		state = &localLockState{locks: map[string]lockInfo{}}
-		localLockRegistry.buckets[registryKey] = state
-	}
-
+func newLocalLockBackend() *localLockBackend {
 	return &localLockBackend{
-		state: state,
+		locks: map[string]lockInfo{},
 		now:   time.Now,
 	}
 }
@@ -47,15 +27,15 @@ func (b *localLockBackend) Create(ctx context.Context, key string, info lockInfo
 		return err
 	}
 
-	b.state.mu.Lock()
-	defer b.state.mu.Unlock()
+	b.mu.Lock()
+	defer b.mu.Unlock()
 
-	existing, ok := b.state.locks[key]
+	existing, ok := b.locks[key]
 	if ok && b.now().Before(existing.Heartbeat.Add(existing.TTL)) {
 		return errLockHeld
 	}
 
-	b.state.locks[key] = info
+	b.locks[key] = info
 	return nil
 }
 
@@ -64,10 +44,10 @@ func (b *localLockBackend) Update(ctx context.Context, key string, info lockInfo
 		return err
 	}
 
-	b.state.mu.Lock()
-	defer b.state.mu.Unlock()
+	b.mu.Lock()
+	defer b.mu.Unlock()
 
-	existing, ok := b.state.locks[key]
+	existing, ok := b.locks[key]
 	if !ok {
 		return errLockNotFound
 	}
@@ -78,7 +58,7 @@ func (b *localLockBackend) Update(ctx context.Context, key string, info lockInfo
 		return errLeaseExpired
 	}
 
-	b.state.locks[key] = info
+	b.locks[key] = info
 	return nil
 }
 
@@ -87,10 +67,10 @@ func (b *localLockBackend) Delete(ctx context.Context, key string, owner string)
 		return err
 	}
 
-	b.state.mu.Lock()
-	defer b.state.mu.Unlock()
+	b.mu.Lock()
+	defer b.mu.Unlock()
 
-	existing, ok := b.state.locks[key]
+	existing, ok := b.locks[key]
 	if !ok {
 		return errLockNotFound
 	}
@@ -98,7 +78,7 @@ func (b *localLockBackend) Delete(ctx context.Context, key string, owner string)
 		return errLockHeld
 	}
 
-	delete(b.state.locks, key)
+	delete(b.locks, key)
 	return nil
 }
 
@@ -107,10 +87,10 @@ func (b *localLockBackend) Read(ctx context.Context, key string) (*lockInfo, err
 		return nil, err
 	}
 
-	b.state.mu.Lock()
-	defer b.state.mu.Unlock()
+	b.mu.Lock()
+	defer b.mu.Unlock()
 
-	info, ok := b.state.locks[key]
+	info, ok := b.locks[key]
 	if !ok {
 		return nil, errLockNotFound
 	}

--- a/pkg/storage/unified/search/lock_local_backend.go
+++ b/pkg/storage/unified/search/lock_local_backend.go
@@ -1,0 +1,120 @@
+package search
+
+import (
+	"context"
+	"sync"
+	"time"
+)
+
+// localLockBackend is a process-local lock backend for file:// snapshot buckets.
+// It is intended for local development and integration tests only: locks are not
+// persisted and are not coordinated across processes or hosts.
+type localLockBackend struct {
+	state *localLockState
+	now   func() time.Time
+}
+
+type localLockState struct {
+	mu    sync.Mutex
+	locks map[string]lockInfo
+}
+
+var localLockRegistry = struct {
+	mu      sync.Mutex
+	buckets map[string]*localLockState
+}{
+	buckets: map[string]*localLockState{},
+}
+
+func newLocalLockBackend(registryKey string) *localLockBackend {
+	localLockRegistry.mu.Lock()
+	defer localLockRegistry.mu.Unlock()
+
+	state := localLockRegistry.buckets[registryKey]
+	if state == nil {
+		state = &localLockState{locks: map[string]lockInfo{}}
+		localLockRegistry.buckets[registryKey] = state
+	}
+
+	return &localLockBackend{
+		state: state,
+		now:   time.Now,
+	}
+}
+
+func (b *localLockBackend) Create(ctx context.Context, key string, info lockInfo) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	b.state.mu.Lock()
+	defer b.state.mu.Unlock()
+
+	existing, ok := b.state.locks[key]
+	if ok && b.now().Before(existing.Heartbeat.Add(existing.TTL)) {
+		return errLockHeld
+	}
+
+	b.state.locks[key] = info
+	return nil
+}
+
+func (b *localLockBackend) Update(ctx context.Context, key string, info lockInfo) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	b.state.mu.Lock()
+	defer b.state.mu.Unlock()
+
+	existing, ok := b.state.locks[key]
+	if !ok {
+		return errLockNotFound
+	}
+	if existing.Owner != info.Owner {
+		return errLockHeld
+	}
+	if !b.now().Before(existing.Heartbeat.Add(existing.TTL)) {
+		return errLeaseExpired
+	}
+
+	b.state.locks[key] = info
+	return nil
+}
+
+func (b *localLockBackend) Delete(ctx context.Context, key string, owner string) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	b.state.mu.Lock()
+	defer b.state.mu.Unlock()
+
+	existing, ok := b.state.locks[key]
+	if !ok {
+		return errLockNotFound
+	}
+	if existing.Owner != owner {
+		return errLockHeld
+	}
+
+	delete(b.state.locks, key)
+	return nil
+}
+
+func (b *localLockBackend) Read(ctx context.Context, key string) (*lockInfo, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	b.state.mu.Lock()
+	defer b.state.mu.Unlock()
+
+	info, ok := b.state.locks[key]
+	if !ok {
+		return nil, errLockNotFound
+	}
+	return &info, nil
+}
+
+var _ lockBackend = (*localLockBackend)(nil)

--- a/pkg/storage/unified/search/options.go
+++ b/pkg/storage/unified/search/options.go
@@ -189,12 +189,12 @@ func buildSnapshotOptions(cfg *setting.Cfg, minBuildVersion *semver.Version) (Sn
 }
 
 func snapshotLockBackendForBucket(bucket *blob.Bucket, bucketURL string) (lockBackend, error) {
-	registryKey, ok, err := localLockRegistryKey(bucketURL)
+	ok, err := isFileBucketURL(bucketURL)
 	if err != nil {
 		return nil, err
 	}
 	if ok {
-		return newLocalLockBackend(registryKey), nil
+		return newLocalLockBackend(), nil
 	}
 
 	lockOpts, err := cdkLockOptionsFromBucket(bucket, bucketURL)
@@ -204,20 +204,19 @@ func snapshotLockBackendForBucket(bucket *blob.Bucket, bucketURL string) (lockBa
 	return newCDKLockBackend(bucket, lockOpts), nil
 }
 
-// localLockRegistryKey returns the map key used to share process-local locks for the exact file:// bucket URL.
-func localLockRegistryKey(bucketURL string) (string, bool, error) {
+func isFileBucketURL(bucketURL string) (bool, error) {
 	u, err := url.Parse(bucketURL)
 	if err != nil {
-		return "", false, fmt.Errorf("parse bucket URL: %w", err)
+		return false, fmt.Errorf("parse bucket URL: %w", err)
 	}
 	if !strings.EqualFold(u.Scheme, "file") {
-		return "", false, nil
+		return false, nil
 	}
 	if err := validatePrefix(u.Query().Get("prefix")); err != nil {
-		return "", false, err
+		return false, err
 	}
 
-	return bucketURL, true, nil
+	return true, nil
 }
 
 // cleanupGracePeriodOrDefault returns d if positive, otherwise the default.

--- a/pkg/storage/unified/search/options.go
+++ b/pkg/storage/unified/search/options.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/Masterminds/semver"
@@ -151,11 +153,10 @@ func buildSnapshotOptions(cfg *setting.Cfg, minBuildVersion *semver.Version) (Sn
 		return SnapshotOptions{}, fmt.Errorf("opening snapshot bucket %q: %w", cfg.IndexSnapshotBucketURL, err)
 	}
 
-	lockOpts, err := cdkLockOptionsFromBucket(bucket, cfg.IndexSnapshotBucketURL)
+	lockBackend, err := snapshotLockBackendForBucket(bucket, cfg.IndexSnapshotBucketURL)
 	if err != nil {
 		return SnapshotOptions{}, fmt.Errorf("snapshot lock backend options: %w", err)
 	}
-	lockBackend := newCDKLockBackend(bucket, lockOpts)
 
 	ownerBase := cfg.InstanceID
 	if ownerBase == "" {
@@ -185,6 +186,38 @@ func buildSnapshotOptions(cfg *setting.Cfg, minBuildVersion *semver.Version) (Sn
 		CleanupGracePeriod: cleanupGracePeriodOrDefault(cfg.IndexSnapshotCleanupGracePeriod),
 		CleanupInterval:    DefaultSnapshotCleanupInterval,
 	}, nil
+}
+
+func snapshotLockBackendForBucket(bucket *blob.Bucket, bucketURL string) (lockBackend, error) {
+	registryKey, ok, err := localLockRegistryKey(bucketURL)
+	if err != nil {
+		return nil, err
+	}
+	if ok {
+		return newLocalLockBackend(registryKey), nil
+	}
+
+	lockOpts, err := cdkLockOptionsFromBucket(bucket, bucketURL)
+	if err != nil {
+		return nil, err
+	}
+	return newCDKLockBackend(bucket, lockOpts), nil
+}
+
+// localLockRegistryKey returns the map key used to share process-local locks for the exact file:// bucket URL.
+func localLockRegistryKey(bucketURL string) (string, bool, error) {
+	u, err := url.Parse(bucketURL)
+	if err != nil {
+		return "", false, fmt.Errorf("parse bucket URL: %w", err)
+	}
+	if !strings.EqualFold(u.Scheme, "file") {
+		return "", false, nil
+	}
+	if err := validatePrefix(u.Query().Get("prefix")); err != nil {
+		return "", false, err
+	}
+
+	return bucketURL, true, nil
 }
 
 // cleanupGracePeriodOrDefault returns d if positive, otherwise the default.

--- a/pkg/storage/unified/search/options_test.go
+++ b/pkg/storage/unified/search/options_test.go
@@ -1,10 +1,19 @@
 package search
 
 import (
+	"context"
+	"net/url"
+	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
 )
 
 func TestSnapshotLockHeartbeat(t *testing.T) {
@@ -32,4 +41,113 @@ func TestSnapshotLockHeartbeat(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestBuildSnapshotOptionsGating(t *testing.T) {
+	t.Run("disabled snapshot feature ignores invalid bucket URL", func(t *testing.T) {
+		cfg := snapshotOptionsTestCfg(t)
+		cfg.IndexSnapshotEnabled = false
+		cfg.IndexSnapshotBucketURL = "://not-a-valid-url"
+
+		snapshot, err := buildSnapshotOptions(cfg, nil)
+		require.NoError(t, err)
+		assert.Nil(t, snapshot.Store)
+	})
+
+	t.Run("enabled snapshot feature with empty bucket URL leaves store nil", func(t *testing.T) {
+		cfg := snapshotOptionsTestCfg(t)
+		cfg.IndexSnapshotEnabled = true
+		cfg.IndexSnapshotBucketURL = ""
+
+		snapshot, err := buildSnapshotOptions(cfg, nil)
+		require.NoError(t, err)
+		assert.Nil(t, snapshot.Store)
+	})
+
+	t.Run("enabled snapshot feature with file bucket URL creates store", func(t *testing.T) {
+		cfg := snapshotOptionsTestCfg(t)
+		cfg.IndexSnapshotEnabled = true
+		cfg.IndexSnapshotBucketURL = fileBucketURL(t, t.TempDir())
+
+		snapshot, err := buildSnapshotOptions(cfg, nil)
+		require.NoError(t, err)
+		require.NotNil(t, snapshot.Store)
+	})
+
+	t.Run("unsupported non-cloud provider fails", func(t *testing.T) {
+		cfg := snapshotOptionsTestCfg(t)
+		cfg.IndexSnapshotEnabled = true
+		cfg.IndexSnapshotBucketURL = "mem://snapshot-test"
+
+		snapshot, err := buildSnapshotOptions(cfg, nil)
+		require.Error(t, err)
+		assert.Nil(t, snapshot.Store)
+		assert.Contains(t, err.Error(), "unsupported blob provider")
+	})
+}
+
+func TestBuildSnapshotOptionsFileBucketUsesProcessLocalLocks(t *testing.T) {
+	bucketURL := fileBucketURL(t, t.TempDir())
+
+	cfg1 := snapshotOptionsTestCfg(t)
+	cfg1.IndexSnapshotEnabled = true
+	cfg1.IndexSnapshotBucketURL = bucketURL
+	cfg1.InstanceID = "instance-1"
+	snapshot1, err := buildSnapshotOptions(cfg1, nil)
+	require.NoError(t, err)
+
+	cfg2 := snapshotOptionsTestCfg(t)
+	cfg2.IndexSnapshotEnabled = true
+	cfg2.IndexSnapshotBucketURL = bucketURL
+	cfg2.InstanceID = "instance-2"
+	snapshot2, err := buildSnapshotOptions(cfg2, nil)
+	require.NoError(t, err)
+
+	ns := resource.NamespacedResource{Namespace: "default", Group: "dashboard.grafana.app", Resource: "dashboards"}
+	lock1, err := snapshot1.Store.LockBuildIndex(context.Background(), ns)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, lock1.Release()) }()
+
+	lock2, err := snapshot2.Store.LockBuildIndex(context.Background(), ns)
+	require.ErrorIs(t, err, errLockHeld)
+	assert.Nil(t, lock2)
+}
+
+func TestNewSearchOptionsPassesFileSnapshotStoreToBleveBackend(t *testing.T) {
+	cfg := snapshotOptionsTestCfg(t)
+	cfg.EnableSearch = true
+	cfg.BuildVersion = "11.0.0"
+	cfg.IndexPath = filepath.Join(t.TempDir(), "bleve")
+	cfg.IndexSnapshotEnabled = true
+	cfg.IndexSnapshotBucketURL = fileBucketURL(t, t.TempDir())
+
+	metrics := resource.ProvideIndexMetrics(prometheus.NewRegistry())
+	opts, err := NewSearchOptions(featuremgmt.WithFeatures(), cfg, nil, metrics, nil)
+	require.NoError(t, err)
+
+	backend, ok := opts.Backend.(*bleveBackend)
+	require.True(t, ok)
+	t.Cleanup(backend.Stop)
+
+	assert.True(t, opts.IndexSnapshotEnabled)
+	assert.Equal(t, cfg.IndexSnapshotBucketURL, opts.IndexSnapshotBucketURL)
+	assert.NotNil(t, backend.opts.Snapshot.Store)
+}
+
+func snapshotOptionsTestCfg(t *testing.T) *setting.Cfg {
+	t.Helper()
+	return &setting.Cfg{
+		DataPath:                        t.TempDir(),
+		InstanceName:                    "test-instance",
+		IndexFileThreshold:              1,
+		IndexSnapshotThreshold:          1,
+		IndexSnapshotMaxAge:             time.Hour,
+		IndexSnapshotCleanupGracePeriod: time.Minute,
+	}
+}
+
+func fileBucketURL(t *testing.T, dir string) string {
+	t.Helper()
+	u := url.URL{Scheme: "file", Path: dir}
+	return u.String()
 }

--- a/pkg/storage/unified/search/options_test.go
+++ b/pkg/storage/unified/search/options_test.go
@@ -87,28 +87,19 @@ func TestBuildSnapshotOptionsGating(t *testing.T) {
 }
 
 func TestBuildSnapshotOptionsFileBucketUsesProcessLocalLocks(t *testing.T) {
-	bucketURL := fileBucketURL(t, t.TempDir())
+	cfg := snapshotOptionsTestCfg(t)
+	cfg.IndexSnapshotEnabled = true
+	cfg.IndexSnapshotBucketURL = fileBucketURL(t, t.TempDir())
 
-	cfg1 := snapshotOptionsTestCfg(t)
-	cfg1.IndexSnapshotEnabled = true
-	cfg1.IndexSnapshotBucketURL = bucketURL
-	cfg1.InstanceID = "instance-1"
-	snapshot1, err := buildSnapshotOptions(cfg1, nil)
-	require.NoError(t, err)
-
-	cfg2 := snapshotOptionsTestCfg(t)
-	cfg2.IndexSnapshotEnabled = true
-	cfg2.IndexSnapshotBucketURL = bucketURL
-	cfg2.InstanceID = "instance-2"
-	snapshot2, err := buildSnapshotOptions(cfg2, nil)
+	snapshot, err := buildSnapshotOptions(cfg, nil)
 	require.NoError(t, err)
 
 	ns := resource.NamespacedResource{Namespace: "default", Group: "dashboard.grafana.app", Resource: "dashboards"}
-	lock1, err := snapshot1.Store.LockBuildIndex(context.Background(), ns)
+	lock1, err := snapshot.Store.LockBuildIndex(context.Background(), ns)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, lock1.Release()) }()
 
-	lock2, err := snapshot2.Store.LockBuildIndex(context.Background(), ns)
+	lock2, err := snapshot.Store.LockBuildIndex(context.Background(), ns)
 	require.ErrorIs(t, err, errLockHeld)
 	assert.Nil(t, lock2)
 }


### PR DESCRIPTION
## What this PR does

Adds `file://` support for configured remote Bleve index snapshot buckets by using a simple process-local lock backend for file buckets.

Also adds a lifecycle test that builds a real file-based index, uploads it to a `file://` bucket, starts a fresh backend, downloads the snapshot, and verifies search works.

Cloud bucket locking is unchanged. S3/GCS/Azure still use the existing CDK lock backend, and unsupported non-cloud providers such as `mem://` still fail through config wiring.

## References

- https://github.com/grafana/search-and-storage-team/issues/723