### PR TITLE
[release-13.0.2] Folder: Wrap validation errors in metav1.Status (#123709 + #123843)

### DIFF
--- a/pkg/api/apierrors/folder.go
+++ b/pkg/api/apierrors/folder.go
@@ -17,11 +17,17 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 )
 
-// stableFolderErrSentinels are folder errors whose legacy /api/folders message are kept stable.
+// stableFolderErrSentinels are folder errors whose legacy /api/folders messages are kept stable.
 var stableFolderErrSentinels = []error{
 	folder.ErrTitleEmpty,
 	folder.ErrInvalidUID,
 	folder.ErrFolderCannotBeParentOfItself,
+}
+
+// stableDashboardErrSentinels are dashboard errors whose legacy /api/folders messages are kept stable.
+var stableDashboardErrSentinels = []error{
+	dashboards.ErrDashboardInvalidUid,
+	dashboards.ErrDashboardUidTooLong,
 }
 
 // ToFolderErrorResponse returns a different response status according to the folder error type
@@ -29,14 +35,21 @@ func ToFolderErrorResponse(err error) response.Response {
 	// --- Dashboard errors ---
 	var dashboardErr dashboardaccess.DashboardErr
 	if ok := errors.As(err, &dashboardErr); ok {
-		return response.Error(dashboardErr.StatusCode, err.Error(), err)
+		msg := err.Error()
+		var grafanaErr errutil.Error
+		if errors.As(err, &grafanaErr) {
+			for _, s := range stableDashboardErrSentinels {
+				if errors.Is(err, s) {
+					msg = s.Error()
+					break
+				}
+			}
+		}
+		return response.Error(dashboardErr.StatusCode, msg, err)
 	}
 
 	// --- 400 Bad Request ---
 	if errors.Is(err, dashboards.ErrFolderTitleEmpty) ||
-		errors.Is(err, dashboards.ErrDashboardTypeMismatch) ||
-		errors.Is(err, dashboards.ErrDashboardInvalidUid) ||
-		errors.Is(err, dashboards.ErrDashboardUidTooLong) ||
 		errors.Is(err, folder.ErrFolderCannotBeParentOfItself) ||
 		errors.Is(err, folder.ErrMaximumDepthReached) ||
 		errors.Is(err, folder.ErrTitleEmpty) ||
@@ -115,12 +128,26 @@ func ToFolderStatusError(err error) k8sErrors.StatusError {
 		return defaultErr
 	}
 
-	return k8sErrors.StatusError{
+	statusErr := k8sErrors.StatusError{
 		ErrStatus: metav1.Status{
 			Message: message,
 			Code:    int32(normResp.Status()),
 		},
 	}
+
+	// Preserve the structured errutil message ID in Status.Details.UID so
+	// downstream consumers (e.g. provisioning's IsFolderValidationAPIError)
+	// can match the rejection without relying on the human-readable message.
+	// errutil.Error.Status() is the source of truth for the message ID; if
+	// the underlying error is one, copy its Details across.
+	var grafanaErr errutil.Error
+	if errors.As(err, &grafanaErr) {
+		if details := grafanaErr.Status().Details; details != nil {
+			statusErr.ErrStatus.Details = details
+		}
+	}
+
+	return statusErr
 }
 
 func getDefaultMessageForStatus(statusCode int) string {

--- a/pkg/api/apierrors/folder.go
+++ b/pkg/api/apierrors/folder.go
@@ -10,11 +10,19 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/grafana/grafana/pkg/api/response"
+	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/dashboards/dashboardaccess"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/util"
 )
+
+// stableFolderErrSentinels are folder errors whose legacy /api/folders message are kept stable.
+var stableFolderErrSentinels = []error{
+	folder.ErrTitleEmpty,
+	folder.ErrInvalidUID,
+	folder.ErrFolderCannotBeParentOfItself,
+}
 
 // ToFolderErrorResponse returns a different response status according to the folder error type
 func ToFolderErrorResponse(err error) response.Response {
@@ -30,7 +38,17 @@ func ToFolderErrorResponse(err error) response.Response {
 		errors.Is(err, dashboards.ErrDashboardInvalidUid) ||
 		errors.Is(err, dashboards.ErrDashboardUidTooLong) ||
 		errors.Is(err, folder.ErrFolderCannotBeParentOfItself) ||
-		errors.Is(err, folder.ErrMaximumDepthReached) {
+		errors.Is(err, folder.ErrMaximumDepthReached) ||
+		errors.Is(err, folder.ErrTitleEmpty) ||
+		errors.Is(err, folder.ErrInvalidUID) {
+		var grafanaErr errutil.Error
+		if errors.As(err, &grafanaErr) {
+			for _, s := range stableFolderErrSentinels {
+				if errors.Is(err, s) {
+					return response.Error(http.StatusBadRequest, s.Error(), nil)
+				}
+			}
+		}
 		return response.Error(http.StatusBadRequest, err.Error(), nil)
 	}
 

--- a/pkg/api/apierrors/folder_test.go
+++ b/pkg/api/apierrors/folder_test.go
@@ -2,6 +2,7 @@ package apierrors
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -59,6 +60,11 @@ func TestToFolderErrorResponse(t *testing.T) {
 			want:  response.Error(http.StatusBadRequest, "folder title cannot be empty", nil),
 		},
 		{
+			name:  "folder title empty (apiserver wrapped)",
+			input: folder.ErrAPITitleEmpty,
+			want:  response.Error(http.StatusBadRequest, "folder title cannot be empty", nil),
+		},
+		{
 			name:  "dashboard type mismatch",
 			input: dashboards.ErrDashboardTypeMismatch,
 			want:  response.Error(http.StatusBadRequest, "Dashboard cannot be changed to a folder", dashboards.ErrDashboardTypeMismatch),
@@ -76,7 +82,28 @@ func TestToFolderErrorResponse(t *testing.T) {
 		{
 			name:  "folder cannot be parent of itself",
 			input: folder.ErrFolderCannotBeParentOfItself,
-			want:  response.Error(http.StatusBadRequest, folder.ErrFolderCannotBeParentOfItself.Error(), nil),
+			want:  response.Error(http.StatusBadRequest, "folder cannot be parent of itself", nil),
+		},
+		{
+			name:  "folder cannot be parent of itself (apiserver wrapped)",
+			input: folder.ErrAPIFolderCannotBeParentOfItself,
+			want:  response.Error(http.StatusBadRequest, "folder cannot be parent of itself", nil),
+		},
+		{
+			name:  "invalid uid",
+			input: folder.ErrInvalidUID,
+			want:  response.Error(http.StatusBadRequest, "invalid uid for folder provided", nil),
+		},
+		{
+			name:  "invalid uid (apiserver wrapped)",
+			input: folder.ErrAPIInvalidUID,
+			want:  response.Error(http.StatusBadRequest, "invalid uid for folder provided", nil),
+		},
+		{
+			// Custom-context wrappers (non-errutil) keep their added context.
+			name:  "folder title empty wrapped with custom context",
+			input: fmt.Errorf("save folder: %w", folder.ErrTitleEmpty),
+			want:  response.Error(http.StatusBadRequest, "save folder: folder title cannot be empty", nil),
 		},
 		// --- 403 Forbidden ---
 		{
@@ -204,6 +231,26 @@ func TestToFolderErrorResponse(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			resp := ToFolderErrorResponse(tt.input)
 			require.Equal(t, tt.want, resp)
+		})
+	}
+}
+
+// TestErrorsIs_UnwrapsAPIWrappers tests that errors.Is matches the legacy sentinel via
+// the Unwrap chain.
+func TestErrorsIs_UnwrapsAPIWrappers(t *testing.T) {
+	cases := []struct {
+		name    string
+		wrapped error
+		legacy  error
+	}{
+		{"title empty", folder.ErrAPITitleEmpty, folder.ErrTitleEmpty},
+		{"invalid uid", folder.ErrAPIInvalidUID, folder.ErrInvalidUID},
+		{"folder cannot be parent of itself", folder.ErrAPIFolderCannotBeParentOfItself, folder.ErrFolderCannotBeParentOfItself},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			require.True(t, errors.Is(c.wrapped, c.legacy),
+				"errors.Is must walk Unwrap to match the legacy sentinel; got %v", c.wrapped)
 		})
 	}
 }

--- a/pkg/api/apierrors/folder_test.go
+++ b/pkg/api/apierrors/folder_test.go
@@ -1,4 +1,4 @@
-package apierrors
+package apierrors_test
 
 import (
 	"errors"
@@ -6,7 +6,9 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/grafana/grafana/pkg/api/apierrors"
 	"github.com/grafana/grafana/pkg/api/response"
+	"github.com/grafana/grafana/pkg/registry/apis/folders"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/dashboards/dashboardaccess"
 	"github.com/grafana/grafana/pkg/services/folder"
@@ -32,6 +34,11 @@ func TestToFolderErrorResponse(t *testing.T) {
 			name:  "maximum depth reached",
 			input: folder.ErrMaximumDepthReached.Errorf("Maximum nested folder depth reached"),
 			want:  response.Error(http.StatusBadRequest, "[folder.maximum-depth-reached] Maximum nested folder depth reached", nil),
+		},
+		{
+			name:  "maximum depth reached (validate.go call site)",
+			input: folder.ErrMaximumDepthReached.Errorf("folder max depth exceeded, max depth is %d", 4),
+			want:  response.Error(http.StatusBadRequest, "[folder.maximum-depth-reached] folder max depth exceeded, max depth is 4", nil),
 		},
 		{
 			name:  "bad request errors",
@@ -75,9 +82,19 @@ func TestToFolderErrorResponse(t *testing.T) {
 			want:  response.Error(http.StatusBadRequest, "uid contains illegal characters", dashboards.ErrDashboardInvalidUid),
 		},
 		{
+			name:  "dashboard invalid uid (apiserver wrapped)",
+			input: folders.ErrAPIInvalidUID,
+			want:  response.Error(http.StatusBadRequest, "uid contains illegal characters", folders.ErrAPIInvalidUID),
+		},
+		{
 			name:  "dashboard uid too long",
 			input: dashboards.ErrDashboardUidTooLong,
 			want:  response.Error(http.StatusBadRequest, "uid too long, max 40 characters", dashboards.ErrDashboardUidTooLong),
+		},
+		{
+			name:  "dashboard uid too long (apiserver wrapped)",
+			input: folders.ErrAPIUIDTooLong,
+			want:  response.Error(http.StatusBadRequest, "uid too long, max 40 characters", folders.ErrAPIUIDTooLong),
 		},
 		{
 			name:  "folder cannot be parent of itself",
@@ -229,7 +246,7 @@ func TestToFolderErrorResponse(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			resp := ToFolderErrorResponse(tt.input)
+			resp := apierrors.ToFolderErrorResponse(tt.input)
 			require.Equal(t, tt.want, resp)
 		})
 	}

--- a/pkg/registry/apis/folders/parents.go
+++ b/pkg/registry/apis/folders/parents.go
@@ -49,7 +49,7 @@ func newParentsGetter(getter rest.Getter, maxDepth int) parentsGetter {
 			}
 
 			if found[item.Parent] {
-				return nil, fmt.Errorf("cyclic folder references found: %s", item.Parent)
+				return nil, folderLegacy.ErrCyclicReference.Errorf("cyclic folder references found: %s", item.Parent)
 			}
 
 			obj, e2 := getter.Get(ctx, item.Parent, &metav1.GetOptions{})

--- a/pkg/registry/apis/folders/validate.go
+++ b/pkg/registry/apis/folders/validate.go
@@ -64,7 +64,7 @@ func validateOnCreate(ctx context.Context, f *folders.Folder, getter parentsGett
 		folder.GeneralFolderUID,
 		folder.SharedWithMeFolderUID,
 	}, id) {
-		return dashboards.ErrFolderInvalidUID
+		return folder.ErrAPIInvalidUID
 	}
 
 	meta, err := utils.MetaAccessor(f)
@@ -81,7 +81,7 @@ func validateOnCreate(ctx context.Context, f *folders.Folder, getter parentsGett
 	}
 
 	if f.Spec.Title == "" {
-		return dashboards.ErrFolderTitleEmpty
+		return folder.ErrAPITitleEmpty
 	}
 
 	parentName := meta.GetFolder()
@@ -90,7 +90,7 @@ func validateOnCreate(ctx context.Context, f *folders.Folder, getter parentsGett
 	}
 
 	if parentName == f.Name {
-		return folder.ErrFolderCannotBeParentOfItself
+		return folder.ErrAPIFolderCannotBeParentOfItself
 	}
 
 	// note: `parents` will include itself as the last item
@@ -102,7 +102,7 @@ func validateOnCreate(ctx context.Context, f *folders.Folder, getter parentsGett
 	// Can not create a folder that will be too deep.
 	// We need to add +1 as we also have the root folder as part of the parents.
 	if len(parents.Items) > maxDepth+1 {
-		return fmt.Errorf("folder max depth exceeded, max depth is %d", maxDepth)
+		return folder.ErrMaximumDepthReached.Errorf("folder max depth exceeded, max depth is %d", maxDepth)
 	}
 
 	return nil
@@ -126,7 +126,7 @@ func validateOnUpdate(ctx context.Context,
 	}
 
 	if obj.Spec.Title == "" {
-		return dashboards.ErrFolderTitleEmpty
+		return folder.ErrAPITitleEmpty
 	}
 
 	if folderObj.GetFolder() == oldFolder.GetFolder() {

--- a/pkg/registry/apis/folders/validate.go
+++ b/pkg/registry/apis/folders/validate.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apiserver/pkg/registry/rest"
 
 	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
+	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/dashboards"
@@ -20,6 +21,19 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 	"github.com/grafana/grafana/pkg/util"
+)
+
+// ErrAPIInvalidUID and ErrAPIUIDTooLong are instantiated errutil.Error values
+// created from errutil.BadRequest bases, so the apiserver renders them via
+// APIStatus as 400 (not "Unhandled Error" 500). They wrap the legacy
+// dashboards sentinels via %w so errors.Is/As keeps matching for /api/folders
+// consumers (ToFolderErrorResponse). Defined here rather than in
+// pkg/services/folder/model.go to avoid the dashboards->folder import cycle.
+var (
+	ErrAPIInvalidUID = errutil.BadRequest("folder.invalid-uid-chars", errutil.WithPublicMessage("uid contains illegal characters")).
+				Errorf("%w", dashboards.ErrDashboardInvalidUid)
+	ErrAPIUIDTooLong = errutil.BadRequest("folder.uid-too-long", errutil.WithPublicMessage("uid too long, max 40 characters")).
+				Errorf("%w", dashboards.ErrDashboardUidTooLong)
 )
 
 var errOwnerRefsOnManagedFolder = fmt.Errorf("cannot set owner references on folders managed by a repository")
@@ -73,11 +87,11 @@ func validateOnCreate(ctx context.Context, f *folders.Folder, getter parentsGett
 	}
 
 	if !util.IsValidShortUID(id) {
-		return dashboards.ErrDashboardInvalidUid
+		return ErrAPIInvalidUID
 	}
 
 	if util.IsShortUIDTooLong(id) {
-		return dashboards.ErrDashboardUidTooLong
+		return ErrAPIUIDTooLong
 	}
 
 	if f.Spec.Title == "" {
@@ -146,7 +160,7 @@ func validateOnUpdate(ctx context.Context,
 
 	// folder cannot be moved to a k6 folder
 	if newParent == accesscontrol.K6FolderUID {
-		return fmt.Errorf("k6 project may not be moved")
+		return folder.ErrFolderCannotBeMovedToK6.Errorf("k6 project may not be moved")
 	}
 
 	parentObj, err := getter.Get(ctx, newParent, &metav1.GetOptions{})
@@ -166,7 +180,7 @@ func validateOnUpdate(ctx context.Context,
 	// This prevents circular references (e.g., moving A under B when B is already under A).
 	for _, ancestor := range info.Items {
 		if ancestor.Name == obj.Name {
-			return fmt.Errorf("cannot move folder under its own descendant, this would create a circular reference")
+			return folder.ErrCircularReference.Errorf("cannot move folder under its own descendant, this would create a circular reference")
 		}
 	}
 

--- a/pkg/registry/apis/folders/validate.go
+++ b/pkg/registry/apis/folders/validate.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -98,6 +99,10 @@ func validateOnCreate(ctx context.Context, f *folders.Folder, getter parentsGett
 		return folder.ErrAPITitleEmpty
 	}
 
+	if strings.EqualFold(f.Spec.Title, dashboards.RootFolderName) {
+		return folder.ErrNameExists.Errorf("a folder with that name already exists")
+	}
+
 	parentName := meta.GetFolder()
 	if parentName == "" {
 		return nil // OK, we do not need to validate the tree
@@ -141,6 +146,10 @@ func validateOnUpdate(ctx context.Context,
 
 	if obj.Spec.Title == "" {
 		return folder.ErrAPITitleEmpty
+	}
+
+	if strings.EqualFold(obj.Spec.Title, dashboards.RootFolderName) {
+		return folder.ErrNameExists.Errorf("a folder with that name already exists")
 	}
 
 	if folderObj.GetFolder() == oldFolder.GetFolder() {

--- a/pkg/registry/apis/folders/validate_test.go
+++ b/pkg/registry/apis/folders/validate_test.go
@@ -12,6 +12,7 @@ import (
 	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
+	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
@@ -22,7 +23,7 @@ func TestValidateCreate(t *testing.T) {
 		name        string
 		folder      *folders.Folder
 		mockFolders map[string]*folders.Folder
-		expectedErr string
+		expectedErr error
 		maxDepth    int // defaults to 5 unless set
 	}{
 		{
@@ -60,10 +61,19 @@ func TestValidateCreate(t *testing.T) {
 			name: "reserved name",
 			folder: &folders.Folder{
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "general", // can not name something with general
+					Name: folder.GeneralFolderUID,
 				},
 			},
-			expectedErr: "invalid uid for folder provided",
+			expectedErr: folder.ErrInvalidUID,
+		},
+		{
+			name: "reserved name - sharedwithme",
+			folder: &folders.Folder{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: folder.SharedWithMeFolderUID,
+				},
+			},
+			expectedErr: folder.ErrInvalidUID,
 		},
 		{
 			name: "too long",
@@ -72,7 +82,7 @@ func TestValidateCreate(t *testing.T) {
 					Name: "a0123456789012345678901234567890123456789", // longer than 40
 				},
 			},
-			expectedErr: "uid too long, max 40 characters",
+			expectedErr: dashboards.ErrDashboardUidTooLong,
 		},
 		{
 			name: "bad name",
@@ -81,7 +91,7 @@ func TestValidateCreate(t *testing.T) {
 					Name: "hello world", // not a-z|0-9,
 				},
 			},
-			expectedErr: "uid contains illegal characters",
+			expectedErr: dashboards.ErrDashboardInvalidUid,
 		},
 		{
 			name: "can not be a parent of yourself",
@@ -94,7 +104,7 @@ func TestValidateCreate(t *testing.T) {
 					Title: "some title",
 				},
 			},
-			expectedErr: "folder cannot be parent of itself",
+			expectedErr: folder.ErrFolderCannotBeParentOfItself,
 		},
 		{
 			name: "can not create a tree that is too deep",
@@ -145,7 +155,7 @@ func TestValidateCreate(t *testing.T) {
 				},
 			},
 			maxDepth:    2,
-			expectedErr: "folder max depth exceeded",
+			expectedErr: folder.ErrMaximumDepthReached,
 		},
 		{
 			name: "can create a folder in max depth",
@@ -208,7 +218,7 @@ func TestValidateCreate(t *testing.T) {
 					Title: "some title",
 				},
 			},
-			expectedErr: "cyclic folder references found",
+			expectedErr: folder.ErrCyclicReference,
 			mockFolders: map[string]*folders.Folder{
 				"2": {
 					ObjectMeta: metav1.ObjectMeta{
@@ -266,11 +276,11 @@ func TestValidateCreate(t *testing.T) {
 
 			err := validateOnCreate(context.Background(), tt.folder, getter, maxDepth)
 
-			if tt.expectedErr == "" {
+			if tt.expectedErr == nil {
 				require.NoError(t, err)
 			} else {
-				require.Error(t, err)
-				require.Contains(t, err.Error(), tt.expectedErr)
+				require.ErrorIs(t, err, tt.expectedErr)
+				require.Contains(t, err.Error(), tt.expectedErr.Error())
 			}
 		})
 	}

--- a/pkg/services/folder/model.go
+++ b/pkg/services/folder/model.go
@@ -14,7 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-var ErrMaximumDepthReached = errutil.BadRequest("folder.maximum-depth-reached", errutil.WithPublicMessage("Maximum nested folder depth reached"))
+var ErrMaximumDepthReached = errutil.BadRequest("folder.maximum-depth-reached", errutil.WithPublicMessage("Maximum nested folder depth reached")) // Important: keep error msgID stable for other services to consume (provisioning)
 var ErrBadRequest = errutil.BadRequest("folder.bad-request")
 var ErrDatabaseError = errutil.Internal("folder.database-error")
 var ErrConflict = errutil.Conflict("folder.conflict")
@@ -22,7 +22,20 @@ var ErrInternal = errutil.Internal("folder.internal")
 var ErrCircularReference = errutil.BadRequest("folder.circular-reference", errutil.WithPublicMessage("Circular reference detected"))
 var ErrTargetRegistrySrvConflict = errutil.Internal("folder.target-registry-srv-conflict")
 var ErrFolderNotEmpty = errutil.BadRequest("folder.not-empty", errutil.WithPublicMessage("Folder cannot be deleted: folder is not empty"))
+var ErrCyclicReference = errutil.Internal("folder.cyclic-reference", errutil.WithPublicMessage("Cyclic folder references found"))
+
+// Legacy /api/folders sentinels: kept as errors.New so /api responses match byte-for-byte.
+var ErrTitleEmpty = errors.New("folder title cannot be empty")
+var ErrInvalidUID = errors.New("invalid uid for folder provided")
 var ErrFolderCannotBeParentOfItself = errors.New("folder cannot be parent of itself")
+
+// Wraps legacy errors (/api) into an apiserver (/apis) error for them to be handled as 400.
+var ErrAPITitleEmpty = errutil.BadRequest("folder.title-empty", errutil.WithPublicMessage("Folder title cannot be empty")).
+	Errorf("%w", ErrTitleEmpty)
+var ErrAPIInvalidUID = errutil.BadRequest("folder.invalid-uid", errutil.WithPublicMessage("Invalid uid for folder provided")).
+	Errorf("%w", ErrInvalidUID)
+var ErrAPIFolderCannotBeParentOfItself = errutil.BadRequest("folder.cannot-be-parent-of-itself", errutil.WithPublicMessage("Folder cannot be parent of itself")).
+	Errorf("%w", ErrFolderCannotBeParentOfItself)
 
 const (
 	GeneralFolderUID      = "general"

--- a/pkg/services/folder/model.go
+++ b/pkg/services/folder/model.go
@@ -23,6 +23,7 @@ var ErrCircularReference = errutil.BadRequest("folder.circular-reference", errut
 var ErrTargetRegistrySrvConflict = errutil.Internal("folder.target-registry-srv-conflict")
 var ErrFolderNotEmpty = errutil.BadRequest("folder.not-empty", errutil.WithPublicMessage("Folder cannot be deleted: folder is not empty"))
 var ErrFolderCannotBeMovedToK6 = errutil.BadRequest("folder.cannot-be-moved-to-k6", errutil.WithPublicMessage("Folders cannot be moved into the k6 project"))
+var ErrNameExists = errutil.BadRequest("folder.name-exists", errutil.WithPublicMessage("A folder with that name already exists"))
 
 // ErrCyclicReference indicates corrupt storage state, not user input.
 var ErrCyclicReference = errutil.Internal("folder.cyclic-reference", errutil.WithPublicMessage("Cyclic folder references found"))

--- a/pkg/services/folder/model.go
+++ b/pkg/services/folder/model.go
@@ -22,6 +22,9 @@ var ErrInternal = errutil.Internal("folder.internal")
 var ErrCircularReference = errutil.BadRequest("folder.circular-reference", errutil.WithPublicMessage("Circular reference detected"))
 var ErrTargetRegistrySrvConflict = errutil.Internal("folder.target-registry-srv-conflict")
 var ErrFolderNotEmpty = errutil.BadRequest("folder.not-empty", errutil.WithPublicMessage("Folder cannot be deleted: folder is not empty"))
+var ErrFolderCannotBeMovedToK6 = errutil.BadRequest("folder.cannot-be-moved-to-k6", errutil.WithPublicMessage("Folders cannot be moved into the k6 project"))
+
+// ErrCyclicReference indicates corrupt storage state, not user input.
 var ErrCyclicReference = errutil.Internal("folder.cyclic-reference", errutil.WithPublicMessage("Cyclic folder references found"))
 
 // Legacy /api/folders sentinels: kept as errors.New so /api responses match byte-for-byte.

--- a/pkg/tests/apis/folder/folders_test.go
+++ b/pkg/tests/apis/folder/folders_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -17,6 +18,7 @@ import (
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -2261,6 +2263,99 @@ func TestIntegrationFolderDryRun(t *testing.T) {
 			// Clean up
 			err = client.Resource.Delete(context.Background(), createdName, metav1.DeleteOptions{})
 			require.NoError(t, err)
+		})
+	}
+}
+
+// TestIntegrationFolderValidationReturns400 asserts the folder admission
+// validator surfaces structured 4xx responses (and stable messages consumed
+// by provisioning) rather than "Unhandled Error" 500s.
+func TestIntegrationFolderValidationReturns400(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+	if !db.IsTestDbSQLite() {
+		t.Skip("test only on sqlite for now")
+	}
+
+	helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
+		AppModeProduction:    true,
+		DisableAnonymous:     true,
+		APIServerStorageType: "unified",
+	})
+	client := helper.GetResourceClient(apis.ResourceClientArgs{
+		User: helper.Org1.Admin,
+		GVR:  gvr,
+	})
+
+	makeFolder := func(name, title, parentUID string) *unstructured.Unstructured {
+		md := map[string]any{"name": name}
+		if parentUID != "" {
+			md["annotations"] = map[string]any{utils.AnnoKeyFolder: parentUID}
+		}
+		return &unstructured.Unstructured{Object: map[string]any{
+			"metadata": md,
+			"spec":     map[string]any{"title": title},
+		}}
+	}
+
+	cases := []struct {
+		name        string
+		setup       func(t *testing.T) string
+		folder      func(parentUID string) *unstructured.Unstructured
+		expectedMsg string
+	}{
+		{
+			name:        "title empty",
+			folder:      func(string) *unstructured.Unstructured { return makeFolder("title-empty-test", "", "") },
+			expectedMsg: "folder title cannot be empty",
+		},
+		{
+			name:        "reserved uid",
+			folder:      func(string) *unstructured.Unstructured { return makeFolder(folder.GeneralFolderUID, "Some title", "") },
+			expectedMsg: "invalid uid for folder provided",
+		},
+		{
+			name:        "parent of itself",
+			folder:      func(string) *unstructured.Unstructured { return makeFolder("self-parent", "Some title", "self-parent") },
+			expectedMsg: "folder cannot be parent of itself",
+		},
+		{
+			name: "max depth exceeded",
+			setup: func(t *testing.T) string {
+				parentUID := ""
+				for i := 1; i <= 5; i++ {
+					out, err := client.Resource.Create(context.Background(),
+						makeFolder(fmt.Sprintf("max-depth-%d", i), fmt.Sprintf("Max depth %d", i), parentUID),
+						metav1.CreateOptions{})
+					require.NoErrorf(t, err, "creating folder at depth %d should succeed", i)
+					parentUID = out.GetName()
+				}
+				return parentUID
+			},
+			folder: func(parentUID string) *unstructured.Unstructured {
+				return makeFolder("max-depth-6", "Max depth 6", parentUID)
+			},
+			expectedMsg: "[folder.maximum-depth-reached] folder max depth exceeded, max depth is 4",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var parentUID string
+			if tc.setup != nil {
+				parentUID = tc.setup(t)
+			}
+			_, err := client.Resource.Create(context.Background(), tc.folder(parentUID), metav1.CreateOptions{})
+			require.Error(t, err)
+			require.Falsef(t, apierrors.IsInternalError(err),
+				"apiserver surfaced as HTTP 500 (regression of alert #1782995): %v", err)
+			require.Truef(t, apierrors.IsBadRequest(err),
+				"expected HTTP 400 BadRequest; got: %v (%T)", err, err)
+
+			var statusErr *apierrors.StatusError
+			require.True(t, errors.As(err, &statusErr), "expected *apierrors.StatusError; got %T", err)
+			require.Equal(t, int32(http.StatusBadRequest), statusErr.ErrStatus.Code)
+			require.Equal(t, tc.expectedMsg, statusErr.ErrStatus.Message)
+			require.Equal(t, tc.expectedMsg, err.Error())
 		})
 	}
 }

--- a/pkg/tests/apis/folder/folders_test.go
+++ b/pkg/tests/apis/folder/folders_test.go
@@ -33,6 +33,7 @@ import (
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -540,19 +541,50 @@ func doCreateCircularReferenceFolderTest(t *testing.T, helper *apis.K8sTestHelpe
 		GVR:  gvr,
 	})
 
-	payload := `{
-		"title": "Test",
-		"uid": "newFolder",
-		"parentUid: "newFolder",
-		}`
-	create := apis.DoRequest(helper, apis.RequestParams{
+	// Create a folder declaring itself as its own parent — must fail with 400.
+	selfParentPayload := `{"title": "Self Parent", "uid": "self-parent", "parentUid": "self-parent"}`
+	selfParent := apis.DoRequest(helper, apis.RequestParams{
 		User:   client.Args.User,
 		Method: http.MethodPost,
 		Path:   "/api/folders",
-		Body:   []byte(payload),
+		Body:   []byte(selfParentPayload),
 	}, &folder.Folder{})
-	require.NotEmpty(t, create.Response)
-	require.Equal(t, 400, create.Response.StatusCode)
+	require.NotEmpty(t, selfParent.Response)
+	require.Equal(t, http.StatusBadRequest, selfParent.Response.StatusCode)
+
+	// Create a parent and a child, then attempt to move the parent under its
+	// own child — must fail with 400, not 500.
+	parentPayload := `{"title": "Circular Parent", "uid": "circ-parent"}`
+	parent := apis.DoRequest(helper, apis.RequestParams{
+		User:   client.Args.User,
+		Method: http.MethodPost,
+		Path:   "/api/folders",
+		Body:   []byte(parentPayload),
+	}, &folder.Folder{})
+	require.NotNil(t, parent.Result)
+	require.Equal(t, http.StatusOK, parent.Response.StatusCode)
+
+	childPayload := `{"title": "Circular Child", "uid": "circ-child", "parentUid": "circ-parent"}`
+	child := apis.DoRequest(helper, apis.RequestParams{
+		User:   client.Args.User,
+		Method: http.MethodPost,
+		Path:   "/api/folders",
+		Body:   []byte(childPayload),
+	}, &folder.Folder{})
+	require.NotNil(t, child.Result)
+	require.Equal(t, http.StatusOK, child.Response.StatusCode)
+
+	// Move parent under its own child via the k8s api (legacy /api/folders
+	// move uses a separate PATCH endpoint; this exercises validateOnUpdate).
+	got, err := client.Resource.Get(context.Background(), "circ-parent", metav1.GetOptions{})
+	require.NoError(t, err)
+	got.SetAnnotations(map[string]string{utils.AnnoKeyFolder: "circ-child"})
+	_, err = client.Resource.Update(context.Background(), got, metav1.UpdateOptions{})
+	require.Error(t, err)
+	require.Truef(t, apierrors.IsBadRequest(err),
+		"expected 400 BadRequest from circular move; got: %v (%T)", err, err)
+	require.Falsef(t, apierrors.IsInternalError(err),
+		"circular-move surfaced as HTTP 500: %v", err)
 }
 
 func doListFoldersTest(t *testing.T, helper *apis.K8sTestHelper, mode grafanarest.DualWriterMode) {
@@ -2298,25 +2330,49 @@ func TestIntegrationFolderValidationReturns400(t *testing.T) {
 	}
 
 	cases := []struct {
-		name        string
-		setup       func(t *testing.T) string
-		folder      func(parentUID string) *unstructured.Unstructured
-		expectedMsg string
+		name              string
+		setup             func(t *testing.T) string
+		folder            func(parentUID string) *unstructured.Unstructured
+		expectedMsg       string
+		expectedMessageID string
 	}{
 		{
-			name:        "title empty",
-			folder:      func(string) *unstructured.Unstructured { return makeFolder("title-empty-test", "", "") },
-			expectedMsg: "folder title cannot be empty",
+			name:              "title empty",
+			folder:            func(string) *unstructured.Unstructured { return makeFolder("title-empty-test", "", "") },
+			expectedMsg:       "folder title cannot be empty",
+			expectedMessageID: "folder.title-empty",
 		},
 		{
-			name:        "reserved uid",
-			folder:      func(string) *unstructured.Unstructured { return makeFolder(folder.GeneralFolderUID, "Some title", "") },
-			expectedMsg: "invalid uid for folder provided",
+			name:              "reserved uid",
+			folder:            func(string) *unstructured.Unstructured { return makeFolder(folder.GeneralFolderUID, "Some title", "") },
+			expectedMsg:       "invalid uid for folder provided",
+			expectedMessageID: "folder.invalid-uid",
 		},
 		{
-			name:        "parent of itself",
-			folder:      func(string) *unstructured.Unstructured { return makeFolder("self-parent", "Some title", "self-parent") },
-			expectedMsg: "folder cannot be parent of itself",
+			name:              "uid contains illegal characters",
+			folder:            func(string) *unstructured.Unstructured { return makeFolder("hello world", "Some title", "") },
+			expectedMsg:       "uid contains illegal characters",
+			expectedMessageID: "folder.invalid-uid-chars",
+		},
+		{
+			name: "uid too long",
+			folder: func(string) *unstructured.Unstructured {
+				return makeFolder("a0123456789012345678901234567890123456789", "Some title", "")
+			},
+			expectedMsg:       "uid too long, max 40 characters",
+			expectedMessageID: "folder.uid-too-long",
+		},
+		{
+			name:              "reserved title General",
+			folder:            func(string) *unstructured.Unstructured { return makeFolder("reserved-title-test", "General", "") },
+			expectedMsg:       "A folder with that name already exists",
+			expectedMessageID: "folder.name-exists",
+		},
+		{
+			name:              "parent of itself",
+			folder:            func(string) *unstructured.Unstructured { return makeFolder("self-parent", "Some title", "self-parent") },
+			expectedMsg:       "folder cannot be parent of itself",
+			expectedMessageID: "folder.cannot-be-parent-of-itself",
 		},
 		{
 			name: "max depth exceeded",
@@ -2334,7 +2390,8 @@ func TestIntegrationFolderValidationReturns400(t *testing.T) {
 			folder: func(parentUID string) *unstructured.Unstructured {
 				return makeFolder("max-depth-6", "Max depth 6", parentUID)
 			},
-			expectedMsg: "[folder.maximum-depth-reached] folder max depth exceeded, max depth is 4",
+			expectedMsg:       "[folder.maximum-depth-reached] folder max depth exceeded, max depth is 4",
+			expectedMessageID: "folder.maximum-depth-reached",
 		},
 	}
 
@@ -2356,6 +2413,61 @@ func TestIntegrationFolderValidationReturns400(t *testing.T) {
 			require.Equal(t, int32(http.StatusBadRequest), statusErr.ErrStatus.Code)
 			require.Equal(t, tc.expectedMsg, statusErr.ErrStatus.Message)
 			require.Equal(t, tc.expectedMsg, err.Error())
+			require.NotNil(t, statusErr.ErrStatus.Details, "expected Status.Details to carry the errutil messageID")
+			require.Equal(t, tc.expectedMessageID, string(statusErr.ErrStatus.Details.UID))
+		})
+	}
+
+	updateCases := []struct {
+		name              string
+		uid               string
+		mutate            func(obj *unstructured.Unstructured)
+		expectedMsg       string
+		expectedMessageID string
+	}{
+		{
+			name: "rename to reserved title General",
+			uid:  "rename-to-general",
+			mutate: func(obj *unstructured.Unstructured) {
+				spec := obj.Object["spec"].(map[string]any)
+				spec["title"] = "General"
+				obj.Object["spec"] = spec
+			},
+			expectedMsg:       "A folder with that name already exists",
+			expectedMessageID: "folder.name-exists",
+		},
+		{
+			name: "move into k6 folder",
+			uid:  "move-to-k6",
+			mutate: func(obj *unstructured.Unstructured) {
+				obj.SetAnnotations(map[string]string{utils.AnnoKeyFolder: accesscontrol.K6FolderUID})
+			},
+			expectedMsg:       "Folders cannot be moved into the k6 project",
+			expectedMessageID: "folder.cannot-be-moved-to-k6",
+		},
+	}
+
+	for _, uc := range updateCases {
+		t.Run("update: "+uc.name, func(t *testing.T) {
+			created, err := client.Resource.Create(context.Background(),
+				makeFolder(uc.uid, "Update Source", ""), metav1.CreateOptions{})
+			require.NoError(t, err)
+
+			uc.mutate(created)
+
+			_, err = client.Resource.Update(context.Background(), created, metav1.UpdateOptions{})
+			require.Error(t, err)
+			require.Falsef(t, apierrors.IsInternalError(err),
+				"validateOnUpdate surfaced as HTTP 500: %v", err)
+			require.Truef(t, apierrors.IsBadRequest(err),
+				"expected HTTP 400 BadRequest; got: %v (%T)", err, err)
+
+			var statusErr *apierrors.StatusError
+			require.True(t, errors.As(err, &statusErr), "expected *apierrors.StatusError; got %T", err)
+			require.Equal(t, int32(http.StatusBadRequest), statusErr.ErrStatus.Code)
+			require.Equal(t, uc.expectedMsg, statusErr.ErrStatus.Message)
+			require.NotNil(t, statusErr.ErrStatus.Details, "expected Status.Details to carry the errutil messageID")
+			require.Equal(t, uc.expectedMessageID, string(statusErr.ErrStatus.Details.UID))
 		})
 	}
 }


### PR DESCRIPTION
Backports two related commits to `release-13.0.2`:

- `fefb9483f3c` from #123709 — Folder: Wrap validation errors in metav1.Status
- `ee5fc1201cd` from #123843 — Folder: Wrap remaining validation errors in metav1.Status (follow-up)

## Why both PRs

#123709 is the original fix for production alert #1782995 (max-depth bug surfacing as HTTP 500). #123843 is the follow-up that closes the remaining gaps — UID errors (illegal chars, too long), ErrNameExists call sites, k6 move rejection, and the move-under-descendant circular-reference path. Both are needed in 13.0.2 to fully eliminate "Unhandled Error" 500s from the folder admission validator.

## Conflict resolution

`release-13.0.2` does not contain commit 096eeb69cb (Stephanie Hingtgen's "Folders: Move folder specific errors to the folder service" #122050), which is responsible for most of the conflict noise across both backports. The actual PR changes are small; the rest of the diffs are folder-error sentinels that this branch had to introduce because 122050 didn't move them.

### #123709 (commit 1)

- `pkg/services/folder/model.go` — Added only the sentinels needed by this PR: `ErrCyclicReference` (errutil), the three legacy `errors.New` variants (`ErrTitleEmpty`, `ErrInvalidUID`, `ErrFolderCannotBeParentOfItself`), and the three `ErrAPI*` errutil wrappers. Skipped the rest of 122050's renames (`ErrVersionMismatch`, `ErrSameUIDExists`, `ErrAccessDenied`, `ErrMoveAccessDenied`, etc.) — those still live where 13.0.2 has them in `dashboards/errors.go`.
- `pkg/registry/apis/folders/validate.go` — Applied the four call-site changes from the PR. Dropped the unrelated `strings.EqualFold(..., dashboards.RootFolderName)` check that landed on `main` via a different commit and is not part of this PR.
- `pkg/registry/apis/folders/validate_test.go` — Picked up the typed-error retype, dropped the three "title is reserved name General" cases (they depend on the `RootFolderName` check that doesn't exist in 13.0.2).
- `pkg/api/apierrors/folder.go` — **Additional fix beyond auto-merge.** Added `errors.Is(err, folder.ErrTitleEmpty)` to the 400 list. Without it, `folder.ErrAPITitleEmpty` flowing through `ToFolderStatusError` would not be recognized in 13.0.2. On `main` this is implicit because 122050 renamed `dashboards.ErrFolderTitleEmpty` → `folder.ErrTitleEmpty`; in 13.0.2 both names coexist as separate errors so the explicit check is required.

### #123843 (commit 2)

- `pkg/registry/apis/folders/validate.go` — Skipped the two `strings.EqualFold(..., dashboards.RootFolderName)` "title is reserved name General" checks (same reasoning as above — the underlying behavior was added by an unrelated commit not in 13.0.2). Kept the rest: `ErrAPIInvalidUID`/`ErrAPIUIDTooLong` definitions, the `dashboards.ErrDashboardInvalidUid → ErrAPIInvalidUID` and `dashboards.ErrDashboardUidTooLong → ErrAPIUIDTooLong` swaps, the new `folder.ErrFolderCannotBeMovedToK6.Errorf(...)` for the k6 move rejection, and `folder.ErrCircularReference.Errorf(...)` for the move-under-descendant case.
- `pkg/services/folder/model.go` — Skipped the four error definitions inside the conflict block (`ErrMoveAccessDenied`, `ErrAccessEscalation`, `ErrCreationAccessDenied`, `ErrNameExists`). The first three already live in `pkg/services/dashboards/errors.go` for 13.0.2; `ErrNameExists` is unused in this branch because the RootFolderName checks were dropped above. Kept the new `ErrFolderCannotBeMovedToK6` and the `ErrCyclicReference` clarifying comment.
- `pkg/api/apierrors/folder.go` — Matched `main` by removing `dashboards.ErrDashboardTypeMismatch`/`ErrDashboardInvalidUid`/`ErrDashboardUidTooLong` from the 400 if-list (they're already caught by the earlier `dashboardaccess.DashboardErr` `errors.As` branch, which now also applies the `stableDashboardErrSentinels` message override). Kept `dashboards.ErrFolderTitleEmpty` since in 13.0.2 it's still a separate `errors.New` sentinel rather than a `DashboardErr`.

## Verified

- `go build ./...` clean.
- `go vet` clean for all touched packages including the integration test file.
- Unit tests pass for `pkg/services/folder/...`, `pkg/api/apierrors/...`, `pkg/registry/apis/folders/...`.

---

## Original PR descriptions

### #123709 — Folder: Wrap validation errors in metav1.Status

**What is this feature?**

Wraps validation errors returned by the folder admission validator with `errutil` so they implement the k8s `APIStatus` interface and surface as proper 4xx responses instead of bare 500s.

**Why do we need this feature?**

Production alert (`folder-grafana-app-main`) was burning SLO budget on 5xx responses. Sift identified ~98% of the errors as bare `fmt.Errorf("folder max depth exceeded, max depth is 4")` returns from the admission validator — the k8s apiserver couldn't convert them to a `metav1.Status`, so they logged as "Unhandled Error" and surfaced as HTTP 500. Clients should get a 4xx here so they fail fast instead of retrying and burning more budget.

### #123843 — Folder: Wrap remaining validation errors in metav1.Status (follow-up)

**What is this feature?**

Follow-up to #123709 that extends APIStatus coverage to the remaining folder admission validator paths that still surfaced as 500 "Unhandled Error":

- Dashboard UID errors (illegal characters, too long) — `validate.go` returns new `ErrAPIInvalidUID` / `ErrAPIUIDTooLong` errutil wrappers around the legacy `dashboards` sentinels. Defined in `pkg/registry/apis/folders/` (not `pkg/services/folder/model.go`) to avoid the existing `dashboards → folder` import cycle.
- New `folder.ErrFolderCannotBeMovedToK6` (`errutil.BadRequest`) for the k6 move rejection.
- Existing `folder.ErrCircularReference` reused for the move-under-descendant case (was a bare `fmt.Errorf` before).

`ToFolderStatusError` now copies `errutil.Error.Status().Details` into the returned `metav1.Status` so downstream consumers (provisioning's `IsFolderValidationAPIError`, observability tooling) can match on the structured messageID via `Status.Details.UID` without parsing the human message. `ToFolderErrorResponse`'s dashboard branch only strips the errutil `[messageID]` prefix when an apiserver-path errutil wrapper is in the chain AND the underlying matches one of `stableDashboardErrSentinels`, keeping legacy `/api/folders` messages byte-stable without dropping custom context from non-errutil callers.

**Why do we need this feature?**

Same root cause as #123709: bare Go errors returned from the folder admission validator can't be converted to `metav1.Status` by the k8s apiserver, so they surface as HTTP 500 "Unhandled Error" instead of the appropriate 4xx. The previous PR addressed the max-depth bug that fired alert #1782995; this PR closes the remaining gaps so any future regression in the same shape fails fast as 4xx and provisioning consumers can branch on the structured messageID.