### PR TITLE
FlameGraph: Visual snapshot debug

### DIFF
--- a/packages/grafana-data/typings/jest/index.d.ts
+++ b/packages/grafana-data/typings/jest/index.d.ts
@@ -1,6 +1,5 @@
 import type { CanvasRenderingContext2DEvent } from 'jest-canvas-mock';
 import { type Observable } from 'rxjs';
-import type uPlot from 'uplot';
 
 type ObservableType<T> = T extends Observable<infer V> ? V : never;
 

--- a/packages/grafana-flamegraph/jest.config.js
+++ b/packages/grafana-flamegraph/jest.config.js
@@ -1,0 +1,6 @@
+const sharedConfig = require('../../jest.config.js');
+
+module.exports = {
+  ...sharedConfig,
+  rootDir: '../../',
+};

--- a/packages/grafana-flamegraph/package.json
+++ b/packages/grafana-flamegraph/package.json
@@ -67,6 +67,7 @@
     "@babel/core": "7.28.0",
     "@babel/preset-env": "7.28.0",
     "@babel/preset-react": "7.27.1",
+    "@grafana/test-utils": "workspace:*",
     "@rollup/plugin-node-resolve": "16.0.1",
     "@storybook/addon-webpack5-compiler-swc": "^4.0.2",
     "@storybook/react": "^10.0.8",

--- a/packages/grafana-flamegraph/src/FlameGraph/FlameGraph.test.tsx
+++ b/packages/grafana-flamegraph/src/FlameGraph/FlameGraph.test.tsx
@@ -76,8 +76,8 @@ describe('FlameGraph', () => {
 
     const canvas = screen.getByTestId('flameGraph') as HTMLCanvasElement;
     const ctx = canvas!.getContext('2d');
-    const calls = ctx!.__getDrawCalls();
-    expect(calls).toMatchSnapshot();
+    const calls = ctx!.__getEvents();
+    expect(calls).toMatchUPlotSnapshot([], { height: 550, width: 800 });
   });
 
   it('should render metadata', async () => {
@@ -172,8 +172,8 @@ describe('FlameGraph (new UI)', () => {
 
     const canvas = screen.getByTestId('flameGraph') as HTMLCanvasElement;
     const ctx = canvas!.getContext('2d');
-    const calls = ctx!.__getDrawCalls();
-    expect(calls).toMatchSnapshot();
+    const calls = ctx!.__getEvents();
+    expect(calls).toMatchUPlotSnapshot([], { height: 550, width: 800 });
   });
 
   it('should render metadata', async () => {

--- a/packages/grafana-flamegraph/src/FlameGraph/__snapshots__/FlameGraph.test.tsx.snap
+++ b/packages/grafana-flamegraph/src/FlameGraph/__snapshots__/FlameGraph.test.tsx.snap
@@ -4,6 +4,48 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
 [
   {
     "props": {
+      "value": "middle",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "textBaseline",
+  },
+  {
+    "props": {
+      "value": "12px monospace",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "font",
+  },
+  {
+    "props": {
+      "value": "#ffffff",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "strokeStyle",
+  },
+  {
+    "props": {
       "height": 1100,
       "width": 1600,
       "x": 0,
@@ -18,6 +60,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "clearRect",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 1599,
+      "x": 0.5,
+      "y": 0,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ff7070",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -107,6 +192,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 1599,
+            "x": 0.5,
+            "y": 0,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "total",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -126,6 +296,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 397.5419198055893,
+      "x": 0.5,
+      "y": 22,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffc157",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -215,6 +440,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 397.5419198055893,
+            "x": 0.5,
+            "y": 22,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "(2) test/pkg/agent.(*Target).start.func1",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
+  },
+  {
     "props": {
       "maxWidth": null,
       "text": "(2) test/pkg/agent.(*Target).start.func1 (4.10 Bil)",
@@ -230,6 +540,47 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fillText",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 10,
+      "x": 0,
+      "y": 22,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
   },
   {
     "props": {
@@ -277,6 +628,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 11,
+      "width": 3,
+      "x": 4,
+      "y": 27.5,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#666666",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "fillRule": "nonzero",
       "path": [
@@ -322,6 +716,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 355.74362089914945,
+      "x": 0.5,
+      "y": 44,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffc457",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -409,6 +846,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 355.74362089914945,
+            "x": 0.5,
+            "y": 44,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "test/pkg/distributor.(*Distributor).Push",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -428,6 +950,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 108.84204131227219,
+      "x": 0.5,
+      "y": 66,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffd84d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -515,6 +1092,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 108.84204131227219,
+            "x": 0.5,
+            "y": 66,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "compress/gzip.(*Writer).Write",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -534,6 +1196,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 102.03766707168894,
+      "x": 0.5,
+      "y": 88,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffd84d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -621,6 +1338,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 102.03766707168894,
+            "x": 0.5,
+            "y": 88,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "compress/flate.(*compressor).write",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -640,6 +1442,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 98.1494532199271,
+      "x": 0.5,
+      "y": 110,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffd84d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -727,6 +1584,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 98.1494532199271,
+            "x": 0.5,
+            "y": 110,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "compress/flate.(*compressor).deflate",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -746,6 +1688,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 13.580801944106927,
+      "x": 0.5,
+      "y": 132,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -835,6 +1832,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 50.51883353584447,
+      "x": 15.080801944106927,
+      "y": 132,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffdb4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -922,6 +1962,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 50.51883353584447,
+            "x": 15.080801944106927,
+            "y": 132,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "compress/flate.(*compressor).findMatch",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -941,6 +2066,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 36.91008505467801,
+      "x": 110.34204131227219,
+      "y": 66,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -1030,6 +2210,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 36.91008505467801,
+            "x": 110.34204131227219,
+            "y": 66,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "(2) test/pkg/pprof.OpenRaw",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
+  },
+  {
     "props": {
       "maxWidth": null,
       "text": "(2) test/pkg/pprof.OpenRaw (390 Mil)",
@@ -1045,6 +2310,47 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fillText",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 10,
+      "x": 109.84204131227219,
+      "y": 66,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
   },
   {
     "props": {
@@ -1092,6 +2398,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 11,
+      "width": 3,
+      "x": 113.84204131227219,
+      "y": 71.5,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#666666",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "fillRule": "nonzero",
       "path": [
@@ -1137,6 +2486,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 16.496962332928312,
+      "x": 110.34204131227219,
+      "y": 88,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -1224,6 +2616,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 9.69258809234508,
+      "x": 127.83900364520049,
+      "y": 88,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -1315,6 +2750,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 19.413122721749698,
+      "x": 148.2521263669502,
+      "y": 66,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -1402,6 +2880,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 11.636695018226003,
+      "x": 148.2521263669502,
+      "y": 88,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -1493,6 +3014,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 177.85783718104497,
+      "x": 168.66524908869988,
+      "y": 66,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffd152",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -1580,6 +3144,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 177.85783718104497,
+            "x": 168.66524908869988,
+            "y": 66,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "test/pkg/pprof.(*Profile).Normalize",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -1599,6 +3248,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 22.329283110571083,
+      "x": 168.66524908869988,
+      "y": 88,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -1688,6 +3392,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 22.329283110571083,
+            "x": 168.66524908869988,
+            "y": 88,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "(2) sort.Sort",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
+  },
+  {
     "props": {
       "maxWidth": null,
       "text": "(2) sort.Sort (240 Mil)",
@@ -1703,6 +3492,47 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fillText",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 10,
+      "x": 168.16524908869988,
+      "y": 88,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
   },
   {
     "props": {
@@ -1750,6 +3580,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 11,
+      "width": 3,
+      "x": 172.16524908869988,
+      "y": 93.5,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#666666",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "fillRule": "nonzero",
       "path": [
@@ -1795,6 +3668,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 17.469015795868774,
+      "x": 173.5255164034022,
+      "y": 110,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -1882,6 +3798,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 11.636695018226003,
+      "x": 173.5255164034022,
+      "y": 132,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -1973,6 +3932,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 128.2831105710814,
+      "x": 191.99453219927096,
+      "y": 88,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffd752",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -2060,6 +4062,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 128.2831105710814,
+            "x": 191.99453219927096,
+            "y": 88,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "test/pkg/pprof.(*Profile).clearSampleReferences",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -2079,6 +4166,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 124.39489671931958,
+      "x": 191.99453219927096,
+      "y": 110,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffd752",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -2166,6 +4308,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 124.39489671931958,
+            "x": 191.99453219927096,
+            "y": 110,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "test/pkg/slices.RemoveInPlace[...]",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -2185,6 +4412,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 30.105710814094778,
+      "x": 191.99453219927096,
+      "y": 132,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -2272,6 +4554,105 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 30.105710814094778,
+            "x": 191.99453219927096,
+            "y": 132,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "test/pkg/pprof.(*Profile).clearSampleReferences.func1",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
+  },
+  {
+    "props": {
+      "value": "left",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "textAlign",
   },
   {
     "props": {
@@ -2291,6 +4672,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 11.636695018226003,
+      "x": 321.2776427703524,
+      "y": 88,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -2380,6 +4816,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 40.798298906439854,
+      "x": 357.24362089914945,
+      "y": 44,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -2467,6 +4946,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 40.798298906439854,
+            "x": 357.24362089914945,
+            "y": 44,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "(4) io/ioutil.ReadAll",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -2484,6 +5048,47 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fillText",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 10,
+      "x": 356.74362089914945,
+      "y": 44,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
   },
   {
     "props": {
@@ -2531,6 +5136,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 11,
+      "width": 3,
+      "x": 360.74362089914945,
+      "y": 49.5,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#666666",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "fillRule": "nonzero",
       "path": [
@@ -2576,6 +5224,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 34.96597812879708,
+      "x": 362.1038882138518,
+      "y": 66,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -2663,6 +5354,105 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 34.96597812879708,
+            "x": 362.1038882138518,
+            "y": 66,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "compress/flate.(*decompressor).huffmanBlock",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
+  },
+  {
+    "props": {
+      "value": "left",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "textAlign",
   },
   {
     "props": {
@@ -2682,6 +5472,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 16.496962332928312,
+      "x": 364.0479951397327,
+      "y": 88,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -2771,6 +5616,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 546.26609963548,
+      "x": 399.0419198055893,
+      "y": 22,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffb357",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -2858,6 +5746,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 546.26609963548,
+            "x": 399.0419198055893,
+            "y": 22,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "net/http.(*conn).serve",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -2877,6 +5850,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 541.4058323207777,
+      "x": 399.0419198055893,
+      "y": 44,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffb357",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -2966,6 +5994,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 541.4058323207777,
+            "x": 399.0419198055893,
+            "y": 44,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "(8) net/http.serverHandler.ServeHTTP",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
+  },
+  {
     "props": {
       "maxWidth": null,
       "text": "(8) net/http.serverHandler.ServeHTTP (5.58 Bil)",
@@ -2981,6 +6094,47 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fillText",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 10,
+      "x": 398.5419198055893,
+      "y": 44,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
   },
   {
     "props": {
@@ -3026,6 +6180,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 11,
+      "width": 3,
+      "x": 402.5419198055893,
+      "y": 49.5,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#666666",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -3073,6 +6270,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 537.5176184690158,
+      "x": 399.0419198055893,
+      "y": 66,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffb357",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -3162,6 +6402,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 537.5176184690158,
+            "x": 399.0419198055893,
+            "y": 66,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "(2) net/http.HandlerFunc.ServeHTTP",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
+  },
+  {
     "props": {
       "maxWidth": null,
       "text": "(2) net/http.HandlerFunc.ServeHTTP (5.54 Bil)",
@@ -3177,6 +6502,47 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fillText",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 10,
+      "x": 398.5419198055893,
+      "y": 66,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
   },
   {
     "props": {
@@ -3222,6 +6588,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 11,
+      "width": 3,
+      "x": 402.5419198055893,
+      "y": 71.5,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#666666",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -3269,6 +6678,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 536.5455650060753,
+      "x": 399.0419198055893,
+      "y": 88,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffb357",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -3356,6 +6808,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 536.5455650060753,
+            "x": 399.0419198055893,
+            "y": 88,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "net/http.HandlerFunc.ServeHTTP",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -3375,6 +6912,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 534.6014580801944,
+      "x": 399.0419198055893,
+      "y": 110,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffb357",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -3462,6 +7054,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 534.6014580801944,
+            "x": 399.0419198055893,
+            "y": 110,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "github.com/weaveworks/common/middleware.Instrument.Wrap.func1",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -3481,6 +7158,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 533.629404617254,
+      "x": 399.0419198055893,
+      "y": 132,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffb357",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -3568,6 +7300,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 533.629404617254,
+            "x": 399.0419198055893,
+            "y": 132,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "github.com/felixge/httpsnoop.(*Metrics).CaptureMetrics",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -3587,6 +7404,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 532.6573511543135,
+      "x": 399.0419198055893,
+      "y": 154,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffb357",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -3676,6 +7548,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 532.6573511543135,
+            "x": 399.0419198055893,
+            "y": 154,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "(2) github.com/weaveworks/common/middleware.Instrument.Wrap.func1.2",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
+  },
+  {
     "props": {
       "maxWidth": null,
       "text": "(2) github.com/weaveworks/common/middleware.Instrument.Wrap.func1.2 (5.49 Bil)",
@@ -3691,6 +7648,47 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fillText",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 10,
+      "x": 398.5419198055893,
+      "y": 154,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
   },
   {
     "props": {
@@ -3736,6 +7734,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 11,
+      "width": 3,
+      "x": 402.5419198055893,
+      "y": 159.5,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#666666",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -3783,6 +7824,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 155.50060753341435,
+      "x": 399.0419198055893,
+      "y": 176,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffd452",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -3870,6 +7954,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 155.50060753341435,
+            "x": 399.0419198055893,
+            "y": 176,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "(2) github.com/bufbuild/connect-go.(*Handler).ServeHTTP",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -3889,6 +8058,47 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 10,
+      "x": 398.5419198055893,
+      "y": 176,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
     "props": {
       "fillRule": "nonzero",
       "path": [
@@ -3934,6 +8144,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 11,
+      "width": 3,
+      "x": 402.5419198055893,
+      "y": 181.5,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#666666",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "fillRule": "nonzero",
       "path": [
@@ -3977,6 +8230,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 148.69623329283112,
+      "x": 399.0419198055893,
+      "y": 198,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffd452",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -4066,6 +8362,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 148.69623329283112,
+            "x": 399.0419198055893,
+            "y": 198,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "(2) github.com/bufbuild/connect-go.NewUnaryHandler[...].func1.1",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -4085,6 +8466,47 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 10,
+      "x": 398.5419198055893,
+      "y": 198,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
     "props": {
       "fillRule": "nonzero",
       "path": [
@@ -4128,6 +8550,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 11,
+      "width": 3,
+      "x": 402.5419198055893,
+      "y": 203.5,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#666666",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -4175,6 +8640,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 17.469015795868774,
+      "x": 399.0419198055893,
+      "y": 220,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -4262,6 +8770,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 15.52490886998785,
+      "x": 399.0419198055893,
+      "y": 242,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -4353,6 +8904,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 10.664641555285542,
+      "x": 401.95808019441074,
+      "y": 264,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -4442,6 +9036,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 81.62454434993926,
+      "x": 417.51093560145813,
+      "y": 220,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffd84d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -4529,6 +9166,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 81.62454434993926,
+            "x": 417.51093560145813,
+            "y": 220,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "test/pkg/create.(*Head).Ingest",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -4548,6 +9270,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 33.02187120291616,
+      "x": 417.51093560145813,
+      "y": 242,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -4635,6 +9412,105 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 33.02187120291616,
+            "x": 417.51093560145813,
+            "y": 242,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "test/pkg/create.(*Head).convertSamples",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
+  },
+  {
+    "props": {
+      "value": "left",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "textAlign",
   },
   {
     "props": {
@@ -4654,6 +9530,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 28.161603888213854,
+      "x": 417.51093560145813,
+      "y": 264,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -4741,6 +9672,105 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 28.161603888213854,
+            "x": 417.51093560145813,
+            "y": 264,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "test/pkg/create.(*deduplicatingSlice[...]).ingest",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
+  },
+  {
+    "props": {
+      "value": "left",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "textAlign",
   },
   {
     "props": {
@@ -4760,6 +9790,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 10.664641555285542,
+      "x": 417.51093560145813,
+      "y": 286,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -4847,6 +9932,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 9.69258809234508,
+      "x": 417.51093560145813,
+      "y": 308,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -4938,6 +10066,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 34.96597812879708,
+      "x": 451.5328068043743,
+      "y": 242,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -5025,6 +10196,105 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 34.96597812879708,
+            "x": 451.5328068043743,
+            "y": 242,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "test/pkg/create.(*deduplicatingSlice[...]).ingest",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
+  },
+  {
+    "props": {
+      "value": "left",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "textAlign",
   },
   {
     "props": {
@@ -5044,6 +10314,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 9.69258809234508,
+      "x": 488.4708383961118,
+      "y": 242,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -5133,6 +10458,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 45.658566221142166,
+      "x": 500.1354799513974,
+      "y": 220,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -5220,6 +10588,105 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 45.658566221142166,
+            "x": 500.1354799513974,
+            "y": 220,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "test/pkg/gen/google/v1.(*Profile).UnmarshalVT",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
+  },
+  {
+    "props": {
+      "value": "left",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "textAlign",
   },
   {
     "props": {
@@ -5239,6 +10706,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 13.580801944106927,
+      "x": 500.1354799513974,
+      "y": 242,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -5326,6 +10848,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 11.636695018226003,
+      "x": 501.1075334143378,
+      "y": 264,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -5417,6 +10982,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 12.608748481166465,
+      "x": 514.7162818955043,
+      "y": 242,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -5504,6 +11112,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 10.664641555285542,
+      "x": 528.3250303766707,
+      "y": 242,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -5595,6 +11246,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 376.1567436208992,
+      "x": 555.5425273390036,
+      "y": 176,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffc157",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -5682,6 +11376,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 376.1567436208992,
+            "x": 555.5425273390036,
+            "y": 176,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "(5) net/http.(*ServeMux).ServeHTTP",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -5699,6 +11478,47 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fillText",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 10,
+      "x": 555.0425273390036,
+      "y": 176,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
   },
   {
     "props": {
@@ -5744,6 +11564,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 11,
+      "width": 3,
+      "x": 559.0425273390036,
+      "y": 181.5,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#666666",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -5791,6 +11654,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 312.97326852976914,
+      "x": 555.5425273390036,
+      "y": 198,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffc552",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -5880,6 +11786,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 312.97326852976914,
+            "x": 555.5425273390036,
+            "y": 198,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "(2) runtime/pprof.writeAlloc",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
+  },
+  {
     "props": {
       "maxWidth": null,
       "text": "(2) runtime/pprof.writeAlloc (3.23 Bil)",
@@ -5895,6 +11886,47 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fillText",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 10,
+      "x": 555.0425273390036,
+      "y": 198,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
   },
   {
     "props": {
@@ -5942,6 +11974,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 11,
+      "width": 3,
+      "x": 559.0425273390036,
+      "y": 203.5,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#666666",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "fillRule": "nonzero",
       "path": [
@@ -5987,6 +12062,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 311.0291616038882,
+      "x": 555.5425273390036,
+      "y": 220,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffc552",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -6074,6 +12192,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 311.0291616038882,
+            "x": 555.5425273390036,
+            "y": 220,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime/pprof.writeHeapProto",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -6093,6 +12296,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 30.105710814094778,
+      "x": 555.5425273390036,
+      "y": 242,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -6180,6 +12438,105 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 30.105710814094778,
+            "x": 555.5425273390036,
+            "y": 242,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime/pprof.(*profileBuilder).pbSample",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
+  },
+  {
+    "props": {
+      "value": "left",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "textAlign",
   },
   {
     "props": {
@@ -6199,6 +12556,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 178.82989064398544,
+      "x": 586.6482381530984,
+      "y": 242,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffd152",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -6286,6 +12698,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 178.82989064398544,
+            "x": 586.6482381530984,
+            "y": 242,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime/pprof.(*profileBuilder).appendLocsForStack",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -6305,6 +12802,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 38.85419198055893,
+      "x": 586.6482381530984,
+      "y": 264,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -6392,6 +12944,105 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 38.85419198055893,
+            "x": 586.6482381530984,
+            "y": 264,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime/pprof.(*profileBuilder).emitLocation",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
+  },
+  {
+    "props": {
+      "value": "left",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "textAlign",
   },
   {
     "props": {
@@ -6411,6 +13062,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 9.69258809234508,
+      "x": 586.6482381530984,
+      "y": 286,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -6498,6 +13204,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 14.552855407047389,
+      "x": 626.5024301336574,
+      "y": 264,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -6589,6 +13338,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 10.664641555285542,
+      "x": 626.5024301336574,
+      "y": 286,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -6678,6 +13470,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 61.211421628189555,
+      "x": 642.0552855407047,
+      "y": 264,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffdb4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -6765,6 +13600,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 61.211421628189555,
+            "x": 642.0552855407047,
+            "y": 264,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime/pprof.allFrames",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -6784,6 +13704,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 52.462940461725395,
+      "x": 643.0273390036452,
+      "y": 286,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffdb4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -6871,6 +13846,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 52.462940461725395,
+            "x": 643.0273390036452,
+            "y": 286,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime.(*Frames).Next",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -6890,6 +13950,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 38.85419198055893,
+      "x": 643.0273390036452,
+      "y": 308,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -6977,6 +14092,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 38.85419198055893,
+            "x": 643.0273390036452,
+            "y": 308,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime.funcline1",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -6996,6 +14196,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 24.273390036452007,
+      "x": 650.803766707169,
+      "y": 330,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -7083,6 +14338,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 24.273390036452007,
+            "x": 650.803766707169,
+            "y": 330,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime.pcvalue",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -7102,6 +14442,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 15.52490886998785,
+      "x": 652.7478736330498,
+      "y": 352,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -7191,6 +14586,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 27.189550425273392,
+      "x": 704.2667071688943,
+      "y": 264,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -7278,6 +14716,105 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 27.189550425273392,
+            "x": 704.2667071688943,
+            "y": 264,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime.mapaccess2_fast64",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
+  },
+  {
+    "props": {
+      "value": "left",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "textAlign",
   },
   {
     "props": {
@@ -7297,6 +14834,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 19.413122721749698,
+      "x": 735.3724179829891,
+      "y": 264,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -7384,6 +14976,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 10.664641555285542,
+      "x": 737.3165249088701,
+      "y": 286,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -7475,6 +15110,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 26.21749696233293,
+      "x": 767.4501822600243,
+      "y": 242,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -7562,6 +15240,105 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 26.21749696233293,
+            "x": 767.4501822600243,
+            "y": 242,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime/pprof.(*profileBuilder).build",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
+  },
+  {
+    "props": {
+      "value": "left",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "textAlign",
   },
   {
     "props": {
@@ -7581,6 +15358,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 13.580801944106927,
+      "x": 767.4501822600243,
+      "y": 264,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -7668,6 +15500,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 11.636695018226003,
+      "x": 782.0309842041313,
+      "y": 264,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -7759,6 +15634,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 56.35115431348724,
+      "x": 794.6676792223573,
+      "y": 242,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffdb4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -7846,6 +15764,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 56.35115431348724,
+            "x": 794.6676792223573,
+            "y": 242,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime.FuncForPC",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -7865,6 +15868,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 13.580801944106927,
+      "x": 800.5,
+      "y": 264,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -7952,6 +16010,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 10.664641555285542,
+      "x": 803.4161603888215,
+      "y": 286,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -8043,6 +16144,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 34.96597812879708,
+      "x": 815.080801944107,
+      "y": 264,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -8130,6 +16274,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 34.96597812879708,
+            "x": 815.080801944107,
+            "y": 264,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime.funcline1",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -8149,6 +16378,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 24.273390036452007,
+      "x": 815.080801944107,
+      "y": 286,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -8236,6 +16520,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 24.273390036452007,
+            "x": 815.080801944107,
+            "y": 286,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime.pcvalue",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -8255,6 +16624,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 13.580801944106927,
+      "x": 818.9690157958688,
+      "y": 308,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -8342,6 +16766,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 9.69258809234508,
+      "x": 840.354191980559,
+      "y": 286,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -8433,6 +16900,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 61.211421628189555,
+      "x": 869.5157958687728,
+      "y": 198,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffdb4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -8520,6 +17030,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 61.211421628189555,
+            "x": 869.5157958687728,
+            "y": 198,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "(2) runtime/pprof.writeGoroutine",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -8537,6 +17132,47 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fillText",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 10,
+      "x": 869.0157958687728,
+      "y": 198,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
   },
   {
     "props": {
@@ -8582,6 +17218,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 11,
+      "width": 3,
+      "x": 873.0157958687728,
+      "y": 203.5,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#666666",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -8629,6 +17308,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 23.301336573511545,
+      "x": 869.5157958687728,
+      "y": 220,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -8718,6 +17440,105 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 23.301336573511545,
+            "x": 869.5157958687728,
+            "y": 220,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "(2) runtime/pprof.runtime_goroutineProfileWithLabels",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
+  },
+  {
+    "props": {
+      "value": "left",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "textAlign",
+  },
+  {
     "props": {
       "maxWidth": null,
       "text": "(2) runtime/pprof.runtime_goroutineProfileWithLabels (250 Mil)",
@@ -8733,6 +17554,47 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fillText",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 10,
+      "x": 869.0157958687728,
+      "y": 220,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
   },
   {
     "props": {
@@ -8778,6 +17640,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 11,
+      "width": 3,
+      "x": 873.0157958687728,
+      "y": 225.5,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#666666",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -8825,6 +17730,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 21.35722964763062,
+      "x": 869.5157958687728,
+      "y": 242,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -8912,6 +17860,105 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 21.35722964763062,
+            "x": 869.5157958687728,
+            "y": 242,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime.forEachGRace",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
+  },
+  {
+    "props": {
+      "value": "left",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "textAlign",
   },
   {
     "props": {
@@ -8931,6 +17978,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 16.496962332928312,
+      "x": 869.5157958687728,
+      "y": 264,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -9018,6 +18120,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 15.52490886998785,
+      "x": 869.5157958687728,
+      "y": 286,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -9109,6 +18254,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 36.91008505467801,
+      "x": 893.8171324422843,
+      "y": 220,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -9196,6 +18384,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 36.91008505467801,
+            "x": 893.8171324422843,
+            "y": 220,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime/pprof.printCountProfile",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -9215,6 +18488,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 16.496962332928312,
+      "x": 911.3140947752127,
+      "y": 242,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -9302,6 +18630,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 15.52490886998785,
+      "x": 911.3140947752127,
+      "y": 264,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -9393,6 +18764,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 600.7010935601459,
+      "x": 946.3080194410693,
+      "y": 22,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffb05c",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -9480,6 +18894,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 600.7010935601459,
+            "x": 946.3080194410693,
+            "y": 22,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime.gcBgMarkWorker",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -9499,6 +18998,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 598.7569866342649,
+      "x": 946.3080194410693,
+      "y": 44,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffb05c",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -9588,6 +19142,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 598.7569866342649,
+            "x": 946.3080194410693,
+            "y": 44,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "(2) runtime.systemstack",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
+  },
+  {
     "props": {
       "maxWidth": null,
       "text": "(2) runtime.systemstack (6.17 Bil)",
@@ -9603,6 +19242,47 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fillText",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 10,
+      "x": 945.8080194410693,
+      "y": 44,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
   },
   {
     "props": {
@@ -9650,6 +19330,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 11,
+      "width": 3,
+      "x": 949.8080194410693,
+      "y": 49.5,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#666666",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "fillRule": "nonzero",
       "path": [
@@ -9695,6 +19418,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 589.0364520048603,
+      "x": 946.3080194410693,
+      "y": 66,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffb35c",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -9782,6 +19548,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 589.0364520048603,
+            "x": 946.3080194410693,
+            "y": 66,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime.gcDrain",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -9801,6 +19652,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 432.53584447144596,
+      "x": 946.3080194410693,
+      "y": 88,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffbc57",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -9888,6 +19794,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 432.53584447144596,
+            "x": 946.3080194410693,
+            "y": 88,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime.scanobject",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -9907,6 +19898,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 41.77035236938032,
+      "x": 952.140340218712,
+      "y": 110,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -9994,6 +20040,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 41.77035236938032,
+            "x": 952.140340218712,
+            "y": 110,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime.pageIndexOf",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -10013,6 +20144,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 51.49088699878494,
+      "x": 994.9106925880924,
+      "y": 110,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffdb4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -10100,6 +20286,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 51.49088699878494,
+            "x": 994.9106925880924,
+            "y": 110,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime.greyobject",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -10119,6 +20390,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 94.26123936816525,
+      "x": 1047.4015795868772,
+      "y": 110,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffd84d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -10206,6 +20532,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 94.26123936816525,
+            "x": 1047.4015795868772,
+            "y": 110,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime.findObject",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -10225,6 +20636,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 45.658566221142166,
+      "x": 1147.523086269745,
+      "y": 110,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -10312,6 +20778,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 45.658566221142166,
+            "x": 1147.523086269745,
+            "y": 110,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime.spanOf",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -10331,6 +20882,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 51.49088699878494,
+      "x": 1194.181652490887,
+      "y": 110,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffdb4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -10418,6 +21024,91 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 51.49088699878494,
+            "x": 1194.181652490887,
+            "y": 110,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime.markBits.isMarked",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -10437,6 +21128,61 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 19.413122721749698,
+      "x": 1379.8438639125152,
+      "y": 88,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -10524,6 +21270,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 16.496962332928312,
+      "x": 1409.005467800729,
+      "y": 88,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -10615,6 +21404,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 19.413122721749698,
+      "x": 1427.4744835965978,
+      "y": 88,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -10704,6 +21536,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 15.52490886998785,
+      "x": 1551.897326852977,
+      "y": 22,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -10791,6 +21666,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 14.552855407047389,
+      "x": 1551.897326852977,
+      "y": 44,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -10882,6 +21800,49 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 15.52490886998785,
+      "x": 1568.4222357229648,
+      "y": 22,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -10969,6 +21930,20 @@ exports[`FlameGraph (new UI) should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {
+      "value": "#393d47",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -18201,6 +29176,48 @@ exports[`FlameGraph should render correctly 1`] = `
 [
   {
     "props": {
+      "value": "middle",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "textBaseline",
+  },
+  {
+    "props": {
+      "value": "12px monospace",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "font",
+  },
+  {
+    "props": {
+      "value": "#ffffff",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "strokeStyle",
+  },
+  {
+    "props": {
       "height": 1100,
       "width": 1600,
       "x": 0,
@@ -18215,6 +29232,49 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "clearRect",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 1599,
+      "x": 0.5,
+      "y": 0,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ff7070",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -18304,6 +29364,91 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 1599,
+            "x": 0.5,
+            "y": 0,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "total",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -18323,6 +29468,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 397.5419198055893,
+      "x": 0.5,
+      "y": 22,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffc157",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -18412,6 +29612,91 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 397.5419198055893,
+            "x": 0.5,
+            "y": 22,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "(2) test/pkg/agent.(*Target).start.func1",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
+  },
+  {
     "props": {
       "maxWidth": null,
       "text": "(2) test/pkg/agent.(*Target).start.func1 (4.10 Bil)",
@@ -18427,6 +29712,47 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fillText",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 10,
+      "x": 0,
+      "y": 22,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
   },
   {
     "props": {
@@ -18474,6 +29800,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 11,
+      "width": 3,
+      "x": 4,
+      "y": 27.5,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#666666",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "fillRule": "nonzero",
       "path": [
@@ -18519,6 +29888,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 355.74362089914945,
+      "x": 0.5,
+      "y": 44,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffc457",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -18606,6 +30018,91 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 355.74362089914945,
+            "x": 0.5,
+            "y": 44,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "test/pkg/distributor.(*Distributor).Push",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -18625,6 +30122,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 108.84204131227219,
+      "x": 0.5,
+      "y": 66,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffd84d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -18712,6 +30264,91 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 108.84204131227219,
+            "x": 0.5,
+            "y": 66,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "compress/gzip.(*Writer).Write",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -18731,6 +30368,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 102.03766707168894,
+      "x": 0.5,
+      "y": 88,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffd84d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -18818,6 +30510,91 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 102.03766707168894,
+            "x": 0.5,
+            "y": 88,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "compress/flate.(*compressor).write",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -18837,6 +30614,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 98.1494532199271,
+      "x": 0.5,
+      "y": 110,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffd84d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -18924,6 +30756,91 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 98.1494532199271,
+            "x": 0.5,
+            "y": 110,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "compress/flate.(*compressor).deflate",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -18943,6 +30860,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 13.580801944106927,
+      "x": 0.5,
+      "y": 132,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -19032,6 +31004,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 50.51883353584447,
+      "x": 15.080801944106927,
+      "y": 132,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffdb4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -19119,6 +31134,91 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 50.51883353584447,
+            "x": 15.080801944106927,
+            "y": 132,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "compress/flate.(*compressor).findMatch",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -19138,6 +31238,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 36.91008505467801,
+      "x": 110.34204131227219,
+      "y": 66,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -19227,6 +31382,91 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 36.91008505467801,
+            "x": 110.34204131227219,
+            "y": 66,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "(2) test/pkg/pprof.OpenRaw",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
+  },
+  {
     "props": {
       "maxWidth": null,
       "text": "(2) test/pkg/pprof.OpenRaw (390 Mil)",
@@ -19242,6 +31482,47 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fillText",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 10,
+      "x": 109.84204131227219,
+      "y": 66,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
   },
   {
     "props": {
@@ -19289,6 +31570,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 11,
+      "width": 3,
+      "x": 113.84204131227219,
+      "y": 71.5,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#666666",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "fillRule": "nonzero",
       "path": [
@@ -19334,6 +31658,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 16.496962332928312,
+      "x": 110.34204131227219,
+      "y": 88,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -19421,6 +31788,49 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 9.69258809234508,
+      "x": 127.83900364520049,
+      "y": 88,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -19512,6 +31922,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 19.413122721749698,
+      "x": 148.2521263669502,
+      "y": 66,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -19599,6 +32052,49 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 11.636695018226003,
+      "x": 148.2521263669502,
+      "y": 88,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -19690,6 +32186,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 177.85783718104497,
+      "x": 168.66524908869988,
+      "y": 66,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffd152",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -19777,6 +32316,91 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 177.85783718104497,
+            "x": 168.66524908869988,
+            "y": 66,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "test/pkg/pprof.(*Profile).Normalize",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -19796,6 +32420,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 22.329283110571083,
+      "x": 168.66524908869988,
+      "y": 88,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -19885,6 +32564,91 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 22.329283110571083,
+            "x": 168.66524908869988,
+            "y": 88,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "(2) sort.Sort",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
+  },
+  {
     "props": {
       "maxWidth": null,
       "text": "(2) sort.Sort (240 Mil)",
@@ -19900,6 +32664,47 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fillText",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 10,
+      "x": 168.16524908869988,
+      "y": 88,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
   },
   {
     "props": {
@@ -19947,6 +32752,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 11,
+      "width": 3,
+      "x": 172.16524908869988,
+      "y": 93.5,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#666666",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "fillRule": "nonzero",
       "path": [
@@ -19992,6 +32840,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 17.469015795868774,
+      "x": 173.5255164034022,
+      "y": 110,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -20079,6 +32970,49 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 11.636695018226003,
+      "x": 173.5255164034022,
+      "y": 132,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -20170,6 +33104,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 128.2831105710814,
+      "x": 191.99453219927096,
+      "y": 88,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffd752",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -20257,6 +33234,91 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 128.2831105710814,
+            "x": 191.99453219927096,
+            "y": 88,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "test/pkg/pprof.(*Profile).clearSampleReferences",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -20276,6 +33338,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 124.39489671931958,
+      "x": 191.99453219927096,
+      "y": 110,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffd752",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -20363,6 +33480,91 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 124.39489671931958,
+            "x": 191.99453219927096,
+            "y": 110,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "test/pkg/slices.RemoveInPlace[...]",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -20382,6 +33584,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 30.105710814094778,
+      "x": 191.99453219927096,
+      "y": 132,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -20469,6 +33726,105 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 30.105710814094778,
+            "x": 191.99453219927096,
+            "y": 132,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "test/pkg/pprof.(*Profile).clearSampleReferences.func1",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
+  },
+  {
+    "props": {
+      "value": "left",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "textAlign",
   },
   {
     "props": {
@@ -20488,6 +33844,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 11.636695018226003,
+      "x": 321.2776427703524,
+      "y": 88,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -20577,6 +33988,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 40.798298906439854,
+      "x": 357.24362089914945,
+      "y": 44,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -20664,6 +34118,91 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 40.798298906439854,
+            "x": 357.24362089914945,
+            "y": 44,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "(4) io/ioutil.ReadAll",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -20681,6 +34220,47 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fillText",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 10,
+      "x": 356.74362089914945,
+      "y": 44,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
   },
   {
     "props": {
@@ -20728,6 +34308,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 11,
+      "width": 3,
+      "x": 360.74362089914945,
+      "y": 49.5,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#666666",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "fillRule": "nonzero",
       "path": [
@@ -20773,6 +34396,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 34.96597812879708,
+      "x": 362.1038882138518,
+      "y": 66,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -20860,6 +34526,105 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 34.96597812879708,
+            "x": 362.1038882138518,
+            "y": 66,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "compress/flate.(*decompressor).huffmanBlock",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
+  },
+  {
+    "props": {
+      "value": "left",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "textAlign",
   },
   {
     "props": {
@@ -20879,6 +34644,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 16.496962332928312,
+      "x": 364.0479951397327,
+      "y": 88,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -20968,6 +34788,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 546.26609963548,
+      "x": 399.0419198055893,
+      "y": 22,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffb357",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -21055,6 +34918,91 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 546.26609963548,
+            "x": 399.0419198055893,
+            "y": 22,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "net/http.(*conn).serve",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -21074,6 +35022,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 541.4058323207777,
+      "x": 399.0419198055893,
+      "y": 44,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffb357",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -21163,6 +35166,91 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 541.4058323207777,
+            "x": 399.0419198055893,
+            "y": 44,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "(8) net/http.serverHandler.ServeHTTP",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
+  },
+  {
     "props": {
       "maxWidth": null,
       "text": "(8) net/http.serverHandler.ServeHTTP (5.58 Bil)",
@@ -21178,6 +35266,47 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fillText",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 10,
+      "x": 398.5419198055893,
+      "y": 44,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
   },
   {
     "props": {
@@ -21223,6 +35352,49 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 11,
+      "width": 3,
+      "x": 402.5419198055893,
+      "y": 49.5,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#666666",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -21270,6 +35442,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 537.5176184690158,
+      "x": 399.0419198055893,
+      "y": 66,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffb357",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -21359,6 +35574,91 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 537.5176184690158,
+            "x": 399.0419198055893,
+            "y": 66,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "(2) net/http.HandlerFunc.ServeHTTP",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
+  },
+  {
     "props": {
       "maxWidth": null,
       "text": "(2) net/http.HandlerFunc.ServeHTTP (5.54 Bil)",
@@ -21374,6 +35674,47 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fillText",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 10,
+      "x": 398.5419198055893,
+      "y": 66,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
   },
   {
     "props": {
@@ -21419,6 +35760,49 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 11,
+      "width": 3,
+      "x": 402.5419198055893,
+      "y": 71.5,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#666666",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -21466,6 +35850,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 536.5455650060753,
+      "x": 399.0419198055893,
+      "y": 88,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffb357",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -21553,6 +35980,91 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 536.5455650060753,
+            "x": 399.0419198055893,
+            "y": 88,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "net/http.HandlerFunc.ServeHTTP",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -21572,6 +36084,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 534.6014580801944,
+      "x": 399.0419198055893,
+      "y": 110,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffb357",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -21659,6 +36226,91 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 534.6014580801944,
+            "x": 399.0419198055893,
+            "y": 110,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "github.com/weaveworks/common/middleware.Instrument.Wrap.func1",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -21678,6 +36330,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 533.629404617254,
+      "x": 399.0419198055893,
+      "y": 132,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffb357",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -21765,6 +36472,91 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 533.629404617254,
+            "x": 399.0419198055893,
+            "y": 132,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "github.com/felixge/httpsnoop.(*Metrics).CaptureMetrics",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -21784,6 +36576,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 532.6573511543135,
+      "x": 399.0419198055893,
+      "y": 154,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffb357",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -21873,6 +36720,91 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 532.6573511543135,
+            "x": 399.0419198055893,
+            "y": 154,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "(2) github.com/weaveworks/common/middleware.Instrument.Wrap.func1.2",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
+  },
+  {
     "props": {
       "maxWidth": null,
       "text": "(2) github.com/weaveworks/common/middleware.Instrument.Wrap.func1.2 (5.49 Bil)",
@@ -21888,6 +36820,47 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fillText",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 10,
+      "x": 398.5419198055893,
+      "y": 154,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
   },
   {
     "props": {
@@ -21933,6 +36906,49 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 11,
+      "width": 3,
+      "x": 402.5419198055893,
+      "y": 159.5,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#666666",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -21980,6 +36996,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 155.50060753341435,
+      "x": 399.0419198055893,
+      "y": 176,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffd452",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -22067,6 +37126,91 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 155.50060753341435,
+            "x": 399.0419198055893,
+            "y": 176,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "(2) github.com/bufbuild/connect-go.(*Handler).ServeHTTP",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -22086,6 +37230,47 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 10,
+      "x": 398.5419198055893,
+      "y": 176,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
     "props": {
       "fillRule": "nonzero",
       "path": [
@@ -22131,6 +37316,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 11,
+      "width": 3,
+      "x": 402.5419198055893,
+      "y": 181.5,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#666666",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "fillRule": "nonzero",
       "path": [
@@ -22174,6 +37402,49 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 148.69623329283112,
+      "x": 399.0419198055893,
+      "y": 198,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffd452",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -22263,6 +37534,91 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 148.69623329283112,
+            "x": 399.0419198055893,
+            "y": 198,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "(2) github.com/bufbuild/connect-go.NewUnaryHandler[...].func1.1",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -22282,6 +37638,47 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 10,
+      "x": 398.5419198055893,
+      "y": 198,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
     "props": {
       "fillRule": "nonzero",
       "path": [
@@ -22325,6 +37722,49 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 11,
+      "width": 3,
+      "x": 402.5419198055893,
+      "y": 203.5,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#666666",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -22372,6 +37812,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 17.469015795868774,
+      "x": 399.0419198055893,
+      "y": 220,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -22459,6 +37942,49 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 15.52490886998785,
+      "x": 399.0419198055893,
+      "y": 242,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -22550,6 +38076,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 10.664641555285542,
+      "x": 401.95808019441074,
+      "y": 264,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -22639,6 +38208,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 81.62454434993926,
+      "x": 417.51093560145813,
+      "y": 220,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffd84d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -22726,6 +38338,91 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 81.62454434993926,
+            "x": 417.51093560145813,
+            "y": 220,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "test/pkg/create.(*Head).Ingest",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -22745,6 +38442,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 33.02187120291616,
+      "x": 417.51093560145813,
+      "y": 242,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -22832,6 +38584,105 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 33.02187120291616,
+            "x": 417.51093560145813,
+            "y": 242,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "test/pkg/create.(*Head).convertSamples",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
+  },
+  {
+    "props": {
+      "value": "left",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "textAlign",
   },
   {
     "props": {
@@ -22851,6 +38702,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 28.161603888213854,
+      "x": 417.51093560145813,
+      "y": 264,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -22938,6 +38844,105 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 28.161603888213854,
+            "x": 417.51093560145813,
+            "y": 264,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "test/pkg/create.(*deduplicatingSlice[...]).ingest",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
+  },
+  {
+    "props": {
+      "value": "left",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "textAlign",
   },
   {
     "props": {
@@ -22957,6 +38962,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 10.664641555285542,
+      "x": 417.51093560145813,
+      "y": 286,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -23044,6 +39104,49 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 9.69258809234508,
+      "x": 417.51093560145813,
+      "y": 308,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -23135,6 +39238,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 34.96597812879708,
+      "x": 451.5328068043743,
+      "y": 242,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -23222,6 +39368,105 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 34.96597812879708,
+            "x": 451.5328068043743,
+            "y": 242,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "test/pkg/create.(*deduplicatingSlice[...]).ingest",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
+  },
+  {
+    "props": {
+      "value": "left",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "textAlign",
   },
   {
     "props": {
@@ -23241,6 +39486,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 9.69258809234508,
+      "x": 488.4708383961118,
+      "y": 242,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -23330,6 +39630,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 45.658566221142166,
+      "x": 500.1354799513974,
+      "y": 220,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -23417,6 +39760,105 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 45.658566221142166,
+            "x": 500.1354799513974,
+            "y": 220,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "test/pkg/gen/google/v1.(*Profile).UnmarshalVT",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
+  },
+  {
+    "props": {
+      "value": "left",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "textAlign",
   },
   {
     "props": {
@@ -23436,6 +39878,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 13.580801944106927,
+      "x": 500.1354799513974,
+      "y": 242,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -23523,6 +40020,49 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 11.636695018226003,
+      "x": 501.1075334143378,
+      "y": 264,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -23614,6 +40154,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 12.608748481166465,
+      "x": 514.7162818955043,
+      "y": 242,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -23701,6 +40284,49 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 10.664641555285542,
+      "x": 528.3250303766707,
+      "y": 242,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -23792,6 +40418,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 376.1567436208992,
+      "x": 555.5425273390036,
+      "y": 176,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffc157",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -23879,6 +40548,91 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 376.1567436208992,
+            "x": 555.5425273390036,
+            "y": 176,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "(5) net/http.(*ServeMux).ServeHTTP",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -23896,6 +40650,47 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fillText",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 10,
+      "x": 555.0425273390036,
+      "y": 176,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
   },
   {
     "props": {
@@ -23941,6 +40736,49 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 11,
+      "width": 3,
+      "x": 559.0425273390036,
+      "y": 181.5,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#666666",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -23988,6 +40826,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 312.97326852976914,
+      "x": 555.5425273390036,
+      "y": 198,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffc552",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -24077,6 +40958,91 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 312.97326852976914,
+            "x": 555.5425273390036,
+            "y": 198,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "(2) runtime/pprof.writeAlloc",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
+  },
+  {
     "props": {
       "maxWidth": null,
       "text": "(2) runtime/pprof.writeAlloc (3.23 Bil)",
@@ -24092,6 +41058,47 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fillText",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 10,
+      "x": 555.0425273390036,
+      "y": 198,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
   },
   {
     "props": {
@@ -24139,6 +41146,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 11,
+      "width": 3,
+      "x": 559.0425273390036,
+      "y": 203.5,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#666666",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "fillRule": "nonzero",
       "path": [
@@ -24184,6 +41234,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 311.0291616038882,
+      "x": 555.5425273390036,
+      "y": 220,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffc552",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -24271,6 +41364,91 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 311.0291616038882,
+            "x": 555.5425273390036,
+            "y": 220,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime/pprof.writeHeapProto",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -24290,6 +41468,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 30.105710814094778,
+      "x": 555.5425273390036,
+      "y": 242,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -24377,6 +41610,105 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 30.105710814094778,
+            "x": 555.5425273390036,
+            "y": 242,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime/pprof.(*profileBuilder).pbSample",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
+  },
+  {
+    "props": {
+      "value": "left",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "textAlign",
   },
   {
     "props": {
@@ -24396,6 +41728,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 178.82989064398544,
+      "x": 586.6482381530984,
+      "y": 242,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffd152",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -24483,6 +41870,91 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 178.82989064398544,
+            "x": 586.6482381530984,
+            "y": 242,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime/pprof.(*profileBuilder).appendLocsForStack",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -24502,6 +41974,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 38.85419198055893,
+      "x": 586.6482381530984,
+      "y": 264,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -24589,6 +42116,105 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 38.85419198055893,
+            "x": 586.6482381530984,
+            "y": 264,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime/pprof.(*profileBuilder).emitLocation",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
+  },
+  {
+    "props": {
+      "value": "left",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "textAlign",
   },
   {
     "props": {
@@ -24608,6 +42234,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 9.69258809234508,
+      "x": 586.6482381530984,
+      "y": 286,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -24695,6 +42376,49 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 14.552855407047389,
+      "x": 626.5024301336574,
+      "y": 264,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -24786,6 +42510,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 10.664641555285542,
+      "x": 626.5024301336574,
+      "y": 286,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -24875,6 +42642,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 61.211421628189555,
+      "x": 642.0552855407047,
+      "y": 264,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffdb4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -24962,6 +42772,91 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 61.211421628189555,
+            "x": 642.0552855407047,
+            "y": 264,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime/pprof.allFrames",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -24981,6 +42876,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 52.462940461725395,
+      "x": 643.0273390036452,
+      "y": 286,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffdb4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -25068,6 +43018,91 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 52.462940461725395,
+            "x": 643.0273390036452,
+            "y": 286,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime.(*Frames).Next",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -25087,6 +43122,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 38.85419198055893,
+      "x": 643.0273390036452,
+      "y": 308,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -25174,6 +43264,91 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 38.85419198055893,
+            "x": 643.0273390036452,
+            "y": 308,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime.funcline1",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -25193,6 +43368,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 24.273390036452007,
+      "x": 650.803766707169,
+      "y": 330,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -25280,6 +43510,91 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 24.273390036452007,
+            "x": 650.803766707169,
+            "y": 330,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime.pcvalue",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -25299,6 +43614,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 15.52490886998785,
+      "x": 652.7478736330498,
+      "y": 352,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -25388,6 +43758,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 27.189550425273392,
+      "x": 704.2667071688943,
+      "y": 264,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -25475,6 +43888,105 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 27.189550425273392,
+            "x": 704.2667071688943,
+            "y": 264,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime.mapaccess2_fast64",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
+  },
+  {
+    "props": {
+      "value": "left",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "textAlign",
   },
   {
     "props": {
@@ -25494,6 +44006,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 19.413122721749698,
+      "x": 735.3724179829891,
+      "y": 264,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -25581,6 +44148,49 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 10.664641555285542,
+      "x": 737.3165249088701,
+      "y": 286,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -25672,6 +44282,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 26.21749696233293,
+      "x": 767.4501822600243,
+      "y": 242,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -25759,6 +44412,105 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 26.21749696233293,
+            "x": 767.4501822600243,
+            "y": 242,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime/pprof.(*profileBuilder).build",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
+  },
+  {
+    "props": {
+      "value": "left",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "textAlign",
   },
   {
     "props": {
@@ -25778,6 +44530,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 13.580801944106927,
+      "x": 767.4501822600243,
+      "y": 264,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -25865,6 +44672,49 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 11.636695018226003,
+      "x": 782.0309842041313,
+      "y": 264,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -25956,6 +44806,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 56.35115431348724,
+      "x": 794.6676792223573,
+      "y": 242,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffdb4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -26043,6 +44936,91 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 56.35115431348724,
+            "x": 794.6676792223573,
+            "y": 242,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime.FuncForPC",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -26062,6 +45040,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 13.580801944106927,
+      "x": 800.5,
+      "y": 264,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -26149,6 +45182,49 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 10.664641555285542,
+      "x": 803.4161603888215,
+      "y": 286,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -26240,6 +45316,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 34.96597812879708,
+      "x": 815.080801944107,
+      "y": 264,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -26327,6 +45446,91 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 34.96597812879708,
+            "x": 815.080801944107,
+            "y": 264,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime.funcline1",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -26346,6 +45550,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 24.273390036452007,
+      "x": 815.080801944107,
+      "y": 286,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -26433,6 +45692,91 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 24.273390036452007,
+            "x": 815.080801944107,
+            "y": 286,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime.pcvalue",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -26452,6 +45796,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 13.580801944106927,
+      "x": 818.9690157958688,
+      "y": 308,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -26539,6 +45938,49 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 9.69258809234508,
+      "x": 840.354191980559,
+      "y": 286,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -26630,6 +46072,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 61.211421628189555,
+      "x": 869.5157958687728,
+      "y": 198,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffdb4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -26717,6 +46202,91 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 61.211421628189555,
+            "x": 869.5157958687728,
+            "y": 198,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "(2) runtime/pprof.writeGoroutine",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -26734,6 +46304,47 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fillText",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 10,
+      "x": 869.0157958687728,
+      "y": 198,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
   },
   {
     "props": {
@@ -26779,6 +46390,49 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 11,
+      "width": 3,
+      "x": 873.0157958687728,
+      "y": 203.5,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#666666",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -26826,6 +46480,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 23.301336573511545,
+      "x": 869.5157958687728,
+      "y": 220,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -26915,6 +46612,105 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 23.301336573511545,
+            "x": 869.5157958687728,
+            "y": 220,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "(2) runtime/pprof.runtime_goroutineProfileWithLabels",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
+  },
+  {
+    "props": {
+      "value": "left",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "textAlign",
+  },
+  {
     "props": {
       "maxWidth": null,
       "text": "(2) runtime/pprof.runtime_goroutineProfileWithLabels (250 Mil)",
@@ -26930,6 +46726,47 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fillText",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 10,
+      "x": 869.0157958687728,
+      "y": 220,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
   },
   {
     "props": {
@@ -26975,6 +46812,49 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 11,
+      "width": 3,
+      "x": 873.0157958687728,
+      "y": 225.5,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#666666",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -27022,6 +46902,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 21.35722964763062,
+      "x": 869.5157958687728,
+      "y": 242,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -27109,6 +47032,105 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 21.35722964763062,
+            "x": 869.5157958687728,
+            "y": 242,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime.forEachGRace",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
+  },
+  {
+    "props": {
+      "value": "left",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "textAlign",
   },
   {
     "props": {
@@ -27128,6 +47150,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 16.496962332928312,
+      "x": 869.5157958687728,
+      "y": 264,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -27215,6 +47292,49 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 15.52490886998785,
+      "x": 869.5157958687728,
+      "y": 286,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -27306,6 +47426,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 36.91008505467801,
+      "x": 893.8171324422843,
+      "y": 220,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -27393,6 +47556,91 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 36.91008505467801,
+            "x": 893.8171324422843,
+            "y": 220,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime/pprof.printCountProfile",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -27412,6 +47660,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 16.496962332928312,
+      "x": 911.3140947752127,
+      "y": 242,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -27499,6 +47802,49 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 15.52490886998785,
+      "x": 911.3140947752127,
+      "y": 264,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -27590,6 +47936,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 600.7010935601459,
+      "x": 946.3080194410693,
+      "y": 22,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffb05c",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -27677,6 +48066,91 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 600.7010935601459,
+            "x": 946.3080194410693,
+            "y": 22,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime.gcBgMarkWorker",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -27696,6 +48170,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 598.7569866342649,
+      "x": 946.3080194410693,
+      "y": 44,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffb05c",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -27785,6 +48314,91 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 598.7569866342649,
+            "x": 946.3080194410693,
+            "y": 44,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "(2) runtime.systemstack",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
+  },
+  {
     "props": {
       "maxWidth": null,
       "text": "(2) runtime.systemstack (6.17 Bil)",
@@ -27800,6 +48414,47 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fillText",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 10,
+      "x": 945.8080194410693,
+      "y": 44,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
   },
   {
     "props": {
@@ -27847,6 +48502,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 11,
+      "width": 3,
+      "x": 949.8080194410693,
+      "y": 49.5,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#666666",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "fillRule": "nonzero",
       "path": [
@@ -27892,6 +48590,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 589.0364520048603,
+      "x": 946.3080194410693,
+      "y": 66,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffb35c",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -27979,6 +48720,91 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 589.0364520048603,
+            "x": 946.3080194410693,
+            "y": 66,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime.gcDrain",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -27998,6 +48824,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 432.53584447144596,
+      "x": 946.3080194410693,
+      "y": 88,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffbc57",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -28085,6 +48966,91 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 432.53584447144596,
+            "x": 946.3080194410693,
+            "y": 88,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime.scanobject",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -28104,6 +49070,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 41.77035236938032,
+      "x": 952.140340218712,
+      "y": 110,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -28191,6 +49212,91 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 41.77035236938032,
+            "x": 952.140340218712,
+            "y": 110,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime.pageIndexOf",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -28210,6 +49316,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 51.49088699878494,
+      "x": 994.9106925880924,
+      "y": 110,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffdb4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -28297,6 +49458,91 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 51.49088699878494,
+            "x": 994.9106925880924,
+            "y": 110,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime.greyobject",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -28316,6 +49562,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 94.26123936816525,
+      "x": 1047.4015795868772,
+      "y": 110,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffd84d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -28403,6 +49704,91 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 94.26123936816525,
+            "x": 1047.4015795868772,
+            "y": 110,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime.findObject",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -28422,6 +49808,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 45.658566221142166,
+      "x": 1147.523086269745,
+      "y": 110,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -28509,6 +49950,91 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 45.658566221142166,
+            "x": 1147.523086269745,
+            "y": 110,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime.spanOf",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -28528,6 +50054,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 51.49088699878494,
+      "x": 1194.181652490887,
+      "y": 110,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffdb4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -28615,6 +50196,91 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "save",
+  },
+  {
+    "props": {
+      "fillRule": "nonzero",
+      "path": [
+        {
+          "props": {},
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "beginPath",
+        },
+        {
+          "props": {
+            "height": 22,
+            "width": 51.49088699878494,
+            "x": 1194.181652490887,
+            "y": 110,
+          },
+          "transform": [
+            1,
+            0,
+            0,
+            1,
+            0,
+            0,
+          ],
+          "type": "rect",
+        },
+      ],
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "clip",
+  },
+  {
+    "props": {
+      "value": "#222222",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
+    "props": {
+      "text": "runtime.markBits.isMarked",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "measureText",
   },
   {
     "props": {
@@ -28634,6 +50300,61 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fillText",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "restore",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 19.413122721749698,
+      "x": 1379.8438639125152,
+      "y": 88,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -28721,6 +50442,49 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 16.496962332928312,
+      "x": 1409.005467800729,
+      "y": 88,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -28812,6 +50576,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 19.413122721749698,
+      "x": 1427.4744835965978,
+      "y": 88,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -28901,6 +50708,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 15.52490886998785,
+      "x": 1551.897326852977,
+      "y": 22,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -28988,6 +50838,49 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 14.552855407047389,
+      "x": 1551.897326852977,
+      "y": 44,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffe14d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {
@@ -29079,6 +50972,49 @@ exports[`FlameGraph should render correctly 1`] = `
     "type": "fill",
   },
   {
+    "props": {},
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "beginPath",
+  },
+  {
+    "props": {
+      "height": 22,
+      "width": 15.52490886998785,
+      "x": 1568.4222357229648,
+      "y": 22,
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "rect",
+  },
+  {
+    "props": {
+      "value": "#ffde4d",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
+  },
+  {
     "props": {
       "path": [
         {
@@ -29166,6 +51102,20 @@ exports[`FlameGraph should render correctly 1`] = `
       0,
     ],
     "type": "fill",
+  },
+  {
+    "props": {
+      "value": "#393d47",
+    },
+    "transform": [
+      1,
+      0,
+      0,
+      1,
+      0,
+      0,
+    ],
+    "type": "fillStyle",
   },
   {
     "props": {

--- a/packages/grafana-flamegraph/tsconfig.json
+++ b/packages/grafana-flamegraph/tsconfig.json
@@ -11,5 +11,10 @@
     "moduleResolution": "bundler"
   },
   "exclude": ["dist/**/*"],
-  "include": ["src/**/*.ts*", "../../public/app/types/*.d.ts", "../grafana-ui/src/types/*.d.ts"]
+  "include": [
+    "src/**/*.ts*",
+    "../../public/app/types/*.d.ts",
+    "../grafana-ui/src/types/*.d.ts",
+    "../grafana-data/typings/jest"
+  ]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3812,6 +3812,7 @@ __metadata:
     "@babel/preset-react": "npm:7.27.1"
     "@emotion/css": "npm:11.13.5"
     "@grafana/data": "npm:13.1.0-pre"
+    "@grafana/test-utils": "workspace:*"
     "@grafana/ui": "npm:13.1.0-pre"
     "@leeoniya/ufuzzy": "npm:1.0.19"
     "@rollup/plugin-node-resolve": "npm:16.0.1"


### PR DESCRIPTION
**What is this feature?**

Hooking up uplot-compare in flamegraph to provide way to visually debug snapshot changes (although I think we're going to rename to `jest-canvas-mock-compare` and scrub out all the uPlot specifics).

<img width="1692" height="666" alt="image" src="https://github.com/user-attachments/assets/7522136d-3078-48b9-be51-361b52c84c69" />

<img width="1692" height="653" alt="image" src="https://github.com/user-attachments/assets/88c700ea-6075-4084-b6ca-8bc4448fee35" />

**Why do we need this feature?**
Just a proof of concept for now, I'd like to do rename and refactor on the base package now that I know it might have benefit outside of uPlot in Grafana.

If we were going to merge this, we'd likely want to scrub out all of the identity matrix transforms from the snapshots as they eat up about 16k lines of snapshot.

Also added some jest config that was breaking me run debugging and running tests in my IDE.

**Who is this feature for?**
Flamegraph devs

**Special notes for your reviewer:**
Epic: https://github.com/grafana/grafana/issues/123686
Debug tool initial PR: https://github.com/grafana/grafana/pull/123077
Upcoming features: https://github.com/grafana/grafana/pull/123804


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
