### PR TITLE
CI: Ignore feature flag files in MT compat check

### DIFF
--- a/.github/workflows/pr-mt-service-compatibility.yml
+++ b/.github/workflows/pr-mt-service-compatibility.yml
@@ -3,7 +3,7 @@ name: "MT Service Compatibility"
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled, unlabeled]
-    branches: [main, test/frontend-backend-separation-action]
+    branches: [main]
 
 permissions:
   contents: read
@@ -14,6 +14,8 @@ jobs:
     outputs:
       frontend-strict: ${{ steps.changed-files.outputs.frontend_strict_any_changed }}
       backend-strict: ${{ steps.changed-files.outputs.backend_strict_any_changed }}
+      frontend-strict-files: ${{ steps.changed-files.outputs.frontend_strict_all_changed_files }}
+      backend-strict-files: ${{ steps.changed-files.outputs.backend_strict_all_changed_files }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -29,9 +31,6 @@ jobs:
             frontend_strict:
               - 'public/**'
               - 'packages/**'
-              - '!public/**/*.gen.ts'
-              - '!packages/**/*.gen.ts'
-              - '!packages/grafana-openapi/**'
               - 'scripts/webpack/**'
               - '.eslintrc*'
               - '.prettierrc*'
@@ -42,6 +41,8 @@ jobs:
               - '.betterer*'
               - 'jest.config*'
               - 'playwright**'
+              - '!**/*.gen.ts'
+              - '!**/*.gen.d.ts'
             backend_strict:
               - 'pkg/**'
               - 'go.mod'
@@ -54,6 +55,11 @@ jobs:
               - 'scripts/drone/**'
               - 'scripts/go/**'
               - '.air.toml'
+              - '!pkg/services/featuremgmt/registry.go'
+              - '!pkg/services/featuremgmt/toggles_gen.csv'
+              - '!pkg/services/featuremgmt/toggles_gen.go'
+              - '!pkg/services/featuremgmt/toggles_gen.json'
+
 
   check-separation:
     needs: detect-changes
@@ -80,6 +86,7 @@ jobs:
             echo "• Split this PR into two separate PRs (recommended):"
             echo "  - One PR for frontend changes (public/, packages/, *.ts, *.tsx)"
             echo "  - One PR for backend changes (pkg/, *.go, go.mod)"
+            echo "• Ensure that these two changes are independently compatible without the other"
             echo ""
             echo "Exception process (if changes MUST be coupled):"
             echo "• Add the 'no-check-mt-service-compatibility' label to this PR"
@@ -87,6 +94,12 @@ jobs:
             echo ""
             echo "For more details, see: https://enghub.grafana-ops.net/docs/default/component/deployment-tools/grafana-frontend-service/#guide-for-development-process-in-a-decoupled-deployment"
             echo "If you need help or have feedback, reach us in #proj-mt-frontend"
+            echo ""
+            echo "Frontend changed files:"
+            echo "${{ needs.detect-changes.outputs.frontend-strict-files }}" | tr ' ' '\n' | sed 's/^/- /'
+            echo ""
+            echo "Backend changed files:"
+            echo "${{ needs.detect-changes.outputs.backend-strict-files }}" | tr ' ' '\n' | sed 's/^/- /'
             exit 1
           fi
         env:

--- a/.github/workflows/pr-mt-service-compatibility.yml
+++ b/.github/workflows/pr-mt-service-compatibility.yml
@@ -9,13 +9,10 @@ permissions:
   contents: read
 
 jobs:
-  detect-changes:
-    runs-on: ubuntu-latest
-    outputs:
-      frontend-strict: ${{ steps.changed-files.outputs.frontend_strict_any_changed }}
-      backend-strict: ${{ steps.changed-files.outputs.backend_strict_any_changed }}
-      frontend-strict-files: ${{ steps.changed-files.outputs.frontend_strict_all_changed_files }}
-      backend-strict-files: ${{ steps.changed-files.outputs.backend_strict_all_changed_files }}
+  check-separation:
+    runs-on: ubuntu-arm64-small
+    permissions:
+      pull-requests: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -60,15 +57,8 @@ jobs:
               - '!pkg/services/featuremgmt/toggles_gen.go'
               - '!pkg/services/featuremgmt/toggles_gen.json'
 
-
-  check-separation:
-    needs: detect-changes
-    if: needs.detect-changes.outputs.frontend-strict == 'true' && needs.detect-changes.outputs.backend-strict == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      pull-requests: read
-    steps:
       - name: Check for exception label
+        if: steps.changed-files.outputs.frontend_strict_any_changed == 'true' && steps.changed-files.outputs.backend_strict_any_changed == 'true'
         run: |
           LABELS=$(gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --json labels --jq '.labels[].name')
           if echo "$LABELS" | grep -q "no-check-mt-service-compatibility"; then
@@ -96,10 +86,10 @@ jobs:
             echo "If you need help or have feedback, reach us in #proj-mt-frontend"
             echo ""
             echo "Frontend changed files:"
-            echo "${{ needs.detect-changes.outputs.frontend-strict-files }}" | tr ' ' '\n' | sed 's/^/- /'
+            echo "${{ steps.changed-files.outputs.frontend_strict_all_changed_files }}" | tr ' ' '\n' | sed 's/^/- /'
             echo ""
             echo "Backend changed files:"
-            echo "${{ needs.detect-changes.outputs.backend-strict-files }}" | tr ' ' '\n' | sed 's/^/- /'
+            echo "${{ steps.changed-files.outputs.backend_strict_all_changed_files }}" | tr ' ' '\n' | sed 's/^/- /'
             exit 1
           fi
         env:

--- a/.github/workflows/pr-mt-service-compatibility.yml
+++ b/.github/workflows/pr-mt-service-compatibility.yml
@@ -40,6 +40,7 @@ jobs:
               - 'playwright**'
               - '!**/*.gen.ts'
               - '!**/*.gen.d.ts'
+              - '!packages/grafana-openapi/**'
             backend_strict:
               - 'pkg/**'
               - 'go.mod'

--- a/.policy.yml
+++ b/.policy.yml
@@ -552,7 +552,7 @@ approval_rules:
         paths:
           - ^\.github\/workflows\/pr-mt-service-compatibility\.yml$
       targets_branch:
-        pattern: (^main$|^test\/frontend-backend-separation-action$)
+        pattern: (^main$)
     requires:
       conditions:
         has_workflow_result:


### PR DESCRIPTION
Updates the MT compat check github action:
- Ignore feature flag files to allow adding new feature flags in frontend PRs
- Log changed files for backend and frontend in the error message to help people understand what's triggering the check
- Run entirely in one job to avoid potential minimum usage charges for the two very short steps