### PR TITLE
Loki: Fix promise never resolving when request returns non-array

### DIFF
--- a/public/app/plugins/datasource/loki/LanguageProvider.test.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.test.ts
@@ -288,6 +288,14 @@ describe('Language completion provider', () => {
       expect(values2).not.toStrictEqual(values3);
       expect(requestSpy).toHaveBeenCalledTimes(2);
     });
+
+    it('should return empty array when request returns non-array', async () => {
+      const datasource = setup({});
+      const provider = await getLanguageProvider(datasource);
+      jest.spyOn(provider, 'request').mockResolvedValue(null);
+      const labelValues = await provider.fetchLabelValues('testkey');
+      expect(labelValues).toEqual([]);
+    });
   });
 
   describe('fetchDetectedLabelValues', () => {
@@ -380,6 +388,16 @@ describe('Language completion provider', () => {
       expect(values2).not.toStrictEqual(values3);
       expect(requestSpy).toHaveBeenCalledTimes(1);
       expect(requestSpy2).toHaveBeenCalledTimes(1);
+    });
+
+    it('should return empty array when request returns non-array', async () => {
+      const datasource = detectedLabelValuesSetup(null as unknown as string[], {
+        end: mockTimeRange.to.valueOf(),
+        start: mockTimeRange.from.valueOf(),
+      });
+      const provider = await getLanguageProvider(datasource, false);
+      const labelValues = await provider.fetchDetectedLabelValues('testkey', options);
+      expect(labelValues).toEqual([]);
     });
   });
   describe('fetchDetectedFields', () => {

--- a/public/app/plugins/datasource/loki/LanguageProvider.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.ts
@@ -247,7 +247,11 @@ export default class LokiLanguageProvider extends LanguageProvider {
     const range = options?.timeRange ?? this.getDefaultTimeRange();
     const { start, end } = this.datasource.getTimeRangeParams(range);
     const params = { 'match[]': match, start, end };
-    return await this.request(url, params);
+    const data = await this.request(url, params);
+    if (!Array.isArray(data)) {
+      return [];
+    }
+    return data;
   };
 
   // Cache key is a bit different here. We round up to a minute the intervals.

--- a/public/app/plugins/datasource/loki/LanguageProvider.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.ts
@@ -378,6 +378,7 @@ export default class LokiLanguageProvider extends LanguageProvider {
           resolve([]);
         }
       } catch (error) {
+        this.detectedLabelValuesPromisesCache.delete(cacheKey);
         if (queryOptions?.throwError) {
           reject(error);
         } else {

--- a/public/app/plugins/datasource/loki/LanguageProvider.ts
+++ b/public/app/plugins/datasource/loki/LanguageProvider.ts
@@ -369,6 +369,9 @@ export default class LokiLanguageProvider extends LanguageProvider {
           this.detectedFieldValuesCache.set(cacheKey, labelValues);
           this.detectedLabelValuesPromisesCache.delete(cacheKey);
           resolve(labelValues);
+        } else {
+          this.detectedLabelValuesPromisesCache.delete(cacheKey);
+          resolve([]);
         }
       } catch (error) {
         if (queryOptions?.throwError) {
@@ -442,6 +445,9 @@ export default class LokiLanguageProvider extends LanguageProvider {
           this.labelsCache.set(cacheKey, labelValues);
           this.labelsPromisesCache.delete(cacheKey);
           resolve(labelValues);
+        } else {
+          this.labelsPromisesCache.delete(cacheKey);
+          resolve([]);
         }
       } catch (error) {
         console.error(error);


### PR DESCRIPTION
## Summary

- Fix `fetchLabelValues` and `fetchDetectedLabelValues` methods to properly resolve when the request returns a non-array value
- Previously, if the request returned `null`, `undefined`, or any other non-array value, the promise would hang forever
- Now resolves with an empty array and cleans up the promise cache

## Test plan

- [x] Added unit tests for both methods to verify they return an empty array when request returns non-array
- [x] All existing tests pass

Made with [Cursor](https://cursor.com)