### PR TITLE
ActionRow: fix filter overfloating style

### DIFF
--- a/public/app/features/search/page/components/ActionRow.tsx
+++ b/public/app/features/search/page/components/ActionRow.tsx
@@ -86,7 +86,7 @@ export const ActionRow = ({
 
   return (
     <Stack justifyContent="space-between" alignItems="center" wrap={true}>
-      <Stack alignItems="center">
+      <Stack alignItems="center" wrap={true}>
         <TagFilter isClearable={false} tags={state.tag} tagOptions={getTagOptions} onChange={onTagFilterChange} />
         {config.featureToggles.teamFolders && onOwnerReferenceChange && (
           <OwnersFilter values={state.ownerReference ?? []} onChange={onOwnerReferenceChange} />


### PR DESCRIPTION
**What is this feature?**

Browsing Dashboards -> Filter action row: Fix when on smaller screen, filters are outside of background   

After:  
<img width="500" height="500" alt="image" src="https://github.com/user-attachments/assets/0dc3a036-0bd0-46a0-9703-361f1c28e053" />
 

**Why do we need this feature?**

Better UX on smaller screen

**Who is this feature for?**

all users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/122688

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
