### PR TITLE
Docs: Alertmanager data source updates

### DIFF
--- a/docs/sources/datasources/alertmanager/_index.md
+++ b/docs/sources/datasources/alertmanager/_index.md
@@ -25,7 +25,7 @@ review_date: 2026-04-29
 
 # Alertmanager data source
 
-Grafana includes built-in support for Alertmanager implementations in Prometheus and Grafana Mimir. Once you add an Alertmanager data source, you can use the **Choose Alertmanager** drop-down in [Grafana Alerting](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/) to view and manage Alertmanager resources such as silences, contact points, and notification policies. You can also enable the Alertmanager to receive Grafana-managed alerts.
+Grafana includes built-in support for Alertmanager implementations in Prometheus and Grafana Mimir. After you add an Alertmanager data source, you can use the **Choose Alertmanager** drop-down in [Grafana Alerting](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/) to view and manage Alertmanager resources such as silences, contact points, and notification policies. You can also enable the Alertmanager to receive Grafana-managed alerts.
 
 ## Alertmanager implementations
 
@@ -43,7 +43,9 @@ When using the Prometheus implementation, you can manage silences in the Grafana
 
 To add and configure the Alertmanager data source, complete the following steps:
 
+<!-- vale Grafana.WordList = NO -->
 {{< docs/shared lookup="alerts/add-alertmanager-ds.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+<!-- vale Grafana.WordList = YES -->
 
 ### Authentication
 
@@ -61,7 +63,7 @@ If you're using the Mimir implementation and Mimir Alertmanager hasn't been conf
 
 ## Provision the data source
 
-You can provision Alertmanager data sources using Grafana's configuration files or Terraform.
+You can provision Alertmanager data sources using configuration files or Terraform.
 
 The `jsonData` fields used across both methods are:
 
@@ -177,8 +179,8 @@ If you need full read/write access to contact points and notification policies, 
 
 ## Related resources
 
-- [Grafana Alerting](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/) — Configure and use alerting with Grafana
-- [Configure external Alertmanagers](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/set-up/configure-alertmanager/) — Connect an external Prometheus or Mimir Alertmanager to Grafana
+- [Grafana Alerting](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/)
+- [Configure external Alertmanagers](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/set-up/configure-alertmanager/)
 - [Prometheus Alertmanager documentation](https://prometheus.io/docs/alerting/latest/alertmanager/)
 - [Grafana Mimir documentation](https://grafana.com/docs/mimir/latest/)
 - [Grafana community forums](https://community.grafana.com/)

--- a/docs/sources/datasources/alertmanager/_index.md
+++ b/docs/sources/datasources/alertmanager/_index.md
@@ -2,13 +2,16 @@
 aliases:
   - ../data-sources/alertmanager/
   - ../features/datasources/alertmanager/
-description: Guide for using Alertmanager as a data source in Grafana
+description: Use the Alertmanager data source to manage silences, contact points, and notification policies in the Grafana Alerting UI.
 keywords:
   - grafana
   - prometheus
   - alertmanager
-  - guide
-  - queries
+  - mimir
+  - cortex
+  - silences
+  - contact points
+  - notification policies
 labels:
   products:
     - cloud
@@ -17,34 +20,59 @@ labels:
 menuTitle: Alertmanager
 title: Alertmanager data source
 weight: 150
+review_date: 2026-04-29
 ---
 
 # Alertmanager data source
 
-Grafana includes built-in support for Alertmanager implementations in Prometheus and Mimir.
-
-Once you add an Alertmanager as a data source, you can use the `Choose Alertmanager` drop-down on [Grafana Alerting](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/) to view and manage Alertmanager resources, such as silences, contact points, and notification policies. Additionally, you can enable the Alertmanager to receive Grafana-managed alerts.
-
-For more details about using other Alertmanagers, refer to [Alertmanagers in the Grafana Alerting documentation](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/set-up/configure-alertmanager/).
+Grafana includes built-in support for Alertmanager implementations in Prometheus and Grafana Mimir. Once you add an Alertmanager data source, you can use the **Choose Alertmanager** drop-down in [Grafana Alerting](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/) to view and manage Alertmanager resources such as silences, contact points, and notification policies. You can also enable the Alertmanager to receive Grafana-managed alerts.
 
 ## Alertmanager implementations
 
-The data source supports [Prometheus](https://prometheus.io/) and [Grafana Mimir](https://grafana.com/docs/mimir/latest/) (default) implementations of Alertmanager. You can specify the implementation in the data source's Settings page.
+The data source supports the following Alertmanager implementations. You can specify the implementation on the data source's **Settings** page.
 
-When using Prometheus, you can manage silences in the Grafana Alerting UI. However, other Alertmanager resources such as contact points, notification policies, and templates are read-only because the Prometheus Alertmanager HTTP API does not support updates for these resources.
+| Implementation | Silences | Contact points | Notification policies | Templates |
+|----------------|----------|----------------|----------------------|-----------|
+| **Mimir** (default) | Read/write | Read/write | Read/write | Read/write |
+| **Cortex** | Read/write | Read/write | Read/write | Read/write |
+| **Prometheus** | Read/write | Read-only | Read-only | Read-only |
+
+When using the Prometheus implementation, you can manage silences in the Grafana Alerting UI. Contact points, notification policies, and templates are read-only because the Prometheus Alertmanager API does not support write operations for these resources.
 
 ## Configure the data source
 
-To configure basic settings for the data source, complete the following steps:
+To add and configure the Alertmanager data source, complete the following steps:
 
 {{< docs/shared lookup="alerts/add-alertmanager-ds.md" source="grafana" version="<GRAFANA_VERSION>" >}}
 
-## Provision the Alertmanager data source
+### Authentication
 
-You can provision Alertmanager data sources by updating Grafana's configuration files.
-For more information on provisioning, and common settings available, refer to the [provisioning docs page](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/provisioning/#datasources).
+The data source supports all standard Grafana HTTP authentication methods, including basic auth and TLS. When SigV4 authentication is enabled globally in Grafana, it's also available for this data source.
 
-Here is an example for provisioning the Alertmanager data source:
+For more information about authentication options and connection settings, refer to [Data source management](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/data-source-management/).
+
+### Verify the connection
+
+Click **Save & test** to verify the connection. A successful connection returns `Health check passed.`
+
+{{< admonition type="note" >}}
+If you're using the Mimir implementation and Mimir Alertmanager hasn't been configured yet, the health check may still pass. This is expected behavior when Mimir is running in lazy configuration mode.
+{{< /admonition >}}
+
+## Provision the data source
+
+You can provision Alertmanager data sources using Grafana's configuration files or Terraform.
+
+The `jsonData` fields used across both methods are:
+
+| Field | Description |
+|-------|-------------|
+| `implementation` | The Alertmanager implementation. Supported values: `mimir`, `cortex`, `prometheus`. Defaults to `mimir`. |
+| `handleGrafanaManagedAlerts` | When `true`, this Alertmanager receives Grafana-managed alerts. You must also enable alert forwarding in **Alerting** > **Administration** in the Grafana UI. |
+
+### Configuration file
+
+For more information, refer to [Provisioning data sources](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/provisioning/#data-sources).
 
 ```yaml
 apiVersion: 1
@@ -55,13 +83,102 @@ datasources:
     url: http://localhost:9093
     access: proxy
     jsonData:
-      # Valid options for implementation include mimir, cortex and prometheus
       implementation: prometheus
-      # Whether or not Grafana should send alert instances to this Alertmanager
       handleGrafanaManagedAlerts: false
-    # optionally
     basicAuth: true
-    basicAuthUser: my_user
+    basicAuthUser: <USERNAME>
     secureJsonData:
-      basicAuthPassword: test_password
+      basicAuthPassword: <PASSWORD>
 ```
+
+### Terraform
+
+To provision the data source with Terraform, use the [`grafana_data_source` resource](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/data_source):
+
+```hcl
+resource "grafana_data_source" "alertmanager" {
+  name = "Alertmanager"
+  type = "alertmanager"
+  url  = "http://localhost:9093"
+
+  json_data_encoded = jsonencode({
+    implementation            = "prometheus"
+    handleGrafanaManagedAlerts = false
+  })
+}
+```
+
+For all available configuration options, refer to the [Grafana provider data source resource documentation](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/data_source).
+
+## Troubleshoot the data source
+
+This section covers common issues when configuring or using the Alertmanager data source.
+
+### "Health check failed."
+
+**Symptoms:**
+
+- **Save & test** returns `Health check failed.`
+- The Alertmanager URL may be unreachable or returning an unexpected response.
+
+**Possible causes and solutions:**
+
+| Cause | Solution |
+|-------|----------|
+| Incorrect URL | Verify the URL points to your Alertmanager instance and includes the correct protocol, host, and port (for example, `http://localhost:9093`). |
+| Network or firewall issue | Verify that the Grafana server can reach the Alertmanager endpoint. Check firewall rules and DNS resolution. |
+| Wrong implementation selected | If you changed the implementation type, re-test the connection. See the implementation mismatch errors below. |
+| Incorrect credentials | If basic auth is enabled, verify the username and password are correct. |
+
+### "It looks like you have chosen Prometheus implementation, but detected a Mimir or Cortex endpoint."
+
+**Symptoms:**
+
+- **Save & test** fails with this message when **Alertmanager Implementation** is set to **Prometheus**.
+
+**Solution:**
+
+The URL you entered is a Mimir or Cortex Alertmanager endpoint, not a Prometheus one. Change **Alertmanager Implementation** to **Mimir** or **Cortex** and click **Save & test** again.
+
+### "It looks like you have chosen a Mimir or Cortex implementation, but detected a Prometheus endpoint."
+
+**Symptoms:**
+
+- **Save & test** fails with this message when **Alertmanager Implementation** is set to **Mimir** or **Cortex**.
+
+**Solution:**
+
+The URL you entered is a Prometheus Alertmanager endpoint. Change **Alertmanager Implementation** to **Prometheus** and click **Save & test** again.
+
+### Grafana-managed alerts are not being received
+
+**Symptoms:**
+
+- Grafana-managed alert instances don't appear in this Alertmanager.
+- The **Receive Grafana Alerts** toggle is enabled in the data source settings, but no alerts arrive.
+
+**Solution:**
+
+Enabling **Receive Grafana Alerts** on the data source alone isn't enough. You must also enable alert forwarding in **Alerting** > **Administration** in the Grafana UI. Both settings must be on for Grafana-managed alerts to be forwarded to this Alertmanager.
+
+### Contact points and notification policies are read-only
+
+**Symptoms:**
+
+- You can view but not edit contact points, notification policies, or templates in the Grafana Alerting UI.
+
+**Cause:**
+
+You're using the **Prometheus** implementation. The Prometheus Alertmanager API doesn't support write operations for these resources.
+
+**Solution:**
+
+If you need full read/write access to contact points and notification policies, switch to a **Mimir** or **Cortex** Alertmanager and update the **Alertmanager Implementation** setting.
+
+## Related resources
+
+- [Grafana Alerting](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/) — Configure and use alerting with Grafana
+- [Configure external Alertmanagers](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/alerting/set-up/configure-alertmanager/) — Connect an external Prometheus or Mimir Alertmanager to Grafana
+- [Prometheus Alertmanager documentation](https://prometheus.io/docs/alerting/latest/alertmanager/)
+- [Grafana Mimir documentation](https://grafana.com/docs/mimir/latest/)
+- [Grafana community forums](https://community.grafana.com/)

--- a/docs/sources/datasources/alertmanager/_index.md
+++ b/docs/sources/datasources/alertmanager/_index.md
@@ -31,11 +31,11 @@ Grafana includes built-in support for Alertmanager implementations in Prometheus
 
 The data source supports the following Alertmanager implementations. You can specify the implementation on the data source's **Settings** page.
 
-| Implementation | Silences | Contact points | Notification policies | Templates |
-|----------------|----------|----------------|----------------------|-----------|
-| **Mimir** (default) | Read/write | Read/write | Read/write | Read/write |
-| **Cortex** | Read/write | Read/write | Read/write | Read/write |
-| **Prometheus** | Read/write | Read-only | Read-only | Read-only |
+| Implementation      | Silences   | Contact points | Notification policies | Templates  |
+| ------------------- | ---------- | -------------- | --------------------- | ---------- |
+| **Mimir** (default) | Read/write | Read/write     | Read/write            | Read/write |
+| **Cortex**          | Read/write | Read/write     | Read/write            | Read/write |
+| **Prometheus**      | Read/write | Read-only      | Read-only             | Read-only  |
 
 When using the Prometheus implementation, you can manage silences in the Grafana Alerting UI. Contact points, notification policies, and templates are read-only because the Prometheus Alertmanager API does not support write operations for these resources.
 
@@ -44,7 +44,9 @@ When using the Prometheus implementation, you can manage silences in the Grafana
 To add and configure the Alertmanager data source, complete the following steps:
 
 <!-- vale Grafana.WordList = NO -->
+
 {{< docs/shared lookup="alerts/add-alertmanager-ds.md" source="grafana" version="<GRAFANA_VERSION>" >}}
+
 <!-- vale Grafana.WordList = YES -->
 
 ### Authentication
@@ -67,9 +69,9 @@ You can provision Alertmanager data sources using configuration files or Terrafo
 
 The `jsonData` fields used across both methods are:
 
-| Field | Description |
-|-------|-------------|
-| `implementation` | The Alertmanager implementation. Supported values: `mimir`, `cortex`, `prometheus`. Defaults to `mimir`. |
+| Field                        | Description                                                                                                                                                   |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `implementation`             | The Alertmanager implementation. Supported values: `mimir`, `cortex`, `prometheus`. Defaults to `mimir`.                                                      |
 | `handleGrafanaManagedAlerts` | When `true`, this Alertmanager receives Grafana-managed alerts. You must also enable alert forwarding in **Alerting** > **Administration** in the Grafana UI. |
 
 ### Configuration file
@@ -125,12 +127,12 @@ This section covers common issues when configuring or using the Alertmanager dat
 
 **Possible causes and solutions:**
 
-| Cause | Solution |
-|-------|----------|
-| Incorrect URL | Verify the URL points to your Alertmanager instance and includes the correct protocol, host, and port (for example, `http://localhost:9093`). |
-| Network or firewall issue | Verify that the Grafana server can reach the Alertmanager endpoint. Check firewall rules and DNS resolution. |
-| Wrong implementation selected | If you changed the implementation type, re-test the connection. See the implementation mismatch errors below. |
-| Incorrect credentials | If basic auth is enabled, verify the username and password are correct. |
+| Cause                         | Solution                                                                                                                                      |
+| ----------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| Incorrect URL                 | Verify the URL points to your Alertmanager instance and includes the correct protocol, host, and port (for example, `http://localhost:9093`). |
+| Network or firewall issue     | Verify that the Grafana server can reach the Alertmanager endpoint. Check firewall rules and DNS resolution.                                  |
+| Wrong implementation selected | If you changed the implementation type, re-test the connection. See the implementation mismatch errors below.                                 |
+| Incorrect credentials         | If basic auth is enabled, verify the username and password are correct.                                                                       |
 
 ### "It looks like you have chosen Prometheus implementation, but detected a Mimir or Cortex endpoint."
 

--- a/docs/sources/datasources/alertmanager/_index.md
+++ b/docs/sources/datasources/alertmanager/_index.md
@@ -112,7 +112,7 @@ resource "grafana_data_source" "alertmanager" {
 
 For all available configuration options, refer to the [Grafana provider data source resource documentation](https://registry.terraform.io/providers/grafana/grafana/latest/docs/resources/data_source).
 
-## Troubleshoot the data source
+## Troubleshoot Alertmanager data source issues
 
 This section covers common issues when configuring or using the Alertmanager data source.
 


### PR DESCRIPTION
Documentation updates for the Alertmanager data source, aligned with data source documentation conventions. Content was cross-referenced against the frontend source code for accuracy.

_index.md: Updated frontmatter: added review_date, updated keywords (removed guide, queries; added mimir, cortex, silences, contact points, notification policies), removed refs: block in favour of fully qualified URLs for future standalone repo migration. Updated description to be search-friendly.

Replaced prose-only implementations section with a capability table covering Silences, Contact points, Notification policies, and Templates for each implementation (Mimir, Cortex, Prometheus), making clear which resources are read-only under Prometheus.

Added Authentication subsection covering basic auth, TLS, and SigV4 support with a link to data source management docs.

Added Verify the connection subsection with the exact success message (Health check passed.) and an admonition explaining the Mimir lazy-config edge case.

Updated Provision section: split into Configuration file and Terraform subsections, moved jsonData fields table above both, updated handleGrafanaManagedAlerts description to include the exact UI path (Alerting > Administration), replaced inline YAML comments with placeholder-style values, added Terraform grafana_data_source HCL example.

Added Troubleshooting section with four entries sourced directly from DataSource.ts: generic health check failure, Prometheus-selected-but-Mimir-endpoint detected, Mimir-selected-but-Prometheus-endpoint detected, and Grafana-managed alerts not being received (two-step configuration requirement).

Added Related resources section with links to Grafana Alerting, Configure external Alertmanagers, Prometheus Alertmanager docs, Mimir docs, and community forums.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
