### PR TITLE
dashboards: fix missing folder title in dashboards v2 transform

### DIFF
--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
@@ -51,6 +51,7 @@ import { DEFAULT_ANNOTATION_COLOR } from '@grafana/ui';
 import {
   AnnoKeyCreatedBy,
   AnnoKeyFolder,
+  AnnoKeyFolderTitle,
   AnnoKeyUpdatedBy,
   AnnoKeyUpdatedTimestamp,
   AnnoKeyDashboardIsSnapshot,
@@ -160,6 +161,7 @@ export function transformSaveModelSchemaV2ToScene(
     updated: metadata.annotations?.[AnnoKeyUpdatedTimestamp],
     updatedBy: metadata.annotations?.[AnnoKeyUpdatedBy],
     folderUid: metadata.annotations?.[AnnoKeyFolder],
+    folderTitle: metadata.annotations?.[AnnoKeyFolderTitle],
     isSnapshot: Boolean(metadata.annotations?.[AnnoKeyDashboardIsSnapshot]),
     isEmbedded: Boolean(metadata.annotations?.[AnnoKeyEmbedded]),
     publicDashboardEnabled: dto.access.isPublic,


### PR DESCRIPTION
missing the folder title here. Spotted in the usage-insights logs several events with no folder name.

To reproduce:

  1. Force disable `dashboardNewLayouts`
  2. Create dashboard in a folder
  3. Enable `dashboardNewLayouts` again
  4. Open the dashboard.
  5. Without this fix: indow.__grafanaSceneContext?.state.meta shows folderUid set, but no folderTitle. After fix: both populate.
