### PR TITLE
fix(publicdashboards): add rawQuery to sanitizeData field removal list

### DIFF
--- a/pkg/services/publicdashboards/service/query.go
+++ b/pkg/services/publicdashboards/service/query.go
@@ -459,6 +459,7 @@ func sanitizeData(data *simplejson.Json) {
 			target.Del("expr")
 			target.Del("query")
 			target.Del("rawSql")
+			target.Del("rawQuery")
 		}
 	}
 }
@@ -475,6 +476,7 @@ func sanitizeDataV2(data *simplejson.Json) {
 			dataQuerySpec.Del("expr")
 			dataQuerySpec.Del("query")
 			dataQuerySpec.Del("rawSql")
+			dataQuerySpec.Del("rawQuery")
 		}
 	}
 }


### PR DESCRIPTION
Fixes #123845

## What did you do?

Created a Grafana dashboard with an InfluxDB panel using InfluxQL with rawQuery mode enabled, then enabled public access for the dashboard.

## What did you see instead?

The rawQuery field containing the InfluxQL query string was visible in the request payload sent to the query API when accessing the public dashboard without logging in. This exposes the raw query string to unauthenticated viewers.

## Root Cause

The `sanitizeData` and `sanitizeDataV2` functions in `pkg/services/publicdashboards/service/query.go` remove query strings from panel targets before building public dashboard requests, but only remove three field names: `expr`, `query`, and `rawSql`. InfluxDB uses `rawQuery` which is not removed.

## Fix

Add `target.Del(rawQuery)` to both `sanitizeData` and `sanitizeDataV2` functions.

## Changes

- `pkg/services/publicdashboards/service/query.go`: Added `target.Del(rawQuery)` in both sanitizeData (line ~462) and sanitizeDataV2 (line ~479)

Signed-off-by: wucm667 <stevenwucongmin@gmail.com>