### PR TITLE
Provisioning: Per-verb fallback for the files subresource

### DIFF
--- a/apps/provisioning/pkg/apis/auth/verb_aware_access_checker.go
+++ b/apps/provisioning/pkg/apis/auth/verb_aware_access_checker.go
@@ -1,0 +1,51 @@
+package auth
+
+import (
+	"context"
+
+	authlib "github.com/grafana/authlib/types"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+)
+
+// verbAwareAccessChecker dispatches Check to a read or a write AccessChecker
+// based on the request verb. It exists so a single endpoint that handles both
+// read and write verbs (e.g. the files subresource) can apply different role
+// fallbacks per operation: a reader fallback for get/list/watch and a writer
+// fallback for everything else.
+type verbAwareAccessChecker struct {
+	read  AccessChecker
+	write AccessChecker
+}
+
+// NewVerbAwareAccessChecker composes a read checker and a write checker into
+// a single AccessChecker. The inner checkers are expected to already carry
+// any desired fallback roles (e.g. accessWithViewer / accessWithEditor) —
+// this wrapper does not configure fallbacks itself.
+func NewVerbAwareAccessChecker(read, write AccessChecker) AccessChecker {
+	return &verbAwareAccessChecker{read: read, write: write}
+}
+
+// WithFallbackRole is intentionally a no-op. Per-verb fallbacks are decided at
+// construction by the caller; applying a single role across both inner checkers
+// would defeat the purpose of the split.
+func (c *verbAwareAccessChecker) WithFallbackRole(_ identity.RoleType) AccessChecker {
+	return c
+}
+
+// Check dispatches to the read or write checker based on req.Verb.
+func (c *verbAwareAccessChecker) Check(ctx context.Context, req authlib.CheckRequest, folder string) error {
+	if isReadVerb(req.Verb) {
+		return c.read.Check(ctx, req, folder)
+	}
+	return c.write.Check(ctx, req, folder)
+}
+
+func isReadVerb(verb string) bool {
+	switch verb {
+	case utils.VerbGet, utils.VerbList, utils.VerbWatch:
+		return true
+	default:
+		return false
+	}
+}

--- a/apps/provisioning/pkg/apis/auth/verb_aware_access_checker_test.go
+++ b/apps/provisioning/pkg/apis/auth/verb_aware_access_checker_test.go
@@ -1,0 +1,84 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	authlib "github.com/grafana/authlib/types"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerbAwareAccessChecker_DispatchesByVerb(t *testing.T) {
+	tests := []struct {
+		name         string
+		verb         string
+		expectReader bool
+	}{
+		{name: "get -> reader", verb: utils.VerbGet, expectReader: true},
+		{name: "list -> reader", verb: utils.VerbList, expectReader: true},
+		{name: "watch -> reader", verb: utils.VerbWatch, expectReader: true},
+		{name: "create -> writer", verb: utils.VerbCreate, expectReader: false},
+		{name: "update -> writer", verb: utils.VerbUpdate, expectReader: false},
+		{name: "patch -> writer", verb: utils.VerbPatch, expectReader: false},
+		{name: "delete -> writer", verb: utils.VerbDelete, expectReader: false},
+		{name: "deletecollection -> writer", verb: utils.VerbDeleteCollection, expectReader: false},
+		{name: "unknown verb -> writer (deny-by-default for safety)", verb: "weirdverb", expectReader: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			readErr := errors.New("read called")
+			writeErr := errors.New("write called")
+			checker := NewVerbAwareAccessChecker(
+				&recordingChecker{returnErr: readErr},
+				&recordingChecker{returnErr: writeErr},
+			)
+
+			err := checker.Check(context.Background(), authlib.CheckRequest{Verb: tt.verb}, "")
+
+			if tt.expectReader {
+				assert.Same(t, readErr, err, "expected read checker to be called for verb %q", tt.verb)
+			} else {
+				assert.Same(t, writeErr, err, "expected write checker to be called for verb %q", tt.verb)
+			}
+		})
+	}
+}
+
+func TestVerbAwareAccessChecker_PassesThroughAllowed(t *testing.T) {
+	checker := NewVerbAwareAccessChecker(
+		&recordingChecker{returnErr: nil}, // reader allows
+		&recordingChecker{returnErr: errors.New("should not be called")},
+	)
+
+	require.NoError(t, checker.Check(context.Background(), authlib.CheckRequest{Verb: utils.VerbGet}, ""))
+}
+
+func TestVerbAwareAccessChecker_WithFallbackRoleIsNoOp(t *testing.T) {
+	original := NewVerbAwareAccessChecker(
+		&recordingChecker{},
+		&recordingChecker{},
+	)
+	withFallback := original.WithFallbackRole(identity.RoleAdmin)
+
+	assert.Same(t, original, withFallback,
+		"WithFallbackRole on verb-aware checker must not produce a new instance — fallbacks are configured on the inner checkers")
+}
+
+// recordingChecker is a minimal AccessChecker that records whether it was
+// invoked. Used to verify dispatch in TestVerbAwareAccessChecker_DispatchesByVerb.
+type recordingChecker struct {
+	returnErr error
+}
+
+func (r *recordingChecker) Check(_ context.Context, _ authlib.CheckRequest, _ string) error {
+	return r.returnErr
+}
+
+func (r *recordingChecker) WithFallbackRole(_ identity.RoleType) AccessChecker {
+	return r
+}

--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -793,7 +793,16 @@ func (b *APIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.APIGroupI
 	// TODO: Remove this connector when we deprecate the test endpoint
 	// We should use fieldErrors from status instead.
 	storage[provisioning.RepositoryResourceInfo.StoragePath("test")] = NewTestConnector(b, testTester)
-	storage[provisioning.RepositoryResourceInfo.StoragePath("files")] = NewFilesConnector(b, b.parsers, b.clients, b.accessWithAdmin, b.folderMetadataEnabled, b.folderAPIVersion)
+	// The files subresource handles GET/POST/PUT/DELETE in a single connector
+	// and the appropriate role fallback differs per verb: reads should fall
+	// back to Viewer, writes to Editor. A static accessWithEditor would over-
+	// restrict reads when the inner authz denies; a static accessWithViewer
+	// would over-permit writes. Compose a verb-aware checker so each operation
+	// gets the right fallback. Per-resource authz still happens inside the
+	// connector via ProvisioningAuthorizer.AuthorizeResource, and repository-
+	// level operations remain Admin-gated by authorizeRepositorySubresource.
+	filesAccess := auth.NewVerbAwareAccessChecker(b.accessWithViewer, b.accessWithEditor)
+	storage[provisioning.RepositoryResourceInfo.StoragePath("files")] = NewFilesConnector(b, b.parsers, b.clients, filesAccess, b.folderMetadataEnabled, b.folderAPIVersion)
 	storage[provisioning.RepositoryResourceInfo.StoragePath("refs")] = NewRefsConnector(b)
 	storage[provisioning.RepositoryResourceInfo.StoragePath("resources")] = &listConnector{
 		getter: b,

--- a/pkg/tests/apis/provisioning/files_test.go
+++ b/pkg/tests/apis/provisioning/files_test.go
@@ -14,6 +14,8 @@ import (
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
+	"github.com/grafana/grafana/pkg/services/org"
+	"github.com/grafana/grafana/pkg/tests/apis"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -762,11 +764,13 @@ func TestIntegrationProvisioning_ReadmeFiles(t *testing.T) {
 		require.Equal(t, http.StatusOK, resp.StatusCode, "editor should be able to GET README.md")
 	})
 
-	// Negative case for the folder-scoped check: the nested 'folder/' directory
-	// exists in the repo file tree but has not been synced into Grafana, so the
-	// viewer has no permission grant on its hash-based folder UID. Admins still
-	// pass thanks to wildcard access.
-	t.Run("viewer is denied for README in an unsynced subfolder", func(t *testing.T) {
+	// Raw file reads on the files subresource fall back to the Viewer role for
+	// GET-family verbs, so an org Viewer can read raw files anywhere in a repo
+	// they can see — including paths whose containing directory has not been
+	// synced into Grafana as a real folder resource. Without this, the
+	// folder-scoped check is unsatisfiable on hash-based folder UIDs and the
+	// endpoint is effectively Admin-only for non-synced subfolders.
+	t.Run("viewer can GET README in an unsynced subfolder", func(t *testing.T) {
 		addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
 		url := fmt.Sprintf("http://viewer:viewer@%s/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/%s/files/folder/README.md", addr, repo)
 		req, err := http.NewRequest(http.MethodGet, url, nil)
@@ -776,8 +780,8 @@ func TestIntegrationProvisioning_ReadmeFiles(t *testing.T) {
 		// nolint:errcheck
 		defer resp.Body.Close()
 
-		require.Equal(t, http.StatusForbidden, resp.StatusCode,
-			"viewer without folders:get on the parent folder should be denied")
+		require.Equal(t, http.StatusOK, resp.StatusCode,
+			"viewer should be able to read README in an unsynced subfolder")
 	})
 
 	t.Run("admin can GET README in an unsynced subfolder", func(t *testing.T) {
@@ -791,6 +795,90 @@ func TestIntegrationProvisioning_ReadmeFiles(t *testing.T) {
 		defer resp.Body.Close()
 
 		require.Equal(t, http.StatusOK, resp.StatusCode, "admin should be able to GET README in any folder")
+	})
+
+	// The "viewer can GET README" subtest above relies on the Viewer role
+	// fallback. The next three subtests use users with org role None and
+	// fine-grained folder permissions to verify that the inner authz check
+	// is still authoritative when no role fallback applies — i.e. the
+	// relaxed read semantic is paid for by either basic role membership or
+	// an explicit grant, not given freely to any authenticated user.
+	rootReader := helper.CreateUser("ProvisioningRootReader", apis.Org1, org.RoleNone, []resourcepermissions.SetResourcePermissionCommand{
+		{
+			Actions:           []string{"folders:read"},
+			Resource:          "folders",
+			ResourceAttribute: "uid",
+			ResourceID:        "general",
+		},
+	})
+
+	wildcardReader := helper.CreateUser("ProvisioningFoldersReader", apis.Org1, org.RoleNone, []resourcepermissions.SetResourcePermissionCommand{
+		{
+			Actions:           []string{"folders:read"},
+			Resource:          "folders",
+			ResourceAttribute: "uid",
+			ResourceID:        "*",
+		},
+	})
+
+	noGrants := helper.CreateUser("ProvisioningNoGrants", apis.Org1, org.RoleNone, nil)
+
+	addr := helper.GetEnv().Server.HTTPServer.Listener.Addr().String()
+
+	t.Run("RoleNone with folders:read on general can GET README at the repo root", func(t *testing.T) {
+		url := fmt.Sprintf("http://%s:%s@%s/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/%s/files/README.md",
+			rootReader.Identity.GetLogin(), "ProvisioningRootReader", addr, repo)
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		// nolint:errcheck
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode,
+			"explicit folders:read on general should permit reading README at repo root")
+	})
+
+	t.Run("RoleNone with folders:read on general is denied for README in unsynced subfolder", func(t *testing.T) {
+		url := fmt.Sprintf("http://%s:%s@%s/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/%s/files/folder/README.md",
+			rootReader.Identity.GetLogin(), "ProvisioningRootReader", addr, repo)
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		// nolint:errcheck
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusForbidden, resp.StatusCode,
+			"folders:read on general should not extend to a hash-based UID for an unsynced subfolder, and there is no role fallback for org-None")
+	})
+
+	t.Run("RoleNone with folders:read wildcard can GET README in an unsynced subfolder", func(t *testing.T) {
+		url := fmt.Sprintf("http://%s:%s@%s/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/%s/files/folder/README.md",
+			wildcardReader.Identity.GetLogin(), "ProvisioningFoldersReader", addr, repo)
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		// nolint:errcheck
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusOK, resp.StatusCode,
+			"folders:read wildcard should permit reading README in any (including unsynced) subfolder without role fallback")
+	})
+
+	t.Run("RoleNone with no grants is denied for README at the repo root", func(t *testing.T) {
+		url := fmt.Sprintf("http://%s:%s@%s/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/%s/files/README.md",
+			noGrants.Identity.GetLogin(), "ProvisioningNoGrants", addr, repo)
+		req, err := http.NewRequest(http.MethodGet, url, nil)
+		require.NoError(t, err)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		// nolint:errcheck
+		defer resp.Body.Close()
+
+		require.Equal(t, http.StatusForbidden, resp.StatusCode,
+			"a user without any folder grants and no basic role should be denied")
 	})
 
 	_ = ctx


### PR DESCRIPTION
Related to https://github.com/grafana/support-escalations/issues/22042
Fixes https://github.com/grafana/git-ui-sync-project/issues/1117

**What is this feature?**

Two related changes to the provisioning files subresource:

1. Per-verb role fallback dispatch — reads fall back to Viewer, writes to Editor — instead of one static `accessWithAdmin` covering all four HTTP verbs.
2. Test updates reflecting the resulting policy: an org Viewer can GET raw files (e.g. README.md) anywhere in a repo they can see, including paths whose containing directory hasn't been synced into Grafana as a real folder. New fine-grained-permission cases lock in that the relaxed read semantic is paid for by basic-role membership **or** an explicit wildcard grant — not given for free.

**Why do we need this feature?**

The files subresource handles GET/POST/PUT/DELETE in one connector. With a single `accessWithAdmin` checker, the role fallback was wrong for at least one verb family no matter how you set it: GET should only fall back to Viewer (not Admin/Editor), and writes should not be saved by a Viewer fallback.

The concrete user-facing consequence on the read side: `AuthorizeReadRawFile` resolves the file's parent path to a folder UID and checks `folders:get` on it. For directories that exist on disk but haven't been synced to a Grafana folder, that UID is a hash with no permissions object backing it. The only RBAC grant that satisfies the check is `fixed:folders:reader` (`folders:read` on `*`), which is **Admin-only**. So raw file reads in unsynced subfolders were structurally Admin-only — no Viewer or Editor RBAC configuration could fix it. That's not what users expect ("if I can see the repo, I can read its docs").

A per-verb dispatch lets the read side fall back to Viewer (matching the spirit of "any logged-in user who can see the repo can read its raw files") while keeping writes denied unless the user actually has Editor permission via the inner authz check.

## Scope (read this if you came here from the customer escalation)

The reported customer issue — Editor users getting `dashboards.dashboard.grafana.app "<uid>" is forbidden: permission denied` when saving into a Git Sync–managed folder in MT — is a regression on the **MT authz service side**, not in this repo. The dashboard create path goes through `ProvisioningAuthorizer.AuthorizeResource(VerbCreate)` against a **real, synced folder UID** with real Editor permissions; the inner authz service is denying the action set expansion (`folders:edit` → `dashboards:create`) on that folder. That fix lives in authlib / Zanzana, separate ticket. The customer-side mitigation is reverting `useExclusivelyAccessCheckerForAuthz` for the affected stack.

This PR doesn't try to work around that on the Grafana side. It does, however, fix an adjacent unsoundness — the unsatisfiable folder check on raw files in unsynced subfolders — which surfaced while investigating the customer report.

## Changes

- **`apps/provisioning/pkg/apis/auth/verb_aware_access_checker.go`** — `NewVerbAwareAccessChecker(read, write AccessChecker)` returns a checker that dispatches `Check` to a read or write inner checker based on `req.Verb` (get/list/watch → read, everything else → write). `WithFallbackRole` is intentionally a no-op (per-verb fallbacks are decided at construction).
- **`apps/provisioning/pkg/apis/auth/verb_aware_access_checker_test.go`** — table covering all canonical Kubernetes verbs (get/list/watch as read; create/update/patch/delete/deletecollection as write), plus an unknown-verb case (defaults to write for safety) and a no-op `WithFallbackRole` assertion.
- **`pkg/registry/apis/provisioning/register.go`** — files connector wired with `auth.NewVerbAwareAccessChecker(b.accessWithViewer, b.accessWithEditor)`. The mode-switch wireup (`accessChecker = NewTokenAccessChecker / NewSessionAccessChecker`) is unchanged from `main`.
- **`pkg/tests/apis/provisioning/files_test.go`**:
  - Flips `viewer is denied for README in an unsynced subfolder` (403) → `viewer can GET README in an unsynced subfolder` (200), matching the new policy.
  - Adds four `RoleNone` fine-grained-permission subtests that exercise the auth path without basic-role fallback in the picture:
    - `folders:read` on `general` → can read root README, denied for unsynced subfolder
    - `folders:read` on `*` → can read README in unsynced subfolder
    - no grants → denied at the repo root
  - These confirm the inner auth check is still authoritative; the relaxed semantic for unsynced paths comes from either basic-role fallback or an explicit wildcard grant, not from any authenticated user being trusted by default.

## Behavioral note

The Viewer fallback applies to all reads on the files subresource, not just raw markdown. That includes parsed-resource reads (dashboards) routed through `dualReadWriter.Read` → `AuthorizeResource(VerbGet)`. Default Grafana Viewers don't have wildcard `dashboards:read` (`fixed:dashboards:reader` is Admin-only), so this is a real semantic shift: any org Viewer can read any dashboard via the provisioning files API regardless of folder permissions. Most dashboard reads still go through the dashboards apiserver (which is unchanged); the files API is primarily a Git Sync admin tool, so the impact is narrow. Calling this out so reviewers don't miss it.

## Testing

- `go build ./apps/provisioning/... ./pkg/registry/apis/provisioning/...` — clean
- `go vet ./apps/provisioning/pkg/apis/auth/... ./pkg/registry/apis/provisioning/ ./pkg/tests/apis/provisioning/...` — clean
- `go test ./apps/provisioning/pkg/apis/auth/...` — pass (12 unit-test cases for the verb-aware dispatcher)
- `go test -run TestIntegrationProvisioning_ReadmeFiles ./pkg/tests/apis/provisioning/...` — pass (14 subtests, including the 4 new fine-grained cases)

## Special notes for your reviewer

Please check that:
- [x] It works as expected from a user's perspective. _(Viewers can now read README.md anywhere in a repo they can see; admins are unaffected; fine-grained perms behave as expected without role fallback)_
- [ ] If this is a pre-GA feature, it is behind a feature toggle. _(N/A — defensive cleanup of existing wiring)_
- [ ] The docs are updated. _(N/A)_

Reviewer attention worth noting:
- The verb-aware checker defaults unknown verbs to the writer side. Alternative is fail-closed (deny outright); I picked the writer because it preserves forward compatibility if a verb is added that we haven't taught the dispatcher about. Easy to flip if a reviewer prefers fail-closed.
- The "Viewer fallback also applies to parsed dashboard reads via this connector" point in the Behavioral Note is the only intentional semantic shift beyond raw files. If that's surprising, happy to refactor toward a finer-grained read policy (e.g., raw vs. parsed split inside `ProvisioningAuthorizer`) — but I think files-API reads being broadly Viewer-readable is consistent with the rest of the API surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)