### PR TITLE
CI: Add Renovate config for Go deps

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,6 @@
 {
   extends: ["config:recommended"],
-  enabledManagers: ["npm", "docker-compose"],
+  enabledManagers: ["npm", "docker-compose", "gomod"],
   ignorePresets: [
     "github>grafana/grafana-renovate-config//presets/labels",
   ],
@@ -25,7 +25,7 @@
     "@types/slate-react", // we don't want to continue using this on the long run, use Monaco editor instead of Slate
     "@types/slate", // we don't want to continue using this on the long run, use Monaco editor instead of Slate
   ],
-  includePaths: ["package.json", "packages/**", "public/app/plugins/**", "devenv/frontend-service/docker-compose.yaml"],
+  includePaths: ["package.json", "packages/**", "public/app/plugins/**", "devenv/frontend-service/docker-compose.yaml", "**/go.mod"],
   ignorePaths: ["emails/**", "**/mocks/**"],
   labels: ["area/frontend", "dependencies", "no-changelog"],
   postUpdateOptions: ["yarnDedupeHighest"],
@@ -109,6 +109,44 @@
     {
       "matchDepTypes": ["devDependencies"],
       "prPriority": -1
+    },
+    {
+      matchManagers: ["gomod"],
+      labels: ["area/backend", "dependencies", "no-changelog"],
+      minimumReleaseAge: "7 days",
+      postUpgradeTasks: {
+        commands: ["make update-workspace"],
+        fileFilters: ["go.work", "go.work.sum", "**/go.mod", "**/go.sum"],
+        executionMode: "branch",
+      },
+    },
+    {
+      groupName: "aws-sdk-go",
+      minimumReleaseAge: "7 days",
+      matchManagers: ["gomod"],
+      matchPackageNames: ["github.com/aws/aws-sdk-go{/,}**"],
+      postUpgradeTasks: {
+        commands: ["make update-workspace"],
+        fileFilters: ["go.work", "go.work.sum", "**/go.mod", "**/go.sum"],
+        executionMode: "branch",
+      },
+    },
+    {
+      groupName: "opentelemetry-go",
+      minimumReleaseAge: "7 days",
+      matchManagers: ["gomod"],
+      matchPackageNames: ["go.opentelemetry.io/{/,}**"],
+      postUpgradeTasks: {
+        commands: ["make update-workspace"],
+        fileFilters: ["go.work", "go.work.sum", "**/go.mod", "**/go.sum"],
+        executionMode: "branch",
+      },
+    },
+    // k8s.io/* upgrades are done manually due to frequent breaking changes
+    {
+      matchManagers: ["gomod"],
+      matchPackageNames: ["k8s.io/{/,}**"],
+      enabled: false,
     },
   ],
   pin: {


### PR DESCRIPTION
**What is this feature?**

Extends the Renovate config to support Go dependencies being updated.

**Why do we need this feature?**

More flexibility when configuring the updates, especially since we can run `make update-workspace` directly from the bot, which would mean no manual intervention to merge these update PRs.

Also from my understanding, Renovate would open a single one for the whole "go workspace", rather than 1 PR per module, which reduces reviewing fatigue.

**Who is this feature for?**

Maintainers!

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
