### PR TITLE
Secrets: Inline secure values must always be created on the system keeper

### DIFF
--- a/pkg/registry/apis/secret/service/secure_value.go
+++ b/pkg/registry/apis/secret/service/secure_value.go
@@ -89,10 +89,21 @@ func (s *SecureValueService) Create(ctx context.Context, sv *secretv1beta1.Secur
 		s.metrics.SecureValueCreateDuration.WithLabelValues(strconv.FormatBool(success)).Observe(time.Since(start).Seconds())
 	}()
 
-	// Secure value creation uses the active keeper
-	keeperName, keeperCfg, err := s.keeperMetadataStorage.GetActiveKeeperConfig(ctx, sv.Namespace)
-	if err != nil {
-		return nil, fmt.Errorf("fetching active keeper config: namespace=%+v %w", sv.Namespace, err)
+	var (
+		keeperName                            = contracts.SystemKeeperName
+		keeperCfg  secretv1beta1.KeeperConfig = secretv1beta1.NewNamedKeeperConfig(contracts.SystemKeeperName, &secretv1beta1.SystemKeeperConfig{})
+	)
+
+	// Secure value creation for non-inline secure values uses the active keeper
+	// Inline secure values always use the `system` keeper.
+	if isInline := len(sv.OwnerReferences) > 0; !isInline {
+		activeKeeperName, activeKeeperCfg, err := s.keeperMetadataStorage.GetActiveKeeperConfig(ctx, sv.Namespace)
+		if err != nil {
+			return nil, fmt.Errorf("fetching active keeper config: namespace=%+v %w", sv.Namespace, err)
+		}
+
+		keeperName = activeKeeperName
+		keeperCfg = activeKeeperCfg
 	}
 
 	return s.createNewVersion(ctx, keeperName, keeperCfg, sv, actorUID)

--- a/pkg/registry/apis/secret/service/secure_value_test.go
+++ b/pkg/registry/apis/secret/service/secure_value_test.go
@@ -177,6 +177,51 @@ func TestCrud(t *testing.T) {
 		require.NotNil(t, sv)
 	})
 
+	t.Run("inline secure values always use the system keeper, even when a 3rd party keeper is active", func(t *testing.T) {
+		t.Parallel()
+
+		sut := testutils.Setup(t)
+
+		ns := "ns1"
+
+		// Create a 3rd party keeper and set it as active in the namespace.
+		keeper, err := sut.KeeperMetadataStorage.Create(t.Context(), &secretv1beta1.Keeper{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: ns,
+				Name:      "k1",
+			},
+			Spec: secretv1beta1.KeeperSpec{
+				Aws: &secretv1beta1.KeeperAWSConfig{},
+			},
+		}, "actor-uid")
+		require.NoError(t, err)
+		require.NoError(t, sut.KeeperMetadataStorage.SetAsActive(t.Context(), xkube.Namespace(keeper.Namespace), keeper.Name))
+
+		// If not inline, it will use the active keeper.
+		notInlineSv, err := sut.CreateSv(t.Context(), func(cfg *testutils.CreateSvConfig) {
+			cfg.Sv.Name = "not-inline"
+			cfg.Sv.Namespace = ns
+		})
+		require.NoError(t, err)
+		require.Equal(t, keeper.Name, notInlineSv.Status.Keeper)
+
+		// An inline secure value (one with OwnerReferences) must use the `system` keeper.
+		owner := common.ObjectReference{
+			APIGroup:   "prometheus.datasource.grafana.app",
+			APIVersion: "v0alpha1",
+			Kind:       "DataSource",
+			Name:       "test-ds",
+			Namespace:  ns,
+		}
+		inlineSv, err := sut.CreateSv(t.Context(), func(cfg *testutils.CreateSvConfig) {
+			cfg.Sv.Name = "inline"
+			cfg.Sv.Namespace = ns
+			cfg.Sv.OwnerReferences = []metav1.OwnerReference{owner.ToOwnerReference()}
+		})
+		require.NoError(t, err)
+		require.Equal(t, contracts.SystemKeeperName, inlineSv.Status.Keeper)
+	})
+
 	t.Run("delete all from group", func(t *testing.T) {
 		t.Parallel()
 

--- a/pkg/storage/secret/metadata/decrypt_store_test.go
+++ b/pkg/storage/secret/metadata/decrypt_store_test.go
@@ -420,6 +420,57 @@ func TestIntegrationDecrypt(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, "value", exposed.DangerouslyExposeAndConsumeValue())
 	})
+
+	t.Run("happy path, inline secure value uses the system keeper and can be decrypted even when a 3rd party keeper is active", func(t *testing.T) {
+		t.Parallel()
+
+		ctx, cancel := context.WithCancel(context.Background())
+		t.Cleanup(cancel)
+
+		svcIdentity := "svc"
+		authCtx := createAuthContext(ctx, "default", []string{"secret.grafana.app/securevalues:decrypt"}, svcIdentity, types.TypeUser)
+
+		sut := testutils.Setup(t)
+
+		// Activate a 3rd party keeper
+		keeper, err := sut.KeeperMetadataStorage.Create(t.Context(), &secretv1beta1.Keeper{
+			ObjectMeta: v1.ObjectMeta{
+				Namespace: "default",
+				Name:      "k1",
+			},
+			Spec: secretv1beta1.KeeperSpec{
+				Aws: &secretv1beta1.KeeperAWSConfig{},
+			},
+		}, "actor-uid")
+		require.NoError(t, err)
+		require.NoError(t, sut.KeeperMetadataStorage.SetAsActive(t.Context(), xkube.Namespace(keeper.Namespace), keeper.Name))
+
+		// Inline secure values are identified by having OwnerReferences
+		sv := &secretv1beta1.SecureValue{
+			ObjectMeta: v1.ObjectMeta{
+				Namespace: "default",
+				Name:      "sv-inline",
+				OwnerReferences: []v1.OwnerReference{{
+					APIVersion: "prometheus.datasource.grafana.app/v0alpha1",
+					Kind:       "DataSource",
+					Name:       "test-ds",
+				}},
+			},
+			Spec: secretv1beta1.SecureValueSpec{
+				Description: "description",
+				Decrypters:  []string{svcIdentity},
+				Value:       ptr.To(secretv1beta1.NewExposedSecureValue("inline-value")),
+			},
+		}
+		created, err := sut.CreateSv(authCtx, testutils.CreateSvWithSv(sv))
+		require.NoError(t, err)
+		require.Equal(t, contracts.SystemKeeperName, created.Status.Keeper)
+
+		// Can still decrypt it
+		exposed, err := sut.DecryptStorage.Decrypt(authCtx, "default", "sv-inline")
+		require.NoError(t, err)
+		require.Equal(t, "inline-value", exposed.DangerouslyExposeAndConsumeValue())
+	})
 }
 
 func createAuthContext(ctx context.Context, namespace string, permissions []string, svc string, identityType types.IdentityType) context.Context {


### PR DESCRIPTION
**What is this feature?**

Inline secure values should not be created on 3rdparty keepers, and must only be created using the `system` keeper, as they are not meant to be shared or mutated by users.

**Why do we need this feature?**

Tighten restrictions around inline secure value creation.

**Who is this feature for?**

Operators, users of Secrets with 3rdparty Keepers

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
