### PR TITLE
Provisioning: Fix flaky folder-count assertion in quota sync test

### DIFF
--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -1007,6 +1007,31 @@ func (h *ProvisioningTestHelper) RequireRepoDashboardCount(t *testing.T, repoNam
 		"expected %d dashboard(s) managed by repo %s", expectedCount, repoName)
 }
 
+// RequireRepoFolderCount polls the folders list until the number of folders
+// managed by the given repo matches the expected count, or the default wait
+// timeout elapses. Like the dashboard variant, this avoids races where the
+// sync job has completed but the folders-list API has not yet observed the
+// newly-created folders or their grafana.app/managerId annotation.
+func (h *ProvisioningTestHelper) RequireRepoFolderCount(t *testing.T, repoName string, expectedCount int) {
+	t.Helper()
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		folders, err := h.Folders.Resource.List(t.Context(), metav1.ListOptions{})
+		if !assert.NoError(c, err, "failed to list folders") {
+			return
+		}
+
+		var count int
+		for _, f := range folders.Items {
+			managerID, _, _ := unstructured.NestedString(f.Object, "metadata", "annotations", "grafana.app/managerId")
+			if managerID == repoName {
+				count++
+			}
+		}
+		assert.Equal(c, expectedCount, count, "unexpected number of folders managed by repo %s", repoName)
+	}, WaitTimeoutDefault, WaitIntervalDefault,
+		"expected %d folder(s) managed by repo %s", expectedCount, repoName)
+}
+
 // TriggerConnectionReconciliation forces the controller to re-process a connection
 // by touching its status (aging the health timestamp by 1ms). A merge patch on the
 // status subresource carries no resourceVersion, so it never conflicts with

--- a/pkg/tests/apis/provisioning/quota/sync_quota_test.go
+++ b/pkg/tests/apis/provisioning/quota/sync_quota_test.go
@@ -280,7 +280,7 @@ func TestIntegrationProvisioning_SyncQuotaHandling(t *testing.T) {
 		helper.RequireRepoDashboardCount(t, repo, 2)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonWithinQuota)
 
-		// Verify we have 3 folders (root + subfolder + subfolder/nested)
+		// Should have 3 folders: root + subfolder + subfolder/nested
 		helper.RequireRepoFolderCount(t, repo, 3)
 
 		// Step 2: Add 2 dashboards in new subfolders (each creates a folder + a dashboard).
@@ -353,7 +353,7 @@ func TestIntegrationProvisioning_SyncQuotaHandling(t *testing.T) {
 				"should still have only 2 dashboards: both new dashboards were skipped due to quota")
 		}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
 
-		// Verify 1 new folder was created and 1 was skipped (4 total managed folders)
+		// Should have 4 folders: root + subfolder + subfolder/nested + 1 new (the other was skipped)
 		helper.RequireRepoFolderCount(t, repo, 4)
 
 		// Step 6: Verify the repo is now at quota (4 folders + 2 dashboards = 6/6)

--- a/pkg/tests/apis/provisioning/quota/sync_quota_test.go
+++ b/pkg/tests/apis/provisioning/quota/sync_quota_test.go
@@ -281,21 +281,12 @@ func TestIntegrationProvisioning_SyncQuotaHandling(t *testing.T) {
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonWithinQuota)
 
 		// Verify we have 3 folders (root + subfolder + subfolder/nested)
-		folders, err := helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
-		require.NoError(t, err)
-		var managedFolderCount int
-		for _, f := range folders.Items {
-			managerID, _, _ := unstructured.NestedString(f.Object, "metadata", "annotations", "grafana.app/managerId")
-			if managerID == repo {
-				managedFolderCount++
-			}
-		}
-		require.Equal(t, 3, managedFolderCount, "should have 3 folders: root + subfolder + subfolder/nested")
+		helper.RequireRepoFolderCount(t, repo, 3)
 
 		// Step 2: Add 2 dashboards in new subfolders (each creates a folder + a dashboard).
 		// This would bring total to 9 (5 existing + 2 folders + 2 dashboards), exceeding limit of 6.
 		newDash1Content := helper.LoadFile("../testdata/timeline-demo.json")
-		err = os.MkdirAll(filepath.Join(repoPath, "new_a"), 0o750)
+		err := os.MkdirAll(filepath.Join(repoPath, "new_a"), 0o750)
 		require.NoError(t, err)
 		err = os.WriteFile(filepath.Join(repoPath, "new_a", "dashboard_new1.json"), newDash1Content, 0o600)
 		require.NoError(t, err, "should be able to write new_a/dashboard_new1.json")
@@ -363,17 +354,7 @@ func TestIntegrationProvisioning_SyncQuotaHandling(t *testing.T) {
 		}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
 
 		// Verify 1 new folder was created and 1 was skipped (4 total managed folders)
-		folders, err = helper.Folders.Resource.List(t.Context(), metav1.ListOptions{})
-		require.NoError(t, err)
-		managedFolderCount = 0
-		for _, f := range folders.Items {
-			managerID, _, _ := unstructured.NestedString(f.Object, "metadata", "annotations", "grafana.app/managerId")
-			if managerID == repo {
-				managedFolderCount++
-			}
-		}
-		require.Equal(t, 4, managedFolderCount,
-			"should have 4 folders: root + subfolder + subfolder/nested + 1 new (the other was skipped)")
+		helper.RequireRepoFolderCount(t, repo, 4)
 
 		// Step 6: Verify the repo is now at quota (4 folders + 2 dashboards = 6/6)
 		helper.WaitForQuotaReconciliation(t, repo, provisioning.ReasonQuotaReached)


### PR DESCRIPTION
## Summary

Fixes a flake in `TestIntegrationProvisioning_SyncQuotaHandling/full_sync_with_nested_folders_counts_folders_toward_quota_and_skips_resources` (seen on the SQLite Enterprise integration test shard, e.g. [job 73491557512](https://github.com/grafana/grafana/actions/runs/25082796677/job/73491557512)).

The test listed folders once via `helper.Folders.Resource.List(...)` right after `SyncAndWait` and counted those whose `grafana.app/managerId` matched the repo. `SyncAndWait` only waits for the sync **job** resource to complete; the folders-list API can lag behind, occasionally returning 0 managed folders and producing:

```
sync_quota_test.go:293
    Error:      Not equal:
                expected: 3
                actual  : 0
    Messages:   should have 3 folders: root + subfolder + subfolder/nested
```

## Changes

- Add `(*ProvisioningTestHelper).RequireRepoFolderCount` — the folder-side mirror of `RequireRepoDashboardCount` (the same race was fixed for dashboards in #123362). It polls `Folders.List` with `EventuallyWithT` until the manager-id-filtered count matches.
- Replace both direct list-and-count blocks in `sync_quota_test.go` (the failing assertion at line 293, and the analogous one later in the same subtest) with `helper.RequireRepoFolderCount`. Removes ~22 lines of duplicated logic.

## Testing

- `go build ./pkg/tests/apis/provisioning/...` ✅
- `go vet ./pkg/tests/apis/provisioning/quota/...` ✅
- `go test -tags=integration -c ./pkg/tests/apis/provisioning/quota/` ✅
- The integration test itself runs in CI (it requires the full Grafana test harness).

## Checklist

- [x] Tests updated
- [x] No new tests needed — this is a flake fix that brings the assertion in line with the existing eventual-consistency pattern used for dashboards
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)