### PR TITLE
Provisioning: Retry SQLITE_BUSY on repository status patch

### DIFF
--- a/apps/provisioning/pkg/controller/status.go
+++ b/apps/provisioning/pkg/controller/status.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	client "github.com/grafana/grafana/apps/provisioning/pkg/generated/clientset/versioned/typed/provisioning/v0alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
@@ -22,17 +24,32 @@ func NewRepositoryStatusPatcher(client client.ProvisioningV0alpha1Interface) *Re
 	}
 }
 
+// isRetriablePatchError returns true for transient errors that should be retried
+// when patching a repository status subresource. We retry K8s optimistic-concurrency
+// conflicts (the apiserver translates JSON Patch into read-modify-write keyed on RV)
+// and SQLite write contention surfaced from the unified storage backend.
+func isRetriablePatchError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if apierrors.IsConflict(err) {
+		return true
+	}
+	// SQLite serializes writes; lock contention surfaces as an InternalError (500)
+	// whose message carries the raw "database is locked"/"SQLITE_BUSY" text from
+	// the unified storage layer. The PRAGMA busy_timeout already absorbs short
+	// waits, so anything that bubbles up here is rare and safe to retry.
+	msg := err.Error()
+	return strings.Contains(msg, "SQLITE_BUSY") || strings.Contains(msg, "database is locked")
+}
+
 func (r *RepositoryStatusPatcher) Patch(ctx context.Context, repo *provisioning.Repository, patchOperations ...map[string]interface{}) error {
 	patch, err := json.Marshal(patchOperations)
 	if err != nil {
 		return fmt.Errorf("unable to marshal patch data: %w", err)
 	}
 
-	// Retry on optimistic-concurrency conflicts from the unified storage
-	// layer ("requested RV does not match current RV"). The apiserver
-	// translates a JSON Patch into a read-modify-write with the just-read
-	// RV as PreviousRV, so concurrent status updates race with this call.
-	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+	err = retry.OnError(retry.DefaultRetry, isRetriablePatchError, func() error {
 		_, err := r.client.Repositories(repo.Namespace).
 			Patch(ctx, repo.Name, types.JSONPatchType, patch, metav1.PatchOptions{}, "status")
 		return err

--- a/apps/provisioning/pkg/controller/status_test.go
+++ b/apps/provisioning/pkg/controller/status_test.go
@@ -190,4 +190,27 @@ func TestRepositoryStatusPatcher_Patch_RetriesOnConflict(t *testing.T) {
 		require.Error(t, err)
 		require.Equal(t, int32(1), atomic.LoadInt32(&calls), "non-conflict errors should not be retried")
 	})
+
+	t.Run("transient SQLITE_BUSY is retried and succeeds", func(t *testing.T) {
+		var calls int32
+		c := fake.FakeProvisioningV0alpha1{Fake: &k8testing.Fake{}}
+		c.AddReactor("patch", "repositories", func(action k8testing.Action) (bool, runtime.Object, error) {
+			n := atomic.AddInt32(&calls, 1)
+			if n == 1 {
+				// Mimics the wrapped error returned by the unified storage SQL
+				// backend when SQLite write contention bubbles up through the
+				// apiserver as an internal error.
+				return true, nil, apierrors.NewInternalError(fmt.Errorf(
+					"transactional operation: resource update: resource_update.sql: " +
+						"Exec with 10 input arguments and 0 output destination arguments: " +
+						"database is locked (5) (SQLITE_BUSY); query: UPDATE \"resource\" SET ...",
+				))
+			}
+			return true, &provisioning.Repository{}, nil
+		})
+
+		err := NewRepositoryStatusPatcher(&c).Patch(context.Background(), repo, ops...)
+		require.NoError(t, err)
+		require.Equal(t, int32(2), atomic.LoadInt32(&calls), "patch should retry once after SQLITE_BUSY")
+	})
 }


### PR DESCRIPTION
## Summary

`RepositoryStatusPatcher.Patch` (`apps/provisioning/pkg/controller/status.go`) only retried K8s optimistic-concurrency conflicts via `retry.RetryOnConflict`. When the unified-storage SQL backend bubbles a transient `SQLITE_BUSY` through the apiserver as a 500 `InternalError` carrying the raw `database is locked`/`SQLITE_BUSY` text, the patch failed without retry, surfacing as a test flake.

Observed failure (CI run [25077824160](https://github.com/grafana/grafana/actions/runs/25077824160/job/73475086349)):

```
--- FAIL: TestIntegrationProvisioning_FullSync_FolderMetadataTitle/folder_uses_directory_name_when_no__folder.json_exists
unable to update repo with job status: transactional operation: resource update: resource_update.sql:
Exec with 10 input arguments and 0 output destination arguments:
database is locked (5) (SQLITE_BUSY); query: UPDATE "resource" SET ...
```

The chain: test POSTs a sync job → `pkg/registry/apis/provisioning/jobs.go:198` synchronously calls `RepositoryStatusPatcher.Patch` → SQLite write contention surfaces as 500 InternalError → no retry → test fails.

## Changes

- Replace `retry.RetryOnConflict` with `retry.OnError` + `isRetriablePatchError` predicate that retries both K8s conflicts and `SQLITE_BUSY` / `database is locked` errors. SQLite serializes writes; lock contention is genuinely transient, the status patch is idempotent, and the SQLite `PRAGMA busy_timeout` already absorbs short waits — what bubbles up here is rare and safe to retry.
- Add unit test covering the new SQLITE_BUSY retry path; existing conflict / non-retry tests unchanged.

## Test plan

- [x] `go test -count=1 ./apps/provisioning/pkg/controller/...` — passes
- [x] `go vet ./apps/provisioning/pkg/controller/...` — clean
- [ ] Sqlite Enterprise integration shard re-runs cleanly

## Notes

Targeted scope: this only affects `RepositoryStatusPatcher`. A broader retry on SQLITE_BUSY at the unified-storage SQL backend is a separate, larger change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)