### PR TITLE
Search: add snapshot lifecycle observability

### DIFF
--- a/pkg/storage/unified/search/bleve_snapshot.go
+++ b/pkg/storage/unified/search/bleve_snapshot.go
@@ -12,6 +12,8 @@ import (
 	"github.com/Masterminds/semver"
 	"github.com/blevesearch/bleve/v2"
 	"github.com/oklog/ulid/v2"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
@@ -49,17 +51,53 @@ func (b *bleveBackend) tryDownloadRemoteSnapshot(
 	key resource.NamespacedResource,
 	resourceDir string,
 	logger log.Logger,
-) (bleve.Index, string, int64, error) {
+) (_ bleve.Index, _ string, _ int64, retErr error) {
+	ctx, span := tracer.Start(ctx, "search.remote_index_snapshot.download")
+	start := time.Now()
+	outcome := snapshotStatusSuccess
+	var candidate snapshotCandidate
+
+	defer func() {
+		attrs := []attribute.KeyValue{
+			attribute.String("namespace", key.Namespace),
+			attribute.String("group", key.Group),
+			attribute.String("resource", key.Resource),
+			attribute.String("outcome", outcome),
+		}
+		if candidate.key != (ulid.ULID{}) {
+			attrs = append(attrs,
+				attribute.String("snapshot_key", candidate.key.String()),
+				attribute.String("snapshot_version", candidate.version.String()),
+				attribute.Int64("snapshot_rv", candidate.meta.LatestResourceVersion),
+				attribute.Int("snapshot_tier", candidate.tier),
+			)
+		}
+		span.SetAttributes(attrs...)
+		elapsed := time.Since(start)
+		if retErr != nil {
+			span.RecordError(retErr)
+			span.SetStatus(codes.Error, retErr.Error())
+			logger.Warn("Remote index snapshot download failed", "elapsed", elapsed, "outcome", outcome, "err", retErr)
+		} else {
+			logger.Info("Remote index snapshot download completed", "elapsed", elapsed, "outcome", outcome)
+		}
+		span.End()
+	}()
+
+	logger.Info("Remote index snapshot download started")
 	store := b.opts.Snapshot.Store
 
 	all, err := store.ListIndexes(ctx, key)
 	if err != nil {
+		outcome = snapshotStatusDownloadError
 		b.recordSnapshotDownloadStatus(snapshotStatusDownloadError)
 		return nil, "", 0, fmt.Errorf("listing remote snapshots: %w", err)
 	}
 
-	candidate, ok := b.pickBestSnapshot(all, time.Now())
+	var ok bool
+	candidate, ok = b.pickBestSnapshot(all, time.Now())
 	if !ok {
+		outcome = snapshotStatusEmpty
 		b.recordSnapshotDownloadStatus(snapshotStatusEmpty)
 		return nil, "", 0, nil
 	}
@@ -77,11 +115,11 @@ func (b *bleveBackend) tryDownloadRemoteSnapshot(
 	// when creating new file-based indexes.
 	destDir, name, err := b.reserveSnapshotDir(resourceDir)
 	if err != nil {
+		outcome = snapshotStatusDownloadError
 		b.recordSnapshotDownloadStatus(snapshotStatusDownloadError)
 		return nil, "", 0, fmt.Errorf("reserving local snapshot dir: %w", err)
 	}
 
-	start := time.Now()
 	// TODO: retry DownloadIndex on transient errors before falling through to a
 	// from-scratch KV rebuild. The object store is its own fault domain;
 	// a single failed download shouldn't force a full rebuild for large
@@ -89,6 +127,7 @@ func (b *bleveBackend) tryDownloadRemoteSnapshot(
 	downloadedMeta, err := store.DownloadIndex(ctx, key, candidate.key, destDir)
 	if err != nil {
 		_ = os.RemoveAll(destDir)
+		outcome = snapshotStatusDownloadError
 		b.recordSnapshotDownloadStatus(snapshotStatusDownloadError)
 		return nil, "", 0, fmt.Errorf("downloading snapshot: %w", err)
 	}
@@ -96,6 +135,7 @@ func (b *bleveBackend) tryDownloadRemoteSnapshot(
 	idx, err := bleve.OpenUsing(destDir, map[string]interface{}{"bolt_timeout": boltTimeout})
 	if err != nil {
 		_ = os.RemoveAll(destDir)
+		outcome = snapshotStatusValidateError
 		b.recordSnapshotDownloadStatus(snapshotStatusValidateError)
 		return nil, "", 0, fmt.Errorf("opening downloaded snapshot: %w", err)
 	}
@@ -104,6 +144,7 @@ func (b *bleveBackend) tryDownloadRemoteSnapshot(
 	if err != nil {
 		_ = idx.Close()
 		_ = os.RemoveAll(destDir)
+		outcome = snapshotStatusValidateError
 		b.recordSnapshotDownloadStatus(snapshotStatusValidateError)
 		return nil, "", 0, fmt.Errorf("validating downloaded snapshot: %w", err)
 	}
@@ -122,12 +163,12 @@ func (b *bleveBackend) tryDownloadRemoteSnapshot(
 	if err := writeSnapshotMutationCount(idx, 0); err != nil {
 		_ = idx.Close()
 		_ = os.RemoveAll(destDir)
+		outcome = snapshotStatusValidateError
 		b.recordSnapshotDownloadStatus(snapshotStatusValidateError)
 		return nil, "", 0, fmt.Errorf("resetting snapshot mutation count: %w", err)
 	}
 	b.setUploadTracking(key, uploadedAt)
 
-	logger.Info("Downloaded remote index snapshot", "elapsed", elapsed, "rv", rv, "directory", destDir)
 	return idx, name, rv, nil
 }
 

--- a/pkg/storage/unified/search/bleve_snapshot_observability_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_observability_test.go
@@ -1,0 +1,119 @@
+package search
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	tracesdk "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"gocloud.dev/blob/memblob"
+)
+
+func setupSnapshotSpanRecorder(t *testing.T) *tracetest.SpanRecorder {
+	t.Helper()
+	recorder := tracetest.NewSpanRecorder()
+	provider := tracesdk.NewTracerProvider(tracesdk.WithSpanProcessor(recorder))
+	previous := otel.GetTracerProvider()
+	previousTracer := tracer
+	otel.SetTracerProvider(provider)
+	tracer = otel.Tracer("github.com/grafana/grafana/pkg/storage/unified/search")
+	t.Cleanup(func() {
+		tracer = previousTracer
+		otel.SetTracerProvider(previous)
+		require.NoError(t, provider.Shutdown(context.Background()))
+	})
+	return recorder
+}
+
+func assertSpanNames(t *testing.T, recorder *tracetest.SpanRecorder, expected ...string) {
+	t.Helper()
+	seen := map[string]bool{}
+	for _, span := range recorder.Ended() {
+		seen[span.Name()] = true
+	}
+	for _, name := range expected {
+		assert.True(t, seen[name], "expected span %q; got %v", name, seen)
+	}
+}
+
+func assertSpanEvents(t *testing.T, recorder *tracetest.SpanRecorder, spanName string, expected ...string) {
+	t.Helper()
+	for _, span := range recorder.Ended() {
+		if span.Name() != spanName {
+			continue
+		}
+		seen := map[string]bool{}
+		for _, event := range span.Events() {
+			seen[event.Name] = true
+		}
+		for _, name := range expected {
+			assert.True(t, seen[name], "expected event %q on span %q; got %v", name, spanName, seen)
+		}
+		return
+	}
+	require.Failf(t, "span not found", "expected span %q", spanName)
+}
+
+func TestSnapshotDownloadEmitsSpan(t *testing.T) {
+	recorder := setupSnapshotSpanRecorder(t)
+
+	store := &fakeRemoteIndexStore{}
+	store.put(makeULID(t, time.Now()), &IndexMeta{
+		GrafanaBuildVersion:   "11.5.0",
+		LatestResourceVersion: 42,
+		UploadTimestamp:       time.Now(),
+	})
+	dt := newDownloadTest(t, store)
+
+	_, _, err := dt.run(t)
+	require.NoError(t, err)
+
+	assertSpanNames(t, recorder, "search.remote_index_snapshot.download")
+}
+
+func TestSnapshotUploadEmitsSpanAndLockEvents(t *testing.T) {
+	recorder := setupSnapshotSpanRecorder(t)
+
+	store := &uploadTestStore{}
+	be, _ := newTestBleveBackend(t, SnapshotOptions{Store: store})
+	key := newTestNsResource()
+	idx := newUploadTestIndex(t, be, key, 42)
+
+	require.NoError(t, be.uploadSnapshot(t.Context(), key, idx))
+
+	assertSpanNames(t, recorder, "search.remote_index_snapshot.upload")
+	assertSpanEvents(t, recorder, "search.remote_index_snapshot.upload",
+		"snapshot.lock.acquire.started",
+		"snapshot.lock.acquire.completed",
+		"snapshot.lock.release.started",
+		"snapshot.lock.release.completed",
+	)
+}
+
+func TestSnapshotCleanupEmitsSpanAndLockEvents(t *testing.T) {
+	recorder := setupSnapshotSpanRecorder(t)
+
+	ctx := t.Context()
+	bucket := memblob.OpenBucket(nil)
+	t.Cleanup(func() { _ = bucket.Close() })
+	store := newTestRemoteIndexStore(t, bucket)
+	ns := newTestNsResource()
+	now := time.Now()
+	seedSnapshot(t, ctx, bucket, ns, makeULID(t, now.Add(-3*time.Hour)), mkMeta("11.5.0", 100, now.Add(-3*time.Hour)))
+	seedSnapshot(t, ctx, bucket, ns, makeULID(t, now.Add(-2*time.Hour)), mkMeta("11.5.0", 200, now.Add(-2*time.Hour)))
+
+	be, _ := newCleanupTestBackend(t, store, nil)
+	be.runCleanup(ctx)
+
+	assertSpanNames(t, recorder, "search.remote_index_snapshot.cleanup")
+	assertSpanEvents(t, recorder, "search.remote_index_snapshot.cleanup",
+		"snapshot.lock.acquire.started",
+		"snapshot.lock.acquire.completed",
+		"snapshot.lock.release.started",
+		"snapshot.lock.release.completed",
+	)
+}

--- a/pkg/storage/unified/search/bleve_snapshot_observability_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_observability_test.go
@@ -109,8 +109,11 @@ func TestSnapshotCleanupEmitsSpanAndLockEvents(t *testing.T) {
 	be, _ := newCleanupTestBackend(t, store, nil)
 	be.runCleanup(ctx)
 
-	assertSpanNames(t, recorder, "search.remote_index_snapshot.cleanup")
-	assertSpanEvents(t, recorder, "search.remote_index_snapshot.cleanup",
+	assertSpanNames(t, recorder,
+		"search.remote_index_snapshot.cleanup",
+		"search.remote_index_snapshot.namespace_cleanup",
+	)
+	assertSpanEvents(t, recorder, "search.remote_index_snapshot.namespace_cleanup",
 		"snapshot.lock.acquire.started",
 		"snapshot.lock.acquire.completed",
 		"snapshot.lock.release.started",

--- a/pkg/storage/unified/search/bleve_snapshot_upload.go
+++ b/pkg/storage/unified/search/bleve_snapshot_upload.go
@@ -2,32 +2,79 @@ package search
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"time"
 
 	"github.com/blevesearch/bleve/v2"
+	"github.com/oklog/ulid/v2"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	oteltrace "go.opentelemetry.io/otel/trace"
 
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 )
 
 func (b *bleveBackend) uploadSnapshot(ctx context.Context, key resource.NamespacedResource, idx *bleveIndex) (retErr error) {
+	ctx, span := tracer.Start(ctx, "search.remote_index_snapshot.upload")
+	start := time.Now()
+	logger := b.log.New("namespace", key.Namespace, "group", key.Group, "resource", key.Resource)
+	var rv int64
+	var uploadKey ulid.ULID
+
+	defer func() {
+		outcome := "success"
+		if retErr != nil {
+			outcome = "error"
+		}
+		attrs := []attribute.KeyValue{
+			attribute.String("namespace", key.Namespace),
+			attribute.String("group", key.Group),
+			attribute.String("resource", key.Resource),
+			attribute.String("outcome", outcome),
+		}
+		if rv > 0 {
+			attrs = append(attrs, attribute.Int64("snapshot_rv", rv))
+		}
+		if uploadKey != (ulid.ULID{}) {
+			attrs = append(attrs, attribute.String("snapshot_key", uploadKey.String()))
+		}
+		if retErr != nil {
+			span.RecordError(retErr)
+			span.SetStatus(codes.Error, retErr.Error())
+			logger.Warn("Remote index snapshot upload failed", "elapsed", time.Since(start), "err", retErr)
+		} else {
+			logger.Info("Remote index snapshot upload completed", "elapsed", time.Since(start), "snapshot_key", uploadKey.String(), "snapshot_rv", rv)
+		}
+		span.SetAttributes(attrs...)
+		span.End()
+	}()
+
+	logger.Info("Remote index snapshot upload started")
+
+	lockAttrs := []attribute.KeyValue{
+		attribute.String("lock_scope", "build"),
+		attribute.String("namespace", key.Namespace),
+		attribute.String("group", key.Group),
+		attribute.String("resource", key.Resource),
+	}
+	span.AddEvent("snapshot.lock.acquire.started", oteltrace.WithAttributes(lockAttrs...))
 	lock, err := b.opts.Snapshot.Store.LockBuildIndex(ctx, key)
 	if err != nil {
+		span.AddEvent("snapshot.lock.acquire.failed", oteltrace.WithAttributes(lockAttrs...))
 		return fmt.Errorf("acquiring snapshot upload lock: %w", err)
 	}
+	span.AddEvent("snapshot.lock.acquire.completed", oteltrace.WithAttributes(lockAttrs...))
+
 	defer func() {
-		releaseErr := lock.Release()
-		if releaseErr == nil {
+		span.AddEvent("snapshot.lock.release.started", oteltrace.WithAttributes(lockAttrs...))
+		if releaseErr := lock.Release(); releaseErr != nil {
+			span.AddEvent("snapshot.lock.release.failed", oteltrace.WithAttributes(lockAttrs...))
+			logger.Warn("releasing snapshot upload lock", "err", releaseErr)
 			return
 		}
-		if retErr == nil {
-			retErr = fmt.Errorf("releasing snapshot upload lock: %w", releaseErr)
-			return
-		}
-		retErr = errors.Join(retErr, fmt.Errorf("releasing snapshot upload lock: %w", releaseErr))
+		span.AddEvent("snapshot.lock.release.completed", oteltrace.WithAttributes(lockAttrs...))
 	}()
 
 	stagingDir, err := b.newSnapshotStagingDir(key)
@@ -36,7 +83,6 @@ func (b *bleveBackend) uploadSnapshot(ctx context.Context, key resource.Namespac
 	}
 	defer func() { _ = os.RemoveAll(stagingDir) }()
 
-	start := time.Now()
 	if err := b.snapshotIndex(idx.index, stagingDir); err != nil {
 		return err
 	}
@@ -56,31 +102,26 @@ func (b *bleveBackend) uploadSnapshot(ctx context.Context, key resource.Namespac
 		return fmt.Errorf("opening staged snapshot: %w", err)
 	}
 
-	rv, rvErr := getRV(snapshotIdx)
+	rv, err = getRV(snapshotIdx)
 	bi, biErr := getBuildInfo(snapshotIdx)
 	if closeErr := snapshotIdx.Close(); closeErr != nil {
 		return fmt.Errorf("closing staged snapshot: %w", closeErr)
 	}
-	if rvErr != nil {
-		return fmt.Errorf("reading snapshot rv: %w", rvErr)
+	if err != nil {
+		return fmt.Errorf("reading snapshot rv: %w", err)
 	}
 	if biErr != nil {
 		return fmt.Errorf("reading snapshot build info: %w", biErr)
 	}
 
-	_, err = b.opts.Snapshot.Store.UploadIndex(ctx, key, stagingDir, IndexMeta{
+	uploadKey, err = b.opts.Snapshot.Store.UploadIndex(ctx, key, stagingDir, IndexMeta{
 		GrafanaBuildVersion:   bi.BuildVersion,
 		LatestResourceVersion: rv,
 	})
 	if err != nil {
 		return fmt.Errorf("uploading snapshot: %w", err)
 	}
-	if err := checkSnapshotLock(lock); err != nil {
-		return err
-	}
 
-	elapsed := time.Since(start)
-	b.log.Info("Uploaded remote index snapshot", "key", key, "elapsed", elapsed, "rv", rv)
 	return nil
 }
 

--- a/pkg/storage/unified/search/bleve_snapshot_upload.go
+++ b/pkg/storage/unified/search/bleve_snapshot_upload.go
@@ -20,6 +20,11 @@ func (b *bleveBackend) uploadSnapshot(ctx context.Context, key resource.Namespac
 	ctx, span := tracer.Start(ctx, "search.remote_index_snapshot.upload")
 	start := time.Now()
 	logger := b.log.New("namespace", key.Namespace, "group", key.Group, "resource", key.Resource)
+	commonSpanAttrs := []attribute.KeyValue{
+		attribute.String("namespace", key.Namespace),
+		attribute.String("group", key.Group),
+		attribute.String("resource", key.Resource),
+	}
 	var rv int64
 	var uploadKey ulid.ULID
 
@@ -28,12 +33,8 @@ func (b *bleveBackend) uploadSnapshot(ctx context.Context, key resource.Namespac
 		if retErr != nil {
 			outcome = "error"
 		}
-		attrs := []attribute.KeyValue{
-			attribute.String("namespace", key.Namespace),
-			attribute.String("group", key.Group),
-			attribute.String("resource", key.Resource),
-			attribute.String("outcome", outcome),
-		}
+		attrs := append([]attribute.KeyValue{}, commonSpanAttrs...)
+		attrs = append(attrs, attribute.String("outcome", outcome))
 		if rv > 0 {
 			attrs = append(attrs, attribute.Int64("snapshot_rv", rv))
 		}
@@ -53,12 +54,7 @@ func (b *bleveBackend) uploadSnapshot(ctx context.Context, key resource.Namespac
 
 	logger.Info("Remote index snapshot upload started")
 
-	lockAttrs := []attribute.KeyValue{
-		attribute.String("lock_scope", "build"),
-		attribute.String("namespace", key.Namespace),
-		attribute.String("group", key.Group),
-		attribute.String("resource", key.Resource),
-	}
+	lockAttrs := append([]attribute.KeyValue{attribute.String("lock_scope", "build")}, commonSpanAttrs...)
 	span.AddEvent("snapshot.lock.acquire.started", oteltrace.WithAttributes(lockAttrs...))
 	lock, err := b.opts.Snapshot.Store.LockBuildIndex(ctx, key)
 	if err != nil {
@@ -71,6 +67,7 @@ func (b *bleveBackend) uploadSnapshot(ctx context.Context, key resource.Namespac
 		span.AddEvent("snapshot.lock.release.started", oteltrace.WithAttributes(lockAttrs...))
 		if releaseErr := lock.Release(); releaseErr != nil {
 			span.AddEvent("snapshot.lock.release.failed", oteltrace.WithAttributes(lockAttrs...))
+			// A release failure after UploadIndex succeeds does not make the uploaded snapshot invalid.
 			logger.Warn("releasing snapshot upload lock", "err", releaseErr)
 			return
 		}

--- a/pkg/storage/unified/search/remote_index_cleanup.go
+++ b/pkg/storage/unified/search/remote_index_cleanup.go
@@ -19,14 +19,15 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 )
 
-// snapshotNamespaceCleanupStatus labels for the
-// index_server_snapshot_namespace_cleanups_total counter. One increment per
-// (namespace, outcome) tuple per cleanup pass.
+// snapshotNamespaceCleanupStatus values are used for namespace cleanup logs,
+// spans, and the index_server_snapshot_namespace_cleanups_total counter.
+// Canceled is intentionally not recorded in the counter because it usually means shutdown.
 const (
 	snapshotNamespaceCleanupStatusSuccess      = "success"
 	snapshotNamespaceCleanupStatusError        = "error"
 	snapshotNamespaceCleanupStatusSkipLockHeld = "skip_lock_held"
 	snapshotNamespaceCleanupStatusSkipUnowned  = "skip_unowned"
+	snapshotNamespaceCleanupStatusCanceled     = "canceled"
 )
 
 // snapshotDeleteOutcome labels for the index_server_snapshot_deleted_total
@@ -111,35 +112,23 @@ func (b *bleveBackend) runCleanup(ctx context.Context) {
 	hadNamespaceError := false
 	for _, ns := range namespaces {
 		if ctx.Err() != nil {
-			span.SetAttributes(attribute.String("outcome", "canceled"))
+			span.SetAttributes(attribute.String("outcome", snapshotNamespaceCleanupStatusCanceled))
 			b.log.Info("Remote index snapshot cleanup completed",
 				"elapsed", time.Since(start),
-				"outcome", "canceled",
+				"outcome", snapshotNamespaceCleanupStatusCanceled,
 			)
 			return
 		}
 
-		nsLogger := b.log.New("namespace", ns)
-		nsLogger.Info("Remote index snapshot namespace cleanup started")
-		nsStart := time.Now()
-		outcome, err := b.runNamespaceCleanup(ctx, ns, nsLogger)
+		outcome, err := b.runNamespaceCleanup(ctx, ns)
 		// Cancellation usually means shutdown; keep it out of the namespace outcome metric.
-		if outcome != "canceled" {
+		if outcome != snapshotNamespaceCleanupStatusCanceled {
 			b.recordSnapshotNamespaceCleanupStatus(outcome)
 		}
 		if err != nil {
 			hadNamespaceError = true
-			nsLogger.Warn("Remote index snapshot namespace cleanup failed",
-				"elapsed", time.Since(nsStart),
-				"outcome", outcome,
-				"err", err,
-			)
 			continue
 		}
-		nsLogger.Info("Remote index snapshot namespace cleanup completed",
-			"elapsed", time.Since(nsStart),
-			"outcome", outcome,
-		)
 	}
 	if hadNamespaceError {
 		err := fmt.Errorf("one or more namespace cleanups failed")
@@ -159,8 +148,26 @@ func (b *bleveBackend) runCleanup(ctx context.Context) {
 // runNamespaceCleanup applies the retention rules to every resource under one
 // namespace. Errors in one namespace must not abort the rest of the cleanup
 // pass, so all error paths return without panicking.
-func (b *bleveBackend) runNamespaceCleanup(ctx context.Context, namespace string, nsLogger log.Logger) (string, error) {
+func (b *bleveBackend) runNamespaceCleanup(ctx context.Context, namespace string) (outcome string, retErr error) {
 	store := b.opts.Snapshot.Store
+	nsLogger := b.log.New("namespace", namespace)
+	ctx, span := tracer.Start(ctx, "search.remote_index_snapshot.namespace_cleanup",
+		oteltrace.WithAttributes(attribute.String("namespace", namespace)),
+	)
+	start := time.Now()
+
+	nsLogger.Info("Remote index snapshot namespace cleanup started")
+	defer func() {
+		span.SetAttributes(attribute.String("outcome", outcome))
+		if retErr != nil {
+			span.RecordError(retErr)
+			span.SetStatus(codes.Error, retErr.Error())
+			nsLogger.Warn("Remote index snapshot namespace cleanup failed", "elapsed", time.Since(start), "outcome", outcome, "err", retErr)
+		} else {
+			nsLogger.Info("Remote index snapshot namespace cleanup completed", "elapsed", time.Since(start), "outcome", outcome)
+		}
+		span.End()
+	}()
 
 	// Ownership is checked at namespace granularity. The production OwnsIndex
 	// implementation hashes on Namespace alone, so calling it with an empty
@@ -174,10 +181,8 @@ func (b *bleveBackend) runNamespaceCleanup(ctx context.Context, namespace string
 		return snapshotNamespaceCleanupStatusSkipUnowned, nil
 	}
 
-	span := oteltrace.SpanFromContext(ctx)
 	lockAttrs := []attribute.KeyValue{
 		attribute.String("lock_scope", "cleanup"),
-		attribute.String("namespace", namespace),
 	}
 	span.AddEvent("snapshot.lock.acquire.started", oteltrace.WithAttributes(lockAttrs...))
 	lock, err := store.LockNamespaceForCleanup(ctx, namespace)
@@ -259,7 +264,7 @@ func (b *bleveBackend) runNamespaceCleanup(ctx context.Context, namespace string
 		return snapshotNamespaceCleanupStatusError, errCleanupLockLost
 	}
 	if ctx.Err() != nil {
-		return "canceled", nil
+		return snapshotNamespaceCleanupStatusCanceled, nil
 	}
 	if len(resourceErrs) > 0 {
 		return snapshotNamespaceCleanupStatusError, fmt.Errorf("resource cleanup failed: %w", errors.Join(resourceErrs...))

--- a/pkg/storage/unified/search/remote_index_cleanup.go
+++ b/pkg/storage/unified/search/remote_index_cleanup.go
@@ -11,6 +11,9 @@ import (
 
 	"github.com/Masterminds/semver"
 	"github.com/oklog/ulid/v2"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	oteltrace "go.opentelemetry.io/otel/trace"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
@@ -84,32 +87,80 @@ func (b *bleveBackend) cleanupSnapshotsPeriodically(ctx context.Context) {
 // replicas sharing ownership are unlikely to contend on the same namespace's
 // cleanup lock at the same instant.
 func (b *bleveBackend) runCleanup(ctx context.Context) {
+	ctx, span := tracer.Start(ctx, "search.remote_index_snapshot.cleanup")
+	start := time.Now()
+	b.log.Info("Remote index snapshot cleanup started")
+	defer span.End()
+
 	store := b.opts.Snapshot.Store
 	namespaces, err := store.ListNamespaces(ctx)
 	if err != nil {
 		// We can't attribute this error to any single namespace, so it shows up
 		// as a single "error" cleanup. Logged at warn so operators see it.
 		b.recordSnapshotNamespaceCleanupStatus(snapshotNamespaceCleanupStatusError)
-		b.log.Warn("listing namespaces for snapshot cleanup", "err", err)
+		span.SetAttributes(attribute.String("outcome", snapshotNamespaceCleanupStatusError))
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		b.log.Warn("Remote index snapshot cleanup failed", "elapsed", time.Since(start), "err", err)
 		return
 	}
+	span.SetAttributes(attribute.Int("namespace_count", len(namespaces)))
 	rand.Shuffle(len(namespaces), func(i, j int) {
 		namespaces[i], namespaces[j] = namespaces[j], namespaces[i]
 	})
+	hadNamespaceError := false
 	for _, ns := range namespaces {
 		if ctx.Err() != nil {
+			span.SetAttributes(attribute.String("outcome", "canceled"))
+			b.log.Info("Remote index snapshot cleanup completed",
+				"elapsed", time.Since(start),
+				"outcome", "canceled",
+			)
 			return
 		}
-		b.runNamespaceCleanup(ctx, ns)
+
+		nsLogger := b.log.New("namespace", ns)
+		nsLogger.Info("Remote index snapshot namespace cleanup started")
+		nsStart := time.Now()
+		outcome, err := b.runNamespaceCleanup(ctx, ns, nsLogger)
+		// Cancellation usually means shutdown; keep it out of the namespace outcome metric.
+		if outcome != "canceled" {
+			b.recordSnapshotNamespaceCleanupStatus(outcome)
+		}
+		if err != nil {
+			hadNamespaceError = true
+			nsLogger.Warn("Remote index snapshot namespace cleanup failed",
+				"elapsed", time.Since(nsStart),
+				"outcome", outcome,
+				"err", err,
+			)
+			continue
+		}
+		nsLogger.Info("Remote index snapshot namespace cleanup completed",
+			"elapsed", time.Since(nsStart),
+			"outcome", outcome,
+		)
 	}
+	if hadNamespaceError {
+		err := fmt.Errorf("one or more namespace cleanups failed")
+		span.SetAttributes(attribute.String("outcome", snapshotNamespaceCleanupStatusError))
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		b.log.Warn("Remote index snapshot cleanup failed", "elapsed", time.Since(start), "err", err)
+		return
+	}
+	span.SetAttributes(attribute.String("outcome", snapshotNamespaceCleanupStatusSuccess))
+	b.log.Info("Remote index snapshot cleanup completed",
+		"elapsed", time.Since(start),
+		"outcome", snapshotNamespaceCleanupStatusSuccess,
+	)
 }
 
 // runNamespaceCleanup applies the retention rules to every resource under one
 // namespace. Errors in one namespace must not abort the rest of the cleanup
 // pass, so all error paths return without panicking.
-func (b *bleveBackend) runNamespaceCleanup(ctx context.Context, namespace string) {
+func (b *bleveBackend) runNamespaceCleanup(ctx context.Context, namespace string, nsLogger log.Logger) (string, error) {
 	store := b.opts.Snapshot.Store
-	logger := b.log.New("namespace", namespace)
 
 	// Ownership is checked at namespace granularity. The production OwnsIndex
 	// implementation hashes on Namespace alone, so calling it with an empty
@@ -117,25 +168,31 @@ func (b *bleveBackend) runNamespaceCleanup(ctx context.Context, namespace string
 	// trip the assertion in TestRunCleanup_OwnershipFilter_NamespaceLevel.
 	owned, err := b.ownsIndexFn(resource.NamespacedResource{Namespace: namespace})
 	if err != nil {
-		b.recordSnapshotNamespaceCleanupStatus(snapshotNamespaceCleanupStatusError)
-		logger.Warn("ownership check failed during cleanup", "err", err)
-		return
+		return snapshotNamespaceCleanupStatusError, fmt.Errorf("ownership check failed during cleanup: %w", err)
 	}
 	if !owned {
-		b.recordSnapshotNamespaceCleanupStatus(snapshotNamespaceCleanupStatusSkipUnowned)
-		return
+		return snapshotNamespaceCleanupStatusSkipUnowned, nil
 	}
 
+	span := oteltrace.SpanFromContext(ctx)
+	lockAttrs := []attribute.KeyValue{
+		attribute.String("lock_scope", "cleanup"),
+		attribute.String("namespace", namespace),
+	}
+	span.AddEvent("snapshot.lock.acquire.started", oteltrace.WithAttributes(lockAttrs...))
 	lock, err := store.LockNamespaceForCleanup(ctx, namespace)
 	if errors.Is(err, errLockHeld) {
-		b.recordSnapshotNamespaceCleanupStatus(snapshotNamespaceCleanupStatusSkipLockHeld)
-		return
+		span.AddEvent("snapshot.lock.acquire.skipped", oteltrace.WithAttributes(
+			append(lockAttrs, attribute.String("reason", "lock_held"))...,
+		))
+		return snapshotNamespaceCleanupStatusSkipLockHeld, nil
 	}
 	if err != nil {
-		b.recordSnapshotNamespaceCleanupStatus(snapshotNamespaceCleanupStatusError)
-		logger.Warn("acquiring cleanup lock", "err", err)
-		return
+		span.AddEvent("snapshot.lock.acquire.failed", oteltrace.WithAttributes(lockAttrs...))
+		return snapshotNamespaceCleanupStatusError, fmt.Errorf("acquiring cleanup lock: %w", err)
 	}
+	span.AddEvent("snapshot.lock.acquire.completed", oteltrace.WithAttributes(lockAttrs...))
+
 	// Tie a per-namespace context to the cleanup lock: if the lock is lost
 	// mid-run, cancel the context so any in-flight bucket operation
 	// (List/Delete) aborts immediately rather than waiting for the next
@@ -150,23 +207,27 @@ func (b *bleveBackend) runNamespaceCleanup(ctx context.Context, namespace string
 		case <-nsCtx.Done():
 		}
 	})
+
 	// Order matters: cancel + wait for the watcher first, so it can't fire
 	// against a stale lock; then release the lock.
 	defer func() {
 		cancelNs(nil)
 		watcher.Wait()
+		span.AddEvent("snapshot.lock.release.started", oteltrace.WithAttributes(lockAttrs...))
 		if releaseErr := lock.Release(); releaseErr != nil {
-			logger.Warn("releasing cleanup lock", "err", releaseErr)
+			span.AddEvent("snapshot.lock.release.failed", oteltrace.WithAttributes(lockAttrs...))
+			nsLogger.Warn("releasing cleanup lock", "err", releaseErr)
+			return
 		}
+		span.AddEvent("snapshot.lock.release.completed", oteltrace.WithAttributes(lockAttrs...))
 	}()
 
 	resources, err := store.ListNamespaceIndexes(nsCtx, namespace)
 	if err != nil {
-		b.recordSnapshotNamespaceCleanupStatus(snapshotNamespaceCleanupStatusError)
-		logger.Warn("listing namespace indexes", "err", err)
-		return
+		return snapshotNamespaceCleanupStatusError, fmt.Errorf("listing namespace indexes: %w", err)
 	}
-	// Resource order is randomised so a single misbehaving resource (panic,
+
+	// Resource order is randomized so a single misbehaving resource (panic,
 	// slow listing, lock loss before this point in the run) doesn't permanently
 	// starve the resources after it. Unlike namespace shuffling above, this is
 	// not about cross-replica contention — we hold the cleanup lock here, so no
@@ -175,7 +236,7 @@ func (b *bleveBackend) runNamespaceCleanup(ctx context.Context, namespace string
 		resources[i], resources[j] = resources[j], resources[i]
 	})
 
-	hadResourceError := false
+	var resourceErrs []error
 	for _, res := range resources {
 		// nsCtx covers both cancellation paths: lock loss (cause =
 		// errCleanupLockLost) and parent shutdown (parent ctx cancelled,
@@ -183,30 +244,27 @@ func (b *bleveBackend) runNamespaceCleanup(ctx context.Context, namespace string
 		if nsCtx.Err() != nil {
 			break
 		}
-		if err := b.runResourceCleanup(nsCtx, res, logger); err != nil {
+		if err := b.runResourceCleanup(nsCtx, res, nsLogger); err != nil {
 			if errors.Is(err, context.Canceled) {
 				// Cancellation propagated from lock loss or parent shutdown;
 				// not a resource-level failure.
 				break
 			}
-			hadResourceError = true
-			logger.Warn("resource cleanup failed", "resource", res, "err", err)
+			resourceErrs = append(resourceErrs, err)
+			nsLogger.Warn("resource cleanup failed", "resource", res, "err", err)
 		}
 	}
 
 	if errors.Is(context.Cause(nsCtx), errCleanupLockLost) {
-		logger.Warn("cleanup lock lost mid-run, aborted namespace")
-		b.recordSnapshotNamespaceCleanupStatus(snapshotNamespaceCleanupStatusError)
-		return
+		return snapshotNamespaceCleanupStatusError, errCleanupLockLost
 	}
 	if ctx.Err() != nil {
-		return
+		return "canceled", nil
 	}
-	if hadResourceError {
-		b.recordSnapshotNamespaceCleanupStatus(snapshotNamespaceCleanupStatusError)
-		return
+	if len(resourceErrs) > 0 {
+		return snapshotNamespaceCleanupStatusError, fmt.Errorf("resource cleanup failed: %w", errors.Join(resourceErrs...))
 	}
-	b.recordSnapshotNamespaceCleanupStatus(snapshotNamespaceCleanupStatusSuccess)
+	return snapshotNamespaceCleanupStatusSuccess, nil
 }
 
 // runResourceCleanup applies the retention rules to one resource and sweeps any


### PR DESCRIPTION
## What this PR does

Adds observability around remote Bleve index snapshot lifecycle operations.

This adds OTel spans for snapshot download, upload, and cleanup, with lock acquire/release represented as events on the upload and cleanup spans.

It also adds structured lifecycle logs for snapshot download, upload, cleanup, and namespace cleanup started/completed/failed paths.

## References

- https://github.com/grafana/search-and-storage-team/issues/723