### PR TITLE
datasources: querier: use an openapi-mounted web handler

### DIFF
--- a/packages/grafana-openapi/src/apis/query.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/query.grafana.app-v0alpha1.json
@@ -91,6 +91,7 @@
         "tags": ["Query"],
         "description": "Query any datasources (with expressions)",
         "operationId": "queryDatasources",
+        "parameters": [],
         "requestBody": {
           "content": {
             "application/json": {
@@ -114,24 +115,16 @@
         },
         "responses": {
           "200": {
-            "description": "OK",
             "content": {
-              "*/*": {
+              "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/QueryDataResponse"
                 }
               }
             }
           }
-        },
-        "x-kubernetes-action": "connect",
-        "x-kubernetes-group-version-kind": {
-          "group": "query.grafana.app",
-          "version": "v0alpha1",
-          "kind": "QueryDataResponse"
         }
-      },
-      "parameters": []
+      }
     },
     "/query/sqlschemas": {
       "post": {
@@ -203,11 +196,6 @@
         },
         "additionalProperties": false
       },
-      "com.github.grafana.grafana-plugin-sdk-go.backend.DataResponse": {
-        "description": "todo... improve schema",
-        "type": "object",
-        "additionalProperties": true
-      },
       "QueryDataResponse": {
         "description": "Wraps backend.QueryDataResponse, however it includes TypeMeta and implements runtime.Object",
         "type": "object",
@@ -225,22 +213,10 @@
             "description": "Responses is a map of RefIDs (Unique Query ID) to *DataResponse.",
             "type": "object",
             "additionalProperties": {
-              "default": {},
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/com.github.grafana.grafana-plugin-sdk-go.backend.DataResponse"
-                }
-              ]
+              "default": {}
             }
           }
-        },
-        "x-kubernetes-group-version-kind": [
-          {
-            "group": "query.grafana.app",
-            "kind": "QueryDataResponse",
-            "version": "v0alpha1"
-          }
-        ]
+        }
       },
       "APIResource": {
         "description": "APIResource specifies the name of a resource and whether it is namespaced.",

--- a/pkg/registry/apis/query/noop.go
+++ b/pkg/registry/apis/query/noop.go
@@ -1,0 +1,57 @@
+package query
+
+import (
+	"context"
+	"net/http"
+
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/registry/rest"
+
+	datasourceV0 "github.com/grafana/grafana/pkg/apis/datasource/v0alpha1"
+)
+
+// Temporary noop storage that lets us map /connections/{name}/query
+type noopREST struct{}
+
+var (
+	_ rest.Storage              = (*noopREST)(nil)
+	_ rest.Connecter            = (*noopREST)(nil)
+	_ rest.Scoper               = (*noopREST)(nil)
+	_ rest.SingularNameProvider = (*noopREST)(nil)
+)
+
+// New implements [rest.Storage].
+func (r *noopREST) New() runtime.Object {
+	return &datasourceV0.QueryDataResponse{}
+}
+
+// ConnectMethods implements [rest.Storage].
+func (r *noopREST) Destroy() {}
+
+// NamespaceScoped implements [rest.Scoper].
+func (r *noopREST) NamespaceScoped() bool {
+	return false // will be removed from openapi spec, so doesn't matter
+}
+
+// GetSingularName implements [rest.SingularNameProvider].
+func (r *noopREST) GetSingularName() string {
+	return "noop"
+}
+
+// Connect implements [rest.Connecter].
+func (*noopREST) Connect(ctx context.Context, id string, options runtime.Object, r rest.Responder) (http.Handler, error) {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		r.Object(200, &v1.Status{Message: "noop"})
+	}), nil
+}
+
+// ConnectMethods implements [rest.Connecter].
+func (r *noopREST) ConnectMethods() []string {
+	return []string{"GET"}
+}
+
+// NewConnectOptions implements [rest.Connecter].
+func (r *noopREST) NewConnectOptions() (runtime.Object, bool, string) {
+	return nil, false, ""
+}

--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -14,8 +14,6 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	errorsK8s "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apiserver/pkg/endpoints/request"
 	"k8s.io/apiserver/pkg/registry/rest"
 
 	"github.com/grafana/authlib/authn"
@@ -36,11 +34,6 @@ import (
 	"github.com/grafana/grafana/pkg/util/errhttp"
 	"github.com/grafana/grafana/pkg/web"
 )
-
-type queryREST struct {
-	logger  log.Logger
-	builder *QueryAPIBuilder
-}
 
 type MyCacheService struct {
 	legacy ds_service.LegacyDataSourceLookup
@@ -68,218 +61,160 @@ func (mcs *MyCacheService) GetDatasourceByUID(ctx context.Context, datasourceUID
 	}, nil
 }
 
-var (
-	_ rest.Storage              = (*queryREST)(nil)
-	_ rest.SingularNameProvider = (*queryREST)(nil)
-	_ rest.Connecter            = (*queryREST)(nil)
-	_ rest.Scoper               = (*queryREST)(nil)
-	_ rest.StorageMetadata      = (*queryREST)(nil)
-)
+func (b *QueryAPIBuilder) QueryDatasources(w http.ResponseWriter, httpreq *http.Request) {
+	w.Header().Set("X-Ds-Querier", b.instanceProvider.GetMode())
 
-func newQueryREST(builder *QueryAPIBuilder) *queryREST {
-	return &queryREST{
-		logger:  log.New("query"),
-		builder: builder,
-	}
-}
+	ctx, span := b.tracer.Start(httpreq.Context(), "QueryService.Query")
+	defer span.End()
+	traceId := span.SpanContext().TraceID()
+	connectLogger := b.log.New(
+		"traceId", traceId.String(),
+		"rule_uid", httpreq.Header.Get("X-Rule-Uid"),
+		"caller", getCaller(ctx),
+	)
+	responderOnObjectFn := func(statusCode *int, obj runtime.Object) {
+		if *statusCode/100 == 4 {
+			span.SetStatus(codes.Error, strconv.Itoa(*statusCode))
+		}
 
-func (r *queryREST) New() runtime.Object {
-	// This is added as the "ResponseType" regardless what ProducesObject() says :)
-	return &query.QueryDataResponse{}
-}
-
-func (r *queryREST) Destroy() {}
-
-func (r *queryREST) NamespaceScoped() bool {
-	return true
-}
-
-func (r *queryREST) GetSingularName() string {
-	return "QueryResults" // Used for the
-}
-
-func (r *queryREST) ProducesMIMETypes(verb string) []string {
-	return []string{"application/json"} // and parquet!
-}
-
-func (r *queryREST) ProducesObject(verb string) interface{} {
-	return &query.QueryDataResponse{}
-}
-
-func (r *queryREST) ConnectMethods() []string {
-	return []string{"POST"}
-}
-
-func (r *queryREST) NewConnectOptions() (runtime.Object, bool, string) {
-	return nil, false, "" // true means you can use the trailing path as a variable
-}
-
-// called by mt query service and also when queryServiceFromUI is enabled, can be both mt and st
-func (r *queryREST) Connect(connectCtx context.Context, name string, _ runtime.Object, incomingResponder rest.Responder) (http.Handler, error) {
-	// See: /pkg/services/apiserver/builder/helper.go#L34
-	// The name is set with a rewriter hack
-	if name != "name" {
-		r.logger.Debug("Connect name is not name")
-		return nil, errorsK8s.NewNotFound(schema.GroupResource{}, name)
-	}
-	b := r.builder
-
-	return http.HandlerFunc(func(w http.ResponseWriter, httpreq *http.Request) {
-		w.Header().Set("X-Ds-Querier", b.instanceProvider.GetMode())
-
-		ctx, span := b.tracer.Start(httpreq.Context(), "QueryService.Query")
-		defer span.End()
-		ctx = request.WithNamespace(ctx, request.NamespaceValue(connectCtx))
-		traceId := span.SpanContext().TraceID()
-		connectLogger := b.log.New(
-			"traceId", traceId.String(),
-			"rule_uid", httpreq.Header.Get("X-Rule-Uid"),
-			"caller", getCaller(ctx),
-		)
-		responderOnObjectFn := func(statusCode *int, obj runtime.Object) {
-			if *statusCode/100 == 4 {
-				span.SetStatus(codes.Error, strconv.Itoa(*statusCode))
-			}
-
-			if *statusCode >= 500 {
-				o, ok := obj.(*query.QueryDataResponse)
-				if ok && o.Responses != nil {
-					for refId, response := range o.Responses {
-						if response.ErrorSource == backend.ErrorSourceDownstream {
-							*statusCode = http.StatusBadRequest //force this to be a 400 since it's downstream
-							span.SetStatus(codes.Error, strconv.Itoa(*statusCode))
-							span.SetAttributes(attribute.String("error.source", "downstream"))
-							break
-						} else if response.Error != nil {
-							connectLogger.Debug("500 error without downstream error source", "error", response.Error, "errorSource", response.ErrorSource, "refId", refId)
-							span.SetStatus(codes.Error, "500 error without downstream error source")
-						} else {
-							span.SetStatus(codes.Error, "500 error without downstream error source and no Error message")
-							span.SetAttributes(attribute.String("error.ref_id", refId))
-						}
+		if *statusCode >= 500 {
+			o, ok := obj.(*query.QueryDataResponse)
+			if ok && o.Responses != nil {
+				for refId, response := range o.Responses {
+					if response.ErrorSource == backend.ErrorSourceDownstream {
+						*statusCode = http.StatusBadRequest //force this to be a 400 since it's downstream
+						span.SetStatus(codes.Error, strconv.Itoa(*statusCode))
+						span.SetAttributes(attribute.String("error.source", "downstream"))
+						break
+					} else if response.Error != nil {
+						connectLogger.Debug("500 error without downstream error source", "error", response.Error, "errorSource", response.ErrorSource, "refId", refId)
+						span.SetStatus(codes.Error, "500 error without downstream error source")
+					} else {
+						span.SetStatus(codes.Error, "500 error without downstream error source and no Error message")
+						span.SetAttributes(attribute.String("error.ref_id", refId))
 					}
 				}
 			}
-			connectLogger.Debug("responder sending status code", "statusCode", statusCode, "caller", getCaller(ctx))
-			b.reportStatus(ctx, *statusCode)
 		}
-		responderOnErrorFn := func(err error) {
-			connectLogger.Error("error caught in handler", "err", err, "caller", getCaller(ctx))
-			span.SetStatus(codes.Error, "query error")
+		connectLogger.Debug("responder sending status code", "statusCode", statusCode, "caller", getCaller(ctx))
+		b.reportStatus(ctx, *statusCode)
+	}
+	responderOnErrorFn := func(err error) {
+		connectLogger.Error("error caught in handler", "err", err, "caller", getCaller(ctx))
+		span.SetStatus(codes.Error, "query error")
 
-			if err == nil {
-				return
-			}
-
-			span.RecordError(err)
-
-			statusCode := 0
-			var k8sErr *errorsK8s.StatusError
-			switch {
-			case errors.As(err, &k8sErr):
-				statusCode = int(k8sErr.Status().Code)
-			case errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded):
-				statusCode = http.StatusGatewayTimeout
-			case errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled):
-				// 499 follows the widely used "client closed request" convention.
-				statusCode = 499
-			default:
-				// we do not know what kind of error it is,
-				// we do not know what status code will get assigned to it,
-				// so we use the zero to indicate the unknown.
-				connectLogger.Debug("Connect: unknown error returned", "error", err)
-			}
-			b.reportStatus(ctx, statusCode)
-		}
-
-		responder := newRawResponderWrapper(ctx, w, responderOnObjectFn, responderOnErrorFn)
-
-		raw := &query.QueryDataRequest{}
-		err := web.Bind(httpreq, raw)
-		if err != nil {
-			connectLogger.Error("Hit unexpected error when reading query", "err", err)
-			err = errorsK8s.NewBadRequest("error reading query")
-			// TODO: can we wrap the error so details are not lost?!
-			// errutil.BadRequest(
-			// 	"query.bind",
-			// 	errutil.WithPublicMessage("Error reading query")).
-			// 	Errorf("error reading: %w", err)
-			responder.Error(err)
+		if err == nil {
 			return
 		}
 
-		qdr, err := handleQuery(ctx, *raw, *b, httpreq, responder, connectLogger)
+		span.RecordError(err)
 
-		if err != nil {
-			if errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
-				connectLogger.Warn(
-					"query-service request deadline exceeded",
-					"ctx_err", ctx.Err(),
-					"cause", context.Cause(ctx),
-				)
-			} else if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
-				connectLogger.Warn(
-					"query-service request cancelled",
-					"ctx_err", ctx.Err(),
-					"cause", context.Cause(ctx),
-				)
-			}
-			connectLogger.Error("execute error", "http code", query.GetResponseCode(qdr), "err", err)
-			logEmptyRefids(raw.Queries, connectLogger)
-			if qdr != nil { // if we have a response, we assume the err is set in the response
-				responder.Object(query.GetResponseCode(qdr), &query.QueryDataResponse{
-					QueryDataResponse: *qdr,
-				})
-				return
-			} else {
-				var errorDataResponse backend.DataResponse
-
-				badRequestErrors := []error{
-					service.ErrInvalidDatasourceID,
-					service.ErrNoQueriesFound,
-					service.ErrMissingDataSourceInfo,
-					service.ErrQueryParamMismatch,
-					service.ErrDuplicateRefId,
-					datasources.ErrDataSourceNotFound,
-				}
-				isTypedBadRequestError := false
-				for _, badRequestError := range badRequestErrors {
-					if errors.Is(err, badRequestError) {
-						isTypedBadRequestError = true
-					}
-				}
-				if isTypedBadRequestError {
-					errorDataResponse = backend.ErrDataResponseWithSource(backend.StatusBadRequest, backend.ErrorSourceDownstream, err.Error())
-				} else if strings.Contains(err.Error(), "expression request error") {
-					connectLogger.Error("Error calling TransformData in an expression", "err", err)
-					errorDataResponse = backend.ErrDataResponseWithSource(backend.StatusBadRequest, backend.ErrorSourceDownstream, err.Error())
-				} else {
-					connectLogger.Error("unknown error, treated as a 500", "err", err)
-					responder.Error(err)
-					return
-				}
-				// TODO ensure errors also return the refId wherever possible
-				errorRefId := raw.Queries[0].RefID
-				if errorRefId == "" {
-					errorRefId = "A"
-				}
-
-				qdr = &backend.QueryDataResponse{
-					Responses: map[string]backend.DataResponse{
-						errorRefId: errorDataResponse,
-					},
-				}
-				responder.Object(query.GetResponseCode(qdr), &query.QueryDataResponse{
-					QueryDataResponse: *qdr,
-				})
-				return
-			}
+		statusCode := 0
+		var k8sErr *errorsK8s.StatusError
+		switch {
+		case errors.As(err, &k8sErr):
+			statusCode = int(k8sErr.Status().Code)
+		case errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded):
+			statusCode = http.StatusGatewayTimeout
+		case errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled):
+			// 499 follows the widely used "client closed request" convention.
+			statusCode = 499
+		default:
+			// we do not know what kind of error it is,
+			// we do not know what status code will get assigned to it,
+			// so we use the zero to indicate the unknown.
+			connectLogger.Debug("Connect: unknown error returned", "error", err)
 		}
+		b.reportStatus(ctx, statusCode)
+	}
 
-		responder.Object(query.GetResponseCode(qdr), &query.QueryDataResponse{
-			QueryDataResponse: *qdr, // wrap the backend response as a QueryDataResponse
-		})
-	}), nil
+	responder := newRawResponderWrapper(ctx, w, responderOnObjectFn, responderOnErrorFn)
+
+	raw := &query.QueryDataRequest{}
+	err := web.Bind(httpreq, raw)
+	if err != nil {
+		connectLogger.Error("Hit unexpected error when reading query", "err", err)
+		err = errorsK8s.NewBadRequest("error reading query")
+		// TODO: can we wrap the error so details are not lost?!
+		// errutil.BadRequest(
+		// 	"query.bind",
+		// 	errutil.WithPublicMessage("Error reading query")).
+		// 	Errorf("error reading: %w", err)
+		responder.Error(err)
+		return
+	}
+
+	qdr, err := handleQuery(ctx, *raw, *b, httpreq, responder, connectLogger)
+
+	if err != nil {
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
+			connectLogger.Warn(
+				"query-service request deadline exceeded",
+				"ctx_err", ctx.Err(),
+				"cause", context.Cause(ctx),
+			)
+		} else if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
+			connectLogger.Warn(
+				"query-service request cancelled",
+				"ctx_err", ctx.Err(),
+				"cause", context.Cause(ctx),
+			)
+		}
+		connectLogger.Error("execute error", "http code", query.GetResponseCode(qdr), "err", err)
+		logEmptyRefids(raw.Queries, connectLogger)
+		if qdr != nil { // if we have a response, we assume the err is set in the response
+			responder.Object(query.GetResponseCode(qdr), &query.QueryDataResponse{
+				QueryDataResponse: *qdr,
+			})
+			return
+		} else {
+			var errorDataResponse backend.DataResponse
+
+			badRequestErrors := []error{
+				service.ErrInvalidDatasourceID,
+				service.ErrNoQueriesFound,
+				service.ErrMissingDataSourceInfo,
+				service.ErrQueryParamMismatch,
+				service.ErrDuplicateRefId,
+				datasources.ErrDataSourceNotFound,
+			}
+			isTypedBadRequestError := false
+			for _, badRequestError := range badRequestErrors {
+				if errors.Is(err, badRequestError) {
+					isTypedBadRequestError = true
+				}
+			}
+			if isTypedBadRequestError {
+				errorDataResponse = backend.ErrDataResponseWithSource(backend.StatusBadRequest, backend.ErrorSourceDownstream, err.Error())
+			} else if strings.Contains(err.Error(), "expression request error") {
+				connectLogger.Error("Error calling TransformData in an expression", "err", err)
+				errorDataResponse = backend.ErrDataResponseWithSource(backend.StatusBadRequest, backend.ErrorSourceDownstream, err.Error())
+			} else {
+				connectLogger.Error("unknown error, treated as a 500", "err", err)
+				responder.Error(err)
+				return
+			}
+			// TODO ensure errors also return the refId wherever possible
+			errorRefId := raw.Queries[0].RefID
+			if errorRefId == "" {
+				errorRefId = "A"
+			}
+
+			qdr = &backend.QueryDataResponse{
+				Responses: map[string]backend.DataResponse{
+					errorRefId: errorDataResponse,
+				},
+			}
+			responder.Object(query.GetResponseCode(qdr), &query.QueryDataResponse{
+				QueryDataResponse: *qdr,
+			})
+			return
+		}
+	}
+
+	responder.Object(query.GetResponseCode(qdr), &query.QueryDataResponse{
+		QueryDataResponse: *qdr, // wrap the backend response as a QueryDataResponse
+	})
 }
 
 type preparedQuery struct {

--- a/pkg/registry/apis/query/query_test.go
+++ b/pkg/registry/apis/query/query_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/stretchr/testify/require"
-	"k8s.io/apimachinery/pkg/runtime"
 
 	claims "github.com/grafana/authlib/types"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -193,27 +192,19 @@ func TestQueryAPI(t *testing.T) {
 				req.Header.Set(key, value)
 			}
 
-			ctx := context.Background()
-			mr := &mockResponder{}
-			qr := newQueryREST(builder)
-
-			handler, err := qr.Connect(ctx, "name", nil, mr)
-			require.NoError(t, err)
 			rr := httptest.NewRecorder()
-			handler.ServeHTTP(rr, req)
-
+			builder.QueryDatasources(rr, req)
 			result := rr.Result()
+
 			defer func() {
 				_ = result.Body.Close()
 			}()
-
-			require.False(t, mr.used, "Responder should be unused")
 
 			require.Equal(t, tc.expectedStatus, result.StatusCode, "Should return expected status code")
 
 			// Verify the response is the expected type
 			qdr := &queryapi.QueryDataResponse{}
-			err = json.NewDecoder(result.Body).Decode(qdr)
+			err := json.NewDecoder(result.Body).Decode(qdr)
 			require.NoError(t, err, "Failed to decode response body")
 
 			require.NotNil(t, qdr.Responses, "Should have responses")
@@ -252,26 +243,6 @@ func TestQueryAPI(t *testing.T) {
 			t.Logf("Test case '%s' completed successfully", tc.name)
 		})
 	}
-}
-
-type mockResponder struct {
-	used       bool
-	statusCode int
-	response   runtime.Object
-	err        error
-}
-
-// Object writes the provided object to the response. Invoking this method multiple times is undefined.
-func (m *mockResponder) Object(statusCode int, obj runtime.Object) {
-	m.statusCode = statusCode
-	m.response = obj
-	m.used = true
-}
-
-// Error writes the provided error to the response. This method may only be invoked once.
-func (m *mockResponder) Error(err error) {
-	m.err = err
-	m.used = true
 }
 
 type mockClient struct {

--- a/pkg/registry/apis/query/register.go
+++ b/pkg/registry/apis/query/register.go
@@ -16,6 +16,7 @@ import (
 	genericapiserver "k8s.io/apiserver/pkg/server"
 	common "k8s.io/kube-openapi/pkg/common"
 	"k8s.io/kube-openapi/pkg/spec3"
+	"k8s.io/kube-openapi/pkg/validation/spec"
 
 	claims "github.com/grafana/authlib/types"
 	datasourceV0 "github.com/grafana/grafana/pkg/apis/datasource/v0alpha1"
@@ -37,7 +38,10 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 )
 
-var _ builder.APIGroupBuilder = (*QueryAPIBuilder)(nil)
+var (
+	_ builder.APIGroupBuilder      = (*QueryAPIBuilder)(nil)
+	_ builder.OpenAPIPostProcessor = (*QueryAPIBuilder)(nil)
+)
 
 type QueryAPIBuilder struct {
 	log                  log.Logger
@@ -201,8 +205,9 @@ func (b *QueryAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.APIG
 
 	storage := map[string]rest.Storage{}
 
-	// The query endpoint -- NOTE, this uses a rewrite hack to allow requests without a name parameter
-	storage["query"] = newQueryREST(b)
+	// k8s needs a real storage registered -- we add this, but hide it for now
+	// because connections and queries are handled directly
+	storage["noop"] = &noopREST{}
 
 	// Register the expressions query schemas
 	err := queryschema.RegisterQueryTypes(b.queryTypes, storage)
@@ -234,7 +239,7 @@ func (b *QueryAPIBuilder) PostProcessOpenAPI(oas *spec3.OpenAPI) (*spec3.OpenAPI
 		},
 		QueryTypes:       b.queryTypes,
 		Root:             root,
-		QueryPath:        "namespaces/{namespace}/query/{name}",
+		QueryPath:        "namespaces/{namespace}/query",
 		QueryDescription: "Query any datasources (with expressions)",
 
 		// An explicit set of examples (otherwise we iterate the query type examples)
@@ -306,10 +311,6 @@ func (b *QueryAPIBuilder) PostProcessOpenAPI(oas *spec3.OpenAPI) (*spec3.OpenAPI
 	if !ok || query.Post == nil || query.Post.RequestBody == nil {
 		return nil, fmt.Errorf("could not find query path")
 	}
-	if len(query.Parameters) != 2 && query.Parameters[0].Name != "name" {
-		return nil, fmt.Errorf("expected name parameter in query service")
-	}
-	query.Parameters = []*spec3.Parameter{query.Parameters[1]}
 	query.Post.OperationId = "queryDatasources"
 	query.Post.Tags = []string{"Query"}
 
@@ -317,6 +318,17 @@ func (b *QueryAPIBuilder) PostProcessOpenAPI(oas *spec3.OpenAPI) (*spec3.OpenAPI
 	if ok && sqlschemas.Post != nil {
 		sqlschemas.Post.RequestBody = query.Post.RequestBody
 	}
+
+	// Add the core definitions
+	for k, v := range b.GetOpenAPIDefinitions()(func(path string) spec.Ref { return spec.Ref{} }) {
+		switch k {
+		case "com.github.grafana.grafana.pkg.apis.datasource.v0alpha1.QueryDataResponse":
+			oas.Components.Schemas[k] = &v.Schema
+		}
+	}
+
+	// Remove the noop path -- it was only required to make k8s behave normally
+	delete(oas.Paths.Paths, root+"noop/{name}")
 
 	return oas, nil
 }

--- a/pkg/registry/apis/query/routes.go
+++ b/pkg/registry/apis/query/routes.go
@@ -19,6 +19,50 @@ func (b *QueryAPIBuilder) GetAPIRoutes(gv schema.GroupVersion) *builder.APIRoute
 	sqlSchemas := defs[queryV1.OpenAPIPrefix+"QueryResponseSQLSchemas"].Schema
 	routes := &builder.APIRoutes{
 		Namespace: []builder.APIRouteHandler{
+			{Path: "query",
+				Spec: &spec3.PathProps{
+					Post: &spec3.Operation{
+						OperationProps: spec3.OperationProps{
+							Tags:        []string{"Query"},
+							OperationId: "queryDatasources",
+							Parameters: []*spec3.Parameter{
+								{
+									ParameterProps: spec3.ParameterProps{
+										Name:        "namespace",
+										In:          "path",
+										Required:    true,
+										Example:     "default",
+										Description: "workspace",
+										Schema:      spec.StringProperty(),
+									},
+								},
+							},
+							Responses: &spec3.Responses{
+								ResponsesProps: spec3.ResponsesProps{
+									StatusCodeResponses: map[int]*spec3.Response{
+										200: {
+											ResponseProps: spec3.ResponseProps{
+												Content: map[string]*spec3.MediaType{
+													"application/json": {
+														MediaTypeProps: spec3.MediaTypeProps{
+															Schema: &spec.Schema{
+																SchemaProps: spec.SchemaProps{
+																	Ref: spec.MustCreateRef("#/components/schemas/com.github.grafana.grafana.pkg.apis.datasource.v0alpha1.QueryDataResponse"),
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+				Handler: b.QueryDatasources,
+			},
 			{
 				Path: "query/sqlschemas",
 				Spec: &spec3.PathProps{

--- a/pkg/services/apiserver/builder/helper.go
+++ b/pkg/services/apiserver/builder/helper.go
@@ -54,9 +54,6 @@ var PathRewriters = []filters.PathRewriter{
 		Pattern: regexp.MustCompile(`/apis/datasource.grafana.app/v0alpha1(.*$)`),
 		ReplaceFunc: func(matches []string) string {
 			result := "/apis/query.grafana.app/v0alpha1" + matches[1]
-			if strings.HasSuffix(matches[1], "/query") {
-				result += "/name" // same as the rewrite pattern below
-			}
 			if strings.HasSuffix(matches[1], "/sqlschemas") && !strings.Contains(matches[1], "/query/") {
 				result = strings.Replace(result, "/sqlschemas", "/query/sqlschemas", 1)
 			}
@@ -64,9 +61,9 @@ var PathRewriters = []filters.PathRewriter{
 		},
 	},
 	{
-		Pattern: regexp.MustCompile(`(/apis/query.grafana.app/v0alpha1/namespaces/.*/query$)`),
+		Pattern: regexp.MustCompile(`(/apis/query.grafana.app/v0alpha1/namespaces/.*/)query/name$`),
 		ReplaceFunc: func(matches []string) string {
-			return matches[1] + "/name" // connector requires a name
+			return matches[1] + "query" // redirect from with-name to without-name
 		},
 	},
 	{

--- a/pkg/services/apiserver/builder/helper_test.go
+++ b/pkg/services/apiserver/builder/helper_test.go
@@ -100,9 +100,9 @@ func TestRedirection(t *testing.T) {
 			url:    "/apis/query.grafana.app/v0alpha1/namespaces/default/connections",
 			expect: "/apis/query.grafana.app/v0alpha1/namespaces/default/connections",
 		}, {
-			name:   "query (with name hack)",
-			url:    "/apis/query.grafana.app/v0alpha1/namespaces/default/query",
-			expect: "/apis/query.grafana.app/v0alpha1/namespaces/default/query/name",
+			name:   "query (with name hack)", // deprecated
+			url:    "/apis/query.grafana.app/v0alpha1/namespaces/default/query/name",
+			expect: "/apis/query.grafana.app/v0alpha1/namespaces/default/query",
 		}, {
 			name:   "query sqlschemas at root",
 			url:    "/apis/query.grafana.app/v0alpha1/namespaces/default/sqlschemas",
@@ -114,7 +114,7 @@ func TestRedirection(t *testing.T) {
 		}, {
 			name:   "name hack in datasource service",
 			url:    "/apis/query.grafana.app/v0alpha1/namespaces/default/query",
-			expect: "/apis/query.grafana.app/v0alpha1/namespaces/default/query/name", // hack :(
+			expect: "/apis/query.grafana.app/v0alpha1/namespaces/default/query",
 		}, {
 			name:   "datasource connections",
 			url:    "/apis/datasource.grafana.app/v0alpha1/namespaces/default/connections",
@@ -122,7 +122,7 @@ func TestRedirection(t *testing.T) {
 		}, {
 			name:   "datasource query",
 			url:    "/apis/datasource.grafana.app/v0alpha1/namespaces/default/query",
-			expect: "/apis/query.grafana.app/v0alpha1/namespaces/default/query/name",
+			expect: "/apis/query.grafana.app/v0alpha1/namespaces/default/query",
 		}, {
 			name:   "datasource query (using connections)",
 			url:    "/apis/prometheus.datasource.grafana.app/v0alpha1/namespaces/default/connections/xxx/query",

--- a/pkg/tests/apis/openapi_snapshots/query.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/query.grafana.app-v0alpha1.json
@@ -109,6 +109,18 @@
         ],
         "description": "Query any datasources (with expressions)",
         "operationId": "queryDatasources",
+        "parameters": [
+          {
+            "name": "namespace",
+            "in": "path",
+            "description": "workspace",
+            "required": true,
+            "schema": {
+              "type": "string"
+            },
+            "example": "default"
+          }
+        ],
         "requestBody": {
           "content": {
             "application/json": {
@@ -132,35 +144,16 @@
         },
         "responses": {
           "200": {
-            "description": "OK",
             "content": {
-              "*/*": {
+              "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/com.github.grafana.grafana.pkg.apis.datasource.v0alpha1.QueryDataResponse"
                 }
               }
             }
           }
-        },
-        "x-kubernetes-action": "connect",
-        "x-kubernetes-group-version-kind": {
-          "group": "query.grafana.app",
-          "version": "v0alpha1",
-          "kind": "QueryDataResponse"
         }
-      },
-      "parameters": [
-        {
-          "name": "namespace",
-          "in": "path",
-          "description": "object name and auth scope, such as for teams and projects",
-          "required": true,
-          "schema": {
-            "type": "string",
-            "uniqueItems": true
-          }
-        }
-      ]
+      }
     },
     "/apis/query.grafana.app/v0alpha1/namespaces/{namespace}/query/sqlschemas": {
       "post": {
@@ -249,11 +242,6 @@
         },
         "additionalProperties": false
       },
-      "com.github.grafana.grafana-plugin-sdk-go.backend.DataResponse": {
-        "description": "todo... improve schema",
-        "type": "object",
-        "additionalProperties": true
-      },
       "com.github.grafana.grafana.pkg.apis.datasource.v0alpha1.QueryDataResponse": {
         "description": "Wraps backend.QueryDataResponse, however it includes TypeMeta and implements runtime.Object",
         "type": "object",
@@ -273,22 +261,10 @@
             "description": "Responses is a map of RefIDs (Unique Query ID) to *DataResponse.",
             "type": "object",
             "additionalProperties": {
-              "default": {},
-              "allOf": [
-                {
-                  "$ref": "#/components/schemas/com.github.grafana.grafana-plugin-sdk-go.backend.DataResponse"
-                }
-              ]
+              "default": {}
             }
           }
-        },
-        "x-kubernetes-group-version-kind": [
-          {
-            "group": "query.grafana.app",
-            "kind": "QueryDataResponse",
-            "version": "v0alpha1"
-          }
-        ]
+        }
       },
       "io.k8s.apimachinery.pkg.apis.meta.v1.APIResource": {
         "description": "APIResource specifies the name of a resource and whether it is namespaced.",


### PR DESCRIPTION
we simplify the way query-service requests are handled.

changes taken from https://github.com/grafana/grafana/pull/118803 , thanks @ryantxu !