### PR TITLE
RefreshPicker: Add new `loadingText` prop

### DIFF
--- a/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.story.tsx
+++ b/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.story.tsx
@@ -21,7 +21,7 @@ const meta: Meta<typeof RefreshPicker> = {
     isLive: false,
     width: 'auto',
     text: 'Refresh time picker',
-    // tooltip: 'My tooltip text goes here',
+    tooltip: 'My tooltip text goes here',
     value: '1h',
     primary: false,
     noIntervalPicker: false,

--- a/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.story.tsx
+++ b/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.story.tsx
@@ -20,8 +20,8 @@ const meta: Meta<typeof RefreshPicker> = {
     isLoading: false,
     isLive: false,
     width: 'auto',
-    text: 'Run query',
-    tooltip: 'My tooltip text goes here',
+    text: 'Refresh time picker',
+    // tooltip: 'My tooltip text goes here',
     value: '1h',
     primary: false,
     noIntervalPicker: false,
@@ -40,20 +40,7 @@ export const Examples: StoryFn<typeof RefreshPicker> = (args) => {
     action('onRefresh fired')();
   };
 
-  return (
-    <RefreshPicker
-      tooltip={args.tooltip}
-      value={args.value}
-      text={args.text}
-      isLoading={args.isLoading}
-      intervals={args.intervals}
-      width={args.width}
-      onIntervalChanged={onIntervalChanged}
-      onRefresh={onRefresh}
-      noIntervalPicker={args.noIntervalPicker}
-      primary={args.primary}
-    />
-  );
+  return <RefreshPicker {...args} onIntervalChanged={onIntervalChanged} onRefresh={onRefresh} />;
 };
 
 export default meta;

--- a/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
+++ b/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
@@ -1,11 +1,12 @@
-import { css } from '@emotion/css';
+import { css, cx } from '@emotion/css';
 import { formatDuration } from 'date-fns/formatDuration';
 import { memo } from 'react';
 
-import { type SelectableValue, parseDuration } from '@grafana/data';
+import { type GrafanaTheme2, type SelectableValue, parseDuration } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 
+import { useStyles2 } from '../../themes/ThemeContext';
 import { ButtonGroup } from '../Button/ButtonGroup';
 import { ButtonSelect } from '../Dropdown/ButtonSelect';
 import { ToolbarButton, type ToolbarButtonVariant } from '../ToolbarButton/ToolbarButton';
@@ -22,6 +23,7 @@ export interface Props {
   isLoading?: boolean;
   isLive?: boolean;
   text?: string;
+  loadingText?: string;
   noIntervalPicker?: boolean;
   showAutoInterval?: boolean;
   width?: string;
@@ -60,12 +62,14 @@ const RefreshPickerComponent = memo((props: Props) => {
     isLoading,
     isLive,
     text,
+    loadingText,
     noIntervalPicker,
     showAutoInterval,
     width,
     primary,
     isOnCanvas,
   } = props;
+  const styles = useStyles2(getStyles);
   const currentValue = value || '';
   const options = intervalsToOptions({ intervals, showAutoInterval });
   const option = options.find(({ value }) => value === currentValue);
@@ -113,7 +117,7 @@ const RefreshPickerComponent = memo((props: Props) => {
   return (
     <ButtonGroup className="refresh-picker">
       <ToolbarButton
-        aria-label={text}
+        // aria-label={text}
         tooltip={tooltip}
         onClick={onRefresh}
         variant={variant}
@@ -121,7 +125,22 @@ const RefreshPickerComponent = memo((props: Props) => {
         style={width ? { width } : undefined}
         data-testid={selectors.components.RefreshPicker.runButtonV2}
       >
-        {text}
+        <span className={styles.textWrapper}>
+          <span
+            className={cx(styles.text, {
+              [styles.hideText]: Boolean(loadingText && isLoading),
+            })}
+          >
+            {text}
+          </span>
+          <span
+            className={cx(styles.loadingText, {
+              [styles.hideLoadingText]: !loadingText || !isLoading,
+            })}
+          >
+            {loadingText}
+          </span>
+        </span>
       </ToolbarButton>
       {!noIntervalPicker && (
         <ButtonSelect
@@ -196,3 +215,25 @@ export const intervalsToOptions = ({
   options.unshift(translateOption(offOption.value));
   return options;
 };
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  textWrapper: css({
+    display: 'grid',
+    gridTemplateColumns: '1fr',
+    gridTemplateRows: '1fr',
+  }),
+  text: css({
+    gridColumnStart: 1,
+    gridRowStart: 1,
+  }),
+  hideText: css({
+    visibility: 'hidden',
+  }),
+  loadingText: css({
+    gridColumnStart: 1,
+    gridRowStart: 1,
+  }),
+  hideLoadingText: css({
+    visibility: 'hidden',
+  }),
+});

--- a/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
+++ b/packages/grafana-ui/src/components/RefreshPicker/RefreshPicker.tsx
@@ -117,7 +117,7 @@ const RefreshPickerComponent = memo((props: Props) => {
   return (
     <ButtonGroup className="refresh-picker">
       <ToolbarButton
-        // aria-label={text}
+        aria-label={loadingText && isLoading ? loadingText : text}
         tooltip={tooltip}
         onClick={onRefresh}
         variant={variant}
@@ -134,8 +134,8 @@ const RefreshPickerComponent = memo((props: Props) => {
             {text}
           </span>
           <span
-            className={cx(styles.loadingText, {
-              [styles.hideLoadingText]: !loadingText || !isLoading,
+            className={cx(styles.text, {
+              [styles.hideText]: !loadingText || !isLoading,
             })}
           >
             {loadingText}
@@ -227,13 +227,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
     gridRowStart: 1,
   }),
   hideText: css({
-    visibility: 'hidden',
-  }),
-  loadingText: css({
-    gridColumnStart: 1,
-    gridRowStart: 1,
-  }),
-  hideLoadingText: css({
     visibility: 'hidden',
   }),
 });

--- a/public/app/features/explore/ExploreToolbar.tsx
+++ b/public/app/features/explore/ExploreToolbar.tsx
@@ -94,9 +94,9 @@ export function ExploreToolbar({ exploreId, onChangeTime, onContentOutlineToogle
     [isLeftPane, isLargerPane]
   );
 
-  const refreshPickerLabel = loading
-    ? t('explore.toolbar.refresh-picker-cancel', 'Cancel')
-    : t('explore.toolbar.refresh-picker-run', 'Run query');
+  const refreshPickerLabel = t('explore.toolbar.refresh-picker-run', 'Run query');
+  const refreshPickerCancelLabel = t('explore.toolbar.refresh-picker-cancel', 'Cancel');
+  const tooltipLabel = loading ? refreshPickerCancelLabel : refreshPickerLabel;
 
   const onChangeDatasource = async (dsSettings: DataSourceInstanceSettings) => {
     if (!isCorrelationsEditorMode) {
@@ -303,13 +303,14 @@ export function ExploreToolbar({ exploreId, onChangeTime, onContentOutlineToogle
             value={refreshInterval}
             isLoading={loading}
             text={showSmallTimePicker ? undefined : refreshPickerLabel}
-            tooltip={showSmallTimePicker ? refreshPickerLabel : undefined}
+            loadingText={showSmallTimePicker ? undefined : refreshPickerCancelLabel}
+            tooltip={showSmallTimePicker ? tooltipLabel : undefined}
             intervals={contextSrv.getValidIntervals(defaultIntervals)}
             isLive={isLive}
             onRefresh={() => onRunQuery(loading)}
             noIntervalPicker={isLive}
             primary={true}
-            width={(showSmallTimePicker ? 35 : 108) + 'px'}
+            width={showSmallTimePicker ? '35px' : undefined}
             data-testid={selectors.pages.Explore.toolbar.refreshPicker}
           />,
           (!splitted || !isLeftPane) && <ShortLinkButtonMenu key="share" hideText={showSmallTimePicker} />,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- adds a new `loadingText` prop to `RefreshPicker`
- `RefreshPicker` now renders both the `text` and `loadingText` stacked on top of each other in a grid, and the `isLoading` prop controls which is visible at any one time
  - because both are in the dom, the picker will grow to fit the largest text string even if it's not visible
  - this removes the need for a hardcoded width in both Explore and scenes (followup PR to come)
  - the only downside is the new prop, `loadingText`
  
|  | before | after |
| --- | --- | --- |
| normal | <img width="606" height="219" alt="image" src="https://github.com/user-attachments/assets/1217a1e4-7d41-4569-b5c2-03a861d18e44" /> | <img width="552" height="206" alt="image" src="https://github.com/user-attachments/assets/46f939ae-e6a6-470f-acf8-f37be9fffa1e" /> |
| loading | <img width="629" height="228" alt="image" src="https://github.com/user-attachments/assets/74a63bc3-4b3c-4d3e-b558-2f51d29f8f13" /> | <img width="589" height="230" alt="image" src="https://github.com/user-attachments/assets/759159df-a940-4753-b82d-6f9946655099" /> |

**Why do we need this feature?**

- so the `RefreshPicker` correctly renders the full text in different languages

**Who is this feature for?**

- anyone using a different language

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

For https://github.com/grafana/grafana/issues/123801

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
