### PR TITLE
Provisioning: Fix TestIntegrationProvisioning_BlockManagerChange cleanup flake

### DIFF
--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -58,6 +58,13 @@ import (
 const (
 	WaitTimeoutDefault  = 60 * time.Second
 	WaitIntervalDefault = 100 * time.Millisecond
+
+	// waitTimeoutCleanup is the per-step budget for CleanupAllResources. Folder
+	// admission validates "folder is empty" against the resource search index,
+	// which is eventually consistent with respect to dashboard deletes. Under
+	// SQLite write contention that lag has been observed to exceed 60s, so
+	// cleanup gets a larger budget than the default per-operation wait.
+	waitTimeoutCleanup = 2 * WaitTimeoutDefault
 )
 
 //nolint:gosec // Test RSA private key (generated for testing purposes only, never used in production)
@@ -1398,7 +1405,7 @@ func deleteAndWait(ctx context.Context, client dynamic.ResourceInterface, timeou
 // a previous test don't leak into the next one.
 // Failures are fatal because cleanup is the primary test-isolation mechanism.
 //
-// Every step uses WaitTimeoutDefault because each one can be blocked by an
+// Every step uses waitTimeoutCleanup because each one can be blocked by an
 // eventually-consistent signal: repository finalizers draining orphan
 // resources, dashboards freeing their folder reference in the search index,
 // and folder admission rejecting deletion until that index catches up. Under
@@ -1414,7 +1421,7 @@ func (h *ProvisioningTestHelper) CleanupAllResources(t *testing.T, ctx context.C
 		{"dashboards", h.DashboardsV1.Resource},
 		{"folders", h.Folders.Resource},
 	} {
-		if err := deleteAndWait(ctx, c.client, WaitTimeoutDefault); err != nil {
+		if err := deleteAndWait(ctx, c.client, waitTimeoutCleanup); err != nil {
 			t.Fatalf("CleanupAllResources(%s): %v", c.name, err)
 		}
 	}


### PR DESCRIPTION
**What is this feature?**

Bumps the per-step timeout in \`CleanupAllResources\` from 60s to 120s by introducing a dedicated \`waitTimeoutCleanup\` constant (2x \`WaitTimeoutDefault\`).

**Why do we need this feature?**

Folder admission validates \"folder is empty\" against the resource search index (\`searcher.GetStats\`), which is eventually consistent with respect to dashboard deletes. Under SQLite write contention that lag has been observed to exceed 60s, causing \`TestIntegrationProvisioning_BlockManagerChange\` to fail in cleanup with \"folder is not empty\" on leftovers from the preceding \`TestIntegrationFolderManagerConsistency\` test (which creates ~12 folders, many containing dashboards). This is a recurrence of the same class of flake addressed in #123360 (10s -> 60s); 60s still isn't enough.

**Who is this feature for?**

Grafana developers — reduces CI flakes in the provisioning integration test package.

**Which issue(s) does this PR fix?**:

Fixes flake observed in https://github.com/grafana/grafana/actions/runs/25128899686/job/73651187518

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.