### PR TITLE
Analytics: silent option for reportInteraction and defineFeatureEvents

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "repository": "github:grafana/grafana",
   "scripts": {
     "analytics-report": "node ./scripts/cli/analytics/main.mts",
+    "analytics-report:test": "node --test ./scripts/cli/analytics/*.test.mts",
     "check-frontend-dev": "./scripts/check-frontend-dev.sh",
     "build": "NODE_ENV=production nx exec --verbose -- webpack --config scripts/webpack/webpack.prod.ts && yarn build:react19",
     "build:react19": "NODE_ENV=production nx exec --verbose -- webpack --config scripts/webpack/webpack.prod.ts --env react19=1",

--- a/packages/grafana-runtime/src/analytics/types.ts
+++ b/packages/grafana-runtime/src/analytics/types.ts
@@ -105,6 +105,12 @@ export type PageviewEchoEvent = EchoEvent<EchoEventType.Pageview, PageviewEchoEv
 export interface InteractionEchoEventPayload {
   interactionName: string;
   properties?: Record<string, any>;
+  /**
+   * If true, the event is dispatched to {@link EchoSrv} subscribers but is
+   * not forwarded to analytics backends. Use for high-frequency UI signals
+   * that downstream subscribers care about but shouldn't pollute analytics.
+   */
+  silent?: boolean;
 }
 
 /**

--- a/packages/grafana-runtime/src/analytics/utils.test.ts
+++ b/packages/grafana-runtime/src/analytics/utils.test.ts
@@ -2,7 +2,7 @@ import { config } from '../config';
 import { locationService } from '../services';
 import { getEchoSrv, EchoEventType } from '../services/EchoSrv';
 
-import { MAX_PAGE_URL_LENGTH, TRUNCATION_MARKER, reportPageview } from './utils';
+import { MAX_PAGE_URL_LENGTH, TRUNCATION_MARKER, reportInteraction, reportPageview } from './utils';
 
 jest.mock('../services/EchoSrv');
 jest.mock('../services', () => ({
@@ -68,6 +68,40 @@ describe('reportPageview', () => {
     expect(mockAddEvent).toHaveBeenCalledWith({
       type: EchoEventType.Pageview,
       payload: { page: '/grafana/d/abc' },
+    });
+  });
+});
+
+describe('reportInteraction', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(getEchoSrv).mockReturnValue({ addEvent: mockAddEvent } as unknown as ReturnType<typeof getEchoSrv>);
+  });
+
+  it('emits an Interaction event without silent by default', () => {
+    reportInteraction('test_event', { foo: 'bar' });
+
+    expect(mockAddEvent).toHaveBeenCalledWith({
+      type: EchoEventType.Interaction,
+      payload: { interactionName: 'test_event', properties: { foo: 'bar' }, silent: undefined },
+    });
+  });
+
+  it('threads silent: true through to the payload when passed', () => {
+    reportInteraction('test_event', { foo: 'bar' }, { silent: true });
+
+    expect(mockAddEvent).toHaveBeenCalledWith({
+      type: EchoEventType.Interaction,
+      payload: { interactionName: 'test_event', properties: { foo: 'bar' }, silent: true },
+    });
+  });
+
+  it('passes silent: false explicitly when set', () => {
+    reportInteraction('test_event', undefined, { silent: false });
+
+    expect(mockAddEvent).toHaveBeenCalledWith({
+      type: EchoEventType.Interaction,
+      payload: { interactionName: 'test_event', properties: undefined, silent: false },
     });
   });
 });

--- a/packages/grafana-runtime/src/analytics/utils.ts
+++ b/packages/grafana-runtime/src/analytics/utils.ts
@@ -48,9 +48,17 @@ export const reportPageview = () => {
 /**
  * Helper function to report interaction events to the {@link EchoSrv}.
  *
+ * @param options.silent - If true, the event is dispatched to EchoSrv subscribers
+ * but not forwarded to analytics backends. Use for high-frequency UI signals
+ * that downstream subscribers care about but shouldn't pollute the analytics stream.
+ *
  * @public
  */
-export const reportInteraction = (interactionName: string, properties?: Record<string, unknown>) => {
+export const reportInteraction = (
+  interactionName: string,
+  properties?: Record<string, unknown>,
+  options?: { silent?: boolean }
+) => {
   // get static reporting context and append it to properties
   if (config.reportingStaticContext && config.reportingStaticContext instanceof Object) {
     properties = { ...properties, ...config.reportingStaticContext };
@@ -60,6 +68,7 @@ export const reportInteraction = (interactionName: string, properties?: Record<s
     payload: {
       interactionName,
       properties,
+      silent: options?.silent,
     },
   });
 };

--- a/packages/grafana-runtime/src/internal/analyticsFramework/main.test.ts
+++ b/packages/grafana-runtime/src/internal/analyticsFramework/main.test.ts
@@ -1,0 +1,94 @@
+import { EchoEventType, getEchoSrv } from '../../services/EchoSrv';
+
+import { defineFeatureEvents } from './main';
+
+jest.mock('../../services/EchoSrv');
+jest.mock('../../config', () => ({
+  config: {},
+}));
+
+const mockAddEvent = jest.fn();
+jest.mocked(getEchoSrv).mockReturnValue({ addEvent: mockAddEvent } as unknown as ReturnType<typeof getEchoSrv>);
+
+describe('defineFeatureEvents', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.mocked(getEchoSrv).mockReturnValue({ addEvent: mockAddEvent } as unknown as ReturnType<typeof getEchoSrv>);
+  });
+
+  it('emits an interaction event with the prefixed name', () => {
+    const factory = defineFeatureEvents('grafana', 'feature_x');
+    const myEvent = factory('my_event');
+    myEvent();
+
+    expect(mockAddEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: EchoEventType.Interaction,
+        payload: expect.objectContaining({ interactionName: 'grafana_feature_x_my_event' }),
+      })
+    );
+  });
+
+  it('merges defaultProps into every event', () => {
+    interface Props {
+      [k: string]: string | number | boolean | null | undefined;
+      foo: string;
+    }
+    const factory = defineFeatureEvents('grafana', 'feature_x', { schema_version: 1 });
+    const myEvent = factory<Props>('my_event');
+    myEvent({ foo: 'bar' });
+
+    expect(mockAddEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({
+          properties: { schema_version: 1, foo: 'bar' },
+        }),
+      })
+    );
+  });
+
+  it('does not pass silent by default', () => {
+    const factory = defineFeatureEvents('grafana', 'feature_x');
+    const myEvent = factory('my_event');
+    myEvent();
+
+    expect(mockAddEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({ silent: undefined }),
+      })
+    );
+  });
+
+  it('marks every event as silent when factory options.silent = true', () => {
+    const factory = defineFeatureEvents('grafana', 'feature_x', undefined, { silent: true });
+    const eventA = factory('a');
+    const eventB = factory('b');
+    eventA();
+    eventB();
+
+    expect(mockAddEvent).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        payload: expect.objectContaining({ interactionName: 'grafana_feature_x_a', silent: true }),
+      })
+    );
+    expect(mockAddEvent).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        payload: expect.objectContaining({ interactionName: 'grafana_feature_x_b', silent: true }),
+      })
+    );
+  });
+
+  it('does not pass silent when factory options.silent = false', () => {
+    const factory = defineFeatureEvents('grafana', 'feature_x', undefined, { silent: false });
+    const myEvent = factory('my_event');
+    myEvent();
+
+    expect(mockAddEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({ silent: undefined }),
+      })
+    );
+  });
+});

--- a/packages/grafana-runtime/src/internal/analyticsFramework/main.test.ts
+++ b/packages/grafana-runtime/src/internal/analyticsFramework/main.test.ts
@@ -91,4 +91,46 @@ describe('defineFeatureEvents', () => {
       })
     );
   });
+
+  it('per-event silent: true overrides factory-level silent: false', () => {
+    const factory = defineFeatureEvents('grafana', 'feature_x', undefined, { silent: false });
+    const loud = factory('loud');
+    const silent = factory('silent', { silent: true });
+    loud();
+    silent();
+
+    expect(mockAddEvent).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        payload: expect.objectContaining({ interactionName: 'grafana_feature_x_loud', silent: undefined }),
+      })
+    );
+    expect(mockAddEvent).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        payload: expect.objectContaining({ interactionName: 'grafana_feature_x_silent', silent: true }),
+      })
+    );
+  });
+
+  it('per-event silent: false overrides factory-level silent: true', () => {
+    const factory = defineFeatureEvents('grafana', 'feature_x', undefined, { silent: true });
+    const loud = factory('loud', { silent: false });
+    const silent = factory('silent');
+    loud();
+    silent();
+
+    expect(mockAddEvent).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({
+        payload: expect.objectContaining({ interactionName: 'grafana_feature_x_loud', silent: undefined }),
+      })
+    );
+    expect(mockAddEvent).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({
+        payload: expect.objectContaining({ interactionName: 'grafana_feature_x_silent', silent: true }),
+      })
+    );
+  });
 });

--- a/packages/grafana-runtime/src/internal/analyticsFramework/main.ts
+++ b/packages/grafana-runtime/src/internal/analyticsFramework/main.ts
@@ -10,13 +10,20 @@ export const defineFeatureEvents = (
   repo: Event['repo'] = 'grafana',
   feature: Event['feature'],
   defaultProps?: EventProperty,
-  options?: DefineFeatureEventsOptions
+  factoryOptions?: DefineFeatureEventsOptions
 ) => {
-  return <P extends EventProperty | undefined = undefined>(eventName: string) =>
-    <A extends P extends EventProperty ? P : never>(props: P extends EventProperty ? Exact<P, A> : void) =>
+  return <P extends EventProperty | undefined = undefined>(
+      eventName: string,
+      eventOptions?: DefineFeatureEventsOptions
+    ) =>
+    <A extends P extends EventProperty ? P : never>(props: P extends EventProperty ? Exact<P, A> : void) => {
+      // Per-event silent overrides factory-level silent so a single factory
+      // can mix loud (analytics) and silent (CUJ-internal) events.
+      const silent = eventOptions?.silent ?? factoryOptions?.silent ?? false;
       reportInteraction(
         `${repo}_${feature}_${eventName}`,
         { ...defaultProps, ...(props ?? undefined) },
-        options?.silent ? { silent: true } : undefined
+        silent ? { silent: true } : undefined
       );
+    };
 };

--- a/packages/grafana-runtime/src/internal/analyticsFramework/main.ts
+++ b/packages/grafana-runtime/src/internal/analyticsFramework/main.ts
@@ -4,14 +4,19 @@
 
 import { reportInteraction } from '../../analytics/utils';
 
-import { type Exact, type Event, type EventProperty } from './types';
+import { type DefineFeatureEventsOptions, type Exact, type Event, type EventProperty } from './types';
 
 export const defineFeatureEvents = (
   repo: Event['repo'] = 'grafana',
   feature: Event['feature'],
-  defaultProps?: EventProperty
+  defaultProps?: EventProperty,
+  options?: DefineFeatureEventsOptions
 ) => {
   return <P extends EventProperty | undefined = undefined>(eventName: string) =>
     <A extends P extends EventProperty ? P : never>(props: P extends EventProperty ? Exact<P, A> : void) =>
-      reportInteraction(`${repo}_${feature}_${eventName}`, { ...defaultProps, ...(props ?? undefined) });
+      reportInteraction(
+        `${repo}_${feature}_${eventName}`,
+        { ...defaultProps, ...(props ?? undefined) },
+        options?.silent ? { silent: true } : undefined
+      );
 };

--- a/packages/grafana-runtime/src/internal/analyticsFramework/types.ts
+++ b/packages/grafana-runtime/src/internal/analyticsFramework/types.ts
@@ -42,3 +42,14 @@ export interface EventData extends Omit<Event, 'properties'> {
   owner?: string;
   properties?: EventPropertySchema[];
 }
+
+/**
+ * Factory-level options for {@link defineFeatureEvents}. `silent: true` marks
+ * every event produced by the factory as silent — dispatched to {@link EchoSrv}
+ * subscribers but not forwarded to analytics backends. Use for high-frequency
+ * UI signals that downstream subscribers (e.g. CUJ instrumentation) care about
+ * but shouldn't pollute the analytics stream.
+ */
+export interface DefineFeatureEventsOptions {
+  silent?: boolean;
+}

--- a/scripts/cli/analytics/eventParser.mts
+++ b/scripts/cli/analytics/eventParser.mts
@@ -13,6 +13,7 @@ import {
 
 import type { EventData, EventNamespace, EventPropertySchema, JSDocMetadata } from './types.mts';
 
+import { extractSilentFromOptions } from './findAllEvents.mts';
 import { getMetadataFromJSDocs, getJsDocsFromNode, resolveType } from './typeResolution.mts';
 import { resolveOwner } from './codeowners.mts';
 
@@ -63,10 +64,15 @@ const parseEventFromCall = (
     return null;
   }
 
-  const [arg, ...restArgs] = callExpr.getArguments();
+  const [arg, eventOptionsArg, ...restArgs] = callExpr.getArguments();
   if (!arg || !Node.isStringLiteral(arg) || restArgs.length > 0) {
-    throw new Error(`Expected ${fnName} to be called with only 1 string literal argument`);
+    throw new Error(`Expected ${fnName} to be called with a string literal name and an optional options object`);
   }
+
+  // Per-event silent (`factory(name, { silent: true })`) overrides the
+  // factory-level setting. Falls back to factoryOptions.silent if not present.
+  const eventSilent = eventOptionsArg ? extractSilentFromOptions(eventOptionsArg) : undefined;
+  const silent = eventSilent ?? eventNamespace.silent;
 
   const metadata = parseEventMetadata(callExpr);
   if (!metadata.description) {
@@ -102,6 +108,7 @@ const parseEventFromCall = (
     description: metadata.description,
     owner: metadata.owner,
     properties: mergedProperties,
+    silent,
   };
 };
 

--- a/scripts/cli/analytics/findAllEvents.mts
+++ b/scripts/cli/analytics/findAllEvents.mts
@@ -1,4 +1,4 @@
-import { Node, type SourceFile } from 'ts-morph';
+import { Node, SyntaxKind, type SourceFile } from 'ts-morph';
 
 import type { EventData, EventNamespace, EventPropertySchema } from './types.mts';
 
@@ -79,7 +79,7 @@ const findEventNamespaces = (sourceFile: SourceFile, defineFeatureEventsName: st
     }
 
     // Extract the two required string literal args: ('grafana', 'navigation')
-    const [repoArg, featureArg, defaultPropsArg] = initializer.getArguments();
+    const [repoArg, featureArg, defaultPropsArg, factoryOptionsArg] = initializer.getArguments();
     if (!repoArg || !featureArg || !Node.isStringLiteral(repoArg) || !Node.isStringLiteral(featureArg)) {
       throw new Error(
         `defineFeatureEvents must be called with two string literal arguments at ${sourceFile.getFilePath()}`
@@ -109,14 +109,49 @@ const findEventNamespaces = (sourceFile: SourceFile, defineFeatureEventsName: st
       });
     }
 
+    // Extract the optional fourth argument: factoryOptions.silent.
+    // e.g. defineFeatureEvents('grafana', 'cuj', undefined, { silent: true })
+    // marks every event from this factory as silent unless overridden per-event.
+    const silent = factoryOptionsArg ? extractSilentFromOptions(factoryOptionsArg) : undefined;
+
     const factoryName = variableDecl.getName();
     namespaces.set(factoryName, {
       factoryName,
       eventPrefixProject: repoArg.getLiteralText(), // "grafana"
       eventPrefixFeature: featureArg.getLiteralText(), // "navigation"
       defaultProperties,
+      silent,
     });
   }
 
   return namespaces;
+};
+
+/**
+ * Extracts `silent` from an object literal like `{ silent: true }`. Returns
+ * undefined when the property is missing, not a boolean literal, or the
+ * argument is not an object literal at all (e.g. `undefined`, a variable).
+ */
+export const extractSilentFromOptions = (optionsArg: Node): boolean | undefined => {
+  if (!Node.isObjectLiteralExpression(optionsArg)) {
+    return undefined;
+  }
+
+  const silentProperty = optionsArg.getProperty('silent');
+  if (!silentProperty || !Node.isPropertyAssignment(silentProperty)) {
+    return undefined;
+  }
+
+  const initializer = silentProperty.getInitializer();
+  if (!initializer) {
+    return undefined;
+  }
+
+  if (initializer.getKind() === SyntaxKind.TrueKeyword) {
+    return true;
+  }
+  if (initializer.getKind() === SyntaxKind.FalseKeyword) {
+    return false;
+  }
+  return undefined;
 };

--- a/scripts/cli/analytics/generateMarkdown.mts
+++ b/scripts/cli/analytics/generateMarkdown.mts
@@ -47,9 +47,14 @@ export const formatEventAsMarkdown = (event: EventData): string => {
 };
 
 export async function formatEventsAsMarkdown(events: EventData[]): Promise<string> {
+  // Silent events are subscriber-only and never forwarded to analytics backends,
+  // so they don't belong in a Rudderstack-facing registry. The silent flag is
+  // still preserved on EventData for non-markdown consumers (e.g. JSON output).
+  const reportableEvents = events.filter((event) => !event.silent);
+
   const byFeature: Record<string, EventData[]> = {};
 
-  for (const event of events) {
+  for (const event of reportableEvents) {
     const feature = event.feature;
     byFeature[feature] = byFeature[feature] ?? [];
     byFeature[feature].push(event);

--- a/scripts/cli/analytics/silent.test.mts
+++ b/scripts/cli/analytics/silent.test.mts
@@ -1,0 +1,202 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+
+import { Project, type SourceFile } from 'ts-morph';
+
+import { findAllEvents } from './findAllEvents.mts';
+import { formatEventsAsMarkdown } from './generateMarkdown.mts';
+
+const FAKE_RUNTIME = `
+  export type EventProperty = Record<string, unknown>;
+  export interface DefineFeatureEventsOptions { silent?: boolean }
+  type Factory = <P extends EventProperty | undefined = undefined>(
+    eventName: string,
+    eventOptions?: DefineFeatureEventsOptions
+  ) => (props: P extends undefined ? void : P) => void;
+  export const defineFeatureEvents: (
+    repo: string,
+    feature: string,
+    defaultProps?: EventProperty,
+    factoryOptions?: DefineFeatureEventsOptions
+  ) => Factory = (() => () => () => {}) as never;
+`;
+
+const buildProject = (sources: Record<string, string>) => {
+  const project = new Project({
+    useInMemoryFileSystem: true,
+    compilerOptions: { strict: false, target: 99, module: 99 },
+  });
+  project.createSourceFile('runtime.ts', FAKE_RUNTIME);
+  const files: SourceFile[] = [];
+  for (const [name, content] of Object.entries(sources)) {
+    files.push(project.createSourceFile(name, content));
+  }
+  return files;
+};
+
+const findEvent = (events: ReturnType<typeof findAllEvents>, name: string) => {
+  const event = events.find((e) => e.eventName === name);
+  if (!event) {
+    throw new Error(`event ${name} not found`);
+  }
+  return event;
+};
+
+describe('analytics report — silent extraction', () => {
+  it('marks per-event silent: true (loud factory + silent override)', () => {
+    const files = buildProject({
+      'feature.ts': `
+        import { defineFeatureEvents } from './runtime';
+        const factory = defineFeatureEvents('grafana', 'mixed');
+        /**
+         * Loud event.
+         * @owner grafana-test
+         */
+        export const loud = factory('loud_event');
+        /**
+         * Silent override.
+         * @owner grafana-test
+         */
+        export const silent = factory('silent_event', { silent: true });
+      `,
+    });
+
+    const events = findAllEvents(files, './runtime');
+
+    assert.equal(findEvent(events, 'loud_event').silent, undefined);
+    assert.equal(findEvent(events, 'silent_event').silent, true);
+  });
+
+  it('inherits factory-level silent: true on all events', () => {
+    const files = buildProject({
+      'feature.ts': `
+        import { defineFeatureEvents } from './runtime';
+        const factory = defineFeatureEvents('grafana', 'cuj', undefined, { silent: true });
+        /**
+         * Inherited silent.
+         * @owner grafana-test
+         */
+        export const a = factory('a');
+        /**
+         * Also inherited.
+         * @owner grafana-test
+         */
+        export const b = factory('b');
+      `,
+    });
+
+    const events = findAllEvents(files, './runtime');
+
+    assert.equal(findEvent(events, 'a').silent, true);
+    assert.equal(findEvent(events, 'b').silent, true);
+  });
+
+  it('per-event silent: false overrides factory-level silent: true', () => {
+    const files = buildProject({
+      'feature.ts': `
+        import { defineFeatureEvents } from './runtime';
+        const factory = defineFeatureEvents('grafana', 'cuj', undefined, { silent: true });
+        /**
+         * Inherited silent.
+         * @owner grafana-test
+         */
+        export const inherited = factory('inherited');
+        /**
+         * Override back to loud.
+         * @owner grafana-test
+         */
+        export const loud = factory('loud_override', { silent: false });
+      `,
+    });
+
+    const events = findAllEvents(files, './runtime');
+
+    assert.equal(findEvent(events, 'inherited').silent, true);
+    assert.equal(findEvent(events, 'loud_override').silent, false);
+  });
+
+  it('treats omitted silent as undefined', () => {
+    const files = buildProject({
+      'feature.ts': `
+        import { defineFeatureEvents } from './runtime';
+        const factory = defineFeatureEvents('grafana', 'plain');
+        /**
+         * No options.
+         * @owner grafana-test
+         */
+        export const a = factory('a');
+      `,
+    });
+
+    const events = findAllEvents(files, './runtime');
+
+    assert.equal(findEvent(events, 'a').silent, undefined);
+  });
+
+  it('omits silent events from the markdown report entirely', async () => {
+    const files = buildProject({
+      'feature.ts': `
+        import { defineFeatureEvents } from './runtime';
+        const factory = defineFeatureEvents('grafana', 'feature_x');
+        /**
+         * Loud event.
+         * @owner grafana-test
+         */
+        export const loud = factory('loud_event');
+        /**
+         * Silent event.
+         * @owner grafana-test
+         */
+        export const quiet = factory('silent_event', { silent: true });
+      `,
+    });
+
+    const events = findAllEvents(files, './runtime');
+    const markdown = await formatEventsAsMarkdown(events);
+
+    assert.match(markdown, /grafana_feature_x_loud_event/);
+    assert.doesNotMatch(markdown, /grafana_feature_x_silent_event/);
+  });
+
+  it('drops a feature section entirely when all its events are silent', async () => {
+    const files = buildProject({
+      'feature.ts': `
+        import { defineFeatureEvents } from './runtime';
+        const factory = defineFeatureEvents('grafana', 'all_silent', undefined, { silent: true });
+        /**
+         * Inherited silent.
+         * @owner grafana-test
+         */
+        export const a = factory('a');
+        /**
+         * Also inherited.
+         * @owner grafana-test
+         */
+        export const b = factory('b');
+      `,
+    });
+
+    const events = findAllEvents(files, './runtime');
+    const markdown = await formatEventsAsMarkdown(events);
+
+    assert.doesNotMatch(markdown, /all_silent/);
+  });
+
+  it('preserves silent on EventData for non-markdown consumers', () => {
+    const files = buildProject({
+      'feature.ts': `
+        import { defineFeatureEvents } from './runtime';
+        const factory = defineFeatureEvents('grafana', 'feature_x');
+        /**
+         * Silent event.
+         * @owner grafana-test
+         */
+        export const quiet = factory('silent_event', { silent: true });
+      `,
+    });
+
+    const events = findAllEvents(files, './runtime');
+
+    assert.equal(findEvent(events, 'silent_event').silent, true);
+  });
+});

--- a/scripts/cli/analytics/types.mts
+++ b/scripts/cli/analytics/types.mts
@@ -27,6 +27,9 @@ export interface EventNamespace {
   // Properties that are merged into every event in this namespace via the third
   // argument of defineFeatureEvents (e.g. { schema_version: 1 })
   defaultProperties?: EventPropertySchema[];
+  // Factory-level silent setting from the fourth argument of defineFeatureEvents.
+  // Every event from this factory inherits this unless overridden per-event.
+  silent?: boolean;
 }
 
 // The full event descriptor produced by the script
@@ -34,6 +37,10 @@ export interface EventData extends Omit<Event, 'properties'> {
   fullEventName: string;
   owner?: string;
   properties?: EventPropertySchema[];
+  // Silent events are dispatched to EchoSrv subscribers but not forwarded to
+  // analytics backends (e.g. Rudderstack). Resolved from per-event options
+  // first, falling back to the factory-level setting.
+  silent?: boolean;
 }
 
 export interface JSDocMetadata {


### PR DESCRIPTION
Adds optional `silent` flag to `reportInteraction` and `defineFeatureEvents`. When `silent: true`, events go to `EchoSrv` subscribers but not analytics backends — for high-frequency UI signals that downstream subscribers (CUJ instrumentation) care about but shouldn't pollute Rudderstack.

Extracted from #123719 so the framework change isn't tangled with CUJ work.

## Usage

```ts
// Loud (default) — analytics + subscribers
const events = defineFeatureEvents('grafana', 'dashboard');
events('opened')();

// Silent factory — every event subscriber-only
const cuj = defineFeatureEvents('grafana', 'cuj', undefined, { silent: true });
cuj('step_start')();

// Mixed — per-event override wins over factory default
const search = defineFeatureEvents('grafana', 'search');
search('submitted')();                      // loud
search('keystroke', { silent: true })();    // silent
```

Direct `reportInteraction` use also accepts the flag:

```ts
reportInteraction('grafana_search_keystroke', { len: 3 }, { silent: true });
```

## Notes

- Framework is `@alpha`, additive change. Existing callers unaffected.
- `DefineFeatureEventsOptions` lives in `analyticsFramework/types.ts` to stay clear of the `@grafana/define-feature-events` ESLint rule.
