### PR TITLE
Zanzana: Lock database during OpenFGA migrations

### DIFF
--- a/pkg/services/authz/zanzana/store/migration/migrator.go
+++ b/pkg/services/authz/zanzana/store/migration/migrator.go
@@ -7,14 +7,15 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/openfga/openfga/pkg/storage/migrate"
+	"github.com/pressly/goose/v3"
+
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/sqlstore"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/util/xorm"
-	"github.com/openfga/openfga/pkg/storage/migrate"
-	"github.com/pressly/goose/v3"
 )
 
 var (
@@ -51,7 +52,7 @@ func Run(cfg *setting.Cfg, dbType string, grafanaDBConfig *sqlstore.DatabaseConf
 		Engine: dbType,
 	}
 
-	if err := runOpenFGAMigrations(migrationConfig, logger); err != nil {
+	if err := runOpenFGAMigrationsLocked(engine, m.Dialect, cfg, migrationConfig, logger); err != nil {
 		return fmt.Errorf("failed to run openfga migrations: %w", err)
 	}
 
@@ -60,6 +61,59 @@ func Run(cfg *setting.Cfg, dbType string, grafanaDBConfig *sqlstore.DatabaseConf
 	}
 
 	return nil
+}
+
+// runOpenFGAMigrationsLocked acquires the same advisory lock that Grafana's
+// main migrator uses for this database and runs the openfga migrations under
+// it. openfga's goose migrator has no cross-process locking of its own, so
+// without this wrapper concurrent pod startups race on schema creation.
+//
+// The lock is server-wide (MySQL GET_LOCK / Postgres pg_advisory_lock), so it
+// serializes correctly even though the openfga goose driver opens its own
+// database connection. For SQLite Dialect.Lock is a no-op, which is fine
+// because SQLite deployments are single-process.
+func runOpenFGAMigrationsLocked(
+	engine *xorm.Engine,
+	dialect migrator.Dialect,
+	cfg *setting.Cfg,
+	migrationConfig migrate.MigrationConfig,
+	logger log.Logger,
+) error {
+	sec := cfg.Raw.Section("database")
+	if !sec.Key("migration_locking").MustBool(true) {
+		return runOpenFGAMigrations(migrationConfig, logger)
+	}
+
+	dbName, err := dialect.GetDBName(engine.DataSourceName())
+	if err != nil {
+		return fmt.Errorf("failed to derive db name for advisory lock: %w", err)
+	}
+	// Reuse the same key as Grafana's main migrator (no additional name) so
+	// openfga and Grafana migrations are mutually exclusive per database.
+	key, err := migrator.GenerateAdvisoryLockID(dbName)
+	if err != nil {
+		return fmt.Errorf("failed to generate advisory lock id: %w", err)
+	}
+
+	lockCfg := migrator.LockCfg{
+		Session: engine.NewSession(),
+		Key:     key,
+		Timeout: sec.Key("locking_attempt_timeout_sec").MustInt(30),
+	}
+	defer lockCfg.Session.Close()
+
+	logger.Info("Locking database for openfga migrations", "key", key)
+	if err := dialect.Lock(lockCfg); err != nil {
+		return fmt.Errorf("failed to acquire openfga migration lock: %w", err)
+	}
+	defer func() {
+		logger.Info("Unlocking database after openfga migrations")
+		if err := dialect.Unlock(lockCfg); err != nil {
+			logger.Warn("failed to release openfga migration lock", "error", err)
+		}
+	}()
+
+	return runOpenFGAMigrations(migrationConfig, logger)
 }
 
 func runOpenFGAMigrations(migrationConfig migrate.MigrationConfig, logger log.Logger) error {


### PR DESCRIPTION
## Summary

- Wrap the OpenFGA goose migrator in the same advisory lock Grafana's main migrator uses (`Dialect.Lock`/`Unlock` with the per-database key from `migrator.GenerateAdvisoryLockID`).
- Without this, concurrent pod startups race on schema creation: the OpenFGA goose driver opens its own DB connection and has no cross-process locking of its own.
- Honors `database.migration_locking` and `database.locking_attempt_timeout_sec` to match the existing Grafana migrator behavior. SQLite `Lock` is a no-op, which is fine since SQLite deployments are single-process.

## Test plan

- [ ] Unit tests still pass: `go test ./pkg/services/authz/zanzana/...`
- [ ] Manual: start two Grafana instances simultaneously against a fresh MySQL/Postgres DB and confirm only one runs the OpenFGA migrations while the other waits.
- [ ] Verify SQLite startup is unaffected (single-process, lock is a no-op).
- [ ] Verify `migration_locking = false` bypasses the lock.