### PR TITLE
Chore: Remove JS code for grafana.meticulousAIRecorder

### DIFF
--- a/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
@@ -37,8 +37,7 @@ declare module "@openfeature/core" {
     | "datasources.config.ui.useNewDatasourceCRUDAPIs"
     | "datasources.apiserver.useNewAPIsForDatasourceResources"
     | "reporting.anyPageReporting"
-    | "assistant.frontend.tools.dashboardTemplates"
-    | "grafana.meticulousAIRecorder";
+    | "assistant.frontend.tools.dashboardTemplates";
   export type NumberFlagKey = never;
   export type StringFlagKey = never;
   export type ObjectFlagKey = never;

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -35,8 +35,6 @@ export const FlagKeys = {
   FaroSessionReplay: "faroSessionReplay",
   /** Enables the new Flame Graph UI containing the Call Tree view */
   FlameGraphWithCallTree: "flameGraphWithCallTree",
-  /** Enable Meticulous AI session recorder for automated UI test generation */
-  GrafanaMeticulousAIRecorder: "grafana.meticulousAIRecorder",
   /** Whether to use the new SharedPreferences functional component */
   GrafanaNewPreferencesPage: "grafana.newPreferencesPage",
   /** Enables an inline version of Log Details that creates no new scrolls */
@@ -192,17 +190,6 @@ export const useFlagFaroSessionReplay = (options?: ReactFlagEvaluationOptions): 
  */
 export const useFlagFlameGraphWithCallTree = (options?: ReactFlagEvaluationOptions): boolean => {
   return useFlag("flameGraphWithCallTree", false, options).value;
-};
-
-/**
- * Enable Meticulous AI session recorder for automated UI test generation
- *
- * **Details:**
- * - flag key: `grafana.meticulousAIRecorder`
- * - default value: `false`
- */
-export const useFlagGrafanaMeticulousAIRecorder = (options?: ReactFlagEvaluationOptions): boolean => {
-  return useFlag("grafana.meticulousAIRecorder", false, options).value;
 };
 
 /**

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -3084,7 +3084,7 @@ var (
 			Owner:        grafanaDatavizSquad,
 			Expression:   "false",
 			HideFromDocs: true,
-			Generate:     Generate{React: true, Go: true},
+			Generate:     Generate{Go: true},
 		},
 		// tl;dr: name your new flag `component.featureName`, specify Go and/or React generation targets, and use with OpenFeature!
 		//


### PR DESCRIPTION
with the presence of the `window.__meticulous` object, we don't need to have the flag in the frontend, but instead can detect the presence of the object when deciding how to disable recording in any frontend code.