### PR TITLE
Correlations: Ensure adding an external correlation does not add target datasource data

### DIFF
--- a/public/app/features/correlations/utils.test.ts
+++ b/public/app/features/correlations/utils.test.ts
@@ -12,7 +12,7 @@ import { type DataQuery } from '@grafana/schema/dist/esm/index';
 import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
 import { type ExploreItemState } from 'app/types/explore';
 
-import { type EditFormDTO } from './Forms/types';
+import { type EditFormDTO, type FormDTO } from './Forms/types';
 import { type Correlation } from './types';
 import { attachCorrelationsToDataFrames, generateDefaultLabel, generatePartialEditSpec } from './utils';
 import * as utils from './utils';
@@ -226,6 +226,20 @@ describe('correlations utils', () => {
     } as unknown as ExploreItemState;
     const label = await generateDefaultLabel(sourcePane, targetPane);
     expect(label).toBe('getTest to testB');
+  });
+
+  it('does not add target data when the correlation is external', async () => {
+    const addForm = {
+      config: { field: 'test', target: { url: 'test' } },
+      sourceUID: 'test',
+      label: 'test',
+      description: 'test',
+      targetUID: undefined,
+      type: 'external',
+    };
+    // this mimics the real scenario this form gets in, even though it is technically invalid (external types shouldn't have the targetUID property)
+    const addSpec = await utils.generateAddSpec(addForm as FormDTO);
+    expect(addSpec.target).not.toBeDefined();
   });
   describe('getCorrelationsFromStorage', () => {
     const originalFeatureToggles = config.featureToggles;

--- a/public/app/features/correlations/utils.ts
+++ b/public/app/features/correlations/utils.ts
@@ -185,7 +185,7 @@ export const generateAddSpec = async (data: FormDTO): Promise<CorrelationSpec> =
   const dsSrv = getDataSourceSrv();
   const sourceDs = await dsSrv.get(data.sourceUID);
   let targetDs;
-  if ('targetUID' in data) {
+  if ('targetUID' in data && data.targetUID !== undefined) {
     targetDs = await dsSrv.get(data.targetUID!);
   }
 


### PR DESCRIPTION
This fixes a bug found while testing correlations and app platform in https://github.com/grafana/grafana/pull/123178 

The FormDTO type has two types: query and external. For external correlations, we do not have a target datasource, as the correlation builds a URL.

The Form object entering this function to generate the add spec has the `targetUID` field as undefined, and that datasource.get still returns the default datasource as a value even if the uid is undefined, so we end up saving external correlations with target datasource data.

This test is not great, because any typecasting on this will remove the targetUID property, but still added a test for future proofing. 

If you'd like to test this, add a Correlation through the Admin page that is of type external, with the `kubernetesCorrelations` flag on. The save object sent to app platform will contain target datasource data, when it should be omitted.