### PR TITLE
Analytics Framework: Fix property types in the report

### DIFF
--- a/scripts/cli/analytics/typeResolution.mts
+++ b/scripts/cli/analytics/typeResolution.mts
@@ -51,6 +51,13 @@ export function resolveType(type: Type): string {
     return `"${type.getLiteralValue()}"`;
   }
 
+  // Without this, mapped types like Exact<P, A> make properties look like A["key"]
+  // in the report instead of their actual type. Getting the constraint resolves that.
+  const constraint = type.getConstraint();
+  if (constraint) {
+    return resolveType(constraint);
+  }
+
   return type.getText(); // Default to the type's text representation
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Fix the property types shown in the analytics report.

**Why do we need this feature?**
To be able to show the proper type in the properties table.

**Who is this feature for?**
Anyone using the analytics report

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Before:
**Properties**:

| name           | type                  | description                                                                              |
| -------------- | --------------------- | ---------------------------------------------------------------------------------------- |
| schema_version | `number`              | Version of the event schema, used to handle breaking changes in the properties contract. |
| dashboardId    | `A["dashboardId"]`    | Unique identifier of the dashboard being checked.                                        |
| dashboardTitle | `A["dashboardTitle"]` | Display title of the dashboard being checked.                                            |
| datasourceType | `A["datasourceType"]` | Plugin ID of the data source being evaluated for compatibility.                          |
| triggerMethod  | `A["triggerMethod"]`  | Whether the check was started by the user or automatically on page load.                 |
| eventLocation  | `A["eventLocation"]`  | The specific UI location within the product where the check was triggered.               |

After:

**Properties**:

| name           | type                                                                                                       | description                                                                              |
| -------------- | ---------------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------- |
| schema_version | `number`                                                                                                   | Version of the event schema, used to handle breaking changes in the properties contract. |
| dashboardId    | `string`                                                                                                   | Unique identifier of the dashboard being checked.                                        |
| dashboardTitle | `string`                                                                                                   | Display title of the dashboard being checked.                                            |
| datasourceType | `string`                                                                                                   | Plugin ID of the data source being evaluated for compatibility.                          |
| triggerMethod  | `"manual" \| "auto_initial_load"`                                                                          | Whether the check was started by the user or automatically on page load.                 |
| eventLocation  | `"dashboard_page_suggested_dashboards_banner" \| "suggested_dashboards_modal" \| "browse_dashboards_page"` | The specific UI location within the product where the check was triggered.               |

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
