### PR TITLE
unified-storage: make badgerKV honour context cancelation in every function

### DIFF
--- a/pkg/storage/unified/resource/kv/kv.go
+++ b/pkg/storage/unified/resource/kv/kv.go
@@ -161,6 +161,9 @@ func (k *badgerKV) Get(ctx context.Context, section string, key string) (io.Read
 	if key == "" {
 		return nil, fmt.Errorf("key is required")
 	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 
 	key = section + "/" + key
 
@@ -244,6 +247,7 @@ func (k *badgerKV) BatchGet(ctx context.Context, section string, keys []string) 
 // badgerWriteCloser implements io.WriteCloser for badgerKV
 type badgerWriteCloser struct {
 	db             *badger.DB
+	ctx            context.Context
 	keyWithSection string
 	buf            *bytes.Buffer
 	closed         bool
@@ -253,6 +257,9 @@ type badgerWriteCloser struct {
 func (w *badgerWriteCloser) Write(p []byte) (int, error) {
 	if w.closed {
 		return 0, fmt.Errorf("write to closed writer")
+	}
+	if err := w.ctx.Err(); err != nil {
+		return 0, err
 	}
 	return w.buf.Write(p)
 }
@@ -264,6 +271,9 @@ func (w *badgerWriteCloser) Close() error {
 	}
 	w.closed = true
 
+	if err := w.ctx.Err(); err != nil {
+		return err
+	}
 	if w.db.IsClosed() {
 		return fmt.Errorf("database is closed")
 	}
@@ -295,9 +305,13 @@ func (k *badgerKV) Save(ctx context.Context, section string, key string) (io.Wri
 	if key == "" {
 		return nil, fmt.Errorf("key is required")
 	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
 
 	return &badgerWriteCloser{
 		db:             k.db,
+		ctx:            ctx,
 		keyWithSection: section + "/" + key,
 		buf:            &bytes.Buffer{},
 		closed:         false,
@@ -314,6 +328,9 @@ func (k *badgerKV) Delete(ctx context.Context, section string, key string) error
 	}
 	if key == "" {
 		return fmt.Errorf("key is required")
+	}
+	if err := ctx.Err(); err != nil {
+		return err
 	}
 
 	txn := k.db.NewTransaction(true)
@@ -457,6 +474,9 @@ func (k *badgerKV) BatchDelete(ctx context.Context, section string, keys []strin
 }
 
 func (k *badgerKV) Batch(ctx context.Context, section string, ops []BatchOp) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
 	if k.db.IsClosed() {
 		return fmt.Errorf("database is closed")
 	}
@@ -478,7 +498,10 @@ func (k *badgerKV) Batch(ctx context.Context, section string, ops []BatchOp) err
 	const maxRetryJitter = 100 * time.Millisecond
 	var lastConflict error
 	for attempt := range maxAttempts {
-		err := k.batchOnce(section, ops)
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		err := k.batchOnce(ctx, section, ops)
 		if errors.Is(err, badger.ErrConflict) {
 			lastConflict = err
 			if attempt < maxAttempts-1 {
@@ -493,11 +516,14 @@ func (k *badgerKV) Batch(ctx context.Context, section string, ops []BatchOp) err
 	return fmt.Errorf("after %d attempts: %w", maxAttempts, lastConflict)
 }
 
-func (k *badgerKV) batchOnce(section string, ops []BatchOp) error {
+func (k *badgerKV) batchOnce(ctx context.Context, section string, ops []BatchOp) error {
 	txn := k.db.NewTransaction(true)
 	defer txn.Discard()
 
 	for i, op := range ops {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
 		keyWithSection := section + "/" + op.Key
 
 		switch op.Mode {

--- a/pkg/storage/unified/resource/kv/kv_test.go
+++ b/pkg/storage/unified/resource/kv/kv_test.go
@@ -637,6 +637,75 @@ func TestBadgerKV_ContextCancellation(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("Get: pre-cancelled ctx returns error", func(t *testing.T) {
+		kv := setupTestKV(t)
+		keys := seed(t, kv, 1)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		_, err := kv.Get(ctx, section, keys[0])
+		require.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("Save: pre-cancelled ctx returns error", func(t *testing.T) {
+		kv := setupTestKV(t)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		writer, err := kv.Save(ctx, section, "save-cancelled")
+		require.ErrorIs(t, err, context.Canceled)
+		require.Nil(t, writer)
+	})
+
+	t.Run("Save writer: cancellation before close returns error and saves nothing", func(t *testing.T) {
+		kv := setupTestKV(t)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		writer, err := kv.Save(ctx, section, "save-writer-cancelled")
+		require.NoError(t, err)
+		_, err = writer.Write([]byte("value"))
+		require.NoError(t, err)
+
+		cancel()
+
+		err = writer.Close()
+		require.ErrorIs(t, err, context.Canceled)
+
+		_, err = kv.Get(context.Background(), section, "save-writer-cancelled")
+		require.ErrorIs(t, err, ErrNotFound)
+	})
+
+	t.Run("Delete: pre-cancelled ctx returns error and deletes nothing", func(t *testing.T) {
+		kv := setupTestKV(t)
+		keys := seed(t, kv, 1)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		err := kv.Delete(ctx, section, keys[0])
+		require.ErrorIs(t, err, context.Canceled)
+
+		_, err = kv.Get(context.Background(), section, keys[0])
+		require.NoError(t, err)
+	})
+
+	t.Run("Batch: pre-cancelled ctx returns error and applies nothing", func(t *testing.T) {
+		kv := setupTestKV(t)
+
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		err := kv.Batch(ctx, section, []BatchOp{
+			{Mode: BatchOpPut, Key: "batch-cancelled", Value: []byte("value")},
+		})
+		require.ErrorIs(t, err, context.Canceled)
+
+		_, err = kv.Get(context.Background(), section, "batch-cancelled")
+		require.ErrorIs(t, err, ErrNotFound)
+	})
+
 	t.Run("sanity: errors.Is matches context.Canceled", func(t *testing.T) {
 		// Guards against a future change wrapping ctx.Err() into an opaque
 		// error type that breaks errors.Is for callers (e.g. retry logic).


### PR DESCRIPTION
This extends the work done in #123748 by making the `badgerKV` implementation honour context cancelation in every function in the KV interface (except `UnixTimestamp`, intentionally).