### PR TITLE
TeamSearch: Chore: skip TestTeamSearchFallback

### DIFF
--- a/pkg/registry/apis/iam/team_search_test.go
+++ b/pkg/registry/apis/iam/team_search_test.go
@@ -31,6 +31,8 @@ import (
 )
 
 func TestTeamSearchFallback(t *testing.T) {
+	t.Skip("Skipping team search fallback test: https://github.com/grafana/identity-access-team/issues/2048")
+
 	testCases := []struct {
 		name                  string
 		mode                  rest.DualWriterMode


### PR DESCRIPTION
Skipping the flaky test `TeamSearch`.
Created the task on @grafana/identity-squad to address it https://github.com/grafana/identity-access-team/issues/2048

more info: https://raintank-corp.slack.com/archives/C05PJJ5JFAP/p1777557726181239