### PR TITLE
Time Range: Remove timeRangePan feature flag from code

### DIFF
--- a/e2e-playwright/panels-suite/heatmap.spec.ts
+++ b/e2e-playwright/panels-suite/heatmap.spec.ts
@@ -182,7 +182,6 @@ test.describe('Panels test: Heatmap', { tag: ['@panels', '@heatmap'] }, () => {
 
 test.use({
   featureToggles: {
-    timeRangePan: true,
     dashboardNewLayouts: false,
   },
 });

--- a/e2e-playwright/panels-suite/state-timeline.spec.ts
+++ b/e2e-playwright/panels-suite/state-timeline.spec.ts
@@ -98,12 +98,6 @@ test.describe('Panels test: StateTimeine', { tag: ['@panels', '@state-timeline']
   });
 });
 
-test.use({
-  featureToggles: {
-    timeRangePan: true,
-  },
-});
-
 test.describe('Panels test: State Timeline X-axis panning', { tag: ['@panels', '@state-timeline'] }, () => {
   test('x-axis panning functionality', async ({ gotoDashboardPage, page, selectors }) => {
     let centerX: number;

--- a/e2e-playwright/panels-suite/status-history.spec.ts
+++ b/e2e-playwright/panels-suite/status-history.spec.ts
@@ -96,12 +96,6 @@ test.describe('Panels test: StatusHistory', { tag: ['@panels', '@status-history'
   });
 });
 
-test.use({
-  featureToggles: {
-    timeRangePan: true,
-  },
-});
-
 test.describe('Panels test: Status History X-axis panning', { tag: ['@panels', '@status-history'] }, () => {
   test('x-axis panning functionality', async ({ gotoDashboardPage, page, selectors }) => {
     let centerX: number;

--- a/e2e-playwright/panels-suite/timeseries.spec.ts
+++ b/e2e-playwright/panels-suite/timeseries.spec.ts
@@ -120,12 +120,6 @@ test.describe('Panels test: TimeSeries', { tag: ['@panels', '@timeseries'] }, ()
   });
 });
 
-test.use({
-  featureToggles: {
-    timeRangePan: true,
-  },
-});
-
 test.describe('Panels test: TimeSeries X-axis panning', { tag: ['@panels', '@timeseries'] }, () => {
   test('x-axis panning functionality', async ({ gotoDashboardPage, page, selectors }) => {
     let centerX: number;

--- a/packages/grafana-ui/src/components/uPlot/plugins/XAxisInteractionAreaPlugin.test.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/XAxisInteractionAreaPlugin.test.tsx
@@ -1,8 +1,6 @@
 import { render } from '@testing-library/react';
 import type uPlot from 'uplot';
 
-import type { BootData } from '@grafana/data';
-
 import { UPlotConfigBuilder, type UPlotConfigBuilder as UPlotConfigBuilderType } from '../config/UPlotConfigBuilder';
 
 import { calculatePanRange, setupXAxisPan, XAxisInteractionAreaPlugin } from './XAxisInteractionAreaPlugin';
@@ -175,17 +173,7 @@ describe('XAxisInteractionAreaPlugin', () => {
   });
 
   describe('event listeners', () => {
-    let prevBootData: typeof window.grafanaBootData;
-
-    beforeEach(() => {
-      prevBootData = window.grafanaBootData;
-      window.grafanaBootData = {
-        settings: { featureToggles: { timeRangePan: true } },
-      } as BootData;
-    });
-
     afterEach(() => {
-      window.grafanaBootData = prevBootData;
       document.body.innerHTML = '';
     });
 

--- a/packages/grafana-ui/src/components/uPlot/plugins/XAxisInteractionAreaPlugin.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/XAxisInteractionAreaPlugin.tsx
@@ -1,7 +1,6 @@
 import { useLayoutEffect } from 'react';
 import uPlot from 'uplot';
 
-import { getFeatureToggle } from '../../../utils/featureToggle';
 import { type UPlotConfigBuilder } from '../config/UPlotConfigBuilder';
 
 const MIN_PAN_DIST = 5;
@@ -151,7 +150,7 @@ export const XAxisInteractionAreaPlugin = ({ config, queryZoom }: XAxisInteracti
     let cleanup: (() => void) | undefined;
 
     config.addHook('init', (u) => {
-      if (queryZoom != null && getFeatureToggle('timeRangePan')) {
+      if (queryZoom != null) {
         cleanup = setupXAxisPan(u, config, queryZoom);
       }
     });


### PR DESCRIPTION
This PR removes references/checks for \`timeRangePan\` from code, assuming the flag is permanently enabled.

Time range panning on the x-axis is now always active.

The flag definition itself is intentionally kept and will be removed in a separate step for architectural reasons.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.