### PR TITLE
Time Range: Remove newTimeRangeZoomShortcuts feature flag from code

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.test.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-import { dateTime, makeTimeRange, type TimeRange, type BootData } from '@grafana/data';
+import { dateTime, makeTimeRange, type TimeRange } from '@grafana/data';
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors';
 
 import { TimeRangeProvider } from './TimeRangeContext';
@@ -154,41 +154,7 @@ it('does not submit wrapping forms', async () => {
   expect(onSubmit).not.toHaveBeenCalled();
 });
 
-it('shows CTRL+Z in zoom out tooltip when feature flag is disabled', async () => {
-  window.grafanaBootData = {
-    settings: {
-      featureToggles: {
-        newTimeRangeZoomShortcuts: false,
-      },
-    },
-  } as BootData;
-
-  render(
-    <TimeRangePicker
-      onChangeTimeZone={() => {}}
-      onChange={(value) => {}}
-      value={value}
-      onMoveBackward={() => {}}
-      onMoveForward={() => {}}
-      onZoom={() => {}}
-    />
-  );
-
-  const zoomButton = screen.getByLabelText('Zoom out time range');
-  await userEvent.hover(zoomButton);
-
-  expect(await screen.findByText(/CTRL\+Z/)).toBeInTheDocument();
-});
-
-it('shows t - in zoom out tooltip when feature flag is enabled', async () => {
-  window.grafanaBootData = {
-    settings: {
-      featureToggles: {
-        newTimeRangeZoomShortcuts: true,
-      },
-    },
-  } as BootData;
-
+it('shows t - in zoom out tooltip', async () => {
   render(
     <TimeRangePicker
       onChangeTimeZone={() => {}}

--- a/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.tsx
+++ b/packages/grafana-ui/src/components/DateTimePickers/TimeRangePicker.tsx
@@ -18,7 +18,6 @@ import { t, Trans } from '@grafana/i18n';
 import { type TimeZone } from '@grafana/schema';
 
 import { useStyles2 } from '../../themes/ThemeContext';
-import { getFeatureToggle } from '../../utils/featureToggle';
 import { ButtonGroup } from '../Button/ButtonGroup';
 import { Stack } from '../Layout/Stack/Stack';
 import { getModalStyles } from '../Modal/getModalStyles';
@@ -249,19 +248,10 @@ export function TimeRangePicker(props: TimeRangePickerProps) {
 TimeRangePicker.displayName = 'TimeRangePicker';
 
 const ZoomOutTooltip = () => {
-  const newShortcuts = getFeatureToggle('newTimeRangeZoomShortcuts');
   return (
-    <>
-      {newShortcuts ? (
-        <Trans i18nKey="time-picker.range-picker.zoom-out-tooltip-new">
-          Time range zoom out <br /> t -
-        </Trans>
-      ) : (
-        <Trans i18nKey="time-picker.range-picker.zoom-out-tooltip">
-          Time range zoom out <br /> CTRL+Z
-        </Trans>
-      )}
-    </>
+    <Trans i18nKey="time-picker.range-picker.zoom-out-tooltip-new">
+      Time range zoom out <br /> t -
+    </Trans>
   );
 };
 

--- a/public/app/core/components/help/HelpModal.test.tsx
+++ b/public/app/core/components/help/HelpModal.test.tsx
@@ -1,8 +1,6 @@
 import { renderHook } from '@testing-library/react';
 
 import { useAssistant } from '@grafana/assistant';
-import { config } from '@grafana/runtime';
-
 import { useShortcuts } from './HelpModal';
 
 // Mock the assistant hook
@@ -168,9 +166,7 @@ describe('useShortcuts', () => {
       });
     });
 
-    it('should show new zoom shortcuts when feature toggle is enabled', () => {
-      config.featureToggles.newTimeRangeZoomShortcuts = true;
-
+    it('should show new zoom shortcuts', () => {
       const { result } = renderHook(() => useShortcuts());
 
       const timeRangeCategory = result.current.find((cat) => cat.category.includes('Time range'));
@@ -184,37 +180,7 @@ describe('useShortcuts', () => {
       expect(zoomOutShortcut!.isNew).toBe(true);
     });
 
-    it('should show legacy t z shortcut when feature toggle is disabled', () => {
-      config.featureToggles.newTimeRangeZoomShortcuts = false;
-
-      const { result } = renderHook(() => useShortcuts());
-
-      const timeRangeCategory = result.current.find((cat) => cat.category.includes('Time range'));
-
-      const legacyZoomShortcut = timeRangeCategory!.shortcuts.find((s) => s.keys.includes('t') && s.keys.includes('z'));
-      const newZoomInShortcut = timeRangeCategory!.shortcuts.find((s) => s.keys.includes('t') && s.keys.includes('+'));
-      const newZoomOutShortcut = timeRangeCategory!.shortcuts.find((s) => s.keys.includes('t') && s.keys.includes('-'));
-
-      expect(legacyZoomShortcut).toBeDefined();
-      expect(newZoomInShortcut).toBeUndefined();
-      expect(newZoomOutShortcut).toBeUndefined();
-    });
-
-    it('should not show isNew badge on legacy shortcuts', () => {
-      config.featureToggles.newTimeRangeZoomShortcuts = false;
-
-      const { result } = renderHook(() => useShortcuts());
-
-      const timeRangeCategory = result.current.find((cat) => cat.category.includes('Time range'));
-
-      const legacyZoomShortcut = timeRangeCategory!.shortcuts.find((s) => s.keys.includes('t') && s.keys.includes('z'));
-
-      expect(legacyZoomShortcut!.isNew).toBeUndefined();
-    });
-
-    it('should show isNew badge on new shortcuts when feature toggle is enabled', () => {
-      config.featureToggles.newTimeRangeZoomShortcuts = true;
-
+    it('should show isNew badge on new shortcuts', () => {
       const { result } = renderHook(() => useShortcuts());
 
       const timeRangeCategory = result.current.find((cat) => cat.category.includes('Time range'));

--- a/public/app/core/components/help/HelpModal.test.tsx
+++ b/public/app/core/components/help/HelpModal.test.tsx
@@ -1,6 +1,7 @@
 import { renderHook } from '@testing-library/react';
 
 import { useAssistant } from '@grafana/assistant';
+
 import { useShortcuts } from './HelpModal';
 
 // Mock the assistant hook

--- a/public/app/core/components/help/HelpModal.tsx
+++ b/public/app/core/components/help/HelpModal.tsx
@@ -4,7 +4,6 @@ import { useMemo, type JSX } from 'react';
 import { useAssistant } from '@grafana/assistant';
 import { FeatureState, type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { config } from '@grafana/runtime';
 import { Grid, Modal, useStyles2, Text, FeatureBadge } from '@grafana/ui';
 import { getModKey } from 'app/core/utils/browser';
 
@@ -113,25 +112,16 @@ export const useShortcuts = () => {
       {
         category: t('help-modal.shortcuts-category.time-range', 'Time range'),
         shortcuts: [
-          ...(config.featureToggles.newTimeRangeZoomShortcuts
-            ? [
-                {
-                  keys: ['t', '+'],
-                  description: t('help-modal.shortcuts-description.zoom-in-time-range', 'Zoom in time range'),
-                  isNew: true,
-                },
-                {
-                  keys: ['t', '-'],
-                  description: t('help-modal.shortcuts-description.zoom-out-time-range', 'Zoom out time range'),
-                  isNew: true,
-                },
-              ]
-            : [
-                {
-                  keys: ['t', 'z'],
-                  description: t('help-modal.shortcuts-description.zoom-out-time-range', 'Zoom out time range'),
-                },
-              ]),
+          {
+            keys: ['t', '+'],
+            description: t('help-modal.shortcuts-description.zoom-in-time-range', 'Zoom in time range'),
+            isNew: true,
+          },
+          {
+            keys: ['t', '-'],
+            description: t('help-modal.shortcuts-description.zoom-out-time-range', 'Zoom out time range'),
+            isNew: true,
+          },
           {
             keys: ['t', '←'],
             description: t('help-modal.shortcuts-description.move-time-range-back', 'Move time range back'),

--- a/public/app/core/services/keybindingSrv.ts
+++ b/public/app/core/services/keybindingSrv.ts
@@ -1,6 +1,6 @@
 import { toggleAssistant, isAssistantAvailable } from '@grafana/assistant';
 import { LegacyGraphHoverClearEvent, SetPanelAttentionEvent, locationUtil } from '@grafana/data';
-import { type LocationService, config } from '@grafana/runtime';
+import { type LocationService } from '@grafana/runtime';
 import { appEvents } from 'app/core/app_events';
 import { getExploreUrl } from 'app/core/utils/explore';
 import { toggleMockApiAndReload, togglePseudoLocale } from 'app/dev-utils';
@@ -231,23 +231,17 @@ export class KeybindingSrv {
       appEvents.publish(new AbsoluteTimeEvent({ updateUrl }));
     });
 
-    if (config.featureToggles.newTimeRangeZoomShortcuts) {
-      this.bind('t +', () => {
-        appEvents.publish(new ZoomOutEvent({ scale: 0.5, updateUrl }));
-      });
+    this.bind('t +', () => {
+      appEvents.publish(new ZoomOutEvent({ scale: 0.5, updateUrl }));
+    });
 
-      this.bind('t =', () => {
-        appEvents.publish(new ZoomOutEvent({ scale: 0.5, updateUrl }));
-      });
+    this.bind('t =', () => {
+      appEvents.publish(new ZoomOutEvent({ scale: 0.5, updateUrl }));
+    });
 
-      this.bind('t -', () => {
-        appEvents.publish(new ZoomOutEvent({ scale: 2, updateUrl }));
-      });
-    } else {
-      this.bind('t z', () => {
-        appEvents.publish(new ZoomOutEvent({ scale: 2, updateUrl }));
-      });
-    }
+    this.bind('t -', () => {
+      appEvents.publish(new ZoomOutEvent({ scale: 2, updateUrl }));
+    });
 
     this.bind('ctrl+z', () => {
       appEvents.publish(new ZoomOutEvent({ scale: 2, updateUrl }));

--- a/public/app/features/dashboard-scene/scene/keyboardShortcuts.test.ts
+++ b/public/app/features/dashboard-scene/scene/keyboardShortcuts.test.ts
@@ -1,5 +1,4 @@
 import { LegacyGraphHoverClearEvent } from '@grafana/data';
-import { config } from '@grafana/runtime';
 import { behaviors, sceneGraph, SceneTimeRange } from '@grafana/scenes';
 import { DashboardCursorSync } from '@grafana/schema';
 import { appEvents } from 'app/core/app_events';
@@ -172,7 +171,6 @@ describe('setupKeyboardShortcuts', () => {
 
   describe('other keyboard shortcuts', () => {
     beforeEach(() => {
-      config.featureToggles.newTimeRangeZoomShortcuts = false;
       setupKeyboardShortcuts(mockScene);
     });
 
@@ -184,11 +182,6 @@ describe('setupKeyboardShortcuts', () => {
     it('should setup refresh shortcut (d r)', () => {
       const drBinding = mockKeybindingSet.addBinding.mock.calls.find((call) => call[0].key === 'd r');
       expect(drBinding).toBeDefined();
-    });
-
-    it('should setup zoom out shortcut (t z)', () => {
-      const tzBinding = mockKeybindingSet.addBinding.mock.calls.find((call) => call[0].key === 't z');
-      expect(tzBinding).toBeDefined();
     });
 
     it('should setup zoom out shortcut (ctrl+z)', () => {
@@ -265,10 +258,9 @@ describe('setupKeyboardShortcuts', () => {
     });
   });
 
-  describe('time range zoom shortcuts with feature toggle', () => {
-    describe('when newTimeRangeZoomShortcuts is enabled', () => {
+  describe('time range zoom shortcuts', () => {
+    describe('zoom key bindings', () => {
       beforeEach(() => {
-        config.featureToggles.newTimeRangeZoomShortcuts = true;
         jest.clearAllMocks();
       });
 
@@ -294,37 +286,11 @@ describe('setupKeyboardShortcuts', () => {
         expect(tMinusBinding![0].type).toBe('keypress');
       });
 
-      it('should not setup t z shortcut when feature toggle is on', () => {
+      it('should not setup t z shortcut', () => {
         setupKeyboardShortcuts(mockScene);
 
         const tzBinding = mockKeybindingSet.addBinding.mock.calls.find((call) => call[0].key === 't z');
         expect(tzBinding).toBeUndefined();
-      });
-    });
-
-    describe('when newTimeRangeZoomShortcuts is disabled', () => {
-      beforeEach(() => {
-        config.featureToggles.newTimeRangeZoomShortcuts = false;
-        jest.clearAllMocks();
-      });
-
-      it('should setup legacy t z shortcut', () => {
-        setupKeyboardShortcuts(mockScene);
-
-        const tzBinding = mockKeybindingSet.addBinding.mock.calls.find((call) => call[0].key === 't z');
-        expect(tzBinding).toBeDefined();
-      });
-
-      it('should not setup new zoom shortcuts when feature toggle is off', () => {
-        setupKeyboardShortcuts(mockScene);
-
-        const tPlusBinding = mockKeybindingSet.addBinding.mock.calls.find((call) => call[0].key === 't +');
-        const tEqualsBinding = mockKeybindingSet.addBinding.mock.calls.find((call) => call[0].key === 't =');
-        const tMinusBinding = mockKeybindingSet.addBinding.mock.calls.find((call) => call[0].key === 't -');
-
-        expect(tPlusBinding).toBeUndefined();
-        expect(tEqualsBinding).toBeUndefined();
-        expect(tMinusBinding).toBeUndefined();
       });
     });
 
@@ -354,7 +320,6 @@ describe('setupKeyboardShortcuts', () => {
       }
 
       beforeEach(() => {
-        config.featureToggles.newTimeRangeZoomShortcuts = true;
         mockTimeRange = createMockTimeRange();
 
         (sceneGraph.getTimeRange as jest.Mock).mockReturnValue(mockTimeRange);

--- a/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
+++ b/public/app/features/dashboard-scene/scene/keyboardShortcuts.ts
@@ -136,36 +136,27 @@ export function setupKeyboardShortcuts(scene: DashboardScene) {
     onTrigger: () => sceneGraph.getTimeRange(scene).onRefresh(),
   });
 
-  if (config.featureToggles.newTimeRangeZoomShortcuts) {
-    keybindings.addBinding({
-      key: 't +',
-      onTrigger: () => {
-        handleZoom(scene, 0.5);
-      },
-    });
+  keybindings.addBinding({
+    key: 't +',
+    onTrigger: () => {
+      handleZoom(scene, 0.5);
+    },
+  });
 
-    keybindings.addBinding({
-      key: 't =',
-      onTrigger: () => {
-        handleZoom(scene, 0.5);
-      },
-    });
+  keybindings.addBinding({
+    key: 't =',
+    onTrigger: () => {
+      handleZoom(scene, 0.5);
+    },
+  });
 
-    keybindings.addBinding({
-      key: 't -',
-      type: 'keypress', // NOTE: Because some browsers/OS identify minus symbol differently.
-      onTrigger: () => {
-        handleZoomOut(scene);
-      },
-    });
-  } else {
-    keybindings.addBinding({
-      key: 't z',
-      onTrigger: () => {
-        handleZoomOut(scene);
-      },
-    });
-  }
+  keybindings.addBinding({
+    key: 't -',
+    type: 'keypress', // NOTE: Because some browsers/OS identify minus symbol differently.
+    onTrigger: () => {
+      handleZoomOut(scene);
+    },
+  });
 
   keybindings.addBinding({
     key: 'ctrl+z',

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -15447,7 +15447,6 @@
       "forwards-time-aria-label": "Move time range forwards",
       "to": "to",
       "zoom-out-button": "Zoom out time range",
-      "zoom-out-tooltip": "Time range zoom out <br/> CTRL+Z",
       "zoom-out-tooltip-new": "Time range zoom out <br/> t -"
     },
     "time-range": {


### PR DESCRIPTION
This PR removes references/checks for \`newTimeRangeZoomShortcuts\` from code, assuming the flag is permanently enabled.

The new keyboard shortcuts (t+, t=, t-) are now always active. The legacy \`t z\` shortcut code has been removed.

The flag definition itself is intentionally kept and will be removed in a separate step for architectural reasons.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.