### PR TITLE
fix(dashboard-scene): enable resize for panels in tabs and rows added mid–edit session

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.test.tsx
@@ -102,28 +102,37 @@ describe('RowsLayoutManager', () => {
     });
 
     it('should sync edit mode to a new row inner layout when the dashboard is already editing', () => {
+      // New rows use getDefaultLayout() (clone of preferences.defaultLayoutTemplate). Without a template,
+      // RowItem falls back to AutoGridLayoutManager.createEmpty(), which already has isDraggable true, so a
+      // missing edit-mode sync would not fail the test. A template with interaction disabled forces the sync.
+      const defaultLayoutTemplate = new DefaultGridLayoutManager({
+        grid: new SceneGridLayout({
+          children: [],
+          isDraggable: false,
+          isResizable: false,
+        }),
+      });
+
       const rowsLayoutManager = new RowsLayoutManager({
         key: 'test-RowsLayoutManager',
         rows: [new RowItem({ title: 'First' })],
       });
-      const dashboard = new DashboardScene({
+      new DashboardScene({
         body: rowsLayoutManager,
         isEditing: true,
         editable: true,
+        preferences: { defaultLayoutTemplate },
       });
-      dashboard.state.body.editModeChanged?.(true);
+
+      rowsLayoutManager.editModeChanged(true);
 
       const newRow = rowsLayoutManager.addNewRow();
       const layout = newRow.getLayout();
+      expect(layout).toBeInstanceOf(DefaultGridLayoutManager);
 
-      if (layout instanceof DefaultGridLayoutManager) {
-        expect(layout.state.grid.state.isResizable).toBe(true);
-        expect(layout.state.grid.state.isDraggable).toBe(true);
-      } else if (layout instanceof AutoGridLayoutManager) {
-        expect(layout.state.layout.state.isDraggable).toBe(true);
-      } else {
-        throw new Error(`Unexpected layout type for assertion: ${layout.constructor.name}`);
-      }
+      const grid = (layout as DefaultGridLayoutManager).state.grid;
+      expect(grid.state.isDraggable).toBe(true);
+      expect(grid.state.isResizable).toBe(true);
     });
   });
 

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.test.tsx
@@ -100,6 +100,31 @@ describe('RowsLayoutManager', () => {
 
       expect(rowsLayoutManager.state.rows).toHaveLength(0);
     });
+
+    it('should sync edit mode to a new row inner layout when the dashboard is already editing', () => {
+      const rowsLayoutManager = new RowsLayoutManager({
+        key: 'test-RowsLayoutManager',
+        rows: [new RowItem({ title: 'First' })],
+      });
+      const dashboard = new DashboardScene({
+        body: rowsLayoutManager,
+        isEditing: true,
+        editable: true,
+      });
+      dashboard.state.body.editModeChanged?.(true);
+
+      const newRow = rowsLayoutManager.addNewRow();
+      const layout = newRow.getLayout();
+
+      if (layout instanceof DefaultGridLayoutManager) {
+        expect(layout.state.grid.state.isResizable).toBe(true);
+        expect(layout.state.grid.state.isDraggable).toBe(true);
+      } else if (layout instanceof AutoGridLayoutManager) {
+        expect(layout.state.layout.state.isDraggable).toBe(true);
+      } else {
+        throw new Error(`Unexpected layout type for assertion: ${layout.constructor.name}`);
+      }
+    });
   });
 
   describe('removeRow', () => {

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowsLayoutManager.tsx
@@ -145,7 +145,13 @@ export class RowsLayoutManager
     dashboardEditActions.addElement({
       addedObject: newRow,
       source: this,
-      perform: () => this.setState({ rows: [...this.state.rows, newRow] }),
+      perform: () => {
+        this.setState({ rows: [...this.state.rows, newRow] });
+        const dashboard = getDashboardSceneFor(this);
+        if (dashboard.state.isEditing) {
+          newRow.getLayout().editModeChanged?.(true);
+        }
+      },
       undo: () => this.setState({ rows: this.state.rows.filter((r) => r !== newRow) }),
     });
 

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.test.tsx
@@ -142,28 +142,37 @@ describe('TabsLayoutManager', () => {
     });
 
     it('should sync edit mode to a new tab inner layout when the dashboard is already editing', () => {
+      // New tabs use getDefaultLayout() (clone of preferences.defaultLayoutTemplate). Without a template,
+      // TabItem falls back to AutoGridLayoutManager.createEmpty(), which already has isDraggable true, so a
+      // missing edit-mode sync would not fail the test. A template with interaction disabled forces the sync.
+      const defaultLayoutTemplate = new DefaultGridLayoutManager({
+        grid: new SceneGridLayout({
+          children: [],
+          isDraggable: false,
+          isResizable: false,
+        }),
+      });
+
       const tabsLayoutManager = new TabsLayoutManager({
         key: 'test-TabsLayoutManager',
         tabs: [new TabItem({ title: 'First' })],
       });
-      const dashboard = new DashboardScene({
+      new DashboardScene({
         body: tabsLayoutManager,
         isEditing: true,
         editable: true,
+        preferences: { defaultLayoutTemplate },
       });
-      dashboard.state.body.editModeChanged?.(true);
+
+      tabsLayoutManager.editModeChanged(true);
 
       const newTab = tabsLayoutManager.addNewTab();
       const layout = newTab.getLayout();
+      expect(layout).toBeInstanceOf(DefaultGridLayoutManager);
 
-      if (layout instanceof DefaultGridLayoutManager) {
-        expect(layout.state.grid.state.isResizable).toBe(true);
-        expect(layout.state.grid.state.isDraggable).toBe(true);
-      } else if (layout instanceof AutoGridLayoutManager) {
-        expect(layout.state.layout.state.isDraggable).toBe(true);
-      } else {
-        throw new Error(`Unexpected layout type for assertion: ${layout.constructor.name}`);
-      }
+      const grid = (layout as DefaultGridLayoutManager).state.grid;
+      expect(grid.state.isDraggable).toBe(true);
+      expect(grid.state.isResizable).toBe(true);
     });
   });
 

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.test.tsx
@@ -140,6 +140,31 @@ describe('TabsLayoutManager', () => {
 
       expect(tabsLayoutManager.state.tabs).toHaveLength(0);
     });
+
+    it('should sync edit mode to a new tab inner layout when the dashboard is already editing', () => {
+      const tabsLayoutManager = new TabsLayoutManager({
+        key: 'test-TabsLayoutManager',
+        tabs: [new TabItem({ title: 'First' })],
+      });
+      const dashboard = new DashboardScene({
+        body: tabsLayoutManager,
+        isEditing: true,
+        editable: true,
+      });
+      dashboard.state.body.editModeChanged?.(true);
+
+      const newTab = tabsLayoutManager.addNewTab();
+      const layout = newTab.getLayout();
+
+      if (layout instanceof DefaultGridLayoutManager) {
+        expect(layout.state.grid.state.isResizable).toBe(true);
+        expect(layout.state.grid.state.isDraggable).toBe(true);
+      } else if (layout instanceof AutoGridLayoutManager) {
+        expect(layout.state.layout.state.isDraggable).toBe(true);
+      } else {
+        throw new Error(`Unexpected layout type for assertion: ${layout.constructor.name}`);
+      }
+    });
   });
 
   describe('removeTab', () => {

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabsLayoutManager.tsx
@@ -212,7 +212,13 @@ export class TabsLayoutManager
     dashboardEditActions.addElement({
       addedObject: newTab,
       source: this,
-      perform: () => this.setState({ tabs: [...this.state.tabs, newTab], currentTabSlug: newTab.getSlug() }),
+      perform: () => {
+        this.setState({ tabs: [...this.state.tabs, newTab], currentTabSlug: newTab.getSlug() });
+        const dashboard = getDashboardSceneFor(this);
+        if (dashboard.state.isEditing) {
+          newTab.getLayout().editModeChanged?.(true);
+        }
+      },
       undo: () => {
         this.setState({
           tabs: this.state.tabs.filter((t) => t !== newTab),


### PR DESCRIPTION
## Summary
New tabs or rows added while the dashboard is already in edit mode never received `editModeChanged(true)`, so their inner grid kept resize/drag disabled until leaving and re-entering edit mode.

## Changes
- Call `editModeChanged(true)` on the new tab/row layout inside the add undo `perform` when `isEditing` (covers redo).
- Add regression test for new tab layout under editing.

## Demo 

Before:

https://github.com/user-attachments/assets/32259f73-5179-4c67-8e34-1a07d3572bd0

After:


https://github.com/user-attachments/assets/2b01cbd2-0288-406a-a472-58da72162cf1

Fixes: https://github.com/grafana/support-escalations/issues/22090
Fixes: https://github.com/grafana/grafana/issues/123560

