### PR TITLE
unified-storage: add tracing and timing to TenantDeleter

### DIFF
--- a/pkg/storage/unified/resource/tenant_deleter.go
+++ b/pkg/storage/unified/resource/tenant_deleter.go
@@ -12,6 +12,9 @@ import (
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/gcom"
 	"github.com/grafana/grafana/pkg/setting"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // TenantDeleterConfig holds configuration for the TenantDeleter.
@@ -154,6 +157,11 @@ func (td *TenantDeleter) runDeletionPass(ctx context.Context) {
 // gcomAllowsTenantDeletion returns true when GCOM returns 200 with Status "deleted" for the given
 // tenant name. Otherwise it returns false and logs.
 func (td *TenantDeleter) gcomAllowsTenantDeletion(ctx context.Context, tenantName string) bool {
+	ctx, span := tracer.Start(ctx, "resource.TenantDeleter.gcomAllowsTenantDeletion", trace.WithAttributes(
+		attribute.String("tenant", tenantName),
+	))
+	defer span.End()
+
 	if td.gcom == nil {
 		return false
 	}
@@ -162,32 +170,52 @@ func (td *TenantDeleter) gcomAllowsTenantDeletion(ctx context.Context, tenantNam
 	if err != nil || info.StackID <= 0 {
 		td.log.Error("GCOM verification requires a cloud stack namespace (stacks-{stackId}); skipping local data deletion",
 			"tenant", tenantName, "err", err, "stack_id", info.StackID)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "invalid namespace")
 		return false
 	}
 	instanceID := strconv.FormatInt(info.StackID, 10)
+	span.SetAttributes(attribute.String("gcom_instance_id", instanceID))
 
 	reqID := tracing.TraceIDFromContext(ctx, false)
+	gcomStart := time.Now()
 	inst, err := td.gcom.GetInstanceByID(ctx, reqID, instanceID)
+	gcomDuration := time.Since(gcomStart)
+	span.SetAttributes(attribute.Int64("gcom_request_duration_ms", gcomDuration.Milliseconds()))
+
 	if err != nil {
-		td.log.Error("GCOM instance check failed; skipping local data deletion", "tenant", tenantName, "gcom_instance_id", instanceID, "err", err)
+		td.log.Error("GCOM instance check failed; skipping local data deletion",
+			"tenant", tenantName, "gcom_instance_id", instanceID, "err", err,
+			"gcom_request_duration_ms", gcomDuration.Milliseconds())
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "GCOM request failed")
 		return false
 	}
 
+	span.SetAttributes(attribute.String("gcom_status", inst.Status))
 	if inst.Status != "deleted" {
 		td.log.Warn("stack still active in GCOM; skipping local data deletion",
 			"tenant", tenantName, "gcom_instance_id", instanceID, "gcom_status", inst.Status)
 		return false
 	}
 
-	// If we get here, the stack is deleted in GCOM.
 	return true
 }
 
 // deleteTenant removes all resource data for the given tenant from the data
 // store, then removes its pending-delete record.
 func (td *TenantDeleter) deleteTenant(ctx context.Context, tenantName string, groupResources []GroupResource) error {
+	ctx, span := tracer.Start(ctx, "resource.TenantDeleter.deleteTenant", trace.WithAttributes(
+		attribute.String("tenant", tenantName),
+		attribute.Bool("dry_run", td.cfg.DryRun),
+		attribute.Int("group_resources", len(groupResources)),
+	))
+	defer span.End()
+
+	start := time.Now()
 	td.log.Info("tenant data deletion", "tenant", tenantName, "dry_run", td.cfg.DryRun)
 
+	var totalKeys int
 	for _, gr := range groupResources {
 		listKey := ListRequestKey{
 			Group:     gr.Group,
@@ -202,10 +230,14 @@ func (td *TenantDeleter) deleteTenant(ctx context.Context, tenantName string, gr
 			EndKey:   PrefixRangeEnd(prefix),
 		}) {
 			if err != nil {
+				span.RecordError(err)
+				span.SetStatus(codes.Error, "listing resource keys failed")
 				return err
 			}
 			dk, err := ParseKey(k)
 			if err != nil {
+				span.RecordError(err)
+				span.SetStatus(codes.Error, "parsing resource key failed")
 				return err
 			}
 			keys = append(keys, dk)
@@ -221,10 +253,32 @@ func (td *TenantDeleter) deleteTenant(ctx context.Context, tenantName string, gr
 			continue
 		}
 
+		grStart := time.Now()
 		if err := td.dataStore.batchDelete(ctx, keys); err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, "batch delete failed")
 			return err
 		}
+		td.log.Info("deleted tenant resources",
+			"tenant", tenantName,
+			"group", gr.Group,
+			"resource", gr.Resource,
+			"count", len(keys),
+			"duration_ms", time.Since(grStart).Milliseconds(),
+		)
+		totalKeys += len(keys)
 	}
+
+	span.SetAttributes(
+		attribute.Int("total_keys_deleted", totalKeys),
+		attribute.Int64("duration_ms", time.Since(start).Milliseconds()),
+	)
+	td.log.Info("tenant data deletion complete",
+		"tenant", tenantName,
+		"dry_run", td.cfg.DryRun,
+		"total_keys_deleted", totalKeys,
+		"duration_ms", time.Since(start).Milliseconds(),
+	)
 
 	if td.cfg.DryRun {
 		return nil
@@ -232,6 +286,8 @@ func (td *TenantDeleter) deleteTenant(ctx context.Context, tenantName string, gr
 
 	record, err := td.pendingDeleteStore.Get(ctx, tenantName)
 	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "reading pending delete record failed")
 		return fmt.Errorf("reading pending delete record: %w", err)
 	}
 


### PR DESCRIPTION
Adds OTel spans and structured log fields to `gcomAllowsTenantDeletion` and `deleteTenant` to make tenant deletion latency observable, including GCOM request duration, per-resource batch delete timing, and total keys deleted.