### PR TITLE
Alerting: fix pagination for ungrouped alert rules

### DIFF
--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -777,7 +777,10 @@ func (st DBstore) ListAlertRulesByGroup(ctx context.Context, query *ngmodels.Lis
 
 		// Build group cursor condition
 		if cursor.NamespaceUID != "" {
-			q = buildGroupCursorCondition(q, cursor)
+			q, err = buildGroupCursorCondition(q, cursor, query.OrgID)
+			if err != nil {
+				return err
+			}
 		}
 
 		// No arbitrary fetch limit - let the loop control pagination
@@ -867,27 +870,60 @@ func (st DBstore) ListAlertRulesByGroup(ctx context.Context, query *ngmodels.Lis
 	return result, nextToken, err
 }
 
-func buildGroupCursorCondition(sess *xorm.Session, c ngmodels.GroupCursor) *xorm.Session {
+func buildGroupCursorCondition(sess *xorm.Session, c ngmodels.GroupCursor, orgID int64) (*xorm.Session, error) {
 	// We need to handle this here otherwise we end up checking rule_group > "no_group_for_rule..."
 	// and skipping everything
+	isNoGroupRule := ngmodels.IsNoGroupRuleGroup(c.RuleGroup)
 	ruleGroup := c.RuleGroup
-	if ngmodels.IsNoGroupRuleGroup(ruleGroup) {
+	var uid string
+	var uidSubquery string
+	if isNoGroupRule {
+		parsedRuleGroup, err := ngmodels.ParseNoRuleGroup(c.RuleGroup)
+		if err != nil {
+			return nil, err
+		}
+
+		uid = parsedRuleGroup.GetRuleUID()
+		uidSubquery = "(SELECT id FROM alert_rule WHERE org_id = ? AND uid = ?)"
 		ruleGroup = ""
 	}
 
 	if c.FolderFullpath != "" {
-		return sess.And(
-			"((folder_fullpath > ?) OR (folder_fullpath = ? AND namespace_uid > ?) OR (folder_fullpath = ? AND namespace_uid = ? AND rule_group > ?))",
+		sql := `(folder_fullpath > ?)
+			OR (folder_fullpath = ? AND namespace_uid > ?)
+			OR (folder_fullpath = ? AND namespace_uid = ? AND rule_group > ?)
+		`
+
+		args := []any{
 			c.FolderFullpath,
 			c.FolderFullpath, c.NamespaceUID,
 			c.FolderFullpath, c.NamespaceUID, ruleGroup,
-		)
+		}
+
+		// If the cursor is an ungrouped rule we need to look up the rule id from the uid to use as a row level tiebreaker
+		if isNoGroupRule {
+			sql += " OR (folder_fullpath = ? AND namespace_uid = ? AND rule_group = '' AND id > " + uidSubquery + ")"
+			args = append(args, c.FolderFullpath, c.NamespaceUID, orgID, uid)
+		}
+
+		return sess.And("("+sql+")", args...), nil
 	}
+
 	// fallback to previous cursor condition if folder fullpath is not available, this means that pagination will be less efficient as it cannot take advantage of folder fullpath ordering, but at least it will work and not return duplicate or missing groups.
-	return sess.And(
-		"((namespace_uid > ?) OR (namespace_uid = ? AND rule_group > ?))",
-		c.NamespaceUID, c.NamespaceUID, ruleGroup,
-	)
+	sql := `(namespace_uid > ?)
+		OR (namespace_uid = ? AND rule_group > ?)`
+	args := []any{
+		c.NamespaceUID,
+		c.NamespaceUID, ruleGroup,
+	}
+
+	if isNoGroupRule {
+		// Same note on the row level tiebreaker as above here
+		sql += " OR (namespace_uid = ? AND rule_group = '' AND id > " + uidSubquery + ")"
+		args = append(args, c.NamespaceUID, orgID, uid)
+	}
+
+	return sess.And("("+sql+")", args...), nil
 }
 
 func shouldIncludeRule(rule *ngmodels.AlertRule, query *ngmodels.ListAlertRulesExtendedQuery, groupsMap map[string]struct{}) bool {

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -2297,6 +2297,23 @@ func TestIntegration_ListAlertRulesByGroup(t *testing.T) {
 		store := createTestStore(sqlStore, folderService2, &logtest.Fake{}, cfg.UnifiedAlerting, &fakeBus{})
 
 		ns := "test-ns-nogroup-paginated"
+		// Create a rule that we'll query via no-group
+		noGroupRule1 := createRule(t, store, ruleGen.With(
+			ruleGen.WithNamespaceUID(ns),
+			ruleGen.WithGroupName(""),
+			ruleGen.WithGroupIndex(0),
+		))
+		noGroupRule2 := createRule(t, store, ruleGen.With(
+			ruleGen.WithNamespaceUID(ns),
+			ruleGen.WithGroupName(""),
+			ruleGen.WithGroupIndex(0),
+		))
+
+		noGroup1, err := models.NewNoGroupRuleGroup(noGroupRule1.UID)
+		require.NoError(t, err)
+		noGroup2, err := models.NewNoGroupRuleGroup(noGroupRule2.UID)
+		require.NoError(t, err)
+
 		// Create rules in a normal group
 		groupedRule1 := createRule(t, store, ruleGen.With(
 			ruleGen.WithNamespaceUID(ns),
@@ -2306,20 +2323,12 @@ func TestIntegration_ListAlertRulesByGroup(t *testing.T) {
 			ruleGen.WithNamespaceUID(ns),
 			ruleGen.WithGroupName("group-a"),
 		))
-		// Create a rule that we'll query via no-group
-		noGroupRule := createRule(t, store, ruleGen.With(
-			ruleGen.WithNamespaceUID(ns),
-			ruleGen.WithGroupName(""),
-		))
-
-		noGroup, err := models.NewNoGroupRuleGroup(noGroupRule.UID)
-		require.NoError(t, err)
 
 		// Page 1: limit to 1 group
 		page1, token1, err := store.ListAlertRulesByGroup(context.Background(), &models.ListAlertRulesExtendedQuery{
 			ListAlertRulesQuery: models.ListAlertRulesQuery{
 				OrgID:      orgID,
-				RuleGroups: []string{groupedRule1.RuleGroup, noGroup.String()},
+				RuleGroups: []string{groupedRule1.RuleGroup, noGroup1.String(), noGroup2.String()},
 			},
 			Limit: 1,
 		})
@@ -2330,9 +2339,9 @@ func TestIntegration_ListAlertRulesByGroup(t *testing.T) {
 		page2, token2, err := store.ListAlertRulesByGroup(context.Background(), &models.ListAlertRulesExtendedQuery{
 			ListAlertRulesQuery: models.ListAlertRulesQuery{
 				OrgID:      orgID,
-				RuleGroups: []string{groupedRule1.RuleGroup, noGroup.String()},
+				RuleGroups: []string{groupedRule1.RuleGroup, noGroup1.String(), noGroup2.String()},
 			},
-			Limit:         1,
+			Limit:         2,
 			ContinueToken: token1,
 		})
 		require.NoError(t, err)
@@ -2342,7 +2351,7 @@ func TestIntegration_ListAlertRulesByGroup(t *testing.T) {
 		for _, r := range allResults {
 			allUIDs = append(allUIDs, r.UID)
 		}
-		require.ElementsMatch(t, []string{groupedRule1.UID, groupedRule2.UID, noGroupRule.UID}, allUIDs)
+		require.ElementsMatch(t, []string{groupedRule1.UID, groupedRule2.UID, noGroupRule1.UID, noGroupRule2.UID}, allUIDs)
 		require.Empty(t, token2, "should have no more pages")
 	})
 


### PR DESCRIPTION
**What is this feature?**

This fixes an issue where pagination breaks when the cursor is pointing at an ungrouped alert rule. In this case we translate the group name to the empty string to match the db but end up skipping all subsequent ungrouped rules because we filter on `rule_group > ""`. The fix is to use the rule id as a tiebreaker which we need to look up from the rule uid encoded in the cursor in a nested query.


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
