### PR TITLE
DataLinks: Nested scope handling

### DIFF
--- a/apps/dashboard/pkg/migration/testdata/golden_checksums.json
+++ b/apps/dashboard/pkg/migration/testdata/golden_checksums.json
@@ -100,7 +100,7 @@
   "dev-dashboards-output/panel-table/table_footer.v42.json": "46ee3c13168a5e3861203d538ec510e5a440fd6b9be08dac6621d27a8d53c100",
   "dev-dashboards-output/panel-table/table_kitchen_sink.v42.json": "2dcb9c684f71e32ebfa6a2e460da39c09493def44413ab843f4ea8278b6e0800",
   "dev-dashboards-output/panel-table/table_markdown.v42.json": "b5b25bcace7cbf11553b5df708e29af768c1c30fe3a8351f72d3fd411d22473a",
-  "dev-dashboards-output/panel-table/table_nested.v42.json": "aebbb448a6d19fd981402f87dad0436dd71ee8803cc63e108023adeb8c0b5ec3",
+  "dev-dashboards-output/panel-table/table_nested.v42.json": "3fd7c47f3dc15a3abd4b68e56d1f193170a8e049fa1ea56a3a9527a7bd902574",
   "dev-dashboards-output/panel-table/table_pagination.v42.json": "da64e181f9bcda639b0f0b39aa0a3f9d265c24e896468eb87117b6050c3b90c4",
   "dev-dashboards-output/panel-table/table_sparkline_cell.v42.json": "1528bd19d5fc9c453344884cf48db654ddef9076b8eccd318aabf61394a12b58",
   "dev-dashboards-output/panel-table/table_tests.v42.json": "fce0821b5c5f08eb871b6234568b64b554285b188ce7a755f104a70509a08306",

--- a/devenv/dev-dashboards/panel-table/table_nested.json
+++ b/devenv/dev-dashboards/panel-table/table_nested.json
@@ -388,6 +388,11 @@
                     "targetBlank": true,
                     "title": "Grafana",
                     "url": "https://grafana.com"
+                  },
+                  {
+                    "targetBlank": true,
+                    "title": "Min param",
+                    "url": "https://example.com?min=${__data.fields.Min.numeric}"
                   }
                 ]
               },

--- a/e2e-playwright/panels-suite/table-nested.spec.ts
+++ b/e2e-playwright/panels-suite/table-nested.spec.ts
@@ -442,7 +442,9 @@ test.describe('Panels test: Table - Nested', { tag: ['@panels', '@table'] }, () 
     await expect(tooltip, 'data link tooltip appears after clicking Info cell').toBeVisible();
 
     const googleHref = await tooltip.getByRole('link', { name: 'Google this term' }).getAttribute('href');
-    expect(googleHref, '"Google this term" href contains the Info cell value').toContain(`q=${encodeURIComponent(infoCellValue)}`);
+    expect(googleHref, '"Google this term" href contains the Info cell value').toContain(
+      `q=${encodeURIComponent(infoCellValue)}`
+    );
 
     // --- Part 2: Data Link column resolves ${__data.fields.Min.numeric} from nested row context ---
     // The "Table - Nested Kitchen Sink" panel groups by Info; nested rows have a "Data Link" column

--- a/e2e-playwright/panels-suite/table-nested.spec.ts
+++ b/e2e-playwright/panels-suite/table-nested.spec.ts
@@ -406,6 +406,71 @@ test.describe('Panels test: Table - Nested', { tag: ['@panels', '@table'] }, () 
     await expect(firstNestedTable.getByRole('columnheader', { name: 'Gauge' })).toBeVisible();
   });
 
+  test('datalinks resolve field variables in nested table context', async ({ gotoDashboardPage, selectors, page }) => {
+    // --- Part 1: Info column "Google this term" link interpolates ${__value:percentencode} ---
+    // Panel 4 groups by State; Info is a nested field with 1 link + 1 action (→ tooltip on click).
+    const dashboardPage = await gotoDashboardPage({
+      uid: DASHBOARD_UID,
+      queryParams: new URLSearchParams({ editPanel: '4' }),
+    });
+
+    await expect(
+      dashboardPage.getByGrafanaSelector(selectors.components.Panels.Panel.title('Nested tables'))
+    ).toBeVisible();
+
+    await waitForTableLoad(page);
+
+    await dashboardPage
+      .getByGrafanaSelector(selectors.components.Panels.Visualization.TableNG.RowExpander)
+      .first()
+      .click();
+    await dashboardPage
+      .getByGrafanaSelector(selectors.components.Panels.Visualization.TableNG.RowExpander)
+      .last()
+      .click();
+
+    const firstNestedTableKs = page.locator('.rdg').nth(1);
+    const infoIdx = await getColumnIdx(firstNestedTableKs, 'Info');
+    const infoCell = getCell(firstNestedTableKs, 1, infoIdx);
+    const infoCellValue = (await infoCell.textContent())?.trim() ?? '';
+    expect(infoCellValue, 'Info cell has a non-empty value').not.toBe('');
+
+    // 1 link + 1 action renders as <a aria-haspopup="menu"> — click to open the tooltip.
+    await infoCell.locator('a[aria-haspopup]').click();
+
+    const tooltip = page.getByTestId(selectors.components.DataLinksActionsTooltip.tooltipWrapper);
+    await expect(tooltip, 'data link tooltip appears after clicking Info cell').toBeVisible();
+
+    const googleHref = await tooltip.getByRole('link', { name: 'Google this term' }).getAttribute('href');
+    expect(googleHref, '"Google this term" href contains the Info cell value').toContain(`q=${encodeURIComponent(infoCellValue)}`);
+
+    // --- Part 2: Data Link column resolves ${__data.fields.Min.numeric} from nested row context ---
+    // The "Table - Nested Kitchen Sink" panel groups by Info; nested rows have a "Data Link" column
+    // with a "Min param" link whose URL contains ${__data.fields.Min.numeric}.
+    const nestedDashboardPage = await gotoDashboardPage({
+      uid: NESTED_COMPLEX_DASHBOARD_UID,
+      queryParams: new URLSearchParams({ editPanel: '1' }),
+    });
+
+    await waitForTableLoad(page);
+
+    await nestedDashboardPage
+      .getByGrafanaSelector(selectors.components.Panels.Visualization.TableNG.RowExpander)
+      .first()
+      .click();
+
+    const firstNestedTable = page.locator('.rdg').nth(1);
+    const dataLinkIdx = await getColumnIdx(firstNestedTable, 'Data Link');
+
+    // The "Min param" link is rendered directly in the DataLinksCell as an <a> tag.
+    const minParamLink = getCell(firstNestedTable, 1, dataLinkIdx).getByRole('link', { name: 'Min param' });
+    const minParamHref = await minParamLink.getAttribute('href');
+
+    expect(minParamHref, '"Min param" href is not null').not.toBeNull();
+    expect(minParamHref, '"Min param" href does not contain unresolved template variable').not.toContain('${');
+    expect(minParamHref, '"Min param" href contains min= with a numeric value').toMatch(/min=[\d.]+/);
+  });
+
   test('tooltip from field', async ({ gotoPanelEditPage, page, selectors }) => {
     const panelEditPage = await gotoPanelEditPage({
       dashboard: {

--- a/public/app/features/dashboard/components/PanelEditor/getFieldOverrideElements.test.ts
+++ b/public/app/features/dashboard/components/PanelEditor/getFieldOverrideElements.test.ts
@@ -2,6 +2,8 @@ import {
   type FieldConfigOptionsRegistry,
   type FieldConfigPropertyItem,
   type FieldConfigSource,
+  type DataFrame,
+  FieldType,
   Registry,
 } from '@grafana/data';
 
@@ -51,6 +53,46 @@ function makeItem(id: string, overrides?: Partial<FieldConfigPropertyItem>): Fie
 }
 
 describe('getFieldOverrideCategories', () => {
+  describe('scope-aware context for DataLink suggestions', () => {
+    it('passes nested frames as context data for nested-scope overrides', () => {
+      const nestedFrame: DataFrame = {
+        fields: [{ name: 'event', type: FieldType.string, config: {}, values: [] }],
+        length: 0,
+      };
+      const topLevelFrame: DataFrame = {
+        fields: [
+          { name: 'time', type: FieldType.time, config: {}, values: [] },
+          { name: 'nested', type: FieldType.nestedFrames, config: {}, values: [[nestedFrame]] },
+        ],
+        length: 1,
+      };
+
+      const registry = makeRegistry([makeItem('links')]);
+      const fieldConfig: FieldConfigSource = {
+        defaults: {},
+        overrides: [
+          { matcher: { id: 'byName', options: 'nested', scope: 'nested' }, properties: [{ id: 'links', value: [] }] },
+          { matcher: { id: 'byName', options: 'time' }, properties: [{ id: 'links', value: [] }] },
+        ],
+      };
+
+      const categories = getFieldOverrideCategories(fieldConfig, registry, [topLevelFrame], '', jest.fn());
+
+      function getContextData(categoryIndex: number): DataFrame[] {
+        const propertyItem = categories[categoryIndex].items.find((item) =>
+          item.props.id?.includes('-property-')
+        );
+        const element = propertyItem?.props.render(propertyItem) as React.ReactElement<{
+          context: { data: DataFrame[] };
+        }>;
+        return element.props.context.data;
+      }
+
+      expect(getContextData(0)).toEqual([nestedFrame]);
+      expect(getContextData(1)).toEqual([topLevelFrame]);
+    });
+  });
+
   describe('hideFromOverrides', () => {
     it('excludes items with hideFromOverrides:true from the add override property picker', () => {
       const registry = makeRegistry([

--- a/public/app/features/dashboard/components/PanelEditor/getFieldOverrideElements.test.ts
+++ b/public/app/features/dashboard/components/PanelEditor/getFieldOverrideElements.test.ts
@@ -79,9 +79,7 @@ describe('getFieldOverrideCategories', () => {
       const categories = getFieldOverrideCategories(fieldConfig, registry, [topLevelFrame], '', jest.fn());
 
       function getContextData(categoryIndex: number): DataFrame[] {
-        const propertyItem = categories[categoryIndex].items.find((item) =>
-          item.props.id?.includes('-property-')
-        );
+        const propertyItem = categories[categoryIndex].items.find((item) => item.props.id?.includes('-property-'));
         const element = propertyItem?.props.render(propertyItem) as React.ReactElement<{
           context: { data: DataFrame[] };
         }>;

--- a/public/app/features/dashboard/components/PanelEditor/getFieldOverrideElements.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/getFieldOverrideElements.tsx
@@ -11,6 +11,7 @@ import {
   fieldMatchers,
   type FieldConfigSource,
   type DataFrame,
+  FieldType,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
@@ -36,7 +37,19 @@ if (config.featureToggles.nestedFramesFieldOverrides) {
   ALLOWED_SCOPES.push('nested');
 }
 
-// [FIXME] Is there something else we need to do in here?
+function getFramesForMatcherScope(data: DataFrame[], scope?: MatcherScope): DataFrame[] {
+  if (scope !== 'nested') {
+    return data;
+  }
+  for (const frame of data) {
+    for (const field of frame.fields) {
+      if (field.type === FieldType.nestedFrames && field.values.length > 0) {
+        return field.values[0];
+      }
+    }
+  }
+  return data;
+}
 
 export function getFieldOverrideCategories(
   fieldConfig: FieldConfigSource,
@@ -79,12 +92,6 @@ export function getFieldOverrideCategories(
     });
   };
 
-  const context = {
-    data,
-    getSuggestions: (scope?: VariableSuggestionsScope) => getDataLinksVariableSuggestions(data, scope),
-    isOverride: true,
-  };
-
   const uniqueMatcherScopes = getUniqueMatcherScopes(data);
 
   /**
@@ -92,6 +99,12 @@ export function getFieldOverrideCategories(
    */
   for (let idx = 0; idx < currentFieldConfig.overrides.length; idx++) {
     const override = currentFieldConfig.overrides[idx];
+    const overrideData = getFramesForMatcherScope(data, override.matcher.scope);
+    const context = {
+      data: overrideData,
+      getSuggestions: (scope?: VariableSuggestionsScope) => getDataLinksVariableSuggestions(overrideData, scope),
+      isOverride: true,
+    };
     const overrideName = t('dashboard.get-field-override-categories.override-name', 'Override {{overrideNum}}', {
       overrideNum: idx + 1,
     });

--- a/public/app/features/panel/panellinks/link_srv.ts
+++ b/public/app/features/panel/panellinks/link_srv.ts
@@ -178,6 +178,10 @@ export const getDataFrameVars = (dataFrames: DataFrame[]) => {
   const frame = dataFrames[0];
 
   for (const field of frame.fields) {
+    if (field.type === FieldType.nestedFrames) {
+      continue;
+    }
+
     const displayName = getFieldDisplayName(field, frame, dataFrames);
 
     if (keys[displayName]) {

--- a/public/app/features/panel/panellinks/specs/link_srv.test.ts
+++ b/public/app/features/panel/panellinks/specs/link_srv.test.ts
@@ -477,6 +477,26 @@ describe('linkSrv', () => {
       });
     });
 
+    describe('when called with a DataFrame that contains a nestedFrames field', () => {
+      it('then it should skip the nestedFrames field and return suggestions for other fields', () => {
+        const frame = toDataFrame({
+          name: 'events',
+          fields: [
+            { name: 'time', type: FieldType.time, values: [1, 2, 3] },
+            { name: 'nested', type: FieldType.nestedFrames, values: [] },
+            { name: 'value', type: FieldType.number, values: [10, 11, 12] },
+          ],
+        });
+
+        const suggestions = getDataFrameVars([frame]);
+
+        const labels = suggestions.map((s) => s.label);
+        expect(labels).not.toContain('nested');
+        expect(labels).toContain('time');
+        expect(labels).toContain('value');
+      });
+    });
+
     describe('when called with multiple DataFrames', () => {
       it('it should not return any suggestions', () => {
         const frame1 = toDataFrame({


### PR DESCRIPTION
## Summary

Fixes a UI bug present in the `nestedTableFieldOverrides` flag.

- when setting datalinks for a field override in the "nested" scope, the suggested fields were the fields in the "top-level" dataframe. now, they will be the nested fields instead.
- fields with the type `FieldType.nestedFrames` will now be hidden from the DataLinks suggestions altogether.
- add an e2e test which just helps us confirm that field variable interpolation works in datalinks at the nested and top level.
  - this worked before this PR but I don't believe we had a test to confirm it keeps working.
  - I want to add a test for the typeahead changes in _this_ PR, but historically, e2es of the DataLinks and Actions modals have been ultimately disabled due to flakiness, so I'm going to hold off for now because I want to try to research the root cause of that in the coming weeks. 

## Demo

https://github.com/user-attachments/assets/273b5027-28e2-4970-8e72-bef7afb81d1e