### PR TITLE
Chore: Add pre-commit hook for golden checksum regen

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -37,3 +37,9 @@ pre-commit:
       glob: '*public/app/plugins/**/**/*.cue'
       run: make fix-cue
       stage_fixed: true
+
+    dashboard-golden-checksums:
+      glob: 'devenv/dev-dashboards/**/*.json'
+      run: |
+        cd apps/dashboard && make regenerate-golden-checksums &&
+        git add pkg/migration/testdata/golden_checksums.json pkg/migration/conversion/testdata/golden_checksums.json


### PR DESCRIPTION
I have forgotten a few times now to go into apps/dashboard and regenerate the golden checksums when committing a change to a gdev panel. I can't be the only one!

What if we just... did it automatically if we detect changes? Is that too much? Does my filter need refinement?