### PR TITLE
Dashboard: Add annotation CRUD to mutation API

### DIFF
--- a/public/app/features/dashboard-scene/mutation-api/commands/addAnnotation.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/addAnnotation.ts
@@ -18,9 +18,7 @@ import {
 import { payloads } from './schemas';
 import { enterEditModeIfNeeded, requiresEdit, type MutationCommand } from './types';
 
-export const addAnnotationPayloadSchema = payloads.addAnnotation;
-
-export type AddAnnotationPayload = z.infer<typeof addAnnotationPayloadSchema>;
+type AddAnnotationPayload = z.infer<typeof payloads.addAnnotation>;
 
 export const addAnnotationCommand: MutationCommand<AddAnnotationPayload> = {
   name: 'ADD_ANNOTATION',

--- a/public/app/features/dashboard-scene/mutation-api/commands/addAnnotation.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/addAnnotation.ts
@@ -1,0 +1,76 @@
+/**
+ * ADD_ANNOTATION command
+ *
+ * Add a dashboard annotation layer using v2beta1 AnnotationQueryKind format.
+ */
+
+import { type z } from 'zod';
+
+import { type AnnotationQueryKind } from '@grafana/schema/apis/dashboard.grafana.app/v2';
+
+import {
+  buildAnnotationLayer,
+  findAnnotationLayer,
+  getAnnotationLayerSet,
+  hasBuiltInAnnotation,
+  replaceAnnotationLayers,
+} from './annotationUtils';
+import { payloads } from './schemas';
+import { enterEditModeIfNeeded, requiresEdit, type MutationCommand } from './types';
+
+export const addAnnotationPayloadSchema = payloads.addAnnotation;
+
+export type AddAnnotationPayload = z.infer<typeof addAnnotationPayloadSchema>;
+
+export const addAnnotationCommand: MutationCommand<AddAnnotationPayload> = {
+  name: 'ADD_ANNOTATION',
+  description: payloads.addAnnotation.description ?? '',
+
+  payloadSchema: payloads.addAnnotation,
+  permission: requiresEdit,
+  readOnly: false,
+
+  handler: async (payload, context) => {
+    const { scene } = context;
+    enterEditModeIfNeeded(scene);
+
+    try {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Zod output is structurally compatible with AnnotationQueryKind
+      const annotation = payload.annotation as AnnotationQueryKind;
+      const name = annotation.spec.name;
+      const set = getAnnotationLayerSet(scene);
+
+      if (findAnnotationLayer(set, name)) {
+        throw new Error(`Annotation '${name}' already exists`);
+      }
+
+      if (annotation.spec.builtIn && hasBuiltInAnnotation(set)) {
+        throw new Error('Dashboard already has a built-in annotation layer');
+      }
+
+      const newLayer = buildAnnotationLayer(annotation);
+      const updated = [...set.state.annotationLayers];
+      const { position } = payload;
+
+      if (position !== undefined && position >= 0 && position < updated.length) {
+        updated.splice(position, 0, newLayer);
+      } else {
+        updated.push(newLayer);
+      }
+
+      replaceAnnotationLayers(set, updated);
+
+      return {
+        success: true,
+        data: { name },
+        changes: [{ path: `/annotations/${name}`, previousValue: null, newValue: name }],
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+        changes: [],
+      };
+    }
+  },
+};

--- a/public/app/features/dashboard-scene/mutation-api/commands/annotationCommands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/annotationCommands.test.ts
@@ -1,0 +1,345 @@
+import { dataLayers, type SceneDataLayerProvider } from '@grafana/scenes';
+import type { AnnotationQueryKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+
+import { DashboardAnnotationsDataLayer } from '../../scene/DashboardAnnotationsDataLayer';
+import { DashboardDataLayerSet } from '../../scene/DashboardDataLayerSet';
+import type { DashboardScene } from '../../scene/DashboardScene';
+import { DashboardMutationClient } from '../DashboardMutationClient';
+import type { MutationResult } from '../types';
+
+const grafanaBuiltInLayer = (): DashboardAnnotationsDataLayer =>
+  new DashboardAnnotationsDataLayer({
+    name: 'Annotations & Alerts',
+    isEnabled: true,
+    isHidden: false,
+    query: {
+      builtIn: 1,
+      datasource: { type: 'grafana', uid: '-- Grafana --' },
+      enable: true,
+      hide: true,
+      iconColor: 'rgba(0, 211, 255, 1)',
+      name: 'Annotations & Alerts',
+      type: 'dashboard',
+    },
+  });
+
+function buildMockScene(
+  options: {
+    editable?: boolean;
+    isEditing?: boolean;
+    annotationLayers?: SceneDataLayerProvider[];
+    withDataLayerSet?: boolean;
+  } = {}
+): DashboardScene {
+  const { editable = true, isEditing = false, annotationLayers = [], withDataLayerSet = true } = options;
+
+  const dataLayerSet = withDataLayerSet ? new DashboardDataLayerSet({ annotationLayers }) : undefined;
+
+  const state: Record<string, unknown> = {
+    uid: 'test-dash',
+    isEditing,
+    $data: dataLayerSet,
+  };
+  const scene = {
+    state,
+    canEditDashboard: jest.fn(() => editable),
+    onEnterEditMode: jest.fn(() => {
+      state.isEditing = true;
+    }),
+    forceRender: jest.fn(),
+    publishEvent: undefined,
+    setState: jest.fn((partial: Record<string, unknown>) => {
+      Object.assign(state, partial);
+    }),
+  };
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- mock scene satisfies DashboardScene at runtime
+  return scene as unknown as DashboardScene;
+}
+
+function makeAnnotationKind(name: string, overrides: Partial<AnnotationQueryKind['spec']> = {}): AnnotationQueryKind {
+  return {
+    kind: 'AnnotationQuery',
+    spec: {
+      name,
+      enable: true,
+      hide: false,
+      iconColor: 'red',
+      query: {
+        kind: 'DataQuery',
+        version: 'v0',
+        group: 'prometheus',
+        datasource: { name: 'prom-uid' },
+        spec: { expr: 'changes(deploy_total[5m])' },
+      },
+      ...overrides,
+    },
+  };
+}
+
+describe('Annotation mutation commands', () => {
+  let scene: ReturnType<typeof buildMockScene>;
+  let client: DashboardMutationClient;
+
+  beforeEach(() => {
+    scene = buildMockScene({ editable: true });
+    client = new DashboardMutationClient(scene);
+  });
+
+  describe('ADD_ANNOTATION', () => {
+    it('adds an annotation layer', async () => {
+      const result: MutationResult = await client.execute({
+        type: 'ADD_ANNOTATION',
+        payload: { annotation: makeAnnotationKind('deploys') },
+      });
+
+      expect(result.success).toBe(true);
+      expect(result.changes[0]).toEqual({
+        path: '/annotations/deploys',
+        previousValue: null,
+        newValue: 'deploys',
+      });
+
+      const set = scene.state.$data as DashboardDataLayerSet;
+      expect(set.state.annotationLayers).toHaveLength(1);
+      expect(set.state.annotationLayers[0].state.name).toBe('deploys');
+    });
+
+    it('appends after existing layers when no position is given', async () => {
+      scene = buildMockScene({
+        editable: true,
+        annotationLayers: [grafanaBuiltInLayer()],
+      });
+      client = new DashboardMutationClient(scene);
+
+      const result = await client.execute({
+        type: 'ADD_ANNOTATION',
+        payload: { annotation: makeAnnotationKind('deploys') },
+      });
+
+      expect(result.success).toBe(true);
+      const set = scene.state.$data as DashboardDataLayerSet;
+      expect(set.state.annotationLayers.map((l) => l.state.name)).toEqual(['Annotations & Alerts', 'deploys']);
+    });
+
+    it('inserts at the specified position', async () => {
+      scene = buildMockScene({
+        editable: true,
+        annotationLayers: [grafanaBuiltInLayer()],
+      });
+      client = new DashboardMutationClient(scene);
+
+      // First, add another annotation at the end.
+      await client.execute({
+        type: 'ADD_ANNOTATION',
+        payload: { annotation: makeAnnotationKind('errors') },
+      });
+
+      // Then, insert "deploys" between built-in and errors.
+      await client.execute({
+        type: 'ADD_ANNOTATION',
+        payload: { annotation: makeAnnotationKind('deploys'), position: 1 },
+      });
+
+      const set = scene.state.$data as DashboardDataLayerSet;
+      expect(set.state.annotationLayers.map((l) => l.state.name)).toEqual([
+        'Annotations & Alerts',
+        'deploys',
+        'errors',
+      ]);
+    });
+
+    it('rejects duplicate annotation name', async () => {
+      await client.execute({
+        type: 'ADD_ANNOTATION',
+        payload: { annotation: makeAnnotationKind('deploys') },
+      });
+
+      const result = await client.execute({
+        type: 'ADD_ANNOTATION',
+        payload: { annotation: makeAnnotationKind('deploys') },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Annotation 'deploys' already exists");
+    });
+
+    it('rejects a second built-in annotation', async () => {
+      scene = buildMockScene({
+        editable: true,
+        annotationLayers: [grafanaBuiltInLayer()],
+      });
+      client = new DashboardMutationClient(scene);
+
+      const result = await client.execute({
+        type: 'ADD_ANNOTATION',
+        payload: {
+          annotation: makeAnnotationKind('Another Built-in', { builtIn: true }),
+        },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('built-in annotation');
+    });
+  });
+
+  describe('UPDATE_ANNOTATION', () => {
+    it('replaces an annotation layer in place', async () => {
+      await client.execute({
+        type: 'ADD_ANNOTATION',
+        payload: { annotation: makeAnnotationKind('deploys', { iconColor: 'red' }) },
+      });
+      await client.execute({
+        type: 'ADD_ANNOTATION',
+        payload: { annotation: makeAnnotationKind('errors') },
+      });
+
+      const result = await client.execute({
+        type: 'UPDATE_ANNOTATION',
+        payload: {
+          name: 'deploys',
+          annotation: makeAnnotationKind('deploys', { iconColor: 'green' }),
+        },
+      });
+
+      expect(result.success).toBe(true);
+      const set = scene.state.$data as DashboardDataLayerSet;
+      expect(set.state.annotationLayers.map((l) => l.state.name)).toEqual(['deploys', 'errors']);
+      expect((set.state.annotationLayers[0] as DashboardAnnotationsDataLayer).state.query.iconColor).toBe('green');
+    });
+
+    it('returns error when annotation not found', async () => {
+      const result = await client.execute({
+        type: 'UPDATE_ANNOTATION',
+        payload: {
+          name: 'missing',
+          annotation: makeAnnotationKind('missing'),
+        },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Annotation 'missing' not found");
+    });
+  });
+
+  describe('REMOVE_ANNOTATION', () => {
+    it('removes an annotation by name', async () => {
+      await client.execute({
+        type: 'ADD_ANNOTATION',
+        payload: { annotation: makeAnnotationKind('deploys') },
+      });
+
+      const result = await client.execute({
+        type: 'REMOVE_ANNOTATION',
+        payload: { name: 'deploys' },
+      });
+
+      expect(result.success).toBe(true);
+      const set = scene.state.$data as DashboardDataLayerSet;
+      expect(set.state.annotationLayers).toHaveLength(0);
+    });
+
+    it('returns error for non-existent annotation', async () => {
+      const result = await client.execute({
+        type: 'REMOVE_ANNOTATION',
+        payload: { name: 'missing' },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Annotation 'missing' not found");
+    });
+
+    it('rejects removing the built-in annotation', async () => {
+      scene = buildMockScene({
+        editable: true,
+        annotationLayers: [grafanaBuiltInLayer()],
+      });
+      client = new DashboardMutationClient(scene);
+
+      const result = await client.execute({
+        type: 'REMOVE_ANNOTATION',
+        payload: { name: 'Annotations & Alerts' },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('built-in');
+    });
+  });
+
+  describe('LIST_ANNOTATIONS', () => {
+    it('returns all annotation layers in scene order', async () => {
+      scene = buildMockScene({
+        editable: true,
+        annotationLayers: [grafanaBuiltInLayer()],
+      });
+      client = new DashboardMutationClient(scene);
+
+      await client.execute({
+        type: 'ADD_ANNOTATION',
+        payload: { annotation: makeAnnotationKind('deploys') },
+      });
+
+      const result = await client.execute({ type: 'LIST_ANNOTATIONS', payload: {} });
+
+      expect(result.success).toBe(true);
+      const data = result.data as { annotations: AnnotationQueryKind[] };
+      expect(data.annotations.map((a) => a.spec.name)).toEqual(['Annotations & Alerts', 'deploys']);
+    });
+
+    it('returns an empty list when the dashboard has no data layer set', async () => {
+      scene = buildMockScene({ editable: true, withDataLayerSet: false });
+      client = new DashboardMutationClient(scene);
+
+      const result = await client.execute({ type: 'LIST_ANNOTATIONS', payload: {} });
+
+      expect(result.success).toBe(true);
+      expect((result.data as { annotations: unknown[] }).annotations).toEqual([]);
+    });
+
+    it('skips non-annotation layers', async () => {
+      scene = buildMockScene({
+        editable: true,
+        annotationLayers: [grafanaBuiltInLayer()],
+      });
+      client = new DashboardMutationClient(scene);
+
+      // Inject a non-annotation provider to confirm filtering.
+      const set = scene.state.$data as DashboardDataLayerSet;
+      const fakeLayer = {
+        state: { name: 'fake-layer' },
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- structural mock for filtering test
+      } as unknown as SceneDataLayerProvider;
+      set.setState({ annotationLayers: [...set.state.annotationLayers, fakeLayer] });
+
+      const result = await client.execute({ type: 'LIST_ANNOTATIONS', payload: {} });
+      const data = result.data as { annotations: AnnotationQueryKind[] };
+      expect(data.annotations.map((a) => a.spec.name)).toEqual(['Annotations & Alerts']);
+      expect(dataLayers.AnnotationsDataLayer).toBeDefined();
+    });
+  });
+
+  describe('Permissions and validation', () => {
+    it('rejects writes when dashboard is not editable', async () => {
+      scene = buildMockScene({ editable: false });
+      client = new DashboardMutationClient(scene);
+
+      const result = await client.execute({
+        type: 'ADD_ANNOTATION',
+        payload: { annotation: makeAnnotationKind('deploys') },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Cannot edit dashboard');
+    });
+
+    it('rejects ADD_ANNOTATION with missing required spec.name', async () => {
+      const result = await client.execute({
+        type: 'ADD_ANNOTATION',
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- intentionally invalid for validation test
+        payload: { annotation: { kind: 'AnnotationQuery', spec: {} } } as unknown as Record<string, unknown>,
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Validation failed');
+    });
+  });
+});

--- a/public/app/features/dashboard-scene/mutation-api/commands/annotationCommands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/annotationCommands.test.ts
@@ -183,7 +183,7 @@ describe('Annotation mutation commands', () => {
   });
 
   describe('UPDATE_ANNOTATION', () => {
-    it('replaces an annotation layer in place', async () => {
+    it('applies a partial spec, preserving untouched fields', async () => {
       await client.execute({
         type: 'ADD_ANNOTATION',
         payload: { annotation: makeAnnotationKind('deploys', { iconColor: 'red' }) },
@@ -197,14 +197,100 @@ describe('Annotation mutation commands', () => {
         type: 'UPDATE_ANNOTATION',
         payload: {
           name: 'deploys',
-          annotation: makeAnnotationKind('deploys', { iconColor: 'green' }),
+          annotation: { spec: { iconColor: 'green' } },
         },
       });
 
       expect(result.success).toBe(true);
       const set = scene.state.$data as DashboardDataLayerSet;
       expect(set.state.annotationLayers.map((l) => l.state.name)).toEqual(['deploys', 'errors']);
-      expect((set.state.annotationLayers[0] as DashboardAnnotationsDataLayer).state.query.iconColor).toBe('green');
+      const layer = set.state.annotationLayers[0] as DashboardAnnotationsDataLayer;
+      expect(layer.state.query.iconColor).toBe('green');
+      expect(layer.state.query.datasource?.type).toBe('prometheus');
+      expect(layer.state.query.target).toMatchObject({ expr: 'changes(deploy_total[5m])' });
+    });
+
+    it('deep-merges a nested query spec', async () => {
+      await client.execute({
+        type: 'ADD_ANNOTATION',
+        payload: { annotation: makeAnnotationKind('deploys') },
+      });
+
+      const result = await client.execute({
+        type: 'UPDATE_ANNOTATION',
+        payload: {
+          name: 'deploys',
+          annotation: { spec: { query: { spec: { expr: 'changes(deploy_total[10m])' } } } },
+        },
+      });
+
+      expect(result.success).toBe(true);
+      const set = scene.state.$data as DashboardDataLayerSet;
+      const layer = set.state.annotationLayers[0] as DashboardAnnotationsDataLayer;
+      expect(layer.state.query.datasource?.type).toBe('prometheus');
+      expect(layer.state.query.datasource?.uid).toBe('prom-uid');
+      expect(layer.state.query.target).toMatchObject({ expr: 'changes(deploy_total[10m])' });
+    });
+
+    it('replaces array fields wholesale (filter.ids)', async () => {
+      await client.execute({
+        type: 'ADD_ANNOTATION',
+        payload: {
+          annotation: makeAnnotationKind('deploys', { filter: { exclude: false, ids: [1, 2, 3] } }),
+        },
+      });
+
+      const result = await client.execute({
+        type: 'UPDATE_ANNOTATION',
+        payload: {
+          name: 'deploys',
+          annotation: { spec: { filter: { ids: [9] } } },
+        },
+      });
+
+      expect(result.success).toBe(true);
+      const set = scene.state.$data as DashboardDataLayerSet;
+      const layer = set.state.annotationLayers[0] as DashboardAnnotationsDataLayer;
+      expect(layer.state.query.filter?.ids).toEqual([9]);
+      expect(layer.state.query.filter?.exclude).toBe(false);
+    });
+
+    it('renames via partial spec.name', async () => {
+      await client.execute({
+        type: 'ADD_ANNOTATION',
+        payload: { annotation: makeAnnotationKind('old-name', { iconColor: 'blue' }) },
+      });
+
+      const result = await client.execute({
+        type: 'UPDATE_ANNOTATION',
+        payload: {
+          name: 'old-name',
+          annotation: { spec: { name: 'new-name' } },
+        },
+      });
+
+      expect(result.success).toBe(true);
+      const set = scene.state.$data as DashboardDataLayerSet;
+      expect(set.state.annotationLayers.map((l) => l.state.name)).toEqual(['new-name']);
+      expect((set.state.annotationLayers[0] as DashboardAnnotationsDataLayer).state.query.iconColor).toBe('blue');
+    });
+
+    it('treats an empty partial spec as a no-op', async () => {
+      await client.execute({
+        type: 'ADD_ANNOTATION',
+        payload: { annotation: makeAnnotationKind('deploys', { iconColor: 'orange' }) },
+      });
+
+      const result = await client.execute({
+        type: 'UPDATE_ANNOTATION',
+        payload: { name: 'deploys', annotation: { spec: {} } },
+      });
+
+      expect(result.success).toBe(true);
+      const set = scene.state.$data as DashboardDataLayerSet;
+      const layer = set.state.annotationLayers[0] as DashboardAnnotationsDataLayer;
+      expect(layer.state.name).toBe('deploys');
+      expect(layer.state.query.iconColor).toBe('orange');
     });
 
     it('returns error when annotation not found', async () => {
@@ -212,7 +298,7 @@ describe('Annotation mutation commands', () => {
         type: 'UPDATE_ANNOTATION',
         payload: {
           name: 'missing',
-          annotation: makeAnnotationKind('missing'),
+          annotation: { spec: { iconColor: 'green' } },
         },
       });
 
@@ -234,7 +320,7 @@ describe('Annotation mutation commands', () => {
         type: 'UPDATE_ANNOTATION',
         payload: {
           name: 'A',
-          annotation: makeAnnotationKind('B'),
+          annotation: { spec: { name: 'B' } },
         },
       });
 

--- a/public/app/features/dashboard-scene/mutation-api/commands/annotationCommands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/annotationCommands.test.ts
@@ -219,6 +219,30 @@ describe('Annotation mutation commands', () => {
       expect(result.success).toBe(false);
       expect(result.error).toContain("Annotation 'missing' not found");
     });
+
+    it('rejects renaming to a name that already exists', async () => {
+      await client.execute({
+        type: 'ADD_ANNOTATION',
+        payload: { annotation: makeAnnotationKind('A') },
+      });
+      await client.execute({
+        type: 'ADD_ANNOTATION',
+        payload: { annotation: makeAnnotationKind('B') },
+      });
+
+      const result = await client.execute({
+        type: 'UPDATE_ANNOTATION',
+        payload: {
+          name: 'A',
+          annotation: makeAnnotationKind('B'),
+        },
+      });
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain("Annotation 'B' already exists");
+      const set = scene.state.$data as DashboardDataLayerSet;
+      expect(set.state.annotationLayers.map((l) => l.state.name)).toEqual(['A', 'B']);
+    });
   });
 
   describe('REMOVE_ANNOTATION', () => {

--- a/public/app/features/dashboard-scene/mutation-api/commands/annotationUtils.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/annotationUtils.ts
@@ -1,0 +1,105 @@
+/**
+ * Helpers shared by annotation mutation commands.
+ */
+
+import { type AnnotationQuery } from '@grafana/data';
+import { dataLayers, type SceneDataLayerProvider } from '@grafana/scenes';
+import { type AnnotationQueryKind } from '@grafana/schema/apis/dashboard.grafana.app/v2';
+
+import { DashboardAnnotationsDataLayer } from '../../scene/DashboardAnnotationsDataLayer';
+import type { DashboardDataLayerSet } from '../../scene/DashboardDataLayerSet';
+import type { DashboardScene } from '../../scene/DashboardScene';
+import { transformV1ToV2AnnotationQuery, transformV2ToV1AnnotationQuery } from '../../serialization/annotations';
+import { dashboardSceneGraph } from '../../utils/dashboardSceneGraph';
+
+/**
+ * Returns the dashboard's `DashboardDataLayerSet`. Throws when the scene has
+ * no annotations layer set (should not happen on real dashboards).
+ */
+export function getAnnotationLayerSet(scene: DashboardScene): DashboardDataLayerSet {
+  return dashboardSceneGraph.getDataLayers(scene);
+}
+
+/**
+ * Find an annotation layer by its `state.name`. Returns the layer and its index
+ * within `annotationLayers`, or `null` if not found.
+ */
+export function findAnnotationLayer(
+  set: DashboardDataLayerSet,
+  name: string
+): { layer: SceneDataLayerProvider; index: number } | null {
+  const layers = set.state.annotationLayers;
+  for (let i = 0; i < layers.length; i++) {
+    if (layers[i].state.name === name) {
+      return { layer: layers[i], index: i };
+    }
+  }
+  return null;
+}
+
+/**
+ * Build a new `DashboardAnnotationsDataLayer` from a v2beta1 `AnnotationQueryKind`.
+ *
+ * Uses `transformV2ToV1AnnotationQuery` to derive the v1 `AnnotationQuery` that
+ * scene layers actually store, then mirrors the layer-level fields
+ * (`name`, `isEnabled`, `isHidden`, `placement`) the same way the v2 load path
+ * does in `transformSaveModelSchemaV2ToScene`.
+ */
+export function buildAnnotationLayer(annotation: AnnotationQueryKind): DashboardAnnotationsDataLayer {
+  const query: AnnotationQuery = transformV2ToV1AnnotationQuery(annotation);
+  return new DashboardAnnotationsDataLayer({
+    query,
+    name: annotation.spec.name,
+    isEnabled: Boolean(annotation.spec.enable),
+    isHidden: Boolean(annotation.spec.hide),
+    placement: annotation.spec.placement,
+  });
+}
+
+/**
+ * Replace the annotation layers list. The set's existing activation handler
+ * re-subscribes when `annotationLayers !== oldState.annotationLayers`, so no
+ * manual re-activation is required.
+ */
+export function replaceAnnotationLayers(set: DashboardDataLayerSet, layers: SceneDataLayerProvider[]): void {
+  set.setState({ annotationLayers: layers });
+}
+
+/**
+ * Convert a layer back to a v2beta1 `AnnotationQueryKind`. Used by `LIST_ANNOTATIONS`
+ * to surface current scene state to LLM tool callers.
+ *
+ * Layers built outside the v2 load path may not carry full datasource type/uid
+ * metadata; in that case the v1 → v2 transform falls back to whatever is stored
+ * on the underlying `AnnotationQuery`. Returns `null` for unsupported layer types.
+ */
+export function annotationLayerToKind(layer: SceneDataLayerProvider): AnnotationQueryKind | null {
+  if (!(layer instanceof dataLayers.AnnotationsDataLayer)) {
+    return null;
+  }
+  const query = layer.state.query;
+  const dsType = query.datasource?.type ?? '';
+  const dsUid = query.datasource?.uid;
+  return transformV1ToV2AnnotationQuery(query, dsType, dsUid, {
+    enable: layer.state.isEnabled,
+    hide: layer.state.isHidden,
+  });
+}
+
+/**
+ * `true` when the layer represents the built-in Grafana annotations entry,
+ * which is auto-injected on dashboard load and cannot be removed.
+ */
+export function isBuiltInAnnotation(layer: SceneDataLayerProvider): boolean {
+  if (!(layer instanceof dataLayers.AnnotationsDataLayer)) {
+    return false;
+  }
+  return Boolean(layer.state.query.builtIn);
+}
+
+/**
+ * `true` when any layer in the set is the built-in Grafana annotation.
+ */
+export function hasBuiltInAnnotation(set: DashboardDataLayerSet): boolean {
+  return set.state.annotationLayers.some(isBuiltInAnnotation);
+}

--- a/public/app/features/dashboard-scene/mutation-api/commands/commands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/commands.test.ts
@@ -36,6 +36,7 @@ describe('Command consistency', () => {
     for (const cmd of ALL_COMMANDS) {
       if (
         cmd.name === 'LIST_VARIABLES' ||
+        cmd.name === 'LIST_ANNOTATIONS' ||
         cmd.name === 'ENTER_EDIT_MODE' ||
         cmd.name === 'GET_LAYOUT' ||
         cmd.name === 'LIST_PANELS' ||
@@ -50,6 +51,7 @@ describe('Command consistency', () => {
   it('registers the expected set of commands', () => {
     const names = ALL_COMMANDS.map((cmd) => cmd.name).sort();
     expect(names).toEqual([
+      'ADD_ANNOTATION',
       'ADD_PANEL',
       'ADD_ROW',
       'ADD_TAB',
@@ -57,15 +59,18 @@ describe('Command consistency', () => {
       'ENTER_EDIT_MODE',
       'GET_DASHBOARD_INFO',
       'GET_LAYOUT',
+      'LIST_ANNOTATIONS',
       'LIST_PANELS',
       'LIST_VARIABLES',
       'MOVE_PANEL',
       'MOVE_ROW',
       'MOVE_TAB',
+      'REMOVE_ANNOTATION',
       'REMOVE_PANEL',
       'REMOVE_ROW',
       'REMOVE_TAB',
       'REMOVE_VARIABLE',
+      'UPDATE_ANNOTATION',
       'UPDATE_DASHBOARD_SETTINGS',
       'UPDATE_LAYOUT',
       'UPDATE_PANEL',

--- a/public/app/features/dashboard-scene/mutation-api/commands/listAnnotations.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/listAnnotations.ts
@@ -1,0 +1,58 @@
+/**
+ * LIST_ANNOTATIONS command
+ *
+ * List all annotation layers on the current dashboard in v2beta1
+ * AnnotationQueryKind format. Returns layers in scene order (built-in first
+ * by load convention).
+ */
+
+import type { AnnotationQueryKind } from '@grafana/schema/apis/dashboard.grafana.app/v2';
+
+import type { DashboardDataLayerSet } from '../../scene/DashboardDataLayerSet';
+import { dashboardSceneGraph } from '../../utils/dashboardSceneGraph';
+
+import { annotationLayerToKind } from './annotationUtils';
+import { payloads } from './schemas';
+import { readOnly, type MutationCommand } from './types';
+
+export const listAnnotationsCommand: MutationCommand<Record<string, never>> = {
+  name: 'LIST_ANNOTATIONS',
+  description: payloads.listAnnotations.description ?? '',
+
+  payloadSchema: payloads.listAnnotations,
+  permission: readOnly,
+  readOnly: true,
+
+  handler: async (_payload, context) => {
+    const { scene } = context;
+
+    try {
+      let set: DashboardDataLayerSet;
+      try {
+        set = dashboardSceneGraph.getDataLayers(scene);
+      } catch {
+        return { success: true, data: { annotations: [] }, changes: [] };
+      }
+
+      const annotations: AnnotationQueryKind[] = [];
+      for (const layer of set.state.annotationLayers) {
+        const kind = annotationLayerToKind(layer);
+        if (kind) {
+          annotations.push(kind);
+        }
+      }
+
+      return {
+        success: true,
+        data: { annotations },
+        changes: [],
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+        changes: [],
+      };
+    }
+  },
+};

--- a/public/app/features/dashboard-scene/mutation-api/commands/registry.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/registry.ts
@@ -5,6 +5,7 @@
  * The DashboardMutationClient iterates over ALL_COMMANDS generically.
  */
 
+import { addAnnotationCommand } from './addAnnotation';
 import { addPanelCommand } from './addPanel';
 import { addRowCommand } from './addRow';
 import { addTabCommand } from './addTab';
@@ -12,16 +13,19 @@ import { addVariableCommand } from './addVariable';
 import { enterEditModeCommand } from './enterEditMode';
 import { getDashboardInfoCommand } from './getDashboardInfo';
 import { getLayoutCommand } from './getLayout';
+import { listAnnotationsCommand } from './listAnnotations';
 import { listPanelsCommand } from './listPanels';
 import { listVariablesCommand } from './listVariables';
 import { movePanelCommand } from './movePanel';
 import { moveRowCommand } from './moveRow';
 import { moveTabCommand } from './moveTab';
+import { removeAnnotationCommand } from './removeAnnotation';
 import { removePanelCommand } from './removePanel';
 import { removeRowCommand } from './removeRow';
 import { removeTabCommand } from './removeTab';
 import { removeVariableCommand } from './removeVariable';
 import type { MutationCommand } from './types';
+import { updateAnnotationCommand } from './updateAnnotation';
 import { updateDashboardSettingsCommand } from './updateDashboardSettings';
 import { updateLayoutCommand } from './updateLayout';
 import { updatePanelCommand } from './updatePanel';
@@ -35,6 +39,10 @@ export const ALL_COMMANDS: Array<MutationCommand<any>> = [
   removeVariableCommand,
   updateVariableCommand,
   listVariablesCommand,
+  addAnnotationCommand,
+  updateAnnotationCommand,
+  removeAnnotationCommand,
+  listAnnotationsCommand,
   enterEditModeCommand,
   getLayoutCommand,
   addRowCommand,

--- a/public/app/features/dashboard-scene/mutation-api/commands/removeAnnotation.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/removeAnnotation.ts
@@ -1,0 +1,64 @@
+/**
+ * REMOVE_ANNOTATION command
+ *
+ * Remove a dashboard annotation layer by name. Built-in Grafana annotations
+ * cannot be removed (they are auto-injected on dashboard load).
+ */
+
+import { type z } from 'zod';
+
+import {
+  findAnnotationLayer,
+  getAnnotationLayerSet,
+  isBuiltInAnnotation,
+  replaceAnnotationLayers,
+} from './annotationUtils';
+import { payloads } from './schemas';
+import { enterEditModeIfNeeded, requiresEdit, type MutationCommand } from './types';
+
+export const removeAnnotationPayloadSchema = payloads.removeAnnotation;
+
+export type RemoveAnnotationPayload = z.infer<typeof removeAnnotationPayloadSchema>;
+
+export const removeAnnotationCommand: MutationCommand<RemoveAnnotationPayload> = {
+  name: 'REMOVE_ANNOTATION',
+  description: payloads.removeAnnotation.description ?? '',
+
+  payloadSchema: payloads.removeAnnotation,
+  permission: requiresEdit,
+  readOnly: false,
+
+  handler: async (payload, context) => {
+    const { scene } = context;
+    enterEditModeIfNeeded(scene);
+
+    try {
+      const { name } = payload;
+      const set = getAnnotationLayerSet(scene);
+      const found = findAnnotationLayer(set, name);
+      if (!found) {
+        throw new Error(`Annotation '${name}' not found`);
+      }
+
+      if (isBuiltInAnnotation(found.layer)) {
+        throw new Error(`Cannot remove the built-in Grafana annotation layer`);
+      }
+
+      const previousState = found.layer.state;
+      const updated = set.state.annotationLayers.filter((_, idx) => idx !== found.index);
+      replaceAnnotationLayers(set, updated);
+
+      return {
+        success: true,
+        data: { name },
+        changes: [{ path: `/annotations/${name}`, previousValue: previousState, newValue: null }],
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+        changes: [],
+      };
+    }
+  },
+};

--- a/public/app/features/dashboard-scene/mutation-api/commands/removeAnnotation.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/removeAnnotation.ts
@@ -16,9 +16,7 @@ import {
 import { payloads } from './schemas';
 import { enterEditModeIfNeeded, requiresEdit, type MutationCommand } from './types';
 
-export const removeAnnotationPayloadSchema = payloads.removeAnnotation;
-
-export type RemoveAnnotationPayload = z.infer<typeof removeAnnotationPayloadSchema>;
+type RemoveAnnotationPayload = z.infer<typeof payloads.removeAnnotation>;
 
 export const removeAnnotationCommand: MutationCommand<RemoveAnnotationPayload> = {
   name: 'REMOVE_ANNOTATION',

--- a/public/app/features/dashboard-scene/mutation-api/commands/schemas.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/schemas.ts
@@ -544,6 +544,62 @@ export const partialTabSpecSchema = z
   })
   .describe('Fields to update (partial TabsLayoutTabSpec)');
 
+// Annotation building-block schemas (v2beta1)
+
+const annotationPanelFilterSchema = z.object({
+  exclude: z
+    .boolean()
+    .optional()
+    .describe('When true, the listed panels are excluded; otherwise only those panels show the annotation'),
+  ids: z.array(z.number()).describe('Panel IDs to include or exclude'),
+});
+
+const annotationEventFieldMappingSchema = z.object({
+  source: z.string().optional().describe('Source type for the field value (e.g., "field", "text")'),
+  value: z.string().optional().describe('Constant value to use when source is "text"'),
+  regex: z.string().optional().describe('Regular expression applied to the field value'),
+});
+
+export const annotationQueryKindSchema = z.object({
+  kind: z.literal('AnnotationQuery').optional().default('AnnotationQuery'),
+  spec: z.object({
+    name: z.string().describe('Annotation name. Must be unique within the dashboard.'),
+    enable: z.boolean().optional().default(true).describe('Whether the annotation is enabled by default'),
+    hide: z
+      .boolean()
+      .optional()
+      .default(false)
+      .describe('Whether the annotation toggle is hidden from the dashboard controls'),
+    iconColor: z
+      .string()
+      .optional()
+      .default('red')
+      .describe('Icon color for the annotation marker (e.g., "red", "blue", semantic color name)'),
+    builtIn: z
+      .boolean()
+      .optional()
+      .describe(
+        'Built-in Grafana dashboard annotations layer. Exactly one built-in annotation exists per dashboard and is managed by Grafana.'
+      ),
+    placement: z
+      .literal('inControlsMenu')
+      .optional()
+      .describe('Render the annotation toggle in the dashboard controls dropdown menu instead of inline'),
+    filter: annotationPanelFilterSchema.optional().describe('Limit the annotation to specific panels'),
+    mappings: z
+      .record(z.string(), annotationEventFieldMappingSchema)
+      .optional()
+      .describe('Map data frame fields to annotation event fields'),
+    legacyOptions: z
+      .record(z.string(), z.unknown())
+      .optional()
+      .describe('Catch-all bag for datasource-specific properties'),
+    query: dataQueryKindSchema.describe(
+      'Annotation query (DataQueryKind). For built-in dashboard annotations use group: "grafana".'
+    ),
+  }),
+});
+
 // Payload schemas -- one per mutation command.
 // These compose the building-block schemas above into the exact shape
 // each command's `payload` field expects.
@@ -560,6 +616,22 @@ export const updateVariablePayloadSchema = z.object({
 
 export const removeVariablePayloadSchema = z.object({
   name: z.string().describe('Variable name to remove'),
+});
+
+// Annotation payload schemas
+
+export const addAnnotationPayloadSchema = z.object({
+  annotation: annotationQueryKindSchema.describe('Annotation definition (AnnotationQueryKind)'),
+  position: z.number().optional().describe('Position in annotations list (optional, appends if not set)'),
+});
+
+export const updateAnnotationPayloadSchema = z.object({
+  name: z.string().describe('Annotation name to update'),
+  annotation: annotationQueryKindSchema.describe('New annotation definition (AnnotationQueryKind)'),
+});
+
+export const removeAnnotationPayloadSchema = z.object({
+  name: z.string().describe('Annotation name to remove'),
 });
 
 // Layout payload schemas
@@ -1012,6 +1084,10 @@ export const payloads = {
   removeVariable: removeVariablePayloadSchema.describe('Remove a template variable'),
   updateVariable: updateVariablePayloadSchema.describe('Update an existing template variable'),
   listVariables: emptyPayloadSchema.describe('List all template variables on the dashboard'),
+  addAnnotation: addAnnotationPayloadSchema.describe('Add a new dashboard annotation layer'),
+  updateAnnotation: updateAnnotationPayloadSchema.describe('Update an existing dashboard annotation layer by name'),
+  removeAnnotation: removeAnnotationPayloadSchema.describe('Remove a dashboard annotation layer by name'),
+  listAnnotations: emptyPayloadSchema.describe('List all annotation layers on the dashboard'),
   enterEditMode: emptyPayloadSchema.describe('Enter dashboard edit mode'),
   getLayout: getLayoutPayloadSchema.describe('Get the dashboard layout tree and trimmed elements map'),
   addRow: addRowPayloadSchema.describe('Add a new row to the dashboard layout'),

--- a/public/app/features/dashboard-scene/mutation-api/commands/schemas.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/schemas.ts
@@ -600,6 +600,46 @@ export const annotationQueryKindSchema = z.object({
   }),
 });
 
+const partialAnnotationPanelFilterSchema = z.object({
+  exclude: z
+    .boolean()
+    .optional()
+    .describe('When true, the listed panels are excluded; otherwise only those panels show the annotation'),
+  ids: z.array(z.number()).optional().describe('Panel IDs to include or exclude (replaces existing array)'),
+});
+
+const partialDataQueryKindSchema = z.object({
+  kind: z.literal('DataQuery').optional(),
+  group: z.string().optional().describe('Datasource type (e.g., "prometheus", "loki", "grafana")'),
+  version: z.string().optional(),
+  datasource: z
+    .object({
+      name: z.string().optional(),
+    })
+    .optional(),
+  spec: z
+    .record(z.string(), z.unknown())
+    .optional()
+    .describe('Query-specific fields. Deep-merged into the existing query spec.'),
+});
+
+export const partialAnnotationQueryKindSchema = z.object({
+  kind: z.literal('AnnotationQuery').optional(),
+  spec: z
+    .object({
+      name: z.string().optional().describe('Rename the annotation. Must remain unique within the dashboard.'),
+      enable: z.boolean().optional(),
+      hide: z.boolean().optional(),
+      iconColor: z.string().optional(),
+      placement: z.literal('inControlsMenu').optional(),
+      filter: partialAnnotationPanelFilterSchema.optional(),
+      mappings: z.record(z.string(), annotationEventFieldMappingSchema).optional(),
+      legacyOptions: z.record(z.string(), z.unknown()).optional(),
+      query: partialDataQueryKindSchema.optional().describe('Partial query update; deep-merged into existing query.'),
+    })
+    .describe('Fields to update (partial AnnotationQuerySpec). Omitted fields are left unchanged.'),
+});
+
 // Payload schemas -- one per mutation command.
 // These compose the building-block schemas above into the exact shape
 // each command's `payload` field expects.
@@ -627,7 +667,10 @@ export const addAnnotationPayloadSchema = z.object({
 
 export const updateAnnotationPayloadSchema = z.object({
   name: z.string().describe('Annotation name to update'),
-  annotation: annotationQueryKindSchema.describe('New annotation definition (AnnotationQueryKind)'),
+  annotation: partialAnnotationQueryKindSchema.describe(
+    'Partial annotation update. Only provided fields are applied. Object fields are deep-merged. ' +
+      'Arrays (e.g. filter.ids) are replaced wholesale.'
+  ),
 });
 
 export const removeAnnotationPayloadSchema = z.object({
@@ -1085,7 +1128,9 @@ export const payloads = {
   updateVariable: updateVariablePayloadSchema.describe('Update an existing template variable'),
   listVariables: emptyPayloadSchema.describe('List all template variables on the dashboard'),
   addAnnotation: addAnnotationPayloadSchema.describe('Add a new dashboard annotation layer'),
-  updateAnnotation: updateAnnotationPayloadSchema.describe('Update an existing dashboard annotation layer by name'),
+  updateAnnotation: updateAnnotationPayloadSchema.describe(
+    'Update an existing dashboard annotation layer by name (partial update, deep-merge)'
+  ),
   removeAnnotation: removeAnnotationPayloadSchema.describe('Remove a dashboard annotation layer by name'),
   listAnnotations: emptyPayloadSchema.describe('List all annotation layers on the dashboard'),
   enterEditMode: emptyPayloadSchema.describe('Enter dashboard edit mode'),

--- a/public/app/features/dashboard-scene/mutation-api/commands/updateAnnotation.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updateAnnotation.ts
@@ -18,9 +18,7 @@ import {
 import { payloads } from './schemas';
 import { enterEditModeIfNeeded, requiresEdit, type MutationCommand } from './types';
 
-export const updateAnnotationPayloadSchema = payloads.updateAnnotation;
-
-export type UpdateAnnotationPayload = z.infer<typeof updateAnnotationPayloadSchema>;
+type UpdateAnnotationPayload = z.infer<typeof payloads.updateAnnotation>;
 
 export const updateAnnotationCommand: MutationCommand<UpdateAnnotationPayload> = {
   name: 'UPDATE_ANNOTATION',

--- a/public/app/features/dashboard-scene/mutation-api/commands/updateAnnotation.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updateAnnotation.ts
@@ -1,0 +1,73 @@
+/**
+ * UPDATE_ANNOTATION command
+ *
+ * Replace an existing dashboard annotation layer with a new definition,
+ * preserving its position in the annotations list.
+ */
+
+import { type z } from 'zod';
+
+import { type AnnotationQueryKind } from '@grafana/schema/apis/dashboard.grafana.app/v2';
+
+import {
+  buildAnnotationLayer,
+  findAnnotationLayer,
+  getAnnotationLayerSet,
+  replaceAnnotationLayers,
+} from './annotationUtils';
+import { payloads } from './schemas';
+import { enterEditModeIfNeeded, requiresEdit, type MutationCommand } from './types';
+
+export const updateAnnotationPayloadSchema = payloads.updateAnnotation;
+
+export type UpdateAnnotationPayload = z.infer<typeof updateAnnotationPayloadSchema>;
+
+export const updateAnnotationCommand: MutationCommand<UpdateAnnotationPayload> = {
+  name: 'UPDATE_ANNOTATION',
+  description: payloads.updateAnnotation.description ?? '',
+
+  payloadSchema: payloads.updateAnnotation,
+  permission: requiresEdit,
+  readOnly: false,
+
+  handler: async (payload, context) => {
+    const { scene } = context;
+    enterEditModeIfNeeded(scene);
+
+    try {
+      const { name } = payload;
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Zod output is structurally compatible with AnnotationQueryKind
+      const annotation = payload.annotation as AnnotationQueryKind;
+      const set = getAnnotationLayerSet(scene);
+
+      const found = findAnnotationLayer(set, name);
+      if (!found) {
+        throw new Error(`Annotation '${name}' not found`);
+      }
+
+      const previousState = found.layer.state;
+      const newLayer = buildAnnotationLayer(annotation);
+      const updated = [...set.state.annotationLayers];
+      updated[found.index] = newLayer;
+      replaceAnnotationLayers(set, updated);
+
+      return {
+        success: true,
+        data: { name: annotation.spec.name },
+        changes: [
+          {
+            path: `/annotations/${name}`,
+            previousValue: previousState,
+            newValue: annotation.spec.name,
+          },
+        ],
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+        changes: [],
+      };
+    }
+  },
+};

--- a/public/app/features/dashboard-scene/mutation-api/commands/updateAnnotation.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updateAnnotation.ts
@@ -43,6 +43,11 @@ export const updateAnnotationCommand: MutationCommand<UpdateAnnotationPayload> =
         throw new Error(`Annotation '${name}' not found`);
       }
 
+      const newName = annotation.spec.name;
+      if (newName !== name && findAnnotationLayer(set, newName)) {
+        throw new Error(`Annotation '${newName}' already exists`);
+      }
+
       const previousState = found.layer.state;
       const newLayer = buildAnnotationLayer(annotation);
       const updated = [...set.state.annotationLayers];

--- a/public/app/features/dashboard-scene/mutation-api/commands/updateAnnotation.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updateAnnotation.ts
@@ -1,15 +1,19 @@
 /**
  * UPDATE_ANNOTATION command
  *
- * Replace an existing dashboard annotation layer with a new definition,
- * preserving its position in the annotations list.
+ * Partial update of an existing dashboard annotation layer. Only the fields
+ * provided in `annotation.spec` are applied; everything else on the layer is
+ * preserved. Object fields are deep-merged; arrays (e.g. `filter.ids`) are
+ * replaced wholesale to match `UPDATE_PANEL` semantics.
  */
 
+import { cloneDeep, isArray, mergeWith } from 'lodash';
 import { type z } from 'zod';
 
 import { type AnnotationQueryKind } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 
 import {
+  annotationLayerToKind,
   buildAnnotationLayer,
   findAnnotationLayer,
   getAnnotationLayerSet,
@@ -19,6 +23,20 @@ import { payloads } from './schemas';
 import { enterEditModeIfNeeded, requiresEdit, type MutationCommand } from './types';
 
 type UpdateAnnotationPayload = z.infer<typeof payloads.updateAnnotation>;
+
+// Mirrors the helper inlined in updatePanel.ts. Kept local here to avoid touching
+// already-shipped panel code; share via a common util once both PRs land.
+function mergeReplacingArrays(
+  target: Record<string, unknown>,
+  source: Record<string, unknown>
+): Record<string, unknown> {
+  return mergeWith(cloneDeep(target), source, (_objValue: unknown, srcValue: unknown) => {
+    if (isArray(srcValue)) {
+      return srcValue;
+    }
+    return undefined;
+  });
+}
 
 export const updateAnnotationCommand: MutationCommand<UpdateAnnotationPayload> = {
   name: 'UPDATE_ANNOTATION',
@@ -34,8 +52,6 @@ export const updateAnnotationCommand: MutationCommand<UpdateAnnotationPayload> =
 
     try {
       const { name } = payload;
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Zod output is structurally compatible with AnnotationQueryKind
-      const annotation = payload.annotation as AnnotationQueryKind;
       const set = getAnnotationLayerSet(scene);
 
       const found = findAnnotationLayer(set, name);
@@ -43,25 +59,38 @@ export const updateAnnotationCommand: MutationCommand<UpdateAnnotationPayload> =
         throw new Error(`Annotation '${name}' not found`);
       }
 
-      const newName = annotation.spec.name;
-      if (newName !== name && findAnnotationLayer(set, newName)) {
+      const existingKind = annotationLayerToKind(found.layer);
+      if (!existingKind) {
+        throw new Error(`Annotation '${name}' could not be read for partial update`);
+      }
+
+      const newName = payload.annotation.spec?.name;
+      if (newName !== undefined && newName !== name && findAnnotationLayer(set, newName)) {
         throw new Error(`Annotation '${newName}' already exists`);
       }
 
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- mergeReplacingArrays is structurally typed; cast both sides through Record for the helper and back to the kind shape.
+      const existingAsRecord = existingKind as unknown as Record<string, unknown>;
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- partial Zod output is structurally a Record subset of AnnotationQueryKind.
+      const partialAsRecord = payload.annotation as Record<string, unknown>;
+      const mergedRecord = mergeReplacingArrays(existingAsRecord, partialAsRecord);
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- merge result is structurally an AnnotationQueryKind because both inputs were.
+      const merged = mergedRecord as unknown as AnnotationQueryKind;
+
       const previousState = found.layer.state;
-      const newLayer = buildAnnotationLayer(annotation);
+      const newLayer = buildAnnotationLayer(merged);
       const updated = [...set.state.annotationLayers];
       updated[found.index] = newLayer;
       replaceAnnotationLayers(set, updated);
 
       return {
         success: true,
-        data: { name: annotation.spec.name },
+        data: { name: merged.spec.name },
         changes: [
           {
             path: `/annotations/${name}`,
             previousValue: previousState,
-            newValue: annotation.spec.name,
+            newValue: merged.spec.name,
           },
         ],
       };

--- a/public/app/features/dashboard-scene/mutation-api/index.ts
+++ b/public/app/features/dashboard-scene/mutation-api/index.ts
@@ -20,6 +20,7 @@ export type {
   PanelElementEntry,
   PanelElementsData,
   ListVariablesData,
+  ListAnnotationsData,
 } from './types';
 
 export { ALL_COMMANDS, MUTATION_TYPES, validatePayload } from './commands/registry';

--- a/public/app/features/dashboard-scene/mutation-api/types.ts
+++ b/public/app/features/dashboard-scene/mutation-api/types.ts
@@ -7,6 +7,7 @@
  */
 
 import type {
+  AnnotationQueryKind,
   AutoGridLayoutItemKind,
   Element,
   GridLayoutItemKind,
@@ -50,4 +51,8 @@ export interface PanelElementsData {
 
 export interface ListVariablesData {
   variables: VariableKind[];
+}
+
+export interface ListAnnotationsData {
+  annotations: AnnotationQueryKind[];
 }


### PR DESCRIPTION
## Summary

Adds `ADD_ANNOTATION`, `UPDATE_ANNOTATION`, `REMOVE_ANNOTATION`, and `LIST_ANNOTATIONS` to the Dashboard Mutation API so external tooling (e.g. the Grafana Assistant) can manage dashboard annotation layers without touching the scene tree directly.

`UPDATE_ANNOTATION` accepts a **partial `AnnotationQueryKind`** and deep-merges it into the existing layer, mirroring `UPDATE_PANEL`. Object fields are deep-merged; arrays (e.g. `filter.ids`) are replaced wholesale. Callers can now say "change just `iconColor`" without re-emitting the full kind.

## What

- New commands under `public/app/features/dashboard-scene/mutation-api/commands/`:
  - `addAnnotation`, `updateAnnotation`, `removeAnnotation`, `listAnnotations`
  - `annotationUtils` with shared helpers (layer resolution, v2↔v1 conversion via the existing `transformV2ToV1AnnotationQuery` / `transformV1ToV2AnnotationQuery`, built-in detection)
- Building-block `annotationQueryKindSchema` + new `partialAnnotationQueryKindSchema` (every `spec` field optional, partial sub-schemas for `query` and `filter`), and the four payload schemas added to `commands/schemas.ts` and the `payloads` record (so `cmd.addAnnotation(...)` is auto-derived).
- `updateAnnotation` handler reads the existing kind via `annotationLayerToKind`, deep-merges the partial input via a local `mergeReplacingArrays` helper (kept inline to avoid touching shipped `updatePanel.ts` — dedupe is a separate cleanup), and rebuilds the layer in place.
- Rename detection gated on `payload.annotation.spec.name` being defined; collisions still throw.
- `ListAnnotationsData { annotations: AnnotationQueryKind[] }` exported from the public mutation-api `index.ts` (parity with `ListVariablesData`).

### Edge cases

- Annotations are identified by `name`. Duplicate add and missing update/remove return clear errors.
- The built-in Grafana annotation cannot be removed and a second built-in cannot be added — the v2 load path auto-injects it on next save/load anyway.
- `UPDATE_ANNOTATION` with an empty `spec: {}` is a no-op (covered by tests).

## Follow-up

A separate PR will align `UPDATE_VARIABLE` (and any other `UPDATE_*` command that still requires a full kind) on the same partial-merge contract, so all CRUD commands behave consistently with `UPDATE_PANEL`. Tracked separately to keep the blast radius small.

## Test plan

- [x] `yarn jest --no-watch public/app/features/dashboard-scene/mutation-api/commands/` — 185 tests pass across 7 suites (20 in `annotationCommands.test.ts`, including 5 new partial-merge cases: untouched-fields preserved, nested `query.spec` merge, `filter.ids` array replacement, rename via partial spec, empty-spec no-op).
- [x] `panelCommands.test.ts` regression — 35 tests pass, no behavior change (verified `updatePanel.ts` was not touched).
- [x] `yarn typecheck` — clean.
- [x] `yarn lint:ts` on the mutation-api directory — clean.
- [ ] CI green