### PR TITLE
Alerting: Wire additional AlertRule and RecordingRule field selectors to legacy storage

### DIFF
--- a/apps/alerting/rules/definitions/alerting-manifest.yaml
+++ b/apps/alerting/rules/definitions/alerting-manifest.yaml
@@ -268,6 +268,9 @@ spec:
       - spec.paused
       - spec.panelRef.dashboardUID
       - spec.panelRef.panelID
+      - spec.notificationSettings.type
+      - spec.notificationSettings.receiver
+      - spec.notificationSettings.routingTree
     - admission:
         mutation:
           operations:
@@ -429,5 +432,7 @@ spec:
       selectableFields:
       - spec.title
       - spec.paused
+      - spec.metric
+      - spec.targetDatasourceUID
     name: v0alpha1
     served: true

--- a/apps/alerting/rules/definitions/alertrule.rules.alerting.grafana.app.yaml
+++ b/apps/alerting/rules/definitions/alertrule.rules.alerting.grafana.app.yaml
@@ -216,6 +216,9 @@ spec:
     - jsonPath: .spec.paused
     - jsonPath: .spec.panelRef.dashboardUID
     - jsonPath: .spec.panelRef.panelID
+    - jsonPath: .spec.notificationSettings.type
+    - jsonPath: .spec.notificationSettings.receiver
+    - jsonPath: .spec.notificationSettings.routingTree
     served: true
     storage: true
     subresources:

--- a/apps/alerting/rules/definitions/recordingrule.rules.alerting.grafana.app.yaml
+++ b/apps/alerting/rules/definitions/recordingrule.rules.alerting.grafana.app.yaml
@@ -128,6 +128,8 @@ spec:
     selectableFields:
     - jsonPath: .spec.title
     - jsonPath: .spec.paused
+    - jsonPath: .spec.metric
+    - jsonPath: .spec.targetDatasourceUID
     served: true
     storage: true
     subresources:

--- a/apps/alerting/rules/kinds/alertRule.cue
+++ b/apps/alerting/rules/kinds/alertRule.cue
@@ -30,8 +30,9 @@ alertRulev0alpha1: alertRuleKind & {
 		"spec.paused",
 		"spec.panelRef.dashboardUID",
 		"spec.panelRef.panelID",
-		// TODO: make selectableFields play nicely with union types
-		// "spec.notificationSettings.receiver",
+		"spec.notificationSettings.type",
+		"spec.notificationSettings.receiver",
+		"spec.notificationSettings.routingTree",
 		// TODO: add status fields for filtering
 	]
 

--- a/apps/alerting/rules/kinds/recordingRule.cue
+++ b/apps/alerting/rules/kinds/recordingRule.cue
@@ -28,9 +28,8 @@ recordingRulev0alpha1: recordingRuleKind & {
 	selectableFields: [
 		"spec.title",
 		"spec.paused",
-		// FIXME(@moustafab): not sure why these fields are being considered structs... Bug in codegen
-		// "spec.metric",
-		// "spec.targetDatasourceUID",
+		"spec.metric",
+		"spec.targetDatasourceUID",
 		// TODO: add status fields for filtering
 	]
 }

--- a/apps/alerting/rules/pkg/apis/alerting/v0alpha1/alertrule_schema_gen.go
+++ b/apps/alerting/rules/pkg/apis/alerting/v0alpha1/alertrule_schema_gen.go
@@ -67,6 +67,57 @@ var (
 					return fmt.Sprintf("%d", cast.Spec.PanelRef.PanelID), nil
 				},
 			},
+			{
+				FieldSelector: "spec.notificationSettings.type",
+				FieldValueFunc: func(o resource.Object) (string, error) {
+					cast, ok := o.(*AlertRule)
+					if !ok {
+						return "", errors.New("provided object must be of type *AlertRule")
+					}
+					if cast.Spec.NotificationSettings == nil {
+						return "", nil
+					}
+					if cast.Spec.NotificationSettings.SimplifiedRouting != nil {
+						return "SimplifiedRouting", nil
+					}
+					if cast.Spec.NotificationSettings.NamedRoutingTree != nil {
+						return "NamedRoutingTree", nil
+					}
+					return "", nil
+				},
+			},
+			{
+				FieldSelector: "spec.notificationSettings.receiver",
+				FieldValueFunc: func(o resource.Object) (string, error) {
+					cast, ok := o.(*AlertRule)
+					if !ok {
+						return "", errors.New("provided object must be of type *AlertRule")
+					}
+					if cast.Spec.NotificationSettings == nil {
+						return "", nil
+					}
+					if cast.Spec.NotificationSettings.SimplifiedRouting != nil {
+						return string(cast.Spec.NotificationSettings.SimplifiedRouting.Receiver), nil
+					}
+					return "", nil
+				},
+			},
+			{
+				FieldSelector: "spec.notificationSettings.routingTree",
+				FieldValueFunc: func(o resource.Object) (string, error) {
+					cast, ok := o.(*AlertRule)
+					if !ok {
+						return "", errors.New("provided object must be of type *AlertRule")
+					}
+					if cast.Spec.NotificationSettings == nil {
+						return "", nil
+					}
+					if cast.Spec.NotificationSettings.NamedRoutingTree != nil {
+						return string(cast.Spec.NotificationSettings.NamedRoutingTree.RoutingTree), nil
+					}
+					return "", nil
+				},
+			},
 		}))
 	kindAlertRule = resource.Kind{
 		Schema: schemaAlertRule,

--- a/apps/alerting/rules/pkg/apis/alerting/v0alpha1/recordingrule_schema_gen.go
+++ b/apps/alerting/rules/pkg/apis/alerting/v0alpha1/recordingrule_schema_gen.go
@@ -39,6 +39,28 @@ var (
 					return fmt.Sprintf("%v", *cast.Spec.Paused), nil
 				},
 			},
+			{
+				FieldSelector: "spec.metric",
+				FieldValueFunc: func(o resource.Object) (string, error) {
+					cast, ok := o.(*RecordingRule)
+					if !ok {
+						return "", errors.New("provided object must be of type *RecordingRule")
+					}
+
+					return string(cast.Spec.Metric), nil
+				},
+			},
+			{
+				FieldSelector: "spec.targetDatasourceUID",
+				FieldValueFunc: func(o resource.Object) (string, error) {
+					cast, ok := o.(*RecordingRule)
+					if !ok {
+						return "", errors.New("provided object must be of type *RecordingRule")
+					}
+
+					return string(cast.Spec.TargetDatasourceUID), nil
+				},
+			},
 		}))
 	kindRecordingRule = resource.Kind{
 		Schema: schemaRecordingRule,

--- a/apps/alerting/rules/pkg/apis/alerting_manifest.go
+++ b/apps/alerting/rules/pkg/apis/alerting_manifest.go
@@ -63,6 +63,9 @@ var appManifestData = app.ManifestData{
 						"spec.paused",
 						"spec.panelRef.dashboardUID",
 						"spec.panelRef.panelID",
+						"spec.notificationSettings.type",
+						"spec.notificationSettings.receiver",
+						"spec.notificationSettings.routingTree",
 					},
 				},
 
@@ -89,6 +92,8 @@ var appManifestData = app.ManifestData{
 					SelectableFields: []string{
 						"spec.title",
 						"spec.paused",
+						"spec.metric",
+						"spec.targetDatasourceUID",
 					},
 				},
 			},

--- a/pkg/registry/apps/alerting/rules/alertrule/legacy_storage.go
+++ b/pkg/registry/apps/alerting/rules/alertrule/legacy_storage.go
@@ -23,6 +23,11 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
 )
 
+var validNotificationSettingsTypes = []string{
+	string(ngmodels.NotificationSettingsTypeSimplifiedRouting),
+	string(ngmodels.NotificationSettingsTypeNamedRoutingTree),
+}
+
 var (
 	_ grafanarest.Storage = (*legacyStorage)(nil)
 )
@@ -76,42 +81,55 @@ func (s *legacyStorage) List(ctx context.Context, opts *internalversion.ListOpti
 	}
 
 	var (
-		titleFilter     provisioning.ListRuleStringFilter
-		pausedFilter    provisioning.ListRuleBoolFilter
-		dashboardFilter provisioning.ListRuleStringFilter
-		panelIDFilter   provisioning.ListRuleStringFilter
+		titleFilter            provisioning.ListRuleStringFilter
+		pausedFilter           provisioning.ListRuleBoolFilter
+		dashboardFilter        provisioning.ListRuleStringFilter
+		panelIDFilter          provisioning.ListRuleStringFilter
+		notificationTypeFilter provisioning.ListRuleStringFilter
+		receiverFilter         provisioning.ListRuleStringFilter
+		routingTreeFilter      provisioning.ListRuleStringFilter
 	)
 	if opts.FieldSelector != nil && !opts.FieldSelector.Empty() {
 		for _, r := range opts.FieldSelector.Requirements() {
-			isEq := r.Operator == selection.Equals || r.Operator == selection.DoubleEquals
 			switch r.Field {
 			case "spec.title":
-				if !isEq {
-					return nil, k8serrors.NewBadRequest("unsupported operator for spec.title (only = supported)")
+				if err := common.ApplyFieldSelectorRequirement(&titleFilter, r, nil); err != nil {
+					return nil, k8serrors.NewBadRequest(err.Error())
 				}
-				titleFilter.Include = []string{r.Value}
 			case "spec.paused":
-				if !isEq {
-					return nil, k8serrors.NewBadRequest("unsupported operator for spec.paused (only = supported)")
-				}
 				v, err := strconv.ParseBool(r.Value)
 				if err != nil {
 					return nil, k8serrors.NewBadRequest(fmt.Sprintf("invalid value for spec.paused: %s", r.Value))
 				}
-				pausedFilter.Value = &v
+				switch r.Operator {
+				case selection.Equals, selection.DoubleEquals:
+					pausedFilter.Value = &v
+				case selection.NotEquals:
+					negated := !v
+					pausedFilter.Value = &negated
+				default:
+					return nil, k8serrors.NewBadRequest(fmt.Sprintf("unsupported operator %q for spec.paused (only =, ==, != are supported)", r.Operator))
+				}
 			case "spec.panelRef.dashboardUID":
-				if !isEq {
-					return nil, k8serrors.NewBadRequest("unsupported operator for spec.panelRef.dashboardUID (only = supported)")
+				if err := common.ApplyFieldSelectorRequirement(&dashboardFilter, r, nil); err != nil {
+					return nil, k8serrors.NewBadRequest(err.Error())
 				}
-				dashboardFilter.Include = []string{r.Value}
 			case "spec.panelRef.panelID":
-				if !isEq {
-					return nil, k8serrors.NewBadRequest("unsupported operator for spec.panelRef.panelID (only = supported)")
+				if err := common.ApplyFieldSelectorRequirement(&panelIDFilter, r, common.ValidateInt64String("spec.panelRef.panelID")); err != nil {
+					return nil, k8serrors.NewBadRequest(err.Error())
 				}
-				if _, err := strconv.ParseInt(r.Value, 10, 64); err != nil {
-					return nil, k8serrors.NewBadRequest(fmt.Sprintf("invalid value for spec.panelRef.panelID: %s", r.Value))
+			case "spec.notificationSettings.type":
+				if err := common.ApplyFieldSelectorRequirement(&notificationTypeFilter, r, common.ValidateOneOf("spec.notificationSettings.type", validNotificationSettingsTypes)); err != nil {
+					return nil, k8serrors.NewBadRequest(err.Error())
 				}
-				panelIDFilter.Include = []string{r.Value}
+			case "spec.notificationSettings.receiver":
+				if err := common.ApplyFieldSelectorRequirement(&receiverFilter, r, nil); err != nil {
+					return nil, k8serrors.NewBadRequest(err.Error())
+				}
+			case "spec.notificationSettings.routingTree":
+				if err := common.ApplyFieldSelectorRequirement(&routingTreeFilter, r, nil); err != nil {
+					return nil, k8serrors.NewBadRequest(err.Error())
+				}
 			default:
 				return nil, k8serrors.NewBadRequest(fmt.Sprintf("unknown field selector: %s", r.Field))
 			}
@@ -119,15 +137,18 @@ func (s *legacyStorage) List(ctx context.Context, opts *internalversion.ListOpti
 	}
 
 	rules, provenanceMap, continueToken, err := s.service.ListAlertRules(ctx, user, provisioning.ListAlertRulesOptions{
-		RuleType:        ngmodels.RuleTypeFilterAlerting,
-		Limit:           opts.Limit,
-		ContinueToken:   opts.Continue,
-		GroupFilter:     groupFilter,
-		FolderFilter:    folderFilter,
-		TitleFilter:     titleFilter,
-		PausedFilter:    pausedFilter,
-		DashboardFilter: dashboardFilter,
-		PanelIDFilter:   panelIDFilter,
+		RuleType:               ngmodels.RuleTypeFilterAlerting,
+		Limit:                  opts.Limit,
+		ContinueToken:          opts.Continue,
+		GroupFilter:            groupFilter,
+		FolderFilter:           folderFilter,
+		TitleFilter:            titleFilter,
+		PausedFilter:           pausedFilter,
+		DashboardFilter:        dashboardFilter,
+		PanelIDFilter:          panelIDFilter,
+		NotificationTypeFilter: notificationTypeFilter,
+		ReceiverFilter:         receiverFilter,
+		RoutingTreeFilter:      routingTreeFilter,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/registry/apps/alerting/rules/common/selectors.go
+++ b/pkg/registry/apps/alerting/rules/common/selectors.go
@@ -2,7 +2,10 @@ package common
 
 import (
 	"fmt"
+	"slices"
+	"strconv"
 
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 
@@ -41,4 +44,52 @@ func ParseLabelSelectorFilter(selector labels.Selector, key string) (provisionin
 		}
 	}
 	return filter, nil
+}
+
+// ApplyFieldSelectorRequirement applies a single field selector requirement to the given filter.
+// Field selectors only support equality (= and ==) and inequality (!=); = and == add to Include,
+// != adds to Exclude. The same field cannot be used twice on the same side (e.g. two `=` for
+// `spec.title`) since that's not meaningful semantics for a field selector. The validate
+// callback, when non-nil, is run on the value before bucketing.
+func ApplyFieldSelectorRequirement(filter *provisioning.ListRuleStringFilter, req fields.Requirement, validate func(string) error) error {
+	if validate != nil {
+		if err := validate(req.Value); err != nil {
+			return err
+		}
+	}
+	switch req.Operator {
+	case selection.Equals, selection.DoubleEquals:
+		if len(filter.Include) > 0 {
+			return fmt.Errorf("field %q already has an include value, only one is supported", req.Field)
+		}
+		filter.Include = []string{req.Value}
+	case selection.NotEquals:
+		if len(filter.Exclude) > 0 {
+			return fmt.Errorf("field %q already has an exclude value, only one is supported", req.Field)
+		}
+		filter.Exclude = []string{req.Value}
+	default:
+		return fmt.Errorf("unsupported operator %q for field %q (only =, ==, != are supported)", req.Operator, req.Field)
+	}
+	return nil
+}
+
+// ValidateInt64String returns a validator that checks the value parses as a base-10 int64.
+func ValidateInt64String(field string) func(string) error {
+	return func(v string) error {
+		if _, err := strconv.ParseInt(v, 10, 64); err != nil {
+			return fmt.Errorf("invalid value for %s: %s", field, v)
+		}
+		return nil
+	}
+}
+
+// ValidateOneOf returns a validator that checks the value is in the provided allowlist.
+func ValidateOneOf(field string, allowed []string) func(string) error {
+	return func(v string) error {
+		if !slices.Contains(allowed, v) {
+			return fmt.Errorf("invalid value for %s: %s (expected one of %v)", field, v, allowed)
+		}
+		return nil
+	}
 }

--- a/pkg/registry/apps/alerting/rules/common/selectors_test.go
+++ b/pkg/registry/apps/alerting/rules/common/selectors_test.go
@@ -5,7 +5,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+
+	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
 )
 
 func TestParseLabelSelectorFilter(t *testing.T) {
@@ -107,5 +111,57 @@ func TestParseLabelSelectorFilter(t *testing.T) {
 		assert.Nil(t, filter.Exists)
 		assert.Empty(t, filter.Include)
 		assert.Empty(t, filter.Exclude)
+	})
+}
+
+func TestApplyFieldSelectorRequirement(t *testing.T) {
+	t.Run("Equals sets Include", func(t *testing.T) {
+		f := provisioning.ListRuleStringFilter{}
+		err := ApplyFieldSelectorRequirement(&f, fields.Requirement{Field: "spec.title", Operator: selection.Equals, Value: "a"}, nil)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"a"}, f.Include)
+		assert.Empty(t, f.Exclude)
+	})
+
+	t.Run("DoubleEquals sets Include", func(t *testing.T) {
+		f := provisioning.ListRuleStringFilter{}
+		err := ApplyFieldSelectorRequirement(&f, fields.Requirement{Field: "spec.title", Operator: selection.DoubleEquals, Value: "a"}, nil)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"a"}, f.Include)
+	})
+
+	t.Run("NotEquals sets Exclude", func(t *testing.T) {
+		f := provisioning.ListRuleStringFilter{}
+		err := ApplyFieldSelectorRequirement(&f, fields.Requirement{Field: "spec.title", Operator: selection.NotEquals, Value: "a"}, nil)
+		require.NoError(t, err)
+		assert.Empty(t, f.Include)
+		assert.Equal(t, []string{"a"}, f.Exclude)
+	})
+
+	t.Run("two Equals requirements for the same field returns an error", func(t *testing.T) {
+		f := provisioning.ListRuleStringFilter{}
+		require.NoError(t, ApplyFieldSelectorRequirement(&f, fields.Requirement{Field: "spec.title", Operator: selection.Equals, Value: "a"}, nil))
+		err := ApplyFieldSelectorRequirement(&f, fields.Requirement{Field: "spec.title", Operator: selection.Equals, Value: "b"}, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("two NotEquals requirements for the same field returns an error", func(t *testing.T) {
+		f := provisioning.ListRuleStringFilter{}
+		require.NoError(t, ApplyFieldSelectorRequirement(&f, fields.Requirement{Field: "spec.title", Operator: selection.NotEquals, Value: "a"}, nil))
+		err := ApplyFieldSelectorRequirement(&f, fields.Requirement{Field: "spec.title", Operator: selection.NotEquals, Value: "b"}, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("In operator returns an error (field selectors do not support it)", func(t *testing.T) {
+		f := provisioning.ListRuleStringFilter{}
+		err := ApplyFieldSelectorRequirement(&f, fields.Requirement{Field: "spec.title", Operator: selection.In, Value: "a"}, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("validate is invoked on the value before bucketing", func(t *testing.T) {
+		f := provisioning.ListRuleStringFilter{}
+		err := ApplyFieldSelectorRequirement(&f, fields.Requirement{Field: "spec.foo", Operator: selection.Equals, Value: "x"}, ValidateOneOf("spec.foo", []string{"y"}))
+		require.Error(t, err)
+		assert.Empty(t, f.Include)
 	})
 }

--- a/pkg/registry/apps/alerting/rules/recordingrule/legacy_storage.go
+++ b/pkg/registry/apps/alerting/rules/recordingrule/legacy_storage.go
@@ -77,27 +77,40 @@ func (s *legacyStorage) List(ctx context.Context, opts *internalversion.ListOpti
 	}
 
 	var (
-		titleFilter  provisioning.ListRuleStringFilter
-		pausedFilter provisioning.ListRuleBoolFilter
+		titleFilter               provisioning.ListRuleStringFilter
+		pausedFilter              provisioning.ListRuleBoolFilter
+		metricFilter              provisioning.ListRuleStringFilter
+		targetDatasourceUIDFilter provisioning.ListRuleStringFilter
 	)
 	if opts.FieldSelector != nil && !opts.FieldSelector.Empty() {
 		for _, r := range opts.FieldSelector.Requirements() {
-			isEq := r.Operator == selection.Equals || r.Operator == selection.DoubleEquals
 			switch r.Field {
 			case "spec.title":
-				if !isEq {
-					return nil, k8serrors.NewBadRequest("unsupported operator for spec.title (only = supported)")
+				if err := common.ApplyFieldSelectorRequirement(&titleFilter, r, nil); err != nil {
+					return nil, k8serrors.NewBadRequest(err.Error())
 				}
-				titleFilter.Include = []string{r.Value}
 			case "spec.paused":
-				if !isEq {
-					return nil, k8serrors.NewBadRequest("unsupported operator for spec.paused (only = supported)")
-				}
 				v, err := strconv.ParseBool(r.Value)
 				if err != nil {
 					return nil, k8serrors.NewBadRequest(fmt.Sprintf("invalid value for spec.paused: %s", r.Value))
 				}
-				pausedFilter.Value = &v
+				switch r.Operator {
+				case selection.Equals, selection.DoubleEquals:
+					pausedFilter.Value = &v
+				case selection.NotEquals:
+					negated := !v
+					pausedFilter.Value = &negated
+				default:
+					return nil, k8serrors.NewBadRequest(fmt.Sprintf("unsupported operator %q for spec.paused (only =, ==, != are supported)", r.Operator))
+				}
+			case "spec.metric":
+				if err := common.ApplyFieldSelectorRequirement(&metricFilter, r, nil); err != nil {
+					return nil, k8serrors.NewBadRequest(err.Error())
+				}
+			case "spec.targetDatasourceUID":
+				if err := common.ApplyFieldSelectorRequirement(&targetDatasourceUIDFilter, r, nil); err != nil {
+					return nil, k8serrors.NewBadRequest(err.Error())
+				}
 			default:
 				return nil, k8serrors.NewBadRequest(fmt.Sprintf("unknown field selector: %s", r.Field))
 			}
@@ -105,13 +118,15 @@ func (s *legacyStorage) List(ctx context.Context, opts *internalversion.ListOpti
 	}
 
 	rules, provenanceMap, continueToken, err := s.service.ListAlertRules(ctx, user, provisioning.ListAlertRulesOptions{
-		RuleType:      ngmodels.RuleTypeFilterRecording,
-		Limit:         opts.Limit,
-		ContinueToken: opts.Continue,
-		GroupFilter:   groupFilter,
-		FolderFilter:  folderFilter,
-		TitleFilter:   titleFilter,
-		PausedFilter:  pausedFilter,
+		RuleType:                  ngmodels.RuleTypeFilterRecording,
+		Limit:                     opts.Limit,
+		ContinueToken:             opts.Continue,
+		GroupFilter:               groupFilter,
+		FolderFilter:              folderFilter,
+		TitleFilter:               titleFilter,
+		PausedFilter:              pausedFilter,
+		MetricFilter:              metricFilter,
+		TargetDatasourceUIDFilter: targetDatasourceUIDFilter,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -1059,6 +1059,10 @@ type ListAlertRulesQuery struct {
 	// to return just those for a dashboard and panel.
 	DashboardUID string
 	PanelID      int64
+	// ExcludeDashboardUID, when non-empty, excludes rules whose dashboard UID matches.
+	ExcludeDashboardUID string
+	// ExcludePanelID, when non-zero, excludes rules whose panel ID matches.
+	ExcludePanelID int64
 
 	// IsPaused filters rules by their paused state.
 	// nil means no filter; true means only paused rules; false means only non-paused rules.
@@ -1066,9 +1070,36 @@ type ListAlertRulesQuery struct {
 	// TitleExact filters rules to those with an exact title match (case-sensitive).
 	// Empty string means no filter.
 	TitleExact string
+	// ExcludeTitle, when non-empty, excludes rules whose title matches exactly.
+	ExcludeTitle string
 
-	ReceiverName     string
-	TimeIntervalName string
+	// NotificationSettingsType filters rules by the type of notification settings configured.
+	// Empty string means no filter.
+	NotificationSettingsType NotificationSettingsType
+	// ExcludeNotificationSettingsType, when set, excludes rules whose notification settings type
+	// matches the given enum value.
+	ExcludeNotificationSettingsType NotificationSettingsType
+	// RoutingPolicyExact filters rules to those whose named routing policy matches exactly.
+	// Empty string means no filter.
+	RoutingPolicyExact string
+	// ExcludeRoutingPolicy, when non-empty, excludes rules whose named routing policy matches.
+	ExcludeRoutingPolicy string
+	// RecordMetricExact filters recording rules by their target metric name (exact match).
+	// Empty string means no filter.
+	RecordMetricExact string
+	// ExcludeRecordMetric, when non-empty, excludes recording rules whose target metric name matches.
+	ExcludeRecordMetric string
+	// RecordTargetDatasourceUIDExact filters recording rules by their target data source UID (exact match).
+	// Empty string means no filter.
+	RecordTargetDatasourceUIDExact string
+	// ExcludeRecordTargetDatasourceUID, when non-empty, excludes recording rules whose target
+	// data source UID matches.
+	ExcludeRecordTargetDatasourceUID string
+
+	ReceiverName string
+	// ExcludeReceiverName, when non-empty, excludes rules whose contact-point receiver name matches.
+	ExcludeReceiverName string
+	TimeIntervalName    string
 
 	// DataSourceUIDs allows searching for alert rules using data sources
 	// that match any of the given UIDs exactly (case sensitive).

--- a/pkg/services/ngalert/models/notifications.go
+++ b/pkg/services/ngalert/models/notifications.go
@@ -20,6 +20,15 @@ const GroupByAll = "..."
 const DefaultRoutingTreeName = "user-defined"
 const NamedRouteLabel = "__grafana_managed_route__"
 
+// NotificationSettingsType is an enum of the notification settings configurations a rule may have.
+// It is used by ListAlertRulesQuery to filter rules by the type of notification settings configured.
+type NotificationSettingsType string
+
+const (
+	NotificationSettingsTypeSimplifiedRouting NotificationSettingsType = "SimplifiedRouting"
+	NotificationSettingsTypeNamedRoutingTree  NotificationSettingsType = "NamedRoutingTree"
+)
+
 // DefaultNotificationSettingsGroupBy are the default required GroupBy fields for notification settings.
 var DefaultNotificationSettingsGroupBy = []string{FolderTitleLabel, model.AlertNameLabel}
 

--- a/pkg/services/ngalert/provisioning/alert_rules.go
+++ b/pkg/services/ngalert/provisioning/alert_rules.go
@@ -94,45 +94,134 @@ type ListRuleBoolFilter struct {
 }
 
 type ListAlertRulesOptions struct {
-	RuleType        models.RuleTypeFilter
-	Limit           int64
-	ContinueToken   string
-	GroupFilter     ListRuleStringFilter
-	FolderFilter    ListRuleStringFilter
-	TitleFilter     ListRuleStringFilter
-	PausedFilter    ListRuleBoolFilter
-	DashboardFilter ListRuleStringFilter
-	PanelIDFilter   ListRuleStringFilter
-	// TODO: add the following filters
-	// receiver filter - string
-	// metric filter - string
-	// targetDatasourceUID filter - string
+	RuleType                  models.RuleTypeFilter
+	Limit                     int64
+	ContinueToken             string
+	GroupFilter               ListRuleStringFilter
+	FolderFilter              ListRuleStringFilter
+	TitleFilter               ListRuleStringFilter
+	PausedFilter              ListRuleBoolFilter
+	DashboardFilter           ListRuleStringFilter
+	PanelIDFilter             ListRuleStringFilter
+	NotificationTypeFilter    ListRuleStringFilter
+	ReceiverFilter            ListRuleStringFilter
+	RoutingTreeFilter         ListRuleStringFilter
+	MetricFilter              ListRuleStringFilter
+	TargetDatasourceUIDFilter ListRuleStringFilter
+}
+
+// singleString returns the single value from a ListRuleStringFilter's Include or Exclude slice,
+// returning an error when the slice has more than one entry. Field selectors only support
+// equality and inequality, so multiple `=` or multiple `!=` requirements for the same field are
+// not meaningful for field-selector-derived filters. Empty slice returns an empty string.
+func singleString(values []string, field, side string) (string, error) {
+	switch len(values) {
+	case 0:
+		return "", nil
+	case 1:
+		return values[0], nil
+	default:
+		return "", fmt.Errorf("%s only accepts a single %s value, got %d", field, side, len(values))
+	}
 }
 
 func (service *AlertRuleService) ListAlertRules(ctx context.Context, user identity.Requester, opts ListAlertRulesOptions) (rules []*models.AlertRule, provenances map[string]models.Provenance, nextToken string, err error) {
-	titleExact := ""
-	if len(opts.TitleFilter.Include) > 0 {
-		titleExact = opts.TitleFilter.Include[0]
+	titleExact, err := singleString(opts.TitleFilter.Include, "spec.title", "include")
+	if err != nil {
+		return nil, nil, "", err
 	}
-	dashboardUID := ""
-	if len(opts.DashboardFilter.Include) > 0 {
-		dashboardUID = opts.DashboardFilter.Include[0]
+	excludeTitle, err := singleString(opts.TitleFilter.Exclude, "spec.title", "exclude")
+	if err != nil {
+		return nil, nil, "", err
+	}
+	dashboardUID, err := singleString(opts.DashboardFilter.Include, "spec.panelRef.dashboardUID", "include")
+	if err != nil {
+		return nil, nil, "", err
+	}
+	excludeDashboardUID, err := singleString(opts.DashboardFilter.Exclude, "spec.panelRef.dashboardUID", "exclude")
+	if err != nil {
+		return nil, nil, "", err
+	}
+	panelIDStr, err := singleString(opts.PanelIDFilter.Include, "spec.panelRef.panelID", "include")
+	if err != nil {
+		return nil, nil, "", err
+	}
+	excludePanelIDStr, err := singleString(opts.PanelIDFilter.Exclude, "spec.panelRef.panelID", "exclude")
+	if err != nil {
+		return nil, nil, "", err
 	}
 	panelID := int64(0)
-	if len(opts.PanelIDFilter.Include) > 0 {
-		panelID, _ = strconv.ParseInt(opts.PanelIDFilter.Include[0], 10, 64)
+	if panelIDStr != "" {
+		panelID, _ = strconv.ParseInt(panelIDStr, 10, 64)
+	}
+	excludePanelID := int64(0)
+	if excludePanelIDStr != "" {
+		excludePanelID, _ = strconv.ParseInt(excludePanelIDStr, 10, 64)
+	}
+	notifType, err := singleString(opts.NotificationTypeFilter.Include, "spec.notificationSettings.type", "include")
+	if err != nil {
+		return nil, nil, "", err
+	}
+	excludeNotifType, err := singleString(opts.NotificationTypeFilter.Exclude, "spec.notificationSettings.type", "exclude")
+	if err != nil {
+		return nil, nil, "", err
+	}
+	receiverName, err := singleString(opts.ReceiverFilter.Include, "spec.notificationSettings.receiver", "include")
+	if err != nil {
+		return nil, nil, "", err
+	}
+	excludeReceiverName, err := singleString(opts.ReceiverFilter.Exclude, "spec.notificationSettings.receiver", "exclude")
+	if err != nil {
+		return nil, nil, "", err
+	}
+	routingPolicy, err := singleString(opts.RoutingTreeFilter.Include, "spec.notificationSettings.routingTree", "include")
+	if err != nil {
+		return nil, nil, "", err
+	}
+	excludeRoutingPolicy, err := singleString(opts.RoutingTreeFilter.Exclude, "spec.notificationSettings.routingTree", "exclude")
+	if err != nil {
+		return nil, nil, "", err
+	}
+	metricExact, err := singleString(opts.MetricFilter.Include, "spec.metric", "include")
+	if err != nil {
+		return nil, nil, "", err
+	}
+	excludeMetric, err := singleString(opts.MetricFilter.Exclude, "spec.metric", "exclude")
+	if err != nil {
+		return nil, nil, "", err
+	}
+	targetUIDExact, err := singleString(opts.TargetDatasourceUIDFilter.Include, "spec.targetDatasourceUID", "include")
+	if err != nil {
+		return nil, nil, "", err
+	}
+	excludeTargetUID, err := singleString(opts.TargetDatasourceUIDFilter.Exclude, "spec.targetDatasourceUID", "exclude")
+	if err != nil {
+		return nil, nil, "", err
 	}
 	q := models.ListAlertRulesExtendedQuery{
 		ListAlertRulesQuery: models.ListAlertRulesQuery{
-			OrgID:                user.GetOrgID(),
-			RuleGroups:           opts.GroupFilter.Include,
-			ExcludeRuleGroups:    opts.GroupFilter.Exclude,
-			RuleGroupExists:      opts.GroupFilter.Exists,
-			ExcludeNamespaceUIDs: opts.FolderFilter.Exclude,
-			TitleExact:           titleExact,
-			IsPaused:             opts.PausedFilter.Value,
-			DashboardUID:         dashboardUID,
-			PanelID:              panelID,
+			OrgID:                            user.GetOrgID(),
+			RuleGroups:                       opts.GroupFilter.Include,
+			ExcludeRuleGroups:                opts.GroupFilter.Exclude,
+			RuleGroupExists:                  opts.GroupFilter.Exists,
+			ExcludeNamespaceUIDs:             opts.FolderFilter.Exclude,
+			TitleExact:                       titleExact,
+			ExcludeTitle:                     excludeTitle,
+			IsPaused:                         opts.PausedFilter.Value,
+			DashboardUID:                     dashboardUID,
+			ExcludeDashboardUID:              excludeDashboardUID,
+			PanelID:                          panelID,
+			ExcludePanelID:                   excludePanelID,
+			NotificationSettingsType:         models.NotificationSettingsType(notifType),
+			ExcludeNotificationSettingsType:  models.NotificationSettingsType(excludeNotifType),
+			ReceiverName:                     receiverName,
+			ExcludeReceiverName:              excludeReceiverName,
+			RoutingPolicyExact:               routingPolicy,
+			ExcludeRoutingPolicy:             excludeRoutingPolicy,
+			RecordMetricExact:                metricExact,
+			ExcludeRecordMetric:              excludeMetric,
+			RecordTargetDatasourceUIDExact:   targetUIDExact,
+			ExcludeRecordTargetDatasourceUID: excludeTargetUID,
 		},
 		RuleType:      opts.RuleType,
 		Limit:         opts.Limit,

--- a/pkg/services/ngalert/provisioning/alert_rules.go
+++ b/pkg/services/ngalert/provisioning/alert_rules.go
@@ -125,76 +125,88 @@ func singleString(values []string, field, side string) (string, error) {
 	}
 }
 
+// singleStringFilter resolves a ListRuleStringFilter to scalar (include, exclude) string values,
+// returning an error when either side has more than one entry.
+func singleStringFilter(filter ListRuleStringFilter, field string) (include, exclude string, err error) {
+	include, err = singleString(filter.Include, field, "include")
+	if err != nil {
+		return "", "", err
+	}
+	exclude, err = singleString(filter.Exclude, field, "exclude")
+	if err != nil {
+		return "", "", err
+	}
+	return include, exclude, nil
+}
+
+// singleInt64Filter resolves a ListRuleStringFilter to scalar (include, exclude) int64 values,
+// returning an error when either side has more than one entry or fails to parse as int64.
+func singleInt64Filter(filter ListRuleStringFilter, field string) (include, exclude int64, err error) {
+	includeStr, excludeStr, err := singleStringFilter(filter, field)
+	if err != nil {
+		return 0, 0, err
+	}
+	if includeStr != "" {
+		include, err = strconv.ParseInt(includeStr, 10, 64)
+		if err != nil {
+			return 0, 0, fmt.Errorf("invalid include value for %s: %w", field, err)
+		}
+	}
+	if excludeStr != "" {
+		exclude, err = strconv.ParseInt(excludeStr, 10, 64)
+		if err != nil {
+			return 0, 0, fmt.Errorf("invalid exclude value for %s: %w", field, err)
+		}
+	}
+	return include, exclude, nil
+}
+
+// scalarFieldSelectorFilters collapses every field-selector-backed filter on opts into the
+// scalar query fields the rule store accepts. It enforces the single-value rule for each
+// (filter, side) pair.
+type scalarFieldSelectorFilters struct {
+	titleInclude, titleExclude         string
+	dashboardInclude, dashboardExclude string
+	panelIDInclude, panelIDExclude     int64
+	notifTypeInclude, notifTypeExclude string
+	receiverInclude, receiverExclude   string
+	routingInclude, routingExclude     string
+	metricInclude, metricExclude       string
+	targetDSInclude, targetDSExclude   string
+}
+
+func resolveFieldSelectorFilters(opts ListAlertRulesOptions) (scalarFieldSelectorFilters, error) {
+	var f scalarFieldSelectorFilters
+	var err error
+	if f.titleInclude, f.titleExclude, err = singleStringFilter(opts.TitleFilter, "spec.title"); err != nil {
+		return f, err
+	}
+	if f.dashboardInclude, f.dashboardExclude, err = singleStringFilter(opts.DashboardFilter, "spec.panelRef.dashboardUID"); err != nil {
+		return f, err
+	}
+	if f.panelIDInclude, f.panelIDExclude, err = singleInt64Filter(opts.PanelIDFilter, "spec.panelRef.panelID"); err != nil {
+		return f, err
+	}
+	if f.notifTypeInclude, f.notifTypeExclude, err = singleStringFilter(opts.NotificationTypeFilter, "spec.notificationSettings.type"); err != nil {
+		return f, err
+	}
+	if f.receiverInclude, f.receiverExclude, err = singleStringFilter(opts.ReceiverFilter, "spec.notificationSettings.receiver"); err != nil {
+		return f, err
+	}
+	if f.routingInclude, f.routingExclude, err = singleStringFilter(opts.RoutingTreeFilter, "spec.notificationSettings.routingTree"); err != nil {
+		return f, err
+	}
+	if f.metricInclude, f.metricExclude, err = singleStringFilter(opts.MetricFilter, "spec.metric"); err != nil {
+		return f, err
+	}
+	if f.targetDSInclude, f.targetDSExclude, err = singleStringFilter(opts.TargetDatasourceUIDFilter, "spec.targetDatasourceUID"); err != nil {
+		return f, err
+	}
+	return f, nil
+}
+
 func (service *AlertRuleService) ListAlertRules(ctx context.Context, user identity.Requester, opts ListAlertRulesOptions) (rules []*models.AlertRule, provenances map[string]models.Provenance, nextToken string, err error) {
-	titleExact, err := singleString(opts.TitleFilter.Include, "spec.title", "include")
-	if err != nil {
-		return nil, nil, "", err
-	}
-	excludeTitle, err := singleString(opts.TitleFilter.Exclude, "spec.title", "exclude")
-	if err != nil {
-		return nil, nil, "", err
-	}
-	dashboardUID, err := singleString(opts.DashboardFilter.Include, "spec.panelRef.dashboardUID", "include")
-	if err != nil {
-		return nil, nil, "", err
-	}
-	excludeDashboardUID, err := singleString(opts.DashboardFilter.Exclude, "spec.panelRef.dashboardUID", "exclude")
-	if err != nil {
-		return nil, nil, "", err
-	}
-	panelIDStr, err := singleString(opts.PanelIDFilter.Include, "spec.panelRef.panelID", "include")
-	if err != nil {
-		return nil, nil, "", err
-	}
-	excludePanelIDStr, err := singleString(opts.PanelIDFilter.Exclude, "spec.panelRef.panelID", "exclude")
-	if err != nil {
-		return nil, nil, "", err
-	}
-	panelID := int64(0)
-	if panelIDStr != "" {
-		panelID, _ = strconv.ParseInt(panelIDStr, 10, 64)
-	}
-	excludePanelID := int64(0)
-	if excludePanelIDStr != "" {
-		excludePanelID, _ = strconv.ParseInt(excludePanelIDStr, 10, 64)
-	}
-	notifType, err := singleString(opts.NotificationTypeFilter.Include, "spec.notificationSettings.type", "include")
-	if err != nil {
-		return nil, nil, "", err
-	}
-	excludeNotifType, err := singleString(opts.NotificationTypeFilter.Exclude, "spec.notificationSettings.type", "exclude")
-	if err != nil {
-		return nil, nil, "", err
-	}
-	receiverName, err := singleString(opts.ReceiverFilter.Include, "spec.notificationSettings.receiver", "include")
-	if err != nil {
-		return nil, nil, "", err
-	}
-	excludeReceiverName, err := singleString(opts.ReceiverFilter.Exclude, "spec.notificationSettings.receiver", "exclude")
-	if err != nil {
-		return nil, nil, "", err
-	}
-	routingPolicy, err := singleString(opts.RoutingTreeFilter.Include, "spec.notificationSettings.routingTree", "include")
-	if err != nil {
-		return nil, nil, "", err
-	}
-	excludeRoutingPolicy, err := singleString(opts.RoutingTreeFilter.Exclude, "spec.notificationSettings.routingTree", "exclude")
-	if err != nil {
-		return nil, nil, "", err
-	}
-	metricExact, err := singleString(opts.MetricFilter.Include, "spec.metric", "include")
-	if err != nil {
-		return nil, nil, "", err
-	}
-	excludeMetric, err := singleString(opts.MetricFilter.Exclude, "spec.metric", "exclude")
-	if err != nil {
-		return nil, nil, "", err
-	}
-	targetUIDExact, err := singleString(opts.TargetDatasourceUIDFilter.Include, "spec.targetDatasourceUID", "include")
-	if err != nil {
-		return nil, nil, "", err
-	}
-	excludeTargetUID, err := singleString(opts.TargetDatasourceUIDFilter.Exclude, "spec.targetDatasourceUID", "exclude")
+	f, err := resolveFieldSelectorFilters(opts)
 	if err != nil {
 		return nil, nil, "", err
 	}
@@ -205,23 +217,23 @@ func (service *AlertRuleService) ListAlertRules(ctx context.Context, user identi
 			ExcludeRuleGroups:                opts.GroupFilter.Exclude,
 			RuleGroupExists:                  opts.GroupFilter.Exists,
 			ExcludeNamespaceUIDs:             opts.FolderFilter.Exclude,
-			TitleExact:                       titleExact,
-			ExcludeTitle:                     excludeTitle,
+			TitleExact:                       f.titleInclude,
+			ExcludeTitle:                     f.titleExclude,
 			IsPaused:                         opts.PausedFilter.Value,
-			DashboardUID:                     dashboardUID,
-			ExcludeDashboardUID:              excludeDashboardUID,
-			PanelID:                          panelID,
-			ExcludePanelID:                   excludePanelID,
-			NotificationSettingsType:         models.NotificationSettingsType(notifType),
-			ExcludeNotificationSettingsType:  models.NotificationSettingsType(excludeNotifType),
-			ReceiverName:                     receiverName,
-			ExcludeReceiverName:              excludeReceiverName,
-			RoutingPolicyExact:               routingPolicy,
-			ExcludeRoutingPolicy:             excludeRoutingPolicy,
-			RecordMetricExact:                metricExact,
-			ExcludeRecordMetric:              excludeMetric,
-			RecordTargetDatasourceUIDExact:   targetUIDExact,
-			ExcludeRecordTargetDatasourceUID: excludeTargetUID,
+			DashboardUID:                     f.dashboardInclude,
+			ExcludeDashboardUID:              f.dashboardExclude,
+			PanelID:                          f.panelIDInclude,
+			ExcludePanelID:                   f.panelIDExclude,
+			NotificationSettingsType:         models.NotificationSettingsType(f.notifTypeInclude),
+			ExcludeNotificationSettingsType:  models.NotificationSettingsType(f.notifTypeExclude),
+			ReceiverName:                     f.receiverInclude,
+			ExcludeReceiverName:              f.receiverExclude,
+			RoutingPolicyExact:               f.routingInclude,
+			ExcludeRoutingPolicy:             f.routingExclude,
+			RecordMetricExact:                f.metricInclude,
+			ExcludeRecordMetric:              f.metricExclude,
+			RecordTargetDatasourceUIDExact:   f.targetDSInclude,
+			ExcludeRecordTargetDatasourceUID: f.targetDSExclude,
 		},
 		RuleType:      opts.RuleType,
 		Limit:         opts.Limit,

--- a/pkg/services/ngalert/provisioning/alert_rules.go
+++ b/pkg/services/ngalert/provisioning/alert_rules.go
@@ -110,11 +110,11 @@ type ListAlertRulesOptions struct {
 	TargetDatasourceUIDFilter ListRuleStringFilter
 }
 
-// singleString returns the single value from a ListRuleStringFilter's Include or Exclude slice,
+// extractSingleValue returns the single value from a ListRuleStringFilter's Include or Exclude slice,
 // returning an error when the slice has more than one entry. Field selectors only support
 // equality and inequality, so multiple `=` or multiple `!=` requirements for the same field are
 // not meaningful for field-selector-derived filters. Empty slice returns an empty string.
-func singleString(values []string, field, side string) (string, error) {
+func extractSingleValue(values []string, field, side string) (string, error) {
 	switch len(values) {
 	case 0:
 		return "", nil
@@ -125,24 +125,24 @@ func singleString(values []string, field, side string) (string, error) {
 	}
 }
 
-// singleStringFilter resolves a ListRuleStringFilter to scalar (include, exclude) string values,
+// unwrapSingleStringFilter resolves a ListRuleStringFilter to scalar (include, exclude) string values,
 // returning an error when either side has more than one entry.
-func singleStringFilter(filter ListRuleStringFilter, field string) (include, exclude string, err error) {
-	include, err = singleString(filter.Include, field, "include")
+func unwrapSingleStringFilter(filter ListRuleStringFilter, field string) (include, exclude string, err error) {
+	include, err = extractSingleValue(filter.Include, field, "include")
 	if err != nil {
 		return "", "", err
 	}
-	exclude, err = singleString(filter.Exclude, field, "exclude")
+	exclude, err = extractSingleValue(filter.Exclude, field, "exclude")
 	if err != nil {
 		return "", "", err
 	}
 	return include, exclude, nil
 }
 
-// singleInt64Filter resolves a ListRuleStringFilter to scalar (include, exclude) int64 values,
+// unwrapSingleInt64Filter resolves a ListRuleStringFilter to scalar (include, exclude) int64 values,
 // returning an error when either side has more than one entry or fails to parse as int64.
-func singleInt64Filter(filter ListRuleStringFilter, field string) (include, exclude int64, err error) {
-	includeStr, excludeStr, err := singleStringFilter(filter, field)
+func unwrapSingleInt64Filter(filter ListRuleStringFilter, field string) (include, exclude int64, err error) {
+	includeStr, excludeStr, err := unwrapSingleStringFilter(filter, field)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -178,28 +178,28 @@ type scalarFieldSelectorFilters struct {
 func resolveFieldSelectorFilters(opts ListAlertRulesOptions) (scalarFieldSelectorFilters, error) {
 	var f scalarFieldSelectorFilters
 	var err error
-	if f.titleInclude, f.titleExclude, err = singleStringFilter(opts.TitleFilter, "spec.title"); err != nil {
+	if f.titleInclude, f.titleExclude, err = unwrapSingleStringFilter(opts.TitleFilter, "spec.title"); err != nil {
 		return f, err
 	}
-	if f.dashboardInclude, f.dashboardExclude, err = singleStringFilter(opts.DashboardFilter, "spec.panelRef.dashboardUID"); err != nil {
+	if f.dashboardInclude, f.dashboardExclude, err = unwrapSingleStringFilter(opts.DashboardFilter, "spec.panelRef.dashboardUID"); err != nil {
 		return f, err
 	}
-	if f.panelIDInclude, f.panelIDExclude, err = singleInt64Filter(opts.PanelIDFilter, "spec.panelRef.panelID"); err != nil {
+	if f.panelIDInclude, f.panelIDExclude, err = unwrapSingleInt64Filter(opts.PanelIDFilter, "spec.panelRef.panelID"); err != nil {
 		return f, err
 	}
-	if f.notifTypeInclude, f.notifTypeExclude, err = singleStringFilter(opts.NotificationTypeFilter, "spec.notificationSettings.type"); err != nil {
+	if f.notifTypeInclude, f.notifTypeExclude, err = unwrapSingleStringFilter(opts.NotificationTypeFilter, "spec.notificationSettings.type"); err != nil {
 		return f, err
 	}
-	if f.receiverInclude, f.receiverExclude, err = singleStringFilter(opts.ReceiverFilter, "spec.notificationSettings.receiver"); err != nil {
+	if f.receiverInclude, f.receiverExclude, err = unwrapSingleStringFilter(opts.ReceiverFilter, "spec.notificationSettings.receiver"); err != nil {
 		return f, err
 	}
-	if f.routingInclude, f.routingExclude, err = singleStringFilter(opts.RoutingTreeFilter, "spec.notificationSettings.routingTree"); err != nil {
+	if f.routingInclude, f.routingExclude, err = unwrapSingleStringFilter(opts.RoutingTreeFilter, "spec.notificationSettings.routingTree"); err != nil {
 		return f, err
 	}
-	if f.metricInclude, f.metricExclude, err = singleStringFilter(opts.MetricFilter, "spec.metric"); err != nil {
+	if f.metricInclude, f.metricExclude, err = unwrapSingleStringFilter(opts.MetricFilter, "spec.metric"); err != nil {
 		return f, err
 	}
-	if f.targetDSInclude, f.targetDSExclude, err = singleStringFilter(opts.TargetDatasourceUIDFilter, "spec.targetDatasourceUID"); err != nil {
+	if f.targetDSInclude, f.targetDSExclude, err = unwrapSingleStringFilter(opts.TargetDatasourceUIDFilter, "spec.targetDatasourceUID"); err != nil {
 		return f, err
 	}
 	return f, nil

--- a/pkg/services/ngalert/provisioning/alert_rules_test.go
+++ b/pkg/services/ngalert/provisioning/alert_rules_test.go
@@ -2267,38 +2267,72 @@ func TestListAlertRules(t *testing.T) {
 			}
 		})
 	})
+}
 
+// fieldSelectorFilterTestSetup mirrors the closures in TestListAlertRules so each filter test
+// below is self-contained without inflating the parent function's cyclomatic complexity.
+type fieldSelectorFilterTestSetup struct {
+	orgID        int64
+	user         *user.SignedInUser
+	groupKey1    models.AlertRuleGroupKey
+	groupKey2    models.AlertRuleGroupKey
+	gen          *models.AlertRuleGenerator
+	folderSvc    *foldertest.FakeService
+	allowReadAll bool
+}
+
+func newFieldSelectorFilterTestSetup() *fieldSelectorFilterTestSetup {
+	orgID := rand.Int63()
+	groupKey1 := models.GenerateGroupKey(orgID)
+	groupKey2 := models.GenerateGroupKey(orgID)
+	fs := foldertest.NewFakeService()
+	fs.AddFolder(&folder.Folder{OrgID: orgID, UID: groupKey1.NamespaceUID, Title: "folder1"})
+	fs.AddFolder(&folder.Folder{OrgID: orgID, UID: groupKey2.NamespaceUID, Title: "folder2"})
+	return &fieldSelectorFilterTestSetup{
+		orgID:        orgID,
+		user:         &user.SignedInUser{OrgID: orgID},
+		groupKey1:    groupKey1,
+		groupKey2:    groupKey2,
+		gen:          models.RuleGen,
+		folderSvc:    fs,
+		allowReadAll: true,
+	}
+}
+
+func (s *fieldSelectorFilterTestSetup) initService(t *testing.T, rules ...*models.AlertRule) *AlertRuleService {
+	t.Helper()
+	service, ruleStore, _, ac := initService(t)
+	service.folderService = s.folderSvc
+	ruleStore.Rules = map[int64][]*models.AlertRule{s.orgID: rules}
+	ac.CanReadAllRulesFunc = func(ctx context.Context, user identity.Requester) (bool, error) {
+		return s.allowReadAll, nil
+	}
+	return service
+}
+
+func TestListAlertRulesFieldSelectorFilters(t *testing.T) {
 	t.Run("NotificationTypeFilter", func(t *testing.T) {
-		simplifiedRules := gen.With(
-			gen.WithGroupKey(groupKey1),
-			gen.WithUniqueGroupIndex(),
-			gen.WithContactPointRouting(models.NewDefaultContactPointRouting("recv-a")),
+		s := newFieldSelectorFilterTestSetup()
+		simplifiedRules := s.gen.With(
+			s.gen.WithGroupKey(s.groupKey1),
+			s.gen.WithUniqueGroupIndex(),
+			s.gen.WithContactPointRouting(models.NewDefaultContactPointRouting("recv-a")),
 		).GenerateManyRef(2)
-		policyRules := gen.With(
-			gen.WithGroupKey(groupKey1),
-			gen.WithUniqueGroupIndex(),
-			gen.WithPolicyRouting(models.PolicyRouting{Policy: "policy-a"}),
+		policyRules := s.gen.With(
+			s.gen.WithGroupKey(s.groupKey1),
+			s.gen.WithUniqueGroupIndex(),
+			s.gen.WithPolicyRouting(models.PolicyRouting{Policy: "policy-a"}),
 		).GenerateManyRef(3)
-		noNotifRules := gen.With(
-			gen.WithGroupKey(groupKey2),
-			gen.WithUniqueGroupIndex(),
-			gen.WithNoNotificationSettings(),
+		noNotifRules := s.gen.With(
+			s.gen.WithGroupKey(s.groupKey2),
+			s.gen.WithUniqueGroupIndex(),
+			s.gen.WithNoNotificationSettings(),
 		).GenerateManyRef(4)
-
-		setup := func(t *testing.T) *AlertRuleService {
-			service, ruleStore, _, ac := initService(t)
-			service.folderService = fs
-			combined := append(append(simplifiedRules, policyRules...), noNotifRules...)
-			ruleStore.Rules = map[int64][]*models.AlertRule{orgID: combined}
-			ac.CanReadAllRulesFunc = func(ctx context.Context, user identity.Requester) (bool, error) {
-				return true, nil
-			}
-			return service
-		}
+		all := append(append(simplifiedRules, policyRules...), noNotifRules...)
 
 		t.Run("Include SimplifiedRouting returns only rules with contact point routing", func(t *testing.T) {
-			service := setup(t)
-			rules, _, _, err := service.ListAlertRules(context.Background(), u, ListAlertRulesOptions{
+			service := s.initService(t, all...)
+			rules, _, _, err := service.ListAlertRules(context.Background(), s.user, ListAlertRulesOptions{
 				NotificationTypeFilter: ListRuleStringFilter{Include: []string{string(models.NotificationSettingsTypeSimplifiedRouting)}},
 			})
 			require.NoError(t, err)
@@ -2309,8 +2343,8 @@ func TestListAlertRules(t *testing.T) {
 		})
 
 		t.Run("Include NamedRoutingTree returns only rules with policy routing", func(t *testing.T) {
-			service := setup(t)
-			rules, _, _, err := service.ListAlertRules(context.Background(), u, ListAlertRulesOptions{
+			service := s.initService(t, all...)
+			rules, _, _, err := service.ListAlertRules(context.Background(), s.user, ListAlertRulesOptions{
 				NotificationTypeFilter: ListRuleStringFilter{Include: []string{string(models.NotificationSettingsTypeNamedRoutingTree)}},
 			})
 			require.NoError(t, err)
@@ -2322,8 +2356,8 @@ func TestListAlertRules(t *testing.T) {
 		})
 
 		t.Run("Exclude SimplifiedRouting returns rules without contact point routing", func(t *testing.T) {
-			service := setup(t)
-			rules, _, _, err := service.ListAlertRules(context.Background(), u, ListAlertRulesOptions{
+			service := s.initService(t, all...)
+			rules, _, _, err := service.ListAlertRules(context.Background(), s.user, ListAlertRulesOptions{
 				NotificationTypeFilter: ListRuleStringFilter{Exclude: []string{string(models.NotificationSettingsTypeSimplifiedRouting)}},
 			})
 			require.NoError(t, err)
@@ -2336,27 +2370,23 @@ func TestListAlertRules(t *testing.T) {
 	})
 
 	t.Run("ReceiverFilter", func(t *testing.T) {
+		s := newFieldSelectorFilterTestSetup()
 		matchReceiver := "match-receiver"
-		matchRules := gen.With(
-			gen.WithGroupKey(groupKey1),
-			gen.WithUniqueGroupIndex(),
-			gen.WithContactPointRouting(models.NewDefaultContactPointRouting(matchReceiver)),
+		matchRules := s.gen.With(
+			s.gen.WithGroupKey(s.groupKey1),
+			s.gen.WithUniqueGroupIndex(),
+			s.gen.WithContactPointRouting(models.NewDefaultContactPointRouting(matchReceiver)),
 		).GenerateManyRef(2)
-		otherRules := gen.With(
-			gen.WithGroupKey(groupKey2),
-			gen.WithUniqueGroupIndex(),
-			gen.WithContactPointRouting(models.NewDefaultContactPointRouting("other-receiver")),
+		otherRules := s.gen.With(
+			s.gen.WithGroupKey(s.groupKey2),
+			s.gen.WithUniqueGroupIndex(),
+			s.gen.WithContactPointRouting(models.NewDefaultContactPointRouting("other-receiver")),
 		).GenerateManyRef(3)
-
-		service, ruleStore, _, ac := initService(t)
-		service.folderService = fs
-		ruleStore.Rules = map[int64][]*models.AlertRule{orgID: append(matchRules, otherRules...)}
-		ac.CanReadAllRulesFunc = func(ctx context.Context, user identity.Requester) (bool, error) {
-			return true, nil
-		}
+		all := append(matchRules, otherRules...)
 
 		t.Run("Include should return only rules with the exact receiver", func(t *testing.T) {
-			rules, _, _, err := service.ListAlertRules(context.Background(), u, ListAlertRulesOptions{
+			service := s.initService(t, all...)
+			rules, _, _, err := service.ListAlertRules(context.Background(), s.user, ListAlertRulesOptions{
 				ReceiverFilter: ListRuleStringFilter{Include: []string{matchReceiver}},
 			})
 			require.NoError(t, err)
@@ -2369,7 +2399,8 @@ func TestListAlertRules(t *testing.T) {
 		})
 
 		t.Run("Exclude should return rules whose receiver differs", func(t *testing.T) {
-			rules, _, _, err := service.ListAlertRules(context.Background(), u, ListAlertRulesOptions{
+			service := s.initService(t, all...)
+			rules, _, _, err := service.ListAlertRules(context.Background(), s.user, ListAlertRulesOptions{
 				ReceiverFilter: ListRuleStringFilter{Exclude: []string{matchReceiver}},
 			})
 			require.NoError(t, err)
@@ -2384,27 +2415,23 @@ func TestListAlertRules(t *testing.T) {
 	})
 
 	t.Run("RoutingTreeFilter", func(t *testing.T) {
+		s := newFieldSelectorFilterTestSetup()
 		matchPolicy := "match-policy"
-		matchRules := gen.With(
-			gen.WithGroupKey(groupKey1),
-			gen.WithUniqueGroupIndex(),
-			gen.WithPolicyRouting(models.PolicyRouting{Policy: matchPolicy}),
+		matchRules := s.gen.With(
+			s.gen.WithGroupKey(s.groupKey1),
+			s.gen.WithUniqueGroupIndex(),
+			s.gen.WithPolicyRouting(models.PolicyRouting{Policy: matchPolicy}),
 		).GenerateManyRef(2)
-		otherRules := gen.With(
-			gen.WithGroupKey(groupKey2),
-			gen.WithUniqueGroupIndex(),
-			gen.WithPolicyRouting(models.PolicyRouting{Policy: "other-policy"}),
+		otherRules := s.gen.With(
+			s.gen.WithGroupKey(s.groupKey2),
+			s.gen.WithUniqueGroupIndex(),
+			s.gen.WithPolicyRouting(models.PolicyRouting{Policy: "other-policy"}),
 		).GenerateManyRef(3)
-
-		service, ruleStore, _, ac := initService(t)
-		service.folderService = fs
-		ruleStore.Rules = map[int64][]*models.AlertRule{orgID: append(matchRules, otherRules...)}
-		ac.CanReadAllRulesFunc = func(ctx context.Context, user identity.Requester) (bool, error) {
-			return true, nil
-		}
+		all := append(matchRules, otherRules...)
 
 		t.Run("Include should return only rules with the exact routing policy", func(t *testing.T) {
-			rules, _, _, err := service.ListAlertRules(context.Background(), u, ListAlertRulesOptions{
+			service := s.initService(t, all...)
+			rules, _, _, err := service.ListAlertRules(context.Background(), s.user, ListAlertRulesOptions{
 				RoutingTreeFilter: ListRuleStringFilter{Include: []string{matchPolicy}},
 			})
 			require.NoError(t, err)
@@ -2417,7 +2444,8 @@ func TestListAlertRules(t *testing.T) {
 		})
 
 		t.Run("Exclude should return rules whose routing policy differs", func(t *testing.T) {
-			rules, _, _, err := service.ListAlertRules(context.Background(), u, ListAlertRulesOptions{
+			service := s.initService(t, all...)
+			rules, _, _, err := service.ListAlertRules(context.Background(), s.user, ListAlertRulesOptions{
 				RoutingTreeFilter: ListRuleStringFilter{Exclude: []string{matchPolicy}},
 			})
 			require.NoError(t, err)
@@ -2432,29 +2460,25 @@ func TestListAlertRules(t *testing.T) {
 	})
 
 	t.Run("MetricFilter", func(t *testing.T) {
+		s := newFieldSelectorFilterTestSetup()
 		matchMetric := "match_metric"
-		matchRules := gen.With(
-			gen.WithGroupKey(groupKey1),
-			gen.WithUniqueGroupIndex(),
-			gen.WithAllRecordingRules(),
-			gen.WithMetric(matchMetric),
+		matchRules := s.gen.With(
+			s.gen.WithGroupKey(s.groupKey1),
+			s.gen.WithUniqueGroupIndex(),
+			s.gen.WithAllRecordingRules(),
+			s.gen.WithMetric(matchMetric),
 		).GenerateManyRef(2)
-		otherRules := gen.With(
-			gen.WithGroupKey(groupKey2),
-			gen.WithUniqueGroupIndex(),
-			gen.WithAllRecordingRules(),
-			gen.WithMetric("other_metric"),
+		otherRules := s.gen.With(
+			s.gen.WithGroupKey(s.groupKey2),
+			s.gen.WithUniqueGroupIndex(),
+			s.gen.WithAllRecordingRules(),
+			s.gen.WithMetric("other_metric"),
 		).GenerateManyRef(3)
-
-		service, ruleStore, _, ac := initService(t)
-		service.folderService = fs
-		ruleStore.Rules = map[int64][]*models.AlertRule{orgID: append(matchRules, otherRules...)}
-		ac.CanReadAllRulesFunc = func(ctx context.Context, user identity.Requester) (bool, error) {
-			return true, nil
-		}
+		all := append(matchRules, otherRules...)
 
 		t.Run("Include should return only recording rules with the exact metric", func(t *testing.T) {
-			rules, _, _, err := service.ListAlertRules(context.Background(), u, ListAlertRulesOptions{
+			service := s.initService(t, all...)
+			rules, _, _, err := service.ListAlertRules(context.Background(), s.user, ListAlertRulesOptions{
 				MetricFilter: ListRuleStringFilter{Include: []string{matchMetric}},
 			})
 			require.NoError(t, err)
@@ -2466,7 +2490,8 @@ func TestListAlertRules(t *testing.T) {
 		})
 
 		t.Run("Exclude should return only recording rules whose metric differs", func(t *testing.T) {
-			rules, _, _, err := service.ListAlertRules(context.Background(), u, ListAlertRulesOptions{
+			service := s.initService(t, all...)
+			rules, _, _, err := service.ListAlertRules(context.Background(), s.user, ListAlertRulesOptions{
 				MetricFilter: ListRuleStringFilter{Exclude: []string{matchMetric}},
 			})
 			require.NoError(t, err)
@@ -2479,6 +2504,7 @@ func TestListAlertRules(t *testing.T) {
 	})
 
 	t.Run("TargetDatasourceUIDFilter", func(t *testing.T) {
+		s := newFieldSelectorFilterTestSetup()
 		matchUID := "match-ds-uid"
 		setTargetUID := func(uid string) models.AlertRuleMutator {
 			return func(rule *models.AlertRule) {
@@ -2488,28 +2514,23 @@ func TestListAlertRules(t *testing.T) {
 				rule.Record.TargetDatasourceUID = uid
 			}
 		}
-		matchRules := gen.With(
-			gen.WithGroupKey(groupKey1),
-			gen.WithUniqueGroupIndex(),
-			gen.WithAllRecordingRules(),
+		matchRules := s.gen.With(
+			s.gen.WithGroupKey(s.groupKey1),
+			s.gen.WithUniqueGroupIndex(),
+			s.gen.WithAllRecordingRules(),
 			setTargetUID(matchUID),
 		).GenerateManyRef(2)
-		otherRules := gen.With(
-			gen.WithGroupKey(groupKey2),
-			gen.WithUniqueGroupIndex(),
-			gen.WithAllRecordingRules(),
+		otherRules := s.gen.With(
+			s.gen.WithGroupKey(s.groupKey2),
+			s.gen.WithUniqueGroupIndex(),
+			s.gen.WithAllRecordingRules(),
 			setTargetUID("other-ds-uid"),
 		).GenerateManyRef(3)
-
-		service, ruleStore, _, ac := initService(t)
-		service.folderService = fs
-		ruleStore.Rules = map[int64][]*models.AlertRule{orgID: append(matchRules, otherRules...)}
-		ac.CanReadAllRulesFunc = func(ctx context.Context, user identity.Requester) (bool, error) {
-			return true, nil
-		}
+		all := append(matchRules, otherRules...)
 
 		t.Run("Include should return only recording rules with the exact target datasource UID", func(t *testing.T) {
-			rules, _, _, err := service.ListAlertRules(context.Background(), u, ListAlertRulesOptions{
+			service := s.initService(t, all...)
+			rules, _, _, err := service.ListAlertRules(context.Background(), s.user, ListAlertRulesOptions{
 				TargetDatasourceUIDFilter: ListRuleStringFilter{Include: []string{matchUID}},
 			})
 			require.NoError(t, err)
@@ -2521,7 +2542,8 @@ func TestListAlertRules(t *testing.T) {
 		})
 
 		t.Run("Exclude should return only recording rules whose target datasource UID differs", func(t *testing.T) {
-			rules, _, _, err := service.ListAlertRules(context.Background(), u, ListAlertRulesOptions{
+			service := s.initService(t, all...)
+			rules, _, _, err := service.ListAlertRules(context.Background(), s.user, ListAlertRulesOptions{
 				TargetDatasourceUIDFilter: ListRuleStringFilter{Exclude: []string{matchUID}},
 			})
 			require.NoError(t, err)

--- a/pkg/services/ngalert/provisioning/alert_rules_test.go
+++ b/pkg/services/ngalert/provisioning/alert_rules_test.go
@@ -2113,6 +2113,34 @@ func TestListAlertRules(t *testing.T) {
 				require.Equal(t, matchTitle, r.Title)
 			}
 		})
+
+		t.Run("Exclude should return only rules whose title differs", func(t *testing.T) {
+			service, _ := initWithTitleData(t)
+			rules, _, _, err := service.ListAlertRules(context.Background(), u, ListAlertRulesOptions{
+				TitleFilter: ListRuleStringFilter{Exclude: []string{matchTitle}},
+			})
+			require.NoError(t, err)
+			require.Len(t, rules, 3)
+			for _, r := range rules {
+				require.NotEqual(t, matchTitle, r.Title)
+			}
+		})
+
+		t.Run("multiple Include values returns an error", func(t *testing.T) {
+			service, _ := initWithTitleData(t)
+			_, _, _, err := service.ListAlertRules(context.Background(), u, ListAlertRulesOptions{
+				TitleFilter: ListRuleStringFilter{Include: []string{matchTitle, "another"}},
+			})
+			require.Error(t, err)
+		})
+
+		t.Run("multiple Exclude values returns an error", func(t *testing.T) {
+			service, _ := initWithTitleData(t)
+			_, _, _, err := service.ListAlertRules(context.Background(), u, ListAlertRulesOptions{
+				TitleFilter: ListRuleStringFilter{Exclude: []string{matchTitle, "another"}},
+			})
+			require.Error(t, err)
+		})
 	})
 
 	t.Run("PausedFilter", func(t *testing.T) {
@@ -2183,6 +2211,18 @@ func TestListAlertRules(t *testing.T) {
 				require.Equal(t, dashUID, r.GetDashboardUID())
 			}
 		})
+
+		t.Run("Exclude should return only rules whose dashboardUID differs", func(t *testing.T) {
+			service, _ := initWithDashData(t)
+			rules, _, _, err := service.ListAlertRules(context.Background(), u, ListAlertRulesOptions{
+				DashboardFilter: ListRuleStringFilter{Exclude: []string{dashUID}},
+			})
+			require.NoError(t, err)
+			require.Len(t, rules, 3)
+			for _, r := range rules {
+				require.NotEqual(t, dashUID, r.GetDashboardUID())
+			}
+		})
 	})
 
 	t.Run("PanelIDFilter", func(t *testing.T) {
@@ -2212,6 +2252,283 @@ func TestListAlertRules(t *testing.T) {
 			require.Len(t, rules, 2)
 			for _, r := range rules {
 				require.Equal(t, panelID, r.GetPanelID())
+			}
+		})
+
+		t.Run("Exclude should return only rules whose panelID differs", func(t *testing.T) {
+			service, _ := initWithPanelData(t)
+			rules, _, _, err := service.ListAlertRules(context.Background(), u, ListAlertRulesOptions{
+				PanelIDFilter: ListRuleStringFilter{Exclude: []string{panelIDStr}},
+			})
+			require.NoError(t, err)
+			require.Len(t, rules, 3)
+			for _, r := range rules {
+				require.NotEqual(t, panelID, r.GetPanelID())
+			}
+		})
+	})
+
+	t.Run("NotificationTypeFilter", func(t *testing.T) {
+		simplifiedRules := gen.With(
+			gen.WithGroupKey(groupKey1),
+			gen.WithUniqueGroupIndex(),
+			gen.WithContactPointRouting(models.NewDefaultContactPointRouting("recv-a")),
+		).GenerateManyRef(2)
+		policyRules := gen.With(
+			gen.WithGroupKey(groupKey1),
+			gen.WithUniqueGroupIndex(),
+			gen.WithPolicyRouting(models.PolicyRouting{Policy: "policy-a"}),
+		).GenerateManyRef(3)
+		noNotifRules := gen.With(
+			gen.WithGroupKey(groupKey2),
+			gen.WithUniqueGroupIndex(),
+			gen.WithNoNotificationSettings(),
+		).GenerateManyRef(4)
+
+		setup := func(t *testing.T) *AlertRuleService {
+			service, ruleStore, _, ac := initService(t)
+			service.folderService = fs
+			combined := append(append(simplifiedRules, policyRules...), noNotifRules...)
+			ruleStore.Rules = map[int64][]*models.AlertRule{orgID: combined}
+			ac.CanReadAllRulesFunc = func(ctx context.Context, user identity.Requester) (bool, error) {
+				return true, nil
+			}
+			return service
+		}
+
+		t.Run("Include SimplifiedRouting returns only rules with contact point routing", func(t *testing.T) {
+			service := setup(t)
+			rules, _, _, err := service.ListAlertRules(context.Background(), u, ListAlertRulesOptions{
+				NotificationTypeFilter: ListRuleStringFilter{Include: []string{string(models.NotificationSettingsTypeSimplifiedRouting)}},
+			})
+			require.NoError(t, err)
+			require.Len(t, rules, 2)
+			for _, r := range rules {
+				require.NotNil(t, r.ContactPointRouting())
+			}
+		})
+
+		t.Run("Include NamedRoutingTree returns only rules with policy routing", func(t *testing.T) {
+			service := setup(t)
+			rules, _, _, err := service.ListAlertRules(context.Background(), u, ListAlertRulesOptions{
+				NotificationTypeFilter: ListRuleStringFilter{Include: []string{string(models.NotificationSettingsTypeNamedRoutingTree)}},
+			})
+			require.NoError(t, err)
+			require.Len(t, rules, 3)
+			for _, r := range rules {
+				require.Nil(t, r.ContactPointRouting())
+				require.NotNil(t, r.PolicyRouting())
+			}
+		})
+
+		t.Run("Exclude SimplifiedRouting returns rules without contact point routing", func(t *testing.T) {
+			service := setup(t)
+			rules, _, _, err := service.ListAlertRules(context.Background(), u, ListAlertRulesOptions{
+				NotificationTypeFilter: ListRuleStringFilter{Exclude: []string{string(models.NotificationSettingsTypeSimplifiedRouting)}},
+			})
+			require.NoError(t, err)
+			// 3 policy + 4 no-settings = 7
+			require.Len(t, rules, 7)
+			for _, r := range rules {
+				require.Nil(t, r.ContactPointRouting())
+			}
+		})
+	})
+
+	t.Run("ReceiverFilter", func(t *testing.T) {
+		matchReceiver := "match-receiver"
+		matchRules := gen.With(
+			gen.WithGroupKey(groupKey1),
+			gen.WithUniqueGroupIndex(),
+			gen.WithContactPointRouting(models.NewDefaultContactPointRouting(matchReceiver)),
+		).GenerateManyRef(2)
+		otherRules := gen.With(
+			gen.WithGroupKey(groupKey2),
+			gen.WithUniqueGroupIndex(),
+			gen.WithContactPointRouting(models.NewDefaultContactPointRouting("other-receiver")),
+		).GenerateManyRef(3)
+
+		service, ruleStore, _, ac := initService(t)
+		service.folderService = fs
+		ruleStore.Rules = map[int64][]*models.AlertRule{orgID: append(matchRules, otherRules...)}
+		ac.CanReadAllRulesFunc = func(ctx context.Context, user identity.Requester) (bool, error) {
+			return true, nil
+		}
+
+		t.Run("Include should return only rules with the exact receiver", func(t *testing.T) {
+			rules, _, _, err := service.ListAlertRules(context.Background(), u, ListAlertRulesOptions{
+				ReceiverFilter: ListRuleStringFilter{Include: []string{matchReceiver}},
+			})
+			require.NoError(t, err)
+			require.Len(t, rules, 2)
+			for _, r := range rules {
+				cpr := r.ContactPointRouting()
+				require.NotNil(t, cpr)
+				require.Equal(t, matchReceiver, cpr.Receiver)
+			}
+		})
+
+		t.Run("Exclude should return rules whose receiver differs", func(t *testing.T) {
+			rules, _, _, err := service.ListAlertRules(context.Background(), u, ListAlertRulesOptions{
+				ReceiverFilter: ListRuleStringFilter{Exclude: []string{matchReceiver}},
+			})
+			require.NoError(t, err)
+			require.Len(t, rules, 3)
+			for _, r := range rules {
+				cpr := r.ContactPointRouting()
+				if cpr != nil {
+					require.NotEqual(t, matchReceiver, cpr.Receiver)
+				}
+			}
+		})
+	})
+
+	t.Run("RoutingTreeFilter", func(t *testing.T) {
+		matchPolicy := "match-policy"
+		matchRules := gen.With(
+			gen.WithGroupKey(groupKey1),
+			gen.WithUniqueGroupIndex(),
+			gen.WithPolicyRouting(models.PolicyRouting{Policy: matchPolicy}),
+		).GenerateManyRef(2)
+		otherRules := gen.With(
+			gen.WithGroupKey(groupKey2),
+			gen.WithUniqueGroupIndex(),
+			gen.WithPolicyRouting(models.PolicyRouting{Policy: "other-policy"}),
+		).GenerateManyRef(3)
+
+		service, ruleStore, _, ac := initService(t)
+		service.folderService = fs
+		ruleStore.Rules = map[int64][]*models.AlertRule{orgID: append(matchRules, otherRules...)}
+		ac.CanReadAllRulesFunc = func(ctx context.Context, user identity.Requester) (bool, error) {
+			return true, nil
+		}
+
+		t.Run("Include should return only rules with the exact routing policy", func(t *testing.T) {
+			rules, _, _, err := service.ListAlertRules(context.Background(), u, ListAlertRulesOptions{
+				RoutingTreeFilter: ListRuleStringFilter{Include: []string{matchPolicy}},
+			})
+			require.NoError(t, err)
+			require.Len(t, rules, 2)
+			for _, r := range rules {
+				pr := r.PolicyRouting()
+				require.NotNil(t, pr)
+				require.Equal(t, matchPolicy, pr.Policy)
+			}
+		})
+
+		t.Run("Exclude should return rules whose routing policy differs", func(t *testing.T) {
+			rules, _, _, err := service.ListAlertRules(context.Background(), u, ListAlertRulesOptions{
+				RoutingTreeFilter: ListRuleStringFilter{Exclude: []string{matchPolicy}},
+			})
+			require.NoError(t, err)
+			require.Len(t, rules, 3)
+			for _, r := range rules {
+				pr := r.PolicyRouting()
+				if pr != nil {
+					require.NotEqual(t, matchPolicy, pr.Policy)
+				}
+			}
+		})
+	})
+
+	t.Run("MetricFilter", func(t *testing.T) {
+		matchMetric := "match_metric"
+		matchRules := gen.With(
+			gen.WithGroupKey(groupKey1),
+			gen.WithUniqueGroupIndex(),
+			gen.WithAllRecordingRules(),
+			gen.WithMetric(matchMetric),
+		).GenerateManyRef(2)
+		otherRules := gen.With(
+			gen.WithGroupKey(groupKey2),
+			gen.WithUniqueGroupIndex(),
+			gen.WithAllRecordingRules(),
+			gen.WithMetric("other_metric"),
+		).GenerateManyRef(3)
+
+		service, ruleStore, _, ac := initService(t)
+		service.folderService = fs
+		ruleStore.Rules = map[int64][]*models.AlertRule{orgID: append(matchRules, otherRules...)}
+		ac.CanReadAllRulesFunc = func(ctx context.Context, user identity.Requester) (bool, error) {
+			return true, nil
+		}
+
+		t.Run("Include should return only recording rules with the exact metric", func(t *testing.T) {
+			rules, _, _, err := service.ListAlertRules(context.Background(), u, ListAlertRulesOptions{
+				MetricFilter: ListRuleStringFilter{Include: []string{matchMetric}},
+			})
+			require.NoError(t, err)
+			require.Len(t, rules, 2)
+			for _, r := range rules {
+				require.NotNil(t, r.Record)
+				require.Equal(t, matchMetric, r.Record.Metric)
+			}
+		})
+
+		t.Run("Exclude should return only recording rules whose metric differs", func(t *testing.T) {
+			rules, _, _, err := service.ListAlertRules(context.Background(), u, ListAlertRulesOptions{
+				MetricFilter: ListRuleStringFilter{Exclude: []string{matchMetric}},
+			})
+			require.NoError(t, err)
+			require.Len(t, rules, 3)
+			for _, r := range rules {
+				require.NotNil(t, r.Record)
+				require.NotEqual(t, matchMetric, r.Record.Metric)
+			}
+		})
+	})
+
+	t.Run("TargetDatasourceUIDFilter", func(t *testing.T) {
+		matchUID := "match-ds-uid"
+		setTargetUID := func(uid string) models.AlertRuleMutator {
+			return func(rule *models.AlertRule) {
+				if rule.Record == nil {
+					rule.Record = &models.Record{}
+				}
+				rule.Record.TargetDatasourceUID = uid
+			}
+		}
+		matchRules := gen.With(
+			gen.WithGroupKey(groupKey1),
+			gen.WithUniqueGroupIndex(),
+			gen.WithAllRecordingRules(),
+			setTargetUID(matchUID),
+		).GenerateManyRef(2)
+		otherRules := gen.With(
+			gen.WithGroupKey(groupKey2),
+			gen.WithUniqueGroupIndex(),
+			gen.WithAllRecordingRules(),
+			setTargetUID("other-ds-uid"),
+		).GenerateManyRef(3)
+
+		service, ruleStore, _, ac := initService(t)
+		service.folderService = fs
+		ruleStore.Rules = map[int64][]*models.AlertRule{orgID: append(matchRules, otherRules...)}
+		ac.CanReadAllRulesFunc = func(ctx context.Context, user identity.Requester) (bool, error) {
+			return true, nil
+		}
+
+		t.Run("Include should return only recording rules with the exact target datasource UID", func(t *testing.T) {
+			rules, _, _, err := service.ListAlertRules(context.Background(), u, ListAlertRulesOptions{
+				TargetDatasourceUIDFilter: ListRuleStringFilter{Include: []string{matchUID}},
+			})
+			require.NoError(t, err)
+			require.Len(t, rules, 2)
+			for _, r := range rules {
+				require.NotNil(t, r.Record)
+				require.Equal(t, matchUID, r.Record.TargetDatasourceUID)
+			}
+		})
+
+		t.Run("Exclude should return only recording rules whose target datasource UID differs", func(t *testing.T) {
+			rules, _, _, err := service.ListAlertRules(context.Background(), u, ListAlertRulesOptions{
+				TargetDatasourceUIDFilter: ListRuleStringFilter{Exclude: []string{matchUID}},
+			})
+			require.NoError(t, err)
+			require.Len(t, rules, 3)
+			for _, r := range rules {
+				require.NotNil(t, r.Record)
+				require.NotEqual(t, matchUID, r.Record.TargetDatasourceUID)
 			}
 		})
 	})

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -928,13 +928,8 @@ func buildGroupCursorCondition(sess *xorm.Session, c ngmodels.GroupCursor, orgID
 
 func shouldIncludeRule(rule *ngmodels.AlertRule, query *ngmodels.ListAlertRulesExtendedQuery, groupsMap map[string]struct{}) bool {
 	settings := rule.ContactPointRouting()
-	if query.ReceiverName != "" {
-		if settings == nil {
-			return false
-		}
-		if settings.Receiver != query.ReceiverName {
-			return false
-		}
+	if !matchesReceiverFilters(settings, query) {
+		return false
 	}
 
 	if query.TimeIntervalName != "" {
@@ -945,6 +940,10 @@ func shouldIncludeRule(rule *ngmodels.AlertRule, query *ngmodels.ListAlertRulesE
 			!slices.Contains(settings.ActiveTimeIntervals, query.TimeIntervalName) {
 			return false
 		}
+	}
+
+	if !matchesRecordFilters(rule, query) {
+		return false
 	}
 
 	if query.HasPrometheusRuleDefinition != nil {
@@ -959,6 +958,51 @@ func shouldIncludeRule(rule *ngmodels.AlertRule, query *ngmodels.ListAlertRulesE
 		}
 	}
 
+	return true
+}
+
+// matchesReceiverFilters verifies the ReceiverName / ExcludeReceiverName scalar filters exactly
+// against the rule's contact-point routing. The SQL pre-filter uses substring matching on the
+// notification_settings JSON, so this post-filter removes false positives.
+func matchesReceiverFilters(settings *ngmodels.ContactPointRouting, query *ngmodels.ListAlertRulesExtendedQuery) bool {
+	receiver := ""
+	if settings != nil {
+		receiver = settings.Receiver
+	}
+	if query.ReceiverName != "" && receiver != query.ReceiverName {
+		return false
+	}
+	if query.ExcludeReceiverName != "" && receiver == query.ExcludeReceiverName {
+		return false
+	}
+	return true
+}
+
+// matchesRecordFilters verifies the record-related scalar filters exactly against the rule's
+// Record. The SQL pre-filter uses substring matching on the record JSON column, so this
+// post-filter removes false positives.
+func matchesRecordFilters(rule *ngmodels.AlertRule, query *ngmodels.ListAlertRulesExtendedQuery) bool {
+	if query.RecordMetricExact == "" && query.ExcludeRecordMetric == "" &&
+		query.RecordTargetDatasourceUIDExact == "" && query.ExcludeRecordTargetDatasourceUID == "" {
+		return true
+	}
+	metric, target := "", ""
+	if rule.Record != nil {
+		metric = rule.Record.Metric
+		target = rule.Record.TargetDatasourceUID
+	}
+	if query.RecordMetricExact != "" && metric != query.RecordMetricExact {
+		return false
+	}
+	if query.ExcludeRecordMetric != "" && metric == query.ExcludeRecordMetric {
+		return false
+	}
+	if query.RecordTargetDatasourceUIDExact != "" && target != query.RecordTargetDatasourceUIDExact {
+		return false
+	}
+	if query.ExcludeRecordTargetDatasourceUID != "" && target == query.ExcludeRecordTargetDatasourceUID {
+		return false
+	}
 	return true
 }
 
@@ -1134,14 +1178,69 @@ func (st DBstore) buildListAlertRulesQuery(sess *db.Session, query *ngmodels.Lis
 	if query.DashboardUID != "" {
 		q = q.Where("dashboard_uid = ?", query.DashboardUID)
 	}
+	if query.ExcludeDashboardUID != "" {
+		// dashboard_uid is nullable, so a NULL value should also satisfy `!=`.
+		q = q.Where("(dashboard_uid IS NULL OR dashboard_uid <> ?)", query.ExcludeDashboardUID)
+	}
 	if query.PanelID != 0 {
 		q = q.Where("panel_id = ?", query.PanelID)
+	}
+	if query.ExcludePanelID != 0 {
+		q = q.Where("(panel_id IS NULL OR panel_id <> ?)", query.ExcludePanelID)
 	}
 	if query.IsPaused != nil {
 		q = q.Where("is_paused = ?", *query.IsPaused)
 	}
 	if query.TitleExact != "" {
 		q = q.Where("title = ?", query.TitleExact)
+	}
+	if query.ExcludeTitle != "" {
+		q = q.Where("title <> ?", query.ExcludeTitle)
+	}
+	if t := query.NotificationSettingsType; t != "" {
+		clause, err := notificationSettingsTypeClause(t)
+		if err != nil {
+			return nil, groupsSet, err
+		}
+		q = q.Where(clause)
+	}
+	if t := query.ExcludeNotificationSettingsType; t != "" {
+		clause, err := notificationSettingsTypeClause(t)
+		if err != nil {
+			return nil, groupsSet, err
+		}
+		q = q.Where("NOT (" + clause + ")")
+	}
+	if query.RoutingPolicyExact != "" {
+		q = q.Where("alert_routing_policy = ?", query.RoutingPolicyExact)
+	}
+	if query.ExcludeRoutingPolicy != "" {
+		// alert_routing_policy is nullable; NULL should satisfy `!=` to match k8s field-selector semantics.
+		q = q.Where("(alert_routing_policy IS NULL OR alert_routing_policy <> ?)", query.ExcludeRoutingPolicy)
+	}
+	if query.RecordMetricExact != "" {
+		q, err = st.filterByContentInRecord("Metric", query.RecordMetricExact, false, q)
+		if err != nil {
+			return nil, groupsSet, err
+		}
+	}
+	if query.ExcludeRecordMetric != "" {
+		q, err = st.filterByContentInRecord("Metric", query.ExcludeRecordMetric, true, q)
+		if err != nil {
+			return nil, groupsSet, err
+		}
+	}
+	if query.RecordTargetDatasourceUIDExact != "" {
+		q, err = st.filterByContentInRecord("TargetDatasourceUID", query.RecordTargetDatasourceUIDExact, false, q)
+		if err != nil {
+			return nil, groupsSet, err
+		}
+	}
+	if query.ExcludeRecordTargetDatasourceUID != "" {
+		q, err = st.filterByContentInRecord("TargetDatasourceUID", query.ExcludeRecordTargetDatasourceUID, true, q)
+		if err != nil {
+			return nil, groupsSet, err
+		}
 	}
 
 	if len(query.NamespaceUIDs) > 0 {
@@ -1183,6 +1282,9 @@ func (st DBstore) buildListAlertRulesQuery(sess *db.Session, query *ngmodels.Lis
 			return nil, groupsSet, err
 		}
 	}
+	// ExcludeReceiverName has no SQL pre-filter (LIKE-based exclusion would over-exclude rules
+	// that contain the value as a substring of an unrelated JSON field). The exact-match check
+	// happens in matchesReceiverFilters in the post-query filter.
 
 	if query.TimeIntervalName != "" {
 		q, err = st.filterByContentInNotificationSettings(query.TimeIntervalName, q)
@@ -1291,13 +1393,8 @@ func (st DBstore) handleRuleRow(rows *xorm.Rows, query *ngmodels.ListAlertRulesE
 		return nil, false
 	}
 	settings := converted.ContactPointRouting()
-	if query.ReceiverName != "" { // remove false-positive hits from the result
-		if settings == nil {
-			return nil, false
-		}
-		if settings.Receiver != query.ReceiverName {
-			return nil, false
-		}
+	if !matchesReceiverFilters(settings, query) { // remove false-positive hits from the result
+		return nil, false
 	}
 	if query.TimeIntervalName != "" {
 		if settings == nil {
@@ -1307,6 +1404,9 @@ func (st DBstore) handleRuleRow(rows *xorm.Rows, query *ngmodels.ListAlertRulesE
 			!slices.Contains(settings.ActiveTimeIntervals, query.TimeIntervalName) {
 			return nil, false
 		}
+	}
+	if !matchesRecordFilters(&converted, query) { // remove false-positive hits from the result
+		return nil, false
 	}
 	if query.HasPrometheusRuleDefinition != nil { // remove false-positive hits from the result
 		if *query.HasPrometheusRuleDefinition != converted.HasPrometheusRuleDefinition() {
@@ -1686,6 +1786,50 @@ func (st DBstore) filterByContentInNotificationSettings(value string, sess *xorm
 		search = strings.ReplaceAll(strings.ReplaceAll(search, `\`, `\\`), `"`, `\"`)
 	}
 	sql, param := st.SQLStore.GetDialect().LikeOperator("notification_settings", true, search, true)
+	return sess.And(sql, param), nil
+}
+
+// notificationSettingsTypeClause returns a SQL predicate matching rules whose effective
+// notification settings type equals t. Effective type is SimplifiedRouting when
+// notification_settings is set, otherwise NamedRoutingTree when alert_routing_policy is set.
+// SimplifiedRouting takes precedence on rules that have both columns populated.
+func notificationSettingsTypeClause(t ngmodels.NotificationSettingsType) (string, error) {
+	const simplifiedSet = "notification_settings IS NOT NULL AND notification_settings <> '' AND notification_settings <> 'null' AND notification_settings <> '[]'"
+	const simplifiedUnset = "(notification_settings IS NULL OR notification_settings = '' OR notification_settings = 'null' OR notification_settings = '[]')"
+	switch t {
+	case ngmodels.NotificationSettingsTypeSimplifiedRouting:
+		return simplifiedSet, nil
+	case ngmodels.NotificationSettingsTypeNamedRoutingTree:
+		return "alert_routing_policy IS NOT NULL AND " + simplifiedUnset, nil
+	default:
+		return "", fmt.Errorf("unsupported notification settings type %q", t)
+	}
+}
+
+// filterByContentInRecord adds a LIKE filter to the query for the given key/value pair in the
+// `record` JSON column. When exclude is true, the rule must not match. Callers should still
+// verify the match by parsing the column after the query runs, as LIKE matches the raw JSON
+// serialization and may include false positives.
+func (st DBstore) filterByContentInRecord(key, value string, exclude bool, sess *xorm.Session) (*xorm.Session, error) {
+	if value == "" {
+		return sess, nil
+	}
+	keyBytes, err := json.Marshal(key)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshall key for record content filter: %w", err)
+	}
+	valueBytes, err := json.Marshal(value)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshall value for record content filter: %w", err)
+	}
+	search := string(keyBytes) + ":" + string(valueBytes)
+	if st.SQLStore.GetDialect().DriverName() != migrator.SQLite {
+		search = strings.ReplaceAll(strings.ReplaceAll(search, `\`, `\\`), `"`, `\"`)
+	}
+	sql, param := st.SQLStore.GetDialect().LikeOperator("record", true, search, true)
+	if exclude {
+		return sess.And("NOT ("+sql+")", param), nil
+	}
 	return sess.And(sql, param), nil
 }
 

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -3419,6 +3419,381 @@ func TestIntegration_ListAlertRulesPaginatedFilters(t *testing.T) {
 		}
 		require.ElementsMatch(t, []string{panel1.UID, panel2.UID}, gotUIDs)
 	})
+
+	t.Run("ExcludeTitle", func(t *testing.T) {
+		sqlStore := db.InitTestDB(t)
+		folderService := setupFolderService(t, sqlStore, cfg, featuremgmt.WithFeatures())
+		store := createTestStore(sqlStore, folderService, &logtest.Fake{}, cfg.UnifiedAlerting, b)
+
+		excludedTitle := "excluded-title"
+		excludedGen := ruleGen.With(ruleGen.WithTitle(excludedTitle))
+		otherGen := ruleGen.With(ruleGen.WithUniqueTitle())
+
+		createRule(t, store, excludedGen)
+		createRule(t, store, excludedGen)
+		other1 := createRule(t, store, otherGen)
+		other2 := createRule(t, store, otherGen)
+
+		query := &models.ListAlertRulesExtendedQuery{
+			ListAlertRulesQuery: models.ListAlertRulesQuery{
+				OrgID:        orgID,
+				ExcludeTitle: excludedTitle,
+			},
+		}
+		result, _, err := store.ListAlertRulesPaginated(context.Background(), query)
+		require.NoError(t, err)
+		require.Len(t, result, 2)
+		gotUIDs := make([]string, 0, len(result))
+		for _, r := range result {
+			gotUIDs = append(gotUIDs, r.UID)
+		}
+		require.ElementsMatch(t, []string{other1.UID, other2.UID}, gotUIDs)
+	})
+
+	t.Run("ExcludeDashboardUID", func(t *testing.T) {
+		sqlStore := db.InitTestDB(t)
+		folderService := setupFolderService(t, sqlStore, cfg, featuremgmt.WithFeatures())
+		store := createTestStore(sqlStore, folderService, &logtest.Fake{}, cfg.UnifiedAlerting, b)
+
+		excludedDash := "excluded-dashboard"
+		otherDash := "other-dashboard"
+		excludedGen := ruleGen.With(ruleGen.WithDashboardAndPanel(&excludedDash, nil))
+		otherGen := ruleGen.With(ruleGen.WithDashboardAndPanel(&otherDash, nil))
+
+		createRule(t, store, excludedGen)
+		other1 := createRule(t, store, otherGen)
+		other2 := createRule(t, store, otherGen)
+
+		query := &models.ListAlertRulesExtendedQuery{
+			ListAlertRulesQuery: models.ListAlertRulesQuery{
+				OrgID:               orgID,
+				ExcludeDashboardUID: excludedDash,
+			},
+		}
+		result, _, err := store.ListAlertRulesPaginated(context.Background(), query)
+		require.NoError(t, err)
+		require.Len(t, result, 2)
+		gotUIDs := make([]string, 0, len(result))
+		for _, r := range result {
+			gotUIDs = append(gotUIDs, r.UID)
+		}
+		require.ElementsMatch(t, []string{other1.UID, other2.UID}, gotUIDs)
+	})
+
+	t.Run("ExcludePanelID", func(t *testing.T) {
+		sqlStore := db.InitTestDB(t)
+		folderService := setupFolderService(t, sqlStore, cfg, featuremgmt.WithFeatures())
+		store := createTestStore(sqlStore, folderService, &logtest.Fake{}, cfg.UnifiedAlerting, b)
+
+		dashUID := "dash-for-panel-exclude"
+		excludedPanelID := int64(42)
+		otherPanelID := int64(99)
+		excludedGen := ruleGen.With(ruleGen.WithDashboardAndPanel(&dashUID, &excludedPanelID))
+		otherGen := ruleGen.With(ruleGen.WithDashboardAndPanel(&dashUID, &otherPanelID))
+
+		createRule(t, store, excludedGen)
+		other1 := createRule(t, store, otherGen)
+		other2 := createRule(t, store, otherGen)
+
+		query := &models.ListAlertRulesExtendedQuery{
+			ListAlertRulesQuery: models.ListAlertRulesQuery{
+				OrgID:          orgID,
+				ExcludePanelID: excludedPanelID,
+			},
+		}
+		result, _, err := store.ListAlertRulesPaginated(context.Background(), query)
+		require.NoError(t, err)
+		require.Len(t, result, 2)
+		gotUIDs := make([]string, 0, len(result))
+		for _, r := range result {
+			gotUIDs = append(gotUIDs, r.UID)
+		}
+		require.ElementsMatch(t, []string{other1.UID, other2.UID}, gotUIDs)
+	})
+
+	t.Run("NotificationSettingsType=SimplifiedRouting", func(t *testing.T) {
+		sqlStore := db.InitTestDB(t)
+		folderService := setupFolderService(t, sqlStore, cfg, featuremgmt.WithFeatures())
+		store := createTestStore(sqlStore, folderService, &logtest.Fake{}, cfg.UnifiedAlerting, b)
+
+		simplifiedGen := ruleGen.With(ruleGen.WithContactPointRouting(models.NewDefaultContactPointRouting("recv-x")))
+		policyGen := ruleGen.With(ruleGen.WithPolicyRouting(models.PolicyRouting{Policy: "policy-x"}))
+		noNotifGen := ruleGen.With(ruleGen.WithNoNotificationSettings())
+
+		s1 := createRule(t, store, simplifiedGen)
+		s2 := createRule(t, store, simplifiedGen)
+		createRule(t, store, policyGen)
+		createRule(t, store, noNotifGen)
+
+		query := &models.ListAlertRulesExtendedQuery{
+			ListAlertRulesQuery: models.ListAlertRulesQuery{
+				OrgID:                    orgID,
+				NotificationSettingsType: models.NotificationSettingsTypeSimplifiedRouting,
+			},
+		}
+		result, _, err := store.ListAlertRulesPaginated(context.Background(), query)
+		require.NoError(t, err)
+		require.Len(t, result, 2)
+		gotUIDs := make([]string, 0, len(result))
+		for _, r := range result {
+			gotUIDs = append(gotUIDs, r.UID)
+		}
+		require.ElementsMatch(t, []string{s1.UID, s2.UID}, gotUIDs)
+	})
+
+	t.Run("NotificationSettingsType=NamedRoutingTree", func(t *testing.T) {
+		sqlStore := db.InitTestDB(t)
+		folderService := setupFolderService(t, sqlStore, cfg, featuremgmt.WithFeatures())
+		store := createTestStore(sqlStore, folderService, &logtest.Fake{}, cfg.UnifiedAlerting, b)
+
+		simplifiedGen := ruleGen.With(ruleGen.WithContactPointRouting(models.NewDefaultContactPointRouting("recv-y")))
+		policyGen := ruleGen.With(ruleGen.WithPolicyRouting(models.PolicyRouting{Policy: "policy-y"}))
+		noNotifGen := ruleGen.With(ruleGen.WithNoNotificationSettings())
+
+		createRule(t, store, simplifiedGen)
+		p1 := createRule(t, store, policyGen)
+		p2 := createRule(t, store, policyGen)
+		createRule(t, store, noNotifGen)
+
+		query := &models.ListAlertRulesExtendedQuery{
+			ListAlertRulesQuery: models.ListAlertRulesQuery{
+				OrgID:                    orgID,
+				NotificationSettingsType: models.NotificationSettingsTypeNamedRoutingTree,
+			},
+		}
+		result, _, err := store.ListAlertRulesPaginated(context.Background(), query)
+		require.NoError(t, err)
+		require.Len(t, result, 2)
+		gotUIDs := make([]string, 0, len(result))
+		for _, r := range result {
+			gotUIDs = append(gotUIDs, r.UID)
+		}
+		require.ElementsMatch(t, []string{p1.UID, p2.UID}, gotUIDs)
+	})
+
+	t.Run("ExcludeNotificationSettingsType excludes simplified rules", func(t *testing.T) {
+		sqlStore := db.InitTestDB(t)
+		folderService := setupFolderService(t, sqlStore, cfg, featuremgmt.WithFeatures())
+		store := createTestStore(sqlStore, folderService, &logtest.Fake{}, cfg.UnifiedAlerting, b)
+
+		simplifiedGen := ruleGen.With(ruleGen.WithContactPointRouting(models.NewDefaultContactPointRouting("recv-z")))
+		policyGen := ruleGen.With(ruleGen.WithPolicyRouting(models.PolicyRouting{Policy: "policy-z"}))
+		noNotifGen := ruleGen.With(ruleGen.WithNoNotificationSettings())
+
+		createRule(t, store, simplifiedGen)
+		p1 := createRule(t, store, policyGen)
+		n1 := createRule(t, store, noNotifGen)
+
+		query := &models.ListAlertRulesExtendedQuery{
+			ListAlertRulesQuery: models.ListAlertRulesQuery{
+				OrgID:                           orgID,
+				ExcludeNotificationSettingsType: models.NotificationSettingsTypeSimplifiedRouting,
+			},
+		}
+		result, _, err := store.ListAlertRulesPaginated(context.Background(), query)
+		require.NoError(t, err)
+		require.Len(t, result, 2)
+		gotUIDs := make([]string, 0, len(result))
+		for _, r := range result {
+			gotUIDs = append(gotUIDs, r.UID)
+		}
+		require.ElementsMatch(t, []string{p1.UID, n1.UID}, gotUIDs)
+	})
+
+	t.Run("RoutingPolicyExact", func(t *testing.T) {
+		sqlStore := db.InitTestDB(t)
+		folderService := setupFolderService(t, sqlStore, cfg, featuremgmt.WithFeatures())
+		store := createTestStore(sqlStore, folderService, &logtest.Fake{}, cfg.UnifiedAlerting, b)
+
+		matchPolicy := "match-policy"
+		matchGen := ruleGen.With(ruleGen.WithPolicyRouting(models.PolicyRouting{Policy: matchPolicy}))
+		otherGen := ruleGen.With(ruleGen.WithPolicyRouting(models.PolicyRouting{Policy: "other-policy"}))
+
+		p1 := createRule(t, store, matchGen)
+		p2 := createRule(t, store, matchGen)
+		createRule(t, store, otherGen)
+
+		query := &models.ListAlertRulesExtendedQuery{
+			ListAlertRulesQuery: models.ListAlertRulesQuery{
+				OrgID:              orgID,
+				RoutingPolicyExact: matchPolicy,
+			},
+		}
+		result, _, err := store.ListAlertRulesPaginated(context.Background(), query)
+		require.NoError(t, err)
+		require.Len(t, result, 2)
+		gotUIDs := make([]string, 0, len(result))
+		for _, r := range result {
+			gotUIDs = append(gotUIDs, r.UID)
+		}
+		require.ElementsMatch(t, []string{p1.UID, p2.UID}, gotUIDs)
+	})
+
+	t.Run("ExcludeRoutingPolicy includes rules with no policy", func(t *testing.T) {
+		sqlStore := db.InitTestDB(t)
+		folderService := setupFolderService(t, sqlStore, cfg, featuremgmt.WithFeatures())
+		store := createTestStore(sqlStore, folderService, &logtest.Fake{}, cfg.UnifiedAlerting, b)
+
+		excludedPolicy := "excluded-policy"
+		excludedGen := ruleGen.With(ruleGen.WithPolicyRouting(models.PolicyRouting{Policy: excludedPolicy}))
+		otherGen := ruleGen.With(ruleGen.WithPolicyRouting(models.PolicyRouting{Policy: "other-policy"}))
+		noPolicyGen := ruleGen.With(ruleGen.WithNoNotificationSettings())
+
+		createRule(t, store, excludedGen)
+		other1 := createRule(t, store, otherGen)
+		noPolicy := createRule(t, store, noPolicyGen)
+
+		query := &models.ListAlertRulesExtendedQuery{
+			ListAlertRulesQuery: models.ListAlertRulesQuery{
+				OrgID:                orgID,
+				ExcludeRoutingPolicy: excludedPolicy,
+			},
+		}
+		result, _, err := store.ListAlertRulesPaginated(context.Background(), query)
+		require.NoError(t, err)
+		// Both the rule with a different policy and the rule with no policy should match `!=`.
+		require.Len(t, result, 2)
+		gotUIDs := make([]string, 0, len(result))
+		for _, r := range result {
+			gotUIDs = append(gotUIDs, r.UID)
+		}
+		require.ElementsMatch(t, []string{other1.UID, noPolicy.UID}, gotUIDs)
+	})
+
+	t.Run("RecordMetricExact", func(t *testing.T) {
+		sqlStore := db.InitTestDB(t)
+		folderService := setupFolderService(t, sqlStore, cfg, featuremgmt.WithFeatures())
+		store := createTestStore(sqlStore, folderService, &logtest.Fake{}, cfg.UnifiedAlerting, b)
+
+		matchMetric := "match_metric"
+		matchGen := ruleGen.With(ruleGen.WithAllRecordingRules(), ruleGen.WithMetric(matchMetric))
+		otherGen := ruleGen.With(ruleGen.WithAllRecordingRules(), ruleGen.WithMetric("other_metric"))
+
+		m1 := createRule(t, store, matchGen)
+		m2 := createRule(t, store, matchGen)
+		createRule(t, store, otherGen)
+
+		query := &models.ListAlertRulesExtendedQuery{
+			ListAlertRulesQuery: models.ListAlertRulesQuery{
+				OrgID:             orgID,
+				RecordMetricExact: matchMetric,
+			},
+		}
+		result, _, err := store.ListAlertRulesPaginated(context.Background(), query)
+		require.NoError(t, err)
+		require.Len(t, result, 2)
+		gotUIDs := make([]string, 0, len(result))
+		for _, r := range result {
+			gotUIDs = append(gotUIDs, r.UID)
+		}
+		require.ElementsMatch(t, []string{m1.UID, m2.UID}, gotUIDs)
+	})
+
+	t.Run("ExcludeRecordMetric", func(t *testing.T) {
+		sqlStore := db.InitTestDB(t)
+		folderService := setupFolderService(t, sqlStore, cfg, featuremgmt.WithFeatures())
+		store := createTestStore(sqlStore, folderService, &logtest.Fake{}, cfg.UnifiedAlerting, b)
+
+		excludedMetric := "excluded_metric"
+		excludedGen := ruleGen.With(ruleGen.WithAllRecordingRules(), ruleGen.WithMetric(excludedMetric))
+		otherGen := ruleGen.With(ruleGen.WithAllRecordingRules(), ruleGen.WithMetric("other_metric"))
+
+		createRule(t, store, excludedGen)
+		other1 := createRule(t, store, otherGen)
+		other2 := createRule(t, store, otherGen)
+
+		query := &models.ListAlertRulesExtendedQuery{
+			ListAlertRulesQuery: models.ListAlertRulesQuery{
+				OrgID:               orgID,
+				ExcludeRecordMetric: excludedMetric,
+			},
+			// scope to recording rules so we don't pick up alerting noise.
+			RuleType: models.RuleTypeFilterRecording,
+		}
+		result, _, err := store.ListAlertRulesPaginated(context.Background(), query)
+		require.NoError(t, err)
+		require.Len(t, result, 2)
+		gotUIDs := make([]string, 0, len(result))
+		for _, r := range result {
+			gotUIDs = append(gotUIDs, r.UID)
+		}
+		require.ElementsMatch(t, []string{other1.UID, other2.UID}, gotUIDs)
+	})
+
+	t.Run("RecordTargetDatasourceUIDExact", func(t *testing.T) {
+		sqlStore := db.InitTestDB(t)
+		folderService := setupFolderService(t, sqlStore, cfg, featuremgmt.WithFeatures())
+		store := createTestStore(sqlStore, folderService, &logtest.Fake{}, cfg.UnifiedAlerting, b)
+
+		matchUID := "match-target-ds-uid"
+		setTargetUID := func(uid string) models.AlertRuleMutator {
+			return func(rule *models.AlertRule) {
+				if rule.Record == nil {
+					rule.Record = &models.Record{}
+				}
+				rule.Record.TargetDatasourceUID = uid
+			}
+		}
+		matchGen := ruleGen.With(ruleGen.WithAllRecordingRules(), setTargetUID(matchUID))
+		otherGen := ruleGen.With(ruleGen.WithAllRecordingRules(), setTargetUID("other-target-ds-uid"))
+
+		t1 := createRule(t, store, matchGen)
+		t2 := createRule(t, store, matchGen)
+		createRule(t, store, otherGen)
+
+		query := &models.ListAlertRulesExtendedQuery{
+			ListAlertRulesQuery: models.ListAlertRulesQuery{
+				OrgID:                          orgID,
+				RecordTargetDatasourceUIDExact: matchUID,
+			},
+		}
+		result, _, err := store.ListAlertRulesPaginated(context.Background(), query)
+		require.NoError(t, err)
+		require.Len(t, result, 2)
+		gotUIDs := make([]string, 0, len(result))
+		for _, r := range result {
+			gotUIDs = append(gotUIDs, r.UID)
+		}
+		require.ElementsMatch(t, []string{t1.UID, t2.UID}, gotUIDs)
+	})
+
+	t.Run("ExcludeRecordTargetDatasourceUID", func(t *testing.T) {
+		sqlStore := db.InitTestDB(t)
+		folderService := setupFolderService(t, sqlStore, cfg, featuremgmt.WithFeatures())
+		store := createTestStore(sqlStore, folderService, &logtest.Fake{}, cfg.UnifiedAlerting, b)
+
+		excludedUID := "excluded-target-ds-uid"
+		setTargetUID := func(uid string) models.AlertRuleMutator {
+			return func(rule *models.AlertRule) {
+				if rule.Record == nil {
+					rule.Record = &models.Record{}
+				}
+				rule.Record.TargetDatasourceUID = uid
+			}
+		}
+		excludedGen := ruleGen.With(ruleGen.WithAllRecordingRules(), setTargetUID(excludedUID))
+		otherGen := ruleGen.With(ruleGen.WithAllRecordingRules(), setTargetUID("other-target-ds-uid"))
+
+		createRule(t, store, excludedGen)
+		other1 := createRule(t, store, otherGen)
+		other2 := createRule(t, store, otherGen)
+
+		query := &models.ListAlertRulesExtendedQuery{
+			ListAlertRulesQuery: models.ListAlertRulesQuery{
+				OrgID:                            orgID,
+				ExcludeRecordTargetDatasourceUID: excludedUID,
+			},
+			RuleType: models.RuleTypeFilterRecording,
+		}
+		result, _, err := store.ListAlertRulesPaginated(context.Background(), query)
+		require.NoError(t, err)
+		require.Len(t, result, 2)
+		gotUIDs := make([]string, 0, len(result))
+		for _, r := range result {
+			gotUIDs = append(gotUIDs, r.UID)
+		}
+		require.ElementsMatch(t, []string{other1.UID, other2.UID}, gotUIDs)
+	})
 }
 
 func TestIntegration_ListDeletedRules(t *testing.T) {

--- a/pkg/services/ngalert/tests/fakes/rules.go
+++ b/pkg/services/ngalert/tests/fakes/rules.go
@@ -330,20 +330,33 @@ func (f *RuleStore) ListAlertRules(_ context.Context, q *models.ListAlertRulesQu
 func (f *RuleStore) listAlertRules(q *models.ListAlertRulesQuery) (models.RulesGroup, error) {
 	ruleList := models.RulesGroup{}
 	for _, r := range f.Rules[q.OrgID] {
-		if q.DashboardUID != "" {
-			if r.DashboardUID == nil || *r.DashboardUID != q.DashboardUID {
-				continue
-			}
+		ruleDashUID := ""
+		if r.DashboardUID != nil {
+			ruleDashUID = *r.DashboardUID
 		}
-		if q.PanelID != 0 {
-			if r.PanelID == nil || *r.PanelID != q.PanelID {
-				continue
-			}
+		if q.DashboardUID != "" && ruleDashUID != q.DashboardUID {
+			continue
+		}
+		if q.ExcludeDashboardUID != "" && ruleDashUID == q.ExcludeDashboardUID {
+			continue
+		}
+		var rulePanelID int64
+		if r.PanelID != nil {
+			rulePanelID = *r.PanelID
+		}
+		if q.PanelID != 0 && rulePanelID != q.PanelID {
+			continue
+		}
+		if q.ExcludePanelID != 0 && rulePanelID == q.ExcludePanelID {
+			continue
 		}
 		if q.IsPaused != nil && r.IsPaused != *q.IsPaused {
 			continue
 		}
 		if q.TitleExact != "" && r.Title != q.TitleExact {
+			continue
+		}
+		if q.ExcludeTitle != "" && r.Title == q.ExcludeTitle {
 			continue
 		}
 		if len(q.NamespaceUIDs) > 0 && !slices.Contains(q.NamespaceUIDs, r.NamespaceUID) {
@@ -361,7 +374,57 @@ func (f *RuleStore) listAlertRules(q *models.ListAlertRulesQuery) (models.RulesG
 			}
 		}
 
-		if cpr := r.ContactPointRouting(); q.ReceiverName != "" && (cpr == nil || cpr.Receiver != q.ReceiverName) {
+		ruleReceiver := ""
+		if cpr := r.ContactPointRouting(); cpr != nil {
+			ruleReceiver = cpr.Receiver
+		}
+		if q.ReceiverName != "" && ruleReceiver != q.ReceiverName {
+			continue
+		}
+		if q.ExcludeReceiverName != "" && ruleReceiver == q.ExcludeReceiverName {
+			continue
+		}
+
+		var ruleNotifType models.NotificationSettingsType
+		switch {
+		case r.ContactPointRouting() != nil:
+			ruleNotifType = models.NotificationSettingsTypeSimplifiedRouting
+		case r.PolicyRouting() != nil:
+			ruleNotifType = models.NotificationSettingsTypeNamedRoutingTree
+		}
+		if q.NotificationSettingsType != "" && ruleNotifType != q.NotificationSettingsType {
+			continue
+		}
+		if q.ExcludeNotificationSettingsType != "" && ruleNotifType == q.ExcludeNotificationSettingsType {
+			continue
+		}
+
+		rulePolicy := ""
+		if pr := r.PolicyRouting(); pr != nil {
+			rulePolicy = pr.Policy
+		}
+		if q.RoutingPolicyExact != "" && rulePolicy != q.RoutingPolicyExact {
+			continue
+		}
+		if q.ExcludeRoutingPolicy != "" && rulePolicy == q.ExcludeRoutingPolicy {
+			continue
+		}
+
+		ruleMetric, ruleTargetUID := "", ""
+		if r.Record != nil {
+			ruleMetric = r.Record.Metric
+			ruleTargetUID = r.Record.TargetDatasourceUID
+		}
+		if q.RecordMetricExact != "" && ruleMetric != q.RecordMetricExact {
+			continue
+		}
+		if q.ExcludeRecordMetric != "" && ruleMetric == q.ExcludeRecordMetric {
+			continue
+		}
+		if q.RecordTargetDatasourceUIDExact != "" && ruleTargetUID != q.RecordTargetDatasourceUIDExact {
+			continue
+		}
+		if q.ExcludeRecordTargetDatasourceUID != "" && ruleTargetUID == q.ExcludeRecordTargetDatasourceUID {
 			continue
 		}
 

--- a/pkg/tests/apis/alerting/rules/alertrule/alertrule_test.go
+++ b/pkg/tests/apis/alerting/rules/alertrule/alertrule_test.go
@@ -1073,6 +1073,7 @@ func TestIntegrationListWithFieldSelectors(t *testing.T) {
 		r1 := baseRule("fs-folder")
 		r1.Spec.Title = "field-sel-title-unique-abc"
 		r2 := baseRule("fs-folder")
+		r2.Spec.Title = "field-sel-title-unique-other"
 
 		created1, err := client.Create(ctx, r1, v1.CreateOptions{})
 		require.NoError(t, err)
@@ -1083,10 +1084,26 @@ func TestIntegrationListWithFieldSelectors(t *testing.T) {
 			_ = client.Delete(ctx, created2.Name, v1.DeleteOptions{})
 		})
 
-		list, err := client.List(ctx, v1.ListOptions{FieldSelector: "spec.title=field-sel-title-unique-abc"})
-		require.NoError(t, err)
-		require.Len(t, list.Items, 1)
-		require.Equal(t, "field-sel-title-unique-abc", list.Items[0].Spec.Title)
+		t.Run("equals returns only matching rules", func(t *testing.T) {
+			list, err := client.List(ctx, v1.ListOptions{FieldSelector: "spec.title=field-sel-title-unique-abc"})
+			require.NoError(t, err)
+			require.Len(t, list.Items, 1)
+			require.Equal(t, "field-sel-title-unique-abc", list.Items[0].Spec.Title)
+		})
+
+		t.Run("not-equals returns only rules whose title differs", func(t *testing.T) {
+			list, err := client.List(ctx, v1.ListOptions{
+				LabelSelector: "grafana.app/folder=fs-folder",
+				FieldSelector: "spec.title!=field-sel-title-unique-abc",
+			})
+			require.NoError(t, err)
+			titles := make([]string, 0, len(list.Items))
+			for _, item := range list.Items {
+				titles = append(titles, item.Spec.Title)
+			}
+			require.Contains(t, titles, "field-sel-title-unique-other")
+			require.NotContains(t, titles, "field-sel-title-unique-abc")
+		})
 	})
 
 	t.Run("filter by spec.paused", func(t *testing.T) {
@@ -1159,13 +1176,28 @@ func TestIntegrationListWithFieldSelectors(t *testing.T) {
 			_ = client.Delete(ctx, c3.Name, v1.DeleteOptions{})
 		})
 
-		list, err := client.List(ctx, v1.ListOptions{FieldSelector: "spec.panelRef.dashboardUID=" + dashUID})
-		require.NoError(t, err)
-		require.Len(t, list.Items, 2)
-		for _, item := range list.Items {
-			require.NotNil(t, item.Spec.PanelRef)
-			require.Equal(t, dashUID, item.Spec.PanelRef.DashboardUID)
-		}
+		t.Run("equals returns only matching rules", func(t *testing.T) {
+			list, err := client.List(ctx, v1.ListOptions{FieldSelector: "spec.panelRef.dashboardUID=" + dashUID})
+			require.NoError(t, err)
+			require.Len(t, list.Items, 2)
+			for _, item := range list.Items {
+				require.NotNil(t, item.Spec.PanelRef)
+				require.Equal(t, dashUID, item.Spec.PanelRef.DashboardUID)
+			}
+		})
+
+		t.Run("not-equals excludes matching rules", func(t *testing.T) {
+			list, err := client.List(ctx, v1.ListOptions{
+				LabelSelector: "grafana.app/folder=fs-folder",
+				FieldSelector: "spec.panelRef.dashboardUID!=" + dashUID,
+			})
+			require.NoError(t, err)
+			for _, item := range list.Items {
+				if item.Spec.PanelRef != nil {
+					require.NotEqual(t, dashUID, item.Spec.PanelRef.DashboardUID)
+				}
+			}
+		})
 	})
 
 	t.Run("filter by spec.panelRef.panelID", func(t *testing.T) {
@@ -1189,12 +1221,325 @@ func TestIntegrationListWithFieldSelectors(t *testing.T) {
 			_ = client.Delete(ctx, c3.Name, v1.DeleteOptions{})
 		})
 
-		list, err := client.List(ctx, v1.ListOptions{FieldSelector: "spec.panelRef.panelID=7"})
-		require.NoError(t, err)
-		require.Len(t, list.Items, 2)
-		for _, item := range list.Items {
-			require.NotNil(t, item.Spec.PanelRef)
-			require.Equal(t, int64(7), item.Spec.PanelRef.PanelID)
+		t.Run("equals returns only matching rules", func(t *testing.T) {
+			list, err := client.List(ctx, v1.ListOptions{FieldSelector: "spec.panelRef.panelID=7"})
+			require.NoError(t, err)
+			require.Len(t, list.Items, 2)
+			for _, item := range list.Items {
+				require.NotNil(t, item.Spec.PanelRef)
+				require.Equal(t, int64(7), item.Spec.PanelRef.PanelID)
+			}
+		})
+
+		t.Run("not-equals excludes matching rules", func(t *testing.T) {
+			list, err := client.List(ctx, v1.ListOptions{
+				LabelSelector: "grafana.app/folder=fs-folder",
+				FieldSelector: "spec.panelRef.panelID!=7",
+			})
+			require.NoError(t, err)
+			for _, item := range list.Items {
+				if item.Spec.PanelRef != nil {
+					require.NotEqual(t, int64(7), item.Spec.PanelRef.PanelID)
+				}
+			}
+		})
+	})
+
+	t.Run("filter by spec.notificationSettings.receiver", func(t *testing.T) {
+		// Use the default "empty" receiver, since creating ad-hoc receivers is heavy and rule
+		// create-time validates that the receiver exists.
+		const matchReceiver = "empty"
+		r1 := baseRule("fs-folder")
+		r1.Spec.NotificationSettings = &v0alpha1.AlertRuleNotificationSettings{
+			SimplifiedRouting: &v0alpha1.AlertRuleSimplifiedRouting{
+				Type:     v0alpha1.AlertRuleNotificationSettingsTypeSimplifiedRouting,
+				Receiver: matchReceiver,
+			},
 		}
+		r2 := baseRule("fs-folder")
+		r2.Spec.NotificationSettings = &v0alpha1.AlertRuleNotificationSettings{
+			SimplifiedRouting: &v0alpha1.AlertRuleSimplifiedRouting{
+				Type:     v0alpha1.AlertRuleNotificationSettingsTypeSimplifiedRouting,
+				Receiver: matchReceiver,
+			},
+		}
+		r3 := baseRule("fs-folder") // no notification settings
+
+		c1, err := client.Create(ctx, r1, v1.CreateOptions{})
+		require.NoError(t, err)
+		c2, err := client.Create(ctx, r2, v1.CreateOptions{})
+		require.NoError(t, err)
+		c3, err := client.Create(ctx, r3, v1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_ = client.Delete(ctx, c1.Name, v1.DeleteOptions{})
+			_ = client.Delete(ctx, c2.Name, v1.DeleteOptions{})
+			_ = client.Delete(ctx, c3.Name, v1.DeleteOptions{})
+		})
+
+		t.Run("equals returns only rules with the matching receiver", func(t *testing.T) {
+			list, err := client.List(ctx, v1.ListOptions{
+				LabelSelector: "grafana.app/folder=fs-folder",
+				FieldSelector: "spec.notificationSettings.receiver=" + matchReceiver,
+			})
+			require.NoError(t, err)
+			require.Len(t, list.Items, 2)
+			for _, item := range list.Items {
+				require.NotNil(t, item.Spec.NotificationSettings)
+				require.NotNil(t, item.Spec.NotificationSettings.SimplifiedRouting)
+				require.Equal(t, matchReceiver, item.Spec.NotificationSettings.SimplifiedRouting.Receiver)
+			}
+		})
+
+		t.Run("not-equals excludes rules with the matching receiver", func(t *testing.T) {
+			list, err := client.List(ctx, v1.ListOptions{
+				LabelSelector: "grafana.app/folder=fs-folder",
+				FieldSelector: "spec.notificationSettings.receiver!=" + matchReceiver,
+			})
+			require.NoError(t, err)
+			for _, item := range list.Items {
+				if item.Spec.NotificationSettings != nil && item.Spec.NotificationSettings.SimplifiedRouting != nil {
+					require.NotEqual(t, matchReceiver, item.Spec.NotificationSettings.SimplifiedRouting.Receiver)
+				}
+			}
+		})
+	})
+
+	t.Run("filter by spec.notificationSettings.type=SimplifiedRouting", func(t *testing.T) {
+		r1 := baseRule("fs-folder")
+		r1.Spec.NotificationSettings = &v0alpha1.AlertRuleNotificationSettings{
+			SimplifiedRouting: &v0alpha1.AlertRuleSimplifiedRouting{
+				Type:     v0alpha1.AlertRuleNotificationSettingsTypeSimplifiedRouting,
+				Receiver: "empty",
+			},
+		}
+		r2 := baseRule("fs-folder")
+		r2.Spec.NotificationSettings = &v0alpha1.AlertRuleNotificationSettings{
+			SimplifiedRouting: &v0alpha1.AlertRuleSimplifiedRouting{
+				Type:     v0alpha1.AlertRuleNotificationSettingsTypeSimplifiedRouting,
+				Receiver: "empty",
+			},
+		}
+		r3 := baseRule("fs-folder") // no notification settings
+
+		c1, err := client.Create(ctx, r1, v1.CreateOptions{})
+		require.NoError(t, err)
+		c2, err := client.Create(ctx, r2, v1.CreateOptions{})
+		require.NoError(t, err)
+		c3, err := client.Create(ctx, r3, v1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_ = client.Delete(ctx, c1.Name, v1.DeleteOptions{})
+			_ = client.Delete(ctx, c2.Name, v1.DeleteOptions{})
+			_ = client.Delete(ctx, c3.Name, v1.DeleteOptions{})
+		})
+
+		t.Run("equals returns only rules with simplified routing", func(t *testing.T) {
+			list, err := client.List(ctx, v1.ListOptions{
+				LabelSelector: "grafana.app/folder=fs-folder",
+				FieldSelector: "spec.notificationSettings.type=SimplifiedRouting",
+			})
+			require.NoError(t, err)
+			require.Len(t, list.Items, 2)
+			for _, item := range list.Items {
+				require.NotNil(t, item.Spec.NotificationSettings)
+				require.NotNil(t, item.Spec.NotificationSettings.SimplifiedRouting)
+			}
+		})
+
+		t.Run("not-equals excludes rules with simplified routing", func(t *testing.T) {
+			list, err := client.List(ctx, v1.ListOptions{
+				LabelSelector: "grafana.app/folder=fs-folder",
+				FieldSelector: "spec.notificationSettings.type!=SimplifiedRouting",
+			})
+			require.NoError(t, err)
+			for _, item := range list.Items {
+				require.True(t, item.Spec.NotificationSettings == nil || item.Spec.NotificationSettings.SimplifiedRouting == nil)
+			}
+		})
+	})
+
+	t.Run("invalid value for spec.notificationSettings.type returns 400", func(t *testing.T) {
+		_, err := client.List(ctx, v1.ListOptions{FieldSelector: "spec.notificationSettings.type=Invalid"})
+		require.Error(t, err)
+	})
+}
+
+func TestIntegrationListWithNamedRoutingTreeFieldSelectors(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	ctx := context.Background()
+	helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
+		EnableFeatureToggles: []string{
+			featuremgmt.FlagAlertingMultiplePolicies,
+		},
+	})
+	client := common.NewAlertRuleClient(t, helper.Org1.Admin)
+
+	common.CreateTestFolder(t, helper, "rt-fs-folder")
+
+	routingTreeClient, err := v1beta1.NewRoutingTreeClientFromGenerator(helper.Org1.Admin.GetClientRegistry())
+	require.NoError(t, err)
+	matchTree := &v1beta1.RoutingTree{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "rt-tree-match",
+			Namespace: "default",
+		},
+		Spec: v1beta1.RoutingTreeSpec{
+			Defaults: v1beta1.RoutingTreeRouteDefaults{Receiver: "empty"},
+		},
+	}
+	otherTree := &v1beta1.RoutingTree{
+		ObjectMeta: v1.ObjectMeta{
+			Name:      "rt-tree-other",
+			Namespace: "default",
+		},
+		Spec: v1beta1.RoutingTreeSpec{
+			Defaults: v1beta1.RoutingTreeRouteDefaults{Receiver: "empty"},
+		},
+	}
+	_, err = routingTreeClient.Create(ctx, matchTree, resource.CreateOptions{})
+	require.NoError(t, err)
+	_, err = routingTreeClient.Create(ctx, otherTree, resource.CreateOptions{})
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		_ = routingTreeClient.Delete(ctx, matchTree.GetStaticMetadata().Identifier(), resource.DeleteOptions{})
+		_ = routingTreeClient.Delete(ctx, otherTree.GetStaticMetadata().Identifier(), resource.DeleteOptions{})
+	})
+
+	baseRule := func(folder string) *v0alpha1.AlertRule {
+		rule := ngmodels.RuleGen.With(
+			ngmodels.RuleMuts.WithUniqueUID(),
+			ngmodels.RuleMuts.WithUniqueTitle(),
+			ngmodels.RuleMuts.WithNamespaceUID(folder),
+			ngmodels.RuleMuts.WithIntervalMatching(time.Duration(10)*time.Second),
+		).Generate()
+		return &v0alpha1.AlertRule{
+			ObjectMeta: v1.ObjectMeta{
+				Namespace: "default",
+				Annotations: map[string]string{
+					"grafana.app/folder": folder,
+				},
+			},
+			Spec: v0alpha1.AlertRuleSpec{
+				Title: rule.Title,
+				Expressions: v0alpha1.AlertRuleExpressionMap{
+					"A": {
+						QueryType:     util.Pointer("query"),
+						DatasourceUID: util.Pointer(v0alpha1.AlertRuleDatasourceUID(rule.Data[0].DatasourceUID)),
+						Model:         rule.Data[0].Model,
+						Source:        util.Pointer(true),
+						RelativeTimeRange: &v0alpha1.AlertRuleRelativeTimeRange{
+							From: v0alpha1.AlertRulePromDurationWMillis("5m"),
+							To:   v0alpha1.AlertRulePromDurationWMillis("0s"),
+						},
+					},
+				},
+				Trigger: v0alpha1.AlertRuleIntervalTrigger{
+					Interval: v0alpha1.AlertRulePromDuration(fmt.Sprintf("%ds", rule.IntervalSeconds)),
+				},
+				NoDataState:  v0alpha1.AlertRuleNoDataState(rule.NoDataState),
+				ExecErrState: v0alpha1.AlertRuleExecErrState(rule.ExecErrState),
+			},
+		}
+	}
+
+	t.Run("filter by spec.notificationSettings.routingTree", func(t *testing.T) {
+		r1 := baseRule("rt-fs-folder")
+		r1.Spec.NotificationSettings = &v0alpha1.AlertRuleNotificationSettings{
+			NamedRoutingTree: &v0alpha1.AlertRuleNamedRoutingTree{
+				Type:        v0alpha1.AlertRuleNotificationSettingsTypeNamedRoutingTree,
+				RoutingTree: matchTree.Name,
+			},
+		}
+		r2 := baseRule("rt-fs-folder")
+		r2.Spec.NotificationSettings = &v0alpha1.AlertRuleNotificationSettings{
+			NamedRoutingTree: &v0alpha1.AlertRuleNamedRoutingTree{
+				Type:        v0alpha1.AlertRuleNotificationSettingsTypeNamedRoutingTree,
+				RoutingTree: matchTree.Name,
+			},
+		}
+		r3 := baseRule("rt-fs-folder")
+		r3.Spec.NotificationSettings = &v0alpha1.AlertRuleNotificationSettings{
+			NamedRoutingTree: &v0alpha1.AlertRuleNamedRoutingTree{
+				Type:        v0alpha1.AlertRuleNotificationSettingsTypeNamedRoutingTree,
+				RoutingTree: otherTree.Name,
+			},
+		}
+
+		c1, err := client.Create(ctx, r1, v1.CreateOptions{})
+		require.NoError(t, err)
+		c2, err := client.Create(ctx, r2, v1.CreateOptions{})
+		require.NoError(t, err)
+		c3, err := client.Create(ctx, r3, v1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_ = client.Delete(ctx, c1.Name, v1.DeleteOptions{})
+			_ = client.Delete(ctx, c2.Name, v1.DeleteOptions{})
+			_ = client.Delete(ctx, c3.Name, v1.DeleteOptions{})
+		})
+
+		t.Run("equals returns only matching rules", func(t *testing.T) {
+			list, err := client.List(ctx, v1.ListOptions{FieldSelector: "spec.notificationSettings.routingTree=" + matchTree.Name})
+			require.NoError(t, err)
+			require.Len(t, list.Items, 2)
+			for _, item := range list.Items {
+				require.NotNil(t, item.Spec.NotificationSettings)
+				require.NotNil(t, item.Spec.NotificationSettings.NamedRoutingTree)
+				require.Equal(t, matchTree.Name, item.Spec.NotificationSettings.NamedRoutingTree.RoutingTree)
+			}
+		})
+
+		t.Run("not-equals returns rules whose routing tree differs (or have none)", func(t *testing.T) {
+			list, err := client.List(ctx, v1.ListOptions{
+				LabelSelector: "grafana.app/folder=rt-fs-folder",
+				FieldSelector: "spec.notificationSettings.routingTree!=" + matchTree.Name,
+			})
+			require.NoError(t, err)
+			for _, item := range list.Items {
+				if item.Spec.NotificationSettings != nil && item.Spec.NotificationSettings.NamedRoutingTree != nil {
+					require.NotEqual(t, matchTree.Name, item.Spec.NotificationSettings.NamedRoutingTree.RoutingTree)
+				}
+			}
+		})
+	})
+
+	t.Run("filter by spec.notificationSettings.type=NamedRoutingTree", func(t *testing.T) {
+		r1 := baseRule("rt-fs-folder")
+		r1.Spec.NotificationSettings = &v0alpha1.AlertRuleNotificationSettings{
+			NamedRoutingTree: &v0alpha1.AlertRuleNamedRoutingTree{
+				Type:        v0alpha1.AlertRuleNotificationSettingsTypeNamedRoutingTree,
+				RoutingTree: matchTree.Name,
+			},
+		}
+		r2 := baseRule("rt-fs-folder")
+		r2.Spec.NotificationSettings = &v0alpha1.AlertRuleNotificationSettings{
+			SimplifiedRouting: &v0alpha1.AlertRuleSimplifiedRouting{
+				Type:     v0alpha1.AlertRuleNotificationSettingsTypeSimplifiedRouting,
+				Receiver: "empty",
+			},
+		}
+		r3 := baseRule("rt-fs-folder") // no settings
+
+		c1, err := client.Create(ctx, r1, v1.CreateOptions{})
+		require.NoError(t, err)
+		c2, err := client.Create(ctx, r2, v1.CreateOptions{})
+		require.NoError(t, err)
+		c3, err := client.Create(ctx, r3, v1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_ = client.Delete(ctx, c1.Name, v1.DeleteOptions{})
+			_ = client.Delete(ctx, c2.Name, v1.DeleteOptions{})
+			_ = client.Delete(ctx, c3.Name, v1.DeleteOptions{})
+		})
+
+		list, err := client.List(ctx, v1.ListOptions{
+			LabelSelector: "grafana.app/folder=rt-fs-folder",
+			FieldSelector: "spec.notificationSettings.type=NamedRoutingTree",
+		})
+		require.NoError(t, err)
+		require.Len(t, list.Items, 1)
+		require.NotNil(t, list.Items[0].Spec.NotificationSettings)
+		require.NotNil(t, list.Items[0].Spec.NotificationSettings.NamedRoutingTree)
 	})
 }

--- a/pkg/tests/apis/alerting/rules/recordingrule/recordingrule_test.go
+++ b/pkg/tests/apis/alerting/rules/recordingrule/recordingrule_test.go
@@ -830,6 +830,7 @@ func TestIntegrationListWithFieldSelectors(t *testing.T) {
 		r1 := baseRule("rr-fs-folder")
 		r1.Spec.Title = "rr-field-sel-title-unique-xyz"
 		r2 := baseRule("rr-fs-folder")
+		r2.Spec.Title = "rr-field-sel-title-unique-other"
 
 		c1, err := client.Create(ctx, r1, v1.CreateOptions{})
 		require.NoError(t, err)
@@ -840,10 +841,26 @@ func TestIntegrationListWithFieldSelectors(t *testing.T) {
 			_ = client.Delete(ctx, c2.Name, v1.DeleteOptions{})
 		})
 
-		list, err := client.List(ctx, v1.ListOptions{FieldSelector: "spec.title=rr-field-sel-title-unique-xyz"})
-		require.NoError(t, err)
-		require.Len(t, list.Items, 1)
-		require.Equal(t, "rr-field-sel-title-unique-xyz", list.Items[0].Spec.Title)
+		t.Run("equals returns only matching rules", func(t *testing.T) {
+			list, err := client.List(ctx, v1.ListOptions{FieldSelector: "spec.title=rr-field-sel-title-unique-xyz"})
+			require.NoError(t, err)
+			require.Len(t, list.Items, 1)
+			require.Equal(t, "rr-field-sel-title-unique-xyz", list.Items[0].Spec.Title)
+		})
+
+		t.Run("not-equals returns only rules whose title differs", func(t *testing.T) {
+			list, err := client.List(ctx, v1.ListOptions{
+				LabelSelector: "grafana.app/folder=rr-fs-folder",
+				FieldSelector: "spec.title!=rr-field-sel-title-unique-xyz",
+			})
+			require.NoError(t, err)
+			titles := make([]string, 0, len(list.Items))
+			for _, item := range list.Items {
+				titles = append(titles, item.Spec.Title)
+			}
+			require.Contains(t, titles, "rr-field-sel-title-unique-other")
+			require.NotContains(t, titles, "rr-field-sel-title-unique-xyz")
+		})
 	})
 
 	t.Run("filter by spec.paused", func(t *testing.T) {
@@ -891,6 +908,89 @@ func TestIntegrationListWithFieldSelectors(t *testing.T) {
 			require.Len(t, list.Items, 2)
 			for _, item := range list.Items {
 				require.True(t, item.Spec.Paused == nil || !*item.Spec.Paused)
+			}
+		})
+	})
+
+	t.Run("filter by spec.metric", func(t *testing.T) {
+		matchMetric := "rr_match_metric_unique"
+		r1 := baseRule("rr-fs-folder")
+		r1.Spec.Metric = v0alpha1.RecordingRuleMetricName(matchMetric)
+		r2 := baseRule("rr-fs-folder")
+		r2.Spec.Metric = v0alpha1.RecordingRuleMetricName(matchMetric)
+		r3 := baseRule("rr-fs-folder") // a different unique metric from baseRule
+
+		c1, err := client.Create(ctx, r1, v1.CreateOptions{})
+		require.NoError(t, err)
+		c2, err := client.Create(ctx, r2, v1.CreateOptions{})
+		require.NoError(t, err)
+		c3, err := client.Create(ctx, r3, v1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_ = client.Delete(ctx, c1.Name, v1.DeleteOptions{})
+			_ = client.Delete(ctx, c2.Name, v1.DeleteOptions{})
+			_ = client.Delete(ctx, c3.Name, v1.DeleteOptions{})
+		})
+
+		t.Run("equals returns only matching rules", func(t *testing.T) {
+			list, err := client.List(ctx, v1.ListOptions{FieldSelector: "spec.metric=" + matchMetric})
+			require.NoError(t, err)
+			require.Len(t, list.Items, 2)
+			for _, item := range list.Items {
+				require.Equal(t, matchMetric, string(item.Spec.Metric))
+			}
+		})
+
+		t.Run("not-equals excludes matching rules", func(t *testing.T) {
+			list, err := client.List(ctx, v1.ListOptions{
+				LabelSelector: "grafana.app/folder=rr-fs-folder",
+				FieldSelector: "spec.metric!=" + matchMetric,
+			})
+			require.NoError(t, err)
+			for _, item := range list.Items {
+				require.NotEqual(t, matchMetric, string(item.Spec.Metric))
+			}
+		})
+	})
+
+	t.Run("filter by spec.targetDatasourceUID", func(t *testing.T) {
+		matchUID := "rr-target-ds-unique-uid"
+		r1 := baseRule("rr-fs-folder")
+		r1.Spec.TargetDatasourceUID = v0alpha1.RecordingRuleDatasourceUID(matchUID)
+		r2 := baseRule("rr-fs-folder")
+		r2.Spec.TargetDatasourceUID = v0alpha1.RecordingRuleDatasourceUID(matchUID)
+		r3 := baseRule("rr-fs-folder")
+		r3.Spec.TargetDatasourceUID = v0alpha1.RecordingRuleDatasourceUID("rr-target-ds-other-uid")
+
+		c1, err := client.Create(ctx, r1, v1.CreateOptions{})
+		require.NoError(t, err)
+		c2, err := client.Create(ctx, r2, v1.CreateOptions{})
+		require.NoError(t, err)
+		c3, err := client.Create(ctx, r3, v1.CreateOptions{})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			_ = client.Delete(ctx, c1.Name, v1.DeleteOptions{})
+			_ = client.Delete(ctx, c2.Name, v1.DeleteOptions{})
+			_ = client.Delete(ctx, c3.Name, v1.DeleteOptions{})
+		})
+
+		t.Run("equals returns only matching rules", func(t *testing.T) {
+			list, err := client.List(ctx, v1.ListOptions{FieldSelector: "spec.targetDatasourceUID=" + matchUID})
+			require.NoError(t, err)
+			require.Len(t, list.Items, 2)
+			for _, item := range list.Items {
+				require.Equal(t, matchUID, string(item.Spec.TargetDatasourceUID))
+			}
+		})
+
+		t.Run("not-equals excludes matching rules", func(t *testing.T) {
+			list, err := client.List(ctx, v1.ListOptions{
+				LabelSelector: "grafana.app/folder=rr-fs-folder",
+				FieldSelector: "spec.targetDatasourceUID!=" + matchUID,
+			})
+			require.NoError(t, err)
+			for _, item := range list.Items {
+				require.NotEqual(t, matchUID, string(item.Spec.TargetDatasourceUID))
 			}
 		})
 	})


### PR DESCRIPTION
**What is this feature?**

Wires the additional `AlertRule` and `RecordingRule` field selectors added in the previous commit to the legacy storage list path so they can be used for server-side filtering. Specifically:

- `AlertRule`: `spec.notificationSettings.type`, `spec.notificationSettings.receiver`, `spec.notificationSettings.routingTree`
- `RecordingRule`: `spec.metric`, `spec.targetDatasourceUID`

Selector parsing now handles all three operators k8s field selectors support (`=`, `==`, `!=`) consistently across the new selectors and the existing ones from #122748 (`spec.title`, `spec.paused`, `spec.panelRef.dashboardUID`, `spec.panelRef.panelID`). Each `(field, operator)` pair accepts a single value — multiple `=` or multiple `!=` requirements for the same field return a 400, since field selectors don't have IN / NOT IN semantics.

A small `ApplyFieldSelectorRequirement` helper bundles the operator handling and single-value enforcement so the AlertRule and RecordingRule legacy storages share the same parsing logic. The provisioning service forwards `Include[0]` / `Exclude[0]` through to scalar query fields, and the store emits `col = ?` or `col <> ?` predicates per filter. Nullable columns (`dashboard_uid`, `panel_id`, `alert_routing_policy`) are special-cased so a NULL value satisfies `!=`, matching the expected k8s field-selector semantics.

**Why do we need this feature?**

Without server-side wiring for these selectors, listing `AlertRule` and `RecordingRule` resources via the Kubernetes-style API can't narrow on notification routing or recording-rule output fields, which makes automation and targeted lookups slower and more expensive. This PR is a direct follow-up to #122748, which laid the groundwork by adding selector parsing for `spec.title`, `spec.paused`, `spec.panelRef.dashboardUID`, and `spec.panelRef.panelID`.

**Who is this feature for?**

Engineers, operators, and integrations that manage `AlertRule` and `RecordingRule` resources through the API and need server-side filtering when listing rules — particularly when scoping by notification routing target or recording-rule output.

**Which issue(s) does this PR fix?**:

Fixes N/A

**Special notes for your reviewer:**

- Builds on top of #122748; please consider reviewing that one first if you haven't.
- The first commit on this branch picks up the generator fixes from grafana/grafana-app-sdk#1373, which were needed before the additional selectable fields could be expressed cleanly in the kinds.
- Validation is added for unsupported operators and invalid values for the new selectors (e.g. invalid notification settings types, non-int panel IDs).
- Tests added:
  - Unit tests for the new `ApplyFieldSelectorRequirement` helper in `pkg/registry/apps/alerting/rules/common`, covering `=` / `==` / `!=` bucketing, single-value enforcement, and rejection of operators like `In` that field selectors don't support.
  - Unit tests in `pkg/services/ngalert/provisioning` for each filter, with both Include (`=`) and Exclude (`!=`) variants.
  - Integration tests in `pkg/services/ngalert/store` for each new scalar filter and matching `Exclude*` filter through the rule store.
  - Integration tests in `pkg/tests/apis/alerting/rules/{alertrule,recordingrule}` for `=` and `!=` on every field selector through the API. NamedRoutingTree-related tests are isolated in their own integration test that enables the `alertingMultiplePolicies` feature toggle.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.