### PR TITLE
Folders: use MSW in v1beta1 update hook test

### DIFF
--- a/public/app/api/clients/folder/v1beta1/hooks.test.ts
+++ b/public/app/api/clients/folder/v1beta1/hooks.test.ts
@@ -1,5 +1,5 @@
 import { http, HttpResponse } from 'msw';
-import { renderHook, getWrapper, waitFor, screen } from 'test/test-utils';
+import { act, renderHook, getWrapper, waitFor, screen } from 'test/test-utils';
 
 import { folderAPIVersionResolver } from '@grafana/api-clients/rtkq/folder/v1beta1';
 import { AppEvents } from '@grafana/data';
@@ -23,19 +23,12 @@ import {
 } from './hooks';
 import { setupCreateFolder, setupUpdateFolder } from './test-utils';
 
-import { useDeleteFolderMutation, useUpdateFolderMutation } from './index';
-
-type FolderIndexModule = {
-  useUpdateFolderMutation: typeof useUpdateFolderMutation;
-};
-
-const actualFolderIndex = jest.requireActual('./index') as FolderIndexModule;
+import { useDeleteFolderMutation } from './index';
 
 // Mocks for the hooks used inside useGetFolderQueryFacade
 jest.mock('./index', () => ({
   ...jest.requireActual('./index'),
   useDeleteFolderMutation: jest.fn(),
-  useUpdateFolderMutation: jest.fn(),
 }));
 
 const publishMockFn = jest.fn();
@@ -82,6 +75,31 @@ const renderFolderHook = async () => {
     expect(result.current.data).toBeDefined();
   });
   return result;
+};
+
+const setupUpdateFolderHandler = (onPatch?: jest.Mock) => {
+  folderAPIVersionResolver.set('v1beta1');
+  server.use(
+    http.patch('/apis/folder.grafana.app/v1beta1/namespaces/:namespace/folders/:name', async ({ params, request }) => {
+      const body = await request.json();
+      onPatch?.({ name: params.name, body });
+
+      return HttpResponse.json({
+        apiVersion: 'folder.grafana.app/v1beta1',
+        kind: 'Folder',
+        metadata: {
+          name: params.name,
+          generation: 1,
+        },
+        spec: {
+          title:
+            body && typeof body === 'object' && 'spec' in body
+              ? (body.spec?.title ?? 'Updated Folder')
+              : 'Updated Folder',
+        },
+      });
+    })
+  );
 };
 
 const originalToggles = { ...config.featureToggles };
@@ -200,30 +218,37 @@ describe('useDeleteMultipleFoldersMutationFacade', () => {
 });
 
 describe('useMoveMultipleFoldersMutationFacade', () => {
-  const mockUpdateFolder = jest.fn(() => ({ error: undefined }));
   const mockMoveFolders = jest.fn(() => ({ error: undefined }));
+  const patchSpy = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
-    (useUpdateFolderMutation as jest.Mock).mockReturnValue([mockUpdateFolder]);
     (useMoveFoldersMutationLegacy as jest.Mock).mockReturnValue([mockMoveFolders]);
+    patchSpy.mockReset();
+  });
+  afterEach(() => {
+    folderAPIVersionResolver.reset();
   });
 
   it('moves multiple folders and publishes success alert', async () => {
     config.featureToggles.foldersAppPlatformAPI = true;
+    setupUpdateFolderHandler(patchSpy);
     const folderUIDs = ['uid1', 'uid2'];
-    const [moveFolders] = useMoveMultipleFoldersMutationFacade();
-    await moveFolders({ folderUIDs, destinationUID: 'uid3' });
-
-    // Should call deleteFolder for each UID
-    expect(mockUpdateFolder).toHaveBeenCalledTimes(folderUIDs.length);
-    expect(mockUpdateFolder).toHaveBeenCalledWith({
-      name: 'uid1',
-      patch: { metadata: { annotations: { [AnnoKeyFolder]: 'uid3' } } },
+    const { result } = renderHook(() => useMoveMultipleFoldersMutationFacade(), {
+      wrapper: getWrapper({}),
     });
-    expect(mockUpdateFolder).toHaveBeenCalledWith({
+    await act(async () => {
+      await result.current[0]({ folderUIDs, destinationUID: 'uid3' });
+    });
+
+    expect(patchSpy).toHaveBeenCalledTimes(folderUIDs.length);
+    expect(patchSpy).toHaveBeenCalledWith({
+      name: 'uid1',
+      body: { metadata: { annotations: { [AnnoKeyFolder]: 'uid3' } } },
+    });
+    expect(patchSpy).toHaveBeenCalledWith({
       name: 'uid2',
-      patch: { metadata: { annotations: { [AnnoKeyFolder]: 'uid3' } } },
+      body: { metadata: { annotations: { [AnnoKeyFolder]: 'uid3' } } },
     });
 
     // Should publish a success alert
@@ -239,8 +264,12 @@ describe('useMoveMultipleFoldersMutationFacade', () => {
   it('uses legacy call when flag is false', async () => {
     config.featureToggles.foldersAppPlatformAPI = false;
     const folderUIDs = ['uid1', 'uid2'];
-    const [moveFolders] = useMoveMultipleFoldersMutationFacade();
-    await moveFolders({ folderUIDs, destinationUID: 'uid3' });
+    const { result } = renderHook(() => useMoveMultipleFoldersMutationFacade(), {
+      wrapper: getWrapper({}),
+    });
+    await act(async () => {
+      await result.current[0]({ folderUIDs, destinationUID: 'uid3' });
+    });
 
     // Should call deleteFolder for each UID
     expect(mockMoveFolders).toHaveBeenCalledTimes(1);
@@ -256,9 +285,13 @@ describe.each([
 ])('folderAppPlatformAPI toggle set to: %s', (toggle) => {
   beforeEach(() => {
     config.featureToggles.foldersAppPlatformAPI = toggle;
+    if (toggle) {
+      folderAPIVersionResolver.set('v1beta1');
+    }
   });
   afterEach(() => {
     config.featureToggles = originalToggles;
+    folderAPIVersionResolver.reset();
   });
 
   describe('useCreateFolder', () => {
@@ -284,28 +317,7 @@ describe.each([
   describe('useUpdateFolder', () => {
     beforeEach(() => {
       jest.clearAllMocks();
-      folderAPIVersionResolver.set('v1beta1');
-      (useUpdateFolderMutation as jest.Mock).mockImplementation(actualFolderIndex.useUpdateFolderMutation);
-      server.use(
-        http.patch(
-          '/apis/folder.grafana.app/v1beta1/namespaces/:namespace/folders/:name',
-          async ({ params, request }) => {
-            const body = await request.json();
-
-            return HttpResponse.json({
-              apiVersion: 'folder.grafana.app/v1beta1',
-              kind: 'Folder',
-              metadata: {
-                name: params.name,
-                generation: 1,
-              },
-              spec: {
-                title: body?.spec?.title ?? 'Updated Folder',
-              },
-            });
-          }
-        )
-      );
+      setupUpdateFolderHandler();
     });
 
     it('updates a folder', async () => {

--- a/public/app/api/clients/folder/v1beta1/hooks.test.ts
+++ b/public/app/api/clients/folder/v1beta1/hooks.test.ts
@@ -1,8 +1,10 @@
+import { http, HttpResponse } from 'msw';
 import { renderHook, getWrapper, waitFor, screen } from 'test/test-utils';
 
+import { folderAPIVersionResolver } from '@grafana/api-clients/rtkq/folder/v1beta1';
 import { AppEvents } from '@grafana/data';
 import { config, setBackendSrv } from '@grafana/runtime';
-import { setupMockServer } from '@grafana/test-utils/server';
+import server, { setupMockServer } from '@grafana/test-utils/server';
 import { getFolderFixtures } from '@grafana/test-utils/unstable';
 import { backendSrv } from 'app/core/services/backend_srv';
 import {
@@ -22,6 +24,12 @@ import {
 import { setupCreateFolder, setupUpdateFolder } from './test-utils';
 
 import { useDeleteFolderMutation, useUpdateFolderMutation } from './index';
+
+type FolderIndexModule = {
+  useUpdateFolderMutation: typeof useUpdateFolderMutation;
+};
+
+const actualFolderIndex = jest.requireActual('./index') as FolderIndexModule;
 
 // Mocks for the hooks used inside useGetFolderQueryFacade
 jest.mock('./index', () => ({
@@ -274,12 +282,30 @@ describe.each([
   });
 
   describe('useUpdateFolder', () => {
-    // TODO: Remove manual mocking and move this to MSW handlers instead
-    const mockUpdateFolder = jest.fn(() => ({ error: undefined, result: { isSuccess: true } }));
-
     beforeEach(() => {
       jest.clearAllMocks();
-      (useUpdateFolderMutation as jest.Mock).mockReturnValue([mockUpdateFolder, { isSuccess: true }]);
+      folderAPIVersionResolver.set('v1beta1');
+      (useUpdateFolderMutation as jest.Mock).mockImplementation(actualFolderIndex.useUpdateFolderMutation);
+      server.use(
+        http.patch(
+          '/apis/folder.grafana.app/v1beta1/namespaces/:namespace/folders/:name',
+          async ({ params, request }) => {
+            const body = await request.json();
+
+            return HttpResponse.json({
+              apiVersion: 'folder.grafana.app/v1beta1',
+              kind: 'Folder',
+              metadata: {
+                name: params.name,
+                generation: 1,
+              },
+              spec: {
+                title: body?.spec?.title ?? 'Updated Folder',
+              },
+            });
+          }
+        )
+      );
     });
 
     it('updates a folder', async () => {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Updates the folder/v1beta1 hook tests to use MSW for the `useUpdateFolder` app-platform path instead of manually mocking `useUpdateFolderMutation`

**Why do we need this feature?**

The previous test manually mocked the mutation hook, which bypassed the actual request path and made the test less representative of production behavior.
Moving this test to MSW improves confidence in the app-platform update flow and aligns it with the existing testing approach used elsewhere in the folder client tests.

**Who is this feature for?**

For Grafana contributors and maintainers working on folder app-platform APIs and related frontend tests

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
