### PR TITLE
Combobox: Fix caret jumping to the end of the input

### DIFF
--- a/packages/grafana-ui/src/components/Combobox/MultiCombobox.test.tsx
+++ b/packages/grafana-ui/src/components/Combobox/MultiCombobox.test.tsx
@@ -31,6 +31,28 @@ describe('MultiCombobox', () => {
     user = userEvent.setup();
   });
 
+  it('keeps the caret position when typing in the middle of the input', async () => {
+    const options = [
+      { label: 'A', value: 'a' },
+      { label: 'B', value: 'b' },
+      { label: 'C', value: 'c' },
+    ];
+
+    render(<MultiCombobox options={options} value={[]} onChange={jest.fn()} />);
+    const input = screen.getByRole<HTMLInputElement>('combobox');
+
+    await user.click(input);
+    await user.type(input, 'hello');
+
+    input.setSelectionRange(3, 3);
+
+    await user.keyboard('X');
+
+    expect(input).toHaveValue('helXlo');
+    expect(input.selectionStart).toBe(4);
+    expect(input.selectionEnd).toBe(4);
+  });
+
   it('should render with options', async () => {
     const options = [
       { label: 'A', value: 'a' },

--- a/packages/grafana-ui/src/components/Combobox/MultiCombobox.tsx
+++ b/packages/grafana-ui/src/components/Combobox/MultiCombobox.tsx
@@ -126,6 +126,12 @@ export const MultiCombobox = <T extends string | number>(props: MultiComboboxPro
     [selectedItems]
   );
 
+  const handleInputChange = useCallback((event: React.ChangeEvent<HTMLInputElement>) => {
+    // Synchronously update inputValue so it is batched with downshift's dispatch
+    // in a single React render. See onStateChange InputChange case for details.
+    setInputValue(event.target.value);
+  }, []);
+
   const { getSelectedItemProps, getDropdownProps, setSelectedItems, addSelectedItem, removeSelectedItem, reset } =
     useMultipleSelection({
       selectedItems, // initially selected items,
@@ -253,9 +259,10 @@ export const MultiCombobox = <T extends string | number>(props: MultiComboboxPro
           }
           break;
         case useCombobox.stateChangeTypes.InputChange:
-          setInputValue(newInputValue ?? '');
+          // setInputValue is intentionally NOT called here. It is called synchronously in the
+          // input's onChange handler instead, so that it is batched with downshift's dispatch
+          // in a single React render.
           updateOptions(newInputValue ?? '');
-
           break;
         default:
           break;
@@ -332,6 +339,7 @@ export const MultiCombobox = <T extends string | number>(props: MultiComboboxPro
               'aria-describedby': ariaDescribedBy, // Description should be handled with the Field component
               'aria-labelledby': ariaLabelledBy, // Label should be handled with the Field component
               'data-testid': dataTestId,
+              onChange: handleInputChange,
               onKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => {
                 // Stop Escape from propagating to parent overlays (e.g. Modals, Drawers)
                 // so that only the dropdown menu closes, not the parent.


### PR DESCRIPTION
Fixes an issue in the MultiCombobox where if you move the caret to the middle of a word and type, the caret jumps to the end of the word. Very annoying!!!

This was due to updating the input state in the `onStateChange` reducer, which downshifts call on the render _after_ the internal input update. 

The fix was to instead update the input state properly in the `onChange` handler, like a normal input field :)

Thanks to @ZammadNasir from https://github.com/grafana/grafana/pull/122234 for the unit test - it was useful TDD to ensure this is fixed!

Fixes https://github.com/grafana/grafana/issues/122205