### PR TITLE
Search: split build vs cleanup lock options, make timeouts configurable

### DIFF
--- a/pkg/storage/unified/search/bleve_snapshot_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_test.go
@@ -654,7 +654,14 @@ func TestIntegrationBleveSnapshotRoundTrip(t *testing.T) {
 	bucket := memblob.OpenBucket(nil)
 	t.Cleanup(func() { _ = bucket.Close() })
 
-	store := NewBucketRemoteIndexStore(bucket, newFakeBackend(newConditionalBucket()), "test-owner", 5*time.Second, 500*time.Millisecond)
+	lockOpts := LockOptions{TTL: 5 * time.Second, HeartbeatInterval: 500 * time.Millisecond}
+	store := NewBucketRemoteIndexStore(BucketRemoteIndexStoreConfig{
+		Bucket:      bucket,
+		LockBackend: newFakeBackend(newConditionalBucket()),
+		LockOwner:   "test-owner",
+		BuildLock:   lockOpts,
+		CleanupLock: lockOpts,
+	})
 	key := newTestNsResource()
 	meta := IndexMeta{
 		GrafanaBuildVersion:   "11.5.0",

--- a/pkg/storage/unified/search/lock_objstore.go
+++ b/pkg/storage/unified/search/lock_objstore.go
@@ -52,11 +52,13 @@ var errInvalidLockKey = errors.New("invalid lock key")
 // goroutine only touches immutable config and closes lostCh.
 type objectStorageLock struct {
 	// Immutable after construction.
-	backend           lockBackend
-	key               string
-	owner             string
-	ttl               time.Duration
-	heartbeatInterval time.Duration
+	backend                lockBackend
+	key                    string
+	owner                  string
+	ttl                    time.Duration
+	heartbeatInterval      time.Duration
+	heartbeatUpdateTimeout time.Duration
+	releaseDeleteTimeout   time.Duration
 
 	held     bool
 	hbCancel context.CancelFunc
@@ -73,6 +75,14 @@ type objectStorageLockConfig struct {
 	Owner             string
 	TTL               time.Duration // Default: 180s
 	HeartbeatInterval time.Duration // Default: 60s
+	// HeartbeatUpdateTimeout caps each heartbeat Update call. It also bounds how
+	// long Release blocks waiting for an in-flight Update to complete (the
+	// heartbeat uses context.Background() for the Update itself to avoid a GCS
+	// conditional-write race; see runHeartbeat). Default: 30s.
+	HeartbeatUpdateTimeout time.Duration
+	// ReleaseDeleteTimeout caps the conditional Delete call performed by
+	// Release. Default: 30s.
+	ReleaseDeleteTimeout time.Duration
 }
 
 // newObjectStorageLock creates a new distributed lock.
@@ -82,6 +92,12 @@ func newObjectStorageLock(cfg objectStorageLockConfig) (*objectStorageLock, erro
 	}
 	if cfg.HeartbeatInterval == 0 {
 		cfg.HeartbeatInterval = 60 * time.Second
+	}
+	if cfg.HeartbeatUpdateTimeout == 0 {
+		cfg.HeartbeatUpdateTimeout = 30 * time.Second
+	}
+	if cfg.ReleaseDeleteTimeout == 0 {
+		cfg.ReleaseDeleteTimeout = 30 * time.Second
 	}
 	if cfg.Backend == nil {
 		return nil, fmt.Errorf("backend must not be nil")
@@ -101,13 +117,21 @@ func newObjectStorageLock(cfg objectStorageLockConfig) (*objectStorageLock, erro
 	if cfg.TTL < 2*cfg.HeartbeatInterval {
 		return nil, fmt.Errorf("TTL (%s) must be at least 2x HeartbeatInterval (%s)", cfg.TTL, cfg.HeartbeatInterval)
 	}
+	if cfg.HeartbeatUpdateTimeout <= 0 {
+		return nil, fmt.Errorf("HeartbeatUpdateTimeout must be positive, got %s", cfg.HeartbeatUpdateTimeout)
+	}
+	if cfg.ReleaseDeleteTimeout <= 0 {
+		return nil, fmt.Errorf("ReleaseDeleteTimeout must be positive, got %s", cfg.ReleaseDeleteTimeout)
+	}
 	return &objectStorageLock{
-		backend:           cfg.Backend,
-		key:               cfg.Key,
-		owner:             cfg.Owner,
-		ttl:               cfg.TTL,
-		heartbeatInterval: cfg.HeartbeatInterval,
-		lostCh:            make(chan struct{}),
+		backend:                cfg.Backend,
+		key:                    cfg.Key,
+		owner:                  cfg.Owner,
+		ttl:                    cfg.TTL,
+		heartbeatInterval:      cfg.HeartbeatInterval,
+		heartbeatUpdateTimeout: cfg.HeartbeatUpdateTimeout,
+		releaseDeleteTimeout:   cfg.ReleaseDeleteTimeout,
+		lostCh:                 make(chan struct{}),
 	}, nil
 }
 
@@ -154,7 +178,7 @@ func (l *objectStorageLock) Release() error {
 	l.hbCancel()
 	<-l.hbDone
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), l.releaseDeleteTimeout)
 	defer cancel()
 	err := l.backend.Delete(ctx, l.key, l.owner)
 	if err == nil || errors.Is(err, errLockNotFound) || errors.Is(err, errLockHeld) {
@@ -190,11 +214,11 @@ func (l *objectStorageLock) runHeartbeat(ctx context.Context, done chan struct{}
 			// GCS, a cancelled-but-committed Update can leave the object at a new
 			// ETag server-side, which would then mismatch Release's conditional
 			// Delete and surface as errPreconditionFailed. Tradeoff: hbCancel() +
-			// <-hbDone in Release can block up to the 30s timeout below if a tick
+			// <-hbDone in Release can block up to heartbeatUpdateTimeout if a tick
 			// is in flight. See also the ctx.Err() != nil guard below, which
 			// prevents the goroutine from signalling Lost when Release is the
 			// reason we're exiting.
-			updateCtx, updateCancel := context.WithTimeout(context.Background(), 30*time.Second)
+			updateCtx, updateCancel := context.WithTimeout(context.Background(), l.heartbeatUpdateTimeout)
 			err := l.backend.Update(updateCtx, l.key, info)
 			updateCancel()
 			if err != nil {

--- a/pkg/storage/unified/search/lock_objstore_test.go
+++ b/pkg/storage/unified/search/lock_objstore_test.go
@@ -157,6 +157,16 @@ func TestNewObjectStorageLock_Validation(t *testing.T) {
 			cfg:     objectStorageLockConfig{Backend: backend, Key: validKey, Owner: "instance-1", TTL: 100 * time.Millisecond, HeartbeatInterval: 75 * time.Millisecond},
 			wantErr: "at least 2x HeartbeatInterval",
 		},
+		{
+			name:    "negative HeartbeatUpdateTimeout",
+			cfg:     objectStorageLockConfig{Backend: backend, Key: validKey, Owner: "instance-1", TTL: time.Second, HeartbeatInterval: 100 * time.Millisecond, HeartbeatUpdateTimeout: -1 * time.Millisecond},
+			wantErr: "HeartbeatUpdateTimeout must be positive",
+		},
+		{
+			name:    "negative ReleaseDeleteTimeout",
+			cfg:     objectStorageLockConfig{Backend: backend, Key: validKey, Owner: "instance-1", TTL: time.Second, HeartbeatInterval: 100 * time.Millisecond, ReleaseDeleteTimeout: -1 * time.Millisecond},
+			wantErr: "ReleaseDeleteTimeout must be positive",
+		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -303,6 +313,60 @@ func TestObjectStorageLock_ImmediateLossOnOwnershipError(t *testing.T) {
 	case <-time.After(500 * time.Millisecond):
 		t.Fatal("expected immediate lock loss on errLockHeld, but it was not detected")
 	}
+}
+
+// TestObjectStorageLock_HeartbeatUpdateTimeoutHonored asserts that the
+// configured HeartbeatUpdateTimeout caps each heartbeat Update call. Without
+// a configurable knob this defaulted to 30s, which made Release block up to
+// 30s on shutdown if a heartbeat tick was in flight.
+func TestObjectStorageLock_HeartbeatUpdateTimeoutHonored(t *testing.T) {
+	inner := newFakeBackend(newConditionalBucket())
+	backend := &ctxRespectingBlockingBackend{
+		lockBackend:    inner,
+		updateDuration: make(chan time.Duration, 1),
+	}
+
+	configuredTimeout := 100 * time.Millisecond
+	lock, err := newObjectStorageLock(objectStorageLockConfig{
+		Backend:                backend,
+		Key:                    "test-lock",
+		Owner:                  "instance-1",
+		TTL:                    1 * time.Second,
+		HeartbeatInterval:      50 * time.Millisecond,
+		HeartbeatUpdateTimeout: configuredTimeout,
+	})
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	require.NoError(t, lock.Acquire(ctx))
+	t.Cleanup(func() { _ = lock.Release() })
+
+	select {
+	case d := <-backend.updateDuration:
+		// Heartbeat Update returned within the configured timeout, not the 30s default.
+		require.GreaterOrEqual(t, d, configuredTimeout-20*time.Millisecond)
+		require.Less(t, d, configuredTimeout+200*time.Millisecond)
+	case <-time.After(2 * time.Second):
+		t.Fatal("expected heartbeat Update to return within configured timeout")
+	}
+}
+
+// ctxRespectingBlockingBackend blocks Update on ctx.Done() and reports the
+// elapsed time on updateDuration. Used to verify that callers honor the
+// timeout context they pass in.
+type ctxRespectingBlockingBackend struct {
+	lockBackend
+	updateDuration chan time.Duration
+}
+
+func (b *ctxRespectingBlockingBackend) Update(ctx context.Context, _ string, _ lockInfo) error {
+	start := time.Now()
+	<-ctx.Done()
+	select {
+	case b.updateDuration <- time.Since(start):
+	default:
+	}
+	return ctx.Err()
 }
 
 // failingUpdateBackend wraps a lockBackend and fails Update calls

--- a/pkg/storage/unified/search/options.go
+++ b/pkg/storage/unified/search/options.go
@@ -174,10 +174,19 @@ func buildSnapshotOptions(cfg *setting.Cfg, minBuildVersion *semver.Version) (Sn
 	owner := fmt.Sprintf("%s/%s", ownerBase, lockOwnerSuffix.String())
 
 	lockTTL := DefaultSnapshotLockTTL
-	lockHeartbeat := snapshotLockHeartbeat(lockTTL)
+	lockOpts := LockOptions{
+		TTL:               lockTTL,
+		HeartbeatInterval: snapshotLockHeartbeat(lockTTL),
+	}
 
 	return SnapshotOptions{
-		Store:              NewBucketRemoteIndexStore(bucket, lockBackend, owner, lockTTL, lockHeartbeat),
+		Store: NewBucketRemoteIndexStore(BucketRemoteIndexStoreConfig{
+			Bucket:      bucket,
+			LockBackend: lockBackend,
+			LockOwner:   owner,
+			BuildLock:   lockOpts,
+			CleanupLock: lockOpts,
+		}),
 		MinDocCount:        int64(cfg.IndexSnapshotThreshold),
 		MaxIndexAge:        cfg.IndexSnapshotMaxAge,
 		MinBuildVersion:    minBuildVersion,

--- a/pkg/storage/unified/search/remote_index_cleanup_test.go
+++ b/pkg/storage/unified/search/remote_index_cleanup_test.go
@@ -364,8 +364,15 @@ func TestRunCleanup_LockContentionSkipsNamespace(t *testing.T) {
 	// directly rather than via newCleanupTestBucket because we need distinct
 	// lock owners.
 	backend := newFakeBackend(newConditionalBucket())
-	storeA := NewBucketRemoteIndexStore(bucket, backend, "instance-A", 5*time.Second, 500*time.Millisecond)
-	storeB := NewBucketRemoteIndexStore(bucket, backend, "instance-B", 5*time.Second, 500*time.Millisecond)
+	lockOpts := LockOptions{TTL: 5 * time.Second, HeartbeatInterval: 500 * time.Millisecond}
+	storeA := NewBucketRemoteIndexStore(BucketRemoteIndexStoreConfig{
+		Bucket: bucket, LockBackend: backend, LockOwner: "instance-A",
+		BuildLock: lockOpts, CleanupLock: lockOpts,
+	})
+	storeB := NewBucketRemoteIndexStore(BucketRemoteIndexStoreConfig{
+		Bucket: bucket, LockBackend: backend, LockOwner: "instance-B",
+		BuildLock: lockOpts, CleanupLock: lockOpts,
+	})
 
 	nsA := resource.NamespacedResource{Namespace: "stack-1", Group: "dashboard.grafana.app", Resource: "dashboards"}
 	nsB := resource.NamespacedResource{Namespace: "stack-2", Group: "dashboard.grafana.app", Resource: "dashboards"}

--- a/pkg/storage/unified/search/remote_index_store.go
+++ b/pkg/storage/unified/search/remote_index_store.go
@@ -90,6 +90,28 @@ type RemoteIndexStore interface {
 	CleanupIncompleteUploads(ctx context.Context, nsResource resource.NamespacedResource, minAge time.Duration) (int, error)
 }
 
+// LockOptions controls the timing and shutdown behaviour of an
+// objectStorageLock created by BucketRemoteIndexStore. Zero values fall back
+// to the defaults documented in objectStorageLockConfig.
+type LockOptions struct {
+	TTL                    time.Duration
+	HeartbeatInterval      time.Duration
+	HeartbeatUpdateTimeout time.Duration
+	ReleaseDeleteTimeout   time.Duration
+}
+
+// BucketRemoteIndexStoreConfig configures NewBucketRemoteIndexStore. Build and
+// cleanup locks have separate option blocks so they can diverge: build locks
+// are per-snapshot and benefit from a tight shutdown budget, while cleanup
+// locks run on a 6h cadence and can tolerate longer waits.
+type BucketRemoteIndexStoreConfig struct {
+	Bucket      resource.CDKBucket
+	LockBackend lockBackend
+	LockOwner   string
+	BuildLock   LockOptions
+	CleanupLock LockOptions
+}
+
 // BucketRemoteIndexStore implements RemoteIndexStore using a CDKBucket.
 //
 // Object storage layout:
@@ -102,23 +124,23 @@ type RemoteIndexStore interface {
 // meta.json is uploaded last during upload and deleted first during delete,
 // serving as the completion signal.
 type BucketRemoteIndexStore struct {
-	bucket                resource.CDKBucket
-	lockBackend           lockBackend
-	lockOwner             string
-	lockTTL               time.Duration
-	lockHeartbeatInterval time.Duration
-	log                   log.Logger
+	bucket          resource.CDKBucket
+	lockBackend     lockBackend
+	lockOwner       string
+	buildLockOpts   LockOptions
+	cleanupLockOpts LockOptions
+	log             log.Logger
 }
 
 // NewBucketRemoteIndexStore creates a new RemoteIndexStore backed by the given bucket.
-func NewBucketRemoteIndexStore(bucket resource.CDKBucket, lockBackend lockBackend, lockOwner string, lockTTL, lockHeartbeatInterval time.Duration) *BucketRemoteIndexStore {
+func NewBucketRemoteIndexStore(cfg BucketRemoteIndexStoreConfig) *BucketRemoteIndexStore {
 	return &BucketRemoteIndexStore{
-		bucket:                bucket,
-		lockBackend:           lockBackend,
-		lockOwner:             lockOwner,
-		lockTTL:               lockTTL,
-		lockHeartbeatInterval: lockHeartbeatInterval,
-		log:                   log.New("bucket-remote-index-store"),
+		bucket:          cfg.Bucket,
+		lockBackend:     cfg.LockBackend,
+		lockOwner:       cfg.LockOwner,
+		buildLockOpts:   cfg.BuildLock,
+		cleanupLockOpts: cfg.CleanupLock,
+		log:             log.New("bucket-remote-index-store"),
 	}
 }
 
@@ -144,13 +166,7 @@ func cleanupLockKey(namespace string) string {
 }
 
 func (s *BucketRemoteIndexStore) LockBuildIndex(ctx context.Context, nsResource resource.NamespacedResource) (IndexStoreLock, error) {
-	l, err := newObjectStorageLock(objectStorageLockConfig{
-		Backend:           s.lockBackend,
-		Key:               buildIndexLockKey(nsResource),
-		Owner:             s.lockOwner,
-		TTL:               s.lockTTL,
-		HeartbeatInterval: s.lockHeartbeatInterval,
-	})
+	l, err := newObjectStorageLock(s.lockConfig(buildIndexLockKey(nsResource), s.buildLockOpts))
 	if err != nil {
 		return nil, fmt.Errorf("creating build lock: %w", err)
 	}
@@ -161,13 +177,7 @@ func (s *BucketRemoteIndexStore) LockBuildIndex(ctx context.Context, nsResource 
 }
 
 func (s *BucketRemoteIndexStore) LockNamespaceForCleanup(ctx context.Context, namespace string) (IndexStoreLock, error) {
-	l, err := newObjectStorageLock(objectStorageLockConfig{
-		Backend:           s.lockBackend,
-		Key:               cleanupLockKey(namespace),
-		Owner:             s.lockOwner,
-		TTL:               s.lockTTL,
-		HeartbeatInterval: s.lockHeartbeatInterval,
-	})
+	l, err := newObjectStorageLock(s.lockConfig(cleanupLockKey(namespace), s.cleanupLockOpts))
 	if err != nil {
 		return nil, fmt.Errorf("creating cleanup lock: %w", err)
 	}
@@ -175,6 +185,21 @@ func (s *BucketRemoteIndexStore) LockNamespaceForCleanup(ctx context.Context, na
 		return nil, err
 	}
 	return l, nil
+}
+
+// lockConfig folds a LockOptions block into the shared per-store backend/owner
+// fields. Zero-valued LockOptions fields are passed through to
+// newObjectStorageLock, which applies its own defaults.
+func (s *BucketRemoteIndexStore) lockConfig(key string, opts LockOptions) objectStorageLockConfig {
+	return objectStorageLockConfig{
+		Backend:                s.lockBackend,
+		Key:                    key,
+		Owner:                  s.lockOwner,
+		TTL:                    opts.TTL,
+		HeartbeatInterval:      opts.HeartbeatInterval,
+		HeartbeatUpdateTimeout: opts.HeartbeatUpdateTimeout,
+		ReleaseDeleteTimeout:   opts.ReleaseDeleteTimeout,
+	}
 }
 
 func (s *BucketRemoteIndexStore) UploadIndex(ctx context.Context, nsResource resource.NamespacedResource, localDir string, meta IndexMeta) (_ ulid.ULID, retErr error) {

--- a/pkg/storage/unified/search/remote_index_store_test.go
+++ b/pkg/storage/unified/search/remote_index_store_test.go
@@ -61,7 +61,14 @@ func newTestRemoteIndexStore(t *testing.T, bucket resource.CDKBucket) *BucketRem
 
 func newTestRemoteIndexStoreWithLockOwner(t *testing.T, bucket resource.CDKBucket, backend lockBackend, owner string) *BucketRemoteIndexStore {
 	t.Helper()
-	return NewBucketRemoteIndexStore(bucket, backend, owner, 5*time.Second, 500*time.Millisecond)
+	opts := LockOptions{TTL: 5 * time.Second, HeartbeatInterval: 500 * time.Millisecond}
+	return NewBucketRemoteIndexStore(BucketRemoteIndexStoreConfig{
+		Bucket:      bucket,
+		LockBackend: backend,
+		LockOwner:   owner,
+		BuildLock:   opts,
+		CleanupLock: opts,
+	})
 }
 
 // createTestBleveIndex creates a real bleve index with sample documents.
@@ -881,4 +888,40 @@ func TestRemoteIndexStore_LockNamespaceForCleanup_DistinctFromBuildLock(t *testi
 	require.NoError(t, buildLock.Release())
 
 	require.NotEqual(t, cleanupLockKey(ns.Namespace), buildIndexLockKey(ns))
+}
+
+// Smoke-tests the LockOptions plumbing. Only TTL is observable in lockInfo;
+// HeartbeatUpdateTimeout behaviour is covered separately on objectStorageLock.
+func TestRemoteIndexStore_BuildAndCleanupLockTTLsWiredIndependently(t *testing.T) {
+	ctx := context.Background()
+	backend := newFakeBackend(newConditionalBucket())
+	bucket := memblob.OpenBucket(nil)
+	defer func() { _ = bucket.Close() }()
+
+	buildTTL := 1 * time.Second
+	cleanupTTL := 5 * time.Second
+	store := NewBucketRemoteIndexStore(BucketRemoteIndexStoreConfig{
+		Bucket:      bucket,
+		LockBackend: backend,
+		LockOwner:   "instance-1",
+		BuildLock:   LockOptions{TTL: buildTTL, HeartbeatInterval: 200 * time.Millisecond},
+		CleanupLock: LockOptions{TTL: cleanupTTL, HeartbeatInterval: 200 * time.Millisecond},
+	})
+	ns := newTestNsResource()
+
+	buildLock, err := store.LockBuildIndex(ctx, ns)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = buildLock.Release() })
+
+	info, err := backend.Read(ctx, buildIndexLockKey(ns))
+	require.NoError(t, err)
+	require.Equal(t, buildTTL, info.TTL)
+
+	cleanupLock, err := store.LockNamespaceForCleanup(ctx, ns.Namespace)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cleanupLock.Release() })
+
+	info, err = backend.Read(ctx, cleanupLockKey(ns.Namespace))
+	require.NoError(t, err)
+	require.Equal(t, cleanupTTL, info.TTL)
 }


### PR DESCRIPTION
1. `NewBucketRemoteIndexStore` takes a config struct instead of five positional args.
2. Build and cleanup locks have separate `LockOptions` (build is per-snapshot, cleanup runs on 6h cadence).
3. Heartbeat Update and Release Delete timeouts are configurable (previously hardcoded to 30s, which made `Release()` block up to 30s on shutdown).

No behaviour change: defaults match previous timings; build and cleanup currently share the same options. Follow-up to #123951.
