### PR TITLE
Chore: Update feature-toggles.md

### DIFF
--- a/contribute/feature-toggles.md
+++ b/contribute/feature-toggles.md
@@ -7,7 +7,7 @@ Exhaustive documentation on OpenFeature can be found at [OpenFeature.dev](https:
 ## Steps to adding a feature flag
 
 1. Define the feature flag in [registry.go](../pkg/services/featuremgmt/registry.go).
-   - New flags must be named with a prefix, separated by a dot. e.g `grafana.newPreferencesPage`. The prefix is the name of the standalone service that owns this feature flag. For flags that are single-tenant Grafana-only, with no plans for a standalone deployment in the future, use `grafana.` as a prefix. 
+   - New flags must be named with a prefix, separated by a dot. e.g `grafana.newPreferencesPage`. The prefix is the name of the standalone service that owns this feature flag. For flags that are single-tenant Grafana-only, with no plans for a standalone deployment in the future, use `grafana.` as a prefix.
    - Set the `Generate` field to control which clients are generated for your flag (see [Generation targets](#generation-targets) below).
    - To see what each feature stage means, look at the [related comments](../pkg/services/featuremgmt/features.go).
    - If you are a community member, use the [CODEOWNERS](../.github/CODEOWNERS) file to determine which team owns the package you are updating.

--- a/contribute/feature-toggles.md
+++ b/contribute/feature-toggles.md
@@ -7,7 +7,7 @@ Exhaustive documentation on OpenFeature can be found at [OpenFeature.dev](https:
 ## Steps to adding a feature flag
 
 1. Define the feature flag in [registry.go](../pkg/services/featuremgmt/registry.go).
-   - New flags must by named with a component, seperated by a dot. e.g `grafana.newPreferencesPage`.
+   - New flags must be named with a prefix, separated by a dot. e.g `grafana.newPreferencesPage`. The prefix is the name of the standalone service that owns this feature flag. For flags that are single-tenant Grafana-only, with no standalone deployment, use `grafana.` as a prefix. 
    - Set the `Generate` field to control which clients are generated for your flag (see [Generation targets](#generation-targets) below).
    - To see what each feature stage means, look at the [related comments](../pkg/services/featuremgmt/features.go).
    - If you are a community member, use the [CODEOWNERS](../.github/CODEOWNERS) file to determine which team owns the package you are updating.

--- a/contribute/feature-toggles.md
+++ b/contribute/feature-toggles.md
@@ -7,7 +7,7 @@ Exhaustive documentation on OpenFeature can be found at [OpenFeature.dev](https:
 ## Steps to adding a feature flag
 
 1. Define the feature flag in [registry.go](../pkg/services/featuremgmt/registry.go).
-   - New flags must be named with a prefix, separated by a dot. e.g `grafana.newPreferencesPage`. The prefix is the name of the standalone service that owns this feature flag. For flags that are single-tenant Grafana-only, with no standalone deployment, use `grafana.` as a prefix. 
+   - New flags must be named with a prefix, separated by a dot. e.g `grafana.newPreferencesPage`. The prefix is the name of the standalone service that owns this feature flag. For flags that are single-tenant Grafana-only, with no plans for a standalone deployment in the future, use `grafana.` as a prefix. 
    - Set the `Generate` field to control which clients are generated for your flag (see [Generation targets](#generation-targets) below).
    - To see what each feature stage means, look at the [related comments](../pkg/services/featuremgmt/features.go).
    - If you are a community member, use the [CODEOWNERS](../.github/CODEOWNERS) file to determine which team owns the package you are updating.


### PR DESCRIPTION
Currently we have three patterns in use:
- No prefix: `frontendServiceSSOAutoLogin` (old style)
- Feature-area prefix: `stateTimeline.nameAboveBars`, `reporting.pdfTablesFrontend`
- Service prefix: `frontendService.settingsSourceFilter`, `grafana.assetSriChecks`

Going forward:
_Prefix = name of the standalone service that owns this flag. For flags that are single-tenant Grafana-only, with no plans for a standalone deployment in the future, use grafana._

So `stateTimeline.nameAboveBars` -> `grafana.nameAboveBars`, `frontendService.settingsSourceFilter` stays as-is, old flags stay intact as well. 