### PR TITLE
AuthN: migrate auth token and session code to ConfigProvider

### DIFF
--- a/pkg/server/wire_gen.go
+++ b/pkg/server/wire_gen.go
@@ -607,7 +607,7 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts Options, apiOpts api
 		return nil, err
 	}
 	authinfoimplService := authinfoimpl.ProvideService(loginStore, remoteCache, secretsService)
-	userAuthTokenService, err := authimpl.ProvideUserAuthTokenService(sqlStore, serverLockService, quotaService, secretsService, cfg, tracingService, featureToggles)
+	userAuthTokenService, err := authimpl.ProvideUserAuthTokenService(ctx, sqlStore, serverLockService, quotaService, secretsService, configProvider, tracingService, featureToggles)
 	if err != nil {
 		return nil, err
 	}
@@ -993,7 +993,10 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts Options, apiOpts api
 		return nil, err
 	}
 	ossUserProtectionImpl := authinfoimpl.ProvideOSSUserProtectionService()
-	registration := authnimpl.ProvideRegistration(cfg, authnService, orgService, userAuthTokenService, acimplService, permissionRegistry, apikeyService, userimplService, authService, ossUserProtectionImpl, loginattemptimplService, quotaService, authinfoimplService, renderingService, featureToggles, oauthtokenService, socialService, remoteCache, ldapImpl, ossImpl, tracingService, tempuserService, notificationService)
+	registration, err := authnimpl.ProvideRegistration(ctx, configProvider, authnService, orgService, userAuthTokenService, acimplService, permissionRegistry, apikeyService, userimplService, authService, ossUserProtectionImpl, loginattemptimplService, quotaService, authinfoimplService, renderingService, featureToggles, oauthtokenService, socialService, remoteCache, ldapImpl, ossImpl, tracingService, tempuserService, notificationService)
+	if err != nil {
+		return nil, err
+	}
 	backgroundServiceRegistry := backgroundsvcs.ProvideBackgroundServiceRegistry(httpServer, alertNG, cleanUpService, grafanaLive, gateway, notificationService, pluginstoreService, renderingService, userAuthTokenService, tracingService, provisioningServiceImpl, usageStats, statscollectorService, grafanaService, pluginsService, internalMetricsService, secretsService, remoteCache, storageService, serviceAccountsService, grpcserverProvider, secretMigrationProviderImpl, loginattemptimplService, supportbundlesimplService, metricService, keyRetriever, angulardetectorsproviderDynamic, apiserverService, anonDeviceService, ssosettingsimplService, pluginexternalService, plugininstallerService, zanzanaReconciler, appregistryService, dashboardUpdater, dashboardServiceImpl, worker, fixedRolesLoader, noopIAMRolesSyncer, syncer, embeddedZanzanaService, serviceImpl, serviceAccountsProxy, healthService, reflectionService, apiService, apiregistryService, idimplService, teamAPI, ssosettingsimplService, cloudmigrationService, registration)
 	usageStatsProvidersRegistry := usagestatssvcs.ProvideUsageStatsProvidersRegistry(acimplService, userimplService)
 	serverServer, err := New(opts, cfg, httpServer, acimplService, provisioningServiceImpl, backgroundServiceRegistry, usageStatsProvidersRegistry, statscollectorService, tracingService, featureToggles, registerer)
@@ -1346,7 +1349,7 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	pluginInstaller := manager4.ProvideInstaller(pluginManagementCfg, inMemory, loaderLoader, repoManager, serviceregistrationService, acimplService)
 	ossProvider := guardian.ProvideGuardian()
 	cacheServiceImpl := service7.ProvideCacheService(cacheService, sqlStore, ossProvider)
-	userAuthTokenService, err := authimpl.ProvideUserAuthTokenService(sqlStore, serverLockService, quotaService, secretsService, cfg, tracingService, featureToggles)
+	userAuthTokenService, err := authimpl.ProvideUserAuthTokenService(ctx, sqlStore, serverLockService, quotaService, secretsService, configProvider, tracingService, featureToggles)
 	if err != nil {
 		return nil, err
 	}
@@ -1698,7 +1701,10 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 		return nil, err
 	}
 	ossUserProtectionImpl := authinfoimpl.ProvideOSSUserProtectionService()
-	registration := authnimpl.ProvideRegistration(cfg, authnService, orgService, userAuthTokenService, acimplService, permissionRegistry, apikeyService, userimplService, authService, ossUserProtectionImpl, loginattemptimplService, quotaService, authinfoimplService, renderingService, featureToggles, oauthtokentestService, socialService, remoteCache, ldapImpl, ossImpl, tracingService, tempuserService, notificationServiceMock)
+	registration, err := authnimpl.ProvideRegistration(ctx, configProvider, authnService, orgService, userAuthTokenService, acimplService, permissionRegistry, apikeyService, userimplService, authService, ossUserProtectionImpl, loginattemptimplService, quotaService, authinfoimplService, renderingService, featureToggles, oauthtokentestService, socialService, remoteCache, ldapImpl, ossImpl, tracingService, tempuserService, notificationServiceMock)
+	if err != nil {
+		return nil, err
+	}
 	backgroundServiceRegistry := backgroundsvcs.ProvideBackgroundServiceRegistry(httpServer, alertNG, cleanUpService, grafanaLive, gateway, notificationService, pluginstoreService, renderingService, userAuthTokenService, tracingService, provisioningServiceImpl, usageStats, statscollectorService, grafanaService, pluginsService, internalMetricsService, secretsService, remoteCache, storageService, serviceAccountsService, grpcserverProvider, secretMigrationProviderImpl, loginattemptimplService, supportbundlesimplService, metricService, keyRetriever, angulardetectorsproviderDynamic, apiserverService, anonDeviceService, ssosettingsimplService, pluginexternalService, plugininstallerService, zanzanaReconciler, appregistryService, dashboardUpdater, dashboardServiceImpl, worker, fixedRolesLoader, noopIAMRolesSyncer, syncer, embeddedZanzanaService, serviceImpl, serviceAccountsProxy, healthService, reflectionService, apiService, apiregistryService, idimplService, teamAPI, ssosettingsimplService, cloudmigrationService, registration)
 	usageStatsProvidersRegistry := usagestatssvcs.ProvideUsageStatsProvidersRegistry(acimplService, userimplService)
 	serverServer, err := New(opts, cfg, httpServer, acimplService, provisioningServiceImpl, backgroundServiceRegistry, usageStatsProvidersRegistry, statscollectorService, tracingService, featureToggles, registerer)

--- a/pkg/services/auth/authimpl/auth_token.go
+++ b/pkg/services/auth/authimpl/auth_token.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/otel/codes"
 	"golang.org/x/sync/singleflight"
 
+	"github.com/grafana/grafana/pkg/configprovider"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/serverlock"
@@ -36,22 +37,28 @@ const SkipRotationTime = 5 * time.Second
 
 var _ auth.UserTokenService = (*UserAuthTokenService)(nil)
 
-func ProvideUserAuthTokenService(sqlStore db.DB,
+func ProvideUserAuthTokenService(ctx context.Context, sqlStore db.DB,
 	serverLockService *serverlock.ServerLockService,
 	quotaService quota.Service, secretService secrets.Service,
-	cfg *setting.Cfg, tracer tracing.Tracer, features featuremgmt.FeatureToggles,
+	cfgProvider configprovider.ConfigProvider, tracer tracing.Tracer,
+	features featuremgmt.FeatureToggles,
 ) (*UserAuthTokenService, error) {
 	s := &UserAuthTokenService{
 		sqlStore:          sqlStore,
 		serverLockService: serverLockService,
-		cfg:               cfg,
+		cfgProvider:       cfgProvider,
 		log:               log.New("auth"),
 		singleflight:      new(singleflight.Group),
 		features:          features,
 		tracer:            tracer,
 	}
+
 	s.externalSessionStore = provideExternalSessionStore(sqlStore, secretService, tracer)
 
+	cfg, err := cfgProvider.Get(ctx)
+	if err != nil {
+		return s, err
+	}
 	defaultLimits, err := readQuotaConfig(cfg)
 	if err != nil {
 		return s, err
@@ -71,7 +78,7 @@ func ProvideUserAuthTokenService(sqlStore db.DB,
 type UserAuthTokenService struct {
 	sqlStore             db.DB
 	serverLockService    *serverlock.ServerLockService
-	cfg                  *setting.Cfg
+	cfgProvider          configprovider.ConfigProvider
 	log                  log.Logger
 	externalSessionStore auth.ExternalSessionStore
 	singleflight         *singleflight.Group
@@ -83,7 +90,12 @@ func (s *UserAuthTokenService) CreateToken(ctx context.Context, cmd *auth.Create
 	ctx, span := s.tracer.Start(ctx, "authtoken.CreateToken")
 	defer span.End()
 
-	token, hashedToken, err := generateAndHashToken(s.cfg.SecretKey)
+	cfg, err := s.cfgProvider.Get(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	token, hashedToken, err := generateAndHashToken(cfg.SecretKey)
 	if err != nil {
 		return nil, err
 	}
@@ -142,10 +154,14 @@ func (s *UserAuthTokenService) LookupToken(ctx context.Context, unhashedToken st
 	ctx, span := s.tracer.Start(ctx, "authtoken.LookupToken")
 	defer span.End()
 
-	hashedToken := hashToken(s.cfg.SecretKey, unhashedToken)
+	cfg, err := s.cfgProvider.Get(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	hashedToken := hashToken(cfg.SecretKey, unhashedToken)
 	var model userAuthToken
 	var exists bool
-	var err error
 	err = s.sqlStore.WithDbSession(ctx, func(dbSession *db.Session) error {
 		exists, err = dbSession.Where("(auth_token = ? OR prev_auth_token = ?)",
 			hashedToken,
@@ -172,7 +188,7 @@ func (s *UserAuthTokenService) LookupToken(ctx context.Context, unhashedToken st
 		}
 	}
 
-	if model.CreatedAt <= s.createdAfterParam() || model.RotatedAt <= s.rotatedAfterParam() {
+	if model.CreatedAt <= s.createdAfterParam(cfg) || model.RotatedAt <= s.rotatedAfterParam(cfg) {
 		ctxLogger.Debug("User token has expired", "userID", model.UserId, "tokenID", model.Id, "createdAt", model.CreatedAt, "rotatedAt", model.RotatedAt)
 		return nil, &auth.TokenExpiredError{
 			UserID:  model.UserId,
@@ -352,7 +368,12 @@ func (s *UserAuthTokenService) rotateToken(ctx context.Context, token *auth.User
 		clientIPStr = clientIP.String()
 	}
 
-	newToken, hashedToken, err := generateAndHashToken(s.cfg.SecretKey)
+	cfg, err := s.cfgProvider.Get(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	newToken, hashedToken, err := generateAndHashToken(cfg.SecretKey)
 	if err != nil {
 		return nil, err
 	}
@@ -555,13 +576,18 @@ func (s *UserAuthTokenService) GetUserTokens(ctx context.Context, userId int64) 
 	ctx, span := s.tracer.Start(ctx, "authtoken.GetUserTokens")
 	defer span.End()
 
+	cfg, err := s.cfgProvider.Get(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	result := []*auth.UserToken{}
-	err := s.sqlStore.WithDbSession(ctx, func(dbSession *db.Session) error {
+	err = s.sqlStore.WithDbSession(ctx, func(dbSession *db.Session) error {
 		var tokens []*userAuthToken
 		err := dbSession.Where("user_id = ? AND created_at > ? AND rotated_at > ? AND revoked_at = 0",
 			userId,
-			s.createdAfterParam(),
-			s.rotatedAfterParam()).
+			s.createdAfterParam(cfg),
+			s.rotatedAfterParam(cfg)).
 			Find(&tokens)
 		if err != nil {
 			return err
@@ -590,10 +616,15 @@ func (s *UserAuthTokenService) ActiveTokenCount(ctx context.Context, userID *int
 		return 0, errUserIDInvalid
 	}
 
+	cfg, err := s.cfgProvider.Get(ctx)
+	if err != nil {
+		return 0, err
+	}
+
 	var count int64
-	err := s.sqlStore.WithDbSession(ctx, func(dbSession *db.Session) error {
+	err = s.sqlStore.WithDbSession(ctx, func(dbSession *db.Session) error {
 		query := `SELECT COUNT(*) FROM user_auth_token WHERE created_at > ? AND rotated_at > ? AND revoked_at = 0`
-		args := []interface{}{s.createdAfterParam(), s.rotatedAfterParam()}
+		args := []interface{}{s.createdAfterParam(cfg), s.rotatedAfterParam(cfg)}
 		if userID != nil {
 			query += " AND user_id = ?"
 			args = append(args, *userID)
@@ -669,12 +700,12 @@ func (s *UserAuthTokenService) reportActiveTokenCount(ctx context.Context, _ *qu
 	return u, err
 }
 
-func (s *UserAuthTokenService) createdAfterParam() int64 {
-	return getTime().Add(-s.cfg.LoginMaxLifetime).Unix()
+func (s *UserAuthTokenService) createdAfterParam(cfg *setting.Cfg) int64 {
+	return getTime().Add(-cfg.LoginMaxLifetime).Unix()
 }
 
-func (s *UserAuthTokenService) rotatedAfterParam() int64 {
-	return getTime().Add(-s.cfg.LoginMaxInactiveLifetime).Unix()
+func (s *UserAuthTokenService) rotatedAfterParam(cfg *setting.Cfg) int64 {
+	return getTime().Add(-cfg.LoginMaxInactiveLifetime).Unix()
 }
 
 func createToken() (string, error) {

--- a/pkg/services/auth/authimpl/auth_token_test.go
+++ b/pkg/services/auth/authimpl/auth_token_test.go
@@ -15,6 +15,7 @@ import (
 	"golang.org/x/sync/singleflight"
 
 	"github.com/grafana/grafana/pkg/components/simplejson"
+	"github.com/grafana/grafana/pkg/configprovider"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
@@ -714,9 +715,12 @@ func createTestContext(t *testing.T) *testContext {
 
 	extSessionStore := provideExternalSessionStore(sqlstore, &fakes.FakeSecretsService{}, tracer)
 
+	cfgProvider, err := configprovider.ProvideService(cfg)
+	require.NoError(t, err)
+
 	tokenService := &UserAuthTokenService{
 		sqlStore:             sqlstore,
-		cfg:                  cfg,
+		cfgProvider:          cfgProvider,
 		log:                  log.New("test-logger"),
 		singleflight:         new(singleflight.Group),
 		externalSessionStore: extSessionStore,
@@ -725,6 +729,7 @@ func createTestContext(t *testing.T) *testContext {
 
 	return &testContext{
 		sqlstore:        sqlstore,
+		cfg:             cfg,
 		tokenService:    tokenService,
 		extSessionStore: &extSessionStore,
 	}
@@ -732,6 +737,7 @@ func createTestContext(t *testing.T) *testContext {
 
 type testContext struct {
 	sqlstore        db.DB
+	cfg             *setting.Cfg
 	tokenService    *UserAuthTokenService
 	extSessionStore *auth.ExternalSessionStore
 }

--- a/pkg/services/auth/authimpl/token_cleanup.go
+++ b/pkg/services/auth/authimpl/token_cleanup.go
@@ -9,10 +9,14 @@ import (
 
 func (s *UserAuthTokenService) Run(ctx context.Context) error {
 	ticker := time.NewTicker(time.Hour)
-	maxInactiveLifetime := s.cfg.LoginMaxInactiveLifetime
-	maxLifetime := s.cfg.LoginMaxLifetime
+	cfg, err := s.cfgProvider.Get(ctx)
+	if err != nil {
+		return err
+	}
+	maxInactiveLifetime := cfg.LoginMaxInactiveLifetime
+	maxLifetime := cfg.LoginMaxLifetime
 
-	err := s.serverLockService.LockAndExecute(ctx, "cleanup expired auth tokens", time.Hour*12, func(context.Context) {
+	err = s.serverLockService.LockAndExecute(ctx, "cleanup expired auth tokens", time.Hour*12, func(context.Context) {
 		if _, err := s.deleteExpiredTokens(ctx, maxInactiveLifetime, maxLifetime); err != nil {
 			s.log.Error("An error occurred while deleting expired tokens", "err", err)
 		}

--- a/pkg/services/auth/authimpl/token_cleanup_test.go
+++ b/pkg/services/auth/authimpl/token_cleanup_test.go
@@ -20,8 +20,8 @@ func TestIntegrationUserAuthTokenCleanup(t *testing.T) {
 		ctx := createTestContext(t)
 		maxInactiveLifetime, _ := time.ParseDuration("168h")
 		maxLifetime, _ := time.ParseDuration("720h")
-		ctx.tokenService.cfg.LoginMaxInactiveLifetime = maxInactiveLifetime
-		ctx.tokenService.cfg.LoginMaxLifetime = maxLifetime
+		ctx.cfg.LoginMaxInactiveLifetime = maxInactiveLifetime
+		ctx.cfg.LoginMaxLifetime = maxLifetime
 		return ctx
 	}
 

--- a/pkg/services/authn/authnimpl/registration.go
+++ b/pkg/services/authn/authnimpl/registration.go
@@ -1,6 +1,9 @@
 package authnimpl
 
 import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/configprovider"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/remotecache"
 	"github.com/grafana/grafana/pkg/infra/tracing"
@@ -31,7 +34,7 @@ import (
 type Registration struct{}
 
 func ProvideRegistration(
-	cfg *setting.Cfg, authnSvc authn.Service,
+	ctx context.Context, cfgProvider configprovider.ConfigProvider, authnSvc authn.Service,
 	orgService org.Service, sessionService auth.UserTokenService,
 	accessControlService accesscontrol.Service, permRegistry permreg.PermissionRegistry,
 	apikeyService apikey.Service, userService user.Service,
@@ -42,14 +45,19 @@ func ProvideRegistration(
 	socialService social.Service, cache *remotecache.RemoteCache,
 	ldapService service.LDAP, settingsProviderService setting.Provider,
 	tracer tracing.Tracer, tempUserService tempuser.Service, notificationService notifications.Service,
-) Registration {
+) (Registration, error) {
 	logger := log.New("authn.registration")
+
+	cfg, err := cfgProvider.Get(ctx)
+	if err != nil {
+		return Registration{}, err
+	}
 
 	authnSvc.RegisterClient(clients.ProvideRender(renderService))
 	authnSvc.RegisterClient(clients.ProvideAPIKey(apikeyService, tracer))
 
 	if cfg.LoginCookieName != "" {
-		authnSvc.RegisterClient(clients.ProvideSession(cfg, sessionService, authInfoService, tracer))
+		authnSvc.RegisterClient(clients.ProvideSession(cfgProvider, sessionService, authInfoService, tracer))
 	}
 
 	var proxyClients []authn.ProxyClient
@@ -137,5 +145,5 @@ func ProvideRegistration(
 	authnSvc.RegisterPostAuthHook(nsSync.SyncNamespace, 150)
 	authnSvc.RegisterPostAuthHook(sync.AccessClaimsHook, 160)
 
-	return Registration{}
+	return Registration{}, nil
 }

--- a/pkg/services/authn/clients/session.go
+++ b/pkg/services/authn/clients/session.go
@@ -10,20 +10,20 @@ import (
 	"go.opentelemetry.io/otel/trace"
 
 	claims "github.com/grafana/authlib/types"
+	"github.com/grafana/grafana/pkg/configprovider"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/auth"
 	"github.com/grafana/grafana/pkg/services/authn"
 	"github.com/grafana/grafana/pkg/services/login"
 	"github.com/grafana/grafana/pkg/services/user"
-	"github.com/grafana/grafana/pkg/setting"
 )
 
 var _ authn.ContextAwareClient = new(Session)
 
-func ProvideSession(cfg *setting.Cfg, sessionService auth.UserTokenService,
+func ProvideSession(cfgProvider configprovider.ConfigProvider, sessionService auth.UserTokenService,
 	authInfoService login.AuthInfoService, tracer trace.Tracer) *Session {
 	return &Session{
-		cfg:             cfg,
+		cfgProvider:     cfgProvider,
 		log:             log.New(authn.ClientSession),
 		sessionService:  sessionService,
 		authInfoService: authInfoService,
@@ -32,7 +32,7 @@ func ProvideSession(cfg *setting.Cfg, sessionService auth.UserTokenService,
 }
 
 type Session struct {
-	cfg             *setting.Cfg
+	cfgProvider     configprovider.ConfigProvider
 	log             log.Logger
 	sessionService  auth.UserTokenService
 	authInfoService login.AuthInfoService
@@ -44,7 +44,12 @@ func (s *Session) Name() string {
 }
 
 func (s *Session) Authenticate(ctx context.Context, r *authn.Request) (*authn.Identity, error) {
-	unescapedCookie, err := r.HTTPRequest.Cookie(s.cfg.LoginCookieName)
+	cfg, err := s.cfgProvider.Get(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	unescapedCookie, err := r.HTTPRequest.Cookie(cfg.LoginCookieName)
 	if err != nil {
 		return nil, err
 	}
@@ -59,7 +64,7 @@ func (s *Session) Authenticate(ctx context.Context, r *authn.Request) (*authn.Id
 		return nil, err
 	}
 
-	if token.NeedsRotation(time.Duration(s.cfg.TokenRotationIntervalMinutes) * time.Minute) {
+	if token.NeedsRotation(time.Duration(cfg.TokenRotationIntervalMinutes) * time.Minute) {
 		return nil, authn.NewTokenNeedsRotationError(token.UserId)
 	}
 
@@ -91,11 +96,17 @@ func (s *Session) IsEnabled() bool {
 }
 
 func (s *Session) Test(ctx context.Context, r *authn.Request) bool {
-	if s.cfg.LoginCookieName == "" {
+	cfg, err := s.cfgProvider.Get(ctx)
+	if err != nil {
+		s.log.FromContext(ctx).Error("Failed to load config", "err", err)
 		return false
 	}
 
-	if _, err := r.HTTPRequest.Cookie(s.cfg.LoginCookieName); err != nil {
+	if cfg.LoginCookieName == "" {
+		return false
+	}
+
+	if _, err := r.HTTPRequest.Cookie(cfg.LoginCookieName); err != nil {
 		return false
 	}
 

--- a/pkg/services/authn/clients/session_test.go
+++ b/pkg/services/authn/clients/session_test.go
@@ -11,6 +11,7 @@ import (
 
 	claims "github.com/grafana/authlib/types"
 
+	"github.com/grafana/grafana/pkg/configprovider"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/models/usertoken"
 	"github.com/grafana/grafana/pkg/services/auth"
@@ -32,12 +33,14 @@ func TestSession_Test(t *testing.T) {
 	cfg := setting.NewCfg()
 	cfg.LoginCookieName = ""
 	cfg.LoginMaxLifetime = 20 * time.Second
-	s := ProvideSession(cfg, &authtest.FakeUserAuthTokenService{}, &authinfotest.FakeService{}, tracing.InitializeTracerForTest())
+	cfgProvider, err := configprovider.ProvideService(cfg)
+	require.NoError(t, err)
+	s := ProvideSession(cfgProvider, &authtest.FakeUserAuthTokenService{}, &authinfotest.FakeService{}, tracing.InitializeTracerForTest())
 
 	disabled := s.Test(context.Background(), &authn.Request{HTTPRequest: validHTTPReq})
 	assert.False(t, disabled)
 
-	s.cfg.LoginCookieName = cookieName
+	cfg.LoginCookieName = cookieName
 
 	good := s.Test(context.Background(), &authn.Request{HTTPRequest: validHTTPReq})
 	assert.True(t, good)
@@ -195,7 +198,9 @@ func TestSession_Authenticate(t *testing.T) {
 			cfg.LoginCookieName = cookieName
 			cfg.TokenRotationIntervalMinutes = 10
 			cfg.LoginMaxLifetime = 20 * time.Second
-			s := ProvideSession(cfg, tt.fields.sessionService, tt.fields.authInfoService, tracing.InitializeTracerForTest())
+			cfgProvider, err := configprovider.ProvideService(cfg)
+			require.NoError(t, err)
+			s := ProvideSession(cfgProvider, tt.fields.sessionService, tt.fields.authInfoService, tracing.InitializeTracerForTest())
 
 			got, err := s.Authenticate(context.Background(), tt.args.r)
 			require.True(t, (err != nil) == tt.wantErr, err)

--- a/pkg/services/quota/quotaimpl/quota_test.go
+++ b/pkg/services/quota/quotaimpl/quota_test.go
@@ -495,10 +495,12 @@ func getQuotaBySrvTargetScope(t *testing.T, quotaService quota.Service, srv quot
 }
 
 func setupEnv(t *testing.T, sqlStore db.DB, cfg *setting.Cfg, b bus.Bus, quotaService quota.Service) {
-	tracer := tracing.InitializeTracerForTest()
-	_, err := apikeyimpl.ProvideService(sqlStore, cfg, quotaService)
+	cfgProvider, err := configprovider.ProvideService(cfg)
 	require.NoError(t, err)
-	_, err = authimpl.ProvideUserAuthTokenService(sqlStore, nil, quotaService, fakes.NewFakeSecretsService(), cfg, tracing.InitializeTracerForTest(), featuremgmt.WithFeatures())
+	tracer := tracing.InitializeTracerForTest()
+	_, err = apikeyimpl.ProvideService(sqlStore, cfg, quotaService)
+	require.NoError(t, err)
+	_, err = authimpl.ProvideUserAuthTokenService(t.Context(), sqlStore, nil, quotaService, fakes.NewFakeSecretsService(), cfgProvider, tracing.InitializeTracerForTest(), featuremgmt.WithFeatures())
 	require.NoError(t, err)
 	ac := acimpl.ProvideAccessControl(featuremgmt.WithFeatures())
 	emptySearchResponse := &resourcepb.ResourceSearchResponse{TotalHits: 0}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR begins the migration of auth code from directly accessing `*setting.Cfg` (deprecated) to getting settings via the `ConfigProvider`.

**Why do we need this feature?**

This allows config to be fetched per-request, needed to make session code multitenant-aware.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
