### PR TITLE
Search: log per-snapshot deletes and unify wording to "index snapshot"

### DIFF
--- a/pkg/storage/unified/search/bleve_snapshot.go
+++ b/pkg/storage/unified/search/bleve_snapshot.go
@@ -208,7 +208,7 @@ func (b *bleveBackend) pickBestSnapshot(all map[ulid.ULID]*IndexMeta, now time.T
 			tier:    snapshotTier(v, minVersion, running),
 		}
 		candidates = append(candidates, c)
-		b.log.Debug("snapshot candidate",
+		b.log.Debug("index snapshot candidate",
 			"key", c.key.String(),
 			"tier", c.tier,
 			"version", c.version.String(),
@@ -218,7 +218,7 @@ func (b *bleveBackend) pickBestSnapshot(all map[ulid.ULID]*IndexMeta, now time.T
 	}
 
 	if len(candidates) == 0 {
-		b.log.Debug("no snapshot candidates", "total", len(all), "dropped_age", droppedAge, "dropped_unparseable", droppedUnparseable)
+		b.log.Debug("no index snapshot candidates", "total", len(all), "dropped_age", droppedAge, "dropped_unparseable", droppedUnparseable)
 		return snapshotCandidate{}, false
 	}
 
@@ -235,7 +235,7 @@ func (b *bleveBackend) pickBestSnapshot(all map[ulid.ULID]*IndexMeta, now time.T
 		return candidates[i].meta.UploadTimestamp.After(candidates[j].meta.UploadTimestamp)
 	})
 
-	b.log.Debug("selected snapshot",
+	b.log.Debug("selected index snapshot",
 		"key", candidates[0].key.String(),
 		"tier", candidates[0].tier,
 		"candidates", len(candidates),

--- a/pkg/storage/unified/search/bleve_snapshot_upload.go
+++ b/pkg/storage/unified/search/bleve_snapshot_upload.go
@@ -68,7 +68,7 @@ func (b *bleveBackend) uploadSnapshot(ctx context.Context, key resource.Namespac
 		if releaseErr := lock.Release(); releaseErr != nil {
 			span.AddEvent("snapshot.lock.release.failed", oteltrace.WithAttributes(lockAttrs...))
 			// A release failure after UploadIndex succeeds does not make the uploaded snapshot invalid.
-			logger.Warn("releasing snapshot upload lock", "err", releaseErr)
+			logger.Warn("releasing index snapshot upload lock", "err", releaseErr)
 			return
 		}
 		span.AddEvent("snapshot.lock.release.completed", oteltrace.WithAttributes(lockAttrs...))

--- a/pkg/storage/unified/search/remote_index_cleanup.go
+++ b/pkg/storage/unified/search/remote_index_cleanup.go
@@ -290,11 +290,12 @@ func (b *bleveBackend) runResourceCleanup(ctx context.Context, res resource.Name
 			return ctx.Err()
 		}
 		if err := store.DeleteIndex(ctx, res, key); err != nil {
-			logger.Warn("deleting snapshot", "resource", res, "snapshot", key.String(), "err", err)
+			logger.Warn("deleting index snapshot", "resource", res, "snapshot", key.String(), "err", err)
 			b.recordSnapshotDeleted(snapshotDeleteOutcomeError)
 			deleteFailures++
 			continue
 		}
+		logger.Info("deleted index snapshot", "resource", res, "snapshot", key.String(), "uploaded", metas[key].UploadTimestamp, "age", time.Since(metas[key].UploadTimestamp))
 		b.recordSnapshotDeleted(snapshotDeleteOutcomeSuccess)
 	}
 

--- a/pkg/storage/unified/search/remote_index_store.go
+++ b/pkg/storage/unified/search/remote_index_store.go
@@ -414,7 +414,7 @@ func (s *BucketRemoteIndexStore) ListIndexes(ctx context.Context, nsResource res
 		}
 		indexKey, err := ulid.Parse(keyStr)
 		if err != nil {
-			s.log.Warn("skipping index with non-ULID key", "key", keyStr, "err", err)
+			s.log.Warn("skipping index snapshot with non-ULID key", "key", keyStr, "err", err)
 			continue
 		}
 
@@ -430,7 +430,7 @@ func (s *BucketRemoteIndexStore) ListIndexes(ctx context.Context, nsResource res
 			continue
 		}
 		if len(meta.Files) == 0 || validateManifestPaths(meta.Files) != nil {
-			s.log.Warn("skipping index with invalid manifest", "key", obj.Key)
+			s.log.Warn("skipping index snapshot with invalid manifest", "key", obj.Key)
 			continue
 		}
 		result[indexKey] = &meta


### PR DESCRIPTION
Add an `Info` log line for each successful retention-driven snapshot delete in `runResourceCleanup` (key, upload timestamp, age) so operators can audit which snapshots were removed — previously only the `grafana_index_server_snapshot_deleted_total` metric was incremented.

Also rewords six lower-level log messages from bare "snapshot" / "index" to "index snapshot" for consistency with the existing aggregate logs.