### PR TITLE
Search: rename remote index snapshot manifest to grafana-index-snapshot.json

### DIFF
--- a/pkg/storage/unified/search/remote_index_cleanup.go
+++ b/pkg/storage/unified/search/remote_index_cleanup.go
@@ -336,7 +336,7 @@ func (b *bleveBackend) runResourceCleanup(ctx context.Context, res resource.Name
 // Snapshots with an unparseable GrafanaBuildVersion are excluded from any
 // version group; rule A still applies, but otherwise they are left untouched.
 // CleanupIncompleteUploads does NOT pick them up — it only targets prefixes
-// with missing or syntactically invalid meta.json, and an unparseable version
+// with missing or syntactically invalid snapshot manifest, and an unparseable version
 // string lives inside a structurally valid manifest. Rule A's age cutoff is
 // therefore the only mechanism that bounds their lifetime.
 //

--- a/pkg/storage/unified/search/remote_index_cleanup_test.go
+++ b/pkg/storage/unified/search/remote_index_cleanup_test.go
@@ -312,7 +312,7 @@ func TestRunCleanup_ReplicaVersionAgnostic(t *testing.T) {
 
 // seedSnapshot writes a minimal but valid snapshot at indexKey under ns,
 // matching the layout BucketRemoteIndexStore expects: a single placeholder file
-// plus meta.json declaring it. Bypasses store.UploadIndex so tests can pin
+// plus a snapshot manifest declaring it. Bypasses store.UploadIndex so tests can pin
 // arbitrary UploadTimestamps without being tied to wall-clock or ULID.Time().
 // Takes *IndexMeta so callers can use mkMeta directly.
 func seedSnapshot(t *testing.T, ctx context.Context, bucket *blob.Bucket, ns resource.NamespacedResource, indexKey ulid.ULID, meta *IndexMeta) {
@@ -324,7 +324,7 @@ func seedSnapshot(t *testing.T, ctx context.Context, bucket *blob.Bucket, ns res
 	}
 	metaBytes, err := json.Marshal(meta)
 	require.NoError(t, err)
-	require.NoError(t, bucket.WriteAll(ctx, pfx+metaJSONFile, metaBytes, nil))
+	require.NoError(t, bucket.WriteAll(ctx, pfx+snapshotManifestFile, metaBytes, nil))
 }
 
 // listSeededIndexKeys returns the index keys still present at ns in the bucket.
@@ -412,7 +412,7 @@ func TestRunCleanup_IncompleteUploadsCounted(t *testing.T) {
 	ns := newTestNsResource()
 	old := makeULID(t, time.Now().Add(-48*time.Hour))
 	pfx := indexPrefix(ns, old.String())
-	// Stale prefix without meta.json — older than CleanupIncompleteUploads' minAge.
+	// Stale prefix without a snapshot manifest — older than CleanupIncompleteUploads' minAge.
 	require.NoError(t, bucket.WriteAll(ctx, pfx+"store/data.bin", []byte("partial"), nil))
 
 	be, metrics := newCleanupTestBackend(t, store, nil)

--- a/pkg/storage/unified/search/remote_index_store.go
+++ b/pkg/storage/unified/search/remote_index_store.go
@@ -406,7 +406,7 @@ func validateManifestPaths(files map[string]int64) error {
 // downloadFile creates localPath and streams the remote object into it,
 // capping the transfer at expectedSize+1 bytes so a misadvertised manifest
 // size or a bucket object that's grown out of band fails fast before we
-// transfer unbounded data. meta.json uses the same pattern.
+// transfer unbounded data. The snapshot manifest uses the same pattern.
 func (s *BucketRemoteIndexStore) downloadFile(ctx context.Context, objectKey, localPath string, expectedSize int64) error {
 	f, err := os.Create(localPath) //nolint:gosec // path is under a Grafana-controlled staging directory
 	if err != nil {

--- a/pkg/storage/unified/search/remote_index_store.go
+++ b/pkg/storage/unified/search/remote_index_store.go
@@ -23,9 +23,15 @@ import (
 )
 
 const (
-	metaJSONFile = "meta.json"
-	// maxMetaJSONSize is the maximum allowed size for a meta.json file (1 MiB).
-	maxMetaJSONSize = 1 << 20
+	// snapshotManifestFile is the name of the manifest object written at the
+	// root of each index snapshot prefix. It is uploaded last and serves as the
+	// completion signal: its presence means the snapshot is fully uploaded.
+	// Named with a grafana- prefix to avoid confusion with Bleve's own
+	// index_meta.json that lives alongside it inside the snapshot.
+	snapshotManifestFile = "grafana-index-snapshot.json"
+	// maxSnapshotManifestSize is the maximum allowed size for a snapshot
+	// manifest file (1 MiB).
+	maxSnapshotManifestSize = 1 << 20
 )
 
 // ErrNonRegularFile is returned when a non-regular file (symlink, pipe, socket, device) is found during index upload.
@@ -116,13 +122,13 @@ type BucketRemoteIndexStoreConfig struct {
 //
 // Object storage layout:
 //
-//	/<namespace>/<resource>.<group>/<index-key>/index_meta.json
+//	/<namespace>/<resource>.<group>/<index-key>/index_meta.json   <- Bleve's own metadata, part of the index
 //	/<namespace>/<resource>.<group>/<index-key>/store/root.bolt
 //	/<namespace>/<resource>.<group>/<index-key>/store/*.zap
-//	/<namespace>/<resource>.<group>/<index-key>/meta.json  <- uploaded last, signals complete upload
+//	/<namespace>/<resource>.<group>/<index-key>/grafana-index-snapshot.json  <- uploaded last, signals complete upload
 //
-// meta.json is uploaded last during upload and deleted first during delete,
-// serving as the completion signal.
+// grafana-index-snapshot.json is uploaded last during upload and deleted first
+// during delete, serving as the completion signal.
 type BucketRemoteIndexStore struct {
 	bucket          resource.CDKBucket
 	lockBackend     lockBackend
@@ -227,9 +233,9 @@ func (s *BucketRemoteIndexStore) UploadIndex(ctx context.Context, nsResource res
 		if !d.Type().IsRegular() {
 			return fmt.Errorf("%w: %s (mode: %s)", ErrNonRegularFile, path, d.Type())
 		}
-		// Skip meta.json — we generate our own manifest and uploading a pre-existing
-		// one would cause a size mismatch on round-trip.
-		if d.Name() == metaJSONFile {
+		// Skip the snapshot manifest — we generate our own and uploading a
+		// pre-existing one would cause a size mismatch on round-trip.
+		if d.Name() == snapshotManifestFile {
 			return nil
 		}
 		rel, err := filepath.Rel(absLocalDir, path)
@@ -266,13 +272,13 @@ func (s *BucketRemoteIndexStore) UploadIndex(ctx context.Context, nsResource res
 		}
 	}
 
-	// Upload meta.json last — its presence signals a complete upload.
+	// Upload the snapshot manifest last — its presence signals a complete upload.
 	metaBytes, err := json.Marshal(meta)
 	if err != nil {
-		return ulid.ULID{}, fmt.Errorf("marshaling meta: %w", err)
+		return ulid.ULID{}, fmt.Errorf("marshaling snapshot manifest: %w", err)
 	}
-	if err := s.bucket.WriteAll(ctx, pfx+metaJSONFile, metaBytes, nil); err != nil {
-		return ulid.ULID{}, fmt.Errorf("uploading meta.json: %w", err)
+	if err := s.bucket.WriteAll(ctx, pfx+snapshotManifestFile, metaBytes, nil); err != nil {
+		return ulid.ULID{}, fmt.Errorf("uploading snapshot manifest: %w", err)
 	}
 
 	return indexKey, nil
@@ -312,17 +318,17 @@ func (s *BucketRemoteIndexStore) uploadFile(ctx context.Context, objectKey, loca
 func (s *BucketRemoteIndexStore) DownloadIndex(ctx context.Context, nsResource resource.NamespacedResource, indexKey ulid.ULID, destDir string) (_ *IndexMeta, retErr error) {
 	pfx := indexPrefix(nsResource, indexKey.String())
 
-	// Download and parse meta.json with a size limit to avoid OOM on malicious files.
+	// Download and parse the snapshot manifest with a size limit to avoid OOM on malicious files.
 	var metaBuf bytes.Buffer
-	if err := s.bucket.Download(ctx, pfx+metaJSONFile, &resource.LimitedWriter{W: &metaBuf, N: maxMetaJSONSize}, nil); err != nil {
-		return nil, fmt.Errorf("reading meta.json: %w", err)
+	if err := s.bucket.Download(ctx, pfx+snapshotManifestFile, &resource.LimitedWriter{W: &metaBuf, N: maxSnapshotManifestSize}, nil); err != nil {
+		return nil, fmt.Errorf("reading snapshot manifest: %w", err)
 	}
 	var meta IndexMeta
 	if err := json.Unmarshal(metaBuf.Bytes(), &meta); err != nil {
-		return nil, fmt.Errorf("parsing meta.json: %w", err)
+		return nil, fmt.Errorf("parsing snapshot manifest: %w", err)
 	}
 	if len(meta.Files) == 0 {
-		return nil, fmt.Errorf("meta.json has empty file manifest for index %q", indexKey)
+		return nil, fmt.Errorf("snapshot manifest has empty file manifest for index %q", indexKey)
 	}
 	if err := validateManifestPaths(meta.Files); err != nil {
 		return nil, fmt.Errorf("invalid manifest: %w", err)
@@ -422,7 +428,7 @@ func (s *BucketRemoteIndexStore) ListIndexes(ctx context.Context, nsResource res
 	nsPfx := nsPrefix(nsResource)
 	result := make(map[ulid.ULID]*IndexMeta)
 
-	// List all objects under the namespace prefix, looking for meta.json files
+	// List all objects under the namespace prefix, looking for snapshot manifest files
 	iter := s.bucket.List(&blob.ListOptions{Prefix: nsPfx})
 	for {
 		obj, err := iter.Next(ctx)
@@ -433,14 +439,14 @@ func (s *BucketRemoteIndexStore) ListIndexes(ctx context.Context, nsResource res
 			return nil, fmt.Errorf("failed to list objects: %w", err)
 		}
 
-		// We only care about meta.json files
-		if !strings.HasSuffix(obj.Key, "/"+metaJSONFile) {
+		// We only care about snapshot manifest files
+		if !strings.HasSuffix(obj.Key, "/"+snapshotManifestFile) {
 			continue
 		}
 
-		// Extract index key from: <nsPfx><indexKey>/meta.json
+		// Extract index key from: <nsPfx><indexKey>/<snapshotManifestFile>
 		rel := strings.TrimPrefix(obj.Key, nsPfx)
-		keyStr := strings.TrimSuffix(rel, "/"+metaJSONFile)
+		keyStr := strings.TrimSuffix(rel, "/"+snapshotManifestFile)
 		if keyStr == "" || strings.Contains(keyStr, "/") {
 			continue // skip nested or malformed paths
 		}
@@ -450,15 +456,15 @@ func (s *BucketRemoteIndexStore) ListIndexes(ctx context.Context, nsResource res
 			continue
 		}
 
-		// Fetch and parse meta.json with a size limit.
+		// Fetch and parse the snapshot manifest with a size limit.
 		var metaBuf bytes.Buffer
-		if err := s.bucket.Download(ctx, obj.Key, &resource.LimitedWriter{W: &metaBuf, N: maxMetaJSONSize}, nil); err != nil {
-			s.log.Error("failed to read meta.json", "key", obj.Key, "err", err)
+		if err := s.bucket.Download(ctx, obj.Key, &resource.LimitedWriter{W: &metaBuf, N: maxSnapshotManifestSize}, nil); err != nil {
+			s.log.Error("failed to read snapshot manifest", "key", obj.Key, "err", err)
 			continue
 		}
 		var meta IndexMeta
 		if err := json.Unmarshal(metaBuf.Bytes(), &meta); err != nil {
-			s.log.Error("failed to parse meta.json", "key", obj.Key, "err", err)
+			s.log.Error("failed to parse snapshot manifest", "key", obj.Key, "err", err)
 			continue
 		}
 		if len(meta.Files) == 0 || validateManifestPaths(meta.Files) != nil {
@@ -532,9 +538,9 @@ func (s *BucketRemoteIndexStore) ListNamespaceIndexes(ctx context.Context, names
 func (s *BucketRemoteIndexStore) DeleteIndex(ctx context.Context, nsResource resource.NamespacedResource, indexKey ulid.ULID) error {
 	pfx := indexPrefix(nsResource, indexKey.String())
 
-	// Delete meta.json first
-	if err := s.bucket.Delete(ctx, pfx+metaJSONFile); err != nil && gcerrors.Code(err) != gcerrors.NotFound {
-		return fmt.Errorf("failed to delete meta.json: %w", err)
+	// Delete the snapshot manifest first
+	if err := s.bucket.Delete(ctx, pfx+snapshotManifestFile); err != nil && gcerrors.Code(err) != gcerrors.NotFound {
+		return fmt.Errorf("failed to delete snapshot manifest: %w", err)
 	}
 
 	// List all objects under this prefix and delete them
@@ -558,10 +564,11 @@ func (s *BucketRemoteIndexStore) DeleteIndex(ctx context.Context, nsResource res
 func (s *BucketRemoteIndexStore) CleanupIncompleteUploads(ctx context.Context, nsResource resource.NamespacedResource, minAge time.Duration) (int, error) {
 	nsPfx := nsPrefix(nsResource)
 
-	// First pass: collect all keys grouped by index prefix, recording the meta.json key if present.
+	// First pass: collect all keys grouped by index prefix, recording the
+	// snapshot manifest key if present.
 	type prefixInfo struct {
 		keys    []string
-		metaKey string // empty = no meta.json seen
+		metaKey string // empty = no snapshot manifest seen
 	}
 	prefixes := make(map[string]*prefixInfo)
 
@@ -596,14 +603,14 @@ func (s *BucketRemoteIndexStore) CleanupIncompleteUploads(ctx context.Context, n
 			prefixes[keyStr] = info
 		}
 		info.keys = append(info.keys, obj.Key)
-		if strings.HasSuffix(obj.Key, "/"+metaJSONFile) {
+		if strings.HasSuffix(obj.Key, "/"+snapshotManifestFile) {
 			info.metaKey = obj.Key
 		}
 	}
 
 	// Second pass: delete incomplete prefixes.
-	// A prefix is incomplete if it has no meta.json, or if the meta.json is
-	// positively known to be invalid (unparseable or empty file manifest).
+	// A prefix is incomplete if it has no snapshot manifest, or if the manifest
+	// is positively known to be invalid (unparseable or empty file list).
 	cleaned := 0
 	for keyStr, info := range prefixes {
 		if info.metaKey != "" {
@@ -628,13 +635,13 @@ func (s *BucketRemoteIndexStore) CleanupIncompleteUploads(ctx context.Context, n
 	return cleaned, nil
 }
 
-// isValidManifest downloads and parses a meta.json object with a size limit.
+// isValidManifest downloads and parses a snapshot manifest object with a size limit.
 // Returns (true, nil) for a valid manifest, (false, nil) for a positively
 // invalid one (oversized, corrupt JSON, or empty Files), and (false, err) for
 // transient download errors.
 func (s *BucketRemoteIndexStore) isValidManifest(ctx context.Context, metaKey string) (bool, error) {
 	var buf bytes.Buffer
-	if err := s.bucket.Download(ctx, metaKey, &resource.LimitedWriter{W: &buf, N: maxMetaJSONSize}, nil); err != nil {
+	if err := s.bucket.Download(ctx, metaKey, &resource.LimitedWriter{W: &buf, N: maxSnapshotManifestSize}, nil); err != nil {
 		if errors.Is(err, resource.ErrWriteLimitExceeded) {
 			return false, nil // positively invalid: oversized
 		}

--- a/pkg/storage/unified/search/remote_index_store_test.go
+++ b/pkg/storage/unified/search/remote_index_store_test.go
@@ -224,24 +224,24 @@ func TestRemoteIndexStore_DownloadRejectsCorruptMetaJSON(t *testing.T) {
 	key := ulid.Make()
 	pfx := indexPrefix(ns, key.String())
 
-	t.Run("missing meta.json", func(t *testing.T) {
+	t.Run("missing snapshot manifest", func(t *testing.T) {
 		_, err := store.DownloadIndex(ctx, ns, key, t.TempDir())
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "reading meta.json")
+		require.Contains(t, err.Error(), "reading snapshot manifest")
 	})
 
 	t.Run("invalid JSON", func(t *testing.T) {
-		require.NoError(t, bucket.WriteAll(ctx, pfx+"meta.json", []byte("{not json"), nil))
+		require.NoError(t, bucket.WriteAll(ctx, pfx+snapshotManifestFile, []byte("{not json"), nil))
 		_, err := store.DownloadIndex(ctx, ns, key, t.TempDir())
 		require.Error(t, err)
-		require.Contains(t, err.Error(), "parsing meta.json")
+		require.Contains(t, err.Error(), "parsing snapshot manifest")
 	})
 
 	t.Run("empty file manifest", func(t *testing.T) {
 		meta := IndexMeta{GrafanaBuildVersion: "11.0.0", Files: map[string]int64{}}
 		metaBytes, err := json.Marshal(meta)
 		require.NoError(t, err)
-		require.NoError(t, bucket.WriteAll(ctx, pfx+"meta.json", metaBytes, nil))
+		require.NoError(t, bucket.WriteAll(ctx, pfx+snapshotManifestFile, metaBytes, nil))
 		_, err = store.DownloadIndex(ctx, ns, key, t.TempDir())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "empty file manifest")
@@ -251,7 +251,7 @@ func TestRemoteIndexStore_DownloadRejectsCorruptMetaJSON(t *testing.T) {
 		meta := IndexMeta{GrafanaBuildVersion: "11.0.0", Files: map[string]int64{"store/../store/root.bolt": 100}}
 		metaBytes, err := json.Marshal(meta)
 		require.NoError(t, err)
-		require.NoError(t, bucket.WriteAll(ctx, pfx+"meta.json", metaBytes, nil))
+		require.NoError(t, bucket.WriteAll(ctx, pfx+snapshotManifestFile, metaBytes, nil))
 		_, err = store.DownloadIndex(ctx, ns, key, t.TempDir())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "non-canonical")
@@ -261,19 +261,19 @@ func TestRemoteIndexStore_DownloadRejectsCorruptMetaJSON(t *testing.T) {
 		meta := IndexMeta{GrafanaBuildVersion: "11.0.0", Files: map[string]int64{"/etc/passwd": 100}}
 		metaBytes, err := json.Marshal(meta)
 		require.NoError(t, err)
-		require.NoError(t, bucket.WriteAll(ctx, pfx+"meta.json", metaBytes, nil))
+		require.NoError(t, bucket.WriteAll(ctx, pfx+snapshotManifestFile, metaBytes, nil))
 		_, err = store.DownloadIndex(ctx, ns, key, t.TempDir())
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "invalid")
 	})
 
-	t.Run("oversized meta.json", func(t *testing.T) {
-		// Write a meta.json that exceeds the 1 MiB limit
-		oversized := make([]byte, maxMetaJSONSize+1)
+	t.Run("oversized snapshot manifest", func(t *testing.T) {
+		// Write a manifest that exceeds the 1 MiB limit
+		oversized := make([]byte, maxSnapshotManifestSize+1)
 		for i := range oversized {
 			oversized[i] = 'x'
 		}
-		require.NoError(t, bucket.WriteAll(ctx, pfx+"meta.json", oversized, nil))
+		require.NoError(t, bucket.WriteAll(ctx, pfx+snapshotManifestFile, oversized, nil))
 		_, err := store.DownloadIndex(ctx, ns, key, filepath.Join(t.TempDir(), "dl"))
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "write limit exceeded")
@@ -323,7 +323,7 @@ func TestRemoteIndexStore_DownloadValidatesCompleteness(t *testing.T) {
 
 	// Delete one file from the bucket to simulate partial upload
 	pfx := indexPrefix(ns, indexKey.String())
-	metaRaw, err := bucket.ReadAll(ctx, pfx+"meta.json")
+	metaRaw, err := bucket.ReadAll(ctx, pfx+snapshotManifestFile)
 	require.NoError(t, err)
 	require.NoError(t, json.Unmarshal(metaRaw, &meta))
 	for relPath := range meta.Files {
@@ -358,19 +358,19 @@ func TestRemoteIndexStore_UploadExcludesMetaJSON(t *testing.T) {
 	ns := newTestNsResource()
 
 	srcDir := createTestBleveIndex(t)
-	// Plant a stale meta.json in the source directory
-	require.NoError(t, os.WriteFile(filepath.Join(srcDir, "meta.json"), []byte(`{"stale":"data"}`), 0600))
+	// Plant a stale snapshot manifest in the source directory
+	require.NoError(t, os.WriteFile(filepath.Join(srcDir, snapshotManifestFile), []byte(`{"stale":"data"}`), 0600))
 
 	meta := IndexMeta{GrafanaBuildVersion: "11.0.0", LatestResourceVersion: 10}
 	indexKey, err := store.UploadIndex(ctx, ns, srcDir, meta)
 	require.NoError(t, err)
 
 	pfx := indexPrefix(ns, indexKey.String())
-	metaBytes, err := bucket.ReadAll(ctx, pfx+"meta.json")
+	metaBytes, err := bucket.ReadAll(ctx, pfx+snapshotManifestFile)
 	require.NoError(t, err)
 	var uploaded IndexMeta
 	require.NoError(t, json.Unmarshal(metaBytes, &uploaded))
-	require.NotContains(t, uploaded.Files, "meta.json")
+	require.NotContains(t, uploaded.Files, snapshotManifestFile)
 }
 
 // --- Error injection tests (memblob + errorBucket) ---
@@ -449,7 +449,7 @@ func TestRemoteIndexStore_BucketErrors(t *testing.T) {
 		require.Contains(t, err.Error(), "upload network timeout")
 	})
 
-	t.Run("meta.json write error", func(t *testing.T) {
+	t.Run("snapshot manifest write error", func(t *testing.T) {
 		real := memblob.OpenBucket(nil)
 		defer func() { _ = real.Close() }()
 		store := newTestRemoteIndexStore(t, &errorBucket{CDKBucket: real, writeAllErr: fmt.Errorf("write quota exceeded")})
@@ -460,13 +460,13 @@ func TestRemoteIndexStore_BucketErrors(t *testing.T) {
 		require.Contains(t, err.Error(), "write quota exceeded")
 	})
 
-	t.Run("meta.json download error", func(t *testing.T) {
+	t.Run("snapshot manifest download error", func(t *testing.T) {
 		real := memblob.OpenBucket(nil)
 		defer func() { _ = real.Close() }()
 		store := newTestRemoteIndexStore(t, &errorBucket{
 			CDKBucket: real,
 			downloadFn: func(key string) error {
-				if strings.HasSuffix(key, "/meta.json") {
+				if strings.HasSuffix(key, "/"+snapshotManifestFile) {
 					return fmt.Errorf("access denied")
 				}
 				return nil
@@ -531,13 +531,13 @@ func TestRemoteIndexStore_CleanupIncompleteUploads(t *testing.T) {
 	store := newTestRemoteIndexStore(t, bucket)
 	ns := newTestNsResource()
 
-	// Upload a complete index (has meta.json)
+	// Upload a complete index (has a snapshot manifest)
 	srcDir := createTestBleveIndex(t)
 	meta := IndexMeta{GrafanaBuildVersion: "11.0.0", LatestResourceVersion: 10}
 	completeKey, err := store.UploadIndex(ctx, ns, srcDir, meta)
 	require.NoError(t, err)
 
-	// Simulate an incomplete upload: write objects under a ULID prefix without meta.json
+	// Simulate an incomplete upload: write objects under a ULID prefix without a snapshot manifest
 	incompleteKey := ulid.Make()
 	incompletePfx := indexPrefix(ns, incompleteKey.String())
 	require.NoError(t, bucket.WriteAll(ctx, incompletePfx+"store/root.bolt", []byte("orphaned"), nil))
@@ -596,7 +596,7 @@ func TestRemoteIndexStore_CleanupIncompleteUploads_CorruptManifest(t *testing.T)
 		key := ulid.Make()
 		pfx := indexPrefix(ns, key.String())
 		require.NoError(t, bucket.WriteAll(ctx, pfx+"store/root.bolt", []byte("data"), nil))
-		require.NoError(t, bucket.WriteAll(ctx, pfx+"meta.json", []byte("{corrupt"), nil))
+		require.NoError(t, bucket.WriteAll(ctx, pfx+snapshotManifestFile, []byte("{corrupt"), nil))
 
 		cleaned, err := store.CleanupIncompleteUploads(ctx, ns, 0)
 		require.NoError(t, err)
@@ -608,7 +608,7 @@ func TestRemoteIndexStore_CleanupIncompleteUploads_CorruptManifest(t *testing.T)
 		pfx := indexPrefix(ns, key.String())
 		require.NoError(t, bucket.WriteAll(ctx, pfx+"store/root.bolt", []byte("data"), nil))
 		emptyMeta, _ := json.Marshal(IndexMeta{GrafanaBuildVersion: "11.0.0", Files: map[string]int64{}})
-		require.NoError(t, bucket.WriteAll(ctx, pfx+"meta.json", emptyMeta, nil))
+		require.NoError(t, bucket.WriteAll(ctx, pfx+snapshotManifestFile, emptyMeta, nil))
 
 		cleaned, err := store.CleanupIncompleteUploads(ctx, ns, 0)
 		require.NoError(t, err)

--- a/pkg/storage/unified/search/remote_index_store_test.go
+++ b/pkg/storage/unified/search/remote_index_store_test.go
@@ -281,8 +281,9 @@ func TestRemoteIndexStore_DownloadRejectsCorruptMetaJSON(t *testing.T) {
 }
 
 func TestRemoteIndexStore_DownloadRejectsOversizedFile(t *testing.T) {
-	// A bucket object that exceeds the size advertised in meta.json must fail
-	// fast — we should not transfer unbounded bytes to disk before noticing.
+	// A bucket object that exceeds the size advertised in the snapshot manifest
+	// must fail fast — we should not transfer unbounded bytes to disk before
+	// noticing.
 	ctx := context.Background()
 	bucket := memblob.OpenBucket(nil)
 	defer func() { _ = bucket.Close() }()
@@ -298,9 +299,9 @@ func TestRemoteIndexStore_DownloadRejectsOversizedFile(t *testing.T) {
 	}
 	metaBytes, err := json.Marshal(meta)
 	require.NoError(t, err)
-	require.NoError(t, bucket.WriteAll(ctx, pfx+"meta.json", metaBytes, nil))
+	require.NoError(t, bucket.WriteAll(ctx, pfx+snapshotManifestFile, metaBytes, nil))
 
-	// Plant a file far larger than what meta.json claims.
+	// Plant a file far larger than what the snapshot manifest claims.
 	oversized := bytes.Repeat([]byte("x"), advertised*1000)
 	require.NoError(t, bucket.WriteAll(ctx, pfx+"store/root.bolt", oversized, nil))
 


### PR DESCRIPTION
Renames the per-snapshot manifest file written to object storage from `meta.json` to `grafana-index-snapshot.json`.

The previous name was easy to confuse with Bleve's own `index_meta.json`, which the upload step ships as part of the snapshot directory and lives at the same prefix level in the bucket:

```
<namespace>/<resource>.<group>/<index-key>/index_meta.json              <- Bleve
<namespace>/<resource>.<group>/<index-key>/store/...                    <- Bleve segments
<namespace>/<resource>.<group>/<index-key>/grafana-index-snapshot.json  <- ours, completion sentinel
```

The new name makes ownership unambiguous when inspecting a bucket.

## Changes

- File: `meta.json` → `grafana-index-snapshot.json`.
- Internal constants: `metaJSONFile` → `snapshotManifestFile`, `maxMetaJSONSize` → `maxSnapshotManifestSize`.
- Updated comments, log fields and error messages to say "snapshot manifest".
- Tests updated accordingly.

No backwards-compat read path is added; existing `meta.json` objects in the single environment using this today will be reaped as incomplete uploads.

Builds on #123796 / #123745 / #123474.
