### PR TITLE
Datasources: Remove duplicate type from header subtitle

### DIFF
--- a/e2e-playwright/plugin-e2e/azuremonitor/azuremonitor.spec.ts
+++ b/e2e-playwright/plugin-e2e/azuremonitor/azuremonitor.spec.ts
@@ -8,7 +8,7 @@ test(
   async ({ createDataSourceConfigPage, page }) => {
     await createDataSourceConfigPage({ type: 'grafana-azure-monitor-datasource' });
 
-    await expect(await page.getByText('Type: Azure Monitor', { exact: true })).toBeVisible();
+    await expect(await page.getByText(/^Type\s*Azure Monitor$/, { exact: true })).toBeVisible();
     await expect(await page.getByRole('heading', { name: 'Authentication', exact: true })).toBeVisible();
   }
 );

--- a/e2e-playwright/plugin-e2e/cloudmonitoring/cloudmonitoring.spec.ts
+++ b/e2e-playwright/plugin-e2e/cloudmonitoring/cloudmonitoring.spec.ts
@@ -8,7 +8,7 @@ test(
   async ({ createDataSourceConfigPage, page }) => {
     await createDataSourceConfigPage({ type: 'stackdriver' });
 
-    await expect(await page.getByText('Type: Google Cloud Monitoring', { exact: true })).toBeVisible();
+    await expect(await page.getByText(/^Type\s*Google Cloud Monitoring$/, { exact: true })).toBeVisible();
     await expect(await page.getByText('Google JWT File', { exact: true })).toBeVisible();
   }
 );

--- a/e2e-playwright/plugin-e2e/cloudwatch/cloudwatch.spec.ts
+++ b/e2e-playwright/plugin-e2e/cloudwatch/cloudwatch.spec.ts
@@ -8,7 +8,7 @@ test(
   async ({ createDataSourceConfigPage, page }) => {
     await createDataSourceConfigPage({ type: 'cloudwatch' });
 
-    await expect(await page.getByText('Type: CloudWatch', { exact: true })).toBeVisible();
+    await expect(await page.getByText(/^Type\s*CloudWatch$/, { exact: true })).toBeVisible();
     await expect(await page.getByRole('heading', { name: 'Connection Details', exact: true })).toBeVisible();
   }
 );

--- a/e2e-playwright/plugin-e2e/graphite/graphite.spec.ts
+++ b/e2e-playwright/plugin-e2e/graphite/graphite.spec.ts
@@ -8,7 +8,7 @@ test(
   async ({ createDataSourceConfigPage, page }) => {
     await createDataSourceConfigPage({ type: 'graphite' });
 
-    await expect(await page.getByText('Type: Graphite', { exact: true })).toBeVisible();
+    await expect(await page.getByText(/^Type\s*Graphite$/, { exact: true })).toBeVisible();
     await expect(await page.getByRole('heading', { name: 'HTTP', exact: true })).toBeVisible();
   }
 );

--- a/e2e-playwright/plugin-e2e/influxdb/influxdb.spec.ts
+++ b/e2e-playwright/plugin-e2e/influxdb/influxdb.spec.ts
@@ -8,7 +8,7 @@ test(
   async ({ createDataSourceConfigPage, page }) => {
     await createDataSourceConfigPage({ type: 'influxdb' });
 
-    await expect(await page.getByText('Type: InfluxDB', { exact: true })).toBeVisible();
+    await expect(await page.getByText(/^Type\s*InfluxDB$/, { exact: true })).toBeVisible();
     await expect(await page.getByRole('heading', { name: 'HTTP', exact: true })).toBeVisible();
   }
 );

--- a/e2e-playwright/plugin-e2e/jaeger/jaeger.spec.ts
+++ b/e2e-playwright/plugin-e2e/jaeger/jaeger.spec.ts
@@ -8,7 +8,7 @@ test(
   async ({ createDataSourceConfigPage, page }) => {
     await createDataSourceConfigPage({ type: 'jaeger' });
 
-    await expect(await page.getByText('Type: Jaeger', { exact: true })).toBeVisible();
+    await expect(await page.getByText(/^Type\s*Jaeger$/, { exact: true })).toBeVisible();
     await expect(await page.getByRole('heading', { name: 'Connection', exact: true })).toBeVisible();
   }
 );

--- a/e2e-playwright/plugin-e2e/loki/loki.spec.ts
+++ b/e2e-playwright/plugin-e2e/loki/loki.spec.ts
@@ -3,6 +3,6 @@ import { test, expect } from '@grafana/plugin-e2e';
 test('Smoke test: decoupled frontend plugin loads', async ({ createDataSourceConfigPage, page }) => {
   await createDataSourceConfigPage({ type: 'loki' });
 
-  await expect(page.getByText('Type: Loki', { exact: true })).toBeVisible();
+  await expect(page.getByText(/^Type\s*Loki$/, { exact: true })).toBeVisible();
   await expect(page.getByRole('heading', { name: 'Connection', exact: true })).toBeVisible();
 });

--- a/e2e-playwright/plugin-e2e/mssql/mssql.spec.ts
+++ b/e2e-playwright/plugin-e2e/mssql/mssql.spec.ts
@@ -8,7 +8,7 @@ test(
   async ({ createDataSourceConfigPage, page }) => {
     await createDataSourceConfigPage({ type: 'mssql' });
 
-    await expect(await page.getByText('Type: Microsoft SQL Server', { exact: true })).toBeVisible();
+    await expect(await page.getByText(/^Type\s*Microsoft SQL Server$/, { exact: true })).toBeVisible();
     await expect(await page.getByRole('heading', { name: 'Connection', exact: true })).toBeVisible();
   }
 );

--- a/e2e-playwright/plugin-e2e/opentsdb/opentsdb.spec.ts
+++ b/e2e-playwright/plugin-e2e/opentsdb/opentsdb.spec.ts
@@ -8,7 +8,7 @@ test(
   async ({ createDataSourceConfigPage, page }) => {
     await createDataSourceConfigPage({ type: 'opentsdb' });
 
-    await expect(await page.getByText('Type: OpenTSDB', { exact: true })).toBeVisible();
+    await expect(await page.getByText(/^Type\s*OpenTSDB$/, { exact: true })).toBeVisible();
     await expect(await page.getByRole('heading', { name: 'HTTP', exact: true })).toBeVisible();
   }
 );

--- a/e2e-playwright/plugin-e2e/postgres/postgres.spec.ts
+++ b/e2e-playwright/plugin-e2e/postgres/postgres.spec.ts
@@ -8,7 +8,7 @@ test(
   async ({ createDataSourceConfigPage, page }) => {
     await createDataSourceConfigPage({ type: 'grafana-postgresql-datasource' });
 
-    await expect(await page.getByText('Type: PostgreSQL', { exact: true })).toBeVisible();
+    await expect(await page.getByText(/^Type\s*PostgreSQL$/, { exact: true })).toBeVisible();
     await expect(await page.getByRole('heading', { name: 'Connection', exact: true })).toBeVisible();
   }
 );

--- a/e2e-playwright/plugin-e2e/zipkin/zipkin.spec.ts
+++ b/e2e-playwright/plugin-e2e/zipkin/zipkin.spec.ts
@@ -8,7 +8,7 @@ test(
   async ({ createDataSourceConfigPage, page }) => {
     await createDataSourceConfigPage({ type: 'zipkin' });
 
-    await expect(await page.getByText('Type: Zipkin', { exact: true })).toBeVisible();
+    await expect(await page.getByText(/^Type\s*Zipkin$/, { exact: true })).toBeVisible();
     await expect(await page.getByRole('heading', { name: 'Connection', exact: true })).toBeVisible();
   }
 );

--- a/public/app/features/connections/hooks/useDataSourceSettingsNav.ts
+++ b/public/app/features/connections/hooks/useDataSourceSettingsNav.ts
@@ -4,7 +4,7 @@ import { type NavModel, type NavModelItem } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { getDataSourceSrv } from '@grafana/runtime';
 import { getNavModel } from 'app/core/selectors/navModel';
-import { useDataSource, useDataSourceMeta, useDataSourceSettings } from 'app/features/datasources/state/hooks';
+import { useDataSource, useDataSourceSettings } from 'app/features/datasources/state/hooks';
 import { getDataSourceLoadingNav, buildNavModel, getDataSourceNav } from 'app/features/datasources/state/navModel';
 import { useGetSingle } from 'app/features/plugins/admin/state/hooks';
 import { useSelector } from 'app/types/store';
@@ -13,7 +13,6 @@ export function useDataSourceSettingsNav(pageIdParam?: string) {
   const { uid = '' } = useParams<{ uid: string }>();
   const location = useLocation();
   const datasource = useDataSource(uid);
-  const dataSourceMeta = useDataSourceMeta(datasource.type);
   const datasourcePlugin = useGetSingle(datasource.type);
   const params = new URLSearchParams(location.search);
   const pageId = pageIdParam || params.get('page');
@@ -77,7 +76,6 @@ export function useDataSourceSettingsNav(pageIdParam?: string) {
     dataSourcePluginName: datasourcePlugin?.name || plugin?.meta.name || '',
     active: true,
     text: datasource.name || '',
-    subTitle: dataSourceMeta.name ? `Type: ${dataSourceMeta.name}` : '',
     url: `/connections/datasources/edit/${uid}/`,
     children: (pageNav.main.children || []).map((navModelItem) => ({
       ...navModelItem,


### PR DESCRIPTION
**What is this feature?**

Removes the `Type: ...` subtitle from the datasources page header, as it is also displayed on the right as part of the page header info.

**Why do we need this feature?**

Cleaning up the page, removing duplicate information, cc #122847 + #122053 + #123965.

**Who is this feature for?**

All administrators.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
