### PR TITLE
unified-storage: add kv lease test for hierarchical names

### DIFF
--- a/pkg/storage/unified/testing/lease.go
+++ b/pkg/storage/unified/testing/lease.go
@@ -106,6 +106,26 @@ func runLeaseContention(t *testing.T, store kv.KV) {
 		require.NoError(t, m.Release(ctx, leaseA))
 		require.NoError(t, m.Release(ctx, leaseB))
 	})
+
+	t.Run("names sharing a prefix do not interfere", func(t *testing.T) {
+		m := lease.NewManager(store, "holder-shared-prefix")
+		shortName := "contention/shared-prefix/a/b"
+		longName := "contention/shared-prefix/a/b/c"
+
+		short, err := m.Acquire(ctx, shortName)
+		require.NoError(t, err)
+		long, err := m.Acquire(ctx, longName)
+		require.NoError(t, err)
+		require.NoError(t, m.Release(ctx, short))
+		require.NoError(t, m.Release(ctx, long))
+
+		long, err = m.Acquire(ctx, longName)
+		require.NoError(t, err)
+		short, err = m.Acquire(ctx, shortName)
+		require.NoError(t, err)
+		require.NoError(t, m.Release(ctx, short))
+		require.NoError(t, m.Release(ctx, long))
+	})
 }
 
 func runLeaseConcurrency(t *testing.T, store kv.KV) {


### PR DESCRIPTION
Small addon after #123773: another requirement for the implementation: the leased names are not associated with one another by prefix, and each name should be handled as if it's unique. Adding an explicit test for hierarchical names to make sure the implementation deals with them appropriately.

Part of: https://github.com/grafana/hyperion-planning/issues/608