### PR TITLE
unified-storage: log case mismatches when reading resources

### DIFF
--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -12,6 +12,7 @@ import (
 	"math/rand/v2"
 	"net/http"
 	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -44,6 +45,22 @@ const (
 	defaultSearchLookback             = 1 * time.Second
 	defaultGarbageCollectionBatchWait = 1 * time.Second
 )
+
+// IsResourceNameMixedCase reports whether a successful read returned a
+// resource whose stored name matches the requested name case-insensitively but
+// differs in case. This indicates a case-mismatched lookup, which can occur
+// when the underlying database collation is case-insensitive (for example,
+// MySQL's default collation): the row is found despite the case difference,
+// and the stored name retains its original casing.
+func IsResourceNameMixedCase(req *resourcepb.ReadRequest, res *BackendReadResponse) bool {
+	if req == nil || req.Key == nil || res == nil || res.Error != nil || res.Key == nil {
+		return false
+	}
+	if req.Key.Name == res.Key.Name {
+		return false
+	}
+	return strings.EqualFold(req.Key.Name, res.Key.Name)
+}
 
 type GarbageCollectionConfig struct {
 	Enabled          bool
@@ -829,6 +846,17 @@ func (k *kvStorageBackend) WriteEvent(ctx context.Context, event WriteEvent) (in
 			}
 
 			if err := k.dataStore.applyBackwardsCompatibleChanges(txnCtx, tx, event, dataKey); err != nil {
+				if apierrors.IsConflict(err) {
+					// Log conflict errors when creating resources to monitor potential
+					// case mismatches between the resource_history's `key_path` column and
+					// the resource table's `name` column.
+					k.log.Warn("conflict when creating resource",
+						"namespace", event.Key.Namespace,
+						"group", event.Key.Group,
+						"resource", event.Key.Resource,
+						"name", event.Key.Name,
+					)
+				}
 				return "", fmt.Errorf("failed to apply backwards compatible updates: %w", err)
 			}
 

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -850,11 +850,12 @@ func (k *kvStorageBackend) WriteEvent(ctx context.Context, event WriteEvent) (in
 					// Log conflict errors when creating resources to monitor potential
 					// case mismatches between the resource_history's `key_path` column and
 					// the resource table's `name` column.
-					k.log.Warn("conflict when creating resource",
+					k.log.Warn("conflict when applying compatibility changes",
 						"namespace", event.Key.Namespace,
 						"group", event.Key.Group,
 						"resource", event.Key.Resource,
 						"name", event.Key.Name,
+						"action", action,
 					)
 				}
 				return "", fmt.Errorf("failed to apply backwards compatible updates: %w", err)

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -847,7 +847,7 @@ func (k *kvStorageBackend) WriteEvent(ctx context.Context, event WriteEvent) (in
 
 			if err := k.dataStore.applyBackwardsCompatibleChanges(txnCtx, tx, event, dataKey); err != nil {
 				if apierrors.IsConflict(err) {
-					// Log conflict errors when creating resources to monitor potential
+					// Log conflict errors when applying compatibility changes to monitor potential
 					// case mismatches between the resource_history's `key_path` column and
 					// the resource table's `name` column.
 					k.log.Warn("conflict when applying compatibility changes",

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -953,30 +953,38 @@ func (b *backend) ReadResource(ctx context.Context, req *resourcepb.ReadRequest)
 
 	// TODO: validate key ?
 
-	if req.ResourceVersion > 0 {
-		return b.readHistory(ctx, req.Key, req.ResourceVersion)
-	}
-
-	readReq := &sqlResourceReadRequest{
-		SQLTemplate: sqltemplate.New(b.dialect),
-		Request:     req,
-		Response:    NewReadResponse(),
-	}
 	var res *resource.BackendReadResponse
-	err := b.db.WithTx(ctx, ReadCommittedRO, func(ctx context.Context, tx db.Tx) error {
-		var err error
-		res, err = dbutil.QueryRow(ctx, tx, sqlResourceRead, readReq)
-		return err
-	})
-
-	if errors.Is(err, sql.ErrNoRows) {
-		return &resource.BackendReadResponse{
-			Error: resource.NewNotFoundError(req.Key),
+	if req.ResourceVersion > 0 {
+		res = b.readHistory(ctx, req.Key, req.ResourceVersion)
+	} else {
+		readReq := &sqlResourceReadRequest{
+			SQLTemplate: sqltemplate.New(b.dialect),
+			Request:     req,
+			Response:    NewReadResponse(),
 		}
-	} else if err != nil {
-		return &resource.BackendReadResponse{Error: resource.AsErrorResult(err)}
+		err := b.db.WithTx(ctx, ReadCommittedRO, func(ctx context.Context, tx db.Tx) error {
+			var err error
+			res, err = dbutil.QueryRow(ctx, tx, sqlResourceRead, readReq)
+			return err
+		})
+
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+			res = &resource.BackendReadResponse{Error: resource.NewNotFoundError(req.Key)}
+		case err != nil:
+			res = &resource.BackendReadResponse{Error: resource.AsErrorResult(err)}
+		}
 	}
 
+	if resource.IsResourceNameMixedCase(req, res) {
+		b.log.Warn("resource name case mismatch in ReadResource",
+			"namespace", req.Key.Namespace,
+			"group", req.Key.Group,
+			"resource", req.Key.Resource,
+			"requested_name", req.Key.Name,
+			"stored_name", res.Key.Name,
+		)
+	}
 	return res
 }
 

--- a/pkg/storage/unified/testing/storage_backend_sql_compatibility.go
+++ b/pkg/storage/unified/testing/storage_backend_sql_compatibility.go
@@ -86,6 +86,7 @@ func RunSQLStorageBackendCompatibilityTest(t *testing.T, newSqlBackend NewBacken
 		{"last import time cross backend", runTestLastImportTimeCrossBackend},
 		{"cluster scoped resources compatibility", runTestClusterScopedResources},
 		{"cross backend rv list compatibility", runTestCrossBackendRVListCompatibility},
+		{"resource name case mismatch", runTestResourceNameCaseMismatch},
 	}
 
 	for _, tc := range cases {
@@ -2751,5 +2752,91 @@ func runTestCrossBackendRVListCompatibility(t *testing.T, sqlBackend, kvBackend 
 
 	t.Run("KV to SQL", func(t *testing.T) {
 		testCrossBackendList(t, kvServer, sqlServer, true, nsPrefix+"-rv-kv2sql")
+	})
+}
+
+// runTestResourceNameCaseMismatch verifies how the SQL and KV backends behave
+// when a resource is read with a name whose case differs from the stored name.
+// On MySQL the resource table's `name` column uses the default
+// (case-insensitive) collation, so a read against the SQL backend resolves the
+// row even when the case differs; the KV backend's key_path lookup is
+// case-sensitive on every supported database, so the same read against the KV
+// backend does not resolve. The test exercises [resource.IsResourceNameMixedCase]
+// against the actual backend responses in both directions.
+func runTestResourceNameCaseMismatch(t *testing.T, sqlBackend, kvBackend resource.StorageBackend, nsPrefix string, db sqldb.DB) {
+	ctx := newIntegrationTestContext(t)
+
+	// Servers are used for the writes (they handle validation and metadata
+	// plumbing); reads go directly through the backend so the response carries
+	// the stored ResourceKey that IsResourceNameMixedCase needs.
+	sqlServer := createStorageServer(t, sqlBackend)
+	kvServer := createStorageServer(t, kvBackend)
+
+	const (
+		storedName = "MixedCaseName"
+		readName   = "mixedcasename"
+	)
+
+	t.Run("Write KV, Read SQL with mixed case", func(t *testing.T) {
+		ns := nsPrefix + "-write-kv-read-sql"
+		createPlaylistResource(t, kvServer, ctx, PlaylistResourceOptions{
+			Name:       storedName,
+			Namespace:  ns,
+			UID:        "case-mismatch-kv",
+			Generation: 1,
+			Title:      "kv-stored",
+		})
+
+		req := &resourcepb.ReadRequest{Key: createPlaylistKey(ns, readName)}
+		resp := sqlBackend.ReadResource(ctx, req)
+		require.NotNil(t, resp)
+
+		if db.DriverName() == "mysql" {
+			require.Nil(t, resp.Error,
+				"MySQL is case-insensitive on the resource.name column; the row should resolve")
+			require.NotNil(t, resp.Key)
+			require.Equal(t, storedName, resp.Key.Name,
+				"stored name retains its original casing")
+			require.True(t, resource.IsResourceNameMixedCase(req, resp),
+				"helper should detect the case mismatch on a successful cross-case read")
+		} else {
+			require.NotNil(t, resp.Error,
+				"case-sensitive DB should not match across cases")
+			require.Equal(t, int32(http.StatusNotFound), resp.Error.Code)
+			require.False(t, resource.IsResourceNameMixedCase(req, resp),
+				"helper should not flag a mismatch when the read failed")
+		}
+	})
+
+	t.Run("Write SQL, Read KV with mixed case", func(t *testing.T) {
+		ns := nsPrefix + "-write-sql-read-kv"
+		createPlaylistResource(t, sqlServer, ctx, PlaylistResourceOptions{
+			Name:       storedName,
+			Namespace:  ns,
+			UID:        "case-mismatch-sql",
+			Generation: 1,
+			Title:      "sql-stored",
+		})
+
+		req := &resourcepb.ReadRequest{Key: createPlaylistKey(ns, readName)}
+		resp := kvBackend.ReadResource(ctx, req)
+		require.NotNil(t, resp)
+		// The KV backend looks resources up by key_path with binary
+		// (case-sensitive) comparison on every database, so a mixed-case read
+		// should not resolve regardless of the underlying engine.
+		require.NotNil(t, resp.Error,
+			"KV backend lookup is case-sensitive; mixed-case read should not resolve")
+		require.Equal(t, int32(http.StatusNotFound), resp.Error.Code)
+		require.False(t, resource.IsResourceNameMixedCase(req, resp),
+			"helper should not flag a mismatch when the read failed")
+
+		// Sanity check: reading with the original casing succeeds and the
+		// helper does not flag identical names.
+		matchingReq := &resourcepb.ReadRequest{Key: createPlaylistKey(ns, storedName)}
+		matchingResp := kvBackend.ReadResource(ctx, matchingReq)
+		require.NotNil(t, matchingResp)
+		require.Nil(t, matchingResp.Error)
+		require.False(t, resource.IsResourceNameMixedCase(matchingReq, matchingResp),
+			"helper should not flag identical names")
 	})
 }


### PR DESCRIPTION
Add some logging when a request to read a resource comes in specifying a resource name with different case than the one used when creating the resource in the first place.