### PR TITLE
Features: Implement OpenFeature provider proxy wrapper

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -693,6 +693,7 @@ i18next.config.ts @grafana/grafana-frontend-platform
 /packages/grafana-runtime/src/utils/userStorage* @grafana/plugins-platform-frontend @grafana/grafana-frontend-platform
 /packages/grafana-runtime/src/utils/useFavoriteDatasources* @grafana/plugins-platform-frontend
 /packages/grafana-runtime/src/utils/getCachedPromise* @grafana/grafana-frontend-platform
+/packages/grafana-runtime/src/utils/openfeature* @grafana/grafana-frontend-platform
 
 # @grafana/schema
 /packages/grafana-schema/ @grafana/grafana-app-platform-squad

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -695,6 +695,7 @@ i18next.config.ts @grafana/grafana-frontend-platform
 /packages/grafana-runtime/src/utils/userStorage* @grafana/grafana-catalog @grafana/grafana-frontend-platform
 /packages/grafana-runtime/src/utils/useFavoriteDatasources* @grafana/grafana-catalog
 /packages/grafana-runtime/src/utils/getCachedPromise* @grafana/grafana-frontend-platform
+/packages/grafana-runtime/src/utils/openfeature* @grafana/grafana-frontend-platform
 
 # @grafana/schema
 /packages/grafana-schema/ @grafana/grafana-app-platform-squad

--- a/packages/grafana-runtime/src/index.ts
+++ b/packages/grafana-runtime/src/index.ts
@@ -93,3 +93,4 @@ export {
   usePanelPluginVersion,
 } from './services/pluginMeta/hooks';
 export { getListedPanelPluginIds, getPanelPluginVersion, isPanelPluginInstalled } from './services/pluginMeta/panels';
+export { createGrafanaOFREPProvider } from './utils/openfeature';

--- a/packages/grafana-runtime/src/index.ts
+++ b/packages/grafana-runtime/src/index.ts
@@ -99,3 +99,4 @@ export {
 export { getListedPanelPluginIds, getPanelPluginVersion, isPanelPluginInstalled } from './services/pluginMeta/panels';
 export { isAppPluginEnabled } from './services/pluginSettings/settings';
 export { useAppPluginEnabled } from './services/pluginSettings/hooks';
+export { createOpenFeatureOFREPWebProvider, createOpenFeatureLocalStorageProvider } from './utils/openfeature';

--- a/packages/grafana-runtime/src/internal/openFeature/index.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/index.ts
@@ -6,6 +6,8 @@ import { type FeatureToggles } from '@grafana/data';
 import { config } from '../../config';
 import { logError } from '../../utils/logging';
 
+import { createProxyableProvider, type ProxyableProvider } from './proxy';
+
 // Ensure the module augmentation is pulled in
 import './openfeature-types.gen.d.ts';
 
@@ -37,20 +39,21 @@ export type FeatureFlagName = keyof FeatureToggles;
 // to ensure tests work correctly.
 export const GRAFANA_CORE_OPEN_FEATURE_DOMAIN = 'internal-grafana-core';
 
+// Allow internal direct access to the OFREP provider to expose a proxy to plugins.
+let ofrepWebProvider: ProxyableProvider<OFREPWebProvider> | undefined;
+export function getOFREPWebProvider() {
+  return (ofrepWebProvider ??= new (createProxyableProvider(OFREPWebProvider))({
+    baseUrl: `${config.appSubUrl || ''}/apis/features.grafana.app/v0alpha1/namespaces/${config.namespace}`,
+    pollInterval: -1, // disable polling
+    timeoutMs: 5_000,
+  }));
+}
+
 export async function initOpenFeature() {
   OpenFeature.addHandler(ProviderEvents.Ready, checkDefaultProvider);
   OpenFeature.addHandler(ProviderEvents.Error, checkDefaultProvider);
 
-  const subPath = config.appSubUrl || '';
-  const baseUrl = `${subPath}/apis/features.grafana.app/v0alpha1/namespaces/${config.namespace}`;
-
-  const ofProvider = new OFREPWebProvider({
-    baseUrl: baseUrl,
-    pollInterval: -1, // disable polling
-    timeoutMs: 5_000,
-  });
-
-  await OpenFeature.setProviderAndWait(GRAFANA_CORE_OPEN_FEATURE_DOMAIN, ofProvider, {
+  await OpenFeature.setProviderAndWait(GRAFANA_CORE_OPEN_FEATURE_DOMAIN, getOFREPWebProvider(), {
     targetingKey: config.namespace,
     ...config.openFeatureContext,
   });

--- a/packages/grafana-runtime/src/internal/openFeature/proxy.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/proxy.ts
@@ -1,0 +1,151 @@
+import {
+  ClientProviderEvents,
+  OpenFeatureEventEmitter,
+  type EvaluationContext,
+  type EventHandler,
+  type JsonValue,
+  type Logger,
+  type Provider,
+  type ProviderEmittableEvents,
+  type ResolutionDetails,
+} from '@openfeature/web-sdk';
+
+interface Proxyable {
+  initialize: Promise<void>;
+}
+
+type ProxyableProvider<T extends Provider = Provider> = T & { readonly proxyable: Proxyable };
+
+function createProxyableProvider<
+  T extends new (...args: any[]) => Provider, // eslint-disable-line @typescript-eslint/no-explicit-any
+>(ProviderClass: T): new (...args: ConstructorParameters<T>) => ProxyableProvider<InstanceType<T>>;
+function createProxyableProvider(ProviderClass: new (...args: unknown[]) => Provider) {
+  return class ProxyableProviderImpl extends ProviderClass implements ProxyableProvider {
+    private initializePromise: Promise<void>;
+    private initializeResolve!: () => void;
+    private initializeReject!: (err: unknown) => void;
+
+    constructor(...args: unknown[]) {
+      super(...args);
+
+      this.initializePromise = new Promise<void>((resolve, reject) => {
+        this.initializeResolve = resolve;
+        this.initializeReject = reject;
+      });
+    }
+
+    get proxyable(): Proxyable {
+      return {
+        initialize: this.initializePromise,
+      };
+    }
+
+    async initialize(): Promise<void> {
+      try {
+        await super.initialize?.();
+        this.initializeResolve();
+      } catch (err) {
+        this.initializeReject(err);
+        throw err;
+      }
+    }
+  };
+}
+
+class ProxyProvider implements Provider {
+  readonly runsOn = 'client';
+  readonly events = new OpenFeatureEventEmitter();
+
+  private readonly provider: ProxyableProvider;
+  private readonly cleanup: Array<() => void> = [];
+
+  constructor(provider: ProxyableProvider) {
+    this.provider = provider;
+    this.registerEventForwarding();
+  }
+
+  hooks = [];
+
+  get metadata() {
+    return {
+      name: `Proxy(${this.provider.metadata.name})`,
+    };
+  }
+
+  initialize(): Promise<void> {
+    return this.provider.proxyable.initialize;
+  }
+
+  resolveBooleanEvaluation(
+    flagKey: string,
+    defaultValue: boolean,
+    context: EvaluationContext,
+    logger: Logger
+  ): ResolutionDetails<boolean> {
+    return this.provider.resolveBooleanEvaluation(flagKey, defaultValue, context, logger);
+  }
+
+  resolveStringEvaluation(
+    flagKey: string,
+    defaultValue: string,
+    context: EvaluationContext,
+    logger: Logger
+  ): ResolutionDetails<string> {
+    return this.provider.resolveStringEvaluation(flagKey, defaultValue, context, logger);
+  }
+
+  resolveNumberEvaluation(
+    flagKey: string,
+    defaultValue: number,
+    context: EvaluationContext,
+    logger: Logger
+  ): ResolutionDetails<number> {
+    return this.provider.resolveNumberEvaluation(flagKey, defaultValue, context, logger);
+  }
+
+  resolveObjectEvaluation<T extends JsonValue>(
+    flagKey: string,
+    defaultValue: T,
+    context: EvaluationContext,
+    logger: Logger
+  ): ResolutionDetails<T> {
+    return this.provider.resolveObjectEvaluation(flagKey, defaultValue, context, logger);
+  }
+
+  onClose(): Promise<void> {
+    this.unregisterEventForwarding();
+    return Promise.resolve();
+  }
+
+  private registerEventForwarding() {
+    const events = [
+      ClientProviderEvents.Ready,
+      ClientProviderEvents.Error,
+      ClientProviderEvents.Stale,
+      ClientProviderEvents.ConfigurationChanged,
+      ClientProviderEvents.Reconciling,
+    ] as const satisfies ProviderEmittableEvents[];
+
+    // Do a compile-time check that we've got all the expected events
+    type Missing = Exclude<ProviderEmittableEvents, (typeof events)[number]>;
+    const missing: Missing extends never ? null : Missing = null;
+    void missing;
+
+    events.forEach((event) => {
+      const handler: EventHandler = (...args) => this.events.emit(event, ...args);
+      this.provider.events?.addHandler(event, handler);
+      this.cleanup.push(() => this.provider.events?.removeHandler(event, handler));
+    });
+  }
+
+  private unregisterEventForwarding() {
+    this.cleanup.forEach((fn) => fn());
+    this.cleanup.length = 0;
+  }
+}
+
+function createProxyProvider(provider: ProxyableProvider): Provider {
+  return new ProxyProvider(provider);
+}
+
+export { createProxyableProvider, createProxyProvider, type ProxyableProvider, type ProxyProvider };

--- a/packages/grafana-runtime/src/internal/openFeature/proxy.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/proxy.ts
@@ -1,0 +1,106 @@
+import {
+  ClientProviderEvents,
+  OpenFeatureEventEmitter,
+  type EvaluationContext,
+  type EventHandler,
+  type JsonValue,
+  type Logger,
+  type Provider,
+  type ProviderEmittableEvents,
+  type ResolutionDetails,
+} from '@openfeature/web-sdk';
+
+/**
+ * A proxy provider that provides a read-only view of an underlying provider.
+ *
+ * This is useful for plugins that want to use the same provider as Grafana without being able to modify its state or context.
+ */
+export class ProxyProvider implements Provider {
+  readonly runsOn = 'client';
+  readonly events = new OpenFeatureEventEmitter();
+
+  private readonly provider: Provider;
+  private readonly cleanup: Array<() => void> = [];
+
+  constructor(provider: Provider) {
+    this.provider = provider;
+    this.registerEventForwarding();
+  }
+
+  get metadata() {
+    return {
+      name: `Proxy(${this.provider.metadata.name})`,
+    };
+  }
+
+  // Should this wait for the underlying provider to initialize? For now, we don't do anything.
+  // In the context of Grafana, this should be fine, as Grafana blocks loading on initializing OpenFeature.
+  // Once https://github.com/open-feature/spec/pull/385 lands, there will be an event that we can forward.
+
+  resolveBooleanEvaluation(
+    flagKey: string,
+    defaultValue: boolean,
+    context: EvaluationContext,
+    logger: Logger
+  ): ResolutionDetails<boolean> {
+    return this.provider.resolveBooleanEvaluation(flagKey, defaultValue, context, logger);
+  }
+
+  resolveStringEvaluation(
+    flagKey: string,
+    defaultValue: string,
+    context: EvaluationContext,
+    logger: Logger
+  ): ResolutionDetails<string> {
+    return this.provider.resolveStringEvaluation(flagKey, defaultValue, context, logger);
+  }
+
+  resolveNumberEvaluation(
+    flagKey: string,
+    defaultValue: number,
+    context: EvaluationContext,
+    logger: Logger
+  ): ResolutionDetails<number> {
+    return this.provider.resolveNumberEvaluation(flagKey, defaultValue, context, logger);
+  }
+
+  resolveObjectEvaluation<T extends JsonValue>(
+    flagKey: string,
+    defaultValue: T,
+    context: EvaluationContext,
+    logger: Logger
+  ): ResolutionDetails<T> {
+    return this.provider.resolveObjectEvaluation(flagKey, defaultValue, context, logger);
+  }
+
+  onClose(): Promise<void> {
+    this.unregisterEventForwarding();
+    return Promise.resolve();
+  }
+
+  private registerEventForwarding() {
+    const events = [
+      ClientProviderEvents.Ready,
+      ClientProviderEvents.Error,
+      ClientProviderEvents.Stale,
+      ClientProviderEvents.ConfigurationChanged,
+      ClientProviderEvents.Reconciling,
+    ] as const satisfies ProviderEmittableEvents[];
+
+    // Do a compile-time check that we've got all the expected events
+    type Missing = Exclude<ProviderEmittableEvents, (typeof events)[number]>;
+    const missing: Missing extends never ? null : Missing = null;
+    void missing;
+
+    events.forEach((event) => {
+      const handler: EventHandler = (...args) => this.events.emit(event, ...args);
+      this.provider.events?.addHandler(event, handler);
+      this.cleanup.push(() => this.provider.events?.removeHandler(event, handler));
+    });
+  }
+
+  private unregisterEventForwarding() {
+    this.cleanup.forEach((fn) => fn());
+    this.cleanup.length = 0;
+  }
+}

--- a/packages/grafana-runtime/src/utils/openfeature.ts
+++ b/packages/grafana-runtime/src/utils/openfeature.ts
@@ -1,0 +1,11 @@
+import { getOFREPWebProvider } from '../internal/openFeature';
+import { createProxyProvider } from '../internal/openFeature/proxy';
+
+/**
+ * Create a new OpenFeature provider that proxies Grafana's own OFREP provider.
+ *
+ * Allows plugins to safely rely on the same OFREP evaluations as Grafana without sharing a mutable domain or provider instance.
+ */
+export function createGrafanaOFREPProvider() {
+  return createProxyProvider(getOFREPWebProvider());
+}

--- a/packages/grafana-runtime/src/utils/openfeature.ts
+++ b/packages/grafana-runtime/src/utils/openfeature.ts
@@ -1,0 +1,20 @@
+import { getLocalStorageProvider, getOFREPWebProvider } from '../internal/openFeature';
+import { ProxyProvider } from '../internal/openFeature/proxy';
+
+/**
+ * Create a new OpenFeature provider that proxies Grafana's own OFREP provider.
+ *
+ * Allows plugins to safely rely on the same OFREP evaluations as Grafana without sharing a mutable domain or provider instance.
+ */
+export function createOpenFeatureOFREPWebProvider() {
+  return new ProxyProvider(getOFREPWebProvider());
+}
+
+/**
+ * Create a new OpenFeature provider that proxies Grafana's own localStorage provider.
+ *
+ * Allows plugins to safely rely on the same localStorage overrides as Grafana without sharing a mutable domain or provider instance.
+ */
+export function createOpenFeatureLocalStorageProvider() {
+  return new ProxyProvider(getLocalStorageProvider());
+}


### PR DESCRIPTION
**What is this feature?**

Implements new `createOpenFeatureOFREPWebProvider` + `createOpenFeatureLocalStorageProvider` util methods that any plugin can consume, which expose the results of Grafana core's OFREP web + localStorage providers in a read-only manner, based on the [design doc for reducing OFREP requests on the frontend](https://docs.google.com/document/d/1Wwjh7kH4QvFz4zkPrDoH4aad9VAmTzKDApr6xI15C7Q/edit?usp=sharing) (🔐).

Demo of this working with a plugin: https://github.com/grafana/grafana-setupguide-app/pull/1232 (🔐)

**Why do we need this feature?**

As adoption of OpenFeature continues to grow across Grafana plugins, we're seeing an increasing number of duplicate OFREP requests. As very few plugins rely on a custom context, we want a way to share the OFREP evaluations that Grafana core is doing with those plugins.

Further, we now have a UI built into Grafana itself for frontend feature flag overrides (#123451), but this currently only controls flags for Grafana's UI and not the UI of any plugins, so it'd be great to be able to share this with plugins as well.

We can achieve this by using the same OpenFeature domain, or by sharing the same singleton provider, but both of these expose methods that can mutate OpenFeature to the plugins. As plugins can be external code, we instead want a safer method of exposing only read-only access, which is what this proxy wrapper achieves.

**Who is this feature for?**

Developers.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
