### PR TITLE
fix: normalize undefined and empty array in adHocVariableFiltersEqual

### DIFF
--- a/public/app/features/dashboard-scene/saving/getDashboardChanges.test.ts
+++ b/public/app/features/dashboard-scene/saving/getDashboardChanges.test.ts
@@ -50,23 +50,19 @@ describe('adHocVariableFiltersEqual', () => {
     ).toBeFalsy();
   });
 
-  describe('when filter property is undefined', () => {
-    afterAll(() => {
-      jest.clearAllMocks();
-    });
-
+  describe('when filter property is undefined or empty', () => {
     it('should compare two adhoc variables where both are missing the filter property and return true', () => {
-      const warnSpy = jest.spyOn(console, 'warn').mockImplementationOnce(() => {});
       expect(adHocVariableFiltersEqual(undefined, undefined)).toBeTruthy();
-
-      expect(warnSpy).toHaveBeenCalledWith('Adhoc variable filter property is undefined');
     });
 
-    it('should compare two adhoc variables where one is undefined and return false', () => {
-      const warnSpy = jest.spyOn(console, 'warn').mockImplementationOnce(() => {});
-      expect(adHocVariableFiltersEqual(undefined, [{ value: 'asdio', key: 'qwe', operator: 'wer' }])).toBeFalsy();
+    it('should compare undefined filters with empty array and return true', () => {
+      expect(adHocVariableFiltersEqual(undefined, [])).toBeTruthy();
+      expect(adHocVariableFiltersEqual([], undefined)).toBeTruthy();
+    });
 
-      expect(warnSpy).toHaveBeenCalledWith('Adhoc variable filter property is undefined');
+    it('should compare two adhoc variables where one is undefined and the other has filters and return false', () => {
+      expect(adHocVariableFiltersEqual(undefined, [{ value: 'asdio', key: 'qwe', operator: 'wer' }])).toBeFalsy();
+      expect(adHocVariableFiltersEqual([], [{ value: 'asdio', key: 'qwe', operator: 'wer' }])).toBeFalsy();
     });
   });
 });

--- a/public/app/features/dashboard-scene/saving/getDashboardChanges.ts
+++ b/public/app/features/dashboard-scene/saving/getDashboardChanges.ts
@@ -135,23 +135,16 @@ export function getHasTimeChanged(
 }
 
 export function adHocVariableFiltersEqual(filtersA?: AdHocFilterWithLabels[], filtersB?: AdHocFilterWithLabels[]) {
-  if (filtersA === undefined && filtersB === undefined) {
-    console.warn('Adhoc variable filter property is undefined');
-    return true;
-  }
+  const a = filtersA ?? [];
+  const b = filtersB ?? [];
 
-  if ((filtersA === undefined && filtersB !== undefined) || (filtersB === undefined && filtersA !== undefined)) {
-    console.warn('Adhoc variable filter property is undefined');
+  if (a.length !== b.length) {
     return false;
   }
 
-  if (filtersA?.length !== filtersB?.length) {
-    return false;
-  }
-
-  for (let i = 0; i < (filtersA?.length ?? 0); i++) {
-    const aFilter = filtersA?.[i];
-    const bFilter = filtersB?.[i];
+  for (let i = 0; i < a.length; i++) {
+    const aFilter = a[i];
+    const bFilter = b[i];
     if (aFilter?.key !== bFilter?.key || aFilter?.operator !== bFilter?.operator || aFilter?.value !== bFilter?.value) {
       return false;
     }


### PR DESCRIPTION
## Problem

Dashboards with ad-hoc filters could show unsaved changes even when nothing had changed. `adHocVariableFiltersEqual` treated `undefined` and `[]` as different.

## Solution

Normalize both filter lists with `?? []` before comparing length and filter fields.

Fixes https://github.com/grafana/grafana/issues/123960