### PR TITLE
Provisioning: Prevent bulk move to same folder

### DIFF
--- a/public/app/features/provisioning/components/BulkActions/BulkMoveProvisionedResource.tsx
+++ b/public/app/features/provisioning/components/BulkActions/BulkMoveProvisionedResource.tsx
@@ -30,7 +30,7 @@ import { RepoInvalidStateBanner } from '../Shared/RepoInvalidStateBanner';
 import { ResourceEditFormSharedFields } from '../Shared/ResourceEditFormSharedFields';
 
 import { type MoveJobSpec, useBulkActionJob } from './useBulkActionJob';
-import { type BulkActionFormData, type BulkActionProvisionResourceProps, getTargetFolderPathInRepo } from './utils';
+import { type BulkActionFormData, type BulkActionProvisionResourceProps, getTargetFolderPathInRepo, isSameFolderPath } from './utils';
 
 interface FormProps extends BulkActionProvisionResourceProps {
   initialValues: BulkActionFormData;
@@ -39,7 +39,7 @@ interface FormProps extends BulkActionProvisionResourceProps {
   folderPath?: string;
 }
 
-function FormContent({ initialValues, selectedItems, repository, canPushToConfiguredBranch, onDismiss }: FormProps) {
+function FormContent({ initialValues, selectedItems, repository, canPushToConfiguredBranch, folderPath, onDismiss }: FormProps) {
   // States
   const [job, setJob] = useState<Job>();
   const [jobError, setJobError] = useState<string | StatusInfo>();
@@ -82,6 +82,18 @@ function FormContent({ initialValues, selectedItems, repository, canPushToConfig
         message: t(
           'browse-dashboards.bulk-move-resources-form.error-no-target-folder-path',
           'Target folder path is invalid or empty, please select again.'
+        ),
+      });
+      setHasSubmitted(false);
+      return;
+    }
+
+    if (isSameFolderPath(folderPath, targetFolderPathInRepo)) {
+      setError('targetFolderUID', {
+        type: 'manual',
+        message: t(
+          'browse-dashboards.bulk-move-resources-form.error-already-in-target-folder',
+          'Selected resources are already in the target folder.'
         ),
       });
       setHasSubmitted(false);

--- a/public/app/features/provisioning/components/BulkActions/BulkMoveProvisionedResource.tsx
+++ b/public/app/features/provisioning/components/BulkActions/BulkMoveProvisionedResource.tsx
@@ -30,7 +30,12 @@ import { RepoInvalidStateBanner } from '../Shared/RepoInvalidStateBanner';
 import { ResourceEditFormSharedFields } from '../Shared/ResourceEditFormSharedFields';
 
 import { type MoveJobSpec, useBulkActionJob } from './useBulkActionJob';
-import { type BulkActionFormData, type BulkActionProvisionResourceProps, getTargetFolderPathInRepo, isSameFolderPath } from './utils';
+import {
+  type BulkActionFormData,
+  type BulkActionProvisionResourceProps,
+  getTargetFolderPathInRepo,
+  isSameFolderPath,
+} from './utils';
 
 interface FormProps extends BulkActionProvisionResourceProps {
   initialValues: BulkActionFormData;
@@ -39,7 +44,14 @@ interface FormProps extends BulkActionProvisionResourceProps {
   folderPath?: string;
 }
 
-function FormContent({ initialValues, selectedItems, repository, canPushToConfiguredBranch, folderPath, onDismiss }: FormProps) {
+function FormContent({
+  initialValues,
+  selectedItems,
+  repository,
+  canPushToConfiguredBranch,
+  folderPath,
+  onDismiss,
+}: FormProps) {
   // States
   const [job, setJob] = useState<Job>();
   const [jobError, setJobError] = useState<string | StatusInfo>();

--- a/public/app/features/provisioning/components/BulkActions/utils.test.ts
+++ b/public/app/features/provisioning/components/BulkActions/utils.test.ts
@@ -1,6 +1,11 @@
 import { AnnoKeySourcePath } from 'app/features/apiserver/types';
 
-import { getTargetFolderPathInRepo, getNestedFolderPath, getResourceTargetPath, isResourceAlreadyInTarget } from './utils';
+import {
+  getTargetFolderPathInRepo,
+  getNestedFolderPath,
+  getResourceTargetPath,
+  isResourceAlreadyInTarget,
+} from './utils';
 
 const MOCK_FOLDER = {
   metadata: { annotations: { [AnnoKeySourcePath]: 'path/to/folder' } },

--- a/public/app/features/provisioning/components/BulkActions/utils.test.ts
+++ b/public/app/features/provisioning/components/BulkActions/utils.test.ts
@@ -1,6 +1,6 @@
 import { AnnoKeySourcePath } from 'app/features/apiserver/types';
 
-import { getTargetFolderPathInRepo, getNestedFolderPath, getResourceTargetPath } from './utils';
+import { getTargetFolderPathInRepo, getNestedFolderPath, getResourceTargetPath, isResourceAlreadyInTarget } from './utils';
 
 const MOCK_FOLDER = {
   metadata: { annotations: { [AnnoKeySourcePath]: 'path/to/folder' } },
@@ -92,5 +92,15 @@ describe('getResourceTargetPath', () => {
 
   it('should throw for invalid path', () => {
     expect(() => getResourceTargetPath('/', 'new/path')).toThrow('Invalid path');
+  });
+});
+
+describe('isResourceAlreadyInTarget', () => {
+  it('returns true when the computed target path matches the current resource path', () => {
+    expect(isResourceAlreadyInTarget('test/dashboard.json', 'test/')).toBe(true);
+  });
+
+  it('returns false when the resource would move to a different path', () => {
+    expect(isResourceAlreadyInTarget('test/dashboard.json', 'test2/')).toBe(false);
   });
 });

--- a/public/app/features/provisioning/components/BulkActions/utils.ts
+++ b/public/app/features/provisioning/components/BulkActions/utils.ts
@@ -94,3 +94,15 @@ export function getResourceTargetPath(currentPath: string, targetFolderPath: str
   const basePath = joinPath(targetFolderPath, filename);
   return isFolder ? `${basePath}/` : basePath;
 }
+
+function normalizeRepoPath(path: string): string {
+  return path.replace(/^\/+/, '').replace(/\/+$/, '');
+}
+
+export function isResourceAlreadyInTarget(currentPath: string, targetFolderPath: string): boolean {
+  return normalizeRepoPath(currentPath) === normalizeRepoPath(getResourceTargetPath(currentPath, targetFolderPath));
+}
+
+export function isSameFolderPath(currentFolderPath: string | undefined, targetFolderPath: string): boolean {
+  return normalizeRepoPath(currentFolderPath || '') === normalizeRepoPath(targetFolderPath);
+}

--- a/public/app/features/provisioning/components/Dashboards/MoveProvisionedDashboardForm.test.tsx
+++ b/public/app/features/provisioning/components/Dashboards/MoveProvisionedDashboardForm.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import { AppEvents } from '@grafana/data';
 import { getAppEvents } from '@grafana/runtime';
 import { useGetFolderQuery } from 'app/api/clients/folder/v1beta1';
 import {
@@ -61,6 +62,9 @@ function setup(props: Partial<Props> = {}) {
     }),
     state: {
       title: 'Test Dashboard',
+      meta: {
+        uid: 'dashboard-uid',
+      },
     },
   } as unknown as DashboardScene;
 
@@ -239,5 +243,33 @@ describe('MoveProvisionedDashboardForm', () => {
     await user.click(cancelButton);
 
     expect(props.onDismiss).toHaveBeenCalled();
+  });
+
+  it('does not submit a move job when the dashboard is already at the target path', async () => {
+    const createJob = jest.fn();
+    (useCreateRepositoryJobsMutation as jest.Mock).mockReturnValue([createJob, mockCreateRequest]);
+    (useGetFolderQuery as jest.Mock).mockReturnValue({
+      data: {
+        metadata: {
+          annotations: {
+            [AnnoKeySourcePath]: 'folder1',
+          },
+        },
+      },
+      isLoading: false,
+    });
+
+    const { user } = setup();
+
+    await user.click(screen.getByRole('button', { name: /move dashboard/i }));
+
+    expect(createJob).not.toHaveBeenCalled();
+    expect(getAppEvents().publish).toHaveBeenCalledWith({
+      type: AppEvents.alertError.name,
+      payload: [
+        'Failed to move dashboard',
+        'Dashboard is already in the selected folder.',
+      ],
+    });
   });
 });

--- a/public/app/features/provisioning/components/Dashboards/MoveProvisionedDashboardForm.test.tsx
+++ b/public/app/features/provisioning/components/Dashboards/MoveProvisionedDashboardForm.test.tsx
@@ -266,10 +266,7 @@ describe('MoveProvisionedDashboardForm', () => {
     expect(createJob).not.toHaveBeenCalled();
     expect(getAppEvents().publish).toHaveBeenCalledWith({
       type: AppEvents.alertError.name,
-      payload: [
-        'Failed to move dashboard',
-        'Dashboard is already in the selected folder.',
-      ],
+      payload: ['Failed to move dashboard', 'Dashboard is already in the selected folder.'],
     });
   });
 });

--- a/public/app/features/provisioning/components/Dashboards/MoveProvisionedDashboardForm.tsx
+++ b/public/app/features/provisioning/components/Dashboards/MoveProvisionedDashboardForm.tsx
@@ -126,7 +126,12 @@ export function MoveProvisionedDashboardForm({
 
     const currentSourcePath = currentFileData?.resource?.dryRun?.metadata?.annotations?.[AnnoKeySourcePath];
     if (currentSourcePath && isResourceAlreadyInTarget(currentSourcePath, targetFolderPath)) {
-      showError(t('dashboard-scene.move-provisioned-dashboard-form.already-in-folder', 'Dashboard is already in the selected folder.'));
+      showError(
+        t(
+          'dashboard-scene.move-provisioned-dashboard-form.already-in-folder',
+          'Dashboard is already in the selected folder.'
+        )
+      );
       return;
     }
 

--- a/public/app/features/provisioning/components/Dashboards/MoveProvisionedDashboardForm.tsx
+++ b/public/app/features/provisioning/components/Dashboards/MoveProvisionedDashboardForm.tsx
@@ -25,7 +25,7 @@ import { type StatusInfo } from '../../types';
 import { type ProvisionedDashboardFormData } from '../../types/form';
 import { buildResourceBranchRedirectUrl } from '../../utils/redirect';
 import { useBulkActionJob } from '../BulkActions/useBulkActionJob';
-import { getTargetFolderPathInRepo } from '../BulkActions/utils';
+import { getTargetFolderPathInRepo, isResourceAlreadyInTarget } from '../BulkActions/utils';
 import { ResourceEditFormSharedFields } from '../Shared/ResourceEditFormSharedFields';
 import { joinPath } from '../utils/path';
 
@@ -121,6 +121,12 @@ export function MoveProvisionedDashboardForm({
 
     if (!targetFolderPath) {
       showError();
+      return;
+    }
+
+    const currentSourcePath = currentFileData?.resource?.dryRun?.metadata?.annotations?.[AnnoKeySourcePath];
+    if (currentSourcePath && isResourceAlreadyInTarget(currentSourcePath, targetFolderPath)) {
+      showError(t('dashboard-scene.move-provisioned-dashboard-form.already-in-folder', 'Dashboard is already in the selected folder.'));
       return;
     }
 

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -4322,6 +4322,7 @@
         "repository-not-found-message": "The repository for the selected folder could not be found. Please ensure that the folder is provisioned correctly.",
         "repository-not-found-title": "Repository not found"
       },
+      "error-already-in-target-folder": "Selected resources are already in the target folder.",
       "error-moving-resources": "Error moving resources",
       "error-no-target-folder-path": "Target folder path is invalid or empty, please select again.",
       "move-total": "In total, this will affect:",
@@ -7313,6 +7314,7 @@
       "terraform": "Managed by: Terraform"
     },
     "move-provisioned-dashboard-form": {
+      "already-in-folder": "Dashboard is already in the selected folder.",
       "api-error": "Failed to move dashboard",
       "cancel-action": "Cancel",
       "current-file-not-found": "Current dashboard file could not be found",


### PR DESCRIPTION
This PR prevents users from bulk moving dashboards to the same git sync folder, as we do not want to trigger a job for that.

<img width="664" height="108" alt="Screenshot 2026-05-01 at 2 25 10 PM" src="https://github.com/user-attachments/assets/823f37dd-b52c-455d-8a2d-57260b78aa6b" />
