### PR TITLE
Provisioning: Skip move if the path is the same

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/move/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/move/worker.go
@@ -162,6 +162,15 @@ func (w *Worker) moveFiles(ctx context.Context, rw repository.ReaderWriter, prog
 		// Construct the target path by combining the job's target path with the file/folder name
 		targetPath := w.constructTargetPath(opts.TargetPath, path)
 
+		if path == targetPath {
+			progress.SetMessage(ctx, "Skipping "+path+" because it is already in "+opts.TargetPath)
+			progress.Record(ctx, jobs.NewPathOnlyResult(path).WithAction(repository.FileActionIgnored).Build())
+			if err := progress.TooManyErrors(); err != nil {
+				return err
+			}
+			continue
+		}
+
 		progress.SetMessage(ctx, "Moving "+path+" to "+targetPath)
 		if err := rw.Move(ctx, path, targetPath, opts.Ref, "Move "+path+" to "+targetPath); err != nil {
 			resultBuilder.WithError(fmt.Errorf("moving file %s to %s: %w", path, targetPath, err))

--- a/pkg/registry/apis/provisioning/jobs/move/worker_test.go
+++ b/pkg/registry/apis/provisioning/jobs/move/worker_test.go
@@ -230,6 +230,44 @@ func TestMoveWorker_ProcessMoveFilesSuccess(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestMoveWorker_ProcessMoveFilesSkipsSameSourceAndTarget(t *testing.T) {
+	job := provisioning.Job{
+		Spec: provisioning.JobSpec{
+			Action: provisioning.JobActionMove,
+			Move: &provisioning.MoveJobOptions{
+				Paths:      []string{"test/dashboard.json"},
+				TargetPath: "test/",
+				Ref:        "main",
+			},
+		},
+	}
+
+	mockRepo := &mockReaderWriter{
+		MockRepository: repository.NewMockRepository(t),
+	}
+	mockProgress := jobs.NewMockJobProgressRecorder(t)
+	mockWrapFn := repository.NewMockWrapWithStageFn(t)
+
+	mockWrapFn.On("Execute", mock.Anything, mockRepo, mock.Anything, mock.Anything).Return(func(ctx context.Context, repo repository.Repository, stageOptions repository.StageOptions, fn func(repository.Repository, bool) error) error {
+		return fn(mockRepo, false)
+	})
+
+	mockProgress.On("SetTotal", mock.Anything, 1).Return()
+	mockProgress.On("StrictMaxErrors", 1).Return()
+	mockProgress.On("SetMessage", mock.Anything, "Skipping test/dashboard.json because it is already in test/").Return()
+	mockProgress.On("TooManyErrors").Return(nil)
+	mockProgress.On("Complete", mock.Anything, mock.Anything).Return(provisioning.JobStatus{})
+
+	mockProgress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
+		return result.Path() == "test/dashboard.json" && result.Action() == repository.FileActionIgnored && result.Error() == nil
+	})).Return()
+
+	worker := NewWorker(nil, mockWrapFn.Execute, nil, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
+	err := worker.Process(context.Background(), mockRepo, job, mockProgress)
+	require.NoError(t, err)
+	mockRepo.AssertNotCalled(t, "Move", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+}
+
 func TestMoveWorker_ProcessMoveFilesWithError(t *testing.T) {
 	job := provisioning.Job{
 		Spec: provisioning.JobSpec{


### PR DESCRIPTION
Backend counterpart to https://github.com/grafana/grafana/pull/123978

If run without the frontend piece, you can still trigger the job, and then you'll see the log:
```
vers=3 driver_id=0 logger=job-driver job=repository-bf45b53-move namespace=default repository=repository-bf45b53 action=move connection= repositoryType=github options="&{bulk-move/2026-05-01-ews1z [] grafana/ [{7f1abdb3-be62-44b6-a274-28c086b148ec Dashboard dashboard.grafana.app} {ddf0ebq1lbjxmoc Dashboard dashboard.grafana.app}]}" message="Skipping grafana/not-git-sync.json because it is already in grafana/"
```