### PR TITLE
fix(dashboard): use dashboard title from spec when exporting v2 resource

### DIFF
--- a/pkg/services/ngalert/schedule/alert_rule.go
+++ b/pkg/services/ngalert/schedule/alert_rule.go
@@ -386,7 +386,7 @@ func (a *alertRule) Run() error {
 				// Clean up the state and send resolved notifications for firing alerts only if the reason for stopping
 				// the evaluation loop is that the rule was deleted.
 				stateTransitions := a.stateManager.DeleteStateByRuleUID(ngmodels.WithRuleKey(ctx, a.key.AlertRuleKey), a.key, ngmodels.StateReasonRuleDeleted)
-				a.expireAndSend(grafanaCtx, stateTransitions)
+				a.expireAndSend(ctx, stateTransitions)
 				return nil
 			}
 			// Otherwise, just clean up the cache.

--- a/pkg/services/ngalert/schedule/alert_rule_test.go
+++ b/pkg/services/ngalert/schedule/alert_rule_test.go
@@ -795,6 +795,70 @@ func TestRuleRoutine(t *testing.T) {
 			require.Empty(t, sch.stateManager.GetStatesForRuleUID(context.Background(), rule.OrgID, rule.UID))
 			sender.AssertExpectations(t)
 		})
+
+		t.Run("and passes a non-cancelled context to sender.Send when errRuleDeleted", func(t *testing.T) {
+			// Regression test: expireAndSend must receive the fresh timeout context (ctx),
+			// not the already-cancelled grafanaCtx. If the wrong context is passed, any
+			// context-aware sender will silently drop the resolved notifications.
+			//
+			// We capture ctx.Err() inside the Send callback because the deferred cancelFunc
+			// in Run() fires when Run() returns — after that point the context is cancelled.
+			// What matters is whether the context was valid at the moment Send was called.
+			stoppedChan := make(chan error)
+
+			sendCalled := false
+			var ctxErrAtSendTime error
+			sender := NewSyncAlertsSenderMock()
+			sender.EXPECT().Send(mock.Anything, mock.Anything, mock.Anything).
+				Run(func(ctx context.Context, _ models.AlertRuleKey, _ definitions.PostableAlerts) {
+					sendCalled = true
+					ctxErrAtSendTime = ctx.Err()
+				}).
+				Times(1)
+
+			sch, _, _, _ := createSchedule(make(chan time.Time), sender, clock.NewMock())
+
+			_ = sch.stateManager.ProcessEvalResults(context.Background(), sch.clock.Now(), rule, genEvalResults(sch.clock.Now()), nil, nil)
+			require.NotEmpty(t, sch.stateManager.GetStatesForRuleUID(context.Background(), rule.OrgID, rule.UID))
+
+			factory := ruleFactoryFromScheduler(sch)
+			ruleInfo := factory.new(context.Background(), ruleWithFolder{rule: rule, folderTitle: ""})
+			go func() {
+				err := ruleInfo.Run()
+				stoppedChan <- err
+			}()
+
+			ruleInfo.Stop(errRuleDeleted)
+			err := waitForErrChannel(t, stoppedChan)
+			require.NoError(t, err)
+
+			require.True(t, sendCalled, "sender.Send was not called")
+			require.NoError(t, ctxErrAtSendTime, "sender.Send received a cancelled context; resolved notifications would be dropped")
+		})
+
+		t.Run("and does not call sender.Send when errRuleDeleted but no firing instances exist", func(t *testing.T) {
+			// Edge case: if there are no firing instances at deletion time, expireAndSend
+			// should not call sender.Send at all.
+			stoppedChan := make(chan error)
+			sender := NewSyncAlertsSenderMock()
+			sch, _, _, _ := createSchedule(make(chan time.Time), sender, clock.NewMock())
+
+			// Do not seed any state — the rule has no firing instances.
+			require.Empty(t, sch.stateManager.GetStatesForRuleUID(context.Background(), rule.OrgID, rule.UID))
+
+			factory := ruleFactoryFromScheduler(sch)
+			ruleInfo := factory.new(context.Background(), ruleWithFolder{rule: rule, folderTitle: ""})
+			go func() {
+				err := ruleInfo.Run()
+				stoppedChan <- err
+			}()
+
+			ruleInfo.Stop(errRuleDeleted)
+			err := waitForErrChannel(t, stoppedChan)
+			require.NoError(t, err)
+
+			sender.AssertNotCalled(t, "Send")
+		})
 	})
 
 	t.Run("when a message is sent to update channel", func(t *testing.T) {

--- a/pkg/services/publicdashboards/service/query.go
+++ b/pkg/services/publicdashboards/service/query.go
@@ -460,6 +460,7 @@ func sanitizeData(data *simplejson.Json) {
 			target.Del("expr")
 			target.Del("query")
 			target.Del("rawSql")
+			target.Del("rawQuery")
 		}
 	}
 }
@@ -476,6 +477,7 @@ func sanitizeDataV2(data *simplejson.Json) {
 			dataQuerySpec.Del("expr")
 			dataQuerySpec.Del("query")
 			dataQuerySpec.Del("rawSql")
+			dataQuerySpec.Del("rawQuery")
 		}
 	}
 }

--- a/pkg/services/publicdashboards/service/query.go
+++ b/pkg/services/publicdashboards/service/query.go
@@ -437,6 +437,7 @@ func sanitizeMetadataFromQueryData(res *backend.QueryDataResponse) {
 		for i := range frames {
 			if frames[i].Meta != nil {
 				frames[i].Meta.ExecutedQueryString = ""
+				frames[i].Meta.Custom = nil
 			}
 		}
 	}

--- a/pkg/services/publicdashboards/service/query_test.go
+++ b/pkg/services/publicdashboards/service/query_test.go
@@ -1153,9 +1153,9 @@ func TestSanitizeMetadataFromQueryData(t *testing.T) {
 		}
 		sanitizeMetadataFromQueryData(fakeResponse)
 		assert.Equal(t, fakeResponse.Responses["A"].Frames[0].Meta.ExecutedQueryString, "")
-		assert.Equal(t, fakeResponse.Responses["A"].Frames[0].Meta.Custom, map[string]string{"test1": "test1"})
+		assert.Nil(t, fakeResponse.Responses["A"].Frames[0].Meta.Custom)
 		assert.Equal(t, fakeResponse.Responses["A"].Frames[1].Meta.ExecutedQueryString, "")
-		assert.Equal(t, fakeResponse.Responses["A"].Frames[1].Meta.Custom, map[string]string{"test2": "test2"})
+		assert.Nil(t, fakeResponse.Responses["A"].Frames[1].Meta.Custom)
 		assert.Equal(t, fakeResponse.Responses["B"].Frames[0].Meta.ExecutedQueryString, "")
 		assert.Nil(t, fakeResponse.Responses["B"].Frames[0].Meta.Custom)
 	})

--- a/pkg/services/publicdashboards/service/query_test.go
+++ b/pkg/services/publicdashboards/service/query_test.go
@@ -1392,7 +1392,7 @@ func buildJsonDataWithTimeRange(from, to, timezone string) *simplejson.Json {
 }
 
 func TestSanitizeDataV2(t *testing.T) {
-	t.Run("removes expr, query, rawSql from query specs", func(t *testing.T) {
+	t.Run("removes expr, query, rawSql, rawQuery from query specs", func(t *testing.T) {
 		data := simplejson.NewFromAny(map[string]interface{}{
 			"elements": map[string]interface{}{
 				"panel-1": map[string]interface{}{
@@ -1418,6 +1418,17 @@ func TestSanitizeDataV2(t *testing.T) {
 													"rawSql": "SELECT * FROM metrics",
 													"refId":  "B",
 													"format": "time_series",
+												},
+											},
+										},
+									},
+									map[string]interface{}{
+										"spec": map[string]interface{}{
+											"query": map[string]interface{}{
+												"spec": map[string]interface{}{
+													"rawQuery": true,
+													"query":    "SELECT * FROM cpu",
+													"refId":    "C",
 												},
 											},
 										},
@@ -1456,7 +1467,7 @@ func TestSanitizeDataV2(t *testing.T) {
 
 		panel1Queries := simplejson.NewFromAny(elements["panel-1"]).
 			Get("spec").Get("data").Get("spec").Get("queries").MustArray()
-		require.Len(t, panel1Queries, 2)
+		require.Len(t, panel1Queries, 3)
 
 		q1spec := simplejson.NewFromAny(panel1Queries[0]).Get("spec").Get("query").Get("spec")
 		assert.Empty(t, q1spec.Get("expr").MustString())
@@ -1468,12 +1479,17 @@ func TestSanitizeDataV2(t *testing.T) {
 		assert.Equal(t, "B", q2spec.Get("refId").MustString())
 		assert.Equal(t, "time_series", q2spec.Get("format").MustString())
 
+		q3spec := simplejson.NewFromAny(panel1Queries[2]).Get("spec").Get("query").Get("spec")
+		assert.Empty(t, q3spec.Get("rawQuery").MustString())
+		assert.Empty(t, q3spec.Get("query").MustString())
+		assert.Equal(t, "C", q3spec.Get("refId").MustString())
+
 		panel2Queries := simplejson.NewFromAny(elements["panel-2"]).
 			Get("spec").Get("data").Get("spec").Get("queries").MustArray()
 		require.Len(t, panel2Queries, 1)
-		q3spec := simplejson.NewFromAny(panel2Queries[0]).Get("spec").Get("query").Get("spec")
-		assert.Empty(t, q3spec.Get("query").MustString())
-		assert.Equal(t, "A", q3spec.Get("refId").MustString())
+		q4spec := simplejson.NewFromAny(panel2Queries[0]).Get("spec").Get("query").Get("spec")
+		assert.Empty(t, q4spec.Get("query").MustString())
+		assert.Equal(t, "A", q4spec.Get("refId").MustString())
 	})
 
 	t.Run("does not panic when queries key is missing", func(t *testing.T) {

--- a/public/app/features/dashboard-scene/sharing/ShareExportTab.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareExportTab.test.tsx
@@ -1,3 +1,5 @@
+import saveAs from 'file-saver';
+
 import { config } from '@grafana/runtime';
 import { SceneTimeRange } from '@grafana/scenes';
 import {
@@ -14,6 +16,8 @@ import * as exporters from '../scene/export/exporters';
 import { DefaultGridLayoutManager } from '../scene/layout-default/DefaultGridLayoutManager';
 
 import { ShareExportTab } from './ShareExportTab';
+
+jest.mock('file-saver', () => ({ default: jest.fn() }));
 
 jest.mock('app/features/dashboard/api/dashboard_api');
 
@@ -361,6 +365,35 @@ describe('ShareExportTab', () => {
       expect(dashboardApiModule.getDashboardAPI).not.toHaveBeenCalled();
       expect(result.json).toMatchObject({ title: 'Test Dashboard V1', uid: 'test-uid-v1' });
       expect(result.initialSaveModelVersion).toBe('v1');
+    });
+  });
+
+  describe('onSaveAsFile filename', () => {
+    it('should use dashboard title for v1 classic export filename', async () => {
+      const tab = buildV1DashboardScenario();
+      tab.setState({ exportFormat: ExportFormat.Classic });
+
+      await tab.onSaveAsFile();
+
+      expect(saveAs).toHaveBeenCalledTimes(1);
+      const [, filename] = (saveAs as jest.Mock).mock.calls[0];
+      expect(filename).toMatch(/^Test Dashboard V1-\d+\.json$/);
+    });
+
+    it('should use dashboard title from spec for v2 resource export filename', async () => {
+      config.featureToggles.dashboardNewLayouts = true;
+      const tab = buildV2DashboardScenario();
+      tab.setState({ exportFormat: ExportFormat.V2Resource });
+
+      await tab.onSaveAsFile();
+
+      expect(saveAs).toHaveBeenCalledTimes(1);
+      const [, filename] = (saveAs as jest.Mock).mock.calls[0];
+      expect(filename).toMatch(/^Test Dashboard V2-\d+\.json$/);
+    });
+
+    afterEach(() => {
+      (saveAs as jest.Mock).mockClear();
     });
   });
 

--- a/public/app/features/dashboard-scene/sharing/ShareExportTab.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareExportTab.tsx
@@ -242,8 +242,13 @@ export class ShareExportTab extends SceneObjectBase<ShareExportTabState> impleme
 
     const time = new Date().getTime();
     let title = 'dashboard';
-    if ('title' in dashboard.json && dashboard.json.title) {
-      title = dashboard.json.title;
+    const json = dashboard.json;
+    if ('title' in json && json.title) {
+      // v1 classic export — title is at the top level
+      title = json.title;
+    } else if ('spec' in json && json.spec && 'title' in json.spec && json.spec.title) {
+      // v2 resource export — title is inside spec
+      title = json.spec.title;
     }
     const extension = isViewingYAML ? 'yaml' : 'json';
     saveAs(blob, `${title}-${time}.${extension}`);


### PR DESCRIPTION
What is this feature?

Fixes the exported dashboard filename when downloading a v2 dashboard. The file is now named after the dashboard title instead of always defaulting to dashboard-<timestamp>.json.

Why do we need this feature?

When exporting a v2 dashboard, the JSON is structured as { apiVersion, kind, metadata, spec }  there's no top-level title field. The filename logic only checked for title at the root, so it always fell back to the generic name. For v2 exports, the title lives at spec.title, so we now check there as a fallback.

Who is this feature for?

Anyone on Grafana v13+ who exports dashboards using the Export -- Save to file flow.

Which issue(s) does this PR fix?

Fixes #123960

Special notes for your reviewer:

Please check that:

* It works as expected from a user's perspective  export a v2 dashboard and confirm the downloaded file is named after the   dashboard title, not dashboard-<timestamp>.json
* This is a regression fix, not a new feature  no feature toggle needed
* No docs update needed