### PR TITLE
Dashboards: fix exported filename for v2 dashboards

### DIFF
--- a/public/app/features/dashboard-scene/sharing/ShareExportTab.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareExportTab.test.tsx
@@ -1,3 +1,5 @@
+import saveAs from 'file-saver';
+
 import { config } from '@grafana/runtime';
 import { SceneTimeRange } from '@grafana/scenes';
 import {
@@ -14,6 +16,8 @@ import * as exporters from '../scene/export/exporters';
 import { DefaultGridLayoutManager } from '../scene/layout-default/DefaultGridLayoutManager';
 
 import { ShareExportTab } from './ShareExportTab';
+
+jest.mock('file-saver', () => ({ default: jest.fn() }));
 
 jest.mock('app/features/dashboard/api/dashboard_api');
 
@@ -361,6 +365,35 @@ describe('ShareExportTab', () => {
       expect(dashboardApiModule.getDashboardAPI).not.toHaveBeenCalled();
       expect(result.json).toMatchObject({ title: 'Test Dashboard V1', uid: 'test-uid-v1' });
       expect(result.initialSaveModelVersion).toBe('v1');
+    });
+  });
+
+  describe('onSaveAsFile filename', () => {
+    it('should use dashboard title for v1 classic export filename', async () => {
+      const tab = buildV1DashboardScenario();
+      tab.setState({ exportFormat: ExportFormat.Classic });
+
+      await tab.onSaveAsFile();
+
+      expect(saveAs).toHaveBeenCalledTimes(1);
+      const [, filename] = (saveAs as jest.Mock).mock.calls[0];
+      expect(filename).toMatch(/^Test Dashboard V1-\d+\.json$/);
+    });
+
+    it('should use dashboard title from spec for v2 resource export filename', async () => {
+      config.featureToggles.dashboardNewLayouts = true;
+      const tab = buildV2DashboardScenario();
+      tab.setState({ exportFormat: ExportFormat.V2Resource });
+
+      await tab.onSaveAsFile();
+
+      expect(saveAs).toHaveBeenCalledTimes(1);
+      const [, filename] = (saveAs as jest.Mock).mock.calls[0];
+      expect(filename).toMatch(/^Test Dashboard V2-\d+\.json$/);
+    });
+
+    afterEach(() => {
+      (saveAs as jest.Mock).mockClear();
     });
   });
 

--- a/public/app/features/dashboard-scene/sharing/ShareExportTab.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareExportTab.tsx
@@ -242,8 +242,13 @@ export class ShareExportTab extends SceneObjectBase<ShareExportTabState> impleme
 
     const time = new Date().getTime();
     let title = 'dashboard';
-    if ('title' in dashboard.json && dashboard.json.title) {
-      title = dashboard.json.title;
+    const json = dashboard.json;
+    if ('title' in json && json.title) {
+      // v1 classic export — title is at the top level
+      title = json.title;
+    } else if ('spec' in json && json.spec && 'title' in json.spec && json.spec.title) {
+      // v2 resource export — title is inside spec
+      title = json.spec.title;
     }
     const extension = isViewingYAML ? 'yaml' : 'json';
     saveAs(blob, `${title}-${time}.${extension}`);


### PR DESCRIPTION
**What is this feature?**

Fixes the exported dashboard filename when downloading a v2 dashboard. The file is now named after the dashboard title instead of always defaulting to `dashboard-<timestamp>.json`.

**Why do we need this feature?**

When exporting a v2 dashboard, the JSON is structured as `{ apiVersion, kind, metadata, spec }` —there's no top-level `title` field. The filename logic only checked for `title` at the root, so it always fell back to the generic name. For v2 exports, the title lives at `spec.title`, so we now check there as a fallback.

**Who is this feature for?**

Anyone on Grafana v13+ who exports dashboards using the Export → Save to file flow.

**Which issue(s) does this PR fix?**

Fixes #123961

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective  export a v2 dashboard and confirm the downloaded file is named after the dashboard title, not `dashboard-<timestamp>.json`
- [x] This is a regression fix, not a new feature  no feature toggle needed
- [x] No docs update needed
