### PR TITLE
Table: Fix width bi-directional updates for nested tables

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -175,6 +175,7 @@ export function TableNG(props: TableNGProps) {
   );
 
   const resizeHandler = useColumnResize(onColumnResize);
+  const nestedResizeHandler = useColumnResize(onColumnResize, 'nested');
 
   const hasNestedFrames = useMemo(() => getIsNestedTable(data.fields), [data]);
   const tableHasGeoCell = useMemo(() => hasGeoCell(data), [data]);
@@ -302,6 +303,7 @@ export function TableNG(props: TableNGProps) {
   const { nestedFieldWidths, nestedColWidths, handleNestedColumnWidthsChange } = useNestedColWidths({
     nestedVisibleFields,
     availableWidth,
+    structureRev,
   });
 
   const hasNestedHeaders = useMemo(() => firstRowNestedData?.meta?.custom?.noHeader !== true, [firstRowNestedData]);
@@ -429,7 +431,6 @@ export function TableNG(props: TableNGProps) {
           sortable: true,
           // draggable: true,
         },
-        onColumnResize: resizeHandler,
         onSortColumnsChange: (newSortColumns: SortColumn[]) => {
           setSortColumns(newSortColumns);
           onSortByChange?.(
@@ -449,7 +450,6 @@ export function TableNG(props: TableNGProps) {
     [
       enableVirtualization,
       hasFooter,
-      resizeHandler,
       sortColumns,
       rowHeight,
       styles.headerRow,
@@ -529,6 +529,7 @@ export function TableNG(props: TableNGProps) {
               className={clsx(styles.grid, styles.gridNested)}
               headerRowClass={clsx(styles.headerRow, hasNestedHeaders ? '' : styles.displayNone)}
               headerRowHeight={hasNestedHeaders ? nestedHeaderHeightPx : 0}
+              onColumnResize={nestedResizeHandler}
               columns={nestedColumns}
               rows={expandedRecords}
               renderers={{ ...renderers, noRowsFallback: <EmptyTablePlaceholder noValue={noValue} /> }}
@@ -560,6 +561,7 @@ export function TableNG(props: TableNGProps) {
       onCellClick,
       uniqueId,
       nestedColWidths,
+      nestedResizeHandler,
       handleNestedColumnWidthsChange,
     ]
   );
@@ -994,6 +996,7 @@ export function TableNG(props: TableNGProps) {
         onSelectedRowsChange={setSelectedRows}
         headerRowClass={clsx(styles.headerRow, noHeader ? styles.displayNone : '')}
         headerRowHeight={headerHeight}
+        onColumnResize={resizeHandler}
         onCellClick={onCellClick}
         onCellKeyDown={({ column, row }, event) => {
           // if top-left cell, use default browser tabbing

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -18,7 +18,6 @@ import {
 import {
   Cell,
   type CellRendererProps,
-  type ColumnWidths,
   DataGrid,
   type DataGridHandle,
   type DataGridProps,
@@ -65,6 +64,7 @@ import {
   useFilteredRows,
   useHeaderHeight,
   useManagedSort,
+  useNestedColWidths,
   useNestedRows,
   usePaginatedRows,
   useRowHeight,
@@ -91,7 +91,6 @@ import {
   type TableSummaryRow,
 } from './types';
 import {
-  buildNestedColumnWidthsMap,
   calculateFooterHeight,
   canFieldBeColorized,
   compileFrameToRecords,
@@ -300,27 +299,10 @@ export function TableNG(props: TableNGProps) {
     [nestedRows, expandedRows]
   );
 
-  const [nestedFieldWidths] = useColWidths(nestedVisibleFields, availableWidth);
-
-  const [nestedColWidths, setNestedColWidths] = useState<ColumnWidths>(() =>
-    buildNestedColumnWidthsMap(nestedVisibleFields, nestedFieldWidths)
-  );
-
-  // Re-initialise when field schema or panel-configured widths change.
-  // Serialise both names and widths so the effect fires for either change, but NOT during a
-  // user drag (drag writes to `nestedColWidths` via onColumnWidthsChange without touching
-  // nestedFieldWidths, so the key stays stable and the live state is not overwritten).
-  const nestedFieldsStateKey = nestedVisibleFields
-    .map((f, idx) => `${getDisplayName(f)}:${nestedFieldWidths[idx]}`)
-    .join('\0');
-  useEffect(() => {
-    setNestedColWidths(buildNestedColumnWidthsMap(nestedVisibleFields, nestedFieldWidths));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [nestedFieldsStateKey]);
-
-  const handleNestedColumnWidthsChange = useCallback((widths: ColumnWidths) => {
-    setNestedColWidths(widths);
-  }, []);
+  const { nestedFieldWidths, nestedColWidths, handleNestedColumnWidthsChange } = useNestedColWidths({
+    nestedVisibleFields,
+    availableWidth,
+  });
 
   const hasNestedHeaders = useMemo(() => firstRowNestedData?.meta?.custom?.noHeader !== true, [firstRowNestedData]);
   const nestedHeaderHeight = useHeaderHeight({

--- a/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/TableNG.tsx
@@ -18,6 +18,7 @@ import {
 import {
   Cell,
   type CellRendererProps,
+  type ColumnWidths,
   DataGrid,
   type DataGridHandle,
   type DataGridProps,
@@ -90,6 +91,7 @@ import {
   type TableSummaryRow,
 } from './types';
 import {
+  buildNestedColumnWidthsMap,
   calculateFooterHeight,
   canFieldBeColorized,
   compileFrameToRecords,
@@ -299,6 +301,26 @@ export function TableNG(props: TableNGProps) {
   );
 
   const [nestedFieldWidths] = useColWidths(nestedVisibleFields, availableWidth);
+
+  const [nestedColWidths, setNestedColWidths] = useState<ColumnWidths>(() =>
+    buildNestedColumnWidthsMap(nestedVisibleFields, nestedFieldWidths)
+  );
+
+  // Re-initialise when field schema or panel-configured widths change.
+  // Serialise both names and widths so the effect fires for either change, but NOT during a
+  // user drag (drag writes to `nestedColWidths` via onColumnWidthsChange without touching
+  // nestedFieldWidths, so the key stays stable and the live state is not overwritten).
+  const nestedFieldsStateKey = nestedVisibleFields
+    .map((f, idx) => `${getDisplayName(f)}:${nestedFieldWidths[idx]}`)
+    .join('\0');
+  useEffect(() => {
+    setNestedColWidths(buildNestedColumnWidthsMap(nestedVisibleFields, nestedFieldWidths));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [nestedFieldsStateKey]);
+
+  const handleNestedColumnWidthsChange = useCallback((widths: ColumnWidths) => {
+    setNestedColWidths(widths);
+  }, []);
 
   const hasNestedHeaders = useMemo(() => firstRowNestedData?.meta?.custom?.noHeader !== true, [firstRowNestedData]);
   const nestedHeaderHeight = useHeaderHeight({
@@ -529,6 +551,8 @@ export function TableNG(props: TableNGProps) {
               rows={expandedRecords}
               renderers={{ ...renderers, noRowsFallback: <EmptyTablePlaceholder noValue={noValue} /> }}
               onCellClick={onCellClick}
+              columnWidths={nestedColWidths}
+              onColumnWidthsChange={handleNestedColumnWidthsChange}
             />
           </div>
         );
@@ -553,6 +577,8 @@ export function TableNG(props: TableNGProps) {
       noValue,
       onCellClick,
       uniqueId,
+      nestedColWidths,
+      handleNestedColumnWidthsChange,
     ]
   );
 

--- a/packages/grafana-ui/src/components/Table/TableNG/hooks.test.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/hooks.test.ts
@@ -1226,9 +1226,9 @@ describe('TableNG hooks', () => {
     it('resets to schema widths when field schema changes', () => {
       const fields = makeFields(['a', 'b']);
       const { result, rerender } = renderHook(
-        ({ nestedVisibleFields }: { nestedVisibleFields: Field[] }) =>
-          useNestedColWidths({ nestedVisibleFields, availableWidth: 300 }),
-        { initialProps: { nestedVisibleFields: fields } }
+        ({ nestedVisibleFields, structureRev }: { nestedVisibleFields: Field[]; structureRev: number }) =>
+          useNestedColWidths({ nestedVisibleFields, availableWidth: 300, structureRev }),
+        { initialProps: { nestedVisibleFields: fields, structureRev: 1 } }
       );
 
       // simulate a user drag
@@ -1242,9 +1242,9 @@ describe('TableNG hooks', () => {
       });
       expect(result.current.nestedFieldWidths).toEqual([200, 200]);
 
-      // now the field schema changes (different configured width)
+      // now the field schema changes (different configured width) — structureRev bumped to signal the change
       const newFields = makeFields(['a', 'b'], 120);
-      rerender({ nestedVisibleFields: newFields });
+      rerender({ nestedVisibleFields: newFields, structureRev: 2 });
 
       expect(result.current.nestedFieldWidths).toEqual([120, 120]);
     });
@@ -1252,9 +1252,9 @@ describe('TableNG hooks', () => {
     it('resets when a new field is added', () => {
       const fields = makeFields(['a', 'b']);
       const { result, rerender } = renderHook(
-        ({ nestedVisibleFields }: { nestedVisibleFields: Field[] }) =>
-          useNestedColWidths({ nestedVisibleFields, availableWidth: 300 }),
-        { initialProps: { nestedVisibleFields: fields } }
+        ({ nestedVisibleFields, structureRev }: { nestedVisibleFields: Field[]; structureRev: number }) =>
+          useNestedColWidths({ nestedVisibleFields, availableWidth: 300, structureRev }),
+        { initialProps: { nestedVisibleFields: fields, structureRev: 1 } }
       );
 
       // simulate a user drag on the original columns
@@ -1268,7 +1268,7 @@ describe('TableNG hooks', () => {
       });
 
       const fieldsWithExtra = makeFields(['a', 'b', 'c']);
-      rerender({ nestedVisibleFields: fieldsWithExtra });
+      rerender({ nestedVisibleFields: fieldsWithExtra, structureRev: 2 });
 
       expect(result.current.nestedFieldWidths).toHaveLength(3);
       expect(result.current.nestedFieldWidths).toEqual([100, 100, 100]);

--- a/packages/grafana-ui/src/components/Table/TableNG/hooks.test.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/hooks.test.ts
@@ -6,6 +6,7 @@ import { TableCellDisplayMode } from '@grafana/schema';
 import { TABLE } from './constants';
 import {
   useFilteredRows,
+  useNestedColWidths,
   usePaginatedRows,
   useSortedRows,
   useHeaderHeight,
@@ -1170,6 +1171,131 @@ describe('TableNG hooks', () => {
         [reducerId, '3'],
         [ReducerID.first, '30 years'],
       ]);
+    });
+  });
+
+  describe('useNestedColWidths', () => {
+    function makeFields(names: string[], width = 100): Field[] {
+      return names.map((name) => ({
+        name,
+        type: FieldType.string,
+        config: { custom: { width } },
+        values: [],
+      }));
+    }
+
+    it('initializes nestedFieldWidths and nestedColWidths from schema', () => {
+      const fields = makeFields(['a', 'b']);
+      const { result } = renderHook(() => useNestedColWidths({ nestedVisibleFields: fields, availableWidth: 300 }));
+
+      expect(result.current.nestedFieldWidths).toEqual([100, 100]);
+      expect(result.current.nestedColWidths.get('a')).toEqual({ type: 'resized', width: 100 });
+      expect(result.current.nestedColWidths.get('b')).toEqual({ type: 'resized', width: 100 });
+    });
+
+    it('handleNestedColumnWidthsChange updates nestedFieldWidths and nestedColWidths', () => {
+      const fields = makeFields(['a', 'b']);
+      const { result } = renderHook(() => useNestedColWidths({ nestedVisibleFields: fields, availableWidth: 300 }));
+
+      act(() => {
+        result.current.handleNestedColumnWidthsChange(
+          new Map([
+            ['a', { type: 'resized', width: 200 }],
+            ['b', { type: 'resized', width: 150 }],
+          ])
+        );
+      });
+
+      expect(result.current.nestedFieldWidths).toEqual([200, 150]);
+      expect(result.current.nestedColWidths.get('a')).toEqual({ type: 'resized', width: 200 });
+      expect(result.current.nestedColWidths.get('b')).toEqual({ type: 'resized', width: 150 });
+    });
+
+    it('handleNestedColumnWidthsChange preserves existing width for missing columns', () => {
+      const fields = makeFields(['a', 'b']);
+      const { result } = renderHook(() => useNestedColWidths({ nestedVisibleFields: fields, availableWidth: 300 }));
+
+      act(() => {
+        // only update 'a', leave 'b' absent from the map
+        result.current.handleNestedColumnWidthsChange(new Map([['a', { type: 'resized', width: 250 }]]));
+      });
+
+      expect(result.current.nestedFieldWidths).toEqual([250, 100]);
+    });
+
+    it('resets to schema widths when field schema changes', () => {
+      const fields = makeFields(['a', 'b']);
+      const { result, rerender } = renderHook(
+        ({ nestedVisibleFields }: { nestedVisibleFields: Field[] }) =>
+          useNestedColWidths({ nestedVisibleFields, availableWidth: 300 }),
+        { initialProps: { nestedVisibleFields: fields } }
+      );
+
+      // simulate a user drag
+      act(() => {
+        result.current.handleNestedColumnWidthsChange(
+          new Map([
+            ['a', { type: 'resized', width: 200 }],
+            ['b', { type: 'resized', width: 200 }],
+          ])
+        );
+      });
+      expect(result.current.nestedFieldWidths).toEqual([200, 200]);
+
+      // now the field schema changes (different configured width)
+      const newFields = makeFields(['a', 'b'], 120);
+      rerender({ nestedVisibleFields: newFields });
+
+      expect(result.current.nestedFieldWidths).toEqual([120, 120]);
+    });
+
+    it('resets when a new field is added', () => {
+      const fields = makeFields(['a', 'b']);
+      const { result, rerender } = renderHook(
+        ({ nestedVisibleFields }: { nestedVisibleFields: Field[] }) =>
+          useNestedColWidths({ nestedVisibleFields, availableWidth: 300 }),
+        { initialProps: { nestedVisibleFields: fields } }
+      );
+
+      // simulate a user drag on the original columns
+      act(() => {
+        result.current.handleNestedColumnWidthsChange(
+          new Map([
+            ['a', { type: 'resized', width: 200 }],
+            ['b', { type: 'resized', width: 200 }],
+          ])
+        );
+      });
+
+      const fieldsWithExtra = makeFields(['a', 'b', 'c']);
+      rerender({ nestedVisibleFields: fieldsWithExtra });
+
+      expect(result.current.nestedFieldWidths).toHaveLength(3);
+      expect(result.current.nestedFieldWidths).toEqual([100, 100, 100]);
+    });
+
+    it('does not reset on re-render if schema is unchanged (stable between drags)', () => {
+      const fields = makeFields(['a', 'b']);
+      const { result, rerender } = renderHook(
+        ({ nestedVisibleFields, availableWidth }: { nestedVisibleFields: Field[]; availableWidth: number }) =>
+          useNestedColWidths({ nestedVisibleFields, availableWidth }),
+        { initialProps: { nestedVisibleFields: fields, availableWidth: 300 } }
+      );
+
+      act(() => {
+        result.current.handleNestedColumnWidthsChange(
+          new Map([
+            ['a', { type: 'resized', width: 200 }],
+            ['b', { type: 'resized', width: 200 }],
+          ])
+        );
+      });
+      expect(result.current.nestedFieldWidths).toEqual([200, 200]);
+
+      // rerender with same fields reference — state must be preserved
+      rerender({ nestedVisibleFields: fields, availableWidth: 300 });
+
+      expect(result.current.nestedFieldWidths).toEqual([200, 200]);
     });
   });
 });

--- a/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
@@ -9,7 +9,7 @@ import {
   type CSSProperties,
   useEffect,
 } from 'react';
-import { type Column, type DataGridHandle, type DataGridProps, type SortColumn } from 'react-data-grid';
+import { type Column, type ColumnWidths, type DataGridHandle, type DataGridProps, type SortColumn } from 'react-data-grid';
 
 import { type DataFrame, type Field, FieldType, formattedValueToString, reduceField, ReducerID } from '@grafana/data';
 
@@ -32,6 +32,7 @@ import {
   getColumnTypes,
   getRowHeight,
   computeColWidths,
+  buildNestedColumnWidthsMap,
   buildHeaderHeightMeasurers,
   buildCellHeightMeasurers,
   IS_SAFARI_26,
@@ -637,6 +638,66 @@ export function useScrollbarWidth(ref: RefObject<DataGridHandle | null>, height:
   }, [ref, height, updateScrollbarDimensions]);
 
   return scrollbarWidth;
+}
+
+interface UseNestedColWidthsOptions {
+  nestedVisibleFields: Field[];
+  availableWidth: number;
+}
+
+interface UseNestedColWidthsResult {
+  nestedFieldWidths: number[];
+  nestedColWidths: ColumnWidths;
+  handleNestedColumnWidthsChange: (newColWidths: ColumnWidths) => void;
+}
+
+/**
+ * Manages per-column widths for nested tables.
+ *
+ * nestedFieldWidths (number[]) is the source of truth; nestedColWidths (ColumnWidths Map)
+ * is derived from it for react-data-grid. The state key detects schema/config changes
+ * without re-firing during user drags, which update nestedFieldWidths directly via
+ * handleNestedColumnWidthsChange without touching the schema-derived widths.
+ */
+export function useNestedColWidths({ nestedVisibleFields, availableWidth }: UseNestedColWidthsOptions): UseNestedColWidthsResult {
+  // before we do anything, figure out what the widths are based on the panel configuration.
+  const configuredWidths = useMemo(
+    () => computeColWidths(nestedVisibleFields, availableWidth),
+    [nestedVisibleFields, availableWidth]
+  );
+
+  // Serialize field names + configured widths so the effect fires on panel changes,
+  // but NOT during user drags (drags write to nestedFieldWidths without touching configuredWidths).
+  const nestedFieldsStateKey = nestedVisibleFields
+    .map((f, idx) => `${getDisplayName(f)}:${configuredWidths[idx]}`)
+    .join('\0');
+
+  const [nestedFieldWidths, setNestedFieldWidths] = useState(() => configuredWidths);
+
+  useEffect(() => {
+    setNestedFieldWidths(computeColWidths(nestedVisibleFields, availableWidth));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [nestedFieldsStateKey]);
+
+  const nestedColWidths = useMemo(
+    () => buildNestedColumnWidthsMap(nestedVisibleFields, nestedFieldWidths),
+    [nestedVisibleFields, nestedFieldWidths]
+  );
+
+  const handleNestedColumnWidthsChange = useCallback(
+    (newColWidths: ColumnWidths) => {
+      setNestedFieldWidths(
+        nestedVisibleFields.map((f, idx) => {
+          const entry = newColWidths.get(getDisplayName(f));
+          // ColumnWidth always has a width property (both 'resized' and 'measured' variants)
+          return entry != null ? entry.width : nestedFieldWidths[idx];
+        })
+      );
+    },
+    [nestedVisibleFields, nestedFieldWidths]
+  );
+
+  return { nestedFieldWidths, nestedColWidths, handleNestedColumnWidthsChange };
 }
 
 export function useColWidths(

--- a/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
@@ -12,6 +12,7 @@ import {
 import { type Column, type ColumnWidths, type DataGridHandle, type DataGridProps, type SortColumn } from 'react-data-grid';
 
 import { type DataFrame, type Field, FieldType, formattedValueToString, reduceField, ReducerID } from '@grafana/data';
+import { type MatcherScope } from '@grafana/schema';
 
 import { type TableColumnResizeActionCallback } from '../types';
 
@@ -552,12 +553,14 @@ export function useRowHeight({
 interface UseColumnResizeState {
   columnKey: string | undefined;
   width: number;
+  fieldScope?: MatcherScope;
 }
 
 const INITIAL_COL_RESIZE_STATE = Object.freeze({ columnKey: undefined, width: 0 }) satisfies UseColumnResizeState;
 
 export function useColumnResize(
-  onColumnResize: TableColumnResizeActionCallback = () => {}
+  onColumnResize: TableColumnResizeActionCallback = () => {},
+  fieldScope?: MatcherScope
 ): DataGridProps<TableRow, TableSummaryRow>['onColumnResize'] {
   // these must be refs. if we used setState, we would run into race conditions with these event listeners
   const colResizeState = useRef<UseColumnResizeState>({ ...INITIAL_COL_RESIZE_STATE });
@@ -584,7 +587,7 @@ export function useColumnResize(
 
   const dispatchEvent = useCallback(() => {
     if (colResizeState.current.columnKey) {
-      onColumnResize(colResizeState.current.columnKey, Math.floor(colResizeState.current.width));
+      onColumnResize(colResizeState.current.columnKey, Math.floor(colResizeState.current.width), colResizeState.current.fieldScope);
       colResizeState.current = { ...INITIAL_COL_RESIZE_STATE };
     }
     window.removeEventListener('click', dispatchEvent, { capture: true });
@@ -600,13 +603,17 @@ export function useColumnResize(
       colResizeState.current.columnKey = column.key;
       colResizeState.current.width = width;
 
+      if (fieldScope) {
+        colResizeState.current.fieldScope = fieldScope;
+      }
+
       // when double clicking to resize, this handler will fire, but the pointer will not be down,
       // meaning that we should immediately flush the new width
       if (!pointerIsDown.current) {
         dispatchEvent();
       }
     },
-    [dispatchEvent]
+    [fieldScope, dispatchEvent]
   );
 
   return dataGridResizeHandler;
@@ -643,6 +650,7 @@ export function useScrollbarWidth(ref: RefObject<DataGridHandle | null>, height:
 interface UseNestedColWidthsOptions {
   nestedVisibleFields: Field[];
   availableWidth: number;
+  structureRev?: number;
 }
 
 interface UseNestedColWidthsResult {
@@ -653,32 +661,42 @@ interface UseNestedColWidthsResult {
 
 /**
  * Manages per-column widths for nested tables.
- *
- * nestedFieldWidths (number[]) is the source of truth; nestedColWidths (ColumnWidths Map)
- * is derived from it for react-data-grid. The state key detects schema/config changes
- * without re-firing during user drags, which update nestedFieldWidths directly via
- * handleNestedColumnWidthsChange without touching the schema-derived widths.
  */
-export function useNestedColWidths({ nestedVisibleFields, availableWidth }: UseNestedColWidthsOptions): UseNestedColWidthsResult {
+export function useNestedColWidths({
+  nestedVisibleFields,
+  availableWidth,
+  structureRev,
+}: UseNestedColWidthsOptions): UseNestedColWidthsResult {
   // before we do anything, figure out what the widths are based on the panel configuration.
   const configuredWidths = useMemo(
     () => computeColWidths(nestedVisibleFields, availableWidth),
     [nestedVisibleFields, availableWidth]
   );
 
-  // Serialize field names + configured widths so the effect fires on panel changes,
-  // but NOT during user drags (drags write to nestedFieldWidths without touching configuredWidths).
-  const nestedFieldsStateKey = nestedVisibleFields
-    .map((f, idx) => `${getDisplayName(f)}:${configuredWidths[idx]}`)
-    .join('\0');
-
   const [nestedFieldWidths, setNestedFieldWidths] = useState(() => configuredWidths);
 
+  // on structureRev change, sync the widths from config and check whether we ought to dispatch an update.
   useEffect(() => {
-    setNestedFieldWidths(computeColWidths(nestedVisibleFields, availableWidth));
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [nestedFieldsStateKey]);
+    const newWidths = computeColWidths(nestedVisibleFields, availableWidth);
+    let hasChanges = false;
+    if (nestedFieldWidths.length !== newWidths.length) {
+      // if we have fewer columns than the new widths, we have changes
+      hasChanges = true;
+    }
+    for (let i = 0; i < newWidths.length; i++) {
+      if (nestedFieldWidths[i] !== newWidths[i]) {
+        hasChanges = true;
+        break;
+      }
+    }
 
+    if (hasChanges) {
+      setNestedFieldWidths(newWidths);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [structureRev]);
+
+  // this is the representation that react-data-grid wants, which we derive from the source of truth (nestedFieldWidths) on every render
   const nestedColWidths = useMemo(
     () => buildNestedColumnWidthsMap(nestedVisibleFields, nestedFieldWidths),
     [nestedVisibleFields, nestedFieldWidths]

--- a/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/hooks.ts
@@ -9,7 +9,13 @@ import {
   type CSSProperties,
   useEffect,
 } from 'react';
-import { type Column, type ColumnWidths, type DataGridHandle, type DataGridProps, type SortColumn } from 'react-data-grid';
+import {
+  type Column,
+  type ColumnWidths,
+  type DataGridHandle,
+  type DataGridProps,
+  type SortColumn,
+} from 'react-data-grid';
 
 import { type DataFrame, type Field, FieldType, formattedValueToString, reduceField, ReducerID } from '@grafana/data';
 import { type MatcherScope } from '@grafana/schema';
@@ -587,7 +593,11 @@ export function useColumnResize(
 
   const dispatchEvent = useCallback(() => {
     if (colResizeState.current.columnKey) {
-      onColumnResize(colResizeState.current.columnKey, Math.floor(colResizeState.current.width), colResizeState.current.fieldScope);
+      onColumnResize(
+        colResizeState.current.columnKey,
+        Math.floor(colResizeState.current.width),
+        colResizeState.current.fieldScope
+      );
       colResizeState.current = { ...INITIAL_COL_RESIZE_STATE };
     }
     window.removeEventListener('click', dispatchEvent, { capture: true });

--- a/packages/grafana-ui/src/components/Table/TableNG/types.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/types.ts
@@ -14,7 +14,7 @@ import {
   type SelectableValue,
   type FieldState,
 } from '@grafana/data';
-import { type TableCellHeight, type TableFieldOptions } from '@grafana/schema';
+import { type MatcherScope, type TableCellHeight, type TableFieldOptions } from '@grafana/schema';
 
 import { type TableCellInspectorMode } from '../TableCellInspector';
 import { type TableCellOptions } from '../types';
@@ -27,7 +27,7 @@ export const FILTER_OUT_OPERATOR = '!=';
 export type AdHocFilterOperator = typeof FILTER_FOR_OPERATOR | typeof FILTER_OUT_OPERATOR;
 export type AdHocFilterItem = { key: string; value: string; operator: AdHocFilterOperator };
 export type TableFilterActionCallback = (item: AdHocFilterItem) => void;
-export type TableColumnResizeActionCallback = (fieldDisplayName: string, width: number) => void;
+export type TableColumnResizeActionCallback = (fieldDisplayName: string, width: number, fieldScope?: MatcherScope) => void;
 export type TableSortByActionCallback = (state: TableSortByFieldState[]) => void;
 export type FooterItem = Array<KeyValue<string>> | string | undefined;
 

--- a/packages/grafana-ui/src/components/Table/TableNG/types.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/types.ts
@@ -27,7 +27,11 @@ export const FILTER_OUT_OPERATOR = '!=';
 export type AdHocFilterOperator = typeof FILTER_FOR_OPERATOR | typeof FILTER_OUT_OPERATOR;
 export type AdHocFilterItem = { key: string; value: string; operator: AdHocFilterOperator };
 export type TableFilterActionCallback = (item: AdHocFilterItem) => void;
-export type TableColumnResizeActionCallback = (fieldDisplayName: string, width: number, fieldScope?: MatcherScope) => void;
+export type TableColumnResizeActionCallback = (
+  fieldDisplayName: string,
+  width: number,
+  fieldScope?: MatcherScope
+) => void;
 export type TableSortByActionCallback = (state: TableSortByFieldState[]) => void;
 export type FooterItem = Array<KeyValue<string>> | string | undefined;
 

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.test.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.test.ts
@@ -27,6 +27,7 @@ import {
   buildCellHeightMeasurers,
   buildHeaderHeightMeasurers,
   buildInspectValue,
+  buildNestedColumnWidthsMap,
   calculateFooterHeight,
   compileFrameToRecords,
   computeColWidths,
@@ -1533,6 +1534,43 @@ describe('TableNG utils', () => {
           COLUMN.DEFAULT_WIDTH
         )
       ).toEqual([COLUMN.DEFAULT_WIDTH, COLUMN.DEFAULT_WIDTH]);
+    });
+  });
+
+  describe('buildNestedColumnWidthsMap', () => {
+    it('maps field display names to ColumnWidth entries', () => {
+      const fields: Field[] = [
+        { name: 'Time', type: FieldType.time, values: [], config: {}, state: { displayName: 'Time' } },
+        { name: 'Value', type: FieldType.number, values: [], config: {}, state: { displayName: 'Value' } },
+      ];
+      const widths = [120, 200];
+
+      const result = buildNestedColumnWidthsMap(fields, widths);
+
+      expect(result.get('Time')).toEqual({ type: 'resized', width: 120 });
+      expect(result.get('Value')).toEqual({ type: 'resized', width: 200 });
+      expect(result.size).toBe(2);
+    });
+
+    it('uses the field display name (from state.displayName) as the map key', () => {
+      const fields: Field[] = [
+        {
+          name: 'raw_name',
+          type: FieldType.string,
+          values: [],
+          config: {},
+          state: { displayName: 'Pretty Name' },
+        },
+      ];
+
+      const result = buildNestedColumnWidthsMap(fields, [150]);
+
+      expect(result.has('Pretty Name')).toBe(true);
+      expect(result.has('raw_name')).toBe(false);
+    });
+
+    it('returns an empty map for empty inputs', () => {
+      expect(buildNestedColumnWidthsMap([], []).size).toBe(0);
     });
   });
 

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.ts
@@ -1023,11 +1023,9 @@ export function computeColWidths(fields: Field[], availWidth: number) {
 }
 
 export function buildNestedColumnWidthsMap(fields: Field[], widths: number[]): ColumnWidths {
-  const map = new Map<string, ColumnWidth>();
-  fields.forEach((field, idx) => {
-    map.set(getDisplayName(field), { type: 'resized', width: widths[idx] });
-  });
-  return map;
+  return new Map<string, ColumnWidth>(
+    fields.map((field, idx) => [getDisplayName(field), { type: 'resized', width: widths[idx] }])
+  );
 }
 
 /**

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.ts
@@ -1,7 +1,7 @@
 import { type Property } from 'csstype';
 import memoize from 'micro-memoize';
 import { type CSSProperties } from 'react';
-import { type SortColumn } from 'react-data-grid';
+import { type ColumnWidth, type ColumnWidths, type SortColumn } from 'react-data-grid';
 import tinycolor from 'tinycolor2';
 import { type Count, varPreLine } from 'uwrap';
 
@@ -1020,6 +1020,14 @@ export function computeColWidths(fields: Field[], availWidth: number) {
           Math.max(fields[i].config.custom?.minWidth ?? COLUMN.DEFAULT_WIDTH, (availWidth - definedWidth) / autoCount)
       )
   );
+}
+
+export function buildNestedColumnWidthsMap(fields: Field[], widths: number[]): ColumnWidths {
+  const map = new Map<string, ColumnWidth>();
+  fields.forEach((field, idx) => {
+    map.set(getDisplayName(field), { type: 'resized', width: widths[idx] });
+  });
+  return map;
 }
 
 /**

--- a/packages/grafana-ui/src/components/Table/types.ts
+++ b/packages/grafana-ui/src/components/Table/types.ts
@@ -41,7 +41,7 @@ export const FILTER_OUT_OPERATOR = '!=';
 export type AdHocFilterOperator = typeof FILTER_FOR_OPERATOR | typeof FILTER_OUT_OPERATOR;
 export type AdHocFilterItem = { key: string; value: string; operator: AdHocFilterOperator };
 export type TableFilterActionCallback = (item: AdHocFilterItem) => void;
-export type TableColumnResizeActionCallback = (fieldDisplayName: string, width: number) => void;
+export type TableColumnResizeActionCallback = (fieldDisplayName: string, width: number, fieldScope?: schema.MatcherScope) => void;
 export type TableSortByActionCallback = (state: TableSortByFieldState[]) => void;
 export type TableInspectCellCallback = (state: InspectCell) => void;
 

--- a/packages/grafana-ui/src/components/Table/types.ts
+++ b/packages/grafana-ui/src/components/Table/types.ts
@@ -41,7 +41,11 @@ export const FILTER_OUT_OPERATOR = '!=';
 export type AdHocFilterOperator = typeof FILTER_FOR_OPERATOR | typeof FILTER_OUT_OPERATOR;
 export type AdHocFilterItem = { key: string; value: string; operator: AdHocFilterOperator };
 export type TableFilterActionCallback = (item: AdHocFilterItem) => void;
-export type TableColumnResizeActionCallback = (fieldDisplayName: string, width: number, fieldScope?: schema.MatcherScope) => void;
+export type TableColumnResizeActionCallback = (
+  fieldDisplayName: string,
+  width: number,
+  fieldScope?: schema.MatcherScope
+) => void;
 export type TableSortByActionCallback = (state: TableSortByFieldState[]) => void;
 export type TableInspectCellCallback = (state: InspectCell) => void;
 

--- a/public/app/plugins/panel/table/TablePanel.tsx
+++ b/public/app/plugins/panel/table/TablePanel.tsx
@@ -14,6 +14,7 @@ import {
   cacheFieldDisplayNames,
 } from '@grafana/data';
 import { config, PanelDataErrorView } from '@grafana/runtime';
+import { type MatcherScope } from '@grafana/schema';
 import { Combobox, usePanelContext, useTheme2 } from '@grafana/ui';
 import { type TableSortByFieldState } from '@grafana/ui/internal';
 import { TableNG } from '@grafana/ui/unstable';
@@ -93,7 +94,7 @@ export function TablePanel(props: Props) {
       sortByBehavior={sortByBehavior}
       sortBy={options.sortBy}
       onSortByChange={(sortBy) => onSortByChange(sortBy, props)}
-      onColumnResize={(displayName, resizedWidth) => onColumnResize(displayName, resizedWidth, props)}
+      onColumnResize={(displayName, resizedWidth, fieldScope) => onColumnResize(displayName, resizedWidth, fieldScope, props)}
       onCellFilterAdded={panelContext.onAddAdHocFilter}
       frozenColumns={options.frozenColumns?.left}
       enablePagination={options.enablePagination}
@@ -135,7 +136,7 @@ function getCurrentFrameIndex(frames: DataFrame[], options: Options) {
   return options.frameIndex > 0 && options.frameIndex < frames.length ? options.frameIndex : 0;
 }
 
-function onColumnResize(fieldDisplayName: string, width: number, props: Props) {
+function onColumnResize(fieldDisplayName: string, width: number, fieldScope: MatcherScope = 'series', props: Props) {
   const { fieldConfig } = props;
   const { overrides } = fieldConfig;
 
@@ -143,7 +144,7 @@ function onColumnResize(fieldDisplayName: string, width: number, props: Props) {
   const propId = 'custom.width';
 
   // look for existing override
-  const override = overrides.find((o) => o.matcher.id === matcherId && o.matcher.options === fieldDisplayName);
+  const override = overrides.find((o) => o.matcher.id === matcherId && o.matcher.options === fieldDisplayName && o.matcher.scope === fieldScope);
 
   if (override) {
     // look for existing property
@@ -155,7 +156,7 @@ function onColumnResize(fieldDisplayName: string, width: number, props: Props) {
     }
   } else {
     overrides.push({
-      matcher: { id: matcherId, options: fieldDisplayName },
+      matcher: { id: matcherId, options: fieldDisplayName, scope: fieldScope },
       properties: [{ id: propId, value: width }],
     });
   }

--- a/public/app/plugins/panel/table/TablePanel.tsx
+++ b/public/app/plugins/panel/table/TablePanel.tsx
@@ -94,7 +94,9 @@ export function TablePanel(props: Props) {
       sortByBehavior={sortByBehavior}
       sortBy={options.sortBy}
       onSortByChange={(sortBy) => onSortByChange(sortBy, props)}
-      onColumnResize={(displayName, resizedWidth, fieldScope) => onColumnResize(displayName, resizedWidth, fieldScope, props)}
+      onColumnResize={(displayName, resizedWidth, fieldScope) =>
+        onColumnResize(displayName, resizedWidth, fieldScope, props)
+      }
       onCellFilterAdded={panelContext.onAddAdHocFilter}
       frozenColumns={options.frozenColumns?.left}
       enablePagination={options.enablePagination}
@@ -144,7 +146,9 @@ function onColumnResize(fieldDisplayName: string, width: number, fieldScope: Mat
   const propId = 'custom.width';
 
   // look for existing override
-  const override = overrides.find((o) => o.matcher.id === matcherId && o.matcher.options === fieldDisplayName && o.matcher.scope === fieldScope);
+  const override = overrides.find(
+    (o) => o.matcher.id === matcherId && o.matcher.options === fieldDisplayName && o.matcher.scope === fieldScope
+  );
 
   if (override) {
     // look for existing property


### PR DESCRIPTION
## Summary

Fixes https://github.com/grafana/grafana/issues/118893

- updates the handlers for column resizing to be scope-aware.
  - when a resize event is dispatched from a nested table, the callback is sent with an optional argument indicating the `nested` scope, and the logic in the panel which searches for the appropriate matcher will take that into account when searching.
- updates how nested tables manage their state in particular, which allows the nested state to all update bidirectionally from the PanelOptions and any instance of a nested table.
  - we needed to use the `columnWidths` and `onColumnWidthsResize` for nested tables to accomplish this.
  - the `onColumnResize` callback is still used to handle dispatching updates to panel options for consistency.
  - as part of the bidirectional nature, some new state was introduced based on panel options, and the state is written over either when the panel options change (as indicated by structureRev) or when the nested table is resized (as indicated by `onColumnWidthsChange`)
- grouped all nested width logic into a hook.
- updated unit tests.
