### PR TITLE
InfluxDB: Escape single quotes in InfluxQL string literals

### DIFF
--- a/pkg/tsdb/influxdb/models/query.go
+++ b/pkg/tsdb/influxdb/models/query.go
@@ -142,7 +142,7 @@ func renderTags(tags []*Tag) []string {
 
 			// Always quote tag values
 			if strings.HasSuffix(tag.Key, "::tag") {
-				textValue = fmt.Sprintf("'%s'", strings.ReplaceAll(tag.Value, `\`, `\\`))
+				textValue = fmt.Sprintf("'%s'", escapeStringLiteral(tag.Value))
 				return textValue, operator
 			}
 
@@ -155,7 +155,7 @@ func renderTags(tags []*Tag) []string {
 				textValue = tag.Value
 			} else {
 				// String (or unknown) - quote
-				textValue = fmt.Sprintf("'%s'", strings.ReplaceAll(tag.Value, `\`, `\\`))
+				textValue = fmt.Sprintf("'%s'", escapeStringLiteral(tag.Value))
 			}
 
 			return removeRegexWrappers(textValue, `'`), operator
@@ -171,7 +171,7 @@ func renderTags(tags []*Tag) []string {
 		case "Is", "Is Not":
 			textValue, tag.Operator = isOperatorTypeHandler(tag)
 		default:
-			textValue = fmt.Sprintf("'%s'", strings.ReplaceAll(removeRegexWrappers(tag.Value, ""), `\`, `\\`))
+			textValue = fmt.Sprintf("'%s'", escapeStringLiteral(removeRegexWrappers(tag.Value, "")))
 		}
 
 		escapedKey := fmt.Sprintf(`"%s"`, tag.Key)
@@ -301,6 +301,13 @@ func epochMStoInfluxTime(tr *backend.TimeRange) (string, string) {
 	to := tr.To.UnixNano() / int64(time.Millisecond)
 
 	return fmt.Sprintf("%dms", from), fmt.Sprintf("%dms", to)
+}
+
+func escapeStringLiteral(value string) string {
+	// Escape backslashes before quotes so the \ we insert for ' is not itself re-escaped.
+	value = strings.ReplaceAll(value, `\`, `\\`)
+	value = strings.ReplaceAll(value, `'`, `\'`)
+	return value
 }
 
 func removeRegexWrappers(wrappedValue string, wrapper string) string {

--- a/pkg/tsdb/influxdb/models/query_test.go
+++ b/pkg/tsdb/influxdb/models/query_test.go
@@ -294,6 +294,24 @@ func TestInfluxdbQueryBuilder(t *testing.T) {
 			require.Equal(t, strings.Join(query.renderTags(), ""), `"key" = 'C:\\test\\'`)
 		})
 
+		t.Run("can escape single quotes when rendering string tags", func(t *testing.T) {
+			query := &Query{Tags: []*Tag{{Operator: "=", Value: `Syl's thermostat`, Key: "deviceName"}}}
+
+			require.Equal(t, strings.Join(query.renderTags(), ""), `"deviceName" = 'Syl\'s thermostat'`)
+		})
+
+		t.Run("can escape single quotes when rendering Is tag with ::tag suffix", func(t *testing.T) {
+			query := &Query{Tags: []*Tag{{Operator: "Is", Value: `Syl's`, Key: "deviceName::tag"}}}
+
+			require.Equal(t, strings.Join(query.renderTags(), ""), `"deviceName"::tag = 'Syl\'s'`)
+		})
+
+		t.Run("can escape single quotes when rendering Is tag with string field", func(t *testing.T) {
+			query := &Query{Tags: []*Tag{{Operator: "Is", Value: `Syl's`, Key: "name"}}}
+
+			require.Equal(t, strings.Join(query.renderTags(), ""), `"name" = 'Syl\'s'`)
+		})
+
 		t.Run("can render regular measurement", func(t *testing.T) {
 			query := &Query{Measurement: `apa`, Policy: "policy"}
 


### PR DESCRIPTION
**What is this feature?**

Escapes single quotes (`'`) inside string values when InfluxQL queries are rendered from the visual query builder, so values like `Syl's bedroom thermostat` produce a syntactically valid query.

**Why do we need this feature?**

Currently `renderTags` wraps tag values in single quotes and escapes backslashes, but leaves single quotes untouched. As a result, a value containing an apostrophe breaks the resulting query:

```
WHERE "deviceName"::tag = 'Syl's bedroom thermostat'
```

InfluxDB rejects this with `failed to parse query: found s, expected ;`. Switching the same query into raw mode in the UI produces a correctly-escaped version (`'Syl\'s bedroom thermostat'`) which works — so the visual builder is the only path that emits broken SQL.

The same gap exists in three places in `renderTags`:
- `Is` / `Is Not` with a `::tag` key
- `Is` / `Is Not` with a string field
- the `default` branch (`=`, `!=`, etc. — the case reported in the issue)

This PR extracts a small `escapeStringLiteral` helper and applies it consistently in all three places, plus adds tests covering each.

**Who is this feature for?**

InfluxDB / InfluxQL users whose tag values or string fields contain apostrophes (device names, labels with possessives, etc.).

**Which issue(s) does this PR fix?**:

Fixes #112185

**Special notes for your reviewer:**

- Backend-only change. No frontend or docs changes.
- The issue only mentions the `=` case, but the same bug exists in two sibling branches in `renderTags`. I [flagged this scope on the issue](https://github.com/grafana/grafana/issues/112185#issuecomment-4275186014) before opening the PR — happy to narrow if you'd prefer a tighter fix.
- Order matters in `escapeStringLiteral`: backslashes are escaped first so the `\` we insert for `'` is not itself re-escaped. Existing backslash-escape behavior is preserved (the existing `C:\test\` test still passes).

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle. (n/a — bug fix)
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc. (n/a — bug fix)