### PR TITLE
Dashboards: don't set loadError state for DashboardVersionError

### DIFF
--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -474,6 +474,12 @@ abstract class DashboardScenePageStateManagerBase<T>
         });
       }
     } catch (err) {
+      // DashboardVersionError signals a schema version mismatch — the caller retries
+      // with the correct version. Don't set loadError here or it persists after retry.
+      if (err instanceof DashboardVersionError) {
+        throw err;
+      }
+
       const status = getStatusFromError(err);
       const message = getMessageFromError(err);
       const messageId = getMessageIdFromError(err);
@@ -489,12 +495,6 @@ abstract class DashboardScenePageStateManagerBase<T>
 
       if (!isFetchError(err)) {
         console.error('Error loading dashboard:', err);
-      }
-
-      // If the error is a DashboardVersionError, we want to throw it so that the error boundary is triggered
-      // This enables us to switch to the correct version of the dashboard
-      if (err instanceof DashboardVersionError) {
-        throw err;
       }
     }
   }


### PR DESCRIPTION
**What is this feature?**

Fixes v2 dashboards shared externally showing a blank page for viewers.

**Why do we need this feature?**

When a v2 public dashboard is loaded through the v1 path (default when dashboardNewLayouts is off), the v1 manager throws DashboardVersionError to signal a retry with the v2 manager. The catch block was setting loadError on the unified manager before rethrowing, leaving stale error state that persisted after the v2 retry succeeded.

PublicDashboardScenePage checks loadError before dashboard, so the stale error caused a blank page even though the dashboard loaded fine on retry.

Fix: rethrow DashboardVersionError before touching state, so only real failures set loadError.

**Who is this feature for?**

Anyone on Grafana v13+ who shares v2 dashboards externally.

**Which issue(s) does this PR fix?**

Fixes #123985

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected  share a v2 dashboard externally and confirm it renders correctly for unauthenticated viewers
- [x] Regression fix, no feature toggle needed
- [x] No docs update needed
