### PR TITLE
Docs: Fix typos, broken links, and outdated references in contribution guides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Thank you for your interest in contributing to Grafana! We welcome all people who want to contribute in a healthy and constructive manner within our community. To help us create a safe and positive community experience for all, we require all participants to adhere to the [Code of Conduct](CODE_OF_CONDUCT.md).
 
-This document is a guide to help you through the process of contributing to Grafana. Be sure to check out the [Grafana Champions program]([https://grafana.com/community/champions/?src=github&camp=community-cross-platform-engagement](https://grafana.com/community/champions/) as you start to contribute. It's designed to recognize and empower individuals who are actively contributing to the growth and success of the Grafana ecosystem.
+This document is a guide to help you through the process of contributing to Grafana. Be sure to check out the [Grafana Champions program](https://grafana.com/community/champions/) as you start to contribute. It's designed to recognize and empower individuals who are actively contributing to the growth and success of the Grafana ecosystem.
 
 > **Help us improve!** We'd love to hear about your contributor experience. Take a moment to share your feedback in our [Open Source Contributor Experience Survey](https://gra.fan/ome). Your input helps us make contributing to Grafana better for everyone.
 

--- a/contribute/README.md
+++ b/contribute/README.md
@@ -9,7 +9,6 @@ These are some good resources to explore for developers:
 - [Developer guide](developer-guide.md)
 - [Triage issues](triage-issues.md)
 - [Merge a pull request](merge-pull-request.md)
-- [Making changes to the CI pipeline](drone-pipeline.md)
 - [Breaking changes in frontend APIs](./breaking-changes-guide/breaking-changes-guide.md)
 
 Learn how to create great documentation and apps for Grafana:

--- a/contribute/deprecation-policy.md
+++ b/contribute/deprecation-policy.md
@@ -16,7 +16,7 @@ We want the deprecation plan to be in the form of written communication for all 
 
 > Grafana employees can find more details in our internal docs.
 
-Additionally, the size of the feature requires different notice times between depreciation and disabling as well as disabling and removal. The actual duration will depend on releases of Grafana and the table below should be used as a guide.
+Additionally, the size of the feature requires different notice times between deprecation and disabling as well as disabling and removal. The actual duration will depend on releases of Grafana and the table below should be used as a guide.
 
 ## Grace period between announcement and disabling feature by default
 

--- a/contribute/developer-guide.md
+++ b/contribute/developer-guide.md
@@ -9,7 +9,7 @@ Make sure you have the following dependencies installed before setting up your d
 - [Git](https://git-scm.com/)
 - [Go](https://golang.org/dl/) (see [go.mod](../go.mod#L3) for minimum required version)
 - [Node.js (Long Term Support)](https://nodejs.org), with [corepack enabled](https://nodejs.org/api/corepack.html#enabling-the-feature). See [.nvmrc](../.nvmrc) for supported version. We recommend that you use a version manager such as [nvm](https://github.com/nvm-sh/nvm), [fnm](https://github.com/Schniz/fnm), or similar.
-- [GCC](https://gcc.gnu.org/) (optional, not recommded; enables CGO for smaller, dynamically linked binaries)
+- [GCC](https://gcc.gnu.org/) (optional, not recommended; enables CGO for smaller, dynamically linked binaries)
 
 ### macOS
 
@@ -86,7 +86,7 @@ After the command has finished, you can start building the source code:
 yarn start
 ```
 
-This command generates SASS theme files, builds all external plugins, and then builds the frontend assets.
+This command builds the frontend assets and starts a dev server that watches for changes.
 
 After `yarn start` has built the assets, it will continue to do so whenever any of the files change. This means you don't have to manually build the assets every time you change the code.
 

--- a/contribute/feature-toggles.md
+++ b/contribute/feature-toggles.md
@@ -7,9 +7,9 @@ Exhaustive documentation on OpenFeature can be found at [OpenFeature.dev](https:
 ## Steps to adding a feature flag
 
 1. Define the feature flag in [registry.go](../pkg/services/featuremgmt/registry.go).
-   - New flags must by named with a component, seperated by a dot. e.g `grafana.newPreferencesPage`.
+   - New flags must be named with a component, separated by a dot. e.g `grafana.newPreferencesPage`.
    - Set the `Generate` field to control which clients are generated for your flag (see [Generation targets](#generation-targets) below).
-   - To see what each feature stage means, look at the [related comments](../pkg/services/featuremgmt/features.go).
+   - To see what each feature stage means, look at the [related comments](../pkg/services/featuremgmt/registry.go).
    - If you are a community member, use the [CODEOWNERS](../.github/CODEOWNERS) file to determine which team owns the package you are updating.
 
 2. Run `make gen-feature-toggles` to regenerate all derived files: the backend constants, the legacy frontend types, the OpenFeature React client, and docs.
@@ -159,9 +159,9 @@ If using non-boolean flags (a unique feature of the new feature flag system), ex
 
 For advanced, non-React contexts (utilities, class methods, callbacks), you can use the OpenFeature client directly.
 
-However, because this is seperate from the React render loop there are important caveats you must be aware of:
+However, because this is separate from the React render loop there are important caveats you must be aware of:
 
-- Flag values are loaded asynchronously, so you cannot call `getBooleanValue()` just at the top-level of a module. You must wait until `app.ts` has initialised until you call a flag otherwise you will only get the default value
+- Flag values are loaded asynchronously, so you cannot call `getBooleanValue()` just at the top-level of a module. You must wait until `app.ts` has initialized before you call a flag, otherwise you will only get the default value
 - Flag values can change over the lifetime of the session, so do not store or cache the result. Always evaluate flags just in time when you use them, preferably in the if statement, for example.
 
 It is strongly preferred to use the React hooks instead of getting the client.

--- a/contribute/internationalization.md
+++ b/contribute/internationalization.md
@@ -72,7 +72,7 @@ const ErrorMessage = ({ id, message }) => <Trans i18nKey={`errors.${id}`}>There 
 
 ### Plain JS usage
 
-Sometimes you may need to translate a string cannot be represented in JSX, such as `placeholder` props. Use the `t` macro for this.
+Sometimes you may need to translate a string that cannot be represented in JSX, such as `placeholder` props. Use the `t` macro for this.
 
 ```jsx
 import { t } from "@grafana/i18n"

--- a/contribute/merge-pull-request.md
+++ b/contribute/merge-pull-request.md
@@ -120,7 +120,7 @@ Backporting is the process of copying the pull request into the version branch o
 
 Backporting should be a rare exception, reserved only for critical bug fixes, and must be initiated by a Grafana Labs employee. We generally avoid automatic backports, as these changes carry some risk: they typically receive less manual testing than changes included in regular point releases.
 
-If a pull request addresses a critical bug and backporting is warranted, a Grafana Labs team member can apply the appropriate `backport vx.x` labels for the relevant release branches. The team will review and approve the backport before proceeding. When the pull request is merged, seperate backport PRs will automatically be creataed.
+If a pull request addresses a critical bug and backporting is warranted, a Grafana Labs team member can apply the appropriate `backport vx.x` labels for the relevant release branches. The team will review and approve the backport before proceeding. When the pull request is merged, separate backport PRs will automatically be created.
 
 #### Required labels
 

--- a/contribute/style-guides/e2e-playwright.md
+++ b/contribute/style-guides/e2e-playwright.md
@@ -4,7 +4,7 @@ Grafana Labs uses a minimal [homegrown solution](https://github.com/grafana/plug
 
 Important notes:
 
-- We generally store all element identifiers ([CSS selectors](https://mdn.io/docs/Web/CSS/CSS_Selectors)) within the framework for reuse and maintainability.
+- We generally store all element identifiers ([CSS selectors](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Selectors)) within the framework for reuse and maintainability.
 - We generally do not use stubs or mocks as to fully simulate a real user.
 - We also use Playwright for the [plugins' end-to-end tests](#playwright-for-plugins).
 
@@ -240,7 +240,7 @@ test(
     await page.goto(selectors.pages.Datasources.url);
     // Select datasource
     const dataSource = 'B';
-    await page.getByTextId(dataSource).click();
+    await page.getByTestId(dataSource).click();
   }
 );
 ```
@@ -291,4 +291,4 @@ You can add Playwright end-to-end tests for plugins to the [`e2e-playwright/plug
 
 > ### Playwright tests in Grafana Enterprise
 >
-> We are currently working on make Playwright available for creating end-to-end tests in [grafana-enterprise](https://github.com/grafana/grafana-enterprise).
+> We are currently working on making Playwright available for creating end-to-end tests in [grafana-enterprise](https://github.com/grafana/grafana-enterprise).

--- a/contribute/style-guides/redux.md
+++ b/contribute/style-guides/redux.md
@@ -2,8 +2,6 @@
 
 Grafana uses [Redux Toolkit](https://redux-toolkit.js.org/) to handle Redux boilerplate code.
 
-> **Note:** Some of our reducers are used by Angular; therefore, consider state to be mutable for those reducers.
-
 ## Test functionality
 
 Here's how to test the functioning of your Redux reducers.

--- a/contribute/style-guides/styling.md
+++ b/contribute/style-guides/styling.md
@@ -1,6 +1,6 @@
 # Styling Grafana
 
-[Emotion](https://emotion.sh/docs/introduction) is Grafana's default-to-be approach to styling React components. It provides a way for styles to be a consequence of properties and state of a component.
+[Emotion](https://emotion.sh/docs/introduction) is Grafana's default approach to styling React components. It provides a way for styles to be a consequence of properties and state of a component.
 
 ## Usage
 
@@ -8,7 +8,7 @@ For styling components, use [Emotion's `css` function](https://emotion.sh/docs/@
 
 ### Basic styling
 
-To access the Emotion theme in your styles, use the `useStyles` hook. This hook provides basic memoization and access to the theme object.
+To access the Emotion theme in your styles, use the `useStyles2` hook. This hook provides basic memoization and access to the theme object.
 
 > **Note:** Please remember to put `getStyles` function at the end of the file!
 
@@ -71,7 +71,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     }),
     active: css({
       background: theme.colors.primary.main,
-      text: theme.colors.primary.contrastText,
+      color: theme.colors.primary.contrastText,
     }),
     icon: css({
       fontSize: theme.typography.bodySmall.fontSize,


### PR DESCRIPTION
## Summary

Fixes multiple documentation issues I found while reading through the contribution guides and style guides.

**Typos fixed:**
- "recommded" -> "recommended" in contribute/developer-guide.md
- "seperated" -> "separated" and "by" -> "be" in contribute/feature-toggles.md
- "initialised" -> "initialized" in contribute/feature-toggles.md
- "seperate" -> "separate" and "creataed" -> "created" in contribute/merge-pull-request.md
- "depreciation" -> "deprecation" in contribute/deprecation-policy.md
- Missing word "that" in contribute/internationalization.md
- "getByTextId" -> "getByTestId" in contribute/style-guides/e2e-playwright.md
- "make" -> "making" in contribute/style-guides/e2e-playwright.md

**Broken links fixed:**
- Malformed nested markdown link for Grafana Champions in CONTRIBUTING.md
- Broken link to non-existent features.go (updated to registry.go) in contribute/feature-toggles.md
- Removed broken link to non-existent drone-pipeline.md in contribute/README.md
- Fixed invalid mdn.io URL in contribute/style-guides/e2e-playwright.md

**Outdated content fixed:**
- Updated useStyles -> useStyles2 in contribute/style-guides/styling.md
- Fixed invalid CSS property text -> color in contribute/style-guides/styling.md
- Updated "default-to-be" -> "default" for Emotion in contribute/style-guides/styling.md
- Removed outdated Angular note in contribute/style-guides/redux.md
- Updated outdated SASS theme description in contribute/developer-guide.md

## Test plan

- [x] All changes are documentation-only (no code changes)
- [x] Verified linked files exist on disk (e.g., registry.go exists, features.go does not)
- [x] Verified broken link targets do not exist (drone-pipeline.md, features.go)

Made with [Cursor](https://cursor.com)