### PR TITLE
Explore: Add unit tests for NoData, LogsColumnSearch, CorrelationUnsavedChangesModal, and EntityNotFound

### DIFF
--- a/public/app/core/components/PageNotFound/EntityNotFound.test.tsx
+++ b/public/app/core/components/PageNotFound/EntityNotFound.test.tsx
@@ -1,0 +1,38 @@
+import { screen } from '@testing-library/react';
+
+import { selectors } from '@grafana/e2e-selectors';
+
+import { render } from '../../../../test/test-utils';
+
+import { EntityNotFound } from './EntityNotFound';
+
+describe('EntityNotFound', () => {
+  it('should render with default "Page" entity', () => {
+    render(<EntityNotFound />);
+    expect(screen.getByText(/page not found/i)).toBeInTheDocument();
+  });
+
+  it('should render with a custom entity name', () => {
+    render(<EntityNotFound entity="Dashboard" />);
+    expect(screen.getByText(/dashboard not found/i)).toBeInTheDocument();
+  });
+
+  it('should render the container with the correct test id', () => {
+    render(<EntityNotFound />);
+    expect(screen.getByTestId(selectors.components.EntityNotFound.container)).toBeInTheDocument();
+  });
+
+  it('should render a link back to home', () => {
+    render(<EntityNotFound />);
+    const homeLink = screen.getByRole('link', { name: /back to home/i });
+    expect(homeLink).toBeInTheDocument();
+    expect(homeLink).toHaveAttribute('href', '/');
+  });
+
+  it('should render a link to community help', () => {
+    render(<EntityNotFound />);
+    const communityLink = screen.getByRole('link', { name: /community help/i });
+    expect(communityLink).toBeInTheDocument();
+    expect(communityLink).toHaveAttribute('href', 'https://community.grafana.com');
+  });
+});

--- a/public/app/features/explore/CorrelationUnsavedChangesModal.test.tsx
+++ b/public/app/features/explore/CorrelationUnsavedChangesModal.test.tsx
@@ -1,0 +1,60 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { render } from '../../../test/test-utils';
+
+import { CorrelationUnsavedChangesModal } from './CorrelationUnsavedChangesModal';
+
+describe('CorrelationUnsavedChangesModal', () => {
+  const defaultProps = {
+    message: 'You have unsaved changes.',
+    onDiscard: jest.fn(),
+    onCancel: jest.fn(),
+    onSave: jest.fn(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should render the modal title', () => {
+    render(<CorrelationUnsavedChangesModal {...defaultProps} />);
+    expect(screen.getByText('Unsaved changes to correlation')).toBeInTheDocument();
+  });
+
+  it('should render the provided message', () => {
+    render(<CorrelationUnsavedChangesModal {...defaultProps} />);
+    expect(screen.getByText('You have unsaved changes.')).toBeInTheDocument();
+  });
+
+  it('should render all action buttons', () => {
+    render(<CorrelationUnsavedChangesModal {...defaultProps} />);
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /continue without saving/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /save correlation/i })).toBeInTheDocument();
+  });
+
+  it('should call onCancel when Cancel is clicked', async () => {
+    const user = userEvent.setup();
+    render(<CorrelationUnsavedChangesModal {...defaultProps} />);
+
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(defaultProps.onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call onDiscard when Continue without saving is clicked', async () => {
+    const user = userEvent.setup();
+    render(<CorrelationUnsavedChangesModal {...defaultProps} />);
+
+    await user.click(screen.getByRole('button', { name: /continue without saving/i }));
+    expect(defaultProps.onDiscard).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call onSave when Save correlation is clicked', async () => {
+    const user = userEvent.setup();
+    render(<CorrelationUnsavedChangesModal {...defaultProps} />);
+
+    await user.click(screen.getByRole('button', { name: /save correlation/i }));
+    expect(defaultProps.onSave).toHaveBeenCalledTimes(1);
+  });
+});

--- a/public/app/features/explore/Logs/LogsColumnSearch.test.tsx
+++ b/public/app/features/explore/Logs/LogsColumnSearch.test.tsx
@@ -1,0 +1,28 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { render } from '../../../../test/test-utils';
+
+import { LogsColumnSearch } from './LogsColumnSearch';
+
+describe('LogsColumnSearch', () => {
+  it('should render with the provided value', () => {
+    render(<LogsColumnSearch value="test-value" onChange={jest.fn()} />);
+    expect(screen.getByPlaceholderText('Search fields by name')).toHaveValue('test-value');
+  });
+
+  it('should render with empty value', () => {
+    render(<LogsColumnSearch value="" onChange={jest.fn()} />);
+    expect(screen.getByPlaceholderText('Search fields by name')).toHaveValue('');
+  });
+
+  it('should call onChange when user types', async () => {
+    const user = userEvent.setup();
+    const onChange = jest.fn();
+
+    render(<LogsColumnSearch value="" onChange={onChange} />);
+
+    await user.type(screen.getByPlaceholderText('Search fields by name'), 'a');
+    expect(onChange).toHaveBeenCalled();
+  });
+});

--- a/public/app/features/explore/NoData.test.tsx
+++ b/public/app/features/explore/NoData.test.tsx
@@ -1,0 +1,17 @@
+import { screen } from '@testing-library/react';
+
+import { render } from '../../../test/test-utils';
+
+import { NoData } from './NoData';
+
+describe('NoData', () => {
+  it('should render "No data" message', () => {
+    render(<NoData />);
+    expect(screen.getByText('No data')).toBeInTheDocument();
+  });
+
+  it('should have the correct test id', () => {
+    render(<NoData />);
+    expect(screen.getByTestId('explore-no-data')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Adds missing unit tests for four components that previously had no test coverage.

**Components tested:**

- **NoData** (`public/app/features/explore/NoData.tsx`) - Verifies "No data" message rendering and `data-testid` attribute
- **LogsColumnSearch** (`public/app/features/explore/Logs/LogsColumnSearch.tsx`) - Verifies input value display, placeholder text, and onChange callback
- **CorrelationUnsavedChangesModal** (`public/app/features/explore/CorrelationUnsavedChangesModal.tsx`) - Verifies modal title, message display, button rendering, and all three action callbacks (cancel, discard, save)
- **EntityNotFound** (`public/app/core/components/PageNotFound/EntityNotFound.tsx`) - Verifies default and custom entity names, data-testid, and navigation links

All tests use React Testing Library (no snapshot tests).

## Test plan

- [x] All 16 tests pass locally (`yarn jest --no-watch`)
- [x] No snapshot tests added
- [x] Uses React Testing Library and `userEvent.setup()` per project conventions

Made with [Cursor](https://cursor.com)