### PR TITLE
Accessibility: Fix missing ARIA labels and keyboard support in interactive elements

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/DashboardAnnotationField.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/DashboardAnnotationField.tsx
@@ -1,8 +1,8 @@
 import { css } from '@emotion/css';
 
 import { type GrafanaTheme2 } from '@grafana/data';
-import { Trans } from '@grafana/i18n';
-import { Icon, Text, useStyles2 } from '@grafana/ui';
+import { Trans, t } from '@grafana/i18n';
+import { IconButton, Text, useStyles2 } from '@grafana/ui';
 
 import { makeDashboardLink, makePanelLink } from '../../utils/misc';
 
@@ -69,8 +69,22 @@ const DashboardAnnotationField = ({
 
       {(dashboard || panel) && (
         <>
-          <Icon name={'pen'} onClick={onEditClick} className={styles.icon} />
-          <Icon name={'trash-alt'} onClick={onDeleteClick} className={styles.icon} />
+          <IconButton
+            name="pen"
+            onClick={onEditClick}
+            aria-label={t(
+              'alerting.annotations.dashboard-annotation-field.edit',
+              'Edit annotation'
+            )}
+          />
+          <IconButton
+            name="trash-alt"
+            onClick={onDeleteClick}
+            aria-label={t(
+              'alerting.annotations.dashboard-annotation-field.delete',
+              'Delete annotation'
+            )}
+          />
         </>
       )}
     </div>
@@ -90,10 +104,6 @@ const getStyles = (theme: GrafanaTheme2) => ({
     marginRight: theme.spacing(1.5),
   }),
 
-  icon: css({
-    marginRight: theme.spacing(1),
-    cursor: 'pointer',
-  }),
 });
 
 export default DashboardAnnotationField;

--- a/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryWrapper.tsx
@@ -19,7 +19,7 @@ import {
 import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
-import { type GraphThresholdsStyleMode, Icon, InlineField, Input, Stack, Tooltip, useStyles2 } from '@grafana/ui';
+import { type GraphThresholdsStyleMode, IconButton, InlineField, Input, Stack, useStyles2 } from '@grafana/ui';
 import { logInfo } from 'app/features/alerting/unified/Analytics';
 import { QueryEditorRow } from 'app/features/query/components/QueryEditorRow';
 import { type AlertDataQuery, type AlertQuery } from 'app/types/unified-alerting-dto';
@@ -121,16 +121,18 @@ export const QueryWrapper = ({
     const styles = useStyles2(getStyles);
     return (
       <div className={styles.dsTooltip}>
-        <Tooltip
-          content={
-            <Trans i18nKey="alerting.selecting-data-source-tooltip.tooltip-content">
-              Not finding the data source you want? Some data sources are not supported for alerting. Click on the icon
-              for more information.
-            </Trans>
-          }
-        >
-          <Icon name="info-circle" onClick={() => window.open(DOCS_URL_DATA_SOURCE_ALERTING, '_blank')} />
-        </Tooltip>
+        <IconButton
+          name="info-circle"
+          aria-label={t(
+            'alerting.selecting-data-source-tooltip.aria-label',
+            'Data source alerting documentation'
+          )}
+          tooltip={t(
+            'alerting.selecting-data-source-tooltip.tooltip',
+            'Not finding the data source you want? Some data sources are not supported for alerting. Click for more information.'
+          )}
+          onClick={() => window.open(DOCS_URL_DATA_SOURCE_ALERTING, '_blank')}
+        />
       </div>
     );
   }

--- a/public/app/features/expressions/ExpressionQueryEditor.tsx
+++ b/public/app/features/expressions/ExpressionQueryEditor.tsx
@@ -166,7 +166,13 @@ export function ExpressionQueryEditor(props: ExpressionQueryEditorProps) {
         </InlineField>
         <div className={styles.fieldContainer}>
           {featureState && <FeatureBadge featureState={featureState} />}
-          {helperText && <IconButton name="info-circle" tooltip={helperText} />}
+          {helperText && (
+            <IconButton
+              name="info-circle"
+              tooltip={helperText}
+              aria-label={t('expressions.expression-query-editor.info-label', 'Expression type information')}
+            />
+          )}
         </div>
       </div>
       {renderExpressionType()}

--- a/public/app/features/transformers/editors/EnumMappingRow.tsx
+++ b/public/app/features/transformers/editors/EnumMappingRow.tsx
@@ -109,9 +109,18 @@ const EnumMappingRow = ({
               {validationError && <FieldValidationMessage>{validationError}</FieldValidationMessage>}
             </td>
           ) : (
-            // TODO fix accessibility issue here
-            // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-noninteractive-element-interactions
-            <td onClick={onEnumValueClick} className={styles.clickableTableCell}>
+            <td
+              onClick={onEnumValueClick}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  onEnumValueClick();
+                }
+              }}
+              role="button"
+              tabIndex={0}
+              className={styles.clickableTableCell}
+            >
               {value && value !== '' ? value : t('transformers.enum-mapping-row.click-to-edit', 'Click to edit')}
             </td>
           )}


### PR DESCRIPTION
## Summary

Fixes several accessibility issues where interactive elements were not keyboard-accessible or lacked proper ARIA labels.

**Changes:**

- **DashboardAnnotationField.tsx**: Replace clickable `<Icon>` elements (edit/delete) with `<IconButton>` components that provide built-in keyboard support, focus management, and `aria-label` attributes
- **QueryWrapper.tsx**: Replace clickable `<Icon>` wrapped in `<Tooltip>` with a single `<IconButton>` that has proper `aria-label` and `tooltip` props
- **EnumMappingRow.tsx**: Add `role="button"`, `tabIndex={0}`, and `onKeyDown` handler to the clickable `<td>` element so keyboard users can trigger the "click to edit" action with Enter or Space. Removes the `// TODO fix accessibility issue here` comment
- **ExpressionQueryEditor.tsx**: Add explicit `aria-label` to `<IconButton>` whose `tooltip` prop receives JSX (which doesn't auto-derive an accessible label)

## Test plan

- [x] All changes are safe -- existing mouse interactions unchanged
- [x] Keyboard navigation now works for previously inaccessible elements
- [x] Screen readers now announce proper labels for all interactive elements
