### PR TITLE
Transformations: Add copy to clipboard button for debug input/output data

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/TransformationDebugDisplay.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/TransformationDebugDisplay.tsx
@@ -3,7 +3,7 @@ import { useMemo } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
-import { Drawer, Icon, JSONFormatter, Stack, useStyles2 } from '@grafana/ui';
+import { Drawer, Icon, IconButton, JSONFormatter, Stack, useStyles2 } from '@grafana/ui';
 
 import { usePanelContext, useQueryEditorUIContext, useQueryRunnerContext } from './QueryEditorContext';
 import { useTransformationDebugData } from './hooks/useTransformationDebugData';
@@ -37,7 +37,16 @@ export function TransformationDebugDisplay() {
       <Stack direction="row" gap={1}>
         <div className={styles.debug}>
           <div className={styles.debugTitle}>
-            <Trans i18nKey="query-editor-next.transformation-debug.input-data">Input data</Trans>
+            <Stack direction="row" justifyContent="space-between" alignItems="center">
+              <Trans i18nKey="query-editor-next.transformation-debug.input-data">Input data</Trans>
+              <IconButton
+                name="copy"
+                size="sm"
+                tooltip={t('query-editor-next.transformation-debug.copy-input', 'Copy input data to clipboard')}
+                aria-label={t('query-editor-next.transformation-debug.copy-input', 'Copy input data to clipboard')}
+                onClick={() => navigator.clipboard.writeText(JSON.stringify(input, null, 2))}
+              />
+            </Stack>
           </div>
           <div className={styles.debugJson}>
             <JSONFormatter json={input} />
@@ -48,7 +57,16 @@ export function TransformationDebugDisplay() {
         </div>
         <div className={styles.debug}>
           <div className={styles.debugTitle}>
-            <Trans i18nKey="query-editor-next.transformation-debug.output-data">Output data</Trans>
+            <Stack direction="row" justifyContent="space-between" alignItems="center">
+              <Trans i18nKey="query-editor-next.transformation-debug.output-data">Output data</Trans>
+              <IconButton
+                name="copy"
+                size="sm"
+                tooltip={t('query-editor-next.transformation-debug.copy-output', 'Copy output data to clipboard')}
+                aria-label={t('query-editor-next.transformation-debug.copy-output', 'Copy output data to clipboard')}
+                onClick={() => navigator.clipboard.writeText(JSON.stringify(output, null, 2))}
+              />
+            </Stack>
           </div>
           <div className={styles.debugJson}>
             <JSONFormatter json={output} />

--- a/public/app/features/dashboard/components/TransformationsEditor/TransformationEditor.tsx
+++ b/public/app/features/dashboard/components/TransformationsEditor/TransformationEditor.tsx
@@ -9,7 +9,12 @@ import {
 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
-import { Icon, JSONFormatter, LoadingPlaceholder, useStyles2, Drawer } from '@grafana/ui';
+import { Drawer, Icon, IconButton, JSONFormatter, LoadingPlaceholder, Stack, useStyles2 } from '@grafana/ui';
+
+function copyToClipboard(data: DataFrame[]) {
+  const text = JSON.stringify(data, null, 2);
+  navigator.clipboard.writeText(text);
+}
 
 import { type TransformationsEditorTransformation } from './types';
 
@@ -71,7 +76,16 @@ export const TransformationEditor = ({
           >
             <div className={styles.debug}>
               <div className={styles.debugTitle}>
-                <Trans i18nKey="dashboard.transformation-editor.input-data">Input data</Trans>
+                <Stack direction="row" justifyContent="space-between" alignItems="center">
+                  <Trans i18nKey="dashboard.transformation-editor.input-data">Input data</Trans>
+                  <IconButton
+                    name="copy"
+                    size="sm"
+                    tooltip={t('dashboard.transformation-editor.copy-input', 'Copy input data to clipboard')}
+                    aria-label={t('dashboard.transformation-editor.copy-input', 'Copy input data to clipboard')}
+                    onClick={() => copyToClipboard(input)}
+                  />
+                </Stack>
               </div>
               <div className={styles.debugJson}>
                 <JSONFormatter json={input} />
@@ -82,7 +96,16 @@ export const TransformationEditor = ({
             </div>
             <div className={styles.debug}>
               <div className={styles.debugTitle}>
-                <Trans i18nKey="dashboard.transformation-editor.output-data">Output data</Trans>
+                <Stack direction="row" justifyContent="space-between" alignItems="center">
+                  <Trans i18nKey="dashboard.transformation-editor.output-data">Output data</Trans>
+                  <IconButton
+                    name="copy"
+                    size="sm"
+                    tooltip={t('dashboard.transformation-editor.copy-output', 'Copy output data to clipboard')}
+                    aria-label={t('dashboard.transformation-editor.copy-output', 'Copy output data to clipboard')}
+                    onClick={() => copyToClipboard(output)}
+                  />
+                </Stack>
               </div>
               <div className={styles.debugJson}>{output && <JSONFormatter json={output} />}</div>
             </div>


### PR DESCRIPTION
## Summary

Closes #115711

Adds a "Copy to clipboard" button next to the "Input data" and "Output data" headers in the transformation debug view. This allows users to easily copy the JSON data to their clipboard for debugging with external tools like `jq` or custom scripts, rather than having to manually select and copy large objects from the UI.

**Changes:**
- `TransformationEditor.tsx` (legacy editor): Added copy-to-clipboard `IconButton` to both input and output data sections
- `TransformationDebugDisplay.tsx` (new panel editor): Added copy-to-clipboard `IconButton` to both input and output data sections
- All strings are properly internationalized with `t()` calls
- Buttons have proper `aria-label` attributes for accessibility

The data is copied as pretty-printed JSON (`JSON.stringify(data, null, 2)`) so it's immediately usable in external tools.

## Test plan

- [ ] Open a dashboard with transformations
- [ ] Enable debug mode on a transformation
- [ ] Verify the copy button appears next to "Input data" and "Output data" headers
- [ ] Click the copy button and verify the JSON data is copied to the clipboard
- [ ] Paste the copied data and verify it's valid, pretty-printed JSON
