### PR TITLE
Alerting: Recover from mail.v2 nil pointer panic when sending email attachments

### DIFF
--- a/pkg/services/notifications/smtp.go
+++ b/pkg/services/notifications/smtp.go
@@ -67,7 +67,7 @@ func (sc *SmtpClient) Send(ctx context.Context, messages ...*Message) (int, erro
 	return sentEmailsCount, nil
 }
 
-func (sc *SmtpClient) sendMessage(ctx context.Context, dialer *gomail.Dialer, msg *Message) error {
+func (sc *SmtpClient) sendMessage(ctx context.Context, dialer *gomail.Dialer, msg *Message) (err error) {
 	ctx, span := tracer.Start(ctx, "notifications.SmtpClient.sendMessage", trace.WithAttributes(
 		attribute.String("smtp.sender", msg.From),
 		attribute.StringSlice("smtp.recipients", msg.To),
@@ -76,7 +76,18 @@ func (sc *SmtpClient) sendMessage(ctx context.Context, dialer *gomail.Dialer, ms
 
 	m := sc.buildEmail(ctx, msg)
 
-	err := dialer.DialAndSend(m)
+	// Recover from panics inside gopkg.in/mail.v2 (e.g. nil pointer in base64LineWriter
+	// when writing file attachments, see https://github.com/go-gomail/gomail/issues/89).
+	// Convert the panic into a regular error so a single bad message cannot crash the
+	// process or take down sibling alert-notification goroutines.
+	defer func() {
+		if r := recover(); r != nil {
+			emailsSentFailed.Inc()
+			err = tracing.Errorf(span, "panic while sending email: %v", r)
+		}
+	}()
+
+	err = dialer.DialAndSend(m)
 	emailsSentTotal.Inc()
 	if err != nil {
 		// As gomail does not returned typed errors we have to parse the error
@@ -143,15 +154,25 @@ func (sc *SmtpClient) setFiles(
 	}
 
 	for _, file := range msg.EmbeddedContents {
+		file := file
 		m.Embed(file.Name, gomail.SetCopyFunc(func(writer io.Writer) error {
+			if writer == nil {
+				return fmt.Errorf("nil writer passed for embedded content %q", file.Name)
+			}
 			_, err := writer.Write(file.Content)
 			return err
 		}))
 	}
 
 	for _, file := range msg.AttachedFiles {
+		if file == nil {
+			continue
+		}
 		file := file
 		m.Attach(file.Name, gomail.SetCopyFunc(func(writer io.Writer) error {
+			if writer == nil {
+				return fmt.Errorf("nil writer passed for attached file %q", file.Name)
+			}
 			_, err := writer.Write(file.Content)
 			return err
 		}))

--- a/pkg/services/notifications/smtp_test.go
+++ b/pkg/services/notifications/smtp_test.go
@@ -278,6 +278,32 @@ func TestSmtpSend(t *testing.T) {
 		require.True(t, found)
 	})
 
+	t.Run("does not panic when AttachedFiles contains a nil entry", func(t *testing.T) {
+		tracer := tracing.InitializeTracerForTest()
+		ctx, span := tracer.Start(ctx, "notifications.SmtpClient.SendContext")
+		defer span.End()
+
+		message := &Message{
+			From:    "from@example.com",
+			To:      []string{"rcpt@example.com"},
+			Subject: "subject",
+			Body:    map[string]string{"text/plain": "hello world"},
+			AttachedFiles: []*AttachedFile{
+				nil,
+				{Name: "ok.txt", Content: []byte("payload")},
+			},
+		}
+
+		require.NotPanics(t, func() {
+			count, sendErr := client.Send(ctx, message)
+			require.NoError(t, sendErr)
+			require.Equal(t, 1, count)
+		})
+
+		_, err := srv.WaitForMessagesAndPurge(1, 5*time.Second)
+		require.NoError(t, err)
+	})
+
 	t.Run("multiple recipients, multiple messages", func(t *testing.T) {
 		tracer := tracing.InitializeTracerForTest()
 		ctx, span := tracer.Start(ctx, "notifications.SmtpClient.SendContext")


### PR DESCRIPTION
**What is this feature?**

Recovers from panics raised inside `gopkg.in/mail.v2` while sending email and skips nil `AttachedFile` entries before passing them to gomail. A single bad message now returns a normal error from `SmtpClient.sendMessage` instead of taking down the process.

**Why do we need this feature?**

Grafana 12.0.5 panics with a nil pointer dereference at `gopkg.in/mail.v2@v2.3.1/writeto.go:299` (`(*base64LineWriter).Write`) every time an alert email with a screenshot attachment is sent. The crash hits every concurrent alert-notification goroutine simultaneously and crashes the entire process. The bug originates upstream in `gomail`/`mail.v2` (see go-gomail/gomail#89) and was never fixed there, so we have to defend at the Grafana boundary.

The closest goroutine boundary we control is `SmtpClient.sendMessage`, so a `defer recover()` there converts the panic into a regular error and increments `emailsSentFailed`, keeping the process alive and other notifications flowing. As defense in depth, `setFiles` now skips nil `AttachedFile` entries and returns an explicit error if a closure ever receives a nil writer instead of dereferencing it.

**Who is this feature for?**

Operators running Grafana with `[unified_alerting.screenshots] capture = true` and SMTP-based contact points - currently the only workaround is to disable screenshots or upload them to external storage.

**Which issue(s) does this PR fix?**:

Fixes #124000

**Special notes for your reviewer:**

- Added `TestSmtpSend/does not panic when AttachedFiles contains a nil entry` covering the nil-attachment skip path; existing `TestSmtpSend` and `TestBuildMail` suites still pass.
- The recover only fires on a true panic; happy-path errors from `dialer.DialAndSend` are returned exactly as before.
- No upstream fix exists for the gomail nil-writer issue, so a long-term option is to vendor or replace `gopkg.in/mail.v2`; this PR is the minimal safe patch.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. (n/a - bug fix)
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc. (n/a - bug fix, no user-facing config change)