### PR TITLE
Pyroscope: fix multi-value template variable regex interpolation

### DIFF
--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/datasource.test.ts
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/datasource.test.ts
@@ -9,7 +9,10 @@ import { type Query } from './types';
 function setupDatasource() {
   mockFetchPyroscopeDatasourceSettings();
   const templateSrv = {
-    replace: (query: string): string => {
+    replace: (query: string, _scopedVars?: unknown, format?: string): string => {
+      if (format === 'regex') {
+        return query.replace(/\$var/g, '(interpolated|interpolated2)');
+      }
       return query.replace(/\$var/g, 'interpolated');
     },
   } as unknown as TemplateSrv;
@@ -76,7 +79,20 @@ describe('Pyroscope data source', () => {
         defaultQuery({ labelSelector: `{$var="$var"}`, profileTypeId: '$var' }),
         {}
       );
-      expect(query).toMatchObject({ labelSelector: `{interpolated="interpolated"}`, profileTypeId: 'interpolated' });
+      expect(query).toMatchObject({
+        labelSelector: `{(interpolated|interpolated2)="(interpolated|interpolated2)"}`,
+        profileTypeId: 'interpolated',
+      });
+    });
+
+    it('should interpolate regex matchers using regex formatting for multi-value variables', () => {
+      const ds = setupDatasource();
+      const query = ds.applyTemplateVariables(
+        defaultQuery({ labelSelector: `{pod=~"$var"}`, profileTypeId: 'cpu' }),
+        {}
+      );
+
+      expect(query).toMatchObject({ labelSelector: `{pod=~"(interpolated|interpolated2)"}` });
     });
   });
 

--- a/public/app/plugins/datasource/grafana-pyroscope-datasource/datasource.ts
+++ b/public/app/plugins/datasource/grafana-pyroscope-datasource/datasource.ts
@@ -105,7 +105,7 @@ export class PyroscopeDataSource extends DataSourceWithBackend<Query, PyroscopeD
   }
 
   applyTemplateVariables(query: Query, scopedVars: ScopedVars, filters?: AdHocVariableFilter[]): Query {
-    let labelSelector = this.templateSrv.replace(query.labelSelector ?? '', scopedVars);
+    let labelSelector = this.templateSrv.replace(query.labelSelector ?? '', scopedVars, 'regex');
     if (filters && labelSelector) {
       for (const filter of filters) {
         labelSelector = addLabelToQuery(labelSelector, filter.key, filter.value, filter.operator);


### PR DESCRIPTION
**What is this feature?**

This update fixes template variable interpolation in Pyroscope profile queries by applying regex formatting to `labelSelector`.

**Why do we need this feature?**

Multi-value dashboard variables currently produce invalid regex selectors in profile queries, for example `{pod=~"{pod-1,pod-2}"}`. This change makes those selectors render as valid regex expressions.

**Who is this feature for?**

Users working with Grafana Pyroscope profile queries that use multi-value dashboard variables.

**Which issue(s) does this PR fix?**:

Fixes #68092

**Special notes for your reviewer:**

This change is limited to Pyroscope datasource variable interpolation for `labelSelector` and includes regression coverage for the multi-value matcher case.
