### PR TITLE
SQLite: enable WAL mode by default to reduce database lock contention

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -202,8 +202,11 @@ path = grafana.db
 # For "sqlite3" only. cache mode setting used for connecting to the database
 cache_mode = private
 
-# For "sqlite3" only. Enable/disable Write-Ahead Logging, https://sqlite.org/wal.html. Default is false.
-wal = false
+# For "sqlite3" only. Enable/disable Write-Ahead Logging, https://sqlite.org/wal.html. Default is true.
+# WAL mode significantly reduces "database is locked" errors under concurrent load.
+# Set to false if your database file resides on a network-mounted volume (NFS, EFS, CIFS),
+# as SQLite WAL requires file locking that most network filesystems do not support reliably.
+wal = true
 
 # For "mysql" and "postgres". Lock the database for the migrations, default is true.
 migration_locking = true

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -188,8 +188,11 @@
 # For "sqlite3" only. cache mode setting used for connecting to the database. (private, shared)
 ;cache_mode = private
 
-# For "sqlite3" only. Enable/disable Write-Ahead Logging, https://sqlite.org/wal.html. Default is false.
-;wal = false
+# For "sqlite3" only. Enable/disable Write-Ahead Logging, https://sqlite.org/wal.html. Default is true.
+# WAL mode significantly reduces "database is locked" errors under concurrent load.
+# Set to false if your database file resides on a network-mounted volume (NFS, EFS, CIFS),
+# as SQLite WAL requires file locking that most network filesystems do not support reliably.
+;wal = true
 
 # For "mysql" and "postgres" only. Lock the database for the migrations, default is true.
 ;migration_locking = true

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -473,7 +473,9 @@ Defaults to `private`.
 
 #### `wal`
 
-For "sqlite3" only. Setting to enable/disable [Write-Ahead Logging](https://sqlite.org/wal.html). The default value is `false` (disabled).
+For "sqlite3" only. Setting to enable/disable [Write-Ahead Logging](https://sqlite.org/wal.html). The default value is `true` (enabled).
+
+WAL mode significantly reduces "database is locked" errors under concurrent load. Set to `false` if your SQLite database file resides on a network-mounted volume (NFS, EFS, CIFS), as WAL requires file locking that most network filesystems do not support reliably.
 
 #### `query_retries`
 

--- a/pkg/services/sqlstore/database_config.go
+++ b/pkg/services/sqlstore/database_config.go
@@ -117,7 +117,7 @@ func (dbCfg *DatabaseConfig) readConfig(cfg *setting.Cfg) error {
 	dbCfg.IsolationLevel = sec.Key("isolation_level").String()
 
 	dbCfg.CacheMode = sec.Key("cache_mode").MustString("private")
-	dbCfg.WALEnabled = sec.Key("wal").MustBool(false)
+	dbCfg.WALEnabled = sec.Key("wal").MustBool(true)
 	dbCfg.SkipMigrations = sec.Key("skip_migrations").MustBool()
 	dbCfg.EnsureDefaultOrgAndUser = sec.Key("ensure_default_org_and_user").MustBool(true)
 	dbCfg.MigrationLock = sec.Key("migration_locking").MustBool(true)

--- a/pkg/services/sqlstore/database_config_test.go
+++ b/pkg/services/sqlstore/database_config_test.go
@@ -3,6 +3,7 @@ package sqlstore
 import (
 	"errors"
 	"net/url"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -213,4 +214,60 @@ func TestBuildConnectionStringPostgres(t *testing.T) {
 			assert.Equal(t, tc.expectedConnStr, tc.dbCfg.ConnectionString)
 		})
 	}
+}
+
+func TestSQLiteWALDefault(t *testing.T) {
+	t.Run("WAL is enabled by default when not explicitly configured", func(t *testing.T) {
+		// nolint:staticcheck
+		cfg := setting.NewCfgWithFeatures(featuremgmt.WithFeatures().IsEnabledGlobally)
+		sec, err := cfg.Raw.NewSection("database")
+		require.NoError(t, err)
+		_, err = sec.NewKey("type", migrator.SQLite)
+		require.NoError(t, err)
+
+		dbCfg := &DatabaseConfig{}
+		require.NoError(t, dbCfg.readConfig(cfg))
+
+		assert.True(t, dbCfg.WALEnabled, "WAL should be enabled by default for SQLite")
+	})
+
+	t.Run("WAL can be explicitly disabled", func(t *testing.T) {
+		// nolint:staticcheck
+		cfg := setting.NewCfgWithFeatures(featuremgmt.WithFeatures().IsEnabledGlobally)
+		sec, err := cfg.Raw.NewSection("database")
+		require.NoError(t, err)
+		_, err = sec.NewKey("type", migrator.SQLite)
+		require.NoError(t, err)
+		_, err = sec.NewKey("wal", "false")
+		require.NoError(t, err)
+
+		dbCfg := &DatabaseConfig{}
+		require.NoError(t, dbCfg.readConfig(cfg))
+
+		assert.False(t, dbCfg.WALEnabled, "WAL should be disabled when explicitly set to false")
+	})
+
+	t.Run("WAL enabled adds journal_mode to SQLite connection string", func(t *testing.T) {
+		dbCfg := &DatabaseConfig{
+			Type:       migrator.SQLite,
+			Path:       filepath.Join(t.TempDir(), "grafana_test.db"),
+			WALEnabled: true,
+			CacheMode:  "private",
+		}
+		cfg := &setting.Cfg{}
+		require.NoError(t, dbCfg.buildConnectionString(cfg, nil))
+		assert.Contains(t, dbCfg.ConnectionString, "_journal_mode=WAL")
+	})
+
+	t.Run("WAL disabled omits journal_mode from SQLite connection string", func(t *testing.T) {
+		dbCfg := &DatabaseConfig{
+			Type:       migrator.SQLite,
+			Path:       filepath.Join(t.TempDir(), "grafana_test.db"),
+			WALEnabled: false,
+			CacheMode:  "private",
+		}
+		cfg := &setting.Cfg{}
+		require.NoError(t, dbCfg.buildConnectionString(cfg, nil))
+		assert.NotContains(t, dbCfg.ConnectionString, "_journal_mode=WAL")
+	})
 }


### PR DESCRIPTION
**What is this feature?**

Changes the SQLite WAL (Write-Ahead Logging) default from `false` to `true` in `database_config.go`, `conf/defaults.ini`, `conf/sample.ini`, and the official configuration docs.

**Why do we need this feature?**

WAL mode significantly reduces "database is locked" errors under concurrent load (multiple readers + one writer). The previous default of `false` forced users to discover and manually enable this — often only after hitting production lock errors. Test infrastructure already enabled WAL explicitly (`testinfra.go:895`) and the `sqlutil` test helper already appended `_journal_mode=WAL` to test connection strings. This aligns the production default with what the codebase already relies on for correctness in tests.

Operators on network-mounted volumes (NFS, EFS, CIFS) should set `wal = false`, as WAL requires advisory file locking not reliably supported by those filesystems. This caveat is now documented in `defaults.ini`, `sample.ini`, and the configuration reference docs.

**Who is this feature for?**

All users running Grafana with the default SQLite backend, especially those seeing intermittent "database is locked" errors under normal load.

**Which issue(s) does this PR fix?**

Fixes #65115

**Special notes for your reviewer:**

- Previous attempt (#91778) only changed the ini files but missed updating `MustBool` in `database_config.go`, the comment saying "Default is false", the NFS warning, unit tests, and the official docs. This PR addresses all of those gaps.
- No feature flag needed — WAL is a stable, well-established SQLite feature since 2010.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] This is not a pre-GA feature — no feature toggle required.
- [x] The docs are updated (`docs/sources/setup-grafana/configure-grafana/_index.md`).