### PR TITLE
ci: use github-hosted-ubuntu-x64-small for codeowners validator

### DIFF
--- a/.github/workflows/codeowners-validator.yml
+++ b/.github/workflows/codeowners-validator.yml
@@ -13,7 +13,7 @@ jobs:
       contents: read
     steps:
       # Checks-out your repository, which is validated in the next step
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - name: GitHub CODEOWNERS Validator

--- a/.github/workflows/codeowners-validator.yml
+++ b/.github/workflows/codeowners-validator.yml
@@ -8,7 +8,7 @@ permissions: {}
 
 jobs:
   codeowners-validator:
-    runs-on: ubuntu-latest
+    runs-on: github-hosted-ubuntu-x64-small
     permissions:
       contents: read
     steps:


### PR DESCRIPTION
Switch the codeowners validator workflow to the `github-hosted-ubuntu-x64-small` runner.