### PR TITLE
Add StyleConfig options builder to lastPointTracker

### DIFF
--- a/public/app/plugins/panel/geomap/layers/data/lastPointTracker.ts
+++ b/public/app/plugins/panel/geomap/layers/data/lastPointTracker.ts
@@ -4,14 +4,24 @@ import * as layer from 'ol/layer';
 import * as source from 'ol/source';
 import * as style from 'ol/style';
 
-import { type MapLayerRegistryItem, type MapLayerOptions, type PanelData, type GrafanaTheme2, PluginState, type EventBus } from '@grafana/data';
+import { type MapLayerRegistryItem, type MapLayerOptions, type PanelData, type GrafanaTheme2, type EventBus, PluginState } from '@grafana/data';
 import { getGeometryField, getLocationMatchers } from 'app/features/geo/utils/location';
 
+import { StyleEditor } from '../../editor/StyleEditor';
+import { defaultStyleConfig, type StyleConfig } from '../../style/types';
+import { getStyleConfigState } from '../../style/utils';
+import { getStyleDimension } from '../../utils/utils';
+
 export interface LastPointConfig {
+  style: StyleConfig;
   icon?: string;
 }
 
 const defaultOptions: LastPointConfig = {
+  style: {
+    ...defaultStyleConfig,
+    opacity: 1,
+  },
   icon: 'https://openlayers.org/en/latest/examples/data/icon.png',
 };
 
@@ -32,14 +42,20 @@ export const lastPointTracker: MapLayerRegistryItem<LastPointConfig> = {
   create: async (map: OpenLayersMap, options: MapLayerOptions<LastPointConfig>, eventBus: EventBus, theme: GrafanaTheme2) => {
     const point = new Feature({});
     const config = { ...defaultOptions, ...options.config };
+    const styleState = await getStyleConfigState(config.style);
+    const useLegacyIcon = Boolean(options.config?.icon && !options.config?.style);
 
-    point.setStyle(
-      new style.Style({
-        image: new style.Icon({
-          src: config.icon,
-        }),
-      })
-    );
+    if (useLegacyIcon) {
+      point.setStyle(
+        new style.Style({
+          image: new style.Icon({
+            src: config.icon,
+          }),
+        })
+      );
+    } else {
+      point.setStyle(styleState.maker(styleState.base));
+    }
 
     const vectorSource = new source.Vector({
       features: [point],
@@ -59,8 +75,43 @@ export const lastPointTracker: MapLayerRegistryItem<LastPointConfig> = {
           if (!out.field) {
             return; // ???
           }
+
+          if (!useLegacyIcon) {
+            const dims = getStyleDimension(frame, styleState, theme);
+            const rowIndex = frame.length - 1;
+            const values = { ...styleState.base };
+
+            if (dims.color) {
+              values.color = dims.color.get(rowIndex);
+            }
+            if (dims.size) {
+              values.size = dims.size.get(rowIndex);
+            }
+            if (dims.text) {
+              values.text = dims.text.get(rowIndex);
+            }
+            if (dims.rotation) {
+              values.rotation = dims.rotation.get(rowIndex);
+            }
+
+            point.setStyle(styleState.maker(values));
+          }
+
           point.setGeometry(out.field.values[frame.length - 1]);
         }
+      },
+
+      registerOptionsUI: (builder) => {
+        builder.addCustomEditor({
+          id: 'config.style',
+          path: 'config.style',
+          name: 'Style',
+          editor: StyleEditor,
+          settings: {
+            displayRotation: true,
+          },
+          defaultValue: defaultOptions.style,
+        });
       },
     };
   },


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Use the StyleConfig interface & builder for the icon at last point layer for the geomap plugin.

**Why do we need this feature?**

This features allows to use a n svg in place of the placeholder png, and use queries to scale/color/rotate the icon.

**Who is this feature for?**

Any user of the layer

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
