### PR TITLE
Dashboard: Restore keyboard focus to adjacent panel after deletion

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
@@ -28,6 +28,7 @@ import {
 } from '../../utils/utils';
 import { DashboardGridItem } from '../layout-default/DashboardGridItem';
 import { clearClipboard, getAutoGridItemFromClipboard } from '../layouts-shared/paste';
+import { findAdjacentVizPanel, focusVizPanel } from '../layouts-shared/utils';
 import { type DashboardDropTarget } from '../types/DashboardDropTarget';
 import { type DashboardLayoutGrid } from '../types/DashboardLayoutGrid';
 import { type DashboardLayoutManager } from '../types/DashboardLayoutManager';
@@ -184,6 +185,9 @@ export class AutoGridLayoutManager
     }
 
     const gridItemIndex = this.state.layout.state.children.indexOf(gridItem);
+    const adjacentPanel = findAdjacentVizPanel(gridItem, this.state.layout.state.children, (item) =>
+      item instanceof AutoGridItem ? item.state.body : undefined
+    );
 
     dashboardEditActions.removeElement({
       removedObject: panel,
@@ -203,6 +207,7 @@ export class AutoGridLayoutManager
         });
       },
     });
+    focusVizPanel(adjacentPanel);
   }
 
   // panelIdGenerator is a shared counter to ensure unique panel IDs across siblings.

--- a/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
@@ -49,6 +49,7 @@ import { AutoGridItem } from '../layout-auto-grid/AutoGridItem';
 import { CanvasGridAddActions } from '../layouts-shared/CanvasGridAddActions';
 import { clearClipboard, getDashboardGridItemFromClipboard } from '../layouts-shared/paste';
 import { dashboardCanvasAddButtonHoverStyles } from '../layouts-shared/styles';
+import { findAdjacentVizPanel, focusVizPanel } from '../layouts-shared/utils';
 import { type DashboardLayoutGrid } from '../types/DashboardLayoutGrid';
 import { type DashboardLayoutManager } from '../types/DashboardLayoutManager';
 import { type LayoutRegistryItem } from '../types/LayoutRegistryItem';
@@ -241,15 +242,22 @@ export class DefaultGridLayoutManager
       row = undefined;
     }
 
+    const siblings = row ? row.state.children : layout.state.children;
+    const adjacentPanel = findAdjacentVizPanel(gridItem, siblings, (item) =>
+      item instanceof DashboardGridItem ? item.state.body : undefined
+    );
+
     if (row) {
       row.setState({ children: row.state.children.filter((child) => child !== gridItem) });
       layout.forceRender();
+      focusVizPanel(adjacentPanel);
       return;
     }
 
     if (!config.featureToggles.dashboardNewLayouts) {
       // No undo/redo support in legacy edit mode
       layout.setState({ children: layout.state.children.filter((child) => child !== gridItem) });
+      focusVizPanel(adjacentPanel);
       return;
     }
 
@@ -259,6 +267,7 @@ export class DefaultGridLayoutManager
       perform: () => layout.setState({ children: layout.state.children.filter((child) => child !== gridItem) }),
       undo: () => layout.setState({ children: [...layout.state.children, gridItem] }),
     });
+    focusVizPanel(adjacentPanel);
   }
 
   public duplicatePanel(vizPanel: VizPanel) {

--- a/public/app/features/dashboard-scene/scene/layouts-shared/utils.test.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/utils.test.ts
@@ -1,4 +1,6 @@
-import { generateUniqueTitle } from './utils';
+import { VizPanel } from '@grafana/scenes';
+
+import { findAdjacentVizPanel, focusVizPanel, generateUniqueTitle } from './utils';
 
 describe('generateUniqueTitle', () => {
   it('should return the original title if it is not in the existing titles', () => {
@@ -46,5 +48,86 @@ describe('generateUniqueTitle', () => {
     const title = 'My Title';
     const existingTitles = new Set<string>();
     expect(generateUniqueTitle(title, existingTitles)).toBe(title);
+  });
+});
+
+describe('findAdjacentVizPanel', () => {
+  const a = new VizPanel({ key: 'panel-a', pluginId: 'table' });
+  const b = new VizPanel({ key: 'panel-b', pluginId: 'table' });
+  const c = new VizPanel({ key: 'panel-c', pluginId: 'table' });
+
+  it('returns the next sibling when one exists', () => {
+    const siblings = [{ panel: a }, { panel: b }, { panel: c }];
+    expect(findAdjacentVizPanel(siblings[1], siblings, (s) => s.panel)).toBe(c);
+  });
+
+  it('falls back to the previous sibling when removing the last item', () => {
+    const siblings = [{ panel: a }, { panel: b }, { panel: c }];
+    expect(findAdjacentVizPanel(siblings[2], siblings, (s) => s.panel)).toBe(b);
+  });
+
+  it('skips siblings whose getPanel returns undefined', () => {
+    const siblings = [{ panel: a }, { panel: undefined }, { panel: c }];
+    expect(findAdjacentVizPanel(siblings[0], siblings, (s) => s.panel)).toBe(c);
+  });
+
+  it('returns undefined when the removed item is not in siblings', () => {
+    const siblings = [{ panel: a }];
+    expect(findAdjacentVizPanel({ panel: b }, siblings, (s) => s.panel)).toBeUndefined();
+  });
+
+  it('returns undefined when there are no other panels', () => {
+    const siblings = [{ panel: a }];
+    expect(findAdjacentVizPanel(siblings[0], siblings, (s) => s.panel)).toBeUndefined();
+  });
+});
+
+describe('focusVizPanel', () => {
+  const originalRAF = window.requestAnimationFrame;
+
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    window.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      cb(0);
+      return 0;
+    }) as typeof window.requestAnimationFrame;
+  });
+
+  afterEach(() => {
+    window.requestAnimationFrame = originalRAF;
+  });
+
+  it('focuses the section inside the matching data-viz-panel-key wrapper', () => {
+    document.body.innerHTML = `
+      <div data-viz-panel-key="panel-a"><section tabindex="0"></section></div>
+      <div data-viz-panel-key="panel-b"><section tabindex="0"></section></div>
+    `;
+
+    const panel = new VizPanel({ key: 'panel-b', pluginId: 'table' });
+    focusVizPanel(panel);
+
+    const target = document.querySelector('[data-viz-panel-key="panel-b"] section');
+    expect(document.activeElement).toBe(target);
+  });
+
+  it('does nothing when panel is undefined', () => {
+    document.body.innerHTML = `<button id="other"></button>`;
+    const other = document.getElementById('other')!;
+    other.focus();
+
+    focusVizPanel(undefined);
+
+    expect(document.activeElement).toBe(other);
+  });
+
+  it('does nothing when no element matches the panel key', () => {
+    document.body.innerHTML = `<button id="other"></button>`;
+    const other = document.getElementById('other')!;
+    other.focus();
+
+    const panel = new VizPanel({ key: 'panel-missing', pluginId: 'table' });
+    focusVizPanel(panel);
+
+    expect(document.activeElement).toBe(other);
   });
 });

--- a/public/app/features/dashboard-scene/scene/layouts-shared/utils.ts
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/utils.ts
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 
-import { type SceneObject } from '@grafana/scenes';
+import { type SceneObject, type VizPanel } from '@grafana/scenes';
 import { contextSrv } from 'app/core/services/context_srv';
 
 import { type DashboardLayoutManager, isDashboardLayoutManager } from '../types/DashboardLayoutManager';
@@ -80,6 +80,50 @@ export function ungroupLayout(layout: DashboardLayoutManager, innerLayout: Dashb
 export function getIsLazy(preload: boolean | undefined): boolean {
   // We don't want to lazy load panels in the case of image renderer
   return !(preload || (contextSrv.user && contextSrv.user.authenticatedBy === 'render'));
+}
+
+export function findAdjacentVizPanel<T>(
+  removedSibling: T,
+  siblings: T[],
+  getPanel: (sibling: T) => VizPanel | undefined
+): VizPanel | undefined {
+  const index = siblings.indexOf(removedSibling);
+  if (index === -1) {
+    return undefined;
+  }
+
+  for (let i = index + 1; i < siblings.length; i++) {
+    const panel = getPanel(siblings[i]);
+    if (panel) {
+      return panel;
+    }
+  }
+  for (let i = index - 1; i >= 0; i--) {
+    const panel = getPanel(siblings[i]);
+    if (panel) {
+      return panel;
+    }
+  }
+  return undefined;
+}
+
+export function focusVizPanel(panel: VizPanel | undefined): void {
+  if (!panel || typeof window === 'undefined' || typeof requestAnimationFrame === 'undefined') {
+    return;
+  }
+
+  const key = panel.state.key;
+  if (!key) {
+    return;
+  }
+
+  // Wait one frame so React commits the removal and the confirm modal's
+  // FloatingFocusManager has a chance to run its (now-failing) focus restore
+  // before we move focus to the adjacent panel.
+  requestAnimationFrame(() => {
+    const target = document.querySelector<HTMLElement>(`[data-viz-panel-key="${CSS.escape(key)}"] section`);
+    target?.focus();
+  });
 }
 
 export enum GridLayoutType {


### PR DESCRIPTION
**What is this feature?**

Keep keyboard focus on a neighboring panel after a panel is deleted, instead of letting it fall back to `document.body`.

Before(with shortcut):

[Screencast from 2026-05-04 17-40-27.webm](https://github.com/user-attachments/assets/3053bdeb-c3ad-4ae8-9a2a-62fbfd229695)

After(with shortcut):

[Screencast from 2026-05-04 17-37-38.webm](https://github.com/user-attachments/assets/f8ea86ae-79d0-44b4-9134-ed58a95f9b4a)

**Why do we need this feature?**

After a panel is deleted, keyboard focus moves to the next (or previous) panel instead of being lost. 
**Who is this feature for?**

Keyboard and screen reader users who edit dashboards.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #95721 

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.


Notes:
Unit tests added for `findAdjacentVizPanel` and `focusVizPanel`.
