### PR TITLE
Unified Storage: retry batched RV transaction on SQLITE_BUSY

### DIFF
--- a/pkg/storage/unified/sql/rvmanager/rv_manager.go
+++ b/pkg/storage/unified/sql/rvmanager/rv_manager.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/bwmarrin/snowflake"
+	"github.com/grafana/dskit/backoff"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.opentelemetry.io/otel"
@@ -19,6 +20,7 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/sql/db"
 	"github.com/grafana/grafana/pkg/storage/unified/sql/dbutil"
 	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
+	"github.com/grafana/grafana/pkg/util/sqlite"
 )
 
 var tracer = otel.Tracer("github.com/grafana/grafana/pkg/storage/unified/sql/rvmanager")
@@ -67,6 +69,13 @@ const (
 	// ResourceManagerOptions.BatchTransactionTimeout (wired from the
 	// [unified_storage] resource_version_batch_transaction_timeout ini key).
 	defaultBatchTimeout = 5 * time.Second
+
+	// SQLite serializes writes; under contention an INSERT/UPDATE can return
+	// SQLITE_BUSY even with the busy_timeout pragma. The transaction is rolled
+	// back, so the whole batched WithTx is safe to retry from the start.
+	sqliteBusyMaxRetries = 5
+	sqliteBusyMinBackoff = 50 * time.Millisecond
+	sqliteBusyMaxBackoff = 500 * time.Millisecond
 )
 
 // ResourceVersionManager handles resource version operations
@@ -273,90 +282,124 @@ func (m *ResourceVersionManager) execBatch(ctx context.Context, group, resource 
 	ctx, cancel := context.WithTimeout(ctx, m.batchTransactionTimeout())
 	defer cancel()
 
-	guidToRV := make(map[string]int64, len(batch))
-	guidToSnowflakeRV := make(map[string]int64, len(batch))
-	guids := make([]string, len(batch)) // The GUIDs of the created resources in the same order as the batch
-	rvs := make([]int64, len(batch))    // The RVs of the created resources in the same order as the batch
+	var (
+		guidToRV          map[string]int64
+		guidToSnowflakeRV map[string]int64
+		guids             []string
+		rvs               []int64
+	)
 
-	err = m.db.WithTx(ctx, readCommitted, func(ctx context.Context, tx db.Tx) error {
-		span.AddEvent("starting_batch_transaction")
+	runBatch := func() error {
+		// Reset per-attempt state so SQLite busy retries do not carry over
+		// guids/rvs from a rolled-back attempt.
+		guidToRV = make(map[string]int64, len(batch))
+		guidToSnowflakeRV = make(map[string]int64, len(batch))
+		guids = make([]string, len(batch))
+		rvs = make([]int64, len(batch))
 
-		writeTimer := prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {
-			rvmExecBatchPhaseDuration.WithLabelValues(group, resource, "write_ops").Observe(v)
-		}))
-		for i := range batch {
-			guid, err := batch[i].fn(ctx, tx)
+		return m.db.WithTx(ctx, readCommitted, func(ctx context.Context, tx db.Tx) error {
+			span.AddEvent("starting_batch_transaction")
+
+			writeTimer := prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {
+				rvmExecBatchPhaseDuration.WithLabelValues(group, resource, "write_ops").Observe(v)
+			}))
+			for i := range batch {
+				guid, err := batch[i].fn(ctx, tx)
+				if err != nil {
+					span.AddEvent("batch_operation_failed", trace.WithAttributes(
+						attribute.Int("operation_index", i),
+						attribute.String("error", err.Error()),
+					))
+					return err
+				}
+				guids[i] = guid
+			}
+			writeTimer.ObserveDuration()
+			span.AddEvent("batch_operations_completed")
+
+			lockTimer := prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {
+				rvmExecBatchPhaseDuration.WithLabelValues(group, resource, "waiting_for_lock").Observe(v)
+			}))
+			rv, err := m.Lock(ctx, tx, group, resource)
+			lockTimer.ObserveDuration()
 			if err != nil {
-				span.AddEvent("batch_operation_failed", trace.WithAttributes(
-					attribute.Int("operation_index", i),
+				span.AddEvent("resource_version_lock_failed", trace.WithAttributes(
 					attribute.String("error", err.Error()),
 				))
-				return err
+				return fmt.Errorf("failed to increment resource version: %w", err)
 			}
-			guids[i] = guid
-		}
-		writeTimer.ObserveDuration()
-		span.AddEvent("batch_operations_completed")
+			span.AddEvent("resource_version_locked", trace.WithAttributes(
+				attribute.Int64("initial_rv", rv),
+			))
 
-		lockTimer := prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {
-			rvmExecBatchPhaseDuration.WithLabelValues(group, resource, "waiting_for_lock").Observe(v)
-		}))
-		rv, err := m.Lock(ctx, tx, group, resource)
-		lockTimer.ObserveDuration()
-		if err != nil {
-			span.AddEvent("resource_version_lock_failed", trace.WithAttributes(
+			rvUpdateTimer := prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {
+				rvmExecBatchPhaseDuration.WithLabelValues(group, resource, "update_resource_versions").Observe(v)
+			}))
+			defer rvUpdateTimer.ObserveDuration()
+			// Allocate the RVs
+			for i, guid := range guids {
+				guidToRV[guid] = rv
+				guidToSnowflakeRV[guid] = SnowflakeFromRV(rv)
+				rvs[i] = rv
+				rv++
+			}
+			// Update the resource version for the created resources in both the resource and the resource history
+			if _, err := dbutil.Exec(ctx, tx, SqlResourceUpdateRV, SqlResourceUpdateRVRequest{
+				SQLTemplate: sqltemplate.New(m.dialect),
+				GUIDToRV:    guidToRV,
+			}); err != nil {
+				span.AddEvent("resource_update_rv_failed", trace.WithAttributes(
+					attribute.String("error", err.Error()),
+				))
+				return fmt.Errorf("update resource version: %w", err)
+			}
+			span.AddEvent("resource_versions_updated")
+
+			if _, err := dbutil.Exec(ctx, tx, SqlResourceHistoryUpdateRV, SqlResourceUpdateRVRequest{
+				SQLTemplate:       sqltemplate.New(m.dialect),
+				GUIDToRV:          guidToRV,
+				GUIDToSnowflakeRV: guidToSnowflakeRV,
+			}); err != nil {
+				span.AddEvent("resource_history_update_rv_failed", trace.WithAttributes(
+					attribute.String("error", err.Error()),
+				))
+				return fmt.Errorf("update resource history version: %w", err)
+			}
+			span.AddEvent("resource_history_versions_updated")
+
+			// Record the latest RV in the resource version table
+			err = m.SaveRV(ctx, tx, group, resource, rv)
+			if err != nil {
+				span.AddEvent("save_rv_failed", trace.WithAttributes(
+					attribute.String("error", err.Error()),
+				))
+			}
+			return err
+		})
+	}
+
+	err = runBatch()
+	if err != nil && sqlite.IsBusyOrLocked(err) {
+		boff := backoff.New(ctx, backoff.Config{
+			MinBackoff: sqliteBusyMinBackoff,
+			MaxBackoff: sqliteBusyMaxBackoff,
+			MaxRetries: sqliteBusyMaxRetries,
+		})
+		for boff.Ongoing() {
+			span.AddEvent("batch_transaction_retry_sqlite_busy", trace.WithAttributes(
+				attribute.Int("attempt", boff.NumRetries()+1),
 				attribute.String("error", err.Error()),
 			))
-			return fmt.Errorf("failed to increment resource version: %w", err)
+			boff.Wait()
+			if ctx.Err() != nil {
+				break
+			}
+			err = runBatch()
+			if err == nil || !sqlite.IsBusyOrLocked(err) {
+				break
+			}
 		}
-		span.AddEvent("resource_version_locked", trace.WithAttributes(
-			attribute.Int64("initial_rv", rv),
-		))
-
-		rvUpdateTimer := prometheus.NewTimer(prometheus.ObserverFunc(func(v float64) {
-			rvmExecBatchPhaseDuration.WithLabelValues(group, resource, "update_resource_versions").Observe(v)
-		}))
-		defer rvUpdateTimer.ObserveDuration()
-		// Allocate the RVs
-		for i, guid := range guids {
-			guidToRV[guid] = rv
-			guidToSnowflakeRV[guid] = SnowflakeFromRV(rv)
-			rvs[i] = rv
-			rv++
-		}
-		// Update the resource version for the created resources in both the resource and the resource history
-		if _, err := dbutil.Exec(ctx, tx, SqlResourceUpdateRV, SqlResourceUpdateRVRequest{
-			SQLTemplate: sqltemplate.New(m.dialect),
-			GUIDToRV:    guidToRV,
-		}); err != nil {
-			span.AddEvent("resource_update_rv_failed", trace.WithAttributes(
-				attribute.String("error", err.Error()),
-			))
-			return fmt.Errorf("update resource version: %w", err)
-		}
-		span.AddEvent("resource_versions_updated")
-
-		if _, err := dbutil.Exec(ctx, tx, SqlResourceHistoryUpdateRV, SqlResourceUpdateRVRequest{
-			SQLTemplate:       sqltemplate.New(m.dialect),
-			GUIDToRV:          guidToRV,
-			GUIDToSnowflakeRV: guidToSnowflakeRV,
-		}); err != nil {
-			span.AddEvent("resource_history_update_rv_failed", trace.WithAttributes(
-				attribute.String("error", err.Error()),
-			))
-			return fmt.Errorf("update resource history version: %w", err)
-		}
-		span.AddEvent("resource_history_versions_updated")
-
-		// Record the latest RV in the resource version table
-		err = m.SaveRV(ctx, tx, group, resource, rv)
-		if err != nil {
-			span.AddEvent("save_rv_failed", trace.WithAttributes(
-				attribute.String("error", err.Error()),
-			))
-		}
-		return err
-	})
+	}
 
 	if err != nil {
 		span.AddEvent("batch_transaction_failed", trace.WithAttributes(

--- a/pkg/storage/unified/sql/rvmanager/rv_manager_test.go
+++ b/pkg/storage/unified/sql/rvmanager/rv_manager_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/sql/db"
 	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
 	"github.com/grafana/grafana/pkg/storage/unified/sql/test"
+	"github.com/grafana/grafana/pkg/util/sqlite"
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
 
@@ -144,6 +145,66 @@ func TestExecWithRV_transactionContextRegression(t *testing.T) {
 		})
 		require.Error(t, err)
 		require.True(t, errors.Is(err, context.Canceled), "got %v", err)
+	})
+}
+
+// TestExecBatch_RetriesOnSQLiteBusy guards the retry path added to absorb
+// transient SQLITE_BUSY errors during provisioning sync, where the unified
+// storage layer would otherwise surface "database is locked" through the
+// resource_insert.sql write and fail the whole sync job.
+func TestExecBatch_RetriesOnSQLiteBusy(t *testing.T) {
+	ctx := testutil.NewDefaultTestContext(t)
+
+	t.Run("retries until success", func(t *testing.T) {
+		dbp := test.NewDBProviderMatchWords(t)
+		dialect := sqltemplate.DialectForDriver(dbp.DB.DriverName())
+		manager, err := NewResourceVersionManager(ResourceManagerOptions{
+			DB:      dbp.DB,
+			Dialect: dialect,
+		})
+		require.NoError(t, err)
+
+		// First attempt: insert returns BUSY, transaction rolled back.
+		dbp.SQLMock.ExpectBegin()
+		dbp.SQLMock.ExpectExec("insert resource").WillReturnError(sqlite.ErrTestBusy)
+		dbp.SQLMock.ExpectRollback()
+
+		// Second attempt: clean run, including RV bookkeeping that ExecWithRV does.
+		dbp.SQLMock.ExpectBegin()
+		dbp.SQLMock.ExpectExec("insert resource").WillReturnResult(sqlmock.NewResult(1, 1))
+		expectSuccessfulResourceVersionExec(t, dbp)
+		dbp.SQLMock.ExpectCommit()
+
+		key := &resourcepb.ResourceKey{Group: "retry-busy", Resource: "res"}
+		rv, err := manager.ExecWithRV(ctx, key, func(txnCtx context.Context, tx db.Tx) (string, error) {
+			_, err := tx.ExecContext(txnCtx, "insert resource")
+			return "guid-1", err
+		})
+		require.NoError(t, err)
+		require.Equal(t, int64(200), rv)
+	})
+
+	t.Run("non-busy errors do not retry", func(t *testing.T) {
+		dbp := test.NewDBProviderMatchWords(t)
+		dialect := sqltemplate.DialectForDriver(dbp.DB.DriverName())
+		manager, err := NewResourceVersionManager(ResourceManagerOptions{
+			DB:      dbp.DB,
+			Dialect: dialect,
+		})
+		require.NoError(t, err)
+
+		boom := errors.New("not a busy error")
+		dbp.SQLMock.ExpectBegin()
+		dbp.SQLMock.ExpectExec("insert resource").WillReturnError(boom)
+		dbp.SQLMock.ExpectRollback()
+
+		key := &resourcepb.ResourceKey{Group: "no-retry", Resource: "res"}
+		_, err = manager.ExecWithRV(ctx, key, func(txnCtx context.Context, tx db.Tx) (string, error) {
+			_, err := tx.ExecContext(txnCtx, "insert resource")
+			return "guid-1", err
+		})
+		require.Error(t, err)
+		require.ErrorIs(t, err, boom)
 	})
 }
 


### PR DESCRIPTION
## Summary

Fixes a provisioning integration-test flake (e.g. `TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename/non-metadata_folder_rename_still_works_via_delete_and_create` in [run #25173843119](https://github.com/grafana/grafana/actions/runs/25173843119/job/73801398070)) where sync fails with:

```
writing resource from file old-team/dashboard1.json: transactional operation:
insert into resource: resource_insert.sql: ... database is locked (5) (SQLITE_BUSY)
```

SQLite serializes writes; even with `busy_timeout=7500ms` set via PRAGMA, hard contention bursts in CI can push a single statement over budget and surface `SQLITE_BUSY`. `rvmanager.execBatch` wraps the whole batched write — `WriteEventFunc` calls plus the resource-version lock and RV stamp updates — in one `WithTx`. When that transaction returns BUSY it is rolled back cleanly, so re-running the whole batch from scratch is safe, but no retry was wired up.

## Changes

- `pkg/storage/unified/sql/rvmanager/rv_manager.go`: extract the `WithTx` body into a `runBatch` closure, then wrap the call in a bounded `dskit/backoff` retry that fires only when `sqlite.IsBusyOrLocked(err)` returns true. Backoff: 50ms→500ms, max 5 attempts, capped by the existing batch context timeout. Per-attempt state (`guidToRV`, `guidToSnowflakeRV`, `guids`, `rvs`) is reset at the start of each attempt so a rolled-back batch cannot leak entries forward. Non-busy errors and non-SQLite drivers fall through unchanged (the helper returns false for them).
- `pkg/storage/unified/sql/rvmanager/rv_manager_test.go`: new `TestExecBatch_RetriesOnSQLiteBusy` covers retry-until-success (using `sqlite.ErrTestBusy`) and the no-retry-on-other-errors path via sqlmock.

This mirrors the existing pattern in `pkg/services/sqlstore/migrator/migrator.go` and `apps/provisioning/pkg/controller/status.go`, both of which already retry SQLITE_BUSY at their respective transaction boundaries.

## Test plan

- [x] `go test ./pkg/storage/unified/sql/rvmanager/... -count=1`
- [x] `go test ./pkg/storage/unified/sql/... -count=1 -short`
- [x] `go build ./...`
- [ ] CI: re-run the flaky `TestIntegrationProvisioning_IncrementalSync_GracefulFolderRename` integration test on SQLite to confirm the busy retry absorbs the contention

🤖 Generated with [Claude Code](https://claude.com/claude-code)