### PR TITLE
Provisioning: Fix flaky EmptyPath multi-repo resource-count assertions

### DIFF
--- a/pkg/tests/apis/provisioning/repository/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository/repository_test.go
@@ -1829,13 +1829,21 @@ func TestIntegrationProvisioning_EmptyPath(t *testing.T) {
 		// Verify global resource counts:
 		// - Folders: 12 total (6 from repo1 + 6 from repo2) - folders are duplicated per repository
 		// - Dashboards: 3 total (only from repo1) - repo2's dashboards fail with ownership conflicts
-		dashboards, err := helper.DashboardsV1.Resource.List(ctx, metav1.ListOptions{})
-		require.NoError(t, err)
-		require.Len(t, dashboards.Items, 3, "should have 3 dashboards (only from repo1)")
+		// Poll because repo2's sync job can return before the folder/dashboard
+		// list endpoints have observed all of the newly-created resources.
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			dashboards, err := helper.DashboardsV1.Resource.List(ctx, metav1.ListOptions{})
+			if !assert.NoError(collect, err) {
+				return
+			}
+			assert.Len(collect, dashboards.Items, 3, "should have 3 dashboards (only from repo1)")
 
-		folders, err := helper.Folders.Resource.List(ctx, metav1.ListOptions{})
-		require.NoError(t, err)
-		require.Len(t, folders.Items, 12, "should have 12 folders (6 from repo1 + 6 from repo2)")
+			folders, err := helper.Folders.Resource.List(ctx, metav1.ListOptions{})
+			if !assert.NoError(collect, err) {
+				return
+			}
+			assert.Len(collect, folders.Items, 12, "should have 12 folders (6 from repo1 + 6 from repo2)")
+		}, common.WaitTimeoutDefault, common.WaitIntervalDefault, "should observe all dashboards and folders after both repos sync")
 
 		// Clean up
 		err = helper.Repositories.Resource.Delete(ctx, repo1, metav1.DeleteOptions{})


### PR DESCRIPTION
## Summary

Fixes a flake in `TestIntegrationProvisioning_EmptyPath/multiple_repositories_with_empty_path_-_creation_succeeds_but_sync_warns_on_ownership_conflicts`.

Example failure: https://github.com/grafana/grafana/actions/runs/25208291298/job/73913208631

```
repository_test.go:1838:
    Error:      "[]" should have 12 item(s), but has 0
    Test:       TestIntegrationProvisioning_EmptyPath/multiple_repositories_with_empty_path_-_creation_succeeds_but_sync_warns_on_ownership_conflicts
    Messages:   should have 12 folders (6 from repo1 + 6 from repo2)
```

## Root cause

After creating `repo2` (which sets `SkipResourceAssertions: true`), the test listed dashboards and folders once and asserted exact counts:

```go
dashboards, err := helper.DashboardsV1.Resource.List(ctx, metav1.ListOptions{})
require.NoError(t, err)
require.Len(t, dashboards.Items, 3, ...)

folders, err := helper.Folders.Resource.List(ctx, metav1.ListOptions{})
require.NoError(t, err)
require.Len(t, folders.Items, 12, ...)
```

`SkipResourceAssertions: true` means the helper skips its usual `EventuallyWithT` poll, and the list endpoints can lag behind sync-job completion. The debug dump immediately before the assertion showed all 12 folders, but the subsequent `List` call sometimes returned 0. Same root cause as #123362 (dashboards) and #123872 (folders, in the quota test).

## Changes

- Wrap the dashboard- and folder-count checks in a single `require.EventuallyWithT` block using the standard `common.WaitTimeoutDefault` / `common.WaitIntervalDefault`.

## Testing

- `go build ./pkg/tests/apis/provisioning/repository/...`
- `go vet ./pkg/tests/apis/provisioning/repository/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)