### PR TITLE
Secrets: Preserve owner reference in updates for non-access policies

### DIFF
--- a/pkg/registry/apis/secret/service/secure_value.go
+++ b/pkg/registry/apis/secret/service/secure_value.go
@@ -146,6 +146,10 @@ func (s *SecureValueService) Update(ctx context.Context, newSecureValue *secretv
 		return nil, false, fmt.Errorf("reading secure value secret: %+w", err)
 	}
 
+	// only service identities are allowed to mutate owner references after a secure value is created.
+	// for any other identity, preserve the existing ones to prevent unauthorized changes.
+	s.preserveOwnerReferencesForNonAccessPolicy(ctx, currentVersion, newSecureValue)
+
 	keeperCfg, err := s.keeperMetadataStorage.GetKeeperConfig(ctx, currentVersion.Namespace, currentVersion.Status.Keeper, contracts.ReadOpts{})
 	if err != nil {
 		return nil, false, fmt.Errorf("fetching keeper config: namespace=%+v keeper: %q %w", newSecureValue.Namespace, currentVersion.Status.Keeper, err)
@@ -442,4 +446,13 @@ func (s *SecureValueService) SetKeeperAsActive(ctx context.Context, namespace xk
 		return fmt.Errorf("calling keeper metadata storage to set keeper as active: %w", err)
 	}
 	return nil
+}
+
+func (s *SecureValueService) preserveOwnerReferencesForNonAccessPolicy(ctx context.Context, currentSecureValue, newSecureValue *secretv1beta1.SecureValue) {
+	authInfo, ok := claims.AuthInfoFrom(ctx)
+	if ok && authInfo.GetIdentityType() == claims.TypeAccessPolicy {
+		return
+	}
+
+	newSecureValue.OwnerReferences = currentSecureValue.OwnerReferences
 }

--- a/pkg/registry/apis/secret/service/secure_value_test.go
+++ b/pkg/registry/apis/secret/service/secure_value_test.go
@@ -282,6 +282,210 @@ func TestCrud(t *testing.T) {
 	})
 }
 
+func TestUpdateOwnerReferences(t *testing.T) {
+	t.Parallel()
+
+	namespace := "ns1"
+	owner := common.ObjectReference{
+		APIGroup:   "prometheus.datasource.grafana.app",
+		APIVersion: "v0alpha1",
+		Kind:       "DataSource",
+		Name:       "test-ds",
+		Namespace:  namespace,
+	}
+
+	t.Run("update without owner references on either side does not require AccessPolicy identity", func(t *testing.T) {
+		t.Parallel()
+		sut := testutils.Setup(t)
+
+		sv1, err := sut.CreateSv(t.Context())
+		require.NoError(t, err)
+		require.Empty(t, sv1.OwnerReferences)
+
+		input := sv1.DeepCopy()
+		input.Spec.Description = "updated"
+
+		sv2, err := sut.UpdateSv(t.Context(), input)
+		require.NoError(t, err)
+		require.Equal(t, "updated", sv2.Spec.Description)
+	})
+
+	t.Run("update keeping the same owner reference does not require AccessPolicy identity", func(t *testing.T) {
+		t.Parallel()
+		sut := testutils.Setup(t)
+
+		sv1, err := sut.CreateSv(t.Context(), func(cfg *testutils.CreateSvConfig) {
+			cfg.Sv.OwnerReferences = []metav1.OwnerReference{owner.ToOwnerReference()}
+		})
+		require.NoError(t, err)
+		require.Len(t, sv1.OwnerReferences, 1)
+
+		input := sv1.DeepCopy()
+		input.Spec.Description = "updated"
+
+		sv2, err := sut.UpdateSv(t.Context(), input)
+		require.NoError(t, err)
+		require.Equal(t, "updated", sv2.Spec.Description)
+		require.Len(t, sv2.OwnerReferences, 1)
+	})
+
+	t.Run("adding an owner reference", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("applied for AccessPolicy identity", func(t *testing.T) {
+			t.Parallel()
+			sut := testutils.Setup(t)
+
+			sv1, err := sut.CreateSv(t.Context())
+			require.NoError(t, err)
+			require.Empty(t, sv1.OwnerReferences)
+
+			input := sv1.DeepCopy()
+			input.OwnerReferences = []metav1.OwnerReference{owner.ToOwnerReference()}
+
+			ctx := testutils.CreateServiceAuthContext(t.Context(), "service-identity", namespace, nil)
+			sv2, err := sut.UpdateSv(ctx, input)
+			require.NoError(t, err)
+			require.Len(t, sv2.OwnerReferences, 1)
+			require.Equal(t, owner.Name, sv2.OwnerReferences[0].Name)
+		})
+
+		t.Run("ignored for any other identity, owner references stay empty", func(t *testing.T) {
+			t.Parallel()
+			sut := testutils.Setup(t)
+
+			sv1, err := sut.CreateSv(t.Context())
+			require.NoError(t, err)
+			require.Empty(t, sv1.OwnerReferences)
+
+			input := sv1.DeepCopy()
+			input.Spec.Description = "updated"
+			input.OwnerReferences = []metav1.OwnerReference{owner.ToOwnerReference()}
+
+			ctx := testutils.CreateUserAuthContext(t.Context(), namespace, nil)
+			sv2, err := sut.UpdateSv(ctx, input)
+			require.NoError(t, err)
+			require.Empty(t, sv2.OwnerReferences)
+			// Other fields are still updated.
+			require.Equal(t, "updated", sv2.Spec.Description)
+		})
+	})
+
+	t.Run("removing an owner reference", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("applied for AccessPolicy identity", func(t *testing.T) {
+			t.Parallel()
+			sut := testutils.Setup(t)
+
+			sv1, err := sut.CreateSv(t.Context(), func(cfg *testutils.CreateSvConfig) {
+				cfg.Sv.OwnerReferences = []metav1.OwnerReference{owner.ToOwnerReference()}
+			})
+			require.NoError(t, err)
+			require.Len(t, sv1.OwnerReferences, 1)
+
+			input := sv1.DeepCopy()
+			input.OwnerReferences = nil
+
+			ctx := testutils.CreateServiceAuthContext(t.Context(), "service-identity", namespace, nil)
+			sv2, err := sut.UpdateSv(ctx, input)
+			require.NoError(t, err)
+			require.Empty(t, sv2.OwnerReferences)
+		})
+
+		t.Run("ignored for any other identity, owner references are preserved", func(t *testing.T) {
+			t.Parallel()
+			sut := testutils.Setup(t)
+
+			sv1, err := sut.CreateSv(t.Context(), func(cfg *testutils.CreateSvConfig) {
+				cfg.Sv.OwnerReferences = []metav1.OwnerReference{owner.ToOwnerReference()}
+			})
+			require.NoError(t, err)
+			require.Len(t, sv1.OwnerReferences, 1)
+
+			input := sv1.DeepCopy()
+			input.Spec.Description = "updated"
+			input.OwnerReferences = nil
+
+			ctx := testutils.CreateUserAuthContext(t.Context(), namespace, nil)
+			sv2, err := sut.UpdateSv(ctx, input)
+			require.NoError(t, err)
+			require.Len(t, sv2.OwnerReferences, 1)
+			require.Equal(t, owner.Name, sv2.OwnerReferences[0].Name)
+			require.Equal(t, "updated", sv2.Spec.Description)
+		})
+	})
+
+	t.Run("changing an owner reference", func(t *testing.T) {
+		t.Parallel()
+
+		differentOwner := common.ObjectReference{
+			APIGroup:   "prometheus.datasource.grafana.app",
+			APIVersion: "v0alpha1",
+			Kind:       "DataSource",
+			Name:       "other-ds",
+			Namespace:  namespace,
+		}
+
+		t.Run("applied for AccessPolicy identity", func(t *testing.T) {
+			t.Parallel()
+			sut := testutils.Setup(t)
+
+			sv1, err := sut.CreateSv(t.Context(), func(cfg *testutils.CreateSvConfig) {
+				cfg.Sv.OwnerReferences = []metav1.OwnerReference{owner.ToOwnerReference()}
+			})
+			require.NoError(t, err)
+			require.Len(t, sv1.OwnerReferences, 1)
+
+			input := sv1.DeepCopy()
+			input.OwnerReferences = []metav1.OwnerReference{differentOwner.ToOwnerReference()}
+
+			ctx := testutils.CreateServiceAuthContext(t.Context(), "service-identity", namespace, nil)
+			sv2, err := sut.UpdateSv(ctx, input)
+			require.NoError(t, err)
+			require.Len(t, sv2.OwnerReferences, 1)
+			require.Equal(t, differentOwner.Name, sv2.OwnerReferences[0].Name)
+		})
+
+		t.Run("ignored for any other identity, owner references are preserved", func(t *testing.T) {
+			t.Parallel()
+			sut := testutils.Setup(t)
+
+			sv1, err := sut.CreateSv(t.Context(), func(cfg *testutils.CreateSvConfig) {
+				cfg.Sv.OwnerReferences = []metav1.OwnerReference{owner.ToOwnerReference()}
+			})
+			require.NoError(t, err)
+
+			input := sv1.DeepCopy()
+			input.OwnerReferences = []metav1.OwnerReference{differentOwner.ToOwnerReference()}
+
+			ctx := testutils.CreateUserAuthContext(t.Context(), namespace, nil)
+			sv2, err := sut.UpdateSv(ctx, input)
+			require.NoError(t, err)
+			require.Len(t, sv2.OwnerReferences, 1)
+			require.Equal(t, owner.Name, sv2.OwnerReferences[0].Name)
+		})
+
+		t.Run("ignored when auth info is missing, owner references are preserved", func(t *testing.T) {
+			t.Parallel()
+			sut := testutils.Setup(t)
+
+			sv1, err := sut.CreateSv(t.Context(), func(cfg *testutils.CreateSvConfig) {
+				cfg.Sv.OwnerReferences = []metav1.OwnerReference{owner.ToOwnerReference()}
+			})
+			require.NoError(t, err)
+
+			input := sv1.DeepCopy()
+			input.OwnerReferences = []metav1.OwnerReference{differentOwner.ToOwnerReference()}
+
+			sv2, err := sut.UpdateSv(t.Context(), input)
+			require.NoError(t, err)
+			require.Len(t, sv2.OwnerReferences, 1)
+			require.Equal(t, owner.Name, sv2.OwnerReferences[0].Name)
+		})
+	})
+}
+
 func Test_SetAsActive(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
After a secure value is created, restrict changing the `ownerReferences` field to only access policies.

This would prohibit users or service accounts from transforming an inline secure value into a shared one and vice-versa.