### PR TITLE
Dashboards: don't set loadError for DashboardVersionError in loadSnapshot and reloadDashboard

### DIFF
--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -474,6 +474,12 @@ abstract class DashboardScenePageStateManagerBase<T>
         });
       }
     } catch (err) {
+      // DashboardVersionError signals a schema version mismatch — the caller retries
+      // with the correct version. Don't set loadError here or it persists after retry.
+      if (err instanceof DashboardVersionError) {
+        throw err;
+      }
+
       const status = getStatusFromError(err);
       const message = getMessageFromError(err);
       const messageId = getMessageIdFromError(err);
@@ -489,12 +495,6 @@ abstract class DashboardScenePageStateManagerBase<T>
 
       if (!isFetchError(err)) {
         console.error('Error loading dashboard:', err);
-      }
-
-      // If the error is a DashboardVersionError, we want to throw it so that the error boundary is triggered
-      // This enables us to switch to the correct version of the dashboard
-      if (err instanceof DashboardVersionError) {
-        throw err;
       }
     }
   }

--- a/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePageStateManager.ts
@@ -263,6 +263,10 @@ abstract class DashboardScenePageStateManagerBase<T>
 
       this.setState({ dashboard: dashboard, isLoading: false });
     } catch (err) {
+      if (err instanceof DashboardVersionError) {
+        throw err;
+      }
+
       const status = getStatusFromError(err);
       const message = getMessageFromError(err);
       const messageId = getMessageIdFromError(err);
@@ -275,11 +279,6 @@ abstract class DashboardScenePageStateManagerBase<T>
           messageId,
         },
       });
-      // If the error is a DashboardVersionError, we want to throw it so that the error boundary is triggered
-      // This enables us to switch to the correct version of the dashboard
-      if (err instanceof DashboardVersionError) {
-        throw err;
-      }
     }
   }
 
@@ -955,6 +954,10 @@ export class DashboardScenePageStateManager extends DashboardScenePageStateManag
       const status = getStatusFromError(err);
       const message = getMessageFromError(err);
 
+      if (err instanceof DashboardVersionError) {
+        throw err;
+      }
+
       this.setState({
         isLoading: false,
         loadError: {
@@ -962,10 +965,6 @@ export class DashboardScenePageStateManager extends DashboardScenePageStateManag
           status,
         },
       });
-
-      if (err instanceof DashboardVersionError) {
-        throw err;
-      }
     }
   }
 }


### PR DESCRIPTION
**What is this feature?**

Fixes v2 snapshots and post-save dashboard reloads showing a blank error page.

**Why do we need this feature?**

Same root cause as #123990  both loadSnapshot and reloadDashboard were setting loadError state before rethrowing DashboardVersionError. The retry via the correct version manager succeeds and sets the dashboard state, but the stale loadError persists and causes the error page to render instead of the dashboard.

Affected scenarios:
- Opening a snapshot of a v2 dashboard shows a blank error page
- After saving a v2 dashboard, the post-save reload shows an error page instead of the updated dashboard

**Who is this feature for?**

Anyone on Grafana v13+ using v2 dashboards with snapshots or saving dashboards.

**Which issue(s) does this PR fix?**

Related to #123985

**Special notes for your reviewer:**

Please check that:
- [x] Opening a v2 dashboard snapshot renders correctly
- [x] Saving a v2 dashboard and the post-save reload works correctly
- [x] Regression fix, no feature toggle needed
- [x] No docs update needed
