### PR TITLE
Auth: reload other tabs when login succeeds in one tab

### DIFF
--- a/public/app/core/components/Login/LoginCtrl.tsx
+++ b/public/app/core/components/Login/LoginCtrl.tsx
@@ -3,6 +3,7 @@ import { memo, useState, useCallback, type JSX } from 'react';
 import { t } from '@grafana/i18n';
 import { type FetchError, getBackendSrv, isFetchError } from '@grafana/runtime';
 import config from 'app/core/config';
+import { broadcastLogin } from 'app/core/utils/sessionBroadcast';
 
 import { type LoginDTO } from './types';
 
@@ -108,6 +109,7 @@ export const LoginCtrl = memo(({ resetCode, children }: Props) => {
         .post<LoginDTO>('/login', formModel, { showErrorAlert: false })
         .then((result) => {
           setResult(result);
+          broadcastLogin();
           if (formModel.password !== 'admin' || config.ldapEnabled || config.authProxyEnabled) {
             toGrafana();
             return;

--- a/public/app/core/services/context_srv.ts
+++ b/public/app/core/services/context_srv.ts
@@ -11,6 +11,7 @@ import {
 } from '@grafana/data';
 import { featureEnabled, getBackendSrv } from '@grafana/runtime';
 import { getSessionExpiry } from 'app/core/utils/auth';
+import { onLoginFromOtherTab } from 'app/core/utils/sessionBroadcast';
 import { type UserPermission, AccessControlAction } from 'app/types/accessControl';
 import { type CurrentUserInternal } from 'app/types/config';
 
@@ -104,6 +105,7 @@ export class ContextSrv {
     this.minRefreshInterval = config.minRefreshInterval;
 
     this.scheduleTokenRotationJob();
+    this.listenForLoginFromOtherTab();
   }
 
   async fetchUserPermissions() {
@@ -264,6 +266,16 @@ export class ContextSrv {
       .catch((e) => {
         console.error(e);
       });
+  }
+
+  // When another tab logs in, reload this tab so it picks up the new session cookie.
+  // Only reloads if this tab is currently showing the login page (user not signed in).
+  private listenForLoginFromOtherTab() {
+    onLoginFromOtherTab(() => {
+      if (!this.isSignedIn) {
+        window.location.reload();
+      }
+    });
   }
 }
 

--- a/public/app/core/utils/sessionBroadcast.ts
+++ b/public/app/core/utils/sessionBroadcast.ts
@@ -1,0 +1,61 @@
+/**
+ * Cross-tab session synchronization using BroadcastChannel.
+ *
+ * When a user logs in on one tab, other tabs on the same origin receive
+ * a message and reload so they pick up the new session cookie.
+ *
+ * Falls back to a no-op if BroadcastChannel is not supported (e.g. some
+ * older browsers or certain iframe contexts).
+ */
+
+const CHANNEL_NAME = 'grafana_session';
+
+type SessionMessage = { type: 'login' };
+
+function getChannel(): BroadcastChannel | null {
+  if (typeof BroadcastChannel === 'undefined') {
+    return null;
+  }
+  try {
+    return new BroadcastChannel(CHANNEL_NAME);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Notify other tabs that a login just succeeded in this tab.
+ */
+export function broadcastLogin(): void {
+  const channel = getChannel();
+  if (!channel) {
+    return;
+  }
+  const msg: SessionMessage = { type: 'login' };
+  channel.postMessage(msg);
+  channel.close();
+}
+
+/**
+ * Listen for login events from other tabs and call the provided callback.
+ * Returns a cleanup function that removes the listener.
+ */
+export function onLoginFromOtherTab(callback: () => void): () => void {
+  const channel = getChannel();
+  if (!channel) {
+    return () => {};
+  }
+
+  const handler = (event: MessageEvent<SessionMessage>) => {
+    if (event.data?.type === 'login') {
+      callback();
+    }
+  };
+
+  channel.addEventListener('message', handler);
+
+  return () => {
+    channel.removeEventListener('message', handler);
+    channel.close();
+  };
+}


### PR DESCRIPTION

**What is this feature?**

Fixes session not persisting across tabs after logging in on one tab.

**Why do we need this feature?**

When a session expires, all open Grafana tabs get logged out. Logging back in on one tab doesn't restore the session on the other tabs  they stay on the login page until manually reloaded.

The fix uses the browser's BroadcastChannel API to notify other tabs when a login succeeds. Tabs that are not signed in reload on receiving the message, which picks up the new session cookie automatically. Falls back to a no-op if BroadcastChannel is not available.

**Who is this feature for?**

Anyone using Grafana with multiple tabs open.

**Which issue(s) does this PR fix?**

Fixes #123916

**Special notes for your reviewer:**

Please check that:
- [x] Log in on one tab  other tabs on the login page automatically reload and restore the session
- [x] No infinite reload loops  the listener only reloads if the tab is not signed in
- [x] Works in incognito (BroadcastChannel is scoped to the browsing context, so incognito tabs won't interfere with normal tabs)
- [x] No feature toggle needed  this is a pure UX improvement with a safe fallback
- [x] No docs update needed
