### PR TITLE
fix: star migration count validation

### DIFF
--- a/pkg/registry/apis/collections/legacy/migrator.go
+++ b/pkg/registry/apis/collections/legacy/migrator.go
@@ -34,8 +34,14 @@ func StarsMigrationDefinition(migrator StarsMigrator) migrations.MigrationDefini
 		Validators: []migrations.ValidatorFactory{
 			migrations.CountValidation(starsGR, migrations.CountValidationOptions{
 				Table:    "star",
-				Where:    "org_id = ?",
-				Distinct: "user_id",
+				Where:    "star.org_id = ?",
+				Distinct: "star.user_id",
+				// Join filters out orphaned stars whose user has been deleted,
+				// matching exactly what MigrateStars processes via sql_list_users.sql.
+				Join: &migrations.CountValidationJoin{
+					Table: []string{"user", "u"},
+					On:    "star.user_id = u.id",
+				},
 			}),
 		},
 		RenameTables: []string{},

--- a/pkg/storage/unified/migrations/validator.go
+++ b/pkg/storage/unified/migrations/validator.go
@@ -118,6 +118,9 @@ func (v *CountValidator) Validate(ctx context.Context, sess *xorm.Session, respo
 	}
 
 	counter := sess.Table(v.opts.Table).Where(v.opts.Where, orgID)
+	if v.opts.Join != nil {
+		counter = counter.Join("INNER", v.opts.Join.Table, v.opts.Join.On)
+	}
 	if v.opts.Distinct != "" {
 		counter = counter.Distinct(v.opts.Distinct)
 	}
@@ -406,11 +409,21 @@ func (v *FolderTreeValidator) buildUnifiedFolderParentMapSQLite(sess *xorm.Sessi
 	return parentMap, nil
 }
 
+// CountValidationJoin configures an optional INNER JOIN for the legacy count query.
+// Use []string{"tablename", "alias"} as Table to get dialect-correct quoting from xorm.
+type CountValidationJoin struct {
+	Table any    // passed directly to xorm Join(); use []string{"table", "alias"} for quoting
+	On    string // JOIN condition, may use the alias
+}
+
 type CountValidationOptions struct {
 	Table string
 	// includes org_id
 	Where    string
 	Distinct string
+	// Join optionally adds an INNER JOIN so the legacy count matches exactly what the
+	// migrator processes (e.g. excluding orphaned rows whose foreign key was deleted).
+	Join *CountValidationJoin
 }
 
 // CountValidation creates a ValidatorFactory for count-based validation.


### PR DESCRIPTION
Some slugs (8 in total) in production have mismatches when it comes to star migration count validation. It is due to the deleted users and idle star records.

Error: https://ops.grafana-ops.net/goto/dfl1h3vf13cowb?orgId=stacks-27821
Failing slugs: https://ops.grafana-ops.net/goto/dfl1h6fwxqf40d?orgId=stacks-27821

Ticket: https://github.com/grafana/search-and-storage-team/issues/738