### PR TITLE
Explore: Add "Add alert rule" option to Explore toolbar

### DIFF
--- a/public/app/features/explore/extensions/AddAlertRule/ExploreToAlertingModal.test.tsx
+++ b/public/app/features/explore/extensions/AddAlertRule/ExploreToAlertingModal.test.tsx
@@ -1,0 +1,113 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { locationService } from '@grafana/runtime';
+import { type DataQuery } from '@grafana/schema';
+
+import { ExploreToAlertingModal } from './ExploreToAlertingModal';
+
+jest.mock('app/features/alerting/unified/utils/rule-form', () => ({
+  dataQueriesToGrafanaQueries: jest.fn(),
+  getDefaultExpressions: jest.fn(),
+}));
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  locationService: {
+    push: jest.fn(),
+  },
+}));
+
+const mockDataQueriesToGrafanaQueries = jest.requireMock(
+  'app/features/alerting/unified/utils/rule-form'
+).dataQueriesToGrafanaQueries;
+const mockGetDefaultExpressions = jest.requireMock(
+  'app/features/alerting/unified/utils/rule-form'
+).getDefaultExpressions;
+
+const mockLocationServicePush = jest.mocked(locationService.push);
+
+const defaultQueries: DataQuery[] = [{ refId: 'A', datasource: { uid: 'prometheus-uid', type: 'prometheus' } }];
+
+const defaultGrafanaQueries = [
+  {
+    refId: 'A',
+    datasourceUid: 'prometheus-uid',
+    queryType: '',
+    model: { refId: 'A', expr: 'up', datasource: { uid: 'prometheus-uid' } },
+    relativeTimeRange: { from: 600, to: 0 },
+  },
+];
+
+const defaultExpressions = [
+  {
+    refId: 'B',
+    datasourceUid: '-100',
+    queryType: '',
+    model: { refId: 'B', type: 'reduce', datasource: { uid: '-100' } },
+    relativeTimeRange: { from: 600, to: 0 },
+  },
+  {
+    refId: 'C',
+    datasourceUid: '-100',
+    queryType: '',
+    model: { refId: 'C', type: 'threshold', datasource: { uid: '-100' } },
+    relativeTimeRange: { from: 600, to: 0 },
+  },
+];
+
+describe('ExploreToAlertingModal', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockDataQueriesToGrafanaQueries.mockResolvedValue(defaultGrafanaQueries);
+    mockGetDefaultExpressions.mockReturnValue(defaultExpressions);
+  });
+
+  it('renders the modal with title', async () => {
+    render(<ExploreToAlertingModal onDismiss={jest.fn()} queries={defaultQueries} />);
+    expect(await screen.findByRole('dialog', { name: /create alert rule/i })).toBeInTheDocument();
+  });
+
+  it('shows navigation options when queries are convertible', async () => {
+    render(<ExploreToAlertingModal onDismiss={jest.fn()} queries={defaultQueries} />);
+
+    expect(await screen.findByRole('button', { name: /open in new tab/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /^open$/i })).toBeInTheDocument();
+  });
+
+  it('shows "no queries" message when no valid queries provided', async () => {
+    mockDataQueriesToGrafanaQueries.mockResolvedValue([]);
+
+    render(<ExploreToAlertingModal onDismiss={jest.fn()} queries={[]} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/no alerting-capable queries found/i)
+      ).toBeInTheDocument();
+    });
+    expect(screen.queryByRole('button', { name: /open in new tab/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^open$/i })).not.toBeInTheDocument();
+  });
+
+  it('calls locationService.push when "Open" button is clicked', async () => {
+    const user = userEvent.setup();
+    render(<ExploreToAlertingModal onDismiss={jest.fn()} queries={defaultQueries} />);
+
+    const openButton = await screen.findByRole('button', { name: /^open$/i });
+    await user.click(openButton);
+
+    expect(mockLocationServicePush).toHaveBeenCalledWith(expect.stringContaining('/alerting/new'));
+  });
+
+  it('calls onDismiss when Cancel button is clicked', async () => {
+    const onDismiss = jest.fn();
+    const user = userEvent.setup();
+
+    render(<ExploreToAlertingModal onDismiss={onDismiss} queries={defaultQueries} />);
+
+    const cancelButton = await screen.findByRole('button', { name: /cancel/i });
+    await user.click(cancelButton);
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+});

--- a/public/app/features/explore/extensions/AddAlertRule/ExploreToAlertingModal.tsx
+++ b/public/app/features/explore/extensions/AddAlertRule/ExploreToAlertingModal.tsx
@@ -1,0 +1,90 @@
+import { useAsync } from 'react-use';
+
+import { getDefaultRelativeTimeRange, getNextRefId, locationUtil, urlUtil } from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
+import { locationService } from '@grafana/runtime';
+import { type DataQuery } from '@grafana/schema';
+import { Button, Modal } from '@grafana/ui';
+import { RuleFormType } from 'app/features/alerting/unified/types/rule-form';
+import { dataQueriesToGrafanaQueries, getDefaultExpressions } from 'app/features/alerting/unified/utils/rule-form';
+import { ExpressionDatasourceUID } from 'app/features/expressions/types';
+
+interface Props {
+  onDismiss: () => void;
+  queries: DataQuery[];
+}
+
+export function ExploreToAlertingModal({ onDismiss, queries }: Props) {
+  const { loading, value: formValues } = useAsync(async () => {
+    if (!queries?.length) {
+      return undefined;
+    }
+
+    const relativeTimeRange = getDefaultRelativeTimeRange();
+    const grafanaQueries = await dataQueriesToGrafanaQueries(queries, relativeTimeRange, {});
+
+    if (!grafanaQueries.length) {
+      return undefined;
+    }
+
+    if (!grafanaQueries.find((q) => q.datasourceUid === ExpressionDatasourceUID)) {
+      const lastQuery = grafanaQueries.at(-1)!;
+      const reduceRefId = getNextRefId(grafanaQueries);
+      const queriesWithReduce = [
+        ...grafanaQueries,
+        { refId: reduceRefId, datasourceUid: '', queryType: '', model: {} },
+      ];
+      const thresholdRefId = getNextRefId(queriesWithReduce);
+      const expressions = getDefaultExpressions(reduceRefId, thresholdRefId, lastQuery.refId);
+      grafanaQueries.push(...expressions);
+    }
+
+    return {
+      type: RuleFormType.grafana,
+      queries: grafanaQueries,
+      condition: grafanaQueries.at(-1)!.refId,
+    };
+  }, [queries]);
+
+  const buildUrl = () => urlUtil.renderUrl('/alerting/new', { defaults: JSON.stringify(formValues) });
+
+  const openInNewTab = () => {
+    window.open(locationUtil.assureBaseUrl(buildUrl()), '_blank');
+    onDismiss();
+  };
+
+  const openInCurrentTab = () => locationService.push(buildUrl());
+
+  const canCreate = !loading && formValues;
+
+  return (
+    <Modal title={t('explore.add-alert-rule.modal-title', 'Create alert rule')} isOpen onDismiss={onDismiss}>
+      <p>
+        {canCreate ? (
+          <Trans i18nKey="explore.add-alert-rule.modal-description">
+            Open the alert creation form in the current tab or a new tab?
+          </Trans>
+        ) : (
+          <Trans i18nKey="explore.add-alert-rule.no-queries">
+            No alerting-capable queries found. Please run a query first.
+          </Trans>
+        )}
+      </p>
+      <Modal.ButtonRow>
+        <Button onClick={onDismiss} fill="outline" variant="secondary">
+          <Trans i18nKey="alerting.common.cancel">Cancel</Trans>
+        </Button>
+        {canCreate && (
+          <>
+            <Button variant="secondary" onClick={openInNewTab} icon="external-link-alt">
+              <Trans i18nKey="explore.add-alert-rule.open-in-new-tab">Open in new tab</Trans>
+            </Button>
+            <Button variant="primary" onClick={openInCurrentTab} icon="bell">
+              <Trans i18nKey="explore.add-alert-rule.open">Open</Trans>
+            </Button>
+          </>
+        )}
+      </Modal.ButtonRow>
+    </Modal>
+  );
+}

--- a/public/app/features/explore/extensions/getExploreExtensionConfigs.test.tsx
+++ b/public/app/features/explore/extensions/getExploreExtensionConfigs.test.tsx
@@ -1,15 +1,23 @@
 import { PluginExtensionPoints } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
 
+import { type PluginExtensionExploreContext } from './ToolbarExtensionPoint';
 import { getExploreExtensionConfigs } from './getExploreExtensionConfigs';
 
 jest.mock('app/core/services/context_srv');
+jest.mock('./AddAlertRule/ExploreToAlertingModal', () => ({
+  ExploreToAlertingModal: () => null,
+}));
 
 const contextSrvMock = jest.mocked(contextSrv);
 
 describe('getExploreExtensionConfigs', () => {
   describe('configured items returned', () => {
     it('should return array with core extensions added in explore', () => {
+      contextSrvMock.hasPermission.mockReturnValue(true);
+      config.unifiedAlertingEnabled = true;
+
       const extensions = getExploreExtensionConfigs();
 
       expect(extensions).toEqual([
@@ -21,6 +29,15 @@ describe('getExploreExtensionConfigs', () => {
           configure: expect.any(Function),
           onClick: expect.any(Function),
           category: 'Dashboards',
+        },
+        {
+          title: 'Add alert rule',
+          description: 'Create an alert rule from the current Explore query',
+          targets: [PluginExtensionPoints.ExploreToolbarAction],
+          icon: 'bell',
+          category: 'Alerts',
+          configure: expect.any(Function),
+          onClick: expect.any(Function),
         },
         {
           title: 'Add correlation',
@@ -53,6 +70,57 @@ describe('getExploreExtensionConfigs', () => {
       const [extension] = extensions;
 
       expect(extension?.configure?.(undefined)).toEqual({});
+    });
+  });
+
+  describe('configure function for "add alert rule" extension', () => {
+    afterEach(() => {
+      contextSrvMock.hasPermission.mockRestore();
+      config.unifiedAlertingEnabled = true;
+    });
+
+    it('should return undefined if unified alerting is disabled', () => {
+      contextSrvMock.hasPermission.mockReturnValue(true);
+      config.unifiedAlertingEnabled = false;
+
+      const extensions = getExploreExtensionConfigs();
+      const alertRuleExtension = extensions.find((e) => e.title === 'Add alert rule');
+
+      const context = { targets: [{ refId: 'A', datasource: { uid: 'ds1' } }] } as unknown as PluginExtensionExploreContext;
+      expect(alertRuleExtension?.configure?.(context)).toBeUndefined();
+    });
+
+    it('should return undefined if user has no alerting permissions', () => {
+      contextSrvMock.hasPermission.mockReturnValue(false);
+      config.unifiedAlertingEnabled = true;
+
+      const extensions = getExploreExtensionConfigs();
+      const alertRuleExtension = extensions.find((e) => e.title === 'Add alert rule');
+
+      const context = { targets: [{ refId: 'A', datasource: { uid: 'ds1' } }] } as unknown as PluginExtensionExploreContext;
+      expect(alertRuleExtension?.configure?.(context)).toBeUndefined();
+    });
+
+    it('should return undefined if there are no queries', () => {
+      contextSrvMock.hasPermission.mockReturnValue(true);
+      config.unifiedAlertingEnabled = true;
+
+      const extensions = getExploreExtensionConfigs();
+      const alertRuleExtension = extensions.find((e) => e.title === 'Add alert rule');
+
+      const context = { targets: [] } as unknown as PluginExtensionExploreContext;
+      expect(alertRuleExtension?.configure?.(context)).toBeUndefined();
+    });
+
+    it('should return empty object if alerting is enabled, user has permissions, and there are queries', () => {
+      contextSrvMock.hasPermission.mockReturnValue(true);
+      config.unifiedAlertingEnabled = true;
+
+      const extensions = getExploreExtensionConfigs();
+      const alertRuleExtension = extensions.find((e) => e.title === 'Add alert rule');
+
+      const context = { targets: [{ refId: 'A', datasource: { uid: 'ds1' } }] } as unknown as PluginExtensionExploreContext;
+      expect(alertRuleExtension?.configure?.(context)).toEqual({});
     });
   });
 });

--- a/public/app/features/explore/extensions/getExploreExtensionConfigs.tsx
+++ b/public/app/features/explore/extensions/getExploreExtensionConfigs.tsx
@@ -1,4 +1,5 @@
 import { type PluginExtensionAddedLinkConfig, PluginExtensionPoints } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
 import { dispatch } from 'app/store/store';
 import { AccessControlAction } from 'app/types/accessControl';
@@ -8,6 +9,7 @@ import { createAddedLinkConfig } from '../../plugins/extensions/utils';
 import { changeCorrelationEditorDetails } from '../state/main';
 import { runQueries } from '../state/query';
 
+import { ExploreToAlertingModal } from './AddAlertRule/ExploreToAlertingModal';
 import { ExploreToDashboardPanel } from './AddToDashboard/ExploreToDashboardPanel';
 import { getAddToDashboardTitle } from './AddToDashboard/getAddToDashboardTitle';
 import { type PluginExtensionExploreContext } from './ToolbarExtensionPoint';
@@ -39,6 +41,45 @@ export function getExploreExtensionConfigs(): PluginExtensionAddedLinkConfig[] {
           openModal({
             title: getAddToDashboardTitle(),
             body: ({ onDismiss }) => <ExploreToDashboardPanel onClose={onDismiss!} exploreId={context?.exploreId!} />,
+          });
+        },
+      }),
+      createAddedLinkConfig<PluginExtensionExploreContext>({
+        // This is called at the top level, so will break if we add a translation here 😱
+        // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
+        title: 'Add alert rule',
+        // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
+        description: 'Create an alert rule from the current Explore query',
+        targets: [PluginExtensionPoints.ExploreToolbarAction],
+        icon: 'bell',
+        category: 'Alerts',
+        configure: (context) => {
+          if (!config.unifiedAlertingEnabled) {
+            return undefined;
+          }
+
+          const canCreateAlertRule =
+            contextSrv.hasPermission(AccessControlAction.AlertingRuleCreate) ||
+            contextSrv.hasPermission(AccessControlAction.AlertingRuleExternalWrite);
+
+          if (!canCreateAlertRule) {
+            return undefined;
+          }
+
+          const hasQueries = context?.targets && context.targets.length > 0;
+          if (!hasQueries) {
+            return undefined;
+          }
+
+          return {};
+        },
+        onClick: (_, { context, openModal }) => {
+          openModal({
+            // eslint-disable-next-line @grafana/i18n/no-untranslated-strings
+            title: 'Create alert rule',
+            body: ({ onDismiss }) => (
+              <ExploreToAlertingModal onDismiss={onDismiss!} queries={context?.targets ?? []} />
+            ),
           });
         },
       }),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What is this PR?

Adds an "Add alert rule" button to the Explore toolbar, alongside the existing "Add to dashboard" button. This implements the feature requested in #60142 using Explore's existing extension point mechanism (`PluginExtensionPoints.ExploreToolbarAction`).

## What does it do?

- Adds a new "Add alert rule" action to the Explore toolbar (under the **Alerts** category with a bell icon)
- Clicking it opens a modal that lets the user navigate to the alert rule creation form in the **current tab** or a **new tab**
- The current Explore queries are pre-populated in the alert rule form via the `defaults` query parameter
- Default reduce and threshold expressions are added when the queries have no expressions already

## Conditions for the button to appear

- Unified alerting must be enabled (`config.unifiedAlertingEnabled`)
- User must have `AlertingRuleCreate` or `AlertingRuleExternalWrite` permission
- There must be at least one active query in the Explore pane

## Files changed

- `public/app/features/explore/extensions/getExploreExtensionConfigs.tsx` — registers the new extension link
- `public/app/features/explore/extensions/AddAlertRule/ExploreToAlertingModal.tsx` — the modal component
- `public/app/features/explore/extensions/AddAlertRule/ExploreToAlertingModal.test.tsx` — tests for the modal
- `public/app/features/explore/extensions/getExploreExtensionConfigs.test.tsx` — updated to cover new extension

## Implementation approach

The feature leverages the existing `ExploreToolbarAction` extension point (same mechanism as "Add to dashboard"). The `ExploreToAlertingModal` component reuses `dataQueriesToGrafanaQueries` from the alerting utilities to convert Explore queries to the alert rule format, matching the behavior of the existing `CreateAlertFromPanelExposedComponent`.

Closes #60142
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5587a12f-ee6d-4c23-9d5f-0c0f864f2b63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5587a12f-ee6d-4c23-9d5f-0c0f864f2b63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

