### PR TITLE
Provisioning: Give folder cleanup a larger budget than other steps

### DIFF
--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -59,12 +59,21 @@ const (
 	WaitTimeoutDefault  = 60 * time.Second
 	WaitIntervalDefault = 100 * time.Millisecond
 
-	// waitTimeoutCleanup is the per-step budget for CleanupAllResources. Folder
-	// admission validates "folder is empty" against the resource search index,
-	// which is eventually consistent with respect to dashboard deletes. Under
-	// SQLite write contention that lag has been observed to exceed 60s, so
-	// cleanup gets a larger budget than the default per-operation wait.
+	// waitTimeoutCleanup is the per-step budget for non-folder steps in
+	// CleanupAllResources (repositories, connections, dashboards). It is
+	// larger than the default per-operation wait because finalizers and
+	// controller reconciliation can briefly hold these resources past the
+	// initial delete call.
 	waitTimeoutCleanup = 2 * WaitTimeoutDefault
+
+	// waitTimeoutFolderCleanup is the budget for the folders step in
+	// CleanupAllResources. Folder admission validates "folder is empty"
+	// against the resource search index, which is eventually consistent
+	// with respect to dashboard deletes. Under SQLite write contention that
+	// lag has been observed to exceed waitTimeoutCleanup, so folders alone
+	// get a larger budget — bumping every step would slow the common case
+	// for no benefit.
+	waitTimeoutFolderCleanup = 4 * WaitTimeoutDefault
 )
 
 //nolint:gosec // Test RSA private key (generated for testing purposes only, never used in production)
@@ -1354,12 +1363,10 @@ func deleteAndWait(ctx context.Context, client dynamic.ResourceInterface, timeou
 		return nil
 	}
 
-	var firstErr error
+	var lastErr error
 	for _, item := range list.Items {
 		if err := client.Delete(ctx, item.GetName(), metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-			if firstErr == nil {
-				firstErr = fmt.Errorf("deleteAndWait: delete %q: %w", item.GetName(), err)
-			}
+			lastErr = fmt.Errorf("deleteAndWait: delete %q: %w", item.GetName(), err)
 		}
 	}
 
@@ -1378,20 +1385,18 @@ func deleteAndWait(ctx context.Context, client dynamic.ResourceInterface, timeou
 		}
 		for _, item := range remaining.Items {
 			if err := client.Delete(ctx, item.GetName(), metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
-				if firstErr == nil {
-					firstErr = fmt.Errorf("deleteAndWait: delete %q: %w", item.GetName(), err)
-				}
+				lastErr = fmt.Errorf("deleteAndWait: delete %q: %w", item.GetName(), err)
 			}
 		}
 		select {
 		case <-ctx.Done():
-			if firstErr != nil {
-				return fmt.Errorf("deleteAndWait: context cancelled (first delete error: %v): %w", firstErr, ctx.Err())
+			if lastErr != nil {
+				return fmt.Errorf("deleteAndWait: context cancelled (last delete error: %v): %w", lastErr, ctx.Err())
 			}
 			return fmt.Errorf("deleteAndWait: context cancelled: %w", ctx.Err())
 		case <-timer.C:
-			if firstErr != nil {
-				return fmt.Errorf("deleteAndWait: timed out with %d items remaining (first delete error: %v)", len(remaining.Items), firstErr)
+			if lastErr != nil {
+				return fmt.Errorf("deleteAndWait: timed out with %d items remaining (last delete error: %v)", len(remaining.Items), lastErr)
 			}
 			return fmt.Errorf("deleteAndWait: timed out with %d items remaining", len(remaining.Items))
 		case <-ticker.C:
@@ -1413,15 +1418,16 @@ func deleteAndWait(ctx context.Context, client dynamic.ResourceInterface, timeou
 func (h *ProvisioningTestHelper) CleanupAllResources(t *testing.T, ctx context.Context) {
 	t.Helper()
 	for _, c := range []struct {
-		name   string
-		client dynamic.ResourceInterface
+		name    string
+		client  dynamic.ResourceInterface
+		timeout time.Duration
 	}{
-		{"repositories", h.Repositories.Resource},
-		{"connections", h.Connections.Resource},
-		{"dashboards", h.DashboardsV1.Resource},
-		{"folders", h.Folders.Resource},
+		{"repositories", h.Repositories.Resource, waitTimeoutCleanup},
+		{"connections", h.Connections.Resource, waitTimeoutCleanup},
+		{"dashboards", h.DashboardsV1.Resource, waitTimeoutCleanup},
+		{"folders", h.Folders.Resource, waitTimeoutFolderCleanup},
 	} {
-		if err := deleteAndWait(ctx, c.client, waitTimeoutCleanup); err != nil {
+		if err := deleteAndWait(ctx, c.client, c.timeout); err != nil {
 			t.Fatalf("CleanupAllResources(%s): %v", c.name, err)
 		}
 	}


### PR DESCRIPTION
## Summary

Fixes a recurring SQLite-only flake in `pkg/tests/apis/provisioning` where the next test's `CleanupAllResources` aborts with:

```
CleanupAllResources(folders): deleteAndWait: timed out with 1 items remaining
  (first delete error: deleteAndWait: delete "terraform-test-folder-XXXX":
   Folder cannot be deleted: folder is not empty)
```

Observed in [run 25313039521 / job 74204159366](https://github.com/grafana/grafana/actions/runs/25313039521/job/74204159366) (Sqlite Enterprise 8/16) and several earlier `pr-test-integration.yml` failures on `main`.

## Root cause

`CleanupAllResources` deletes resources in dependency order: `repositories → connections → dashboards → folders`. Even after dashboards are gone from the K8s API, **folder admission consults the resource search index** (`searcher.GetStats` in `pkg/registry/apis/folders/validate.go:362`), which is eventually consistent w.r.t. dashboard deletes. Under SQLite write contention that lag has been observed to exceed the shared 120s budget — see the existing comment on `waitTimeoutCleanup`. The recent run timed out at ~127s, just past the 120s window.

## Changes

- **Split the cleanup timeout.** Folders alone are gated on the search index, so only folders get the bigger budget (`waitTimeoutFolderCleanup = 4 * WaitTimeoutDefault = 240s`). Repos/connections/dashboards stay at 120s — bumping every step would slow the common case for no benefit.
- **`deleteAndWait` now tracks the *latest* delete error, not the first.** Today the helper sticks on the first failure ever observed and reports it on timeout, even when the actual blocker has changed many iterations later. With `lastErr`, timeout messages reflect what's *currently* rejecting the delete (e.g. `folder is not empty` for index-lag), making the next flake self-explanatory.

This is a shared-helper change, so every test that goes through `GetCleanHelper` benefits — no per-test cleanup needed.

## What this does and doesn't fix

- **Fixes:** the specific 127s timeout we saw (240s gives ~2x headroom over the worst observed lag) and improves the debug signal for any future cleanup flake.
- **Does not fix:** the underlying SQLite write contention causing the search index to lag in the first place. That is a separate, deeper issue out of scope for a test-helper change.

## Test plan

- [ ] CI integration tests pass on Postgres / MySQL / SQLite (Enterprise + OSS)
- [ ] Re-run the previously failing job (`Sqlite Enterprise (8/16)`) several times to confirm the flake no longer reproduces
- [ ] Local: `go vet ./pkg/tests/apis/provisioning/...` and `go build ./pkg/tests/apis/provisioning/common/...` (done — clean)

🤖 Generated with [Claude Code](https://claude.com/claude-code)