### PR TITLE
Provisioning: fix SyncAndWait race causing folder metadata test flake

### DIFF
--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -250,7 +250,21 @@ func (h *ProvisioningTestHelper) SyncAndWait(t *testing.T, repo string, options 
 
 	name := unstruct.GetName()
 	require.NotEmpty(t, name, "expecting name to be set")
-	h.AwaitJobs(t, repo)
+
+	// Wait for the specific job we just queued via its UID rather than a
+	// list-based scan. AwaitJobs lists active jobs and, if it observes none
+	// for this repo, queues a failsafe pull and only checks that
+	// successCount >= len(waitUntilComplete); when our job has already moved
+	// to the historic subresource that check trivially passes (0 >= 0) and
+	// SyncAndWait returns without having waited for the sync to complete,
+	// causing flakes in callers that immediately list provisioned resources.
+	job := h.AwaitJob(t, t.Context(), unstruct)
+	state := MustNestedString(job.Object, "status", "state")
+	if state == string(provisioning.JobStateError) {
+		h.DebugState(t, repo, fmt.Sprintf("SYNC FAILED: %s", name))
+		errs := MustNestedStringSlice(job.Object, "status", "errors")
+		t.Fatalf("sync job %q for repo %q ended in error state; errors: %v", name, repo, errs)
+	}
 }
 
 func (h *ProvisioningTestHelper) TriggerJobAndWaitForSuccess(t *testing.T, repo string, spec provisioning.JobSpec) {

--- a/pkg/tests/apis/provisioning/foldermetadata/sync_folder_metadata_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/sync_folder_metadata_test.go
@@ -4,6 +4,7 @@ import (
 	//nolint:gosec // Test SHA-1 hash (generated for testing purposes only, never used in production)
 	"crypto/sha1"
 	"encoding/hex"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -173,21 +174,23 @@ func requireRepoFolderTitle(t *testing.T, helper *common.ProvisioningTestHelper,
 		if !assert.NoError(c, err, "failed to list folders") {
 			return
 		}
+		// Collect what we did see for the repo so a flake's error message
+		// shows whether the folder is missing entirely vs. has a wrong title.
+		var seen []string
 		for _, f := range list.Items {
 			mgr, _, _ := unstructured.NestedString(f.Object, "metadata", "annotations", "grafana.app/managerId")
 			if mgr != repoName {
 				continue
 			}
 			srcPath, _, _ := unstructured.NestedString(f.Object, "metadata", "annotations", "grafana.app/sourcePath")
-			if srcPath != expectedSourcePath {
-				continue
-			}
 			title, _, _ := unstructured.NestedString(f.Object, "spec", "title")
-			if title == expectedTitle {
+			if srcPath == expectedSourcePath && title == expectedTitle {
 				return
 			}
+			seen = append(seen, fmt.Sprintf("{name=%s sourcePath=%q title=%q}", f.GetName(), srcPath, title))
 		}
-		c.Errorf("no folder managed by %q at path %q with title %q found", repoName, expectedSourcePath, expectedTitle)
+		c.Errorf("no folder managed by %q at path %q with title %q found; folders for repo: [%s]",
+			repoName, expectedSourcePath, expectedTitle, strings.Join(seen, ", "))
 	}, 30*time.Second, 100*time.Millisecond,
 		"expected folder with title %q at path %q for repo %q", expectedTitle, expectedSourcePath, repoName)
 }


### PR DESCRIPTION
## Summary

Fixes the flake in `TestIntegrationProvisioning_FullSync_FolderMetadataTitle` (e.g. [run 25313415419](https://github.com/grafana/grafana/actions/runs/25313415419/job/74206022138)).

## Root cause

`SyncAndWait` POSTs a sync job, then calls `AwaitJobs(repo)` which lists *active* jobs for the repo. If the just-queued job has already moved to the historic subresource by the time the list call runs (which happens with fast local syncs), `waitUntilComplete` ends up empty and the success check `successCount >= len(waitUntilComplete)` trivially passes (`0 >= 0`). `SyncAndWait` returns "successfully" without ever having waited for our sync, so callers that immediately list provisioned resources race against the actual sync and time out.

That race is what surfaced as:

```
sync_folder_metadata_test.go:217: no folder managed by "full-sync-meta-title" at path "my-team" with title "My Team Display Name" found
```

The 30.85s test runtime equaling the 30s `EventuallyWithT` timeout is the giveaway — `SyncAndWait` returned essentially instantly, leaving the poll as the only synchronization point.

## Changes

- `pkg/tests/apis/provisioning/common/testing.go`: in `SyncAndWait`, replace the final `AwaitJobs(t, repo)` with `AwaitJob(t, ctx, unstruct)`, which fetches the historic job by UID directly (no list-based race). Then assert the resulting state is not `JobStateError`. `Warning` is still accepted, matching prior semantics. On error, dump `DebugState` and `t.Fatalf` so future failures are diagnosable.
- `pkg/tests/apis/provisioning/foldermetadata/sync_folder_metadata_test.go`: when `requireRepoFolderTitle` times out, include the folders that *were* found for the repo in the error message, so a future flake distinguishes "folder missing entirely" from "folder exists with wrong path/title".

## Testing

- `go test -count=1 -run "^TestIntegrationProvisioning_FullSync_FolderMetadataTitle$" ./pkg/tests/apis/provisioning/foldermetadata/` — passes (17s)
- Also ran the broader sync-related foldermetadata suites (Checksum, Reconciliation, UIDChange, DeletedReverts) — all pass.

## Checklist

- [x] Fix targets the actual race, not a symptom
- [x] No semantic change for green tests (Warning state still accepted)
- [x] Improved diagnostics for future flakes

🤖 Generated with [Claude Code](https://claude.com/claude-code)