### PR TITLE
datasources: querier: log error types we encounter

### DIFF
--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -133,7 +133,7 @@ func (b *QueryAPIBuilder) QueryDatasources(w http.ResponseWriter, httpreq *http.
 	raw := &query.QueryDataRequest{}
 	err := web.Bind(httpreq, raw)
 	if err != nil {
-		connectLogger.Error("Hit unexpected error when reading query", "err", err)
+		connectLogger.Error("Hit unexpected error when reading query", "err", err, "err_type", fmt.Sprintf("%T", err))
 		err = errorsK8s.NewBadRequest("error reading query")
 		// TODO: can we wrap the error so details are not lost?!
 		// errutil.BadRequest(
@@ -160,7 +160,7 @@ func (b *QueryAPIBuilder) QueryDatasources(w http.ResponseWriter, httpreq *http.
 				"cause", context.Cause(ctx),
 			)
 		}
-		connectLogger.Error("execute error", "http code", query.GetResponseCode(qdr), "err", err)
+		connectLogger.Error("execute error", "http code", query.GetResponseCode(qdr), "err", err, "err_type", fmt.Sprintf("%T", err))
 		logEmptyRefids(raw.Queries, connectLogger)
 		if qdr != nil { // if we have a response, we assume the err is set in the response
 			responder.Object(query.GetResponseCode(qdr), &query.QueryDataResponse{


### PR DESCRIPTION
i'm working on improvements to how we handle errors (what http-status-codes we emit), but i need to know what type of errors does happen, so i adjusted two log-lines to have more info in them.

the plan is to release this, collect data for a short while then remove the extra logging.