### PR TITLE
search: skip periodic snapshot upload when same-version remote is fresh

### DIFF
--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -407,11 +407,12 @@ func (b *bleveBackend) clearUploadTracking(key resource.NamespacedResource) {
 }
 
 const (
-	snapshotUploadCheckInterval       = 5 * time.Minute
-	snapshotUploadStatusSuccess       = "success"
-	snapshotUploadStatusSkipNoChanges = "skip_no_changes"
-	snapshotUploadStatusSkipLockHeld  = "skip_lock_contention"
-	snapshotUploadStatusError         = "error"
+	snapshotUploadCheckInterval          = 5 * time.Minute
+	snapshotUploadStatusSuccess          = "success"
+	snapshotUploadStatusSkipNoChanges    = "skip_no_changes"
+	snapshotUploadStatusSkipLockHeld     = "skip_lock_contention"
+	snapshotUploadStatusSkipRecentRemote = "skip_recent_remote"
+	snapshotUploadStatusError            = "error"
 )
 
 func (b *bleveBackend) uploadSnapshotsPeriodically(ctx context.Context) {
@@ -457,9 +458,17 @@ func (b *bleveBackend) runUploadSnapshots(ctx context.Context) {
 
 		start := time.Now()
 		if err := b.uploadSnapshot(ctx, key, idx); err != nil {
-			if errors.Is(err, errLockHeld) {
+			switch {
+			case errors.Is(err, errLockHeld):
 				b.recordSnapshotUploadStatus(snapshotUploadStatusSkipLockHeld)
-			} else {
+			case errors.Is(err, errSkipRecentRemote):
+				// A recent remote upload covers this resource for the cross-instance
+				// dedup window. Update lastUploadTime so this replica's local probe
+				// also rate-limits to once per UploadInterval, and don't reset the
+				// mutation baseline — we didn't actually take a snapshot.
+				b.setUploadTracking(key, time.Now())
+				b.recordSnapshotUploadStatus(snapshotUploadStatusSkipRecentRemote)
+			default:
 				b.recordSnapshotUploadStatus(snapshotUploadStatusError)
 				b.log.Warn("snapshot upload failed", "key", key, "err", err)
 			}

--- a/pkg/storage/unified/search/bleve_snapshot.go
+++ b/pkg/storage/unified/search/bleve_snapshot.go
@@ -306,3 +306,61 @@ func (b *bleveBackend) recordSnapshotDownloadStatus(status string) {
 	}
 	b.indexMetrics.IndexSnapshotDownloads.WithLabelValues(status).Inc()
 }
+
+// findFreshSnapshotByUploadTime walks namespace snapshots newest-first and
+// returns the first one whose GrafanaBuildVersion matches runningVersion and
+// whose ULID time falls within [now-maxAge, now]. Returns a zero key and nil
+// meta when no such snapshot exists.
+//
+// Walking (rather than checking only the newest) is necessary in mixed-version
+// clusters — either transiently during rolling upgrades, or as a deliberate
+// steady-state configuration. V1 and V2 replicas may interleave uploads, so
+// the newest snapshot can be the wrong version while a same-version match
+// lives a few keys back. In homogeneous clusters the walk degenerates to one
+// GET.
+//
+// ErrSnapshotNotFound / ErrInvalidManifest on individual keys is tolerated
+// (skip and continue) — these are races with cleanup or concurrently-written
+// manifests and shouldn't fail the probe. Other errors are surfaced.
+func findFreshSnapshotByUploadTime(
+	ctx context.Context,
+	store RemoteIndexStore,
+	ns resource.NamespacedResource,
+	maxAge time.Duration,
+	runningVersion string,
+) (ulid.ULID, *IndexMeta, error) {
+	keys, err := store.ListIndexKeys(ctx, ns)
+	if err != nil {
+		return ulid.ULID{}, nil, fmt.Errorf("listing index keys: %w", err)
+	}
+
+	// Sort newest-first by ULID time. ULID time equals upload time (set in
+	// UploadIndex from the ULID's own timestamp), so this is also the
+	// upload-time ordering.
+	sort.Slice(keys, func(i, j int) bool {
+		return keys[i].Time() > keys[j].Time()
+	})
+
+	cutoff := time.Now().Add(-maxAge)
+	for _, k := range keys {
+		// ULID time is the upload time. Once we cross the cutoff, no
+		// remaining candidate can satisfy the freshness criterion.
+		if !ulid.Time(k.Time()).After(cutoff) {
+			return ulid.ULID{}, nil, nil
+		}
+
+		meta, err := store.GetIndexMeta(ctx, ns, k)
+		if err != nil {
+			if errors.Is(err, ErrSnapshotNotFound) || errors.Is(err, ErrInvalidManifest) {
+				continue
+			}
+			return ulid.ULID{}, nil, fmt.Errorf("reading manifest for %s: %w", k, err)
+		}
+
+		if meta.GrafanaBuildVersion == runningVersion {
+			return k, meta, nil
+		}
+	}
+
+	return ulid.ULID{}, nil, nil
+}

--- a/pkg/storage/unified/search/bleve_snapshot_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_test.go
@@ -732,3 +732,136 @@ func TestIntegrationBleveSnapshotRoundTrip(t *testing.T) {
 	require.NoError(t, err)
 	assert.Zero(t, mutationCount)
 }
+
+// --- findFreshSnapshotByUploadTime ---
+
+// probeFakeStore embeds fakeRemoteIndexStore but lets individual GetIndexMeta
+// calls fail with a chosen error, so we can test mid-walk error tolerance.
+type probeFakeStore struct {
+	*fakeRemoteIndexStore
+	getErr     map[ulid.ULID]error
+	getCalls   []ulid.ULID
+	listKeyErr error
+}
+
+func (s *probeFakeStore) ListIndexKeys(ctx context.Context, ns resource.NamespacedResource) ([]ulid.ULID, error) {
+	if s.listKeyErr != nil {
+		return nil, s.listKeyErr
+	}
+	return s.fakeRemoteIndexStore.ListIndexKeys(ctx, ns)
+}
+
+func (s *probeFakeStore) GetIndexMeta(ctx context.Context, ns resource.NamespacedResource, k ulid.ULID) (*IndexMeta, error) {
+	s.getCalls = append(s.getCalls, k)
+	if e, ok := s.getErr[k]; ok {
+		return nil, e
+	}
+	return s.fakeRemoteIndexStore.GetIndexMeta(ctx, ns, k)
+}
+
+func newProbeFake() *probeFakeStore {
+	return &probeFakeStore{fakeRemoteIndexStore: &fakeRemoteIndexStore{}, getErr: map[ulid.ULID]error{}}
+}
+
+func TestFindFreshSnapshotByUploadTime_HomogeneousCluster(t *testing.T) {
+	now := time.Now()
+	store := newProbeFake()
+	want := makeULID(t, now.Add(-5*time.Minute))
+	store.put(want, &IndexMeta{GrafanaBuildVersion: "11.5.0"})
+
+	k, meta, err := findFreshSnapshotByUploadTime(t.Context(), store, newTestNsResource(), time.Hour, "11.5.0")
+	require.NoError(t, err)
+	assert.Equal(t, want, k)
+	require.NotNil(t, meta)
+	assert.Equal(t, "11.5.0", meta.GrafanaBuildVersion)
+	assert.Len(t, store.getCalls, 1, "should fetch only the newest manifest in homogeneous case")
+}
+
+func TestFindFreshSnapshotByUploadTime_MixedVersionWalksPastNewerOtherVersion(t *testing.T) {
+	now := time.Now()
+	store := newProbeFake()
+	// Newest: V1, 5 min old. Skipped on version mismatch.
+	v1New := makeULID(t, now.Add(-5*time.Minute))
+	store.put(v1New, &IndexMeta{GrafanaBuildVersion: "11.4.0"})
+	// Match: V2, 30 min old, well within the 1h window.
+	v2Match := makeULID(t, now.Add(-30*time.Minute))
+	store.put(v2Match, &IndexMeta{GrafanaBuildVersion: "11.5.0"})
+	// Older V2 still in window — should not be picked, but also not visited.
+	store.put(makeULID(t, now.Add(-50*time.Minute)), &IndexMeta{GrafanaBuildVersion: "11.5.0"})
+
+	k, meta, err := findFreshSnapshotByUploadTime(t.Context(), store, newTestNsResource(), time.Hour, "11.5.0")
+	require.NoError(t, err)
+	assert.Equal(t, v2Match, k)
+	require.NotNil(t, meta)
+	// Walk visits the newest (V1, mismatch) then the next (V2, match) and stops.
+	assert.Equal(t, []ulid.ULID{v1New, v2Match}, store.getCalls)
+}
+
+func TestFindFreshSnapshotByUploadTime_StopsAtAgeCutoff(t *testing.T) {
+	now := time.Now()
+	store := newProbeFake()
+	// Newest is V1, 5 min ago — skipped on version.
+	v1 := makeULID(t, now.Add(-5*time.Minute))
+	store.put(v1, &IndexMeta{GrafanaBuildVersion: "11.4.0"})
+	// Only V2 candidate is older than the window — must NOT be returned.
+	stale := makeULID(t, now.Add(-90*time.Minute))
+	store.put(stale, &IndexMeta{GrafanaBuildVersion: "11.5.0"})
+
+	k, meta, err := findFreshSnapshotByUploadTime(t.Context(), store, newTestNsResource(), time.Hour, "11.5.0")
+	require.NoError(t, err)
+	assert.Equal(t, ulid.ULID{}, k)
+	assert.Nil(t, meta)
+	// Walk should have visited only v1 before hitting the cutoff.
+	assert.Equal(t, []ulid.ULID{v1}, store.getCalls)
+}
+
+func TestFindFreshSnapshotByUploadTime_NoCandidates(t *testing.T) {
+	store := newProbeFake()
+	k, meta, err := findFreshSnapshotByUploadTime(t.Context(), store, newTestNsResource(), time.Hour, "11.5.0")
+	require.NoError(t, err)
+	assert.Equal(t, ulid.ULID{}, k)
+	assert.Nil(t, meta)
+	assert.Empty(t, store.getCalls)
+}
+
+func TestFindFreshSnapshotByUploadTime_TolerateNotFoundAndInvalid(t *testing.T) {
+	now := time.Now()
+	store := newProbeFake()
+	// Newest: races with cleanup → ErrSnapshotNotFound. Skip and continue.
+	notFound := makeULID(t, now.Add(-5*time.Minute))
+	store.put(notFound, &IndexMeta{GrafanaBuildVersion: "11.5.0"})
+	store.getErr[notFound] = ErrSnapshotNotFound
+	// Next: corrupt manifest → ErrInvalidManifest. Skip and continue.
+	invalid := makeULID(t, now.Add(-10*time.Minute))
+	store.put(invalid, &IndexMeta{GrafanaBuildVersion: "11.5.0"})
+	store.getErr[invalid] = ErrInvalidManifest
+	// Then: a clean V2 match.
+	match := makeULID(t, now.Add(-15*time.Minute))
+	store.put(match, &IndexMeta{GrafanaBuildVersion: "11.5.0"})
+
+	k, _, err := findFreshSnapshotByUploadTime(t.Context(), store, newTestNsResource(), time.Hour, "11.5.0")
+	require.NoError(t, err)
+	assert.Equal(t, match, k)
+	assert.Equal(t, []ulid.ULID{notFound, invalid, match}, store.getCalls)
+}
+
+func TestFindFreshSnapshotByUploadTime_SurfacesListError(t *testing.T) {
+	store := newProbeFake()
+	store.listKeyErr = errors.New("boom")
+
+	_, _, err := findFreshSnapshotByUploadTime(t.Context(), store, newTestNsResource(), time.Hour, "11.5.0")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "boom")
+}
+
+func TestFindFreshSnapshotByUploadTime_SurfacesUnexpectedGetError(t *testing.T) {
+	now := time.Now()
+	store := newProbeFake()
+	bad := makeULID(t, now.Add(-5*time.Minute))
+	store.put(bad, &IndexMeta{GrafanaBuildVersion: "11.5.0"})
+	store.getErr[bad] = errors.New("transport boom")
+
+	_, _, err := findFreshSnapshotByUploadTime(t.Context(), store, newTestNsResource(), time.Hour, "11.5.0")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "transport boom")
+}

--- a/pkg/storage/unified/search/bleve_snapshot_upload.go
+++ b/pkg/storage/unified/search/bleve_snapshot_upload.go
@@ -2,6 +2,7 @@ package search
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -16,6 +17,11 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 )
 
+// errSkipRecentRemote is returned by uploadSnapshot when the cross-instance
+// upload-time probe finds a same-version remote snapshot uploaded within
+// UploadInterval. Callers treat this as a non-error skip.
+var errSkipRecentRemote = errors.New("skipping upload: recent remote snapshot exists")
+
 func (b *bleveBackend) uploadSnapshot(ctx context.Context, key resource.NamespacedResource, idx *bleveIndex) (retErr error) {
 	ctx, span := tracer.Start(ctx, "search.remote_index_snapshot.upload")
 	start := time.Now()
@@ -29,8 +35,12 @@ func (b *bleveBackend) uploadSnapshot(ctx context.Context, key resource.Namespac
 	var uploadKey ulid.ULID
 
 	defer func() {
+		skip := errors.Is(retErr, errSkipRecentRemote)
 		outcome := "success"
-		if retErr != nil {
+		switch {
+		case skip:
+			outcome = "skip_recent_remote"
+		case retErr != nil:
 			outcome = "error"
 		}
 		attrs := append([]attribute.KeyValue{}, commonSpanAttrs...)
@@ -41,11 +51,14 @@ func (b *bleveBackend) uploadSnapshot(ctx context.Context, key resource.Namespac
 		if uploadKey != (ulid.ULID{}) {
 			attrs = append(attrs, attribute.String("snapshot_key", uploadKey.String()))
 		}
-		if retErr != nil {
+		switch {
+		case skip:
+			logger.Info("Remote index snapshot upload skipped: recent remote snapshot exists", "elapsed", time.Since(start))
+		case retErr != nil:
 			span.RecordError(retErr)
 			span.SetStatus(codes.Error, retErr.Error())
 			logger.Warn("Remote index snapshot upload failed", "elapsed", time.Since(start), "err", retErr)
-		} else {
+		default:
 			logger.Info("Remote index snapshot upload completed", "elapsed", time.Since(start), "snapshot_key", uploadKey.String(), "snapshot_rv", rv)
 		}
 		span.SetAttributes(attrs...)
@@ -53,6 +66,20 @@ func (b *bleveBackend) uploadSnapshot(ctx context.Context, key resource.Namespac
 	}()
 
 	logger.Info("Remote index snapshot upload started")
+
+	// Cross-instance dedup: if another replica recently uploaded a same-version
+	// snapshot for this resource, skip without doing any local work. Probe
+	// failures fall through to today's upload path — the probe is an
+	// optimisation, not a correctness check.
+	if interval := b.opts.Snapshot.UploadInterval; interval > 0 {
+		k, _, err := findFreshSnapshotByUploadTime(ctx, b.opts.Snapshot.Store, key, interval, b.opts.BuildVersion)
+		if err != nil {
+			logger.Warn("Snapshot upload-time probe failed; proceeding with upload", "err", err)
+		} else if k != (ulid.ULID{}) {
+			span.SetAttributes(attribute.String("skip_remote_snapshot_key", k.String()))
+			return errSkipRecentRemote
+		}
+	}
 
 	lockAttrs := append([]attribute.KeyValue{attribute.String("lock_scope", "build")}, commonSpanAttrs...)
 	span.AddEvent("snapshot.lock.acquire.started", oteltrace.WithAttributes(lockAttrs...))

--- a/pkg/storage/unified/search/bleve_snapshot_upload_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_upload_test.go
@@ -29,6 +29,14 @@ type uploadTestStore struct {
 	uploadMeta  IndexMeta
 	uploaded    []string
 	onUpload    func() error
+
+	// Probe support: keys returned from ListIndexKeys, manifest fetched by
+	// GetIndexMeta. probeListErr forces a transport error from ListIndexKeys.
+	probeKeys     []ulid.ULID
+	probeMetas    map[ulid.ULID]*IndexMeta
+	probeListErr  error
+	probeListCall atomic.Int32
+	probeGetCalls atomic.Int32
 }
 
 func (s *uploadTestStore) LockBuildIndex(context.Context, resource.NamespacedResource) (IndexStoreLock, error) {
@@ -79,11 +87,20 @@ func (s *uploadTestStore) ListIndexes(context.Context, resource.NamespacedResour
 }
 
 func (s *uploadTestStore) ListIndexKeys(context.Context, resource.NamespacedResource) ([]ulid.ULID, error) {
-	panic("ListIndexKeys not implemented for uploadTestStore")
+	s.probeListCall.Add(1)
+	if s.probeListErr != nil {
+		return nil, s.probeListErr
+	}
+	return append([]ulid.ULID(nil), s.probeKeys...), nil
 }
 
-func (s *uploadTestStore) GetIndexMeta(context.Context, resource.NamespacedResource, ulid.ULID) (*IndexMeta, error) {
-	panic("GetIndexMeta not implemented for uploadTestStore")
+func (s *uploadTestStore) GetIndexMeta(_ context.Context, _ resource.NamespacedResource, k ulid.ULID) (*IndexMeta, error) {
+	s.probeGetCalls.Add(1)
+	m, ok := s.probeMetas[k]
+	if !ok {
+		return nil, ErrSnapshotNotFound
+	}
+	return m, nil
 }
 
 func (s *uploadTestStore) DeleteIndex(context.Context, resource.NamespacedResource, ulid.ULID) error {
@@ -327,4 +344,112 @@ func TestRunUploadSnapshots_PreservesConcurrentMutations(t *testing.T) {
 	count, err := readSnapshotMutationCount(idx.index)
 	require.NoError(t, err)
 	assert.Equal(t, int64(1), count)
+}
+
+// --- cross-instance upload-time dedup ---
+
+// TestUploadSnapshot_SkipsWhenRecentSameVersionRemoteExists verifies that the
+// upload-time probe short-circuits the upload path when a same-version remote
+// snapshot exists within UploadInterval. The lock must not be acquired and no
+// upload must happen.
+func TestUploadSnapshot_SkipsWhenRecentSameVersionRemoteExists(t *testing.T) {
+	store := &uploadTestStore{
+		probeMetas: map[ulid.ULID]*IndexMeta{},
+	}
+	recent := makeULID(t, time.Now().Add(-5*time.Minute))
+	store.probeKeys = []ulid.ULID{recent}
+	store.probeMetas[recent] = &IndexMeta{GrafanaBuildVersion: "11.5.0"}
+
+	be, _ := newTestBleveBackend(t, SnapshotOptions{Store: store, UploadInterval: time.Hour})
+	key := newTestNsResource()
+	idx := newUploadTestIndex(t, be, key, 42)
+
+	err := be.uploadSnapshot(t.Context(), key, idx)
+	require.ErrorIs(t, err, errSkipRecentRemote)
+	assert.Zero(t, store.uploadCalls.Load(), "upload must not happen on probe hit")
+	// The probe must run, and the lock must NOT be acquired (lockErr is unset
+	// here, so we can only assert via uploadCalls; LockBuildIndex is implicitly
+	// not exercised because no upload path runs).
+	assert.Equal(t, int32(1), store.probeListCall.Load())
+	assert.Equal(t, int32(1), store.probeGetCalls.Load())
+}
+
+// TestUploadSnapshot_ProceedsWhenRemoteIsDifferentVersion verifies that the
+// probe does not skip when only different-version snapshots are present.
+func TestUploadSnapshot_ProceedsWhenRemoteIsDifferentVersion(t *testing.T) {
+	store := &uploadTestStore{
+		probeMetas: map[ulid.ULID]*IndexMeta{},
+	}
+	recent := makeULID(t, time.Now().Add(-5*time.Minute))
+	store.probeKeys = []ulid.ULID{recent}
+	store.probeMetas[recent] = &IndexMeta{GrafanaBuildVersion: "11.4.0"}
+
+	be, _ := newTestBleveBackend(t, SnapshotOptions{Store: store, UploadInterval: time.Hour})
+	key := newTestNsResource()
+	idx := newUploadTestIndex(t, be, key, 42)
+
+	require.NoError(t, be.uploadSnapshot(t.Context(), key, idx))
+	assert.Equal(t, int32(1), store.uploadCalls.Load())
+}
+
+// TestUploadSnapshot_ProceedsWhenProbeErrors verifies that the probe is an
+// optimisation, not a correctness check: a probe failure must not block the
+// upload path.
+func TestUploadSnapshot_ProceedsWhenProbeErrors(t *testing.T) {
+	store := &uploadTestStore{probeListErr: errors.New("transport boom")}
+	be, _ := newTestBleveBackend(t, SnapshotOptions{Store: store, UploadInterval: time.Hour})
+	key := newTestNsResource()
+	idx := newUploadTestIndex(t, be, key, 42)
+
+	require.NoError(t, be.uploadSnapshot(t.Context(), key, idx))
+	assert.Equal(t, int32(1), store.uploadCalls.Load())
+}
+
+// TestUploadSnapshot_SkipsProbeWhenUploadIntervalZero verifies that the probe
+// is gated on UploadInterval > 0, mirroring the local lastUploadTime logic.
+func TestUploadSnapshot_SkipsProbeWhenUploadIntervalZero(t *testing.T) {
+	store := &uploadTestStore{}
+	be, _ := newTestBleveBackend(t, SnapshotOptions{Store: store /* UploadInterval omitted (0) */})
+	key := newTestNsResource()
+	idx := newUploadTestIndex(t, be, key, 42)
+
+	require.NoError(t, be.uploadSnapshot(t.Context(), key, idx))
+	assert.Zero(t, store.probeListCall.Load(), "probe must not be called when UploadInterval == 0")
+	assert.Equal(t, int32(1), store.uploadCalls.Load())
+}
+
+// TestRunUploadSnapshots_SkipRecentRemote verifies the periodic loop's
+// handling of errSkipRecentRemote: lastUploadTime is bumped to ~now, the
+// skip_recent_remote metric is incremented, and the mutation baseline is
+// preserved (no snapshot was actually taken).
+func TestRunUploadSnapshots_SkipRecentRemote(t *testing.T) {
+	store := &uploadTestStore{
+		probeMetas: map[ulid.ULID]*IndexMeta{},
+	}
+	recent := makeULID(t, time.Now().Add(-5*time.Minute))
+	store.probeKeys = []ulid.ULID{recent}
+	store.probeMetas[recent] = &IndexMeta{GrafanaBuildVersion: "11.5.0"}
+
+	be, metrics := newTestBleveBackend(t, SnapshotOptions{Store: store, MinDocCount: 1, UploadInterval: time.Hour, MinDocChanges: 1})
+	key := newTestNsResource()
+	idx := newCachedUploadTestIndex(t, be, key, 42)
+	require.NoError(t, writeSnapshotMutationCount(idx.index, 5))
+
+	before := time.Now()
+	be.runUploadSnapshots(t.Context())
+
+	assert.Zero(t, store.uploadCalls.Load(), "upload must not happen on probe hit")
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotUploads.WithLabelValues(snapshotUploadStatusSkipRecentRemote)))
+
+	// lastUploadTime should be advanced to ~now (rate-limits this replica's
+	// probes to once per UploadInterval).
+	trackedAt, ok := be.getUploadTracking(key)
+	require.True(t, ok)
+	assert.False(t, trackedAt.Before(before), "lastUploadTime should be bumped to >= probe start time")
+
+	// Mutation baseline must be preserved: no snapshot was actually taken, so
+	// the next eligible upload should still see these mutations.
+	count, err := readSnapshotMutationCount(idx.index)
+	require.NoError(t, err)
+	assert.Equal(t, int64(5), count)
 }


### PR DESCRIPTION
## What

Adds a cross-instance dedup probe to the periodic snapshot upload path. Before acquiring the build lock, `uploadSnapshot` walks namespace snapshots newest-first by ULID time, looking for a same-version snapshot uploaded within `UploadInterval`. On hit, the upload is skipped, `lastUploadTime` is bumped to now, and the mutation baseline is preserved.

Disabled when `UploadInterval == 0` (uploads then gated only by `MinDocChanges` / `MinDocCount`, mirroring today's local logic). New metric label on `index_server_snapshot_uploads_total`: `skip_recent_remote`.

## Why

The periodic loop only consults this instance's in-memory `lastUploadTime`. After a restart, that map is empty, so a fresh process can upload over a recent remote snapshot. This makes the cross-instance behaviour match the per-instance check.

## Why walk, not just check the newest

In mixed-version clusters — rolling upgrades, or deliberate steady-state — V1 and V2 replicas may interleave uploads, so the newest snapshot can be the wrong version while a same-version match lives a few keys back. The walk stops at the age cutoff, so cost is bounded by uploads in the window.

## Correctness

The probe is an optimisation. Probe failures fall through to today's upload path. ULIDs guarantee unique keys, so duplicate uploads remain safe; cleanup reaps the loser.

## Which issue(s) does this PR fix?

Refs grafana/search-and-storage-team#767