### PR TITLE
Scopes: Skip scope_node URL write when defaultPath is source of truth

### DIFF
--- a/devenv/scopes/scopes-config.yaml
+++ b/devenv/scopes/scopes-config.yaml
@@ -6,6 +6,43 @@ scopes:
         operator: equals
         value: shoe
 
+  # Cluster 1 needs a scope definition; the tree references it but the API
+  # returns 404 without one. defaultPath drives tree expansion to the leaf node.
+  cluster1:
+    title: Cluster 1
+    defaultPath:
+      - gdev-scopes
+      - gdev-scopes-clusters
+      - gdev-scopes-clusters-cluster1-node
+    filters:
+      - key: cluster
+        operator: equals
+        value: cluster1
+
+  # app1 with defaultPath — tree expansion via production path.
+  app1:
+    title: Application 1
+    defaultPath:
+      - gdev-scopes
+      - gdev-scopes-production
+      - gdev-scopes-production-app1-prod
+    filters:
+      - key: app
+        operator: equals
+        value: app1
+
+  # app2 with defaultPath — tree expansion via production path.
+  app2:
+    title: Application 2
+    defaultPath:
+      - gdev-scopes
+      - gdev-scopes-production
+      - gdev-scopes-production-app2-prod
+    filters:
+      - key: app
+        operator: equals
+        value: app2
+
   shoes:
     title: Shoes
     filters:

--- a/devenv/scopes/scopes-config.yaml
+++ b/devenv/scopes/scopes-config.yaml
@@ -9,7 +9,7 @@ scopes:
   # Cluster 1 needs a scope definition; the tree references it but the API
   # returns 404 without one. defaultPath drives tree expansion to the leaf node.
   cluster1:
-    title: Cluster 1
+    title: Cluster 1 (defaultPath)
     defaultPath:
       - gdev-scopes
       - gdev-scopes-clusters

--- a/devenv/scopes/scopes-config.yaml
+++ b/devenv/scopes/scopes-config.yaml
@@ -19,9 +19,8 @@ scopes:
         operator: equals
         value: cluster1
 
-  # app1 with defaultPath — tree expansion via production path.
   app1:
-    title: Application 1
+    title: Application 1 (defaultPath)
     defaultPath:
       - gdev-scopes
       - gdev-scopes-production
@@ -31,9 +30,8 @@ scopes:
         operator: equals
         value: app1
 
-  # app2 with defaultPath — tree expansion via production path.
   app2:
-    title: Application 2
+    title: Application 2 (defaultPath)
     defaultPath:
       - gdev-scopes
       - gdev-scopes-production
@@ -89,7 +87,7 @@ scopes:
   # The defaultPath determines which path is shown when this scope is selected
   # (e.g., from a URL or programmatically), even if another path also links to it.
   shared-service:
-    title: Shared Service
+    title: Shared Service (defaultPath)
     # Path from the root node down to the direct scopeNode.
     # Node names are hierarchical (parent-child), so use the full names.
     # This points to: gdev-scopes > production > shared-service-prod

--- a/public/app/features/scopes/ScopesService.test.ts
+++ b/public/app/features/scopes/ScopesService.test.ts
@@ -1022,6 +1022,91 @@ describe('ScopesService', () => {
         true
       );
     });
+
+    it('should clear scopes URL params when enabling with no applied scopes', () => {
+      // Covers the firstScope-falsy short-circuit in the defer guard:
+      // when appliedScopes is empty, the guard does not fire and the URL
+      // write proceeds with empty scopes and scope_node: null.
+      selectorService.state.appliedScopes = [];
+      selectorService.state.scopes = {};
+
+      service.setEnabled(true);
+
+      expect(locationService.partial).toHaveBeenCalledWith(
+        {
+          scopes: [],
+          scope_node: null,
+          scope_parent: null,
+        },
+        true
+      );
+    });
+
+    it('should not write URL when setEnabled is called with the current enabled state', () => {
+      selectorService.state.appliedScopes = [{ scopeId: 'scope1', scopeNodeId: 'node1' }];
+      selectorService.state.scopes = {
+        scope1: { metadata: { name: 'scope1' }, spec: { title: 'Scope 1', filters: [] } },
+      };
+
+      service.setEnabled(true);
+      jest.clearAllMocks();
+
+      // Calling setEnabled(true) again should be a no-op since state is unchanged.
+      service.setEnabled(true);
+
+      expect(locationService.partial).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('setReadOnly', () => {
+    beforeEach(() => {
+      locationService.getLocation = jest.fn().mockReturnValue({
+        pathname: '/test',
+        search: '',
+      });
+      service = new ScopesService(selectorService, dashboardsService, locationService);
+    });
+
+    it('should update readOnly state when changed', () => {
+      service.setReadOnly(true);
+
+      expect(service.state.readOnly).toBe(true);
+    });
+
+    it('should not call closeAndReset when setting readOnly to false', () => {
+      selectorService.state.opened = true;
+      selectorService.closeAndReset = jest.fn();
+
+      service.setReadOnly(false);
+
+      expect(selectorService.closeAndReset).not.toHaveBeenCalled();
+    });
+
+    it('should close the selector when setting readOnly to true with selector opened', () => {
+      selectorService.state.opened = true;
+      selectorService.closeAndReset = jest.fn();
+
+      service.setReadOnly(true);
+
+      expect(selectorService.closeAndReset).toHaveBeenCalled();
+    });
+
+    it('should not close the selector when setting readOnly to true with selector already closed', () => {
+      selectorService.state.opened = false;
+      selectorService.closeAndReset = jest.fn();
+
+      service.setReadOnly(true);
+
+      expect(selectorService.closeAndReset).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('cleanUp', () => {
+    it('should unsubscribe all subscriptions without throwing', () => {
+      service = new ScopesService(selectorService, dashboardsService, locationService);
+
+      expect(() => service.cleanUp()).not.toThrow();
+    });
   });
 
   describe('back/forward navigation handling', () => {

--- a/public/app/features/scopes/ScopesService.test.ts
+++ b/public/app/features/scopes/ScopesService.test.ts
@@ -418,7 +418,9 @@ describe('ScopesService', () => {
       selectorStateSubscription(
         {
           appliedScopes: [{ scopeId: 'scope1', scopeNodeId: 'node1' }],
-          scopes: {},
+          scopes: {
+            scope1: { metadata: { name: 'scope1' }, spec: { title: 'Scope 1', filters: [] } },
+          },
         },
         {
           appliedScopes: [],
@@ -444,7 +446,9 @@ describe('ScopesService', () => {
       selectorStateSubscription(
         {
           appliedScopes: [{ scopeId: 'scope1', scopeNodeId: 'node1', parentNodeId: 'parent1' }],
-          scopes: {},
+          scopes: {
+            scope1: { metadata: { name: 'scope1' }, spec: { title: 'Scope 1', filters: [] } },
+          },
         },
         {
           appliedScopes: [],
@@ -468,7 +472,9 @@ describe('ScopesService', () => {
       selectorStateSubscription(
         {
           appliedScopes: [{ scopeId: 'scope1', scopeNodeId: 'node2' }],
-          scopes: {},
+          scopes: {
+            scope1: { metadata: { name: 'scope1' }, spec: { title: 'Scope 1', filters: [] } },
+          },
         },
         {
           appliedScopes: [{ scopeId: 'scope1', scopeNodeId: 'node1' }],
@@ -494,7 +500,9 @@ describe('ScopesService', () => {
       selectorStateSubscription(
         {
           appliedScopes: [{ scopeId: 'scope1' }],
-          scopes: {},
+          scopes: {
+            scope1: { metadata: { name: 'scope1' }, spec: { title: 'Scope 1', filters: [] } },
+          },
         },
         {
           appliedScopes: [],
@@ -534,7 +542,7 @@ describe('ScopesService', () => {
     });
 
     describe('defaultPath support', () => {
-      it('should extract scope_node from defaultPath when available', () => {
+      it('should not write scope_node to URL when defaultPath is available', () => {
         if (!selectorStateSubscription) {
           throw new Error('selectorStateSubscription not set');
         }
@@ -559,11 +567,12 @@ describe('ScopesService', () => {
           }
         );
 
-        // Should use 'correct-node' from defaultPath, not 'old-node' from appliedScopes
+        // When defaultPath is available, scope_node is redundant (it is re-derived
+        // from defaultPath on load), so the URL param is cleared.
         expect(locationService.partial).toHaveBeenCalledWith(
           {
             scopes: ['scope1'],
-            scope_node: 'correct-node',
+            scope_node: null,
             scope_parent: null,
           },
           true
@@ -641,10 +650,54 @@ describe('ScopesService', () => {
         );
       });
 
-      it('should detect changes in defaultPath-derived scopeNodeId', () => {
+      it('should clear stale scope_node when scope metadata loads with defaultPath', () => {
         if (!selectorStateSubscription) {
           throw new Error('selectorStateSubscription not set');
         }
+
+        jest.clearAllMocks();
+
+        // Simulates the second emit in applyScopes: the first emit ran while
+        // scope metadata was still loading (so the subscription fell through
+        // to firstScope.scopeNodeId and a stale value may have been written
+        // to the URL). Once metadata loads and defaultPath becomes visible,
+        // the subscription must fire with scope_node: null to clear it.
+        selectorStateSubscription(
+          {
+            appliedScopes: [{ scopeId: 'scope1', scopeNodeId: 'stale-node' }],
+            scopes: {
+              scope1: {
+                metadata: { name: 'scope1' },
+                spec: {
+                  title: 'Scope 1',
+                  defaultPath: ['', 'parent', 'derived-node'],
+                  filters: [],
+                },
+              },
+            },
+          },
+          {
+            appliedScopes: [{ scopeId: 'scope1', scopeNodeId: 'stale-node' }],
+            scopes: {},
+          }
+        );
+
+        expect(locationService.partial).toHaveBeenCalledWith(
+          {
+            scopes: ['scope1'],
+            scope_node: null,
+            scope_parent: null,
+          },
+          true
+        );
+      });
+
+      it('should not update URL when only defaultPath changes and scopes are unchanged', () => {
+        if (!selectorStateSubscription) {
+          throw new Error('selectorStateSubscription not set');
+        }
+
+        jest.clearAllMocks();
 
         selectorStateSubscription(
           {
@@ -675,15 +728,9 @@ describe('ScopesService', () => {
           }
         );
 
-        // Should detect the change in defaultPath-derived scopeNodeId
-        expect(locationService.partial).toHaveBeenCalledWith(
-          {
-            scopes: ['scope1'],
-            scope_node: 'new-node',
-            scope_parent: null,
-          },
-          true
-        );
+        // scope_node is no longer synced when defaultPath is present, so a
+        // defaultPath-only change does not trigger a URL update.
+        expect(locationService.partial).not.toHaveBeenCalled();
       });
     });
 
@@ -907,6 +954,9 @@ describe('ScopesService', () => {
 
     it('should sync scopeNodeId when enabling scopes', () => {
       selectorService.state.appliedScopes = [{ scopeId: 'scope1', scopeNodeId: 'node1' }];
+      selectorService.state.scopes = {
+        scope1: { metadata: { name: 'scope1' }, spec: { title: 'Scope 1', filters: [] } },
+      };
 
       service.setEnabled(true);
 
@@ -920,6 +970,9 @@ describe('ScopesService', () => {
 
     it('should reset scope_parent when enabling scopes', () => {
       selectorService.state.appliedScopes = [{ scopeId: 'scope1', scopeNodeId: 'node1' }];
+      selectorService.state.scopes = {
+        scope1: { metadata: { name: 'scope1' }, spec: { title: 'Scope 1', filters: [] } },
+      };
 
       service.setEnabled(true);
 
@@ -931,7 +984,21 @@ describe('ScopesService', () => {
       );
     });
 
-    it('should use defaultPath for scope_node when enabling scopes', () => {
+    it('should defer URL write when scope metadata has not loaded', () => {
+      // setEnabled is called from `@grafana/scenes` during dashboard mount,
+      // which can race with applyScopes. If metadata is not loaded yet, the
+      // helper would fall through to firstScope.scopeNodeId — a value that
+      // the URL-sync subscription is about to settle to a different state.
+      // Defer to avoid the race-write.
+      selectorService.state.appliedScopes = [{ scopeId: 'scope1', scopeNodeId: 'node1' }];
+      selectorService.state.scopes = {};
+
+      service.setEnabled(true);
+
+      expect(locationService.partial).not.toHaveBeenCalled();
+    });
+
+    it('should clear scope_node when enabling scopes for a scope with defaultPath', () => {
       selectorService.state.appliedScopes = [{ scopeId: 'scope1', scopeNodeId: 'old-node' }];
       selectorService.state.scopes = {
         scope1: {
@@ -946,10 +1013,11 @@ describe('ScopesService', () => {
 
       service.setEnabled(true);
 
-      // Should use defaultPath instead of scopeNodeId from appliedScopes
+      // When defaultPath is available, scope_node is redundant and should be
+      // cleared from the URL (passing null removes any stale value).
       expect(locationService.partial).toHaveBeenCalledWith(
         expect.objectContaining({
-          scope_node: 'correct-node-from-defaultPath',
+          scope_node: null,
         }),
         true
       );

--- a/public/app/features/scopes/ScopesService.test.ts
+++ b/public/app/features/scopes/ScopesService.test.ts
@@ -1023,6 +1023,24 @@ describe('ScopesService', () => {
       );
     });
 
+    it('should overwrite stale scope_node in URL when enabling scopes with unchanged scopes', () => {
+      // When navigating to a dashboard with the same scopes already applied, the
+      // location subscription exits early (enabled=false at navigation time), so
+      // applyScopes never fires. setEnabled is the only write path that clears a
+      // stale scope_node left in the URL.
+      selectorService.state.appliedScopes = [{ scopeId: 'scope1', scopeNodeId: 'correct-node' }];
+      selectorService.state.scopes = {
+        scope1: { metadata: { name: 'scope1' }, spec: { title: 'Scope 1', filters: [] } },
+      };
+
+      service.setEnabled(true);
+
+      expect(locationService.partial).toHaveBeenCalledWith(
+        expect.objectContaining({ scope_node: 'correct-node' }),
+        true
+      );
+    });
+
     it('should clear scopes URL params when enabling with no applied scopes', () => {
       // Covers the firstScope-falsy short-circuit in the defer guard:
       // when appliedScopes is empty, the guard does not fire and the URL

--- a/public/app/features/scopes/ScopesService.ts
+++ b/public/app/features/scopes/ScopesService.ts
@@ -7,6 +7,7 @@ import { type LocationService, type ScopesContextValue, type ScopesContextValueS
 import { type ScopesDashboardsService } from './dashboards/ScopesDashboardsService';
 import { deserializeFolderPath, serializeFolderPath } from './dashboards/scopeNavgiationUtils';
 import { type ScopesSelectorService } from './selector/ScopesSelectorService';
+import { type ScopesMap, type SelectedScope } from './selector/types';
 
 export interface State {
   enabled: boolean;
@@ -170,22 +171,8 @@ export class ScopesService implements ScopesContextValue {
         const oldScopeNames = prevState.appliedScopes.map((scope) => scope.scopeId);
         const newScopeNames = state.appliedScopes.map((scope) => scope.scopeId);
 
-        // Extract scopeNodeId from defaultPath when available
-        const getScopeNodeId = (appliedScopes: typeof state.appliedScopes, scopes: typeof state.scopes) => {
-          const firstScope = appliedScopes[0];
-          if (!firstScope) {
-            return undefined;
-          }
-          const scope = scopes[firstScope.scopeId];
-          // Prefer defaultPath when available
-          if (scope?.spec.defaultPath && scope.spec.defaultPath.length > 0) {
-            return scope.spec.defaultPath[scope.spec.defaultPath.length - 1];
-          }
-          return firstScope.scopeNodeId;
-        };
-
-        const oldScopeNodeId = getScopeNodeId(prevState.appliedScopes, prevState.scopes);
-        const newScopeNodeId = getScopeNodeId(state.appliedScopes, state.scopes);
+        const oldScopeNodeId = this.getScopeNodeIdForUrl(prevState.appliedScopes, prevState.scopes);
+        const newScopeNodeId = this.getScopeNodeIdForUrl(state.appliedScopes, state.scopes);
 
         const scopesChanged = !isEqual(oldScopeNames, newScopeNames);
         const scopeNodeChanged = oldScopeNodeId !== newScopeNodeId;
@@ -194,7 +181,7 @@ export class ScopesService implements ScopesContextValue {
           this.locationService.partial(
             {
               scopes: newScopeNames,
-              scope_node: newScopeNodeId || null,
+              scope_node: newScopeNodeId ?? null,
               scope_parent: null,
             },
             true
@@ -260,11 +247,21 @@ export class ScopesService implements ScopesContextValue {
     if (this.state.enabled !== enabled) {
       this.updateState({ enabled });
       if (enabled) {
-        const scopeNodeId = this.getScopeNodeIdForUrl();
+        const { appliedScopes, scopes } = this.selectorService.state;
+        // Defer the URL write when scope metadata has not loaded yet.
+        // setEnabled is called from `@grafana/scenes` during dashboard mount,
+        // which can race with `applyScopes` and re-write a stale `scope_node`
+        // that the subscription has already settled (or is about to settle).
+        // The URL-sync subscription will fire once metadata arrives.
+        const firstScope = appliedScopes[0];
+        if (firstScope && !scopes[firstScope.scopeId]) {
+          return;
+        }
+        const scopeNodeId = this.getScopeNodeIdForUrl(appliedScopes, scopes);
         this.locationService.partial(
           {
-            scopes: this.selectorService.state.appliedScopes.map((s) => s.scopeId),
-            scope_node: scopeNodeId,
+            scopes: appliedScopes.map((s) => s.scopeId),
+            scope_node: scopeNodeId ?? null,
             scope_parent: null,
           },
           true
@@ -274,25 +271,27 @@ export class ScopesService implements ScopesContextValue {
   };
 
   /**
-   * Extracts the scopeNodeId for URL syncing, preferring defaultPath when available.
-   * When a scope has defaultPath, that is the source of truth for the node ID.
+   * Returns the scope node id to sync with the URL, or `undefined` when the
+   * URL should not carry `scope_node` at all.
+   *
+   * We skip writing `scope_node` when the scope has a non-empty `defaultPath`,
+   * since that value is redundant — it is re-derived from `defaultPath` on load
+   * and kept in sync by the selector service. Bookmarked URLs that still carry
+   * `scope_node=...` continue to work via the read path.
    * @private
    */
-  private getScopeNodeIdForUrl(): string | undefined {
-    const firstScope = this.selectorService.state.appliedScopes[0];
+  private getScopeNodeIdForUrl(appliedScopes: SelectedScope[], scopes: ScopesMap): string | undefined {
+    const firstScope = appliedScopes[0];
     if (!firstScope) {
       return undefined;
     }
 
-    const scope = this.selectorService.state.scopes[firstScope.scopeId];
+    const scope = scopes[firstScope.scopeId];
 
-    // Prefer scopeNodeId from defaultPath if available (most reliable source)
     if (scope?.spec.defaultPath && scope.spec.defaultPath.length > 0) {
-      // Extract scopeNodeId from the last element of defaultPath
-      return scope.spec.defaultPath[scope.spec.defaultPath.length - 1];
+      return undefined;
     }
 
-    // Fallback to next in priority order: scopeNodeId from appliedScopes
     return firstScope.scopeNodeId;
   }
 


### PR DESCRIPTION
## What this PR does / why we need it

When a Grafana scope has `spec.defaultPath` set, the URL was getting `scope_node=<id>` written alongside `scopes=<id>`. `defaultPath` is already the source of truth — it re-derives the node on load and keeps in-memory state in sync — so the URL parameter is redundant and exposes implementation-detail IDs that change across versions, making URLs non-portable and harder to share.

This is a re-application of #123130 (reverted in #123626) with one added guard: `setEnabled` defers its URL write when scope metadata has not yet loaded, which closes the most likely race window contributing to the prior revert.

## Root cause

`ScopesService.ts` writes the URL via two paths: the `selectorService` state subscription (fires on every applied-scope change) and `setEnabled(true)` (fires once per page when scopes activate). Both previously preferred `defaultPath[last]` as the value to write; this PR makes both return `undefined` when `defaultPath` is present so the URL param is cleared.

The `setEnabled` defer guard prevents a brief window — during the gap between `applyScopes`' two `updateState` calls (line 420 & line 502 in `ScopesSelectorService.ts`) — where `setEnabled` could be called from `@grafana/scenes`'s `ScopesVariable.setContext` and write a stale fallback value before metadata arrives.

## Behavioral matrix

| Scenario | Before fix | After fix |
|---|---|---|
| Load `?scopes=gdev-shared-service` (no `scope_node`) | URL gains `scope_node=gdev-gdev-scopes-production-shared-service-prod` | URL stays clean |
| Load `?scopes=gdev-shared-service&scope_node=stale-foo` (bookmarked stale) | `scope_node=stale-foo` retained on refresh | `scope_node` cleared after metadata loads |
| Load `?scopes=gdev-shoe-org&scope_node=foo` | `scope_node=foo` retained | `scope_node=foo` retained (unchanged) |
| Select `gdev-app1` from tree (defaultPath) | URL gains `scope_node=gdev-gdev-scopes-production-app1-prod` | URL has only `scopes=gdev-app1` |
| Select `gdev-shoe-org` from tree (non-defaultPath) | URL gains `scope_node=gdev-gdev-scopes-shoe-org-root` | URL gains `scope_node=gdev-gdev-scopes-shoe-org-root` (unchanged) |
| Switch `gdev-shared-service` → `gdev-app1` (defaultPath → defaultPath) | `scope_node` updates to new leaf | URL stays clean across both |

## Verification process

Tested via local browser automation against devenv. Sequence:

1. Hard reload of `?scopes=gdev-shared-service` → URL stays clean
2. `gdev-shared-service` → `gdev-app1` transition (defaultPath → defaultPath) → URL stays clean
3. `gdev-app1` → `gdev-shoe-org` transition (defaultPath → non-defaultPath) → URL gains `scope_node`
4. `gdev-shoe-org` → `gdev-shared-service` transition (non-defaultPath → defaultPath) → URL clears `scope_node`
5. Reload at each step → URL preserved correctly
6. Bookmarked stale `scope_node=stale-foo` for `gdev-shared-service` → cleared on next subscription emit
7. Manual paste of `?scopes=gdev-app1&scope_node=stale-foo` → settles to clean URL

All 7 scenarios pass with the fix. Confirmed against clean `main` (with fix temporarily reverted) that scenarios 1, 6, 7 fail without the fix.

## Devenv companion change

`devenv/scopes/scopes-config.yaml` now has `defaultPath` on `gdev-app1`, `gdev-app2`, and a definition for `gdev-cluster1` (which was previously referenced in the tree but undefined as a scope, returning 404 from the API). This gives the local devenv multiple defaultPath scopes for exercising defaultPath ↔ defaultPath and defaultPath ↔ non-defaultPath transitions during review and future Scopes work.

To pick up the new test data after pulling the branch, run:

```bash
cd devenv/scopes && go run scopes.go -clean && go run scopes.go
```

## Known caveats

- **Tree auto-expansion on reload** — pre-existing bug, not caused by this fix. After reloading a page with a defaultPath scope in URL, opening the scope-selector tree shows the parent collapsed instead of auto-expanded to the leaf. Verified pre-existing on `main`. Filed as grafana/hyperion-planning#621.
- **localStorage `scopeNodeId` persistence in `addRecentScopes`** is being worked on in @tskarhed 's [new PR](https://github.com/grafana/grafana/pull/123823).
- 

## Which issue(s) this PR fixes

Continuation of grafana/hyperion-planning#542 after revert in #123626.

## Test plan

- Note: to separate this change from potential localStorage issues, run `localStorage.removeItem('grafana.scopes.recent')` before doing any direct URL changes or browser refreshes
- [x] Initial load with `?scopes=gdev-shared-service` → URL stays clean
- [x] Bookmarked URL with stale `scope_node=stale-foo` for `gdev-shared-service` → URL settles to `?scopes=gdev-shared-service` after refresh
- [x] Selecting `gdev-app1` from the scope-selector tree → URL has only `scopes=gdev-app1`
- [x] Selecting `gdev-shoe-org` from the scope-selector tree → URL has `scopes=gdev-shoe-org&scope_node=gdev-gdev-scopes-shoe-org-root`
- [x] Switching `gdev-shoe-org` → `gdev-app1` (non-defaultPath → defaultPath) → `scope_node` clears
- [x] Switching `gdev-app1` → `gdev-app2` (defaultPath → defaultPath) → URL stays clean
