### PR TITLE
Alerting: Skip TestIntegrationSetProvenance_DeadlockScenarios on SQLite

### DIFF
--- a/pkg/services/ngalert/store/provisioning_store_test.go
+++ b/pkg/services/ngalert/store/provisioning_store_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/ngalert"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -207,6 +208,15 @@ func TestIntegrationProvisioningStore(t *testing.T) {
 
 func TestIntegrationSetProvenance_DeadlockScenarios(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
+
+	// The deadlock class this test targets is specific to MySQL's gap/insert-intention locks
+	// (see setProvenanceWithLocking, gated by FlagAlertingProvenanceLockWrites). On SQLite,
+	// SELECT ... FOR UPDATE is a no-op and the single-writer model makes 20 concurrent
+	// transactions contend on busy_timeout, producing SQLITE_BUSY rather than exercising
+	// the fix.
+	if db.IsTestDbSQLite() {
+		t.Skip("DeadlockScenarios targets MySQL gap-lock semantics; skipped on SQLite")
+	}
 
 	ng, dbStore := tests.SetupTestEnv(t, testAlertingIntervalSeconds)
 	dbStore.FeatureToggles = featuremgmt.WithFeatures(featuremgmt.FlagAlertingProvenanceLockWrites)


### PR DESCRIPTION
## Summary

Fixes a flaky integration test on SQLite Enterprise CI shards.

`TestIntegrationSetProvenance_DeadlockScenarios` was added in #106370 to validate the MySQL gap-lock deadlock fix gated by `FlagAlertingProvenanceLockWrites`. On SQLite, `SELECT ... FOR UPDATE` is a no-op and the single-writer model makes 20 concurrent writers contend on `busy_timeout`, producing `SQLITE_BUSY` — the test exercises nothing related to the fix it was designed to guard.

Skipping on SQLite (via `db.IsTestDbSQLite()`, same pattern as `pkg/server/module_server_test.go`) is preferred over the alternatives:
- Lowering fan-out / bumping `_busy_timeout` hides the symptom while still testing nothing useful on SQLite.
- Retrying on `SQLITE_BUSY` in production code would add complexity to a path where the locking is itself a no-op on this engine.

MySQL and Postgres continue to run all three subtests, preserving deadlock-fix coverage. Across 6 failed `pr-test-integration.yml` runs on `main` in the last ~28h, every failure was on a `Sqlite Enterprise` shard — zero MySQL/Postgres failures.

## Test plan

- [x] CI green on the `Sqlite Enterprise` shards (test should report SKIP).
- [x] CI green on `MySQL Enterprise` and `Postgres Enterprise` shards (test should still run and pass).