### PR TITLE
storage/unified/search: add findFreshSnapshotByBuildStart probe and align IndexMeta field names

### DIFF
--- a/pkg/storage/unified/search/bleve_snapshot.go
+++ b/pkg/storage/unified/search/bleve_snapshot.go
@@ -196,7 +196,7 @@ func (b *bleveBackend) pickBestSnapshot(all map[ulid.ULID]*IndexMeta, now time.T
 		// Hard filter: unparseable version (we can't tier it). Metadata validation
 		// lives here rather than in the store so we don't have to duplicate it
 		// across store implementations.
-		v, err := semver.NewVersion(m.GrafanaBuildVersion)
+		v, err := semver.NewVersion(m.BuildVersion)
 		if err != nil {
 			droppedUnparseable++
 			continue
@@ -308,7 +308,7 @@ func (b *bleveBackend) recordSnapshotDownloadStatus(status string) {
 }
 
 // findFreshSnapshotByUploadTime walks namespace snapshots newest-first and
-// returns the first one whose GrafanaBuildVersion matches runningVersion and
+// returns the first one whose BuildVersion matches runningVersion and
 // whose ULID time falls within [now-maxAge, now]. Returns a zero key and nil
 // meta when no such snapshot exists.
 //
@@ -357,9 +357,72 @@ func findFreshSnapshotByUploadTime(
 			return ulid.ULID{}, nil, fmt.Errorf("reading manifest for %s: %w", k, err)
 		}
 
-		if meta.GrafanaBuildVersion == runningVersion {
+		if meta.BuildVersion == runningVersion {
 			return k, meta, nil
 		}
+	}
+
+	return ulid.ULID{}, nil, nil
+}
+
+// findFreshSnapshotByBuildStart is the build-start-time variant of
+// findFreshSnapshotByUploadTime: it returns the first same-version
+// snapshot whose BuildTime (not upload time) falls within
+// [now-maxAge, now].
+//
+// Use this for data-freshness questions, e.g. "is the remote snapshot
+// fresh enough to skip a rebuild?". Periodic re-uploads preserve the
+// original BuildTime and are correctly rejected once the
+// underlying data ages out, even when their ULID is recent.
+//
+// Manifests with a zero-value BuildTime are skipped (no freshness
+// signal). The stopping rule is unchanged: BuildTime <= ULID time, so a
+// ULID below the cutoff cannot yield a fresh build-start time.
+func findFreshSnapshotByBuildStart(
+	ctx context.Context,
+	store RemoteIndexStore,
+	ns resource.NamespacedResource,
+	maxAge time.Duration,
+	runningVersion string,
+) (ulid.ULID, *IndexMeta, error) {
+	keys, err := store.ListIndexKeys(ctx, ns)
+	if err != nil {
+		return ulid.ULID{}, nil, fmt.Errorf("listing index keys: %w", err)
+	}
+
+	sort.Slice(keys, func(i, j int) bool {
+		return keys[i].Time() > keys[j].Time()
+	})
+
+	cutoff := time.Now().Add(-maxAge)
+	for _, k := range keys {
+		// BuildTime <= UploadTimestamp = ULID time. Once ULID
+		// time crosses the cutoff, no remaining candidate can satisfy.
+		if !ulid.Time(k.Time()).After(cutoff) {
+			return ulid.ULID{}, nil, nil
+		}
+
+		meta, err := store.GetIndexMeta(ctx, ns, k)
+		if err != nil {
+			if errors.Is(err, ErrSnapshotNotFound) || errors.Is(err, ErrInvalidManifest) {
+				continue
+			}
+			return ulid.ULID{}, nil, fmt.Errorf("reading manifest for %s: %w", k, err)
+		}
+
+		if meta.BuildVersion != runningVersion {
+			continue
+		}
+		// Zero-value BuildTime carries no freshness signal; never selected.
+		if meta.BuildTime.IsZero() {
+			continue
+		}
+		if meta.BuildTime.After(cutoff) {
+			return k, meta, nil
+		}
+		// Recent ULID but old BuildTime (e.g. periodic re-upload
+		// of a long-lived index): keep walking — an earlier candidate may
+		// still have a fresh build-start time.
 	}
 
 	return ulid.ULID{}, nil, nil

--- a/pkg/storage/unified/search/bleve_snapshot_observability_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_observability_test.go
@@ -63,7 +63,7 @@ func TestSnapshotDownloadEmitsSpan(t *testing.T) {
 
 	store := &fakeRemoteIndexStore{}
 	store.put(makeULID(t, time.Now()), &IndexMeta{
-		GrafanaBuildVersion:   "11.5.0",
+		BuildVersion:   "11.5.0",
 		LatestResourceVersion: 42,
 		UploadTimestamp:       time.Now(),
 	})

--- a/pkg/storage/unified/search/bleve_snapshot_observability_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_observability_test.go
@@ -63,7 +63,7 @@ func TestSnapshotDownloadEmitsSpan(t *testing.T) {
 
 	store := &fakeRemoteIndexStore{}
 	store.put(makeULID(t, time.Now()), &IndexMeta{
-		BuildVersion:   "11.5.0",
+		BuildVersion:          "11.5.0",
 		LatestResourceVersion: 42,
 		UploadTimestamp:       time.Now(),
 	})

--- a/pkg/storage/unified/search/bleve_snapshot_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_test.go
@@ -140,7 +140,7 @@ func writeFakeSnapshot(dir string, meta *IndexMeta) error {
 	}
 	bi, err := json.Marshal(buildInfo{
 		BuildTime:    meta.UploadTimestamp.Unix(),
-		BuildVersion: meta.GrafanaBuildVersion,
+		BuildVersion: meta.BuildVersion,
 	})
 	if err != nil {
 		return err
@@ -201,7 +201,7 @@ func TestPickBestSnapshot(t *testing.T) {
 
 	snap := func(ver string, rv int64, age time.Duration) *IndexMeta {
 		return &IndexMeta{
-			GrafanaBuildVersion:   ver,
+			BuildVersion:   ver,
 			LatestResourceVersion: rv,
 			UploadTimestamp:       now.Add(-age),
 		}
@@ -352,7 +352,7 @@ func TestTryDownloadRemoteSnapshot_ListError(t *testing.T) {
 func TestTryDownloadRemoteSnapshot_DownloadError(t *testing.T) {
 	store := &fakeRemoteIndexStore{downloadErr: errors.New("network dropped")}
 	store.put(makeULID(t, time.Now()), &IndexMeta{
-		GrafanaBuildVersion:   "11.5.0",
+		BuildVersion:   "11.5.0",
 		LatestResourceVersion: 42,
 		UploadTimestamp:       time.Now(),
 	})
@@ -370,7 +370,7 @@ func TestTryDownloadRemoteSnapshot_DownloadError(t *testing.T) {
 func TestTryDownloadRemoteSnapshot_ValidationError(t *testing.T) {
 	store := &fakeRemoteIndexStore{}
 	store.put(makeULID(t, time.Now()), &IndexMeta{
-		GrafanaBuildVersion:   "11.5.0",
+		BuildVersion:   "11.5.0",
 		LatestResourceVersion: 0, // invalid (<=0)
 		UploadTimestamp:       time.Now(),
 	})
@@ -388,7 +388,7 @@ func TestTryDownloadRemoteSnapshot_ValidationError(t *testing.T) {
 func TestTryDownloadRemoteSnapshot_Success(t *testing.T) {
 	store := &fakeRemoteIndexStore{}
 	store.put(makeULID(t, time.Now()), &IndexMeta{
-		GrafanaBuildVersion:   "11.5.0",
+		BuildVersion:   "11.5.0",
 		LatestResourceVersion: 42,
 		UploadTimestamp:       time.Now(),
 	})
@@ -408,7 +408,7 @@ func TestTryDownloadRemoteSnapshot_Success(t *testing.T) {
 func TestTryDownloadRemoteSnapshot_AllFilteredOut(t *testing.T) {
 	store := &fakeRemoteIndexStore{}
 	store.put(makeULID(t, time.Now().Add(-2*time.Hour)), &IndexMeta{
-		GrafanaBuildVersion:   "11.5.0",
+		BuildVersion:   "11.5.0",
 		LatestResourceVersion: 42,
 		UploadTimestamp:       time.Now().Add(-2 * time.Hour),
 	})
@@ -683,7 +683,7 @@ func TestIntegrationBleveSnapshotRoundTrip(t *testing.T) {
 	})
 	key := newTestNsResource()
 	meta := IndexMeta{
-		GrafanaBuildVersion:   "11.5.0",
+		BuildVersion:   "11.5.0",
 		LatestResourceVersion: 123,
 		UploadTimestamp:       time.Now(),
 	}
@@ -733,14 +733,13 @@ func TestIntegrationBleveSnapshotRoundTrip(t *testing.T) {
 	assert.Zero(t, mutationCount)
 }
 
-// --- findFreshSnapshotByUploadTime ---
+// --- findFreshSnapshot{ByUploadTime,ByBuildStart} ---
 
 // probeFakeStore embeds fakeRemoteIndexStore but lets individual GetIndexMeta
 // calls fail with a chosen error, so we can test mid-walk error tolerance.
 type probeFakeStore struct {
 	*fakeRemoteIndexStore
 	getErr     map[ulid.ULID]error
-	getCalls   []ulid.ULID
 	listKeyErr error
 }
 
@@ -752,7 +751,6 @@ func (s *probeFakeStore) ListIndexKeys(ctx context.Context, ns resource.Namespac
 }
 
 func (s *probeFakeStore) GetIndexMeta(ctx context.Context, ns resource.NamespacedResource, k ulid.ULID) (*IndexMeta, error) {
-	s.getCalls = append(s.getCalls, k)
 	if e, ok := s.getErr[k]; ok {
 		return nil, e
 	}
@@ -763,105 +761,181 @@ func newProbeFake() *probeFakeStore {
 	return &probeFakeStore{fakeRemoteIndexStore: &fakeRemoteIndexStore{}, getErr: map[ulid.ULID]error{}}
 }
 
-func TestFindFreshSnapshotByUploadTime_HomogeneousCluster(t *testing.T) {
+// probeCase is one row in a table-driven test for findFreshSnapshotBy*.
+// setup populates the per-case store and returns the ULID we expect the
+// probe to return (zero ULID means "no match"). wantErr (substring) flags
+// error-path cases; when set, the probe is expected to return an error.
+type probeCase struct {
+	name    string
+	setup   func(s *probeFakeStore) ulid.ULID
+	wantErr string
+}
+
+type probeFn func(ctx context.Context, s RemoteIndexStore, ns resource.NamespacedResource, maxAge time.Duration, v string) (ulid.ULID, *IndexMeta, error)
+
+func runProbeCases(t *testing.T, probe probeFn, cases []probeCase) {
+	t.Helper()
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newProbeFake()
+			want := tc.setup(store)
+			k, meta, err := probe(t.Context(), store, newTestNsResource(), time.Hour, "11.5.0")
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, want, k)
+			if (want == ulid.ULID{}) {
+				assert.Nil(t, meta)
+			} else {
+				require.NotNil(t, meta)
+			}
+		})
+	}
+}
+
+func TestFindFreshSnapshotByUploadTime(t *testing.T) {
 	now := time.Now()
-	store := newProbeFake()
-	want := makeULID(t, now.Add(-5*time.Minute))
-	store.put(want, &IndexMeta{GrafanaBuildVersion: "11.5.0"})
+	mk := func(d time.Duration) ulid.ULID { return makeULID(t, now.Add(d)) }
 
-	k, meta, err := findFreshSnapshotByUploadTime(t.Context(), store, newTestNsResource(), time.Hour, "11.5.0")
-	require.NoError(t, err)
-	assert.Equal(t, want, k)
-	require.NotNil(t, meta)
-	assert.Equal(t, "11.5.0", meta.GrafanaBuildVersion)
-	assert.Len(t, store.getCalls, 1, "should fetch only the newest manifest in homogeneous case")
+	runProbeCases(t, findFreshSnapshotByUploadTime, []probeCase{
+		{
+			name: "homogeneous cluster: newest same-version returned",
+			setup: func(s *probeFakeStore) ulid.ULID {
+				s.put(mk(-30*time.Minute), &IndexMeta{BuildVersion: "11.5.0"})
+				k := mk(-5 * time.Minute)
+				s.put(k, &IndexMeta{BuildVersion: "11.5.0"})
+				return k
+			},
+		},
+		{
+			name: "mixed version: walks past newer wrong-version",
+			setup: func(s *probeFakeStore) ulid.ULID {
+				s.put(mk(-5*time.Minute), &IndexMeta{BuildVersion: "11.4.0"})
+				match := mk(-30 * time.Minute)
+				s.put(match, &IndexMeta{BuildVersion: "11.5.0"})
+				s.put(mk(-50*time.Minute), &IndexMeta{BuildVersion: "11.5.0"})
+				return match
+			},
+		},
+		{
+			name:  "no candidates",
+			setup: func(s *probeFakeStore) ulid.ULID { return ulid.ULID{} },
+		},
+		{
+			name: "tolerates ErrSnapshotNotFound and ErrInvalidManifest mid-walk",
+			setup: func(s *probeFakeStore) ulid.ULID {
+				nf := mk(-5 * time.Minute)
+				s.put(nf, &IndexMeta{BuildVersion: "11.5.0"})
+				s.getErr[nf] = ErrSnapshotNotFound
+				iv := mk(-10 * time.Minute)
+				s.put(iv, &IndexMeta{BuildVersion: "11.5.0"})
+				s.getErr[iv] = ErrInvalidManifest
+				m := mk(-15 * time.Minute)
+				s.put(m, &IndexMeta{BuildVersion: "11.5.0"})
+				return m
+			},
+		},
+		{
+			name: "surfaces list error",
+			setup: func(s *probeFakeStore) ulid.ULID {
+				s.listKeyErr = errors.New("boom")
+				return ulid.ULID{}
+			},
+			wantErr: "boom",
+		},
+		{
+			name: "surfaces unexpected GET error",
+			setup: func(s *probeFakeStore) ulid.ULID {
+				bad := mk(-5 * time.Minute)
+				s.put(bad, &IndexMeta{BuildVersion: "11.5.0"})
+				s.getErr[bad] = errors.New("transport boom")
+				return ulid.ULID{}
+			},
+			wantErr: "transport boom",
+		},
+	})
 }
 
-func TestFindFreshSnapshotByUploadTime_MixedVersionWalksPastNewerOtherVersion(t *testing.T) {
+func TestFindFreshSnapshotByBuildStart(t *testing.T) {
 	now := time.Now()
-	store := newProbeFake()
-	// Newest: V1, 5 min old. Skipped on version mismatch.
-	v1New := makeULID(t, now.Add(-5*time.Minute))
-	store.put(v1New, &IndexMeta{GrafanaBuildVersion: "11.4.0"})
-	// Match: V2, 30 min old, well within the 1h window.
-	v2Match := makeULID(t, now.Add(-30*time.Minute))
-	store.put(v2Match, &IndexMeta{GrafanaBuildVersion: "11.5.0"})
-	// Older V2 still in window — should not be picked, but also not visited.
-	store.put(makeULID(t, now.Add(-50*time.Minute)), &IndexMeta{GrafanaBuildVersion: "11.5.0"})
+	mk := func(d time.Duration) ulid.ULID { return makeULID(t, now.Add(d)) }
 
-	k, meta, err := findFreshSnapshotByUploadTime(t.Context(), store, newTestNsResource(), time.Hour, "11.5.0")
-	require.NoError(t, err)
-	assert.Equal(t, v2Match, k)
-	require.NotNil(t, meta)
-	// Walk visits the newest (V1, mismatch) then the next (V2, match) and stops.
-	assert.Equal(t, []ulid.ULID{v1New, v2Match}, store.getCalls)
-}
-
-func TestFindFreshSnapshotByUploadTime_StopsAtAgeCutoff(t *testing.T) {
-	now := time.Now()
-	store := newProbeFake()
-	// Newest is V1, 5 min ago — skipped on version.
-	v1 := makeULID(t, now.Add(-5*time.Minute))
-	store.put(v1, &IndexMeta{GrafanaBuildVersion: "11.4.0"})
-	// Only V2 candidate is older than the window — must NOT be returned.
-	stale := makeULID(t, now.Add(-90*time.Minute))
-	store.put(stale, &IndexMeta{GrafanaBuildVersion: "11.5.0"})
-
-	k, meta, err := findFreshSnapshotByUploadTime(t.Context(), store, newTestNsResource(), time.Hour, "11.5.0")
-	require.NoError(t, err)
-	assert.Equal(t, ulid.ULID{}, k)
-	assert.Nil(t, meta)
-	// Walk should have visited only v1 before hitting the cutoff.
-	assert.Equal(t, []ulid.ULID{v1}, store.getCalls)
-}
-
-func TestFindFreshSnapshotByUploadTime_NoCandidates(t *testing.T) {
-	store := newProbeFake()
-	k, meta, err := findFreshSnapshotByUploadTime(t.Context(), store, newTestNsResource(), time.Hour, "11.5.0")
-	require.NoError(t, err)
-	assert.Equal(t, ulid.ULID{}, k)
-	assert.Nil(t, meta)
-	assert.Empty(t, store.getCalls)
-}
-
-func TestFindFreshSnapshotByUploadTime_TolerateNotFoundAndInvalid(t *testing.T) {
-	now := time.Now()
-	store := newProbeFake()
-	// Newest: races with cleanup → ErrSnapshotNotFound. Skip and continue.
-	notFound := makeULID(t, now.Add(-5*time.Minute))
-	store.put(notFound, &IndexMeta{GrafanaBuildVersion: "11.5.0"})
-	store.getErr[notFound] = ErrSnapshotNotFound
-	// Next: corrupt manifest → ErrInvalidManifest. Skip and continue.
-	invalid := makeULID(t, now.Add(-10*time.Minute))
-	store.put(invalid, &IndexMeta{GrafanaBuildVersion: "11.5.0"})
-	store.getErr[invalid] = ErrInvalidManifest
-	// Then: a clean V2 match.
-	match := makeULID(t, now.Add(-15*time.Minute))
-	store.put(match, &IndexMeta{GrafanaBuildVersion: "11.5.0"})
-
-	k, _, err := findFreshSnapshotByUploadTime(t.Context(), store, newTestNsResource(), time.Hour, "11.5.0")
-	require.NoError(t, err)
-	assert.Equal(t, match, k)
-	assert.Equal(t, []ulid.ULID{notFound, invalid, match}, store.getCalls)
-}
-
-func TestFindFreshSnapshotByUploadTime_SurfacesListError(t *testing.T) {
-	store := newProbeFake()
-	store.listKeyErr = errors.New("boom")
-
-	_, _, err := findFreshSnapshotByUploadTime(t.Context(), store, newTestNsResource(), time.Hour, "11.5.0")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "boom")
-}
-
-func TestFindFreshSnapshotByUploadTime_SurfacesUnexpectedGetError(t *testing.T) {
-	now := time.Now()
-	store := newProbeFake()
-	bad := makeULID(t, now.Add(-5*time.Minute))
-	store.put(bad, &IndexMeta{GrafanaBuildVersion: "11.5.0"})
-	store.getErr[bad] = errors.New("transport boom")
-
-	_, _, err := findFreshSnapshotByUploadTime(t.Context(), store, newTestNsResource(), time.Hour, "11.5.0")
-	require.Error(t, err)
-	assert.Contains(t, err.Error(), "transport boom")
+	runProbeCases(t, findFreshSnapshotByBuildStart, []probeCase{
+		{
+			name: "homogeneous cluster: newest same-version returned",
+			setup: func(s *probeFakeStore) ulid.ULID {
+				s.put(mk(-30*time.Minute), &IndexMeta{BuildVersion: "11.5.0", BuildTime: now.Add(-35 * time.Minute)})
+				k := mk(-5 * time.Minute)
+				s.put(k, &IndexMeta{BuildVersion: "11.5.0", BuildTime: now.Add(-10 * time.Minute)})
+				return k
+			},
+		},
+		{
+			name: "mixed version: walks past newer wrong-version",
+			setup: func(s *probeFakeStore) ulid.ULID {
+				s.put(mk(-5*time.Minute), &IndexMeta{BuildVersion: "11.4.0", BuildTime: now.Add(-10 * time.Minute)})
+				match := mk(-30 * time.Minute)
+				s.put(match, &IndexMeta{BuildVersion: "11.5.0", BuildTime: now.Add(-35 * time.Minute)})
+				s.put(mk(-50*time.Minute), &IndexMeta{BuildVersion: "11.5.0", BuildTime: now.Add(-55 * time.Minute)})
+				return match
+			},
+		},
+		{
+			// Behavioural difference vs findFreshSnapshotByUploadTime:
+			// recent ULID + matching version + old BuildTime (a periodic
+			// re-upload of a long-lived index) must be rejected.
+			name: "skips recent re-upload of old build",
+			setup: func(s *probeFakeStore) ulid.ULID {
+				s.put(mk(-5*time.Minute), &IndexMeta{BuildVersion: "11.5.0", BuildTime: now.Add(-3 * time.Hour)})
+				return ulid.ULID{}
+			},
+		},
+		{
+			// Zero-value BuildTime carries no freshness signal.
+			name: "skips zero BuildTime",
+			setup: func(s *probeFakeStore) ulid.ULID {
+				s.put(mk(-5*time.Minute), &IndexMeta{BuildVersion: "11.5.0"})
+				return ulid.ULID{}
+			},
+		},
+		{
+			name:  "no candidates",
+			setup: func(s *probeFakeStore) ulid.ULID { return ulid.ULID{} },
+		},
+		{
+			name: "tolerates ErrSnapshotNotFound and ErrInvalidManifest mid-walk",
+			setup: func(s *probeFakeStore) ulid.ULID {
+				nf := mk(-5 * time.Minute)
+				s.put(nf, &IndexMeta{BuildVersion: "11.5.0", BuildTime: now.Add(-10 * time.Minute)})
+				s.getErr[nf] = ErrSnapshotNotFound
+				iv := mk(-10 * time.Minute)
+				s.put(iv, &IndexMeta{BuildVersion: "11.5.0", BuildTime: now.Add(-15 * time.Minute)})
+				s.getErr[iv] = ErrInvalidManifest
+				m := mk(-15 * time.Minute)
+				s.put(m, &IndexMeta{BuildVersion: "11.5.0", BuildTime: now.Add(-20 * time.Minute)})
+				return m
+			},
+		},
+		{
+			name: "surfaces list error",
+			setup: func(s *probeFakeStore) ulid.ULID {
+				s.listKeyErr = errors.New("boom")
+				return ulid.ULID{}
+			},
+			wantErr: "boom",
+		},
+		{
+			name: "surfaces unexpected GET error",
+			setup: func(s *probeFakeStore) ulid.ULID {
+				bad := mk(-5 * time.Minute)
+				s.put(bad, &IndexMeta{BuildVersion: "11.5.0", BuildTime: now.Add(-10 * time.Minute)})
+				s.getErr[bad] = errors.New("transport boom")
+				return ulid.ULID{}
+			},
+			wantErr: "transport boom",
+		},
+	})
 }

--- a/pkg/storage/unified/search/bleve_snapshot_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_test.go
@@ -201,7 +201,7 @@ func TestPickBestSnapshot(t *testing.T) {
 
 	snap := func(ver string, rv int64, age time.Duration) *IndexMeta {
 		return &IndexMeta{
-			BuildVersion:   ver,
+			BuildVersion:          ver,
 			LatestResourceVersion: rv,
 			UploadTimestamp:       now.Add(-age),
 		}
@@ -352,7 +352,7 @@ func TestTryDownloadRemoteSnapshot_ListError(t *testing.T) {
 func TestTryDownloadRemoteSnapshot_DownloadError(t *testing.T) {
 	store := &fakeRemoteIndexStore{downloadErr: errors.New("network dropped")}
 	store.put(makeULID(t, time.Now()), &IndexMeta{
-		BuildVersion:   "11.5.0",
+		BuildVersion:          "11.5.0",
 		LatestResourceVersion: 42,
 		UploadTimestamp:       time.Now(),
 	})
@@ -370,7 +370,7 @@ func TestTryDownloadRemoteSnapshot_DownloadError(t *testing.T) {
 func TestTryDownloadRemoteSnapshot_ValidationError(t *testing.T) {
 	store := &fakeRemoteIndexStore{}
 	store.put(makeULID(t, time.Now()), &IndexMeta{
-		BuildVersion:   "11.5.0",
+		BuildVersion:          "11.5.0",
 		LatestResourceVersion: 0, // invalid (<=0)
 		UploadTimestamp:       time.Now(),
 	})
@@ -388,7 +388,7 @@ func TestTryDownloadRemoteSnapshot_ValidationError(t *testing.T) {
 func TestTryDownloadRemoteSnapshot_Success(t *testing.T) {
 	store := &fakeRemoteIndexStore{}
 	store.put(makeULID(t, time.Now()), &IndexMeta{
-		BuildVersion:   "11.5.0",
+		BuildVersion:          "11.5.0",
 		LatestResourceVersion: 42,
 		UploadTimestamp:       time.Now(),
 	})
@@ -408,7 +408,7 @@ func TestTryDownloadRemoteSnapshot_Success(t *testing.T) {
 func TestTryDownloadRemoteSnapshot_AllFilteredOut(t *testing.T) {
 	store := &fakeRemoteIndexStore{}
 	store.put(makeULID(t, time.Now().Add(-2*time.Hour)), &IndexMeta{
-		BuildVersion:   "11.5.0",
+		BuildVersion:          "11.5.0",
 		LatestResourceVersion: 42,
 		UploadTimestamp:       time.Now().Add(-2 * time.Hour),
 	})
@@ -683,7 +683,7 @@ func TestIntegrationBleveSnapshotRoundTrip(t *testing.T) {
 	})
 	key := newTestNsResource()
 	meta := IndexMeta{
-		BuildVersion:   "11.5.0",
+		BuildVersion:          "11.5.0",
 		LatestResourceVersion: 123,
 		UploadTimestamp:       time.Now(),
 	}

--- a/pkg/storage/unified/search/bleve_snapshot_upload.go
+++ b/pkg/storage/unified/search/bleve_snapshot_upload.go
@@ -139,14 +139,14 @@ func (b *bleveBackend) uploadSnapshot(ctx context.Context, key resource.Namespac
 	}
 
 	meta := IndexMeta{
-		GrafanaBuildVersion:   bi.BuildVersion,
+		BuildVersion:   bi.BuildVersion,
 		LatestResourceVersion: rv,
 	}
 	// bi.BuildTime is the original index creation time; it survives reopens and
 	// downloads, so periodic re-uploads keep the original build-start time.
 	// Guard zero so legacy indexes without BuildTime stay zero in the manifest.
 	if bi.BuildTime > 0 {
-		meta.BuildStartTimestamp = time.Unix(bi.BuildTime, 0).UTC()
+		meta.BuildTime = time.Unix(bi.BuildTime, 0).UTC()
 	}
 
 	uploadKey, err = b.opts.Snapshot.Store.UploadIndex(ctx, key, stagingDir, meta)

--- a/pkg/storage/unified/search/bleve_snapshot_upload.go
+++ b/pkg/storage/unified/search/bleve_snapshot_upload.go
@@ -139,7 +139,7 @@ func (b *bleveBackend) uploadSnapshot(ctx context.Context, key resource.Namespac
 	}
 
 	meta := IndexMeta{
-		BuildVersion:   bi.BuildVersion,
+		BuildVersion:          bi.BuildVersion,
 		LatestResourceVersion: rv,
 	}
 	// bi.BuildTime is the original index creation time; it survives reopens and

--- a/pkg/storage/unified/search/bleve_snapshot_upload_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_upload_test.go
@@ -191,13 +191,13 @@ func TestUploadSnapshot_Success(t *testing.T) {
 	require.NoError(t, be.uploadSnapshot(context.Background(), key, idx))
 	assert.Equal(t, int32(1), store.uploadCalls.Load())
 	assert.Equal(t, int64(42), store.uploadMeta.LatestResourceVersion)
-	assert.Equal(t, be.opts.BuildVersion, store.uploadMeta.GrafanaBuildVersion)
-	// BuildStartTimestamp must be populated from the index's internal build
+	assert.Equal(t, be.opts.BuildVersion, store.uploadMeta.BuildVersion)
+	// BuildTime must be populated from the index's internal build
 	// info (set by newBleveIndex), not left zero. Compare with second-level
 	// granularity since buildInfo persists Unix seconds.
-	assert.False(t, store.uploadMeta.BuildStartTimestamp.IsZero(), "BuildStartTimestamp should be set")
-	assert.False(t, store.uploadMeta.BuildStartTimestamp.Before(beforeBuild),
-		"BuildStartTimestamp %s should be at or after %s", store.uploadMeta.BuildStartTimestamp, beforeBuild)
+	assert.False(t, store.uploadMeta.BuildTime.IsZero(), "BuildTime should be set")
+	assert.False(t, store.uploadMeta.BuildTime.Before(beforeBuild),
+		"BuildTime %s should be at or after %s", store.uploadMeta.BuildTime, beforeBuild)
 	assert.NotEmpty(t, store.uploaded)
 
 	snapshotParent := filepath.Join(be.opts.Root, "snapshots", resourceSubPath(key))
@@ -235,7 +235,7 @@ func TestUploadSnapshot_PreservesOriginalBuildStartTime(t *testing.T) {
 
 	require.NoError(t, be.uploadSnapshot(context.Background(), key, wrapped))
 	require.Equal(t, int32(1), store.uploadCalls.Load())
-	assert.Equal(t, originalBuildTime.UTC(), store.uploadMeta.BuildStartTimestamp,
+	assert.Equal(t, originalBuildTime.UTC(), store.uploadMeta.BuildTime,
 		"periodic re-upload should preserve the original build-start time")
 }
 
@@ -358,7 +358,7 @@ func TestUploadSnapshot_SkipsWhenRecentSameVersionRemoteExists(t *testing.T) {
 	}
 	recent := makeULID(t, time.Now().Add(-5*time.Minute))
 	store.probeKeys = []ulid.ULID{recent}
-	store.probeMetas[recent] = &IndexMeta{GrafanaBuildVersion: "11.5.0"}
+	store.probeMetas[recent] = &IndexMeta{BuildVersion: "11.5.0"}
 
 	be, _ := newTestBleveBackend(t, SnapshotOptions{Store: store, UploadInterval: time.Hour})
 	key := newTestNsResource()
@@ -382,7 +382,7 @@ func TestUploadSnapshot_ProceedsWhenRemoteIsDifferentVersion(t *testing.T) {
 	}
 	recent := makeULID(t, time.Now().Add(-5*time.Minute))
 	store.probeKeys = []ulid.ULID{recent}
-	store.probeMetas[recent] = &IndexMeta{GrafanaBuildVersion: "11.4.0"}
+	store.probeMetas[recent] = &IndexMeta{BuildVersion: "11.4.0"}
 
 	be, _ := newTestBleveBackend(t, SnapshotOptions{Store: store, UploadInterval: time.Hour})
 	key := newTestNsResource()
@@ -428,7 +428,7 @@ func TestRunUploadSnapshots_SkipRecentRemote(t *testing.T) {
 	}
 	recent := makeULID(t, time.Now().Add(-5*time.Minute))
 	store.probeKeys = []ulid.ULID{recent}
-	store.probeMetas[recent] = &IndexMeta{GrafanaBuildVersion: "11.5.0"}
+	store.probeMetas[recent] = &IndexMeta{BuildVersion: "11.5.0"}
 
 	be, metrics := newTestBleveBackend(t, SnapshotOptions{Store: store, MinDocCount: 1, UploadInterval: time.Hour, MinDocChanges: 1})
 	key := newTestNsResource()

--- a/pkg/storage/unified/search/remote_index_cleanup.go
+++ b/pkg/storage/unified/search/remote_index_cleanup.go
@@ -333,7 +333,7 @@ func (b *bleveBackend) runResourceCleanup(ctx context.Context, res resource.Name
 //	   snapshots except the newest are deletable once the newest has lived
 //	   beyond gracePeriod.
 //
-// Snapshots with an unparseable GrafanaBuildVersion are excluded from any
+// Snapshots with an unparseable BuildVersion are excluded from any
 // version group; rule A still applies, but otherwise they are left untouched.
 // CleanupIncompleteUploads does NOT pick them up — it only targets prefixes
 // with missing or syntactically invalid snapshot manifest, and an unparseable version
@@ -358,7 +358,7 @@ func selectSnapshotsToDelete(metas map[ulid.ULID]*IndexMeta, now time.Time, maxA
 			toDelete = append(toDelete, k)
 			continue
 		}
-		v, err := semver.NewVersion(m.GrafanaBuildVersion)
+		v, err := semver.NewVersion(m.BuildVersion)
 		if err != nil {
 			continue
 		}

--- a/pkg/storage/unified/search/remote_index_cleanup_test.go
+++ b/pkg/storage/unified/search/remote_index_cleanup_test.go
@@ -37,7 +37,7 @@ const (
 
 func mkMeta(version string, rv int64, uploadedAt time.Time) *IndexMeta {
 	return &IndexMeta{
-		GrafanaBuildVersion:   version,
+		BuildVersion:   version,
 		LatestResourceVersion: rv,
 		UploadTimestamp:       uploadedAt,
 	}

--- a/pkg/storage/unified/search/remote_index_cleanup_test.go
+++ b/pkg/storage/unified/search/remote_index_cleanup_test.go
@@ -37,7 +37,7 @@ const (
 
 func mkMeta(version string, rv int64, uploadedAt time.Time) *IndexMeta {
 	return &IndexMeta{
-		BuildVersion:   version,
+		BuildVersion:          version,
 		LatestResourceVersion: rv,
 		UploadTimestamp:       uploadedAt,
 	}

--- a/pkg/storage/unified/search/remote_index_store.go
+++ b/pkg/storage/unified/search/remote_index_store.go
@@ -50,18 +50,18 @@ var ErrInvalidManifest = errors.New("invalid manifest")
 
 // IndexMeta contains metadata about a remote index snapshot.
 type IndexMeta struct {
-	// GrafanaBuildVersion is the version of Grafana that built this index.
-	GrafanaBuildVersion string `json:"grafana_build_version"`
+	// BuildVersion is the version of Grafana that built this index.
+	BuildVersion string `json:"build_version"`
 	// UploadTimestamp is when the snapshot was uploaded.
 	UploadTimestamp time.Time `json:"upload_timestamp"`
-	// BuildStartTimestamp is when the bleve index was originally created
-	// (start of the from-scratch build that produced it). Persisted across
-	// periodic re-uploads of the same index, so it always describes the
-	// underlying data, not the most recent upload.
+	// BuildTime is when the bleve index was originally created (start of
+	// the from-scratch build that produced it). Persisted across periodic
+	// re-uploads of the same index, so it always describes the underlying
+	// data, not the most recent upload.
 	//
-	// Zero-value means "unknown" — snapshots produced before this field was
-	// introduced. Readers fall back to other criteria in that case.
-	BuildStartTimestamp time.Time `json:"build_start_timestamp,omitempty"`
+	// Zero-value means "unknown"; readers must not treat it as a freshness
+	// signal.
+	BuildTime time.Time `json:"build_time,omitempty"`
 	// LatestResourceVersion is the latest resource version included in the index.
 	LatestResourceVersion int64 `json:"latest_resource_version"`
 	// Files maps relative file paths to their sizes in bytes.

--- a/pkg/storage/unified/search/remote_index_store_test.go
+++ b/pkg/storage/unified/search/remote_index_store_test.go
@@ -98,9 +98,9 @@ func TestRemoteIndexStore_UploadDownloadBleveIndex(t *testing.T) {
 	srcDir := createTestBleveIndex(t)
 	buildStart := time.Now().Add(-2 * time.Hour).UTC().Truncate(time.Second)
 	meta := IndexMeta{
-		GrafanaBuildVersion:   "11.0.0",
+		BuildVersion:   "11.0.0",
 		LatestResourceVersion: 99,
-		BuildStartTimestamp:   buildStart,
+		BuildTime:   buildStart,
 	}
 
 	indexKey, err := store.UploadIndex(ctx, ns, srcDir, meta)
@@ -110,18 +110,18 @@ func TestRemoteIndexStore_UploadDownloadBleveIndex(t *testing.T) {
 	destDir := filepath.Join(t.TempDir(), "downloaded")
 	gotMeta, err := store.DownloadIndex(ctx, ns, indexKey, destDir)
 	require.NoError(t, err)
-	assert.Equal(t, meta.GrafanaBuildVersion, gotMeta.GrafanaBuildVersion)
+	assert.Equal(t, meta.BuildVersion, gotMeta.BuildVersion)
 	assert.Equal(t, meta.LatestResourceVersion, gotMeta.LatestResourceVersion)
-	assert.True(t, gotMeta.BuildStartTimestamp.Equal(buildStart),
-		"BuildStartTimestamp should round-trip: got %s, want %s", gotMeta.BuildStartTimestamp, buildStart)
+	assert.True(t, gotMeta.BuildTime.Equal(buildStart),
+		"BuildTime should round-trip: got %s, want %s", gotMeta.BuildTime, buildStart)
 
 	// ListIndexes must surface the same value.
 	listed, err := store.ListIndexes(ctx, ns)
 	require.NoError(t, err)
 	require.Contains(t, listed, indexKey)
-	assert.True(t, listed[indexKey].BuildStartTimestamp.Equal(buildStart),
-		"BuildStartTimestamp should round-trip via ListIndexes: got %s, want %s",
-		listed[indexKey].BuildStartTimestamp, buildStart)
+	assert.True(t, listed[indexKey].BuildTime.Equal(buildStart),
+		"BuildTime should round-trip via ListIndexes: got %s, want %s",
+		listed[indexKey].BuildTime, buildStart)
 
 	// Open and query the downloaded index
 	idx, err := bleve.Open(destDir)
@@ -144,9 +144,9 @@ func TestRemoteIndexStore_UploadDownloadBleveIndex(t *testing.T) {
 }
 
 // TestRemoteIndexStore_ListIndexes_LegacyMetaWithoutBuildStartTime verifies
-// that a snapshot manifest produced before the BuildStartTimestamp field was
+// that a snapshot manifest produced before the BuildTime field was
 // introduced is still accepted by ListIndexes and surfaces a zero-value
-// BuildStartTimestamp. Readers must treat zero as "unknown".
+// BuildTime. Readers must treat zero as "unknown".
 func TestRemoteIndexStore_ListIndexes_LegacyMetaWithoutBuildStartTime(t *testing.T) {
 	ctx := context.Background()
 	bucket := memblob.OpenBucket(nil)
@@ -155,10 +155,10 @@ func TestRemoteIndexStore_ListIndexes_LegacyMetaWithoutBuildStartTime(t *testing
 	ns := newTestNsResource()
 	indexKey := ulid.Make()
 
-	// Hand-crafted manifest with no build_start_timestamp field at all,
+	// Hand-crafted manifest with no build_time field at all,
 	// mirroring the on-disk shape of legacy snapshots.
 	legacyManifest := []byte(`{
-		"grafana_build_version": "11.0.0",
+		"build_version": "11.0.0",
 		"upload_timestamp": "2024-01-01T00:00:00Z",
 		"latest_resource_version": 42,
 		"files": {"store/root.bolt": 1}
@@ -169,10 +169,10 @@ func TestRemoteIndexStore_ListIndexes_LegacyMetaWithoutBuildStartTime(t *testing
 	listed, err := store.ListIndexes(ctx, ns)
 	require.NoError(t, err)
 	require.Contains(t, listed, indexKey)
-	assert.True(t, listed[indexKey].BuildStartTimestamp.IsZero(),
-		"legacy manifest should decode to zero-valued BuildStartTimestamp, got %s",
-		listed[indexKey].BuildStartTimestamp)
-	assert.Equal(t, "11.0.0", listed[indexKey].GrafanaBuildVersion)
+	assert.True(t, listed[indexKey].BuildTime.IsZero(),
+		"legacy manifest should decode to zero-valued BuildTime, got %s",
+		listed[indexKey].BuildTime)
+	assert.Equal(t, "11.0.0", listed[indexKey].BuildVersion)
 	assert.Equal(t, int64(42), listed[indexKey].LatestResourceVersion)
 }
 
@@ -184,7 +184,7 @@ func TestRemoteIndexStore_ListAndDeleteIndexes(t *testing.T) {
 	keys := make([]ulid.ULID, 0, 3)
 	for range 3 {
 		srcDir := createTestBleveIndex(t)
-		meta := IndexMeta{GrafanaBuildVersion: "11.0.0", LatestResourceVersion: 10}
+		meta := IndexMeta{BuildVersion: "11.0.0", LatestResourceVersion: 10}
 		key, err := store.UploadIndex(ctx, ns, srcDir, meta)
 		require.NoError(t, err)
 		keys = append(keys, key)
@@ -254,7 +254,7 @@ func TestRemoteIndexStore_UploadRejectsNonRegularFiles(t *testing.T) {
 	require.NoError(t, os.WriteFile(externalFile, []byte("secret"), 0600))
 	require.NoError(t, os.Symlink(externalFile, filepath.Join(srcDir, "sneaky.zap")))
 
-	meta := IndexMeta{GrafanaBuildVersion: "11.0.0", LatestResourceVersion: 10}
+	meta := IndexMeta{BuildVersion: "11.0.0", LatestResourceVersion: 10}
 	_, err := store.UploadIndex(ctx, ns, srcDir, meta)
 	require.Error(t, err)
 	require.ErrorIs(t, err, ErrNonRegularFile)
@@ -282,7 +282,7 @@ func TestRemoteIndexStore_DownloadRejectsCorruptMetaJSON(t *testing.T) {
 	})
 
 	t.Run("empty file manifest", func(t *testing.T) {
-		meta := IndexMeta{GrafanaBuildVersion: "11.0.0", Files: map[string]int64{}}
+		meta := IndexMeta{BuildVersion: "11.0.0", Files: map[string]int64{}}
 		metaBytes, err := json.Marshal(meta)
 		require.NoError(t, err)
 		require.NoError(t, bucket.WriteAll(ctx, pfx+snapshotManifestFile, metaBytes, nil))
@@ -292,7 +292,7 @@ func TestRemoteIndexStore_DownloadRejectsCorruptMetaJSON(t *testing.T) {
 	})
 
 	t.Run("non-canonical path", func(t *testing.T) {
-		meta := IndexMeta{GrafanaBuildVersion: "11.0.0", Files: map[string]int64{"store/../store/root.bolt": 100}}
+		meta := IndexMeta{BuildVersion: "11.0.0", Files: map[string]int64{"store/../store/root.bolt": 100}}
 		metaBytes, err := json.Marshal(meta)
 		require.NoError(t, err)
 		require.NoError(t, bucket.WriteAll(ctx, pfx+snapshotManifestFile, metaBytes, nil))
@@ -302,7 +302,7 @@ func TestRemoteIndexStore_DownloadRejectsCorruptMetaJSON(t *testing.T) {
 	})
 
 	t.Run("absolute path", func(t *testing.T) {
-		meta := IndexMeta{GrafanaBuildVersion: "11.0.0", Files: map[string]int64{"/etc/passwd": 100}}
+		meta := IndexMeta{BuildVersion: "11.0.0", Files: map[string]int64{"/etc/passwd": 100}}
 		metaBytes, err := json.Marshal(meta)
 		require.NoError(t, err)
 		require.NoError(t, bucket.WriteAll(ctx, pfx+snapshotManifestFile, metaBytes, nil))
@@ -338,7 +338,7 @@ func TestRemoteIndexStore_DownloadRejectsOversizedFile(t *testing.T) {
 
 	const advertised = 10
 	meta := IndexMeta{
-		GrafanaBuildVersion: "11.0.0",
+		BuildVersion: "11.0.0",
 		Files:               map[string]int64{"store/root.bolt": advertised},
 	}
 	metaBytes, err := json.Marshal(meta)
@@ -362,7 +362,7 @@ func TestRemoteIndexStore_DownloadValidatesCompleteness(t *testing.T) {
 	ns := newTestNsResource()
 
 	srcDir := createTestBleveIndex(t)
-	meta := IndexMeta{GrafanaBuildVersion: "11.0.0", LatestResourceVersion: 10}
+	meta := IndexMeta{BuildVersion: "11.0.0", LatestResourceVersion: 10}
 	indexKey, err := store.UploadIndex(ctx, ns, srcDir, meta)
 	require.NoError(t, err)
 
@@ -389,7 +389,7 @@ func TestRemoteIndexStore_UploadRejectsEmptyDirectory(t *testing.T) {
 	ns := newTestNsResource()
 
 	emptyDir := t.TempDir()
-	meta := IndexMeta{GrafanaBuildVersion: "11.0.0", LatestResourceVersion: 10}
+	meta := IndexMeta{BuildVersion: "11.0.0", LatestResourceVersion: 10}
 	_, err := store.UploadIndex(ctx, ns, emptyDir, meta)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "no files to upload")
@@ -406,7 +406,7 @@ func TestRemoteIndexStore_UploadExcludesMetaJSON(t *testing.T) {
 	// Plant a stale snapshot manifest in the source directory
 	require.NoError(t, os.WriteFile(filepath.Join(srcDir, snapshotManifestFile), []byte(`{"stale":"data"}`), 0600))
 
-	meta := IndexMeta{GrafanaBuildVersion: "11.0.0", LatestResourceVersion: 10}
+	meta := IndexMeta{BuildVersion: "11.0.0", LatestResourceVersion: 10}
 	indexKey, err := store.UploadIndex(ctx, ns, srcDir, meta)
 	require.NoError(t, err)
 
@@ -477,7 +477,7 @@ func TestRemoteIndexStore_BucketErrors(t *testing.T) {
 		t.Helper()
 		store := newTestRemoteIndexStore(t, bucket)
 		srcDir := createTestBleveIndex(t)
-		meta := IndexMeta{GrafanaBuildVersion: "11.0.0", LatestResourceVersion: 10}
+		meta := IndexMeta{BuildVersion: "11.0.0", LatestResourceVersion: 10}
 		key, err := store.UploadIndex(ctx, ns, srcDir, meta)
 		require.NoError(t, err)
 		return key
@@ -489,7 +489,7 @@ func TestRemoteIndexStore_BucketErrors(t *testing.T) {
 		store := newTestRemoteIndexStore(t, &errorBucket{CDKBucket: real, uploadErr: fmt.Errorf("upload network timeout")})
 
 		_, err := store.UploadIndex(ctx, ns, createTestBleveIndex(t),
-			IndexMeta{GrafanaBuildVersion: "11.0.0", LatestResourceVersion: 10})
+			IndexMeta{BuildVersion: "11.0.0", LatestResourceVersion: 10})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "upload network timeout")
 	})
@@ -500,7 +500,7 @@ func TestRemoteIndexStore_BucketErrors(t *testing.T) {
 		store := newTestRemoteIndexStore(t, &errorBucket{CDKBucket: real, writeAllErr: fmt.Errorf("write quota exceeded")})
 
 		_, err := store.UploadIndex(ctx, ns, createTestBleveIndex(t),
-			IndexMeta{GrafanaBuildVersion: "11.0.0", LatestResourceVersion: 10})
+			IndexMeta{BuildVersion: "11.0.0", LatestResourceVersion: 10})
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "write quota exceeded")
 	})
@@ -578,7 +578,7 @@ func TestRemoteIndexStore_CleanupIncompleteUploads(t *testing.T) {
 
 	// Upload a complete index (has a snapshot manifest)
 	srcDir := createTestBleveIndex(t)
-	meta := IndexMeta{GrafanaBuildVersion: "11.0.0", LatestResourceVersion: 10}
+	meta := IndexMeta{BuildVersion: "11.0.0", LatestResourceVersion: 10}
 	completeKey, err := store.UploadIndex(ctx, ns, srcDir, meta)
 	require.NoError(t, err)
 
@@ -614,7 +614,7 @@ func TestRemoteIndexStore_CleanupIncompleteUploads_NoneFound(t *testing.T) {
 
 	// Upload a complete index
 	srcDir := createTestBleveIndex(t)
-	meta := IndexMeta{GrafanaBuildVersion: "11.0.0", LatestResourceVersion: 10}
+	meta := IndexMeta{BuildVersion: "11.0.0", LatestResourceVersion: 10}
 	_, err := store.UploadIndex(ctx, ns, srcDir, meta)
 	require.NoError(t, err)
 
@@ -633,7 +633,7 @@ func TestRemoteIndexStore_CleanupIncompleteUploads_CorruptManifest(t *testing.T)
 
 	// Upload a valid complete index
 	srcDir := createTestBleveIndex(t)
-	meta := IndexMeta{GrafanaBuildVersion: "11.0.0", LatestResourceVersion: 10}
+	meta := IndexMeta{BuildVersion: "11.0.0", LatestResourceVersion: 10}
 	completeKey, err := store.UploadIndex(ctx, ns, srcDir, meta)
 	require.NoError(t, err)
 
@@ -652,7 +652,7 @@ func TestRemoteIndexStore_CleanupIncompleteUploads_CorruptManifest(t *testing.T)
 		key := ulid.Make()
 		pfx := indexPrefix(ns, key.String())
 		require.NoError(t, bucket.WriteAll(ctx, pfx+"store/root.bolt", []byte("data"), nil))
-		emptyMeta, _ := json.Marshal(IndexMeta{GrafanaBuildVersion: "11.0.0", Files: map[string]int64{}})
+		emptyMeta, _ := json.Marshal(IndexMeta{BuildVersion: "11.0.0", Files: map[string]int64{}})
 		require.NoError(t, bucket.WriteAll(ctx, pfx+snapshotManifestFile, emptyMeta, nil))
 
 		cleaned, err := store.CleanupIncompleteUploads(ctx, ns, 0)
@@ -792,7 +792,7 @@ func TestRemoteIndexStore_ListNamespaces(t *testing.T) {
 	for _, ns := range []string{"stack-1", "stack-2", "stack-3"} {
 		nsRes := resource.NamespacedResource{Namespace: ns, Group: "dashboard.grafana.app", Resource: "dashboards"}
 		_, err := store.UploadIndex(ctx, nsRes, createTestBleveIndex(t),
-			IndexMeta{GrafanaBuildVersion: "11.0.0", LatestResourceVersion: 1})
+			IndexMeta{BuildVersion: "11.0.0", LatestResourceVersion: 1})
 		require.NoError(t, err)
 	}
 
@@ -812,7 +812,7 @@ func TestRemoteIndexStore_ListNamespaces_IgnoresStrayObjects(t *testing.T) {
 
 	nsRes := resource.NamespacedResource{Namespace: "stack-1", Group: "dashboard.grafana.app", Resource: "dashboards"}
 	_, err := store.UploadIndex(ctx, nsRes, createTestBleveIndex(t),
-		IndexMeta{GrafanaBuildVersion: "11.0.0", LatestResourceVersion: 1})
+		IndexMeta{BuildVersion: "11.0.0", LatestResourceVersion: 1})
 	require.NoError(t, err)
 
 	got, err := store.ListNamespaces(ctx)
@@ -833,7 +833,7 @@ func TestRemoteIndexStore_ListNamespaceIndexes(t *testing.T) {
 	}
 	for _, r := range resources {
 		_, err := store.UploadIndex(ctx, r, createTestBleveIndex(t),
-			IndexMeta{GrafanaBuildVersion: "11.0.0", LatestResourceVersion: 1})
+			IndexMeta{BuildVersion: "11.0.0", LatestResourceVersion: 1})
 		require.NoError(t, err)
 	}
 
@@ -870,7 +870,7 @@ func TestRemoteIndexStore_ListIndexes_SkipsLockSibling(t *testing.T) {
 	ns := newTestNsResource()
 
 	indexKey, err := store.UploadIndex(ctx, ns, createTestBleveIndex(t),
-		IndexMeta{GrafanaBuildVersion: "11.0.0", LatestResourceVersion: 1})
+		IndexMeta{BuildVersion: "11.0.0", LatestResourceVersion: 1})
 	require.NoError(t, err)
 
 	// Plant a `<resource-group>/locks/build` object directly in the data bucket.
@@ -892,7 +892,7 @@ func TestRemoteIndexStore_ListNamespaceIndexes_SkipsLockSibling(t *testing.T) {
 
 	nsRes := resource.NamespacedResource{Namespace: "stack-1", Group: "dashboard.grafana.app", Resource: "dashboards"}
 	_, err := store.UploadIndex(ctx, nsRes, createTestBleveIndex(t),
-		IndexMeta{GrafanaBuildVersion: "11.0.0", LatestResourceVersion: 1})
+		IndexMeta{BuildVersion: "11.0.0", LatestResourceVersion: 1})
 	require.NoError(t, err)
 
 	// Plant a `stack-1/locks/...` object directly in the data bucket. In production

--- a/pkg/storage/unified/search/remote_index_store_test.go
+++ b/pkg/storage/unified/search/remote_index_store_test.go
@@ -98,9 +98,9 @@ func TestRemoteIndexStore_UploadDownloadBleveIndex(t *testing.T) {
 	srcDir := createTestBleveIndex(t)
 	buildStart := time.Now().Add(-2 * time.Hour).UTC().Truncate(time.Second)
 	meta := IndexMeta{
-		BuildVersion:   "11.0.0",
+		BuildVersion:          "11.0.0",
 		LatestResourceVersion: 99,
-		BuildTime:   buildStart,
+		BuildTime:             buildStart,
 	}
 
 	indexKey, err := store.UploadIndex(ctx, ns, srcDir, meta)
@@ -339,7 +339,7 @@ func TestRemoteIndexStore_DownloadRejectsOversizedFile(t *testing.T) {
 	const advertised = 10
 	meta := IndexMeta{
 		BuildVersion: "11.0.0",
-		Files:               map[string]int64{"store/root.bolt": advertised},
+		Files:        map[string]int64{"store/root.bolt": advertised},
 	}
 	metaBytes, err := json.Marshal(meta)
 	require.NoError(t, err)


### PR DESCRIPTION
Adds a backend-agnostic probe that walks namespace snapshots newest-first and returns the first one whose `BuildVersion` matches the running version and whose `BuildTime` falls within `[now-maxAge, now]`. Mirrors the existing `findFreshSnapshotByUploadTime`, but uses build-start time so periodic re-uploads of long-lived indexes are correctly rejected when their underlying data ages past `maxAge`, even though their ULID (= upload time) is recent.

First piece of [search-and-storage-team#769](https://github.com/grafana/search-and-storage-team/issues/769); no call sites yet, wiring into `BuildIndex` follows in a separate PR.

### Why two probe variants

`findFreshSnapshotByUploadTime` answers "did anyone upload recently?" — a cadence question. `findFreshSnapshotByBuildStart` answers "is the underlying data fresh enough to skip a rebuild?" — a data-freshness question, where upload time is misleading (long builds and periodic re-uploads pull it in opposite directions).

### IndexMeta field renames

Renamed two fields to match `resource.IndexBuildInfo` already used elsewhere in the package:

- `BuildStartTimestamp` → `BuildTime` (json: `build_time`)
- `GrafanaBuildVersion` → `BuildVersion` (json: `build_version`)

Introduced recently in #124035 and not deployed yet, so no compat shim needed.

### Tests

Probe tests are table-driven and share a small `runProbeCases` helper, so the upload-time and build-start variants stay structurally parallel. The build-start table additionally covers behaviours unique to that probe: rejecting recent re-uploads of old builds, and rejecting manifests with zero-value `BuildTime`.

### References

- [search-and-storage-team#769](https://github.com/grafana/search-and-storage-team/issues/769), under epic [#715](https://github.com/grafana/search-and-storage-team/issues/715)
- Predecessor: #124051 (`findFreshSnapshotByUploadTime`)
- `BuildTime` field origin: #124035
- `ListIndexKeys` / `GetIndexMeta`: #124039
