### PR TITLE
feat(plugins): add extension point to QueryErrorAlert

### DIFF
--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -3,6 +3,7 @@ import type * as React from 'react';
 import { type DataQuery, type DataSourceJsonData } from '@grafana/schema';
 
 import { type ScopedVars } from './ScopedVars';
+import { type DataQueryError } from './datasource';
 import { type DataSourcePluginMeta, type DataSourceSettings } from './datasource';
 import { type IconName } from './icon';
 import { type PanelData } from './panel';
@@ -237,6 +238,7 @@ export enum PluginExtensionPoints {
   AdvisorCompletedChecks = 'grafana/advisor/completed-checks/v1',
   AdvisorCreateChecks = 'grafana/advisor/create-checks/v1',
   AdvisorRetryCheck = 'grafana/advisor/retry-check/v1',
+  QueryEditorErrorAction = 'grafana/query-editor-error/action/v1',
 }
 
 // Don't use directly in a plugin!
@@ -277,6 +279,11 @@ export type CentralAlertHistorySceneV1Props = {
   defaultTimeRange?: { from: string; to: string };
   hideFilters?: boolean;
   hideAlertRuleColumn?: boolean;
+};
+
+export type PluginExtensionQueryEditorErrorActionContext = {
+  error: DataQueryError;
+  query?: DataQuery;
 };
 
 export type PluginExtensionQueryEditorRowAdaptiveTelemetryV1Context = {

--- a/public/app/features/query/components/QueryErrorAlert.tsx
+++ b/public/app/features/query/components/QueryErrorAlert.tsx
@@ -7,8 +7,9 @@ import {
   useAssistant,
   useProvidePageContext,
 } from '@grafana/assistant';
-import { type DataQueryError, type GrafanaTheme2 } from '@grafana/data';
+import { type DataQueryError, type GrafanaTheme2, PluginExtensionPoints } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
+import { renderLimitedComponents, usePluginComponents } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
 import { Icon, useStyles2 } from '@grafana/ui';
 
@@ -54,8 +55,30 @@ export function QueryErrorAlert({ error, query }: Props) {
           />
         </div>
       )}
+      <QueryErrorActions error={error} query={query} />
     </div>
   );
+}
+
+function QueryErrorActions({ error, query }: Props) {
+  try {
+    const { isLoading, components } = usePluginComponents({
+      extensionPointId: PluginExtensionPoints.QueryEditorErrorAction,
+    });
+
+    if (isLoading || !components.length) {
+      return null;
+    }
+
+    return renderLimitedComponents({
+      props: { error, query },
+      components,
+      limit: 1,
+      pluginId: /grafana-adaptive.*/,
+    });
+  } catch {
+    return null;
+  }
 }
 
 function buildAssistantContext(error: DataQueryError, message: string, query?: DataQuery) {

--- a/public/app/features/query/components/QueryErrorAlert.tsx
+++ b/public/app/features/query/components/QueryErrorAlert.tsx
@@ -29,32 +29,34 @@ export function QueryErrorAlert({ error, query }: Props) {
 
   return (
     <div className={styles.wrapper}>
-      <div className={styles.icon}>
-        <Icon name="exclamation-triangle" />
-      </div>
-      <div className={styles.message}>
-        {message}
-        {error.traceId != null && (
-          <>
-            <br />{' '}
-            <span>
-              <Trans i18nKey="query.query-error-alert.trace-id" values={{ traceId: error.traceId }}>
-                (Trace ID: {'{{traceId}}'})
-              </Trans>
-            </span>
-          </>
+      <div className={styles.row}>
+        <div className={styles.icon}>
+          <Icon name="exclamation-triangle" />
+        </div>
+        <div className={styles.message}>
+          {message}
+          {error.traceId != null && (
+            <>
+              <br />{' '}
+              <span>
+                <Trans i18nKey="query.query-error-alert.trace-id" values={{ traceId: error.traceId }}>
+                  (Trace ID: {'{{traceId}}'})
+                </Trans>
+              </span>
+            </>
+          )}
+        </div>
+        {isAvailable && (
+          <div className={styles.assistantButton}>
+            <OpenAssistantButton
+              origin="grafana/query-editor-error"
+              prompt={`Help me analyze and fix the following ${error.type ? `\`${error.type}\`` : ''} query error: \`\`\`${message}\`\`\``}
+              title={t('query.query-error-alert.fix-with-assistant', 'Fix with Assistant')}
+              size="sm"
+            />
+          </div>
         )}
       </div>
-      {isAvailable && (
-        <div className={styles.assistantButton}>
-          <OpenAssistantButton
-            origin="grafana/query-editor-error"
-            prompt={`Help me analyze and fix the following ${error.type ? `\`${error.type}\`` : ''} query error: \`\`\`${message}\`\`\``}
-            title={t('query.query-error-alert.fix-with-assistant', 'Fix with Assistant')}
-            size="sm"
-          />
-        </div>
-      )}
       <QueryErrorActions error={error} query={query} />
     </div>
   );
@@ -116,6 +118,8 @@ const getStyles = (theme: GrafanaTheme2) => ({
   wrapper: css({
     marginTop: theme.spacing(0.5),
     background: theme.colors.background.secondary,
+  }),
+  row: css({
     display: 'flex',
     alignItems: 'center',
   }),


### PR DESCRIPTION
Part of a three-PR feature to show a contextual deeplink to the Adaptive Metrics rule management page when an aggregation error occurs in Explore.

**Related PRs:**
- Backend: grafana/backend-enterprise#12384
- App plugin: grafana/grafana-adaptive-metrics-app (link to follow)

## Summary
- Adds `QueryEditorErrorAction = 'grafana/query-editor-error/action/v1'` to `PluginExtensionPoints`
- Adds `PluginExtensionQueryEditorErrorActionContext` type with `error` and `query` fields
- Renders a `QueryErrorActions` component in `QueryErrorAlert` that calls `usePluginComponents` at the new extension point — same pattern as `QueryEditorRowAdaptiveTelemetryV1`

## Test plan
- [ ] Verify `QueryErrorAlert` still renders correctly with no plugins registered at the extension point
- [ ] Verify a plugin component registered at `grafana/query-editor-error/action/v1` appears in the error banner