### PR TITLE
IAM: Reject permission changes for external team members

### DIFF
--- a/pkg/services/accesscontrol/resourcepermissions/api.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api.go
@@ -376,6 +376,9 @@ func (a *api) setUserPermission(c *contextmodel.ReqContext) response.Response {
 		err := a.setUserPermissionInTeamMembers(c, c.Namespace, resourceID, userID, cmd.Permission)
 		if err != nil {
 			span.RecordError(err)
+			if errors.Is(err, ErrExternalTeamMember) {
+				return response.Err(err)
+			}
 			if errors.Is(err, ErrRestConfigNotAvailable) {
 				a.logger.Debug("k8s API not available for team permissions via team members, continuing with legacy", "error", err, "resourceID", resourceID)
 			} else {

--- a/pkg/services/accesscontrol/resourcepermissions/api_adapter.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api_adapter.go
@@ -23,7 +23,6 @@ import (
 	folderv1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
 	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/api/dtos"
-	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
@@ -759,9 +758,9 @@ func (a *api) setTeamMember(c *contextmodel.ReqContext, dynamicClient dynamic.In
 		// dual-write caller from proceeding with the legacy SQL write, which would
 		// otherwise cause k8s and SQL to diverge until the next reconciliation.
 		if idx >= 0 && t.Spec.Members[idx].External {
-			return ErrExternalTeamMember.Build(errutil.TemplateData{
-				Error: fmt.Errorf("user %q is externally-synced", userDetails.UID),
-			})
+			return ErrExternalTeamMember.Build(ErrExternalTeamMemberData(
+				fmt.Errorf("user %q is externally-synced", userDetails.UID),
+			))
 		}
 
 		switch {

--- a/pkg/services/accesscontrol/resourcepermissions/api_adapter.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api_adapter.go
@@ -758,9 +758,7 @@ func (a *api) setTeamMember(c *contextmodel.ReqContext, dynamicClient dynamic.In
 		// dual-write caller from proceeding with the legacy SQL write, which would
 		// otherwise cause k8s and SQL to diverge until the next reconciliation.
 		if idx >= 0 && t.Spec.Members[idx].External {
-			return ErrExternalTeamMember.Build(ErrExternalTeamMemberData(
-				fmt.Errorf("user %q is externally-synced", userDetails.UID),
-			))
+			return ErrExternalTeamMember.Errorf("user %q is externally-synced", userDetails.UID)
 		}
 
 		switch {

--- a/pkg/services/accesscontrol/resourcepermissions/api_adapter.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api_adapter.go
@@ -23,6 +23,7 @@ import (
 	folderv1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
 	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/api/dtos"
+	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
@@ -753,8 +754,14 @@ func (a *api) setTeamMember(c *contextmodel.ReqContext, dynamicClient dynamic.In
 			return m.Kind == subjectKindUser && m.Name == userDetails.UID
 		})
 
+		// External members are owned by team-sync and must not be mutated through
+		// this path. Returning an error (rather than a silent no-op) prevents the
+		// dual-write caller from proceeding with the legacy SQL write, which would
+		// otherwise cause k8s and SQL to diverge until the next reconciliation.
 		if idx >= 0 && t.Spec.Members[idx].External {
-			return nil
+			return ErrExternalTeamMember.Build(errutil.TemplateData{
+				Error: fmt.Errorf("user %q is externally-synced", userDetails.UID),
+			})
 		}
 
 		switch {

--- a/pkg/services/accesscontrol/resourcepermissions/api_adapter_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api_adapter_test.go
@@ -1466,7 +1466,7 @@ func TestSetTeamMember(t *testing.T) {
 			},
 		},
 		{
-			name:       "does not update external members",
+			name:       "rejects updates to external members",
 			permission: "Admin",
 			userID:     1,
 			userSvc: func() *usertest.MockService {
@@ -1481,12 +1481,13 @@ func TestSetTeamMember(t *testing.T) {
 					},
 				}
 			},
+			expectedErrMsg: "externally-synced",
 			validateCalls: func(t *testing.T, _, updateCalls int) {
 				assert.Equal(t, 0, updateCalls, "should not Update when target member is External")
 			},
 		},
 		{
-			name:       "does not delete external members",
+			name:       "rejects deletes of external members",
 			permission: "",
 			userID:     1,
 			userSvc: func() *usertest.MockService {
@@ -1501,6 +1502,7 @@ func TestSetTeamMember(t *testing.T) {
 					},
 				}
 			},
+			expectedErrMsg: "externally-synced",
 			validateCalls: func(t *testing.T, _, updateCalls int) {
 				assert.Equal(t, 0, updateCalls, "should not Update when deleting an External member")
 			},

--- a/pkg/services/accesscontrol/resourcepermissions/error.go
+++ b/pkg/services/accesscontrol/resourcepermissions/error.go
@@ -5,12 +5,11 @@ import (
 )
 
 const (
-	invalidPermissionMessage  = `Permission [{{ .Public.permission }}] is invalid for this resource type`
-	invalidAssignmentMessage  = `Assignment [{{ .Public.assignment }}] is invalid for this resource type`
-	invalidParamMessage       = `Param [{{ .Public.param }}] is invalid`
-	invalidRequestBody        = `Request body is invalid: {{ .Public.reason }}`
-	invalidResourceIDMessage  = `Resource ID [{{ .Public.resourceID }}] is not valid: wildcard "*" is not allowed`
-	externalTeamMemberMessage = `Cannot modify permission of externally-synced team member`
+	invalidPermissionMessage = `Permission [{{ .Public.permission }}] is invalid for this resource type`
+	invalidAssignmentMessage = `Assignment [{{ .Public.assignment }}] is invalid for this resource type`
+	invalidParamMessage      = `Param [{{ .Public.param }}] is invalid`
+	invalidRequestBody       = `Request body is invalid: {{ .Public.reason }}`
+	invalidResourceIDMessage = `Resource ID [{{ .Public.resourceID }}] is not valid: wildcard "*" is not allowed`
 )
 
 var (
@@ -24,8 +23,8 @@ var (
 				MustTemplate(invalidAssignmentMessage, errutil.WithPublic(invalidAssignmentMessage))
 	ErrInvalidResourceID = errutil.BadRequest("resourcePermissions.invalidResourceID").
 				MustTemplate(invalidResourceIDMessage, errutil.WithPublic(invalidResourceIDMessage))
-	ErrExternalTeamMember = errutil.BadRequest("resourcePermissions.externalTeamMember").
-				MustTemplate(externalTeamMemberMessage, errutil.WithPublic(externalTeamMemberMessage))
+	ErrExternalTeamMember = errutil.BadRequest("resourcePermissions.externalTeamMember",
+		errutil.WithPublicMessage("Cannot modify permission of externally-synced team member"))
 )
 
 func ErrInvalidParamData(param string, err error) errutil.TemplateData {
@@ -67,8 +66,4 @@ func ErrInvalidResourceIDData(resourceID string) errutil.TemplateData {
 			"resourceID": resourceID,
 		},
 	}
-}
-
-func ErrExternalTeamMemberData(err error) errutil.TemplateData {
-	return errutil.TemplateData{Error: err}
 }

--- a/pkg/services/accesscontrol/resourcepermissions/error.go
+++ b/pkg/services/accesscontrol/resourcepermissions/error.go
@@ -5,11 +5,12 @@ import (
 )
 
 const (
-	invalidPermissionMessage = `Permission [{{ .Public.permission }}] is invalid for this resource type`
-	invalidAssignmentMessage = `Assignment [{{ .Public.assignment }}] is invalid for this resource type`
-	invalidParamMessage      = `Param [{{ .Public.param }}] is invalid`
-	invalidRequestBody       = `Request body is invalid: {{ .Public.reason }}`
-	invalidResourceIDMessage = `Resource ID [{{ .Public.resourceID }}] is not valid: wildcard "*" is not allowed`
+	invalidPermissionMessage  = `Permission [{{ .Public.permission }}] is invalid for this resource type`
+	invalidAssignmentMessage  = `Assignment [{{ .Public.assignment }}] is invalid for this resource type`
+	invalidParamMessage       = `Param [{{ .Public.param }}] is invalid`
+	invalidRequestBody        = `Request body is invalid: {{ .Public.reason }}`
+	invalidResourceIDMessage  = `Resource ID [{{ .Public.resourceID }}] is not valid: wildcard "*" is not allowed`
+	externalTeamMemberMessage = `Cannot modify permission of externally-synced team member`
 )
 
 var (
@@ -23,6 +24,8 @@ var (
 				MustTemplate(invalidAssignmentMessage, errutil.WithPublic(invalidAssignmentMessage))
 	ErrInvalidResourceID = errutil.BadRequest("resourcePermissions.invalidResourceID").
 				MustTemplate(invalidResourceIDMessage, errutil.WithPublic(invalidResourceIDMessage))
+	ErrExternalTeamMember = errutil.BadRequest("resourcePermissions.externalTeamMember").
+				MustTemplate(externalTeamMemberMessage, errutil.WithPublic(externalTeamMemberMessage))
 )
 
 func ErrInvalidParamData(param string, err error) errutil.TemplateData {

--- a/pkg/services/accesscontrol/resourcepermissions/error.go
+++ b/pkg/services/accesscontrol/resourcepermissions/error.go
@@ -68,3 +68,7 @@ func ErrInvalidResourceIDData(resourceID string) errutil.TemplateData {
 		},
 	}
 }
+
+func ErrExternalTeamMemberData(err error) errutil.TemplateData {
+	return errutil.TemplateData{Error: err}
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Fixes https://github.com/grafana/grafana/pull/123914/changes#r3183661563

Return a 400 from the k8s path instead, and short-circuit the dual-write caller before the legacy SQL write so both stores stay consistent. This mirrors the existing rejection for provisioned teams.

**Why do we need this feature?**
The k8s team-members write path silently no-ops when the target member is `External: true`, but the dual-write fell through to the legacy SQL write, which has no such guard. Callers got 200 OK while k8s and SQL diverged until the next team-sync reconciliation.
