### PR TITLE
annotations: horizontal sharding for postgres store

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1800,13 +1800,16 @@ grpc_tls_ca_file =
 # Skip TLS verification (insecure, for testing only, only used when grpc_use_tls = true)
 grpc_tls_skip_verify = false
 
-# PostgreSQL connection string (only used when store_backend = "postgres")
-postgres_connection_string =
+# Comma-separated PostgreSQL connection strings, one per data shard (only used when store_backend = "postgres")
+postgres_connection_strings =
 
-# Maximum number of connections in the Postgres pool (only used when store_backend = "postgres")
+# PostgreSQL connection string for the metadata database (only used when store_backend = "postgres")
+postgres_metadata_connection_string =
+
+# Maximum number of connections per shard in the Postgres pool (only used when store_backend = "postgres")
 postgres_max_connections = 10
 
-# Maximum number of idle connections in the Postgres pool (only used when store_backend = "postgres")
+# Maximum number of idle connections per shard in the Postgres pool (only used when store_backend = "postgres")
 postgres_max_idle_conns = 5
 
 # Maximum lifetime of a connection in the Postgres pool (only used when store_backend = "postgres")

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -1729,13 +1729,16 @@ default_datasource_uid =
 # Skip TLS verification (insecure, for testing only, only used when grpc_use_tls = true)
 ;grpc_tls_skip_verify = false
 
-# PostgreSQL connection string (only used when store_backend = "postgres")
-;postgres_connection_string =
+# Comma-separated PostgreSQL connection strings, one per data shard (only used when store_backend = "postgres")
+;postgres_connection_strings =
 
-# Maximum number of connections in the Postgres pool (only used when store_backend = "postgres")
+# PostgreSQL connection string for the metadata database (only used when store_backend = "postgres")
+;postgres_metadata_connection_string =
+
+# Maximum number of connections per shard in the Postgres pool (only used when store_backend = "postgres")
 ;postgres_max_connections = 10
 
-# Maximum number of idle connections in the Postgres pool (only used when store_backend = "postgres")
+# Maximum number of idle connections per shard in the Postgres pool (only used when store_backend = "postgres")
 ;postgres_max_idle_conns = 5
 
 # Maximum lifetime of a connection in the Postgres pool (only used when store_backend = "postgres")

--- a/pkg/registry/apps/annotation/config.go
+++ b/pkg/registry/apps/annotation/config.go
@@ -31,12 +31,13 @@ type Config struct {
 	GRPCTLSSkipVerify bool
 
 	// Postgres store configuration
-	PostgresConnectionString string
-	PostgresMaxConnections   int
-	PostgresMaxIdleConns     int
-	PostgresConnMaxLifetime  time.Duration
-	PostgresTagCacheTTL      time.Duration
-	PostgresTagCacheSize     int
+	PostgresConnStrings        []string
+	PostgresMetadataConnString string
+	PostgresMaxConnections     int
+	PostgresMaxIdleConns       int
+	PostgresConnMaxLifetime    time.Duration
+	PostgresTagCacheTTL        time.Duration
+	PostgresTagCacheSize       int
 
 	// CleanupSettings configures annotation pruning for the SQL backend's LifecycleManager.
 	// Zero value (all limits unset) disables cleanup. Not used by memory or gRPC backends.
@@ -57,12 +58,13 @@ func (c *Config) AddFlags(flags *pflag.FlagSet) {
 	flags.BoolVar(&c.GRPCTLSSkipVerify, "annotation.grpc-tls-skip-verify", false, "Skip TLS verification for the annotation gRPC connection (insecure)")
 
 	// Postgres flags
-	flags.StringVar(&c.PostgresConnectionString, "annotation.postgres-connection-string", "", "PostgreSQL connection string for annotation store")
-	flags.IntVar(&c.PostgresMaxConnections, "annotation.postgres-max-connections", defaultMaxConnections, "Maximum number of connections in the Postgres pool")
-	flags.IntVar(&c.PostgresMaxIdleConns, "annotation.postgres-max-idle-conns", defaultMaxIdleConns, "Maximum number of idle connections in the Postgres pool")
+	flags.StringSliceVar(&c.PostgresConnStrings, "annotation.postgres-connection-strings", nil, "Comma-separated PostgreSQL connection strings, one per shard (ordered by shard index)")
+	flags.StringVar(&c.PostgresMetadataConnString, "annotation.postgres-metadata-connection-string", "", "PostgreSQL connection string for the metadata database")
+	flags.IntVar(&c.PostgresMaxConnections, "annotation.postgres-max-connections", defaultMaxConnections, "Maximum number of connections per shard in the Postgres pool")
+	flags.IntVar(&c.PostgresMaxIdleConns, "annotation.postgres-max-idle-conns", defaultMaxIdleConns, "Maximum number of idle connections per shard in the Postgres pool")
 	flags.DurationVar(&c.PostgresConnMaxLifetime, "annotation.postgres-conn-max-lifetime", defaultConnMaxLifetime, "Maximum lifetime of a connection in the Postgres pool")
-	flags.DurationVar(&c.PostgresTagCacheTTL, "annotation.postgres-tag-cache-ttl", defaultTagCacheTTL, "TTL for tag query cache")
-	flags.IntVar(&c.PostgresTagCacheSize, "annotation.postgres-tag-cache-size", defaultTagCacheSize, "Size of the tag query cache")
+	flags.DurationVar(&c.PostgresTagCacheTTL, "annotation.postgres-tag-cache-ttl", defaultTagCacheTTL, "TTL for tag query cache per shard")
+	flags.IntVar(&c.PostgresTagCacheSize, "annotation.postgres-tag-cache-size", defaultTagCacheSize, "Size of the tag query cache per shard")
 }
 
 func newConfigFromSettings(cfg *setting.Cfg) Config {
@@ -80,12 +82,13 @@ func newConfigFromSettings(cfg *setting.Cfg) Config {
 		GRPCTLSCAFile:     cfg.AnnotationAppPlatform.GRPCTLSCAFile,
 		GRPCTLSSkipVerify: cfg.AnnotationAppPlatform.GRPCTLSSkipVerify,
 
-		PostgresConnectionString: cfg.AnnotationAppPlatform.PostgresConnectionString,
-		PostgresMaxConnections:   cfg.AnnotationAppPlatform.PostgresMaxConnections,
-		PostgresMaxIdleConns:     cfg.AnnotationAppPlatform.PostgresMaxIdleConns,
-		PostgresConnMaxLifetime:  cfg.AnnotationAppPlatform.PostgresConnMaxLifetime,
-		PostgresTagCacheTTL:      cfg.AnnotationAppPlatform.PostgresTagCacheTTL,
-		PostgresTagCacheSize:     cfg.AnnotationAppPlatform.PostgresTagCacheSize,
+		PostgresConnStrings:        cfg.AnnotationAppPlatform.PostgresConnStrings,
+		PostgresMetadataConnString: cfg.AnnotationAppPlatform.PostgresMetadataConnString,
+		PostgresMaxConnections:     cfg.AnnotationAppPlatform.PostgresMaxConnections,
+		PostgresMaxIdleConns:       cfg.AnnotationAppPlatform.PostgresMaxIdleConns,
+		PostgresConnMaxLifetime:    cfg.AnnotationAppPlatform.PostgresConnMaxLifetime,
+		PostgresTagCacheTTL:        cfg.AnnotationAppPlatform.PostgresTagCacheTTL,
+		PostgresTagCacheSize:       cfg.AnnotationAppPlatform.PostgresTagCacheSize,
 
 		CleanupSettings: annotations.CleanupSettings{
 			Alerting:  cfg.AlertingAnnotationCleanupSetting,

--- a/pkg/registry/apps/annotation/metadata_migrations/00001_shard_assignments.sql
+++ b/pkg/registry/apps/annotation/metadata_migrations/00001_shard_assignments.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+-- Stores the shard index assigned to each namespace (tenant).
+CREATE TABLE IF NOT EXISTS shard_assignments (
+    namespace VARCHAR(255) PRIMARY KEY,
+    shard_index INT NOT NULL,
+    created_at BIGINT NOT NULL
+);
+
+-- +goose Down
+DROP TABLE IF EXISTS shard_assignments;

--- a/pkg/registry/apps/annotation/postgres_schema.go
+++ b/pkg/registry/apps/annotation/postgres_schema.go
@@ -17,6 +17,9 @@ import (
 //go:embed migrations/*.sql
 var embedMigrations embed.FS
 
+//go:embed metadata_migrations/*.sql
+var embedMetadataMigrations embed.FS
+
 // PartitionInfo contains metadata about a partition
 type PartitionInfo struct {
 	Name       string
@@ -161,9 +164,17 @@ func listPartitions(ctx context.Context, pool *pgxpool.Pool) ([]PartitionInfo, e
 	return partitions, nil
 }
 
-// runMigrations executes database migrations using goose
+// runMigrations executes data shard migrations using goose
 func runMigrations(ctx context.Context, pool *pgxpool.Pool, logger log.Logger) error {
-	// goose operates on *sql.DB, so we need to create one from our pgxpool
+	return runMigrationsFrom(ctx, pool, logger, embedMigrations, "migrations")
+}
+
+// runMetadataMigrations executes metadata database migrations using goose
+func runMetadataMigrations(ctx context.Context, pool *pgxpool.Pool, logger log.Logger) error {
+	return runMigrationsFrom(ctx, pool, logger, embedMetadataMigrations, "metadata_migrations")
+}
+
+func runMigrationsFrom(ctx context.Context, pool *pgxpool.Pool, logger log.Logger, fs embed.FS, dir string) error {
 	db := stdlib.OpenDBFromPool(pool)
 	defer func() {
 		if err := db.Close(); err != nil {
@@ -172,14 +183,14 @@ func runMigrations(ctx context.Context, pool *pgxpool.Pool, logger log.Logger) e
 	}()
 
 	// Configure goose to use embedded migrations
-	goose.SetBaseFS(embedMigrations)
+	goose.SetBaseFS(fs)
 
 	if err := goose.SetDialect("postgres"); err != nil {
 		return fmt.Errorf("failed to set goose dialect: %w", err)
 	}
 
 	// Run all pending migrations
-	if err := goose.UpContext(ctx, db, "migrations"); err != nil {
+	if err := goose.UpContext(ctx, db, dir); err != nil {
 		return fmt.Errorf("failed to run migrations: %w", err)
 	}
 

--- a/pkg/registry/apps/annotation/register.go
+++ b/pkg/registry/apps/annotation/register.go
@@ -181,21 +181,22 @@ func loadTLSConfig(cfg Config) (*tls.Config, error) {
 }
 
 func newPostgresStore(ctx context.Context, cfg Config) (Store, error) {
-	if cfg.PostgresConnectionString == "" {
-		return nil, fmt.Errorf("postgres connection string is required")
+	if len(cfg.PostgresConnStrings) == 0 {
+		return nil, fmt.Errorf("at least one postgres connection string is required")
 	}
 
-	pgCfg := PostgreSQLStoreConfig{
-		ConnectionString: cfg.PostgresConnectionString,
-		MaxConnections:   cfg.PostgresMaxConnections,
-		MaxIdleConns:     cfg.PostgresMaxIdleConns,
-		ConnMaxLifetime:  cfg.PostgresConnMaxLifetime,
-		RetentionTTL:     cfg.RetentionTTL,
-		TagCacheTTL:      cfg.PostgresTagCacheTTL,
-		TagCacheSize:     cfg.PostgresTagCacheSize,
+	shardCfg := ShardedStoreConfig{
+		ShardConnectionStrings:   cfg.PostgresConnStrings,
+		MetadataConnectionString: cfg.PostgresMetadataConnString,
+		MaxConnections:           cfg.PostgresMaxConnections,
+		MaxIdleConns:             cfg.PostgresMaxIdleConns,
+		ConnMaxLifetime:          cfg.PostgresConnMaxLifetime,
+		RetentionTTL:             cfg.RetentionTTL,
+		TagCacheTTL:              cfg.PostgresTagCacheTTL,
+		TagCacheSize:             cfg.PostgresTagCacheSize,
 	}
 
-	return NewPostgreSQLStore(ctx, pgCfg)
+	return NewShardedPostgresStore(ctx, shardCfg)
 }
 
 // GetLegacyStorage returns the K8s REST storage implementation for the annotation resource.

--- a/pkg/registry/apps/annotation/shard_assignment.go
+++ b/pkg/registry/apps/annotation/shard_assignment.go
@@ -1,0 +1,166 @@
+package annotation
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"sync"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+)
+
+// shardAssignmentResolver determines which shard a namespace belongs to.
+//
+// Assignments are persisted in a shard_assignments table in a dedicated metadata
+// database. The resolution order is:
+//
+//  1. In-memory cache (populated from the database at startup)
+//  2. Database lookup in the metadata database
+//  3. Least-loaded assignment for new namespaces (written to database and cached)
+type shardAssignmentResolver struct {
+	pool       *pgxpool.Pool
+	shardCount int
+	mu         sync.RWMutex
+	cache      map[string]int
+	logger     log.Logger
+}
+
+func newShardAssignmentResolver(pool *pgxpool.Pool, shardCount int, logger log.Logger) *shardAssignmentResolver {
+	return &shardAssignmentResolver{
+		pool:       pool,
+		shardCount: shardCount,
+		cache:      make(map[string]int),
+		logger:     logger,
+	}
+}
+
+// resolve returns the shard index for a namespace. It is safe for concurrent use.
+func (r *shardAssignmentResolver) resolve(ctx context.Context, namespace string) (int, error) {
+	// 1. Check in-memory cache
+	r.mu.RLock()
+	if idx, ok := r.cache[namespace]; ok {
+		r.mu.RUnlock()
+		return idx, nil
+	}
+	r.mu.RUnlock()
+
+	// 2. Check database
+	idx, found, err := r.lookupAssignment(ctx, namespace)
+	if err != nil {
+		return 0, err
+	}
+	if found {
+		r.cacheAssignment(namespace, idx)
+		return idx, nil
+	}
+
+	// 3. New namespace — assign to least-loaded shard and persist
+	idx = r.leastLoadedShard()
+	if err := r.persistAssignment(ctx, namespace, idx); err != nil {
+		return 0, err
+	}
+	return idx, nil
+}
+
+// leastLoadedShard returns the shard index with the fewest assigned tenants,
+// computed from the in-memory cache. Ties are broken by lowest index.
+func (r *shardAssignmentResolver) leastLoadedShard() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	counts := make([]int, r.shardCount)
+	for _, idx := range r.cache {
+		if idx >= 0 && idx < r.shardCount {
+			counts[idx]++
+		}
+	}
+
+	minCount := math.MaxInt
+	minIdx := 0
+	for i, c := range counts {
+		if c < minCount {
+			minCount = c
+			minIdx = i
+		}
+	}
+	return minIdx
+}
+
+func (r *shardAssignmentResolver) lookupAssignment(ctx context.Context, namespace string) (int, bool, error) {
+	var idx int
+	err := r.pool.QueryRow(ctx,
+		"SELECT shard_index FROM shard_assignments WHERE namespace = $1",
+		namespace,
+	).Scan(&idx)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return 0, false, nil
+		}
+		return 0, false, fmt.Errorf("failed to lookup shard assignment for %q: %w", namespace, err)
+	}
+	return idx, true, nil
+}
+
+func (r *shardAssignmentResolver) persistAssignment(ctx context.Context, namespace string, shardIndex int) error {
+	// Use ON CONFLICT to handle races. If two replicas try to assign the same
+	// namespace concurrently, the first write wins and subsequent ones are no-ops.
+	_, err := r.pool.Exec(ctx,
+		`INSERT INTO shard_assignments (namespace, shard_index, created_at)
+		 VALUES ($1, $2, $3)
+		 ON CONFLICT (namespace) DO NOTHING`,
+		namespace, shardIndex, time.Now().UTC().UnixMilli(),
+	)
+	if err != nil {
+		return fmt.Errorf("failed to persist shard assignment for %q: %w", namespace, err)
+	}
+
+	// Re-read to handle the race: if another replica inserted first, use their value.
+	storedIdx, found, err := r.lookupAssignment(ctx, namespace)
+	if err != nil {
+		return err
+	}
+	if found {
+		r.cacheAssignment(namespace, storedIdx)
+	}
+	return nil
+}
+
+func (r *shardAssignmentResolver) cacheAssignment(namespace string, shardIndex int) {
+	r.mu.Lock()
+	r.cache[namespace] = shardIndex
+	r.mu.Unlock()
+}
+
+// preloadAssignments loads all existing assignments into the cache at startup.
+// This avoids a database round-trip on the first request for each known tenant.
+func (r *shardAssignmentResolver) preloadAssignments(ctx context.Context) error {
+	rows, err := r.pool.Query(ctx, "SELECT namespace, shard_index FROM shard_assignments")
+	if err != nil {
+		return fmt.Errorf("failed to preload shard assignments: %w", err)
+	}
+	defer rows.Close()
+
+	count := 0
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	for rows.Next() {
+		var ns string
+		var idx int
+		if err := rows.Scan(&ns, &idx); err != nil {
+			return fmt.Errorf("failed to scan shard assignment: %w", err)
+		}
+		r.cache[ns] = idx
+		count++
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("error iterating shard assignments: %w", err)
+	}
+
+	r.logger.Info("Preloaded shard assignments", "count", count)
+	return nil
+}

--- a/pkg/registry/apps/annotation/sharded_store.go
+++ b/pkg/registry/apps/annotation/sharded_store.go
@@ -1,0 +1,232 @@
+package annotation
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	annotationV0 "github.com/grafana/grafana/apps/annotation/pkg/apis/annotation/v0alpha1"
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// ShardedStoreConfig holds the configuration for a sharded PostgreSQL store.
+type ShardedStoreConfig struct {
+	// ShardConnectionStrings are the connection strings for each data shard, ordered by shard index.
+	ShardConnectionStrings []string
+
+	// MetadataConnectionString is the connection string for the dedicated metadata database.
+	MetadataConnectionString string
+
+	// Per-shard PostgreSQL settings (applied uniformly to all shards)
+	MaxConnections  int
+	MaxIdleConns    int
+	ConnMaxLifetime time.Duration
+	RetentionTTL    time.Duration
+	TagCacheTTL     time.Duration
+	TagCacheSize    int
+}
+
+// ShardedPostgresStore implements Store, TagProvider, and LifecycleManager by routing
+// requests to one of N PostgreSQLStore instances based on namespace.
+//
+// Shard assignments are persisted in a dedicated metadata database. Once a
+// namespace is assigned to a shard, it stays there. Adding new shards does not
+// remap existing tenants — only new namespaces will be assigned to the expanded
+// shard set.
+type ShardedPostgresStore struct {
+	shards       []*PostgreSQLStore
+	metadataPool *pgxpool.Pool
+	resolver     *shardAssignmentResolver
+	logger       log.Logger
+}
+
+var _ Store = (*ShardedPostgresStore)(nil)
+var _ TagProvider = (*ShardedPostgresStore)(nil)
+var _ LifecycleManager = (*ShardedPostgresStore)(nil)
+
+// NewShardedPostgresStore creates a sharded store backed by multiple PostgreSQL databases.
+// A dedicated metadata database stores namespace-to-shard assignments.
+func NewShardedPostgresStore(ctx context.Context, cfg ShardedStoreConfig) (*ShardedPostgresStore, error) {
+	if len(cfg.ShardConnectionStrings) == 0 {
+		return nil, fmt.Errorf("at least one shard connection string is required")
+	}
+	if cfg.MetadataConnectionString == "" {
+		return nil, fmt.Errorf("metadata connection string is required")
+	}
+
+	logger := log.New("sharded.annotation.store")
+
+	metadataPool, err := createMetadataPool(ctx, cfg, logger)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create metadata pool: %w", err)
+	}
+
+	shards := make([]*PostgreSQLStore, len(cfg.ShardConnectionStrings))
+	for i, connStr := range cfg.ShardConnectionStrings {
+		pgCfg := PostgreSQLStoreConfig{
+			ConnectionString: connStr,
+			MaxConnections:   cfg.MaxConnections,
+			MaxIdleConns:     cfg.MaxIdleConns,
+			ConnMaxLifetime:  cfg.ConnMaxLifetime,
+			RetentionTTL:     cfg.RetentionTTL,
+			TagCacheTTL:      cfg.TagCacheTTL,
+			TagCacheSize:     cfg.TagCacheSize,
+		}
+
+		store, err := NewPostgreSQLStore(ctx, pgCfg)
+		if err != nil {
+			for j := 0; j < i; j++ {
+				shards[j].Close()
+			}
+			metadataPool.Close()
+			return nil, fmt.Errorf("failed to create shard %d: %w", i, err)
+		}
+		shards[i] = store
+	}
+
+	resolver := newShardAssignmentResolver(metadataPool, len(shards), logger)
+
+	if err := resolver.preloadAssignments(ctx); err != nil {
+		for _, shard := range shards {
+			shard.Close()
+		}
+		metadataPool.Close()
+		return nil, fmt.Errorf("failed to preload shard assignments: %w", err)
+	}
+
+	logger.Info("Initialized sharded annotation store",
+		"shard_count", len(shards),
+	)
+
+	return &ShardedPostgresStore{
+		shards:       shards,
+		metadataPool: metadataPool,
+		resolver:     resolver,
+		logger:       logger,
+	}, nil
+}
+
+func createMetadataPool(ctx context.Context, cfg ShardedStoreConfig, logger log.Logger) (*pgxpool.Pool, error) {
+	poolConfig, err := pgxpool.ParseConfig(cfg.MetadataConnectionString)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse metadata connection string: %w", err)
+	}
+
+	// The metadata DB is lightweight, so a small connection pool is sufficient
+	poolConfig.MaxConns = 5
+	poolConfig.MinConns = 1
+	poolConfig.MaxConnLifetime = cfg.ConnMaxLifetime
+
+	pool, err := pgxpool.NewWithConfig(ctx, poolConfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create metadata connection pool: %w", err)
+	}
+
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		return nil, fmt.Errorf("failed to ping metadata database: %w", err)
+	}
+
+	if err := runMetadataMigrations(ctx, pool, logger); err != nil {
+		pool.Close()
+		return nil, fmt.Errorf("failed to run metadata migrations: %w", err)
+	}
+
+	return pool, nil
+}
+
+// Close closes all underlying connections.
+func (s *ShardedPostgresStore) Close() {
+	for _, shard := range s.shards {
+		shard.Close()
+	}
+	if s.metadataPool != nil {
+		s.metadataPool.Close()
+	}
+}
+
+// shardFor returns the shard for a given namespace by resolving its assignment.
+func (s *ShardedPostgresStore) shardFor(ctx context.Context, namespace string) (*PostgreSQLStore, error) {
+	idx, err := s.resolver.resolve(ctx, namespace)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve shard for namespace %q: %w", namespace, err)
+	}
+	if idx < 0 || idx >= len(s.shards) {
+		return nil, fmt.Errorf("shard index %d out of range for namespace %q (have %d shards)", idx, namespace, len(s.shards))
+	}
+	return s.shards[idx], nil
+}
+
+// Get retrieves an annotation, routing to the correct shard by namespace.
+func (s *ShardedPostgresStore) Get(ctx context.Context, namespace, name string) (*annotationV0.Annotation, error) {
+	shard, err := s.shardFor(ctx, namespace)
+	if err != nil {
+		return nil, err
+	}
+	return shard.Get(ctx, namespace, name)
+}
+
+// Create creates an annotation on the correct shard.
+func (s *ShardedPostgresStore) Create(ctx context.Context, anno *annotationV0.Annotation) (*annotationV0.Annotation, error) {
+	shard, err := s.shardFor(ctx, anno.Namespace)
+	if err != nil {
+		return nil, err
+	}
+	return shard.Create(ctx, anno)
+}
+
+// Update updates an annotation on the correct shard.
+func (s *ShardedPostgresStore) Update(ctx context.Context, anno *annotationV0.Annotation) (*annotationV0.Annotation, error) {
+	shard, err := s.shardFor(ctx, anno.Namespace)
+	if err != nil {
+		return nil, err
+	}
+	return shard.Update(ctx, anno)
+}
+
+// Delete deletes an annotation from the correct shard.
+func (s *ShardedPostgresStore) Delete(ctx context.Context, namespace, name string) error {
+	shard, err := s.shardFor(ctx, namespace)
+	if err != nil {
+		return err
+	}
+	return shard.Delete(ctx, namespace, name)
+}
+
+// List lists annotations from the correct shard.
+func (s *ShardedPostgresStore) List(ctx context.Context, namespace string, opts ListOptions) (*AnnotationList, error) {
+	shard, err := s.shardFor(ctx, namespace)
+	if err != nil {
+		return nil, err
+	}
+	return shard.List(ctx, namespace, opts)
+}
+
+// ListTags returns tags from the correct shard.
+func (s *ShardedPostgresStore) ListTags(ctx context.Context, namespace string, opts TagListOptions) ([]Tag, error) {
+	shard, err := s.shardFor(ctx, namespace)
+	if err != nil {
+		return nil, err
+	}
+	return shard.ListTags(ctx, namespace, opts)
+}
+
+// Cleanup runs partition cleanup on all shards.
+func (s *ShardedPostgresStore) Cleanup(ctx context.Context) (int64, error) {
+	var total int64
+	var errs []string
+	for i, shard := range s.shards {
+		deleted, err := shard.Cleanup(ctx)
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("shard %d: %v", i, err))
+			continue
+		}
+		total += deleted
+	}
+	if len(errs) > 0 {
+		return total, fmt.Errorf("cleanup errors: %s", strings.Join(errs, "; "))
+	}
+	return total, nil
+}

--- a/pkg/registry/apps/annotation/sharded_store_test.go
+++ b/pkg/registry/apps/annotation/sharded_store_test.go
@@ -1,0 +1,78 @@
+package annotation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewShardedPostgresStore_Validation(t *testing.T) {
+	t.Run("no shard connection strings", func(t *testing.T) {
+		_, err := NewShardedPostgresStore(t.Context(), ShardedStoreConfig{
+			MetadataConnectionString: "postgresql://metadata",
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "at least one shard connection string")
+	})
+
+	t.Run("no metadata connection string", func(t *testing.T) {
+		_, err := NewShardedPostgresStore(t.Context(), ShardedStoreConfig{
+			ShardConnectionStrings: []string{"postgresql://shard0"},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "metadata connection string is required")
+	})
+}
+
+func TestLeastLoadedShard(t *testing.T) {
+	t.Run("empty cache picks shard 0", func(t *testing.T) {
+		r := newShardAssignmentResolver(nil, 4, nil)
+		assert.Equal(t, 0, r.leastLoadedShard())
+	})
+
+	t.Run("picks shard with fewest assignments", func(t *testing.T) {
+		r := newShardAssignmentResolver(nil, 4, nil)
+		r.cache["org-1"] = 0
+		r.cache["org-2"] = 0
+		r.cache["org-3"] = 1
+		r.cache["org-4"] = 2
+		assert.Equal(t, 3, r.leastLoadedShard())
+	})
+
+	t.Run("ties broken by lowest index", func(t *testing.T) {
+		r := newShardAssignmentResolver(nil, 4, nil)
+		r.cache["org-a"] = 0
+		r.cache["org-b"] = 1
+		assert.Equal(t, 2, r.leastLoadedShard())
+	})
+
+	t.Run("single shard always returns 0", func(t *testing.T) {
+		r := newShardAssignmentResolver(nil, 1, nil)
+		r.cache["org-1"] = 0
+		r.cache["org-2"] = 0
+		assert.Equal(t, 0, r.leastLoadedShard())
+	})
+}
+
+func TestShardAssignmentResolver_CacheHit(t *testing.T) {
+	r := newShardAssignmentResolver(nil, 4, nil)
+	r.cacheAssignment("org-cached", 3)
+
+	idx, err := r.resolve(t.Context(), "org-cached")
+	require.NoError(t, err)
+	assert.Equal(t, 3, idx)
+}
+
+func TestShardForOutOfRange(t *testing.T) {
+	s := &ShardedPostgresStore{
+		shards:   make([]*PostgreSQLStore, 2),
+		resolver: newShardAssignmentResolver(nil, 2, nil),
+	}
+	// Seed a cached assignment pointing beyond the shard slice
+	s.resolver.cacheAssignment("org-bad", 5)
+
+	_, err := s.shardFor(t.Context(), "org-bad")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "out of range")
+}

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -1063,12 +1063,13 @@ type AnnotationAppPlatformSettings struct {
 	GRPCTLSSkipVerify bool   // Skip TLS verification (insecure, for testing)
 
 	// Postgres store configuration
-	PostgresConnectionString string        // PostgreSQL connection string
-	PostgresMaxConnections   int           // Maximum number of connections in the pool
-	PostgresMaxIdleConns     int           // Maximum number of idle connections
-	PostgresConnMaxLifetime  time.Duration // Maximum lifetime of a connection
-	PostgresTagCacheTTL      time.Duration // TTL for tag query cache
-	PostgresTagCacheSize     int           // Size of the tag query cache
+	PostgresConnStrings        []string      // Connection strings for data shards
+	PostgresMetadataConnString string        // Connection string for the metadata database
+	PostgresMaxConnections     int           // Maximum number of connections per shard
+	PostgresMaxIdleConns       int           // Maximum number of idle connections per shard
+	PostgresConnMaxLifetime    time.Duration // Maximum lifetime of a connection
+	PostgresTagCacheTTL        time.Duration // TTL for tag query cache
+	PostgresTagCacheSize       int           // Size of the tag query cache
 }
 
 func loadAnnotationAppPlatformSettings(cfg *ini.File) AnnotationAppPlatformSettings {
@@ -1084,13 +1085,29 @@ func loadAnnotationAppPlatformSettings(cfg *ini.File) AnnotationAppPlatformSetti
 		GRPCTLSSkipVerify: appPlatformSection.Key("grpc_tls_skip_verify").MustBool(false),
 
 		// Postgres configuration
-		PostgresConnectionString: appPlatformSection.Key("postgres_connection_string").MustString(""),
-		PostgresMaxConnections:   appPlatformSection.Key("postgres_max_connections").MustInt(10),
-		PostgresMaxIdleConns:     appPlatformSection.Key("postgres_max_idle_conns").MustInt(5),
-		PostgresConnMaxLifetime:  appPlatformSection.Key("postgres_conn_max_lifetime").MustDuration(time.Hour),
-		PostgresTagCacheTTL:      appPlatformSection.Key("postgres_tag_cache_ttl").MustDuration(60 * time.Second),
-		PostgresTagCacheSize:     appPlatformSection.Key("postgres_tag_cache_size").MustInt(1000),
+		PostgresConnStrings:        parseConnStrings(appPlatformSection.Key("postgres_connection_strings").MustString("")),
+		PostgresMetadataConnString: appPlatformSection.Key("postgres_metadata_connection_string").MustString(""),
+		PostgresMaxConnections:     appPlatformSection.Key("postgres_max_connections").MustInt(10),
+		PostgresMaxIdleConns:       appPlatformSection.Key("postgres_max_idle_conns").MustInt(5),
+		PostgresConnMaxLifetime:    appPlatformSection.Key("postgres_conn_max_lifetime").MustDuration(time.Hour),
+		PostgresTagCacheTTL:        appPlatformSection.Key("postgres_tag_cache_ttl").MustDuration(60 * time.Second),
+		PostgresTagCacheSize:       appPlatformSection.Key("postgres_tag_cache_size").MustInt(1000),
 	}
+}
+
+func parseConnStrings(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+	parts := strings.Split(raw, ",")
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			result = append(result, p)
+		}
+	}
+	return result
 }
 
 // envNameFromIniName converts an ini-style name (section or key) to the


### PR DESCRIPTION
Adds horizontal database sharding to the annotation app's PostgreSQL store. Requests are routed to one of N PostgreSQL databases based on namespace. Shard assignments are stored in a dedicated metadata database. New tenants are placed on the least-loaded shard, with assignments cached in-memory and written to the metadata DB as needed.

The `postgres` store configuration was updated to now accept multiple connection strings, `--annotation.postgres-connection-strings` for the data shards and `--annotation.postgres-metadata-connection-string` for the metadata instance.