### PR TITLE
CloudWatch: Add pagination support for log groups selection

### DIFF
--- a/pkg/tsdb/cloudwatch/cloudwatch_test.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch_test.go
@@ -266,15 +266,17 @@ func TestQuery_ResourceRequest_DescribeLogGroups_with_CrossAccountQuerying(t *te
 		err := ds.CallResource(contextWithFeaturesEnabled(features.FlagCloudWatchCrossAccountQuerying), req, sender)
 		assert.NoError(t, err)
 
-		assert.JSONEq(t, `[
-		   {
-			  "accountId":"111",
-			  "value":{
-				 "arn":"arn:aws:logs:us-east-1:111:log-group:group_a",
-				 "name":"group_a"
+		assert.JSONEq(t, `{
+		   "results":[
+			  {
+				 "accountId":"111",
+				 "value":{
+					"arn":"arn:aws:logs:us-east-1:111:log-group:group_a",
+					"name":"group_a"
+				 }
 			  }
-		   }
-		]`, string(sender.Response.Body))
+		   ]
+		}`, string(sender.Response.Body))
 
 		logsApi.AssertCalled(t, "DescribeLogGroups",
 			&cloudwatchlogs.DescribeLogGroupsInput{

--- a/pkg/tsdb/cloudwatch/cloudwatch_test.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch_test.go
@@ -266,17 +266,15 @@ func TestQuery_ResourceRequest_DescribeLogGroups_with_CrossAccountQuerying(t *te
 		err := ds.CallResource(contextWithFeaturesEnabled(features.FlagCloudWatchCrossAccountQuerying), req, sender)
 		assert.NoError(t, err)
 
-		assert.JSONEq(t, `{
-		   "results":[
-			  {
-				 "accountId":"111",
-				 "value":{
+		assert.JSONEq(t, `[
+			{
+				"accountId":"111",
+				"value":{
 					"arn":"arn:aws:logs:us-east-1:111:log-group:group_a",
 					"name":"group_a"
-				 }
-			  }
-		   ]
-		}`, string(sender.Response.Body))
+				}
+			}
+		]`, string(sender.Response.Body))
 
 		logsApi.AssertCalled(t, "DescribeLogGroups",
 			&cloudwatchlogs.DescribeLogGroupsInput{

--- a/pkg/tsdb/cloudwatch/log_groups_test.go
+++ b/pkg/tsdb/cloudwatch/log_groups_test.go
@@ -29,13 +29,15 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("successfully returns 1 log group with account id", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{{
-			Value: resources.LogGroup{
-				Arn:  "some arn",
-				Name: "some name",
-			},
-			AccountId: utils.Pointer("111"),
-		}}, nil)
+		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{
+			Results: []resources.ResourceResponse[resources.LogGroup]{{
+				Value: resources.LogGroup{
+					Arn:  "some arn",
+					Name: "some name",
+				},
+				AccountId: utils.Pointer("111"),
+			}},
+		}, nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups", nil)
@@ -44,25 +46,27 @@ func TestLogGroupsRoute(t *testing.T) {
 		handler.ServeHTTP(rr, req)
 
 		assert.Equal(t, http.StatusOK, rr.Code)
-		assert.JSONEq(t, `[{"value":{"name":"some name", "arn":"some arn"},"accountId":"111"}]`, rr.Body.String())
+		assert.JSONEq(t, `{"results":[{"value":{"name":"some name", "arn":"some arn"},"accountId":"111"}]}`, rr.Body.String())
 	})
 
 	t.Run("successfully returns multiple log groups with account id", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
 		mockLogsService.On("GetLogGroups", mock.Anything).Return(
-			[]resources.ResourceResponse[resources.LogGroup]{
-				{
-					Value: resources.LogGroup{
-						Arn:  "arn 1",
-						Name: "name 1",
+			resources.LogGroupsResponse{
+				Results: []resources.ResourceResponse[resources.LogGroup]{
+					{
+						Value: resources.LogGroup{
+							Arn:  "arn 1",
+							Name: "name 1",
+						},
+						AccountId: utils.Pointer("111"),
+					}, {
+						Value: resources.LogGroup{
+							Arn:  "arn 2",
+							Name: "name 2",
+						},
+						AccountId: utils.Pointer("222"),
 					},
-					AccountId: utils.Pointer("111"),
-				}, {
-					Value: resources.LogGroup{
-						Arn:  "arn 2",
-						Name: "name 2",
-					},
-					AccountId: utils.Pointer("222"),
 				},
 			}, nil)
 
@@ -73,7 +77,7 @@ func TestLogGroupsRoute(t *testing.T) {
 		handler.ServeHTTP(rr, req)
 
 		assert.Equal(t, http.StatusOK, rr.Code)
-		assert.JSONEq(t, `[
+		assert.JSONEq(t, `{"results":[
 		   {
 			  "value":{
 				 "name":"name 1",
@@ -88,12 +92,12 @@ func TestLogGroupsRoute(t *testing.T) {
 			  },
 			  "accountId":"222"
 		   }
-		]`, rr.Body.String())
+		]}`, rr.Body.String())
 	})
 
 	t.Run("returns error when both logGroupPrefix and logGroup Pattern are provided", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, nil)
+		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{Results: []resources.ResourceResponse[resources.LogGroup]{}}, nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups?logGroupNamePrefix=some-prefix&logGroupPattern=some-pattern", nil)
@@ -107,7 +111,7 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("passes default log group limit and nil for logGroupNamePrefix, accountId, and logGroupPattern", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, nil)
+		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{Results: []resources.ResourceResponse[resources.LogGroup]{}}, nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups", nil)
@@ -125,7 +129,7 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("passes default log group limit and nil for logGroupNamePrefix when both are absent", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, nil)
+		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{Results: []resources.ResourceResponse[resources.LogGroup]{}}, nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups", nil)
@@ -141,7 +145,7 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("passes log group limit from query parameter", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, nil)
+		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{Results: []resources.ResourceResponse[resources.LogGroup]{}}, nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups?limit=2", nil)
@@ -156,7 +160,7 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("passes logGroupPrefix from query parameter", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, nil)
+		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{Results: []resources.ResourceResponse[resources.LogGroup]{}}, nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups?logGroupNamePrefix=some-prefix", nil)
@@ -172,7 +176,7 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("passes logGroupPattern from query parameter", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, nil)
+		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{Results: []resources.ResourceResponse[resources.LogGroup]{}}, nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups?logGroupPattern=some-pattern", nil)
@@ -188,7 +192,7 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("passes logGroupPattern from query parameter", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, nil)
+		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{Results: []resources.ResourceResponse[resources.LogGroup]{}}, nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups?accountId=some-account-id", nil)
@@ -205,7 +209,7 @@ func TestLogGroupsRoute(t *testing.T) {
 	t.Run("returns error if service returns error", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
 		mockLogsService.On("GetLogGroups", mock.Anything).
-			Return([]resources.ResourceResponse[resources.LogGroup]{}, fmt.Errorf("some error"))
+			Return(resources.LogGroupsResponse{Results: []resources.ResourceResponse[resources.LogGroup]{}}, fmt.Errorf("some error"))
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups", nil)
@@ -215,5 +219,28 @@ func TestLogGroupsRoute(t *testing.T) {
 
 		assert.Equal(t, http.StatusInternalServerError, rr.Code)
 		assert.JSONEq(t, `{"Error":"some error","Message":"GetLogGroups error: some error","StatusCode":500}`, rr.Body.String())
+	})
+
+	t.Run("successfully returns log groups with nextToken", func(t *testing.T) {
+		mockLogsService = mocks.LogsService{}
+		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{
+			Results: []resources.ResourceResponse[resources.LogGroup]{{
+				Value: resources.LogGroup{
+					Arn:  "some arn",
+					Name: "some name",
+				},
+				AccountId: utils.Pointer("111"),
+			}},
+			NextToken: utils.Pointer("next_page_token"),
+		}, nil)
+
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/log-groups", nil)
+		ds := newTestDatasource()
+		handler := http.HandlerFunc(ds.resourceRequestMiddleware(ds.LogGroupsHandler))
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.JSONEq(t, `{"results":[{"value":{"name":"some name","arn":"some arn"},"accountId":"111"}],"nextToken":"next_page_token"}`, rr.Body.String())
 	})
 }

--- a/pkg/tsdb/cloudwatch/log_groups_test.go
+++ b/pkg/tsdb/cloudwatch/log_groups_test.go
@@ -46,7 +46,7 @@ func TestLogGroupsRoute(t *testing.T) {
 		handler.ServeHTTP(rr, req)
 
 		assert.Equal(t, http.StatusOK, rr.Code)
-		assert.JSONEq(t, `{"results":[{"value":{"name":"some name", "arn":"some arn"},"accountId":"111"}]}`, rr.Body.String())
+		assert.JSONEq(t, `[{"value":{"name":"some name", "arn":"some arn"},"accountId":"111"}]`, rr.Body.String())
 	})
 
 	t.Run("successfully returns multiple log groups with account id", func(t *testing.T) {
@@ -77,7 +77,7 @@ func TestLogGroupsRoute(t *testing.T) {
 		handler.ServeHTTP(rr, req)
 
 		assert.Equal(t, http.StatusOK, rr.Code)
-		assert.JSONEq(t, `{"results":[
+		assert.JSONEq(t, `[
 		   {
 			  "value":{
 				 "name":"name 1",
@@ -92,7 +92,7 @@ func TestLogGroupsRoute(t *testing.T) {
 			  },
 			  "accountId":"222"
 		   }
-		]}`, rr.Body.String())
+		]`, rr.Body.String())
 	})
 
 	t.Run("returns error when both logGroupPrefix and logGroup Pattern are provided", func(t *testing.T) {
@@ -242,6 +242,6 @@ func TestLogGroupsRoute(t *testing.T) {
 
 		assert.Equal(t, http.StatusOK, rr.Code)
 		assert.Equal(t, "next_page_token", rr.Header().Get("cursor-next"))
-		assert.JSONEq(t, `{"results":[{"value":{"name":"some name","arn":"some arn"},"accountId":"111"}]}`, rr.Body.String())
+		assert.JSONEq(t, `[{"value":{"name":"some name","arn":"some arn"},"accountId":"111"}]`, rr.Body.String())
 	})
 }

--- a/pkg/tsdb/cloudwatch/log_groups_test.go
+++ b/pkg/tsdb/cloudwatch/log_groups_test.go
@@ -42,7 +42,7 @@ func TestLogGroupsRoute(t *testing.T) {
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups", nil)
 		ds := newTestDatasource()
-		handler := http.HandlerFunc(ds.resourceRequestMiddleware(ds.LogGroupsHandler))
+		handler := http.HandlerFunc(ds.cursorPagenationMiddleware(ds.LogGroupsHandler))
 		handler.ServeHTTP(rr, req)
 
 		assert.Equal(t, http.StatusOK, rr.Code)
@@ -73,7 +73,7 @@ func TestLogGroupsRoute(t *testing.T) {
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups", nil)
 		ds := newTestDatasource()
-		handler := http.HandlerFunc(ds.resourceRequestMiddleware(ds.LogGroupsHandler))
+		handler := http.HandlerFunc(ds.cursorPagenationMiddleware(ds.LogGroupsHandler))
 		handler.ServeHTTP(rr, req)
 
 		assert.Equal(t, http.StatusOK, rr.Code)
@@ -102,7 +102,7 @@ func TestLogGroupsRoute(t *testing.T) {
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups?logGroupNamePrefix=some-prefix&logGroupPattern=some-pattern", nil)
 		ds := newTestDatasource()
-		handler := http.HandlerFunc(ds.resourceRequestMiddleware(ds.LogGroupsHandler))
+		handler := http.HandlerFunc(ds.cursorPagenationMiddleware(ds.LogGroupsHandler))
 		handler.ServeHTTP(rr, req)
 
 		assert.Equal(t, http.StatusBadRequest, rr.Code)
@@ -116,7 +116,7 @@ func TestLogGroupsRoute(t *testing.T) {
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups", nil)
 		ds := newTestDatasource()
-		handler := http.HandlerFunc(ds.resourceRequestMiddleware(ds.LogGroupsHandler))
+		handler := http.HandlerFunc(ds.cursorPagenationMiddleware(ds.LogGroupsHandler))
 		handler.ServeHTTP(rr, req)
 
 		mockLogsService.AssertCalled(t, "GetLogGroups", resources.LogGroupsRequest{
@@ -134,7 +134,7 @@ func TestLogGroupsRoute(t *testing.T) {
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups", nil)
 		ds := newTestDatasource()
-		handler := http.HandlerFunc(ds.resourceRequestMiddleware(ds.LogGroupsHandler))
+		handler := http.HandlerFunc(ds.cursorPagenationMiddleware(ds.LogGroupsHandler))
 		handler.ServeHTTP(rr, req)
 
 		mockLogsService.AssertCalled(t, "GetLogGroups", resources.LogGroupsRequest{
@@ -150,7 +150,7 @@ func TestLogGroupsRoute(t *testing.T) {
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups?limit=2", nil)
 		ds := newTestDatasource()
-		handler := http.HandlerFunc(ds.resourceRequestMiddleware(ds.LogGroupsHandler))
+		handler := http.HandlerFunc(ds.cursorPagenationMiddleware(ds.LogGroupsHandler))
 		handler.ServeHTTP(rr, req)
 
 		mockLogsService.AssertCalled(t, "GetLogGroups", resources.LogGroupsRequest{
@@ -165,7 +165,7 @@ func TestLogGroupsRoute(t *testing.T) {
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups?logGroupNamePrefix=some-prefix", nil)
 		ds := newTestDatasource()
-		handler := http.HandlerFunc(ds.resourceRequestMiddleware(ds.LogGroupsHandler))
+		handler := http.HandlerFunc(ds.cursorPagenationMiddleware(ds.LogGroupsHandler))
 		handler.ServeHTTP(rr, req)
 
 		mockLogsService.AssertCalled(t, "GetLogGroups", resources.LogGroupsRequest{
@@ -181,7 +181,7 @@ func TestLogGroupsRoute(t *testing.T) {
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups?logGroupPattern=some-pattern", nil)
 		ds := newTestDatasource()
-		handler := http.HandlerFunc(ds.resourceRequestMiddleware(ds.LogGroupsHandler))
+		handler := http.HandlerFunc(ds.cursorPagenationMiddleware(ds.LogGroupsHandler))
 		handler.ServeHTTP(rr, req)
 
 		mockLogsService.AssertCalled(t, "GetLogGroups", resources.LogGroupsRequest{
@@ -197,7 +197,7 @@ func TestLogGroupsRoute(t *testing.T) {
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups?accountId=some-account-id", nil)
 		ds := newTestDatasource()
-		handler := http.HandlerFunc(ds.resourceRequestMiddleware(ds.LogGroupsHandler))
+		handler := http.HandlerFunc(ds.cursorPagenationMiddleware(ds.LogGroupsHandler))
 		handler.ServeHTTP(rr, req)
 
 		mockLogsService.AssertCalled(t, "GetLogGroups", resources.LogGroupsRequest{
@@ -214,14 +214,14 @@ func TestLogGroupsRoute(t *testing.T) {
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups", nil)
 		ds := newTestDatasource()
-		handler := http.HandlerFunc(ds.resourceRequestMiddleware(ds.LogGroupsHandler))
+		handler := http.HandlerFunc(ds.cursorPagenationMiddleware(ds.LogGroupsHandler))
 		handler.ServeHTTP(rr, req)
 
 		assert.Equal(t, http.StatusInternalServerError, rr.Code)
 		assert.JSONEq(t, `{"Error":"some error","Message":"GetLogGroups error: some error","StatusCode":500}`, rr.Body.String())
 	})
 
-	t.Run("successfully returns log groups with nextToken", func(t *testing.T) {
+	t.Run("successfully returns log groups with nextToken in cursor-next header", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
 		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{
 			Results: []resources.ResourceResponse[resources.LogGroup]{{
@@ -231,16 +231,17 @@ func TestLogGroupsRoute(t *testing.T) {
 				},
 				AccountId: utils.Pointer("111"),
 			}},
-			NextToken: utils.Pointer("next_page_token"),
+			CursorNext: utils.Pointer("next_page_token"),
 		}, nil)
 
 		rr := httptest.NewRecorder()
-		req := httptest.NewRequest("GET", "/log-groups", nil)
+		req := httptest.NewRequest("GET", "/log-groups?region=us-east-1", nil)
 		ds := newTestDatasource()
-		handler := http.HandlerFunc(ds.resourceRequestMiddleware(ds.LogGroupsHandler))
+		handler := http.HandlerFunc(ds.cursorPagenationMiddleware(ds.LogGroupsHandler))
 		handler.ServeHTTP(rr, req)
 
 		assert.Equal(t, http.StatusOK, rr.Code)
-		assert.JSONEq(t, `{"results":[{"value":{"name":"some name","arn":"some arn"},"accountId":"111"}],"nextToken":"next_page_token"}`, rr.Body.String())
+		assert.Equal(t, "next_page_token", rr.Header().Get("cursor-next"))
+		assert.JSONEq(t, `{"results":[{"value":{"name":"some name","arn":"some arn"},"accountId":"111"}]}`, rr.Body.String())
 	})
 }

--- a/pkg/tsdb/cloudwatch/log_groups_test.go
+++ b/pkg/tsdb/cloudwatch/log_groups_test.go
@@ -29,15 +29,13 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("successfully returns 1 log group with account id", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{
-			Results: []resources.ResourceResponse[resources.LogGroup]{{
-				Value: resources.LogGroup{
-					Arn:  "some arn",
-					Name: "some name",
-				},
-				AccountId: utils.Pointer("111"),
-			}},
-		}, nil)
+		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{{
+			Value: resources.LogGroup{
+				Arn:  "some arn",
+				Name: "some name",
+			},
+			AccountId: utils.Pointer("111"),
+		}}, (*string)(nil), nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups", nil)
@@ -52,23 +50,21 @@ func TestLogGroupsRoute(t *testing.T) {
 	t.Run("successfully returns multiple log groups with account id", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
 		mockLogsService.On("GetLogGroups", mock.Anything).Return(
-			resources.LogGroupsResponse{
-				Results: []resources.ResourceResponse[resources.LogGroup]{
-					{
-						Value: resources.LogGroup{
-							Arn:  "arn 1",
-							Name: "name 1",
-						},
-						AccountId: utils.Pointer("111"),
-					}, {
-						Value: resources.LogGroup{
-							Arn:  "arn 2",
-							Name: "name 2",
-						},
-						AccountId: utils.Pointer("222"),
+			[]resources.ResourceResponse[resources.LogGroup]{
+				{
+					Value: resources.LogGroup{
+						Arn:  "arn 1",
+						Name: "name 1",
 					},
+					AccountId: utils.Pointer("111"),
+				}, {
+					Value: resources.LogGroup{
+						Arn:  "arn 2",
+						Name: "name 2",
+					},
+					AccountId: utils.Pointer("222"),
 				},
-			}, nil)
+			}, (*string)(nil), nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups", nil)
@@ -97,7 +93,7 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("returns error when both logGroupPrefix and logGroup Pattern are provided", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{Results: []resources.ResourceResponse[resources.LogGroup]{}}, nil)
+		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, (*string)(nil), nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups?logGroupNamePrefix=some-prefix&logGroupPattern=some-pattern", nil)
@@ -111,7 +107,7 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("passes default log group limit and nil for logGroupNamePrefix, accountId, and logGroupPattern", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{Results: []resources.ResourceResponse[resources.LogGroup]{}}, nil)
+		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, (*string)(nil), nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups", nil)
@@ -129,7 +125,7 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("passes default log group limit and nil for logGroupNamePrefix when both are absent", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{Results: []resources.ResourceResponse[resources.LogGroup]{}}, nil)
+		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, (*string)(nil), nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups", nil)
@@ -145,7 +141,7 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("passes log group limit from query parameter", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{Results: []resources.ResourceResponse[resources.LogGroup]{}}, nil)
+		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, (*string)(nil), nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups?limit=2", nil)
@@ -160,7 +156,7 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("passes logGroupPrefix from query parameter", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{Results: []resources.ResourceResponse[resources.LogGroup]{}}, nil)
+		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, (*string)(nil), nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups?logGroupNamePrefix=some-prefix", nil)
@@ -176,7 +172,7 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("passes logGroupPattern from query parameter", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{Results: []resources.ResourceResponse[resources.LogGroup]{}}, nil)
+		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, (*string)(nil), nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups?logGroupPattern=some-pattern", nil)
@@ -192,7 +188,7 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("passes logGroupPattern from query parameter", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{Results: []resources.ResourceResponse[resources.LogGroup]{}}, nil)
+		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, (*string)(nil), nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups?accountId=some-account-id", nil)
@@ -209,7 +205,7 @@ func TestLogGroupsRoute(t *testing.T) {
 	t.Run("returns error if service returns error", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
 		mockLogsService.On("GetLogGroups", mock.Anything).
-			Return(resources.LogGroupsResponse{Results: []resources.ResourceResponse[resources.LogGroup]{}}, fmt.Errorf("some error"))
+			Return([]resources.ResourceResponse[resources.LogGroup]{}, (*string)(nil), fmt.Errorf("some error"))
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups", nil)
@@ -223,16 +219,13 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("successfully returns log groups with nextToken in cursor-next header", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{
-			Results: []resources.ResourceResponse[resources.LogGroup]{{
-				Value: resources.LogGroup{
-					Arn:  "some arn",
-					Name: "some name",
-				},
-				AccountId: utils.Pointer("111"),
-			}},
-			CursorNext: utils.Pointer("next_page_token"),
-		}, nil)
+		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{{
+			Value: resources.LogGroup{
+				Arn:  "some arn",
+				Name: "some name",
+			},
+			AccountId: utils.Pointer("111"),
+		}}, utils.Pointer("next_page_token"), nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups?region=us-east-1", nil)

--- a/pkg/tsdb/cloudwatch/middleware_test.go
+++ b/pkg/tsdb/cloudwatch/middleware_test.go
@@ -36,4 +36,19 @@ func Test_Middleware(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, rr.Code)
 		assert.Equal(t, `{"Message":"error: error from handler","Error":"error from handler","StatusCode":400}`, rr.Body.String())
 	})
+
+	t.Run("should pass cursor-next header to handler as cursorNext parameter", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/log-groups", nil)
+		req.Header.Set("cursor-next", "some-token")
+		ds := newTestDatasource()
+		var receivedCursor string
+		handler := http.HandlerFunc(ds.cursorPagenationMiddleware(func(_ context.Context, parameters url.Values) ([]byte, *string, *models.HttpError) {
+			receivedCursor = parameters.Get("cursorNext")
+			return []byte(`[]`), nil, nil
+		}))
+		handler.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, "some-token", receivedCursor)
+	})
 }

--- a/pkg/tsdb/cloudwatch/mocks/logs.go
+++ b/pkg/tsdb/cloudwatch/mocks/logs.go
@@ -29,10 +29,10 @@ type LogsService struct {
 	mock.Mock
 }
 
-func (l *LogsService) GetLogGroups(_ context.Context, request resources.LogGroupsRequest) ([]resources.ResourceResponse[resources.LogGroup], error) {
+func (l *LogsService) GetLogGroups(_ context.Context, request resources.LogGroupsRequest) (resources.LogGroupsResponse, error) {
 	args := l.Called(request)
 
-	return args.Get(0).([]resources.ResourceResponse[resources.LogGroup]), args.Error(1)
+	return args.Get(0).(resources.LogGroupsResponse), args.Error(1)
 }
 
 func (l *LogsService) GetLogGroupFields(_ context.Context, request resources.LogGroupFieldsRequest) ([]resources.ResourceResponse[resources.LogGroupField], error) {

--- a/pkg/tsdb/cloudwatch/mocks/logs.go
+++ b/pkg/tsdb/cloudwatch/mocks/logs.go
@@ -29,10 +29,11 @@ type LogsService struct {
 	mock.Mock
 }
 
-func (l *LogsService) GetLogGroups(_ context.Context, request resources.LogGroupsRequest) (resources.LogGroupsResponse, error) {
+func (l *LogsService) GetLogGroups(_ context.Context, request resources.LogGroupsRequest) ([]resources.ResourceResponse[resources.LogGroup], *string, error) {
 	args := l.Called(request)
 
-	return args.Get(0).(resources.LogGroupsResponse), args.Error(1)
+	cursor, _ := args.Get(1).(*string)
+	return args.Get(0).([]resources.ResourceResponse[resources.LogGroup]), cursor, args.Error(2)
 }
 
 func (l *LogsService) GetLogGroupFields(_ context.Context, request resources.LogGroupFieldsRequest) ([]resources.ResourceResponse[resources.LogGroupField], error) {

--- a/pkg/tsdb/cloudwatch/models/api.go
+++ b/pkg/tsdb/cloudwatch/models/api.go
@@ -34,7 +34,7 @@ type ListMetricsProvider interface {
 }
 
 type LogGroupsProvider interface {
-	GetLogGroups(ctx context.Context, request resources.LogGroupsRequest) ([]resources.ResourceResponse[resources.LogGroup], error)
+	GetLogGroups(ctx context.Context, request resources.LogGroupsRequest) (resources.LogGroupsResponse, error)
 	GetLogGroupFields(ctx context.Context, request resources.LogGroupFieldsRequest) ([]resources.ResourceResponse[resources.LogGroupField], error)
 }
 

--- a/pkg/tsdb/cloudwatch/models/api.go
+++ b/pkg/tsdb/cloudwatch/models/api.go
@@ -17,6 +17,8 @@ type RequestContextFactoryFunc func(ctx context.Context, region string) (reqCtx 
 
 type RouteHandlerFunc func(ctx context.Context, parameters url.Values) ([]byte, *HttpError)
 
+type CursorHandlerFunc func(ctx context.Context, parameters url.Values) ([]byte, *string, *HttpError)
+
 type RequestContext struct {
 	MetricsClientProvider  MetricsClientProvider
 	ListMetricsAPIProvider cloudwatch.ListMetricsAPIClient

--- a/pkg/tsdb/cloudwatch/models/api.go
+++ b/pkg/tsdb/cloudwatch/models/api.go
@@ -36,7 +36,7 @@ type ListMetricsProvider interface {
 }
 
 type LogGroupsProvider interface {
-	GetLogGroups(ctx context.Context, request resources.LogGroupsRequest) (resources.LogGroupsResponse, error)
+	GetLogGroups(ctx context.Context, request resources.LogGroupsRequest) ([]resources.ResourceResponse[resources.LogGroup], *string, error)
 	GetLogGroupFields(ctx context.Context, request resources.LogGroupFieldsRequest) ([]resources.ResourceResponse[resources.LogGroupField], error)
 }
 

--- a/pkg/tsdb/cloudwatch/models/resources/log_groups_resource_request.go
+++ b/pkg/tsdb/cloudwatch/models/resources/log_groups_resource_request.go
@@ -13,6 +13,7 @@ type LogGroupsRequest struct {
 	Limit                                   int32
 	LogGroupNamePrefix, LogGroupNamePattern *string
 	ListAllLogGroups                        bool
+	NextToken                               *string
 }
 
 func (r LogGroupsRequest) IsTargetingAllAccounts() bool {
@@ -35,6 +36,7 @@ func ParseLogGroupsRequest(parameters url.Values) (LogGroupsRequest, error) {
 		LogGroupNamePrefix:  logGroupNamePrefix,
 		LogGroupNamePattern: logGroupPattern,
 		ListAllLogGroups:    parameters.Get("listAllLogGroups") == "true",
+		NextToken:           setIfNotEmptyString(parameters.Get("nextToken")),
 	}, nil
 }
 

--- a/pkg/tsdb/cloudwatch/models/resources/log_groups_resource_request.go
+++ b/pkg/tsdb/cloudwatch/models/resources/log_groups_resource_request.go
@@ -13,7 +13,7 @@ type LogGroupsRequest struct {
 	Limit                                   int32
 	LogGroupNamePrefix, LogGroupNamePattern *string
 	ListAllLogGroups                        bool
-	NextToken                               *string
+	CursorNext                              *string
 }
 
 func (r LogGroupsRequest) IsTargetingAllAccounts() bool {
@@ -36,7 +36,7 @@ func ParseLogGroupsRequest(parameters url.Values) (LogGroupsRequest, error) {
 		LogGroupNamePrefix:  logGroupNamePrefix,
 		LogGroupNamePattern: logGroupPattern,
 		ListAllLogGroups:    parameters.Get("listAllLogGroups") == "true",
-		NextToken:           setIfNotEmptyString(parameters.Get("nextToken")),
+		CursorNext:          setIfNotEmptyString(parameters.Get("cursorNext")),
 	}, nil
 }
 

--- a/pkg/tsdb/cloudwatch/models/resources/types.go
+++ b/pkg/tsdb/cloudwatch/models/resources/types.go
@@ -44,3 +44,8 @@ type LogGroupField struct {
 	Percent int64  `json:"percent"`
 	Name    string `json:"name"`
 }
+
+type LogGroupsResponse struct {
+	Results   []ResourceResponse[LogGroup] `json:"results"`
+	NextToken *string                      `json:"nextToken,omitempty"`
+}

--- a/pkg/tsdb/cloudwatch/models/resources/types.go
+++ b/pkg/tsdb/cloudwatch/models/resources/types.go
@@ -44,8 +44,3 @@ type LogGroupField struct {
 	Percent int64  `json:"percent"`
 	Name    string `json:"name"`
 }
-
-type LogGroupsResponse struct {
-	Results    []ResourceResponse[LogGroup] `json:"results"`
-	CursorNext *string                      `json:"-"`
-}

--- a/pkg/tsdb/cloudwatch/models/resources/types.go
+++ b/pkg/tsdb/cloudwatch/models/resources/types.go
@@ -46,6 +46,6 @@ type LogGroupField struct {
 }
 
 type LogGroupsResponse struct {
-	Results   []ResourceResponse[LogGroup] `json:"results"`
-	NextToken *string                      `json:"nextToken,omitempty"`
+	Results    []ResourceResponse[LogGroup] `json:"results"`
+	CursorNext *string                      `json:"-"`
 }

--- a/pkg/tsdb/cloudwatch/resource_handler.go
+++ b/pkg/tsdb/cloudwatch/resource_handler.go
@@ -88,17 +88,17 @@ func (ds *DataSource) LogGroupsHandler(ctx context.Context, parameters url.Value
 		return nil, nil, models.NewHttpError("GetLogGroupsService error", http.StatusInternalServerError, err)
 	}
 
-	logGroups, err := service.GetLogGroups(ctx, request)
+	logGroups, cursor, err := service.GetLogGroups(ctx, request)
 	if err != nil {
 		return nil, nil, models.NewHttpError("GetLogGroups error", http.StatusInternalServerError, err)
 	}
 
-	logGroupsResponse, err := json.Marshal(logGroups.Results)
+	logGroupsResponse, err := json.Marshal(logGroups)
 	if err != nil {
 		return nil, nil, models.NewHttpError("LogGroupsHandler json error", http.StatusInternalServerError, err)
 	}
 
-	return logGroupsResponse, logGroups.CursorNext, nil
+	return logGroupsResponse, cursor, nil
 }
 func (ds *DataSource) MetricsHandler(ctx context.Context, parameters url.Values) ([]byte, *models.HttpError) {
 	metricsRequest, err := resources.GetMetricsRequest(parameters)

--- a/pkg/tsdb/cloudwatch/resource_handler.go
+++ b/pkg/tsdb/cloudwatch/resource_handler.go
@@ -338,6 +338,7 @@ func (ds *DataSource) resourceRequestMiddleware(handleFunc models.RouteHandlerFu
 	return ds.cursorPagenationMiddleware(adaptRouteHandler(handleFunc))
 }
 
+// TODO: merge this and handleResourceReq
 func (ds *DataSource) cursorPagenationMiddleware(handleFunc models.CursorHandlerFunc) func(rw http.ResponseWriter, req *http.Request) {
 	return func(rw http.ResponseWriter, req *http.Request) {
 		if req.Method != "GET" {

--- a/pkg/tsdb/cloudwatch/resource_handler.go
+++ b/pkg/tsdb/cloudwatch/resource_handler.go
@@ -347,7 +347,11 @@ func (ds *DataSource) cursorPagenationMiddleware(handleFunc models.CursorHandler
 		}
 
 		ctx := req.Context()
-		jsonResponse, cursor, httpError := handleFunc(ctx, req.URL.Query())
+		parameters := req.URL.Query()
+		if cursorHeader := req.Header.Get("cursor-next"); cursorHeader != "" {
+			parameters.Set("cursorNext", cursorHeader)
+		}
+		jsonResponse, cursor, httpError := handleFunc(ctx, parameters)
 		if httpError != nil {
 			ds.logger.FromContext(ctx).Error("Error handling resource request", "error", httpError.Message)
 			respondWithError(rw, httpError)

--- a/pkg/tsdb/cloudwatch/resource_handler.go
+++ b/pkg/tsdb/cloudwatch/resource_handler.go
@@ -23,7 +23,7 @@ func (ds *DataSource) newResourceMux() *http.ServeMux {
 	mux.HandleFunc("/ebs-volume-ids", ds.handleResourceReq(ds.handleGetEbsVolumeIds))
 	mux.HandleFunc("/ec2-instance-attribute", ds.handleResourceReq(ds.handleGetEc2InstanceAttribute))
 	mux.HandleFunc("/resource-arns", ds.handleResourceReq(ds.handleGetResourceArns))
-	mux.HandleFunc("/log-groups", ds.resourceRequestMiddleware(ds.LogGroupsHandler))
+	mux.HandleFunc("/log-groups", ds.cursorPagenationMiddleware(ds.LogGroupsHandler))
 	mux.HandleFunc("/metrics", ds.resourceRequestMiddleware(ds.MetricsHandler))
 	mux.HandleFunc("/dimension-values", ds.resourceRequestMiddleware(ds.DimensionValuesHandler))
 	mux.HandleFunc("/dimension-keys", ds.resourceRequestMiddleware(ds.DimensionKeysHandler))
@@ -77,28 +77,28 @@ func writeResponse(rw http.ResponseWriter, code int, msg string, logger log.Logg
 	}
 }
 
-func (ds *DataSource) LogGroupsHandler(ctx context.Context, parameters url.Values) ([]byte, *models.HttpError) {
+func (ds *DataSource) LogGroupsHandler(ctx context.Context, parameters url.Values) ([]byte, *string, *models.HttpError) {
 	request, err := resources.ParseLogGroupsRequest(parameters)
 	if err != nil {
-		return nil, models.NewHttpError("cannot set both log group name prefix and pattern", http.StatusBadRequest, err)
+		return nil, nil, models.NewHttpError("cannot set both log group name prefix and pattern", http.StatusBadRequest, err)
 	}
 
 	service, err := ds.GetLogGroupsService(ctx, request.Region)
 	if err != nil {
-		return nil, models.NewHttpError("GetLogGroupsService error", http.StatusInternalServerError, err)
+		return nil, nil, models.NewHttpError("GetLogGroupsService error", http.StatusInternalServerError, err)
 	}
 
 	logGroups, err := service.GetLogGroups(ctx, request)
 	if err != nil {
-		return nil, models.NewHttpError("GetLogGroups error", http.StatusInternalServerError, err)
+		return nil, nil, models.NewHttpError("GetLogGroups error", http.StatusInternalServerError, err)
 	}
 
 	logGroupsResponse, err := json.Marshal(logGroups)
 	if err != nil {
-		return nil, models.NewHttpError("LogGroupsHandler json error", http.StatusInternalServerError, err)
+		return nil, nil, models.NewHttpError("LogGroupsHandler json error", http.StatusInternalServerError, err)
 	}
 
-	return logGroupsResponse, nil
+	return logGroupsResponse, logGroups.CursorNext, nil
 }
 func (ds *DataSource) MetricsHandler(ctx context.Context, parameters url.Values) ([]byte, *models.HttpError) {
 	metricsRequest, err := resources.GetMetricsRequest(parameters)
@@ -327,8 +327,18 @@ func (ds *DataSource) GetRegionsService(ctx context.Context, region string) (mod
 	return services.NewRegionsService(NewEC2API(awsCfg), ds.logger), nil
 }
 
-// TODO: merge this and handleResourceReq
+func adaptRouteHandler(fn models.RouteHandlerFunc) models.CursorHandlerFunc {
+	return func(ctx context.Context, parameters url.Values) ([]byte, *string, *models.HttpError) {
+		b, httpErr := fn(ctx, parameters)
+		return b, nil, httpErr
+	}
+}
+
 func (ds *DataSource) resourceRequestMiddleware(handleFunc models.RouteHandlerFunc) func(rw http.ResponseWriter, req *http.Request) {
+	return ds.cursorPagenationMiddleware(adaptRouteHandler(handleFunc))
+}
+
+func (ds *DataSource) cursorPagenationMiddleware(handleFunc models.CursorHandlerFunc) func(rw http.ResponseWriter, req *http.Request) {
 	return func(rw http.ResponseWriter, req *http.Request) {
 		if req.Method != "GET" {
 			respondWithError(rw, models.NewHttpError("Invalid method", http.StatusMethodNotAllowed, nil))
@@ -336,11 +346,15 @@ func (ds *DataSource) resourceRequestMiddleware(handleFunc models.RouteHandlerFu
 		}
 
 		ctx := req.Context()
-		jsonResponse, httpError := handleFunc(ctx, req.URL.Query())
+		jsonResponse, cursor, httpError := handleFunc(ctx, req.URL.Query())
 		if httpError != nil {
 			ds.logger.FromContext(ctx).Error("Error handling resource request", "error", httpError.Message)
 			respondWithError(rw, httpError)
 			return
+		}
+
+		if cursor != nil {
+			rw.Header().Set("cursor-next", *cursor)
 		}
 
 		rw.Header().Set("Content-Type", "application/json")

--- a/pkg/tsdb/cloudwatch/resource_handler.go
+++ b/pkg/tsdb/cloudwatch/resource_handler.go
@@ -93,7 +93,7 @@ func (ds *DataSource) LogGroupsHandler(ctx context.Context, parameters url.Value
 		return nil, nil, models.NewHttpError("GetLogGroups error", http.StatusInternalServerError, err)
 	}
 
-	logGroupsResponse, err := json.Marshal(logGroups)
+	logGroupsResponse, err := json.Marshal(logGroups.Results)
 	if err != nil {
 		return nil, nil, models.NewHttpError("LogGroupsHandler json error", http.StatusInternalServerError, err)
 	}

--- a/pkg/tsdb/cloudwatch/services/log_groups.go
+++ b/pkg/tsdb/cloudwatch/services/log_groups.go
@@ -20,7 +20,7 @@ var NewLogGroupsService = func(logsClient models.CloudWatchLogsAPIProvider, isCr
 	return &LogGroupsService{logGroupsAPI: logsClient, isCrossAccountEnabled: isCrossAccountEnabled}
 }
 
-func (s *LogGroupsService) GetLogGroups(ctx context.Context, req resources.LogGroupsRequest) ([]resources.ResourceResponse[resources.LogGroup], error) {
+func (s *LogGroupsService) GetLogGroups(ctx context.Context, req resources.LogGroupsRequest) (resources.LogGroupsResponse, error) {
 	input := &cloudwatchlogs.DescribeLogGroupsInput{
 		Limit:              aws.Int32(req.Limit),
 		LogGroupNamePrefix: req.LogGroupNamePrefix,
@@ -36,12 +36,17 @@ func (s *LogGroupsService) GetLogGroups(ctx context.Context, req resources.LogGr
 			input.AccountIdentifiers = []string{*req.AccountId}
 		}
 	}
+
+	if req.NextToken != nil {
+		input.NextToken = req.NextToken
+	}
+
 	result := []resources.ResourceResponse[resources.LogGroup]{}
 
 	for {
 		response, err := s.logGroupsAPI.DescribeLogGroups(ctx, input)
 		if err != nil || response == nil {
-			return nil, err
+			return resources.LogGroupsResponse{}, err
 		}
 
 		for _, logGroup := range response.LogGroups {
@@ -55,12 +60,13 @@ func (s *LogGroupsService) GetLogGroups(ctx context.Context, req resources.LogGr
 		}
 
 		if !req.ListAllLogGroups || response.NextToken == nil {
-			break
+			return resources.LogGroupsResponse{
+				Results:   result,
+				NextToken: response.NextToken,
+			}, nil
 		}
 		input.NextToken = response.NextToken
 	}
-
-	return result, nil
 }
 
 func (s *LogGroupsService) GetLogGroupFields(ctx context.Context, request resources.LogGroupFieldsRequest) ([]resources.ResourceResponse[resources.LogGroupField], error) {

--- a/pkg/tsdb/cloudwatch/services/log_groups.go
+++ b/pkg/tsdb/cloudwatch/services/log_groups.go
@@ -20,7 +20,7 @@ var NewLogGroupsService = func(logsClient models.CloudWatchLogsAPIProvider, isCr
 	return &LogGroupsService{logGroupsAPI: logsClient, isCrossAccountEnabled: isCrossAccountEnabled}
 }
 
-func (s *LogGroupsService) GetLogGroups(ctx context.Context, req resources.LogGroupsRequest) (resources.LogGroupsResponse, error) {
+func (s *LogGroupsService) GetLogGroups(ctx context.Context, req resources.LogGroupsRequest) ([]resources.ResourceResponse[resources.LogGroup], *string, error) {
 	input := &cloudwatchlogs.DescribeLogGroupsInput{
 		Limit:              aws.Int32(req.Limit),
 		LogGroupNamePrefix: req.LogGroupNamePrefix,
@@ -46,7 +46,7 @@ func (s *LogGroupsService) GetLogGroups(ctx context.Context, req resources.LogGr
 	for {
 		response, err := s.logGroupsAPI.DescribeLogGroups(ctx, input)
 		if err != nil || response == nil {
-			return resources.LogGroupsResponse{}, err
+			return nil, nil, err
 		}
 
 		for _, logGroup := range response.LogGroups {
@@ -60,10 +60,7 @@ func (s *LogGroupsService) GetLogGroups(ctx context.Context, req resources.LogGr
 		}
 
 		if !req.ListAllLogGroups || response.NextToken == nil {
-			return resources.LogGroupsResponse{
-				Results:    result,
-				CursorNext: response.NextToken,
-			}, nil
+			return result, response.NextToken, nil
 		}
 		input.NextToken = response.NextToken
 	}

--- a/pkg/tsdb/cloudwatch/services/log_groups.go
+++ b/pkg/tsdb/cloudwatch/services/log_groups.go
@@ -37,8 +37,8 @@ func (s *LogGroupsService) GetLogGroups(ctx context.Context, req resources.LogGr
 		}
 	}
 
-	if req.NextToken != nil {
-		input.NextToken = req.NextToken
+	if req.CursorNext != nil {
+		input.NextToken = req.CursorNext
 	}
 
 	result := []resources.ResourceResponse[resources.LogGroup]{}
@@ -61,8 +61,8 @@ func (s *LogGroupsService) GetLogGroups(ctx context.Context, req resources.LogGr
 
 		if !req.ListAllLogGroups || response.NextToken == nil {
 			return resources.LogGroupsResponse{
-				Results:   result,
-				NextToken: response.NextToken,
+				Results:    result,
+				CursorNext: response.NextToken,
 			}, nil
 		}
 		input.NextToken = response.NextToken

--- a/pkg/tsdb/cloudwatch/services/log_groups_test.go
+++ b/pkg/tsdb/cloudwatch/services/log_groups_test.go
@@ -46,7 +46,7 @@ func TestGetLogGroups(t *testing.T) {
 				AccountId: utils.Pointer("333"),
 				Value:     resources.LogGroup{Arn: "arn:aws:logs:us-east-1:333:log-group:group_c", Name: "group_c"},
 			},
-		}, resp)
+		}, resp.Results)
 	})
 
 	t.Run("Should return an empty error if api doesn't return any data", func(t *testing.T) {
@@ -57,7 +57,7 @@ func TestGetLogGroups(t *testing.T) {
 		resp, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{})
 
 		assert.NoError(t, err)
-		assert.Equal(t, []resources.ResourceResponse[resources.LogGroup]{}, resp)
+		assert.Equal(t, []resources.ResourceResponse[resources.LogGroup]{}, resp.Results)
 	})
 
 	t.Run("Should only use LogGroupNamePrefix even if LogGroupNamePattern passed in resource call", func(t *testing.T) {
@@ -131,7 +131,41 @@ func TestGetLogGroups(t *testing.T) {
 				AccountId: utils.Pointer("111"),
 				Value:     resources.LogGroup{Arn: "arn:aws:logs:us-east-1:111:log-group:group_a", Name: "group_a"},
 			},
-		}, resp)
+		}, resp.Results)
+		assert.Equal(t, aws.String("next_token"), resp.NextToken)
+	})
+
+	t.Run("Should pass NextToken to the API when provided in the request", func(t *testing.T) {
+		mockLogsAPI := &mocks.LogsAPI{}
+		req := resources.LogGroupsRequest{
+			Limit:              2,
+			LogGroupNamePrefix: utils.Pointer("test"),
+			NextToken:          utils.Pointer("some_token"),
+		}
+
+		mockLogsAPI.On("DescribeLogGroups", &cloudwatchlogs.DescribeLogGroupsInput{
+			Limit:              aws.Int32(req.Limit),
+			LogGroupNamePrefix: req.LogGroupNamePrefix,
+			NextToken:          utils.Pointer("some_token"),
+		}).Return(&cloudwatchlogs.DescribeLogGroupsOutput{
+			LogGroups: []cloudwatchlogstypes.LogGroup{
+				{Arn: utils.Pointer("arn:aws:logs:us-east-1:111:log-group:group_a"), LogGroupName: utils.Pointer("group_a")},
+			},
+			NextToken: aws.String("another_token"),
+		}, nil)
+
+		service := NewLogGroupsService(mockLogsAPI, false)
+		resp, err := service.GetLogGroups(context.Background(), req)
+
+		assert.NoError(t, err)
+		mockLogsAPI.AssertNumberOfCalls(t, "DescribeLogGroups", 1)
+		assert.Equal(t, []resources.ResourceResponse[resources.LogGroup]{
+			{
+				AccountId: utils.Pointer("111"),
+				Value:     resources.LogGroup{Arn: "arn:aws:logs:us-east-1:111:log-group:group_a", Name: "group_a"},
+			},
+		}, resp.Results)
+		assert.Equal(t, aws.String("another_token"), resp.NextToken)
 	})
 
 	t.Run("Should keep on calling the api until NextToken is empty in case ListAllLogGroups is set to true", func(t *testing.T) {
@@ -176,7 +210,8 @@ func TestGetLogGroups(t *testing.T) {
 				AccountId: utils.Pointer("222"),
 				Value:     resources.LogGroup{Arn: "arn:aws:logs:us-east-1:222:log-group:group_b", Name: "group_b"},
 			},
-		}, resp)
+		}, resp.Results)
+		assert.Nil(t, resp.NextToken)
 	})
 }
 

--- a/pkg/tsdb/cloudwatch/services/log_groups_test.go
+++ b/pkg/tsdb/cloudwatch/services/log_groups_test.go
@@ -30,7 +30,7 @@ func TestGetLogGroups(t *testing.T) {
 			}, nil)
 		service := NewLogGroupsService(mockLogsAPI, false)
 
-		resp, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{})
+		resp, _, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{})
 
 		assert.NoError(t, err)
 		assert.Equal(t, []resources.ResourceResponse[resources.LogGroup]{
@@ -46,7 +46,7 @@ func TestGetLogGroups(t *testing.T) {
 				AccountId: utils.Pointer("333"),
 				Value:     resources.LogGroup{Arn: "arn:aws:logs:us-east-1:333:log-group:group_c", Name: "group_c"},
 			},
-		}, resp.Results)
+		}, resp)
 	})
 
 	t.Run("Should return an empty error if api doesn't return any data", func(t *testing.T) {
@@ -54,10 +54,10 @@ func TestGetLogGroups(t *testing.T) {
 		mockLogsAPI.On("DescribeLogGroups", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
 		service := NewLogGroupsService(mockLogsAPI, false)
 
-		resp, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{})
+		resp, _, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{})
 
 		assert.NoError(t, err)
-		assert.Equal(t, []resources.ResourceResponse[resources.LogGroup]{}, resp.Results)
+		assert.Equal(t, []resources.ResourceResponse[resources.LogGroup]{}, resp)
 	})
 
 	t.Run("Should only use LogGroupNamePrefix even if LogGroupNamePattern passed in resource call", func(t *testing.T) {
@@ -66,7 +66,7 @@ func TestGetLogGroups(t *testing.T) {
 		mockLogsAPI.On("DescribeLogGroups", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
 		service := NewLogGroupsService(mockLogsAPI, false)
 
-		_, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{
+		_, _, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{
 			Limit:              0,
 			LogGroupNamePrefix: utils.Pointer("test"),
 		})
@@ -83,7 +83,7 @@ func TestGetLogGroups(t *testing.T) {
 		mockLogsAPI.On("DescribeLogGroups", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
 		service := NewLogGroupsService(mockLogsAPI, false)
 
-		_, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{})
+		_, _, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{})
 
 		assert.NoError(t, err)
 		mockLogsAPI.AssertCalled(t, "DescribeLogGroups", &cloudwatchlogs.DescribeLogGroupsInput{
@@ -97,7 +97,7 @@ func TestGetLogGroups(t *testing.T) {
 			fmt.Errorf("some error"))
 		service := NewLogGroupsService(mockLogsAPI, false)
 
-		_, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{})
+		_, _, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{})
 
 		assert.Error(t, err)
 		assert.Equal(t, "some error", err.Error())
@@ -122,7 +122,7 @@ func TestGetLogGroups(t *testing.T) {
 		}, nil)
 
 		service := NewLogGroupsService(mockLogsAPI, false)
-		resp, err := service.GetLogGroups(context.Background(), req)
+		resp, cursor, err := service.GetLogGroups(context.Background(), req)
 
 		assert.NoError(t, err)
 		mockLogsAPI.AssertNumberOfCalls(t, "DescribeLogGroups", 1)
@@ -131,8 +131,8 @@ func TestGetLogGroups(t *testing.T) {
 				AccountId: utils.Pointer("111"),
 				Value:     resources.LogGroup{Arn: "arn:aws:logs:us-east-1:111:log-group:group_a", Name: "group_a"},
 			},
-		}, resp.Results)
-		assert.Equal(t, aws.String("next_token"), resp.CursorNext)
+		}, resp)
+		assert.Equal(t, aws.String("next_token"), cursor)
 	})
 
 	t.Run("Should pass NextToken to the API when provided in the request", func(t *testing.T) {
@@ -155,7 +155,7 @@ func TestGetLogGroups(t *testing.T) {
 		}, nil)
 
 		service := NewLogGroupsService(mockLogsAPI, false)
-		resp, err := service.GetLogGroups(context.Background(), req)
+		resp, cursor, err := service.GetLogGroups(context.Background(), req)
 
 		assert.NoError(t, err)
 		mockLogsAPI.AssertNumberOfCalls(t, "DescribeLogGroups", 1)
@@ -164,8 +164,8 @@ func TestGetLogGroups(t *testing.T) {
 				AccountId: utils.Pointer("111"),
 				Value:     resources.LogGroup{Arn: "arn:aws:logs:us-east-1:111:log-group:group_a", Name: "group_a"},
 			},
-		}, resp.Results)
-		assert.Equal(t, aws.String("another_token"), resp.CursorNext)
+		}, resp)
+		assert.Equal(t, aws.String("another_token"), cursor)
 	})
 
 	t.Run("Should keep on calling the api until NextToken is empty in case ListAllLogGroups is set to true", func(t *testing.T) {
@@ -198,7 +198,7 @@ func TestGetLogGroups(t *testing.T) {
 			},
 		}, nil)
 		service := NewLogGroupsService(mockLogsAPI, false)
-		resp, err := service.GetLogGroups(context.Background(), req)
+		resp, cursor, err := service.GetLogGroups(context.Background(), req)
 		assert.NoError(t, err)
 		mockLogsAPI.AssertNumberOfCalls(t, "DescribeLogGroups", 2)
 		assert.Equal(t, []resources.ResourceResponse[resources.LogGroup]{
@@ -210,8 +210,8 @@ func TestGetLogGroups(t *testing.T) {
 				AccountId: utils.Pointer("222"),
 				Value:     resources.LogGroup{Arn: "arn:aws:logs:us-east-1:222:log-group:group_b", Name: "group_b"},
 			},
-		}, resp.Results)
-		assert.Nil(t, resp.CursorNext)
+		}, resp)
+		assert.Nil(t, cursor)
 	})
 }
 
@@ -221,7 +221,7 @@ func TestGetLogGroupsCrossAccountQuerying(t *testing.T) {
 		mockLogsAPI.On("DescribeLogGroups", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
 		service := NewLogGroupsService(mockLogsAPI, false)
 
-		_, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{
+		_, _, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{
 			ResourceRequest:    resources.ResourceRequest{AccountId: utils.Pointer("accountId")},
 			LogGroupNamePrefix: utils.Pointer("prefix"),
 		})
@@ -238,7 +238,7 @@ func TestGetLogGroupsCrossAccountQuerying(t *testing.T) {
 		mockLogsAPI.On("DescribeLogGroups", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
 		service := NewLogGroupsService(mockLogsAPI, true)
 
-		_, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{
+		_, _, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{
 			ResourceRequest:     resources.ResourceRequest{AccountId: utils.Pointer("accountId")},
 			LogGroupNamePrefix:  utils.Pointer("prefix"),
 			LogGroupNamePattern: utils.Pointer("pattern"),
@@ -258,7 +258,7 @@ func TestGetLogGroupsCrossAccountQuerying(t *testing.T) {
 		mockLogsAPI.On("DescribeLogGroups", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
 		service := NewLogGroupsService(mockLogsAPI, true)
 
-		_, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{
+		_, _, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{
 			ResourceRequest: resources.ResourceRequest{AccountId: utils.Pointer("accountId")},
 		})
 
@@ -275,7 +275,7 @@ func TestGetLogGroupsCrossAccountQuerying(t *testing.T) {
 		mockLogsAPI.On("DescribeLogGroups", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
 		service := NewLogGroupsService(mockLogsAPI, true)
 
-		_, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{
+		_, _, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{
 			ResourceRequest:    resources.ResourceRequest{AccountId: utils.Pointer("accountId")},
 			LogGroupNamePrefix: utils.Pointer("prefix"),
 		})
@@ -293,7 +293,7 @@ func TestGetLogGroupsCrossAccountQuerying(t *testing.T) {
 		mockLogsAPI.On("DescribeLogGroups", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
 		service := NewLogGroupsService(mockLogsAPI, true)
 
-		_, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{
+		_, _, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{
 			LogGroupNamePrefix: utils.Pointer("prefix"),
 		})
 
@@ -309,7 +309,7 @@ func TestGetLogGroupsCrossAccountQuerying(t *testing.T) {
 		mockLogsAPI.On("DescribeLogGroups", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
 		service := NewLogGroupsService(mockLogsAPI, true)
 
-		_, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{
+		_, _, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{
 			ResourceRequest: resources.ResourceRequest{
 				AccountId: utils.Pointer("accountId"),
 			},

--- a/pkg/tsdb/cloudwatch/services/log_groups_test.go
+++ b/pkg/tsdb/cloudwatch/services/log_groups_test.go
@@ -132,7 +132,7 @@ func TestGetLogGroups(t *testing.T) {
 				Value:     resources.LogGroup{Arn: "arn:aws:logs:us-east-1:111:log-group:group_a", Name: "group_a"},
 			},
 		}, resp.Results)
-		assert.Equal(t, aws.String("next_token"), resp.NextToken)
+		assert.Equal(t, aws.String("next_token"), resp.CursorNext)
 	})
 
 	t.Run("Should pass NextToken to the API when provided in the request", func(t *testing.T) {
@@ -140,7 +140,7 @@ func TestGetLogGroups(t *testing.T) {
 		req := resources.LogGroupsRequest{
 			Limit:              2,
 			LogGroupNamePrefix: utils.Pointer("test"),
-			NextToken:          utils.Pointer("some_token"),
+			CursorNext:         utils.Pointer("some_token"),
 		}
 
 		mockLogsAPI.On("DescribeLogGroups", &cloudwatchlogs.DescribeLogGroupsInput{
@@ -165,7 +165,7 @@ func TestGetLogGroups(t *testing.T) {
 				Value:     resources.LogGroup{Arn: "arn:aws:logs:us-east-1:111:log-group:group_a", Name: "group_a"},
 			},
 		}, resp.Results)
-		assert.Equal(t, aws.String("another_token"), resp.NextToken)
+		assert.Equal(t, aws.String("another_token"), resp.CursorNext)
 	})
 
 	t.Run("Should keep on calling the api until NextToken is empty in case ListAllLogGroups is set to true", func(t *testing.T) {
@@ -211,7 +211,7 @@ func TestGetLogGroups(t *testing.T) {
 				Value:     resources.LogGroup{Arn: "arn:aws:logs:us-east-1:222:log-group:group_b", Name: "group_b"},
 			},
 		}, resp.Results)
-		assert.Nil(t, resp.NextToken)
+		assert.Nil(t, resp.CursorNext)
 	})
 }
 

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsField.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsField.test.tsx
@@ -40,7 +40,7 @@ describe('LogGroupSelection', () => {
     config.featureToggles.cloudWatchCrossAccountQuerying = true;
     defaultProps.datasource.resources.getLogGroups = jest
       .fn()
-      .mockResolvedValue([{ value: { arn: 'arn', name: 'loggroupname' } }]);
+      .mockResolvedValue({ results: [{ value: { arn: 'arn', name: 'loggroupname' } }] });
     defaultProps.datasource.resources.templateSrv = setupMockedTemplateService();
     render(<LogGroupsField {...defaultProps} legacyLogGroupNames={['loggroupname']} />);
 
@@ -57,7 +57,7 @@ describe('LogGroupSelection', () => {
     defaultProps.datasource = setupMockedDataSource({ variables: [logGroupNamesVariable] }).datasource;
     defaultProps.datasource.resources.getLogGroups = jest
       .fn()
-      .mockResolvedValue([{ value: { arn: 'arn', name: 'loggroupname' } }]);
+      .mockResolvedValue({ results: [{ value: { arn: 'arn', name: 'loggroupname' } }] });
     const varName = '$' + logGroupNamesVariable.name;
     render(<LogGroupsField {...defaultProps} legacyLogGroupNames={['loggroupname', varName]} />);
 
@@ -77,7 +77,7 @@ describe('LogGroupSelection', () => {
     config.featureToggles.cloudWatchCrossAccountQuerying = true;
     defaultProps.datasource.resources.getLogGroups = jest
       .fn()
-      .mockResolvedValue([{ value: { arn: 'arn', name: 'loggroupname' } }]);
+      .mockResolvedValue({ results: [{ value: { arn: 'arn', name: 'loggroupname' } }] });
     defaultProps.datasource.resources.templateSrv = setupMockedTemplateService();
     render(<LogGroupsField {...defaultProps} logGroups={[{ arn: 'arn', name: 'loggroupname' }]} />);
     await waitFor(() => expect(screen.getByText('Select log groups')).toBeInTheDocument());

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsField.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsField.test.tsx
@@ -4,6 +4,15 @@ import lodash from 'lodash';
 
 import { config } from '@grafana/runtime';
 
+jest.mock('app/core/copy/appNotification', () => ({
+  useAppNotification: () => ({
+    error: jest.fn(),
+    warning: jest.fn(),
+    info: jest.fn(),
+    success: jest.fn(),
+  }),
+}));
+
 import {
   logGroupNamesVariable,
   setupMockedDataSource,

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsField.tsx
@@ -82,7 +82,7 @@ export const LogGroupsField = ({
       )
         .then((results) => {
           const logGroups = results.flatMap((r) =>
-            r.map((lg) => ({
+            r.results.map((lg) => ({
               arn: lg.value.arn,
               name: lg.value.name,
               accountId: lg.accountId,
@@ -101,7 +101,7 @@ export const LogGroupsField = ({
     <Stack direction="column" gap={1}>
       <LogGroupsSelector
         fetchLogGroups={async (params: Partial<DescribeLogGroupsRequest>) =>
-          datasource?.resources.getLogGroups({ region: region, ...params }) ?? []
+          datasource?.resources.getLogGroups({ region: region, ...params }) ?? { results: [] }
         }
         onChange={onChange}
         accountOptions={accountState.value}

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.test.tsx
@@ -8,6 +8,16 @@ import { type LogGroupsResponse } from '../../../resources/types';
 
 import { LogGroupsSelector } from './LogGroupsSelector';
 
+const mockNotifyError = jest.fn();
+jest.mock('app/core/copy/appNotification', () => ({
+  useAppNotification: () => ({
+    error: mockNotifyError,
+    warning: jest.fn(),
+    info: jest.fn(),
+    success: jest.fn(),
+  }),
+}));
+
 const defaultLogGroupsResponse: LogGroupsResponse = {
   results: [
     {
@@ -190,8 +200,7 @@ describe('LogGroupsSelector', () => {
     ]);
   });
 
-  const labelText =
-    'If you do not see an expected log group, try narrowing down your search.';
+  const labelText = 'If you do not see an expected log group, try narrowing down your search.';
   it('should not display max result info label in case less than 50 logs groups are being displayed', async () => {
     const defer = new Deferred();
     const fetchLogGroups = jest.fn(async () => {
@@ -210,12 +219,14 @@ describe('LogGroupsSelector', () => {
     const fetchLogGroups = jest.fn(async () => {
       await Promise.all([defer.promise]);
       return {
-        results: Array(50).fill(null).map((_, i) => ({
-          value: {
-            arn: `logGroup${i}`,
-            name: `logGroup${i}`,
-          },
-        })),
+        results: Array(50)
+          .fill(null)
+          .map((_, i) => ({
+            value: {
+              arn: `logGroup${i}`,
+              name: `logGroup${i}`,
+            },
+          })),
       } as LogGroupsResponse;
     });
     render(<LogGroupsSelector {...defaultProps} fetchLogGroups={fetchLogGroups} />);
@@ -370,5 +381,37 @@ describe('LogGroupsSelector', () => {
     await userEvent.click(screen.getByText('Select log groups'));
     await waitFor(() => expect(screen.getByText('logGroup1')).toBeInTheDocument());
     expect(screen.queryByText('Load more')).not.toBeInTheDocument();
+  });
+
+  it('should show a toast error when load more fails', async () => {
+    let callCount = 0;
+    const fetchLogGroups = jest.fn(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          results: [
+            {
+              accountId: '123',
+              value: {
+                name: 'logGroup1',
+                arn: 'arn:partition:service:region:account-id123:loggroup:someloggroup',
+              },
+            },
+          ],
+          nextToken: 'page2_token',
+        } as LogGroupsResponse;
+      }
+      throw new Error('network error');
+    });
+
+    render(<LogGroupsSelector {...defaultProps} fetchLogGroups={fetchLogGroups} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Select log groups' }));
+    await waitFor(() => expect(screen.getByText('logGroup1')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: 'Load more' }));
+
+    await waitFor(() =>
+      expect(mockNotifyError).toHaveBeenCalledWith('Failed to load more log groups. Please try again.')
+    );
   });
 });

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.test.tsx
@@ -4,9 +4,28 @@ import userEvent from '@testing-library/user-event';
 import lodash from 'lodash';
 import selectEvent from 'react-select-event';
 
-import { type ResourceResponse, type LogGroupResponse } from '../../../resources/types';
+import { type LogGroupsResponse } from '../../../resources/types';
 
 import { LogGroupsSelector } from './LogGroupsSelector';
+
+const defaultLogGroupsResponse: LogGroupsResponse = {
+  results: [
+    {
+      accountId: '123',
+      value: {
+        name: 'logGroup1',
+        arn: 'arn:partition:service:region:account-id123:loggroup:someloggroup',
+      },
+    },
+    {
+      accountId: '456',
+      value: {
+        name: 'logGroup2',
+        arn: 'arn:partition:service:region:account-id456:loggroup:someotherloggroup',
+      },
+    },
+  ],
+};
 
 const defaultProps = {
   variables: [],
@@ -23,23 +42,7 @@ const defaultProps = {
       label: 'Account Name 456',
     },
   ],
-  fetchLogGroups: () =>
-    Promise.resolve([
-      {
-        accountId: '123',
-        value: {
-          name: 'logGroup1',
-          arn: 'arn:partition:service:region:account-id123:loggroup:someloggroup',
-        },
-      },
-      {
-        accountId: '456',
-        value: {
-          name: 'logGroup2',
-          arn: 'arn:partition:service:region:account-id456:loggroup:someotherloggroup',
-        },
-      },
-    ] as Array<ResourceResponse<LogGroupResponse>>),
+  fetchLogGroups: () => Promise.resolve(defaultLogGroupsResponse),
   onChange: jest.fn(),
 };
 
@@ -77,7 +80,7 @@ describe('LogGroupsSelector', () => {
     const defer = new Deferred();
     const fetchLogGroups = jest.fn(async () => {
       await Promise.all([defer.promise]);
-      return defaultProps.fetchLogGroups();
+      return defaultLogGroupsResponse;
     });
     render(<LogGroupsSelector {...defaultProps} fetchLogGroups={fetchLogGroups} />);
     await userEvent.click(screen.getByText('Select log groups'));
@@ -92,7 +95,7 @@ describe('LogGroupsSelector', () => {
     const defer = new Deferred();
     const fetchLogGroups = jest.fn(async () => {
       await Promise.all([defer.promise]);
-      return [];
+      return { results: [] } as LogGroupsResponse;
     });
     render(<LogGroupsSelector {...defaultProps} fetchLogGroups={fetchLogGroups} />);
     await userEvent.click(screen.getByText('Select log groups'));
@@ -105,7 +108,7 @@ describe('LogGroupsSelector', () => {
   });
 
   it('calls fetchLogGroups with a search phrase when it is typed in the Search Field', async () => {
-    const fetchLogGroups = jest.fn(() => defaultProps.fetchLogGroups());
+    const fetchLogGroups = jest.fn(() => Promise.resolve(defaultLogGroupsResponse));
     render(<LogGroupsSelector {...defaultProps} fetchLogGroups={fetchLogGroups} />);
     await userEvent.click(screen.getByText('Select log groups'));
     expect(screen.getByText('Log group name prefix')).toBeInTheDocument();
@@ -121,11 +124,11 @@ describe('LogGroupsSelector', () => {
     const fetchLogGroups = jest.fn(async () => {
       if (once) {
         await Promise.all([secondCall.promise]);
-        return defaultProps.fetchLogGroups();
+        return defaultLogGroupsResponse;
       }
       await Promise.all([firstCall.promise]);
       once = true;
-      return defaultProps.fetchLogGroups();
+      return defaultLogGroupsResponse;
     });
     render(<LogGroupsSelector {...defaultProps} fetchLogGroups={fetchLogGroups} />);
     await userEvent.click(screen.getByText('Select log groups'));
@@ -188,12 +191,12 @@ describe('LogGroupsSelector', () => {
   });
 
   const labelText =
-    'Only the first 50 results can be shown. If you do not see an expected log group, try narrowing down your search.';
+    'If you do not see an expected log group, try narrowing down your search.';
   it('should not display max result info label in case less than 50 logs groups are being displayed', async () => {
     const defer = new Deferred();
     const fetchLogGroups = jest.fn(async () => {
       await Promise.all([defer.promise]);
-      return [];
+      return { results: [] } as LogGroupsResponse;
     });
     render(<LogGroupsSelector {...defaultProps} fetchLogGroups={fetchLogGroups} />);
     await userEvent.click(screen.getByText('Select log groups'));
@@ -206,12 +209,14 @@ describe('LogGroupsSelector', () => {
     const defer = new Deferred();
     const fetchLogGroups = jest.fn(async () => {
       await Promise.all([defer.promise]);
-      return Array(50).map((i) => ({
-        value: {
-          arn: `logGroup${i}`,
-          name: `logGroup${i}`,
-        },
-      }));
+      return {
+        results: Array(50).fill(null).map((_, i) => ({
+          value: {
+            arn: `logGroup${i}`,
+            name: `logGroup${i}`,
+          },
+        })),
+      } as LogGroupsResponse;
     });
     render(<LogGroupsSelector {...defaultProps} fetchLogGroups={fetchLogGroups} />);
     await userEvent.click(screen.getByText('Select log groups'));
@@ -308,5 +313,62 @@ describe('LogGroupsSelector', () => {
     expect(screen.getByText('Log group name prefix')).toBeInTheDocument();
     expect(screen.queryByText('Account label')).not.toBeInTheDocument();
     waitFor(() => expect(screen.queryByText('Account Name 123')).not.toBeInTheDocument());
+  });
+
+  it('should show Load more button when nextToken is present and append results on click', async () => {
+    let callCount = 0;
+    const fetchLogGroups = jest.fn(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          results: [
+            {
+              accountId: '123',
+              value: {
+                name: 'logGroup1',
+                arn: 'arn:partition:service:region:account-id123:loggroup:someloggroup',
+              },
+            },
+          ],
+          nextToken: 'page2_token',
+        } as LogGroupsResponse;
+      }
+      return {
+        results: [
+          {
+            accountId: '456',
+            value: {
+              name: 'logGroup2',
+              arn: 'arn:partition:service:region:account-id456:loggroup:someotherloggroup',
+            },
+          },
+        ],
+      } as LogGroupsResponse;
+    });
+
+    render(<LogGroupsSelector {...defaultProps} fetchLogGroups={fetchLogGroups} />);
+    await userEvent.click(screen.getByText('Select log groups'));
+
+    await waitFor(() => expect(screen.getByText('logGroup1')).toBeInTheDocument());
+    expect(screen.getByText('Load more')).toBeInTheDocument();
+    expect(screen.queryByText('logGroup2')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('Load more'));
+
+    await waitFor(() => expect(screen.getByText('logGroup2')).toBeInTheDocument());
+    expect(screen.getByText('logGroup1')).toBeInTheDocument();
+    expect(fetchLogGroups).toBeCalledTimes(2);
+    expect(fetchLogGroups).toHaveBeenLastCalledWith({
+      logGroupPattern: '',
+      accountId: 'all',
+      nextToken: 'page2_token',
+    });
+  });
+
+  it('should not show Load more button when nextToken is not present', async () => {
+    render(<LogGroupsSelector {...defaultProps} />);
+    await userEvent.click(screen.getByText('Select log groups'));
+    await waitFor(() => expect(screen.getByText('logGroup1')).toBeInTheDocument());
+    expect(screen.queryByText('Load more')).not.toBeInTheDocument();
   });
 });

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.test.tsx
@@ -326,7 +326,7 @@ describe('LogGroupsSelector', () => {
     waitFor(() => expect(screen.queryByText('Account Name 123')).not.toBeInTheDocument());
   });
 
-  it('should show Load more button when nextToken is present and append results on click', async () => {
+  it('should show Load more button when cursorNext is present and append results on click', async () => {
     let callCount = 0;
     const fetchLogGroups = jest.fn(async () => {
       callCount++;
@@ -341,7 +341,7 @@ describe('LogGroupsSelector', () => {
               },
             },
           ],
-          nextToken: 'page2_token',
+          cursorNext: 'page2_token',
         } as LogGroupsResponse;
       }
       return {
@@ -372,11 +372,11 @@ describe('LogGroupsSelector', () => {
     expect(fetchLogGroups).toHaveBeenLastCalledWith({
       logGroupPattern: '',
       accountId: 'all',
-      nextToken: 'page2_token',
+      cursorNext: 'page2_token',
     });
   });
 
-  it('should not show Load more button when nextToken is not present', async () => {
+  it('should not show Load more button when cursorNext is not present', async () => {
     render(<LogGroupsSelector {...defaultProps} />);
     await userEvent.click(screen.getByText('Select log groups'));
     await waitFor(() => expect(screen.getByText('logGroup1')).toBeInTheDocument());
@@ -398,7 +398,7 @@ describe('LogGroupsSelector', () => {
               },
             },
           ],
-          nextToken: 'page2_token',
+          cursorNext: 'page2_token',
         } as LogGroupsResponse;
       }
       throw new Error('network error');

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.tsx
@@ -15,6 +15,8 @@ import {
   useStyles2,
 } from '@grafana/ui';
 
+import { useAppNotification } from 'app/core/copy/appNotification';
+
 import { type LogGroup } from '../../../dataquery.gen';
 import { type DescribeLogGroupsRequest, type LogGroupsResponse } from '../../../resources/types';
 import getStyles from '../../styles';
@@ -48,6 +50,7 @@ export const LogGroupsSelector = ({
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [nextToken, setNextToken] = useState<string | undefined>();
   const styles = useStyles2(getStyles);
+  const notifyApp = useAppNotification();
   const selectedLogGroupsCounter = useMemo(
     () => selectedLogGroups.filter((lg) => !lg.name?.startsWith('$')).length,
     [selectedLogGroups]
@@ -130,7 +133,7 @@ export const LogGroupsSelector = ({
       ]);
       setNextToken(response.nextToken);
     } catch (err) {
-      // keep existing results on error
+      notifyApp.error('Failed to load more log groups. Please try again.');
     }
     setIsLoadingMore(false);
   };

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.tsx
@@ -16,7 +16,7 @@ import {
 } from '@grafana/ui';
 
 import { type LogGroup } from '../../../dataquery.gen';
-import { type DescribeLogGroupsRequest, type ResourceResponse, type LogGroupResponse } from '../../../resources/types';
+import { type DescribeLogGroupsRequest, type LogGroupsResponse } from '../../../resources/types';
 import getStyles from '../../styles';
 import { Account, ALL_ACCOUNTS_OPTION } from '../Account';
 
@@ -25,7 +25,7 @@ import Search from './Search';
 type CrossAccountLogsQueryProps = {
   selectedLogGroups?: LogGroup[];
   accountOptions?: Array<SelectableValue<string>>;
-  fetchLogGroups: (params: Partial<DescribeLogGroupsRequest>) => Promise<Array<ResourceResponse<LogGroupResponse>>>;
+  fetchLogGroups: (params: Partial<DescribeLogGroupsRequest>) => Promise<LogGroupsResponse>;
   variables?: string[];
   onChange: (selectedLogGroups: LogGroup[]) => void;
   onBeforeOpen?: () => void;
@@ -45,6 +45,8 @@ export const LogGroupsSelector = ({
   const [searchPhrase, setSearchPhrase] = useState('');
   const [searchAccountId, setSearchAccountId] = useState(ALL_ACCOUNTS_OPTION.value);
   const [isLoading, setIsLoading] = useState(false);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [nextToken, setNextToken] = useState<string | undefined>();
   const styles = useStyles2(getStyles);
   const selectedLogGroupsCounter = useMemo(
     () => selectedLogGroups.filter((lg) => !lg.name?.startsWith('$')).length,
@@ -85,23 +87,52 @@ export const LogGroupsSelector = ({
 
   const searchFn = async (searchTerm?: string, accountId?: string) => {
     setIsLoading(true);
+    setNextToken(undefined);
     try {
-      const possibleLogGroups = await fetchLogGroups({
+      const response = await fetchLogGroups({
         logGroupPattern: searchTerm,
         accountId: accountId,
       });
       setSelectableLogGroups(
-        possibleLogGroups.map((lg) => ({
+        response.results.map((lg) => ({
           arn: lg.value.arn,
           name: lg.value.name,
           accountId: lg.accountId,
           accountLabel: lg.accountId ? accountNameById[lg.accountId] : undefined,
         }))
       );
+      setNextToken(response.nextToken);
     } catch (err) {
       setSelectableLogGroups([]);
     }
     setIsLoading(false);
+  };
+
+  const loadMore = async () => {
+    if (!nextToken) {
+      return;
+    }
+    setIsLoadingMore(true);
+    try {
+      const response = await fetchLogGroups({
+        logGroupPattern: searchPhrase,
+        accountId: searchAccountId,
+        nextToken,
+      });
+      setSelectableLogGroups((prev) => [
+        ...prev,
+        ...response.results.map((lg) => ({
+          arn: lg.value.arn,
+          name: lg.value.name,
+          accountId: lg.accountId,
+          accountLabel: lg.accountId ? accountNameById[lg.accountId] : undefined,
+        })),
+      ]);
+      setNextToken(response.nextToken);
+    } catch (err) {
+      // keep existing results on error
+    }
+    setIsLoadingMore(false);
   };
 
   const handleSelectCheckbox = (row: LogGroup, isChecked: boolean) => {
@@ -149,12 +180,11 @@ export const LogGroupsSelector = ({
         </div>
         <Space layout="block" v={2} />
         <div>
-          {!isLoading && selectableLogGroups.length >= 25 && (
+          {!isLoading && !nextToken && selectableLogGroups.length >= 25 && (
             <>
               <div className={styles.limitLabel}>
                 <Icon name="info-circle"></Icon>
-                Only the first 50 results can be shown. If you do not see an expected log group, try narrowing down your
-                search.
+                If you do not see an expected log group, try narrowing down your search.
                 <p>
                   A{' '}
                   <TextLink
@@ -214,6 +244,14 @@ export const LogGroupsSelector = ({
               </tbody>
             </table>
           </div>
+          {!isLoading && nextToken && (
+            <>
+              <Space layout="block" v={1} />
+              <Button variant="secondary" onClick={loadMore} disabled={isLoadingMore} type="button" fill="text">
+                {isLoadingMore ? 'Loading...' : 'Load more'}
+              </Button>
+            </>
+          )}
         </div>
         <Space layout="block" v={2} />
         <Label className={styles.logGroupCountLabel}>

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.tsx
@@ -14,7 +14,6 @@ import {
   TextLink,
   useStyles2,
 } from '@grafana/ui';
-
 import { useAppNotification } from 'app/core/copy/appNotification';
 
 import { type LogGroup } from '../../../dataquery.gen';
@@ -48,7 +47,7 @@ export const LogGroupsSelector = ({
   const [searchAccountId, setSearchAccountId] = useState(ALL_ACCOUNTS_OPTION.value);
   const [isLoading, setIsLoading] = useState(false);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
-  const [nextToken, setNextToken] = useState<string | undefined>();
+  const [cursorNext, setCursorNext] = useState<string | undefined>();
   const styles = useStyles2(getStyles);
   const notifyApp = useAppNotification();
   const selectedLogGroupsCounter = useMemo(
@@ -90,7 +89,7 @@ export const LogGroupsSelector = ({
 
   const searchFn = async (searchTerm?: string, accountId?: string) => {
     setIsLoading(true);
-    setNextToken(undefined);
+    setCursorNext(undefined);
     try {
       const response = await fetchLogGroups({
         logGroupPattern: searchTerm,
@@ -104,7 +103,7 @@ export const LogGroupsSelector = ({
           accountLabel: lg.accountId ? accountNameById[lg.accountId] : undefined,
         }))
       );
-      setNextToken(response.nextToken);
+      setCursorNext(response.cursorNext);
     } catch (err) {
       setSelectableLogGroups([]);
     }
@@ -112,7 +111,7 @@ export const LogGroupsSelector = ({
   };
 
   const loadMore = async () => {
-    if (!nextToken) {
+    if (!cursorNext) {
       return;
     }
     setIsLoadingMore(true);
@@ -120,7 +119,7 @@ export const LogGroupsSelector = ({
       const response = await fetchLogGroups({
         logGroupPattern: searchPhrase,
         accountId: searchAccountId,
-        nextToken,
+        cursorNext,
       });
       setSelectableLogGroups((prev) => [
         ...prev,
@@ -131,7 +130,7 @@ export const LogGroupsSelector = ({
           accountLabel: lg.accountId ? accountNameById[lg.accountId] : undefined,
         })),
       ]);
-      setNextToken(response.nextToken);
+      setCursorNext(response.cursorNext);
     } catch (err) {
       notifyApp.error('Failed to load more log groups. Please try again.');
     }
@@ -183,7 +182,7 @@ export const LogGroupsSelector = ({
         </div>
         <Space layout="block" v={2} />
         <div>
-          {!isLoading && !nextToken && selectableLogGroups.length >= 25 && (
+          {!isLoading && !cursorNext && selectableLogGroups.length >= 25 && (
             <>
               <div className={styles.limitLabel}>
                 <Icon name="info-circle"></Icon>
@@ -247,7 +246,7 @@ export const LogGroupsSelector = ({
               </tbody>
             </table>
           </div>
-          {!isLoading && nextToken && (
+          {!isLoading && cursorNext && (
             <>
               <Space layout="block" v={1} />
               <Button variant="secondary" onClick={loadMore} disabled={isLoadingMore} type="button" fill="text">

--- a/public/app/plugins/datasource/cloudwatch/mocks/CloudWatchDataSource.ts
+++ b/public/app/plugins/datasource/cloudwatch/mocks/CloudWatchDataSource.ts
@@ -126,7 +126,7 @@ export function setupMockedDataSource({
   datasource.resources.getDimensionKeys = jest.fn().mockResolvedValue([]);
   datasource.resources.getMetrics = jest.fn().mockResolvedValue([]);
   datasource.resources.getAccounts = jest.fn().mockResolvedValue([]);
-  datasource.resources.getLogGroups = jest.fn().mockResolvedValue([]);
+  datasource.resources.getLogGroups = jest.fn().mockResolvedValue({ results: [] });
   datasource.resources.isMonitoringAccount = jest.fn().mockResolvedValue(false);
   const fetchMock = jest.fn().mockReturnValue(of({}));
   setBackendSrv({

--- a/public/app/plugins/datasource/cloudwatch/mocks/ResourcesAPI.ts
+++ b/public/app/plugins/datasource/cloudwatch/mocks/ResourcesAPI.ts
@@ -1,3 +1,5 @@
+import { of } from 'rxjs';
+
 import { type CustomVariableModel } from '@grafana/data';
 import { getBackendSrv, setBackendSrv } from '@grafana/runtime';
 
@@ -9,9 +11,11 @@ export function setupMockedResourcesAPI({
   variables,
   response,
   getMock,
+  fetchResponse,
 }: {
   getMock?: jest.Mock;
   response?: unknown;
+  fetchResponse?: { data?: unknown; headers?: Headers };
   variables?: CustomVariableModel[];
   mockGetVariableName?: boolean;
 } = {}) {
@@ -19,10 +23,20 @@ export function setupMockedResourcesAPI({
 
   const api = new ResourcesAPI(CloudWatchSettings, templateService);
   let resourceRequestMock = getMock ? getMock : jest.fn().mockReturnValue(response);
+  const fetchMock = jest.fn().mockReturnValue(
+    of({
+      data: fetchResponse?.data ?? response,
+      headers: fetchResponse?.headers ?? new Headers(),
+      status: 200,
+      ok: true,
+      config: { url: '' },
+    })
+  );
   setBackendSrv({
     ...getBackendSrv(),
     get: resourceRequestMock,
+    fetch: fetchMock,
   });
 
-  return { api, resourceRequestMock, templateService };
+  return { api, resourceRequestMock, fetchMock, templateService };
 }

--- a/public/app/plugins/datasource/cloudwatch/resources/ResourceAPI.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/resources/ResourceAPI.test.ts
@@ -11,47 +11,32 @@ describe('ResourcesAPI', () => {
       expect(resourceRequestMock.mock.calls[1][1].region).toBe('eu-east');
     });
 
-    it('should return log groups as an array of options', async () => {
-      const response = [
-        {
-          text: '/aws/containerinsights/dev303-workshop/application',
-          value: '/aws/containerinsights/dev303-workshop/application',
-          label: '/aws/containerinsights/dev303-workshop/application',
-        },
-        {
-          text: '/aws/containerinsights/dev303-workshop/flowlogs',
-          value: '/aws/containerinsights/dev303-workshop/flowlogs',
-          label: '/aws/containerinsights/dev303-workshop/flowlogs',
-        },
-        {
-          text: '/aws/containerinsights/dev303-workshop/dataplane',
-          value: '/aws/containerinsights/dev303-workshop/dataplane',
-          label: '/aws/containerinsights/dev303-workshop/dataplane',
-        },
-      ];
+    it('should return log groups response with results', async () => {
+      const response = {
+        results: [
+          {
+            value: {
+              arn: 'arn:aws:logs:us-west-1:123456789:log-group:/aws/containerinsights/dev303-workshop/application',
+              name: '/aws/containerinsights/dev303-workshop/application',
+            },
+          },
+          {
+            value: {
+              arn: 'arn:aws:logs:us-west-1:123456789:log-group:/aws/containerinsights/dev303-workshop/flowlogs',
+              name: '/aws/containerinsights/dev303-workshop/flowlogs',
+            },
+          },
+        ],
+        nextToken: 'some_token',
+      };
 
       const { api } = setupMockedResourcesAPI({ response });
-      const expectedLogGroups = [
-        {
-          text: '/aws/containerinsights/dev303-workshop/application',
-          value: '/aws/containerinsights/dev303-workshop/application',
-          label: '/aws/containerinsights/dev303-workshop/application',
-        },
-        {
-          text: '/aws/containerinsights/dev303-workshop/flowlogs',
-          value: '/aws/containerinsights/dev303-workshop/flowlogs',
-          label: '/aws/containerinsights/dev303-workshop/flowlogs',
-        },
-        {
-          text: '/aws/containerinsights/dev303-workshop/dataplane',
-          value: '/aws/containerinsights/dev303-workshop/dataplane',
-          label: '/aws/containerinsights/dev303-workshop/dataplane',
-        },
-      ];
 
       const logGroups = await api.getLogGroups({ region: 'default' });
 
-      expect(logGroups).toEqual(expectedLogGroups);
+      expect(logGroups).toEqual(response);
+      expect(logGroups.results).toHaveLength(2);
+      expect(logGroups.nextToken).toBe('some_token');
     });
   });
 

--- a/public/app/plugins/datasource/cloudwatch/resources/ResourceAPI.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/resources/ResourceAPI.test.ts
@@ -11,6 +11,13 @@ describe('ResourcesAPI', () => {
       expect(fetchMock.mock.calls[1][0].params.region).toBe('eu-east');
     });
 
+    it('should not set cursor-next header when cursorNext is not provided', async () => {
+      const { api, fetchMock } = setupMockedResourcesAPI();
+      await api.getLogGroups({ region: 'default' });
+      const call = fetchMock.mock.calls[0][0];
+      expect(call.headers).toBeUndefined();
+    });
+
     it('should return log groups response with results', async () => {
       const logGroupsData = [
         {

--- a/public/app/plugins/datasource/cloudwatch/resources/ResourceAPI.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/resources/ResourceAPI.test.ts
@@ -3,38 +3,37 @@ import { setupMockedResourcesAPI } from '../mocks/ResourcesAPI';
 describe('ResourcesAPI', () => {
   describe('describeLogGroup', () => {
     it('replaces region correctly in the query', async () => {
-      const { api, resourceRequestMock } = setupMockedResourcesAPI();
+      const { api, fetchMock } = setupMockedResourcesAPI();
       await api.getLogGroups({ region: 'default' });
-      expect(resourceRequestMock.mock.calls[0][1].region).toBe('us-west-1');
+      expect(fetchMock.mock.calls[0][0].params.region).toBe('us-west-1');
 
       await api.getLogGroups({ region: 'eu-east' });
-      expect(resourceRequestMock.mock.calls[1][1].region).toBe('eu-east');
+      expect(fetchMock.mock.calls[1][0].params.region).toBe('eu-east');
     });
 
     it('should return log groups response with results', async () => {
-      const response = {
-        results: [
-          {
-            value: {
-              arn: 'arn:aws:logs:us-west-1:123456789:log-group:/aws/containerinsights/dev303-workshop/application',
-              name: '/aws/containerinsights/dev303-workshop/application',
-            },
+      const logGroupsData = [
+        {
+          value: {
+            arn: 'arn:aws:logs:us-west-1:123456789:log-group:/aws/containerinsights/dev303-workshop/application',
+            name: '/aws/containerinsights/dev303-workshop/application',
           },
-          {
-            value: {
-              arn: 'arn:aws:logs:us-west-1:123456789:log-group:/aws/containerinsights/dev303-workshop/flowlogs',
-              name: '/aws/containerinsights/dev303-workshop/flowlogs',
-            },
+        },
+        {
+          value: {
+            arn: 'arn:aws:logs:us-west-1:123456789:log-group:/aws/containerinsights/dev303-workshop/flowlogs',
+            name: '/aws/containerinsights/dev303-workshop/flowlogs',
           },
-        ],
-        cursorNext: 'some_token',
-      };
+        },
+      ];
 
-      const { api } = setupMockedResourcesAPI({ response });
+      const { api } = setupMockedResourcesAPI({
+        fetchResponse: { data: logGroupsData, headers: new Headers({ 'cursor-next': 'some_token' }) },
+      });
 
       const logGroups = await api.getLogGroups({ region: 'default' });
 
-      expect(logGroups).toEqual(response);
+      expect(logGroups).toEqual({ results: logGroupsData, cursorNext: 'some_token' });
       expect(logGroups.results).toHaveLength(2);
       expect(logGroups.cursorNext).toBe('some_token');
     });

--- a/public/app/plugins/datasource/cloudwatch/resources/ResourceAPI.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/resources/ResourceAPI.test.ts
@@ -27,7 +27,7 @@ describe('ResourcesAPI', () => {
             },
           },
         ],
-        nextToken: 'some_token',
+        cursorNext: 'some_token',
       };
 
       const { api } = setupMockedResourcesAPI({ response });
@@ -36,7 +36,7 @@ describe('ResourcesAPI', () => {
 
       expect(logGroups).toEqual(response);
       expect(logGroups.results).toHaveLength(2);
-      expect(logGroups.nextToken).toBe('some_token');
+      expect(logGroups.cursorNext).toBe('some_token');
     });
   });
 

--- a/public/app/plugins/datasource/cloudwatch/resources/ResourcesAPI.ts
+++ b/public/app/plugins/datasource/cloudwatch/resources/ResourcesAPI.ts
@@ -12,6 +12,7 @@ import {
   type ResourceResponse,
   type DescribeLogGroupsRequest,
   type LogGroupResponse,
+  type LogGroupsResponse,
   type GetMetricsRequest,
   type GetDimensionKeysRequest,
   type GetDimensionValuesRequest,
@@ -69,13 +70,19 @@ export class ResourcesAPI extends CloudWatchRequest {
     );
   }
 
-  getLogGroups(params: DescribeLogGroupsRequest): Promise<Array<ResourceResponse<LogGroupResponse>>> {
-    return this.memoizedGetRequest<Array<ResourceResponse<LogGroupResponse>>>('log-groups', {
+  getLogGroups(params: DescribeLogGroupsRequest): Promise<LogGroupsResponse> {
+    const requestParams: Record<string, string | string[] | number> = {
       ...params,
       region: this.templateSrv.replace(this.getActualRegion(params.region)),
       accountId: this.templateSrv.replace(params.accountId),
       listAllLogGroups: params.listAllLogGroups ? 'true' : 'false',
-    });
+    };
+    // When nextToken is present, bypass memoized cache to avoid stale results
+    if (params.nextToken) {
+      requestParams.nextToken = params.nextToken;
+      return this.getRequest<LogGroupsResponse>('log-groups', requestParams);
+    }
+    return this.memoizedGetRequest<LogGroupsResponse>('log-groups', requestParams);
   }
 
   getLogGroupFields(region: string, logGroupName: string): Promise<Array<ResourceResponse<LogGroupField>>> {

--- a/public/app/plugins/datasource/cloudwatch/resources/ResourcesAPI.ts
+++ b/public/app/plugins/datasource/cloudwatch/resources/ResourcesAPI.ts
@@ -11,7 +11,6 @@ import {
   type Account,
   type ResourceResponse,
   type DescribeLogGroupsRequest,
-  type LogGroupResponse,
   type LogGroupsResponse,
   type GetMetricsRequest,
   type GetDimensionKeysRequest,

--- a/public/app/plugins/datasource/cloudwatch/resources/ResourcesAPI.ts
+++ b/public/app/plugins/datasource/cloudwatch/resources/ResourcesAPI.ts
@@ -37,10 +37,15 @@ export class ResourcesAPI extends CloudWatchRequest {
     return getBackendSrv().get(`/api/datasources/uid/${this.instanceSettings.uid}/resources/${subtype}`, parameters);
   }
 
-  private fetchRequest<T>(subtype: string, parameters?: Record<string, string | string[] | number>) {
+  private fetchRequest<T>(
+    subtype: string,
+    parameters?: Record<string, string | string[] | number>,
+    headers?: Record<string, string>
+  ) {
     return getBackendSrv().fetch<T>({
       url: `/api/datasources/uid/${this.instanceSettings.uid}/resources/${subtype}`,
       params: parameters,
+      headers,
     });
   }
 
@@ -80,17 +85,19 @@ export class ResourcesAPI extends CloudWatchRequest {
   }
 
   getLogGroups(params: DescribeLogGroupsRequest): Promise<LogGroupsResponse> {
+    const { cursorNext, ...restParams } = params;
     const requestParams: Record<string, string | string[] | number> = {
-      ...params,
+      ...restParams,
       region: this.templateSrv.replace(this.getActualRegion(params.region)),
       accountId: this.templateSrv.replace(params.accountId),
       listAllLogGroups: params.listAllLogGroups ? 'true' : 'false',
     };
-    if (params.cursorNext) {
-      requestParams.cursorNext = params.cursorNext;
-    }
     return lastValueFrom(
-      this.fetchRequest<Array<ResourceResponse<LogGroupResponse>>>('log-groups', requestParams).pipe(
+      this.fetchRequest<Array<ResourceResponse<LogGroupResponse>>>(
+        'log-groups',
+        requestParams,
+        cursorNext ? { 'cursor-next': cursorNext } : undefined
+      ).pipe(
         map((response) => ({
           results: response.data,
           cursorNext: response.headers.get('cursor-next') ?? undefined,

--- a/public/app/plugins/datasource/cloudwatch/resources/ResourcesAPI.ts
+++ b/public/app/plugins/datasource/cloudwatch/resources/ResourcesAPI.ts
@@ -13,6 +13,7 @@ import {
   type Account,
   type ResourceResponse,
   type DescribeLogGroupsRequest,
+  type LogGroupResponse,
   type LogGroupsResponse,
   type GetMetricsRequest,
   type GetDimensionKeysRequest,
@@ -89,9 +90,9 @@ export class ResourcesAPI extends CloudWatchRequest {
       requestParams.cursorNext = params.cursorNext;
     }
     return lastValueFrom(
-      this.fetchRequest<LogGroupsResponse>('log-groups', requestParams).pipe(
+      this.fetchRequest<Array<ResourceResponse<LogGroupResponse>>>('log-groups', requestParams).pipe(
         map((response) => ({
-          results: response.data.results,
+          results: response.data,
           cursorNext: response.headers.get('cursor-next') ?? undefined,
         }))
       )

--- a/public/app/plugins/datasource/cloudwatch/resources/ResourcesAPI.ts
+++ b/public/app/plugins/datasource/cloudwatch/resources/ResourcesAPI.ts
@@ -1,4 +1,6 @@
 import { memoize } from 'lodash';
+import { lastValueFrom } from 'rxjs';
+import { map } from 'rxjs/operators';
 
 import { type DataSourceInstanceSettings, type SelectableValue } from '@grafana/data';
 import { getBackendSrv, type TemplateSrv } from '@grafana/runtime';
@@ -32,6 +34,13 @@ export class ResourcesAPI extends CloudWatchRequest {
 
   private getRequest<T>(subtype: string, parameters?: Record<string, string | string[] | number>): Promise<T> {
     return getBackendSrv().get(`/api/datasources/uid/${this.instanceSettings.uid}/resources/${subtype}`, parameters);
+  }
+
+  private fetchRequest<T>(subtype: string, parameters?: Record<string, string | string[] | number>) {
+    return getBackendSrv().fetch<T>({
+      url: `/api/datasources/uid/${this.instanceSettings.uid}/resources/${subtype}`,
+      params: parameters,
+    });
   }
 
   async getExternalId(): Promise<string> {
@@ -76,12 +85,17 @@ export class ResourcesAPI extends CloudWatchRequest {
       accountId: this.templateSrv.replace(params.accountId),
       listAllLogGroups: params.listAllLogGroups ? 'true' : 'false',
     };
-    // When nextToken is present, bypass memoized cache to avoid stale results
-    if (params.nextToken) {
-      requestParams.nextToken = params.nextToken;
-      return this.getRequest<LogGroupsResponse>('log-groups', requestParams);
+    if (params.cursorNext) {
+      requestParams.cursorNext = params.cursorNext;
     }
-    return this.memoizedGetRequest<LogGroupsResponse>('log-groups', requestParams);
+    return lastValueFrom(
+      this.fetchRequest<LogGroupsResponse>('log-groups', requestParams).pipe(
+        map((response) => ({
+          results: response.data.results,
+          cursorNext: response.headers.get('cursor-next') ?? undefined,
+        }))
+      )
+    );
   }
 
   getLogGroupFields(region: string, logGroupName: string): Promise<Array<ResourceResponse<LogGroupField>>> {

--- a/public/app/plugins/datasource/cloudwatch/resources/types.ts
+++ b/public/app/plugins/datasource/cloudwatch/resources/types.ts
@@ -35,6 +35,7 @@ export interface DescribeLogGroupsRequest extends ResourceRequest {
   limit?: number;
   listAllLogGroups?: boolean;
   accountId?: string;
+  nextToken?: string;
 }
 
 export interface Account {
@@ -56,6 +57,11 @@ export interface MetricResponse {
 
 export interface RegionResponse {
   name: string;
+}
+
+export interface LogGroupsResponse {
+  results: Array<ResourceResponse<LogGroupResponse>>;
+  nextToken?: string;
 }
 
 export interface SelectableResourceValue extends SelectableValue<string> {

--- a/public/app/plugins/datasource/cloudwatch/resources/types.ts
+++ b/public/app/plugins/datasource/cloudwatch/resources/types.ts
@@ -35,7 +35,7 @@ export interface DescribeLogGroupsRequest extends ResourceRequest {
   limit?: number;
   listAllLogGroups?: boolean;
   accountId?: string;
-  nextToken?: string;
+  cursorNext?: string;
 }
 
 export interface Account {
@@ -61,7 +61,7 @@ export interface RegionResponse {
 
 export interface LogGroupsResponse {
   results: Array<ResourceResponse<LogGroupResponse>>;
-  nextToken?: string;
+  cursorNext?: string;
 }
 
 export interface SelectableResourceValue extends SelectableValue<string> {

--- a/public/app/plugins/datasource/cloudwatch/variables.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/variables.test.ts
@@ -27,7 +27,7 @@ const getEc2InstanceAttribute = jest.fn().mockResolvedValue([{ label: 'g', value
 const getResourceARNs = jest.fn().mockResolvedValue([{ label: 'h', value: 'h' }]);
 const getLogGroups = jest
   .fn()
-  .mockResolvedValue([{ value: { arn: 'a', name: 'a' } }, { value: { arn: 'b', name: 'b' } }]);
+  .mockResolvedValue({ results: [{ value: { arn: 'a', name: 'a' } }, { value: { arn: 'b', name: 'b' } }] });
 
 const variables = new CloudWatchVariableSupport(mock.datasource.resources);
 

--- a/public/app/plugins/datasource/cloudwatch/variables.ts
+++ b/public/app/plugins/datasource/cloudwatch/variables.ts
@@ -71,8 +71,8 @@ export class CloudWatchVariableSupport extends CustomVariableSupport<CloudWatchD
         logGroupNamePrefix: interpolatedPrefix,
         listAllLogGroups: true,
       })
-      .then((logGroups) =>
-        logGroups.map((lg) => {
+      .then((response) =>
+        response.results.map((lg) => {
           return {
             text: lg.value.name,
             value: lg.value.arn,


### PR DESCRIPTION
**Copied from Pull Request** https://github.com/grafana/grafana/pull/121391

> The log groups selector modal was limited to displaying only the first 50 results due to the AWS DescribeLogGroups API page size limit. Users with many log groups across multiple accounts could not access groups beyond the first page.
> 
> This adds cursor-based pagination using the AWS NextToken:
> - Backend: Accepts nextToken in requests and returns it in responses
> - Frontend: Adds a "Load more" button that appends additional results
> - The listAllLogGroups=true path (used by variable queries) is unchanged
> 
> Closes #118097

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #118097

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
