### PR TITLE
chore: add overload to replaceCachedPromise

### DIFF
--- a/packages/grafana-runtime/src/utils/getCachedPromise.test.ts
+++ b/packages/grafana-runtime/src/utils/getCachedPromise.test.ts
@@ -907,7 +907,7 @@ describe('cached promises', () => {
       const replacement = { ok: true, status: 201, statusText: 'replaced' };
 
       await getCachedPromise(simulateOkRequest, { cacheKey: 'the-key' });
-      replaceCachedPromise(simulateOkRequest, replacement, { cacheKey: 'the-key' });
+      replaceCachedPromise('the-key', replacement);
       const actual = await getCachedPromise(simulateOkRequest, { cacheKey: 'the-key' });
 
       expect(actual).toBe(replacement);
@@ -941,23 +941,23 @@ describe('cached promises', () => {
       expect(b1).toBe(b2);
     });
 
-    test('should throw when called with an anonymous function and no cacheKey', () => {
+    test('should throw when called with an anonymous function', () => {
       expect(() => replaceCachedPromise(async () => 2, 99)).toThrow(
         'replaceCachedPromise function must be invoked with a named function or cacheKey'
       );
     });
 
-    test('should not throw when called with an anonymous function and a cacheKey', () => {
-      expect(() => replaceCachedPromise(async () => 2, 99, { cacheKey: 'a-cache-key' })).not.toThrow();
+    test('should not throw when called with a cacheKey', () => {
+      expect(() => replaceCachedPromise('a-cache-key', 99)).not.toThrow();
     });
 
-    test('should prefer cacheKey over the key derived from the function', async () => {
+    test('cacheKey overload only affects entries under that key', async () => {
       const replacement = { ok: false, status: 500, statusText: 'replaced' };
 
       const a1 = await getCachedPromise(simulateOkRequest);
       const b1 = await getCachedPromise(simulateOkRequest, { cacheKey: 'explicit-key' });
 
-      replaceCachedPromise(simulateOkRequest, replacement, { cacheKey: 'explicit-key' });
+      replaceCachedPromise('explicit-key', replacement);
 
       const a2 = await getCachedPromise(simulateOkRequest);
       const b2 = await getCachedPromise(simulateOkRequest, { cacheKey: 'explicit-key' });

--- a/packages/grafana-runtime/src/utils/getCachedPromise.ts
+++ b/packages/grafana-runtime/src/utils/getCachedPromise.ts
@@ -316,26 +316,32 @@ export function invalidateCachedPromise<T>(promise: PromiseFunction<T>, options?
  * Replaces the cached promise entry with an already-resolved value, so subsequent reads with the
  * same key return `updatedValue` without re-invoking the function.
  *
- * The key is derived from the promise function's name and body via {@link getCacheKeyFromPromise},
- * unless an explicit `cacheKey` is provided — in which case it takes precedence and `promise` is
- * only used for type inference.
- *
+ * The key is derived from the promise function's name and body via {@link getCacheKeyFromPromise}.
  * Adds the entry even when no prior value was cached for the key.
  *
  * @template T - The type of the resolved promise value
  * @param promise - The promise-returning function whose cache entry should be replaced. Inline
- *   arrow functions are anonymous and require an explicit `cacheKey` — or assign the arrow to a
- *   `const` first so name inference applies.
+ *   arrow functions are anonymous and will be rejected — use the `cacheKey` overload instead, or
+ *   assign the arrow to a `const` first so name inference applies.
  * @param updatedValue - The resolved value to cache. Subsequent cache reads with the same
  *   key will resolve to this value without re-invoking the function.
- * @param options - Optional options object
- * @param options.cacheKey - Optional explicit cache key. When provided, takes precedence over the key
- *   derived from `promise`.
- * @throws {Error} when neither a named function nor a `cacheKey` is supplied
+ * @throws {Error} when the function is anonymous
  */
-export function replaceCachedPromise<T>(promise: PromiseFunction<T>, updatedValue: T, options?: CacheKeyOptions): void {
-  const { cacheKey } = options ?? {};
-  const key = cacheKey ?? getCacheKeyFromPromise(promise);
+export function replaceCachedPromise<T>(promise: PromiseFunction<T>, updatedValue: T): void;
+/**
+ * Replaces the cached promise entry with an already-resolved value, so subsequent reads with the
+ * same key return `updatedValue` without re-invoking the function.
+ *
+ * Adds the entry even when no prior value was cached for the key.
+ *
+ * @param cacheKey - The explicit cache key for the entry to replace.
+ * @param updatedValue - The resolved value to cache. Subsequent cache reads with the same
+ *   key will resolve to this value without re-invoking the function.
+ * @throws {Error} when `cacheKey` is empty
+ */
+export function replaceCachedPromise(cacheKey: string, updatedValue: unknown): void;
+export function replaceCachedPromise(promiseOrKey: PromiseFunction<unknown> | string, updatedValue: unknown): void {
+  const key = typeof promiseOrKey === 'string' ? promiseOrKey : getCacheKeyFromPromise(promiseOrKey);
 
   if (!key) {
     throw new Error(`replaceCachedPromise function must be invoked with a named function or cacheKey`);


### PR DESCRIPTION
**What is this feature?**

Adds a `cacheKey` overload to `replaceCachedPromise` so callers can replace a cache entry by key without passing the original promise function.

```ts
// before
replaceCachedPromise(fetchPlugin, replacement, { cacheKey: 'plugin-id' });

// after
replaceCachedPromise('plugin-id', replacement);
```

**Why do we need this feature?**

So callers that already have a cache key don't need to drag the original function along just for type inference.

**Who is this feature for?**

Grafana devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
