### PR TITLE
BrowseDashboards: Fix cleared sort reset when switching to folder view

### DIFF
--- a/public/app/features/search/state/SearchStateManager.test.ts
+++ b/public/app/features/search/state/SearchStateManager.test.ts
@@ -213,4 +213,58 @@ describe('SearchStateManager', () => {
       await waitFor(() => expect(stm.state.result?.totalRows).toEqual(10));
     });
   });
+
+  describe('onLayoutChange', () => {
+    beforeEach(() => {
+      localStorage.clear();
+    });
+
+    it('does not resurrect a cleared sort when switching to Folders', () => {
+      store.set(SEARCH_SELECTED_LAYOUT, SearchLayout.List);
+      store.set(SEARCH_SELECTED_SORT, 'name_sort');
+      const stm = createSearchStateManager();
+      stm.initStateFromUrl(undefined, false);
+      expect(stm.state.sort).toBe('name_sort');
+      expect(stm.state.prevSort).toBe('name_sort');
+
+      // User clears the sort picker
+      stm.onSortChange(undefined);
+      expect(stm.state.sort).toBeUndefined();
+
+      // User switches to Folders — sort must stay cleared
+      stm.onLayoutChange(SearchLayout.Folders);
+      expect(stm.state.layout).toBe(SearchLayout.Folders);
+      expect(stm.state.sort).toBeUndefined();
+      expect(stm.state.prevSort).toBeUndefined();
+    });
+
+    it('round-trips sort through List → Folders → List via prevSort', () => {
+      const stm = createSearchStateManager();
+      stm.setState({ layout: SearchLayout.List, sort: 'name_sort' });
+
+      stm.onLayoutChange(SearchLayout.Folders);
+      expect(stm.state.sort).toBeUndefined();
+      expect(stm.state.prevSort).toBe('name_sort');
+
+      stm.onLayoutChange(SearchLayout.List);
+      expect(stm.state.sort).toBe('name_sort');
+    });
+
+    it('restores prevSort when switching to List with no current sort', () => {
+      const stm = createSearchStateManager();
+      stm.setState({ layout: SearchLayout.Folders, sort: undefined, prevSort: 'name_sort' });
+
+      stm.onLayoutChange(SearchLayout.List);
+      expect(stm.state.sort).toBe('name_sort');
+      expect(stm.state.layout).toBe(SearchLayout.List);
+    });
+
+    it('keeps current sort when switching to List if sort is already set', () => {
+      const stm = createSearchStateManager();
+      stm.setState({ layout: SearchLayout.Folders, sort: '-name_sort', prevSort: 'name_sort' });
+
+      stm.onLayoutChange(SearchLayout.List);
+      expect(stm.state.sort).toBe('-name_sort');
+    });
+  });
 });

--- a/public/app/features/search/state/SearchStateManager.ts
+++ b/public/app/features/search/state/SearchStateManager.ts
@@ -231,10 +231,12 @@ export class SearchStateManager extends StateManagerBase<SearchState> {
   onLayoutChange = (layout: SearchLayout) => {
     store.set(this.layoutStorageKey, layout);
 
-    if (this.state.sort && layout === SearchLayout.Folders) {
+    if (layout === SearchLayout.Folders) {
+      // Folders never has sort. Stash current sort so List can restore it later.
       this.setStateAndDoSearch({ layout, prevSort: this.state.sort, sort: undefined });
     } else {
-      this.setStateAndDoSearch({ layout, sort: this.state.prevSort });
+      // List: keep current sort if set, otherwise restore prevSort.
+      this.setStateAndDoSearch({ layout, sort: this.state.sort ?? this.state.prevSort });
     }
   };
 


### PR DESCRIPTION
**What is this feature?**

Fixes a bug in the Browse Dashboards page where clearing the Sort picker and then clicking "View by folders" would silently restore the previously cleared sort, forcing the user back into list view with the Folders radio disabled.

**Why do we need this feature?**

When a user explicitly clears a sort and switches to folder view, the cleared sort was resurrected via `prevSort` in `onLayoutChange`. This happened because the Folders branch only fired when `this.state.sort` was truthy — when sort was already cleared (`undefined`), the else branch ran instead and unconditionally restored `prevSort`. After reload, `prevSort` was populated from localStorage by `initStateFromUrl`, making this a one-click reproduction: pick a sort → reload → clear sort → click Folders → stuck in list view.

The fix makes `onLayoutChange` branch on `layout === SearchLayout.Folders` unconditionally (not `this.state.sort && layout === SearchLayout.Folders`), so switching to Folders always stashes `state.sort` into `prevSort` and clears sort — even when `state.sort` is already `undefined`. The List branch now uses `this.state.sort ?? this.state.prevSort` to preserve an active sort while still falling back to `prevSort` when no sort is set.
