### PR TITLE
Alerting: Save options tooltip values when closing by clicking outside

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/QueryOptions.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/QueryOptions.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 
 import { type GrafanaTheme2, type RelativeTimeRange, getDefaultRelativeTimeRange } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
@@ -28,14 +28,40 @@ export const QueryOptions = ({
   const styles = useStyles2(getStyles);
 
   const [showOptions, setShowOptions] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
 
   const separator = <span>, </span>;
+
+  const handleClose = useCallback(() => {
+    // When the toggletip closes (e.g. clicking outside), onBlur may not fire on inputs.
+    // Read current input values and commit them.
+    if (containerRef.current) {
+      const maxDataPointsInput = containerRef.current.querySelector<HTMLInputElement>('input[type="number"]');
+      const minIntervalInput = containerRef.current.querySelector<HTMLInputElement>('input[type="text"]');
+
+      let maxDataPoints: number | undefined = queryOptions.maxDataPoints;
+      let minInterval: string | undefined = queryOptions.minInterval;
+
+      if (maxDataPointsInput) {
+        const parsed = parseInt(maxDataPointsInput.value, 10);
+        maxDataPoints = isNaN(parsed) || parsed === 0 ? undefined : parsed;
+      }
+
+      if (minIntervalInput) {
+        minInterval = minIntervalInput.value || undefined;
+      }
+
+      if (maxDataPoints !== queryOptions.maxDataPoints || minInterval !== queryOptions.minInterval) {
+        onChangeQueryOptions({ maxDataPoints, minInterval }, index);
+      }
+    }
+  }, [queryOptions, onChangeQueryOptions, index]);
 
   return (
     <>
       <Toggletip
         content={
-          <div className={styles.queryOptions}>
+          <div className={styles.queryOptions} ref={containerRef}>
             {onChangeTimeRange && (
               <InlineField label={t('alerting.query-options.label-time-range', 'Time Range')}>
                 <RelativeTimeRangePicker
@@ -48,6 +74,7 @@ export const QueryOptions = ({
             <MinIntervalOption options={queryOptions} onChange={(options) => onChangeQueryOptions(options, index)} />
           </div>
         }
+        onClose={handleClose}
         closeButton={true}
         placement="bottom-start"
       >


### PR DESCRIPTION
## Summary

- Fixes the alerting options tooltip (next to the datasource selector) not saving interval/max data points values when the tooltip is closed by clicking outside
- The root cause is that `onBlur` on the inputs does not fire when the Toggletip is dismissed by clicking outside, since the popover is removed from the DOM before the blur event propagates
- Adds an `onClose` handler to the Toggletip that reads the current input values from the DOM and commits any changes

## Test plan

- [ ] Open the alert rule editor, click "Options" next to a data source query
- [ ] Change the "Max data points" or "Interval" value
- [ ] Click outside the tooltip to close it (do NOT press Enter or Tab first)
- [ ] Verify the value is saved and displayed in the options summary
- [ ] Verify that closing via the X button also saves the value
- [ ] Verify that tabbing out of the input (triggering onBlur) still works as before

Fixes #111664