### PR TITLE
Unified storage: Retry batched WithTx on MySQL/Postgres deadlocks

### DIFF
--- a/pkg/storage/unified/sql/rvmanager/retryable.go
+++ b/pkg/storage/unified/sql/rvmanager/retryable.go
@@ -1,0 +1,65 @@
+package rvmanager
+
+import (
+	"errors"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/lib/pq"
+
+	"github.com/grafana/grafana/pkg/util/sqlite"
+)
+
+// MySQL error numbers for transactional conflicts that the engine has already
+// rolled back, so the whole WithTx body is safe to retry from the start.
+//   1213: ER_LOCK_DEADLOCK
+//   1205: ER_LOCK_WAIT_TIMEOUT
+// https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html
+const (
+	mysqlErrLockDeadlock    uint16 = 1213
+	mysqlErrLockWaitTimeout uint16 = 1205
+)
+
+// PostgreSQL SQLSTATE codes for transient, retryable transaction failures.
+//   40P01: deadlock_detected
+//   40001: serialization_failure
+// https://www.postgresql.org/docs/current/errcodes-appendix.html
+const (
+	postgresErrDeadlockDetected     = "40P01"
+	postgresErrSerializationFailure = "40001"
+)
+
+// isRetryableTxnError reports whether err represents a transient transactional
+// conflict where the engine has already rolled the transaction back. The
+// batched WithTx in execBatch is a closed loop (writes, RV lock, RV stamp), so
+// rolling back and re-running it from the start is safe for any of these.
+//
+// SQLite: busy/locked (delegated to sqlite.IsBusyOrLocked).
+// MySQL: 1213 deadlock, 1205 lock-wait timeout (InnoDB releases locks on rollback).
+// PostgreSQL: 40P01 deadlock_detected, 40001 serialization_failure.
+func isRetryableTxnError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if sqlite.IsBusyOrLocked(err) {
+		return true
+	}
+	var mysqlErr *mysql.MySQLError
+	if errors.As(err, &mysqlErr) {
+		switch mysqlErr.Number {
+		case mysqlErrLockDeadlock, mysqlErrLockWaitTimeout:
+			return true
+		}
+	}
+	var pgErr *pgconn.PgError
+	if errors.As(err, &pgErr) {
+		return pgErr.Code == postgresErrDeadlockDetected ||
+			pgErr.Code == postgresErrSerializationFailure
+	}
+	var pqErr *pq.Error
+	if errors.As(err, &pqErr) {
+		return string(pqErr.Code) == postgresErrDeadlockDetected ||
+			string(pqErr.Code) == postgresErrSerializationFailure
+	}
+	return false
+}

--- a/pkg/storage/unified/sql/rvmanager/retryable.go
+++ b/pkg/storage/unified/sql/rvmanager/retryable.go
@@ -12,8 +12,10 @@ import (
 
 // MySQL error numbers for transactional conflicts that the engine has already
 // rolled back, so the whole WithTx body is safe to retry from the start.
-//   1213: ER_LOCK_DEADLOCK
-//   1205: ER_LOCK_WAIT_TIMEOUT
+//
+//	1213: ER_LOCK_DEADLOCK
+//	1205: ER_LOCK_WAIT_TIMEOUT
+//
 // https://dev.mysql.com/doc/mysql-errors/8.0/en/server-error-reference.html
 const (
 	mysqlErrLockDeadlock    uint16 = 1213
@@ -21,8 +23,10 @@ const (
 )
 
 // PostgreSQL SQLSTATE codes for transient, retryable transaction failures.
-//   40P01: deadlock_detected
-//   40001: serialization_failure
+//
+//	40P01: deadlock_detected
+//	40001: serialization_failure
+//
 // https://www.postgresql.org/docs/current/errcodes-appendix.html
 const (
 	postgresErrDeadlockDetected     = "40P01"

--- a/pkg/storage/unified/sql/rvmanager/rv_manager.go
+++ b/pkg/storage/unified/sql/rvmanager/rv_manager.go
@@ -20,7 +20,6 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/sql/db"
 	"github.com/grafana/grafana/pkg/storage/unified/sql/dbutil"
 	"github.com/grafana/grafana/pkg/storage/unified/sql/sqltemplate"
-	"github.com/grafana/grafana/pkg/util/sqlite"
 )
 
 var tracer = otel.Tracer("github.com/grafana/grafana/pkg/storage/unified/sql/rvmanager")
@@ -70,12 +69,13 @@ const (
 	// [unified_storage] resource_version_batch_transaction_timeout ini key).
 	defaultBatchTimeout = 5 * time.Second
 
-	// SQLite serializes writes; under contention an INSERT/UPDATE can return
-	// SQLITE_BUSY even with the busy_timeout pragma. The transaction is rolled
-	// back, so the whole batched WithTx is safe to retry from the start.
-	sqliteBusyMaxRetries = 5
-	sqliteBusyMinBackoff = 50 * time.Millisecond
-	sqliteBusyMaxBackoff = 500 * time.Millisecond
+	// Bounded retry for transient transactional conflicts that leave the
+	// transaction rolled back (and therefore safe to re-run from the start):
+	// SQLite busy/locked, MySQL deadlock / lock-wait timeout, and PostgreSQL
+	// deadlock / serialization failures. See isRetryableTxnError.
+	txnRetryMaxRetries = 5
+	txnRetryMinBackoff = 50 * time.Millisecond
+	txnRetryMaxBackoff = 500 * time.Millisecond
 )
 
 // ResourceVersionManager handles resource version operations
@@ -379,14 +379,14 @@ func (m *ResourceVersionManager) execBatch(ctx context.Context, group, resource 
 	}
 
 	err = runBatch()
-	if err != nil && sqlite.IsBusyOrLocked(err) {
+	if err != nil && isRetryableTxnError(err) {
 		boff := backoff.New(ctx, backoff.Config{
-			MinBackoff: sqliteBusyMinBackoff,
-			MaxBackoff: sqliteBusyMaxBackoff,
-			MaxRetries: sqliteBusyMaxRetries,
+			MinBackoff: txnRetryMinBackoff,
+			MaxBackoff: txnRetryMaxBackoff,
+			MaxRetries: txnRetryMaxRetries,
 		})
 		for boff.Ongoing() {
-			span.AddEvent("batch_transaction_retry_sqlite_busy", trace.WithAttributes(
+			span.AddEvent("batch_transaction_retry", trace.WithAttributes(
 				attribute.Int("attempt", boff.NumRetries()+1),
 				attribute.String("error", err.Error()),
 			))
@@ -395,7 +395,7 @@ func (m *ResourceVersionManager) execBatch(ctx context.Context, group, resource 
 				break
 			}
 			err = runBatch()
-			if err == nil || !sqlite.IsBusyOrLocked(err) {
+			if err == nil || !isRetryableTxnError(err) {
 				break
 			}
 		}

--- a/pkg/storage/unified/sql/rvmanager/rv_manager_test.go
+++ b/pkg/storage/unified/sql/rvmanager/rv_manager_test.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/bwmarrin/snowflake"
+	"github.com/go-sql-driver/mysql"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
@@ -205,6 +207,96 @@ func TestExecBatch_RetriesOnSQLiteBusy(t *testing.T) {
 		})
 		require.Error(t, err)
 		require.ErrorIs(t, err, boom)
+	})
+}
+
+// TestExecBatch_RetriesOnDeadlock guards the cross-engine retry path: a MySQL
+// 1213 deadlock or a Postgres 40P01 deadlock_detected leaves the transaction
+// rolled back, so the whole batched WithTx is safe to run again. Without this
+// the batch surfaces an HTTP 500 to the caller and concurrent team-sync
+// addmember writes silently lose membership rows once the upstream retry
+// budget is exhausted.
+func TestExecBatch_RetriesOnDeadlock(t *testing.T) {
+	ctx := testutil.NewDefaultTestContext(t)
+
+	t.Run("retries on MySQL 1213 deadlock", func(t *testing.T) {
+		dbp := test.NewDBProviderMatchWords(t)
+		dialect := sqltemplate.DialectForDriver(dbp.DB.DriverName())
+		manager, err := NewResourceVersionManager(ResourceManagerOptions{
+			DB:      dbp.DB,
+			Dialect: dialect,
+		})
+		require.NoError(t, err)
+
+		deadlock := &mysql.MySQLError{Number: 1213, Message: "Deadlock found when trying to get lock; try restarting transaction"}
+		dbp.SQLMock.ExpectBegin()
+		dbp.SQLMock.ExpectExec("insert resource").WillReturnError(deadlock)
+		dbp.SQLMock.ExpectRollback()
+
+		dbp.SQLMock.ExpectBegin()
+		dbp.SQLMock.ExpectExec("insert resource").WillReturnResult(sqlmock.NewResult(1, 1))
+		expectSuccessfulResourceVersionExec(t, dbp)
+		dbp.SQLMock.ExpectCommit()
+
+		key := &resourcepb.ResourceKey{Group: "retry-mysql-deadlock", Resource: "res"}
+		rv, err := manager.ExecWithRV(ctx, key, func(txnCtx context.Context, tx db.Tx) (string, error) {
+			_, err := tx.ExecContext(txnCtx, "insert resource")
+			return "guid-1", err
+		})
+		require.NoError(t, err)
+		require.Equal(t, int64(200), rv)
+	})
+
+	t.Run("retries on Postgres 40P01 deadlock", func(t *testing.T) {
+		dbp := test.NewDBProviderMatchWords(t)
+		dialect := sqltemplate.DialectForDriver(dbp.DB.DriverName())
+		manager, err := NewResourceVersionManager(ResourceManagerOptions{
+			DB:      dbp.DB,
+			Dialect: dialect,
+		})
+		require.NoError(t, err)
+
+		deadlock := &pgconn.PgError{Code: "40P01", Message: "deadlock detected"}
+		dbp.SQLMock.ExpectBegin()
+		dbp.SQLMock.ExpectExec("insert resource").WillReturnError(deadlock)
+		dbp.SQLMock.ExpectRollback()
+
+		dbp.SQLMock.ExpectBegin()
+		dbp.SQLMock.ExpectExec("insert resource").WillReturnResult(sqlmock.NewResult(1, 1))
+		expectSuccessfulResourceVersionExec(t, dbp)
+		dbp.SQLMock.ExpectCommit()
+
+		key := &resourcepb.ResourceKey{Group: "retry-pg-deadlock", Resource: "res"}
+		rv, err := manager.ExecWithRV(ctx, key, func(txnCtx context.Context, tx db.Tx) (string, error) {
+			_, err := tx.ExecContext(txnCtx, "insert resource")
+			return "guid-1", err
+		})
+		require.NoError(t, err)
+		require.Equal(t, int64(200), rv)
+	})
+
+	t.Run("non-deadlock MySQL errors do not retry", func(t *testing.T) {
+		dbp := test.NewDBProviderMatchWords(t)
+		dialect := sqltemplate.DialectForDriver(dbp.DB.DriverName())
+		manager, err := NewResourceVersionManager(ResourceManagerOptions{
+			DB:      dbp.DB,
+			Dialect: dialect,
+		})
+		require.NoError(t, err)
+
+		// 1062 is ER_DUP_ENTRY — not retryable, must fall through.
+		dup := &mysql.MySQLError{Number: 1062, Message: "Duplicate entry"}
+		dbp.SQLMock.ExpectBegin()
+		dbp.SQLMock.ExpectExec("insert resource").WillReturnError(dup)
+		dbp.SQLMock.ExpectRollback()
+
+		key := &resourcepb.ResourceKey{Group: "no-retry-dup", Resource: "res"}
+		_, err = manager.ExecWithRV(ctx, key, func(txnCtx context.Context, tx db.Tx) (string, error) {
+			_, err := tx.ExecContext(txnCtx, "insert resource")
+			return "guid-1", err
+		})
+		require.Error(t, err)
+		require.ErrorIs(t, err, dup)
 	})
 }
 


### PR DESCRIPTION
## Summary

- Extends the existing batched `WithTx` retry loop in `pkg/storage/unified/sql/rvmanager` beyond SQLite busy/locked to also cover MySQL deadlock (1213) / lock-wait timeout (1205) and PostgreSQL deadlock_detected (40P01) / serialization_failure (40001). All four cases leave the transaction rolled back, so re-running the closed `runBatch` loop from the start is safe.
- Introduces `isRetryableTxnError` (`pkg/storage/unified/sql/rvmanager/retryable.go`) that classifies SQLite, MySQL (`*mysql.MySQLError`) and Postgres (`*pgconn.PgError`, `*pq.Error`) errors. Renames the SQLite-specific retry constants to `txnRetry*` and the span event to `batch_transaction_retry`.
- Adds `TestExecBatch_RetriesOnDeadlock` covering the MySQL 1213 retry, the Postgres 40P01 retry, and a non-retryable MySQL error (1062 dup-entry) that must surface immediately.

Relates to https://github.com/grafana/grafana/pull/124026

## Why

Under concurrent writes (e.g. team-sync addmember storms) MySQL/Postgres can pick a deadlock victim. Today only SQLite busy is retried, so deadlocks bubble up as HTTP 500 and the upstream retry budget eventually drops membership rows. The batched `WithTx` here is a closed loop (writes → RV lock → RV stamp), so a bounded retry on a rolled-back transaction is the right fix.

## Test plan

- [ ] `go test ./pkg/storage/unified/sql/rvmanager/... -count=1`
- [ ] Soak test against MySQL/Postgres with concurrent writers to confirm deadlocks now retry instead of returning 500