### PR TITLE
[release-13.0.2] CI: Switch frontend-lint to self-hosted runners

### DIFF
--- a/.github/workflows/frontend-lint.yml
+++ b/.github/workflows/frontend-lint.yml
@@ -11,7 +11,7 @@ permissions: {}
 jobs:
   detect-changes:
     name: Detect whether code changed
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-arm64-small
     permissions:
       contents: read
     outputs:
@@ -39,7 +39,7 @@ jobs:
     # the `lint-frontend-prettier-enterprise` workflow will run instead
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true && needs.detect-changes.outputs.prettier == 'true'
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     steps:
     - uses: actions/checkout@v5
       with:
@@ -58,7 +58,7 @@ jobs:
     # Run this workflow for non-PR events (like pushes to `main` or `release-*`) OR for internal PRs (PRs not from forks)
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false && needs.detect-changes.outputs.prettier == 'true'
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     steps:
     - uses: actions/checkout@v5
       with:
@@ -82,7 +82,7 @@ jobs:
     # the `lint-frontend-typecheck-enterprise` workflow will run instead
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true && needs.detect-changes.outputs.changed == 'true'
     name: Typecheck
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     env:
       NODE_OPTIONS: --max-old-space-size=8192
     steps:
@@ -102,7 +102,7 @@ jobs:
     # Run this workflow for non-PR events (like pushes to `main` or `release-*`) OR for internal PRs (PRs not from forks)
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false && needs.detect-changes.outputs.changed == 'true'
     name: Typecheck
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     env:
       NODE_OPTIONS: --max-old-space-size=8192
     steps:
@@ -126,7 +126,7 @@ jobs:
     # the `lint-frontend-api-clients-enterprise` workflow will run instead
     if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == true
     name: Verify API clients
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     steps:
     - uses: actions/checkout@v5
       with:
@@ -154,7 +154,7 @@ jobs:
       contents: read
       id-token: write
     name: Verify OpenAPI specs
-    runs-on: ubuntu-x64-large
+    runs-on: ubuntu-x64
     steps:
     - uses: actions/checkout@v5
       with:
@@ -190,7 +190,7 @@ jobs:
     # Run this workflow for non-PR events (like pushes to `main` or `release-*`) OR for internal PRs (PRs not from forks)
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false
     name: Verify API clients (enterprise)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     steps:
     - uses: actions/checkout@v5
       with:
@@ -223,7 +223,7 @@ jobs:
       id-token: write
     if: github.event_name == 'pull_request' && needs.detect-changes.outputs.changed-frontend-packages == 'true'
     name: Verify packed frontend packages
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64
     steps:
     - name: Checkout build commit
       uses: actions/checkout@v5
@@ -246,7 +246,7 @@ jobs:
       id-token: write
     if: github.event_name == 'pull_request' && github.event.pull_request.base.ref == 'main' && needs.detect-changes.outputs.changed == 'true'
     name: Check circular dependencies
-    runs-on: ubuntu-x64-small
+    runs-on: ubuntu-x64
     steps:
     - name: Checkout build commit
       uses: actions/checkout@v5
@@ -311,7 +311,7 @@ jobs:
     needs:
       - detect-changes
     if: needs.detect-changes.outputs.changed-frontend-dependencies == 'true'
-    runs-on: ubuntu-x64-small
+    runs-on: ubuntu-x64
     name: Validate yarn install
     permissions:
       contents: read

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -43,7 +43,11 @@ jobs:
 
   publish:
     name: Publish NPM packages
+
+    # MUST use GitHub-hosted runners, as Trusted Publishing currently doesn't support self-hosted runners.cancel-timeout-minutes.
+    # https://docs.npmjs.com/trusted-publishers#supported-cicd-providers
     runs-on: github-hosted-ubuntu-x64-small
+
     if: inputs.version_type == 'canary' || inputs.version_type == 'stable'
     # Required for this workflow to have permission to publish NPM packages
     environment: npm-publish


### PR DESCRIPTION
Backport be9eb3b739b54fc29370143e0aa2dc0f84c22120 from #124098

---

Switches the frontend-lint.yml Github Actions to self-hosted runners.
