### PR TITLE
search: download fresh same-version snapshot instead of rebuilding

### DIFF
--- a/pkg/storage/unified/resource/bleve_index_metrics.go
+++ b/pkg/storage/unified/resource/bleve_index_metrics.go
@@ -104,8 +104,8 @@ func ProvideIndexMetrics(reg prometheus.Registerer) *BleveIndexMetrics {
 		}),
 		IndexSnapshotDownloads: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "index_server_snapshot_downloads_total",
-			Help: "Number of remote index snapshot download attempts at index build time, by outcome.",
-		}, []string{"status"}), // status: success, empty, download_error, validate_error
+			Help: "Number of remote index snapshot download attempts at index build time, by selection policy and outcome.",
+		}, []string{"policy", "status"}), // policy: tiered, same_version. status: success, empty, download_error, validate_error
 		IndexSnapshotDownloadDuration: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 			Name:                            "index_server_snapshot_download_duration_seconds",
 			Help:                            "Duration of successful remote index snapshot downloads, including open and validation.",
@@ -157,10 +157,12 @@ func (m *BleveIndexMetrics) InitSnapshotMetrics() {
 	if m == nil {
 		return
 	}
-	m.IndexSnapshotDownloads.WithLabelValues("success").Add(0)
-	m.IndexSnapshotDownloads.WithLabelValues("empty").Add(0)
-	m.IndexSnapshotDownloads.WithLabelValues("download_error").Add(0)
-	m.IndexSnapshotDownloads.WithLabelValues("validate_error").Add(0)
+	for _, policy := range []string{"tiered", "same_version"} {
+		m.IndexSnapshotDownloads.WithLabelValues(policy, "success").Add(0)
+		m.IndexSnapshotDownloads.WithLabelValues(policy, "empty").Add(0)
+		m.IndexSnapshotDownloads.WithLabelValues(policy, "download_error").Add(0)
+		m.IndexSnapshotDownloads.WithLabelValues(policy, "validate_error").Add(0)
+	}
 	m.IndexSnapshotUploads.WithLabelValues("success").Add(0)
 	m.IndexSnapshotUploads.WithLabelValues("skip_no_changes").Add(0)
 	m.IndexSnapshotUploads.WithLabelValues("skip_lock_contention").Add(0)

--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -116,6 +116,9 @@ type SearchBackend interface {
 	// Updater function is used to update the index before performing the search.
 	// rebuild forces a full rebuild of the index, regardless of state.
 	// lastImportTime is used to determine if an existing file-based index needs to be rebuilt before opening.
+	// maxFreshSnapshotAge is the freshness window (by snapshot BuildTime) within
+	// which a same-version remote snapshot is preferred over rebuilding from
+	// scratch on the rebuild path. Zero disables that fast path.
 	BuildIndex(
 		ctx context.Context,
 		key NamespacedResource,
@@ -126,6 +129,7 @@ type SearchBackend interface {
 		updater UpdateFn,
 		rebuild bool,
 		lastImportTime time.Time,
+		maxFreshSnapshotAge time.Duration,
 	) (ResourceIndex, error)
 
 	// TotalDocs returns the total number of documents across all indexes.
@@ -169,6 +173,16 @@ type searchServer struct {
 	indexModificationCacheTTL time.Duration
 
 	backendDiagnostics resourcepb.DiagnosticsServer //nolint:staticcheck
+}
+
+// getIndexMaxAge returns the configured rebuild interval for the given
+// resource: dashboards use IndexRebuildInterval (cfg.IndexRebuildInterval),
+// other resources use MaxFileIndexAge. Zero means "no age-based rebuild".
+func (s *searchServer) getIndexMaxAge(key NamespacedResource) time.Duration {
+	if key.Resource == dashboardv1.DASHBOARD_RESOURCE {
+		return s.dashboardIndexMaxAge
+	}
+	return s.maxIndexAge
 }
 
 // maybeInjectFailure returns an error for a configured percentage of calls.
@@ -804,10 +818,7 @@ func (s *searchServer) findIndexesToRebuild(lastImportTimes map[NamespacedResour
 			continue
 		}
 
-		maxAge := s.maxIndexAge
-		if key.Resource == dashboardv1.DASHBOARD_RESOURCE {
-			maxAge = s.dashboardIndexMaxAge
-		}
+		maxAge := s.getIndexMaxAge(key)
 
 		var minBuildTime time.Time
 		if maxAge > 0 {
@@ -1352,7 +1363,12 @@ func (s *searchServer) build(ctx context.Context, nsr NamespacedResource, size i
 		s.builders.clearNamespacedCache(nsr)
 	}
 
-	index, err := s.search.BuildIndex(ctx, nsr, size, fields, indexBuildReason, builderFn, updaterFn, rebuild, lastImportTime)
+	// On the rebuild path, prefer downloading a fresh same-version remote
+	// snapshot over rebuilding from scratch when one exists with BuildTime
+	// within ~10% of the per-resource rebuild interval.
+	maxFreshSnapshotAge := s.getIndexMaxAge(nsr) / 10
+
+	index, err := s.search.BuildIndex(ctx, nsr, size, fields, indexBuildReason, builderFn, updaterFn, rebuild, lastImportTime, maxFreshSnapshotAge)
 
 	if err != nil {
 		return nil, err

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -149,7 +149,7 @@ func (m *mockSearchBackend) GetIndex(key NamespacedResource) ResourceIndex {
 	return m.cache[key]
 }
 
-func (m *mockSearchBackend) BuildIndex(ctx context.Context, key NamespacedResource, size int64, fields SearchableDocumentFields, reason string, builder BuildFn, updater UpdateFn, rebuild bool, lastImportTime time.Time) (ResourceIndex, error) {
+func (m *mockSearchBackend) BuildIndex(ctx context.Context, key NamespacedResource, size int64, fields SearchableDocumentFields, reason string, builder BuildFn, updater UpdateFn, rebuild bool, lastImportTime time.Time, _ time.Duration) (ResourceIndex, error) {
 	index := &MockResourceIndex{}
 
 	// Call the builder function (required by the contract)
@@ -355,7 +355,7 @@ func (m *slowSearchBackendWithCache) GetIndex(key NamespacedResource) ResourceIn
 	return m.cache[key]
 }
 
-func (m *slowSearchBackendWithCache) BuildIndex(ctx context.Context, key NamespacedResource, size int64, fields SearchableDocumentFields, reason string, builder BuildFn, updater UpdateFn, rebuild bool, lastImportTime time.Time) (ResourceIndex, error) {
+func (m *slowSearchBackendWithCache) BuildIndex(ctx context.Context, key NamespacedResource, size int64, fields SearchableDocumentFields, reason string, builder BuildFn, updater UpdateFn, rebuild bool, lastImportTime time.Time, maxFreshSnapshotAge time.Duration) (ResourceIndex, error) {
 	defer m.slowBuildCalls.Add(1)
 
 	time.Sleep(1 * time.Second)
@@ -364,7 +364,7 @@ func (m *slowSearchBackendWithCache) BuildIndex(ctx context.Context, key Namespa
 	if ctx.Err() != nil {
 		return nil, ctx.Err()
 	}
-	idx, err := m.mockSearchBackend.BuildIndex(ctx, key, size, fields, reason, builder, updater, rebuild, lastImportTime)
+	idx, err := m.mockSearchBackend.BuildIndex(ctx, key, size, fields, reason, builder, updater, rebuild, lastImportTime, maxFreshSnapshotAge)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -577,7 +577,13 @@ type buildInfo struct {
 // If built successfully, the new index replaces the old index in the cache (if there was any).
 // Existing index in the file system is reused, if it exists, and if size indicates that we should use file-based index,
 // and lastImportTime check passes (if the index was built before lastImportTime, it will be rebuilt).
-// The return value of "builder" should be the RV returned from List. This will be stored as the index RV
+// The return value of "builder" should be the RV returned from List. This will be stored as the index RV.
+//
+// maxFreshSnapshotAge is the maximum age (by BuildTime) of a remote snapshot
+// that BuildIndex will download instead of rebuilding from scratch on the
+// rebuild path. Zero disables the strict same-version fast path; the snapshot
+// store, if configured, is still consulted on the initial-startup path via
+// pickBestSnapshot.
 //
 //nolint:gocyclo
 func (b *bleveBackend) BuildIndex(
@@ -590,6 +596,7 @@ func (b *bleveBackend) BuildIndex(
 	updater resource.UpdateFn,
 	rebuild bool,
 	lastImportTime time.Time,
+	maxFreshSnapshotAge time.Duration,
 ) (resource.ResourceIndex, error) {
 	_, span := tracer.Start(ctx, "search.bleveBackend.BuildIndex")
 	defer span.End()
@@ -687,6 +694,19 @@ func (b *bleveBackend) BuildIndex(
 				} else if dlIdx != nil {
 					index, fileIndexName, indexRV = dlIdx, dlName, dlRV
 				}
+			}
+		} else if rebuild && b.opts.Snapshot.Store != nil && size >= b.opts.Snapshot.MinDocCount && maxFreshSnapshotAge > 0 {
+			// Rebuild path: before paying the cost of a from-scratch
+			// rebuild, check whether the remote index store holds a same-version snapshot
+			// fresh enough to serve as a drop-in replacement. Strict policy:
+			// exact BuildVersion match, BuildTime within maxFreshSnapshotAge
+			// AND strictly after lastImportTime. On miss, fall through to
+			// rebuild — no tiered fallback (we already have a working index).
+			dlIdx, dlName, dlRV, dlErr := b.tryDownloadFreshSnapshot(ctx, key, resourceDir, lastImportTime, maxFreshSnapshotAge, logWithDetails)
+			if dlErr != nil {
+				logWithDetails.Warn("Failed to download fresh remote snapshot, will rebuild from scratch", "err", dlErr)
+			} else if dlIdx != nil {
+				index, fileIndexName, indexRV = dlIdx, dlName, dlRV
 			}
 		}
 

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -631,7 +631,7 @@ func newTestDashboardsIndex(t testing.TB, threshold int64, size int64, writer re
 		Namespace: key.Namespace,
 		Group:     key.Group,
 		Resource:  key.Resource,
-	}, size, info.Fields, "test", writer, nil, false, time.Time{})
+	}, size, info.Fields, "test", writer, nil, false, time.Time{}, 0)
 	require.NoError(t, err)
 
 	return index
@@ -651,7 +651,7 @@ func newTestIndexWithFields(t testing.TB, key resource.NamespacedResource, colum
 	fields, err := resource.NewSearchableDocumentFields(columns)
 	require.NoError(t, err)
 
-	index, err := backend.BuildIndex(ctx, key, 2, fields, "test", noop, nil, false, time.Time{})
+	index, err := backend.BuildIndex(ctx, key, 2, fields, "test", noop, nil, false, time.Time{}, 0)
 	require.NoError(t, err)
 	return index
 }
@@ -721,7 +721,7 @@ func TestIndexAndSearchSelectableFields(t *testing.T) {
 		Namespace: key.Namespace,
 		Group:     key.Group,
 		Resource:  key.Resource,
-	}, 10, nil, "test", noop, nil, false, time.Time{})
+	}, 10, nil, "test", noop, nil, false, time.Time{}, 0)
 	require.NoError(t, err)
 
 	err = index.BulkIndex(&resource.BulkIndexRequest{

--- a/pkg/storage/unified/search/bleve_snapshot.go
+++ b/pkg/storage/unified/search/bleve_snapshot.go
@@ -19,8 +19,15 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 )
 
-// snapshotDownloadStatus labels for the index_server_snapshot_downloads_total counter.
+// Labels for the index_server_snapshot_downloads_total counter.
 const (
+	// snapshotPolicyTiered selects via pickBestSnapshot (initial startup;
+	// any version >= MinBuildVersion accepted, with tiered preference).
+	snapshotPolicyTiered = "tiered"
+	// snapshotPolicySameVersion selects via findFreshSnapshotByBuildStart
+	// (rebuild; strict same-version freshness).
+	snapshotPolicySameVersion = "same_version"
+
 	snapshotStatusSuccess       = "success"
 	snapshotStatusEmpty         = "empty"
 	snapshotStatusDownloadError = "download_error"
@@ -35,6 +42,14 @@ type snapshotCandidate struct {
 	version *semver.Version // always non-nil; pickBestSnapshot drops unparseable entries
 	tier    int             // 0 = best, 2 = last resort
 }
+
+// snapshotSelectFn picks a snapshot under a given policy.
+//
+// Returns:
+//   - (key, meta, nil):                a snapshot was chosen.
+//   - (zero ULID, nil, nil):           no candidate; caller proceeds to its fallback.
+//   - (zero ULID, nil, err):           selection failed; caller treats as a download error.
+type snapshotSelectFn func(context.Context) (ulid.ULID, *IndexMeta, error)
 
 // tryDownloadRemoteSnapshot lists remote snapshots for the given resource,
 // picks the best candidate (see pickBestSnapshot), downloads and opens it
@@ -51,84 +66,169 @@ func (b *bleveBackend) tryDownloadRemoteSnapshot(
 	key resource.NamespacedResource,
 	resourceDir string,
 	logger log.Logger,
+) (bleve.Index, string, int64, error) {
+	logger.Info("Remote index snapshot download started", "policy", snapshotPolicyTiered)
+	return b.downloadSelectedSnapshot(ctx, key, resourceDir,
+		snapshotPolicyTiered, "search.remote_index_snapshot.download", logger,
+		func(ctx context.Context) (ulid.ULID, *IndexMeta, error) {
+			all, err := b.opts.Snapshot.Store.ListIndexes(ctx, key)
+			if err != nil {
+				return ulid.ULID{}, nil, fmt.Errorf("listing remote snapshots: %w", err)
+			}
+			c, ok := b.pickBestSnapshot(all, time.Now())
+			if !ok {
+				return ulid.ULID{}, nil, nil
+			}
+			return c.key, c.meta, nil
+		},
+	)
+}
+
+// tryDownloadFreshSnapshot probes the remote index store for a same-version
+// snapshot whose BuildTime is within the last maxFreshSnapshotAge AND
+// strictly after lastImportTime, downloads and opens it locally.
+//
+// Used on the rebuild path: when a fresh-enough same-version snapshot
+// exists, we download it instead of paying the cost of rebuilding from
+// scratch.
+//
+// Return contract mirrors tryDownloadRemoteSnapshot:
+//   - On success: (idx, dirName, rv, nil)
+//   - No fresh candidate: (nil, "", 0, nil) — caller should rebuild
+//   - Error: (nil, "", 0, err)
+//
+// Combining the two cutoffs: the probe accepts BuildTime > now-maxAge.
+// We bump maxAge down so that BuildTime > lastImportTime is also enforced
+// in the same pass — equivalent to BuildTime > max(now-maxAge, lastImport).
+func (b *bleveBackend) tryDownloadFreshSnapshot(
+	ctx context.Context,
+	key resource.NamespacedResource,
+	resourceDir string,
+	lastImportTime time.Time,
+	maxFreshSnapshotAge time.Duration,
+	logger log.Logger,
+) (bleve.Index, string, int64, error) {
+	logger.Info("Fresh remote index snapshot download started", "policy", snapshotPolicySameVersion, "max_fresh_age", maxFreshSnapshotAge, "last_import_time", lastImportTime)
+
+	// Combine the freshness cutoff with the lastImportTime correctness check.
+	// Both are "BuildTime must be after X"; take the more restrictive X.
+	effectiveMaxAge := maxFreshSnapshotAge
+	if !lastImportTime.IsZero() {
+		if since := time.Since(lastImportTime); since < effectiveMaxAge {
+			effectiveMaxAge = since
+		}
+	}
+
+	return b.downloadSelectedSnapshot(ctx, key, resourceDir,
+		snapshotPolicySameVersion, "search.remote_index_snapshot.download_fresh", logger,
+		func(ctx context.Context) (ulid.ULID, *IndexMeta, error) {
+			if effectiveMaxAge <= 0 {
+				// lastImportTime is in the future (clock skew) or
+				// maxFreshSnapshotAge is non-positive; no snapshot can satisfy
+				// the freshness window.
+				return ulid.ULID{}, nil, nil
+			}
+			k, m, err := findFreshSnapshotByBuildStart(ctx, b.opts.Snapshot.Store, key, effectiveMaxAge, b.opts.BuildVersion)
+			if err != nil {
+				return ulid.ULID{}, nil, fmt.Errorf("probing for fresh snapshot: %w", err)
+			}
+			return k, m, nil
+		},
+	)
+}
+
+// downloadSelectedSnapshot is the shared scaffolding for tryDownload*
+// helpers: trace span, completion / failure log, outcome metric, and the
+// reserve-download-open-validate flow. Each policy provides its
+// selection logic via selectFn; the template handles everything else.
+func (b *bleveBackend) downloadSelectedSnapshot(
+	ctx context.Context,
+	key resource.NamespacedResource,
+	resourceDir string,
+	policy string,
+	spanName string,
+	logger log.Logger,
+	selectFn snapshotSelectFn,
 ) (_ bleve.Index, _ string, _ int64, retErr error) {
-	ctx, span := tracer.Start(ctx, "search.remote_index_snapshot.download")
+	ctx, span := tracer.Start(ctx, spanName)
 	start := time.Now()
 	outcome := snapshotStatusSuccess
-	var candidate snapshotCandidate
+	var snapKey ulid.ULID
+	var meta *IndexMeta
 
 	defer func() {
 		attrs := []attribute.KeyValue{
 			attribute.String("namespace", key.Namespace),
 			attribute.String("group", key.Group),
 			attribute.String("resource", key.Resource),
+			attribute.String("policy", policy),
 			attribute.String("outcome", outcome),
 		}
-		if candidate.key != (ulid.ULID{}) {
+		if meta != nil {
 			attrs = append(attrs,
-				attribute.String("snapshot_key", candidate.key.String()),
-				attribute.String("snapshot_version", candidate.version.String()),
-				attribute.Int64("snapshot_rv", candidate.meta.LatestResourceVersion),
-				attribute.Int("snapshot_tier", candidate.tier),
+				attribute.String("snapshot_key", snapKey.String()),
+				attribute.String("snapshot_version", meta.BuildVersion),
+				attribute.Int64("snapshot_rv", meta.LatestResourceVersion),
 			)
+			// Zero-value BuildTime means the snapshot was uploaded before #768
+			// added the field; logging "0001-01-01" would be misleading.
+			if !meta.BuildTime.IsZero() {
+				attrs = append(attrs, attribute.String("snapshot_build_time", meta.BuildTime.UTC().Format(time.RFC3339)))
+			}
 		}
 		span.SetAttributes(attrs...)
 		elapsed := time.Since(start)
 		if retErr != nil {
 			span.RecordError(retErr)
 			span.SetStatus(codes.Error, retErr.Error())
-			logger.Warn("Remote index snapshot download failed", "elapsed", elapsed, "outcome", outcome, "err", retErr)
+			logger.Warn("Remote index snapshot download failed", "elapsed", elapsed, "policy", policy, "outcome", outcome, "err", retErr)
 		} else {
-			logger.Info("Remote index snapshot download completed", "elapsed", elapsed, "outcome", outcome)
+			logger.Info("Remote index snapshot download completed", "elapsed", elapsed, "policy", policy, "outcome", outcome)
 		}
+		b.recordSnapshotDownloadOutcome(policy, outcome)
 		span.End()
 	}()
 
-	logger.Info("Remote index snapshot download started")
-	store := b.opts.Snapshot.Store
-
-	all, err := store.ListIndexes(ctx, key)
+	var err error
+	snapKey, meta, err = selectFn(ctx)
 	if err != nil {
 		outcome = snapshotStatusDownloadError
-		b.recordSnapshotDownloadStatus(snapshotStatusDownloadError)
-		return nil, "", 0, fmt.Errorf("listing remote snapshots: %w", err)
+		return nil, "", 0, err
 	}
-
-	var ok bool
-	candidate, ok = b.pickBestSnapshot(all, time.Now())
-	if !ok {
+	if meta == nil {
 		outcome = snapshotStatusEmpty
-		b.recordSnapshotDownloadStatus(snapshotStatusEmpty)
 		return nil, "", 0, nil
 	}
 
-	logger = logger.New(
-		"snapshot_key", candidate.key.String(),
-		"snapshot_version", candidate.version.String(),
-		"snapshot_rv", candidate.meta.LatestResourceVersion,
-		"snapshot_uploaded", candidate.meta.UploadTimestamp,
-		"snapshot_tier", candidate.tier,
-	)
+	logFields := []any{
+		"snapshot_key", snapKey.String(),
+		"snapshot_version", meta.BuildVersion,
+		"snapshot_rv", meta.LatestResourceVersion,
+		"snapshot_uploaded", meta.UploadTimestamp,
+	}
+	if !meta.BuildTime.IsZero() {
+		logFields = append(logFields, "snapshot_build_time", meta.BuildTime)
+	}
+	logger = logger.New(logFields...)
 
-	// Pick a fresh destination directory name. DownloadIndex refuses to overwrite
-	// an existing destDir; the bump-on-exists loop mirrors what BuildIndex does
-	// when creating new file-based indexes.
+	// Pick a fresh destination directory name. DownloadIndex refuses to
+	// overwrite an existing destDir; the bump-on-exists loop mirrors what
+	// BuildIndex does when creating new file-based indexes.
 	destDir, name, err := b.reserveSnapshotDir(resourceDir)
 	if err != nil {
 		outcome = snapshotStatusDownloadError
-		b.recordSnapshotDownloadStatus(snapshotStatusDownloadError)
 		return nil, "", 0, fmt.Errorf("reserving local snapshot dir: %w", err)
 	}
 
-	// TODO: retry DownloadIndex on transient errors before falling through to a
-	// from-scratch KV rebuild. The object store is its own fault domain;
+	// TODO: retry DownloadIndex on transient errors before falling through to
+	// a from-scratch KV rebuild. The object store is its own fault domain;
 	// a single failed download shouldn't force a full rebuild for large
 	// indexes (e.g. a 1M-doc dashboard index would re-pay every read).
-	downloadedMeta, err := store.DownloadIndex(ctx, key, candidate.key, destDir)
+	downloadStart := time.Now()
+	downloadedMeta, err := b.opts.Snapshot.Store.DownloadIndex(ctx, key, snapKey, destDir)
 	if err != nil {
 		_ = os.RemoveAll(destDir)
 		outcome = snapshotStatusDownloadError
-		b.recordSnapshotDownloadStatus(snapshotStatusDownloadError)
 		return nil, "", 0, fmt.Errorf("downloading snapshot: %w", err)
 	}
 
@@ -136,7 +236,6 @@ func (b *bleveBackend) tryDownloadRemoteSnapshot(
 	if err != nil {
 		_ = os.RemoveAll(destDir)
 		outcome = snapshotStatusValidateError
-		b.recordSnapshotDownloadStatus(snapshotStatusValidateError)
 		return nil, "", 0, fmt.Errorf("opening downloaded snapshot: %w", err)
 	}
 
@@ -145,17 +244,14 @@ func (b *bleveBackend) tryDownloadRemoteSnapshot(
 		_ = idx.Close()
 		_ = os.RemoveAll(destDir)
 		outcome = snapshotStatusValidateError
-		b.recordSnapshotDownloadStatus(snapshotStatusValidateError)
 		return nil, "", 0, fmt.Errorf("validating downloaded snapshot: %w", err)
 	}
 
-	elapsed := time.Since(start)
-	b.recordSnapshotDownloadStatus(snapshotStatusSuccess)
 	if b.indexMetrics != nil {
-		b.indexMetrics.IndexSnapshotDownloadDuration.Observe(elapsed.Seconds())
+		b.indexMetrics.IndexSnapshotDownloadDuration.Observe(time.Since(downloadStart).Seconds())
 	}
 
-	uploadedAt := candidate.meta.UploadTimestamp
+	uploadedAt := meta.UploadTimestamp
 	if downloadedMeta != nil && !downloadedMeta.UploadTimestamp.IsZero() {
 		uploadedAt = downloadedMeta.UploadTimestamp
 	}
@@ -164,7 +260,6 @@ func (b *bleveBackend) tryDownloadRemoteSnapshot(
 		_ = idx.Close()
 		_ = os.RemoveAll(destDir)
 		outcome = snapshotStatusValidateError
-		b.recordSnapshotDownloadStatus(snapshotStatusValidateError)
 		return nil, "", 0, fmt.Errorf("resetting snapshot mutation count: %w", err)
 	}
 	b.setUploadTracking(key, uploadedAt)
@@ -300,11 +395,11 @@ func (b *bleveBackend) validateDownloadedIndex(idx bleve.Index) (int64, error) {
 	return rv, nil
 }
 
-func (b *bleveBackend) recordSnapshotDownloadStatus(status string) {
+func (b *bleveBackend) recordSnapshotDownloadOutcome(policy, status string) {
 	if b.indexMetrics == nil {
 		return
 	}
-	b.indexMetrics.IndexSnapshotDownloads.WithLabelValues(status).Inc()
+	b.indexMetrics.IndexSnapshotDownloads.WithLabelValues(policy, status).Inc()
 }
 
 // findFreshSnapshotByUploadTime walks namespace snapshots newest-first and

--- a/pkg/storage/unified/search/bleve_snapshot_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_test.go
@@ -330,7 +330,7 @@ func (dt downloadTest) run(t *testing.T) (bleve.Index, int64, error) {
 }
 
 func (dt downloadTest) counter(status string) float64 {
-	return testutil.ToFloat64(dt.metrics.IndexSnapshotDownloads.WithLabelValues(status))
+	return testutil.ToFloat64(dt.metrics.IndexSnapshotDownloads.WithLabelValues(snapshotPolicyTiered, status))
 }
 
 func TestTryDownloadRemoteSnapshot_Empty(t *testing.T) {
@@ -422,6 +422,273 @@ func TestTryDownloadRemoteSnapshot_AllFilteredOut(t *testing.T) {
 	assert.Zero(t, dt.store.downloadCalls.Load(), "DownloadIndex should not be called when all candidates are filtered out")
 }
 
+// freshDownloadTest bundles the shared setup used by tryDownloadFreshSnapshot tests.
+type freshDownloadTest struct {
+	be          *bleveBackend
+	metrics     *resource.BleveIndexMetrics
+	store       *fakeRemoteIndexStore
+	ns          resource.NamespacedResource
+	resourceDir string
+}
+
+func newFreshDownloadTest(t *testing.T, store *fakeRemoteIndexStore) freshDownloadTest {
+	t.Helper()
+	be, metrics := newTestBleveBackend(t, SnapshotOptions{
+		Store:       store,
+		MinDocCount: 1,
+		MaxIndexAge: 24 * time.Hour,
+	})
+	ns := newTestNsResource()
+	return freshDownloadTest{
+		be:          be,
+		metrics:     metrics,
+		store:       store,
+		ns:          ns,
+		resourceDir: filepath.Join(be.opts.Root, ns.Namespace, ns.Resource+"."+ns.Group),
+	}
+}
+
+func (dt freshDownloadTest) run(t *testing.T, lastImportTime time.Time, maxFreshSnapshotAge time.Duration) (bleve.Index, int64, error) {
+	t.Helper()
+	idx, _, rv, err := dt.be.tryDownloadFreshSnapshot(context.Background(), dt.ns, dt.resourceDir, lastImportTime, maxFreshSnapshotAge, dt.be.log)
+	if idx != nil {
+		t.Cleanup(func() { _ = idx.Close() })
+	}
+	return idx, rv, err
+}
+
+func (dt freshDownloadTest) counter(status string) float64 {
+	return testutil.ToFloat64(dt.metrics.IndexSnapshotDownloads.WithLabelValues(snapshotPolicySameVersion, status))
+}
+
+// freshSnapshot returns metadata for a freshly-built same-version snapshot at age.
+func freshSnapshot(buildAge time.Duration) *IndexMeta {
+	now := time.Now()
+	return &IndexMeta{
+		BuildVersion:          "11.5.0",
+		LatestResourceVersion: 42,
+		UploadTimestamp:       now.Add(-buildAge),
+		BuildTime:             now.Add(-buildAge),
+	}
+}
+
+func TestTryDownloadFreshSnapshot_Hit(t *testing.T) {
+	store := &fakeRemoteIndexStore{}
+	store.put(makeULID(t, time.Now()), freshSnapshot(time.Minute))
+	dt := newFreshDownloadTest(t, store)
+
+	idx, rv, err := dt.run(t, time.Time{}, time.Hour)
+	require.NoError(t, err)
+	require.NotNil(t, idx)
+	assert.Equal(t, int64(42), rv)
+	assert.Equal(t, 1.0, dt.counter(snapshotStatusSuccess))
+}
+
+func TestTryDownloadFreshSnapshot_DisabledByZeroMaxAge(t *testing.T) {
+	store := &fakeRemoteIndexStore{}
+	store.put(makeULID(t, time.Now()), freshSnapshot(time.Minute))
+	dt := newFreshDownloadTest(t, store)
+
+	idx, _, err := dt.run(t, time.Time{}, 0)
+	require.NoError(t, err)
+	assert.Nil(t, idx)
+	assert.Equal(t, 1.0, dt.counter(snapshotStatusEmpty))
+	assert.Zero(t, dt.store.downloadCalls.Load())
+}
+
+func TestTryDownloadFreshSnapshot_VersionMismatchSkipped(t *testing.T) {
+	store := &fakeRemoteIndexStore{}
+	meta := freshSnapshot(time.Minute)
+	meta.BuildVersion = "11.4.0" // backend runs 11.5.0
+	store.put(makeULID(t, time.Now()), meta)
+	dt := newFreshDownloadTest(t, store)
+
+	idx, _, err := dt.run(t, time.Time{}, time.Hour)
+	require.NoError(t, err)
+	assert.Nil(t, idx)
+	assert.Equal(t, 1.0, dt.counter(snapshotStatusEmpty))
+	assert.Zero(t, dt.store.downloadCalls.Load())
+}
+
+func TestTryDownloadFreshSnapshot_BuildTimeOlderThanMaxAge(t *testing.T) {
+	store := &fakeRemoteIndexStore{}
+	// Periodic re-upload: ULID (upload time) is recent, but BuildTime is old.
+	meta := &IndexMeta{
+		BuildVersion:          "11.5.0",
+		LatestResourceVersion: 42,
+		UploadTimestamp:       time.Now(),
+		BuildTime:             time.Now().Add(-3 * time.Hour),
+	}
+	store.put(makeULID(t, time.Now()), meta)
+	dt := newFreshDownloadTest(t, store)
+
+	idx, _, err := dt.run(t, time.Time{}, time.Hour)
+	require.NoError(t, err)
+	assert.Nil(t, idx)
+	assert.Equal(t, 1.0, dt.counter(snapshotStatusEmpty))
+	assert.Zero(t, dt.store.downloadCalls.Load())
+}
+
+func TestTryDownloadFreshSnapshot_RejectedByLastImportTime(t *testing.T) {
+	store := &fakeRemoteIndexStore{}
+	// Snapshot built 5 minutes ago, but lastImportTime says KV mutated 2 minutes ago.
+	// The snapshot pre-dates known mutations and must be rejected even though it
+	// fits the maxFreshSnapshotAge window.
+	store.put(makeULID(t, time.Now()), freshSnapshot(5*time.Minute))
+	dt := newFreshDownloadTest(t, store)
+
+	lastImportTime := time.Now().Add(-2 * time.Minute)
+	idx, _, err := dt.run(t, lastImportTime, time.Hour)
+	require.NoError(t, err)
+	assert.Nil(t, idx)
+	assert.Equal(t, 1.0, dt.counter(snapshotStatusEmpty))
+	assert.Zero(t, dt.store.downloadCalls.Load())
+}
+
+func TestTryDownloadFreshSnapshot_AcceptedWhenBuiltAfterLastImportTime(t *testing.T) {
+	store := &fakeRemoteIndexStore{}
+	// Snapshot built 1 minute ago, lastImportTime 5 minutes ago: snapshot is
+	// strictly newer than the latest known mutation, so it's safe to use.
+	store.put(makeULID(t, time.Now()), freshSnapshot(time.Minute))
+	dt := newFreshDownloadTest(t, store)
+
+	lastImportTime := time.Now().Add(-5 * time.Minute)
+	idx, _, err := dt.run(t, lastImportTime, time.Hour)
+	require.NoError(t, err)
+	require.NotNil(t, idx)
+	assert.Equal(t, 1.0, dt.counter(snapshotStatusSuccess))
+}
+
+func TestTryDownloadFreshSnapshot_ListError(t *testing.T) {
+	store := &fakeRemoteIndexStore{listErr: errors.New("boom")}
+	dt := newFreshDownloadTest(t, store)
+
+	_, _, err := dt.run(t, time.Time{}, time.Hour)
+	require.Error(t, err)
+	assert.Equal(t, 1.0, dt.counter(snapshotStatusDownloadError))
+}
+
+func TestTryDownloadFreshSnapshot_Empty(t *testing.T) {
+	dt := newFreshDownloadTest(t, &fakeRemoteIndexStore{})
+	idx, _, err := dt.run(t, time.Time{}, time.Hour)
+	require.NoError(t, err)
+	assert.Nil(t, idx)
+	assert.Equal(t, 1.0, dt.counter(snapshotStatusEmpty))
+}
+
+// TestTryDownloadFreshSnapshot_WalksPastStaleNewerCandidate verifies the
+// probe walks past a recent ULID whose BuildTime is stale (e.g. a periodic
+// re-upload) to find an earlier same-version candidate that's actually fresh.
+func TestTryDownloadFreshSnapshot_WalksPastStaleNewerCandidate(t *testing.T) {
+	store := &fakeRemoteIndexStore{}
+	now := time.Now()
+	// Newer ULID (uploaded just now) but stale BuildTime: a periodic re-upload
+	// of a long-lived index. Must be rejected by build-start freshness.
+	store.put(makeULID(t, now), &IndexMeta{
+		BuildVersion:          "11.5.0",
+		LatestResourceVersion: 10,
+		UploadTimestamp:       now,
+		BuildTime:             now.Add(-3 * time.Hour),
+	})
+	// Older ULID, fresh BuildTime: this is the one we want.
+	store.put(makeULID(t, now.Add(-30*time.Minute)), &IndexMeta{
+		BuildVersion:          "11.5.0",
+		LatestResourceVersion: 42,
+		UploadTimestamp:       now.Add(-30 * time.Minute),
+		BuildTime:             now.Add(-30 * time.Minute),
+	})
+	dt := newFreshDownloadTest(t, store)
+
+	idx, rv, err := dt.run(t, time.Time{}, time.Hour)
+	require.NoError(t, err)
+	require.NotNil(t, idx)
+	assert.Equal(t, int64(42), rv, "should pick the older but fresh-BuildTime candidate")
+	assert.Equal(t, 1.0, dt.counter(snapshotStatusSuccess))
+}
+
+// TestBuildIndex_RebuildUsesFreshSnapshot verifies that on the rebuild path
+// BuildIndex prefers downloading a fresh same-version snapshot over running
+// the builder.
+func TestBuildIndex_RebuildUsesFreshSnapshot(t *testing.T) {
+	store := &fakeRemoteIndexStore{}
+	store.put(makeULID(t, time.Now()), freshSnapshot(time.Minute))
+	be, metrics := newTestBleveBackend(t, SnapshotOptions{
+		Store:       store,
+		MinDocCount: 1,
+		MaxIndexAge: 24 * time.Hour,
+	})
+
+	builderCalled := atomic.Int32{}
+	idx, err := be.BuildIndex(context.Background(), newTestNsResource(), 10, nil, "rebuild",
+		func(resource.ResourceIndex) (int64, error) {
+			builderCalled.Add(1)
+			return 1, nil
+		},
+		nil, true /*rebuild*/, time.Time{}, time.Hour /*maxFreshSnapshotAge*/)
+	require.NoError(t, err)
+	require.NotNil(t, idx)
+	assert.Zero(t, builderCalled.Load(), "builder should not run when a fresh remote snapshot is used")
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotDownloads.WithLabelValues(snapshotPolicySameVersion, snapshotStatusSuccess)))
+}
+
+// TestBuildIndex_RebuildFallsBackToBuilder verifies that on the rebuild path
+// when no fresh same-version snapshot is available, BuildIndex runs the
+// builder rather than falling back to the tiered selection.
+func TestBuildIndex_RebuildFallsBackToBuilder(t *testing.T) {
+	store := &fakeRemoteIndexStore{}
+	// Older snapshot present — would be acceptable to the tiered policy on
+	// the initial-startup path, but must be ignored on the rebuild path.
+	store.put(makeULID(t, time.Now().Add(-3*time.Hour)), &IndexMeta{
+		BuildVersion:          "11.5.0",
+		LatestResourceVersion: 42,
+		UploadTimestamp:       time.Now().Add(-3 * time.Hour),
+		BuildTime:             time.Now().Add(-3 * time.Hour),
+	})
+	be, metrics := newTestBleveBackend(t, SnapshotOptions{
+		Store:       store,
+		MinDocCount: 1,
+		MaxIndexAge: 24 * time.Hour,
+	})
+
+	builderCalled := atomic.Int32{}
+	idx, err := be.BuildIndex(context.Background(), newTestNsResource(), 10, nil, "rebuild",
+		func(index resource.ResourceIndex) (int64, error) {
+			builderCalled.Add(1)
+			return 1, nil
+		},
+		nil, true /*rebuild*/, time.Time{}, time.Hour /*maxFreshSnapshotAge*/)
+	require.NoError(t, err)
+	require.NotNil(t, idx)
+	assert.Equal(t, int32(1), builderCalled.Load(), "builder should run when no fresh snapshot is available")
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotDownloads.WithLabelValues(snapshotPolicySameVersion, snapshotStatusEmpty)))
+	assert.Zero(t, store.downloadCalls.Load(), "older snapshot must not be downloaded on the rebuild path")
+}
+
+// TestBuildIndex_RebuildSkipsFastPathWhenDisabled verifies that passing
+// maxFreshSnapshotAge=0 disables the rebuild-path fast path entirely (no
+// list/get calls against the store).
+func TestBuildIndex_RebuildSkipsFastPathWhenDisabled(t *testing.T) {
+	store := &fakeRemoteIndexStore{}
+	store.put(makeULID(t, time.Now()), freshSnapshot(time.Minute))
+	be, _ := newTestBleveBackend(t, SnapshotOptions{
+		Store:       store,
+		MinDocCount: 1,
+		MaxIndexAge: 24 * time.Hour,
+	})
+
+	builderCalled := atomic.Int32{}
+	idx, err := be.BuildIndex(context.Background(), newTestNsResource(), 10, nil, "rebuild",
+		func(resource.ResourceIndex) (int64, error) {
+			builderCalled.Add(1)
+			return 1, nil
+		},
+		nil, true /*rebuild*/, time.Time{}, 0 /*disabled*/)
+	require.NoError(t, err)
+	require.NotNil(t, idx)
+	assert.Equal(t, int32(1), builderCalled.Load())
+	assert.Zero(t, store.downloadCalls.Load())
+}
+
 // TestBuildIndex_SkipsDownloadBelowMinDocCount ensures ListIndexes is not called
 // when the size parameter is below MinDocCount.
 func TestBuildIndex_SkipsDownloadBelowMinDocCount(t *testing.T) {
@@ -434,7 +701,7 @@ func TestBuildIndex_SkipsDownloadBelowMinDocCount(t *testing.T) {
 
 	idx, err := be.BuildIndex(context.Background(), newTestNsResource(), 1, nil, "test",
 		func(resource.ResourceIndex) (int64, error) { return 1, nil },
-		nil, false, time.Time{})
+		nil, false, time.Time{}, 0)
 	require.NoError(t, err)
 	require.NotNil(t, idx)
 	assert.Zero(t, store.listCalls.Load(), "ListIndexes should not be called below MinDocCount")
@@ -610,7 +877,7 @@ func TestBleveSnapshotLifecycleWithFileBucket(t *testing.T) {
 			},
 		}}))
 		return 2, nil
-	}, nil, false, time.Time{})
+	}, nil, false, time.Time{}, 0)
 	require.NoError(t, err)
 	require.NotNil(t, idxA)
 
@@ -630,12 +897,12 @@ func TestBleveSnapshotLifecycleWithFileBucket(t *testing.T) {
 	idxB, err := beB.BuildIndex(ctx, key, 10, nil, "startup", func(resource.ResourceIndex) (int64, error) {
 		builderCalled.Store(true)
 		return 0, fmt.Errorf("builder should not be called when a remote snapshot is available")
-	}, nil, false, time.Time{})
+	}, nil, false, time.Time{}, 0)
 	require.NoError(t, err)
 	require.NotNil(t, idxB)
 
 	assert.False(t, builderCalled.Load())
-	assert.Equal(t, 1.0, testutil.ToFloat64(metricsB.IndexSnapshotDownloads.WithLabelValues(snapshotStatusSuccess)))
+	assert.Equal(t, 1.0, testutil.ToFloat64(metricsB.IndexSnapshotDownloads.WithLabelValues(snapshotPolicyTiered, snapshotStatusSuccess)))
 
 	res, err := idxB.Search(ctx, nil, &resourcepb.ResourceSearchRequest{
 		Options: &resourcepb.ListOptions{Key: &resourcepb.ResourceKey{
@@ -712,12 +979,12 @@ func TestIntegrationBleveSnapshotRoundTrip(t *testing.T) {
 	idx, err := be.BuildIndex(ctx, key, 10, nil, "startup", func(resource.ResourceIndex) (int64, error) {
 		builderCalled.Store(true)
 		return 0, nil
-	}, nil, false, time.Time{})
+	}, nil, false, time.Time{}, 0)
 	require.NoError(t, err)
 	require.NotNil(t, idx)
 
 	assert.False(t, builderCalled.Load(), "builder should not be called when a remote snapshot is available")
-	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotDownloads.WithLabelValues(snapshotStatusSuccess)))
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotDownloads.WithLabelValues(snapshotPolicyTiered, snapshotStatusSuccess)))
 	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexBuildSkipped))
 
 	bi, ok := idx.(*bleveIndex)

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -197,7 +197,7 @@ func testBleveBackend(t *testing.T, backend *bleveBackend) {
 				return 0, err
 			}
 			return rv, nil
-		}, nil, false, time.Time{})
+		}, nil, false, time.Time{}, 0)
 		require.NoError(t, err)
 		require.NotNil(t, index)
 		dashboardsIndex = index
@@ -477,7 +477,7 @@ func testBleveBackend(t *testing.T, backend *bleveBackend) {
 				return 0, err
 			}
 			return rv, nil
-		}, nil, false, time.Time{})
+		}, nil, false, time.Time{}, 0)
 		require.NoError(t, err)
 		require.NotNil(t, index)
 		foldersIndex = index
@@ -991,7 +991,7 @@ func TestBuildIndexExpiration(t *testing.T) {
 			if !tc.inMemory {
 				size = 100 // above defaultFileTreshold
 			}
-			builtIndex, err := backend.BuildIndex(context.Background(), ns, size, nil, "test", indexTestDocs(ns, 1, 100), nil, false, time.Time{})
+			builtIndex, err := backend.BuildIndex(context.Background(), ns, size, nil, "test", indexTestDocs(ns, 1, 100), nil, false, time.Time{}, 0)
 			require.NoError(t, err)
 
 			// Evict indexes.
@@ -1039,9 +1039,9 @@ func TestCloseAllIndexes(t *testing.T) {
 
 	tmpDir := t.TempDir()
 	backend1, reg := setupBleveBackend(t, withRootDir(tmpDir))
-	_, err := backend1.BuildIndex(context.Background(), ns, 10 /* file based */, nil, "test", indexTestDocs(ns, 10, 100), nil, false, time.Time{})
+	_, err := backend1.BuildIndex(context.Background(), ns, 10 /* file based */, nil, "test", indexTestDocs(ns, 10, 100), nil, false, time.Time{}, 0)
 	require.NoError(t, err)
-	_, err = backend1.BuildIndex(context.Background(), ns2, 1 /* memory based */, nil, "test", indexTestDocs(ns, 10, 100), nil, false, time.Time{})
+	_, err = backend1.BuildIndex(context.Background(), ns2, 1 /* memory based */, nil, "test", indexTestDocs(ns, 10, 100), nil, false, time.Time{}, 0)
 	require.NoError(t, err)
 
 	// Verify two open indexes.
@@ -1079,7 +1079,7 @@ func TestBuildIndex(t *testing.T) {
 
 			{
 				backend, _ := setupBleveBackend(t, withFileThreshold(5), withRootDir(tmpDir))
-				_, err := backend.BuildIndex(context.Background(), ns, firstIndexDocsCount, nil, "test", indexTestDocs(ns, firstIndexDocsCount, 100), nil, false, lastImportTime)
+				_, err := backend.BuildIndex(context.Background(), ns, firstIndexDocsCount, nil, "test", indexTestDocs(ns, firstIndexDocsCount, 100), nil, false, lastImportTime, 0)
 				require.NoError(t, err)
 				backend.Stop()
 			}
@@ -1088,7 +1088,7 @@ func TestBuildIndex(t *testing.T) {
 			time.Sleep(1 * time.Millisecond)
 
 			newBackend, _ := setupBleveBackend(t, withFileThreshold(5), withRootDir(tmpDir))
-			idx, err := newBackend.BuildIndex(context.Background(), ns, secondIndexDocsCount, nil, "test", indexTestDocs(ns, secondIndexDocsCount, 100), nil, false, lastImportTime)
+			idx, err := newBackend.BuildIndex(context.Background(), ns, secondIndexDocsCount, nil, "test", indexTestDocs(ns, secondIndexDocsCount, 100), nil, false, lastImportTime, 0)
 			require.NoError(t, err)
 
 			cnt, err := idx.DocCount(context.Background(), "", nil)
@@ -1125,7 +1125,7 @@ func TestRebuildingIndexClosesPreviousCachedIndex(t *testing.T) {
 			if testCase.firstInMemory {
 				firstSize = 1
 			}
-			firstIndex, err := backend.BuildIndex(context.Background(), ns, int64(firstSize), nil, "test", indexTestDocs(ns, firstSize, 100), nil, false, time.Time{})
+			firstIndex, err := backend.BuildIndex(context.Background(), ns, int64(firstSize), nil, "test", indexTestDocs(ns, firstSize, 100), nil, false, time.Time{}, 0)
 			require.NoError(t, err)
 
 			if testCase.firstInMemory {
@@ -1141,7 +1141,7 @@ func TestRebuildingIndexClosesPreviousCachedIndex(t *testing.T) {
 				secondSize = 1
 				openInMemoryIndexes = 1
 			}
-			secondIndex, err := backend.BuildIndex(context.Background(), ns, int64(secondSize), nil, "test", indexTestDocs(ns, secondSize, 100), nil, false, time.Time{})
+			secondIndex, err := backend.BuildIndex(context.Background(), ns, int64(secondSize), nil, "test", indexTestDocs(ns, secondSize, 100), nil, false, time.Time{}, 0)
 			require.NoError(t, err)
 
 			if testCase.secondInMemory {
@@ -1323,11 +1323,11 @@ func testBleveIndexWithFailures(t *testing.T, fileBased bool) {
 	}
 	_, err := backend.BuildIndex(context.Background(), ns, size, nil, "test", func(index resource.ResourceIndex) (int64, error) {
 		return 0, fmt.Errorf("fail")
-	}, nil, false, time.Time{})
+	}, nil, false, time.Time{}, 0)
 	require.Error(t, err)
 
 	// Even though previous build of the index failed, new building of the index should work.
-	_, err = backend.BuildIndex(context.Background(), ns, size, nil, "test", indexTestDocs(ns, int(size), 100), nil, false, time.Time{})
+	_, err = backend.BuildIndex(context.Background(), ns, size, nil, "test", indexTestDocs(ns, int(size), 100), nil, false, time.Time{}, 0)
 	require.NoError(t, err)
 }
 
@@ -1339,7 +1339,7 @@ func TestIndexUpdate(t *testing.T) {
 	}
 
 	be, _ := setupBleveBackend(t)
-	idx, err := be.BuildIndex(t.Context(), ns, defaultFileThreshold*2 /* file based */, nil, "test", indexTestDocs(ns, 10, 100), updateTestDocs(ns, 5), false, time.Time{})
+	idx, err := be.BuildIndex(t.Context(), ns, defaultFileThreshold*2 /* file based */, nil, "test", indexTestDocs(ns, 10, 100), updateTestDocs(ns, 5), false, time.Time{}, 0)
 	require.NoError(t, err)
 
 	resp := searchTitle(t, idx, "gen", 10, ns)
@@ -1393,7 +1393,7 @@ func TestConcurrentIndexUpdateAndBuildIndex(t *testing.T) {
 		return sinceRV + int64(5), 5, err
 	}
 
-	idx, err := be.BuildIndex(t.Context(), ns, 10 /* file based */, nil, "test", indexTestDocs(ns, 10, 100), updaterFn, false, time.Time{})
+	idx, err := be.BuildIndex(t.Context(), ns, 10 /* file based */, nil, "test", indexTestDocs(ns, 10, 100), updaterFn, false, time.Time{}, 0)
 	require.NoError(t, err)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1401,7 +1401,7 @@ func TestConcurrentIndexUpdateAndBuildIndex(t *testing.T) {
 	_, err = idx.UpdateIndex(ctx)
 	require.NoError(t, err)
 
-	_, err = be.BuildIndex(t.Context(), ns, 10 /* file based */, nil, "test", indexTestDocs(ns, 10, 100), updaterFn, false, time.Time{})
+	_, err = be.BuildIndex(t.Context(), ns, 10 /* file based */, nil, "test", indexTestDocs(ns, 10, 100), updaterFn, false, time.Time{}, 0)
 	require.NoError(t, err)
 
 	_, err = idx.UpdateIndex(ctx)
@@ -1417,7 +1417,7 @@ func TestConcurrentIndexUpdateSearchAndRebuild(t *testing.T) {
 
 	be, _ := setupBleveBackend(t)
 
-	_, err := be.BuildIndex(t.Context(), ns, 10, nil, "test", indexTestDocs(ns, 10, 100), updateTestDocs(ns, 5), false, time.Time{})
+	_, err := be.BuildIndex(t.Context(), ns, 10, nil, "test", indexTestDocs(ns, 10, 100), updateTestDocs(ns, 5), false, time.Time{}, 0)
 	require.NoError(t, err)
 
 	wg := sync.WaitGroup{}
@@ -1478,7 +1478,7 @@ func TestConcurrentIndexUpdateSearchAndRebuild(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for ctx.Err() == nil {
-			_, err := be.BuildIndex(t.Context(), ns, 10, nil, "test", indexTestDocs(ns, 10, 100), updateTestDocs(ns, 5), false, time.Time{})
+			_, err := be.BuildIndex(t.Context(), ns, 10, nil, "test", indexTestDocs(ns, 10, 100), updateTestDocs(ns, 5), false, time.Time{}, 0)
 			require.NoError(t, err)
 			rebuilds.Inc()
 		}
@@ -1501,7 +1501,7 @@ func TestConcurrentIndexUpdateAndSearch(t *testing.T) {
 
 	be, _ := setupBleveBackend(t)
 
-	idx, err := be.BuildIndex(t.Context(), ns, 10 /* file based */, nil, "test", indexTestDocs(ns, 10, 100), updateTestDocs(ns, 5), false, time.Time{})
+	idx, err := be.BuildIndex(t.Context(), ns, 10 /* file based */, nil, "test", indexTestDocs(ns, 10, 100), updateTestDocs(ns, 5), false, time.Time{}, 0)
 	require.NoError(t, err)
 
 	wg := sync.WaitGroup{}
@@ -1561,7 +1561,7 @@ func TestConcurrentIndexUpdateAndSearchWithIndexMinUpdateInterval(t *testing.T) 
 	be, _ := setupBleveBackend(t, withIndexMinUpdateInterval(minInterval))
 
 	updateFn, updateCalls := updateTestDocsReturningMillisTimestamp(ns, 5)
-	idx, err := be.BuildIndex(t.Context(), ns, 10 /* file based */, nil, "test", indexTestDocs(ns, 10, 100), updateFn, false, time.Time{})
+	idx, err := be.BuildIndex(t.Context(), ns, 10 /* file based */, nil, "test", indexTestDocs(ns, 10, 100), updateFn, false, time.Time{}, 0)
 	require.NoError(t, err)
 
 	wg := sync.WaitGroup{}
@@ -1629,7 +1629,7 @@ func TestIndexUpdateWithErrors(t *testing.T) {
 		time.Sleep(100 * time.Millisecond)
 		return 0, 0, updateErr
 	}
-	idx, err := be.BuildIndex(t.Context(), ns, 10 /* file based */, nil, "test", indexTestDocs(ns, 10, 100), updaterFn, false, time.Time{})
+	idx, err := be.BuildIndex(t.Context(), ns, 10 /* file based */, nil, "test", indexTestDocs(ns, 10, 100), updaterFn, false, time.Time{}, 0)
 	require.NoError(t, err)
 
 	t.Run("update fail", func(t *testing.T) {
@@ -1663,7 +1663,7 @@ func TestIndexBuildInfo(t *testing.T) {
 	}
 
 	be, _ := setupBleveBackend(t, withFileThreshold(100))
-	index, err := be.BuildIndex(t.Context(), ns, 10, nil, "test", indexTestDocs(ns, 10, 100), nil, false, time.Time{})
+	index, err := be.BuildIndex(t.Context(), ns, 10, nil, "test", indexTestDocs(ns, 10, 100), nil, false, time.Time{}, 0)
 	require.NoError(t, err)
 
 	buildInfo, err := getBuildInfo(index.(*bleveIndex).index)
@@ -1716,7 +1716,7 @@ func TestBuildIndexReturnsErrorWhenIndexLocked(t *testing.T) {
 
 	// First, create a file-based index with one backend and keep it open
 	backend1, reg1 := setupBleveBackend(t, withRootDir(tmpDir))
-	index1, err := backend1.BuildIndex(context.Background(), ns, 100 /* file based */, nil, "test", indexTestDocs(ns, 10, 100), nil, false, time.Time{})
+	index1, err := backend1.BuildIndex(context.Background(), ns, 100 /* file based */, nil, "test", indexTestDocs(ns, 10, 100), nil, false, time.Time{}, 0)
 	require.NoError(t, err)
 	require.NotNil(t, index1)
 
@@ -1734,7 +1734,7 @@ func TestBuildIndexReturnsErrorWhenIndexLocked(t *testing.T) {
 	now := time.Now()
 	timeout, err := time.ParseDuration(boltTimeout)
 	require.NoError(t, err)
-	index2, err := backend2.BuildIndex(context.Background(), ns, 100 /* file based */, nil, "test", indexTestDocs(ns, 10, 100), nil, false, time.Time{})
+	index2, err := backend2.BuildIndex(context.Background(), ns, 100 /* file based */, nil, "test", indexTestDocs(ns, 10, 100), nil, false, time.Time{}, 0)
 	require.Error(t, err)
 	require.ErrorIs(t, err, bolterrors.ErrTimeout)
 	require.Nil(t, index2)

--- a/pkg/storage/unified/testing/benchmark.go
+++ b/pkg/storage/unified/testing/benchmark.go
@@ -377,7 +377,7 @@ func runSearchBackendBenchmarkWriteThroughput(ctx context.Context, backend resou
 	size := int64(10000) // force the index to be on disk
 	index, err := backend.BuildIndex(ctx, nr, size, nil, "benchmark", func(index resource.ResourceIndex) (int64, error) {
 		return 0, nil
-	}, nil, false, time.Time{})
+	}, nil, false, time.Time{}, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to initialize backend: %w", err)
 	}

--- a/pkg/storage/unified/testing/search_backend.go
+++ b/pkg/storage/unified/testing/search_backend.go
@@ -85,7 +85,7 @@ func runTestSearchBackendBuildIndex(t *testing.T, backend resource.SearchBackend
 			return 0, err
 		}
 		return 1, nil
-	}, nil, false, time.Time{})
+	}, nil, false, time.Time{}, 0)
 	require.NoError(t, err)
 	require.NotNil(t, index)
 
@@ -152,7 +152,7 @@ func runTestResourceIndex(t *testing.T, backend resource.SearchBackend, nsPrefix
 		})
 		require.NoError(t, err)
 		return resourceVersion, nil
-	}, nil, false, time.Time{})
+	}, nil, false, time.Time{}, 0)
 	require.NoError(t, err)
 	require.NotNil(t, index)
 
@@ -335,7 +335,7 @@ func runTestResourceIndex(t *testing.T, backend resource.SearchBackend, nsPrefix
 			})
 			require.NoError(t, err)
 			return newResourceVersion, nil
-		}, nil, false, time.Time{})
+		}, nil, false, time.Time{}, 0)
 		require.NoError(t, err)
 		require.NotNil(t, index)
 


### PR DESCRIPTION
On the rebuild path, BuildIndex now probes the remote index store for a same-version snapshot whose `BuildTime` is fresh enough (within 10% of the per-resource rebuild interval) and strictly newer than `lastImportTime`. On hit, downloads it instead of rebuilding from scratch. On miss, falls through to a from-scratch rebuild — no tiered fallback (we already have a working index).

Built on top of the `findFreshSnapshotByBuildStart` helper landed in #124061.

**Changes**:

- New `tryDownloadFreshSnapshot` helper using the build-start probe, with a `lastImportTime` correctness check folded in (refuses snapshots whose `BuildTime` predates the latest known KV mutation).
- `SearchBackend.BuildIndex` gains a `maxFreshSnapshotAge time.Duration` parameter; the caller in `searchServer.build` derives it from the per-resource rebuild interval.
- `index_server_snapshot_downloads_total` gains a `policy` label with values `tiered` (existing initial-startup path) and `same_version` (new rebuild-path probe).
- Refactor: `tryDownloadRemoteSnapshot` and `tryDownloadFreshSnapshot` now share a `downloadSelectedSnapshot` template that owns the trace span, log lines, outcome metric, and the reserve-download-open-validate flow. Each policy supplies just its selection logic via a `snapshotSelectFn` closure.

**Behaviour preserved**: tiered initial-startup path is unchanged; the metric counter increments exactly once per call; `IndexSnapshotDownloadDuration` histogram still measures only the post-selection download+validate window.

**Follow-up (separate PR)**: refactor `BuildIndex`'s index-acquisition phase. After this lands, `BuildIndex` carries three distinct download/reuse strategies inlined in nested if/else and still wears `//nolint:gocyclo`. Best done after subsequent changes touching the same region land, so we refactor once at the end.
