### PR TITLE
Provisioning: Don't mark folders pending due to _folder.json metadata

### DIFF
--- a/public/app/features/provisioning/utils/folderMetadata.test.ts
+++ b/public/app/features/provisioning/utils/folderMetadata.test.ts
@@ -1,6 +1,11 @@
 import { type Condition } from 'app/api/clients/provisioning/v0alpha1';
 
-import { getFolderMetadataPath, hasMissingFolderMetadata } from './folderMetadata';
+import {
+  getFolderMetadataPath,
+  getParentFolderResourceHash,
+  hasMissingFolderMetadata,
+  isFolderMetadataPath,
+} from './folderMetadata';
 
 describe('getFolderMetadataPath', () => {
   it('returns _folder.json for root (no path)', () => {
@@ -11,6 +16,45 @@ describe('getFolderMetadataPath', () => {
   it('appends _folder.json to a given path', () => {
     expect(getFolderMetadataPath('dashboards')).toBe('dashboards/_folder.json');
     expect(getFolderMetadataPath('a/b')).toBe('a/b/_folder.json');
+  });
+});
+
+describe('isFolderMetadataPath', () => {
+  it('matches root-level _folder.json', () => {
+    expect(isFolderMetadataPath('_folder.json')).toBe(true);
+  });
+
+  it('matches nested _folder.json', () => {
+    expect(isFolderMetadataPath('dashboards/_folder.json')).toBe(true);
+    expect(isFolderMetadataPath('a/b/c/_folder.json')).toBe(true);
+  });
+
+  it('does not match other JSON files', () => {
+    expect(isFolderMetadataPath('dashboards/my-dashboard.json')).toBe(false);
+    expect(isFolderMetadataPath('_folder.json.bak')).toBe(false);
+    expect(isFolderMetadataPath('dashboards/folder.json')).toBe(false);
+  });
+});
+
+describe('getParentFolderResourceHash', () => {
+  const lookup = (entries: Record<string, string | undefined>) => (path: string) => entries[path];
+
+  it('returns undefined for root-level _folder.json (no parent)', () => {
+    expect(getParentFolderResourceHash('_folder.json', lookup({}))).toBeUndefined();
+  });
+
+  it("returns the parent folder's resource hash for nested _folder.json", () => {
+    expect(getParentFolderResourceHash('dashboards/_folder.json', lookup({ dashboards: 'meta-hash' }))).toBe(
+      'meta-hash'
+    );
+  });
+
+  it('returns undefined when the parent folder has no resource hash', () => {
+    expect(getParentFolderResourceHash('dashboards/_folder.json', lookup({}))).toBeUndefined();
+  });
+
+  it('walks deeply nested paths', () => {
+    expect(getParentFolderResourceHash('a/b/c/_folder.json', lookup({ 'a/b/c': 'hash-c' }))).toBe('hash-c');
   });
 });
 

--- a/public/app/features/provisioning/utils/folderMetadata.ts
+++ b/public/app/features/provisioning/utils/folderMetadata.ts
@@ -6,6 +6,26 @@ export function getFolderMetadataPath(sourcePath?: string): string {
   return sourcePath ? `${sourcePath}/${FOLDER_METADATA_FILE}` : FOLDER_METADATA_FILE;
 }
 
+export function isFolderMetadataPath(path: string): boolean {
+  return path === FOLDER_METADATA_FILE || path.endsWith(`/${FOLDER_METADATA_FILE}`);
+}
+
+/**
+ * For a _folder.json path, returns the resource hash of the parent folder it describes
+ * (the synced metadata hash). Returns undefined for root-level _folder.json (no parent
+ * folder exists) or when the parent folder has no resource.
+ */
+export function getParentFolderResourceHash(
+  metadataPath: string,
+  getResourceHashByPath: (path: string) => string | undefined
+): string | undefined {
+  const lastSlash = metadataPath.lastIndexOf('/');
+  if (lastSlash === -1) {
+    return undefined;
+  }
+  return getResourceHashByPath(metadataPath.substring(0, lastSlash));
+}
+
 /** Returns true when the backend's PullStatus condition reports missing _folder.json metadata. */
 export function hasMissingFolderMetadata(conditions: Condition[] | undefined): boolean {
   const condition = conditions?.find((c) => c.type === 'PullStatus');

--- a/public/app/features/provisioning/utils/treeUtils.test.ts
+++ b/public/app/features/provisioning/utils/treeUtils.test.ts
@@ -602,9 +602,9 @@ describe('buildTree', () => {
     expect(metadataNode?.status).toBe('synced');
   });
 
-  it('should mark _folder.json and parent folder pending when _folder.json was updated locally', () => {
-    // File hash differs from the folder resource hash → metadata file was updated in repo
-    // but not yet synced. Both the file row and the parent folder must reflect this.
+  it('should mark _folder.json and parent folder pending when _folder.json was updated remotely', () => {
+    // File hash differs from the folder resource hash → metadata file was updated in the
+    // remote repo but not yet synced. Both the file row and the parent folder must reflect this.
     const syncedDashboard = { ...mockResource, hash: 'matching-hash' };
     const mergedItems = [
       { path: 'dashboards', file: { path: 'dashboards', hash: '' }, resource: mockFolderResource },
@@ -651,9 +651,9 @@ describe('buildTree', () => {
     expect(metadataNode?.status).toBe('pending');
   });
 
-  it('should mark parent folder pending when _folder.json was removed locally but folder resource still has metadata hash', () => {
-    // File missing from repo but folder resource still has a non-empty hash → metadata
-    // was previously synced and the file was deleted. The folder must reflect pending.
+  it('should mark parent folder pending when _folder.json was removed remotely but folder resource still has metadata hash', () => {
+    // File missing from the remote repo but folder resource still has a non-empty hash →
+    // metadata was previously synced and the file was deleted. The folder must reflect pending.
     const syncedDashboard = { ...mockResource, hash: 'matching-hash' };
     const mergedItems = [
       { path: 'dashboards', file: { path: 'dashboards', hash: '' }, resource: mockFolderResource },

--- a/public/app/features/provisioning/utils/treeUtils.test.ts
+++ b/public/app/features/provisioning/utils/treeUtils.test.ts
@@ -403,6 +403,10 @@ describe('buildTree', () => {
     const mergedItems = [
       { path: 'folder', file: { path: 'folder', hash: '' }, resource: mockFolderResource },
       {
+        path: 'folder/_folder.json',
+        file: { path: 'folder/_folder.json', size: '200', hash: mockFolderResource.hash },
+      },
+      {
         path: 'folder/dashboard1.json',
         file: { path: 'folder/dashboard1.json', size: '100', hash: 'matching-hash' },
         resource: syncedResource,
@@ -517,10 +521,15 @@ describe('buildTree', () => {
   });
 
   it('should set synced status for folder inferred from files with matching resource', () => {
-    // Folder inferred from file paths AND exists in resources → synced
+    // Folder inferred from file paths AND exists in resources with its metadata file
+    // matching the resource hash → synced.
     const syncedResource = { ...mockResource, hash: 'matching-hash' };
     const mergedItems = [
       { path: 'folder', file: { path: 'folder', hash: '' }, resource: mockFolderResource },
+      {
+        path: 'folder/_folder.json',
+        file: { path: 'folder/_folder.json', size: '200', hash: mockFolderResource.hash },
+      },
       {
         path: 'folder/dashboard.json',
         file: { path: 'folder/dashboard.json', size: '100', hash: 'matching-hash' },
@@ -642,17 +651,63 @@ describe('buildTree', () => {
     expect(metadataNode?.status).toBe('pending');
   });
 
+  it('should mark parent folder pending when _folder.json was removed locally but folder resource still has metadata hash', () => {
+    // File missing from repo but folder resource still has a non-empty hash → metadata
+    // was previously synced and the file was deleted. The folder must reflect pending.
+    const syncedDashboard = { ...mockResource, hash: 'matching-hash' };
+    const mergedItems = [
+      { path: 'dashboards', file: { path: 'dashboards', hash: '' }, resource: mockFolderResource },
+      {
+        path: 'dashboards/my-dashboard.json',
+        file: { path: 'dashboards/my-dashboard.json', size: '100', hash: 'matching-hash' },
+        resource: syncedDashboard,
+      },
+    ];
+
+    const result = buildTree(mergedItems);
+
+    expect(result[0].type).toBe('Folder');
+    expect(result[0].missingFolderMetadata).toBe(true);
+    expect(result[0].status).toBe('pending');
+  });
+
+  it('should keep parent folder synced when _folder.json is missing and folder has no metadata hash (never had metadata)', () => {
+    // Folder resource hash empty → never had metadata. Missing _folder.json is the
+    // expected state; folder should not be flagged pending on this account.
+    const folderWithoutMetadataHash = { ...mockFolderResource, hash: '' };
+    const syncedDashboard = { ...mockResource, hash: 'matching-hash' };
+    const mergedItems = [
+      { path: 'dashboards', file: { path: 'dashboards', hash: '' }, resource: folderWithoutMetadataHash },
+      {
+        path: 'dashboards/my-dashboard.json',
+        file: { path: 'dashboards/my-dashboard.json', size: '100', hash: 'matching-hash' },
+        resource: syncedDashboard,
+      },
+    ];
+
+    const result = buildTree(mergedItems);
+
+    expect(result[0].type).toBe('Folder');
+    expect(result[0].missingFolderMetadata).toBe(true);
+    expect(result[0].status).toBe('synced');
+  });
+
   it('should compare root-level _folder.json against repository state (no parent resource)', () => {
     // Root-level _folder.json has no parent folder resource, so we cannot determine a
     // matching resource hash — it falls back to pending until the backend reports otherwise.
     const rootFolderResource: ResourceListItem = {
       ...mockFolderResource,
       path: 'dashboards',
+      hash: 'meta-dashboards',
     };
     const syncedResource = { ...mockResource, hash: 'matching-hash' };
     const mergedItems = [
       { path: '_folder.json', file: { path: '_folder.json', size: '200', hash: 'meta-root' } },
       { path: 'dashboards', file: { path: 'dashboards', hash: '' }, resource: rootFolderResource },
+      {
+        path: 'dashboards/_folder.json',
+        file: { path: 'dashboards/_folder.json', size: '200', hash: rootFolderResource.hash },
+      },
       {
         path: 'dashboards/my-dashboard.json',
         file: { path: 'dashboards/my-dashboard.json', size: '100', hash: 'matching-hash' },

--- a/public/app/features/provisioning/utils/treeUtils.test.ts
+++ b/public/app/features/provisioning/utils/treeUtils.test.ts
@@ -568,6 +568,52 @@ describe('buildTree', () => {
     expect(result[0].missingFolderMetadata).toBe(false);
   });
 
+  it('should keep folder synced when only _folder.json has no matching resource', () => {
+    // _folder.json is folder metadata — it should not flip the parent folder to pending,
+    // and it should not show its own sync status.
+    const syncedResource = { ...mockResource, hash: 'matching-hash' };
+    const mergedItems = [
+      { path: 'dashboards', file: { path: 'dashboards', hash: '' }, resource: mockFolderResource },
+      { path: 'dashboards/_folder.json', file: { path: 'dashboards/_folder.json', size: '200', hash: 'meta123' } },
+      {
+        path: 'dashboards/my-dashboard.json',
+        file: { path: 'dashboards/my-dashboard.json', size: '100', hash: 'matching-hash' },
+        resource: syncedResource,
+      },
+    ];
+
+    const result = buildTree(mergedItems);
+
+    expect(result[0].type).toBe('Folder');
+    expect(result[0].status).toBe('synced');
+    const metadataNode = result[0].children.find((c) => c.path === 'dashboards/_folder.json');
+    expect(metadataNode?.status).toBeUndefined();
+  });
+
+  it('should keep root-level folder synced when only root _folder.json has no resource', () => {
+    const rootFolderResource: ResourceListItem = {
+      ...mockFolderResource,
+      path: 'dashboards',
+    };
+    const syncedResource = { ...mockResource, hash: 'matching-hash' };
+    const mergedItems = [
+      { path: '_folder.json', file: { path: '_folder.json', size: '200', hash: 'meta-root' } },
+      { path: 'dashboards', file: { path: 'dashboards', hash: '' }, resource: rootFolderResource },
+      {
+        path: 'dashboards/my-dashboard.json',
+        file: { path: 'dashboards/my-dashboard.json', size: '100', hash: 'matching-hash' },
+        resource: syncedResource,
+      },
+    ];
+
+    const result = buildTree(mergedItems);
+
+    const rootMetadata = result.find((n) => n.path === '_folder.json');
+    expect(rootMetadata?.status).toBeUndefined();
+    const folder = result.find((n) => n.path === 'dashboards');
+    expect(folder?.status).toBe('synced');
+  });
+
   it('should not set missingFolderMetadata for inferred folders without a resource', () => {
     const mergedItems = [
       { path: 'dashboards', file: { path: 'dashboards', hash: '' } },

--- a/public/app/features/provisioning/utils/treeUtils.test.ts
+++ b/public/app/features/provisioning/utils/treeUtils.test.ts
@@ -692,6 +692,111 @@ describe('buildTree', () => {
     expect(result[0].status).toBe('synced');
   });
 
+  it('should mark _folder.json and inferred parent folder pending when parent has no resource', () => {
+    // Matrix row 6: parent folder is inferred from file paths but not yet provisioned
+    // (no resource), so getFolderMetadataResourceHash returns undefined → pending row,
+    // pending folder via child propagation.
+    const syncedDashboard = { ...mockResource, hash: 'matching-hash' };
+    const mergedItems = [
+      // Inferred folder (no resource) — same shape mergeFilesAndResources produces.
+      { path: 'dashboards', file: { path: 'dashboards', hash: '' } },
+      {
+        path: 'dashboards/_folder.json',
+        file: { path: 'dashboards/_folder.json', size: '200', hash: 'some-meta-hash' },
+      },
+      {
+        path: 'dashboards/my-dashboard.json',
+        file: { path: 'dashboards/my-dashboard.json', size: '100', hash: 'matching-hash' },
+        resource: syncedDashboard,
+      },
+    ];
+
+    const result = buildTree(mergedItems);
+
+    const folder = result.find((n) => n.path === 'dashboards');
+    expect(folder?.type).toBe('Folder');
+    expect(folder?.resourceName).toBeUndefined();
+    expect(folder?.status).toBe('pending');
+    const metadataNode = folder?.children.find((c) => c.path === 'dashboards/_folder.json');
+    expect(metadataNode?.status).toBe('pending');
+  });
+
+  it('should mark folder pending when _folder.json is synced but a sibling dashboard is pending', () => {
+    // Matrix row 9: a synced metadata file does not save the parent folder when another
+    // child (a dashboard) is out of sync — the dashboard's pending status propagates.
+    const driftedDashboard = { ...mockResource, hash: 'resource-hash' };
+    const mergedItems = [
+      { path: 'dashboards', file: { path: 'dashboards', hash: '' }, resource: mockFolderResource },
+      {
+        path: 'dashboards/_folder.json',
+        file: { path: 'dashboards/_folder.json', size: '200', hash: mockFolderResource.hash },
+      },
+      {
+        path: 'dashboards/my-dashboard.json',
+        file: { path: 'dashboards/my-dashboard.json', size: '100', hash: 'file-hash-drifted' },
+        resource: driftedDashboard,
+      },
+    ];
+
+    const result = buildTree(mergedItems);
+
+    expect(result[0].status).toBe('pending');
+    const metadataNode = result[0].children.find((c) => c.path === 'dashboards/_folder.json');
+    expect(metadataNode?.status).toBe('synced');
+    const dashboardNode = result[0].children.find((c) => c.path === 'dashboards/my-dashboard.json');
+    expect(dashboardNode?.status).toBe('pending');
+  });
+
+  it('should evaluate sibling folders independently when one has pending metadata and the other is fully synced', () => {
+    // Matrix row 12: a pending _folder.json in one folder must not bleed into a sibling
+    // folder that is fully synced.
+    const folderASynced: ResourceListItem = {
+      ...mockFolderResource,
+      path: 'folder-a',
+      name: 'folder-a-uid',
+      hash: 'meta-a',
+    };
+    const folderBSynced: ResourceListItem = {
+      ...mockFolderResource,
+      path: 'folder-b',
+      name: 'folder-b-uid',
+      hash: 'meta-b',
+    };
+    const dashboardA = { ...mockResource, name: 'dash-a', hash: 'dash-a-hash' };
+    const dashboardB = { ...mockResource, name: 'dash-b', hash: 'dash-b-hash' };
+    const mergedItems = [
+      { path: 'folder-a', file: { path: 'folder-a', hash: '' }, resource: folderASynced },
+      // folder-a metadata is updated remotely (file hash differs from resource hash) → pending
+      {
+        path: 'folder-a/_folder.json',
+        file: { path: 'folder-a/_folder.json', size: '200', hash: 'meta-a-drifted' },
+      },
+      {
+        path: 'folder-a/dashboard.json',
+        file: { path: 'folder-a/dashboard.json', size: '100', hash: 'dash-a-hash' },
+        resource: dashboardA,
+      },
+      // folder-b is fully synced (metadata file hash matches resource hash)
+      { path: 'folder-b', file: { path: 'folder-b', hash: '' }, resource: folderBSynced },
+      {
+        path: 'folder-b/_folder.json',
+        file: { path: 'folder-b/_folder.json', size: '200', hash: folderBSynced.hash },
+      },
+      {
+        path: 'folder-b/dashboard.json',
+        file: { path: 'folder-b/dashboard.json', size: '100', hash: 'dash-b-hash' },
+        resource: dashboardB,
+      },
+    ];
+
+    const result = buildTree(mergedItems);
+
+    const folderA = result.find((n) => n.path === 'folder-a');
+    const folderB = result.find((n) => n.path === 'folder-b');
+    expect(folderA?.status).toBe('pending');
+    expect(folderB?.status).toBe('synced');
+  });
+
   it('should compare root-level _folder.json against repository state (no parent resource)', () => {
     // Root-level _folder.json has no parent folder resource, so we cannot determine a
     // matching resource hash — it falls back to pending until the backend reports otherwise.

--- a/public/app/features/provisioning/utils/treeUtils.test.ts
+++ b/public/app/features/provisioning/utils/treeUtils.test.ts
@@ -568,17 +568,20 @@ describe('buildTree', () => {
     expect(result[0].missingFolderMetadata).toBe(false);
   });
 
-  it('should keep folder synced when only _folder.json has no matching resource', () => {
-    // _folder.json is folder metadata — it should not flip the parent folder to pending,
-    // and it should not show its own sync status.
-    const syncedResource = { ...mockResource, hash: 'matching-hash' };
+  it('should mark _folder.json synced when its hash matches the parent folder resource hash', () => {
+    // The folder resource hash IS the synced metadata hash, so _folder.json is compared
+    // against its parent folder's resource hash (not its own resource — it has none).
+    const syncedDashboard = { ...mockResource, hash: 'matching-hash' };
     const mergedItems = [
       { path: 'dashboards', file: { path: 'dashboards', hash: '' }, resource: mockFolderResource },
-      { path: 'dashboards/_folder.json', file: { path: 'dashboards/_folder.json', size: '200', hash: 'meta123' } },
+      {
+        path: 'dashboards/_folder.json',
+        file: { path: 'dashboards/_folder.json', size: '200', hash: mockFolderResource.hash },
+      },
       {
         path: 'dashboards/my-dashboard.json',
         file: { path: 'dashboards/my-dashboard.json', size: '100', hash: 'matching-hash' },
-        resource: syncedResource,
+        resource: syncedDashboard,
       },
     ];
 
@@ -587,10 +590,61 @@ describe('buildTree', () => {
     expect(result[0].type).toBe('Folder');
     expect(result[0].status).toBe('synced');
     const metadataNode = result[0].children.find((c) => c.path === 'dashboards/_folder.json');
-    expect(metadataNode?.status).toBeUndefined();
+    expect(metadataNode?.status).toBe('synced');
   });
 
-  it('should keep root-level folder synced when only root _folder.json has no resource', () => {
+  it('should mark _folder.json and parent folder pending when _folder.json was updated locally', () => {
+    // File hash differs from the folder resource hash → metadata file was updated in repo
+    // but not yet synced. Both the file row and the parent folder must reflect this.
+    const syncedDashboard = { ...mockResource, hash: 'matching-hash' };
+    const mergedItems = [
+      { path: 'dashboards', file: { path: 'dashboards', hash: '' }, resource: mockFolderResource },
+      {
+        path: 'dashboards/_folder.json',
+        file: { path: 'dashboards/_folder.json', size: '200', hash: 'updated-meta-hash' },
+      },
+      {
+        path: 'dashboards/my-dashboard.json',
+        file: { path: 'dashboards/my-dashboard.json', size: '100', hash: 'matching-hash' },
+        resource: syncedDashboard,
+      },
+    ];
+
+    const result = buildTree(mergedItems);
+
+    expect(result[0].status).toBe('pending');
+    const metadataNode = result[0].children.find((c) => c.path === 'dashboards/_folder.json');
+    expect(metadataNode?.status).toBe('pending');
+  });
+
+  it('should mark _folder.json and parent folder pending when _folder.json was added but folder has no metadata hash yet', () => {
+    // File present in repo but parent folder resource has empty hash → freshly added,
+    // not yet reflected on the resource.
+    const folderWithoutMetadataHash = { ...mockFolderResource, hash: '' };
+    const syncedDashboard = { ...mockResource, hash: 'matching-hash' };
+    const mergedItems = [
+      { path: 'dashboards', file: { path: 'dashboards', hash: '' }, resource: folderWithoutMetadataHash },
+      {
+        path: 'dashboards/_folder.json',
+        file: { path: 'dashboards/_folder.json', size: '200', hash: 'new-meta-hash' },
+      },
+      {
+        path: 'dashboards/my-dashboard.json',
+        file: { path: 'dashboards/my-dashboard.json', size: '100', hash: 'matching-hash' },
+        resource: syncedDashboard,
+      },
+    ];
+
+    const result = buildTree(mergedItems);
+
+    expect(result[0].status).toBe('pending');
+    const metadataNode = result[0].children.find((c) => c.path === 'dashboards/_folder.json');
+    expect(metadataNode?.status).toBe('pending');
+  });
+
+  it('should compare root-level _folder.json against repository state (no parent resource)', () => {
+    // Root-level _folder.json has no parent folder resource, so we cannot determine a
+    // matching resource hash — it falls back to pending until the backend reports otherwise.
     const rootFolderResource: ResourceListItem = {
       ...mockFolderResource,
       path: 'dashboards',
@@ -609,7 +663,7 @@ describe('buildTree', () => {
     const result = buildTree(mergedItems);
 
     const rootMetadata = result.find((n) => n.path === '_folder.json');
-    expect(rootMetadata?.status).toBeUndefined();
+    expect(rootMetadata?.status).toBe('pending');
     const folder = result.find((n) => n.path === 'dashboards');
     expect(folder?.status).toBe('synced');
   });

--- a/public/app/features/provisioning/utils/treeUtils.ts
+++ b/public/app/features/provisioning/utils/treeUtils.ts
@@ -108,12 +108,8 @@ function calculateFolderStatus(node: TreeItem): SyncStatus | undefined {
     return node.status;
   }
 
-  // If any child is pending, folder is pending. _folder.json is folder metadata,
-  // not an independently synced resource, so it is excluded from this aggregation.
+  // If any child is pending, folder is pending.
   for (const child of node.children) {
-    if (isFolderMetadataPath(child.path)) {
-      continue;
-    }
     const childStatus = child.type === 'Folder' ? calculateFolderStatus(child) : child.status;
     if (childStatus === 'pending') {
       return 'pending';
@@ -123,15 +119,34 @@ function calculateFolderStatus(node: TreeItem): SyncStatus | undefined {
   return node.status;
 }
 
+// _folder.json is folder metadata: its sync state is determined by comparing the
+// file hash against the parent folder's resource hash (which is the metadata hash).
+// Returns undefined for root-level _folder.json (no parent folder resource exists).
+function getFolderMetadataResourceHash(
+  metadataPath: string,
+  mergedByPath: Map<string, MergedItem>
+): string | undefined {
+  const lastSlash = metadataPath.lastIndexOf('/');
+  if (lastSlash === -1) {
+    return undefined;
+  }
+  const parentPath = metadataPath.substring(0, lastSlash);
+  return mergedByPath.get(parentPath)?.resource?.hash;
+}
+
 export function buildTree(mergedItems: MergedItem[]): TreeItem[] {
   const nodeMap = new Map<string, TreeItem>();
   const roots: TreeItem[] = [];
+  const mergedByPath = new Map(mergedItems.map((item) => [item.path, item]));
 
   // Create all nodes (files, dashboards, folders)
   for (const item of mergedItems) {
     const type = getItemType(item.path, item.resource);
-    const showStatus =
-      !isFolderMetadataPath(item.path) && (type === 'Dashboard' || type === 'Folder' || item.path.endsWith('.json'));
+    const isFolderMetadata = isFolderMetadataPath(item.path);
+    const showStatus = type === 'Dashboard' || type === 'Folder' || item.path.endsWith('.json');
+    const resourceHash = isFolderMetadata
+      ? getFolderMetadataResourceHash(item.path, mergedByPath)
+      : item.resource?.hash;
 
     nodeMap.set(item.path, {
       path: item.path,
@@ -141,7 +156,7 @@ export function buildTree(mergedItems: MergedItem[]): TreeItem[] {
       children: [],
       resourceName: item.resource?.name,
       hash: item.file?.hash ?? item.resource?.hash,
-      status: showStatus ? getStatus(item.file?.hash, item.resource?.hash) : undefined,
+      status: showStatus ? getStatus(item.file?.hash, resourceHash) : undefined,
       hasFile: !!item.file,
     });
   }

--- a/public/app/features/provisioning/utils/treeUtils.ts
+++ b/public/app/features/provisioning/utils/treeUtils.ts
@@ -1,9 +1,14 @@
 import { type IconName } from '@grafana/ui';
 import { type ResourceListItem } from 'app/api/clients/provisioning/v0alpha1';
 
+import { FOLDER_METADATA_FILE } from '../constants';
 import { type FileDetails, type FlatTreeItem, type ItemType, type SyncStatus, type TreeItem } from '../types';
 
 import { getFolderMetadataPath } from './folderMetadata';
+
+function isFolderMetadataPath(path: string): boolean {
+  return path === FOLDER_METADATA_FILE || path.endsWith(`/${FOLDER_METADATA_FILE}`);
+}
 
 const collator = new Intl.Collator();
 
@@ -103,8 +108,12 @@ function calculateFolderStatus(node: TreeItem): SyncStatus | undefined {
     return node.status;
   }
 
-  // If any child is pending, folder is pending
+  // If any child is pending, folder is pending. _folder.json is folder metadata,
+  // not an independently synced resource, so it is excluded from this aggregation.
   for (const child of node.children) {
+    if (isFolderMetadataPath(child.path)) {
+      continue;
+    }
     const childStatus = child.type === 'Folder' ? calculateFolderStatus(child) : child.status;
     if (childStatus === 'pending') {
       return 'pending';
@@ -121,7 +130,8 @@ export function buildTree(mergedItems: MergedItem[]): TreeItem[] {
   // Create all nodes (files, dashboards, folders)
   for (const item of mergedItems) {
     const type = getItemType(item.path, item.resource);
-    const showStatus = type === 'Dashboard' || type === 'Folder' || item.path.endsWith('.json');
+    const showStatus =
+      !isFolderMetadataPath(item.path) && (type === 'Dashboard' || type === 'Folder' || item.path.endsWith('.json'));
 
     nodeMap.set(item.path, {
       path: item.path,

--- a/public/app/features/provisioning/utils/treeUtils.ts
+++ b/public/app/features/provisioning/utils/treeUtils.ts
@@ -163,7 +163,7 @@ export function buildTree(mergedItems: MergedItem[]): TreeItem[] {
 
   // Detect provisioned folders missing _folder.json metadata. If the folder resource
   // has a non-empty hash, the metadata was previously synced — its absence means the
-  // file was removed from the repo, so the folder is pending until the next sync.
+  // file was removed from the remote repo, so the folder is pending until the next sync.
   for (const [path, node] of nodeMap) {
     if (node.type === 'Folder' && node.resourceName) {
       const metadataPath = getFolderMetadataPath(path);

--- a/public/app/features/provisioning/utils/treeUtils.ts
+++ b/public/app/features/provisioning/utils/treeUtils.ts
@@ -161,11 +161,17 @@ export function buildTree(mergedItems: MergedItem[]): TreeItem[] {
     });
   }
 
-  // Detect provisioned folders missing _folder.json metadata
+  // Detect provisioned folders missing _folder.json metadata. If the folder resource
+  // has a non-empty hash, the metadata was previously synced — its absence means the
+  // file was removed from the repo, so the folder is pending until the next sync.
   for (const [path, node] of nodeMap) {
     if (node.type === 'Folder' && node.resourceName) {
       const metadataPath = getFolderMetadataPath(path);
-      node.missingFolderMetadata = !nodeMap.has(metadataPath);
+      const fileExists = nodeMap.has(metadataPath);
+      node.missingFolderMetadata = !fileExists;
+      if (!fileExists && mergedByPath.get(path)?.resource?.hash) {
+        node.status = 'pending';
+      }
     }
   }
 

--- a/public/app/features/provisioning/utils/treeUtils.ts
+++ b/public/app/features/provisioning/utils/treeUtils.ts
@@ -1,14 +1,9 @@
 import { type IconName } from '@grafana/ui';
 import { type ResourceListItem } from 'app/api/clients/provisioning/v0alpha1';
 
-import { FOLDER_METADATA_FILE } from '../constants';
 import { type FileDetails, type FlatTreeItem, type ItemType, type SyncStatus, type TreeItem } from '../types';
 
-import { getFolderMetadataPath } from './folderMetadata';
-
-function isFolderMetadataPath(path: string): boolean {
-  return path === FOLDER_METADATA_FILE || path.endsWith(`/${FOLDER_METADATA_FILE}`);
-}
+import { getFolderMetadataPath, getParentFolderResourceHash, isFolderMetadataPath } from './folderMetadata';
 
 const collator = new Intl.Collator();
 
@@ -119,25 +114,11 @@ function calculateFolderStatus(node: TreeItem): SyncStatus | undefined {
   return node.status;
 }
 
-// _folder.json is folder metadata: its sync state is determined by comparing the
-// file hash against the parent folder's resource hash (which is the metadata hash).
-// Returns undefined for root-level _folder.json (no parent folder resource exists).
-function getFolderMetadataResourceHash(
-  metadataPath: string,
-  mergedByPath: Map<string, MergedItem>
-): string | undefined {
-  const lastSlash = metadataPath.lastIndexOf('/');
-  if (lastSlash === -1) {
-    return undefined;
-  }
-  const parentPath = metadataPath.substring(0, lastSlash);
-  return mergedByPath.get(parentPath)?.resource?.hash;
-}
-
 export function buildTree(mergedItems: MergedItem[]): TreeItem[] {
   const nodeMap = new Map<string, TreeItem>();
   const roots: TreeItem[] = [];
   const mergedByPath = new Map(mergedItems.map((item) => [item.path, item]));
+  const lookupResourceHash = (path: string) => mergedByPath.get(path)?.resource?.hash;
 
   // Create all nodes (files, dashboards, folders)
   for (const item of mergedItems) {
@@ -145,7 +126,7 @@ export function buildTree(mergedItems: MergedItem[]): TreeItem[] {
     const isFolderMetadata = isFolderMetadataPath(item.path);
     const showStatus = type === 'Dashboard' || type === 'Folder' || item.path.endsWith('.json');
     const resourceHash = isFolderMetadata
-      ? getFolderMetadataResourceHash(item.path, mergedByPath)
+      ? getParentFolderResourceHash(item.path, lookupResourceHash)
       : item.resource?.hash;
 
     nodeMap.set(item.path, {


### PR DESCRIPTION
## Summary

Fixes [grafana/git-ui-sync-project#1130](https://github.com/grafana/git-ui-sync-project/issues/1130).

In the **Git Sync > Resources** tree, folders containing a `_folder.json` metadata file were stuck showing a pending sync icon even when their actual content was fully synced. The root cause was that `_folder.json` had no resource of its own, so its sync status always evaluated to `pending` and propagated up to the parent folder.

<img width="1704" height="1033" alt="Screenshot 2026-05-05 at 14 52 31" src="https://github.com/user-attachments/assets/32f2fe5c-2563-40c6-a730-04a81bad4571" />



This PR makes the tree treat `_folder.json` as the metadata file it actually is: its sync state is derived from comparing its file hash against the **parent folder's resource hash** (which is the synced metadata hash, or empty when no metadata exists). All three remote-repo transitions — added, updated, and removed — now correctly affect both the file row and the parent folder.

## Behavior matrix

Legend: `—` = no row in the tree / not applicable. "Remotely" refers to changes in the source-of-truth git repository that Grafana hasn't reconciled yet.

### Cases involving a single folder + its `_folder.json`

| # | Situation | `_folder.json` file in remote repo | Folder resource hash | `_folder.json` row | Parent folder | Mechanism |
|---|---|---|---|---|---|---|
| 1 | Fully synced | present, hash matches | non-empty (matching) | `synced` | `synced` | Hash match via parent folder lookup |
| 2 | Updated remotely | present, hash differs | non-empty | `pending` | `pending` | Child status propagation |
| 3 | Added remotely (not yet synced) | present | empty | `pending` | `pending` | File hash ≠ empty → mismatch |
| 4 | Removed remotely | absent | non-empty | — | `pending` | `missingFolderMetadata` + non-empty resource hash override |
| 5 | Never had metadata | absent | empty | — | `synced` (+ warning icon) | Existing `missingFolderMetadata` warning, no override fired |
| 6 | Folder not yet provisioned (inferred) | present | n/a (parent has no resource) | `pending` | `pending` | `getFolderMetadataResourceHash` returns `undefined` → pending; propagates |
| 7 | Repo-root `_folder.json` | present at repo root | n/a (no parent folder exists) | `pending` | — (root entry) | No parent path → `undefined` resource hash; no folder is affected |

### Cases involving siblings & nesting (interaction with other tree nodes)

| # | Situation | `_folder.json` row | Other children | Parent folder | Why |
|---|---|---|---|---|---|
| 8 | Synced metadata, all dashboards synced | `synced` | all `synced` | `synced` | Nothing pending |
| 9 | Synced metadata, one dashboard pending | `synced` | one `pending` | `pending` | Dashboard pending propagates |
| 10 | Pending metadata, dashboards synced | `pending` | all `synced` | `pending` | Metadata pending propagates |
| 11 | Nested subfolder is pending | (n/a here) | one nested folder `pending` | `pending` (recursive) | `calculateFolderStatus` recurses |
| 12 | Sibling folders independent | per-folder | per-folder | per-folder | Each folder evaluates `_folder.json` against its own resource — no cross-bleed |

### Non-metadata files (unchanged behavior, included for completeness)

| # | Situation | Row status |
|---|---|---|
| 13 | Dashboard `.json` file matches its resource | `synced` |
| 14 | Dashboard `.json` file hash differs from resource | `pending` |
| 15 | Dashboard `.json` file with no resource | `pending` |
| 16 | Non-`.json` file (e.g. `README.md`) | no status icon (`showStatus = false`) |

## Changes

- **`public/app/features/provisioning/utils/treeUtils.ts`**
  - Added `isFolderMetadataPath()` helper using the existing `FOLDER_METADATA_FILE` constant.
  - Added `getFolderMetadataResourceHash()` to look up the parent folder's resource hash for a `_folder.json` path (returns `undefined` for root-level).
  - In `buildTree`, route `_folder.json` nodes through the parent folder's resource hash when computing their sync status.
  - In the `missingFolderMetadata` detection loop, override the folder status to `pending` when the file is missing **and** the folder's resource hash is non-empty (i.e. metadata was previously synced and the file was deleted from the remote repo).
- **`public/app/features/provisioning/utils/treeUtils.test.ts`**
  - Added new cases covering rows 1–7 above (synced / updated / added / removed / never-had-metadata / inferred parent / root-level).
  - Updated 2 pre-existing tests whose fixtures used a non-empty folder metadata hash without a corresponding `_folder.json` file — that combination now correctly reads as the *removed remotely* state.

## Testing

- `yarn jest public/app/features/provisioning/utils/treeUtils.test.ts` — 60/60 pass.
- `yarn typecheck` — clean.
- `yarn prettier --write` — applied.

## Checklist

- [x] Tests added/updated for every transition (synced/updated/added/removed/never-had-metadata/inferred/root)
- [x] No backend changes (frontend-only fix)
- [x] No breaking changes
- [x] No new dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)