### PR TITLE
Provisioning: Fix ConditionsPatch_AppendDoesNotClobber cleanup flake

### DIFF
--- a/pkg/tests/apis/provisioning/managed_test.go
+++ b/pkg/tests/apis/provisioning/managed_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	dashboardV1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
 	foldersV1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
@@ -894,6 +895,37 @@ func TestIntegrationProvisioning_AdminCanReleaseManagedResourceViaPatch(t *testi
 	})
 
 	const dashboardUID = "n1jR8vnnz"
+
+	// Once the folder/dashboard are released they become regular unmanaged
+	// resources and survive the per-test repo cleanup. If we leave them for
+	// the next test's CleanupAllResources to mop up, the folder step has to
+	// absorb the Bleve search-index lag between the dashboard delete and
+	// folder admission's "is empty" check — which has flaked the next test
+	// in CI. Cleaning up here pays that cost in the test that owns the
+	// resources and shrinks the leak window for the next test. Failures are
+	// only logged; the next test's CleanupAllResources is the safety net.
+	t.Cleanup(func() {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), common.WaitTimeoutDefault)
+		defer cancel()
+		if err := helper.DashboardsV1.Resource.Delete(cleanupCtx, dashboardUID, metav1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
+			t.Logf("cleanup: deleting dashboard %q failed (will be retried by next test): %v", dashboardUID, err)
+		}
+		// Folder admission rejects deletion until the search index reflects
+		// the dashboard delete; retry until it lets us through or the
+		// context budget runs out.
+		for {
+			err := helper.Folders.Resource.Delete(cleanupCtx, repo, metav1.DeleteOptions{})
+			if err == nil || apierrors.IsNotFound(err) {
+				return
+			}
+			select {
+			case <-cleanupCtx.Done():
+				t.Logf("cleanup: deleting folder %q timed out (will be retried by next test): %v", repo, err)
+				return
+			case <-time.After(common.WaitIntervalDefault):
+			}
+		}
+	})
 
 	require.EventuallyWithT(t, func(collect *assert.CollectT) {
 		dashboard, err := helper.DashboardsV1.Resource.Get(ctx, dashboardUID, metav1.GetOptions{})


### PR DESCRIPTION
## Summary

Fixes the flake in `TestIntegrationProvisioning_ConditionsPatch_AppendDoesNotClobber`:

```
helper_test.go:19: CleanupAllResources(folders): deleteAndWait: timed out with 1 items remaining
  (first delete error: deleteAndWait: delete "admin-release-patch-test": Folder cannot be deleted: folder is not empty)
```

(Original failure: https://github.com/grafana/grafana/actions/runs/25321563053/job/74233703704)

## Root cause

`TestIntegrationProvisioning_AdminCanReleaseManagedResourceViaPatch` runs immediately before `ConditionsPatch_AppendDoesNotClobber` (alphabetical file order). It releases its folder and dashboard (removes manager annotations) but leaves them as unmanaged resources for the next test's `CleanupAllResources` to mop up.

The folder step in that cleanup has to absorb the Bleve search-index lag between the dashboard delete and folder admission's "is empty" check (`pkg/registry/apis/folders/validate.go:359`) — and under SQLite write contention that lag had been exceeding the (then 60s) folder cleanup budget, failing the next test before its body even ran.

## Changes

Add a `t.Cleanup` to `AdminCanReleaseManagedResourceViaPatch` that:
- deletes the dashboard immediately, and
- retries the folder delete until the search index catches up (or the 60s budget runs out)

This pays the search-index-lag cost in the test that owns the leak, instead of dumping it on the next test. Failures are logged only — the next test's `CleanupAllResources` (with its 240s folder budget from #124046) remains the safety net.

## Testing

- `go vet ./pkg/tests/apis/provisioning/...` — clean
- `go test -run XXX_NEVER_MATCHES -count=1 ./pkg/tests/apis/provisioning/` — compiles
- The change only adds a cleanup hook at test exit; it doesn't affect what the test asserts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)