### PR TITLE
Advisor: Explicitly skip health checks for frontend-only datasources

### DIFF
--- a/apps/advisor/pkg/app/checks/datasourcecheck/check.go
+++ b/apps/advisor/pkg/app/checks/datasourcecheck/check.go
@@ -103,6 +103,7 @@ func (c *check) Steps() []checks.Step {
 		&uidValidationStep{},
 		&healthCheckStep{
 			HealthChecker: c.healthChecker,
+			PluginStore:   c.PluginStore,
 		},
 		&missingPluginStep{
 			PluginStore:    c.PluginStore,

--- a/apps/advisor/pkg/app/checks/datasourcecheck/check_test.go
+++ b/apps/advisor/pkg/app/checks/datasourcecheck/check_test.go
@@ -137,6 +137,34 @@ func TestCheck_Run(t *testing.T) {
 		assert.Contains(t, *failures[0].MoreInfo, "test message")
 	})
 
+	t.Run("should skip health check when datasource plugin is frontend-only", func(t *testing.T) {
+		datasources := []*datasources.DataSource{
+			{UID: "valid-uid-1", Type: "prometheus", Name: "Prometheus"},
+		}
+
+		mockDatasourceSvc := &MockDatasourceSvc{dss: datasources}
+		mockPluginContextProvider := &MockPluginContextProvider{pCtx: backend.PluginContext{}}
+		mockPluginClient := &MockPluginClient{res: &backend.CheckHealthResult{Status: backend.HealthStatusError, Message: "should not run"}}
+		mockPluginRepo := &MockPluginRepo{plugins: []repo.PluginInfo{
+			{ID: 1, Slug: "prometheus", Status: "active"},
+		}}
+		mockPluginStore := &MockPluginStore{exists: true, frontendOnly: true}
+
+		check := &check{
+			DatasourceSvc: mockDatasourceSvc,
+			PluginRepo:    mockPluginRepo,
+			PluginStore:   mockPluginStore,
+			healthChecker: &checks.HealthCheckerImpl{
+				PluginContextProvider: mockPluginContextProvider,
+				PluginClient:          mockPluginClient,
+			},
+		}
+
+		failures, err := runChecks(check)
+		assert.NoError(t, err)
+		assert.Empty(t, failures)
+	})
+
 	t.Run("should skip health check when plugin does not support backend health checks", func(t *testing.T) {
 		datasources := []*datasources.DataSource{
 			{UID: "valid-uid-1", Type: "prometheus", Name: "Prometheus"},
@@ -460,11 +488,20 @@ func (m *MockPluginClient) CheckHealth(context.Context, *backend.CheckHealthRequ
 type MockPluginStore struct {
 	pluginstore.Store
 
-	exists bool
+	exists       bool
+	frontendOnly bool
 }
 
 func (m *MockPluginStore) Plugin(context.Context, string) (pluginstore.Plugin, bool) {
-	return pluginstore.Plugin{}, m.exists
+	if !m.exists {
+		return pluginstore.Plugin{}, false
+	}
+
+	return pluginstore.Plugin{
+		JSONData: plugins.JSONData{
+			Backend: !m.frontendOnly,
+		},
+	}, true
 }
 
 type MockPluginRepo struct {

--- a/apps/advisor/pkg/app/checks/datasourcecheck/health_check_step.go
+++ b/apps/advisor/pkg/app/checks/datasourcecheck/health_check_step.go
@@ -11,10 +11,12 @@ import (
 	"github.com/grafana/grafana/apps/advisor/pkg/app/checks"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/services/datasources"
+	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginstore"
 )
 
 type healthCheckStep struct {
 	HealthChecker checks.HealthChecker
+	PluginStore   pluginstore.Store
 }
 
 func (s *healthCheckStep) Title() string {
@@ -37,6 +39,11 @@ func (s *healthCheckStep) Run(ctx context.Context, log logging.Logger, obj *advi
 	ds, ok := i.(*datasources.DataSource)
 	if !ok {
 		return nil, fmt.Errorf("invalid item type %T", i)
+	}
+
+	if plugin, exists := s.PluginStore.Plugin(ctx, ds.Type); !exists || !plugin.Backend {
+		log.Debug("Skipping health check because it's missing or a frontend-only plugin", "datasource_uid", ds.UID, "datasource_type", ds.Type, "plugin_exists", exists, "plugin_backend", plugin.Backend)
+		return nil, nil
 	}
 
 	// Health check execution


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

The previous logic relied that running a health check returned a `plugins.ErrPluginUnavailable` but that's no longer the case when trying remote plugins.