### PR TITLE
Chore: Change externalized ds reminder runner from ubuntu-latest to ubuntu-x64-small

### DIFF
--- a/.github/workflows/externalized-datasources-reminder.yml
+++ b/.github/workflows/externalized-datasources-reminder.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   add-comment:
     if: ${{ ! github.event.pull_request.head.repo.fork }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-x64-small
     permissions:
       pull-requests: write
     steps:


### PR DESCRIPTION
**What is this feature?**

We want to use a smaller runners to make it a bit more cost effective.
