### PR TITLE
[release-13.0.2] Provisioning: Bump nanogit to v0.17.0 to fix pushes with repositories using git modules

### DIFF
--- a/apps/provisioning/go.mod
+++ b/apps/provisioning/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/grafana/grafana-app-sdk/logging v0.51.4
 	github.com/grafana/grafana/apps/secret v0.0.0-20260118065639-60cb766a97d6
 	github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260118065639-60cb766a97d6
-	github.com/grafana/nanogit v0.13.0
+	github.com/grafana/nanogit v0.17.0
 	github.com/migueleliasweb/go-github-mock v1.5.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/stretchr/testify v1.11.1

--- a/apps/provisioning/go.sum
+++ b/apps/provisioning/go.sum
@@ -101,8 +101,8 @@ github.com/grafana/grafana/apps/secret v0.0.0-20260118065639-60cb766a97d6 h1:TJd
 github.com/grafana/grafana/apps/secret v0.0.0-20260118065639-60cb766a97d6/go.mod h1:6ZLwJmNc+7dWXQ+NRBV09HZbg/XZ6yN7kWFf7w301Lo=
 github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260118065639-60cb766a97d6 h1:Meoq0neEejGlmclgCInZM7EXl3Dw27zlGGwvEmJwvaY=
 github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260118065639-60cb766a97d6/go.mod h1:BpUYFztGINSLZmkzcS9dSHdNwBZAb8w1KD5unG1oNeg=
-github.com/grafana/nanogit v0.13.0 h1:E1YV8YYLOxoZTl6J7KqsReQ90Ww1lVfmd6kqhhUWYfA=
-github.com/grafana/nanogit v0.13.0/go.mod h1:s8TBdDiUZ9ZWEF/nsAP9HYwJXtLUYpgoQwF2uTTz9ZE=
+github.com/grafana/nanogit v0.17.0 h1:AG2zqnyBl4s7oMYri1eDSpAaYxUNZ0wr8jtoIeAUFn0=
+github.com/grafana/nanogit v0.17.0/go.mod h1:4fLGQZphcwp2AHqdeju11Z8v5jiJ8MbAQqwu8b22CC4=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=

--- a/go.mod
+++ b/go.mod
@@ -485,7 +485,7 @@ require (
 	github.com/gophercloud/gophercloud/v2 v2.9.0 // indirect
 	github.com/gopherjs/gopherjs v1.17.2 // indirect
 	github.com/grafana/jsonparser v0.0.0-20241004153430-023329977675 // indirect
-	github.com/grafana/nanogit v0.13.0 // indirect
+	github.com/grafana/nanogit v0.17.0 // indirect
 	github.com/grafana/regexp v0.0.0-20240518133315-a468a5bfb3bc // indirect
 	github.com/grafana/sqlds/v5 v5.0.4 // indirect
 	github.com/grpc-ecosystem/go-grpc-prometheus v1.2.1-0.20191002090509-6af20e3a5340 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1677,8 +1677,8 @@ github.com/grafana/loki/v3 v3.5.11 h1:cIO1FYgg0o2aj8zIpXz6kFOUxW0AWU3Yk/AZqtwbzo
 github.com/grafana/loki/v3 v3.5.11/go.mod h1:vT/ZnjX2++rBwKSdsjzNELU+66PWkop5KetzeALZH5Y=
 github.com/grafana/memberlist v0.3.1-0.20251126142931-6f9f62ab6f86 h1:aTwfQuroOmOr//QEn9J1MtC4R4CPR9/IbUd8hZrbWKo=
 github.com/grafana/memberlist v0.3.1-0.20251126142931-6f9f62ab6f86/go.mod h1:h60o12SZn/ua/j0B6iKAZezA4eDaGsIuPO70eOaJ6WE=
-github.com/grafana/nanogit v0.13.0 h1:E1YV8YYLOxoZTl6J7KqsReQ90Ww1lVfmd6kqhhUWYfA=
-github.com/grafana/nanogit v0.13.0/go.mod h1:s8TBdDiUZ9ZWEF/nsAP9HYwJXtLUYpgoQwF2uTTz9ZE=
+github.com/grafana/nanogit v0.17.0 h1:AG2zqnyBl4s7oMYri1eDSpAaYxUNZ0wr8jtoIeAUFn0=
+github.com/grafana/nanogit v0.17.0/go.mod h1:4fLGQZphcwp2AHqdeju11Z8v5jiJ8MbAQqwu8b22CC4=
 github.com/grafana/nanogit/gittest v0.10.2 h1:2+e/zvmBCjpTN/8AeHS7OIjEI6FnzqyNs5RmiJYcJdY=
 github.com/grafana/nanogit/gittest v0.10.2/go.mod h1:qewV4AZOErVbxBMYLj9yAv5ITs/VOc+t/Ko/2w3pSfo=
 github.com/grafana/otel-profiling-go v0.5.1 h1:stVPKAFZSa7eGiqbYuG25VcqYksR6iWvF3YH66t4qL8=


### PR DESCRIPTION
Backport f2e88be480415e8a17cafbb2cb33fdf46d7e7898 from #124114

---

## Summary

Bumps nanogit dependency from v0.13.0 to v0.17.0 to fix submodule handling issues.

## Motivation

Addresses issue #123891 where submodules were not being preserved during StagedWriter tree rebuild operations in nanogit. This caused problems when provisioning repositories with submodules.

## Changes

- **apps/provisioning/go.mod**: `github.com/grafana/nanogit v0.13.0` → `v0.17.0`
- **go.mod**: `github.com/grafana/nanogit v0.13.0` → `v0.17.0`
- Updated `go.sum` files accordingly

## nanogit v0.13.0 → v0.17.0 Changelog

### v0.17.0 (Key Fix)
- **Preserve submodules in StagedWriter tree rebuilds** - Fixes #123891
- Surface side-band channel-2 progress in receive-pack errors

### v0.16.0
- Added receive-pack capability override at library and CLI levels
- Added `NANOGIT_REPO` environment variable for default repository URLs

### v0.15.0
- Enhanced receive-pack flexibility

### v0.14.0
- New CLI `put-file` write command
- Enhanced logging options

## Testing

- [ ] Verify provisioning repositories with submodules works correctly
- [ ] Run existing integration tests for provisioning service

## References

- nanogit releases: https://github.com/grafana/nanogit/releases
- Related issue: #123891

🤖 Generated with [Claude Code](https://claude.com/claude-code)
