### PR TITLE
Version-scope remote index build locks

### DIFF
--- a/pkg/storage/unified/search/bleve_snapshot_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_test.go
@@ -103,7 +103,7 @@ func (f *fakeRemoteIndexStore) DownloadIndex(_ context.Context, _ resource.Names
 	return meta, writeFakeSnapshot(destDir, meta)
 }
 
-func (f *fakeRemoteIndexStore) LockBuildIndex(context.Context, resource.NamespacedResource) (IndexStoreLock, error) {
+func (f *fakeRemoteIndexStore) LockBuildIndex(context.Context, resource.NamespacedResource, string) (IndexStoreLock, error) {
 	return &noopIndexStoreLock{lost: make(chan struct{})}, nil
 }
 

--- a/pkg/storage/unified/search/bleve_snapshot_upload.go
+++ b/pkg/storage/unified/search/bleve_snapshot_upload.go
@@ -83,7 +83,7 @@ func (b *bleveBackend) uploadSnapshot(ctx context.Context, key resource.Namespac
 
 	lockAttrs := append([]attribute.KeyValue{attribute.String("lock_scope", "build")}, commonSpanAttrs...)
 	span.AddEvent("snapshot.lock.acquire.started", oteltrace.WithAttributes(lockAttrs...))
-	lock, err := b.opts.Snapshot.Store.LockBuildIndex(ctx, key)
+	lock, err := b.opts.Snapshot.Store.LockBuildIndex(ctx, key, b.opts.BuildVersion)
 	if err != nil {
 		span.AddEvent("snapshot.lock.acquire.failed", oteltrace.WithAttributes(lockAttrs...))
 		return fmt.Errorf("acquiring snapshot upload lock: %w", err)

--- a/pkg/storage/unified/search/bleve_snapshot_upload_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_upload_test.go
@@ -22,7 +22,8 @@ import (
 )
 
 type uploadTestStore struct {
-	lockErr error
+	lockErr          error
+	lockBuildVersion string
 
 	uploadErr   error
 	uploadCalls atomic.Int32
@@ -39,7 +40,8 @@ type uploadTestStore struct {
 	probeGetCalls atomic.Int32
 }
 
-func (s *uploadTestStore) LockBuildIndex(context.Context, resource.NamespacedResource) (IndexStoreLock, error) {
+func (s *uploadTestStore) LockBuildIndex(_ context.Context, _ resource.NamespacedResource, buildVersion string) (IndexStoreLock, error) {
+	s.lockBuildVersion = buildVersion
 	if s.lockErr != nil {
 		return nil, s.lockErr
 	}
@@ -192,6 +194,7 @@ func TestUploadSnapshot_Success(t *testing.T) {
 	assert.Equal(t, int32(1), store.uploadCalls.Load())
 	assert.Equal(t, int64(42), store.uploadMeta.LatestResourceVersion)
 	assert.Equal(t, be.opts.BuildVersion, store.uploadMeta.BuildVersion)
+	assert.Equal(t, be.opts.BuildVersion, store.lockBuildVersion)
 	// BuildTime must be populated from the index's internal build
 	// info (set by newBleveIndex), not left zero. Compare with second-level
 	// granularity since buildInfo persists Unix seconds.

--- a/pkg/storage/unified/search/options_test.go
+++ b/pkg/storage/unified/search/options_test.go
@@ -95,11 +95,11 @@ func TestBuildSnapshotOptionsFileBucketUsesProcessLocalLocks(t *testing.T) {
 	require.NoError(t, err)
 
 	ns := resource.NamespacedResource{Namespace: "default", Group: "dashboard.grafana.app", Resource: "dashboards"}
-	lock1, err := snapshot.Store.LockBuildIndex(context.Background(), ns)
+	lock1, err := snapshot.Store.LockBuildIndex(context.Background(), ns, "11.0.0")
 	require.NoError(t, err)
 	defer func() { require.NoError(t, lock1.Release()) }()
 
-	lock2, err := snapshot.Store.LockBuildIndex(context.Background(), ns)
+	lock2, err := snapshot.Store.LockBuildIndex(context.Background(), ns, "11.0.0")
 	require.ErrorIs(t, err, errLockHeld)
 	assert.Nil(t, lock2)
 }

--- a/pkg/storage/unified/search/remote_index_cleanup_test.go
+++ b/pkg/storage/unified/search/remote_index_cleanup_test.go
@@ -519,8 +519,8 @@ func (s *recordingStore) CleanupIncompleteUploads(ctx context.Context, r resourc
 	s.mu.Unlock()
 	return s.inner.CleanupIncompleteUploads(ctx, r, minAge)
 }
-func (s *recordingStore) LockBuildIndex(ctx context.Context, r resource.NamespacedResource) (IndexStoreLock, error) {
-	return s.inner.LockBuildIndex(ctx, r)
+func (s *recordingStore) LockBuildIndex(ctx context.Context, r resource.NamespacedResource, buildVersion string) (IndexStoreLock, error) {
+	return s.inner.LockBuildIndex(ctx, r, buildVersion)
 }
 func (s *recordingStore) UploadIndex(ctx context.Context, r resource.NamespacedResource, dir string, m IndexMeta) (ulid.ULID, error) {
 	return s.inner.UploadIndex(ctx, r, dir, m)
@@ -644,8 +644,8 @@ func (s *controllableLockStore) CleanupIncompleteUploads(ctx context.Context, r 
 	}
 	return out, err
 }
-func (s *controllableLockStore) LockBuildIndex(ctx context.Context, r resource.NamespacedResource) (IndexStoreLock, error) {
-	return s.inner.LockBuildIndex(ctx, r)
+func (s *controllableLockStore) LockBuildIndex(ctx context.Context, r resource.NamespacedResource, buildVersion string) (IndexStoreLock, error) {
+	return s.inner.LockBuildIndex(ctx, r, buildVersion)
 }
 func (s *controllableLockStore) UploadIndex(ctx context.Context, r resource.NamespacedResource, dir string, m IndexMeta) (ulid.ULID, error) {
 	return s.inner.UploadIndex(ctx, r, dir, m)

--- a/pkg/storage/unified/search/remote_index_store.go
+++ b/pkg/storage/unified/search/remote_index_store.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -77,8 +78,9 @@ type IndexStoreLock interface {
 // RemoteIndexStore manages index snapshots on remote storage.
 // Index keys are immutable: each snapshot uses a unique ULID key.
 type RemoteIndexStore interface {
-	// LockBuildIndex acquires a distributed build lock for namespace/group/resource.
-	LockBuildIndex(ctx context.Context, nsResource resource.NamespacedResource) (IndexStoreLock, error)
+	// LockBuildIndex acquires a distributed build/upload lock for namespace/group/resource.
+	// buildVersion scopes contention to replicas running the same exact Grafana version.
+	LockBuildIndex(ctx context.Context, nsResource resource.NamespacedResource, buildVersion string) (IndexStoreLock, error)
 
 	// LockNamespaceForCleanup acquires a distributed cleanup lock for a namespace.
 	// Uses a different lock key than LockBuildIndex so cleanup never blocks an
@@ -193,8 +195,12 @@ func nsPrefix(ns resource.NamespacedResource) string {
 	return fmt.Sprintf("%s/", resourceSubPath(ns))
 }
 
-func buildIndexLockKey(ns resource.NamespacedResource) string {
-	return fmt.Sprintf("%s/locks/build", resourceSubPath(ns))
+func buildIndexLockKey(ns resource.NamespacedResource, buildVersion string) string {
+	return fmt.Sprintf("%s/locks/build-%s", resourceSubPath(ns), versionLockSegment(buildVersion))
+}
+
+func versionLockSegment(buildVersion string) string {
+	return base64.RawURLEncoding.EncodeToString([]byte(buildVersion))
 }
 
 // cleanupLockKey returns the object-storage lock key used to serialise cleanup
@@ -204,8 +210,11 @@ func cleanupLockKey(namespace string) string {
 	return fmt.Sprintf("%s/locks/cleanup", cleanFileSegment(namespace))
 }
 
-func (s *BucketRemoteIndexStore) LockBuildIndex(ctx context.Context, nsResource resource.NamespacedResource) (IndexStoreLock, error) {
-	l, err := newObjectStorageLock(s.lockConfig(buildIndexLockKey(nsResource), s.buildLockOpts))
+func (s *BucketRemoteIndexStore) LockBuildIndex(ctx context.Context, nsResource resource.NamespacedResource, buildVersion string) (IndexStoreLock, error) {
+	if buildVersion == "" {
+		return nil, fmt.Errorf("build version must not be empty")
+	}
+	l, err := newObjectStorageLock(s.lockConfig(buildIndexLockKey(nsResource, buildVersion), s.buildLockOpts))
 	if err != nil {
 		return nil, fmt.Errorf("creating build lock: %w", err)
 	}

--- a/pkg/storage/unified/search/remote_index_store_test.go
+++ b/pkg/storage/unified/search/remote_index_store_test.go
@@ -710,7 +710,7 @@ func TestRemoteIndexStore_LockBuildIndex_AcquireRelease(t *testing.T) {
 	defer func() { _ = bucket.Close() }()
 	store := newTestRemoteIndexStoreWithLockOwner(t, bucket, backend, "instance-1")
 
-	lock, err := store.LockBuildIndex(ctx, ns)
+	lock, err := store.LockBuildIndex(ctx, ns, "11.5.0")
 	require.NoError(t, err)
 
 	select {
@@ -732,17 +732,59 @@ func TestRemoteIndexStore_LockBuildIndex_Contention(t *testing.T) {
 	store1 := newTestRemoteIndexStoreWithLockOwner(t, bucket, backend, "instance-1")
 	store2 := newTestRemoteIndexStoreWithLockOwner(t, bucket, backend, "instance-2")
 
-	lock1, err := store1.LockBuildIndex(ctx, ns)
+	lock1, err := store1.LockBuildIndex(ctx, ns, "11.5.0")
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = lock1.Release() })
 
-	_, err = store2.LockBuildIndex(ctx, ns)
+	_, err = store2.LockBuildIndex(ctx, ns, "11.5.0")
 	require.ErrorIs(t, err, errLockHeld)
 
 	require.NoError(t, lock1.Release())
-	lock2, err := store2.LockBuildIndex(ctx, ns)
+	lock2, err := store2.LockBuildIndex(ctx, ns, "11.5.0")
 	require.NoError(t, err)
 	require.NoError(t, lock2.Release())
+}
+
+func TestRemoteIndexStore_LockBuildIndex_VersionScoped(t *testing.T) {
+	ctx := context.Background()
+	ns := newTestNsResource()
+	backend := newFakeBackend(newConditionalBucket())
+	bucket := memblob.OpenBucket(nil)
+	defer func() { _ = bucket.Close() }()
+
+	store1 := newTestRemoteIndexStoreWithLockOwner(t, bucket, backend, "instance-1")
+	store2 := newTestRemoteIndexStoreWithLockOwner(t, bucket, backend, "instance-2")
+
+	lock1, err := store1.LockBuildIndex(ctx, ns, "11.5.0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = lock1.Release() })
+
+	lock2, err := store2.LockBuildIndex(ctx, ns, "11.6.0")
+	require.NoError(t, err)
+	require.NoError(t, lock2.Release())
+}
+
+func TestRemoteIndexStore_LockBuildIndex_RequiresBuildVersion(t *testing.T) {
+	ctx := context.Background()
+	ns := newTestNsResource()
+	backend := newFakeBackend(newConditionalBucket())
+	bucket := memblob.OpenBucket(nil)
+	defer func() { _ = bucket.Close() }()
+	store := newTestRemoteIndexStoreWithLockOwner(t, bucket, backend, "instance-1")
+
+	lock, err := store.LockBuildIndex(ctx, ns, "")
+	require.Error(t, err)
+	assert.Nil(t, lock)
+}
+
+func TestRemoteIndexStore_LockBuildIndex_KeyEncodesBuildVersion(t *testing.T) {
+	ns := newTestNsResource()
+	key := buildIndexLockKey(ns, "v11.5.0+security/branch")
+	segment := strings.TrimPrefix(key, resourceSubPath(ns)+"/locks/build-")
+
+	require.NoError(t, validateObjectKey(key))
+	assert.NotEmpty(t, segment)
+	assert.NotContains(t, segment, "/")
 }
 
 func TestRemoteIndexStore_LockBuildIndex_LostAndReleaseAfterLoss(t *testing.T) {
@@ -753,10 +795,10 @@ func TestRemoteIndexStore_LockBuildIndex_LostAndReleaseAfterLoss(t *testing.T) {
 	defer func() { _ = bucket.Close() }()
 	store := newTestRemoteIndexStoreWithLockOwner(t, bucket, backend, "instance-1")
 
-	lock, err := store.LockBuildIndex(ctx, ns)
+	lock, err := store.LockBuildIndex(ctx, ns, "11.5.0")
 	require.NoError(t, err)
 
-	require.NoError(t, backend.Delete(ctx, buildIndexLockKey(ns), "instance-1"))
+	require.NoError(t, backend.Delete(ctx, buildIndexLockKey(ns, "11.5.0"), "instance-1"))
 
 	select {
 	case <-lock.Lost():
@@ -873,10 +915,10 @@ func TestRemoteIndexStore_ListIndexes_SkipsLockSibling(t *testing.T) {
 		IndexMeta{BuildVersion: "11.0.0", LatestResourceVersion: 1})
 	require.NoError(t, err)
 
-	// Plant a `<resource-group>/locks/build` object directly in the data bucket.
+	// Plant a `<resource-group>/locks/build-<version>` object directly in the data bucket.
 	// In production the lock backend shares the snapshot bucket, so this prefix
 	// is observable alongside index-key directories. ListIndexes must skip it.
-	require.NoError(t, bucket.WriteAll(ctx, buildIndexLockKey(ns), []byte("{}"), nil))
+	require.NoError(t, bucket.WriteAll(ctx, buildIndexLockKey(ns, "11.0.0"), []byte("{}"), nil))
 
 	indexes, err := store.ListIndexes(ctx, ns)
 	require.NoError(t, err)
@@ -960,11 +1002,11 @@ func TestRemoteIndexStore_LockNamespaceForCleanup_DistinctFromBuildLock(t *testi
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = cleanupLock.Release() })
 
-	buildLock, err := store.LockBuildIndex(ctx, ns)
+	buildLock, err := store.LockBuildIndex(ctx, ns, "11.5.0")
 	require.NoError(t, err)
 	require.NoError(t, buildLock.Release())
 
-	require.NotEqual(t, cleanupLockKey(ns.Namespace), buildIndexLockKey(ns))
+	require.NotEqual(t, cleanupLockKey(ns.Namespace), buildIndexLockKey(ns, "11.5.0"))
 }
 
 // Smoke-tests the LockOptions plumbing. Only TTL is observable in lockInfo;
@@ -986,11 +1028,11 @@ func TestRemoteIndexStore_BuildAndCleanupLockTTLsWiredIndependently(t *testing.T
 	})
 	ns := newTestNsResource()
 
-	buildLock, err := store.LockBuildIndex(ctx, ns)
+	buildLock, err := store.LockBuildIndex(ctx, ns, "11.5.0")
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = buildLock.Release() })
 
-	info, err := backend.Read(ctx, buildIndexLockKey(ns))
+	info, err := backend.Read(ctx, buildIndexLockKey(ns, "11.5.0"))
 	require.NoError(t, err)
 	require.Equal(t, buildTTL, info.TTL)
 


### PR DESCRIPTION
Version-scope remote index build/upload locks.

Mixed-version clusters use strict same-version snapshot probes for the new snapshot coordination paths. If the build/upload lock is shared across Grafana versions, a replica can end up waiting behind work from a different version whose snapshot it will not use. This makes the lock scope match the snapshot selection semantics: replicas running the same Grafana version coordinate with each other, while different versions build/upload independently.

Cleanup locks remain namespace-scoped because cleanup needs visibility across all version groups.

This updates `LockBuildIndex` to include the Grafana build version in the lock key, updates the upload path to pass the running build version, and adds tests for same-version contention, cross-version independence, and lock key encoding.

Follow-up: stale lock object cleanup is not handled here; existing TTL/takeover semantics keep this out of the correctness path.
