### PR TITLE
Skip snapshot uploads for non-owned indexes

### DIFF
--- a/pkg/storage/unified/resource/bleve_index_metrics.go
+++ b/pkg/storage/unified/resource/bleve_index_metrics.go
@@ -117,7 +117,7 @@ func ProvideIndexMetrics(reg prometheus.Registerer) *BleveIndexMetrics {
 		IndexSnapshotUploads: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "index_server_snapshot_uploads_total",
 			Help: "Number of remote index snapshot upload attempts, by outcome.",
-		}, []string{"status"}), // status: success, skip_no_changes, skip_lock_contention, error
+		}, []string{"status"}), // status: success, skip_no_changes, skip_lock_contention, skip_recent_remote, skip_not_owner, error
 		IndexSnapshotUploadDuration: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 			Name:                            "index_server_snapshot_upload_duration_seconds",
 			Help:                            "Duration of successful remote index snapshot uploads, including snapshot creation.",
@@ -166,6 +166,8 @@ func (m *BleveIndexMetrics) InitSnapshotMetrics() {
 	m.IndexSnapshotUploads.WithLabelValues("success").Add(0)
 	m.IndexSnapshotUploads.WithLabelValues("skip_no_changes").Add(0)
 	m.IndexSnapshotUploads.WithLabelValues("skip_lock_contention").Add(0)
+	m.IndexSnapshotUploads.WithLabelValues("skip_recent_remote").Add(0)
+	m.IndexSnapshotUploads.WithLabelValues("skip_not_owner").Add(0)
 	m.IndexSnapshotUploads.WithLabelValues("error").Add(0)
 	m.IndexSnapshotNamespaceCleanups.WithLabelValues("success").Add(0)
 	m.IndexSnapshotNamespaceCleanups.WithLabelValues("error").Add(0)

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -412,6 +412,7 @@ const (
 	snapshotUploadStatusSkipNoChanges    = "skip_no_changes"
 	snapshotUploadStatusSkipLockHeld     = "skip_lock_contention"
 	snapshotUploadStatusSkipRecentRemote = "skip_recent_remote"
+	snapshotUploadStatusSkipNotOwner     = "skip_not_owner"
 	snapshotUploadStatusError            = "error"
 )
 
@@ -435,6 +436,17 @@ func (b *bleveBackend) runUploadSnapshots(ctx context.Context) {
 	for _, key := range b.GetOpenIndexes() {
 		idx := b.peekCachedIndex(key)
 		if idx == nil || idx.indexStorage != indexStorageFile {
+			continue
+		}
+
+		owned, err := b.ownsIndexFn(key)
+		if err != nil {
+			b.recordSnapshotUploadStatus(snapshotUploadStatusError)
+			b.log.Warn("failed to check if index belongs to this instance", "key", key, "err", err)
+			continue
+		}
+		if !owned {
+			b.recordSnapshotUploadStatus(snapshotUploadStatusSkipNotOwner)
 			continue
 		}
 

--- a/pkg/storage/unified/search/bleve_snapshot_upload_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_upload_test.go
@@ -303,6 +303,45 @@ func TestRunUploadSnapshots_SkipNoChanges(t *testing.T) {
 	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotUploads.WithLabelValues(snapshotUploadStatusSkipNoChanges)))
 }
 
+func TestRunUploadSnapshots_OwnershipCheck(t *testing.T) {
+	tests := []struct {
+		name         string
+		ownsIndexFn  func(resource.NamespacedResource) (bool, error)
+		wantStatus   string
+		probeMessage string
+	}{
+		{
+			name:         "skip not owner",
+			ownsIndexFn:  func(resource.NamespacedResource) (bool, error) { return false, nil },
+			wantStatus:   snapshotUploadStatusSkipNotOwner,
+			probeMessage: "remote probe must not run for non-owned indexes",
+		},
+		{
+			name:         "ownership check error",
+			ownsIndexFn:  func(resource.NamespacedResource) (bool, error) { return false, errors.New("ring unavailable") },
+			wantStatus:   snapshotUploadStatusError,
+			probeMessage: "remote probe must not run when ownership check fails",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := &uploadTestStore{}
+			be, metrics := newTestBleveBackend(t, SnapshotOptions{Store: store, MinDocCount: 1, UploadInterval: time.Hour, MinDocChanges: 1})
+			key := newTestNsResource()
+			idx := newCachedUploadTestIndex(t, be, key, 42)
+			require.NoError(t, writeSnapshotMutationCount(idx.index, 5))
+			be.ownsIndexFn = tt.ownsIndexFn
+
+			be.runUploadSnapshots(t.Context())
+
+			assert.Zero(t, store.uploadCalls.Load())
+			assert.Zero(t, store.probeListCall.Load(), tt.probeMessage)
+			assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotUploads.WithLabelValues(tt.wantStatus)))
+		})
+	}
+}
+
 func TestRunUploadSnapshots_SkipLockContention(t *testing.T) {
 	store := &uploadTestStore{lockErr: errLockHeld}
 	be, metrics := newTestBleveBackend(t, SnapshotOptions{Store: store, MinDocCount: 1, UploadInterval: time.Hour, MinDocChanges: 1})


### PR DESCRIPTION
Adds ownership-based filtering to periodic remote index snapshot uploads.

Non-owning replicas now skip before upload eligibility checks, remote snapshot probes, lock acquisition, or upload work. This reduces duplicate periodic upload work while keeping the existing recent-remote-snapshot dedup as a second line of defense.

Also adds the `skip_not_owner` upload metric outcome and test coverage for ownership skips and ownership check errors.

Related: grafana/search-and-storage-team#770