### PR TITLE
Alerting: add RBAC authorization for alertmanager import API

### DIFF
--- a/pkg/services/accesscontrol/models.go
+++ b/pkg/services/accesscontrol/models.go
@@ -505,6 +505,14 @@ const (
 	ActionAlertingRoutesPermissionsRead  = AlertingRoutesKind + ":set_permissions"
 	ActionAlertingRoutesPermissionsWrite = AlertingRoutesKind + ":get_permissions"
 
+	// Alerting alertmanager import actions (scoped per import identifier, feature-flagged)
+	AlertingAlertmanagerImportsResource     = "alertmanagerimports"
+	AlertingAlertmanagerImportsKind         = AlertingNotificationsApiGroup + "/" + AlertingAlertmanagerImportsResource
+	ActionAlertingAlertmanagerImportsCreate = AlertingAlertmanagerImportsKind + ":create"
+	ActionAlertingAlertmanagerImportsRead   = AlertingAlertmanagerImportsKind + ":get"
+	ActionAlertingAlertmanagerImportsWrite  = AlertingAlertmanagerImportsKind + ":update"
+	ActionAlertingAlertmanagerImportsDelete = AlertingAlertmanagerImportsKind + ":delete"
+
 	// External alerting rule actions. We can only narrow it down to writes or reads, as we don't control the atomicity in the external system.
 	ActionAlertingRuleExternalWrite = "alert.rules.external:write"
 	ActionAlertingRuleExternalRead  = "alert.rules.external:read"

--- a/pkg/services/accesscontrol/permreg/permreg.go
+++ b/pkg/services/accesscontrol/permreg/permreg.go
@@ -103,6 +103,7 @@ func newPermissionRegistry() *permissionRegistry {
 		"secret.securevalues":            "secret.securevalues:uid:",
 		"secret.keepers":                 "secret.keepers:uid:",
 		accesscontrol.AlertingRoutesKind: accesscontrol.AlertingRoutesKind + ":uid:",
+		accesscontrol.AlertingAlertmanagerImportsKind: accesscontrol.AlertingAlertmanagerImportsKind + ":uid:",
 	}
 	return &permissionRegistry{
 		actionScopePrefixes: make(map[string]PrefixSet, 200),

--- a/pkg/services/ngalert/accesscontrol/alertmanager_imports.go
+++ b/pkg/services/ngalert/accesscontrol/alertmanager_imports.go
@@ -1,0 +1,49 @@
+package accesscontrol
+
+import (
+	"context"
+
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+)
+
+// AlertmanagerImportsAccess implements notifier.ExtraConfigAuthz using RBAC.
+type AlertmanagerImportsAccess struct {
+	genericService
+}
+
+func NewAlertmanagerImportsAccess(a ac.AccessControl) *AlertmanagerImportsAccess {
+	return &AlertmanagerImportsAccess{genericService: genericService{ac: a}}
+}
+
+// AuthorizeCreate checks the org-level create permission. No legacy fallback — callers
+// must hold the explicit create action.
+func (s *AlertmanagerImportsAccess) AuthorizeCreate(ctx context.Context, user identity.Requester) error {
+	return s.HasAccessOrError(ctx, user,
+		ac.EvalPermission(ac.ActionAlertingAlertmanagerImportsCreate),
+		func() string { return "create alertmanager imports" },
+	)
+}
+
+// AuthorizeUpdate checks the scoped update permission, with legacy notifications:write as fallback.
+func (s *AlertmanagerImportsAccess) AuthorizeUpdate(ctx context.Context, user identity.Requester, identifier string) error {
+	return s.HasAccessOrError(ctx, user, ac.EvalAny(
+		ac.EvalPermission(ac.ActionAlertingNotificationsWrite),
+		ac.EvalPermission(
+			ac.ActionAlertingAlertmanagerImportsWrite,
+			models.ScopeAlertmanagerImportsProvider.GetResourceScopeUID(identifier),
+		),
+	), func() string { return "update alertmanager import" })
+}
+
+// AuthorizeDelete checks the scoped delete permission, with legacy notifications:write as fallback.
+func (s *AlertmanagerImportsAccess) AuthorizeDelete(ctx context.Context, user identity.Requester, identifier string) error {
+	return s.HasAccessOrError(ctx, user, ac.EvalAny(
+		ac.EvalPermission(ac.ActionAlertingNotificationsWrite),
+		ac.EvalPermission(
+			ac.ActionAlertingAlertmanagerImportsDelete,
+			models.ScopeAlertmanagerImportsProvider.GetResourceScopeUID(identifier),
+		),
+	), func() string { return "delete alertmanager import" })
+}

--- a/pkg/services/ngalert/accesscontrol/alertmanager_imports_test.go
+++ b/pkg/services/ngalert/accesscontrol/alertmanager_imports_test.go
@@ -1,0 +1,160 @@
+package accesscontrol
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+)
+
+func TestAlertmanagerImportsAccess_AuthorizeCreate(t *testing.T) {
+	testCases := []struct {
+		name        string
+		permissions []ac.Permission
+		expectedErr bool
+	}{
+		{
+			name:        "with create permission succeeds",
+			permissions: []ac.Permission{{Action: ac.ActionAlertingAlertmanagerImportsCreate}},
+			expectedErr: false,
+		},
+		{
+			name:        "with only notifications:write fails — no legacy fallback for create",
+			permissions: []ac.Permission{{Action: ac.ActionAlertingNotificationsWrite}},
+			expectedErr: true,
+		},
+		{
+			name:        "with no permissions fails",
+			permissions: []ac.Permission{},
+			expectedErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &recordingAccessControlFake{}
+			svc := NewAlertmanagerImportsAccess(fake)
+			err := svc.AuthorizeCreate(context.Background(), newUser(tc.permissions...))
+			if tc.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestAlertmanagerImportsAccess_AuthorizeUpdate(t *testing.T) {
+	identifier := "test-import"
+	otherIdentifier := "other-import"
+
+	testCases := []struct {
+		name        string
+		permissions []ac.Permission
+		identifier  string
+		expectedErr bool
+	}{
+		{
+			name:        "with notifications:write (legacy) succeeds",
+			permissions: []ac.Permission{{Action: ac.ActionAlertingNotificationsWrite}},
+			identifier:  identifier,
+			expectedErr: false,
+		},
+		{
+			name: "with scoped write for matching identifier succeeds",
+			permissions: []ac.Permission{{
+				Action: ac.ActionAlertingAlertmanagerImportsWrite,
+				Scope:  models.ScopeAlertmanagerImportsProvider.GetResourceScopeUID(identifier),
+			}},
+			identifier:  identifier,
+			expectedErr: false,
+		},
+		{
+			name: "with scoped write for different identifier fails",
+			permissions: []ac.Permission{{
+				Action: ac.ActionAlertingAlertmanagerImportsWrite,
+				Scope:  models.ScopeAlertmanagerImportsProvider.GetResourceScopeUID(otherIdentifier),
+			}},
+			identifier:  identifier,
+			expectedErr: true,
+		},
+		{
+			name:        "with no permissions fails",
+			permissions: []ac.Permission{},
+			identifier:  identifier,
+			expectedErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &recordingAccessControlFake{}
+			svc := NewAlertmanagerImportsAccess(fake)
+			err := svc.AuthorizeUpdate(context.Background(), newUser(tc.permissions...), tc.identifier)
+			if tc.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestAlertmanagerImportsAccess_AuthorizeDelete(t *testing.T) {
+	identifier := "test-import"
+	otherIdentifier := "other-import"
+
+	testCases := []struct {
+		name        string
+		permissions []ac.Permission
+		identifier  string
+		expectedErr bool
+	}{
+		{
+			name:        "with notifications:write (legacy) succeeds",
+			permissions: []ac.Permission{{Action: ac.ActionAlertingNotificationsWrite}},
+			identifier:  identifier,
+			expectedErr: false,
+		},
+		{
+			name: "with scoped delete for matching identifier succeeds",
+			permissions: []ac.Permission{{
+				Action: ac.ActionAlertingAlertmanagerImportsDelete,
+				Scope:  models.ScopeAlertmanagerImportsProvider.GetResourceScopeUID(identifier),
+			}},
+			identifier:  identifier,
+			expectedErr: false,
+		},
+		{
+			name: "with scoped delete for different identifier fails",
+			permissions: []ac.Permission{{
+				Action: ac.ActionAlertingAlertmanagerImportsDelete,
+				Scope:  models.ScopeAlertmanagerImportsProvider.GetResourceScopeUID(otherIdentifier),
+			}},
+			identifier:  identifier,
+			expectedErr: true,
+		},
+		{
+			name:        "with no permissions fails",
+			permissions: []ac.Permission{},
+			identifier:  identifier,
+			expectedErr: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fake := &recordingAccessControlFake{}
+			svc := NewAlertmanagerImportsAccess(fake)
+			err := svc.AuthorizeDelete(context.Background(), newUser(tc.permissions...), tc.identifier)
+			if tc.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/services/ngalert/accesscontrol/roles.go
+++ b/pkg/services/ngalert/accesscontrol/roles.go
@@ -492,6 +492,22 @@ var (
 	}
 )
 
+var alertmanagerImportsAdminRole = accesscontrol.RoleRegistration{
+	Role: accesscontrol.RoleDTO{
+		Name:        accesscontrol.FixedRolePrefix + "alerting.alertmanager-imports:writer",
+		DisplayName: "Alerting alertmanager imports writer",
+		Description: "Read, write, and delete Prometheus/Mimir-compatible alertmanager configurations imported via the convert API.",
+		Group:       models.AlertRolesGroup,
+		Permissions: []accesscontrol.Permission{
+			{Action: accesscontrol.ActionAlertingAlertmanagerImportsCreate, Scope: models.ScopeAlertmanagerImportsAll},
+			{Action: accesscontrol.ActionAlertingAlertmanagerImportsRead, Scope: models.ScopeAlertmanagerImportsAll},
+			{Action: accesscontrol.ActionAlertingAlertmanagerImportsWrite, Scope: models.ScopeAlertmanagerImportsAll},
+			{Action: accesscontrol.ActionAlertingAlertmanagerImportsDelete, Scope: models.ScopeAlertmanagerImportsAll},
+		},
+	},
+	Grants: []string{string(org.RoleAdmin)},
+}
+
 // FixedRoleRegistrations returns all alerting role registrations declared by this package.
 func FixedRoleRegistrations() []accesscontrol.RoleRegistration {
 	return []accesscontrol.RoleRegistration{
@@ -506,6 +522,7 @@ func FixedRoleRegistrations() []accesscontrol.RoleRegistration {
 		timeIntervalsReaderRole, timeIntervalsWriterRole,
 		routesCreatorRole, routesReaderRole, routesWriterRole,
 		inhibitionRulesReaderRole, inhibitionRulesWriterRole,
+		alertmanagerImportsAdminRole,
 	}
 }
 

--- a/pkg/services/ngalert/accesscontrol/roles_test.go
+++ b/pkg/services/ngalert/accesscontrol/roles_test.go
@@ -252,6 +252,10 @@ func allAlertingActions() []string {
 		accesscontrol.ActionAlertingNotificationsProvisioningRead,
 		accesscontrol.ActionAlertingNotificationsProvisioningWrite,
 		accesscontrol.ActionAlertingProvisioningSetStatus,
+		accesscontrol.ActionAlertingAlertmanagerImportsCreate,
+		accesscontrol.ActionAlertingAlertmanagerImportsRead,
+		accesscontrol.ActionAlertingAlertmanagerImportsWrite,
+		accesscontrol.ActionAlertingAlertmanagerImportsDelete,
 	}
 	sort.Strings(actions)
 	return actions

--- a/pkg/services/ngalert/accesscontrol/testdata/alerting_actions_bindings.snapshot.json
+++ b/pkg/services/ngalert/accesscontrol/testdata/alerting_actions_bindings.snapshot.json
@@ -401,6 +401,30 @@
     ]
   },
   {
+    "action": "notifications.alerting.grafana.app/alertmanagerimports:create",
+    "roles": [
+      "fixed:alerting.alertmanager-imports:writer"
+    ]
+  },
+  {
+    "action": "notifications.alerting.grafana.app/alertmanagerimports:delete",
+    "roles": [
+      "fixed:alerting.alertmanager-imports:writer"
+    ]
+  },
+  {
+    "action": "notifications.alerting.grafana.app/alertmanagerimports:get",
+    "roles": [
+      "fixed:alerting.alertmanager-imports:writer"
+    ]
+  },
+  {
+    "action": "notifications.alerting.grafana.app/alertmanagerimports:update",
+    "roles": [
+      "fixed:alerting.alertmanager-imports:writer"
+    ]
+  },
+  {
     "action": "notifications.alerting.grafana.app/routingtrees:create",
     "roles": [
       "fixed:alerting.managed-routes:creator",

--- a/pkg/services/ngalert/accesscontrol/testdata/basic_role_grants.snapshot.json
+++ b/pkg/services/ngalert/accesscontrol/testdata/basic_role_grants.snapshot.json
@@ -2,6 +2,7 @@
   {
     "grant": "Admin",
     "roles": [
+      "fixed:alerting.alertmanager-imports:writer",
       "fixed:alerting.legacy:writer",
       "fixed:alerting.provisioning.provenance:writer",
       "fixed:alerting.provisioning.secrets:reader",
@@ -190,6 +191,22 @@
       {
         "action": "folders:read",
         "scope": "folders:*"
+      },
+      {
+        "action": "notifications.alerting.grafana.app/alertmanagerimports:create",
+        "scope": "notifications.alerting.grafana.app/alertmanagerimports:*"
+      },
+      {
+        "action": "notifications.alerting.grafana.app/alertmanagerimports:delete",
+        "scope": "notifications.alerting.grafana.app/alertmanagerimports:*"
+      },
+      {
+        "action": "notifications.alerting.grafana.app/alertmanagerimports:get",
+        "scope": "notifications.alerting.grafana.app/alertmanagerimports:*"
+      },
+      {
+        "action": "notifications.alerting.grafana.app/alertmanagerimports:update",
+        "scope": "notifications.alerting.grafana.app/alertmanagerimports:*"
       },
       {
         "action": "notifications.alerting.grafana.app/routingtrees:create"

--- a/pkg/services/ngalert/accesscontrol/testdata/fixed_roles.snapshot.json
+++ b/pkg/services/ngalert/accesscontrol/testdata/fixed_roles.snapshot.json
@@ -1064,5 +1064,32 @@
     "grants": [
       "Editor"
     ]
+  },
+  {
+    "name": "fixed:alerting.alertmanager-imports:writer",
+    "displayName": "Alerting alertmanager imports writer",
+    "description": "Read, write, and delete Prometheus/Mimir-compatible alertmanager configurations imported via the convert API.",
+    "group": "Alerting",
+    "permissions": [
+      {
+        "action": "notifications.alerting.grafana.app/alertmanagerimports:create",
+        "scope": "notifications.alerting.grafana.app/alertmanagerimports:*"
+      },
+      {
+        "action": "notifications.alerting.grafana.app/alertmanagerimports:delete",
+        "scope": "notifications.alerting.grafana.app/alertmanagerimports:*"
+      },
+      {
+        "action": "notifications.alerting.grafana.app/alertmanagerimports:get",
+        "scope": "notifications.alerting.grafana.app/alertmanagerimports:*"
+      },
+      {
+        "action": "notifications.alerting.grafana.app/alertmanagerimports:update",
+        "scope": "notifications.alerting.grafana.app/alertmanagerimports:*"
+      }
+    ],
+    "grants": [
+      "Admin"
+    ]
   }
 ]

--- a/pkg/services/ngalert/api/api.go
+++ b/pkg/services/ngalert/api/api.go
@@ -109,6 +109,7 @@ func (api *API) RegisterAPIEndpoints(m *metrics.API) {
 		api.AlertRules,
 		api.FeatureManager,
 		api.MultiOrgAlertmanager,
+		accesscontrol.NewAlertmanagerImportsAccess(api.AccessControl),
 	)
 
 	// Register endpoints for proxying to Alertmanager-compatible backends.

--- a/pkg/services/ngalert/api/api_convert_prometheus.go
+++ b/pkg/services/ngalert/api/api_convert_prometheus.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/log"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/dashboards"
@@ -30,6 +31,7 @@ import (
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/validation"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/notifier"
 	"github.com/grafana/grafana/pkg/services/ngalert/prom"
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrations/ualert"
@@ -140,11 +142,12 @@ type ConvertPrometheusSrv struct {
 	alertRuleService *provisioning.AlertRuleService
 	featureToggles   featuremgmt.FeatureToggles
 	am               Alertmanager
+	importsAuthz     notifier.ExtraConfigAuthz
 }
 
 type Alertmanager interface {
-	DeleteExtraConfiguration(ctx context.Context, org int64, identifier string) error
-	SaveAndApplyExtraConfiguration(ctx context.Context, org int64, extraConfig apimodels.ExtraConfiguration, replace bool, dryRun bool) (definition.RenameResources, error)
+	DeleteExtraConfiguration(ctx context.Context, org int64, user identity.Requester, authz notifier.ExtraConfigAuthz, identifier string) error
+	SaveAndApplyExtraConfiguration(ctx context.Context, org int64, user identity.Requester, authz notifier.ExtraConfigAuthz, extraConfig apimodels.ExtraConfiguration, replace bool, dryRun bool) (definition.RenameResources, error)
 	GetAlertmanagerConfiguration(ctx context.Context, org int64, withAutogen bool, withMergedExtraConfig bool) (apimodels.GettableUserConfig, error)
 }
 
@@ -156,6 +159,7 @@ func NewConvertPrometheusSrv(
 	alertRuleService *provisioning.AlertRuleService,
 	featureToggles featuremgmt.FeatureToggles,
 	am Alertmanager,
+	importsAuthz notifier.ExtraConfigAuthz,
 ) *ConvertPrometheusSrv {
 	return &ConvertPrometheusSrv{
 		cfg:              cfg,
@@ -165,6 +169,7 @@ func NewConvertPrometheusSrv(
 		alertRuleService: alertRuleService,
 		featureToggles:   featureToggles,
 		am:               am,
+		importsAuthz:     importsAuthz,
 	}
 }
 
@@ -635,7 +640,7 @@ func (srv *ConvertPrometheusSrv) RouteConvertPrometheusPostAlertmanagerConfig(c 
 		return errorToResponse(err)
 	}
 
-	renamed, err := srv.am.SaveAndApplyExtraConfiguration(c.Req.Context(), c.GetOrgID(), ec, replace, dryRun)
+	renamed, err := srv.am.SaveAndApplyExtraConfiguration(c.Req.Context(), c.GetOrgID(), c.SignedInUser, srv.importsAuthz, ec, replace, dryRun)
 	if err != nil {
 		logger.Error("Failed to save alertmanager configuration", "error", err, "identifier", identifier)
 		return errorToResponse(fmt.Errorf("failed to save alertmanager configuration: %w", err))
@@ -729,7 +734,7 @@ func (srv *ConvertPrometheusSrv) RouteConvertPrometheusDeleteAlertmanagerConfig(
 		return errorToResponse(err)
 	}
 
-	err = srv.am.DeleteExtraConfiguration(c.Req.Context(), c.GetOrgID(), identifier)
+	err = srv.am.DeleteExtraConfiguration(c.Req.Context(), c.GetOrgID(), c.SignedInUser, srv.importsAuthz, identifier)
 	if err != nil {
 		logger.Error("Failed to delete alertmanager configuration", "error", err, "identifier", identifier)
 		return errorToResponse(fmt.Errorf("failed to delete alertmanager configuration: %w", err))
@@ -944,11 +949,15 @@ func formatMergeMatchers(matchers apimodels.Matchers) string {
 	return strings.Join(pairs, ",")
 }
 
-func parseConfigIdentifierHeader(c *contextmodel.ReqContext) (string, error) {
-	identifier := strings.TrimSpace(c.Req.Header.Get(configIdentifierHeader))
-	if identifier == "" {
-		return defaultConfigIdentifier, nil
+func readConfigIdentifierHeader(c *contextmodel.ReqContext) string {
+	if id := strings.TrimSpace(c.Req.Header.Get(configIdentifierHeader)); id != "" {
+		return id
 	}
+	return defaultConfigIdentifier
+}
+
+func parseConfigIdentifierHeader(c *contextmodel.ReqContext) (string, error) {
+	identifier := readConfigIdentifierHeader(c)
 	if errs := k8svalidation.IsDNS1123Subdomain(identifier); len(errs) > 0 {
 		return "", errInvalidHeaderValue(configIdentifierHeader, errors.New(strings.Join(errs, ",")))
 	}

--- a/pkg/services/ngalert/api/api_convert_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_convert_prometheus_test.go
@@ -29,6 +29,7 @@ import (
 	acfakes "github.com/grafana/grafana/pkg/services/ngalert/accesscontrol/fakes"
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/notifier"
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/services/ngalert/tests/fakes"
@@ -1817,7 +1818,7 @@ func createConvertPrometheusSrv(t *testing.T, opts ...convertPrometheusSrvOption
 		},
 	}
 
-	srv := NewConvertPrometheusSrv(cfg, log.NewNopLogger(), ruleStore, dsCache, alertRuleService, options.featureToggles, options.alertmanager)
+	srv := NewConvertPrometheusSrv(cfg, log.NewNopLogger(), ruleStore, dsCache, alertRuleService, options.featureToggles, options.alertmanager, nil)
 
 	return srv, dsCache, ruleStore
 }
@@ -1964,8 +1965,8 @@ type mockAlertmanager struct {
 	mock.Mock
 }
 
-func (m *mockAlertmanager) SaveAndApplyExtraConfiguration(ctx context.Context, org int64, extraConfig apimodels.ExtraConfiguration, replace bool, dryRun bool) (definition.RenameResources, error) {
-	args := m.Called(ctx, org, extraConfig, replace, dryRun)
+func (m *mockAlertmanager) SaveAndApplyExtraConfiguration(ctx context.Context, org int64, user identity.Requester, authz notifier.ExtraConfigAuthz, extraConfig apimodels.ExtraConfiguration, replace bool, dryRun bool) (definition.RenameResources, error) {
+	args := m.Called(ctx, org, user, authz, extraConfig, replace, dryRun)
 	return args.Get(0).(definition.RenameResources), args.Error(1)
 }
 
@@ -1974,8 +1975,8 @@ func (m *mockAlertmanager) GetAlertmanagerConfiguration(ctx context.Context, org
 	return args.Get(0).(apimodels.GettableUserConfig), args.Error(1)
 }
 
-func (m *mockAlertmanager) DeleteExtraConfiguration(ctx context.Context, org int64, identifier string) error {
-	args := m.Called(ctx, org, identifier)
+func (m *mockAlertmanager) DeleteExtraConfiguration(ctx context.Context, org int64, user identity.Requester, authz notifier.ExtraConfigAuthz, identifier string) error {
+	args := m.Called(ctx, org, user, authz, identifier)
 	return args.Error(0)
 }
 
@@ -1987,7 +1988,7 @@ func TestRouteConvertPrometheusPostAlertmanagerConfig(t *testing.T) {
 	srv, _, _ := createConvertPrometheusSrv(t, withAlertmanager(mockAM), withFeatureToggles(ft))
 
 	t.Run("should parse headers and call SaveAndApplyExtraConfiguration", func(t *testing.T) {
-		mockAM.On("SaveAndApplyExtraConfiguration", mock.Anything, int64(1), mock.MatchedBy(func(extraConfig apimodels.ExtraConfiguration) bool {
+		mockAM.On("SaveAndApplyExtraConfiguration", mock.Anything, int64(1), mock.Anything, mock.Anything, mock.MatchedBy(func(extraConfig apimodels.ExtraConfiguration) bool {
 			return extraConfig.Identifier == identifier &&
 				len(extraConfig.MergeMatchers) == 2 &&
 				len(extraConfig.TemplateFiles) == 1 &&
@@ -2024,7 +2025,7 @@ func TestRouteConvertPrometheusPostAlertmanagerConfig(t *testing.T) {
 		rc := createRequestCtx()
 		rc.Req.Header.Set(mergeMatchersHeader, "test=value")
 		mockAM := &mockAlertmanager{}
-		mockAM.On("SaveAndApplyExtraConfiguration", mock.Anything, int64(1), mock.MatchedBy(func(extraConfig apimodels.ExtraConfiguration) bool {
+		mockAM.On("SaveAndApplyExtraConfiguration", mock.Anything, int64(1), mock.Anything, mock.Anything, mock.MatchedBy(func(extraConfig apimodels.ExtraConfiguration) bool {
 			return extraConfig.Identifier == defaultConfigIdentifier
 		}), false, false).Return(definition.RenameResources{}, nil)
 
@@ -2053,7 +2054,7 @@ func TestRouteConvertPrometheusPostAlertmanagerConfig(t *testing.T) {
 		rc := createRequestCtx()
 		rc.Req.Header.Set(configForceReplaceHeader, "true")
 		mockAM := &mockAlertmanager{}
-		mockAM.On("SaveAndApplyExtraConfiguration", mock.Anything, int64(1), mock.MatchedBy(func(extraConfig apimodels.ExtraConfiguration) bool {
+		mockAM.On("SaveAndApplyExtraConfiguration", mock.Anything, int64(1), mock.Anything, mock.Anything, mock.MatchedBy(func(extraConfig apimodels.ExtraConfiguration) bool {
 			return extraConfig.Identifier == defaultConfigIdentifier
 		}), true, false).Return(definition.RenameResources{}, nil)
 
@@ -2082,7 +2083,7 @@ func TestRouteConvertPrometheusPostAlertmanagerConfig(t *testing.T) {
 		rc := createRequestCtx()
 		rc.Req.Header.Set(dryRunHeader, "true")
 		mockAM := &mockAlertmanager{}
-		mockAM.On("SaveAndApplyExtraConfiguration", mock.Anything, int64(1), mock.MatchedBy(func(extraConfig apimodels.ExtraConfiguration) bool {
+		mockAM.On("SaveAndApplyExtraConfiguration", mock.Anything, int64(1), mock.Anything, mock.Anything, mock.MatchedBy(func(extraConfig apimodels.ExtraConfiguration) bool {
 			return extraConfig.Identifier == defaultConfigIdentifier
 		}), false, true).Return(definition.RenameResources{}, nil)
 
@@ -2121,7 +2122,7 @@ func TestRouteConvertPrometheusPostAlertmanagerConfig(t *testing.T) {
 			},
 		}
 
-		mockAM.On("SaveAndApplyExtraConfiguration", mock.Anything, int64(1), mock.MatchedBy(func(extraConfig apimodels.ExtraConfiguration) bool {
+		mockAM.On("SaveAndApplyExtraConfiguration", mock.Anything, int64(1), mock.Anything, mock.Anything, mock.MatchedBy(func(extraConfig apimodels.ExtraConfiguration) bool {
 			return extraConfig.Identifier == identifier
 		}), false, false).Return(expectedRenames, nil)
 
@@ -2535,7 +2536,7 @@ func TestRouteConvertPrometheusDeleteAlertmanagerConfig(t *testing.T) {
 	srv, _, _ := createConvertPrometheusSrv(t, withAlertmanager(mockAM), withFeatureToggles(ft))
 
 	t.Run("should parse identifier header and call DeleteExtraConfiguration", func(t *testing.T) {
-		mockAM.On("DeleteExtraConfiguration", mock.Anything, orgID, identifier).Return(nil).Once()
+		mockAM.On("DeleteExtraConfiguration", mock.Anything, orgID, mock.Anything, mock.Anything, identifier).Return(nil).Once()
 
 		rc := createRequestCtx()
 		rc.Req.Header.Set(configIdentifierHeader, identifier)
@@ -2547,7 +2548,7 @@ func TestRouteConvertPrometheusDeleteAlertmanagerConfig(t *testing.T) {
 	})
 
 	t.Run("should use default identifier when header is missing", func(t *testing.T) {
-		mockAM.On("DeleteExtraConfiguration", mock.Anything, orgID, defaultConfigIdentifier).Return(nil).Once()
+		mockAM.On("DeleteExtraConfiguration", mock.Anything, orgID, mock.Anything, mock.Anything, defaultConfigIdentifier).Return(nil).Once()
 		rc := createRequestCtx()
 
 		response := srv.RouteConvertPrometheusDeleteAlertmanagerConfig(rc)
@@ -2557,7 +2558,7 @@ func TestRouteConvertPrometheusDeleteAlertmanagerConfig(t *testing.T) {
 	})
 
 	t.Run("should return error when DeleteExtraConfiguration fails", func(t *testing.T) {
-		mockAM.On("DeleteExtraConfiguration", mock.Anything, orgID, identifier).Return(errors.New("delete error")).Once()
+		mockAM.On("DeleteExtraConfiguration", mock.Anything, orgID, mock.Anything, mock.Anything, identifier).Return(errors.New("delete error")).Once()
 
 		rc := createRequestCtx()
 		rc.Req.Header.Set(configIdentifierHeader, identifier)
@@ -2581,7 +2582,7 @@ func TestRouteConvertPrometheusDeleteAlertmanagerConfig(t *testing.T) {
 	})
 
 	t.Run("should use default identifier for empty identifier header", func(t *testing.T) {
-		mockAM.On("DeleteExtraConfiguration", mock.Anything, orgID, defaultConfigIdentifier).Return(nil).Once()
+		mockAM.On("DeleteExtraConfiguration", mock.Anything, orgID, mock.Anything, mock.Anything, defaultConfigIdentifier).Return(nil).Once()
 		rc := createRequestCtx()
 		rc.Req.Header.Set(configIdentifierHeader, "")
 

--- a/pkg/services/ngalert/api/authorization.go
+++ b/pkg/services/ngalert/api/authorization.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/middleware"
 	ac "github.com/grafana/grafana/pkg/services/accesscontrol"
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/ngalert/accesscontrol"
@@ -155,11 +156,37 @@ func (api *API) authorize(method, path string) web.Handler {
 			ac.EvalPermission(ac.ActionAlertingProvisioningSetStatus),
 		)
 
-	case http.MethodPost + "/api/convert/api/v1/alerts",
-		http.MethodDelete + "/api/convert/api/v1/alerts":
-		eval = ac.EvalPermission(ac.ActionAlertingNotificationsWrite)
+	case http.MethodPost + "/api/convert/api/v1/alerts":
+		return func(c *contextmodel.ReqContext) {
+			authorize(ac.EvalAny(
+				ac.EvalPermission(ac.ActionAlertingNotificationsWrite),
+				ac.EvalPermission(ac.ActionAlertingAlertmanagerImportsCreate),
+				ac.EvalPermission(
+					ac.ActionAlertingAlertmanagerImportsWrite,
+					models.ScopeAlertmanagerImportsProvider.GetResourceScopeUID(readConfigIdentifierHeader(c)),
+				),
+			)).(func(*contextmodel.ReqContext))(c)
+		}
+	case http.MethodDelete + "/api/convert/api/v1/alerts":
+		return func(c *contextmodel.ReqContext) {
+			authorize(ac.EvalAny(
+				ac.EvalPermission(ac.ActionAlertingNotificationsWrite),
+				ac.EvalPermission(
+					ac.ActionAlertingAlertmanagerImportsDelete,
+					models.ScopeAlertmanagerImportsProvider.GetResourceScopeUID(readConfigIdentifierHeader(c)),
+				),
+			)).(func(*contextmodel.ReqContext))(c)
+		}
 	case http.MethodGet + "/api/convert/api/v1/alerts":
-		eval = ac.EvalPermission(ac.ActionAlertingNotificationsRead)
+		return func(c *contextmodel.ReqContext) {
+			authorize(ac.EvalAny(
+				ac.EvalPermission(ac.ActionAlertingNotificationsRead),
+				ac.EvalPermission(
+					ac.ActionAlertingAlertmanagerImportsRead,
+					models.ScopeAlertmanagerImportsProvider.GetResourceScopeUID(readConfigIdentifierHeader(c)),
+				),
+			)).(func(*contextmodel.ReqContext))(c)
+		}
 
 	// Alert Instances and Silences
 

--- a/pkg/services/ngalert/models/accesscontrol.go
+++ b/pkg/services/ngalert/models/accesscontrol.go
@@ -29,6 +29,9 @@ var (
 	ScopeRoutesAll               = ScopeRoutesProvider.GetResourceAllScope()
 	ScopeInhibitionRulesProvider = accesscontrol.NewScopeProvider(ScopeInhibitionRulesRoot)
 	ScopeInhibitionRulesAll      = ScopeInhibitionRulesProvider.GetResourceAllScope()
+
+	ScopeAlertmanagerImportsProvider = accesscontrol.NewScopeProvider(accesscontrol.AlertingAlertmanagerImportsKind)
+	ScopeAlertmanagerImportsAll      = ScopeAlertmanagerImportsProvider.GetResourceAllScope()
 )
 
 type ReceiverScopeProvider struct {

--- a/pkg/services/ngalert/notifier/alertmanager_config.go
+++ b/pkg/services/ngalert/notifier/alertmanager_config.go
@@ -14,12 +14,20 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage"
 	"github.com/grafana/grafana/pkg/services/secrets"
 )
+
+// ExtraConfigAuthz is the authorization interface for alertmanager import operations.
+type ExtraConfigAuthz interface {
+	AuthorizeCreate(ctx context.Context, user identity.Requester) error
+	AuthorizeUpdate(ctx context.Context, user identity.Requester, identifier string) error
+	AuthorizeDelete(ctx context.Context, user identity.Requester, identifier string) error
+}
 
 var (
 	// ErrAlertmanagerReceiverInUse is primarily meant for when a receiver is used by a rule and is being deleted.
@@ -449,9 +457,18 @@ func (moa *MultiOrgAlertmanager) modifyAndApplyExtraConfiguration(
 }
 
 // SaveAndApplyExtraConfiguration adds or replaces an ExtraConfiguration while preserving the main AlertmanagerConfig.
-func (moa *MultiOrgAlertmanager) SaveAndApplyExtraConfiguration(ctx context.Context, org int64, extraConfig definitions.ExtraConfiguration, replace bool, dryRun bool) (definition.RenameResources, error) {
+func (moa *MultiOrgAlertmanager) SaveAndApplyExtraConfiguration(ctx context.Context, org int64, user identity.Requester, authz ExtraConfigAuthz, extraConfig definitions.ExtraConfiguration, replace bool, dryRun bool) (definition.RenameResources, error) {
 	modifyFunc := func(configs []definitions.ExtraConfiguration) ([]definitions.ExtraConfiguration, error) {
-		if !replace {
+		if replace {
+			// When replacing all configs, authorize deletion for each config with a different identifier.
+			for _, c := range configs {
+				if c.Identifier != extraConfig.Identifier {
+					if err := authz.AuthorizeDelete(ctx, user, c.Identifier); err != nil {
+						return nil, err
+					}
+				}
+			}
+		} else {
 			// for now we validate that after the update there will be just one extra config.
 			for _, c := range configs {
 				if c.Identifier != extraConfig.Identifier {
@@ -459,6 +476,24 @@ func (moa *MultiOrgAlertmanager) SaveAndApplyExtraConfiguration(ctx context.Cont
 				}
 			}
 		}
+
+		isNew := true
+		for _, c := range configs {
+			if c.Identifier == extraConfig.Identifier {
+				isNew = false
+				break
+			}
+		}
+		if isNew {
+			if err := authz.AuthorizeCreate(ctx, user); err != nil {
+				return nil, err
+			}
+		} else {
+			if err := authz.AuthorizeUpdate(ctx, user, extraConfig.Identifier); err != nil {
+				return nil, err
+			}
+		}
+
 		return []definitions.ExtraConfiguration{extraConfig}, nil
 	}
 
@@ -476,8 +511,11 @@ func (moa *MultiOrgAlertmanager) SaveAndApplyExtraConfiguration(ctx context.Cont
 }
 
 // DeleteExtraConfiguration deletes an ExtraConfiguration by its identifier while preserving the main AlertmanagerConfig.
-func (moa *MultiOrgAlertmanager) DeleteExtraConfiguration(ctx context.Context, org int64, identifier string) error {
+func (moa *MultiOrgAlertmanager) DeleteExtraConfiguration(ctx context.Context, org int64, user identity.Requester, authz ExtraConfigAuthz, identifier string) error {
 	modifyFunc := func(configs []definitions.ExtraConfiguration) ([]definitions.ExtraConfiguration, error) {
+		if err := authz.AuthorizeDelete(ctx, user, identifier); err != nil {
+			return nil, err
+		}
 		filtered := make([]definitions.ExtraConfiguration, 0, len(configs))
 		for _, ec := range configs {
 			if ec.Identifier != identifier {

--- a/pkg/services/ngalert/notifier/alertmanager_config_test.go
+++ b/pkg/services/ngalert/notifier/alertmanager_config_test.go
@@ -3,6 +3,7 @@ package notifier
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 	"time"
@@ -10,9 +11,41 @@ import (
 	"github.com/prometheus/alertmanager/pkg/labels"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/user"
 )
+
+// noopExtraConfigAuthz permits all alertmanager import operations — for use in tests
+// that exercise config logic rather than authorization.
+type noopExtraConfigAuthz struct{}
+
+func (noopExtraConfigAuthz) AuthorizeCreate(_ context.Context, _ identity.Requester) error {
+	return nil
+}
+func (noopExtraConfigAuthz) AuthorizeUpdate(_ context.Context, _ identity.Requester, _ string) error {
+	return nil
+}
+func (noopExtraConfigAuthz) AuthorizeDelete(_ context.Context, _ identity.Requester, _ string) error {
+	return nil
+}
+
+type stubExtraConfigAuthz struct {
+	createErr error
+	updateErr error
+	deleteErr error
+}
+
+func (s stubExtraConfigAuthz) AuthorizeCreate(_ context.Context, _ identity.Requester) error {
+	return s.createErr
+}
+func (s stubExtraConfigAuthz) AuthorizeUpdate(_ context.Context, _ identity.Requester, _ string) error {
+	return s.updateErr
+}
+func (s stubExtraConfigAuthz) AuthorizeDelete(_ context.Context, _ identity.Requester, _ string) error {
+	return s.deleteErr
+}
 
 func TestMultiOrgAlertmanager_SaveAndApplyExtraConfiguration(t *testing.T) {
 	orgID := int64(1)
@@ -28,7 +61,7 @@ func TestMultiOrgAlertmanager_SaveAndApplyExtraConfiguration(t *testing.T) {
   receiver: test-receiver`,
 		}
 
-		_, err := mam.SaveAndApplyExtraConfiguration(ctx, 999, extraConfig, false, false)
+		_, err := mam.SaveAndApplyExtraConfiguration(ctx, 999, &user.SignedInUser{}, noopExtraConfigAuthz{}, extraConfig, false, false)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "failed to get current configuration")
 	})
@@ -48,7 +81,7 @@ receivers:
   - name: test-receiver`,
 		}
 
-		renamed, err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, extraConfig, false, false)
+		renamed, err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, noopExtraConfigAuthz{}, extraConfig, false, false)
 		require.NoError(t, err)
 		require.Empty(t, renamed.Receivers, "no renaming should occur")
 		require.Empty(t, renamed.TimeIntervals, "no renaming should occur")
@@ -84,7 +117,7 @@ receivers:
 		}
 
 		// Call with dryRun=true
-		_, err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, extraConfig, false, true)
+		_, err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, noopExtraConfigAuthz{}, extraConfig, false, true)
 		require.NoError(t, err)
 
 		// Verify configuration was NOT saved
@@ -110,7 +143,7 @@ receivers:
   - name: original-receiver`,
 		}
 
-		_, err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, originalConfig, false, false)
+		_, err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, noopExtraConfigAuthz{}, originalConfig, false, false)
 		require.NoError(t, err)
 
 		// Now replace it
@@ -124,7 +157,7 @@ receivers:
   - name: updated-receiver`,
 		}
 
-		_, err = mam.SaveAndApplyExtraConfiguration(ctx, orgID, updatedConfig, false, false)
+		_, err = mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, noopExtraConfigAuthz{}, updatedConfig, false, false)
 		require.NoError(t, err)
 
 		// Verify only one config exists with updated content
@@ -155,7 +188,7 @@ receivers:
 			}`,
 		}
 
-		_, err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, firstConfig, false, false)
+		_, err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, noopExtraConfigAuthz{}, firstConfig, false, false)
 		require.NoError(t, err)
 
 		secondConfig := definitions.ExtraConfiguration{
@@ -173,13 +206,13 @@ receivers:
 			}`,
 		}
 
-		_, err = mam.SaveAndApplyExtraConfiguration(ctx, orgID, secondConfig, false, false)
+		_, err = mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, noopExtraConfigAuthz{}, secondConfig, false, false)
 		require.Error(t, err)
 		require.ErrorContains(t, err, "multiple extra configurations are not supported")
 		require.ErrorContains(t, err, "first-config")
 
 		t.Run("replaces if replace=true", func(t *testing.T) {
-			_, err = mam.SaveAndApplyExtraConfiguration(ctx, orgID, secondConfig, true, false)
+			_, err = mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, noopExtraConfigAuthz{}, secondConfig, true, false)
 			require.NoError(t, err)
 
 			gettableConfig, err := mam.GetAlertmanagerConfiguration(ctx, orgID, false, false)
@@ -237,7 +270,7 @@ receivers:
   - name: original-receiver`,
 		}
 
-		_, err = mam.SaveAndApplyExtraConfiguration(ctx, orgID, originalConfig, false, false)
+		_, err = mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, noopExtraConfigAuthz{}, originalConfig, false, false)
 		require.ErrorIs(t, err, ErrIdentifierAlreadyExists)
 	})
 }
@@ -261,7 +294,7 @@ receivers:
   - name: test-receiver`,
 		}
 
-		renamed, err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, extraConfig, false, false)
+		renamed, err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, noopExtraConfigAuthz{}, extraConfig, false, false)
 		require.NoError(t, err)
 		require.Empty(t, renamed.Receivers, "no renaming should occur")
 		require.Empty(t, renamed.TimeIntervals, "no renaming should occur")
@@ -270,7 +303,7 @@ receivers:
 		require.NoError(t, err)
 		require.Len(t, gettableConfig.ExtraConfigs, 1)
 
-		err = mam.DeleteExtraConfiguration(ctx, orgID, identifier)
+		err = mam.DeleteExtraConfiguration(ctx, orgID, &user.SignedInUser{}, noopExtraConfigAuthz{}, identifier)
 		require.NoError(t, err)
 
 		gettableConfig, err = mam.GetAlertmanagerConfiguration(ctx, orgID, false, false)
@@ -283,7 +316,7 @@ receivers:
 		ctx := context.Background()
 		require.NoError(t, mam.LoadAndSyncAlertmanagersForOrgs(ctx))
 
-		err := mam.DeleteExtraConfiguration(ctx, orgID, "non-existent")
+		err := mam.DeleteExtraConfiguration(ctx, orgID, &user.SignedInUser{}, noopExtraConfigAuthz{}, "non-existent")
 		require.NoError(t, err)
 	})
 
@@ -291,8 +324,96 @@ receivers:
 		mam := setupMam(t, nil)
 		ctx := context.Background()
 
-		err := mam.DeleteExtraConfiguration(ctx, 999, "test-config")
+		err := mam.DeleteExtraConfiguration(ctx, 999, &user.SignedInUser{}, noopExtraConfigAuthz{}, "test-config")
 		require.Error(t, err)
 		require.ErrorContains(t, err, "failed to get current configuration")
+	})
+}
+
+func TestMultiOrgAlertmanager_ExtraConfigurationAuthz(t *testing.T) {
+	orgID := int64(1)
+	ctx := context.Background()
+
+	validConfig := definitions.ExtraConfiguration{
+		Identifier: "config-a",
+		AlertmanagerConfig: `route:
+  receiver: test-receiver
+receivers:
+  - name: test-receiver`,
+	}
+
+	t.Run("SaveAndApply: AuthorizeCreate denied", func(t *testing.T) {
+		mam := setupMam(t, nil)
+		require.NoError(t, mam.LoadAndSyncAlertmanagersForOrgs(ctx))
+
+		authz := stubExtraConfigAuthz{createErr: errors.New("forbidden")}
+		_, err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, authz, validConfig, false, false)
+		require.Error(t, err)
+
+		// Verify no config was saved.
+		gettableConfig, err := mam.GetAlertmanagerConfiguration(ctx, orgID, false, false)
+		require.NoError(t, err)
+		require.Len(t, gettableConfig.ExtraConfigs, 0)
+	})
+
+	t.Run("SaveAndApply: AuthorizeUpdate denied", func(t *testing.T) {
+		mam := setupMam(t, nil)
+		require.NoError(t, mam.LoadAndSyncAlertmanagersForOrgs(ctx))
+
+		// Save the config first with noop authz.
+		_, err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, noopExtraConfigAuthz{}, validConfig, false, false)
+		require.NoError(t, err)
+
+		// Try updating with update denied.
+		authz := stubExtraConfigAuthz{updateErr: errors.New("forbidden")}
+		_, err = mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, authz, validConfig, false, false)
+		require.Error(t, err)
+	})
+
+	t.Run("SaveAndApply replace=true: AuthorizeDelete denied for displaced config", func(t *testing.T) {
+		mam := setupMam(t, nil)
+		require.NoError(t, mam.LoadAndSyncAlertmanagersForOrgs(ctx))
+
+		// Save config A first.
+		configA := definitions.ExtraConfiguration{
+			Identifier: "config-a",
+			AlertmanagerConfig: `route:
+  receiver: test-receiver
+receivers:
+  - name: test-receiver`,
+		}
+		_, err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, noopExtraConfigAuthz{}, configA, false, false)
+		require.NoError(t, err)
+
+		// Try to save config B with replace=true, but delete is denied.
+		configB := definitions.ExtraConfiguration{
+			Identifier: "config-b",
+			AlertmanagerConfig: `route:
+  receiver: test-receiver
+receivers:
+  - name: test-receiver`,
+		}
+		authz := stubExtraConfigAuthz{deleteErr: errors.New("forbidden")}
+		_, err = mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, authz, configB, true, false)
+		require.Error(t, err)
+	})
+
+	t.Run("Delete: AuthorizeDelete denied", func(t *testing.T) {
+		mam := setupMam(t, nil)
+		require.NoError(t, mam.LoadAndSyncAlertmanagersForOrgs(ctx))
+
+		// Save config first.
+		_, err := mam.SaveAndApplyExtraConfiguration(ctx, orgID, &user.SignedInUser{}, noopExtraConfigAuthz{}, validConfig, false, false)
+		require.NoError(t, err)
+
+		// Try to delete with delete denied.
+		authz := stubExtraConfigAuthz{deleteErr: errors.New("forbidden")}
+		err = mam.DeleteExtraConfiguration(ctx, orgID, &user.SignedInUser{}, authz, validConfig.Identifier)
+		require.Error(t, err)
+
+		// Verify config still exists.
+		gettableConfig, err := mam.GetAlertmanagerConfiguration(ctx, orgID, false, false)
+		require.NoError(t, err)
+		require.Len(t, gettableConfig.ExtraConfigs, 1)
 	})
 }

--- a/pkg/services/ngalert/notifier/alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/alertmanager_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/tests/fakes"
 	"github.com/grafana/grafana/pkg/services/secrets/database"
 	secretsManager "github.com/grafana/grafana/pkg/services/secrets/manager"
+	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
 	"github.com/grafana/grafana/pkg/util"
@@ -100,7 +101,7 @@ func TestAlertmanager_SaveAndApplyExtraConfiguration_WithExternalSecrets(t *test
 	err = moa.saveAndApplyConfig(context.Background(), 1, am, cfg)
 	require.NoError(t, err)
 
-	_, err = moa.SaveAndApplyExtraConfiguration(context.Background(), 1, definitions.ExtraConfiguration{
+	_, err = moa.SaveAndApplyExtraConfiguration(context.Background(), 1, &user.SignedInUser{}, noopExtraConfigAuthz{}, definitions.ExtraConfiguration{
 		Identifier:    "external-prometheus",
 		MergeMatchers: []*labels.Matcher{{Type: labels.MatchEqual, Name: "cluster", Value: "prod"}},
 		AlertmanagerConfig: `


### PR DESCRIPTION
## Summary

Adds RBAC authorization to the convert API endpoints that import Prometheus/Mimir-compatible alertmanager configurations (`GET/POST/DELETE /api/convert/api/v1/alerts`).

- Defines four new scoped RBAC actions under `notifications.alerting.grafana.app/alertmanagerimports`: `create`, `get`, `update`, `delete`
- Introduces `ExtraConfigAuthz` interface in the notifier and enforces authorization inside `SaveAndApplyExtraConfiguration` and `DeleteExtraConfiguration`
- Implements `AlertmanagerImportsAccess` — the RBAC-backed service that checks these actions; `create` has no legacy fallback while `update`/`delete` accept legacy `notifications:write`
- Registers `fixed:alerting.alertmanager-imports:writer` role (granted to Org Admins), gated by `FlagAlertingImportAlertmanagerAPI`
- Threads authorization through the convert API so the signed-in user and authz service are passed down to the notifier on every mutating call

## Test plan

- [ ] Unit tests for `AlertmanagerImportsAccess` (create/update/delete, including legacy fallback and scoped-permission cases)
- [ ] Unit tests for `ExtraConfigAuthz` enforcement in the notifier (`TestMultiOrgAlertmanager_ExtraConfigurationAuthz` — create denied, update denied, replace with delete denied, delete denied)
- [ ] Role snapshot tests updated to include new role and actions
- [ ] Convert API mock tests updated to pass `user`/`authz` through to the `Alertmanager` interface

🤖 Generated with [Claude Code](https://claude.com/claude-code)