### PR TITLE
PluginConfigs: Fix webpack entry resolution on Windows

### DIFF
--- a/packages/grafana-plugin-configs/utils.ts
+++ b/packages/grafana-plugin-configs/utils.ts
@@ -19,14 +19,16 @@ export function getPluginJson() {
 }
 
 export async function getEntries(): Promise<Record<string, string>> {
-  const pluginsJson = await glob(path.resolve(process.cwd(), '**/plugin.json'), {
+  // glob uses POSIX-style forward slashes, so normalize on Windows.
+  const cwdPosix = process.cwd().replace(/\\/g, '/');
+  const pluginsJson = await glob(`${cwdPosix}/**/plugin.json`, {
     ignore: ['**/dist/**'],
     absolute: true,
   });
 
   const plugins = await Promise.all(
     pluginsJson.map((pluginJson) => {
-      const folder = path.dirname(pluginJson);
+      const folder = path.dirname(pluginJson).replace(/\\/g, '/');
       return glob(`${folder}/module.{ts,tsx,js,jsx}`, { absolute: true });
     })
   );


### PR DESCRIPTION
## Summary

Fixes webpack entry resolution for plugins built on Windows. Without this fix, building any plugin (e.g. `azuremonitor`, `cloud-monitoring`, etc.) on Windows produces a `dist/` folder containing only static assets — no `module.js` — and the plugin fails to load at runtime with a 404.

## Root cause

`getEntries()` in `packages/grafana-plugin-configs/utils.ts` uses:

```ts
glob(path.resolve(process.cwd(), '**/plugin.json'), ...)
```

On Windows, `path.resolve()` returns a string with backslash separators (e.g. `C:\Repos\grafana\public\...\**\plugin.json`). The [`glob`](https://github.com/isaacs/node-glob) package treats backslashes as escape characters, not path separators, so the pattern matches nothing and webpack receives an empty `entry` map. Webpack then "succeeds" (no errors) but emits no JS bundle — only the static assets copied by `CopyWebpackPlugin`.

The same issue affects the inner glob that locates each plugin's `module.{ts,tsx,js,jsx}`.

## Fix

Normalise both glob patterns to POSIX-style forward slashes before calling `glob()`. POSIX paths are valid on Windows for glob, and unchanged on macOS/Linux, so this is a no-op on non-Windows platforms.

## Reproduction

On a Windows machine:

```powershell
cd public/app/plugins/datasource/azuremonitor
yarn build
ls dist
```

**Before this PR:** `dist/` contains `plugin.json`, `README.md`, `dashboards/`, `img/`, `locales/` — but **no `module.js`**. Webpack reports "57 assets" but no entry was bundled.

**After this PR:** `dist/module.js` (~417 KiB) is present.

## Risk

Very low — the change is a string normalisation (`replace(/\\/g, '/')`) and only affects the input passed to `glob()`. POSIX paths remain functionally identical on Linux/macOS. No tests change.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
