### PR TITLE
search: add resource to snapshot selection logs

### DIFF
--- a/pkg/storage/unified/search/bleve_snapshot.go
+++ b/pkg/storage/unified/search/bleve_snapshot.go
@@ -75,7 +75,7 @@ func (b *bleveBackend) tryDownloadRemoteSnapshot(
 			if err != nil {
 				return ulid.ULID{}, nil, fmt.Errorf("listing remote snapshots: %w", err)
 			}
-			c, ok := b.pickBestSnapshot(all, time.Now())
+			c, ok := b.pickBestSnapshot(all, time.Now(), logger)
 			if !ok {
 				return ulid.ULID{}, nil, nil
 			}
@@ -275,7 +275,7 @@ func (b *bleveBackend) downloadSelectedSnapshot(
 // Tier 2 (newer, last resort): v > runningVersion
 //
 // Within each tier, sort by version desc -> RV desc -> upload time desc.
-func (b *bleveBackend) pickBestSnapshot(all map[ulid.ULID]*IndexMeta, now time.Time) (snapshotCandidate, bool) {
+func (b *bleveBackend) pickBestSnapshot(all map[ulid.ULID]*IndexMeta, now time.Time, logger log.Logger) (snapshotCandidate, bool) {
 	maxAge := b.opts.Snapshot.MaxIndexAge
 	minVersion := b.opts.Snapshot.MinBuildVersion
 	running := b.runningBuildVersion
@@ -303,7 +303,7 @@ func (b *bleveBackend) pickBestSnapshot(all map[ulid.ULID]*IndexMeta, now time.T
 			tier:    snapshotTier(v, minVersion, running),
 		}
 		candidates = append(candidates, c)
-		b.log.Debug("index snapshot candidate",
+		logger.Debug("index snapshot candidate",
 			"key", c.key.String(),
 			"tier", c.tier,
 			"version", c.version.String(),
@@ -313,7 +313,7 @@ func (b *bleveBackend) pickBestSnapshot(all map[ulid.ULID]*IndexMeta, now time.T
 	}
 
 	if len(candidates) == 0 {
-		b.log.Debug("no index snapshot candidates", "total", len(all), "dropped_age", droppedAge, "dropped_unparseable", droppedUnparseable)
+		logger.Debug("no index snapshot candidates", "total", len(all), "dropped_age", droppedAge, "dropped_unparseable", droppedUnparseable)
 		return snapshotCandidate{}, false
 	}
 
@@ -330,7 +330,7 @@ func (b *bleveBackend) pickBestSnapshot(all map[ulid.ULID]*IndexMeta, now time.T
 		return candidates[i].meta.UploadTimestamp.After(candidates[j].meta.UploadTimestamp)
 	})
 
-	b.log.Debug("selected index snapshot",
+	logger.Debug("selected index snapshot",
 		"key", candidates[0].key.String(),
 		"tier", candidates[0].tier,
 		"candidates", len(candidates),

--- a/pkg/storage/unified/search/bleve_snapshot_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_test.go
@@ -216,19 +216,19 @@ func TestPickBestSnapshot(t *testing.T) {
 	}
 
 	t.Run("empty list", func(t *testing.T) {
-		_, ok := newBackend(24*time.Hour, minV).pickBestSnapshot(nil, now)
+		_, ok := newBackend(24*time.Hour, minV).pickBestSnapshot(nil, now, log.New("bleve-snapshot-test"))
 		assert.False(t, ok)
 	})
 
 	t.Run("dropped by age", func(t *testing.T) {
 		all := map[ulid.ULID]*IndexMeta{makeULID(t, now): snap("11.5.0", 100, 2*time.Hour)}
-		_, ok := newBackend(time.Hour, minV).pickBestSnapshot(all, now)
+		_, ok := newBackend(time.Hour, minV).pickBestSnapshot(all, now, log.New("bleve-snapshot-test"))
 		assert.False(t, ok)
 	})
 
 	t.Run("dropped for unparseable version", func(t *testing.T) {
 		all := map[ulid.ULID]*IndexMeta{makeULID(t, now): snap("not-a-version", 100, time.Minute)}
-		_, ok := newBackend(24*time.Hour, minV).pickBestSnapshot(all, now)
+		_, ok := newBackend(24*time.Hour, minV).pickBestSnapshot(all, now, log.New("bleve-snapshot-test"))
 		assert.False(t, ok)
 	})
 
@@ -241,7 +241,7 @@ func TestPickBestSnapshot(t *testing.T) {
 			newer: snap("11.6.0", 300, time.Minute),  // tier 2 (above running)
 			ideal: snap("11.5.0", 100, 10*time.Hour), // tier 0 wins despite lower RV / older upload
 		}
-		c, ok := newBackend(24*time.Hour, minV).pickBestSnapshot(all, now)
+		c, ok := newBackend(24*time.Hour, minV).pickBestSnapshot(all, now, log.New("bleve-snapshot-test"))
 		require.True(t, ok)
 		assert.Equal(t, ideal, c.key)
 		assert.Equal(t, 0, c.tier)
@@ -254,7 +254,7 @@ func TestPickBestSnapshot(t *testing.T) {
 			older: snap("11.3.0", 100, time.Minute),
 			newer: snap("12.0.0", 999, time.Minute),
 		}
-		c, ok := newBackend(24*time.Hour, minV).pickBestSnapshot(all, now)
+		c, ok := newBackend(24*time.Hour, minV).pickBestSnapshot(all, now, log.New("bleve-snapshot-test"))
 		require.True(t, ok)
 		assert.Equal(t, older, c.key)
 		assert.Equal(t, 1, c.tier)
@@ -263,7 +263,7 @@ func TestPickBestSnapshot(t *testing.T) {
 	t.Run("tier 2 picked as last resort", func(t *testing.T) {
 		only := makeULID(t, now)
 		all := map[ulid.ULID]*IndexMeta{only: snap("12.0.0", 100, time.Minute)}
-		c, ok := newBackend(24*time.Hour, minV).pickBestSnapshot(all, now)
+		c, ok := newBackend(24*time.Hour, minV).pickBestSnapshot(all, now, log.New("bleve-snapshot-test"))
 		require.True(t, ok)
 		assert.Equal(t, only, c.key)
 		assert.Equal(t, 2, c.tier)
@@ -282,13 +282,13 @@ func TestPickBestSnapshot(t *testing.T) {
 			b: snap("11.5.0", 50, time.Minute),     // best version, lowest RV, newer upload
 			c: snap("11.5.0", 200, 30*time.Minute), // best version, high RV, older upload
 		}
-		got, ok := newBackend(24*time.Hour, minV).pickBestSnapshot(all, now)
+		got, ok := newBackend(24*time.Hour, minV).pickBestSnapshot(all, now, log.New("bleve-snapshot-test"))
 		require.True(t, ok)
 		assert.Equal(t, c, got.key)
 
 		// Adding d (same version + RV as c, newer upload): d wins via upload-desc tiebreaker.
 		all[d] = snap("11.5.0", 200, time.Minute)
-		got, ok = newBackend(24*time.Hour, minV).pickBestSnapshot(all, now)
+		got, ok = newBackend(24*time.Hour, minV).pickBestSnapshot(all, now, log.New("bleve-snapshot-test"))
 		require.True(t, ok)
 		assert.Equal(t, d, got.key)
 	})

--- a/pkg/storage/unified/search/remote_index_cleanup_test.go
+++ b/pkg/storage/unified/search/remote_index_cleanup_test.go
@@ -231,7 +231,7 @@ func TestSelectSnapshotsToDelete_NeverDeletesDownloadPick(t *testing.T) {
 				}},
 				runningBuildVersion: running,
 			}
-			picked, ok := be.pickBestSnapshot(metas, now)
+			picked, ok := be.pickBestSnapshot(metas, now, be.log)
 			require.Truef(t, ok, "test case must yield a pickable snapshot — if a no-pick scenario is needed, add a dedicated test case rather than letting this one short-circuit")
 
 			deleted := selectSnapshotsToDelete(metas, now, testCleanupMaxAge, testCleanupGrace)


### PR DESCRIPTION
**What is this feature?**

The `index snapshot candidate`, `selected index snapshot`, and `no index snapshot candidates` debug logs in `pickBestSnapshot` were emitted through the unscoped `b.log`, so they lacked the `namespace`, `group`, and `resource` fields that every surrounding bleve-backend log line carries. This change passes the caller's scoped logger into `pickBestSnapshot` so all three lines now include the same per-resource context.

**Why do we need this feature?**

During init many indexes load concurrently and the unscoped lines can't be attributed to a specific resource, making it hard to tell which snapshot decision was made for which index.

**Who is this feature for?**

Operators and developers debugging unified-storage bleve snapshot selection.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Pure logging change — no behavior change. Tests in `bleve_snapshot_test.go` and `remote_index_cleanup_test.go` were updated for the new `pickBestSnapshot` signature.