### PR TITLE
Live: Don't fail subscriptions when ID token refresh succeeds

### DIFF
--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -585,6 +585,15 @@ func checkAllowedOrigin(origin string, originURL *url.URL, appURL *url.URL, orig
 
 var clientConcurrency = 12
 
+// errorExpiredTemporary mirrors centrifuge.ErrorExpired but sets Temporary so
+// clients retry the operation with backoff after a server-side token refresh,
+// instead of treating the error as fatal and tearing down the subscription.
+var errorExpiredTemporary = &centrifuge.Error{
+	Code:      centrifuge.ErrorExpired.Code,
+	Message:   centrifuge.ErrorExpired.Message,
+	Temporary: true,
+}
+
 func (g *GrafanaLive) IsHA() bool {
 	return g.Cfg != nil && g.Cfg.LiveHAEngine != ""
 }
@@ -616,9 +625,10 @@ func (g *GrafanaLive) checkIDTokenExpirationAndRefresh(user identity.Requester, 
 	err := g.node.Refresh(client.UserID(), centrifuge.WithRefreshExpired(true))
 	if err != nil {
 		logger.Error("Failed to refresh expired ID token", "user", client.UserID(), "client", client.ID(), "error", err)
+		return true
 	}
 
-	return true
+	return false
 }
 
 func (g *GrafanaLive) HandleDatasourceDelete(orgID int64, dsUID string) {
@@ -654,7 +664,7 @@ func (g *GrafanaLive) handleOnRPC(clientContextWithSpan context.Context, client 
 
 	// Check if ID token is expired and trigger refresh if needed
 	if expired := g.checkIDTokenExpirationAndRefresh(user, client); expired {
-		return centrifuge.RPCReply{}, centrifuge.ErrorExpired
+		return centrifuge.RPCReply{}, errorExpiredTemporary
 	}
 
 	// RPC events not available
@@ -672,7 +682,7 @@ func (g *GrafanaLive) handleOnSubscribe(clientContextWithSpan context.Context, c
 
 	// Check if ID token is expired and trigger refresh if needed
 	if expired := g.checkIDTokenExpirationAndRefresh(user, client); expired {
-		return centrifuge.SubscribeReply{}, centrifuge.ErrorExpired
+		return centrifuge.SubscribeReply{}, errorExpiredTemporary
 	}
 
 	// See a detailed comment for StripK8sNamespace about orgID management in Live.
@@ -782,7 +792,7 @@ func (g *GrafanaLive) handleOnPublish(clientCtxWithSpan context.Context, client 
 
 	// Check if ID token is expired and trigger refresh if needed
 	if expired := g.checkIDTokenExpirationAndRefresh(user, client); expired {
-		return centrifuge.PublishReply{}, centrifuge.ErrorExpired
+		return centrifuge.PublishReply{}, errorExpiredTemporary
 	}
 
 	// See a detailed comment for StripK8sNamespace about orgID management in Live.

--- a/pkg/services/live/live_test.go
+++ b/pkg/services/live/live_test.go
@@ -239,6 +239,10 @@ func Test_handleOnPublish_IDTokenExpiration(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("expired token", func(t *testing.T) {
+		// When the token is expired we trigger a refresh. If the refresh
+		// trigger succeeds we let the op proceed instead of failing with
+		// ErrorExpired (which centrifuge-js treats as fatal and would tear
+		// down the subscription with no retry).
 		expiration := time.Now().Add(-time.Hour)
 		token := createToken(t, &expiration)
 		ctx := identity.WithRequester(context.Background(), &identity.StaticRequester{IDToken: token})
@@ -246,7 +250,8 @@ func Test_handleOnPublish_IDTokenExpiration(t *testing.T) {
 			Channel: "test",
 			Data:    []byte("test"),
 		})
-		require.ErrorIs(t, err, centrifuge.ErrorExpired)
+		require.NotErrorIs(t, err, centrifuge.ErrorExpired)
+		require.NotErrorIs(t, err, errorExpiredTemporary)
 		require.Empty(t, reply)
 	})
 
@@ -274,6 +279,9 @@ func Test_handleOnRPC_IDTokenExpiration(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("expired token", func(t *testing.T) {
+		// See the matching note in Test_handleOnPublish_IDTokenExpiration —
+		// successful refresh trigger should let the op continue rather than
+		// returning ErrorExpired.
 		expiration := time.Now().Add(-time.Hour)
 		token := createToken(t, &expiration)
 		ctx := identity.WithRequester(context.Background(), &identity.StaticRequester{IDToken: token})
@@ -281,7 +289,8 @@ func Test_handleOnRPC_IDTokenExpiration(t *testing.T) {
 			Method: "grafana.query",
 			Data:   []byte("test"),
 		})
-		require.ErrorIs(t, err, centrifuge.ErrorExpired)
+		require.NotErrorIs(t, err, centrifuge.ErrorExpired)
+		require.NotErrorIs(t, err, errorExpiredTemporary)
 		require.Empty(t, reply)
 	})
 
@@ -309,13 +318,15 @@ func Test_handleOnSubscribe_IDTokenExpiration(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("expired token", func(t *testing.T) {
+		// See the matching note in Test_handleOnPublish_IDTokenExpiration.
 		expiration := time.Now().Add(-time.Hour)
 		token := createToken(t, &expiration)
 		ctx := identity.WithRequester(context.Background(), &identity.StaticRequester{IDToken: token})
 		reply, err := g.handleOnSubscribe(ctx, client, centrifuge.SubscribeEvent{
 			Channel: "test",
 		})
-		require.ErrorIs(t, err, centrifuge.ErrorExpired)
+		require.NotErrorIs(t, err, centrifuge.ErrorExpired)
+		require.NotErrorIs(t, err, errorExpiredTemporary)
 		require.Empty(t, reply)
 	})
 


### PR DESCRIPTION
**What is this feature?**

Two related fixes to Grafana Live's ID token expiration handling:

1. `checkIDTokenExpirationAndRefresh` no longer returns `true` (which makes callers fail with `ErrorExpired`) when the refresh trigger succeeds — only on refresh failure. Successful refresh lets the current op proceed.
2. The error returned to centrifuge clients on refresh failure now carries `Temporary: true`, so centrifuge-js retries the subscription with backoff instead of permanently tearing it down.

**Why do we need this feature?**

After ~10 min (ID token TTL), any WS subscribe/RPC/publish would return `centrifuge.ErrorExpired` (code 110). centrifuge-js treats code 110 with `Temporary: false` as fatal → permanent unsubscribe, no retry. Symptom: Application Observability Traces tab silently shows no data after long sessions; users have to clear cache.

Reported in support escalation grafana/support-escalations#22029

**Who is this feature for?**

All Grafana Cloud users with long-lived browser sessions, particularly App Observability / Tempo streaming users.

**Special notes for your reviewer:**

- Frontend resilience fix for Tempo streaming (`streaming.ts` swallowing channel-level error events) is being handled in a separate PR per the frontend/backend split convention.
- Existing tests in `live_test.go` for the expired-token path were updated to reflect the new semantics: when the refresh trigger succeeds the op continues rather than returning `ErrorExpired`.

_PR description generated by Claude Code._