### PR TITLE
Dashboard Import: Set default permissions when importing v2 dashboards

### DIFF
--- a/public/app/features/dashboard/api/v2.test.ts
+++ b/public/app/features/dashboard/api/v2.test.ts
@@ -322,13 +322,10 @@ describe('v2 dashboard API', () => {
 
     it.each([
       ['update path (metadata.name set)', { name: 'imported-dash' }, mockPut],
-      ['create path (metadata.name unset)', undefined, mockPost],
-    ])('should set grant-permissions annotation on the %s', async (_name, k8sName, requestMock) => {
+      ['create path (metadata.name unset)', {}, mockPost],
+    ])('should set grant-permissions annotation on the %s', async (_name, k8s, requestMock) => {
       const api = new K8sDashboardV2API();
-      await api.saveDashboard({
-        dashboard: defaultDashboardV2Spec(),
-        ...(k8sName ? { k8s: k8sName } : {}),
-      });
+      await api.saveDashboard({ dashboard: defaultDashboardV2Spec(), k8s });
 
       expect(requestMock).toHaveBeenCalledTimes(1);
       const requestBody = requestMock.mock.calls[0][1];

--- a/public/app/features/dashboard/api/v2.test.ts
+++ b/public/app/features/dashboard/api/v2.test.ts
@@ -246,6 +246,7 @@ describe('v2 dashboard API', () => {
             name: 'existing-dash',
             annotations: {
               [AnnoKeyFolder]: 'folderUidXyz',
+              [AnnoKeyGrantPermissions]: 'default',
               [AnnoKeySavedFromUI]: '10.0.0',
             },
           },
@@ -284,6 +285,7 @@ describe('v2 dashboard API', () => {
             name: 'existing-dash',
             annotations: {
               [AnnoKeyFolder]: '',
+              [AnnoKeyGrantPermissions]: 'default',
               [AnnoKeyMessage]: 'Move to root folder',
               [AnnoKeySavedFromUI]: '10.0.0',
             },
@@ -316,6 +318,23 @@ describe('v2 dashboard API', () => {
       const requestBody = callArgs[1];
       expect(requestBody.metadata.annotations).not.toHaveProperty(AnnoKeyFolder);
       expect(requestBody.metadata.annotations[AnnoKeyMessage]).toBe('Save without folder');
+    });
+
+    it.each([
+      ['update path (metadata.name set)', { name: 'imported-dash' }, mockPut],
+      ['create path (metadata.name unset)', undefined, mockPost],
+    ])('should set grant-permissions annotation on the %s', async (_name, k8sName, requestMock) => {
+      const api = new K8sDashboardV2API();
+      await api.saveDashboard({
+        dashboard: defaultDashboardV2Spec(),
+        ...(k8sName ? { k8s: k8sName } : {}),
+      });
+
+      expect(requestMock).toHaveBeenCalledTimes(1);
+      const requestBody = requestMock.mock.calls[0][1];
+      expect(requestBody.metadata.annotations).toEqual(
+        expect.objectContaining({ [AnnoKeyGrantPermissions]: 'default' })
+      );
     });
   });
 

--- a/public/app/features/dashboard/api/v2.ts
+++ b/public/app/features/dashboard/api/v2.ts
@@ -147,16 +147,18 @@ export class K8sDashboardV2API
       };
     }
 
+    obj.metadata.annotations = {
+      ...obj.metadata.annotations,
+      [AnnoKeyGrantPermissions]: 'default',
+    };
+
     if (obj.metadata.name) {
       // remove resource version when updating
       delete obj.metadata.resourceVersion;
       delete obj.metadata.labels?.[DeprecatedInternalId];
       return this.client.update(obj).then((v) => this.asSaveDashboardResponseDTO(v));
     }
-    obj.metadata.annotations = {
-      ...obj.metadata.annotations,
-      [AnnoKeyGrantPermissions]: 'default',
-    };
+
     // clear the deprecated id label so the backend generates a new unique id to prevent duplicate ids.
     delete obj.metadata.labels?.[DeprecatedInternalId];
     return await this.client.create(obj).then((v) => this.asSaveDashboardResponseDTO(v));


### PR DESCRIPTION
**What is this feature?**

Fixes a permissions issue when importing a v2 dashboard from another Grafana instance. Imported dashboards now get the default role-based permissions, so Editors and Viewers can access them straight away, just like dashboards created from scratch.

Covers same issue as https://github.com/grafana/grafana/pull/121721 but for v2