### PR TITLE
Timeseries: Skip flaky timeseries tooltip E2E test temporarily

### DIFF
--- a/e2e-playwright/panels-suite/timeseries.spec.ts
+++ b/e2e-playwright/panels-suite/timeseries.spec.ts
@@ -16,7 +16,8 @@ test.describe('Panels test: TimeSeries', { tag: ['@panels', '@timeseries'] }, ()
     await expect(errorInfo, 'no errors in the panels').toBeHidden();
   });
 
-  test('tooltip interactions', async ({ gotoDashboardPage, page, selectors }) => {
+  // TODO: https://github.com/grafana/grafana/issues/124170
+  test.skip('tooltip interactions', async ({ gotoDashboardPage, page, selectors }) => {
     const dashboardPage = await gotoDashboardPage({
       uid: DASHBOARD_UID,
       queryParams: new URLSearchParams({ editPanel: '19' }),


### PR DESCRIPTION
🎟️ ⏭️ 🚢 Temporarily skipping a flaky E2E based on `Random walk` test data.

We will endeavour to _fix_ this when time permits, in: https://github.com/grafana/grafana/issues/124170