### PR TITLE
TestDataSource: Seeded random walk scenario

### DIFF
--- a/pkg/tsdb/grafana-testdata-datasource/kinds/query.go
+++ b/pkg/tsdb/grafana-testdata-datasource/kinds/query.go
@@ -69,6 +69,7 @@ const (
 	TestDataQueryTypePredictablePulse             TestDataQueryType = "predictable_pulse"
 	TestDataQueryTypeQueryMeta                    TestDataQueryType = "query_meta"
 	TestDataQueryTypeRandomWalk                   TestDataQueryType = "random_walk"
+	TestDataQueryTypeSeededRandomWalk             TestDataQueryType = "seeded_random_walk"
 	TestDataQueryTypeRandomWalkTable              TestDataQueryType = "random_walk_table"
 	TestDataQueryTypeRandomWalkWithError          TestDataQueryType = "random_walk_with_error"
 	TestDataQueryTypeRawFrame                     TestDataQueryType = "raw_frame"

--- a/pkg/tsdb/grafana-testdata-datasource/scenarios.go
+++ b/pkg/tsdb/grafana-testdata-datasource/scenarios.go
@@ -52,6 +52,12 @@ func (s *Service) registerScenarios() {
 	})
 
 	s.registerScenario(&Scenario{
+		ID:      kinds.TestDataQueryTypeSeededRandomWalk,
+		Name:    "Seeded Random Walk",
+		handler: s.handleSeededRandomWalkScenario,
+	})
+
+	s.registerScenario(&Scenario{
 		ID:      kinds.TestDataQueryTypePredictablePulse,
 		Name:    "Predictable Pulse",
 		handler: s.handlePredictablePulseScenario,
@@ -315,7 +321,27 @@ func (s *Service) handleRandomWalkScenario(ctx context.Context, req *backend.Que
 
 		for i := 0; i < seriesCount; i++ {
 			respD := resp.Responses[q.RefID]
-			respD.Frames = append(respD.Frames, RandomWalk(q, model, i))
+			respD.Frames = append(respD.Frames, RandomWalk(q, model, i, time.Now().UnixNano()))
+			resp.Responses[q.RefID] = respD
+		}
+	}
+
+	return resp, nil
+}
+
+func (s *Service) handleSeededRandomWalkScenario(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+	resp := backend.NewQueryDataResponse()
+
+	for _, q := range req.Queries {
+		model, err := GetJSONModel(q.JSON)
+		if err != nil {
+			continue
+		}
+		seriesCount := model.SeriesCount
+
+		for i := 0; i < seriesCount; i++ {
+			respD := resp.Responses[q.RefID]
+			respD.Frames = append(respD.Frames, RandomWalk(q, model, i, q.TimeRange.From.UnixNano()+q.TimeRange.To.UnixNano()))
 			resp.Responses[q.RefID] = respD
 		}
 	}
@@ -432,7 +458,7 @@ func (s *Service) handleRandomWalkWithErrorScenario(ctx context.Context, req *ba
 		}
 
 		respD := resp.Responses[q.RefID]
-		respD.Frames = append(respD.Frames, RandomWalk(q, model, 0))
+		respD.Frames = append(respD.Frames, RandomWalk(q, model, 0, time.Now().UnixNano()))
 		respD.Error = fmt.Errorf("this is an error and it can include URLs http://grafana.com/")
 		resp.Responses[q.RefID] = respD
 	}
@@ -454,7 +480,7 @@ func (s *Service) handleRandomWalkSlowScenario(ctx context.Context, req *backend
 		time.Sleep(parsedInterval)
 
 		respD := resp.Responses[q.RefID]
-		respD.Frames = append(respD.Frames, RandomWalk(q, model, 0))
+		respD.Frames = append(respD.Frames, RandomWalk(q, model, 0, time.Now().UnixNano()))
 		resp.Responses[q.RefID] = respD
 	}
 
@@ -853,8 +879,8 @@ func (s *Service) handleErrorWithSourceScenario(ctx context.Context, req *backen
 	return resp, nil
 }
 
-func RandomWalk(query backend.DataQuery, model kinds.TestDataQuery, index int) *data.Frame {
-	rand := rand.New(rand.NewSource(time.Now().UnixNano() + int64(index)))
+func RandomWalk(query backend.DataQuery, model kinds.TestDataQuery, index int, seed int64) *data.Frame {
+	rand := rand.New(rand.NewSource(seed + int64(index)))
 	timeWalkerMs := query.TimeRange.From.UnixNano() / int64(time.Millisecond)
 	to := query.TimeRange.To.UnixNano() / int64(time.Millisecond)
 	startValue := model.StartValue

--- a/pkg/tsdb/grafana-testdata-datasource/scenarios_test.go
+++ b/pkg/tsdb/grafana-testdata-datasource/scenarios_test.go
@@ -58,6 +58,46 @@ func TestTestdataScenarios(t *testing.T) {
 		})
 	})
 
+	t.Run("seeded random walk ", func(t *testing.T) {
+		t.Run("Should start at the requested value", func(t *testing.T) {
+			from := time.Now()
+			to := from.Add(5 * time.Minute)
+
+			query := backend.DataQuery{
+				RefID: "A",
+				TimeRange: backend.TimeRange{
+					From: from,
+					To:   to,
+				},
+				Interval:      100 * time.Millisecond,
+				MaxDataPoints: 100,
+				JSON:          []byte(`{"startValue": 1.234}`),
+			}
+
+			req := &backend.QueryDataRequest{
+				PluginContext: backend.PluginContext{},
+				Queries:       []backend.DataQuery{query},
+			}
+
+			resp, err := s.handleSeededRandomWalkScenario(context.Background(), req)
+			require.NoError(t, err)
+			require.NotNil(t, resp)
+
+			dResp, exists := resp.Responses[query.RefID]
+			require.True(t, exists)
+			require.NoError(t, dResp.Error)
+
+			require.Len(t, dResp.Frames, 1)
+			frame := dResp.Frames[0]
+			require.Len(t, frame.Fields, 2)
+			require.Equal(t, "time", frame.Fields[0].Name)
+			require.Equal(t, "A-series", frame.Fields[1].Name)
+			val, ok := frame.Fields[1].ConcreteAt(0)
+			require.True(t, ok)
+			require.Equal(t, 1.234, val)
+		})
+	})
+
 	t.Run("random walk table", func(t *testing.T) {
 		t.Run("Should return a table that looks like value/min/max", func(t *testing.T) {
 			from := time.Now()

--- a/pkg/tsdb/grafanads/grafana.go
+++ b/pkg/tsdb/grafanads/grafana.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"path/filepath"
+	"time"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
@@ -158,7 +159,7 @@ func (s *Service) doRandomWalk(query backend.DataQuery) backend.DataResponse {
 		response.Error = err
 		return response
 	}
-	response.Frames = data.Frames{testdatasource.RandomWalk(query, model, 0)}
+	response.Frames = data.Frames{testdatasource.RandomWalk(query, model, 0, time.Now().UnixNano())}
 
 	return response
 }

--- a/public/app/plugins/datasource/grafana-testdata-datasource/QueryEditor.tsx
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/QueryEditor.tsx
@@ -283,6 +283,9 @@ export const QueryEditor = ({ query, datasource, onChange, onRunQuery }: Props) 
       {scenarioId === TestDataQueryType.RandomWalk && (
         <RandomWalkEditor onChange={onInputChange} query={query} ds={datasource} />
       )}
+      {scenarioId === TestDataQueryType.SeededRandomWalk && (
+        <RandomWalkEditor onChange={onInputChange} query={query} ds={datasource} />
+      )}
       {scenarioId === TestDataQueryType.StreamingClient && (
         <StreamingClientEditor onChange={onStreamClientChange} query={query} ds={datasource} />
       )}

--- a/public/app/plugins/datasource/grafana-testdata-datasource/dataquery.ts
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/dataquery.ts
@@ -23,6 +23,7 @@ export enum TestDataQueryType {
   PredictablePulse = 'predictable_pulse',
   QueryMeta = 'query_meta',
   RandomWalk = 'random_walk',
+  SeededRandomWalk = 'seeded_random_walk',
   RandomWalkTable = 'random_walk_table',
   RandomWalkWithError = 'random_walk_with_error',
   RawFrame = 'raw_frame',

--- a/public/app/plugins/datasource/grafana-testdata-datasource/schema/v0alpha1.json
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/schema/v0alpha1.json
@@ -188,7 +188,7 @@
       {
         "metadata": {
           "name": "default",
-          "resourceVersion": "1776878010416",
+          "resourceVersion": "1778009554524",
           "creationTimestamp": "2026-04-22T17:13:30Z"
         },
         "spec": {
@@ -266,7 +266,7 @@
               },
               "rawFrameContent": { "type": "string" },
               "scenarioId": {
-                "description": "Possible enum values:\n - `\"annotations\"` \n - `\"arrow\"` \n - `\"csv_content\"` \n - `\"csv_file\"` \n - `\"csv_metric_values\"` \n - `\"datapoints_outside_range\"` \n - `\"error_with_source\"` \n - `\"exponential_heatmap_bucket_data\"` \n - `\"flame_graph\"` \n - `\"grafana_api\"` \n - `\"linear_heatmap_bucket_data\"` \n - `\"live\"` \n - `\"logs\"` \n - `\"manual_entry\"` \n - `\"no_data_points\"` \n - `\"node_graph\"` \n - `\"predictable_csv_wave\"` \n - `\"predictable_pulse\"` \n - `\"query_meta\"` \n - `\"random_walk\"` \n - `\"random_walk_table\"` \n - `\"random_walk_with_error\"` \n - `\"raw_frame\"` \n - `\"server_error_500\"` \n - `\"steps\"` \n - `\"simulation\"` \n - `\"slow_query\"` \n - `\"streaming_client\"` \n - `\"table_static\"` \n - `\"trace\"` \n - `\"usa\"` \n - `\"variables-query\"` ",
+                "description": "Possible enum values:\n - `\"annotations\"` \n - `\"arrow\"` \n - `\"csv_content\"` \n - `\"csv_file\"` \n - `\"csv_metric_values\"` \n - `\"datapoints_outside_range\"` \n - `\"error_with_source\"` \n - `\"exponential_heatmap_bucket_data\"` \n - `\"flame_graph\"` \n - `\"grafana_api\"` \n - `\"linear_heatmap_bucket_data\"` \n - `\"live\"` \n - `\"logs\"` \n - `\"manual_entry\"` \n - `\"no_data_points\"` \n - `\"node_graph\"` \n - `\"predictable_csv_wave\"` \n - `\"predictable_pulse\"` \n - `\"query_meta\"` \n - `\"random_walk\"` \n - `\"seeded_random_walk\"` \n - `\"random_walk_table\"` \n - `\"random_walk_with_error\"` \n - `\"raw_frame\"` \n - `\"server_error_500\"` \n - `\"steps\"` \n - `\"simulation\"` \n - `\"slow_query\"` \n - `\"streaming_client\"` \n - `\"table_static\"` \n - `\"trace\"` \n - `\"usa\"` \n - `\"variables-query\"` ",
                 "enum": [
                   "annotations",
                   "arrow",
@@ -288,6 +288,7 @@
                   "predictable_pulse",
                   "query_meta",
                   "random_walk",
+                  "seeded_random_walk",
                   "random_walk_table",
                   "random_walk_with_error",
                   "raw_frame",

--- a/public/app/plugins/datasource/grafana-testdata-datasource/schema/v0alpha1/query.types.json
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/schema/v0alpha1/query.types.json
@@ -8,7 +8,7 @@
     {
       "metadata": {
         "name": "default",
-        "resourceVersion": "1776878010416",
+        "resourceVersion": "1778009554524",
         "creationTimestamp": "2026-04-22T17:13:30Z"
       },
       "spec": {
@@ -138,7 +138,7 @@
               "type": "string"
             },
             "scenarioId": {
-              "description": "Possible enum values:\n - `\"annotations\"` \n - `\"arrow\"` \n - `\"csv_content\"` \n - `\"csv_file\"` \n - `\"csv_metric_values\"` \n - `\"datapoints_outside_range\"` \n - `\"error_with_source\"` \n - `\"exponential_heatmap_bucket_data\"` \n - `\"flame_graph\"` \n - `\"grafana_api\"` \n - `\"linear_heatmap_bucket_data\"` \n - `\"live\"` \n - `\"logs\"` \n - `\"manual_entry\"` \n - `\"no_data_points\"` \n - `\"node_graph\"` \n - `\"predictable_csv_wave\"` \n - `\"predictable_pulse\"` \n - `\"query_meta\"` \n - `\"random_walk\"` \n - `\"random_walk_table\"` \n - `\"random_walk_with_error\"` \n - `\"raw_frame\"` \n - `\"server_error_500\"` \n - `\"steps\"` \n - `\"simulation\"` \n - `\"slow_query\"` \n - `\"streaming_client\"` \n - `\"table_static\"` \n - `\"trace\"` \n - `\"usa\"` \n - `\"variables-query\"` ",
+              "description": "Possible enum values:\n - `\"annotations\"` \n - `\"arrow\"` \n - `\"csv_content\"` \n - `\"csv_file\"` \n - `\"csv_metric_values\"` \n - `\"datapoints_outside_range\"` \n - `\"error_with_source\"` \n - `\"exponential_heatmap_bucket_data\"` \n - `\"flame_graph\"` \n - `\"grafana_api\"` \n - `\"linear_heatmap_bucket_data\"` \n - `\"live\"` \n - `\"logs\"` \n - `\"manual_entry\"` \n - `\"no_data_points\"` \n - `\"node_graph\"` \n - `\"predictable_csv_wave\"` \n - `\"predictable_pulse\"` \n - `\"query_meta\"` \n - `\"random_walk\"` \n - `\"seeded_random_walk\"` \n - `\"random_walk_table\"` \n - `\"random_walk_with_error\"` \n - `\"raw_frame\"` \n - `\"server_error_500\"` \n - `\"steps\"` \n - `\"simulation\"` \n - `\"slow_query\"` \n - `\"streaming_client\"` \n - `\"table_static\"` \n - `\"trace\"` \n - `\"usa\"` \n - `\"variables-query\"` ",
               "enum": [
                 "annotations",
                 "arrow",
@@ -160,6 +160,7 @@
                 "predictable_pulse",
                 "query_meta",
                 "random_walk",
+                "seeded_random_walk",
                 "random_walk_table",
                 "random_walk_with_error",
                 "raw_frame",


### PR DESCRIPTION
**What is this feature?**

Adding time-range seeded random walk scenario.

**Why do we need this feature?**
Random walk gets used a lot in e2e tests, but random values in e2e tests are bad. Seeded random allows consistent UI behavior for static time ranges, but still allows testing scenarios where changing time ranges triggers a change in series values.

**Who is this feature for?**
Users of test data source & Grafana developers.

**Special notes for your reviewer:**
Part of epic: https://github.com/grafana/grafana/issues/123154
The start value is randomized separately, and it wasn't worth blowing up the scope on the frontend changes to add a default value for this scenario, so for now users need to set the start value and an absolute time range. We can follow up later if needed.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
