### PR TITLE
Annotations: Clustering GA

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -36,6 +36,7 @@ Most [generally available](https://grafana.com/docs/release-life-cycle/#general-
 | `dashgpt`                                    | Enable AI powered features in dashboards                                                                                                                      | Yes                |
 | `cloudWatchBatchQueries`                     | Runs CloudWatch metrics queries as separate batches                                                                                                           |                    |
 | `annotationPermissionUpdate`                 | Change the way annotation permissions work by scoping them to folders and dashboards.                                                                         | Yes                |
+| `annotationsClustering`                      | Enables annotation clustering and switches to refactored annotation code                                                                                      | Yes                |
 | `dashboardNewLayouts`                        | Enables new dashboard layouts                                                                                                                                 | Yes                |
 | `dashboardDefaultLayoutSelector`             | Enables default layout selector in dashboard settings                                                                                                         | Yes                |
 | `sceneCsvExport`                             | Enables CSV export using scenes dashboard architecture                                                                                                        | Yes                |
@@ -87,7 +88,6 @@ Most [generally available](https://grafana.com/docs/release-life-cycle/#general-
 | `refactorVariablesTimeRange`      | Refactor time range variables flow to reduce number of API calls made when query variables are chained |
 | `faroDatasourceSelector`          | Enable the data source selector within the Frontend Apps section of the Frontend Observability         |
 | `externalServiceAccounts`         | Automatic service account and token setup for plugins                                                  |
-| `annotationsClustering`           | Enables annotation clustering and switches to refactored annotation code                               |
 | `dashboardFiltersOverview`        | Enables the dashboard filters overview pane                                                            |
 | `feedbackButton`                  | Enables the feedback button in the dashboard edit sidebar                                              |
 | `pdfTables`                       | Enables generating table data as PDF in reporting                                                      |

--- a/docs/sources/shared/visualizations/annotations/options.md
+++ b/docs/sources/shared/visualizations/annotations/options.md
@@ -4,8 +4,8 @@ comments: |
   This file is used in the following visualizations: heatmap, candlestick, state timeline, status history, time series
 ---
 
-| Option                | Description                                                                                                                                                                                              |
-| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Multi-row annotations | Breaks each annotation data frame into a separate row in the visualization. Only visible in panels that display more than one annotation.                                                                |
-| Annotation clustering | Joins adjacent point annotations into a single annotation region. In [public preview](https://grafana.com/docs/release-life-cycle). Requires `annotationsClustering` feature flag.                       |
-| Hide lines and areas  | Controls display of annotation indicator lines, and shaded area for region annotations. In [public preview](https://grafana.com/docs/release-life-cycle). Requires `annotationsClustering` feature flag. |
+| Option                | Description                                                                                                                               |
+| --------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| Multi-row annotations | Breaks each annotation data frame into a separate row in the visualization. Only visible in panels that display more than one annotation. |
+| Annotation clustering | Joins adjacent point annotations into a single annotation region.                                                                         |
+| Hide lines and areas  | Controls display of annotation indicator lines, and shaded area for region annotations.                                                   |

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -355,7 +355,7 @@ export interface FeatureToggles {
   annotationPermissionUpdate?: boolean;
   /**
   * Enables annotation clustering and switches to refactored annotation code
-  * @default false
+  * @default true
   */
   annotationsClustering?: boolean;
   /**

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -623,10 +623,10 @@ var (
 		{
 			Name:        "annotationsClustering",
 			Description: "Enables annotation clustering and switches to refactored annotation code",
-			Stage:       FeatureStagePublicPreview,
+			Stage:       FeatureStageGeneralAvailability,
 			Generate:    Generate{LegacyFrontend: true},
 			Owner:       grafanaDatavizSquad,
-			Expression:  "false",
+			Expression:  "true",
 		},
 		{
 			Name:        "dashboardNewLayouts",

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -70,7 +70,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-03-16,createAlertRuleFromPanel,experimental,@grafana/alerting-squad,false,false,true
 2023-10-30,alertmanagerRemotePrimary,experimental,@grafana/alerting-squad,false,false,false
 2023-10-31,annotationPermissionUpdate,GA,@grafana/identity-access-team,false,false,false
-2026-03-12,annotationsClustering,preview,@grafana/dataviz-squad,false,false,true
+2026-03-12,annotationsClustering,GA,@grafana/dataviz-squad,false,false,true
 2024-10-23,dashboardNewLayouts,GA,@grafana/dashboards-squad,false,false,false
 2026-03-19,dashboardDefaultLayoutSelector,GA,@grafana/dashboards-squad,false,false,true
 2026-03-10,dashboardAssistantPopover,experimental,@grafana/dashboards-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -985,18 +985,18 @@
     {
       "metadata": {
         "name": "annotationsClustering",
-        "resourceVersion": "1775140656883",
+        "resourceVersion": "1778010740790",
         "creationTimestamp": "2026-03-12T21:45:54Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2026-04-02 14:37:36.883749 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2026-05-05 19:52:20.790026 +0000 UTC"
         }
       },
       "spec": {
         "description": "Enables annotation clustering and switches to refactored annotation code",
-        "stage": "preview",
+        "stage": "GA",
         "codeowner": "@grafana/dataviz-squad",
         "frontend": true,
-        "expression": "false"
+        "expression": "true"
       }
     },
     {


### PR DESCRIPTION
**What is this feature?**

Enabling annotationsClustering by default

**Special notes for your reviewer:**
We already have e2e, unit, and integration tests for annotations, and regression coverage for all bugs we've discovered so far while in experimental/public preview, so I think this meets the criteria to go GA in 13.1


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
