### PR TITLE
unified-storage: fix goleak ignored functions

### DIFF
--- a/pkg/storage/unified/resource/eventstore_test.go
+++ b/pkg/storage/unified/resource/eventstore_test.go
@@ -28,7 +28,7 @@ func TestMain(m *testing.M) {
 			db.CleanupTestDB()
 			os.Exit(exitCode)
 		}),
-		goleak.IgnoreTopFunction("github.com/open-feature/go-sdk/openfeature.(*eventExecutor).startEventListener.func1.1"),
+		goleak.IgnoreTopFunction("github.com/open-feature/go-sdk/openfeature.newEventExecutor.(*eventExecutor).startEventListener.func1.1"),
 		goleak.IgnoreTopFunction("github.com/patrickmn/go-cache.(*janitor).Run"),                          // go-cache janitor stops via GC finalizer, not an explicit close.
 		goleak.IgnoreTopFunction("go.opentelemetry.io/otel/sdk/trace.(*batchSpanProcessor).processQueue"), // OTel span processor from test infra.
 		goleak.IgnoreTopFunction("database/sql.(*DB).connectionOpener"),                                   // database/sql background goroutines from test DB setup.

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -39,7 +39,7 @@ import (
 // (Except for goroutines running specific functions. If possible we should fix this, esp. our own updateIndexSizeMetric.)
 func TestMain(m *testing.M) {
 	goleak.VerifyTestMain(m,
-		goleak.IgnoreTopFunction("github.com/open-feature/go-sdk/openfeature.(*eventExecutor).startEventListener.func1.1"),
+		goleak.IgnoreTopFunction("github.com/open-feature/go-sdk/openfeature.newEventExecutor.(*eventExecutor).startEventListener.func1.1"),
 		goleak.IgnoreTopFunction("github.com/blevesearch/bleve_index_api.AnalysisWorker"), // These don't stop when index is closed.
 		goleak.IgnoreAnyFunction("net/http.(*http2clientConnReadLoop).run"),               // HTTP/2 keep-alive from cloud provider SDKs in integration tests.
 	)


### PR DESCRIPTION
The toplevel `open-feature` function signature was incorrect, leading to failures especially when tests run with race detection enabled:

```
❯ go test -count=1 -race ./pkg/storage/unified/resource/
# ...
PASS
goleak: Errors on successful test run: found unexpected goroutines:
[Goroutine 34 in state chan receive, 1 minutes, with github.com/open-feature/go-sdk/openfeature.newEventExecutor.(*eventExecutor).startEventListener.func1.1 on top of the stack:
github.com/open-feature/go-sdk/openfeature.newEventExecutor.(*eventExecutor).startEventListener.func1.1()
        ~/pkg/mod/github.com/open-feature/go-sdk@v1.17.1/openfeature/event_executor.go:278 +0x108
created by github.com/open-feature/go-sdk/openfeature.newEventExecutor.(*eventExecutor).startEventListener.func1 in goroutine 1
        ~/pkg/mod/github.com/open-feature/go-sdk@v1.17.1/openfeature/event_executor.go:277 +0x88
]
FAIL    github.com/grafana/grafana/pkg/storage/unified/resource 71.144s
FAIL
```