### PR TITLE
Alerting: fork merge logic into a Grafana-local package

### DIFF
--- a/pkg/services/ngalert/api/api_convert_prometheus.go
+++ b/pkg/services/ngalert/api/api_convert_prometheus.go
@@ -16,7 +16,6 @@ import (
 	prommodel "github.com/prometheus/common/model"
 	"go.yaml.in/yaml/v3"
 
-	"github.com/grafana/alerting/definition"
 	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/grafana/grafana/pkg/api/response"
@@ -32,6 +31,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/api/validation"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier"
+	"github.com/grafana/grafana/pkg/services/ngalert/notifier/merge"
 	"github.com/grafana/grafana/pkg/services/ngalert/prom"
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrations/ualert"
@@ -147,7 +147,7 @@ type ConvertPrometheusSrv struct {
 
 type Alertmanager interface {
 	DeleteExtraConfiguration(ctx context.Context, org int64, user identity.Requester, authz notifier.ExtraConfigAuthz, identifier string) error
-	SaveAndApplyExtraConfiguration(ctx context.Context, org int64, user identity.Requester, authz notifier.ExtraConfigAuthz, extraConfig apimodels.ExtraConfiguration, replace bool, dryRun bool) (definition.RenameResources, error)
+	SaveAndApplyExtraConfiguration(ctx context.Context, org int64, user identity.Requester, authz notifier.ExtraConfigAuthz, extraConfig apimodels.ExtraConfiguration, replace bool, dryRun bool) (merge.RenameResources, error)
 	GetAlertmanagerConfiguration(ctx context.Context, org int64, withAutogen bool, withMergedExtraConfig bool) (apimodels.GettableUserConfig, error)
 }
 
@@ -646,7 +646,7 @@ func (srv *ConvertPrometheusSrv) RouteConvertPrometheusPostAlertmanagerConfig(c 
 		return errorToResponse(fmt.Errorf("failed to save alertmanager configuration: %w", err))
 	}
 
-	// Convert definition.RenameResources to API RenameResources type
+	// Convert merge.RenameResources to API RenameResources type
 	var apiRenamed *apimodels.RenameResources
 	if len(renamed.Receivers) > 0 || len(renamed.TimeIntervals) > 0 {
 		apiRenamed = &apimodels.RenameResources{

--- a/pkg/services/ngalert/api/api_convert_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_convert_prometheus_test.go
@@ -16,8 +16,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v3"
 
-	"github.com/grafana/alerting/definition"
-
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/log"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
@@ -30,6 +28,7 @@ import (
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier"
+	"github.com/grafana/grafana/pkg/services/ngalert/notifier/merge"
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/services/ngalert/tests/fakes"
@@ -1965,9 +1964,9 @@ type mockAlertmanager struct {
 	mock.Mock
 }
 
-func (m *mockAlertmanager) SaveAndApplyExtraConfiguration(ctx context.Context, org int64, user identity.Requester, authz notifier.ExtraConfigAuthz, extraConfig apimodels.ExtraConfiguration, replace bool, dryRun bool) (definition.RenameResources, error) {
+func (m *mockAlertmanager) SaveAndApplyExtraConfiguration(ctx context.Context, org int64, user identity.Requester, authz notifier.ExtraConfigAuthz, extraConfig apimodels.ExtraConfiguration, replace bool, dryRun bool) (merge.RenameResources, error) {
 	args := m.Called(ctx, org, user, authz, extraConfig, replace, dryRun)
-	return args.Get(0).(definition.RenameResources), args.Error(1)
+	return args.Get(0).(merge.RenameResources), args.Error(1)
 }
 
 func (m *mockAlertmanager) GetAlertmanagerConfiguration(ctx context.Context, org int64, withAutogen bool, withMergedExtraConfig bool) (apimodels.GettableUserConfig, error) {
@@ -1993,7 +1992,7 @@ func TestRouteConvertPrometheusPostAlertmanagerConfig(t *testing.T) {
 				len(extraConfig.MergeMatchers) == 2 &&
 				len(extraConfig.TemplateFiles) == 1 &&
 				extraConfig.TemplateFiles["test.tmpl"] == "{{ define \"test\" }}Hello{{ end }}"
-		}), false, false).Return(definition.RenameResources{}, nil).Once()
+		}), false, false).Return(merge.RenameResources{}, nil).Once()
 
 		rc := createRequestCtx()
 		rc.Req.Header.Set(configIdentifierHeader, identifier)
@@ -2027,7 +2026,7 @@ func TestRouteConvertPrometheusPostAlertmanagerConfig(t *testing.T) {
 		mockAM := &mockAlertmanager{}
 		mockAM.On("SaveAndApplyExtraConfiguration", mock.Anything, int64(1), mock.Anything, mock.Anything, mock.MatchedBy(func(extraConfig apimodels.ExtraConfiguration) bool {
 			return extraConfig.Identifier == defaultConfigIdentifier
-		}), false, false).Return(definition.RenameResources{}, nil)
+		}), false, false).Return(merge.RenameResources{}, nil)
 
 		ft := featuremgmt.WithFeatures(featuremgmt.FlagAlertingImportAlertmanagerAPI)
 		srv, _, _ := createConvertPrometheusSrv(t, withAlertmanager(mockAM), withFeatureToggles(ft))
@@ -2056,7 +2055,7 @@ func TestRouteConvertPrometheusPostAlertmanagerConfig(t *testing.T) {
 		mockAM := &mockAlertmanager{}
 		mockAM.On("SaveAndApplyExtraConfiguration", mock.Anything, int64(1), mock.Anything, mock.Anything, mock.MatchedBy(func(extraConfig apimodels.ExtraConfiguration) bool {
 			return extraConfig.Identifier == defaultConfigIdentifier
-		}), true, false).Return(definition.RenameResources{}, nil)
+		}), true, false).Return(merge.RenameResources{}, nil)
 
 		ft := featuremgmt.WithFeatures(featuremgmt.FlagAlertingImportAlertmanagerAPI)
 		srv, _, _ := createConvertPrometheusSrv(t, withAlertmanager(mockAM), withFeatureToggles(ft))
@@ -2085,7 +2084,7 @@ func TestRouteConvertPrometheusPostAlertmanagerConfig(t *testing.T) {
 		mockAM := &mockAlertmanager{}
 		mockAM.On("SaveAndApplyExtraConfiguration", mock.Anything, int64(1), mock.Anything, mock.Anything, mock.MatchedBy(func(extraConfig apimodels.ExtraConfiguration) bool {
 			return extraConfig.Identifier == defaultConfigIdentifier
-		}), false, true).Return(definition.RenameResources{}, nil)
+		}), false, true).Return(merge.RenameResources{}, nil)
 
 		ft := featuremgmt.WithFeatures(featuremgmt.FlagAlertingImportAlertmanagerAPI)
 		srv, _, _ := createConvertPrometheusSrv(t, withAlertmanager(mockAM), withFeatureToggles(ft))
@@ -2113,7 +2112,7 @@ func TestRouteConvertPrometheusPostAlertmanagerConfig(t *testing.T) {
 		rc.Req.Header.Set(configIdentifierHeader, identifier)
 		mockAM := &mockAlertmanager{}
 
-		expectedRenames := definition.RenameResources{
+		expectedRenames := merge.RenameResources{
 			Receivers: map[string]string{
 				"default": "default-test-config",
 			},

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
@@ -18,6 +18,7 @@ import (
 	alertingmodels "github.com/grafana/alerting/models"
 
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
+	"github.com/grafana/grafana/pkg/services/ngalert/notifier/merge"
 )
 
 // swagger:route POST /alertmanager/{DatasourceUID}/config/api/v1/alerts alertmanager RoutePostAlertingConfig
@@ -262,7 +263,7 @@ type (
 )
 
 type MergeResult struct {
-	definition.MergeResult
+	merge.MergeResult
 	Identifier        string
 	ExtraRoute        *Route
 	ExtraInhibitRules []config.InhibitRule
@@ -756,7 +757,7 @@ type PostableUserConfig struct {
 func (c *PostableUserConfig) GetMergedAlertmanagerConfig() (MergeResult, error) {
 	if len(c.ExtraConfigs) == 0 {
 		return MergeResult{
-			MergeResult: definition.MergeResult{
+			MergeResult: merge.MergeResult{
 				Config: c.AlertmanagerConfig,
 			},
 		}, nil
@@ -766,7 +767,7 @@ func (c *PostableUserConfig) GetMergedAlertmanagerConfig() (MergeResult, error) 
 	if err := mimirCfg.Validate(); err != nil {
 		return MergeResult{}, fmt.Errorf("invalid extra configuration: %w", err)
 	}
-	opts := definition.MergeOpts{
+	opts := merge.MergeOpts{
 		DedupSuffix:     mimirCfg.Identifier,
 		SubtreeMatchers: mimirCfg.MergeMatchers,
 	}
@@ -779,13 +780,13 @@ func (c *PostableUserConfig) GetMergedAlertmanagerConfig() (MergeResult, error) 
 		return MergeResult{}, fmt.Errorf("failed to get mimir alertmanager config: %w", err)
 	}
 
-	m, err := definition.Merge(c.AlertmanagerConfig, mcfg, opts)
+	m, err := merge.Merge(c.AlertmanagerConfig, mcfg, opts)
 	if err != nil {
 		return MergeResult{}, fmt.Errorf("failed to merge alertmanager config: %w", err)
 	}
 
 	route := mcfg.Route
-	definition.RenameResourceUsagesInRoutes([]*definition.Route{route}, m.RenameResources)
+	merge.RenameResourceUsagesInRoutes([]*definition.Route{route}, m.RenameResources)
 
 	return MergeResult{
 		MergeResult:       m,

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"strings"
 
 	"github.com/go-openapi/strfmt"
 	"github.com/grafana/alerting/definition/compat"
@@ -261,35 +260,6 @@ type (
 	TimeInterval              = config.TimeInterval
 	InhibitRule               = config.InhibitRule
 )
-
-type MergeResult struct {
-	merge.MergeResult
-	Identifier        string
-	ExtraRoute        *Route
-	ExtraInhibitRules []config.InhibitRule
-}
-
-func (m MergeResult) LogContext() []any {
-	if len(m.Receivers) == 0 && len(m.TimeIntervals) == 0 {
-		return nil
-	}
-	logCtx := make([]any, 0, 4)
-	if len(m.Receivers) > 0 {
-		rcvBuilder := strings.Builder{}
-		for from, to := range m.Receivers {
-			rcvBuilder.WriteString(fmt.Sprintf("'%s'->'%s',", from, to))
-		}
-		logCtx = append(logCtx, "renamedReceivers", fmt.Sprintf("[%s]", rcvBuilder.String()[0:rcvBuilder.Len()-1]))
-	}
-	if len(m.TimeIntervals) > 0 {
-		intervalBuilder := strings.Builder{}
-		for from, to := range m.TimeIntervals {
-			intervalBuilder.WriteString(fmt.Sprintf("'%s'->'%s',", from, to))
-		}
-		logCtx = append(logCtx, "renamedTimeIntervals", fmt.Sprintf("[%s]", intervalBuilder.String()[0:intervalBuilder.Len()-1]))
-	}
-	return logCtx
-}
 
 const (
 	errInvalidExtraConfigurationMsg = "Invalid Alertmanager configuration: {{.Public.Error}}"
@@ -754,46 +724,20 @@ type PostableUserConfig struct {
 	amSimple               map[string]interface{}    `yaml:"-" json:"-"`
 }
 
-func (c *PostableUserConfig) GetMergedAlertmanagerConfig() (MergeResult, error) {
+func (c *PostableUserConfig) GetMergedAlertmanagerConfig() (merge.MergeResult, error) {
 	if len(c.ExtraConfigs) == 0 {
-		return MergeResult{
-			MergeResult: merge.MergeResult{
-				Config: c.AlertmanagerConfig,
-			},
-		}, nil
+		return merge.MergeResult{Config: c.AlertmanagerConfig}, nil
 	}
 	// support only one config for now
 	mimirCfg := c.ExtraConfigs[0]
 	if err := mimirCfg.Validate(); err != nil {
-		return MergeResult{}, fmt.Errorf("invalid extra configuration: %w", err)
+		return merge.MergeResult{}, fmt.Errorf("invalid extra configuration: %w", err)
 	}
-	opts := merge.MergeOpts{
-		DedupSuffix:     mimirCfg.Identifier,
-		SubtreeMatchers: mimirCfg.MergeMatchers,
-	}
-	if err := opts.Validate(); err != nil {
-		return MergeResult{}, fmt.Errorf("invalid merge options: %w", err)
-	}
-
 	mcfg, err := mimirCfg.GetAlertmanagerConfig()
 	if err != nil {
-		return MergeResult{}, fmt.Errorf("failed to get mimir alertmanager config: %w", err)
+		return merge.MergeResult{}, fmt.Errorf("failed to get mimir alertmanager config: %w", err)
 	}
-
-	m, err := merge.Merge(c.AlertmanagerConfig, mcfg, opts)
-	if err != nil {
-		return MergeResult{}, fmt.Errorf("failed to merge alertmanager config: %w", err)
-	}
-
-	route := mcfg.Route
-	merge.RenameResourceUsagesInRoutes([]*definition.Route{route}, m.RenameResources)
-
-	return MergeResult{
-		MergeResult:       m,
-		Identifier:        mimirCfg.Identifier,
-		ExtraRoute:        route,
-		ExtraInhibitRules: mcfg.InhibitRules,
-	}, nil
+	return merge.GetMergedAlertmanagerConfig(c.AlertmanagerConfig, mcfg, mimirCfg.Identifier, mimirCfg.MergeMatchers)
 }
 
 // GetMergedTemplateDefinitions converts the given PostableUserConfig's TemplateFiles to a slice of Templates.

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager_test.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager_test.go
@@ -270,31 +270,29 @@ func TestPostableUserConfig_GetMergedAlertmanagerConfig(t *testing.T) {
 		name          string
 		config        PostableUserConfig
 		expectedError string
-		expected      MergeResult
+		expected      merge.MergeResult
 	}{
 		{
 			name: "no extra configs",
 			config: PostableUserConfig{
 				AlertmanagerConfig: alertmanagerCfg,
 			},
-			expected: MergeResult{
-				MergeResult: merge.MergeResult{
-					Config: definition.PostableApiAlertingConfig{
-						Config: Config{
-							Route: &Route{
-								Receiver: "default",
-							},
+			expected: merge.MergeResult{
+				Config: definition.PostableApiAlertingConfig{
+					Config: Config{
+						Route: &Route{
+							Receiver: "default",
 						},
-						Receivers: []*PostableApiReceiver{
-							{
-								Receiver: definition.Receiver{
-									Name: "default",
-								},
+					},
+					Receivers: []*PostableApiReceiver{
+						{
+							Receiver: definition.Receiver{
+								Name: "default",
 							},
 						},
 					},
-					RenameResources: merge.RenameResources{},
 				},
+				RenameResources: merge.RenameResources{},
 			},
 		},
 		{
@@ -324,71 +322,69 @@ receivers:
 					},
 				},
 			},
-			expected: MergeResult{
-				MergeResult: merge.MergeResult{
-					Config: definition.PostableApiAlertingConfig{
-						Config: Config{
-							Route: &Route{
-								Receiver: "default",
-								Routes: []*Route{
-									{
-										Matchers: []*labels.Matcher{
-											{
-												Type:  labels.MatchEqual,
-												Name:  "cluster",
-												Value: "prod",
-											},
+			expected: merge.MergeResult{
+				Config: definition.PostableApiAlertingConfig{
+					Config: Config{
+						Route: &Route{
+							Receiver: "default",
+							Routes: []*Route{
+								{
+									Matchers: []*labels.Matcher{
+										{
+											Type:  labels.MatchEqual,
+											Name:  "cluster",
+											Value: "prod",
 										},
-										GroupInterval:  util.Pointer(model.Duration(5 * time.Minute)),
-										GroupWait:      util.Pointer(model.Duration(30 * time.Second)),
-										RepeatInterval: util.Pointer(model.Duration(4 * time.Hour)),
-										Continue:       false,
-										Receiver:       "mimir-receiver",
-										GroupByStr:     []string{"alertname"},
-										GroupBy:        []model.LabelName{"alertname"},
-										Routes: []*Route{
-											{
-												Matchers: []*labels.Matcher{
-													{
-														Type:  labels.MatchEqual,
-														Name:  "severity",
-														Value: "critical",
-													},
+									},
+									GroupInterval:  util.Pointer(model.Duration(5 * time.Minute)),
+									GroupWait:      util.Pointer(model.Duration(30 * time.Second)),
+									RepeatInterval: util.Pointer(model.Duration(4 * time.Hour)),
+									Continue:       false,
+									Receiver:       "mimir-receiver",
+									GroupByStr:     []string{"alertname"},
+									GroupBy:        []model.LabelName{"alertname"},
+									Routes: []*Route{
+										{
+											Matchers: []*labels.Matcher{
+												{
+													Type:  labels.MatchEqual,
+													Name:  "severity",
+													Value: "critical",
 												},
-												Receiver: "defaultmimir-1",
-												Routes:   []*Route{},
 											},
+											Receiver: "defaultmimir-1",
+											Routes:   []*Route{},
 										},
 									},
 								},
 							},
-							InhibitRules:  []InhibitRule{},
-							TimeIntervals: []config.TimeInterval{},
 						},
-						Receivers: []*PostableApiReceiver{
-							{
-								Receiver: definition.Receiver{
-									Name: "default",
-								},
+						InhibitRules:  []InhibitRule{},
+						TimeIntervals: []config.TimeInterval{},
+					},
+					Receivers: []*PostableApiReceiver{
+						{
+							Receiver: definition.Receiver{
+								Name: "default",
 							},
-							{
-								Receiver: definition.Receiver{
-									Name: "mimir-receiver",
-								},
+						},
+						{
+							Receiver: definition.Receiver{
+								Name: "mimir-receiver",
 							},
-							{
-								Receiver: definition.Receiver{
-									Name: "defaultmimir-1",
-								},
+						},
+						{
+							Receiver: definition.Receiver{
+								Name: "defaultmimir-1",
 							},
 						},
 					},
-					RenameResources: merge.RenameResources{
-						Receivers: map[string]string{
-							"default": "defaultmimir-1",
-						},
-						TimeIntervals: map[string]string{},
+				},
+				RenameResources: merge.RenameResources{
+					Receivers: map[string]string{
+						"default": "defaultmimir-1",
 					},
+					TimeIntervals: map[string]string{},
 				},
 				Identifier: "mimir-1",
 				ExtraRoute: &Route{
@@ -431,39 +427,37 @@ receivers:
 					},
 				},
 			},
-			expected: MergeResult{
-				MergeResult: merge.MergeResult{
-					Config: definition.PostableApiAlertingConfig{
-						Config: Config{
-							Route: &Route{
-								Receiver: "default",
-							},
-							TimeIntervals: []config.TimeInterval{},
+			expected: merge.MergeResult{
+				Config: definition.PostableApiAlertingConfig{
+					Config: Config{
+						Route: &Route{
+							Receiver: "default",
 						},
-						Receivers: []*PostableApiReceiver{
-							{
-								Receiver: definition.Receiver{
-									Name: "default",
-								},
+						TimeIntervals: []config.TimeInterval{},
+					},
+					Receivers: []*PostableApiReceiver{
+						{
+							Receiver: definition.Receiver{
+								Name: "default",
 							},
-							{
-								Receiver: definition.Receiver{
-									Name: "mimir-receiver",
-								},
+						},
+						{
+							Receiver: definition.Receiver{
+								Name: "mimir-receiver",
 							},
-							{
-								Receiver: definition.Receiver{
-									Name: "defaultmimir-1",
-								},
+						},
+						{
+							Receiver: definition.Receiver{
+								Name: "defaultmimir-1",
 							},
 						},
 					},
-					RenameResources: merge.RenameResources{
-						Receivers: map[string]string{
-							"default": "defaultmimir-1",
-						},
-						TimeIntervals: map[string]string{},
+				},
+				RenameResources: merge.RenameResources{
+					Receivers: map[string]string{
+						"default": "defaultmimir-1",
 					},
+					TimeIntervals: map[string]string{},
 				},
 				Identifier: "mimir-1",
 				ExtraRoute: &Route{

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager_test.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v3"
 
+	"github.com/grafana/grafana/pkg/services/ngalert/notifier/merge"
 	"github.com/grafana/grafana/pkg/util"
 )
 
@@ -277,7 +278,7 @@ func TestPostableUserConfig_GetMergedAlertmanagerConfig(t *testing.T) {
 				AlertmanagerConfig: alertmanagerCfg,
 			},
 			expected: MergeResult{
-				MergeResult: definition.MergeResult{
+				MergeResult: merge.MergeResult{
 					Config: definition.PostableApiAlertingConfig{
 						Config: Config{
 							Route: &Route{
@@ -292,7 +293,7 @@ func TestPostableUserConfig_GetMergedAlertmanagerConfig(t *testing.T) {
 							},
 						},
 					},
-					RenameResources: definition.RenameResources{},
+					RenameResources: merge.RenameResources{},
 				},
 			},
 		},
@@ -324,7 +325,7 @@ receivers:
 				},
 			},
 			expected: MergeResult{
-				MergeResult: definition.MergeResult{
+				MergeResult: merge.MergeResult{
 					Config: definition.PostableApiAlertingConfig{
 						Config: Config{
 							Route: &Route{
@@ -382,7 +383,7 @@ receivers:
 							},
 						},
 					},
-					RenameResources: definition.RenameResources{
+					RenameResources: merge.RenameResources{
 						Receivers: map[string]string{
 							"default": "defaultmimir-1",
 						},
@@ -431,7 +432,7 @@ receivers:
 				},
 			},
 			expected: MergeResult{
-				MergeResult: definition.MergeResult{
+				MergeResult: merge.MergeResult{
 					Config: definition.PostableApiAlertingConfig{
 						Config: Config{
 							Route: &Route{
@@ -457,7 +458,7 @@ receivers:
 							},
 						},
 					},
-					RenameResources: definition.RenameResources{
+					RenameResources: merge.RenameResources{
 						Receivers: map[string]string{
 							"default": "defaultmimir-1",
 						},

--- a/pkg/services/ngalert/notifier/alertmanager_config.go
+++ b/pkg/services/ngalert/notifier/alertmanager_config.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/go-openapi/strfmt"
-	"github.com/grafana/alerting/definition"
 	alertingNotify "github.com/grafana/alerting/notify"
 	"k8s.io/apimachinery/pkg/util/sets"
 
@@ -19,6 +18,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage"
+	"github.com/grafana/grafana/pkg/services/ngalert/notifier/merge"
 	"github.com/grafana/grafana/pkg/services/secrets"
 )
 
@@ -423,63 +423,63 @@ func (moa *MultiOrgAlertmanager) modifyAndApplyExtraConfiguration(
 	org int64,
 	modifyFn func([]definitions.ExtraConfiguration) ([]definitions.ExtraConfiguration, error),
 	dryRun bool,
-) (definition.RenameResources, error) {
+) (merge.RenameResources, error) {
 	currentCfg, err := moa.configStore.GetLatestAlertmanagerConfiguration(ctx, org)
 	if err != nil {
-		return definition.RenameResources{}, fmt.Errorf("failed to get current configuration: %w", err)
+		return merge.RenameResources{}, fmt.Errorf("failed to get current configuration: %w", err)
 	}
 
 	cfg, err := Load([]byte(currentCfg.AlertmanagerConfiguration))
 	if err != nil {
-		return definition.RenameResources{}, fmt.Errorf("failed to unmarshal current alertmanager configuration: %w", err)
+		return merge.RenameResources{}, fmt.Errorf("failed to unmarshal current alertmanager configuration: %w", err)
 	}
 
 	cfg.ExtraConfigs, err = modifyFn(cfg.ExtraConfigs)
 	if err != nil {
-		return definition.RenameResources{}, fmt.Errorf("failed to apply extra configuration: %w", err)
+		return merge.RenameResources{}, fmt.Errorf("failed to apply extra configuration: %w", err)
 	}
 
 	if len(cfg.ManagedRoutes) > 0 {
 		for _, c := range cfg.ExtraConfigs {
 			if _, ok := cfg.ManagedRoutes[c.Identifier]; ok {
-				return definition.RenameResources{}, ErrIdentifierAlreadyExists.Build(errutil.TemplateData{Public: map[string]interface{}{"Identifier": c.Identifier}})
+				return merge.RenameResources{}, ErrIdentifierAlreadyExists.Build(errutil.TemplateData{Public: map[string]interface{}{"Identifier": c.Identifier}})
 			}
 		}
 	}
 
-	merge, err := cfg.GetMergedAlertmanagerConfig()
+	mergeResult, err := cfg.GetMergedAlertmanagerConfig()
 	if err != nil {
-		return definition.RenameResources{}, fmt.Errorf("cannot merge imported configuration into Grafana: %w", err)
+		return merge.RenameResources{}, fmt.Errorf("cannot merge imported configuration into Grafana: %w", err)
 	}
 
 	if dryRun {
 		moa.logger.Debug("Dry run: extra configuration validated successfully", "org", org)
-		return merge.RenameResources, nil
+		return mergeResult.RenameResources, nil
 	}
 
 	am, err := moa.AlertmanagerFor(org)
 	if err != nil {
 		// It's okay if the alertmanager isn't ready yet, we're changing its config anyway.
 		if !errors.Is(err, ErrAlertmanagerNotReady) {
-			return definition.RenameResources{}, err
+			return merge.RenameResources{}, err
 		}
 	}
 
 	if err := moa.Crypto.EncryptExtraConfigs(ctx, cfg); err != nil {
-		return definition.RenameResources{}, fmt.Errorf("failed to encrypt external configurations: %w", err)
+		return merge.RenameResources{}, fmt.Errorf("failed to encrypt external configurations: %w", err)
 	}
 
 	if err := moa.saveAndApplyConfig(ctx, org, am, cfg); err != nil {
 		moa.logger.Error("Unable to save and apply alertmanager configuration with extra config", "error", err, "org", org)
-		return definition.RenameResources{}, AlertmanagerConfigRejectedError{err}
+		return merge.RenameResources{}, AlertmanagerConfigRejectedError{err}
 	}
 
 	moa.logger.Info("Applied alertmanager configuration with extra config", "org", org)
-	return merge.RenameResources, nil
+	return mergeResult.RenameResources, nil
 }
 
 // SaveAndApplyExtraConfiguration adds or replaces an ExtraConfiguration while preserving the main AlertmanagerConfig.
-func (moa *MultiOrgAlertmanager) SaveAndApplyExtraConfiguration(ctx context.Context, org int64, user identity.Requester, authz ExtraConfigAuthz, extraConfig definitions.ExtraConfiguration, replace bool, dryRun bool) (definition.RenameResources, error) {
+func (moa *MultiOrgAlertmanager) SaveAndApplyExtraConfiguration(ctx context.Context, org int64, user identity.Requester, authz ExtraConfigAuthz, extraConfig definitions.ExtraConfiguration, replace bool, dryRun bool) (merge.RenameResources, error) {
 	modifyFunc := func(configs []definitions.ExtraConfiguration) ([]definitions.ExtraConfiguration, error) {
 		if replace {
 			// When replacing all configs, authorize deletion for each config with a different identifier.
@@ -521,7 +521,7 @@ func (moa *MultiOrgAlertmanager) SaveAndApplyExtraConfiguration(ctx context.Cont
 
 	renamed, err := moa.modifyAndApplyExtraConfiguration(ctx, org, modifyFunc, dryRun)
 	if err != nil {
-		return definition.RenameResources{}, err
+		return merge.RenameResources{}, err
 	}
 
 	if dryRun {

--- a/pkg/services/ngalert/notifier/legacy_storage/imported.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/imported.go
@@ -9,13 +9,14 @@ import (
 
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/ngalert/notifier/merge"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrations/ualert"
 )
 
 type ImportedConfigRevision struct {
 	identifier     string
 	rev            *ConfigRevision
-	opts           definition.MergeOpts
+	opts           merge.MergeOpts
 	importedConfig *definition.PostableApiAlertingConfig
 }
 
@@ -29,7 +30,7 @@ func (rev *ConfigRevision) Imported() (ImportedConfigRevision, error) {
 	// support only one config for now
 	mimirCfg := rev.Config.ExtraConfigs[0]
 	result.identifier = mimirCfg.Identifier
-	opts := definition.MergeOpts{
+	opts := merge.MergeOpts{
 		DedupSuffix:     mimirCfg.Identifier,
 		SubtreeMatchers: mimirCfg.MergeMatchers,
 	}
@@ -51,7 +52,7 @@ func (e ImportedConfigRevision) GetReceivers(uids []string) ([]*models.Receiver,
 		return nil, nil
 	}
 	original := e.rev.Config.AlertmanagerConfig.GetReceivers()
-	merged, _ := definition.MergeReceivers(original, e.importedConfig.GetReceivers(), e.opts.DedupSuffix)
+	merged, _ := merge.MergeReceivers(original, e.importedConfig.GetReceivers(), e.opts.DedupSuffix)
 
 	capacity := len(uids)
 	if capacity == 0 {
@@ -91,7 +92,7 @@ func (e ImportedConfigRevision) GetMuteTimeIntervals() ([]definitions.AmMuteTime
 	grafanaTime := e.rev.Config.AlertmanagerConfig.TimeIntervals
 
 	// Merge to get the renames map (only renamed if name collision occurs)
-	_, renames := definition.MergeTimeIntervals(
+	_, renames := merge.MergeTimeIntervals(
 		grafanaMute,
 		grafanaTime,
 		importedMute,
@@ -127,7 +128,7 @@ func (e ImportedConfigRevision) ReceiverUseByName() map[string]int {
 	}
 	m := make(map[string]int)
 	receiverUseCounts([]*definitions.Route{e.importedConfig.Route}, m)
-	_, renames := definition.MergeReceivers(e.rev.Config.AlertmanagerConfig.GetReceivers(), e.importedConfig.GetReceivers(), e.opts.DedupSuffix)
+	_, renames := merge.MergeReceivers(e.rev.Config.AlertmanagerConfig.GetReceivers(), e.importedConfig.GetReceivers(), e.opts.DedupSuffix)
 	for original, renamed := range renames {
 		if cnt, ok := m[original]; ok {
 			delete(m, original)
@@ -142,12 +143,12 @@ func (e ImportedConfigRevision) GetManagedRoute() (*ManagedRoute, error) {
 		return nil, nil
 	}
 
-	renamed, err := definition.DeduplicateResources(e.rev.Config.AlertmanagerConfig, *e.importedConfig, e.opts)
+	renamed, err := merge.DeduplicateResources(e.rev.Config.AlertmanagerConfig, *e.importedConfig, e.opts)
 	if err != nil {
 		return nil, fmt.Errorf("failed to deduplicate imported config resources: %w", err)
 	}
 
-	definition.RenameResourceUsagesInRoutes([]*definition.Route{e.importedConfig.Route}, renamed)
+	merge.RenameResourceUsagesInRoutes([]*definition.Route{e.importedConfig.Route}, renamed)
 
 	mr := NewManagedRoute(e.identifier, e.importedConfig.Route)
 	mr.Provenance = models.ProvenanceConvertedPrometheus

--- a/pkg/services/ngalert/notifier/merge/merge.go
+++ b/pkg/services/ngalert/notifier/merge/merge.go
@@ -1,0 +1,420 @@
+// Package merge contains the Alertmanager configuration merge logic used by Grafana to
+// reconcile imported (Mimir/Prometheus-format) configurations with Grafana-native ones.
+//
+// The implementation in this package is forked from
+// github.com/grafana/alerting/definition/merge.go so that Grafana can evolve the merge
+// behaviour independently of the upstream alerting library. The wire-format types
+// (PostableApiAlertingConfig, Route, PostableApiReceiver, …) continue to come from
+// github.com/grafana/alerting/definition; only the merge logic is local.
+package merge
+
+import (
+	"errors"
+	"fmt"
+	"math"
+
+	"github.com/grafana/alerting/definition"
+	"github.com/prometheus/alertmanager/config"
+	"github.com/prometheus/alertmanager/dispatch"
+	"github.com/prometheus/alertmanager/pkg/labels"
+	"github.com/prometheus/common/model"
+)
+
+var (
+	ErrInvalidMatchers         = errors.New("only equality matchers are allowed")
+	ErrDuplicateMatchers       = errors.New("matchers should be unique")
+	ErrSubtreeMatchersConflict = errors.New("subtree matchers conflict with existing Grafana routes, merging will break existing notifications")
+)
+
+type MergeOpts struct {
+	// DedupSuffix is a string suffix that will be appended to any resources (receivers or time intervals)
+	// from the secondary configuration that have name conflicts with the primary configuration.
+	//
+	// The deduplication process works as follows:
+	// 1. If a resource from the secondary config has the same name as one in the primary config,
+	//    this suffix is appended to create a new name (e.g., "webhook" becomes "webhooksuffix")
+	// 2. If the new name still conflicts, a sequential number is added (e.g., "webhooksuffix_01")
+	// 3. All references to renamed resources are automatically updated throughout the configuration
+	//
+	// When left empty, only numeric suffixes will be used for deduplication (e.g., "webhook_01").
+	//
+	// Example usage:
+	//   MergeOpts{
+	//     DedupSuffix: "_secondary",  // Results in names like "webhook_secondary" or "webhook_secondary_01"
+	//   }
+	//
+	// This field helps maintain distinct resource identities while preserving relationships
+	// between components during the merge process.
+	DedupSuffix string
+	// SubtreeMatchers specifies a list of matchers that will be applied to the root route
+	// of the routing tree being merged. These matchers are essential for properly isolating
+	// and identifying alerts from the secondary configuration after merging.
+	//
+	// The matchers must follow these requirements:
+	// - At least one matcher must be provided (cannot be empty)
+	// - Each matcher must use the equality operator (labels.MatchEqual type)
+	// - Each matcher name must be unique within the list
+	//
+	// Example usage:
+	//   SubtreeMatchers: config.Matchers{
+	//     {Name: "source", Value: "external", Type: labels.MatchEqual},
+	//     {Name: "environment", Value: "production", Type: labels.MatchEqual},
+	//   }
+	//
+	// These matchers will be:
+	// 1. Added to the root of the secondary routing tree during merge
+	// 2. Added to both source and target matchers of all inhibit rules from the secondary config
+	// 3. Used to ensure alerts are properly routed after configurations are merged
+	//
+	// Warning: If these matchers conflict with existing routes in the primary configuration,
+	// the merge operation will fail with ErrSubtreeMatchersConflict to prevent breaking
+	// existing notification flows.
+	SubtreeMatchers config.Matchers
+}
+
+func (o MergeOpts) Validate() error {
+	seenNames := make(map[string]struct{}, len(o.SubtreeMatchers))
+	for _, matcher := range o.SubtreeMatchers {
+		if _, ok := seenNames[matcher.Name]; ok {
+			return ErrDuplicateMatchers
+		}
+		if matcher.Type != labels.MatchEqual {
+			return ErrInvalidMatchers
+		}
+		seenNames[matcher.Name] = struct{}{}
+	}
+	return nil
+}
+
+// MergeResult represents the result of merging two Alertmanager configurations.
+// It contains the unified configuration and maps of renamed receivers and time intervals.
+type MergeResult struct {
+	Config definition.PostableApiAlertingConfig
+	RenameResources
+}
+
+type RenameResources struct {
+	Receivers     map[string]string
+	TimeIntervals map[string]string
+}
+
+// Merge combines two Alertmanager configurations into a single unified configuration.
+//
+// The function handles three main aspects of the merge process:
+//
+//  1. Resource Deduplication:
+//     When resources (receivers or time intervals) with identical names exist in both configurations,
+//     resources from configuration "b" are renamed according to these rules:
+//     - First, the MergeOpts.DedupSuffix is appended to the name
+//     - If the name is still not unique, a numbered suffix is added (e.g., "_01", "_02")
+//     - All references to renamed resources are automatically updated throughout the configuration
+//
+// 2. Route Merging:
+//   - The entire routing tree from "b" is inserted as a sub-tree under the root route of "a"
+//   - The sub-tree is positioned as the first route in the list of routes
+//   - The MergeOpts.SubtreeMatchers are added to the root of the "b" routing tree
+//   - Default timing settings (GroupWait, GroupInterval, RepeatInterval) are explicitly set
+//     on the "b" route to prevent inheriting potentially unwanted defaults from the parent configuration
+//   - If any existing routes in "a" would match the SubtreeMatchers, the merge will fail with
+//     ErrSubtreeMatchersConflict to prevent breaking existing routing behavior
+//
+// 3. Inhibit Rule Merging:
+//   - All inhibit rules from "b" are copied to the result
+//   - MergeOpts.SubtreeMatchers are added to both source and target matchers of each
+//     copied inhibit rule to maintain proper context separation
+//
+// Returns a MergeResult containing the merged configuration and maps of renamed resources
+// that can be used to track the renaming that occurred during the merge process.
+//
+// Example usage:
+//
+//	result, err := Merge(primaryConfig, secondaryConfig, MergeOpts{
+//	  DedupSuffix: "_secondary",
+//	  SubtreeMatchers: config.Matchers{
+//	    {Name: "source", Value: "external", Type: labels.MatchEqual},
+//	  },
+//	})
+//
+// If the merge fails with ErrSubtreeMatchersConflict, it indicates that the SubtreeMatchers
+// would conflict with existing routes, potentially disrupting alert notifications. In this
+// case, you should choose different SubtreeMatchers that don't overlap with existing route
+// matchers.
+func Merge(a, b definition.PostableApiAlertingConfig, opts MergeOpts) (MergeResult, error) {
+	if err := opts.Validate(); err != nil {
+		return MergeResult{}, err
+	}
+
+	if len(opts.SubtreeMatchers) > 0 {
+		match, err := checkIfMatchersUsed(opts.SubtreeMatchers, a.Route.Routes)
+		if err != nil {
+			return MergeResult{}, err
+		}
+		if match {
+			return MergeResult{}, fmt.Errorf("%w: sub tree matchers: %s", ErrSubtreeMatchersConflict, opts.SubtreeMatchers)
+		}
+	}
+
+	mergedReceivers, renamedReceivers := MergeReceivers(a.Receivers, b.Receivers, opts.DedupSuffix)
+
+	mergedTimeInterval, renamedTimeIntervals := MergeTimeIntervals(
+		a.MuteTimeIntervals,
+		a.TimeIntervals,
+		b.MuteTimeIntervals,
+		b.TimeIntervals,
+		opts.DedupSuffix,
+	)
+
+	renamed := RenameResources{
+		Receivers:     renamedReceivers,
+		TimeIntervals: renamedTimeIntervals,
+	}
+
+	route := a.Route
+	inhibitRules := a.InhibitRules
+	if len(opts.SubtreeMatchers) > 0 {
+		RenameResourceUsagesInRoutes([]*definition.Route{b.Route}, renamed)
+		if route == nil {
+			return MergeResult{}, fmt.Errorf("cannot merge into undefined routing tree")
+		}
+		if b.Route == nil {
+			return MergeResult{}, fmt.Errorf("cannot merge undefined routing tree")
+		}
+		route = MergeRoutes(*route, *b.Route, opts.SubtreeMatchers)
+		inhibitRules = MergeInhibitRules(inhibitRules, b.InhibitRules, opts.SubtreeMatchers)
+	}
+
+	return MergeResult{
+		Config: definition.PostableApiAlertingConfig{
+			Config: definition.Config{
+				Global:            nil, // Grafana does not have global.
+				Route:             route,
+				InhibitRules:      inhibitRules,
+				MuteTimeIntervals: a.MuteTimeIntervals,
+				TimeIntervals:     mergedTimeInterval,
+				Templates:         nil, // we do not use this.
+			},
+			Receivers: mergedReceivers,
+		},
+		RenameResources: renamed,
+	}, nil
+}
+
+// DeduplicateResources merges existing and incoming resources (receivers and time intervals) and ensures unique names by applying suffixes. Returns renamed resources for tracking adjustments made.
+func DeduplicateResources(a, b definition.PostableApiAlertingConfig, opts MergeOpts) (RenameResources, error) {
+	_, renamedReceivers := MergeReceivers(a.Receivers, b.Receivers, opts.DedupSuffix)
+
+	_, renamedTimeIntervals := MergeTimeIntervals(
+		a.MuteTimeIntervals,
+		a.TimeIntervals,
+		b.MuteTimeIntervals,
+		b.TimeIntervals,
+		opts.DedupSuffix,
+	)
+	return RenameResources{
+		Receivers:     renamedReceivers,
+		TimeIntervals: renamedTimeIntervals,
+	}, nil
+}
+
+// MergeTimeIntervals merges existing and incoming time intervals and mute intervals, ensuring unique names by applying suffixes.
+// It returns a merged list of time intervals and a map of renamed interval names for tracking adjustments made. Mute time intervals are converted to time intervals.
+func MergeTimeIntervals(
+	existingMuteIntervals []config.MuteTimeInterval,
+	existingTimeIntervals []config.TimeInterval,
+	incomingMuteIntervals []config.MuteTimeInterval,
+	incomingTimeIntervals []config.TimeInterval,
+	suffix string,
+) ([]config.TimeInterval, map[string]string) {
+	// combine all incoming intervals into a single list
+	incomingAll := make([]config.TimeInterval, 0, len(incomingTimeIntervals)+len(incomingMuteIntervals))
+	incomingAll = append(incomingAll, incomingTimeIntervals...)
+	for _, interval := range incomingMuteIntervals {
+		incomingAll = append(incomingAll, config.TimeInterval(interval))
+	}
+	usedNames := createIndexTimeIntervals(existingMuteIntervals, existingTimeIntervals, incomingAll)
+	result := make([]config.TimeInterval, 0, len(existingTimeIntervals)+len(incomingMuteIntervals)+len(incomingTimeIntervals))
+	result = append(result, existingTimeIntervals...)
+	renames := make(map[string]string)
+	for idx, interval := range incomingAll {
+		curName := interval.Name
+		if i, ok := usedNames[curName]; ok && i != idx { // if the name is already used by another interval, append a suffix.
+			newName := getUniqueName(curName, suffix, usedNames)
+			renames[curName] = newName
+			usedNames[newName] = idx
+			interval.Name = newName
+		}
+		result = append(result, interval)
+	}
+	return result, renames
+}
+
+func createIndexTimeIntervals(
+	existingMuteIntervals []config.MuteTimeInterval,
+	existingTimeIntervals []config.TimeInterval,
+	incomingTimeIntervals []config.TimeInterval,
+) map[string]int {
+	// usedNames is a map of existing interval names where value is the index of the interval that holds the name in the incoming list.
+	usedNames := make(map[string]int, len(existingMuteIntervals)+len(existingTimeIntervals)+len(incomingTimeIntervals))
+	for _, r := range existingMuteIntervals {
+		usedNames[r.Name] = -1
+	}
+	for _, r := range existingTimeIntervals {
+		usedNames[r.Name] = -1
+	}
+	for idx, r := range incomingTimeIntervals {
+		if _, ok := usedNames[r.Name]; !ok {
+			usedNames[r.Name] = idx
+		}
+	}
+	return usedNames
+}
+
+func MergeRoutes(a, b definition.Route, matcher config.Matchers) *definition.Route {
+	// get a and b by value so we get shallow copies of the top level routes, which we can modify.
+	// make sure "b" route has all defaults set explicitly to avoid inheriting "a"'s default route settings.
+	defaultOpts := dispatch.DefaultRouteOpts
+	if b.GroupWait == nil {
+		gw := model.Duration(defaultOpts.GroupWait)
+		b.GroupWait = &gw
+	}
+	if b.GroupInterval == nil {
+		gi := model.Duration(defaultOpts.GroupInterval)
+		b.GroupInterval = &gi
+	}
+	if b.RepeatInterval == nil {
+		ri := model.Duration(defaultOpts.RepeatInterval)
+		b.RepeatInterval = &ri
+	}
+	b.Matchers = append(b.Matchers, matcher...)
+	a.Routes = append([]*definition.Route{&b}, a.Routes...)
+	return &a
+}
+
+func checkIfMatchersUsed(matchers config.Matchers, routes []*definition.Route) (bool, error) {
+	// matchers are always equality type. So we can confidently convert them to labelsSet
+	// and check if they are contained in any of the routes.
+	ls := make(model.LabelSet, len(matchers))
+	for _, matcher := range matchers {
+		ls[model.LabelName(matcher.Name)] = model.LabelValue(matcher.Value)
+	}
+	for _, r := range routes {
+		if r == nil {
+			continue
+		}
+		m, err := r.AllMatchers()
+		if err != nil {
+			return false, err
+		}
+		if (labels.Matchers(m)).Matches(ls) {
+			return true, nil
+		}
+
+		sameNames := make(labels.Matchers, 0, len(ls))
+		seenNames := make(map[string]struct{}, len(ls))
+		for _, matcher := range m {
+			if _, ok := ls[model.LabelName(matcher.Name)]; ok {
+				sameNames = append(sameNames, matcher)
+				seenNames[matcher.Name] = struct{}{}
+			}
+		}
+		// if the route contains matchers that match ALL labels, then check if sub-matchers will match them.
+		if len(seenNames) == len(ls) && sameNames.Matches(ls) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// RenameResourceUsagesInRoutes updates the receiver and mute/active time intervals of routes based on the provided rename resources.
+func RenameResourceUsagesInRoutes(routes []*definition.Route, renames RenameResources) {
+	for _, r := range routes {
+		if r == nil {
+			continue
+		}
+		if r.Receiver != "" {
+			if newName, ok := renames.Receivers[r.Receiver]; ok {
+				r.Receiver = newName
+			}
+		}
+		for i := range r.MuteTimeIntervals {
+			if newName, ok := renames.TimeIntervals[r.MuteTimeIntervals[i]]; ok {
+				r.MuteTimeIntervals[i] = newName
+			}
+		}
+		for i := range r.ActiveTimeIntervals {
+			if newName, ok := renames.TimeIntervals[r.ActiveTimeIntervals[i]]; ok {
+				r.ActiveTimeIntervals[i] = newName
+			}
+		}
+		RenameResourceUsagesInRoutes(r.Routes, renames)
+	}
+}
+
+func MergeInhibitRules(a, b []config.InhibitRule, matcher config.Matchers) []config.InhibitRule {
+	result := make([]config.InhibitRule, 0, len(a)+len(b))
+	result = append(result, a...)
+	for _, rule := range b {
+		rule.SourceMatchers = append(rule.SourceMatchers, matcher...)
+		rule.TargetMatchers = append(rule.TargetMatchers, matcher...)
+		result = append(result, rule)
+	}
+	return result
+}
+
+// MergeReceivers merges two lists of PostableApiReceiver objects, ensuring unique names by appending a suffix if necessary.
+// It returns the combined list of receivers and a map of renamed original names to their new unique names.
+// The items of the existing list are added to the result list as is whereas the items of incoming list are copied (shallow copy)
+// and renamed if necessary.
+func MergeReceivers(existing, incoming []*definition.PostableApiReceiver, suffix string) ([]*definition.PostableApiReceiver, map[string]string) {
+	result := make([]*definition.PostableApiReceiver, 0, len(existing)+len(incoming))
+	result = append(result, existing...)
+	usedNames := createIndexReceivers(existing, incoming)
+	renames := make(map[string]string)
+	for idx, r := range incoming {
+		if r == nil {
+			continue
+		}
+		cpy := *r
+		if i, ok := usedNames[cpy.Name]; ok && i != idx {
+			newName := getUniqueName(cpy.Name, suffix, usedNames)
+			renames[cpy.Name] = newName
+			cpy.Name = newName
+			usedNames[cpy.Name] = i
+		}
+		result = append(result, &cpy)
+	}
+	return result, renames
+}
+
+func createIndexReceivers(existing, incoming []*definition.PostableApiReceiver) map[string]int {
+	usedNames := make(map[string]int, len(existing)+len(incoming))
+	for _, e := range existing {
+		usedNames[e.Name] = -1
+	}
+	for idx, i := range incoming {
+		if _, ok := usedNames[i.Name]; !ok {
+			usedNames[i.Name] = idx
+		}
+	}
+	return usedNames
+}
+
+func getUniqueName[T any](name string, suffix string, usedNames map[string]T) string {
+	result := name
+	done := false
+	for i := 0; i <= math.MaxInt32; i++ {
+		if _, ok := usedNames[result]; !ok {
+			done = true
+			break
+		}
+		if i == 0 {
+			result = fmt.Sprintf("%s%s", name, suffix)
+		} else {
+			result = fmt.Sprintf("%s%s_%02d", name, suffix, i) // in case "a" has both receivers with and without a suffix
+		}
+	}
+	if !done {
+		panic(fmt.Sprintf("unable to find unique name for %s", name))
+	}
+	return result
+}

--- a/pkg/services/ngalert/notifier/merge/merge.go
+++ b/pkg/services/ngalert/notifier/merge/merge.go
@@ -52,7 +52,6 @@ type MergeOpts struct {
 	// and identifying alerts from the secondary configuration after merging.
 	//
 	// The matchers must follow these requirements:
-	// - At least one matcher must be provided (cannot be empty)
 	// - Each matcher must use the equality operator (labels.MatchEqual type)
 	// - Each matcher name must be unique within the list
 	//
@@ -113,7 +112,8 @@ func (m MergeResult) LogContext() []any {
 	if len(m.Receivers) == 0 && len(m.TimeIntervals) == 0 {
 		return nil
 	}
-	logCtx := make([]any, 0, 4)
+	logCtx := make([]any, 0, 6)
+	logCtx = append(logCtx, "identifier", m.Identifier)
 	if len(m.Receivers) > 0 {
 		rcvBuilder := strings.Builder{}
 		for from, to := range m.Receivers {

--- a/pkg/services/ngalert/notifier/merge/merge.go
+++ b/pkg/services/ngalert/notifier/merge/merge.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"strings"
 
 	"github.com/grafana/alerting/definition"
 	"github.com/prometheus/alertmanager/config"
@@ -88,14 +89,85 @@ func (o MergeOpts) Validate() error {
 
 // MergeResult represents the result of merging two Alertmanager configurations.
 // It contains the unified configuration and maps of renamed receivers and time intervals.
+//
+// Identifier, ExtraRoute and ExtraInhibitRules are populated by GetMergedAlertmanagerConfig
+// when the merge consumed an imported (Mimir-format) configuration; they expose the
+// imported route subtree and inhibit rules separately so callers can register them as
+// managed routes / managed inhibit rules. Plain calls to Merge leave these fields zero.
 type MergeResult struct {
 	Config definition.PostableApiAlertingConfig
 	RenameResources
+	Identifier        string
+	ExtraRoute        *definition.Route
+	ExtraInhibitRules []config.InhibitRule
 }
 
 type RenameResources struct {
 	Receivers     map[string]string
 	TimeIntervals map[string]string
+}
+
+// LogContext returns key-value pairs describing any receiver or time-interval renames the
+// merge produced, suitable for structured logging. Returns nil when nothing was renamed.
+func (m MergeResult) LogContext() []any {
+	if len(m.Receivers) == 0 && len(m.TimeIntervals) == 0 {
+		return nil
+	}
+	logCtx := make([]any, 0, 4)
+	if len(m.Receivers) > 0 {
+		rcvBuilder := strings.Builder{}
+		for from, to := range m.Receivers {
+			fmt.Fprintf(&rcvBuilder, "'%s'->'%s',", from, to)
+		}
+		logCtx = append(logCtx, "renamedReceivers", fmt.Sprintf("[%s]", rcvBuilder.String()[0:rcvBuilder.Len()-1]))
+	}
+	if len(m.TimeIntervals) > 0 {
+		intervalBuilder := strings.Builder{}
+		for from, to := range m.TimeIntervals {
+			fmt.Fprintf(&intervalBuilder, "'%s'->'%s',", from, to)
+		}
+		logCtx = append(logCtx, "renamedTimeIntervals", fmt.Sprintf("[%s]", intervalBuilder.String()[0:intervalBuilder.Len()-1]))
+	}
+	return logCtx
+}
+
+// GetMergedAlertmanagerConfig merges the given imported alertmanager configuration into
+// the base Grafana configuration. The imported route is also returned separately on
+// MergeResult.ExtraRoute (after rename application) so callers can register it as a
+// managed route. The imported inhibit rules are returned on MergeResult.ExtraInhibitRules.
+//
+// The given identifier is used as the dedup suffix for receiver / time-interval name
+// collisions and as the MergeResult.Identifier. The given matchers are used as the subtree
+// matchers for the merge.
+func GetMergedAlertmanagerConfig(
+	base definition.PostableApiAlertingConfig,
+	imported definition.PostableApiAlertingConfig,
+	identifier string,
+	matchers config.Matchers,
+) (MergeResult, error) {
+	opts := MergeOpts{
+		DedupSuffix:     identifier,
+		SubtreeMatchers: matchers,
+	}
+	if err := opts.Validate(); err != nil {
+		return MergeResult{}, fmt.Errorf("invalid merge options: %w", err)
+	}
+
+	m, err := Merge(base, imported, opts)
+	if err != nil {
+		return MergeResult{}, fmt.Errorf("failed to merge alertmanager config: %w", err)
+	}
+
+	route := imported.Route
+	RenameResourceUsagesInRoutes([]*definition.Route{route}, m.RenameResources)
+
+	return MergeResult{
+		Config:            m.Config,
+		RenameResources:   m.RenameResources,
+		Identifier:        identifier,
+		ExtraRoute:        route,
+		ExtraInhibitRules: imported.InhibitRules,
+	}, nil
 }
 
 // Merge combines two Alertmanager configurations into a single unified configuration.

--- a/pkg/services/ngalert/notifier/merge/merge_test.go
+++ b/pkg/services/ngalert/notifier/merge/merge_test.go
@@ -1,0 +1,1064 @@
+package merge
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/grafana/alerting/definition"
+	httpcfg "github.com/grafana/alerting/http/v0mimir"
+	"github.com/prometheus/alertmanager/config"
+	"github.com/prometheus/alertmanager/dispatch"
+	"github.com/prometheus/alertmanager/pkg/labels"
+	commoncfg "github.com/prometheus/common/config"
+	"github.com/prometheus/common/model"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.yaml.in/yaml/v3"
+)
+
+func TestMergeOpts_Validate(t *testing.T) {
+	testCases := []struct {
+		name        string
+		opts        MergeOpts
+		expectedErr error
+	}{
+		{
+			name: "no error if subtree matchers are empty",
+			opts: MergeOpts{
+				SubtreeMatchers: config.Matchers{},
+			},
+		},
+		{
+			name: "error if subtree matchers are not equal",
+			opts: MergeOpts{
+				SubtreeMatchers: config.Matchers{
+					{
+						Type:  labels.MatchNotEqual,
+						Name:  "label",
+						Value: "test",
+					},
+				},
+			},
+			expectedErr: ErrInvalidMatchers,
+		},
+		{
+			name: "error if subtree matchers are regex",
+			opts: MergeOpts{
+				SubtreeMatchers: config.Matchers{
+					{
+						Type:  labels.MatchRegexp,
+						Name:  "label",
+						Value: "test",
+					},
+				},
+			},
+			expectedErr: ErrInvalidMatchers,
+		},
+		{
+			name: "error if subtree matchers are not-regex",
+			opts: MergeOpts{
+				SubtreeMatchers: config.Matchers{
+					{
+						Type:  labels.MatchNotRegexp,
+						Name:  "label",
+						Value: "test",
+					},
+				},
+			},
+			expectedErr: ErrInvalidMatchers,
+		},
+		{
+			name: "error if duplicates",
+			opts: MergeOpts{
+				SubtreeMatchers: config.Matchers{
+					{
+						Type:  labels.MatchEqual,
+						Name:  "label",
+						Value: "test",
+					},
+					{
+						Type:  labels.MatchEqual,
+						Name:  "label",
+						Value: "test",
+					},
+				},
+			},
+			expectedErr: ErrDuplicateMatchers,
+		},
+		{
+			name: "valid if no duplicates and only equal matchers",
+			opts: MergeOpts{
+				SubtreeMatchers: config.Matchers{
+					{
+						Type:  labels.MatchEqual,
+						Name:  "al",
+						Value: "test",
+					},
+					{
+						Type:  labels.MatchEqual,
+						Name:  "bl",
+						Value: "test",
+					},
+				},
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := tc.opts.Validate()
+			if tc.expectedErr != nil {
+				assert.ErrorIs(t, actual, tc.expectedErr)
+				return
+			}
+			assert.NoError(t, actual)
+		})
+	}
+}
+
+func TestMerge(t *testing.T) {
+	opts := MergeOpts{
+		DedupSuffix: "_mimir-12345",
+		SubtreeMatchers: config.Matchers{
+			{
+				Type:  labels.MatchEqual,
+				Name:  "__datasource_uid__",
+				Value: "12345",
+			},
+			{
+				Type:  labels.MatchEqual,
+				Name:  "__mimir__",
+				Value: "true",
+			},
+		},
+	}
+
+	testCases := []struct {
+		name        string
+		grafana     *definition.PostableApiAlertingConfig
+		mimir       *definition.PostableApiAlertingConfig
+		expected    MergeResult
+		expectedErr error
+	}{
+		{
+			name:    "should merge all resources, no renames",
+			grafana: load(t, fullGrafanaConfig),
+			mimir:   load(t, fullMimirConfig),
+			expected: MergeResult{
+				Config: *load(t, fullMergedConfig),
+			},
+		},
+		{
+			name:    "should populate intervals by defaults",
+			grafana: load(t, fullGrafanaConfig),
+			mimir: load(t, fullMimirConfig, func(p *definition.PostableApiAlertingConfig) {
+				p.Route.GroupWait = nil
+				p.Route.GroupInterval = nil
+				p.Route.RepeatInterval = nil
+			}),
+			expected: MergeResult{
+				Config: *load(t, fullMergedConfig, func(p *definition.PostableApiAlertingConfig) {
+					gw := model.Duration(dispatch.DefaultRouteOpts.GroupWait)
+					gi := model.Duration(dispatch.DefaultRouteOpts.GroupInterval)
+					ri := model.Duration(dispatch.DefaultRouteOpts.RepeatInterval)
+					p.Route.Routes[0].GroupWait = &gw
+					p.Route.Routes[0].GroupInterval = &gi
+					p.Route.Routes[0].RepeatInterval = &ri
+				}),
+			},
+		},
+		{
+			name:    "should rename receivers and refactor usages",
+			grafana: load(t, fullGrafanaConfig),
+			mimir: load(t, fullMimirConfig, func(p *definition.PostableApiAlertingConfig) {
+				p.Receivers = append(p.Receivers, &definition.PostableApiReceiver{
+					Receiver: definition.Receiver{
+						Name: "grafana-default-email",
+					},
+				})
+				p.Route.Routes = append(p.Route.Routes, &definition.Route{
+					Receiver: "grafana-default-email",
+					Matchers: config.Matchers{
+						{
+							Type:  labels.MatchEqual,
+							Name:  "label",
+							Value: "test",
+						},
+					},
+				})
+			}),
+			expected: MergeResult{
+				Config: *load(t, fullMergedConfig, func(p *definition.PostableApiAlertingConfig) {
+					p.Route.Routes[0].Routes = append(p.Route.Routes[0].Routes, &definition.Route{
+						Receiver: "grafana-default-email_mimir-12345",
+						Matchers: config.Matchers{
+							{
+								Type:  labels.MatchEqual,
+								Name:  "label",
+								Value: "test",
+							},
+						},
+					})
+					p.Receivers = append(p.Receivers, &definition.PostableApiReceiver{
+						Receiver: definition.Receiver{
+							Name: "grafana-default-email_mimir-12345",
+						},
+					})
+
+				}),
+				RenameResources: RenameResources{
+					Receivers: map[string]string{
+						"grafana-default-email": "grafana-default-email_mimir-12345",
+					},
+				},
+			},
+		},
+		{
+			name: "should append index suffix if rename still collides",
+			grafana: load(t, fullGrafanaConfig, func(p *definition.PostableApiAlertingConfig) {
+				p.Receivers = append(p.Receivers, &definition.PostableApiReceiver{
+					Receiver: definition.Receiver{
+						Name: "grafana-default-email_mimir-12345",
+					},
+				})
+			}),
+			mimir: load(t, fullMimirConfig, func(p *definition.PostableApiAlertingConfig) {
+				p.Receivers = append(p.Receivers, &definition.PostableApiReceiver{
+					Receiver: definition.Receiver{
+						Name: "grafana-default-email",
+					},
+				})
+			}),
+			expected: MergeResult{
+				Config: *load(t, fullMergedConfig, func(p *definition.PostableApiAlertingConfig) {
+					p.Receivers = append(p.Receivers,
+						&definition.PostableApiReceiver{
+							Receiver: definition.Receiver{
+								Name: "grafana-default-email_mimir-12345",
+							},
+						},
+						&definition.PostableApiReceiver{
+							Receiver: definition.Receiver{
+								Name: "grafana-default-email_mimir-12345_01",
+							},
+						},
+					)
+				}),
+				RenameResources: RenameResources{
+					Receivers: map[string]string{
+						"grafana-default-email": "grafana-default-email_mimir-12345_01",
+					},
+				},
+			},
+		},
+		{
+			name:    "should rename time intervals and refactor usages",
+			grafana: load(t, fullGrafanaConfig),
+			mimir: load(t, fullMimirConfig, func(p *definition.PostableApiAlertingConfig) {
+				// intentionally swap intervals here, just make sure the uniqueness is enforced across both fields
+				p.TimeIntervals = append(p.TimeIntervals, config.TimeInterval{
+					Name: "mti-1",
+				})
+				p.MuteTimeIntervals = []config.MuteTimeInterval{
+					{
+						Name: "ti-1",
+					},
+				}
+				p.Route.Routes = append(p.Route.Routes, &definition.Route{
+					Matchers: config.Matchers{
+						{
+							Type:  labels.MatchEqual,
+							Name:  "label",
+							Value: "test",
+						},
+					},
+					MuteTimeIntervals:   []string{"ti-1"},
+					ActiveTimeIntervals: []string{"mti-1"},
+				})
+			}),
+			expected: MergeResult{
+				Config: *load(t, fullMergedConfig, func(p *definition.PostableApiAlertingConfig) {
+					// remove mti2 that we replaced with ti-1
+					expected := p.TimeIntervals[:len(p.TimeIntervals)-1]
+					expected = append(expected, config.TimeInterval{
+						Name: "mti-1_mimir-12345",
+					})
+					expected = append(expected, config.TimeInterval{
+						Name: "ti-1_mimir-12345",
+					})
+					p.TimeIntervals = expected
+					p.Route.Routes[0].Routes = append(p.Route.Routes[0].Routes, &definition.Route{
+						Matchers: config.Matchers{
+							{
+								Type:  labels.MatchEqual,
+								Name:  "label",
+								Value: "test",
+							},
+						},
+						MuteTimeIntervals:   []string{"ti-1_mimir-12345"},
+						ActiveTimeIntervals: []string{"mti-1_mimir-12345"},
+					})
+				}),
+				RenameResources: RenameResources{
+					TimeIntervals: map[string]string{
+						"ti-1":  "ti-1_mimir-12345",
+						"mti-1": "mti-1_mimir-12345",
+					},
+				},
+			},
+		},
+		{
+			name: "should fail if merging matchers conflict with Grafana, exact match",
+			grafana: load(t, fullGrafanaConfig, func(p *definition.PostableApiAlertingConfig) {
+				p.Route.Routes = append(p.Route.Routes, &definition.Route{
+					Matchers: opts.SubtreeMatchers,
+				})
+			}),
+			mimir:       load(t, fullMimirConfig),
+			expectedErr: ErrSubtreeMatchersConflict,
+		},
+		{
+			name: "should fail if merging matchers conflict with Grafana, subset match",
+			grafana: load(t, fullGrafanaConfig, func(p *definition.PostableApiAlertingConfig) {
+				m, err := labels.NewMatcher(labels.MatchEqual, "label", "test")
+				require.NoError(t, err)
+				p.Route.Routes = append(p.Route.Routes, &definition.Route{
+					Matchers: append(opts.SubtreeMatchers, m),
+				})
+			}),
+			mimir:       load(t, fullMimirConfig),
+			expectedErr: ErrSubtreeMatchersConflict,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := Merge(*tc.grafana, *tc.mimir, opts)
+			if tc.expectedErr != nil {
+				if err == nil {
+					data, err := yaml.Marshal(result.Config)
+					require.NoError(t, err)
+					t.Fatalf("Expected error but got result. YAML:\n%v", string(data))
+				}
+				assert.ErrorIs(t, err, tc.expectedErr)
+				return
+			}
+			require.NoError(t, err)
+			tc.expected.Config.Global = nil
+
+			diff := cmp.Diff(tc.expected, result,
+				cmpopts.IgnoreUnexported(commoncfg.ProxyConfig{}, httpcfg.ProxyConfig{}, labels.Matcher{}),
+				cmpopts.SortSlices(func(a, b *labels.Matcher) bool {
+					return a.Name < b.Name
+				}),
+				cmpopts.SortSlices(func(a, b *definition.PostableApiReceiver) bool {
+					return a.Name < b.Name
+				}),
+				cmpopts.EquateEmpty(),
+			)
+			if !assert.Empty(t, diff) {
+				data, err := yaml.Marshal(result.Config)
+				require.NoError(t, err)
+				t.Fatalf("YAML:\n%v", string(data))
+			}
+		})
+	}
+
+	t.Run("should not modify existing config", func(t *testing.T) {
+		g := load(t, fullGrafanaConfig)
+		m := load(t, fullMimirConfig)
+		_, err := Merge(*g, *m, opts)
+		require.NoError(t, err)
+		assert.Equal(t, load(t, fullGrafanaConfig), g)
+		assert.Equal(t, load(t, fullMimirConfig), m)
+	})
+
+	t.Run("should skip merging routes and inhibition rules if matchers are empty", func(t *testing.T) {
+		g := load(t, fullGrafanaConfig)
+		m := load(t, fullMimirConfig)
+		opts := MergeOpts{
+			DedupSuffix:     "_mimir-12345",
+			SubtreeMatchers: config.Matchers{},
+		}
+		result, err := Merge(*g, *m, opts)
+		require.NoError(t, err)
+
+		full := load(t, fullMergedConfig)
+		full.Route.Routes = full.Route.Routes[1:]
+		full.InhibitRules = g.InhibitRules
+		full.Global = nil
+
+		diff := cmp.Diff(MergeResult{Config: *full}, result,
+			cmpopts.IgnoreUnexported(commoncfg.ProxyConfig{}, httpcfg.ProxyConfig{}, labels.Matcher{}),
+			cmpopts.SortSlices(func(a, b *labels.Matcher) bool {
+				return a.Name < b.Name
+			}),
+			cmpopts.SortSlices(func(a, b *definition.PostableApiReceiver) bool {
+				return a.Name < b.Name
+			}),
+			cmpopts.EquateEmpty(),
+		)
+		if !assert.Empty(t, diff) {
+			data, err := yaml.Marshal(result.Config)
+			require.NoError(t, err)
+			t.Fatalf("YAML:\n%v", string(data))
+		}
+	})
+}
+
+func TestCheckIfMatchersUsed(t *testing.T) {
+	m := config.Matchers{
+		{
+			Type:  labels.MatchEqual,
+			Name:  "al",
+			Value: "av",
+		},
+		{
+			Type:  labels.MatchEqual,
+			Name:  "bl",
+			Value: "bv",
+		},
+	}
+
+	mustMatcher := func(mt labels.MatchType, n, v string) *labels.Matcher {
+		m, err := labels.NewMatcher(mt, n, v)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return m
+	}
+
+	testCases := []struct {
+		name     string
+		route    *definition.Route
+		expected bool
+	}{
+		{
+			name: "true if the same matchers",
+			route: &definition.Route{
+				Matchers: m,
+			},
+			expected: true,
+		},
+		{
+			name: "true if sub set of matchers",
+			route: &definition.Route{
+				Matchers: config.Matchers{
+					{
+						Type:  labels.MatchEqual,
+						Name:  "al",
+						Value: "av",
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "true if regex that matches",
+			route: &definition.Route{
+				Matchers: append(m, mustMatcher(labels.MatchRegexp, "al", ".*")),
+			},
+			expected: true,
+		},
+		{
+			name: "true if superset of matchers",
+			route: &definition.Route{
+				Matchers: append(m, &labels.Matcher{
+					Type:  labels.MatchEqual,
+					Name:  "cl",
+					Value: "cv",
+				}),
+			},
+			expected: true,
+		},
+		{
+			name: "false if different matchers",
+			route: &definition.Route{
+				Matchers: config.Matchers{
+					{
+						Type:  labels.MatchEqual,
+						Name:  "al",
+						Value: "test",
+					},
+					{
+						Type:  labels.MatchEqual,
+						Name:  "bl",
+						Value: "bv",
+					},
+				},
+			},
+			expected: false,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual, err := checkIfMatchersUsed(m, []*definition.Route{tc.route})
+			require.NoError(t, err)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}
+
+func TestMergeReceivers(t *testing.T) {
+	r := func(name string) *definition.PostableApiReceiver {
+		return &definition.PostableApiReceiver{
+			Receiver: definition.Receiver{
+				Name: name,
+			},
+		}
+	}
+
+	suffix := "-dupe"
+
+	r1 := r("r1")
+	r2 := r("r2")
+	r2s := r("r2" + suffix)
+	r3 := r("r3")
+
+	testCases := []struct {
+		name            string
+		existing        []*definition.PostableApiReceiver
+		incoming        []*definition.PostableApiReceiver
+		expected        []*definition.PostableApiReceiver
+		expectedRenames map[string]string
+	}{
+		{
+			name: "should append copies of incoming to existing",
+			existing: []*definition.PostableApiReceiver{
+				r2,
+			},
+			incoming: []*definition.PostableApiReceiver{
+				r1,
+				r3,
+			},
+			expected: []*definition.PostableApiReceiver{
+				r2,
+				r1,
+				r3,
+			},
+			expectedRenames: map[string]string{},
+		},
+		{
+			name: "should rename incoming if there is existing",
+			existing: []*definition.PostableApiReceiver{
+				r2,
+			},
+			incoming: []*definition.PostableApiReceiver{
+				r("r2"),
+			},
+			expected: []*definition.PostableApiReceiver{
+				r2,
+				r("r2" + suffix),
+			},
+			expectedRenames: map[string]string{
+				"r2": "r2" + suffix,
+			},
+		},
+		{
+			name: "should rename incoming if there is existing after dedup",
+			existing: []*definition.PostableApiReceiver{
+				r2,
+				r2s,
+			},
+			incoming: []*definition.PostableApiReceiver{
+				r("r2"),
+			},
+			expected: []*definition.PostableApiReceiver{
+				r2,
+				r2s,
+				r("r2" + suffix + "_01"),
+			},
+			expectedRenames: map[string]string{
+				"r2": "r2" + suffix + "_01",
+			},
+		},
+		{
+			name: "should keep names unique across both sets",
+			existing: []*definition.PostableApiReceiver{
+				r2,
+				r2s,
+			},
+			incoming: []*definition.PostableApiReceiver{
+				r("r2"),
+				r("r2" + suffix + "_01"),
+			},
+			expected: []*definition.PostableApiReceiver{
+				r2,
+				r2s,
+				r("r2" + suffix + "_02"),
+				r("r2" + suffix + "_01"),
+			},
+			expectedRenames: map[string]string{
+				"r2": "r2" + suffix + "_02",
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var existingNames, incomingNames []string
+			for _, r := range tc.existing {
+				existingNames = append(existingNames, r.Name)
+			}
+			for _, r := range tc.incoming {
+				incomingNames = append(incomingNames, r.Name)
+			}
+
+			actual, actualRenames := MergeReceivers(tc.existing, tc.incoming, suffix)
+			require.Len(t, actual, len(tc.expected))
+			assert.EqualValues(t, tc.expectedRenames, actualRenames)
+			for i := range tc.expected {
+				assert.EqualValues(t, tc.expected[i], actual[i])
+				if i < len(tc.existing) {
+					assert.Same(t, tc.existing[i], actual[i])
+				} else {
+					idx := i - len(tc.existing)
+					assert.NotSame(t, tc.incoming[idx], actual[i])
+				}
+			}
+
+			t.Run("items of the lists should not be changed", func(t *testing.T) {
+				var names []string
+				for _, r := range tc.existing {
+					names = append(names, r.Name)
+				}
+				assert.Equal(t, existingNames, names)
+				names = nil
+				for _, r := range tc.incoming {
+					names = append(names, r.Name)
+				}
+				assert.Equal(t, incomingNames, names)
+			})
+		})
+	}
+}
+
+func TestMergeTimeIntervals(t *testing.T) {
+	ti := func(name string) config.TimeInterval {
+		return config.TimeInterval{
+			Name: name,
+		}
+	}
+	mti := func(name string) config.MuteTimeInterval {
+		return config.MuteTimeInterval{
+			Name: name,
+		}
+	}
+
+	suffix := "-dupe"
+
+	testCases := []struct {
+		name                  string
+		existingMuteIntervals []config.MuteTimeInterval
+		existingTimeIntervals []config.TimeInterval
+		incomingMuteIntervals []config.MuteTimeInterval
+		incomingTimeIntervals []config.TimeInterval
+		expected              []config.TimeInterval
+		expectedRenames       map[string]string
+	}{
+		{
+			name: "should append copies of incoming to existing time intervals",
+			existingMuteIntervals: []config.MuteTimeInterval{
+				mti("mti1"),
+			},
+			existingTimeIntervals: []config.TimeInterval{
+				ti("ti2"),
+			},
+			incomingTimeIntervals: []config.TimeInterval{
+				ti("ti4"),
+			},
+			incomingMuteIntervals: []config.MuteTimeInterval{
+				mti("mti3"),
+			},
+			expected: []config.TimeInterval{
+				ti("ti2"),
+				ti("ti4"),
+				ti("mti3"),
+			},
+			expectedRenames: map[string]string{},
+		},
+		{
+			name: "should rename incoming if there is existing",
+			existingMuteIntervals: []config.MuteTimeInterval{
+				mti("mti1"),
+			},
+			existingTimeIntervals: []config.TimeInterval{
+				ti("ti2"),
+			},
+			incomingTimeIntervals: []config.TimeInterval{
+				ti("mti1"),
+			},
+			incomingMuteIntervals: []config.MuteTimeInterval{
+				mti("ti2"),
+			},
+			expected: []config.TimeInterval{
+				ti("ti2"),
+				ti("mti1" + suffix),
+				ti("ti2" + suffix),
+			},
+			expectedRenames: map[string]string{
+				"ti2":  "ti2" + suffix,
+				"mti1": "mti1" + suffix,
+			},
+		},
+		{
+			name: "should rename incoming if there is existing after dedup",
+			existingMuteIntervals: []config.MuteTimeInterval{
+				mti("ti1"),
+			},
+			existingTimeIntervals: []config.TimeInterval{
+				ti("ti1" + suffix),
+			},
+			incomingTimeIntervals: []config.TimeInterval{
+				ti("ti1" + suffix),
+			},
+			incomingMuteIntervals: []config.MuteTimeInterval{
+				mti("ti1"),
+			},
+			expected: []config.TimeInterval{
+				ti("ti1" + suffix),
+				ti("ti1" + suffix + suffix),
+				ti("ti1" + suffix + "_01"),
+			},
+			expectedRenames: map[string]string{
+				"ti1" + suffix: "ti1" + suffix + suffix,
+				"ti1":          "ti1" + suffix + "_01",
+			},
+		},
+		{
+			name: "should rename dupe among incoming",
+			existingTimeIntervals: []config.TimeInterval{
+				ti("ti2"),
+			},
+			incomingTimeIntervals: []config.TimeInterval{
+				ti("ti2"),
+			},
+			incomingMuteIntervals: []config.MuteTimeInterval{
+				mti("ti2"),
+			},
+			expected: []config.TimeInterval{ // mute intervals have precedence over time intervals in the case of duplicates (see https://github.com/grafana/alerting/blob/85dab908dcb43f7718a638b4c3cf9c214f7e48da/notify/grafana_alertmanager.go#L676-L685)
+				ti("ti2"),
+				ti("ti2" + suffix),
+				ti("ti2" + suffix + "_01"),
+			},
+			expectedRenames: map[string]string{
+				"ti2": "ti2" + suffix + "_01",
+			},
+		},
+		{
+			name: "should ensure uniqueness across existing and incoming",
+			existingMuteIntervals: []config.MuteTimeInterval{
+				mti("ti1"),
+			},
+			existingTimeIntervals: []config.TimeInterval{
+				ti("ti1" + suffix),
+			},
+			incomingTimeIntervals: []config.TimeInterval{
+				ti("ti1"),
+				ti("ti2"),
+			},
+			incomingMuteIntervals: []config.MuteTimeInterval{
+				mti("ti1" + suffix + "_01"),
+			},
+			expected: []config.TimeInterval{
+				ti("ti1" + suffix),
+				ti("ti1" + suffix + "_02"),
+				ti("ti2"),
+				ti("ti1" + suffix + "_01"),
+			},
+			expectedRenames: map[string]string{
+				"ti1": "ti1" + suffix + "_02",
+			},
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var existingNames, incomingNames []string
+			for _, r := range tc.existingMuteIntervals {
+				existingNames = append(existingNames, r.Name)
+			}
+			for _, r := range tc.existingTimeIntervals {
+				existingNames = append(existingNames, r.Name)
+			}
+			for _, r := range tc.incomingTimeIntervals {
+				incomingNames = append(incomingNames, r.Name)
+			}
+			for _, r := range tc.incomingMuteIntervals {
+				incomingNames = append(incomingNames, r.Name)
+			}
+
+			actualTimeIntervals, actualRenames := MergeTimeIntervals(tc.existingMuteIntervals, tc.existingTimeIntervals, tc.incomingMuteIntervals, tc.incomingTimeIntervals, suffix)
+			assert.Equal(t, tc.expected, actualTimeIntervals)
+			assert.EqualValues(t, tc.expectedRenames, actualRenames)
+
+			// check that existing and incoming lists are not changed
+			var names []string
+			for _, r := range tc.existingMuteIntervals {
+				names = append(names, r.Name)
+			}
+			for _, r := range tc.existingTimeIntervals {
+				names = append(names, r.Name)
+			}
+			assert.Equal(t, existingNames, names)
+			names = nil
+			for _, r := range tc.incomingTimeIntervals {
+				names = append(names, r.Name)
+			}
+			for _, r := range tc.incomingMuteIntervals {
+				names = append(names, r.Name)
+			}
+			assert.Equal(t, incomingNames, names)
+		})
+	}
+}
+
+func load(t *testing.T, yaml string, mutate ...func(p *definition.PostableApiAlertingConfig)) *definition.PostableApiAlertingConfig {
+	t.Helper()
+	p, err := definition.LoadCompat([]byte(yaml))
+	require.NoError(t, err)
+	for _, m := range mutate {
+		m(p)
+	}
+	return p
+}
+
+const fullGrafanaConfig = `
+mute_time_intervals:
+  - name: mti-1
+    time_intervals:
+    - times:
+      - start_time: 00:00
+        end_time: 12:00
+time_intervals:
+  - name: ti-1
+    time_intervals:
+    - weekdays:
+      - saturday
+      - sunday
+inhibit_rules:
+    - source_matchers:
+        - alertname="test"
+        - cluster="test1"
+      target_matchers:
+        - alertname="test2"
+        - cluster="test1"
+      equal:
+        - namespace
+route:
+  receiver: grafana-default-email
+  group_by: [test, test2]
+  group_wait: 1m
+  group_interval: 1m
+  repeat_interval: 1m
+  routes:
+  - receiver: test-webhook
+    object_matchers:
+    - - team
+      - =
+      - teamC
+    group_by:
+    - teste
+    - test2f
+    group_wait: 0s
+    group_interval: 1m
+    repeat_interval: 1m
+    mute_time_intervals:
+    - mti-1
+    active_time_intervals:
+    - ti-1
+receivers:
+  - name: grafana-default-email
+    grafana_managed_receiver_configs:
+      - uid: uxwfZvtnz
+        type: email
+        disableResolveMessage: false
+        settings:
+          addresses: "<example@email.com>"
+        secureFields: {}
+  - name: test-webhook
+    grafana_managed_receiver_configs:
+      - uid: 12345
+        type: webhook
+        disableResolveMessage: false
+        settings:
+          url: "http://localhost/api/v1/alerts"
+        secureFields: {}
+`
+
+const fullMimirConfig = `
+mute_time_intervals:
+  - name: mti-2
+    time_intervals:
+      - times:
+          - start_time: 00:00
+            end_time: 12:00
+time_intervals:
+  - name: ti-2
+    time_intervals:
+    - weekdays:
+      - monday
+      - tuesday
+      - wednesday
+      - thursday
+      - friday
+inhibit_rules:
+    - source_matchers:
+        - alertname="test"
+      target_matchers:
+        - servicename="test2"
+      equal:
+        - namespace
+route:
+  receiver: recv
+  group_by:
+    - alertname
+    - groupby
+  group_wait: 65s
+  group_interval: 20m
+  repeat_interval: 10h   
+  routes:
+    - receiver: recv2
+      object_matchers:
+        - - team
+          - =
+          - teamC
+      group_by:
+        - teste
+        - test2f
+      group_wait: 0s
+      group_interval: 1m
+      repeat_interval: 1m
+      mute_time_intervals:
+        - mti-2
+      active_time_intervals:
+        - ti-2
+receivers:
+  - name: recv
+    email_configs:
+      - to: recv
+        smarthost: smtp.example.org:587
+        from: email@example.com
+  - name: recv2
+    webhook_configs:
+      - url: http://localhost
+`
+
+const fullMergedConfig = `
+route:
+    receiver: grafana-default-email
+    group_by:
+        - test
+        - test2
+    group_wait: 1m
+    group_interval: 1m
+    repeat_interval: 1m
+    routes:
+        - receiver: recv
+          group_by:
+            - alertname
+            - groupby
+          group_wait: 65s
+          group_interval: 20m
+          repeat_interval: 10h        
+          matchers:
+            - __mimir__="true"
+            - __datasource_uid__="12345"
+          routes:
+            - receiver: recv2
+              group_by:
+                - teste
+                - test2f
+              object_matchers:
+                - - team
+                  - =
+                  - teamC
+              mute_time_intervals:
+                - mti-2
+              active_time_intervals:
+                - ti-2
+              group_wait: 0s
+              group_interval: 1m
+              repeat_interval: 1m
+        - receiver: test-webhook
+          group_by:
+            - teste
+            - test2f
+          object_matchers:
+            - - team
+              - =
+              - teamC
+          mute_time_intervals:
+            - mti-1
+          active_time_intervals:
+            - ti-1
+          group_wait: 0s
+          group_interval: 1m
+          repeat_interval: 1m
+mute_time_intervals:
+    - name: mti-1
+      time_intervals:
+        - times:
+            - start_time: "00:00"
+              end_time: "12:00"
+time_intervals:
+    - name: ti-1
+      time_intervals:
+        - weekdays: 
+          - saturday
+          - sunday
+    - name: ti-2
+      time_intervals:
+        - weekdays:
+          - monday
+          - tuesday
+          - wednesday
+          - thursday
+          - friday
+    - name: mti-2
+      time_intervals:
+        - times:
+            - start_time: "00:00"
+              end_time: "12:00"
+receivers:
+    - name: grafana-default-email
+      grafana_managed_receiver_configs:
+        - uid: uxwfZvtnz
+          type: email
+          disableResolveMessage: false
+          settings:
+            addresses: <example@email.com>
+    - name: test-webhook
+      grafana_managed_receiver_configs:
+        - uid: "12345"
+          type: webhook
+          disableResolveMessage: false
+          settings:
+            url: http://localhost/api/v1/alerts
+    - name: recv
+      email_configs:
+        - to: recv
+          from: email@example.com
+          smarthost: smtp.example.org:587
+    - name: recv2
+      webhook_configs:
+        - url: http://localhost
+inhibit_rules:
+    - source_matchers:
+        - alertname="test"
+        - cluster="test1"
+      target_matchers:
+        - alertname="test2"
+        - cluster="test1"
+      equal:
+        - namespace
+    - source_matchers:
+        - alertname="test"
+        - __datasource_uid__="12345"
+        - __mimir__="true"
+      target_matchers:
+        - servicename="test2"
+        - __datasource_uid__="12345"
+        - __mimir__="true"
+      equal:
+        - namespace
+
+`

--- a/pkg/services/ngalert/notifier/merge/merge_test.go
+++ b/pkg/services/ngalert/notifier/merge/merge_test.go
@@ -204,7 +204,6 @@ func TestMerge(t *testing.T) {
 							Name: "grafana-default-email_mimir-12345",
 						},
 					})
-
 				}),
 				RenameResources: RenameResources{
 					Receivers: map[string]string{

--- a/pkg/services/ngalert/notifier/routes/service.go
+++ b/pkg/services/ngalert/notifier/routes/service.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/grafana/alerting/definition"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 
@@ -16,6 +15,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage"
+	"github.com/grafana/grafana/pkg/services/ngalert/notifier/merge"
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning/validation"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -276,7 +276,7 @@ func (nps *Service) UpdateManagedRoute(ctx context.Context, orgID int64, name st
 
 	_, err = revision.Config.GetMergedAlertmanagerConfig()
 	if err != nil {
-		if errors.Is(err, definition.ErrSubtreeMatchersConflict) {
+		if errors.Is(err, merge.ErrSubtreeMatchersConflict) {
 			// TODO temporarily get the conflicting matchers
 			return nil, models.MakeErrRouteConflictingMatchers(fmt.Sprintf("%s", revision.Config.ExtraConfigs[0].MergeMatchers))
 		}

--- a/pkg/services/ngalert/provisioning/notification_policies.go
+++ b/pkg/services/ngalert/provisioning/notification_policies.go
@@ -5,13 +5,12 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/grafana/alerting/definition"
-
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage"
+	"github.com/grafana/grafana/pkg/services/ngalert/notifier/merge"
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning/validation"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -96,7 +95,7 @@ func (nps *NotificationPolicyService) UpdatePolicyTree(ctx context.Context, orgI
 
 	_, err = revision.Config.GetMergedAlertmanagerConfig()
 	if err != nil {
-		if errors.Is(err, definition.ErrSubtreeMatchersConflict) {
+		if errors.Is(err, merge.ErrSubtreeMatchersConflict) {
 			// TODO temporarily get the conflicting matchers
 			return definitions.Route{}, "", models.MakeErrRouteConflictingMatchers(fmt.Sprintf("%s", revision.Config.ExtraConfigs[0].MergeMatchers))
 		}


### PR DESCRIPTION
**What is this feature?**

Forks the Alertmanager configuration merge logic from
\`github.com/grafana/alerting/definition\` into a new Grafana-local package
\`pkg/services/ngalert/notifier/merge\`. The merge functions (\`Merge\`,
\`MergeReceivers\`, \`MergeTimeIntervals\`, \`MergeRoutes\`, \`MergeInhibitRules\`,
\`RenameResourceUsagesInRoutes\`, \`DeduplicateResources\`) and their helpers
now live in Grafana, alongside the matching upstream tests as a regression
net.

A second commit moves \`PostableUserConfig.GetMergedAlertmanagerConfig\` into
the merge package as a function. The wrapping \`MergeResult\` struct in
\`tooling/definitions\` is gone — its \`Identifier\` / \`ExtraRoute\` /
\`ExtraInhibitRules\` fields and the \`LogContext\` method are now on
\`merge.MergeResult\` directly. \`PostableUserConfig.GetMergedAlertmanagerConfig\`
stays as a thin shim that parses the staged extra config YAML and
delegates.

The wire-format types (\`PostableApiAlertingConfig\`, \`Route\`,
\`PostableApiReceiver\`, etc.) continue to come from the upstream package;
only the merge logic is forked.

**Why do we need this feature?**

To enable upcoming changes to the merge behaviour — adding a managed-route
output mode, integration UID generation, and template merging — without
coupling the cadence of those changes to the upstream alerting library
release cycle. This PR is intentionally a pure refactor with no behaviour
change so the diff stays trivial to review and the follow-up PRs can focus
on each new capability in turn.

**Who is this feature for?**

Grafana developers working on the Alertmanager imports / convert API
flow. End-user behaviour is unchanged.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

- Two commits, both pure refactors:
  1. \`Alerting: fork merge logic into a Grafana-local package\` —
     copy of \`merge.go\` and \`merge_test.go\` into the new package, plus
     migration of every Grafana call site and error reference.
  2. \`Alerting: move GetMergedAlertmanagerConfig into the merge package\`
     — function moved out of \`PostableUserConfig\` (left as a thin shim);
     wrapping \`MergeResult\` collapsed into \`merge.MergeResult\`.
- The forked \`merge_test.go\` is a verbatim copy of the upstream test
  file, with bare type references prefixed with \`definition.\` where
  needed and the package name swapped.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. (n/a — pure refactor)
- [x] The docs are updated, and if this is a notable improvement, it's added to our What's New doc. (n/a — internal refactor)