### PR TITLE
Alerting: return 409 when changing provenance isn't allowed in provisioning APIs

### DIFF
--- a/pkg/services/ngalert/provisioning/alert_rules.go
+++ b/pkg/services/ngalert/provisioning/alert_rules.go
@@ -820,7 +820,13 @@ func (service *AlertRuleService) UpdateAlertRule(ctx context.Context, user ident
 		return models.AlertRule{}, err
 	}
 	if storedProvenance != provenance && storedProvenance != models.ProvenanceNone {
-		return models.AlertRule{}, fmt.Errorf("cannot change provenance from '%s' to '%s'", storedProvenance, provenance)
+		return models.AlertRule{}, errProvenanceMismatch.Build(errutil.TemplateData{
+			Public: map[string]interface{}{
+				"ProvidedProvenance": provenance,
+				"StoredProvenance":   storedProvenance,
+				"Operation":          "update",
+			},
+		})
 	}
 	if rule.NotificationSettings != nil {
 		validator, err := service.nsValidatorProvider.Validator(ctx, rule.OrgID)

--- a/pkg/services/ngalert/provisioning/alert_rules_test.go
+++ b/pkg/services/ngalert/provisioning/alert_rules_test.go
@@ -626,6 +626,7 @@ func TestIntegrationAlertRuleService(t *testing.T) {
 					require.NoError(t, err)
 				} else {
 					require.Error(t, err)
+					require.True(t, errProvenanceMismatch.Base.Is(err))
 				}
 			})
 		}


### PR DESCRIPTION
**What is this feature?**

This PR changes the error code we return from the provisioning API when disabling provenance isn't allowed to be a 409. Specifically this reuses the error and message we throw in the other provisioning handlers for consistency.

**Why do we need this feature?**

We currently throw a 500 which is incorrect as this case is an explicitly disallowed request, not an internal server error.

**Who is this feature for?**

Users of the provisioning APIs.