### PR TITLE
feat(settings): add cache miss counter to remote settings service

### DIFF
--- a/pkg/services/setting/service.go
+++ b/pkg/services/setting/service.go
@@ -78,6 +78,7 @@ type clientMetrics struct {
 	listResultSize           prometheus.Histogram
 	rateLimiterThrottleTotal prometheus.Counter
 	cacheHitTotal            prometheus.Counter
+	cacheMissTotal           prometheus.Counter
 }
 
 // Service retrieves configuration settings from a remote settings service.
@@ -322,6 +323,7 @@ func (s *remoteSettingService) List(ctx context.Context, labelSelector metav1.La
 		}
 	}
 
+	s.metrics.cacheMissTotal.Inc()
 	allSettings, err := s.fetch(ctx, namespace, lSelector, span)
 	if err != nil {
 		oErr = err
@@ -647,6 +649,12 @@ func initMetrics() clientMetrics {
 			Name:      "list_settings_cache_hit_total",
 			Help:      "Total number of List cache hits",
 		}),
+		cacheMissTotal: prometheus.NewCounter(prometheus.CounterOpts{
+			Namespace: "settings",
+			Subsystem: "service",
+			Name:      "list_settings_cache_miss_total",
+			Help:      "Total number of List cache misses",
+		}),
 	}
 	return metrics
 }
@@ -656,6 +664,7 @@ func (s *remoteSettingService) Describe(descs chan<- *prometheus.Desc) {
 	s.metrics.listResultSize.Describe(descs)
 	s.metrics.rateLimiterThrottleTotal.Describe(descs)
 	s.metrics.cacheHitTotal.Describe(descs)
+	s.metrics.cacheMissTotal.Describe(descs)
 }
 
 func (s *remoteSettingService) Collect(metrics chan<- prometheus.Metric) {
@@ -663,4 +672,5 @@ func (s *remoteSettingService) Collect(metrics chan<- prometheus.Metric) {
 	s.metrics.listResultSize.Collect(metrics)
 	s.metrics.rateLimiterThrottleTotal.Collect(metrics)
 	s.metrics.cacheHitTotal.Collect(metrics)
+	s.metrics.cacheMissTotal.Collect(metrics)
 }

--- a/pkg/services/setting/service_test.go
+++ b/pkg/services/setting/service_test.go
@@ -693,6 +693,7 @@ func TestListCache(t *testing.T) {
 
 		remoteClient := client.(*remoteSettingService)
 		assert.Equal(t, float64(1), testutil.ToFloat64(remoteClient.metrics.cacheHitTotal))
+		assert.Equal(t, float64(1), testutil.ToFloat64(remoteClient.metrics.cacheMissTotal))
 	})
 
 	t.Run("should miss cache for different selectors", func(t *testing.T) {
@@ -795,6 +796,7 @@ func TestListCache(t *testing.T) {
 		remoteClient := client.(*remoteSettingService)
 		assert.NotNil(t, remoteClient.cache, "cache should be enabled by default")
 		assert.NotNil(t, remoteClient.metrics.cacheHitTotal, "cacheHitTotal should be set when cache enabled")
+		assert.NotNil(t, remoteClient.metrics.cacheMissTotal, "cacheMissTotal should be set when cache enabled")
 	})
 
 	t.Run("should not observe listResultSize on cache hit", func(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

Adds a `settings_service_list_settings_cache_miss_total` Prometheus counter alongside the existing hit counter

**Why do we need this feature?**

It enables operators to compute the cache hit/miss ratio (hits / (hits + misses)) for the remote settings service List path.

**Who is this feature for?**


**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
