### PR TITLE
KV: add EventualKVProvider for deferred store resolution

### DIFF
--- a/pkg/infra/leaderelection/kv_lease_elector.go
+++ b/pkg/infra/leaderelection/kv_lease_elector.go
@@ -1,0 +1,219 @@
+package leaderelection
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/storage/unified/resource/kv"
+	"github.com/grafana/grafana/pkg/storage/unified/resource/lease"
+)
+
+// KVLeaseElector implements Elector using the KV store lease primitive.
+// It is used for leader election in embedded mode where Kubernetes Lease
+// objects are not available.
+type KVLeaseElector struct {
+	kvProvider    *kv.EventualKVProvider
+	leaseName     string
+	identity      string
+	leaseDuration time.Duration
+	renewDeadline time.Duration
+	retryPeriod   time.Duration
+	logger        log.Logger
+	managerOpts   []lease.ManagerOption
+}
+
+// KVLeaseElectorOption configures a KVLeaseElector.
+type KVLeaseElectorOption func(*KVLeaseElector)
+
+// WithManagerOptions passes options to the underlying lease.Manager.
+// Intended for tests that need short TTLs via lease.WithInternalMinTTL.
+func WithManagerOptions(opts ...lease.ManagerOption) KVLeaseElectorOption {
+	return func(e *KVLeaseElector) {
+		e.managerOpts = opts
+	}
+}
+
+// NewKVLeaseElector creates a KVLeaseElector. If cfg.Identity is empty, it is
+// auto-generated from hostname:PID.
+func NewKVLeaseElector(
+	kvProvider *kv.EventualKVProvider,
+	cfg Config,
+	logger log.Logger,
+	opts ...KVLeaseElectorOption,
+) (*KVLeaseElector, error) {
+	if cfg.LeaseName == "" {
+		return nil, fmt.Errorf("leader_election_lease_name must be set")
+	}
+
+	identity := cfg.Identity
+	if identity == "" {
+		hostname, err := os.Hostname()
+		if err != nil {
+			hostname = "unknown"
+		}
+		identity = fmt.Sprintf("%s:%d", hostname, os.Getpid())
+	}
+
+	e := &KVLeaseElector{
+		kvProvider:    kvProvider,
+		leaseName:     cfg.LeaseName,
+		identity:      identity,
+		leaseDuration: cfg.LeaseDuration,
+		renewDeadline: cfg.RenewDeadline,
+		retryPeriod:   cfg.RetryPeriod,
+		logger:        logger,
+	}
+	for _, opt := range opts {
+		opt(e)
+	}
+	return e, nil
+}
+
+func (k *KVLeaseElector) Run(ctx context.Context, fn func(ctx context.Context), opts ...RunOption) error {
+	o := &runOptions{
+		releaseOnCancel: true,
+		onStartedLeading: func(ctx context.Context) {
+			k.logger.Info("Acquired KV lease, starting leader work",
+				"identity", k.identity,
+				"lease", k.leaseName,
+			)
+		},
+		onStoppedLeading: func() {
+			k.logger.Info("Lost KV lease, stopping leader work",
+				"identity", k.identity,
+			)
+		},
+		onNewLeader: func(identity string) {
+			if identity != k.identity {
+				k.logger.Info("New leader elected", "leader", identity)
+			}
+		},
+	}
+	for _, opt := range opts {
+		opt(o)
+	}
+
+	store, err := k.kvProvider.Get(ctx)
+	if err != nil {
+		return fmt.Errorf("waiting for KV store: %w", err)
+	}
+
+	mgr := lease.NewManager(store, k.identity, k.managerOpts...)
+
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+
+		l, err := k.tryAcquire(ctx, mgr)
+		if err != nil {
+			return err
+		}
+		if l == nil {
+			continue
+		}
+
+		k.runAsLeader(ctx, l, mgr, fn, o)
+	}
+}
+
+// tryAcquire attempts to acquire the lease. Returns the lease on success,
+// nil if the lease is held by someone else (after sleeping retryPeriod),
+// or an error if the context is cancelled.
+func (k *KVLeaseElector) tryAcquire(ctx context.Context, mgr *lease.Manager) (*lease.Lease, error) {
+	l, err := mgr.Acquire(ctx, k.leaseName, lease.WithTTL(k.leaseDuration))
+	if err == nil {
+		return l, nil
+	}
+
+	if errors.Is(err, lease.ErrLeaseAlreadyHeld) {
+		select {
+		case <-time.After(k.retryPeriod):
+			return nil, nil
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+
+	return nil, fmt.Errorf("acquiring lease: %w", err)
+}
+
+// runAsLeader runs the leader work function and renewal loop. Returns when
+// leadership is lost or the context is cancelled.
+func (k *KVLeaseElector) runAsLeader(
+	ctx context.Context,
+	l *lease.Lease,
+	mgr *lease.Manager,
+	fn func(ctx context.Context),
+	o *runOptions,
+) {
+	leaderCtx, leaderCancel := context.WithCancel(ctx)
+	defer leaderCancel()
+
+	o.onStartedLeading(leaderCtx)
+
+	done := make(chan struct{})
+	go func() {
+		fn(leaderCtx)
+		close(done)
+	}()
+
+	k.renewLoop(ctx, l, mgr)
+
+	leaderCancel()
+	o.onStoppedLeading()
+
+	if o.releaseOnCancel {
+		if releaseErr := mgr.Release(context.Background(), l); releaseErr != nil {
+			k.logger.Debug("Failed to release lease on shutdown", "error", releaseErr)
+		}
+	}
+
+	<-done
+}
+
+// renewLoop periodically extends the lease. Returns when renewal fails for
+// longer than renewDeadline or the parent context is cancelled.
+func (k *KVLeaseElector) renewLoop(ctx context.Context, l *lease.Lease, mgr *lease.Manager) {
+	ticker := time.NewTicker(k.retryPeriod)
+	defer ticker.Stop()
+
+	var firstFailure time.Time
+
+	for {
+		select {
+		case <-ticker.C:
+			err := mgr.Extend(ctx, l, lease.WithTTL(k.leaseDuration))
+			if err == nil {
+				firstFailure = time.Time{}
+				continue
+			}
+
+			if errors.Is(err, lease.ErrLeaseLost) {
+				k.logger.Warn("Lease lost", "error", err)
+				return
+			}
+
+			now := time.Now()
+			if firstFailure.IsZero() {
+				firstFailure = now
+			}
+			if now.Sub(firstFailure) >= k.renewDeadline {
+				k.logger.Warn("Lease renewal exceeded deadline", "deadline", k.renewDeadline, "error", err)
+				return
+			}
+			k.logger.Warn("Lease renewal failed, retrying", "error", err)
+
+		case <-l.Lost():
+			k.logger.Warn("Lease TTL expired")
+			return
+
+		case <-ctx.Done():
+			return
+		}
+	}
+}

--- a/pkg/infra/leaderelection/kv_lease_elector.go
+++ b/pkg/infra/leaderelection/kv_lease_elector.go
@@ -167,7 +167,7 @@ func (k *KVLeaseElector) runAsLeader(
 	leaderCancel()
 	o.onStoppedLeading()
 
-	if o.releaseOnCancel {
+	if o.releaseOnCancel && ctx.Err() != nil {
 		if releaseErr := mgr.Release(context.Background(), l); releaseErr != nil {
 			k.logger.Debug("Failed to release lease on shutdown", "error", releaseErr)
 		}

--- a/pkg/infra/leaderelection/kv_lease_elector_test.go
+++ b/pkg/infra/leaderelection/kv_lease_elector_test.go
@@ -1,0 +1,317 @@
+package leaderelection
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"iter"
+	"slices"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/storage/unified/resource/kv"
+	"github.com/grafana/grafana/pkg/storage/unified/resource/lease"
+)
+
+func newTestKVProvider(t *testing.T) *kv.EventualKVProvider {
+	t.Helper()
+	p := kv.ProvideEventualKVStore()
+	p.Set(newMapKV())
+	return p
+}
+
+func testConfig() Config {
+	return Config{
+		LeaseName:     "test-lease",
+		Identity:      "test-holder",
+		LeaseDuration: 500 * time.Millisecond,
+		RenewDeadline: 300 * time.Millisecond,
+		RetryPeriod:   100 * time.Millisecond,
+	}
+}
+
+func testElectorOpts() []KVLeaseElectorOption {
+	return []KVLeaseElectorOption{
+		WithManagerOptions(lease.WithInternalMinTTL(50 * time.Millisecond)),
+	}
+}
+
+func TestKVLeaseElector_AcquireLeadership(t *testing.T) {
+	kvp := newTestKVProvider(t)
+	cfg := testConfig()
+
+	elector, err := NewKVLeaseElector(kvp, cfg, log.NewNopLogger(), testElectorOpts()...)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel()
+
+	var leaderCalled atomic.Bool
+	go func() {
+		_ = elector.Run(ctx, func(ctx context.Context) {
+			leaderCalled.Store(true)
+			<-ctx.Done()
+		})
+	}()
+
+	require.Eventually(t, func() bool {
+		return leaderCalled.Load()
+	}, 2*time.Second, 10*time.Millisecond)
+
+	cancel()
+}
+
+func TestKVLeaseElector_GracefulRelease(t *testing.T) {
+	kvp := newTestKVProvider(t)
+	cfg := testConfig()
+
+	elector, err := NewKVLeaseElector(kvp, cfg, log.NewNopLogger(), testElectorOpts()...)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- elector.Run(ctx, func(ctx context.Context) {
+			<-ctx.Done()
+		})
+	}()
+
+	// Wait for leadership to be acquired.
+	time.Sleep(200 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		require.ErrorIs(t, err, context.Canceled)
+	case <-time.After(3 * time.Second):
+		t.Fatal("Run did not return after cancel")
+	}
+}
+
+func TestKVLeaseElector_LeadershipHandoff(t *testing.T) {
+	kvp := newTestKVProvider(t)
+	cfg := testConfig()
+
+	var leader1Called, leader2Called atomic.Bool
+
+	elector1, err := NewKVLeaseElector(kvp, Config{
+		LeaseName:     cfg.LeaseName,
+		Identity:      "holder-1",
+		LeaseDuration: cfg.LeaseDuration,
+		RenewDeadline: cfg.RenewDeadline,
+		RetryPeriod:   cfg.RetryPeriod,
+	}, log.NewNopLogger(), testElectorOpts()...)
+	require.NoError(t, err)
+
+	elector2, err := NewKVLeaseElector(kvp, Config{
+		LeaseName:     cfg.LeaseName,
+		Identity:      "holder-2",
+		LeaseDuration: cfg.LeaseDuration,
+		RenewDeadline: cfg.RenewDeadline,
+		RetryPeriod:   cfg.RetryPeriod,
+	}, log.NewNopLogger(), testElectorOpts()...)
+	require.NoError(t, err)
+
+	ctx1, cancel1 := context.WithCancel(t.Context())
+	ctx2, cancel2 := context.WithTimeout(t.Context(), 5*time.Second)
+	defer cancel2()
+
+	// Start elector 1
+	go func() {
+		_ = elector1.Run(ctx1, func(ctx context.Context) {
+			leader1Called.Store(true)
+			<-ctx.Done()
+		})
+	}()
+
+	// Wait for leader 1 to acquire
+	require.Eventually(t, func() bool {
+		return leader1Called.Load()
+	}, 2*time.Second, 10*time.Millisecond)
+
+	// Start elector 2 (should be blocked)
+	go func() {
+		_ = elector2.Run(ctx2, func(ctx context.Context) {
+			leader2Called.Store(true)
+			<-ctx.Done()
+		})
+	}()
+
+	// Kill leader 1
+	cancel1()
+
+	// Leader 2 should take over within lease duration + retry period.
+	require.Eventually(t, func() bool {
+		return leader2Called.Load()
+	}, 3*time.Second, 50*time.Millisecond)
+
+	cancel2()
+}
+
+func TestKVLeaseElector_IdentityAutoGeneration(t *testing.T) {
+	kvp := newTestKVProvider(t)
+
+	elector, err := NewKVLeaseElector(kvp, Config{
+		LeaseName:     "test-auto-id",
+		Identity:      "",
+		LeaseDuration: time.Second,
+		RenewDeadline: 500 * time.Millisecond,
+		RetryPeriod:   200 * time.Millisecond,
+	}, log.NewNopLogger())
+	require.NoError(t, err)
+	require.NotEmpty(t, elector.identity)
+	require.Contains(t, elector.identity, ":")
+}
+
+func TestKVLeaseElector_MissingLeaseName(t *testing.T) {
+	kvp := newTestKVProvider(t)
+
+	_, err := NewKVLeaseElector(kvp, Config{
+		LeaseName: "",
+	}, log.NewNopLogger())
+	require.Error(t, err)
+	require.ErrorContains(t, err, "leader_election_lease_name")
+}
+
+func TestKVLeaseElector_KVProviderCancelled(t *testing.T) {
+	p := kv.ProvideEventualKVStore() // never set
+	cfg := testConfig()
+
+	elector, err := NewKVLeaseElector(p, cfg, log.NewNopLogger())
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+	defer cancel()
+
+	err = elector.Run(ctx, func(ctx context.Context) {
+		<-ctx.Done()
+	})
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+// mapKV is a minimal in-memory KV for testing the elector.
+type mapKV struct {
+	mu   sync.Mutex
+	data map[string][]byte
+}
+
+func newMapKV() *mapKV {
+	return &mapKV{data: make(map[string][]byte)}
+}
+
+func (m *mapKV) Get(_ context.Context, _, key string) (io.ReadCloser, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	v, ok := m.data[key]
+	if !ok {
+		return nil, kv.ErrNotFound
+	}
+	return io.NopCloser(bytes.NewReader(v)), nil
+}
+
+func (m *mapKV) Keys(_ context.Context, _ string, opt kv.ListOptions) iter.Seq2[string, error] {
+	m.mu.Lock()
+	keys := make([]string, 0, len(m.data))
+	for k := range m.data {
+		if opt.StartKey != "" && k < opt.StartKey {
+			continue
+		}
+		if opt.EndKey != "" && k >= opt.EndKey {
+			continue
+		}
+		keys = append(keys, k)
+	}
+	m.mu.Unlock()
+
+	slices.Sort(keys)
+	if opt.Sort == kv.SortOrderDesc {
+		slices.Reverse(keys)
+	}
+	if opt.Limit > 0 && int64(len(keys)) > opt.Limit {
+		keys = keys[:opt.Limit]
+	}
+
+	return func(yield func(string, error) bool) {
+		for _, k := range keys {
+			if !yield(k, nil) {
+				return
+			}
+		}
+	}
+}
+
+func (m *mapKV) Batch(_ context.Context, _ string, ops []kv.BatchOp) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	snapshot := make(map[string][]byte, len(m.data))
+	for k, v := range m.data {
+		snapshot[k] = v
+	}
+
+	for i, op := range ops {
+		switch op.Mode {
+		case kv.BatchOpCreate:
+			if len(op.Value) == 0 {
+				m.data = snapshot
+				return &kv.BatchError{Err: kv.ErrEmptyValue, Index: i, Op: op}
+			}
+			if _, exists := m.data[op.Key]; exists {
+				m.data = snapshot
+				return &kv.BatchError{Err: kv.ErrKeyAlreadyExists, Index: i, Op: op}
+			}
+			v := make([]byte, len(op.Value))
+			copy(v, op.Value)
+			m.data[op.Key] = v
+		default:
+			panic(fmt.Sprintf("mapKV: Batch mode %d not implemented", op.Mode))
+		}
+	}
+	return nil
+}
+
+func (m *mapKV) Save(_ context.Context, _, key string) (io.WriteCloser, error) {
+	return &mapKVWriter{m: m, key: key}, nil
+}
+
+type mapKVWriter struct {
+	m   *mapKV
+	key string
+	buf bytes.Buffer
+}
+
+func (w *mapKVWriter) Write(p []byte) (int, error) { return w.buf.Write(p) }
+
+func (w *mapKVWriter) Close() error {
+	data := w.buf.Bytes()
+	if len(data) == 0 {
+		return kv.ErrEmptyValue
+	}
+	w.m.mu.Lock()
+	defer w.m.mu.Unlock()
+	w.m.data[w.key] = data
+	return nil
+}
+
+func (m *mapKV) Delete(context.Context, string, string) error {
+	panic("not implemented")
+}
+
+func (m *mapKV) BatchGet(context.Context, string, []string) iter.Seq2[kv.KeyValue, error] {
+	panic("not implemented")
+}
+
+func (m *mapKV) BatchDelete(context.Context, string, []string) error {
+	panic("not implemented")
+}
+
+func (m *mapKV) UnixTimestamp(context.Context) (int64, error) {
+	panic("not implemented")
+}

--- a/pkg/server/module_server.go
+++ b/pkg/server/module_server.go
@@ -34,6 +34,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/licensing"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	resourcekv "github.com/grafana/grafana/pkg/storage/unified/resource/kv"
 	"github.com/grafana/grafana/pkg/storage/unified/search/vector"
 	"github.com/grafana/grafana/pkg/storage/unified/sql"
 	"go.opentelemetry.io/otel"
@@ -56,8 +57,9 @@ func NewModule(opts Options,
 	hooksService *hooks.HooksService,
 	storeProvider zStore.StoreProvider,
 	reconcileCRDs []schema.GroupVersionResource,
+	kvProvider *resourcekv.EventualKVProvider,
 ) (*ModuleServer, error) {
-	s, err := newModuleServer(opts, apiOpts, features, cfg, storageMetrics, indexMetrics, reg, promGatherer, license, moduleRegisterer, storageBackend, hooksService, storeProvider, reconcileCRDs)
+	s, err := newModuleServer(opts, apiOpts, features, cfg, storageMetrics, indexMetrics, reg, promGatherer, license, moduleRegisterer, storageBackend, hooksService, storeProvider, reconcileCRDs, kvProvider)
 	if err != nil {
 		return nil, err
 	}
@@ -83,6 +85,7 @@ func newModuleServer(opts Options,
 	hooksService *hooks.HooksService,
 	storeProvider zStore.StoreProvider,
 	reconcileCRDs []schema.GroupVersionResource,
+	kvProvider *resourcekv.EventualKVProvider,
 ) (*ModuleServer, error) {
 	rootCtx, shutdownFn := context.WithCancel(context.Background())
 
@@ -117,6 +120,7 @@ func newModuleServer(opts Options,
 		healthNotifier:   NewHealthNotifier(),
 		storeProvider:    storeProvider,
 		reconcileCRDs:    reconcileCRDs,
+		kvProvider:       kvProvider,
 	}
 
 	return s, nil
@@ -143,6 +147,7 @@ type ModuleServer struct {
 	searchClient     resourcepb.ResourceIndexClient
 	storageMetrics   *resource.StorageMetrics
 	indexMetrics     *resource.BleveIndexMetrics
+	kvProvider       *resourcekv.EventualKVProvider
 	license          licensing.Licensing
 
 	pidFile     string
@@ -234,7 +239,7 @@ func (s *ModuleServer) Run() error {
 		if s.storageBackend == nil {
 			// If storage server not being used, disable GC, pruner, and RV manager
 			disableStorageServices := !m.IsModuleEnabled(modules.StorageServer)
-			s.storageBackend, err = sql.NewStorageBackend(s.cfg, nil, s.registerer, s.storageMetrics, disableStorageServices)
+			s.storageBackend, err = sql.NewStorageBackend(s.cfg, nil, s.registerer, s.storageMetrics, disableStorageServices, s.kvProvider)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/server/search_server_distributor_test.go
+++ b/pkg/server/search_server_distributor_test.go
@@ -367,7 +367,7 @@ func initModuleServerForTest(
 	tracer := tracing.InitializeTracerForTest()
 	hooksService := hooks.ProvideService()
 	license := &licensing.OSSLicensingService{}
-	ms, err := NewModule(opts, apiOpts, featuremgmt.WithFeatures(), cfg, nil, nil, prometheus.NewRegistry(), prometheus.DefaultGatherer, tracer, license, ProvideNoopModuleRegisterer(), nil, hooksService, zStore.ProvideDefaultStoreProvider(), nil)
+	ms, err := NewModule(opts, apiOpts, featuremgmt.WithFeatures(), cfg, nil, nil, prometheus.NewRegistry(), prometheus.DefaultGatherer, tracer, license, ProvideNoopModuleRegisterer(), nil, hooksService, zStore.ProvideDefaultStoreProvider(), nil, nil)
 	require.NoError(t, err)
 
 	conn, err := grpc.NewClient(cfg.GRPCServer.Address,
@@ -399,7 +399,7 @@ func createBaselineServer(t *testing.T, dbType, dbConnStr string, testNamespaces
 	searchOpts, err := search.NewSearchOptions(features, cfg, docBuilders, nil, nil)
 	require.NoError(t, err)
 	cfg.DisablePruner = dbType == "sqlite3"
-	backend, err := sql.NewStorageBackend(cfg, nil, nil, nil, false)
+	backend, err := sql.NewStorageBackend(cfg, nil, nil, nil, false, nil)
 	require.NoError(t, err)
 	backendService := backend.(services.Service)
 	require.NotNil(t, backendService)

--- a/pkg/server/wire_gen.go
+++ b/pkg/server/wire_gen.go
@@ -274,6 +274,7 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified"
 	migrations2 "github.com/grafana/grafana/pkg/storage/unified/migrations"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/grafana/grafana/pkg/storage/unified/resource/kv"
 	"github.com/grafana/grafana/pkg/storage/unified/search"
 	"github.com/grafana/grafana/pkg/storage/unified/search/builders"
 	"github.com/grafana/grafana/pkg/storage/unified/search/vector"
@@ -1884,7 +1885,8 @@ func InitializeModuleServer(cfg *setting.Cfg, opts Options, apiOpts api.ServerOp
 	}
 	storeProvider := store2.ProvideDefaultStoreProvider()
 	v := authz.ProvideReconcileCRDs()
-	moduleServer, err := NewModule(opts, apiOpts, featureToggles, cfg, storageMetrics, bleveIndexMetrics, registerer, gatherer, tracingService, ossLicensingService, moduleRegisterer, storageBackend, hooksService, storeProvider, v)
+	eventualKVProvider := kv.ProvideEventualKVStore()
+	moduleServer, err := NewModule(opts, apiOpts, featureToggles, cfg, storageMetrics, bleveIndexMetrics, registerer, gatherer, tracingService, ossLicensingService, moduleRegisterer, storageBackend, hooksService, storeProvider, v, eventualKVProvider)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/server/wire_gen.go
+++ b/pkg/server/wire_gen.go
@@ -440,7 +440,8 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts Options, apiOpts api
 	registerer := metrics.ProvideRegisterer()
 	storeProvider := store2.ProvideDefaultStoreProvider()
 	v := authz.ProvideReconcileCRDs()
-	server, err := authz.ProvideEmbeddedZanzanaServer(cfg, sqlStore, tracingService, featureToggles, registerer, eventualRestConfigProvider, storeProvider, v)
+	eventualKVProvider := kv.ProvideEventualKVStore()
+	server, err := authz.ProvideEmbeddedZanzanaServer(cfg, sqlStore, tracingService, featureToggles, registerer, eventualRestConfigProvider, storeProvider, v, eventualKVProvider)
 	if err != nil {
 		return nil, err
 	}
@@ -1146,7 +1147,8 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	registerer := metrics.ProvideRegistererForTest()
 	storeProvider := store2.ProvideDefaultStoreProvider()
 	v := authz.ProvideReconcileCRDs()
-	server, err := authz.ProvideEmbeddedZanzanaServer(cfg, sqlStore, tracingService, featureToggles, registerer, eventualRestConfigProvider, storeProvider, v)
+	eventualKVProvider := kv.ProvideEventualKVStore()
+	server, err := authz.ProvideEmbeddedZanzanaServer(cfg, sqlStore, tracingService, featureToggles, registerer, eventualRestConfigProvider, storeProvider, v, eventualKVProvider)
 	if err != nil {
 		return nil, err
 	}
@@ -1819,7 +1821,8 @@ func InitializeForCLI(ctx context.Context, cfg *setting.Cfg) (Runner, error) {
 	serverLockService := serverlock.ProvideService(sqlStore, tracingService)
 	storeProvider := store2.ProvideDefaultStoreProvider()
 	v := authz.ProvideReconcileCRDs()
-	server, err := authz.ProvideEmbeddedZanzanaServer(cfg, sqlStore, tracingService, featureToggles, registerer, eventualRestConfigProvider, storeProvider, v)
+	eventualKVProvider := kv.ProvideEventualKVStore()
+	server, err := authz.ProvideEmbeddedZanzanaServer(cfg, sqlStore, tracingService, featureToggles, registerer, eventualRestConfigProvider, storeProvider, v, eventualKVProvider)
 	if err != nil {
 		return Runner{}, err
 	}

--- a/pkg/server/wireexts_oss.go
+++ b/pkg/server/wireexts_oss.go
@@ -69,6 +69,7 @@ import (
 	"github.com/grafana/grafana/pkg/storage/legacysql"
 	"github.com/grafana/grafana/pkg/storage/unified"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	resourcekv "github.com/grafana/grafana/pkg/storage/unified/resource/kv"
 	search2 "github.com/grafana/grafana/pkg/storage/unified/search"
 	"github.com/grafana/grafana/pkg/storage/unified/search/builders"
 	"github.com/grafana/grafana/pkg/storage/unified/search/vector"
@@ -167,6 +168,7 @@ var wireExtsBasicSet = wire.NewSet(
 	advisor.ProvideAppInstaller,
 	zStore.ProvideDefaultStoreProvider,
 	authz.ProvideReconcileCRDs,
+	resourcekv.ProvideEventualKVStore,
 )
 
 var wireExtsSet = wire.NewSet(
@@ -217,6 +219,8 @@ var wireExtsModuleServerSet = wire.NewSet(
 	zStore.ProvideDefaultStoreProvider,
 	// Zanzana MT reconciler CRD list
 	authz.ProvideReconcileCRDs,
+	// KV store provider for lease-based leader election
+	resourcekv.ProvideEventualKVStore,
 )
 
 var wireExtsStandaloneAPIServerSet = wire.NewSet(

--- a/pkg/services/authz/zanzana.go
+++ b/pkg/services/authz/zanzana.go
@@ -38,6 +38,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/grpcserver"
 	"github.com/grafana/grafana/pkg/services/grpcserver/interceptors"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/storage/unified/resource/kv"
 )
 
 // ProvideZanzanaClient used to register ZanzanaClient.
@@ -89,7 +90,7 @@ func ProvideZanzanaClient(cfg *setting.Cfg, db db.DB, zanzanaServer zanzana.Serv
 }
 
 // ProvideEmbeddedZanzanaServer creates and registers embedded ZanzanaServer.
-func ProvideEmbeddedZanzanaServer(cfg *setting.Cfg, db db.DB, tracer tracing.Tracer, features featuremgmt.FeatureToggles, reg prometheus.Registerer, restConfig apiserver.RestConfigProvider, storeProvider zStore.StoreProvider, reconcileCRDs []schema.GroupVersionResource) (zanzana.Server, error) {
+func ProvideEmbeddedZanzanaServer(cfg *setting.Cfg, db db.DB, tracer tracing.Tracer, features featuremgmt.FeatureToggles, reg prometheus.Registerer, restConfig apiserver.RestConfigProvider, storeProvider zStore.StoreProvider, reconcileCRDs []schema.GroupVersionResource, kvProvider *kv.EventualKVProvider) (zanzana.Server, error) {
 	//nolint:staticcheck // not yet migrated to OpenFeature
 	if !features.IsEnabledGlobally(featuremgmt.FlagZanzana) {
 		return zServer.NewNoopServer(), nil
@@ -102,7 +103,7 @@ func ProvideEmbeddedZanzanaServer(cfg *setting.Cfg, db db.DB, tracer tracing.Tra
 		return nil, fmt.Errorf("failed to create zanzana store: %w", err)
 	}
 
-	srv, err := zServer.NewEmbeddedZanzanaServer(cfg, store, logger, tracer, reg, restConfig, reconcileCRDs)
+	srv, err := zServer.NewEmbeddedZanzanaServer(cfg, store, logger, tracer, reg, restConfig, reconcileCRDs, kvProvider)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start zanzana: %w", err)
 	}

--- a/pkg/services/authz/zanzana/server/server.go
+++ b/pkg/services/authz/zanzana/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -35,6 +36,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/authz/zanzana/common"
 	"github.com/grafana/grafana/pkg/services/authz/zanzana/server/reconciler"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/storage/unified/resource/kv"
 )
 
 const cacheCleanInterval = 2 * time.Minute
@@ -72,13 +74,13 @@ type Server struct {
 	nsLimiterSize     int64
 }
 
-func NewEmbeddedZanzanaServer(cfg *setting.Cfg, store storage.OpenFGADatastore, logger log.Logger, tracer tracing.Tracer, reg prometheus.Registerer, restConfig apiserver.RestConfigProvider, reconcileCRDs []schema.GroupVersionResource) (*Server, error) {
+func NewEmbeddedZanzanaServer(cfg *setting.Cfg, store storage.OpenFGADatastore, logger log.Logger, tracer tracing.Tracer, reg prometheus.Registerer, restConfig apiserver.RestConfigProvider, reconcileCRDs []schema.GroupVersionResource, kvProvider *kv.EventualKVProvider) (*Server, error) {
 	openfga, err := NewOpenFGAServer(cfg.ZanzanaServer, store)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start zanzana: %w", err)
 	}
 
-	return newServer(cfg, openfga, store, logger, tracer, reg, restConfig, reconcileCRDs)
+	return newServer(cfg, openfga, store, logger, tracer, reg, restConfig, reconcileCRDs, kvProvider)
 }
 
 func NewZanzanaServer(cfg *setting.Cfg, store storage.OpenFGADatastore, logger log.Logger, tracer tracing.Tracer, reg prometheus.Registerer, reconcileCRDs []schema.GroupVersionResource) (*Server, error) {
@@ -87,10 +89,10 @@ func NewZanzanaServer(cfg *setting.Cfg, store storage.OpenFGADatastore, logger l
 		return nil, fmt.Errorf("failed to start zanzana: %w", err)
 	}
 
-	return newServer(cfg, openfgaServer, store, logger, tracer, reg, nil, reconcileCRDs)
+	return newServer(cfg, openfgaServer, store, logger, tracer, reg, nil, reconcileCRDs, nil)
 }
 
-func newServer(cfg *setting.Cfg, openfga OpenFGAServer, store storage.OpenFGADatastore, logger log.Logger, tracer tracing.Tracer, reg prometheus.Registerer, restConfig apiserver.RestConfigProvider, reconcileCRDs []schema.GroupVersionResource) (*Server, error) {
+func newServer(cfg *setting.Cfg, openfga OpenFGAServer, store storage.OpenFGADatastore, logger log.Logger, tracer tracing.Tracer, reg prometheus.Registerer, restConfig apiserver.RestConfigProvider, reconcileCRDs []schema.GroupVersionResource, kvProvider *kv.EventualKVProvider) (*Server, error) {
 	channel := &inprocgrpc.Channel{}
 	openfgav1.RegisterOpenFGAServiceServer(channel, openfga)
 	openFGAClient := openfgav1.NewOpenFGAServiceClient(channel)
@@ -184,17 +186,32 @@ func newServer(cfg *setting.Cfg, openfga OpenFGAServer, store storage.OpenFGADat
 
 		var le leaderelection.Elector
 		if cfg.ZanzanaReconciler.LeaderElection.Enabled {
-			restCfg, err := clientrest.InClusterConfig()
-			if err != nil {
-				return nil, fmt.Errorf("failed to get in-cluster config for leader election: %w", err)
-			}
-			le, err = leaderelection.NewKubernetesElector(
-				restCfg,
-				cfg.ZanzanaReconciler.LeaderElection,
-				reconcilerLogger,
-			)
-			if err != nil {
-				return nil, fmt.Errorf("failed to create leader elector: %w", err)
+			if restConfig != nil {
+				// Embedded mode: use KV lease elector
+				if kvProvider == nil {
+					return nil, fmt.Errorf("KV lease leader election requires unified storage KV backend")
+				}
+				leCfg := cfg.ZanzanaReconciler.LeaderElection
+				leCfg.Identity = resolveIdentity(cfg)
+				var leErr error
+				le, leErr = leaderelection.NewKVLeaseElector(kvProvider, leCfg, reconcilerLogger)
+				if leErr != nil {
+					return nil, fmt.Errorf("failed to create KV lease elector: %w", leErr)
+				}
+			} else {
+				// Standalone mode: use K8s elector
+				restCfg, err := clientrest.InClusterConfig()
+				if err != nil {
+					return nil, fmt.Errorf("failed to get in-cluster config for leader election: %w", err)
+				}
+				le, err = leaderelection.NewKubernetesElector(
+					restCfg,
+					cfg.ZanzanaReconciler.LeaderElection,
+					reconcilerLogger,
+				)
+				if err != nil {
+					return nil, fmt.Errorf("failed to create leader elector: %w", err)
+				}
 			}
 		} else {
 			le = leaderelection.NewDefaultElector()
@@ -224,6 +241,20 @@ func newServer(cfg *setting.Cfg, openfga OpenFGAServer, store storage.OpenFGADat
 	s.mtReconciler = mtReconciler
 
 	return s, nil
+}
+
+func resolveIdentity(cfg *setting.Cfg) string {
+	if id := cfg.ZanzanaReconciler.LeaderElection.Identity; id != "" {
+		return id
+	}
+	if id := cfg.InstanceID; id != "" {
+		return id
+	}
+	hostname, err := os.Hostname()
+	if err != nil {
+		hostname = "unknown"
+	}
+	return fmt.Sprintf("%s:%d", hostname, os.Getpid())
 }
 
 func (s *Server) RunReconciler(ctx context.Context) error {

--- a/pkg/services/authz/zanzana/server/server_bench_test.go
+++ b/pkg/services/authz/zanzana/server/server_bench_test.go
@@ -353,7 +353,7 @@ func setupBenchmarkServer(b *testing.B) (*Server, *benchmarkData) {
 	store, err := zStore.NewEmbeddedStore(cfg, testStore, log.NewNopLogger())
 	require.NoError(b, err)
 
-	srv, err := NewEmbeddedZanzanaServer(cfg, store, log.NewNopLogger(), tracing.NewNoopTracerService(), prometheus.NewRegistry(), nil, nil)
+	srv, err := NewEmbeddedZanzanaServer(cfg, store, log.NewNopLogger(), tracing.NewNoopTracerService(), prometheus.NewRegistry(), nil, nil, nil)
 	require.NoError(b, err)
 
 	// Generate test data
@@ -453,7 +453,7 @@ func setupSubresourceDepthBenchmarkServer(b *testing.B, childrenPerLevel, depth 
 	store, err := zStore.NewEmbeddedStore(cfg, testStore, log.NewNopLogger())
 	require.NoError(b, err)
 
-	srv, err := NewEmbeddedZanzanaServer(cfg, store, log.NewNopLogger(), tracing.NewNoopTracerService(), prometheus.NewRegistry(), nil, nil)
+	srv, err := NewEmbeddedZanzanaServer(cfg, store, log.NewNopLogger(), tracing.NewNoopTracerService(), prometheus.NewRegistry(), nil, nil, nil)
 	require.NoError(b, err)
 
 	// Build only the hierarchy needed to force TTU walks.

--- a/pkg/services/authz/zanzana/server/server_list_test.go
+++ b/pkg/services/authz/zanzana/server/server_list_test.go
@@ -396,7 +396,7 @@ func TestIntegrationServerListStreamDeadline(t *testing.T) {
 	store, err := zStore.NewEmbeddedStore(cfg, testStore, log.NewNopLogger())
 	require.NoError(t, err)
 
-	srv, err := NewEmbeddedZanzanaServer(cfg, store, log.NewNopLogger(), tracing.NewNoopTracerService(), prometheus.NewRegistry(), nil, nil)
+	srv, err := NewEmbeddedZanzanaServer(cfg, store, log.NewNopLogger(), tracing.NewNoopTracerService(), prometheus.NewRegistry(), nil, nil, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { srv.Close() })
 

--- a/pkg/services/authz/zanzana/server/server_test.go
+++ b/pkg/services/authz/zanzana/server/server_test.go
@@ -96,7 +96,7 @@ func setupOpenFGAServer(t *testing.T) *Server {
 	store, err := zStore.NewEmbeddedStore(cfg, testStore, log.NewNopLogger())
 	require.NoError(t, err)
 
-	srv, err := NewEmbeddedZanzanaServer(cfg, store, log.NewNopLogger(), tracing.NewNoopTracerService(), prometheus.NewRegistry(), nil, nil)
+	srv, err := NewEmbeddedZanzanaServer(cfg, store, log.NewNopLogger(), tracing.NewNoopTracerService(), prometheus.NewRegistry(), nil, nil, nil)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/pkg/storage/unified/client.go
+++ b/pkg/storage/unified/client.go
@@ -102,7 +102,7 @@ func newClient(opts options.StorageOptions,
 
 	switch opts.StorageType {
 	case options.StorageTypeFile:
-		backend, err := sql.NewFileBackend(cfg)
+		backend, err := sql.NewFileBackend(cfg, nil)
 		if err != nil {
 			return nil, err
 		}
@@ -154,7 +154,7 @@ func newClient(opts options.StorageOptions,
 			return nil, err
 		}
 
-		backend, err := sql.NewStorageBackend(cfg, db, reg, storageMetrics, false)
+		backend, err := sql.NewStorageBackend(cfg, db, reg, storageMetrics, false, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/storage/unified/resource/kv/provider.go
+++ b/pkg/storage/unified/resource/kv/provider.go
@@ -1,0 +1,37 @@
+package kv
+
+import "context"
+
+// EventualKVProvider is a deferred KV store reference that blocks callers
+// until the real store is available. This exists because the KV store is
+// created during module initialization (after Wire DI), while consumers
+// like the lease-based leader elector are constructed during Wire DI.
+//
+// Follows the same pattern as apiserver.eventualRestConfigProvider.
+type EventualKVProvider struct {
+	ready chan struct{}
+	store KV
+}
+
+func ProvideEventualKVStore() *EventualKVProvider {
+	return &EventualKVProvider{
+		ready: make(chan struct{}),
+	}
+}
+
+// Set makes the KV store available to all blocked Get callers. Must be
+// called exactly once; subsequent calls panic.
+func (p *EventualKVProvider) Set(store KV) {
+	p.store = store
+	close(p.ready)
+}
+
+// Get blocks until Set is called or ctx is cancelled.
+func (p *EventualKVProvider) Get(ctx context.Context) (KV, error) {
+	select {
+	case <-p.ready:
+		return p.store, nil
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	}
+}

--- a/pkg/storage/unified/resource/lease/lease.go
+++ b/pkg/storage/unified/resource/lease/lease.go
@@ -55,6 +55,7 @@ type Lease struct {
 	generation int64
 	lostCh     chan struct{}
 	lostOnce   sync.Once
+	timerMu    sync.Mutex
 	lostTimer  *time.Timer
 }
 
@@ -232,6 +233,8 @@ func (m *Manager) Release(ctx context.Context, lease *Lease) error {
 		return fmt.Errorf("releasing %s/%d: %w", lease.name, lease.generation, err)
 	}
 
+	lease.timerMu.Lock()
+	defer lease.timerMu.Unlock()
 	lease.lostTimer.Stop()
 	lease.notifyLoss()
 	return nil
@@ -267,6 +270,8 @@ func (m *Manager) Extend(ctx context.Context, lease *Lease, opts ...AcquireOptio
 		return fmt.Errorf("extending %s/%d: %w", lease.name, lease.generation, err)
 	}
 
+	lease.timerMu.Lock()
+	defer lease.timerMu.Unlock()
 	lease.lostTimer.Stop()
 	lease.lostTimer = time.AfterFunc(time.Until(expires), lease.notifyLoss)
 	return nil

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -107,12 +107,13 @@ func NewStorageBackend(
 	reg prometheus.Registerer,
 	storageMetrics *resource.StorageMetrics,
 	disableStorageServices bool,
+	kvProvider *kv.EventualKVProvider,
 ) (resource.StorageBackend, error) {
 	storageType := options.StorageType(cfg.SectionWithEnvOverrides("grafana-apiserver").Key("storage_type").
 		MustString(string(options.StorageTypeUnified)))
 	switch storageType {
 	case options.StorageTypeFile:
-		return NewFileBackend(cfg)
+		return NewFileBackend(cfg, kvProvider)
 	case options.StorageTypeUnifiedGrpc:
 		return nil, nil
 	default: // fall back to SQL backend
@@ -166,6 +167,10 @@ func NewStorageBackend(
 		return nil, fmt.Errorf("error creating sqlkv: %s", err)
 	}
 
+	if kvProvider != nil {
+		kvProvider.Set(sqlkv)
+	}
+
 	tenantDeleterCfg := resource.NewTenantDeleterConfig(cfg)
 	if tenantDeleterCfg != nil {
 		if gcomClient := newTenantDeleterGcomClient(cfg); gcomClient != nil {
@@ -214,7 +219,7 @@ func NewStorageBackend(
 	return resource.NewKVStorageBackend(kvBackendOpts)
 }
 
-func NewFileBackend(cfg *setting.Cfg) (resource.StorageBackend, error) {
+func NewFileBackend(cfg *setting.Cfg, kvProvider *kv.EventualKVProvider) (resource.StorageBackend, error) {
 	apiserverCfg := cfg.SectionWithEnvOverrides("grafana-apiserver")
 	dataPath := apiserverCfg.Key("storage_path").
 		MustString(filepath.Join(cfg.DataPath, "grafana-apiserver"))
@@ -225,6 +230,9 @@ func NewFileBackend(cfg *setting.Cfg) (resource.StorageBackend, error) {
 	}
 
 	kvStore := resource.NewBadgerKV(db)
+	if kvProvider != nil {
+		kvProvider.Set(kvStore)
+	}
 	return resource.NewKVStorageBackend(resource.KVBackendOptions{
 		KvStore:                 kvStore,
 		Log:                     log.New("storage-backend"),

--- a/pkg/storage/unified/sql/test/integration_test.go
+++ b/pkg/storage/unified/sql/test/integration_test.go
@@ -69,7 +69,7 @@ func newTestBackend(t *testing.T, isHA bool, simulatedNetworkLatency time.Durati
 	if maxOpenConn > 0 {
 		dbSection.Key("max_open_conn").SetValue(strconv.Itoa(maxOpenConn))
 	}
-	backend, err := sql.NewStorageBackend(cfg, dbstore, registerer, storageMetrics, false)
+	backend, err := sql.NewStorageBackend(cfg, dbstore, registerer, storageMetrics, false, nil)
 	require.NoError(t, err)
 	require.NotNil(t, backend)
 	backendService, ok := backend.(services.Service)
@@ -223,7 +223,7 @@ func TestClientServer(t *testing.T) {
 
 	registerer := prometheus.NewPedanticRegistry()
 	storageMetrics := resource.ProvideStorageMetrics(registerer)
-	backend, err := sql.NewStorageBackend(cfg, dbstore, registerer, storageMetrics, false)
+	backend, err := sql.NewStorageBackend(cfg, dbstore, registerer, storageMetrics, false, nil)
 	require.NoError(t, err)
 
 	grpcService, err := grpcserver.ProvideDSKitService(cfg, otel.Tracer("test-grpc-server"), prometheus.NewPedanticRegistry(), "test-grpc-server")
@@ -333,7 +333,7 @@ func TestIntegrationSearchClientServer(t *testing.T) {
 
 	registerer := prometheus.NewPedanticRegistry()
 	storageMetrics := resource.ProvideStorageMetrics(registerer)
-	backend, err := sql.NewStorageBackend(cfg, dbstore, registerer, storageMetrics, false)
+	backend, err := sql.NewStorageBackend(cfg, dbstore, registerer, storageMetrics, false, nil)
 	require.NoError(t, err)
 	backendService := backend.(services.Service)
 	require.NotNil(t, backendService)

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -173,7 +173,7 @@ func StartGrafanaEnvWithManualCleanup(t *testing.T, grafDir, cfgPath string) (st
 		storageMetrics := resource.ProvideStorageMetrics(registerer)
 		env.Cfg.SectionWithEnvOverrides("grafana-apiserver").Key("storage_type").SetValue(string(options.StorageTypeUnified))
 		env.Cfg.DisablePruner = db.IsTestDbSQLite()
-		storageBackend, err := sql.NewStorageBackend(env.Cfg, env.SQLStore, registerer, storageMetrics, false)
+		storageBackend, err := sql.NewStorageBackend(env.Cfg, env.SQLStore, registerer, storageMetrics, false, nil)
 		require.NoError(t, err)
 		require.NotNil(t, storageBackend)
 		backendService := storageBackend.(services.Service)


### PR DESCRIPTION
## Summary
- Add `EventualKVProvider` that blocks `Get()` callers until the real KV store is available via `Set()`
- Bridges the lifecycle gap between Wire DI (where consumers are constructed) and module initialization (where the KV store is created)
- Follows the established `eventualRestConfigProvider` pattern in `pkg/services/apiserver/restconfig.go`

## Stack
1. #124181 Lease: add Extend method
2. **This PR**
3. #... Leader election: add KVLeaseElector
4. #... Wire: thread EventualKVProvider through storage backend
5. #... Zanzana: auto-select KV lease elector for embedded mode

## Test plan
- [x] `go test ./pkg/storage/unified/resource/kv/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)