### PR TITLE
Zanzana: auto-select KV lease elector for embedded mode

### DIFF
--- a/pkg/infra/leaderelection/kv_lease_elector.go
+++ b/pkg/infra/leaderelection/kv_lease_elector.go
@@ -167,7 +167,7 @@ func (k *KVLeaseElector) runAsLeader(
 	leaderCancel()
 	o.onStoppedLeading()
 
-	if o.releaseOnCancel {
+	if o.releaseOnCancel && ctx.Err() != nil {
 		if releaseErr := mgr.Release(context.Background(), l); releaseErr != nil {
 			k.logger.Debug("Failed to release lease on shutdown", "error", releaseErr)
 		}

--- a/pkg/server/wire_gen.go
+++ b/pkg/server/wire_gen.go
@@ -440,7 +440,8 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts Options, apiOpts api
 	registerer := metrics.ProvideRegisterer()
 	storeProvider := store2.ProvideDefaultStoreProvider()
 	v := authz.ProvideReconcileCRDs()
-	server, err := authz.ProvideEmbeddedZanzanaServer(cfg, sqlStore, tracingService, featureToggles, registerer, eventualRestConfigProvider, storeProvider, v)
+	eventualKVProvider := kv.ProvideEventualKVStore()
+	server, err := authz.ProvideEmbeddedZanzanaServer(cfg, sqlStore, tracingService, featureToggles, registerer, eventualRestConfigProvider, storeProvider, v, eventualKVProvider)
 	if err != nil {
 		return nil, err
 	}
@@ -1146,7 +1147,8 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	registerer := metrics.ProvideRegistererForTest()
 	storeProvider := store2.ProvideDefaultStoreProvider()
 	v := authz.ProvideReconcileCRDs()
-	server, err := authz.ProvideEmbeddedZanzanaServer(cfg, sqlStore, tracingService, featureToggles, registerer, eventualRestConfigProvider, storeProvider, v)
+	eventualKVProvider := kv.ProvideEventualKVStore()
+	server, err := authz.ProvideEmbeddedZanzanaServer(cfg, sqlStore, tracingService, featureToggles, registerer, eventualRestConfigProvider, storeProvider, v, eventualKVProvider)
 	if err != nil {
 		return nil, err
 	}
@@ -1819,7 +1821,8 @@ func InitializeForCLI(ctx context.Context, cfg *setting.Cfg) (Runner, error) {
 	serverLockService := serverlock.ProvideService(sqlStore, tracingService)
 	storeProvider := store2.ProvideDefaultStoreProvider()
 	v := authz.ProvideReconcileCRDs()
-	server, err := authz.ProvideEmbeddedZanzanaServer(cfg, sqlStore, tracingService, featureToggles, registerer, eventualRestConfigProvider, storeProvider, v)
+	eventualKVProvider := kv.ProvideEventualKVStore()
+	server, err := authz.ProvideEmbeddedZanzanaServer(cfg, sqlStore, tracingService, featureToggles, registerer, eventualRestConfigProvider, storeProvider, v, eventualKVProvider)
 	if err != nil {
 		return Runner{}, err
 	}

--- a/pkg/services/authz/zanzana.go
+++ b/pkg/services/authz/zanzana.go
@@ -38,6 +38,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/grpcserver"
 	"github.com/grafana/grafana/pkg/services/grpcserver/interceptors"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/storage/unified/resource/kv"
 )
 
 // ProvideZanzanaClient used to register ZanzanaClient.
@@ -89,7 +90,7 @@ func ProvideZanzanaClient(cfg *setting.Cfg, db db.DB, zanzanaServer zanzana.Serv
 }
 
 // ProvideEmbeddedZanzanaServer creates and registers embedded ZanzanaServer.
-func ProvideEmbeddedZanzanaServer(cfg *setting.Cfg, db db.DB, tracer tracing.Tracer, features featuremgmt.FeatureToggles, reg prometheus.Registerer, restConfig apiserver.RestConfigProvider, storeProvider zStore.StoreProvider, reconcileCRDs []schema.GroupVersionResource) (zanzana.Server, error) {
+func ProvideEmbeddedZanzanaServer(cfg *setting.Cfg, db db.DB, tracer tracing.Tracer, features featuremgmt.FeatureToggles, reg prometheus.Registerer, restConfig apiserver.RestConfigProvider, storeProvider zStore.StoreProvider, reconcileCRDs []schema.GroupVersionResource, kvProvider *kv.EventualKVProvider) (zanzana.Server, error) {
 	//nolint:staticcheck // not yet migrated to OpenFeature
 	if !features.IsEnabledGlobally(featuremgmt.FlagZanzana) {
 		return zServer.NewNoopServer(), nil
@@ -102,7 +103,7 @@ func ProvideEmbeddedZanzanaServer(cfg *setting.Cfg, db db.DB, tracer tracing.Tra
 		return nil, fmt.Errorf("failed to create zanzana store: %w", err)
 	}
 
-	srv, err := zServer.NewEmbeddedZanzanaServer(cfg, store, logger, tracer, reg, restConfig, reconcileCRDs)
+	srv, err := zServer.NewEmbeddedZanzanaServer(cfg, store, logger, tracer, reg, restConfig, reconcileCRDs, kvProvider)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start zanzana: %w", err)
 	}

--- a/pkg/services/authz/zanzana/server/server.go
+++ b/pkg/services/authz/zanzana/server/server.go
@@ -3,6 +3,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -35,6 +36,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/authz/zanzana/common"
 	"github.com/grafana/grafana/pkg/services/authz/zanzana/server/reconciler"
 	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/storage/unified/resource/kv"
 )
 
 const cacheCleanInterval = 2 * time.Minute
@@ -72,13 +74,13 @@ type Server struct {
 	nsLimiterSize     int64
 }
 
-func NewEmbeddedZanzanaServer(cfg *setting.Cfg, store storage.OpenFGADatastore, logger log.Logger, tracer tracing.Tracer, reg prometheus.Registerer, restConfig apiserver.RestConfigProvider, reconcileCRDs []schema.GroupVersionResource) (*Server, error) {
+func NewEmbeddedZanzanaServer(cfg *setting.Cfg, store storage.OpenFGADatastore, logger log.Logger, tracer tracing.Tracer, reg prometheus.Registerer, restConfig apiserver.RestConfigProvider, reconcileCRDs []schema.GroupVersionResource, kvProvider *kv.EventualKVProvider) (*Server, error) {
 	openfga, err := NewOpenFGAServer(cfg.ZanzanaServer, store)
 	if err != nil {
 		return nil, fmt.Errorf("failed to start zanzana: %w", err)
 	}
 
-	return newServer(cfg, openfga, store, logger, tracer, reg, restConfig, reconcileCRDs)
+	return newServer(cfg, openfga, store, logger, tracer, reg, restConfig, reconcileCRDs, kvProvider)
 }
 
 func NewZanzanaServer(cfg *setting.Cfg, store storage.OpenFGADatastore, logger log.Logger, tracer tracing.Tracer, reg prometheus.Registerer, reconcileCRDs []schema.GroupVersionResource) (*Server, error) {
@@ -87,10 +89,10 @@ func NewZanzanaServer(cfg *setting.Cfg, store storage.OpenFGADatastore, logger l
 		return nil, fmt.Errorf("failed to start zanzana: %w", err)
 	}
 
-	return newServer(cfg, openfgaServer, store, logger, tracer, reg, nil, reconcileCRDs)
+	return newServer(cfg, openfgaServer, store, logger, tracer, reg, nil, reconcileCRDs, nil)
 }
 
-func newServer(cfg *setting.Cfg, openfga OpenFGAServer, store storage.OpenFGADatastore, logger log.Logger, tracer tracing.Tracer, reg prometheus.Registerer, restConfig apiserver.RestConfigProvider, reconcileCRDs []schema.GroupVersionResource) (*Server, error) {
+func newServer(cfg *setting.Cfg, openfga OpenFGAServer, store storage.OpenFGADatastore, logger log.Logger, tracer tracing.Tracer, reg prometheus.Registerer, restConfig apiserver.RestConfigProvider, reconcileCRDs []schema.GroupVersionResource, kvProvider *kv.EventualKVProvider) (*Server, error) {
 	channel := &inprocgrpc.Channel{}
 	openfgav1.RegisterOpenFGAServiceServer(channel, openfga)
 	openFGAClient := openfgav1.NewOpenFGAServiceClient(channel)
@@ -184,17 +186,32 @@ func newServer(cfg *setting.Cfg, openfga OpenFGAServer, store storage.OpenFGADat
 
 		var le leaderelection.Elector
 		if cfg.ZanzanaReconciler.LeaderElection.Enabled {
-			restCfg, err := clientrest.InClusterConfig()
-			if err != nil {
-				return nil, fmt.Errorf("failed to get in-cluster config for leader election: %w", err)
-			}
-			le, err = leaderelection.NewKubernetesElector(
-				restCfg,
-				cfg.ZanzanaReconciler.LeaderElection,
-				reconcilerLogger,
-			)
-			if err != nil {
-				return nil, fmt.Errorf("failed to create leader elector: %w", err)
+			if restConfig != nil {
+				// Embedded mode: use KV lease elector
+				if kvProvider == nil {
+					return nil, fmt.Errorf("KV lease leader election requires unified storage KV backend")
+				}
+				leCfg := cfg.ZanzanaReconciler.LeaderElection
+				leCfg.Identity = resolveIdentity(cfg)
+				var leErr error
+				le, leErr = leaderelection.NewKVLeaseElector(kvProvider, leCfg, reconcilerLogger)
+				if leErr != nil {
+					return nil, fmt.Errorf("failed to create KV lease elector: %w", leErr)
+				}
+			} else {
+				// Standalone mode: use K8s elector
+				restCfg, err := clientrest.InClusterConfig()
+				if err != nil {
+					return nil, fmt.Errorf("failed to get in-cluster config for leader election: %w", err)
+				}
+				le, err = leaderelection.NewKubernetesElector(
+					restCfg,
+					cfg.ZanzanaReconciler.LeaderElection,
+					reconcilerLogger,
+				)
+				if err != nil {
+					return nil, fmt.Errorf("failed to create leader elector: %w", err)
+				}
 			}
 		} else {
 			le = leaderelection.NewDefaultElector()
@@ -224,6 +241,20 @@ func newServer(cfg *setting.Cfg, openfga OpenFGAServer, store storage.OpenFGADat
 	s.mtReconciler = mtReconciler
 
 	return s, nil
+}
+
+func resolveIdentity(cfg *setting.Cfg) string {
+	if id := cfg.ZanzanaReconciler.LeaderElection.Identity; id != "" {
+		return id
+	}
+	if id := cfg.InstanceID; id != "" {
+		return id
+	}
+	hostname, err := os.Hostname()
+	if err != nil {
+		hostname = "unknown"
+	}
+	return fmt.Sprintf("%s:%d", hostname, os.Getpid())
 }
 
 func (s *Server) RunReconciler(ctx context.Context) error {

--- a/pkg/services/authz/zanzana/server/server_bench_test.go
+++ b/pkg/services/authz/zanzana/server/server_bench_test.go
@@ -353,7 +353,7 @@ func setupBenchmarkServer(b *testing.B) (*Server, *benchmarkData) {
 	store, err := zStore.NewEmbeddedStore(cfg, testStore, log.NewNopLogger())
 	require.NoError(b, err)
 
-	srv, err := NewEmbeddedZanzanaServer(cfg, store, log.NewNopLogger(), tracing.NewNoopTracerService(), prometheus.NewRegistry(), nil, nil)
+	srv, err := NewEmbeddedZanzanaServer(cfg, store, log.NewNopLogger(), tracing.NewNoopTracerService(), prometheus.NewRegistry(), nil, nil, nil)
 	require.NoError(b, err)
 
 	// Generate test data
@@ -453,7 +453,7 @@ func setupSubresourceDepthBenchmarkServer(b *testing.B, childrenPerLevel, depth 
 	store, err := zStore.NewEmbeddedStore(cfg, testStore, log.NewNopLogger())
 	require.NoError(b, err)
 
-	srv, err := NewEmbeddedZanzanaServer(cfg, store, log.NewNopLogger(), tracing.NewNoopTracerService(), prometheus.NewRegistry(), nil, nil)
+	srv, err := NewEmbeddedZanzanaServer(cfg, store, log.NewNopLogger(), tracing.NewNoopTracerService(), prometheus.NewRegistry(), nil, nil, nil)
 	require.NoError(b, err)
 
 	// Build only the hierarchy needed to force TTU walks.

--- a/pkg/services/authz/zanzana/server/server_list_test.go
+++ b/pkg/services/authz/zanzana/server/server_list_test.go
@@ -396,7 +396,7 @@ func TestIntegrationServerListStreamDeadline(t *testing.T) {
 	store, err := zStore.NewEmbeddedStore(cfg, testStore, log.NewNopLogger())
 	require.NoError(t, err)
 
-	srv, err := NewEmbeddedZanzanaServer(cfg, store, log.NewNopLogger(), tracing.NewNoopTracerService(), prometheus.NewRegistry(), nil, nil)
+	srv, err := NewEmbeddedZanzanaServer(cfg, store, log.NewNopLogger(), tracing.NewNoopTracerService(), prometheus.NewRegistry(), nil, nil, nil)
 	require.NoError(t, err)
 	t.Cleanup(func() { srv.Close() })
 

--- a/pkg/services/authz/zanzana/server/server_test.go
+++ b/pkg/services/authz/zanzana/server/server_test.go
@@ -96,7 +96,7 @@ func setupOpenFGAServer(t *testing.T) *Server {
 	store, err := zStore.NewEmbeddedStore(cfg, testStore, log.NewNopLogger())
 	require.NoError(t, err)
 
-	srv, err := NewEmbeddedZanzanaServer(cfg, store, log.NewNopLogger(), tracing.NewNoopTracerService(), prometheus.NewRegistry(), nil, nil)
+	srv, err := NewEmbeddedZanzanaServer(cfg, store, log.NewNopLogger(), tracing.NewNoopTracerService(), prometheus.NewRegistry(), nil, nil, nil)
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/pkg/storage/unified/resource/lease/lease.go
+++ b/pkg/storage/unified/resource/lease/lease.go
@@ -55,6 +55,7 @@ type Lease struct {
 	generation int64
 	lostCh     chan struct{}
 	lostOnce   sync.Once
+	timerMu    sync.Mutex
 	lostTimer  *time.Timer
 }
 
@@ -232,6 +233,8 @@ func (m *Manager) Release(ctx context.Context, lease *Lease) error {
 		return fmt.Errorf("releasing %s/%d: %w", lease.name, lease.generation, err)
 	}
 
+	lease.timerMu.Lock()
+	defer lease.timerMu.Unlock()
 	lease.lostTimer.Stop()
 	lease.notifyLoss()
 	return nil
@@ -267,6 +270,8 @@ func (m *Manager) Extend(ctx context.Context, lease *Lease, opts ...AcquireOptio
 		return fmt.Errorf("extending %s/%d: %w", lease.name, lease.generation, err)
 	}
 
+	lease.timerMu.Lock()
+	defer lease.timerMu.Unlock()
 	lease.lostTimer.Stop()
 	lease.lostTimer = time.AfterFunc(time.Until(expires), lease.notifyLoss)
 	return nil


### PR DESCRIPTION
## Summary
- When leader election is enabled and Zanzana runs in embedded mode, automatically use `KVLeaseElector` backed by the unified storage KV store
- Standalone mode continues to use `KubernetesElector` (unchanged)
- Identity resolution: `leader_election_identity` config → `cfg.InstanceID` → `hostname:PID`
- Fails loudly if KV provider is nil when leader election is enabled in embedded mode

## Stack
1. #124181 Lease: add Extend method
2. #124182 KV: add EventualKVProvider
3. #124183 Leader election: add KVLeaseElector
4. #124184 Wire: thread EventualKVProvider
5. **This PR**

## Test plan
- [x] `go test ./pkg/services/authz/...` — all Zanzana tests pass
- [x] `go build ./pkg/server/` compiles
- [ ] Manual HA test: run two Grafana instances with embedded Zanzana + MT reconciler + leader election enabled + EnableSQLKVBackend=true — verify only one runs the reconciler, kill leader, verify failover

🤖 Generated with [Claude Code](https://claude.com/claude-code)