### PR TITLE
CloudWatch: Add pagination support for log groups selection

### DIFF
--- a/pkg/tsdb/cloudwatch/cloudwatch_test.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch_test.go
@@ -266,15 +266,17 @@ func TestQuery_ResourceRequest_DescribeLogGroups_with_CrossAccountQuerying(t *te
 		err := ds.CallResource(contextWithFeaturesEnabled(features.FlagCloudWatchCrossAccountQuerying), req, sender)
 		assert.NoError(t, err)
 
-		assert.JSONEq(t, `[
-		   {
-			  "accountId":"111",
-			  "value":{
-				 "arn":"arn:aws:logs:us-east-1:111:log-group:group_a",
-				 "name":"group_a"
+		assert.JSONEq(t, `{
+		   "results":[
+			  {
+				 "accountId":"111",
+				 "value":{
+					"arn":"arn:aws:logs:us-east-1:111:log-group:group_a",
+					"name":"group_a"
+				 }
 			  }
-		   }
-		]`, string(sender.Response.Body))
+		   ]
+		}`, string(sender.Response.Body))
 
 		logsApi.AssertCalled(t, "DescribeLogGroups",
 			&cloudwatchlogs.DescribeLogGroupsInput{

--- a/pkg/tsdb/cloudwatch/cloudwatch_test.go
+++ b/pkg/tsdb/cloudwatch/cloudwatch_test.go
@@ -266,17 +266,15 @@ func TestQuery_ResourceRequest_DescribeLogGroups_with_CrossAccountQuerying(t *te
 		err := ds.CallResource(contextWithFeaturesEnabled(features.FlagCloudWatchCrossAccountQuerying), req, sender)
 		assert.NoError(t, err)
 
-		assert.JSONEq(t, `{
-		   "results":[
-			  {
-				 "accountId":"111",
-				 "value":{
+		assert.JSONEq(t, `[
+			{
+				"accountId":"111",
+				"value":{
 					"arn":"arn:aws:logs:us-east-1:111:log-group:group_a",
 					"name":"group_a"
-				 }
-			  }
-		   ]
-		}`, string(sender.Response.Body))
+				}
+			}
+		]`, string(sender.Response.Body))
 
 		logsApi.AssertCalled(t, "DescribeLogGroups",
 			&cloudwatchlogs.DescribeLogGroupsInput{

--- a/pkg/tsdb/cloudwatch/log_groups_test.go
+++ b/pkg/tsdb/cloudwatch/log_groups_test.go
@@ -29,13 +29,15 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("successfully returns 1 log group with account id", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{{
-			Value: resources.LogGroup{
-				Arn:  "some arn",
-				Name: "some name",
-			},
-			AccountId: utils.Pointer("111"),
-		}}, nil)
+		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{
+			Results: []resources.ResourceResponse[resources.LogGroup]{{
+				Value: resources.LogGroup{
+					Arn:  "some arn",
+					Name: "some name",
+				},
+				AccountId: utils.Pointer("111"),
+			}},
+		}, nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups", nil)
@@ -44,25 +46,27 @@ func TestLogGroupsRoute(t *testing.T) {
 		handler.ServeHTTP(rr, req)
 
 		assert.Equal(t, http.StatusOK, rr.Code)
-		assert.JSONEq(t, `[{"value":{"name":"some name", "arn":"some arn"},"accountId":"111"}]`, rr.Body.String())
+		assert.JSONEq(t, `{"results":[{"value":{"name":"some name", "arn":"some arn"},"accountId":"111"}]}`, rr.Body.String())
 	})
 
 	t.Run("successfully returns multiple log groups with account id", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
 		mockLogsService.On("GetLogGroups", mock.Anything).Return(
-			[]resources.ResourceResponse[resources.LogGroup]{
-				{
-					Value: resources.LogGroup{
-						Arn:  "arn 1",
-						Name: "name 1",
+			resources.LogGroupsResponse{
+				Results: []resources.ResourceResponse[resources.LogGroup]{
+					{
+						Value: resources.LogGroup{
+							Arn:  "arn 1",
+							Name: "name 1",
+						},
+						AccountId: utils.Pointer("111"),
+					}, {
+						Value: resources.LogGroup{
+							Arn:  "arn 2",
+							Name: "name 2",
+						},
+						AccountId: utils.Pointer("222"),
 					},
-					AccountId: utils.Pointer("111"),
-				}, {
-					Value: resources.LogGroup{
-						Arn:  "arn 2",
-						Name: "name 2",
-					},
-					AccountId: utils.Pointer("222"),
 				},
 			}, nil)
 
@@ -73,7 +77,7 @@ func TestLogGroupsRoute(t *testing.T) {
 		handler.ServeHTTP(rr, req)
 
 		assert.Equal(t, http.StatusOK, rr.Code)
-		assert.JSONEq(t, `[
+		assert.JSONEq(t, `{"results":[
 		   {
 			  "value":{
 				 "name":"name 1",
@@ -88,12 +92,12 @@ func TestLogGroupsRoute(t *testing.T) {
 			  },
 			  "accountId":"222"
 		   }
-		]`, rr.Body.String())
+		]}`, rr.Body.String())
 	})
 
 	t.Run("returns error when both logGroupPrefix and logGroup Pattern are provided", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, nil)
+		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{Results: []resources.ResourceResponse[resources.LogGroup]{}}, nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups?logGroupNamePrefix=some-prefix&logGroupPattern=some-pattern", nil)
@@ -107,7 +111,7 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("passes default log group limit and nil for logGroupNamePrefix, accountId, and logGroupPattern", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, nil)
+		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{Results: []resources.ResourceResponse[resources.LogGroup]{}}, nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups", nil)
@@ -125,7 +129,7 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("passes default log group limit and nil for logGroupNamePrefix when both are absent", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, nil)
+		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{Results: []resources.ResourceResponse[resources.LogGroup]{}}, nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups", nil)
@@ -141,7 +145,7 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("passes log group limit from query parameter", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, nil)
+		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{Results: []resources.ResourceResponse[resources.LogGroup]{}}, nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups?limit=2", nil)
@@ -156,7 +160,7 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("passes logGroupPrefix from query parameter", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, nil)
+		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{Results: []resources.ResourceResponse[resources.LogGroup]{}}, nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups?logGroupNamePrefix=some-prefix", nil)
@@ -172,7 +176,7 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("passes logGroupPattern from query parameter", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, nil)
+		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{Results: []resources.ResourceResponse[resources.LogGroup]{}}, nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups?logGroupPattern=some-pattern", nil)
@@ -188,7 +192,7 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("passes logGroupPattern from query parameter", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, nil)
+		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{Results: []resources.ResourceResponse[resources.LogGroup]{}}, nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups?accountId=some-account-id", nil)
@@ -205,7 +209,7 @@ func TestLogGroupsRoute(t *testing.T) {
 	t.Run("returns error if service returns error", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
 		mockLogsService.On("GetLogGroups", mock.Anything).
-			Return([]resources.ResourceResponse[resources.LogGroup]{}, fmt.Errorf("some error"))
+			Return(resources.LogGroupsResponse{Results: []resources.ResourceResponse[resources.LogGroup]{}}, fmt.Errorf("some error"))
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups", nil)
@@ -215,5 +219,28 @@ func TestLogGroupsRoute(t *testing.T) {
 
 		assert.Equal(t, http.StatusInternalServerError, rr.Code)
 		assert.JSONEq(t, `{"Error":"some error","Message":"GetLogGroups error: some error","StatusCode":500}`, rr.Body.String())
+	})
+
+	t.Run("successfully returns log groups with nextToken", func(t *testing.T) {
+		mockLogsService = mocks.LogsService{}
+		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{
+			Results: []resources.ResourceResponse[resources.LogGroup]{{
+				Value: resources.LogGroup{
+					Arn:  "some arn",
+					Name: "some name",
+				},
+				AccountId: utils.Pointer("111"),
+			}},
+			NextToken: utils.Pointer("next_page_token"),
+		}, nil)
+
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/log-groups", nil)
+		ds := newTestDatasource()
+		handler := http.HandlerFunc(ds.resourceRequestMiddleware(ds.LogGroupsHandler))
+		handler.ServeHTTP(rr, req)
+
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.JSONEq(t, `{"results":[{"value":{"name":"some name","arn":"some arn"},"accountId":"111"}],"nextToken":"next_page_token"}`, rr.Body.String())
 	})
 }

--- a/pkg/tsdb/cloudwatch/log_groups_test.go
+++ b/pkg/tsdb/cloudwatch/log_groups_test.go
@@ -29,55 +29,51 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("successfully returns 1 log group with account id", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{
-			Results: []resources.ResourceResponse[resources.LogGroup]{{
-				Value: resources.LogGroup{
-					Arn:  "some arn",
-					Name: "some name",
-				},
-				AccountId: utils.Pointer("111"),
-			}},
-		}, nil)
+		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{{
+			Value: resources.LogGroup{
+				Arn:  "some arn",
+				Name: "some name",
+			},
+			AccountId: utils.Pointer("111"),
+		}}, (*string)(nil), nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups", nil)
 		ds := newTestDatasource()
-		handler := http.HandlerFunc(ds.resourceRequestMiddleware(ds.LogGroupsHandler))
+		handler := http.HandlerFunc(ds.cursorPagenationMiddleware(ds.LogGroupsHandler))
 		handler.ServeHTTP(rr, req)
 
 		assert.Equal(t, http.StatusOK, rr.Code)
-		assert.JSONEq(t, `{"results":[{"value":{"name":"some name", "arn":"some arn"},"accountId":"111"}]}`, rr.Body.String())
+		assert.JSONEq(t, `[{"value":{"name":"some name", "arn":"some arn"},"accountId":"111"}]`, rr.Body.String())
 	})
 
 	t.Run("successfully returns multiple log groups with account id", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
 		mockLogsService.On("GetLogGroups", mock.Anything).Return(
-			resources.LogGroupsResponse{
-				Results: []resources.ResourceResponse[resources.LogGroup]{
-					{
-						Value: resources.LogGroup{
-							Arn:  "arn 1",
-							Name: "name 1",
-						},
-						AccountId: utils.Pointer("111"),
-					}, {
-						Value: resources.LogGroup{
-							Arn:  "arn 2",
-							Name: "name 2",
-						},
-						AccountId: utils.Pointer("222"),
+			[]resources.ResourceResponse[resources.LogGroup]{
+				{
+					Value: resources.LogGroup{
+						Arn:  "arn 1",
+						Name: "name 1",
 					},
+					AccountId: utils.Pointer("111"),
+				}, {
+					Value: resources.LogGroup{
+						Arn:  "arn 2",
+						Name: "name 2",
+					},
+					AccountId: utils.Pointer("222"),
 				},
-			}, nil)
+			}, (*string)(nil), nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups", nil)
 		ds := newTestDatasource()
-		handler := http.HandlerFunc(ds.resourceRequestMiddleware(ds.LogGroupsHandler))
+		handler := http.HandlerFunc(ds.cursorPagenationMiddleware(ds.LogGroupsHandler))
 		handler.ServeHTTP(rr, req)
 
 		assert.Equal(t, http.StatusOK, rr.Code)
-		assert.JSONEq(t, `{"results":[
+		assert.JSONEq(t, `[
 		   {
 			  "value":{
 				 "name":"name 1",
@@ -92,17 +88,17 @@ func TestLogGroupsRoute(t *testing.T) {
 			  },
 			  "accountId":"222"
 		   }
-		]}`, rr.Body.String())
+		]`, rr.Body.String())
 	})
 
 	t.Run("returns error when both logGroupPrefix and logGroup Pattern are provided", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{Results: []resources.ResourceResponse[resources.LogGroup]{}}, nil)
+		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, (*string)(nil), nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups?logGroupNamePrefix=some-prefix&logGroupPattern=some-pattern", nil)
 		ds := newTestDatasource()
-		handler := http.HandlerFunc(ds.resourceRequestMiddleware(ds.LogGroupsHandler))
+		handler := http.HandlerFunc(ds.cursorPagenationMiddleware(ds.LogGroupsHandler))
 		handler.ServeHTTP(rr, req)
 
 		assert.Equal(t, http.StatusBadRequest, rr.Code)
@@ -111,12 +107,12 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("passes default log group limit and nil for logGroupNamePrefix, accountId, and logGroupPattern", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{Results: []resources.ResourceResponse[resources.LogGroup]{}}, nil)
+		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, (*string)(nil), nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups", nil)
 		ds := newTestDatasource()
-		handler := http.HandlerFunc(ds.resourceRequestMiddleware(ds.LogGroupsHandler))
+		handler := http.HandlerFunc(ds.cursorPagenationMiddleware(ds.LogGroupsHandler))
 		handler.ServeHTTP(rr, req)
 
 		mockLogsService.AssertCalled(t, "GetLogGroups", resources.LogGroupsRequest{
@@ -129,12 +125,12 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("passes default log group limit and nil for logGroupNamePrefix when both are absent", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{Results: []resources.ResourceResponse[resources.LogGroup]{}}, nil)
+		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, (*string)(nil), nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups", nil)
 		ds := newTestDatasource()
-		handler := http.HandlerFunc(ds.resourceRequestMiddleware(ds.LogGroupsHandler))
+		handler := http.HandlerFunc(ds.cursorPagenationMiddleware(ds.LogGroupsHandler))
 		handler.ServeHTTP(rr, req)
 
 		mockLogsService.AssertCalled(t, "GetLogGroups", resources.LogGroupsRequest{
@@ -145,12 +141,12 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("passes log group limit from query parameter", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{Results: []resources.ResourceResponse[resources.LogGroup]{}}, nil)
+		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, (*string)(nil), nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups?limit=2", nil)
 		ds := newTestDatasource()
-		handler := http.HandlerFunc(ds.resourceRequestMiddleware(ds.LogGroupsHandler))
+		handler := http.HandlerFunc(ds.cursorPagenationMiddleware(ds.LogGroupsHandler))
 		handler.ServeHTTP(rr, req)
 
 		mockLogsService.AssertCalled(t, "GetLogGroups", resources.LogGroupsRequest{
@@ -160,12 +156,12 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("passes logGroupPrefix from query parameter", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{Results: []resources.ResourceResponse[resources.LogGroup]{}}, nil)
+		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, (*string)(nil), nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups?logGroupNamePrefix=some-prefix", nil)
 		ds := newTestDatasource()
-		handler := http.HandlerFunc(ds.resourceRequestMiddleware(ds.LogGroupsHandler))
+		handler := http.HandlerFunc(ds.cursorPagenationMiddleware(ds.LogGroupsHandler))
 		handler.ServeHTTP(rr, req)
 
 		mockLogsService.AssertCalled(t, "GetLogGroups", resources.LogGroupsRequest{
@@ -176,12 +172,12 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("passes logGroupPattern from query parameter", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{Results: []resources.ResourceResponse[resources.LogGroup]{}}, nil)
+		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, (*string)(nil), nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups?logGroupPattern=some-pattern", nil)
 		ds := newTestDatasource()
-		handler := http.HandlerFunc(ds.resourceRequestMiddleware(ds.LogGroupsHandler))
+		handler := http.HandlerFunc(ds.cursorPagenationMiddleware(ds.LogGroupsHandler))
 		handler.ServeHTTP(rr, req)
 
 		mockLogsService.AssertCalled(t, "GetLogGroups", resources.LogGroupsRequest{
@@ -192,12 +188,12 @@ func TestLogGroupsRoute(t *testing.T) {
 
 	t.Run("passes logGroupPattern from query parameter", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{Results: []resources.ResourceResponse[resources.LogGroup]{}}, nil)
+		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{}, (*string)(nil), nil)
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups?accountId=some-account-id", nil)
 		ds := newTestDatasource()
-		handler := http.HandlerFunc(ds.resourceRequestMiddleware(ds.LogGroupsHandler))
+		handler := http.HandlerFunc(ds.cursorPagenationMiddleware(ds.LogGroupsHandler))
 		handler.ServeHTTP(rr, req)
 
 		mockLogsService.AssertCalled(t, "GetLogGroups", resources.LogGroupsRequest{
@@ -209,38 +205,36 @@ func TestLogGroupsRoute(t *testing.T) {
 	t.Run("returns error if service returns error", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
 		mockLogsService.On("GetLogGroups", mock.Anything).
-			Return(resources.LogGroupsResponse{Results: []resources.ResourceResponse[resources.LogGroup]{}}, fmt.Errorf("some error"))
+			Return([]resources.ResourceResponse[resources.LogGroup]{}, (*string)(nil), fmt.Errorf("some error"))
 
 		rr := httptest.NewRecorder()
 		req := httptest.NewRequest("GET", "/log-groups", nil)
 		ds := newTestDatasource()
-		handler := http.HandlerFunc(ds.resourceRequestMiddleware(ds.LogGroupsHandler))
+		handler := http.HandlerFunc(ds.cursorPagenationMiddleware(ds.LogGroupsHandler))
 		handler.ServeHTTP(rr, req)
 
 		assert.Equal(t, http.StatusInternalServerError, rr.Code)
 		assert.JSONEq(t, `{"Error":"some error","Message":"GetLogGroups error: some error","StatusCode":500}`, rr.Body.String())
 	})
 
-	t.Run("successfully returns log groups with nextToken", func(t *testing.T) {
+	t.Run("successfully returns log groups with nextToken in cursor-next header", func(t *testing.T) {
 		mockLogsService = mocks.LogsService{}
-		mockLogsService.On("GetLogGroups", mock.Anything).Return(resources.LogGroupsResponse{
-			Results: []resources.ResourceResponse[resources.LogGroup]{{
-				Value: resources.LogGroup{
-					Arn:  "some arn",
-					Name: "some name",
-				},
-				AccountId: utils.Pointer("111"),
-			}},
-			NextToken: utils.Pointer("next_page_token"),
-		}, nil)
+		mockLogsService.On("GetLogGroups", mock.Anything).Return([]resources.ResourceResponse[resources.LogGroup]{{
+			Value: resources.LogGroup{
+				Arn:  "some arn",
+				Name: "some name",
+			},
+			AccountId: utils.Pointer("111"),
+		}}, utils.Pointer("next_page_token"), nil)
 
 		rr := httptest.NewRecorder()
-		req := httptest.NewRequest("GET", "/log-groups", nil)
+		req := httptest.NewRequest("GET", "/log-groups?region=us-east-1", nil)
 		ds := newTestDatasource()
-		handler := http.HandlerFunc(ds.resourceRequestMiddleware(ds.LogGroupsHandler))
+		handler := http.HandlerFunc(ds.cursorPagenationMiddleware(ds.LogGroupsHandler))
 		handler.ServeHTTP(rr, req)
 
 		assert.Equal(t, http.StatusOK, rr.Code)
-		assert.JSONEq(t, `{"results":[{"value":{"name":"some name","arn":"some arn"},"accountId":"111"}],"nextToken":"next_page_token"}`, rr.Body.String())
+		assert.Equal(t, "next_page_token", rr.Header().Get("cursor-next"))
+		assert.JSONEq(t, `[{"value":{"name":"some name","arn":"some arn"},"accountId":"111"}]`, rr.Body.String())
 	})
 }

--- a/pkg/tsdb/cloudwatch/middleware_test.go
+++ b/pkg/tsdb/cloudwatch/middleware_test.go
@@ -36,4 +36,19 @@ func Test_Middleware(t *testing.T) {
 		assert.Equal(t, http.StatusBadRequest, rr.Code)
 		assert.Equal(t, `{"Message":"error: error from handler","Error":"error from handler","StatusCode":400}`, rr.Body.String())
 	})
+
+	t.Run("should pass cursor-next header to handler as cursorNext parameter", func(t *testing.T) {
+		rr := httptest.NewRecorder()
+		req := httptest.NewRequest("GET", "/log-groups", nil)
+		req.Header.Set("cursor-next", "some-token")
+		ds := newTestDatasource()
+		var receivedCursor string
+		handler := http.HandlerFunc(ds.cursorPagenationMiddleware(func(_ context.Context, parameters url.Values) ([]byte, *string, *models.HttpError) {
+			receivedCursor = parameters.Get("cursorNext")
+			return []byte(`[]`), nil, nil
+		}))
+		handler.ServeHTTP(rr, req)
+		assert.Equal(t, http.StatusOK, rr.Code)
+		assert.Equal(t, "some-token", receivedCursor)
+	})
 }

--- a/pkg/tsdb/cloudwatch/mocks/logs.go
+++ b/pkg/tsdb/cloudwatch/mocks/logs.go
@@ -29,10 +29,10 @@ type LogsService struct {
 	mock.Mock
 }
 
-func (l *LogsService) GetLogGroups(_ context.Context, request resources.LogGroupsRequest) ([]resources.ResourceResponse[resources.LogGroup], error) {
+func (l *LogsService) GetLogGroups(_ context.Context, request resources.LogGroupsRequest) (resources.LogGroupsResponse, error) {
 	args := l.Called(request)
 
-	return args.Get(0).([]resources.ResourceResponse[resources.LogGroup]), args.Error(1)
+	return args.Get(0).(resources.LogGroupsResponse), args.Error(1)
 }
 
 func (l *LogsService) GetLogGroupFields(_ context.Context, request resources.LogGroupFieldsRequest) ([]resources.ResourceResponse[resources.LogGroupField], error) {

--- a/pkg/tsdb/cloudwatch/mocks/logs.go
+++ b/pkg/tsdb/cloudwatch/mocks/logs.go
@@ -29,10 +29,11 @@ type LogsService struct {
 	mock.Mock
 }
 
-func (l *LogsService) GetLogGroups(_ context.Context, request resources.LogGroupsRequest) (resources.LogGroupsResponse, error) {
+func (l *LogsService) GetLogGroups(_ context.Context, request resources.LogGroupsRequest) ([]resources.ResourceResponse[resources.LogGroup], *string, error) {
 	args := l.Called(request)
 
-	return args.Get(0).(resources.LogGroupsResponse), args.Error(1)
+	cursor, _ := args.Get(1).(*string)
+	return args.Get(0).([]resources.ResourceResponse[resources.LogGroup]), cursor, args.Error(2)
 }
 
 func (l *LogsService) GetLogGroupFields(_ context.Context, request resources.LogGroupFieldsRequest) ([]resources.ResourceResponse[resources.LogGroupField], error) {

--- a/pkg/tsdb/cloudwatch/models/api.go
+++ b/pkg/tsdb/cloudwatch/models/api.go
@@ -34,7 +34,7 @@ type ListMetricsProvider interface {
 }
 
 type LogGroupsProvider interface {
-	GetLogGroups(ctx context.Context, request resources.LogGroupsRequest) ([]resources.ResourceResponse[resources.LogGroup], error)
+	GetLogGroups(ctx context.Context, request resources.LogGroupsRequest) (resources.LogGroupsResponse, error)
 	GetLogGroupFields(ctx context.Context, request resources.LogGroupFieldsRequest) ([]resources.ResourceResponse[resources.LogGroupField], error)
 }
 

--- a/pkg/tsdb/cloudwatch/models/api.go
+++ b/pkg/tsdb/cloudwatch/models/api.go
@@ -17,6 +17,8 @@ type RequestContextFactoryFunc func(ctx context.Context, region string) (reqCtx 
 
 type RouteHandlerFunc func(ctx context.Context, parameters url.Values) ([]byte, *HttpError)
 
+type CursorHandlerFunc func(ctx context.Context, parameters url.Values) ([]byte, *string, *HttpError)
+
 type RequestContext struct {
 	MetricsClientProvider  MetricsClientProvider
 	ListMetricsAPIProvider cloudwatch.ListMetricsAPIClient
@@ -34,7 +36,7 @@ type ListMetricsProvider interface {
 }
 
 type LogGroupsProvider interface {
-	GetLogGroups(ctx context.Context, request resources.LogGroupsRequest) (resources.LogGroupsResponse, error)
+	GetLogGroups(ctx context.Context, request resources.LogGroupsRequest) ([]resources.ResourceResponse[resources.LogGroup], *string, error)
 	GetLogGroupFields(ctx context.Context, request resources.LogGroupFieldsRequest) ([]resources.ResourceResponse[resources.LogGroupField], error)
 }
 

--- a/pkg/tsdb/cloudwatch/models/resources/log_groups_resource_request.go
+++ b/pkg/tsdb/cloudwatch/models/resources/log_groups_resource_request.go
@@ -13,6 +13,7 @@ type LogGroupsRequest struct {
 	Limit                                   int32
 	LogGroupNamePrefix, LogGroupNamePattern *string
 	ListAllLogGroups                        bool
+	NextToken                               *string
 }
 
 func (r LogGroupsRequest) IsTargetingAllAccounts() bool {
@@ -35,6 +36,7 @@ func ParseLogGroupsRequest(parameters url.Values) (LogGroupsRequest, error) {
 		LogGroupNamePrefix:  logGroupNamePrefix,
 		LogGroupNamePattern: logGroupPattern,
 		ListAllLogGroups:    parameters.Get("listAllLogGroups") == "true",
+		NextToken:           setIfNotEmptyString(parameters.Get("nextToken")),
 	}, nil
 }
 

--- a/pkg/tsdb/cloudwatch/models/resources/log_groups_resource_request.go
+++ b/pkg/tsdb/cloudwatch/models/resources/log_groups_resource_request.go
@@ -13,7 +13,7 @@ type LogGroupsRequest struct {
 	Limit                                   int32
 	LogGroupNamePrefix, LogGroupNamePattern *string
 	ListAllLogGroups                        bool
-	NextToken                               *string
+	CursorNext                              *string
 }
 
 func (r LogGroupsRequest) IsTargetingAllAccounts() bool {
@@ -36,7 +36,7 @@ func ParseLogGroupsRequest(parameters url.Values) (LogGroupsRequest, error) {
 		LogGroupNamePrefix:  logGroupNamePrefix,
 		LogGroupNamePattern: logGroupPattern,
 		ListAllLogGroups:    parameters.Get("listAllLogGroups") == "true",
-		NextToken:           setIfNotEmptyString(parameters.Get("nextToken")),
+		CursorNext:          setIfNotEmptyString(parameters.Get("cursorNext")),
 	}, nil
 }
 

--- a/pkg/tsdb/cloudwatch/models/resources/types.go
+++ b/pkg/tsdb/cloudwatch/models/resources/types.go
@@ -44,3 +44,8 @@ type LogGroupField struct {
 	Percent int64  `json:"percent"`
 	Name    string `json:"name"`
 }
+
+type LogGroupsResponse struct {
+	Results   []ResourceResponse[LogGroup] `json:"results"`
+	NextToken *string                      `json:"nextToken,omitempty"`
+}

--- a/pkg/tsdb/cloudwatch/models/resources/types.go
+++ b/pkg/tsdb/cloudwatch/models/resources/types.go
@@ -44,8 +44,3 @@ type LogGroupField struct {
 	Percent int64  `json:"percent"`
 	Name    string `json:"name"`
 }
-
-type LogGroupsResponse struct {
-	Results   []ResourceResponse[LogGroup] `json:"results"`
-	NextToken *string                      `json:"nextToken,omitempty"`
-}

--- a/pkg/tsdb/cloudwatch/resource_handler.go
+++ b/pkg/tsdb/cloudwatch/resource_handler.go
@@ -23,7 +23,7 @@ func (ds *DataSource) newResourceMux() *http.ServeMux {
 	mux.HandleFunc("/ebs-volume-ids", ds.handleResourceReq(ds.handleGetEbsVolumeIds))
 	mux.HandleFunc("/ec2-instance-attribute", ds.handleResourceReq(ds.handleGetEc2InstanceAttribute))
 	mux.HandleFunc("/resource-arns", ds.handleResourceReq(ds.handleGetResourceArns))
-	mux.HandleFunc("/log-groups", ds.resourceRequestMiddleware(ds.LogGroupsHandler))
+	mux.HandleFunc("/log-groups", ds.cursorPagenationMiddleware(ds.LogGroupsHandler))
 	mux.HandleFunc("/metrics", ds.resourceRequestMiddleware(ds.MetricsHandler))
 	mux.HandleFunc("/dimension-values", ds.resourceRequestMiddleware(ds.DimensionValuesHandler))
 	mux.HandleFunc("/dimension-keys", ds.resourceRequestMiddleware(ds.DimensionKeysHandler))
@@ -77,28 +77,28 @@ func writeResponse(rw http.ResponseWriter, code int, msg string, logger log.Logg
 	}
 }
 
-func (ds *DataSource) LogGroupsHandler(ctx context.Context, parameters url.Values) ([]byte, *models.HttpError) {
+func (ds *DataSource) LogGroupsHandler(ctx context.Context, parameters url.Values) ([]byte, *string, *models.HttpError) {
 	request, err := resources.ParseLogGroupsRequest(parameters)
 	if err != nil {
-		return nil, models.NewHttpError("cannot set both log group name prefix and pattern", http.StatusBadRequest, err)
+		return nil, nil, models.NewHttpError("cannot set both log group name prefix and pattern", http.StatusBadRequest, err)
 	}
 
 	service, err := ds.GetLogGroupsService(ctx, request.Region)
 	if err != nil {
-		return nil, models.NewHttpError("GetLogGroupsService error", http.StatusInternalServerError, err)
+		return nil, nil, models.NewHttpError("GetLogGroupsService error", http.StatusInternalServerError, err)
 	}
 
-	logGroups, err := service.GetLogGroups(ctx, request)
+	logGroups, cursor, err := service.GetLogGroups(ctx, request)
 	if err != nil {
-		return nil, models.NewHttpError("GetLogGroups error", http.StatusInternalServerError, err)
+		return nil, nil, models.NewHttpError("GetLogGroups error", http.StatusInternalServerError, err)
 	}
 
 	logGroupsResponse, err := json.Marshal(logGroups)
 	if err != nil {
-		return nil, models.NewHttpError("LogGroupsHandler json error", http.StatusInternalServerError, err)
+		return nil, nil, models.NewHttpError("LogGroupsHandler json error", http.StatusInternalServerError, err)
 	}
 
-	return logGroupsResponse, nil
+	return logGroupsResponse, cursor, nil
 }
 func (ds *DataSource) MetricsHandler(ctx context.Context, parameters url.Values) ([]byte, *models.HttpError) {
 	metricsRequest, err := resources.GetMetricsRequest(parameters)
@@ -327,8 +327,19 @@ func (ds *DataSource) GetRegionsService(ctx context.Context, region string) (mod
 	return services.NewRegionsService(NewEC2API(awsCfg), ds.logger), nil
 }
 
-// TODO: merge this and handleResourceReq
+func adaptRouteHandler(fn models.RouteHandlerFunc) models.CursorHandlerFunc {
+	return func(ctx context.Context, parameters url.Values) ([]byte, *string, *models.HttpError) {
+		b, httpErr := fn(ctx, parameters)
+		return b, nil, httpErr
+	}
+}
+
 func (ds *DataSource) resourceRequestMiddleware(handleFunc models.RouteHandlerFunc) func(rw http.ResponseWriter, req *http.Request) {
+	return ds.cursorPagenationMiddleware(adaptRouteHandler(handleFunc))
+}
+
+// TODO: merge this and handleResourceReq
+func (ds *DataSource) cursorPagenationMiddleware(handleFunc models.CursorHandlerFunc) func(rw http.ResponseWriter, req *http.Request) {
 	return func(rw http.ResponseWriter, req *http.Request) {
 		if req.Method != "GET" {
 			respondWithError(rw, models.NewHttpError("Invalid method", http.StatusMethodNotAllowed, nil))
@@ -336,11 +347,19 @@ func (ds *DataSource) resourceRequestMiddleware(handleFunc models.RouteHandlerFu
 		}
 
 		ctx := req.Context()
-		jsonResponse, httpError := handleFunc(ctx, req.URL.Query())
+		parameters := req.URL.Query()
+		if cursorHeader := req.Header.Get("cursor-next"); cursorHeader != "" {
+			parameters.Set("cursorNext", cursorHeader)
+		}
+		jsonResponse, cursor, httpError := handleFunc(ctx, parameters)
 		if httpError != nil {
 			ds.logger.FromContext(ctx).Error("Error handling resource request", "error", httpError.Message)
 			respondWithError(rw, httpError)
 			return
+		}
+
+		if cursor != nil {
+			rw.Header().Set("cursor-next", *cursor)
 		}
 
 		rw.Header().Set("Content-Type", "application/json")

--- a/pkg/tsdb/cloudwatch/services/log_groups.go
+++ b/pkg/tsdb/cloudwatch/services/log_groups.go
@@ -20,7 +20,7 @@ var NewLogGroupsService = func(logsClient models.CloudWatchLogsAPIProvider, isCr
 	return &LogGroupsService{logGroupsAPI: logsClient, isCrossAccountEnabled: isCrossAccountEnabled}
 }
 
-func (s *LogGroupsService) GetLogGroups(ctx context.Context, req resources.LogGroupsRequest) ([]resources.ResourceResponse[resources.LogGroup], error) {
+func (s *LogGroupsService) GetLogGroups(ctx context.Context, req resources.LogGroupsRequest) (resources.LogGroupsResponse, error) {
 	input := &cloudwatchlogs.DescribeLogGroupsInput{
 		Limit:              aws.Int32(req.Limit),
 		LogGroupNamePrefix: req.LogGroupNamePrefix,
@@ -36,12 +36,17 @@ func (s *LogGroupsService) GetLogGroups(ctx context.Context, req resources.LogGr
 			input.AccountIdentifiers = []string{*req.AccountId}
 		}
 	}
+
+	if req.NextToken != nil {
+		input.NextToken = req.NextToken
+	}
+
 	result := []resources.ResourceResponse[resources.LogGroup]{}
 
 	for {
 		response, err := s.logGroupsAPI.DescribeLogGroups(ctx, input)
 		if err != nil || response == nil {
-			return nil, err
+			return resources.LogGroupsResponse{}, err
 		}
 
 		for _, logGroup := range response.LogGroups {
@@ -55,12 +60,13 @@ func (s *LogGroupsService) GetLogGroups(ctx context.Context, req resources.LogGr
 		}
 
 		if !req.ListAllLogGroups || response.NextToken == nil {
-			break
+			return resources.LogGroupsResponse{
+				Results:   result,
+				NextToken: response.NextToken,
+			}, nil
 		}
 		input.NextToken = response.NextToken
 	}
-
-	return result, nil
 }
 
 func (s *LogGroupsService) GetLogGroupFields(ctx context.Context, request resources.LogGroupFieldsRequest) ([]resources.ResourceResponse[resources.LogGroupField], error) {

--- a/pkg/tsdb/cloudwatch/services/log_groups.go
+++ b/pkg/tsdb/cloudwatch/services/log_groups.go
@@ -20,7 +20,7 @@ var NewLogGroupsService = func(logsClient models.CloudWatchLogsAPIProvider, isCr
 	return &LogGroupsService{logGroupsAPI: logsClient, isCrossAccountEnabled: isCrossAccountEnabled}
 }
 
-func (s *LogGroupsService) GetLogGroups(ctx context.Context, req resources.LogGroupsRequest) (resources.LogGroupsResponse, error) {
+func (s *LogGroupsService) GetLogGroups(ctx context.Context, req resources.LogGroupsRequest) ([]resources.ResourceResponse[resources.LogGroup], *string, error) {
 	input := &cloudwatchlogs.DescribeLogGroupsInput{
 		Limit:              aws.Int32(req.Limit),
 		LogGroupNamePrefix: req.LogGroupNamePrefix,
@@ -37,8 +37,8 @@ func (s *LogGroupsService) GetLogGroups(ctx context.Context, req resources.LogGr
 		}
 	}
 
-	if req.NextToken != nil {
-		input.NextToken = req.NextToken
+	if req.CursorNext != nil {
+		input.NextToken = req.CursorNext
 	}
 
 	result := []resources.ResourceResponse[resources.LogGroup]{}
@@ -46,7 +46,7 @@ func (s *LogGroupsService) GetLogGroups(ctx context.Context, req resources.LogGr
 	for {
 		response, err := s.logGroupsAPI.DescribeLogGroups(ctx, input)
 		if err != nil || response == nil {
-			return resources.LogGroupsResponse{}, err
+			return nil, nil, err
 		}
 
 		for _, logGroup := range response.LogGroups {
@@ -60,10 +60,7 @@ func (s *LogGroupsService) GetLogGroups(ctx context.Context, req resources.LogGr
 		}
 
 		if !req.ListAllLogGroups || response.NextToken == nil {
-			return resources.LogGroupsResponse{
-				Results:   result,
-				NextToken: response.NextToken,
-			}, nil
+			return result, response.NextToken, nil
 		}
 		input.NextToken = response.NextToken
 	}

--- a/pkg/tsdb/cloudwatch/services/log_groups_test.go
+++ b/pkg/tsdb/cloudwatch/services/log_groups_test.go
@@ -46,7 +46,7 @@ func TestGetLogGroups(t *testing.T) {
 				AccountId: utils.Pointer("333"),
 				Value:     resources.LogGroup{Arn: "arn:aws:logs:us-east-1:333:log-group:group_c", Name: "group_c"},
 			},
-		}, resp)
+		}, resp.Results)
 	})
 
 	t.Run("Should return an empty error if api doesn't return any data", func(t *testing.T) {
@@ -57,7 +57,7 @@ func TestGetLogGroups(t *testing.T) {
 		resp, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{})
 
 		assert.NoError(t, err)
-		assert.Equal(t, []resources.ResourceResponse[resources.LogGroup]{}, resp)
+		assert.Equal(t, []resources.ResourceResponse[resources.LogGroup]{}, resp.Results)
 	})
 
 	t.Run("Should only use LogGroupNamePrefix even if LogGroupNamePattern passed in resource call", func(t *testing.T) {
@@ -131,7 +131,41 @@ func TestGetLogGroups(t *testing.T) {
 				AccountId: utils.Pointer("111"),
 				Value:     resources.LogGroup{Arn: "arn:aws:logs:us-east-1:111:log-group:group_a", Name: "group_a"},
 			},
-		}, resp)
+		}, resp.Results)
+		assert.Equal(t, aws.String("next_token"), resp.NextToken)
+	})
+
+	t.Run("Should pass NextToken to the API when provided in the request", func(t *testing.T) {
+		mockLogsAPI := &mocks.LogsAPI{}
+		req := resources.LogGroupsRequest{
+			Limit:              2,
+			LogGroupNamePrefix: utils.Pointer("test"),
+			NextToken:          utils.Pointer("some_token"),
+		}
+
+		mockLogsAPI.On("DescribeLogGroups", &cloudwatchlogs.DescribeLogGroupsInput{
+			Limit:              aws.Int32(req.Limit),
+			LogGroupNamePrefix: req.LogGroupNamePrefix,
+			NextToken:          utils.Pointer("some_token"),
+		}).Return(&cloudwatchlogs.DescribeLogGroupsOutput{
+			LogGroups: []cloudwatchlogstypes.LogGroup{
+				{Arn: utils.Pointer("arn:aws:logs:us-east-1:111:log-group:group_a"), LogGroupName: utils.Pointer("group_a")},
+			},
+			NextToken: aws.String("another_token"),
+		}, nil)
+
+		service := NewLogGroupsService(mockLogsAPI, false)
+		resp, err := service.GetLogGroups(context.Background(), req)
+
+		assert.NoError(t, err)
+		mockLogsAPI.AssertNumberOfCalls(t, "DescribeLogGroups", 1)
+		assert.Equal(t, []resources.ResourceResponse[resources.LogGroup]{
+			{
+				AccountId: utils.Pointer("111"),
+				Value:     resources.LogGroup{Arn: "arn:aws:logs:us-east-1:111:log-group:group_a", Name: "group_a"},
+			},
+		}, resp.Results)
+		assert.Equal(t, aws.String("another_token"), resp.NextToken)
 	})
 
 	t.Run("Should keep on calling the api until NextToken is empty in case ListAllLogGroups is set to true", func(t *testing.T) {
@@ -176,7 +210,8 @@ func TestGetLogGroups(t *testing.T) {
 				AccountId: utils.Pointer("222"),
 				Value:     resources.LogGroup{Arn: "arn:aws:logs:us-east-1:222:log-group:group_b", Name: "group_b"},
 			},
-		}, resp)
+		}, resp.Results)
+		assert.Nil(t, resp.NextToken)
 	})
 }
 

--- a/pkg/tsdb/cloudwatch/services/log_groups_test.go
+++ b/pkg/tsdb/cloudwatch/services/log_groups_test.go
@@ -30,7 +30,7 @@ func TestGetLogGroups(t *testing.T) {
 			}, nil)
 		service := NewLogGroupsService(mockLogsAPI, false)
 
-		resp, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{})
+		resp, _, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{})
 
 		assert.NoError(t, err)
 		assert.Equal(t, []resources.ResourceResponse[resources.LogGroup]{
@@ -46,7 +46,7 @@ func TestGetLogGroups(t *testing.T) {
 				AccountId: utils.Pointer("333"),
 				Value:     resources.LogGroup{Arn: "arn:aws:logs:us-east-1:333:log-group:group_c", Name: "group_c"},
 			},
-		}, resp.Results)
+		}, resp)
 	})
 
 	t.Run("Should return an empty error if api doesn't return any data", func(t *testing.T) {
@@ -54,10 +54,10 @@ func TestGetLogGroups(t *testing.T) {
 		mockLogsAPI.On("DescribeLogGroups", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
 		service := NewLogGroupsService(mockLogsAPI, false)
 
-		resp, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{})
+		resp, _, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{})
 
 		assert.NoError(t, err)
-		assert.Equal(t, []resources.ResourceResponse[resources.LogGroup]{}, resp.Results)
+		assert.Equal(t, []resources.ResourceResponse[resources.LogGroup]{}, resp)
 	})
 
 	t.Run("Should only use LogGroupNamePrefix even if LogGroupNamePattern passed in resource call", func(t *testing.T) {
@@ -66,7 +66,7 @@ func TestGetLogGroups(t *testing.T) {
 		mockLogsAPI.On("DescribeLogGroups", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
 		service := NewLogGroupsService(mockLogsAPI, false)
 
-		_, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{
+		_, _, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{
 			Limit:              0,
 			LogGroupNamePrefix: utils.Pointer("test"),
 		})
@@ -83,7 +83,7 @@ func TestGetLogGroups(t *testing.T) {
 		mockLogsAPI.On("DescribeLogGroups", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
 		service := NewLogGroupsService(mockLogsAPI, false)
 
-		_, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{})
+		_, _, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{})
 
 		assert.NoError(t, err)
 		mockLogsAPI.AssertCalled(t, "DescribeLogGroups", &cloudwatchlogs.DescribeLogGroupsInput{
@@ -97,7 +97,7 @@ func TestGetLogGroups(t *testing.T) {
 			fmt.Errorf("some error"))
 		service := NewLogGroupsService(mockLogsAPI, false)
 
-		_, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{})
+		_, _, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{})
 
 		assert.Error(t, err)
 		assert.Equal(t, "some error", err.Error())
@@ -122,7 +122,7 @@ func TestGetLogGroups(t *testing.T) {
 		}, nil)
 
 		service := NewLogGroupsService(mockLogsAPI, false)
-		resp, err := service.GetLogGroups(context.Background(), req)
+		resp, cursor, err := service.GetLogGroups(context.Background(), req)
 
 		assert.NoError(t, err)
 		mockLogsAPI.AssertNumberOfCalls(t, "DescribeLogGroups", 1)
@@ -131,8 +131,8 @@ func TestGetLogGroups(t *testing.T) {
 				AccountId: utils.Pointer("111"),
 				Value:     resources.LogGroup{Arn: "arn:aws:logs:us-east-1:111:log-group:group_a", Name: "group_a"},
 			},
-		}, resp.Results)
-		assert.Equal(t, aws.String("next_token"), resp.NextToken)
+		}, resp)
+		assert.Equal(t, aws.String("next_token"), cursor)
 	})
 
 	t.Run("Should pass NextToken to the API when provided in the request", func(t *testing.T) {
@@ -140,7 +140,7 @@ func TestGetLogGroups(t *testing.T) {
 		req := resources.LogGroupsRequest{
 			Limit:              2,
 			LogGroupNamePrefix: utils.Pointer("test"),
-			NextToken:          utils.Pointer("some_token"),
+			CursorNext:         utils.Pointer("some_token"),
 		}
 
 		mockLogsAPI.On("DescribeLogGroups", &cloudwatchlogs.DescribeLogGroupsInput{
@@ -155,7 +155,7 @@ func TestGetLogGroups(t *testing.T) {
 		}, nil)
 
 		service := NewLogGroupsService(mockLogsAPI, false)
-		resp, err := service.GetLogGroups(context.Background(), req)
+		resp, cursor, err := service.GetLogGroups(context.Background(), req)
 
 		assert.NoError(t, err)
 		mockLogsAPI.AssertNumberOfCalls(t, "DescribeLogGroups", 1)
@@ -164,8 +164,8 @@ func TestGetLogGroups(t *testing.T) {
 				AccountId: utils.Pointer("111"),
 				Value:     resources.LogGroup{Arn: "arn:aws:logs:us-east-1:111:log-group:group_a", Name: "group_a"},
 			},
-		}, resp.Results)
-		assert.Equal(t, aws.String("another_token"), resp.NextToken)
+		}, resp)
+		assert.Equal(t, aws.String("another_token"), cursor)
 	})
 
 	t.Run("Should keep on calling the api until NextToken is empty in case ListAllLogGroups is set to true", func(t *testing.T) {
@@ -198,7 +198,7 @@ func TestGetLogGroups(t *testing.T) {
 			},
 		}, nil)
 		service := NewLogGroupsService(mockLogsAPI, false)
-		resp, err := service.GetLogGroups(context.Background(), req)
+		resp, cursor, err := service.GetLogGroups(context.Background(), req)
 		assert.NoError(t, err)
 		mockLogsAPI.AssertNumberOfCalls(t, "DescribeLogGroups", 2)
 		assert.Equal(t, []resources.ResourceResponse[resources.LogGroup]{
@@ -210,8 +210,8 @@ func TestGetLogGroups(t *testing.T) {
 				AccountId: utils.Pointer("222"),
 				Value:     resources.LogGroup{Arn: "arn:aws:logs:us-east-1:222:log-group:group_b", Name: "group_b"},
 			},
-		}, resp.Results)
-		assert.Nil(t, resp.NextToken)
+		}, resp)
+		assert.Nil(t, cursor)
 	})
 }
 
@@ -221,7 +221,7 @@ func TestGetLogGroupsCrossAccountQuerying(t *testing.T) {
 		mockLogsAPI.On("DescribeLogGroups", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
 		service := NewLogGroupsService(mockLogsAPI, false)
 
-		_, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{
+		_, _, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{
 			ResourceRequest:    resources.ResourceRequest{AccountId: utils.Pointer("accountId")},
 			LogGroupNamePrefix: utils.Pointer("prefix"),
 		})
@@ -238,7 +238,7 @@ func TestGetLogGroupsCrossAccountQuerying(t *testing.T) {
 		mockLogsAPI.On("DescribeLogGroups", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
 		service := NewLogGroupsService(mockLogsAPI, true)
 
-		_, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{
+		_, _, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{
 			ResourceRequest:     resources.ResourceRequest{AccountId: utils.Pointer("accountId")},
 			LogGroupNamePrefix:  utils.Pointer("prefix"),
 			LogGroupNamePattern: utils.Pointer("pattern"),
@@ -258,7 +258,7 @@ func TestGetLogGroupsCrossAccountQuerying(t *testing.T) {
 		mockLogsAPI.On("DescribeLogGroups", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
 		service := NewLogGroupsService(mockLogsAPI, true)
 
-		_, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{
+		_, _, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{
 			ResourceRequest: resources.ResourceRequest{AccountId: utils.Pointer("accountId")},
 		})
 
@@ -275,7 +275,7 @@ func TestGetLogGroupsCrossAccountQuerying(t *testing.T) {
 		mockLogsAPI.On("DescribeLogGroups", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
 		service := NewLogGroupsService(mockLogsAPI, true)
 
-		_, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{
+		_, _, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{
 			ResourceRequest:    resources.ResourceRequest{AccountId: utils.Pointer("accountId")},
 			LogGroupNamePrefix: utils.Pointer("prefix"),
 		})
@@ -293,7 +293,7 @@ func TestGetLogGroupsCrossAccountQuerying(t *testing.T) {
 		mockLogsAPI.On("DescribeLogGroups", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
 		service := NewLogGroupsService(mockLogsAPI, true)
 
-		_, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{
+		_, _, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{
 			LogGroupNamePrefix: utils.Pointer("prefix"),
 		})
 
@@ -309,7 +309,7 @@ func TestGetLogGroupsCrossAccountQuerying(t *testing.T) {
 		mockLogsAPI.On("DescribeLogGroups", mock.Anything).Return(&cloudwatchlogs.DescribeLogGroupsOutput{}, nil)
 		service := NewLogGroupsService(mockLogsAPI, true)
 
-		_, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{
+		_, _, err := service.GetLogGroups(context.Background(), resources.LogGroupsRequest{
 			ResourceRequest: resources.ResourceRequest{
 				AccountId: utils.Pointer("accountId"),
 			},


### PR DESCRIPTION
**Copied from Pull Request** https://github.com/grafana/grafana/pull/121391

> The log groups selector modal was limited to displaying only the first 50 results due to the AWS DescribeLogGroups API page size limit. Users with many log groups across multiple accounts could not access groups beyond the first page.
> 
> This adds cursor-based pagination using the AWS NextToken:
> - Backend: Accepts nextToken in requests and returns it in responses
> - Frontend: Adds a "Load more" button that appends additional results
> - The listAllLogGroups=true path (used by variable queries) is unchanged
> 
> Closes #118097

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #118097

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
