### PR TITLE
CloudWatch: Add pagination support for log groups selection [Frontend]

### DIFF
--- a/public/app/core/copy/__mocks__/appNotification.ts
+++ b/public/app/core/copy/__mocks__/appNotification.ts
@@ -1,0 +1,6 @@
+export const useAppNotification = jest.fn(() => ({
+  success: jest.fn(),
+  warning: jest.fn(),
+  error: jest.fn(),
+  info: jest.fn(),
+}));

--- a/public/app/core/copy/__mocks__/appNotification.ts
+++ b/public/app/core/copy/__mocks__/appNotification.ts
@@ -1,6 +1,0 @@
-export const useAppNotification = jest.fn(() => ({
-  success: jest.fn(),
-  warning: jest.fn(),
-  error: jest.fn(),
-  info: jest.fn(),
-}));

--- a/public/app/plugins/datasource/cloudwatch/components/ConfigEditor/ConfigEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/ConfigEditor/ConfigEditor.test.tsx
@@ -18,15 +18,6 @@ import {
   CREDENTIALS_AUTHENTICATION_WARNING_MESSAGE,
 } from './ConfigEditor';
 
-jest.mock('app/core/copy/appNotification', () => ({
-  useAppNotification: () => ({
-    error: jest.fn(),
-    warning: jest.fn(),
-    info: jest.fn(),
-    success: jest.fn(),
-  }),
-}));
-
 const datasource = new CloudWatchDatasource(CloudWatchSettings, setupMockedTemplateService());
 const loadDataSourceMock = jest.fn();
 
@@ -38,6 +29,7 @@ const putMock = jest.fn();
 const getMock = jest.fn();
 const mockAppEvents = {
   subscribe: () => ({ unsubscribe: jest.fn() }),
+  publish: jest.fn(),
 };
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),

--- a/public/app/plugins/datasource/cloudwatch/components/ConfigEditor/ConfigEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/ConfigEditor/ConfigEditor.test.tsx
@@ -18,6 +18,8 @@ import {
   CREDENTIALS_AUTHENTICATION_WARNING_MESSAGE,
 } from './ConfigEditor';
 
+jest.mock('app/core/copy/appNotification');
+
 const datasource = new CloudWatchDatasource(CloudWatchSettings, setupMockedTemplateService());
 const loadDataSourceMock = jest.fn();
 

--- a/public/app/plugins/datasource/cloudwatch/components/ConfigEditor/ConfigEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/ConfigEditor/ConfigEditor.test.tsx
@@ -18,7 +18,14 @@ import {
   CREDENTIALS_AUTHENTICATION_WARNING_MESSAGE,
 } from './ConfigEditor';
 
-jest.mock('app/core/copy/appNotification');
+jest.mock('app/core/copy/appNotification', () => ({
+  useAppNotification: () => ({
+    error: jest.fn(),
+    warning: jest.fn(),
+    info: jest.fn(),
+    success: jest.fn(),
+  }),
+}));
 
 const datasource = new CloudWatchDatasource(CloudWatchSettings, setupMockedTemplateService());
 const loadDataSourceMock = jest.fn();

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/QueryEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/QueryEditor.test.tsx
@@ -18,6 +18,8 @@ import {
 } from '../../mocks/queries';
 import { type CloudWatchJsonData, type CloudWatchQuery } from '../../types';
 
+jest.mock('app/core/copy/appNotification');
+
 import { QueryEditor } from './QueryEditor';
 
 // the following three fields are added to legacy queries in the dashboard migrator

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/QueryEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/QueryEditor.test.tsx
@@ -18,15 +18,6 @@ import {
 } from '../../mocks/queries';
 import { type CloudWatchJsonData, type CloudWatchQuery } from '../../types';
 
-jest.mock('app/core/copy/appNotification', () => ({
-  useAppNotification: () => ({
-    error: jest.fn(),
-    warning: jest.fn(),
-    info: jest.fn(),
-    success: jest.fn(),
-  }),
-}));
-
 import { QueryEditor } from './QueryEditor';
 
 // the following three fields are added to legacy queries in the dashboard migrator
@@ -58,6 +49,9 @@ jest.mock('./MetricsQueryEditor/SQLCodeEditor', () => ({
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
+  getAppEvents: () => ({
+    publish: jest.fn(),
+  }),
   config: {
     ...jest.requireActual('@grafana/runtime').config,
     featureToggles: {

--- a/public/app/plugins/datasource/cloudwatch/components/QueryEditor/QueryEditor.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/QueryEditor/QueryEditor.test.tsx
@@ -18,7 +18,14 @@ import {
 } from '../../mocks/queries';
 import { type CloudWatchJsonData, type CloudWatchQuery } from '../../types';
 
-jest.mock('app/core/copy/appNotification');
+jest.mock('app/core/copy/appNotification', () => ({
+  useAppNotification: () => ({
+    error: jest.fn(),
+    warning: jest.fn(),
+    info: jest.fn(),
+    success: jest.fn(),
+  }),
+}));
 
 import { QueryEditor } from './QueryEditor';
 

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsField.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsField.test.tsx
@@ -40,7 +40,7 @@ describe('LogGroupSelection', () => {
     config.featureToggles.cloudWatchCrossAccountQuerying = true;
     defaultProps.datasource.resources.getLogGroups = jest
       .fn()
-      .mockResolvedValue([{ value: { arn: 'arn', name: 'loggroupname' } }]);
+      .mockResolvedValue({ results: [{ value: { arn: 'arn', name: 'loggroupname' } }] });
     defaultProps.datasource.resources.templateSrv = setupMockedTemplateService();
     render(<LogGroupsField {...defaultProps} legacyLogGroupNames={['loggroupname']} />);
 
@@ -57,7 +57,7 @@ describe('LogGroupSelection', () => {
     defaultProps.datasource = setupMockedDataSource({ variables: [logGroupNamesVariable] }).datasource;
     defaultProps.datasource.resources.getLogGroups = jest
       .fn()
-      .mockResolvedValue([{ value: { arn: 'arn', name: 'loggroupname' } }]);
+      .mockResolvedValue({ results: [{ value: { arn: 'arn', name: 'loggroupname' } }] });
     const varName = '$' + logGroupNamesVariable.name;
     render(<LogGroupsField {...defaultProps} legacyLogGroupNames={['loggroupname', varName]} />);
 
@@ -77,7 +77,7 @@ describe('LogGroupSelection', () => {
     config.featureToggles.cloudWatchCrossAccountQuerying = true;
     defaultProps.datasource.resources.getLogGroups = jest
       .fn()
-      .mockResolvedValue([{ value: { arn: 'arn', name: 'loggroupname' } }]);
+      .mockResolvedValue({ results: [{ value: { arn: 'arn', name: 'loggroupname' } }] });
     defaultProps.datasource.resources.templateSrv = setupMockedTemplateService();
     render(<LogGroupsField {...defaultProps} logGroups={[{ arn: 'arn', name: 'loggroupname' }]} />);
     await waitFor(() => expect(screen.getByText('Select log groups')).toBeInTheDocument());

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsField.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsField.test.tsx
@@ -12,12 +12,10 @@ import {
 
 import { LogGroupsField } from './LogGroupsField';
 
-jest.mock('app/core/copy/appNotification', () => ({
-  useAppNotification: () => ({
-    error: jest.fn(),
-    warning: jest.fn(),
-    info: jest.fn(),
-    success: jest.fn(),
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getAppEvents: () => ({
+    publish: jest.fn(),
   }),
 }));
 

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsField.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsField.test.tsx
@@ -12,7 +12,14 @@ import {
 
 import { LogGroupsField } from './LogGroupsField';
 
-jest.mock('app/core/copy/appNotification');
+jest.mock('app/core/copy/appNotification', () => ({
+  useAppNotification: () => ({
+    error: jest.fn(),
+    warning: jest.fn(),
+    info: jest.fn(),
+    success: jest.fn(),
+  }),
+}));
 
 const originalFeatureToggleValue = config.featureToggles.cloudWatchCrossAccountQuerying;
 const originalDebounce = lodash.debounce;

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsField.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsField.test.tsx
@@ -12,6 +12,8 @@ import {
 
 import { LogGroupsField } from './LogGroupsField';
 
+jest.mock('app/core/copy/appNotification');
+
 const originalFeatureToggleValue = config.featureToggles.cloudWatchCrossAccountQuerying;
 const originalDebounce = lodash.debounce;
 

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsField.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsField.tsx
@@ -82,7 +82,7 @@ export const LogGroupsField = ({
       )
         .then((results) => {
           const logGroups = results.flatMap((r) =>
-            r.map((lg) => ({
+            r.results.map((lg) => ({
               arn: lg.value.arn,
               name: lg.value.name,
               accountId: lg.accountId,
@@ -101,7 +101,7 @@ export const LogGroupsField = ({
     <Stack direction="column" gap={1}>
       <LogGroupsSelector
         fetchLogGroups={async (params: Partial<DescribeLogGroupsRequest>) =>
-          datasource?.resources.getLogGroups({ region: region, ...params }) ?? []
+          datasource?.resources.getLogGroups({ region: region, ...params }) ?? { results: [] }
         }
         onChange={onChange}
         accountOptions={accountState.value}

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.test.tsx
@@ -8,6 +8,16 @@ import { type LogGroupsResponse } from '../../../resources/types';
 
 import { LogGroupsSelector } from './LogGroupsSelector';
 
+const mockNotifyError = jest.fn();
+jest.mock('app/core/copy/appNotification', () => ({
+  useAppNotification: () => ({
+    error: mockNotifyError,
+    warning: jest.fn(),
+    info: jest.fn(),
+    success: jest.fn(),
+  }),
+}));
+
 const defaultLogGroupsResponse: LogGroupsResponse = {
   results: [
     {
@@ -371,5 +381,37 @@ describe('LogGroupsSelector', () => {
     await userEvent.click(screen.getByText('Select log groups'));
     await waitFor(() => expect(screen.getByText('logGroup1')).toBeInTheDocument());
     expect(screen.queryByText('Load more')).not.toBeInTheDocument();
+  });
+
+  it('should show a toast error when load more fails', async () => {
+    let callCount = 0;
+    const fetchLogGroups = jest.fn(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          results: [
+            {
+              accountId: '123',
+              value: {
+                name: 'logGroup1',
+                arn: 'arn:partition:service:region:account-id123:loggroup:someloggroup',
+              },
+            },
+          ],
+          nextToken: 'page2_token',
+        } as LogGroupsResponse;
+      }
+      throw new Error('network error');
+    });
+
+    render(<LogGroupsSelector {...defaultProps} fetchLogGroups={fetchLogGroups} />);
+    await userEvent.click(screen.getByRole('button', { name: 'Select log groups' }));
+    await waitFor(() => expect(screen.getByText('logGroup1')).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: 'Load more' }));
+
+    await waitFor(() =>
+      expect(mockNotifyError).toHaveBeenCalledWith('Failed to load more log groups. Please try again.')
+    );
   });
 });

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.test.tsx
@@ -4,9 +4,28 @@ import userEvent from '@testing-library/user-event';
 import lodash from 'lodash';
 import selectEvent from 'react-select-event';
 
-import { type ResourceResponse, type LogGroupResponse } from '../../../resources/types';
+import { type LogGroupsResponse } from '../../../resources/types';
 
 import { LogGroupsSelector } from './LogGroupsSelector';
+
+const defaultLogGroupsResponse: LogGroupsResponse = {
+  results: [
+    {
+      accountId: '123',
+      value: {
+        name: 'logGroup1',
+        arn: 'arn:partition:service:region:account-id123:loggroup:someloggroup',
+      },
+    },
+    {
+      accountId: '456',
+      value: {
+        name: 'logGroup2',
+        arn: 'arn:partition:service:region:account-id456:loggroup:someotherloggroup',
+      },
+    },
+  ],
+};
 
 const defaultProps = {
   variables: [],
@@ -23,23 +42,7 @@ const defaultProps = {
       label: 'Account Name 456',
     },
   ],
-  fetchLogGroups: () =>
-    Promise.resolve([
-      {
-        accountId: '123',
-        value: {
-          name: 'logGroup1',
-          arn: 'arn:partition:service:region:account-id123:loggroup:someloggroup',
-        },
-      },
-      {
-        accountId: '456',
-        value: {
-          name: 'logGroup2',
-          arn: 'arn:partition:service:region:account-id456:loggroup:someotherloggroup',
-        },
-      },
-    ] as Array<ResourceResponse<LogGroupResponse>>),
+  fetchLogGroups: () => Promise.resolve(defaultLogGroupsResponse),
   onChange: jest.fn(),
 };
 
@@ -77,7 +80,7 @@ describe('LogGroupsSelector', () => {
     const defer = new Deferred();
     const fetchLogGroups = jest.fn(async () => {
       await Promise.all([defer.promise]);
-      return defaultProps.fetchLogGroups();
+      return defaultLogGroupsResponse;
     });
     render(<LogGroupsSelector {...defaultProps} fetchLogGroups={fetchLogGroups} />);
     await userEvent.click(screen.getByText('Select log groups'));
@@ -92,7 +95,7 @@ describe('LogGroupsSelector', () => {
     const defer = new Deferred();
     const fetchLogGroups = jest.fn(async () => {
       await Promise.all([defer.promise]);
-      return [];
+      return { results: [] } as LogGroupsResponse;
     });
     render(<LogGroupsSelector {...defaultProps} fetchLogGroups={fetchLogGroups} />);
     await userEvent.click(screen.getByText('Select log groups'));
@@ -105,7 +108,7 @@ describe('LogGroupsSelector', () => {
   });
 
   it('calls fetchLogGroups with a search phrase when it is typed in the Search Field', async () => {
-    const fetchLogGroups = jest.fn(() => defaultProps.fetchLogGroups());
+    const fetchLogGroups = jest.fn(() => Promise.resolve(defaultLogGroupsResponse));
     render(<LogGroupsSelector {...defaultProps} fetchLogGroups={fetchLogGroups} />);
     await userEvent.click(screen.getByText('Select log groups'));
     expect(screen.getByText('Log group name prefix')).toBeInTheDocument();
@@ -121,11 +124,11 @@ describe('LogGroupsSelector', () => {
     const fetchLogGroups = jest.fn(async () => {
       if (once) {
         await Promise.all([secondCall.promise]);
-        return defaultProps.fetchLogGroups();
+        return defaultLogGroupsResponse;
       }
       await Promise.all([firstCall.promise]);
       once = true;
-      return defaultProps.fetchLogGroups();
+      return defaultLogGroupsResponse;
     });
     render(<LogGroupsSelector {...defaultProps} fetchLogGroups={fetchLogGroups} />);
     await userEvent.click(screen.getByText('Select log groups'));
@@ -187,13 +190,12 @@ describe('LogGroupsSelector', () => {
     ]);
   });
 
-  const labelText =
-    'Only the first 50 results can be shown. If you do not see an expected log group, try narrowing down your search.';
+  const labelText = 'If you do not see an expected log group, try narrowing down your search.';
   it('should not display max result info label in case less than 50 logs groups are being displayed', async () => {
     const defer = new Deferred();
     const fetchLogGroups = jest.fn(async () => {
       await Promise.all([defer.promise]);
-      return [];
+      return { results: [] } as LogGroupsResponse;
     });
     render(<LogGroupsSelector {...defaultProps} fetchLogGroups={fetchLogGroups} />);
     await userEvent.click(screen.getByText('Select log groups'));
@@ -206,12 +208,16 @@ describe('LogGroupsSelector', () => {
     const defer = new Deferred();
     const fetchLogGroups = jest.fn(async () => {
       await Promise.all([defer.promise]);
-      return Array(50).map((i) => ({
-        value: {
-          arn: `logGroup${i}`,
-          name: `logGroup${i}`,
-        },
-      }));
+      return {
+        results: Array(50)
+          .fill(null)
+          .map((_, i) => ({
+            value: {
+              arn: `logGroup${i}`,
+              name: `logGroup${i}`,
+            },
+          })),
+      } as LogGroupsResponse;
     });
     render(<LogGroupsSelector {...defaultProps} fetchLogGroups={fetchLogGroups} />);
     await userEvent.click(screen.getByText('Select log groups'));
@@ -308,5 +314,62 @@ describe('LogGroupsSelector', () => {
     expect(screen.getByText('Log group name prefix')).toBeInTheDocument();
     expect(screen.queryByText('Account label')).not.toBeInTheDocument();
     waitFor(() => expect(screen.queryByText('Account Name 123')).not.toBeInTheDocument());
+  });
+
+  it('should show Load more button when nextToken is present and append results on click', async () => {
+    let callCount = 0;
+    const fetchLogGroups = jest.fn(async () => {
+      callCount++;
+      if (callCount === 1) {
+        return {
+          results: [
+            {
+              accountId: '123',
+              value: {
+                name: 'logGroup1',
+                arn: 'arn:partition:service:region:account-id123:loggroup:someloggroup',
+              },
+            },
+          ],
+          nextToken: 'page2_token',
+        } as LogGroupsResponse;
+      }
+      return {
+        results: [
+          {
+            accountId: '456',
+            value: {
+              name: 'logGroup2',
+              arn: 'arn:partition:service:region:account-id456:loggroup:someotherloggroup',
+            },
+          },
+        ],
+      } as LogGroupsResponse;
+    });
+
+    render(<LogGroupsSelector {...defaultProps} fetchLogGroups={fetchLogGroups} />);
+    await userEvent.click(screen.getByText('Select log groups'));
+
+    await waitFor(() => expect(screen.getByText('logGroup1')).toBeInTheDocument());
+    expect(screen.getByText('Load more')).toBeInTheDocument();
+    expect(screen.queryByText('logGroup2')).not.toBeInTheDocument();
+
+    await userEvent.click(screen.getByText('Load more'));
+
+    await waitFor(() => expect(screen.getByText('logGroup2')).toBeInTheDocument());
+    expect(screen.getByText('logGroup1')).toBeInTheDocument();
+    expect(fetchLogGroups).toBeCalledTimes(2);
+    expect(fetchLogGroups).toHaveBeenLastCalledWith({
+      logGroupPattern: '',
+      accountId: 'all',
+      nextToken: 'page2_token',
+    });
+  });
+
+  it('should not show Load more button when nextToken is not present', async () => {
+    render(<LogGroupsSelector {...defaultProps} />);
+    await userEvent.click(screen.getByText('Select log groups'));
+    await waitFor(() => expect(screen.getByText('logGroup1')).toBeInTheDocument());
+    expect(screen.queryByText('Load more')).not.toBeInTheDocument();
   });
 });

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.test.tsx
@@ -4,17 +4,17 @@ import userEvent from '@testing-library/user-event';
 import lodash from 'lodash';
 import selectEvent from 'react-select-event';
 
+import { AppEvents } from '@grafana/data';
+
 import { type LogGroupsResponse } from '../../../resources/types';
 
 import { LogGroupsSelector } from './LogGroupsSelector';
 
-const mockNotifyError = jest.fn();
-jest.mock('app/core/copy/appNotification', () => ({
-  useAppNotification: () => ({
-    error: mockNotifyError,
-    warning: jest.fn(),
-    info: jest.fn(),
-    success: jest.fn(),
+const mockPublish = jest.fn();
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getAppEvents: () => ({
+    publish: mockPublish,
   }),
 }));
 
@@ -411,7 +411,10 @@ describe('LogGroupsSelector', () => {
     await userEvent.click(screen.getByRole('button', { name: 'Load more' }));
 
     await waitFor(() =>
-      expect(mockNotifyError).toHaveBeenCalledWith('Failed to load more log groups. Please try again.')
+      expect(mockPublish).toHaveBeenCalledWith({
+        type: AppEvents.alertError.name,
+        payload: ['Failed to load more log groups. Please try again.'],
+      })
     );
   });
 });

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.test.tsx
@@ -205,7 +205,7 @@ describe('LogGroupsSelector', () => {
     const defer = new Deferred();
     const fetchLogGroups = jest.fn(async () => {
       await Promise.all([defer.promise]);
-      return { results: [] } as LogGroupsResponse;
+      return { results: [] } satisfies LogGroupsResponse;
     });
     render(<LogGroupsSelector {...defaultProps} fetchLogGroups={fetchLogGroups} />);
     await userEvent.click(screen.getByText('Select log groups'));
@@ -227,7 +227,7 @@ describe('LogGroupsSelector', () => {
               name: `logGroup${i}`,
             },
           })),
-      } as LogGroupsResponse;
+      } satisfies LogGroupsResponse;
     });
     render(<LogGroupsSelector {...defaultProps} fetchLogGroups={fetchLogGroups} />);
     await userEvent.click(screen.getByText('Select log groups'));
@@ -342,7 +342,7 @@ describe('LogGroupsSelector', () => {
             },
           ],
           nextToken: 'page2_token',
-        } as LogGroupsResponse;
+        } satisfies LogGroupsResponse;
       }
       return {
         results: [
@@ -354,14 +354,14 @@ describe('LogGroupsSelector', () => {
             },
           },
         ],
-      } as LogGroupsResponse;
+      } satisfies LogGroupsResponse;
     });
 
     render(<LogGroupsSelector {...defaultProps} fetchLogGroups={fetchLogGroups} />);
     await userEvent.click(screen.getByText('Select log groups'));
 
     await waitFor(() => expect(screen.getByText('logGroup1')).toBeInTheDocument());
-    expect(screen.getByText('Load more')).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: 'Load more' })).toBeInTheDocument();
     expect(screen.queryByText('logGroup2')).not.toBeInTheDocument();
 
     await userEvent.click(screen.getByText('Load more'));
@@ -399,7 +399,7 @@ describe('LogGroupsSelector', () => {
             },
           ],
           nextToken: 'page2_token',
-        } as LogGroupsResponse;
+        } satisfies LogGroupsResponse;
       }
       throw new Error('network error');
     });

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.test.tsx
@@ -105,7 +105,7 @@ describe('LogGroupsSelector', () => {
     const defer = new Deferred();
     const fetchLogGroups = jest.fn(async () => {
       await Promise.all([defer.promise]);
-      return { results: [] } as LogGroupsResponse;
+      return { results: [] } satisfies LogGroupsResponse;
     });
     render(<LogGroupsSelector {...defaultProps} fetchLogGroups={fetchLogGroups} />);
     await userEvent.click(screen.getByText('Select log groups'));

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.test.tsx
@@ -4,15 +4,19 @@ import userEvent from '@testing-library/user-event';
 import lodash from 'lodash';
 import selectEvent from 'react-select-event';
 
-import { useAppNotification } from 'app/core/copy/appNotification';
-
 import { type LogGroupsResponse } from '../../../resources/types';
 
 import { LogGroupsSelector } from './LogGroupsSelector';
 
-jest.mock('app/core/copy/appNotification');
-
 const mockNotifyError = jest.fn();
+jest.mock('app/core/copy/appNotification', () => ({
+  useAppNotification: () => ({
+    error: mockNotifyError,
+    warning: jest.fn(),
+    info: jest.fn(),
+    success: jest.fn(),
+  }),
+}));
 
 const defaultLogGroupsResponse: LogGroupsResponse = {
   results: [
@@ -71,12 +75,6 @@ describe('LogGroupsSelector', () => {
     lodash.debounce = jest.fn().mockImplementation((fn) => {
       fn.cancel = () => {};
       return fn;
-    });
-    jest.mocked(useAppNotification).mockReturnValue({
-      success: jest.fn(),
-      warning: jest.fn(),
-      error: mockNotifyError,
-      info: jest.fn(),
     });
   });
   afterEach(() => {

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.test.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.test.tsx
@@ -4,19 +4,15 @@ import userEvent from '@testing-library/user-event';
 import lodash from 'lodash';
 import selectEvent from 'react-select-event';
 
+import { useAppNotification } from 'app/core/copy/appNotification';
+
 import { type LogGroupsResponse } from '../../../resources/types';
 
 import { LogGroupsSelector } from './LogGroupsSelector';
 
+jest.mock('app/core/copy/appNotification');
+
 const mockNotifyError = jest.fn();
-jest.mock('app/core/copy/appNotification', () => ({
-  useAppNotification: () => ({
-    error: mockNotifyError,
-    warning: jest.fn(),
-    info: jest.fn(),
-    success: jest.fn(),
-  }),
-}));
 
 const defaultLogGroupsResponse: LogGroupsResponse = {
   results: [
@@ -75,6 +71,12 @@ describe('LogGroupsSelector', () => {
     lodash.debounce = jest.fn().mockImplementation((fn) => {
       fn.cancel = () => {};
       return fn;
+    });
+    jest.mocked(useAppNotification).mockReturnValue({
+      success: jest.fn(),
+      warning: jest.fn(),
+      error: mockNotifyError,
+      info: jest.fn(),
     });
   });
   afterEach(() => {

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.tsx
@@ -16,7 +16,7 @@ import {
 } from '@grafana/ui';
 
 import { type LogGroup } from '../../../dataquery.gen';
-import { type DescribeLogGroupsRequest, type ResourceResponse, type LogGroupResponse } from '../../../resources/types';
+import { type DescribeLogGroupsRequest, type LogGroupsResponse } from '../../../resources/types';
 import getStyles from '../../styles';
 import { Account, ALL_ACCOUNTS_OPTION } from '../Account';
 
@@ -25,7 +25,7 @@ import Search from './Search';
 type CrossAccountLogsQueryProps = {
   selectedLogGroups?: LogGroup[];
   accountOptions?: Array<SelectableValue<string>>;
-  fetchLogGroups: (params: Partial<DescribeLogGroupsRequest>) => Promise<Array<ResourceResponse<LogGroupResponse>>>;
+  fetchLogGroups: (params: Partial<DescribeLogGroupsRequest>) => Promise<LogGroupsResponse>;
   variables?: string[];
   onChange: (selectedLogGroups: LogGroup[]) => void;
   onBeforeOpen?: () => void;
@@ -45,6 +45,8 @@ export const LogGroupsSelector = ({
   const [searchPhrase, setSearchPhrase] = useState('');
   const [searchAccountId, setSearchAccountId] = useState(ALL_ACCOUNTS_OPTION.value);
   const [isLoading, setIsLoading] = useState(false);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [nextToken, setNextToken] = useState<string | undefined>();
   const styles = useStyles2(getStyles);
   const selectedLogGroupsCounter = useMemo(
     () => selectedLogGroups.filter((lg) => !lg.name?.startsWith('$')).length,
@@ -85,23 +87,52 @@ export const LogGroupsSelector = ({
 
   const searchFn = async (searchTerm?: string, accountId?: string) => {
     setIsLoading(true);
+    setNextToken(undefined);
     try {
-      const possibleLogGroups = await fetchLogGroups({
+      const response = await fetchLogGroups({
         logGroupPattern: searchTerm,
         accountId: accountId,
       });
       setSelectableLogGroups(
-        possibleLogGroups.map((lg) => ({
+        response.results.map((lg) => ({
           arn: lg.value.arn,
           name: lg.value.name,
           accountId: lg.accountId,
           accountLabel: lg.accountId ? accountNameById[lg.accountId] : undefined,
         }))
       );
+      setNextToken(response.nextToken);
     } catch (err) {
       setSelectableLogGroups([]);
     }
     setIsLoading(false);
+  };
+
+  const loadMore = async () => {
+    if (!nextToken) {
+      return;
+    }
+    setIsLoadingMore(true);
+    try {
+      const response = await fetchLogGroups({
+        logGroupPattern: searchPhrase,
+        accountId: searchAccountId,
+        nextToken,
+      });
+      setSelectableLogGroups((prev) => [
+        ...prev,
+        ...response.results.map((lg) => ({
+          arn: lg.value.arn,
+          name: lg.value.name,
+          accountId: lg.accountId,
+          accountLabel: lg.accountId ? accountNameById[lg.accountId] : undefined,
+        })),
+      ]);
+      setNextToken(response.nextToken);
+    } catch (err) {
+      // keep existing results on error
+    }
+    setIsLoadingMore(false);
   };
 
   const handleSelectCheckbox = (row: LogGroup, isChecked: boolean) => {
@@ -149,12 +180,11 @@ export const LogGroupsSelector = ({
         </div>
         <Space layout="block" v={2} />
         <div>
-          {!isLoading && selectableLogGroups.length >= 25 && (
+          {!isLoading && !nextToken && selectableLogGroups.length >= 25 && (
             <>
               <div className={styles.limitLabel}>
                 <Icon name="info-circle"></Icon>
-                Only the first 50 results can be shown. If you do not see an expected log group, try narrowing down your
-                search.
+                If you do not see an expected log group, try narrowing down your search.
                 <p>
                   A{' '}
                   <TextLink
@@ -214,6 +244,14 @@ export const LogGroupsSelector = ({
               </tbody>
             </table>
           </div>
+          {!isLoading && nextToken && (
+            <>
+              <Space layout="block" v={1} />
+              <Button variant="secondary" onClick={loadMore} disabled={isLoadingMore} type="button" fill="text">
+                {isLoadingMore ? 'Loading...' : 'Load more'}
+              </Button>
+            </>
+          )}
         </div>
         <Space layout="block" v={2} />
         <Label className={styles.logGroupCountLabel}>

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.tsx
@@ -14,6 +14,7 @@ import {
   TextLink,
   useStyles2,
 } from '@grafana/ui';
+import { useAppNotification } from 'app/core/copy/appNotification';
 
 import { type LogGroup } from '../../../dataquery.gen';
 import { type DescribeLogGroupsRequest, type LogGroupsResponse } from '../../../resources/types';
@@ -48,6 +49,7 @@ export const LogGroupsSelector = ({
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [nextToken, setNextToken] = useState<string | undefined>();
   const styles = useStyles2(getStyles);
+  const notifyApp = useAppNotification();
   const selectedLogGroupsCounter = useMemo(
     () => selectedLogGroups.filter((lg) => !lg.name?.startsWith('$')).length,
     [selectedLogGroups]
@@ -130,7 +132,7 @@ export const LogGroupsSelector = ({
       ]);
       setNextToken(response.nextToken);
     } catch (err) {
-      // keep existing results on error
+      notifyApp.error('Failed to load more log groups. Please try again.');
     }
     setIsLoadingMore(false);
   };

--- a/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.tsx
+++ b/public/app/plugins/datasource/cloudwatch/components/shared/LogGroups/LogGroupsSelector.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useMemo, useState } from 'react';
 
-import { type SelectableValue } from '@grafana/data';
+import { type SelectableValue, AppEvents } from '@grafana/data';
 import { EditorField } from '@grafana/plugin-ui';
+import { getAppEvents } from '@grafana/runtime';
 import {
   Button,
   Checkbox,
@@ -14,7 +15,6 @@ import {
   TextLink,
   useStyles2,
 } from '@grafana/ui';
-import { useAppNotification } from 'app/core/copy/appNotification';
 
 import { type LogGroup } from '../../../dataquery.gen';
 import { type DescribeLogGroupsRequest, type LogGroupsResponse } from '../../../resources/types';
@@ -49,7 +49,7 @@ export const LogGroupsSelector = ({
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [nextToken, setNextToken] = useState<string | undefined>();
   const styles = useStyles2(getStyles);
-  const notifyApp = useAppNotification();
+  const appEvents = getAppEvents();
   const selectedLogGroupsCounter = useMemo(
     () => selectedLogGroups.filter((lg) => !lg.name?.startsWith('$')).length,
     [selectedLogGroups]
@@ -132,9 +132,13 @@ export const LogGroupsSelector = ({
       ]);
       setNextToken(response.nextToken);
     } catch (err) {
-      notifyApp.error('Failed to load more log groups. Please try again.');
+      appEvents.publish({
+        type: AppEvents.alertError.name,
+        payload: ['Failed to load more log groups. Please try again.'],
+      });
+    } finally {
+      setIsLoadingMore(false);
     }
-    setIsLoadingMore(false);
   };
 
   const handleSelectCheckbox = (row: LogGroup, isChecked: boolean) => {

--- a/public/app/plugins/datasource/cloudwatch/mocks/CloudWatchDataSource.ts
+++ b/public/app/plugins/datasource/cloudwatch/mocks/CloudWatchDataSource.ts
@@ -126,7 +126,7 @@ export function setupMockedDataSource({
   datasource.resources.getDimensionKeys = jest.fn().mockResolvedValue([]);
   datasource.resources.getMetrics = jest.fn().mockResolvedValue([]);
   datasource.resources.getAccounts = jest.fn().mockResolvedValue([]);
-  datasource.resources.getLogGroups = jest.fn().mockResolvedValue([]);
+  datasource.resources.getLogGroups = jest.fn().mockResolvedValue({ results: [] });
   datasource.resources.isMonitoringAccount = jest.fn().mockResolvedValue(false);
   const fetchMock = jest.fn().mockReturnValue(of({}));
   setBackendSrv({

--- a/public/app/plugins/datasource/cloudwatch/mocks/ResourcesAPI.ts
+++ b/public/app/plugins/datasource/cloudwatch/mocks/ResourcesAPI.ts
@@ -1,3 +1,5 @@
+import { of } from 'rxjs';
+
 import { type CustomVariableModel } from '@grafana/data';
 import { getBackendSrv, setBackendSrv } from '@grafana/runtime';
 
@@ -9,8 +11,10 @@ export function setupMockedResourcesAPI({
   variables,
   response,
   getMock,
+  fetchMock,
 }: {
   getMock?: jest.Mock;
+  fetchMock?: jest.Mock;
   response?: unknown;
   variables?: CustomVariableModel[];
   mockGetVariableName?: boolean;
@@ -18,11 +22,13 @@ export function setupMockedResourcesAPI({
   let templateService = setupMockedTemplateService(variables);
 
   const api = new ResourcesAPI(CloudWatchSettings, templateService);
-  let resourceRequestMock = getMock ? getMock : jest.fn().mockReturnValue(response);
+  const resourceRequestMock = getMock ? getMock : jest.fn().mockReturnValue(response);
+  const defaultFetchMock = fetchMock ?? jest.fn().mockReturnValue(of({ data: response, headers: new Headers() }));
   setBackendSrv({
     ...getBackendSrv(),
     get: resourceRequestMock,
+    fetch: defaultFetchMock,
   });
 
-  return { api, resourceRequestMock, templateService };
+  return { api, resourceRequestMock, fetchMock: defaultFetchMock, templateService };
 }

--- a/public/app/plugins/datasource/cloudwatch/resources/ResourceAPI.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/resources/ResourceAPI.test.ts
@@ -11,47 +11,32 @@ describe('ResourcesAPI', () => {
       expect(resourceRequestMock.mock.calls[1][1].region).toBe('eu-east');
     });
 
-    it('should return log groups as an array of options', async () => {
-      const response = [
-        {
-          text: '/aws/containerinsights/dev303-workshop/application',
-          value: '/aws/containerinsights/dev303-workshop/application',
-          label: '/aws/containerinsights/dev303-workshop/application',
-        },
-        {
-          text: '/aws/containerinsights/dev303-workshop/flowlogs',
-          value: '/aws/containerinsights/dev303-workshop/flowlogs',
-          label: '/aws/containerinsights/dev303-workshop/flowlogs',
-        },
-        {
-          text: '/aws/containerinsights/dev303-workshop/dataplane',
-          value: '/aws/containerinsights/dev303-workshop/dataplane',
-          label: '/aws/containerinsights/dev303-workshop/dataplane',
-        },
-      ];
+    it('should return log groups response with results', async () => {
+      const response = {
+        results: [
+          {
+            value: {
+              arn: 'arn:aws:logs:us-west-1:123456789:log-group:/aws/containerinsights/dev303-workshop/application',
+              name: '/aws/containerinsights/dev303-workshop/application',
+            },
+          },
+          {
+            value: {
+              arn: 'arn:aws:logs:us-west-1:123456789:log-group:/aws/containerinsights/dev303-workshop/flowlogs',
+              name: '/aws/containerinsights/dev303-workshop/flowlogs',
+            },
+          },
+        ],
+        nextToken: 'some_token',
+      };
 
       const { api } = setupMockedResourcesAPI({ response });
-      const expectedLogGroups = [
-        {
-          text: '/aws/containerinsights/dev303-workshop/application',
-          value: '/aws/containerinsights/dev303-workshop/application',
-          label: '/aws/containerinsights/dev303-workshop/application',
-        },
-        {
-          text: '/aws/containerinsights/dev303-workshop/flowlogs',
-          value: '/aws/containerinsights/dev303-workshop/flowlogs',
-          label: '/aws/containerinsights/dev303-workshop/flowlogs',
-        },
-        {
-          text: '/aws/containerinsights/dev303-workshop/dataplane',
-          value: '/aws/containerinsights/dev303-workshop/dataplane',
-          label: '/aws/containerinsights/dev303-workshop/dataplane',
-        },
-      ];
 
       const logGroups = await api.getLogGroups({ region: 'default' });
 
-      expect(logGroups).toEqual(expectedLogGroups);
+      expect(logGroups).toEqual(response);
+      expect(logGroups.results).toHaveLength(2);
+      expect(logGroups.nextToken).toBe('some_token');
     });
   });
 

--- a/public/app/plugins/datasource/cloudwatch/resources/ResourceAPI.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/resources/ResourceAPI.test.ts
@@ -13,7 +13,7 @@ describe('ResourcesAPI', () => {
       expect(fetchMock.mock.calls[1][0].params.region).toBe('eu-east');
     });
 
-    it('extracts results and nextToken from new backend format (bare array + Link header)', async () => {
+    it('extracts results and nextToken from bare array response with Link header', async () => {
       const results = [
         {
           value: {
@@ -36,27 +36,6 @@ describe('ResourcesAPI', () => {
 
       expect(logGroups.results).toHaveLength(2);
       expect(logGroups.nextToken).toBe('some_token');
-    });
-
-    it('extracts results and nextToken from legacy backend format (object with results)', async () => {
-      const response = {
-        results: [
-          {
-            value: {
-              arn: 'arn:aws:logs:us-west-1:123456789:log-group:/aws/containerinsights/dev303-workshop/application',
-              name: '/aws/containerinsights/dev303-workshop/application',
-            },
-          },
-        ],
-        nextToken: 'legacy_token',
-      };
-      const fetchMock = jest.fn().mockReturnValue(of({ data: response, headers: new Headers() }));
-      const { api } = setupMockedResourcesAPI({ fetchMock });
-
-      const logGroups = await api.getLogGroups({ region: 'default' });
-
-      expect(logGroups.results).toHaveLength(1);
-      expect(logGroups.nextToken).toBe('legacy_token');
     });
   });
 

--- a/public/app/plugins/datasource/cloudwatch/resources/ResourceAPI.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/resources/ResourceAPI.test.ts
@@ -1,17 +1,44 @@
+import { of } from 'rxjs';
+
 import { setupMockedResourcesAPI } from '../mocks/ResourcesAPI';
 
 describe('ResourcesAPI', () => {
-  describe('describeLogGroup', () => {
+  describe('getLogGroups', () => {
     it('replaces region correctly in the query', async () => {
-      const { api, resourceRequestMock } = setupMockedResourcesAPI();
+      const { api, fetchMock } = setupMockedResourcesAPI();
       await api.getLogGroups({ region: 'default' });
-      expect(resourceRequestMock.mock.calls[0][1].region).toBe('us-west-1');
+      expect(fetchMock.mock.calls[0][0].params.region).toBe('us-west-1');
 
       await api.getLogGroups({ region: 'eu-east' });
-      expect(resourceRequestMock.mock.calls[1][1].region).toBe('eu-east');
+      expect(fetchMock.mock.calls[1][0].params.region).toBe('eu-east');
     });
 
-    it('should return log groups response with results', async () => {
+    it('extracts results and nextToken from new backend format (bare array + Link header)', async () => {
+      const results = [
+        {
+          value: {
+            arn: 'arn:aws:logs:us-west-1:123456789:log-group:/aws/containerinsights/dev303-workshop/application',
+            name: '/aws/containerinsights/dev303-workshop/application',
+          },
+        },
+        {
+          value: {
+            arn: 'arn:aws:logs:us-west-1:123456789:log-group:/aws/containerinsights/dev303-workshop/flowlogs',
+            name: '/aws/containerinsights/dev303-workshop/flowlogs',
+          },
+        },
+      ];
+      const headers = new Headers({ Link: '<?nextToken=some_token>; rel="next"' });
+      const fetchMock = jest.fn().mockReturnValue(of({ data: results, headers }));
+      const { api } = setupMockedResourcesAPI({ fetchMock });
+
+      const logGroups = await api.getLogGroups({ region: 'default' });
+
+      expect(logGroups.results).toHaveLength(2);
+      expect(logGroups.nextToken).toBe('some_token');
+    });
+
+    it('extracts results and nextToken from legacy backend format (object with results)', async () => {
       const response = {
         results: [
           {
@@ -20,23 +47,16 @@ describe('ResourcesAPI', () => {
               name: '/aws/containerinsights/dev303-workshop/application',
             },
           },
-          {
-            value: {
-              arn: 'arn:aws:logs:us-west-1:123456789:log-group:/aws/containerinsights/dev303-workshop/flowlogs',
-              name: '/aws/containerinsights/dev303-workshop/flowlogs',
-            },
-          },
         ],
-        nextToken: 'some_token',
+        nextToken: 'legacy_token',
       };
-
-      const { api } = setupMockedResourcesAPI({ response });
+      const fetchMock = jest.fn().mockReturnValue(of({ data: response, headers: new Headers() }));
+      const { api } = setupMockedResourcesAPI({ fetchMock });
 
       const logGroups = await api.getLogGroups({ region: 'default' });
 
-      expect(logGroups).toEqual(response);
-      expect(logGroups.results).toHaveLength(2);
-      expect(logGroups.nextToken).toBe('some_token');
+      expect(logGroups.results).toHaveLength(1);
+      expect(logGroups.nextToken).toBe('legacy_token');
     });
   });
 

--- a/public/app/plugins/datasource/cloudwatch/resources/ResourcesAPI.ts
+++ b/public/app/plugins/datasource/cloudwatch/resources/ResourcesAPI.ts
@@ -12,6 +12,7 @@ import {
   type ResourceResponse,
   type DescribeLogGroupsRequest,
   type LogGroupResponse,
+  type LogGroupsResponse,
   type GetMetricsRequest,
   type GetDimensionKeysRequest,
   type GetDimensionValuesRequest,
@@ -69,13 +70,19 @@ export class ResourcesAPI extends CloudWatchRequest {
     );
   }
 
-  getLogGroups(params: DescribeLogGroupsRequest): Promise<Array<ResourceResponse<LogGroupResponse>>> {
-    return this.memoizedGetRequest<Array<ResourceResponse<LogGroupResponse>>>('log-groups', {
+  getLogGroups(params: DescribeLogGroupsRequest): Promise<LogGroupsResponse> {
+    const requestParams: Record<string, string | string[] | number> = {
       ...params,
       region: this.templateSrv.replace(this.getActualRegion(params.region)),
       accountId: this.templateSrv.replace(params.accountId),
       listAllLogGroups: params.listAllLogGroups ? 'true' : 'false',
-    });
+    };
+    // When nextToken is present, bypass memoized cache to avoid stale results
+    if (params.nextToken) {
+      requestParams.nextToken = params.nextToken;
+      return this.getRequest<LogGroupsResponse>('log-groups', requestParams);
+    }
+    return this.memoizedGetRequest<LogGroupsResponse>('log-groups', requestParams);
   }
 
   getLogGroupFields(region: string, logGroupName: string): Promise<Array<ResourceResponse<LogGroupField>>> {

--- a/public/app/plugins/datasource/cloudwatch/resources/ResourcesAPI.ts
+++ b/public/app/plugins/datasource/cloudwatch/resources/ResourcesAPI.ts
@@ -11,7 +11,6 @@ import {
   type Account,
   type ResourceResponse,
   type DescribeLogGroupsRequest,
-  type LogGroupResponse,
   type LogGroupsResponse,
   type GetMetricsRequest,
   type GetDimensionKeysRequest,

--- a/public/app/plugins/datasource/cloudwatch/resources/ResourcesAPI.ts
+++ b/public/app/plugins/datasource/cloudwatch/resources/ResourcesAPI.ts
@@ -12,6 +12,7 @@ import {
   type Account,
   type ResourceResponse,
   type DescribeLogGroupsRequest,
+  type LogGroupResponse,
   type LogGroupsResponse,
   type GetMetricsRequest,
   type GetDimensionKeysRequest,

--- a/public/app/plugins/datasource/cloudwatch/resources/ResourcesAPI.ts
+++ b/public/app/plugins/datasource/cloudwatch/resources/ResourcesAPI.ts
@@ -1,4 +1,5 @@
 import { memoize } from 'lodash';
+import { lastValueFrom } from 'rxjs';
 
 import { type DataSourceInstanceSettings, type SelectableValue } from '@grafana/data';
 import { getBackendSrv, type TemplateSrv } from '@grafana/runtime';
@@ -20,18 +21,45 @@ import {
   type RegionResponse,
 } from './types';
 
+function parseNextLinkToken(linkHeader: string): string | undefined {
+  const match = /<\?([^>]*)>;\s*rel="next"/.exec(linkHeader);
+  if (!match) {
+    return undefined;
+  }
+  return new URLSearchParams(match[1]).get('nextToken') ?? undefined;
+}
+
 export class ResourcesAPI extends CloudWatchRequest {
   private memoizedGetRequest;
+  private memoizedFetchLogGroupsRequest;
 
   constructor(instanceSettings: DataSourceInstanceSettings<CloudWatchJsonData>, templateSrv: TemplateSrv) {
     super(instanceSettings, templateSrv);
     this.memoizedGetRequest = memoize(this.getRequest.bind(this), (path, parameters) =>
       JSON.stringify({ path, parameters })
     );
+    this.memoizedFetchLogGroupsRequest = memoize(this.fetchLogGroupsRequest.bind(this), (params) =>
+      JSON.stringify(params)
+    );
   }
 
   private getRequest<T>(subtype: string, parameters?: Record<string, string | string[] | number>): Promise<T> {
     return getBackendSrv().get(`/api/datasources/uid/${this.instanceSettings.uid}/resources/${subtype}`, parameters);
+  }
+
+  private async fetchLogGroupsRequest(params: Record<string, string | string[] | number>): Promise<LogGroupsResponse> {
+    const response = await lastValueFrom(
+      getBackendSrv().fetch<Array<ResourceResponse<LogGroupResponse>>>({
+        url: `/api/datasources/uid/${this.instanceSettings.uid}/resources/log-groups`,
+        params,
+        method: 'GET',
+        showErrorAlert: false,
+      })
+    );
+    const results: Array<ResourceResponse<LogGroupResponse>> = response.data;
+    const linkHeader = response.headers.get('Link');
+    const nextToken = linkHeader ? parseNextLinkToken(linkHeader) : undefined;
+    return { results, nextToken };
   }
 
   async getExternalId(): Promise<string> {
@@ -79,9 +107,9 @@ export class ResourcesAPI extends CloudWatchRequest {
     // When nextToken is present, bypass memoized cache to avoid stale results
     if (params.nextToken) {
       requestParams.nextToken = params.nextToken;
-      return this.getRequest<LogGroupsResponse>('log-groups', requestParams);
+      return this.fetchLogGroupsRequest(requestParams);
     }
-    return this.memoizedGetRequest<LogGroupsResponse>('log-groups', requestParams);
+    return this.memoizedFetchLogGroupsRequest(requestParams);
   }
 
   getLogGroupFields(region: string, logGroupName: string): Promise<Array<ResourceResponse<LogGroupField>>> {

--- a/public/app/plugins/datasource/cloudwatch/resources/types.ts
+++ b/public/app/plugins/datasource/cloudwatch/resources/types.ts
@@ -35,6 +35,7 @@ export interface DescribeLogGroupsRequest extends ResourceRequest {
   limit?: number;
   listAllLogGroups?: boolean;
   accountId?: string;
+  nextToken?: string;
 }
 
 export interface Account {
@@ -56,6 +57,11 @@ export interface MetricResponse {
 
 export interface RegionResponse {
   name: string;
+}
+
+export interface LogGroupsResponse {
+  results: Array<ResourceResponse<LogGroupResponse>>;
+  nextToken?: string;
 }
 
 export interface SelectableResourceValue extends SelectableValue<string> {

--- a/public/app/plugins/datasource/cloudwatch/variables.test.ts
+++ b/public/app/plugins/datasource/cloudwatch/variables.test.ts
@@ -27,7 +27,7 @@ const getEc2InstanceAttribute = jest.fn().mockResolvedValue([{ label: 'g', value
 const getResourceARNs = jest.fn().mockResolvedValue([{ label: 'h', value: 'h' }]);
 const getLogGroups = jest
   .fn()
-  .mockResolvedValue([{ value: { arn: 'a', name: 'a' } }, { value: { arn: 'b', name: 'b' } }]);
+  .mockResolvedValue({ results: [{ value: { arn: 'a', name: 'a' } }, { value: { arn: 'b', name: 'b' } }] });
 
 const variables = new CloudWatchVariableSupport(mock.datasource.resources);
 

--- a/public/app/plugins/datasource/cloudwatch/variables.ts
+++ b/public/app/plugins/datasource/cloudwatch/variables.ts
@@ -71,8 +71,8 @@ export class CloudWatchVariableSupport extends CustomVariableSupport<CloudWatchD
         logGroupNamePrefix: interpolatedPrefix,
         listAllLogGroups: true,
       })
-      .then((logGroups) =>
-        logGroups.map((lg) => {
+      .then((response) =>
+        response.results.map((lg) => {
           return {
             text: lg.value.name,
             value: lg.value.arn,


### PR DESCRIPTION
**Copied from Pull Request** https://github.com/grafana/grafana/pull/121391

> The log groups selector modal was limited to displaying only the first 50 results due to the AWS DescribeLogGroups API page size limit. Users with many log groups across multiple accounts could not access groups beyond the first page.
> 
> This adds cursor-based pagination using the AWS NextToken:
> - Backend: Accepts nextToken in requests and returns it in responses
> - Frontend: Adds a "Load more" button that appends additional results
> - The listAllLogGroups=true path (used by variable queries) is unchanged
> 
> Closes #118097

**Which issue(s) does this PR fix?**:

Fixes #118097

Additional Changes:
  - The server now returns the cursor token in a next Link header per the [web linking RFC](https://datatracker.ietf.org/doc/html/rfc8288). Technically, it's idiomatic REST, not that anything is, and you do unlock some interesting caching strategies when you don't have to deserialize the response body to get the next token....Though, most importantly, it has less of an effect on backwards compatibility since the response body schema is preserved.

Please check that:
- [ ] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
