### PR TITLE
accesscontrol: batch insert in default notification policy migration

### DIFF
--- a/pkg/services/sqlstore/migrations/accesscontrol/alerting.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/alerting.go
@@ -296,7 +296,13 @@ func (m *managedRoutesPermissions) Exec(sess *xorm.Session, mg *migrator.Migrato
 	}
 
 	if len(toInsert) > 0 {
-		if _, err := sess.InsertMulti(&toInsert); err != nil {
+		err := batch(len(toInsert), batchSize, func(start, end int) error {
+			if _, err := sess.InsertMulti(toInsert[start:end]); err != nil {
+				return err
+			}
+			return nil
+		})
+		if err != nil {
 			return fmt.Errorf("failed to insert permissions: %w", err)
 		}
 	}


### PR DESCRIPTION
### Motivation
- The `grant basic roles access to default notification policy` migration built a large slice of `permission` rows and used a single `InsertMulti`, which can exceed SQLite bound-variable limits and fail with `too many SQL variables` on large installs.
- The change prevents migration failures on SQLite by limiting the number of placeholders per statement.

### Description
- Update `pkg/services/sqlstore/migrations/accesscontrol/alerting.go` to insert the built `toInsert` permissions in batches using the existing `batch` helper and shared `batchSize` instead of a single `InsertMulti` call.
- This preserves the original permission semantics and only changes how rows are written to the database to avoid oversized SQL statements.

### Testing
- Ran `go test ./pkg/services/sqlstore/migrations/accesscontrol -run TestBatch -count=1`, which passed successfully.

Fixes: https://github.com/grafana/grafana/issues/124016

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69fae85b5f6c832490362cc2c84b2f6f)