### PR TITLE
Alerting: batch InsertMulti in default notification policy migration

### DIFF
--- a/pkg/services/sqlstore/migrations/accesscontrol/alerting.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/alerting.go
@@ -295,10 +295,13 @@ func (m *managedRoutesPermissions) Exec(sess *xorm.Session, mg *migrator.Migrato
 		}
 	}
 
-	if len(toInsert) > 0 {
-		if _, err := sess.InsertMulti(&toInsert); err != nil {
+	if err := batch(len(toInsert), batchSize, func(start, end int) error {
+		if _, err := sess.InsertMulti(toInsert[start:end]); err != nil {
 			return fmt.Errorf("failed to insert permissions: %w", err)
 		}
+		return nil
+	}); err != nil {
+		return err
 	}
 	return nil
 }

--- a/pkg/services/sqlstore/migrations/accesscontrol/test/alerting_test.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/test/alerting_test.go
@@ -1,0 +1,67 @@
+package test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/services/org"
+	acmig "github.com/grafana/grafana/pkg/services/sqlstore/migrations/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+const managedRoutesPermissionsMigrationID = "grant basic roles access to default notification policy"
+
+// TestManagedRoutesPermissionsMigration_ManyOrgs reproduces issue #124016.
+// With enough managed editor/viewer roles (one pair per org), the bulk
+// InsertMulti exceeds SQLite's SQLITE_MAX_VARIABLE_NUMBER (32766 in modernc),
+// failing with "too many SQL variables (1)".
+func TestManagedRoutesPermissionsMigration_ManyOrgs(t *testing.T) {
+	x := setupTestDB(t)
+
+	// Drop the migration log entry so we can re-run the migration on top of
+	// a fully populated role table.
+	_, err := x.Exec(`DELETE FROM migration_log WHERE migration_id = ?`, managedRoutesPermissionsMigrationID)
+	require.NoError(t, err)
+
+	// Seed managed editor + viewer roles across many orgs. Need enough orgs
+	// so that 4 permissions/org * 9 columns/permission > 32766.
+	// 1000 orgs -> 4000 permissions -> 36000 placeholders, well over the limit.
+	const orgCount = 1000
+
+	editorRoleName := accesscontrol.ManagedBuiltInRoleName(string(org.RoleEditor))
+	viewerRoleName := accesscontrol.ManagedBuiltInRoleName(string(org.RoleViewer))
+
+	roles := make([]accesscontrol.Role, 0, orgCount*2)
+	for i := int64(1); i <= orgCount; i++ {
+		roles = append(roles,
+			accesscontrol.Role{OrgID: i, Version: 1, UID: fmt.Sprintf("managed_%d_editor", i), Name: editorRoleName, Updated: now, Created: now},
+			accesscontrol.Role{OrgID: i, Version: 1, UID: fmt.Sprintf("managed_%d_viewer", i), Name: viewerRoleName, Updated: now, Created: now},
+		)
+	}
+	// Insert in chunks small enough to stay under the SQLite variable limit
+	// (Role has fewer columns than Permission, but be safe).
+	const chunk = 500
+	for i := 0; i < len(roles); i += chunk {
+		end := min(i+chunk, len(roles))
+		_, err := x.Insert(roles[i:end])
+		require.NoError(t, err)
+	}
+
+	// Run only the failing migration on the prepared DB.
+	mg := migrator.NewMigrator(x, &setting.Cfg{Logger: log.New("acmigration.test")})
+	acmig.AddManagedRoutesPermissions(mg)
+	require.NoError(t, mg.Start(false, 0))
+
+	// Verify all expected permissions were created.
+	scope := models.ScopeRoutesProvider.GetResourceScopeUID(models.DefaultRoutingTreeName)
+	count, err := x.Table("permission").Where("scope = ?", scope).Count(&accesscontrol.Permission{})
+	require.NoError(t, err)
+	// 1 viewer action + 3 editor actions per org.
+	require.Equal(t, int64(orgCount*4), count)
+}


### PR DESCRIPTION
**What is this feature?**

Batches the bulk insert in the `grant basic roles access to default notification policy` migration so it stays within SQLite's per-statement bind-variable limit, matching the pattern used by every other bulk-insert migration in `pkg/services/sqlstore/migrations/accesscontrol/`.

**Why do we need this feature?**

On instances with many orgs, upgrading from 12.x to 13.0.x fails on SQLite with:

```
✗ migration failed (id = grant basic roles access to default notification policy):
  failed to insert permissions: SQL logic error: too many SQL variables (1)
```

`managedRoutesPermissions.Exec` calls `sess.InsertMulti(&toInsert)` once for every new permission across every org. xorm builds a single `INSERT INTO permission ... VALUES (?,?,?,...),(?,?,?,...),...` statement — with 9 columns per `Permission` and 4 new permissions per org (3 editor + 1 viewer), the placeholder count exceeds `modernc.org/sqlite`'s `SQLITE_MAX_VARIABLE_NUMBER` (32766) at roughly 910+ orgs, blocking the upgrade entirely.

Wrapping the call in the existing `batch(..., batchSize, ...)` helper (`batchSize = 500`) keeps each statement well under the limit. This is the same shape already used in `dashboard_permissions.go`, `action_set_migration.go`, `service_account_action_set_migration.go`, and `permission_migrator.go` in the same package.

**Who is this feature for?**

Operators upgrading Grafana to 13.0+ on SQLite with a large number of orgs.

**Which issue(s) does this PR fix?**:

Fixes #124016

**Special notes for your reviewer:**

- Added a regression test `TestManagedRoutesPermissionsMigration_ManyOrgs` that seeds 1000 orgs of managed editor/viewer roles and runs only this migration. Without the fix it reproduces the exact error string from the issue (`too many SQL variables (1)`); with the fix it passes and inserts all `orgCount * 4` permissions.
- No behaviour change beyond batching — the dedupe/skip-existing logic is untouched.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle. (n/a — bug fix)
- [ ] The docs are updated, and if this is a notable improvement, it's added to What's New. (n/a — bug fix)