### PR TITLE
Filters: Runtime migration now preserves URL state

### DIFF
--- a/public/app/features/dashboard-scene/serialization/groupByMigration.test.ts
+++ b/public/app/features/dashboard-scene/serialization/groupByMigration.test.ts
@@ -4,18 +4,24 @@ import {
   LoadingState,
   type TypedVariableModel,
 } from '@grafana/data';
-import { config } from '@grafana/runtime';
+import { config, locationService } from '@grafana/runtime';
 import type { AdhocVariableKind, GroupByVariableKind } from '@grafana/schema/apis/dashboard.grafana.app/v2';
 
 import { migrateGroupByVariablesV1, migrateGroupByVariablesV2 } from './groupByMigration';
 
+function setUrl(query: string) {
+  locationService.replace(`/?${query}`);
+}
+
 describe('groupByMigration', () => {
   beforeEach(() => {
     config.featureToggles.dashboardUnifiedDrilldownControls = true;
+    locationService.replace('/');
   });
 
   afterEach(() => {
     config.featureToggles.dashboardUnifiedDrilldownControls = false;
+    locationService.replace('/');
   });
 
   describe('migrateGroupByVariablesV1', () => {
@@ -138,6 +144,74 @@ describe('groupByMigration', () => {
       expect((result[0] as AdHocVariableModel).enableGroupBy).toBeUndefined();
       expect((result[0] as AdHocVariableModel).filters).toEqual([]);
     });
+
+    describe('URL state', () => {
+      it('overrides JSON current with values from var-{groupByName}', () => {
+        setUrl('var-groupby=test1&var-groupby=test2');
+
+        const adhoc = makeAdhocV1();
+        const groupBy = makeGroupByV1({
+          current: { selected: true, text: ['cpu'], value: ['cpu'] },
+        });
+        const result = migrateGroupByVariablesV1([adhoc, groupBy]);
+        const migrated = result[0] as AdHocVariableModel;
+
+        expect(migrated.filters).toEqual([
+          { key: 'test1', operator: 'groupBy', value: '', condition: '' },
+          { key: 'test2', operator: 'groupBy', value: '', condition: '' },
+        ]);
+      });
+
+      it('rewrites URL: drops var-{groupByName}, folds values into var-{adhocName}', () => {
+        setUrl('var-groupby=test1&var-groupby=test2');
+
+        migrateGroupByVariablesV1([makeAdhocV1(), makeGroupByV1()]);
+
+        const after = locationService.getSearch();
+        expect(after.has('var-groupby')).toBe(false);
+        expect(after.getAll('var-adhoc')).toEqual(['test1|groupBy', 'test2|groupBy']);
+      });
+
+      it('drops the empty var-{adhocName} marker when migrating', () => {
+        setUrl('var-adhoc=&var-groupby=test1');
+
+        migrateGroupByVariablesV1([makeAdhocV1(), makeGroupByV1()]);
+
+        expect(locationService.getSearch().getAll('var-adhoc')).toEqual(['test1|groupBy']);
+      });
+
+      it('preserves existing user adhoc filters when merging groupBy URL values', () => {
+        setUrl('var-adhoc=region|=|us-east-1&var-groupby=test1');
+
+        migrateGroupByVariablesV1([makeAdhocV1(), makeGroupByV1()]);
+
+        expect(locationService.getSearch().getAll('var-adhoc')).toEqual(['region|=|us-east-1', 'test1|groupBy']);
+      });
+
+      it('falls back to JSON current when URL only carries the empty marker', () => {
+        setUrl('var-groupby=');
+
+        const adhoc = makeAdhocV1();
+        const groupBy = makeGroupByV1({
+          current: { selected: true, text: ['cpu'], value: ['cpu'] },
+        });
+        const result = migrateGroupByVariablesV1([adhoc, groupBy]);
+        const migrated = result[0] as AdHocVariableModel;
+
+        expect(migrated.filters).toEqual([{ key: 'cpu', operator: 'groupBy', value: '', condition: '' }]);
+      });
+
+      it('does not rewrite URL when groupBy URL is absent', () => {
+        const adhoc = makeAdhocV1();
+        const groupBy = makeGroupByV1({
+          current: { selected: true, text: ['cpu'], value: ['cpu'] },
+        });
+        migrateGroupByVariablesV1([adhoc, groupBy]);
+
+        // groupby key was never there; adhoc key wasn't set, so URL stays empty
+        expect(locationService.getSearch().toString()).toBe('');
+      });
+    });
   });
 
   describe('migrateGroupByVariablesV2', () => {
@@ -212,6 +286,67 @@ describe('groupByMigration', () => {
         { key: 'cpu', keyLabel: 'CPU', operator: 'groupBy', value: '', condition: '', origin: 'dashboard' },
         { key: 'network', keyLabel: 'Network', operator: 'groupBy', value: '', condition: '' },
       ]);
+    });
+
+    describe('URL state', () => {
+      it('overrides spec.current with values from var-{groupByName}', () => {
+        setUrl('var-groupby=test1&var-groupby=test2');
+
+        const adhoc = makeAdhocV2();
+        const groupBy = makeGroupByV2({ current: { text: ['cpu'], value: ['cpu'] } });
+        const result = migrateGroupByVariablesV2([adhoc, groupBy]);
+        const migrated = result[0] as AdhocVariableKind;
+
+        expect(migrated.spec.filters).toEqual([
+          { key: 'test1', operator: 'groupBy', value: '', condition: '' },
+          { key: 'test2', operator: 'groupBy', value: '', condition: '' },
+        ]);
+      });
+
+      it('rewrites URL: drops var-{groupByName}, folds values into var-{adhocName}', () => {
+        setUrl('var-groupby=test1&var-groupby=test2');
+
+        migrateGroupByVariablesV2([makeAdhocV2(), makeGroupByV2()]);
+
+        const after = locationService.getSearch();
+        expect(after.has('var-groupby')).toBe(false);
+        expect(after.getAll('var-adhoc')).toEqual(['test1|groupBy', 'test2|groupBy']);
+      });
+
+      it('drops the empty var-{adhocName} marker when migrating', () => {
+        setUrl('var-adhoc=&var-groupby=test1');
+
+        migrateGroupByVariablesV2([makeAdhocV2(), makeGroupByV2()]);
+
+        expect(locationService.getSearch().getAll('var-adhoc')).toEqual(['test1|groupBy']);
+      });
+
+      it('preserves existing user adhoc filters when merging groupBy URL values', () => {
+        setUrl('var-adhoc=region|=|us-east-1&var-groupby=test1');
+
+        migrateGroupByVariablesV2([makeAdhocV2(), makeGroupByV2()]);
+
+        expect(locationService.getSearch().getAll('var-adhoc')).toEqual(['region|=|us-east-1', 'test1|groupBy']);
+      });
+
+      it('falls back to spec.current when URL only carries the empty marker', () => {
+        setUrl('var-groupby=');
+
+        const adhoc = makeAdhocV2();
+        const groupBy = makeGroupByV2({ current: { text: ['cpu'], value: ['cpu'] } });
+        const result = migrateGroupByVariablesV2([adhoc, groupBy]);
+        const migrated = result[0] as AdhocVariableKind;
+
+        expect(migrated.spec.filters).toEqual([{ key: 'cpu', operator: 'groupBy', value: '', condition: '' }]);
+      });
+
+      it('does not rewrite URL when groupBy URL is absent', () => {
+        const adhoc = makeAdhocV2();
+        const groupBy = makeGroupByV2({ current: { text: ['cpu'], value: ['cpu'] } });
+        migrateGroupByVariablesV2([adhoc, groupBy]);
+
+        expect(locationService.getSearch().toString()).toBe('');
+      });
     });
   });
 });

--- a/public/app/features/dashboard-scene/serialization/groupByMigration.ts
+++ b/public/app/features/dashboard-scene/serialization/groupByMigration.ts
@@ -12,7 +12,7 @@
  * This is a temporary compat layer — remove once GroupByVariable is fully deprecated.
  */
 import type { GroupByVariableModel, TypedVariableModel } from '@grafana/data';
-import { config } from '@grafana/runtime';
+import { config, locationService } from '@grafana/runtime';
 import type {
   AdhocVariableKind,
   GroupByVariableKind,
@@ -64,6 +64,48 @@ function buildGroupByFilters(currentEntries: KeyWithLabel[], defaultEntries: Key
   return filters;
 }
 
+function readGroupByUrlEntries(name: string): KeyWithLabel[] | undefined {
+  const values = locationService
+    .getSearch()
+    .getAll(`var-${name}`)
+    .filter((v) => v !== '');
+  if (values.length === 0) {
+    return undefined;
+  }
+  return values.map((key) => ({ key }));
+}
+
+/**
+ * Rewrites the URL so that groupBy values are
+ * folded into its matching filter as adhoc-style groupBy filter entries. This
+ * runs before the scene activates, so scenes' URL sync sees the merged state
+ * when it first reads the URL.
+ */
+function rewriteUrlForGroupByMigration(groupByName: string, adhocName: string): void {
+  const search = locationService.getSearch();
+  const groupByValues = search.getAll(`var-${groupByName}`);
+
+  if (groupByValues.length === 0) {
+    return;
+  }
+
+  const adhocEntries = groupByValues.filter((v) => v !== '').map((key) => `${key}|groupBy`);
+
+  const groupByKey = `var-${groupByName}`;
+  const adhocKey = `var-${adhocName}`;
+
+  const existingAdhoc = search.getAll(adhocKey).filter((v) => v !== '');
+  const merged = [...existingAdhoc, ...adhocEntries];
+
+  locationService.partial(
+    {
+      [adhocKey]: merged.length === 0 ? '' : merged.length === 1 ? merged[0] : merged,
+      [groupByKey]: null,
+    },
+    true
+  );
+}
+
 // ---------------------------------------------------------------------------
 // V1 (legacy JSON model)
 // ---------------------------------------------------------------------------
@@ -106,9 +148,14 @@ export function migrateGroupByVariablesV1(variables: TypedVariableModel[]): Type
       continue;
     }
 
-    const currentEntries = extractV1Entries(gb.current);
+    const urlEntries = readGroupByUrlEntries(gb.name);
+    const currentEntries = urlEntries ?? extractV1Entries(gb.current);
     const defaultEntries = extractV1Entries(gb.defaultValue);
     const groupByFilters = buildGroupByFilters(currentEntries, defaultEntries);
+
+    if (urlEntries && urlEntries.length > 0) {
+      rewriteUrlForGroupByMigration(gb.name, v.name);
+    }
 
     result.push({
       ...v,
@@ -180,9 +227,14 @@ export function migrateGroupByVariablesV2(variables: VariableKind[]): VariableKi
       continue;
     }
 
-    const currentEntries = extractV2Entries(gb.spec.current);
+    const urlEntries = readGroupByUrlEntries(gb.spec.name);
+    const currentEntries = urlEntries ?? extractV2Entries(gb.spec.current);
     const defaultEntries = extractV2Entries(gb.spec.defaultValue);
     const groupByFilters = buildGroupByFilters(currentEntries, defaultEntries);
+
+    if (urlEntries && urlEntries.length > 0) {
+      rewriteUrlForGroupByMigration(gb.spec.name, v.spec.name);
+    }
 
     const migrated: AdhocVariableKind = {
       ...v,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

With the launch of unified filters and groupBys we have implemented a runtime migration that would move groupBy values saved in the model into the unified filters experience. This works well if the groupBy values are saved on the variable and the url does not contain different state, but for cases where the url overwrites what is saved in the model it does not work.

This PR addresses that by migrating the URL as well if groupBy URL state exists.

**Why do we need this feature?**

To fix cases where going to a dashboard with some groupBy URL state would be preserved during migration. In some situations there might be no values saved on the model, and even if there are, the URL would need to overwrite it normally. So this PR fixes that and maintains the expectation that the URL is the source of truth at runtime.

**Who is this feature for?**

Everyone.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
