### PR TITLE
Data Source: Add forward_user_agent option to preserve client User-Agent

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -296,8 +296,12 @@ response_limit = 0
 # Limits the number of rows that Grafana will process from SQL data sources.
 row_limit = 1000000
 
-# Sets a custom value for the `User-Agent` header for outgoing data proxy requests. If empty, the default value is `Grafana/<BuildVersion>` (for example `Grafana/9.0.0`).
+# Sets a custom value for the `User-Agent` header for outgoing data proxy requests. If empty, the default value is `Grafana/<BuildVersion>` (for example `Grafana/13.0.0`).
 user_agent =
+
+# If enabled, data proxy will preserve the client's original `User-Agent` by appending it to the proxy `User-Agent`
+# (e.g. `Grafana/13.0.0 my-client/1.4`). Useful for tracking the originating client through the proxy. Default is false.
+forward_user_agent = false
 
 #################################### Analytics ###########################
 [analytics]

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -272,8 +272,12 @@
 # Limits the number of rows that Grafana will process from SQL data sources.
 ;row_limit = 1000000
 
-# Sets a custom value for the `User-Agent` header for outgoing data proxy requests. If empty, the default value is `Grafana/<BuildVersion>` (for example `Grafana/9.0.0`).
+# Sets a custom value for the `User-Agent` header for outgoing data proxy requests. If empty, the default value is `Grafana/<BuildVersion>` (for example `Grafana/13.0.0`).
 ;user_agent =
+
+# If enabled, data proxy will preserve the client's original `User-Agent` by appending it to the proxy `User-Agent`.
+# Useful for tracking the originating client through the proxy. Default is false.
+;forward_user_agent = false
 
 #################################### Analytics ####################################
 [analytics]

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -588,7 +588,13 @@ Limits the number of rows that Grafana processes from SQL data sources. Default 
 
 #### `user_agent`
 
-Sets a custom value for the `User-Agent` header for outgoing data proxy requests. If empty, the default value is `Grafana/<BuildVersion>` (for example `Grafana/9.0.0`).
+Sets a custom value for the `User-Agent` header for outgoing data proxy requests. If empty, the default value is `Grafana/<BuildVersion>` (for example `Grafana/13.0.0`).
+
+#### `forward_user_agent`
+
+If enabled, the data proxy preserves the client's original `User-Agent` header by appending it to the proxy's `User-Agent`. Useful for tracking the originating client (browser, CLI, AI agent, etc.) at upstream data sources. Default is `false`.
+
+For example, with this enabled, a request from a client carrying `User-Agent: my-client/1.4` is forwarded with `User-Agent: Grafana/13.0.0 my-client/1.4`.
 
 <hr />
 

--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -236,7 +236,13 @@ func (proxy *DataSourceProxy) director(req *http.Request) {
 	proxyutil.ApplyUserHeader(proxy.cfg.SendUserHeader, req, proxy.ctx.SignedInUser)
 
 	proxyutil.ClearCookieHeader(req, proxy.ds.AllowedCookies(), []string{proxy.cfg.LoginCookieName})
-	req.Header.Set("User-Agent", proxy.cfg.DataProxyUserAgent)
+	ua := proxy.cfg.DataProxyUserAgent
+	if proxy.cfg.DataProxyForwardUserAgent {
+		if originalUA := req.Header.Get("User-Agent"); originalUA != "" {
+			ua = ua + " " + originalUA
+		}
+	}
+	req.Header.Set("User-Agent", ua)
 
 	jsonData := make(map[string]any)
 	if proxy.ds.JsonData != nil {

--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -239,7 +239,11 @@ func (proxy *DataSourceProxy) director(req *http.Request) {
 	ua := proxy.cfg.DataProxyUserAgent
 	if proxy.cfg.DataProxyForwardUserAgent {
 		if originalUA := req.Header.Get("User-Agent"); originalUA != "" {
-			ua = ua + " " + originalUA
+			if ua != "" {
+			   ua = ua + " " + originalUA
+			} else {
+			   ua = originalUA
+			}
 		}
 	}
 	req.Header.Set("User-Agent", ua)

--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -240,9 +240,9 @@ func (proxy *DataSourceProxy) director(req *http.Request) {
 	if proxy.cfg.DataProxyForwardUserAgent {
 		if originalUA := req.Header.Get("User-Agent"); originalUA != "" {
 			if ua != "" {
-			   ua = ua + " " + originalUA
+				ua = ua + " " + originalUA
 			} else {
-			   ua = originalUA
+				ua = originalUA
 			}
 		}
 	}

--- a/pkg/api/pluginproxy/ds_proxy_test.go
+++ b/pkg/api/pluginproxy/ds_proxy_test.go
@@ -763,6 +763,91 @@ func TestIntegrationDataSourceProxy_routeRule(t *testing.T) {
 	})
 }
 
+func TestDataSourceProxy_userAgentHeader(t *testing.T) {
+	ds := &datasources.DataSource{Type: datasources.DS_GRAPHITE, URL: "http://graphite:8080"}
+	var routes []*plugins.Route
+
+	t.Run("When DataProxyForwardUserAgent config is disabled", func(t *testing.T) {
+		ctx := &contextmodel.ReqContext{}
+		proxy, err := setupDSProxyTest(t, ctx, ds, routes, "/render", func(p *DataSourceProxy) {
+			p.cfg = &setting.Cfg{
+				BuildVersion:              "5.3.0",
+				DataProxyUserAgent:        "Grafana/5.3.0",
+				DataProxyForwardUserAgent: false,
+			}
+		})
+		require.NoError(t, err)
+
+		req, err := http.NewRequest(http.MethodGet, "http://grafana.com/sub", nil)
+		require.NoError(t, err)
+		req.Header.Set("User-Agent", "original-client/1.0")
+
+		proxy.director(req)
+
+		assert.Equal(t, "Grafana/5.3.0", req.Header.Get("User-Agent"))
+	})
+
+	t.Run("When DataProxyForwardUserAgent config is enabled", func(t *testing.T) {
+		ctx := &contextmodel.ReqContext{}
+		proxy, err := setupDSProxyTest(t, ctx, ds, routes, "/render", func(p *DataSourceProxy) {
+			p.cfg = &setting.Cfg{
+				BuildVersion:              "5.3.0",
+				DataProxyUserAgent:        "Grafana/5.3.0",
+				DataProxyForwardUserAgent: true,
+			}
+		})
+		require.NoError(t, err)
+
+		req, err := http.NewRequest(http.MethodGet, "http://grafana.com/sub", nil)
+		require.NoError(t, err)
+		req.Header.Set("User-Agent", "original-client/1.0")
+
+		proxy.director(req)
+
+		assert.Equal(t, "Grafana/5.3.0 original-client/1.0", req.Header.Get("User-Agent"))
+	})
+
+	t.Run("When DataProxyForwardUserAgent config is enabled but the client User-Agent is empty", func(t *testing.T) {
+		ctx := &contextmodel.ReqContext{}
+		proxy, err := setupDSProxyTest(t, ctx, ds, routes, "/render", func(p *DataSourceProxy) {
+			p.cfg = &setting.Cfg{
+				BuildVersion:              "5.3.0",
+				DataProxyUserAgent:        "Grafana/5.3.0",
+				DataProxyForwardUserAgent: true,
+			}
+		})
+		require.NoError(t, err)
+
+		req, err := http.NewRequest(http.MethodGet, "http://grafana.com/sub", nil)
+		require.NoError(t, err)
+		// no User-Agent header set
+
+		proxy.director(req)
+
+		assert.Equal(t, "Grafana/5.3.0", req.Header.Get("User-Agent"))
+	})
+
+	t.Run("When DataProxyForwardUserAgent config is enabled with a custom DataProxyUserAgent", func(t *testing.T) {
+		ctx := &contextmodel.ReqContext{}
+		proxy, err := setupDSProxyTest(t, ctx, ds, routes, "/render", func(p *DataSourceProxy) {
+			p.cfg = &setting.Cfg{
+				BuildVersion:              "5.3.0",
+				DataProxyUserAgent:        "MyCorp/1.0",
+				DataProxyForwardUserAgent: true,
+			}
+		})
+		require.NoError(t, err)
+
+		req, err := http.NewRequest(http.MethodGet, "http://grafana.com/sub", nil)
+		require.NoError(t, err)
+		req.Header.Set("User-Agent", "original-client/1.0")
+
+		proxy.director(req)
+
+		assert.Equal(t, "MyCorp/1.0 original-client/1.0", req.Header.Get("User-Agent"))
+	})
+}
+
 // test DataSourceProxy request handling.
 func TestDataSourceProxy_requestHandling(t *testing.T) {
 	var writeErr error

--- a/pkg/api/pluginproxy/ds_proxy_test.go
+++ b/pkg/api/pluginproxy/ds_proxy_test.go
@@ -846,6 +846,26 @@ func TestDataSourceProxy_userAgentHeader(t *testing.T) {
 
 		assert.Equal(t, "MyCorp/1.0 original-client/1.0", req.Header.Get("User-Agent"))
 	})
+
+	t.Run("When DataProxyForwardUserAgent config is enabled and DataProxyUserAgent is empty", func(t *testing.T) {
+		ctx := &contextmodel.ReqContext{}
+		proxy, err := setupDSProxyTest(t, ctx, ds, routes, "/render", func(p *DataSourceProxy) {
+			p.cfg = &setting.Cfg{
+				BuildVersion:              "5.3.0",
+				DataProxyUserAgent:        "",
+				DataProxyForwardUserAgent: true,
+			}
+		})
+		require.NoError(t, err)
+
+		req, err := http.NewRequest(http.MethodGet, "http://grafana.com/sub", nil)
+		require.NoError(t, err)
+		req.Header.Set("User-Agent", "original-client/1.0")
+
+		proxy.director(req)
+
+		assert.Equal(t, "original-client/1.0", req.Header.Get("User-Agent"))
+	})
 }
 
 // test DataSourceProxy request handling.

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -346,6 +346,7 @@ type Cfg struct {
 	ResponseLimit                  int64
 	DataProxyRowLimit              int64
 	DataProxyUserAgent             string
+	DataProxyForwardUserAgent      bool
 
 	// DistributedCache
 	RemoteCacheOptions *RemoteCacheSettings

--- a/pkg/setting/setting_data_proxy.go
+++ b/pkg/setting/setting_data_proxy.go
@@ -23,6 +23,7 @@ func readDataProxySettings(iniFile *ini.File, cfg *Cfg) error {
 	cfg.ResponseLimit = dataproxy.Key("response_limit").MustInt64(0)
 	cfg.DataProxyRowLimit = dataproxy.Key("row_limit").MustInt64(defaultDataProxyRowLimit)
 	cfg.DataProxyUserAgent = dataproxy.Key("user_agent").String()
+	cfg.DataProxyForwardUserAgent = dataproxy.Key("forward_user_agent").MustBool(false)
 
 	if cfg.DataProxyUserAgent == "" {
 		cfg.DataProxyUserAgent = fmt.Sprintf("Grafana/%s", BuildVersion)


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds a new `[dataproxy] forward_user_agent` config option (default `false`). When enabled, Grafana's data source proxy preserves the client's original `User-Agent` header by appending it to the proxy's own `User-Agent` instead of unconditionally overwriting it.

Example: a request from a client carrying `User-Agent: my-client/1.4` is forwarded to the upstream data source as `User-Agent: Grafana/13.0.0 my-client/1.4`.

When disabled (default), behavior is byte-identical to today.

**Why do we need this feature?**

Today the data source proxy unconditionally [rewrites](https://github.com/grafana/grafana/blob/main/pkg/api/pluginproxy/ds_proxy.go#L239) `User-Agent`, which erases the originating client's identity before requests reach upstream data sources. This makes it impossible for upstream data sources to distinguish between clients (browser, CLI, AI agent, third-party tools) for purposes like:
- Per-client traffic attribution and capacity planning
- Forensic investigation of incidents (e.g., correlating a slow-query spike to a specific client)
- AI-agent traffic accounting at the gateway level
- Insight log enrichment: currently every proxied request looks like `user_agent=Grafana/<ver>` regardless of who actually drove it

Making this opt-in keeps the existing default for users / customers / BYOC where forwarding the original UA might be
unexpected, while letting operators who want richer client-attribution turn it on.

**Who is this feature for?**

Anyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #
- https://github.com/grafana/pyroscope-squad/issues/781

Related slack thread https://raintank-corp.slack.com/archives/C04CHPYT954/p1777025454579199

**Special notes for your reviewer:**

Implementation mirrors the existing `[dataproxy] send_user_header` pattern (config-gated header injection that's also default-off). Same setting file, same `Cfg` struct location, same opt-in-by-default privacy.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
