### PR TITLE
Dashboards: Preserve query variable sort modes in v1->v2 conversion

### DIFF
--- a/public/app/features/dashboard-scene/serialization/transformToV2TypesUtils.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformToV2TypesUtils.test.ts
@@ -47,6 +47,10 @@ describe('transformToV2TypesUtils', () => {
       expect(transformSortVariableToEnum(2)).toBe('alphabeticalDesc');
       expect(transformSortVariableToEnum(3)).toBe('numericalAsc');
       expect(transformSortVariableToEnum(4)).toBe('numericalDesc');
+      expect(transformSortVariableToEnum(5)).toBe('alphabeticalCaseInsensitiveAsc');
+      expect(transformSortVariableToEnum(6)).toBe('alphabeticalCaseInsensitiveDesc');
+      expect(transformSortVariableToEnum(7)).toBe('naturalAsc');
+      expect(transformSortVariableToEnum(8)).toBe('naturalDesc');
       expect(transformSortVariableToEnum(undefined)).toBe(defaultVariableSort());
     });
   });

--- a/public/app/features/dashboard-scene/serialization/transformToV2TypesUtils.ts
+++ b/public/app/features/dashboard-scene/serialization/transformToV2TypesUtils.ts
@@ -73,6 +73,14 @@ export function transformSortVariableToEnum(sort?: VariableSortV1): VariableSort
       return 'numericalAsc';
     case 4:
       return 'numericalDesc';
+    case 5:
+      return 'alphabeticalCaseInsensitiveAsc';
+    case 6:
+      return 'alphabeticalCaseInsensitiveDesc';
+    case 7:
+      return 'naturalAsc';
+    case 8:
+      return 'naturalDesc';
     default:
       return defaultVariableSort();
   }


### PR DESCRIPTION
**What is this feature?**

This update preserves all query-variable sort modes when converting variable sort values from the v1 enum to the dashboard v2 string enum.

**Why do we need this feature?**

Several valid sort modes (case-insensitive and natural sort) were previously falling back to `disabled` during v1->v2 conversion, which caused sort settings to appear unsaved and revert after reload.

**Who is this feature for?**

Grafana dashboard authors configuring query variable sorting in dashboard settings.

**Which issue(s) does this PR fix?**:

Fixed #124106

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.

Test details:
- [x] `yarn jest --no-watch public/app/features/dashboard-scene/serialization/transformToV2TypesUtils.test.ts`