### PR TITLE
IAM: Implement UserK8sService.GetProfile method

### DIFF
--- a/pkg/services/user/userimpl/user.go
+++ b/pkg/services/user/userimpl/user.go
@@ -200,6 +200,14 @@ func (s *Service) BatchDisableUsers(ctx context.Context, cmd *user.BatchDisableU
 }
 
 func (s *Service) GetProfile(ctx context.Context, cmd *user.GetUserProfileQuery) (*user.UserProfileDTO, error) {
+	if s.isKubernetesUserServiceEnabled(ctx) {
+		k8sCtx := ctx
+		if !hasOrgID(ctx) {
+			k8sCtx = identity.WithOrgID(ctx, s.cfg.DefaultOrgID())
+		}
+		return s.k8sService.GetProfile(k8sCtx, cmd)
+	}
+
 	return s.legacyService.GetProfile(ctx, cmd)
 }
 

--- a/pkg/services/user/userk8s/user.go
+++ b/pkg/services/user/userk8s/user.go
@@ -430,7 +430,40 @@ func (s *UserK8sService) BatchDisableUsers(ctx context.Context, cmd *user.BatchD
 }
 
 func (s *UserK8sService) GetProfile(ctx context.Context, cmd *user.GetUserProfileQuery) (*user.UserProfileDTO, error) {
-	return nil, errors.New("not implemented")
+	ctx, span := s.tracer.Start(ctx, "user.getProfile", trace.WithAttributes(
+		attribute.Int64("userID", cmd.UserID),
+	))
+	defer span.End()
+
+	ctxLogger := s.logger.FromContext(ctx)
+
+	orgID, err := s.getOrgID(ctx, ctxLogger)
+	if err != nil {
+		ctxLogger.Error("failed to get orgID from context in GetProfile", "err", err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
+	}
+
+	namespace := s.namespaceMapper(orgID)
+	span.SetAttributes(attribute.Int64("orgID", orgID))
+
+	client, err := s.getUserClient()
+	if err != nil {
+		ctxLogger.Error("failed to get k8s client", "namespace", namespace, "err", err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
+	}
+
+	found, err := s.getByInternalID(ctx, ctxLogger, client, cmd.UserID, namespace)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return nil, err
+	}
+
+	return toUserProfileDTO(found, orgID), nil
 }
 
 func (s *UserK8sService) GetUsageStats(ctx context.Context) map[string]any {
@@ -528,6 +561,22 @@ func toSignedInUser(u *iamv0alpha1.User, orgID int64) *user.SignedInUser {
 	}
 
 	return signedInUser
+}
+
+func toUserProfileDTO(u *iamv0alpha1.User, orgID int64) *user.UserProfileDTO {
+	return &user.UserProfileDTO{
+		ID:             getUserID(u),
+		UID:            u.Name,
+		Email:          u.Spec.Email,
+		Name:           u.Spec.Title,
+		Login:          u.Spec.Login,
+		OrgID:          orgID,
+		IsGrafanaAdmin: u.Spec.GrafanaAdmin,
+		IsDisabled:     u.Spec.Disabled,
+		IsProvisioned:  u.Spec.Provisioned,
+		UpdatedAt:      u.GetUpdateTimestamp(),
+		CreatedAt:      u.CreationTimestamp.Time,
+	}
 }
 
 func toUser(u *iamv0alpha1.User, orgID int64) *user.User {

--- a/pkg/services/user/userk8s/user_test.go
+++ b/pkg/services/user/userk8s/user_test.go
@@ -1647,6 +1647,186 @@ func TestUserK8sService_GetSignedInUser(t *testing.T) {
 	}
 }
 
+func TestUserK8sService_GetProfile(t *testing.T) {
+	makeListResponse := func(users ...v0alpha1.User) func(http.ResponseWriter, *http.Request) {
+		return func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			items := make([]any, 0, len(users))
+			for _, u := range users {
+				items = append(items, u)
+			}
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"apiVersion": "v1",
+				"kind":       "List",
+				"items":      items,
+			})
+		}
+	}
+
+	tests := []struct {
+		name           string
+		cmd            *user.GetUserProfileQuery
+		requesterOrgID int64
+		serverResponse func(w http.ResponseWriter, r *http.Request)
+		nilProvider    bool
+		noReqContext   bool
+		noRequester    bool
+		expectErr      bool
+		expectErrIs    error
+		expectProfile  *user.UserProfileDTO
+	}{
+		{
+			name:           "successfully retrieves a user profile by internal ID",
+			requesterOrgID: 1,
+			cmd:            &user.GetUserProfileQuery{UserID: 42},
+			serverResponse: func(w http.ResponseWriter, r *http.Request) {
+				assert.Contains(t, r.URL.RawQuery, "labelSelector=grafana.app")
+				assert.Contains(t, r.URL.RawQuery, "42")
+				makeListResponse(newTestK8sUser("some-uid", "org-1", "jdoe", "jdoe@example.com"))(w, r)
+			},
+			expectProfile: &user.UserProfileDTO{
+				ID:             42,
+				UID:            "some-uid",
+				OrgID:          1,
+				Login:          "jdoe",
+				Email:          "jdoe@example.com",
+				Name:           "John Doe",
+				IsGrafanaAdmin: true,
+			},
+		},
+		{
+			name:           "maps all profile fields correctly",
+			requesterOrgID: 2,
+			cmd:            &user.GetUserProfileQuery{UserID: 7},
+			serverResponse: func(w http.ResponseWriter, r *http.Request) {
+				now := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+				u := v0alpha1.User{
+					TypeMeta: metav1.TypeMeta{
+						APIVersion: v0alpha1.GroupVersion.Identifier(),
+						Kind:       "User",
+					},
+					ObjectMeta: metav1.ObjectMeta{
+						Name:              "admin-uid",
+						Namespace:         "org-2",
+						Labels:            map[string]string{"grafana.app/deprecatedInternalID": "7"},
+						CreationTimestamp: metav1.NewTime(now),
+					},
+					Spec: v0alpha1.UserSpec{
+						Login:        "admin",
+						Email:        "admin@example.com",
+						Title:        "Admin User",
+						GrafanaAdmin: true,
+						Disabled:     true,
+						Provisioned:  true,
+					},
+				}
+				makeListResponse(u)(w, r)
+			},
+			expectProfile: &user.UserProfileDTO{
+				ID:             7,
+				UID:            "admin-uid",
+				OrgID:          2,
+				Login:          "admin",
+				Email:          "admin@example.com",
+				Name:           "Admin User",
+				IsGrafanaAdmin: true,
+				IsDisabled:     true,
+				IsProvisioned:  true,
+				CreatedAt:      time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+			},
+		},
+		{
+			name:           "returns ErrUserNotFound when no user matches",
+			requesterOrgID: 1,
+			cmd:            &user.GetUserProfileQuery{UserID: 99},
+			serverResponse: makeListResponse(),
+			expectErr:      true,
+			expectErrIs:    user.ErrUserNotFound,
+		},
+		{
+			name:           "returns error when multiple users found with same internal ID",
+			requesterOrgID: 1,
+			cmd:            &user.GetUserProfileQuery{UserID: 5},
+			serverResponse: makeListResponse(
+				newTestK8sUser("uid-1", "org-1", "user-a", "a@example.com"),
+				newTestK8sUser("uid-2", "org-1", "user-b", "b@example.com"),
+			),
+			expectErr: true,
+		},
+		{
+			name:           "propagates error from k8s client",
+			requesterOrgID: 1,
+			cmd:            &user.GetUserProfileQuery{UserID: 42},
+			serverResponse: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusInternalServerError)
+				_ = json.NewEncoder(w).Encode(metav1.Status{
+					TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Status"},
+					Status:   metav1.StatusFailure,
+					Message:  "k8s error",
+					Code:     http.StatusInternalServerError,
+				})
+			},
+			expectErr: true,
+		},
+		{
+			name:        "returns error when config provider not initialized",
+			cmd:         &user.GetUserProfileQuery{UserID: 42},
+			nilProvider: true,
+			expectErr:   true,
+		},
+		{
+			name:         "returns error when no request context",
+			cmd:          &user.GetUserProfileQuery{UserID: 42},
+			noReqContext: true,
+			expectErr:    true,
+		},
+		{
+			name:        "returns error when no requester in context",
+			cmd:         &user.GetUserProfileQuery{UserID: 42},
+			noRequester: true,
+			expectErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, ctx := setupServiceAndCtx(t, svcTestSetup{
+				nilProvider:    tt.nilProvider,
+				noReqContext:   tt.noReqContext,
+				noRequester:    tt.noRequester,
+				requesterOrgID: tt.requesterOrgID,
+				serverResponse: tt.serverResponse,
+			})
+
+			result, err := svc.GetProfile(ctx, tt.cmd)
+
+			if tt.expectErr {
+				require.Error(t, err)
+				if tt.expectErrIs != nil {
+					require.ErrorIs(t, err, tt.expectErrIs)
+				}
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			assert.Equal(t, tt.expectProfile.ID, result.ID)
+			assert.Equal(t, tt.expectProfile.UID, result.UID)
+			assert.Equal(t, tt.expectProfile.OrgID, result.OrgID)
+			assert.Equal(t, tt.expectProfile.Login, result.Login)
+			assert.Equal(t, tt.expectProfile.Email, result.Email)
+			assert.Equal(t, tt.expectProfile.Name, result.Name)
+			assert.Equal(t, tt.expectProfile.IsGrafanaAdmin, result.IsGrafanaAdmin)
+			assert.Equal(t, tt.expectProfile.IsDisabled, result.IsDisabled)
+			assert.Equal(t, tt.expectProfile.IsProvisioned, result.IsProvisioned)
+			if !tt.expectProfile.CreatedAt.IsZero() {
+				assert.Equal(t, tt.expectProfile.CreatedAt.UTC(), result.CreatedAt.UTC())
+			}
+		})
+	}
+}
+
 func newTestK8sUser(uid, namespace, login, email string) v0alpha1.User {
 	return v0alpha1.User{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/tests/apis/iam/user/user_service_integration_test.go
+++ b/pkg/tests/apis/iam/user/user_service_integration_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -75,7 +74,7 @@ func TestIntegrationUserServiceGet(t *testing.T) {
 			require.NotEmpty(t, secondUser.Result.UID)
 
 			t.Cleanup(func() {
-				if firstUser.Result.ID != 0 {
+				if mode < rest.Mode4 {
 					apis.DoRequest(helper, apis.RequestParams{
 						User:   helper.Org1.Admin,
 						Method: "DELETE",
@@ -180,77 +179,53 @@ func TestIntegrationUserServiceUpdate(t *testing.T) {
 			require.Equal(t, 200, createRsp.Response.StatusCode, "body: %s", string(createRsp.Body))
 			require.NotEmpty(t, createRsp.Result.UID)
 
-			if mode < rest.Mode4 {
-				// Modes 0–3 write to the legacy SQL database, so the legacy API can verify the updated user.
-				// UserK8sService.Update is exercised via PUT /api/users/{id} → Service.Update →
-				// k8sService.Update (because FlagKubernetesUsersRedirect is enabled).
-				t.Run("should update user via k8s service and verify it using the legacy API", func(t *testing.T) {
-					require.NotZero(t, createRsp.Result.ID)
+			t.Run("should update user via k8s service and verify it using /api/users/:id", func(t *testing.T) {
+				require.NotZero(t, createRsp.Result.ID)
 
-					t.Cleanup(func() {
+				t.Cleanup(func() {
+					if mode < rest.Mode4 {
 						apis.DoRequest(helper, apis.RequestParams{
 							User:   helper.Org1.Admin,
 							Method: "DELETE",
 							Path:   fmt.Sprintf("/api/admin/users/%d", createRsp.Result.ID),
 						}, &struct{}{})
-					})
-
-					updateRsp := apis.DoRequest(helper, apis.RequestParams{
-						User:   helper.Org1.Admin,
-						Method: "PUT",
-						Path:   fmt.Sprintf("/api/users/%d", createRsp.Result.ID),
-						Body:   []byte(`{"name": "Updated Name", "email": "updated@example.com", "login": "updated-user"}`),
-					}, &struct{}{})
-					require.Equal(t, 200, updateRsp.Response.StatusCode, "body: %s", string(updateRsp.Body))
-
-					type getUserResponse struct {
-						ID    int64  `json:"id"`
-						Name  string `json:"name"`
-						Email string `json:"email"`
-						Login string `json:"login"`
-					}
-
-					getRsp := apis.DoRequest(helper, apis.RequestParams{
-						User:   helper.Org1.Admin,
-						Method: "GET",
-						Path:   fmt.Sprintf("/api/users/%d", createRsp.Result.ID),
-					}, &getUserResponse{})
-
-					require.Equal(t, 200, getRsp.Response.StatusCode)
-					require.Equal(t, "Updated Name", getRsp.Result.Name)
-					require.Equal(t, "updated@example.com", getRsp.Result.Email)
-					require.Equal(t, "updated-user", getRsp.Result.Login)
-				})
-			} else {
-				// Modes 4–5 use the kubernetes API as the primary (or only) storage. Since the
-				// internal ID is not populated for these modes, the update is applied directly
-				// via the k8s client and verified with a subsequent Get.
-				t.Run("should update user via k8s service and verify it using the kubernetes API", func(t *testing.T) {
-					ctx := context.Background()
-
-					userClient := helper.GetResourceClient(apis.ResourceClientArgs{
-						User:      helper.Org1.Admin,
-						Namespace: helper.Namespacer(helper.Org1.Admin.Identity.GetOrgID()),
-						GVR:       gvrUsers,
-					})
-
-					t.Cleanup(func() {
+					} else {
+						ctx := context.Background()
+						userClient := helper.GetResourceClient(apis.ResourceClientArgs{
+							User:      helper.Org1.Admin,
+							Namespace: helper.Namespacer(helper.Org1.Admin.Identity.GetOrgID()),
+							GVR:       gvrUsers,
+						})
 						_ = userClient.Resource.Delete(ctx, createRsp.Result.UID, metav1.DeleteOptions{})
-					})
-
-					patchBody := []byte(`{"spec":{"title":"Updated K8s Name","email":"updated-k8s@example.com","login":"updated-k8s-user"}}`)
-					_, err := userClient.Resource.Patch(ctx, createRsp.Result.UID, types.MergePatchType, patchBody, metav1.PatchOptions{})
-					require.NoError(t, err)
-
-					fetched, err := userClient.Resource.Get(ctx, createRsp.Result.UID, metav1.GetOptions{})
-					require.NoError(t, err)
-
-					userSpec := fetched.Object["spec"].(map[string]interface{})
-					require.Equal(t, "Updated K8s Name", userSpec["title"])
-					require.Equal(t, "updated-k8s@example.com", userSpec["email"])
-					require.Equal(t, "updated-k8s-user", userSpec["login"])
+					}
 				})
-			}
+
+				updateRsp := apis.DoRequest(helper, apis.RequestParams{
+					User:   helper.Org1.Admin,
+					Method: "PUT",
+					Path:   fmt.Sprintf("/api/users/%d", createRsp.Result.ID),
+					Body:   []byte(`{"name": "Updated Name", "email": "updated@example.com", "login": "updated-user"}`),
+				}, &struct{}{})
+				require.Equal(t, 200, updateRsp.Response.StatusCode, "body: %s", string(updateRsp.Body))
+
+				type getUserResponse struct {
+					ID    int64  `json:"id"`
+					Name  string `json:"name"`
+					Email string `json:"email"`
+					Login string `json:"login"`
+				}
+
+				getRsp := apis.DoRequest(helper, apis.RequestParams{
+					User:   helper.Org1.Admin,
+					Method: "GET",
+					Path:   fmt.Sprintf("/api/users/%d", createRsp.Result.ID),
+				}, &getUserResponse{})
+
+				require.Equal(t, 200, getRsp.Response.StatusCode)
+				require.Equal(t, "Updated Name", getRsp.Result.Name)
+				require.Equal(t, "updated@example.com", getRsp.Result.Email)
+				require.Equal(t, "updated-user", getRsp.Result.Login)
+			})
 		})
 	}
 }
@@ -294,65 +269,48 @@ func TestIntegrationUserService(t *testing.T) {
 			require.Equal(t, 200, createRsp.Response.StatusCode, "body: %s", string(createRsp.Body))
 			require.NotEmpty(t, createRsp.Result.UID)
 
-			if mode <= rest.Mode3 {
-				// Modes 0–3 write to the legacy SQL database, so the legacy API can verify the user.
-				// UserID is only populated in these modes because SetDeprecatedInternalID is only set
-				// by the LegacyStore on the returned k8s object.
-				t.Run("should create user via k8s service and verify it using the legacy API", func(t *testing.T) {
-					require.NotZero(t, createRsp.Result.ID)
+			t.Run("should create user via k8s service and verify it using /api/users/:id", func(t *testing.T) {
+				require.NotZero(t, createRsp.Result.ID)
 
-					type getUserResponse struct {
-						ID    int64  `json:"id"`
-						UID   string `json:"uid"`
-						Name  string `json:"name"`
-						Email string `json:"email"`
-						Login string `json:"login"`
-					}
+				type getUserResponse struct {
+					ID    int64  `json:"id"`
+					UID   string `json:"uid"`
+					Name  string `json:"name"`
+					Email string `json:"email"`
+					Login string `json:"login"`
+				}
 
-					getRsp := apis.DoRequest(helper, apis.RequestParams{
-						User:   helper.Org1.Admin,
-						Method: "GET",
-						Path:   fmt.Sprintf("/api/users/%d", createRsp.Result.ID),
-					}, &getUserResponse{})
+				getRsp := apis.DoRequest(helper, apis.RequestParams{
+					User:   helper.Org1.Admin,
+					Method: "GET",
+					Path:   fmt.Sprintf("/api/users/%d", createRsp.Result.ID),
+				}, &getUserResponse{})
 
-					require.Equal(t, 200, getRsp.Response.StatusCode)
-					require.Equal(t, createRsp.Result.ID, getRsp.Result.ID)
-					require.Equal(t, createRsp.Result.UID, getRsp.Result.UID)
-					require.Equal(t, "K8s Service User", getRsp.Result.Name)
-					require.Equal(t, "k8s-service-user@example.com", getRsp.Result.Email)
-					require.Equal(t, "k8s-service-user", getRsp.Result.Login)
+				require.Equal(t, 200, getRsp.Response.StatusCode)
+				require.Equal(t, createRsp.Result.ID, getRsp.Result.ID)
+				require.Equal(t, createRsp.Result.UID, getRsp.Result.UID)
+				require.Equal(t, "K8s Service User", getRsp.Result.Name)
+				require.Equal(t, "k8s-service-user@example.com", getRsp.Result.Email)
+				require.Equal(t, "k8s-service-user", getRsp.Result.Login)
 
+				if mode <= rest.Mode3 {
 					deleteRsp := apis.DoRequest(helper, apis.RequestParams{
 						User:   helper.Org1.Admin,
 						Method: "DELETE",
 						Path:   fmt.Sprintf("/api/admin/users/%d", createRsp.Result.ID),
 					}, &struct{}{})
 					require.Equal(t, 200, deleteRsp.Response.StatusCode)
-				})
-			} else {
-				// Modes 4–5 use the kubernetes API as the primary (or only) storage, so the k8s
-				// client is used for verification and cleanup.
-				t.Run("should create user via k8s service and verify it using the kubernetes API", func(t *testing.T) {
+				} else {
 					ctx := context.Background()
-
 					userClient := helper.GetResourceClient(apis.ResourceClientArgs{
 						User:      helper.Org1.Admin,
 						Namespace: helper.Namespacer(helper.Org1.Admin.Identity.GetOrgID()),
 						GVR:       gvrUsers,
 					})
-
-					fetched, err := userClient.Resource.Get(ctx, createRsp.Result.UID, metav1.GetOptions{})
+					err := userClient.Resource.Delete(ctx, createRsp.Result.UID, metav1.DeleteOptions{})
 					require.NoError(t, err)
-
-					userSpec := fetched.Object["spec"].(map[string]interface{})
-					require.Equal(t, "K8s Service User", userSpec["title"])
-					require.Equal(t, "k8s-service-user@example.com", userSpec["email"])
-					require.Equal(t, "k8s-service-user", userSpec["login"])
-
-					err = userClient.Resource.Delete(ctx, createRsp.Result.UID, metav1.DeleteOptions{})
-					require.NoError(t, err)
-				})
-			}
+				}
+			})
 		})
 	}
 }


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR implements `UserK8sService.GetProfile`, which fetches the user from the IAM k8s API by its internal numeric ID and maps the result to `UserProfileDTO`. It also wires the method into the service wrapper so calls are routed to the k8s implementation when the flag is on, consistent with how other methods are dispatched.

With this in place, the GET `/api/users/:id` endpoint is fully served by the k8s backend across all dual-writer modes. Fields like avatarUrl, authLabels, and accessControl continue to be enriched by the HTTP handler layer after GetProfile returns, so there is no change in the shape of the API response.

The integration tests are updated to reflect this: the mode-based branching that previously sent modes 4–5 to the raw k8s API for verification is removed, and all modes now verify through `GET /api/users/:id`.

**Why do we need this feature?**

This is part of the ongoing migration to store users in Kubernetes.

**Who is this feature for?**

all users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
