### PR TITLE
GHActions: Fix workflow that runs make update-workspace for Dependabot

### DIFF
--- a/.github/workflows/pr-dependabot-update-go-workspace.yml
+++ b/.github/workflows/pr-dependabot-update-go-workspace.yml
@@ -34,6 +34,7 @@ jobs:
       uses: actions/create-github-app-token@v1
       with:
         app-id: ${{ env.APP_ID }}
+        installation-id: ${{ env.APP_INSTALLATION_ID }}
         private-key: ${{ env.PRIVATE_KEY }}
 
     - name: Checkout repository
@@ -53,17 +54,17 @@ jobs:
       run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
-          git config --local --add --bool push.autoSetupRemote true
 
     - name: Update workspace
       run: make update-workspace
 
     - name: Commit and push workspace changes
       env:
-        BRANCH_NAME: ${{ github.head_ref || github.ref_name }} 
+        BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+        GH_TOKEN: ${{ steps.generate_token.outputs.token }}
       run: |
         if ! git diff --exit-code --quiet; then
           echo "Committing and pushing workspace changes"
           git commit -a -m "update workspace"
-          git push origin "$BRANCH_NAME"
+          git push "https://x-access-token:${GH_TOKEN}@github.com/grafana/grafana.git" "HEAD:${BRANCH_NAME}"
         fi


### PR DESCRIPTION
Dependabot PRs run this workflow so it can run `make update-workspace` to fix any dependency drifts, but it is failing:

```
fatal: could not read Username for 'https://github.com/': No such device or address
Error: Process completed with exit code 128.
```

Claude mentions:
> Root cause: line 45 sets persist-credentials: false, so after checkout the remote has no auth header. The commit works (local), but git push origin then prompts for a username and fails in CI.
