### PR TITLE
search: cold-start coordination for index snapshot builds

### DIFF
--- a/pkg/storage/unified/resource/bleve_index_metrics.go
+++ b/pkg/storage/unified/resource/bleve_index_metrics.go
@@ -27,6 +27,7 @@ type BleveIndexMetrics struct {
 	IndexSnapshotDownloadDuration         prometheus.Histogram
 	IndexSnapshotUploads                  *prometheus.CounterVec
 	IndexSnapshotUploadDuration           prometheus.Histogram
+	IndexSnapshotColdStarts               *prometheus.CounterVec
 	IndexSnapshotNamespaceCleanups        *prometheus.CounterVec
 	IndexSnapshotDeleted                  *prometheus.CounterVec
 	IndexSnapshotIncompleteUploadsCleaned prometheus.Counter
@@ -117,7 +118,7 @@ func ProvideIndexMetrics(reg prometheus.Registerer) *BleveIndexMetrics {
 		IndexSnapshotUploads: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "index_server_snapshot_uploads_total",
 			Help: "Number of remote index snapshot upload attempts, by outcome.",
-		}, []string{"status"}), // status: success, skip_no_changes, skip_lock_contention, skip_recent_remote, skip_not_owner, error
+		}, []string{"status"}), // status: success, skip_no_changes, skip_lock_contention, skip_lock_lost, skip_recent_remote, skip_not_owner, error
 		IndexSnapshotUploadDuration: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
 			Name:                            "index_server_snapshot_upload_duration_seconds",
 			Help:                            "Duration of successful remote index snapshot uploads, including snapshot creation.",
@@ -126,6 +127,10 @@ func ProvideIndexMetrics(reg prometheus.Registerer) *BleveIndexMetrics {
 			NativeHistogramMaxBucketNumber:  160,
 			NativeHistogramMinResetDuration: time.Hour,
 		}),
+		IndexSnapshotColdStarts: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "index_server_snapshot_cold_start_total",
+			Help: "Number of cold-start build coordination outcomes, by outcome.",
+		}, []string{"outcome"}), // outcome: acquired_lock, downloaded_after_wait, wait_timed_out, lock_error
 		IndexSnapshotNamespaceCleanups: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "index_server_snapshot_namespace_cleanups_total",
 			Help: "Number of namespace-level remote index snapshot cleanup attempts, by outcome.",
@@ -157,7 +162,7 @@ func (m *BleveIndexMetrics) InitSnapshotMetrics() {
 	if m == nil {
 		return
 	}
-	for _, policy := range []string{"tiered", "same_version"} {
+	for _, policy := range []string{"tiered", "same_version", "cold_start"} {
 		m.IndexSnapshotDownloads.WithLabelValues(policy, "success").Add(0)
 		m.IndexSnapshotDownloads.WithLabelValues(policy, "empty").Add(0)
 		m.IndexSnapshotDownloads.WithLabelValues(policy, "download_error").Add(0)
@@ -166,9 +171,14 @@ func (m *BleveIndexMetrics) InitSnapshotMetrics() {
 	m.IndexSnapshotUploads.WithLabelValues("success").Add(0)
 	m.IndexSnapshotUploads.WithLabelValues("skip_no_changes").Add(0)
 	m.IndexSnapshotUploads.WithLabelValues("skip_lock_contention").Add(0)
+	m.IndexSnapshotUploads.WithLabelValues("skip_lock_lost").Add(0)
 	m.IndexSnapshotUploads.WithLabelValues("skip_recent_remote").Add(0)
 	m.IndexSnapshotUploads.WithLabelValues("skip_not_owner").Add(0)
 	m.IndexSnapshotUploads.WithLabelValues("error").Add(0)
+	m.IndexSnapshotColdStarts.WithLabelValues("acquired_lock").Add(0)
+	m.IndexSnapshotColdStarts.WithLabelValues("downloaded_after_wait").Add(0)
+	m.IndexSnapshotColdStarts.WithLabelValues("wait_timed_out").Add(0)
+	m.IndexSnapshotColdStarts.WithLabelValues("lock_error").Add(0)
 	m.IndexSnapshotNamespaceCleanups.WithLabelValues("success").Add(0)
 	m.IndexSnapshotNamespaceCleanups.WithLabelValues("error").Add(0)
 	m.IndexSnapshotNamespaceCleanups.WithLabelValues("skip_lock_held").Add(0)

--- a/pkg/storage/unified/resource/bleve_index_metrics.go
+++ b/pkg/storage/unified/resource/bleve_index_metrics.go
@@ -130,7 +130,7 @@ func ProvideIndexMetrics(reg prometheus.Registerer) *BleveIndexMetrics {
 		IndexSnapshotColdStarts: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "index_server_snapshot_cold_start_total",
 			Help: "Number of cold-start build coordination outcomes, by outcome.",
-		}, []string{"outcome"}), // outcome: acquired_lock, downloaded_after_wait, wait_timed_out, lock_error
+		}, []string{"outcome"}), // outcome: acquired_lock, downloaded_after_wait, wait_timed_out, lock_error, context_canceled
 		IndexSnapshotNamespaceCleanups: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "index_server_snapshot_namespace_cleanups_total",
 			Help: "Number of namespace-level remote index snapshot cleanup attempts, by outcome.",
@@ -179,6 +179,7 @@ func (m *BleveIndexMetrics) InitSnapshotMetrics() {
 	m.IndexSnapshotColdStarts.WithLabelValues("downloaded_after_wait").Add(0)
 	m.IndexSnapshotColdStarts.WithLabelValues("wait_timed_out").Add(0)
 	m.IndexSnapshotColdStarts.WithLabelValues("lock_error").Add(0)
+	m.IndexSnapshotColdStarts.WithLabelValues("context_canceled").Add(0)
 	m.IndexSnapshotNamespaceCleanups.WithLabelValues("success").Add(0)
 	m.IndexSnapshotNamespaceCleanups.WithLabelValues("error").Add(0)
 	m.IndexSnapshotNamespaceCleanups.WithLabelValues("skip_lock_held").Add(0)

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -411,6 +411,7 @@ const (
 	snapshotUploadStatusSuccess          = "success"
 	snapshotUploadStatusSkipNoChanges    = "skip_no_changes"
 	snapshotUploadStatusSkipLockHeld     = "skip_lock_contention"
+	snapshotUploadStatusSkipLockLost     = "skip_lock_lost"
 	snapshotUploadStatusSkipRecentRemote = "skip_recent_remote"
 	snapshotUploadStatusSkipNotOwner     = "skip_not_owner"
 	snapshotUploadStatusError            = "error"
@@ -664,6 +665,14 @@ func (b *bleveBackend) BuildIndex(
 	fileIndexName := "" // Name of the file-based index, or empty for in-memory indexes.
 	newIndexType := indexStorageMemory
 	build := true
+	// Held across a leader's from-scratch build + immediate upload.
+	// Released by a defer set up when the lock is acquired.
+	var coldStartLeaderLock IndexStoreLock
+
+	// True when remote-snapshot interactions (download, cold-start, upload)
+	// are eligible: a snapshot store is configured and the index is large
+	// enough to justify a round-trip.
+	snapshotEnabled := b.opts.Snapshot.Store != nil && size >= b.opts.Snapshot.MinDocCount
 
 	if size >= b.opts.FileThreshold {
 		newIndexType = indexStorageFile
@@ -697,25 +706,59 @@ func (b *bleveBackend) BuildIndex(
 				}
 			}
 
-			// No valid local index — if a remote snapshot store is configured and the
-			// index is large enough to justify a round-trip, try downloading one.
-			if index == nil && b.opts.Snapshot.Store != nil && size >= b.opts.Snapshot.MinDocCount {
+			// No valid local index — if a remote snapshot store is configured
+			// and the index is large enough to justify a round-trip, try
+			// downloading one. First the tiered selection (any usable
+			// snapshot); on miss, cold-start coordination (same-version,
+			// leader builds + uploads while replicas wait to download).
+			if index == nil && snapshotEnabled {
 				dlIdx, dlName, dlRV, dlErr := b.tryDownloadRemoteSnapshot(ctx, key, resourceDir, logWithDetails)
 				if dlErr != nil {
+					if ctxErr := ctx.Err(); ctxErr != nil {
+						return nil, ctxErr
+					}
 					logWithDetails.Warn("Failed to download remote snapshot, will build from scratch", "err", dlErr)
 				} else if dlIdx != nil {
 					index, fileIndexName, indexRV = dlIdx, dlName, dlRV
 				}
+
+				if index == nil {
+					dlIdx, dlName, dlRV, lock, coordErr := b.coordinateColdStartBuild(ctx, key, resourceDir, lastImportTime, logWithDetails)
+					if coordErr != nil {
+						if ctxErr := ctx.Err(); ctxErr != nil {
+							return nil, ctxErr
+						}
+						logWithDetails.Warn("Cold-start coordination failed, will build alone", "err", coordErr)
+					} else if dlIdx != nil {
+						index, fileIndexName, indexRV = dlIdx, dlName, dlRV
+					} else if lock != nil {
+						coldStartLeaderLock = lock
+						defer func() {
+							if coldStartLeaderLock != nil {
+								if releaseErr := coldStartLeaderLock.Release(); releaseErr != nil {
+									logWithDetails.Warn("Releasing cold-start build lock", "err", releaseErr)
+								}
+							}
+						}()
+					}
+				}
 			}
-		} else if rebuild && b.opts.Snapshot.Store != nil && size >= b.opts.Snapshot.MinDocCount && maxFreshSnapshotAge > 0 {
+		} else if rebuild && snapshotEnabled && maxFreshSnapshotAge > 0 {
 			// Rebuild path: before paying the cost of a from-scratch
 			// rebuild, check whether the remote index store holds a same-version snapshot
 			// fresh enough to serve as a drop-in replacement. Strict policy:
 			// exact BuildVersion match, BuildTime within maxFreshSnapshotAge
 			// AND strictly after lastImportTime. On miss, fall through to
 			// rebuild — no tiered fallback (we already have a working index).
-			dlIdx, dlName, dlRV, dlErr := b.tryDownloadFreshSnapshot(ctx, key, resourceDir, lastImportTime, maxFreshSnapshotAge, logWithDetails)
+			dlIdx, dlName, dlRV, dlErr := b.tryDownloadFreshSameVersionSnapshot(
+				ctx, key, resourceDir, lastImportTime, maxFreshSnapshotAge,
+				snapshotPolicySameVersion, "search.remote_index_snapshot.download_fresh",
+				logWithDetails,
+			)
 			if dlErr != nil {
+				if ctxErr := ctx.Err(); ctxErr != nil {
+					return nil, ctxErr
+				}
 				logWithDetails.Warn("Failed to download fresh remote snapshot, will rebuild from scratch", "err", dlErr)
 			} else if dlIdx != nil {
 				index, fileIndexName, indexRV = dlIdx, dlName, dlRV
@@ -790,6 +833,45 @@ func (b *bleveBackend) BuildIndex(
 
 		if b.indexMetrics != nil {
 			b.indexMetrics.IndexCreationTime.WithLabelValues().Observe(elapsed.Seconds())
+		}
+
+		// Leader path: upload the freshly-built snapshot now so waiting
+		// replicas can download it. Skip the periodic upload's probe (we
+		// just built it) and reuse the held lock. On failure the next
+		// periodic tick retries.
+		if coldStartLeaderLock != nil {
+			switch {
+			case checkSnapshotLock(coldStartLeaderLock) != nil:
+				// Lock lost during the build. Another replica may already
+				// be uploading; skip and let the periodic tick reconcile.
+				logWithDetails.Warn("Cold-start leader lock lost during build; skipping immediate upload")
+				if b.indexMetrics != nil {
+					b.indexMetrics.IndexSnapshotUploads.WithLabelValues(snapshotUploadStatusSkipLockLost).Inc()
+				}
+			default:
+				baselineMutations, mErr := idx.getSnapshotMutationCount()
+				if mErr != nil {
+					logWithDetails.Warn("Failed to read snapshot mutation baseline for leader upload", "err", mErr)
+				}
+				uploadKey, uploadRV, upErr := b.snapshotCopyAndUpload(ctx, key, idx, coldStartLeaderLock)
+				if upErr != nil {
+					logWithDetails.Warn("Cold-start leader immediate snapshot upload failed", "err", upErr)
+					if b.indexMetrics != nil {
+						b.indexMetrics.IndexSnapshotUploads.WithLabelValues(snapshotUploadStatusError).Inc()
+					}
+				} else {
+					if mErr == nil {
+						if subErr := idx.subtractSnapshotMutationCount(baselineMutations); subErr != nil {
+							logWithDetails.Warn("Failed to advance snapshot mutation baseline after leader upload", "err", subErr)
+						}
+					}
+					b.setUploadTracking(key, time.Now())
+					if b.indexMetrics != nil {
+						b.indexMetrics.IndexSnapshotUploads.WithLabelValues(snapshotUploadStatusSuccess).Inc()
+					}
+					logWithDetails.Info("Cold-start leader uploaded freshly-built snapshot", "snapshot_key", uploadKey.String(), "snapshot_rv", uploadRV)
+				}
+			}
 		}
 	} else {
 		logWithDetails.Info("Skipping index build, using existing index")

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -722,7 +722,13 @@ func (b *bleveBackend) BuildIndex(
 					index, fileIndexName, indexRV = dlIdx, dlName, dlRV
 				}
 
-				if index == nil {
+				// Cold-start coordination only runs when MaxIndexAge>0; with
+				// MaxIndexAge=0 the probe is a no-op (all freshness filters
+				// reject), so the lock+wait would only serialise N replicas'
+				// from-scratch builds without any snapshot-reuse upside. The
+				// MaxIndexAge=0 semantics deserve a wider revisit (covered by
+				// the follow-up issue), at which point this gate can be removed.
+				if index == nil && b.opts.Snapshot.MaxIndexAge > 0 {
 					dlIdx, dlName, dlRV, lock, coordErr := b.coordinateColdStartBuild(ctx, key, resourceDir, lastImportTime, logWithDetails)
 					if coordErr != nil {
 						if ctxErr := ctx.Err(); ctxErr != nil {
@@ -845,9 +851,7 @@ func (b *bleveBackend) BuildIndex(
 				// Lock lost during the build. Another replica may already
 				// be uploading; skip and let the periodic tick reconcile.
 				logWithDetails.Warn("Cold-start leader lock lost during build; skipping immediate upload")
-				if b.indexMetrics != nil {
-					b.indexMetrics.IndexSnapshotUploads.WithLabelValues(snapshotUploadStatusSkipLockLost).Inc()
-				}
+				b.recordSnapshotUploadStatus(snapshotUploadStatusSkipLockLost)
 			default:
 				baselineMutations, mErr := idx.getSnapshotMutationCount()
 				if mErr != nil {
@@ -856,9 +860,7 @@ func (b *bleveBackend) BuildIndex(
 				uploadKey, uploadRV, upErr := b.snapshotCopyAndUpload(ctx, key, idx, coldStartLeaderLock)
 				if upErr != nil {
 					logWithDetails.Warn("Cold-start leader immediate snapshot upload failed", "err", upErr)
-					if b.indexMetrics != nil {
-						b.indexMetrics.IndexSnapshotUploads.WithLabelValues(snapshotUploadStatusError).Inc()
-					}
+					b.recordSnapshotUploadStatus(snapshotUploadStatusError)
 				} else {
 					if mErr == nil {
 						if subErr := idx.subtractSnapshotMutationCount(baselineMutations); subErr != nil {
@@ -866,9 +868,7 @@ func (b *bleveBackend) BuildIndex(
 						}
 					}
 					b.setUploadTracking(key, time.Now())
-					if b.indexMetrics != nil {
-						b.indexMetrics.IndexSnapshotUploads.WithLabelValues(snapshotUploadStatusSuccess).Inc()
-					}
+					b.recordSnapshotUploadStatus(snapshotUploadStatusSuccess)
 					logWithDetails.Info("Cold-start leader uploaded freshly-built snapshot", "snapshot_key", uploadKey.String(), "snapshot_rv", uploadRV)
 				}
 			}

--- a/pkg/storage/unified/search/bleve_snapshot.go
+++ b/pkg/storage/unified/search/bleve_snapshot.go
@@ -612,6 +612,11 @@ func (b *bleveBackend) coordinateColdStartBuild(
 		case errors.Is(err, errLockHeld):
 			// keep waiting
 		default:
+			// Propagate context cancellation so callers can abort cleanly
+			// instead of falling through to a from-scratch build.
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				return nil, "", 0, nil, ctxErr
+			}
 			logger.Warn("Cold-start lock acquire failed; will build alone", "err", err)
 			outcome = coldStartOutcomeLockError
 			return nil, "", 0, nil, nil

--- a/pkg/storage/unified/search/bleve_snapshot.go
+++ b/pkg/storage/unified/search/bleve_snapshot.go
@@ -27,6 +27,10 @@ const (
 	// snapshotPolicySameVersion selects via findFreshSnapshotByBuildStart
 	// (rebuild; strict same-version freshness).
 	snapshotPolicySameVersion = "same_version"
+	// snapshotPolicyColdStart labels downloads taken during cold-start
+	// coordination. Strict same-version, freshness against
+	// Snapshot.MaxIndexAge.
+	snapshotPolicyColdStart = "cold_start"
 
 	snapshotStatusSuccess       = "success"
 	snapshotStatusEmpty         = "empty"
@@ -84,48 +88,36 @@ func (b *bleveBackend) tryDownloadRemoteSnapshot(
 	)
 }
 
-// tryDownloadFreshSnapshot probes the remote index store for a same-version
-// snapshot whose BuildTime is within the last maxFreshSnapshotAge AND
-// strictly after lastImportTime, downloads and opens it locally.
-//
-// Used on the rebuild path: when a fresh-enough same-version snapshot
-// exists, we download it instead of paying the cost of rebuilding from
-// scratch.
-//
-// Return contract mirrors tryDownloadRemoteSnapshot:
-//   - On success: (idx, dirName, rv, nil)
-//   - No fresh candidate: (nil, "", 0, nil) — caller should rebuild
-//   - Error: (nil, "", 0, err)
-//
-// Combining the two cutoffs: the probe accepts BuildTime > now-maxAge.
-// We bump maxAge down so that BuildTime > lastImportTime is also enforced
-// in the same pass — equivalent to BuildTime > max(now-maxAge, lastImport).
-func (b *bleveBackend) tryDownloadFreshSnapshot(
+// tryDownloadFreshSameVersionSnapshot looks for a same-version snapshot
+// in the remote index store with BuildTime newer than max(now-maxAge,
+// lastImportTime), and downloads it. Shared between the rebuild path and
+// cold-start coordination; callers pass their own maxAge and policy /
+// span labels. Returns (nil, "", 0, nil) when no candidate matches.
+func (b *bleveBackend) tryDownloadFreshSameVersionSnapshot(
 	ctx context.Context,
 	key resource.NamespacedResource,
 	resourceDir string,
 	lastImportTime time.Time,
-	maxFreshSnapshotAge time.Duration,
+	maxAge time.Duration,
+	policy, spanName string,
 	logger log.Logger,
 ) (bleve.Index, string, int64, error) {
-	logger.Info("Fresh remote index snapshot download started", "policy", snapshotPolicySameVersion, "max_fresh_age", maxFreshSnapshotAge, "last_import_time", lastImportTime)
+	logger.Info("Fresh same-version index snapshot download started", "policy", policy, "max_age", maxAge, "last_import_time", lastImportTime)
 
 	// Combine the freshness cutoff with the lastImportTime correctness check.
 	// Both are "BuildTime must be after X"; take the more restrictive X.
-	effectiveMaxAge := maxFreshSnapshotAge
+	effectiveMaxAge := maxAge
 	if !lastImportTime.IsZero() {
 		if since := time.Since(lastImportTime); since < effectiveMaxAge {
 			effectiveMaxAge = since
 		}
 	}
 
-	return b.downloadSelectedSnapshot(ctx, key, resourceDir,
-		snapshotPolicySameVersion, "search.remote_index_snapshot.download_fresh", logger,
+	return b.downloadSelectedSnapshot(ctx, key, resourceDir, policy, spanName, logger,
 		func(ctx context.Context) (ulid.ULID, *IndexMeta, error) {
 			if effectiveMaxAge <= 0 {
-				// lastImportTime is in the future (clock skew) or
-				// maxFreshSnapshotAge is non-positive; no snapshot can satisfy
-				// the freshness window.
+				// lastImportTime is in the future (clock skew) or maxAge is
+				// non-positive; no snapshot can satisfy the freshness window.
 				return ulid.ULID{}, nil, nil
 			}
 			k, m, err := findFreshSnapshotByBuildStart(ctx, b.opts.Snapshot.Store, key, effectiveMaxAge, b.opts.BuildVersion)
@@ -170,8 +162,9 @@ func (b *bleveBackend) downloadSelectedSnapshot(
 				attribute.String("snapshot_version", meta.BuildVersion),
 				attribute.Int64("snapshot_rv", meta.LatestResourceVersion),
 			)
-			// Zero-value BuildTime means the snapshot was uploaded before #768
-			// added the field; logging "0001-01-01" would be misleading.
+			// Zero-value BuildTime means the snapshot was uploaded before that
+			// field was added to IndexMeta; logging "0001-01-01" would be
+			// misleading.
 			if !meta.BuildTime.IsZero() {
 				attrs = append(attrs, attribute.String("snapshot_build_time", meta.BuildTime.UTC().Format(time.RFC3339)))
 			}
@@ -521,4 +514,163 @@ func findFreshSnapshotByBuildStart(
 	}
 
 	return ulid.ULID{}, nil, nil
+}
+
+// Outcome labels for the IndexSnapshotColdStarts metric.
+const (
+	coldStartOutcomeAcquiredLock        = "acquired_lock"
+	coldStartOutcomeDownloadedAfterWait = "downloaded_after_wait"
+	coldStartOutcomeWaitTimedOut        = "wait_timed_out"
+	coldStartOutcomeLockError           = "lock_error"
+)
+
+// Wait-for-leader timing. Package-level vars so tests can shrink them.
+var (
+	coldStartPollInterval = 30 * time.Second
+	coldStartTotalWait    = 15 * time.Minute
+)
+
+// coordinateColdStartBuild coordinates from-scratch index builds across
+// same-version replicas. Called when BuildIndex has no usable local index
+// and the tiered remote selection found nothing.
+//
+// Outcomes:
+//   - (idx, name, rv, nil, nil) -- another replica's snapshot was downloaded; caller skips build.
+//   - (nil, "", 0, lock, nil)   -- caller is the leader; build, upload immediately, then release lock.
+//   - (nil, "", 0, nil, nil)    --  no snapshot and no leader slot in time; caller builds alone.
+//   - (nil, "", 0, nil, err)    -- context cancelled mid-coordination.
+//
+// Each iteration, up to coldStartTotalWait:
+//  1. Probe for a usable same-version snapshot. If found, download it.
+//  2. Try to acquire LockBuildIndex (no waiting). If acquired, return as
+//     leader (lock held for the whole build).
+//  3. Wait coldStartPollInterval and try again.
+//
+// Probe runs before tryAcquire so that we download a leader's just-
+// uploaded snapshot instead of becoming a duplicate leader after the
+// leader releases the lock (the leader uploads then releases; by the
+// time the lock is free the snapshot is in the store).
+//
+// The lock prevents duplicate expensive builds but is not a correctness
+// primitive: lock loss, leader death, or wait timeout all degrade to
+// duplicate work. ULID-keyed snapshots are immutable and cleanup reaps
+// duplicates.
+func (b *bleveBackend) coordinateColdStartBuild(
+	ctx context.Context,
+	key resource.NamespacedResource,
+	resourceDir string,
+	lastImportTime time.Time,
+	logger log.Logger,
+) (_ bleve.Index, _ string, _ int64, _ IndexStoreLock, retErr error) {
+	ctx, span := tracer.Start(ctx, "search.remote_index_snapshot.cold_start")
+	start := time.Now()
+	outcome := coldStartOutcomeWaitTimedOut
+	defer func() {
+		span.SetAttributes(
+			attribute.String("namespace", key.Namespace),
+			attribute.String("group", key.Group),
+			attribute.String("resource", key.Resource),
+			attribute.String("outcome", outcome),
+		)
+		if retErr != nil {
+			span.RecordError(retErr)
+			span.SetStatus(codes.Error, retErr.Error())
+		}
+		b.recordColdStartOutcome(outcome)
+		logger.Info("Cold-start coordination completed", "elapsed", time.Since(start), "outcome", outcome)
+		span.End()
+	}()
+	// Probe freshness window: Snapshot.MaxIndexAge, the same hard age
+	// filter the tiered selection applies. We don't reuse the rebuild
+	// path's tighter maxFreshSnapshotAge — on a cold start any
+	// same-version snapshot beats rebuilding, so we want the loosest
+	// threshold. Zero means "skip the probe"; the lock + wait loop still
+	// coordinates.
+	probeMaxAge := b.opts.Snapshot.MaxIndexAge
+	logger.Info("Cold-start coordination started", "probe_max_age", probeMaxAge, "last_import_time", lastImportTime)
+
+	ticker := time.NewTicker(coldStartPollInterval)
+	defer ticker.Stop()
+	deadline := time.NewTimer(coldStartTotalWait)
+	defer deadline.Stop()
+
+	for {
+		idx, name, rv, err := b.tryDownloadColdStartSnapshot(ctx, key, resourceDir, lastImportTime, probeMaxAge, logger)
+		if err != nil {
+			return nil, "", 0, nil, err
+		}
+		if idx != nil {
+			outcome = coldStartOutcomeDownloadedAfterWait
+			return idx, name, rv, nil, nil
+		}
+
+		lock, err := b.opts.Snapshot.Store.LockBuildIndex(ctx, key, b.opts.BuildVersion)
+		switch {
+		case err == nil:
+			outcome = coldStartOutcomeAcquiredLock
+			return nil, "", 0, lock, nil
+		case errors.Is(err, errLockHeld):
+			// keep waiting
+		default:
+			logger.Warn("Cold-start lock acquire failed; will build alone", "err", err)
+			outcome = coldStartOutcomeLockError
+			return nil, "", 0, nil, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return nil, "", 0, nil, ctx.Err()
+		case <-deadline.C:
+			outcome = coldStartOutcomeWaitTimedOut
+			return nil, "", 0, nil, nil
+		case <-ticker.C:
+		}
+	}
+}
+
+// tryDownloadColdStartSnapshot checks whether a usable same-version
+// snapshot already exists in the remote index store, and downloads it if
+// so. Called once per iteration of coordinateColdStartBuild's loop.
+//
+//   - probeMaxAge <= 0: don't contact the store; coordination falls back
+//     to the lock + wait loop alone.
+//   - idx != nil: snapshot downloaded and returned.
+//   - idx == nil, err == nil: no usable snapshot right now.
+//   - err != nil: only ctx.Err() is propagated. List/get/download failures
+//     are logged and treated as "no hit" — this lookup is an optimisation,
+//     not a correctness check.
+func (b *bleveBackend) tryDownloadColdStartSnapshot(
+	ctx context.Context,
+	key resource.NamespacedResource,
+	resourceDir string,
+	lastImportTime time.Time,
+	probeMaxAge time.Duration,
+	logger log.Logger,
+) (bleve.Index, string, int64, error) {
+	if probeMaxAge <= 0 {
+		return nil, "", 0, nil
+	}
+	idx, name, rv, err := b.tryDownloadFreshSameVersionSnapshot(
+		ctx, key, resourceDir, lastImportTime, probeMaxAge,
+		snapshotPolicyColdStart, "search.remote_index_snapshot.download_cold_start",
+		logger,
+	)
+	if err != nil {
+		// Probe is an optimisation — list/get errors shouldn't abort
+		// coordination. Surface ctx.Err() so the wait loop exits promptly,
+		// but treat everything else as "no hit".
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, "", 0, ctxErr
+		}
+		logger.Warn("Cold-start probe failed; will keep coordinating", "err", err)
+		return nil, "", 0, nil
+	}
+	return idx, name, rv, nil
+}
+
+func (b *bleveBackend) recordColdStartOutcome(outcome string) {
+	if b.indexMetrics == nil {
+		return
+	}
+	b.indexMetrics.IndexSnapshotColdStarts.WithLabelValues(outcome).Inc()
 }

--- a/pkg/storage/unified/search/bleve_snapshot.go
+++ b/pkg/storage/unified/search/bleve_snapshot.go
@@ -522,6 +522,7 @@ const (
 	coldStartOutcomeDownloadedAfterWait = "downloaded_after_wait"
 	coldStartOutcomeWaitTimedOut        = "wait_timed_out"
 	coldStartOutcomeLockError           = "lock_error"
+	coldStartOutcomeContextCanceled     = "context_canceled"
 )
 
 // Wait-for-leader timing. Package-level vars so tests can shrink them.
@@ -538,7 +539,7 @@ var (
 //   - (idx, name, rv, nil, nil) -- another replica's snapshot was downloaded; caller skips build.
 //   - (nil, "", 0, lock, nil)   -- caller is the leader; build, upload immediately, then release lock.
 //   - (nil, "", 0, nil, nil)    --  no snapshot and no leader slot in time; caller builds alone.
-//   - (nil, "", 0, nil, err)    -- context cancelled mid-coordination.
+//   - (nil, "", 0, nil, err)    -- context canceled mid-coordination.
 //
 // Each iteration, up to coldStartTotalWait:
 //  1. Probe for a usable same-version snapshot. If found, download it.
@@ -597,6 +598,7 @@ func (b *bleveBackend) coordinateColdStartBuild(
 	for {
 		idx, name, rv, err := b.tryDownloadColdStartSnapshot(ctx, key, resourceDir, lastImportTime, probeMaxAge, logger)
 		if err != nil {
+			outcome = coldStartOutcomeContextCanceled
 			return nil, "", 0, nil, err
 		}
 		if idx != nil {
@@ -615,6 +617,7 @@ func (b *bleveBackend) coordinateColdStartBuild(
 			// Propagate context cancellation so callers can abort cleanly
 			// instead of falling through to a from-scratch build.
 			if ctxErr := ctx.Err(); ctxErr != nil {
+				outcome = coldStartOutcomeContextCanceled
 				return nil, "", 0, nil, ctxErr
 			}
 			logger.Warn("Cold-start lock acquire failed; will build alone", "err", err)
@@ -624,6 +627,7 @@ func (b *bleveBackend) coordinateColdStartBuild(
 
 		select {
 		case <-ctx.Done():
+			outcome = coldStartOutcomeContextCanceled
 			return nil, "", 0, nil, ctx.Err()
 		case <-deadline.C:
 			outcome = coldStartOutcomeWaitTimedOut

--- a/pkg/storage/unified/search/bleve_snapshot_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -33,7 +34,13 @@ import (
 // fakeRemoteIndexStore is an in-memory RemoteIndexStore for unit tests.
 // DownloadIndex writes a minimal bleve index populated from the stored meta
 // so validateDownloadedIndex sees consistent data.
+//
+// All data access is mutex-guarded so cold-start tests can mutate the
+// snapshot set from a goroutine while coordinateColdStartBuild is
+// probing on the main goroutine. The mutex is uncontended in single-
+// threaded tests.
 type fakeRemoteIndexStore struct {
+	mu            sync.Mutex
 	data          map[ulid.ULID]*IndexMeta
 	listErr       error
 	downloadErr   error
@@ -54,6 +61,8 @@ func (l *noopIndexStoreLock) Lost() <-chan struct{} {
 }
 
 func (f *fakeRemoteIndexStore) put(key ulid.ULID, meta *IndexMeta) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	if f.data == nil {
 		f.data = map[ulid.ULID]*IndexMeta{}
 	}
@@ -62,6 +71,8 @@ func (f *fakeRemoteIndexStore) put(key ulid.ULID, meta *IndexMeta) {
 
 func (f *fakeRemoteIndexStore) ListIndexes(context.Context, resource.NamespacedResource) (map[ulid.ULID]*IndexMeta, error) {
 	f.listCalls.Add(1)
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	if f.listErr != nil {
 		return nil, f.listErr
 	}
@@ -73,6 +84,8 @@ func (f *fakeRemoteIndexStore) ListIndexes(context.Context, resource.NamespacedR
 }
 
 func (f *fakeRemoteIndexStore) ListIndexKeys(context.Context, resource.NamespacedResource) ([]ulid.ULID, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	if f.listErr != nil {
 		return nil, f.listErr
 	}
@@ -84,6 +97,8 @@ func (f *fakeRemoteIndexStore) ListIndexKeys(context.Context, resource.Namespace
 }
 
 func (f *fakeRemoteIndexStore) GetIndexMeta(_ context.Context, _ resource.NamespacedResource, k ulid.ULID) (*IndexMeta, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
 	meta, ok := f.data[k]
 	if !ok {
 		return nil, ErrSnapshotNotFound
@@ -93,10 +108,13 @@ func (f *fakeRemoteIndexStore) GetIndexMeta(_ context.Context, _ resource.Namesp
 
 func (f *fakeRemoteIndexStore) DownloadIndex(_ context.Context, _ resource.NamespacedResource, k ulid.ULID, destDir string) (*IndexMeta, error) {
 	f.downloadCalls.Add(1)
-	if f.downloadErr != nil {
-		return nil, f.downloadErr
-	}
+	f.mu.Lock()
 	meta, ok := f.data[k]
+	downloadErr := f.downloadErr
+	f.mu.Unlock()
+	if downloadErr != nil {
+		return nil, downloadErr
+	}
 	if !ok {
 		return nil, fmt.Errorf("not found")
 	}
@@ -422,7 +440,8 @@ func TestTryDownloadRemoteSnapshot_AllFilteredOut(t *testing.T) {
 	assert.Zero(t, dt.store.downloadCalls.Load(), "DownloadIndex should not be called when all candidates are filtered out")
 }
 
-// freshDownloadTest bundles the shared setup used by tryDownloadFreshSnapshot tests.
+// freshDownloadTest bundles the shared setup used by
+// tryDownloadFreshSameVersionSnapshot tests on the rebuild policy.
 type freshDownloadTest struct {
 	be          *bleveBackend
 	metrics     *resource.BleveIndexMetrics
@@ -450,7 +469,11 @@ func newFreshDownloadTest(t *testing.T, store *fakeRemoteIndexStore) freshDownlo
 
 func (dt freshDownloadTest) run(t *testing.T, lastImportTime time.Time, maxFreshSnapshotAge time.Duration) (bleve.Index, int64, error) {
 	t.Helper()
-	idx, _, rv, err := dt.be.tryDownloadFreshSnapshot(context.Background(), dt.ns, dt.resourceDir, lastImportTime, maxFreshSnapshotAge, dt.be.log)
+	idx, _, rv, err := dt.be.tryDownloadFreshSameVersionSnapshot(
+		context.Background(), dt.ns, dt.resourceDir, lastImportTime, maxFreshSnapshotAge,
+		snapshotPolicySameVersion, "search.remote_index_snapshot.download_fresh",
+		dt.be.log,
+	)
 	if idx != nil {
 		t.Cleanup(func() { _ = idx.Close() })
 	}
@@ -1205,4 +1228,422 @@ func TestFindFreshSnapshotByBuildStart(t *testing.T) {
 			wantErr: "transport boom",
 		},
 	})
+}
+
+// coldStartFakeStore extends fakeRemoteIndexStore with controllable lock
+// behaviour and an UploadIndex stub so we can exercise cold-start
+// coordination paths (acquired-lock, downloaded-after-wait, wait-timed-
+// out, lock backend error). Snapshot data and its mutex come from the
+// embedded base store; this struct's own mu guards only lock-state
+// fields.
+type coldStartFakeStore struct {
+	*fakeRemoteIndexStore
+
+	mu                sync.Mutex // guards lockHeld, lockBackendErr, currentLock
+	lockHeld          bool
+	lockBackendErr    error // returned (instead of errLockHeld) when set
+	currentLock       *coldStartFakeLock
+	lockAcquireCalls  atomic.Int32
+	lockReleasedCalls atomic.Int32
+
+	uploadCalls atomic.Int32
+}
+
+func newColdStartFakeStore() *coldStartFakeStore {
+	return &coldStartFakeStore{fakeRemoteIndexStore: &fakeRemoteIndexStore{}}
+}
+
+func (s *coldStartFakeStore) setLockHeld(held bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.lockHeld = held
+}
+
+func (s *coldStartFakeStore) LockBuildIndex(context.Context, resource.NamespacedResource, string) (IndexStoreLock, error) {
+	s.lockAcquireCalls.Add(1)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.lockBackendErr != nil {
+		return nil, s.lockBackendErr
+	}
+	if s.lockHeld {
+		return nil, errLockHeld
+	}
+	s.lockHeld = true
+	s.currentLock = &coldStartFakeLock{store: s, lost: make(chan struct{})}
+	return s.currentLock, nil
+}
+
+// signalLockLost simulates a heartbeat-detected lease loss on the most
+// recently acquired lock. Tests use this to drive the leader's pre-upload
+// checkSnapshotLock branch.
+func (s *coldStartFakeStore) signalLockLost() {
+	s.mu.Lock()
+	lock := s.currentLock
+	s.mu.Unlock()
+	if lock != nil {
+		lock.markLost()
+	}
+}
+
+func (s *coldStartFakeStore) UploadIndex(context.Context, resource.NamespacedResource, string, IndexMeta) (ulid.ULID, error) {
+	s.uploadCalls.Add(1)
+	return ulid.Make(), nil
+}
+
+type coldStartFakeLock struct {
+	store       *coldStartFakeStore
+	lost        chan struct{}
+	releaseOnce sync.Once
+	lostOnce    sync.Once
+}
+
+func (l *coldStartFakeLock) Release() error {
+	l.releaseOnce.Do(func() {
+		l.store.mu.Lock()
+		l.store.lockHeld = false
+		l.store.mu.Unlock()
+		l.store.lockReleasedCalls.Add(1)
+	})
+	return nil
+}
+
+func (l *coldStartFakeLock) Lost() <-chan struct{} { return l.lost }
+
+func (l *coldStartFakeLock) markLost() {
+	l.lostOnce.Do(func() { close(l.lost) })
+}
+
+// withColdStartTimings overrides the package-level wait-loop timings for the
+// duration of the test. Restored via t.Cleanup.
+func withColdStartTimings(t *testing.T, poll, total time.Duration) {
+	t.Helper()
+	prevPoll, prevTotal := coldStartPollInterval, coldStartTotalWait
+	coldStartPollInterval = poll
+	coldStartTotalWait = total
+	t.Cleanup(func() {
+		coldStartPollInterval = prevPoll
+		coldStartTotalWait = prevTotal
+	})
+}
+
+// coldStartTest bundles common setup for coordinateColdStartBuild tests.
+type coldStartTest struct {
+	be          *bleveBackend
+	metrics     *resource.BleveIndexMetrics
+	store       *coldStartFakeStore
+	ns          resource.NamespacedResource
+	resourceDir string
+}
+
+func newColdStartTest(t *testing.T, store *coldStartFakeStore) coldStartTest {
+	t.Helper()
+	be, metrics := newTestBleveBackend(t, SnapshotOptions{
+		Store:       store,
+		MinDocCount: 1,
+		MaxIndexAge: 24 * time.Hour,
+	})
+	ns := newTestNsResource()
+	return coldStartTest{
+		be:          be,
+		metrics:     metrics,
+		store:       store,
+		ns:          ns,
+		resourceDir: filepath.Join(be.opts.Root, ns.Namespace, ns.Resource+"."+ns.Group),
+	}
+}
+
+func (ct coldStartTest) coordinate(ctx context.Context, lastImportTime time.Time) (string, ulid.ULID, IndexStoreLock, error) {
+	idx, _, _, lock, err := ct.be.coordinateColdStartBuild(ctx, ct.ns, ct.resourceDir, lastImportTime, ct.be.log)
+	var idxKey ulid.ULID
+	role := "build_alone"
+	switch {
+	case err != nil:
+		role = "error"
+	case idx != nil:
+		role = "downloaded"
+		_ = idx.Close()
+	case lock != nil:
+		role = "leader"
+	}
+	return role, idxKey, lock, err
+}
+
+func (ct coldStartTest) coldStartCounter(outcome string) float64 {
+	return testutil.ToFloat64(ct.metrics.IndexSnapshotColdStarts.WithLabelValues(outcome))
+}
+
+func TestColdStart_BecameLeader(t *testing.T) {
+	store := newColdStartFakeStore()
+	ct := newColdStartTest(t, store)
+
+	role, _, lock, err := ct.coordinate(context.Background(), time.Time{})
+	require.NoError(t, err)
+	assert.Equal(t, "leader", role)
+	require.NotNil(t, lock)
+	assert.Equal(t, int32(1), store.lockAcquireCalls.Load())
+	assert.Equal(t, 1.0, ct.coldStartCounter(coldStartOutcomeAcquiredLock))
+
+	// Releasing the leader's lock must unwind the fake's lockHeld state so
+	// other replicas can acquire next.
+	require.NoError(t, lock.Release())
+	store.mu.Lock()
+	assert.False(t, store.lockHeld)
+	store.mu.Unlock()
+}
+
+func TestColdStart_WaitedForLeader(t *testing.T) {
+	store := newColdStartFakeStore()
+	store.setLockHeld(true) // another instance is the leader
+	ct := newColdStartTest(t, store)
+	withColdStartTimings(t, 10*time.Millisecond, time.Second)
+
+	// While coordinateColdStartBuild is in its wait loop, simulate the
+	// leader publishing a snapshot. The next probe tick should pick it up.
+	go func() {
+		time.Sleep(25 * time.Millisecond)
+		store.put(makeULID(t, time.Now()), freshSnapshot(time.Minute))
+	}()
+
+	role, _, lock, err := ct.coordinate(context.Background(), time.Time{})
+	require.NoError(t, err)
+	assert.Equal(t, "downloaded", role)
+	assert.Nil(t, lock)
+	// The waiter must not steal the leader's lock.
+	assert.True(t, store.lockHeldNow())
+	assert.Equal(t, 1.0, ct.coldStartCounter(coldStartOutcomeDownloadedAfterWait))
+}
+
+func TestColdStart_WaitTimeout(t *testing.T) {
+	store := newColdStartFakeStore()
+	store.setLockHeld(true)
+	ct := newColdStartTest(t, store)
+	withColdStartTimings(t, 5*time.Millisecond, 30*time.Millisecond)
+
+	role, _, lock, err := ct.coordinate(context.Background(), time.Time{})
+	require.NoError(t, err)
+	assert.Equal(t, "build_alone", role)
+	assert.Nil(t, lock)
+	assert.Equal(t, 1.0, ct.coldStartCounter(coldStartOutcomeWaitTimedOut))
+	// We retried the lock at least a couple times before giving up.
+	assert.GreaterOrEqual(t, store.lockAcquireCalls.Load(), int32(2))
+}
+
+func TestColdStart_AcquiresLockAfterLeaderRelease(t *testing.T) {
+	store := newColdStartFakeStore()
+	store.setLockHeld(true)
+	ct := newColdStartTest(t, store)
+	withColdStartTimings(t, 10*time.Millisecond, time.Second)
+
+	// Simulate the leader releasing the lock without uploading a snapshot
+	// (e.g. its build failed). The next tryAcquire in the wait loop should
+	// promote us.
+	go func() {
+		time.Sleep(25 * time.Millisecond)
+		store.setLockHeld(false)
+	}()
+
+	role, _, lock, err := ct.coordinate(context.Background(), time.Time{})
+	require.NoError(t, err)
+	assert.Equal(t, "leader", role)
+	require.NotNil(t, lock)
+	assert.Equal(t, 1.0, ct.coldStartCounter(coldStartOutcomeAcquiredLock))
+}
+
+func TestColdStart_LockBackendErrorBuildsAlone(t *testing.T) {
+	store := newColdStartFakeStore()
+	store.lockBackendErr = errors.New("backend down")
+	ct := newColdStartTest(t, store)
+
+	role, _, lock, err := ct.coordinate(context.Background(), time.Time{})
+	require.NoError(t, err)
+	assert.Equal(t, "build_alone", role)
+	assert.Nil(t, lock)
+	assert.Equal(t, 1.0, ct.coldStartCounter(coldStartOutcomeLockError))
+}
+
+func TestColdStart_ContextCancelInWaitLoop(t *testing.T) {
+	store := newColdStartFakeStore()
+	store.setLockHeld(true)
+	ct := newColdStartTest(t, store)
+	withColdStartTimings(t, 10*time.Millisecond, time.Second)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	_, _, _, err := ct.coordinate(ctx, time.Time{})
+	require.ErrorIs(t, err, context.Canceled)
+}
+
+// runBuildIndexColdStart wires a bleveBackend around store and calls
+// BuildIndex on the cachedIndex==nil / !rebuild path with a stock builder
+// that records its invocation count. builderExtra (optional) runs inside
+// the build closure for tests that need to perturb store state
+// mid-build. MinDocCount=1, MaxIndexAge=24h, lastImportTime is zero,
+// rebuild=false, maxFreshSnapshotAge=0 (rebuild-path knob doesn't affect
+// cold-start).
+func runBuildIndexColdStart(t *testing.T, store RemoteIndexStore, builderExtra func()) (
+	*resource.BleveIndexMetrics, *atomic.Int32, resource.ResourceIndex, error,
+) {
+	t.Helper()
+	be, metrics := newTestBleveBackend(t, SnapshotOptions{
+		Store:       store,
+		MinDocCount: 1,
+		MaxIndexAge: 24 * time.Hour,
+	})
+	builderCalled := &atomic.Int32{}
+	idx, err := be.BuildIndex(context.Background(), newTestNsResource(), 10, nil, "startup",
+		func(resource.ResourceIndex) (int64, error) {
+			builderCalled.Add(1)
+			if builderExtra != nil {
+				builderExtra()
+			}
+			return 1, nil
+		},
+		nil, false, time.Time{}, 0)
+	return metrics, builderCalled, idx, err
+}
+
+// TestBuildIndex_ColdStartFastPathDownloads verifies that on the
+// initial-startup path (cachedIndex == nil, !rebuild) BuildIndex picks up
+// a same-version snapshot from the remote store and skips the builder.
+// With a fresh snapshot present, the tiered selection runs first and
+// downloads it before the cold-start path is even considered.
+func TestBuildIndex_ColdStartFastPathDownloads(t *testing.T) {
+	store := newColdStartFakeStore()
+	store.put(makeULID(t, time.Now()), freshSnapshot(time.Minute))
+	metrics, builderCalled, idx, err := runBuildIndexColdStart(t, store, nil)
+	require.NoError(t, err)
+	require.NotNil(t, idx)
+
+	// The tiered remote-snapshot selection runs first and downloads —
+	// that's enough to skip the builder. The cold-start path only runs if
+	// the tiered selection misses; here it finds the snapshot first.
+	assert.Zero(t, builderCalled.Load(), "builder must not run when a snapshot is available")
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotDownloads.WithLabelValues(snapshotPolicyTiered, snapshotStatusSuccess)))
+}
+
+// TestBuildIndex_ColdStartLeaderUploads exercises the leader path: empty
+// store, leader builds from scratch, and the leader's freshly-built snapshot
+// is uploaded immediately under the held lock.
+func TestBuildIndex_ColdStartLeaderUploads(t *testing.T) {
+	store := newColdStartFakeStore()
+	metrics, builderCalled, idx, err := runBuildIndexColdStart(t, store, nil)
+	require.NoError(t, err)
+	require.NotNil(t, idx)
+
+	assert.Equal(t, int32(1), builderCalled.Load(), "builder must run on the leader path")
+	assert.Equal(t, int32(1), store.uploadCalls.Load(), "leader must upload immediately")
+	assert.Equal(t, int32(1), store.lockReleasedCalls.Load(), "leader must release the build lock")
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotColdStarts.WithLabelValues(coldStartOutcomeAcquiredLock)))
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotUploads.WithLabelValues(snapshotUploadStatusSuccess)))
+}
+
+// TestColdStart_NoProbeWindowSkipsWaitLoopProbe verifies that when
+// MaxIndexAge is zero the wait-loop probe is skipped (no list/get against
+// the store) and coordination relies on the lock alone.
+func TestColdStart_NoProbeWindowSkipsWaitLoopProbe(t *testing.T) {
+	store := newColdStartFakeStore()
+	store.setLockHeld(true)
+	be, metrics := newTestBleveBackend(t, SnapshotOptions{
+		Store:       store,
+		MinDocCount: 1,
+		// MaxIndexAge intentionally zero.
+	})
+	ns := newTestNsResource()
+	resourceDir := filepath.Join(be.opts.Root, ns.Namespace, ns.Resource+"."+ns.Group)
+	withColdStartTimings(t, 5*time.Millisecond, time.Second)
+
+	// Release the lock during the wait; we should acquire on the next
+	// iteration without ever probing.
+	go func() {
+		time.Sleep(15 * time.Millisecond)
+		store.setLockHeld(false)
+	}()
+
+	idx, _, _, lock, err := be.coordinateColdStartBuild(context.Background(), ns, resourceDir, time.Time{}, be.log)
+	require.NoError(t, err)
+	assert.Nil(t, idx)
+	require.NotNil(t, lock)
+	t.Cleanup(func() { _ = lock.Release() })
+
+	assert.Zero(t, store.fakeRemoteIndexStore.listCalls.Load(), "wait-loop probe must not list when no freshness window is configured")
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotColdStarts.WithLabelValues(coldStartOutcomeAcquiredLock)))
+}
+
+// TestBuildIndex_ColdStartLeaderLockLostDuringBuild verifies that if the
+// leader's lock is lost while the builder is running, the immediate upload
+// is skipped (recorded as skip_lock_lost) but the build itself still
+// completes — lock-lost is coordination, not a fatal error.
+func TestBuildIndex_ColdStartLeaderLockLostDuringBuild(t *testing.T) {
+	store := newColdStartFakeStore()
+	// Simulate heartbeat-detected lease loss while we're in the middle of
+	// the from-scratch build.
+	metrics, builderCalled, idx, err := runBuildIndexColdStart(t, store, store.signalLockLost)
+	require.NoError(t, err)
+	require.NotNil(t, idx)
+
+	assert.Equal(t, int32(1), builderCalled.Load(), "builder must run on the leader path")
+	assert.Zero(t, store.uploadCalls.Load(), "leader must skip immediate upload after lock loss")
+	assert.Equal(t, int32(1), store.lockReleasedCalls.Load(), "leader still releases the lock object")
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotUploads.WithLabelValues(snapshotUploadStatusSkipLockLost)))
+	assert.Zero(t, testutil.ToFloat64(metrics.IndexSnapshotUploads.WithLabelValues(snapshotUploadStatusSuccess)))
+}
+
+// TestBuildIndex_ColdStartTimeoutBuildsAlone verifies that when the lock is
+// permanently held by another instance and no snapshot ever appears, the
+// timeout path runs the builder anyway (no upload).
+func TestBuildIndex_ColdStartTimeoutBuildsAlone(t *testing.T) {
+	store := newColdStartFakeStore()
+	store.setLockHeld(true)
+	withColdStartTimings(t, 5*time.Millisecond, 30*time.Millisecond)
+	metrics, builderCalled, idx, err := runBuildIndexColdStart(t, store, nil)
+	require.NoError(t, err)
+	require.NotNil(t, idx)
+
+	assert.Equal(t, int32(1), builderCalled.Load(), "build alone after timeout")
+	assert.Zero(t, store.uploadCalls.Load(), "no leader upload on timeout path")
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotColdStarts.WithLabelValues(coldStartOutcomeWaitTimedOut)))
+}
+
+// TestBuildIndex_ColdStartContextCancelPropagates verifies that a context
+// cancellation during cold-start coordination aborts BuildIndex with the
+// context error rather than falling back to a full from-scratch build.
+func TestBuildIndex_ColdStartContextCancelPropagates(t *testing.T) {
+	store := newColdStartFakeStore()
+	store.setLockHeld(true) // force entry to the wait loop
+	withColdStartTimings(t, 5*time.Millisecond, time.Second)
+	be, _ := newTestBleveBackend(t, SnapshotOptions{
+		Store:       store,
+		MinDocCount: 1,
+		MaxIndexAge: 24 * time.Hour,
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		time.Sleep(20 * time.Millisecond)
+		cancel()
+	}()
+
+	builderCalled := atomic.Int32{}
+	idx, err := be.BuildIndex(ctx, newTestNsResource(), 10, nil, "startup",
+		func(resource.ResourceIndex) (int64, error) {
+			builderCalled.Add(1)
+			return 1, nil
+		},
+		nil, false, time.Time{}, 0)
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Nil(t, idx)
+	assert.Zero(t, builderCalled.Load(), "builder must not run after context cancel")
+}
+
+// lockHeldNow exposes the fake's lockHeld state for tests that assert the
+// leader's lock survived a download by a waiter.
+func (s *coldStartFakeStore) lockHeldNow() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lockHeld
 }

--- a/pkg/storage/unified/search/bleve_snapshot_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_test.go
@@ -1461,6 +1461,22 @@ func TestColdStart_LockBackendErrorBuildsAlone(t *testing.T) {
 	assert.Equal(t, 1.0, ct.coldStartCounter(coldStartOutcomeLockError))
 }
 
+// TestColdStart_LockBackendContextErrorPropagates verifies that a context
+// error returned by LockBuildIndex itself (e.g. cancellation arriving
+// mid-acquire) is propagated, not swallowed as a build-alone fallback.
+func TestColdStart_LockBackendContextErrorPropagates(t *testing.T) {
+	store := newColdStartFakeStore()
+	store.lockBackendErr = context.Canceled
+	ct := newColdStartTest(t, store)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // ctx is already canceled before the call
+
+	_, _, err := ct.coordinate(ctx, time.Time{})
+	require.ErrorIs(t, err, context.Canceled)
+	assert.Zero(t, ct.coldStartCounter(coldStartOutcomeLockError), "context cancel must not be recorded as lock_error")
+}
+
 func TestColdStart_ContextCancelInWaitLoop(t *testing.T) {
 	store := newColdStartFakeStore()
 	store.setLockHeld(true)

--- a/pkg/storage/unified/search/bleve_snapshot_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_test.go
@@ -1475,6 +1475,8 @@ func TestColdStart_LockBackendContextErrorPropagates(t *testing.T) {
 	_, _, err := ct.coordinate(ctx, time.Time{})
 	require.ErrorIs(t, err, context.Canceled)
 	assert.Zero(t, ct.coldStartCounter(coldStartOutcomeLockError), "context cancel must not be recorded as lock_error")
+	assert.Zero(t, ct.coldStartCounter(coldStartOutcomeWaitTimedOut), "context cancel must not be recorded as wait_timed_out")
+	assert.Equal(t, 1.0, ct.coldStartCounter(coldStartOutcomeContextCanceled))
 }
 
 func TestColdStart_ContextCancelInWaitLoop(t *testing.T) {
@@ -1491,6 +1493,8 @@ func TestColdStart_ContextCancelInWaitLoop(t *testing.T) {
 
 	_, _, err := ct.coordinate(ctx, time.Time{})
 	require.ErrorIs(t, err, context.Canceled)
+	assert.Zero(t, ct.coldStartCounter(coldStartOutcomeWaitTimedOut), "context cancel must not be recorded as wait_timed_out")
+	assert.Equal(t, 1.0, ct.coldStartCounter(coldStartOutcomeContextCanceled))
 }
 
 // runBuildIndexColdStart wires a bleveBackend around store and calls
@@ -1557,38 +1561,6 @@ func TestBuildIndex_ColdStartLeaderUploads(t *testing.T) {
 	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotUploads.WithLabelValues(snapshotUploadStatusSuccess)))
 }
 
-// TestColdStart_NoProbeWindowSkipsWaitLoopProbe verifies that when
-// MaxIndexAge is zero the wait-loop probe is skipped (no list/get against
-// the store) and coordination relies on the lock alone.
-func TestColdStart_NoProbeWindowSkipsWaitLoopProbe(t *testing.T) {
-	store := newColdStartFakeStore()
-	store.setLockHeld(true)
-	be, metrics := newTestBleveBackend(t, SnapshotOptions{
-		Store:       store,
-		MinDocCount: 1,
-		// MaxIndexAge intentionally zero.
-	})
-	ns := newTestNsResource()
-	resourceDir := filepath.Join(be.opts.Root, ns.Namespace, ns.Resource+"."+ns.Group)
-	withColdStartTimings(t, 5*time.Millisecond, time.Second)
-
-	// Release the lock during the wait; we should acquire on the next
-	// iteration without ever probing.
-	go func() {
-		time.Sleep(15 * time.Millisecond)
-		store.setLockHeld(false)
-	}()
-
-	idx, _, _, lock, err := be.coordinateColdStartBuild(context.Background(), ns, resourceDir, time.Time{}, be.log)
-	require.NoError(t, err)
-	assert.Nil(t, idx)
-	require.NotNil(t, lock)
-	t.Cleanup(func() { _ = lock.Release() })
-
-	assert.Zero(t, store.listCalls.Load(), "wait-loop probe must not list when no freshness window is configured")
-	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotColdStarts.WithLabelValues(coldStartOutcomeAcquiredLock)))
-}
-
 // TestBuildIndex_ColdStartLeaderLockLostDuringBuild verifies that if the
 // leader's lock is lost while the builder is running, the immediate upload
 // is skipped (recorded as skip_lock_lost) but the build itself still
@@ -1622,6 +1594,37 @@ func TestBuildIndex_ColdStartTimeoutBuildsAlone(t *testing.T) {
 	assert.Equal(t, int32(1), builderCalled.Load(), "build alone after timeout")
 	assert.Zero(t, store.uploadCalls.Load(), "no leader upload on timeout path")
 	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotColdStarts.WithLabelValues(coldStartOutcomeWaitTimedOut)))
+}
+
+// TestBuildIndex_ColdStartSkippedWhenMaxIndexAgeZero verifies that
+// BuildIndex skips cold-start coordination entirely when MaxIndexAge=0:
+// the probe would be a no-op (all freshness filters reject) so the
+// lock+wait would only serialise duplicate from-scratch builds without
+// any snapshot-reuse upside. With the gate, the builder runs in parallel
+// across replicas (today's behaviour without this PR's coordination).
+func TestBuildIndex_ColdStartSkippedWhenMaxIndexAgeZero(t *testing.T) {
+	store := newColdStartFakeStore()
+	store.setLockHeld(true) // would force the wait loop if cold-start ran
+	be, metrics := newTestBleveBackend(t, SnapshotOptions{
+		Store:       store,
+		MinDocCount: 1,
+		// MaxIndexAge intentionally zero.
+	})
+
+	builderCalled := atomic.Int32{}
+	idx, err := be.BuildIndex(context.Background(), newTestNsResource(), 10, nil, "startup",
+		func(resource.ResourceIndex) (int64, error) {
+			builderCalled.Add(1)
+			return 1, nil
+		},
+		nil, false, time.Time{}, 0)
+	require.NoError(t, err)
+	require.NotNil(t, idx)
+
+	assert.Equal(t, int32(1), builderCalled.Load(), "builder must run (cold-start coordination is skipped)")
+	assert.Zero(t, store.lockAcquireCalls.Load(), "cold-start must not attempt the lock when MaxIndexAge=0")
+	assert.Zero(t, testutil.ToFloat64(metrics.IndexSnapshotColdStarts.WithLabelValues(coldStartOutcomeAcquiredLock)))
+	assert.Zero(t, testutil.ToFloat64(metrics.IndexSnapshotColdStarts.WithLabelValues(coldStartOutcomeWaitTimedOut)))
 }
 
 // TestBuildIndex_ColdStartContextCancelPropagates verifies that a context

--- a/pkg/storage/unified/search/bleve_snapshot_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_test.go
@@ -1353,9 +1353,8 @@ func newColdStartTest(t *testing.T, store *coldStartFakeStore) coldStartTest {
 	}
 }
 
-func (ct coldStartTest) coordinate(ctx context.Context, lastImportTime time.Time) (string, ulid.ULID, IndexStoreLock, error) {
+func (ct coldStartTest) coordinate(ctx context.Context, lastImportTime time.Time) (string, IndexStoreLock, error) {
 	idx, _, _, lock, err := ct.be.coordinateColdStartBuild(ctx, ct.ns, ct.resourceDir, lastImportTime, ct.be.log)
-	var idxKey ulid.ULID
 	role := "build_alone"
 	switch {
 	case err != nil:
@@ -1366,7 +1365,7 @@ func (ct coldStartTest) coordinate(ctx context.Context, lastImportTime time.Time
 	case lock != nil:
 		role = "leader"
 	}
-	return role, idxKey, lock, err
+	return role, lock, err
 }
 
 func (ct coldStartTest) coldStartCounter(outcome string) float64 {
@@ -1377,7 +1376,7 @@ func TestColdStart_BecameLeader(t *testing.T) {
 	store := newColdStartFakeStore()
 	ct := newColdStartTest(t, store)
 
-	role, _, lock, err := ct.coordinate(context.Background(), time.Time{})
+	role, lock, err := ct.coordinate(context.Background(), time.Time{})
 	require.NoError(t, err)
 	assert.Equal(t, "leader", role)
 	require.NotNil(t, lock)
@@ -1405,7 +1404,7 @@ func TestColdStart_WaitedForLeader(t *testing.T) {
 		store.put(makeULID(t, time.Now()), freshSnapshot(time.Minute))
 	}()
 
-	role, _, lock, err := ct.coordinate(context.Background(), time.Time{})
+	role, lock, err := ct.coordinate(context.Background(), time.Time{})
 	require.NoError(t, err)
 	assert.Equal(t, "downloaded", role)
 	assert.Nil(t, lock)
@@ -1420,7 +1419,7 @@ func TestColdStart_WaitTimeout(t *testing.T) {
 	ct := newColdStartTest(t, store)
 	withColdStartTimings(t, 5*time.Millisecond, 30*time.Millisecond)
 
-	role, _, lock, err := ct.coordinate(context.Background(), time.Time{})
+	role, lock, err := ct.coordinate(context.Background(), time.Time{})
 	require.NoError(t, err)
 	assert.Equal(t, "build_alone", role)
 	assert.Nil(t, lock)
@@ -1443,7 +1442,7 @@ func TestColdStart_AcquiresLockAfterLeaderRelease(t *testing.T) {
 		store.setLockHeld(false)
 	}()
 
-	role, _, lock, err := ct.coordinate(context.Background(), time.Time{})
+	role, lock, err := ct.coordinate(context.Background(), time.Time{})
 	require.NoError(t, err)
 	assert.Equal(t, "leader", role)
 	require.NotNil(t, lock)
@@ -1455,7 +1454,7 @@ func TestColdStart_LockBackendErrorBuildsAlone(t *testing.T) {
 	store.lockBackendErr = errors.New("backend down")
 	ct := newColdStartTest(t, store)
 
-	role, _, lock, err := ct.coordinate(context.Background(), time.Time{})
+	role, lock, err := ct.coordinate(context.Background(), time.Time{})
 	require.NoError(t, err)
 	assert.Equal(t, "build_alone", role)
 	assert.Nil(t, lock)
@@ -1474,7 +1473,7 @@ func TestColdStart_ContextCancelInWaitLoop(t *testing.T) {
 		cancel()
 	}()
 
-	_, _, _, err := ct.coordinate(ctx, time.Time{})
+	_, _, err := ct.coordinate(ctx, time.Time{})
 	require.ErrorIs(t, err, context.Canceled)
 }
 
@@ -1570,7 +1569,7 @@ func TestColdStart_NoProbeWindowSkipsWaitLoopProbe(t *testing.T) {
 	require.NotNil(t, lock)
 	t.Cleanup(func() { _ = lock.Release() })
 
-	assert.Zero(t, store.fakeRemoteIndexStore.listCalls.Load(), "wait-loop probe must not list when no freshness window is configured")
+	assert.Zero(t, store.listCalls.Load(), "wait-loop probe must not list when no freshness window is configured")
 	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotColdStarts.WithLabelValues(coldStartOutcomeAcquiredLock)))
 }
 

--- a/pkg/storage/unified/search/bleve_snapshot_upload.go
+++ b/pkg/storage/unified/search/bleve_snapshot_upload.go
@@ -101,21 +101,30 @@ func (b *bleveBackend) uploadSnapshot(ctx context.Context, key resource.Namespac
 		span.AddEvent("snapshot.lock.release.completed", oteltrace.WithAttributes(lockAttrs...))
 	}()
 
+	uploadKey, rv, err = b.snapshotCopyAndUpload(ctx, key, idx, lock)
+	return err
+}
+
+// snapshotCopyAndUpload copies idx to a staging dir, reads its metadata,
+// and uploads it to the remote index store. The caller acquires and
+// releases the build lock; this helper only re-checks it between steps.
+// Returns the uploaded snapshot key and the RV read from the staged copy.
+func (b *bleveBackend) snapshotCopyAndUpload(ctx context.Context, key resource.NamespacedResource, idx *bleveIndex, lock IndexStoreLock) (ulid.ULID, int64, error) {
 	stagingDir, err := b.newSnapshotStagingDir(key)
 	if err != nil {
-		return fmt.Errorf("creating snapshot staging dir: %w", err)
+		return ulid.ULID{}, 0, fmt.Errorf("creating snapshot staging dir: %w", err)
 	}
 	defer func() { _ = os.RemoveAll(stagingDir) }()
 
 	if err := b.snapshotIndex(idx.index, stagingDir); err != nil {
-		return err
+		return ulid.ULID{}, 0, err
 	}
 	// Lock loss is checked only at step boundaries. The main value of the
 	// distributed lock is preventing duplicate snapshot/upload work up front, and
 	// the upload path is safe to retry because remote snapshots are immutable and
 	// keyed by unique ULIDs.
 	if err := checkSnapshotLock(lock); err != nil {
-		return err
+		return ulid.ULID{}, 0, err
 	}
 
 	// Read RV/build info from the staged snapshot instead of the live index so
@@ -123,19 +132,19 @@ func (b *bleveBackend) uploadSnapshot(ctx context.Context, key resource.Namespac
 	// index advanced while CopyTo was running.
 	snapshotIdx, err := bleve.OpenUsing(stagingDir, map[string]interface{}{"bolt_timeout": boltTimeout})
 	if err != nil {
-		return fmt.Errorf("opening staged snapshot: %w", err)
+		return ulid.ULID{}, 0, fmt.Errorf("opening staged snapshot: %w", err)
 	}
 
-	rv, err = getRV(snapshotIdx)
+	rv, err := getRV(snapshotIdx)
 	bi, biErr := getBuildInfo(snapshotIdx)
 	if closeErr := snapshotIdx.Close(); closeErr != nil {
-		return fmt.Errorf("closing staged snapshot: %w", closeErr)
+		return ulid.ULID{}, 0, fmt.Errorf("closing staged snapshot: %w", closeErr)
 	}
 	if err != nil {
-		return fmt.Errorf("reading snapshot rv: %w", err)
+		return ulid.ULID{}, 0, fmt.Errorf("reading snapshot rv: %w", err)
 	}
 	if biErr != nil {
-		return fmt.Errorf("reading snapshot build info: %w", biErr)
+		return ulid.ULID{}, 0, fmt.Errorf("reading snapshot build info: %w", biErr)
 	}
 
 	meta := IndexMeta{
@@ -149,12 +158,12 @@ func (b *bleveBackend) uploadSnapshot(ctx context.Context, key resource.Namespac
 		meta.BuildTime = time.Unix(bi.BuildTime, 0).UTC()
 	}
 
-	uploadKey, err = b.opts.Snapshot.Store.UploadIndex(ctx, key, stagingDir, meta)
+	uploadKey, err := b.opts.Snapshot.Store.UploadIndex(ctx, key, stagingDir, meta)
 	if err != nil {
-		return fmt.Errorf("uploading snapshot: %w", err)
+		return ulid.ULID{}, 0, fmt.Errorf("uploading snapshot: %w", err)
 	}
 
-	return nil
+	return uploadKey, rv, nil
 }
 
 func (b *bleveBackend) snapshotIndex(idx bleve.Index, destDir string) error {


### PR DESCRIPTION
## Cold-start coordination for index snapshot builds

When multiple replicas of the same Grafana version start at once with no local index, today they each run a from-scratch build independently — wasted CPU and IO that scales with replica count.

This PR adds coordination via the existing build lock: the first replica becomes the leader, builds, and uploads its snapshot. Other replicas wait and download what the leader publishes. If the leader dies without uploading, one of the waiters promotes itself. Wait timeout falls back to building alone — coordination is best-effort, not a correctness primitive.

Each iteration of the wait loop probes the remote index store for a same-version snapshot, then tries to acquire the lock. Probe-before-acquire is intentional: the leader uploads before releasing the lock, so a probe hit is preferable to becoming a duplicate leader after the leader's release.

Cold-start coordination runs only on the initial-startup path (no cached index, not a rebuild) and only when the index snapshot store is configured. It's decoupled from `maxFreshSnapshotAge` (the rebuild-path knob): cold-start uses `Snapshot.MaxIndexAge` for its probe window since any same-version snapshot beats rebuilding from scratch.

### Follow-ups

`BuildIndex` is getting long; planning a follow-up to refactor its branches (cached / fresh-from-store / cold-start / rebuild) into clearer phases.

### References

- Epic: grafana/search-and-storage-team#715
- Issue: grafana/search-and-storage-team#766
