### PR TITLE
Navigation: Rename "AI Observability" to "AI" in nav menu

### DIFF
--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -370,7 +370,7 @@ func (s *ServiceImpl) hasAccessToInclude(c *contextmodel.ReqContext, pluginID st
 
 func (s *ServiceImpl) readNavigationSettings() {
 	s.navigationAppConfig = map[string]NavigationAppConfig{
-		"grafana-sigil-app":                {SectionID: navtree.NavIDObservability, SortWeight: 1, Text: "AI Observability", IsNew: true},
+		"grafana-sigil-app":                {SectionID: navtree.NavIDObservability, SortWeight: 1, Text: "AI", IsNew: true},
 		"grafana-asserts-app":              {SectionID: navtree.NavIDObservability, SortWeight: 2, Icon: "asserts"},
 		"grafana-kowalski-app":             {SectionID: navtree.NavIDObservability, SortWeight: 3, Text: "Frontend"},
 		"grafana-app-observability-app":    {SectionID: navtree.NavIDObservability, SortWeight: 4, Text: "Application"},


### PR DESCRIPTION
## Summary
- Renames the `grafana-sigil-app` nav entry from "AI Observability" to "AI"
- The item already lives under the **Observability** section, so the full name was redundant — this aligns it with sibling entries (Frontend, Application, Infrastructure, etc.) that use short names

## Test plan
- [ ] Verify the nav menu shows "AI" under Observability
- [ ] Confirm no other references to "AI Observability" were missed

Made with [Cursor](https://cursor.com)