### PR TITLE
Preferences: Add feature flag for rerouteLegacyAPIs

### DIFF
--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -3135,6 +3135,14 @@ var (
 			Generate:    Generate{React: true},
 			Expression:  "false",
 		},
+		{
+			Name:        "preferences.rerouteLegacyAPIs",
+			Description: "Use K8s client implementation for legacy preferences API",
+			Stage:       FeatureStageExperimental,
+			Generate:    Generate{Go: true},
+			Owner:       grafanaFrontendPlatformSquad,
+			Expression:  "false",
+		},
 		// tl;dr: name your new flag `component.featureName`, specify Go and/or React generation targets, and use with OpenFeature!
 		//
 		// Adding a new feature flag? Be sure to check out the updated docs at /contribute/feature-toggles.md#Steps-to-adding-a-feature-toggle

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -366,3 +366,4 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-04-30,datasources.useNewStackInfoToSettingsCache,GA,@grafana/grafana-datasources-core-services,false,false,false
 2026-05-04,alerting.disableV0ReceiverConversion,experimental,@grafana/alerting-squad,false,false,false
 2026-05-06,grafana.unifiedHomepage,experimental,@grafana/grafana-frontend-navigation,false,false,true
+2026-05-06,preferences.rerouteLegacyAPIs,experimental,@grafana/grafana-frontend-platform,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -973,4 +973,8 @@ const (
 	// FlagAlertingDisableV0ReceiverConversion
 	// Disable automatic conversion of legacy (V0/Mimir) Alertmanager receivers to Grafana model
 	FlagAlertingDisableV0ReceiverConversion = "alerting.disableV0ReceiverConversion"
+
+	// FlagPreferencesRerouteLegacyAPIs
+	// Use K8s client implementation for legacy preferences API
+	FlagPreferencesRerouteLegacyAPIs = "preferences.rerouteLegacyAPIs"
 )

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2729,8 +2729,11 @@
     {
       "metadata": {
         "name": "grafana.unifiedHomepage",
-        "resourceVersion": "1778051143810",
-        "creationTimestamp": "2026-05-06T07:05:43Z"
+        "resourceVersion": "1778065754369",
+        "creationTimestamp": "2026-05-06T07:05:43Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-05-06 11:09:14.369545 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Replaces the bundled home dashboard with the unified homepage React page",
@@ -4662,6 +4665,19 @@
         "description": "Prefer library panel title over viz panel title.",
         "stage": "privatePreview",
         "codeowner": "@grafana/dashboards-squad",
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
+        "name": "preferences.rerouteLegacyAPIs",
+        "resourceVersion": "1778065172575",
+        "creationTimestamp": "2026-05-06T10:59:32Z"
+      },
+      "spec": {
+        "description": "Use K8s client implementation for legacy preferences API",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-frontend-platform",
         "expression": "false"
       }
     },


### PR DESCRIPTION
Split out from https://github.com/grafana/grafana/pull/123808 - creates the feature flag to use in there.

Part of https://github.com/grafana/grafana-frontend-platform/issues/153