### PR TITLE
[release-13.0.2] Provisioning: add public_root_url instance setting for external URLs

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2386,6 +2386,14 @@ max_resources_per_repository = 0
 # Default is v1 for on-prem (OSS) installations.
 folders_api_version = v1
 
+# Public-facing root URL of this Grafana instance, used by provisioning to construct URLs
+# that must be reachable from external systems (e.g. GitHub PR-comment image fetchers and
+# GitHub webhook deliveries). When empty, falls back to [server] root_url. Set this when
+# root_url points at an internal/cluster URL but provisioning needs an externally-reachable
+# host. Analogous to [rendering] callback_url for the image renderer plugin.
+public_root_url =
+
+
 #################################### Unified Storage ####################################
 [unified_storage]
 # index_path is the path where unified storage can store its index files for search.

--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-extend.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-extend.md
@@ -60,6 +60,22 @@ root_url = https://<PUBLIC_DOMAIN>
 
 To check the configured webhooks, go to **Administration > General > Provisioning** and click the **View** link for your GitHub repository.
 
+{{< admonition type="note" >}}
+
+If your `[server] root_url` must point at an internal address (for example, when Grafana runs behind a private ingress in a Kubernetes cluster), set the publicly-reachable URL with `[provisioning] public_root_url` instead. This URL is used both to register webhook callbacks with the Git provider and as the base for screenshot images embedded in pull-request comments, which the Git provider's servers fetch from the public internet.
+
+```ini
+[server]
+root_url = http://internal.cluster.local
+
+[provisioning]
+public_root_url = https://<PUBLIC_DOMAIN>
+```
+
+The per-repository `spec.webhook.baseUrl` field still overrides `public_root_url` for webhook registration; screenshot URLs always use `public_root_url` (or `root_url` when unset).
+
+{{< /admonition >}}
+
 ### Expose necessary paths only
 
 If your security setup doesn't permit publicly exposing the Grafana instance, you can either choose to allowlist the GitHub IP addresses, or expose only the necessary paths.

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -2790,6 +2790,17 @@ Maximum number of repositories allowed. Default is `10`. Set to `0` for unlimite
 
 Maximum number of resources (dashboards, folders, etc.) allowed per repository. Default is `0`, which means unlimited.
 
+#### `public_root_url`
+
+Public-facing root URL of this Grafana instance, used by provisioning to construct URLs that must be reachable from external systems. When empty, falls back to `[server] root_url`.
+
+Two consumers honor this setting:
+
+- Webhook callbacks registered with the Git provider (for example, GitHub). The per-repository `spec.webhook.baseUrl`, when set, still wins.
+- Screenshot images embedded in pull-request comments. These are fetched by the Git provider's servers, so the URL must be reachable from the public internet.
+
+Set this when `[server] root_url` points at a cluster-internal address (for example, when Grafana runs behind a private ingress) but provisioning needs an externally-reachable host. This is analogous to `[rendering] callback_url`, which serves the same purpose for the image renderer plugin.
+
 <hr>
 
 ### `[plugin.plugin_id]`

--- a/pkg/operators/provisioning/jobs_operator.go
+++ b/pkg/operators/provisioning/jobs_operator.go
@@ -361,7 +361,10 @@ func setupWorkers(
 		return nil, nil, fmt.Errorf("failed to get URL provider: %w", err)
 	}
 	renderer := pullrequest.NewNoOpRenderer()
-	evaluator := pullrequest.NewEvaluator(renderer, parsers, urlProvider, registry)
+	evaluator := pullrequest.NewEvaluator(renderer, parsers, pullrequest.URLProvider{
+		Internal: urlProvider,
+		Public:   urlProvider,
+	}, registry)
 	commenter := pullrequest.NewCommenter(false)
 	prWorker := pullrequest.NewPullRequestWorker(evaluator, commenter, registry)
 	workers = append(workers, prWorker)

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/changes.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/changes.go
@@ -63,20 +63,37 @@ type fileChangeInfo struct {
 	PreviewScreenshotURL string
 }
 
-type evaluator struct {
-	render      ScreenshotRenderer
-	parsers     resources.ParserFactory
-	urlProvider func(ctx context.Context, namespace string) string
-	metrics     screenshotMetrics
+// URLProvider yields the two base URLs Grafana uses when referring to itself
+// from a PR comment. They split because consumers differ:
+//
+//   - Internal builds the dashboard view and preview URLs surfaced as
+//     clickable links. Reviewers click these from their own browsers — usually
+//     from inside the corp network — so the canonical AppURL works.
+//   - Public prefixes screenshot images embedded in the same comment. These
+//     images are fetched server-side by the Git provider's image proxy, so
+//     the URL must be reachable from the public internet.
+//
+// Operator deployments that don't need the split can set both fields to the
+// same closure.
+type URLProvider struct {
+	Internal func(ctx context.Context, namespace string) string
+	Public   func(ctx context.Context, namespace string) string
 }
 
-func NewEvaluator(render ScreenshotRenderer, parsers resources.ParserFactory, urlProvider func(ctx context.Context, namespace string) string, registry prometheus.Registerer) Evaluator {
+type evaluator struct {
+	render  ScreenshotRenderer
+	parsers resources.ParserFactory
+	urls    URLProvider
+	metrics screenshotMetrics
+}
+
+func NewEvaluator(render ScreenshotRenderer, parsers resources.ParserFactory, urls URLProvider, registry prometheus.Registerer) Evaluator {
 	metrics := registerScreenshotMetrics(registry)
 	return &evaluator{
-		render:      render,
-		parsers:     parsers,
-		urlProvider: urlProvider,
-		metrics:     metrics,
+		render:  render,
+		parsers: parsers,
+		urls:    urls,
+		metrics: metrics,
 	}
 }
 
@@ -91,11 +108,12 @@ func (e *evaluator) Evaluate(ctx context.Context, repo repository.Reader, opts p
 	rendererAvailable := e.render.IsAvailable(ctx)
 	shouldRender := rendererAvailable && len(changes) == 1 && cfg.Spec.GitHub.GenerateDashboardPreviews
 	info := changeInfo{
-		GrafanaBaseURL:       e.urlProvider(ctx, cfg.Namespace),
+		GrafanaBaseURL:       e.urls.Internal(ctx, cfg.Namespace),
 		RepositoryName:       cfg.Name,
 		RepositoryTitle:      cfg.Spec.Title,
 		MissingImageRenderer: !rendererAvailable,
 	}
+	screenshotBaseURL := e.urls.Public(ctx, cfg.Namespace)
 
 	logger := logging.FromContext(ctx)
 
@@ -109,7 +127,7 @@ func (e *evaluator) Evaluate(ctx context.Context, repo repository.Reader, opts p
 
 		progress.SetMessage(ctx, fmt.Sprintf("process %s", change.Path))
 		logger.With("action", change.Action).With("path", change.Path)
-		info.Changes = append(info.Changes, e.evaluateFile(ctx, repo, info.GrafanaBaseURL, change, opts, parser, shouldRender))
+		info.Changes = append(info.Changes, e.evaluateFile(ctx, repo, info.GrafanaBaseURL, screenshotBaseURL, change, opts, parser, shouldRender))
 	}
 
 	return info, nil
@@ -117,7 +135,7 @@ func (e *evaluator) Evaluate(ctx context.Context, repo repository.Reader, opts p
 
 var dashboardKind = dashboard.DashboardResourceInfo.GroupVersionKind().Kind
 
-func (e *evaluator) evaluateFile(ctx context.Context, repo repository.Reader, baseURL string, change repository.VersionedFileChange, opts provisioning.PullRequestJobOptions, parser resources.Parser, shouldRender bool) fileChangeInfo {
+func (e *evaluator) evaluateFile(ctx context.Context, repo repository.Reader, baseURL string, screenshotBaseURL string, change repository.VersionedFileChange, opts provisioning.PullRequestJobOptions, parser resources.Parser, shouldRender bool) fileChangeInfo {
 	if change.Action == repository.FileActionDeleted {
 		return e.evaluateDeletedFile(ctx, repo, baseURL, change, parser)
 	}
@@ -176,14 +194,14 @@ func (e *evaluator) evaluateFile(ctx context.Context, repo repository.Reader, ba
 		info.PreviewURL += "?" + query.Encode()
 		if shouldRender {
 			if info.GrafanaURL != "" {
-				info.GrafanaScreenshotURL, err = renderScreenshotFromGrafanaURL(ctx, baseURL, e.render, info.Parsed.Repo, info.GrafanaURL, e.metrics)
+				info.GrafanaScreenshotURL, err = renderScreenshotFromGrafanaURL(ctx, screenshotBaseURL, e.render, info.Parsed.Repo, info.GrafanaURL, e.metrics)
 				if err != nil {
 					info.Error = err.Error()
 				}
 			}
 
 			if info.PreviewURL != "" {
-				info.PreviewScreenshotURL, err = renderScreenshotFromGrafanaURL(ctx, baseURL, e.render, info.Parsed.Repo, info.PreviewURL, e.metrics)
+				info.PreviewScreenshotURL, err = renderScreenshotFromGrafanaURL(ctx, screenshotBaseURL, e.render, info.Parsed.Repo, info.PreviewURL, e.metrics)
 				if err != nil {
 					info.Error = err.Error()
 				}

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/changes_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/changes_test.go
@@ -23,12 +23,13 @@ import (
 
 func TestCalculateChanges(t *testing.T) {
 	tests := []struct {
-		name           string
-		setupMocks     func(parser *resources.MockParser, reader *repository.MockReader, progress *jobs.MockJobProgressRecorder, renderer *MockScreenshotRenderer, parserFactory *resources.MockParserFactory)
-		changes        []repository.VersionedFileChange
-		expectedInfo   changeInfo
-		expectedError  string
-		grafanaBaseURL string
+		name              string
+		setupMocks        func(parser *resources.MockParser, reader *repository.MockReader, progress *jobs.MockJobProgressRecorder, renderer *MockScreenshotRenderer, parserFactory *resources.MockParserFactory)
+		changes           []repository.VersionedFileChange
+		expectedInfo      changeInfo
+		expectedError     string
+		grafanaBaseURL    string
+		screenshotBaseURL string
 	}{
 		{
 			name: "with screenshot",
@@ -100,6 +101,235 @@ func TestCalculateChanges(t *testing.T) {
 					PreviewURL:           "http://host/admin/provisioning/y/dashboard/preview/path/to/file.json?pull_request_url=http%253A%252F%252Fgithub.com%252Fpr%252F&ref=ref",
 					GrafanaScreenshotURL: "https://cdn2.thecatapi.com/images/9e2.jpg",
 					PreviewScreenshotURL: "https://cdn2.thecatapi.com/images/9e2.jpg",
+				}},
+			},
+		},
+		{
+			name:              "screenshot uses ProvisioningPublicRootURL when set",
+			screenshotBaseURL: "https://public.example.com",
+			setupMocks: func(parser *resources.MockParser, reader *repository.MockReader, progress *jobs.MockJobProgressRecorder, renderer *MockScreenshotRenderer, parserFactory *resources.MockParserFactory) {
+				finfo := &repository.FileInfo{
+					Path: "path/to/file.json",
+					Ref:  "ref",
+					Data: []byte("xxxx"),
+				}
+				obj := &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": resources.DashboardResource.GroupVersion().String(),
+						"kind":       dashboardKind,
+						"metadata": map[string]interface{}{
+							"name": "the-uid",
+						},
+						"spec": map[string]interface{}{
+							"title": "hello world",
+						},
+					},
+				}
+				meta, _ := utils.MetaAccessor(obj)
+
+				progress.On("SetMessage", mock.Anything, "process path/to/file.json").Return()
+				reader.On("Read", mock.Anything, "path/to/file.json", "ref").Return(finfo, nil)
+				reader.On("Read", mock.Anything, "path/to/file.json", "").Maybe().Return(nil, repository.ErrFileNotFound)
+				reader.On("Config").Return(&provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-repo",
+						Namespace: "x",
+					},
+					Spec: provisioning.RepositorySpec{
+						GitHub: &provisioning.GitHubRepositoryConfig{
+							GenerateDashboardPreviews: true,
+						},
+					},
+				})
+				parser.On("Parse", mock.Anything, finfo).Return(&resources.ParsedResource{
+					Info: finfo,
+					Repo: provisioning.ResourceRepositoryInfo{
+						Namespace: "x",
+						Name:      "y",
+					},
+					GVK: schema.GroupVersionKind{
+						Kind: dashboardKind,
+					},
+					Obj:            obj,
+					Existing:       obj,
+					Meta:           meta,
+					DryRunResponse: obj,
+				}, nil)
+				renderer.On("IsAvailable", mock.Anything, mock.Anything).Return(true)
+				renderer.On("RenderScreenshot", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Return("screenshots/abc.png", nil)
+				parserFactory.On("GetParser", mock.Anything, mock.Anything).Return(parser, nil)
+			},
+			changes: []repository.VersionedFileChange{{
+				Action: repository.FileActionCreated,
+				Path:   "path/to/file.json",
+				Ref:    "ref",
+			}},
+			expectedInfo: changeInfo{
+				Changes: []fileChangeInfo{{
+					Change: repository.VersionedFileChange{
+						Action: repository.FileActionCreated,
+						Path:   "path/to/file.json",
+						Ref:    "ref",
+					},
+					GrafanaURL:           "http://host/d/the-uid/hello-world",
+					PreviewURL:           "http://host/admin/provisioning/y/dashboard/preview/path/to/file.json?pull_request_url=http%253A%252F%252Fgithub.com%252Fpr%252F&ref=ref",
+					GrafanaScreenshotURL: "https://public.example.com/screenshots/abc.png",
+					PreviewScreenshotURL: "https://public.example.com/screenshots/abc.png",
+				}},
+			},
+		},
+		{
+			name: "screenshot falls back to grafana base url when ProvisioningPublicRootURL empty",
+			setupMocks: func(parser *resources.MockParser, reader *repository.MockReader, progress *jobs.MockJobProgressRecorder, renderer *MockScreenshotRenderer, parserFactory *resources.MockParserFactory) {
+				finfo := &repository.FileInfo{
+					Path: "path/to/file.json",
+					Ref:  "ref",
+					Data: []byte("xxxx"),
+				}
+				obj := &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": resources.DashboardResource.GroupVersion().String(),
+						"kind":       dashboardKind,
+						"metadata": map[string]interface{}{
+							"name": "the-uid",
+						},
+						"spec": map[string]interface{}{
+							"title": "hello world",
+						},
+					},
+				}
+				meta, _ := utils.MetaAccessor(obj)
+
+				progress.On("SetMessage", mock.Anything, "process path/to/file.json").Return()
+				reader.On("Read", mock.Anything, "path/to/file.json", "ref").Return(finfo, nil)
+				reader.On("Read", mock.Anything, "path/to/file.json", "").Maybe().Return(nil, repository.ErrFileNotFound)
+				reader.On("Config").Return(&provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-repo",
+						Namespace: "x",
+					},
+					Spec: provisioning.RepositorySpec{
+						GitHub: &provisioning.GitHubRepositoryConfig{
+							GenerateDashboardPreviews: true,
+						},
+					},
+				})
+				parser.On("Parse", mock.Anything, finfo).Return(&resources.ParsedResource{
+					Info: finfo,
+					Repo: provisioning.ResourceRepositoryInfo{
+						Namespace: "x",
+						Name:      "y",
+					},
+					GVK: schema.GroupVersionKind{
+						Kind: dashboardKind,
+					},
+					Obj:            obj,
+					Existing:       obj,
+					Meta:           meta,
+					DryRunResponse: obj,
+				}, nil)
+				renderer.On("IsAvailable", mock.Anything, mock.Anything).Return(true)
+				renderer.On("RenderScreenshot", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Return("screenshots/abc.png", nil)
+				parserFactory.On("GetParser", mock.Anything, mock.Anything).Return(parser, nil)
+			},
+			changes: []repository.VersionedFileChange{{
+				Action: repository.FileActionCreated,
+				Path:   "path/to/file.json",
+				Ref:    "ref",
+			}},
+			expectedInfo: changeInfo{
+				Changes: []fileChangeInfo{{
+					Change: repository.VersionedFileChange{
+						Action: repository.FileActionCreated,
+						Path:   "path/to/file.json",
+						Ref:    "ref",
+					},
+					GrafanaURL:           "http://host/d/the-uid/hello-world",
+					PreviewURL:           "http://host/admin/provisioning/y/dashboard/preview/path/to/file.json?pull_request_url=http%253A%252F%252Fgithub.com%252Fpr%252F&ref=ref",
+					GrafanaScreenshotURL: "http://host/screenshots/abc.png",
+					PreviewScreenshotURL: "http://host/screenshots/abc.png",
+				}},
+			},
+		},
+		{
+			// Proves the screenshot path does not silently inherit spec.webhook.baseUrl.
+			// The repo has webhook.baseUrl set, but ProvisioningPublicRootURL is empty,
+			// so screenshots must use the grafana base URL — not the webhook URL.
+			name: "screenshot ignores spec.webhook.baseUrl when ProvisioningPublicRootURL empty",
+			setupMocks: func(parser *resources.MockParser, reader *repository.MockReader, progress *jobs.MockJobProgressRecorder, renderer *MockScreenshotRenderer, parserFactory *resources.MockParserFactory) {
+				finfo := &repository.FileInfo{
+					Path: "path/to/file.json",
+					Ref:  "ref",
+					Data: []byte("xxxx"),
+				}
+				obj := &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": resources.DashboardResource.GroupVersion().String(),
+						"kind":       dashboardKind,
+						"metadata": map[string]interface{}{
+							"name": "the-uid",
+						},
+						"spec": map[string]interface{}{
+							"title": "hello world",
+						},
+					},
+				}
+				meta, _ := utils.MetaAccessor(obj)
+
+				progress.On("SetMessage", mock.Anything, "process path/to/file.json").Return()
+				reader.On("Read", mock.Anything, "path/to/file.json", "ref").Return(finfo, nil)
+				reader.On("Read", mock.Anything, "path/to/file.json", "").Maybe().Return(nil, repository.ErrFileNotFound)
+				reader.On("Config").Return(&provisioning.Repository{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-repo",
+						Namespace: "x",
+					},
+					Spec: provisioning.RepositorySpec{
+						GitHub: &provisioning.GitHubRepositoryConfig{
+							GenerateDashboardPreviews: true,
+						},
+						Webhook: &provisioning.WebhookConfig{
+							BaseURL: "https://webhook-only.example.com",
+						},
+					},
+				})
+				parser.On("Parse", mock.Anything, finfo).Return(&resources.ParsedResource{
+					Info: finfo,
+					Repo: provisioning.ResourceRepositoryInfo{
+						Namespace: "x",
+						Name:      "y",
+					},
+					GVK: schema.GroupVersionKind{
+						Kind: dashboardKind,
+					},
+					Obj:            obj,
+					Existing:       obj,
+					Meta:           meta,
+					DryRunResponse: obj,
+				}, nil)
+				renderer.On("IsAvailable", mock.Anything, mock.Anything).Return(true)
+				renderer.On("RenderScreenshot", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+					Return("screenshots/abc.png", nil)
+				parserFactory.On("GetParser", mock.Anything, mock.Anything).Return(parser, nil)
+			},
+			changes: []repository.VersionedFileChange{{
+				Action: repository.FileActionCreated,
+				Path:   "path/to/file.json",
+				Ref:    "ref",
+			}},
+			expectedInfo: changeInfo{
+				Changes: []fileChangeInfo{{
+					Change: repository.VersionedFileChange{
+						Action: repository.FileActionCreated,
+						Path:   "path/to/file.json",
+						Ref:    "ref",
+					},
+					GrafanaURL:           "http://host/d/the-uid/hello-world",
+					PreviewURL:           "http://host/admin/provisioning/y/dashboard/preview/path/to/file.json?pull_request_url=http%253A%252F%252Fgithub.com%252Fpr%252F&ref=ref",
+					GrafanaScreenshotURL: "http://host/screenshots/abc.png",
+					PreviewScreenshotURL: "http://host/screenshots/abc.png",
 				}},
 			},
 		},
@@ -924,12 +1154,17 @@ func TestCalculateChanges(t *testing.T) {
 
 			tt.setupMocks(parser, reader, progress, renderer, parserFactory)
 
-			evaluator := NewEvaluator(renderer, parserFactory, func(_ context.Context, _ string) string {
-				if tt.grafanaBaseURL != "" {
-					return tt.grafanaBaseURL
-				}
-
-				return "http://host/"
+			screenshotBaseURL := tt.screenshotBaseURL
+			if screenshotBaseURL == "" {
+				screenshotBaseURL = "http://host/"
+			}
+			internalURL := "http://host/"
+			if tt.grafanaBaseURL != "" {
+				internalURL = tt.grafanaBaseURL
+			}
+			evaluator := NewEvaluator(renderer, parserFactory, URLProvider{
+				Internal: func(_ context.Context, _ string) string { return internalURL },
+				Public:   func(_ context.Context, _ string) string { return screenshotBaseURL },
 			}, prometheus.NewPedanticRegistry())
 
 			pullRequest := provisioning.PullRequestJobOptions{

--- a/pkg/registry/apis/provisioning/webhooks/pullrequest/worker.go
+++ b/pkg/registry/apis/provisioning/webhooks/pullrequest/worker.go
@@ -30,8 +30,17 @@ func ProvidePullRequestWorker(
 	configProvider apiserver.RestConfigProvider,
 	registry prometheus.Registerer,
 ) *PullRequestWorker {
-	urlProvider := func(_ context.Context, _ string) string {
-		return cfg.AppURL
+	// Screenshot images are fetched server-side by the Git provider's image
+	// proxy and must be reachable from the public internet — prefer
+	// public_root_url when set. Clickable links stay on AppURL so internal
+	// reviewers reach Grafana via the canonical URL.
+	publicURL := cfg.AppURL
+	if cfg.ProvisioningPublicRootURL != "" {
+		publicURL = cfg.ProvisioningPublicRootURL
+	}
+	urls := URLProvider{
+		Internal: func(_ context.Context, _ string) string { return cfg.AppURL },
+		Public:   func(_ context.Context, _ string) string { return publicURL },
 	}
 
 	// FIXME: we should create providers for client and parsers, so that we don't have
@@ -39,7 +48,7 @@ func ProvidePullRequestWorker(
 	clients := resources.NewClientFactory(configProvider)
 	parsers := resources.NewParserFactory(clients, resources.IsFolderMetadataEnabled(cfg))
 	screenshotRenderer := NewScreenshotRenderer(renderer, blobstore)
-	evaluator := NewEvaluator(screenshotRenderer, parsers, urlProvider, registry)
+	evaluator := NewEvaluator(screenshotRenderer, parsers, urls, registry)
 	commenter := NewCommenter(cfg.ProvisioningAllowImageRendering)
 
 	return NewPullRequestWorker(evaluator, commenter, registry)

--- a/pkg/registry/apis/provisioning/webhooks/register.go
+++ b/pkg/registry/apis/provisioning/webhooks/register.go
@@ -72,14 +72,24 @@ func ProvideWebhooksWithImages(
 	configProvider apiserver.RestConfigProvider,
 	registry prometheus.Registerer,
 ) *WebhookExtraBuilder {
-	urlProvider := func(_ context.Context, _ string) string {
-		return cfg.AppURL
+	// Webhook callbacks and screenshot images embedded in PR comments must be
+	// reachable from the public internet (the Git provider fetches them
+	// server-side). Prefer [provisioning] public_root_url when set; fall back
+	// to AppURL. Clickable links stay on AppURL so internal reviewers reach
+	// Grafana via the canonical, corp-network-friendly URL.
+	publicURL := cfg.AppURL
+	if cfg.ProvisioningPublicRootURL != "" {
+		publicURL = cfg.ProvisioningPublicRootURL
 	}
-	isPublic := isPublicURL(urlProvider(context.Background(), ""))
+	urls := pullrequest.URLProvider{
+		Internal: func(_ context.Context, _ string) string { return cfg.AppURL },
+		Public:   func(_ context.Context, _ string) string { return publicURL },
+	}
+	isPublic := isPublicURL(publicURL)
 
 	return &WebhookExtraBuilder{
 		isPublic:    isPublic,
-		urlProvider: urlProvider,
+		urlProvider: urls.Public,
 		ExtraBuilder: func(b *provisioningapis.APIBuilder) provisioningapis.Extra {
 			clients := resources.NewClientFactory(configProvider)
 			parsers := resources.NewParserFactory(clients, resources.IsFolderMetadataEnabled(cfg))
@@ -93,14 +103,14 @@ func ProvideWebhooksWithImages(
 				registry,
 			)
 
-			evaluator := pullrequest.NewEvaluator(screenshotRenderer, parsers, urlProvider, registry)
+			evaluator := pullrequest.NewEvaluator(screenshotRenderer, parsers, urls, registry)
 			commenter := pullrequest.NewCommenter(cfg.ProvisioningAllowImageRendering)
 			pullRequestWorker := pullrequest.NewPullRequestWorker(evaluator, commenter, registry)
 
 			return NewWebhookExtraWithImages(
 				render,
 				webhook,
-				urlProvider,
+				urls.Public,
 				[]jobs.Worker{pullRequestWorker},
 			)
 		},

--- a/pkg/registry/apis/provisioning/webhooks/register_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/register_test.go
@@ -8,6 +8,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/pkg/setting"
 )
 
 func TestWebhookExtraBuilder_WebhookURL(t *testing.T) {
@@ -104,6 +105,56 @@ func TestWebhookExtraBuilder_WebhookURL(t *testing.T) {
 
 			result := builder.WebhookURL(context.Background(), tt.repo)
 			assert.Equal(t, tt.expected, result)
+		})
+	}
+}
+
+// TestResolvePublicURL verifies the urlProvider resolution chain used by
+// ProvideWebhooksWithImages: spec.webhook.baseUrl wins when set on a repo;
+// otherwise the builder falls back to ProvisioningPublicRootURL when set, then
+// to AppURL.
+func TestResolvePublicURL(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         *setting.Cfg
+		repoWebhook *provisioning.WebhookConfig
+		expected    string
+	}{
+		{
+			name:     "uses ProvisioningPublicRootURL when set and no spec override",
+			cfg:      &setting.Cfg{AppURL: "http://internal.cluster.local/", ProvisioningPublicRootURL: "https://public.example.com"},
+			expected: "https://public.example.com/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/my-repo/webhook",
+		},
+		{
+			name:     "falls back to AppURL when ProvisioningPublicRootURL empty",
+			cfg:      &setting.Cfg{AppURL: "https://grafana.example.com/"},
+			expected: "https://grafana.example.com/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/my-repo/webhook",
+		},
+		{
+			name:        "spec.webhook.baseUrl still wins over ProvisioningPublicRootURL",
+			cfg:         &setting.Cfg{AppURL: "http://internal.cluster.local/", ProvisioningPublicRootURL: "https://public.example.com"},
+			repoWebhook: &provisioning.WebhookConfig{BaseURL: "https://repo-override.example.com"},
+			expected:    "https://repo-override.example.com/apis/provisioning.grafana.app/v0alpha1/namespaces/default/repositories/my-repo/webhook",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			publicURL := tt.cfg.AppURL
+			if tt.cfg.ProvisioningPublicRootURL != "" {
+				publicURL = tt.cfg.ProvisioningPublicRootURL
+			}
+			builder := &WebhookExtraBuilder{
+				isPublic: isPublicURL(publicURL),
+				urlProvider: func(_ context.Context, _ string) string {
+					return publicURL
+				},
+			}
+			repo := &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{Name: "my-repo", Namespace: "default"},
+				Spec:       provisioning.RepositorySpec{Webhook: tt.repoWebhook},
+			}
+			assert.Equal(t, tt.expected, builder.WebhookURL(context.Background(), repo))
 		})
 	}
 }

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -156,6 +156,7 @@ type Cfg struct {
 	ProvisioningMaxResourcesPerRepository int64  // 0 = unlimited
 	ProvisioningMaxRepositories           int64  // default 10, 0 in config = unlimited (converted to -1 internally)
 	ProvisioningFolderAPIVersion          string // "v1" (default for on-prem) or "v1beta1"
+	ProvisioningPublicRootURL             string // public-facing root URL of this Grafana instance for provisioning consumers (webhooks, screenshots); falls back to AppURL when empty
 	DataPath                              string
 	LogsPath                              string
 	EnterpriseLicensePath                 string
@@ -2392,6 +2393,7 @@ func (cfg *Cfg) readProvisioningSettings(iniFile *ini.File) error {
 	cfg.ProvisioningMaxResourcesPerRepository = iniFile.Section("provisioning").Key("max_resources_per_repository").MustInt64(0)
 	cfg.ProvisioningMaxRepositories = iniFile.Section("provisioning").Key("max_repositories").MustInt64(10)
 	cfg.ProvisioningFolderAPIVersion = iniFile.Section("provisioning").Key("folders_api_version").MustString("v1")
+	cfg.ProvisioningPublicRootURL = strings.TrimRight(valueAsString(iniFile.Section("provisioning"), "public_root_url", ""), "/")
 
 	// Read job history configuration
 	cfg.ProvisioningLokiURL = valueAsString(iniFile.Section("provisioning"), "loki_url", "")


### PR DESCRIPTION
Backport bd71d665de3a4149d3cc93ebc65e7eb422d51098 from #123613

---

## Summary

Adds a new instance-level `[provisioning] public_root_url` setting that drives the webhook callback URL registered with the Git provider and the screenshot images embedded in pull-request comments. Clickable Grafana/Preview links continue to resolve against `[server] root_url` so internal reviewers reach Grafana via the canonical (corp-network-friendly) URL.

### Why

When Grafana runs behind an internal ingress, `[server] root_url` points at a cluster-private host. GitHub's image fetcher cannot reach those URLs, so dashboard preview images embedded in PR comments come out broken.

### Backport conflict resolution

The auto-backport bot failed because release-13.0.2 lacks `max_incremental_changes` and `webhook_secret_rotation_interval` (introduced after the cut), and `pkg/operators/provisioning/jobs.go` was reorganized into `jobs_operator.go`. Resolutions:

- `conf/defaults.ini`, `pkg/setting/setting.go` — kept only the `public_root_url` / `ProvisioningPublicRootURL` additions; dropped the unrelated incremental-changes / webhook-rotation-interval lines that don't exist on this branch.
- `pkg/operators/provisioning/jobs.go` — file no longer exists on the release branch; the equivalent `pullrequest.NewEvaluator` call lives in `jobs_operator.go`. Updated that call site to pass the new `URLProvider{Internal, Public}` struct (both fields point at the same `urlProvider`, mirroring the upstream operator behavior — operator path doesn't consume `public_root_url`).

## Test plan

- [x] `go build ./pkg/operators/provisioning/... ./pkg/setting/... ./pkg/registry/apis/provisioning/...`
- [x] `go test ./pkg/registry/apis/provisioning/webhooks/... ./pkg/setting/...`