### PR TITLE
Alerting: Replace createMonitoringLogger calls with getLogger

### DIFF
--- a/packages/grafana-runtime/src/services/logging/loggers.ts
+++ b/packages/grafana-runtime/src/services/logging/loggers.ts
@@ -11,6 +11,7 @@ export const Loggers = {
   sandbox: {},
   'ui-extension-logs': {},
   'features.plugins': {},
+  'features.alerting': { context: { module: 'Alerting' } },
 } satisfies Record<string, LoggerDefaults>;
 
 export type LoggerSource = keyof typeof Loggers;

--- a/public/app/features/alerting/unified/Analytics.ts
+++ b/public/app/features/alerting/unified/Analytics.ts
@@ -1,6 +1,8 @@
 import { pickBy } from 'lodash';
 
-import { config, createMonitoringLogger, reportInteraction } from '@grafana/runtime';
+import { type LogContext } from '@grafana/faro-web-sdk';
+import { config, reportInteraction } from '@grafana/runtime';
+import { getLogger } from '@grafana/runtime/unstable';
 import { contextSrv } from 'app/core/services/context_srv';
 
 import { type RuleNamespace } from '../../../types/unified-alerting';
@@ -29,11 +31,20 @@ export const LogMessages = {
   noAlertRuleVersionsFound: 'no alert rule versions found',
 };
 
-const { logInfo, logError, logMeasurement, logWarning } = createMonitoringLogger('features.alerting', {
-  module: 'Alerting',
-});
+export const logDebug = (message: string, contexts?: LogContext) =>
+  getLogger('features.alerting').logDebug(message, contexts);
 
-export { logError, logInfo, logMeasurement, logWarning };
+export const logInfo = (message: string, contexts?: LogContext) =>
+  getLogger('features.alerting').logInfo(message, contexts);
+
+export const logWarning = (message: string, contexts?: LogContext) =>
+  getLogger('features.alerting').logWarning(message, contexts);
+
+export const logError = (error: Error, contexts?: LogContext) =>
+  getLogger('features.alerting').logError(error, contexts);
+
+export const logMeasurement = (type: string, measurement: Record<string, number>, contexts?: LogContext) =>
+  getLogger('features.alerting').logMeasurement(type, measurement, contexts);
 
 /**
  * Utility function to measure performance of async operations


### PR DESCRIPTION
**What is this feature?**

Replaces the `createMonitoringLogger` call in alerting `Analytics.ts` with `getLogger` from `@grafana/runtime/unstable` and registers the `features.alerting` source name in the central `Loggers` registry.

**Why do we need this feature?**

So alerting loggers go through the same registry as the rest of the runtime loggers and we can stop using `createMonitoringLogger` in app code.

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Related #121639

**Special notes for your reviewer:**

The `features.alerting` source name and `module: 'Alerting'` context default are kept as-is so the Faro logs don't change. Each log function is re-exported as a thin wrapper so consumers in `public/app/features/alerting/unified/` don't need to change their imports.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
