### PR TITLE
CI: Exclude generated openapi specs from mt-compat check

### DIFF
--- a/.github/workflows/pr-mt-service-compatibility.yml
+++ b/.github/workflows/pr-mt-service-compatibility.yml
@@ -41,6 +41,9 @@ jobs:
               - '!**/*.gen.ts'
               - '!**/*.gen.d.ts'
               - '!packages/grafana-openapi/**'
+              - '!public/api-enterprise-spec.json'
+              - '!public/api-merged.json'
+              - '!public/openapi3.json'
             backend_strict:
               - 'pkg/**'
               - 'go.mod'


### PR DESCRIPTION
Excludes the legacy OpenAPI/Swagger API specs from frontend files for the mt-compat check. 

These are not 'frontend' files, they're just in the public directory to be served by the backend.