### PR TITLE
TestDataSource: Seeded random walk

### DIFF
--- a/pkg/tsdb/grafana-testdata-datasource/scenarios.go
+++ b/pkg/tsdb/grafana-testdata-datasource/scenarios.go
@@ -854,7 +854,7 @@ func (s *Service) handleErrorWithSourceScenario(ctx context.Context, req *backen
 }
 
 func RandomWalk(query backend.DataQuery, model kinds.TestDataQuery, index int) *data.Frame {
-	rand := rand.New(rand.NewSource(time.Now().UnixNano() + int64(index)))
+	rand := rand.New(rand.NewSource(query.TimeRange.From.UnixNano() + query.TimeRange.To.UnixNano() + int64(index)))
 	timeWalkerMs := query.TimeRange.From.UnixNano() / int64(time.Millisecond)
 	to := query.TimeRange.To.UnixNano() / int64(time.Millisecond)
 	startValue := model.StartValue


### PR DESCRIPTION
**What is this feature?**

Seeding random walk scenario with time range to/from instead of time.Now()

**Why do we need this feature?**
Random walk gets used a lot in e2e tests, but random values in e2e tests are bad. Seeded random allows consistent UI behavior for static time ranges, but still allows testing scenarios where changing time ranges triggers a change in series values.

**Who is this feature for?**

Users of test data source & Grafana developers.

**Special notes for your reviewer:**
Part of epic: https://github.com/grafana/grafana/issues/123154
The start value is randomized separately, and it wasn't worth blowing up the scope on the frontend changes to add a default value for this scenario, so for now users need to set the start value and an absolute time range. We can follow up later if needed.
Alternative approach to https://github.com/grafana/grafana/pull/124172

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
