### PR TITLE
feat: display library panel name in delete confirmation modal

### DIFF
--- a/public/app/features/library-panels/components/DeleteLibraryPanelModal/DeleteLibraryPanelModal.tsx
+++ b/public/app/features/library-panels/components/DeleteLibraryPanelModal/DeleteLibraryPanelModal.tsx
@@ -42,7 +42,7 @@ export const DeleteLibraryPanelModal: FC<Props> = ({ libraryPanel, onDismiss, on
       {done ? (
         <div>
           {connected ? <HasConnectedDashboards dashboardTitles={dashboardTitles} /> : null}
-          {!connected ? <Confirm /> : null}
+          {!connected ? <Confirm name={libraryPanel.name} /> : null}
 
           <Modal.ButtonRow>
             <Button variant="secondary" onClick={onDismiss} fill="outline">
@@ -64,12 +64,14 @@ const LoadingIndicator = () => (
   </span>
 );
 
-const Confirm = () => {
+const Confirm: FC<{ name: string }> = ({ name }) => {
   const styles = useStyles2(getModalStyles);
 
   return (
     <div className={styles.modalText}>
-      <Trans i18nKey="library-panels.confirm.delete-panel">Do you want to delete this panel?</Trans>
+      <Trans i18nKey="library-panels.confirm.delete-panel" values={{ name }}>
+        Are you sure you want to delete the library panel "{name}"?
+      </Trans>
     </div>
   );
 };


### PR DESCRIPTION
This PR addresses a highly requested safety and UX enhancement by dynamically displaying the library panel name in the delete confirmation modal, preventing accidental deletions.

### Changes:
1. **Dynamic Text**: Replaced the generic delete confirmation text with a dynamic message showing the exact library panel name (e.g., *Are you sure you want to delete the library panel "My Panel Name"?*).
2. **Translation Compatibility**: Preserved full localization support by passing the panel name as a prop to the translation `<Trans>` component's `values` parameter.
3. **Clean Integration**: Resides entirely in the React/TypeScript frontend component [`DeleteLibraryPanelModal.tsx`].

Signed-off-by: ArunKG <g.arunkumar27@gmail.com>