### PR TITLE
Logs Panel: Fix interactions between custom displayed fields and OTel log attributes

### DIFF
--- a/public/app/features/logs/components/panel/LogList.test.tsx
+++ b/public/app/features/logs/components/panel/LogList.test.tsx
@@ -271,12 +271,7 @@ describe('LogList', () => {
       const otelLogs = [createLogRow({ uid: '1', labels: { [OTEL_PROBE_FIELD]: '1' } })];
 
       const { rerender } = render(
-        <LogList
-          {...defaultProps}
-          logs={otelLogs}
-          setDisplayedFields={setDisplayedFields}
-          showLogAttributes={true}
-        />
+        <LogList {...defaultProps} logs={otelLogs} setDisplayedFields={setDisplayedFields} showLogAttributes={true} />
       );
 
       await waitFor(() => {
@@ -289,12 +284,7 @@ describe('LogList', () => {
       setDisplayedFields.mockClear();
 
       rerender(
-        <LogList
-          {...defaultProps}
-          logs={otelLogs}
-          setDisplayedFields={setDisplayedFields}
-          showLogAttributes={false}
-        />
+        <LogList {...defaultProps} logs={otelLogs} setDisplayedFields={setDisplayedFields} showLogAttributes={false} />
       );
 
       await waitFor(() => {

--- a/public/app/features/logs/components/panel/LogList.test.tsx
+++ b/public/app/features/logs/components/panel/LogList.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import {
@@ -263,6 +263,43 @@ describe('LogList', () => {
         OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME,
       ]);
       expect(setDisplayedFields).toHaveBeenCalledWith([LOG_LINE_BODY_FIELD_NAME, OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME]);
+    });
+
+    test('Calls setDisplayedFields when showLogAttributes is toggled off externally', async () => {
+      setBooleanFlags({ newLogsPanel: true, otelLogsFormatting: true });
+      const setDisplayedFields = jest.fn();
+      const otelLogs = [createLogRow({ uid: '1', labels: { [OTEL_PROBE_FIELD]: '1' } })];
+
+      const { rerender } = render(
+        <LogList
+          {...defaultProps}
+          logs={otelLogs}
+          setDisplayedFields={setDisplayedFields}
+          showLogAttributes={true}
+        />
+      );
+
+      await waitFor(() => {
+        expect(setDisplayedFields).toHaveBeenCalledWith([
+          LOG_LINE_BODY_FIELD_NAME,
+          OTEL_LOG_LINE_ATTRIBUTES_FIELD_NAME,
+        ]);
+      });
+
+      setDisplayedFields.mockClear();
+
+      rerender(
+        <LogList
+          {...defaultProps}
+          logs={otelLogs}
+          setDisplayedFields={setDisplayedFields}
+          showLogAttributes={false}
+        />
+      );
+
+      await waitFor(() => {
+        expect(setDisplayedFields).toHaveBeenCalledWith([]);
+      });
     });
   });
 

--- a/public/app/features/logs/components/panel/LogListContext.tsx
+++ b/public/app/features/logs/components/panel/LogListContext.tsx
@@ -10,6 +10,7 @@ import {
   useMemo,
   useState,
 } from 'react';
+import { usePrevious } from 'react-use';
 
 import { createAssistantContextItem, type OpenAssistantProps, useAssistant } from '@grafana/assistant';
 import {
@@ -382,11 +383,15 @@ export const LogListContextProvider = ({
   }, [timestampResolution]);
 
   // Sync showLogAttributes
+  const prevShowLogAttributes = usePrevious(showLogAttributes);
   useEffect(() => {
-    if (showLogAttributes === false && setDisplayedFields) {
+    if (prevShowLogAttributes === undefined) {
+      return;
+    }
+    if (prevShowLogAttributes === true && showLogAttributes === false && setDisplayedFields) {
       setDisplayedFields([]);
     }
-  }, [setDisplayedFields, showLogAttributes]);
+  }, [prevShowLogAttributes, setDisplayedFields, showLogAttributes]);
 
   const controlsExpandedFromStore = store.getBool(
     `${logOptionsStorageKey}.controlsExpanded`,

--- a/public/app/plugins/panel/logs/module.tsx
+++ b/public/app/plugins/panel/logs/module.tsx
@@ -168,11 +168,11 @@ export const plugin = new PanelPlugin<Options>(LogsPanel)
     if (config.featureToggles.otelLogsFormatting && config.featureToggles.newLogsPanel) {
       builder.addBooleanSwitch({
         path: 'showLogAttributes',
-        name: t('logs.show-log-attributes', 'Display log attributes for OTel logs'),
+        name: t('logs.show-log-attributes', 'Enable log attributes for OTel logs'),
         category,
         description: t(
           'logs.description-show-log-attributes',
-          'Experimental. When OTel logs are displayed, add an extra displayed field with relevant key-value pairs from labels and metadata.'
+          'Experimental. When OTel logs are displayed, and there are no displayed fields selected, the panel automatically sets displayed fields with relevant key-value pairs from labels and metadata.'
         ),
         defaultValue: true,
       });

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11249,7 +11249,7 @@
     "description-order": "Show newest or oldest logs first. When Oldest first is selected, the view automatically scrolls to the newest logs at the bottom.",
     "description-prettify-json": "Format JSON log entries with indentation and line breaks.",
     "description-show-controls": "Display controls to jump to the last or first log line, and filters by log level.",
-    "description-show-log-attributes": "Experimental. When OTel logs are displayed, add an extra displayed field with relevant key-value pairs from labels and metadata.",
+    "description-show-log-attributes": "Experimental. When OTel logs are displayed, and there are no displayed fields selected, the panel automatically sets displayed fields with relevant key-value pairs from labels and metadata.",
     "description-unwrapped-columns": "Align values using columns when using displayed fields.",
     "description-wrap-lines": "Display logs as a single line or wrap long log entries to fit the panel.",
     "field-selector": {
@@ -11575,7 +11575,7 @@
       "line-contains-not": "Add as line does not contain filter",
       "search-text": "Search in results"
     },
-    "show-log-attributes": "Display log attributes for OTel logs",
+    "show-log-attributes": "Enable log attributes for OTel logs",
     "timestamp-format": "Timestamp resolution",
     "un-themed-log-details": {
       "aria-label-data-links": "Data links",


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/124126

Additionally, it makes the copy for the feature more representative of what it's doing.

### How to test

Set custom displayed fields for the Logs Panel
With and without OTel log attributes enabled, they should be respected by the panel.

See the video showing how to trigger the bug:

https://github.com/user-attachments/assets/a4632bb6-053b-4f03-983c-083876d2b012