### PR TITLE
go.mod: bump schemads to v0.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -734,15 +734,16 @@ replace (
 	// lock for mysql tsdb compat
 	github.com/go-sql-driver/mysql => github.com/go-sql-driver/mysql v1.7.1
 
+	// TEMP: pin schemads to merged-but-untagged main commit
+	// (grafana/schemads#30 squash-merged 2026-05-07). Remove this replace
+	// and bump the require above to the new tag once schemads tags.
+	github.com/grafana/schemads => github.com/grafana/schemads v0.1.1-0.20260507125157-3be9e6c981de
+
 	// Use our fork of memberlist which includes some fixes that haven't been merged upstream yet.
 	github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20251126142931-6f9f62ab6f86
 
 	// Use our fork of the upstream Alertmanager.
 	github.com/prometheus/alertmanager => github.com/grafana/prometheus-alertmanager v0.25.1-0.20260225120258-18275ca76b0c
-
-	// TEMP: pin schemads to PR HEAD until grafana/schemads#30 merges and is tagged.
-	// Remove this replace and bump the require above to the new tag before merging.
-	github.com/grafana/schemads => github.com/grafana/schemads v0.1.1-0.20260506133442-188c20484be7
 
 	// Pin OpenTelemetry log packages to v0.12.2 for compatibility with dagger v0.18.8
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.12.2

--- a/go.mod
+++ b/go.mod
@@ -116,7 +116,7 @@ require (
 	github.com/grafana/otel-profiling-go v0.5.1 // @grafana/grafana-backend-group
 	github.com/grafana/pyroscope-go/godeltaprof v0.1.9 // @grafana/data-sources-plugins
 	github.com/grafana/pyroscope/api v1.3.0 // @grafana/data-sources-plugins
-	github.com/grafana/schemads v0.1.0 // @grafana/data-sources
+	github.com/grafana/schemads v0.2.0 // @grafana/data-sources
 	github.com/grafana/tempo v1.5.1-0.20260427112133-525d1bab07e0 // @grafana/data-sources-plugins
 	github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 // @grafana/grafana-search-and-storage
 	github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0 // @grafana/plugins-platform-backend
@@ -733,11 +733,6 @@ replace (
 
 	// lock for mysql tsdb compat
 	github.com/go-sql-driver/mysql => github.com/go-sql-driver/mysql v1.7.1
-
-	// TEMP: pin schemads to merged-but-untagged main commit
-	// (grafana/schemads#30 squash-merged 2026-05-07). Remove this replace
-	// and bump the require above to the new tag once schemads tags.
-	github.com/grafana/schemads => github.com/grafana/schemads v0.1.1-0.20260507125157-3be9e6c981de
 
 	// Use our fork of memberlist which includes some fixes that haven't been merged upstream yet.
 	github.com/hashicorp/memberlist => github.com/grafana/memberlist v0.3.1-0.20251126142931-6f9f62ab6f86

--- a/go.mod
+++ b/go.mod
@@ -740,6 +740,10 @@ replace (
 	// Use our fork of the upstream Alertmanager.
 	github.com/prometheus/alertmanager => github.com/grafana/prometheus-alertmanager v0.25.1-0.20260225120258-18275ca76b0c
 
+	// TEMP: pin schemads to PR HEAD until grafana/schemads#30 merges and is tagged.
+	// Remove this replace and bump the require above to the new tag before merging.
+	github.com/grafana/schemads => github.com/grafana/schemads v0.1.1-0.20260506133442-188c20484be7
+
 	// Pin OpenTelemetry log packages to v0.12.2 for compatibility with dagger v0.18.8
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploggrpc v0.12.2
 	go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp => go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp v0.12.2

--- a/go.sum
+++ b/go.sum
@@ -1653,8 +1653,8 @@ github.com/grafana/regexp v0.0.0-20250905093917-f7b3be9d1853 h1:cLN4IBkmkYZNnk7E
 github.com/grafana/regexp v0.0.0-20250905093917-f7b3be9d1853/go.mod h1:+JKpmjMGhpgPL+rXZ5nsZieVzvarn86asRlBg4uNGnk=
 github.com/grafana/saml v0.4.15-0.20240917091248-ae3bbdad8a56 h1:SDGrP81Vcd102L3UJEryRd1eestRw73wt+b8vnVEFe0=
 github.com/grafana/saml v0.4.15-0.20240917091248-ae3bbdad8a56/go.mod h1:S4+611dxnKt8z/ulbvaJzcgSHsuhjVc1QHNTcr1R7Fw=
-github.com/grafana/schemads v0.1.1-0.20260507125157-3be9e6c981de h1:KdxRmWvHdpAko4lGm7TUeNCCt0RuwDSC7KmYoLzPXjQ=
-github.com/grafana/schemads v0.1.1-0.20260507125157-3be9e6c981de/go.mod h1:TX0YfoMxJ8dl1ONXTa+rFk1y3sw1khGwQjB8dKKfzds=
+github.com/grafana/schemads v0.2.0 h1:2yiwWAoovj+tZdBX/jRREBTwHycg6ISvUD2unLiSdgI=
+github.com/grafana/schemads v0.2.0/go.mod h1:TX0YfoMxJ8dl1ONXTa+rFk1y3sw1khGwQjB8dKKfzds=
 github.com/grafana/sqlds/v5 v5.1.1 h1:QEZayyzZZZjDnfMX/f5k7oLehOBH7X1MMnpgn+yDkkI=
 github.com/grafana/sqlds/v5 v5.1.1/go.mod h1:fUt31TRrHrBZ6lyaHZyDqSfeouuSXV6PeBgrNFuZVmo=
 github.com/grafana/tempo v1.5.1-0.20260427112133-525d1bab07e0 h1:kE5kdMnyPJmlNUdWhahfzqPYB3vM8DtAxgWymbB8nOA=

--- a/go.sum
+++ b/go.sum
@@ -1653,10 +1653,8 @@ github.com/grafana/regexp v0.0.0-20250905093917-f7b3be9d1853 h1:cLN4IBkmkYZNnk7E
 github.com/grafana/regexp v0.0.0-20250905093917-f7b3be9d1853/go.mod h1:+JKpmjMGhpgPL+rXZ5nsZieVzvarn86asRlBg4uNGnk=
 github.com/grafana/saml v0.4.15-0.20240917091248-ae3bbdad8a56 h1:SDGrP81Vcd102L3UJEryRd1eestRw73wt+b8vnVEFe0=
 github.com/grafana/saml v0.4.15-0.20240917091248-ae3bbdad8a56/go.mod h1:S4+611dxnKt8z/ulbvaJzcgSHsuhjVc1QHNTcr1R7Fw=
-github.com/grafana/schemads v0.1.0 h1:vZVvOHz8bRd1zRAM+jdKHtWmgnyc3uhKVa7E3TValus=
-github.com/grafana/schemads v0.1.0/go.mod h1:TX0YfoMxJ8dl1ONXTa+rFk1y3sw1khGwQjB8dKKfzds=
-github.com/grafana/schemads v0.1.1-0.20260506133442-188c20484be7 h1:AljE9UH26mMnM6muQwYhEbWUo5E/tpPYINoJGk8olXU=
-github.com/grafana/schemads v0.1.1-0.20260506133442-188c20484be7/go.mod h1:TX0YfoMxJ8dl1ONXTa+rFk1y3sw1khGwQjB8dKKfzds=
+github.com/grafana/schemads v0.1.1-0.20260507125157-3be9e6c981de h1:KdxRmWvHdpAko4lGm7TUeNCCt0RuwDSC7KmYoLzPXjQ=
+github.com/grafana/schemads v0.1.1-0.20260507125157-3be9e6c981de/go.mod h1:TX0YfoMxJ8dl1ONXTa+rFk1y3sw1khGwQjB8dKKfzds=
 github.com/grafana/sqlds/v5 v5.1.1 h1:QEZayyzZZZjDnfMX/f5k7oLehOBH7X1MMnpgn+yDkkI=
 github.com/grafana/sqlds/v5 v5.1.1/go.mod h1:fUt31TRrHrBZ6lyaHZyDqSfeouuSXV6PeBgrNFuZVmo=
 github.com/grafana/tempo v1.5.1-0.20260427112133-525d1bab07e0 h1:kE5kdMnyPJmlNUdWhahfzqPYB3vM8DtAxgWymbB8nOA=

--- a/go.sum
+++ b/go.sum
@@ -1655,6 +1655,8 @@ github.com/grafana/saml v0.4.15-0.20240917091248-ae3bbdad8a56 h1:SDGrP81Vcd102L3
 github.com/grafana/saml v0.4.15-0.20240917091248-ae3bbdad8a56/go.mod h1:S4+611dxnKt8z/ulbvaJzcgSHsuhjVc1QHNTcr1R7Fw=
 github.com/grafana/schemads v0.1.0 h1:vZVvOHz8bRd1zRAM+jdKHtWmgnyc3uhKVa7E3TValus=
 github.com/grafana/schemads v0.1.0/go.mod h1:TX0YfoMxJ8dl1ONXTa+rFk1y3sw1khGwQjB8dKKfzds=
+github.com/grafana/schemads v0.1.1-0.20260506133442-188c20484be7 h1:AljE9UH26mMnM6muQwYhEbWUo5E/tpPYINoJGk8olXU=
+github.com/grafana/schemads v0.1.1-0.20260506133442-188c20484be7/go.mod h1:TX0YfoMxJ8dl1ONXTa+rFk1y3sw1khGwQjB8dKKfzds=
 github.com/grafana/sqlds/v5 v5.1.1 h1:QEZayyzZZZjDnfMX/f5k7oLehOBH7X1MMnpgn+yDkkI=
 github.com/grafana/sqlds/v5 v5.1.1/go.mod h1:fUt31TRrHrBZ6lyaHZyDqSfeouuSXV6PeBgrNFuZVmo=
 github.com/grafana/tempo v1.5.1-0.20260427112133-525d1bab07e0 h1:kE5kdMnyPJmlNUdWhahfzqPYB3vM8DtAxgWymbB8nOA=


### PR DESCRIPTION
## Summary
Bumps `github.com/grafana/schemads` from `v0.1.0` to `v0.2.0`. The new release adds two backward-compatible additions to the schema-discovery protocol:

- `schemads.Metadata{Description, Unit, Custom}` attached to both `Table` and `Column` — gives plugins a typed home for descriptive information that previously had nowhere to live (Prometheus `HELP` / `TYPE` / `UNIT`, SQL `TABLE COMMENT` / `COLUMN COMMENT`, OpenAPI field docs, etc.).
- `ColumnsResponse.TableMetadata map[string]Metadata` — a lazy table-level metadata slot returned alongside `Columns()`, mirroring the per-metric label-discovery pattern. Producers that need an extra upstream call to assemble metadata don't have to fan out during fullSchema.

`Column.Description` is kept and marked `Deprecated` for one release; producers SHOULD populate `Metadata.Description` going forward.

Source change: [grafana/schemads#30](https://github.com/grafana/schemads/pull/30) (merged, tagged as `v0.2.0`).

## Why
Today, schema introspection of a Prometheus datasource produces ~1000 tables with **zero** populated descriptions. The native HELP / TYPE / UNIT exists upstream (`/api/v1/metadata`) but had no home in the schemads protocol. Same gap exists for SQL plugins (table/column comments) and OpenAPI-backed plugins. This bump makes those surfaces available to grafana-side consumers.

## Producer wiring
The Prometheus plugin populates the new fields lazily in its `Columns()` handler. See the corresponding plugin PR for the producer side.

## Test plan
- [x] `go mod tidy` clean
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)