### PR TITLE
Fix: fix rand race condition in debouncer test

### DIFF
--- a/pkg/util/debouncer/queue_test.go
+++ b/pkg/util/debouncer/queue_test.go
@@ -3,7 +3,7 @@ package debouncer
 import (
 	"context"
 	"errors"
-	"math/rand"
+	"math/rand/v2"
 	"sync"
 	"testing"
 	"time"
@@ -69,8 +69,6 @@ func TestQueueConcurrency(t *testing.T) {
 	const writeConcurrency = 50
 	const readConcurrency = 25
 
-	r := rand.New(rand.NewSource(time.Now().UnixNano()))
-
 	totalWrittenSum := atomic.NewInt64(0)
 	totalReadSum := atomic.NewInt64(0)
 	addCalls := atomic.NewInt64(0)
@@ -83,7 +81,7 @@ func TestQueueConcurrency(t *testing.T) {
 		go func() {
 			defer writesWG.Done()
 			for j := 0; j < numbers; j++ {
-				v := r.Int63n(100) // Generate small number, so that we have a chance for combining some numbers.
+				v := rand.Int64N(100) // Generate small number, so that we have a chance for combining some numbers.
 				q.Add(v)
 				addCalls.Inc()
 				totalWrittenSum.Add(v)


### PR DESCRIPTION
The test shared a single rand.Rand across 50 goroutines without synchronization, causing a data race that corrupted its internal state and panicked. Switching to `math/rand/v2`'s package-level `rand.Int64N` eliminates the shared mutable state entirely.

you can read more about go 1.22 and math/rand/v2 here: https://go.dev/blog/randv2

basically it's more thread safe to use the package-level v2 functions than the obj returned by `rand.New`.