### PR TITLE
datasources: querier: test refactor

### DIFF
--- a/pkg/registry/apis/query/query_test.go
+++ b/pkg/registry/apis/query/query_test.go
@@ -173,7 +173,7 @@ func TestQueryAPI(t *testing.T) {
 					Features: featuremgmt.WithFeatures(featuremgmt.FlagSqlExpressions),
 					Tracer:   tracing.InitializeTracerForTest(),
 				},
-				instanceProvider: mockClient{
+				instanceProvider: mockInstanceProvider{
 					stubbedFrame: tc.stubbedFrame,
 				},
 				tracer:                 tracing.InitializeTracerForTest(),
@@ -245,31 +245,39 @@ func TestQueryAPI(t *testing.T) {
 	}
 }
 
-type mockClient struct {
+type mockInstanceProvider struct {
+	stubbedFrame *data.Frame
+}
+
+type mockInstance struct {
 	stubbedFrame *data.Frame
 	logger       log.Logger
 }
 
-func (m mockClient) GetInstance(ctx context.Context, logger log.Logger, headers map[string]string) (clientapi.Instance, error) {
-	mclient := mockClient{
+type mockClient struct {
+	stubbedFrame *data.Frame
+}
+
+func (m mockInstanceProvider) GetInstance(ctx context.Context, logger log.Logger, headers map[string]string) (clientapi.Instance, error) {
+	instance := mockInstance{
 		stubbedFrame: m.stubbedFrame,
 		logger:       logger,
 	}
-	return mclient, nil
+	return instance, nil
 }
 
-func (m mockClient) GetMode() string {
+func (m mockInstanceProvider) GetMode() string {
 	return "testing"
 }
 
-func (m mockClient) ReportMetrics() {
+func (m mockInstance) ReportMetrics() {
 }
 
-func (m mockClient) GetLogger() log.Logger {
+func (m mockInstance) GetLogger() log.Logger {
 	return m.logger
 }
 
-func (m mockClient) GetDataSourceClient(ctx context.Context, ref dataapi.DataSourceRef) (clientapi.QueryDataClient, error) {
+func (m mockInstance) GetDataSourceClient(ctx context.Context, ref dataapi.DataSourceRef) (clientapi.QueryDataClient, error) {
 	mclient := mockClient{
 		stubbedFrame: m.stubbedFrame,
 	}
@@ -292,15 +300,7 @@ func (m mockClient) QueryData(ctx context.Context, req dataapi.QueryDataRequest)
 	}, nil
 }
 
-func (m mockClient) CallResource(ctx context.Context, req *backend.CallResourceRequest, sender backend.CallResourceResponseSender) error {
-	return nil
-}
-
-func (m mockClient) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
-	return nil, nil
-}
-
-func (m mockClient) GetSettings() clientapi.InstanceConfigurationSettings {
+func (m mockInstance) GetSettings() clientapi.InstanceConfigurationSettings {
 	return clientapi.InstanceConfigurationSettings{
 		ExpressionsEnabled: true,
 		FeatureToggles:     featuremgmt.WithFeatures(featuremgmt.FlagSqlExpressions),


### PR DESCRIPTION
change only in the unit tests, no functional change.

the PR improves the naming of the mock structure used by the querier unit tests:
- originally hte `mockClient` structure was mocking 3 separate interfaces (InstanceProvider, Instance, DataSourceClient). this made it harder to understand what's going on, so i split it into 3 separate mocks
- i removed unused methods from the mock structure