### PR TITLE
fix: bump the group validation limit

### DIFF
--- a/pkg/apimachinery/validation/validation.go
+++ b/pkg/apimachinery/validation/validation.go
@@ -9,7 +9,7 @@ import (
 const maxNameLength = 253
 const maxNamespaceLength = 40
 const minNamespaceLength = 3
-const maxGroupLength = 60
+const maxGroupLength = 253
 const minGroupLength = 3
 const maxResourceLength = 40
 const minResourceLength = 3

--- a/pkg/apimachinery/validation/validation.go
+++ b/pkg/apimachinery/validation/validation.go
@@ -6,12 +6,21 @@ import (
 	"k8s.io/apimachinery/pkg/util/validation"
 )
 
+// Limits are derived from k8s.io/apimachinery/pkg/util/validation:
+//   - DNS1123SubdomainMaxLength = 253 (RFC 1123 subdomain): applies to name
+//   - DNS1123LabelMaxLength     = 63  (RFC 1123 label):     applies to namespace
+//
+// group and resource are capped at 190 (below the RFC 1123 subdomain max of 253)
+// because the composite unique index (namespace, group, resource, name) is stored
+// in MySQL with utf8mb4 (4 bytes/char). At 253 each, the index would be
+// 63×4 + 253×4 + 253×4 + 253×4 = 3288 bytes, exceeding InnoDB's 3072-byte limit.
+// At 190 each the total is 63×4 + 190×4 + 190×4 + 253×4 = 2784 bytes, which fits.
 const maxNameLength = 253
-const maxNamespaceLength = 40
+const maxNamespaceLength = 63
 const minNamespaceLength = 3
-const maxGroupLength = 253
+const maxGroupLength = 190
 const minGroupLength = 3
-const maxResourceLength = 40
+const maxResourceLength = 190
 const minResourceLength = 3
 
 const grafanaNameFmt = `^[a-zA-Z0-9:\-\_\.]*$`

--- a/pkg/apimachinery/validation/validation_test.go
+++ b/pkg/apimachinery/validation/validation_test.go
@@ -133,7 +133,7 @@ func TestValidation(t *testing.T) {
 		}{{
 			name:   "too long",
 			expect: []string{"group is too long"},
-			input:  []string{strings.Repeat("0", 61)},
+			input:  []string{strings.Repeat("0", 254)},
 		}, {
 			name:   "too short",
 			expect: []string{"group is too short"},
@@ -142,7 +142,7 @@ func TestValidation(t *testing.T) {
 			name: "ok",
 			input: []string{
 				"hello",
-				strings.Repeat("a", 60), // long... alpha
+				strings.Repeat("a", 253), // long... alpha
 				"dashboards.grafana.app",
 				"prometheus-datasource",
 				"1234", // just a numbers

--- a/pkg/apimachinery/validation/validation_test.go
+++ b/pkg/apimachinery/validation/validation_test.go
@@ -77,7 +77,7 @@ func TestValidation(t *testing.T) {
 			input: []string{""},
 		}, {
 			name:   "too long",
-			input:  []string{strings.Repeat("0", 41)},
+			input:  []string{strings.Repeat("0", 64)},
 			expect: []string{"namespace is too long"},
 		}, {
 			name:   "too short",
@@ -87,7 +87,7 @@ func TestValidation(t *testing.T) {
 			name: "ok",
 			input: []string{
 				"hello",
-				strings.Repeat("a", 40), // long... alpha
+				strings.Repeat("a", 63), // long... alpha
 				"hello-world",
 				"hello.world",
 				"hello_world",
@@ -133,7 +133,7 @@ func TestValidation(t *testing.T) {
 		}{{
 			name:   "too long",
 			expect: []string{"group is too long"},
-			input:  []string{strings.Repeat("0", 254)},
+			input:  []string{strings.Repeat("0", 191)},
 		}, {
 			name:   "too short",
 			expect: []string{"group is too short"},
@@ -142,7 +142,7 @@ func TestValidation(t *testing.T) {
 			name: "ok",
 			input: []string{
 				"hello",
-				strings.Repeat("a", 253), // long... alpha
+				strings.Repeat("a", 190), // long... alpha
 				"dashboards.grafana.app",
 				"prometheus-datasource",
 				"1234", // just a numbers
@@ -184,7 +184,7 @@ func TestValidation(t *testing.T) {
 		}{{
 			name:   "too long",
 			expect: []string{"resource is too long"},
-			input:  []string{strings.Repeat("0", 41)},
+			input:  []string{strings.Repeat("0", 191)},
 		}, {
 			name:   "too short",
 			expect: []string{"resource is too short"},
@@ -193,7 +193,7 @@ func TestValidation(t *testing.T) {
 			name: "ok",
 			input: []string{
 				"hello",
-				strings.Repeat("a", 40), // long... alpha
+				strings.Repeat("a", 190), // long... alpha
 				"dashboards",
 				"folders",
 				"folders123",

--- a/pkg/registry/apis/datasource/migrator/migrator.go
+++ b/pkg/registry/apis/datasource/migrator/migrator.go
@@ -11,7 +11,9 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	common "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/validation"
 	datasourceV0 "github.com/grafana/grafana/pkg/apis/datasource/v0alpha1"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/registry/apis/datasource/converter"
 	secret "github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 	"github.com/grafana/grafana/pkg/services/datasources"
@@ -28,6 +30,8 @@ type DataSourceMigrator interface {
 	// pre-authorization.
 	PluginGroups(ctx context.Context, namespace string, client resource.SearchClient) ([]schema.GroupResource, error)
 }
+
+var logger = log.New("storage.unified.datasource.migrator")
 
 type dataSourceMigrator struct {
 	getter      func(ctx context.Context, namespace string) ([]*datasourceV0.DataSource, error)
@@ -203,6 +207,9 @@ func (m *dataSourceMigrator) PluginGroups(ctx context.Context, namespace string,
 		group := ds.GroupVersionKind().Group
 		if group == "" || seen[group] {
 			continue
+		}
+		if errs := validation.IsValidGroup(group); len(errs) > 0 {
+			logger.Error("datasource plugin has invalid group name and cannot be migrated", "name", ds.Name, "group", group, "errors", errs)
 		}
 		seen[group] = true
 		legacy = append(legacy, schema.GroupResource{Group: group, Resource: "datasources"})

--- a/pkg/storage/unified/resource/keys_test.go
+++ b/pkg/storage/unified/resource/keys_test.go
@@ -81,7 +81,7 @@ func TestVerifyRequestKey(t *testing.T) {
 	invalidNamespace := "(((((default"
 	invalidName := "    " // only spaces
 
-	namespaceTooLong := strings.Repeat("a", 61)
+	namespaceTooLong := strings.Repeat("a", 64)
 	nameTooLong := strings.Repeat("a", 300)
 
 	tests := []struct {
@@ -192,7 +192,7 @@ func TestVerifyRequestKeyCollection(t *testing.T) {
 	invalidResource := "##resource"
 	invalidNamespace := "(((((default"
 
-	namespaceTooLong := strings.Repeat("a", 61)
+	namespaceTooLong := strings.Repeat("a", 64)
 
 	tests := []struct {
 		name         string


### PR DESCRIPTION
I encountered errors while migrating datasources in dev. I am here bumping the max length constraints based on the api machinery and database constraints.

```
2026-05-06 15:53:39.231 error ts=2026-05-06T13:53:39.231654724Z level=error caller=controller.go:248 job=migration msg="error migrating instance" instance=testymctestface err="migration datasource: migration failed for org 1 (stacks-1691): migration error: invalid request key: group is too long"
```