### PR TITLE
Meticulous: Update job for main by adding step to pull docker image

### DIFF
--- a/.github/workflows/pr-build-grafana.yml
+++ b/.github/workflows/pr-build-grafana.yml
@@ -160,7 +160,7 @@ jobs:
           environment: 'dev'
 
       - name: Pull image from GAR
-        run: docker pull ${{ needs.push-docker-image.outputs.IMAGE }}
+        run: docker pull "${{ needs.push-docker-image.outputs.IMAGE }}"
 
       - name: Get vault secrets
         id: vault-secrets

--- a/.github/workflows/pr-build-grafana.yml
+++ b/.github/workflows/pr-build-grafana.yml
@@ -140,6 +140,8 @@ jobs:
     name: Run Meticulous tests
     runs-on: ubuntu-x64-small
     continue-on-error: true
+    env:
+      IMAGE_TAG: ${{ needs.push-docker-image.outputs.IMAGE }}
     permissions:
       actions: write
       contents: read
@@ -160,7 +162,7 @@ jobs:
           environment: 'dev'
 
       - name: Pull image from GAR
-        run: docker pull "${{ needs.push-docker-image.outputs.IMAGE }}"
+        run: docker pull "$IMAGE_TAG"
 
       - name: Get vault secrets
         id: vault-secrets
@@ -173,5 +175,5 @@ jobs:
         uses: alwaysmeticulous/report-diffs-action/upload-container@89c6081b30d17cfcc410b5c19c269cd7a4d67cdf # v1
         with:
           api-token: ${{ env.METICULOUS_API_TOKEN }}
-          image-tag: ${{ needs.push-docker-image.outputs.IMAGE }}
+          image-tag: ${{ env.IMAGE_TAG }}
           container-port: 3000

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -937,6 +937,8 @@ jobs:
     name: Run Meticulous tests
     runs-on: ubuntu-x64-small
     continue-on-error: true
+    env:
+      IMAGE_TAG: grafana/grafana-dev:${{ needs.publish-dockerhub.outputs.tag-version }}
     permissions:
       actions: write
       contents: read
@@ -951,7 +953,7 @@ jobs:
           persist-credentials: false
 
       - name: Pull image from Dockerhub
-        run: docker pull grafana/grafana-dev:${{ needs.publish-dockerhub.outputs.tag-version }}
+        run: docker pull ${{ env.IMAGE_TAG }}
 
       - name: Get vault secrets
         id: vault-secrets
@@ -964,7 +966,7 @@ jobs:
         uses: alwaysmeticulous/report-diffs-action/upload-container@89c6081b30d17cfcc410b5c19c269cd7a4d67cdf # v1
         with:
           api-token: ${{ env.METICULOUS_API_TOKEN }}
-          image-tag: grafana/grafana-dev:${{ needs.publish-dockerhub.outputs.tag-version }}
+          image-tag: ${{ env.IMAGE_TAG }}
           container-port: 3000
 
   dispatch-npm-canaries:

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -953,7 +953,7 @@ jobs:
           persist-credentials: false
 
       - name: Pull image from Dockerhub
-        run: docker pull ${{ env.IMAGE_TAG }}
+        run: docker pull "${{ env.IMAGE_TAG }}"
 
       - name: Get vault secrets
         id: vault-secrets

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -938,13 +938,20 @@ jobs:
     runs-on: ubuntu-x64-small
     continue-on-error: true
     permissions:
+      actions: write
       contents: read
       id-token: write
+      issues: write
+      pull-requests: write
+      statuses: read
 
     steps:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
+
+      - name: Pull image from Dockerhub
+        run: docker pull grafana/grafana-dev:${{ needs.publish-dockerhub.outputs.tag-version }}
 
       - name: Get vault secrets
         id: vault-secrets

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -953,7 +953,7 @@ jobs:
           persist-credentials: false
 
       - name: Pull image from Dockerhub
-        run: docker pull "${{ env.IMAGE_TAG }}"
+        run: docker pull "$IMAGE_TAG"
 
       - name: Get vault secrets
         id: vault-secrets


### PR DESCRIPTION
### Summary

- updates permissions for the run-meticulous-tests job to match the permissions they say are required (matching the ones present in the PR job)
- adds a step to pull the Docker image into the job
  - it's created in a separate job, so when the job attempts to push the image up, it's not present on the box and it fails. 