### PR TITLE
Migration: Widen team.updated to DATETIME(3) on MySQL

### DIFF
--- a/pkg/services/sqlstore/migrations/team_mig.go
+++ b/pkg/services/sqlstore/migrations/team_mig.go
@@ -96,4 +96,11 @@ func addTeamMigrations(mg *Migrator) {
 	mg.AddMigration("Add unique index team_member_uid", NewAddIndexMigration(teamMemberV1, &Index{
 		Cols: []string{"uid"}, Type: UniqueIndex,
 	}))
+
+	// Widen `team.updated` to millisecond precision so it can act as a
+	// resourceVersion for optimistic concurrency on writes. SQLite stores
+	// DATETIME values as TEXT verbatim and Postgres TIMESTAMP already
+	// preserves sub-second precision, so only MySQL needs an ALTER.
+	mg.AddMigration("Increase precision of team.updated to DATETIME(3)",
+		NewRawSQLMigration("").Mysql("ALTER TABLE team MODIFY updated DATETIME(3) NOT NULL;"))
 }


### PR DESCRIPTION
> Prerequisite for #124094 — that PR's millisecond-resolution resourceVersion gate on team writes only works once `team.updated` can actually store a millisecond fraction on MySQL.

## Summary

Widens the `team.updated` column to `DATETIME(3)` on MySQL via a one-line ALTER migration. SQLite stores `DATETIME` values as TEXT verbatim and Postgres `TIMESTAMP` already preserves sub-second precision, so neither needs a change.

## Why

`legacy.UpdateTeam` (and the new addmember/removemember subresources in #124094) use `team.updated` as the resourceVersion for optimistic concurrency on apiserver-style writes. The `DBTime` wire format already sends millisecond precision, but MySQL `DATETIME(0)` silently truncates the fractional part on storage, so:

- The in-memory timestamp returned to the caller (millisecond-precise) diverges from what's on disk (second-precise).
- The next caller's `UPDATE … WHERE updated = <ms-precise>` clause finds 0 rows even when the row hasn't been touched, surfacing as a spurious `ErrTeamUpdateConflict` / 409.
- Two writers reading at the same coarse-resolution timestamp can both pass the gate and silently overwrite each other within a 1-second window.

Aligning the column precision with the wire format is the cleanest fix and removes the workaround entirely.

## Migration scope

- **MySQL**: `ALTER TABLE team MODIFY updated DATETIME(3) NOT NULL;` — the only DB engine where this changes anything.
- **SQLite**: no change (TEXT verbatim).
- **PostgreSQL**: no change (TIMESTAMP defaults to microsecond precision).

`team` tables are typically tiny (org-level resource), so the ALTER is fast even on busy clusters.

## Test plan

- [ ] OSS suite: `make test-go-integration`
- [ ] Manual smoke on a MySQL devenv: create team, update team, confirm millisecond fraction round-trips through `team.updated`.