### PR TITLE
Simplify snapshot freshness selection

### DIFF
--- a/pkg/storage/unified/search/bleve_snapshot.go
+++ b/pkg/storage/unified/search/bleve_snapshot.go
@@ -79,7 +79,11 @@ func (b *bleveBackend) tryDownloadRemoteSnapshot(
 			if err != nil {
 				return ulid.ULID{}, nil, fmt.Errorf("listing remote snapshots: %w", err)
 			}
-			c, ok := b.pickBestSnapshot(all, time.Now(), logger)
+			notOlderThan := time.Time{}
+			if maxAge := b.opts.Snapshot.MaxIndexAge; maxAge > 0 {
+				notOlderThan = time.Now().Add(-maxAge)
+			}
+			c, ok := b.pickBestSnapshot(all, notOlderThan, logger)
 			if !ok {
 				return ulid.ULID{}, nil, nil
 			}
@@ -104,23 +108,14 @@ func (b *bleveBackend) tryDownloadFreshSameVersionSnapshot(
 ) (bleve.Index, string, int64, error) {
 	logger.Info("Fresh same-version index snapshot download started", "policy", policy, "max_age", maxAge, "last_import_time", lastImportTime)
 
-	// Combine the freshness cutoff with the lastImportTime correctness check.
-	// Both are "BuildTime must be after X"; take the more restrictive X.
-	effectiveMaxAge := maxAge
-	if !lastImportTime.IsZero() {
-		if since := time.Since(lastImportTime); since < effectiveMaxAge {
-			effectiveMaxAge = since
-		}
+	notOlderThan := time.Now().Add(-maxAge)
+	if lastImportTime.After(notOlderThan) {
+		notOlderThan = lastImportTime
 	}
 
 	return b.downloadSelectedSnapshot(ctx, key, resourceDir, policy, spanName, logger,
 		func(ctx context.Context) (ulid.ULID, *IndexMeta, error) {
-			if effectiveMaxAge <= 0 {
-				// lastImportTime is in the future (clock skew) or maxAge is
-				// non-positive; no snapshot can satisfy the freshness window.
-				return ulid.ULID{}, nil, nil
-			}
-			k, m, err := findFreshSnapshotByBuildStart(ctx, b.opts.Snapshot.Store, key, effectiveMaxAge, b.opts.BuildVersion)
+			k, m, err := findFreshSnapshotByBuildStart(ctx, b.opts.Snapshot.Store, key, notOlderThan, b.opts.BuildVersion)
 			if err != nil {
 				return ulid.ULID{}, nil, fmt.Errorf("probing for fresh snapshot: %w", err)
 			}
@@ -260,16 +255,15 @@ func (b *bleveBackend) downloadSelectedSnapshot(
 	return idx, name, rv, nil
 }
 
-// pickBestSnapshot applies hard filters (age, unparseable version) and the
-// three-tier preference to pick the best snapshot, if any.
+// pickBestSnapshot applies hard filters (upload time, unparseable version)
+// and the three-tier preference to pick the best snapshot, if any.
 //
 // Tier 0 (ideal): MinBuildVersion <= v <= runningVersion
 // Tier 1 (older, acceptable): v < MinBuildVersion
 // Tier 2 (newer, last resort): v > runningVersion
 //
 // Within each tier, sort by version desc -> RV desc -> upload time desc.
-func (b *bleveBackend) pickBestSnapshot(all map[ulid.ULID]*IndexMeta, now time.Time, logger log.Logger) (snapshotCandidate, bool) {
-	maxAge := b.opts.Snapshot.MaxIndexAge
+func (b *bleveBackend) pickBestSnapshot(all map[ulid.ULID]*IndexMeta, notOlderThan time.Time, logger log.Logger) (snapshotCandidate, bool) {
 	minVersion := b.opts.Snapshot.MinBuildVersion
 	running := b.runningBuildVersion
 
@@ -277,7 +271,7 @@ func (b *bleveBackend) pickBestSnapshot(all map[ulid.ULID]*IndexMeta, now time.T
 	candidates := make([]snapshotCandidate, 0, len(all))
 	for k, m := range all {
 		// Hard filter: age.
-		if maxAge > 0 && now.Sub(m.UploadTimestamp) > maxAge {
+		if !notOlderThan.IsZero() && m.UploadTimestamp.Before(notOlderThan) {
 			droppedAge++
 			continue
 		}
@@ -397,8 +391,8 @@ func (b *bleveBackend) recordSnapshotDownloadOutcome(policy, status string) {
 
 // findFreshSnapshotByUploadTime walks namespace snapshots newest-first and
 // returns the first one whose BuildVersion matches runningVersion and
-// whose ULID time falls within [now-maxAge, now]. Returns a zero key and nil
-// meta when no such snapshot exists.
+// whose ULID time is after notOlderThan. Returns a zero key and nil meta when
+// no such snapshot exists.
 //
 // Walking (rather than checking only the newest) is necessary in mixed-version
 // clusters — either transiently during rolling upgrades, or as a deliberate
@@ -414,49 +408,17 @@ func findFreshSnapshotByUploadTime(
 	ctx context.Context,
 	store RemoteIndexStore,
 	ns resource.NamespacedResource,
-	maxAge time.Duration,
+	notOlderThan time.Time,
 	runningVersion string,
 ) (ulid.ULID, *IndexMeta, error) {
-	keys, err := store.ListIndexKeys(ctx, ns)
-	if err != nil {
-		return ulid.ULID{}, nil, fmt.Errorf("listing index keys: %w", err)
-	}
-
-	// Sort newest-first by ULID time. ULID time equals upload time (set in
-	// UploadIndex from the ULID's own timestamp), so this is also the
-	// upload-time ordering.
-	sort.Slice(keys, func(i, j int) bool {
-		return keys[i].Time() > keys[j].Time()
+	return findFreshSnapshot(ctx, store, ns, notOlderThan, runningVersion, func(*IndexMeta) bool {
+		return true
 	})
-
-	cutoff := time.Now().Add(-maxAge)
-	for _, k := range keys {
-		// ULID time is the upload time. Once we cross the cutoff, no
-		// remaining candidate can satisfy the freshness criterion.
-		if !ulid.Time(k.Time()).After(cutoff) {
-			return ulid.ULID{}, nil, nil
-		}
-
-		meta, err := store.GetIndexMeta(ctx, ns, k)
-		if err != nil {
-			if errors.Is(err, ErrSnapshotNotFound) || errors.Is(err, ErrInvalidManifest) {
-				continue
-			}
-			return ulid.ULID{}, nil, fmt.Errorf("reading manifest for %s: %w", k, err)
-		}
-
-		if meta.BuildVersion == runningVersion {
-			return k, meta, nil
-		}
-	}
-
-	return ulid.ULID{}, nil, nil
 }
 
 // findFreshSnapshotByBuildStart is the build-start-time variant of
 // findFreshSnapshotByUploadTime: it returns the first same-version
-// snapshot whose BuildTime (not upload time) falls within
-// [now-maxAge, now].
+// snapshot whose BuildTime (not upload time) is after notOlderThan.
 //
 // Use this for data-freshness questions, e.g. "is the remote snapshot
 // fresh enough to skip a rebuild?". Periodic re-uploads preserve the
@@ -465,28 +427,42 @@ func findFreshSnapshotByUploadTime(
 //
 // Manifests with a zero-value BuildTime are skipped (no freshness
 // signal). The stopping rule is unchanged: BuildTime <= ULID time, so a
-// ULID below the cutoff cannot yield a fresh build-start time.
+// ULID below notOlderThan cannot yield a fresh build-start time.
 func findFreshSnapshotByBuildStart(
 	ctx context.Context,
 	store RemoteIndexStore,
 	ns resource.NamespacedResource,
-	maxAge time.Duration,
+	notOlderThan time.Time,
 	runningVersion string,
+) (ulid.ULID, *IndexMeta, error) {
+	return findFreshSnapshot(ctx, store, ns, notOlderThan, runningVersion, func(meta *IndexMeta) bool {
+		return !meta.BuildTime.IsZero() && meta.BuildTime.After(notOlderThan)
+	})
+}
+
+func findFreshSnapshot(
+	ctx context.Context,
+	store RemoteIndexStore,
+	ns resource.NamespacedResource,
+	notOlderThan time.Time,
+	runningVersion string,
+	isFresh func(*IndexMeta) bool,
 ) (ulid.ULID, *IndexMeta, error) {
 	keys, err := store.ListIndexKeys(ctx, ns)
 	if err != nil {
 		return ulid.ULID{}, nil, fmt.Errorf("listing index keys: %w", err)
 	}
 
+	// Sort newest-first by ULID time. ULID time equals upload time, and upload
+	// time is an upper bound for build-start time, so once we cross notOlderThan
+	// no remaining candidate can satisfy either freshness check.
 	sort.Slice(keys, func(i, j int) bool {
 		return keys[i].Time() > keys[j].Time()
 	})
 
-	cutoff := time.Now().Add(-maxAge)
 	for _, k := range keys {
-		// BuildTime <= UploadTimestamp = ULID time. Once ULID
-		// time crosses the cutoff, no remaining candidate can satisfy.
-		if !ulid.Time(k.Time()).After(cutoff) {
+		// Once ULID time crosses the cutoff, no remaining candidate can satisfy.
+		if ulid.Time(k.Time()).Before(notOlderThan) {
 			return ulid.ULID{}, nil, nil
 		}
 
@@ -498,19 +474,9 @@ func findFreshSnapshotByBuildStart(
 			return ulid.ULID{}, nil, fmt.Errorf("reading manifest for %s: %w", k, err)
 		}
 
-		if meta.BuildVersion != runningVersion {
-			continue
-		}
-		// Zero-value BuildTime carries no freshness signal; never selected.
-		if meta.BuildTime.IsZero() {
-			continue
-		}
-		if meta.BuildTime.After(cutoff) {
+		if meta.BuildVersion == runningVersion && isFresh(meta) {
 			return k, meta, nil
 		}
-		// Recent ULID but old BuildTime (e.g. periodic re-upload
-		// of a long-lived index): keep walking — an earlier candidate may
-		// still have a fresh build-start time.
 	}
 
 	return ulid.ULID{}, nil, nil

--- a/pkg/storage/unified/search/bleve_snapshot_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_test.go
@@ -234,28 +234,29 @@ func TestPickBestSnapshot(t *testing.T) {
 		}
 	}
 
-	newBackend := func(maxAge time.Duration, minVersion *semver.Version) *bleveBackend {
+	newBackend := func(minVersion *semver.Version) *bleveBackend {
 		return &bleveBackend{
 			log:                 log.New("bleve-snapshot-test"),
-			opts:                BleveOptions{Snapshot: SnapshotOptions{MaxIndexAge: maxAge, MinBuildVersion: minVersion}},
+			opts:                BleveOptions{Snapshot: SnapshotOptions{MinBuildVersion: minVersion}},
 			runningBuildVersion: running,
 		}
 	}
+	cutoff := func(maxAge time.Duration) time.Time { return now.Add(-maxAge) }
 
 	t.Run("empty list", func(t *testing.T) {
-		_, ok := newBackend(24*time.Hour, minV).pickBestSnapshot(nil, now, log.New("bleve-snapshot-test"))
+		_, ok := newBackend(minV).pickBestSnapshot(nil, cutoff(24*time.Hour), log.New("bleve-snapshot-test"))
 		assert.False(t, ok)
 	})
 
 	t.Run("dropped by age", func(t *testing.T) {
 		all := map[ulid.ULID]*IndexMeta{makeULID(t, now): snap("11.5.0", 100, 2*time.Hour)}
-		_, ok := newBackend(time.Hour, minV).pickBestSnapshot(all, now, log.New("bleve-snapshot-test"))
+		_, ok := newBackend(minV).pickBestSnapshot(all, cutoff(time.Hour), log.New("bleve-snapshot-test"))
 		assert.False(t, ok)
 	})
 
 	t.Run("dropped for unparseable version", func(t *testing.T) {
 		all := map[ulid.ULID]*IndexMeta{makeULID(t, now): snap("not-a-version", 100, time.Minute)}
-		_, ok := newBackend(24*time.Hour, minV).pickBestSnapshot(all, now, log.New("bleve-snapshot-test"))
+		_, ok := newBackend(minV).pickBestSnapshot(all, cutoff(24*time.Hour), log.New("bleve-snapshot-test"))
 		assert.False(t, ok)
 	})
 
@@ -268,7 +269,7 @@ func TestPickBestSnapshot(t *testing.T) {
 			newer: snap("11.6.0", 300, time.Minute),  // tier 2 (above running)
 			ideal: snap("11.5.0", 100, 10*time.Hour), // tier 0 wins despite lower RV / older upload
 		}
-		c, ok := newBackend(24*time.Hour, minV).pickBestSnapshot(all, now, log.New("bleve-snapshot-test"))
+		c, ok := newBackend(minV).pickBestSnapshot(all, cutoff(24*time.Hour), log.New("bleve-snapshot-test"))
 		require.True(t, ok)
 		assert.Equal(t, ideal, c.key)
 		assert.Equal(t, 0, c.tier)
@@ -281,7 +282,7 @@ func TestPickBestSnapshot(t *testing.T) {
 			older: snap("11.3.0", 100, time.Minute),
 			newer: snap("12.0.0", 999, time.Minute),
 		}
-		c, ok := newBackend(24*time.Hour, minV).pickBestSnapshot(all, now, log.New("bleve-snapshot-test"))
+		c, ok := newBackend(minV).pickBestSnapshot(all, cutoff(24*time.Hour), log.New("bleve-snapshot-test"))
 		require.True(t, ok)
 		assert.Equal(t, older, c.key)
 		assert.Equal(t, 1, c.tier)
@@ -290,7 +291,7 @@ func TestPickBestSnapshot(t *testing.T) {
 	t.Run("tier 2 picked as last resort", func(t *testing.T) {
 		only := makeULID(t, now)
 		all := map[ulid.ULID]*IndexMeta{only: snap("12.0.0", 100, time.Minute)}
-		c, ok := newBackend(24*time.Hour, minV).pickBestSnapshot(all, now, log.New("bleve-snapshot-test"))
+		c, ok := newBackend(minV).pickBestSnapshot(all, cutoff(24*time.Hour), log.New("bleve-snapshot-test"))
 		require.True(t, ok)
 		assert.Equal(t, only, c.key)
 		assert.Equal(t, 2, c.tier)
@@ -309,13 +310,13 @@ func TestPickBestSnapshot(t *testing.T) {
 			b: snap("11.5.0", 50, time.Minute),     // best version, lowest RV, newer upload
 			c: snap("11.5.0", 200, 30*time.Minute), // best version, high RV, older upload
 		}
-		got, ok := newBackend(24*time.Hour, minV).pickBestSnapshot(all, now, log.New("bleve-snapshot-test"))
+		got, ok := newBackend(minV).pickBestSnapshot(all, cutoff(24*time.Hour), log.New("bleve-snapshot-test"))
 		require.True(t, ok)
 		assert.Equal(t, c, got.key)
 
 		// Adding d (same version + RV as c, newer upload): d wins via upload-desc tiebreaker.
 		all[d] = snap("11.5.0", 200, time.Minute)
-		got, ok = newBackend(24*time.Hour, minV).pickBestSnapshot(all, now, log.New("bleve-snapshot-test"))
+		got, ok = newBackend(minV).pickBestSnapshot(all, cutoff(24*time.Hour), log.New("bleve-snapshot-test"))
 		require.True(t, ok)
 		assert.Equal(t, d, got.key)
 	})
@@ -1044,7 +1045,7 @@ type probeCase struct {
 	wantErr string
 }
 
-type probeFn func(ctx context.Context, s RemoteIndexStore, ns resource.NamespacedResource, maxAge time.Duration, v string) (ulid.ULID, *IndexMeta, error)
+type probeFn func(ctx context.Context, s RemoteIndexStore, ns resource.NamespacedResource, notOlderThan time.Time, v string) (ulid.ULID, *IndexMeta, error)
 
 func runProbeCases(t *testing.T, probe probeFn, cases []probeCase) {
 	t.Helper()
@@ -1052,7 +1053,7 @@ func runProbeCases(t *testing.T, probe probeFn, cases []probeCase) {
 		t.Run(tc.name, func(t *testing.T) {
 			store := &fakeRemoteIndexStore{getErr: map[ulid.ULID]error{}}
 			want := tc.setup(store)
-			k, meta, err := probe(t.Context(), store, newTestNsResource(), time.Hour, "11.5.0")
+			k, meta, err := probe(t.Context(), store, newTestNsResource(), time.Now().Add(-time.Hour), "11.5.0")
 			if tc.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.wantErr)

--- a/pkg/storage/unified/search/bleve_snapshot_upload.go
+++ b/pkg/storage/unified/search/bleve_snapshot_upload.go
@@ -72,7 +72,8 @@ func (b *bleveBackend) uploadSnapshot(ctx context.Context, key resource.Namespac
 	// failures fall through to today's upload path — the probe is an
 	// optimisation, not a correctness check.
 	if interval := b.opts.Snapshot.UploadInterval; interval > 0 {
-		k, _, err := findFreshSnapshotByUploadTime(ctx, b.opts.Snapshot.Store, key, interval, b.opts.BuildVersion)
+		notOlderThan := time.Now().Add(-interval)
+		k, _, err := findFreshSnapshotByUploadTime(ctx, b.opts.Snapshot.Store, key, notOlderThan, b.opts.BuildVersion)
 		if err != nil {
 			logger.Warn("Snapshot upload-time probe failed; proceeding with upload", "err", err)
 		} else if k != (ulid.ULID{}) {

--- a/pkg/storage/unified/search/remote_index_cleanup_test.go
+++ b/pkg/storage/unified/search/remote_index_cleanup_test.go
@@ -231,7 +231,7 @@ func TestSelectSnapshotsToDelete_NeverDeletesDownloadPick(t *testing.T) {
 				}},
 				runningBuildVersion: running,
 			}
-			picked, ok := be.pickBestSnapshot(metas, now, be.log)
+			picked, ok := be.pickBestSnapshot(metas, now.Add(-testCleanupMaxAge), be.log)
 			require.Truef(t, ok, "test case must yield a pickable snapshot — if a no-pick scenario is needed, add a dedicated test case rather than letting this one short-circuit")
 
 			deleted := selectSnapshotsToDelete(metas, now, testCleanupMaxAge, testCleanupGrace)


### PR DESCRIPTION
Simplify snapshot freshness selection.

This extracts the shared list/sort/walk/error handling from the upload-time and build-start-time snapshot probes.

It also changes the snapshot selection helpers to use an absolute `notOlderThan` cutoff instead of passing age durations around. This keeps the `lastImportTime` check as a direct cutoff comparison and avoids converting it back into an effective max age.