### PR TITLE
unified-storage: fix flake in lease property based test

### DIFF
--- a/pkg/storage/unified/testing/lease.go
+++ b/pkg/storage/unified/testing/lease.go
@@ -636,13 +636,13 @@ func (p *leasePBT) runOp(serverIdx int, op operation) (violation bool) {
 			// nothing to release.
 			return false
 		}
+		p.m.released(serverIdx, op.leaseIdx)
 		if err := p.managers[serverIdx].Release(p.ctx, l); err != nil {
 			p.t.Logf("violation: server %d failed to release: %v",
 				serverIdx, err)
 			return true
 		}
 		delete(p.held[serverIdx], op.leaseIdx)
-		p.m.released(serverIdx, op.leaseIdx)
 	}
 	return false
 }


### PR DESCRIPTION
Previously, the model's view of who held a lease was only updated after the `Release()` call returned. As a consequence, if the test planned for two concurrent `Acquire()` and `Release()` calls on the same lease name, the following problematic sequence is possible:

* T1 (current lease holder): calls `Release()`, succeeds. Model not updated to reflect that yet.
* T2: calls `Acquire()` on the same lease, succeeds.
* T2: verifies model --> failure due to two holders for the same lease.

This commit reverses the order of the calls such that the model is updated before the `Release()` call, fixing a flake observed in a [CI run](https://github.com/grafana/grafana/actions/runs/25424123606/job/74573141891).