### PR TITLE
CI: Use blobless clone for change detection checkouts

### DIFF
--- a/.github/workflows/backend-code-checks.yml
+++ b/.github/workflows/backend-code-checks.yml
@@ -26,7 +26,8 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: true # required to get more history in the changed-files action
-          fetch-depth: 2
+          fetch-depth: 0
+          filter: blob:none
       - name: Detect changes
         id: detect-changes
         uses: ./.github/actions/change-detection

--- a/.github/workflows/backend-unit-tests.yml
+++ b/.github/workflows/backend-unit-tests.yml
@@ -27,7 +27,8 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: true # required to get more history in the changed-files action
-          fetch-depth: 2
+          fetch-depth: 0
+          filter: blob:none
       - name: Detect changes
         id: detect-changes
         uses: ./.github/actions/change-detection

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -37,7 +37,8 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: true # required to get more history in the changed-files action
-          fetch-depth: 2
+          fetch-depth: 0
+          filter: blob:none
       - name: Detect changes
         id: detect-changes
         uses: ./.github/actions/change-detection

--- a/.github/workflows/feature-toggles-ci.yml
+++ b/.github/workflows/feature-toggles-ci.yml
@@ -20,7 +20,8 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: true # required to get more history in the changed-files action
-          fetch-depth: 2
+          fetch-depth: 0
+          filter: blob:none
       - name: Detect changes
         id: detect-changes
         uses: ./.github/actions/change-detection

--- a/.github/workflows/frontend-lint.yml
+++ b/.github/workflows/frontend-lint.yml
@@ -23,7 +23,8 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: true # required to get more history in the changed-files action
-          fetch-depth: 2
+          fetch-depth: 0
+          filter: blob:none
       - name: Detect changes
         id: detect-changes
         uses: ./.github/actions/change-detection

--- a/.github/workflows/go-lint.yml
+++ b/.github/workflows/go-lint.yml
@@ -26,7 +26,8 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: true # required to get more history in the changed-files action
-          fetch-depth: 2
+          fetch-depth: 0
+          filter: blob:none
       - name: Detect changes
         id: detect-changes
         uses: ./.github/actions/change-detection

--- a/.github/workflows/pr-build-grafana.yml
+++ b/.github/workflows/pr-build-grafana.yml
@@ -25,7 +25,8 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: true # required to get more history in the changed-files action
-          fetch-depth: 2
+          fetch-depth: 0
+          filter: blob:none
       - name: Detect changes
         id: detect-changes
         uses: ./.github/actions/change-detection

--- a/.github/workflows/pr-e2e-tests.yml
+++ b/.github/workflows/pr-e2e-tests.yml
@@ -27,7 +27,8 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: true # required to get more history in the changed-files action
-          fetch-depth: 2
+          fetch-depth: 0
+          filter: blob:none
       - name: Detect changes
         id: detect-changes
         uses: ./.github/actions/change-detection

--- a/.github/workflows/pr-endpoint-feature-toggle.yml
+++ b/.github/workflows/pr-endpoint-feature-toggle.yml
@@ -19,7 +19,8 @@ jobs:
         uses: actions/checkout@v5
         with:
           persist-credentials: true
-          fetch-depth: 2
+          fetch-depth: 0
+          filter: blob:none
 
       - name: Detect changes
         id: changed-files

--- a/.github/workflows/pr-frontend-unit-tests.yml
+++ b/.github/workflows/pr-frontend-unit-tests.yml
@@ -23,7 +23,8 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: true # required to get more history in the changed-files action
-          fetch-depth: 2
+          fetch-depth: 0
+          filter: blob:none
       - name: Detect changes
         id: detect-changes
         uses: ./.github/actions/change-detection

--- a/.github/workflows/pr-go-workspace-check.yml
+++ b/.github/workflows/pr-go-workspace-check.yml
@@ -19,7 +19,8 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: true # required to get more history in the changed-files action
-          fetch-depth: 2
+          fetch-depth: 0
+          filter: blob:none
       - name: Detect changes
         id: detect-changes
         uses: ./.github/actions/change-detection

--- a/.github/workflows/pr-mt-service-compatibility.yml
+++ b/.github/workflows/pr-mt-service-compatibility.yml
@@ -18,7 +18,8 @@ jobs:
         uses: actions/checkout@v5
         with:
           persist-credentials: true
-          fetch-depth: 2
+          fetch-depth: 0
+          filter: blob:none
 
       - name: Detect changes
         id: changed-files

--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -45,7 +45,8 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: true # required to get more history in the changed-files action
-          fetch-depth: 2
+          fetch-depth: 0
+          filter: blob:none
       - name: Detect changes
         id: detect-changes
         uses: ./.github/actions/change-detection

--- a/.github/workflows/storybook-a11y.yml
+++ b/.github/workflows/storybook-a11y.yml
@@ -20,7 +20,8 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: true # required to get more history in the changed-files action
-          fetch-depth: 2
+          fetch-depth: 0
+          filter: blob:none
       - name: Detect changes
         id: detect-changes
         uses: ./.github/actions/change-detection

--- a/.github/workflows/swagger-gen.yml
+++ b/.github/workflows/swagger-gen.yml
@@ -27,7 +27,8 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: true # required to get more history in the changed-files action
-          fetch-depth: 2
+          fetch-depth: 0
+          filter: blob:none
       - name: Detect changes
         id: detect-changes
         uses: ./.github/actions/change-detection


### PR DESCRIPTION
**What is this feature?**

Switches all 15 change-detection checkout steps from `fetch-depth: 2` to `fetch-depth: 0` with `filter: blob:none` (blobless partial clone).

**Why do we need this feature?**

With `fetch-depth: 2`, the `tj-actions/changed-files` action needs to find the merge base between the PR branch and `main`. When a branch diverges far enough, the shallow history is insufficient and the action incrementally fetches more commits. On an active repo this can eventually fail when the depth limit is exceeded.

A blobless clone fetches the full commit graph and tree objects but skips all blob content. This gives the action immediate access to the merge base regardless of branch staleness. Change detection only needs tree diffs to list changed paths; it never reads file contents, so blobs are unnecessary.

**Who is this feature for?**

All contributors: faster, more reliable CI change detection on PRs.

**Which issue(s) does this PR fix?**:

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.