### PR TITLE
Alerting: Fix provisioning API returning 500 for non-admin alert rule deletes

### DIFF
--- a/pkg/services/ngalert/accesscontrol/accesscontrol.go
+++ b/pkg/services/ngalert/accesscontrol/accesscontrol.go
@@ -2,10 +2,14 @@ package accesscontrol
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 )
+
+var logger = log.New("ngalert.accesscontrol")
 
 type genericService struct {
 	ac accesscontrol.AccessControl
@@ -20,7 +24,8 @@ func (r genericService) HasAccess(ctx context.Context, user identity.Requester, 
 func (r genericService) HasAccessOrError(ctx context.Context, user identity.Requester, evaluator accesscontrol.Evaluator, action func() string) error {
 	has, err := r.HasAccess(ctx, user, evaluator)
 	if err != nil {
-		return err
+		logger.Error("Access control evaluation failed", "error", err, "action", action())
+		return fmt.Errorf("%w: %w", NewAuthorizationErrorWithPermissions(action(), evaluator), err)
 	}
 	if !has {
 		return NewAuthorizationErrorWithPermissions(action(), evaluator)

--- a/pkg/services/ngalert/accesscontrol/accesscontrol_test.go
+++ b/pkg/services/ngalert/accesscontrol/accesscontrol_test.go
@@ -1,0 +1,48 @@
+package accesscontrol
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/apimachinery/errutil"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/actest"
+)
+
+func TestHasAccessOrError(t *testing.T) {
+	t.Run("returns nil when user has access", func(t *testing.T) {
+		svc := genericService{ac: &actest.FakeAccessControl{ExpectedEvaluate: true}}
+		err := svc.HasAccessOrError(context.Background(), &identity.StaticRequester{}, accesscontrol.EvalPermission("test:action"), func() string { return "test action" })
+		require.NoError(t, err)
+	})
+
+	t.Run("returns errutil.Forbidden when user lacks access", func(t *testing.T) {
+		svc := genericService{ac: &actest.FakeAccessControl{ExpectedEvaluate: false}}
+		err := svc.HasAccessOrError(context.Background(), &identity.StaticRequester{}, accesscontrol.EvalPermission("test:action"), func() string { return "test action" })
+		require.Error(t, err)
+
+		var grafanaErr errutil.Error
+		require.True(t, errors.As(err, &grafanaErr), "expected errutil.Error, got %T", err)
+		assert.Equal(t, 403, grafanaErr.Reason.Status().HTTPStatus())
+	})
+
+	t.Run("wraps internal evaluation error as errutil.Error", func(t *testing.T) {
+		internalErr := errors.New("scope resolution failed")
+		svc := genericService{ac: &actest.FakeAccessControl{ExpectedErr: internalErr}}
+		err := svc.HasAccessOrError(context.Background(), &identity.StaticRequester{}, accesscontrol.EvalPermission("test:action"), func() string { return "test action" })
+		require.Error(t, err)
+
+		// The wrapped error should be detectable as errutil.Error by ErrOrFallback
+		var grafanaErr errutil.Error
+		require.True(t, errors.As(err, &grafanaErr), "expected errutil.Error in chain, got %T: %v", err, err)
+		assert.Equal(t, 403, grafanaErr.Reason.Status().HTTPStatus())
+
+		// The original internal error should also be in the chain
+		require.True(t, errors.Is(err, internalErr), "expected original error in chain")
+	})
+}

--- a/pkg/services/ngalert/provisioning/alert_rules_test.go
+++ b/pkg/services/ngalert/provisioning/alert_rules_test.go
@@ -1489,8 +1489,8 @@ func TestDeleteAlertRule(t *testing.T) {
 				return expectedErr
 			}
 
-			_, err := service.UpdateAlertRule(context.Background(), u, *rule, groupProvenance)
-			require.ErrorIs(t, expectedErr, err)
+			err := service.DeleteAlertRule(context.Background(), u, rule.UID, groupProvenance)
+			require.ErrorIs(t, err, expectedErr)
 
 			require.Len(t, ac.Calls, 2)
 			assert.Equal(t, "CanWriteAllRules", ac.Calls[0].Method)


### PR DESCRIPTION
**What is this feature?**

Wraps internal `ac.Evaluate` errors in `HasAccessOrError` as `errutil.Error` so
`ErrOrFallback` can extract a proper HTTP status instead of defaulting to 500.

**Why do we need this feature?**

`DELETE /api/v1/provisioning/alert-rules/{UID}` returns 500 for non-admin
service accounts. Admin users skip the affected code path via `CanWriteAllRules`.

**Who is this feature for?**

Users managing alert rules via the provisioning API with granular permissions.

**Special notes for your reviewer:**

Also fixes a copy-paste bug in `TestDeleteAlertRule` (was calling `UpdateAlertRule`).

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.