### PR TITLE
chore: update CODEOWNERS for Classic Explore

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -187,7 +187,7 @@
 /pkg/services/provisioning/ @grafana/grafana-search-and-storage
 /pkg/services/provisioning/alerting/ @grafana/alerting-backend
 /pkg/services/query/ @grafana/grafana-datasources-core-services
-/pkg/services/queryhistory/ @grafana/observability-traces-and-profiling
+/pkg/services/queryhistory/ @grafana/datapro
 /pkg/services/quota/ @grafana/grafana-search-and-storage
 /pkg/services/screenshot/ @grafana/grafana-backend-group
 /pkg/services/search/ @grafana/grafana-search-and-storage
@@ -938,7 +938,7 @@ playwright.storybook.config.ts @grafana/grafana-frontend-platform
 /public/app/core/utils/navBarItem-translations.ts @grafana/grafana-frontend-navigation
 /public/app/core/utils/object* @grafana/grafana-frontend-platform
 /public/app/core/utils/query* @grafana/grafana-datasources-core-services
-/public/app/core/utils/richHistory* @grafana/observability-traces-and-profiling
+/public/app/core/utils/richHistory* @grafana/datapro
 /public/app/core/utils/set.ts @grafana/grafana-frontend-platform
 /public/app/core/utils/shortLinks* @grafana/sharing-squad
 /public/app/core/utils/ticks.ts @grafana/plugins-platform-frontend
@@ -969,7 +969,7 @@ playwright.storybook.config.ts @grafana/grafana-frontend-platform
 /public/app/features/datasources/ @grafana/plugins-platform-frontend
 /public/app/features/dimensions/ @grafana/dataviz-squad
 /public/app/features/dataframe-import/ @grafana/dataviz-squad
-/public/app/features/explore/ @grafana/observability-traces-and-profiling
+/public/app/features/explore/ @grafana/datapro
 /public/app/features/expressions/ @grafana/grafana-datasources-core-services
 /public/app/features/folders/ @grafana/grafana-frontend-navigation
 /public/app/features/inspector/ @grafana/dashboards-squad


### PR DESCRIPTION
**What is this feature?**

Update CODEOWNERS to transfer ownership of Classic Explore and Query History from `@grafana/observability-traces-and-profiling` to `@grafana/datapro`.

**Why do we need this feature?**

Classic Explore is moving to the DataPro team.

**Who is this feature for?**

Internal team routing for PR reviews.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Three entries changed:
- `/pkg/services/queryhistory/` (backend query history service)
- `/public/app/core/utils/richHistory*` (rich history utilities)
- `/public/app/features/explore/` (Classic Explore catch-all)

Subdirectory overrides for Logs, NodeGraph, FlameGraph, TraceView, and RawPrometheus are unchanged — those stay with their current teams.