### PR TITLE
AppPlugin: Allow resources to contain "resources" in their path

### DIFF
--- a/pkg/registry/apis/appplugin/context.go
+++ b/pkg/registry/apis/appplugin/context.go
@@ -73,7 +73,7 @@ func (b *AppPluginAPIBuilder) getSettings(ctx context.Context) (*apppluginV0.Set
 		for k, sv := range settings.Secure {
 			v, ok := lookup[sv.Name]
 			if !ok {
-				continue // or error?
+				return nil, fmt.Errorf("unable to find secure value: %s for key: %s", sv.Name, k)
 			}
 			if v.Error() != nil {
 				return nil, fmt.Errorf("error decrypting secure value: %s / %w", k, v.Error())

--- a/pkg/registry/apis/appplugin/settings.go
+++ b/pkg/registry/apis/appplugin/settings.go
@@ -61,7 +61,7 @@ func toSecureJSONData(secure common.InlineSecureValues) map[string]string {
 	result := map[string]string{}
 	for k, v := range secure {
 		if !v.Create.IsZero() {
-			result[k] = v.Create.DangerouslyExposeAndConsumeValue() // ?????? for dual write, I don't think we can do the dangerous one
+			result[k] = v.Create.DangerouslyExposeAndConsumeValue()
 		}
 		if v.Remove {
 			result[k] = "" // best effort with the legacy API
@@ -72,7 +72,7 @@ func toSecureJSONData(secure common.InlineSecureValues) map[string]string {
 
 type settingsStorage struct {
 	pluginID       string
-	pluginSettings pluginsettings.Service // Do we need an explicitly caching version?
+	pluginSettings pluginsettings.Service // TODO? Do we need an explicitly caching version?
 	resourceInfo   *utils.ResourceInfo
 }
 

--- a/pkg/registry/apis/appplugin/settings.go
+++ b/pkg/registry/apis/appplugin/settings.go
@@ -72,7 +72,7 @@ func toSecureJSONData(secure common.InlineSecureValues) map[string]string {
 
 type settingsStorage struct {
 	pluginID       string
-	pluginSettings pluginsettings.Service // TODO? Do we need an explicitly caching version?
+	pluginSettings pluginsettings.Service // TODO we may need a caching version
 	resourceInfo   *utils.ResourceInfo
 }
 

--- a/pkg/registry/apis/appplugin/sub_proxy.go
+++ b/pkg/registry/apis/appplugin/sub_proxy.go
@@ -140,13 +140,14 @@ func (r *subProxyREST) Connect(ctx context.Context, name string, opts runtime.Ob
 }
 
 func proxyRequest(ctx context.Context, req *http.Request) (*http.Request, string, error) {
-	idx := strings.Index(req.URL.Path, "/proxy")
+	const slug = "/app/instance/proxy"
+	idx := strings.Index(req.URL.Path, slug)
 	if idx < 0 {
 		return nil, "", fmt.Errorf("expected proxy path") // 400?
 	}
 
 	clonedReq := req.Clone(ctx)
-	rawURL := strings.TrimLeft(req.URL.Path[idx+len("/proxy"):], "/")
+	rawURL := strings.TrimLeft(req.URL.Path[idx+len(slug):], "/")
 
 	clonedReq.URL = &url.URL{
 		Path:     rawURL,

--- a/pkg/registry/apis/appplugin/sub_resource.go
+++ b/pkg/registry/apis/appplugin/sub_resource.go
@@ -104,13 +104,14 @@ func (r *subResourceREST) Connect(ctx context.Context, name string, opts runtime
 }
 
 func resourceRequest(req *http.Request) (*http.Request, error) {
-	idx := strings.LastIndex(req.URL.Path, "/resources")
+	const slug = "/app/instance/resources"
+	idx := strings.Index(req.URL.Path, slug)
 	if idx < 0 {
-		return nil, fmt.Errorf("expected resource path") // 400?
+		return nil, fmt.Errorf("expected resources path") // 400?
 	}
 
 	clonedReq := req.Clone(req.Context())
-	rawURL := strings.TrimLeft(req.URL.Path[idx+len("/resources"):], "/")
+	rawURL := strings.TrimLeft(req.URL.Path[idx+len(slug):], "/")
 
 	clonedReq.URL = &url.URL{
 		Path:     rawURL,

--- a/pkg/registry/apis/appplugin/sub_resources_test.go
+++ b/pkg/registry/apis/appplugin/sub_resources_test.go
@@ -1,0 +1,130 @@
+package appplugin
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestResourceRequest(t *testing.T) {
+	tests := []struct {
+		name        string
+		inputURL    string
+		expectPath  string
+		expectQuery string
+		expectErr   bool
+	}{
+		{
+			name:       "empty subpath",
+			inputURL:   "/apis/plugin-id/v0alpha1/namespaces/default/app/instance/resources",
+			expectPath: "",
+		},
+		{
+			name:       "trailing slash only",
+			inputURL:   "/apis/plugin-id/v0alpha1/namespaces/default/app/instance/resources/",
+			expectPath: "",
+		},
+		{
+			name:       "single segment subpath",
+			inputURL:   "/apis/plugin-id/v0alpha1/namespaces/default/app/instance/resources/health",
+			expectPath: "health",
+		},
+		{
+			name:       "multi segment subpath",
+			inputURL:   "/apis/plugin-id/v0alpha1/namespaces/default/app/instance/resources/api/v1/items",
+			expectPath: "api/v1/items",
+		},
+		{
+			name:       "subpath contains 'resources' literal",
+			inputURL:   "/apis/plugin-id/v0alpha1/namespaces/default/app/instance/resources/api/resources/list",
+			expectPath: "api/resources/list",
+		},
+		{
+			name:       "subpath ends with 'resources'",
+			inputURL:   "/apis/plugin-id/v0alpha1/namespaces/default/app/instance/resources/resources",
+			expectPath: "resources",
+		},
+		{
+			name:       "subpath is exactly 'app/instance/resources' again",
+			inputURL:   "/apis/plugin-id/v0alpha1/namespaces/default/app/instance/resources/app/instance/resources/foo",
+			expectPath: "app/instance/resources/foo",
+		},
+		{
+			name:        "subpath with query string",
+			inputURL:    "/apis/plugin-id/v0alpha1/namespaces/default/app/instance/resources/search?q=hello&limit=10",
+			expectPath:  "search",
+			expectQuery: "q=hello&limit=10",
+		},
+		{
+			name:        "empty subpath with query string",
+			inputURL:    "/apis/plugin-id/v0alpha1/namespaces/default/app/instance/resources?foo=bar",
+			expectPath:  "",
+			expectQuery: "foo=bar",
+		},
+		{
+			name:        "subpath containing 'resources' with query string",
+			inputURL:    "/apis/plugin-id/v0alpha1/namespaces/default/app/instance/resources/api/resources?type=alert",
+			expectPath:  "api/resources",
+			expectQuery: "type=alert",
+		},
+		{
+			name:       "multiple leading slashes after slug are trimmed",
+			inputURL:   "/apis/plugin-id/v0alpha1/namespaces/default/app/instance/resources///foo/bar",
+			expectPath: "foo/bar",
+		},
+		{
+			name:      "missing slug returns error",
+			inputURL:  "/apis/plugin-id/v0alpha1/namespaces/default/app/instance/health",
+			expectErr: true,
+		},
+		{
+			name:      "path with 'resources' but missing 'app/instance' prefix returns error",
+			inputURL:  "/apis/plugin-id/v0alpha1/namespaces/default/app/resources/foo",
+			expectErr: true,
+		},
+		{
+			name:      "empty path returns error",
+			inputURL:  "/",
+			expectErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodGet, tt.inputURL, nil)
+			require.NoError(t, err)
+
+			got, err := resourceRequest(req)
+			if tt.expectErr {
+				require.Error(t, err)
+				require.Nil(t, got)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, got)
+			require.Equal(t, tt.expectPath, got.URL.Path)
+			require.Equal(t, tt.expectQuery, got.URL.RawQuery)
+
+			// the original request must not be mutated
+			require.Equal(t, tt.inputURL, req.URL.RequestURI())
+		})
+	}
+}
+
+func TestResourceRequest_PreservesMethodAndHeaders(t *testing.T) {
+	req, err := http.NewRequest(
+		http.MethodPost,
+		"/apis/plugin-id/v0alpha1/namespaces/default/app/instance/resources/api/resources/create",
+		nil,
+	)
+	require.NoError(t, err)
+	req.Header.Set("X-Test-Header", "value")
+
+	got, err := resourceRequest(req)
+	require.NoError(t, err)
+	require.Equal(t, http.MethodPost, got.Method)
+	require.Equal(t, "value", got.Header.Get("X-Test-Header"))
+	require.Equal(t, "api/resources/create", got.URL.Path)
+}


### PR DESCRIPTION
Addressing the feedback from @andresmgot from https://github.com/grafana/grafana/pull/123676

I merged while the CI was 🟢, and this does not have an enterprise twin!