### PR TITLE
Chore: Route area/explore auto-triage to DataPro

### DIFF
--- a/.github/commands.json
+++ b/.github/commands.json
@@ -184,7 +184,7 @@
     "name": "area/explore",
     "action": "addToProject",
     "addToProject": {
-      "url": "https://github.com/orgs/grafana/projects/111"
+      "url": "https://github.com/orgs/grafana/projects/908"
     }
   },
   {


### PR DESCRIPTION
## Summary
- Classic Explore ownership transferred to `@grafana/datapro` in #124340 (CODEOWNERS for `/public/app/features/explore/`, `/pkg/services/queryhistory/`, `/public/app/core/utils/richHistory*`).
- Auto-triage label routing was still pointing `area/explore` at project `111`. This updates it to DataPro's project board (`908`) so new issues land on the correct board.