### PR TITLE
NestedFolderPicker: Hide team folders when scoped to a root folder

### DIFF
--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.test.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.test.tsx
@@ -309,6 +309,14 @@ describe('NestedFolderPicker', () => {
 
       expect(mockOnChange).not.toHaveBeenCalled();
     });
+
+    it('hides team folders when rootFolderUID is set', async () => {
+      const { user } = render(<NestedFolderPicker rootFolderUID="my-repo" onChange={mockOnChange} />);
+      await user.click(await screen.findByRole('button', { name: 'Select folder' }));
+
+      expect(screen.queryByLabelText('Team folders')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText('Team Folder One')).not.toBeInTheDocument();
+    });
   });
 
   describe('when teamFolders is disabled', () => {

--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
@@ -242,9 +242,9 @@ export function NestedFolderPicker({
       }
 
       // Only show team folders when browsing the full tree (no rootFolderUID scope)
-      const treeWithTeamFolders = rootFolderUID ? flatTree : [...teamFolderTreeItems, ...flatTree];
+      const fullTree = rootFolderUID ? flatTree : [...teamFolderTreeItems, ...flatTree];
       // Add "Team folders" at the top of the tree list.
-      return filterExcludedItems(treeWithTeamFolders, excludeUIDs);
+      return filterExcludedItems(fullTree, excludeUIDs);
     } else {
       flatTree = searchResultsToTreeItems(searchResults?.items || []);
       return filterExcludedItems(flatTree, excludeUIDs);

--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
@@ -39,7 +39,9 @@ export interface NestedFolderPickerProps {
   /* Folder UIDs to exclude from the picker, to prevent invalid operations */
   excludeUIDs?: string[];
 
-  /* Start tree from this folder instead of root */
+  /* Start tree from this folder instead of root. When set, the picker is scoped
+   to this subtree — only descendants of this folder are shown, and top-level
+   items like team folders are excluded. */
   rootFolderUID?: string;
 
   /* Custom root folder item, default is "Dashboards" */
@@ -239,9 +241,9 @@ export function NestedFolderPicker({
         flatTree = filterRootItem(flatTree);
       }
 
-      // Add "Team folders" at the top of the tree list.
       // Only show team folders when browsing the full tree (no rootFolderUID scope)
       const treeWithTeamFolders = rootFolderUID ? flatTree : [...teamFolderTreeItems, ...flatTree];
+      // Add "Team folders" at the top of the tree list.
       return filterExcludedItems(treeWithTeamFolders, excludeUIDs);
     } else {
       flatTree = searchResultsToTreeItems(searchResults?.items || []);

--- a/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
+++ b/public/app/core/components/NestedFolderPicker/NestedFolderPicker.tsx
@@ -240,12 +240,22 @@ export function NestedFolderPicker({
       }
 
       // Add "Team folders" at the top of the tree list.
-      return filterExcludedItems([...teamFolderTreeItems, ...flatTree], excludeUIDs);
+      // Only show team folders when browsing the full tree (no rootFolderUID scope)
+      const treeWithTeamFolders = rootFolderUID ? flatTree : [...teamFolderTreeItems, ...flatTree];
+      return filterExcludedItems(treeWithTeamFolders, excludeUIDs);
     } else {
       flatTree = searchResultsToTreeItems(searchResults?.items || []);
       return filterExcludedItems(flatTree, excludeUIDs);
     }
-  }, [browseFlatTree, excludeUIDs, isBrowsing, searchResults?.items, showRootFolder, teamFolderTreeItems]);
+  }, [
+    browseFlatTree,
+    excludeUIDs,
+    isBrowsing,
+    searchResults?.items,
+    showRootFolder,
+    teamFolderTreeItems,
+    rootFolderUID,
+  ]);
 
   const isItemLoaded = useCallback(
     (itemIndex: number) => {


### PR DESCRIPTION
**What is this feature?**

- Conditionally skip prepending `teamFolderTreeItems` to the folder picker tree when `rootFolderUID` is set.
- Add `rootFolderUID` to the `flatTree` useMemo dependency array.

| Current    | After change - Git Sync | After change - non-git sync|
| -------- | ------- | ------- | 
| <img width="729" height="357" alt="image" src="https://github.com/user-attachments/assets/25c9821a-eb71-437f-acde-e2502b9344d6" />  | <img width="732" height="287" alt="image" src="https://github.com/user-attachments/assets/25ca2b63-3454-4cc3-b695-ae2bd54d81ee" /> | <img width="822" height="629" alt="image" src="https://github.com/user-attachments/assets/eb0c081f-d738-476e-8034-690438eed379" /> |

**Why do we need this feature?**

When the folder picker is scoped to a specific subtree via `rootFolderUID` (e.g., provisioned bulk move), team folders are outside that scope and should not appear. They caused confusion by showing irrelevant folders alongside the repo's own folder tree.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

Fixes N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
