### PR TITLE
unified-storage: add support for leases section in sqlkv

### DIFF
--- a/pkg/storage/unified/resource/kv/sqlkv.go
+++ b/pkg/storage/unified/resource/kv/sqlkv.go
@@ -102,6 +102,8 @@ func (k *SqlKV) getQueryBuilder(section string) (*queryBuilder, error) {
 		tableName = "resource_history"
 	case PendingDeleteSection:
 		tableName = "pending_tenant_deletions"
+	case LeasesSection:
+		tableName = "kv_leases"
 	default:
 		return nil, fmt.Errorf("invalid section: %s", section)
 	}
@@ -380,7 +382,7 @@ func (k *SqlKV) Save(ctx context.Context, section string, key string) (io.WriteC
 	if key == "" {
 		return nil, fmt.Errorf("key is required")
 	}
-	if section != DataSection && section != EventsSection && section != PendingDeleteSection && section != LastImportTimeSection {
+	if section != DataSection && section != EventsSection && section != PendingDeleteSection && section != LastImportTimeSection && section != LeasesSection {
 		return nil, fmt.Errorf("invalid section: %s", section)
 	}
 
@@ -433,9 +435,11 @@ func (w *sqlWriteCloser) Close() error {
 
 	keyPath := getKeyPath(w.section, w.key)
 
-	// do regular kv save: simple key_path + value insert with conflict check.
-	// can only do this on resource_events and pending_tenant_deletions for now, until we drop the columns in resource_history
-	if w.section == EventsSection || w.section == PendingDeleteSection {
+	// Do regular kv save: simple key_path + value insert with conflict check.
+	// Used for sections that map to dedicated key-value tables (resource_events,
+	// pending_tenant_deletions, kv_leases). DataSection still goes through the
+	// resource_history-specific path below until the legacy columns are dropped.
+	if w.section == EventsSection || w.section == PendingDeleteSection || w.section == LeasesSection {
 		query, args := qb.buildUpsertQuery(keyPath, value)
 		_, err := w.kv.conn(w.ctx).ExecContext(w.ctx, query, args...)
 		if err != nil {

--- a/pkg/storage/unified/sql/db/migrations/resource_mig.go
+++ b/pkg/storage/unified/sql/db/migrations/resource_mig.go
@@ -243,6 +243,16 @@ func initResourceTables(mg *migrator.Migrator) string {
 	mg.AddMigration("create table "+pending_tenant_deletions_table.Name, migrator.NewAddTableMigration(pending_tenant_deletions_table))
 	mg.AddMigration("Change key_path collation of pending_tenant_deletions in postgres", migrator.NewRawSQLMigration("").Postgres(`ALTER TABLE pending_tenant_deletions ALTER COLUMN key_path TYPE VARCHAR(2048) COLLATE "C";`))
 
+	kv_leases_table := migrator.Table{
+		Name: "kv_leases",
+		Columns: []*migrator.Column{
+			{Name: "key_path", Type: migrator.DB_NVarchar, Length: 2048, Nullable: false, IsPrimaryKey: true, IsLatin: true},
+			{Name: "value", Type: migrator.DB_MediumText, Nullable: false},
+		},
+	}
+	mg.AddMigration("create table "+kv_leases_table.Name, migrator.NewAddTableMigration(kv_leases_table))
+	mg.AddMigration("Change key_path collation of kv_leases in postgres", migrator.NewRawSQLMigration("").Postgres(`ALTER TABLE kv_leases ALTER COLUMN key_path TYPE VARCHAR(2048) COLLATE "C";`))
+
 	return marker
 }
 

--- a/pkg/storage/unified/testing/lease_test.go
+++ b/pkg/storage/unified/testing/lease_test.go
@@ -32,7 +32,6 @@ func TestIntegrationLeaseBadger(t *testing.T) {
 }
 
 func TestIntegrationLeaseSQLKV(t *testing.T) {
-	t.Skip("not implemented yet")
 	testutil.SkipIntegrationTestInShortMode(t)
 	t.Cleanup(db.CleanupTestDB)
 


### PR DESCRIPTION
Adds support for the leases section in `sqlkv`, allowing the leases package to use it as a KV implementation.

Part of: https://github.com/grafana/hyperion-planning/issues/608.