### PR TITLE
Alerting: Fix provisioned alert rules becoming editable after partial DB failure

### DIFF
--- a/pkg/services/ngalert/provisioning/alert_rules.go
+++ b/pkg/services/ngalert/provisioning/alert_rules.go
@@ -940,8 +940,7 @@ func (service *AlertRuleService) deleteRules(ctx context.Context, user identity.
 	}
 	for _, uid := range uids {
 		if err := service.provenanceStore.DeleteProvenance(ctx, &models.AlertRule{UID: uid}, user.GetOrgID()); err != nil {
-			// We failed to clean up the record, but this doesn't break things. Log it and move on.
-			service.log.Warn("Failed to delete provenance record for rule: %w", err)
+			return err
 		}
 	}
 	return nil

--- a/pkg/services/ngalert/provisioning/alert_rules_test.go
+++ b/pkg/services/ngalert/provisioning/alert_rules_test.go
@@ -1625,6 +1625,23 @@ func TestDeleteAlertRule(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("when DeleteProvenance fails the rule deletion is rolled back", func(t *testing.T) {
+		rule := rules[0]
+		service, _, provenanceStore, ac := initServiceWithData(t)
+
+		ac.CanWriteAllRulesFunc = func(ctx context.Context, user identity.Requester) (bool, error) {
+			return true, nil
+		}
+
+		expectedErr := errors.New("provenance delete failed")
+		provenanceStore.DeleteProvenanceFunc = func(ctx context.Context, o models.Provisionable, org int64) error {
+			return expectedErr
+		}
+
+		err := service.DeleteAlertRule(context.Background(), u, rule.UID, groupProvenance)
+		require.ErrorIs(t, err, expectedErr)
+	})
 }
 
 func TestGetAlertRule(t *testing.T) {

--- a/pkg/services/ngalert/store/provisioning_store.go
+++ b/pkg/services/ngalert/store/provisioning_store.go
@@ -91,7 +91,7 @@ func (st DBstore) SetProvenance(ctx context.Context, o models.Provisionable, org
 	recordType := o.ResourceType()
 	recordKey := o.ResourceID()
 
-	return st.SQLStore.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
+	return st.SQLStore.WithDbSession(ctx, func(sess *db.Session) error {
 		// TODO: Add a unit-of-work pattern, so updating objects + provenance will happen consistently with rollbacks across stores.
 		// TODO: Need to make sure that writing a record where our concurrency key fails will also fail the whole transaction. That way, this gets rolled back too. can't just check that 0 updates happened inmemory. Check with jp. If not possible, we need our own concurrency key.
 		// TODO: Clean up stale provenance records periodically.
@@ -155,7 +155,7 @@ func (st DBstore) setProvenanceWithLocking(sess *db.Session, recordKey, recordTy
 
 // DeleteProvenance deletes the provenance record from the table
 func (st DBstore) DeleteProvenance(ctx context.Context, o models.Provisionable, org int64) error {
-	return st.SQLStore.WithTransactionalDbSession(ctx, func(sess *db.Session) error {
+	return st.SQLStore.WithDbSession(ctx, func(sess *db.Session) error {
 		_, err := sess.Delete(provenanceRecord{
 			RecordKey:  o.ResourceID(),
 			RecordType: o.ResourceType(),


### PR DESCRIPTION
**What is this feature?**
Fixes a bug where `SetProvenance` and `DeleteProvenance` would always open their own
transaction instead of joining the caller's. Also fixes `deleteRules` silently ignoring
errors from `DeleteProvenance`.

**Why do we need this feature?**
Both functions used `WithTransactionalDbSession` which commits independently no matter
what. So even when wrapped in `InTransaction`, provenance writes were not atomic with
the rule writes. On top of that, if `DeleteProvenance` failed, the error was swallowed
with a log.Warn rule gets deleted, provenance record stays forever.

**Who is this feature for?**
Anyone using alerting provisioning via API or file provisioning, especially on HA setups.

**Which issue(s) does this PR fix?**:
Fixes #124006

**Special notes for your reviewer:**
Switched `WithTransactionalDbSession` to `WithDbSession` in both `SetProvenance` and
`DeleteProvenance` so they join whatever transaction is already on the context.
`deleteRules` now returns the error instead of swallowing it.

Reproduced the inconsistent state locally with a SQLite trigger to simulate the failure
rule gone, provenance stuck. Verified clean rollback after the fix. Added a unit test
for the error propagation.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.