### PR TITLE
Loki: Fix missing braces in label_values variable query stream selector

### DIFF
--- a/public/app/plugins/datasource/loki/components/VariableQueryEditor.tsx
+++ b/public/app/plugins/datasource/loki/components/VariableQueryEditor.tsx
@@ -5,7 +5,7 @@ import { type QueryEditorProps, type SelectableValue } from '@grafana/data';
 import { InlineField, InlineFieldRow, Input, Select } from '@grafana/ui';
 
 import { type LokiDatasource } from '../datasource';
-import { migrateVariableQuery } from '../migrations/variableQueryMigrations';
+import { ensureStreamSelectorBraces, migrateVariableQuery } from '../migrations/variableQueryMigrations';
 import { type LokiOptions, type LokiQuery, type LokiVariableQuery, LokiVariableQueryType as QueryType } from '../types';
 
 const variableOptions = [
@@ -68,7 +68,11 @@ export const LokiVariableQueryEditor = ({ onChange, query, datasource, range }: 
 
   const handleBlur = () => {
     if (type !== undefined) {
-      onChange({ type, label, stream, refId: 'LokiVariableQueryEditor-VariableQuery' });
+      const normalizedStream = stream ? ensureStreamSelectorBraces(stream) : stream;
+      if (normalizedStream !== stream) {
+        setStream(normalizedStream);
+      }
+      onChange({ type, label, stream: normalizedStream, refId: 'LokiVariableQueryEditor-VariableQuery' });
     }
   };
 

--- a/public/app/plugins/datasource/loki/datasource.test.ts
+++ b/public/app/plugins/datasource/loki/datasource.test.ts
@@ -707,6 +707,27 @@ describe('LokiDatasource', () => {
       );
       expect(templateSrvStub.replace).toHaveBeenCalledWith('label5', scopedVars, expect.any(Function));
     });
+
+    it('should wrap bare stream selector in braces for label_values', async () => {
+      const { ds } = getTestContext();
+
+      const result = await ds.metricFindQuery({
+        refId: 'test',
+        type: LokiVariableQueryType.LabelValues,
+        stream: 'label1="value1"',
+        label: 'label5',
+      });
+
+      expect(result).toEqual([{ text: 'value5' }]);
+    });
+
+    it('should wrap bare stream selector from legacy label_values string', async () => {
+      const { ds } = getTestContext();
+
+      const result = await ds.metricFindQuery('label_values(label1="value1",label5)');
+
+      expect(result).toEqual([{ text: 'value5' }]);
+    });
   });
 
   describe('modifyQuery', () => {

--- a/public/app/plugins/datasource/loki/datasource.ts
+++ b/public/app/plugins/datasource/loki/datasource.ts
@@ -64,7 +64,11 @@ import { LokiAnnotationsQueryEditor } from './components/AnnotationsQueryEditor'
 import { placeHolderScopedVars } from './components/monaco-query-field/monaco-completion-provider/validation';
 import { LokiQueryType, SupportingQueryType } from './dataquery.gen';
 import { escapeLabelValueInSelector, getLokiLabelTypeFromFrame, isRegexSelector } from './languageUtils';
-import { labelNamesRegex, labelValuesRegex } from './migrations/variableQueryMigrations';
+import {
+  ensureStreamSelectorBraces,
+  labelNamesRegex,
+  labelValuesRegex,
+} from './migrations/variableQueryMigrations';
 import {
   addLabelFormatToQuery,
   addLabelToQuery,
@@ -737,7 +741,7 @@ export class LokiDatasource
     }
 
     const result = await this.languageProvider.fetchLabelValues(query.label, {
-      streamSelector: query.stream,
+      streamSelector: query.stream ? ensureStreamSelectorBraces(query.stream) : query.stream,
       timeRange,
     });
     return result.map((value: string) => ({ text: value }));
@@ -762,7 +766,7 @@ export class LokiDatasource
       return {
         type: LokiVariableQueryType.LabelValues,
         label: labelValues[2],
-        stream: labelValues[1],
+        stream: labelValues[1] ? ensureStreamSelectorBraces(labelValues[1]) : labelValues[1],
         refId,
       };
     }

--- a/public/app/plugins/datasource/loki/migrations/variableQueryMigrations.test.ts
+++ b/public/app/plugins/datasource/loki/migrations/variableQueryMigrations.test.ts
@@ -1,6 +1,40 @@
 import { type LokiVariableQuery, LokiVariableQueryType } from '../types';
 
-import { migrateVariableQuery } from './variableQueryMigrations';
+import { ensureStreamSelectorBraces, migrateVariableQuery } from './variableQueryMigrations';
+
+describe('Loki ensureStreamSelectorBraces()', () => {
+  it('wraps bare selector in braces', () => {
+    expect(ensureStreamSelectorBraces('job="scene-logs"')).toBe('{job="scene-logs"}');
+  });
+
+  it('wraps bare selector with template variable in braces', () => {
+    expect(ensureStreamSelectorBraces('$var')).toBe('{$var}');
+  });
+
+  it('does not double-wrap selector that already has braces', () => {
+    expect(ensureStreamSelectorBraces('{job="scene-logs"}')).toBe('{job="scene-logs"}');
+  });
+
+  it('does not double-wrap selector with template variable that already has braces', () => {
+    expect(ensureStreamSelectorBraces('{$var="bar"}')).toBe('{$var="bar"}');
+  });
+
+  it('returns empty string unchanged', () => {
+    expect(ensureStreamSelectorBraces('')).toBe('');
+  });
+
+  it('returns empty selector unchanged', () => {
+    expect(ensureStreamSelectorBraces('{}')).toBe('{}');
+  });
+
+  it('trims whitespace before checking for braces', () => {
+    expect(ensureStreamSelectorBraces('  {job="foo"}  ')).toBe('{job="foo"}');
+  });
+
+  it('wraps trimmed bare selector with surrounding whitespace', () => {
+    expect(ensureStreamSelectorBraces('  job="foo"  ')).toBe('{job="foo"}');
+  });
+});
 
 describe('Loki migrateVariableQuery()', () => {
   it('does not migrate LokiVariableQuery instances', () => {
@@ -46,25 +80,25 @@ describe('Loki migrateVariableQuery()', () => {
     });
   });
 
-  it('migrates label_values(log stream selector, label) queries', () => {
+  it('migrates label_values(log stream selector, label) queries and wraps bare selector in braces', () => {
     const query = 'label_values(log stream selector, label)';
 
     expect(migrateVariableQuery(query)).toStrictEqual({
       refId: 'LokiVariableQueryEditor-VariableQuery',
       type: LokiVariableQueryType.LabelValues,
       label: 'label',
-      stream: 'log stream selector',
+      stream: '{log stream selector}',
     });
   });
 
-  it('migrates label_values(log stream selector, label) with template variable as stream', () => {
+  it('migrates label_values(log stream selector, label) with template variable as stream and wraps in braces', () => {
     const query = 'label_values($b, label)';
 
     expect(migrateVariableQuery(query)).toStrictEqual({
       refId: 'LokiVariableQueryEditor-VariableQuery',
       type: LokiVariableQueryType.LabelValues,
       label: 'label',
-      stream: '$b',
+      stream: '{$b}',
     });
   });
 
@@ -87,6 +121,17 @@ describe('Loki migrateVariableQuery()', () => {
       type: LokiVariableQueryType.LabelValues,
       label: '$label',
       stream: '{$b="bar"}',
+    });
+  });
+
+  it('migrates label_values with bare stream selector and wraps in braces', () => {
+    const query = 'label_values(job="scene-logs", program_name)';
+
+    expect(migrateVariableQuery(query)).toStrictEqual({
+      refId: 'LokiVariableQueryEditor-VariableQuery',
+      type: LokiVariableQueryType.LabelValues,
+      label: 'program_name',
+      stream: '{job="scene-logs"}',
     });
   });
 });

--- a/public/app/plugins/datasource/loki/migrations/variableQueryMigrations.ts
+++ b/public/app/plugins/datasource/loki/migrations/variableQueryMigrations.ts
@@ -3,6 +3,23 @@ import { type LokiVariableQuery, LokiVariableQueryType } from '../types';
 export const labelNamesRegex = /^label_names\(\)\s*$/;
 export const labelValuesRegex = /^label_values\((?:(.+),\s*)?([a-zA-Z_$][a-zA-Z0-9_]*)\)\s*$/;
 
+/**
+ * Ensures a stream selector string is wrapped in curly braces.
+ * LogQL requires stream selectors to be enclosed in `{...}`, but the
+ * label_values() regex and UI previously allowed bare selectors like
+ * `job="foo"`. This helper normalises such values to `{job="foo"}`.
+ */
+export function ensureStreamSelectorBraces(selector: string): string {
+  const trimmed = selector.trim();
+  if (trimmed === '' || trimmed === '{}') {
+    return trimmed;
+  }
+  if (trimmed.startsWith('{')) {
+    return trimmed;
+  }
+  return `{${trimmed}}`;
+}
+
 export function migrateVariableQuery(rawQuery: string | LokiVariableQuery): LokiVariableQuery {
   // If not string, we assume LokiVariableQuery
   if (typeof rawQuery !== 'string') {
@@ -24,11 +41,13 @@ export function migrateVariableQuery(rawQuery: string | LokiVariableQuery): Loki
 
   const labelValues = rawQuery.match(labelValuesRegex);
   if (labelValues) {
+    const label = labelValues[2] ? labelValues[2] : labelValues[1];
+    const rawStream = labelValues[2] ? labelValues[1] : undefined;
     return {
       ...queryBase,
       type: LokiVariableQueryType.LabelValues,
-      label: labelValues[2] ? labelValues[2] : labelValues[1],
-      stream: labelValues[2] ? labelValues[1] : undefined,
+      label,
+      stream: rawStream ? ensureStreamSelectorBraces(rawStream) : undefined,
     };
   }
 


### PR DESCRIPTION
When a label_values() variable query contains a stream selector without curly braces (e.g. label_values(job="foo", label)), the selector is passed directly to the Loki /label/{name}/values API as the query parameter. Loki's ParseMatchers requires valid LogQL with braces, so the request returns 400 Bad Request.

This fix adds ensureStreamSelectorBraces() which normalises stream selectors to always include curly braces, and applies it at three layers:

1. processMetricFindQuery: defensive brace-wrapping before passing query.stream to fetchLabelValues (runtime fix)
2. migrateVariableQuery: normalise stream selector during migration from legacy string format (saved dashboard fix)
3. parseStringToVariableQuery: normalise stream selector when parsing legacy label_values() strings
4. LokiVariableQueryEditor: normalise stream on blur (UI fix)

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds ensureStreamSelectorBraces() to normalise stream selectors in Loki label_values() variable queries, ensuring they are always wrapped in {...} curly braces before being sent to the Loki API.

**Why do we need this feature?**

When a label_values() variable query contains a stream selector without curly braces (e.g. label_values(job="foo", label)), the selector job="foo" is passed directly to the Loki /label/{name}/values API as the query parameter. Loki's ParseMatchers requires valid LogQL with braces, so the request returns 400 Bad Request and the variable fails to resolve.

This affects:
- Legacy string-format queries stored in dashboards
- The LokiVariableQueryEditor UI which has no brace validation on the stream input
- The labelValuesRegex which captures stream selectors without requiring braces
All other code paths that call fetchLabelValues() (buildSelector, renderLabels, getTagValues, etc.) correctly add braces — only the processMetricFindQuery → parseStringToVariableQuery path was missing this.

**Who is this feature for?**

Grafana users who use Loki as a data source and define template variables with label_values() queries that include a stream selector — particularly those who write selectors without explicit braces or who have legacy dashboards with brace-less selectors saved.

**Special notes for your reviewer:**

- The labelValuesRegex is intentionally kept permissive (not tightened to require braces) to maintain backward compatibility with existing saved queries. Normalisation is handled by ensureStreamSelectorBraces() after extraction.
- The fix is applied at 4 layers (migration, string parsing, runtime, UI) to cover all entry points where a brace-less selector could originate.
- No changes to the regex itself — the normalisation happens post-capture, so existing dashboard JSON with brace-less selectors will be silently fixed on next load.
- ensureStreamSelectorBraces() is idempotent: already-braced selectors pass through unchanged.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
