### PR TITLE
Build: Add zipkin to nightly build bundling

### DIFF
--- a/pkg/build/daggerbuild/arguments/catalog_plugins.go
+++ b/pkg/build/daggerbuild/arguments/catalog_plugins.go
@@ -30,6 +30,7 @@ type CatalogPluginsManifest struct {
 var DefaultCatalogPlugins = []CatalogPluginSpec{
 	{ID: "elasticsearch"},
 	{ID: "zipkin"},
+	// Any plugins added here must also be added to scripts/catalog-plugins-defaults!
 }
 
 var flagBundleCatalogPlugins = &cli.StringSliceFlag{

--- a/scripts/catalog-plugins-defaults
+++ b/scripts/catalog-plugins-defaults
@@ -2,3 +2,4 @@
 # Optional pin: id:version. Keep in sync with DefaultCatalogPlugins in
 # pkg/build/daggerbuild/arguments/catalog_plugins.go.
 elasticsearch
+zipkin


### PR DESCRIPTION
**What is this feature?**

This bundles the [newly-removed](https://github.com/grafana/grafana/pull/124148) zipkin datasource plugin in the official grafana builds. It was added to the dagger build for local release building but not the new make-based build.

This also adds a note in the other bundling list to keep the files in sync.