### PR TITLE
Correlations: Replace createMonitoringLogger calls with getLogger

### DIFF
--- a/packages/grafana-runtime/src/services/logging/loggers.ts
+++ b/packages/grafana-runtime/src/services/logging/loggers.ts
@@ -12,6 +12,7 @@ export const Loggers = {
   'ui-extension-logs': {},
   'features.plugins': {},
   'features.alerting': { context: { module: 'Alerting' } },
+  'features.correlations': {},
 } satisfies Record<string, LoggerDefaults>;
 
 export type LoggerSource = keyof typeof Loggers;

--- a/public/app/features/correlations/useCorrelations.ts
+++ b/public/app/features/correlations/useCorrelations.ts
@@ -2,6 +2,7 @@ import { useAsyncFn } from 'react-use';
 import { lastValueFrom } from 'rxjs';
 
 import { getDataSourceSrv, type FetchResponse, type CorrelationData, type CorrelationsData } from '@grafana/runtime';
+import { getLogger } from '@grafana/runtime/unstable';
 import { useGrafana } from 'app/core/context/GrafanaContext';
 
 import {
@@ -14,7 +15,6 @@ import {
   type UpdateCorrelationParams,
   type UpdateCorrelationResponse,
 } from './types';
-import { correlationsLogger } from './utils';
 
 export interface CorrelationsResponse {
   correlations: Correlation[];
@@ -32,7 +32,7 @@ export const toEnrichedCorrelationData = ({ sourceUID, ...correlation }: Correla
   // This logging is to check if there are any customers who did not migrate existing correlations.
   // See Deprecation Notice in https://github.com/grafana/grafana/pull/72258 for more details
   if (correlation?.orgId === undefined || correlation?.orgId === null || correlation?.orgId === 0) {
-    correlationsLogger.logWarning('Invalid correlation config: Missing org id.');
+    getLogger('features.correlations').logWarning('Invalid correlation config: Missing org id.');
   }
 
   if (
@@ -60,7 +60,7 @@ export const toEnrichedCorrelationData = ({ sourceUID, ...correlation }: Correla
     };
   }
 
-  correlationsLogger.logWarning(`Invalid correlation config: Missing source or target.`, {
+  getLogger('features.correlations').logWarning(`Invalid correlation config: Missing source or target.`, {
     source: JSON.stringify(sourceDatasource),
     target: JSON.stringify(targetDatasource),
   });

--- a/public/app/features/correlations/utils.ts
+++ b/public/app/features/correlations/utils.ts
@@ -6,13 +6,7 @@ import {
   type CorrelationSpec,
 } from '@grafana/api-clients/rtkq/correlations/v0alpha1';
 import { type DataFrame, DataLinkConfigOrigin } from '@grafana/data';
-import {
-  config,
-  type CorrelationData,
-  type CorrelationsData,
-  getBackendSrv,
-  getDataSourceSrv,
-} from '@grafana/runtime';
+import { config, type CorrelationData, type CorrelationsData, getBackendSrv, getDataSourceSrv } from '@grafana/runtime';
 import { type DataQuery, type DataSourceRef } from '@grafana/schema';
 import { MIXED_DATASOURCE_NAME } from 'app/plugins/datasource/mixed/MixedDataSource';
 import { type ExploreItemState } from 'app/types/explore';

--- a/public/app/features/correlations/utils.ts
+++ b/public/app/features/correlations/utils.ts
@@ -10,7 +10,6 @@ import {
   config,
   type CorrelationData,
   type CorrelationsData,
-  createMonitoringLogger,
   getBackendSrv,
   getDataSourceSrv,
 } from '@grafana/runtime';
@@ -202,8 +201,6 @@ export const generateAddSpec = async (data: FormDTO): Promise<CorrelationSpec> =
     },
   };
 };
-
-export const correlationsLogger = createMonitoringLogger('features.correlations');
 
 // legacy just needs uid for lookup, remote storage needs name/group
 export const getCorrelationsFromStorage = async (


### PR DESCRIPTION
**What is this feature?**

Replaces the `createMonitoringLogger` call in `public/app/features/correlations/utils.ts` with `getLogger` from `@grafana/runtime/unstable` and registers the existing `features.correlations` source name in the central `Loggers` registry.

**Why do we need this feature?**

So correlations loggers go through the same registry as the rest of the runtime loggers and we can stop using `createMonitoringLogger` in app code.

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

Related #121639

**Special notes for your reviewer:**

The `features.correlations` source name is kept as-is so the Faro logs don't change. The exported `correlationsLogger` is removed and the single consumer (`useCorrelations.ts`) is updated to call `getLogger('features.correlations')` directly — same pattern used in the plugins migration (#124111).

🤖 Generated with [Claude Code](https://claude.com/claude-code)