### PR TITLE
SA: add action set mapping for service accounts

### DIFF
--- a/pkg/services/authz/rbac/mapper.go
+++ b/pkg/services/authz/rbac/mapper.go
@@ -195,6 +195,29 @@ func newFolderTranslation() translation {
 	return folderTranslation
 }
 
+// newServiceAccountTranslation creates a translation for service accounts and maps actions to action sets.
+// Service accounts only have Edit and Admin permission levels — there is no View level.
+func newServiceAccountTranslation() translation {
+	saTranslation := newResourceTranslation("serviceaccounts", "uid", false, map[string]bool{utils.VerbCreate: true})
+
+	actionSetMapping := make(map[string][]string)
+	for verb, rbacAction := range saTranslation.verbMapping {
+		var actionSets []string
+		if slices.Contains(ossaccesscontrol.ServiceAccountEditActions, rbacAction) {
+			actionSets = append(actionSets, "serviceaccounts:edit")
+			actionSets = append(actionSets, "serviceaccounts:admin")
+		}
+		if slices.Contains(ossaccesscontrol.ServiceAccountAdminActions, rbacAction) &&
+			!slices.Contains(ossaccesscontrol.ServiceAccountEditActions, rbacAction) {
+			actionSets = append(actionSets, "serviceaccounts:admin")
+		}
+		actionSetMapping[verb] = actionSets
+	}
+
+	saTranslation.actionSetMapping = actionSetMapping
+	return saTranslation
+}
+
 func NewMapperRegistry() MapperRegistry {
 	skipScopeOnAllVerbs := map[string]bool{
 		utils.VerbCreate:           true,
@@ -265,7 +288,7 @@ func NewMapperRegistry() MapperRegistry {
 				folderSupport:   false,
 				skipScopeOnVerb: map[string]bool{utils.VerbCreate: true},
 			},
-			"serviceaccounts": newResourceTranslation("serviceaccounts", "uid", false, map[string]bool{utils.VerbCreate: true}),
+			"serviceaccounts": newServiceAccountTranslation(),
 			// Teams is a special case. We translate user permissions from id to uid based.
 			"teams": newResourceTranslation("teams", "uid", false, map[string]bool{utils.VerbCreate: true}),
 			"globalroles": translation{

--- a/pkg/services/authz/rbac/mapper.go
+++ b/pkg/services/authz/rbac/mapper.go
@@ -202,13 +202,15 @@ func newServiceAccountTranslation() translation {
 
 	actionSetMapping := make(map[string][]string)
 	for verb, rbacAction := range saTranslation.verbMapping {
-		var actionSets []string
-		if slices.Contains(ossaccesscontrol.ServiceAccountEditActions, rbacAction) {
+		var (
+			actionSets    []string
+			containsEdit  = slices.Contains(ossaccesscontrol.ServiceAccountEditActions, rbacAction)
+			containsAdmin = slices.Contains(ossaccesscontrol.ServiceAccountAdminActions, rbacAction)
+		)
+		if containsEdit {
 			actionSets = append(actionSets, "serviceaccounts:edit")
 			actionSets = append(actionSets, "serviceaccounts:admin")
-		}
-		if slices.Contains(ossaccesscontrol.ServiceAccountAdminActions, rbacAction) &&
-			!slices.Contains(ossaccesscontrol.ServiceAccountEditActions, rbacAction) {
+		} else if containsAdmin {
 			actionSets = append(actionSets, "serviceaccounts:admin")
 		}
 		actionSetMapping[verb] = actionSets

--- a/pkg/services/authz/rbac/mapper_test.go
+++ b/pkg/services/authz/rbac/mapper_test.go
@@ -186,6 +186,41 @@ func TestMapperRegistry_SubresourceLookup(t *testing.T) {
 	})
 }
 
+// TestMapper_ServiceAccountTranslation_ActionSets verifies that service account verbs map to the
+// correct action sets. There is no View level — Edit verbs map to both edit+admin, and admin-only
+// verbs (delete, permissions) map to admin only.
+func TestMapper_ServiceAccountTranslation_ActionSets(t *testing.T) {
+	reg := NewMapperRegistry()
+	mapping, ok := reg.Get("iam.grafana.app", "serviceaccounts", "")
+	require.True(t, ok)
+
+	editAndAdmin := []string{"serviceaccounts:edit", "serviceaccounts:admin"}
+	adminOnly := []string{"serviceaccounts:admin"}
+	empty := []string(nil)
+
+	tests := []struct {
+		verb     string
+		expected []string
+	}{
+		{utils.VerbGet, editAndAdmin},
+		{utils.VerbList, editAndAdmin},
+		{utils.VerbWatch, editAndAdmin},
+		{utils.VerbUpdate, editAndAdmin},
+		{utils.VerbPatch, editAndAdmin},
+		{utils.VerbDelete, adminOnly},
+		{utils.VerbDeleteCollection, adminOnly},
+		{utils.VerbGetPermissions, adminOnly},
+		{utils.VerbSetPermissions, adminOnly},
+		{utils.VerbCreate, empty},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.verb, func(t *testing.T) {
+			assert.Equal(t, tt.expected, mapping.ActionSets(tt.verb))
+		})
+	}
+}
+
 // TestMapper_AnnotationSubresource_ActionSets verifies that managed roles (dashboards:view etc.)
 // flow through to annotation verbs via the subresource action set mapping.
 func TestMapper_AnnotationSubresource_ActionSets(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

Adds `newServiceAccountTranslation()` to the AuthZ RBAC mapper so the AuthZ service can expand verbs into service account action sets during permission checks.

**Why do we need this feature?**

The `serviceaccounts` entry in `NewMapperRegistry` used a bare `newResourceTranslation` with no `actionSetMapping`. This meant the AuthZ service had no way to expand verbs like `get` or `delete` into the corresponding action sets (`serviceaccounts:edit`, `serviceaccounts:admin`) when evaluating permissions — a prerequisite for the SA ResourcePermission K8s API redirect.

Service accounts only have Edit and Admin levels (no View): edit-level actions (`read`, `write`) map to both `serviceaccounts:edit` and `serviceaccounts:admin`; admin-only actions (`delete`, `permissions:read/write`) map to `serviceaccounts:admin` only.

**Who is this feature for?**

Internal — part of the SA ResourcePermission K8s API support epic (grafana/identity-access-team#2001).

**Which issue(s) does this PR fix?**:

Relates to https://github.com/grafana/identity-access-team/issues/2001

**Special notes for your reviewer:**

- Follows the exact same pattern as `newDashboardTranslation` and `newFolderTranslation`
- No behaviour change for any existing resource type
- Covered by `TestMapper_ServiceAccountTranslation_ActionSets` in `mapper_test.go`

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.