### PR TITLE
docs(plugins): document mixed property in plugin.schema.json

### DIFF
--- a/docs/sources/developers/plugins/plugin.schema.json
+++ b/docs/sources/developers/plugins/plugin.schema.json
@@ -332,6 +332,10 @@
       "type": "boolean",
       "description": "For data source plugins, if the plugin supports metric queries. Used to enable the plugin in the panel editor."
     },
+    "mixed": {
+      "type": "boolean",
+      "description": "[internal only] For data source plugins, marks the plugin as a 'mixed' data source — one whose queries each carry their own `datasource` reference and are delegated to other data sources. When `true`, Grafana preserves the per-query `datasource` field instead of overwriting it with the plugin's own ref. Used by the built-in `-- Mixed --` data source. Setting this on a regular data source plugin will break query routing."
+    },
     "multiValueFilterOperators": {
       "type": "boolean",
       "description": "For data source plugins, if the plugin supports multi value operators in filters."


### PR DESCRIPTION
## Summary

- Adds the `mixed` property to `docs/sources/developers/plugins/plugin.schema.json`, which was previously undocumented despite being a real, supported field on the plugin definition (`pkg/plugins/plugins.go:122`).
- Marks it as `[internal only]` (matching the style used for `builtIn`) and explains the actual effect: when `true`, Grafana preserves each query's `datasource` reference instead of rewriting it to the plugin's own ref. This is what enables the built-in `-- Mixed --` data source to delegate to multiple underlying data sources.
- Calls out that setting this on a regular data source plugin will break query routing — a footgun worth surfacing in the schema since plugin authors have asked about it.

## Context

The flag is read in two places that matter for plugin authors:
- `public/app/features/query/state/updateQueries.ts:72` — overwrites per-query `datasource` ref unless `meta.mixed` is true.
- `@grafana/scenes` `SceneQueryRunner` — same behavior on the scenes path.

There's no plugin-loading validation tied to this field, so the schema entry is purely descriptive.

## Test plan

- [ ] JSON validates (`python3 -m json.tool` passes locally).
- [ ] Reviewer to confirm the `[internal only]` framing is the right signal — alternative is to drop the prefix if we want to leave the door open for third-party Mixed-style plugins.