### PR TITLE
SA: enforce kind and verb restrictions in admission validation

### DIFF
--- a/pkg/registry/apis/iam/resourcepermission/validate.go
+++ b/pkg/registry/apis/iam/resourcepermission/validate.go
@@ -36,13 +36,22 @@ func ValidateCreateAndUpdateInput(ctx context.Context, v0ResourcePerm *v0alpha1.
 	}
 
 	// Check that the group/resource is registered and enabled
-	if !mappers.IsEnabled(schema.GroupResource{Group: grn.Group, Resource: grn.Resource}) {
+	groupResource := schema.GroupResource{Group: grn.Group, Resource: grn.Resource}
+	if !mappers.IsEnabled(groupResource) {
 		return apierrors.NewBadRequest(fmt.Sprintf("unknown or disabled group/resource %s/%s", grn.Group, grn.Resource))
 	}
 
-	// Check for duplicate entities (same kind and name should appear only once)
+	mapper, _ := mappers.Get(groupResource)
+
+	// Check for duplicate entities and validate kind/verb per permission
 	seen := make(map[string]bool)
 	for _, perm := range v0ResourcePerm.Spec.Permissions {
+		if !mapper.AllowsKind(perm.Kind) {
+			return apierrors.NewBadRequest(fmt.Sprintf("assignment kind %q is not allowed for resource %q: %s", perm.Kind, grn.Resource, errInvalidSpec))
+		}
+		if _, err := mapper.ActionSet(perm.Verb); err != nil {
+			return apierrors.NewBadRequest(fmt.Sprintf("verb %q is not valid for resource %q: %s", perm.Verb, grn.Resource, errInvalidSpec))
+		}
 		key := fmt.Sprintf("%s:%s", perm.Kind, perm.Name)
 		if seen[key] {
 			return apierrors.NewBadRequest(fmt.Sprintf("duplicate entity found: kind=%s, name=%s (each entity can only appear once per resource): %s", perm.Kind, perm.Name, errInvalidSpec))

--- a/pkg/registry/apis/iam/resourcepermission/validate.go
+++ b/pkg/registry/apis/iam/resourcepermission/validate.go
@@ -41,7 +41,10 @@ func ValidateCreateAndUpdateInput(ctx context.Context, v0ResourcePerm *v0alpha1.
 		return apierrors.NewBadRequest(fmt.Sprintf("unknown or disabled group/resource %s/%s", grn.Group, grn.Resource))
 	}
 
-	mapper, _ := mappers.Get(groupResource)
+	mapper, ok := mappers.Get(groupResource)
+	if !ok {
+		return apierrors.NewBadRequest(fmt.Sprintf("mapper not found for group/resource %s/%s", grn.Group, grn.Resource))
+	}
 
 	// Check for duplicate entities and validate kind/verb per permission
 	seen := make(map[string]bool)

--- a/pkg/registry/apis/iam/resourcepermission/validate_test.go
+++ b/pkg/registry/apis/iam/resourcepermission/validate_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	iamv0alpha1 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 )
@@ -187,6 +188,123 @@ func TestValidateOnCreate(t *testing.T) {
 				assert.NoError(t, err)
 			} else {
 				assert.ErrorAs(t, test.want, &err)
+			}
+		})
+	}
+}
+
+func TestValidateOnCreate_KindAndVerbRestrictions(t *testing.T) {
+	mappers := NewMappersRegistry()
+	mappers.RegisterMapper(
+		schema.GroupResource{Group: "iam.grafana.app", Resource: "serviceaccounts"},
+		NewMapperWithAttribute("serviceaccounts", []string{"Edit", "Admin"}, ScopeAttributeID,
+			[]iamv0alpha1.ResourcePermissionSpecPermissionKind{
+				iamv0alpha1.ResourcePermissionSpecPermissionKindUser,
+				iamv0alpha1.ResourcePermissionSpecPermissionKindServiceAccount,
+				iamv0alpha1.ResourcePermissionSpecPermissionKindTeam,
+			}),
+		nil,
+	)
+
+	tests := []struct {
+		name    string
+		obj     *iamv0alpha1.ResourcePermission
+		wantErr bool
+	}{
+		{
+			name: "serviceaccount with BasicRole kind - should fail",
+			obj: &iamv0alpha1.ResourcePermission{
+				ObjectMeta: v1.ObjectMeta{Name: "iam.grafana.app-serviceaccounts-sa-abc123"},
+				Spec: iamv0alpha1.ResourcePermissionSpec{
+					Resource: iamv0alpha1.ResourcePermissionspecResource{
+						ApiGroup: "iam.grafana.app",
+						Resource: "serviceaccounts",
+						Name:     "sa-abc123",
+					},
+					Permissions: []iamv0alpha1.ResourcePermissionspecPermission{
+						{Kind: iamv0alpha1.ResourcePermissionSpecPermissionKindBasicRole, Name: "Editor", Verb: "edit"},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "serviceaccount with view verb - should fail",
+			obj: &iamv0alpha1.ResourcePermission{
+				ObjectMeta: v1.ObjectMeta{Name: "iam.grafana.app-serviceaccounts-sa-abc123"},
+				Spec: iamv0alpha1.ResourcePermissionSpec{
+					Resource: iamv0alpha1.ResourcePermissionspecResource{
+						ApiGroup: "iam.grafana.app",
+						Resource: "serviceaccounts",
+						Name:     "sa-abc123",
+					},
+					Permissions: []iamv0alpha1.ResourcePermissionspecPermission{
+						{Kind: iamv0alpha1.ResourcePermissionSpecPermissionKindUser, Name: "user-uid-xyz", Verb: "view"},
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "serviceaccount with User kind and edit verb - should pass",
+			obj: &iamv0alpha1.ResourcePermission{
+				ObjectMeta: v1.ObjectMeta{Name: "iam.grafana.app-serviceaccounts-sa-abc123"},
+				Spec: iamv0alpha1.ResourcePermissionSpec{
+					Resource: iamv0alpha1.ResourcePermissionspecResource{
+						ApiGroup: "iam.grafana.app",
+						Resource: "serviceaccounts",
+						Name:     "sa-abc123",
+					},
+					Permissions: []iamv0alpha1.ResourcePermissionspecPermission{
+						{Kind: iamv0alpha1.ResourcePermissionSpecPermissionKindUser, Name: "user-uid-xyz", Verb: "edit"},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "serviceaccount with Team kind and admin verb - should pass",
+			obj: &iamv0alpha1.ResourcePermission{
+				ObjectMeta: v1.ObjectMeta{Name: "iam.grafana.app-serviceaccounts-sa-abc123"},
+				Spec: iamv0alpha1.ResourcePermissionSpec{
+					Resource: iamv0alpha1.ResourcePermissionspecResource{
+						ApiGroup: "iam.grafana.app",
+						Resource: "serviceaccounts",
+						Name:     "sa-abc123",
+					},
+					Permissions: []iamv0alpha1.ResourcePermissionspecPermission{
+						{Kind: iamv0alpha1.ResourcePermissionSpecPermissionKindTeam, Name: "team-uid-abc", Verb: "admin"},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "folder with BasicRole kind - should still pass (no kind restriction)",
+			obj: &iamv0alpha1.ResourcePermission{
+				ObjectMeta: v1.ObjectMeta{Name: "folder.grafana.app-folders-test_folder"},
+				Spec: iamv0alpha1.ResourcePermissionSpec{
+					Resource: iamv0alpha1.ResourcePermissionspecResource{
+						ApiGroup: "folder.grafana.app",
+						Resource: "folders",
+						Name:     "test_folder",
+					},
+					Permissions: []iamv0alpha1.ResourcePermissionspecPermission{
+						{Kind: iamv0alpha1.ResourcePermissionSpecPermissionKindBasicRole, Name: "Editor", Verb: "edit"},
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := ValidateCreateAndUpdateInput(context.Background(), test.obj, mappers)
+			if test.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
 			}
 		})
 	}


### PR DESCRIPTION
**What is this feature?**

Adds kind and verb validation to the `ResourcePermission` admission hook so that resource-specific restrictions are enforced before any backend is reached.

**Why do we need this feature?**

Two business rules were enforced only in the SQL storage backend (`buildRbacAssignments`) but not at admission time. The SQL backend is transitional and will be replaced by unified storage, so all business rule validation must run in the admission hook regardless of backend. Concretely for service accounts: `BasicRole` assignments are not permitted, and only `edit`/`admin` verbs are valid (no `view`).

**Who is this feature for?**

Internal — part of the SA ResourcePermission K8s API support epic (grafana/identity-access-team#2004).

**Which issue(s) does this PR fix?**:

Relates to https://github.com/grafana/identity-access-team/issues/2004

**Special notes for your reviewer:**

- No behaviour change for folders or dashboards — `NewMapper` passes `nil` for `allowedKinds` (all kinds allowed) and registers `view/edit/admin` as levels
- The `MappersRegistry.Get` call is safe after `IsEnabled` — both use the same lookup and `IsEnabled` already confirmed the entry exists
- Covered by `TestValidateOnCreate_KindAndVerbRestrictions` in `validate_test.go`

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.