### PR TITLE
IAM: Implement UserK8sService.Delete method

### DIFF
--- a/pkg/services/user/userimpl/user.go
+++ b/pkg/services/user/userimpl/user.go
@@ -75,6 +75,14 @@ func (s *Service) CreateServiceAccount(ctx context.Context, cmd *user.CreateUser
 }
 
 func (s *Service) Delete(ctx context.Context, cmd *user.DeleteUserCommand) error {
+	if s.isKubernetesUserServiceEnabled(ctx) {
+		k8sCtx := ctx
+		if !hasOrgID(ctx) {
+			k8sCtx = identity.WithOrgID(ctx, s.cfg.DefaultOrgID())
+		}
+		return s.k8sService.Delete(k8sCtx, cmd)
+	}
+
 	return s.legacyService.Delete(ctx, cmd)
 }
 

--- a/pkg/services/user/userk8s/user.go
+++ b/pkg/services/user/userk8s/user.go
@@ -132,7 +132,51 @@ func (s *UserK8sService) CreateServiceAccount(ctx context.Context, cmd *user.Cre
 }
 
 func (s *UserK8sService) Delete(ctx context.Context, cmd *user.DeleteUserCommand) error {
-	return errors.New("not implemented")
+	ctx, span := s.tracer.Start(ctx, "user.delete", trace.WithAttributes(
+		attribute.Int64("userID", cmd.UserID),
+	))
+	defer span.End()
+
+	ctxLogger := s.logger.FromContext(ctx)
+
+	orgID, err := s.getOrgID(ctx, ctxLogger)
+	if err != nil {
+		ctxLogger.Error("failed to get orgID from context in Delete", "err", err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+
+	namespace := s.namespaceMapper(orgID)
+	span.SetAttributes(attribute.Int64("orgID", orgID))
+
+	client, err := s.getUserClient()
+	if err != nil {
+		ctxLogger.Error("failed to get k8s client", "namespace", namespace, "err", err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+
+	existing, err := s.getByInternalID(ctx, ctxLogger, client, cmd.UserID, namespace)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+
+	err = client.Delete(ctx, resource.Identifier{
+		Namespace: namespace,
+		Name:      existing.Name,
+	}, resource.DeleteOptions{})
+	if err != nil {
+		ctxLogger.Error("k8s user delete failed", "namespace", namespace, "orgID", orgID, "userID", cmd.UserID, "err", err)
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+
+	return nil
 }
 
 func (s *UserK8sService) GetByID(ctx context.Context, cmd *user.GetUserByIDQuery) (*user.User, error) {

--- a/pkg/services/user/userk8s/user_test.go
+++ b/pkg/services/user/userk8s/user_test.go
@@ -1139,6 +1139,154 @@ func TestUserK8sService_Update(t *testing.T) {
 	}
 }
 
+func TestUserK8sService_Delete(t *testing.T) {
+	tests := []struct {
+		name           string
+		cmd            *user.DeleteUserCommand
+		requesterOrgID int64
+		serverResponse func(w http.ResponseWriter, r *http.Request)
+		nilProvider    bool
+		noReqContext   bool
+		noRequester    bool
+		expectErr      bool
+	}{
+		{
+			name:           "successfully deletes a user",
+			requesterOrgID: 1,
+			cmd:            &user.DeleteUserCommand{UserID: 42},
+			serverResponse: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if r.Method == http.MethodGet {
+					resp := map[string]any{
+						"apiVersion": "v1",
+						"kind":       "List",
+						"items":      []any{newTestK8sUser("some-uid", "org-1", "jdoe", "jdoe@example.com")},
+					}
+					_ = json.NewEncoder(w).Encode(resp)
+					return
+				}
+				assert.Equal(t, http.MethodDelete, r.Method)
+				assert.Contains(t, r.URL.Path, "some-uid")
+				w.WriteHeader(http.StatusOK)
+				_ = json.NewEncoder(w).Encode(metav1.Status{
+					TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Status"},
+					Status:   metav1.StatusSuccess,
+					Code:     http.StatusOK,
+				})
+			},
+		},
+		{
+			name:           "returns ErrUserNotFound when no user matches",
+			requesterOrgID: 1,
+			cmd:            &user.DeleteUserCommand{UserID: 99},
+			serverResponse: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"apiVersion": "v1",
+					"kind":       "List",
+					"items":      []any{},
+				})
+			},
+			expectErr: true,
+		},
+		{
+			name:           "returns error when multiple users found with same internal ID",
+			requesterOrgID: 1,
+			cmd:            &user.DeleteUserCommand{UserID: 5},
+			serverResponse: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(map[string]any{
+					"apiVersion": "v1",
+					"kind":       "List",
+					"items": []any{
+						newTestK8sUser("uid-1", "org-1", "user-a", "a@example.com"),
+						newTestK8sUser("uid-2", "org-1", "user-b", "b@example.com"),
+					},
+				})
+			},
+			expectErr: true,
+		},
+		{
+			name:           "returns error when list call fails",
+			requesterOrgID: 1,
+			cmd:            &user.DeleteUserCommand{UserID: 42},
+			serverResponse: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(http.StatusInternalServerError)
+				_ = json.NewEncoder(w).Encode(metav1.Status{
+					TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Status"},
+					Status:   metav1.StatusFailure,
+					Message:  "internal server error",
+					Code:     http.StatusInternalServerError,
+				})
+			},
+			expectErr: true,
+		},
+		{
+			name:           "propagates error from client.Delete",
+			requesterOrgID: 1,
+			cmd:            &user.DeleteUserCommand{UserID: 42},
+			serverResponse: func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				if r.Method == http.MethodGet {
+					_ = json.NewEncoder(w).Encode(map[string]any{
+						"apiVersion": "v1",
+						"kind":       "List",
+						"items":      []any{newTestK8sUser("some-uid", "org-1", "jdoe", "jdoe@example.com")},
+					})
+					return
+				}
+				w.WriteHeader(http.StatusConflict)
+				_ = json.NewEncoder(w).Encode(metav1.Status{
+					TypeMeta: metav1.TypeMeta{APIVersion: "v1", Kind: "Status"},
+					Status:   metav1.StatusFailure,
+					Message:  "conflict",
+					Code:     http.StatusConflict,
+				})
+			},
+			expectErr: true,
+		},
+		{
+			name:        "returns error when config provider not initialized",
+			cmd:         &user.DeleteUserCommand{UserID: 42},
+			nilProvider: true,
+			expectErr:   true,
+		},
+		{
+			name:         "returns error when no request context",
+			cmd:          &user.DeleteUserCommand{UserID: 42},
+			noReqContext: true,
+			expectErr:    true,
+		},
+		{
+			name:        "returns error when no requester in context",
+			cmd:         &user.DeleteUserCommand{UserID: 42},
+			noRequester: true,
+			expectErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			svc, ctx := setupServiceAndCtx(t, svcTestSetup{
+				nilProvider:    tt.nilProvider,
+				noReqContext:   tt.noReqContext,
+				noRequester:    tt.noRequester,
+				requesterOrgID: tt.requesterOrgID,
+				serverResponse: tt.serverResponse,
+			})
+
+			err := svc.Delete(ctx, tt.cmd)
+
+			if tt.expectErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
 func TestUserK8sService_UpdateLastSeenAt(t *testing.T) {
 	makeListResponse := func(userID int64, lastSeenAtSec int64) func(http.ResponseWriter, *http.Request) {
 		return func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/tests/apis/iam/user/user_service_integration_test.go
+++ b/pkg/tests/apis/iam/user/user_service_integration_test.go
@@ -1,13 +1,11 @@
 package user
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -75,27 +73,16 @@ func TestIntegrationUserServiceGet(t *testing.T) {
 			require.NotEmpty(t, secondUser.Result.UID)
 
 			t.Cleanup(func() {
-				if mode < rest.Mode4 {
-					apis.DoRequest(helper, apis.RequestParams{
-						User:   helper.Org1.Admin,
-						Method: "DELETE",
-						Path:   fmt.Sprintf("/api/admin/users/%d", firstUser.Result.ID),
-					}, &struct{}{})
-					apis.DoRequest(helper, apis.RequestParams{
-						User:   helper.Org1.Admin,
-						Method: "DELETE",
-						Path:   fmt.Sprintf("/api/admin/users/%d", secondUser.Result.ID),
-					}, &struct{}{})
-				} else {
-					ctx := context.Background()
-					userClient := helper.GetResourceClient(apis.ResourceClientArgs{
-						User:      helper.Org1.Admin,
-						Namespace: helper.Namespacer(helper.Org1.Admin.Identity.GetOrgID()),
-						GVR:       gvrUsers,
-					})
-					_ = userClient.Resource.Delete(ctx, firstUser.Result.UID, metav1.DeleteOptions{})
-					_ = userClient.Resource.Delete(ctx, secondUser.Result.UID, metav1.DeleteOptions{})
-				}
+				apis.DoRequest(helper, apis.RequestParams{
+					User:   helper.Org1.Admin,
+					Method: "DELETE",
+					Path:   fmt.Sprintf("/api/admin/users/%d", firstUser.Result.ID),
+				}, &struct{}{})
+				apis.DoRequest(helper, apis.RequestParams{
+					User:   helper.Org1.Admin,
+					Method: "DELETE",
+					Path:   fmt.Sprintf("/api/admin/users/%d", secondUser.Result.ID),
+				}, &struct{}{})
 			})
 
 			// /api/users/lookup routes through UserK8sService.GetByLogin
@@ -184,21 +171,11 @@ func TestIntegrationUserServiceUpdate(t *testing.T) {
 				require.NotZero(t, createRsp.Result.ID)
 
 				t.Cleanup(func() {
-					if mode < rest.Mode4 {
-						apis.DoRequest(helper, apis.RequestParams{
-							User:   helper.Org1.Admin,
-							Method: "DELETE",
-							Path:   fmt.Sprintf("/api/admin/users/%d", createRsp.Result.ID),
-						}, &struct{}{})
-					} else {
-						ctx := context.Background()
-						userClient := helper.GetResourceClient(apis.ResourceClientArgs{
-							User:      helper.Org1.Admin,
-							Namespace: helper.Namespacer(helper.Org1.Admin.Identity.GetOrgID()),
-							GVR:       gvrUsers,
-						})
-						_ = userClient.Resource.Delete(ctx, createRsp.Result.UID, metav1.DeleteOptions{})
-					}
+					apis.DoRequest(helper, apis.RequestParams{
+						User:   helper.Org1.Admin,
+						Method: "DELETE",
+						Path:   fmt.Sprintf("/api/admin/users/%d", createRsp.Result.ID),
+					}, &struct{}{})
 				})
 
 				updateRsp := apis.DoRequest(helper, apis.RequestParams{
@@ -294,23 +271,90 @@ func TestIntegrationUserService(t *testing.T) {
 				require.Equal(t, "k8s-service-user@example.com", getRsp.Result.Email)
 				require.Equal(t, "k8s-service-user", getRsp.Result.Login)
 
-				if mode <= rest.Mode3 {
-					deleteRsp := apis.DoRequest(helper, apis.RequestParams{
-						User:   helper.Org1.Admin,
-						Method: "DELETE",
-						Path:   fmt.Sprintf("/api/admin/users/%d", createRsp.Result.ID),
-					}, &struct{}{})
-					require.Equal(t, 200, deleteRsp.Response.StatusCode)
-				} else {
-					ctx := context.Background()
-					userClient := helper.GetResourceClient(apis.ResourceClientArgs{
-						User:      helper.Org1.Admin,
-						Namespace: helper.Namespacer(helper.Org1.Admin.Identity.GetOrgID()),
-						GVR:       gvrUsers,
-					})
-					err := userClient.Resource.Delete(ctx, createRsp.Result.UID, metav1.DeleteOptions{})
-					require.NoError(t, err)
-				}
+				deleteRsp := apis.DoRequest(helper, apis.RequestParams{
+					User:   helper.Org1.Admin,
+					Method: "DELETE",
+					Path:   fmt.Sprintf("/api/admin/users/%d", createRsp.Result.ID),
+				}, &struct{}{})
+				require.Equal(t, 200, deleteRsp.Response.StatusCode)
+			})
+		})
+	}
+}
+
+// go test --tags "pro" -timeout 120s -run ^TestIntegrationUserServiceDelete$ github.com/grafana/grafana/pkg/tests/apis/iam -count=1
+func TestIntegrationUserServiceDelete(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	type createUserResponse struct {
+		ID  int64  `json:"id"`
+		UID string `json:"uid"`
+	}
+
+	type getUserResponse struct {
+		ID    int64  `json:"id"`
+		UID   string `json:"uid"`
+		Name  string `json:"name"`
+		Email string `json:"email"`
+		Login string `json:"login"`
+	}
+
+	for _, mode := range []rest.DualWriterMode{rest.Mode0, rest.Mode1, rest.Mode2, rest.Mode3, rest.Mode4, rest.Mode5} {
+		t.Run(fmt.Sprintf("dual writer mode %d", mode), func(t *testing.T) {
+			helper := apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
+				AppModeProduction:      false,
+				DisableAnonymous:       true,
+				APIServerStorageType:   "unified",
+				RBACSingleOrganization: true,
+				UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
+					"users.iam.grafana.app": {
+						DualWriterMode: mode,
+					},
+				},
+				EnableFeatureToggles: []string{
+					featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs,
+					featuremgmt.FlagKubernetesUsersApi,
+					featuremgmt.FlagKubernetesUsersRedirect,
+				},
+			})
+
+			createRsp := apis.DoRequest(helper, apis.RequestParams{
+				User:   helper.Org1.Admin,
+				Method: "POST",
+				Path:   "/api/admin/users",
+				Body:   []byte(`{"name": "Delete Test User", "email": "delete-test@example.com", "login": "delete-test-user", "password": "password123"}`),
+			}, &createUserResponse{})
+			require.Equal(t, 200, createRsp.Response.StatusCode, "body: %s", string(createRsp.Body))
+			require.NotZero(t, createRsp.Result.ID)
+			require.NotEmpty(t, createRsp.Result.UID)
+
+			t.Run("user exists after creation", func(t *testing.T) {
+				getRsp := apis.DoRequest(helper, apis.RequestParams{
+					User:   helper.Org1.Admin,
+					Method: "GET",
+					Path:   fmt.Sprintf("/api/users/%d", createRsp.Result.ID),
+				}, &getUserResponse{})
+				require.Equal(t, 200, getRsp.Response.StatusCode, "body: %s", string(getRsp.Body))
+				require.Equal(t, createRsp.Result.ID, getRsp.Result.ID)
+				require.Equal(t, createRsp.Result.UID, getRsp.Result.UID)
+			})
+
+			t.Run("delete succeeds", func(t *testing.T) {
+				deleteRsp := apis.DoRequest(helper, apis.RequestParams{
+					User:   helper.Org1.Admin,
+					Method: "DELETE",
+					Path:   fmt.Sprintf("/api/admin/users/%d", createRsp.Result.ID),
+				}, &struct{}{})
+				require.Equal(t, 200, deleteRsp.Response.StatusCode, "body: %s", string(deleteRsp.Body))
+			})
+
+			t.Run("user is gone after deletion", func(t *testing.T) {
+				getRsp := apis.DoRequest(helper, apis.RequestParams{
+					User:   helper.Org1.Admin,
+					Method: "GET",
+					Path:   fmt.Sprintf("/api/users/%d", createRsp.Result.ID),
+				}, &getUserResponse{})
+				require.Equal(t, 404, getRsp.Response.StatusCode, "body: %s", string(getRsp.Body))
 			})
 		})
 	}
@@ -382,14 +426,16 @@ func TestIntegrationUserServiceSearch(t *testing.T) {
 			time.Sleep(2 * time.Second)
 
 			t.Cleanup(func() {
-				ctx := context.Background()
-				userClient := helper.GetResourceClient(apis.ResourceClientArgs{
-					User:      helper.Org1.Admin,
-					Namespace: helper.Namespacer(helper.Org1.Admin.Identity.GetOrgID()),
-					GVR:       gvrUsers,
-				})
-				_ = userClient.Resource.Delete(ctx, alphaUser.Result.UID, metav1.DeleteOptions{})
-				_ = userClient.Resource.Delete(ctx, betaUser.Result.UID, metav1.DeleteOptions{})
+				apis.DoRequest(helper, apis.RequestParams{
+					User:   helper.Org1.Admin,
+					Method: "DELETE",
+					Path:   fmt.Sprintf("/api/admin/users/%d", alphaUser.Result.ID),
+				}, &struct{}{})
+				apis.DoRequest(helper, apis.RequestParams{
+					User:   helper.Org1.Admin,
+					Method: "DELETE",
+					Path:   fmt.Sprintf("/api/admin/users/%d", betaUser.Result.ID),
+				}, &struct{}{})
 			})
 
 			t.Run("should return users with correct fields", func(t *testing.T) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR adds the Implementation of `UserK8sService.Delete`. It looks up the user by internal ID label selector, then deletes the k8s resource by name/namespace identifier. It also wires the method into the service wrapper so calls are routed to the k8s implementation when the flag `kubernetesUsersRedirect` is on, consistent with how other methods are dispatched.

The user integration test cleanups are simplified. Previously the cleanup was splitting by dual-writer mode: `DELETE /api/admin/users/:id` for modes 0–3, k8s client delete for modes 4–5. Since the HTTP endpoint now works for all modes, the mode split is removed and all cleanups use `DELETE /api/admin/users/:id` uniformly.

**Why do we need this feature?**

This is part of the ongoing migration to store users in Kubernetes.

**Who is this feature for?**

all users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
