### PR TITLE
Annotations: Add `kubernetesAnnotationsClient` feature flag

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -227,7 +227,7 @@ export interface FeatureToggles {
   * Routes manual annotation create/update/delete and tag autocomplete from /api/annotations to the /apis/annotation.grafana.app endpoint
   * @default false
   */
-  kubernetesAnnotations?: boolean;
+  kubernetesAnnotationsClient?: boolean;
   /**
   * Enables k8s short url api and uses it under the hood when handling legacy /api
   * @default false

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -224,6 +224,11 @@ export interface FeatureToggles {
   */
   kubernetesLibraryPanels?: boolean;
   /**
+  * Routes manual annotation create/update/delete and tag autocomplete from /api/annotations to the /apis/annotation.grafana.app endpoint
+  * @default false
+  */
+  kubernetesAnnotations?: boolean;
+  /**
   * Enables k8s short url api and uses it under the hood when handling legacy /api
   * @default false
   */

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -224,7 +224,7 @@ export interface FeatureToggles {
   */
   kubernetesLibraryPanels?: boolean;
   /**
-  * Routes manual annotation create/update/delete and tag autocomplete from /api/annotations to the /apis/annotation.grafana.app endpoint
+  * Enables usage of the new annotations API client
   * @default false
   */
   kubernetesAnnotationsClient?: boolean;

--- a/pkg/registry/apps/apps.go
+++ b/pkg/registry/apps/apps.go
@@ -102,8 +102,8 @@ func ProvideAppInstallers(
 	//
 	// Developers are encouraged to explore the built-in functionality of the App Platform
 	// to control the app registration (see `docs/apps/example/README.md`).
-	//nolint:staticcheck // kubernetesAnnotations FF must also enable the app so routes exist when frontend routes to the new API
-	if cfg.AnnotationAppPlatform.Enabled || features.IsEnabledGlobally(featuremgmt.FlagKubernetesAnnotations) {
+	//nolint:staticcheck // kubernetesAnnotationsClient FF must also enable the app so routes exist when frontend routes to the new API
+	if cfg.AnnotationAppPlatform.Enabled || features.IsEnabledGlobally(featuremgmt.FlagKubernetesAnnotationsClient) {
 		installers = append(installers, annotationAppInstaller)
 	}
 	return installers

--- a/pkg/registry/apps/apps.go
+++ b/pkg/registry/apps/apps.go
@@ -102,7 +102,8 @@ func ProvideAppInstallers(
 	//
 	// Developers are encouraged to explore the built-in functionality of the App Platform
 	// to control the app registration (see `docs/apps/example/README.md`).
-	if cfg.AnnotationAppPlatform.Enabled {
+	//nolint:staticcheck // kubernetesAnnotations FF must also enable the app so routes exist when frontend routes to the new API
+	if cfg.AnnotationAppPlatform.Enabled || features.IsEnabledGlobally(featuremgmt.FlagKubernetesAnnotations) {
 		installers = append(installers, annotationAppInstaller)
 	}
 	return installers

--- a/pkg/registry/apps/apps.go
+++ b/pkg/registry/apps/apps.go
@@ -102,8 +102,7 @@ func ProvideAppInstallers(
 	//
 	// Developers are encouraged to explore the built-in functionality of the App Platform
 	// to control the app registration (see `docs/apps/example/README.md`).
-	//nolint:staticcheck // kubernetesAnnotationsClient FF must also enable the app so routes exist when frontend routes to the new API
-	if cfg.AnnotationAppPlatform.Enabled || features.IsEnabledGlobally(featuremgmt.FlagKubernetesAnnotationsClient) {
+	if cfg.AnnotationAppPlatform.Enabled {
 		installers = append(installers, annotationAppInstaller)
 	}
 	return installers

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -371,6 +371,15 @@ var (
 			Generate:        Generate{LegacyGo: true, LegacyFrontend: true},
 		},
 		{
+			Name:            "kubernetesAnnotations",
+			Description:     "Routes manual annotation create/update/delete and tag autocomplete from /api/annotations to the /apis/annotation.grafana.app endpoint",
+			Stage:           FeatureStageExperimental,
+			Owner:           grafanaAppPlatformSquad,
+			RequiresRestart: true, // changes the API routing
+			Expression:      "false",
+			Generate:        Generate{LegacyGo: true, LegacyFrontend: true},
+		},
+		{
 			Name:            "kubernetesShortURLs",
 			Description:     "Enables k8s short url api and uses it under the hood when handling legacy /api",
 			Stage:           FeatureStageExperimental,

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -372,10 +372,10 @@ var (
 		},
 		{
 			Name:            "kubernetesAnnotationsClient",
-			Description:     "Routes manual annotation create/update/delete and tag autocomplete from /api/annotations to the /apis/annotation.grafana.app endpoint",
+			Description:     "Enables usage of the new annotations API client",
 			Stage:           FeatureStageExperimental,
 			Owner:           grafanaDashboardsSquad,
-			RequiresRestart: true, // changes the API routing
+			RequiresRestart: false,
 			Expression:      "false",
 			Generate:        Generate{LegacyGo: true, LegacyFrontend: true},
 		},

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -371,7 +371,7 @@ var (
 			Generate:        Generate{LegacyGo: true, LegacyFrontend: true},
 		},
 		{
-			Name:            "kubernetesAnnotations",
+			Name:            "kubernetesAnnotationsClient",
 			Description:     "Routes manual annotation create/update/delete and tag autocomplete from /api/annotations to the /apis/annotation.grafana.app endpoint",
 			Stage:           FeatureStageExperimental,
 			Owner:           grafanaAppPlatformSquad,

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -374,7 +374,7 @@ var (
 			Name:            "kubernetesAnnotationsClient",
 			Description:     "Routes manual annotation create/update/delete and tag autocomplete from /api/annotations to the /apis/annotation.grafana.app endpoint",
 			Stage:           FeatureStageExperimental,
-			Owner:           grafanaAppPlatformSquad,
+			Owner:           grafanaDashboardsSquad,
 			RequiresRestart: true, // changes the API routing
 			Expression:      "false",
 			Generate:        Generate{LegacyGo: true, LegacyFrontend: true},

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -41,7 +41,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2023-09-28,externalServiceAccounts,preview,@grafana/identity-access-team,false,false,false
 2023-12-05,kubernetesSnapshots,experimental,@grafana/grafana-app-platform-squad,false,true,false
 2025-06-25,kubernetesLibraryPanels,experimental,@grafana/grafana-app-platform-squad,false,true,false
-2025-11-06,kubernetesAnnotationsClient,experimental,@grafana/grafana-app-platform-squad,false,true,false
+2026-05-07,kubernetesAnnotationsClient,experimental,@grafana/dashboards-squad,false,true,false
 2025-07-31,kubernetesShortURLs,experimental,@grafana/grafana-app-platform-squad,false,true,false
 2025-08-29,useKubernetesShortURLsAPI,experimental,@grafana/sharing-squad,false,false,true
 2025-08-29,kubernetesCorrelations,experimental,@grafana/datapro,false,true,false

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -41,7 +41,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2023-09-28,externalServiceAccounts,preview,@grafana/identity-access-team,false,false,false
 2023-12-05,kubernetesSnapshots,experimental,@grafana/grafana-app-platform-squad,false,true,false
 2025-06-25,kubernetesLibraryPanels,experimental,@grafana/grafana-app-platform-squad,false,true,false
-2025-11-06,kubernetesAnnotations,experimental,@grafana/grafana-app-platform-squad,false,true,false
+2025-11-06,kubernetesAnnotationsClient,experimental,@grafana/grafana-app-platform-squad,false,true,false
 2025-07-31,kubernetesShortURLs,experimental,@grafana/grafana-app-platform-squad,false,true,false
 2025-08-29,useKubernetesShortURLsAPI,experimental,@grafana/sharing-squad,false,false,true
 2025-08-29,kubernetesCorrelations,experimental,@grafana/datapro,false,true,false

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -41,7 +41,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2023-09-28,externalServiceAccounts,preview,@grafana/identity-access-team,false,false,false
 2023-12-05,kubernetesSnapshots,experimental,@grafana/grafana-app-platform-squad,false,true,false
 2025-06-25,kubernetesLibraryPanels,experimental,@grafana/grafana-app-platform-squad,false,true,false
-2026-05-07,kubernetesAnnotationsClient,experimental,@grafana/dashboards-squad,false,true,false
+2026-05-07,kubernetesAnnotationsClient,experimental,@grafana/dashboards-squad,false,false,false
 2025-07-31,kubernetesShortURLs,experimental,@grafana/grafana-app-platform-squad,false,true,false
 2025-08-29,useKubernetesShortURLsAPI,experimental,@grafana/sharing-squad,false,false,true
 2025-08-29,kubernetesCorrelations,experimental,@grafana/datapro,false,true,false

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -41,6 +41,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2023-09-28,externalServiceAccounts,preview,@grafana/identity-access-team,false,false,false
 2023-12-05,kubernetesSnapshots,experimental,@grafana/grafana-app-platform-squad,false,true,false
 2025-06-25,kubernetesLibraryPanels,experimental,@grafana/grafana-app-platform-squad,false,true,false
+2025-11-06,kubernetesAnnotations,experimental,@grafana/grafana-app-platform-squad,false,true,false
 2025-07-31,kubernetesShortURLs,experimental,@grafana/grafana-app-platform-squad,false,true,false
 2025-08-29,useKubernetesShortURLsAPI,experimental,@grafana/sharing-squad,false,false,true
 2025-08-29,kubernetesCorrelations,experimental,@grafana/datapro,false,true,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -131,9 +131,9 @@ const (
 	// Routes library panel requests from /api to the /apis endpoint
 	FlagKubernetesLibraryPanels = "kubernetesLibraryPanels"
 
-	// FlagKubernetesAnnotations
+	// FlagKubernetesAnnotationsClient
 	// Routes manual annotation create/update/delete and tag autocomplete from /api/annotations to the /apis/annotation.grafana.app endpoint
-	FlagKubernetesAnnotations = "kubernetesAnnotations"
+	FlagKubernetesAnnotationsClient = "kubernetesAnnotationsClient"
 
 	// FlagKubernetesShortURLs
 	// Enables k8s short url api and uses it under the hood when handling legacy /api

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -132,7 +132,7 @@ const (
 	FlagKubernetesLibraryPanels = "kubernetesLibraryPanels"
 
 	// FlagKubernetesAnnotationsClient
-	// Routes manual annotation create/update/delete and tag autocomplete from /api/annotations to the /apis/annotation.grafana.app endpoint
+	// Enables usage of the new annotations API client
 	FlagKubernetesAnnotationsClient = "kubernetesAnnotationsClient"
 
 	// FlagKubernetesShortURLs

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -131,6 +131,10 @@ const (
 	// Routes library panel requests from /api to the /apis endpoint
 	FlagKubernetesLibraryPanels = "kubernetesLibraryPanels"
 
+	// FlagKubernetesAnnotations
+	// Routes manual annotation create/update/delete and tag autocomplete from /api/annotations to the /apis/annotation.grafana.app endpoint
+	FlagKubernetesAnnotations = "kubernetesAnnotations"
+
 	// FlagKubernetesShortURLs
 	// Enables k8s short url api and uses it under the hood when handling legacy /api
 	FlagKubernetesShortURLs = "kubernetesShortURLs"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2939,12 +2939,16 @@
     {
       "metadata": {
         "name": "kubernetesAnnotationsClient",
-        "creationTimestamp": "2026-05-07T00:00:00Z"
+        "resourceVersion": "1778146254687",
+        "creationTimestamp": "2026-05-07T00:00:00Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-05-07 09:30:54.687995422 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Routes manual annotation create/update/delete and tag autocomplete from /api/annotations to the /apis/annotation.grafana.app endpoint",
         "stage": "experimental",
-        "codeowner": "@grafana/grafana-app-platform-squad",
+        "codeowner": "@grafana/dashboards-squad",
         "requiresRestart": true,
         "expression": "false"
       }

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2939,17 +2939,16 @@
     {
       "metadata": {
         "name": "kubernetesAnnotationsClient",
-        "resourceVersion": "1778146254687",
+        "resourceVersion": "1778163715528",
         "creationTimestamp": "2026-05-07T00:00:00Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2026-05-07 09:30:54.687995422 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2026-05-07 14:21:55.528883 +0000 UTC"
         }
       },
       "spec": {
-        "description": "Routes manual annotation create/update/delete and tag autocomplete from /api/annotations to the /apis/annotation.grafana.app endpoint",
+        "description": "Enables usage of the new annotations API client",
         "stage": "experimental",
         "codeowner": "@grafana/dashboards-squad",
-        "requiresRestart": true,
         "expression": "false"
       }
     },

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2924,7 +2924,7 @@
     },
     {
       "metadata": {
-        "name": "kubernetesAnnotations",
+        "name": "kubernetesAnnotationsClient",
         "resourceVersion": "1777284736317",
         "creationTimestamp": "2025-11-06T18:22:20Z",
         "deletionTimestamp": "2026-02-19T21:17:23Z",

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2925,14 +2925,18 @@
     {
       "metadata": {
         "name": "kubernetesAnnotations",
-        "resourceVersion": "1771434338561",
+        "resourceVersion": "1777284736317",
         "creationTimestamp": "2025-11-06T18:22:20Z",
-        "deletionTimestamp": "2026-02-19T21:17:23Z"
+        "deletionTimestamp": "2026-02-19T21:17:23Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-04-27 10:12:16.317328 +0000 UTC"
+        }
       },
       "spec": {
-        "description": "Enables app platform API for annotations",
+        "description": "Routes manual annotation create/update/delete and tag autocomplete from /api/annotations to the /apis/annotation.grafana.app endpoint",
         "stage": "experimental",
-        "codeowner": "@grafana/grafana-backend-services-squad",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresRestart": true,
         "expression": "false"
       }
     },

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2924,13 +2924,22 @@
     },
     {
       "metadata": {
-        "name": "kubernetesAnnotationsClient",
-        "resourceVersion": "1777284736317",
+        "name": "kubernetesAnnotations",
+        "resourceVersion": "1771434338561",
         "creationTimestamp": "2025-11-06T18:22:20Z",
-        "deletionTimestamp": "2026-02-19T21:17:23Z",
-        "annotations": {
-          "grafana.app/updatedTimestamp": "2026-04-27 10:12:16.317328 +0000 UTC"
-        }
+        "deletionTimestamp": "2026-02-19T21:17:23Z"
+      },
+      "spec": {
+        "description": "Enables app platform API for annotations",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-backend-services-squad",
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
+        "name": "kubernetesAnnotationsClient",
+        "creationTimestamp": "2026-05-07T00:00:00Z"
       },
       "spec": {
         "description": "Routes manual annotation create/update/delete and tag autocomplete from /api/annotations to the /apis/annotation.grafana.app endpoint",


### PR DESCRIPTION
**What is this feature?**

Adds a new feature flag to support the new annotations API client migration 