### PR TITLE
Search snapshots: MaxIndexAge=0 means "no age limit"

### DIFF
--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -104,7 +104,10 @@ type SnapshotOptions struct {
 	MinDocCount int64
 
 	// MaxIndexAge is the maximum age of a remote snapshot that can be downloaded.
-	// Older snapshots are skipped (hard filter).
+	// Older snapshots are skipped (hard filter). Zero means "no age limit":
+	// snapshots are accepted regardless of age, and cleanup does not delete
+	// snapshots based on age (cleanup's per-version-group eviction of
+	// superseded snapshots still applies; see selectSnapshotsToDelete).
 	MaxIndexAge time.Duration
 
 	// MinBuildVersion, if non-nil, is the preferred lower bound on the Grafana
@@ -878,12 +881,6 @@ func (b *bleveBackend) prepareUncachedFileIndex(
 			indexStorage:  indexStorageFile,
 			source:        buildIndexSourceDownloadedSnapshot,
 		}, nil
-	}
-
-	// With MaxIndexAge=0 the cold-start probe cannot find a reusable snapshot,
-	// so coordination would only serialize replicas rebuilding from scratch.
-	if b.opts.Snapshot.MaxIndexAge <= 0 {
-		return b.createEmptyFileIndex(resourceDir, mapper, selectableFields, logger)
 	}
 
 	idx, name, rv, lock, err := b.coordinateColdStartBuild(ctx, key, resourceDir, lastImportTime, logger)

--- a/pkg/storage/unified/search/bleve_snapshot.go
+++ b/pkg/storage/unified/search/bleve_snapshot.go
@@ -97,6 +97,9 @@ func (b *bleveBackend) tryDownloadRemoteSnapshot(
 // lastImportTime), and downloads it. Shared between the rebuild path and
 // cold-start coordination; callers pass their own maxAge and policy /
 // span labels. Returns (nil, "", 0, nil) when no candidate matches.
+//
+// maxAge <= 0 means "no age limit": the only freshness floor is
+// lastImportTime (which itself may be zero, meaning no floor at all).
 func (b *bleveBackend) tryDownloadFreshSameVersionSnapshot(
 	ctx context.Context,
 	key resource.NamespacedResource,
@@ -108,7 +111,10 @@ func (b *bleveBackend) tryDownloadFreshSameVersionSnapshot(
 ) (bleve.Index, string, int64, error) {
 	logger.Info("Fresh same-version index snapshot download started", "policy", policy, "max_age", maxAge, "last_import_time", lastImportTime)
 
-	notOlderThan := time.Now().Add(-maxAge)
+	var notOlderThan time.Time
+	if maxAge > 0 {
+		notOlderThan = time.Now().Add(-maxAge)
+	}
 	if lastImportTime.After(notOlderThan) {
 		notOlderThan = lastImportTime
 	}
@@ -551,8 +557,8 @@ func (b *bleveBackend) coordinateColdStartBuild(
 	// filter the tiered selection applies. We don't reuse the rebuild
 	// path's tighter maxFreshSnapshotAge — on a cold start any
 	// same-version snapshot beats rebuilding, so we want the loosest
-	// threshold. Zero means "skip the probe"; the lock + wait loop still
-	// coordinates.
+	// threshold. Zero means "no age limit": the probe still runs and
+	// accepts any same-version snapshot.
 	probeMaxAge := b.opts.Snapshot.MaxIndexAge
 	logger.Info("Cold-start coordination started", "probe_max_age", probeMaxAge, "last_import_time", lastImportTime)
 
@@ -607,13 +613,14 @@ func (b *bleveBackend) coordinateColdStartBuild(
 // snapshot already exists in the remote index store, and downloads it if
 // so. Called once per iteration of coordinateColdStartBuild's loop.
 //
-//   - probeMaxAge <= 0: don't contact the store; coordination falls back
-//     to the lock + wait loop alone.
 //   - idx != nil: snapshot downloaded and returned.
 //   - idx == nil, err == nil: no usable snapshot right now.
 //   - err != nil: only ctx.Err() is propagated. List/get/download failures
 //     are logged and treated as "no hit" — this lookup is an optimisation,
 //     not a correctness check.
+//
+// probeMaxAge <= 0 means "no age limit" — the probe walks the namespace
+// and accepts any same-version snapshot.
 func (b *bleveBackend) tryDownloadColdStartSnapshot(
 	ctx context.Context,
 	key resource.NamespacedResource,
@@ -622,9 +629,6 @@ func (b *bleveBackend) tryDownloadColdStartSnapshot(
 	probeMaxAge time.Duration,
 	logger log.Logger,
 ) (bleve.Index, string, int64, error) {
-	if probeMaxAge <= 0 {
-		return nil, "", 0, nil
-	}
 	idx, name, rv, err := b.tryDownloadFreshSameVersionSnapshot(
 		ctx, key, resourceDir, lastImportTime, probeMaxAge,
 		snapshotPolicyColdStart, "search.remote_index_snapshot.download_cold_start",

--- a/pkg/storage/unified/search/bleve_snapshot_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_test.go
@@ -254,6 +254,18 @@ func TestPickBestSnapshot(t *testing.T) {
 		assert.False(t, ok)
 	})
 
+	// Pins the "MaxIndexAge=0 means no age limit" semantic for the tiered
+	// selection path: tryDownloadRemoteSnapshot leaves notOlderThan as the
+	// zero time when MaxIndexAge is zero, and pickBestSnapshot must skip
+	// the age filter rather than rejecting everything.
+	t.Run("zero cutoff is no age limit", func(t *testing.T) {
+		old := makeULID(t, now.Add(-30*24*time.Hour))
+		all := map[ulid.ULID]*IndexMeta{old: snap("11.5.0", 100, 30*24*time.Hour)}
+		c, ok := newBackend(minV).pickBestSnapshot(all, time.Time{}, log.New("bleve-snapshot-test"))
+		require.True(t, ok)
+		assert.Equal(t, old, c.key)
+	})
+
 	t.Run("dropped for unparseable version", func(t *testing.T) {
 		all := map[ulid.ULID]*IndexMeta{makeULID(t, now): snap("not-a-version", 100, time.Minute)}
 		_, ok := newBackend(minV).pickBestSnapshot(all, cutoff(24*time.Hour), log.New("bleve-snapshot-test"))
@@ -450,6 +462,26 @@ func TestTryDownloadRemoteSnapshot_AllFilteredOut(t *testing.T) {
 	assert.Zero(t, dt.store.downloadCalls.Load(), "DownloadIndex should not be called when all candidates are filtered out")
 }
 
+// TestTryDownloadRemoteSnapshot_NoAgeLimitWhenZero pins the
+// "MaxIndexAge=0 means no age limit" semantic for the tiered selection
+// path: an arbitrarily old same-version snapshot is still downloaded.
+func TestTryDownloadRemoteSnapshot_NoAgeLimitWhenZero(t *testing.T) {
+	store := &fakeRemoteIndexStore{}
+	store.put(makeULID(t, time.Now().Add(-30*24*time.Hour)), &IndexMeta{
+		BuildVersion:          "11.5.0",
+		LatestResourceVersion: 42,
+		UploadTimestamp:       time.Now().Add(-30 * 24 * time.Hour),
+	})
+	dt := newDownloadTest(t, store)
+	dt.be.opts.Snapshot.MaxIndexAge = 0
+
+	idx, rv, err := dt.run(t)
+	require.NoError(t, err)
+	require.NotNil(t, idx)
+	assert.Equal(t, int64(42), rv)
+	assert.Equal(t, 1.0, dt.counter(snapshotStatusSuccess))
+}
+
 // freshDownloadTest bundles the shared setup used by
 // tryDownloadFreshSameVersionSnapshot tests on the rebuild policy.
 type freshDownloadTest struct {
@@ -517,16 +549,19 @@ func TestTryDownloadFreshSnapshot_Hit(t *testing.T) {
 	assert.Equal(t, 1.0, dt.counter(snapshotStatusSuccess))
 }
 
-func TestTryDownloadFreshSnapshot_DisabledByZeroMaxAge(t *testing.T) {
+// TestTryDownloadFreshSnapshot_NoAgeLimitWhenZero verifies that maxAge=0
+// means "no age limit": an arbitrarily old same-version snapshot is
+// accepted as long as it is newer than lastImportTime.
+func TestTryDownloadFreshSnapshot_NoAgeLimitWhenZero(t *testing.T) {
 	store := &fakeRemoteIndexStore{}
-	store.put(makeULID(t, time.Now()), freshSnapshot(time.Minute))
+	store.put(makeULID(t, time.Now()), freshSnapshot(30*24*time.Hour))
 	dt := newFreshDownloadTest(t, store)
 
-	idx, _, err := dt.run(t, time.Time{}, 0)
+	idx, rv, err := dt.run(t, time.Time{}, 0)
 	require.NoError(t, err)
-	assert.Nil(t, idx)
-	assert.Equal(t, 1.0, dt.counter(snapshotStatusEmpty))
-	assert.Zero(t, dt.store.downloadCalls.Load())
+	require.NotNil(t, idx)
+	assert.Equal(t, int64(42), rv)
+	assert.Equal(t, 1.0, dt.counter(snapshotStatusSuccess))
 }
 
 func TestTryDownloadFreshSnapshot_VersionMismatchSkipped(t *testing.T) {
@@ -1580,19 +1615,16 @@ func TestBuildIndex_ColdStartTimeoutBuildsAlone(t *testing.T) {
 	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotColdStarts.WithLabelValues(coldStartOutcomeWaitTimedOut)))
 }
 
-// TestBuildIndex_ColdStartSkippedWhenMaxIndexAgeZero verifies that
-// BuildIndex skips cold-start coordination entirely when MaxIndexAge=0:
-// the probe would be a no-op (all freshness filters reject) so the
-// lock+wait would only serialise duplicate from-scratch builds without
-// any snapshot-reuse upside. With the gate, the builder runs in parallel
-// across replicas (today's behaviour without this PR's coordination).
-func TestBuildIndex_ColdStartSkippedWhenMaxIndexAgeZero(t *testing.T) {
+// TestBuildIndex_ColdStartRunsWhenMaxIndexAgeZero verifies that
+// MaxIndexAge=0 means "no age limit" rather than "reject everything":
+// cold-start coordination still runs, the leader path is taken, and the
+// freshly-built snapshot is uploaded immediately under the held lock.
+func TestBuildIndex_ColdStartRunsWhenMaxIndexAgeZero(t *testing.T) {
 	store := newColdStartFakeStore()
-	store.setLockHeld(true) // would force the wait loop if cold-start ran
 	be, metrics := newTestBleveBackend(t, SnapshotOptions{
 		Store:       store,
 		MinDocCount: 1,
-		// MaxIndexAge intentionally zero.
+		// MaxIndexAge intentionally zero — "no age limit".
 	})
 
 	builderCalled := atomic.Int32{}
@@ -1605,10 +1637,12 @@ func TestBuildIndex_ColdStartSkippedWhenMaxIndexAgeZero(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, idx)
 
-	assert.Equal(t, int32(1), builderCalled.Load(), "builder must run (cold-start coordination is skipped)")
-	assert.Zero(t, store.lockAcquireCalls.Load(), "cold-start must not attempt the lock when MaxIndexAge=0")
-	assert.Zero(t, testutil.ToFloat64(metrics.IndexSnapshotColdStarts.WithLabelValues(coldStartOutcomeAcquiredLock)))
-	assert.Zero(t, testutil.ToFloat64(metrics.IndexSnapshotColdStarts.WithLabelValues(coldStartOutcomeWaitTimedOut)))
+	assert.Equal(t, int32(1), builderCalled.Load(), "builder must run on the leader path")
+	assert.Equal(t, int32(1), store.lockAcquireCalls.Load(), "cold-start must attempt the lock even when MaxIndexAge=0")
+	assert.Equal(t, int32(1), store.uploadCalls.Load(), "leader must upload immediately")
+	assert.Equal(t, int32(1), store.lockReleasedCalls.Load(), "leader must release the build lock")
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotColdStarts.WithLabelValues(coldStartOutcomeAcquiredLock)))
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotUploads.WithLabelValues(snapshotUploadStatusSuccess)))
 }
 
 // TestBuildIndex_ColdStartContextCancelPropagates verifies that a context

--- a/pkg/storage/unified/search/remote_index_cleanup.go
+++ b/pkg/storage/unified/search/remote_index_cleanup.go
@@ -328,10 +328,11 @@ func (b *bleveBackend) runResourceCleanup(ctx context.Context, res resource.Name
 // that should be deleted. Two independent rules; a snapshot is deletable if
 // either fires:
 //
-//	A. Age cutoff: anything older than maxAge, regardless of group/successor.
-//	B. Superseded with stable replacement: within a Grafana-version group, all
-//	   snapshots except the newest are deletable once the newest has lived
-//	   beyond gracePeriod.
+//	rule A — age cutoff: anything older than maxAge, regardless of group/successor.
+//	rule B — within a Grafana-version group, an older snapshot is deleted
+//	         once a newer same-version snapshot has existed for longer than
+//	         gracePeriod (the grace period gives in-flight downloaders that
+//	         picked the older snapshot time to finish before it goes away).
 //
 // Snapshots with an unparseable BuildVersion are excluded from any
 // version group; rule A still applies, but otherwise they are left untouched.

--- a/pkg/storage/unified/search/remote_index_cleanup_test.go
+++ b/pkg/storage/unified/search/remote_index_cleanup_test.go
@@ -135,6 +135,23 @@ func TestSelectSnapshotsToDelete_RuleAWinsOnLoneOldSnapshot(t *testing.T) {
 	assert.Equal(t, []ulid.ULID{only}, got)
 }
 
+// TestSelectSnapshotsToDelete_ZeroMaxAgeKeepsLoneOldSnapshot pins the
+// "MaxIndexAge=0 means no age limit" semantic for cleanup rule A: an
+// arbitrarily old lone snapshot is not eligible for age-based deletion.
+// Rule B (per-version-group eviction) still applies in the multi-snapshot
+// case — covered by TestSelectSnapshotsToDelete_PerVersionIsolation.
+func TestSelectSnapshotsToDelete_ZeroMaxAgeKeepsLoneOldSnapshot(t *testing.T) {
+	now := time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC)
+
+	only := makeULID(t, now.Add(-30*24*time.Hour))
+	metas := map[ulid.ULID]*IndexMeta{
+		only: mkMeta("11.5.0", 100, now.Add(-30*24*time.Hour)),
+	}
+
+	got := selectSnapshotsToDelete(metas, now, 0, testCleanupGrace)
+	assert.Empty(t, got, "maxAge=0 must disable age-based deletion (rule A)")
+}
+
 func TestSelectSnapshotsToDelete_PerVersionIsolation(t *testing.T) {
 	now := time.Date(2026, 4, 22, 12, 0, 0, 0, time.UTC)
 


### PR DESCRIPTION
Make `Snapshot.MaxIndexAge=0` mean "no age limit" everywhere it's checked, matching the idiomatic Go reading of a zero-valued duration. Today the tiered-selection and cleanup paths already do this; the rebuild / cold-start freshness check treats 0 as "reject everything", and cold-start coordination has a workaround that skips the lock entirely when `MaxIndexAge=0`. This PR changes the freshness check to accept any same-version snapshot when `MaxIndexAge=0`, and removes the now-unnecessary cold-start workaround.

The default `index_snapshot_max_age` is 7 days, so this only affects operators who explicitly set it to 0.

Tests: flipped two tests that pinned the old "reject all" behaviour, and added regression tests for the paths that already had the right semantic but weren't covered.

Closes grafana/search-and-storage-team#773.
