### PR TITLE
GrafanaUI: Ensure RadioButtons always have valid ID

### DIFF
--- a/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButton.tsx
+++ b/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButton.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { forwardRef, type HTMLProps } from 'react';
+import { forwardRef, useId, type HTMLProps } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { type StringSelector, selectors } from '@grafana/e2e-selectors';
@@ -18,7 +18,6 @@ export interface RadioButtonProps extends Omit<HTMLProps<HTMLInputElement>, 'siz
   name?: string;
   description?: string;
   active: boolean;
-  id: string;
   onChange: () => void;
   onClick: () => void;
   fullWidth?: boolean;
@@ -35,7 +34,6 @@ export const RadioButton = forwardRef<HTMLInputElement, RadioButtonProps>(
       size = 'md',
       onChange,
       onClick,
-      id,
       name = undefined,
       description,
       fullWidth,
@@ -45,6 +43,7 @@ export const RadioButton = forwardRef<HTMLInputElement, RadioButtonProps>(
     ref
   ) => {
     const styles = useStyles2(getRadioButtonStyles, size, fullWidth);
+    const id = useId();
 
     const inputRadioButton = (
       <input

--- a/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButtonGroup.tsx
+++ b/packages/grafana-ui/src/components/Forms/RadioButtonGroup/RadioButtonGroup.tsx
@@ -110,7 +110,6 @@ export function RadioButtonGroup<T>({
             aria-describedby={ariaDescribedBy}
             onChange={handleOnChange(opt)}
             onClick={handleOnClick(opt)}
-            id={`option-${opt.value}-${internalId}`}
             name={groupName.current}
             description={opt.description}
             fullWidth={fullWidth}


### PR DESCRIPTION
Fixes an issue with RadioButtonGroup, spotted in dynamic dashboards where the ID can be invalid, and not unique, due to trying to use the option value in it.


<img width="643" height="120" alt="Screenshot 2026-05-07 at 11 09 10 am" src="https://github.com/user-attachments/assets/d955bfb1-2db9-4012-a194-0d3a347fddc3" />


There's no need for that, instead RadioButton can just generate its own ID.