### PR TITLE
Analytics Framework: Update documentation after moving it to `unstable`

### DIFF
--- a/scripts/cli/analytics/README.md
+++ b/scripts/cli/analytics/README.md
@@ -2,11 +2,11 @@
 
 ## What is the analytics framework?
 
-The analytics framework is a typed, self-documenting system for defining and tracking product analytics events in Grafana. It is built around `defineFeatureEvents`, a factory exported from `@grafana/runtime/internal`, which produces strongly-typed event reporters. Events defined with this factory are automatically discoverable by the report script in this folder.
+The analytics framework is a typed, self-documenting system for defining and tracking product analytics events in Grafana. It is built around `defineFeatureEvents`, a factory exported from `@grafana/runtime/unstable`, which produces strongly-typed event reporters. Events defined with this factory are automatically discoverable by the report script in this folder.
 
 The framework is split into two parts with distinct responsibilities:
 
-- **Framework library** (`packages/grafana-runtime/src/internal/analyticsFramework/`): production code that ships with Grafana. It exports the `defineFeatureEvents` factory and the `EventProperty` base type.
+- **Framework library** (`packages/grafana-runtime/src/analyticsFramework/`): production code that ships with Grafana. It exports the `defineFeatureEvents` factory and the `EventProperty` base type.
 - **Report generator** (`scripts/cli/analytics/`): a developer tool that runs offline and is never bundled with the application. It reads the TypeScript AST to find every event declared with the factory and writes a human-readable catalogue.
 
 The framework ensures that:
@@ -25,10 +25,10 @@ Create a `events.ts` file next to your feature. Ownership of events is resolved 
 
 ### 1. Define the property interfaces
 
-Each interface must extend `EventProperty` from `@grafana/runtime/internal`, and every property must have a JSDoc comment:
+Each interface must extend `EventProperty` from `@grafana/runtime/unstable`, and every property must have a JSDoc comment:
 
 ```ts
-import { type EventProperty } from '@grafana/runtime/internal';
+import { type EventProperty } from '@grafana/runtime/unstable';
 
 export interface ThemeChanged extends EventProperty {
   /** Whether the preference being changed belongs to an org, team, or individual user. */
@@ -64,7 +64,7 @@ Events can be declared in two ways. Both are fully supported by the report scrip
 Each event is exported as its own `const`. This works well for small, cohesive sets of events. The JSDoc comment above each export becomes its description in the report.
 
 ```ts
-import { defineFeatureEvents } from '@grafana/runtime/internal';
+import { defineFeatureEvents } from '@grafana/runtime/unstable';
 import { type ThemeChanged, type LanguageChanged } from './types';
 
 const createSharedPreferencesEvents = defineFeatureEvents('grafana', 'preferences');
@@ -81,7 +81,7 @@ export const languageChanged = createSharedPreferencesEvents<LanguageChanged>('l
 All events are collected into a single exported `const` object. This is useful for larger feature areas where events are used together. Each property of the object must have a JSDoc comment. The object can also spread another events object to inherit and override entries:
 
 ```ts
-import { defineFeatureEvents } from '@grafana/runtime/internal';
+import { defineFeatureEvents } from '@grafana/runtime/unstable';
 import { type LoadedProperties, type ItemClickedProperties } from './types';
 
 const newDashboardLibraryInteraction = defineFeatureEvents('grafana', 'dashboard_library', {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Updates the Analytics Framework documentation.

**Why do we need this feature?**
To have an updated guide.

**Who is this feature for?**
Everybody using Analytics Framework

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
