### PR TITLE
CI: Only cancel in-progress swagger gen in PRs

### DIFF
--- a/.github/workflows/swagger-gen.yml
+++ b/.github/workflows/swagger-gen.yml
@@ -11,7 +11,7 @@ permissions: {}
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   detect-changes:


### PR DESCRIPTION
This will improve what "green" builds on main look like.