### PR TITLE
RichHistory: Replace createMonitoringLogger calls with getLogger

### DIFF
--- a/packages/grafana-runtime/src/services/logging/loggers.ts
+++ b/packages/grafana-runtime/src/services/logging/loggers.ts
@@ -15,6 +15,7 @@ export const Loggers = {
   'features.alerting': { context: { module: 'Alerting' } },
   'features.correlations': {},
   'features.dashboards.genai': {},
+  'features.query-history.local-storage': {},
 } satisfies Record<string, LoggerDefaults>;
 
 export type LoggerSource = keyof typeof Loggers;

--- a/public/app/core/history/RichHistoryLocalStorage.test.ts
+++ b/public/app/core/history/RichHistoryLocalStorage.test.ts
@@ -1,5 +1,6 @@
 import { type DataQuery, store } from '@grafana/data';
-import { createMonitoringLogger, type MonitoringLogger } from '@grafana/runtime';
+import { type MonitoringLogger } from '@grafana/runtime';
+import { mockLogger } from '@grafana/test-utils/unstable';
 import { type RichHistoryQuery } from 'app/types/explore';
 
 import { DatasourceSrv } from '../../features/plugins/datasource_srv';
@@ -26,14 +27,9 @@ jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   getBackendSrv: () => backendSrv,
   getDataSourceSrv: () => dsMock,
-  createMonitoringLogger: jest.fn().mockReturnValue({ logWarning: jest.fn() }),
 }));
 
-// logger is created at import so we cannot initialize inside the test
-const loggerIndex = (createMonitoringLogger as jest.Mock).mock.calls.findIndex(
-  (args) => args[0] === 'features.query-history.local-storage'
-);
-const loggerMock: MonitoringLogger = (createMonitoringLogger as jest.Mock).mock.results[loggerIndex]?.value;
+let loggerMock: MonitoringLogger;
 
 interface MockQuery extends DataQuery {
   query: string;
@@ -80,10 +76,9 @@ describe('RichHistoryLocalStorage', () => {
 
     jest.useFakeTimers();
     jest.setSystemTime(now);
+    loggerMock = mockLogger('features.query-history.local-storage');
     storage = new RichHistoryLocalStorage();
     await storage.deleteAll();
-
-    (loggerMock.logWarning as jest.Mock).mockReset();
   });
 
   afterEach(() => {

--- a/public/app/core/history/RichHistoryLocalStorage.ts
+++ b/public/app/core/history/RichHistoryLocalStorage.ts
@@ -1,7 +1,7 @@
 import { find, isEqual, omit } from 'lodash';
 
 import { type DataQuery, type SelectableValue, store } from '@grafana/data';
-import { createMonitoringLogger } from '@grafana/runtime';
+import { getLogger } from '@grafana/runtime/unstable';
 import { type RichHistorySearchFilters, type RichHistorySettings, SortOrder } from 'app/core/utils/richHistoryTypes';
 import { type RichHistoryQuery } from 'app/types/explore';
 
@@ -28,8 +28,6 @@ export type RichHistoryLocalStorageDTO = {
   comment: string;
   queries: DataQuery[];
 };
-
-const logger = createMonitoringLogger('features.query-history.local-storage');
 
 /**
  * Local storage implementation for Rich History. It keeps all entries in browser's local storage.
@@ -203,7 +201,7 @@ export default class RichHistoryLocalStorage implements RichHistoryStorage {
       allQueriesCount: allQueriesCount?.toString(),
     };
 
-    logger.logWarning(message, {
+    getLogger('features.query-history.local-storage').logWarning(message, {
       ...localStats,
       ...additionalInfo,
     });


### PR DESCRIPTION
**What is this feature?**

Replaces the `createMonitoringLogger` call in `public/app/core/history/RichHistoryLocalStorage.ts` with `getLogger` from `@grafana/runtime/unstable` and registers the existing `features.query-history.local-storage` source name in the central `Loggers` registry.

**Why do we need this feature?**

So query-history loggers go through the same registry as the rest of the runtime loggers and we can stop using `createMonitoringLogger` in app code.

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

Related #121639

**Special notes for your reviewer:**

The `features.query-history.local-storage` source name is kept as-is so the Faro logs don't change. The corresponding test file is migrated from a `jest.mock('@grafana/runtime', { createMonitoringLogger: ... })` pattern to `mockLogger('features.query-history.local-storage')` from `@grafana/test-utils/unstable`. All existing assertions on `logWarning` calls keep working.

🤖 Generated with [Claude Code](https://claude.com/claude-code)