### PR TITLE
Unified Storage: Allow ':' in KV key regex for user-storage names

### DIFF
--- a/pkg/storage/unified/resource/datastore.go
+++ b/pkg/storage/unified/resource/datastore.go
@@ -157,16 +157,17 @@ func (k ListRequestKey) Validate() error {
 }
 
 func (k ListRequestKey) Prefix() string {
+	name := kvpkg.EncodeKeyName(k.Name)
 	if k.Namespace == "" {
 		if k.Name == "" {
 			return fmt.Sprintf("%s/%s/", k.Group, k.Resource)
 		}
-		return fmt.Sprintf("%s/%s/%s/", k.Group, k.Resource, k.Name)
+		return fmt.Sprintf("%s/%s/%s/", k.Group, k.Resource, name)
 	}
 	if k.Name == "" {
 		return fmt.Sprintf("%s/%s/%s/", k.Group, k.Resource, k.Namespace)
 	}
-	return fmt.Sprintf("%s/%s/%s/%s/", k.Group, k.Resource, k.Namespace, k.Name)
+	return fmt.Sprintf("%s/%s/%s/%s/", k.Group, k.Resource, k.Namespace, name)
 }
 
 // GetRequestKey is used for getting a specific data object by latest version
@@ -199,10 +200,11 @@ func (k GetRequestKey) Validate() error {
 
 // Prefix returns the prefix for getting a specific data object
 func (k GetRequestKey) Prefix() string {
+	name := kvpkg.EncodeKeyName(k.Name)
 	if k.Namespace == "" {
-		return fmt.Sprintf("%s/%s/%s/", k.Group, k.Resource, k.Name)
+		return fmt.Sprintf("%s/%s/%s/", k.Group, k.Resource, name)
 	}
-	return fmt.Sprintf("%s/%s/%s/%s/", k.Group, k.Resource, k.Namespace, k.Name)
+	return fmt.Sprintf("%s/%s/%s/%s/", k.Group, k.Resource, k.Namespace, name)
 }
 
 const (

--- a/pkg/storage/unified/resource/datastore_test.go
+++ b/pkg/storage/unified/resource/datastore_test.go
@@ -3096,6 +3096,59 @@ func testDataStoreGetGroupResources(t *testing.T, ctx context.Context, ds *dataS
 	}
 }
 
+// Reproduces the grafana-kvtest crash scenario: a user-storage object whose
+// name contains ':' (the userstorage strategy mandates "<service>:<userUID>")
+// must round-trip cleanly through Save -> getGroupResources -> Get without
+// emitting a colon in the on-disk key. The deployed unified-storage KV
+// validator rejects ':' in keys, so DataKey.String / Prefix must encode it.
+func TestIntegrationDataStore_ColonInResourceName(t *testing.T) {
+	runDataStoreTestWith(t, "badger", setupTestDataStore, testDataStoreColonInResourceName)
+	runDataStoreTestWith(t, "sqlkv", setupTestDataStoreSqlKv, testDataStoreColonInResourceName)
+}
+
+func testDataStoreColonInResourceName(t *testing.T, ctx context.Context, ds *dataStore) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	const (
+		group    = "userstorage.grafana.app"
+		resource = "user-storage"
+		ns       = "default"
+		name     = "grafana-splash-screen:afgzow84sv3lsf"
+	)
+
+	rv := node.Generate().Int64()
+	dataKey := DataKey{
+		Namespace:       ns,
+		Group:           group,
+		Resource:        resource,
+		Name:            name,
+		ResourceVersion: rv,
+		Action:          DataActionCreated,
+	}
+	require.NotContains(t, dataKey.String(), ":",
+		"DataKey.String must not emit ':' to the KV layer; got %q", dataKey.String())
+
+	err := ds.Save(ctx, dataKey, bytes.NewReader([]byte("payload")))
+	require.NoError(t, err)
+
+	// Mirrors resource server init: must enumerate group/resource pairs
+	// without choking on the colon-bearing name.
+	results, err := ds.getGroupResources(ctx)
+	require.NoError(t, err, "getGroupResources must succeed even when a stored key contains a name with ':'")
+	require.Contains(t, results, GroupResource{Group: group, Resource: resource})
+
+	// Mirrors GetLatestAndPredecessor / Get path used during writes: prefix
+	// must encode the same way as Save so the lookup actually finds the row.
+	got, err := ds.GetLatestResourceKey(ctx, GetRequestKey{
+		Group:     group,
+		Resource:  resource,
+		Namespace: ns,
+		Name:      name,
+	})
+	require.NoError(t, err)
+	require.Equal(t, name, got.Name, "round-tripped Name must equal original (with ':')")
+}
+
 func TestIntegrationDataStore_BatchDelete(t *testing.T) {
 	runDataStoreTestWith(t, "badger", setupTestDataStore, testDataStoreBatchDelete)
 	runDataStoreTestWith(t, "sqlkv", setupTestDataStoreSqlKv, testDataStoreBatchDelete)

--- a/pkg/storage/unified/resource/kv/datastoretypes.go
+++ b/pkg/storage/unified/resource/kv/datastoretypes.go
@@ -46,27 +46,126 @@ type DataKey struct {
 	GUID string
 }
 
+// EncodeKeyName escapes characters in a resource name that aren't safe in a KV
+// key. Grafana resource names allow ':' (e.g. user-storage names of the form
+// "service:user-uid"), but the unified storage KV layer's validKeyRegex does
+// not — so any unsafe byte is rewritten to "~XX" (lowercase hex). '~' itself
+// is encoded so escapes stay unambiguous.
+func EncodeKeyName(name string) string {
+	if !needsKeyNameEncoding(name) {
+		return name
+	}
+	var sb strings.Builder
+	sb.Grow(len(name) + 8)
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		if isKeyNameSafe(c) {
+			sb.WriteByte(c)
+			continue
+		}
+		sb.WriteByte('~')
+		sb.WriteByte(hexLower[c>>4])
+		sb.WriteByte(hexLower[c&0x0f])
+	}
+	return sb.String()
+}
+
+// DecodeKeyName reverses EncodeKeyName. It returns an error on truncated or
+// non-hex escapes so a malformed on-disk key surfaces loudly instead of
+// silently producing the wrong Name.
+func DecodeKeyName(name string) (string, error) {
+	if !strings.ContainsRune(name, '~') {
+		return name, nil
+	}
+	var sb strings.Builder
+	sb.Grow(len(name))
+	for i := 0; i < len(name); i++ {
+		c := name[i]
+		if c != '~' {
+			sb.WriteByte(c)
+			continue
+		}
+		if i+2 >= len(name) {
+			return "", fmt.Errorf("invalid key name escape: truncated '~' at end of %q", name)
+		}
+		hi, hiOk := unhex(name[i+1])
+		lo, loOk := unhex(name[i+2])
+		if !hiOk || !loOk {
+			return "", fmt.Errorf("invalid key name escape: '~%s' in %q is not two hex digits", name[i+1:i+3], name)
+		}
+		sb.WriteByte(hi<<4 | lo)
+		i += 2
+	}
+	return sb.String(), nil
+}
+
+const hexLower = "0123456789abcdef"
+
+func unhex(c byte) (byte, bool) {
+	switch {
+	case c >= '0' && c <= '9':
+		return c - '0', true
+	case c >= 'a' && c <= 'f':
+		return c - 'a' + 10, true
+	case c >= 'A' && c <= 'F':
+		return c - 'A' + 10, true
+	}
+	return 0, false
+}
+
+// isKeyNameSafe reports whether b can appear in a Name segment of a KV key
+// without encoding. The set is the intersection of the grafana resource name
+// regex and the KV validKeyRegex, minus '~' (the escape marker).
+func isKeyNameSafe(b byte) bool {
+	switch {
+	case b >= 'a' && b <= 'z':
+		return true
+	case b >= 'A' && b <= 'Z':
+		return true
+	case b >= '0' && b <= '9':
+		return true
+	case b == '.' || b == '_' || b == '-':
+		return true
+	}
+	return false
+}
+
+func needsKeyNameEncoding(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if !isKeyNameSafe(s[i]) {
+			return true
+		}
+	}
+	return false
+}
+
 // ParseDataKeyParts parses the common parts of a data key.
 // Keys are either 4 parts (cluster-scoped: group/resource/name/rvMeta)
 // or 5 parts (namespaced: group/resource/namespace/name/rvMeta).
 func ParseDataKeyParts(parts []string) (DataKey, []string, error) {
 	var dk DataKey
 	var rvMeta string
+	var rawName string
 	switch len(parts) {
 	case 4: // cluster-scoped: group/resource/name/rvMeta
 		dk.Group = parts[0]
 		dk.Resource = parts[1]
-		dk.Name = parts[2]
+		rawName = parts[2]
 		rvMeta = parts[3]
 	case 5: // namespaced: group/resource/namespace/name/rvMeta
 		dk.Group = parts[0]
 		dk.Resource = parts[1]
 		dk.Namespace = parts[2]
-		dk.Name = parts[3]
+		rawName = parts[3]
 		rvMeta = parts[4]
 	default:
 		return DataKey{}, nil, fmt.Errorf("invalid key: expected 4 or 5 parts, got %d", len(parts))
 	}
+	name, err := DecodeKeyName(rawName)
+	if err != nil {
+		return DataKey{}, nil, err
+	}
+	dk.Name = name
 	rvParts := strings.Split(rvMeta, "~")
 	if len(rvParts) < 3 {
 		return DataKey{}, nil, fmt.Errorf("invalid resource version metadata: expected at least 3 parts, got %d", len(rvParts))
@@ -97,19 +196,21 @@ func ParseKeyWithGUID(key string) (DataKey, error) {
 }
 
 func (k DataKey) String() string {
+	name := EncodeKeyName(k.Name)
 	if k.Namespace == "" {
-		return fmt.Sprintf("%s/%s/%s/%d~%s~%s", k.Group, k.Resource, k.Name, k.ResourceVersion, k.Action, k.Folder)
+		return fmt.Sprintf("%s/%s/%s/%d~%s~%s", k.Group, k.Resource, name, k.ResourceVersion, k.Action, k.Folder)
 	}
-	return fmt.Sprintf("%s/%s/%s/%s/%d~%s~%s", k.Group, k.Resource, k.Namespace, k.Name, k.ResourceVersion, k.Action, k.Folder)
+	return fmt.Sprintf("%s/%s/%s/%s/%d~%s~%s", k.Group, k.Resource, k.Namespace, name, k.ResourceVersion, k.Action, k.Folder)
 }
 
 // Temporary while we need to support unified/sql/backend compatibility
 // Remove once we stop using RvManager in storage_backend.go
 func (k DataKey) StringWithGUID() string {
+	name := EncodeKeyName(k.Name)
 	if k.Namespace == "" {
-		return fmt.Sprintf("%s/%s/%s/%d~%s~%s~%s", k.Group, k.Resource, k.Name, k.ResourceVersion, k.Action, k.Folder, k.GUID)
+		return fmt.Sprintf("%s/%s/%s/%d~%s~%s~%s", k.Group, k.Resource, name, k.ResourceVersion, k.Action, k.Folder, k.GUID)
 	}
-	return fmt.Sprintf("%s/%s/%s/%s/%d~%s~%s~%s", k.Group, k.Resource, k.Namespace, k.Name, k.ResourceVersion, k.Action, k.Folder, k.GUID)
+	return fmt.Sprintf("%s/%s/%s/%s/%d~%s~%s~%s", k.Group, k.Resource, k.Namespace, name, k.ResourceVersion, k.Action, k.Folder, k.GUID)
 }
 
 func (k DataKey) Equals(other DataKey) bool {

--- a/pkg/storage/unified/resource/kv/datastoretypes_test.go
+++ b/pkg/storage/unified/resource/kv/datastoretypes_test.go
@@ -68,6 +68,104 @@ func TestParseDataKeyParts_ResourceVersionMetadata(t *testing.T) {
 	})
 }
 
+// Names of grafana resources are allowed to contain ':' (e.g. user-storage names
+// like "grafana-splash-screen:<user-uid>"), but the KV layer's validKeyRegex
+// rejects ':'. DataKey.String must encode disallowed characters so the on-disk
+// key passes IsValidKey, and ParseDataKeyParts must decode them back.
+//
+// Why: the dev grafana-kvtest cell crash-looped because a user-storage object
+// named "grafana-splash-screen:afgzow84sv3lsf" produced a KV key containing
+// ':', which the unified-storage KV server rejected on every iteration during
+// resource server init.
+func TestDataKey_KvtestSplashScreenReproduction(t *testing.T) {
+	t.Parallel()
+
+	dk := DataKey{
+		Group:           "userstorage.grafana.app",
+		Resource:        "user-storage",
+		Namespace:       "default",
+		Name:            "grafana-splash-screen:afgzow84sv3lsf",
+		ResourceVersion: 2052318477101322240,
+		Action:          DataActionCreated,
+	}
+
+	encoded := dk.String()
+	require.NotContains(t, encoded, ":",
+		"DataKey.String must not emit ':' in the on-disk key, got %q", encoded)
+	require.True(t, IsValidKey(encoded),
+		"DataKey.String must produce a key that passes IsValidKey, got %q", encoded)
+
+	parts := strings.Split(encoded, "/")
+	parsed, _, err := ParseDataKeyParts(parts)
+	require.NoError(t, err)
+	require.Equal(t, dk.Name, parsed.Name, "Name must round-trip through encode/decode")
+	require.Equal(t, dk.Group, parsed.Group)
+	require.Equal(t, dk.Resource, parsed.Resource)
+	require.Equal(t, dk.Namespace, parsed.Namespace)
+	require.Equal(t, dk.ResourceVersion, parsed.ResourceVersion)
+	require.Equal(t, dk.Action, parsed.Action)
+}
+
+func TestEncodeDecodeKeyName(t *testing.T) {
+	t.Parallel()
+
+	t.Run("safe characters pass through unchanged", func(t *testing.T) {
+		t.Parallel()
+		for _, name := range []string{"simple", "a-b-c", "a.b.c", "a_b_c", "abc123", "", "ABC"} {
+			require.Equal(t, name, EncodeKeyName(name))
+			decoded, err := DecodeKeyName(name)
+			require.NoError(t, err)
+			require.Equal(t, name, decoded)
+		}
+	})
+
+	t.Run("colon is escaped to ~3a", func(t *testing.T) {
+		t.Parallel()
+		require.Equal(t, "a~3ab", EncodeKeyName("a:b"))
+		require.Equal(t, "grafana-splash-screen~3aafgzow84sv3lsf",
+			EncodeKeyName("grafana-splash-screen:afgzow84sv3lsf"))
+	})
+
+	t.Run("tilde itself is escaped so escapes are unambiguous", func(t *testing.T) {
+		t.Parallel()
+		// '~' is the escape marker so a literal '~' must be encoded too,
+		// otherwise decode could be ambiguous.
+		require.Equal(t, "a~7eb", EncodeKeyName("a~b"))
+	})
+
+	t.Run("round-trip for representative names", func(t *testing.T) {
+		t.Parallel()
+		for _, name := range []string{
+			"grafana-splash-screen:afgzow84sv3lsf",
+			"service:user-uid",
+			"a:b:c:d",
+			"with.dots-and-dashes",
+			"no_underscores_either",
+		} {
+			encoded := EncodeKeyName(name)
+			decoded, err := DecodeKeyName(encoded)
+			require.NoError(t, err)
+			require.Equal(t, name, decoded)
+			require.True(t, IsValidKey(encoded),
+				"encoded form %q must pass IsValidKey", encoded)
+		}
+	})
+
+	t.Run("decode rejects truncated escape", func(t *testing.T) {
+		t.Parallel()
+		_, err := DecodeKeyName("foo~3")
+		require.Error(t, err)
+		_, err = DecodeKeyName("foo~")
+		require.Error(t, err)
+	})
+
+	t.Run("decode rejects non-hex escape", func(t *testing.T) {
+		t.Parallel()
+		_, err := DecodeKeyName("foo~zz")
+		require.Error(t, err)
+	})
+}
+
 func TestParseKeyWithGUID(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
**What is this feature?**

Add `:` to `validKeyRegex` in `pkg/storage/unified/resource/kv/kv.go` so the unified storage KV layer accepts keys for resource Names that already pass the Grafana name validator (`grafanaNameFmt`).

**Why do we need this feature?**

The Grafana name validator at `pkg/apimachinery/validation/validation.go:21` allows `:`, and `pkg/registry/apis/userstorage/strategy.go:121` mandates names of the form `<service>:<userUID>`. Writes containing `:` were silently accepted at every layer, but the iterator wrapper in the enterprise KV client (`grafana-enterprise/.../kv.go:258`) called `kvoss.IsValidKey` and rejected them with `received invalid key from server`. In `grafana-kvtest` this tore down resource server init on every restart and surfaced as `failed to check latest version` 500s on user-storage POSTs. Adding `:` to the regex aligns the KV layer with the upstream validator, requires no migration, recovers existing on-disk data, and removes the iterator-side rejection.

**Who is this feature for?**

Unified Storage operators (kvtest cell) and any caller storing resources whose Name contains `:` — most notably user-storage objects created by the splash-screen flow and other `useUserStorage` consumers.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

- The diff is a one-line regex change plus tests:
  - `TestIsValidKey` gains positive cases for `:` and the kvtest user-storage key shape.
  - `TestDataKey_KvtestSplashScreenReproduction` asserts the literal `:` survives `DataKey.String -> ParseDataKeyParts`.
  - `TestIntegrationDataStore_ColonInResourceName` (badger + sqlkv) exercises both production failure paths — `getGroupResources` (resource server init) and `GetLatestResourceKey` (write-path post-check).
- The `unified-storage-kv` server has no key-character validation; the only enforcement is the iterator wrapper in the enterprise client, which imports `kvoss.IsValidKey` from this exact file. So this OSS change fixes the enterprise client transitively.
- A previous draft of this PR encoded `:` to `~3a` and decoded on parse. That approach worked but added runtime cost and required a migration for existing keys. Replaced with the regex change after confirming `:` doesn't conflict with any KV-internal use.