### PR TITLE
Dashboards: Avoid empty controls container in kiosk mode

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardControls.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControls.test.tsx
@@ -118,13 +118,13 @@ describe('DashboardControls', () => {
     it('should render', () => {
       const scene = buildTestScene();
       expect(() => {
-        render(<scene.Component model={scene} />);
+        renderInGrafanaContext(<scene.Component model={scene} />);
       }).not.toThrow();
     });
 
     it('should render visible controls', async () => {
       const scene = buildTestScene({});
-      const renderer = render(<scene.Component model={scene} />);
+      const renderer = renderInGrafanaContext(<scene.Component model={scene} />);
 
       expect(await renderer.findByTestId(selectors.pages.Dashboard.Controls)).toBeInTheDocument();
       expect(await renderer.findByTestId(selectors.components.DashboardLinks.container)).toBeInTheDocument();
@@ -140,9 +140,29 @@ describe('DashboardControls', () => {
         hideLinksControls: true,
         hideDashboardControls: true,
       });
-      const renderer = render(<scene.Component model={scene} />);
+      const renderer = renderInGrafanaContext(<scene.Component model={scene} />);
 
       expect(renderer.queryByTestId(selectors.pages.Dashboard.Controls)).not.toBeInTheDocument();
+    });
+
+    it('should not render an empty controls container in kiosk mode when controls are hidden', () => {
+      const originalFeatureToggles = { ...config.featureToggles };
+      try {
+        config.featureToggles.dashboardNewLayouts = true;
+
+        const scene = buildTestScene({
+          hideTimeControls: true,
+          hideVariableControls: true,
+          hideLinksControls: true,
+          hideDashboardControls: true,
+        });
+
+        renderInGrafanaContext(<scene.Component model={scene} />, KioskMode.Full);
+
+        expect(screen.queryByTestId(selectors.pages.Dashboard.Controls)).not.toBeInTheDocument();
+      } finally {
+        config.featureToggles = originalFeatureToggles;
+      }
     });
 
     it('should render Table view toggle in panel edit mode even when all other controls are hidden', () => {
@@ -161,7 +181,7 @@ describe('DashboardControls', () => {
 
       dashboard.activate();
 
-      render(<controls.Component model={controls} />);
+      renderInGrafanaContext(<controls.Component model={controls} />);
 
       expect(screen.getByTestId('mock-panel-edit-controls')).toBeInTheDocument();
     });
@@ -195,7 +215,7 @@ describe('DashboardControls', () => {
         return <div>Mocked Component</div>;
       });
 
-      const renderer = render(<controls.Component model={controls} />);
+      const renderer = renderInGrafanaContext(<controls.Component model={controls} />);
 
       // Verify UNSAFE_renderAsHidden is set (required for renderHiddenVariables to include it)
       expect(scopeVariable.UNSAFE_renderAsHidden).toBe(true);
@@ -212,7 +232,7 @@ describe('DashboardControls', () => {
       const dashboard = getDashboard(scene);
       dashboard.setState({ defaultVariablesLoading: true });
 
-      const { container } = render(<scene.Component model={scene} />);
+      const { container } = renderInGrafanaContext(<scene.Component model={scene} />);
       expect(container.querySelector('.react-loading-skeleton')).toBeInTheDocument();
     });
 
@@ -221,7 +241,7 @@ describe('DashboardControls', () => {
       const dashboard = getDashboard(scene);
       dashboard.setState({ defaultVariablesLoading: false, defaultLinksLoading: false });
 
-      const { container } = render(<scene.Component model={scene} />);
+      const { container } = renderInGrafanaContext(<scene.Component model={scene} />);
       expect(container.querySelector('.react-loading-skeleton')).not.toBeInTheDocument();
     });
   });

--- a/public/app/features/dashboard-scene/scene/DashboardControls.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControls.tsx
@@ -167,12 +167,14 @@ function DashboardControlsRenderer({ model }: SceneComponentProps<DashboardContr
   const styles = useStyles2(getStyles, isQueryEditorNext);
   const showDebugger = window.location.search.includes('scene-debugger');
   const hasDashboardControls = useHasDashboardControls(dashboard);
+  const { chrome } = useGrafana();
+  const { kioskMode } = chrome.useState();
 
   if (!model.hasControls()) {
     // If dynamic dashboards is enabled, we need to show the edit/share/playlist buttons
     // However we shouldn't do it if we're in edit panel view
     // `DashboardControlActions` already check for edit panel view but we need to prevent showing the container as well
-    if (config.featureToggles.dashboardNewLayouts && !editPanel) {
+    if (config.featureToggles.dashboardNewLayouts && !editPanel && kioskMode !== KioskMode.Full) {
       return (
         <>
           <div data-testid={selectors.pages.Dashboard.Controls} className={styles.controls}>

--- a/public/app/features/dashboard-scene/scene/DashboardLinksControls.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardLinksControls.test.tsx
@@ -1,8 +1,11 @@
 import { act, render } from '@testing-library/react';
+import { type ReactNode } from 'react';
+import { getGrafanaContextMock } from 'test/mocks/getGrafanaContextMock';
 
 import { toUtc } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { SceneTimeRange } from '@grafana/scenes';
+import { GrafanaContext } from 'app/core/context/GrafanaContext';
 
 import { DashboardControls } from './DashboardControls';
 import { DashboardScene } from './DashboardScene';
@@ -23,7 +26,7 @@ jest.mock('app/features/panel/panellinks/link_srv', () => ({
 describe('DashboardLinksControls', () => {
   it('renders dashboard links correctly', () => {
     const { controls } = buildTestScene();
-    const renderer = render(<controls.Component model={controls} />);
+    const renderer = renderInGrafanaContext(<controls.Component model={controls} />);
 
     // // Expect two dashboard link containers to be rendered
     const linkContainers = renderer.getAllByTestId(selectors.components.DashboardLinks.container);
@@ -37,7 +40,7 @@ describe('DashboardLinksControls', () => {
 
   it('updates link hrefs when time range changes', () => {
     const { controls, dashboard } = buildTestScene();
-    render(<controls.Component model={controls} />);
+    renderInGrafanaContext(<controls.Component model={controls} />);
 
     //clear initial calls to getAnchorInfo
     mockGetAnchorInfo.mockClear();
@@ -57,6 +60,11 @@ describe('DashboardLinksControls', () => {
     expect(mockGetAnchorInfo).toHaveBeenCalledTimes(2);
   });
 });
+
+function renderInGrafanaContext(child: ReactNode) {
+  const context = getGrafanaContextMock();
+  return render(<GrafanaContext.Provider value={context}>{child}</GrafanaContext.Provider>);
+}
 
 function buildTestScene(): { controls: DashboardControls; dashboard: DashboardScene } {
   const dashboard = new DashboardScene({


### PR DESCRIPTION
**What is this feature?**

This change prevents rendering the dashboard controls container in kiosk mode when there are no visible controls. It also adds a regression test to ensure the empty controls wrapper is not rendered in that scenario.

**Why do we need this feature?**

In kiosk mode, the empty controls container still applied top padding/background in some new-layout cases, which could appear as a blank/black bar overlaying dashboard content.

**Who is this feature for?**

Users displaying dashboards in kiosk/TV mode where vertical space and clean rendering are important.

**Which issue(s) does this PR fix?**:

Fixes #122932

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.

## Summary
- Use `chrome.kioskMode` to detect kiosk mode when deciding whether to render the controls wrapper.
- Skip rendering the new-layout controls container when controls are hidden and kiosk mode is active.
- Add regression coverage in `DashboardControls.test.tsx` for hidden controls in kiosk mode.

## Test plan
- [x] `yarn jest --no-watch public/app/features/dashboard-scene/scene/DashboardControls.test.tsx`
- [ ] Manually open a kiosk dashboard with hidden controls and verify no blank top strip is rendered.