### PR TITLE
AnnotationListPlugin: rebuild row layout to stop heading + timestamp overlap

### DIFF
--- a/public/app/plugins/panel/annolist/AnnotationListItem.tsx
+++ b/public/app/plugins/panel/annolist/AnnotationListItem.tsx
@@ -30,10 +30,9 @@ export const AnnotationListItem = ({ options, annotation, formatDate, onClick, o
   const showTimeStampEnd = timeEnd && timeEnd !== time && showTime;
 
   return (
-    // Plain-div row instead of <Card> — Card's internal grid layout (Description
-    // gets its own row, Heading spans across columns) fights every override we
-    // tried in single-row form. Keeping the visual styling close to the
-    // surrounding cards.
+    // Plain-div row rather than <Card>: Card's grid layout puts Description on its
+    // own row and makes Heading span across columns, which the panel's single-row
+    // layout can't override cleanly. Visual styling kept close to a Card.
     <div role="button" tabIndex={0} className={styles.row} onClick={onItemClick}>
       <RenderUserContentAsHTML
         className={styles.heading}
@@ -143,8 +142,6 @@ function getStyles(theme: GrafanaTheme2) {
       fontSize: theme.typography.size.md,
       fontWeight: theme.typography.fontWeightMedium,
       a: {
-        zIndex: 1,
-        position: 'relative',
         color: theme.colors.text.link,
         '&:hover': {
           textDecoration: 'underline',
@@ -153,13 +150,10 @@ function getStyles(theme: GrafanaTheme2) {
     }),
     meta: css({
       margin: 0,
-      position: 'relative',
       justifySelf: 'end',
     }),
     timestamp: css({
       margin: 0,
-      color: theme.colors.text.secondary,
-      lineHeight: theme.typography.body.lineHeight,
     }),
     tagList: css({
       justifySelf: 'end',

--- a/public/app/plugins/panel/annolist/AnnotationListItem.tsx
+++ b/public/app/plugins/panel/annolist/AnnotationListItem.tsx
@@ -3,7 +3,7 @@ import { type MouseEvent } from 'react';
 
 import { type AnnotationEvent, type DateTimeInput, type GrafanaTheme2, type PanelProps } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
-import { Card, RenderUserContentAsHTML, TagList, Tooltip, useStyles2 } from '@grafana/ui';
+import { RenderUserContentAsHTML, TagList, Tooltip, useStyles2 } from '@grafana/ui';
 
 import { type Options } from './panelcfg.gen';
 
@@ -30,18 +30,20 @@ export const AnnotationListItem = ({ options, annotation, formatDate, onClick, o
   const showTimeStampEnd = timeEnd && timeEnd !== time && showTime;
 
   return (
-    <Card noMargin className={styles.card} onClick={onItemClick}>
-      <Card.Heading>
-        <RenderUserContentAsHTML
-          className={styles.heading}
-          onClick={(e) => {
-            e.stopPropagation();
-          }}
-          content={text}
-        />
-      </Card.Heading>
+    // Plain-div row instead of <Card> — Card's internal grid layout (Description
+    // gets its own row, Heading spans across columns) fights every override we
+    // tried in single-row form. Keeping the visual styling close to the
+    // surrounding cards.
+    <div role="button" tabIndex={0} className={styles.row} onClick={onItemClick}>
+      <RenderUserContentAsHTML
+        className={styles.heading}
+        onClick={(e) => {
+          e.stopPropagation();
+        }}
+        content={text}
+      />
       {showTimeStamp && (
-        <Card.Description className={styles.timestamp}>
+        <div className={styles.timestamp}>
           <TimeStamp formatDate={formatDate} time={time!} />
           {showTimeStampEnd && (
             <>
@@ -49,19 +51,19 @@ export const AnnotationListItem = ({ options, annotation, formatDate, onClick, o
               <TimeStamp formatDate={formatDate} time={timeEnd!} />{' '}
             </>
           )}
-        </Card.Description>
+        </div>
       )}
       {showAvatar && (
-        <Card.Meta className={styles.meta}>
+        <div className={styles.meta}>
           <Avatar email={email} login={login!} avatarUrl={avatarUrl} onClick={onLoginClick} />
-        </Card.Meta>
+        </div>
       )}
       {showTags && tags && (
-        <Card.Tags>
+        <div className={styles.tagList}>
           <TagList tags={tags} onClick={(tag) => onTagClick(tag, false)} />
-        </Card.Tags>
+        </div>
       )}
-    </Card>
+    </div>
   );
 };
 
@@ -113,14 +115,33 @@ const TimeStamp = ({ time, formatDate }: TimeStampProps) => {
 
 function getStyles(theme: GrafanaTheme2) {
   return {
-    card: css({
-      gridTemplateAreas: `"Heading Description Meta Tags"`,
-      gridTemplateColumns: 'auto 1fr auto auto',
+    row: css({
+      display: 'grid',
+      gridTemplateColumns: 'minmax(0, max-content) 1fr auto auto',
+      alignItems: 'center',
+      gap: theme.spacing(1),
       padding: theme.spacing(1),
       margin: theme.spacing(0.5),
-      width: 'inherit',
+      background: theme.colors.background.secondary,
+      borderRadius: theme.shape.radius.default,
+      cursor: 'pointer',
+      [theme.transitions.handleMotion('no-preference', 'reduce')]: {
+        transition: theme.transitions.create(['background-color'], {
+          duration: theme.transitions.duration.short,
+        }),
+      },
+      '&:hover': {
+        background: theme.colors.emphasize(theme.colors.background.secondary, 0.03),
+      },
     }),
     heading: css({
+      minWidth: 0,
+      overflow: 'hidden',
+      textOverflow: 'ellipsis',
+      whiteSpace: 'nowrap',
+      color: theme.colors.text.primary,
+      fontSize: theme.typography.size.md,
+      fontWeight: theme.typography.fontWeightMedium,
       a: {
         zIndex: 1,
         position: 'relative',
@@ -133,11 +154,15 @@ function getStyles(theme: GrafanaTheme2) {
     meta: css({
       margin: 0,
       position: 'relative',
-      justifyContent: 'end',
+      justifySelf: 'end',
     }),
     timestamp: css({
       margin: 0,
-      alignSelf: 'center',
+      color: theme.colors.text.secondary,
+      lineHeight: theme.typography.body.lineHeight,
+    }),
+    tagList: css({
+      justifySelf: 'end',
     }),
     time: css({
       marginLeft: theme.spacing(1),

--- a/public/app/plugins/panel/annolist/AnnotationListItem.tsx
+++ b/public/app/plugins/panel/annolist/AnnotationListItem.tsx
@@ -33,7 +33,18 @@ export const AnnotationListItem = ({ options, annotation, formatDate, onClick, o
     // Plain-div row rather than <Card>: Card's grid layout puts Description on its
     // own row and makes Heading span across columns, which the panel's single-row
     // layout can't override cleanly. Visual styling kept close to a Card.
-    <div role="button" tabIndex={0} className={styles.row} onClick={onItemClick}>
+    <div
+      role="button"
+      tabIndex={0}
+      className={styles.row}
+      onClick={onItemClick}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault();
+          onItemClick();
+        }
+      }}
+    >
       <RenderUserContentAsHTML
         className={styles.heading}
         onClick={(e) => {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fixes  design for the anno list item rows. The timestamp and anno name were overlapping.

The Card component is built for a multi-row layout: Card.Heading and Card.Description both default to gridColumnEnd: 'Tags' so each spans the middle column horizontally. AnnoListPanel rendered them in a custom single-row grid where that span made the heading and timestamp cells visually overlap.

Card's internal styles couldn't be overridden cleanly — @emotion/css cx() merges the className we pass with the internal class into one, where neither selector-doubling (&&) nor !important reliably won the cascade. Replacing Card with a plain-div CSS grid we own removes the fight entirely. Visual styling (background, hover, padding, radius) mirrors the previous Card look.

**Why do we need this feature?**

Fixes the design

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
