### PR TITLE
unified-storage: don't share BeginTx deadline with fixture setup in incident 2144 regression test

### DIFF
--- a/pkg/storage/unified/sql/db/dbimpl/regression_incident_2144_test.go
+++ b/pkg/storage/unified/sql/db/dbimpl/regression_incident_2144_test.go
@@ -55,21 +55,23 @@ func TestReproIncident2144UsingGrafanaDB(t *testing.T) {
 	t.Run("core Grafana db without instrumentation preserves driver ability to use isolation levels",
 		func(t *testing.T) {
 			t.Run("base behaviour is preserved", func(t *testing.T) {
-				ctx := testutil.NewTestContext(t, time.Now().Add(testTimeout))
 				cfgMap := cfgMap{}
-				setupDBForGrafana(t, ctx, cfgMap)
+				// Fixture setup can take longer than testTimeout on slow CI
+				// runners, so don't share its deadline with the BeginTx call
+				// that's actually under test.
+				setupDBForGrafana(t, t.Context(), cfgMap)
 				grafanaDB := newTestInfraDB(t, cfgMap)
 				db := grafanaDB.GetEngine().DB().DB
+				ctx := testutil.NewTestContext(t, time.Now().Add(testTimeout))
 				_, err := db.BeginTx(ctx, txOpts)
 				require.NoError(t, err)
 			})
 
 			t.Run("Resource API does not fail and correctly uses Grafana DB as fallback",
 				func(t *testing.T) {
-					ctx := testutil.NewTestContext(t, time.Now().Add(testTimeout))
 					cfgMap := cfgMap{}
 					cfg := newCfgFromIniMap(t, cfgMap)
-					setupDBForGrafana(t, ctx, cfgMap)
+					setupDBForGrafana(t, t.Context(), cfgMap)
 					grafanaDB := newTestInfraDB(t, cfgMap)
 					resourceDB, err := ProvideResourceDB(grafanaDB, cfg, nil)
 					require.NotNil(t, resourceDB)
@@ -79,13 +81,12 @@ func TestReproIncident2144UsingGrafanaDB(t *testing.T) {
 
 	t.Run("core Grafana db instrumentation removes driver ability to use isolation levels",
 		func(t *testing.T) {
-			ctx := testutil.NewTestContext(t, time.Now().Add(testTimeout))
 			cfgMap := cfgMap{
 				"database": cfgSectionMap{
 					grafanaDBInstrumentQueriesKey: "true",
 				},
 			}
-			setupDBForGrafana(t, ctx, cfgMap)
+			setupDBForGrafana(t, t.Context(), cfgMap)
 			grafanaDB := newTestInfraDB(t, cfgMap)
 
 			t.Run("base failure caused by instrumentation", func(t *testing.T) {


### PR DESCRIPTION
`TestReproIncident2144UsingGrafanaDB` is flaky on slow CI runners. Example failure: https://github.com/grafana/grafana/actions/runs/25484435362/job/74777449166

The subtests create a 2s-deadline context and pass it to both `setupDBForGrafana` (cfg load + sqlite + default org/admin) and the `BeginTx` call that's actually under test. On a slow runner the fixture setup alone consumed ~2s, so `BeginTx` was hit with an already-expired context and failed with `context deadline exceeded`.

PR #120483 previously bumped this timeout from 1s to 2s for the same reason. Bumping again would just push the threshold up; this PR addresses the cause: setup now runs with `t.Context()` (no deadline, canceled on test cleanup), and the 2s deadline is created fresh just before `BeginTx`. The hang guard around `BeginTx` is preserved.

No behaviour change for the assertions; the deadline is only a safety net and none of the subtests assert on timing.