### PR TITLE
[release-12.4.4] fix: exclude github.com/moby/moby from swagger generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,7 @@ swagger-oss-gen: ## Generate API Swagger specification
 	-x "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options" \
 	-x "github.com/prometheus/alertmanager" \
 	-x "github.com/docker/docker" \
+	-x "github.com/moby/moby" \
 	-i pkg/api/swagger_tags.json \
 	--exclude-tag=alpha \
 	--exclude-tag=enterprise
@@ -131,6 +132,7 @@ swagger-enterprise-gen: ## Generate API Swagger specification
 	-x "github.com/grpc-ecosystem/grpc-gateway/v2/protoc-gen-openapiv2/options" \
 	-x "github.com/prometheus/alertmanager" \
 	-x "github.com/docker/docker" \
+	-x "github.com/moby/moby" \
 	-i pkg/api/swagger_tags.json \
 	-t enterprise \
 	--exclude-tag=alpha \


### PR DESCRIPTION
Noticed some drift in the swagger docs on 12.4.4. github.com/moby/moby is excluded from swagger generation on main so this PR backports that so that the swagger doc generation stops generating diffs.