### PR TITLE
Agents: Add guidance to keep humans in the loop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ Grafana is a monitoring and observability platform. Go backend, TypeScript/React
 
 ## Human Review Gates
 
-Before running `git push` or creating a PR (e.g. `gh pr create`), stop and get explicit human approval. When changes are ready: show a summary of changes and wait for instruction. "Open a PR" in a task description is intent, not permission to push without review.
+Before running `git push`, stop and get explicit human approval. When changes are ready, show a summary of changes and wait for instruction. "Open a PR" in a task description is intent, not permission to push without review.
 
 ## Commands
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,10 @@ Grafana is a monitoring and observability platform. Go backend, TypeScript/React
 - Only add a comment when it explains **why** something is done or reveals non-obvious logic that a reader must know to safely change the code. If the code is self-explanatory, no comment is needed.
 - Never include links (Slack, GitHub, Jira, etc.) in code comments.
 
+## Human Review Gates
+
+Before running `git push` or creating a PR (e.g. `gh pr create`), stop and get explicit human approval. When changes are ready: show a summary of changes and wait for instruction. "Open a PR" in a task description is intent, not permission to push without review.
+
 ## Commands
 
 ### Build & Run


### PR DESCRIPTION
## Goals

- Provide some level of mitigation against unintentional pushing of commits by agents
- Increase thoughtfulness and care that goes into code contributions

## What this PR does

Adds a brief **Human Review Gates** section to [`AGENTS.md`](https://agents.md), guiding agents to pursue human input / approval before pushing commits.

## What this PR doesn't do

This PR does not provide any harness-level or tool-level configuration or restrictions. It will still be possible for agents to push commits without human input, just somewhat less likely in practice.

## Anticipated side-effects

### Fewer contributions without a human in the loop

The rise of agentic coding has led to a flurry of PRs to address issues in this repo, especially those with the [**good-first-issue**](https://github.com/grafana/grafana/issues?q=is%3Aissue%20label%3A%22good%20first%20issue%22) label. In some ways this is great. In other ways, it's presented challenges.

**good-first-issue** issues have traditionally been a stepping stone for new contributors to get involved with Grafana or perhaps with OSS in general. These issues are typically approachable problems that can be solved with first-principles thinking and by becoming more familiar with a particular part of the Grafana codebase. Today, it seems that many PRs are being crafted by agents, and the elements of learning and familiarization by PR authors are probably mostly lost in this context. Some issues have receive many competing PRs of this nature hours after they're opened.

I expect that merging this PR will add some friction to the `"hey ${agent}, let's fix https://github.com/grafana/grafana/issues/xxxxxx"`-driven contribution process. But I think this is helpful friction that encourages contributors to have more ownership over their contributions.