### PR TITLE
Authn: Enrich gRPC log fields with client, code, namespace, and header names

### DIFF
--- a/pkg/services/authn/authnserver/service.go
+++ b/pkg/services/authn/authnserver/service.go
@@ -2,7 +2,10 @@ package authnserver
 
 import (
 	"context"
+	"slices"
+	"strings"
 
+	grpclog "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 	"go.opentelemetry.io/otel/attribute"
 
 	authnv1 "github.com/grafana/authlib/authn/proto/v1"
@@ -51,6 +54,8 @@ func (s *Service) Authenticate(ctx context.Context, req *authnv1.AuthenticateReq
 	ctx, span := s.tracer.Start(ctx, "authnserver.Authenticate")
 	defer span.End()
 
+	grpclog.AddFields(ctx, grpclog.Fields{"authn.headers", headerNames(req.GetHttpHeaders())})
+
 	for _, c := range s.clients {
 		if !c.Test(ctx, req) {
 			continue
@@ -61,15 +66,27 @@ func (s *Service) Authenticate(ctx context.Context, req *authnv1.AuthenticateReq
 		resp, err := c.Authenticate(ctx, req)
 		if err != nil {
 			s.log.Error("Client authentication error", "client", c.Name(), "error", err)
+			grpclog.AddFields(ctx, grpclog.Fields{"authn.client", c.Name(), "authn.namespace", req.GetNamespace()})
 			return nil, err
 		}
 
 		if resp.Code != authnv1.AuthenticateCode_AUTHENTICATE_CODE_NOT_HANDLED {
+			grpclog.AddFields(ctx, grpclog.Fields{"authn.client", c.Name(), "authn.code", resp.Code.String(), "authn.namespace", req.GetNamespace()})
 			return resp, nil
 		}
 	}
 
+	grpclog.AddFields(ctx, grpclog.Fields{"authn.client", "none", "authn.code", authnv1.AuthenticateCode_AUTHENTICATE_CODE_NOT_HANDLED.String(), "authn.namespace", req.GetNamespace()})
 	return &authnv1.AuthenticateResponse{
 		Code: authnv1.AuthenticateCode_AUTHENTICATE_CODE_NOT_HANDLED,
 	}, nil
+}
+
+func headerNames(headers map[string]string) string {
+	names := make([]string, 0, len(headers))
+	for k := range headers {
+		names = append(names, k)
+	}
+	slices.Sort(names)
+	return strings.Join(names, ",")
 }

--- a/pkg/services/authn/authnserver/service_test.go
+++ b/pkg/services/authn/authnserver/service_test.go
@@ -204,15 +204,15 @@ func TestAuthenticate_GRPCLogFields(t *testing.T) {
 	grpcCtx := func(ctx context.Context) context.Context {
 		return grpclog.InjectFields(ctx, grpclog.Fields{})
 	}
+
+	// gRPC log fields are stored as alternating (key, value, key, value, ...)
+	// in a flat []any slice. This helper converts it to a map to simplify assertions.
 	extractFieldMap := func(ctx context.Context) map[string]string {
-		raw := grpclog.ExtractFields(ctx)
-		m := make(map[string]string, len(raw)/2)
-		for i := 0; i+1 < len(raw); i += 2 {
-			if k, ok := raw[i].(string); ok {
-				if v, ok := raw[i+1].(string); ok {
-					m[k] = v
-				}
-			}
+		m := make(map[string]string)
+		it := grpclog.ExtractFields(ctx).Iterator()
+		for it.Next() {
+			k, v := it.At()
+			m[k] = v.(string)
 		}
 		return m
 	}

--- a/pkg/services/authn/authnserver/service_test.go
+++ b/pkg/services/authn/authnserver/service_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	grpclog "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -197,4 +198,88 @@ func TestRegisterClient(t *testing.T) {
 	assert.Len(t, svc.clients, 2)
 	assert.Equal(t, "first", svc.clients[0].Name())
 	assert.Equal(t, "second", svc.clients[1].Name())
+}
+
+func TestAuthenticate_GRPCLogFields(t *testing.T) {
+	grpcCtx := func(ctx context.Context) context.Context {
+		return grpclog.InjectFields(ctx, grpclog.Fields{})
+	}
+	extractFieldMap := func(ctx context.Context) map[string]string {
+		raw := grpclog.ExtractFields(ctx)
+		m := make(map[string]string, len(raw)/2)
+		for i := 0; i+1 < len(raw); i += 2 {
+			if k, ok := raw[i].(string); ok {
+				if v, ok := raw[i+1].(string); ok {
+					m[k] = v
+				}
+			}
+		}
+		return m
+	}
+
+	t.Run("OK injects client, code, namespace, and headers", func(t *testing.T) {
+		svc := NewService(tracing.InitializeTracerForTest())
+		svc.RegisterClient(&mockClient{
+			name:       "ext_jwt",
+			testResult: true,
+			authResponse: &authnv1.AuthenticateResponse{
+				Code:  authnv1.AuthenticateCode_AUTHENTICATE_CODE_OK,
+				Token: "tok",
+			},
+		})
+
+		ctx := grpcCtx(t.Context())
+		req := &authnv1.AuthenticateRequest{
+			Namespace:   "stacks-123",
+			HttpHeaders: map[string]string{"Authorization": "Bearer xxx", "X-Grafana-Id": "id-token"},
+		}
+
+		_, err := svc.Authenticate(ctx, req)
+		require.NoError(t, err)
+
+		fields := extractFieldMap(ctx)
+		assert.Equal(t, "ext_jwt", fields["authn.client"])
+		assert.Equal(t, authnv1.AuthenticateCode_AUTHENTICATE_CODE_OK.String(), fields["authn.code"])
+		assert.Equal(t, "stacks-123", fields["authn.namespace"])
+		assert.Equal(t, "Authorization,X-Grafana-Id", fields["authn.headers"])
+	})
+
+	t.Run("no match injects none client and NOT_HANDLED code", func(t *testing.T) {
+		svc := NewService(tracing.InitializeTracerForTest())
+		svc.RegisterClient(&mockClient{name: "ext_jwt", testResult: false})
+
+		ctx := grpcCtx(t.Context())
+		req := &authnv1.AuthenticateRequest{Namespace: "stacks-123"}
+
+		_, err := svc.Authenticate(ctx, req)
+		require.NoError(t, err)
+
+		fields := extractFieldMap(ctx)
+		assert.Equal(t, "none", fields["authn.client"])
+		assert.Equal(t, authnv1.AuthenticateCode_AUTHENTICATE_CODE_NOT_HANDLED.String(), fields["authn.code"])
+		assert.Equal(t, "", fields["authn.headers"])
+	})
+
+	t.Run("error injects client and namespace", func(t *testing.T) {
+		svc := NewService(tracing.InitializeTracerForTest())
+		svc.RegisterClient(&mockClient{
+			name:       "ext_jwt",
+			testResult: true,
+			authError:  fmt.Errorf("boom"),
+		})
+
+		ctx := grpcCtx(t.Context())
+		req := &authnv1.AuthenticateRequest{
+			Namespace:   "stacks-456",
+			HttpHeaders: map[string]string{"Authorization": "Bearer xxx"},
+		}
+
+		_, err := svc.Authenticate(ctx, req)
+		require.Error(t, err)
+
+		fields := extractFieldMap(ctx)
+		assert.Equal(t, "ext_jwt", fields["authn.client"])
+		assert.Equal(t, "stacks-456", fields["authn.namespace"])
+		assert.Equal(t, "Authorization", fields["authn.headers"])
+	})
 }


### PR DESCRIPTION
## Why
The authn gRPC server currently only logs on error. When investigating authentication issues (e.g. which client handled a request, whether credentials were even present), there's no easy way to filter or correlate in Loki without adding verbose standalone log lines.
## Summary
Piggybacks on the existing gRPC logging interceptor (`go-grpc-middleware/v2`) by calling `grpclog.AddFields` inside `Service.Authenticate`. This enriches the interceptor's "finished call" log line with:
- `authn.client` -- which client handled the request (e.g. `ext_jwt`), or `"none"` if no client matched
- `authn.code` -- the authentication response code (e.g. `AUTHENTICATE_CODE_OK`, `AUTHENTICATE_CODE_FAILED`)
- `authn.namespace` -- the request namespace (e.g. `stacks-123`)
- `authn.headers` -- comma-separated names of HTTP headers sent in the request (values excluded for security)
No new log lines are added -- the fields appear on the existing gRPC interceptor output.
**Prerequisite:** `EnableLogging` must be `true` for the gRPC server config for these fields to appear in logs.
**Related:** https://github.com/grafana/identity-access-team/issues/1953