### PR TITLE
Meticulous: Only run tests on frontend PRs

### DIFF
--- a/.github/workflows/pr-build-grafana.yml
+++ b/.github/workflows/pr-build-grafana.yml
@@ -21,6 +21,7 @@ jobs:
       contents: read
     outputs:
       changed: ${{ steps.detect-changes.outputs.frontend == 'true' || steps.detect-changes.outputs.backend == 'true' }}
+      frontend: ${{ steps.detect-changes.outputs.frontend }}
     steps:
       - uses: actions/checkout@v5
         with:
@@ -135,8 +136,8 @@ jobs:
            -f "output[text]=${IMAGE}"
 
   run-meticulous-tests:
-    if: github.repository == 'grafana/grafana'
-    needs: push-docker-image
+    if: github.repository == 'grafana/grafana' && needs.detect-changes.outputs.frontend == 'true'
+    needs: [push-docker-image, detect-changes]
     name: Run Meticulous tests
     runs-on: ubuntu-x64-small
     continue-on-error: true


### PR DESCRIPTION
Per our conversation with the vendor, we would like to scope the PR runs down to only be on PRs which have frontend changes. The backend is mocked in Meticulous tests anyway.