### PR TITLE
`iam`: Add metrics and traces to the Storage Wrapper

### DIFF
--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -531,7 +531,11 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateTeamBindingsAPIGroup(opts bui
 		}
 	}
 
-	authzWrapper := storewrapper.New(teamBindingStore, iamauthorizer.NewTeamBindingAuthorizer(b.accessClient))
+	authzWrapper := storewrapper.New(
+		teamBindingStore,
+		teamBindingResource.GroupResource(),
+		iamauthorizer.NewTeamBindingAuthorizer(b.accessClient),
+	)
 	storage[teamBindingResource.StoragePath()] = authzWrapper
 	if b.teamSearch != nil {
 		b.teamSearch.teamBindingStore = authzWrapper
@@ -573,7 +577,12 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateUsersAPIGroup(opts builder.AP
 	}
 
 	b.userGetter = userStore
-	storage[userResource.StoragePath()] = storewrapper.New(userStore, user.NewStoreWrapper(b.cfgProvider, b.settingService), storewrapper.WithPreserveIdentity())
+	storage[userResource.StoragePath()] = storewrapper.New(
+		userStore,
+		iamv0.UserResourceInfo.GroupResource(),
+		user.NewStoreWrapper(b.cfgProvider, b.settingService),
+		storewrapper.WithPreserveIdentity(),
+	)
 
 	if b.dual != nil && b.unified != nil {
 		teamSearchClient := resource.NewSearchClient(
@@ -695,7 +704,11 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateResourcePermissionsAPIGroup(
 		}
 	}
 
-	authzWrapper := storewrapper.New(regStoreDW, iamauthorizer.NewResourcePermissionsAuthorizer(b.accessClient, b.resourceParentProvider))
+	authzWrapper := storewrapper.New(
+		regStoreDW,
+		iamv0.ResourcePermissionInfo.GroupResource(),
+		iamauthorizer.NewResourcePermissionsAuthorizer(b.accessClient, b.resourceParentProvider),
+	)
 
 	storage[iamv0.ResourcePermissionInfo.StoragePath()] = authzWrapper
 

--- a/pkg/services/apiserver/appinstaller/server.go
+++ b/pkg/services/apiserver/appinstaller/server.go
@@ -129,7 +129,7 @@ func (s *serverWrapper) configureStorage(gr schema.GroupResource, dualWriteSuppo
 			if provider, ok := s.installer.(NamespaceScopedStorageAuthorizerProvider); ok {
 				authz := provider.GetNamespaceScopedStorageAuthorizer(gr)
 				if authz != nil {
-					return storewrapper.New(gs, authz)
+					return storewrapper.New(gs, gr, authz)
 				}
 			}
 
@@ -160,7 +160,7 @@ func (s *serverWrapper) configureStorage(gr schema.GroupResource, dualWriteSuppo
 			authz = &storewrapper.DenyAuthorizer{}
 		}
 
-		return storewrapper.New(gs, authz)
+		return storewrapper.New(gs, gr, authz)
 	}
 
 	// if the storage is a status store, we need to extract the underlying generic registry store

--- a/pkg/services/apiserver/auth/authorizer/storewrapper/wrapper.go
+++ b/pkg/services/apiserver/auth/authorizer/storewrapper/wrapper.go
@@ -7,13 +7,19 @@ import (
 	"sync"
 	"time"
 
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+	"go.opentelemetry.io/otel/trace/noop"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
 	k8srest "k8s.io/apiserver/pkg/registry/rest"
 
+	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apiserver/rest"
 )
@@ -24,9 +30,27 @@ var (
 	ErrUnexpectedType  = errors.NewBadRequest("unexpected object type")
 )
 
+const (
+	tracerName = "github.com/grafana/grafana/pkg/services/apiserver/auth/authorizer/storewrapper"
+
+	OpBeforeCreate      = "before_create"
+	OpCreate            = "create"
+	OpBeforeDelete      = "before_delete"
+	OpDelete            = "delete"
+	OpDeleteGet         = "delete_get"
+	OpGet               = "get"
+	OpList              = "list"
+	OpBeforeUpdate      = "before_update"
+	OpUpdate            = "update"
+	OpAfterGet          = "after_get"
+	OpFilterList        = "filter_list"
+	OpWatchFilter       = "watch_filter"
+	OpFilterWatchEvents = "filter_watch_events"
+	OpSendWatchEvents   = "send_watch_events"
+)
+
 // WatchEventFilter is a batch filter for watch events. Given a slice of
 // data-carrying events (Added, Modified, Deleted) it returns a same-length bool
-// slice indicating which events to forward. Returning an error terminates the watch.
 // Implementations are called from a single goroutine and need not be concurrency-safe.
 type WatchEventFilter func(events []watch.Event) ([]bool, error)
 
@@ -48,7 +72,6 @@ func isPassThroughWatchFilter(filter WatchEventFilter) bool {
 	return reflect.ValueOf(filter).Pointer() == reflect.ValueOf(PassThroughWatchFilter).Pointer()
 }
 
-// ResourceStorageAuthorizer defines authorization hooks for resource storage operations.
 type ResourceStorageAuthorizer interface {
 	BeforeCreate(ctx context.Context, obj runtime.Object) error
 	BeforeUpdate(ctx context.Context, oldObj, obj runtime.Object) error
@@ -65,6 +88,22 @@ type ResourceStorageAuthorizer interface {
 	WatchFilter(ctx context.Context) (WatchEventFilter, error)
 }
 
+// Layer constants distinguish the two timing slices the wrapper records.
+// Consumers map these to whatever histogram label scheme they want.
+const (
+	LayerAuthz = "store_wrapper_authz" // Authorization hook (BeforeCreate, BeforeUpdate, BeforeDelete, AfterGet, FilterList).
+	LayerInner = "store_wrapper_inner" // Inner store call (Create, Get, List, Update, Delete, Watch).
+)
+
+// Observer records wrapper latency for authorization hooks and inner store calls.
+type Observer interface {
+	Observe(layer, op string, resource schema.GroupResource, dur time.Duration, status string)
+}
+
+type noopObserver struct{}
+
+func (noopObserver) Observe(string, string, schema.GroupResource, time.Duration, string) {}
+
 // Wrapper is a k8sStorage (e.g. registry.Store) wrapper that enforces authorization based on ResourceStorageAuthorizer.
 // It overrides the identity in the context to use service identity for the underlying store operations so the
 // store's authorization always succeeds and the wrapper enforces authorization. The wrapper injects the original
@@ -75,6 +114,9 @@ type Wrapper struct {
 	inner              K8sStorage
 	authorizer         ResourceStorageAuthorizer
 	preserveIdentity   bool
+	tracer             trace.Tracer
+	observer           Observer
+	resource           schema.GroupResource
 	watchFlushInterval time.Duration
 }
 
@@ -102,6 +144,24 @@ func WithWatchFlushInterval(d time.Duration) Option {
 	}
 }
 
+// WithTracer configures tracing for wrapper operations.
+func WithTracer(t trace.Tracer) Option {
+	return func(w *Wrapper) {
+		if t != nil {
+			w.tracer = t
+		}
+	}
+}
+
+// WithObserver configures metrics observation for wrapper operations.
+func WithObserver(observer Observer) Option {
+	return func(w *Wrapper) {
+		if observer != nil {
+			w.observer = observer
+		}
+	}
+}
+
 type K8sStorage interface {
 	k8srest.Storage
 	k8srest.Scoper
@@ -117,8 +177,14 @@ var _ k8srest.Watcher = (*Wrapper)(nil)
 
 // New returns a Wrapper that enforces authorization and uses service identity for inner store calls,
 // injecting the original user's UID for createdBy/updatedBy annotations.
-func New(store K8sStorage, authz ResourceStorageAuthorizer, opts ...Option) *Wrapper {
-	w := &Wrapper{inner: store, authorizer: authz}
+func New(store K8sStorage, resource schema.GroupResource, authz ResourceStorageAuthorizer, opts ...Option) *Wrapper {
+	w := &Wrapper{
+		inner:      store,
+		authorizer: authz,
+		resource:   resource,
+		tracer:     noop.NewTracerProvider().Tracer(tracerName),
+		observer:   noopObserver{},
+	}
 	for _, opt := range opts {
 		opt(w)
 	}
@@ -141,52 +207,140 @@ func (w *Wrapper) storeCtx(ctx context.Context) context.Context {
 	return srvCtx
 }
 
+func startSpan(ctx context.Context, tracer trace.Tracer, resource schema.GroupResource, method string) (context.Context, trace.Span) {
+	return tracer.Start(ctx, "authz.storewrapper."+method, trace.WithAttributes(
+		attribute.String("resource.group", resource.Group),
+		attribute.String("resource.resource", resource.Resource),
+	))
+}
+
+func (w *Wrapper) startSpan(ctx context.Context, method string) (context.Context, trace.Span) {
+	return startSpan(ctx, w.tracer, w.resource, method)
+}
+
+func (w *Wrapper) observeAuthz(op string, start time.Time, err error) {
+	w.observer.Observe(LayerAuthz, op, w.resource, time.Since(start), statusFromError(err))
+}
+
+func (w *Wrapper) observeInner(op string, start time.Time, err error) {
+	w.observer.Observe(LayerInner, op, w.resource, time.Since(start), statusFromError(err))
+}
+
+func recordSpanError(span trace.Span, err error) {
+	if err == nil {
+		return
+	}
+	span.RecordError(err)
+	span.SetStatus(codes.Error, err.Error())
+}
+
+func statusFromError(err error) string {
+	if err == nil {
+		return "success"
+	}
+	if errors.IsForbidden(err) {
+		return "forbidden"
+	}
+	if errors.IsUnauthorized(err) {
+		return "unauthorized"
+	}
+	if errors.IsNotFound(err) {
+		return "not_found"
+	}
+	if errors.IsMethodNotSupported(err) {
+		return "method_not_supported"
+	}
+	if errors.IsConflict(err) {
+		return "conflict"
+	}
+	if errors.IsBadRequest(err) {
+		return "bad_request"
+	}
+	return "error"
+}
+
 func (w *Wrapper) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metaV1.Table, error) {
 	return w.inner.ConvertToTable(ctx, object, tableOptions)
 }
 
-func (w *Wrapper) Create(ctx context.Context, obj runtime.Object, createValidation k8srest.ValidateObjectFunc, options *metaV1.CreateOptions) (runtime.Object, error) {
+func (w *Wrapper) Create(ctx context.Context, obj runtime.Object, createValidation k8srest.ValidateObjectFunc, options *metaV1.CreateOptions) (result runtime.Object, err error) {
+	ctx, span := w.startSpan(ctx, "Create")
+	defer func() {
+		recordSpanError(span, err)
+		span.End()
+	}()
+
 	// Enforce authorization based on the user permissions before creating the object
-	err := w.authorizer.BeforeCreate(ctx, obj)
+	authzStart := time.Now()
+	err = w.authorizer.BeforeCreate(ctx, obj)
+	w.observeAuthz(OpBeforeCreate, authzStart, err)
 	if err != nil {
 		return nil, err
 	}
 
-	return w.inner.Create(w.storeCtx(ctx), obj, createValidation, options)
+	innerStart := time.Now()
+	result, err = w.inner.Create(w.storeCtx(ctx), obj, createValidation, options)
+	w.observeInner(OpCreate, innerStart, err)
+	return result, err
 }
 
-func (w *Wrapper) Delete(ctx context.Context, name string, deleteValidation k8srest.ValidateObjectFunc, options *metaV1.DeleteOptions) (runtime.Object, bool, error) {
+func (w *Wrapper) Delete(ctx context.Context, name string, deleteValidation k8srest.ValidateObjectFunc, options *metaV1.DeleteOptions) (result runtime.Object, deleted bool, err error) {
+	ctx, span := w.startSpan(ctx, "Delete")
+	defer func() {
+		recordSpanError(span, err)
+		span.End()
+	}()
+
 	// Fetch the object first to authorize
 	storeCtx := w.storeCtx(ctx)
 	getOpts := &metaV1.GetOptions{TypeMeta: options.TypeMeta}
 	if options.Preconditions != nil {
 		getOpts.ResourceVersion = *options.Preconditions.ResourceVersion
 	}
-	obj, err := w.inner.Get(storeCtx, name, getOpts)
+	innerGetStart := time.Now()
+	var obj runtime.Object
+	obj, err = w.inner.Get(storeCtx, name, getOpts)
+	w.observeInner(OpDeleteGet, innerGetStart, err)
 	if err != nil {
 		return nil, false, err
 	}
 
 	// Enforce authorization based on the user permissions
-	if err := w.authorizer.BeforeDelete(ctx, obj); err != nil {
+	authzStart := time.Now()
+	err = w.authorizer.BeforeDelete(ctx, obj)
+	w.observeAuthz(OpBeforeDelete, authzStart, err)
+	if err != nil {
 		return nil, false, err
 	}
 
-	return w.inner.Delete(storeCtx, name, deleteValidation, options)
+	innerStart := time.Now()
+	result, deleted, err = w.inner.Delete(storeCtx, name, deleteValidation, options)
+	w.observeInner(OpDelete, innerStart, err)
+	return result, deleted, err
 }
 
 func (w *Wrapper) Destroy() {
 	w.inner.Destroy()
 }
 
-func (w *Wrapper) Get(ctx context.Context, name string, options *metaV1.GetOptions) (runtime.Object, error) {
-	item, err := w.inner.Get(w.storeCtx(ctx), name, options)
+func (w *Wrapper) Get(ctx context.Context, name string, options *metaV1.GetOptions) (item runtime.Object, err error) {
+	ctx, span := w.startSpan(ctx, "Get")
+	defer func() {
+		recordSpanError(span, err)
+		span.End()
+	}()
+
+	innerStart := time.Now()
+	item, err = w.inner.Get(w.storeCtx(ctx), name, options)
+	w.observeInner(OpGet, innerStart, err)
 	if err != nil {
 		return nil, err
 	}
 
 	// Enforce authorization based on the user permissions after retrieving the object
+	authzStart := time.Now()
 	err = w.authorizer.AfterGet(ctx, item)
+	w.observeAuthz(OpAfterGet, authzStart, err)
 	if err != nil {
 		return nil, err
 	}
@@ -197,14 +351,26 @@ func (w *Wrapper) GetSingularName() string {
 	return w.inner.GetSingularName()
 }
 
-func (w *Wrapper) List(ctx context.Context, options *internalversion.ListOptions) (runtime.Object, error) {
-	list, err := w.inner.List(w.storeCtx(ctx), options)
+func (w *Wrapper) List(ctx context.Context, options *internalversion.ListOptions) (result runtime.Object, err error) {
+	ctx, span := w.startSpan(ctx, "List")
+	defer func() {
+		recordSpanError(span, err)
+		span.End()
+	}()
+
+	innerStart := time.Now()
+	var list runtime.Object
+	list, err = w.inner.List(w.storeCtx(ctx), options)
+	w.observeInner(OpList, innerStart, err)
 	if err != nil {
 		return nil, err
 	}
 
 	// Enforce authorization based on the user permissions after retrieving the list
-	return w.authorizer.FilterList(ctx, list)
+	authzStart := time.Now()
+	result, err = w.authorizer.FilterList(ctx, list)
+	w.observeAuthz(OpFilterList, authzStart, err)
+	return result, err
 }
 
 func (w *Wrapper) NamespaceScoped() bool {
@@ -227,74 +393,114 @@ func (w *Wrapper) Update(
 	updateValidation k8srest.ValidateObjectUpdateFunc,
 	forceAllowCreate bool,
 	options *metaV1.UpdateOptions,
-) (runtime.Object, bool, error) {
+) (result runtime.Object, updated bool, err error) {
+	ctx, span := w.startSpan(ctx, "Update")
+	defer func() {
+		recordSpanError(span, err)
+		span.End()
+	}()
+
 	// Create a wrapper around UpdatedObjectInfo to inject authorization
 	wrappedObjInfo := &authorizedUpdateInfo{
 		inner:      objInfo,
 		authorizer: w.authorizer,
 		userCtx:    ctx, // Keep original context for authorization
+		tracer:     w.tracer,
+		observer:   w.observer,
+		resource:   w.resource,
 	}
 
-	return w.inner.Update(w.storeCtx(ctx), name, wrappedObjInfo, createValidation, updateValidation, forceAllowCreate, options)
+	innerStart := time.Now()
+	result, updated, err = w.inner.Update(w.storeCtx(ctx), name, wrappedObjInfo, createValidation, updateValidation, forceAllowCreate, options)
+	// Technically also includes the authorizer time, but it's not worth the complexity to split it out.
+	w.observeInner(OpUpdate, innerStart, err)
+	return result, updated, err
 }
 
 type authorizedUpdateInfo struct {
 	inner      k8srest.UpdatedObjectInfo
 	authorizer ResourceStorageAuthorizer
 	userCtx    context.Context
+	tracer     trace.Tracer
+	observer   Observer
+	resource   schema.GroupResource
 }
 
 func (a *authorizedUpdateInfo) Preconditions() *metaV1.Preconditions {
 	return a.inner.Preconditions()
 }
 
-func (a *authorizedUpdateInfo) UpdatedObject(ctx context.Context, oldObj runtime.Object) (runtime.Object, error) {
+func (a *authorizedUpdateInfo) UpdatedObject(ctx context.Context, oldObj runtime.Object) (updatedObj runtime.Object, err error) {
 	// Get the updated object
-	updatedObj, err := a.inner.UpdatedObject(ctx, oldObj)
+	updatedObj, err = a.inner.UpdatedObject(ctx, oldObj)
 	if err != nil {
 		return nil, err
 	}
 
 	// Enforce authorization using the original user context
-	if err := a.authorizer.BeforeUpdate(a.userCtx, oldObj, updatedObj); err != nil {
+	authzCtx, span := startSpan(a.userCtx, a.tracer, a.resource, "UpdateAuthz")
+	defer func() {
+		recordSpanError(span, err)
+		span.End()
+	}()
+
+	authzStart := time.Now()
+	err = a.authorizer.BeforeUpdate(authzCtx, oldObj, updatedObj)
+	a.observer.Observe(LayerAuthz, OpBeforeUpdate, a.resource, time.Since(authzStart), statusFromError(err))
+	if err != nil {
 		return nil, err
 	}
 
 	return updatedObj, nil
 }
 
-func (w *Wrapper) Watch(ctx context.Context, options *internalversion.ListOptions) (watch.Interface, error) {
+func (w *Wrapper) Watch(ctx context.Context, options *internalversion.ListOptions) (result watch.Interface, err error) {
+	ctx, span := w.startSpan(ctx, "WatchSetup")
+	defer func() {
+		recordSpanError(span, err)
+		span.End()
+	}()
+
 	// Check if the underlying storage supports Watch
 	watcher, ok := w.inner.(k8srest.Watcher)
 	if !ok {
-		return nil, fmt.Errorf("watch is not supported on the underlying storage")
+		err = fmt.Errorf("watch is not supported on the underlying storage")
+		return nil, err
 	}
 
 	// Build the filter once, before starting the watch, so callers get an immediate
 	// error if authorization state cannot be resolved (e.g. auth backend unavailable).
-	filter, err := w.authorizer.WatchFilter(ctx)
+	var filter WatchEventFilter
+	watchFilterStart := time.Now()
+	filter, err = w.authorizer.WatchFilter(ctx)
+	w.observeAuthz(OpWatchFilter, watchFilterStart, err)
 	if err != nil {
 		return nil, err
 	}
 	// Fail-closed: a nil filter is treated as RejectAllWatchFilter.
 	// Implementors should return PassThroughWatchFilter explicitly for unrestricted resources.
 	if filter == nil {
-		return nil, errors.NewUnauthorized("watch filter not implemented")
+		err = errors.NewUnauthorized("watch filter not implemented")
+		return nil, err
 	}
 
 	// Call the underlying storage's Watch method
-	inner, err := watcher.Watch(w.storeCtx(ctx), options)
+	var inner watch.Interface
+	inner, err = watcher.Watch(w.storeCtx(ctx), options)
 	if err != nil {
 		return nil, err
 	}
 
 	if isPassThroughWatchFilter(filter) {
+		span.SetAttributes(attribute.Bool("filtered", false))
 		return inner, nil
 	}
 
 	// Return a new filtered watcher that runs the filter over the buffered events
 	// and forwards the events to the caller.
-	return newFilteredWatcher(ctx, inner, filter, w.watchFlushInterval), nil
+	result = newFilteredWatcher(ctx, w.tracer, w.observer, w.resource, inner, filter, w.watchFlushInterval)
+	span.SetAttributes(attribute.Bool("filtered", true))
+	return result, nil
 }
 
 // filteredWatcher wraps a watch.Interface and runs the WatchEventFilter over
@@ -306,6 +512,9 @@ func (w *Wrapper) Watch(ctx context.Context, options *internalversion.ListOption
 // and flushed either when the buffer is full or the ticker fires, amortizing the
 // cost of expensive filter implementations (e.g. BatchCheck RPCs) across bursts.
 type filteredWatcher struct {
+	tracer        trace.Tracer
+	observer      Observer
+	resource      schema.GroupResource
 	inner         watch.Interface  // The underlying watch.Interface.
 	filter        WatchEventFilter // Filter to apply to the buffered events.
 	flushInterval time.Duration    // The interval to flush the buffered events.
@@ -322,8 +531,17 @@ const watchBatchSize = 100
 // defaultSendTimeout is the timeout for sending an event to the caller.
 var defaultSendTimeout = 1 * time.Second
 
-func newFilteredWatcher(ctx context.Context, inner watch.Interface, filter WatchEventFilter, flushInterval time.Duration) *filteredWatcher {
+func newFilteredWatcher(ctx context.Context,
+	tracer trace.Tracer,
+	observer Observer,
+	resource schema.GroupResource,
+	inner watch.Interface,
+	filter WatchEventFilter,
+	flushInterval time.Duration) *filteredWatcher {
 	fw := &filteredWatcher{
+		tracer:        tracer,
+		observer:      observer,
+		resource:      resource,
 		inner:         inner,
 		filter:        filter,
 		flushInterval: flushInterval,
@@ -369,20 +587,48 @@ func (fw *filteredWatcher) sendEvent(ctx context.Context, event watch.Event) sen
 	}
 }
 
-func (fw *filteredWatcher) filterEvents(pending []watch.Event) ([]bool, error) {
-	allowed, err := fw.filter(pending)
-	if err == nil && len(allowed) != len(pending) {
-		err = fmt.Errorf("watch filter contract violation: returned %d entries for %d events", len(allowed), len(pending))
+func (fw *filteredWatcher) filterEvents(ctx context.Context, pending []watch.Event) (allowed []bool, err error) {
+	_, span := startSpan(ctx, fw.tracer, fw.resource, "Watch.FilterEvents")
+	span.SetAttributes(attribute.Int("events_count", len(pending)))
+	defer func(startTime time.Time) {
+		recordSpanError(span, err)
+		fw.observer.Observe(LayerAuthz, OpFilterWatchEvents, fw.resource, time.Since(startTime), statusFromError(err))
+		span.End()
+	}(time.Now())
+
+	allowed, err = fw.filter(pending)
+	if err != nil {
+		return nil, err
 	}
-	return allowed, err
+
+	if len(allowed) != len(pending) {
+		return nil, fmt.Errorf("watch filter contract violation: returned %d entries for %d events", len(allowed), len(pending))
+	}
+	return allowed, nil
 }
 
 func (fw *filteredWatcher) sendAllowed(ctx context.Context, pending []watch.Event, allowed []bool) bool {
+	_, span := startSpan(ctx, fw.tracer, fw.resource, "Watch.SendEvents")
+	sent := 0
+	result := sendEventSuccess
+
+	defer func(startTime time.Time) {
+		span.SetAttributes(attribute.String("send_result", string(result)))
+		span.SetAttributes(attribute.Int("sent_count", sent))
+		if result == sendEventTimeout {
+			recordSpanError(span, errutil.Internal("watch event send timed out"))
+		}
+		span.End()
+		fw.observer.Observe(LayerInner, OpSendWatchEvents, fw.resource, time.Since(startTime), string(result))
+	}(time.Now())
+
 	for i, event := range pending {
 		if allowed[i] {
-			if fw.sendEvent(ctx, event) != sendEventSuccess {
+			result = fw.sendEvent(ctx, event)
+			if result != sendEventSuccess {
 				return false
 			}
+			sent++
 		}
 	}
 	return true
@@ -393,7 +639,7 @@ func (fw *filteredWatcher) flush(ctx context.Context) bool {
 		return true
 	}
 
-	allowed, err := fw.filterEvents(fw.pending)
+	allowed, err := fw.filterEvents(ctx, fw.pending)
 	if err != nil {
 		errEvent := watch.Event{Type: watch.Error, Object: &metaV1.Status{Status: metaV1.StatusFailure, Message: err.Error()}}
 		_ = fw.sendEvent(ctx, errEvent)

--- a/pkg/services/apiserver/auth/authorizer/storewrapper/wrapper.go
+++ b/pkg/services/apiserver/auth/authorizer/storewrapper/wrapper.go
@@ -47,6 +47,8 @@ const (
 	OpWatchFilter       = "watch_filter"
 	OpFilterWatchEvents = "filter_watch_events"
 	OpSendWatchEvents   = "send_watch_events"
+
+	defaultWatchSendTimeout = 1 * time.Second
 )
 
 // WatchEventFilter is a batch filter for watch events. Given a slice of
@@ -118,6 +120,7 @@ type Wrapper struct {
 	observer           Observer
 	resource           schema.GroupResource
 	watchFlushInterval time.Duration
+	watchSendTimeout   time.Duration
 }
 
 // Option configures a Wrapper.
@@ -141,6 +144,15 @@ func WithPreserveIdentity() Option {
 func WithWatchFlushInterval(d time.Duration) Option {
 	return func(w *Wrapper) {
 		w.watchFlushInterval = d
+	}
+}
+
+// WithWatchSendTimeout configures how long to wait when sending an event to the caller.
+// If the caller fails to receive the event within this timeframe (default 1s),
+// it is considered too slow, which will stop the watcher and return an error.
+func WithWatchSendTimeout(d time.Duration) Option {
+	return func(w *Wrapper) {
+		w.watchSendTimeout = d
 	}
 }
 
@@ -179,11 +191,12 @@ var _ k8srest.Watcher = (*Wrapper)(nil)
 // injecting the original user's UID for createdBy/updatedBy annotations.
 func New(store K8sStorage, resource schema.GroupResource, authz ResourceStorageAuthorizer, opts ...Option) *Wrapper {
 	w := &Wrapper{
-		inner:      store,
-		authorizer: authz,
-		resource:   resource,
-		tracer:     noop.NewTracerProvider().Tracer(tracerName),
-		observer:   noopObserver{},
+		inner:            store,
+		authorizer:       authz,
+		resource:         resource,
+		tracer:           noop.NewTracerProvider().Tracer(tracerName),
+		observer:         noopObserver{},
+		watchSendTimeout: defaultWatchSendTimeout,
 	}
 	for _, opt := range opts {
 		opt(w)
@@ -446,6 +459,8 @@ func (a *authorizedUpdateInfo) UpdatedObject(ctx context.Context, oldObj runtime
 
 	authzStart := time.Now()
 	err = a.authorizer.BeforeUpdate(authzCtx, oldObj, updatedObj)
+	// OpUpdate includes OpBeforeUpdate latency (BeforeUpdate runs inside the inner
+	// store via UpdatedObject). We'll need to subtract OpBeforeUpdate for pure storage time.
 	a.observer.Observe(LayerAuthz, OpBeforeUpdate, a.resource, time.Since(authzStart), statusFromError(err))
 	if err != nil {
 		return nil, err
@@ -498,7 +513,7 @@ func (w *Wrapper) Watch(ctx context.Context, options *internalversion.ListOption
 
 	// Return a new filtered watcher that runs the filter over the buffered events
 	// and forwards the events to the caller.
-	result = newFilteredWatcher(ctx, w.tracer, w.observer, w.resource, inner, filter, w.watchFlushInterval)
+	result = newFilteredWatcher(ctx, w.tracer, w.observer, w.resource, inner, filter, w.watchFlushInterval, w.watchSendTimeout)
 	span.SetAttributes(attribute.Bool("filtered", true))
 	return result, nil
 }
@@ -522,14 +537,12 @@ type filteredWatcher struct {
 	stopOnce      sync.Once        // Ensures Stop() is called only once to prevent race conditions.
 	done          chan struct{}    // Closed when the watcher Stop() method is called.
 	pending       []watch.Event    // Buffered events awaiting flush; only accessed from run goroutine.
+	sendTimeout   time.Duration    // The timeout for sending an event to the caller.
 }
 
 // watchBatchSize is the maximum number of events buffered before a forced flush.
 // Matches watch.DefaultChanSize so the batch can never exceed the inner channel capacity.
 const watchBatchSize = 100
-
-// defaultSendTimeout is the timeout for sending an event to the caller.
-var defaultSendTimeout = 1 * time.Second
 
 func newFilteredWatcher(ctx context.Context,
 	tracer trace.Tracer,
@@ -537,7 +550,8 @@ func newFilteredWatcher(ctx context.Context,
 	resource schema.GroupResource,
 	inner watch.Interface,
 	filter WatchEventFilter,
-	flushInterval time.Duration) *filteredWatcher {
+	flushInterval time.Duration,
+	sendTimeout time.Duration) *filteredWatcher {
 	fw := &filteredWatcher{
 		tracer:        tracer,
 		observer:      observer,
@@ -547,6 +561,7 @@ func newFilteredWatcher(ctx context.Context,
 		flushInterval: flushInterval,
 		result:        make(chan watch.Event, watch.DefaultChanSize),
 		done:          make(chan struct{}),
+		sendTimeout:   sendTimeout,
 	}
 	go fw.run(ctx)
 	return fw
@@ -565,7 +580,7 @@ const (
 func (fw *filteredWatcher) sendEvent(ctx context.Context, event watch.Event) sendEventResult {
 	// If we could not send the event on time, emit an Error
 	// and shut down to release backpressure on the inner storage.
-	timer := time.NewTimer(defaultSendTimeout)
+	timer := time.NewTimer(fw.sendTimeout)
 	select {
 	case <-ctx.Done(): // User context is done.
 		return sendEventStopped

--- a/pkg/services/apiserver/auth/authorizer/storewrapper/wrapper.go
+++ b/pkg/services/apiserver/auth/authorizer/storewrapper/wrapper.go
@@ -53,6 +53,7 @@ const (
 
 // WatchEventFilter is a batch filter for watch events. Given a slice of
 // data-carrying events (Added, Modified, Deleted) it returns a same-length bool
+// slice indicating which events to forward. Returning an error terminates the watch.
 // Implementations are called from a single goroutine and need not be concurrency-safe.
 type WatchEventFilter func(events []watch.Event) ([]bool, error)
 
@@ -74,6 +75,7 @@ func isPassThroughWatchFilter(filter WatchEventFilter) bool {
 	return reflect.ValueOf(filter).Pointer() == reflect.ValueOf(PassThroughWatchFilter).Pointer()
 }
 
+// ResourceStorageAuthorizer defines authorization hooks for resource storage operations.
 type ResourceStorageAuthorizer interface {
 	BeforeCreate(ctx context.Context, obj runtime.Object) error
 	BeforeUpdate(ctx context.Context, oldObj, obj runtime.Object) error
@@ -144,15 +146,6 @@ func WithPreserveIdentity() Option {
 func WithWatchFlushInterval(d time.Duration) Option {
 	return func(w *Wrapper) {
 		w.watchFlushInterval = d
-	}
-}
-
-// WithWatchSendTimeout configures how long to wait when sending an event to the caller.
-// If the caller fails to receive the event within this timeframe (default 1s),
-// it is considered too slow, which will stop the watcher and return an error.
-func WithWatchSendTimeout(d time.Duration) Option {
-	return func(w *Wrapper) {
-		w.watchSendTimeout = d
 	}
 }
 
@@ -231,14 +224,6 @@ func (w *Wrapper) startSpan(ctx context.Context, method string) (context.Context
 	return startSpan(ctx, w.tracer, w.resource, method)
 }
 
-func (w *Wrapper) observeAuthz(op string, start time.Time, err error) {
-	w.observer.Observe(LayerAuthz, op, w.resource, time.Since(start), statusFromError(err))
-}
-
-func (w *Wrapper) observeInner(op string, start time.Time, err error) {
-	w.observer.Observe(LayerInner, op, w.resource, time.Since(start), statusFromError(err))
-}
-
 func recordSpanError(span trace.Span, err error) {
 	if err == nil {
 		return
@@ -247,29 +232,22 @@ func recordSpanError(span trace.Span, err error) {
 	span.SetStatus(codes.Error, err.Error())
 }
 
+func (w *Wrapper) observeAuthz(op string, start time.Time, err error) {
+	w.observer.Observe(LayerAuthz, op, w.resource, time.Since(start), statusFromError(err))
+}
+
+func (w *Wrapper) observeInner(op string, start time.Time, err error) {
+	w.observer.Observe(LayerInner, op, w.resource, time.Since(start), statusFromError(err))
+}
+
 func statusFromError(err error) string {
 	if err == nil {
-		return "success"
+		return metaV1.StatusSuccess
 	}
-	if errors.IsForbidden(err) {
-		return "forbidden"
+	if reason := errors.ReasonForError(err); reason != metaV1.StatusReasonUnknown {
+		return string(reason)
 	}
-	if errors.IsUnauthorized(err) {
-		return "unauthorized"
-	}
-	if errors.IsNotFound(err) {
-		return "not_found"
-	}
-	if errors.IsMethodNotSupported(err) {
-		return "method_not_supported"
-	}
-	if errors.IsConflict(err) {
-		return "conflict"
-	}
-	if errors.IsBadRequest(err) {
-		return "bad_request"
-	}
-	return "error"
+	return metaV1.StatusFailure
 }
 
 func (w *Wrapper) ConvertToTable(ctx context.Context, object runtime.Object, tableOptions runtime.Object) (*metaV1.Table, error) {
@@ -495,7 +473,7 @@ func (w *Wrapper) Watch(ctx context.Context, options *internalversion.ListOption
 	// Fail-closed: a nil filter is treated as RejectAllWatchFilter.
 	// Implementors should return PassThroughWatchFilter explicitly for unrestricted resources.
 	if filter == nil {
-		err = errors.NewUnauthorized("watch filter not implemented")
+		err = errors.NewUnauthorized("watch denied")
 		return nil, err
 	}
 
@@ -567,13 +545,22 @@ func newFilteredWatcher(ctx context.Context,
 	return fw
 }
 
-type sendEventResult string
+type sendEventResult int
 
 const (
-	sendEventSuccess sendEventResult = "success"
-	sendEventTimeout sendEventResult = "timeout"
-	sendEventStopped sendEventResult = "stopped"
+	sendEventSuccess sendEventResult = iota
+	sendEventTimeout
+	sendEventStopped
 )
+
+// statusFromSendResult converts a sendEventResult to a string status.
+// Use statuses consistent with the statusFromError function.
+func statusFromSendResult(r sendEventResult) string {
+	if r == sendEventTimeout {
+		return string(metaV1.StatusReasonTimeout)
+	}
+	return metaV1.StatusSuccess
+}
 
 // sendEvent forwards an event to the caller.
 // It returns if the user context is done or the watcher is stopped.
@@ -628,13 +615,13 @@ func (fw *filteredWatcher) sendAllowed(ctx context.Context, pending []watch.Even
 	result := sendEventSuccess
 
 	defer func(startTime time.Time) {
-		span.SetAttributes(attribute.String("send_result", string(result)))
+		span.SetAttributes(attribute.String("send_result", statusFromSendResult(result)))
 		span.SetAttributes(attribute.Int("sent_count", sent))
 		if result == sendEventTimeout {
 			recordSpanError(span, errutil.Internal("watch event send timed out"))
 		}
 		span.End()
-		fw.observer.Observe(LayerInner, OpSendWatchEvents, fw.resource, time.Since(startTime), string(result))
+		fw.observer.Observe(LayerInner, OpSendWatchEvents, fw.resource, time.Since(startTime), statusFromSendResult(result))
 	}(time.Now())
 
 	for i, event := range pending {

--- a/pkg/services/apiserver/auth/authorizer/storewrapper/wrapper_test.go
+++ b/pkg/services/apiserver/auth/authorizer/storewrapper/wrapper_test.go
@@ -144,8 +144,8 @@ func TestWrapper_Observer(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, expectedObj, result)
 		assert.Equal(t, []observerCall{
-			{layer: LayerAuthz, resource: resource, op: "before_create", status: "success"},
-			{layer: LayerInner, resource: resource, op: "create", status: "success"},
+			{layer: LayerAuthz, resource: resource, op: "before_create", status: metaV1.StatusSuccess},
+			{layer: LayerInner, resource: resource, op: "create", status: metaV1.StatusSuccess},
 		}, observer.calls)
 	})
 
@@ -165,7 +165,7 @@ func TestWrapper_Observer(t *testing.T) {
 		require.Error(t, err)
 		assert.Nil(t, result)
 		assert.Equal(t, []observerCall{
-			{layer: LayerAuthz, resource: resource, op: "before_create", status: "unauthorized"},
+			{layer: LayerAuthz, resource: resource, op: "before_create", status: string(metaV1.StatusReasonUnauthorized)},
 		}, observer.calls)
 		mockStore.AssertNotCalled(t, "Create")
 	})

--- a/pkg/services/apiserver/auth/authorizer/storewrapper/wrapper_test.go
+++ b/pkg/services/apiserver/auth/authorizer/storewrapper/wrapper_test.go
@@ -146,7 +146,7 @@ func TestWrapper_Observer(t *testing.T) {
 		assert.Equal(t, []observerCall{
 			{layer: LayerAuthz, resource: resource, op: "before_create", status: "success"},
 			{layer: LayerInner, resource: resource, op: "create", status: "success"},
-		}, observer.callsWithoutDuration())
+		}, observer.calls)
 	})
 
 	t.Run("records authz failure without inner call", func(t *testing.T) {
@@ -166,7 +166,7 @@ func TestWrapper_Observer(t *testing.T) {
 		assert.Nil(t, result)
 		assert.Equal(t, []observerCall{
 			{layer: LayerAuthz, resource: resource, op: "before_create", status: "unauthorized"},
-		}, observer.callsWithoutDuration())
+		}, observer.calls)
 		mockStore.AssertNotCalled(t, "Create")
 	})
 }
@@ -824,14 +824,14 @@ func TestWrapper_Watch(t *testing.T) {
 
 		setup.mockAuth.On("WatchFilter", mock.Anything).Return(allowAllWatchFilter, nil)
 
+		w, err := setup.wrapper.Watch(setup.ctx, &internalversion.ListOptions{})
+		require.NoError(t, err)
+
 		// Fill the inner channel buffer without ever reading from w.ResultChan().
 		// Wrapper watcher result channel will be blocked at DefaultChanSize.
 		for i := int32(0); i < watch.DefaultChanSize*2; i++ {
 			inner.push(watch.Event{Type: watch.Added, Object: &fakeObject{ObjectMeta: metaV1.ObjectMeta{Name: "item"}}})
 		}
-
-		w, err := setup.wrapper.Watch(setup.ctx, &internalversion.ListOptions{})
-		require.NoError(t, err)
 
 		// Wait for the send timeout to trigger. Use a generous overall timeout
 		// because the run goroutine must first process ~100 events through the
@@ -985,9 +985,9 @@ func (f *fakeWatcherStorage) Watch(ctx context.Context, _ *internalversion.ListO
 // need to push events without racing on Stop (watch.FakeWatcher's Add/Stop are
 // not safe to call concurrently).
 type pumpedWatcher struct {
-	ch       chan watch.Event
-	stopOnce sync.Once
-	done     atomic.Bool
+	ch   chan watch.Event
+	mu   sync.Mutex
+	done atomic.Bool
 }
 
 func newPumpedWatcher(buffer int) *pumpedWatcher {
@@ -997,20 +997,33 @@ func newPumpedWatcher(buffer int) *pumpedWatcher {
 // Events will be written to the channel without blocking.
 // If the buffer is full, the event will be dropped.
 func (p *pumpedWatcher) push(e watch.Event) {
-	select {
-	case p.ch <- e:
-	default:
-		// Buffer full — drop. Tests using this just want to fill the pipeline.
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if !p.done.Load() {
+		select {
+		case p.ch <- e:
+		default:
+			// Buffer full — drop. Tests using this just want to fill the pipeline.
+		}
 	}
 }
 
 func (p *pumpedWatcher) Stop() {
-	p.stopOnce.Do(func() { close(p.ch); p.done.Store(true) })
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if !p.done.Load() {
+		p.done.Store(true)
+		close(p.ch)
+	}
 }
 
-func (p *pumpedWatcher) ResultChan() <-chan watch.Event { return p.ch }
+func (p *pumpedWatcher) ResultChan() <-chan watch.Event {
+	return p.ch
+}
 
-func (p *pumpedWatcher) IsStopped() bool { return p.done.Load() }
+func (p *pumpedWatcher) IsStopped() bool {
+	return p.done.Load()
+}
 
 type observerCall struct {
 	layer    string
@@ -1025,8 +1038,4 @@ type fakeObserver struct {
 
 func (f *fakeObserver) Observe(layer, op string, resource schema.GroupResource, _ time.Duration, status string) {
 	f.calls = append(f.calls, observerCall{layer: layer, resource: resource, op: op, status: status})
-}
-
-func (f *fakeObserver) callsWithoutDuration() []observerCall {
-	return f.calls
 }

--- a/pkg/services/apiserver/auth/authorizer/storewrapper/wrapper_test.go
+++ b/pkg/services/apiserver/auth/authorizer/storewrapper/wrapper_test.go
@@ -15,6 +15,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/watch"
 
 	"github.com/grafana/authlib/types"
@@ -37,10 +38,12 @@ type testSetup struct {
 	ctx       context.Context
 }
 
+var testResource = schema.GroupResource{Group: "test.grafana.app", Resource: "fakes"}
+
 func newTestSetup(t *testing.T) *testSetup {
 	mockStore := rest.NewMockStorage(t)
 	mockAuth := &FakeAuthorizer{}
-	wrapper := New(mockStore, mockAuth)
+	wrapper := New(mockStore, testResource, mockAuth)
 
 	ctx := identity.WithRequester(
 		context.Background(),
@@ -53,7 +56,7 @@ func newTestSetup(t *testing.T) *testSetup {
 func newTestSetupWithPreserveIdentity(t *testing.T) *testSetup {
 	mockStore := rest.NewMockStorage(t)
 	mockAuth := &FakeAuthorizer{}
-	wrapper := New(mockStore, mockAuth, WithPreserveIdentity())
+	wrapper := New(mockStore, testResource, mockAuth, WithPreserveIdentity())
 
 	ctx := identity.WithRequester(
 		context.Background(),
@@ -117,6 +120,54 @@ func TestWrapper_Create(t *testing.T) {
 		// Assert expectations
 		setup.mockAuth.AssertExpectations(t)
 		setup.mockStore.AssertNotCalled(t, "Create")
+	})
+}
+
+func TestWrapper_Observer(t *testing.T) {
+	t.Run("records authz and inner calls with explicit resource", func(t *testing.T) {
+		mockStore := rest.NewMockStorage(t)
+		mockAuth := &FakeAuthorizer{}
+		observer := &fakeObserver{}
+		resource := schema.GroupResource{Group: "iam.grafana.app", Resource: "resourcepermissions"}
+		wrapper := New(mockStore, resource, mockAuth, WithObserver(observer))
+		ctx := identity.WithRequester(context.Background(), &identity.StaticRequester{UserUID: "u001", Type: types.TypeUser})
+
+		obj := &fakeObject{}
+		createOpts := &metaV1.CreateOptions{}
+		expectedObj := &fakeObject{ObjectMeta: metaV1.ObjectMeta{Name: "created"}}
+
+		mockAuth.On("BeforeCreate", mock.MatchedBy(matchesOriginalUser()), obj).Return(nil)
+		mockStore.On("Create", mock.MatchedBy(matchesServiceIdentity()), obj, mock.Anything, createOpts).Return(expectedObj, nil)
+
+		result, err := wrapper.Create(ctx, obj, nil, createOpts)
+
+		require.NoError(t, err)
+		assert.Equal(t, expectedObj, result)
+		assert.Equal(t, []observerCall{
+			{layer: LayerAuthz, resource: resource, op: "before_create", status: "success"},
+			{layer: LayerInner, resource: resource, op: "create", status: "success"},
+		}, observer.callsWithoutDuration())
+	})
+
+	t.Run("records authz failure without inner call", func(t *testing.T) {
+		mockStore := rest.NewMockStorage(t)
+		mockAuth := &FakeAuthorizer{}
+		observer := &fakeObserver{}
+		resource := schema.GroupResource{Group: "iam.grafana.app", Resource: "resourcepermissions"}
+		wrapper := New(mockStore, resource, mockAuth, WithObserver(observer))
+		ctx := identity.WithRequester(context.Background(), &identity.StaticRequester{UserUID: "u001", Type: types.TypeUser})
+
+		obj := &fakeObject{}
+		mockAuth.On("BeforeCreate", mock.MatchedBy(matchesOriginalUser()), obj).Return(ErrUnauthorized)
+
+		result, err := wrapper.Create(ctx, obj, nil, &metaV1.CreateOptions{})
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Equal(t, []observerCall{
+			{layer: LayerAuthz, resource: resource, op: "before_create", status: "unauthorized"},
+		}, observer.callsWithoutDuration())
+		mockStore.AssertNotCalled(t, "Create")
 	})
 }
 
@@ -803,7 +854,7 @@ func TestWrapper_Watch(t *testing.T) {
 		fakeWatcher := watch.NewFake()
 		watcherStore := &fakeWatcherStorage{K8sStorage: setup.mockStore, watcher: fakeWatcher}
 		// Re-create the wrapper with a short flush interval so the ticker case fires.
-		setup.wrapper = New(watcherStore, setup.mockAuth, WithWatchFlushInterval(10*time.Millisecond))
+		setup.wrapper = New(watcherStore, testResource, setup.mockAuth, WithWatchFlushInterval(10*time.Millisecond))
 
 		setup.mockAuth.On("WatchFilter", mock.Anything).Return(allowAllWatchFilter, nil)
 
@@ -964,3 +1015,22 @@ func (p *pumpedWatcher) Stop() {
 func (p *pumpedWatcher) ResultChan() <-chan watch.Event { return p.ch }
 
 func (p *pumpedWatcher) IsStopped() bool { return p.done.Load() }
+
+type observerCall struct {
+	layer    string
+	resource schema.GroupResource
+	op       string
+	status   string
+}
+
+type fakeObserver struct {
+	calls []observerCall
+}
+
+func (f *fakeObserver) Observe(layer, op string, resource schema.GroupResource, _ time.Duration, status string) {
+	f.calls = append(f.calls, observerCall{layer: layer, resource: resource, op: op, status: status})
+}
+
+func (f *fakeObserver) callsWithoutDuration() []observerCall {
+	return f.calls
+}

--- a/pkg/services/apiserver/auth/authorizer/storewrapper/wrapper_test.go
+++ b/pkg/services/apiserver/auth/authorizer/storewrapper/wrapper_test.go
@@ -815,11 +815,7 @@ func TestWrapper_Watch(t *testing.T) {
 
 	t.Run("blocked consumer automatically shuts down the watch", func(t *testing.T) {
 		setup := newTestSetup(t)
-
-		defaultSendTimeout = 10 * time.Millisecond
-		defer func() {
-			defaultSendTimeout = 1 * time.Second
-		}()
+		setup.wrapper.watchSendTimeout = 10 * time.Millisecond
 
 		// Inner watcher has enough room to buffer the events without blocking.
 		inner := newPumpedWatcher(int(watch.DefaultChanSize) * 3)
@@ -828,14 +824,14 @@ func TestWrapper_Watch(t *testing.T) {
 
 		setup.mockAuth.On("WatchFilter", mock.Anything).Return(allowAllWatchFilter, nil)
 
-		w, err := setup.wrapper.Watch(setup.ctx, &internalversion.ListOptions{})
-		require.NoError(t, err)
-
 		// Fill the inner channel buffer without ever reading from w.ResultChan().
 		// Wrapper watcher result channel will be blocked at DefaultChanSize.
 		for i := int32(0); i < watch.DefaultChanSize*2; i++ {
 			inner.push(watch.Event{Type: watch.Added, Object: &fakeObject{ObjectMeta: metaV1.ObjectMeta{Name: "item"}}})
 		}
+
+		w, err := setup.wrapper.Watch(setup.ctx, &internalversion.ListOptions{})
+		require.NoError(t, err)
 
 		// Wait for the send timeout to trigger. Use a generous overall timeout
 		// because the run goroutine must first process ~100 events through the


### PR DESCRIPTION
## Why the change

The storage wrapper sits between the API handler and the inner store, calling authorization hooks on each operation. We had no visibility into how long those hooks take, whether they are failing, or how the inner store compares in latency. This PR adds the instrumentation surface.

## Summary

- Add `Observer` interface and no-op default so existing callers are unaffected
- Add `WithTracer` and `WithObserver` options to `New()`
- Add `LayerAuthz` / `LayerInner` constants to distinguish which half of each operation is being timed
- Add `Op*` constants for every operation
- Status labels use K8s native reasons (`Success`, `Unauthorized`, `NotFound`, `Timeout`, …) for consistency across ops
- Instrument every CRUD method + `filteredWatcher` with spans and observer calls
- `New()` gains a `schema.GroupResource` parameter so metrics carry the right resource label
- Send timeout is now a per-wrapper field instead of a package-level var (fixes test race)

Part 2 of 3:
- ~~**P1**: `filteredWatcher` refactor~~ ✅ #124388
- **P2 (this PR)**: Add tracing and observer to the wrapper
- **P3**: Wire IAM histogram into the observer

Made with [Cursor](https://cursor.com)