### PR TITLE
Export CodeMirror completion types

### DIFF
--- a/packages/grafana-ui/src/components/CodeMirror/types.ts
+++ b/packages/grafana-ui/src/components/CodeMirror/types.ts
@@ -1,6 +1,9 @@
-import { type CompletionSource } from '@codemirror/autocomplete';
+import type { Completion, CompletionContext, CompletionResult, CompletionSource } from '@codemirror/autocomplete';
 import { type Extension } from '@codemirror/state';
 
+export type CodeMirrorCompletion = Completion;
+export type CodeMirrorCompletionContext = CompletionContext;
+export type CodeMirrorCompletionResult = CompletionResult;
 export type CodeMirrorCompletionSource = CompletionSource;
 
 export type CodeMirrorExtension = Extension;

--- a/packages/grafana-ui/src/unstable.ts
+++ b/packages/grafana-ui/src/unstable.ts
@@ -13,7 +13,10 @@ export * from './utils/skeleton';
 
 export { CodeMirrorEditor } from './components/CodeMirror/CodeEditorLazy';
 export type {
+  CodeMirrorCompletion,
+  CodeMirrorCompletionContext,
   CodeMirrorCompletionMode,
+  CodeMirrorCompletionResult,
   CodeMirrorCompletionSource,
   CodeMirrorEditorLanguage,
   CodeMirrorEditorProps,


### PR DESCRIPTION
**What is this feature?**

Extracting some types from CodeMirror that are needed for the Sql Editor work in a separate PR (#123738). Breaking this change up into its own PR so its easier for FEP to review it.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

Fixes grafana/grafana#123239