### PR TITLE
unified-storage: log errors in resource server and in KV backend tracing

### DIFF
--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -44,6 +44,21 @@ var tracer = otel.Tracer("github.com/grafana/grafana/pkg/storage/unified/resourc
 // Uses gRPC Unavailable so clients with retry interceptors will retry on another backend.
 var errStopping = status.Error(codes.Unavailable, "server is stopping")
 
+// logIfServerError logs errRes at Error level if it represents a 5xx (server) error.
+func (s *server) logIfServerError(ctx context.Context, op string, key *resourcepb.ResourceKey, errRes *resourcepb.ErrorResult) {
+	if errRes == nil || errRes.Code < 500 {
+		return
+	}
+	s.log.FromContext(ctx).Error(fmt.Sprintf("server error: %s", op),
+		"group", key.Group,
+		"resource", key.Resource,
+		"namespace", key.Namespace,
+		"name", key.Name,
+		"code", errRes.Code,
+		"error", errRes.Message,
+	)
+}
+
 // defaultBookmarkFrequency is how often periodic bookmark events are sent
 // to Watch clients that have AllowWatchBookmarks enabled.
 const defaultBookmarkFrequency = 10 * time.Second
@@ -927,6 +942,7 @@ func (s *server) Create(ctx context.Context, req *resourcepb.CreateRequest) (*re
 
 func (s *server) create(ctx context.Context, user claims.AuthInfo, req *resourcepb.CreateRequest) (*resourcepb.CreateResponse, error) {
 	rsp := &resourcepb.CreateResponse{}
+	defer func() { s.logIfServerError(ctx, "server.create", req.Key, rsp.Error) }()
 
 	event, e := s.newEvent(ctx, user, req.Key, 0, req.Value, nil)
 	if e != nil {
@@ -946,7 +962,6 @@ func (s *server) create(ctx context.Context, user claims.AuthInfo, req *resource
 		}
 		rsp.Error = AsErrorResult(err)
 	}
-	s.log.FromContext(ctx).Debug("server.WriteEvent", "type", event.Type, "rv", rsp.ResourceVersion, "previousRV", event.PreviousRV, "group", event.Key.Group, "namespace", event.Key.Namespace, "name", event.Key.Name, "resource", event.Key.Resource)
 	return rsp, nil
 }
 
@@ -1031,6 +1046,8 @@ func (s *server) Update(ctx context.Context, req *resourcepb.UpdateRequest) (*re
 
 func (s *server) update(ctx context.Context, user claims.AuthInfo, req *resourcepb.UpdateRequest) (*resourcepb.UpdateResponse, error) {
 	rsp := &resourcepb.UpdateResponse{}
+	defer func() { s.logIfServerError(ctx, "server.update", req.Key, rsp.Error) }()
+
 	latest := s.backend.ReadResource(ctx, &resourcepb.ReadRequest{
 		Key: req.Key,
 	})
@@ -1097,6 +1114,8 @@ func (s *server) Delete(ctx context.Context, req *resourcepb.DeleteRequest) (*re
 
 func (s *server) delete(ctx context.Context, user claims.AuthInfo, req *resourcepb.DeleteRequest) (*resourcepb.DeleteResponse, error) {
 	rsp := &resourcepb.DeleteResponse{}
+	defer func() { s.logIfServerError(ctx, "server.delete", req.Key, rsp.Error) }()
+
 	latest := s.backend.ReadResource(ctx, &resourcepb.ReadRequest{
 		Key: req.Key,
 	})
@@ -1197,7 +1216,13 @@ func (s *server) Read(ctx context.Context, req *resourcepb.ReadRequest) (*resour
 	return res, err
 }
 
-func (s *server) read(ctx context.Context, user claims.AuthInfo, req *resourcepb.ReadRequest) (*resourcepb.ReadResponse, error) {
+func (s *server) read(ctx context.Context, user claims.AuthInfo, req *resourcepb.ReadRequest) (readRsp *resourcepb.ReadResponse, readErr error) {
+	defer func() {
+		if readRsp != nil {
+			s.logIfServerError(ctx, "server.read", req.Key, readRsp.Error)
+		}
+	}()
+
 	rsp := s.backend.ReadResource(ctx, req)
 	if rsp.Error != nil && rsp.Error.Code == http.StatusNotFound {
 		return &resourcepb.ReadResponse{Error: rsp.Error}, nil
@@ -1365,7 +1390,7 @@ func (s *server) listAuthorized(ctx context.Context, req *resourcepb.ListRequest
 		return iter.Error()
 	})
 
-	return s.finalizeListResponse(rsp, rv, err, nextToken, req.Options.Key)
+	return s.finalizeListResponse(ctx, rsp, rv, err, nextToken, req.Options.Key)
 }
 
 // listFromTrash lists deleted resources. Trash uses a different authorization
@@ -1435,12 +1460,14 @@ func (s *server) listFromTrash(ctx context.Context, req *resourcepb.ListRequest)
 		return iter.Error()
 	})
 
-	return s.finalizeListResponse(rsp, rv, err, nextToken, req.Options.Key)
+	return s.finalizeListResponse(ctx, rsp, rv, err, nextToken, req.Options.Key)
 }
 
 // finalizeListResponse validates the resource version, sets pagination token,
 // and records metrics. Shared by listFromStore, listFromHistory, and listFromTrash.
-func (s *server) finalizeListResponse(rsp *resourcepb.ListResponse, rv int64, err error, nextToken string, key *resourcepb.ResourceKey) (*resourcepb.ListResponse, error) {
+func (s *server) finalizeListResponse(ctx context.Context, rsp *resourcepb.ListResponse, rv int64, err error, nextToken string, key *resourcepb.ResourceKey) (*resourcepb.ListResponse, error) {
+	defer func() { s.logIfServerError(ctx, "server.list", key, rsp.Error) }()
+
 	if err != nil {
 		rsp.Error = AsErrorResult(err)
 		return rsp, nil

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -22,6 +22,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.opentelemetry.io/otel/attribute"
+	otelcodes "go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -829,10 +830,18 @@ func (k *kvStorageBackend) maybeAcquireWriteLease(ctx context.Context, event Wri
 	return leaseCtx, true, release, nil
 }
 
+func recordSpanError(span trace.Span, err error) {
+	if err == nil {
+		return
+	}
+	span.RecordError(err)
+	span.SetStatus(otelcodes.Error, err.Error())
+}
+
 // WriteEvent writes a resource event (create/update/delete) to the storage backend.
 //
 //nolint:gocyclo
-func (k *kvStorageBackend) WriteEvent(ctx context.Context, event WriteEvent) (int64, error) {
+func (k *kvStorageBackend) WriteEvent(ctx context.Context, event WriteEvent) (rv int64, err error) {
 	if err := event.Validate(); err != nil {
 		return 0, apierrors.NewBadRequest(err.Error())
 	}
@@ -846,6 +855,7 @@ func (k *kvStorageBackend) WriteEvent(ctx context.Context, event WriteEvent) (in
 		attribute.String("namespace", event.Key.Namespace),
 	))
 	defer span.End()
+	defer func() { recordSpanError(span, err) }()
 
 	ctx, leasesActive, releaseLease, err := k.maybeAcquireWriteLease(ctx, event)
 	if err != nil {
@@ -853,8 +863,7 @@ func (k *kvStorageBackend) WriteEvent(ctx context.Context, event WriteEvent) (in
 	}
 	defer releaseLease()
 
-	rv := k.snowflake.Generate().Int64()
-
+	rv = k.snowflake.Generate().Int64()
 	namespace := event.Key.Namespace
 
 	// When PreviousRV is not 0, fetch the latest resource and verify that the RV matches the PreviousRV
@@ -1109,7 +1118,7 @@ func (k *kvStorageBackend) confirmExistence(ctx context.Context, key DataKey) (b
 	return false, err
 }
 
-func (k *kvStorageBackend) ReadResource(ctx context.Context, req *resourcepb.ReadRequest) *BackendReadResponse {
+func (k *kvStorageBackend) ReadResource(ctx context.Context, req *resourcepb.ReadRequest) (rsp *BackendReadResponse) {
 	if req.Key == nil {
 		return &BackendReadResponse{Error: &resourcepb.ErrorResult{Code: http.StatusBadRequest, Message: "missing key"}}
 	}
@@ -1122,7 +1131,13 @@ func (k *kvStorageBackend) ReadResource(ctx context.Context, req *resourcepb.Rea
 		attribute.String("resource", req.Key.Resource),
 		attribute.String("name", req.Key.Name),
 	))
+	var err error
 	defer span.End()
+	defer func() {
+		if rsp != nil && rsp.Error != nil && rsp.Error.Code >= 500 {
+			recordSpanError(span, err)
+		}
+	}()
 
 	namespace := req.Key.Namespace
 
@@ -1183,7 +1198,7 @@ func (k *kvStorageBackend) ReadResource(ctx context.Context, req *resourcepb.Rea
 }
 
 // ListIterator returns an iterator for listing resources.
-func (k *kvStorageBackend) ListIterator(ctx context.Context, req *resourcepb.ListRequest, cb func(ListIterator) error) (int64, error) {
+func (k *kvStorageBackend) ListIterator(ctx context.Context, req *resourcepb.ListRequest, cb func(ListIterator) error) (rv int64, err error) {
 	if req.Options == nil || req.Options.Key == nil {
 		return 0, fmt.Errorf("missing options or key in ListRequest")
 	}
@@ -1196,6 +1211,7 @@ func (k *kvStorageBackend) ListIterator(ctx context.Context, req *resourcepb.Lis
 		attribute.String("resource", req.Options.Key.Resource),
 	))
 	defer span.End()
+	defer func() { recordSpanError(span, err) }()
 
 	// Parse continue token if provided
 	listOptions := ListRequestOptions{
@@ -1258,8 +1274,7 @@ func (k *kvStorageBackend) ListIterator(ctx context.Context, req *resourcepb.Lis
 	iter := newKvListIterator(ctx, k.dataStore, keys, listRV, req.Options.Key.Namespace == "")
 	defer iter.stop()
 
-	err := cb(iter)
-	if err != nil {
+	if err := cb(iter); err != nil {
 		return 0, err
 	}
 
@@ -1496,8 +1511,10 @@ func (k *kvStorageBackend) ListModifiedSince(ctx context.Context, key Namespaced
 			return sinceRv, func(yield func(*ModifiedResource, error) bool) { /* nothing to return */ }
 		}
 
+		err = fmt.Errorf("error trying to retrieve last event key: %w", err)
+		recordSpanError(span, err)
 		return 0, func(yield func(*ModifiedResource, error) bool) {
-			yield(nil, fmt.Errorf("error trying to retrieve last event key: %w", err))
+			yield(nil, err)
 		}
 	}
 
@@ -1684,7 +1701,7 @@ func (k *kvStorageBackend) listModifiedSinceEventStore(ctx context.Context, key 
 }
 
 // ListHistory is like ListIterator, but it returns the history of a resource.
-func (k *kvStorageBackend) ListHistory(ctx context.Context, req *resourcepb.ListRequest, fn func(ListIterator) error) (int64, error) {
+func (k *kvStorageBackend) ListHistory(ctx context.Context, req *resourcepb.ListRequest, fn func(ListIterator) error) (rv int64, err error) {
 	if err := validateListHistoryRequest(req); err != nil {
 		return 0, err
 	}
@@ -1697,6 +1714,7 @@ func (k *kvStorageBackend) ListHistory(ctx context.Context, req *resourcepb.List
 		attribute.String("resource", key.Resource),
 	))
 	defer span.End()
+	defer func() { recordSpanError(span, err) }()
 
 	// Parse continue token if provided
 	lastSeenRV := int64(0)

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -1145,7 +1145,8 @@ func (k *kvStorageBackend) ReadResource(ctx context.Context, req *resourcepb.Rea
 	if req.ResourceVersion > 0 {
 		// Fetch the latest RV
 		latestRV := k.snowflake.Generate().Int64()
-		if lastEventKey, err := k.eventStore.LastEventKey(ctx); err == nil {
+		var lastEventKey EventKey
+		if lastEventKey, err = k.eventStore.LastEventKey(ctx); err == nil {
 			latestRV = lastEventKey.ResourceVersion
 		} else if !errors.Is(err, ErrNotFound) {
 			return &BackendReadResponse{Error: &resourcepb.ErrorResult{


### PR DESCRIPTION
Makes it easier for us to understand errors in the resource server and storage backend by logging when an internal error is returned. KV backend errors are also recorded in tracing spans.