### PR TITLE
Provisioning: Fallback reading metadata from configured branch in parser

### DIFF
--- a/pkg/registry/apis/provisioning/resources/parser.go
+++ b/pkg/registry/apis/provisioning/resources/parser.go
@@ -218,6 +218,12 @@ func (r *parser) Parse(ctx context.Context, info *repository.FileInfo) (parsed *
 			if r.folderMetadataEnabled && r.reader != nil {
 				if meta, _, err := ReadFolderMetadata(ctx, r.reader, dirPath, info.Ref); err == nil && meta.Name != "" {
 					folderID = meta.Name
+				} else if err != nil && errors.Is(err, repository.ErrRefNotFound) {
+					// Target branch doesn't exist yet (e.g. new PR branch). Fall back to
+					// the configured branch where _folder.json is already committed.
+					if meta, _, err := ReadFolderMetadata(ctx, r.reader, dirPath, ""); err == nil && meta.Name != "" {
+						folderID = meta.Name
+					}
 				}
 			}
 			parsed.Meta.SetFolder(folderID)

--- a/pkg/registry/apis/provisioning/resources/parser_test.go
+++ b/pkg/registry/apis/provisioning/resources/parser_test.go
@@ -154,6 +154,130 @@ spec:
 	})
 }
 
+func TestParser_FolderMetadataRefFallback(t *testing.T) {
+	clients := NewMockResourceClients(t)
+	clients.On("ForKind", mock.Anything, mock.Anything).
+		Return(nil, dashboardV0.DashboardResourceInfo.GroupVersionResource(), nil).Maybe()
+
+	folderMetadataJSON := `{"apiVersion":"folder.grafana.app/v1beta1","kind":"Folder","metadata":{"name":"stable-uid"},"spec":{"title":"Team A"}}`
+
+	dashboardYAML := `apiVersion: dashboard.grafana.app/v0alpha1
+kind: Dashboard
+metadata:
+  name: test-dashboard
+spec:
+  title: Test dashboard
+`
+
+	repoConfig := &provisioning.Repository{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "xxx", Name: "repo"},
+		Spec: provisioning.RepositorySpec{
+			Type: provisioning.GitHubRepositoryType,
+			Sync: provisioning.SyncOptions{Target: provisioning.SyncTargetTypeFolder},
+		},
+	}
+
+	t.Run("reads folder metadata from target ref", func(t *testing.T) {
+		reader := repository.NewMockReader(t)
+		reader.On("Config").Return(repoConfig).Maybe()
+		reader.On("Read", mock.Anything, "team-a/_folder.json", "feature-branch").
+			Return(&repository.FileInfo{Data: []byte(folderMetadataJSON), Hash: "h1"}, nil)
+
+		p := &parser{
+			repo:                  provisioning.ResourceRepositoryInfo{Type: provisioning.GitHubRepositoryType, Namespace: "xxx", Name: "repo"},
+			clients:               clients,
+			config:                repoConfig,
+			reader:                reader,
+			folderMetadataEnabled: true,
+		}
+
+		parsed, err := p.Parse(context.Background(), &repository.FileInfo{
+			Path: "team-a/dashboard.json",
+			Ref:  "feature-branch",
+			Data: []byte(dashboardYAML),
+		})
+		require.NoError(t, err)
+		require.Equal(t, "stable-uid", parsed.Meta.GetFolder())
+	})
+
+	t.Run("falls back to configured branch when target ref not found", func(t *testing.T) {
+		reader := repository.NewMockReader(t)
+		reader.On("Config").Return(repoConfig).Maybe()
+		reader.On("Read", mock.Anything, "team-a/_folder.json", "new-pr-branch").
+			Return(nil, fmt.Errorf("ref not found: refs/heads/new-pr-branch: %w", repository.ErrRefNotFound))
+		reader.On("Read", mock.Anything, "team-a/_folder.json", "").
+			Return(&repository.FileInfo{Data: []byte(folderMetadataJSON), Hash: "h1"}, nil)
+
+		p := &parser{
+			repo:                  provisioning.ResourceRepositoryInfo{Type: provisioning.GitHubRepositoryType, Namespace: "xxx", Name: "repo"},
+			clients:               clients,
+			config:                repoConfig,
+			reader:                reader,
+			folderMetadataEnabled: true,
+		}
+
+		parsed, err := p.Parse(context.Background(), &repository.FileInfo{
+			Path: "team-a/dashboard.json",
+			Ref:  "new-pr-branch",
+			Data: []byte(dashboardYAML),
+		})
+		require.NoError(t, err)
+		require.Equal(t, "stable-uid", parsed.Meta.GetFolder(),
+			"should use stable UID from configured branch when PR branch doesn't exist")
+	})
+
+	t.Run("falls back to hash-based ID when both refs lack metadata", func(t *testing.T) {
+		reader := repository.NewMockReader(t)
+		reader.On("Config").Return(repoConfig).Maybe()
+		reader.On("Read", mock.Anything, "team-a/_folder.json", "new-pr-branch").
+			Return(nil, fmt.Errorf("ref not found: refs/heads/new-pr-branch: %w", repository.ErrRefNotFound))
+		reader.On("Read", mock.Anything, "team-a/_folder.json", "").
+			Return(nil, repository.ErrFileNotFound)
+
+		p := &parser{
+			repo:                  provisioning.ResourceRepositoryInfo{Type: provisioning.GitHubRepositoryType, Namespace: "xxx", Name: "repo"},
+			clients:               clients,
+			config:                repoConfig,
+			reader:                reader,
+			folderMetadataEnabled: true,
+		}
+
+		parsed, err := p.Parse(context.Background(), &repository.FileInfo{
+			Path: "team-a/dashboard.json",
+			Ref:  "new-pr-branch",
+			Data: []byte(dashboardYAML),
+		})
+		require.NoError(t, err)
+		require.Equal(t, ParseFolder("team-a/", "repo").ID, parsed.Meta.GetFolder(),
+			"should fall back to hash-based folder ID when no _folder.json on any branch")
+	})
+
+	t.Run("does not fall back for non-ref errors", func(t *testing.T) {
+		reader := repository.NewMockReader(t)
+		reader.On("Config").Return(repoConfig).Maybe()
+		reader.On("Read", mock.Anything, "team-a/_folder.json", "feature-branch").
+			Return(nil, repository.ErrFileNotFound)
+
+		p := &parser{
+			repo:                  provisioning.ResourceRepositoryInfo{Type: provisioning.GitHubRepositoryType, Namespace: "xxx", Name: "repo"},
+			clients:               clients,
+			config:                repoConfig,
+			reader:                reader,
+			folderMetadataEnabled: true,
+		}
+
+		parsed, err := p.Parse(context.Background(), &repository.FileInfo{
+			Path: "team-a/dashboard.json",
+			Ref:  "feature-branch",
+			Data: []byte(dashboardYAML),
+		})
+		require.NoError(t, err)
+		require.Equal(t, ParseFolder("team-a/", "repo").ID, parsed.Meta.GetFolder(),
+			"should not retry on configured branch for non-ref errors like ErrFileNotFound")
+		reader.AssertNotCalled(t, "Read", mock.Anything, "team-a/_folder.json", "")
+	})
+}
+
 func TestSameIdentity(t *testing.T) {
 	makeParsed := func(name, group, kind string) *ParsedResource {
 		return &ParsedResource{

--- a/pkg/setting/setting_plugins.go
+++ b/pkg/setting/setting_plugins.go
@@ -156,6 +156,9 @@ func (cfg *Cfg) readPluginSettings(iniFile *ini.File) error {
 		if cfg.IsFeatureToggleEnabled("interactiveLearning") { // Use literal string to avoid circular dependency
 			preinstallPluginsAsync["grafana-pathfinder-app"] = InstallPlugin{"grafana-pathfinder-app", "", ""}
 		}
+		if cfg.IsEnterprise {
+			preinstallPluginsAsync["grafana-assistant-app"] = InstallPlugin{"grafana-assistant-app", "", ""}
+		}
 		cfg.processPreinstallPlugins(rawInstallPluginsAsync, preinstallPluginsAsync)
 
 		rawInstallPluginsSync := util.SplitString(pluginsSection.Key("preinstall_sync").MustString(""))

--- a/pkg/setting/setting_plugins.go
+++ b/pkg/setting/setting_plugins.go
@@ -156,9 +156,6 @@ func (cfg *Cfg) readPluginSettings(iniFile *ini.File) error {
 		if cfg.IsFeatureToggleEnabled("interactiveLearning") { // Use literal string to avoid circular dependency
 			preinstallPluginsAsync["grafana-pathfinder-app"] = InstallPlugin{"grafana-pathfinder-app", "", ""}
 		}
-		if cfg.IsEnterprise {
-			preinstallPluginsAsync["grafana-assistant-app"] = InstallPlugin{"grafana-assistant-app", "", ""}
-		}
 		cfg.processPreinstallPlugins(rawInstallPluginsAsync, preinstallPluginsAsync)
 
 		rawInstallPluginsSync := util.SplitString(pluginsSection.Key("preinstall_sync").MustString(""))

--- a/pkg/tests/apis/provisioning/foldermetadata/update_folder_metadata_git_test.go
+++ b/pkg/tests/apis/provisioning/foldermetadata/update_folder_metadata_git_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
+	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
 	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
 )
 
@@ -121,6 +122,66 @@ func TestIntegrationGitFiles_UpdateFolderMetadataOnNewBranch(t *testing.T) {
 			"rename-target/child/_folder.json", nestedBranch, "metadata", "name")
 		require.Equal(t, childUID, uid, "nested folder UID must not change")
 	})
+}
+
+// TestIntegrationGitFiles_EditorCreatesDashboardOnNewBranchWithGranularPermissions
+// verifies that an editor with granular folder-scoped permissions can create a
+// dashboard on a new PR branch. Before the fix, the parser read _folder.json from
+// the target branch (which didn't exist yet), fell back to a hash-based folder UID,
+// and the RBAC ancestor walk failed because the hash-based UID wasn't in the folder tree.
+func TestIntegrationGitFiles_EditorCreatesDashboardOnNewBranchWithGranularPermissions(t *testing.T) {
+	helper := sharedGitHelper(t)
+	ctx := context.Background()
+
+	const repoName = "editor-new-branch-granular-perms"
+	helper.CreateGitRepo(t, repoName, nil, "write", "branch")
+
+	// Create a subfolder on the default branch (writes _folder.json with stable UID).
+	resp := postFolderViaFilesAPI(t, helper, repoName, "team-a/", "", "Create team-a folder")
+	body, _ := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode, "folder creation should succeed: %s", string(body))
+
+	folderUID := readFolderFieldOnRef(t, helper, ctx, repoName, "team-a/_folder.json", "", "metadata", "name")
+	require.NotEmpty(t, folderUID, "team-a should have a stable UID from _folder.json")
+
+	// Grant editor granular permissions scoped to the repo root folder only.
+	helper.SetPermissions(helper.Org1.Editor, []resourcepermissions.SetResourcePermissionCommand{
+		{
+			Actions:           []string{"dashboards:read", "dashboards:write", "dashboards:create", "dashboards:delete"},
+			Resource:          "folders",
+			ResourceAttribute: "uid",
+			ResourceID:        repoName,
+		},
+	})
+
+	// Editor creates a dashboard inside team-a/ on a new branch.
+	const branchName = "editor/add-dashboard"
+	dashboardContent := common.DashboardJSON("editor-dash-1", "Editor Dashboard 1", 1)
+
+	result := helper.EditorREST.Post().
+		Namespace("default").
+		Resource("repositories").
+		Name(repoName).
+		SubResource("files", "team-a", "editor-dashboard.json").
+		Param("ref", branchName).
+		Param("message", "Add dashboard on new branch").
+		Body(dashboardContent).
+		SetHeader("Content-Type", "application/json").
+		Do(ctx)
+
+	require.NoError(t, result.Error(),
+		"editor with granular folder permissions should be able to create a dashboard on a new branch")
+
+	// Verify the file was actually created on the branch.
+	getResult := helper.AdminREST.Get().
+		Namespace("default").
+		Resource("repositories").
+		Name(repoName).
+		SubResource("files", "team-a", "editor-dashboard.json").
+		Param("ref", branchName).
+		Do(ctx)
+	require.NoError(t, getResult.Error(), "dashboard file should exist on the new branch")
 }
 
 // ── helpers ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixes a 403 Forbidden error when saving a dashboard into a Git Sync subfolder on a **new PR branch** with granular RBAC scope (e.g. `dashboards:create` scoped to `folders:uid:<repo-folder-uid>`).

### Root cause

When saving a dashboard to a GitHub repo, the provisioning parser reads `_folder.json` from the target ref (`info.Ref`) to resolve the parent folder's stable UID. For new PR branches, this ref doesn't exist yet — `ReadFolderMetadata` fails with `ErrRefNotFound` and the parser silently falls back to a **hash-based folder UID** that doesn't match the actual folder in unified storage.

The RBAC ancestor walk then tries to find the repo folder as an ancestor of this phantom UID, fails (because it's not in the folder tree), and returns 403. Wildcard `folders:*` scope bypasses the issue because it short-circuits before the tree walk.

### Fix

When `ReadFolderMetadata` fails with `ErrRefNotFound`, the parser now retries with `ref=""` (the configured default branch), where `_folder.json` is already committed. This matches how the authorizer already resolves folder IDs (`getFolderID` always uses `ref=""`).

### Files changed

- **`parser.go`**: Added fallback to configured branch when target ref is not found during folder metadata resolution.
- **`parser_test.go`**: Added `TestParser_FolderMetadataRefFallback` with 4 cases:
  - Reads metadata from target ref (existing behavior)
  - Falls back to configured branch when target ref not found
  - Falls back to hash-based ID when both refs lack metadata
  - Does not retry for non-ref errors (e.g. `ErrFileNotFound`)
- **`update_folder_metadata_git_test.go`**: Added integration test `TestIntegrationGitFiles_EditorCreatesDashboardOnNewBranchWithGranularPermissions` — editor with granular folder-scoped permissions creates a dashboard on a new PR branch and succeeds.

### Backward compatibility

This only changes behavior when `ReadFolderMetadata` returns `ErrRefNotFound`. All other error paths (file not found, parse errors) are unchanged. The fallback reads the same `_folder.json` the authorizer would use, so the resolved UID is always consistent.

## Test plan

- [x] `go test ./pkg/registry/apis/provisioning/resources/... -run TestParser_FolderMetadataRefFallback`
- [x] `go test -tags=enterprise ./pkg/tests/apis/provisioning/foldermetadata/... -run TestIntegrationGitFiles_EditorCreatesDashboardOnNewBranchWithGranularPermissions`
- [x] `go test -tags=enterprise ./pkg/tests/apis/provisioning/foldermetadata/...` (full suite — all pass)
- [x] `make gofmt && make lint-go-diff` (0 issues)