### PR TITLE
Logs: Highlight multi-unit durations in log syntax highlighting

### DIFF
--- a/public/app/features/logs/components/panel/grammar.test.ts
+++ b/public/app/features/logs/components/panel/grammar.test.ts
@@ -75,6 +75,23 @@ describe('generateLogGrammar', () => {
     expect.assertions(7);
   });
 
+  test.each([['1m30s'], ['2h30m45s'], ['1m30.5s'], ['1h30m'], ['1d2h']])(
+    'Identifies multi-unit durations: %s',
+    (duration: string) => {
+      const { tokens } = generateScenario(duration);
+      if (tokens[0] instanceof Token) {
+        expect(tokens[0].content).toBe(duration);
+        expect(tokens[0].type).toBe('log-token-duration');
+      }
+      expect.assertions(3);
+    }
+  );
+
+  test('Does not identify invalid duration-like strings', () => {
+    const { tokens } = generateScenario('5min');
+    expect(tokens.every((token) => !(token instanceof Token) || token.type !== 'log-token-duration')).toBe(true);
+  });
+
   test.each(['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'HEAD', 'OPTIONS', 'TRACE', 'CONNECT'])(
     'Identifies HTTP methods',
     (method: string) => {

--- a/public/app/features/logs/components/panel/grammar.ts
+++ b/public/app/features/logs/components/panel/grammar.ts
@@ -13,7 +13,7 @@ const logsGrammar: Grammar = {
 const tokensGrammar: Grammar = {
   'log-token-uuid': /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}/g,
   'log-token-size': /(?:\b|")\d+\.{0,1}\d*\s*[kKmMGgtTPp]*[bB]{1}(?:"|\b)/g,
-  'log-token-duration': /(?:\b)\d+(\.\d+)?(ns|µs|ms|s|m|h|d)(?:\b)/g,
+  'log-token-duration': /\b(?:\d+(?:\.\d+)?(?:ns|µs|ms|s|m|h|d))+\b/g,
   'log-token-method': /\b(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|TRACE|CONNECT)\b/g,
 };
 


### PR DESCRIPTION
**What is this feature?**

Fixes the duration token highlighting in the Logs panel to correctly match multi-unit durations such as `1m30s`, `2h30m45s`, and `1m30.5s`.

**Why do we need this feature?**

The previous regex required a single number-and-unit pair, so multi-unit durations like `1m30s` (which are extremely common in Go-formatted log output) were not highlighted at all. The trailing `\b` failed between the unit character and the following digit, so the entire match was dropped.

The fix is intentionally minimal — it allows the existing `<number><unit>` segment to repeat, while preserving the same set of supported units (`ns | µs | ms | s | m | h | d`) and decimal handling.

**Who is this feature for?**

Anyone viewing Go-formatted duration values in Grafana's Logs panel / Explore.

**Which issue(s) does this PR fix?**:

Fixes #124307

**Special notes for your reviewer:**

- Tests for `1m30s`, `2h30m45s`, `1m30.5s`, `1h30m`, `1d2h`, plus a negative test for `5min`, were added to `grammar.test.ts`.
- Adding `w` and `y` to the unit list (to align with `isValidGrafanaDuration` and the Loki query editor's syntax highlighter) is tracked separately in #124432 — it is intentionally out of scope for this fix.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.