### PR TITLE
Chore: make govulncheck non-policy-blocking

### DIFF
--- a/.policy.yml
+++ b/.policy.yml
@@ -308,6 +308,7 @@ approval_rules:
           conclusions:
             - skipped
             - success
+            - failure
           workflows:
             - .github/workflows/govulncheck.yml
   - name: Workflow .github/workflows/i18n-verify.yml succeeded or skipped

--- a/Makefile
+++ b/Makefile
@@ -795,3 +795,5 @@ GENERATE_POLICY_BOT_CONFIG_SHA := sha256:d05ff5c7d4247da155c85f8c6f1f9f7c6d013d1
 		.
 # We don't want the patch workflow to be run. This is exclusively useful for the security-mirror. It won't work in OSS.
 	sed -i.bak '/- Workflow \.github\/workflows\/create-security-patch-from-security-mirror/d' .policy.yml; rm -f .policy.yml.bak
+# Make govulncheck non-blocking - accept failure so it doesn't prevent merge
+	sed -i.bak '/name: Workflow \.github\/workflows\/govulncheck\.yml/,/workflows:/{s/- success/- success\n            - failure/;}' .policy.yml; rm -f .policy.yml.bak


### PR DESCRIPTION
My original intent in #123435 was that it'd be non-blocking, but the new(ish) policy-bot blocks by default. This attempts to work around that.