### PR TITLE
fix(queryhistory): propagate insert errors from QueryHistoryDetails

### DIFF
--- a/pkg/services/queryhistory/database.go
+++ b/pkg/services/queryhistory/database.go
@@ -51,10 +51,15 @@ func (s QueryHistoryService) createQuery(ctx context.Context, user *user.SignedI
 
 		err = s.store.WithDbSession(ctx, func(session *db.Session) error {
 			for _, queryHistoryDetailsItem := range queryHistoryDetailsItems {
-				_, err = session.Insert(queryHistoryDetailsItem)
+				if _, insertErr := session.Insert(queryHistoryDetailsItem); insertErr != nil {
+					return insertErr
+				}
 			}
 			return nil
 		})
+		if err != nil {
+			return QueryHistoryDTO{}, err
+		}
 	}
 
 	dto := QueryHistoryDTO{


### PR DESCRIPTION
Resubmission of #123691 (closed when fork was accidentally deleted).

Closes #123331

The `createQuery` function in `pkg/services/queryhistory/database.go` has two bugs:

1. The `WithDbSession` callback always returns `nil`, discarding any `session.Insert` errors for `QueryHistoryDetails` rows.
2. The error from `WithDbSession` is assigned but never checked before the function returns success.

Database failures during detail inserts (constraint violations, connection errors) are invisible. Affected queries appear in query history but are missing from `query_history_details`, so they cannot be filtered by datasource in the Explore UI.

**Changes:**
- Return insert errors from the session callback on first failure (using a distinct `insertErr` to avoid shadowing the outer `err`)
- Check the `WithDbSession` error and return early if details insert failed

This matches the error handling pattern used throughout the rest of the file.