### PR TITLE
Heatmap: Fix runaway loop/crash in uPlot triggered by suggestions

### DIFF
--- a/public/app/plugins/panel/heatmap/fields.test.ts
+++ b/public/app/plugins/panel/heatmap/fields.test.ts
@@ -723,7 +723,7 @@ describe('Heatmap data', () => {
       const heatmap = prepareHeatmapData({ ...tpl, frames: [frame1, frame2], palette: ['#000', '#fff'] });
 
       expect(heatmap.warning).toBeUndefined();
-      expect(heatmap.xBucketSize).toBeGreaterThan(0);
+      expect(heatmap.xBucketSize).toEqual(1000);
     });
   });
 

--- a/public/app/plugins/panel/heatmap/fields.test.ts
+++ b/public/app/plugins/panel/heatmap/fields.test.ts
@@ -658,26 +658,73 @@ describe('Heatmap data', () => {
     });
   });
 
-  it('returns a warning when first field is not monotonically increasing (non-sortable x)', () => {
-    const unsortedIdValues = [1042, 87, 305, 1199, 41, 980];
-    const frame = toDataFrame({
-      fields: [
-        { name: 'id', type: FieldType.number, values: unsortedIdValues },
-        { name: 'lastSeen', type: FieldType.time, values: [1000, 2000, 3000, 4000, 5000, 6000] },
-        { name: 'count', type: FieldType.number, values: [3, 7, 1, 9, 4, 2], state: { displayName: 'count' } },
-        { name: 'users', type: FieldType.number, values: [1, 2, 1, 3, 2, 1], state: { displayName: 'users' } },
-      ],
+  describe('non-monotonic x guard', () => {
+    function expectWarningWithoutInvalidBucketSize(heatmap: ReturnType<typeof prepareHeatmapData>) {
+      expect(heatmap.warning).toEqual(expect.any(String));
+      expect(heatmap.warning?.length ?? 0).toBeGreaterThan(0);
+      if (heatmap.xBucketSize !== undefined) {
+        expect(Number.isFinite(heatmap.xBucketSize)).toBe(true);
+        expect(heatmap.xBucketSize).toBeGreaterThan(0);
+      }
+    }
+
+    it('returns a warning for a generic table frame whose first field is unsorted (rows-fallback path)', () => {
+      const frame = toDataFrame({
+        fields: [
+          { name: 'id', type: FieldType.number, values: [1042, 87, 305, 1199, 41, 980] },
+          { name: 'lastSeen', type: FieldType.time, values: [1000, 2000, 3000, 4000, 5000, 6000] },
+          { name: 'count', type: FieldType.number, values: [3, 7, 1, 9, 4, 2], state: { displayName: 'count' } },
+          { name: 'users', type: FieldType.number, values: [1, 2, 1, 3, 2, 1], state: { displayName: 'users' } },
+        ],
+      });
+
+      expectWarningWithoutInvalidBucketSize(prepareHeatmapData({ ...tpl, frames: [frame], palette: ['#000', '#fff'] }));
     });
 
-    const heatmap = prepareHeatmapData({ ...tpl, frames: [frame], palette: ['#000', '#fff'] });
+    it('returns a warning for a HeatmapCells frame whose x field is unsorted (direct cells path)', () => {
+      const frame = toDataFrame({
+        meta: { type: DataFrameType.HeatmapCells },
+        fields: [
+          { name: 'x', type: FieldType.number, values: [3000, 1000, 3000, 1000] },
+          { name: 'y', type: FieldType.number, values: [1, 1, 2, 2] },
+          { name: 'count', type: FieldType.number, values: [5, 10, 15, 20] },
+        ],
+      });
 
-    expect(heatmap.warning).toEqual(expect.any(String));
-    expect(heatmap.warning?.length ?? 0).toBeGreaterThan(0);
+      expectWarningWithoutInvalidBucketSize(prepareHeatmapData({ ...tpl, frames: [frame], palette: ['#000', '#fff'] }));
+    });
 
-    if (heatmap.xBucketSize !== undefined) {
-      expect(Number.isFinite(heatmap.xBucketSize)).toBe(true);
+    it('returns a warning for a single frame whose first field is a string (rows-fallback path)', () => {
+      const frame = toDataFrame({
+        fields: [
+          { name: 'category', type: FieldType.string, values: ['c', 'a', 'b'] },
+          { name: 'count', type: FieldType.number, values: [3, 7, 1], state: { displayName: 'count' } },
+          { name: 'users', type: FieldType.number, values: [1, 2, 1], state: { displayName: 'users' } },
+        ],
+      });
+
+      expectWarningWithoutInvalidBucketSize(prepareHeatmapData({ ...tpl, frames: [frame], palette: ['#000', '#fff'] }));
+    });
+
+    it('does not warn when multiple time-keyed frames are outer-joined (multi-frame path)', () => {
+      const frame1 = toDataFrame({
+        fields: [
+          { name: 'time', type: FieldType.time, values: [3000, 1000, 2000] },
+          { name: 'value', type: FieldType.number, values: [10, 20, 30], state: { displayName: '1' } },
+        ],
+      });
+      const frame2 = toDataFrame({
+        fields: [
+          { name: 'time', type: FieldType.time, values: [2000, 3000, 1000] },
+          { name: 'value', type: FieldType.number, values: [40, 50, 60], state: { displayName: '2' } },
+        ],
+      });
+
+      const heatmap = prepareHeatmapData({ ...tpl, frames: [frame1, frame2], palette: ['#000', '#fff'] });
+
+      expect(heatmap.warning).toBeUndefined();
       expect(heatmap.xBucketSize).toBeGreaterThan(0);
-    }
+    });
   });
 
   describe('getDenseHeatmapData edge cases', () => {

--- a/public/app/plugins/panel/heatmap/fields.test.ts
+++ b/public/app/plugins/panel/heatmap/fields.test.ts
@@ -658,6 +658,28 @@ describe('Heatmap data', () => {
     });
   });
 
+  it('returns a warning when first field is not monotonically increasing (non-sortable x)', () => {
+    const unsortedIdValues = [1042, 87, 305, 1199, 41, 980];
+    const frame = toDataFrame({
+      fields: [
+        { name: 'id', type: FieldType.number, values: unsortedIdValues },
+        { name: 'lastSeen', type: FieldType.time, values: [1000, 2000, 3000, 4000, 5000, 6000] },
+        { name: 'count', type: FieldType.number, values: [3, 7, 1, 9, 4, 2], state: { displayName: 'count' } },
+        { name: 'users', type: FieldType.number, values: [1, 2, 1, 3, 2, 1], state: { displayName: 'users' } },
+      ],
+    });
+
+    const heatmap = prepareHeatmapData({ ...tpl, frames: [frame], palette: ['#000', '#fff'] });
+
+    expect(heatmap.warning).toEqual(expect.any(String));
+    expect(heatmap.warning?.length ?? 0).toBeGreaterThan(0);
+
+    if (heatmap.xBucketSize !== undefined) {
+      expect(Number.isFinite(heatmap.xBucketSize)).toBe(true);
+      expect(heatmap.xBucketSize).toBeGreaterThan(0);
+    }
+  });
+
   describe('getDenseHeatmapData edge cases', () => {
     it('returns warning when dense frame has no value field', () => {
       const frame = toDataFrame({

--- a/public/app/plugins/panel/heatmap/fields.ts
+++ b/public/app/plugins/panel/heatmap/fields.ts
@@ -338,6 +338,14 @@ const getDenseHeatmapData = (
   let xBinQty = dlen / yBinQty;
   let yBinIncr = ys[1] - ys[0];
   let xBinIncr = xs[yBinQty] - xs[0];
+  const hasValidXBucketSize = Number.isFinite(xBinIncr) && xBinIncr > 0;
+
+  if (!hasValidXBucketSize) {
+    return {
+      warning: 'Could not infer heatmap bucket size; x field is not sorted ascending',
+      heatmap: frame,
+    };
+  }
 
   let [minValue, maxValue] = boundedMinMax(
     valueField.values,

--- a/public/app/plugins/panel/heatmap/fields.ts
+++ b/public/app/plugins/panel/heatmap/fields.ts
@@ -338,7 +338,7 @@ const getDenseHeatmapData = (
   let xBinQty = dlen / yBinQty;
   let yBinIncr = ys[1] - ys[0];
   let xBinIncr = xs[yBinQty] - xs[0];
-  const hasValidXBucketSize = Number.isFinite(xBinIncr) && xBinIncr > 0;
+  const hasValidXBucketSize = Number.isFinite(xBinIncr) && xBinIncr >= 0;
 
   if (!hasValidXBucketSize) {
     return {

--- a/public/app/plugins/panel/heatmap/suggestions.test.ts
+++ b/public/app/plugins/panel/heatmap/suggestions.test.ts
@@ -73,12 +73,9 @@ describe('heatmap suggestions', () => {
         .spyOn(fields, 'prepareHeatmapData')
         .mockReturnValue({ heatmap: frame, xBucketSize: 1, yBucketSize: 1 });
 
-      try {
-        const suggestions = heatmapSuggestionsSupplier(dataSummary);
-        expect(suggestions).toBeUndefined();
-      } finally {
-        prepareSpy.mockRestore();
-      }
+      const suggestions = heatmapSuggestionsSupplier(dataSummary);
+      expect(suggestions).toBeUndefined();
+      prepareSpy.mockRestore();
     });
 
     describe('first field shape determines whether a heatmap suggestion is offered', () => {

--- a/public/app/plugins/panel/heatmap/suggestions.test.ts
+++ b/public/app/plugins/panel/heatmap/suggestions.test.ts
@@ -80,6 +80,38 @@ describe('heatmap suggestions', () => {
         prepareSpy.mockRestore();
       }
     });
+
+    describe('first field shape determines whether a heatmap suggestion is offered', () => {
+      function summaryWithFirstField(type: FieldType, values: readonly unknown[]) {
+        return getPanelDataSummary([
+          createDataFrame({
+            fields: [
+              { name: 'x', type, values: [...values] },
+              { name: 'time', type: FieldType.time, values: [1000, 2000, 3000] },
+              { name: 'count', type: FieldType.number, values: [1, 2, 3] },
+            ],
+          }),
+        ]);
+      }
+
+      it.each([
+        ['ascending number', FieldType.number, [1, 2, 3], true],
+        ['descending number', FieldType.number, [3, 2, 1], false],
+        ['number with NaN', FieldType.number, [1, NaN, 3], false],
+        ['number with adjacent duplicates', FieldType.number, [1, 1, 2, 2, 3], false],
+        ['string', FieldType.string, ['a', 'b', 'c'], false],
+        ['boolean', FieldType.boolean, [true, false, true], false],
+        ['ascending time', FieldType.time, [1000, 2000, 3000], true],
+        ['unsorted time', FieldType.time, [3000, 1000, 2000], false],
+      ] as const)('%s first field offers suggestion: %s', (_label, type, values, shouldSuggest) => {
+        const suggestions = heatmapSuggestionsSupplier(summaryWithFirstField(type, values));
+        if (shouldSuggest) {
+          expect(suggestions).toHaveLength(1);
+        } else {
+          expect(suggestions).toBeUndefined();
+        }
+      });
+    });
   });
 
   describe('scoring', () => {

--- a/public/app/plugins/panel/heatmap/suggestions.test.ts
+++ b/public/app/plugins/panel/heatmap/suggestions.test.ts
@@ -6,6 +6,7 @@ import {
   VisualizationSuggestionScore,
 } from '@grafana/data';
 
+import * as fields from './fields';
 import { heatmapSuggestionsSupplier } from './suggestions';
 
 describe('heatmap suggestions', () => {
@@ -37,6 +38,47 @@ describe('heatmap suggestions', () => {
 
       const suggestions = heatmapSuggestionsSupplier(dataSummary);
       expect(suggestions).toHaveLength(1);
+    });
+
+    it('should not suggest for a generic table frame whose first field is non-monotonic (e.g. issue ids)', () => {
+      const unsortedIssueIds = [1042, 87, 305, 1199, 41, 980];
+      const dataSummary = getPanelDataSummary([
+        createDataFrame({
+          fields: [
+            { name: 'id', type: FieldType.number, values: unsortedIssueIds },
+            { name: 'lastSeen', type: FieldType.time, values: [1000, 2000, 3000, 4000, 5000, 6000] },
+            { name: 'count', type: FieldType.number, values: [3, 7, 1, 9, 4, 2] },
+            { name: 'users', type: FieldType.number, values: [1, 2, 1, 3, 2, 1] },
+          ],
+        }),
+      ]);
+
+      const suggestions = heatmapSuggestionsSupplier(dataSummary);
+      expect(suggestions).toBeUndefined();
+    });
+
+    it('should not suggest when first field is non-monotonic even if prepareHeatmapData returns no warning', () => {
+      const unsortedIssueIds = [1042, 87, 305, 1199, 41, 980];
+      const frame = createDataFrame({
+        fields: [
+          { name: 'id', type: FieldType.number, values: unsortedIssueIds },
+          { name: 'lastSeen', type: FieldType.time, values: [1000, 2000, 3000, 4000, 5000, 6000] },
+          { name: 'count', type: FieldType.number, values: [3, 7, 1, 9, 4, 2] },
+          { name: 'users', type: FieldType.number, values: [1, 2, 1, 3, 2, 1] },
+        ],
+      });
+      const dataSummary = getPanelDataSummary([frame]);
+
+      const prepareSpy = jest
+        .spyOn(fields, 'prepareHeatmapData')
+        .mockReturnValue({ heatmap: frame, xBucketSize: 1, yBucketSize: 1 });
+
+      try {
+        const suggestions = heatmapSuggestionsSupplier(dataSummary);
+        expect(suggestions).toBeUndefined();
+      } finally {
+        prepareSpy.mockRestore();
+      }
     });
   });
 

--- a/public/app/plugins/panel/heatmap/suggestions.test.ts
+++ b/public/app/plugins/panel/heatmap/suggestions.test.ts
@@ -98,7 +98,7 @@ describe('heatmap suggestions', () => {
         ['ascending number', FieldType.number, [1, 2, 3], true],
         ['descending number', FieldType.number, [3, 2, 1], false],
         ['number with NaN', FieldType.number, [1, NaN, 3], false],
-        ['number with adjacent duplicates', FieldType.number, [1, 1, 2, 2, 3], false],
+        ['number with adjacent duplicates', FieldType.number, [1, 1, 2, 2, 3], true],
         ['string', FieldType.string, ['a', 'b', 'c'], false],
         ['boolean', FieldType.boolean, [true, false, true], false],
         ['ascending time', FieldType.time, [1000, 2000, 3000], true],

--- a/public/app/plugins/panel/heatmap/suggestions.ts
+++ b/public/app/plugins/panel/heatmap/suggestions.ts
@@ -1,4 +1,5 @@
 import {
+  type DataFrame,
   DataFrameType,
   FieldType,
   type PanelDataSummary,
@@ -14,6 +15,26 @@ import { type Options } from './panelcfg.gen';
 import { defaultOptions } from './types';
 
 const MAX_SUGGESTIONS_SERIES = 20;
+
+function isFirstFieldSortableAsX(frame: DataFrame): boolean {
+  const firstField = frame.fields[0];
+  if (!firstField) {
+    return false;
+  }
+  if (firstField.type === FieldType.time) {
+    return true;
+  }
+  if (firstField.type !== FieldType.number) {
+    return false;
+  }
+  const values = firstField.values;
+  for (let i = 1; i < values.length; i++) {
+    if (values[i] < values[i - 1]) {
+      return false;
+    }
+  }
+  return true;
+}
 
 function determineScore(dataSummary: PanelDataSummary): VisualizationSuggestionScore {
   // look to see if the data has an explicity marker for heatmap data on it.
@@ -55,6 +76,10 @@ export const heatmapSuggestionsSupplier: VisualizationSuggestionsSupplier<Option
     !dataSummary.hasFieldType(FieldType.time) ||
     !dataSummary.hasFieldType(FieldType.number)
   ) {
+    return;
+  }
+
+  if (!dataSummary.rawFrames.every(isFirstFieldSortableAsX)) {
     return;
   }
 

--- a/public/app/plugins/panel/heatmap/utils.test.ts
+++ b/public/app/plugins/panel/heatmap/utils.test.ts
@@ -443,7 +443,7 @@ describe('prepConfig', () => {
 
       it('does not declare the x facet as sorted when xBucketSize is negative', () => {
         const builder = buildBuilderWithInvalidBucketSize(-50);
-        expect(getHeatmapSeriesXFacetSorted(builder)).not.toBe(1);
+        expect(getHeatmapSeriesXFacetSorted(builder)).toBe(0);
       });
 
       it('does not declare the x facet as sorted when xBucketSize is zero', () => {

--- a/public/app/plugins/panel/heatmap/utils.test.ts
+++ b/public/app/plugins/panel/heatmap/utils.test.ts
@@ -434,6 +434,13 @@ describe('prepConfig', () => {
         return xFacet?.sorted;
       }
 
+      function getExemplarSeriesXFacetSorted(builder: ReturnType<typeof prepConfig>): number | undefined {
+        const config = builder.getConfig();
+        const exemplarSeries = config.series?.[2];
+        const xFacet = exemplarSeries?.facets?.[0];
+        return xFacet?.sorted;
+      }
+
       it('does not declare the x facet as sorted when xBucketSize is negative', () => {
         const builder = buildBuilderWithInvalidBucketSize(-50);
         expect(getHeatmapSeriesXFacetSorted(builder)).not.toBe(1);
@@ -446,6 +453,26 @@ describe('prepConfig', () => {
 
       it('does declare the x facet as sorted when xBucketSize is positive', () => {
         const builder = buildBuilderWithInvalidBucketSize(4);
+        expect(getHeatmapSeriesXFacetSorted(builder)).toBe(1);
+      });
+
+      it('exemplar series x facet sorted matches heatmap series x facet sorted', () => {
+        for (const xBucketSize of [-50, 0, 4]) {
+          const builder = buildBuilderWithInvalidBucketSize(xBucketSize);
+          expect(getExemplarSeriesXFacetSorted(builder)).toBe(getHeatmapSeriesXFacetSorted(builder));
+        }
+      });
+
+      it('declares x facet as sorted for time-axis heatmaps regardless of xBucketSize', () => {
+        const dataRef = { current: createMinimalHeatmapData() };
+        const builder = prepConfig({
+          dataRef,
+          theme,
+          timeZone: 'utc',
+          getTimeRange: () => timeRange,
+          exemplarColor: 'red',
+          yAxisConfig: { axisPlacement: AxisPlacement.Left },
+        });
         expect(getHeatmapSeriesXFacetSorted(builder)).toBe(1);
       });
 

--- a/public/app/plugins/panel/heatmap/utils.test.ts
+++ b/public/app/plugins/panel/heatmap/utils.test.ts
@@ -405,6 +405,66 @@ describe('prepConfig', () => {
       expect(result[0]).toBe(8);
       expect(result[1]).toBe(22);
     });
+
+    describe('uPlot config hardening when xBucketSize is non-positive', () => {
+      function buildBuilderWithInvalidBucketSize(xBucketSize: number) {
+        const dataRef = {
+          current: createNonTimeHeatmapData({ xLayout: HeatmapCellLayout.unknown, xBucketSize }),
+        };
+        return prepConfig({
+          dataRef,
+          theme,
+          timeZone: 'utc',
+          getTimeRange: () => timeRange,
+          exemplarColor: 'red',
+          yAxisConfig: { axisPlacement: AxisPlacement.Left },
+        });
+      }
+
+      function getXAxisIncrs(builder: ReturnType<typeof prepConfig>): uPlot.Axis.Incrs | undefined {
+        const config = builder.getConfig();
+        const xAxis = config.axes?.find((a) => a.scale === 'x');
+        return xAxis?.incrs;
+      }
+
+      function getHeatmapSeriesXFacetSorted(builder: ReturnType<typeof prepConfig>): number | undefined {
+        const config = builder.getConfig();
+        const heatmapSeries = config.series?.[1];
+        const xFacet = heatmapSeries?.facets?.[0];
+        return xFacet?.sorted;
+      }
+
+      it('does not declare the x facet as sorted when xBucketSize is negative', () => {
+        const builder = buildBuilderWithInvalidBucketSize(-50);
+        expect(getHeatmapSeriesXFacetSorted(builder)).not.toBe(1);
+      });
+
+      it('does not declare the x facet as sorted when xBucketSize is zero', () => {
+        const builder = buildBuilderWithInvalidBucketSize(0);
+        expect(getHeatmapSeriesXFacetSorted(builder)).not.toBe(1);
+      });
+
+      it('does declare the x facet as sorted when xBucketSize is positive', () => {
+        const builder = buildBuilderWithInvalidBucketSize(4);
+        expect(getHeatmapSeriesXFacetSorted(builder)).toBe(1);
+      });
+
+      it('does not push non-positive axis increments when xBucketSize is negative', () => {
+        const builder = buildBuilderWithInvalidBucketSize(-50);
+        const incrs = getXAxisIncrs(builder);
+        if (Array.isArray(incrs)) {
+          incrs.forEach((incr) => expect(incr).toBeGreaterThan(0));
+        }
+      });
+
+      it('does not push non-positive axis increments when xBucketSize is zero', () => {
+        const builder = buildBuilderWithInvalidBucketSize(0);
+        const incrs = getXAxisIncrs(builder);
+        if (Array.isArray(incrs)) {
+          incrs.forEach((incr) => expect(incr).toBeGreaterThan(0));
+        }
+      });
+    });
   });
 
   describe('y-scale range callback', () => {

--- a/public/app/plugins/panel/heatmap/utils.ts
+++ b/public/app/plugins/panel/heatmap/utils.ts
@@ -171,11 +171,14 @@ export function prepConfig(opts: PrepConfigOpts) {
 
   let incrs;
 
-  if (!isTime) {
+  const xBucketSize = dataRef.current?.xBucketSize;
+  const hasPositiveXBucketSize = typeof xBucketSize === 'number' && xBucketSize > 0;
+
+  if (!isTime && hasPositiveXBucketSize) {
     incrs = [];
 
-    for (let i = 0; i < 10; i++) {
-      incrs.push(i * dataRef.current?.xBucketSize!);
+    for (let i = 1; i < 10; i++) {
+      incrs.push(i * xBucketSize);
     }
   }
 
@@ -451,13 +454,15 @@ export function prepConfig(opts: PrepConfigOpts) {
 
   const pathBuilder = isSparseHeatmap ? heatmapPathsSparse : heatmapPathsDense;
 
+  const xFacetSorted = hasPositiveXBucketSize || isTime ? 1 : 0;
+
   // heatmap layer
   builder.addSeries({
     facets: [
       {
         scale: xScaleKey,
         auto: true,
-        sorted: 1,
+        sorted: xFacetSorted,
       },
       {
         scale: yScaleKey,
@@ -511,7 +516,7 @@ export function prepConfig(opts: PrepConfigOpts) {
       {
         scale: xScaleKey,
         auto: true,
-        sorted: 1,
+        sorted: xFacetSorted,
       },
       {
         scale: yScaleKey,


### PR DESCRIPTION
**What is this feature?**

This change adds guards around Heatmap inputs to uPlot to avoid a runaway loop/crash condition.

**Why do we need this feature?**

Crashing bad.

**Who is this feature for?**

Users of the Heatmap panel visualization.

**Which issue(s) does this PR fix?**:

🎟️ Fixes https://github.com/grafana/support-escalations/issues/22103

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- `N/A` If this is a pre-GA feature, it is behind a feature toggle.
- `N/A` The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
