### PR TITLE
Notifications: Recover from panics in mail.v2 attachment writer

### DIFF
--- a/pkg/services/notifications/smtp.go
+++ b/pkg/services/notifications/smtp.go
@@ -143,18 +143,34 @@ func (sc *SmtpClient) setFiles(
 	}
 
 	for _, file := range msg.EmbeddedContents {
-		m.Embed(file.Name, gomail.SetCopyFunc(func(writer io.Writer) error {
-			_, err := writer.Write(file.Content)
-			return err
-		}))
+		m.Embed(file.Name, safeCopyContent(file.Name, file.Content))
 	}
 
 	for _, file := range msg.AttachedFiles {
-		file := file
-		m.Attach(file.Name, gomail.SetCopyFunc(func(writer io.Writer) error {
-			_, err := writer.Write(file.Content)
-			return err
-		}))
+		m.Attach(file.Name, safeCopyContent(file.Name, file.Content))
+	}
+}
+
+// safeCopyContent returns a gomail SetCopyFunc closure that copies the given
+// content to the writer provided by mail.v2, converting panics into errors.
+// mail.v2's base64LineWriter (gh-go-gomail/gomail#89) does not nil-guard its
+// underlying writer and can panic mid-encoding, killing the entire process
+// because the panic propagates through the calling alert-notification
+// goroutine. Recovering here keeps the process alive: the email send fails
+// with a regular error and other notifications continue.
+func safeCopyContent(name string, content []byte) gomail.FileSetting {
+	return gomail.SetCopyFunc(copyContentFunc(name, content))
+}
+
+func copyContentFunc(name string, content []byte) func(io.Writer) error {
+	return func(writer io.Writer) (err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				err = fmt.Errorf("panic while writing email attachment %q: %v", name, r)
+			}
+		}()
+		_, err = writer.Write(content)
+		return err
 	}
 }
 

--- a/pkg/services/notifications/smtp_attachment_panic_test.go
+++ b/pkg/services/notifications/smtp_attachment_panic_test.go
@@ -1,0 +1,67 @@
+package notifications
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Regression for grafana/grafana#124000: a panic inside the writer passed by
+// mail.v2 to the SetCopyFunc closure used to crash the calling alert
+// notification goroutine, taking the whole Grafana process down. The closure
+// must convert the panic into an error so the caller can fail gracefully.
+
+type panickingWriter struct{}
+
+func (panickingWriter) Write([]byte) (int, error) {
+	var w io.Writer
+	// reproduce the mail.v2 base64LineWriter shape: call Write on a nil
+	// embedded io.Writer.
+	return w.Write(nil)
+}
+
+type stubWriter struct {
+	written []byte
+}
+
+func (s *stubWriter) Write(p []byte) (int, error) {
+	s.written = append(s.written, p...)
+	return len(p), nil
+}
+
+type errWriter struct{}
+
+var errBoom = errors.New("boom")
+
+func (errWriter) Write([]byte) (int, error) { return 0, errBoom }
+
+func TestCopyContentFunc_RecoversFromWriterPanic(t *testing.T) {
+	fn := copyContentFunc("screenshot.png", []byte("payload"))
+
+	require.NotPanics(t, func() {
+		err := fn(panickingWriter{})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "panic while writing email attachment")
+		require.Contains(t, err.Error(), "screenshot.png")
+	})
+}
+
+func TestCopyContentFunc_HappyPath(t *testing.T) {
+	w := &stubWriter{}
+	fn := copyContentFunc("ok.png", []byte("payload"))
+
+	require.NoError(t, fn(w))
+	require.Equal(t, "payload", string(w.written))
+}
+
+func TestCopyContentFunc_PropagatesWriteError(t *testing.T) {
+	fn := copyContentFunc("err.png", []byte("payload"))
+
+	err := fn(errWriter{})
+	require.ErrorIs(t, err, errBoom)
+	require.False(t, strings.Contains(err.Error(), "panic"),
+		"plain write errors must not be reported as panics")
+}


### PR DESCRIPTION
## What this PR does

Wraps the `gomail.SetCopyFunc` closure used by `SmtpClient.setFiles` with a deferred `recover` so a panic from `mail.v2`'s `base64LineWriter` is converted into a regular error instead of crashing the calling alert-notification goroutine.

## Why

Reported in #124000: when an alert email is sent with a file attachment (e.g. a panel screenshot), `mail.v2@v2.3.1` panics inside `(*base64LineWriter).Write` because the embedded `io.Writer` is nil. The panic propagates from the user-supplied `SetCopyFunc` closure up through `dialer.DialAndSend` and kills the calling goroutine. Multiple concurrent alert notifications hit the same path simultaneously and the entire Grafana process crashes.

This is a longstanding upstream `mail.v2` bug (go-gomail/gomail#89). Until/unless it is fixed upstream, the safe option is for Grafana to defend at the closure boundary it owns.

## What changes

- `pkg/services/notifications/smtp.go`: extract the per-file copy closure into `copyContentFunc`, wrap it with `defer/recover`, and route both `EmbeddedContents` and `AttachedFiles` through `safeCopyContent`. On panic, the closure now returns `panic while writing email attachment "<name>": <reason>`.
- `pkg/services/notifications/smtp_attachment_panic_test.go`: regression coverage for
  - panic from the writer is recovered and surfaced as an error,
  - the happy path still copies content unchanged,
  - plain `Write` errors are propagated as-is and not mislabeled as panics.

The fix is intentionally narrow: it does not try to address the root cause inside `mail.v2`, and does not attempt to recover panics from other mail.v2 code paths (header parsing, etc.). It addresses exactly the scenario from #124000 — a panic inside the writer passed to our `SetCopyFunc` closure — without masking unrelated bugs.

## Test plan

- [x] `go test ./pkg/services/notifications/` passes locally
- [x] New tests cover the panic-recover, happy path, and plain-error paths
- [ ] CI green

Fixes #124000