### PR TITLE
Provisioning: Return Bad request for repo mismatch in webhook

### DIFF
--- a/apps/provisioning/pkg/repository/github/webhook.go
+++ b/apps/provisioning/pkg/repository/github/webhook.go
@@ -76,11 +76,11 @@ func (r *githubWebhookRepository) Webhook(ctx context.Context, req *http.Request
 		return nil, apierrors.NewUnauthorized("invalid signature")
 	}
 
-	return r.parseWebhook(github.WebHookType(req), payload)
+	return r.parseWebhook(ctx, github.WebHookType(req), payload)
 }
 
 // This method does not include context because it does delegate any more requests
-func (r *githubWebhookRepository) parseWebhook(messageType string, payload []byte) (*provisioning.WebhookResponse, error) {
+func (r *githubWebhookRepository) parseWebhook(ctx context.Context, messageType string, payload []byte) (*provisioning.WebhookResponse, error) {
 	event, err := github.ParseWebHook(messageType, payload)
 	if err != nil {
 		return nil, apierrors.NewBadRequest("invalid payload")
@@ -88,7 +88,7 @@ func (r *githubWebhookRepository) parseWebhook(messageType string, payload []byt
 
 	switch event := event.(type) {
 	case *github.PushEvent:
-		return r.parsePushEvent(event)
+		return r.parsePushEvent(ctx, event)
 	case *github.PullRequestEvent:
 		return r.parsePullRequestEvent(event)
 	case *github.PingEvent:
@@ -104,12 +104,16 @@ func (r *githubWebhookRepository) parseWebhook(messageType string, payload []byt
 	}
 }
 
-func (r *githubWebhookRepository) parsePushEvent(event *github.PushEvent) (*provisioning.WebhookResponse, error) {
+func (r *githubWebhookRepository) parsePushEvent(ctx context.Context, event *github.PushEvent) (*provisioning.WebhookResponse, error) {
+	ctx, logger := r.logger(ctx, "")
+
 	if event.GetRepo() == nil {
 		return nil, fmt.Errorf("missing repository in push event")
 	}
-	if event.GetRepo().GetFullName() != fmt.Sprintf("%s/%s", r.owner, r.repo) {
-		return nil, fmt.Errorf("repository mismatch")
+	expected := fmt.Sprintf("%s/%s", r.owner, r.repo)
+	if event.GetRepo().GetFullName() != expected {
+		logger.Warn("webhook push event repository mismatch", "expected", expected, "got", event.GetRepo().GetFullName())
+		return nil, repository.ErrRepositoryMismatch
 	}
 
 	// No need to sync if not enabled
@@ -153,8 +157,10 @@ func (r *githubWebhookRepository) parsePullRequestEvent(event *github.PullReques
 		return nil, fmt.Errorf("missing GitHub config")
 	}
 
-	if event.GetRepo().GetFullName() != fmt.Sprintf("%s/%s", r.owner, r.repo) {
-		return nil, fmt.Errorf("repository mismatch")
+	expected := fmt.Sprintf("%s/%s", r.owner, r.repo)
+	if event.GetRepo().GetFullName() != expected {
+		slog.Warn("webhook pull request event repository mismatch", "expected", expected, "got", event.GetRepo().GetFullName())
+		return nil, repository.ErrRepositoryMismatch
 	}
 	pr := event.GetPullRequest()
 	if pr == nil {

--- a/apps/provisioning/pkg/repository/github/webhook.go
+++ b/apps/provisioning/pkg/repository/github/webhook.go
@@ -105,7 +105,7 @@ func (r *githubWebhookRepository) parseWebhook(ctx context.Context, messageType 
 }
 
 func (r *githubWebhookRepository) parsePushEvent(ctx context.Context, event *github.PushEvent) (*provisioning.WebhookResponse, error) {
-	ctx, logger := r.logger(ctx, "")
+	_, logger := r.logger(ctx, "")
 
 	if event.GetRepo() == nil {
 		return nil, fmt.Errorf("missing repository in push event")

--- a/apps/provisioning/pkg/repository/github/webhook_test.go
+++ b/apps/provisioning/pkg/repository/github/webhook_test.go
@@ -133,7 +133,7 @@ func TestParseWebhooks(t *testing.T) {
 			payload, err := os.ReadFile(path.Join("testdata", name))
 			require.NoError(t, err)
 
-			rsp, err := gh.parseWebhook(tt.messageType, payload)
+			rsp, err := gh.parseWebhook(context.Background(), tt.messageType, payload)
 			require.NoError(t, err)
 
 			require.Equal(t, tt.expected.Code, rsp.Code)
@@ -167,7 +167,7 @@ func TestParsePushEvent_LargeDiffForcesFullSync(t *testing.T) {
 	payload, err := os.ReadFile(path.Join("testdata", "webhook-push-large_diff.json"))
 	require.NoError(t, err)
 
-	rsp, err := gh.parseWebhook("push", payload)
+	rsp, err := gh.parseWebhook(context.Background(), "push", payload)
 	require.NoError(t, err)
 
 	require.Equal(t, http.StatusAccepted, rsp.Code)

--- a/apps/provisioning/pkg/repository/github/webhook_test.go
+++ b/apps/provisioning/pkg/repository/github/webhook_test.go
@@ -400,7 +400,7 @@ func TestGitHubRepository_Webhook(t *testing.T) {
 
 				return req
 			},
-			expectedError: fmt.Errorf("repository mismatch"),
+			expectedError: repo.ErrRepositoryMismatch,
 		},
 		{
 			name: "push event when sync is disabled",
@@ -779,7 +779,7 @@ func TestGitHubRepository_Webhook(t *testing.T) {
 
 				return req
 			},
-			expectedError: fmt.Errorf("repository mismatch"),
+			expectedError: repo.ErrRepositoryMismatch,
 		},
 		{
 			name: "pull request event missing pull request info",

--- a/apps/provisioning/pkg/repository/repository.go
+++ b/apps/provisioning/pkg/repository/repository.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"errors"
 	"net/http"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -75,6 +76,8 @@ var ErrTooManyItems error = &apierrors.StatusError{ErrStatus: metav1.Status{
 	Reason:  metav1.StatusReasonBadRequest,
 	Message: "maximum number of items exceeded",
 }}
+
+var ErrRepositoryMismatch = errors.New("repository mismatch")
 
 type FileInfo struct {
 	// Path to the file on disk.

--- a/apps/provisioning/pkg/repository/repository.go
+++ b/apps/provisioning/pkg/repository/repository.go
@@ -2,7 +2,6 @@ package repository
 
 import (
 	"context"
-	"errors"
 	"net/http"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -77,7 +76,7 @@ var ErrTooManyItems error = &apierrors.StatusError{ErrStatus: metav1.Status{
 	Message: "maximum number of items exceeded",
 }}
 
-var ErrRepositoryMismatch = errors.New("repository mismatch")
+var ErrRepositoryMismatch = apierrors.NewBadRequest("repository mismatch")
 
 type FileInfo struct {
 	// Path to the file on disk.

--- a/pkg/registry/apis/provisioning/webhooks/webhook.go
+++ b/pkg/registry/apis/provisioning/webhooks/webhook.go
@@ -2,6 +2,7 @@ package webhooks
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -152,6 +153,10 @@ func (s *webhookConnector) Connect(ctx context.Context, name string, opts runtim
 		rsp, err := hooks.Webhook(ctx, r)
 		if err != nil {
 			span.RecordError(err)
+			if stderrors.Is(err, repository.ErrRepositoryMismatch) {
+				responder.Error(errors.NewBadRequest(repository.ErrRepositoryMismatch.Error()))
+				return
+			}
 			responder.Error(err)
 			return
 		}

--- a/pkg/registry/apis/provisioning/webhooks/webhook.go
+++ b/pkg/registry/apis/provisioning/webhooks/webhook.go
@@ -2,7 +2,6 @@ package webhooks
 
 import (
 	"context"
-	stderrors "errors"
 	"fmt"
 	"net/http"
 	"time"
@@ -153,10 +152,6 @@ func (s *webhookConnector) Connect(ctx context.Context, name string, opts runtim
 		rsp, err := hooks.Webhook(ctx, r)
 		if err != nil {
 			span.RecordError(err)
-			if stderrors.Is(err, repository.ErrRepositoryMismatch) {
-				responder.Error(errors.NewBadRequest(repository.ErrRepositoryMismatch.Error()))
-				return
-			}
 			responder.Error(err)
 			return
 		}


### PR DESCRIPTION
## Summary

Returns HTTP 400 instead of 500 when a GitHub webhook event targets a different repository than the one configured.

### Problem

When a webhook push or pull request event arrives with a `repository.full_name` that doesn't match the configured owner/repo, the webhook handler returned a plain `fmt.Errorf("repository mismatch")`. The K8s responder treated this as an internal error and responded with HTTP 500, which counted against the Git Sync provisioning SLO error budget.

### Fix

- Added `ErrRepositoryMismatch` sentinel error in the repository package.
- Webhook handler returns the sentinel and logs expected vs actual repo names at `Warn` level (details stay server-side, not leaked in the response).
- Webhook connector checks for the sentinel via `errors.Is` and converts it to a `400 Bad Request`.

### Files changed

- **`apps/provisioning/pkg/repository/repository.go`**: Added `ErrRepositoryMismatch` sentinel error.
- **`apps/provisioning/pkg/repository/github/webhook.go`**: Push and PR event parsers return the sentinel on mismatch, log expected/got values.
- **`pkg/registry/apis/provisioning/webhooks/webhook.go`**: Connector converts `ErrRepositoryMismatch` to `400 Bad Request`.
- **`apps/provisioning/pkg/repository/github/webhook_test.go`**: Updated mismatch test expectations to use the sentinel.

## Test plan

- [x] `go test ./apps/provisioning/pkg/repository/github/...`
- [x] `make gofmt && make lint-go-diff` (0 issues)