### PR TITLE
chore: add overload to invalidateCachedPromise

### DIFF
--- a/packages/grafana-runtime/src/utils/getCachedPromise.test.ts
+++ b/packages/grafana-runtime/src/utils/getCachedPromise.test.ts
@@ -841,7 +841,7 @@ describe('cached promises', () => {
 
     test('should invalidate cache for cacheKey', async () => {
       const actual1 = await getCachedPromise(simulateOkRequest, { cacheKey: 'the-key' });
-      invalidateCachedPromise(simulateOkRequest, { cacheKey: 'the-key' });
+      invalidateCachedPromise('the-key');
       const actual2 = await getCachedPromise(simulateOkRequest, { cacheKey: 'the-key' });
 
       expect(actual1).toStrictEqual({ ok: true, status: 200, statusText: 'ok' });
@@ -873,22 +873,41 @@ describe('cached promises', () => {
       );
     });
 
-    test('should not throw when called with an anonymous function and a cacheKey', () => {
-      expect(() => invalidateCachedPromise(async () => 2, { cacheKey: 'a-cache-key' })).not.toThrow();
+    test('should not throw when called with a cacheKey', () => {
+      expect(() => invalidateCachedPromise('a-cache-key')).not.toThrow();
     });
 
-    test('should prefer cacheKey over the key derived from the function', async () => {
-      const actual1 = await getCachedPromise(simulateOkRequest);
-      const actual2 = await getCachedPromise(simulateOkRequest, { cacheKey: 'explicit-key' });
+    test('should throw when called with an empty cacheKey', () => {
+      expect(() => invalidateCachedPromise('')).toThrow(
+        'invalidateCachedPromise function must be invoked with a named function or cacheKey'
+      );
+    });
 
-      invalidateCachedPromise(simulateOkRequest, { cacheKey: 'explicit-key' });
+    test('cacheKey overload only affects entries under that key', async () => {
+      const a1 = await getCachedPromise(simulateOkRequest);
+      const b1 = await getCachedPromise(simulateOkRequest, { cacheKey: 'explicit-key' });
 
-      const actual3 = await getCachedPromise(simulateOkRequest);
-      const actual4 = await getCachedPromise(simulateOkRequest, { cacheKey: 'explicit-key' });
+      invalidateCachedPromise('explicit-key');
 
-      expect(actual1).toBe(actual3);
-      expect(actual1).not.toBe(actual2);
-      expect(actual2).not.toBe(actual4);
+      const a2 = await getCachedPromise(simulateOkRequest);
+      const b2 = await getCachedPromise(simulateOkRequest, { cacheKey: 'explicit-key' });
+
+      expect(a2).toBe(a1);
+      expect(b2).not.toBe(b1);
+    });
+
+    test('should be a no-op when there is no cached entry for the cacheKey', () => {
+      expect(() => invalidateCachedPromise('non-existent-key')).not.toThrow();
+    });
+
+    test('should accept a cacheKey returned by getCacheKeyFromPromise', async () => {
+      const a1 = await getCachedPromise(simulateOkRequest);
+      const derivedKey = getCacheKeyFromPromise(simulateOkRequest)!;
+
+      invalidateCachedPromise(derivedKey);
+      const a2 = await getCachedPromise(simulateOkRequest);
+
+      expect(a2).not.toBe(a1);
     });
   });
 

--- a/packages/grafana-runtime/src/utils/getCachedPromise.ts
+++ b/packages/grafana-runtime/src/utils/getCachedPromise.ts
@@ -286,24 +286,27 @@ export function getCachedPromiseWithArgs<T, TArgs extends unknown[]>(
 /**
  * Removes a cached promise entry so the next call with the same key re-executes the function.
  *
- * The key is derived from the promise function's name and body via {@link getCacheKeyFromPromise},
- * unless an explicit `cacheKey` is provided — in which case it takes precedence and `promise` is
- * only used for type inference.
- *
+ * The key is derived from the promise function's name and body via {@link getCacheKeyFromPromise}.
  * Silently no-ops when no entry exists for the resolved key.
  *
  * @template T - The type of the resolved promise value
  * @param promise - The promise-returning function whose cache entry should be invalidated. Inline
- *   arrow functions are anonymous and require an explicit `cacheKey` — or assign the arrow to a
- *   `const` first so name inference applies.
- * @param options - Optional options object
- * @param options.cacheKey - Optional explicit cache key. When provided, takes precedence over the key
- *   derived from `promise`.
- * @throws {Error} when neither a named function nor a `cacheKey` is supplied
+ *   arrow functions are anonymous and will be rejected — use the `cacheKey` overload instead, or
+ *   assign the arrow to a `const` first so name inference applies.
+ * @throws {Error} when the function is anonymous
  */
-export function invalidateCachedPromise<T>(promise: PromiseFunction<T>, options?: CacheKeyOptions): void {
-  const { cacheKey } = options ?? {};
-  const key = cacheKey ?? getCacheKeyFromPromise(promise);
+export function invalidateCachedPromise<T>(promise: PromiseFunction<T>): void;
+/**
+ * Removes a cached promise entry so the next call with the same key re-executes the function.
+ *
+ * Silently no-ops when no entry exists for the given key.
+ *
+ * @param cacheKey - The explicit cache key for the entry to invalidate.
+ * @throws {Error} when `cacheKey` is empty
+ */
+export function invalidateCachedPromise(cacheKey: string): void;
+export function invalidateCachedPromise(promiseOrKey: PromiseFunction<unknown> | string): void {
+  const key = typeof promiseOrKey === 'string' ? promiseOrKey : getCacheKeyFromPromise(promiseOrKey);
 
   if (!key) {
     throw new Error(`invalidateCachedPromise function must be invoked with a named function or cacheKey`);


### PR DESCRIPTION
**What is this feature?**

Adds a `cacheKey` overload to `invalidateCachedPromise` so callers with an explicit key can invoke it as `invalidateCachedPromise('the-key')` instead of `invalidateCachedPromise(promise, { cacheKey: 'the-key' })`.

**Why do we need this feature?**

So the signature lines up with `replaceCachedPromise` and callers that already have the key don't have to drag the promise function along.

**Who is this feature for?**

Grafana devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
