### PR TITLE
Plugins: preinstall grafana-assistant-app on Enterprise

### DIFF
--- a/pkg/setting/setting_plugins.go
+++ b/pkg/setting/setting_plugins.go
@@ -156,6 +156,9 @@ func (cfg *Cfg) readPluginSettings(iniFile *ini.File) error {
 		if cfg.IsFeatureToggleEnabled("interactiveLearning") { // Use literal string to avoid circular dependency
 			preinstallPluginsAsync["grafana-pathfinder-app"] = InstallPlugin{"grafana-pathfinder-app", "", ""}
 		}
+		if cfg.IsEnterprise {
+			preinstallPluginsAsync["grafana-assistant-app"] = InstallPlugin{"grafana-assistant-app", "", ""}
+		}
 		cfg.processPreinstallPlugins(rawInstallPluginsAsync, preinstallPluginsAsync)
 
 		rawInstallPluginsSync := util.SplitString(pluginsSection.Key("preinstall_sync").MustString(""))

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -504,6 +504,11 @@ func createGrafDir(t *testing.T, tmpDir string, opts GrafanaOpts) (string, strin
 		return section, err
 	}
 
+	pluginsSect, err := getOrCreateSection("plugins")
+	require.NoError(t, err)
+	_, err = pluginsSect.NewKey("disable_plugins", "grafana-assistant-app")
+	require.NoError(t, err)
+
 	if opts.EnableCSP {
 		securitySect, err := cfg.NewSection("security")
 		require.NoError(t, err)
@@ -567,15 +572,15 @@ func createGrafDir(t *testing.T, tmpDir string, opts GrafanaOpts) (string, strin
 		require.NoError(t, err)
 	}
 	if opts.PluginAdminEnabled {
-		anonSect, err := cfg.NewSection("plugins")
+		pluginsSect, err := getOrCreateSection("plugins")
 		require.NoError(t, err)
-		_, err = anonSect.NewKey("plugin_admin_enabled", "true")
+		_, err = pluginsSect.NewKey("plugin_admin_enabled", "true")
 		require.NoError(t, err)
 	}
 	if opts.PluginAdminExternalManageEnabled {
-		anonSect, err := cfg.NewSection("plugins")
+		pluginsSect, err := getOrCreateSection("plugins")
 		require.NoError(t, err)
-		_, err = anonSect.NewKey("plugin_admin_external_manage_enabled", "true")
+		_, err = pluginsSect.NewKey("plugin_admin_external_manage_enabled", "true")
 		require.NoError(t, err)
 	}
 	if opts.ViewersCanEdit {


### PR DESCRIPTION
## Summary

* Adds `grafana-assistant-app` to the async preinstall plugin list when running Grafana Enterprise.
* Follows the same conditional pattern used for feature-toggle-gated plugins (e.g. `grafana-advisor-app`).
* Users can opt out by adding `grafana-assistant-app` to the `disable_plugins` configuration.
* Disables plugin preinstall in the integration test infrastructure to prevent real network calls to `grafana.com` during tests — this was causing cumulative timeouts (the alerting test package alone spins up ~120 Grafana server instances, each triggering preinstall HTTP calls).

## Test plan

* Verify `grafana-assistant-app` appears in `PreinstallPluginsAsync` when `cfg.IsEnterprise == true`
* Verify it does not appear when `cfg.IsEnterprise == false` (OSS build)
* Verify it is removed when listed in `disable_plugins`
* Verify integration tests pass without timeout (the `preinstall_disabled = true` setting prevents network calls)