### PR TITLE
fix: Display the add variable button in edit mode when there are no controls and the time picker is hidden

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardControls.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControls.test.tsx
@@ -165,6 +165,29 @@ describe('DashboardControls', () => {
       }
     });
 
+    it('in edit mode, should render the "Add variable" button when hasControls returns false and time controls are hidden', async () => {
+      const originalFeatureToggles = { ...config.featureToggles };
+      try {
+        config.featureToggles.dashboardNewLayouts = true;
+
+        const controls = buildTestSceneWithEditable({
+          editable: true,
+          canEdit: true,
+          isEditing: true,
+        });
+        controls.setState({ hideTimeControls: true });
+
+        const renderer = renderInGrafanaContext(<controls.Component model={controls} />);
+
+        expect(renderer.getByTestId(selectors.pages.Dashboard.Controls)).toBeInTheDocument();
+        expect(renderer.queryByTestId(selectors.components.TimePicker.openButton)).not.toBeInTheDocument();
+        expect(renderer.queryByTestId(selectors.components.RefreshPicker.runButtonV2)).not.toBeInTheDocument();
+        expect(renderer.getByRole('button', { name: /add variable/i })).toBeInTheDocument();
+      } finally {
+        config.featureToggles = originalFeatureToggles;
+      }
+    });
+
     it('should render Table view toggle in panel edit mode even when all other controls are hidden', () => {
       const controls = new DashboardControls({
         hideTimeControls: true,

--- a/public/app/features/dashboard-scene/scene/DashboardControls.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControls.tsx
@@ -178,6 +178,7 @@ function DashboardControlsRenderer({ model }: SceneComponentProps<DashboardContr
       return (
         <>
           <div data-testid={selectors.pages.Dashboard.Controls} className={styles.controls}>
+            {!hideVariableControls && <VariableControls dashboard={dashboard} />}
             <div className={styles.rightControls}>
               <div className={styles.fixedControls}>
                 <DashboardControlActions dashboard={dashboard} hidePlaylistNav={hidePlaylistNav} />


### PR DESCRIPTION
This PR fixes a small bug spotted while testing https://github.com/grafana/grafana/pull/124396

When hiding the time picker via the URL (setting `_dash.hideTimePicker=true`) and no existing variables, links, or annotations exist on the dashboard, the "Add variable" button does not appear in edit mode.

**How to test?**

- Open or create a dashboard with no variables, no links, no annotations. no filters
- Enter edit mode
- Confirm the "Add variable" (+) button is visible
- Append `&_dash.hideTimePicker=true` to the URL and reload
- Confirm the "Add variable" button is still visible
- Append `&_dash.hideVariables=true` and reload 
- Confirm the button is hidden