### PR TITLE
Alerting: Bound size of label/annotation strings in external sender

### DIFF
--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -113,6 +113,11 @@ type AlertmanagerConfig struct {
 
 	// RuntimeConfig specifies runtime behavior settings for the remote Alertmanager.
 	RuntimeConfig remoteClient.RuntimeConfig
+
+	// MaxLabelStringSize overrides the sender's byte cap on any single
+	// label/annotation name or value. Nil keeps the sender default
+	// (sender.DefaultMaxLabelStringSize); a non-positive value disables the clamp.
+	MaxLabelStringSize *int
 }
 
 func (cfg *AlertmanagerConfig) Validate() error {
@@ -179,11 +184,17 @@ func NewAlertmanager(
 		return c.Do(req.WithContext(ctx))
 	}
 	senderLogger := log.New("ngalert.sender.external-alertmanager")
+	senderOpts := []sender.Option{
+		sender.WithDoFunc(doFunc),
+		sender.WithUTF8Labels(),
+	}
+	if cfg.MaxLabelStringSize != nil {
+		senderOpts = append(senderOpts, sender.WithMaxLabelStringSize(*cfg.MaxLabelStringSize))
+	}
 	s, err := sender.NewExternalAlertmanagerSender(
 		senderLogger,
 		prometheus.NewRegistry(),
-		sender.WithDoFunc(doFunc),
-		sender.WithUTF8Labels(),
+		senderOpts...,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/services/ngalert/sender/notifier.go
+++ b/pkg/services/ngalert/sender/notifier.go
@@ -138,6 +138,8 @@ type alertMetrics struct {
 	queueLength             prometheus.GaugeFunc
 	queueCapacity           prometheus.Gauge
 	alertmanagersDiscovered prometheus.GaugeFunc
+	// Extension: counts label/annotation strings clamped by the sender.
+	clampedStrings *prometheus.CounterVec
 }
 
 // NewManager is the manager constructor.

--- a/pkg/services/ngalert/sender/notifier_ext.go
+++ b/pkg/services/ngalert/sender/notifier_ext.go
@@ -104,6 +104,15 @@ func newAlertMetrics(r prometheus.Registerer, queueCap int, queueLen, alertmanag
 			Name: "alertmanagers_discovered",
 			Help: "The number of alertmanagers discovered and active.",
 		}, alertmanagersDiscovered),
+		// Extension: New metric counting label/annotation strings clamped before sending.
+		clampedStrings: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: namespace,
+			Subsystem: subsystem,
+			Name:      "clamped_strings_total",
+			Help:      "Total number of label/annotation strings clamped before sending: oversized values truncated or oversized names dropped.",
+		},
+			[]string{"kind", "reason"},
+		),
 	}
 
 	m.queueCapacity.Set(float64(queueCap))
@@ -117,6 +126,7 @@ func newAlertMetrics(r prometheus.Registerer, queueCap int, queueLen, alertmanag
 			m.queueLength,
 			m.queueCapacity,
 			m.alertmanagersDiscovered,
+			m.clampedStrings,
 		)
 	}
 

--- a/pkg/services/ngalert/sender/sender.go
+++ b/pkg/services/ngalert/sender/sender.go
@@ -12,7 +12,9 @@ import (
 	"sync"
 	"time"
 	"unicode"
+	"unicode/utf8"
 
+	alertingModels "github.com/grafana/alerting/models"
 	"github.com/prometheus/alertmanager/api/v2/models"
 	"github.com/prometheus/client_golang/prometheus"
 	common_config "github.com/prometheus/common/config"
@@ -29,6 +31,11 @@ const (
 	defaultMaxQueueCapacity = 10000
 	defaultTimeout          = 10 * time.Second
 	defaultDrainOnShutdown  = true
+
+	// DefaultMaxLabelStringSize is the default byte cap applied to any single
+	// label/annotation name or value forwarded to an Alertmanager. The
+	// prometheus stringlabels encoder panics on strings larger than 16 MiB.
+	DefaultMaxLabelStringSize = 1 << 22 // 4 MiB
 )
 
 // ExternalAlertmanager is responsible for dispatching alert notifications to an external Alertmanager service.
@@ -61,6 +68,9 @@ type ExternalAMcfg struct {
 type ExternalAMOptions struct {
 	Options
 	sanitizeLabelSetFn func(lbls models.LabelSet) labels.Labels
+	// MaxLabelStringSize caps the byte length of any single label/annotation
+	// name or value. A non-positive value disables the clamp.
+	MaxLabelStringSize int
 }
 
 type Option func(*ExternalAMOptions)
@@ -85,6 +95,15 @@ func WithUTF8Labels() Option {
 			}
 			return labels.New(ls...)
 		}
+	}
+}
+
+// WithMaxLabelStringSize overrides the byte cap applied to label/annotation
+// names and values. The default is [DefaultMaxLabelStringSize]; a non-positive
+// value disables the clamp.
+func WithMaxLabelStringSize(size int) Option {
+	return func(opts *ExternalAMOptions) {
+		opts.MaxLabelStringSize = size
 	}
 }
 
@@ -145,6 +164,7 @@ func NewExternalAlertmanagerSender(l log.Logger, reg prometheus.Registerer, opts
 			Registerer:      reg,
 			DrainOnShutdown: defaultDrainOnShutdown,
 		},
+		MaxLabelStringSize: DefaultMaxLabelStringSize,
 	}
 
 	for _, opt := range opts {
@@ -356,14 +376,68 @@ func externalAMcfgToAlertmanagerConfig(am ExternalAMcfg) (*config.AlertmanagerCo
 }
 
 func (s *ExternalAlertmanager) alertToNotifierAlert(alert models.PostableAlert) *Alert {
+	alertName := alert.Labels[model.AlertNameLabel]
+	ruleUID := alert.Labels[alertingModels.RuleUIDLabel]
 	// Prometheus alertmanager has stricter rules for annotations/labels than grafana's internal alertmanager, so we sanitize invalid keys.
 	return &Alert{
-		Labels:       s.options.sanitizeLabelSetFn(alert.Labels),
-		Annotations:  s.options.sanitizeLabelSetFn(alert.Annotations),
+		Labels:       s.options.sanitizeLabelSetFn(s.clampLabelSet(alert.Labels, "label", alertName, ruleUID)),
+		Annotations:  s.options.sanitizeLabelSetFn(s.clampLabelSet(alert.Annotations, "annotation", alertName, ruleUID)),
 		StartsAt:     time.Time(alert.StartsAt),
 		EndsAt:       time.Time(alert.EndsAt),
 		GeneratorURL: alert.GeneratorURL.String(),
 	}
+}
+
+// clampLabelSet bounds every name and value to MaxLabelStringSize so labels.New
+// cannot hit the prometheus stringlabels panic on strings larger than 16 MiB.
+// Oversized values are truncated; oversized names are dropped, since truncating
+// names risks key collisions.
+func (s *ExternalAlertmanager) clampLabelSet(lbls models.LabelSet, kind, alertName, ruleUID string) models.LabelSet {
+	maxSize := s.options.MaxLabelStringSize
+	if maxSize <= 0 {
+		return lbls
+	}
+
+	needsClamp := false
+	for k, v := range lbls {
+		if len(k) > maxSize || len(v) > maxSize {
+			needsClamp = true
+			break
+		}
+	}
+	if !needsClamp {
+		return lbls
+	}
+
+	clamped := make(models.LabelSet, len(lbls))
+	for k, v := range lbls {
+		if len(k) > maxSize {
+			s.logger.Warn("Dropping label/annotation with name exceeding size cap",
+				"kind", kind, "namePrefix", truncateUTF8(k, 64), "size", len(k), "cap", maxSize, "alertname", alertName, "rule_uid", ruleUID)
+			s.manager.metrics.clampedStrings.WithLabelValues(kind, "name_dropped").Inc()
+			continue
+		}
+		if len(v) > maxSize {
+			s.logger.Warn("Truncating label/annotation value exceeding size cap",
+				"kind", kind, "name", k, "size", len(v), "cap", maxSize, "alertname", alertName, "rule_uid", ruleUID)
+			s.manager.metrics.clampedStrings.WithLabelValues(kind, "value_truncated").Inc()
+			v = truncateUTF8(v, maxSize)
+		}
+		clamped[k] = v
+	}
+	return clamped
+}
+
+// truncateUTF8 truncates s to at most n bytes without splitting a multi-byte
+// rune; the Alertmanager API rejects invalid UTF-8 label values.
+func truncateUTF8(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	for n > 0 && !utf8.RuneStart(s[n]) {
+		n--
+	}
+	return s[:n]
 }
 
 // sanitizeLabelSet sanitizes all given LabelSet keys according to sanitizeLabelName.

--- a/pkg/services/ngalert/sender/sender_test.go
+++ b/pkg/services/ngalert/sender/sender_test.go
@@ -2,11 +2,14 @@ package sender
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 	"time"
+	"unicode/utf8"
 
 	"github.com/prometheus/alertmanager/api/v2/models"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
 	common_config "github.com/prometheus/common/config"
 	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
@@ -230,6 +233,113 @@ func TestWithUTF8Labels(t *testing.T) {
 		result := am.alertToNotifierAlert(alert)
 		require.Equal(t, "test", result.Annotations.Get("some_name"))
 		require.Equal(t, "fire", result.Labels.Get("_0x1f525"))
+	})
+}
+
+func TestClampLabelSet(t *testing.T) {
+	logger := log.NewNopLogger()
+
+	t.Run("default cap: oversized value truncated, oversized name dropped, no panic", func(t *testing.T) {
+		// Above the prometheus stringlabels panic threshold (1<<24); without the
+		// clamp this would panic in labels.New downstream.
+		hugeVal := strings.Repeat("a", (1<<24)+1024)
+		hugeName := strings.Repeat("n", (1<<24)+1)
+
+		alert := models.PostableAlert{
+			Annotations: models.LabelSet{
+				"__value_string__": hugeVal,
+				hugeName:           "anything",
+			},
+			Alert: models.Alert{
+				Labels: models.LabelSet{
+					"alertname": "X",
+					"big":       hugeVal,
+				},
+			},
+		}
+
+		// Both sanitizeLabelSetFn paths call labels.New, the panic point.
+		for _, opts := range [][]Option{{WithUTF8Labels()}, nil} {
+			am, err := NewExternalAlertmanagerSender(logger, prometheus.NewRegistry(), opts...)
+			require.NoError(t, err)
+
+			require.NotPanics(t, func() {
+				result := am.alertToNotifierAlert(alert)
+				require.Len(t, result.Labels.Get("big"), DefaultMaxLabelStringSize)
+				require.Len(t, result.Annotations.Get("__value_string__"), DefaultMaxLabelStringSize)
+				require.Equal(t, "", result.Annotations.Get(hugeName))
+				require.Equal(t, "X", result.Labels.Get("alertname"))
+			})
+
+			clamped := am.manager.metrics.clampedStrings
+			require.Equal(t, float64(1), testutil.ToFloat64(clamped.WithLabelValues("annotation", "value_truncated")))
+			require.Equal(t, float64(1), testutil.ToFloat64(clamped.WithLabelValues("annotation", "name_dropped")))
+			require.Equal(t, float64(1), testutil.ToFloat64(clamped.WithLabelValues("label", "value_truncated")))
+		}
+	})
+
+	t.Run("payload below cap is unchanged", func(t *testing.T) {
+		alert := models.PostableAlert{
+			Annotations: models.LabelSet{"summary": "ok"},
+			Alert:       models.Alert{Labels: models.LabelSet{"alertname": "X"}},
+		}
+		am, err := NewExternalAlertmanagerSender(logger, prometheus.NewRegistry(), WithUTF8Labels())
+		require.NoError(t, err)
+		result := am.alertToNotifierAlert(alert)
+		require.Equal(t, "ok", result.Annotations.Get("summary"))
+		require.Equal(t, "X", result.Labels.Get("alertname"))
+	})
+
+	t.Run("WithMaxLabelStringSize overrides the cap", func(t *testing.T) {
+		const customCap = 16
+		alert := models.PostableAlert{
+			Annotations: models.LabelSet{"summary": strings.Repeat("a", 100)},
+			Alert:       models.Alert{Labels: models.LabelSet{"alertname": "X"}},
+		}
+		am, err := NewExternalAlertmanagerSender(
+			logger, prometheus.NewRegistry(),
+			WithUTF8Labels(),
+			WithMaxLabelStringSize(customCap),
+		)
+		require.NoError(t, err)
+		result := am.alertToNotifierAlert(alert)
+		require.Len(t, result.Annotations.Get("summary"), customCap)
+	})
+
+	t.Run("WithMaxLabelStringSize(0) disables the clamp", func(t *testing.T) {
+		val := strings.Repeat("a", 100)
+		alert := models.PostableAlert{
+			Annotations: models.LabelSet{"summary": val},
+			Alert:       models.Alert{Labels: models.LabelSet{"alertname": "X"}},
+		}
+		am, err := NewExternalAlertmanagerSender(
+			logger, prometheus.NewRegistry(),
+			WithUTF8Labels(),
+			WithMaxLabelStringSize(0),
+		)
+		require.NoError(t, err)
+		result := am.alertToNotifierAlert(alert)
+		require.Equal(t, val, result.Annotations.Get("summary"))
+	})
+
+	t.Run("truncation does not split a multi-byte rune", func(t *testing.T) {
+		// 10-byte cap lands mid-rune: three 4-byte runes occupy bytes 0-11.
+		const customCap = 10
+		val := strings.Repeat("🔥", 3)
+		alert := models.PostableAlert{
+			Annotations: models.LabelSet{"summary": val},
+			Alert:       models.Alert{Labels: models.LabelSet{"alertname": "X"}},
+		}
+		am, err := NewExternalAlertmanagerSender(
+			logger, prometheus.NewRegistry(),
+			WithUTF8Labels(),
+			WithMaxLabelStringSize(customCap),
+		)
+		require.NoError(t, err)
+		result := am.alertToNotifierAlert(alert)
+		got := result.Annotations.Get("summary")
+		require.True(t, utf8.ValidString(got))
+		require.Equal(t, strings.Repeat("🔥", 2), got)
 	})
 }
 


### PR DESCRIPTION
**What is this feature?**

Caps the byte length of label/annotation names and values forwarded by the ngalert external Alertmanager sender. Oversized values are truncated at a rune boundary; oversized names are dropped. The default cap is 4 MiB (`DefaultMaxLabelStringSize`), tunable per-sender with `WithMaxLabelStringSize`; a non-positive value disables it.

**Why do we need this feature?**

#123736 bumped prometheus to v0.311.3, where `stringlabels` became the default labels implementation. Its encoder panics on any single string larger than 16 MiB, a limit structural to the wire format (24-bit length prefix), so it cannot be raised upstream. A single rule producing a sufficiently large templated annotation is enough to take down the whole process; there is no `recover()` in the dispatch path. The previous slice-based implementation had no size limit, so this is a regression guard.

**Who is this feature for?**

Operators of the ngalert sender (in-tree and downstream consumers of `pkg/services/ngalert/sender`).

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

- The clamp runs in `alertToNotifierAlert` before `sanitizeLabelSetFn`, so it covers both the default sanitize path and `WithUTF8Labels`.
- Truncation lands on a rune boundary because the Alertmanager API rejects invalid UTF-8 label values; a mid-rune cut would swap the panic for silently rejected alerts.
- 4 MiB leaves generous headroom under the 16 MiB panic threshold without changing behavior for any realistic annotation. The truncation warn logs identify affected rules.
- Observability: clamps increment `grafana_alerting_sender_clamped_strings_total{kind="label"|"annotation", reason="value_truncated"|"name_dropped"}`, and the warn logs carry `alertname` and `rule_uid` so the offending rule can be identified directly.
- `remote.AlertmanagerConfig` gets an optional `MaxLabelStringSize *int` field so embedders of the remote Alertmanager (e.g. the ruler) can tune the cap: nil keeps the default, a non-positive value disables the clamp.
