### PR TITLE
Provisioning: Migrate provisioningReadmes toggle to OpenFeature (provisioning.readmes)

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -154,11 +154,6 @@ export interface FeatureToggles {
   */
   provisioningExport?: boolean;
   /**
-  * Render the README.md of a Git Sync provisioned folder inline below its dashboards list
-  * @default false
-  */
-  provisioningReadmes?: boolean;
-  /**
   * Start an additional https handler and write kubectl options
   * @default false
   */

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
@@ -13,6 +13,7 @@ declare module "@openfeature/core" {
     | "lokiShardSplitting"
     | "faroSessionReplay"
     | "provisioningFolderMetadata"
+    | "provisioning.readmes"
     | "stateTimeline.nameAboveBars"
     | "newSavedQueriesExperience"
     | "grafana.orgDashboardTemplates"

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -61,6 +61,8 @@ export const FlagKeys = {
   PluginsUseMTPluginSettings: "plugins.useMTPluginSettings",
   /** Enables plugins decoupling from bootdata */
   PluginsUseMTPlugins: "plugins.useMTPlugins",
+  /** Render the README.md of a Git Sync provisioned folder inline below its dashboards list */
+  ProvisioningReadmes: "provisioning.readmes",
   /** Allow setting folder metadata for provisioned folders */
   ProvisioningFolderMetadata: "provisioningFolderMetadata",
   /** Enables next generation query editor experience */
@@ -341,6 +343,17 @@ export const useFlagPluginsUseMTPluginSettings = (options?: ReactFlagEvaluationO
  */
 export const useFlagPluginsUseMTPlugins = (options?: ReactFlagEvaluationOptions): boolean => {
   return useFlag("plugins.useMTPlugins", false, options).value;
+};
+
+/**
+ * Render the README.md of a Git Sync provisioned folder inline below its dashboards list
+ *
+ * **Details:**
+ * - flag key: `provisioning.readmes`
+ * - default value: `false`
+ */
+export const useFlagProvisioningReadmes = (options?: ReactFlagEvaluationOptions): boolean => {
+  return useFlag("provisioning.readmes", false, options).value;
 };
 
 /**

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -253,12 +253,12 @@ var (
 			Generate:        Generate{LegacyGo: true, LegacyFrontend: true},
 		},
 		{
-			Name:        "provisioningReadmes",
+			Name:        "provisioning.readmes",
 			Description: "Render the README.md of a Git Sync provisioned folder inline below its dashboards list",
 			Stage:       FeatureStageExperimental,
 			Owner:       grafanaAppPlatformSquad,
 			Expression:  "false",
-			Generate:    Generate{LegacyFrontend: true},
+			Generate:    Generate{React: true},
 		},
 		{
 			Name:            "grafanaAPIServerEnsureKubectlAccess",

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -27,7 +27,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2024-11-22,provisioning,GA,@grafana/grafana-app-platform-squad,false,true,false
 2026-02-23,provisioningFolderMetadata,GA,@grafana/grafana-app-platform-squad,false,true,false
 2026-02-23,provisioningExport,experimental,@grafana/grafana-app-platform-squad,false,true,false
-2026-04-28,provisioningReadmes,experimental,@grafana/grafana-app-platform-squad,false,false,true
+2026-05-08,provisioning.readmes,experimental,@grafana/grafana-app-platform-squad,false,false,true
 2023-12-06,grafanaAPIServerEnsureKubectlAccess,experimental,@grafana/grafana-app-platform-squad,true,true,false
 2023-07-21,awsAsyncQueryCaching,GA,@grafana/data-sources-plugins,false,false,false
 2023-07-26,configurableSchedulerTick,experimental,@grafana/alerting-squad,false,true,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -4901,6 +4901,20 @@
     },
     {
       "metadata": {
+        "name": "provisioning.readmes",
+        "resourceVersion": "1778221429422",
+        "creationTimestamp": "2026-05-08T06:23:49Z"
+      },
+      "spec": {
+        "description": "Render the README.md of a Git Sync provisioned folder inline below its dashboards list",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "frontend": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "provisioningExport",
         "resourceVersion": "1771845933585",
         "creationTimestamp": "2026-02-23T11:25:33Z"
@@ -4934,7 +4948,8 @@
       "metadata": {
         "name": "provisioningReadmes",
         "resourceVersion": "1777397546983",
-        "creationTimestamp": "2026-04-28T17:32:26Z"
+        "creationTimestamp": "2026-04-28T17:32:26Z",
+        "deletionTimestamp": "2026-05-08T06:23:49Z"
       },
       "spec": {
         "description": "Render the README.md of a Git Sync provisioned folder inline below its dashboards list",

--- a/public/app/features/browse-dashboards/components/BrowseView.test.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseView.test.tsx
@@ -1,9 +1,9 @@
-import { getByLabelText, render, screen, userEvent } from 'test/test-utils';
+import { act, getByLabelText, render, screen, userEvent } from 'test/test-utils';
 
 import { selectors } from '@grafana/e2e-selectors';
-import { config, setBackendSrv } from '@grafana/runtime';
+import { setBackendSrv } from '@grafana/runtime';
 import { setupMockServer } from '@grafana/test-utils/server';
-import { getFolderFixtures } from '@grafana/test-utils/unstable';
+import { getFolderFixtures, setTestFlags } from '@grafana/test-utils/unstable';
 import { backendSrv } from 'app/core/services/backend_srv';
 import { contextSrv } from 'app/core/services/context_srv';
 import * as useFolderReadmeModule from 'app/features/provisioning/hooks/useFolderReadme';
@@ -187,19 +187,15 @@ describe('browse-dashboards BrowseView', () => {
       });
     }
 
-    let originalFlag: boolean | undefined;
-
-    beforeEach(() => {
-      originalFlag = config.featureToggles.provisioningReadmes;
-    });
-
     afterEach(() => {
-      config.featureToggles.provisioningReadmes = originalFlag;
+      act(() => {
+        setTestFlags({});
+      });
       jest.restoreAllMocks();
     });
 
     it('appends the README panel as the last row when the folder is provisioned and has children', async () => {
-      config.featureToggles.provisioningReadmes = true;
+      setTestFlags({ 'provisioning.readmes': true });
       mockReadme();
 
       render(
@@ -216,7 +212,7 @@ describe('browse-dashboards BrowseView', () => {
     });
 
     it('does not append the README row when the toggle is off', async () => {
-      config.featureToggles.provisioningReadmes = false;
+      setTestFlags({ 'provisioning.readmes': false });
       mockReadme();
 
       render(
@@ -234,7 +230,7 @@ describe('browse-dashboards BrowseView', () => {
     });
 
     it('does not append the README row when the folder is not provisioned', async () => {
-      config.featureToggles.provisioningReadmes = true;
+      setTestFlags({ 'provisioning.readmes': true });
       mockReadme();
 
       render(<BrowseView permissions={mockPermissions} folderUID={folderA.item.uid} width={WIDTH} height={HEIGHT} />);
@@ -244,7 +240,7 @@ describe('browse-dashboards BrowseView', () => {
     });
 
     it('does not append the README row when there is no folderUID (root)', async () => {
-      config.featureToggles.provisioningReadmes = true;
+      setTestFlags({ 'provisioning.readmes': true });
       mockReadme();
 
       render(
@@ -262,7 +258,7 @@ describe('browse-dashboards BrowseView', () => {
     });
 
     it('does not append the README row for empty folders', async () => {
-      config.featureToggles.provisioningReadmes = true;
+      setTestFlags({ 'provisioning.readmes': true });
       mockReadme();
 
       render(

--- a/public/app/features/browse-dashboards/components/BrowseView.tsx
+++ b/public/app/features/browse-dashboards/components/BrowseView.tsx
@@ -1,3 +1,4 @@
+import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { skipToken } from '@reduxjs/toolkit/query';
 import { useCallback, useMemo } from 'react';
 
@@ -147,8 +148,10 @@ export function BrowseView({
     [selectedItems, childrenByParentUID]
   );
 
+  const provisioningReadmesEnabled = useBooleanFlagValue('provisioning.readmes', false);
+
   const flatTreeWithReadme = useMemo(() => {
-    if (!config.featureToggles.provisioningReadmes || !isProvisionedFolder || !folderUID || flatTree.length === 0) {
+    if (!provisioningReadmesEnabled || !isProvisionedFolder || !folderUID || flatTree.length === 0) {
       return flatTree;
     }
 
@@ -160,7 +163,7 @@ export function BrowseView({
         isOpen: false,
       },
     ];
-  }, [flatTree, isProvisionedFolder, folderUID]);
+  }, [flatTree, isProvisionedFolder, folderUID, provisioningReadmesEnabled]);
 
   const isItemLoaded = useCallback(
     (itemIndex: number) => {

--- a/public/app/features/provisioning/components/Folders/FolderReadmePanel.test.tsx
+++ b/public/app/features/provisioning/components/Folders/FolderReadmePanel.test.tsx
@@ -1,6 +1,6 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, render, screen } from 'test/test-utils';
 
-import { config } from '@grafana/runtime';
+import { setTestFlags } from '@grafana/test-utils/unstable';
 
 import { type UseFolderReadmeResult, useFolderReadme } from '../../hooks/useFolderReadme';
 
@@ -46,10 +46,20 @@ function setReadmeResult(overrides: Partial<UseFolderReadmeResult> = {}) {
   });
 }
 
+function setup(folderUID = 'test-folder') {
+  return render(<FolderReadmePanel folderUID={folderUID} />);
+}
+
 describe('FolderReadmePanel', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    config.featureToggles = { provisioningReadmes: true };
+    setTestFlags({ 'provisioning.readmes': true });
+  });
+
+  afterEach(() => {
+    act(() => {
+      setTestFlags({});
+    });
   });
 
   it('renders the README markdown inside a panel with an anchor id', () => {
@@ -84,11 +94,11 @@ describe('FolderReadmePanel', () => {
     );
   });
 
-  it('reports an interaction when the edit link is clicked', () => {
+  it('reports an interaction when the edit link is clicked', async () => {
     setReadmeResult();
 
-    render(<FolderReadmePanel folderUID="test-folder" />);
-    fireEvent.click(screen.getByRole('link', { name: /Edit README/i }));
+    const { user } = setup();
+    await user.click(screen.getByRole('link', { name: /Edit README/i }));
 
     expect(editClickedSpy).toHaveBeenCalledWith({ repositoryType: 'github' });
   });
@@ -106,11 +116,11 @@ describe('FolderReadmePanel', () => {
       expect(value).toContain('# Test Folder');
     });
 
-    it('reports an interaction when the Add README button is clicked', () => {
+    it('reports an interaction when the Add README button is clicked', async () => {
       setReadmeResult({ status: 'missing', markdownContent: undefined });
 
-      render(<FolderReadmePanel folderUID="test-folder" />);
-      fireEvent.click(screen.getByRole('link', { name: /Add README/i }));
+      const { user } = setup();
+      await user.click(screen.getByRole('link', { name: /Add README/i }));
 
       expect(createClickedSpy).toHaveBeenCalledWith({ repositoryType: 'github' });
     });
@@ -133,12 +143,12 @@ describe('FolderReadmePanel', () => {
       expect(screen.getByRole('button', { name: /Try again/i })).toBeInTheDocument();
     });
 
-    it('calls refetch when the retry button is clicked', () => {
+    it('calls refetch when the retry button is clicked', async () => {
       const refetch = jest.fn();
       setReadmeResult({ status: 'error', markdownContent: undefined, refetch });
 
-      render(<FolderReadmePanel folderUID="test-folder" />);
-      fireEvent.click(screen.getByRole('button', { name: /Try again/i }));
+      const { user } = setup();
+      await user.click(screen.getByRole('button', { name: /Try again/i }));
 
       expect(refetch).toHaveBeenCalledTimes(1);
     });
@@ -159,7 +169,7 @@ describe('FolderReadmePanel', () => {
   });
 
   it('renders nothing when the feature toggle is off', () => {
-    config.featureToggles = { provisioningReadmes: false };
+    setTestFlags({ 'provisioning.readmes': false });
     setReadmeResult();
 
     const { container } = render(<FolderReadmePanel folderUID="test-folder" />);
@@ -167,7 +177,7 @@ describe('FolderReadmePanel', () => {
   });
 
   it('does not invoke useFolderReadme when the feature toggle is off', () => {
-    config.featureToggles = { provisioningReadmes: false };
+    setTestFlags({ 'provisioning.readmes': false });
     setReadmeResult();
     render(<FolderReadmePanel folderUID="test-folder" />);
     expect(mockUseFolderReadme).not.toHaveBeenCalled();

--- a/public/app/features/provisioning/components/Folders/FolderReadmePanel.tsx
+++ b/public/app/features/provisioning/components/Folders/FolderReadmePanel.tsx
@@ -1,10 +1,10 @@
 import { css } from '@emotion/css';
+import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { useEffect, useRef } from 'react';
 import { useIntersection } from 'react-use';
 
 import { type GrafanaTheme2, renderMarkdown } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { config } from '@grafana/runtime';
 import { Alert, Button, Icon, LinkButton, Stack, Text, useStyles2 } from '@grafana/ui';
 import { type RepositoryView } from 'app/api/clients/provisioning/v0alpha1';
 
@@ -25,11 +25,12 @@ interface Props {
  * Header shows the file name + an Edit pencil that opens the host editor;
  * the body either renders the markdown or shows an "Add README" empty state.
  *
- * Returns null and triggers no data fetching when the feature toggle is off
- * or when the folder isn't provisioned.
+ * Returns null and triggers no data fetching when the `provisioning.readmes`
+ * OpenFeature toggle is off or when the folder isn't provisioned.
  */
 export function FolderReadmePanel({ folderUID }: Props) {
-  if (!config.featureToggles.provisioningReadmes) {
+  const provisioningReadmesEnabled = useBooleanFlagValue('provisioning.readmes', false);
+  if (!provisioningReadmesEnabled) {
     return null;
   }
   return <FolderReadmePanelContent folderUID={folderUID} />;

--- a/public/app/features/provisioning/components/Folders/analytics/main.ts
+++ b/public/app/features/provisioning/components/Folders/analytics/main.ts
@@ -11,7 +11,7 @@ import {
 const createProvisioningEvent = defineFeatureEvents('grafana', 'provisioning');
 
 /**
- * Analytics events for the provisioned folder README experiment (`provisioningReadmes` toggle).
+ * Analytics events for the provisioned folder README experiment (`provisioning.readmes` toggle).
  */
 export const FolderReadmeEvents = {
   /** Fired once per status when the README panel scrolls at least 50 % into view. Provides the denominator for engagement and the status distribution for feature health. */

--- a/public/app/features/provisioning/hooks/useFolderReadme.ts
+++ b/public/app/features/provisioning/hooks/useFolderReadme.ts
@@ -1,6 +1,6 @@
 import { skipToken } from '@reduxjs/toolkit/query/react';
 
-import { config, isFetchError } from '@grafana/runtime';
+import { isFetchError } from '@grafana/runtime';
 import { type Folder } from 'app/api/clients/folder/v1beta1';
 import { type RepositoryView, useGetRepositoryFilesWithPathQuery } from 'app/api/clients/provisioning/v0alpha1';
 import { AnnoKeySourcePath } from 'app/features/apiserver/types';
@@ -22,8 +22,10 @@ export interface UseFolderReadmeResult {
 
 /**
  * Resolves a folder's README.md path (using the source-path annotation when
- * present) and fetches it through the provisioning files API. Skips the fetch
- * when the `provisioningReadmes` toggle is off.
+ * present) and fetches it through the provisioning files API.
+ *
+ * Callers must gate on the `provisioning.readmes` OpenFeature toggle before
+ * mounting any component that invokes this hook.
  *
  * Returns a tagged `status` instead of raw boolean flags so callers can
  * exhaustively switch on the four states without reconstructing the machine.
@@ -34,7 +36,7 @@ export function useFolderReadme(folderUID: string): UseFolderReadmeResult {
   const sourcePath = folder?.metadata?.annotations?.[AnnoKeySourcePath] || '';
   const readmePath = sourcePath ? `${sourcePath.replace(/\/+$/, '')}/README.md` : 'README.md';
 
-  const shouldFetch = !!config.featureToggles.provisioningReadmes && !!repository && !!folderUID && !isRepoLoading;
+  const shouldFetch = !!repository && !!folderUID && !isRepoLoading;
 
   const {
     data: fileData,


### PR DESCRIPTION
**What is this feature?**

Migrates the `provisioningReadmes` feature toggle from the legacy `config.featureToggles` channel to the React-based OpenFeature client, renaming it to `provisioning.readmes` to satisfy the registry naming rule that non-legacy flags must contain a dot separator.

