### PR TITLE
search: serialize concurrent index rebuilds and protect in-flight build directories

### DIFF
--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -1114,7 +1114,9 @@ func (s *searchServer) rebuildIndex(ctx context.Context, req rebuildRequest) {
 		// so its conditions (e.g. a newer lastImportTime) are re-evaluated against
 		// the just-built index when the in-flight rebuild finishes.
 		if state.deferred == nil {
-			state.deferred = &req
+			// new(req), not &req: we mutate req.completeChannels = nil below,
+			// and state.deferred must observe the values seen here, not those.
+			state.deferred = new(req)
 		} else {
 			merged, _ := combineRebuildRequests(*state.deferred, req)
 			state.deferred = &merged

--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -1114,7 +1114,7 @@ func (s *searchServer) rebuildIndex(ctx context.Context, req rebuildRequest) {
 		// so its conditions (e.g. a newer lastImportTime) are re-evaluated against
 		// the just-built index when the in-flight rebuild finishes.
 		if state.deferred == nil {
-			state.deferred = new(req)
+			state.deferred = &req
 		} else {
 			merged, _ := combineRebuildRequests(*state.deferred, req)
 			state.deferred = &merged

--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -182,6 +182,15 @@ type searchServer struct {
 	rebuildQueue   *debouncer.Queue[rebuildRequest]
 	rebuildWorkers int
 
+	// inFlightRebuilds tracks rebuilds currently being executed by a worker.
+	// Presence of a key means a worker is rebuilding the index for that key,
+	// so other workers that pick up requests for the same key should defer
+	// their work to a follow-up rebuild rather than running concurrently.
+	// Concurrent rebuilds for the same key would corrupt each other's on-disk
+	// index directories via cleanOldIndexes.
+	inFlightRebuildsMu sync.Mutex
+	inFlightRebuilds   map[NamespacedResource]*rebuildState
+
 	injectFailuresPercent     int
 	indexModificationCacheTTL time.Duration
 
@@ -257,6 +266,7 @@ func newSearchServer(opts SearchOptions, storage StorageBackend, vectorBackend v
 	}
 
 	s.rebuildQueue = debouncer.NewQueue(combineRebuildRequests)
+	s.inFlightRebuilds = map[NamespacedResource]*rebuildState{}
 
 	info, err := opts.Resources.GetDocumentBuilders()
 	if err != nil {
@@ -1095,6 +1105,50 @@ func (s *searchServer) rebuildIndex(ctx context.Context, req rebuildRequest) {
 		return
 	}
 
+	// Coordinate with any other worker that is already rebuilding this key.
+	// Concurrent rebuilds for the same key would race in cleanOldIndexes and
+	// delete each other's on-disk directories.
+	s.inFlightRebuildsMu.Lock()
+	if state, inFlight := s.inFlightRebuilds[req.NamespacedResource]; inFlight {
+		// Another worker is already rebuilding. Stash this request as a follow-up
+		// so its conditions (e.g. a newer lastImportTime) are re-evaluated against
+		// the just-built index when the in-flight rebuild finishes.
+		if state.deferred == nil {
+			state.deferred = new(req)
+		} else {
+			merged, _ := combineRebuildRequests(*state.deferred, req)
+			state.deferred = &merged
+		}
+		// The follow-up rebuild will close these completion channels (or close
+		// them as a no-op via the recheck path); clear them here so the top-level
+		// defer in this function does not close them prematurely.
+		req.completeChannels = nil
+		s.inFlightRebuildsMu.Unlock()
+		span.AddEvent("rebuild already in flight, deferring as follow-up")
+		l.Info("rebuild already in flight for key, deferring as follow-up")
+		return
+	}
+	state := &rebuildState{}
+	s.inFlightRebuilds[req.NamespacedResource] = state
+	s.inFlightRebuildsMu.Unlock()
+
+	defer func() {
+		s.inFlightRebuildsMu.Lock()
+		deferred := state.deferred
+		delete(s.inFlightRebuilds, req.NamespacedResource)
+		s.inFlightRebuildsMu.Unlock()
+
+		if deferred != nil {
+			// Re-enqueue the follow-up. The worker that picks it up will re-check
+			// shouldRebuildIndex against the just-built BuildTime and either run
+			// another rebuild or close the deferred completion channels as a no-op.
+			s.rebuildQueue.Add(*deferred)
+			if s.indexMetrics != nil {
+				s.indexMetrics.RebuildQueueLength.Set(float64(s.rebuildQueue.Len()))
+			}
+		}
+	}()
+
 	if req.Resource == dashboardv1.DASHBOARD_RESOURCE {
 		// we need to clear the cache to make sure we get the latest usage insights data
 		s.builders.clearNamespacedCache(req.NamespacedResource)
@@ -1192,6 +1246,13 @@ func newSelectableFieldsAdded(indexSelectableFields, selectableFields []string) 
 		}
 	}
 	return false
+}
+
+// rebuildState tracks an in-flight rebuild for a single key. The deferred
+// field accumulates requests that arrived while this rebuild was running, so
+// they can be re-enqueued as a follow-up once it finishes.
+type rebuildState struct {
+	deferred *rebuildRequest
 }
 
 type rebuildRequest struct {

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -295,9 +295,7 @@ func TestSearchGetOrCreateIndexWithCancellation(t *testing.T) {
 			{NamespacedResource: NamespacedResource{Namespace: "ns", Group: "group", Resource: "resource"}, Count: 50, ResourceVersion: 11111111},
 		},
 	}
-	search := &slowSearchBackendWithCache{
-		mockSearchBackend: mockSearchBackend{},
-	}
+	search := newBlockingSearchBackend(nil)
 
 	supplier := &TestDocumentBuilderSupplier{
 		GroupsResources: map[string]string{
@@ -321,54 +319,27 @@ func TestSearchGetOrCreateIndexWithCancellation(t *testing.T) {
 	defer cancel()
 
 	_, err = support.getOrCreateIndex(ctx, nil, key, "test")
-	// Make sure we get context deadline error
+	// Make sure we get context deadline error.
 	require.ErrorIs(t, err, context.DeadlineExceeded)
 
-	// Wait until indexing is finished. We need to wait 2 seconds here,
-	// because BuildIndex simulates a 1 second build time, and we want
-	// to be sure it has started before we check the calls.
+	// BuildIndex started despite the cancellation: getOrCreateIndex's singleflight
+	// uses context.WithoutCancel so the underlying build runs to completion.
+	select {
+	case <-search.onStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("BuildIndex never started")
+	}
+
+	// Release the in-flight build; the index should land in the cache.
+	close(search.proceed)
 	require.Eventually(t, func() bool {
-		return search.slowBuildCalls.Load() > 0
-	}, 2*time.Second, 100*time.Millisecond, "BuildIndex never started")
+		return support.search.GetIndex(key) != nil
+	}, 1*time.Second, 100*time.Millisecond, "index not cached after build finished")
 
-	require.NotEmpty(t, search.buildIndexCalls)
-
-	// Wait until new index is put into cache.
-	require.Eventually(t, func() bool {
-		idx := support.search.GetIndex(key)
-		return idx != nil
-	}, 1*time.Second, 100*time.Millisecond, "Indexing finishes despite context cancellation")
-
-	// Second call to getOrCreateIndex returns index immediately, even if context is canceled, as the index is now ready and cached.
+	// Second call to getOrCreateIndex returns the cached index immediately, even
+	// though ctx is already done.
 	_, err = support.getOrCreateIndex(ctx, nil, key, "test")
 	require.NoError(t, err)
-}
-
-type slowSearchBackendWithCache struct {
-	mockSearchBackend
-	slowBuildCalls atomic.Int64
-}
-
-func (m *slowSearchBackendWithCache) GetIndex(key NamespacedResource) ResourceIndex {
-	m.mu.Lock()
-	defer m.mu.Unlock()
-	return m.cache[key]
-}
-
-func (m *slowSearchBackendWithCache) BuildIndex(ctx context.Context, key NamespacedResource, size int64, fields SearchableDocumentFields, reason string, builder BuildFn, updater UpdateFn, rebuild bool, lastImportTime time.Time, maxFreshSnapshotAge time.Duration) (ResourceIndex, error) {
-	defer m.slowBuildCalls.Add(1)
-
-	time.Sleep(1 * time.Second)
-
-	// Simulate erroring out when context is cancelled.
-	if ctx.Err() != nil {
-		return nil, ctx.Err()
-	}
-	idx, err := m.mockSearchBackend.BuildIndex(ctx, key, size, fields, reason, builder, updater, rebuild, lastImportTime, maxFreshSnapshotAge)
-	if err != nil {
-		return nil, err
-	}
-	return idx, nil
 }
 
 func TestCombineBuildRequests(t *testing.T) {
@@ -1152,4 +1123,211 @@ func TestFindIndexesToRebuildWithJitter(t *testing.T) {
 	chsWithJitter := support2.findIndexesToRebuild(importTimes, nil, now, true)
 	require.Less(t, len(chsWithJitter), numIndexes, "jitter should cause some indexes to not be queued yet")
 	require.Greater(t, len(chsWithJitter), 0, "at least some indexes should still be queued")
+}
+
+// blockingSearchBackend wraps mockSearchBackend so a test can pause inside
+// BuildIndex. onStarted is closed when the first build enters; the test
+// closes proceed to release any blocked builds.
+type blockingSearchBackend struct {
+	mockSearchBackend
+
+	onStarted chan struct{}
+	proceed   chan struct{}
+
+	startedOnce sync.Once
+	buildCalls  atomic.Int32
+}
+
+func newBlockingSearchBackend(cache map[NamespacedResource]ResourceIndex) *blockingSearchBackend {
+	return &blockingSearchBackend{
+		mockSearchBackend: mockSearchBackend{cache: cache},
+		onStarted:         make(chan struct{}),
+		proceed:           make(chan struct{}),
+	}
+}
+
+func (b *blockingSearchBackend) BuildIndex(ctx context.Context, key NamespacedResource, size int64, fields SearchableDocumentFields, reason string, builder BuildFn, updater UpdateFn, rebuild bool, lastImportTime time.Time, maxFreshSnapshotAge time.Duration) (ResourceIndex, error) {
+	b.buildCalls.Add(1)
+	b.startedOnce.Do(func() { close(b.onStarted) })
+	<-b.proceed
+	return b.mockSearchBackend.BuildIndex(ctx, key, size, fields, reason, builder, updater, rebuild, lastImportTime, maxFreshSnapshotAge)
+}
+
+// TestRebuildIndexConcurrentRebuildsForSameKeyAreDeduplicated verifies the
+// in-flight tracker added by rebuildIndex: while a rebuild is running for a
+// key, additional rebuild requests for the same key do not call BuildIndex
+// and instead get stashed as a single follow-up that is re-enqueued when the
+// in-flight rebuild finishes.
+func TestRebuildIndexConcurrentRebuildsForSameKeyAreDeduplicated(t *testing.T) {
+	key := NamespacedResource{Namespace: "ns", Group: "group", Resource: "res"}
+
+	initialBuildTime := time.Now().Add(-2 * time.Hour)
+	search := newBlockingSearchBackend(map[NamespacedResource]ResourceIndex{
+		key: &MockResourceIndex{buildInfo: IndexBuildInfo{BuildTime: initialBuildTime}},
+	})
+
+	storage := &mockStorageBackend{
+		resourceStats: []ResourceStats{
+			{NamespacedResource: key, Count: 50, ResourceVersion: 11111111},
+		},
+	}
+	supplier := &TestDocumentBuilderSupplier{
+		GroupsResources: map[string]string{"group": "res"},
+	}
+
+	opts := SearchOptions{Backend: search, Resources: supplier}
+	support, err := newSearchServer(opts, storage, nil, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	// Fire the first rebuild. It will claim the in-flight slot and block
+	// inside BuildIndex.
+	firstDone := make(chan struct{})
+	firstReq := rebuildRequest{
+		NamespacedResource: key,
+		minBuildTime:       time.Now().Add(-1 * time.Hour),
+		completeChannels:   []chan<- struct{}{firstDone},
+	}
+	firstReturned := make(chan struct{})
+	go func() {
+		defer close(firstReturned)
+		support.rebuildIndex(t.Context(), firstReq)
+	}()
+
+	// Wait for the first rebuild to be in flight.
+	select {
+	case <-search.onStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first rebuild did not enter BuildIndex")
+	}
+
+	support.inFlightRebuildsMu.Lock()
+	_, inFlight := support.inFlightRebuilds[key]
+	support.inFlightRebuildsMu.Unlock()
+	require.True(t, inFlight, "rebuild for key should be marked in flight")
+
+	// Fire 4 more rebuild requests for the same key with varying conditions.
+	// Each should return promptly (deferred) without calling BuildIndex; the
+	// strictest minBuildTime should win when the requests get merged.
+	latestMinBuildTime := time.Now() // strictest condition
+	laterTimes := []time.Time{
+		time.Now().Add(-50 * time.Minute),
+		latestMinBuildTime,
+		time.Now().Add(-40 * time.Minute),
+		time.Now().Add(-30 * time.Minute),
+	}
+	deferredChans := make([]chan struct{}, len(laterTimes))
+	for i, mbt := range laterTimes {
+		deferredChans[i] = make(chan struct{})
+		req := rebuildRequest{
+			NamespacedResource: key,
+			minBuildTime:       mbt,
+			completeChannels:   []chan<- struct{}{deferredChans[i]},
+		}
+		returned := make(chan struct{})
+		go func() {
+			defer close(returned)
+			support.rebuildIndex(t.Context(), req)
+		}()
+		select {
+		case <-returned:
+		case <-time.After(2 * time.Second):
+			t.Fatalf("rebuildIndex %d did not return; expected to be deferred", i)
+		}
+	}
+
+	// None of the deferred completion channels should be closed yet — they
+	// are owned by the follow-up rebuild that hasn't run.
+	for i, ch := range deferredChans {
+		select {
+		case <-ch:
+			t.Fatalf("deferred completion channel %d closed prematurely", i)
+		default:
+		}
+	}
+
+	// Queue is empty: deferred requests live on rebuildState.deferred until
+	// the in-flight rebuild's defer re-enqueues them.
+	require.Equal(t, 0, support.rebuildQueue.Len())
+
+	// Only one BuildIndex call should be in progress so far.
+	require.Equal(t, int32(1), search.buildCalls.Load())
+
+	// Release the first rebuild and wait for it to finish.
+	close(search.proceed)
+	select {
+	case <-firstReturned:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first rebuildIndex did not return after unblocking")
+	}
+	select {
+	case <-firstDone:
+	case <-time.After(2 * time.Second):
+		t.Fatal("first rebuild's completion channel was not closed")
+	}
+
+	// In-flight tracker should be cleared.
+	support.inFlightRebuildsMu.Lock()
+	_, stillInFlight := support.inFlightRebuilds[key]
+	support.inFlightRebuildsMu.Unlock()
+	require.False(t, stillInFlight, "in-flight tracker should be cleared after rebuild finishes")
+
+	// The deferred follow-up should have been re-enqueued as a single item
+	// carrying all 4 deferred completion channels and the strictest
+	// minBuildTime among the deferred requests.
+	require.Equal(t, 1, support.rebuildQueue.Len())
+	items := support.rebuildQueue.Elements()
+	require.Len(t, items, 1)
+	req := items[0]
+	require.Equal(t, key, req.NamespacedResource)
+	require.Len(t, req.completeChannels, len(deferredChans))
+	require.True(t, req.minBuildTime.Equal(latestMinBuildTime),
+		"follow-up should carry the strictest minBuildTime; got %v want %v",
+		req.minBuildTime, latestMinBuildTime)
+
+	// Still only one BuildIndex call: the deferred follow-up has been
+	// enqueued but no worker is running in this test to pick it up.
+	require.Equal(t, int32(1), search.buildCalls.Load())
+}
+
+// TestRebuildIndexNoFollowUpWhenNotInFlight verifies the happy path: a single
+// rebuild request for a key runs to completion, clears the in-flight tracker,
+// and does not re-enqueue anything.
+func TestRebuildIndexNoFollowUpWhenNotInFlight(t *testing.T) {
+	key := NamespacedResource{Namespace: "ns", Group: "group", Resource: "res"}
+
+	search := &mockSearchBackend{
+		cache: map[NamespacedResource]ResourceIndex{
+			key: &MockResourceIndex{buildInfo: IndexBuildInfo{BuildTime: time.Now().Add(-2 * time.Hour)}},
+		},
+	}
+	storage := &mockStorageBackend{
+		resourceStats: []ResourceStats{
+			{NamespacedResource: key, Count: 50, ResourceVersion: 11111111},
+		},
+	}
+	supplier := &TestDocumentBuilderSupplier{
+		GroupsResources: map[string]string{"group": "res"},
+	}
+	opts := SearchOptions{Backend: search, Resources: supplier}
+	support, err := newSearchServer(opts, storage, nil, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	done := make(chan struct{})
+	support.rebuildIndex(t.Context(), rebuildRequest{
+		NamespacedResource: key,
+		minBuildTime:       time.Now().Add(-1 * time.Hour),
+		completeChannels:   []chan<- struct{}{done},
+	})
+
+	select {
+	case <-done:
+	default:
+		t.Fatal("completion channel should be closed after rebuildIndex returns")
+	}
+
+	support.inFlightRebuildsMu.Lock()
+	_, inFlight := support.inFlightRebuilds[key]
+	support.inFlightRebuildsMu.Unlock()
+	require.False(t, inFlight, "in-flight tracker should be cleared")
+	require.Equal(t, 0, support.rebuildQueue.Len(), "no follow-up should be re-enqueued")
 }

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -158,6 +158,14 @@ type bleveBackend struct {
 
 	uploadTrackingMu sync.Mutex
 	lastUploadTime   map[resource.NamespacedResource]time.Time
+
+	// inFlightBuildDirs is a refcount of absolute directory paths that belong
+	// to BuildIndex calls (or their helpers) which haven't returned yet.
+	// cleanOldIndexes must not delete these. Helpers that allocate or open a
+	// directory under resourceDir are responsible for registering the path,
+	// and BuildIndex unregisters it after the call completes.
+	inFlightBuildDirsMu sync.Mutex
+	inFlightBuildDirs   map[string]int
 }
 
 func NewBleveBackend(opts BleveOptions, indexMetrics *resource.BleveIndexMetrics) (*bleveBackend, error) {
@@ -215,6 +223,7 @@ func NewBleveBackend(opts BleveOptions, indexMetrics *resource.BleveIndexMetrics
 		selectableFields:    opts.SelectableFieldsForKinds,
 		runningBuildVersion: runningBuildVersion,
 		lastUploadTime:      map[resource.NamespacedResource]time.Time{},
+		inFlightBuildDirs:   map[string]int{},
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -684,6 +693,15 @@ func (b *bleveBackend) BuildIndex(
 		return nil, err
 	}
 
+	// prepareIndex's helpers register the working directory before returning;
+	// release that registration when BuildIndex returns, regardless of success
+	// or failure path. cleanOldIndexes still runs before this defer fires, so
+	// our own dir is protected via skipName during the cleanup.
+	if prepared.fileIndexName != "" {
+		inFlightDir := filepath.Join(resourceDir, prepared.fileIndexName)
+		defer b.unregisterInFlightBuildDir(inFlightDir)
+	}
+
 	if prepared.coldStartLeaderLock != nil {
 		defer func() {
 			if releaseErr := prepared.coldStartLeaderLock.Release(); releaseErr != nil {
@@ -962,6 +980,7 @@ func (b *bleveBackend) createEmptyFileIndex(resourceDir string, mapper mapping.I
 	}
 
 	logger.Info("Building index using filesystem", "directory", indexDir)
+	b.registerInFlightBuildDir(indexDir)
 	return preparedBuildIndex{
 		index:         idx,
 		fileIndexName: fileIndexName,
@@ -1059,7 +1078,20 @@ func cleanFileSegment(input string) string {
 }
 
 // cleanOldIndexes deletes all subdirectories inside dir, skipping directory with "skipName".
-// "skipName" can be empty.
+// "skipName" can be empty. Directories belonging to other in-flight BuildIndex
+// calls are also skipped: concurrent rebuilds for the same resource each have
+// their own working directory, and deleting another build's directory would
+// corrupt its index.
+//
+// MAINTAINER NOTE: any code that allocates or opens a directory under a
+// resource's directory before BuildIndex has finished must call
+// registerInFlightBuildDir on that absolute path; otherwise a concurrent
+// BuildIndex call (for the same key) can wipe it from disk while it is still
+// being populated. The matching unregister is owned by BuildIndex (deferred
+// after prepareIndex returns successfully) for paths that flow through
+// preparedBuildIndex.fileIndexName, and by the helper itself on its own
+// failure paths. If you add a new directory-allocating helper, follow the
+// same pattern.
 func (b *bleveBackend) cleanOldIndexes(resourceDir string, skipName string) {
 	entries, err := os.ReadDir(resourceDir)
 	if err != nil {
@@ -1077,6 +1109,11 @@ func (b *bleveBackend) cleanOldIndexes(resourceDir string, skipName string) {
 				continue
 			}
 
+			if b.isInFlightBuildDir(entryDir) {
+				b.log.Info("Skipping cleanup of in-flight build directory", "directory", entryDir)
+				continue
+			}
+
 			err = os.RemoveAll(entryDir)
 			if err != nil {
 				b.log.Error("Unable to remove old index folder", "directory", entryDir, "error", err)
@@ -1085,6 +1122,40 @@ func (b *bleveBackend) cleanOldIndexes(resourceDir string, skipName string) {
 			}
 		}
 	}
+}
+
+// registerInFlightBuildDir marks an absolute directory path as actively used
+// by an in-flight BuildIndex call. cleanOldIndexes will skip such paths.
+// Must be paired with a call to unregisterInFlightBuildDir; the refcount
+// allows the same path to be registered more than once if multiple callers
+// happen to land on the same name (rare, but cheap insurance).
+func (b *bleveBackend) registerInFlightBuildDir(path string) {
+	if path == "" {
+		return
+	}
+	b.inFlightBuildDirsMu.Lock()
+	defer b.inFlightBuildDirsMu.Unlock()
+	b.inFlightBuildDirs[path]++
+}
+
+func (b *bleveBackend) unregisterInFlightBuildDir(path string) {
+	if path == "" {
+		return
+	}
+	b.inFlightBuildDirsMu.Lock()
+	defer b.inFlightBuildDirsMu.Unlock()
+	if c := b.inFlightBuildDirs[path]; c > 1 {
+		b.inFlightBuildDirs[path] = c - 1
+	} else {
+		delete(b.inFlightBuildDirs, path)
+	}
+}
+
+func (b *bleveBackend) isInFlightBuildDir(path string) bool {
+	b.inFlightBuildDirsMu.Lock()
+	defer b.inFlightBuildDirsMu.Unlock()
+	_, ok := b.inFlightBuildDirs[path]
+	return ok
 }
 
 // isPathWithinRoot verifies that path is within given absoluteRoot.
@@ -1160,6 +1231,7 @@ func (b *bleveBackend) findPreviousFileBasedIndex(resourceDir string) (bleve.Ind
 			continue
 		}
 
+		b.registerInFlightBuildDir(indexDir)
 		return idx, indexName, indexRV, nil
 	}
 

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -952,6 +952,10 @@ func (b *bleveBackend) tryReuseFileIndex(resourceDir string, lastImportTime time
 
 	logger.Info("File-based index needs rebuild before opening", "buildTime", indexBuildTime, "lastImportTime", lastImportTime)
 	_ = idx.Close()
+	// Release the registration findPreviousFileBasedIndex installed on this
+	// directory: we are discarding the reused index, so cleanOldIndexes is
+	// allowed to remove its directory once the rebuild finishes.
+	b.unregisterInFlightBuildDir(filepath.Join(resourceDir, name))
 	return nil, "", 0, nil
 }
 
@@ -1144,7 +1148,15 @@ func (b *bleveBackend) unregisterInFlightBuildDir(path string) {
 	}
 	b.inFlightBuildDirsMu.Lock()
 	defer b.inFlightBuildDirsMu.Unlock()
-	if c := b.inFlightBuildDirs[path]; c > 1 {
+	c, ok := b.inFlightBuildDirs[path]
+	if !ok {
+		// A missing entry means a registration was never installed for this
+		// path, or that the path is being unregistered twice. Both indicate a
+		// pairing bug in a helper; log so it surfaces in tests and prod logs.
+		b.log.Error("unregisterInFlightBuildDir called with unknown path; missing register or double unregister", "path", path)
+		return
+	}
+	if c > 1 {
 		b.inFlightBuildDirs[path] = c - 1
 	} else {
 		delete(b.inFlightBuildDirs, path)

--- a/pkg/storage/unified/search/bleve_snapshot.go
+++ b/pkg/storage/unified/search/bleve_snapshot.go
@@ -214,6 +214,17 @@ func (b *bleveBackend) downloadSelectedSnapshot(
 		return nil, "", 0, fmt.Errorf("reserving local snapshot dir: %w", err)
 	}
 
+	// Protect destDir from cleanOldIndexes for the duration of the download
+	// and validation. On success, ownership of the registration transfers to
+	// the caller (BuildIndex unregisters via its own defer); on any failure
+	// path below, this defer releases it.
+	b.registerInFlightBuildDir(destDir)
+	defer func() {
+		if retErr != nil {
+			b.unregisterInFlightBuildDir(destDir)
+		}
+	}()
+
 	// TODO: retry DownloadIndex on transient errors before falling through to
 	// a from-scratch KV rebuild. The object store is its own fault domain;
 	// a single failed download shouldn't force a full rebuild for large

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -1388,6 +1388,46 @@ func TestBuildIndexConcurrentBuildsForSameKeyDoNotDeleteEachOthersDirs(t *testin
 	// Let A finish so its goroutine cleans up before the test ends.
 	close(aRelease)
 	<-aDone
+
+	require.Empty(t, backend.inFlightBuildDirs,
+		"in-flight directory registrations leaked after both builds finished")
+}
+
+// TestBuildIndexColdStartReuseRejectionDoesNotLeakInFlightDir guards against
+// a leak in the path where findPreviousFileBasedIndex registers the reused
+// directory but tryReuseFileIndex then rejects it because its BuildTime
+// predates lastImportTime. Without unregistering on the reject path, the
+// stale directory would remain registered for the lifetime of the process,
+// causing cleanOldIndexes to skip it forever.
+func TestBuildIndexColdStartReuseRejectionDoesNotLeakInFlightDir(t *testing.T) {
+	backend, _ := setupBleveBackend(t, withFileThreshold(1))
+	ns := resource.NamespacedResource{Namespace: "ns", Group: "group", Resource: "res"}
+
+	// Build an initial file-based index so a directory exists on disk.
+	_, err := backend.BuildIndex(t.Context(), ns, 100, nil, "init",
+		func(_ resource.ResourceIndex) (int64, error) { return 1, nil },
+		nil, false, time.Time{}, 0)
+	require.NoError(t, err)
+
+	// Drop the cached entry and close the index, simulating a fresh process
+	// boot that finds an out-of-date persisted index on disk.
+	backend.cacheMx.Lock()
+	prev := backend.cache[ns]
+	delete(backend.cache, ns)
+	backend.cacheMx.Unlock()
+	require.NotNil(t, prev)
+	require.NoError(t, prev.stopUpdaterAndCloseIndex())
+
+	// Call BuildIndex with lastImportTime > the existing index's BuildTime.
+	// tryReuseFileIndex opens the on-disk dir, sees the build is stale, and
+	// closes + rejects it; createEmptyFileIndex then builds a fresh one.
+	_, err = backend.BuildIndex(t.Context(), ns, 100, nil, "rebuild-after-import",
+		func(_ resource.ResourceIndex) (int64, error) { return 2, nil },
+		nil, false, time.Now().Add(time.Hour), 0)
+	require.NoError(t, err)
+
+	require.Empty(t, backend.inFlightBuildDirs,
+		"in-flight directory registrations leaked after cold-start reuse rejection")
 }
 
 func TestBleveIndexWithFailures(t *testing.T) {

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -1296,6 +1296,98 @@ func TestCleanOldIndexes(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, files, 0)
 	})
+
+	t.Run("in-flight build directory is preserved", func(t *testing.T) {
+		dir := t.TempDir()
+		b, _ := setupBleveBackend(t, withRootDir(dir))
+
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "index-1/a"), 0750))
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "index-2/b"), 0750))
+		require.NoError(t, os.MkdirAll(filepath.Join(dir, "index-3/c"), 0750))
+
+		// Pretend a concurrent BuildIndex is using index-2.
+		inFlightDir := filepath.Join(dir, "index-2")
+		b.registerInFlightBuildDir(inFlightDir)
+		t.Cleanup(func() { b.unregisterInFlightBuildDir(inFlightDir) })
+
+		b.cleanOldIndexes(dir, "index-3")
+
+		names := dirEntryNames(t, dir)
+		require.ElementsMatch(t, []string{"index-2", "index-3"}, names,
+			"in-flight directory and skipName must both survive cleanup")
+	})
+}
+
+func dirEntryNames(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+	names := make([]string, 0, len(entries))
+	for _, e := range entries {
+		names = append(names, e.Name())
+	}
+	return names
+}
+
+// TestBuildIndexConcurrentBuildsForSameKeyDoNotDeleteEachOthersDirs covers
+// the case of two concurrent BuildIndex calls for the same key, the second
+// finishing first and running cleanOldIndexes while the first is still
+// building. cleanOldIndexes must skip the first build's directory, otherwise
+// the still-running build's segments get wiped from disk and persists fail
+// with ENOENT.
+func TestBuildIndexConcurrentBuildsForSameKeyDoNotDeleteEachOthersDirs(t *testing.T) {
+	backend, _ := setupBleveBackend(t, withFileThreshold(1))
+	ns := resource.NamespacedResource{Namespace: "ns", Group: "group", Resource: "res"}
+	resourceDir := backend.getResourceDir(ns)
+
+	// Seed the cache with a file-based index so the subsequent rebuilds skip
+	// the cold-start reuse path (which would otherwise collide on the bolt
+	// lock of the already-open initial index).
+	_, err := backend.BuildIndex(t.Context(), ns, 100, nil, "init",
+		func(_ resource.ResourceIndex) (int64, error) { return 1, nil },
+		nil, false, time.Time{}, 0)
+	require.NoError(t, err)
+	initDirs := dirEntryNames(t, resourceDir)
+	require.Len(t, initDirs, 1)
+
+	// Start build A and park its builder, so A's directory is on disk and
+	// registered as in-flight while B runs.
+	aEntered := make(chan struct{})
+	aRelease := make(chan struct{})
+	aDone := make(chan struct{})
+	go func() {
+		defer close(aDone)
+		_, _ = backend.BuildIndex(t.Context(), ns, 100, nil, "build-a",
+			func(_ resource.ResourceIndex) (int64, error) {
+				close(aEntered)
+				<-aRelease
+				return 1, nil
+			}, nil, true, time.Time{}, 0)
+	}()
+	<-aEntered
+
+	// A's directory is the new entry that appeared since the initial build.
+	var aDir string
+	for _, name := range dirEntryNames(t, resourceDir) {
+		if name != initDirs[0] {
+			aDir = name
+			break
+		}
+	}
+	require.NotEmpty(t, aDir)
+
+	// Run B to completion. B's cleanOldIndexes runs while A is still in flight.
+	_, err = backend.BuildIndex(t.Context(), ns, 100, nil, "build-b",
+		func(_ resource.ResourceIndex) (int64, error) { return 2, nil },
+		nil, true, time.Time{}, 0)
+	require.NoError(t, err)
+
+	require.Contains(t, dirEntryNames(t, resourceDir), aDir,
+		"A's directory was deleted by B's cleanOldIndexes while A was still in flight")
+
+	// Let A finish so its goroutine cleans up before the test ends.
+	close(aRelease)
+	<-aDone
 }
 
 func TestBleveIndexWithFailures(t *testing.T) {


### PR DESCRIPTION
Concurrent `BuildIndex` calls for the same `{namespace, group, resource}` could corrupt each other's on-disk directories. When several rebuilds finished within milliseconds of each other, each one's `cleanOldIndexes` removed every sibling directory except its own — including the one that won the cache slot. Reads kept working (open fds + mmaps) but every write failed with `ENOENT` until pod restart.

Two independent fixes:

**1. Serialize rebuilds per key** (`pkg/storage/unified/resource/search.go`)

`rebuildIndex` workers check an in-flight tracker before calling `s.build`. If another worker is already rebuilding the same key, the request is stashed as a follow-up (merged into a single deferred request via the existing `combineRebuildRequests`) and re-enqueued when the in-flight rebuild finishes, so newer conditions like `lastImportTime` get re-evaluated against the just-built index. At most one rebuild per key runs at a time; workers don't park so a hot key can't starve others. This alone prevents the corruption above by ensuring two `rebuildIndex` workers never run for the same key.

**2. Defensive protection in `cleanOldIndexes`** (`pkg/storage/unified/search/bleve.go`, `bleve_snapshot.go`)

To stay robust against any caller (cold-start, snapshot downloads, future code), `cleanOldIndexes` now skips directories of any in-flight `BuildIndex` call. Helpers register the absolute path as soon as the directory becomes visible on disk — `createEmptyFileIndex`, `findPreviousFileBasedIndex`, and `downloadSelectedSnapshot` (covering the multi-minute download window). `BuildIndex` unregisters via a single deferred call. A maintainer note on `cleanOldIndexes` documents the contract for future helpers.

Refs https://github.com/grafana/search-and-storage-team/issues/783
