### PR TITLE
chore: replace hardcoded feature flag strings with FlagKeys enums

### DIFF
--- a/packages/grafana-runtime/src/services/pluginMeta/apps.test.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/apps.test.ts
@@ -1,5 +1,6 @@
 import { setTestFlags } from '@grafana/test-utils/unstable';
 
+import { FlagKeys } from '../../internal/openFeature/openfeature.gen';
 import { getLogger, setLogger } from '../logging/registry';
 
 import {
@@ -21,7 +22,7 @@ const getGrafanaExploretracesApp = () =>
 
 describe('when plugins.useMTPlugins flag is enabled', () => {
   beforeAll(() => {
-    setTestFlags({ 'plugins.useMTPlugins': true });
+    setTestFlags({ [FlagKeys.PluginsUseMTPlugins]: true });
   });
 
   afterAll(() => {
@@ -182,7 +183,7 @@ describe('when plugins.useMTPlugins flag is enabled', () => {
 
 describe('when plugins.useMTPlugins flag is disabled', () => {
   beforeAll(() => {
-    setTestFlags({ 'plugins.useMTPlugins': false });
+    setTestFlags({ [FlagKeys.PluginsUseMTPlugins]: false });
   });
 
   afterAll(() => {

--- a/packages/grafana-runtime/src/services/pluginMeta/datasources.test.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/datasources.test.ts
@@ -2,6 +2,7 @@ import { PluginType } from '@grafana/data';
 import { setTestFlags } from '@grafana/test-utils/unstable';
 
 import { config } from '../../config';
+import { FlagKeys } from '../../internal/openFeature/openfeature.gen';
 import { type BackendSrv, setBackendSrv } from '../backendSrv';
 import { setLogger } from '../logging/registry';
 
@@ -37,7 +38,7 @@ const datasourceIdsFromApi = datasourceItemsFromApi.map((i) => i.spec.pluginJson
 
 describe('when plugins.useMTPlugins flag is enabled', () => {
   beforeAll(() => {
-    setTestFlags({ 'plugins.useMTPlugins': true });
+    setTestFlags({ [FlagKeys.PluginsUseMTPlugins]: true });
     setLogger('grafana/runtime.plugins.settings', {
       logDebug: jest.fn(),
       logError: jest.fn(),
@@ -233,7 +234,7 @@ describe('when plugins.useMTPlugins flag is enabled', () => {
 
 describe('when plugins.useMTPlugins flag is disabled', () => {
   beforeAll(() => {
-    setTestFlags({ 'plugins.useMTPlugins': false });
+    setTestFlags({ [FlagKeys.PluginsUseMTPlugins]: false });
   });
 
   afterAll(() => {

--- a/packages/grafana-runtime/src/services/pluginMeta/panels.test.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/panels.test.ts
@@ -1,5 +1,6 @@
 import { setTestFlags } from '@grafana/test-utils/unstable';
 
+import { FlagKeys } from '../../internal/openFeature/openfeature.gen';
 import { type BackendSrv, setBackendSrv } from '../backendSrv';
 import { getLogger, setLogger } from '../logging/registry';
 
@@ -30,7 +31,7 @@ const refetchPluginMetasMock = jest.mocked(refetchPluginMetas);
 
 describe('when plugins.useMTPlugins flag is enabled', () => {
   beforeAll(() => {
-    setTestFlags({ 'plugins.useMTPlugins': true });
+    setTestFlags({ [FlagKeys.PluginsUseMTPlugins]: true });
     (window as unknown as Record<string, unknown>).__grafana_public_path__ = '';
     setLogger('grafana/runtime.plugins.settings', {
       logDebug: jest.fn(),
@@ -381,7 +382,7 @@ describe('when plugins.useMTPlugins flag is enabled', () => {
 
 describe('when plugins.useMTPlugins flag is disabled', () => {
   beforeAll(() => {
-    setTestFlags({ 'plugins.useMTPlugins': false });
+    setTestFlags({ [FlagKeys.PluginsUseMTPlugins]: false });
   });
 
   afterAll(() => {

--- a/packages/grafana-runtime/src/services/pluginMeta/plugins.test.ts
+++ b/packages/grafana-runtime/src/services/pluginMeta/plugins.test.ts
@@ -1,5 +1,6 @@
 import { setTestFlags } from '@grafana/test-utils/unstable';
 
+import { FlagKeys } from '../../internal/openFeature/openfeature.gen';
 import { invalidateCachedPromisesCache } from '../../utils/getCachedPromise';
 import { getLogger, setLogger } from '../logging/registry';
 
@@ -34,7 +35,7 @@ afterEach(() => {
 
 describe('when plugins.useMTPlugins flag is enabled', () => {
   beforeAll(() => {
-    setTestFlags({ 'plugins.useMTPlugins': true });
+    setTestFlags({ [FlagKeys.PluginsUseMTPlugins]: true });
   });
 
   afterAll(() => {
@@ -314,7 +315,7 @@ describe('when plugins.useMTPlugins flag is enabled', () => {
 
 describe('when plugins.useMTPlugins flag is disabled', () => {
   beforeAll(() => {
-    setTestFlags({ 'plugins.useMTPlugins': false });
+    setTestFlags({ [FlagKeys.PluginsUseMTPlugins]: false });
   });
 
   afterAll(() => {

--- a/packages/grafana-runtime/src/services/pluginSettings/getPluginSettings.test.ts
+++ b/packages/grafana-runtime/src/services/pluginSettings/getPluginSettings.test.ts
@@ -1,5 +1,6 @@
 import { setTestFlags } from '@grafana/test-utils/unstable';
 
+import { FlagKeys } from '../../internal/openFeature/openfeature.gen';
 import { invalidateCachedPromisesCache } from '../../utils/getCachedPromise';
 import { type MonitoringLogger } from '../../utils/logging';
 import { type BackendSrv, setBackendSrv } from '../backendSrv';
@@ -60,7 +61,7 @@ describe('settings', () => {
 
   describe('when plugins.useMTPluginSettings flag is enabled', () => {
     beforeAll(() => {
-      setTestFlags({ 'plugins.useMTPluginSettings': true });
+      setTestFlags({ [FlagKeys.PluginsUseMTPluginSettings]: true });
     });
 
     afterAll(() => {
@@ -173,7 +174,7 @@ describe('settings', () => {
 
   describe('when plugins.useMTPluginSettings flag is disabled', () => {
     beforeAll(() => {
-      setTestFlags({ 'plugins.useMTPluginSettings': false });
+      setTestFlags({ [FlagKeys.PluginsUseMTPluginSettings]: false });
     });
 
     afterAll(() => {
@@ -234,8 +235,8 @@ describe('settings', () => {
 
   describe('when plugins.useMTPluginSettings flag is enabled but plugins.useMTPlugins is disabled', () => {
     beforeAll(() => {
-      setTestFlags({ 'plugins.useMTPlugins': false });
-      setTestFlags({ 'plugins.useMTPluginSettings': true });
+      setTestFlags({ [FlagKeys.PluginsUseMTPlugins]: false });
+      setTestFlags({ [FlagKeys.PluginsUseMTPluginSettings]: true });
     });
 
     afterAll(() => {

--- a/packages/grafana-runtime/src/services/pluginSettings/refetchPluginSettings.test.ts
+++ b/packages/grafana-runtime/src/services/pluginSettings/refetchPluginSettings.test.ts
@@ -1,5 +1,6 @@
 import { setTestFlags } from '@grafana/test-utils/unstable';
 
+import { FlagKeys } from '../../internal/openFeature/openfeature.gen';
 import { invalidateCachedPromisesCache } from '../../utils/getCachedPromise';
 import { type MonitoringLogger } from '../../utils/logging';
 import { type BackendSrv, setBackendSrv } from '../backendSrv';
@@ -61,7 +62,7 @@ describe('settings', () => {
 
   describe('when plugins.useMTPluginSettings flag is enabled', () => {
     beforeAll(() => {
-      setTestFlags({ 'plugins.useMTPluginSettings': true });
+      setTestFlags({ [FlagKeys.PluginsUseMTPluginSettings]: true });
     });
 
     afterAll(() => {
@@ -160,7 +161,7 @@ describe('settings', () => {
 
   describe('when plugins.useMTPluginSettings flag is disabled', () => {
     beforeAll(() => {
-      setTestFlags({ 'plugins.useMTPluginSettings': false });
+      setTestFlags({ [FlagKeys.PluginsUseMTPluginSettings]: false });
     });
 
     afterAll(() => {

--- a/packages/grafana-runtime/src/services/pluginSettings/settings.test.ts
+++ b/packages/grafana-runtime/src/services/pluginSettings/settings.test.ts
@@ -1,5 +1,6 @@
 import { setTestFlags } from '@grafana/test-utils/unstable';
 
+import { FlagKeys } from '../../internal/openFeature/openfeature.gen';
 import { invalidateCachedPromisesCache } from '../../utils/getCachedPromise';
 import { type MonitoringLogger } from '../../utils/logging';
 import { type BackendSrv, setBackendSrv } from '../backendSrv';
@@ -10,7 +11,6 @@ import { clockPanelMetaOnPrem, myOrgTestAppMeta } from '../pluginMeta/test-fixtu
 import { isAppPluginEnabled } from './settings';
 import { legacyClockPanelOnPrem, legacyMyOrgTestAppSettings } from './test-fixtures/legacy.settings';
 import { myOrgTestAppSettings } from './test-fixtures/v0alpha1Response';
-
 jest.mock('../pluginMeta/plugins', () => ({
   ...jest.requireActual('../pluginMeta/plugins'),
   getPluginMetaFromCache: jest.fn(),
@@ -55,7 +55,7 @@ describe('settings', () => {
 
   describe('when plugins.useMTPluginSettings flag is enabled', () => {
     beforeAll(() => {
-      setTestFlags({ 'plugins.useMTPluginSettings': true });
+      setTestFlags({ [FlagKeys.PluginsUseMTPluginSettings]: true });
     });
 
     afterAll(() => {
@@ -160,7 +160,7 @@ describe('settings', () => {
 
   describe('when plugins.useMTPluginSettings flag is disabled', () => {
     beforeAll(() => {
-      setTestFlags({ 'plugins.useMTPluginSettings': false });
+      setTestFlags({ [FlagKeys.PluginsUseMTPluginSettings]: false });
     });
 
     afterAll(() => {

--- a/packages/grafana-runtime/src/services/pluginSettings/updateAppPluginSettings.test.ts
+++ b/packages/grafana-runtime/src/services/pluginSettings/updateAppPluginSettings.test.ts
@@ -1,5 +1,6 @@
 import { setTestFlags } from '@grafana/test-utils/unstable';
 
+import { FlagKeys } from '../../internal/openFeature/openfeature.gen';
 import { invalidateCachedPromisesCache, getCachedPromise } from '../../utils/getCachedPromise';
 import { type MonitoringLogger } from '../../utils/logging';
 import { type BackendSrv, setBackendSrv } from '../backendSrv';
@@ -62,7 +63,7 @@ describe('settings', () => {
 
   describe('when plugins.useMTPluginSettings flag is enabled', () => {
     beforeAll(() => {
-      setTestFlags({ 'plugins.useMTPluginSettings': true });
+      setTestFlags({ [FlagKeys.PluginsUseMTPluginSettings]: true });
     });
 
     afterAll(() => {
@@ -251,7 +252,7 @@ describe('settings', () => {
 
   describe('when plugins.useMTPluginSettings flag is disabled', () => {
     beforeAll(() => {
-      setTestFlags({ 'plugins.useMTPluginSettings': false });
+      setTestFlags({ [FlagKeys.PluginsUseMTPluginSettings]: false });
     });
 
     afterAll(() => {

--- a/public/app/features/plugins/admin/api.test.ts
+++ b/public/app/features/plugins/admin/api.test.ts
@@ -1,5 +1,5 @@
 import { getBackendSrv, type MonitoringLogger, setBackendSrv } from '@grafana/runtime';
-import { installPluginMeta, uninstallPluginMeta } from '@grafana/runtime/internal';
+import { installPluginMeta, uninstallPluginMeta, FlagKeys } from '@grafana/runtime/internal';
 import { mockLogger, setTestFlags } from '@grafana/test-utils/unstable';
 
 import { installPlugin, uninstallPlugin } from './api';
@@ -45,7 +45,7 @@ describe('api', () => {
 
   describe('when plugins.useMTPlugins flag is enabled', () => {
     beforeAll(() => {
-      setTestFlags({ 'plugins.useMTPlugins': true });
+      setTestFlags({ [FlagKeys.PluginsUseMTPlugins]: true });
     });
 
     afterAll(() => {
@@ -149,7 +149,7 @@ describe('api', () => {
 
   describe('when plugins.useMTPlugins flag is disabled', () => {
     beforeAll(() => {
-      setTestFlags({ 'plugins.useMTPlugins': false });
+      setTestFlags({ [FlagKeys.PluginsUseMTPlugins]: false });
     });
 
     afterAll(() => {


### PR DESCRIPTION
**What is this feature?**

Replaces hardcoded feature flag strings like `'plugins.useMTPlugins'` with the generated `FlagKeys` enum from `@grafana/runtime` in tests that use `setTestFlags`.

**Why do we need this feature?**

So a typo in a flag name fails at compile time instead of silently making a test pass.

**Who is this feature for?**

Grafana devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
