### PR TITLE
docs: update doc references from plugins-platform handles to @grafana/grafana-catalog

### DIFF
--- a/contribute/breaking-changes-guide/breaking-changes-guide.md
+++ b/contribute/breaking-changes-guide/breaking-changes-guide.md
@@ -106,7 +106,7 @@ myOldFunction(name: string) {
 
 ### Communicate
 
-Reach out to `@grafana/plugins-platform-frontend` to help find which plugins are using the code that is just about to change, so we try making it smoother by communicating it to the developers.
+Reach out to `@grafana/grafana-catalog` to help find which plugins are using the code that is just about to change, so we try making it smoother by communicating it to the developers.
 
 ---
 
@@ -114,4 +114,4 @@ Reach out to `@grafana/plugins-platform-frontend` to help find which plugins are
 
 We are here to help.
 
-Please either ping us in the pull request by using the `@grafana/plugins-platform-frontend` handle or reach out to us on the internal Slack in `#grafana-plugins-platform`.
+Please either ping us in the pull request by using the `@grafana/grafana-catalog` handle or reach out to us on the internal Slack in `#grafana-plugins-platform`.

--- a/scripts/modowners/README.md
+++ b/scripts/modowners/README.md
@@ -41,7 +41,7 @@ Example output:
 @grafana/observability-metrics 4
 @grafana/observability-traces-and-profiling 6
 @grafana/alerting-squad-backend 22
-@grafana/plugins-platform-backend 7
+@grafana/grafana-catalog 7
 @grafana/grafana-operator-experience-squad 3
 @grafana/dataviz-squad 1
 @grafana/grafana-backend-group 75


### PR DESCRIPTION
## Summary

Two doc references to retiring team handles, surfaced during the broader codeowners migration but kept out of the CODEOWNERS PRs to keep diffs scannable:

- `contribute/breaking-changes-guide/breaking-changes-guide.md` — two mentions of `@grafana/plugins-platform-frontend` updated to `@grafana/grafana-catalog`. The `#grafana-plugins-platform` Slack channel reference is left alone (separate cleanup).
- `scripts/modowners/README.md` — example output updated to reflect the renamed handle. The count `7` is illustrative only and may not match current state.

Tracking issue: grafana/grafana-catalog-team#870

## Test plan
- [ ] CI passes (docs-only change, low risk)