### PR TITLE
TestInfra: Do not install any plugin

### DIFF
--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -506,7 +506,19 @@ func createGrafDir(t *testing.T, tmpDir string, opts GrafanaOpts) (string, strin
 
 	pluginsSect, err := getOrCreateSection("plugins")
 	require.NoError(t, err)
-	_, err = pluginsSect.NewKey("disable_plugins", "grafana-assistant-app")
+
+	// Plugins that are automatically installed, but not relevant in tests
+	disabledPlugins := []string{
+		"grafana-pathfinder-app",
+		"grafana-advisor-app",
+		"grafana-assistant-app",
+		"grafana-lokiexplore-app",
+		"grafana-pyroscope-app",
+		"grafana-exploretraces-app",
+		"grafana-metricsdrilldown-app",
+		"elasticsearch",
+	}
+	_, err = pluginsSect.NewKey("disable_plugins", strings.Join(disabledPlugins, ","))
 	require.NoError(t, err)
 
 	if opts.EnableCSP {


### PR DESCRIPTION
Not installing these plugins makes the integration tests run ~4min faster, very scientific benchmark:

Without plugins
Run1: 18m52s
Run2: 17m38s
Run3: 19m19s
Avg : 18m36s

main
Run1: 24m18s
Run1: 22m02s
Run1: 20m53s
Avg : 22m24s
