### PR TITLE
Home: Add IsDefaultHome flag to home dashboard API response

### DIFF
--- a/packages/grafana-api-clients/src/clients/rtkq/legacy/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/legacy/endpoints.gen.ts
@@ -4625,6 +4625,7 @@ export type DashboardMeta = {
   folderUid?: string;
   folderUrl?: string;
   hasAcl?: boolean;
+  isDefaultHome?: boolean;
   isFolder?: boolean;
   isSnapshot?: boolean;
   provisioned?: boolean;

--- a/packages/grafana-api-clients/src/clients/rtkq/migrate-to-cloud/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/migrate-to-cloud/endpoints.gen.ts
@@ -352,6 +352,7 @@ export type DashboardMeta = {
   folderUid?: string;
   folderUrl?: string;
   hasAcl?: boolean;
+  isDefaultHome?: boolean;
   isFolder?: boolean;
   isSnapshot?: boolean;
   provisioned?: boolean;

--- a/packages/grafana-openapi/src/api/openapi3.json
+++ b/packages/grafana-openapi/src/api/openapi3.json
@@ -4569,6 +4569,9 @@
           "hasAcl": {
             "type": "boolean"
           },
+          "isDefaultHome": {
+            "type": "boolean"
+          },
           "isFolder": {
             "type": "boolean"
           },

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -733,6 +733,7 @@ func (hs *HTTPServer) GetHomeDashboard(c *contextmodel.ReqContext) response.Resp
 	dash := dtos.DashboardFullWithMeta{}
 	dash.Meta.CanEdit = c.HasRole(org.RoleEditor)
 	dash.Meta.FolderTitle = "General"
+	dash.Meta.IsDefaultHome = hs.Cfg.DefaultHomeDashboardPath == ""
 	dash.Dashboard = doc
 
 	hs.addGettingStartedPanelToHomeDashboard(c, dash.Dashboard)

--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -165,6 +165,7 @@ func TestGetHomeDashboard(t *testing.T) {
 				require.NoError(t, err)
 				wrapper := dtos.DashboardFullWithMeta{}
 				wrapper.Meta.FolderTitle = "General"
+				wrapper.Meta.IsDefaultHome = true
 				wrapper.Dashboard = j
 				out, err := json.Marshal(wrapper)
 				require.NoError(t, err)

--- a/pkg/api/dtos/dashboard.go
+++ b/pkg/api/dtos/dashboard.go
@@ -35,6 +35,7 @@ type DashboardMeta struct {
 	ProvisionedExternalId  string                             `json:"provisionedExternalId"`
 	AnnotationsPermissions *dashboardsV1.AnnotationPermission `json:"annotationsPermissions"`
 	PublicDashboardEnabled bool                               `json:"publicDashboardEnabled,omitempty"`
+	IsDefaultHome          bool                               `json:"isDefaultHome,omitempty"`
 }
 
 type DashboardFullWithMeta struct {

--- a/public/api-enterprise-spec.json
+++ b/public/api-enterprise-spec.json
@@ -4237,6 +4237,9 @@
         "hasAcl": {
           "type": "boolean"
         },
+        "isDefaultHome": {
+          "type": "boolean"
+        },
         "isFolder": {
           "type": "boolean"
         },

--- a/public/api-merged.json
+++ b/public/api-merged.json
@@ -14922,6 +14922,9 @@
         "hasAcl": {
           "type": "boolean"
         },
+        "isDefaultHome": {
+          "type": "boolean"
+        },
         "isFolder": {
           "type": "boolean"
         },

--- a/public/openapi3.json
+++ b/public/openapi3.json
@@ -4690,6 +4690,9 @@
           "hasAcl": {
             "type": "boolean"
           },
+          "isDefaultHome": {
+            "type": "boolean"
+          },
           "isFolder": {
             "type": "boolean"
           },


### PR DESCRIPTION
**What is this feature?**

Add `IsDefaultHome` boolean field to `DashboardMeta`, set to `true` when `GET /api/dashboards/home` serves the bundled default `home.json` (no custom `default_home_dashboard_path` configured). 

**Why do we need this feature?**

The frontend `HomeRoute` checks `meta.isDefaultHome === true` to decide whether to render the unified `<HomePage />` vs the legacy `<DashboardPageProxy />`. The frontend type already declares `isDefaultHome?: boolean` but the backend never set it — this provides the missing signal.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/124468
