### PR TITLE
CI: Enable anonymous admin auth for Meticulous container tests

### DIFF
--- a/.github/workflows/pr-build-grafana.yml
+++ b/.github/workflows/pr-build-grafana.yml
@@ -177,3 +177,6 @@ jobs:
           api-token: ${{ env.METICULOUS_API_TOKEN }}
           image-tag: ${{ env.IMAGE_TAG }}
           container-port: 3000
+          container-env: |
+            GF_AUTH_ANONYMOUS_ENABLED=true
+            GF_AUTH_ANONYMOUS_ORG_ROLE=Admin

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -968,6 +968,9 @@ jobs:
           api-token: ${{ env.METICULOUS_API_TOKEN }}
           image-tag: ${{ env.IMAGE_TAG }}
           container-port: 3000
+          container-env: |
+            GF_AUTH_ANONYMOUS_ENABLED=true
+            GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
 
   dispatch-npm-canaries:
     if: github.repository == 'grafana/grafana' && github.ref_name == 'main'


### PR DESCRIPTION


<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Pass GF_AUTH_ANONYMOUS_ENABLED=true and GF_AUTH_ANONYMOUS_ORG_ROLE=Admin to the Grafana container started by the Meticulous upload-container action so recorded sessions can replay without an interactive login.

**Why do we need this feature?**

Meticulous test runs are currently failing to get beyond the login screen.

**Who is this feature for?**

[Meticulous](meticulous.ai) pilot @ DataViz

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
