### PR TITLE
Internationalisation: Update documentation and expose `tOptions` on `Trans`

### DIFF
--- a/contribute/internationalization.md
+++ b/contribute/internationalization.md
@@ -199,23 +199,40 @@ import { Trans } from "@grafana/i18n"
 
 ### Plurals
 
-Plurals require special handling to make sure they can be translated according to the rules of each locale (which may be more complex than you think). Use either the `<Trans />` component or the `t` function, with the `count` prop to provide a singular form. For example:
+Plurals require special handling to make sure they can be translated according to the rules of each locale (which may be more complex than you think). Use either the `<Trans />` component or the `t` function, providing a separate singular form alongside the `count` prop. For example:
 
-```js
+#### `Trans`
+
+```tsx
 import { Trans } from '@grafana/i18n';
 
-<Trans i18nKey="inbox.heading" count={messages.length}>
+<Trans
+  i18nKey="inbox.heading"
+  count={messages.length}
+  tOptions={{
+    defaultValue_one: 'You got {{count}} message',
+  }}
+>
   You got {{ count: messages.length }} messages
 </Trans>;
 ```
 
-```js
+#### `t`
+
+```ts
 import { t } from '@grafana/i18n';
 
-const translatedString = t('inbox.heading', 'You got {{count}} messages', { count: messages.length });
+const translatedString = t(
+  'inbox.heading',
+  'You got {{count}} messages',
+  {
+    count: messages.length
+    defaultValue_one: 'You got {{count}} message',
+  }
+);
 ```
 
-Once extracted with `make i18n-extract` you need to manually edit the [English `grafana.json` message catalog](../public/locales/en-US/grafana.json) to correct the plural forms. Refer to the [react-i18next docs](https://react.i18next.com/latest/trans-component#plural) for more details.
+Once extracted with `yarn i18n-extract`, you'll see your updated strings in the [English `grafana.json` message catalog](../public/locales/en-US/grafana.json). Refer to the [react-i18next docs](https://react.i18next.com/latest/trans-component#plural) for more details.
 
 ```json
 {

--- a/packages/grafana-i18n/src/types.ts
+++ b/packages/grafana-i18n/src/types.ts
@@ -1,3 +1,4 @@
+import { type TOptions } from 'i18next';
 /**
  * Hook type for translation function that takes an ID, default message, and optional values
  * @returns A function that returns the translated string
@@ -44,6 +45,11 @@ interface TransPropsBase {
    * Class name for the Trans component
    */
   className?: string;
+  /**
+   * Options to pass to the internal t function. Needed for plural forms.
+   * Note: use the separate `context` prop rather than setting context here.
+   */
+  tOptions?: Omit<TOptions, 'context'>;
 }
 
 interface TransPropsWithChildren extends TransPropsBase {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- exposes `tOptions` on `Trans`
- updates documentation to correctly show how to do plurals

**Why do we need this feature?**

- so users can correctly translate plurals

**Who is this feature for?**

- everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

slack context here: https://raintank-corp.slack.com/archives/C025WTVRBSN/p1778242592901159 

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
