### PR TITLE
Logs: Deprecate getLogLevel

### DIFF
--- a/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
@@ -45,7 +45,8 @@ declare module "@openfeature/core" {
     | "assistant.frontend.tools.dashboardTemplates"
     | "grafana.unifiedHomepage"
     | "alerting.syncExternalAlertmanager"
-    | "grafana.enableScopesFirstMode";
+    | "grafana.enableScopesFirstMode"
+    | "grafana.logLevelInference";
   export type NumberFlagKey = never;
   export type StringFlagKey = never;
   export type ObjectFlagKey = never;

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -39,6 +39,8 @@ export const FlagKeys = {
   FlameGraphWithCallTree: "flameGraphWithCallTree",
   /** Enables UI changes for integrations that require a scope to always be selected (for example, hides the scope selector's Remove all button) */
   GrafanaEnableScopesFirstMode: "grafana.enableScopesFirstMode",
+  /** Enables log level inference from log line contents when level is not defined as a field or a label */
+  GrafanaLogLevelInference: "grafana.logLevelInference",
   /** Whether to use the new SharedPreferences functional component */
   GrafanaNewPreferencesPage: "grafana.newPreferencesPage",
   /** Enables org-defined dashboard templates for enterprise */
@@ -228,6 +230,17 @@ export const useFlagFlameGraphWithCallTree = (options?: ReactFlagEvaluationOptio
  */
 export const useFlagGrafanaEnableScopesFirstMode = (options?: ReactFlagEvaluationOptions): boolean => {
   return useFlag("grafana.enableScopesFirstMode", false, options).value;
+};
+
+/**
+ * Enables log level inference from log line contents when level is not defined as a field or a label
+ *
+ * **Details:**
+ * - flag key: `grafana.logLevelInference`
+ * - default value: `false`
+ */
+export const useFlagGrafanaLogLevelInference = (options?: ReactFlagEvaluationOptions): boolean => {
+  return useFlag("grafana.logLevelInference", false, options).value;
 };
 
 /**

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -3136,6 +3136,15 @@ var (
 			Expression:   "false",
 			Generate:     Generate{React: true},
 		},
+		{
+			Name:         "grafana.logLevelInference",
+			Description:  "Enables log level inference from log line contents when level is not defined as a field or a label",
+			Stage:        FeatureStageDeprecated,
+			Owner:        grafanaObservabilityLogsSquad,
+			HideFromDocs: true,
+			Expression:   "false",
+			Generate:     Generate{React: true},
+		},
 		// tl;dr: name your new flag `component.featureName`, specify Go and/or React generation targets, and use with OpenFeature!
 		//
 		// Adding a new feature flag? Be sure to check out the updated docs at /contribute/feature-toggles.md#Steps-to-adding-a-feature-toggle

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -365,3 +365,4 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-05-05,plugins.marketplaceLicensing,experimental,@grafana/grafana-catalog,false,true,false
 2026-05-11,alerting.syncExternalAlertmanager,experimental,@grafana/alerting-squad,false,true,false
 2026-05-12,grafana.enableScopesFirstMode,experimental,@grafana/grafana-operator-experience-squad,false,false,true
+2026-05-08,grafana.logLevelInference,deprecated,@grafana/observability-logs,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2766,6 +2766,21 @@
     },
     {
       "metadata": {
+        "name": "grafana.logLevelInference",
+        "resourceVersion": "1778252024619",
+        "creationTimestamp": "2026-05-08T14:53:44Z"
+      },
+      "spec": {
+        "description": "Enables log level inference from log line contents when level is not defined as a field or a label",
+        "stage": "deprecated",
+        "codeowner": "@grafana/observability-logs",
+        "frontend": true,
+        "hideFromDocs": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "grafana.meticulousAIRecorder",
         "resourceVersion": "1777401759422",
         "creationTimestamp": "2026-04-28T17:20:14Z",

--- a/public/app/features/logs/logsModel.test.ts
+++ b/public/app/features/logs/logsModel.test.ts
@@ -30,7 +30,7 @@ import { MockObservableDataSourceApi } from '../../../test/mocks/datasource_srv'
 const mockGetBooleanValue = jest.fn((key: string, defaultValue: boolean) => defaultValue);
 
 jest.mock('@grafana/runtime/internal', () => {
-  const actual = jest.requireActual<typeof import('@grafana/runtime/internal')>('@grafana/runtime/internal');
+  const actual = jest.requireActual('@grafana/runtime/internal');
   return {
     ...actual,
     getFeatureFlagClient: jest.fn(() => ({

--- a/public/app/features/logs/logsModel.test.ts
+++ b/public/app/features/logs/logsModel.test.ts
@@ -21,10 +21,23 @@ import {
   sortDataFrame,
   toDataFrame,
 } from '@grafana/data';
+import { FlagKeys } from '@grafana/runtime/internal';
 import { LokiQueryDirection } from 'app/plugins/datasource/loki/dataquery.gen';
 import { getMockFrames } from 'app/plugins/datasource/loki/mocks/frames';
 
 import { MockObservableDataSourceApi } from '../../../test/mocks/datasource_srv';
+
+const mockGetBooleanValue = jest.fn((key: string, defaultValue: boolean) => defaultValue);
+
+jest.mock('@grafana/runtime/internal', () => {
+  const actual = jest.requireActual<typeof import('@grafana/runtime/internal')>('@grafana/runtime/internal');
+  return {
+    ...actual,
+    getFeatureFlagClient: jest.fn(() => ({
+      getBooleanValue: mockGetBooleanValue,
+    })),
+  };
+});
 
 import {
   COMMON_LABELS,
@@ -234,10 +247,22 @@ describe('dataFrameToLogsModel', () => {
               't=2019-04-26T11:05:28+0200 lvl=info msg="Initializing DatasourceCacheService" logger=server',
               't=2019-04-26T16:42:50+0200 lvl=eror msg="new token…t unhashed token=56d9fdc5c8b7400bd51b060eea8ca9d7',
             ],
-            labels: {
-              filename: '/var/log/grafana/grafana.log',
-              job: 'grafana',
-            },
+          },
+          {
+            name: 'labels',
+            type: FieldType.other,
+            values: [
+              {
+                filename: '/var/log/grafana/grafana.log',
+                job: 'grafana',
+                level: 'info',
+              },
+              {
+                filename: '/var/log/grafana/grafana.log',
+                job: 'grafana',
+                level: 'error',
+              },
+            ],
           },
           {
             name: 'id',
@@ -252,7 +277,7 @@ describe('dataFrameToLogsModel', () => {
       }),
     ];
     const logsModel = dataFrameToLogsModel(series, 1);
-    expect(logsModel.hasUniqueLabels).toBeFalsy();
+    expect(logsModel.hasUniqueLabels).toBeTruthy();
     expect(logsModel.rows).toHaveLength(2);
     expect(logsModel.rows).toMatchObject([
       {
@@ -678,10 +703,12 @@ describe('dataFrameToLogsModel', () => {
               {
                 filename: '/var/log/grafana/grafana.log',
                 job: 'grafana',
+                level: 'info',
               },
               {
                 filename: '/var/log/grafana/grafana.log',
                 job: 'grafana',
+                level: 'error',
               },
             ],
           },
@@ -711,7 +738,7 @@ describe('dataFrameToLogsModel', () => {
       }),
     ];
     const logsModel = dataFrameToLogsModel(series, 1);
-    expect(logsModel.hasUniqueLabels).toBeFalsy();
+    expect(logsModel.hasUniqueLabels).toBeTruthy();
     expect(logsModel.rows).toHaveLength(2);
     expect(logsModel.rows).toMatchObject([
       {
@@ -852,20 +879,20 @@ describe('dataFrameToLogsModel', () => {
       {
         entry: 't=2019-04-26T11:05:28+0200 lvl=info msg="Initializing DatasourceCacheService" logger=server',
         labels: { filename: '/var/log/grafana/grafana.log', job: 'grafana', __error__: 'Failed while parsing' },
-        logLevel: 'info',
+        logLevel: 'unknown',
         uniqueLabels: {},
         uid: 'A_foo',
       },
       {
         entry: 't=2019-04-26T16:42:50+0200 lvl=eror msg="new token…t unhashed token=56d9fdc5c8b7400bd51b060eea8ca9d7',
         labels: { filename: '/var/log/grafana/grafana.log', job: 'grafana', __error__: 'Failed while parsing' },
-        logLevel: 'error',
+        logLevel: 'unknown',
         uniqueLabels: {},
         uid: 'A_bar',
       },
     ]);
 
-    expect(logsModel.series).toHaveLength(2);
+    expect(logsModel.series).toHaveLength(1);
     expect(logsModel.meta).toHaveLength(3);
     expect(logsModel.meta![0]).toMatchObject({
       label: '',
@@ -1445,34 +1472,46 @@ describe('logSeriesToLogsModel', () => {
     ]);
   });
 
-  it('should correctly get the log level if the message has ANSI color', () => {
-    const logSeries: DataFrame[] = [
-      toDataFrame({
-        fields: [
-          {
-            name: 'ts',
-            type: FieldType.time,
-            values: ['1970-01-01T00:00:01Z'],
-          },
-          {
-            name: 'line',
-            type: FieldType.string,
-            values: ['Line with ANSI \u001B[31mwarn\u001B[0m et dolor'],
-          },
-          {
-            name: 'id',
-            type: FieldType.string,
-            values: ['0'],
-          },
-        ],
-        refId: 'A',
-        meta: {},
-      }),
-    ];
+  describe('Deprecated log level inference', () => {
+    describe('with grafana.logLevelInference enabled', () => {
+      beforeEach(() => {
+        mockGetBooleanValue.mockImplementation((key, def) => (key === FlagKeys.GrafanaLogLevelInference ? true : def));
+      });
 
-    const logsModel = dataFrameToLogsModel(logSeries, 0);
-    expect(logsModel.rows).toHaveLength(1);
-    expect(logsModel.rows[0].logLevel).toEqual(LogLevel.warn);
+      afterEach(() => {
+        mockGetBooleanValue.mockImplementation((key, def) => def);
+      });
+
+      it('should correctly get the log level if the message has ANSI color', () => {
+        const logSeries: DataFrame[] = [
+          toDataFrame({
+            fields: [
+              {
+                name: 'ts',
+                type: FieldType.time,
+                values: ['1970-01-01T00:00:01Z'],
+              },
+              {
+                name: 'line',
+                type: FieldType.string,
+                values: ['Line with ANSI \u001B[31mwarn\u001B[0m et dolor'],
+              },
+              {
+                name: 'id',
+                type: FieldType.string,
+                values: ['0'],
+              },
+            ],
+            refId: 'A',
+            meta: {},
+          }),
+        ];
+
+        const logsModel = dataFrameToLogsModel(logSeries, 0);
+        expect(logsModel.rows).toHaveLength(1);
+        expect(logsModel.rows[0].logLevel).toEqual(LogLevel.warn);
+      });
+    });
   });
 });
 

--- a/public/app/features/logs/utils.test.ts
+++ b/public/app/features/logs/utils.test.ts
@@ -18,6 +18,7 @@ import {
   mockTransformationsRegistry,
   organizeFieldsTransformer,
 } from '@grafana/data/internal';
+import { FlagKeys } from '@grafana/runtime/internal';
 import { extractFieldsTransformer } from 'app/features/transformers/extractFields/extractFields';
 import { getMockFrames } from 'app/plugins/datasource/loki/mocks/frames';
 
@@ -43,6 +44,18 @@ import {
   DownloadFormat,
 } from './utils';
 
+const mockGetBooleanValue = jest.fn((key: string, defaultValue: boolean) => defaultValue);
+
+jest.mock('@grafana/runtime/internal', () => {
+  const actual = jest.requireActual<typeof import('@grafana/runtime/internal')>('@grafana/runtime/internal');
+  return {
+    ...actual,
+    getFeatureFlagClient: jest.fn(() => ({
+      getBooleanValue: mockGetBooleanValue,
+    })),
+  };
+});
+
 jest.mock('file-saver', () => jest.fn());
 
 jest.mock('../inspector/utils/download', () => ({
@@ -50,33 +63,47 @@ jest.mock('../inspector/utils/download', () => ({
   downloadDataFrameAsCsv: jest.fn(),
 }));
 
-describe('getLoglevel()', () => {
-  it('returns no log level on empty line', () => {
-    expect(getLogLevel('')).toBe(LogLevel.unknown);
+describe('deprecated getLoglevel()', () => {
+  describe('with grafana.logLevelInference enabled', () => {
+    beforeEach(() => {
+      mockGetBooleanValue.mockImplementation((key, def) => (key === FlagKeys.GrafanaLogLevelInference ? true : def));
+    });
+
+    afterEach(() => {
+      mockGetBooleanValue.mockImplementation((key, def) => def);
+    });
+
+    it('returns no log level on empty line', () => {
+      expect(getLogLevel('')).toBe(LogLevel.unknown);
+    });
+
+    it('returns no log level on when level is part of a word', () => {
+      expect(getLogLevel('who warns us')).toBe(LogLevel.unknown);
+    });
+
+    it('returns same log level for long and short version', () => {
+      expect(getLogLevel('[Warn]')).toBe(LogLevel.warning);
+      expect(getLogLevel('[Warning]')).toBe(LogLevel.warning);
+      expect(getLogLevel('[Warn]')).toBe('warning');
+    });
+
+    it('returns correct log level when level is capitalized', () => {
+      expect(getLogLevel('WARN')).toBe(LogLevel.warn);
+    });
+
+    it('returns log level on line contains a log level', () => {
+      expect(getLogLevel('warn: it is looking bad')).toBe(LogLevel.warn);
+      expect(getLogLevel('2007-12-12 12:12:12 [WARN]: it is looking bad')).toBe(LogLevel.warn);
+    });
+
+    it('returns first log level found', () => {
+      expect(getLogLevel('WARN this could be a debug message')).toBe(LogLevel.warn);
+      expect(getLogLevel('WARN this is a non-critical message')).toBe(LogLevel.warn);
+    });
   });
 
-  it('returns no log level on when level is part of a word', () => {
-    expect(getLogLevel('who warns us')).toBe(LogLevel.unknown);
-  });
-
-  it('returns same log level for long and short version', () => {
-    expect(getLogLevel('[Warn]')).toBe(LogLevel.warning);
-    expect(getLogLevel('[Warning]')).toBe(LogLevel.warning);
-    expect(getLogLevel('[Warn]')).toBe('warning');
-  });
-
-  it('returns correct log level when level is capitalized', () => {
-    expect(getLogLevel('WARN')).toBe(LogLevel.warn);
-  });
-
-  it('returns log level on line contains a log level', () => {
-    expect(getLogLevel('warn: it is looking bad')).toBe(LogLevel.warn);
-    expect(getLogLevel('2007-12-12 12:12:12 [WARN]: it is looking bad')).toBe(LogLevel.warn);
-  });
-
-  it('returns first log level found', () => {
-    expect(getLogLevel('WARN this could be a debug message')).toBe(LogLevel.warn);
-    expect(getLogLevel('WARN this is a non-critical message')).toBe(LogLevel.warn);
+  describe('with grafana.logLevelInference disaabled', () => {
+    expect(getLogLevel('error warn info')).toBe(LogLevel.unknown);
   });
 });
 

--- a/public/app/features/logs/utils.test.ts
+++ b/public/app/features/logs/utils.test.ts
@@ -47,7 +47,7 @@ import {
 const mockGetBooleanValue = jest.fn((key: string, defaultValue: boolean) => defaultValue);
 
 jest.mock('@grafana/runtime/internal', () => {
-  const actual = jest.requireActual<typeof import('@grafana/runtime/internal')>('@grafana/runtime/internal');
+  const actual = jest.requireActual('@grafana/runtime/internal');
   return {
     ...actual,
     getFeatureFlagClient: jest.fn(() => ({

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -51,7 +51,7 @@ import { DATAPLANE_LABELS_NAME, DATAPLANE_LABEL_TYPES_NAME, parseLogsFrame } fro
  * @deprecated
  */
 export function getLogLevel(line: string): LogLevel {
-  const enabled = getFeatureFlagClient().getBooleanValue(FlagKeys.GrafanaLogLevelInference, false)
+  const enabled = getFeatureFlagClient().getBooleanValue(FlagKeys.GrafanaLogLevelInference, false);
   if (!enabled) {
     return LogLevel.unknown;
   }

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -32,6 +32,7 @@ import {
   store,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
 import { getConfig } from 'app/core/config';
 
 import { getLogsExtractFields } from '../explore/Logs/LogsTable';
@@ -47,8 +48,13 @@ import { DATAPLANE_LABELS_NAME, DATAPLANE_LABEL_TYPES_NAME, parseLogsFrame } fro
  * Parse the line for level words. If no level is found, it returns `LogLevel.unknown`.
  *
  * Example: `getLogLevel('WARN 1999-12-31 this is great') // LogLevel.warn`
+ * @deprecated
  */
 export function getLogLevel(line: string): LogLevel {
+  const enabled = getFeatureFlagClient().getBooleanValue(FlagKeys.GrafanaLogLevelInference, false)
+  if (!enabled) {
+    return LogLevel.unknown;
+  }
   if (!line) {
     return LogLevel.unknown;
   }


### PR DESCRIPTION
getLogLevel was introduced many years ago, to attempt to infer level from the content of the log lines. Since there, logs have evolved, defining [stardard rules](https://grafana.com/developers/dataplane/logs) on how to specifically tell the corresponding level for each log line.

Log level inference from log lines not only is inaccurate, but it also hides incorrect setups or or misconfiguration of logging tools, which is why it's now being deprecated.

If it needs to be re-enabled, it can be done through the feature flag `grafana.logLevelInference`

Part of https://github.com/grafana/grafana/issues/117687