### PR TITLE
Alerting: Fix rule UIDs mapping for legacy storage

### DIFF
--- a/pkg/registry/apps/alerting/rules/alertrule/compat.go
+++ b/pkg/registry/apps/alerting/rules/alertrule/compat.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/expr"
@@ -17,7 +18,6 @@ import (
 
 	model "github.com/grafana/grafana/apps/alerting/rules/pkg/apis/alerting/v0alpha1"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
-	gapiutil "github.com/grafana/grafana/pkg/services/apiserver/utils"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
@@ -41,6 +41,7 @@ func convertToK8sResource(
 	k8sRule := &model.AlertRule{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            rule.UID,
+			UID:             types.UID(rule.GUID),
 			Namespace:       namespaceMapper(orgID),
 			ResourceVersion: fmt.Sprint(rule.Version),
 			Labels:          make(map[string]string),
@@ -162,8 +163,6 @@ func convertToK8sResource(
 	// FIXME: we don't have a creation timestamp in the domain model, so we can't set it here.
 	// We should consider adding it to the domain model. Migration can set it to the Updated timestamp for existing
 	// k8sRule.SetCreationTimestamp(rule.)
-
-	k8sRule.UID = gapiutil.CalculateClusterWideUID(k8sRule)
 	return k8sRule, nil
 }
 

--- a/pkg/registry/apps/alerting/rules/alertrule/legacy_storage.go
+++ b/pkg/registry/apps/alerting/rules/alertrule/legacy_storage.go
@@ -195,7 +195,13 @@ func (s *legacyStorage) Create(ctx context.Context, obj runtime.Object, createVa
 		return nil, err
 	}
 
-	return convertToK8sResource(info.OrgID, &created, provenance, s.namespacer)
+	// perform the get after to ensure we return the object with all the system filled fields set
+	rule, provenance, err := s.service.GetAlertRule(ctx, user, created.UID)
+	if err != nil {
+		return nil, err
+	}
+
+	return convertToK8sResource(info.OrgID, &rule, provenance, s.namespacer)
 }
 
 func (s *legacyStorage) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {

--- a/pkg/registry/apps/alerting/rules/recordingrule/compat.go
+++ b/pkg/registry/apps/alerting/rules/recordingrule/compat.go
@@ -9,12 +9,12 @@ import (
 
 	prom_model "github.com/prometheus/common/model"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	model "github.com/grafana/grafana/apps/alerting/rules/pkg/apis/alerting/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/expr"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
-	gapiutil "github.com/grafana/grafana/pkg/services/apiserver/utils"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/util"
 )
@@ -39,6 +39,7 @@ func convertToK8sResource(
 	k8sRule := &model.RecordingRule{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            rule.UID,
+			UID:             types.UID(rule.GUID),
 			Namespace:       namespaceMapper(orgID),
 			ResourceVersion: fmt.Sprint(rule.Version),
 			Labels:          make(map[string]string),
@@ -95,8 +96,6 @@ func convertToK8sResource(
 	// FIXME: we don't have a creation timestamp in the domain model, so we can't set it here.
 	// We should consider adding it to the domain model. Migration can set it to the Updated timestamp for existing
 	// k8sRule.SetCreationTimestamp(rule.)
-
-	k8sRule.UID = gapiutil.CalculateClusterWideUID(k8sRule)
 	return k8sRule, nil
 }
 

--- a/pkg/registry/apps/alerting/rules/recordingrule/legacy_storage.go
+++ b/pkg/registry/apps/alerting/rules/recordingrule/legacy_storage.go
@@ -180,7 +180,13 @@ func (s *legacyStorage) Create(ctx context.Context, obj runtime.Object, createVa
 		return nil, err
 	}
 
-	rule, err := s.service.CreateAlertRule(ctx, user, *model, provenance)
+	created, err := s.service.CreateAlertRule(ctx, user, *model, provenance)
+	if err != nil {
+		return nil, err
+	}
+
+	// perform the get after to ensure we return the object with all the system filled fields set
+	rule, provenance, err := s.service.GetAlertRule(ctx, user, created.UID)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
**What is this feature?**

Sets the Kubernetes resource `UID` for alert rules and recording rules to the rule's `GUID` from the database, instead of computing a cluster-wide UID at conversion time.

**Why do we need this feature?**

The rule UID needs to be stable and consistent with the GUID persisted in the database so the legacy storage history implementation can correctly correlate revisions of a rule across reads. Computing the UID via `CalculateClusterWideUID` at conversion time produced a value that did not match the stored GUID, breaking history lookups.

**Who is this feature for?**

Users of Grafana alerting on the legacy storage path (history of alert rules and recording rules).

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.