### PR TITLE
Zanzana: Update reconciler to use Team.spec.members instead of TeamBinding

### DIFF
--- a/pkg/services/authz/zanzana/server/reconciler/namespace.go
+++ b/pkg/services/authz/zanzana/server/reconciler/namespace.go
@@ -127,7 +127,7 @@ func (r *Reconciler) fetchAndTranslateTuples(ctx context.Context, namespace stri
 		},
 		"rolebindings":        TranslateRoleBindingToTuples,
 		"resourcepermissions": TranslateResourcePermissionToTuples,
-		"teambindings":        TranslateTeamBindingToTuples,
+		"teams":               TranslateTeamToMemberTuples,
 		"users":               TranslateUserToTuples,
 		"serviceaccounts":     TranslateServiceAccountToTuples,
 	}

--- a/pkg/services/authz/zanzana/server/reconciler/reconciler.go
+++ b/pkg/services/authz/zanzana/server/reconciler/reconciler.go
@@ -98,7 +98,7 @@ func (c Config) listPageSize() int64 {
 var DefaultCRDs = []schema.GroupVersionResource{
 	folderv1.FolderResourceInfo.GroupVersionResource(),
 	iamv0.ResourcePermissionInfo.GroupVersionResource(),
-	iamv0.TeamBindingResourceInfo.GroupVersionResource(),
+	iamv0.TeamResourceInfo.GroupVersionResource(),
 	iamv0.UserResourceInfo.GroupVersionResource(),
 	iamv0.ServiceAccountResourceInfo.GroupVersionResource(),
 }

--- a/pkg/services/authz/zanzana/server/reconciler/translators.go
+++ b/pkg/services/authz/zanzana/server/reconciler/translators.go
@@ -174,20 +174,27 @@ func TranslateResourcePermissionToTuples(obj *unstructured.Unstructured) ([]*ope
 	return tuples, nil
 }
 
-// TranslateTeamBindingToTuples converts a TeamBinding CRD to team membership tuples.
-func TranslateTeamBindingToTuples(obj *unstructured.Unstructured) ([]*openfgav1.TupleKey, error) {
-	var tb iamv0.TeamBinding
-	if err := convertUnstructured(obj, &tb); err != nil {
+// TranslateTeamToMemberTuples converts a Team CRD to team membership tuples.
+// Each member in spec.members produces one tuple.
+func TranslateTeamToMemberTuples(obj *unstructured.Unstructured) ([]*openfgav1.TupleKey, error) {
+	var team iamv0.Team
+	if err := convertUnstructured(obj, &team); err != nil {
 		return nil, err
 	}
 
-	// Use the shared server logic to create the tuple
-	tuple, err := zanzana.GetTeamBindingTuple(tb.Spec.Subject.Name, tb.Spec.TeamRef.Name, string(tb.Spec.Permission))
-	if err != nil {
-		return nil, err
+	tuples := make([]*openfgav1.TupleKey, 0, len(team.Spec.Members))
+	for _, m := range team.Spec.Members {
+		if m.Name == "" {
+			continue
+		}
+		tuple, err := zanzana.GetTeamBindingTuple(m.Name, team.Name, string(m.Permission))
+		if err != nil {
+			return nil, err
+		}
+		tuples = append(tuples, tuple)
 	}
 
-	return []*openfgav1.TupleKey{tuple}, nil
+	return tuples, nil
 }
 
 // TranslateUserToTuples converts a User CRD to basic role assignment tuples.

--- a/pkg/services/authz/zanzana/server/reconciler/translators_test.go
+++ b/pkg/services/authz/zanzana/server/reconciler/translators_test.go
@@ -112,44 +112,60 @@ func TestTranslateResourcePermissionToTuples(t *testing.T) {
 	}
 }
 
-func TestTranslateTeamBindingToTuples(t *testing.T) {
-	tests := []struct {
-		name             string
-		permission       iamv0.TeamBindingTeamPermission
-		expectedRelation string
-	}{
-		{
-			name:             "member binding",
-			permission:       iamv0.TeamBindingTeamPermissionMember,
-			expectedRelation: common.RelationTeamMember,
-		},
-		{
-			name:             "admin binding",
-			permission:       iamv0.TeamBindingTeamPermissionAdmin,
-			expectedRelation: common.RelationTeamAdmin,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			tb := &iamv0.TeamBinding{
-				ObjectMeta: metav1.ObjectMeta{Name: "tb-test"},
-				Spec: iamv0.TeamBindingSpec{
-					Subject:    iamv0.TeamBindingspecSubject{Kind: "User", Name: "user1"},
-					TeamRef:    iamv0.TeamBindingTeamRef{Name: "teamA"},
-					Permission: tt.permission,
+func TestTranslateTeamToMemberTuples(t *testing.T) {
+	t.Run("admin and member", func(t *testing.T) {
+		team := &iamv0.Team{
+			ObjectMeta: metav1.ObjectMeta{Name: "teamA"},
+			Spec: iamv0.TeamSpec{
+				Members: []iamv0.TeamTeamMember{
+					{Kind: "User", Name: "user1", Permission: iamv0.TeamTeamPermissionAdmin},
+					{Kind: "User", Name: "user2", Permission: iamv0.TeamTeamPermissionMember},
 				},
-			}
+			},
+		}
 
-			tuples, err := TranslateTeamBindingToTuples(toUnstructured(t, tb))
-			require.NoError(t, err)
-			require.Len(t, tuples, 1)
+		tuples, err := TranslateTeamToMemberTuples(toUnstructured(t, team))
+		require.NoError(t, err)
+		require.Len(t, tuples, 2)
 
-			assert.Equal(t, "user:user1", tuples[0].GetUser())
-			assert.Equal(t, tt.expectedRelation, tuples[0].GetRelation())
-			assert.Equal(t, "team:teamA", tuples[0].GetObject())
-		})
-	}
+		tupleMap := make(map[string]string)
+		for _, tup := range tuples {
+			tupleMap[tup.GetUser()] = tup.GetRelation()
+		}
+		assert.Equal(t, common.RelationTeamAdmin, tupleMap["user:user1"])
+		assert.Equal(t, common.RelationTeamMember, tupleMap["user:user2"])
+		for _, tup := range tuples {
+			assert.Equal(t, "team:teamA", tup.GetObject())
+		}
+	})
+
+	t.Run("no members", func(t *testing.T) {
+		team := &iamv0.Team{
+			ObjectMeta: metav1.ObjectMeta{Name: "teamB"},
+			Spec:       iamv0.TeamSpec{Members: []iamv0.TeamTeamMember{}},
+		}
+
+		tuples, err := TranslateTeamToMemberTuples(toUnstructured(t, team))
+		require.NoError(t, err)
+		assert.Empty(t, tuples)
+	})
+
+	t.Run("member with empty name is skipped", func(t *testing.T) {
+		team := &iamv0.Team{
+			ObjectMeta: metav1.ObjectMeta{Name: "teamC"},
+			Spec: iamv0.TeamSpec{
+				Members: []iamv0.TeamTeamMember{
+					{Kind: "User", Name: "", Permission: iamv0.TeamTeamPermissionMember},
+					{Kind: "User", Name: "user3", Permission: iamv0.TeamTeamPermissionMember},
+				},
+			},
+		}
+
+		tuples, err := TranslateTeamToMemberTuples(toUnstructured(t, team))
+		require.NoError(t, err)
+		require.Len(t, tuples, 1)
+		assert.Equal(t, "user:user3", tuples[0].GetUser())
+	})
 }
 
 func TestTranslateGlobalRoleBindingToTuples(t *testing.T) {
@@ -812,22 +828,22 @@ func TestTranslatedTuplesAreSchemaValid(t *testing.T) {
 		}
 	})
 
-	t.Run("team bindings", func(t *testing.T) {
-		for _, perm := range []iamv0.TeamBindingTeamPermission{
-			iamv0.TeamBindingTeamPermissionMember,
-			iamv0.TeamBindingTeamPermissionAdmin,
+	t.Run("team members", func(t *testing.T) {
+		for _, perm := range []iamv0.TeamTeamPermission{
+			iamv0.TeamTeamPermissionMember,
+			iamv0.TeamTeamPermissionAdmin,
 		} {
 			t.Run(string(perm), func(t *testing.T) {
-				tb := &iamv0.TeamBinding{
-					ObjectMeta: metav1.ObjectMeta{Name: "tb-schema-test"},
-					Spec: iamv0.TeamBindingSpec{
-						Subject:    iamv0.TeamBindingspecSubject{Kind: "User", Name: "user1"},
-						TeamRef:    iamv0.TeamBindingTeamRef{Name: "teamA"},
-						Permission: perm,
+				team := &iamv0.Team{
+					ObjectMeta: metav1.ObjectMeta{Name: "teamA"},
+					Spec: iamv0.TeamSpec{
+						Members: []iamv0.TeamTeamMember{
+							{Kind: "User", Name: "user1", Permission: perm},
+						},
 					},
 				}
 
-				tuples, err := TranslateTeamBindingToTuples(toUnstructured(t, tb))
+				tuples, err := TranslateTeamToMemberTuples(toUnstructured(t, team))
 				require.NoError(t, err)
 
 				for _, tuple := range tuples {


### PR DESCRIPTION
## Summary
- Replaces `TeamBindingResourceInfo` with `TeamResourceInfo` in the reconciler's `DefaultCRDs` list
- Adds `TranslateTeamToMemberTuples` translator that reads `Team.spec.members` and produces one tuple per member, replacing the old `TranslateTeamBindingToTuples`
- Updates the dispatcher map key from `"teambindings"` to `"teams"`

**What is this PR doing?**

TeamBinding (`teambindings.iam.grafana.app`) is being removed. Team membership already lives in `Team.spec.members` and the real-time hooks were migrated in #123851. This PR updates the background reconciler to read from Team instead of TeamBinding.

Enterprise's `ProvideEnterpriseReconcileCRDs()` inherits `DefaultCRDs` via `slices.Concat`, so no enterprise changes are needed.

**Which issue(s) does this PR fix?**

Fixes https://github.com/grafana/identity-access-team/issues/2062

## Test plan
- [x] `go test ./pkg/services/authz/zanzana/server/reconciler/...` passes
- [x] `go test ./pkg/services/authz/zanzana/...` passes
- [x] Verify enterprise builds (inherits DefaultCRDs automatically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)