### PR TITLE
Table: Safer row building if frame.length is ever unset

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/utils.test.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.test.ts
@@ -275,6 +275,34 @@ describe('TableNG utils', () => {
       expect(records[0]).toEqual({ __depth: 0, __index: 0, __parentIndex: 3, time: 1, value: 10 });
       expect(records[1]).toEqual({ __depth: 0, __index: 1, __parentIndex: 3, time: 2, value: 20 });
     });
+
+    it('should infer length from field values when frame.length is not set', () => {
+      const frame: DataFrame = {
+        fields: [
+          { name: 'time', type: FieldType.time, values: [1, 2, 3], config: {} },
+          { name: 'value', type: FieldType.number, values: [10, 20, 30], config: {} },
+        ],
+      } as unknown as DataFrame;
+
+      const frameToRecords = compileFrameToRecords(frame);
+      const records = frameToRecords(frame);
+
+      expect(records).toHaveLength(3);
+      expect(records[0]).toEqual({ __depth: 0, __index: 0, time: 1, value: 10 });
+      expect(records[1]).toEqual({ __depth: 0, __index: 1, time: 2, value: 20 });
+      expect(records[2]).toEqual({ __depth: 0, __index: 2, time: 3, value: 30 });
+    });
+
+    it('should produce no rows when frame.length is not set and the nested frame has no fields', () => {
+      const frame: DataFrame = {
+        fields: [],
+      } as unknown as DataFrame;
+
+      const frameToRecords = compileFrameToRecords(frame);
+      const records = frameToRecords(frame, 3);
+
+      expect(records).toHaveLength(0);
+    });
   });
 
   describe('getAlignmentFactor', () => {

--- a/packages/grafana-ui/src/components/Table/TableNG/utils.ts
+++ b/packages/grafana-ui/src/components/Table/TableNG/utils.ts
@@ -786,12 +786,13 @@ export function applyFilter(
  */
 export function compileFrameToRecords(frame: DataFrame, nestedFramesFieldName?: string): FrameToRowsConverter {
   const fnBody = `
-    const rows = Array(frame.length);
     const values = frame.fields.map(f => f.values);
     const hasNestedFrames = '${nestedFramesFieldName ?? ''}'.length > 0;
+    const frameLength = frame.length ?? values[0]?.length ?? 0;
+    const rows = Array(frameLength);
 
     let rowCount = 0;
-    for (let i = 0; i < frame.length; i++) {
+    for (let i = 0; i < frameLength; i++) {
       rows[rowCount] = {
         __depth: 0,
         __index: i,


### PR DESCRIPTION
### Summary

Adds a fallback for if frame.length is undefined, which is to grab the length of the values array.

### Background

I discovered a situation where frame.length isn't set in nestedFrame. To repro it:
- go to https://ops.grafana-ops.net/d/hokkht9/kme-traces?orgId=1&from=now-1h&to=now&timezone=browser&viewPanel=panel-2
- export the panel as a debug dashboard
- import that dashboard into a local instance
- expand a row

you'll see that the table throws upon expanding. but looking at the "real" table on ops, the frame.length is fine there. I guess this is an artifact of the debug dashboard output, but I do think that this is a good change to make regardless just to make the table a bit more durable since the nestedFrame is a bit of an odd field type. (I believe we've actually had issues in the past where Tempo was failing to send frame.length for nestedFrames, and it's something we don't currently e2e test I don't think)
