### PR TITLE
Alerting: Remove redundant read after create in recording and alert rules

### DIFF
--- a/pkg/registry/apps/alerting/rules/alertrule/legacy_storage.go
+++ b/pkg/registry/apps/alerting/rules/alertrule/legacy_storage.go
@@ -195,13 +195,7 @@ func (s *legacyStorage) Create(ctx context.Context, obj runtime.Object, createVa
 		return nil, err
 	}
 
-	// perform the get after to ensure we return the object with all the system filled fields set
-	rule, provenance, err := s.service.GetAlertRule(ctx, user, created.UID)
-	if err != nil {
-		return nil, err
-	}
-
-	return convertToK8sResource(info.OrgID, &rule, provenance, s.namespacer)
+	return convertToK8sResource(info.OrgID, &created, provenance, s.namespacer)
 }
 
 func (s *legacyStorage) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, createValidation rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, forceAllowCreate bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {

--- a/pkg/registry/apps/alerting/rules/recordingrule/legacy_storage.go
+++ b/pkg/registry/apps/alerting/rules/recordingrule/legacy_storage.go
@@ -185,13 +185,7 @@ func (s *legacyStorage) Create(ctx context.Context, obj runtime.Object, createVa
 		return nil, err
 	}
 
-	// perform the get after to ensure we return the object with all the system filled fields set
-	rule, provenance, err := s.service.GetAlertRule(ctx, user, created.UID)
-	if err != nil {
-		return nil, err
-	}
-
-	return convertToK8sResource(info.OrgID, &rule, provenance, s.namespacer)
+	return convertToK8sResource(info.OrgID, &created, provenance, s.namespacer)
 }
 
 func (s *legacyStorage) Update(ctx context.Context, name string, objInfo rest.UpdatedObjectInfo, _ rest.ValidateObjectFunc, updateValidation rest.ValidateObjectUpdateFunc, _ bool, options *metav1.UpdateOptions) (runtime.Object, bool, error) {

--- a/pkg/services/ngalert/models/alert_rule.go
+++ b/pkg/services/ngalert/models/alert_rule.go
@@ -670,7 +670,8 @@ type AlertRuleKeyWithGroup struct {
 
 type AlertRuleKeyWithId struct {
 	AlertRuleKey
-	ID int64
+	ID   int64
+	GUID string
 }
 
 // AlertRuleGroupKey is the identifier of a group of alerts

--- a/pkg/services/ngalert/provisioning/alert_rules.go
+++ b/pkg/services/ngalert/provisioning/alert_rules.go
@@ -373,6 +373,7 @@ func (service *AlertRuleService) CreateAlertRule(ctx context.Context, user ident
 		for _, key := range ids {
 			if key.UID == rule.UID {
 				rule.ID = key.ID
+				rule.GUID = key.GUID
 				fixed = true
 				break
 			}

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -541,7 +541,7 @@ func (st DBstore) InsertAlertRules(ctx context.Context, user *ngmodels.UserUID, 
 				r := newRules[i]
 				key := ngmodels.AlertRuleKey{OrgID: r.OrgID, UID: r.UID}
 
-				ids = append(ids, ngmodels.AlertRuleKeyWithId{AlertRuleKey: key, ID: r.ID})
+				ids = append(ids, ngmodels.AlertRuleKeyWithId{AlertRuleKey: key, ID: r.ID, GUID: r.GUID})
 				keys = append(keys, key)
 			}
 		}


### PR DESCRIPTION
**What is this feature?**

Removes a redundant `GetAlertRule` call that was performed after creating an alert rule or recording rule via the K8s legacy storage layer. Instead, the created rule (now returned directly from the insert path with all system-filled fields, including `GUID`) is converted to its K8s resource representation directly.

To make this possible, `AlertRuleKeyWithId` now also carries `GUID`, and the provisioning service propagates the `GUID` back onto the rule after insert (alongside the existing `ID` propagation).

**Why do we need this feature?**

PR #124487 added a read-after-create to ensure system-filled fields (notably `GUID`) were included in the response. Now that the insert path returns the fully populated rule, the extra round-trip is unnecessary and can be removed for a small performance win and simpler code.

**Who is this feature for?**

Backend / Alerting maintainers — this is an internal cleanup with no user-facing behavior change.

**Which issue(s) does this PR fix?**:

Follow-up to #124487.

Fixes #

**Special notes for your reviewer:**

- Verified `convertToK8sResource(info.OrgID, &created, provenance, s.namespacer)` returns the same payload as the previous read-after-create, since `created` now has `GUID` populated by the store/provisioning layer.
- Tests pass for `pkg/services/ngalert/{models,provisioning,store}`.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.