### PR TITLE
SqlExpressions: Measure SQL function usage

### DIFF
--- a/pkg/expr/metrics/metrics.go
+++ b/pkg/expr/metrics/metrics.go
@@ -73,7 +73,7 @@ func newExprMetrics(subsystem string) *ExprMetrics {
 			Namespace: "grafana",
 			Subsystem: subsystem,
 			Name:      "sql_command_function_count",
-			Help:      "Number of SQL expression executions that include a call to a particular SQL function. The 'function' label is the lower-cased function name. The 'allowed' label is 'true' when the function is in the SQL expression allowlist and 'false' when it is not. Incremented once per unique function name per query execution, regardless of how many times the function appears in the query.",
+			Help:      "Number of SQL expression execution attempts that include a call to a particular SQL function. The 'function' label is the lower-cased function name. The 'allowed' label is 'true' when the function is in the SQL expression allowlist and 'false' when it is not. Incremented once per unique function name per query execution attempt, regardless of whether the query succeeded, was blocked by the allowlist, or errored.",
 		}, []string{"function", "allowed"}),
 	}
 }

--- a/pkg/expr/metrics/metrics.go
+++ b/pkg/expr/metrics/metrics.go
@@ -125,7 +125,7 @@ func NewQueryServiceExpressionsMetrics(reg prometheus.Registerer) *ExprMetrics {
 		SqlCommandDuration: newExprMetrics(metricsSubSystem).SqlCommandDuration,
 
 		SqlCommandCount: newExprMetrics(metricsSubSystem).SqlCommandCount,
-	
+
 		SqlCommandCellCount: newExprMetrics(metricsSubSystem).SqlCommandCellCount,
 
 		SqlCommandInputCount: newExprMetrics(metricsSubSystem).SqlCommandInputCount,

--- a/pkg/expr/metrics/metrics.go
+++ b/pkg/expr/metrics/metrics.go
@@ -13,6 +13,7 @@ type ExprMetrics struct {
 	SqlCommandCount         *prometheus.CounterVec
 	SqlCommandCellCount     *prometheus.HistogramVec
 	SqlCommandInputCount    *prometheus.CounterVec
+	SqlCommandFunctionCount *prometheus.CounterVec
 }
 
 func newExprMetrics(subsystem string) *ExprMetrics {
@@ -67,6 +68,13 @@ func newExprMetrics(subsystem string) *ExprMetrics {
 			Name:      "sql_command_input_count",
 			Help:      "Total number of inputs to the SQL command. Errors here are also counted in the sql_command_count metric but without the datasource_type and input_frame_type. The attempted_conversion label indicates if the input was converted from another format (e.g. from labeled time series) or passed through as a table. Since a single SQL expression can have multiple inputs, this can count higher than sql_command_count.",
 		}, []string{"status", "attempted_conversion", "datasource_type", "input_frame_type"}),
+
+		SqlCommandFunctionCount: prometheus.NewCounterVec(prometheus.CounterOpts{
+			Namespace: "grafana",
+			Subsystem: subsystem,
+			Name:      "sql_command_function_count",
+			Help:      "Number of SQL expression executions that include a call to a particular SQL function. The 'function' label is the lower-cased function name. The 'allowed' label is 'true' when the function is in the SQL expression allowlist and 'false' when it is not. Incremented once per unique function name per query execution, regardless of how many times the function appears in the query.",
+		}, []string{"function", "allowed"}),
 	}
 }
 
@@ -86,6 +94,8 @@ func NewSSEMetrics(reg prometheus.Registerer) *ExprMetrics {
 		SqlCommandCellCount: newExprMetrics(metricsSubSystem).SqlCommandCellCount,
 
 		SqlCommandInputCount: newExprMetrics(metricsSubSystem).SqlCommandInputCount,
+
+		SqlCommandFunctionCount: newExprMetrics(metricsSubSystem).SqlCommandFunctionCount,
 	}
 
 	if reg != nil {
@@ -96,6 +106,7 @@ func NewSSEMetrics(reg prometheus.Registerer) *ExprMetrics {
 			m.SqlCommandCount,
 			m.SqlCommandCellCount,
 			m.SqlCommandInputCount,
+			m.SqlCommandFunctionCount,
 		)
 	}
 
@@ -114,10 +125,12 @@ func NewQueryServiceExpressionsMetrics(reg prometheus.Registerer) *ExprMetrics {
 		SqlCommandDuration: newExprMetrics(metricsSubSystem).SqlCommandDuration,
 
 		SqlCommandCount: newExprMetrics(metricsSubSystem).SqlCommandCount,
-
+	
 		SqlCommandCellCount: newExprMetrics(metricsSubSystem).SqlCommandCellCount,
 
 		SqlCommandInputCount: newExprMetrics(metricsSubSystem).SqlCommandInputCount,
+
+		SqlCommandFunctionCount: newExprMetrics(metricsSubSystem).SqlCommandFunctionCount,
 	}
 
 	if reg != nil {
@@ -128,6 +141,7 @@ func NewQueryServiceExpressionsMetrics(reg prometheus.Registerer) *ExprMetrics {
 			m.SqlCommandCount,
 			m.SqlCommandCellCount,
 			m.SqlCommandInputCount,
+			m.SqlCommandFunctionCount,
 		)
 	}
 

--- a/pkg/expr/sql/gms_function_registry.go
+++ b/pkg/expr/sql/gms_function_registry.go
@@ -5,6 +5,7 @@ package sql
 import (
 	"strings"
 
+	gmssql "github.com/dolthub/go-mysql-server/sql"
 	"github.com/dolthub/go-mysql-server/sql/expression/function"
 )
 
@@ -20,21 +21,18 @@ var gmsBuiltinFunctions = func() map[string]struct{} {
 	return m
 }()
 
-// gmsExtraFunctions covers GMS functions that are registered outside of
-// function.BuiltIns and therefore absent from gmsBuiltinFunctions:
-//   - Locking functions come from function.GetLockingFuncs and are registered
-//     separately by the engine outside function.BuiltIns.
-//   - version() is registered separately by the engine outside function.BuiltIns.
-//
-// These names are finite and well-known, so they are safe as metric label values.
-var gmsExtraFunctions = map[string]struct{}{
-	"version":           {},
-	"get_lock":          {},
-	"is_free_lock":      {},
-	"is_used_lock":      {},
-	"release_lock":      {},
-	"release_all_locks": {},
-}
+// gmsExtraFunctions covers GMS functions that are registered separately by the
+// engine outside of function.BuiltIns. These names are finite and well-known, so
+// they are safe as metric label values.
+var gmsExtraFunctions = func() map[string]struct{} {
+	m := map[string]struct{}{
+		"version": {},
+	}
+	for _, fn := range function.GetLockingFuncs(gmssql.NewLockSubsystem()) {
+		m[strings.ToLower(fn.FunctionName())] = struct{}{}
+	}
+	return m
+}()
 
 // IsKnownEngineFunction reports whether name (case-insensitive) is a known
 // go-mysql-server function — either in its default built-in registry or in

--- a/pkg/expr/sql/gms_function_registry.go
+++ b/pkg/expr/sql/gms_function_registry.go
@@ -1,0 +1,50 @@
+//go:build !arm
+
+package sql
+
+import (
+	"strings"
+
+	"github.com/dolthub/go-mysql-server/sql/expression/function"
+)
+
+// gmsBuiltinFunctions is the set of function names registered in
+// go-mysql-server's default built-in function registry, built once at startup
+// from function.BuiltIns. Used solely for metric label bounding: it does not
+// affect which functions are allowed to execute (that is IsAllowedFunctionName's job).
+var gmsBuiltinFunctions = func() map[string]struct{} {
+	m := make(map[string]struct{}, len(function.BuiltIns))
+	for _, fn := range function.BuiltIns {
+		m[fn.FunctionName()] = struct{}{}
+	}
+	return m
+}()
+
+// gmsExtraFunctions covers GMS functions that are registered outside of
+// function.BuiltIns and therefore absent from gmsBuiltinFunctions:
+//   - Locking functions come from function.GetLockingFuncs and are registered
+//     separately by the engine outside function.BuiltIns.
+//   - version() is registered separately by the engine outside function.BuiltIns.
+//
+// These names are finite and well-known, so they are safe as metric label values.
+var gmsExtraFunctions = map[string]struct{}{
+	"version":           {},
+	"get_lock":          {},
+	"is_free_lock":      {},
+	"is_used_lock":      {},
+	"release_lock":      {},
+	"release_all_locks": {},
+}
+
+// IsKnownEngineFunction reports whether name (case-insensitive) is a known
+// go-mysql-server function — either in its default built-in registry or in
+// the small set of functions registered separately by the engine. A true
+// result means the name is safe to use as a Prometheus label value because it
+// comes from a bounded, well-known vocabulary. A false result means the name
+// may be arbitrary user-supplied text and should be recorded as "unknown".
+func IsKnownEngineFunction(name string) bool {
+	lower := strings.ToLower(name)
+	_, inBuiltins := gmsBuiltinFunctions[lower]
+	_, inExtra := gmsExtraFunctions[lower]
+	return inBuiltins || inExtra
+}

--- a/pkg/expr/sql/gms_function_registry.go
+++ b/pkg/expr/sql/gms_function_registry.go
@@ -10,26 +10,24 @@ import (
 )
 
 // gmsBuiltinFunctions indexes function.BuiltIns by name for IsKnownEngineFunction.
-var gmsBuiltinFunctions = func() map[string]struct{} {
-	m := make(map[string]struct{}, len(function.BuiltIns))
-	for _, fn := range function.BuiltIns {
-		m[strings.ToLower(fn.FunctionName())] = struct{}{}
-	}
-	return m
-}()
+var gmsBuiltinFunctions map[string]struct{}
 
 // gmsExtraFunctions covers GMS functions that are registered separately by the
 // engine outside of function.BuiltIns. These names are finite and well-known, so
 // they are safe as metric label values.
-var gmsExtraFunctions = func() map[string]struct{} {
-	m := map[string]struct{}{
-		"version": {},
+var gmsExtraFunctions map[string]struct{}
+
+func init() {
+	gmsBuiltinFunctions = make(map[string]struct{}, len(function.BuiltIns))
+	for _, fn := range function.BuiltIns {
+		gmsBuiltinFunctions[strings.ToLower(fn.FunctionName())] = struct{}{}
 	}
+
+	gmsExtraFunctions = map[string]struct{}{"version": {}}
 	for _, fn := range function.GetLockingFuncs(gmssql.NewLockSubsystem()) {
-		m[strings.ToLower(fn.FunctionName())] = struct{}{}
+		gmsExtraFunctions[strings.ToLower(fn.FunctionName())] = struct{}{}
 	}
-	return m
-}()
+}
 
 // IsKnownEngineFunction reports whether name (case-insensitive) is a known
 // go-mysql-server function. True means the name comes from a finite vocabulary

--- a/pkg/expr/sql/gms_function_registry.go
+++ b/pkg/expr/sql/gms_function_registry.go
@@ -13,7 +13,7 @@ import (
 var gmsBuiltinFunctions = func() map[string]struct{} {
 	m := make(map[string]struct{}, len(function.BuiltIns))
 	for _, fn := range function.BuiltIns {
-		m[fn.FunctionName()] = struct{}{}
+		m[strings.ToLower(fn.FunctionName())] = struct{}{}
 	}
 	return m
 }()

--- a/pkg/expr/sql/gms_function_registry.go
+++ b/pkg/expr/sql/gms_function_registry.go
@@ -9,10 +9,7 @@ import (
 	"github.com/dolthub/go-mysql-server/sql/expression/function"
 )
 
-// gmsBuiltinFunctions is the set of function names registered in
-// go-mysql-server's default built-in function registry, built once at startup
-// from function.BuiltIns. Used solely for metric label bounding: it does not
-// affect which functions are allowed to execute (that is IsAllowedFunctionName's job).
+// gmsBuiltinFunctions indexes function.BuiltIns by name for IsKnownEngineFunction.
 var gmsBuiltinFunctions = func() map[string]struct{} {
 	m := make(map[string]struct{}, len(function.BuiltIns))
 	for _, fn := range function.BuiltIns {
@@ -35,11 +32,8 @@ var gmsExtraFunctions = func() map[string]struct{} {
 }()
 
 // IsKnownEngineFunction reports whether name (case-insensitive) is a known
-// go-mysql-server function — either in its default built-in registry or in
-// the small set of functions registered separately by the engine. A true
-// result means the name is safe to use as a Prometheus label value because it
-// comes from a bounded, well-known vocabulary. A false result means the name
-// may be arbitrary user-supplied text and should be recorded as "unknown".
+// go-mysql-server function. True means the name comes from a finite vocabulary
+// and is safe as a Prometheus label value; false means it should be bucketed as "unknown".
 func IsKnownEngineFunction(name string) bool {
 	lower := strings.ToLower(name)
 	_, inBuiltins := gmsBuiltinFunctions[lower]

--- a/pkg/expr/sql/gms_function_registry_arm.go
+++ b/pkg/expr/sql/gms_function_registry_arm.go
@@ -1,0 +1,9 @@
+//go:build arm
+
+package sql
+
+// IsKnownEngineFunction always returns false on arm, where go-mysql-server is
+// not available. All disallowed function names are bucketed as "unknown".
+func IsKnownEngineFunction(_ string) bool {
+	return false
+}

--- a/pkg/expr/sql/gms_function_registry_test.go
+++ b/pkg/expr/sql/gms_function_registry_test.go
@@ -1,0 +1,51 @@
+//go:build !arm
+
+package sql
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsKnownEngineFunction(t *testing.T) {
+	t.Run("GMS BuiltIns are recognised", func(t *testing.T) {
+		// A sample of GMS built-ins that are intentionally absent from our allowlist.
+		knownEngineButDisallowed := []string{
+			"sleep", "load_file", "md5", "sha1", "lpad", "rpad",
+			"user", "database", "connection_id", "found_rows",
+			"compress", "uuid", "hex", "unhex",
+		}
+		for _, fn := range knownEngineButDisallowed {
+			require.Truef(t, IsKnownEngineFunction(fn), "expected %q to be a known GMS function", fn)
+			// Check must be case-insensitive.
+			require.Truef(t, IsKnownEngineFunction(strings.ToUpper(fn)), "expected upper-case %q to be a known GMS function", fn)
+		}
+	})
+
+	t.Run("functions registered outside BuiltIns are recognised", func(t *testing.T) {
+		// These come from GetLockingFuncs / separate engine registration,
+		// not from function.BuiltIns, so they are covered by gmsExtraFunctions.
+		extra := []string{"get_lock", "is_free_lock", "is_used_lock", "release_lock", "release_all_locks", "version"}
+		for _, fn := range extra {
+			require.Truef(t, IsKnownEngineFunction(fn), "expected %q (extra GMS function) to be recognised", fn)
+		}
+	})
+
+	t.Run("arbitrary user-supplied names are not recognised", func(t *testing.T) {
+		for _, fn := range []string{"my_custom_udf", "nonexistent_fn"} {
+			require.Falsef(t, IsKnownEngineFunction(fn), "expected %q to NOT be a known GMS function", fn)
+		}
+	})
+
+	t.Run("allowlisted parser-special forms absent from the GMS registry return false", func(t *testing.T) {
+		// trim and timestampadd are allowed via special AST node types (TrimExpr,
+		// TimestampFuncExpr) and are not in the GMS function registry. They are
+		// never disallowed so this false result has no practical effect on metrics,
+		// but it is documented here so the gap is explicit.
+		for _, fn := range []string{"trim", "timestampadd"} {
+			require.Falsef(t, IsKnownEngineFunction(fn), "%q is allowlisted via a special AST node type and is absent from the GMS registry", fn)
+		}
+	})
+}

--- a/pkg/expr/sql/parser.go
+++ b/pkg/expr/sql/parser.go
@@ -34,9 +34,8 @@ func ExtractFunctionNames(rawSQL string) ([]string, error) {
 			// ExtractFuncExpr.Name is the token string, e.g. "EXTRACT" — normalise it.
 			seen[strings.ToLower(v.Name)] = struct{}{}
 		case *sqlparser.TimestampFuncExpr:
-			// TimestampFuncExpr.Name is already lower-case, e.g. "timestampdiff".
 			if v.Name != "" {
-				seen[v.Name] = struct{}{}
+				seen[strings.ToLower(v.Name)] = struct{}{}
 			}
 		case *sqlparser.TrimExpr:
 			seen["trim"] = struct{}{}

--- a/pkg/expr/sql/parser.go
+++ b/pkg/expr/sql/parser.go
@@ -42,6 +42,11 @@ func ExtractFunctionNames(rawSQL string) ([]string, error) {
 			seen["trim"] = struct{}{}
 		case *sqlparser.CharExpr:
 			seen["char"] = struct{}{}
+		case *sqlparser.ConvertExpr:
+			// ConvertExpr.Name is the token string: "cast" or "convert".
+			if v.Name != "" {
+				seen[strings.ToLower(v.Name)] = struct{}{}
+			}
 		}
 		return true, nil
 	}, stmt)

--- a/pkg/expr/sql/parser.go
+++ b/pkg/expr/sql/parser.go
@@ -10,6 +10,50 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
 
+// ExtractFunctionNames parses rawSQL and returns a deduplicated, sorted list of
+// SQL function names (lower-cased) found in the query. It covers regular FuncExpr
+// calls as well as the special AST node types that the parser creates for
+// GROUP_CONCAT, EXTRACT, TIMESTAMPDIFF/TIMESTAMPADD, TRIM, and CHAR.
+//
+// Only function names are returned. No column names, literal values, or table
+// names, so the result is safe to use in metrics labels.
+func ExtractFunctionNames(rawSQL string) ([]string, error) {
+	stmt, err := sqlparser.Parse(rawSQL)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing sql: %s", err.Error())
+	}
+
+	seen := make(map[string]struct{})
+	_ = sqlparser.Walk(func(node sqlparser.SQLNode) (bool, error) {
+		switch v := node.(type) {
+		case *sqlparser.FuncExpr:
+			seen[strings.ToLower(v.Name.String())] = struct{}{}
+		case *sqlparser.GroupConcatExpr:
+			seen["group_concat"] = struct{}{}
+		case *sqlparser.ExtractFuncExpr:
+			// ExtractFuncExpr.Name is the token string, e.g. "EXTRACT" — normalise it.
+			seen[strings.ToLower(v.Name)] = struct{}{}
+		case *sqlparser.TimestampFuncExpr:
+			// TimestampFuncExpr.Name is already lower-case, e.g. "timestampdiff".
+			if v.Name != "" {
+				seen[v.Name] = struct{}{}
+			}
+		case *sqlparser.TrimExpr:
+			seen["trim"] = struct{}{}
+		case *sqlparser.CharExpr:
+			seen["char"] = struct{}{}
+		}
+		return true, nil
+	}, stmt)
+
+	result := make([]string, 0, len(seen))
+	for name := range seen {
+		result = append(result, name)
+	}
+	sort.Strings(result)
+	return result, nil
+}
+
 // TablesList returns a list of tables for the sql statement excluding
 // CTEs and the 'dual' table. The list is sorted alphabetically.
 func TablesList(ctx context.Context, rawSQL string) ([]string, error) {

--- a/pkg/expr/sql/parser.go
+++ b/pkg/expr/sql/parser.go
@@ -10,13 +10,10 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
 
-// ExtractFunctionNames parses rawSQL and returns a deduplicated, sorted list of
-// SQL function names (lower-cased) found in the query. It covers regular FuncExpr
-// calls as well as the special AST node types that the parser creates for
-// GROUP_CONCAT, EXTRACT, TIMESTAMPDIFF/TIMESTAMPADD, TRIM, and CHAR.
-//
-// Only function names are returned. No column names, literal values, or table
-// names, so the result is safe to use in metrics labels.
+// ExtractFunctionNames returns a deduplicated, sorted, lower-cased list of SQL
+// function names found in rawSQL. Covers regular FuncExpr plus the special AST
+// node types vitess uses for GROUP_CONCAT, EXTRACT, TIMESTAMPDIFF/TIMESTAMPADD,
+// TRIM, CHAR, and CAST/CONVERT.
 func ExtractFunctionNames(rawSQL string) ([]string, error) {
 	stmt, err := sqlparser.Parse(rawSQL)
 	if err != nil {

--- a/pkg/expr/sql/parser_allow.go
+++ b/pkg/expr/sql/parser_allow.go
@@ -178,134 +178,143 @@ func allowedNode(node sqlparser.SQLNode) (b bool) {
 	}
 }
 
-// nolint:gocyclo,nakedret
-func allowedFunction(f *sqlparser.FuncExpr) (b bool) {
-	b = true // so don't have to return true in every case but default
+func allowedFunction(f *sqlparser.FuncExpr) bool {
+	return IsAllowedFunctionName(f.Name.String())
+}
 
-	switch strings.ToLower(f.Name.String()) {
+// IsAllowedFunctionName reports whether name (case-insensitive) is in the SQL
+// Expressions function allowlist. It covers both regular FuncExpr calls and the
+// special AST node types that the parser uses for GROUP_CONCAT, EXTRACT, TRIM,
+// TIMESTAMPDIFF/TIMESTAMPADD, and CHAR.
+//
+//nolint:gocyclo
+func IsAllowedFunctionName(name string) bool {
+	switch strings.ToLower(name) {
+	// Special AST node types (not FuncExpr) that are treated as function calls
+	case "group_concat", "extract", "trim", "char":
+		return true
+
 	// Conditional functions
 	case "if", "coalesce", "ifnull", "nullif":
-		return
+		return true
 	case "least":
-		return
+		return true
 
 	// Aggregation functions
 	case "sum", "avg", "count", "min", "max":
-		return
+		return true
 	case "stddev", "std", "stddev_pop", "stddev_sample":
-		return
+		return true
 	case "variance", "var_pop", "var_samp":
-		return
-	case "group_concat":
-		return
+		return true
 
 	// Window Functions
 	case "row_number", "rank", "dense_rank", "percent_rank":
-		return
+		return true
 	case "first_value", "last_value", "ntile":
-		return
+		return true
 	case "lead", "lag":
-		return
+		return true
 
 	// Mathematical functions
 	case "abs":
-		return
+		return true
 	case "round", "floor", "ceiling", "ceil":
-		return
+		return true
 	case "sqrt", "pow", "power":
-		return
+		return true
 	case "mod", "log", "log2", "log10", "exp":
-		return
+		return true
 	case "sign", "ln", "truncate":
-		return
+		return true
 	case "sin", "cos", "tan", "cot":
-		return
+		return true
 	case "asin", "acos", "atan", "atan2":
-		return
+		return true
 	case "conv", "degrees", "radians":
-		return
+		return true
 	case "rand", "pi":
-		return
+		return true
 
 	// String functions
 	case "concat", "length", "char_length":
-		return
+		return true
 	case "lower", "upper":
-		return
+		return true
 	case "substring", "substring_index":
-		return
+		return true
 	case "left", "right":
-		return
+		return true
 	case "ltrim", "rtrim":
-		return
+		return true
 	case "replace", "reverse":
-		return
+		return true
 	case "lcase", "ucase", "mid", "repeat":
-		return
+		return true
 	case "position", "instr", "locate":
-		return
-	case "ascii", "ord", "char":
-		return
+		return true
+	case "ascii", "ord":
+		return true
 	case "elt", "quote":
-		return
+		return true
 	case "from_base64", "format":
-		return
+		return true
 	case "regexp_substr", "regexp_replace", "regexp_instr", "regexp_like":
-		return
+		return true
 
 	// Date functions
 	case "str_to_date":
-		return
+		return true
 	case "date_format", "get_format":
-		return
+		return true
 	case "date_add", "adddate", "date_sub", "subdate":
-		return
+		return true
 	case "year", "month", "day", "weekday", "last_day":
-		return
+		return true
 	case "yearweek", "weekofyear":
-		return
+		return true
 	case "datediff":
-		return
+		return true
 	case "unix_timestamp", "from_unixtime":
-		return
-	case "extract", "hour", "minute", "second", "microsecond":
-		return
+		return true
+	case "hour", "minute", "second", "microsecond":
+		return true
 	case "dayname", "monthname", "dayofweek", "dayofmonth", "dayofyear":
-		return
+		return true
 	case "week", "quarter", "time_to_sec", "sec_to_time":
-		return
+		return true
 	case "timestampdiff", "timestampadd":
-		return
+		return true
 	case "from_days", "to_days":
-		return
+		return true
 	case "time_format", "time", "timediff":
-		return
+		return true
 
 	// Type conversion
 	case "cast", "convert":
-		return
+		return true
 
 	// JSON functions
 	case "json_extract", "json_object", "json_array", "json_valid":
-		return
+		return true
 	case "json_merge", "json_merge_patch", "json_merge_preserve":
-		return
+		return true
 	case "json_contains", "json_length", "json_type", "json_keys":
-		return
+		return true
 	case "json_contains_path", "json_depth":
-		return
+		return true
 	case "json_search", "json_quote", "json_unquote":
-		return
+		return true
 	case "json_set", "json_insert", "json_replace", "json_remove":
-		return
+		return true
 	case "json_array_append", "json_array_insert":
-		return
+		return true
 	case "json_objectagg", "json_arrayagg":
-		return
+		return true
 	case "json_overlaps":
-		return
+		return true
 	case "json_pretty", "json_value":
-		return
+		return true
 
 	default:
 		return false

--- a/pkg/expr/sql/parser_allow_test.go
+++ b/pkg/expr/sql/parser_allow_test.go
@@ -1,10 +1,82 @@
 package sql
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func TestIsAllowedFunctionName(t *testing.T) {
+	// Spot-check each category from the allowlist.
+	allowed := []string{
+		// Conditional
+		"if", "coalesce", "ifnull", "nullif", "least",
+		// Aggregation
+		"sum", "avg", "count", "min", "max",
+		"stddev", "std", "stddev_pop", "stddev_sample",
+		"variance", "var_pop", "var_samp",
+		// Window
+		"row_number", "rank", "dense_rank", "percent_rank",
+		"first_value", "last_value", "ntile", "lead", "lag",
+		// Math
+		"abs", "round", "floor", "ceiling", "ceil",
+		"sqrt", "pow", "power", "mod", "log", "log2", "log10", "exp",
+		"sign", "ln", "truncate",
+		"sin", "cos", "tan", "cot", "asin", "acos", "atan", "atan2",
+		"conv", "degrees", "radians", "rand", "pi",
+		// String
+		"concat", "length", "char_length",
+		"lower", "upper", "substring", "substring_index",
+		"left", "right", "ltrim", "rtrim", "replace", "reverse",
+		"lcase", "ucase", "mid", "repeat",
+		"position", "instr", "locate", "ascii", "ord",
+		"elt", "quote", "from_base64", "format",
+		"regexp_substr", "regexp_replace", "regexp_instr", "regexp_like",
+		// Date
+		"str_to_date", "date_format", "get_format",
+		"date_add", "adddate", "date_sub", "subdate",
+		"year", "month", "day", "weekday", "last_day",
+		"yearweek", "weekofyear", "datediff",
+		"unix_timestamp", "from_unixtime",
+		"hour", "minute", "second", "microsecond",
+		"dayname", "monthname", "dayofweek", "dayofmonth", "dayofyear",
+		"week", "quarter", "time_to_sec", "sec_to_time",
+		"timestampdiff", "timestampadd", "from_days", "to_days",
+		"time_format", "time", "timediff",
+		// Type conversion
+		"cast", "convert",
+		// JSON
+		"json_extract", "json_object", "json_array", "json_valid",
+		"json_merge", "json_merge_patch", "json_merge_preserve",
+		"json_contains", "json_length", "json_type", "json_keys",
+		"json_contains_path", "json_depth",
+		"json_search", "json_quote", "json_unquote",
+		"json_set", "json_insert", "json_replace", "json_remove",
+		"json_array_append", "json_array_insert",
+		"json_objectagg", "json_arrayagg", "json_overlaps",
+		"json_pretty", "json_value",
+		// Special AST node types
+		"group_concat", "extract", "trim", "char",
+	}
+	for _, fn := range allowed {
+		require.Truef(t, IsAllowedFunctionName(fn), "expected %q to be allowed", fn)
+		// Allowlist check must be case-insensitive.
+		require.Truef(t, IsAllowedFunctionName(strings.ToUpper(fn)), "expected upper-case %q to be allowed", fn)
+	}
+
+	// Functions that are intentionally not in the allowlist.
+	notAllowed := []string{
+		"sleep",      // could be used for DoS
+		"load_file",  // filesystem access
+		"benchmark", // DoS / resource exhaustion
+		"get_lock",   // server-state mutation
+		"nonexistent_fn",
+	}
+	for _, fn := range notAllowed {
+		require.Falsef(t, IsAllowedFunctionName(fn), "expected %q to NOT be allowed", fn)
+	}
+}
 
 func TestAllowQuery(t *testing.T) {
 	testCases := []struct {

--- a/pkg/expr/sql/parser_allow_test.go
+++ b/pkg/expr/sql/parser_allow_test.go
@@ -67,10 +67,10 @@ func TestIsAllowedFunctionName(t *testing.T) {
 
 	// Functions that are intentionally not in the allowlist.
 	notAllowed := []string{
-		"sleep",      // could be used for DoS
-		"load_file",  // filesystem access
+		"sleep",     // could be used for DoS
+		"load_file", // filesystem access
 		"benchmark", // DoS / resource exhaustion
-		"get_lock",   // server-state mutation
+		"get_lock",  // server-state mutation
 		"nonexistent_fn",
 	}
 	for _, fn := range notAllowed {

--- a/pkg/expr/sql/parser_test.go
+++ b/pkg/expr/sql/parser_test.go
@@ -6,6 +6,101 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestExtractFunctionNames(t *testing.T) {
+	tests := []struct {
+		name     string
+		sql      string
+		want     []string
+		wantErr  bool
+	}{
+		{
+			name: "regular FuncExpr calls are collected and sorted",
+			sql:  "SELECT SUM(val), AVG(val), COUNT(*) FROM A",
+			want: []string{"avg", "count", "sum"},
+		},
+		{
+			name: "GROUP_CONCAT comes through as a GroupConcatExpr node",
+			sql:  "SELECT GROUP_CONCAT(col) FROM A",
+			want: []string{"group_concat"},
+		},
+		{
+			name: "EXTRACT comes through as an ExtractFuncExpr node",
+			sql:  "SELECT EXTRACT(YEAR FROM ts) FROM A",
+			want: []string{"extract"},
+		},
+		{
+			name: "TIMESTAMPDIFF comes through as a TimestampFuncExpr node",
+			sql:  "SELECT TIMESTAMPDIFF(YEAR, d1, d2) FROM A",
+			want: []string{"timestampdiff"},
+		},
+		{
+			name: "TIMESTAMPADD comes through as a TimestampFuncExpr node",
+			sql:  "SELECT TIMESTAMPADD(DAY, 1, d1) FROM A",
+			want: []string{"timestampadd"},
+		},
+		{
+			name: "TRIM comes through as a TrimExpr node",
+			sql:  "SELECT TRIM(col) FROM A",
+			want: []string{"trim"},
+		},
+		{
+			name: "TRIM with direction comes through as a TrimExpr node",
+			sql:  "SELECT TRIM(LEADING 'x' FROM col) FROM A",
+			want: []string{"trim"},
+		},
+		{
+			name: "CHAR comes through as a CharExpr node",
+			sql:  "SELECT CHAR(65) FROM A",
+			want: []string{"char"},
+		},
+		{
+			name: "same function appearing multiple times is deduplicated",
+			sql:  "SELECT ROUND(SUM(a), 2), ROUND(AVG(b), 2) FROM A",
+			want: []string{"avg", "round", "sum"},
+		},
+		{
+			name: "mix of FuncExpr and special node types",
+			sql:  "SELECT SUM(val), GROUP_CONCAT(label), TRIM(name) FROM A",
+			want: []string{"group_concat", "sum", "trim"},
+		},
+		{
+			name: "query with no function calls returns empty slice",
+			sql:  "SELECT col FROM A WHERE col > 1",
+			want: []string{},
+		},
+		{
+			name: "function names are lower-cased regardless of input case",
+			sql:  "SELECT SuM(val), AvG(val) FROM A",
+			want: []string{"avg", "sum"},
+		},
+		{
+			name:    "invalid SQL returns an error",
+			sql:     "SELECT * FROM zzz aaa zzz",
+			wantErr: true,
+		},
+		{
+			name: "blocked function name is still collected",
+			sql:  "SELECT SLEEP(1) FROM A",
+			want: []string{"sleep"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ExtractFunctionNames(tc.sql)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+			if tc.want == nil {
+				tc.want = []string{}
+			}
+			require.Equal(t, tc.want, got)
+		})
+	}
+}
+
 func TestTablesList(t *testing.T) {
 	tests := []struct {
 		name        string

--- a/pkg/expr/sql/parser_test.go
+++ b/pkg/expr/sql/parser_test.go
@@ -8,10 +8,10 @@ import (
 
 func TestExtractFunctionNames(t *testing.T) {
 	tests := []struct {
-		name     string
-		sql      string
-		want     []string
-		wantErr  bool
+		name    string
+		sql     string
+		want    []string
+		wantErr bool
 	}{
 		{
 			name: "regular FuncExpr calls are collected and sorted",
@@ -72,6 +72,16 @@ func TestExtractFunctionNames(t *testing.T) {
 			name: "function names are lower-cased regardless of input case",
 			sql:  "SELECT SuM(val), AvG(val) FROM A",
 			want: []string{"avg", "sum"},
+		},
+		{
+			name: "CAST comes through as a ConvertExpr node",
+			sql:  "SELECT CAST(col AS UNSIGNED) FROM A",
+			want: []string{"cast"},
+		},
+		{
+			name: "CONVERT comes through as a ConvertExpr node",
+			sql:  "SELECT CONVERT(col, CHAR) FROM A",
+			want: []string{"convert"},
 		},
 		{
 			name:    "invalid SQL returns an error",

--- a/pkg/expr/sql_command.go
+++ b/pkg/expr/sql_command.go
@@ -37,6 +37,11 @@ type SQLCommand struct {
 	outputLimit int64
 	timeout     time.Duration
 	logger      log.Logger
+
+	// functions is the deduplicated, lower-cased list of SQL function names found
+	// in the query AST. Populated at construction time; used to emit per-function
+	// metrics on every execution.
+	functions []string
 }
 
 // NewSQLCommand creates a new SQLCommand.
@@ -57,6 +62,14 @@ func NewSQLCommand(ctx context.Context, logger log.Logger, refID, format, rawSQL
 		sqlLogger.Debug("REF tables", "tables", tables, "sql", rawSQL)
 	}
 
+	// Extract function names for metrics. The SQL was already successfully parsed
+	// above (TablesList would have returned an error otherwise), so a failure here
+	// is unexpected; treat it as non-fatal so it does not block query execution.
+	functions, err := sql.ExtractFunctionNames(rawSQL)
+	if err != nil {
+		sqlLogger.Warn("failed to extract function names for metrics", "error", err)
+	}
+
 	return &SQLCommand{
 		query:       rawSQL,
 		varsToQuery: tables,
@@ -66,6 +79,7 @@ func NewSQLCommand(ctx context.Context, logger log.Logger, refID, format, rawSQL
 		timeout:     timeout,
 		format:      format,
 		logger:      sqlLogger,
+		functions:   functions,
 	}, nil
 }
 
@@ -178,6 +192,18 @@ func (gr *SQLCommand) Execute(ctx context.Context, now time.Time, vars mathexp.V
 			}
 		} else {
 			obsCells.Observe(float64(tc))
+		}
+
+		// --- Per-function counter ---
+		// Incremented once per unique function name in the query, regardless of
+		// execution outcome. allowed=true means the function is in the allowlist;
+		// allowed=false means the user attempted a function that is not permitted.
+		for _, fn := range gr.functions {
+			allowed := "false"
+			if sql.IsAllowedFunctionName(fn) {
+				allowed = "true"
+			}
+			metrics.SqlCommandFunctionCount.WithLabelValues(fn, allowed).Inc()
 		}
 	}()
 

--- a/pkg/expr/sql_command.go
+++ b/pkg/expr/sql_command.go
@@ -198,12 +198,23 @@ func (gr *SQLCommand) Execute(ctx context.Context, now time.Time, vars mathexp.V
 		// Incremented once per unique function name in the query, regardless of
 		// execution outcome. allowed=true means the function is in the allowlist;
 		// allowed=false means the user attempted a function that is not permitted.
+		//
+		// For disallowed functions, the label value is bounded to the GMS function
+		// vocabulary (function.BuiltIns plus functions registered separately by the
+		// engine): if the name is recognised by go-mysql-server it is safe to emit
+		// as-is (it comes from a finite, well-known set). Anything else is recorded
+		// as "unknown" so that arbitrary user-supplied strings never appear as
+		// Prometheus label values.
 		for _, fn := range gr.functions {
-			allowed := "false"
 			if sql.IsAllowedFunctionName(fn) {
-				allowed = "true"
+				metrics.SqlCommandFunctionCount.WithLabelValues(fn, "true").Inc()
+			} else {
+				label := "unknown"
+				if sql.IsKnownEngineFunction(fn) {
+					label = fn
+				}
+				metrics.SqlCommandFunctionCount.WithLabelValues(label, "false").Inc()
 			}
-			metrics.SqlCommandFunctionCount.WithLabelValues(fn, allowed).Inc()
 		}
 	}()
 

--- a/pkg/expr/sql_command.go
+++ b/pkg/expr/sql_command.go
@@ -38,9 +38,6 @@ type SQLCommand struct {
 	timeout     time.Duration
 	logger      log.Logger
 
-	// functions is the deduplicated, lower-cased list of SQL function names found
-	// in the query AST. Populated at construction time; used to emit per-function
-	// metrics on every execution.
 	functions []string
 }
 
@@ -62,9 +59,7 @@ func NewSQLCommand(ctx context.Context, logger log.Logger, refID, format, rawSQL
 		sqlLogger.Debug("REF tables", "tables", tables, "sql", rawSQL)
 	}
 
-	// Extract function names for metrics. The SQL was already successfully parsed
-	// above (TablesList would have returned an error otherwise), so a failure here
-	// is unexpected; treat it as non-fatal so it does not block query execution.
+	// SQL already parsed by TablesList above, so a failure here is unexpected; non-fatal.
 	functions, err := sql.ExtractFunctionNames(rawSQL)
 	if err != nil {
 		sqlLogger.Warn("failed to extract function names for metrics", "error", err)
@@ -195,16 +190,9 @@ func (gr *SQLCommand) Execute(ctx context.Context, now time.Time, vars mathexp.V
 		}
 
 		// --- Per-function counter ---
-		// Incremented once per unique function name in the query, regardless of
-		// execution outcome. allowed=true means the function is in the allowlist;
-		// allowed=false means the user attempted a function that is not permitted.
-		//
-		// For disallowed functions, the label value is bounded to the GMS function
-		// vocabulary (function.BuiltIns plus functions registered separately by the
-		// engine): if the name is recognised by go-mysql-server it is safe to emit
-		// as-is (it comes from a finite, well-known set). Anything else is recorded
-		// as "unknown" so that arbitrary user-supplied strings never appear as
-		// Prometheus label values.
+		// Incremented once per unique function name in the query regardless of
+		// execution outcome. Disallowed names are bounded by IsKnownEngineFunction
+		// to keep label cardinality finite; unrecognised names are bucketed as "unknown".
 		for _, fn := range gr.functions {
 			if sql.IsAllowedFunctionName(fn) {
 				metrics.SqlCommandFunctionCount.WithLabelValues(fn, "true").Inc()

--- a/pkg/expr/sql_command_test.go
+++ b/pkg/expr/sql_command_test.go
@@ -194,9 +194,9 @@ func TestSQLCommandFunctionMetrics(t *testing.T) {
 			"round should be counted as allowed")
 	})
 
-	t.Run("blocked function is counted with allowed=false", func(t *testing.T) {
+	t.Run("known disallowed function is counted under its own name with allowed=false", func(t *testing.T) {
 		m := metrics.NewTestMetrics()
-		// SLEEP is syntactically valid but not in the allowlist.
+		// SLEEP is syntactically valid, not in the allowlist, and is a known GMS built-in.
 		cmd, err := NewSQLCommand(t.Context(), log.NewNullLogger(), "A", "",
 			"SELECT SLEEP(1) FROM foo", 0, 0, 0)
 		require.NoError(t, err)
@@ -206,10 +206,48 @@ func TestSQLCommandFunctionMetrics(t *testing.T) {
 
 		require.Equal(t, float64(1),
 			testutil.ToFloat64(m.SqlCommandFunctionCount.WithLabelValues("sleep", "false")),
-			"sleep should be counted as not allowed")
+			"sleep should be counted under its own name")
 		require.Equal(t, float64(0),
 			testutil.ToFloat64(m.SqlCommandFunctionCount.WithLabelValues("sleep", "true")),
 			"sleep must not appear with allowed=true")
+	})
+
+	t.Run("GMS built-in not in allowlist is emitted under its own name with allowed=false", func(t *testing.T) {
+		m := metrics.NewTestMetrics()
+		// LPAD is in the GMS built-in registry but not in our allowlist,
+		// so it should be named in the metric rather than bucketed.
+		cmd, err := NewSQLCommand(t.Context(), log.NewNullLogger(), "A", "",
+			"SELECT LPAD(col, 10, '0') FROM foo", 0, 0, 0)
+		require.NoError(t, err)
+		require.Equal(t, []string{"lpad"}, cmd.functions)
+
+		_, _ = cmd.Execute(t.Context(), time.Now(), mathexp.Vars{}, &testTracer{}, m)
+
+		require.Equal(t, float64(1),
+			testutil.ToFloat64(m.SqlCommandFunctionCount.WithLabelValues("lpad", "false")),
+			"lpad is a known GMS function and should appear under its own name")
+		require.Equal(t, float64(0),
+			testutil.ToFloat64(m.SqlCommandFunctionCount.WithLabelValues("unknown", "false")),
+			"lpad must not be bucketed as unknown")
+	})
+
+	t.Run("truly unknown function is bucketed as unknown", func(t *testing.T) {
+		m := metrics.NewTestMetrics()
+		// MY_CUSTOM_UDF is not in the GMS registry or the allowlist, so its
+		// raw name must never appear as a Prometheus label value.
+		cmd, err := NewSQLCommand(t.Context(), log.NewNullLogger(), "A", "",
+			"SELECT MY_CUSTOM_UDF(col) FROM foo", 0, 0, 0)
+		require.NoError(t, err)
+		require.Equal(t, []string{"my_custom_udf"}, cmd.functions)
+
+		_, _ = cmd.Execute(t.Context(), time.Now(), mathexp.Vars{}, &testTracer{}, m)
+
+		require.Equal(t, float64(1),
+			testutil.ToFloat64(m.SqlCommandFunctionCount.WithLabelValues("unknown", "false")),
+			"unrecognised function should be bucketed as unknown")
+		require.Equal(t, float64(0),
+			testutil.ToFloat64(m.SqlCommandFunctionCount.WithLabelValues("my_custom_udf", "false")),
+			"raw UDF name must not appear as a label value")
 	})
 
 	t.Run("each function is counted once per execution even if called multiple times", func(t *testing.T) {

--- a/pkg/expr/sql_command_test.go
+++ b/pkg/expr/sql_command_test.go
@@ -173,6 +173,74 @@ func TestSQLCommandMetrics(t *testing.T) {
 	require.Equal(t, 1, testutil.CollectAndCount(m.SqlCommandCellCount), "Expected cell count metric to be recorded")
 }
 
+func TestSQLCommandFunctionMetrics(t *testing.T) {
+	t.Run("allowed functions are counted with allowed=true", func(t *testing.T) {
+		m := metrics.NewTestMetrics()
+		cmd, err := NewSQLCommand(t.Context(), log.NewNullLogger(), "A", "",
+			"SELECT SUM(val), ROUND(AVG(val), 2) FROM foo", 0, 0, 0)
+		require.NoError(t, err)
+		require.ElementsMatch(t, []string{"avg", "round", "sum"}, cmd.functions)
+
+		_, _ = cmd.Execute(t.Context(), time.Now(), mathexp.Vars{}, &testTracer{}, m)
+
+		require.Equal(t, float64(1),
+			testutil.ToFloat64(m.SqlCommandFunctionCount.WithLabelValues("sum", "true")),
+			"sum should be counted as allowed")
+		require.Equal(t, float64(1),
+			testutil.ToFloat64(m.SqlCommandFunctionCount.WithLabelValues("avg", "true")),
+			"avg should be counted as allowed")
+		require.Equal(t, float64(1),
+			testutil.ToFloat64(m.SqlCommandFunctionCount.WithLabelValues("round", "true")),
+			"round should be counted as allowed")
+	})
+
+	t.Run("blocked function is counted with allowed=false", func(t *testing.T) {
+		m := metrics.NewTestMetrics()
+		// SLEEP is syntactically valid but not in the allowlist.
+		cmd, err := NewSQLCommand(t.Context(), log.NewNullLogger(), "A", "",
+			"SELECT SLEEP(1) FROM foo", 0, 0, 0)
+		require.NoError(t, err)
+		require.Equal(t, []string{"sleep"}, cmd.functions)
+
+		_, _ = cmd.Execute(t.Context(), time.Now(), mathexp.Vars{}, &testTracer{}, m)
+
+		require.Equal(t, float64(1),
+			testutil.ToFloat64(m.SqlCommandFunctionCount.WithLabelValues("sleep", "false")),
+			"sleep should be counted as not allowed")
+		require.Equal(t, float64(0),
+			testutil.ToFloat64(m.SqlCommandFunctionCount.WithLabelValues("sleep", "true")),
+			"sleep must not appear with allowed=true")
+	})
+
+	t.Run("each function is counted once per execution even if called multiple times", func(t *testing.T) {
+		m := metrics.NewTestMetrics()
+		cmd, err := NewSQLCommand(t.Context(), log.NewNullLogger(), "A", "",
+			"SELECT ROUND(SUM(a), 0), ROUND(AVG(b), 0) FROM foo", 0, 0, 0)
+		require.NoError(t, err)
+		// ROUND appears twice but should only produce one entry in cmd.functions.
+		require.ElementsMatch(t, []string{"avg", "round", "sum"}, cmd.functions)
+
+		_, _ = cmd.Execute(t.Context(), time.Now(), mathexp.Vars{}, &testTracer{}, m)
+
+		require.Equal(t, float64(1),
+			testutil.ToFloat64(m.SqlCommandFunctionCount.WithLabelValues("round", "true")),
+			"round should be counted exactly once despite appearing twice in the query")
+	})
+
+	t.Run("query with no functions records nothing in the function counter", func(t *testing.T) {
+		m := metrics.NewTestMetrics()
+		cmd, err := NewSQLCommand(t.Context(), log.NewNullLogger(), "A", "",
+			"SELECT col FROM foo WHERE col > 1", 0, 0, 0)
+		require.NoError(t, err)
+		require.Empty(t, cmd.functions)
+
+		_, _ = cmd.Execute(t.Context(), time.Now(), mathexp.Vars{}, &testTracer{}, m)
+
+		require.Equal(t, 0, testutil.CollectAndCount(m.SqlCommandFunctionCount),
+			"no function metrics should be emitted for a query with no function calls")
+	})
+}
+
 func TestHandleSqlInput(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
## Motivation

Closes https://github.com/grafana/grafana/issues/124492 / [DPRO-77: Instrument SQL function usage in SQL Expressions](https://linear.app/grafana/issue/DPRO-77/instrument-sql-function-usage-in-sql-expressions)

Our current instrumentation helps us know when SQL expression queries fail and why, but we don't know anything about what's in them. By surfacing which SQL functions users are including in their SQL Expressions, we can learn things that will likely steer the direction of SQL Expressions.

## What this PR does

Adds a Prometheus counter tracking which SQL functions appear in SQL Expression queries, with a label indicating whether the function is in the allowlist or not.

A query blocked by the allowlist still has its functions captured. Known blocked engine functions show up with `allowed="false"`, and unrecognized function-like identifiers are grouped under `function="unknown"`. So this metric gives us a handful of useful insights:
- which allowed functions are popular (to answer things like "What's the relative popularity of `JSON_EXTRACT` vs `JSON_OBJECT` vs `JSON_VALUE`?")
- which blocked functions people are actually trying to use
  - this may reveal some functions that we may want to add to the allowlist (e.g. https://github.com/grafana/grafana/issues/124199)
  - it'll be interesting to know how often people try to execute queries with functions that are not included in the allowlist for good reasons

## Privacy

The metric only records function names extracted from the SQL AST. It does not capture column names, table names, literal values, aliases, or other query text.

## Metric cardinality

Allowed functions are emitted by their normalized function name. Disallowed functions are emitted by name only when they are part of the finite go-mysql-server function vocabulary; unrecognized function names are bucketed as `unknown`. This keeps the metric useful for understanding known blocked-function usage while avoiding arbitrary user-supplied label values. Cardinality-wise, given the size of the allowlist and `function.BuiltIns`, I expect the upper bound is well under 1k series.

## Code changes worth calling out

The AST walker (`ExtractFunctionNames`) is slightly more involved than a simple `FuncExpr` walk because the vitess parser represents several common functions as dedicated node types. `GROUP_CONCAT` comes through as `GroupConcatExpr`, `EXTRACT` as `ExtractFuncExpr`, `TRIM` as `TrimExpr`, `CAST`/`CONVERT` as `ConvertExpr`, etc. The walker handles these forms so the metric reflects the function syntax users actually wrote.

This PR also refactors `allowedFunction`. The existing private `allowedFunction(*sqlparser.FuncExpr) bool` switch couldn't be called with just a string, so it's been extracted into `IsAllowedFunctionName(string) bool`, which `allowedFunction` now delegates to.

For disallowed functions, metric label values are bounded. If the function is a known go-mysql-server function, it is emitted by name with `allowed="false"`; otherwise it is bucketed as `function="unknown"` with `allowed="false"`. This lets us see attempts to use known blocked functions like `SLEEP` or `LOAD_FILE` without allowing arbitrary user-supplied function names to become Prometheus label values.
