### PR TITLE
Dashboards: respect editable flag and disable drag in view mode for dynamic layouts

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.test.ts
+++ b/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.test.ts
@@ -1,4 +1,8 @@
+import { type PointerEvent as ReactPointerEvent } from 'react';
+
 import { VizPanel } from '@grafana/scenes';
+
+import * as utils from '../utils/utils';
 
 import { DashboardLayoutOrchestrator } from './DashboardLayoutOrchestrator';
 import { DashboardScene } from './DashboardScene';
@@ -402,6 +406,22 @@ describe('DashboardLayoutOrchestrator', () => {
       // Empty title should be falsy, which the orchestrator handles with fallback to 'Panel'
       expect(gridItem.state.body.state.title).toBe('');
       expect(gridItem.state.body.state.title || 'Panel').toBe('Panel');
+    });
+  });
+
+  describe('startDraggingSync', () => {
+    it('returns early without setting a source drop target when dashboard is not in edit mode', () => {
+      const { orchestrator, gridItem } = setupWithTwoTabs();
+      const viewModeDashboard = new DashboardScene({ isEditing: false });
+      const spy = jest.spyOn(utils, 'getDashboardSceneFor').mockReturnValue(viewModeDashboard);
+
+      const evt = { clientX: 0, clientY: 0, preventDefault: jest.fn() } as unknown as ReactPointerEvent;
+
+      orchestrator.startDraggingSync(evt, gridItem);
+
+      // @ts-expect-error - accessing private property for testing
+      expect(orchestrator._sourceDropTarget).toBeNull();
+      spy.mockRestore();
     });
   });
 });

--- a/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardLayoutOrchestrator.tsx
@@ -18,7 +18,7 @@ import { getLayoutType } from 'app/features/dashboard/utils/tracking';
 
 import { dashboardEditActions, DashboardStateChangedEvent, ObjectsReorderedOnCanvasEvent } from '../edit-pane/shared';
 import { DashboardInteractions } from '../utils/interactions';
-import { getDefaultVizPanel, getLayoutForObject } from '../utils/utils';
+import { getDashboardSceneFor, getDefaultVizPanel, getLayoutForObject } from '../utils/utils';
 
 import { DashboardScene } from './DashboardScene';
 import { AutoGridLayoutManager } from './layout-auto-grid/AutoGridLayoutManager';
@@ -139,6 +139,11 @@ export class DashboardLayoutOrchestrator extends SceneObjectBase<DashboardLayout
   }
 
   public startDraggingSync(evt: ReactPointerEvent, gridItem: SceneGridItemLike): void {
+    const dashboard = getDashboardSceneFor(this);
+    if (!dashboard.state.isEditing) {
+      return;
+    }
+
     const dropTarget = sceneGraph.findObject(gridItem, isDashboardDropTarget);
 
     if (!dropTarget || !isDashboardDropTarget(dropTarget)) {

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.test.ts
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.test.ts
@@ -191,6 +191,14 @@ describe('AutoGridLayoutManager', () => {
       expect(autoLayout.state.layout.state.isDraggable).toBe(false);
     });
   });
+
+  describe('default layout', () => {
+    it('defaults isDraggable to false when constructed without an explicit layout', () => {
+      const manager = new AutoGridLayoutManager({});
+
+      expect(manager.state.layout.state.isDraggable).toBe(false);
+    });
+  });
 });
 
 describe('AutoGridItem repeat + conditional rendering', () => {

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
@@ -99,7 +99,7 @@ export class AutoGridLayoutManager
       layout:
         state.layout ??
         new AutoGridLayout({
-          isDraggable: true,
+          isDraggable: false,
           templateColumns: getTemplateColumnsTemplate(maxColumnCount, columnWidth),
           autoRows: getAutoRowsTemplate(rowHeight, fillScreen),
         }),

--- a/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.test.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.test.tsx
@@ -8,6 +8,7 @@ import {
   VizPanel,
 } from '@grafana/scenes';
 
+import { activateFullSceneTree } from '../../utils/test-utils';
 import { findVizPanelByKey, getQueryRunnerFor } from '../../utils/utils';
 import { DashboardScene, type DashboardSceneState } from '../DashboardScene';
 import { AutoGridItem } from '../layout-auto-grid/AutoGridItem';
@@ -362,6 +363,22 @@ describe('DefaultGridLayoutManager', () => {
       expect((children[0] as DashboardGridItem).state.variableName).toBeUndefined();
     });
   });
+
+  describe('activation handler', () => {
+    it('syncs grid isDraggable and isResizable to true when dashboard is in edit mode', () => {
+      const { grid } = setupAndActivate({ isEditing: true });
+
+      expect(grid.state.isDraggable).toBe(true);
+      expect(grid.state.isResizable).toBe(true);
+    });
+
+    it('syncs grid isDraggable and isResizable to false when dashboard is in view mode', () => {
+      const { grid } = setupAndActivate({ isEditing: false });
+
+      expect(grid.state.isDraggable ?? false).toBe(false);
+      expect(grid.state.isResizable ?? false).toBe(false);
+    });
+  });
 });
 
 interface TestOptions {
@@ -416,6 +433,14 @@ function setup(options?: TestOptions) {
   new DashboardScene({ body: manager });
 
   return { manager, grid };
+}
+
+function setupAndActivate(sceneOptions?: Partial<DashboardSceneState>) {
+  const grid = new SceneGridLayout({ children: [] });
+  const manager = new DefaultGridLayoutManager({ grid });
+  const dashboard = new DashboardScene({ body: manager, ...sceneOptions });
+  activateFullSceneTree(dashboard);
+  return { dashboard, manager, grid };
 }
 
 const panelOptions = { legend: { displayMode: 'list', placement: 'bottom' } };

--- a/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
@@ -43,6 +43,7 @@ import {
   useDashboard,
   getLayoutOrchestratorFor,
   getDashboardSceneFor,
+  tryGetDashboardSceneFor,
 } from '../../utils/utils';
 import { useSoloPanelContext } from '../SoloPanelContext';
 import { AutoGridItem } from '../layout-auto-grid/AutoGridItem';
@@ -128,6 +129,17 @@ export class DefaultGridLayoutManager
   }
 
   private _activationHandler() {
+    const dashboard = tryGetDashboardSceneFor(this);
+    if (dashboard) {
+      const isEditing = dashboard.state.isEditing ?? false;
+      const grid = this.state.grid;
+      const currentDraggable = grid.state.isDraggable ?? false;
+      const currentResizable = grid.state.isResizable ?? false;
+      if (currentDraggable !== isEditing || currentResizable !== isEditing) {
+        grid.setState({ isDraggable: isEditing, isResizable: isEditing });
+      }
+    }
+
     if (config.featureToggles.dashboardNewLayouts) {
       this._subs.add(
         this.subscribeToEvent(SceneGridLayoutDragStartEvent, ({ payload: { evt, panel } }) => {

--- a/public/app/features/dashboard-scene/utils/utils.ts
+++ b/public/app/features/dashboard-scene/utils/utils.ts
@@ -254,6 +254,11 @@ export function getDashboardSceneFor(sceneObject: SceneObject): DashboardScene {
   throw new Error('SceneObject root is not a DashboardScene');
 }
 
+export function tryGetDashboardSceneFor(sceneObject: SceneObject): DashboardScene | undefined {
+  const root = sceneObject.getRoot();
+  return root instanceof DashboardScene ? root : undefined;
+}
+
 export function getClosestVizPanel(sceneObject: SceneObject): VizPanel | null {
   if (sceneObject instanceof VizPanel) {
     return sceneObject;


### PR DESCRIPTION
The new dynamic dashboards layout was leaving panels and rows draggable in view mode and ignoring the dashboard-level `editable=false` flag, since `SceneGridLayout` was constructed without an explicit `isDraggable` and react-grid-layout treats that as `true`. This change initialises the grid's drag/resize state from the current edit mode on activation, gates row and tab drag on the `editable` flag in addition to `isEditing`, and adds a guard in `DashboardLayoutOrchestrator` so cross-row panel drags are blocked unless the dashboard is both in edit mode and editable. Fixes #124490