### PR TITLE
Public dashboards: skip variable refresh and broken /panels/undefined/query in v2

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -683,7 +683,7 @@ i18next.config.ts @grafana/grafana-frontend-platform
 /packages/grafana-runtime/src/utils/megaMenuOpen.ts @grafana/grafana-frontend-navigation
 /packages/grafana-runtime/src/utils/migrationHandler* @grafana/plugins-platform-frontend @grafana/plugins-platform-backend
 /packages/grafana-runtime/src/utils/plugin.ts @grafana/grafana-frontend-platform
-/packages/grafana-runtime/src/utils/publicDashboardQueryHandler.ts @grafana/grafana-operator-experience-squad
+/packages/grafana-runtime/src/utils/publicDashboardQueryHandler* @grafana/grafana-operator-experience-squad
 /packages/grafana-runtime/src/utils/qscheck* @grafana/grafana-datasources-core-services
 /packages/grafana-runtime/src/utils/queryResponse* @grafana/grafana-datasources-core-services
 /packages/grafana-runtime/src/utils/rbac.ts @grafana/identity-access-team

--- a/packages/grafana-runtime/src/utils/publicDashboardQueryHandler.test.ts
+++ b/packages/grafana-runtime/src/utils/publicDashboardQueryHandler.test.ts
@@ -1,0 +1,71 @@
+import { lastValueFrom, of } from 'rxjs';
+
+import { type DataQueryRequest, getDefaultTimeRange } from '@grafana/data';
+
+import { config } from '../config';
+import { type BackendSrv, type BackendSrvRequest, type FetchResponse } from '../services';
+
+import { publicDashboardQueryHandler } from './publicDashboardQueryHandler';
+
+const fetchMock = jest.fn();
+const backendSrv = {
+  fetch: (options: BackendSrvRequest) => of(fetchMock(options) as FetchResponse),
+} as unknown as BackendSrv;
+
+jest.mock('../services/backendSrv', () => ({
+  ...jest.requireActual('../services/backendSrv'),
+  getBackendSrv: () => backendSrv,
+}));
+
+function makeRequest(overrides: Partial<DataQueryRequest> = {}): DataQueryRequest {
+  return {
+    targets: [{ refId: 'A' }],
+    range: getDefaultTimeRange(),
+    requestId: 'req-1',
+    intervalMs: 5000,
+    maxDataPoints: 100,
+    ...overrides,
+  } as DataQueryRequest;
+}
+
+describe('publicDashboardQueryHandler', () => {
+  const originalToken = config.publicDashboardAccessToken;
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    fetchMock.mockReturnValue({ data: { results: {} }, status: 200 });
+    config.publicDashboardAccessToken = 'test-token';
+  });
+
+  afterEach(() => {
+    config.publicDashboardAccessToken = originalToken;
+  });
+
+  it('returns an empty response and does not call fetch when panelId is undefined', async () => {
+    const response = await lastValueFrom(publicDashboardQueryHandler(makeRequest({ panelId: undefined })));
+
+    expect(response.data).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('returns an empty response and does not call fetch when panelId is NaN', async () => {
+    const response = await lastValueFrom(publicDashboardQueryHandler(makeRequest({ panelId: NaN })));
+
+    expect(response.data).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('calls fetch with the panelId-bearing URL when panelId is valid', async () => {
+    await lastValueFrom(publicDashboardQueryHandler(makeRequest({ panelId: 42 })));
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0][0].url).toBe('/api/public/dashboards/test-token/panels/42/query');
+  });
+
+  it('returns an empty response when targets is empty, irrespective of panelId', async () => {
+    const response = await lastValueFrom(publicDashboardQueryHandler(makeRequest({ panelId: 42, targets: [] })));
+
+    expect(response.data).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/packages/grafana-runtime/src/utils/publicDashboardQueryHandler.ts
+++ b/packages/grafana-runtime/src/utils/publicDashboardQueryHandler.ts
@@ -21,6 +21,10 @@ export function publicDashboardQueryHandler(request: DataQueryRequest<DataQuery>
     return of({ data: [] });
   }
 
+  if (panelId == null || Number.isNaN(panelId)) {
+    return of({ data: [] });
+  }
+
   const body = {
     intervalMs,
     maxDataPoints,

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.test.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.test.ts
@@ -16,6 +16,7 @@ import {
   type SceneGridItem,
   SwitchVariable,
 } from '@grafana/scenes';
+import { VariableRefresh } from '@grafana/schema';
 import {
   type AdhocVariableKind,
   type ConstantVariableKind,
@@ -379,6 +380,42 @@ describe('transformSaveModelSchemaV2ToScene', () => {
       const variable = scene.state.$variables?.getByName('intervalVar') as IntervalVariable;
 
       expect(variable.state.value).toBe('$__auto');
+    });
+  });
+
+  describe('query variables in public dashboard mode', () => {
+    it('forces refresh to never when publicDashboardAccessToken is set, regardless of spec refresh', () => {
+      const originalToken = config.publicDashboardAccessToken;
+      config.publicDashboardAccessToken = 'test-public-token';
+      try {
+        const dashboard = cloneDeep(defaultDashboard);
+        const queryVar = dashboard.spec.variables.find((v) => v.kind === 'QueryVariable') as QueryVariableKind;
+        queryVar.spec.refresh = 'onDashboardLoad';
+
+        const scene = transformSaveModelSchemaV2ToScene(dashboard);
+        const variable = scene.state.$variables?.getByName('queryVar') as QueryVariable;
+
+        expect(variable.state.refresh).toBe(VariableRefresh.never);
+      } finally {
+        config.publicDashboardAccessToken = originalToken;
+      }
+    });
+
+    it('honors the spec refresh value when not in public dashboard mode', () => {
+      const originalToken = config.publicDashboardAccessToken;
+      config.publicDashboardAccessToken = '';
+      try {
+        const dashboard = cloneDeep(defaultDashboard);
+        const queryVar = dashboard.spec.variables.find((v) => v.kind === 'QueryVariable') as QueryVariableKind;
+        queryVar.spec.refresh = 'onDashboardLoad';
+
+        const scene = transformSaveModelSchemaV2ToScene(dashboard);
+        const variable = scene.state.$variables?.getByName('queryVar') as QueryVariable;
+
+        expect(variable.state.refresh).toBe(VariableRefresh.onDashboardLoad);
+      } finally {
+        config.publicDashboardAccessToken = originalToken;
+      }
     });
   });
 

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
@@ -1,6 +1,7 @@
 import { uniqueId } from 'lodash';
 
 import { config, getDataSourceSrv } from '@grafana/runtime';
+import { VariableRefresh } from '@grafana/schema';
 import {
   AdHocFiltersVariable,
   type AdHocFilterWithLabels,
@@ -409,6 +410,9 @@ export function createSceneVariableFromVariableModel(variable: TypedVariableMode
       valuesFormat: variable.spec.valuesFormat || 'csv',
     });
   } else if (variable.kind === defaultQueryVariableKind().kind) {
+    const refresh = config.publicDashboardAccessToken
+      ? VariableRefresh.never
+      : transformVariableRefreshToEnumV1(variable.spec.refresh);
     return new QueryVariable({
       ...commonProperties,
       value: variable.spec.current?.value ?? '',
@@ -416,7 +420,7 @@ export function createSceneVariableFromVariableModel(variable: TypedVariableMode
       query: getDataQueryForVariable(variable),
       datasource: getRuntimeVariableDataSource(variable),
       sort: transformSortVariableToEnumV1(variable.spec.sort),
-      refresh: transformVariableRefreshToEnumV1(variable.spec.refresh),
+      refresh,
       regex: variable.spec.regex,
       regexApplyTo: variable.spec.regexApplyTo,
       allValue: variable.spec.allValue || undefined,

--- a/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
+++ b/public/app/features/dashboard-scene/serialization/transformSaveModelSchemaV2ToScene.ts
@@ -1,7 +1,6 @@
 import { uniqueId } from 'lodash';
 
 import { config, getDataSourceSrv } from '@grafana/runtime';
-import { VariableRefresh } from '@grafana/schema';
 import {
   AdHocFiltersVariable,
   type AdHocFilterWithLabels,
@@ -21,6 +20,7 @@ import {
   SwitchVariable,
   TextBoxVariable,
 } from '@grafana/scenes';
+import { VariableRefresh } from '@grafana/schema';
 import {
   type AdhocVariableKind,
   type ConstantVariableKind,


### PR DESCRIPTION
On v2 native dashboards in public mode, query variables call `updateAndValidate` on activation, which routes through `publicDashboardQueryHandler` and produces a `/api/public/dashboards/{token}/panels/undefined/query` request (variables don't carry a panel id). The 400 response then cascades and prevents unrelated panels from rendering. This change pins query variables to `refresh: never` when a public dashboard access token is set so the persisted current value is used instead, the same behaviour v1 public dashboards effectively get and short-circuits the query handler with an empty response when a request has no panel id, so any future stray non-panel query won't break the page.

**Note:** this is a partial fix. Variables whose templating relies on resolved options (e.g. SQL expansions of `$__all`) still won't expand correctly on v2 public dashboards; that needs a backend route or persisted options and is out of scope here. Fixes #124422