### PR TITLE
Remote cache: use dialect UPSERT to avoid Postgres log spam under HA

### DIFF
--- a/pkg/infra/remotecache/database_storage.go
+++ b/pkg/infra/remotecache/database_storage.go
@@ -90,25 +90,16 @@ func (dc *databaseCache) Set(ctx context.Context, key string, data []byte, expir
 			expiresInSeconds = int64(expire) / int64(time.Second)
 		}
 
-		// attempt to insert the key
-		sql := `INSERT INTO cache_data (cache_key,data,created_at,expires) VALUES(?,?,?,?)`
-		_, err := session.Exec(sql, key, data, getTime().Unix(), expiresInSeconds)
-		if err != nil {
-			// attempt to update if a unique constrain violation or a deadlock (for MySQL) occurs
-			// if the update fails propagate the error
-			// which eventually will result in a key that is not finally set
-			// but since it's a cache does not harm a lot
-			if dc.SQLStore.GetDialect().IsUniqueConstraintViolation(err) || dc.SQLStore.GetDialect().IsDeadlock(err) {
-				sql := `UPDATE cache_data SET data=?, created_at=?, expires=? WHERE cache_key=?`
-				_, err = session.Exec(sql, data, getTime().Unix(), expiresInSeconds, key)
-				if err != nil && dc.SQLStore.GetDialect().IsDeadlock(err) {
-					// most probably somebody else is upserting the key
-					// so it is safe enough not to propagate this error
-					return nil
-				}
-			}
+		upsertSQL := dc.SQLStore.GetDialect().UpsertSQL(
+			"cache_data",
+			[]string{"cache_key"},
+			[]string{"cache_key", "data", "created_at", "expires"},
+		)
+		_, err := session.Exec(upsertSQL, key, data, getTime().Unix(), expiresInSeconds)
+		if err != nil && dc.SQLStore.GetDialect().IsDeadlock(err) {
+			// Another writer is upserting the same key; the cache will converge.
+			return nil
 		}
-
 		return err
 	})
 }

--- a/pkg/infra/remotecache/database_storage_test.go
+++ b/pkg/infra/remotecache/database_storage_test.go
@@ -2,10 +2,12 @@ package remotecache
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -79,4 +81,40 @@ func TestIntegrationSecondSet(t *testing.T) {
 
 	err = db.Set(context.Background(), "killa-gorilla", obj, 0)
 	assert.Equal(t, err, nil)
+}
+
+func TestIntegrationConcurrentSet(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	sqlstore := db.InitTestDB(t)
+	cache := &databaseCache{
+		SQLStore: sqlstore,
+		log:      log.New("remotecache.database"),
+	}
+
+	const writers = 10
+	const key = "shared-key"
+	value := []byte("v")
+
+	var wg sync.WaitGroup
+	errs := make(chan error, writers)
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			if err := cache.Set(context.Background(), key, value, 5*time.Minute); err != nil {
+				errs <- err
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Errorf("concurrent Set returned error: %v", err)
+	}
+
+	got, err := cache.Get(context.Background(), key)
+	require.NoError(t, err)
+	assert.Equal(t, value, got)
 }


### PR DESCRIPTION
The database-backed remote cache currently does an INSERT and, on a unique-constraint error, falls back to UPDATE. That's functionally correct, but on Postgres the constraint violation is logged at ERROR level by the database before the application sees it, which produces a constant stream of `idx_16492_primary` errors in the Postgres log on any HA setup where multiple Grafana replicas concurrently miss the auth id-token cache and write the same key. This change switches `databaseCache.Set` to use the existing `Dialect.UpsertSQL` helper, which emits dialect-aware UPSERT statements (`ON CONFLICT DO UPDATE` on Postgres/SQLite, `ON DUPLICATE KEY UPDATE` on MySQL) so concurrent writers no longer collide. Adds an integration test that fires ten goroutines at the same key and asserts none surface an error. Fixes #124063