### PR TITLE
SplashScreenModal: respect appSubUrl when resolving CTA links

### DIFF
--- a/public/app/core/components/SplashScreenModal/SplashScreenModal.test.tsx
+++ b/public/app/core/components/SplashScreenModal/SplashScreenModal.test.tsx
@@ -1,0 +1,72 @@
+import { type GrafanaConfig, locationUtil } from '@grafana/data';
+import { contextSrv } from 'app/core/services/context_srv';
+
+import { resolveCtaUrl } from './SplashScreenModal';
+import { type SplashFeatureCta } from './splashContent';
+
+function initLocationUtil(appSubUrl: string) {
+  locationUtil.initialize({
+    config: { appSubUrl } as GrafanaConfig,
+    getTimeRangeForUrl: jest.fn(),
+    getVariablesUrlParams: jest.fn(),
+  });
+}
+
+describe('resolveCtaUrl', () => {
+  beforeEach(() => {
+    jest.spyOn(contextSrv, 'hasRole').mockReturnValue(true);
+    jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    initLocationUtil('');
+  });
+
+  it('prepends appSubUrl to internal paths when Grafana is served from a sub-path', () => {
+    initLocationUtil('/grafana');
+    const cta: SplashFeatureCta = { text: 'Show me', url: '/plugins/grafana-assistant-app/' };
+
+    expect(resolveCtaUrl(cta)).toBe('/grafana/plugins/grafana-assistant-app/');
+  });
+
+  it('returns internal paths unchanged when no sub-path is configured', () => {
+    initLocationUtil('');
+    const cta: SplashFeatureCta = { text: 'Show me', url: '/dashboard/new' };
+
+    expect(resolveCtaUrl(cta)).toBe('/dashboard/new');
+  });
+
+  it('does not modify external https URLs', () => {
+    initLocationUtil('/grafana');
+    const cta: SplashFeatureCta = { text: 'Docs', url: 'https://grafana.com/docs/' };
+
+    expect(resolveCtaUrl(cta)).toBe('https://grafana.com/docs/');
+  });
+
+  it('falls back to fallbackUrl when admin requirement is not met, and prepends appSubUrl if fallback is internal', () => {
+    initLocationUtil('/grafana');
+    jest.spyOn(contextSrv, 'hasRole').mockReturnValue(false);
+    const cta: SplashFeatureCta = {
+      text: 'Show me',
+      url: '/admin/provisioning',
+      fallbackUrl: '/docs/inline',
+      requiresAdmin: true,
+    };
+
+    expect(resolveCtaUrl(cta)).toBe('/grafana/docs/inline');
+  });
+
+  it('falls back to external fallbackUrl when permission requirement is not met, leaving it unchanged', () => {
+    initLocationUtil('/grafana');
+    jest.spyOn(contextSrv, 'hasPermission').mockReturnValue(false);
+    const cta: SplashFeatureCta = {
+      text: 'Show me',
+      url: '/dashboard/new',
+      fallbackUrl: 'https://grafana.com/docs/',
+      permission: 'dashboards:create',
+    };
+
+    expect(resolveCtaUrl(cta)).toBe('https://grafana.com/docs/');
+  });
+});

--- a/public/app/core/components/SplashScreenModal/SplashScreenModal.tsx
+++ b/public/app/core/components/SplashScreenModal/SplashScreenModal.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 import { useCallback, useState } from 'react';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import { type GrafanaTheme2, locationUtil } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { IconButton, LinkButton, useStyles2 } from '@grafana/ui';
 import { ModalBase } from '@grafana/ui/internal';
@@ -12,14 +12,16 @@ import { SplashScreenSlide } from './SplashScreenSlide';
 import { type SplashFeatureCta, getSplashScreenConfig } from './splashContent';
 import { useShouldShowSplash } from './useShouldShowSplash';
 
-function resolveCtaUrl(cta: SplashFeatureCta): string {
+export function resolveCtaUrl(cta: SplashFeatureCta): string {
+  let url: string;
   if (cta.requiresAdmin && !contextSrv.hasRole('Admin')) {
-    return cta.fallbackUrl ?? cta.url;
+    url = cta.fallbackUrl ?? cta.url;
+  } else if (cta.permission && !contextSrv.hasPermission(cta.permission)) {
+    url = cta.fallbackUrl ?? cta.url;
+  } else {
+    url = cta.url;
   }
-  if (cta.permission && !contextSrv.hasPermission(cta.permission)) {
-    return cta.fallbackUrl ?? cta.url;
-  }
-  return cta.url;
+  return locationUtil.assureBaseUrl(url);
 }
 
 export function SplashScreenModal() {

--- a/public/app/core/components/SplashScreenModal/splashContent.ts
+++ b/public/app/core/components/SplashScreenModal/splashContent.ts
@@ -54,7 +54,7 @@ export function getSplashScreenConfig(): SplashScreenConfig {
         ],
         cta: {
           text: t('splash-screen.assistant.cta', 'Show me'),
-          url: `${window.location.origin}/plugins/grafana-assistant-app/?${UTM}`,
+          url: `/plugins/grafana-assistant-app/?${UTM}`,
         },
         heroImageUrl: assistantHeroImage,
       },


### PR DESCRIPTION
The "What's new" splash screen built CTA links as relative paths (and one as `\${window.location.origin}/plugins/grafana-assistant-app/...`) without prepending `appSubUrl`, so under `GF_SERVER_SERVE_FROM_SUB_PATH=true` the buttons routed to the wrong path e.g. clicking "Show me" for the assistant on a sub-path install ended up at `https://host/plugins/grafana-assistant-app/` instead of `https://host/grafana/plugins/grafana-assistant-app/`. This switches `resolveCtaUrl` to run the chosen URL through `locationUtil.assureBaseUrl`, which prepends `appSubUrl` to internal paths and leaves external `https://...` URLs unchanged, and drops the redundant `window.location.origin` prefix from the assistant CTA. Adds a small unit test covering the sub-path, no-sub-path, external, and admin/permission fallback cases.

Note: this only addresses the splash-screen CTAs in core. The original report (#123591) is about the `grafana-assistant-app` plugin's own resource API calls (`/api/plugins/grafana-assistant-app/resources/api/v1/chats`), which are constructed inside the plugin itself and aren't part of this repository and those need to be fixed in the plugin by using `getBackendSrv().fetch()` (which prepends `appSubUrl` automatically) instead of raw `fetch`. Fixes #123591