### PR TITLE
Datasources: use k8s access metadata subresource

### DIFF
--- a/pkg/api/datasources_k8s.go
+++ b/pkg/api/datasources_k8s.go
@@ -13,12 +13,14 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/rest"
 
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/api/routing"
 	datasourceV0 "github.com/grafana/grafana/pkg/apis/datasource/v0alpha1"
 	"github.com/grafana/grafana/pkg/infra/metrics/metricutil"
 	dsconverter "github.com/grafana/grafana/pkg/registry/apis/datasource/converter"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/services/datasources"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -83,8 +85,15 @@ func (hs *HTTPServer) getK8sDataSourceByUIDHandler() web.Handler {
 
 		dto := hs.convertModelToDtos(c.Req.Context(), legacyDS)
 
-		// TODO get access control from the new api endpoint too.
-		dto.AccessControl = getAccessControlMetadata(c, datasources.ScopePrefix, dto.UID)
+		if c.QueryBool("accesscontrol") {
+			accessMetadata, err := hs.getK8sDataSourceAccess(c, conn.APIGroup, conn.APIVersion, conn.Name)
+			if err != nil {
+				// Fallback to the existing local metadata path so the datasource read itself still succeeds.
+				dto.AccessControl = getAccessControlMetadata(c, datasources.ScopePrefix, dto.UID)
+			} else {
+				dto.AccessControl = accessMetadata
+			}
+		}
 
 		return response.JSON(http.StatusOK, &dto)
 	})
@@ -120,6 +129,36 @@ func (hs *HTTPServer) getK8sDataSource(c *contextmodel.ReqContext, group, versio
 	}
 
 	return &ds, nil
+}
+
+func (hs *HTTPServer) getK8sDataSourceAccess(c *contextmodel.ReqContext, group, version, uid string) (accesscontrol.Metadata, error) {
+	cfg := dynamic.ConfigFor(hs.clientConfigProvider.GetDirectRestConfig(c))
+	cfg.GroupVersion = &schema.GroupVersion{Group: group, Version: version}
+
+	client, err := rest.RESTClientFor(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create rest client: %w", err)
+	}
+
+	namespace := hs.namespacer(c.GetOrgID())
+	result := client.Get().
+		AbsPath("apis", group, version, "namespaces", namespace, "datasources", uid, "access").
+		Do(c.Req.Context())
+	if err := result.Error(); err != nil {
+		return nil, fmt.Errorf("failed to get datasource access metadata: %w", err)
+	}
+
+	body, err := result.Raw()
+	if err != nil {
+		return nil, fmt.Errorf("failed to read datasource access metadata response: %w", err)
+	}
+
+	var accessInfo datasourceV0.DatasourceAccessInfo
+	if err := json.Unmarshal(body, &accessInfo); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal datasource access metadata: %w", err)
+	}
+
+	return accessInfo.Permissions, nil
 }
 
 // callK8sDataSourceResourceHandler returns a handler that proxies

--- a/pkg/api/datasources_k8s_test.go
+++ b/pkg/api/datasources_k8s_test.go
@@ -96,15 +96,28 @@ func (m *mockDirectRestConfigProvider) IsReady() bool { return true }
 type mockRoundTripper struct {
 	statusCode   int
 	responseBody []byte
+	responses    map[string]mockRoundTripResponse
+}
+
+type mockRoundTripResponse struct {
+	statusCode   int
+	responseBody []byte
 }
 
 func (m *mockRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	statusCode := m.statusCode
+	responseBody := m.responseBody
+	if resp, ok := m.responses[req.URL.Path]; ok {
+		statusCode = resp.statusCode
+		responseBody = resp.responseBody
+	}
+
 	header := http.Header{}
 	header.Set("Content-Type", "application/json")
 	return &http.Response{
-		StatusCode: m.statusCode,
+		StatusCode: statusCode,
 		Header:     header,
-		Body:       io.NopCloser(bytes.NewReader(m.responseBody)),
+		Body:       io.NopCloser(bytes.NewReader(responseBody)),
 		Request:    req,
 	}, nil
 }
@@ -209,6 +222,66 @@ func TestGetK8sDataSourceByUIDHandler(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetK8sDataSourceByUIDHandler_AccessControlMetadata(t *testing.T) {
+	transport := &mockRoundTripper{
+		responses: map[string]mockRoundTripResponse{
+			"/apis/prometheus.datasource.grafana.app/v0alpha1/namespaces/default/datasources/test-uid": {
+				statusCode: http.StatusOK,
+				responseBody: []byte(`{
+					"apiVersion": "prometheus.datasource.grafana.app/v0alpha1",
+					"kind": "DataSource",
+					"metadata": {"name": "test-uid", "namespace": "default"},
+					"spec": {"title": "Test Prometheus", "url": "http://localhost:9090"}
+				}`),
+			},
+			"/apis/prometheus.datasource.grafana.app/v0alpha1/namespaces/default/datasources/test-uid/access": {
+				statusCode:   http.StatusOK,
+				responseBody: []byte(`{"permissions":{"datasources:read":true,"datasources:query":true}}`),
+			},
+		},
+	}
+
+	hs := &HTTPServer{
+		Cfg: setting.NewCfg(),
+		Features: featuremgmt.WithFeatures(
+			featuremgmt.FlagDatasourcesRerouteLegacyCRUDAPIs,
+			featuremgmt.FlagQueryService,
+			featuremgmt.FlagDatasourceUseNewCRUDAPIs,
+			featuremgmt.FlagDatasourcesApiServerEnableResourceEndpoint,
+		),
+		dsConnectionClient: &mockConnectionClient{
+			result: &queryV0.DataSourceConnectionList{
+				Items: []queryV0.DataSourceConnection{
+					{Name: "test-uid", APIGroup: "prometheus.datasource.grafana.app", APIVersion: "v0alpha1"},
+				},
+			},
+		},
+		clientConfigProvider: &mockDirectRestConfigProvider{host: "http://localhost", transport: transport},
+		namespacer:           func(int64) string { return "default" },
+		DataSourcesService:   &dataSourcesServiceMock{},
+	}
+	hs.promRegister, hs.dsConfigHandlerRequestsDuration, hs.dsEndpointRedirects = setupDsConfigHandlerMetrics()
+
+	sc := setupScenarioContext(t, "/api/datasources/uid/test-uid?accesscontrol=true")
+	handler := hs.getK8sDataSourceByUIDHandler()
+	sc.m.Get("/api/datasources/uid/:uid", func(c *contextmodel.ReqContext) {
+		c.Req = web.SetURLParams(c.Req, map[string]string{":uid": "test-uid"})
+		c.SignedInUser = &user.SignedInUser{OrgID: 1}
+		handler.(func(*contextmodel.ReqContext))(c)
+	})
+	sc.fakeReqWithParams("GET", sc.url, map[string]string{}).exec()
+
+	require.Equal(t, http.StatusOK, sc.resp.Code)
+
+	var body map[string]any
+	require.NoError(t, json.Unmarshal(sc.resp.Body.Bytes(), &body))
+
+	require.Equal(t, map[string]any{
+		"datasources:read":  true,
+		"datasources:query": true,
+	}, body["accessControl"])
 }
 
 func newTestContext(t *testing.T, method, urlPath string, params map[string]string) (*contextmodel.ReqContext, *httptest.ResponseRecorder) {

--- a/pkg/registry/apis/datasource/sub_access.go
+++ b/pkg/registry/apis/datasource/sub_access.go
@@ -54,9 +54,9 @@ func (r *subAccessREST) Connect(ctx context.Context, name string, opts runtime.O
 
 func (r *subAccessREST) getAccessInfo(ctx context.Context, name string) (*datasourceV0alpha1.DatasourceAccessInfo, error) {
 	reqContext := contexthandler.FromContext(ctx)
-	resourceIDs := map[string]bool{datasources.ScopePrefix: true}
+	resourceIDs := map[string]bool{name: true}
 	access := accesscontrol.GetResourcesMetadata(reqContext.Req.Context(), reqContext.GetPermissions(), datasources.ScopePrefix, resourceIDs)
 	return &datasourceV0alpha1.DatasourceAccessInfo{
-		Permissions: access[datasources.ScopePrefix],
+		Permissions: access[name],
 	}, nil
 }

--- a/pkg/registry/apis/datasource/sub_access_test.go
+++ b/pkg/registry/apis/datasource/sub_access_test.go
@@ -1,0 +1,46 @@
+package datasource
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	datasourceV0alpha1 "github.com/grafana/grafana/pkg/apis/datasource/v0alpha1"
+	"github.com/grafana/grafana/pkg/services/contexthandler/ctxkey"
+	"github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/services/user"
+	"github.com/grafana/grafana/pkg/web"
+)
+
+func TestSubAccessREST_GetAccessInfoUsesDatasourceUID(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "/apis/prometheus.datasource.grafana.app/v0alpha1/namespaces/default/datasources/test-uid/access", nil)
+	recorder := httptest.NewRecorder()
+	reqCtx := &contextmodel.ReqContext{
+		Context: &web.Context{
+			Req:  req,
+			Resp: web.NewResponseWriter(req.Method, recorder),
+		},
+		SignedInUser: &user.SignedInUser{
+			OrgID: 1,
+			Permissions: map[int64]map[string][]string{
+				1: {
+					"datasources:read":  {"datasources:uid:test-uid"},
+					"datasources:query": {"datasources:uid:other-uid"},
+				},
+			},
+		},
+	}
+	ctx := ctxkey.Set(context.Background(), reqCtx)
+
+	accessREST := &subAccessREST{}
+	accessInfo, err := accessREST.getAccessInfo(ctx, "test-uid")
+	require.NoError(t, err)
+	require.Equal(t, &datasourceV0alpha1.DatasourceAccessInfo{
+		Permissions: map[string]bool{
+			"datasources:read": true,
+		},
+	}, accessInfo)
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- Updates the rerouted datasource-by-UID read path to fetch access control metadata from the k8s datasource /access subresource when accesscontrol=true.
- Fixes the datasource access subresource to resolve permissions for the requested datasource UID.

**Why do we need this feature?**

- The legacy /api/datasources/uid/:uid endpoint is rerouted to the new k8s datasource API, so its access metadata should come from the new API too.
- Before this change, the rerouted path still used the legacy local metadata helper, and the /access subresource was not looking up permissions by datasource UID.

**Who is this feature for?**

- Users and API clients reading datasource details with access control metadata enabled.
- Maintainers working on parity between legacy datasource endpoints and the k8s-style API.

**Which issue(s) does this PR fix?**:

No issue. Addresses the inline TODO in pkg/api/datasources_k8s.go and fixes the datasource access subresource UID lookup.

**Special notes for your reviewer:**

- Backend-only parity fix.
- The rerouted legacy handler now prefers the k8s /access subresource and falls back to the existing local metadata path if that request fails.
- Verified with:
    - go test ./pkg/api -run TestGetK8sDataSourceByUIDHandler
    - go test ./pkg/registry/apis/datasource -run TestSubAccessREST_GetAccessInfoUsesDatasourceUID

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
