### PR TITLE
Navigation: Grafana Assistant onboarding stub when the plugin is not installed

### DIFF
--- a/e2e-playwright/various-suite/assistant-onboarding.spec.ts
+++ b/e2e-playwright/various-suite/assistant-onboarding.spec.ts
@@ -1,0 +1,36 @@
+import { test, expect } from '@grafana/plugin-e2e';
+
+test.use({
+  featureToggles: {
+    assistantStubNav: true,
+  },
+});
+
+test.describe(
+  'Assistant onboarding stub',
+  {
+    tag: ['@various'],
+  },
+  () => {
+    test('renders the onboarding fallback at the plugin URL when the plugin is not installed', async ({ page }) => {
+      await page.goto('/a/grafana-assistant-app');
+
+      await expect(page.getByRole('heading', { name: 'Grafana Assistant', level: 1 })).toBeVisible();
+
+      const installCta = page.getByRole('link', { name: /install grafana assistant/i });
+      await expect(installCta).toBeVisible();
+      await expect(installCta).toHaveAttribute('href', '/plugins/grafana-assistant-app');
+    });
+
+    test('exposes an Assistant entry in the main nav that points at the plugin URL', async ({ page, selectors }) => {
+      await page.goto('/');
+
+      const navMenu = page.getByTestId(selectors.components.NavMenu.Menu);
+      await expect(navMenu).toBeVisible();
+
+      const assistantEntry = navMenu.getByRole('link', { name: /^Assistant/ });
+      await expect(assistantEntry).toBeVisible();
+      await expect(assistantEntry).toHaveAttribute('href', '/a/grafana-assistant-app');
+    });
+  }
+);

--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -930,6 +930,11 @@ export interface FeatureToggles {
   */
   grafanaAdvisor?: boolean;
   /**
+  * Show a Grafana Assistant entry in the main nav with an onboarding stub when the assistant app plugin is not installed.
+  * @default false
+  */
+  assistantStubNav?: boolean;
+  /**
   * Enables less memory intensive Elasticsearch result parsing
   * @default false
   */

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1624,6 +1624,14 @@ var (
 			Generate:    Generate{LegacyGo: true, LegacyFrontend: true},
 		},
 		{
+			Name:        "assistantStubNav",
+			Description: "Show a Grafana Assistant entry in the main nav with an onboarding stub when the assistant app plugin is not installed.",
+			Stage:       FeatureStageExperimental,
+			Owner:       grafanaPluginsPlatformSquad,
+			Expression:  "false",
+			Generate:    Generate{LegacyGo: true, LegacyFrontend: true},
+		},
+		{
 			Name:        "elasticsearchImprovedParsing",
 			Description: "Enables less memory intensive Elasticsearch result parsing",
 			Stage:       FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -189,6 +189,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-03-16,teamLBACApiReadFromAppPlatform,experimental,@grafana/identity-access-team,false,false,false
 2026-04-09,teamLBACApiWriteFromAppPlatform,experimental,@grafana/identity-access-team,false,false,false
 2025-01-20,grafanaAdvisor,GA,@grafana/plugins-platform-backend,false,false,false
+2026-05-09,assistantStubNav,experimental,@grafana/plugins-platform-backend,false,false,false
 2025-01-15,elasticsearchImprovedParsing,experimental,@grafana/data-sources-plugins,false,false,false
 2025-01-21,datasourceConnectionsTab,privatePreview,@grafana/plugins-platform-backend,false,false,true
 2025-01-29,fetchRulesUsingPost,experimental,@grafana/alerting-squad,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -535,6 +535,10 @@ const (
 	// Enables Advisor app
 	FlagGrafanaAdvisor = "grafanaAdvisor"
 
+	// FlagAssistantStubNav
+	// Show a Grafana Assistant entry in the main nav with an onboarding stub when the assistant app plugin is not installed.
+	FlagAssistantStubNav = "assistantStubNav"
+
 	// FlagElasticsearchImprovedParsing
 	// Enables less memory intensive Elasticsearch result parsing
 	FlagElasticsearchImprovedParsing = "elasticsearchImprovedParsing"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1117,6 +1117,19 @@
     },
     {
       "metadata": {
+        "name": "assistantStubNav",
+        "resourceVersion": "1778345328029",
+        "creationTimestamp": "2026-05-09T16:48:48Z"
+      },
+      "spec": {
+        "description": "Show a Grafana Assistant entry in the main nav with an onboarding stub when the assistant app plugin is not installed.",
+        "stage": "experimental",
+        "codeowner": "@grafana/plugins-platform-backend",
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "auditLoggingAppPlatform",
         "resourceVersion": "1771434338561",
         "creationTimestamp": "2025-12-29T15:28:29Z"

--- a/pkg/services/navtree/models.go
+++ b/pkg/services/navtree/models.go
@@ -43,6 +43,7 @@ const (
 	NavIDDashboards           = "dashboards/browse"
 	NavIDExplore              = "explore"
 	NavIDDrilldown            = "drilldown"
+	NavIDAssistant            = "assistant"
 	NavIDAdaptiveTelemetry    = "adaptive-telemetry"
 	NavIDCfg                  = "cfg" // NavIDCfg is the id for org configuration navigation node
 	NavIDAlertsAndIncidents   = "alerts-and-incidents"

--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -17,6 +17,8 @@ import (
 	"github.com/grafana/grafana/pkg/util"
 )
 
+const assistantPluginID = "grafana-assistant-app"
+
 func (s *ServiceImpl) addAppLinks(treeRoot *navtree.NavTreeRoot, c *contextmodel.ReqContext) error {
 	hasAccess := ac.HasAccess(s.accessControl, c)
 	appLinks := []*navtree.NavLink{}
@@ -39,10 +41,18 @@ func (s *ServiceImpl) addAppLinks(treeRoot *navtree.NavTreeRoot, c *contextmodel
 	}
 
 	enabledAccessibleAppPluginMap := make(map[string]*pluginstore.Plugin)
+	// Tracks whether the assistant app is enabled at the org level, regardless of whether the current
+	// user has access to it. The stub-nav decision below needs the org-level fact, not the per-user one
+	// — otherwise we'd surface "go install" to a user for whom the plugin is already present.
+	assistantEnabled := false
 
 	for _, plugin := range s.pluginStore.Plugins(c.Req.Context(), plugins.TypeApp) {
 		if !isPluginEnabled(plugin) {
 			continue
+		}
+
+		if plugin.ID == assistantPluginID {
+			assistantEnabled = true
 		}
 
 		if !hasAccess(ac.EvalPermission(pluginaccesscontrol.ActionAppAccess, pluginaccesscontrol.ScopeProvider.GetResourceScope(plugin.ID))) {
@@ -63,18 +73,21 @@ func (s *ServiceImpl) addAppLinks(treeRoot *navtree.NavTreeRoot, c *contextmodel
 		}
 	}
 
-	// When the assistant app plugin isn't installed/enabled, surface an Assistant nav entry pointing at the
-	// plugin's own URL so the navtree never has to mutate when the plugin's installation state changes. The
-	// AppRootPage at /a/grafana-assistant-app falls back to a core onboarding page when the plugin isn't loaded.
+	// When the assistant app plugin isn't enabled at the org level, surface an Assistant nav entry pointing
+	// at the plugin's own URL so the navtree never has to mutate when the plugin's installation state changes.
+	// The AppRootPage at /a/grafana-assistant-app falls back to a core onboarding page when the plugin isn't
+	// loaded. Gated on plugins:install so the stub doesn't surface a CTA users without that permission can't
+	// follow through on — those users should reach the plugin via an admin-installed instance, not the stub.
 	if s.features.IsEnabled(c.Req.Context(), featuremgmt.FlagAssistantStubNav) &&
-		enabledAccessibleAppPluginMap["grafana-assistant-app"] == nil {
+		!assistantEnabled &&
+		hasAccess(ac.EvalPermission(pluginaccesscontrol.ActionInstall)) {
 		appLinks = append(appLinks, &navtree.NavLink{
 			Text:       "Assistant",
 			Id:         navtree.NavIDAssistant,
 			SubTitle:   "AI-powered assistant for Grafana",
 			Icon:       "ai-sparkle",
 			SortWeight: navtree.WeightAssistant,
-			Url:        s.cfg.AppSubURL + "/a/grafana-assistant-app",
+			Url:        s.cfg.AppSubURL + "/a/" + assistantPluginID,
 		})
 	}
 

--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -63,6 +63,21 @@ func (s *ServiceImpl) addAppLinks(treeRoot *navtree.NavTreeRoot, c *contextmodel
 		}
 	}
 
+	// When the assistant app plugin isn't installed/enabled, surface an Assistant nav entry pointing at the
+	// plugin's own URL so the navtree never has to mutate when the plugin's installation state changes. The
+	// AppRootPage at /a/grafana-assistant-app falls back to a core onboarding page when the plugin isn't loaded.
+	if s.features.IsEnabled(c.Req.Context(), featuremgmt.FlagAssistantStubNav) &&
+		enabledAccessibleAppPluginMap["grafana-assistant-app"] == nil {
+		appLinks = append(appLinks, &navtree.NavLink{
+			Text:       "Assistant",
+			Id:         navtree.NavIDAssistant,
+			SubTitle:   "AI-powered assistant for Grafana",
+			Icon:       "ai-sparkle",
+			SortWeight: navtree.WeightAssistant,
+			Url:        s.cfg.AppSubURL + "/a/grafana-assistant-app",
+		})
+	}
+
 	if len(appLinks) > 0 {
 		sort.SliceStable(appLinks, func(i, j int) bool {
 			return appLinks[i].Text < appLinks[j].Text

--- a/pkg/services/navtree/navtreeimpl/applinks_test.go
+++ b/pkg/services/navtree/navtreeimpl/applinks_test.go
@@ -376,6 +376,83 @@ func TestAddAppLinks(t *testing.T) {
 	})
 }
 
+func TestAssistantStubNav(t *testing.T) {
+	httpReq, _ := http.NewRequest(http.MethodGet, "", nil)
+	reqCtx := &contextmodel.ReqContext{SignedInUser: &user.SignedInUser{}, Context: &web.Context{Req: httpReq}}
+	permissions := []ac.Permission{
+		{Action: pluginaccesscontrol.ActionAppAccess, Scope: "*"},
+	}
+
+	assistantPlugin := pluginstore.Plugin{
+		JSONData: plugins.JSONData{
+			ID:   "grafana-assistant-app",
+			Name: "Grafana Assistant",
+			Type: plugins.TypeApp,
+			Includes: []*plugins.Includes{
+				{Name: "Workspace", Path: "/a/grafana-assistant-app/workspace", Type: "page", AddToNav: true},
+			},
+		},
+	}
+
+	newService := func(togglesOn bool, plugins ...pluginstore.Plugin) *ServiceImpl {
+		settings := pluginsettings.FakePluginSettings{Plugins: map[string]*pluginsettings.DTO{}}
+		for _, p := range plugins {
+			settings.Plugins[p.ID] = &pluginsettings.DTO{ID: 0, OrgID: 1, PluginID: p.ID, PluginVersion: "1.0.0", Enabled: true}
+		}
+
+		var features featuremgmt.FeatureToggles
+		if togglesOn {
+			features = featuremgmt.WithFeatures(featuremgmt.FlagAssistantStubNav)
+		} else {
+			features = featuremgmt.WithFeatures()
+		}
+
+		s := &ServiceImpl{
+			log:            log.New("navtree"),
+			cfg:            setting.NewCfg(),
+			accessControl:  accesscontrolmock.New().WithPermissions(permissions),
+			pluginSettings: &settings,
+			features:       features,
+			pluginStore:    &pluginstore.FakePluginStore{PluginList: plugins},
+		}
+		s.readNavigationSettings()
+		return s
+	}
+
+	t.Run("stub appears with the plugin's URL when toggle is on and the plugin is not installed", func(t *testing.T) {
+		service := newService(true)
+		treeRoot := navtree.NavTreeRoot{}
+
+		require.NoError(t, service.addAppLinks(&treeRoot, reqCtx))
+
+		stub := treeRoot.FindById(navtree.NavIDAssistant)
+		require.NotNil(t, stub, "expected an assistant stub nav node")
+		require.Equal(t, "Assistant", stub.Text)
+		require.Equal(t, "/a/grafana-assistant-app", stub.Url, "stub must point at the plugin's canonical URL so the navtree never has to mutate when install state changes")
+		require.Equal(t, "ai-sparkle", stub.Icon)
+		require.Empty(t, stub.PluginID, "stub should not advertise a plugin id")
+	})
+
+	t.Run("stub is suppressed when the plugin is installed and enabled", func(t *testing.T) {
+		service := newService(true, assistantPlugin)
+		treeRoot := navtree.NavTreeRoot{}
+
+		require.NoError(t, service.addAppLinks(&treeRoot, reqCtx))
+
+		require.Nil(t, treeRoot.FindById(navtree.NavIDAssistant), "stub should not be added when plugin is enabled")
+		require.NotNil(t, treeRoot.FindById("plugin-page-grafana-assistant-app"), "real plugin nav should be present")
+	})
+
+	t.Run("stub does not appear when toggle is off", func(t *testing.T) {
+		service := newService(false)
+		treeRoot := navtree.NavTreeRoot{}
+
+		require.NoError(t, service.addAppLinks(&treeRoot, reqCtx))
+
+		require.Nil(t, treeRoot.FindById(navtree.NavIDAssistant))
+	})
+}
+
 func TestBuildDataConnectionsNavLink(t *testing.T) {
 	httpReq, _ := http.NewRequest(http.MethodGet, "", nil)
 	reqCtx := &contextmodel.ReqContext{SignedInUser: &user.SignedInUser{}, Context: &web.Context{Req: httpReq}}

--- a/pkg/services/navtree/navtreeimpl/applinks_test.go
+++ b/pkg/services/navtree/navtreeimpl/applinks_test.go
@@ -379,7 +379,11 @@ func TestAddAppLinks(t *testing.T) {
 func TestAssistantStubNav(t *testing.T) {
 	httpReq, _ := http.NewRequest(http.MethodGet, "", nil)
 	reqCtx := &contextmodel.ReqContext{SignedInUser: &user.SignedInUser{}, Context: &web.Context{Req: httpReq}}
-	permissions := []ac.Permission{
+	installerPermissions := []ac.Permission{
+		{Action: pluginaccesscontrol.ActionAppAccess, Scope: "*"},
+		{Action: pluginaccesscontrol.ActionInstall},
+	}
+	nonInstallerPermissions := []ac.Permission{
 		{Action: pluginaccesscontrol.ActionAppAccess, Scope: "*"},
 	}
 
@@ -394,7 +398,7 @@ func TestAssistantStubNav(t *testing.T) {
 		},
 	}
 
-	newService := func(togglesOn bool, plugins ...pluginstore.Plugin) *ServiceImpl {
+	newService := func(togglesOn bool, permissions []ac.Permission, plugins ...pluginstore.Plugin) *ServiceImpl {
 		settings := pluginsettings.FakePluginSettings{Plugins: map[string]*pluginsettings.DTO{}}
 		for _, p := range plugins {
 			settings.Plugins[p.ID] = &pluginsettings.DTO{ID: 0, OrgID: 1, PluginID: p.ID, PluginVersion: "1.0.0", Enabled: true}
@@ -419,8 +423,8 @@ func TestAssistantStubNav(t *testing.T) {
 		return s
 	}
 
-	t.Run("stub appears with the plugin's URL when toggle is on and the plugin is not installed", func(t *testing.T) {
-		service := newService(true)
+	t.Run("stub appears with the plugin's URL when toggle is on, plugin not installed, user can install", func(t *testing.T) {
+		service := newService(true, installerPermissions)
 		treeRoot := navtree.NavTreeRoot{}
 
 		require.NoError(t, service.addAppLinks(&treeRoot, reqCtx))
@@ -434,7 +438,7 @@ func TestAssistantStubNav(t *testing.T) {
 	})
 
 	t.Run("stub is suppressed when the plugin is installed and enabled", func(t *testing.T) {
-		service := newService(true, assistantPlugin)
+		service := newService(true, installerPermissions, assistantPlugin)
 		treeRoot := navtree.NavTreeRoot{}
 
 		require.NoError(t, service.addAppLinks(&treeRoot, reqCtx))
@@ -443,8 +447,29 @@ func TestAssistantStubNav(t *testing.T) {
 		require.NotNil(t, treeRoot.FindById("plugin-page-grafana-assistant-app"), "real plugin nav should be present")
 	})
 
+	t.Run("stub is suppressed when the plugin is enabled but the current user lacks app-access", func(t *testing.T) {
+		// Plugin is installed and enabled at the org level but the user has neither app-access nor install
+		// permission. The stub must NOT appear — surfacing a "go install" CTA to a user for whom the plugin
+		// already exists (just hidden from them) would be wrong.
+		service := newService(true, []ac.Permission{}, assistantPlugin)
+		treeRoot := navtree.NavTreeRoot{}
+
+		require.NoError(t, service.addAppLinks(&treeRoot, reqCtx))
+
+		require.Nil(t, treeRoot.FindById(navtree.NavIDAssistant), "stub should be suppressed when plugin is enabled regardless of access")
+	})
+
+	t.Run("stub is suppressed when the user lacks plugins:install permission", func(t *testing.T) {
+		service := newService(true, nonInstallerPermissions)
+		treeRoot := navtree.NavTreeRoot{}
+
+		require.NoError(t, service.addAppLinks(&treeRoot, reqCtx))
+
+		require.Nil(t, treeRoot.FindById(navtree.NavIDAssistant), "stub should not appear for users who can't install plugins")
+	})
+
 	t.Run("stub does not appear when toggle is off", func(t *testing.T) {
-		service := newService(false)
+		service := newService(false, installerPermissions)
 		treeRoot := navtree.NavTreeRoot{}
 
 		require.NoError(t, service.addAppLinks(&treeRoot, reqCtx))

--- a/public/app/features/assistant-onboarding/AssistantOnboardingPage.test.tsx
+++ b/public/app/features/assistant-onboarding/AssistantOnboardingPage.test.tsx
@@ -2,28 +2,19 @@ import { render, screen } from '@testing-library/react';
 import { TestProvider } from 'test/helpers/TestProvider';
 
 import { config } from '@grafana/runtime';
-import { contextSrv } from 'app/core/services/context_srv';
 
 import AssistantOnboardingPage from './AssistantOnboardingPage';
 
 const ASSISTANT_PLUGIN_ID = 'grafana-assistant-app';
 
 describe('AssistantOnboardingPage', () => {
-  let hasPermissionSpy: jest.SpyInstance;
   const originalAppSubUrl = config.appSubUrl;
 
-  beforeEach(() => {
-    hasPermissionSpy = jest.spyOn(contextSrv, 'hasPermission');
-  });
-
   afterEach(() => {
-    hasPermissionSpy.mockRestore();
     config.appSubUrl = originalAppSubUrl;
   });
 
-  it('renders the install CTA when the user has plugins:install', () => {
-    hasPermissionSpy.mockReturnValue(true);
-
+  it('renders the install CTA pointing at the plugin catalog', () => {
     render(
       <TestProvider>
         <AssistantOnboardingPage />
@@ -37,7 +28,6 @@ describe('AssistantOnboardingPage', () => {
   });
 
   it('prefixes the install link with appSubUrl for subpath deployments', () => {
-    hasPermissionSpy.mockReturnValue(true);
     config.appSubUrl = '/grafana';
 
     render(
@@ -48,18 +38,5 @@ describe('AssistantOnboardingPage', () => {
 
     const cta = screen.getByRole('link', { name: /install grafana assistant/i });
     expect(cta).toHaveAttribute('href', `/grafana/plugins/${ASSISTANT_PLUGIN_ID}`);
-  });
-
-  it('hides the install CTA and shows admin-help copy when the user lacks plugins:install', () => {
-    hasPermissionSpy.mockReturnValue(false);
-
-    render(
-      <TestProvider>
-        <AssistantOnboardingPage />
-      </TestProvider>
-    );
-
-    expect(screen.queryByRole('link', { name: /install grafana assistant/i })).not.toBeInTheDocument();
-    expect(screen.getByText(/ask a grafana administrator/i)).toBeVisible();
   });
 });

--- a/public/app/features/assistant-onboarding/AssistantOnboardingPage.test.tsx
+++ b/public/app/features/assistant-onboarding/AssistantOnboardingPage.test.tsx
@@ -1,12 +1,29 @@
 import { render, screen } from '@testing-library/react';
 import { TestProvider } from 'test/helpers/TestProvider';
 
+import { config } from '@grafana/runtime';
+import { contextSrv } from 'app/core/services/context_srv';
+
 import AssistantOnboardingPage from './AssistantOnboardingPage';
 
 const ASSISTANT_PLUGIN_ID = 'grafana-assistant-app';
 
 describe('AssistantOnboardingPage', () => {
-  it('renders the install CTA pointing at the plugin catalog', async () => {
+  let hasPermissionSpy: jest.SpyInstance;
+  const originalAppSubUrl = config.appSubUrl;
+
+  beforeEach(() => {
+    hasPermissionSpy = jest.spyOn(contextSrv, 'hasPermission');
+  });
+
+  afterEach(() => {
+    hasPermissionSpy.mockRestore();
+    config.appSubUrl = originalAppSubUrl;
+  });
+
+  it('renders the install CTA when the user has plugins:install', () => {
+    hasPermissionSpy.mockReturnValue(true);
+
     render(
       <TestProvider>
         <AssistantOnboardingPage />
@@ -17,5 +34,32 @@ describe('AssistantOnboardingPage', () => {
     expect(cta).toBeVisible();
     expect(cta).toHaveAttribute('href', `/plugins/${ASSISTANT_PLUGIN_ID}`);
     expect(screen.getByRole('heading', { name: /grafana assistant/i })).toBeVisible();
+  });
+
+  it('prefixes the install link with appSubUrl for subpath deployments', () => {
+    hasPermissionSpy.mockReturnValue(true);
+    config.appSubUrl = '/grafana';
+
+    render(
+      <TestProvider>
+        <AssistantOnboardingPage />
+      </TestProvider>
+    );
+
+    const cta = screen.getByRole('link', { name: /install grafana assistant/i });
+    expect(cta).toHaveAttribute('href', `/grafana/plugins/${ASSISTANT_PLUGIN_ID}`);
+  });
+
+  it('hides the install CTA and shows admin-help copy when the user lacks plugins:install', () => {
+    hasPermissionSpy.mockReturnValue(false);
+
+    render(
+      <TestProvider>
+        <AssistantOnboardingPage />
+      </TestProvider>
+    );
+
+    expect(screen.queryByRole('link', { name: /install grafana assistant/i })).not.toBeInTheDocument();
+    expect(screen.getByText(/ask a grafana administrator/i)).toBeVisible();
   });
 });

--- a/public/app/features/assistant-onboarding/AssistantOnboardingPage.test.tsx
+++ b/public/app/features/assistant-onboarding/AssistantOnboardingPage.test.tsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react';
+import { TestProvider } from 'test/helpers/TestProvider';
+
+import AssistantOnboardingPage from './AssistantOnboardingPage';
+
+const ASSISTANT_PLUGIN_ID = 'grafana-assistant-app';
+
+describe('AssistantOnboardingPage', () => {
+  it('renders the install CTA pointing at the plugin catalog', async () => {
+    render(
+      <TestProvider>
+        <AssistantOnboardingPage />
+      </TestProvider>
+    );
+
+    const cta = screen.getByRole('link', { name: /install grafana assistant/i });
+    expect(cta).toBeVisible();
+    expect(cta).toHaveAttribute('href', `/plugins/${ASSISTANT_PLUGIN_ID}`);
+    expect(screen.getByRole('heading', { name: /grafana assistant/i })).toBeVisible();
+  });
+});

--- a/public/app/features/assistant-onboarding/AssistantOnboardingPage.tsx
+++ b/public/app/features/assistant-onboarding/AssistantOnboardingPage.tsx
@@ -62,14 +62,7 @@ export default function AssistantOnboardingPage() {
         </header>
 
         <section className={styles.ctaSection}>
-          <LinkButton
-            href={INSTALL_PATH}
-            icon="plus-circle"
-            size="lg"
-            variant="primary"
-            onClick={onInstallClick}
-            className={styles.ctaButton}
-          >
+          <LinkButton href={INSTALL_PATH} icon="plus-circle" size="lg" variant="primary" onClick={onInstallClick}>
             <Trans i18nKey="assistant-onboarding.install-cta">Install Grafana Assistant</Trans>
           </LinkButton>
           <p className={styles.ctaSubnote}>
@@ -290,16 +283,11 @@ const getStyles = (theme: GrafanaTheme2) => ({
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
-    gap: theme.spacing(1.5),
+    gap: theme.spacing(2),
     marginBottom: theme.spacing(8),
   }),
-  ctaButton: css({
-    padding: `${theme.spacing(1.5)} ${theme.spacing(4)}`,
-    fontSize: '1.125rem',
-    height: 'auto',
-  }),
   ctaSubnote: css({
-    fontSize: theme.typography.bodySmall.fontSize,
+    fontSize: theme.typography.body.fontSize,
     color: theme.colors.text.secondary,
     margin: 0,
     textAlign: 'center',

--- a/public/app/features/assistant-onboarding/AssistantOnboardingPage.tsx
+++ b/public/app/features/assistant-onboarding/AssistantOnboardingPage.tsx
@@ -68,11 +68,11 @@ export default function AssistantOnboardingPage() {
           <p className={styles.ctaSubnote}>
             <Trans i18nKey="assistant-onboarding.subnote">
               Once installed, connect it to Grafana Cloud to get started.
-            </Trans>{' '}
-            <TextLink href={SELF_MANAGED_DOCS_URL} external>
-              <Trans i18nKey="assistant-onboarding.learn-how">Learn how</Trans>
-            </TextLink>
+            </Trans>
           </p>
+          <TextLink href={SELF_MANAGED_DOCS_URL} external>
+            <Trans i18nKey="assistant-onboarding.learn-how">Learn how</Trans>
+          </TextLink>
         </section>
 
         <section className={styles.learnMore}>

--- a/public/app/features/assistant-onboarding/AssistantOnboardingPage.tsx
+++ b/public/app/features/assistant-onboarding/AssistantOnboardingPage.tsx
@@ -1,0 +1,63 @@
+import { css } from '@emotion/css';
+
+import { type GrafanaTheme2 } from '@grafana/data';
+import { Trans } from '@grafana/i18n';
+import { reportInteraction } from '@grafana/runtime';
+import { Box, Icon, LinkButton, Stack, Text, useStyles2 } from '@grafana/ui';
+
+const ASSISTANT_PLUGIN_ID = 'grafana-assistant-app';
+const INSTALL_PATH = `/plugins/${ASSISTANT_PLUGIN_ID}`;
+
+export default function AssistantOnboardingPage() {
+  const styles = useStyles2(getStyles);
+
+  const onInstallClick = () => {
+    reportInteraction('assistant_onboarding_install_clicked', {
+      plugin_id: ASSISTANT_PLUGIN_ID,
+    });
+  };
+
+  return (
+    <Stack direction="column" alignItems="center" gap={4}>
+      <div className={styles.hero}>
+        <Icon name="ai-sparkle" size="xxxl" className={styles.heroIcon} />
+        <Text element="h1" textAlignment="center" variant="h1">
+          <Trans i18nKey="assistant-onboarding.heading">Grafana Assistant</Trans>
+        </Text>
+        <Text element="p" textAlignment="center" color="secondary" variant="body">
+          <Trans i18nKey="assistant-onboarding.description">
+            A purpose-built AI assistant for Grafana that helps you query metrics, investigate alerts, analyze logs and
+            traces, and navigate your data through natural language.
+          </Trans>
+        </Text>
+      </div>
+
+      <Box>
+        <LinkButton href={INSTALL_PATH} icon="plus-circle" size="lg" onClick={onInstallClick}>
+          <Trans i18nKey="assistant-onboarding.install-cta">Install Grafana Assistant</Trans>
+        </LinkButton>
+      </Box>
+
+      <Text element="p" color="secondary" variant="bodySmall">
+        <Trans i18nKey="assistant-onboarding.subnote">
+          The Assistant is delivered as a Grafana plugin. Once installed, you&apos;ll connect it to Grafana Cloud to get
+          started.
+        </Trans>
+      </Text>
+    </Stack>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  hero: css({
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: theme.spacing(2),
+    paddingTop: theme.spacing(6),
+    maxWidth: '640px',
+  }),
+  heroIcon: css({
+    color: theme.colors.primary.text,
+  }),
+});

--- a/public/app/features/assistant-onboarding/AssistantOnboardingPage.tsx
+++ b/public/app/features/assistant-onboarding/AssistantOnboardingPage.tsx
@@ -2,11 +2,12 @@ import { css } from '@emotion/css';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { reportInteraction } from '@grafana/runtime';
+import { config, reportInteraction } from '@grafana/runtime';
 import { LinkButton, TextLink, useStyles2 } from '@grafana/ui';
+import { contextSrv } from 'app/core/services/context_srv';
+import { AccessControlAction } from 'app/types/accessControl';
 
 const ASSISTANT_PLUGIN_ID = 'grafana-assistant-app';
-const INSTALL_PATH = `/plugins/${ASSISTANT_PLUGIN_ID}`;
 const DOCS_URL = 'https://grafana.com/docs/plugins/grafana-assistant-app/latest/';
 const BLOG_URL =
   'https://grafana.com/blog/2025/08/14/ai-for-grafana-onboarding-get-your-teams-started-quicker-with-grafana-assistant';
@@ -18,6 +19,10 @@ const BLOG_THUMB = 'https://a-us.storyblok.com/f/1022730/1200x630/78f2b37ebc/onb
 
 export default function AssistantOnboardingPage() {
   const styles = useStyles2(getStyles);
+  // Direct-URL access bypasses the nav-level gate, so the page itself has to branch on install permission.
+  // Without it we'd render an Install button the user cannot follow through on.
+  const canInstall = contextSrv.hasPermission(AccessControlAction.PluginsInstall);
+  const installPath = `${config.appSubUrl}/plugins/${ASSISTANT_PLUGIN_ID}`;
 
   const onInstallClick = () => {
     reportInteraction('assistant_onboarding_install_clicked', {
@@ -62,17 +67,27 @@ export default function AssistantOnboardingPage() {
         </header>
 
         <section className={styles.ctaSection}>
-          <LinkButton href={INSTALL_PATH} icon="plus-circle" size="lg" variant="primary" onClick={onInstallClick}>
-            <Trans i18nKey="assistant-onboarding.install-cta">Install Grafana Assistant</Trans>
-          </LinkButton>
-          <p className={styles.ctaSubnote}>
-            <Trans i18nKey="assistant-onboarding.subnote">
-              Once installed, connect it to Grafana Cloud to get started.
-            </Trans>
-          </p>
-          <TextLink href={SELF_MANAGED_DOCS_URL} external>
-            <Trans i18nKey="assistant-onboarding.learn-how">Learn how</Trans>
-          </TextLink>
+          {canInstall ? (
+            <>
+              <LinkButton href={installPath} icon="plus-circle" size="lg" variant="primary" onClick={onInstallClick}>
+                <Trans i18nKey="assistant-onboarding.install-cta">Install Grafana Assistant</Trans>
+              </LinkButton>
+              <p className={styles.ctaSubnote}>
+                <Trans i18nKey="assistant-onboarding.subnote">
+                  Once installed, connect it to Grafana Cloud to get started.
+                </Trans>
+              </p>
+              <TextLink href={SELF_MANAGED_DOCS_URL} external>
+                <Trans i18nKey="assistant-onboarding.learn-how">Learn how</Trans>
+              </TextLink>
+            </>
+          ) : (
+            <p className={styles.ctaSubnote}>
+              <Trans i18nKey="assistant-onboarding.no-permission">
+                Ask a Grafana administrator to install Grafana Assistant for your organization.
+              </Trans>
+            </p>
+          )}
         </section>
 
         <section className={styles.learnMore}>

--- a/public/app/features/assistant-onboarding/AssistantOnboardingPage.tsx
+++ b/public/app/features/assistant-onboarding/AssistantOnboardingPage.tsx
@@ -3,7 +3,7 @@ import { css } from '@emotion/css';
 import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
-import { LinkButton, useStyles2 } from '@grafana/ui';
+import { LinkButton, TextLink, useStyles2 } from '@grafana/ui';
 
 const ASSISTANT_PLUGIN_ID = 'grafana-assistant-app';
 const INSTALL_PATH = `/plugins/${ASSISTANT_PLUGIN_ID}`;
@@ -11,6 +11,7 @@ const DOCS_URL = 'https://grafana.com/docs/plugins/grafana-assistant-app/latest/
 const BLOG_URL =
   'https://grafana.com/blog/2025/08/14/ai-for-grafana-onboarding-get-your-teams-started-quicker-with-grafana-assistant';
 const VIDEO_URL = 'https://www.youtube.com/watch?v=UtZkFYUmjrM';
+const SELF_MANAGED_DOCS_URL = 'https://grafana.com/docs/grafana-cloud/machine-learning/assistant/self-managed/';
 const VIDEO_THUMB = 'https://img.youtube.com/vi/UtZkFYUmjrM/hqdefault.jpg';
 const DOCS_THUMB = 'https://grafana.com/meta-generator/Grafana+Assistant@@@cloud@@@1.png';
 const BLOG_THUMB = 'https://a-us.storyblok.com/f/1022730/1200x630/78f2b37ebc/onboarding-assistant-meta.png?w=1504';
@@ -73,8 +74,11 @@ export default function AssistantOnboardingPage() {
           </LinkButton>
           <p className={styles.ctaSubnote}>
             <Trans i18nKey="assistant-onboarding.subnote">
-              Delivered as a Grafana plugin. Once installed, connect it to Grafana Cloud to get started.
-            </Trans>
+              Once installed, connect it to Grafana Cloud to get started.
+            </Trans>{' '}
+            <TextLink href={SELF_MANAGED_DOCS_URL} external>
+              <Trans i18nKey="assistant-onboarding.learn-how">Learn how</Trans>
+            </TextLink>
           </p>
         </section>
 

--- a/public/app/features/assistant-onboarding/AssistantOnboardingPage.tsx
+++ b/public/app/features/assistant-onboarding/AssistantOnboardingPage.tsx
@@ -1,12 +1,19 @@
 import { css } from '@emotion/css';
 
 import { type GrafanaTheme2 } from '@grafana/data';
-import { Trans } from '@grafana/i18n';
+import { Trans, t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
-import { Box, Icon, LinkButton, Stack, Text, useStyles2 } from '@grafana/ui';
+import { LinkButton, useStyles2 } from '@grafana/ui';
 
 const ASSISTANT_PLUGIN_ID = 'grafana-assistant-app';
 const INSTALL_PATH = `/plugins/${ASSISTANT_PLUGIN_ID}`;
+const DOCS_URL = 'https://grafana.com/docs/plugins/grafana-assistant-app/latest/';
+const BLOG_URL =
+  'https://grafana.com/blog/2025/08/14/ai-for-grafana-onboarding-get-your-teams-started-quicker-with-grafana-assistant';
+const VIDEO_URL = 'https://www.youtube.com/watch?v=UtZkFYUmjrM';
+const VIDEO_THUMB = 'https://img.youtube.com/vi/UtZkFYUmjrM/hqdefault.jpg';
+const DOCS_THUMB = 'https://grafana.com/meta-generator/Grafana+Assistant@@@cloud@@@1.png';
+const BLOG_THUMB = 'https://a-us.storyblok.com/f/1022730/1200x630/78f2b37ebc/onboarding-assistant-meta.png?w=1504';
 
 export default function AssistantOnboardingPage() {
   const styles = useStyles2(getStyles);
@@ -18,46 +25,405 @@ export default function AssistantOnboardingPage() {
   };
 
   return (
-    <Stack direction="column" alignItems="center" gap={4}>
-      <div className={styles.hero}>
-        <Icon name="ai-sparkle" size="xxxl" className={styles.heroIcon} />
-        <Text element="h1" textAlignment="center" variant="h1">
-          <Trans i18nKey="assistant-onboarding.heading">Grafana Assistant</Trans>
-        </Text>
-        <Text element="p" textAlignment="center" color="secondary" variant="body">
-          <Trans i18nKey="assistant-onboarding.description">
-            A purpose-built AI assistant for Grafana that helps you query metrics, investigate alerts, analyze logs and
-            traces, and navigate your data through natural language.
-          </Trans>
-        </Text>
+    <div className={styles.container}>
+      <div className={styles.content}>
+        <header className={styles.header}>
+          <div className={styles.titleWithIcon}>
+            <svg className={styles.sparkleIcon} viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+              <path d="M12 0L14.59 8.41L23 11L14.59 13.59L12 22L9.41 13.59L1 11L9.41 8.41L12 0Z" fill="currentColor" />
+              <path
+                d="M19 3L20.5 7.5L25 9L20.5 10.5L19 15L17.5 10.5L13 9L17.5 7.5L19 3Z"
+                fill="currentColor"
+                opacity="0.6"
+              />
+              <path
+                d="M7 1L7.75 3.25L10 4L7.75 4.75L7 7L6.25 4.75L4 4L6.25 3.25L7 1Z"
+                fill="currentColor"
+                opacity="0.4"
+              />
+            </svg>
+            <div className={styles.titleText}>
+              <p className={styles.greeting}>
+                <Trans i18nKey="assistant-onboarding.greeting">Hi, I&apos;m</Trans>
+              </p>
+              <h1 className={styles.title}>
+                <Trans i18nKey="assistant-onboarding.heading">Grafana Assistant</Trans>
+              </h1>
+            </div>
+          </div>
+
+          <p className={styles.subtitle}>
+            <Trans i18nKey="assistant-onboarding.subtitle">
+              A purpose-built <span className={styles.magicText}>agentic LLM assistant</span> for Grafana that helps you
+              learn, investigate, make changes and more.
+            </Trans>
+          </p>
+        </header>
+
+        <section className={styles.ctaSection}>
+          <LinkButton
+            href={INSTALL_PATH}
+            icon="plus-circle"
+            size="lg"
+            variant="primary"
+            onClick={onInstallClick}
+            className={styles.ctaButton}
+          >
+            <Trans i18nKey="assistant-onboarding.install-cta">Install Grafana Assistant</Trans>
+          </LinkButton>
+          <p className={styles.ctaSubnote}>
+            <Trans i18nKey="assistant-onboarding.subnote">
+              Delivered as a Grafana plugin. Once installed, connect it to Grafana Cloud to get started.
+            </Trans>
+          </p>
+        </section>
+
+        <section className={styles.learnMore}>
+          <header className={styles.learnMoreHeader}>
+            <h2 className={styles.learnMoreTitle}>
+              <Trans i18nKey="assistant-onboarding.learn-more.title">Learn more</Trans>
+            </h2>
+            <p className={styles.learnMoreSubtitle}>
+              <Trans i18nKey="assistant-onboarding.learn-more.subtitle">
+                Explore tutorials, documentation, and best practices
+              </Trans>
+            </p>
+          </header>
+
+          <div className={styles.cards}>
+            <ResourceCard
+              styles={styles}
+              iconColor="#3B82F6"
+              icon={
+                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path
+                    d="M14 2H6C4.9 2 4 2.9 4 4V20C4 21.1 4.89 22 5.99 22H18C19.1 22 20 21.1 20 20V8L14 2ZM18 20H6V4H13V9H18V20Z"
+                    fill="currentColor"
+                  />
+                  <path d="M8 12H16V14H8V12ZM8 16H13V18H8V16Z" fill="currentColor" />
+                </svg>
+              }
+              title={t('assistant-onboarding.cards.docs.title', 'Documentation')}
+              description={t(
+                'assistant-onboarding.cards.docs.description',
+                'Setup guide and feature reference for getting started'
+              )}
+              linkText={t('assistant-onboarding.cards.docs.link', 'Read docs')}
+              href={DOCS_URL}
+              thumbnail={DOCS_THUMB}
+            />
+            <ResourceCard
+              styles={styles}
+              iconColor="#F59E0B"
+              icon={
+                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path
+                    d="M21 5C21 3.9 20.1 3 19 3H5C3.9 3 3 3.9 3 5V19C3 20.1 3.9 21 5 21H19C20.1 21 21 20.1 21 19V5ZM7 17V15H17V17H7ZM17 13H7V11H17V13ZM17 9H7V7H17V9Z"
+                    fill="currentColor"
+                  />
+                </svg>
+              }
+              title={t('assistant-onboarding.cards.blog.title', 'Blog & use cases')}
+              description={t(
+                'assistant-onboarding.cards.blog.description',
+                'Real-world examples and best practices for using Assistant'
+              )}
+              linkText={t('assistant-onboarding.cards.blog.link', 'Read blog')}
+              href={BLOG_URL}
+              thumbnail={BLOG_THUMB}
+            />
+            <ResourceCard
+              styles={styles}
+              iconColor="#EF4444"
+              icon={
+                <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M8 5V19L19 12L8 5Z" fill="currentColor" />
+                </svg>
+              }
+              title={t('assistant-onboarding.cards.video.title', 'Video demo')}
+              description={t(
+                'assistant-onboarding.cards.video.description',
+                'Watch a walkthrough of key features and capabilities'
+              )}
+              linkText={t('assistant-onboarding.cards.video.link', 'Watch video')}
+              href={VIDEO_URL}
+              thumbnail={VIDEO_THUMB}
+            />
+          </div>
+        </section>
       </div>
+    </div>
+  );
+}
 
-      <Box>
-        <LinkButton href={INSTALL_PATH} icon="plus-circle" size="lg" onClick={onInstallClick}>
-          <Trans i18nKey="assistant-onboarding.install-cta">Install Grafana Assistant</Trans>
-        </LinkButton>
-      </Box>
+interface ResourceCardProps {
+  styles: ReturnType<typeof getStyles>;
+  iconColor: string;
+  icon: React.ReactNode;
+  title: string;
+  description: string;
+  linkText: string;
+  href: string;
+  thumbnail: string;
+}
 
-      <Text element="p" color="secondary" variant="bodySmall">
-        <Trans i18nKey="assistant-onboarding.subnote">
-          The Assistant is delivered as a Grafana plugin. Once installed, you&apos;ll connect it to Grafana Cloud to get
-          started.
-        </Trans>
-      </Text>
-    </Stack>
+function ResourceCard({ styles, iconColor, icon, title, description, linkText, href, thumbnail }: ResourceCardProps) {
+  return (
+    <div className={styles.card}>
+      <div className={styles.cardIcon} style={{ backgroundColor: iconColor }}>
+        {icon}
+      </div>
+      <div className={styles.cardContent}>
+        <h3 className={styles.cardTitle}>{title}</h3>
+        <p className={styles.cardDescription}>{description}</p>
+        <a href={href} target="_blank" rel="noreferrer" className={styles.cardLink}>
+          {linkText}
+        </a>
+      </div>
+      <a href={href} target="_blank" rel="noreferrer" className={styles.cardThumbnail} aria-hidden="true" tabIndex={-1}>
+        <div className={styles.cardThumbnailImage} style={{ backgroundImage: `url(${thumbnail})` }} />
+      </a>
+    </div>
   );
 }
 
 const getStyles = (theme: GrafanaTheme2) => ({
-  hero: css({
+  container: css({
+    display: 'flex',
+    flexDirection: 'column',
+    height: '100%',
+    containerType: 'inline-size',
+    padding: theme.spacing(2),
+    alignItems: 'center',
+    '@container (min-width: 624px)': {
+      padding: theme.spacing(4),
+    },
+  }),
+  content: css({
+    maxWidth: '900px',
+    width: '100%',
+  }),
+  header: css({
+    textAlign: 'center',
+    marginBottom: theme.spacing(4),
     display: 'flex',
     flexDirection: 'column',
     alignItems: 'center',
     gap: theme.spacing(2),
-    paddingTop: theme.spacing(6),
-    maxWidth: '640px',
   }),
-  heroIcon: css({
-    color: theme.colors.primary.text,
+  titleWithIcon: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(0),
+  }),
+  titleText: css({
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+  }),
+  greeting: css({
+    fontSize: '1.2rem',
+    color: theme.colors.text.secondary,
+    marginBottom: 0,
+  }),
+  title: css({
+    fontSize: '2.5rem',
+    fontWeight: 600,
+    color: theme.colors.text.primary,
+    margin: 0,
+    '@container (min-width: 624px)': {
+      fontSize: '3rem',
+    },
+  }),
+  sparkleIcon: css({
+    width: '48px',
+    height: '48px',
+    color: theme.colors.text.primary,
+    filter: 'drop-shadow(0 2px 4px rgba(0, 0, 0, 0.1))',
+    [theme.transitions.handleMotion('no-preference')]: {
+      animation: 'sparkle 10s ease-in-out infinite',
+    },
+    '@keyframes sparkle': {
+      '0%, 100%': {
+        transform: 'rotate(0deg) scale(1)',
+        opacity: 0.8,
+      },
+      '50%': {
+        transform: 'rotate(5deg) scale(1.05)',
+        opacity: 1,
+      },
+    },
+  }),
+  subtitle: css({
+    fontSize: '1.25rem',
+    color: theme.colors.text.secondary,
+    lineHeight: 1.6,
+    maxWidth: '700px',
+    margin: '0 auto',
+    padding: `0 ${theme.spacing(2)}`,
+    '@container (min-width: 624px)': {
+      fontSize: '1.5rem',
+      padding: 0,
+    },
+  }),
+  magicText: css({
+    background: 'linear-gradient(45deg, #A855F7, #F97316, #A855F7, #F97316)',
+    backgroundSize: '300% 300%',
+    backgroundClip: 'text',
+    WebkitBackgroundClip: 'text',
+    WebkitTextFillColor: 'transparent',
+    fontWeight: 'bold',
+    display: 'inline-block',
+    [theme.transitions.handleMotion('no-preference')]: {
+      animation: 'gradientShift 15s ease-in-out infinite',
+    },
+    '@keyframes gradientShift': {
+      '0%, 100%': { backgroundPosition: '0% 50%' },
+      '50%': { backgroundPosition: '100% 50%' },
+    },
+  }),
+  ctaSection: css({
+    display: 'flex',
+    flexDirection: 'column',
+    alignItems: 'center',
+    gap: theme.spacing(1.5),
+    marginBottom: theme.spacing(8),
+  }),
+  ctaButton: css({
+    padding: `${theme.spacing(1.5)} ${theme.spacing(4)}`,
+    fontSize: '1.125rem',
+    height: 'auto',
+  }),
+  ctaSubnote: css({
+    fontSize: theme.typography.bodySmall.fontSize,
+    color: theme.colors.text.secondary,
+    margin: 0,
+    textAlign: 'center',
+    maxWidth: '480px',
+  }),
+  learnMore: css({
+    padding: theme.spacing(2),
+  }),
+  learnMoreHeader: css({
+    marginBottom: theme.spacing(3),
+    textAlign: 'left',
+  }),
+  learnMoreTitle: css({
+    fontSize: '28px',
+    fontWeight: 700,
+    background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+    backgroundClip: 'text',
+    WebkitBackgroundClip: 'text',
+    WebkitTextFillColor: 'transparent',
+    margin: `0 0 ${theme.spacing(1)} 0`,
+    letterSpacing: '-0.02em',
+  }),
+  learnMoreSubtitle: css({
+    fontSize: '16px',
+    color: theme.colors.text.secondary,
+    margin: 0,
+    lineHeight: 1.5,
+    maxWidth: '600px',
+  }),
+  cards: css({
+    display: 'grid',
+    gridTemplateColumns: '1fr',
+    gap: theme.spacing(2),
+    '@container (min-width: 768px)': {
+      gap: theme.spacing(4),
+    },
+  }),
+  card: css({
+    padding: theme.spacing(4),
+    backgroundColor: theme.colors.background.primary,
+    border: `1px solid ${theme.colors.border.weak}`,
+    borderRadius: theme.shape.radius.lg,
+    textAlign: 'left',
+    boxShadow: `
+      0 8px 32px rgba(0, 0, 0, 0.12),
+      0 2px 8px rgba(0, 0, 0, 0.08),
+      inset 0 1px 0 rgba(255, 255, 255, 0.1)
+    `,
+    [theme.transitions.handleMotion('no-preference')]: {
+      transition: 'all 0.3s ease',
+    },
+    display: 'flex',
+    gap: theme.spacing(3),
+    alignItems: 'flex-start',
+    '&:hover': {
+      boxShadow: `
+        0 12px 40px rgba(0, 0, 0, 0.15),
+        0 4px 16px rgba(0, 0, 0, 0.1),
+        inset 0 1px 0 rgba(255, 255, 255, 0.15)
+      `,
+    },
+  }),
+  cardIcon: css({
+    width: '56px',
+    height: '56px',
+    borderRadius: theme.shape.radius.default,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    color: 'white',
+    flexShrink: 0,
+    '& svg': {
+      width: '28px',
+      height: '28px',
+    },
+  }),
+  cardContent: css({
+    flex: 1,
+    display: 'flex',
+    flexDirection: 'column',
+  }),
+  cardTitle: css({
+    fontSize: '20px',
+    fontWeight: 600,
+    color: theme.colors.text.primary,
+    margin: `0 0 ${theme.spacing(1)} 0`,
+    letterSpacing: '-0.01em',
+  }),
+  cardDescription: css({
+    fontSize: '15px',
+    color: theme.colors.text.secondary,
+    margin: `0 0 ${theme.spacing(2)} 0`,
+    lineHeight: 1.5,
+  }),
+  cardLink: css({
+    display: 'inline-flex',
+    alignItems: 'center',
+    alignSelf: 'flex-start',
+    padding: theme.spacing(0.5, 1),
+    color: theme.colors.text.link,
+    border: `1px solid ${theme.colors.text.link}`,
+    borderRadius: theme.shape.radius.default,
+    textDecoration: 'none',
+    fontWeight: 600,
+    fontSize: '12px',
+    [theme.transitions.handleMotion('no-preference')]: {
+      transition: 'all 0.2s ease',
+    },
+    '&:hover': {
+      backgroundColor: theme.colors.text.link,
+      color: theme.colors.background.primary,
+    },
+  }),
+  cardThumbnail: css({
+    display: 'none',
+    '@container (min-width: 640px)': {
+      display: 'block',
+      width: '120px',
+      height: '70px',
+      borderRadius: theme.shape.radius.default,
+      overflow: 'hidden',
+      flexShrink: 0,
+    },
+  }),
+  cardThumbnailImage: css({
+    width: '100%',
+    height: '100%',
+    backgroundSize: 'cover',
+    backgroundPosition: 'center',
   }),
 });

--- a/public/app/features/assistant-onboarding/AssistantOnboardingPage.tsx
+++ b/public/app/features/assistant-onboarding/AssistantOnboardingPage.tsx
@@ -4,8 +4,6 @@ import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config, reportInteraction } from '@grafana/runtime';
 import { LinkButton, TextLink, useStyles2 } from '@grafana/ui';
-import { contextSrv } from 'app/core/services/context_srv';
-import { AccessControlAction } from 'app/types/accessControl';
 
 const ASSISTANT_PLUGIN_ID = 'grafana-assistant-app';
 const DOCS_URL = 'https://grafana.com/docs/plugins/grafana-assistant-app/latest/';
@@ -19,9 +17,6 @@ const BLOG_THUMB = 'https://a-us.storyblok.com/f/1022730/1200x630/78f2b37ebc/onb
 
 export default function AssistantOnboardingPage() {
   const styles = useStyles2(getStyles);
-  // Direct-URL access bypasses the nav-level gate, so the page itself has to branch on install permission.
-  // Without it we'd render an Install button the user cannot follow through on.
-  const canInstall = contextSrv.hasPermission(AccessControlAction.PluginsInstall);
   const installPath = `${config.appSubUrl}/plugins/${ASSISTANT_PLUGIN_ID}`;
 
   const onInstallClick = () => {
@@ -67,27 +62,17 @@ export default function AssistantOnboardingPage() {
         </header>
 
         <section className={styles.ctaSection}>
-          {canInstall ? (
-            <>
-              <LinkButton href={installPath} icon="plus-circle" size="lg" variant="primary" onClick={onInstallClick}>
-                <Trans i18nKey="assistant-onboarding.install-cta">Install Grafana Assistant</Trans>
-              </LinkButton>
-              <p className={styles.ctaSubnote}>
-                <Trans i18nKey="assistant-onboarding.subnote">
-                  Once installed, connect it to Grafana Cloud to get started.
-                </Trans>
-              </p>
-              <TextLink href={SELF_MANAGED_DOCS_URL} external>
-                <Trans i18nKey="assistant-onboarding.learn-how">Learn how</Trans>
-              </TextLink>
-            </>
-          ) : (
-            <p className={styles.ctaSubnote}>
-              <Trans i18nKey="assistant-onboarding.no-permission">
-                Ask a Grafana administrator to install Grafana Assistant for your organization.
-              </Trans>
-            </p>
-          )}
+          <LinkButton href={installPath} icon="plus-circle" size="lg" variant="primary" onClick={onInstallClick}>
+            <Trans i18nKey="assistant-onboarding.install-cta">Install Grafana Assistant</Trans>
+          </LinkButton>
+          <p className={styles.ctaSubnote}>
+            <Trans i18nKey="assistant-onboarding.subnote">
+              Once installed, connect it to Grafana Cloud to get started.
+            </Trans>
+          </p>
+          <TextLink href={SELF_MANAGED_DOCS_URL} external>
+            <Trans i18nKey="assistant-onboarding.learn-how">Learn how</Trans>
+          </TextLink>
         </section>
 
         <section className={styles.learnMore}>

--- a/public/app/features/plugins/components/AppRootPage.test.tsx
+++ b/public/app/features/plugins/components/AppRootPage.test.tsx
@@ -19,6 +19,7 @@ import { pluginImporter } from '../importer/pluginImporter';
 import { getPluginSettings } from '../pluginSettings';
 
 import AppRootPage from './AppRootPage';
+import { pluginNavFallbacks } from './pluginNavFallbacks';
 
 jest.mock('../pluginSettings', () => ({
   getPluginSettings: jest.fn(),
@@ -151,6 +152,24 @@ describe('AppRootPage', () => {
     // Renders once for the first time
     renderUnderRouter();
     expect(await screen.findByText('App not found')).toBeVisible();
+  });
+
+  it('renders a registered nav fallback component when a known plugin fails to load', async () => {
+    jest.spyOn(console, 'error').mockImplementation();
+    getPluginSettingsMock.mockRejectedValue(new Error('Unknown Plugin'));
+
+    // Inject a fallback for the pluginId the renderUnderRouter helper uses, then restore.
+    const FALLBACK_TEXT = 'fallback-onboarding-page';
+    const Fallback = () => <div>{FALLBACK_TEXT}</div>;
+    pluginNavFallbacks['my-awesome-plugin'] = Fallback;
+
+    try {
+      renderUnderRouter();
+      expect(await screen.findByText(FALLBACK_TEXT)).toBeVisible();
+      expect(screen.queryByText('App not found')).not.toBeInTheDocument();
+    } finally {
+      delete pluginNavFallbacks['my-awesome-plugin'];
+    }
   });
 
   it('should not render the component if we are not under a plugin path', async () => {

--- a/public/app/features/plugins/components/AppRootPage.test.tsx
+++ b/public/app/features/plugins/components/AppRootPage.test.tsx
@@ -9,6 +9,7 @@ import { setEchoSrv } from '@grafana/runtime';
 import { GrafanaRouteWrapper } from 'app/core/navigation/GrafanaRoute';
 import { contextSrv } from 'app/core/services/context_srv';
 import { Echo } from 'app/core/services/echo/Echo';
+import { AccessControlAction } from 'app/types/accessControl';
 
 import { ExtensionRegistriesProvider } from '../extensions/ExtensionRegistriesContext';
 import { AddedComponentsRegistry } from '../extensions/registry/AddedComponentsRegistry';
@@ -138,6 +139,13 @@ describe('AppRootPage', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     setEchoSrv(new Echo());
+    // Default: user can install plugins. Specific tests override this to exercise the unauthorized
+    // path where fallbacks should NOT render.
+    contextSrv.user.permissions = { [AccessControlAction.PluginsInstall]: true };
+  });
+
+  afterEach(() => {
+    contextSrv.user.permissions = {};
   });
 
   const pluginMeta = getMockPlugin({
@@ -205,6 +213,27 @@ describe('AppRootPage', () => {
 
     try {
       renderUnderRouter();
+      expect(await screen.findByText('App not found')).toBeVisible();
+      expect(screen.queryByText(FALLBACK_TEXT)).not.toBeInTheDocument();
+    } finally {
+      delete pluginNavFallbacks['my-awesome-plugin'];
+    }
+  });
+
+  it('does NOT render the fallback when the user lacks plugins:install', async () => {
+    jest.spyOn(console, 'error').mockImplementation();
+    getPluginSettingsMock.mockRejectedValue(fetchError(404));
+    contextSrv.user.permissions = {};
+
+    const FALLBACK_TEXT = 'fallback-onboarding-page';
+    const Fallback = () => <div>{FALLBACK_TEXT}</div>;
+    pluginNavFallbacks['my-awesome-plugin'] = Fallback;
+
+    try {
+      renderUnderRouter();
+      // Without install permission, the fallback's "go install" CTA would be useless. Standardize
+      // on the existing not-found UI for unauthorized users — same as every other unavailable
+      // plugin URL in Grafana.
       expect(await screen.findByText('App not found')).toBeVisible();
       expect(screen.queryByText(FALLBACK_TEXT)).not.toBeInTheDocument();
     } finally {

--- a/public/app/features/plugins/components/AppRootPage.test.tsx
+++ b/public/app/features/plugins/components/AppRootPage.test.tsx
@@ -172,6 +172,32 @@ describe('AppRootPage', () => {
     }
   });
 
+  it('suppresses the backend auto-toast for plugins with a registered fallback', async () => {
+    jest.spyOn(console, 'error').mockImplementation();
+    getPluginSettingsMock.mockRejectedValue(new Error('Unknown Plugin'));
+
+    const Fallback = () => <div>fallback</div>;
+    pluginNavFallbacks['my-awesome-plugin'] = Fallback;
+
+    try {
+      renderUnderRouter();
+      await screen.findByText('fallback');
+      expect(getPluginSettingsMock).toHaveBeenCalledWith('my-awesome-plugin', { showErrorAlert: false });
+    } finally {
+      delete pluginNavFallbacks['my-awesome-plugin'];
+    }
+  });
+
+  it('does NOT suppress the backend auto-toast for plugins without a registered fallback', async () => {
+    jest.spyOn(console, 'error').mockImplementation();
+    getPluginSettingsMock.mockRejectedValue(new Error('Unknown Plugin'));
+
+    renderUnderRouter();
+    await screen.findByText('App not found');
+    // No fallback for "my-awesome-plugin" → second arg should be undefined so the auto-toast still fires.
+    expect(getPluginSettingsMock).toHaveBeenCalledWith('my-awesome-plugin', undefined);
+  });
+
   it('should not render the component if we are not under a plugin path', async () => {
     getPluginSettingsMock.mockResolvedValue(pluginMeta);
 

--- a/public/app/features/plugins/components/AppRootPage.test.tsx
+++ b/public/app/features/plugins/components/AppRootPage.test.tsx
@@ -146,6 +146,10 @@ describe('AppRootPage', () => {
     enabled: true,
   });
 
+  // Shape that matches isFetchError ({ status, data, ... }). We rely on this rather than a plain Error
+  // so the production code can differentiate "plugin not installed" (404) from real backend failures.
+  const fetchError = (status: number) => ({ status, data: { message: `status ${status}` } });
+
   it("should show a not found page if the plugin settings can't load", async () => {
     jest.spyOn(console, 'error').mockImplementation();
     getPluginSettingsMock.mockRejectedValue(new Error('Unknown Plugin'));
@@ -154,9 +158,9 @@ describe('AppRootPage', () => {
     expect(await screen.findByText('App not found')).toBeVisible();
   });
 
-  it('renders a registered nav fallback component when a known plugin fails to load', async () => {
+  it('renders a registered nav fallback component when settings returns 404', async () => {
     jest.spyOn(console, 'error').mockImplementation();
-    getPluginSettingsMock.mockRejectedValue(new Error('Unknown Plugin'));
+    getPluginSettingsMock.mockRejectedValue(fetchError(404));
 
     // Inject a fallback for the pluginId the renderUnderRouter helper uses, then restore.
     const FALLBACK_TEXT = 'fallback-onboarding-page';
@@ -172,9 +176,64 @@ describe('AppRootPage', () => {
     }
   });
 
+  it('does NOT render the fallback when settings returns 5xx (real backend failure)', async () => {
+    jest.spyOn(console, 'error').mockImplementation();
+    getPluginSettingsMock.mockRejectedValue(fetchError(500));
+
+    const FALLBACK_TEXT = 'fallback-onboarding-page';
+    const Fallback = () => <div>{FALLBACK_TEXT}</div>;
+    pluginNavFallbacks['my-awesome-plugin'] = Fallback;
+
+    try {
+      renderUnderRouter();
+      // 500 is a real failure, not "plugin not installed" — show the not-found UI rather than the
+      // onboarding stub, so the user knows something went wrong.
+      expect(await screen.findByText('App not found')).toBeVisible();
+      expect(screen.queryByText(FALLBACK_TEXT)).not.toBeInTheDocument();
+    } finally {
+      delete pluginNavFallbacks['my-awesome-plugin'];
+    }
+  });
+
+  it('does NOT render the fallback when settings returns 403', async () => {
+    jest.spyOn(console, 'error').mockImplementation();
+    getPluginSettingsMock.mockRejectedValue(fetchError(403));
+
+    const FALLBACK_TEXT = 'fallback-onboarding-page';
+    const Fallback = () => <div>{FALLBACK_TEXT}</div>;
+    pluginNavFallbacks['my-awesome-plugin'] = Fallback;
+
+    try {
+      renderUnderRouter();
+      expect(await screen.findByText('App not found')).toBeVisible();
+      expect(screen.queryByText(FALLBACK_TEXT)).not.toBeInTheDocument();
+    } finally {
+      delete pluginNavFallbacks['my-awesome-plugin'];
+    }
+  });
+
+  it('does NOT render the fallback when the error is not a FetchError (e.g. import failure)', async () => {
+    jest.spyOn(console, 'error').mockImplementation();
+    // A plain Error stands in for an unexpected throw, e.g. pluginImporter.importApp blowing up.
+    // No HTTP status → can't be a 404 → we should not silently morph this into onboarding.
+    getPluginSettingsMock.mockRejectedValue(new Error('boom'));
+
+    const FALLBACK_TEXT = 'fallback-onboarding-page';
+    const Fallback = () => <div>{FALLBACK_TEXT}</div>;
+    pluginNavFallbacks['my-awesome-plugin'] = Fallback;
+
+    try {
+      renderUnderRouter();
+      expect(await screen.findByText('App not found')).toBeVisible();
+      expect(screen.queryByText(FALLBACK_TEXT)).not.toBeInTheDocument();
+    } finally {
+      delete pluginNavFallbacks['my-awesome-plugin'];
+    }
+  });
+
   it('suppresses the backend auto-toast for plugins with a registered fallback', async () => {
     jest.spyOn(console, 'error').mockImplementation();
-    getPluginSettingsMock.mockRejectedValue(new Error('Unknown Plugin'));
+    getPluginSettingsMock.mockRejectedValue(fetchError(404));
 
     const Fallback = () => <div>fallback</div>;
     pluginNavFallbacks['my-awesome-plugin'] = Fallback;

--- a/public/app/features/plugins/components/AppRootPage.tsx
+++ b/public/app/features/plugins/components/AppRootPage.tsx
@@ -15,7 +15,7 @@ import {
   PluginContextProvider,
 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import { config, locationSearchToObject } from '@grafana/runtime';
+import { config, isFetchError, locationSearchToObject } from '@grafana/runtime';
 import { getLogger } from '@grafana/runtime/unstable';
 import { Alert, ErrorWithStack } from '@grafana/ui';
 import { appEvents } from 'app/core/app_events';
@@ -54,6 +54,11 @@ interface Props {
 interface State {
   loading: boolean;
   loadingError: boolean;
+  // HTTP status from a settings fetch failure, if any. Only a 404 is interpreted as "plugin is not
+  // installed" and triggers a registered fallback; other failures (401/403/5xx/network/import) keep
+  // the existing not-found UI and re-emit a user-facing alert so backend errors don't silently
+  // morph into the onboarding stub.
+  errorStatus?: number;
   plugin?: AppPlugin | null;
   // Used to display a tab navigation (used before the new Top Nav)
   pluginNav: NavModel | null;
@@ -71,7 +76,7 @@ export function AppRootPage({ pluginId, pluginNavSection }: Props) {
   const location = useLocation();
   const [state, dispatch] = useReducer(stateSlice.reducer, initialState);
   const currentUrl = config.appSubUrl + location.pathname + location.search;
-  const { plugin, loading, loadingError, pluginNav } = state;
+  const { plugin, loading, loadingError, errorStatus, pluginNav } = state;
   const navModel = buildPluginSectionNav(currentUrl, pluginNavSection);
   const queryParams = useMemo(() => locationSearchToObject(location.search), [location.search]);
   const context = useMemo(() => buildPluginPageContext(navModel), [navModel]);
@@ -89,7 +94,11 @@ export function AppRootPage({ pluginId, pluginNavSection }: Props) {
   if (!plugin || pluginId !== plugin.meta.id) {
     // Use current layout while loading to reduce flickering
     const currentLayout = grafanaContext.chrome.state.getValue().layout;
-    const FallbackComponent = !loading && loadingError ? pluginNavFallbacks[pluginId] : undefined;
+    // Only render a registered fallback when the settings fetch returned 404 — that is the genuine
+    // "plugin is not installed" signal. Other failures (auth, server, import) keep the not-found UI
+    // and the user gets a real toast (re-emitted in loadAppPlugin's catch).
+    const FallbackComponent =
+      !loading && loadingError && errorStatus === 404 ? pluginNavFallbacks[pluginId] : undefined;
     return (
       <Page navModel={navModel} pageNav={{ text: '' }} layout={currentLayout}>
         {loading && <PageLoader />}
@@ -235,10 +244,10 @@ const stateSlice = createSlice({
 });
 
 async function loadAppPlugin(pluginId: string, dispatch: React.Dispatch<AnyAction>) {
-  // For plugins with a registered nav fallback, the dummy fallback component IS the inline error UI,
-  // so the backend's auto-toast on 404 ("Plugin not found, no installed plugin with that id") is just
-  // redundant noise. Suppressing it follows the same pattern Login uses (showErrorAlert: false +
-  // surface errors inline). Genuine failures still hit the catch below and log to console / Faro.
+  // For plugins with a registered nav fallback, the dummy fallback component IS the inline error UI
+  // for the "plugin is not installed" (404) case, so the backend's auto-toast there is just redundant
+  // noise. Suppressing it follows the same pattern Login uses. Failures other than 404 are NOT silent
+  // — we re-emit the alert from the catch block so backend errors still surface to the user.
   const hasFallback = pluginNavFallbacks[pluginId] !== undefined;
   const settingsRequestOptions = hasFallback ? { showErrorAlert: false } : undefined;
   try {
@@ -251,13 +260,29 @@ async function loadAppPlugin(pluginId: string, dispatch: React.Dispatch<AnyActio
       }
       return pluginImporter.importApp(info);
     });
-    dispatch(stateSlice.actions.setState({ plugin: app, loading: false, loadingError: false, pluginNav: null }));
+    dispatch(
+      stateSlice.actions.setState({
+        plugin: app,
+        loading: false,
+        loadingError: false,
+        errorStatus: undefined,
+        pluginNav: null,
+      })
+    );
   } catch (err) {
+    const errorStatus = isFetchError(err) ? err.status : undefined;
+    // We suppressed the auto-toast assuming a 404. Anything else (401/403/5xx, network, import error)
+    // must still produce a user-visible alert — otherwise a real backend failure silently morphs into
+    // the onboarding fallback and the user has no idea why nothing works.
+    if (hasFallback && errorStatus !== 404) {
+      appEvents.emit(AppEvents.alertError, [getMessageFromError(err)]);
+    }
     dispatch(
       stateSlice.actions.setState({
         plugin: null,
         loading: false,
         loadingError: true,
+        errorStatus,
         pluginNav: process.env.NODE_ENV === 'development' ? getExceptionNav(err) : getNotFoundNav(),
       })
     );

--- a/public/app/features/plugins/components/AppRootPage.tsx
+++ b/public/app/features/plugins/components/AppRootPage.tsx
@@ -1,6 +1,6 @@
 // Libraries
 import { type AnyAction, createSlice, type PayloadAction } from '@reduxjs/toolkit';
-import { useCallback, useEffect, useMemo, useReducer } from 'react';
+import { Suspense, useCallback, useEffect, useMemo, useReducer } from 'react';
 import * as React from 'react';
 import { useLocation, useParams } from 'react-router-dom-v5-compat';
 
@@ -40,6 +40,7 @@ import { buildPluginSectionNav } from '../utils';
 
 import { PluginErrorBoundary } from './PluginErrorBoundary';
 import { buildPluginPageContext, PluginPageContext } from './PluginPageContext';
+import { pluginNavFallbacks } from './pluginNavFallbacks';
 import { RestrictedGrafanaApisProvider } from './restrictedGrafanaApis/RestrictedGrafanaApisProvider';
 
 interface Props {
@@ -88,10 +89,16 @@ export function AppRootPage({ pluginId, pluginNavSection }: Props) {
   if (!plugin || pluginId !== plugin.meta.id) {
     // Use current layout while loading to reduce flickering
     const currentLayout = grafanaContext.chrome.state.getValue().layout;
+    const FallbackComponent = !loading && loadingError ? pluginNavFallbacks[pluginId] : undefined;
     return (
       <Page navModel={navModel} pageNav={{ text: '' }} layout={currentLayout}>
         {loading && <PageLoader />}
-        {!loading && loadingError && <EntityNotFound entity="App" />}
+        {!loading && loadingError && FallbackComponent && (
+          <Suspense fallback={<PageLoader />}>
+            <FallbackComponent />
+          </Suspense>
+        )}
+        {!loading && loadingError && !FallbackComponent && <EntityNotFound entity="App" />}
       </Page>
     );
   }

--- a/public/app/features/plugins/components/AppRootPage.tsx
+++ b/public/app/features/plugins/components/AppRootPage.tsx
@@ -26,6 +26,7 @@ import { useGrafana } from 'app/core/context/GrafanaContext';
 import { getNotFoundNav, getWarningNav, getExceptionNav } from 'app/core/navigation/errorModels';
 import { contextSrv } from 'app/core/services/context_srv';
 import { getMessageFromError } from 'app/core/utils/errors';
+import { AccessControlAction } from 'app/types/accessControl';
 
 import {
   ExtensionRegistriesProvider,
@@ -97,8 +98,13 @@ export function AppRootPage({ pluginId, pluginNavSection }: Props) {
     // Only render a registered fallback when the settings fetch returned 404 — that is the genuine
     // "plugin is not installed" signal. Other failures (auth, server, import) keep the not-found UI
     // and the user gets a real toast (re-emitted in loadAppPlugin's catch).
+    //
+    // Also gate on plugins:install. Fallbacks are conceptually onboarding screens that direct the
+    // user to install; for users without that permission we fall through to the standard not-found
+    // UI so this matches how every other unavailable plugin URL behaves in Grafana.
+    const canInstallPlugins = contextSrv.hasPermission(AccessControlAction.PluginsInstall);
     const FallbackComponent =
-      !loading && loadingError && errorStatus === 404 ? pluginNavFallbacks[pluginId] : undefined;
+      !loading && loadingError && errorStatus === 404 && canInstallPlugins ? pluginNavFallbacks[pluginId] : undefined;
     return (
       <Page navModel={navModel} pageNav={{ text: '' }} layout={currentLayout}>
         {loading && <PageLoader />}

--- a/public/app/features/plugins/components/AppRootPage.tsx
+++ b/public/app/features/plugins/components/AppRootPage.tsx
@@ -235,8 +235,14 @@ const stateSlice = createSlice({
 });
 
 async function loadAppPlugin(pluginId: string, dispatch: React.Dispatch<AnyAction>) {
+  // For plugins with a registered nav fallback, the dummy fallback component IS the inline error UI,
+  // so the backend's auto-toast on 404 ("Plugin not found, no installed plugin with that id") is just
+  // redundant noise. Suppressing it follows the same pattern Login uses (showErrorAlert: false +
+  // surface errors inline). Genuine failures still hit the catch below and log to console / Faro.
+  const hasFallback = pluginNavFallbacks[pluginId] !== undefined;
+  const settingsRequestOptions = hasFallback ? { showErrorAlert: false } : undefined;
   try {
-    const app = await getPluginSettings(pluginId).then((info) => {
+    const app = await getPluginSettings(pluginId, settingsRequestOptions).then((info) => {
       const error = getAppPluginPageError(info);
       if (error) {
         appEvents.emit(AppEvents.alertError, [error]);

--- a/public/app/features/plugins/components/pluginNavFallbacks.tsx
+++ b/public/app/features/plugins/components/pluginNavFallbacks.tsx
@@ -1,0 +1,12 @@
+import { type ComponentType, lazy } from 'react';
+
+// Map of pluginId -> core React component to render when AppRootPage tries to load the plugin and fails
+// (typically because the plugin isn't installed). Lets a known plugin's nav slot stay at its canonical
+// /a/<pluginId> URL across install states — the URL is constant, only the renderer differs.
+//
+// Add an entry only when there is a corresponding navtree contribution that puts /a/<pluginId> in the
+// sidebar even when the plugin isn't installed (see e.g. assistantStubNav). Without that, the fallback
+// is unreachable from the nav.
+export const pluginNavFallbacks: Record<string, ComponentType> = {
+  'grafana-assistant-app': lazy(() => import('app/features/assistant-onboarding/AssistantOnboardingPage')),
+};

--- a/public/app/features/plugins/pluginSettings.test.ts
+++ b/public/app/features/plugins/pluginSettings.test.ts
@@ -115,11 +115,21 @@ describe('PluginSettings', () => {
     expect(getRequestSpy).toHaveBeenCalledTimes(2);
   });
 
-  it('should reject with Unknown Plugin message if error status is not 403 or 401', async () => {
+  it('should preserve a 404 FetchError shape so callers can discriminate "plugin not installed"', async () => {
     const error = { status: 404, message: 'Not found' };
     jest.spyOn(getBackendSrv(), 'get').mockRejectedValue(error);
 
-    await expect(getPluginSettings('test')).rejects.toEqual(new Error('Unknown Plugin'));
+    // The previous behaviour wrapped 404 in `new Error('Unknown Plugin')`, which discarded the status
+    // and prevented downstream code (e.g. AppRootPage's onboarding fallback) from telling a 404 apart
+    // from a real backend failure.
+    await expect(getPluginSettings('test')).rejects.toEqual(error);
+  });
+
+  it('should preserve a 5xx FetchError shape (no isHandled mark)', async () => {
+    const error = { status: 500, message: 'Internal Server Error' };
+    jest.spyOn(getBackendSrv(), 'get').mockRejectedValue(error);
+
+    await expect(getPluginSettings('test')).rejects.toEqual(error);
   });
 
   it('should reject thrown error if error status is 403', async () => {
@@ -134,5 +144,13 @@ describe('PluginSettings', () => {
     jest.spyOn(getBackendSrv(), 'get').mockRejectedValue(error);
 
     await expect(getPluginSettings('test')).rejects.toEqual({ ...error, isHandled: true });
+  });
+
+  it('should fall back to the opaque "Unknown Plugin" Error for status-less rejections', async () => {
+    // Network error / JSON parse failure / similar — no status field. Keep the legacy shape so
+    // pre-existing callers that don't read status keep working.
+    jest.spyOn(getBackendSrv(), 'get').mockRejectedValue(new TypeError('NetworkError'));
+
+    await expect(getPluginSettings('test')).rejects.toEqual(new Error('Unknown Plugin'));
   });
 });

--- a/public/app/features/plugins/pluginSettings.ts
+++ b/public/app/features/plugins/pluginSettings.ts
@@ -19,12 +19,17 @@ export function getPluginSettings(pluginId: string, options?: Partial<BackendSrv
       return settings;
     })
     .catch((e) => {
-      // User does not have access to plugin
-      if (typeof e === 'object' && e !== null && 'status' in e && (e.status === 403 || e.status === 401)) {
-        e.isHandled = true;
+      // Preserve the FetchError shape (status, data, ...) so callers can discriminate by status —
+      // e.g. AppRootPage only renders the onboarding fallback for a genuine 404, not for 5xx/auth.
+      // 401/403 are also marked isHandled so the caller knows the auto-toast already fired.
+      if (typeof e === 'object' && e !== null && 'status' in e) {
+        if (e.status === 403 || e.status === 401) {
+          e.isHandled = true;
+        }
         return Promise.reject(e);
       }
 
+      // Status-less errors (network failure, JSON parse, ...) keep the legacy opaque shape.
       return Promise.reject(new Error('Unknown Plugin'));
     });
 }

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3929,6 +3929,36 @@
       "trace-id": "Trace ID: {{traceId}}"
     }
   },
+  "assistant-onboarding": {
+    "cards": {
+      "blog": {
+        "description": "Real-world examples and best practices for using Assistant",
+        "link": "Read blog",
+        "title": "Blog & use cases"
+      },
+      "docs": {
+        "description": "Setup guide and feature reference for getting started",
+        "link": "Read docs",
+        "title": "Documentation"
+      },
+      "video": {
+        "description": "Watch a walkthrough of key features and capabilities",
+        "link": "Watch video",
+        "title": "Video demo"
+      }
+    },
+    "greeting": "Hi, I'm",
+    "heading": "Grafana Assistant",
+    "install-cta": "Install Grafana Assistant",
+    "learn-how": "Learn how",
+    "learn-more": {
+      "subtitle": "Explore tutorials, documentation, and best practices",
+      "title": "Learn more"
+    },
+    "no-permission": "Ask a Grafana administrator to install Grafana Assistant for your organization.",
+    "subnote": "Once installed, connect it to Grafana Cloud to get started.",
+    "subtitle": "A purpose-built <1>agentic LLM assistant</1> for Grafana that helps you learn, investigate, make changes and more."
+  },
   "auth-config": {
     "auth-config-page-unconnected": {
       "auth-settings": "Auth settings"

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3955,7 +3955,6 @@
       "subtitle": "Explore tutorials, documentation, and best practices",
       "title": "Learn more"
     },
-    "no-permission": "Ask a Grafana administrator to install Grafana Assistant for your organization.",
     "subnote": "Once installed, connect it to Grafana Cloud to get started.",
     "subtitle": "A purpose-built <1>agentic LLM assistant</1> for Grafana that helps you learn, investigate, make changes and more."
   },


### PR DESCRIPTION
## What this does

Surfaces an "Assistant" entry in the main nav even when `grafana-assistant-app` isn't installed, so users on a fresh Grafana have an in-product entry point. Feature-toggle gated (`assistantStubNav`, default off).

When the plugin isn't installed, navigating to `/a/grafana-assistant-app` renders a core onboarding fallback page that introduces Grafana Assistant and links out to install / docs / blog / video. When the plugin *is* installed, it takes over the same URL — the navtree never has to mutate as install state changes.

## Why

Today the Assistant nav entry only appears once `grafana-assistant-app` is installed and enabled, so users on a fresh Grafana have no in-product entry point for it. Reverting the binary preinstall (which roughly tripled the bundled binary size) would leave users with no breadcrumb at all unless they happen to discover the plugin in the catalog.

## How it works

- `pkg/services/navtree/navtreeimpl/applinks.go` — toggle-gated stub injected into the navtree at `/a/grafana-assistant-app` when the plugin isn't enabled. Suppressed automatically when the plugin is enabled (the existing applinks loop wins).
- `public/app/features/plugins/components/pluginNavFallbacks.tsx` — small registry mapping plugin id → React component.
- `public/app/features/plugins/components/AppRootPage.tsx` — when the plugin fails to load and a fallback is registered, render the fallback instead of the existing `EntityNotFound` "App not found" state.
- `public/app/features/assistant-onboarding/AssistantOnboardingPage.tsx` — the fallback for `grafana-assistant-app`. Hero + install CTA + Learn more cards (docs, blog, video).

## Design choices

### Why `/a/grafana-assistant-app` instead of a distinct `/assistant`?

An earlier iteration of this PoC put the dummy at a separate `/assistant` URL. That broke down on the install-without-refresh path:

- The navtree is server-rendered into `bootData` and isn't refetched on plugin install. After install, the sidebar entry's `href` is still whatever was rendered on initial page load.
- With a separate URL, the sidebar would still point at `/assistant` after install. Clicking "Assistant" would land on the dummy onboarding page even though the real plugin's bundle was just loaded into `pluginsCache` one click away. Required a refresh to make the sidebar useful.
- With a constant URL (the plugin's own `/a/grafana-assistant-app`), the sidebar `href` is correct in every state. `AppRootPage` decides at click time what to render: real plugin if loadable, fallback otherwise. Install-without-refresh "just works" because `loadAppPlugin` succeeds against the in-memory cache. Uninstall-without-refresh also works — the load fails, fallback renders again.

The one concern with this approach is that core "squats" on the plugin's URL namespace. But `AppRootPage` already handles `/a/<pluginId>/*` for *all* plugin ids — it just renders `EntityNotFound` for missing ones. Replacing that error state with a registered fallback for known plugins is a small extension of existing behaviour, not a new architectural overlap. The Connections section follows a similar pattern (core handles `/connections/*`, plugin can override).

### Why suppress the 404 auto-toast for fallback plugins?

`getPluginSettings(pluginId)` returns 404 when a plugin isn't installed. `backend_srv` auto-fires a warning toast ("Plugin not found, no installed plugin with that id") for any non-2xx local API response. Without intervention, users navigating to `/a/grafana-assistant-app` (uninstalled) saw both the dummy onboarding page *and* a redundant warning toast on top.

**Fix**: pass `{ showErrorAlert: false }` to `getPluginSettings` only for plugin ids that have a registered fallback. The fallback IS the inline error UI; the toast is redundant.

This mirrors the pattern in `LoginCtrl.tsx` and several datasource calls — suppress the auto-toast when the caller has its own error presentation.

**Alternatives considered:**

- **Re-emit the toast manually for non-404 errors**: would catch genuine 5xx breakage, but duplicates `backend_srv`'s toast formatting in two places. Rejected for DRY.
- **Pre-check installation via `config.apps[pluginId]` and skip the backend call entirely**: avoids the toast, but `config.apps` is also from `bootData` and goes stale post-install. Would re-introduce the staleness problem.
- **Backend stops 404'ing for known plugin ids**: backend would need to know about frontend UI choices. Architecturally backwards.

**Trade-off accepted**: if `grafana-assistant-app`'s metadata endpoint genuinely returns 5xx, the user sees the dummy onboarding page with no toast. They might think the plugin's just not installed when it's actually broken. Mitigations: the catch handler still logs via `console.error` and `getLogger().logError` — failures are still observable for operators. The fallback signature could later be extended with a `loadError` prop so the page itself renders an error banner for non-404 cases. Out of scope for this PoC.

### Onboarding page styling

Visually echoes the plugin's installed homepage (`apps/plugin/src/pages/AssistantHomepage.tsx` in the assistant-app repo): animated sparkle icon, "Hi, I'm Grafana Assistant" hero, gradient "agentic LLM assistant" subtitle, Learn more cards. Markup is duplicated on purpose — the plugin isn't installed when this page renders, so importing from it would defeat the purpose. Animation properties are guarded with `theme.transitions.handleMotion('no-preference')` to respect `prefers-reduced-motion`.

The Install CTA is the focal action: large primary `LinkButton` with a short subnote and a "Learn how" link to the self-managed setup docs. That's the legitimate UI difference vs the live homepage (which has a chat input in this slot once the plugin is connected).

## Tests

- **Backend**: `TestAssistantStubNav` (3 subtests) — stub appears with the plugin's URL when toggle is on and plugin not installed; suppressed when plugin is enabled; absent when toggle is off.
- **Frontend unit**: `AssistantOnboardingPage.test.tsx` — install CTA href + heading. `AppRootPage.test.tsx` — three new subtests covering the fallback render path, the suppressed toast for fallback plugins, and unchanged toast behaviour for plugins without a fallback.
- **E2E**: `e2e-playwright/various-suite/assistant-onboarding.spec.ts` — toggle-on flow asserts the onboarding page renders at `/a/grafana-assistant-app` and the sidebar entry points at the same URL.

## Test plan

- [ ] Local Grafana with `assistantStubNav=true` and `grafana-assistant-app` not installed: sidebar shows "Assistant", clicking navigates to `/a/grafana-assistant-app`, onboarding page renders, no warning toast.
- [ ] Same setup, install the plugin: sidebar entry stays in place, clicking lands on the real plugin homepage (no refresh required).
- [ ] Same setup, uninstall the plugin: sidebar entry stays, clicking lands back on the onboarding fallback (no refresh required).
- [ ] `assistantStubNav=false`: no Assistant entry in nav.
- [ ] Plugins without registered fallbacks (e.g. typo'd plugin id): existing 404 toast and `EntityNotFound` behaviour unchanged.

## Follow-ups not in this PR

- The 5xx-of-fallback-plugin trade-off — extend the fallback signature with a `loadError` prop if the gap matters in practice.
- Real reactivity for `config.apps` / navtree on plugin install is a deeper Grafana-platform issue. Not blocking this PoC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)