### PR TITLE
Plugins: keep catalog detail page mounted during post-action re-fetches

### DIFF
--- a/public/app/features/plugins/admin/components/PluginActions.tsx
+++ b/public/app/features/plugins/admin/components/PluginActions.tsx
@@ -38,7 +38,7 @@ export const PluginActions = ({ plugin }: Props) => {
   const isInstallControlsDisabled = getInstallControlsDisabled(plugin, latestCompatibleVersion);
 
   return (
-    <Stack direction="column">
+    <Stack direction="column" alignItems="flex-end">
       <Stack alignItems="center">
         {!isInstallControlsDisabled && (
           <InstallControlsButton

--- a/public/app/features/plugins/admin/components/PluginDetailsPage.test.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsPage.test.tsx
@@ -108,12 +108,24 @@ describe('PluginDetailsPage', () => {
 
   it('should keep the page mounted when re-fetching while a plugin is already loaded', () => {
     // Simulates the post-install fetchDetails refresh: useFetchDetailsStatus reports loading,
-    // but useGetSingle already returns the cached plugin. The page must NOT swap to <Loader />,
-    // otherwise transient state in the actions slot (the "Refresh the page" notice) is lost.
+    // but useGetSingle already returns the cached plugin (with details). The page must NOT swap
+    // to <Loader />, otherwise transient state in the actions slot (the "Refresh the page" notice)
+    // is lost.
     jest.requireMock('../state/hooks').useFetchDetailsStatus.mockReturnValueOnce({ isLoading: true });
     render(<PluginDetailsPage pluginId="test-plugin" />);
     expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
     expect(screen.getByText('Test Plugin')).toBeInTheDocument();
+  });
+
+  it('should still show loader on initial details fetch when only the plugin shell is available', () => {
+    // useFetchAll populates the shell first (no `details`), then useFetchDetails kicks in. Without
+    // gating on `plugin.details` the page would render mid-fetch and flash empty fallbacks in
+    // Overview/Changelog/Screenshots/Versions.
+    const { details, ...shellOnly } = plugin;
+    mockUseGetSingle.mockReturnValue(shellOnly as CatalogPlugin);
+    jest.requireMock('../state/hooks').useFetchDetailsStatus.mockReturnValueOnce({ isLoading: true });
+    render(<PluginDetailsPage pluginId="test-plugin" />);
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
   });
 
   it('should show not found component when plugin doesnt exist', () => {

--- a/public/app/features/plugins/admin/components/PluginDetailsPage.test.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsPage.test.tsx
@@ -72,7 +72,7 @@ jest.mock('../state/hooks', () => ({
   useGetSingle: jest.fn(),
   useGetPluginInsights: jest.fn(),
   useFetchStatus: jest.fn().mockReturnValue({ isLoading: false }),
-  useFetchDetailsStatus: () => ({ isLoading: false }),
+  useFetchDetailsStatus: jest.fn().mockReturnValue({ isLoading: false }),
   useIsRemotePluginsAvailable: () => false,
   useInstallStatus: () => ({ error: null, isInstalling: false }),
   useUninstallStatus: () => ({ error: null, isUninstalling: false }),
@@ -99,10 +99,21 @@ describe('PluginDetailsPage', () => {
     jest.clearAllMocks();
   });
 
-  it('should show loader when fetching plugin details', () => {
+  it('should show loader on initial load when no plugin is available yet', () => {
+    mockUseGetSingle.mockReturnValue(undefined);
     jest.requireMock('../state/hooks').useFetchStatus.mockReturnValueOnce({ isLoading: true });
     render(<PluginDetailsPage pluginId="test-plugin" />);
     expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  it('should keep the page mounted when re-fetching while a plugin is already loaded', () => {
+    // Simulates the post-install fetchDetails refresh: useFetchDetailsStatus reports loading,
+    // but useGetSingle already returns the cached plugin. The page must NOT swap to <Loader />,
+    // otherwise transient state in the actions slot (the "Refresh the page" notice) is lost.
+    jest.requireMock('../state/hooks').useFetchDetailsStatus.mockReturnValueOnce({ isLoading: true });
+    render(<PluginDetailsPage pluginId="test-plugin" />);
+    expect(screen.queryByText('Loading...')).not.toBeInTheDocument();
+    expect(screen.getByText('Test Plugin')).toBeInTheDocument();
   });
 
   it('should show not found component when plugin doesnt exist', () => {

--- a/public/app/features/plugins/admin/components/PluginDetailsPage.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsPage.tsx
@@ -57,7 +57,10 @@ export function PluginDetailsPage({
   const { isLoading: isFetchDetailsLoading } = useFetchDetailsStatus();
   const styles = useStyles2(getStyles);
 
-  if (isFetchLoading || isFetchDetailsLoading) {
+  // Only show the page-level loader on the initial load (when we don't yet have a plugin to render).
+  // Re-fetches that happen after an action (e.g. fetchDetails after install) keep the page mounted so
+  // transient UI state in the actions slot — like the "Refresh the page to see the changes" notice — survives.
+  if (!plugin && (isFetchLoading || isFetchDetailsLoading)) {
     return (
       <Page
         navId={navId}

--- a/public/app/features/plugins/admin/components/PluginDetailsPage.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsPage.tsx
@@ -57,10 +57,14 @@ export function PluginDetailsPage({
   const { isLoading: isFetchDetailsLoading } = useFetchDetailsStatus();
   const styles = useStyles2(getStyles);
 
-  // Only show the page-level loader on the initial load (when we don't yet have a plugin to render).
-  // Re-fetches that happen after an action (e.g. fetchDetails after install) keep the page mounted so
-  // transient UI state in the actions slot — like the "Refresh the page to see the changes" notice — survives.
-  if (!plugin && (isFetchLoading || isFetchDetailsLoading)) {
+  // Only show the page-level loader while we don't yet have data to render:
+  //   - the plugin list is still loading (no shell in the store yet), OR
+  //   - the shell is here but `plugin.details` (readme, versions, changelog, screenshots) hasn't
+  //     arrived — tabs read from `plugin.details` and would flash their empty fallback otherwise.
+  // Re-fetches that happen after an action (e.g. fetchDetails after install) already have full
+  // details, so the loader skips and the page stays mounted — transient UI state in the actions
+  // slot (the "Refresh the page to see the changes" notice) survives.
+  if (isFetchLoading || (isFetchDetailsLoading && !plugin?.details)) {
     return (
       <Page
         navId={navId}

--- a/public/app/features/plugins/admin/components/PluginDetailsPage.tsx
+++ b/public/app/features/plugins/admin/components/PluginDetailsPage.tsx
@@ -57,13 +57,9 @@ export function PluginDetailsPage({
   const { isLoading: isFetchDetailsLoading } = useFetchDetailsStatus();
   const styles = useStyles2(getStyles);
 
-  // Only show the page-level loader while we don't yet have data to render:
-  //   - the plugin list is still loading (no shell in the store yet), OR
-  //   - the shell is here but `plugin.details` (readme, versions, changelog, screenshots) hasn't
-  //     arrived — tabs read from `plugin.details` and would flash their empty fallback otherwise.
-  // Re-fetches that happen after an action (e.g. fetchDetails after install) already have full
-  // details, so the loader skips and the page stays mounted — transient UI state in the actions
-  // slot (the "Refresh the page to see the changes" notice) survives.
+  // Gate on `!plugin?.details` so post-action refetches (e.g. fetchDetails after install) keep
+  // the page mounted — otherwise the "Refresh the page" notice in PluginActions is lost. Initial
+  // fetches still hit the loader because tabs read from plugin.details and would flash empty.
   if (isFetchLoading || (isFetchDetailsLoading && !plugin?.details)) {
     return (
       <Page


### PR DESCRIPTION
## Summary

When users install the assistant app plugin, after install there is no visual cue that a refresh is required in order for the configuration/enable assistant tabs to be displayed. We had an existing warning message, but it was not being triggered - this attempts to fix that. 

I considered a forced refresh instead, which in a way would be nicer for the user even with a small risk of being destructive, but figured simpler to try this approach first

**Now**
<img width="1019" height="215" alt="Screenshot 2026-05-11 at 09 57 50" src="https://github.com/user-attachments/assets/3da69870-625c-416a-8de9-de13ead9c71a" />


## What

Two small, related fixes to the **plugin catalog detail page** (`/plugins/<pluginId>`):

1. **`PluginDetailsPage` no longer unmounts on post-action re-fetches.** It used to swap its entire tree for `<Loader />` whenever `useFetchStatus` or `useFetchDetailsStatus` reported `isLoading`. After an install, `InstallControlsButton` calls `setNeedReload(true)` and then awaits `fetchDetails(plugin.id)`. That fetch flips `isLoading=true`, the page unmounts, the `useState` backing `needReload` in `PluginActions` is destroyed, and the page remounts with `needReload=false`. The "Refresh the page to see the changes" notice was therefore **never visible** even though the maintainers wired it up correctly.

   Fix: only show the page-level loader on the initial load (no plugin yet). Subsequent re-fetches keep the page mounted, so transient UI state in the actions slot survives.

2. **Right-align the post-install refresh notice.** The actions slot in the page header used a column-direction `Stack` with no `alignItems`. The notice row is wider than the install/uninstall button row, so the column sized to the notice and the button rendered at its left edge — visibly misaligned versus everything else on the right of the header. One-line fix: `alignItems="flex-end"` on the column.

**Previous styling once displaying again**
<img width="1211" height="202" alt="Screenshot 2026-05-09 at 17 24 48" src="https://github.com/user-attachments/assets/8aacaf55-74b0-4012-ad37-ff65e8728b63" />

## Why

The "Refresh the page to see the changes" notice is the only signal the catalog gives a user that an app plugin needs a reload to fully appear (config tabs, contributed nav). Without it, an install looks like a dead end: the success toast fires, no further UI changes, and the user has to guess that they need to refresh. The notice was already coded — it was just being unmounted before render.

## Scope

This is a **plugin-platform** fix, not specific to any one plugin. Any app plugin that calls `setNeedReload?.(true)` after install (the path is gated only on `plugin.type === 'app'`) benefits. We discovered it via `grafana-assistant-app` but the underlying bug applies to all app plugins on the catalog detail page.

## Tests

- New regression test in `PluginDetailsPage.test.tsx`: when `useFetchDetailsStatus` reports loading **but** `useGetSingle` already returns a cached plugin, the page does **not** show the page-level loader and continues to render the existing plugin content. This is the post-action re-fetch case the previous behaviour broke.
- Existing initial-load test renamed and updated to assert `useGetSingle` returns `undefined` so it specifically covers the genuine first-load path.
- The alignment change is a single CSS attribute and is best validated visually.

## Test plan

- [ ] Local Grafana, install an app plugin (e.g. `grafana-assistant-app`) from the catalog detail page.
- [ ] After the install success toast, the "⚠ Refresh the page to see the changes" notice appears in the actions slot of the header.
- [ ] The notice is right-aligned with the Uninstall button (no horizontal misalignment).
- [ ] Refreshing the page surfaces the plugin's config tabs (Connection / Enable Assistant for the assistant app) and contributed nav.
- [ ] Initial loads still show the page-level loader (no regression for first-render).

## Out of scope

- Auto-reloading after install (a separate, more opinionated change).
- The post-install nav/tab population itself — the existing notice already sets the expectation; this PR just makes that notice actually visible.