### PR TITLE
Server: Add configurable `WriteTimeout` and `IdleTimeout` to HTTP server

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -101,6 +101,16 @@ cdn_url =
 # `0` means there is no timeout for reading the request.
 read_timeout = 0
 
+# Sets the maximum duration before timing out writes of the response.
+# `0` means there is no timeout for writing the response.
+# Note: if you have long-running streaming responses (e.g. live, SSE, large data source queries),
+# set this to a value higher than the longest expected response time, or leave at `0`.
+write_timeout = 0
+
+# Sets the maximum amount of time to wait for the next request when keep-alives are enabled.
+# If idle_timeout is zero, the value of read_timeout is used.
+idle_timeout = 0
+
 # This setting enables you to specify additional headers that the server adds to HTTP(S) responses.
 [server.custom_response_headers]
 #exampleHeader1 = exampleValue1

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -104,6 +104,16 @@ cdn_url =
 # `0` means there is no timeout for reading the request.
 read_timeout = 0
 
+# Sets the maximum duration before timing out writes of the response.
+# `0` means there is no timeout for writing the response.
+# Note: if you have long-running streaming responses (e.g. live, SSE, large data source queries),
+# set this to a value higher than the longest expected response time, or leave at `0`.
+write_timeout = 0
+
+# Sets the maximum amount of time to wait for the next request when keep-alives are enabled.
+# If idle_timeout is zero, the value of read_timeout is used.
+idle_timeout = 0
+
 # This setting enables you to specify additional headers that the server adds to HTTP(S) responses.
 [server.custom_response_headers]
 #exampleHeader1 = exampleValue1

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -104,6 +104,11 @@ cdn_url =
 # `0` means there is no timeout for reading the request.
 read_timeout = 0
 
+# Sets the maximum amount of time allowed to read request headers.
+# If read_header_timeout is zero, the value of read_timeout is used.
+# If both are zero, there is no timeout.
+read_header_timeout = 0
+
 # Sets the maximum duration before timing out writes of the response.
 # `0` means there is no timeout for writing the response.
 # Note: if you have long-running streaming responses (e.g. live, SSE, large data source queries),

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -102,6 +102,16 @@
 # `0` means there is no timeout for reading the request.
 ;read_timeout = 0
 
+# Sets the maximum duration before timing out writes of the response.
+# `0` means there is no timeout for writing the response.
+# Note: if you have long-running streaming responses (e.g. live, SSE, large data source queries),
+# set this to a value higher than the longest expected response time, or leave at `0`.
+;write_timeout = 0
+
+# Sets the maximum amount of time to wait for the next request when keep-alives are enabled.
+# If idle_timeout is zero, the value of read_timeout is used.
+;idle_timeout = 0
+
 # This setting enables you to specify additional headers that the server adds to HTTP(S) responses.
 [server.custom_response_headers]
 #exampleHeader1 = exampleValue1

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -105,6 +105,16 @@
 # `0` means there is no timeout for reading the request.
 ;read_timeout = 0
 
+# Sets the maximum duration before timing out writes of the response.
+# `0` means there is no timeout for writing the response.
+# Note: if you have long-running streaming responses (e.g. live, SSE, large data source queries),
+# set this to a value higher than the longest expected response time, or leave at `0`.
+;write_timeout = 0
+
+# Sets the maximum amount of time to wait for the next request when keep-alives are enabled.
+# If idle_timeout is zero, the value of read_timeout is used.
+;idle_timeout = 0
+
 # This setting enables you to specify additional headers that the server adds to HTTP(S) responses.
 [server.custom_response_headers]
 #exampleHeader1 = exampleValue1

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -105,6 +105,11 @@
 # `0` means there is no timeout for reading the request.
 ;read_timeout = 0
 
+# Sets the maximum amount of time allowed to read request headers.
+# If read_header_timeout is zero, the value of read_timeout is used.
+# If both are zero, there is no timeout.
+;read_header_timeout = 0
+
 # Sets the maximum duration before timing out writes of the response.
 # `0` means there is no timeout for writing the response.
 # Note: if you have long-running streaming responses (e.g. live, SSE, large data source queries),

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -355,6 +355,14 @@ For example, given a CDN URL like `https://cdn.myserver.com`, Grafana tries to l
 Sets the maximum time using a duration format (5s/5m/5ms) before timing out read of an incoming request and closing idle connections.
 `0` means there is no timeout for reading the request.
 
+#### `write_timeout`
+
+Sets the maximum duration using a duration format (5s/5m/5ms) before timing out writes of the response. `0` means there is no timeout for writing the response. If you have long-running streaming responses such as Live WebSocket connections, SSE, or large data source queries, set this to a value higher than the longest expected response time or leave at `0`.
+
+#### `idle_timeout`
+
+Sets the maximum amount of time using a duration format (5s/5m/5ms) to wait for the next request when keep-alive connections are enabled. If `idle_timeout` is zero, the value of `read_timeout` is used. If both are zero, there is no timeout.
+
 <hr />
 
 ### `[server.custom_response_headers]`

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -363,6 +363,12 @@ For example, given a CDN URL like `https://cdn.myserver.com`, Grafana tries to l
 Sets the maximum time using a duration format (5s/5m/5ms) before timing out read of an incoming request and closing idle connections.
 `0` means there is no timeout for reading the request.
 
+#### `read_header_timeout`
+
+Sets the maximum amount of time using a duration format (5s/5m/5ms) allowed to read request headers.
+If `read_header_timeout` is zero, the value of `read_timeout` is used.
+If both are zero, there is no timeout.
+
 #### `write_timeout`
 
 Sets the maximum duration using a duration format (5s/5m/5ms) before timing out writes of the response.

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -363,6 +363,18 @@ For example, given a CDN URL like `https://cdn.myserver.com`, Grafana tries to l
 Sets the maximum time using a duration format (5s/5m/5ms) before timing out read of an incoming request and closing idle connections.
 `0` means there is no timeout for reading the request.
 
+#### `write_timeout`
+
+Sets the maximum duration using a duration format (5s/5m/5ms) before timing out writes of the response.
+`0` means there is no timeout for writing the response.
+If you have long-running streaming responses such as Live WebSocket connections, SSE, or large data source queries, set this to a value higher than the longest expected response time or leave at `0`.
+
+#### `idle_timeout`
+
+Sets the maximum amount of time using a duration format (5s/5m/5ms) to wait for the next request when keep-alive connections are enabled.
+If `idle_timeout` is zero, the value of `read_timeout` is used.
+If both are zero, there is no timeout.
+
 <hr />
 
 ### `[server.custom_response_headers]`

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -466,9 +466,11 @@ func (hs *HTTPServer) Run(ctx context.Context) error {
 	// Remove any square brackets enclosing IPv6 addresses, a format we support for backwards compatibility
 	host := strings.TrimSuffix(strings.TrimPrefix(hs.Cfg.HTTPAddr, "["), "]")
 	hs.httpSrv = &http.Server{
-		Addr:        net.JoinHostPort(host, hs.Cfg.HTTPPort),
-		Handler:     hs.web,
-		ReadTimeout: hs.Cfg.ReadTimeout,
+		Addr:         net.JoinHostPort(host, hs.Cfg.HTTPPort),
+		Handler:      hs.web,
+		ReadTimeout:  hs.Cfg.ReadTimeout,
+		WriteTimeout: hs.Cfg.WriteTimeout,
+		IdleTimeout:  hs.Cfg.IdleTimeout,
 	}
 
 	customErrorLogger := &customErrorLogger{

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -467,9 +467,11 @@ func (hs *HTTPServer) Run(ctx context.Context) error {
 	// Remove any square brackets enclosing IPv6 addresses, a format we support for backwards compatibility
 	host := strings.TrimSuffix(strings.TrimPrefix(hs.Cfg.HTTPAddr, "["), "]")
 	hs.httpSrv = &http.Server{
-		Addr:        net.JoinHostPort(host, hs.Cfg.HTTPPort),
-		Handler:     hs.web,
-		ReadTimeout: hs.Cfg.ReadTimeout,
+		Addr:         net.JoinHostPort(host, hs.Cfg.HTTPPort),
+		Handler:      hs.web,
+		ReadTimeout:  hs.Cfg.ReadTimeout,
+		WriteTimeout: hs.Cfg.WriteTimeout,
+		IdleTimeout:  hs.Cfg.IdleTimeout,
 	}
 
 	customErrorLogger := &customErrorLogger{

--- a/pkg/api/http_server.go
+++ b/pkg/api/http_server.go
@@ -467,11 +467,12 @@ func (hs *HTTPServer) Run(ctx context.Context) error {
 	// Remove any square brackets enclosing IPv6 addresses, a format we support for backwards compatibility
 	host := strings.TrimSuffix(strings.TrimPrefix(hs.Cfg.HTTPAddr, "["), "]")
 	hs.httpSrv = &http.Server{
-		Addr:         net.JoinHostPort(host, hs.Cfg.HTTPPort),
-		Handler:      hs.web,
-		ReadTimeout:  hs.Cfg.ReadTimeout,
-		WriteTimeout: hs.Cfg.WriteTimeout,
-		IdleTimeout:  hs.Cfg.IdleTimeout,
+		Addr:              net.JoinHostPort(host, hs.Cfg.HTTPPort),
+		Handler:           hs.web,
+		ReadTimeout:       hs.Cfg.ReadTimeout,
+		ReadHeaderTimeout: hs.Cfg.ReadHeaderTimeout,
+		WriteTimeout:      hs.Cfg.WriteTimeout,
+		IdleTimeout:       hs.Cfg.IdleTimeout,
 	}
 
 	customErrorLogger := &customErrorLogger{

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -159,6 +159,8 @@ type Cfg struct {
 	Domain            string
 	CDNRootURL        *url.URL
 	ReadTimeout       time.Duration
+	WriteTimeout      time.Duration
+	IdleTimeout       time.Duration
 	EnableGzip        bool
 	EnforceDomain     bool
 	MinTLSVersion     string
@@ -2388,6 +2390,8 @@ func (cfg *Cfg) readServerSettings(iniFile *ini.File) error {
 	}
 
 	cfg.ReadTimeout = server.Key("read_timeout").MustDuration(0)
+	cfg.WriteTimeout = server.Key("write_timeout").MustDuration(0)
+	cfg.IdleTimeout = server.Key("idle_timeout").MustDuration(0)
 
 	headersSection := cfg.Raw.Section("server.custom_response_headers")
 	keys := headersSection.Keys()

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -159,6 +159,8 @@ type Cfg struct {
 	Domain            string
 	CDNRootURL        *url.URL
 	ReadTimeout       time.Duration
+	WriteTimeout      time.Duration
+	IdleTimeout       time.Duration
 	EnableGzip        bool
 	EnforceDomain     bool
 	MinTLSVersion     string
@@ -2397,6 +2399,8 @@ func (cfg *Cfg) readServerSettings(iniFile *ini.File) error {
 	}
 
 	cfg.ReadTimeout = server.Key("read_timeout").MustDuration(0)
+	cfg.WriteTimeout = server.Key("write_timeout").MustDuration(0)
+	cfg.IdleTimeout = server.Key("idle_timeout").MustDuration(0)
 
 	headersSection := cfg.Raw.Section("server.custom_response_headers")
 	keys := headersSection.Keys()

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -159,6 +159,7 @@ type Cfg struct {
 	Domain            string
 	CDNRootURL        *url.URL
 	ReadTimeout       time.Duration
+	ReadHeaderTimeout time.Duration
 	WriteTimeout      time.Duration
 	IdleTimeout       time.Duration
 	EnableGzip        bool
@@ -2399,6 +2400,7 @@ func (cfg *Cfg) readServerSettings(iniFile *ini.File) error {
 	}
 
 	cfg.ReadTimeout = server.Key("read_timeout").MustDuration(0)
+	cfg.ReadHeaderTimeout = server.Key("read_header_timeout").MustDuration(0)
 	cfg.WriteTimeout = server.Key("write_timeout").MustDuration(0)
 	cfg.IdleTimeout = server.Key("idle_timeout").MustDuration(0)
 


### PR DESCRIPTION
**What is this feature?**

Adds two new configuration options under `[server]` in `grafana.ini`:
- `write_timeout` — maximum duration before timing out writes of the response
- `idle_timeout` — maximum time to wait for the next request on keep-alive connections

Both are wired into Go's `http.Server` alongside the existing `read_timeout`.

**Why do we need this feature?**

The HTTP server currently only exposes `ReadTimeout`. Without `WriteTimeout` or `IdleTimeout`, a slow client can hold a server goroutine indefinitely by reading the response one byte at a time with long delays between reads (Slowloris-style attack). Each stuck connection consumes a goroutine (~8KB stack), a file descriptor, and associated buffers. Under attack, this can exhaust server resources and deny service to legitimate users.

Go's `net/http` defaults all three timeouts to `0` (no timeout) when unset, so the server currently has no protection against this class of DoS.

**Who is this feature for?**

Grafana operators running production instances, especially those exposed to untrusted networks or the public internet.

**Special notes for your reviewer:**

Both new options default to `0` (no timeout) to preserve backward compatibility. This is intentional:
- Grafana has streaming endpoints (Grafana Live WebSockets, SSE, long-running data source queries) that would break with a short global `WriteTimeout`
- The existing `read_timeout` also defaults to `0`, so this follows the established pattern
- Operators who want hardening can set e.g. `write_timeout = 60s` and `idle_timeout = 120s`

For deployments without streaming needs, the recommended production values are:
```ini
[server]
write_timeout = 60s
idle_timeout = 120s
```

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

Co-authored-by: Grok <noreply@xai.com>