### PR TITLE
PostgreSQL: re-read PGPASSFILE before each new pool connection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -132,6 +132,7 @@ require (
 	github.com/influxdata/influxdb-client-go/v2 v2.14.0 // @grafana/data-sources-plugins
 	github.com/influxdata/influxql v1.4.1 // @grafana/data-sources-plugins
 	github.com/influxdata/line-protocol v0.0.0-20210922203350-b1ad95c89adf // @grafana/grafana-app-platform-squad
+	github.com/jackc/pgpassfile v1.0.0 // @grafana/data-sources-plugins
 	github.com/jackc/pgx/v5 v5.10.0 // @grafana/grafana-search-and-storage
 	github.com/jmespath-community/go-jmespath v1.1.1 // @grafana/identity-access-team
 	github.com/jmoiron/sqlx v1.4.0 // @grafana/grafana-backend-group
@@ -503,7 +504,6 @@ require (
 	github.com/huandu/xstrings v1.5.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/invopop/jsonschema v0.14.0 // indirect
-	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jaegertracing/jaeger-idl v0.6.0 // indirect

--- a/pkg/tsdb/grafana-postgresql-datasource/pgpassfile_regression_test.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/pgpassfile_regression_test.go
@@ -1,0 +1,167 @@
+package postgres
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/stretchr/testify/require"
+)
+
+// Hypothesis for grafana/grafana#123617:
+//   - pgconn.ParseConfig reads PGPASSFILE on every call (re-read works at parse time).
+//   - pgxpool keeps a single ConnConfig snapshot. Without BeforeConnect, the
+//     password captured at ParseConfig time is reused for the lifetime of the pool.
+//   - Current postgres.go does not set BeforeConnect, so rotated PGPASSFILE
+//     credentials are never picked up.
+
+func writePgpass(t *testing.T, path, password string) {
+	t.Helper()
+	// host:port:database:user:password
+	line := "localhost:5432:db:u:" + password + "\n"
+	require.NoError(t, os.WriteFile(path, []byte(line), 0o600))
+}
+
+// testCACert returns a self-signed CA certificate in PEM form, so that pgx
+// accepts sslrootcert while the file still exists.
+func testCACert(t *testing.T) []byte {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+}
+
+func TestPGPASSFILE_ParseConfigReReadsFile(t *testing.T) {
+	dir := t.TempDir()
+	passfile := filepath.Join(dir, "pgpass")
+	writePgpass(t, passfile, "A")
+	t.Setenv("PGPASSFILE", passfile)
+
+	connStr := "host=localhost port=5432 user=u dbname=db"
+
+	cfgA, err := pgxpool.ParseConfig(connStr)
+	require.NoError(t, err)
+	require.Equal(t, "A", cfgA.ConnConfig.Password, "first parse should pick up password from PGPASSFILE")
+
+	writePgpass(t, passfile, "B")
+
+	cfgB, err := pgxpool.ParseConfig(connStr)
+	require.NoError(t, err)
+	require.Equal(t, "B", cfgB.ConnConfig.Password, "second parse should re-read PGPASSFILE")
+}
+
+func TestPGPASSFILE_PoolConfigDoesNotAutoRefresh(t *testing.T) {
+	dir := t.TempDir()
+	passfile := filepath.Join(dir, "pgpass")
+	writePgpass(t, passfile, "A")
+	t.Setenv("PGPASSFILE", passfile)
+
+	connStr := "host=localhost port=5432 user=u dbname=db"
+
+	cfg, err := pgxpool.ParseConfig(connStr)
+	require.NoError(t, err)
+	require.Equal(t, "A", cfg.ConnConfig.Password)
+
+	writePgpass(t, passfile, "B")
+
+	// Pool keeps the snapshot. No automatic reload.
+	require.Equal(t, "A", cfg.ConnConfig.Password,
+		"pgxpool.Config caches ConnConfig — password is not refreshed when PGPASSFILE changes")
+}
+
+// After the fix: when the data source carries no password of its own,
+// maybeWirePGPassRefresh installs a BeforeConnect hook that re-resolves the
+// password from PGPASSFILE for every new connection.
+func TestPGPASSFILE_BeforeConnectRefreshesPassword(t *testing.T) {
+	dir := t.TempDir()
+	passfile := filepath.Join(dir, "pgpass")
+	writePgpass(t, passfile, "A")
+	t.Setenv("PGPASSFILE", passfile)
+
+	connStr := "user='u' host='localhost' dbname='db' port=5432 sslmode='disable'"
+
+	cfg, err := pgxpool.ParseConfig(connStr)
+	require.NoError(t, err)
+	require.Equal(t, "A", cfg.ConnConfig.Password)
+
+	maybeWirePGPassRefresh(cfg, false)
+	require.NotNil(t, cfg.BeforeConnect, "BeforeConnect must be wired when password is empty")
+
+	writePgpass(t, passfile, "B")
+
+	cc, err := pgx.ParseConfig(connStr)
+	require.NoError(t, err)
+	require.NoError(t, cfg.BeforeConnect(context.Background(), cc))
+	require.Equal(t, "B", cc.Password, "BeforeConnect must pull the rotated password from PGPASSFILE")
+}
+
+// Grafana writes TLS certificates supplied as file *content* to temporary files
+// and deletes them once the pool is set up (see TLSManager.cleanupCertFiles).
+// The refresh hook must not depend on anything in the connection string other
+// than the password, or it breaks exactly the setup it is meant to fix: a data
+// source using PGPASSFILE together with certificate content.
+func TestPGPASSFILE_RefreshSurvivesDeletedCertFiles(t *testing.T) {
+	dir := t.TempDir()
+	passfile := filepath.Join(dir, "pgpass")
+	writePgpass(t, passfile, "A")
+	t.Setenv("PGPASSFILE", passfile)
+
+	rootCert := filepath.Join(dir, "root.crt")
+	require.NoError(t, os.WriteFile(rootCert, testCACert(t), 0o600))
+
+	connStr := "user='u' host='localhost' dbname='db' port=5432 sslmode='verify-ca' sslrootcert='" + rootCert + "'"
+
+	cfg, err := pgxpool.ParseConfig(connStr)
+	require.NoError(t, err)
+	require.Equal(t, "A", cfg.ConnConfig.Password)
+
+	maybeWirePGPassRefresh(cfg, false)
+	require.NotNil(t, cfg.BeforeConnect)
+
+	// Grafana deletes the temporary certificate files right after pool setup,
+	// then the credential rotates.
+	require.NoError(t, os.Remove(rootCert))
+	writePgpass(t, passfile, "B")
+
+	cc := cfg.ConnConfig.Copy()
+	require.NoError(t, cfg.BeforeConnect(context.Background(), cc),
+		"refresh must not fail once the temporary certificate files are gone")
+	require.Equal(t, "B", cc.Password, "rotated password must still be picked up")
+}
+
+// When the password is provided inline, no BeforeConnect should be installed —
+// the credential is static and re-reading on every connect would be wasted IO.
+func TestPGPASSFILE_NoBeforeConnectWhenPasswordInline(t *testing.T) {
+	connStr := "user='u' host='localhost' dbname='db' port=5432 password='inline' sslmode='disable'"
+
+	cfg, err := pgxpool.ParseConfig(connStr)
+	require.NoError(t, err)
+
+	maybeWirePGPassRefresh(cfg, true)
+	require.Nil(t, cfg.BeforeConnect, "BeforeConnect must not be set when password is inline")
+}

--- a/pkg/tsdb/grafana-postgresql-datasource/postgres.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/postgres.go
@@ -4,11 +4,15 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/jackc/pgpassfile"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -49,6 +53,8 @@ func newPostgres(ctx context.Context, userFacingDefaultError string, rowLimit in
 	pgxConf.ConnConfig.LookupFunc = func(_ context.Context, host string) ([]string, error) {
 		return []string{host}, nil
 	}
+
+	maybeWirePGPassRefresh(pgxConf, dsInfo.DecryptedSecureJSONData["password"] != "")
 
 	config := sqleng.DataPluginConfiguration{
 		DSInfo:            dsInfo,
@@ -145,6 +151,52 @@ func NewInstanceSettings(logger log.Logger) datasource.InstanceFactoryFunc {
 // escape single quotes and backslashes in Postgres connection string parameters.
 func escape(input string) string {
 	return strings.ReplaceAll(strings.ReplaceAll(input, `\`, `\\`), "'", `\'`)
+}
+
+// maybeWirePGPassRefresh re-reads the password from PGPASSFILE before every new
+// connection when the data source has no password of its own. pgx resolves the
+// passfile once during ParseConfig and the pool then caches that snapshot, so
+// rotated credentials would otherwise never be picked up.
+//
+// Only the password is re-read: the rest of the parsed config, including the
+// TLS setup, is left untouched. Certificates supplied as content live in
+// temporary files that are removed once the pool is up, so re-parsing the whole
+// connection string here would fail for those data sources.
+func maybeWirePGPassRefresh(pgxConf *pgxpool.Config, hasInlinePassword bool) {
+	if hasInlinePassword {
+		return
+	}
+	pgxConf.BeforeConnect = func(_ context.Context, cc *pgx.ConnConfig) error {
+		password, err := passwordFromPassfile(cc.Host, cc.Port, cc.Database, cc.User)
+		if err != nil || password == "" {
+			// Keep the password resolved at startup: a missing or unreadable
+			// passfile is not a reason to fail the connection here, pgx will
+			// surface an authentication error if the old one no longer works.
+			return nil
+		}
+		cc.Password = password
+		return nil
+	}
+}
+
+// passwordFromPassfile looks up a password the same way pgx does when no
+// password is configured: PGPASSFILE if set, otherwise ~/.pgpass.
+func passwordFromPassfile(host string, port uint16, database, user string) (string, error) {
+	path := os.Getenv("PGPASSFILE")
+	if path == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		path = filepath.Join(home, ".pgpass")
+	}
+
+	passfile, err := pgpassfile.ReadPassfile(path)
+	if err != nil {
+		return "", err
+	}
+
+	return passfile.FindPassword(host, strconv.Itoa(int(port)), database, user), nil
 }
 
 type connectionParams struct {


### PR DESCRIPTION
**What is this feature?**

Wires `pgxpool.Config.BeforeConnect` in the PostgreSQL data source so that, when the data source has no password of its own, the password is re-resolved from `PGPASSFILE` before every new pool connection.

**Why do we need this feature?**

`pgconn.ParseConfig` reads `PGPASSFILE` once and stores the resolved value in `Config.Password`. `pgxpool` then caches that parsed `*pgx.ConnConfig` for the lifetime of the pool, so every subsequent connection reuses the password captured at startup — the file is never read again.

The old `lib/pq` driver re-read `PGPASSFILE` on each new connection, so rotating the file was enough for Grafana to pick up new credentials. After the move to pgx (#113675) that stopped working: rotated credentials are ignored until Grafana is restarted, and once the old password is revoked the data source starts failing.

`BeforeConnect` is the per-connection hook pgxpool exposes for exactly this, so the fix looks the password up there and refreshes `ConnConfig.Password`.

**Who is this feature for?**

Operators who authenticate the PostgreSQL data source through `PGPASSFILE` with rotating credentials — typically short-lived credentials issued by Vault, IAM, or a similar broker.

**Which issue(s) does this PR fix?**:

Fixes grafana/grafana-postgresql-datasource#127

**Special notes for your reviewer:**

The hook resolves the password through `pgpassfile`, the same module pgx itself uses, rather than re-running `pgx.ParseConfig` on the connection string. That matters: certificates supplied as *content* are written to temporary files that `TLSManager.cleanupCertFiles` removes as soon as the pool is up, and `ParseConfig` reads `sslrootcert`/`sslcert` eagerly. Re-parsing the whole string on each connect would therefore fail with "unable to read CA file" for precisely the data sources this fix targets — `PGPASSFILE` plus certificate content. Only the password is refreshed; the rest of the parsed config, TLS included, is left alone.

A passfile that is missing or unreadable is not treated as a connection failure — the password resolved at startup is kept and pgx surfaces an authentication error if it has since been revoked.

The hook is only installed when the data source carries no password of its own, decided from `dsInfo.DecryptedSecureJSONData["password"]` in `newPostgres`. When a password is configured inline the credential is static, so the lookup is skipped. On the issue I asked whether that flag should come from the settings rather than be pattern-matched out of the connection string; this PR takes the settings route.

`github.com/jackc/pgpassfile` was already present as an indirect dependency (pgx pulls it in) and is now promoted to a direct one.

Tests in `pkg/tsdb/grafana-postgresql-datasource/pgpassfile_regression_test.go` cover five cases:
- `pgconn.ParseConfig` does re-read `PGPASSFILE` between calls,
- the pooled config does not refresh on its own — this is the regression itself,
- `BeforeConnect` is wired and pulls the rotated password when no inline password is set,
- the refresh still works once the temporary certificate files have been deleted,
- no hook is installed when the password is inline.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle. — n/a, bug fix
- [ ] The docs are updated — n/a, restores previously documented behaviour
