### PR TITLE
CrashDetection: Replace createMonitoringLogger calls with getLogger

### DIFF
--- a/packages/grafana-runtime/src/services/logging/loggers.ts
+++ b/packages/grafana-runtime/src/services/logging/loggers.ts
@@ -16,6 +16,7 @@ export const Loggers = {
   'features.correlations': {},
   'features.dashboards.genai': {},
   'features.query-history.local-storage': {},
+  'core.crash-detection': {},
 } satisfies Record<string, LoggerDefaults>;
 
 export type LoggerSource = keyof typeof Loggers;

--- a/public/app/core/crash/index.ts
+++ b/public/app/core/crash/index.ts
@@ -2,15 +2,14 @@ import { initCrashDetection } from 'crashme';
 import { type BaseStateReport } from 'crashme/dist/types';
 import { nanoid } from 'nanoid';
 
-import { config, createMonitoringLogger } from '@grafana/runtime';
+import { config } from '@grafana/runtime';
+import { getLogger } from '@grafana/runtime/unstable';
 import { CorsWorker as Worker } from 'app/core/utils/CorsWorker';
 
 import { contextSrv } from '../services/context_srv';
 import { CorsSharedWorker as SharedWorker, sharedWorkersSupported } from '../utils/CorsSharedWorker';
 
 import { isChromePerformance, prepareContext } from './crash.utils';
-
-const logger = createMonitoringLogger('core.crash-detection');
 
 interface GrafanaCrashReport extends BaseStateReport {
   app: {
@@ -67,13 +66,13 @@ export function initializeCrashDetection() {
 
     reportCrash: async (report) => {
       const preparedContext = prepareContext(report);
-      logger.logWarning('browser crash detected', preparedContext);
+      getLogger('core.crash-detection').logWarning('browser crash detected', preparedContext);
       return true;
     },
 
     reportStaleTab: async (report) => {
       const preparedContext = prepareContext(report);
-      logger.logWarning('stale browser tab detected', preparedContext);
+      getLogger('core.crash-detection').logWarning('stale browser tab detected', preparedContext);
       return true;
     },
 


### PR DESCRIPTION
**What is this feature?**

Replaces `createMonitoringLogger` with `getLogger` from `@grafana/runtime/unstable` in crash detection, and registers `core.crash-detection` in the central `Loggers` definition.

**Why do we need this feature?**

So crash detection uses the new central logger registry like the other already migrated sources.

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #121639

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
