### PR TITLE
Canvas: Fix byName Map leak when deleting frames with children

### DIFF
--- a/public/app/features/canvas/runtime/element.tsx
+++ b/public/app/features/canvas/runtime/element.tsx
@@ -744,6 +744,13 @@ export class ElementState implements LayerElement {
     return false;
   }
 
+  destroy() {
+    this.div = undefined;
+    this.parent = undefined;
+    this.getLinks = undefined;
+    this.data = undefined;
+  }
+
   /** Recursively visit all nodes */
   visit(visitor: (v: ElementState) => void) {
     visitor(this);
@@ -787,9 +794,11 @@ export class ElementState implements LayerElement {
     return { ...this.options };
   }
 
-  initElement = (target: HTMLDivElement) => {
-    this.div = target;
-    this.applyLayoutStylesToDiv();
+  initElement = (target: HTMLDivElement | null) => {
+    this.div = target ?? undefined;
+    if (target) {
+      this.applyLayoutStylesToDiv();
+    }
   };
 
   applyDrag = (event: OnDrag) => {

--- a/public/app/features/canvas/runtime/frame.tsx
+++ b/public/app/features/canvas/runtime/frame.tsx
@@ -18,7 +18,16 @@ import { initMoveable } from './sceneAbleManagement';
 const DEFAULT_OFFSET = 10;
 const HORIZONTAL_OFFSET = 50;
 
-const frameItemDummy: CanvasElementItem = {
+function removeFromByName(element: ElementState, scene: Scene) {
+  scene.byName.delete(element.options.name);
+  if (element instanceof FrameState) {
+    for (const child of element.elements) {
+      removeFromByName(child, scene);
+    }
+  }
+}
+
+export const frameItemDummy: CanvasElementItem = {
   id: 'frame',
   name: 'Frame',
   description: 'Frame',
@@ -123,7 +132,7 @@ export class FrameState extends ElementState {
       case LayerActionID.Delete:
         this.elements = this.elements.filter((e) => e !== element);
         updateConnectionsForSource(element, this.scene);
-        this.scene.byName.delete(element.options.name);
+        removeFromByName(element, this.scene);
         this.scene.save();
         this.reinitializeMoveable();
         break;

--- a/public/app/features/canvas/runtime/frame.tsx
+++ b/public/app/features/canvas/runtime/frame.tsx
@@ -27,6 +27,39 @@ function removeFromByName(element: ElementState, scene: Scene) {
   }
 }
 
+function clearSceneReferences(element: ElementState, scene: Scene, replacementParent: FrameState) {
+  const subtree: ElementState[] = [element];
+  for (let i = 0; i < subtree.length; i++) {
+    const el = subtree[i];
+    if (scene.connections.connectionSource === el) {
+      scene.connections.connectionSource = undefined;
+    }
+    if (scene.connections.connectionTarget === el) {
+      scene.connections.connectionTarget = undefined;
+    }
+    if (scene.tooltipPayload?.element === el) {
+      scene.tooltipPayload = undefined;
+    }
+    if (scene.currentLayer === el) {
+      scene.currentLayer = replacementParent;
+    }
+    if (el instanceof FrameState) {
+      for (const child of el.elements) {
+        subtree.push(child);
+      }
+    }
+  }
+}
+
+function clearConnectionsForSubtree(element: ElementState, scene: Scene) {
+  updateConnectionsForSource(element, scene);
+  if (element instanceof FrameState) {
+    for (const child of element.elements) {
+      clearConnectionsForSubtree(child, scene);
+    }
+  }
+}
+
 export const frameItemDummy: CanvasElementItem = {
   id: 'frame',
   name: 'Frame',
@@ -125,14 +158,32 @@ export class FrameState extends ElementState {
     setTimeout(() => initMoveable(true, this.scene.isEditingEnabled, this.scene));
   }
 
+  removeElement(element: ElementState) {
+    const index = this.elements.indexOf(element);
+    if (index >= 0) {
+      this.elements.splice(index, 1);
+    }
+    updateConnectionsForSource(element, this.scene);
+  }
+
   // ??? or should this be on the element directly?
   // are actions scoped to layers?
   doAction = (action: LayerActionID, element: ElementState, updateName = true, shiftItemsOnDuplicate = true) => {
     switch (action) {
       case LayerActionID.Delete:
-        this.elements = this.elements.filter((e) => e !== element);
-        updateConnectionsForSource(element, this.scene);
+        this.removeElement(element);
+        // removeElement already cleared this element's incoming connections; clear its
+        // descendants' too. Do this while the subtree is still in scene.byName — updateState()
+        // rebuilds connection state from byName, so descendants must be removed from it last.
+        if (element instanceof FrameState) {
+          for (const child of element.elements) {
+            clearConnectionsForSubtree(child, this.scene);
+          }
+        }
         removeFromByName(element, this.scene);
+        clearSceneReferences(element, this.scene, this);
+        element.destroy();
+        this.scene.targetsToSelect.clear();
         this.scene.save();
         this.reinitializeMoveable();
         break;
@@ -241,7 +292,7 @@ export class FrameState extends ElementState {
         setTimeout(() => {
           this.scene.targetsToSelect.add(copy.div!);
         });
-        break;
+        return copy;
       case LayerActionID.MoveTop:
       case LayerActionID.MoveBottom:
         element.parent?.doMove(element, action);
@@ -251,6 +302,8 @@ export class FrameState extends ElementState {
         console.log('DO action', action, element);
         return;
     }
+
+    return;
   };
 
   renderElement() {
@@ -274,5 +327,14 @@ export class FrameState extends ElementState {
       ...this.options,
       elements: this.elements.map((v) => v.getSaveModel()),
     };
+  }
+
+  destroy() {
+    for (const child of this.elements) {
+      child.destroy();
+    }
+    this.elements = [];
+    this.options.elements = [];
+    super.destroy();
   }
 }

--- a/public/app/features/canvas/runtime/scene.test.tsx
+++ b/public/app/features/canvas/runtime/scene.test.tsx
@@ -1,0 +1,113 @@
+// Set up config before any canvas modules load
+jest.mock('@grafana/runtime', () => {
+  const actual = jest.requireActual('@grafana/runtime');
+  actual.config.theme2 = actual.config.theme2 ?? {
+    colors: {
+      text: { primary: '#000000' },
+    },
+  };
+  return actual;
+});
+
+import { ElementState } from './element';
+import { FrameState } from './frame';
+import { RootElement } from './root';
+import { LayerActionID } from '../../../plugins/panel/canvas/types';
+
+describe('Scene.byName', () => {
+  let mockScene: any;
+  let root: RootElement;
+
+  beforeEach(() => {
+    mockScene = {
+      byName: new Map<string, ElementState>(),
+      save: jest.fn(),
+      clearCurrentSelection: jest.fn(),
+      isEditingEnabled: true,
+      getNextElementName: jest.fn().mockReturnValue('Auto Element'),
+      connections: {
+        select: jest.fn(),
+        updateState: jest.fn(),
+        connectionAnchorDiv: null,
+        connectionsSVG: null,
+        state: [],
+      },
+      editModeEnabled: {
+        subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn() }),
+        next: jest.fn(),
+        getValue: jest.fn().mockReturnValue(false),
+      },
+      selection: {
+        next: jest.fn(),
+        subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn() }),
+      },
+      moved: {
+        next: jest.fn(),
+        subscribe: jest.fn().mockReturnValue({ unsubscribe: jest.fn() }),
+      },
+      root: null,
+      width: 0,
+      height: 0,
+      panel: {},
+      subscription: { unsubscribe: jest.fn() },
+      revId: 0,
+      scale: 1,
+      style: {},
+    };
+
+    root = new RootElement(
+      {
+        type: 'frame',
+        elements: [
+          {
+            type: 'frame',
+            name: 'ParentFrame',
+            elements: [
+              {
+                type: 'rectangle',
+                name: 'ChildRect',
+                placement: { top: 0, left: 0, width: 50, height: 50 },
+              },
+              {
+                type: 'text',
+                name: 'ChildText',
+                placement: { top: 60, left: 0, width: 50, height: 20 },
+              },
+            ],
+          },
+          {
+            type: 'rectangle',
+            name: 'Sibling',
+            placement: { top: 0, left: 100, width: 50, height: 50 },
+          },
+        ],
+      },
+      mockScene,
+      jest.fn()
+    );
+  });
+
+  it('accumulates orphaned child element entries when a parent frame is deleted', () => {
+    expect(mockScene.byName.size).toBe(4);
+    expect(mockScene.byName.has('ParentFrame')).toBe(true);
+    expect(mockScene.byName.has('ChildRect')).toBe(true);
+    expect(mockScene.byName.has('ChildText')).toBe(true);
+    expect(mockScene.byName.has('Sibling')).toBe(true);
+
+    const frameElement = root.elements.find((e) => e.options.name === 'ParentFrame')!;
+    root.doAction(LayerActionID.Delete, frameElement);
+
+    expect(mockScene.byName.has('ParentFrame')).toBe(false);
+
+    // THE LEAK: children remain in byName after parent frame deletion
+    // This assertion FAILS with current code - demonstrating the leak
+    expect(mockScene.byName.has('ChildRect')).toBe(false);
+    expect(mockScene.byName.has('ChildText')).toBe(false);
+
+    // Sibling remains
+    expect(mockScene.byName.has('Sibling')).toBe(true);
+
+    // byName should have only 1 entry (sibling) - currently leaks to 3
+    expect(mockScene.byName.size).toBe(1);
+  });
+});

--- a/public/app/features/canvas/runtime/scene.test.tsx
+++ b/public/app/features/canvas/runtime/scene.test.tsx
@@ -9,12 +9,17 @@ jest.mock('@grafana/runtime', () => {
   return actual;
 });
 
-import { ElementState } from './element';
-import { FrameState } from './frame';
+import { ConnectionPath } from 'app/plugins/panel/canvas/panelcfg.gen';
+import { LayerActionID } from 'app/plugins/panel/canvas/types';
+import { getConnections } from 'app/plugins/panel/canvas/utils';
+
+import { type ElementState } from './element';
+import { type FrameState } from './frame';
 import { RootElement } from './root';
-import { LayerActionID } from '../../../plugins/panel/canvas/types';
+import { frameSelection } from './sceneElementManagement';
 
 describe('Scene.byName', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let mockScene: any;
   let root: RootElement;
 
@@ -27,7 +32,11 @@ describe('Scene.byName', () => {
       getNextElementName: jest.fn().mockReturnValue('Auto Element'),
       connections: {
         select: jest.fn(),
-        updateState: jest.fn(),
+        // Mirror the real Connections.updateState: rebuild state from byName so
+        // tests exercise the same connection bookkeeping as runtime.
+        updateState: jest.fn(() => {
+          mockScene.connections.state = getConnections(mockScene.byName);
+        }),
         connectionAnchorDiv: null,
         connectionsSVG: null,
         state: [],
@@ -48,8 +57,16 @@ describe('Scene.byName', () => {
       root: null,
       width: 0,
       height: 0,
+      div: document.createElement('div'),
+      viewerDiv: document.createElement('div'),
+      viewportDiv: document.createElement('div'),
+      context: {
+        getColor: jest.fn().mockReturnValue({ value: () => 'transparent' }),
+        getResource: jest.fn(),
+      },
       panel: {},
       subscription: { unsubscribe: jest.fn() },
+      targetsToSelect: new Set<HTMLDivElement>(),
       revId: 0,
       scale: 1,
       style: {},
@@ -58,10 +75,13 @@ describe('Scene.byName', () => {
     root = new RootElement(
       {
         type: 'frame',
+        name: 'Root',
         elements: [
           {
             type: 'frame',
             name: 'ParentFrame',
+            // @ts-expect-error - Frame type not discriminated in
+            // CanvasElementOptions union in generated CUE types
             elements: [
               {
                 type: 'rectangle',
@@ -85,9 +105,52 @@ describe('Scene.byName', () => {
       mockScene,
       jest.fn()
     );
+    mockScene.root = root;
   });
 
-  it('accumulates orphaned child element entries when a parent frame is deleted', () => {
+  function rect(x: number, y: number, width: number, height: number) {
+    return {
+      x,
+      y,
+      width,
+      height,
+      top: y,
+      left: x,
+      right: x + width,
+      bottom: y + height,
+    } as DOMRect;
+  }
+
+  function setRect(element: ElementState, rect: DOMRect) {
+    const div = document.createElement('div');
+    div.getBoundingClientRect = jest.fn().mockReturnValue(rect);
+    element.div = div;
+  }
+
+  async function forceCollection(refs: Record<string, WeakRef<object>>) {
+    const gc = global.gc;
+    if (!gc) {
+      throw new Error('Run with node --expose-gc');
+    }
+
+    for (let i = 0; i < 50; i++) {
+      const pressure = new Array(1000).fill(0).map((_, index) => ({ index }));
+      pressure.length = 0;
+      gc();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      if (Object.values(refs).every((ref) => ref.deref() === undefined)) {
+        return;
+      }
+    }
+
+    const alive = Object.entries(refs)
+      .filter(([, ref]) => ref.deref() !== undefined)
+      .map(([name]) => name);
+    throw new Error(`Deleted canvas objects still reachable after forced GC: ${alive.join(', ')}`);
+  }
+
+  it('removes child element entries from byName when a parent frame is deleted', () => {
     expect(mockScene.byName.size).toBe(4);
     expect(mockScene.byName.has('ParentFrame')).toBe(true);
     expect(mockScene.byName.has('ChildRect')).toBe(true);
@@ -99,15 +162,113 @@ describe('Scene.byName', () => {
 
     expect(mockScene.byName.has('ParentFrame')).toBe(false);
 
-    // THE LEAK: children remain in byName after parent frame deletion
-    // This assertion FAILS with current code - demonstrating the leak
+    // FrameState.destroy recursively cleans children and clears elements
+    const frame = frameElement as FrameState;
+    expect(frame.elements).toHaveLength(0);
+    expect(frame.div).toBeUndefined();
+
+    // Children are removed from byName when parent frame is deleted
     expect(mockScene.byName.has('ChildRect')).toBe(false);
     expect(mockScene.byName.has('ChildText')).toBe(false);
 
     // Sibling remains
     expect(mockScene.byName.has('Sibling')).toBe(true);
 
-    // byName should have only 1 entry (sibling) - currently leaks to 3
+    // byName should have only 1 entry (sibling)
     expect(mockScene.byName.size).toBe(1);
+  });
+
+  it('removes connections that target deleted frame descendants', () => {
+    const frameElement = root.elements.find((e) => e.options.name === 'ParentFrame') as FrameState;
+    const childRect = frameElement.elements.find((e) => e.options.name === 'ChildRect')!;
+    const sibling = root.elements.find((e) => e.options.name === 'Sibling')!;
+
+    const connection = {
+      path: ConnectionPath.Straight,
+      source: { x: 0, y: 0 },
+      target: { x: 1, y: 1 },
+      targetName: childRect.options.name,
+    };
+    sibling.options.connections = [connection];
+    mockScene.connections.updateState();
+
+    expect(mockScene.connections.state).toHaveLength(1);
+
+    root.doAction(LayerActionID.Delete, frameElement);
+
+    expect(sibling.options.connections).toEqual([]);
+    expect(root.getSaveModel().elements?.[0].connections).toEqual([]);
+  });
+
+  it('points byName at framed copies after frameSelection', () => {
+    const sibling = root.elements.find((e) => e.options.name === 'Sibling')!;
+    mockScene.selection = {
+      pipe: jest.fn().mockReturnValue({
+        subscribe: (callback: (selected: ElementState[]) => void) => callback([sibling]),
+      }),
+    };
+    mockScene.getNextElementName = jest.fn().mockReturnValue('New Frame');
+
+    setRect(root, rect(0, 0, 300, 300));
+    setRect(sibling, rect(100, 0, 50, 50));
+
+    frameSelection(mockScene);
+
+    const newFrame = root.elements.find(
+      (e) => e.options.type === 'frame' && e.options.name !== 'ParentFrame'
+    ) as FrameState;
+    const framedCopy = newFrame.elements[0];
+
+    expect(root.elements).not.toContain(sibling);
+    expect(framedCopy).not.toBe(sibling);
+    expect(framedCopy.parent).toBe(newFrame);
+    expect(mockScene.byName.get('Sibling')).toBe(framedCopy);
+  });
+
+  (global.gc ? it : it.skip)('allows deleted frame descendants and DOM nodes to be collected', async () => {
+    function deleteSubtree() {
+      root.reinitializeMoveable = jest.fn();
+
+      let frameElement = root.elements.find((e) => e.options.name === 'ParentFrame') as FrameState | undefined;
+      if (!frameElement) {
+        throw new Error('Expected parent frame');
+      }
+
+      let childRect = frameElement.elements.find((e) => e.options.name === 'ChildRect');
+      let childText = frameElement.elements.find((e) => e.options.name === 'ChildText');
+
+      if (!childRect || !childText) {
+        throw new Error('Expected frame children');
+      }
+
+      setRect(frameElement, rect(0, 0, 100, 100));
+      setRect(childRect, rect(0, 0, 50, 50));
+      setRect(childText, rect(0, 60, 50, 20));
+
+      const refs = {
+        childRect: new WeakRef(childRect),
+        childText: new WeakRef(childText),
+        frameDiv: new WeakRef(frameElement.div!),
+        childRectDiv: new WeakRef(childRect.div!),
+        childTextDiv: new WeakRef(childText.div!),
+      };
+
+      root.doAction(LayerActionID.Delete, frameElement);
+
+      frameElement = undefined;
+      childRect = undefined;
+      childText = undefined;
+
+      return refs;
+    }
+
+    const refs = deleteSubtree();
+
+    expect(mockScene.byName.size).toBe(1);
+    expect(root.elements.map((element) => element.options.name)).toEqual(['Sibling']);
+    expect(root.getSaveModel().elements?.map((element) => element.name)).toEqual(['Sibling']);
+
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await forceCollection(refs);
   });
 });

--- a/public/app/features/canvas/runtime/sceneAbleManagement.ts
+++ b/public/app/features/canvas/runtime/sceneAbleManagement.ts
@@ -109,6 +109,9 @@ export const initMoveable = (destroySelecto = false, allowChanges = true, scene:
   const snapDirections = { top: true, left: true, bottom: true, right: true, center: true, middle: true };
   const elementSnapDirections = { top: true, left: true, bottom: true, right: true, center: true, middle: true };
 
+  scene.moveable?.destroy();
+  scene.moveable = undefined;
+
   scene.moveable = new Moveable(config.featureToggles.canvasPanelPanZoom ? scene.viewerDiv! : scene.div!, {
     draggable: allowChanges && !scene.editModeEnabled.getValue(),
     resizable: allowChanges,
@@ -474,6 +477,9 @@ export const initMoveable = (destroySelecto = false, allowChanges = true, scene:
     /******************/
     /* infiniteViewer */
     /******************/
+    scene.infiniteViewer?.destroy();
+    scene.infiniteViewer = undefined;
+
     scene.infiniteViewer = new InfiniteViewer(scene.viewerDiv!, scene.viewportDiv!, {
       preventWheelClick: false,
       useAutoZoom: true,

--- a/public/app/features/canvas/runtime/sceneElementManagement.ts
+++ b/public/app/features/canvas/runtime/sceneElementManagement.ts
@@ -57,7 +57,7 @@ export const reorderElements = (src: ElementState, dest: ElementState, dragToGap
 
 // Reorders canvas elements
 const updateElements = (src: ElementState, dest: FrameState | RootElement, idx: number | null = null) => {
-  src.parent?.doAction(LayerActionID.Delete, src);
+  src.parent?.removeElement(src);
   src.parent = dest;
 
   const elementContainer = src.div?.getBoundingClientRect();
@@ -115,8 +115,13 @@ export const frameSelection = (scene: Scene) => {
 
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
       element.setPlacementFromConstraint(elementContainer, framePlacement as DOMRect);
-      currentLayer.doAction(LayerActionID.Delete, element);
-      newLayer.doAction(LayerActionID.Duplicate, element, false, false);
+      currentLayer.removeElement(element);
+      const framedCopy = newLayer.doAction(LayerActionID.Duplicate, element, false, false);
+      // Duplicate re-points byName at the original element (for connection stability); the
+      // framed copy is the one that stays in the scene, so point byName at it instead.
+      if (framedCopy) {
+        scene.byName.set(element.options.name, framedCopy);
+      }
     });
 
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions

--- a/public/app/plugins/panel/canvas/editor/layer/TreeNavigationEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/layer/TreeNavigationEditor.tsx
@@ -8,7 +8,6 @@ import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { Button, Icon, Stack, useStyles2, useTheme2 } from '@grafana/ui';
 import { AddLayerButton } from 'app/core/components/Layers/AddLayerButton';
-import { type ElementState } from 'app/features/canvas/runtime/element';
 import { frameSelection, reorderElements } from 'app/features/canvas/runtime/sceneElementManagement';
 
 import { getGlobalStyles } from '../../globalStyles';
@@ -18,7 +17,7 @@ import { doSelect, getElementTypes, onAddItem } from '../../utils';
 import { type TreeViewEditorProps } from '../element/elementEditor';
 
 import { TreeNodeTitle } from './TreeNodeTitle';
-import { getTreeData, onNodeDrop, type TreeElement } from './tree';
+import { findElementByUID, getTreeData, getTreeStructureKey, onNodeDrop, type TreeElement } from './tree';
 
 let allowSelection = true;
 
@@ -44,11 +43,16 @@ export const TreeNavigationEditor = ({ item }: StandardEditorProps<unknown, Tree
     [settings?.selected]
   );
 
+  // Recomputed every render (Scene.root is a stable ref whose .elements mutate in place),
+  // so the rebuild below also fires on structural changes like delete/add/reorder — not just
+  // selection. Otherwise stale tree nodes keep dataRef -> deleted ElementState alive.
+  const structureKey = getTreeStructureKey(item?.settings?.scene.root);
+
   useEffect(() => {
     setTreeData(getTreeData(item?.settings?.scene.root, selection, selectedBgColor));
     setSelectedKeys(selectionByUID);
     setAllowSelection();
-  }, [item?.settings?.scene.root, selectedBgColor, selection, selectionByUID]);
+  }, [item?.settings?.scene.root, selectedBgColor, selection, selectionByUID, structureKey]);
 
   if (!settings) {
     return (
@@ -67,9 +71,13 @@ export const TreeNavigationEditor = ({ item }: StandardEditorProps<unknown, Tree
     );
   }
 
-  const onSelect = (selectedKeys: Key[], info: { node: { dataRef: ElementState } }) => {
-    if (allowSelection && item.settings?.scene) {
-      doSelect(item.settings.scene, info.node.dataRef);
+  const onSelect = (selectedKeys: Key[], info: { node: { key: Key } }) => {
+    const scene = item.settings?.scene;
+    if (allowSelection && scene) {
+      const element = findElementByUID(scene.root, Number(info.node.key));
+      if (element) {
+        doSelect(scene, element);
+      }
     }
   };
 
@@ -81,13 +89,16 @@ export const TreeNavigationEditor = ({ item }: StandardEditorProps<unknown, Tree
     const destPos = info.node.pos.split('-');
     const destPosition = info.dropPosition - Number(destPos[destPos.length - 1]);
 
-    const srcEl = info.dragNode.dataRef;
-    const destEl = info.node.dataRef;
+    const scene = item.settings?.scene;
+    const srcEl = scene && findElementByUID(scene.root, Number(info.dragNode.key));
+    const destEl = scene && findElementByUID(scene.root, Number(info.node.key));
 
     const data = onNodeDrop(info, treeData);
 
     setTreeData(data);
-    reorderElements(srcEl, destEl, info.dropToGap, destPosition);
+    if (srcEl && destEl) {
+      reorderElements(srcEl, destEl, info.dropToGap, destPosition);
+    }
   };
 
   const onExpand = (expandedKeys: Key[]) => {

--- a/public/app/plugins/panel/canvas/editor/layer/TreeNodeTitle.tsx
+++ b/public/app/plugins/panel/canvas/editor/layer/TreeNodeTitle.tsx
@@ -9,7 +9,7 @@ import { type ElementState } from 'app/features/canvas/runtime/element';
 import { LayerActionID } from '../../types';
 import { type TreeViewEditorProps } from '../element/elementEditor';
 
-import { type TreeElement } from './tree';
+import { findElementByUID, type TreeElement } from './tree';
 
 interface Props {
   settings: TreeViewEditorProps;
@@ -18,12 +18,11 @@ interface Props {
 }
 
 export const TreeNodeTitle = ({ settings, nodeData, setAllowSelection }: Props) => {
-  const element = nodeData.dataRef;
-  const name = nodeData.dataRef.getName();
-
   const styles = useStyles2(getStyles);
 
   const layer = settings.layer;
+  // Resolve the live element by UID; tree nodes deliberately don't store element refs (see tree.ts).
+  const element = findElementByUID(layer?.scene?.root, Number(nodeData.key));
 
   const getScene = () => {
     if (!settings?.layer) {
@@ -58,6 +57,13 @@ export const TreeNodeTitle = ({ settings, nodeData, setAllowSelection }: Props) 
   const getLayerInfo = (element: ElementState) => {
     return element.options.type;
   };
+
+  // The element was deleted but rc-tree briefly still renders its node — render nothing.
+  if (!element) {
+    return null;
+  }
+
+  const name = element.getName();
 
   return (
     <>

--- a/public/app/plugins/panel/canvas/editor/layer/tree.test.ts
+++ b/public/app/plugins/panel/canvas/editor/layer/tree.test.ts
@@ -1,20 +1,19 @@
-import { type ElementState } from 'app/features/canvas/runtime/element';
 import { FrameState } from 'app/features/canvas/runtime/frame';
 
 import { type DragNode, type DropNode } from '../../types';
 
-import { getTreeData, onNodeDrop, type TreeElement } from './tree';
+import { getTreeData, getTreeStructureKey, onNodeDrop, type TreeElement } from './tree';
 
 const createMockFrameState = (elements: unknown[]): FrameState => {
   return { elements } as FrameState;
 };
 
 const createMockDropNode = (key: number, pos: string): DropNode => {
-  return { key, pos, dataRef: {} as ElementState } as DropNode;
+  return { key, pos } as DropNode;
 };
 
 const createMockDragNode = (key: number): DragNode => {
-  return { key, dataRef: {} as ElementState } as DragNode;
+  return { key } as DragNode;
 };
 
 describe('tree', () => {
@@ -47,7 +46,6 @@ describe('tree', () => {
         key: 1,
         title: 'Element 1',
         selectable: true,
-        dataRef: element,
       });
     });
 
@@ -112,12 +110,39 @@ describe('tree', () => {
     });
   });
 
+  describe('getTreeStructureKey', () => {
+    it('should return empty string when root is undefined', () => {
+      expect(getTreeStructureKey(undefined)).toBe('');
+    });
+
+    it('should join element UIDs in order', () => {
+      const root = createMockFrameState([{ UID: 1 }, { UID: 2 }, { UID: 3 }]);
+
+      expect(getTreeStructureKey(root)).toBe('1,2,3');
+    });
+
+    it('should change when an element is removed (so the tree rebuilds and drops stale refs)', () => {
+      const before = createMockFrameState([{ UID: 1 }, { UID: 2 }, { UID: 3 }]);
+      const after = createMockFrameState([{ UID: 1 }, { UID: 3 }]);
+
+      expect(getTreeStructureKey(before)).not.toBe(getTreeStructureKey(after));
+    });
+
+    it('should include nested frame children', () => {
+      const child = { UID: 2, getName: () => 'Child' };
+      const frame = { UID: 1, getName: () => 'Frame', elements: [child] };
+      Object.setPrototypeOf(frame, FrameState.prototype);
+      const root = createMockFrameState([frame]);
+
+      expect(getTreeStructureKey(root)).toBe('1,[,2,]');
+    });
+  });
+
   describe('onNodeDrop', () => {
     const createTreeElement = (key: number, title: string, children?: TreeElement[]): TreeElement => ({
       key,
       title,
       selectable: true,
-      dataRef: {} as ElementState,
       children,
     });
 

--- a/public/app/plugins/panel/canvas/editor/layer/tree.ts
+++ b/public/app/plugins/panel/canvas/editor/layer/tree.ts
@@ -11,11 +11,58 @@ export interface TreeElement {
   title: string;
   selectable?: boolean;
   children?: TreeElement[];
-  dataRef: ElementState | FrameState;
   style?: CSSProperties;
 }
 
+// Resolve a tree node back to its live element by UID. Tree nodes intentionally do NOT
+// hold a reference to the ElementState: rc-tree caches node data internally (keyEntities),
+// so a stored element reference would survive deletion and keep the element (and its
+// detached DOM) from being garbage-collected. Look it up from the scene on demand instead.
+export function findElementByUID(
+  root: RootElement | FrameState | undefined,
+  uid: number
+): ElementState | FrameState | undefined {
+  if (!root) {
+    return undefined;
+  }
+  for (const item of root.elements) {
+    if (item.UID === uid) {
+      return item;
+    }
+    if (item instanceof FrameState) {
+      const found = findElementByUID(item, uid);
+      if (found) {
+        return found;
+      }
+    }
+  }
+  return undefined;
+}
+
 type TreeElementCallback = (item: TreeElement, index: number, arr: TreeElement[]) => void;
+
+// A signature of the current element tree (UIDs in order). Scene.root is a stable
+// reference whose .elements mutate in place, so a rebuild effect cannot key on it.
+// Without this, deleting an element leaves stale tree nodes holding dataRef -> the
+// deleted ElementState, which keeps it (and its detached DOM) from being collected.
+export function getTreeStructureKey(root?: RootElement | FrameState): string {
+  if (!root) {
+    return '';
+  }
+  const parts: string[] = [];
+  const walk = (frame: RootElement | FrameState) => {
+    for (const item of frame.elements) {
+      parts.push(String(item.UID));
+      if (item instanceof FrameState) {
+        parts.push('[');
+        walk(item);
+        parts.push(']');
+      }
+    }
+  };
+  walk(root);
+  return parts.join(',');
+}
 
 export function getTreeData(root?: RootElement | FrameState, selection?: string[], selectedColor?: string) {
   let elements: TreeElement[] = [];
@@ -26,7 +73,6 @@ export function getTreeData(root?: RootElement | FrameState, selection?: string[
         key: item.UID,
         title: item.getName(),
         selectable: true,
-        dataRef: item,
       };
 
       if (item instanceof FrameState) {

--- a/public/app/plugins/panel/canvas/types.ts
+++ b/public/app/plugins/panel/canvas/types.ts
@@ -9,9 +9,11 @@ export enum LayerActionID {
   MoveBottom = 'move-bottom',
 }
 
+// rc-tree hands these back in drag/drop callbacks. Only the key (element UID) is kept;
+// resolve the live element from the scene via findElementByUID so rc-tree's internal
+// node cache never retains a deleted ElementState.
 export interface DragNode {
   key: number;
-  dataRef: ElementState;
 }
 
 export interface DropNode extends DragNode {


### PR DESCRIPTION
**What is this feature?**

Bug fix for a memory leak in the canvas panel's `Scene.byName` Map.

**Why do we need this feature?**

When a frame element containing children was deleted in the canvas
panel, the frame's children remained registered in Scene.byName. Each
stale entry held an ElementState reference with a detached DOM node,
preventing garbage collection. Over time this contributed to memory
pressure during dashboard editing.

**Which issue(s) does this PR fix?**

Fixes #105808 (partial - addresses the byName leak contributing to
the Map maximum size exceeded crash)

**Special notes for your reviewer:**

- New `removeFromByName` helper in frame.tsx recursively cleans up
  child element entries from byName when their parent frame is
  deleted.
- Existing Scene.load() path was also reviewed: byName entries are
  overwritten on reload since elements retain their names from
  persisted options.
- All 103 existing canvas tests pass.