### PR TITLE
chore: break circular dependencies in processDataFrame

### DIFF
--- a/packages/grafana-data/src/dataframe/ArrayDataFrame.ts
+++ b/packages/grafana-data/src/dataframe/ArrayDataFrame.ts
@@ -1,7 +1,7 @@
 import { type QueryResultMeta } from '../types/data';
 import { type Field, FieldType, type DataFrame, TIME_SERIES_VALUE_FIELD_NAME } from '../types/dataFrame';
 
-import { guessFieldTypeForField } from './processDataFrame';
+import { guessFieldTypeForField } from './guessFieldType';
 
 /**
  * The ArrayDataFrame takes an array of objects and presents it as a DataFrame

--- a/packages/grafana-data/src/dataframe/DataFrameJSON.ts
+++ b/packages/grafana-data/src/dataframe/DataFrameJSON.ts
@@ -1,7 +1,7 @@
 import { type Labels, type QueryResultMeta } from '../types/data';
 import { FieldType, type DataFrame, type Field, type FieldConfig } from '../types/dataFrame';
 
-import { guessFieldTypeFromNameAndValue } from './processDataFrame';
+import { guessFieldTypeFromNameAndValue } from './guessFieldType';
 
 /**
  * The JSON transfer object for DataFrames.  Values are stored in simple JSON

--- a/packages/grafana-data/src/dataframe/FieldCache.ts
+++ b/packages/grafana-data/src/dataframe/FieldCache.ts
@@ -1,6 +1,6 @@
 import { type DataFrame, type Field, FieldType } from '../types/dataFrame';
 
-import { guessFieldTypeForField } from './processDataFrame';
+import { guessFieldTypeForField } from './guessFieldType';
 
 export interface FieldWithIndex extends Field {
   index: number;

--- a/packages/grafana-data/src/dataframe/MutableDataFrame.ts
+++ b/packages/grafana-data/src/dataframe/MutableDataFrame.ts
@@ -5,7 +5,8 @@ import { type Field, type DataFrame, type DataFrameDTO, type FieldDTO, FieldType
 import { makeFieldParser } from '../utils/fieldParser';
 import { FunctionalVector } from '../vector/FunctionalVector';
 
-import { guessFieldTypeFromValue, guessFieldTypeForField, toDataFrameDTO } from './processDataFrame';
+import { guessFieldTypeFromValue, guessFieldTypeForField } from './guessFieldType';
+import { toDataFrameDTO } from './processDataFrame';
 
 /** @deprecated */
 export type MutableField<T = any> = Field<T>;

--- a/packages/grafana-data/src/dataframe/StreamingDataFrame.ts
+++ b/packages/grafana-data/src/dataframe/StreamingDataFrame.ts
@@ -7,7 +7,8 @@ import { parseLabels } from '../utils/labels';
 import { renderLegendFormat } from '../utils/legend';
 
 import { type DataFrameJSON, decodeFieldValueEntities, type FieldSchema } from './DataFrameJSON';
-import { guessFieldTypeFromValue, toFilteredDataFrameDTO } from './processDataFrame';
+import { guessFieldTypeFromValue } from './guessFieldType';
+import { toFilteredDataFrameDTO } from './processDataFrame';
 
 /**
  * Indicate if the frame is appened or replace

--- a/packages/grafana-data/src/dataframe/guessFieldType.test.ts
+++ b/packages/grafana-data/src/dataframe/guessFieldType.test.ts
@@ -1,0 +1,111 @@
+import { dateTime } from '../datetime/moment_wrapper';
+import { FieldType, type Field } from '../types/dataFrame';
+
+import {
+  getFieldTypeFromValue,
+  guessFieldTypeForField,
+  guessFieldTypeFromValue,
+  guessFieldTypes,
+} from './guessFieldType';
+import { createDataFrame } from './processDataFrame';
+
+describe('guessFieldTypeFromValue', () => {
+  it('Guess Column Types from value', () => {
+    expect(guessFieldTypeFromValue(1)).toBe(FieldType.number);
+    expect(guessFieldTypeFromValue(1.234)).toBe(FieldType.number);
+    expect(guessFieldTypeFromValue(3.125e7)).toBe(FieldType.number);
+    expect(guessFieldTypeFromValue(true)).toBe(FieldType.boolean);
+    expect(guessFieldTypeFromValue(false)).toBe(FieldType.boolean);
+    expect(guessFieldTypeFromValue(new Date())).toBe(FieldType.time);
+    expect(guessFieldTypeFromValue(dateTime())).toBe(FieldType.time);
+  });
+
+  it('Guess Column Types from strings', () => {
+    expect(guessFieldTypeFromValue('1')).toBe(FieldType.number);
+    expect(guessFieldTypeFromValue('1.234')).toBe(FieldType.number);
+    expect(guessFieldTypeFromValue('NaN')).toBe(FieldType.number);
+    expect(guessFieldTypeFromValue('3.125e7')).toBe(FieldType.number);
+    expect(guessFieldTypeFromValue('True')).toBe(FieldType.boolean);
+    expect(guessFieldTypeFromValue('FALSE')).toBe(FieldType.boolean);
+    expect(guessFieldTypeFromValue('true')).toBe(FieldType.boolean);
+    expect(guessFieldTypeFromValue('xxxx')).toBe(FieldType.string);
+  });
+});
+
+describe('getFieldTypeFromValue', () => {
+  it('Get column types from values', () => {
+    expect(getFieldTypeFromValue(1)).toBe(FieldType.number);
+    expect(getFieldTypeFromValue(1.234)).toBe(FieldType.number);
+    expect(getFieldTypeFromValue(NaN)).toBe(FieldType.number);
+    expect(getFieldTypeFromValue(3.125e7)).toBe(FieldType.number);
+    expect(getFieldTypeFromValue(true)).toBe(FieldType.boolean);
+    expect(getFieldTypeFromValue('xxxx')).toBe(FieldType.string);
+  });
+});
+
+describe('guessFieldTypeForField', () => {
+  it('should guess types if value exists', () => {
+    const field: Field = {
+      name: 'Field',
+      config: {},
+      type: FieldType.other,
+      values: [1, 2, 3],
+    };
+
+    expect(guessFieldTypeForField(field)).toBe(FieldType.number);
+
+    field.values = [null, null, 3];
+
+    expect(guessFieldTypeForField(field)).toBe(FieldType.number);
+  });
+
+  it('should guess type if name suggests time values', () => {
+    const field: Field = {
+      name: 'Date',
+      config: {},
+      type: FieldType.other,
+      values: [1, 2, 3],
+    };
+
+    expect(guessFieldTypeForField(field)).toBe(FieldType.time);
+
+    field.name = 'time';
+
+    expect(guessFieldTypeForField(field)).toBe(FieldType.time);
+  });
+
+  it('should return undefined if no values present', () => {
+    const field: Field = {
+      name: 'Val',
+      config: {},
+      type: FieldType.other,
+      values: [null, null],
+    };
+
+    expect(guessFieldTypeForField(field)).toBe(undefined);
+
+    field.values = [];
+
+    expect(guessFieldTypeForField(field)).toBe(undefined);
+  });
+});
+
+describe('guessFieldTypes', () => {
+  it('Guess Column Types from series', () => {
+    const series = createDataFrame({
+      fields: [
+        { name: 'A (number)', values: [123, null] },
+        { name: 'B (strings)', values: [null, 'Hello'] },
+        { name: 'C (nulls)', values: [null, null] },
+        { name: 'Time', values: ['2000', 1967] },
+        { name: 'D (number strings)', values: ['NaN', null, 1] },
+      ],
+    });
+    const norm = guessFieldTypes(series);
+    expect(norm.fields[0].type).toBe(FieldType.number);
+    expect(norm.fields[1].type).toBe(FieldType.string);
+    expect(norm.fields[2].type).toBe(FieldType.other);
+    expect(norm.fields[3].type).toBe(FieldType.time); // based on name
+    expect(norm.fields[4].type).toBe(FieldType.number);
+  });
+});

--- a/packages/grafana-data/src/dataframe/guessFieldType.ts
+++ b/packages/grafana-data/src/dataframe/guessFieldType.ts
@@ -1,0 +1,130 @@
+import { isBoolean, isNumber, isString } from 'lodash';
+
+import { isDateTime } from '../datetime/moment_wrapper';
+import { type DataFrame, type Field, FieldType } from '../types/dataFrame';
+
+// PapaParse Dynamic Typing regex:
+// https://github.com/mholt/PapaParse/blob/master/papaparse.js#L998
+const NUMBER = /^\s*(-?(\d*\.?\d+|\d+\.?\d*)(e[-+]?\d+)?|NAN)\s*$/i;
+
+/**
+ * Given a name and value, this will pick a reasonable field type
+ */
+export function guessFieldTypeFromNameAndValue(name: string, v: unknown): FieldType {
+  if (name) {
+    name = name.toLowerCase();
+    if (name === 'date' || name === 'time') {
+      return FieldType.time;
+    }
+  }
+  return guessFieldTypeFromValue(v);
+}
+
+/**
+ * Check the field type to see what the contents are
+ */
+export function getFieldTypeFromValue(v: unknown): FieldType {
+  if (v instanceof Date || isDateTime(v)) {
+    return FieldType.time;
+  }
+
+  if (isNumber(v)) {
+    return FieldType.number;
+  }
+
+  if (isString(v)) {
+    return FieldType.string;
+  }
+
+  if (isBoolean(v)) {
+    return FieldType.boolean;
+  }
+
+  return FieldType.other;
+}
+
+/**
+ * Given a value this will guess the best column type
+ *
+ * NOTE: this is will try to see if string values can be mapped to other types (like number)
+ */
+export function guessFieldTypeFromValue(v: unknown): FieldType {
+  if (v instanceof Date || isDateTime(v)) {
+    return FieldType.time;
+  }
+
+  if (isNumber(v)) {
+    return FieldType.number;
+  }
+
+  if (isString(v)) {
+    if (NUMBER.test(v)) {
+      return FieldType.number;
+    }
+
+    if (v === 'true' || v === 'TRUE' || v === 'True' || v === 'false' || v === 'FALSE' || v === 'False') {
+      return FieldType.boolean;
+    }
+
+    return FieldType.string;
+  }
+
+  if (isBoolean(v)) {
+    return FieldType.boolean;
+  }
+
+  return FieldType.other;
+}
+
+/**
+ * Looks at the data to guess the column type.  This ignores any existing setting
+ */
+export function guessFieldTypeForField(field: Field): FieldType | undefined {
+  // 1. Use the column name to guess
+  if (field.name) {
+    const name = field.name.toLowerCase();
+    if (name === 'date' || name === 'time') {
+      return FieldType.time;
+    }
+  }
+
+  // 2. Check the first non-null value
+  for (let i = 0; i < field.values.length; i++) {
+    const v = field.values[i];
+    if (v != null) {
+      return guessFieldTypeFromValue(v);
+    }
+  }
+
+  // Could not find anything
+  return undefined;
+}
+
+/**
+ * @returns A copy of the series with the best guess for each field type.
+ * If the series already has field types defined, they will be used, unless `guessDefined` is true.
+ * @param series The DataFrame whose field's types should be guessed
+ * @param guessDefined Whether to guess types of fields with already defined types
+ */
+export const guessFieldTypes = (series: DataFrame, guessDefined = false): DataFrame => {
+  for (const field of series.fields) {
+    if (!field.type || field.type === FieldType.other || guessDefined) {
+      // Something is missing a type, return a modified copy
+      return {
+        ...series,
+        fields: series.fields.map((field) => {
+          if (field.type && field.type !== FieldType.other && !guessDefined) {
+            return field;
+          }
+          // Calculate a reasonable schema value
+          return {
+            ...field,
+            type: guessFieldTypeForField(field) || FieldType.other,
+          };
+        }),
+      };
+    }
+  }
+  // No changes necessary
+  return series;
+};

--- a/packages/grafana-data/src/dataframe/processDataFrame.test.ts
+++ b/packages/grafana-data/src/dataframe/processDataFrame.test.ts
@@ -1,14 +1,9 @@
 import { dateTime } from '../datetime/moment_wrapper';
 import { type TimeSeries, type TableData } from '../types/data';
-import { FieldType, type DataFrameDTO, type Field } from '../types/dataFrame';
+import { FieldType, type DataFrameDTO } from '../types/dataFrame';
 
 import { ArrayDataFrame } from './ArrayDataFrame';
 import {
-  createDataFrame,
-  getFieldTypeFromValue,
-  guessFieldTypeForField,
-  guessFieldTypeFromValue,
-  guessFieldTypes,
   isDataFrame,
   isTableData,
   reverseDataFrame,
@@ -99,54 +94,6 @@ describe('toDataFrame', () => {
         rows: {},
       })
     ).toThrowError('Expected table rows to be array, got object.');
-  });
-
-  it('Guess Column Types from value', () => {
-    expect(guessFieldTypeFromValue(1)).toBe(FieldType.number);
-    expect(guessFieldTypeFromValue(1.234)).toBe(FieldType.number);
-    expect(guessFieldTypeFromValue(3.125e7)).toBe(FieldType.number);
-    expect(guessFieldTypeFromValue(true)).toBe(FieldType.boolean);
-    expect(guessFieldTypeFromValue(false)).toBe(FieldType.boolean);
-    expect(guessFieldTypeFromValue(new Date())).toBe(FieldType.time);
-    expect(guessFieldTypeFromValue(dateTime())).toBe(FieldType.time);
-  });
-
-  it('Guess Column Types from strings', () => {
-    expect(guessFieldTypeFromValue('1')).toBe(FieldType.number);
-    expect(guessFieldTypeFromValue('1.234')).toBe(FieldType.number);
-    expect(guessFieldTypeFromValue('NaN')).toBe(FieldType.number);
-    expect(guessFieldTypeFromValue('3.125e7')).toBe(FieldType.number);
-    expect(guessFieldTypeFromValue('True')).toBe(FieldType.boolean);
-    expect(guessFieldTypeFromValue('FALSE')).toBe(FieldType.boolean);
-    expect(guessFieldTypeFromValue('true')).toBe(FieldType.boolean);
-    expect(guessFieldTypeFromValue('xxxx')).toBe(FieldType.string);
-  });
-
-  it('Get column types from values', () => {
-    expect(getFieldTypeFromValue(1)).toBe(FieldType.number);
-    expect(getFieldTypeFromValue(1.234)).toBe(FieldType.number);
-    expect(getFieldTypeFromValue(NaN)).toBe(FieldType.number);
-    expect(getFieldTypeFromValue(3.125e7)).toBe(FieldType.number);
-    expect(getFieldTypeFromValue(true)).toBe(FieldType.boolean);
-    expect(getFieldTypeFromValue('xxxx')).toBe(FieldType.string);
-  });
-
-  it('Guess Column Types from series', () => {
-    const series = createDataFrame({
-      fields: [
-        { name: 'A (number)', values: [123, null] },
-        { name: 'B (strings)', values: [null, 'Hello'] },
-        { name: 'C (nulls)', values: [null, null] },
-        { name: 'Time', values: ['2000', 1967] },
-        { name: 'D (number strings)', values: ['NaN', null, 1] },
-      ],
-    });
-    const norm = guessFieldTypes(series);
-    expect(norm.fields[0].type).toBe(FieldType.number);
-    expect(norm.fields[1].type).toBe(FieldType.string);
-    expect(norm.fields[2].type).toBe(FieldType.other);
-    expect(norm.fields[3].type).toBe(FieldType.time); // based on name
-    expect(norm.fields[4].type).toBe(FieldType.number);
   });
 
   it('converts JSON document data to series', () => {
@@ -467,52 +414,5 @@ describe('reverse DataFrame', () => {
     expect(rev.fields[0].nanos).toEqual([30, 20, 10]);
     expect(rev.fields[1].values).toEqual(['c', 'b', 'a']);
     expect(rev.fields[1].nanos).toBeUndefined();
-  });
-});
-
-describe('guessFieldTypeForField', () => {
-  it('should guess types if value exists', () => {
-    const field: Field = {
-      name: 'Field',
-      config: {},
-      type: FieldType.other,
-      values: [1, 2, 3],
-    };
-
-    expect(guessFieldTypeForField(field)).toBe(FieldType.number);
-
-    field.values = [null, null, 3];
-
-    expect(guessFieldTypeForField(field)).toBe(FieldType.number);
-  });
-
-  it('should guess type if name suggests time values', () => {
-    const field: Field = {
-      name: 'Date',
-      config: {},
-      type: FieldType.other,
-      values: [1, 2, 3],
-    };
-
-    expect(guessFieldTypeForField(field)).toBe(FieldType.time);
-
-    field.name = 'time';
-
-    expect(guessFieldTypeForField(field)).toBe(FieldType.time);
-  });
-
-  it('should return undefined if no values present', () => {
-    const field: Field = {
-      name: 'Val',
-      config: {},
-      type: FieldType.other,
-      values: [null, null],
-    };
-
-    expect(guessFieldTypeForField(field)).toBe(undefined);
-
-    field.values = [];
-
-    expect(guessFieldTypeForField(field)).toBe(undefined);
   });
 });

--- a/packages/grafana-data/src/dataframe/processDataFrame.ts
+++ b/packages/grafana-data/src/dataframe/processDataFrame.ts
@@ -1,7 +1,6 @@
 // Libraries
-import { isArray, isBoolean, isNumber, isString } from 'lodash';
+import { isArray } from 'lodash';
 
-import { isDateTime } from '../datetime/moment_wrapper';
 import { fieldIndexComparer } from '../field/fieldComparers';
 import { getFieldDisplayName } from '../field/fieldState';
 import { type Column, LoadingState, type TableData, type TimeSeries, type TimeSeriesValue } from '../types/data';
@@ -22,6 +21,7 @@ import { type PanelData } from '../types/panel';
 
 import { arrayToDataFrame } from './ArrayDataFrame';
 import { dataFrameFromJSON } from './DataFrameJSON';
+import { guessFieldTypeForField, guessFieldTypes } from './guessFieldType';
 
 function convertTableToDataFrame(table: TableData): DataFrame {
   const fields = table.columns.map((c) => {
@@ -168,132 +168,6 @@ function convertJSONDocumentDataToDataFrame(timeSeries: TimeSeries): DataFrame {
     length: timeSeries.datapoints.length,
   };
 }
-
-// PapaParse Dynamic Typing regex:
-// https://github.com/mholt/PapaParse/blob/master/papaparse.js#L998
-const NUMBER = /^\s*(-?(\d*\.?\d+|\d+\.?\d*)(e[-+]?\d+)?|NAN)\s*$/i;
-
-/**
- * Given a name and value, this will pick a reasonable field type
- */
-export function guessFieldTypeFromNameAndValue(name: string, v: unknown): FieldType {
-  if (name) {
-    name = name.toLowerCase();
-    if (name === 'date' || name === 'time') {
-      return FieldType.time;
-    }
-  }
-  return guessFieldTypeFromValue(v);
-}
-
-/**
- * Check the field type to see what the contents are
- */
-export function getFieldTypeFromValue(v: unknown): FieldType {
-  if (v instanceof Date || isDateTime(v)) {
-    return FieldType.time;
-  }
-
-  if (isNumber(v)) {
-    return FieldType.number;
-  }
-
-  if (isString(v)) {
-    return FieldType.string;
-  }
-
-  if (isBoolean(v)) {
-    return FieldType.boolean;
-  }
-
-  return FieldType.other;
-}
-
-/**
- * Given a value this will guess the best column type
- *
- * NOTE: this is will try to see if string values can be mapped to other types (like number)
- */
-export function guessFieldTypeFromValue(v: unknown): FieldType {
-  if (v instanceof Date || isDateTime(v)) {
-    return FieldType.time;
-  }
-
-  if (isNumber(v)) {
-    return FieldType.number;
-  }
-
-  if (isString(v)) {
-    if (NUMBER.test(v)) {
-      return FieldType.number;
-    }
-
-    if (v === 'true' || v === 'TRUE' || v === 'True' || v === 'false' || v === 'FALSE' || v === 'False') {
-      return FieldType.boolean;
-    }
-
-    return FieldType.string;
-  }
-
-  if (isBoolean(v)) {
-    return FieldType.boolean;
-  }
-
-  return FieldType.other;
-}
-
-/**
- * Looks at the data to guess the column type.  This ignores any existing setting
- */
-export function guessFieldTypeForField(field: Field): FieldType | undefined {
-  // 1. Use the column name to guess
-  if (field.name) {
-    const name = field.name.toLowerCase();
-    if (name === 'date' || name === 'time') {
-      return FieldType.time;
-    }
-  }
-
-  // 2. Check the first non-null value
-  for (let i = 0; i < field.values.length; i++) {
-    const v = field.values[i];
-    if (v != null) {
-      return guessFieldTypeFromValue(v);
-    }
-  }
-
-  // Could not find anything
-  return undefined;
-}
-
-/**
- * @returns A copy of the series with the best guess for each field type.
- * If the series already has field types defined, they will be used, unless `guessDefined` is true.
- * @param series The DataFrame whose field's types should be guessed
- * @param guessDefined Whether to guess types of fields with already defined types
- */
-export const guessFieldTypes = (series: DataFrame, guessDefined = false): DataFrame => {
-  for (const field of series.fields) {
-    if (!field.type || field.type === FieldType.other || guessDefined) {
-      // Something is missing a type, return a modified copy
-      return {
-        ...series,
-        fields: series.fields.map((field) => {
-          if (field.type && field.type !== FieldType.other && !guessDefined) {
-            return field;
-          }
-          // Calculate a reasonable schema value
-          return {
-            ...field,
-            type: guessFieldTypeForField(field) || FieldType.other,
-          };
-        }),
-      };
-    }
-  }
-  // No changes necessary
-  return series;
-};
 
 export const isTableData = (data: unknown): data is DataFrame => Boolean(data && data.hasOwnProperty('columns'));
 

--- a/packages/grafana-data/src/field/displayProcessor.ts
+++ b/packages/grafana-data/src/field/displayProcessor.ts
@@ -2,7 +2,7 @@
 import { toString, toNumber as _toNumber, isEmpty, isBoolean, isArray, join } from 'lodash';
 
 // Types
-import { getFieldTypeFromValue } from '../dataframe/processDataFrame';
+import { getFieldTypeFromValue } from '../dataframe/guessFieldType';
 import { toUtc } from '../datetime/moment_wrapper';
 import { dateTimeParse } from '../datetime/parser';
 import { type GrafanaTheme2 } from '../themes/types';

--- a/packages/grafana-data/src/field/fieldOverrides.ts
+++ b/packages/grafana-data/src/field/fieldOverrides.ts
@@ -6,7 +6,8 @@ import { ThresholdsMode, VariableFormatID, type MatcherScope } from '@grafana/sc
 
 import { NullValueMode } from '../../src/types/data';
 import { compareArrayValues, compareDataFrameStructures } from '../dataframe/frameComparisons';
-import { createDataFrame, guessFieldTypeForField } from '../dataframe/processDataFrame';
+import { guessFieldTypeForField } from '../dataframe/guessFieldType';
+import { createDataFrame } from '../dataframe/processDataFrame';
 import { type PanelPlugin } from '../panel/PanelPlugin';
 import { asHexString } from '../themes/colorManipulator';
 import { type GrafanaTheme2 } from '../themes/types';

--- a/packages/grafana-data/src/index.ts
+++ b/packages/grafana-data/src/index.ts
@@ -16,6 +16,8 @@ export {
   guessFieldTypeFromValue,
   guessFieldTypeForField,
   guessFieldTypes,
+} from './dataframe/guessFieldType';
+export {
   isTableData,
   isDataFrame,
   isDataFrameWithValue,

--- a/packages/grafana-data/src/transformations/fieldReducer.test.ts
+++ b/packages/grafana-data/src/transformations/fieldReducer.test.ts
@@ -1,6 +1,7 @@
 import { difference } from 'lodash';
 
-import { createDataFrame, guessFieldTypeFromValue } from '../dataframe/processDataFrame';
+import { guessFieldTypeFromValue } from '../dataframe/guessFieldType';
+import { createDataFrame } from '../dataframe/processDataFrame';
 import { NullValueMode } from '../types/data';
 import { type Field, FieldType } from '../types/dataFrame';
 

--- a/packages/grafana-data/src/transformations/transformers/groupToNestedTable.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupToNestedTable.ts
@@ -2,7 +2,7 @@ import { map } from 'rxjs/operators';
 
 import type { MatcherConfig } from '@grafana/schema';
 
-import { guessFieldTypeForField } from '../../dataframe/processDataFrame';
+import { guessFieldTypeForField } from '../../dataframe/guessFieldType';
 import { getFieldDisplayName } from '../../field/fieldState';
 import { type DataFrame, type Field, FieldType } from '../../types/dataFrame';
 import { type DataTransformerInfo, TransformationApplicabilityLevels } from '../../types/transformations';

--- a/packages/grafana-data/src/transformations/transformers/reduce.ts
+++ b/packages/grafana-data/src/transformations/transformers/reduce.ts
@@ -1,6 +1,6 @@
 import { map } from 'rxjs/operators';
 
-import { guessFieldTypeForField } from '../../dataframe/processDataFrame';
+import { guessFieldTypeForField } from '../../dataframe/guessFieldType';
 import { getFieldDisplayName } from '../../field/fieldState';
 import { type KeyValue } from '../../types/data';
 import { type DataFrame, type Field, FieldType } from '../../types/dataFrame';

--- a/packages/grafana-data/src/utils/csv.ts
+++ b/packages/grafana-data/src/utils/csv.ts
@@ -4,7 +4,7 @@ import Papa, { type ParseConfig, type Parser, type ParseResult } from 'papaparse
 
 // Types
 import { MutableDataFrame } from '../dataframe/MutableDataFrame';
-import { guessFieldTypeFromValue } from '../dataframe/processDataFrame';
+import { guessFieldTypeFromValue } from '../dataframe/guessFieldType';
 import { getFieldDisplayName } from '../field/fieldState';
 import { type DataFrame, type Field, type FieldConfig, FieldType } from '../types/dataFrame';
 import { formattedValueToString } from '../valueFormats/valueFormats';

--- a/packages/grafana-data/src/utils/fieldParser.ts
+++ b/packages/grafana-data/src/utils/fieldParser.ts
@@ -1,4 +1,4 @@
-import { guessFieldTypeFromValue } from '../dataframe/processDataFrame';
+import { guessFieldTypeFromValue } from '../dataframe/guessFieldType';
 import { type Field, FieldType } from '../types/dataFrame';
 
 export function makeFieldParser(value: unknown, field: Field) {


### PR DESCRIPTION

**What is this feature?**

Breaks two circular dependencies in `@grafana/data` by extracting the field-type-guessing helpers (`guessFieldTypeFromNameAndValue`, `getFieldTypeFromValue`, `guessFieldTypeFromValue`, `guessFieldTypeForField`, `guessFieldTypes`) and the `NUMBER` regex out of `processDataFrame.ts` into a new `guessFieldType.ts`. Related tests are moved into `guessFieldType.test.ts`. All internal `grafana-data` consumers and the `index.ts` barrel now import from `./guessFieldType` directly.

**Why do we need this feature?**

So `ArrayDataFrame.ts` and `DataFrameJSON.ts` no longer cycle through `processDataFrame.ts`

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Relates #117144

**Special notes for your reviewer:**

Public API is unchanged — the four helpers are still exported from `@grafana/data`, just re-exported from a different internal path. `yarn madge` drops from 434 → 432 circular deps.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
- [x] `yarn madge` confirms cycles are broken (434 -> 432)

🤖 Generated with [Claude Code](https://claude.com/claude-code)