### PR TITLE
Alerting: Add common section to filter dropdown in Alerts Activity

### DIFF
--- a/public/app/features/alerting/unified/triage/scene/tagKeysProviders.test.ts
+++ b/public/app/features/alerting/unified/triage/scene/tagKeysProviders.test.ts
@@ -83,7 +83,7 @@ describe('tagKeysProviders', () => {
   });
 
   describe('getAdHocTagKeysProvider', () => {
-    it('should return all labels sorted under All', async () => {
+    it('should show promoted labels first under Common, then remaining sorted under All', async () => {
       mockGetDataSourceSrv({
         getTagKeys: jest.fn().mockResolvedValue([
           { text: 'alertstate', value: 'alertstate' },
@@ -105,24 +105,14 @@ describe('tagKeysProviders', () => {
       const result = await getAdHocTagKeysProvider(variable, null);
 
       expect(result.replace).toBe(true);
-      expect(result.values).toEqual(
-        expect.arrayContaining([
-          { text: 'alertstate', value: 'alertstate', group: 'All' },
-          { text: 'alertname', value: 'alertname', group: 'All' },
-          { text: 'grafana_folder', value: 'grafana_folder', group: 'All' },
-          { text: 'environment', value: 'environment', group: 'All' },
-          { text: 'severity', value: 'severity', group: 'All' },
-          { text: 'team', value: 'team', group: 'All' },
-        ])
-      );
-      expect(result.values).not.toEqual(expect.arrayContaining([expect.objectContaining({ group: 'Common' })]));
-      expect(result.values).not.toEqual(
-        expect.arrayContaining([
-          { value: 'service', text: 'Service', group: 'Common' },
-          { text: 'Team', value: 'team', group: 'Common' },
-          { text: 'Namespace', value: 'namespace', group: 'Common' },
-        ])
-      );
+      expect(result.values).toEqual([
+        { value: 'alertname', text: 'Rule name', group: 'Common' },
+        { value: 'alertstate', text: 'State', group: 'Common' },
+        { value: 'grafana_folder', text: 'Folder', group: 'Common' },
+        { text: 'environment', value: 'environment', group: 'All' },
+        { text: 'severity', value: 'severity', group: 'All' },
+        { text: 'team', value: 'team', group: 'All' },
+      ]);
       expect(result.values).not.toEqual(expect.arrayContaining([{ text: 'service', value: 'service', group: 'All' }]));
       expect(result.values).not.toEqual(
         expect.arrayContaining([{ text: 'service_name', value: 'service_name', group: 'All' }])

--- a/public/app/features/alerting/unified/triage/scene/tagKeysProviders.ts
+++ b/public/app/features/alerting/unified/triage/scene/tagKeysProviders.ts
@@ -26,6 +26,13 @@ const GROUPBY_PROMOTED: MetricFindValue[] = [
   { value: 'namespace', text: 'Namespace', group: COMMON_GROUP },
 ];
 
+/** Labels promoted to the top of the ad-hoc Filters dropdown (aligned with triage sidebar copy) */
+const FILTERS_PROMOTED: MetricFindValue[] = [
+  { value: 'alertname', text: 'Rule name', group: COMMON_GROUP },
+  { value: 'alertstate', text: 'State', group: COMMON_GROUP },
+  { value: 'grafana_folder', text: 'Folder', group: COMMON_GROUP },
+];
+
 /** Labels that should never appear in dropdowns */
 const EXCLUDED = new Set<string>([
   '__name__',
@@ -101,11 +108,11 @@ export function getGroupByTagKeysProvider(variable: GroupByVariable, _currentKey
 
 /**
  * Provider for the AdHoc Filters variable.
- * Returns datasource labels under the "All" group.
+ * Shows promoted labels first, then remaining datasource labels alphabetically under "All".
  */
 export function getAdHocTagKeysProvider(variable: AdHocFiltersVariable, _currentKey: string | null) {
   const timeRange = sceneGraph.getTimeRange(variable).state.value;
-  return buildTagKeysResult(timeRange);
+  return buildTagKeysResult(timeRange, FILTERS_PROMOTED);
 }
 
 /**


### PR DESCRIPTION
This PR creates Common section in the filters dropdown on alerts activity page to match the UI/UX of the groupBy dropdown
Common: Rule name (alertname), State (alertstate), and Folder (grafana_folder). 
Other label keys stay under All, sorted as before.

https://github.com/user-attachments/assets/5dd50e76-5320-4139-ac1b-af6c435f30cb


Issue: https://github.com/grafana/alerting-squad/issues/1418