### PR TITLE
fix: require JSDoc comments in define-feature-events ESLint rule

### DIFF
--- a/packages/grafana-eslint-rules/rules/define-feature-events.cjs
+++ b/packages/grafana-eslint-rules/rules/define-feature-events.cjs
@@ -46,6 +46,13 @@ const defineFeatureEventsRule = createRule({
       return false;
     }
 
+    /** @param {import('@typescript-eslint/utils').TSESTree.Node} node */
+    function hasJSDocBefore(node) {
+      return context.sourceCode
+        .getCommentsBefore(node)
+        .some((comment) => comment.type === 'Block' && comment.value.startsWith('*'));
+    }
+
     return {
       ImportSpecifier(node) {
         if (node.imported.type !== AST_NODE_TYPES.Identifier) {
@@ -118,7 +125,7 @@ const defineFeatureEventsRule = createRule({
             if (!propertyValueCallsFactory(prop.value)) {
               continue;
             }
-            if (context.sourceCode.getCommentsBefore(prop).length === 0) {
+            if (!hasJSDocBefore(prop)) {
               context.report({ node: prop, messageId: 'missingEventComment' });
             }
           }
@@ -127,7 +134,7 @@ const defineFeatureEventsRule = createRule({
 
         // Pattern (b) — individual export
         if (callsFactoryVariable(init)) {
-          if (context.sourceCode.getCommentsBefore(node).length === 0) {
+          if (!hasJSDocBefore(node)) {
             context.report({ node: decl.declarations[0].id, messageId: 'missingEventComment' });
           }
         }
@@ -150,7 +157,7 @@ const defineFeatureEventsRule = createRule({
         }
 
         for (const member of node.body.body) {
-          if (context.sourceCode.getCommentsBefore(member).length === 0) {
+          if (!hasJSDocBefore(member)) {
             context.report({ node: member, messageId: 'missingPropertyComment' });
           }
         }

--- a/packages/grafana-eslint-rules/tests/define-feature-events.test.js
+++ b/packages/grafana-eslint-rules/tests/define-feature-events.test.js
@@ -95,5 +95,50 @@ ruleTester.run('define-feature-events', defineFeatureEventsRule, {
       `,
       errors: [{ messageId: 'missingPropertyComment' }],
     },
+    // Plain // comment on a grouped-object event should not satisfy the JSDoc requirement
+    {
+      code: `
+        ${DEFINE_EVENTS_IMPORT}
+        const createEvent = defineFeatureEvents('grafana', 'dashboard_library');
+        export const MyInteractions = {
+          // This is a plain line comment, not JSDoc
+          loaded: createEvent('loaded'),
+        };
+      `,
+      errors: [{ messageId: 'missingEventComment' }],
+    },
+    // Plain // comment on an individual export event should not satisfy the JSDoc requirement
+    {
+      code: `
+        ${DEFINE_EVENTS_IMPORT}
+        const createEvent = defineFeatureEvents('grafana', 'dashboard_library');
+        // This is a plain line comment, not JSDoc
+        export const loaded = createEvent('loaded');
+      `,
+      errors: [{ messageId: 'missingEventComment' }],
+    },
+    // Non-JSDoc block comment (/* */ without leading *) should not satisfy the JSDoc requirement
+    {
+      code: `
+        ${DEFINE_EVENTS_IMPORT}
+        const createEvent = defineFeatureEvents('grafana', 'dashboard_library');
+        export const MyInteractions = {
+          /* Not a JSDoc comment */
+          loaded: createEvent('loaded'),
+        };
+      `,
+      errors: [{ messageId: 'missingEventComment' }],
+    },
+    // Plain // comment on an interface property should not satisfy the JSDoc requirement
+    {
+      code: `
+        ${EVENT_PROPERTY_IMPORT}
+        interface LoadedProps extends EventProperty {
+          // This is a plain line comment, not JSDoc
+          numberOfItems: number;
+        }
+      `,
+      errors: [{ messageId: 'missingPropertyComment' }],
+    },
   ],
 });

--- a/scripts/cli/analytics/silent.test.mts
+++ b/scripts/cli/analytics/silent.test.mts
@@ -42,6 +42,58 @@ const findEvent = (events: ReturnType<typeof findAllEvents>, name: string) => {
   return event;
 };
 
+describe('analytics report — JSDoc comment validation', () => {
+  it('throws when an event has a plain // comment instead of JSDoc', () => {
+    const files = buildProject({
+      'feature.ts': `
+        import { defineFeatureEvents } from './runtime';
+        const factory = defineFeatureEvents('grafana', 'test');
+        // Not a JSDoc comment
+        export const loaded = factory('loaded');
+      `,
+    });
+
+    assert.throws(() => findAllEvents(files, './runtime'));
+  });
+
+  it('throws when an event in a grouped object has a plain // comment instead of JSDoc', () => {
+    const files = buildProject({
+      'feature.ts': `
+        import { defineFeatureEvents } from './runtime';
+        const factory = defineFeatureEvents('grafana', 'test');
+        export const Events = {
+          // Not a JSDoc comment
+          loaded: factory('loaded'),
+        };
+      `,
+    });
+
+    assert.throws(() => findAllEvents(files, './runtime'));
+  });
+
+  it('produces empty description when a property has a // comment instead of JSDoc', () => {
+    const files = buildProject({
+      'feature.ts': `
+        import { defineFeatureEvents, EventProperty } from './runtime';
+        const factory = defineFeatureEvents('grafana', 'test');
+        interface LoadedProps extends EventProperty {
+          // Not JSDoc
+          count: number;
+        }
+        /**
+         * Loaded event.
+         * @owner grafana-test
+         */
+        export const loaded = factory<LoadedProps>('loaded');
+      `,
+    });
+
+    const events = findAllEvents(files, './runtime');
+    const event = findEvent(events, 'loaded');
+    assert.equal(event.properties?.[0]?.description, undefined);
+  });
+});
+
 describe('analytics report — silent extraction', () => {
   it('marks per-event silent: true (loud factory + silent override)', () => {
     const files = buildProject({


### PR DESCRIPTION
## Summary

- The `define-feature-events` ESLint rule checks that comments exist on analytics events and `EventProperty` interface properties, but it accepts **any** comment type (`//`, `/* */`). The `analytics-report` scanner requires **JSDoc** (`/** ... */`) to extract descriptions.
- This mismatch causes either a **hard crash** (event-level plain comments) or **silent data loss** in the report (property-level plain comments).
- Adds a `hasJSDocBefore()` helper that filters for `Block` comments starting with `*`, and replaces all three bare `getCommentsBefore().length` checks.

Related: #101697 (original hackathon PR where this gap was identified in review)

## CI failure evidence

The first commit (`0e79b66`) adds failing tests only. CI confirms the 4 ESLint test failures before the fix:
https://github.com/grafana/grafana/actions/runs/25659915567/job/75318002070

## Test plan

**ESLint rule tests** (4 new invalid cases):
- [x] `//` comment on a grouped-object event → should report `missingEventComment`
- [x] `//` comment on an individual export event → should report `missingEventComment`
- [x] `/* */` block comment on an event → should report `missingEventComment`
- [x] `//` comment on an interface property → should report `missingPropertyComment`

**Analytics report tests** (3 new cases documenting scanner behavior with plain comments):
- [x] `//` on individual export event → scanner throws (crash)
- [x] `//` on grouped-object event → scanner throws (crash)
- [x] `//` on property → scanner produces empty description (data loss)

All 12 ESLint rule tests and 10 analytics report tests pass after the fix commit.