### PR TITLE
Dashboards: Fix broken add panel button after removing last panel 

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-default/DefaultGridLayoutManager.tsx
@@ -683,7 +683,14 @@ function DefaultGridLayoutManagerRenderer({ model }: SceneComponentProps<Default
       className={cx(styles.container, isEditing && styles.containerEditing)}
       data-testid={selectors.components.LayoutContainer(getTestIdForLayout(model))}
     >
-      {model.state.grid.Component && <model.state.grid.Component model={model.state.grid} />}
+      {model.state.grid.Component && (
+        // #123563: Workaround, needs proper fixing downstream
+        // Force-remount when toggling between empty and populated. react-grid-layout caches its
+        // computed container height in internal state; without a fresh mount it stays sized to
+        // the last panel and overflows on top of the Add panel button below. Needs further investigation
+        // as part of #123563.
+        <model.state.grid.Component model={model.state.grid} key={children.length === 0 ? 'empty' : 'populated'} />
+      )}
       {showCanvasActions && (
         <div className={styles.actionsWrapper}>
           <CanvasGridAddActions layoutManager={model} />


### PR DESCRIPTION
Related to #123563

When `react-grid-layout` becomes empty it keeps the stale height preventing clicking on buttons. 

This workaround forces remount to recalculate the height on that specific edge case. This affects only Custom Grid.

The issue not resolved yet as it needs further investigation on finding a proper fix in scenes or `react-grid-layout`.