### PR TITLE
search: replace ad-hoc remote-store fakes with a single hookable wrapper

### DIFF
--- a/pkg/storage/unified/search/bleve_snapshot_observability_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_observability_test.go
@@ -61,13 +61,13 @@ func assertSpanEvents(t *testing.T, recorder *tracetest.SpanRecorder, spanName s
 func TestSnapshotDownloadEmitsSpan(t *testing.T) {
 	recorder := setupSnapshotSpanRecorder(t)
 
-	store := &fakeRemoteIndexStore{}
-	store.put(makeULID(t, time.Now()), &IndexMeta{
+	store := newHookableStore(t)
+	dt := newDownloadTest(t, store)
+	seedDownloadableSnapshot(t, t.Context(), store.bucket, dt.ns, makeULID(t, time.Now()), &IndexMeta{
 		BuildVersion:          "11.5.0",
 		LatestResourceVersion: 42,
 		UploadTimestamp:       time.Now(),
 	})
-	dt := newDownloadTest(t, store)
 
 	_, _, err := dt.run(t)
 	require.NoError(t, err)
@@ -78,7 +78,7 @@ func TestSnapshotDownloadEmitsSpan(t *testing.T) {
 func TestSnapshotUploadEmitsSpanAndLockEvents(t *testing.T) {
 	recorder := setupSnapshotSpanRecorder(t)
 
-	store := &uploadTestStore{}
+	store := newHookableStore(t)
 	be, _ := newTestBleveBackend(t, SnapshotOptions{Store: store})
 	key := newTestNsResource()
 	idx := newUploadTestIndex(t, be, key, 42)

--- a/pkg/storage/unified/search/bleve_snapshot_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -30,128 +29,6 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
-
-// fakeRemoteIndexStore is an in-memory RemoteIndexStore for unit tests.
-// DownloadIndex writes a minimal bleve index populated from the stored meta
-// so validateDownloadedIndex sees consistent data.
-//
-// All data access is mutex-guarded so cold-start tests can mutate the
-// snapshot set from a goroutine while coordinateColdStartBuild is
-// probing on the main goroutine. The mutex is uncontended in single-
-// threaded tests.
-type fakeRemoteIndexStore struct {
-	mu          sync.Mutex
-	data        map[ulid.ULID]*IndexMeta
-	getErr      map[ulid.ULID]error
-	listErr     error
-	downloadErr error
-
-	listCalls     atomic.Int32
-	listKeyCalls  atomic.Int32
-	getMetaCalls  atomic.Int32
-	downloadCalls atomic.Int32
-}
-
-type noopIndexStoreLock struct {
-	lost chan struct{}
-}
-
-func (l *noopIndexStoreLock) Release() error {
-	return nil
-}
-
-func (l *noopIndexStoreLock) Lost() <-chan struct{} {
-	return l.lost
-}
-
-func (f *fakeRemoteIndexStore) put(key ulid.ULID, meta *IndexMeta) {
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	if f.data == nil {
-		f.data = map[ulid.ULID]*IndexMeta{}
-	}
-	f.data[key] = meta
-}
-
-func (f *fakeRemoteIndexStore) ListIndexes(context.Context, resource.NamespacedResource) (map[ulid.ULID]*IndexMeta, error) {
-	f.listCalls.Add(1)
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	if f.listErr != nil {
-		return nil, f.listErr
-	}
-	out := make(map[ulid.ULID]*IndexMeta, len(f.data))
-	for k, v := range f.data {
-		out[k] = v
-	}
-	return out, nil
-}
-
-func (f *fakeRemoteIndexStore) ListIndexKeys(context.Context, resource.NamespacedResource) ([]ulid.ULID, error) {
-	f.listKeyCalls.Add(1)
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	if f.listErr != nil {
-		return nil, f.listErr
-	}
-	keys := make([]ulid.ULID, 0, len(f.data))
-	for k := range f.data {
-		keys = append(keys, k)
-	}
-	return keys, nil
-}
-
-func (f *fakeRemoteIndexStore) GetIndexMeta(_ context.Context, _ resource.NamespacedResource, k ulid.ULID) (*IndexMeta, error) {
-	f.getMetaCalls.Add(1)
-	f.mu.Lock()
-	defer f.mu.Unlock()
-	if err, ok := f.getErr[k]; ok {
-		return nil, err
-	}
-	meta, ok := f.data[k]
-	if !ok {
-		return nil, ErrSnapshotNotFound
-	}
-	return meta, nil
-}
-
-func (f *fakeRemoteIndexStore) DownloadIndex(_ context.Context, _ resource.NamespacedResource, k ulid.ULID, destDir string) (*IndexMeta, error) {
-	f.downloadCalls.Add(1)
-	f.mu.Lock()
-	meta, ok := f.data[k]
-	downloadErr := f.downloadErr
-	f.mu.Unlock()
-	if downloadErr != nil {
-		return nil, downloadErr
-	}
-	if !ok {
-		return nil, fmt.Errorf("not found")
-	}
-	return meta, writeFakeSnapshot(destDir, meta)
-}
-
-func (f *fakeRemoteIndexStore) LockBuildIndex(context.Context, resource.NamespacedResource, string) (IndexStoreLock, error) {
-	return &noopIndexStoreLock{lost: make(chan struct{})}, nil
-}
-
-func (f *fakeRemoteIndexStore) UploadIndex(context.Context, resource.NamespacedResource, string, IndexMeta) (ulid.ULID, error) {
-	panic("UploadIndex not implemented for fakeRemoteIndexStore")
-}
-func (f *fakeRemoteIndexStore) DeleteIndex(context.Context, resource.NamespacedResource, ulid.ULID) error {
-	panic("DeleteIndex not implemented for fakeRemoteIndexStore")
-}
-func (f *fakeRemoteIndexStore) CleanupIncompleteUploads(context.Context, resource.NamespacedResource, time.Duration) (int, error) {
-	panic("CleanupIncompleteUploads not implemented for fakeRemoteIndexStore")
-}
-func (f *fakeRemoteIndexStore) ListNamespaces(context.Context) ([]string, error) {
-	panic("ListNamespaces not implemented for fakeRemoteIndexStore")
-}
-func (f *fakeRemoteIndexStore) ListNamespaceIndexes(context.Context, string) ([]resource.NamespacedResource, error) {
-	panic("ListNamespaceIndexes not implemented for fakeRemoteIndexStore")
-}
-func (f *fakeRemoteIndexStore) LockNamespaceForCleanup(context.Context, string) (IndexStoreLock, error) {
-	panic("LockNamespaceForCleanup not implemented for fakeRemoteIndexStore")
-}
 
 // writeFakeSnapshot creates an empty bleve index at dir with RV and build info
 // matching meta. validateDownloadedIndex reads these back.
@@ -338,12 +215,12 @@ func TestPickBestSnapshot(t *testing.T) {
 type downloadTest struct {
 	be          *bleveBackend
 	metrics     *resource.BleveIndexMetrics
-	store       *fakeRemoteIndexStore
+	store       *hookableStore
 	ns          resource.NamespacedResource
 	resourceDir string
 }
 
-func newDownloadTest(t *testing.T, store *fakeRemoteIndexStore) downloadTest {
+func newDownloadTest(t *testing.T, store *hookableStore) downloadTest {
 	t.Helper()
 	be, metrics := newTestBleveBackend(t, SnapshotOptions{
 		Store:       store,
@@ -374,7 +251,7 @@ func (dt downloadTest) counter(status string) float64 {
 }
 
 func TestTryDownloadRemoteSnapshot_Empty(t *testing.T) {
-	dt := newDownloadTest(t, &fakeRemoteIndexStore{})
+	dt := newDownloadTest(t, newHookableStore(t))
 	idx, _, err := dt.run(t)
 	require.NoError(t, err)
 	assert.Nil(t, idx)
@@ -383,20 +260,23 @@ func TestTryDownloadRemoteSnapshot_Empty(t *testing.T) {
 }
 
 func TestTryDownloadRemoteSnapshot_ListError(t *testing.T) {
-	dt := newDownloadTest(t, &fakeRemoteIndexStore{listErr: errors.New("boom")})
+	store := newHookableStore(t)
+	store.setListIndexesErr(errors.New("boom"))
+	dt := newDownloadTest(t, store)
 	_, _, err := dt.run(t)
 	require.Error(t, err)
 	assert.Equal(t, 1.0, dt.counter(snapshotStatusDownloadError))
 }
 
 func TestTryDownloadRemoteSnapshot_DownloadError(t *testing.T) {
-	store := &fakeRemoteIndexStore{downloadErr: errors.New("network dropped")}
-	store.put(makeULID(t, time.Now()), &IndexMeta{
+	store := newHookableStore(t)
+	store.setDownloadErr(errors.New("network dropped"))
+	dt := newDownloadTest(t, store)
+	seedDownloadableSnapshot(t, t.Context(), store.bucket, dt.ns, makeULID(t, time.Now()), &IndexMeta{
 		BuildVersion:          "11.5.0",
 		LatestResourceVersion: 42,
 		UploadTimestamp:       time.Now(),
 	})
-	dt := newDownloadTest(t, store)
 
 	_, _, err := dt.run(t)
 	require.Error(t, err)
@@ -408,13 +288,13 @@ func TestTryDownloadRemoteSnapshot_DownloadError(t *testing.T) {
 }
 
 func TestTryDownloadRemoteSnapshot_ValidationError(t *testing.T) {
-	store := &fakeRemoteIndexStore{}
-	store.put(makeULID(t, time.Now()), &IndexMeta{
+	store := newHookableStore(t)
+	dt := newDownloadTest(t, store)
+	seedDownloadableSnapshot(t, t.Context(), store.bucket, dt.ns, makeULID(t, time.Now()), &IndexMeta{
 		BuildVersion:          "11.5.0",
 		LatestResourceVersion: 0, // invalid (<=0)
 		UploadTimestamp:       time.Now(),
 	})
-	dt := newDownloadTest(t, store)
 
 	_, _, err := dt.run(t)
 	require.Error(t, err)
@@ -426,13 +306,13 @@ func TestTryDownloadRemoteSnapshot_ValidationError(t *testing.T) {
 }
 
 func TestTryDownloadRemoteSnapshot_Success(t *testing.T) {
-	store := &fakeRemoteIndexStore{}
-	store.put(makeULID(t, time.Now()), &IndexMeta{
+	store := newHookableStore(t)
+	dt := newDownloadTest(t, store)
+	seedDownloadableSnapshot(t, t.Context(), store.bucket, dt.ns, makeULID(t, time.Now()), &IndexMeta{
 		BuildVersion:          "11.5.0",
 		LatestResourceVersion: 42,
 		UploadTimestamp:       time.Now(),
 	})
-	dt := newDownloadTest(t, store)
 
 	idx, rv, err := dt.run(t)
 	require.NoError(t, err)
@@ -446,13 +326,13 @@ func TestTryDownloadRemoteSnapshot_Success(t *testing.T) {
 }
 
 func TestTryDownloadRemoteSnapshot_AllFilteredOut(t *testing.T) {
-	store := &fakeRemoteIndexStore{}
-	store.put(makeULID(t, time.Now().Add(-2*time.Hour)), &IndexMeta{
+	store := newHookableStore(t)
+	dt := newDownloadTest(t, store)
+	seedDownloadableSnapshot(t, t.Context(), store.bucket, dt.ns, makeULID(t, time.Now().Add(-2*time.Hour)), &IndexMeta{
 		BuildVersion:          "11.5.0",
 		LatestResourceVersion: 42,
 		UploadTimestamp:       time.Now().Add(-2 * time.Hour),
 	})
-	dt := newDownloadTest(t, store)
 	dt.be.opts.Snapshot.MaxIndexAge = time.Hour
 
 	idx, _, err := dt.run(t)
@@ -466,13 +346,13 @@ func TestTryDownloadRemoteSnapshot_AllFilteredOut(t *testing.T) {
 // "MaxIndexAge=0 means no age limit" semantic for the tiered selection
 // path: an arbitrarily old same-version snapshot is still downloaded.
 func TestTryDownloadRemoteSnapshot_NoAgeLimitWhenZero(t *testing.T) {
-	store := &fakeRemoteIndexStore{}
-	store.put(makeULID(t, time.Now().Add(-30*24*time.Hour)), &IndexMeta{
+	store := newHookableStore(t)
+	dt := newDownloadTest(t, store)
+	seedDownloadableSnapshot(t, t.Context(), store.bucket, dt.ns, makeULID(t, time.Now().Add(-30*24*time.Hour)), &IndexMeta{
 		BuildVersion:          "11.5.0",
 		LatestResourceVersion: 42,
 		UploadTimestamp:       time.Now().Add(-30 * 24 * time.Hour),
 	})
-	dt := newDownloadTest(t, store)
 	dt.be.opts.Snapshot.MaxIndexAge = 0
 
 	idx, rv, err := dt.run(t)
@@ -487,12 +367,12 @@ func TestTryDownloadRemoteSnapshot_NoAgeLimitWhenZero(t *testing.T) {
 type freshDownloadTest struct {
 	be          *bleveBackend
 	metrics     *resource.BleveIndexMetrics
-	store       *fakeRemoteIndexStore
+	store       *hookableStore
 	ns          resource.NamespacedResource
 	resourceDir string
 }
 
-func newFreshDownloadTest(t *testing.T, store *fakeRemoteIndexStore) freshDownloadTest {
+func newFreshDownloadTest(t *testing.T, store *hookableStore) freshDownloadTest {
 	t.Helper()
 	be, metrics := newTestBleveBackend(t, SnapshotOptions{
 		Store:       store,
@@ -538,9 +418,9 @@ func freshSnapshot(buildAge time.Duration) *IndexMeta {
 }
 
 func TestTryDownloadFreshSnapshot_Hit(t *testing.T) {
-	store := &fakeRemoteIndexStore{}
-	store.put(makeULID(t, time.Now()), freshSnapshot(time.Minute))
+	store := newHookableStore(t)
 	dt := newFreshDownloadTest(t, store)
+	seedDownloadableSnapshot(t, t.Context(), store.bucket, dt.ns, makeULID(t, time.Now()), freshSnapshot(time.Minute))
 
 	idx, rv, err := dt.run(t, time.Time{}, time.Hour)
 	require.NoError(t, err)
@@ -553,9 +433,9 @@ func TestTryDownloadFreshSnapshot_Hit(t *testing.T) {
 // means "no age limit": an arbitrarily old same-version snapshot is
 // accepted as long as it is newer than lastImportTime.
 func TestTryDownloadFreshSnapshot_NoAgeLimitWhenZero(t *testing.T) {
-	store := &fakeRemoteIndexStore{}
-	store.put(makeULID(t, time.Now()), freshSnapshot(30*24*time.Hour))
+	store := newHookableStore(t)
 	dt := newFreshDownloadTest(t, store)
+	seedDownloadableSnapshot(t, t.Context(), store.bucket, dt.ns, makeULID(t, time.Now()), freshSnapshot(30*24*time.Hour))
 
 	idx, rv, err := dt.run(t, time.Time{}, 0)
 	require.NoError(t, err)
@@ -565,11 +445,11 @@ func TestTryDownloadFreshSnapshot_NoAgeLimitWhenZero(t *testing.T) {
 }
 
 func TestTryDownloadFreshSnapshot_VersionMismatchSkipped(t *testing.T) {
-	store := &fakeRemoteIndexStore{}
+	store := newHookableStore(t)
+	dt := newFreshDownloadTest(t, store)
 	meta := freshSnapshot(time.Minute)
 	meta.BuildVersion = "11.4.0" // backend runs 11.5.0
-	store.put(makeULID(t, time.Now()), meta)
-	dt := newFreshDownloadTest(t, store)
+	seedSnapshot(t, t.Context(), store.bucket, dt.ns, makeULID(t, time.Now()), meta)
 
 	idx, _, err := dt.run(t, time.Time{}, time.Hour)
 	require.NoError(t, err)
@@ -579,7 +459,8 @@ func TestTryDownloadFreshSnapshot_VersionMismatchSkipped(t *testing.T) {
 }
 
 func TestTryDownloadFreshSnapshot_BuildTimeOlderThanMaxAge(t *testing.T) {
-	store := &fakeRemoteIndexStore{}
+	store := newHookableStore(t)
+	dt := newFreshDownloadTest(t, store)
 	// Periodic re-upload: ULID (upload time) is recent, but BuildTime is old.
 	meta := &IndexMeta{
 		BuildVersion:          "11.5.0",
@@ -587,8 +468,7 @@ func TestTryDownloadFreshSnapshot_BuildTimeOlderThanMaxAge(t *testing.T) {
 		UploadTimestamp:       time.Now(),
 		BuildTime:             time.Now().Add(-3 * time.Hour),
 	}
-	store.put(makeULID(t, time.Now()), meta)
-	dt := newFreshDownloadTest(t, store)
+	seedSnapshot(t, t.Context(), store.bucket, dt.ns, makeULID(t, time.Now()), meta)
 
 	idx, _, err := dt.run(t, time.Time{}, time.Hour)
 	require.NoError(t, err)
@@ -598,12 +478,12 @@ func TestTryDownloadFreshSnapshot_BuildTimeOlderThanMaxAge(t *testing.T) {
 }
 
 func TestTryDownloadFreshSnapshot_RejectedByLastImportTime(t *testing.T) {
-	store := &fakeRemoteIndexStore{}
+	store := newHookableStore(t)
+	dt := newFreshDownloadTest(t, store)
 	// Snapshot built 5 minutes ago, but lastImportTime says KV mutated 2 minutes ago.
 	// The snapshot pre-dates known mutations and must be rejected even though it
 	// fits the maxFreshSnapshotAge window.
-	store.put(makeULID(t, time.Now()), freshSnapshot(5*time.Minute))
-	dt := newFreshDownloadTest(t, store)
+	seedSnapshot(t, t.Context(), store.bucket, dt.ns, makeULID(t, time.Now()), freshSnapshot(5*time.Minute))
 
 	lastImportTime := time.Now().Add(-2 * time.Minute)
 	idx, _, err := dt.run(t, lastImportTime, time.Hour)
@@ -614,11 +494,11 @@ func TestTryDownloadFreshSnapshot_RejectedByLastImportTime(t *testing.T) {
 }
 
 func TestTryDownloadFreshSnapshot_AcceptedWhenBuiltAfterLastImportTime(t *testing.T) {
-	store := &fakeRemoteIndexStore{}
+	store := newHookableStore(t)
+	dt := newFreshDownloadTest(t, store)
 	// Snapshot built 1 minute ago, lastImportTime 5 minutes ago: snapshot is
 	// strictly newer than the latest known mutation, so it's safe to use.
-	store.put(makeULID(t, time.Now()), freshSnapshot(time.Minute))
-	dt := newFreshDownloadTest(t, store)
+	seedDownloadableSnapshot(t, t.Context(), store.bucket, dt.ns, makeULID(t, time.Now()), freshSnapshot(time.Minute))
 
 	lastImportTime := time.Now().Add(-5 * time.Minute)
 	idx, _, err := dt.run(t, lastImportTime, time.Hour)
@@ -628,7 +508,8 @@ func TestTryDownloadFreshSnapshot_AcceptedWhenBuiltAfterLastImportTime(t *testin
 }
 
 func TestTryDownloadFreshSnapshot_ListError(t *testing.T) {
-	store := &fakeRemoteIndexStore{listErr: errors.New("boom")}
+	store := newHookableStore(t)
+	store.setListKeysErr(errors.New("boom"))
 	dt := newFreshDownloadTest(t, store)
 
 	_, _, err := dt.run(t, time.Time{}, time.Hour)
@@ -637,7 +518,7 @@ func TestTryDownloadFreshSnapshot_ListError(t *testing.T) {
 }
 
 func TestTryDownloadFreshSnapshot_Empty(t *testing.T) {
-	dt := newFreshDownloadTest(t, &fakeRemoteIndexStore{})
+	dt := newFreshDownloadTest(t, newHookableStore(t))
 	idx, _, err := dt.run(t, time.Time{}, time.Hour)
 	require.NoError(t, err)
 	assert.Nil(t, idx)
@@ -648,24 +529,24 @@ func TestTryDownloadFreshSnapshot_Empty(t *testing.T) {
 // probe walks past a recent ULID whose BuildTime is stale (e.g. a periodic
 // re-upload) to find an earlier same-version candidate that's actually fresh.
 func TestTryDownloadFreshSnapshot_WalksPastStaleNewerCandidate(t *testing.T) {
-	store := &fakeRemoteIndexStore{}
+	store := newHookableStore(t)
+	dt := newFreshDownloadTest(t, store)
 	now := time.Now()
 	// Newer ULID (uploaded just now) but stale BuildTime: a periodic re-upload
 	// of a long-lived index. Must be rejected by build-start freshness.
-	store.put(makeULID(t, now), &IndexMeta{
+	seedSnapshot(t, t.Context(), store.bucket, dt.ns, makeULID(t, now), &IndexMeta{
 		BuildVersion:          "11.5.0",
 		LatestResourceVersion: 10,
 		UploadTimestamp:       now,
 		BuildTime:             now.Add(-3 * time.Hour),
 	})
 	// Older ULID, fresh BuildTime: this is the one we want.
-	store.put(makeULID(t, now.Add(-30*time.Minute)), &IndexMeta{
+	seedDownloadableSnapshot(t, t.Context(), store.bucket, dt.ns, makeULID(t, now.Add(-30*time.Minute)), &IndexMeta{
 		BuildVersion:          "11.5.0",
 		LatestResourceVersion: 42,
 		UploadTimestamp:       now.Add(-30 * time.Minute),
 		BuildTime:             now.Add(-30 * time.Minute),
 	})
-	dt := newFreshDownloadTest(t, store)
 
 	idx, rv, err := dt.run(t, time.Time{}, time.Hour)
 	require.NoError(t, err)
@@ -678,8 +559,9 @@ func TestTryDownloadFreshSnapshot_WalksPastStaleNewerCandidate(t *testing.T) {
 // BuildIndex prefers downloading a fresh same-version snapshot over running
 // the builder.
 func TestBuildIndex_RebuildUsesFreshSnapshot(t *testing.T) {
-	store := &fakeRemoteIndexStore{}
-	store.put(makeULID(t, time.Now()), freshSnapshot(time.Minute))
+	store := newHookableStore(t)
+	ns := newTestNsResource()
+	seedDownloadableSnapshot(t, t.Context(), store.bucket, ns, makeULID(t, time.Now()), freshSnapshot(time.Minute))
 	be, metrics := newTestBleveBackend(t, SnapshotOptions{
 		Store:       store,
 		MinDocCount: 1,
@@ -687,7 +569,7 @@ func TestBuildIndex_RebuildUsesFreshSnapshot(t *testing.T) {
 	})
 
 	builderCalled := atomic.Int32{}
-	idx, err := be.BuildIndex(context.Background(), newTestNsResource(), 10, nil, "rebuild",
+	idx, err := be.BuildIndex(context.Background(), ns, 10, nil, "rebuild",
 		func(resource.ResourceIndex) (int64, error) {
 			builderCalled.Add(1)
 			return 1, nil
@@ -703,10 +585,11 @@ func TestBuildIndex_RebuildUsesFreshSnapshot(t *testing.T) {
 // when no fresh same-version snapshot is available, BuildIndex runs the
 // builder rather than falling back to the tiered selection.
 func TestBuildIndex_RebuildFallsBackToBuilder(t *testing.T) {
-	store := &fakeRemoteIndexStore{}
+	store := newHookableStore(t)
+	ns := newTestNsResource()
 	// Older snapshot present — would be acceptable to the tiered policy on
 	// the initial-startup path, but must be ignored on the rebuild path.
-	store.put(makeULID(t, time.Now().Add(-3*time.Hour)), &IndexMeta{
+	seedSnapshot(t, t.Context(), store.bucket, ns, makeULID(t, time.Now().Add(-3*time.Hour)), &IndexMeta{
 		BuildVersion:          "11.5.0",
 		LatestResourceVersion: 42,
 		UploadTimestamp:       time.Now().Add(-3 * time.Hour),
@@ -719,7 +602,7 @@ func TestBuildIndex_RebuildFallsBackToBuilder(t *testing.T) {
 	})
 
 	builderCalled := atomic.Int32{}
-	idx, err := be.BuildIndex(context.Background(), newTestNsResource(), 10, nil, "rebuild",
+	idx, err := be.BuildIndex(context.Background(), ns, 10, nil, "rebuild",
 		func(index resource.ResourceIndex) (int64, error) {
 			builderCalled.Add(1)
 			return 1, nil
@@ -736,8 +619,9 @@ func TestBuildIndex_RebuildFallsBackToBuilder(t *testing.T) {
 // maxFreshSnapshotAge=0 disables the rebuild-path fast path entirely (no
 // list/get calls against the store).
 func TestBuildIndex_RebuildSkipsFastPathWhenDisabled(t *testing.T) {
-	store := &fakeRemoteIndexStore{}
-	store.put(makeULID(t, time.Now()), freshSnapshot(time.Minute))
+	store := newHookableStore(t)
+	ns := newTestNsResource()
+	seedSnapshot(t, t.Context(), store.bucket, ns, makeULID(t, time.Now()), freshSnapshot(time.Minute))
 	be, _ := newTestBleveBackend(t, SnapshotOptions{
 		Store:       store,
 		MinDocCount: 1,
@@ -745,7 +629,7 @@ func TestBuildIndex_RebuildSkipsFastPathWhenDisabled(t *testing.T) {
 	})
 
 	builderCalled := atomic.Int32{}
-	idx, err := be.BuildIndex(context.Background(), newTestNsResource(), 10, nil, "rebuild",
+	idx, err := be.BuildIndex(context.Background(), ns, 10, nil, "rebuild",
 		func(resource.ResourceIndex) (int64, error) {
 			builderCalled.Add(1)
 			return 1, nil
@@ -760,7 +644,7 @@ func TestBuildIndex_RebuildSkipsFastPathWhenDisabled(t *testing.T) {
 // TestBuildIndex_SkipsDownloadBelowMinDocCount ensures ListIndexes is not called
 // when the size parameter is below MinDocCount.
 func TestBuildIndex_SkipsDownloadBelowMinDocCount(t *testing.T) {
-	store := &fakeRemoteIndexStore{}
+	store := newHookableStore(t)
 	be, _ := newTestBleveBackend(t, SnapshotOptions{
 		Store:       store,
 		MinDocCount: 1000, // much higher than size below
@@ -1076,7 +960,7 @@ func TestIntegrationBleveSnapshotRoundTrip(t *testing.T) {
 // error-path cases; when set, the probe is expected to return an error.
 type probeCase struct {
 	name    string
-	setup   func(s *fakeRemoteIndexStore) ulid.ULID
+	setup   func(t *testing.T, s *hookableStore, ns resource.NamespacedResource) ulid.ULID
 	wantErr string
 }
 
@@ -1086,9 +970,10 @@ func runProbeCases(t *testing.T, probe probeFn, cases []probeCase) {
 	t.Helper()
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			store := &fakeRemoteIndexStore{getErr: map[ulid.ULID]error{}}
-			want := tc.setup(store)
-			k, meta, err := probe(t.Context(), store, newTestNsResource(), time.Now().Add(-time.Hour), "11.5.0")
+			store := newHookableStore(t)
+			ns := newTestNsResource()
+			want := tc.setup(t, store, ns)
+			k, meta, err := probe(t.Context(), store, ns, time.Now().Add(-time.Hour), "11.5.0")
 			if tc.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.wantErr)
@@ -1112,55 +997,55 @@ func TestFindFreshSnapshotByUploadTime(t *testing.T) {
 	runProbeCases(t, findFreshSnapshotByUploadTime, []probeCase{
 		{
 			name: "homogeneous cluster: newest same-version returned",
-			setup: func(s *fakeRemoteIndexStore) ulid.ULID {
-				s.put(mk(-30*time.Minute), &IndexMeta{BuildVersion: "11.5.0"})
+			setup: func(t *testing.T, s *hookableStore, ns resource.NamespacedResource) ulid.ULID {
+				seedSnapshot(t, t.Context(), s.bucket, ns, mk(-30*time.Minute), &IndexMeta{BuildVersion: "11.5.0"})
 				k := mk(-5 * time.Minute)
-				s.put(k, &IndexMeta{BuildVersion: "11.5.0"})
+				seedSnapshot(t, t.Context(), s.bucket, ns, k, &IndexMeta{BuildVersion: "11.5.0"})
 				return k
 			},
 		},
 		{
 			name: "mixed version: walks past newer wrong-version",
-			setup: func(s *fakeRemoteIndexStore) ulid.ULID {
-				s.put(mk(-5*time.Minute), &IndexMeta{BuildVersion: "11.4.0"})
+			setup: func(t *testing.T, s *hookableStore, ns resource.NamespacedResource) ulid.ULID {
+				seedSnapshot(t, t.Context(), s.bucket, ns, mk(-5*time.Minute), &IndexMeta{BuildVersion: "11.4.0"})
 				match := mk(-30 * time.Minute)
-				s.put(match, &IndexMeta{BuildVersion: "11.5.0"})
-				s.put(mk(-50*time.Minute), &IndexMeta{BuildVersion: "11.5.0"})
+				seedSnapshot(t, t.Context(), s.bucket, ns, match, &IndexMeta{BuildVersion: "11.5.0"})
+				seedSnapshot(t, t.Context(), s.bucket, ns, mk(-50*time.Minute), &IndexMeta{BuildVersion: "11.5.0"})
 				return match
 			},
 		},
 		{
 			name:  "no candidates",
-			setup: func(s *fakeRemoteIndexStore) ulid.ULID { return ulid.ULID{} },
+			setup: func(*testing.T, *hookableStore, resource.NamespacedResource) ulid.ULID { return ulid.ULID{} },
 		},
 		{
 			name: "tolerates ErrSnapshotNotFound and ErrInvalidManifest mid-walk",
-			setup: func(s *fakeRemoteIndexStore) ulid.ULID {
+			setup: func(t *testing.T, s *hookableStore, ns resource.NamespacedResource) ulid.ULID {
 				nf := mk(-5 * time.Minute)
-				s.put(nf, &IndexMeta{BuildVersion: "11.5.0"})
-				s.getErr[nf] = ErrSnapshotNotFound
+				seedSnapshot(t, t.Context(), s.bucket, ns, nf, &IndexMeta{BuildVersion: "11.5.0"})
+				s.setGetMetaErr(nf, ErrSnapshotNotFound)
 				iv := mk(-10 * time.Minute)
-				s.put(iv, &IndexMeta{BuildVersion: "11.5.0"})
-				s.getErr[iv] = ErrInvalidManifest
+				seedSnapshot(t, t.Context(), s.bucket, ns, iv, &IndexMeta{BuildVersion: "11.5.0"})
+				s.setGetMetaErr(iv, ErrInvalidManifest)
 				m := mk(-15 * time.Minute)
-				s.put(m, &IndexMeta{BuildVersion: "11.5.0"})
+				seedSnapshot(t, t.Context(), s.bucket, ns, m, &IndexMeta{BuildVersion: "11.5.0"})
 				return m
 			},
 		},
 		{
 			name: "surfaces list error",
-			setup: func(s *fakeRemoteIndexStore) ulid.ULID {
-				s.listErr = errors.New("boom")
+			setup: func(t *testing.T, s *hookableStore, _ resource.NamespacedResource) ulid.ULID {
+				s.setListKeysErr(errors.New("boom"))
 				return ulid.ULID{}
 			},
 			wantErr: "boom",
 		},
 		{
 			name: "surfaces unexpected GET error",
-			setup: func(s *fakeRemoteIndexStore) ulid.ULID {
+			setup: func(t *testing.T, s *hookableStore, ns resource.NamespacedResource) ulid.ULID {
 				bad := mk(-5 * time.Minute)
-				s.put(bad, &IndexMeta{BuildVersion: "11.5.0"})
-				s.getErr[bad] = errors.New("transport boom")
+				seedSnapshot(t, t.Context(), s.bucket, ns, bad, &IndexMeta{BuildVersion: "11.5.0"})
+				s.setGetMetaErr(bad, errors.New("transport boom"))
 				return ulid.ULID{}
 			},
 			wantErr: "transport boom",
@@ -1175,20 +1060,20 @@ func TestFindFreshSnapshotByBuildStart(t *testing.T) {
 	runProbeCases(t, findFreshSnapshotByBuildStart, []probeCase{
 		{
 			name: "homogeneous cluster: newest same-version returned",
-			setup: func(s *fakeRemoteIndexStore) ulid.ULID {
-				s.put(mk(-30*time.Minute), &IndexMeta{BuildVersion: "11.5.0", BuildTime: now.Add(-35 * time.Minute)})
+			setup: func(t *testing.T, s *hookableStore, ns resource.NamespacedResource) ulid.ULID {
+				seedSnapshot(t, t.Context(), s.bucket, ns, mk(-30*time.Minute), &IndexMeta{BuildVersion: "11.5.0", BuildTime: now.Add(-35 * time.Minute)})
 				k := mk(-5 * time.Minute)
-				s.put(k, &IndexMeta{BuildVersion: "11.5.0", BuildTime: now.Add(-10 * time.Minute)})
+				seedSnapshot(t, t.Context(), s.bucket, ns, k, &IndexMeta{BuildVersion: "11.5.0", BuildTime: now.Add(-10 * time.Minute)})
 				return k
 			},
 		},
 		{
 			name: "mixed version: walks past newer wrong-version",
-			setup: func(s *fakeRemoteIndexStore) ulid.ULID {
-				s.put(mk(-5*time.Minute), &IndexMeta{BuildVersion: "11.4.0", BuildTime: now.Add(-10 * time.Minute)})
+			setup: func(t *testing.T, s *hookableStore, ns resource.NamespacedResource) ulid.ULID {
+				seedSnapshot(t, t.Context(), s.bucket, ns, mk(-5*time.Minute), &IndexMeta{BuildVersion: "11.4.0", BuildTime: now.Add(-10 * time.Minute)})
 				match := mk(-30 * time.Minute)
-				s.put(match, &IndexMeta{BuildVersion: "11.5.0", BuildTime: now.Add(-35 * time.Minute)})
-				s.put(mk(-50*time.Minute), &IndexMeta{BuildVersion: "11.5.0", BuildTime: now.Add(-55 * time.Minute)})
+				seedSnapshot(t, t.Context(), s.bucket, ns, match, &IndexMeta{BuildVersion: "11.5.0", BuildTime: now.Add(-35 * time.Minute)})
+				seedSnapshot(t, t.Context(), s.bucket, ns, mk(-50*time.Minute), &IndexMeta{BuildVersion: "11.5.0", BuildTime: now.Add(-55 * time.Minute)})
 				return match
 			},
 		},
@@ -1197,140 +1082,56 @@ func TestFindFreshSnapshotByBuildStart(t *testing.T) {
 			// recent ULID + matching version + old BuildTime (a periodic
 			// re-upload of a long-lived index) must be rejected.
 			name: "skips recent re-upload of old build",
-			setup: func(s *fakeRemoteIndexStore) ulid.ULID {
-				s.put(mk(-5*time.Minute), &IndexMeta{BuildVersion: "11.5.0", BuildTime: now.Add(-3 * time.Hour)})
+			setup: func(t *testing.T, s *hookableStore, ns resource.NamespacedResource) ulid.ULID {
+				seedSnapshot(t, t.Context(), s.bucket, ns, mk(-5*time.Minute), &IndexMeta{BuildVersion: "11.5.0", BuildTime: now.Add(-3 * time.Hour)})
 				return ulid.ULID{}
 			},
 		},
 		{
 			// Zero-value BuildTime carries no freshness signal.
 			name: "skips zero BuildTime",
-			setup: func(s *fakeRemoteIndexStore) ulid.ULID {
-				s.put(mk(-5*time.Minute), &IndexMeta{BuildVersion: "11.5.0"})
+			setup: func(t *testing.T, s *hookableStore, ns resource.NamespacedResource) ulid.ULID {
+				seedSnapshot(t, t.Context(), s.bucket, ns, mk(-5*time.Minute), &IndexMeta{BuildVersion: "11.5.0"})
 				return ulid.ULID{}
 			},
 		},
 		{
 			name:  "no candidates",
-			setup: func(s *fakeRemoteIndexStore) ulid.ULID { return ulid.ULID{} },
+			setup: func(*testing.T, *hookableStore, resource.NamespacedResource) ulid.ULID { return ulid.ULID{} },
 		},
 		{
 			name: "tolerates ErrSnapshotNotFound and ErrInvalidManifest mid-walk",
-			setup: func(s *fakeRemoteIndexStore) ulid.ULID {
+			setup: func(t *testing.T, s *hookableStore, ns resource.NamespacedResource) ulid.ULID {
 				nf := mk(-5 * time.Minute)
-				s.put(nf, &IndexMeta{BuildVersion: "11.5.0", BuildTime: now.Add(-10 * time.Minute)})
-				s.getErr[nf] = ErrSnapshotNotFound
+				seedSnapshot(t, t.Context(), s.bucket, ns, nf, &IndexMeta{BuildVersion: "11.5.0", BuildTime: now.Add(-10 * time.Minute)})
+				s.setGetMetaErr(nf, ErrSnapshotNotFound)
 				iv := mk(-10 * time.Minute)
-				s.put(iv, &IndexMeta{BuildVersion: "11.5.0", BuildTime: now.Add(-15 * time.Minute)})
-				s.getErr[iv] = ErrInvalidManifest
+				seedSnapshot(t, t.Context(), s.bucket, ns, iv, &IndexMeta{BuildVersion: "11.5.0", BuildTime: now.Add(-15 * time.Minute)})
+				s.setGetMetaErr(iv, ErrInvalidManifest)
 				m := mk(-15 * time.Minute)
-				s.put(m, &IndexMeta{BuildVersion: "11.5.0", BuildTime: now.Add(-20 * time.Minute)})
+				seedSnapshot(t, t.Context(), s.bucket, ns, m, &IndexMeta{BuildVersion: "11.5.0", BuildTime: now.Add(-20 * time.Minute)})
 				return m
 			},
 		},
 		{
 			name: "surfaces list error",
-			setup: func(s *fakeRemoteIndexStore) ulid.ULID {
-				s.listErr = errors.New("boom")
+			setup: func(t *testing.T, s *hookableStore, _ resource.NamespacedResource) ulid.ULID {
+				s.setListKeysErr(errors.New("boom"))
 				return ulid.ULID{}
 			},
 			wantErr: "boom",
 		},
 		{
 			name: "surfaces unexpected GET error",
-			setup: func(s *fakeRemoteIndexStore) ulid.ULID {
+			setup: func(t *testing.T, s *hookableStore, ns resource.NamespacedResource) ulid.ULID {
 				bad := mk(-5 * time.Minute)
-				s.put(bad, &IndexMeta{BuildVersion: "11.5.0", BuildTime: now.Add(-10 * time.Minute)})
-				s.getErr[bad] = errors.New("transport boom")
+				seedSnapshot(t, t.Context(), s.bucket, ns, bad, &IndexMeta{BuildVersion: "11.5.0", BuildTime: now.Add(-10 * time.Minute)})
+				s.setGetMetaErr(bad, errors.New("transport boom"))
 				return ulid.ULID{}
 			},
 			wantErr: "transport boom",
 		},
 	})
-}
-
-// coldStartFakeStore extends fakeRemoteIndexStore with controllable lock
-// behaviour and an UploadIndex stub so we can exercise cold-start
-// coordination paths (acquired-lock, downloaded-after-wait, wait-timed-
-// out, lock backend error). Snapshot data and its mutex come from the
-// embedded base store; this struct's own mu guards only lock-state
-// fields.
-type coldStartFakeStore struct {
-	*fakeRemoteIndexStore
-
-	mu                sync.Mutex // guards lockHeld, lockBackendErr, currentLock
-	lockHeld          bool
-	lockBackendErr    error // returned (instead of errLockHeld) when set
-	currentLock       *coldStartFakeLock
-	lockAcquireCalls  atomic.Int32
-	lockReleasedCalls atomic.Int32
-
-	uploadCalls atomic.Int32
-}
-
-func newColdStartFakeStore() *coldStartFakeStore {
-	return &coldStartFakeStore{fakeRemoteIndexStore: &fakeRemoteIndexStore{}}
-}
-
-func (s *coldStartFakeStore) setLockHeld(held bool) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	s.lockHeld = held
-}
-
-func (s *coldStartFakeStore) LockBuildIndex(context.Context, resource.NamespacedResource, string) (IndexStoreLock, error) {
-	s.lockAcquireCalls.Add(1)
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if s.lockBackendErr != nil {
-		return nil, s.lockBackendErr
-	}
-	if s.lockHeld {
-		return nil, errLockHeld
-	}
-	s.lockHeld = true
-	s.currentLock = &coldStartFakeLock{store: s, lost: make(chan struct{})}
-	return s.currentLock, nil
-}
-
-// signalLockLost simulates a heartbeat-detected lease loss on the most
-// recently acquired lock. Tests use this to drive the leader's pre-upload
-// checkSnapshotLock branch.
-func (s *coldStartFakeStore) signalLockLost() {
-	s.mu.Lock()
-	lock := s.currentLock
-	s.mu.Unlock()
-	if lock != nil {
-		lock.markLost()
-	}
-}
-
-func (s *coldStartFakeStore) UploadIndex(context.Context, resource.NamespacedResource, string, IndexMeta) (ulid.ULID, error) {
-	s.uploadCalls.Add(1)
-	return ulid.Make(), nil
-}
-
-type coldStartFakeLock struct {
-	store       *coldStartFakeStore
-	lost        chan struct{}
-	releaseOnce sync.Once
-	lostOnce    sync.Once
-}
-
-func (l *coldStartFakeLock) Release() error {
-	l.releaseOnce.Do(func() {
-		l.store.mu.Lock()
-		l.store.lockHeld = false
-		l.store.mu.Unlock()
-		l.store.lockReleasedCalls.Add(1)
-	})
-	return nil
-}
-
-func (l *coldStartFakeLock) Lost() <-chan struct{} { return l.lost }
-
-func (l *coldStartFakeLock) markLost() {
-	l.lostOnce.Do(func() { close(l.lost) })
 }
 
 // withColdStartTimings overrides the package-level wait-loop timings for the
@@ -1350,12 +1151,12 @@ func withColdStartTimings(t *testing.T, poll, total time.Duration) {
 type coldStartTest struct {
 	be          *bleveBackend
 	metrics     *resource.BleveIndexMetrics
-	store       *coldStartFakeStore
+	store       *hookableStore
 	ns          resource.NamespacedResource
 	resourceDir string
 }
 
-func newColdStartTest(t *testing.T, store *coldStartFakeStore) coldStartTest {
+func newColdStartTest(t *testing.T, store *hookableStore) coldStartTest {
 	t.Helper()
 	be, metrics := newTestBleveBackend(t, SnapshotOptions{
 		Store:       store,
@@ -1392,7 +1193,7 @@ func (ct coldStartTest) coldStartCounter(outcome string) float64 {
 }
 
 func TestColdStart_BecameLeader(t *testing.T) {
-	store := newColdStartFakeStore()
+	store := newHookableStore(t)
 	ct := newColdStartTest(t, store)
 
 	role, lock, err := ct.coordinate(context.Background(), time.Time{})
@@ -1402,39 +1203,48 @@ func TestColdStart_BecameLeader(t *testing.T) {
 	assert.Equal(t, int32(1), store.lockAcquireCalls.Load())
 	assert.Equal(t, 1.0, ct.coldStartCounter(coldStartOutcomeAcquiredLock))
 
-	// Releasing the leader's lock must unwind the fake's lockHeld state so
-	// other replicas can acquire next.
 	require.NoError(t, lock.Release())
-	store.mu.Lock()
-	assert.False(t, store.lockHeld)
-	store.mu.Unlock()
+	assert.Equal(t, int32(1), store.lockReleaseCalls.Load(),
+		"Release() must reach the underlying lock so the bucket entry is removed")
 }
 
 func TestColdStart_WaitedForLeader(t *testing.T) {
-	store := newColdStartFakeStore()
-	store.setLockHeld(true) // another instance is the leader
+	store := newHookableStore(t)
+	store.setLockBuildErr(errLockHeld) // another instance is the leader
 	ct := newColdStartTest(t, store)
 	withColdStartTimings(t, 10*time.Millisecond, time.Second)
 
+	// Build the snapshot on the test goroutine — the build uses require.*,
+	// which would violate testing.TB rules if called from the helper
+	// goroutine below. The helper goroutine only writes prepared bytes to
+	// the bucket and reports any error back via errCh.
+	snap := buildDownloadableSnapshot(t, ct.ns, makeULID(t, time.Now()), freshSnapshot(time.Minute))
+	ctx := t.Context()
+
 	// While coordinateColdStartBuild is in its wait loop, simulate the
-	// leader publishing a snapshot. The next probe tick should pick it up.
+	// leader publishing the prepared snapshot. The next probe tick should
+	// pick it up.
+	errCh := make(chan error, 1)
 	go func() {
 		time.Sleep(25 * time.Millisecond)
-		store.put(makeULID(t, time.Now()), freshSnapshot(time.Minute))
+		errCh <- snap.publish(ctx, store.bucket)
 	}()
 
 	role, lock, err := ct.coordinate(context.Background(), time.Time{})
 	require.NoError(t, err)
+	require.NoError(t, <-errCh)
 	assert.Equal(t, "downloaded", role)
 	assert.Nil(t, lock)
-	// The waiter must not steal the leader's lock.
-	assert.True(t, store.lockHeldNow())
+	// The waiter must not have taken the lock, so lockReleaseCalls stays at
+	// zero (no Release was invoked because no Acquire ever succeeded).
+	assert.Zero(t, store.lockReleaseCalls.Load(),
+		"waiter must not acquire the lock when a snapshot becomes available")
 	assert.Equal(t, 1.0, ct.coldStartCounter(coldStartOutcomeDownloadedAfterWait))
 }
 
 func TestColdStart_WaitTimeout(t *testing.T) {
-	store := newColdStartFakeStore()
-	store.setLockHeld(true)
+	store := newHookableStore(t)
+	store.setLockBuildErr(errLockHeld)
 	ct := newColdStartTest(t, store)
 	withColdStartTimings(t, 5*time.Millisecond, 30*time.Millisecond)
 
@@ -1448,8 +1258,8 @@ func TestColdStart_WaitTimeout(t *testing.T) {
 }
 
 func TestColdStart_AcquiresLockAfterLeaderRelease(t *testing.T) {
-	store := newColdStartFakeStore()
-	store.setLockHeld(true)
+	store := newHookableStore(t)
+	store.setLockBuildErr(errLockHeld)
 	ct := newColdStartTest(t, store)
 	withColdStartTimings(t, 10*time.Millisecond, time.Second)
 
@@ -1458,19 +1268,20 @@ func TestColdStart_AcquiresLockAfterLeaderRelease(t *testing.T) {
 	// promote us.
 	go func() {
 		time.Sleep(25 * time.Millisecond)
-		store.setLockHeld(false)
+		store.setLockBuildErr(nil)
 	}()
 
 	role, lock, err := ct.coordinate(context.Background(), time.Time{})
 	require.NoError(t, err)
 	assert.Equal(t, "leader", role)
 	require.NotNil(t, lock)
+	t.Cleanup(func() { _ = lock.Release() })
 	assert.Equal(t, 1.0, ct.coldStartCounter(coldStartOutcomeAcquiredLock))
 }
 
 func TestColdStart_LockBackendErrorBuildsAlone(t *testing.T) {
-	store := newColdStartFakeStore()
-	store.lockBackendErr = errors.New("backend down")
+	store := newHookableStore(t)
+	store.setLockBuildErr(errors.New("backend down"))
 	ct := newColdStartTest(t, store)
 
 	role, lock, err := ct.coordinate(context.Background(), time.Time{})
@@ -1484,8 +1295,8 @@ func TestColdStart_LockBackendErrorBuildsAlone(t *testing.T) {
 // error returned by LockBuildIndex itself (e.g. cancellation arriving
 // mid-acquire) is propagated, not swallowed as a build-alone fallback.
 func TestColdStart_LockBackendContextErrorPropagates(t *testing.T) {
-	store := newColdStartFakeStore()
-	store.lockBackendErr = context.Canceled
+	store := newHookableStore(t)
+	store.setLockBuildErr(context.Canceled)
 	ct := newColdStartTest(t, store)
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -1499,8 +1310,8 @@ func TestColdStart_LockBackendContextErrorPropagates(t *testing.T) {
 }
 
 func TestColdStart_ContextCancelInWaitLoop(t *testing.T) {
-	store := newColdStartFakeStore()
-	store.setLockHeld(true)
+	store := newHookableStore(t)
+	store.setLockBuildErr(errLockHeld)
 	ct := newColdStartTest(t, store)
 	withColdStartTimings(t, 10*time.Millisecond, time.Second)
 
@@ -1551,8 +1362,8 @@ func runBuildIndexColdStart(t *testing.T, store RemoteIndexStore, builderExtra f
 // With a fresh snapshot present, the tiered selection runs first and
 // downloads it before the cold-start path is even considered.
 func TestBuildIndex_ColdStartFastPathDownloads(t *testing.T) {
-	store := newColdStartFakeStore()
-	store.put(makeULID(t, time.Now()), freshSnapshot(time.Minute))
+	store := newHookableStore(t)
+	seedDownloadableSnapshot(t, t.Context(), store.bucket, newTestNsResource(), makeULID(t, time.Now()), freshSnapshot(time.Minute))
 	metrics, builderCalled, idx, err := runBuildIndexColdStart(t, store, nil)
 	require.NoError(t, err)
 	require.NotNil(t, idx)
@@ -1568,14 +1379,14 @@ func TestBuildIndex_ColdStartFastPathDownloads(t *testing.T) {
 // store, leader builds from scratch, and the leader's freshly-built snapshot
 // is uploaded immediately under the held lock.
 func TestBuildIndex_ColdStartLeaderUploads(t *testing.T) {
-	store := newColdStartFakeStore()
+	store := newHookableStore(t)
 	metrics, builderCalled, idx, err := runBuildIndexColdStart(t, store, nil)
 	require.NoError(t, err)
 	require.NotNil(t, idx)
 
 	assert.Equal(t, int32(1), builderCalled.Load(), "builder must run on the leader path")
 	assert.Equal(t, int32(1), store.uploadCalls.Load(), "leader must upload immediately")
-	assert.Equal(t, int32(1), store.lockReleasedCalls.Load(), "leader must release the build lock")
+	assert.Equal(t, int32(1), store.lockReleaseCalls.Load(), "leader must release the build lock")
 	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotColdStarts.WithLabelValues(coldStartOutcomeAcquiredLock)))
 	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotUploads.WithLabelValues(snapshotUploadStatusSuccess)))
 }
@@ -1585,7 +1396,7 @@ func TestBuildIndex_ColdStartLeaderUploads(t *testing.T) {
 // is skipped (recorded as skip_lock_lost) but the build itself still
 // completes — lock-lost is coordination, not a fatal error.
 func TestBuildIndex_ColdStartLeaderLockLostDuringBuild(t *testing.T) {
-	store := newColdStartFakeStore()
+	store := newHookableStore(t)
 	// Simulate heartbeat-detected lease loss while we're in the middle of
 	// the from-scratch build.
 	metrics, builderCalled, idx, err := runBuildIndexColdStart(t, store, store.signalLockLost)
@@ -1594,7 +1405,7 @@ func TestBuildIndex_ColdStartLeaderLockLostDuringBuild(t *testing.T) {
 
 	assert.Equal(t, int32(1), builderCalled.Load(), "builder must run on the leader path")
 	assert.Zero(t, store.uploadCalls.Load(), "leader must skip immediate upload after lock loss")
-	assert.Equal(t, int32(1), store.lockReleasedCalls.Load(), "leader still releases the lock object")
+	assert.Equal(t, int32(1), store.lockReleaseCalls.Load(), "leader still releases the lock object")
 	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotUploads.WithLabelValues(snapshotUploadStatusSkipLockLost)))
 	assert.Zero(t, testutil.ToFloat64(metrics.IndexSnapshotUploads.WithLabelValues(snapshotUploadStatusSuccess)))
 }
@@ -1603,8 +1414,8 @@ func TestBuildIndex_ColdStartLeaderLockLostDuringBuild(t *testing.T) {
 // permanently held by another instance and no snapshot ever appears, the
 // timeout path runs the builder anyway (no upload).
 func TestBuildIndex_ColdStartTimeoutBuildsAlone(t *testing.T) {
-	store := newColdStartFakeStore()
-	store.setLockHeld(true)
+	store := newHookableStore(t)
+	store.setLockBuildErr(errLockHeld)
 	withColdStartTimings(t, 5*time.Millisecond, 30*time.Millisecond)
 	metrics, builderCalled, idx, err := runBuildIndexColdStart(t, store, nil)
 	require.NoError(t, err)
@@ -1620,7 +1431,7 @@ func TestBuildIndex_ColdStartTimeoutBuildsAlone(t *testing.T) {
 // cold-start coordination still runs, the leader path is taken, and the
 // freshly-built snapshot is uploaded immediately under the held lock.
 func TestBuildIndex_ColdStartRunsWhenMaxIndexAgeZero(t *testing.T) {
-	store := newColdStartFakeStore()
+	store := newHookableStore(t)
 	be, metrics := newTestBleveBackend(t, SnapshotOptions{
 		Store:       store,
 		MinDocCount: 1,
@@ -1640,7 +1451,7 @@ func TestBuildIndex_ColdStartRunsWhenMaxIndexAgeZero(t *testing.T) {
 	assert.Equal(t, int32(1), builderCalled.Load(), "builder must run on the leader path")
 	assert.Equal(t, int32(1), store.lockAcquireCalls.Load(), "cold-start must attempt the lock even when MaxIndexAge=0")
 	assert.Equal(t, int32(1), store.uploadCalls.Load(), "leader must upload immediately")
-	assert.Equal(t, int32(1), store.lockReleasedCalls.Load(), "leader must release the build lock")
+	assert.Equal(t, int32(1), store.lockReleaseCalls.Load(), "leader must release the build lock")
 	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotColdStarts.WithLabelValues(coldStartOutcomeAcquiredLock)))
 	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotUploads.WithLabelValues(snapshotUploadStatusSuccess)))
 }
@@ -1649,8 +1460,8 @@ func TestBuildIndex_ColdStartRunsWhenMaxIndexAgeZero(t *testing.T) {
 // cancellation during cold-start coordination aborts BuildIndex with the
 // context error rather than falling back to a full from-scratch build.
 func TestBuildIndex_ColdStartContextCancelPropagates(t *testing.T) {
-	store := newColdStartFakeStore()
-	store.setLockHeld(true) // force entry to the wait loop
+	store := newHookableStore(t)
+	store.setLockBuildErr(errLockHeld) // force entry to the wait loop
 	withColdStartTimings(t, 5*time.Millisecond, time.Second)
 	be, _ := newTestBleveBackend(t, SnapshotOptions{
 		Store:       store,
@@ -1674,12 +1485,4 @@ func TestBuildIndex_ColdStartContextCancelPropagates(t *testing.T) {
 	require.ErrorIs(t, err, context.Canceled)
 	assert.Nil(t, idx)
 	assert.Zero(t, builderCalled.Load(), "builder must not run after context cancel")
-}
-
-// lockHeldNow exposes the fake's lockHeld state for tests that assert the
-// leader's lock survived a download by a waiter.
-func (s *coldStartFakeStore) lockHeldNow() bool {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	return s.lockHeld
 }

--- a/pkg/storage/unified/search/bleve_snapshot_upload_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_upload_test.go
@@ -3,15 +3,12 @@ package search
 import (
 	"context"
 	"errors"
-	"io/fs"
 	"os"
 	"path/filepath"
-	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/blevesearch/bleve/v2"
-	"github.com/oklog/ulid/v2"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	dto "github.com/prometheus/client_model/go"
 	"github.com/stretchr/testify/assert"
@@ -20,87 +17,6 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
-
-type uploadTestStore struct {
-	fakeRemoteIndexStore
-
-	lockErr          error
-	lockBuildVersion string
-
-	uploadErr   error
-	uploadCalls atomic.Int32
-	uploadMeta  IndexMeta
-	uploaded    []string
-	onUpload    func() error
-}
-
-func (s *uploadTestStore) LockBuildIndex(_ context.Context, _ resource.NamespacedResource, buildVersion string) (IndexStoreLock, error) {
-	s.lockBuildVersion = buildVersion
-	if s.lockErr != nil {
-		return nil, s.lockErr
-	}
-	return &noopIndexStoreLock{lost: make(chan struct{})}, nil
-}
-
-func (s *uploadTestStore) UploadIndex(_ context.Context, _ resource.NamespacedResource, localDir string, meta IndexMeta) (ulid.ULID, error) {
-	s.uploadCalls.Add(1)
-	s.uploadMeta = meta
-
-	err := filepath.WalkDir(localDir, func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() {
-			return nil
-		}
-		rel, err := filepath.Rel(localDir, path)
-		if err != nil {
-			return err
-		}
-		s.uploaded = append(s.uploaded, filepath.ToSlash(rel))
-		return nil
-	})
-	if err != nil {
-		return ulid.ULID{}, err
-	}
-	if s.onUpload != nil {
-		if err := s.onUpload(); err != nil {
-			return ulid.ULID{}, err
-		}
-	}
-	if s.uploadErr != nil {
-		return ulid.ULID{}, s.uploadErr
-	}
-	return ulid.Make(), nil
-}
-
-func (s *uploadTestStore) DownloadIndex(context.Context, resource.NamespacedResource, ulid.ULID, string) (*IndexMeta, error) {
-	panic("DownloadIndex not implemented for uploadTestStore")
-}
-
-func (s *uploadTestStore) ListIndexes(context.Context, resource.NamespacedResource) (map[ulid.ULID]*IndexMeta, error) {
-	panic("ListIndexes not implemented for uploadTestStore")
-}
-
-func (s *uploadTestStore) DeleteIndex(context.Context, resource.NamespacedResource, ulid.ULID) error {
-	panic("DeleteIndex not implemented for uploadTestStore")
-}
-
-func (s *uploadTestStore) CleanupIncompleteUploads(context.Context, resource.NamespacedResource, time.Duration) (int, error) {
-	panic("CleanupIncompleteUploads not implemented for uploadTestStore")
-}
-
-func (s *uploadTestStore) ListNamespaces(context.Context) ([]string, error) {
-	panic("ListNamespaces not implemented for uploadTestStore")
-}
-
-func (s *uploadTestStore) ListNamespaceIndexes(context.Context, string) ([]resource.NamespacedResource, error) {
-	panic("ListNamespaceIndexes not implemented for uploadTestStore")
-}
-
-func (s *uploadTestStore) LockNamespaceForCleanup(context.Context, string) (IndexStoreLock, error) {
-	panic("LockNamespaceForCleanup not implemented for uploadTestStore")
-}
 
 func newUploadTestIndex(t *testing.T, be *bleveBackend, key resource.NamespacedResource, rv int64) *bleveIndex {
 	t.Helper()
@@ -161,7 +77,7 @@ func TestSnapshotIndex_CreatesUsableCopy(t *testing.T) {
 }
 
 func TestUploadSnapshot_Success(t *testing.T) {
-	store := &uploadTestStore{}
+	store := newHookableStore(t)
 	be, _ := newTestBleveBackend(t, SnapshotOptions{Store: store})
 	key := newTestNsResource()
 	beforeBuild := time.Now().Add(-time.Second).Truncate(time.Second)
@@ -169,16 +85,17 @@ func TestUploadSnapshot_Success(t *testing.T) {
 
 	require.NoError(t, be.uploadSnapshot(context.Background(), key, idx))
 	assert.Equal(t, int32(1), store.uploadCalls.Load())
-	assert.Equal(t, int64(42), store.uploadMeta.LatestResourceVersion)
-	assert.Equal(t, be.opts.BuildVersion, store.uploadMeta.BuildVersion)
-	assert.Equal(t, be.opts.BuildVersion, store.lockBuildVersion)
+	uploadedMeta := store.getLastUploadedMeta()
+	assert.Equal(t, int64(42), uploadedMeta.LatestResourceVersion)
+	assert.Equal(t, be.opts.BuildVersion, uploadedMeta.BuildVersion)
+	assert.Equal(t, be.opts.BuildVersion, store.getLastLockBuildVersion())
 	// BuildTime must be populated from the index's internal build
 	// info (set by newBleveIndex), not left zero. Compare with second-level
 	// granularity since buildInfo persists Unix seconds.
-	assert.False(t, store.uploadMeta.BuildTime.IsZero(), "BuildTime should be set")
-	assert.False(t, store.uploadMeta.BuildTime.Before(beforeBuild),
-		"BuildTime %s should be at or after %s", store.uploadMeta.BuildTime, beforeBuild)
-	assert.NotEmpty(t, store.uploaded)
+	assert.False(t, uploadedMeta.BuildTime.IsZero(), "BuildTime should be set")
+	assert.False(t, uploadedMeta.BuildTime.Before(beforeBuild),
+		"BuildTime %s should be at or after %s", uploadedMeta.BuildTime, beforeBuild)
+	assert.NotEmpty(t, store.getLastUploadedFiles())
 
 	snapshotParent := filepath.Join(be.opts.Root, "snapshots", resourceSubPath(key))
 	entries, err := os.ReadDir(snapshotParent)
@@ -190,7 +107,7 @@ func TestUploadSnapshot_Success(t *testing.T) {
 // re-uploads of a long-lived index re-emit the original build-start time
 // (carried in the bleve index's internal buildInfo), not the upload time.
 func TestUploadSnapshot_PreservesOriginalBuildStartTime(t *testing.T) {
-	store := &uploadTestStore{}
+	store := newHookableStore(t)
 	be, _ := newTestBleveBackend(t, SnapshotOptions{Store: store})
 	key := newTestNsResource()
 
@@ -215,12 +132,13 @@ func TestUploadSnapshot_PreservesOriginalBuildStartTime(t *testing.T) {
 
 	require.NoError(t, be.uploadSnapshot(context.Background(), key, wrapped))
 	require.Equal(t, int32(1), store.uploadCalls.Load())
-	assert.Equal(t, originalBuildTime.UTC(), store.uploadMeta.BuildTime,
+	assert.Equal(t, originalBuildTime.UTC(), store.getLastUploadedMeta().BuildTime,
 		"periodic re-upload should preserve the original build-start time")
 }
 
 func TestUploadSnapshot_LockContention(t *testing.T) {
-	store := &uploadTestStore{lockErr: errLockHeld}
+	store := newHookableStore(t)
+	store.setLockBuildErr(errLockHeld)
 	be, _ := newTestBleveBackend(t, SnapshotOptions{Store: store})
 	key := newTestNsResource()
 	idx := newUploadTestIndex(t, be, key, 42)
@@ -231,7 +149,8 @@ func TestUploadSnapshot_LockContention(t *testing.T) {
 }
 
 func TestUploadSnapshot_UploadErrorCleansStagingDir(t *testing.T) {
-	store := &uploadTestStore{uploadErr: errors.New("boom")}
+	store := newHookableStore(t)
+	store.setUploadErr(errors.New("boom"))
 	be, _ := newTestBleveBackend(t, SnapshotOptions{Store: store})
 	key := newTestNsResource()
 	idx := newUploadTestIndex(t, be, key, 42)
@@ -246,7 +165,7 @@ func TestUploadSnapshot_UploadErrorCleansStagingDir(t *testing.T) {
 }
 
 func TestRunUploadSnapshots_Success(t *testing.T) {
-	store := &uploadTestStore{}
+	store := newHookableStore(t)
 	be, metrics := newTestBleveBackend(t, SnapshotOptions{Store: store, MinDocCount: 1, UploadInterval: time.Hour, MinDocChanges: 1})
 	key := newTestNsResource()
 	idx := newCachedUploadTestIndex(t, be, key, 42)
@@ -270,7 +189,7 @@ func TestRunUploadSnapshots_Success(t *testing.T) {
 }
 
 func TestRunUploadSnapshots_SkipNoChanges(t *testing.T) {
-	store := &uploadTestStore{}
+	store := newHookableStore(t)
 	be, metrics := newTestBleveBackend(t, SnapshotOptions{Store: store, MinDocCount: 1, UploadInterval: time.Hour, MinDocChanges: 10})
 	key := newTestNsResource()
 	idx := newCachedUploadTestIndex(t, be, key, 42)
@@ -306,7 +225,7 @@ func TestRunUploadSnapshots_OwnershipCheck(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			store := &uploadTestStore{}
+			store := newHookableStore(t)
 			be, metrics := newTestBleveBackend(t, SnapshotOptions{Store: store, MinDocCount: 1, UploadInterval: time.Hour, MinDocChanges: 1})
 			key := newTestNsResource()
 			idx := newCachedUploadTestIndex(t, be, key, 42)
@@ -323,7 +242,8 @@ func TestRunUploadSnapshots_OwnershipCheck(t *testing.T) {
 }
 
 func TestRunUploadSnapshots_SkipLockContention(t *testing.T) {
-	store := &uploadTestStore{lockErr: errLockHeld}
+	store := newHookableStore(t)
+	store.setLockBuildErr(errLockHeld)
 	be, metrics := newTestBleveBackend(t, SnapshotOptions{Store: store, MinDocCount: 1, UploadInterval: time.Hour, MinDocChanges: 1})
 	key := newTestNsResource()
 	idx := newCachedUploadTestIndex(t, be, key, 42)
@@ -337,12 +257,12 @@ func TestRunUploadSnapshots_SkipLockContention(t *testing.T) {
 }
 
 func TestRunUploadSnapshots_PreservesConcurrentMutations(t *testing.T) {
-	store := &uploadTestStore{}
+	store := newHookableStore(t)
 	be, _ := newTestBleveBackend(t, SnapshotOptions{Store: store, MinDocCount: 1, UploadInterval: time.Hour, MinDocChanges: 1})
 	key := newTestNsResource()
 	idx := newCachedUploadTestIndex(t, be, key, 42)
 	require.NoError(t, writeSnapshotMutationCount(idx.index, 3))
-	store.onUpload = func() error {
+	store.setOnUpload(func() error {
 		return idx.BulkIndex(&resource.BulkIndexRequest{Items: []*resource.BulkIndexItem{{
 			Action: resource.ActionIndex,
 			Doc: &resource.IndexableDocument{
@@ -356,7 +276,7 @@ func TestRunUploadSnapshots_PreservesConcurrentMutations(t *testing.T) {
 				},
 			},
 		}}})
-	}
+	})
 
 	be.runUploadSnapshots(context.Background())
 
@@ -372,12 +292,12 @@ func TestRunUploadSnapshots_PreservesConcurrentMutations(t *testing.T) {
 // snapshot exists within UploadInterval. The lock must not be acquired and no
 // upload must happen.
 func TestUploadSnapshot_SkipsWhenRecentSameVersionRemoteExists(t *testing.T) {
-	store := &uploadTestStore{}
+	store := newHookableStore(t)
 	recent := makeULID(t, time.Now().Add(-5*time.Minute))
-	store.put(recent, &IndexMeta{BuildVersion: "11.5.0"})
+	key := newTestNsResource()
+	seedSnapshot(t, context.Background(), store.bucket, key, recent, &IndexMeta{BuildVersion: "11.5.0"})
 
 	be, _ := newTestBleveBackend(t, SnapshotOptions{Store: store, UploadInterval: time.Hour})
-	key := newTestNsResource()
 	idx := newUploadTestIndex(t, be, key, 42)
 
 	err := be.uploadSnapshot(t.Context(), key, idx)
@@ -393,12 +313,12 @@ func TestUploadSnapshot_SkipsWhenRecentSameVersionRemoteExists(t *testing.T) {
 // TestUploadSnapshot_ProceedsWhenRemoteIsDifferentVersion verifies that the
 // probe does not skip when only different-version snapshots are present.
 func TestUploadSnapshot_ProceedsWhenRemoteIsDifferentVersion(t *testing.T) {
-	store := &uploadTestStore{}
+	store := newHookableStore(t)
 	recent := makeULID(t, time.Now().Add(-5*time.Minute))
-	store.put(recent, &IndexMeta{BuildVersion: "11.4.0"})
+	key := newTestNsResource()
+	seedSnapshot(t, context.Background(), store.bucket, key, recent, &IndexMeta{BuildVersion: "11.4.0"})
 
 	be, _ := newTestBleveBackend(t, SnapshotOptions{Store: store, UploadInterval: time.Hour})
-	key := newTestNsResource()
 	idx := newUploadTestIndex(t, be, key, 42)
 
 	require.NoError(t, be.uploadSnapshot(t.Context(), key, idx))
@@ -409,8 +329,8 @@ func TestUploadSnapshot_ProceedsWhenRemoteIsDifferentVersion(t *testing.T) {
 // optimisation, not a correctness check: a probe failure must not block the
 // upload path.
 func TestUploadSnapshot_ProceedsWhenProbeErrors(t *testing.T) {
-	store := &uploadTestStore{}
-	store.listErr = errors.New("transport boom")
+	store := newHookableStore(t)
+	store.setListIndexesErr(errors.New("transport boom"))
 	be, _ := newTestBleveBackend(t, SnapshotOptions{Store: store, UploadInterval: time.Hour})
 	key := newTestNsResource()
 	idx := newUploadTestIndex(t, be, key, 42)
@@ -422,7 +342,7 @@ func TestUploadSnapshot_ProceedsWhenProbeErrors(t *testing.T) {
 // TestUploadSnapshot_SkipsProbeWhenUploadIntervalZero verifies that the probe
 // is gated on UploadInterval > 0, mirroring the local lastUploadTime logic.
 func TestUploadSnapshot_SkipsProbeWhenUploadIntervalZero(t *testing.T) {
-	store := &uploadTestStore{}
+	store := newHookableStore(t)
 	be, _ := newTestBleveBackend(t, SnapshotOptions{Store: store /* UploadInterval omitted (0) */})
 	key := newTestNsResource()
 	idx := newUploadTestIndex(t, be, key, 42)
@@ -437,12 +357,12 @@ func TestUploadSnapshot_SkipsProbeWhenUploadIntervalZero(t *testing.T) {
 // skip_recent_remote metric is incremented, and the mutation baseline is
 // preserved (no snapshot was actually taken).
 func TestRunUploadSnapshots_SkipRecentRemote(t *testing.T) {
-	store := &uploadTestStore{}
+	store := newHookableStore(t)
 	recent := makeULID(t, time.Now().Add(-5*time.Minute))
-	store.put(recent, &IndexMeta{BuildVersion: "11.5.0"})
+	key := newTestNsResource()
+	seedSnapshot(t, context.Background(), store.bucket, key, recent, &IndexMeta{BuildVersion: "11.5.0"})
 
 	be, metrics := newTestBleveBackend(t, SnapshotOptions{Store: store, MinDocCount: 1, UploadInterval: time.Hour, MinDocChanges: 1})
-	key := newTestNsResource()
 	idx := newCachedUploadTestIndex(t, be, key, 42)
 	require.NoError(t, writeSnapshotMutationCount(idx.index, 5))
 

--- a/pkg/storage/unified/search/remote_index_cleanup_test.go
+++ b/pkg/storage/unified/search/remote_index_cleanup_test.go
@@ -2,7 +2,6 @@ package search
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"sync"
 	"sync/atomic"
@@ -326,23 +325,6 @@ func TestRunCleanup_ReplicaVersionAgnostic(t *testing.T) {
 }
 
 // --- end-to-end runCleanup tests against a memblob bucket ---
-
-// seedSnapshot writes a minimal but valid snapshot at indexKey under ns,
-// matching the layout BucketRemoteIndexStore expects: a single placeholder file
-// plus a snapshot manifest declaring it. Bypasses store.UploadIndex so tests can pin
-// arbitrary UploadTimestamps without being tied to wall-clock or ULID.Time().
-// Takes *IndexMeta so callers can use mkMeta directly.
-func seedSnapshot(t *testing.T, ctx context.Context, bucket *blob.Bucket, ns resource.NamespacedResource, indexKey ulid.ULID, meta *IndexMeta) {
-	t.Helper()
-	pfx := indexPrefix(ns, indexKey.String())
-	require.NoError(t, bucket.WriteAll(ctx, pfx+"store/data.bin", []byte("x"), nil))
-	if meta.Files == nil {
-		meta.Files = map[string]int64{"store/data.bin": 1}
-	}
-	metaBytes, err := json.Marshal(meta)
-	require.NoError(t, err)
-	require.NoError(t, bucket.WriteAll(ctx, pfx+snapshotManifestFile, metaBytes, nil))
-}
 
 // listSeededIndexKeys returns the index keys still present at ns in the bucket.
 func listSeededIndexKeys(t *testing.T, ctx context.Context, store *BucketRemoteIndexStore, ns resource.NamespacedResource) []ulid.ULID {

--- a/pkg/storage/unified/search/remote_index_store_test.go
+++ b/pkg/storage/unified/search/remote_index_store_test.go
@@ -8,9 +8,12 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1043,4 +1046,432 @@ func TestRemoteIndexStore_BuildAndCleanupLockTTLsWiredIndependently(t *testing.T
 	info, err = backend.Read(ctx, cleanupLockKey(ns.Namespace))
 	require.NoError(t, err)
 	require.Equal(t, cleanupTTL, info.TTL)
+}
+
+// hookableStore wraps a real BucketRemoteIndexStore (backed by an in-memory
+// memblob bucket) and adds per-method error injection, call counters,
+// mid-call callbacks, and controllable lock loss.
+//
+// Tests seed snapshots by writing directly to the bucket via seedSnapshot or
+// seedDownloadableSnapshot, which lets them pin manifest fields independent
+// of UploadIndex's ULID-derived UploadTimestamp.
+type hookableStore struct {
+	inner  *BucketRemoteIndexStore
+	bucket *blob.Bucket
+
+	// Error injection. nil means pass through to the inner store.
+	mu             sync.Mutex
+	lockBuildErr   error
+	lockCleanupErr error
+	listIndexesErr error
+	listKeysErr    error
+	downloadErr    error
+	uploadErr      error
+	getMetaErrs    map[ulid.ULID]error
+
+	onUpload func() error
+
+	// Counters.
+	lockAcquireCalls atomic.Int32
+	lockReleaseCalls atomic.Int32
+	listCalls        atomic.Int32
+	listKeyCalls     atomic.Int32
+	getMetaCalls     atomic.Int32
+	downloadCalls    atomic.Int32
+	uploadCalls      atomic.Int32
+
+	// Last-call observations. Tests that previously inspected fake-internal
+	// state read these instead.
+	lastUploadedMeta     IndexMeta
+	lastUploadedFiles    []string
+	lastLockBuildVersion string
+
+	// Tracks the most recently acquired build lock so signalLockLost can
+	// fire it.
+	currentLock *hookableLock
+}
+
+// newHookableStore returns a fresh hookableStore wrapping a real
+// BucketRemoteIndexStore over an in-memory memblob bucket.
+func newHookableStore(t *testing.T) *hookableStore {
+	t.Helper()
+	bucket := memblob.OpenBucket(nil)
+	t.Cleanup(func() { _ = bucket.Close() })
+	return &hookableStore{
+		inner:  newTestRemoteIndexStore(t, bucket),
+		bucket: bucket,
+	}
+}
+
+func (s *hookableStore) LockBuildIndex(ctx context.Context, ns resource.NamespacedResource, buildVersion string) (IndexStoreLock, error) {
+	s.lockAcquireCalls.Add(1)
+	s.mu.Lock()
+	s.lastLockBuildVersion = buildVersion
+	injected := s.lockBuildErr
+	s.mu.Unlock()
+	if injected != nil {
+		return nil, injected
+	}
+	innerLock, err := s.inner.LockBuildIndex(ctx, ns, buildVersion)
+	if err != nil {
+		return nil, err
+	}
+	lock := newHookableLock(innerLock, s)
+	s.mu.Lock()
+	s.currentLock = lock
+	s.mu.Unlock()
+	return lock, nil
+}
+
+func (s *hookableStore) LockNamespaceForCleanup(ctx context.Context, namespace string) (IndexStoreLock, error) {
+	s.mu.Lock()
+	injected := s.lockCleanupErr
+	s.mu.Unlock()
+	if injected != nil {
+		return nil, injected
+	}
+	return s.inner.LockNamespaceForCleanup(ctx, namespace)
+}
+
+func (s *hookableStore) UploadIndex(ctx context.Context, ns resource.NamespacedResource, localDir string, meta IndexMeta) (ulid.ULID, error) {
+	s.uploadCalls.Add(1)
+	s.mu.Lock()
+	onUpload := s.onUpload
+	injected := s.uploadErr
+	s.lastUploadedMeta = meta
+	s.lastUploadedFiles = nil
+	s.mu.Unlock()
+
+	// Capture the relative paths the caller intends to upload by walking
+	// localDir before delegating. This mirrors what BucketRemoteIndexStore
+	// itself does, so tests can assert on the file set without inspecting
+	// the bucket afterwards.
+	var files []string
+	if walkErr := filepath.WalkDir(localDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, relErr := filepath.Rel(localDir, path)
+		if relErr != nil {
+			return relErr
+		}
+		files = append(files, filepath.ToSlash(rel))
+		return nil
+	}); walkErr != nil {
+		return ulid.ULID{}, walkErr
+	}
+	s.mu.Lock()
+	s.lastUploadedFiles = files
+	s.mu.Unlock()
+
+	if onUpload != nil {
+		if err := onUpload(); err != nil {
+			return ulid.ULID{}, err
+		}
+	}
+	if injected != nil {
+		return ulid.ULID{}, injected
+	}
+	return s.inner.UploadIndex(ctx, ns, localDir, meta)
+}
+
+func (s *hookableStore) DownloadIndex(ctx context.Context, ns resource.NamespacedResource, indexKey ulid.ULID, destDir string) (*IndexMeta, error) {
+	s.downloadCalls.Add(1)
+	s.mu.Lock()
+	injected := s.downloadErr
+	s.mu.Unlock()
+	if injected != nil {
+		return nil, injected
+	}
+	return s.inner.DownloadIndex(ctx, ns, indexKey, destDir)
+}
+
+func (s *hookableStore) ListNamespaces(ctx context.Context) ([]string, error) {
+	return s.inner.ListNamespaces(ctx)
+}
+
+func (s *hookableStore) ListNamespaceIndexes(ctx context.Context, namespace string) ([]resource.NamespacedResource, error) {
+	return s.inner.ListNamespaceIndexes(ctx, namespace)
+}
+
+func (s *hookableStore) ListIndexes(ctx context.Context, ns resource.NamespacedResource) (map[ulid.ULID]*IndexMeta, error) {
+	s.listCalls.Add(1)
+	s.mu.Lock()
+	injected := s.listIndexesErr
+	s.mu.Unlock()
+	if injected != nil {
+		return nil, injected
+	}
+	return s.inner.ListIndexes(ctx, ns)
+}
+
+func (s *hookableStore) ListIndexKeys(ctx context.Context, ns resource.NamespacedResource) ([]ulid.ULID, error) {
+	s.listKeyCalls.Add(1)
+	s.mu.Lock()
+	injected := s.listKeysErr
+	s.mu.Unlock()
+	if injected != nil {
+		return nil, injected
+	}
+	return s.inner.ListIndexKeys(ctx, ns)
+}
+
+func (s *hookableStore) GetIndexMeta(ctx context.Context, ns resource.NamespacedResource, indexKey ulid.ULID) (*IndexMeta, error) {
+	s.getMetaCalls.Add(1)
+	s.mu.Lock()
+	injected := s.getMetaErrs[indexKey]
+	s.mu.Unlock()
+	if injected != nil {
+		return nil, injected
+	}
+	return s.inner.GetIndexMeta(ctx, ns, indexKey)
+}
+
+func (s *hookableStore) DeleteIndex(ctx context.Context, ns resource.NamespacedResource, indexKey ulid.ULID) error {
+	return s.inner.DeleteIndex(ctx, ns, indexKey)
+}
+
+func (s *hookableStore) CleanupIncompleteUploads(ctx context.Context, ns resource.NamespacedResource, minAge time.Duration) (int, error) {
+	return s.inner.CleanupIncompleteUploads(ctx, ns, minAge)
+}
+
+// setLockBuildErr installs an error for the next LockBuildIndex calls. Use
+// errLockHeld to simulate "another instance is the leader", or any other
+// error to simulate a lock-backend failure. Pass nil to clear.
+func (s *hookableStore) setLockBuildErr(err error) {
+	s.mu.Lock()
+	s.lockBuildErr = err
+	s.mu.Unlock()
+}
+
+func (s *hookableStore) setListIndexesErr(err error) {
+	s.mu.Lock()
+	s.listIndexesErr = err
+	s.mu.Unlock()
+}
+
+func (s *hookableStore) setListKeysErr(err error) {
+	s.mu.Lock()
+	s.listKeysErr = err
+	s.mu.Unlock()
+}
+
+func (s *hookableStore) setUploadErr(err error) {
+	s.mu.Lock()
+	s.uploadErr = err
+	s.mu.Unlock()
+}
+
+func (s *hookableStore) setDownloadErr(err error) {
+	s.mu.Lock()
+	s.downloadErr = err
+	s.mu.Unlock()
+}
+
+// getLastUploadedMeta returns the IndexMeta passed to the most recent
+// UploadIndex call, guarded by the same mutex used for error injection.
+func (s *hookableStore) getLastUploadedMeta() IndexMeta {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastUploadedMeta
+}
+
+// getLastUploadedFiles returns the slash-separated relative paths captured
+// during the most recent UploadIndex call.
+func (s *hookableStore) getLastUploadedFiles() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.lastUploadedFiles...)
+}
+
+func (s *hookableStore) getLastLockBuildVersion() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastLockBuildVersion
+}
+
+// setGetMetaErr installs an error to return on GetIndexMeta(indexKey).
+// Existing snapshot data in the bucket is left in place — only the manifest
+// read for this key fails.
+func (s *hookableStore) setGetMetaErr(indexKey ulid.ULID, err error) {
+	s.mu.Lock()
+	if s.getMetaErrs == nil {
+		s.getMetaErrs = map[ulid.ULID]error{}
+	}
+	s.getMetaErrs[indexKey] = err
+	s.mu.Unlock()
+}
+
+// setOnUpload installs a callback fired inside UploadIndex before delegating
+// to the inner store. The callback's returned error short-circuits the
+// upload. Used to trigger races (e.g. concurrent mutations during upload)
+// at a deterministic point.
+func (s *hookableStore) setOnUpload(fn func() error) {
+	s.mu.Lock()
+	s.onUpload = fn
+	s.mu.Unlock()
+}
+
+// signalLockLost closes the Lost() channel on the most recently acquired
+// build lock, simulating a heartbeat-detected lease loss without depending
+// on real heartbeat timing.
+func (s *hookableStore) signalLockLost() {
+	s.mu.Lock()
+	lock := s.currentLock
+	s.mu.Unlock()
+	if lock != nil {
+		lock.markLost()
+	}
+}
+
+// hookableLock wraps a real IndexStoreLock so tests can drive lock loss via
+// signalLockLost without depending on real heartbeat timing. The exposed
+// Lost() channel only closes when markLost is called; inner-lock loss is
+// not forwarded, because no test triggers it (real heartbeat loss requires
+// disturbing the bucket entry, which no test does).
+type hookableLock struct {
+	inner       IndexStoreLock
+	lost        chan struct{}
+	lostOnce    sync.Once
+	releaseOnce sync.Once
+	store       *hookableStore
+}
+
+func newHookableLock(inner IndexStoreLock, store *hookableStore) *hookableLock {
+	return &hookableLock{inner: inner, lost: make(chan struct{}), store: store}
+}
+
+func (l *hookableLock) Release() error {
+	var err error
+	l.releaseOnce.Do(func() {
+		l.store.lockReleaseCalls.Add(1)
+		err = l.inner.Release()
+	})
+	return err
+}
+
+func (l *hookableLock) Lost() <-chan struct{} { return l.lost }
+
+func (l *hookableLock) markLost() {
+	l.lostOnce.Do(func() { close(l.lost) })
+}
+
+// seedSnapshot writes a snapshot at indexKey under ns directly to bucket,
+// bypassing store.UploadIndex. The snapshot has a single placeholder file
+// plus a manifest with the caller-provided meta. Use this when a test only
+// needs the snapshot to be visible to ListIndexes / GetIndexMeta — the
+// snapshot is not downloadable as a real bleve index.
+//
+// Manifest fields (UploadTimestamp, BuildTime, etc.) are written as-is, so
+// callers can pin arbitrary values independent of indexKey's ULID time.
+func seedSnapshot(t *testing.T, ctx context.Context, bucket *blob.Bucket, ns resource.NamespacedResource, indexKey ulid.ULID, meta *IndexMeta) {
+	t.Helper()
+	pfx := indexPrefix(ns, indexKey.String())
+	require.NoError(t, bucket.WriteAll(ctx, pfx+"store/data.bin", []byte("x"), nil))
+	if meta.Files == nil {
+		meta.Files = map[string]int64{"store/data.bin": 1}
+	}
+	metaBytes, err := json.Marshal(meta)
+	require.NoError(t, err)
+	require.NoError(t, bucket.WriteAll(ctx, pfx+snapshotManifestFile, metaBytes, nil))
+}
+
+// downloadableSnapshot is a snapshot prepared in memory and ready to be
+// written to a bucket. Building uses testing.T (require.*); publishing
+// returns errors, so the publish step can run on a helper goroutine
+// without violating the testing.TB rule that FailNow must run on the test
+// goroutine.
+type downloadableSnapshot struct {
+	prefix   string
+	files    map[string][]byte
+	manifest []byte
+}
+
+// buildDownloadableSnapshot creates a real (minimal) bleve index for
+// indexKey under ns, walks it into memory, and marshals a manifest. The
+// returned snapshot can be published to any bucket via publish.
+//
+// The internal buildInfo.BuildTime is taken from meta.BuildTime when
+// non-zero, falling back to meta.UploadTimestamp. This mirrors production:
+// real snapshots derive manifest BuildTime from the index's internal
+// buildInfo (see bleve_snapshot_upload.go), so the two stay consistent
+// when readers (local reuse vs fresh-remote selection) compare them.
+func buildDownloadableSnapshot(t *testing.T, ns resource.NamespacedResource, indexKey ulid.ULID, meta *IndexMeta) *downloadableSnapshot {
+	t.Helper()
+	srcDir := filepath.Join(t.TempDir(), "idx")
+	idx, err := bleve.New(srcDir, bleve.NewIndexMapping())
+	require.NoError(t, err)
+	require.NoError(t, setRV(idx, meta.LatestResourceVersion))
+
+	buildTime := meta.BuildTime
+	if buildTime.IsZero() {
+		buildTime = meta.UploadTimestamp
+	}
+	bi, err := json.Marshal(buildInfo{
+		BuildTime:    buildTime.Unix(),
+		BuildVersion: meta.BuildVersion,
+	})
+	require.NoError(t, err)
+	require.NoError(t, idx.SetInternal([]byte(internalBuildInfoKey), bi))
+	require.NoError(t, idx.Close())
+
+	files := map[string][]byte{}
+	require.NoError(t, filepath.WalkDir(srcDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+		rel, err := filepath.Rel(srcDir, path)
+		if err != nil {
+			return err
+		}
+		data, err := os.ReadFile(path) //nolint:gosec // path is under a test-controlled temp dir
+		if err != nil {
+			return err
+		}
+		files[filepath.ToSlash(rel)] = data
+		return nil
+	}))
+
+	if meta.Files == nil {
+		meta.Files = make(map[string]int64, len(files))
+		for rel, data := range files {
+			meta.Files[rel] = int64(len(data))
+		}
+	}
+	manifest, err := json.Marshal(meta)
+	require.NoError(t, err)
+
+	return &downloadableSnapshot{
+		prefix:   indexPrefix(ns, indexKey.String()),
+		files:    files,
+		manifest: manifest,
+	}
+}
+
+// publish writes the snapshot's data files first, then the manifest (which
+// is the completion signal). Uses no testing.T, so it is safe to call from
+// a helper goroutine.
+func (s *downloadableSnapshot) publish(ctx context.Context, bucket *blob.Bucket) error {
+	for rel, data := range s.files {
+		if err := bucket.WriteAll(ctx, s.prefix+rel, data, nil); err != nil {
+			return fmt.Errorf("writing %s: %w", rel, err)
+		}
+	}
+	return bucket.WriteAll(ctx, s.prefix+snapshotManifestFile, s.manifest, nil)
+}
+
+// seedDownloadableSnapshot is buildDownloadableSnapshot + publish, for the
+// common case of seeding before the system under test runs. For tests that
+// need to publish from a helper goroutine, call buildDownloadableSnapshot
+// on the test goroutine and publish from the goroutine via the returned
+// snapshot.
+func seedDownloadableSnapshot(t *testing.T, ctx context.Context, bucket *blob.Bucket, ns resource.NamespacedResource, indexKey ulid.ULID, meta *IndexMeta) {
+	t.Helper()
+	require.NoError(t, buildDownloadableSnapshot(t, ns, indexKey, meta).publish(ctx, bucket))
 }


### PR DESCRIPTION
Test-only refactor. No production code or interface changes.

Replaces three ad-hoc `RemoteIndexStore` fakes (`fakeRemoteIndexStore`, `coldStartFakeStore`, `uploadTestStore`) with a single `hookableStore` that wraps the real `BucketRemoteIndexStore` over gocloud's in-memory `memblob` bucket. Tests now run against the same code path that runs in production, including the real lock backend.

The wrapper carries the test instrumentation the old fakes had: per-method error injection, call counters, controllable lock loss, and mid-call callbacks.

Groundwork for a follow-up PR that reshapes the `RemoteIndexStore` interface — doing it separately keeps that diff focused on the interface change.