### PR TITLE
Undo/Redo Experiments: Encapsulate user action in a class

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AddPanelToAutoGridAction.test.ts
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AddPanelToAutoGridAction.test.ts
@@ -1,0 +1,107 @@
+import { VizPanel } from '@grafana/scenes';
+
+import { DashboardScene } from '../DashboardScene';
+
+import { AddPanelToAutoGridAction } from './AddPanelToAutoGridAction';
+import { AutoGridItem } from './AutoGridItem';
+import { AutoGridLayout } from './AutoGridLayout';
+import { AutoGridLayoutManager } from './AutoGridLayoutManager';
+
+function setup(existingPanels: VizPanel[] = []) {
+  const gridItems = existingPanels.map(
+    (panel, index) => new AutoGridItem({ key: `grid-item-${index + 1}`, body: panel })
+  );
+
+  const manager = new AutoGridLayoutManager({
+    key: 'test-AutoGridLayoutManager',
+    layout: new AutoGridLayout({ children: gridItems }),
+  });
+
+  new DashboardScene({ body: manager });
+
+  return { manager, gridItems };
+}
+
+function newPanel(key: string, title = 'Untitled') {
+  return new VizPanel({ key, title, pluginId: 'table' });
+}
+
+describe('AddPanelToAutoGridAction', () => {
+  describe('perform', () => {
+    it('appends a grid item wrapping the panel to the layout', () => {
+      const { manager } = setup();
+      const panel = newPanel('incoming');
+      const action = new AddPanelToAutoGridAction(manager, panel);
+
+      action.perform();
+
+      const children = manager.state.layout.state.children;
+      expect(children).toHaveLength(1);
+      expect(children[0]).toBeInstanceOf(AutoGridItem);
+      expect((children[0] as AutoGridItem).state.body).toBe(panel);
+    });
+
+    it('preserves existing children', () => {
+      const existing = newPanel('panel-1');
+      const { manager, gridItems } = setup([existing]);
+      const action = new AddPanelToAutoGridAction(manager, newPanel('incoming'));
+
+      action.perform();
+
+      const children = manager.state.layout.state.children;
+      expect(children).toHaveLength(2);
+      expect(children[0]).toBe(gridItems[0]);
+    });
+  });
+
+  describe('undo', () => {
+    it('removes the grid item that perform added', () => {
+      const { manager } = setup();
+      const action = new AddPanelToAutoGridAction(manager, newPanel('incoming'));
+
+      action.perform();
+      action.undo();
+
+      expect(manager.state.layout.state.children).toHaveLength(0);
+    });
+
+    it('leaves existing children untouched', () => {
+      const existing = newPanel('panel-1');
+      const { manager, gridItems } = setup([existing]);
+      const action = new AddPanelToAutoGridAction(manager, newPanel('incoming'));
+
+      action.perform();
+      action.undo();
+
+      expect(manager.state.layout.state.children).toHaveLength(1);
+      expect(manager.state.layout.state.children[0]).toBe(gridItems[0]);
+    });
+  });
+
+  describe('redo (replaying perform after undo)', () => {
+    it('restores the same grid item instance', () => {
+      const { manager } = setup();
+      const action = new AddPanelToAutoGridAction(manager, newPanel('incoming'));
+
+      action.perform();
+      const addedItem = manager.state.layout.state.children[0];
+      action.undo();
+      action.perform();
+
+      expect(manager.state.layout.state.children).toHaveLength(1);
+      expect(manager.state.layout.state.children[0]).toBe(addedItem);
+    });
+
+    it('survives multiple undo/redo cycles', () => {
+      const { manager } = setup();
+      const action = new AddPanelToAutoGridAction(manager, newPanel('incoming'));
+
+      for (let i = 0; i < 3; i++) {
+        action.perform();
+        expect(manager.state.layout.state.children).toHaveLength(1);
+        action.undo();
+        expect(manager.state.layout.state.children).toHaveLength(0);
+      }
+    });
+  });
+});

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AddPanelToAutoGridAction.ts
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AddPanelToAutoGridAction.ts
@@ -1,0 +1,42 @@
+import { t } from '@grafana/i18n';
+import { type VizPanel } from '@grafana/scenes';
+
+import { type DashboardEditActionEventPayload } from '../../edit-pane/events';
+import { dashboardSceneGraph } from '../../utils/dashboardSceneGraph';
+import { getVizPanelKeyForPanelId } from '../../utils/utils';
+
+import { AutoGridItem } from './AutoGridItem';
+import { type AutoGridLayoutManager } from './AutoGridLayoutManager';
+
+export class AddPanelToAutoGridAction implements DashboardEditActionEventPayload {
+  public readonly source: AutoGridLayoutManager;
+  public readonly addedObject: VizPanel;
+  public readonly description: string;
+
+  private readonly gridItem: AutoGridItem;
+
+  public constructor(layoutManager: AutoGridLayoutManager, vizPanel: VizPanel) {
+    const panelId = dashboardSceneGraph.getNextPanelId(layoutManager);
+    vizPanel.setState({ key: getVizPanelKeyForPanelId(panelId) });
+    vizPanel.clearParent();
+
+    this.source = layoutManager;
+    this.addedObject = vizPanel;
+    this.gridItem = new AutoGridItem({ body: vizPanel });
+    this.description = t('dashboard.edit-actions.add', 'Add {{typeName}}', {
+      typeName: t('dashboard.edit-pane.elements.panel', 'Panel'),
+    });
+  }
+
+  public perform = (): void => {
+    const layout = this.source.state.layout;
+    layout.setState({ children: [...layout.state.children, this.gridItem] });
+  };
+
+  public undo = (): void => {
+    const layout = this.source.state.layout;
+    layout.setState({
+      children: layout.state.children.filter((child) => child !== this.gridItem),
+    });
+  };
+}

--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutManager.tsx
@@ -33,6 +33,7 @@ import { type DashboardLayoutGrid } from '../types/DashboardLayoutGrid';
 import { type DashboardLayoutManager } from '../types/DashboardLayoutManager';
 import { type LayoutRegistryItem } from '../types/LayoutRegistryItem';
 
+import { AddPanelToAutoGridAction } from './AddPanelToAutoGridAction';
 import { AutoGridItem } from './AutoGridItem';
 import { AutoGridLayout } from './AutoGridLayout';
 import { getEditOptions } from './AutoGridLayoutManagerEditor';
@@ -121,25 +122,7 @@ export class AutoGridLayoutManager
   }
 
   public addPanel(vizPanel: VizPanel) {
-    const panelId = dashboardSceneGraph.getNextPanelId(this);
-
-    vizPanel.setState({ key: getVizPanelKeyForPanelId(panelId) });
-    vizPanel.clearParent();
-
-    const newGridItem = new AutoGridItem({ body: vizPanel });
-
-    dashboardEditActions.addElement({
-      addedObject: vizPanel,
-      source: this,
-      perform: () => {
-        this.state.layout.setState({ children: [...this.state.layout.state.children, newGridItem] });
-      },
-      undo: () => {
-        this.state.layout.setState({
-          children: this.state.layout.state.children.filter((child) => child !== newGridItem),
-        });
-      },
-    });
+    dashboardEditActions.edit(new AddPanelToAutoGridAction(this, vizPanel));
   }
 
   public pastePanel() {


### PR DESCRIPTION
We could move all actions to separate classes/files to: 

- Improve readability and discoverability of what is covered and what’s not
- Improve testing coverage for single actions with unit tests
- Allow isolated unit testing for chain of actions

Taking this approach could help working with mutation API - Mutation API refactoring could take following steps:
1. move all mutations to action classes (with empty undo) to just keep the same functionality
2. keep mutation API as a thin integration wrapper with actions
3. implement undo with unit tests
4. refactor/simplify mutations api actions (so ideally they use the same actions as the rest of the UI if possible)

Additional benefit is that it would be easier to express batch actions with `new BatchAction(new Action1(), new Action2(), ...)`

Drawbacks:
- it's more verbose, especially with very simple actions.
- makes sense only if all actions are converted