### PR TITLE
Canvas: Fix inline editor showing in react 19 by passing `nodeRef`

### DIFF
--- a/public/app/plugins/panel/canvas/editor/inline/InlineEdit.tsx
+++ b/public/app/plugins/panel/canvas/editor/inline/InlineEdit.tsx
@@ -74,7 +74,7 @@ export function InlineEdit({ onClose, id, scene }: Props) {
   return (
     <Portal>
       <div className={styles.draggableWrapper}>
-        <Draggable handle="strong" onStop={onDragStop} position={{ x: placement.x, y: placement.y }}>
+        <Draggable handle="strong" onStop={onDragStop} position={{ x: placement.x, y: placement.y }} nodeRef={ref}>
           <Resizable height={measurements.height} width={measurements.width} onResize={onResizeStop}>
             <div
               className={styles.inlineEditorContainer}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

- passes `nodeRef` to `Draggable` so it doesn't try to use the now removed `findDOMNode`

**Why do we need this feature?**

- so the canvas inline editor displays correctly when running with react 19

**Who is this feature for?**

- anyone using canvas

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

For https://github.com/grafana/grafana/issues/98813

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
