### PR TITLE
Provisioning: Remove nested scroll from folder README panel

### DIFF
--- a/public/app/features/provisioning/components/Folders/FolderReadmePanel.tsx
+++ b/public/app/features/provisioning/components/Folders/FolderReadmePanel.tsx
@@ -287,7 +287,5 @@ const getStyles = (theme: GrafanaTheme2) => ({
   }),
   body: css({
     padding: theme.spacing(2),
-    maxHeight: '60vh',
-    overflowY: 'auto',
   }),
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**What is this feature?**

This PR removes the nested scroll container from the folder README panel by eliminating the `maxHeight: '60vh'` and `overflowY: 'auto'` CSS constraints from the panel body.

**Why do we need this feature?**

The folder README panel currently has a fixed max-height of 60vh with its own internal scrollbar, creating a nested scroll container. This results in a poor user experience where users must scroll within a small, constrained panel instead of scrolling the page naturally. The nested scrollbar is not immediately obvious and makes it difficult to read longer README files.

**Who is this feature for?**

All users who use the Git Sync / provisioning feature with folder READMEs enabled via the `provisioning.readmes` feature toggle.

**Which issue(s) does this PR fix?**:

N/A - UX improvement based on team feedback

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. (Already gated by `provisioning.readmes` toggle)
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.

**Technical details:**

Changed `FolderReadmePanel.tsx` (lines 288-292):
- Removed `maxHeight: '60vh'` constraint
- Removed `overflowY: 'auto'` scrollbar
- Kept `padding: theme.spacing(2)` for consistent spacing

This allows the README content to flow naturally with the page, following GitHub-style README rendering patterns.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://raintank-corp.slack.com/archives/C08T7NVBCUA/p1778218796617379?thread_ts=1778218796.617379&cid=C08T7NVBCUA)

<div><a href="https://cursor.com/agents/bc-d6303460-0b61-5d00-8d1f-66439a52fea3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d6303460-0b61-5d00-8d1f-66439a52fea3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

