### PR TITLE
ESLint: Add no-direct-create-monitoring-logger rule

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -172,6 +172,7 @@ module.exports = [
       '@grafana/no-unreduced-motion': 'error',
       '@grafana/no-restricted-img-srcs': 'error',
       '@grafana/no-direct-date-fns': 'error',
+      '@grafana/no-direct-create-monitoring-logger': 'error',
       'react-prefer-function-component/react-prefer-function-component': ['error', { allowJsxUtilityClass: true }],
       'react/prop-types': 'off',
       // need to ignore emotion's `css` prop, see https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/no-unknown-property.md#rule-options

--- a/packages/grafana-eslint-rules/README.md
+++ b/packages/grafana-eslint-rules/README.md
@@ -294,3 +294,21 @@ interface LoadedProperties extends EventProperty {
   numberOfItems: number;
 }
 ```
+
+### `no-direct-create-monitoring-logger`
+
+Disallow direct named imports of `createMonitoringLogger` from `@grafana/runtime`. New loggers must be registered in `packages/grafana-runtime/src/services/logging/loggers.ts` and retrieved via `getLogger` from `@grafana/runtime/unstable`.
+
+This keeps every valid logger source declared in one place so its defaults (context, console output) are discoverable and the registry can initialize it at app boot.
+
+#### Examples
+
+```ts
+// Bad ❌
+import { createMonitoringLogger } from '@grafana/runtime';
+const logger = createMonitoringLogger('features.my-area');
+
+// Good ✅ — register the source in loggers.ts, then:
+import { getLogger } from '@grafana/runtime/unstable';
+const logger = getLogger('features.my-area');
+```

--- a/packages/grafana-eslint-rules/rules/no-restricted-syntax.cjs
+++ b/packages/grafana-eslint-rules/rules/no-restricted-syntax.cjs
@@ -53,5 +53,14 @@ module.exports = createNoRestrictedSyntax(
     name: 'no-direct-date-fns',
     selector: 'ImportDeclaration[source.value="date-fns"][importKind!="type"]',
     message: 'Use deep imports instead (e.g. date-fns/format) to avoid pulling in the entire library.',
+  },
+  {
+    name: 'no-direct-create-monitoring-logger',
+    selector: [
+      'ImportDeclaration[source.value="@grafana/runtime"] > ImportSpecifier[imported.name="createMonitoringLogger"]',
+      'Program:has(ImportDeclaration[source.value="@grafana/runtime"] > ImportDefaultSpecifier, ImportDeclaration[source.value="@grafana/runtime"] > ImportNamespaceSpecifier) MemberExpression[property.name="createMonitoringLogger"]',
+    ].join(', '),
+    message:
+      'Direct usage of createMonitoringLogger is not allowed. Register your logger source in packages/grafana-runtime/src/services/logging/loggers.ts and use getLogger from @grafana/runtime/unstable instead.',
   }
 );

--- a/packages/grafana-eslint-rules/tests/no-restricted-syntax.test.js
+++ b/packages/grafana-eslint-rules/tests/no-restricted-syntax.test.js
@@ -1,0 +1,62 @@
+import { RuleTester } from 'eslint';
+
+import noRestrictedSyntax from '../rules/no-restricted-syntax.cjs';
+
+RuleTester.setDefaultConfig({
+  languageOptions: {
+    ecmaVersion: 2020,
+    sourceType: 'module',
+    parser: require('@typescript-eslint/parser'),
+  },
+});
+
+const ruleTester = new RuleTester();
+
+const rule = noRestrictedSyntax.rules['no-direct-create-monitoring-logger'];
+
+const expectedMessage =
+  'Direct usage of createMonitoringLogger is not allowed. Register your logger source in packages/grafana-runtime/src/services/logging/loggers.ts and use getLogger from @grafana/runtime/unstable instead.';
+
+ruleTester.run('no-direct-create-monitoring-logger', rule, {
+  valid: [
+    {
+      name: 'getLogger from @grafana/runtime/unstable',
+      code: `import { getLogger } from '@grafana/runtime/unstable';`,
+    },
+    {
+      name: 'other named imports from @grafana/runtime',
+      code: `import { config, type MonitoringLogger } from '@grafana/runtime';`,
+    },
+    {
+      name: 'createMonitoringLogger imported from a relative path (registry use)',
+      code: `import { createMonitoringLogger } from '../../utils/logging';`,
+    },
+  ],
+  invalid: [
+    {
+      name: 'createMonitoringLogger imported from @grafana/runtime',
+      code: `import { createMonitoringLogger } from '@grafana/runtime';`,
+      errors: [{ message: expectedMessage }],
+    },
+    {
+      name: 'aliased createMonitoringLogger import from @grafana/runtime',
+      code: `import { createMonitoringLogger as cml } from '@grafana/runtime';`,
+      errors: [{ message: expectedMessage }],
+    },
+    {
+      name: 'createMonitoringLogger alongside other imports — only one error',
+      code: `import { config, createMonitoringLogger, type MonitoringLogger } from '@grafana/runtime';`,
+      errors: [{ message: expectedMessage }],
+    },
+    {
+      name: 'runtime import from @grafana/runtime',
+      code: `import runtime from '@grafana/runtime'; const logger = runtime.createMonitoringLogger('my-logger');`,
+      errors: [{ message: expectedMessage }],
+    },
+    {
+      name: 'runtime star import from @grafana/runtime',
+      code: `import * as runtime from '@grafana/runtime'; const logger = runtime.createMonitoringLogger('my-logger');`,
+      errors: [{ message: expectedMessage }],
+    },
+  ],
+});

--- a/packages/grafana-sql/src/utils/logging.ts
+++ b/packages/grafana-sql/src/utils/logging.ts
@@ -1,3 +1,4 @@
+// eslint-disable-next-line @grafana/no-direct-create-monitoring-logger
 import { createMonitoringLogger, type MonitoringLogger } from '@grafana/runtime';
 
 export const sqlPluginLogger: MonitoringLogger = createMonitoringLogger('features.plugins.sql');


### PR DESCRIPTION
**What is this feature?**

Adds a new ESLint rule `@grafana/no-direct-create-monitoring-logger` that disallows direct named imports of `createMonitoringLogger` from `@grafana/runtime`. New loggers should be registered in `packages/grafana-runtime/src/services/logging/loggers.ts` and retrieved via `getLogger` from `@grafana/runtime/unstable` instead.

**Why do we need this feature?**

So every valid logger source is declared in one place and the registry can initialize it at app boot.

**Who is this feature for?**

Grafana devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Relates https://github.com/grafana/grafana/issues/121639

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
