### PR TITLE
HomePage: Fix redirect when served under a subpath (#124557)

### DIFF
--- a/packages/grafana-data/src/utils/location.test.ts
+++ b/packages/grafana-data/src/utils/location.test.ts
@@ -340,6 +340,27 @@ describe('locationUtil', () => {
         const result = locationUtil.processRedirectUri(redirectUri, currentLocation);
         expect(result).toBe('http://www.domain.com:1234/grafana/a/custom-home-plugin?tab=overview&theme=dark');
       });
+
+      test('handles relative path without subpath prefix (e.g. home_page = /admin/users)', () => {
+        const redirectUri = '/admin/users';
+        const currentLocation = { ...mockLocation, search: '' };
+        const result = locationUtil.processRedirectUri(redirectUri, currentLocation);
+        expect(result).toBe('/admin/users');
+      });
+
+      test('merges current params into relative path without subpath prefix', () => {
+        const redirectUri = '/admin/users';
+        const currentLocation = { ...mockLocation, search: '?orgId=2' };
+        const result = locationUtil.processRedirectUri(redirectUri, currentLocation);
+        expect(result).toBe('/admin/users?orgId=2');
+      });
+
+      test('redirect URI params take precedence over current params when no subpath prefix', () => {
+        const redirectUri = '/admin/users?tab=access';
+        const currentLocation = { ...mockLocation, search: '?tab=profile&orgId=2' };
+        const result = locationUtil.processRedirectUri(redirectUri, currentLocation);
+        expect(result).toBe('/admin/users?tab=access&orgId=2');
+      });
     });
   });
 });

--- a/packages/grafana-data/src/utils/location.ts
+++ b/packages/grafana-data/src/utils/location.ts
@@ -168,7 +168,11 @@ export const locationUtil = {
         }
       });
 
-      return stripBaseFromUrl(redirectUrl.href);
+      // For relative paths, use pathname+search rather than href. new URL(relativePath, origin)
+      // produces an absolute URL without the appSubUrl prefix, which stripBaseFromUrl cannot strip,
+      // causing the router to treat the full URL string as a literal path.
+      const isAbsoluteUri = redirectUri.startsWith('http');
+      return stripBaseFromUrl(isAbsoluteUri ? redirectUrl.href : redirectUrl.pathname + redirectUrl.search);
     } catch {
       return stripBaseFromUrl(redirectUri);
     }


### PR DESCRIPTION
fix processRedirectUri to handle relative paths without the subpath

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

manual backport of https://github.com/grafana/grafana/pull/124557

**Why do we need this feature?**

- 

**Who is this feature for?**



**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
