### PR TITLE
Plugins: Distinguish missing-from-catalog from incompatible-version install errors

### DIFF
--- a/pkg/plugins/repo/errors.go
+++ b/pkg/plugins/repo/errors.go
@@ -52,9 +52,13 @@ var (
 	ErrVersionUnsupportedBase = errutil.Conflict("plugin.unsupportedVersion").
 					MustTemplate(ErrVersionUnsupportedMsg, errutil.WithPublic(ErrVersionUnsupportedMsg))
 
-	ErrVersionNotFoundMsg  = "{{.Public.PluginID}} v{{.Public.Version}} either does not exist or is not supported on your system {{.Public.SysInfo}}"
+	ErrVersionNotFoundMsg  = "{{.Public.PluginID}} v{{.Public.Version}} was not returned by the Grafana.com catalog. The version may not exist, or the configured Grafana.com proxy token ([grafana_com].proxy_token or GF_GRAFANA_COM_PROXY_TOKEN) may lack the required scopes."
 	ErrVersionNotFoundBase = errutil.NotFound("plugin.versionNotFound").
 				MustTemplate(ErrVersionNotFoundMsg, errutil.WithPublic(ErrVersionNotFoundMsg))
+
+	ErrVersionNotCompatibleMsg  = "{{.Public.PluginID}} v{{.Public.Version}} is not compatible with your Grafana version: {{.Public.GrafanaVersion}}"
+	ErrVersionNotCompatibleBase = errutil.NotFound("plugin.versionNotCompatible").
+					MustTemplate(ErrVersionNotCompatibleMsg, errutil.WithPublic(ErrVersionNotCompatibleMsg))
 
 	ErrArcNotFoundMsg  = "{{.Public.PluginID}} is not compatible with your system architecture: {{.Public.SysInfo}}"
 	ErrArcNotFoundBase = errutil.NotFound("plugin.archNotFound").
@@ -77,8 +81,19 @@ func ErrVersionUnsupported(pluginID, requestedVersion, systemInfo string) error 
 	return ErrVersionUnsupportedBase.Build(errutil.TemplateData{Public: map[string]any{"PluginID": pluginID, "Version": requestedVersion, "SysInfo": systemInfo}})
 }
 
-func ErrVersionNotFound(pluginID, requestedVersion, systemInfo string) error {
-	return ErrVersionNotFoundBase.Build(errutil.TemplateData{Public: map[string]any{"PluginID": pluginID, "Version": requestedVersion, "SysInfo": systemInfo}})
+func ErrVersionNotFound(pluginID, requestedVersion string) error {
+	return ErrVersionNotFoundBase.Build(errutil.TemplateData{Public: map[string]any{
+		"PluginID": pluginID,
+		"Version":  requestedVersion,
+	}})
+}
+
+func ErrVersionNotCompatible(pluginID, requestedVersion, grafanaVersion string) error {
+	return ErrVersionNotCompatibleBase.Build(errutil.TemplateData{Public: map[string]any{
+		"PluginID":       pluginID,
+		"Version":        requestedVersion,
+		"GrafanaVersion": grafanaVersion,
+	}})
 }
 
 func ErrArcNotFound(pluginID, systemInfo string) error {

--- a/pkg/plugins/repo/errors_test.go
+++ b/pkg/plugins/repo/errors_test.go
@@ -37,11 +37,17 @@ func TestErrorTemplates(t *testing.T) {
 	require.Equal(t, "plugin.unsupportedVersion", base.Public().MessageID)
 	require.Equal(t, "grafana-test-app v1.0.0 is not supported on your system darwin-amd64", base.Public().Message)
 
-	err = ErrVersionNotFound("grafana-test-app", "1.0.0", "darwin-amd64")
+	err = ErrVersionNotFound("grafana-test-app", "1.0.0")
 	require.True(t, errors.As(err, base))
 	require.Equal(t, http.StatusNotFound, base.Public().StatusCode)
 	require.Equal(t, "plugin.versionNotFound", base.Public().MessageID)
-	require.Equal(t, "grafana-test-app v1.0.0 either does not exist or is not supported on your system darwin-amd64", base.Public().Message)
+	require.Equal(t, "grafana-test-app v1.0.0 was not returned by the Grafana.com catalog. The version may not exist, or the configured Grafana.com proxy token ([grafana_com].proxy_token or GF_GRAFANA_COM_PROXY_TOKEN) may lack the required scopes.", base.Public().Message)
+
+	err = ErrVersionNotCompatible("grafana-test-app", "1.0.0", "10.0.0")
+	require.True(t, errors.As(err, base))
+	require.Equal(t, http.StatusNotFound, base.Public().StatusCode)
+	require.Equal(t, "plugin.versionNotCompatible", base.Public().MessageID)
+	require.Equal(t, "grafana-test-app v1.0.0 is not compatible with your Grafana version: 10.0.0", base.Public().Message)
 
 	err = ErrArcNotFound("grafana-test-app", "darwin-amd64")
 	require.True(t, errors.As(err, base))

--- a/pkg/plugins/repo/version.go
+++ b/pkg/plugins/repo/version.go
@@ -21,12 +21,10 @@ type VersionData struct {
 //   - Returns the latest grafana-compatible + arch-compatible version when no version
 //     is specified.
 //
-// Errors for a pinned version:
-//   - ErrVersionNotFound:      version not present in the catalog listing
-//   - ErrVersionNotCompatible: version present but incompatible with this Grafana version
-//   - ErrVersionUnsupported:   version is grafana-compatible but not built for this OS/arch
-//
-// Errors when the whole plugin can't be installed here:
+// Errors:
+//   - ErrVersionNotFound:      specified version not present in the catalog listing
+//   - ErrVersionNotCompatible: specified version is incompatible with this Grafana version
+//   - ErrVersionUnsupported:   specified version is grafana-compatible but not built for this OS/arch
 //   - ErrNoCompatibleVersions: no version in the listing is compatible with this Grafana version
 //   - ErrArcNotFound:          some versions are grafana-compatible but none for this OS/arch
 //

--- a/pkg/plugins/repo/version.go
+++ b/pkg/plugins/repo/version.go
@@ -2,7 +2,6 @@ package repo
 
 import (
 	"errors"
-	"slices"
 	"strings"
 
 	"github.com/grafana/grafana/pkg/plugins/log"
@@ -15,11 +14,22 @@ type VersionData struct {
 	URL      string
 }
 
-// SelectSystemCompatibleVersion selects the most appropriate plugin version based on os + architecture
-// returns the specified version if supported.
-// returns the latest version if no specific version is specified.
-// returns error if the supplied version does not exist.
-// returns error if supplied version exists but is not supported.
+// SelectSystemCompatibleVersion selects the most appropriate plugin version for
+// the current Grafana version and OS/architecture.
+//
+//   - Returns the specified version when it's grafana-compatible and arch-compatible.
+//   - Returns the latest grafana-compatible + arch-compatible version when no version
+//     is specified.
+//
+// Errors for a pinned version:
+//   - ErrVersionNotFound:      version not present in the catalog listing
+//   - ErrVersionNotCompatible: version present but incompatible with this Grafana version
+//   - ErrVersionUnsupported:   version is grafana-compatible but not built for this OS/arch
+//
+// Errors when the whole plugin can't be installed here:
+//   - ErrNoCompatibleVersions: no version in the listing is compatible with this Grafana version
+//   - ErrArcNotFound:          some versions are grafana-compatible but none for this OS/arch
+//
 // NOTE: It expects plugin.Versions to be sorted so the newest version is first.
 func SelectSystemCompatibleVersion(log log.PrettyLogger, versions []Version, pluginID, version string, compatOpts CompatOpts) (VersionData, error) {
 	version = normalizeVersion(version)
@@ -29,11 +39,11 @@ func SelectSystemCompatibleVersion(log log.PrettyLogger, versions []Version, plu
 		return VersionData{}, errors.New("no system compatibility requirements set")
 	}
 
-	var ver Version
-	latestForArch, err := latestSupportedVersion(pluginID, versions, compatOpts)
-	if err != nil {
+	if err := validateCompatibility(pluginID, versions, compatOpts); err != nil {
 		return VersionData{}, err
 	}
+
+	latestForArch := latestSupportedVersion(versions, compatOpts)
 
 	if version == "" {
 		return VersionData{
@@ -43,6 +53,8 @@ func SelectSystemCompatibleVersion(log log.PrettyLogger, versions []Version, plu
 			URL:      latestForArch.URL,
 		}, nil
 	}
+
+	var ver Version
 	for _, v := range versions {
 		if normalizeVersion(v.Version) == version {
 			ver = v
@@ -51,9 +63,16 @@ func SelectSystemCompatibleVersion(log log.PrettyLogger, versions []Version, plu
 	}
 
 	if len(ver.Version) == 0 {
-		log.Debugf("Requested plugin version %s v%s not found but potential fallback version '%s' was found",
+		log.Debugf("Requested plugin version %s v%s not found in catalog; latest available is '%s'",
 			pluginID, version, latestForArch.Version)
-		return VersionData{}, ErrVersionNotFound(pluginID, version, sysCompatOpts.OSAndArch())
+		return VersionData{}, ErrVersionNotFound(pluginID, version)
+	}
+
+	if ver.IsCompatible != nil && !*ver.IsCompatible {
+		runningGrafanaVersion, _ := compatOpts.GrafanaVersion()
+		log.Debugf("Requested plugin version %s v%s is incompatible with this Grafana version; latest compatible is '%s'",
+			pluginID, version, latestForArch.Version)
+		return VersionData{}, ErrVersionNotCompatible(pluginID, version, runningGrafanaVersion)
 	}
 
 	if !supportsCurrentArch(ver, sysCompatOpts) {
@@ -93,22 +112,37 @@ func supportsCurrentArch(version Version, compatOpts SystemCompatOpts) bool {
 	return false
 }
 
-func latestSupportedVersion(pluginID string, versions []Version, compatOpts CompatOpts) (Version, error) {
-	// First check if the version are compatible with the current Grafana version
-	versions = slices.DeleteFunc(versions, func(v Version) bool {
-		return v.IsCompatible != nil && !*v.IsCompatible
-	})
-	if len(versions) == 0 {
-		return Version{}, ErrNoCompatibleVersions(pluginID, compatOpts.grafanaVersion)
-	}
-
-	// Then check if the version are compatible with the current system
+// validateCompatibility reports why no compatible version can be found, or nil
+// if at least one grafana-compatible + arch-compatible version exists in the listing.
+func validateCompatibility(pluginID string, versions []Version, compatOpts CompatOpts) error {
+	var hasGrafanaCompat bool
 	for _, v := range versions {
+		if v.IsCompatible != nil && !*v.IsCompatible {
+			continue
+		}
+		hasGrafanaCompat = true
 		if supportsCurrentArch(v, compatOpts.system) {
-			return v, nil
+			return nil
 		}
 	}
-	return Version{}, ErrArcNotFound(pluginID, compatOpts.system.OSAndArch())
+	if !hasGrafanaCompat {
+		return ErrNoCompatibleVersions(pluginID, compatOpts.grafanaVersion)
+	}
+	return ErrArcNotFound(pluginID, compatOpts.system.OSAndArch())
+}
+
+// latestSupportedVersion returns the newest grafana-compatible and arch-compatible
+// version in the listing, or Version{} if none exists.
+func latestSupportedVersion(versions []Version, compatOpts CompatOpts) Version {
+	for _, v := range versions {
+		if v.IsCompatible != nil && !*v.IsCompatible {
+			continue
+		}
+		if supportsCurrentArch(v, compatOpts.system) {
+			return v
+		}
+	}
+	return Version{}
 }
 
 func normalizeVersion(version string) string {

--- a/pkg/plugins/repo/version_test.go
+++ b/pkg/plugins/repo/version_test.go
@@ -1,10 +1,12 @@
 package repo
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/plugins/log"
 )
 
@@ -80,5 +82,46 @@ func TestSelectSystemCompatibleVersion(t *testing.T) {
 			"test", "2.0.0", fakeCompatOpts(),
 		)
 		require.NoError(t, err)
+	})
+
+	t.Run("Should return versionNotFound when pinned version is missing from catalog", func(t *testing.T) {
+		_, err := SelectSystemCompatibleVersion(logger,
+			createPluginVersions(versionArg{version: "2.0.0"}),
+			"test", "1.0.0+sha-not-published", fakeCompatOpts(),
+		)
+		require.Error(t, err)
+		base := &errutil.Error{}
+		require.True(t, errors.As(err, base))
+		require.Equal(t, "plugin.versionNotFound", base.Public().MessageID)
+	})
+
+	t.Run("Should return versionNotCompatible when pinned version is incompatible but others are", func(t *testing.T) {
+		isCompatibleFalse := false
+		_, err := SelectSystemCompatibleVersion(logger,
+			createPluginVersions(
+				versionArg{version: "2.0.0"},
+				versionArg{version: "1.0.0", isCompatible: &isCompatibleFalse},
+			),
+			"test", "1.0.0", fakeCompatOpts(),
+		)
+		require.Error(t, err)
+		base := &errutil.Error{}
+		require.True(t, errors.As(err, base))
+		require.Equal(t, "plugin.versionNotCompatible", base.Public().MessageID)
+	})
+
+	t.Run("Should return grafanaVersionNotCompatible when no version is compatible", func(t *testing.T) {
+		isCompatibleFalse := false
+		_, err := SelectSystemCompatibleVersion(logger,
+			createPluginVersions(
+				versionArg{version: "2.0.0", isCompatible: &isCompatibleFalse},
+				versionArg{version: "1.0.0", isCompatible: &isCompatibleFalse},
+			),
+			"test", "1.0.0", fakeCompatOpts(),
+		)
+		require.Error(t, err)
+		base := &errutil.Error{}
+		require.True(t, errors.As(err, base))
+		require.Equal(t, "plugin.grafanaVersionNotCompatible", base.Public().MessageID)
 	})
 }


### PR DESCRIPTION
**What is this feature?**

Splits the catch-all `plugin.versionNotFound` error into two distinct codes during plugin install:

- `plugin.versionNotFound` (narrowed): the requested version is not in the Grafana.com catalog listing.
- `plugin.versionNotCompatible` (new): the requested version is in the listing but marked `isCompatible: false` for this Grafana version.

Also refactors `SelectSystemCompatibleVersion`: extracts `validateCompatibility` for whole-plugin failures, makes `latestSupportedVersion` non-mutating (fixes a latent `slices.DeleteFunc` aliasing bug), and updates the function doc to reflect the per-version vs per-plugin error matrix.

**Why do we need this feature?**

As of now, every pinned-install failure surfaces as `plugin.versionNotFound`, which conflates a pin typo / version actually does not exist / token-scope issue with a `grafanaDependency` mismatch. 

- "pin missing from catalog" → stack owner / operator action (fix the pin, check token scope)
- "version not compatible with this Grafana" → plugin publisher action (broaden `grafanaDependency` or republish)

**Who is this feature for?**

- Plugin publishers diagnosing why a build can't install
- Self-hosted operators using `grafana-cli plugin install` with a pinned version

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

- `latestSupportedVersion` no longer mutates the caller's slice via `slices.DeleteFunc`.
- `PluginInstallErrorRateTooHigh` alert's run book log will show informative message alongside the `failed to install plugin` message.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle. (n/a — error-code refinement, no behavior change)
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.