### PR TITLE
Scopes: hide dashboards sidebar when entering edit mode

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardSceneRenderer.tsx
@@ -31,10 +31,20 @@ export function DashboardSceneRenderer({ model }: SceneComponentProps<DashboardS
   const scopesServices = useScopesServices();
 
   // Disable scope redirects while in edit mode so users aren't navigated away mid-edit.
+  // Also close the scopes dashboards drawer while editing and restore it on exit.
   useEffect(() => {
     scopesServices?.scopesSelectorService.setRedirectEnabled(!isEditing);
+
+    const drawerWasOpen = Boolean(isEditing && scopesServices?.scopesDashboardsService.state.drawerOpened);
+    if (drawerWasOpen) {
+      scopesServices?.scopesDashboardsService.toggleDrawer();
+    }
+
     return () => {
       scopesServices?.scopesSelectorService.setRedirectEnabled(true);
+      if (drawerWasOpen && !scopesServices?.scopesDashboardsService.state.drawerOpened) {
+        scopesServices?.scopesDashboardsService.toggleDrawer();
+      }
     };
   }, [scopesServices, isEditing]);
 

--- a/public/app/features/scopes/tests/editMode.test.ts
+++ b/public/app/features/scopes/tests/editMode.test.ts
@@ -9,7 +9,7 @@ import { type ScopesService } from '../ScopesService';
 import { type ScopesSelectorService } from '../selector/ScopesSelectorService';
 
 import { enterEditMode, openSelector, toggleDashboards } from './utils/actions';
-import { expectDashboardsOpen } from './utils/assertions';
+import { expectDashboardsClosed, expectDashboardsOpen } from './utils/assertions';
 import { getDatasource, getInstanceSettings } from './utils/mocks';
 import { renderDashboard, resetScenes } from './utils/render';
 import { getDashboardsExpand, getSelectorInput, querySelectorApply } from './utils/selectors';
@@ -55,9 +55,19 @@ describe('Scope selector in edit mode', () => {
     expect(querySelectorApply()).toBeInTheDocument();
   });
 
-  it('Does not close dashboards list when entering edit mode', async () => {
+  it('Closes dashboards list when entering edit mode', async () => {
     await toggleDashboards();
     await enterEditMode(dashboardScene);
+    expectDashboardsClosed();
+  });
+
+  it('Restores dashboards list when exiting edit mode', async () => {
+    await toggleDashboards();
+    await enterEditMode(dashboardScene);
+    expectDashboardsClosed();
+    act(() => {
+      dashboardScene.exitEditMode({ skipConfirm: true });
+    });
     expectDashboardsOpen();
   });
 


### PR DESCRIPTION
## Summary

- Closes https://github.com/grafana/hyperion-planning/issues/616
- When a user enters dashboard edit mode, the scope-based dashboard navigation sidebar is now automatically hidden
- When the user exits edit mode (save or discard), the sidebar is restored to its previous open/closed state
- If the sidebar was already closed before entering edit mode, nothing changes

## Implementation

`DashboardSceneRenderer` already wired edit mode to scopes behavior (disabling redirects via `setRedirectEnabled`). This PR extends that same `useEffect` to also close the sidebar on edit enter and restore it on exit, using the existing `toggleDrawer()` API. The closure over a local `drawerWasOpen` variable handles the restore logic cleanly — no new service methods or refs needed.

## Test plan

- [ ] Updated existing test "Does not close dashboards list when entering edit mode" → now asserts the sidebar **is** closed
- [ ] Added new test verifying the sidebar is restored when exiting edit mode
- [ ] Manual: open a dashboard with scopes enabled, open the sidebar, enter edit mode → sidebar disappears; exit edit mode → sidebar reappears

🤖 Generated with [Claude Code](https://claude.com/claude-code)