### PR TITLE
AuthN: authnserver: extract namespace when available

### DIFF
--- a/pkg/services/authn/authnserver/service.go
+++ b/pkg/services/authn/authnserver/service.go
@@ -57,7 +57,7 @@ func (s *Service) Authenticate(ctx context.Context, req *authnv1.AuthenticateReq
 
 	if req != nil && req.Namespace != "" {
 		ctx = request.WithNamespace(ctx, req.Namespace)
-		span.SetAttributes(attribute.String("namespace", req.Namespace))
+		span.SetAttributes(attribute.String("authn.namespace", req.Namespace))
 	}
 
 	grpclog.AddFields(ctx, grpclog.Fields{"authn.headers", headerNames(req.GetHttpHeaders())})

--- a/pkg/services/authn/authnserver/service.go
+++ b/pkg/services/authn/authnserver/service.go
@@ -7,6 +7,7 @@ import (
 
 	grpclog "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 	"go.opentelemetry.io/otel/attribute"
+	"k8s.io/apiserver/pkg/endpoints/request"
 
 	authnv1 "github.com/grafana/authlib/authn/proto/v1"
 
@@ -53,6 +54,11 @@ func (s *Service) RegisterClient(c Client) {
 func (s *Service) Authenticate(ctx context.Context, req *authnv1.AuthenticateRequest) (*authnv1.AuthenticateResponse, error) {
 	ctx, span := s.tracer.Start(ctx, "authnserver.Authenticate")
 	defer span.End()
+
+	if req != nil && req.Namespace != "" {
+		ctx = request.WithNamespace(ctx, req.Namespace)
+		span.SetAttributes(attribute.String("namespace", req.Namespace))
+	}
 
 	grpclog.AddFields(ctx, grpclog.Fields{"authn.headers", headerNames(req.GetHttpHeaders())})
 

--- a/pkg/services/authn/authnserver/service.go
+++ b/pkg/services/authn/authnserver/service.go
@@ -2,6 +2,7 @@ package authnserver
 
 import (
 	"context"
+	"errors"
 	"slices"
 	"strings"
 
@@ -14,6 +15,8 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 )
+
+var errExpectedNamespace = errors.New("expected namespace")
 
 // Client is the interface that MT auth clients implement.
 // This is the MT equivalent of authn.ContextAwareClient, but operating
@@ -55,10 +58,15 @@ func (s *Service) Authenticate(ctx context.Context, req *authnv1.AuthenticateReq
 	ctx, span := s.tracer.Start(ctx, "authnserver.Authenticate")
 	defer span.End()
 
-	if req != nil && req.Namespace != "" {
-		ctx = request.WithNamespace(ctx, req.Namespace)
-		span.SetAttributes(attribute.String("authn.namespace", req.Namespace))
+	if req == nil || req.Namespace == "" {
+		s.log.Error("Authenticate request error", "error", errExpectedNamespace)
+		return &authnv1.AuthenticateResponse{
+			Code: authnv1.AuthenticateCode_AUTHENTICATE_CODE_FAILED,
+		}, errExpectedNamespace
 	}
+
+	ctx = request.WithNamespace(ctx, req.Namespace)
+	span.SetAttributes(attribute.String("authn.namespace", req.Namespace))
 
 	grpclog.AddFields(ctx, grpclog.Fields{"authn.headers", headerNames(req.GetHttpHeaders())})
 

--- a/pkg/services/authn/authnserver/service_test.go
+++ b/pkg/services/authn/authnserver/service_test.go
@@ -2,12 +2,14 @@ package authnserver
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
 	grpclog "github.com/grpc-ecosystem/go-grpc-middleware/v2/interceptors/logging"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"k8s.io/apiserver/pkg/endpoints/request"
 
 	authnv1 "github.com/grafana/authlib/authn/proto/v1"
 
@@ -19,15 +21,20 @@ type mockClient struct {
 	testResult   bool
 	authResponse *authnv1.AuthenticateResponse
 	authError    error
+
+	gotTestCtx context.Context
+	gotAuthCtx context.Context
 }
 
 func (m *mockClient) Name() string { return m.name }
 
-func (m *mockClient) Test(_ context.Context, _ *authnv1.AuthenticateRequest) bool {
+func (m *mockClient) Test(ctx context.Context, _ *authnv1.AuthenticateRequest) bool {
+	m.gotTestCtx = ctx
 	return m.testResult
 }
 
-func (m *mockClient) Authenticate(_ context.Context, _ *authnv1.AuthenticateRequest) (*authnv1.AuthenticateResponse, error) {
+func (m *mockClient) Authenticate(ctx context.Context, _ *authnv1.AuthenticateRequest) (*authnv1.AuthenticateResponse, error) {
+	m.gotAuthCtx = ctx
 	return m.authResponse, m.authError
 }
 
@@ -162,6 +169,64 @@ func TestAuthenticate(t *testing.T) {
 		require.Error(t, err)
 		assert.Nil(t, resp)
 		assert.Contains(t, err.Error(), "internal failure")
+	})
+
+	t.Run("nil request returns FAILED with errExpectedNamespace", func(t *testing.T) {
+		svc := NewService(tracing.InitializeTracerForTest())
+		client := &mockClient{name: "should-not-run", testResult: true}
+		svc.RegisterClient(client)
+
+		resp, err := svc.Authenticate(context.Background(), nil)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, errExpectedNamespace))
+		require.NotNil(t, resp)
+		assert.Equal(t, authnv1.AuthenticateCode_AUTHENTICATE_CODE_FAILED, resp.Code)
+		assert.Nil(t, client.gotTestCtx, "clients must not be dispatched when namespace is missing")
+		assert.Nil(t, client.gotAuthCtx)
+	})
+
+	t.Run("empty namespace returns FAILED with errExpectedNamespace", func(t *testing.T) {
+		svc := NewService(tracing.InitializeTracerForTest())
+		client := &mockClient{name: "should-not-run", testResult: true}
+		svc.RegisterClient(client)
+
+		emptyNS := &authnv1.AuthenticateRequest{
+			Namespace:   "",
+			HttpHeaders: map[string]string{"X-Access-Token": "some-token"},
+		}
+		resp, err := svc.Authenticate(context.Background(), emptyNS)
+		require.Error(t, err)
+		assert.True(t, errors.Is(err, errExpectedNamespace))
+		require.NotNil(t, resp)
+		assert.Equal(t, authnv1.AuthenticateCode_AUTHENTICATE_CODE_FAILED, resp.Code)
+		assert.Nil(t, client.gotTestCtx, "clients must not be dispatched when namespace is empty")
+		assert.Nil(t, client.gotAuthCtx)
+	})
+
+	t.Run("namespace from request is propagated into client context", func(t *testing.T) {
+		svc := NewService(tracing.InitializeTracerForTest())
+		client := &mockClient{
+			name:       "ns-capture",
+			testResult: true,
+			authResponse: &authnv1.AuthenticateResponse{
+				Code:  authnv1.AuthenticateCode_AUTHENTICATE_CODE_OK,
+				Token: "ok",
+			},
+		}
+		svc.RegisterClient(client)
+
+		_, err := svc.Authenticate(context.Background(), req)
+		require.NoError(t, err)
+
+		require.NotNil(t, client.gotTestCtx)
+		gotTestNS, ok := request.NamespaceFrom(client.gotTestCtx)
+		require.True(t, ok, "namespace must be set on Test ctx")
+		assert.Equal(t, "stacks-1234", gotTestNS)
+
+		require.NotNil(t, client.gotAuthCtx)
+		gotAuthNS, ok := request.NamespaceFrom(client.gotAuthCtx)
+		require.True(t, ok, "namespace must be set on Authenticate ctx")
+		assert.Equal(t, "stacks-1234", gotAuthNS)
 	})
 
 	t.Run("all clients decline via NOT_HANDLED returns NOT_HANDLED", func(t *testing.T) {


### PR DESCRIPTION
Propagates the k8s request namespace from the request into the authn client. Needed to determine the request's tenant.

Related to: https://github.com/grafana/grafana-enterprise/pull/11975