### PR TITLE
PanelEditNext: Hide card actions in multi-select mode

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Cards/SidebarCard.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Cards/SidebarCard.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { type DataQuery } from '@grafana/schema';
 
 import { QueryEditorType } from '../../../constants';
+import { type QueryEditorUIState } from '../../QueryEditorContext';
 import { ds1SettingsMock, renderWithQueryEditorProvider } from '../../testUtils';
 import { type Transformation } from '../../types';
 
@@ -31,6 +32,7 @@ interface RenderSidebarCardProps {
     onToggleHide?: jest.Mock;
     onDuplicate?: jest.Mock;
   };
+  uiStateOverrides?: Partial<QueryEditorUIState>;
 }
 
 function renderSidebarCard({
@@ -46,6 +48,7 @@ function renderSidebarCard({
     onToggleHide: jest.fn(),
     onDuplicate: jest.fn(),
   },
+  uiStateOverrides = {},
 }: RenderSidebarCardProps = {}) {
   const queries: DataQuery[] = [{ refId: id, datasource: { type: 'test', uid: 'test' } }];
   const item = {
@@ -69,7 +72,7 @@ function renderSidebarCard({
     {
       queries,
       selectedQuery: queries[0],
-      uiStateOverrides: { setSelectedQuery, setPendingExpression },
+      uiStateOverrides: { setSelectedQuery, setPendingExpression, ...uiStateOverrides },
       actionsOverrides: { addQuery },
     }
   );
@@ -421,6 +424,17 @@ describe('SidebarCard', () => {
       expect(screen.getByRole('button', { name: /hide query/i })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /duplicate query/i })).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /remove query/i })).toBeInTheDocument();
+    });
+
+    it('does not render hover actions in multi-select mode', () => {
+      renderSidebarCard({
+        id: 'A',
+        uiStateOverrides: { multiSelectMode: true },
+      });
+
+      expect(screen.queryByRole('button', { name: /hide query/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /duplicate query/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /remove query/i })).not.toBeInTheDocument();
     });
 
     it('does not render the hover actions when hasActions is false', () => {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Cards/SidebarCard.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Cards/SidebarCard.tsx
@@ -61,6 +61,7 @@ export const SidebarCard = ({
   // of the selection (checkbox-style) instead of replacing it.
   const showSelectionControls =
     multiSelectMode || selectedQueryRefIds.length >= 2 || selectedTransformationIds.length >= 2;
+  const showHoverActions = hasActions && !multiSelectMode;
 
   const styles = useStyles2(getStyles, { isSelected, isPartOfSelection, item });
 
@@ -140,28 +141,28 @@ export const SidebarCard = ({
           )}
           {children}
         </div>
-        {/** Alerts don't have actions and cannot be hidden so we don't need to show the hidden icon or hover actions. */}
-        {/** hasActions is indicating if this is an alert card or a query/transformation card. */}
         {hasActions && (
           <div>
             <div className={styles.cardContentIcons}>
               {item.isHidden && <Icon name="eye-slash" size="sm" />}
               {!!item.error && <Icon name="exclamation-triangle" size="sm" color={theme.colors.error.text} />}
             </div>
-            <div className={cx(styles.hoverActions, { [styles.hoverActionsVisible]: hasFocusWithin })}>
-              <Actions
-                handleResetFocus={handleResetFocus}
-                item={item}
-                onDelete={onDelete}
-                onDuplicate={onDuplicate}
-                onToggleHide={onToggleHide}
-                order={{
-                  delete: 1,
-                  duplicate: 0,
-                  hide: 2,
-                }}
-              />
-            </div>
+            {showHoverActions && (
+              <div className={cx(styles.hoverActions, { [styles.hoverActionsVisible]: hasFocusWithin })}>
+                <Actions
+                  handleResetFocus={handleResetFocus}
+                  item={item}
+                  onDelete={onDelete}
+                  onDuplicate={onDuplicate}
+                  onToggleHide={onToggleHide}
+                  order={{
+                    delete: 1,
+                    duplicate: 0,
+                    hide: 2,
+                  }}
+                />
+              </div>
+            )}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Description
Hides individual sidebar card actions while the query editor is in multi-select mode, so users only see the bulk action UI during multi-select workflows.

## Changes
- Updated `SidebarCard` to hide per-card hover actions when `multiSelectMode` is active.
- Added a focused regression test covering that card actions are not rendered in multi-select mode.
- Kept the change scoped to the PanelEditNext query editor sidebar.

## Risks
- Low risk: this only changes action visibility while explicit multi-select mode is active.
- Most likely area to regress is sidebar card action availability, especially delete/duplicate/hide actions outside multi-select mode.

## Demo
N/A

## Testing Instructions
- Open PanelEditNext.
- Enter multi-select mode from the sidebar.
- Verify individual card actions like duplicate, hide/show, and delete are not shown on hover.
- Select one or more cards and verify bulk actions remain available.
- Exit multi-select mode and verify individual card actions appear again on hover.

## Reviewer Checklist
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable