### PR TITLE
K8s Dashboards: Fix folder permission check to use dashboards:create

### DIFF
--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -1120,27 +1120,19 @@ func (b *DashboardsAPIBuilder) verifyFolderAccessPermissions(ctx context.Context
 	if err != nil {
 		return err
 	}
-	folderClient := b.folderClientProvider.GetOrCreateHandler(ns.Value)
 
+	gvr := dashv1.DashboardResourceInfo.GroupVersionResource()
 	for _, folderId := range folderIds {
-		resp, err := folderClient.Get(ctx, folderId, ns.OrgID, metav1.GetOptions{}, "access")
+		resp, err := b.accessClient.Check(ctx, user, authlib.CheckRequest{
+			Verb:      utils.VerbCreate,
+			Group:     gvr.Group,
+			Resource:  gvr.Resource,
+			Namespace: ns.Value,
+		}, folderId)
 		if err != nil {
-			if apierrors.IsNotFound(err) {
-				return apierrors.NewNotFound(folders.FolderResourceInfo.GroupResource(), folderId)
-			}
-			if apierrors.IsForbidden(err) {
-				return apierrors.NewForbidden(folders.FolderResourceInfo.GroupResource(), folderId, folder.ErrAccessDenied)
-			}
 			return err
 		}
-		var accessInfo folders.FolderAccessInfo
-		err = runtime.DefaultUnstructuredConverter.FromUnstructured(resp.Object, &accessInfo)
-		if err != nil {
-			logging.FromContext(ctx).Error("Failed to convert folder access response", "error", err)
-			return err
-		}
-
-		if !accessInfo.CanEdit {
+		if !resp.Allowed {
 			return apierrors.NewForbidden(folders.FolderResourceInfo.GroupResource(), folderId, folder.ErrAccessDenied)
 		}
 	}

--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -1115,26 +1115,24 @@ func (b *DashboardsAPIBuilder) GetAuthorizer() authorizer.Authorizer {
 		})
 }
 
-func (b *DashboardsAPIBuilder) verifyFolderAccessPermissions(ctx context.Context, user identity.Requester, folderIds ...string) error {
+func (b *DashboardsAPIBuilder) verifyFolderAccessPermissions(ctx context.Context, user identity.Requester, folderID string) error {
 	ns, err := request.NamespaceInfoFrom(ctx, false)
 	if err != nil {
 		return err
 	}
 
 	gvr := dashv1.DashboardResourceInfo.GroupVersionResource()
-	for _, folderId := range folderIds {
-		resp, err := b.accessClient.Check(ctx, user, authlib.CheckRequest{
-			Verb:      utils.VerbCreate,
-			Group:     gvr.Group,
-			Resource:  gvr.Resource,
-			Namespace: ns.Value,
-		}, folderId)
-		if err != nil {
-			return err
-		}
-		if !resp.Allowed {
-			return apierrors.NewForbidden(folders.FolderResourceInfo.GroupResource(), folderId, folder.ErrAccessDenied)
-		}
+	resp, err := b.accessClient.Check(ctx, user, authlib.CheckRequest{
+		Verb:      utils.VerbCreate,
+		Group:     gvr.Group,
+		Resource:  gvr.Resource,
+		Namespace: ns.Value,
+	}, folderID)
+	if err != nil {
+		return err
+	}
+	if !resp.Allowed {
+		return apierrors.NewForbidden(folders.FolderResourceInfo.GroupResource(), folderID, folder.ErrAccessDenied)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

- Fix `verifyFolderAccessPermissions` to check `dashboards:create` directly via `accessClient.Check()` instead of fetching the folder's access subresource and checking `CanEdit` (which required `folders:write`)
- This allows users with `dashboards:create` + `dashboards:write` scoped to a specific folder to actually create dashboards in that folder
- Fixes both dashboard creation and dashboard folder-move (update) paths, since both share the same method

## Problem

When creating a dashboard via the K8s API, `verifyFolderAccessPermissions` (added in #121816) fetches the folder's `access` subresource and checks `CanEdit`. The `CanEdit` field is computed in `sub_access.go` as:

```go
rsp.CanEdit = rsp.CanAdmin || check(utils.VerbUpdate)
```

`VerbUpdate` on the `folders` resource maps to `folders:write` via the RBAC mapper. This means users with `dashboards:create` + `dashboards:write` scoped to `folders:uid:xxx` are denied because they lack `folders:write`.

The resource permissions API's "Edit" level works because it grants the `folders:edit` action set, which bundles both `dashboards:create` **and** `folders:write`.

## Fix

Replace the folder access subresource fetch with a direct `accessClient.Check()` call:

```go
resp, err := b.accessClient.Check(ctx, user, authlib.CheckRequest{
    Verb:      utils.VerbCreate,
    Group:     gvr.Group,       // "dashboard.grafana.app"
    Resource:  gvr.Resource,    // "dashboards"
    Namespace: ns.Value,
}, folderId)
```

This checks `dashboards:create` scoped to the target folder, which is the semantically correct permission. It works for both:
- **Custom roles**: User has `dashboards:create` on `folders:uid:xxx` directly
- **"Edit" permission level**: `folders:edit` action set includes `dashboards:create`, resolved by the RBAC mapper

## Regression analysis

| Scenario | Before | After | Risk |
|----------|--------|-------|------|
| Custom role with `dashboards:create` on folder | Denied (`folders:write` required) | **Allowed** | Fix |
| "Edit" level on folder | Allowed (`folders:edit` includes `folders:write`) | Allowed (`folders:edit` includes `dashboards:create`) | None |
| `folders.permissions:write` without `dashboards:create` | Allowed (via `CanAdmin` fallthrough) | Denied | Negligible — this permission combo doesn't occur in practice; `folders:admin` action set bundles both |
| Folder existence check | Implicitly checked by subresource fetch | Checked by `validateFolderExists` called immediately after | None |
| Folder move (update) | Checked `folders:write` on destination | Checks `dashboards:create` on destination — semantically correct | None |

## Test plan

- [x] Verify user with `dashboards:create` + `dashboards:write` scoped to a specific folder can create dashboards in that folder
- [x] Verify user with "Edit" permission on a folder can still create dashboards
- [x] Verify user without any folder permissions is denied
- [x] Verify dashboard folder-move is denied when user lacks `dashboards:create` on destination folder
- [ ] Existing integration tests pass (`api_validation_test.go` folder permission tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)