### PR TITLE
Card: description overlaps with tags

### DIFF
--- a/packages/grafana-ui/src/components/Card/Card.story.tsx
+++ b/packages/grafana-ui/src/components/Card/Card.story.tsx
@@ -40,7 +40,7 @@ export const Basic: StoryFn<typeof Card> = (args) => {
  */
 export const MultipleMetadataElements: StoryFn<typeof Card> = (args) => {
   return (
-    <Card noMargin>
+    <Card noMargin {...args}>
       <Card.Heading>Test dashboard</Card.Heading>
       <Card.Meta>{['Folder: Test', 'Views: 100']}</Card.Meta>
     </Card>
@@ -53,7 +53,7 @@ export const MultipleMetadataElements: StoryFn<typeof Card> = (args) => {
  */
 export const ComplexMetadataElements: StoryFn<typeof Card> = (args) => {
   return (
-    <Card noMargin>
+    <Card noMargin {...args}>
       <Card.Heading>Test dashboard</Card.Heading>
       <Card.Meta>
         <>Grafana</>
@@ -70,7 +70,7 @@ export const ComplexMetadataElements: StoryFn<typeof Card> = (args) => {
  */
 export const MultipleMetadataWithCustomSeparator: StoryFn<typeof Card> = (args) => {
   return (
-    <Card noMargin>
+    <Card noMargin {...args}>
       <Card.Heading>Test dashboard</Card.Heading>
       <Card.Meta separator={'-'}>
         Grafana
@@ -89,7 +89,7 @@ export const MultipleMetadataWithCustomSeparator: StoryFn<typeof Card> = (args) 
  */
 export const Tags: StoryFn<typeof Card> = (args) => {
   return (
-    <Card noMargin>
+    <Card noMargin {...args}>
       <Card.Heading>Test dashboard</Card.Heading>
       <Card.Description>Card with a list of tags</Card.Description>
       <Card.Tags>
@@ -104,7 +104,7 @@ export const Tags: StoryFn<typeof Card> = (args) => {
  */
 export const AsALink: StoryFn<typeof Card> = (args) => {
   return (
-    <Card noMargin href="https://grafana.com">
+    <Card noMargin href="https://grafana.com" {...args}>
       <Card.Heading>Redirect to Grafana</Card.Heading>
       <Card.Description>Clicking this card will redirect to grafana website</Card.Description>
     </Card>
@@ -118,7 +118,7 @@ export const AsALink: StoryFn<typeof Card> = (args) => {
  */
 export const AsAButton: StoryFn<typeof Card> = (args) => {
   return (
-    <Card noMargin onClick={() => alert('Hello, Grafana!')}>
+    <Card noMargin onClick={() => alert('Hello, Grafana!')} {...args}>
       <Card.Heading>Hello, Grafana</Card.Heading>
       <Card.Description>Clicking this card will create an alert</Card.Description>
     </Card>
@@ -132,25 +132,25 @@ export const InsideAListItem: StoryFn<typeof Card> = (args) => {
   return (
     <ul style={{ padding: '20px', listStyle: 'none', display: 'grid', gap: '8px' }}>
       <li>
-        <Card noMargin>
+        <Card noMargin {...args}>
           <Card.Heading>List card item</Card.Heading>
           <Card.Description>Card that is rendered inside li element.</Card.Description>
         </Card>
       </li>
       <li>
-        <Card noMargin>
+        <Card noMargin {...args}>
           <Card.Heading>List card item</Card.Heading>
           <Card.Description>Card that is rendered inside li element.</Card.Description>
         </Card>
       </li>
       <li>
-        <Card noMargin>
+        <Card noMargin {...args}>
           <Card.Heading>List card item</Card.Heading>
           <Card.Description>Card that is rendered inside li element.</Card.Description>
         </Card>
       </li>
       <li>
-        <Card noMargin>
+        <Card noMargin {...args}>
           <Card.Heading>List card item</Card.Heading>
           <Card.Description>Card that is rendered inside li element.</Card.Description>
         </Card>
@@ -164,7 +164,7 @@ export const InsideAListItem: StoryFn<typeof Card> = (args) => {
  */
 export const WithMediaElements: StoryFn<typeof Card> = (args) => {
   return (
-    <Card noMargin>
+    <Card noMargin {...args}>
       <Card.Heading>1-ops-tools1-fallback</Card.Heading>
       <Card.Figure>
         <img src={logo} alt="Grafana Logo" width="40" height="40" />

--- a/packages/grafana-ui/src/components/Card/Card.story.tsx
+++ b/packages/grafana-ui/src/components/Card/Card.story.tsx
@@ -276,6 +276,9 @@ export const Full: StoryFn<typeof Card> = (args) => {
       <Card.Figure>
         <img src={logo} alt="Prometheus Logo" height="40" width="40" />
       </Card.Figure>
+      <Card.Tags>
+        <TagList tags={['tag1', 'tag2', 'tag3']} onClick={(tag) => console.log(tag)} />
+      </Card.Tags>
       <Card.Actions>
         <Button key="settings" variant="secondary">
           Main action

--- a/packages/grafana-ui/src/components/Card/Card.tsx
+++ b/packages/grafana-ui/src/components/Card/Card.tsx
@@ -14,7 +14,8 @@ import { CardContainer, type CardContainerProps, getCardContainerStyles } from '
 /**
  * @public
  */
-export interface Props extends Omit<CardContainerProps, 'disableEvents' | 'disableHover'> {
+export interface Props
+  extends Omit<CardContainerProps, 'disableEvents' | 'disableHover' | 'hasDescriptionComponent' | 'hasTagsComponent'> {
   /** Indicates if the card and all its actions can be interacted with */
   disabled?: boolean;
   /** Link to redirect to on card click. If provided, the Card inner content will be rendered inside `a` */
@@ -100,6 +101,7 @@ export const Card: CardInterface = ({
       className={cx(styles.container, className)}
       noMargin={noMargin}
       hasDescriptionComponent={hasDescriptionComponent}
+      hasTagsComponent={hasTagsComponent}
       {...htmlProps}
     >
       <CardContext.Provider value={{ href, onClick: onCardClick, disabled, isSelected }}>
@@ -152,7 +154,6 @@ Heading.displayName = 'Heading';
 const getHeadingStyles = (theme: GrafanaTheme2) => ({
   heading: css({
     gridArea: 'Heading',
-    gridColumnEnd: 'var(--card-content-column-end, auto)',
     justifySelf: 'start',
     display: 'flex',
     justifyContent: 'space-between',
@@ -219,7 +220,6 @@ const getDescriptionStyles = (theme: GrafanaTheme2) => ({
   description: css({
     width: '100%',
     gridArea: 'Description',
-    gridColumnEnd: 'var(--card-content-column-end, auto)',
     margin: theme.spacing(1, 0, 0),
     color: theme.colors.text.secondary,
     lineHeight: theme.typography.body.lineHeight,
@@ -292,7 +292,6 @@ Meta.displayName = 'Meta';
 const getMetaStyles = (theme: GrafanaTheme2) => ({
   metadata: css({
     gridArea: 'Meta',
-    gridColumnEnd: 'var(--card-content-column-end, auto)',
     display: 'flex',
     alignItems: 'center',
     width: '100%',

--- a/packages/grafana-ui/src/components/Card/Card.tsx
+++ b/packages/grafana-ui/src/components/Card/Card.tsx
@@ -47,7 +47,6 @@ const CardContext = React.createContext<{
   onClick?: (e: React.MouseEvent<HTMLElement>) => void;
   disabled?: boolean;
   isSelected?: boolean;
-  hasTags?: boolean;
 } | null>(null);
 
 /**
@@ -87,6 +86,7 @@ export const Card: CardInterface = ({
     disabled,
     disableHover,
     hasDescriptionComponent,
+    hasTagsComponent,
     isSelected,
     isCompact,
     noMargin
@@ -102,7 +102,7 @@ export const Card: CardInterface = ({
       hasDescriptionComponent={hasDescriptionComponent}
       {...htmlProps}
     >
-      <CardContext.Provider value={{ href, onClick: onCardClick, disabled, isSelected, hasTags: hasTagsComponent }}>
+      <CardContext.Provider value={{ href, onClick: onCardClick, disabled, isSelected }}>
         {!hasHeadingComponent && <Heading />}
         {children}
       </CardContext.Provider>
@@ -120,8 +120,7 @@ interface ChildProps {
 /** Main heading for the card */
 const Heading = ({ children, className, 'aria-label': ariaLabel }: ChildProps & { 'aria-label'?: string }) => {
   const context = useContext(CardContext);
-  const hasTags = context?.hasTags ?? false;
-  const styles = useStyles2(getHeadingStyles, hasTags);
+  const styles = useStyles2(getHeadingStyles);
 
   const { href, onClick, isSelected } = context ?? {
     href: undefined,
@@ -150,10 +149,10 @@ const Heading = ({ children, className, 'aria-label': ariaLabel }: ChildProps & 
 };
 Heading.displayName = 'Heading';
 
-const getHeadingStyles = (theme: GrafanaTheme2, hasTags: boolean) => ({
+const getHeadingStyles = (theme: GrafanaTheme2) => ({
   heading: css({
     gridArea: 'Heading',
-    ...(!hasTags && { gridColumnEnd: -1 }),
+    gridColumnEnd: 'var(--card-content-column-end, auto)',
     justifySelf: 'start',
     display: 'flex',
     justifyContent: 'space-between',
@@ -210,19 +209,17 @@ const getTagStyles = (theme: GrafanaTheme2) => ({
 
 /** Card description text */
 const Description = ({ children, className }: ChildProps) => {
-  const context = useContext(CardContext);
-  const hasTags = context?.hasTags ?? false;
-  const styles = useStyles2(getDescriptionStyles, hasTags);
+  const styles = useStyles2(getDescriptionStyles);
   const Element = typeof children === 'string' ? 'p' : 'div';
   return <Element className={cx(styles.description, className)}>{children}</Element>;
 };
 Description.displayName = 'Description';
 
-const getDescriptionStyles = (theme: GrafanaTheme2, hasTags: boolean) => ({
+const getDescriptionStyles = (theme: GrafanaTheme2) => ({
   description: css({
     width: '100%',
     gridArea: 'Description',
-    ...(!hasTags && { gridColumnEnd: -1 }),
+    gridColumnEnd: 'var(--card-content-column-end, auto)',
     margin: theme.spacing(1, 0, 0),
     color: theme.colors.text.secondary,
     lineHeight: theme.typography.body.lineHeight,
@@ -266,9 +263,7 @@ const getFigureStyles = (theme: GrafanaTheme2) => ({
 });
 
 const Meta = memo(({ children, className, separator = '|' }: ChildProps & { separator?: string }) => {
-  const context = useContext(CardContext);
-  const hasTags = context?.hasTags ?? false;
-  const styles = useStyles2(getMetaStyles, hasTags);
+  const styles = useStyles2(getMetaStyles);
   let meta = children;
 
   const filtered = React.Children.toArray(children).filter(Boolean);
@@ -294,10 +289,10 @@ const Meta = memo(({ children, className, separator = '|' }: ChildProps & { sepa
 });
 Meta.displayName = 'Meta';
 
-const getMetaStyles = (theme: GrafanaTheme2, hasTags: boolean) => ({
+const getMetaStyles = (theme: GrafanaTheme2) => ({
   metadata: css({
     gridArea: 'Meta',
-    ...(!hasTags && { gridColumnEnd: -1 }),
+    gridColumnEnd: 'var(--card-content-column-end, auto)',
     display: 'flex',
     alignItems: 'center',
     width: '100%',
@@ -390,9 +385,9 @@ export const getCardStyles = (theme: GrafanaTheme2) => {
       width: '100%',
       flexWrap: 'wrap',
     }),
-    ...getHeadingStyles(theme, false),
-    ...getMetaStyles(theme, false),
-    ...getDescriptionStyles(theme, false),
+    ...getHeadingStyles(theme),
+    ...getMetaStyles(theme),
+    ...getDescriptionStyles(theme),
     ...getFigureStyles(theme),
     ...getActionStyles(theme),
     ...getTagStyles(theme),

--- a/packages/grafana-ui/src/components/Card/Card.tsx
+++ b/packages/grafana-ui/src/components/Card/Card.tsx
@@ -47,6 +47,7 @@ const CardContext = React.createContext<{
   onClick?: (e: React.MouseEvent<HTMLElement>) => void;
   disabled?: boolean;
   isSelected?: boolean;
+  hasTags?: boolean;
 } | null>(null);
 
 /**
@@ -74,6 +75,10 @@ export const Card: CardInterface = ({
     () => React.Children.toArray(children).some((c) => React.isValidElement(c) && c.type === Description),
     [children]
   );
+  const hasTagsComponent = useMemo(
+    () => React.Children.toArray(children).some((c) => React.isValidElement(c) && c.type === Tags),
+    [children]
+  );
 
   const disableHover = disabled || (!onClick && !href);
   const onCardClick = onClick && !disabled ? onClick : undefined;
@@ -97,7 +102,7 @@ export const Card: CardInterface = ({
       hasDescriptionComponent={hasDescriptionComponent}
       {...htmlProps}
     >
-      <CardContext.Provider value={{ href, onClick: onCardClick, disabled, isSelected }}>
+      <CardContext.Provider value={{ href, onClick: onCardClick, disabled, isSelected, hasTags: hasTagsComponent }}>
         {!hasHeadingComponent && <Heading />}
         {children}
       </CardContext.Provider>
@@ -115,7 +120,8 @@ interface ChildProps {
 /** Main heading for the card */
 const Heading = ({ children, className, 'aria-label': ariaLabel }: ChildProps & { 'aria-label'?: string }) => {
   const context = useContext(CardContext);
-  const styles = useStyles2(getHeadingStyles);
+  const hasTags = context?.hasTags ?? false;
+  const styles = useStyles2(getHeadingStyles, hasTags);
 
   const { href, onClick, isSelected } = context ?? {
     href: undefined,
@@ -144,10 +150,10 @@ const Heading = ({ children, className, 'aria-label': ariaLabel }: ChildProps & 
 };
 Heading.displayName = 'Heading';
 
-const getHeadingStyles = (theme: GrafanaTheme2) => ({
+const getHeadingStyles = (theme: GrafanaTheme2, hasTags: boolean) => ({
   heading: css({
     gridArea: 'Heading',
-    gridColumnEnd: 'Tags',
+    ...(!hasTags && { gridColumnEnd: -1 }),
     justifySelf: 'start',
     display: 'flex',
     justifyContent: 'space-between',
@@ -204,17 +210,19 @@ const getTagStyles = (theme: GrafanaTheme2) => ({
 
 /** Card description text */
 const Description = ({ children, className }: ChildProps) => {
-  const styles = useStyles2(getDescriptionStyles);
+  const context = useContext(CardContext);
+  const hasTags = context?.hasTags ?? false;
+  const styles = useStyles2(getDescriptionStyles, hasTags);
   const Element = typeof children === 'string' ? 'p' : 'div';
   return <Element className={cx(styles.description, className)}>{children}</Element>;
 };
 Description.displayName = 'Description';
 
-const getDescriptionStyles = (theme: GrafanaTheme2) => ({
+const getDescriptionStyles = (theme: GrafanaTheme2, hasTags: boolean) => ({
   description: css({
     width: '100%',
     gridArea: 'Description',
-    gridColumnEnd: 'Tags',
+    ...(!hasTags && { gridColumnEnd: -1 }),
     margin: theme.spacing(1, 0, 0),
     color: theme.colors.text.secondary,
     lineHeight: theme.typography.body.lineHeight,
@@ -258,7 +266,9 @@ const getFigureStyles = (theme: GrafanaTheme2) => ({
 });
 
 const Meta = memo(({ children, className, separator = '|' }: ChildProps & { separator?: string }) => {
-  const styles = useStyles2(getMetaStyles);
+  const context = useContext(CardContext);
+  const hasTags = context?.hasTags ?? false;
+  const styles = useStyles2(getMetaStyles, hasTags);
   let meta = children;
 
   const filtered = React.Children.toArray(children).filter(Boolean);
@@ -284,10 +294,10 @@ const Meta = memo(({ children, className, separator = '|' }: ChildProps & { sepa
 });
 Meta.displayName = 'Meta';
 
-const getMetaStyles = (theme: GrafanaTheme2) => ({
+const getMetaStyles = (theme: GrafanaTheme2, hasTags: boolean) => ({
   metadata: css({
     gridArea: 'Meta',
-    gridColumnEnd: 'Tags',
+    ...(!hasTags && { gridColumnEnd: -1 }),
     display: 'flex',
     alignItems: 'center',
     width: '100%',
@@ -380,9 +390,9 @@ export const getCardStyles = (theme: GrafanaTheme2) => {
       width: '100%',
       flexWrap: 'wrap',
     }),
-    ...getHeadingStyles(theme),
-    ...getMetaStyles(theme),
-    ...getDescriptionStyles(theme),
+    ...getHeadingStyles(theme, false),
+    ...getMetaStyles(theme, false),
+    ...getDescriptionStyles(theme, false),
     ...getFigureStyles(theme),
     ...getActionStyles(theme),
     ...getTagStyles(theme),

--- a/packages/grafana-ui/src/components/Card/CardContainer.tsx
+++ b/packages/grafana-ui/src/components/Card/CardContainer.tsx
@@ -96,7 +96,7 @@ export const getCardContainerStyles = (
 ) => {
   const isSelectable = isSelected !== undefined;
 
-  const headingRow = `"Figure Heading Heading" ${hasDescriptionComponent ? '' : '1fr'}`;
+  const headingRow = `"Figure Heading ${hasTagsComponent && !isSelectable ? 'Tags' : 'Heading'}" ${hasDescriptionComponent ? '' : '1fr'}`;
   const metaRow = `"Figure Meta ${hasTagsComponent ? 'Tags' : 'Meta'}"`;
   const descriptionRow = `"Figure Description ${hasTagsComponent ? 'Tags' : 'Description'}" 1fr`;
   const actionsRow = `"Figure Actions Secondary" / auto 1fr auto`;

--- a/packages/grafana-ui/src/components/Card/CardContainer.tsx
+++ b/packages/grafana-ui/src/components/Card/CardContainer.tsx
@@ -69,6 +69,7 @@ export const CardContainer = ({
     disableEvents,
     disableHover,
     hasDescriptionComponent,
+    false,
     isSelected,
     undefined,
     noMargin
@@ -86,6 +87,7 @@ export const getCardContainerStyles = (
   disabled = false,
   disableHover = false,
   hasDescriptionComponent: boolean,
+  hasTagsComponent = false,
   isSelected?: boolean,
   isCompact?: boolean,
   noMargin = false
@@ -96,6 +98,7 @@ export const getCardContainerStyles = (
     container: css({
       display: 'grid',
       position: 'relative',
+      ...(!hasTagsComponent && { '--card-content-column-end': '-1' }),
       gridTemplate: hasDescriptionComponent
         ? `
         "Figure Heading Tags"

--- a/packages/grafana-ui/src/components/Card/CardContainer.tsx
+++ b/packages/grafana-ui/src/components/Card/CardContainer.tsx
@@ -50,6 +50,7 @@ export interface CardContainerProps extends HTMLAttributes<HTMLOrSVGElement>, Ca
   /** Remove the bottom margin */
   noMargin?: boolean;
   hasDescriptionComponent?: boolean;
+  hasTagsComponent?: boolean;
 }
 
 /** @deprecated Using `CardContainer` directly is discouraged and should be replaced with `Card` */
@@ -62,6 +63,7 @@ export const CardContainer = ({
   href,
   noMargin,
   hasDescriptionComponent = false,
+  hasTagsComponent = false,
   ...props
 }: CardContainerProps) => {
   const { oldContainer } = useStyles2(
@@ -69,7 +71,7 @@ export const CardContainer = ({
     disableEvents,
     disableHover,
     hasDescriptionComponent,
-    false,
+    hasTagsComponent,
     isSelected,
     undefined,
     noMargin
@@ -87,29 +89,27 @@ export const getCardContainerStyles = (
   disabled = false,
   disableHover = false,
   hasDescriptionComponent: boolean,
-  hasTagsComponent = false,
+  hasTagsComponent: boolean,
   isSelected?: boolean,
   isCompact?: boolean,
   noMargin = false
 ) => {
   const isSelectable = isSelected !== undefined;
 
+  const headingRow = `"Figure Heading Heading" ${hasDescriptionComponent ? '' : '1fr'}`;
+  const metaRow = `"Figure Meta ${hasTagsComponent ? 'Tags' : 'Meta'}"`;
+  const descriptionRow = `"Figure Description ${hasTagsComponent ? 'Tags' : 'Description'}" 1fr`;
+  const actionsRow = `"Figure Actions Secondary" / auto 1fr auto`;
+
   return {
     container: css({
       display: 'grid',
       position: 'relative',
-      ...(!hasTagsComponent && { '--card-content-column-end': '-1' }),
-      gridTemplate: hasDescriptionComponent
-        ? `
-        "Figure Heading Tags"
-        "Figure Meta Tags"
-        "Figure Description Tags" 1fr
-        "Figure Actions Secondary" / auto 1fr auto
-      `
-        : `
-        "Figure Heading Tags" 1fr
-        "Figure Meta Tags"
-        "Figure Actions Secondary" / auto 1fr auto
+      gridTemplate: `
+        ${headingRow}
+        ${metaRow}
+        ${hasDescriptionComponent ? descriptionRow : ''}
+        ${actionsRow}
       `,
       gridAutoColumns: '1fr',
       gridAutoFlow: 'row',


### PR DESCRIPTION
**What is this feature?**

[This PR](https://github.com/grafana/grafana/pull/123876) introduced an improvement to the card responsiveness at small screen widths. Unfortunately it also seems to have caused the card Description to overflow into the card's Tag grid area.

**Why do we need this feature?**

This PR prevents the Description area from overlapping with the Tags area, while maintaining the responsiveness improvement from the mentioned PR.

**Who is this feature for?**

Me :)
We make use of these cards extensively in Vuln O11y and this caused a visual regression for us. 

## Screenshots

### Before
  
<img width="1195" height="220" alt="Screenshot 2026-05-11 at 2 20 12 PM" src="https://github.com/user-attachments/assets/8153b966-11f8-4470-94dc-98e1a014472d" />

### After

#### With Tags
<img width="1335" height="198" alt="Screenshot 2026-05-11 at 2 36 50 PM" src="https://github.com/user-attachments/assets/3d9bf843-9aee-4a57-aed7-795c1b9ec5d6" />

#### Without Tags (no regression)
<img width="488" height="319" alt="Screenshot 2026-05-11 at 2 37 15 PM" src="https://github.com/user-attachments/assets/3b5a9b4b-1715-4184-9a63-46b4259d3f56" />

### Other considerations

I played around with conditions in the CardContainer gridTemplate, but that starts to get messy and won't scale well. 
I also played around with adding a "hasTags" prop to the CardContext, but that was more verbose and may have broken some memoization.

I ultimately decided to go with a CSS variable, which is simpler code-wise and doesn't introduce any React overhead.  It's not a paradigm used much in grafana/ui though, so let me know if you see a better solution!