### PR TITLE
Google Cloud Monitoring: Add OAuth Passthrough authentication (backend)

### DIFF
--- a/pkg/tsdb/cloud-monitoring/cloudmonitoring.go
+++ b/pkg/tsdb/cloud-monitoring/cloudmonitoring.go
@@ -61,6 +61,13 @@ const (
 	perSeriesAlignerDefault        = "ALIGN_MEAN"
 )
 
+// CheckHealth messages for OAuth passthrough failure modes admins hit most often.
+const (
+	oauthPassthroughMissingDefaultProjectMessage = "Default project is required when using OAuth passthrough authentication."
+	oauthPassthroughUnauthorizedMessage          = "401 Unauthorized: Usage of this data source requires you to be authenticated via Google OAuth. If you are signed in via Google, your session token may have expired — sign out and back in to refresh it."
+	oauthPassthroughForbiddenMessage             = "403 Forbidden: Permission denied. Make sure the https://www.googleapis.com/auth/monitoring.read scope is configured in Grafana's Google OAuth settings, and that the signed-in user has the Monitoring Viewer role on the default project."
+)
+
 func ProvideService(httpClientProvider *httpclient.Provider) *Service {
 	s := &Service{
 		httpClientProvider: *httpClientProvider,
@@ -96,7 +103,7 @@ func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthReque
 	if dsInfo.oauthPassThru && defaultProject == "" {
 		return &backend.CheckHealthResult{
 			Status:  backend.HealthStatusError,
-			Message: "Default project is required when using OAuth passthrough authentication.",
+			Message: oauthPassthroughMissingDefaultProjectMessage,
 		}, nil
 	}
 
@@ -121,6 +128,14 @@ func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthReque
 	if res.StatusCode != 200 {
 		status = backend.HealthStatusError
 		message = res.Status
+		if dsInfo.oauthPassThru {
+			switch res.StatusCode {
+			case http.StatusUnauthorized:
+				message = oauthPassthroughUnauthorizedMessage
+			case http.StatusForbidden:
+				message = oauthPassthroughForbiddenMessage
+			}
+		}
 	}
 	return &backend.CheckHealthResult{
 		Status:  status,

--- a/pkg/tsdb/cloud-monitoring/cloudmonitoring.go
+++ b/pkg/tsdb/cloud-monitoring/cloudmonitoring.go
@@ -61,20 +61,6 @@ const (
 	perSeriesAlignerDefault        = "ALIGN_MEAN"
 )
 
-type authHeaderCtxKey struct{}
-
-func withAuthHeader(ctx context.Context, h string) context.Context {
-	if h == "" {
-		return ctx
-	}
-	return context.WithValue(ctx, authHeaderCtxKey{}, h)
-}
-
-func authHeaderFromContext(ctx context.Context) string {
-	v, _ := ctx.Value(authHeaderCtxKey{}).(string)
-	return v
-}
-
 func ProvideService(httpClientProvider *httpclient.Provider) *Service {
 	s := &Service{
 		httpClientProvider: *httpClientProvider,
@@ -94,8 +80,6 @@ func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceReq
 }
 
 func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
-	ctx = withAuthHeader(ctx, req.Headers["Authorization"])
-
 	dsInfo, err := s.getDSInfo(ctx, req.PluginContext)
 	if err != nil {
 		return nil, err
@@ -222,6 +206,10 @@ func newInstanceSettings(httpClientProvider httpclient.Provider) datasource.Inst
 		opts, err := settings.HTTPClientOptions(ctx)
 		if err != nil {
 			return nil, err
+		}
+
+		if jsonData.AuthenticationType == oauthPassthroughAuthentication {
+			opts.ForwardHTTPHeaders = true
 		}
 
 		for name := range routes {
@@ -363,8 +351,6 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 	if len(req.Queries) == 0 {
 		return nil, fmt.Errorf("query contains no queries")
 	}
-
-	ctx = withAuthHeader(ctx, req.Headers["Authorization"])
 
 	err := migrateRequest(req)
 	if err != nil {

--- a/pkg/tsdb/cloud-monitoring/cloudmonitoring.go
+++ b/pkg/tsdb/cloud-monitoring/cloudmonitoring.go
@@ -49,16 +49,31 @@ var (
 )
 
 const (
-	gceAuthentication         = "gce"
-	jwtAuthentication         = "jwt"
-	annotationQueryType       = dataquery.QueryTypeANNOTATION
-	timeSeriesListQueryType   = dataquery.QueryTypeTIMESERIESLIST
-	timeSeriesQueryQueryType  = dataquery.QueryTypeTIMESERIESQUERY
-	sloQueryType              = dataquery.QueryTypeSLO
-	promQLQueryType           = dataquery.QueryTypePROMQL
-	crossSeriesReducerDefault = "REDUCE_NONE"
-	perSeriesAlignerDefault   = "ALIGN_MEAN"
+	gceAuthentication              = "gce"
+	jwtAuthentication              = "jwt"
+	oauthPassthroughAuthentication = "oauthPassthrough"
+	annotationQueryType            = dataquery.QueryTypeANNOTATION
+	timeSeriesListQueryType        = dataquery.QueryTypeTIMESERIESLIST
+	timeSeriesQueryQueryType       = dataquery.QueryTypeTIMESERIESQUERY
+	sloQueryType                   = dataquery.QueryTypeSLO
+	promQLQueryType                = dataquery.QueryTypePROMQL
+	crossSeriesReducerDefault      = "REDUCE_NONE"
+	perSeriesAlignerDefault        = "ALIGN_MEAN"
 )
+
+type authHeaderCtxKey struct{}
+
+func withAuthHeader(ctx context.Context, h string) context.Context {
+	if h == "" {
+		return ctx
+	}
+	return context.WithValue(ctx, authHeaderCtxKey{}, h)
+}
+
+func authHeaderFromContext(ctx context.Context) string {
+	v, _ := ctx.Value(authHeaderCtxKey{}).(string)
+	return v
+}
 
 func ProvideService(httpClientProvider *httpclient.Provider) *Service {
 	s := &Service{
@@ -79,6 +94,8 @@ func (s *Service) CallResource(ctx context.Context, req *backend.CallResourceReq
 }
 
 func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthRequest) (*backend.CheckHealthResult, error) {
+	ctx = withAuthHeader(ctx, req.Headers["Authorization"])
+
 	dsInfo, err := s.getDSInfo(ctx, req.PluginContext)
 	if err != nil {
 		return nil, err
@@ -92,8 +109,15 @@ func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthReque
 		}, nil
 	}
 
+	if dsInfo.oauthPassThru && defaultProject == "" {
+		return &backend.CheckHealthResult{
+			Status:  backend.HealthStatusError,
+			Message: "Default project is required when using OAuth passthrough authentication.",
+		}, nil
+	}
+
 	url := fmt.Sprintf("%s/v3/projects/%s/metricDescriptors", dsInfo.services[cloudMonitor].url, defaultProject)
-	request, err := http.NewRequest(http.MethodGet, url, nil)
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -144,6 +168,7 @@ type datasourceInfo struct {
 	privateKey                  string
 	usingImpersonation          bool
 	serviceAccountToImpersonate string
+	oauthPassThru               bool
 }
 
 type datasourceJSONData struct {
@@ -154,6 +179,7 @@ type datasourceJSONData struct {
 	UniverseDomain              string `json:"universeDomain"`
 	UsingImpersonation          bool   `json:"usingImpersonation"`
 	ServiceAccountToImpersonate string `json:"serviceAccountToImpersonate"`
+	OAuthPassThru               bool   `json:"oauthPassThru"`
 }
 
 type datasourceService struct {
@@ -184,6 +210,7 @@ func newInstanceSettings(httpClientProvider httpclient.Provider) datasource.Inst
 			universeDomain:              jsonData.UniverseDomain,
 			usingImpersonation:          jsonData.UsingImpersonation,
 			serviceAccountToImpersonate: jsonData.ServiceAccountToImpersonate,
+			oauthPassThru:               jsonData.OAuthPassThru,
 			services:                    map[string]datasourceService{},
 		}
 
@@ -336,6 +363,8 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 	if len(req.Queries) == 0 {
 		return nil, fmt.Errorf("query contains no queries")
 	}
+
+	ctx = withAuthHeader(ctx, req.Headers["Authorization"])
 
 	err := migrateRequest(req)
 	if err != nil {

--- a/pkg/tsdb/cloud-monitoring/cloudmonitoring.go
+++ b/pkg/tsdb/cloud-monitoring/cloudmonitoring.go
@@ -68,7 +68,7 @@ const (
 	oauthPassthroughMissingDefaultProjectMessage = "Default project is required when using OAuth passthrough authentication."
 	oauthPassthroughUnauthorizedMessage          = "401 Unauthorized: Usage of this data source requires you to be authenticated via Google OAuth. If you are signed in via Google, your session token may have expired — sign out and back in to refresh it."
 	oauthPassthroughForbiddenMessage             = "403 Forbidden: Permission denied. Make sure the https://www.googleapis.com/auth/monitoring.read scope is configured in Grafana's Google OAuth settings, and that the signed-in user has the Monitoring Viewer role on the default project."
-	oauthPassthroughAlertingNotSupportedMessage  = "Forward OAuth Identity authentication is not supported in alerting queries. Use Google JWT File or GCE Default Service Account authentication for data sources used by alerting rules."
+	oauthPassthroughAlertingNotSupportedMessage  = "Forward OAuth Identity authentication is not supported in alerting queries; use Google JWT File or GCE Default Service Account authentication for data sources used by alerting rules"
 )
 
 func ProvideService(httpClientProvider *httpclient.Provider) *Service {

--- a/pkg/tsdb/cloud-monitoring/cloudmonitoring.go
+++ b/pkg/tsdb/cloud-monitoring/cloudmonitoring.go
@@ -3,6 +3,7 @@ package cloudmonitoring
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math"
@@ -61,11 +62,13 @@ const (
 	perSeriesAlignerDefault        = "ALIGN_MEAN"
 )
 
-// CheckHealth messages for OAuth passthrough failure modes admins hit most often.
+const fromAlertHeaderName = "FromAlert"
+
 const (
 	oauthPassthroughMissingDefaultProjectMessage = "Default project is required when using OAuth passthrough authentication."
 	oauthPassthroughUnauthorizedMessage          = "401 Unauthorized: Usage of this data source requires you to be authenticated via Google OAuth. If you are signed in via Google, your session token may have expired — sign out and back in to refresh it."
 	oauthPassthroughForbiddenMessage             = "403 Forbidden: Permission denied. Make sure the https://www.googleapis.com/auth/monitoring.read scope is configured in Grafana's Google OAuth settings, and that the signed-in user has the Monitoring Viewer role on the default project."
+	oauthPassthroughAlertingNotSupportedMessage  = "Forward OAuth Identity authentication is not supported in alerting queries. Use Google JWT File or GCE Default Service Account authentication for data sources used by alerting rules."
 )
 
 func ProvideService(httpClientProvider *httpclient.Provider) *Service {
@@ -375,6 +378,13 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 	dsInfo, err := s.getDSInfo(ctx, req.PluginContext)
 	if err != nil {
 		return nil, err
+	}
+
+	// OAuth passthrough requires a signed-in user to source the bearer token from.
+	// Alert rule evaluations run without a user context, so fail fast with a clear
+	// message rather than letting the request reach GCM with no Authorization header.
+	if dsInfo.oauthPassThru && req.Headers[fromAlertHeaderName] == "true" {
+		return nil, backend.DownstreamError(errors.New(oauthPassthroughAlertingNotSupportedMessage))
 	}
 
 	// There aren't any possible downstream errors here

--- a/pkg/tsdb/cloud-monitoring/cloudmonitoring.go
+++ b/pkg/tsdb/cloud-monitoring/cloudmonitoring.go
@@ -68,7 +68,7 @@ const (
 	oauthPassthroughMissingDefaultProjectMessage = "Default project is required when using OAuth passthrough authentication."
 	oauthPassthroughUnauthorizedMessage          = "401 Unauthorized: Usage of this data source requires you to be authenticated via Google OAuth. If you are signed in via Google, your session token may have expired — sign out and back in to refresh it."
 	oauthPassthroughForbiddenMessage             = "403 Forbidden: Permission denied. Make sure the https://www.googleapis.com/auth/monitoring.read scope is configured in Grafana's Google OAuth settings, and that the signed-in user has the Monitoring Viewer role on the default project."
-	oauthPassthroughAlertingNotSupportedMessage  = "Forward OAuth Identity authentication is not supported in alerting queries; use Google JWT File or GCE Default Service Account authentication for data sources used by alerting rules"
+	oauthPassthroughAlertingNotSupportedMessage  = "alerting queries are not supported with the Forward OAuth Identity authentication type; use Google JWT File or GCE Default Service Account for data sources used by alerting rules"
 )
 
 func ProvideService(httpClientProvider *httpclient.Provider) *Service {

--- a/pkg/tsdb/cloud-monitoring/cloudmonitoring.go
+++ b/pkg/tsdb/cloud-monitoring/cloudmonitoring.go
@@ -50,25 +50,25 @@ var (
 )
 
 const (
-	gceAuthentication              = "gce"
-	jwtAuthentication              = "jwt"
-	oauthPassthroughAuthentication = "oauthPassthrough"
-	annotationQueryType            = dataquery.QueryTypeANNOTATION
-	timeSeriesListQueryType        = dataquery.QueryTypeTIMESERIESLIST
-	timeSeriesQueryQueryType       = dataquery.QueryTypeTIMESERIESQUERY
-	sloQueryType                   = dataquery.QueryTypeSLO
-	promQLQueryType                = dataquery.QueryTypePROMQL
-	crossSeriesReducerDefault      = "REDUCE_NONE"
-	perSeriesAlignerDefault        = "ALIGN_MEAN"
+	gceAuthentication                  = "gce"
+	jwtAuthentication                  = "jwt"
+	forwardOAuthIdentityAuthentication = "forwardOAuthIdentity"
+	annotationQueryType                = dataquery.QueryTypeANNOTATION
+	timeSeriesListQueryType            = dataquery.QueryTypeTIMESERIESLIST
+	timeSeriesQueryQueryType           = dataquery.QueryTypeTIMESERIESQUERY
+	sloQueryType                       = dataquery.QueryTypeSLO
+	promQLQueryType                    = dataquery.QueryTypePROMQL
+	crossSeriesReducerDefault          = "REDUCE_NONE"
+	perSeriesAlignerDefault            = "ALIGN_MEAN"
 )
 
 const fromAlertHeaderName = "FromAlert"
 
 const (
-	oauthPassthroughMissingDefaultProjectMessage = "Default project is required when using OAuth passthrough authentication."
-	oauthPassthroughUnauthorizedMessage          = "401 Unauthorized: Usage of this data source requires you to be authenticated via Google OAuth. If you are signed in via Google, your session token may have expired — sign out and back in to refresh it."
-	oauthPassthroughForbiddenMessage             = "403 Forbidden: Permission denied. Make sure the https://www.googleapis.com/auth/monitoring.read scope is configured in Grafana's Google OAuth settings, and that the signed-in user has the Monitoring Viewer role on the default project."
-	oauthPassthroughAlertingNotSupportedMessage  = "alerting queries are not supported with the Forward OAuth Identity authentication type; use Google JWT File or GCE Default Service Account for data sources used by alerting rules"
+	forwardOAuthIdentityMissingDefaultProjectMessage = "Default project is required when using OAuth passthrough authentication."
+	forwardOAuthIdentityUnauthorizedMessage          = "401 Unauthorized: Usage of this data source requires you to be authenticated via Google OAuth. If you are signed in via Google, your session token may have expired — sign out and back in to refresh it."
+	forwardOAuthIdentityForbiddenMessage             = "403 Forbidden: Permission denied. Make sure the https://www.googleapis.com/auth/monitoring.read scope is configured in Grafana's Google OAuth settings, and that the signed-in user has the Monitoring Viewer role on the default project."
+	forwardOAuthIdentityAlertingNotSupportedMessage  = "alerting queries are not supported with the Forward OAuth Identity authentication type; use Google JWT File or GCE Default Service Account for data sources used by alerting rules"
 )
 
 func ProvideService(httpClientProvider *httpclient.Provider) *Service {
@@ -106,7 +106,7 @@ func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthReque
 	if dsInfo.oauthPassThru && defaultProject == "" {
 		return &backend.CheckHealthResult{
 			Status:  backend.HealthStatusError,
-			Message: oauthPassthroughMissingDefaultProjectMessage,
+			Message: forwardOAuthIdentityMissingDefaultProjectMessage,
 		}, nil
 	}
 
@@ -134,9 +134,9 @@ func (s *Service) CheckHealth(ctx context.Context, req *backend.CheckHealthReque
 		if dsInfo.oauthPassThru {
 			switch res.StatusCode {
 			case http.StatusUnauthorized:
-				message = oauthPassthroughUnauthorizedMessage
+				message = forwardOAuthIdentityUnauthorizedMessage
 			case http.StatusForbidden:
-				message = oauthPassthroughForbiddenMessage
+				message = forwardOAuthIdentityForbiddenMessage
 			}
 		}
 	}
@@ -226,7 +226,7 @@ func newInstanceSettings(httpClientProvider httpclient.Provider) datasource.Inst
 			return nil, err
 		}
 
-		if jsonData.AuthenticationType == oauthPassthroughAuthentication {
+		if jsonData.AuthenticationType == forwardOAuthIdentityAuthentication {
 			opts.ForwardHTTPHeaders = true
 		}
 
@@ -384,7 +384,7 @@ func (s *Service) QueryData(ctx context.Context, req *backend.QueryDataRequest) 
 	// Alert rule evaluations run without a user context, so fail fast with a clear
 	// message rather than letting the request reach GCM with no Authorization header.
 	if dsInfo.oauthPassThru && req.Headers[fromAlertHeaderName] == "true" {
-		return nil, backend.DownstreamError(errors.New(oauthPassthroughAlertingNotSupportedMessage))
+		return nil, backend.DownstreamError(errors.New(forwardOAuthIdentityAlertingNotSupportedMessage))
 	}
 
 	// There aren't any possible downstream errors here

--- a/pkg/tsdb/cloud-monitoring/cloudmonitoring_test.go
+++ b/pkg/tsdb/cloud-monitoring/cloudmonitoring_test.go
@@ -1283,3 +1283,63 @@ func TestCheckHealth(t *testing.T) {
 		assert.NotContains(t, res.Message, "Monitoring Viewer role")
 	})
 }
+
+func TestQueryData_oauthPassthrough(t *testing.T) {
+	t.Run("rejects alerting queries when oauthPassThru is set", func(t *testing.T) {
+		im := datasource.NewInstanceManager(func(_ context.Context, _ backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+			return &datasourceInfo{
+				authenticationType: oauthPassthroughAuthentication,
+				oauthPassThru:      true,
+				defaultProject:     "p1",
+			}, nil
+		})
+		service := &Service{im: im, logger: backend.NewLoggerWith("logger", "test")}
+
+		_, err := service.QueryData(context.Background(), &backend.QueryDataRequest{
+			PluginContext: backend.PluginContext{
+				DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{},
+			},
+			Headers: map[string]string{"FromAlert": "true"},
+			Queries: []backend.DataQuery{
+				{RefID: "A", QueryType: string(dataquery.QueryTypeTIMESERIESLIST), JSON: json.RawMessage(`{}`)},
+			},
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "alerting queries")
+		// The error must be flagged as a downstream/client error so error sources are
+		// attributed correctly in Grafana's plugin metrics.
+		assert.True(t, backend.IsDownstreamError(err))
+	})
+
+	t.Run("does not reject alerting queries when oauthPassThru is unset", func(t *testing.T) {
+		// JWT auth should pass straight through the alerting guard. The request will
+		// still fail later (no services configured), but the error must NOT mention
+		// alerting — that would indicate the guard misfired.
+		im := datasource.NewInstanceManager(func(_ context.Context, _ backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+			return &datasourceInfo{
+				authenticationType: jwtAuthentication,
+				oauthPassThru:      false,
+				defaultProject:     "p1",
+			}, nil
+		})
+		service := &Service{im: im, logger: backend.NewLoggerWith("logger", "test")}
+
+		defer func() {
+			// The query pipeline will panic on the nil http.Client; recover and assert
+			// that the panic happens AFTER the guard (i.e. the guard didn't fire).
+			_ = recover()
+		}()
+		_, err := service.QueryData(context.Background(), &backend.QueryDataRequest{
+			PluginContext: backend.PluginContext{
+				DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{},
+			},
+			Headers: map[string]string{"FromAlert": "true"},
+			Queries: []backend.DataQuery{
+				{RefID: "A", QueryType: string(dataquery.QueryTypeTIMESERIESLIST), JSON: json.RawMessage(`{}`)},
+			},
+		})
+		if err != nil {
+			assert.NotContains(t, err.Error(), "alerting queries")
+		}
+	})
+}

--- a/pkg/tsdb/cloud-monitoring/cloudmonitoring_test.go
+++ b/pkg/tsdb/cloud-monitoring/cloudmonitoring_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"reflect"
 	"strings"
@@ -45,6 +47,21 @@ func TestNewInstanceSettings(t *testing.T) {
 		assert.Equal(t, "test", dsInfoCasted.defaultProject)
 		assert.Equal(t, "test", dsInfoCasted.clientEmail)
 		assert.Equal(t, "test", dsInfoCasted.tokenUri)
+	})
+
+	t.Run("should parse oauthPassthrough authentication", func(t *testing.T) {
+		cli := httpclient.NewProvider()
+		f := newInstanceSettings(*cli)
+		dsInfo, err := f(context.Background(), backend.DataSourceInstanceSettings{
+			JSONData: json.RawMessage(`{"authenticationType": "oauthPassthrough", "oauthPassThru": true, "defaultProject": "p1"}`),
+		})
+		require.NoError(t, err)
+		dsInfoCasted := dsInfo.(*datasourceInfo)
+		assert.Equal(t, oauthPassthroughAuthentication, dsInfoCasted.authenticationType)
+		assert.True(t, dsInfoCasted.oauthPassThru)
+		assert.Equal(t, "p1", dsInfoCasted.defaultProject)
+		assert.NotNil(t, dsInfoCasted.services[cloudMonitor].client)
+		assert.NotNil(t, dsInfoCasted.services[resourceManager].client)
 	})
 }
 
@@ -1165,5 +1182,94 @@ func TestCheckHealth(t *testing.T) {
 			Status:  backend.HealthStatusError,
 			Message: "not found!",
 		}, res)
+	})
+
+	t.Run("oauthPassthrough without a default project returns an error", func(t *testing.T) {
+		im := datasource.NewInstanceManager(func(_ context.Context, s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+			return &datasourceInfo{
+				authenticationType: oauthPassthroughAuthentication,
+				oauthPassThru:      true,
+				defaultProject:     "",
+			}, nil
+		})
+		service := &Service{im: im}
+		res, err := service.CheckHealth(context.Background(), &backend.CheckHealthRequest{
+			PluginContext: backend.PluginContext{
+				DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{},
+			},
+		})
+		assert.Nil(t, err)
+		assert.Equal(t, backend.HealthStatusError, res.Status)
+		assert.Contains(t, res.Message, "Default project is required")
+	})
+
+	t.Run("oauthPassthrough forwards Authorization header to outgoing request", func(t *testing.T) {
+		var received string
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			received = r.Header.Get("Authorization")
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(ts.Close)
+
+		client := &http.Client{Transport: oauthPassthroughMiddleware().CreateMiddleware(httpclient.Options{}, http.DefaultTransport)}
+
+		im := datasource.NewInstanceManager(func(_ context.Context, s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+			return &datasourceInfo{
+				authenticationType: oauthPassthroughAuthentication,
+				oauthPassThru:      true,
+				defaultProject:     "p1",
+				services: map[string]datasourceService{
+					cloudMonitor: {url: ts.URL, client: client},
+				},
+			}, nil
+		})
+		service := &Service{im: im}
+		res, err := service.CheckHealth(context.Background(), &backend.CheckHealthRequest{
+			PluginContext: backend.PluginContext{
+				DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{},
+			},
+			Headers: map[string]string{"Authorization": "Bearer test-token-123"},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, backend.HealthStatusOk, res.Status)
+		assert.Equal(t, "Bearer test-token-123", received)
+	})
+}
+
+func TestOAuthPassthroughMiddleware(t *testing.T) {
+	t.Run("injects per-request Authorization from context", func(t *testing.T) {
+		var got string
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			got = r.Header.Get("Authorization")
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(ts.Close)
+
+		client := &http.Client{Transport: oauthPassthroughMiddleware().CreateMiddleware(httpclient.Options{}, http.DefaultTransport)}
+
+		req, err := http.NewRequestWithContext(withAuthHeader(context.Background(), "Bearer abc"), http.MethodGet, ts.URL, nil)
+		require.NoError(t, err)
+		res, err := client.Do(req)
+		require.NoError(t, err)
+		_ = res.Body.Close()
+		assert.Equal(t, "Bearer abc", got)
+	})
+
+	t.Run("does not set Authorization when ctx has no token", func(t *testing.T) {
+		var got string
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			got = r.Header.Get("Authorization")
+			w.WriteHeader(http.StatusOK)
+		}))
+		t.Cleanup(ts.Close)
+
+		client := &http.Client{Transport: oauthPassthroughMiddleware().CreateMiddleware(httpclient.Options{}, http.DefaultTransport)}
+
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, ts.URL, nil)
+		require.NoError(t, err)
+		res, err := client.Do(req)
+		require.NoError(t, err)
+		_ = res.Body.Close()
+		assert.Equal(t, "", got)
 	})
 }

--- a/pkg/tsdb/cloud-monitoring/cloudmonitoring_test.go
+++ b/pkg/tsdb/cloud-monitoring/cloudmonitoring_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"net/http"
-	"net/http/httptest"
 	"net/url"
 	"reflect"
 	"strings"
@@ -1203,73 +1201,4 @@ func TestCheckHealth(t *testing.T) {
 		assert.Contains(t, res.Message, "Default project is required")
 	})
 
-	t.Run("oauthPassthrough forwards Authorization header to outgoing request", func(t *testing.T) {
-		var received string
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			received = r.Header.Get("Authorization")
-			w.WriteHeader(http.StatusOK)
-		}))
-		t.Cleanup(ts.Close)
-
-		client := &http.Client{Transport: oauthPassthroughMiddleware().CreateMiddleware(httpclient.Options{}, http.DefaultTransport)}
-
-		im := datasource.NewInstanceManager(func(_ context.Context, s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
-			return &datasourceInfo{
-				authenticationType: oauthPassthroughAuthentication,
-				oauthPassThru:      true,
-				defaultProject:     "p1",
-				services: map[string]datasourceService{
-					cloudMonitor: {url: ts.URL, client: client},
-				},
-			}, nil
-		})
-		service := &Service{im: im}
-		res, err := service.CheckHealth(context.Background(), &backend.CheckHealthRequest{
-			PluginContext: backend.PluginContext{
-				DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{},
-			},
-			Headers: map[string]string{"Authorization": "Bearer test-token-123"},
-		})
-		require.NoError(t, err)
-		assert.Equal(t, backend.HealthStatusOk, res.Status)
-		assert.Equal(t, "Bearer test-token-123", received)
-	})
-}
-
-func TestOAuthPassthroughMiddleware(t *testing.T) {
-	t.Run("injects per-request Authorization from context", func(t *testing.T) {
-		var got string
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			got = r.Header.Get("Authorization")
-			w.WriteHeader(http.StatusOK)
-		}))
-		t.Cleanup(ts.Close)
-
-		client := &http.Client{Transport: oauthPassthroughMiddleware().CreateMiddleware(httpclient.Options{}, http.DefaultTransport)}
-
-		req, err := http.NewRequestWithContext(withAuthHeader(context.Background(), "Bearer abc"), http.MethodGet, ts.URL, nil)
-		require.NoError(t, err)
-		res, err := client.Do(req)
-		require.NoError(t, err)
-		_ = res.Body.Close()
-		assert.Equal(t, "Bearer abc", got)
-	})
-
-	t.Run("does not set Authorization when ctx has no token", func(t *testing.T) {
-		var got string
-		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			got = r.Header.Get("Authorization")
-			w.WriteHeader(http.StatusOK)
-		}))
-		t.Cleanup(ts.Close)
-
-		client := &http.Client{Transport: oauthPassthroughMiddleware().CreateMiddleware(httpclient.Options{}, http.DefaultTransport)}
-
-		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, ts.URL, nil)
-		require.NoError(t, err)
-		res, err := client.Do(req)
-		require.NoError(t, err)
-		_ = res.Body.Close()
-		assert.Equal(t, "", got)
-	})
 }

--- a/pkg/tsdb/cloud-monitoring/cloudmonitoring_test.go
+++ b/pkg/tsdb/cloud-monitoring/cloudmonitoring_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"reflect"
 	"strings"
@@ -1199,5 +1201,85 @@ func TestCheckHealth(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, backend.HealthStatusError, res.Status)
 		assert.Contains(t, res.Message, "Default project is required")
+	})
+
+	t.Run("oauthPassthrough surfaces friendlier message on 401 Unauthorized", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnauthorized)
+		}))
+		t.Cleanup(ts.Close)
+
+		im := datasource.NewInstanceManager(func(_ context.Context, _ backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+			return &datasourceInfo{
+				authenticationType: oauthPassthroughAuthentication,
+				oauthPassThru:      true,
+				defaultProject:     "p1",
+				services: map[string]datasourceService{
+					cloudMonitor: {url: ts.URL, client: http.DefaultClient},
+				},
+			}, nil
+		})
+		service := &Service{im: im}
+		res, err := service.CheckHealth(context.Background(), &backend.CheckHealthRequest{
+			PluginContext: backend.PluginContext{
+				DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, backend.HealthStatusError, res.Status)
+		assert.Contains(t, res.Message, "authenticated via Google OAuth")
+	})
+
+	t.Run("oauthPassthrough surfaces friendlier message on 403 Forbidden", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+		}))
+		t.Cleanup(ts.Close)
+
+		im := datasource.NewInstanceManager(func(_ context.Context, _ backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+			return &datasourceInfo{
+				authenticationType: oauthPassthroughAuthentication,
+				oauthPassThru:      true,
+				defaultProject:     "p1",
+				services: map[string]datasourceService{
+					cloudMonitor: {url: ts.URL, client: http.DefaultClient},
+				},
+			}, nil
+		})
+		service := &Service{im: im}
+		res, err := service.CheckHealth(context.Background(), &backend.CheckHealthRequest{
+			PluginContext: backend.PluginContext{
+				DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, backend.HealthStatusError, res.Status)
+		assert.Contains(t, res.Message, "Monitoring Viewer role")
+	})
+
+	t.Run("non-oauthPassthrough preserves the original response status on errors", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusForbidden)
+		}))
+		t.Cleanup(ts.Close)
+
+		im := datasource.NewInstanceManager(func(_ context.Context, _ backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
+			return &datasourceInfo{
+				authenticationType: jwtAuthentication,
+				defaultProject:     "p1",
+				services: map[string]datasourceService{
+					cloudMonitor: {url: ts.URL, client: http.DefaultClient},
+				},
+			}, nil
+		})
+		service := &Service{im: im}
+		res, err := service.CheckHealth(context.Background(), &backend.CheckHealthRequest{
+			PluginContext: backend.PluginContext{
+				DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, backend.HealthStatusError, res.Status)
+		assert.NotContains(t, res.Message, "Monitoring Viewer role")
 	})
 }

--- a/pkg/tsdb/cloud-monitoring/cloudmonitoring_test.go
+++ b/pkg/tsdb/cloud-monitoring/cloudmonitoring_test.go
@@ -49,15 +49,15 @@ func TestNewInstanceSettings(t *testing.T) {
 		assert.Equal(t, "test", dsInfoCasted.tokenUri)
 	})
 
-	t.Run("should parse oauthPassthrough authentication", func(t *testing.T) {
+	t.Run("should parse forwardOAuthIdentity authentication", func(t *testing.T) {
 		cli := httpclient.NewProvider()
 		f := newInstanceSettings(*cli)
 		dsInfo, err := f(context.Background(), backend.DataSourceInstanceSettings{
-			JSONData: json.RawMessage(`{"authenticationType": "oauthPassthrough", "oauthPassThru": true, "defaultProject": "p1"}`),
+			JSONData: json.RawMessage(`{"authenticationType": "forwardOAuthIdentity", "oauthPassThru": true, "defaultProject": "p1"}`),
 		})
 		require.NoError(t, err)
 		dsInfoCasted := dsInfo.(*datasourceInfo)
-		assert.Equal(t, oauthPassthroughAuthentication, dsInfoCasted.authenticationType)
+		assert.Equal(t, forwardOAuthIdentityAuthentication, dsInfoCasted.authenticationType)
 		assert.True(t, dsInfoCasted.oauthPassThru)
 		assert.Equal(t, "p1", dsInfoCasted.defaultProject)
 		assert.NotNil(t, dsInfoCasted.services[cloudMonitor].client)
@@ -1184,10 +1184,10 @@ func TestCheckHealth(t *testing.T) {
 		}, res)
 	})
 
-	t.Run("oauthPassthrough without a default project returns an error", func(t *testing.T) {
+	t.Run("forwardOAuthIdentity without a default project returns an error", func(t *testing.T) {
 		im := datasource.NewInstanceManager(func(_ context.Context, s backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
 			return &datasourceInfo{
-				authenticationType: oauthPassthroughAuthentication,
+				authenticationType: forwardOAuthIdentityAuthentication,
 				oauthPassThru:      true,
 				defaultProject:     "",
 			}, nil
@@ -1203,7 +1203,7 @@ func TestCheckHealth(t *testing.T) {
 		assert.Contains(t, res.Message, "Default project is required")
 	})
 
-	t.Run("oauthPassthrough surfaces friendlier message on 401 Unauthorized", func(t *testing.T) {
+	t.Run("forwardOAuthIdentity surfaces friendlier message on 401 Unauthorized", func(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusUnauthorized)
 		}))
@@ -1211,7 +1211,7 @@ func TestCheckHealth(t *testing.T) {
 
 		im := datasource.NewInstanceManager(func(_ context.Context, _ backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
 			return &datasourceInfo{
-				authenticationType: oauthPassthroughAuthentication,
+				authenticationType: forwardOAuthIdentityAuthentication,
 				oauthPassThru:      true,
 				defaultProject:     "p1",
 				services: map[string]datasourceService{
@@ -1230,7 +1230,7 @@ func TestCheckHealth(t *testing.T) {
 		assert.Contains(t, res.Message, "authenticated via Google OAuth")
 	})
 
-	t.Run("oauthPassthrough surfaces friendlier message on 403 Forbidden", func(t *testing.T) {
+	t.Run("forwardOAuthIdentity surfaces friendlier message on 403 Forbidden", func(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusForbidden)
 		}))
@@ -1238,7 +1238,7 @@ func TestCheckHealth(t *testing.T) {
 
 		im := datasource.NewInstanceManager(func(_ context.Context, _ backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
 			return &datasourceInfo{
-				authenticationType: oauthPassthroughAuthentication,
+				authenticationType: forwardOAuthIdentityAuthentication,
 				oauthPassThru:      true,
 				defaultProject:     "p1",
 				services: map[string]datasourceService{
@@ -1257,7 +1257,7 @@ func TestCheckHealth(t *testing.T) {
 		assert.Contains(t, res.Message, "Monitoring Viewer role")
 	})
 
-	t.Run("non-oauthPassthrough preserves the original response status on errors", func(t *testing.T) {
+	t.Run("non-forwardOAuthIdentity preserves the original response status on errors", func(t *testing.T) {
 		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 			w.WriteHeader(http.StatusForbidden)
 		}))
@@ -1284,11 +1284,11 @@ func TestCheckHealth(t *testing.T) {
 	})
 }
 
-func TestQueryData_oauthPassthrough(t *testing.T) {
+func TestQueryData_forwardOAuthIdentity(t *testing.T) {
 	t.Run("rejects alerting queries when oauthPassThru is set", func(t *testing.T) {
 		im := datasource.NewInstanceManager(func(_ context.Context, _ backend.DataSourceInstanceSettings) (instancemgmt.Instance, error) {
 			return &datasourceInfo{
-				authenticationType: oauthPassthroughAuthentication,
+				authenticationType: forwardOAuthIdentityAuthentication,
 				oauthPassThru:      true,
 				defaultProject:     "p1",
 			}, nil

--- a/pkg/tsdb/cloud-monitoring/cloudmonitoring_test.go
+++ b/pkg/tsdb/cloud-monitoring/cloudmonitoring_test.go
@@ -1200,5 +1200,4 @@ func TestCheckHealth(t *testing.T) {
 		assert.Equal(t, backend.HealthStatusError, res.Status)
 		assert.Contains(t, res.Message, "Default project is required")
 	})
-
 }

--- a/pkg/tsdb/cloud-monitoring/httpclient.go
+++ b/pkg/tsdb/cloud-monitoring/httpclient.go
@@ -8,10 +8,11 @@ import (
 )
 
 const (
-	cloudMonitor         = "cloudmonitoring"
-	resourceManager      = "cloudresourcemanager"
-	cloudMonitorScope    = "https://www.googleapis.com/auth/monitoring.read"
-	resourceManagerScope = "https://www.googleapis.com/auth/cloudplatformprojects.readonly"
+	cloudMonitor                           = "cloudmonitoring"
+	resourceManager                        = "cloudresourcemanager"
+	cloudMonitorScope                      = "https://www.googleapis.com/auth/monitoring.read"
+	resourceManagerScope                   = "https://www.googleapis.com/auth/cloudplatformprojects.readonly"
+	forwardOAuthIdentityRequestHTTPHeaders = "forward-oauth-identity-request-http-headers"
 )
 
 type routeInfo struct {
@@ -34,6 +35,10 @@ var routes = map[string]routeInfo{
 }
 
 func getMiddleware(model *datasourceInfo, routePath string) (httpclient.Middleware, error) {
+	if model.authenticationType == oauthPassthroughAuthentication {
+		return oauthPassthroughMiddleware(), nil
+	}
+
 	providerConfig := tokenprovider.Config{
 		RoutePath:         routePath,
 		RouteMethod:       routes[routePath].method,
@@ -66,6 +71,17 @@ func getMiddleware(model *datasourceInfo, routePath string) (httpclient.Middlewa
 	}
 
 	return tokenprovider.AuthMiddleware(provider), nil
+}
+
+func oauthPassthroughMiddleware() httpclient.Middleware {
+	return httpclient.NamedMiddlewareFunc(forwardOAuthIdentityRequestHTTPHeaders, func(_ httpclient.Options, next http.RoundTripper) http.RoundTripper {
+		return httpclient.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			if h := authHeaderFromContext(req.Context()); h != "" {
+				req.Header.Set("Authorization", h)
+			}
+			return next.RoundTrip(req)
+		})
+	})
 }
 
 func buildURL(route string, universeDomain string) string {

--- a/pkg/tsdb/cloud-monitoring/httpclient.go
+++ b/pkg/tsdb/cloud-monitoring/httpclient.go
@@ -34,7 +34,7 @@ var routes = map[string]routeInfo{
 }
 
 func getMiddleware(model *datasourceInfo, routePath string) (httpclient.Middleware, error) {
-	if model.authenticationType == oauthPassthroughAuthentication {
+	if model.authenticationType == forwardOAuthIdentityAuthentication {
 		return nil, nil
 	}
 

--- a/pkg/tsdb/cloud-monitoring/httpclient.go
+++ b/pkg/tsdb/cloud-monitoring/httpclient.go
@@ -8,11 +8,10 @@ import (
 )
 
 const (
-	cloudMonitor                           = "cloudmonitoring"
-	resourceManager                        = "cloudresourcemanager"
-	cloudMonitorScope                      = "https://www.googleapis.com/auth/monitoring.read"
-	resourceManagerScope                   = "https://www.googleapis.com/auth/cloudplatformprojects.readonly"
-	forwardOAuthIdentityRequestHTTPHeaders = "forward-oauth-identity-request-http-headers"
+	cloudMonitor         = "cloudmonitoring"
+	resourceManager      = "cloudresourcemanager"
+	cloudMonitorScope    = "https://www.googleapis.com/auth/monitoring.read"
+	resourceManagerScope = "https://www.googleapis.com/auth/cloudplatformprojects.readonly"
 )
 
 type routeInfo struct {
@@ -36,7 +35,7 @@ var routes = map[string]routeInfo{
 
 func getMiddleware(model *datasourceInfo, routePath string) (httpclient.Middleware, error) {
 	if model.authenticationType == oauthPassthroughAuthentication {
-		return oauthPassthroughMiddleware(), nil
+		return nil, nil
 	}
 
 	providerConfig := tokenprovider.Config{
@@ -73,17 +72,6 @@ func getMiddleware(model *datasourceInfo, routePath string) (httpclient.Middlewa
 	return tokenprovider.AuthMiddleware(provider), nil
 }
 
-func oauthPassthroughMiddleware() httpclient.Middleware {
-	return httpclient.NamedMiddlewareFunc(forwardOAuthIdentityRequestHTTPHeaders, func(_ httpclient.Options, next http.RoundTripper) http.RoundTripper {
-		return httpclient.RoundTripperFunc(func(req *http.Request) (*http.Response, error) {
-			if h := authHeaderFromContext(req.Context()); h != "" {
-				req.Header.Set("Authorization", h)
-			}
-			return next.RoundTrip(req)
-		})
-	})
-}
-
 func buildURL(route string, universeDomain string) string {
 	if universeDomain == "" {
 		universeDomain = "googleapis.com"
@@ -97,6 +85,8 @@ func newHTTPClient(model *datasourceInfo, opts httpclient.Options, clientProvide
 		return nil, err
 	}
 
-	opts.Middlewares = append(opts.Middlewares, m)
+	if m != nil {
+		opts.Middlewares = append(opts.Middlewares, m)
+	}
 	return clientProvider.New(opts)
 }

--- a/pkg/tsdb/cloud-monitoring/resource_handler.go
+++ b/pkg/tsdb/cloud-monitoring/resource_handler.go
@@ -366,10 +366,6 @@ func (s *Service) setRequestVariables(req *http.Request, subDataSource string) (
 	req.URL.Host = serviceURL.Host
 	req.URL.Scheme = serviceURL.Scheme
 
-	if auth := req.Header.Get("Authorization"); auth != "" {
-		*req = *req.WithContext(withAuthHeader(req.Context(), auth))
-	}
-
 	return dsInfo.services[subDataSource].client, 0, nil
 }
 

--- a/pkg/tsdb/cloud-monitoring/resource_handler.go
+++ b/pkg/tsdb/cloud-monitoring/resource_handler.go
@@ -366,6 +366,10 @@ func (s *Service) setRequestVariables(req *http.Request, subDataSource string) (
 	req.URL.Host = serviceURL.Host
 	req.URL.Scheme = serviceURL.Scheme
 
+	if auth := req.Header.Get("Authorization"); auth != "" {
+		*req = *req.WithContext(withAuthHeader(req.Context(), auth))
+	}
+
 	return dsInfo.services[subDataSource].client, 0, nil
 }
 


### PR DESCRIPTION

**What is this feature?**

Adds Forward OAuth Identity as a third authentication method on the Google Cloud Monitoring data source, alongside the existing Google JWT File and GCE Default Service Account options.
When enabled on a data source, every outgoing Cloud Monitoring API call is made using the signed-in Grafana user's own Google OAuth access token (forwarded as Authorization: Bearer <user-token>), rather than a shared service account credential. This PR covers the backend changes only — [frontend](https://github.com/grafana/grafana/pull/124618) (radio button, default-project field) and docs ship in separate PRs.

**Why do we need this feature?**

With JWT or GCE authentication, every Grafana user queries Cloud Monitoring as the same service account. That account has whatever IAM access it was granted, and there's no way to restrict what an individual viewer sees beyond what's enforced at the dashboard level.

With Forward OAuth Identity, queries run as the viewing user. A user without roles/monitoring.viewer on a project sees no data from that project, even when the dashboard's data source is shared. This:

Aligns Grafana queries with the GCP IAM model rather than re-implementing access control inside Grafana.
Makes per-user audit trails in Cloud Audit Logs meaningful — each query is attributed to the actual user, not to a shared service account.
Mirrors the pattern already shipped by the sibling Google plugins: [cloud-logging#145](https://github.com/GoogleCloudPlatform/cloud-logging-data-source-plugin/pull/145), [google-bigquery-datasource#346](https://github.com/grafana/google-bigquery-datasource/pull/346).

**Who is this feature for?**

Grafana operators whose users already sign in to Grafana via Google OAuth and who want Cloud Monitoring dashboards to enforce per-user data scoping using existing GCP IAM. 

**Which issue(s) does this PR fix?**: N/A

Fixes # 


Please check that:
- [x] It works as expected from a user's perspective.
- [ ] ~If this is a pre-GA feature, it is behind a feature toggle.~
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
