### PR TITLE
Google Cloud Monitoring: Add Forward OAuth Identity authentication (docs)

### DIFF
--- a/docs/sources/datasources/google-cloud-monitoring/configure/index.md
+++ b/docs/sources/datasources/google-cloud-monitoring/configure/index.md
@@ -92,7 +92,7 @@ Configure how Grafana authenticates with Google Cloud.
 
 | Setting                 | Description                                                                                                                                                                                                                                                                 |
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Authentication type** | Select the authentication method. Choose **Google JWT File** to use a service account key file, **GCE Default Service Account** if Grafana is running on a GCE virtual machine, or **Forward OAuth Identity** to authenticate as the Google-signed-in Grafana user instead. |
+| **Authentication type** | Select the authentication method. Choose **Google JWT File** to use a service account key file, **GCE Default Service Account** if Grafana is running on a GCE virtual machine, or **Forward OAuth Identity** to authenticate as the Google-signed-in Grafana user. |
 
 ### JWT Key Details
 

--- a/docs/sources/datasources/google-cloud-monitoring/configure/index.md
+++ b/docs/sources/datasources/google-cloud-monitoring/configure/index.md
@@ -90,8 +90,8 @@ The following are configuration options for the Google Cloud Monitoring data sou
 
 Configure how Grafana authenticates with Google Cloud.
 
-| Setting                 | Description                                                                                                                                                                                                                                                                  |
-| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Setting                 | Description                                                                                                                                                                                                                                                                 |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Authentication type** | Select the authentication method. Choose **Google JWT File** to use a service account key file, **GCE Default Service Account** if Grafana is running on a GCE virtual machine, or **Forward OAuth Identity** to authenticate as the Google-signed-in Grafana user instead. |
 
 ### JWT Key Details
@@ -106,9 +106,9 @@ These settings appear when you select **Google JWT File** as the authentication 
 
 These settings appear when you select **Forward OAuth Identity** as the authentication type.
 
-| Setting             | Description                                                                                                                                                                                                                                                                                                                  |
-| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Default project** | Enter the GCP project ID to query. This field is required because the user's OAuth token doesn't carry a project context. The signed-in user must have the **Monitoring Viewer** role on this project.                                                                                                                       |
+| Setting             | Description                                                                                                                                                                                            |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Default project** | Enter the GCP project ID to query. This field is required because the user's OAuth token doesn't carry a project context. The signed-in user must have the **Monitoring Viewer** role on this project. |
 
 The Grafana Google authentication must request the following scopes so the forwarded token can read Cloud Monitoring data. Set the full list under `[auth.google]` in `grafana.ini` or `custom.ini`, or under **Scopes** in the SSO Settings UI:
 

--- a/docs/sources/datasources/google-cloud-monitoring/configure/index.md
+++ b/docs/sources/datasources/google-cloud-monitoring/configure/index.md
@@ -90,9 +90,9 @@ The following are configuration options for the Google Cloud Monitoring data sou
 
 Configure how Grafana authenticates with Google Cloud.
 
-| Setting                 | Description                                                                                                                                                                        |
-| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Authentication type** | Select the authentication method. Choose **Google JWT File** to use a service account key file, or **GCE Default Service Account** if Grafana is running on a GCE virtual machine. |
+| Setting                 | Description                                                                                                                                                                                                                                                                  |
+| ----------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Authentication type** | Select the authentication method. Choose **Google JWT File** to use a service account key file, **GCE Default Service Account** if Grafana is running on a GCE virtual machine, or **Forward OAuth Identity** to authenticate as the Google-signed-in Grafana user instead. |
 
 ### JWT Key Details
 
@@ -101,6 +101,26 @@ These settings appear when you select **Google JWT File** as the authentication 
 | Setting       | Description                                                                                                                                                                               |
 | ------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **JWT token** | Upload or paste your Google JWT token. You can drag and drop a `.json` key file, click **Click to browse files** to upload, or use **Paste JWT Token** or **Fill In JWT Token manually**. |
+
+### Forward OAuth Identity
+
+These settings appear when you select **Forward OAuth Identity** as the authentication type.
+
+| Setting             | Description                                                                                                                                                                                                                                                                                                                  |
+| ------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Default project** | Enter the GCP project ID to query. This field is required because the user's OAuth token doesn't carry a project context. The signed-in user must have the **Monitoring Viewer** role on this project.                                                                                                                       |
+
+The Grafana Google authentication must request the following scopes so the forwarded token can read Cloud Monitoring data. Set the full list under `[auth.google]` in `grafana.ini` or `custom.ini`, or under **Scopes** in the SSO Settings UI:
+
+```ini
+[auth.google]
+scopes = openid email profile https://www.googleapis.com/auth/monitoring.read
+```
+
+- `openid`, `email`, `profile`: Grafana's default sign-in scopes. Required for the user to log in.
+- `https://www.googleapis.com/auth/monitoring.read`: required for the forwarded token to call the Cloud Monitoring API.
+
+After you change the scopes, each user must sign out, revoke the existing grant at [https://myaccount.google.com/permissions](https://myaccount.google.com/permissions), and sign in again. Google reuses the previous consent until the grant is revoked, so existing sessions continue to hold tokens issued under the old scope set.
 
 ### Service account impersonation
 

--- a/docs/sources/datasources/google-cloud-monitoring/configure/index.md
+++ b/docs/sources/datasources/google-cloud-monitoring/configure/index.md
@@ -90,8 +90,8 @@ The following are configuration options for the Google Cloud Monitoring data sou
 
 Configure how Grafana authenticates with Google Cloud.
 
-| Setting                 | Description                                                                                                                                                                                                                                                                 |
-| ----------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Setting                 | Description                                                                                                                                                                                                                                                         |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | **Authentication type** | Select the authentication method. Choose **Google JWT File** to use a service account key file, **GCE Default Service Account** if Grafana is running on a GCE virtual machine, or **Forward OAuth Identity** to authenticate as the Google-signed-in Grafana user. |
 
 ### JWT Key Details

--- a/docs/sources/datasources/google-cloud-monitoring/configure/index.md
+++ b/docs/sources/datasources/google-cloud-monitoring/configure/index.md
@@ -117,7 +117,7 @@ The Grafana Google authentication must request the following scopes so the forwa
 scopes = openid email profile https://www.googleapis.com/auth/monitoring.read
 ```
 
-- `openid`, `email`, `profile`: Grafana's default sign-in scopes. Required for the user to log in.
+- `openid`, `email`, `profile`: the default Grafana sign-in scopes. Required for the user to log in.
 - `https://www.googleapis.com/auth/monitoring.read`: required for the forwarded token to call the Cloud Monitoring API.
 
 After you change the scopes, each user must sign out, revoke the existing grant at [https://myaccount.google.com/permissions](https://myaccount.google.com/permissions), and sign in again. Google reuses the previous consent until the grant is revoked, so existing sessions continue to hold tokens issued under the old scope set.

--- a/docs/sources/datasources/google-cloud-monitoring/google-authentication/index.md
+++ b/docs/sources/datasources/google-cloud-monitoring/google-authentication/index.md
@@ -11,6 +11,7 @@ keywords:
   - service account
   - jwt
   - gce
+  - oauth
 labels:
   products:
     - cloud
@@ -43,6 +44,7 @@ The Google Cloud Monitoring data source supports the following authentication me
 | --------------------------------- | --------------------------------------------------------------------------------------------------- |
 | **Google JWT File**               | Use when Grafana runs outside of GCP, or when you need explicit control over credentials.           |
 | **GCE Default Service Account**   | Use when Grafana runs on a Google Compute Engine VM with a configured service account.              |
+| **Forward OAuth Identity**        | Use when you sign in to Grafana with Google and want each query to run as the signed-in user.       |
 | **Service Account Impersonation** | Use when you need Grafana to act as a different service account than the one it authenticates with. |
 
 ## Use a Google service account key file
@@ -118,6 +120,44 @@ Before using this method, ensure the following:
 1. Click **Save & test** to verify the connection.
 
 For more information about GCE service accounts, refer to the [Google documentation on service accounts for instances](https://cloud.google.com/compute/docs/access/create-enable-service-accounts-for-instances).
+
+## Use Forward OAuth Identity
+
+Use this method when your Grafana instance authenticates users with Google OAuth and you want each query to run as the signed-in user instead of as a shared service account. This enables per-user access control: a viewer who lacks Cloud Monitoring permissions on a project sees no data from that project, even when the dashboard's data source is shared.
+
+Grafana forwards the user's existing Google OAuth access token as the bearer token on outgoing Cloud Monitoring API requests. No service account key is stored on the server.
+
+### Prerequisites for Forward OAuth Identity
+
+Before using this method, ensure the following:
+
+- Your Grafana instance is configured to sign users in with [Google authentication](https://grafana.com/docs/grafana/latest/setup-grafana/configure-security/configure-authentication/google/).
+- The Google OAuth client requests the `https://www.googleapis.com/auth/monitoring.read` scope on top of the default `openid email profile` scopes. Without this scope, the user's token is rejected by the Cloud Monitoring API with a `403` response.
+- Each user who needs to query the data source has the **Monitoring Viewer** role (`roles/monitoring.viewer`) on the target GCP project.
+
+### Configure the Google OAuth scope
+
+Add the Cloud Monitoring read scope to the Grafana Google authentication configuration. In your `grafana.ini` or `custom.ini`:
+
+```ini
+[auth.google]
+scopes = openid email profile https://www.googleapis.com/auth/monitoring.read
+```
+
+If you configure Google authentication through the Grafana SSO settings UI, add the same scope value to the **Scopes** field.
+
+After you change the scopes, existing user sessions still hold tokens issued under the old scope set. Each affected user must sign out, revoke the existing grant at [https://myaccount.google.com/permissions](https://myaccount.google.com/permissions), and sign in again to consent to the new scope. Otherwise, queries continue to fail with `403`.
+
+### Configure the data source
+
+1. In Grafana, navigate to the Google Cloud Monitoring data source configuration page.
+1. Under **Authentication type**, select **Forward OAuth Identity**.
+1. In **Default project**, enter the GCP project ID to query. This field is required because the user's OAuth token doesn't carry a project context.
+1. Click **Save & test** to verify the connection.
+
+{{< admonition type="note" >}}
+Service account impersonation isn't compatible with Forward OAuth Identity. The data source authenticates as the signed-in user, so there's no service account to impersonate from.
+{{< /admonition >}}
 
 ## Configure service account impersonation
 

--- a/docs/sources/datasources/google-cloud-monitoring/google-authentication/index.md
+++ b/docs/sources/datasources/google-cloud-monitoring/google-authentication/index.md
@@ -137,7 +137,7 @@ Before using this method, ensure the following:
 
 ### Configure the Google OAuth scope
 
-Add the Cloud Monitoring read scope to the Grafana Google authentication configuration. In your `grafana.ini` or `custom.ini`:
+Add the Cloud Monitoring read scope to your Google authentication configuration in `grafana.ini` or `custom.ini`:
 
 ```ini
 [auth.google]

--- a/docs/sources/datasources/google-cloud-monitoring/google-authentication/index.md
+++ b/docs/sources/datasources/google-cloud-monitoring/google-authentication/index.md
@@ -156,7 +156,7 @@ After you change the scopes, existing user sessions still hold tokens issued und
 1. Click **Save & test** to verify the connection.
 
 {{< admonition type="note" >}}
-Service account impersonation isn't compatible with Forward OAuth Identity. The data source authenticates as the signed-in user, so there's no service account to impersonate from.
+Service account impersonation isn't compatible with Forward OAuth Identity. The data source authenticates as the signed-in user, so there's no service account to impersonate.
 {{< /admonition >}}
 
 ## Configure service account impersonation

--- a/docs/sources/datasources/google-cloud-monitoring/troubleshooting/index.md
+++ b/docs/sources/datasources/google-cloud-monitoring/troubleshooting/index.md
@@ -90,6 +90,21 @@ These errors occur when GCP credentials are invalid, missing, or don't have the 
 1. Ensure the target service account has the **Monitoring Viewer** role.
 1. Verify both service accounts are in projects that have the required APIs enabled.
 
+### Forward OAuth Identity returns 403
+
+**Symptoms:**
+
+- Save & Test fails with `403 Forbidden` when using Forward OAuth Identity.
+- Queries succeed for some users but not others.
+
+**Solutions:**
+
+1. Confirm you're signed in to Grafana with Google, not as the local `admin` user. The Forward OAuth Identity method only forwards a token if the current session has one.
+1. Verify the Grafana Google authentication includes the `https://www.googleapis.com/auth/monitoring.read` scope. Refer to [Configure the Google OAuth scope](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/google-cloud-monitoring/google-authentication/#configure-the-google-oauth-scope).
+1. After you add the scope, sign out of Grafana, revoke the existing grant at [https://myaccount.google.com/permissions](https://myaccount.google.com/permissions), and sign back in. Google reuses the previous consent and doesn't reissue tokens with new scopes until the grant is revoked.
+1. Verify the signed-in user has the **Monitoring Viewer** role (`roles/monitoring.viewer`) on the project set in **Default project**.
+1. Check the **Default project** field is populated. The user's OAuth token doesn't carry a project context, so the data source can't fall back to a project from the credentials.
+
 ## Connection errors
 
 These errors occur when Grafana cannot reach Google Cloud Monitoring endpoints.


### PR DESCRIPTION
Related https://github.com/grafana/grafana/pull/124617 https://github.com/grafana/grafana/pull/124618

**What is this feature?**

Docs update for GCM Google OAuth Passthrough

**Why do we need this feature?**

Updating docs for the feautre

**Who is this feature for?**

Google Cloud Monitoring users for choosing Google OAuth authentication method


**Which issue(s) does this PR fix?**: N/A
