### PR TITLE
CI: increase SQLite integration test timeout from 8m to 12m

### DIFF
--- a/.github/workflows/pr-test-integration.yml
+++ b/.github/workflows/pr-test-integration.yml
@@ -82,7 +82,7 @@ jobs:
         run: |
           set -euo pipefail
           readarray -t PACKAGES <<< "$(./scripts/ci/backend-tests/pkgs-with-tests-named.sh -b TestIntegration | ./scripts/ci/backend-tests/shard.sh -N "$SHARD" -d -)"
-          go test -timeout=8m -run '^TestIntegration' "${PACKAGES[@]}"
+          go test -timeout=12m -run '^TestIntegration' "${PACKAGES[@]}"
 
   mysql:
     # Run this workflow only for PRs from forks
@@ -177,7 +177,7 @@ jobs:
           echo "Precompiling, no tests will be run"
           CGO_ENABLED=0 go test -run='^$' "${PACKAGES[@]}"
           echo "Running tests now"
-          CGO_ENABLED=0 go test -p=1 -timeout=8m -run '^TestIntegration' "${PACKAGES[@]}"
+          CGO_ENABLED=0 go test -p=1 -timeout=12m -run '^TestIntegration' "${PACKAGES[@]}"
       - name: Cleanup Postgres
         if: always()
         run: |
@@ -227,7 +227,7 @@ jobs:
         run: |
           set -euo pipefail
           readarray -t PACKAGES <<< "$(./scripts/ci/backend-tests/pkgs-with-tests-named.sh -b TestIntegration | ./scripts/ci/backend-tests/shard.sh -N "$SHARD" -d -)"
-          go test -tags=enterprise -timeout=8m -run '^TestIntegration' "${PACKAGES[@]}"
+          go test -tags=enterprise -timeout=12m -run '^TestIntegration' "${PACKAGES[@]}"
 
   mysql-enterprise:
     # Run this workflow for non-PR events (like pushes to `main` or `release-*`) OR for internal PRs (PRs not from forks)
@@ -346,7 +346,7 @@ jobs:
           echo "Precompiling, no tests will be run"
           CGO_ENABLED=0 go test -tags=enterprise -run='^$' "${PACKAGES[@]}"
           echo "Running tests now"
-          CGO_ENABLED=0 go test -p=1 -tags=enterprise -timeout=8m -run '^TestIntegration' "${PACKAGES[@]}"
+          CGO_ENABLED=0 go test -p=1 -tags=enterprise -timeout=12m -run '^TestIntegration' "${PACKAGES[@]}"
       - name: Cleanup Postgres
         if: always()
         run: |


### PR DESCRIPTION
## Summary

- SQLite integration test shards have been failing intermittently because `pkg/tests/api/alerting` (65+ sequential tests) exceeds the 8-minute budget on slower CI runners
- MySQL and Postgres already use `12m`; this aligns SQLite to the same limit
- Root cause analysis across 30 failed main-branch runs showed `pkg/tests/api/alerting` timing out on SQLite exclusively, with `TestIntegrationAlertRuleCRUD` (1291-line test) and `TestIntegrationRulePause` consistently appearing at timeout

## Test plan

- [ ] Verify the `sqlite` and `sqlite-enterprise` CI jobs no longer time out on main after merge
- [ ] Confirm no new failures introduced (MySQL/Postgres behaviour unchanged)