### PR TITLE
Alerting: Add feature flag for notifications api migration

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1686,4 +1686,9 @@ export interface FeatureToggles {
   * @default false
   */
   ['alerting.rulesAPIV2']?: boolean;
+  /**
+  * Switch the Grafana Alerting UI from notifications.alerting.grafana.app/v0alpha1 to v1beta1
+  * @default false
+  */
+  ['alerting.notificationsAPIV1Beta1']?: boolean;
 }

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -3072,6 +3072,14 @@ var (
 			Generate:     Generate{LegacyGo: true, LegacyFrontend: true},
 		},
 		{
+			Name:        "alerting.notificationsAPIV1Beta1",
+			Description: "Switch the Grafana Alerting UI from notifications.alerting.grafana.app/v0alpha1 to v1beta1",
+			Stage:       FeatureStageExperimental,
+			Owner:       grafanaAlertingSquad,
+			Expression:  "false",
+			Generate:    Generate{LegacyFrontend: true},
+		},
+		{
 			Name:        "assistant.frontend.tools.dashboardTemplates",
 			Description: "Enables the template dashboard assistant",
 			Stage:       FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -358,6 +358,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-04-23,datasources.apiserver.useNewAPIsForDatasourceResources,experimental,@grafana/grafana-datasources-core-services,false,false,true
 2026-04-17,reporting.anyPageReporting,experimental,@grafana/sharing-squad,false,false,false
 2026-04-14,alerting.rulesAPIV2,experimental,@grafana/alerting-squad,false,false,false
+2026-05-11,alerting.notificationsAPIV1Beta1,experimental,@grafana/alerting-squad,false,false,true
 2026-04-23,assistant.frontend.tools.dashboardTemplates,experimental,@grafana/sharing-squad,false,false,true
 2026-04-27,grafana.correlationsSkipLegacy,experimental,@grafana/datapro,false,false,false
 2026-04-28,grafana.meticulousAIRecorder,experimental,@grafana/dataviz-squad,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -145,6 +145,20 @@
     },
     {
       "metadata": {
+        "name": "alerting.notificationsAPIV1Beta1",
+        "resourceVersion": "1778531950507",
+        "creationTimestamp": "2026-05-11T20:39:10Z"
+      },
+      "spec": {
+        "description": "Switch the Grafana Alerting UI from notifications.alerting.grafana.app/v0alpha1 to v1beta1",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad",
+        "frontend": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "alerting.rulesAPIV2",
         "resourceVersion": "1776193652999",
         "creationTimestamp": "2026-04-14T19:07:32Z"
@@ -631,6 +645,36 @@
         "stage": "experimental",
         "codeowner": "@grafana/alerting-squad",
         "hideFromDocs": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertingNotificationsApiV1Beta1",
+        "resourceVersion": "1778531729509",
+        "creationTimestamp": "2026-05-11T20:35:29Z",
+        "deletionTimestamp": "2026-05-11T20:39:10Z"
+      },
+      "spec": {
+        "description": "Switch the Grafana Alerting UI from notifications.alerting.grafana.app/v0alpha1 to v1beta1",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad",
+        "frontend": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
+        "name": "alertingNotificationsApiV1beta1",
+        "resourceVersion": "1778531705784",
+        "creationTimestamp": "2026-05-11T20:35:05Z",
+        "deletionTimestamp": "2026-05-11T20:35:29Z"
+      },
+      "spec": {
+        "description": "Switch the Grafana Alerting UI from notifications.alerting.grafana.app/v0alpha1 to v1beta1",
+        "stage": "experimental",
+        "codeowner": "@grafana/alerting-squad",
+        "frontend": true,
         "expression": "false"
       }
     },


### PR DESCRIPTION
**Changes**

This PR adds a feature flag `alerting.notificationsAPIV1Beta1` to be used when migrating the api calls on the frontend in a future PR