### PR TITLE
Alerting: split TestIntegrationAlertRuleCRUD into validation and CRUD tests

### DIFF
--- a/pkg/tests/api/alerting/api_ruler_test.go
+++ b/pkg/tests/api/alerting/api_ruler_test.go
@@ -2890,7 +2890,7 @@ func TestIntegrationDeleteFolderWithRules(t *testing.T) {
 	// TODO(@leonorfmartins): write tests for uni store when we are able to support it
 }
 
-func TestIntegrationAlertRuleCRUD(t *testing.T) {
+func TestIntegrationAlertRuleCRUD_Validation(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	// Setup Grafana and its Database
@@ -3168,6 +3168,38 @@ func TestIntegrationAlertRuleCRUD(t *testing.T) {
 			})
 		}
 	}
+}
+
+func TestIntegrationAlertRuleCRUD(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	// Setup Grafana and its Database
+
+	testinfra.SQLiteIntegrationTest(t)
+
+	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{
+		DisableLegacyAlerting: true,
+		EnableUnifiedAlerting: true,
+		EnableQuota:           true,
+		DisableAnonymous:      true,
+		AppModeProduction:     true,
+	})
+
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
+
+	createUser(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
+		DefaultOrgRole: string(org.RoleEditor),
+		Password:       "password",
+		Login:          "grafana",
+	})
+
+	apiClient := newAlertingApiClient(grafanaListedAddr, "grafana", "password")
+
+	// Create the namespace we'll save our alerts to.
+	apiClient.CreateFolder(t, "default", "default")
+
+	interval, err := model.ParseDuration("1m")
+	require.NoError(t, err)
 
 	var ruleUID string
 	var expectedGetNamespaceResponseBody string


### PR DESCRIPTION
## Summary

- Extracts the input-validation block (7 invalid-rule scenarios) from the 1291-line `TestIntegrationAlertRuleCRUD` into a new independent `TestIntegrationAlertRuleCRUD_Validation` function with its own Grafana instance
- `TestIntegrationAlertRuleCRUD` shrinks from 1291 → 1043 lines
- The new validation test is self-contained and clearly named

## Motivation

`pkg/tests/api/alerting` runs all 65+ integration tests sequentially in a single binary with an 8-minute SQLite timeout. `TestIntegrationAlertRuleCRUD` was consuming most of the time budget near the end of execution, causing `TestIntegrationRulePause` to start with only seconds remaining and panic with `test timed out after 8m0s`. This was identified via analysis of 30 failed CI runs on main.

Related: #124624 (raise SQLite timeout from 8m → 12m as a parallel mitigation)

## Test plan

- [ ] `go build ./pkg/tests/api/alerting/...` passes (verified locally)
- [ ] Both `TestIntegrationAlertRuleCRUD_Validation` and `TestIntegrationAlertRuleCRUD` appear in CI run output
- [ ] SQLite shard 14 no longer times out on main after merge