### PR TITLE
Docs: MySQL quarterly docs update

### DIFF
--- a/docs/sources/datasources/mysql/_index.md
+++ b/docs/sources/datasources/mysql/_index.md
@@ -16,6 +16,7 @@ labels:
 menuTitle: MySQL
 title: MySQL data source
 weight: 1000
+review_date: 2026-05-11
 ---
 
 # MySQL data source

--- a/docs/sources/datasources/mysql/_index.md
+++ b/docs/sources/datasources/mysql/_index.md
@@ -26,7 +26,7 @@ You can query and visualize data from MySQL-compatible databases like [MariaDB](
 
 Use this data source to create dashboards, explore SQL data, and monitor MySQL-based workloads in real time.
 
-Watch this video to learn more about using the Grafana MySQL data source plugin: {{< youtube id="p_RDHfHS-P8">}}
+Watch the following video to learn more about using the Grafana MySQL data source plugin: {{< youtube id="p_RDHfHS-P8">}}
 
 {{< docs/play title="MySQL Overview" url="https://play.grafana.org/d/edyh1ib7db6rkb/mysql-overview" >}}
 

--- a/docs/sources/datasources/mysql/alerting/index.md
+++ b/docs/sources/datasources/mysql/alerting/index.md
@@ -13,6 +13,7 @@ labels:
 menuTitle: Alerting
 title: MySQL alerting
 weight: 350
+review_date: 2026-05-11
 ---
 
 # MySQL alerting

--- a/docs/sources/datasources/mysql/annotations/index.md
+++ b/docs/sources/datasources/mysql/annotations/index.md
@@ -13,6 +13,7 @@ labels:
 menuTitle: Annotations
 title: MySQL annotations
 weight: 340
+review_date: 2026-05-11
 ---
 
 # MySQL annotations

--- a/docs/sources/datasources/mysql/configure/_index.md
+++ b/docs/sources/datasources/mysql/configure/_index.md
@@ -15,6 +15,7 @@ labels:
 menuTitle: Configure
 title: Configure the MySQL data source
 weight: 10
+review_date: 2026-05-11
 ---
 
 # Configure the MySQL data source
@@ -110,6 +111,14 @@ The following are additional MySQL settings.
 **Private data source connect** - _Only for Grafana Cloud users._ Private data source connect, or PDC, allows you to establish a private, secured connection between a Grafana Cloud instance, or stack, and data sources secured within a private network. Click the drop-down to locate the URL for PDC. For more information regarding Grafana PDC refer to [Private data source connect (PDC)](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/).
 
 Click **Manage private data source connect** to be taken to your PDC connection page, where you’ll find your PDC configuration details.
+
+**Secure SOCKS proxy:**
+
+{{< admonition type="note" >}}
+This section is only visible when the Grafana server has the secure SOCKS proxy feature enabled.
+{{< /admonition >}}
+
+- **Enabled** - Toggle to route requests to the MySQL instance through a secure SOCKS proxy.
 
 Once you have added your MySQL connection settings, click **Save & test** to test and save the data source connection.
 

--- a/docs/sources/datasources/mysql/configure/_index.md
+++ b/docs/sources/datasources/mysql/configure/_index.md
@@ -26,7 +26,7 @@ This document provides instructions for configuring the MySQL data source and ex
 
 Before configuring the MySQL data source, ensure you have the following:
 
-- **Grafana permissions:** You must have the `Organization administrator` role to configure data sources. Organization administrators can also [configure the data source via YAML](#provision-the-data-source) with the Grafana provisioning system.
+- **Grafana permissions:** You must have the Organization administrator role to configure data sources. Organization administrators can also [configure the data source via YAML](#provision-the-data-source) with the Grafana provisioning system.
 
 - **A running MySQL instance:** MySQL 5.7 or newer, MariaDB 10.2 or newer, or a compatible MySQL-based database such as Percona Server.
 
@@ -41,7 +41,7 @@ Grafana ships with a built-in MySQL data source plugin. No additional installati
 {{< /admonition >}}
 
 {{< admonition type="tip" >}}
-**Grafana Cloud users:** If your MySQL server is in a private network, you can configure [Private data source connect](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/) to establish connectivity.
+**Grafana Cloud users:** Grafana Cloud doesn't provide static outbound IP addresses for data source connections, so IP allowlisting isn't a supported connectivity method. If your MySQL server is in a private network, configure [Private data source connect (PDC)](https://grafana.com/docs/grafana-cloud/connect-externally-hosted/private-data-source-connect/) to establish a secure connection without exposing your database to the public internet.
 {{< /admonition >}}
 
 ### Database user permissions
@@ -83,7 +83,9 @@ Following is a list of MySQL configuration options:
 
 **Authentication:**
 
-- **Username**- Enter the username used to connect to your MySQL database.
+The MySQL data source supports username and password authentication, with optional TLS for encrypted connections. Kerberos, gMSA, and other external authentication mechanisms aren't supported. Create a dedicated MySQL user for Grafana instead.
+
+- **Username** - Enter the username used to connect to your MySQL database.
 - **Password** - Enter the password used to connect to the MySQL database.
 - **Use TLS Client Auth** - Toggle to enable TLS authentication using the client certificate specified in the secure JSON configuration. Refer to [Using TLS Connections](https://dev.mysql.com/doc/refman/8.4/en/mysql-cluster-tls-using.html) and [Configuring MySQL to Use Encrypted Connections](https://dev.mysql.com/doc/refman/8.4/en/using-encrypted-connections.html) for more information regarding TLS and configuring encrypted connections in MySQL. Provide the client certificate under **TLS/SSL Client Certificate**. Provide the key under **TLS/SSL Client Key**.
 - **With CA Cert** - Toggle to authenticate using a CA certificate. Required for verifying self-signed TLS Certs. Follow the instructions of your CA (Certificate Authority) to download the certificate file. Provide the root certificate under **TLS/SSL Root Certificate** if TLS/SSL mode requires it.

--- a/docs/sources/datasources/mysql/configure/_index.md
+++ b/docs/sources/datasources/mysql/configure/_index.md
@@ -122,7 +122,7 @@ This section is only visible when the Grafana server has the secure SOCKS proxy 
 
 - **Enabled** - Toggle to route requests to the MySQL instance through a secure SOCKS proxy.
 
-Once you have added your MySQL connection settings, click **Save & test** to test and save the data source connection.
+After you have added your MySQL connection settings, click **Save & test** to test and save the data source connection.
 
 ### Min time interval
 

--- a/docs/sources/datasources/mysql/query-editor/_index.md
+++ b/docs/sources/datasources/mysql/query-editor/_index.md
@@ -12,6 +12,7 @@ labels:
 menuTitle: Query editor
 title: MySQL query editor
 weight: 30
+review_date: 2026-05-11
 ---
 
 # MySQL query editor
@@ -35,8 +36,6 @@ If your table or database name contains a reserved word or a [prohibited charact
 {{< /admonition >}}
 
 ## MySQL Builder mode
-
-{{< figure alt="Builder mode" src="/media/docs/mysql/screenshot-mysql-query-editor.v11.3.png" class="docs-image--no-shadow" >}}
 
 The following components will help you build a MySQL query:
 
@@ -66,8 +65,6 @@ The following components will help you build a MySQL query:
 ## MySQL Code mode
 
 To create advanced queries, switch to **Code mode** by clicking **Code** in the upper right of the editor window. Code mode supports the auto-completion of tables, columns, SQL keywords, standard SQL functions, Grafana template variables, and Grafana macros. Columns cannot be completed before a table has been specified.
-
-{{< figure src="/static/img/docs/v92/sql_code_editor.png" class="docs-image--no-shadow" >}}
 
 Select **Table** or **Time Series** as the format. Click the **{}** in the bottom right to format the query. Click the **downward caret** to expand the Code mode editor. **CTRL/CMD + Return** serves as a keyboard shortcut to execute the query.
 
@@ -100,6 +97,10 @@ You can add macros to your queries to simplify the syntax and enable dynamic ele
 | `$__unixEpochGroup(dateColumn,'5m', [fillmode])`      | Same as $\_\_timeGroup but for times stored as Unix timestamp. **Note that `fillMode` only works with time series queries.**                                                                                                                   |
 | `$__unixEpochGroupAlias(dateColumn,'5m', [fillmode])` | Same as $\_\_timeGroup but also adds a column alias. **Note that `fillMode` only works with time series queries.**                                                                                                                             |
 
+{{< admonition type="note" >}}
+As of Grafana 13.0, fill resampling in `$__timeGroup` and `$__unixEpochGroup` includes additional safeguards to prevent incorrect data points when the query returns no rows or the time range falls outside the data boundaries.
+{{< /admonition >}}
+
 ## Table SQL queries
 
 If the **Format** option is set to **Table**, you can execute virtually any type of SQL query. The Table panel will automatically display the resulting columns and rows from your query.
@@ -115,10 +116,6 @@ SELECT
 INNER JOIN user on user.id = dashboard.created_by
 WHERE $__timeFilter(dashboard.created)
 ```
-
-Table panel results:
-
-![](/static/img/docs/v43/mysql_table.png)
 
 ## Time series queries
 

--- a/docs/sources/datasources/mysql/template-variables/index.md
+++ b/docs/sources/datasources/mysql/template-variables/index.md
@@ -131,7 +131,7 @@ This outputs the values as an unquoted comma-separated list.
 
 ### Use explicit quoting for string variables
 
-Don't rely on Grafana's implicit quoting behavior for string variables in SQL queries. Quoting behavior can vary depending on panel type and context:
+Don't rely on implicit quoting behavior for string variables in SQL queries. Quoting behavior can vary depending on panel type and context:
 
 - **Repeat panels** may not quote single-value variables at all, causing bare values to appear in the SQL and breaking the query.
 - If you manually wrap a variable in quotes (for example, `WHERE name = '$myvar'`) and Grafana also applies its own quoting, the value gets double-quoted (for example, `''30''` instead of `'30'`). This intentional quoting behavior was restored in Grafana 11.3.

--- a/docs/sources/datasources/mysql/template-variables/index.md
+++ b/docs/sources/datasources/mysql/template-variables/index.md
@@ -14,6 +14,7 @@ labels:
 menuTitle: Template variables
 title: MySQL template variables
 weight: 300
+review_date: 2026-05-11
 ---
 
 # MySQL template variables
@@ -27,6 +28,8 @@ For an introduction to templating and template variables, refer to [Templating](
 ## Query variable
 
 A query variable in Grafana dynamically retrieves values from your data source using a query. With a query variable, you can write a SQL query that returns values such as measurement names, key names, or key values that are shown in a drop-down select box.
+
+The variable query editor supports the same **Builder** and **Code** modes as the main query editor. Use Builder mode to construct queries visually by selecting a dataset, table, columns, and filters. Use Code mode to write SQL directly.
 
 For example, the following query returns all values from the `hostname` column:
 
@@ -48,18 +51,17 @@ SELECT event_name FROM event_log WHERE $__timeFilter(time_column)
 
 ### Key/value variables
 
-You can create a key/value variable using a query that returns two columns named `__text` and `__value`.
+You can create a key/value variable so the drop-down shows a user-friendly label (for example, hostname) while panel queries use a different value (for example, ID). Use the variable editor's **Value field** and **Text field** at the bottom of the query section to specify which query columns supply the value and the label. Your query can use any column names; you don't need `__value` or `__text` in the SQL.
 
-- The `__text` column defines the label shown in the drop-down.
-- The `__value` column defines the value passed to panel queries.
-
-This is useful when you want to display a user-friendly label (like a hostname) but use a different underlying value (like an ID).
-
-Note that the values in the `__text` column should be unique. If there are duplicates, Grafana uses only the first matching entry.
+Example: run a query that returns `hostname` and `id`, then set **Text field** to `hostname` and **Value field** to `id`.
 
 ```sql
-SELECT hostname AS __text, id AS __value FROM my_host
+SELECT hostname, id FROM my_host
 ```
+
+Note that the values in the text column should be unique. If there are duplicates, Grafana uses only the first matching entry.
+
+Alternatively, you can use the legacy approach: return columns named `__text` and `__value` in your query (for example, `SELECT hostname AS __text, id AS __value FROM my_host`).
 
 ### Nested variables
 

--- a/docs/sources/datasources/mysql/template-variables/index.md
+++ b/docs/sources/datasources/mysql/template-variables/index.md
@@ -129,4 +129,31 @@ ${servers:csv}
 
 This outputs the values as an unquoted comma-separated list.
 
+### Use explicit quoting for string variables
+
+Don't rely on Grafana's implicit quoting behavior for string variables in SQL queries. Quoting behavior can vary depending on panel type and context:
+
+- **Repeat panels** may not quote single-value variables at all, causing bare values to appear in the SQL and breaking the query.
+- If you manually wrap a variable in quotes (for example, `WHERE name = '$myvar'`) and Grafana also applies its own quoting, the value gets double-quoted (for example, `''30''` instead of `'30'`). This intentional quoting behavior was restored in Grafana 11.3.
+
+To avoid both problems, use the `sqlstring` format option. It handles escaping and quoting in a single step, so you don't add your own quotes around the variable:
+
+```sql
+SELECT *
+FROM my_table
+WHERE hostname = ${hostname:sqlstring}
+```
+
+This produces a safely quoted string (for example, `'server01'`) regardless of panel type or context. For multi-value variables, use `IN` with `${var:sqlstring}`:
+
+```sql
+SELECT *
+FROM my_table
+WHERE hostname IN (${hostname:sqlstring})
+```
+
+{{< admonition type="caution" >}}
+Don't wrap `${var:sqlstring}` in additional quotes. The `sqlstring` formatter already produces a quoted value. Writing `'${var:sqlstring}'` results in double quoting.
+{{< /admonition >}}
+
 Refer to [Advanced variable format options](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/dashboards/variables/variable-syntax/#advanced-variable-format-options) for additional information.

--- a/docs/sources/datasources/mysql/troubleshooting/index.md
+++ b/docs/sources/datasources/mysql/troubleshooting/index.md
@@ -268,11 +268,11 @@ These errors occur when there are issues with query syntax or configuration.
 1. If the column name contains special characters or spaces, enclose it in backticks: `` `column-name` ``.
 1. Ensure the correct database is selected if you're referencing columns without the full table path.
 
-### CASE expression fails on non-standard string column types
+### `CASE` expression fails on non-standard string column types
 
 **Error message:** Query with `CASE WHEN` returns an error or unexpected results in Grafana, but works in other MySQL clients
 
-**Cause:** Grafana's MySQL driver doesn't handle all MySQL string subtypes (such as `ENUM`, `SET`, `TINYTEXT`, or `MEDIUMTEXT`) in `CASE` expressions. The driver may fail to infer the result type correctly.
+**Cause:** The Grafana MySQL driver doesn't handle all MySQL string subtypes (such as `ENUM`, `SET`, `TINYTEXT`, or `MEDIUMTEXT`) in `CASE` expressions. The driver may fail to infer the result type correctly.
 
 **Solution:**
 

--- a/docs/sources/datasources/mysql/troubleshooting/index.md
+++ b/docs/sources/datasources/mysql/troubleshooting/index.md
@@ -15,6 +15,7 @@ labels:
 menuTitle: Troubleshooting
 title: Troubleshoot MySQL data source issues
 weight: 400
+review_date: 2026-05-11
 ---
 
 # Troubleshoot MySQL data source issues
@@ -170,6 +171,17 @@ These errors occur when there are issues with query syntax or configuration.
 1. Check that the column name passed to macros exists in your table.
 1. View the expanded query by clicking **Generated SQL** after running the query to debug macro expansion.
 1. Ensure backticks are used for reserved words or special characters in column names: `$__timeFilter(\`time-column\`)`.
+
+### Hash character in quoted strings causes query errors
+
+**Error message:** Query returns unexpected results or errors when string values contain `#`
+
+**Cause:** In versions before Grafana 13.0, the SQL comment stripping logic incorrectly treated `#` inside quoted strings (for example, `WHERE color = '#FF0000'`) as a comment delimiter, which stripped the rest of the line.
+
+**Solution:**
+
+1. Upgrade to Grafana 13.0 or later, which preserves `#` inside quoted strings.
+1. As a workaround on older versions, use the `CONCAT` function or a hexadecimal literal to avoid the `#` character in string literals.
 
 ### Timezone and time shift issues
 

--- a/docs/sources/datasources/mysql/troubleshooting/index.md
+++ b/docs/sources/datasources/mysql/troubleshooting/index.md
@@ -55,17 +55,45 @@ These errors occur when Grafana cannot establish or maintain a connection to the
 
 ### TLS/SSL connection failures
 
-**Error message:** "TLS handshake failed" or "x509: certificate verify failed"
+TLS errors occur when the MySQL server requires or expects encrypted connections but the Grafana data source isn't configured to match. Common error messages include:
 
-**Cause:** There is a mismatch between the TLS settings in Grafana and what the MySQL server supports or requires.
+- "TLS handshake failed" or "x509: certificate verify failed"
+- "Connection refused" or connection drops immediately
+- "Error 3159: Connections using insecure transport are prohibited while --require_secure_transport=ON"
 
-**Solution:**
+**Possible causes and solutions:**
 
-1. Verify that the MySQL server has a valid SSL certificate if encryption is enabled.
-1. Check that the certificate is trusted by the Grafana server.
-1. If using a self-signed certificate, enable **With CA Cert** and provide the root certificate under **TLS/SSL Root Certificate**.
-1. To bypass certificate validation (not recommended for production), enable **Skip TLS Verification** in the data source configuration.
-1. Ensure the SSL certificate hasn't expired.
+| Cause | Solution |
+| ----- | -------- |
+| MySQL has `require_secure_transport` enabled or AWS RDS Proxy enforces TLS | Enable **With CA Cert** or **Skip TLS Verification** in the data source configuration. Either option establishes a TLS connection. |
+| Self-signed or private CA certificate isn't trusted | Enable **With CA Cert** and provide the root certificate under **TLS/SSL Root Certificate**. |
+| Certificate has expired or doesn't match the hostname | Renew the certificate, or enable **Skip TLS Verification** for development environments only. |
+| TLS handshake fails against AWS RDS or RDS Proxy | Provide the [Amazon RDS root CA certificate](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html) under **TLS/SSL Root Certificate** with **With CA Cert** enabled. |
+| Organization requires mutual TLS (mTLS) | Enable **Use TLS Client Auth** and provide both a client certificate and key in addition to the CA certificate. |
+
+{{< admonition type="note" >}}
+**Skip TLS Verification** and **With CA Cert** both establish encrypted connections. You don't need **Use TLS Client Auth** unless your setup requires mutual TLS. For most AWS RDS and RDS Proxy connections, **With CA Cert** with the Amazon root CA is sufficient.
+{{< /admonition >}}
+
+For provisioned data sources, enable TLS in `jsonData`:
+
+```yaml
+jsonData:
+  tlsAuthWithCACert: true
+secureJsonData:
+  tlsCACert: ${CA_CERT}
+```
+
+To skip certificate validation instead, use:
+
+```yaml
+jsonData:
+  tlsSkipVerify: true
+```
+
+If you're deploying the MySQL integration through the Kubernetes Monitoring Helm chart, use the dedicated TLS configuration parameters available in the chart. Earlier versions didn't expose a way to append `/?tls=true` to the connection string -- upgrade to the latest chart version to access these parameters.
+
+For all available TLS provisioning options, refer to the [TLS provisioning examples](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/mysql/configure/#mysql-provisioning-examples).
 
 ### Connection reset by peer
 
@@ -240,6 +268,24 @@ These errors occur when there are issues with query syntax or configuration.
 1. If the column name contains special characters or spaces, enclose it in backticks: `` `column-name` ``.
 1. Ensure the correct database is selected if you're referencing columns without the full table path.
 
+### CASE expression fails on non-standard string column types
+
+**Error message:** Query with `CASE WHEN` returns an error or unexpected results in Grafana, but works in other MySQL clients
+
+**Cause:** Grafana's MySQL driver doesn't handle all MySQL string subtypes (such as `ENUM`, `SET`, `TINYTEXT`, or `MEDIUMTEXT`) in `CASE` expressions. The driver may fail to infer the result type correctly.
+
+**Solution:**
+
+1. Use `CAST()` to normalize the column to `CHAR` before using it in a `CASE` expression:
+
+   ```sql
+   SELECT
+     CASE WHEN CAST(status_column AS CHAR) = 'active' THEN 1 ELSE 0 END AS is_active
+   FROM my_table
+   ```
+
+1. This is a known limitation of the Go MySQL driver used by Grafana. Explicitly casting to `CHAR` ensures consistent type handling.
+
 ## Performance issues
 
 These issues relate to slow queries or high resource usage.
@@ -332,6 +378,34 @@ The following issues don't produce specific error messages but are commonly enco
 1. Enclose identifiers with special characters in backticks: `` `my-database`.`my-table` ``.
 1. The query editor automatically handles this for selections, but manual queries require backticks.
 1. Avoid using reserved words as identifiers when possible.
+
+### Query caching can't be enabled on a provisioned data source
+
+**Cause:** When a MySQL data source is provisioned via YAML, the query caching toggle in the UI is greyed out. YAML provisioning doesn't currently support setting caching configuration.
+
+**Solution:**
+
+1. Use the Grafana HTTP API to enable query caching on the provisioned data source. Send a `PUT` request to update the data source with caching enabled:
+
+   ```sh
+   curl -X PUT -H "Content-Type: application/json" \
+     -H "Authorization: Bearer <API_TOKEN>" \
+     "https://<GRAFANA_URL>/api/datasources/<DATASOURCE_ID>" \
+     -d '{
+       "jsonData": {
+         "queryCachingTTL": 300
+       }
+     }'
+   ```
+
+   Replace `<API_TOKEN>` with a valid Grafana API token, `<GRAFANA_URL>` with your Grafana instance URL, and `<DATASOURCE_ID>` with the numeric ID of the data source. Set `queryCachingTTL` to the desired cache duration in seconds.
+
+1. Retrieve the data source ID by calling `GET /api/datasources/name/<DATA_SOURCE_NAME>`.
+1. YAML-based caching configuration is an open feature request. Check [Grafana GitHub issues](https://github.com/grafana/grafana/issues) for current status.
+
+{{< admonition type="note" >}}
+Query caching is available in Grafana Enterprise and Grafana Cloud. For more information, refer to [Query and resource caching](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/data-source-management/#query-and-resource-caching).
+{{< /admonition >}}
 
 ### An unexpected error happened
 

--- a/docs/sources/datasources/mysql/troubleshooting/index.md
+++ b/docs/sources/datasources/mysql/troubleshooting/index.md
@@ -63,13 +63,13 @@ TLS errors occur when the MySQL server requires or expects encrypted connections
 
 **Possible causes and solutions:**
 
-| Cause | Solution |
-| ----- | -------- |
-| MySQL has `require_secure_transport` enabled or AWS RDS Proxy enforces TLS | Enable **With CA Cert** or **Skip TLS Verification** in the data source configuration. Either option establishes a TLS connection. |
-| Self-signed or private CA certificate isn't trusted | Enable **With CA Cert** and provide the root certificate under **TLS/SSL Root Certificate**. |
-| Certificate has expired or doesn't match the hostname | Renew the certificate, or enable **Skip TLS Verification** for development environments only. |
-| TLS handshake fails against AWS RDS or RDS Proxy | Provide the [Amazon RDS root CA certificate](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html) under **TLS/SSL Root Certificate** with **With CA Cert** enabled. |
-| Organization requires mutual TLS (mTLS) | Enable **Use TLS Client Auth** and provide both a client certificate and key in addition to the CA certificate. |
+| Cause                                                                      | Solution                                                                                                                                                                                     |
+| -------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| MySQL has `require_secure_transport` enabled or AWS RDS Proxy enforces TLS | Enable **With CA Cert** or **Skip TLS Verification** in the data source configuration. Either option establishes a TLS connection.                                                           |
+| Self-signed or private CA certificate isn't trusted                        | Enable **With CA Cert** and provide the root certificate under **TLS/SSL Root Certificate**.                                                                                                 |
+| Certificate has expired or doesn't match the hostname                      | Renew the certificate, or enable **Skip TLS Verification** for development environments only.                                                                                                |
+| TLS handshake fails against AWS RDS or RDS Proxy                           | Provide the [Amazon RDS root CA certificate](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.SSL.html) under **TLS/SSL Root Certificate** with **With CA Cert** enabled. |
+| Organization requires mutual TLS (mTLS)                                    | Enable **Use TLS Client Auth** and provide both a client certificate and key in addition to the CA certificate.                                                                              |
 
 {{< admonition type="note" >}}
 **Skip TLS Verification** and **With CA Cert** both establish encrypted connections. You don't need **Use TLS Client Auth** unless your setup requires mutual TLS. For most AWS RDS and RDS Proxy connections, **With CA Cert** with the Amazon root CA is sufficient.

--- a/docs/sources/datasources/mysql/troubleshooting/index.md
+++ b/docs/sources/datasources/mysql/troubleshooting/index.md
@@ -91,7 +91,7 @@ jsonData:
   tlsSkipVerify: true
 ```
 
-If you're deploying the MySQL integration through the Kubernetes Monitoring Helm chart, use the dedicated TLS configuration parameters available in the chart. Earlier versions didn't expose a way to append `/?tls=true` to the connection string -- upgrade to the latest chart version to access these parameters.
+If you're using the MySQL _integration_ rather than the data source, TLS is configured through the Kubernetes Monitoring Helm chart. Refer to the [MySQL integration documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-mysql/) for details.
 
 For all available TLS provisioning options, refer to the [TLS provisioning examples](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/mysql/configure/#mysql-provisioning-examples).
 

--- a/docs/sources/datasources/mysql/troubleshooting/index.md
+++ b/docs/sources/datasources/mysql/troubleshooting/index.md
@@ -91,8 +91,6 @@ jsonData:
   tlsSkipVerify: true
 ```
 
-If you're using the MySQL _integration_ rather than the data source, TLS is configured through the Kubernetes Monitoring Helm chart. Refer to the [MySQL integration documentation](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-mysql/) for details.
-
 For all available TLS provisioning options, refer to the [TLS provisioning examples](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/mysql/configure/#mysql-provisioning-examples).
 
 ### Connection reset by peer


### PR DESCRIPTION
Quarterly documentation update for the MySQL data source, aligned with data source documentation conventions. Content was cross-referenced against backend source code and changelog entries for accuracy. Incorporates Zendesk case findings to address common customer issues.

configure/_index.md: Added review_date, clarified supported authentication methods (username/password and TLS only, no Kerberos/gMSA), updated Grafana Cloud tip to state static IP allowlisting is unsupported and recommend PDC, added Secure SOCKS proxy section

query-editor/_index.md: Added review_date, removed outdated Builder mode and Code mode screenshots (v11.3/v92), added Grafana 13.0 fill resampling safeguards admonition after macros table

template-variables/index.md: Added review_date, documented Builder/Code modes for the variable query editor, rewrote Key/value variables section to explain Value field and Text field UI controls, added "Use explicit quoting for string variables" section covering ${var:sqlstring} best practice and double-quoting behavior in repeat panels

troubleshooting/index.md: Added review_date, consolidated three TLS entries into a single section with cause/solution table and provisioning examples, added "Hash character in quoted strings causes query errors" entry (v13 fix), added "CASE expression fails on non-standard string column types" workaround, added "Query caching can't be enabled on a provisioned data source" API workaround


**Why do we need this feature?**

Part of the quarterly update cycle

**Who is this feature for?**

Users of all levels

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
