### PR TITLE
update the react-data-grid pinned commit for our fork to pin tanstack router

### DIFF
--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -116,7 +116,7 @@
     "react-calendar": "^6.0.0",
     "react-colorful": "5.6.1",
     "react-custom-scrollbars-2": "4.5.0",
-    "react-data-grid": "grafana/react-data-grid#a10c748f40edc538425b458af4e471a8262ec4ed",
+    "react-data-grid": "grafana/react-data-grid#b4c12050a5a0ab41b4ea153193a0f5b3eea13102",
     "react-dropzone": "14.3.8",
     "react-highlight-words": "0.21.0",
     "react-hook-form": "^7.49.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4477,7 +4477,7 @@ __metadata:
     react-calendar: "npm:^6.0.0"
     react-colorful: "npm:5.6.1"
     react-custom-scrollbars-2: "npm:4.5.0"
-    react-data-grid: "grafana/react-data-grid#a10c748f40edc538425b458af4e471a8262ec4ed"
+    react-data-grid: "grafana/react-data-grid#b4c12050a5a0ab41b4ea153193a0f5b3eea13102"
     react-dom: "npm:18.3.1"
     react-dropzone: "npm:14.3.8"
     react-element-to-jsx-string: "npm:^17.0.1"
@@ -29675,15 +29675,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-data-grid@grafana/react-data-grid#a10c748f40edc538425b458af4e471a8262ec4ed":
+"react-data-grid@grafana/react-data-grid#b4c12050a5a0ab41b4ea153193a0f5b3eea13102":
   version: 7.0.0-beta.56
-  resolution: "react-data-grid@https://github.com/grafana/react-data-grid.git#commit=a10c748f40edc538425b458af4e471a8262ec4ed"
+  resolution: "react-data-grid@https://github.com/grafana/react-data-grid.git#commit=b4c12050a5a0ab41b4ea153193a0f5b3eea13102"
   dependencies:
     clsx: "npm:^2.0.0"
   peerDependencies:
     react: ^18.0 || ^19.0
     react-dom: ^18.0 || ^19.0
-  checksum: 10/ba5ae10da5a0b104a8dad11ad3ae6b0e624edf8ec3f48f56bb392fc08cc453233e9a47cf713cf8d6f133265cae690ee0ea81112f7594f1007893883f5409d0e8
+  checksum: 10/6768e448bd5c414160f0bf17b51df5272d309e3c3363e2214f5381e447b227691224516f3b929fc9e9a730e64681717200eaf77c88a1a22bc254949ee3b7a457
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Updates react-data-grid to a newly released version of the fork which pins the tanstack devDependencies.