### PR TITLE
PostgreSQL: add tests documenting int64 to float64 precision boundary in series format

### DIFF
--- a/pkg/tsdb/grafana-postgresql-datasource/sqleng/sql_engine_test.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/sqleng/sql_engine_test.go
@@ -398,6 +398,26 @@ func TestSQLEngine(t *testing.T) {
 		}
 	})
 
+	t.Run("convertSQLValueColumnToFloat converts large int64 values to float64 with IEEE 754 rounding", func(t *testing.T) {
+		// 2^53+1 = 9007199254740993 is the first integer that cannot be represented
+		// exactly in float64 (53-bit mantissa). IEEE 754 rounds it down to 2^53.
+		// This documents the precision boundary when bigint columns are converted
+		// in series format. See https://github.com/grafana/grafana/issues/115358
+		const input = int64(9007199254740993)
+		const rounded = float64(9007199254740992)
+
+		frame := data.NewFrame("",
+			data.NewField("bigint_col", nil, []*int64{Pointer(input)}),
+		)
+
+		result, err := convertSQLValueColumnToFloat(frame, 0)
+		require.NoError(t, err)
+
+		got := result.Fields[0].At(0).(*float64)
+		require.NotNil(t, got)
+		assert.Equal(t, rounded, *got)
+	})
+
 	t.Run("Should not return raw connection errors", func(t *testing.T) {
 		err := net.OpError{Op: "Dial", Err: fmt.Errorf("inner-error")}
 		transformer := &testQueryResultTransformer{}
@@ -664,6 +684,41 @@ func TestConvertResultsToFrame(t *testing.T) {
 			frame.Fields[0].At(1) // null id
 			frame.Fields[1].At(0) // null name
 		})
+	})
+
+	t.Run("bigint column preserves int64 precision in frame; series format converts to float64", func(t *testing.T) {
+		// Documents the precision boundary for PostgreSQL bigint (Int8OID) values
+		// flowing through the series-format pipeline.
+		//
+		// Stage 1 — convertResultsToFrame: Int8OID → FieldTypeNullableInt64. Value exact.
+		// Stage 2 — convertSQLValueColumnToFloat (series format): int64 → float64.
+		//            Values above 2^53 cannot be represented exactly in float64.
+		//
+		// See https://github.com/grafana/grafana/issues/115358
+		const input = int64(9007199254740993) // 2^53 + 1
+		const rounded = float64(9007199254740992)
+
+		fieldDescs := []pgconn.FieldDescription{
+			{Name: "ts", DataTypeOID: pgtype.TimestamptzOID},
+			{Name: "counter", DataTypeOID: pgtype.Int8OID},
+		}
+		mockRows := [][][]byte{
+			{[]byte("2024-01-01 00:00:00+00"), []byte("9007199254740993")},
+		}
+		result := &pgconn.Result{FieldDescriptions: fieldDescs, Rows: mockRows}
+		result.CommandTag = pgconn.NewCommandTag("SELECT 1")
+
+		frame, err := convertResultsToFrame([]*pgconn.Result{result}, 1000)
+		require.NoError(t, err)
+
+		// Stage 1: int64 is exact
+		require.Equal(t, data.FieldTypeNullableInt64, frame.Fields[1].Type())
+		assert.Equal(t, input, *frame.Fields[1].At(0).(*int64))
+
+		// Stage 2: series format converts numeric values to float64
+		converted, err := convertSQLValueColumnToFloat(frame, 1)
+		require.NoError(t, err)
+		assert.Equal(t, rounded, *converted.Fields[1].At(0).(*float64))
 	})
 }
 


### PR DESCRIPTION
## Summary

Adds two tests to \`sql_engine_test.go\` documenting the IEEE 754 precision boundary for PostgreSQL \`bigint\` columns.

**No behavior change. Tests only.**

## Investigation

Issue grafana/grafana-postgresql-datasource#148 reports that large \`bigint\` values appear incorrectly in Grafana. Full pipeline investigation found **two independent precision-loss points**.

### Point 1 — Backend, series format (inside this datasource)

\`\`\`
pgtype.Int8OID
  → getFieldTypesFromDescriptions()  → FieldTypeNullableInt64   ✅ exact
  → convertResultsToFrame()          → *int64 in data.Frame     ✅ exact
  → convertSQLValueColumnToFloat()   → float64(*iv)             ⚠ bounded by float64 mantissa
\`\`\`

\`convertSQLValueColumnToFloat\` is called for all non-string, non-time value columns in **series format** (the default). \`float64\` has a 53-bit mantissa; \`int64\` values above \`2^53 = 9007199254740992\` cannot be represented exactly. In **table format** the backend conversion is skipped and \`int64\` is preserved in the data.Frame.

### Point 2 — Frontend JSON deserialization (SDK + all datasources)

Even when \`FieldTypeNullableInt64\` reaches the wire intact, the SDK serializes it as a plain JSON number:

\`\`\`go
// grafana-plugin-sdk-go: data/frame_json.gen.go
stream.WriteInt64(v.Value(i))  // emits: 9007199254740993
\`\`\`

The frontend reads this via JavaScript \`JSON.parse\`:

\`\`\`typescript
// packages/grafana-data/src/dataframe/DataFrameJSON.ts
type FieldValues = unknown[];  // populated by JSON.parse
// JSON.parse("9007199254740993") → 9007199254740992  (JS Number is float64)
\`\`\`

JSON has no integer type. \`9007199254740993\` is a valid JSON number, but JavaScript's \`Number\` (IEEE 754 double) cannot represent it — precision is lost at parse time regardless of what the backend sends.

**A fix scoped to this datasource alone moves Point 1 to Point 2 without changing the user-visible result.**

### What was checked

| Component | Finding |
|---|---|
| \`getFieldTypesFromDescriptions\` | Correctly maps \`Int8OID\` → \`FieldTypeNullableInt64\` |
| \`convertResultsToFrame\` | Preserves \`int64\` exactly — no loss here |
| \`convertSQLValueColumnToFloat\` | Explicit \`float64(*iv)\` cast — **Point 1** |
| \`mathexp/type_series.go\` | \`default\` branch converts non-float64 numeric fields via \`NullableFloatAt\` — same cast |
| \`mathexp/Float64Field.GetValue\` | Type-asserts directly to \`float64\`/\`*float64\`; field is already converted before reaching reducers |
| \`data.LongToWide\` (SDK) | Uses \`CopyAt\` — type-preserving, no float64 requirement |
| \`frame_json.gen.go\` (SDK) | Writes \`int64\` as JSON integer via \`WriteInt64\` |
| \`DataFrameJSON.ts\` | \`FieldValues = unknown[]\`, populated by \`JSON.parse\` — **Point 2** |

### Boundary summary

\`\`\`
Postgres bigint
  → Go int64            exact
  → data.Frame int64    exact (table format) / float64 (series format, Point 1)
  → SDK JSON encoder    exact JSON integer
  → JS JSON.parse       IEEE 754 double, precision lost for |v| > 2^53  (Point 2)
\`\`\`

This is a cross-layer issue. The solution space (Arrow transport, BigInt-aware parser, explicit display semantics for \`FieldTypeInt64\`) involves tradeoffs across the SDK, data transport, and frontend that are outside the scope of this datasource.

## Tests added

**Test 1** — unit, isolates \`convertSQLValueColumnToFloat\`:

Verifies that \`int64(9007199254740993)\` (2^53+1) converts to \`float64(9007199254740992)\` — the deterministic IEEE 754 result.

**Test 2** — pipeline, \`convertResultsToFrame\` → \`convertSQLValueColumnToFloat\`:

Shows the two-stage boundary: \`convertResultsToFrame\` with \`Int8OID\` produces an exact \`*int64\`; the subsequent float conversion in series format introduces rounding at the 53-bit mantissa boundary.

## Question for maintainers

Where is the preferred layer to address this — SDK transport, frontend parsing, or an explicit display path for \`FieldTypeInt64\`? Happy to contribute once the approach is decided.

Fixes grafana/grafana-postgresql-datasource#148