### PR TITLE
fix(annotations): backfill missing tags field before toDataFrame

### DIFF
--- a/public/app/features/annotations/api.ts
+++ b/public/app/features/annotations/api.ts
@@ -17,7 +17,19 @@ class LegacyAnnotationServer implements AnnotationServer {
   query(params: unknown, requestId: string): Promise<DataFrame> {
     return getBackendSrv()
       .get('/api/annotations', params, requestId)
-      .then((v) => toDataFrame(v));
+      .then((v) => {
+        // arrayToDataFrame infers the schema from the first object's keys,
+        // so `tags` is lost when the first annotation lacks it.
+        // Backfill with an empty array so the field always appears.
+        if (Array.isArray(v)) {
+          for (const item of v) {
+            if (item && typeof item === 'object' && !('tags' in item)) {
+              item.tags = [];
+            }
+          }
+        }
+        return toDataFrame(v);
+      });
   }
 
   forAlert(alertUID: string) {


### PR DESCRIPTION
## Summary

- `arrayToDataFrame` infers the DataFrame schema from the first object's keys. When the first annotation returned by the API lacks a `tags` field, the column is missing from the resulting DataFrame, breaking tag-based filtering and display.
- Backfills `tags: []` on any annotation object missing the field before calling `toDataFrame`, ensuring the column always appears regardless of API response ordering.

## Test plan

- Verified `tsc` compiles `api.ts` without errors
- Ran unit test for backfill logic confirming empty arrays are added only when `tags` is absent
- Confirmed existing annotations with tags are unaffected