### PR TITLE
SCIM: Replace createMonitoringLogger calls with getLogger

### DIFF
--- a/packages/grafana-runtime/src/services/logging/loggers.ts
+++ b/packages/grafana-runtime/src/services/logging/loggers.ts
@@ -17,6 +17,7 @@ export const Loggers = {
   'features.dashboards.genai': {},
   'features.query-history.local-storage': {},
   'core.crash-detection': {},
+  'extensions.auth-config.scim': { context: { module: 'SCIM' } },
 } satisfies Record<string, LoggerDefaults>;
 
 export type LoggerSource = keyof typeof Loggers;


### PR DESCRIPTION
**What is this feature?**

Replaces `createMonitoringLogger` with `getLogger` from `@grafana/runtime/unstable` for SCIM logging.

**Why do we need this feature?**

So SCIM uses the new logger API from `@grafana/runtime/unstable`

**Who is this feature for?**

Grafana maintainers

Relates #121639

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
