### PR TITLE
Annotations: Switch kubernetesAnnotationsClient flag to OpenFeature

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -224,11 +224,6 @@ export interface FeatureToggles {
   */
   kubernetesLibraryPanels?: boolean;
   /**
-  * Enables usage of the new annotations API client
-  * @default false
-  */
-  kubernetesAnnotationsClient?: boolean;
-  /**
   * Enables k8s short url api and uses it under the hood when handling legacy /api
   * @default false
   */

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
@@ -14,6 +14,7 @@ declare module "@openfeature/core" {
     | "faroSessionReplay"
     | "provisioningFolderMetadata"
     | "provisioning.readmes"
+    | "kubernetesAnnotationsClient"
     | "stateTimeline.nameAboveBars"
     | "newSavedQueriesExperience"
     | "grafana.orgDashboardTemplates"

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -45,6 +45,8 @@ export const FlagKeys = {
   GrafanaUnifiedHomepage: "grafana.unifiedHomepage",
   /** Enables an inline version of Log Details that creates no new scrolls */
   InlineLogDetailsNoScrolls: "inlineLogDetailsNoScrolls",
+  /** Enables usage of the new annotations API client */
+  KubernetesAnnotationsClient: "kubernetesAnnotationsClient",
   /** Use stream shards to split queries into smaller subqueries */
   LokiShardSplitting: "lokiShardSplitting",
   /** Enables managed plugins v2 (expanded rollout, community plugin coverage) */
@@ -255,6 +257,17 @@ export const useFlagGrafanaUnifiedHomepage = (options?: ReactFlagEvaluationOptio
  */
 export const useFlagInlineLogDetailsNoScrolls = (options?: ReactFlagEvaluationOptions): boolean => {
   return useFlag("inlineLogDetailsNoScrolls", false, options).value;
+};
+
+/**
+ * Enables usage of the new annotations API client
+ *
+ * **Details:**
+ * - flag key: `kubernetesAnnotationsClient`
+ * - default value: `false`
+ */
+export const useFlagKubernetesAnnotationsClient = (options?: ReactFlagEvaluationOptions): boolean => {
+  return useFlag("kubernetesAnnotationsClient", false, options).value;
 };
 
 /**

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -385,7 +385,7 @@ var (
 			Owner:           grafanaDashboardsSquad,
 			RequiresRestart: false,
 			Expression:      "false",
-			Generate:        Generate{LegacyGo: true, LegacyFrontend: true},
+			Generate:        Generate{LegacyGo: true, React: true},
 		},
 		{
 			Name:            "kubernetesShortURLs",


### PR DESCRIPTION
## Summary

- Switches the `kubernetesAnnotationsClient` feature flag from `LegacyFrontend` to `React` generation, so the frontend can consume it via the OpenFeature SDK (`useFlagKubernetesAnnotationsClient` / `FlagKeys.KubernetesAnnotationsClient`) instead of `config.featureToggles`.
- The backend Go constant (`FlagKubernetesAnnotationsClient`) is unchanged — `LegacyGo: true` is preserved, so all backend consumers continue to work without modification.
- No flag rename: the wire key stays `kubernetesAnnotationsClient`, so any existing INI / env-var configuration is preserved.

This is the backend half of the migration suggested in https://github.com/grafana/grafana/pull/124104#discussion_r__ — splitting BE and FE per `AGENTS.md` deploy-cadence guidance. The frontend consumer swap (currently `config.featureToggles.kubernetesAnnotationsClient` in `public/app/features/annotations/api.ts`) will follow in a separate PR once this lands.

## Test plan

- [ ] `go test ./pkg/services/featuremgmt/...` passes (verified locally)
- [ ] Generated artifacts (`featureToggles.gen.ts`, `openfeature.gen.ts`, `openfeature-types.gen.d.ts`) match what `make gen-feature-toggles` produces
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)