### PR TITLE
DashboardDS: Fix Mixed panels not updating on time-range change with stale upstreams

### DIFF
--- a/public/app/plugins/datasource/dashboard/datasource.test.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.test.ts
@@ -114,14 +114,12 @@ describe('DashboardDatasource', () => {
   });
 
   it('Should skip the stale Done replayed by the upstream ReplaySubject on time-range change in MixedDS', async () => {
-    // Regression test for support-escalations#22242: in a Mixed datasource panel
-    // with Dashboard datasource subqueries, the upstream SceneQueryRunner exposes
-    // its results via a ReplaySubject(1) which synchronously replays the previous
-    // range's Done state to new subscribers on time-range change. The Mixed-DS
-    // operator's `first(Done || Error)` used to match that stale Done and
-    // complete the substream before the upstream re-ran for the new range, so
-    // the chain panel rendered with stale data and never re-rendered when the
-    // real Done arrived seconds later.
+    // The upstream SceneQueryRunner exposes its results via a ReplaySubject(1)
+    // that synchronously replays the previous range's Done state on subscribe.
+    // The Mixed-DS operator's `first(Done || Error)` used to match that stale
+    // Done and complete the substream before the upstream re-ran for the new
+    // range, so the chain panel rendered with stale data and never re-rendered
+    // when the real Done arrived seconds later.
     const oldRange = makeRange('2026-05-01T00:00:00Z', '2026-05-08T00:00:00Z');
     const newRange = makeRange('2026-05-04T00:00:00Z', '2026-05-08T00:00:00Z');
 

--- a/public/app/plugins/datasource/dashboard/datasource.test.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.test.ts
@@ -1,11 +1,13 @@
-import { first } from 'rxjs';
+import { first, Subject } from 'rxjs';
 
 import {
   arrayToDataFrame,
+  dateTime,
   type DataQueryResponse,
   type DataSourceInstanceSettings,
   getDefaultTimeRange,
   LoadingState,
+  type PanelData,
   standardTransformersRegistry,
   FieldType,
   type DataFrame,
@@ -16,6 +18,7 @@ import { getPanelPlugin } from '@grafana/data/test';
 import { setPluginImportUtils } from '@grafana/runtime';
 import {
   SafeSerializableSceneObject,
+  type SceneDataProviderResult,
   SceneDataNode,
   SceneDataTransformer,
   SceneFlexItem,
@@ -108,6 +111,64 @@ describe('DashboardDatasource', () => {
     observable.subscribe({ next: () => {} });
 
     expect(first).not.toHaveBeenCalled();
+  });
+
+  it('Should skip stale Done from a different time range and emit the fresh Done when used within MixedDS', async () => {
+    // Regression test for support-escalations#22242: in a Mixed datasource panel with
+    // Dashboard datasource subqueries, a time-range change causes the upstream
+    // SceneQueryRunner ReplaySubject to replay a stale Done for the previous range.
+    // The Mixed-DS operator's `first(Done || Error)` used to match that stale Done
+    // and complete the substream before the upstream re-ran for the new range, so
+    // the chain panel rendered with stale/empty data and never re-rendered when the
+    // real Done arrived seconds later.
+    const oldRange = makeRange('2026-05-01T00:00:00Z', '2026-05-08T00:00:00Z');
+    const newRange = makeRange('2026-05-04T00:00:00Z', '2026-05-08T00:00:00Z');
+
+    const { observable, upstreamStream } = setupWithControllableUpstream(
+      { refId: 'A', panelId: 1 },
+      `${MIXED_REQUEST_PREFIX}1`,
+      newRange
+    );
+
+    const emissions: DataQueryResponse[] = [];
+    observable.subscribe({ next: (data) => emissions.push(data) });
+
+    // Replayed stale Done from the previous range — must be dropped by the filter
+    // before `emitFirstLoadedDataIfMixedDS`.
+    upstreamStream.next(makeResult(LoadingState.Done, arrayToDataFrame([1]), oldRange));
+
+    await waitForDebounce();
+    expect(emissions).toEqual([]);
+
+    // Upstream now re-runs for the new range: Loading then Done.
+    upstreamStream.next(makeResult(LoadingState.Loading, arrayToDataFrame([1]), newRange));
+    upstreamStream.next(makeResult(LoadingState.Done, arrayToDataFrame([2, 3]), newRange));
+
+    await waitForDebounce();
+    expect(emissions).toHaveLength(1);
+    expect(emissions[0].state).toBe(LoadingState.Done);
+    expect(emissions[0].data[0].fields[0].values).toEqual([2, 3]);
+  });
+
+  it('Should still emit when upstream request range matches and the only emission is Done (editor-add path)', async () => {
+    // The filter must not skip the editor-add case: same range, single Done emission.
+    const range = makeRange('2026-05-04T00:00:00Z', '2026-05-08T00:00:00Z');
+
+    const { observable, upstreamStream } = setupWithControllableUpstream(
+      { refId: 'A', panelId: 1 },
+      `${MIXED_REQUEST_PREFIX}1`,
+      range
+    );
+
+    const emissions: DataQueryResponse[] = [];
+    observable.subscribe({ next: (data) => emissions.push(data) });
+
+    upstreamStream.next(makeResult(LoadingState.Done, arrayToDataFrame([7, 8, 9]), range));
+
+    await waitForDebounce();
+    expect(emissions).toHaveLength(1);
+    expect(emissions[0].state).toBe(LoadingState.Done);
+    expect(emissions[0].data[0].fields[0].values).toEqual([7, 8, 9]);
   });
 
   it('Should not mutate field state in dataframe', async () => {
@@ -887,6 +948,84 @@ function setupWithAnnotations(query: DashboardQuery, requestId?: string) {
   });
 
   return { observable, sourceData };
+}
+
+function makeRange(fromIso: string, toIso: string) {
+  const from = dateTime(fromIso);
+  const to = dateTime(toIso);
+  return { from, to, raw: { from, to } };
+}
+
+function makeResult(
+  state: LoadingState,
+  frame: DataFrame,
+  range: ReturnType<typeof makeRange>
+): SceneDataProviderResult {
+  const data: PanelData = {
+    series: [frame],
+    state,
+    timeRange: range,
+    request: {
+      requestId: 'upstream-req',
+      interval: '',
+      intervalMs: 0,
+      range,
+      scopedVars: {},
+      targets: [],
+      timezone: 'utc',
+      app: '',
+      startTime: 0,
+    },
+  };
+  return { origin: undefined as unknown as SceneDataProviderResult['origin'], data };
+}
+
+function waitForDebounce() {
+  // datasource.ts uses debounceTime(50) followed by the Mixed-DS operator which adds
+  // an internal 400ms debounce on the first Done. Wait long enough for both to drain.
+  return new Promise((r) => setTimeout(r, 600));
+}
+
+function setupWithControllableUpstream(query: DashboardQuery, requestId: string, range: ReturnType<typeof makeRange>) {
+  const upstreamStream = new Subject<SceneDataProviderResult>();
+
+  const sourceData = new SceneDataNode({
+    data: {
+      series: [arrayToDataFrame([0])],
+      state: LoadingState.Done,
+      timeRange: getDefaultTimeRange(),
+    },
+  });
+  jest.spyOn(sourceData, 'getResultsStream').mockReturnValue(upstreamStream);
+
+  const scene = new SceneFlexLayout({
+    children: [
+      new SceneFlexItem({
+        body: new VizPanel({
+          key: getVizPanelKeyForPanelId(1),
+          $data: sourceData,
+        }),
+      }),
+    ],
+  });
+
+  const ds = new DashboardDatasource({} as DataSourceInstanceSettings);
+
+  const observable = ds.query({
+    timezone: 'utc',
+    targets: [query],
+    requestId,
+    interval: '',
+    intervalMs: 0,
+    range,
+    scopedVars: {
+      __sceneObject: new SafeSerializableSceneObject(scene),
+    },
+    app: '',
+    startTime: 0,
+  });
+
+  return { observable, upstreamStream, sourceData };
 }
 
 function setup(query: DashboardQuery, requestId?: string) {

--- a/public/app/plugins/datasource/dashboard/datasource.test.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.test.ts
@@ -1,4 +1,4 @@
-import { first, Subject } from 'rxjs';
+import { first, ReplaySubject } from 'rxjs';
 
 import {
   arrayToDataFrame,
@@ -113,13 +113,14 @@ describe('DashboardDatasource', () => {
     expect(first).not.toHaveBeenCalled();
   });
 
-  it('Should skip stale Done from a different time range and emit the fresh Done when used within MixedDS', async () => {
-    // Regression test for support-escalations#22242: in a Mixed datasource panel with
-    // Dashboard datasource subqueries, a time-range change causes the upstream
-    // SceneQueryRunner ReplaySubject to replay a stale Done for the previous range.
-    // The Mixed-DS operator's `first(Done || Error)` used to match that stale Done
-    // and complete the substream before the upstream re-ran for the new range, so
-    // the chain panel rendered with stale/empty data and never re-rendered when the
+  it('Should skip the stale Done replayed by the upstream ReplaySubject on time-range change in MixedDS', async () => {
+    // Regression test for support-escalations#22242: in a Mixed datasource panel
+    // with Dashboard datasource subqueries, the upstream SceneQueryRunner exposes
+    // its results via a ReplaySubject(1) which synchronously replays the previous
+    // range's Done state to new subscribers on time-range change. The Mixed-DS
+    // operator's `first(Done || Error)` used to match that stale Done and
+    // complete the substream before the upstream re-ran for the new range, so
+    // the chain panel rendered with stale data and never re-rendered when the
     // real Done arrived seconds later.
     const oldRange = makeRange('2026-05-01T00:00:00Z', '2026-05-08T00:00:00Z');
     const newRange = makeRange('2026-05-04T00:00:00Z', '2026-05-08T00:00:00Z');
@@ -130,12 +131,12 @@ describe('DashboardDatasource', () => {
       newRange
     );
 
+    // Prime the ReplaySubject with the stale Done BEFORE subscribing, so it gets
+    // replayed synchronously on subscribe — exactly the production scenario.
+    upstreamStream.next(makeResult(LoadingState.Done, arrayToDataFrame([1]), oldRange));
+
     const emissions: DataQueryResponse[] = [];
     observable.subscribe({ next: (data) => emissions.push(data) });
-
-    // Replayed stale Done from the previous range — must be dropped by the filter
-    // before `emitFirstLoadedDataIfMixedDS`.
-    upstreamStream.next(makeResult(LoadingState.Done, arrayToDataFrame([1]), oldRange));
 
     await waitForDebounce();
     expect(emissions).toEqual([]);
@@ -150,7 +151,7 @@ describe('DashboardDatasource', () => {
     expect(emissions[0].data[0].fields[0].values).toEqual([2, 3]);
   });
 
-  it('Should still emit when upstream request range matches and the only emission is Done (editor-add path)', async () => {
+  it('Should still emit the only Done when ranges match (Mixed editor-add path)', async () => {
     // The filter must not skip the editor-add case: same range, single Done emission.
     const range = makeRange('2026-05-04T00:00:00Z', '2026-05-08T00:00:00Z');
 
@@ -160,15 +161,40 @@ describe('DashboardDatasource', () => {
       range
     );
 
+    upstreamStream.next(makeResult(LoadingState.Done, arrayToDataFrame([7, 8, 9]), range));
+
     const emissions: DataQueryResponse[] = [];
     observable.subscribe({ next: (data) => emissions.push(data) });
-
-    upstreamStream.next(makeResult(LoadingState.Done, arrayToDataFrame([7, 8, 9]), range));
 
     await waitForDebounce();
     expect(emissions).toHaveLength(1);
     expect(emissions[0].state).toBe(LoadingState.Done);
     expect(emissions[0].data[0].fields[0].values).toEqual([7, 8, 9]);
+  });
+
+  it('Should not drop Done when the chain panel has a different range than the upstream (non-Mixed PanelTimeRange override)', async () => {
+    // Regression guard: a chain panel with a PanelTimeRange override (timeFrom,
+    // timeShift, ...) legitimately observes ranges that differ from the upstream.
+    // The range-mismatch filter only runs on the Mixed-DS path; the non-Mixed
+    // path must keep forwarding terminal emissions regardless of range.
+    const chainRange = makeRange('2026-05-04T00:00:00Z', '2026-05-08T00:00:00Z');
+    const upstreamRange = makeRange('2026-04-27T00:00:00Z', '2026-05-04T00:00:00Z');
+
+    const { observable, upstreamStream } = setupWithControllableUpstream(
+      { refId: 'A', panelId: 1 },
+      /* non-Mixed requestId */ 'panel-1',
+      chainRange
+    );
+
+    upstreamStream.next(makeResult(LoadingState.Done, arrayToDataFrame([42]), upstreamRange));
+
+    const emissions: DataQueryResponse[] = [];
+    observable.subscribe({ next: (data) => emissions.push(data) });
+
+    await waitForDebounce();
+    expect(emissions).toHaveLength(1);
+    expect(emissions[0].state).toBe(LoadingState.Done);
+    expect(emissions[0].data[0].fields[0].values).toEqual([42]);
   });
 
   it('Should not mutate field state in dataframe', async () => {
@@ -987,7 +1013,10 @@ function waitForDebounce() {
 }
 
 function setupWithControllableUpstream(query: DashboardQuery, requestId: string, range: ReturnType<typeof makeRange>) {
-  const upstreamStream = new Subject<SceneDataProviderResult>();
+  // Match production: upstream SceneQueryRunner exposes a ReplaySubject(1) so
+  // subscribers attaching after the upstream has already emitted Done get the
+  // stale Done replayed synchronously on subscribe.
+  const upstreamStream = new ReplaySubject<SceneDataProviderResult>(1);
 
   const sourceData = new SceneDataNode({
     data: {

--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -16,6 +16,7 @@ import {
   type AdHocVariableFilter,
   type MetricFindValue,
   getValueMatcher,
+  type TimeRange,
   ValueMatcherID,
   type DataSourceGetDrilldownsApplicabilityOptions,
   type DrilldownsApplicability,
@@ -30,6 +31,13 @@ import {
 import { MIXED_REQUEST_PREFIX } from '../mixed/MixedDataSource';
 
 import { type DashboardQuery } from './types';
+
+function isSameRange(a: TimeRange | undefined, b: TimeRange | undefined): boolean {
+  if (!a?.from || !a?.to || !b?.from || !b?.to) {
+    return false;
+  }
+  return a.from.valueOf() === b.from.valueOf() && a.to.valueOf() === b.to.valueOf();
+}
 
 /**
  * This should not really be called
@@ -96,15 +104,22 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
 
       const activateCleanUp = activateSceneObjectAndParentTree(sourceDataProvider!);
 
+      // Only the Mixed-DS path uses `first(Done || Error)` to complete the
+      // substream, so only that path needs to defend against a stale Done
+      // replayed from the upstream SceneQueryRunner's ReplaySubject after a
+      // time-range change. The non-Mixed path stays open and naturally
+      // re-emits when the fresh Done arrives, so adding the filter there
+      // could only hurt: a chain panel with a `PanelTimeRange` override
+      // legitimately observes ranges that differ from the upstream and we
+      // would block its terminal emission indefinitely.
+      const isMixedDs = options.requestId.includes(MIXED_REQUEST_PREFIX);
+
       return sourceDataProvider!.getResultsStream!().pipe(
         debounceTime(50),
         filter((result) => {
-          // Drop terminal (Done/Error) emissions whose upstream request range
-          // does not match this query's range. These are stale replays from
-          // the upstream SceneQueryRunner's ReplaySubject after a time-range
-          // change: without this guard, `emitFirstLoadedDataIfMixedDS` would
-          // match the stale Done with first(...) and complete the substream
-          // before the upstream re-runs for the new range.
+          if (!isMixedDs) {
+            return true;
+          }
           const state = result.data.state;
           if (state !== LoadingState.Done && state !== LoadingState.Error) {
             return true;
@@ -113,10 +128,7 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
           if (!upstreamRange?.from || !upstreamRange?.to) {
             return true;
           }
-          return (
-            upstreamRange.from.valueOf() === options.range.from.valueOf() &&
-            upstreamRange.to.valueOf() === options.range.to.valueOf()
-          );
+          return isSameRange(upstreamRange, options.range);
         }),
         map((result) => {
           return {

--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -1,4 +1,4 @@
-import { type Observable, debounce, debounceTime, defer, finalize, first, interval, map, of } from 'rxjs';
+import { type Observable, debounce, debounceTime, defer, filter, finalize, first, interval, map, of } from 'rxjs';
 
 import {
   DataSourceApi,
@@ -98,6 +98,26 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
 
       return sourceDataProvider!.getResultsStream!().pipe(
         debounceTime(50),
+        filter((result) => {
+          // Drop terminal (Done/Error) emissions whose upstream request range
+          // does not match this query's range. These are stale replays from
+          // the upstream SceneQueryRunner's ReplaySubject after a time-range
+          // change: without this guard, `emitFirstLoadedDataIfMixedDS` would
+          // match the stale Done with first(...) and complete the substream
+          // before the upstream re-runs for the new range.
+          const state = result.data.state;
+          if (state !== LoadingState.Done && state !== LoadingState.Error) {
+            return true;
+          }
+          const upstreamRange = result.data.request?.range;
+          if (!upstreamRange?.from || !upstreamRange?.to) {
+            return true;
+          }
+          return (
+            upstreamRange.from.valueOf() === options.range.from.valueOf() &&
+            upstreamRange.to.valueOf() === options.range.to.valueOf()
+          );
+        }),
         map((result) => {
           return {
             data: this.getDataFramesForQueryTopic(result.data, query, adHocFilters),


### PR DESCRIPTION
## What this PR does

In a Mixed datasource panel where each subquery uses the `-- Dashboard --` datasource, the chain panel can render data from the previous time range after a time-range change and never re-render when the real query for the new range completes.

The upstream `SceneQueryRunner` exposes its results via a `ReplaySubject(1)` that retains the previous `Done` state. On time-range change, the chain panel's Dashboard datasource subscribes to that stream and immediately receives the stale `Done`. The Mixed-DS operator (`emitFirstLoadedDataIfMixedDS`) used to match that stale `Done` with `first(Done || Error)` and complete the substream before the upstream re-ran for the new range. Mixed DS's `forkJoin` then resolved with stale frames, and when the real `Done` arrived 3-6s later the chain panel never re-rendered because its substream was already closed.

Hard refresh did not reproduce because the whole scene tree is reinstantiated and the ReplaySubjects start empty. The bug only surfaced on time-range change in the live scene tree.

Regression from https://github.com/grafana/grafana/pull/97116, which introduced the Mixed-DS path for Dashboard datasource subqueries (the `emitFirstLoadedDataIfMixedDS` operator with `first(Done || Error)`).

## How it is fixed

Before the existing Mixed-DS operator, drop terminal (`Done`/`Error`) emissions whose upstream `request.range` does not match the chain panel's `options.range`. On time-range change the ranges differ (stale = old, chain = new), so the stale `Done` is dropped and the operator waits for the fresh `Loading` -> `Done` for the new range.

The filter is scoped to the Mixed-DS path (`requestId.includes(MIXED_REQUEST_PREFIX)`) because that is the only path where `first(Done || Error)` short-circuits the substream. Non-Mixed Dashboard datasource queries stay open and naturally re-emit when the fresh `Done` arrives, so adding the filter there would only hurt: a chain panel with a `PanelTimeRange` override (`timeFrom`, `timeShift`) legitimately observes ranges that differ from the upstream, and we must not block its terminal emission.

## Which issue(s) this PR fixes

Adjacent (variable-change variants of the same race): https://github.com/grafana/grafana/issues/111294, https://github.com/grafana/grafana/issues/113579

## Test plan

- [x] New unit test reproduces the production bug using a real `ReplaySubject(1)` primed with a stale `Done` before subscribe, then a fresh `Loading` -> `Done` for the new range. Verified that the test fails without the production change.
- [x] New unit test locks in the filter scope: a non-Mixed chain panel with a different range than the upstream (the `PanelTimeRange` override case) keeps receiving terminal emissions normally.
- [x] Existing 51 `public/app/plugins/datasource/dashboard/` unit tests pass.
- [x] Manual smoke: time-range change, refresh button, editor-add (add a sub-query), and panel-level time override scenarios traced through the operator chain and verified consistent with the tests.

## Notes

- Should be backported to `v11.6.x`: the bug exists on the customer's reported version and the fix has no new APIs.
- Customer-visible bug fix; needs a changelog entry.