### PR TITLE
Clarify remote index lock loss semantics

### DIFF
--- a/pkg/storage/unified/search/lock_objstore.go
+++ b/pkg/storage/unified/search/lock_objstore.go
@@ -48,7 +48,7 @@ var errInvalidLockKey = errors.New("invalid lock key")
 // objectStorageLock provides distributed locking via conditional object storage writes.
 //
 // Not safe for concurrent use from the caller side. A single goroutine should
-// call Acquire, then either Release or consume Lost(). The internal heartbeat
+// call Acquire once, then either Release or consume Lost(). The internal heartbeat
 // goroutine only touches immutable config and closes lostCh.
 type objectStorageLock struct {
 	// Immutable after construction.
@@ -64,7 +64,7 @@ type objectStorageLock struct {
 	hbCancel context.CancelFunc
 	hbDone   chan struct{}
 
-	// lostCh is created in Acquire and only closed by the heartbeat goroutine.
+	// lostCh is created during construction and only closed by the heartbeat goroutine.
 	lostCh chan struct{}
 }
 
@@ -160,7 +160,6 @@ func (l *objectStorageLock) Acquire(ctx context.Context) error {
 	}
 
 	l.held = true
-	l.lostCh = make(chan struct{})
 
 	hbCtx, cancel := context.WithCancel(context.Background())
 	l.hbCancel = cancel
@@ -170,6 +169,8 @@ func (l *objectStorageLock) Acquire(ctx context.Context) error {
 }
 
 // Release stops the heartbeat and deletes the lock object.
+// After Lost is signaled, Release is best-effort cleanup; a nil return does not mean
+// this caller retained ownership until release.
 // Non-retriable errors: errLockHeld, errLockNotFound
 func (l *objectStorageLock) Release() error {
 	if !l.held {

--- a/pkg/storage/unified/search/lock_objstore_test.go
+++ b/pkg/storage/unified/search/lock_objstore_test.go
@@ -117,6 +117,28 @@ func TestObjectStorageLock_LostChannel(t *testing.T) {
 	}
 }
 
+func TestObjectStorageLock_LostChannelStableAcrossAcquire(t *testing.T) {
+	backend := newFakeBackend(newConditionalBucket())
+	lock := newTestLock(t, backend, "test-lock", "instance-1", 100*time.Millisecond, 50*time.Millisecond)
+
+	lost := lock.Lost()
+	require.Equal(t, lost, lock.Lost())
+
+	ctx := t.Context()
+	require.NoError(t, lock.Acquire(ctx))
+	require.Equal(t, lost, lock.Lost())
+
+	// Delete the lock to simulate external loss. The channel obtained before
+	// Acquire should be the one that signals the loss.
+	require.NoError(t, backend.Delete(ctx, "test-lock", "instance-1"))
+
+	select {
+	case <-lost:
+	case <-time.After(1 * time.Second):
+		t.Fatal("expected pre-Acquire Lost channel to be signaled")
+	}
+}
+
 func TestNewObjectStorageLock_Validation(t *testing.T) {
 	backend := newFakeBackend(newConditionalBucket())
 	validKey := "test-lock"

--- a/pkg/storage/unified/search/remote_index_store.go
+++ b/pkg/storage/unified/search/remote_index_store.go
@@ -93,6 +93,9 @@ type IndexMeta struct {
 
 // IndexStoreLock represents a distributed lock used to coordinate index store operations.
 type IndexStoreLock interface {
+	// Release stops renewing the lock and attempts to delete the lock object.
+	// After Lost is signaled, Release is best-effort cleanup; a nil return does
+	// not mean this caller retained ownership until release.
 	Release() error
 	Lost() <-chan struct{}
 }


### PR DESCRIPTION
Clarify remote index store lock-loss semantics

This updates `IndexStoreLock.Release` documentation to make the post-`Lost()` behavior explicit: releasing a lost lock is best-effort cleanup, and a nil release error does not mean the caller retained ownership until release.

It also keeps the lock's `Lost()` channel stable across `Acquire()` by removing the channel reassignment in `Acquire()`. This avoids stale channel references if a caller obtains `Lost()` before acquiring the lock.

A small test covers the stable-channel behavior.
