### PR TITLE
Dashboards: Fix auto height in the auto grid layout placed in a row

### DIFF
--- a/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-auto-grid/AutoGridLayoutRenderer.tsx
@@ -89,6 +89,7 @@ const getStyles = (theme: GrafanaTheme2, state: AutoGridLayoutState) => ({
     justifyItems: state.justifyItems || 'unset',
     alignItems: state.alignItems || 'unset',
     justifyContent: state.justifyContent || 'unset',
+    height: '100%',
     [theme.breakpoints.down('md')]: state.md
       ? {
           gridTemplateRows: state.md.templateRows,

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.tsx
@@ -168,7 +168,7 @@ export function RowItemRenderer({ model }: SceneComponentProps<RowItem>) {
             </div>
           )}
           {!isCollapsed && (
-            <div>
+            <div className={styles.rowLayoutWrapper}>
               {sectionVariablesEnabled && rowVariablesSet && <SectionVariableControls variableSet={rowVariablesSet} />}
               <layout.Component model={layout} />
             </div>
@@ -303,6 +303,9 @@ function getStyles(theme: GrafanaTheme2) {
       display: 'flex',
       alignItems: 'center',
       paddingLeft: theme.spacing(1),
+    }),
+    rowLayoutWrapper: css({
+      height: '100%',
     }),
   };
 }

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.tsx
@@ -305,7 +305,10 @@ function getStyles(theme: GrafanaTheme2) {
       paddingLeft: theme.spacing(1),
     }),
     rowLayoutWrapper: css({
-      height: '100%',
+      display: 'flex',
+      flexDirection: 'column',
+      flex: 1,
+      minHeight: 0,
     }),
   };
 }


### PR DESCRIPTION
**What is this feature?**

Set the height to 100% on the auto grid layout and the layout wrapper inside a row. This allows panels to properly resize when the "auto height" option is enabled in the auto grid layout.

**Why do we need this feature?**

FIx bug.

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

- Fixes https://github.com/grafana/grafana/issues/124115

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
