### PR TITLE
Alerting: Fix notification routing preview for non-default policy trees

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/NotificationsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/NotificationsStep.tsx
@@ -13,6 +13,7 @@ import { type KBObjectArray, RuleFormType, type RuleFormValues } from '../../typ
 import { GRAFANA_RULES_SOURCE_NAME } from '../../utils/datasource';
 import { DOCS_URL_NOTIFICATIONS, DOCS_URL_NOTIFICATION_POLICIES } from '../../utils/docs';
 import { isGrafanaManagedRuleByType, isGrafanaRecordingRuleByType, isRecordingRuleByType } from '../../utils/rules';
+import { NAMED_ROOT_LABEL_NAME } from '../notification-policies/useNotificationPolicyRoute';
 
 import { NeedHelpInfo } from './NeedHelpInfo';
 import { RuleEditorSection } from './RuleEditorSection';
@@ -244,6 +245,13 @@ function AutomaticRooting({ alertUid }: AutomaticRootingProps) {
   const multiplePoliciesEnabled = config.featureToggles.alertingMultiplePolicies ?? false;
   const policyRoutingSettingsEnabled = config.featureToggles.alertingPolicyRoutingSettings ?? false;
 
+  // When using the new routing settings FF, the policy is stored in selectedPolicy.
+  // In legacy mode (label-based routing), extract it from the __grafana_managed_route__ label so
+  // the notification preview fetches the correct routing tree instead of always defaulting to root.
+  const policyNameForPreview = policyRoutingSettingsEnabled
+    ? selectedPolicy
+    : labels.find((l) => l.key === NAMED_ROOT_LABEL_NAME)?.value;
+
   return (
     <Stack direction="column" gap={2}>
       {multiplePoliciesEnabled && <PolicyTreeSelector />}
@@ -254,7 +262,7 @@ function AutomaticRooting({ alertUid }: AutomaticRootingProps) {
         folder={folder}
         alertName={alertName}
         alertUid={alertUid}
-        policyName={policyRoutingSettingsEnabled ? selectedPolicy : undefined}
+        policyName={policyNameForPreview}
       />
     </Stack>
   );

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreview.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreview.tsx
@@ -12,6 +12,8 @@ import { type AlertQuery, type Labels } from 'app/types/unified-alerting-dto';
 
 import { type Folder, type KBObjectArray } from '../../../types/rule-form';
 import { useGetAlertManagerDataSourcesByPermissionAndConfig } from '../../../utils/datasource';
+import ConditionalWrap from '../../ConditionalWrap';
+import { NAMED_ROOT_LABEL_NAME } from '../../notification-policies/useNotificationPolicyRoute';
 
 const NotificationPreviewByAlertManager = lazy(() => import('./NotificationPreviewByAlertManager'));
 const NotificationPreviewForGrafanaManaged = lazy(() => import('./NotificationPreviewGrafanaManaged'));
@@ -27,6 +29,12 @@ interface NotificationPreviewProps {
 }
 
 const { preview } = alertRuleApi.endpoints;
+
+// strips labels that are routing infrastructure and should never be shown to users
+function stripInternalLabels(labels: Labels): Labels {
+  const { [NAMED_ROOT_LABEL_NAME]: _, ...rest } = labels;
+  return rest;
+}
 
 // TODO the scroll position keeps resetting when we preview
 // this is to be expected because the list of routes dissapears as we start the request but is very annoying
@@ -47,13 +55,9 @@ export const NotificationPreview = ({
 
   // potential instances are the instances that are going to be routed to the notification policies
   // convert data to list of labels: are the representation of the potential instances
-  const potentialInstances = data.reduce<Labels[]>((acc = [], instance) => {
-    if (instance.labels) {
-      acc.push(instance.labels);
-    }
-
-    return acc;
-  }, []);
+  const potentialInstances = data.flatMap((instance) =>
+    instance.labels ? [stripInternalLabels(instance.labels)] : []
+  );
 
   const onPreview = () => {
     if (previewRoutingDisabled) {
@@ -87,12 +91,9 @@ export const NotificationPreview = ({
         </Trans>
       );
     }
-    if (!folder) {
-      return (
-        <Trans i18nKey="alerting.notification-preview.select-folder-tooltip">Select a folder to preview routing</Trans>
-      );
-    }
-    return '';
+    return (
+      <Trans i18nKey="alerting.notification-preview.select-folder-tooltip">Select a folder to preview routing</Trans>
+    );
   };
 
   return (
@@ -123,11 +124,14 @@ export const NotificationPreview = ({
             </Text>
           )}
         </Stack>
-        <Tooltip content={getTooltipContent()}>
+        <ConditionalWrap
+          shouldWrap={previewRoutingDisabled}
+          wrap={(button) => <Tooltip content={getTooltipContent()}>{button}</Tooltip>}
+        >
           <Button icon="sync" variant="secondary" type="button" onClick={onPreview} disabled={previewRoutingDisabled}>
             <Trans i18nKey="alerting.notification-preview.preview-routing">Preview routing</Trans>
           </Button>
-        </Tooltip>
+        </ConditionalWrap>
       </Stack>
       {potentialInstances.length > 0 && (
         <Suspense

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/useAlertmanagerNotificationRoutingPreview.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/useAlertmanagerNotificationRoutingPreview.ts
@@ -40,8 +40,16 @@ export const useAlertmanagerNotificationRoutingPreview = (
     if (!defaultPolicy) {
       return;
     }
-    return normalizeRoute(addUniqueIdentifierToRoute(defaultPolicy));
-  }, [defaultPolicy]);
+    const normalized = normalizeRoute(addUniqueIdentifierToRoute(defaultPolicy));
+    // k8sRouteToRoute adds a synthetic root matcher (__grafana_managed_route__ = <name>)
+    // to tell apart different routing trees. But once we know which tree we want
+    // (policyName is set), that matcher just gets in the way — real Alertmanager
+    // doesn't know about it. Strip it so instances can actually flow into the sub-routes.
+    if (policyName) {
+      return { ...normalized, object_matchers: [] };
+    }
+    return normalized;
+  }, [defaultPolicy, policyName]);
 
   // match labels in the tree => map of notification policies and the alert instances (list of labels) in each one
   const {


### PR DESCRIPTION
**What is this feature?**

Fixes the notification routing preview in the alert rule creation/edit form when a non-default policy tree is selected via `PolicyTreeSelector`.

**Why do we need this feature?**

Three bugs existed when the `alertingMultiplePolicies` feature flag is enabled:

1. **Preview used the wrong tree (legacy mode).** `AutomaticRooting` passed `policyName={undefined}` to `NotificationPreview` unless `alertingPolicyRoutingSettings` was also enabled. With only `alertingMultiplePolicies` on, the selected tree (stored as a `__grafana_managed_route__` label on the form) was never forwarded to the preview hook, so routing was always evaluated against the default tree.

2. **No results shown for named trees (new mode).** When `alertingPolicyRoutingSettings` is on, the `__grafana_managed_route__` label is never added to `customLabels` — the policy is stored in `notification_settings.policy` instead. The routing tree's root has a synthetic `object_matchers: [['__grafana_managed_route__', '=', '<name>']]` injected by `k8sRouteToRoute`. Because instances never carry that label, the root rejected every instance (`'' !== '<name>'`) and nothing was shown — not even the root of the selected tree.

3. **`__grafana_managed_route__` visible in the preview.** In legacy mode the label was included in `customLabels`, so the backend added it to alert instances. It then surfaced in the instance label display and in the "Non-matching labels" section of the route drawer.

**Who is this feature for?**

Users creating or editing Grafana-managed alert rules while `alertingMultiplePolicies` is enabled.

**Which issue(s) does this PR fix?**:

Fixes #

**Changes**

- `NotificationsStep.tsx` — `AutomaticRooting` now derives `policyNameForPreview` from `formValues.labels[__grafana_managed_route__]` when `alertingPolicyRoutingSettings` is off, so the selected tree is always forwarded to the preview regardless of which FF combination is active.

- `useAlertmanagerNotificationRoutingPreview.ts` — when `policyName` is explicitly set, the root route's `object_matchers` are cleared before matching. The synthetic root matcher is a tree-selection discriminator; once the tree has already been chosen it blocks all instances from entering. Real Alertmanager root routes are catch-alls.

- `NotificationPreview.tsx` — `__grafana_managed_route__` is stripped from instances via a `stripInternalLabels` helper before they reach any display or matching component. It is routing infrastructure, not a user-visible label.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.