### PR TITLE
Data Source: Cap forwarded User-Agent length

### DIFF
--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -36,6 +36,10 @@ var (
 	errPluginProxyRouteAccessDenied = errors.New("plugin proxy route access denied")
 )
 
+// maxForwardedUserAgentLen is the maximum byte length of the client User-Agent
+// appended to the data proxy User-Agent when forward_user_agent is enabled.
+const maxForwardedUserAgentLen = 255
+
 type DataSourceProxy struct {
 	ds                 *datasources.DataSource
 	ctx                *contextmodel.ReqContext
@@ -239,6 +243,9 @@ func (proxy *DataSourceProxy) director(req *http.Request) {
 	ua := proxy.cfg.DataProxyUserAgent
 	if proxy.cfg.DataProxyForwardUserAgent {
 		if originalUA := req.Header.Get("User-Agent"); originalUA != "" {
+			if len(originalUA) > maxForwardedUserAgentLen {
+				originalUA = originalUA[:maxForwardedUserAgentLen]
+			}
 			if ua != "" {
 				ua = ua + " " + originalUA
 			} else {

--- a/pkg/api/pluginproxy/ds_proxy_test.go
+++ b/pkg/api/pluginproxy/ds_proxy_test.go
@@ -866,6 +866,49 @@ func TestDataSourceProxy_userAgentHeader(t *testing.T) {
 
 		assert.Equal(t, "original-client/1.0", req.Header.Get("User-Agent"))
 	})
+
+	t.Run("When DataProxyForwardUserAgent is enabled and the client User-Agent exceeds the length cap, it is truncated", func(t *testing.T) {
+		ctx := &contextmodel.ReqContext{}
+		proxy, err := setupDSProxyTest(t, ctx, ds, routes, "/render", func(p *DataSourceProxy) {
+			p.cfg = &setting.Cfg{
+				BuildVersion:              "5.3.0",
+				DataProxyUserAgent:        "Grafana/5.3.0",
+				DataProxyForwardUserAgent: true,
+			}
+		})
+		require.NoError(t, err)
+
+		oversized := strings.Repeat("a", maxForwardedUserAgentLen+100)
+		req, err := http.NewRequest(http.MethodGet, "http://grafana.com/sub", nil)
+		require.NoError(t, err)
+		req.Header.Set("User-Agent", oversized)
+
+		proxy.director(req)
+
+		expected := "Grafana/5.3.0 " + strings.Repeat("a", maxForwardedUserAgentLen)
+		assert.Equal(t, expected, req.Header.Get("User-Agent"))
+	})
+
+	t.Run("When DataProxyForwardUserAgent is enabled and the client User-Agent is exactly the cap, it is forwarded unchanged", func(t *testing.T) {
+		ctx := &contextmodel.ReqContext{}
+		proxy, err := setupDSProxyTest(t, ctx, ds, routes, "/render", func(p *DataSourceProxy) {
+			p.cfg = &setting.Cfg{
+				BuildVersion:              "5.3.0",
+				DataProxyUserAgent:        "Grafana/5.3.0",
+				DataProxyForwardUserAgent: true,
+			}
+		})
+		require.NoError(t, err)
+
+		exact := strings.Repeat("b", maxForwardedUserAgentLen)
+		req, err := http.NewRequest(http.MethodGet, "http://grafana.com/sub", nil)
+		require.NoError(t, err)
+		req.Header.Set("User-Agent", exact)
+
+		proxy.director(req)
+
+		assert.Equal(t, "Grafana/5.3.0 "+exact, req.Header.Get("User-Agent"))
+	})
 }
 
 // test DataSourceProxy request handling.


### PR DESCRIPTION
Follow-up to #124244. Caps the client `User-Agent` appended by the data proxy at 255 bytes when `forward_user_agent` is enabled, aligned with the existing `user_agent` column length used in `user_auth_token` / anon device tables. Truncation preserves leading product tokens (e.g. `gcx`, `Claude-Code`, browser identifiers), which is what downstream UA-attribution middlewares match on.

Byte-level header validity (no CTL, blocks header splitting) is already enforced by Go's `net/http` on both ingress and egress, so this PR adds the only gap that wasn't covered: an unbounded length on the forwarded portion.

Added as a nit after this conversation https://raintank-corp.slack.com/archives/CHQDPC970/p1778507575129229

## Test plan

- [x] `go test ./pkg/api/pluginproxy/ -run TestDataSourceProxy_userAgentHeader`