### PR TITLE
fix(transformations): process first frame in Grouping to Matrix when …

### DIFF
--- a/packages/grafana-data/src/transformations/transformers/groupingToMatrix.test.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupingToMatrix.test.ts
@@ -334,6 +334,62 @@ describe('Grouping to Matrix', () => {
     });
   });
 
+  it('processes first frame and passes through remaining frames', async () => {
+    const cfg: DataTransformerConfig<GroupingToMatrixTransformerOptions> = {
+      id: DataTransformerID.groupingToMatrix,
+      options: {
+        columnField: 'Column',
+        rowField: 'Row',
+        valueField: 'Temp',
+      },
+    };
+
+    const seriesA = toDataFrame({
+      name: 'A',
+      fields: [
+        { name: 'Column', type: FieldType.string, values: ['C1', 'C1', 'C2'] },
+        { name: 'Row', type: FieldType.string, values: ['R1', 'R2', 'R1'] },
+        { name: 'Temp', type: FieldType.number, values: [1, 4, 5] },
+      ],
+    });
+
+    const seriesB = toDataFrame({
+      name: 'B',
+      fields: [
+        { name: 'Time', type: FieldType.time, values: [1000, 2000] },
+        { name: 'Value', type: FieldType.number, values: [10, 20] },
+      ],
+    });
+
+    await expect(transformDataFrame([cfg], [seriesA, seriesB])).toEmitValuesWith((received) => {
+      const processed = received[0];
+
+      expect(processed).toHaveLength(2);
+
+      expect(processed[0].fields).toEqual([
+        { name: 'Row\\Column', type: FieldType.string, values: ['R1', 'R2'], config: {} },
+        { name: 'C1', type: FieldType.number, values: [1, 4], config: {} },
+        { name: 'C2', type: FieldType.number, values: [5, ''], config: {} },
+      ]);
+
+      expect(processed[1].name).toBe('B');
+      expect(processed[1].fields[0].name).toBe('Time');
+      expect(processed[1].fields[1].name).toBe('Value');
+    });
+  });
+
+  it('returns empty array for empty input', async () => {
+    const cfg: DataTransformerConfig<GroupingToMatrixTransformerOptions> = {
+      id: DataTransformerID.groupingToMatrix,
+      options: {},
+    };
+
+    await expect(transformDataFrame([cfg], [])).toEmitValuesWith((received) => {
+      const processed = received[0];
+      expect(processed).toHaveLength(0);
+    });
+  });
+
   it('generates Matrix ignoring special value when value type is frame', async () => {
     const cfg: DataTransformerConfig<GroupingToMatrixTransformerOptions> = {
       id: DataTransformerID.groupingToMatrix,

--- a/packages/grafana-data/src/transformations/transformers/groupingToMatrix.ts
+++ b/packages/grafana-data/src/transformations/transformers/groupingToMatrix.ts
@@ -65,8 +65,7 @@ export const groupingToMatrixTransformer: DataTransformerInfo<GroupingToMatrixTr
         const valueFieldMatch = options.valueField || DEFAULT_VALUE_FIELD;
         const emptyValue = options.emptyValue || DEFAULT_EMPTY_VALUE;
 
-        // Accept only single queries
-        if (data.length !== 1) {
+        if (data.length < 1) {
           return data;
         }
 
@@ -140,6 +139,7 @@ export const groupingToMatrixTransformer: DataTransformerInfo<GroupingToMatrixTr
             fields,
             length: rowValues.length,
           },
+          ...data.slice(1),
         ];
       })
     ),

--- a/public/app/features/transformers/editors/GroupingToMatrixTransformerEditor.tsx
+++ b/public/app/features/transformers/editors/GroupingToMatrixTransformerEditor.tsx
@@ -6,9 +6,9 @@ import {
   type GroupingToMatrixTransformerOptions,
   type SpecialValue,
 } from '@grafana/data';
-import { t } from '@grafana/i18n';
+import { Trans, t } from '@grafana/i18n';
 import { getTemplateSrv } from '@grafana/runtime';
-import { InlineField, InlineFieldRow, Select } from '@grafana/ui';
+import { FieldValidationMessage, InlineField, InlineFieldRow, Select } from '@grafana/ui';
 
 import { getEmptyOptions, useAllFieldNamesFromDataFrames } from '../utils';
 
@@ -66,6 +66,14 @@ export const GroupingToMatrixTransformerEditor = ({
 
   return (
     <>
+      {input.length > 1 && (
+        <FieldValidationMessage>
+          <Trans i18nKey="transformers.grouping-to-matrix-transformer-editor.multiple-frames-warning">
+            Grouping to matrix only processes the first data frame. Consider applying a merge or join transformation
+            first.
+          </Trans>
+        </FieldValidationMessage>
+      )}
       <InlineFieldRow>
         <InlineField
           label={t('transformers.grouping-to-matrix-transformer-editor.label-column', 'Column')}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -16054,6 +16054,7 @@
       "label-column": "Column",
       "label-empty-value": "Empty value",
       "label-row": "Row",
+      "multiple-frames-warning": "Grouping to matrix only processes the first data frame. Consider applying a merge or join transformation first.",
       "name": {
         "grouping-to-matrix": "Grouping to matrix"
       }


### PR DESCRIPTION
**What is this feature?**

The Grouping to Matrix transformation now processes the first data frame when multiple frames are present. Only the first frame is transformed into a matrix; all remaining frames are passed through unchanged. An inline warning informs the user that only the first frame is processed.

**Why do we need this feature?**

Previously, the transformation silently returned data unchanged when multiple frames were present (`data.length !== 1`), with no indication to the user why it wasn't working.

**Who is this feature for?**

Users applying Grouping to Matrix in panels with multiple queries or data sources.

**Which issue(s) does this PR fix?**:

Fixes #82343

**Special notes for your reviewer:**

- Single-frame behavior is completely unchanged - all existing tests pass as-is.
- The inline editor warning follows the same pattern as the Organize Fields transformation.
- Two new unit tests cover multi-frame processing and empty input.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.