### PR TITLE
Dashboards: Populate storedVersion from decoded object GVK

### DIFF
--- a/apps/dashboard/pkg/apis/dashboard/v0alpha1/conversion.go
+++ b/apps/dashboard/pkg/apis/dashboard/v0alpha1/conversion.go
@@ -51,3 +51,19 @@ func (d *Dashboard) SetAPIVersion(version string) {
 func (d *Dashboard) EnsureDefaultSpec() {
 	// v0alpha1 doesn't require default spec setup
 }
+
+// SetDecodedVersion implements apistore.DecodedVersionAware. It records the
+// API version the codec just decoded onto status.conversion.storedVersion,
+// preserving any existing failed/error/source fields. This is the
+// authoritative ground truth at the storage boundary: the decoded GVK is
+// the on-disk version, so it overwrites any stale value that may have been
+// encoded into the stored bytes.
+func (d *Dashboard) SetDecodedVersion(version string) {
+	if version == "" {
+		return
+	}
+	if d.Status.Conversion == nil {
+		d.Status.Conversion = &DashboardConversionStatus{}
+	}
+	d.Status.Conversion.StoredVersion = new(version)
+}

--- a/apps/dashboard/pkg/apis/dashboard/v1/conversion.go
+++ b/apps/dashboard/pkg/apis/dashboard/v1/conversion.go
@@ -51,3 +51,17 @@ func (d *Dashboard) SetAPIVersion(version string) {
 func (d *Dashboard) EnsureDefaultSpec() {
 	// v1 doesn't require default spec setup
 }
+
+// SetDecodedVersion implements apistore.DecodedVersionAware. It records the
+// API version the codec just decoded onto status.conversion.storedVersion,
+// preserving any existing failed/error/source fields. The same method
+// serves both v1 and v1beta1, since v1beta1 is a type alias for v1.
+func (d *Dashboard) SetDecodedVersion(version string) {
+	if version == "" {
+		return
+	}
+	if d.Status.Conversion == nil {
+		d.Status.Conversion = &DashboardConversionStatus{}
+	}
+	d.Status.Conversion.StoredVersion = new(version)
+}

--- a/apps/dashboard/pkg/apis/dashboard/v2/conversion.go
+++ b/apps/dashboard/pkg/apis/dashboard/v2/conversion.go
@@ -50,3 +50,16 @@ func (d *Dashboard) SetAPIVersion(version string) {
 
 // EnsureDefaultSpec is a no-op for v2: its typed spec fields are safe at zero values.
 func (d *Dashboard) EnsureDefaultSpec() {}
+
+// SetDecodedVersion implements apistore.DecodedVersionAware. It records the
+// API version the codec just decoded onto status.conversion.storedVersion,
+// preserving any existing failed/error/source fields.
+func (d *Dashboard) SetDecodedVersion(version string) {
+	if version == "" {
+		return
+	}
+	if d.Status.Conversion == nil {
+		d.Status.Conversion = &DashboardConversionStatus{}
+	}
+	d.Status.Conversion.StoredVersion = new(version)
+}

--- a/apps/dashboard/pkg/apis/dashboard/v2alpha1/conversion.go
+++ b/apps/dashboard/pkg/apis/dashboard/v2alpha1/conversion.go
@@ -54,3 +54,16 @@ func (d *Dashboard) EnsureDefaultSpec() {
 		d.Spec.Layout.GridLayoutKind = NewDashboardGridLayoutKind()
 	}
 }
+
+// SetDecodedVersion implements apistore.DecodedVersionAware. It records the
+// API version the codec just decoded onto status.conversion.storedVersion,
+// preserving any existing failed/error/source fields.
+func (d *Dashboard) SetDecodedVersion(version string) {
+	if version == "" {
+		return
+	}
+	if d.Status.Conversion == nil {
+		d.Status.Conversion = &DashboardConversionStatus{}
+	}
+	d.Status.Conversion.StoredVersion = new(version)
+}

--- a/apps/dashboard/pkg/apis/dashboard/v2beta1/conversion.go
+++ b/apps/dashboard/pkg/apis/dashboard/v2beta1/conversion.go
@@ -54,3 +54,16 @@ func (d *Dashboard) EnsureDefaultSpec() {
 		d.Spec.Layout.GridLayoutKind = NewDashboardGridLayoutKind()
 	}
 }
+
+// SetDecodedVersion implements apistore.DecodedVersionAware. It records the
+// API version the codec just decoded onto status.conversion.storedVersion,
+// preserving any existing failed/error/source fields.
+func (d *Dashboard) SetDecodedVersion(version string) {
+	if version == "" {
+		return
+	}
+	if d.Status.Conversion == nil {
+		d.Status.Conversion = &DashboardConversionStatus{}
+	}
+	d.Status.Conversion.StoredVersion = new(version)
+}

--- a/apps/dashboard/pkg/migration/conversion/conversion.go
+++ b/apps/dashboard/pkg/migration/conversion/conversion.go
@@ -56,6 +56,24 @@ func setConversionStatus(in DashboardConversion, out DashboardConversion, err er
 	out.SetConversionStatus(storedVersion, err != nil, errMsg, source)
 }
 
+// EnsureStoredVersion fills status.conversion.storedVersion on the given dashboard
+// from the supplied fallback version when it is missing or empty.
+//
+// Same-version reads (e.g., a v2beta1 GET against bytes stored as v2beta1) bypass
+// every external-to-external AddConversionFunc, so normalizeConversion never runs
+// and any stale storedVersion already encoded in the stored bytes leaks through.
+// Read-path DTO builders use this helper to ground storedVersion in the actual
+// decoded GVK they are about to return.
+func EnsureStoredVersion(d DashboardConversion, fallback string) {
+	if d == nil || fallback == "" {
+		return
+	}
+	if d.GetStoredVersion() != "" {
+		return
+	}
+	d.SetConversionStatus(fallback, false, nil, nil)
+}
+
 // setMetadata copies ObjectMeta and Kind from input to output, and sets output's APIVersion.
 func setMetadata(in, out DashboardConversion) {
 	out.SetObjectMeta(in.GetObjectMeta())

--- a/apps/dashboard/pkg/migration/conversion/conversion_test.go
+++ b/apps/dashboard/pkg/migration/conversion/conversion_test.go
@@ -298,6 +298,174 @@ func TestConversionErrorPathPreservesMetadataAndStatus(t *testing.T) {
 	}
 }
 
+// TestEnsureStoredVersion verifies that EnsureStoredVersion only populates
+// storedVersion when the dashboard is missing one, and that it never clobbers
+// an existing value (so cross-version conversions that already populated
+// storedVersion via normalizeConversion are preserved).
+func TestEnsureStoredVersion(t *testing.T) {
+	existing := "v2beta1"
+	tests := []struct {
+		name             string
+		dashboard        DashboardConversion
+		fallback         string
+		expectedStored   string
+		expectedFailed   bool
+		expectedHasError bool
+	}{
+		{
+			name:           "v0alpha1 empty status gets fallback",
+			dashboard:      &dashv0.Dashboard{},
+			fallback:       dashv0.VERSION,
+			expectedStored: dashv0.VERSION,
+		},
+		{
+			name:           "v1 empty status gets fallback",
+			dashboard:      &dashv1.Dashboard{},
+			fallback:       dashv1.VERSION,
+			expectedStored: dashv1.VERSION,
+		},
+		{
+			name:           "v2alpha1 empty status gets fallback",
+			dashboard:      &dashv2alpha1.Dashboard{},
+			fallback:       dashv2alpha1.VERSION,
+			expectedStored: dashv2alpha1.VERSION,
+		},
+		{
+			name:           "v2beta1 empty status gets fallback",
+			dashboard:      &dashv2beta1.Dashboard{},
+			fallback:       dashv2beta1.VERSION,
+			expectedStored: dashv2beta1.VERSION,
+		},
+		{
+			name:           "v2 empty status gets fallback",
+			dashboard:      &dashv2.Dashboard{},
+			fallback:       dashv2.VERSION,
+			expectedStored: dashv2.VERSION,
+		},
+		{
+			name: "existing storedVersion is not overwritten",
+			dashboard: &dashv1.Dashboard{
+				Status: dashv1.DashboardStatus{
+					Conversion: &dashv1.DashboardConversionStatus{
+						StoredVersion: &existing,
+					},
+				},
+			},
+			fallback:       dashv1.VERSION,
+			expectedStored: existing,
+		},
+		{
+			name: "failed conversion status with storedVersion is preserved",
+			dashboard: func() DashboardConversion {
+				d := &dashv0.Dashboard{}
+				errMsg := "boom"
+				d.SetConversionStatus(existing, true, &errMsg, nil)
+				return d
+			}(),
+			fallback:         dashv0.VERSION,
+			expectedStored:   existing,
+			expectedFailed:   true,
+			expectedHasError: true,
+		},
+		{
+			name:           "empty fallback is a no-op when storedVersion is missing",
+			dashboard:      &dashv1.Dashboard{},
+			fallback:       "",
+			expectedStored: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			EnsureStoredVersion(tt.dashboard, tt.fallback)
+			require.Equal(t, tt.expectedStored, tt.dashboard.GetStoredVersion())
+
+			// Spot-check that we did not clobber Failed/Error when an existing
+			// status was already in place.
+			switch d := tt.dashboard.(type) {
+			case *dashv0.Dashboard:
+				if tt.expectedFailed || tt.expectedHasError {
+					require.NotNil(t, d.Status.Conversion)
+					require.Equal(t, tt.expectedFailed, d.Status.Conversion.Failed)
+					if tt.expectedHasError {
+						require.NotNil(t, d.Status.Conversion.Error)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestStoredVersionAcrossStoredAndRequestedVersionPairs simulates the three
+// scenarios called out by https://github.com/grafana/grafana/issues/124675:
+//   - Same-version read returns the stored bytes' version.
+//   - Cross-version read with conversion returns the stored bytes' version,
+//     not the requested version.
+//   - Legacy v0alpha1 same-version read returns v0alpha1.
+//
+// We model "decoded bytes" by constructing a typed dashboard of the stored
+// version and either applying the registered scheme conversion (cross-version)
+// or running EnsureStoredVersion against the same type (same-version).
+func TestStoredVersionAcrossStoredAndRequestedVersionPairs(t *testing.T) {
+	dsProvider := migrationtestutil.NewDataSourceProvider(migrationtestutil.StandardTestConfig)
+	leProvider := migrationtestutil.NewTestLibraryElementProvider()
+	migration.Initialize(dsProvider, leProvider, migration.DefaultCacheTTL)
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, RegisterConversions(scheme, dsProvider, leProvider))
+
+	t.Run("same-version read v2beta1/v2beta1 returns v2beta1", func(t *testing.T) {
+		stored := &dashv2beta1.Dashboard{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "d"},
+			Spec: dashv2beta1.DashboardSpec{
+				Title: "t",
+				Layout: dashv2beta1.DashboardGridLayoutKindOrRowsLayoutKindOrAutoGridLayoutKindOrTabsLayoutKind{
+					GridLayoutKind: &dashv2beta1.DashboardGridLayoutKind{
+						Kind: "GridLayout",
+						Spec: dashv2beta1.DashboardGridLayoutSpec{},
+					},
+				},
+			},
+		}
+		// No AddConversionFunc fires for same-version reads, so the DTO builder
+		// is the only thing that can populate storedVersion.
+		EnsureStoredVersion(stored, dashv2beta1.VERSION)
+		require.Equal(t, dashv2beta1.VERSION, stored.GetStoredVersion())
+	})
+
+	t.Run("cross-version read v2beta1 stored, v1 requested returns v2beta1", func(t *testing.T) {
+		stored := &dashv2beta1.Dashboard{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "d"},
+			Spec: dashv2beta1.DashboardSpec{
+				Title: "t",
+				Layout: dashv2beta1.DashboardGridLayoutKindOrRowsLayoutKindOrAutoGridLayoutKindOrTabsLayoutKind{
+					GridLayoutKind: &dashv2beta1.DashboardGridLayoutKind{
+						Kind: "GridLayout",
+						Spec: dashv2beta1.DashboardGridLayoutSpec{},
+					},
+				},
+			},
+		}
+		out := &dashv1.Dashboard{}
+		require.NoError(t, scheme.Convert(stored, out, nil))
+		// normalizeConversion already populated storedVersion to the source's
+		// version. The DTO builder helper must not clobber it.
+		require.Equal(t, dashv2beta1.VERSION, out.GetStoredVersion())
+		EnsureStoredVersion(out, dashv1.VERSION)
+		require.Equal(t, dashv2beta1.VERSION, out.GetStoredVersion(),
+			"DTO-level fallback must not overwrite the version set by normalizeConversion")
+	})
+
+	t.Run("legacy same-version read v0alpha1/v0alpha1 returns v0alpha1", func(t *testing.T) {
+		stored := &dashv0.Dashboard{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "d"},
+			Spec:       common.Unstructured{Object: map[string]any{"title": "t", "schemaVersion": 42}},
+		}
+		EnsureStoredVersion(stored, dashv0.VERSION)
+		require.Equal(t, dashv0.VERSION, stored.GetStoredVersion())
+	})
+}
+
 func TestConversionMatrixExist(t *testing.T) {
 	// Initialize the migrator with a test data source provider
 	dsProvider := migrationtestutil.NewDataSourceProvider(migrationtestutil.StandardTestConfig)

--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -651,6 +651,9 @@ func (b *DashboardsAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver
 			dash, ok := obj.(*dashv0.Dashboard)
 			if ok {
 				dto.Dashboard = *dash
+				// Ground storedVersion in the decoded GVK so same-version reads do not
+				// leak whatever (possibly stale) value is encoded in the stored bytes.
+				conversion.EnsureStoredVersion(&dto.Dashboard, dashv0.DashboardResourceInfo.GroupVersion().Version)
 			}
 			if access != nil {
 				err = b.scheme.Convert(access, &dto.Access, nil)
@@ -670,6 +673,7 @@ func (b *DashboardsAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver
 			dash, ok := obj.(*dashv1beta1.Dashboard)
 			if ok {
 				dto.Dashboard = *dash
+				conversion.EnsureStoredVersion(&dto.Dashboard, dashv1beta1.DashboardResourceInfo.GroupVersion().Version)
 			}
 			if access != nil {
 				err = b.scheme.Convert(access, &dto.Access, nil)
@@ -689,6 +693,7 @@ func (b *DashboardsAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver
 			dash, ok := obj.(*dashv1.Dashboard)
 			if ok {
 				dto.Dashboard = *dash
+				conversion.EnsureStoredVersion(&dto.Dashboard, dashv1.DashboardResourceInfo.GroupVersion().Version)
 			}
 			if access != nil {
 				err = b.scheme.Convert(access, &dto.Access, nil)
@@ -708,6 +713,7 @@ func (b *DashboardsAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver
 			dash, ok := obj.(*dashv2alpha1.Dashboard)
 			if ok {
 				dto.Dashboard = *dash
+				conversion.EnsureStoredVersion(&dto.Dashboard, dashv2alpha1.DashboardResourceInfo.GroupVersion().Version)
 			}
 			if access != nil {
 				err = b.scheme.Convert(access, &dto.Access, nil)
@@ -726,6 +732,7 @@ func (b *DashboardsAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver
 			dash, ok := obj.(*dashv2beta1.Dashboard)
 			if ok {
 				dto.Dashboard = *dash
+				conversion.EnsureStoredVersion(&dto.Dashboard, dashv2beta1.DashboardResourceInfo.GroupVersion().Version)
 			}
 			if access != nil {
 				err = b.scheme.Convert(access, &dto.Access, nil)
@@ -745,6 +752,7 @@ func (b *DashboardsAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver
 			dash, ok := obj.(*dashv2.Dashboard)
 			if ok {
 				dto.Dashboard = *dash
+				conversion.EnsureStoredVersion(&dto.Dashboard, dashv2.DashboardResourceInfo.GroupVersion().Version)
 			}
 			if access != nil {
 				err = b.scheme.Convert(access, &dto.Access, nil)

--- a/pkg/registry/apis/dashboard/register_test.go
+++ b/pkg/registry/apis/dashboard/register_test.go
@@ -9,15 +9,18 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apiserver/pkg/admission"
 
+	internal "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard"
 	dashv0 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
 	dashv1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
 	dashv1beta1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1beta1"
 	dashv2 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2"
 	dashv2alpha1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1"
 	dashv2beta1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2beta1"
+	"github.com/grafana/grafana/apps/dashboard/pkg/migration/conversion"
 	common "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -321,4 +324,149 @@ func (m *mockFeatureToggles) GetEnabled(ctx context.Context) map[string]bool {
 	}
 
 	return res
+}
+
+// TestDTOBuilderStoredVersion exercises the storedVersion-population branch
+// that lives inside each per-version DTO builder closure in
+// DashboardsAPIBuilder.UpdateAPIGroupInfo. The closures are constructed inline
+// against private state, so we re-create the same expressions here, one per
+// registered version, and assert that:
+//   - When the decoded object has no storedVersion, the closure grounds the
+//     DTO in the decoded GVK (this version's GroupVersion().Version).
+//   - When the decoded object already carries a storedVersion (e.g. a
+//     cross-version read where normalizeConversion already populated it), the
+//     closure does not clobber it.
+//
+// This is the unit-level guard for
+// https://github.com/grafana/grafana/issues/124675.
+func TestDTOBuilderStoredVersion(t *testing.T) {
+	v2beta1Stored := dashv2beta1.VERSION
+
+	type testCase struct {
+		name              string
+		buildDTO          func(t *testing.T, obj runtime.Object) string
+		decoded           runtime.Object
+		expectedStoredVer string
+	}
+
+	tests := []testCase{
+		{
+			name: "v0alpha1 same-version read populates storedVersion",
+			buildDTO: func(t *testing.T, obj runtime.Object) string {
+				dto := &dashv0.DashboardWithAccessInfo{}
+				dash, ok := obj.(*dashv0.Dashboard)
+				require.True(t, ok)
+				dto.Dashboard = *dash
+				conversion.EnsureStoredVersion(&dto.Dashboard, dashv0.DashboardResourceInfo.GroupVersion().Version)
+				return dto.GetStoredVersion()
+			},
+			decoded:           &dashv0.Dashboard{},
+			expectedStoredVer: dashv0.VERSION,
+		},
+		{
+			name: "v1beta1 same-version read populates storedVersion",
+			buildDTO: func(t *testing.T, obj runtime.Object) string {
+				dto := &dashv1beta1.DashboardWithAccessInfo{}
+				dash, ok := obj.(*dashv1beta1.Dashboard)
+				require.True(t, ok)
+				dto.Dashboard = *dash
+				conversion.EnsureStoredVersion(&dto.Dashboard, dashv1beta1.DashboardResourceInfo.GroupVersion().Version)
+				return dto.GetStoredVersion()
+			},
+			decoded:           &dashv1beta1.Dashboard{},
+			expectedStoredVer: dashv1beta1.VERSION,
+		},
+		{
+			name: "v1 same-version read populates storedVersion",
+			buildDTO: func(t *testing.T, obj runtime.Object) string {
+				dto := &dashv1.DashboardWithAccessInfo{}
+				dash, ok := obj.(*dashv1.Dashboard)
+				require.True(t, ok)
+				dto.Dashboard = *dash
+				conversion.EnsureStoredVersion(&dto.Dashboard, dashv1.DashboardResourceInfo.GroupVersion().Version)
+				return dto.GetStoredVersion()
+			},
+			decoded:           &dashv1.Dashboard{},
+			expectedStoredVer: dashv1.VERSION,
+		},
+		{
+			name: "v2alpha1 same-version read populates storedVersion",
+			buildDTO: func(t *testing.T, obj runtime.Object) string {
+				dto := &dashv2alpha1.DashboardWithAccessInfo{}
+				dash, ok := obj.(*dashv2alpha1.Dashboard)
+				require.True(t, ok)
+				dto.Dashboard = *dash
+				conversion.EnsureStoredVersion(&dto.Dashboard, dashv2alpha1.DashboardResourceInfo.GroupVersion().Version)
+				return dto.GetStoredVersion()
+			},
+			decoded:           &dashv2alpha1.Dashboard{},
+			expectedStoredVer: dashv2alpha1.VERSION,
+		},
+		{
+			name: "v2beta1 same-version read populates storedVersion",
+			buildDTO: func(t *testing.T, obj runtime.Object) string {
+				dto := &dashv2beta1.DashboardWithAccessInfo{}
+				dash, ok := obj.(*dashv2beta1.Dashboard)
+				require.True(t, ok)
+				dto.Dashboard = *dash
+				conversion.EnsureStoredVersion(&dto.Dashboard, dashv2beta1.DashboardResourceInfo.GroupVersion().Version)
+				return dto.GetStoredVersion()
+			},
+			decoded:           &dashv2beta1.Dashboard{},
+			expectedStoredVer: dashv2beta1.VERSION,
+		},
+		{
+			name: "v2 same-version read populates storedVersion",
+			buildDTO: func(t *testing.T, obj runtime.Object) string {
+				dto := &dashv2.DashboardWithAccessInfo{}
+				dash, ok := obj.(*dashv2.Dashboard)
+				require.True(t, ok)
+				dto.Dashboard = *dash
+				conversion.EnsureStoredVersion(&dto.Dashboard, dashv2.DashboardResourceInfo.GroupVersion().Version)
+				return dto.GetStoredVersion()
+			},
+			decoded:           &dashv2.Dashboard{},
+			expectedStoredVer: dashv2.VERSION,
+		},
+		{
+			name: "v1 cross-version read keeps storedVersion from normalizeConversion",
+			buildDTO: func(t *testing.T, obj runtime.Object) string {
+				dto := &dashv1.DashboardWithAccessInfo{}
+				dash, ok := obj.(*dashv1.Dashboard)
+				require.True(t, ok)
+				dto.Dashboard = *dash
+				conversion.EnsureStoredVersion(&dto.Dashboard, dashv1.DashboardResourceInfo.GroupVersion().Version)
+				return dto.GetStoredVersion()
+			},
+			decoded: &dashv1.Dashboard{
+				Status: dashv1.DashboardStatus{
+					Conversion: &dashv1.DashboardConversionStatus{
+						StoredVersion: &v2beta1Stored,
+					},
+				},
+			},
+			expectedStoredVer: dashv2beta1.VERSION,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tc.buildDTO(t, tc.decoded)
+			require.Equal(t, tc.expectedStoredVer, got)
+		})
+	}
+
+	// Sanity-check: a nil access pointer (the DTO sub-resource path that does
+	// not request access info) must still produce a populated storedVersion.
+	t.Run("nil access does not change storedVersion semantics", func(t *testing.T) {
+		var access *internal.DashboardAccess
+		var obj runtime.Object = &dashv2.Dashboard{}
+		dto := &dashv2.DashboardWithAccessInfo{}
+		if dash, ok := obj.(*dashv2.Dashboard); ok {
+			dto.Dashboard = *dash
+			conversion.EnsureStoredVersion(&dto.Dashboard, dashv2.DashboardResourceInfo.GroupVersion().Version)
+		}
+		require.Nil(t, access)
+		require.Equal(t, dashv2.VERSION, dto.GetStoredVersion())
+	})
 }

--- a/pkg/storage/unified/apistore/store.go
+++ b/pkg/storage/unified/apistore/store.go
@@ -234,10 +234,40 @@ func (s *Storage) Versioner() storage.Versioner {
 	return s.versioner
 }
 
+// DecodedVersionAware is implemented by resource types that want to be
+// informed of the API version their bytes were decoded from. After every
+// decode, the storage layer calls SetDecodedVersion with the version the
+// codec just decoded.
+//
+// This lets resources record the authoritative on-disk version (e.g., onto
+// a status field) at the storage boundary, so plain Get/List/Watch reads
+// have a grounded value even though same-version reads bypass every
+// registered external-to-external conversion function.
+type DecodedVersionAware interface {
+	SetDecodedVersion(version string)
+}
+
 func (s *Storage) convertToObject(ctx context.Context, data []byte, obj runtime.Object) (runtime.Object, error) {
 	_, span := tracer.Start(ctx, "apistore.Storage.convertToObject")
 	defer span.End()
-	obj, _, err := s.codec.Decode(data, nil, obj)
+	obj, gvk, err := s.codec.Decode(data, nil, obj)
+	if err == nil && obj != nil {
+		// Prefer the GVK the codec reports for the bytes (this is the on-disk
+		// version) over the GVK on the returned typed object, which a versioning
+		// codec rewrites to the decode-target version when a conversion is
+		// applied.
+		version := ""
+		if gvk != nil && gvk.Version != "" {
+			version = gvk.Version
+		} else if kind := obj.GetObjectKind().GroupVersionKind(); kind.Version != "" {
+			version = kind.Version
+		}
+		if version != "" {
+			if setter, ok := obj.(DecodedVersionAware); ok {
+				setter.SetDecodedVersion(version)
+			}
+		}
+	}
 	return obj, err
 }
 

--- a/pkg/storage/unified/apistore/store_decoded_version_test.go
+++ b/pkg/storage/unified/apistore/store_decoded_version_test.go
@@ -1,0 +1,201 @@
+package apistore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/apitesting"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+
+	dashv0 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
+	dashv1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
+	dashv2 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2"
+	dashv2alpha1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2alpha1"
+	dashv2beta1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2beta1"
+)
+
+// newDashboardScheme builds a runtime.Scheme registering every dashboard version
+// so the codec can resolve typed Dashboard objects regardless of which version
+// the bytes carry.
+func newDashboardScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	sch := runtime.NewScheme()
+	metav1.AddToGroupVersion(sch, metav1.SchemeGroupVersion)
+	require.NoError(t, dashv0.AddToScheme(sch))
+	require.NoError(t, dashv1.AddToScheme(sch))
+	require.NoError(t, dashv2alpha1.AddToScheme(sch))
+	require.NoError(t, dashv2beta1.AddToScheme(sch))
+	require.NoError(t, dashv2.AddToScheme(sch))
+	return sch
+}
+
+// storageForVersion builds a Storage with a codec scoped to the given
+// dashboard version so that convertToObject can be driven directly.
+func storageForVersion(t *testing.T, version string) *Storage {
+	t.Helper()
+	sch := newDashboardScheme(t)
+	codecs := serializer.NewCodecFactory(sch)
+
+	var info = dashv1.DashboardResourceInfo
+	switch version {
+	case dashv0.VERSION:
+		info = dashv0.DashboardResourceInfo
+	case dashv1.VERSION:
+		info = dashv1.DashboardResourceInfo
+	case dashv2alpha1.VERSION:
+		info = dashv2alpha1.DashboardResourceInfo
+	case dashv2beta1.VERSION:
+		info = dashv2beta1.DashboardResourceInfo
+	case dashv2.VERSION:
+		info = dashv2.DashboardResourceInfo
+	default:
+		t.Fatalf("unsupported version: %s", version)
+	}
+
+	return &Storage{
+		gr:    info.GroupResource(),
+		codec: apitesting.TestCodec(codecs, info.GroupVersion()),
+		opts:  StorageOptions{Scheme: sch},
+	}
+}
+
+// TestConvertToObject_SetsDecodedVersion verifies the storage decode boundary
+// records the API version the codec just decoded onto status.conversion.storedVersion
+// via the DecodedVersionAware interface. It covers multiple dashboard versions
+// to confirm the hook is not hardcoded to any single value.
+func TestConvertToObject_SetsDecodedVersion(t *testing.T) {
+	ctx := context.Background()
+
+	cases := []struct {
+		name    string
+		version string
+		newObj  func() runtime.Object
+		// encoded ascertains we always encode against the same version as we
+		// decode. This mirrors the most common storage path: same-version
+		// reads, which is exactly where storedVersion was being dropped.
+	}{
+		{
+			name:    "v0alpha1",
+			version: dashv0.VERSION,
+			newObj:  func() runtime.Object { return &dashv0.Dashboard{} },
+		},
+		{
+			name:    "v1",
+			version: dashv1.VERSION,
+			newObj:  func() runtime.Object { return &dashv1.Dashboard{} },
+		},
+		{
+			name:    "v2alpha1",
+			version: dashv2alpha1.VERSION,
+			newObj:  func() runtime.Object { return &dashv2alpha1.Dashboard{} },
+		},
+		{
+			name:    "v2beta1",
+			version: dashv2beta1.VERSION,
+			newObj:  func() runtime.Object { return &dashv2beta1.Dashboard{} },
+		},
+		{
+			name:    "v2",
+			version: dashv2.VERSION,
+			newObj:  func() runtime.Object { return &dashv2.Dashboard{} },
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			s := storageForVersion(t, tc.version)
+
+			// Encode an empty dashboard and feed the bytes back through
+			// convertToObject. The decoded object must carry storedVersion =
+			// the on-disk version.
+			src := tc.newObj()
+			data, err := runtime.Encode(s.codec, src)
+			require.NoError(t, err)
+
+			out := tc.newObj()
+			result, err := s.convertToObject(ctx, data, out)
+			require.NoError(t, err)
+			require.NotNil(t, result)
+
+			got := storedVersionOf(t, result)
+			require.Equal(t, tc.version, got, "storedVersion must match the on-disk version")
+		})
+	}
+}
+
+// TestConvertToObject_OverwritesStaleStoredVersion verifies that the
+// DecodedVersionAware hook overwrites a stale storedVersion already present
+// in the decoded object. The decoded GVK is the ground truth; the in-bytes
+// value can be wrong (a prior bug encoded the wrong value into storage), so
+// the hook must always win.
+func TestConvertToObject_OverwritesStaleStoredVersion(t *testing.T) {
+	ctx := context.Background()
+	s := storageForVersion(t, dashv1.VERSION)
+
+	// Pre-fill the dashboard with a stale storedVersion ("v0alpha1") and a
+	// failed-conversion status. After encoding, the bytes carry that stale
+	// value; after convertToObject, storedVersion must equal v1 (the decoded
+	// version), while the failed-conversion fields are preserved.
+	stale := "v0alpha1"
+	errMsg := "boom"
+	src := &dashv1.Dashboard{
+		Status: dashv1.DashboardStatus{
+			Conversion: &dashv1.DashboardConversionStatus{
+				StoredVersion: &stale,
+				Failed:        true,
+				Error:         &errMsg,
+			},
+		},
+	}
+	data, err := runtime.Encode(s.codec, src)
+	require.NoError(t, err)
+
+	out := &dashv1.Dashboard{}
+	result, err := s.convertToObject(ctx, data, out)
+	require.NoError(t, err)
+
+	d, ok := result.(*dashv1.Dashboard)
+	require.True(t, ok)
+	require.NotNil(t, d.Status.Conversion)
+	require.NotNil(t, d.Status.Conversion.StoredVersion)
+	require.Equal(t, dashv1.VERSION, *d.Status.Conversion.StoredVersion,
+		"storedVersion must be overwritten by the decoded GVK, not preserved from the stored bytes")
+	require.True(t, d.Status.Conversion.Failed, "Failed flag must be preserved")
+	require.NotNil(t, d.Status.Conversion.Error, "Error must be preserved")
+	require.Equal(t, "boom", *d.Status.Conversion.Error)
+}
+
+// TestConvertToObject_NilObjectIsHandled verifies the hook does not panic when
+// decode produces a nil object. This shouldn't happen on a normal happy path,
+// but the guard in convertToObject must hold either way.
+func TestConvertToObject_NilObjectIsHandled(t *testing.T) {
+	ctx := context.Background()
+	s := storageForVersion(t, dashv1.VERSION)
+	// Empty bytes will produce an error and a nil/empty object.
+	_, err := s.convertToObject(ctx, []byte(""), &dashv1.Dashboard{})
+	// We tolerate either an error or a clean decode of an empty document. The
+	// only assertion is the call does not panic.
+	_ = err
+}
+
+func storedVersionOf(t *testing.T, obj runtime.Object) string {
+	t.Helper()
+	switch d := obj.(type) {
+	case *dashv0.Dashboard:
+		return d.GetStoredVersion()
+	case *dashv1.Dashboard:
+		return d.GetStoredVersion()
+	case *dashv2alpha1.Dashboard:
+		return d.GetStoredVersion()
+	case *dashv2beta1.Dashboard:
+		return d.GetStoredVersion()
+	case *dashv2.Dashboard:
+		return d.GetStoredVersion()
+	default:
+		t.Fatalf("unsupported dashboard type: %T", obj)
+		return ""
+	}
+}


### PR DESCRIPTION
## What this PR does

Grounds `status.conversion.storedVersion` on dashboard API responses in the
GVK the apiserver actually decoded, instead of leaving it at whatever was
encoded into the stored bytes (or, on cross-version reads, whatever the
in-storage value happened to be).

The fix has two complementary legs:

1. **Storage layer (primary).** A new generic opt-in interface
   `apistore.DecodedVersionAware` lets resource types be informed of the API
   version their bytes were decoded from. `Storage.convertToObject` calls it
   after every `codec.Decode`. Each of the five dashboard `Dashboard` types
   (v0alpha1, v1 which also serves v1beta1, v2alpha1, v2beta1, v2)
   implements the interface to write the decoded version onto
   `status.conversion.storedVersion`. This ensures plain Get/List/Watch
   reads come out of unified storage with a grounded value, overwriting any
   stale value already encoded in the stored bytes while preserving any
   existing `failed` / `error` / `source` fields.

2. **DTO builder (defense in depth).** Each of the six per-version DTO
   builder closures in `DashboardsAPIBuilder.UpdateAPIGroupInfo` still calls
   `conversion.EnsureStoredVersion` after `dto.Dashboard = *dash`. This is a
   no-op on the normal read path now that the storage layer fills the value
   in, but it keeps any non-storage read path (constructing a Dashboard
   without going through `convertToObject`) producing a grounded value too.

## Why

Fixes https://github.com/grafana/grafana/issues/124675

Noticed during testing of v2 dashboard reads: `status.conversion.storedVersion`
was effectively always reported as `v0alpha1`, regardless of the version the
bytes were actually stored as in unified storage. It should reflect the
storage encoding version of the resource so clients can rely on it to detect
the on-disk version.

Root cause: `status.conversion.storedVersion` is only ever written by the
`normalizeConversion` wrapper, which runs inside every registered external
to external `AddConversionFunc`. Same-version reads do not trigger any
conversion function, so the field is whatever was already in the decoded
bytes. There is no read-side population from the GVK the codec actually
decoded.

## How

- New opt-in interface `apistore.DecodedVersionAware` with a single
  `SetDecodedVersion(version string)` method. Defined in the same package
  as `Storage.convertToObject`, so the storage layer has no resource
  specific concept.
- `Storage.convertToObject` now reads the GVK reported by the codec for
  the bytes (preserved as the second return value even when a versioning
  codec rewrites the GVK on the returned typed object via conversion),
  and calls `SetDecodedVersion` on the decoded object when it satisfies
  the interface.
- Each dashboard `Dashboard` type implements `SetDecodedVersion` to set
  `status.conversion.storedVersion = version`, preserving the other
  fields on the existing conversion status struct.
- The existing `conversion.EnsureStoredVersion(d, fallback)` helper is
  kept and the six DTO builder closures continue to call it. Helper
  semantics remain "only fill if empty", so cross-version reads where
  `normalizeConversion` already populated `storedVersion` are not
  clobbered.

## Test plan

- New unit tests in `pkg/storage/unified/apistore/store_decoded_version_test.go`:
  - `TestConvertToObject_SetsDecodedVersion` exercises the decode hook
    against every dashboard version, proving the hook is not hardcoded
    to any single value.
  - `TestConvertToObject_OverwritesStaleStoredVersion` proves the hook
    overwrites a stale value in the stored bytes while preserving the
    `Failed` / `Error` fields on the conversion status.
  - `TestConvertToObject_NilObjectIsHandled` covers the nil/empty input
    guard.
- Existing unit tests in
  `apps/dashboard/pkg/migration/conversion/conversion_test.go`:
  - `TestEnsureStoredVersion` covers empty-status fill, no-clobber, failed
    conversion preservation, and empty-fallback no-op for every version.
  - `TestStoredVersionAcrossStoredAndRequestedVersionPairs` covers the
    three scenarios from the issue: same-version v2beta1 returns v2beta1,
    cross-version v2beta1 stored / v1 requested still returns v2beta1, and
    legacy same-version v0alpha1 returns v0alpha1.
- Existing unit test `TestDTOBuilderStoredVersion` in
  `pkg/registry/apis/dashboard/register_test.go` mirrors each DTO builder
  closure and asserts the storedVersion is grounded on same-version reads
  and preserved on cross-version reads.
- Existing `TestMultiStepConversionPreservesStoredVersion` continues to
  pass, so multi-step conversion semantics are not affected.

Targeted Go tests pass locally:

```
go test ./pkg/storage/unified/apistore/... \
        ./pkg/registry/apis/dashboard/... \
        ./apps/dashboard/pkg/migration/conversion/... \
        ./apps/dashboard/pkg/apis/dashboard/...
```

Manual validation: stand up a dev instance, create a v2beta1 dashboard,
GET it at `dashboard.grafana.app/v2beta1` and at `dashboard.grafana.app/v1`,
and confirm both responses report `status.conversion.storedVersion: v2beta1`.
