### PR TITLE
Logs: Highlight `w` and `y` duration units in log syntax highlighting

### DIFF
--- a/public/app/features/logs/components/panel/grammar.test.ts
+++ b/public/app/features/logs/components/panel/grammar.test.ts
@@ -87,6 +87,18 @@ describe('generateLogGrammar', () => {
     }
   );
 
+  test.each([['1w'], ['2y'], ['1y6m'], ['1w2d3h']])(
+    'Identifies durations with week/year units: %s',
+    (duration: string) => {
+      const { tokens } = generateScenario(duration);
+      if (tokens[0] instanceof Token) {
+        expect(tokens[0].content).toBe(duration);
+        expect(tokens[0].type).toBe('log-token-duration');
+      }
+      expect.assertions(3);
+    }
+  );
+
   test('Does not identify invalid duration-like strings', () => {
     const { tokens } = generateScenario('5min');
     expect(tokens.every((token) => !(token instanceof Token) || token.type !== 'log-token-duration')).toBe(true);

--- a/public/app/features/logs/components/panel/grammar.ts
+++ b/public/app/features/logs/components/panel/grammar.ts
@@ -13,7 +13,7 @@ const logsGrammar: Grammar = {
 const tokensGrammar: Grammar = {
   'log-token-uuid': /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}/g,
   'log-token-size': /(?:\b|")\d+\.{0,1}\d*\s*[kKmMGgtTPp]*[bB]{1}(?:"|\b)/g,
-  'log-token-duration': /\b(?:\d+(?:\.\d+)?(?:ns|µs|ms|s|m|h|d))+\b/g,
+  'log-token-duration': /\b(?:\d+(?:\.\d+)?(?:ns|µs|ms|s|m|h|d|w|y))+\b/g,
   'log-token-method': /\b(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS|TRACE|CONNECT)\b/g,
 };
 


### PR DESCRIPTION
**What is this feature?**

Adds week (`w`) and year (`y`) units to the `log-token-duration` regex in the Logs panel syntax highlighting (`public/app/features/logs/components/panel/grammar.ts`), so values like `1w`, `2y`, `1y6m`, and `1w2d3h` are highlighted consistently with shorter durations.

**Why do we need this feature?**

The current unit list (`ns | µs | ms | s | m | h | d`) is inconsistent with the precedent already established elsewhere in the codebase for "Grafana extended" duration units:

- `packages/grafana-data/src/datetime/durationutil.ts` defines `isValidGrafanaDuration()` which accepts `y, M, w, d, h, m, s, ms, us, µs, ns`. The time range picker uses this validator, so users can already enter `5w` or `2y` as time ranges.
- `public/app/plugins/datasource/loki/syntax.ts` already highlights `w` and `y` in the Loki query editor's range selectors (`/\b\d+[smhdwy]\b/i`).

The Logs panel grammar already includes `d` (which is outside Go's `time.Duration` set), so the precedent for "Grafana extended duration" units in log highlighting is established — but the list stops at `d` and is missing `w` and `y`. This PR closes that gap.

**Who is this feature for?**

Users of Grafana Logs / Explore who view log streams containing long-range duration values (Loki / Prometheus / scheduler output). It improves visual consistency with adjacent Grafana features.

**Which issue(s) does this PR fix?**:

Closes #124432

**Special notes for your reviewer:**

- The change is intentionally minimal: only `w` and `y` are added to the existing alternation. Multi-unit composition (e.g. `1y6m`) is supported automatically because the surrounding pattern already allows segment repetition (added in #124433).
- Tests for `1w`, `2y`, `1y6m`, `1w2d3h` were added in `grammar.test.ts`. The existing negative test (`5min`) still passes — adding `w`/`y` does not introduce false positives there.
- `M` (months) was intentionally left out: it is case-sensitive in `isValidGrafanaDuration`, could collide with the `M` in the size suffix used by `log-token-size`, and the regex is not case-insensitive. Worth a separate discussion if desired.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.