### PR TITLE
Search: downgrade Bleve to v2.5.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/aws/smithy-go v1.25.1 // @grafana/data-sources-plugins
 	github.com/beevik/etree v1.6.0 // @grafana/grafana-backend-group
 	github.com/benbjohnson/clock v1.3.5 // @grafana/alerting-backend
-	github.com/blevesearch/bleve/v2 v2.6.0 // @grafana/grafana-search-and-storage
+	github.com/blevesearch/bleve/v2 v2.5.7 // @grafana/grafana-search-and-storage
 	github.com/blevesearch/bleve_index_api v1.3.11 // @grafana/grafana-search-and-storage
 	github.com/bradfitz/gomemcache v0.0.0-20250403215159-8d39553ac7cf // @grafana/grafana-backend-group
 	github.com/bwmarrin/snowflake v0.3.0 // @grafana/grafana-app-platform-squad
@@ -397,7 +397,6 @@ require (
 	github.com/blevesearch/zapx/v14 v14.4.3 // indirect
 	github.com/blevesearch/zapx/v15 v15.4.3 // indirect
 	github.com/blevesearch/zapx/v16 v16.3.4 // indirect
-	github.com/blevesearch/zapx/v17 v17.1.2 // indirect
 	github.com/bufbuild/protocompile v0.14.1 // indirect
 	github.com/buger/jsonparser v1.1.2 // indirect
 	github.com/c2h5oh/datasize v0.0.0-20231215233829-aa82cc1e6500 // indirect

--- a/go.sum
+++ b/go.sum
@@ -931,8 +931,8 @@ github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdn
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
-github.com/blevesearch/bleve/v2 v2.6.0 h1:Cyd3dd4q5tCbOV8MnKUVRUDYMHOir9xn12NZzXVSEd4=
-github.com/blevesearch/bleve/v2 v2.6.0/go.mod h1:gLmI8lWgHgrIYf7UpUX7JISI1CaqC6VScu46mHThuAY=
+github.com/blevesearch/bleve/v2 v2.5.7 h1:2d9YrL5zrX5EBBW++GOaEKjE+NPWeZGaX77IM26m1Z8=
+github.com/blevesearch/bleve/v2 v2.5.7/go.mod h1:yj0NlS7ocGC4VOSAedqDDMktdh2935v2CSWOCDMHdSA=
 github.com/blevesearch/bleve_index_api v1.3.11 h1:x29vbV8OjWfLcrDVd7Lr1q+BkLNS0JWNEig0MCVnKH4=
 github.com/blevesearch/bleve_index_api v1.3.11/go.mod h1:xvd48t5XMeeioWQ5/jZvgLrV98flT2rdvEJ3l/ki4Ko=
 github.com/blevesearch/geo v0.2.5 h1:yJg9FX1oRwLnjXSXF+ECHfXFTF4diF02Ca/qUGVjJhE=
@@ -967,8 +967,6 @@ github.com/blevesearch/zapx/v15 v15.4.3 h1:iJiMJOHrz216jyO6lS0m9RTCEkprUnzvqAI2l
 github.com/blevesearch/zapx/v15 v15.4.3/go.mod h1:1pssev/59FsuWcgSnTa0OeEpOzmhtmr/0/11H0Z8+Nw=
 github.com/blevesearch/zapx/v16 v16.3.4 h1:hDAqA8qusZTNbPEL7//w5P65UZ2de6yhSeUaTbp0Po0=
 github.com/blevesearch/zapx/v16 v16.3.4/go.mod h1:zqkPPqs9GS9FzVWzCO3Wf1X044yWAV17+4zb+FTiEHg=
-github.com/blevesearch/zapx/v17 v17.1.2 h1:avbOk2igaASNoiy0BE/jPgcxAnRI2PGeydeP4hg7Ikk=
-github.com/blevesearch/zapx/v17 v17.1.2/go.mod h1:WQObxKrqUX7cd0G1GMvDfc/bmZzQvoy7APOPimx7DiI=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/boombuler/barcode v1.0.1/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=

--- a/go.work.sum
+++ b/go.work.sum
@@ -558,6 +558,8 @@ github.com/bits-and-blooms/bitset v1.22.0/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6
 github.com/bits-and-blooms/bitset v1.24.2/go.mod h1:7hO7Gc7Pp1vODcmWvKMRA9BNmbv6a/7QIWpPxHddWR8=
 github.com/bits-and-blooms/bloom/v3 v3.7.1 h1:WXovk4TRKZttAMJfoQx6K2DM0zNIt8w+c67UqO+etV0=
 github.com/bits-and-blooms/bloom/v3 v3.7.1/go.mod h1:rZzYLLje2dfzXfAkJNxQQHsKurAyK55KUnL43Euk0hU=
+github.com/blevesearch/bleve/v2 v2.5.7 h1:2d9YrL5zrX5EBBW++GOaEKjE+NPWeZGaX77IM26m1Z8=
+github.com/blevesearch/bleve/v2 v2.5.7/go.mod h1:yj0NlS7ocGC4VOSAedqDDMktdh2935v2CSWOCDMHdSA=
 github.com/blevesearch/bleve_index_api v1.3.0/go.mod h1:xvd48t5XMeeioWQ5/jZvgLrV98flT2rdvEJ3l/ki4Ko=
 github.com/blevesearch/go-metrics v0.0.0-20201227073835-cf1acfcdf475 h1:kDy+zgJFJJoJYBvdfBSiZYBbdsUL0XcjHYWezpQBGPA=
 github.com/blevesearch/go-metrics v0.0.0-20201227073835-cf1acfcdf475/go.mod h1:9eJDeqxJ3E7WnLebQUlPD7ZjSce7AnDb9vjGmMCbD0A=

--- a/pkg/storage/unified/search/bleve_mappings_test.go
+++ b/pkg/storage/unified/search/bleve_mappings_test.go
@@ -5,7 +5,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/blevesearch/bleve/v2"
 	"github.com/blevesearch/bleve/v2/document"
+	"github.com/blevesearch/bleve/v2/index/scorch"
+	"github.com/blevesearch/bleve/v2/index/scorch/mergeplan"
 	"github.com/blevesearch/bleve/v2/mapping"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -126,6 +129,73 @@ func TestTermVectorsAndFreqNorm(t *testing.T) {
 				"field %q needs freq/norm for BM25 scoring", name)
 		}
 	}
+}
+
+func TestStoredTitleSurvivesMergeAfterDelete(t *testing.T) {
+	mappings, err := search.GetBleveMappings(nil, nil)
+	require.NoError(t, err)
+
+	idx, err := bleve.NewUsing(t.TempDir(), mappings, bleve.Config.DefaultIndexType, bleve.Config.DefaultKVStore, nil)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, idx.Close()) }()
+
+	const docCount = 3000
+	batch := idx.NewBatch()
+	for i := range docCount {
+		title := fmt.Sprintf("Dashboard title %04d", i)
+		doc := resource.IndexableDocument{
+			Name:        fmt.Sprintf("dash-%05d", i),
+			Title:       title,
+			Description: "description",
+			Folder:      "folder",
+		}
+		doc.UpdateCopyFields()
+
+		require.NoError(t, batch.Index(fmt.Sprintf("id-%05d", i), doc))
+		if batch.Size() >= 1000 {
+			require.NoError(t, idx.Batch(batch))
+			batch = idx.NewBatch()
+		}
+	}
+	if batch.Size() > 0 {
+		require.NoError(t, idx.Batch(batch))
+	}
+
+	require.NoError(t, idx.Delete("id-01000"))
+
+	advancedIndex, err := idx.Advanced()
+	require.NoError(t, err)
+
+	// Grafana creates indexes with Bleve's default index type, which is Scorch.
+	// Merges normally happen in the background; ForceMerge makes that path deterministic for this test.
+	advanced, ok := advancedIndex.(*scorch.Scorch)
+	require.True(t, ok)
+	require.NoError(t, advanced.ForceMerge(t.Context(), &mergeplan.SingleSegmentMergePlanOptions))
+
+	query := bleve.NewMatchQuery("dashboard")
+	query.SetField(resource.SEARCH_FIELD_TITLE)
+	req := bleve.NewSearchRequestOptions(query, docCount, 0, false)
+	req.Fields = []string{resource.SEARCH_FIELD_TITLE}
+
+	result, err := idx.Search(req)
+	require.NoError(t, err)
+	require.Equal(t, uint64(docCount-1), result.Total)
+
+	missingTitles := 0
+	missingTitleExamples := make([]string, 0, 10)
+	for _, hit := range result.Hits {
+		title, ok := hit.Fields[resource.SEARCH_FIELD_TITLE].(string)
+		if !ok || title == "" {
+			missingTitles++
+			if len(missingTitleExamples) < cap(missingTitleExamples) {
+				missingTitleExamples = append(missingTitleExamples, hit.ID)
+			}
+		}
+	}
+
+	// Dashboard search can still match indexed title terms when this regresses,
+	// but clients display the stored title returned in the search hit.
+	require.Zero(t, missingTitles, "stored title missing for %d docs; examples: %v", missingTitles, missingTitleExamples)
 }
 
 func TestDocValuesConfiguration(t *testing.T) {


### PR DESCRIPTION
This downgrades Bleve from v2.6.0 to v2.5.7.

We observed dashboard search results matching dashboards but returning empty titles. The affected Bleve indexes still contained searchable title terms and `title_phrase` doc values, but the stored `title` field was missing for documents in merged Scorch segments.

The added regression test reproduces this with Grafana's dashboard search mappings: index dashboards, delete one document, force a Scorch merge, then verify all matched documents still return a stored title.

This keeps the revert focused on Bleve only, rather than reverting the full dependency update from #124545.