### PR TITLE
Annotations: Prevent runtime error on invalid annotation color

### DIFF
--- a/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin2Cluster.test.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin2Cluster.test.tsx
@@ -6,6 +6,7 @@ import uPlot from 'uplot';
 import {
   applyFieldOverrides,
   arrayToDataFrame,
+  colorManipulator,
   createDataFrame,
   createTheme,
   dateTimeFormat,
@@ -917,6 +918,21 @@ describe('AnnotationsPlugin2', () => {
         expect(ctx.setLineDash).toHaveBeenCalledWith([5, 5]);
         // Yes region fill
         expect(ctx.fillRect).toHaveBeenCalled();
+      });
+      it('falls back to default fill color when alpha throws for invalid annotation color', () => {
+        const alphaSpy = jest.spyOn(colorManipulator, 'alpha').mockImplementationOnce(() => {
+          throw new Error('invalid color');
+        });
+        const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        setUp({ annotations: [mockIRMAnnotationRegion] }, config);
+        const mockU = createMockUPlot();
+        const ctx = mockU.ctx as jest.Mocked<CanvasRenderingContext2D>;
+        invokeDrawHook(hooks, mockU);
+        expect(ctx.fillRect).toHaveBeenCalled();
+        expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('Invalid color:'), expect.any(Error));
+
+        alphaSpy.mockRestore();
+        consoleErrorSpy.mockRestore();
       });
       it('multi-lane disables indicator line and rect fill', () => {
         setUp({

--- a/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin2Cluster.tsx
+++ b/public/app/plugins/panel/timeseries/plugins/AnnotationsPlugin2Cluster.tsx
@@ -193,7 +193,14 @@ export const AnnotationsPlugin2Cluster = ({
                 renderLine(ctx, y0, y1, x1, color);
 
                 if (canvasRegionRendering) {
-                  ctx.fillStyle = colorManipulator.alpha(color, regionOpacity ?? 0.1);
+                  // stop invalid colors from breaking the panel
+                  try {
+                    ctx.fillStyle = colorManipulator.alpha(color, regionOpacity ?? 0.1);
+                  } catch (e) {
+                    console.error(`Invalid color: ${color}.`, e);
+                    ctx.fillStyle = colorManipulator.alpha(DEFAULT_ANNOTATION_COLOR_HEX8, regionOpacity ?? 0.1);
+                  }
+
                   ctx.fillRect(x0, y0, x1 - x0, u.bbox.height);
                 }
               }


### PR DESCRIPTION
**What is this fix?**

Fixes annotations with invalid colors from breaking the panel.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/124715

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
