### PR TITLE
Feature toggle: introduce grafana.enableScopesFirstMode

### DIFF
--- a/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
@@ -42,7 +42,8 @@ declare module "@openfeature/core" {
     | "datasources.apiserver.useNewAPIsForDatasourceResources"
     | "reporting.anyPageReporting"
     | "assistant.frontend.tools.dashboardTemplates"
-    | "grafana.unifiedHomepage";
+    | "grafana.unifiedHomepage"
+    | "grafana.enableScopesFirstMode";
   export type NumberFlagKey = never;
   export type StringFlagKey = never;
   export type ObjectFlagKey = never;

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -35,6 +35,8 @@ export const FlagKeys = {
   FaroSessionReplay: "faroSessionReplay",
   /** Enables the new Flame Graph UI containing the Call Tree view */
   FlameGraphWithCallTree: "flameGraphWithCallTree",
+  /** Enables UI changes for integrations that require a scope to always be selected (for example, hides the scope selector's Remove all button) */
+  GrafanaEnableScopesFirstMode: "grafana.enableScopesFirstMode",
   /** Whether to use the new SharedPreferences functional component */
   GrafanaNewPreferencesPage: "grafana.newPreferencesPage",
   /** Enables org-defined dashboard templates for enterprise */
@@ -200,6 +202,17 @@ export const useFlagFaroSessionReplay = (options?: ReactFlagEvaluationOptions): 
  */
 export const useFlagFlameGraphWithCallTree = (options?: ReactFlagEvaluationOptions): boolean => {
   return useFlag("flameGraphWithCallTree", false, options).value;
+};
+
+/**
+ * Enables UI changes for integrations that require a scope to always be selected (for example, hides the scope selector's Remove all button)
+ *
+ * **Details:**
+ * - flag key: `grafana.enableScopesFirstMode`
+ * - default value: `false`
+ */
+export const useFlagGrafanaEnableScopesFirstMode = (options?: ReactFlagEvaluationOptions): boolean => {
+  return useFlag("grafana.enableScopesFirstMode", false, options).value;
 };
 
 /**

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -3139,6 +3139,15 @@ var (
 			RequiresRestart: true,
 			Expression:      "false",
 		},
+		{
+			Name:         "grafana.enableScopesFirstMode",
+			Description:  "Enables UI changes for integrations that require a scope to always be selected (for example, hides the scope selector's Remove all button)",
+			Stage:        FeatureStageExperimental,
+			Owner:        grafanaOperatorExperienceSquad,
+			HideFromDocs: true,
+			Expression:   "false",
+			Generate:     Generate{React: true},
+		},
 		// tl;dr: name your new flag `component.featureName`, specify Go and/or React generation targets, and use with OpenFeature!
 		//
 		// Adding a new feature flag? Be sure to check out the updated docs at /contribute/feature-toggles.md#Steps-to-adding-a-feature-toggle

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -366,3 +366,4 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-05-06,preferences.rerouteLegacyAPIs,experimental,@grafana/grafana-frontend-platform,false,false,false
 2026-05-05,plugins.marketplaceLicensing,experimental,@grafana/plugins-platform-backend,false,true,false
 2026-05-11,alerting.syncExternalAlertmanager,experimental,@grafana/alerting-squad,false,true,false
+2026-05-12,grafana.enableScopesFirstMode,experimental,@grafana/grafana-operator-experience-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2743,6 +2743,21 @@
     },
     {
       "metadata": {
+        "name": "grafana.enableScopesFirstMode",
+        "resourceVersion": "1778616044322",
+        "creationTimestamp": "2026-05-12T20:00:44Z"
+      },
+      "spec": {
+        "description": "Enables UI changes for integrations that require a scope to always be selected (for example, hides the scope selector's Remove all button)",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-operator-experience-squad",
+        "frontend": true,
+        "hideFromDocs": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "grafana.meticulousAIRecorder",
         "resourceVersion": "1777401759422",
         "creationTimestamp": "2026-04-28T17:20:14Z",


### PR DESCRIPTION
## Summary

Adds OpenFeature flag `grafana.enableScopesFirstMode` to gate UI changes for integrations that require a scope to always be selected. Off by default and hidden from docs while customer rollout is scoped.

This PR registers the flag only. Feature code that uses the flag will land separately to satisfy the `pr-mt-service-compatibility` FE/BE separation.

## Naming note for reviewers

The suffix `enableScopesFirstMode` matches the name proposed in [the issue comment](https://github.com/grafana/hyperion-planning/issues/615#issuecomment-4405291731). The dotted `grafana.` prefix is required by `contribute/feature-toggles.md`. Most recent flags in the registry use noun-phrase suffixes without an `enable*` verb (e.g. `grafana.unifiedHomepage`, `grafana.newPreferencesPage`) — open to renaming to `grafana.scopesFirstMode` if you prefer that form.

## Test plan

- [ ] `make gen-feature-toggles` produces no further diff
- [ ] `go test ./pkg/services/featuremgmt/...` passes
- [ ] Generated hook `useFlagGrafanaEnableScopesFirstMode` is importable from `@grafana/runtime/internal`

Refs: grafana/hyperion-planning#615, grafana/hyperion-planning#616