### PR TITLE
DS-Querier: Mark context cancelled requests as downstream

### DIFF
--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -147,13 +147,16 @@ func (b *QueryAPIBuilder) QueryDatasources(w http.ResponseWriter, httpreq *http.
 	qdr, err := handleQuery(ctx, *raw, *b, httpreq, responder, connectLogger)
 
 	if err != nil {
-		if errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
+		ctxCanceled := errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled)
+		ctxDeadline := errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded)
+
+		if ctxDeadline {
 			connectLogger.Warn(
 				"query-service request deadline exceeded",
 				"ctx_err", ctx.Err(),
 				"cause", context.Cause(ctx),
 			)
-		} else if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
+		} else if ctxCanceled {
 			connectLogger.Warn(
 				"query-service request cancelled",
 				"ctx_err", ctx.Err(),
@@ -189,7 +192,7 @@ func (b *QueryAPIBuilder) QueryDatasources(w http.ResponseWriter, httpreq *http.
 			} else if strings.Contains(err.Error(), "expression request error") {
 				connectLogger.Error("Error calling TransformData in an expression", "err", err)
 				errorDataResponse = backend.ErrDataResponseWithSource(backend.StatusBadRequest, backend.ErrorSourceDownstream, err.Error())
-			} else if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
+			} else if ctxCanceled {
 				// Client-initiated cancellation — never the apiserver's fault.
 				// Tag downstream + status 499 so the response body stays a QueryDataResponse and
 				// errhttp.Write doesn't fall back to errutil.Internal (500).

--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -147,22 +147,6 @@ func (b *QueryAPIBuilder) QueryDatasources(w http.ResponseWriter, httpreq *http.
 	qdr, err := handleQuery(ctx, *raw, *b, httpreq, responder, connectLogger)
 
 	if err != nil {
-		ctxCanceled := errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled)
-		ctxDeadline := errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded)
-
-		if ctxDeadline {
-			connectLogger.Warn(
-				"query-service request deadline exceeded",
-				"ctx_err", ctx.Err(),
-				"cause", context.Cause(ctx),
-			)
-		} else if ctxCanceled {
-			connectLogger.Warn(
-				"query-service request cancelled",
-				"ctx_err", ctx.Err(),
-				"cause", context.Cause(ctx),
-			)
-		}
 		connectLogger.Error("execute error", "http code", query.GetResponseCode(qdr), "err", err, "err_type", fmt.Sprintf("%T", err))
 		logEmptyRefids(raw.Queries, connectLogger)
 		if qdr != nil { // if we have a response, we assume the err is set in the response
@@ -170,54 +154,66 @@ func (b *QueryAPIBuilder) QueryDatasources(w http.ResponseWriter, httpreq *http.
 				QueryDataResponse: *qdr,
 			})
 			return
-		} else {
-			var errorDataResponse backend.DataResponse
+		}
 
-			badRequestErrors := []error{
-				service.ErrInvalidDatasourceID,
-				service.ErrNoQueriesFound,
-				service.ErrMissingDataSourceInfo,
-				service.ErrQueryParamMismatch,
-				service.ErrDuplicateRefId,
-				datasources.ErrDataSourceNotFound,
+		var errorDataResponse backend.DataResponse
+		badRequestErrors := []error{
+			service.ErrInvalidDatasourceID,
+			service.ErrNoQueriesFound,
+			service.ErrMissingDataSourceInfo,
+			service.ErrQueryParamMismatch,
+			service.ErrDuplicateRefId,
+			datasources.ErrDataSourceNotFound,
+		}
+		isTypedBadRequestError := false
+		for _, badRequestError := range badRequestErrors {
+			if errors.Is(err, badRequestError) {
+				isTypedBadRequestError = true
 			}
-			isTypedBadRequestError := false
-			for _, badRequestError := range badRequestErrors {
-				if errors.Is(err, badRequestError) {
-					isTypedBadRequestError = true
-				}
-			}
-			if isTypedBadRequestError {
-				errorDataResponse = backend.ErrDataResponseWithSource(backend.StatusBadRequest, backend.ErrorSourceDownstream, err.Error())
-			} else if strings.Contains(err.Error(), "expression request error") {
-				connectLogger.Error("Error calling TransformData in an expression", "err", err)
-				errorDataResponse = backend.ErrDataResponseWithSource(backend.StatusBadRequest, backend.ErrorSourceDownstream, err.Error())
-			} else if ctxCanceled {
-				// Client-initiated cancellation — never the apiserver's fault.
-				// Tag downstream + status 499 so the response body stays a QueryDataResponse and
-				// errhttp.Write doesn't fall back to errutil.Internal (500).
-				errorDataResponse = backend.ErrDataResponseWithSource(499, backend.ErrorSourceDownstream, err.Error())
-			} else {
-				connectLogger.Error("unknown error, treated as a 500", "err", err)
-				responder.Error(err)
-				return
-			}
-			// TODO ensure errors also return the refId wherever possible
-			errorRefId := raw.Queries[0].RefID
-			if errorRefId == "" {
-				errorRefId = "A"
-			}
-
-			qdr = &backend.QueryDataResponse{
-				Responses: map[string]backend.DataResponse{
-					errorRefId: errorDataResponse,
-				},
-			}
-			responder.Object(query.GetResponseCode(qdr), &query.QueryDataResponse{
-				QueryDataResponse: *qdr,
-			})
+		}
+		switch {
+		case errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded):
+			connectLogger.Warn(
+				"query-service request deadline exceeded",
+				"ctx_err", ctx.Err(),
+				"cause", context.Cause(ctx),
+			)
+			errorDataResponse = backend.ErrDataResponseWithSource(http.StatusGatewayTimeout, backend.ErrorSourcePlugin, err.Error())
+		case errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled):
+			connectLogger.Warn(
+				"query-service request cancelled",
+				"ctx_err", ctx.Err(),
+				"cause", context.Cause(ctx),
+			)
+			// Client-initiated cancellation — never the apiserver's fault.
+			// Tag downstream + status 499 so the response body stays a QueryDataResponse and
+			// errhttp.Write doesn't fall back to errutil.Internal (500).
+			errorDataResponse = backend.ErrDataResponseWithSource(499, backend.ErrorSourceDownstream, err.Error())
+		case isTypedBadRequestError:
+			errorDataResponse = backend.ErrDataResponseWithSource(backend.StatusBadRequest, backend.ErrorSourceDownstream, err.Error())
+		case strings.Contains(err.Error(), "expression request error"):
+			connectLogger.Error("Error calling TransformData in an expression", "err", err)
+			errorDataResponse = backend.ErrDataResponseWithSource(backend.StatusBadRequest, backend.ErrorSourceDownstream, err.Error())
+		default:
+			connectLogger.Error("unknown error, treated as a 500", "err", err)
+			responder.Error(err)
 			return
 		}
+		// TODO ensure errors also return the refId wherever possible
+		errorRefId := raw.Queries[0].RefID
+		if errorRefId == "" {
+			errorRefId = "A"
+		}
+
+		qdr = &backend.QueryDataResponse{
+			Responses: map[string]backend.DataResponse{
+				errorRefId: errorDataResponse,
+			},
+		}
+		responder.Object(query.GetResponseCode(qdr), &query.QueryDataResponse{
+			QueryDataResponse: *qdr,
+		})
+		return
 	}
 
 	responder.Object(query.GetResponseCode(qdr), &query.QueryDataResponse{

--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -189,9 +189,8 @@ func (b *QueryAPIBuilder) QueryDatasources(w http.ResponseWriter, httpreq *http.
 			} else if strings.Contains(err.Error(), "expression request error") {
 				connectLogger.Error("Error calling TransformData in an expression", "err", err)
 				errorDataResponse = backend.ErrDataResponseWithSource(backend.StatusBadRequest, backend.ErrorSourceDownstream, err.Error())
-			} else if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) ||
-				errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
-				// Client-initiated cancellation or our own timeout — never the apiserver's fault.
+			} else if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) {
+				// Client-initiated cancellation — never the apiserver's fault.
 				// Tag downstream + status 499 so the response body stays a QueryDataResponse and
 				// errhttp.Write doesn't fall back to errutil.Internal (500).
 				errorDataResponse = backend.ErrDataResponseWithSource(499, backend.ErrorSourceDownstream, err.Error())

--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -189,6 +189,12 @@ func (b *QueryAPIBuilder) QueryDatasources(w http.ResponseWriter, httpreq *http.
 			} else if strings.Contains(err.Error(), "expression request error") {
 				connectLogger.Error("Error calling TransformData in an expression", "err", err)
 				errorDataResponse = backend.ErrDataResponseWithSource(backend.StatusBadRequest, backend.ErrorSourceDownstream, err.Error())
+			} else if errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled) ||
+				errors.Is(err, context.DeadlineExceeded) || errors.Is(ctx.Err(), context.DeadlineExceeded) {
+				// Client-initiated cancellation or our own timeout — never the apiserver's fault.
+				// Tag downstream + status 499 so the response body stays a QueryDataResponse and
+				// errhttp.Write doesn't fall back to errutil.Internal (500).
+				errorDataResponse = backend.ErrDataResponseWithSource(499, backend.ErrorSourceDownstream, err.Error())
 			} else {
 				connectLogger.Error("unknown error, treated as a 500", "err", err)
 				responder.Error(err)

--- a/pkg/registry/apis/query/query.go
+++ b/pkg/registry/apis/query/query.go
@@ -178,7 +178,7 @@ func (b *QueryAPIBuilder) QueryDatasources(w http.ResponseWriter, httpreq *http.
 				"ctx_err", ctx.Err(),
 				"cause", context.Cause(ctx),
 			)
-			errorDataResponse = backend.ErrDataResponseWithSource(http.StatusGatewayTimeout, backend.ErrorSourcePlugin, err.Error())
+			errorDataResponse = backend.ErrDataResponseWithSource(408, backend.ErrorSourceDownstream, err.Error())
 		case errors.Is(err, context.Canceled) || errors.Is(ctx.Err(), context.Canceled):
 			connectLogger.Warn(
 				"query-service request cancelled",


### PR DESCRIPTION
**What is this feature?**
Marks Context Cancelled requests as downstream in the query service. 

**Why do we need this feature?**
A request getting cancelled is an expected error that we should account for. 

**Who is this feature for?**

grafana-devs

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
