### PR TITLE
TimeSeries: Rename faceted filter option and persist pinned-sidebar state

### DIFF
--- a/packages/grafana-schema/src/raw/composable/timeseries/panelcfg/x/types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/timeseries/panelcfg/x/types.gen.ts
@@ -16,10 +16,12 @@ export const pluginVersion = "13.1.0-pre";
 
 export interface TimeSeriesLegendOptions extends common.VizLegendOptions {
   enableFacetedFilter?: boolean;
+  facetedFilterPinned?: boolean;
 }
 
 export const defaultTimeSeriesLegendOptions: Partial<TimeSeriesLegendOptions> = {
   enableFacetedFilter: true,
+  facetedFilterPinned: false,
 };
 
 export interface Options extends common.OptionsWithTimezones, common.OptionsWithAnnotations {

--- a/packages/grafana-schema/src/raw/composable/timeseries/panelcfg/x/types.gen.ts
+++ b/packages/grafana-schema/src/raw/composable/timeseries/panelcfg/x/types.gen.ts
@@ -20,7 +20,7 @@ export interface TimeSeriesLegendOptions extends common.VizLegendOptions {
 }
 
 export const defaultTimeSeriesLegendOptions: Partial<TimeSeriesLegendOptions> = {
-  enableFacetedFilter: true,
+  enableFacetedFilter: false,
   facetedFilterPinned: false,
 };
 

--- a/packages/grafana-ui/src/components/uPlot/PlotLegend.test.tsx
+++ b/packages/grafana-ui/src/components/uPlot/PlotLegend.test.tsx
@@ -86,8 +86,8 @@ describe('PlotLegend faceted filter', () => {
     expect(onPinnedToSidebarChange).toHaveBeenCalledWith(true);
   });
 
-  it('renders the docked layout when pinnedToSidebar is true and supports clear-all', async () => {
-    const { toggle } = renderWithContext({ pinnedToSidebar: true });
+  it('renders the docked layout when facetedFilterPinned is true and supports clear-all', async () => {
+    const { toggle } = renderWithContext({ facetedFilterPinned: true });
 
     expect(screen.queryByTestId('faceted-labels-filter-toggle')).not.toBeInTheDocument();
     expect(screen.getByLabelText('Unpin')).toBeInTheDocument();
@@ -100,7 +100,7 @@ describe('PlotLegend faceted filter', () => {
   });
 
   it('fires onPinnedToSidebarChange(false) when "Unpin" is clicked in the docked layout', async () => {
-    const { onPinnedToSidebarChange } = renderWithContext({ pinnedToSidebar: true });
+    const { onPinnedToSidebarChange } = renderWithContext({ facetedFilterPinned: true });
 
     await userEvent.click(screen.getByLabelText('Unpin'));
 

--- a/packages/grafana-ui/src/components/uPlot/PlotLegend.test.tsx
+++ b/packages/grafana-ui/src/components/uPlot/PlotLegend.test.tsx
@@ -46,13 +46,15 @@ const defaultProps: React.ComponentProps<typeof PlotLegend> = {
 
 function renderWithContext(overrides: Partial<React.ComponentProps<typeof PlotLegend>> = {}) {
   const toggle = jest.fn();
+  const onPinnedToSidebarChange = jest.fn();
   return {
     toggle,
+    onPinnedToSidebarChange,
     ...render(
       <PanelContextProvider
         value={{ eventsScope: 'test', eventBus: { publish: jest.fn() } as never, onToggleSeriesVisibility: toggle }}
       >
-        <PlotLegend {...defaultProps} {...overrides} />
+        <PlotLegend {...defaultProps} onPinnedToSidebarChange={onPinnedToSidebarChange} {...overrides} />
       </PanelContextProvider>
     ),
   };
@@ -75,11 +77,19 @@ describe('PlotLegend faceted filter', () => {
     expect(toggle).toHaveBeenCalledWith(expect.any(Array), SeriesVisibilityChangeMode.SetExactly);
   });
 
-  it('docks filter, shows clear all when active, and resets on clear', async () => {
-    const { toggle } = renderWithContext();
+  it('fires onPinnedToSidebarChange(true) when "Pin to sidebar" is clicked', async () => {
+    const { onPinnedToSidebarChange } = renderWithContext();
 
     await userEvent.click(screen.getByTestId('faceted-labels-filter-toggle'));
     await userEvent.click(within(screen.getByTestId('toggletip-content')).getByText('Pin to sidebar'));
+
+    expect(onPinnedToSidebarChange).toHaveBeenCalledWith(true);
+  });
+
+  it('renders the docked layout when pinnedToSidebar is true and supports clear-all', async () => {
+    const { toggle } = renderWithContext({ pinnedToSidebar: true });
+
+    expect(screen.queryByTestId('faceted-labels-filter-toggle')).not.toBeInTheDocument();
     expect(screen.getByLabelText('Unpin')).toBeInTheDocument();
 
     await userEvent.click(screen.getByLabelText('cpu'));
@@ -87,5 +97,13 @@ describe('PlotLegend faceted filter', () => {
 
     await userEvent.click(screen.getByLabelText('Clear all'));
     expect(toggle).toHaveBeenCalledWith(null, SeriesVisibilityChangeMode.SetExactly);
+  });
+
+  it('fires onPinnedToSidebarChange(false) when "Unpin" is clicked in the docked layout', async () => {
+    const { onPinnedToSidebarChange } = renderWithContext({ pinnedToSidebar: true });
+
+    await userEvent.click(screen.getByLabelText('Unpin'));
+
+    expect(onPinnedToSidebarChange).toHaveBeenCalledWith(false);
   });
 });

--- a/packages/grafana-ui/src/components/uPlot/PlotLegend.tsx
+++ b/packages/grafana-ui/src/components/uPlot/PlotLegend.tsx
@@ -30,7 +30,7 @@ interface PlotLegendProps extends VizLegendOptions, Omit<VizLayoutLegendProps, '
   data: DataFrame[];
   config: UPlotConfigBuilder;
   enableFacetedFilter?: boolean;
-  pinnedToSidebar?: boolean;
+  facetedFilterPinned?: boolean;
   onPinnedToSidebarChange?: (pinned: boolean) => void;
 }
 
@@ -65,7 +65,7 @@ export const PlotLegend = memo(function PlotLegend({
   displayMode,
   limit,
   enableFacetedFilter = false,
-  pinnedToSidebar = false,
+  facetedFilterPinned = false,
   onPinnedToSidebarChange,
   ...vizLayoutLegendProps
 }: PlotLegendProps) {
@@ -151,8 +151,8 @@ export const PlotLegend = memo(function PlotLegend({
   }, [onToggleSeriesVisibility]);
 
   const handleToggleFilterDock = useCallback(() => {
-    onPinnedToSidebarChange?.(!pinnedToSidebar);
-  }, [onPinnedToSidebarChange, pinnedToSidebar]);
+    onPinnedToSidebarChange?.(!facetedFilterPinned);
+  }, [onPinnedToSidebarChange, facetedFilterPinned]);
 
   const facetedFilter = hasFacetedLabels ? (
     <FacetedLabelsFilter
@@ -203,11 +203,11 @@ export const PlotLegend = memo(function PlotLegend({
       sortDesc={vizLayoutLegendProps.sortDesc}
       isSortable={true}
       limit={limit}
-      filterAction={!pinnedToSidebar ? filterToggle : undefined}
+      filterAction={!facetedFilterPinned ? filterToggle : undefined}
     />
   );
 
-  if (pinnedToSidebar && facetedFilter) {
+  if (facetedFilterPinned && facetedFilter) {
     return (
       <VizLayout.Legend placement={placement} {...vizLayoutLegendProps}>
         <div className={styles.legendWithFilter}>

--- a/packages/grafana-ui/src/components/uPlot/PlotLegend.tsx
+++ b/packages/grafana-ui/src/components/uPlot/PlotLegend.tsx
@@ -30,6 +30,8 @@ interface PlotLegendProps extends VizLegendOptions, Omit<VizLayoutLegendProps, '
   data: DataFrame[];
   config: UPlotConfigBuilder;
   enableFacetedFilter?: boolean;
+  pinnedToSidebar?: boolean;
+  onPinnedToSidebarChange?: (pinned: boolean) => void;
 }
 
 /**
@@ -63,6 +65,8 @@ export const PlotLegend = memo(function PlotLegend({
   displayMode,
   limit,
   enableFacetedFilter = false,
+  pinnedToSidebar = false,
+  onPinnedToSidebarChange,
   ...vizLayoutLegendProps
 }: PlotLegendProps) {
   const theme = useTheme2();
@@ -70,7 +74,6 @@ export const PlotLegend = memo(function PlotLegend({
   const { onToggleSeriesVisibility } = usePanelContext();
 
   const [selectedLabels, setSelectedLabels] = useState<Record<string, string[]>>({});
-  const [filterDocked, setFilterDocked] = useState(false);
 
   const facetedLabels = useMemo(
     () => (enableFacetedFilter && onToggleSeriesVisibility ? extractFacetedLabels(data) : {}),
@@ -148,8 +151,8 @@ export const PlotLegend = memo(function PlotLegend({
   }, [onToggleSeriesVisibility]);
 
   const handleToggleFilterDock = useCallback(() => {
-    setFilterDocked((prev) => !prev);
-  }, []);
+    onPinnedToSidebarChange?.(!pinnedToSidebar);
+  }, [onPinnedToSidebarChange, pinnedToSidebar]);
 
   const facetedFilter = hasFacetedLabels ? (
     <FacetedLabelsFilter
@@ -200,11 +203,11 @@ export const PlotLegend = memo(function PlotLegend({
       sortDesc={vizLayoutLegendProps.sortDesc}
       isSortable={true}
       limit={limit}
-      filterAction={!filterDocked ? filterToggle : undefined}
+      filterAction={!pinnedToSidebar ? filterToggle : undefined}
     />
   );
 
-  if (filterDocked && facetedFilter) {
+  if (pinnedToSidebar && facetedFilter) {
     return (
       <VizLayout.Legend placement={placement} {...vizLayoutLegendProps}>
         <div className={styles.legendWithFilter}>

--- a/public/app/core/components/TimeSeries/TimeSeries.tsx
+++ b/public/app/core/components/TimeSeries/TimeSeries.tsx
@@ -14,10 +14,11 @@ const propsToDiff: Array<string | PropDiffFn> = ['legend', 'options', 'annotatio
 
 type TimeSeriesProps = Omit<GraphNGProps, 'prepConfig' | 'propsToDiff' | 'renderLegend' | 'theme' | 'legend'> & {
   legend: TimeSeriesLegendOptions;
+  onPinnedToSidebarChange?: (pinned: boolean) => void;
 };
 
 export function TimeSeries(props: TimeSeriesProps) {
-  const { timeZone, options, renderers, tweakAxis, tweakScale, legend, frames } = props;
+  const { timeZone, options, renderers, tweakAxis, tweakScale, legend, frames, onPinnedToSidebarChange } = props;
   const theme = useTheme2();
 
   const prepConfig = useCallback(
@@ -46,9 +47,18 @@ export function TimeSeries(props: TimeSeriesProps) {
       }
 
       const enableFacetedFilter = config.featureToggles.vizLegendFacetedFilter && legend?.enableFacetedFilter;
-      return <PlotLegend data={frames} config={uPlotConfig} {...legend} enableFacetedFilter={enableFacetedFilter} />;
+      return (
+        <PlotLegend
+          data={frames}
+          config={uPlotConfig}
+          {...legend}
+          enableFacetedFilter={enableFacetedFilter}
+          pinnedToSidebar={legend?.facetedFilterPinned ?? false}
+          onPinnedToSidebarChange={onPinnedToSidebarChange}
+        />
+      );
     },
-    [legend, frames]
+    [legend, frames, onPinnedToSidebarChange]
   );
 
   return (

--- a/public/app/core/components/TimeSeries/TimeSeries.tsx
+++ b/public/app/core/components/TimeSeries/TimeSeries.tsx
@@ -47,13 +47,14 @@ export function TimeSeries(props: TimeSeriesProps) {
       }
 
       const enableFacetedFilter = config.featureToggles.vizLegendFacetedFilter && legend?.enableFacetedFilter;
+      const facetedFilterPinned = config.featureToggles.vizLegendFacetedFilter && legend?.facetedFilterPinned;
       return (
         <PlotLegend
           data={frames}
           config={uPlotConfig}
           {...legend}
           enableFacetedFilter={enableFacetedFilter}
-          pinnedToSidebar={legend?.facetedFilterPinned ?? false}
+          facetedFilterPinned={facetedFilterPinned}
           onPinnedToSidebarChange={onPinnedToSidebarChange}
         />
       );

--- a/public/app/plugins/panel/timeseries/TimeSeriesPanel.test.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesPanel.test.tsx
@@ -1,8 +1,11 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
-import { createDataFrame, type DataFrame, DataFrameType, FieldType } from '@grafana/data';
+import { createDataFrame, type DataFrame, DataFrameType, EventBusSrv, FieldType, type PanelProps } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
+import { config } from '@grafana/runtime';
 import { LegendDisplayMode, SortOrder, TooltipDisplayMode } from '@grafana/schema';
+import { PanelContextProvider } from '@grafana/ui';
 
 import { getPanelProps } from '../test-utils';
 
@@ -32,10 +35,64 @@ const validFrame = createDataFrame({
   ],
 });
 
+const labeledFrame = createDataFrame({
+  fields: [
+    { name: 'time', type: FieldType.time, values: [1000, 2000, 3000], config: {} },
+    {
+      name: 'cpu',
+      type: FieldType.number,
+      values: [1, 2, 3],
+      config: { custom: {} },
+      labels: { host: 'a' },
+    },
+    {
+      name: 'mem',
+      type: FieldType.number,
+      values: [4, 5, 6],
+      config: { custom: {} },
+      labels: { host: 'b' },
+    },
+  ],
+});
+
 function renderPanel(options?: Partial<Options>, series: DataFrame[] = [validFrame]) {
   const props = getPanelProps<Options>({ ...defaultOptions, ...options });
   props.data.series = series;
   return render(<TimeSeriesPanel {...props} />);
+}
+
+function renderPanelWithFacetedFilter(
+  optionsOverride: Partial<Options> = {},
+  propsOverrides: Partial<Omit<PanelProps<Options>, 'options'>> = {}
+) {
+  const onOptionsChange = jest.fn();
+  const props = getPanelProps<Options>(
+    {
+      ...defaultOptions,
+      ...optionsOverride,
+      legend: {
+        ...defaultOptions.legend,
+        enableFacetedFilter: true,
+        ...(optionsOverride.legend ?? {}),
+      },
+    },
+    { onOptionsChange, ...propsOverrides }
+  );
+  props.data.series = [labeledFrame];
+
+  const renderResult = render(
+    <PanelContextProvider
+      value={{
+        eventsScope: 'test',
+        eventBus: new EventBusSrv(),
+        onToggleSeriesVisibility: jest.fn(),
+      }}
+    >
+      <TimeSeriesPanel {...props} />
+    </PanelContextProvider>
+  );
+
+  return { onOptionsChange, props, ...renderResult };
 }
 
 describe('TimeSeriesPanel', () => {
@@ -90,5 +147,50 @@ describe('TimeSeriesPanel', () => {
     renderPanel({ legend: { ...defaultOptions.legend, showLegend: false } });
 
     expect(screen.queryByTestId(selectors.components.VizLayout.legend)).not.toBeInTheDocument();
+  });
+
+  describe('faceted filter pin-to-sidebar persistence', () => {
+    let originalVizLegendFacetedFilter: boolean | undefined;
+
+    beforeEach(() => {
+      originalVizLegendFacetedFilter = config.featureToggles.vizLegendFacetedFilter;
+      config.featureToggles.vizLegendFacetedFilter = true;
+    });
+
+    afterEach(() => {
+      config.featureToggles.vizLegendFacetedFilter = originalVizLegendFacetedFilter;
+    });
+
+    it('calls onOptionsChange with facetedFilterPinned: true when "Pin to sidebar" is clicked', async () => {
+      const { onOptionsChange, props } = renderPanelWithFacetedFilter();
+
+      await userEvent.click(screen.getByTestId('faceted-labels-filter-toggle'));
+      const popover = screen.getByTestId('toggletip-content');
+      await userEvent.click(within(popover).getByText('Pin to sidebar'));
+
+      expect(onOptionsChange).toHaveBeenCalledTimes(1);
+      expect(onOptionsChange).toHaveBeenCalledWith({
+        ...props.options,
+        legend: { ...props.options.legend, facetedFilterPinned: true },
+      });
+    });
+
+    it('renders the docked layout and calls onOptionsChange with facetedFilterPinned: false when "Unpin" is clicked', async () => {
+      const { onOptionsChange, props } = renderPanelWithFacetedFilter({
+        legend: { ...defaultOptions.legend, enableFacetedFilter: true, facetedFilterPinned: true },
+      });
+
+      expect(screen.queryByTestId('faceted-labels-filter-toggle')).not.toBeInTheDocument();
+      const unpinButton = screen.getByLabelText('Unpin');
+      expect(unpinButton).toBeInTheDocument();
+
+      await userEvent.click(unpinButton);
+
+      expect(onOptionsChange).toHaveBeenCalledTimes(1);
+      expect(onOptionsChange).toHaveBeenCalledWith({
+        ...props.options,
+        legend: { ...props.options.legend, facetedFilterPinned: false },
+      });
+    });
   });
 });

--- a/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
+++ b/public/app/plugins/panel/timeseries/TimeSeriesPanel.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 
 import {
   alignTimeRangeCompareData,
@@ -42,6 +42,7 @@ export const TimeSeriesPanel = ({
   options,
   fieldConfig,
   onChangeTimeRange,
+  onOptionsChange,
   replaceVariables,
   id,
 }: TimeSeriesPanelProps) => {
@@ -108,6 +109,13 @@ export const TimeSeriesPanel = ({
   const [newAnnotationRange, setNewAnnotationRange] = useState<TimeRange2 | null>(null);
   const cursorSync = sync?.() ?? DashboardCursorSync.Off;
 
+  const onPinnedToSidebarChange = useCallback(
+    (pinned: boolean) => {
+      onOptionsChange({ ...options, legend: { ...options.legend, facetedFilterPinned: pinned } });
+    },
+    [onOptionsChange, options]
+  );
+
   if (!frames || suggestions) {
     return (
       <PanelDataErrorView
@@ -136,6 +144,7 @@ export const TimeSeriesPanel = ({
       dataLinkPostProcessor={dataLinkPostProcessor}
       cursorSync={cursorSync}
       annotationLanes={options.annotations?.multiLane ? getXAnnotationFrames(data.annotations).length : undefined}
+      onPinnedToSidebarChange={onPinnedToSidebarChange}
     >
       {(uplotConfig, alignedFrame) => {
         return (

--- a/public/app/plugins/panel/timeseries/module.tsx
+++ b/public/app/plugins/panel/timeseries/module.tsx
@@ -25,9 +25,12 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(TimeSeriesPanel)
     if (config.featureToggles.vizLegendFacetedFilter) {
       builder.addBooleanSwitch({
         path: 'legend.enableFacetedFilter',
-        name: t('timeseries.legend.name-faceted-filter', 'Faceted filter'),
+        name: t('timeseries.legend.name-faceted-filter', 'Series visibility'),
         category: legendCategory,
-        description: t('timeseries.legend.description-faceted-filter', 'Show series visibility filter based on labels'),
+        description: t(
+          'timeseries.legend.description-faceted-filter',
+          'Enable filter to display series based on labels or names'
+        ),
         defaultValue: true,
         showIf: (c) => c.legend.showLegend,
       });

--- a/public/app/plugins/panel/timeseries/module.tsx
+++ b/public/app/plugins/panel/timeseries/module.tsx
@@ -31,7 +31,7 @@ export const plugin = new PanelPlugin<Options, FieldConfig>(TimeSeriesPanel)
           'timeseries.legend.description-faceted-filter',
           'Enable filter to display series based on labels or names'
         ),
-        defaultValue: true,
+        defaultValue: false,
         showIf: (c) => c.legend.showLegend,
       });
     }

--- a/public/app/plugins/panel/timeseries/panelcfg.cue
+++ b/public/app/plugins/panel/timeseries/panelcfg.cue
@@ -24,7 +24,7 @@ composableKinds: PanelCfg: lineage: {
 		schema: {
 			TimeSeriesLegendOptions: {
 				common.VizLegendOptions
-				enableFacetedFilter?: bool | *true
+				enableFacetedFilter?: bool | *false
 				facetedFilterPinned?: bool | *false
 			} @cuetsy(kind="interface")
 			Options: {

--- a/public/app/plugins/panel/timeseries/panelcfg.cue
+++ b/public/app/plugins/panel/timeseries/panelcfg.cue
@@ -25,6 +25,7 @@ composableKinds: PanelCfg: lineage: {
 			TimeSeriesLegendOptions: {
 				common.VizLegendOptions
 				enableFacetedFilter?: bool | *true
+				facetedFilterPinned?: bool | *false
 			} @cuetsy(kind="interface")
 			Options: {
 				common.OptionsWithTimezones

--- a/public/app/plugins/panel/timeseries/panelcfg.gen.ts
+++ b/public/app/plugins/panel/timeseries/panelcfg.gen.ts
@@ -14,10 +14,12 @@ import * as common from '@grafana/schema';
 
 export interface TimeSeriesLegendOptions extends common.VizLegendOptions {
   enableFacetedFilter?: boolean;
+  facetedFilterPinned?: boolean;
 }
 
 export const defaultTimeSeriesLegendOptions: Partial<TimeSeriesLegendOptions> = {
   enableFacetedFilter: true,
+  facetedFilterPinned: false,
 };
 
 export interface Options extends common.OptionsWithTimezones, common.OptionsWithAnnotations {

--- a/public/app/plugins/panel/timeseries/panelcfg.gen.ts
+++ b/public/app/plugins/panel/timeseries/panelcfg.gen.ts
@@ -18,7 +18,7 @@ export interface TimeSeriesLegendOptions extends common.VizLegendOptions {
 }
 
 export const defaultTimeSeriesLegendOptions: Partial<TimeSeriesLegendOptions> = {
-  enableFacetedFilter: true,
+  enableFacetedFilter: false,
   facetedFilterPinned: false,
 };
 

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -15546,8 +15546,8 @@
     },
     "legend": {
       "category": "Legend",
-      "description-faceted-filter": "Show series visibility filter based on labels",
-      "name-faceted-filter": "Faceted filter"
+      "description-faceted-filter": "Enable filter to display series based on labels or names",
+      "name-faceted-filter": "Series visibility"
     },
     "line-style-editor": {
       "line-fill-options": {


### PR DESCRIPTION
- Rename the legend option from "Faceted filter" to "Series visibility" with an updated description.
- Replace the ephemeral pinned-sidebar state in PlotLegend with a controlled prop backed by a new
legend.facetedFilterPinned field in the panel options, so the docked state can be saved as part of the panel JSON.
- updates the default for the option to be false instead of true
