### PR TITLE
unified-storage: leases: add deleted timestamp and logging

### DIFF
--- a/pkg/storage/unified/resource/lease/lease.go
+++ b/pkg/storage/unified/resource/lease/lease.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/grafana/grafana/pkg/storage/unified/resource/kv"
 )
 
@@ -51,6 +52,8 @@ var (
 	// already been released, or was superseded by another holder. When
 	// auto-renewal is enabled, this error also triggers the Lost() channel.
 	ErrLeaseLost = errors.New("lease lost")
+
+	log = logging.DefaultLogger.With("logger", "lease-manager")
 )
 
 type Lease struct {
@@ -334,20 +337,25 @@ func (m *Manager) autoRenewLoop(lease *Lease, expiry time.Time, ttl, renewInterv
 	defer ticker.Stop()
 
 	for {
+		log := log.With("lease", lease.name, "holder", lease.holder, "generation", lease.generation)
+
 		select {
 		case <-lease.stop:
 			return
 		case <-ticker.C:
 			newExpiry, err := m.renewOnce(lease, ttl, renewInterval)
 			if errors.Is(err, ErrLeaseLost) {
+				log.Warn("lease lost to another holder during renewal", "err", err)
 				lease.notifyLoss()
 				return
 			}
 			if err != nil {
 				if time.Now().After(expiry) {
+					log.Error("lease lost: renewal retries exhausted before expiry", "err", err)
 					lease.notifyLoss()
 					return
 				}
+				log.Warn("lease renewal failed, will retry", "time_until_expiry", time.Until(expiry), "err", err)
 				continue
 			}
 			expiry = newExpiry

--- a/pkg/storage/unified/resource/lease/lease.go
+++ b/pkg/storage/unified/resource/lease/lease.go
@@ -86,7 +86,7 @@ func (l *Lease) notifyLoss() {
 type leaseMetadata struct {
 	Holder     string `json:"holder"`
 	Expires    int64  `json:"expires"`
-	Deleted    bool   `json:"deleted,omitempty"` // TODO: remove this field once every pod is running with `DeletedAt` support
+	Deleted    bool   `json:"deleted,omitempty"` // TODO: remove this field once every pod is running with `ReleasedAt` support
 	ReleasedAt int64  `json:"released_at,omitempty"`
 }
 

--- a/pkg/storage/unified/resource/lease/lease.go
+++ b/pkg/storage/unified/resource/lease/lease.go
@@ -21,6 +21,9 @@ const (
 	// minimum TTL accepted. Returns an error if the caller passes a lower duration.
 	defaultMinTTL = 10 * time.Second
 
+	// max TTL accepted
+	maxTTL = 10 * time.Minute
+
 	// maximum tolerated clock skew across hosts when deciding whether an
 	// existing lease is still held by another process.
 	defaultMaxClockSkew = 500 * time.Millisecond
@@ -163,6 +166,10 @@ func (m *Manager) Acquire(ctx context.Context, name string, opts ...AcquireOptio
 
 	if cfg.ttl < m.minTTL {
 		return nil, fmt.Errorf("invalid TTL: %s < %s", cfg.ttl, m.minTTL)
+	}
+
+	if cfg.ttl > maxTTL {
+		return nil, fmt.Errorf("invalid TTL: %s > %s", cfg.ttl, maxTTL)
 	}
 
 	for attempt := 0; ; attempt++ {

--- a/pkg/storage/unified/resource/lease/lease.go
+++ b/pkg/storage/unified/resource/lease/lease.go
@@ -81,13 +81,14 @@ func (l *Lease) notifyLoss() {
 
 // leaseMetadata is the data saved in the KV store for each lease.
 type leaseMetadata struct {
-	Holder  string `json:"holder"`
-	Expires int64  `json:"expires"`
-	Deleted bool   `json:"deleted"`
+	Holder     string `json:"holder"`
+	Expires    int64  `json:"expires"`
+	Deleted    bool   `json:"deleted,omitempty"` // TODO: remove this field once every pod is running with `DeletedAt` support
+	ReleasedAt int64  `json:"released_at,omitempty"`
 }
 
 func (meta *leaseMetadata) ValidAsOf(ts time.Time) bool {
-	return !meta.Deleted && ts.Before(time.Unix(0, meta.Expires))
+	return !meta.Deleted && meta.ReleasedAt == 0 && ts.Before(time.Unix(0, meta.Expires))
 }
 
 // Manager acquires and releases leases backed by a KV store.
@@ -261,6 +262,7 @@ func (m *Manager) Release(ctx context.Context, lease *Lease) error {
 	}
 
 	meta.Deleted = true
+	meta.ReleasedAt = time.Now().UnixNano()
 	if err := m.save(ctx, key, meta); err != nil {
 		return fmt.Errorf("releasing %s/%d: %w", lease.name, lease.generation, err)
 	}
@@ -291,7 +293,9 @@ func (m *Manager) extendGeneration(ctx context.Context, lease *Lease, ttl time.D
 		return time.Time{}, err
 	}
 
-	tombstone, err := json.Marshal(leaseMetadata{Holder: m.holder, Deleted: true})
+	meta.Deleted = true
+	meta.ReleasedAt = time.Now().UnixNano()
+	tombstone, err := json.Marshal(meta)
 	if err != nil {
 		return time.Time{}, err
 	}

--- a/pkg/storage/unified/resource/lease/lease_test.go
+++ b/pkg/storage/unified/resource/lease/lease_test.go
@@ -64,6 +64,8 @@ func TestAcquireTTLValidation(t *testing.T) {
 		{d: time.Millisecond, isValid: false},
 		{d: 100 * time.Millisecond, isValid: true},
 		{d: time.Minute, isValid: true},
+		{d: 10 * time.Minute, isValid: true},
+		{d: 11 * time.Minute, isValid: false}, // too long
 	}
 
 	for _, tc := range testCases {

--- a/pkg/storage/unified/testing/lease.go
+++ b/pkg/storage/unified/testing/lease.go
@@ -2,6 +2,7 @@ package test
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -9,6 +10,7 @@ import (
 	"os"
 	"reflect"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -28,6 +30,7 @@ func RunLeaseTest(t *testing.T, newKV NewKVFunc) {
 	t.Helper()
 
 	store := newKV(t.Context())
+	t.Cleanup(func() { validateLeaseStore(t, store) })
 
 	t.Run("happy path", func(t *testing.T) { runLeaseHappyPath(t, store) })
 	t.Run("contention", func(t *testing.T) { runLeaseContention(t, store) })
@@ -726,4 +729,79 @@ func (f *leaseFailingKV) Batch(ctx context.Context, section string, ops []kv.Bat
 
 func (f *leaseFailingKV) Reset() {
 	f.injectedError = nil
+}
+
+// validateLeaseStore checks store-wide invariants once all subtests have
+// finished: every entry has a non-empty holder and an Expires within 30
+// minutes of current time, and for every lease name a non-latest entry
+// may have ReleasedAt == 0 only if it has already expired.
+func validateLeaseStore(t *testing.T, store kv.KV) {
+	type meta struct {
+		Holder     string `json:"holder"`
+		Expires    int64  `json:"expires"`
+		ReleasedAt int64  `json:"released_at,omitempty"`
+	}
+
+	type entry struct {
+		generation int64
+		expires    int64
+		releasedAt int64
+	}
+
+	ctx := context.Background()
+	now := time.Now()
+	const window = 30 * time.Minute
+
+	byName := make(map[string][]entry)
+
+	for key, err := range store.Keys(ctx, kv.LeasesSection, kv.ListOptions{Sort: kv.SortOrderAsc}) {
+		require.NoError(t, err)
+
+		idx := strings.LastIndex(key, "~")
+		require.GreaterOrEqual(t, idx, 0)
+		name := key[:idx]
+		generation, err := strconv.ParseInt(key[idx+1:], 10, 64)
+		require.NoError(t, err)
+
+		r, err := store.Get(ctx, kv.LeasesSection, key)
+		require.NoError(t, err)
+		data, err := io.ReadAll(r)
+		require.NoError(t, r.Close())
+		require.NoError(t, err)
+
+		var m meta
+		require.NoError(t, json.Unmarshal(data, &m))
+
+		// Every lease has a non-empty holder.
+		require.NotEmpty(t, m.Holder)
+
+		// Every lease's expiration is within a given `window`.
+		expires := time.Unix(0, m.Expires)
+		delta := expires.Sub(now)
+		if delta < 0 {
+			delta = -delta
+		}
+		require.LessOrEqual(t, delta, window)
+
+		byName[name] = append(byName[name], entry{
+			generation: generation,
+			expires:    m.Expires,
+			releasedAt: m.ReleasedAt,
+		})
+	}
+
+	for name, entries := range byName {
+		last := len(entries) - 1
+		latest := entries[last].generation
+		for _, e := range entries[:last] {
+			if e.releasedAt != 0 {
+				continue
+			}
+			// Non-latest, non-tombstoned: only valid if already expired.
+			expiresAt := time.Unix(0, e.expires)
+			require.LessOrEqual(t, expiresAt, now,
+				"lease %q generation %d is not the latest (%d), has ReleasedAt == 0, and is not yet expired (Expires=%s, now=%s)",
+				name, e.generation, latest, expiresAt, now)
+		}
+	}
 }

--- a/pkg/storage/unified/testing/lease.go
+++ b/pkg/storage/unified/testing/lease.go
@@ -748,7 +748,8 @@ func validateLeaseStore(t *testing.T, store kv.KV) {
 		releasedAt int64
 	}
 
-	ctx := context.Background()
+	ctx, stop := context.WithTimeout(context.Background(), 10*time.Second)
+	defer stop()
 	now := time.Now()
 	const window = 30 * time.Minute
 


### PR DESCRIPTION
Minor changes to the leases package:

* enforce a maximum lease TTL to avoid misconfiguration.
* use a timestamp rather than a boolean to annotate release entries (still backwards compatible for now with support for `Deleted`).
* add logging