### PR TITLE
Scopes: Hide selector "Remove all" button in scopes-first mode

### DIFF
--- a/public/app/features/scopes/selector/ScopesInput.test.tsx
+++ b/public/app/features/scopes/selector/ScopesInput.test.tsx
@@ -1,0 +1,50 @@
+import { screen } from '@testing-library/react';
+import { render } from 'test/test-utils';
+
+import { ScopesTooltip, type ScopesTooltipProps } from './ScopesInput';
+import { type NodesMap, type ScopesMap, type SelectedScope } from './types';
+
+const nodes: NodesMap = {
+  'node-1': {
+    metadata: { name: 'node-1' },
+    spec: { nodeType: 'leaf', title: 'Test Node', parentName: '' },
+  },
+};
+
+const scopesMap: ScopesMap = {
+  'scope-1': {
+    metadata: { name: 'scope-1' },
+    spec: { title: 'Test Scope' },
+  },
+};
+
+const appliedScopes: SelectedScope[] = [{ scopeId: 'scope-1', scopeNodeId: 'node-1' }];
+
+const renderTooltip = (overrides: Partial<ScopesTooltipProps> = {}) =>
+  render(
+    <ScopesTooltip
+      nodes={nodes}
+      scopes={scopesMap}
+      appliedScopes={appliedScopes}
+      onRemoveAllClick={jest.fn()}
+      disabled={false}
+      {...overrides}
+    />
+  );
+
+describe('ScopesTooltip', () => {
+  it('renders the Remove all button when onRemoveAllClick is provided and not disabled', () => {
+    renderTooltip();
+    expect(screen.getByTestId('scopes-selector-input-clear')).toBeInTheDocument();
+  });
+
+  it('hides the Remove all button when onRemoveAllClick is undefined (e.g., scopes-first mode active)', () => {
+    renderTooltip({ onRemoveAllClick: undefined });
+    expect(screen.queryByTestId('scopes-selector-input-clear')).not.toBeInTheDocument();
+  });
+
+  it('hides the Remove all button when disabled, even if onRemoveAllClick is provided', () => {
+    renderTooltip({ disabled: true });
+    expect(screen.queryByTestId('scopes-selector-input-clear')).not.toBeInTheDocument();
+  });
+});

--- a/public/app/features/scopes/selector/ScopesInput.tsx
+++ b/public/app/features/scopes/selector/ScopesInput.tsx
@@ -2,6 +2,7 @@ import { css, cx } from '@emotion/css';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
+import { useFlagGrafanaEnableScopesFirstMode } from '@grafana/runtime/internal';
 import { getInputStyles, Icon, LinkButton, Spinner, Tooltip, useStyles2, Text, Stack } from '@grafana/ui';
 import { getFocusStyles } from '@grafana/ui/internal';
 
@@ -34,6 +35,7 @@ export function ScopesInput({
   const firstScope = appliedScopes[0];
   const scope = scopes[firstScope?.scopeId];
   const styles = useStyles2(getStyles);
+  const scopesFirstMode = useFlagGrafanaEnableScopesFirstMode();
 
   // Prefer scopeNodeId from defaultPath if available (most reliable source)
   let scopeNodeId: string | undefined;
@@ -69,7 +71,7 @@ export function ScopesInput({
       nodes={nodes}
       scopes={scopes}
       appliedScopes={appliedScopes}
-      onRemoveAllClick={onRemoveAllClick}
+      onRemoveAllClick={scopesFirstMode ? undefined : onRemoveAllClick}
       disabled={disabled}
     />
   );
@@ -156,7 +158,7 @@ export interface ScopesTooltipProps {
   onRemoveAllClick?: () => void;
 }
 
-function ScopesTooltip({ nodes, scopes, appliedScopes, onRemoveAllClick, disabled }: ScopesTooltipProps) {
+export function ScopesTooltip({ nodes, scopes, appliedScopes, onRemoveAllClick, disabled }: ScopesTooltipProps) {
   if (appliedScopes.length === 0) {
     return t('scopes.selector.input.tooltip', 'Select scope');
   }
@@ -177,7 +179,7 @@ function ScopesTooltip({ nodes, scopes, appliedScopes, onRemoveAllClick, disable
   return (
     <Stack direction="column" gap={1} justifyContent="center" alignItems={'center'}>
       <span>{parentPaths + scopeNames.join(', ')}</span>
-      {!disabled && (
+      {!disabled && onRemoveAllClick && (
         <LinkButton
           onClick={onRemoveAllClick}
           aria-label={t('scopes.selector.input.removeAll', 'Remove all scopes')}


### PR DESCRIPTION
## Summary

Hides the scope selector's "Remove all" button when the `grafana.enableScopesFirstMode` OpenFeature flag is on. Built on top of #124725 which registers the flag.

When the flag is on, `ScopesInput` passes `undefined` for `onRemoveAllClick`, and `ScopesTooltip` omits the `LinkButton`. The tooltip's render guard is tightened to require both `!disabled` and a non-undefined callback, keeping `ScopesTooltip` a pure prop-driven component.

## Stacked PR

This PR is stacked on top of #124725.

## Test plan

- [x] New `ScopesInput.test.tsx` covers the three render branches (callback provided / undefined / disabled).
- [x] Full scopes module suite (467 tests) passes with flag default-off — `clearSelector` integration tests would fail if the wiring were inverted.
- [ ] Manual: with flag off, populated scope selector shows "Remove all" in tooltip. With flag on, button is gone, path/name text still renders.

Refs: grafana/hyperion-planning#615