### PR TITLE
fix(mt-annotations): add uid field to annotation resource for PATCH

### DIFF
--- a/pkg/registry/apps/annotation/grpc_store.go
+++ b/pkg/registry/apps/annotation/grpc_store.go
@@ -9,6 +9,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	annotationV0 "github.com/grafana/grafana/apps/annotation/pkg/apis/annotation/v0alpha1"
 	storev1 "github.com/grafana/grafana/pkg/registry/apps/annotation/storepb/v1"
@@ -276,6 +277,7 @@ func fromProtoAnnotation(protoAnno *storev1.Annotation) *annotationV0.Annotation
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      protoAnno.Name,
 			Namespace: protoAnno.Namespace,
+			UID:       types.UID(protoAnno.Name),
 		},
 	}
 

--- a/pkg/registry/apps/annotation/memory_store.go
+++ b/pkg/registry/apps/annotation/memory_store.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/google/uuid"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	annotationV0 "github.com/grafana/grafana/apps/annotation/pkg/apis/annotation/v0alpha1"
 )
@@ -159,6 +160,9 @@ func (m *memoryStore) Create(ctx context.Context, anno *annotationV0.Annotation)
 	}
 
 	created := anno.DeepCopy()
+	if created.UID == "" {
+		created.UID = types.UID(created.Name)
+	}
 	if created.CreationTimestamp.IsZero() {
 		created.CreationTimestamp = metav1.Now()
 	}

--- a/pkg/registry/apps/annotation/postgres_partitioned.go
+++ b/pkg/registry/apps/annotation/postgres_partitioned.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/lib/pq"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 const (
@@ -402,6 +403,7 @@ func rowToAnnotation(namespace, name string, timeMs int64, timeEnd *int64,
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			UID:       types.UID(name),
 		},
 		Spec: annotationV0.AnnotationSpec{
 			Time:         timeMs,

--- a/pkg/registry/apps/annotation/register_test.go
+++ b/pkg/registry/apps/annotation/register_test.go
@@ -293,6 +293,51 @@ func TestK8sRESTAdapter_TenantIsolation(t *testing.T) {
 	})
 }
 
+func TestK8sRESTAdapter_UIDIsSet(t *testing.T) {
+	store := NewMemoryStore()
+	adapter := &k8sRESTAdapter{
+		store:        store,
+		accessClient: authtypes.FixedAccessClient(true),
+	}
+
+	ctx := k8srequest.WithNamespace(identity.WithRequester(t.Context(), &identity.StaticRequester{
+		Type:    authtypes.TypeUser,
+		UserUID: "test-user",
+		OrgID:   1,
+	}), "default")
+
+	// Create an annotation
+	anno := &annotationV0.Annotation{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "uid-test",
+			Namespace: "default",
+		},
+		Spec: annotationV0.AnnotationSpec{
+			Text: "test annotation",
+			Time: 12345,
+		},
+	}
+	_, err := adapter.Create(ctx, anno, nil, nil)
+	require.NoError(t, err)
+
+	t.Run("get returns annotation with non-empty UID", func(t *testing.T) {
+		obj, err := adapter.Get(ctx, "uid-test", nil)
+		require.NoError(t, err)
+		result := obj.(*annotationV0.Annotation)
+		assert.NotEmpty(t, result.UID)
+	})
+
+	t.Run("list returns annotations with non-empty UID", func(t *testing.T) {
+		obj, err := adapter.List(ctx, &metainternalversion.ListOptions{})
+		require.NoError(t, err)
+		list := obj.(*annotationV0.AnnotationList)
+		require.NotEmpty(t, list.Items)
+		for _, item := range list.Items {
+			assert.NotEmpty(t, item.UID)
+		}
+	})
+}
+
 func TestK8sRESTAdapter_NotFound(t *testing.T) {
 	store := NewMemoryStore()
 	adapter := &k8sRESTAdapter{

--- a/pkg/registry/apps/annotation/sql_adapter.go
+++ b/pkg/registry/apps/annotation/sql_adapter.go
@@ -7,6 +7,7 @@ import (
 
 	claims "github.com/grafana/authlib/types"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	annotationV0 "github.com/grafana/grafana/apps/annotation/pkg/apis/annotation/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
@@ -216,10 +217,12 @@ func (a *sqlAdapter) ListTags(ctx context.Context, namespace string, opts TagLis
 }
 
 func (a *sqlAdapter) toK8sResource(item *annotations.ItemDTO, namespace string) *annotationV0.Annotation {
+	name := fmt.Sprintf("a-%d", item.ID)
 	anno := &annotationV0.Annotation{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      fmt.Sprintf("a-%d", item.ID),
+			Name:      name,
 			Namespace: namespace,
+			UID:       types.UID(name),
 		},
 		Spec: annotationV0.AnnotationSpec{
 			Text: item.Text,


### PR DESCRIPTION
Adds the UID field to the k8s object metadata returned for the `annotation.grafana.app` resource so that PATCH requests work as expected. The K8s PATCH handler requires a non-empty UID to recognize an existing object ([source](https://github.com/kubernetes/apiserver/blob/4275b1386716339093435e3a84f313d0f311d912/pkg/endpoints/handlers/patch.go#L581-L590)). Without it, it falls into the createNewObject path which constructs a new object from just the patch bytes rather than merging with the existing one, ultimately causing the store's Update() to return not found.