### PR TITLE
Table: Threshold support for sparkline cell

### DIFF
--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/SparklineCell.test.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/SparklineCell.test.tsx
@@ -1,0 +1,111 @@
+import { render } from '@testing-library/react';
+
+import {
+  applyFieldOverrides,
+  createTheme,
+  FieldColorModeId,
+  FieldType,
+  type Field,
+  ThresholdsMode,
+  toDataFrame,
+} from '@grafana/data';
+import { GraphGradientMode, TableCellDisplayMode } from '@grafana/schema';
+
+import { SparklineCell } from './SparklineCell';
+
+const sparklineSpy = jest.fn((_props: unknown) => <div data-testid="sparkline-mock" />);
+
+jest.mock('../../../Sparkline/Sparkline', () => ({
+  Sparkline: (props: unknown) => sparklineSpy(props),
+}));
+
+const tsFrame = toDataFrame({
+  fields: [
+    { name: 'time', type: FieldType.time, values: [1000, 2000] },
+    { name: 'v', type: FieldType.number, values: [1, 99] },
+  ],
+});
+
+function sparklineField(config: Field['config']): Field {
+  const raw = toDataFrame({
+    fields: [
+      {
+        name: 'trend',
+        type: FieldType.frame,
+        values: [tsFrame],
+        config,
+      },
+    ],
+  });
+  return applyFieldOverrides({
+    data: [raw],
+    fieldConfig: { defaults: {}, overrides: [] },
+    replaceVariables: (v) => v,
+    theme: createTheme(),
+    timeZone: 'utc',
+  })[0].fields[0];
+}
+
+function renderSparklineCell(field: Field) {
+  return render(
+    <SparklineCell field={field} rowIdx={0} theme={createTheme()} value={tsFrame} width={300} />
+  );
+}
+
+describe('TableNG SparklineCell threshold wiring', () => {
+  beforeEach(() => {
+    sparklineSpy.mockClear();
+  });
+
+  it('passes thresholds and scheme gradient for From thresholds color mode', () => {
+    const field = sparklineField({
+      custom: { cellOptions: { type: TableCellDisplayMode.Sparkline } },
+      color: { mode: FieldColorModeId.Thresholds },
+      thresholds: {
+        mode: ThresholdsMode.Absolute,
+        steps: [
+          { value: -Infinity, color: 'green' },
+          { value: 80, color: 'red' },
+        ],
+      },
+    });
+
+    renderSparklineCell(field);
+
+    expect(sparklineSpy).toHaveBeenCalled();
+    const cfg = (sparklineSpy.mock.calls[0][0] as { config: unknown }).config as Record<string, unknown>;
+    expect(cfg.thresholds).toEqual(field.config.thresholds);
+    expect((cfg.custom as { gradientMode: string }).gradientMode).toBe(GraphGradientMode.Scheme);
+  });
+
+  it('does not pass thresholds onto Sparkline when color is fixed so Hue stays decorative', () => {
+    const field = sparklineField({
+      custom: { cellOptions: { type: TableCellDisplayMode.Sparkline } },
+      color: { mode: FieldColorModeId.Fixed, fixedColor: 'blue' },
+      thresholds: {
+        mode: ThresholdsMode.Absolute,
+        steps: [{ value: 0, color: 'green' }],
+      },
+    });
+
+    renderSparklineCell(field);
+
+    const cfg = (sparklineSpy.mock.calls[0][0] as { config: unknown }).config as Record<string, unknown>;
+    expect(cfg.thresholds).toBeUndefined();
+    expect((cfg.custom as { gradientMode: string }).gradientMode).toBe(GraphGradientMode.Hue);
+  });
+
+  it('does not use scheme when threshold mode has no steps', () => {
+    const field = sparklineField({
+      custom: { cellOptions: { type: TableCellDisplayMode.Sparkline } },
+      color: { mode: FieldColorModeId.Thresholds },
+      thresholds: { mode: ThresholdsMode.Absolute, steps: [] },
+    });
+
+    renderSparklineCell(field);
+
+    const cfg = (sparklineSpy.mock.calls[0][0] as { config: unknown }).config as Record<string, unknown>;
+    expect(cfg.thresholds).toBeUndefined();
+    expect((cfg.custom as { gradientMode: string }).gradientMode).toBe(GraphGradientMode.Hue);
+  });
+});

--- a/packages/grafana-ui/src/components/Table/TableNG/Cells/SparklineCell.tsx
+++ b/packages/grafana-ui/src/components/Table/TableNG/Cells/SparklineCell.tsx
@@ -2,7 +2,13 @@ import { css } from '@emotion/css';
 import memoize from 'micro-memoize';
 import * as React from 'react';
 
-import { type FieldConfig, getMinMaxAndDelta, type Field, isDataFrameWithValue } from '@grafana/data';
+import {
+  FieldColorModeId,
+  type FieldConfig,
+  getMinMaxAndDelta,
+  type Field,
+  isDataFrameWithValue,
+} from '@grafana/data';
 import { t } from '@grafana/i18n';
 import {
   BarAlignment,
@@ -70,11 +76,17 @@ export const SparklineCell = (props: SparklineCellProps) => {
 
   const cellOptions = getTableSparklineCellOptions(field);
 
+  const useSchemeGradient =
+    field.config.color?.mode === FieldColorModeId.Thresholds &&
+    Boolean(field.config.thresholds?.steps?.length);
+
   const config: FieldConfig<GraphFieldConfig> = {
     color: field.config.color,
+    ...(useSchemeGradient && field.config.thresholds != null && { thresholds: field.config.thresholds }),
     custom: {
       ...defaultSparklineCellConfig,
       ...cellOptions,
+      ...(useSchemeGradient && { gradientMode: GraphGradientMode.Scheme }),
     },
   };
 


### PR DESCRIPTION
This PR adds threshold-based coloring for sparkline cells in Table by passing column thresholds into the shared Sparkline plot and switching to Scheme gradient mode when the field uses From thresholds with at least one step.

Before:


After:
<img width="1171" height="481" alt="image" src="https://github.com/user-attachments/assets/0bffb4e5-a7ec-4896-9b0f-0f3d9875b95a" />


Closes https://github.com/grafana/grafana/issues/76777