### PR TITLE
SplashScreen: disable feature toggle by default for OSS

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1613,7 +1613,7 @@ export interface FeatureToggles {
   frontendServiceSSOAutoLogin?: boolean;
   /**
   * Enables the splash screen modal for introducing new Grafana features on first session
-  * @default true
+  * @default false
   */
   splashScreen?: boolean;
   /**

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -416,10 +416,10 @@ export const useFlagReportingAnyPageReporting = (options?: ReactFlagEvaluationOp
  *
  * **Details:**
  * - flag key: `splashScreen`
- * - default value: `true`
+ * - default value: `false`
  */
 export const useFlagSplashScreen = (options?: ReactFlagEvaluationOptions): boolean => {
-  return useFlag("splashScreen", true, options).value;
+  return useFlag("splashScreen", false, options).value;
 };
 
 /**

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2886,7 +2886,7 @@ var (
 			Stage:       FeatureStagePublicPreview,
 			Owner:       grafanaFrontendPlatformSquad,
 			Generate:    Generate{LegacyFrontend: true, React: true}, // legacy frontend for old naming convention
-			Expression:  "true",
+			Expression:  "false",
 		},
 		{
 			Name:         "streamingForwardTeamHeadersTempo",

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -5775,10 +5775,10 @@
     {
       "metadata": {
         "name": "splashScreen",
-        "resourceVersion": "1775046571105",
+        "resourceVersion": "1778658028142",
         "creationTimestamp": "2026-03-25T17:59:16Z",
         "annotations": {
-          "grafana.app/updatedTimestamp": "2026-04-01 12:29:31.105103 +0000 UTC"
+          "grafana.app/updatedTimestamp": "2026-05-13 07:40:28.142297 +0000 UTC"
         }
       },
       "spec": {
@@ -5786,7 +5786,7 @@
         "stage": "preview",
         "codeowner": "@grafana/grafana-frontend-platform",
         "frontend": true,
-        "expression": "true"
+        "expression": "false"
       }
     },
     {


### PR DESCRIPTION
**What is this about?**
Changes the `splashScreen` feature toggle default expression from `true` to `false`, and regenerates all derived files.

**Why do we need this?**
The splash screen modal (shown on first session to highlight G13) was enabled by default for all deployments including OSS. This change disables it by default so it only appears where explicitly enabled (e.g. Grafana Cloud via flag override). Grafana Cloud splash screen got disabled separately.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.