### PR TITLE
Dependabot: Add cooldown of 14 days for updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
-    labels:
-      - "no-changelog"
   - package-ecosystem: "gomod"
     cooldown:
       default-days: 14 # wait 14 days before creating a PR for a new release
@@ -41,5 +39,3 @@ updates:
       grafana-app-sdk:
         patterns:
           - "github.com/grafana/grafana-app-sdk*"
-    labels:
-      - "no-changelog"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,8 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
+    cooldown:
+      default-days: 14 # wait 14 days before creating a PR for a new release
     commit-message:
       prefix: deps(actions)
     directory: "/"
@@ -9,6 +11,8 @@ updates:
     labels:
       - "no-changelog"
   - package-ecosystem: "gomod"
+    cooldown:
+      default-days: 14 # wait 14 days before creating a PR for a new release
     commit-message:
       prefix: deps(go)
     directories:


### PR DESCRIPTION
This lets us wait 14 days before a new release of a dependency is created as a PR.

Important to note that it does not consider security updates for this!
