### PR TITLE
Auth: Support scope-level restrictions from delegated permission tokens

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -751,3 +751,6 @@ replace (
 // This was retracted, but seems to be known by the Go module proxy, and is
 // otherwise pulled in as a transitive dependency.
 exclude k8s.io/client-go v12.0.0+incompatible
+
+// PoC: authlib with RestrictedDelegatedPermissionScopes on AccessTokenClaims
+replace github.com/grafana/authlib => github.com/sd2k/authlib v0.0.0-20260513102450-83b447f30817

--- a/pkg/services/authn/authn.go
+++ b/pkg/services/authn/authn.go
@@ -73,6 +73,11 @@ type FetchPermissionsParams struct {
 	// K8sRestrictedActions will restrict the permissions to only the Grafana actions
 	// that the Kubernetes-style permission strings translate to
 	K8sRestrictedActions []string
+	// RestrictedScopes further restricts permissions to specific resource scopes.
+	// Map of action -> allowed scope patterns. Only scopes matching the patterns
+	// are kept for that action. Actions not present in this map are unaffected.
+	// This is populated from the "restrictedDelegatedPermissionScopes" JWT claim.
+	RestrictedScopes map[string][]string
 	// AllowedActions will be added to the identity permissions
 	AllowedActions []string
 	// Note: Kept for backwards compatibility, use K8s style instead

--- a/pkg/services/authn/authnimpl/sync/rbac_sync.go
+++ b/pkg/services/authn/authnimpl/sync/rbac_sync.go
@@ -91,6 +91,34 @@ func (s *RBACSync) SyncPermissionsHook(ctx context.Context, ident *authn.Identit
 		}
 		grouped = filtered
 	}
+
+	// Further restrict scopes for specific actions.
+	// restrictedScopes maps action -> allowed scope patterns. For each restricted
+	// action, only user scopes matching an allowed pattern are kept.
+	restrictedScopes := ident.ClientParams.FetchPermissionsParams.RestrictedScopes
+	if len(restrictedScopes) > 0 {
+		for action, allowedScopes := range restrictedScopes {
+			userScopes, ok := grouped[action]
+			if !ok {
+				continue
+			}
+			var kept []string
+			for _, userScope := range userScopes {
+				for _, allowed := range allowedScopes {
+					if userScope == allowed || strings.HasPrefix(userScope, allowed) {
+						kept = append(kept, userScope)
+						break
+					}
+				}
+			}
+			if len(kept) > 0 {
+				grouped[action] = kept
+			} else {
+				delete(grouped, action)
+			}
+		}
+	}
+
 	ident.Permissions[ident.OrgID] = grouped
 
 	return nil

--- a/pkg/services/authn/authnimpl/sync/rbac_sync_test.go
+++ b/pkg/services/authn/authnimpl/sync/rbac_sync_test.go
@@ -245,6 +245,156 @@ func TestRBACSync_FetchPermissions(t *testing.T) {
 	}
 }
 
+func TestRBACSync_RestrictedScopes(t *testing.T) {
+	// Custom mock with specific scoped permissions (not just wildcards)
+	// so we can test that scope filtering keeps/removes the right entries.
+	acMock := &acmock.Mock{
+		GetUserPermissionsFunc: func(ctx context.Context, siu identity.Requester, o accesscontrol.Options) ([]accesscontrol.Permission, error) {
+			return []accesscontrol.Permission{
+				{Action: "datasources:read", Scope: "datasources:uid:prometheus"},
+				{Action: "datasources:read", Scope: "datasources:uid:loki"},
+				{Action: "datasources:read", Scope: "datasources:uid:billing-db"},
+				{Action: "datasources:query", Scope: "datasources:uid:prometheus"},
+				{Action: "datasources:query", Scope: "datasources:uid:loki"},
+				{Action: "datasources:query", Scope: "datasources:uid:billing-db"},
+				{Action: "dashboards:read", Scope: "dashboards:uid:*"},
+				{Action: accesscontrol.ActionUsersRead, Scope: accesscontrol.ScopeUsersAll},
+			}, nil
+		},
+	}
+	permRegistry := permreg.ProvidePermissionRegistry(t)
+	s := &RBACSync{
+		ac:           acMock,
+		log:          log.NewNopLogger(),
+		tracer:       tracing.InitializeTracerForTest(),
+		permRegistry: permRegistry,
+		mapper:       rbac.NewMapperRegistry(),
+	}
+
+	type testCase struct {
+		name                string
+		identity            *authn.Identity
+		expectedPermissions map[string][]string
+	}
+
+	testCases := []testCase{
+		{
+			name: "scope restriction filters to specific datasources",
+			identity: &authn.Identity{
+				ID: "2", Type: claims.TypeUser, OrgID: 1,
+				ClientParams: authn.ClientParams{
+					SyncPermissions: true,
+					FetchPermissionsParams: authn.FetchPermissionsParams{
+						RestrictedScopes: map[string][]string{
+							"datasources:query": {"datasources:uid:prometheus", "datasources:uid:loki"},
+						},
+					},
+				},
+			},
+			expectedPermissions: map[string][]string{
+				// datasources:read has no scope restriction, so all scopes kept
+				"datasources:read": {"datasources:uid:prometheus", "datasources:uid:loki", "datasources:uid:billing-db"},
+				// datasources:query restricted to prometheus and loki only
+				"datasources:query": {"datasources:uid:prometheus", "datasources:uid:loki"},
+				// unrelated actions unaffected
+				"dashboards:read":             {"dashboards:uid:*"},
+				accesscontrol.ActionUsersRead: {accesscontrol.ScopeUsersAll},
+			},
+		},
+		{
+			name: "scope restriction removes action when no scopes survive",
+			identity: &authn.Identity{
+				ID: "2", Type: claims.TypeUser, OrgID: 1,
+				ClientParams: authn.ClientParams{
+					SyncPermissions: true,
+					FetchPermissionsParams: authn.FetchPermissionsParams{
+						RestrictedScopes: map[string][]string{
+							"datasources:query": {"datasources:uid:nonexistent"},
+						},
+					},
+				},
+			},
+			expectedPermissions: map[string][]string{
+				"datasources:read":            {"datasources:uid:prometheus", "datasources:uid:loki", "datasources:uid:billing-db"},
+				"dashboards:read":             {"dashboards:uid:*"},
+				accesscontrol.ActionUsersRead: {accesscontrol.ScopeUsersAll},
+				// datasources:query removed entirely — no scopes matched
+			},
+		},
+		{
+			name: "scope restriction combined with action restriction",
+			identity: &authn.Identity{
+				ID: "2", Type: claims.TypeUser, OrgID: 1,
+				ClientParams: authn.ClientParams{
+					SyncPermissions: true,
+					FetchPermissionsParams: authn.FetchPermissionsParams{
+						// Action-level: only allow datasources:read and datasources:query
+						RestrictedActions: []string{"datasources:read", "datasources:query"},
+						// Scope-level: further restrict query to prometheus only
+						RestrictedScopes: map[string][]string{
+							"datasources:query": {"datasources:uid:prometheus"},
+						},
+					},
+				},
+			},
+			expectedPermissions: map[string][]string{
+				"datasources:read":  {"datasources:uid:prometheus", "datasources:uid:loki", "datasources:uid:billing-db"},
+				"datasources:query": {"datasources:uid:prometheus"},
+				// dashboards:read and users:read filtered out by action restriction
+			},
+		},
+		{
+			name: "no restricted scopes — no filtering applied",
+			identity: &authn.Identity{
+				ID: "2", Type: claims.TypeUser, OrgID: 1,
+				ClientParams: authn.ClientParams{
+					SyncPermissions: true,
+				},
+			},
+			expectedPermissions: map[string][]string{
+				"datasources:read":            {"datasources:uid:prometheus", "datasources:uid:loki", "datasources:uid:billing-db"},
+				"datasources:query":           {"datasources:uid:prometheus", "datasources:uid:loki", "datasources:uid:billing-db"},
+				"dashboards:read":             {"dashboards:uid:*"},
+				accesscontrol.ActionUsersRead: {accesscontrol.ScopeUsersAll},
+			},
+		},
+		{
+			name: "scope restriction on action not in user permissions is a no-op",
+			identity: &authn.Identity{
+				ID: "2", Type: claims.TypeUser, OrgID: 1,
+				ClientParams: authn.ClientParams{
+					SyncPermissions: true,
+					FetchPermissionsParams: authn.FetchPermissionsParams{
+						RestrictedScopes: map[string][]string{
+							"alert.rules:read": {"alert.rules:uid:foo"},
+						},
+					},
+				},
+			},
+			expectedPermissions: map[string][]string{
+				"datasources:read":            {"datasources:uid:prometheus", "datasources:uid:loki", "datasources:uid:billing-db"},
+				"datasources:query":           {"datasources:uid:prometheus", "datasources:uid:loki", "datasources:uid:billing-db"},
+				"dashboards:read":             {"dashboards:uid:*"},
+				accesscontrol.ActionUsersRead: {accesscontrol.ScopeUsersAll},
+			},
+		},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			err := s.SyncPermissionsHook(context.Background(), tt.identity, &authn.Request{})
+			require.NoError(t, err)
+
+			require.Equal(t, len(tt.expectedPermissions), len(tt.identity.Permissions[tt.identity.OrgID]),
+				"expected %d actions but got %d: %v", len(tt.expectedPermissions), len(tt.identity.Permissions[tt.identity.OrgID]), tt.identity.Permissions[tt.identity.OrgID])
+			for action, scopes := range tt.expectedPermissions {
+				require.ElementsMatch(t, scopes, tt.identity.Permissions[tt.identity.OrgID][action],
+					"scopes mismatch for action %s", action)
+			}
+		})
+	}
+}
+
 func TestRBACSync_SyncCloudRoles(t *testing.T) {
 	type testCase struct {
 		desc           string

--- a/pkg/services/authn/clients/ext_jwt.go
+++ b/pkg/services/authn/clients/ext_jwt.go
@@ -156,6 +156,9 @@ func (s *ExtendedJWT) authenticateAsUserViaIDToken(
 			fetchPermissionsParams.RestrictedActions = append(fetchPermissionsParams.RestrictedActions, perm)
 		}
 	}
+	if rs := accessTokenClaims.Rest.RestrictedDelegatedPermissionScopes; len(rs) > 0 {
+		fetchPermissionsParams.RestrictedScopes = rs
+	}
 
 	identity := &authn.Identity{
 		ID:                id,
@@ -291,6 +294,9 @@ func (s *ExtendedJWT) authenticateAsUserViaOBO(
 		} else {
 			fetchPermissionsParams.RestrictedActions = append(fetchPermissionsParams.RestrictedActions, perm)
 		}
+	}
+	if rs := accessTokenClaims.Rest.RestrictedDelegatedPermissionScopes; len(rs) > 0 {
+		fetchPermissionsParams.RestrictedScopes = rs
 	}
 
 	identity := &authn.Identity{


### PR DESCRIPTION
## Summary

- Add `RestrictedScopes` field to `FetchPermissionsParams` for scope-level permission filtering
- Extract `restrictedDelegatedPermissionScopes` JWT claim in `ext_jwt.go` (both user-delegation paths)
- Filter user RBAC scopes in `rbac_sync.go` after the existing action-level filter

When a token carries scoped restrictions (e.g., "datasources:query is only allowed for datasources:uid:prometheus"), the RBAC sync filters each action's scopes to only those matching the allowed patterns. Actions with no surviving scopes are removed entirely.

## Context

Grafana Assistant sends user data to external LLMs. Admins need to restrict which specific resources the Assistant can access per-org, beyond what action-level `delegatedPermissions` provides.

The auth API signs tokens with a new `restrictedDelegatedPermissionScopes` claim (see grafana/auth#1299). This PR adds the Grafana-side consumer.

## Related PRs

- **auth API**: grafana/auth#1299 (produces the claim)
- **authlib**: sd2k/authlib@bsull/scoped-restricted-delegated-permissions (type + claim definitions)

## Test plan

- [ ] Existing RBAC sync tests still pass
- [ ] Token without the new claim: no behavior change
- [ ] Token with scoped restrictions: user permissions filtered to matching scopes only
- [ ] Action with no surviving scopes is removed from permission map

🤖 Generated with [Claude Code](https://claude.com/claude-code)