### PR TITLE
Make swagger / OpenAPI docs Agent Friendly

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -266,6 +266,9 @@ func (hs *HTTPServer) registerRoutes() {
 	// add swagger support
 	hs.registerSwaggerUI(r)
 
+	// agent-friendly markdown views of the OpenAPI spec
+	hs.registerAPIDocs(r)
+
 	r.Post("/api/user/auth-tokens/rotate", routing.Wrap(hs.RotateUserAuthToken))
 	r.Get("/user/auth-tokens/rotate", routing.Wrap(hs.RotateUserAuthTokenRedirect))
 

--- a/pkg/api/apidocs.go
+++ b/pkg/api/apidocs.go
@@ -448,9 +448,13 @@ func relatedOps(e *operationEntry, s *apiDocsState) []*operationEntry {
 	var related []*operationEntry
 	seen := map[string]bool{e.OperationID: true}
 
+	// add records a related operation, skipping duplicates (including e
+	// itself, which is pre-seeded in seen). It returns false only once the
+	// cap is reached, signalling callers to stop scanning. Skipped duplicates
+	// return true so scanning continues.
 	add := func(other *operationEntry) bool {
 		if seen[other.OperationID] {
-			return false
+			return true
 		}
 		seen[other.OperationID] = true
 		related = append(related, other)

--- a/pkg/api/apidocs.go
+++ b/pkg/api/apidocs.go
@@ -1,0 +1,407 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/getkin/kin-openapi/openapi3"
+
+	"github.com/grafana/grafana/pkg/api/response"
+	"github.com/grafana/grafana/pkg/api/routing"
+	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
+	"github.com/grafana/grafana/pkg/web"
+)
+
+// apidocs serves agent-friendly markdown views of the classic /api/* OpenAPI
+// surface (sourced from public/openapi3.json). The /apis/* (App Platform)
+// surface is a follow-up.
+
+type operationEntry struct {
+	OperationID string
+	Method      string
+	Path        string
+	Summary     string
+	Description string
+	Tags        []string
+	Operation   *openapi3.Operation
+}
+
+// apiDocsState holds the parsed spec plus the derived lookup structures the
+// handlers need. Built once at route registration and captured by the
+// per-handler closures, so there's no shared mutable state at request time.
+type apiDocsState struct {
+	spec    *openapi3.T
+	ops     map[string]*operationEntry
+	ordered []*operationEntry
+}
+
+// registerAPIDocs loads the spec once at startup and, if it's available, wires
+// up the agent-friendly markdown endpoints. Public posture mirrors /swagger.
+// A missing spec is logged but non-fatal — the routes simply won't be served
+func (hs *HTTPServer) registerAPIDocs(r routing.RouteRegister) {
+	specPath := filepath.Join(hs.Cfg.StaticRootPath, "openapi3.json")
+	loader := openapi3.NewLoader()
+	doc, err := loader.LoadFromFile(specPath)
+	if err != nil {
+		hs.log.Warn("api-docs: openapi3 spec not available, skipping registration",
+			"path", specPath, "error", err)
+		return
+	}
+	state := buildAPIDocsState(doc)
+
+	r.Get("/llms.txt", routing.Wrap(state.llmsTxtHandler))
+	r.Get("/llms-full.txt", routing.Wrap(state.llmsFullTxtHandler))
+	r.Get("/api-docs/index.json", routing.Wrap(state.manifestHandler))
+	r.Get("/api-docs/operations/:operationId", routing.Wrap(state.operationHandler))
+}
+
+func (s *apiDocsState) llmsTxtHandler(_ *contextmodel.ReqContext) response.Response {
+	return markdownResponse(http.StatusOK, renderLLMsTxt(s))
+}
+
+func (s *apiDocsState) llmsFullTxtHandler(_ *contextmodel.ReqContext) response.Response {
+	return markdownResponse(http.StatusOK, renderLLMsFullTxt(s))
+}
+
+func renderLLMsTxt(s *apiDocsState) string {
+	var b strings.Builder
+	title := "Grafana HTTP API"
+	if s.spec.Info != nil && s.spec.Info.Title != "" {
+		title = s.spec.Info.Title
+	}
+	fmt.Fprintf(&b, "# %s\n\n", title)
+	if s.spec.Info != nil && s.spec.Info.Description != "" {
+		fmt.Fprintf(&b, "> %s\n\n", oneLine(s.spec.Info.Description))
+	} else {
+		b.WriteString("> Grafana's HTTP API. Per-operation docs for AI/agent consumption.\n\n")
+	}
+
+	b.WriteString("## Discovery\n\n")
+	b.WriteString("- [Operations manifest (JSON)](/api-docs/index.json)\n")
+	b.WriteString("- [Full markdown bundle](/llms-full.txt)\n")
+	b.WriteString("- [Swagger UI](/swagger)\n\n")
+
+	byTag := map[string][]*operationEntry{}
+	for _, e := range s.ordered {
+		if len(e.Tags) == 0 {
+			byTag["(untagged)"] = append(byTag["(untagged)"], e)
+			continue
+		}
+		for _, t := range e.Tags {
+			byTag[t] = append(byTag[t], e)
+		}
+	}
+	tags := make([]string, 0, len(byTag))
+	for t := range byTag {
+		tags = append(tags, t)
+	}
+	sort.Strings(tags)
+
+	for _, t := range tags {
+		fmt.Fprintf(&b, "## %s\n\n", t)
+		for _, e := range byTag[t] {
+			summary := e.Summary
+			if summary == "" {
+				summary = oneLine(e.Description)
+			}
+			fmt.Fprintf(&b, "- [%s %s](/api-docs/operations/%s): %s\n",
+				e.Method, e.Path, e.OperationID, summary)
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func renderLLMsFullTxt(s *apiDocsState) string {
+	var b strings.Builder
+	title := "Grafana HTTP API"
+	if s.spec.Info != nil && s.spec.Info.Title != "" {
+		title = s.spec.Info.Title
+	}
+	fmt.Fprintf(&b, "# %s — Full Operation Reference\n\n", title)
+	for _, e := range s.ordered {
+		b.WriteString(renderOperationMarkdown(e))
+		b.WriteString("\n---\n\n")
+	}
+	return b.String()
+}
+
+type apiDocsManifestEntry struct {
+	OperationID string   `json:"operationId"`
+	Method      string   `json:"method"`
+	Path        string   `json:"path"`
+	Summary     string   `json:"summary,omitempty"`
+	Tags        []string `json:"tags,omitempty"`
+	MarkdownURL string   `json:"markdownUrl"`
+}
+
+type apiDocsManifest struct {
+	Title      string                 `json:"title"`
+	Version    string                 `json:"version,omitempty"`
+	Operations []apiDocsManifestEntry `json:"operations"`
+}
+
+func (s *apiDocsState) manifestHandler(_ *contextmodel.ReqContext) response.Response {
+	m := apiDocsManifest{
+		Operations: make([]apiDocsManifestEntry, 0, len(s.ordered)),
+	}
+	if s.spec.Info != nil {
+		m.Title = s.spec.Info.Title
+		m.Version = s.spec.Info.Version
+	}
+	for _, e := range s.ordered {
+		m.Operations = append(m.Operations, apiDocsManifestEntry{
+			OperationID: e.OperationID,
+			Method:      e.Method,
+			Path:        e.Path,
+			Summary:     e.Summary,
+			Tags:        e.Tags,
+			MarkdownURL: "/api-docs/operations/" + e.OperationID,
+		})
+	}
+	return response.JSON(http.StatusOK, m)
+}
+
+func (s *apiDocsState) operationHandler(c *contextmodel.ReqContext) response.Response {
+	opID := strings.TrimSuffix(web.Params(c.Req)[":operationId"], ".md")
+	entry, ok := s.ops[opID]
+	if !ok {
+		return response.Error(http.StatusNotFound, "unknown operationId: "+opID, nil)
+	}
+	return markdownResponse(http.StatusOK, renderOperationMarkdown(entry))
+}
+
+func markdownResponse(status int, body string) response.Response {
+	h := http.Header{}
+	h.Set("Content-Type", "text/markdown; charset=utf-8")
+	h.Set("Cache-Control", "public, max-age=300")
+	return response.CreateNormalResponse(h, []byte(body), status)
+}
+
+func buildAPIDocsState(doc *openapi3.T) *apiDocsState {
+	s := &apiDocsState{spec: doc, ops: map[string]*operationEntry{}}
+	if doc.Paths == nil {
+		return s
+	}
+
+	paths := doc.Paths.Map()
+	pathKeys := make([]string, 0, len(paths))
+	for k := range paths {
+		pathKeys = append(pathKeys, k)
+	}
+	sort.Strings(pathKeys)
+
+	for _, p := range pathKeys {
+		item := paths[p]
+		if item == nil {
+			continue
+		}
+		for method, op := range item.Operations() {
+			if op == nil {
+				continue
+			}
+			id := op.OperationID
+			if id == "" {
+				id = synthesizeOperationID(method, p)
+			}
+			entry := &operationEntry{
+				OperationID: id,
+				Method:      strings.ToUpper(method),
+				Path:        p,
+				Summary:     op.Summary,
+				Description: op.Description,
+				Tags:        op.Tags,
+				Operation:   op,
+			}
+			s.ops[id] = entry
+			s.ordered = append(s.ordered, entry)
+		}
+	}
+
+	sort.SliceStable(s.ordered, func(i, j int) bool {
+		if s.ordered[i].Path == s.ordered[j].Path {
+			return s.ordered[i].Method < s.ordered[j].Method
+		}
+		return s.ordered[i].Path < s.ordered[j].Path
+	})
+
+	return s
+}
+
+// synthesizeOperationID produces a stable identifier when the spec omits one.
+func synthesizeOperationID(method, path string) string {
+	s := strings.ToLower(method) + "_" + path
+	out := make([]rune, 0, len(s))
+	prevUnderscore := false
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			out = append(out, r)
+			prevUnderscore = false
+		default:
+			if !prevUnderscore {
+				out = append(out, '_')
+				prevUnderscore = true
+			}
+		}
+	}
+	return strings.Trim(string(out), "_")
+}
+
+func renderOperationMarkdown(e *operationEntry) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "# %s %s\n\n", e.Method, e.Path)
+	if e.Summary != "" {
+		fmt.Fprintf(&b, "%s\n\n", e.Summary)
+	}
+	if e.Description != "" {
+		fmt.Fprintf(&b, "%s\n\n", strings.TrimSpace(e.Description))
+	}
+	fmt.Fprintf(&b, "- Operation ID: `%s`\n", e.OperationID)
+	if len(e.Tags) > 0 {
+		fmt.Fprintf(&b, "- Tags: %s\n", strings.Join(e.Tags, ", "))
+	}
+	if e.Operation.Deprecated {
+		b.WriteString("- Deprecated: yes\n")
+	}
+	b.WriteString("\n")
+
+	if len(e.Operation.Parameters) > 0 {
+		b.WriteString("## Parameters\n\n")
+		for _, pref := range e.Operation.Parameters {
+			if pref == nil || pref.Value == nil {
+				continue
+			}
+			p := pref.Value
+			req := ""
+			if p.Required {
+				req = ", required"
+			}
+			fmt.Fprintf(&b, "- `%s` (%s, %s%s): %s\n",
+				p.Name, p.In, paramTypeOf(p), req, oneLine(p.Description))
+		}
+		b.WriteString("\n")
+	}
+
+	if e.Operation.RequestBody != nil && e.Operation.RequestBody.Value != nil {
+		rb := e.Operation.RequestBody.Value
+		b.WriteString("## Request Body\n\n")
+		if rb.Required {
+			b.WriteString("Required.\n\n")
+		}
+		if rb.Description != "" {
+			fmt.Fprintf(&b, "%s\n\n", oneLine(rb.Description))
+		}
+		mediaTypes := make([]string, 0, len(rb.Content))
+		for mt := range rb.Content {
+			mediaTypes = append(mediaTypes, mt)
+		}
+		sort.Strings(mediaTypes)
+		for _, mt := range mediaTypes {
+			media := rb.Content[mt]
+			fmt.Fprintf(&b, "- Content-Type: `%s`", mt)
+			if media != nil && media.Schema != nil {
+				if ref := refName(media.Schema.Ref); ref != "" {
+					fmt.Fprintf(&b, " — schema: `%s`", ref)
+				} else if media.Schema.Value != nil {
+					fmt.Fprintf(&b, " — type: `%s`", schemaType(media.Schema.Value))
+				}
+			}
+			b.WriteString("\n")
+		}
+		b.WriteString("\n")
+	}
+
+	if e.Operation.Responses != nil {
+		resps := e.Operation.Responses.Map()
+		if len(resps) > 0 {
+			b.WriteString("## Responses\n\n")
+			codes := make([]string, 0, len(resps))
+			for c := range resps {
+				codes = append(codes, c)
+			}
+			sort.Strings(codes)
+			for _, code := range codes {
+				rref := resps[code]
+				if rref == nil || rref.Value == nil {
+					continue
+				}
+				r := rref.Value
+				desc := ""
+				if r.Description != nil {
+					desc = oneLine(*r.Description)
+				}
+				fmt.Fprintf(&b, "- `%s`: %s", code, desc)
+				for mt, media := range r.Content {
+					if media != nil && media.Schema != nil {
+						if ref := refName(media.Schema.Ref); ref != "" {
+							fmt.Fprintf(&b, " (`%s` → `%s`)", mt, ref)
+						}
+					}
+				}
+				b.WriteString("\n")
+			}
+			b.WriteString("\n")
+		}
+	}
+
+	if e.Operation.Security != nil && len(*e.Operation.Security) > 0 {
+		b.WriteString("## Security\n\n")
+		for _, sec := range *e.Operation.Security {
+			for name := range sec {
+				fmt.Fprintf(&b, "- %s\n", name)
+			}
+		}
+		b.WriteString("\n")
+	}
+
+	return b.String()
+}
+
+func paramTypeOf(p *openapi3.Parameter) string {
+	if p.Schema == nil {
+		return "any"
+	}
+	if ref := refName(p.Schema.Ref); ref != "" {
+		return ref
+	}
+	if p.Schema.Value == nil {
+		return "any"
+	}
+	return schemaType(p.Schema.Value)
+}
+
+func schemaType(s *openapi3.Schema) string {
+	if s == nil || s.Type == nil {
+		return "any"
+	}
+	ts := s.Type.Slice()
+	if len(ts) == 0 {
+		return "any"
+	}
+	return strings.Join(ts, "|")
+}
+
+func refName(ref string) string {
+	if ref == "" {
+		return ""
+	}
+	idx := strings.LastIndex(ref, "/")
+	if idx < 0 {
+		return ref
+	}
+	return ref[idx+1:]
+}
+
+func oneLine(s string) string {
+	s = strings.TrimSpace(s)
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "\r", " ")
+	for strings.Contains(s, "  ") {
+		s = strings.ReplaceAll(s, "  ", " ")
+	}
+	return s
+}

--- a/pkg/api/apidocs.go
+++ b/pkg/api/apidocs.go
@@ -42,7 +42,7 @@ type apiDocsState struct {
 	ops     map[string]*operationEntry
 	ordered []*operationEntry
 	// appURL is the externally reachable root of this Grafana instance
-	// (e.g. "https://grafana.example.com"). Used to emit absolute URLs in
+	// (e.g. "https://example.grafana.com"). Used to emit absolute URLs in
 	// llms.txt / llms-full.txt so agents can resolve links without guessing
 	// the hostname. May be empty in tests; relative paths are used as fallback.
 	appURL string

--- a/pkg/api/apidocs.go
+++ b/pkg/api/apidocs.go
@@ -528,11 +528,7 @@ func renderOperationMarkdown(e *operationEntry, s *apiDocsState) string {
 	}
 	b.WriteString("\n")
 
-	// Base URL and auth context — agents fetching this page in isolation need
-	// this to construct a working curl command.
-	opBase := s.appURL
-	fmt.Fprintf(&b, "> Full URL: `%s %s/api%s`\n", e.Method, opBase, e.Path)
-	b.WriteString("> Authenticate with `Authorization: Bearer <SERVICE_ACCOUNT_TOKEN>` or basic auth (`-u admin:password`).\n\n")
+	renderOperationContext(&b, e, s)
 
 	// Caution block for operations with replace-all or irreversible semantics.
 	if note, ok := operationNotes[e.OperationID]; ok {
@@ -540,152 +536,186 @@ func renderOperationMarkdown(e *operationEntry, s *apiDocsState) string {
 		fmt.Fprintf(&b, "> %s\n\n", note)
 	}
 
-	if len(e.Operation.Parameters) > 0 {
-		b.WriteString("## Parameters\n\n")
-		for _, pref := range e.Operation.Parameters {
-			if pref == nil || pref.Value == nil {
-				continue
-			}
-			p := pref.Value
-			req := ""
-			if p.Required {
-				req = ", required"
-			}
-			fmt.Fprintf(&b, "- `%s` (%s, %s%s): %s\n",
-				p.Name, p.In, paramTypeOf(p), req, oneLine(p.Description))
-		}
-		b.WriteString("\n")
-	}
-
-	if e.Operation.RequestBody != nil && e.Operation.RequestBody.Value != nil {
-		rb := e.Operation.RequestBody.Value
-		b.WriteString("## Request Body\n\n")
-		if rb.Required {
-			b.WriteString("Required.\n\n")
-		}
-		if rb.Description != "" {
-			fmt.Fprintf(&b, "%s\n\n", oneLine(rb.Description))
-		}
-		mediaTypes := make([]string, 0, len(rb.Content))
-		for mt := range rb.Content {
-			mediaTypes = append(mediaTypes, mt)
-		}
-		sort.Strings(mediaTypes)
-		for _, mt := range mediaTypes {
-			media := rb.Content[mt]
-			fmt.Fprintf(&b, "- Content-Type: `%s`", mt)
-			if media != nil && media.Schema != nil {
-				if ref := refName(media.Schema.Ref); ref != "" {
-					fmt.Fprintf(&b, " — schema: `%s`", ref)
-				} else if media.Schema.Value != nil {
-					fmt.Fprintf(&b, " — type: `%s`", schemaType(media.Schema.Value))
-				}
-			}
-			b.WriteString("\n")
-			if media != nil {
-				if ex := exampleJSON(media.Schema); ex != "" {
-					fmt.Fprintf(&b, "\n  Example:\n\n  ```json\n%s\n  ```\n", indentBlock(ex, "  "))
-				}
-			}
-		}
-		b.WriteString("\n")
-	}
-
-	if e.Operation.Responses != nil {
-		resps := e.Operation.Responses.Map()
-		if len(resps) > 0 {
-			b.WriteString("## Responses\n\n")
-			codes := make([]string, 0, len(resps))
-			for c := range resps {
-				codes = append(codes, c)
-			}
-			sort.Strings(codes)
-
-			// Track schema refs whose example has already been rendered in
-			// this responses block so we don't repeat the same JSON object
-			// once per error code.
-			renderedExamples := map[string]bool{}
-
-			for _, code := range codes {
-				rref := resps[code]
-				if rref == nil || rref.Value == nil {
-					continue
-				}
-				r := rref.Value
-				desc := ""
-				if r.Description != nil {
-					desc = oneLine(*r.Description)
-				}
-				fmt.Fprintf(&b, "- `%s`: %s", code, desc)
-				mediaTypes := make([]string, 0, len(r.Content))
-				for mt := range r.Content {
-					mediaTypes = append(mediaTypes, mt)
-				}
-				sort.Strings(mediaTypes)
-				for _, mt := range mediaTypes {
-					media := r.Content[mt]
-					if media != nil && media.Schema != nil {
-						if ref := refName(media.Schema.Ref); ref != "" {
-							fmt.Fprintf(&b, " (`%s` → `%s`)", mt, ref)
-						} else if media.Schema.Value != nil {
-							fmt.Fprintf(&b, " (`%s` → `%s`)", mt, schemaType(media.Schema.Value))
-						}
-					}
-				}
-				b.WriteString("\n")
-				for _, mt := range mediaTypes {
-					media := r.Content[mt]
-					if media == nil {
-						continue
-					}
-					// Suppress duplicate examples: same schema ref across
-					// multiple error responses would produce identical JSON.
-					schemaKey := refName(media.Schema.Ref)
-					if schemaKey == "" && media.Schema != nil && media.Schema.Value != nil {
-						schemaKey = schemaType(media.Schema.Value)
-					}
-					if schemaKey != "" && renderedExamples[schemaKey] {
-						continue
-					}
-					if ex := exampleJSON(media.Schema); ex != "" {
-						fmt.Fprintf(&b, "\n  Example (`%s`):\n\n  ```json\n%s\n  ```\n", mt, indentBlock(ex, "  "))
-						if schemaKey != "" {
-							renderedExamples[schemaKey] = true
-						}
-					}
-				}
-			}
-			b.WriteString("\n")
-		}
-	}
-
-	if e.Operation.Security != nil && len(*e.Operation.Security) > 0 {
-		b.WriteString("## Security\n\n")
-		for _, sec := range *e.Operation.Security {
-			for name := range sec {
-				fmt.Fprintf(&b, "- %s\n", name)
-			}
-		}
-		b.WriteString("\n")
-	}
-
-	// Related operations: same-path peers, parent collection, direct children.
-	if s != nil {
-		if rel := relatedOps(e, s); len(rel) > 0 {
-			b.WriteString("## Related Operations\n\n")
-			for _, r := range rel {
-				summary := r.Summary
-				if summary == "" {
-					summary = oneLine(r.Description)
-				}
-				url := s.appURL + "/api-docs/operations/" + r.OperationID
-				fmt.Fprintf(&b, "- [%s %s](%s): %s\n", r.Method, r.Path, url, summary)
-			}
-			b.WriteString("\n")
-		}
-	}
+	renderParametersSection(&b, e)
+	renderRequestBodySection(&b, e)
+	renderResponsesSection(&b, e)
+	renderSecuritySection(&b, e)
+	renderRelatedOpsSection(&b, e, s)
 
 	return b.String()
+}
+
+func renderOperationContext(b *strings.Builder, e *operationEntry, s *apiDocsState) {
+	opBase := ""
+	if s != nil {
+		opBase = s.appURL
+	}
+	fmt.Fprintf(b, "> Full URL: `%s %s/api%s`\n", e.Method, opBase, e.Path)
+	b.WriteString("> Authenticate with `Authorization: Bearer <SERVICE_ACCOUNT_TOKEN>` or basic auth (`-u admin:password`).\n\n")
+}
+
+func renderParametersSection(b *strings.Builder, e *operationEntry) {
+	if len(e.Operation.Parameters) == 0 {
+		return
+	}
+	b.WriteString("## Parameters\n\n")
+	for _, pref := range e.Operation.Parameters {
+		if pref == nil || pref.Value == nil {
+			continue
+		}
+		p := pref.Value
+		req := ""
+		if p.Required {
+			req = ", required"
+		}
+		fmt.Fprintf(b, "- `%s` (%s, %s%s): %s\n",
+			p.Name, p.In, paramTypeOf(p), req, oneLine(p.Description))
+	}
+	b.WriteString("\n")
+}
+
+func renderRequestBodySection(b *strings.Builder, e *operationEntry) {
+	if e.Operation.RequestBody == nil || e.Operation.RequestBody.Value == nil {
+		return
+	}
+	rb := e.Operation.RequestBody.Value
+	b.WriteString("## Request Body\n\n")
+	if rb.Required {
+		b.WriteString("Required.\n\n")
+	}
+	if rb.Description != "" {
+		fmt.Fprintf(b, "%s\n\n", oneLine(rb.Description))
+	}
+	mediaTypes := sortedMediaTypes(rb.Content)
+	for _, mt := range mediaTypes {
+		media := rb.Content[mt]
+		fmt.Fprintf(b, "- Content-Type: `%s`", mt)
+		if media != nil && media.Schema != nil {
+			if ref := refName(media.Schema.Ref); ref != "" {
+				fmt.Fprintf(b, " — schema: `%s`", ref)
+			} else if media.Schema.Value != nil {
+				fmt.Fprintf(b, " — type: `%s`", schemaType(media.Schema.Value))
+			}
+		}
+		b.WriteString("\n")
+		if media != nil {
+			if ex := exampleJSON(media.Schema); ex != "" {
+				fmt.Fprintf(b, "\n  Example:\n\n  ```json\n%s\n  ```\n", indentBlock(ex, "  "))
+			}
+		}
+	}
+	b.WriteString("\n")
+}
+
+func renderResponsesSection(b *strings.Builder, e *operationEntry) {
+	if e.Operation.Responses == nil {
+		return
+	}
+	resps := e.Operation.Responses.Map()
+	if len(resps) == 0 {
+		return
+	}
+	b.WriteString("## Responses\n\n")
+	codes := make([]string, 0, len(resps))
+	for c := range resps {
+		codes = append(codes, c)
+	}
+	sort.Strings(codes)
+	renderedExamples := map[string]bool{}
+
+	for _, code := range codes {
+		rref := resps[code]
+		if rref == nil || rref.Value == nil {
+			continue
+		}
+		renderResponseCode(b, code, rref.Value, renderedExamples)
+	}
+	b.WriteString("\n")
+}
+
+func renderResponseCode(b *strings.Builder, code string, r *openapi3.Response, renderedExamples map[string]bool) {
+	desc := ""
+	if r.Description != nil {
+		desc = oneLine(*r.Description)
+	}
+	fmt.Fprintf(b, "- `%s`: %s", code, desc)
+	mediaTypes := sortedMediaTypes(r.Content)
+	for _, mt := range mediaTypes {
+		media := r.Content[mt]
+		if media == nil || media.Schema == nil {
+			continue
+		}
+		if ref := refName(media.Schema.Ref); ref != "" {
+			fmt.Fprintf(b, " (`%s` → `%s`)", mt, ref)
+		} else if media.Schema.Value != nil {
+			fmt.Fprintf(b, " (`%s` → `%s`)", mt, schemaType(media.Schema.Value))
+		}
+	}
+	b.WriteString("\n")
+	for _, mt := range mediaTypes {
+		renderResponseExample(b, mt, r.Content[mt], renderedExamples)
+	}
+}
+
+func renderResponseExample(b *strings.Builder, mediaType string, media *openapi3.MediaType, renderedExamples map[string]bool) {
+	if media == nil || media.Schema == nil {
+		return
+	}
+	schemaKey := refName(media.Schema.Ref)
+	if schemaKey == "" && media.Schema.Value != nil {
+		schemaKey = schemaType(media.Schema.Value)
+	}
+	if schemaKey != "" && renderedExamples[schemaKey] {
+		return
+	}
+	if ex := exampleJSON(media.Schema); ex != "" {
+		fmt.Fprintf(b, "\n  Example (`%s`):\n\n  ```json\n%s\n  ```\n", mediaType, indentBlock(ex, "  "))
+		if schemaKey != "" {
+			renderedExamples[schemaKey] = true
+		}
+	}
+}
+
+func renderSecuritySection(b *strings.Builder, e *operationEntry) {
+	if e.Operation.Security == nil || len(*e.Operation.Security) == 0 {
+		return
+	}
+	b.WriteString("## Security\n\n")
+	for _, sec := range *e.Operation.Security {
+		for name := range sec {
+			fmt.Fprintf(b, "- %s\n", name)
+		}
+	}
+	b.WriteString("\n")
+}
+
+func renderRelatedOpsSection(b *strings.Builder, e *operationEntry, s *apiDocsState) {
+	if s == nil {
+		return
+	}
+	rel := relatedOps(e, s)
+	if len(rel) == 0 {
+		return
+	}
+	b.WriteString("## Related Operations\n\n")
+	for _, r := range rel {
+		summary := r.Summary
+		if summary == "" {
+			summary = oneLine(r.Description)
+		}
+		url := s.appURL + "/api-docs/operations/" + r.OperationID
+		fmt.Fprintf(b, "- [%s %s](%s): %s\n", r.Method, r.Path, url, summary)
+	}
+	b.WriteString("\n")
+}
+
+func sortedMediaTypes(content openapi3.Content) []string {
+	mediaTypes := make([]string, 0, len(content))
+	for mt := range content {
+		mediaTypes = append(mediaTypes, mt)
+	}
+	sort.Strings(mediaTypes)
+	return mediaTypes
 }
 
 func paramTypeOf(p *openapi3.Parameter) string {
@@ -776,51 +806,64 @@ func exampleValueForSchema(sref *openapi3.SchemaRef, visited map[string]bool, de
 		return s.Example
 	}
 
-	refKey := refName(sref.Ref)
-	if refKey != "" {
-		if visited[refKey] {
-			return map[string]any{"$ref": refKey}
-		}
-		visited[refKey] = true
-		defer delete(visited, refKey)
+	refVal, done, cleanup := beginSchemaRefVisit(sref.Ref, visited)
+	if done {
+		return refVal
+	}
+	if cleanup != nil {
+		defer cleanup()
 	}
 
-	// allOf: merge object properties from all members plus our own.
+	if v := exampleValueForComposites(s, visited, depth); v != nil {
+		return v
+	}
+	return exampleValueForPrimaryType(s, visited, depth)
+}
+
+func beginSchemaRefVisit(ref string, visited map[string]bool) (any, bool, func()) {
+	refKey := refName(ref)
+	if refKey == "" {
+		return nil, false, nil
+	}
+	if visited[refKey] {
+		return map[string]any{"$ref": refKey}, true, nil
+	}
+	visited[refKey] = true
+	return nil, false, func() { delete(visited, refKey) }
+}
+
+func exampleValueForComposites(s *openapi3.Schema, visited map[string]bool, depth int) any {
 	if len(s.AllOf) > 0 {
-		merged := map[string]any{}
-		for _, m := range s.AllOf {
-			if v, ok := exampleValueForSchema(m, visited, depth+1).(map[string]any); ok {
-				for k, val := range v {
-					merged[k] = val
-				}
-			}
-		}
-		for name, prop := range s.Properties {
-			merged[name] = exampleValueForSchema(prop, visited, depth+1)
-		}
-		if len(merged) > 0 {
+		if merged := mergeAllOfExample(s, visited, depth); len(merged) > 0 {
 			return merged
 		}
 	}
-
 	if len(s.OneOf) > 0 {
 		return exampleValueForSchema(s.OneOf[0], visited, depth+1)
 	}
 	if len(s.AnyOf) > 0 {
 		return exampleValueForSchema(s.AnyOf[0], visited, depth+1)
 	}
+	return nil
+}
 
-	primary := ""
-	if s.Type != nil {
-		if ts := s.Type.Slice(); len(ts) > 0 {
-			primary = ts[0]
+func mergeAllOfExample(s *openapi3.Schema, visited map[string]bool, depth int) map[string]any {
+	merged := map[string]any{}
+	for _, m := range s.AllOf {
+		if v, ok := exampleValueForSchema(m, visited, depth+1).(map[string]any); ok {
+			for k, val := range v {
+				merged[k] = val
+			}
 		}
 	}
-	if primary == "" && len(s.Properties) > 0 {
-		primary = "object"
+	for name, prop := range s.Properties {
+		merged[name] = exampleValueForSchema(prop, visited, depth+1)
 	}
+	return merged
+}
 
-	switch primary {
+func exampleValueForPrimaryType(s *openapi3.Schema, visited map[string]bool, depth int) any {
+	switch schemaPrimaryType(s) {
 	case "object":
 		out := map[string]any{}
 		for name, prop := range s.Properties {
@@ -838,24 +881,35 @@ func exampleValueForSchema(sref *openapi3.SchemaRef, visited map[string]bool, de
 		}
 		return stringFormatExample(s.Format)
 	case "integer":
-		if s.Default != nil {
-			return s.Default
-		}
-		return 0
+		return firstNonNil(s.Default, 0)
 	case "number":
-		if s.Default != nil {
-			return s.Default
-		}
-		return 0.0
+		return firstNonNil(s.Default, 0.0)
 	case "boolean":
-		if s.Default != nil {
-			return s.Default
-		}
-		return false
+		return firstNonNil(s.Default, false)
 	case "null":
 		return nil
+	default:
+		return nil
 	}
-	return nil
+}
+
+func schemaPrimaryType(s *openapi3.Schema) string {
+	if s.Type != nil {
+		if ts := s.Type.Slice(); len(ts) > 0 {
+			return ts[0]
+		}
+	}
+	if len(s.Properties) > 0 {
+		return "object"
+	}
+	return ""
+}
+
+func firstNonNil(v any, fallback any) any {
+	if v != nil {
+		return v
+	}
+	return fallback
 }
 
 func stringFormatExample(format string) string {

--- a/pkg/api/apidocs.go
+++ b/pkg/api/apidocs.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"path/filepath"
@@ -14,6 +15,10 @@ import (
 	contextmodel "github.com/grafana/grafana/pkg/services/contexthandler/model"
 	"github.com/grafana/grafana/pkg/web"
 )
+
+// maxExampleDepth caps recursion when synthesizing example payloads to keep
+// output manageable for very nested schemas (e.g. Dashboard).
+const maxExampleDepth = 4
 
 // apidocs serves agent-friendly markdown views of the classic /api/* OpenAPI
 // surface (sourced from public/openapi3.json). The /apis/* (App Platform)
@@ -311,6 +316,11 @@ func renderOperationMarkdown(e *operationEntry) string {
 				}
 			}
 			b.WriteString("\n")
+			if media != nil {
+				if ex := exampleJSON(media.Schema); ex != "" {
+					fmt.Fprintf(&b, "\n  Example:\n\n  ```json\n%s\n  ```\n", indentBlock(ex, "  "))
+				}
+			}
 		}
 		b.WriteString("\n")
 	}
@@ -335,14 +345,31 @@ func renderOperationMarkdown(e *operationEntry) string {
 					desc = oneLine(*r.Description)
 				}
 				fmt.Fprintf(&b, "- `%s`: %s", code, desc)
-				for mt, media := range r.Content {
+				mediaTypes := make([]string, 0, len(r.Content))
+				for mt := range r.Content {
+					mediaTypes = append(mediaTypes, mt)
+				}
+				sort.Strings(mediaTypes)
+				for _, mt := range mediaTypes {
+					media := r.Content[mt]
 					if media != nil && media.Schema != nil {
 						if ref := refName(media.Schema.Ref); ref != "" {
 							fmt.Fprintf(&b, " (`%s` → `%s`)", mt, ref)
+						} else if media.Schema.Value != nil {
+							fmt.Fprintf(&b, " (`%s` → `%s`)", mt, schemaType(media.Schema.Value))
 						}
 					}
 				}
 				b.WriteString("\n")
+				for _, mt := range mediaTypes {
+					media := r.Content[mt]
+					if media == nil {
+						continue
+					}
+					if ex := exampleJSON(media.Schema); ex != "" {
+						fmt.Fprintf(&b, "\n  Example (`%s`):\n\n  ```json\n%s\n  ```\n", mt, indentBlock(ex, "  "))
+					}
+				}
 			}
 			b.WriteString("\n")
 		}
@@ -404,4 +431,147 @@ func oneLine(s string) string {
 		s = strings.ReplaceAll(s, "  ", " ")
 	}
 	return s
+}
+
+// indentBlock prefixes every line of s with prefix. Used to align JSON
+// examples inside a Markdown list item so they render correctly.
+func indentBlock(s, prefix string) string {
+	if s == "" {
+		return s
+	}
+	lines := strings.Split(s, "\n")
+	for i, l := range lines {
+		lines[i] = prefix + l
+	}
+	return strings.Join(lines, "\n")
+}
+
+// exampleJSON synthesizes a representative JSON payload for the given schema
+// and returns it pretty-printed. Returns an empty string when no useful value
+// can be produced (e.g. nil schema or unresolved $ref).
+func exampleJSON(sref *openapi3.SchemaRef) string {
+	v := exampleValueForSchema(sref, map[string]bool{}, 0)
+	if v == nil {
+		return ""
+	}
+	buf, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return ""
+	}
+	return string(buf)
+}
+
+// exampleValueForSchema walks a resolved schema and builds a Go value that
+// JSON-marshals to a plausible example payload. It honors any explicit
+// `example` field on the schema, picks Enum[0] or Default where available,
+// and falls back to format-aware placeholders. Depth-limited via
+// maxExampleDepth, cycle-safe via the visited ref-name set.
+func exampleValueForSchema(sref *openapi3.SchemaRef, visited map[string]bool, depth int) any {
+	if sref == nil || depth > maxExampleDepth || sref.Value == nil {
+		return nil
+	}
+	s := sref.Value
+
+	if s.Example != nil {
+		return s.Example
+	}
+
+	refKey := refName(sref.Ref)
+	if refKey != "" {
+		if visited[refKey] {
+			return map[string]any{"$ref": refKey}
+		}
+		visited[refKey] = true
+		defer delete(visited, refKey)
+	}
+
+	// allOf: merge object properties from all members plus our own.
+	if len(s.AllOf) > 0 {
+		merged := map[string]any{}
+		for _, m := range s.AllOf {
+			if v, ok := exampleValueForSchema(m, visited, depth+1).(map[string]any); ok {
+				for k, val := range v {
+					merged[k] = val
+				}
+			}
+		}
+		for name, prop := range s.Properties {
+			merged[name] = exampleValueForSchema(prop, visited, depth+1)
+		}
+		if len(merged) > 0 {
+			return merged
+		}
+	}
+
+	if len(s.OneOf) > 0 {
+		return exampleValueForSchema(s.OneOf[0], visited, depth+1)
+	}
+	if len(s.AnyOf) > 0 {
+		return exampleValueForSchema(s.AnyOf[0], visited, depth+1)
+	}
+
+	primary := ""
+	if s.Type != nil {
+		if ts := s.Type.Slice(); len(ts) > 0 {
+			primary = ts[0]
+		}
+	}
+	if primary == "" && len(s.Properties) > 0 {
+		primary = "object"
+	}
+
+	switch primary {
+	case "object":
+		out := map[string]any{}
+		for name, prop := range s.Properties {
+			out[name] = exampleValueForSchema(prop, visited, depth+1)
+		}
+		return out
+	case "array":
+		return []any{exampleValueForSchema(s.Items, visited, depth+1)}
+	case "string":
+		if s.Default != nil {
+			return s.Default
+		}
+		if len(s.Enum) > 0 {
+			return s.Enum[0]
+		}
+		return stringFormatExample(s.Format)
+	case "integer":
+		if s.Default != nil {
+			return s.Default
+		}
+		return 0
+	case "number":
+		if s.Default != nil {
+			return s.Default
+		}
+		return 0.0
+	case "boolean":
+		if s.Default != nil {
+			return s.Default
+		}
+		return false
+	case "null":
+		return nil
+	}
+	return nil
+}
+
+func stringFormatExample(format string) string {
+	switch format {
+	case "date-time":
+		return "2025-01-01T00:00:00Z"
+	case "date":
+		return "2025-01-01"
+	case "uuid":
+		return "00000000-0000-0000-0000-000000000000"
+	case "uri", "url":
+		return "https://example.com"
+	case "email":
+		return "user@example.com"
+	case "byte":
+		return "Zm9v"
+	}
+	return "string"
 }

--- a/pkg/api/apidocs.go
+++ b/pkg/api/apidocs.go
@@ -41,6 +41,71 @@ type apiDocsState struct {
 	spec    *openapi3.T
 	ops     map[string]*operationEntry
 	ordered []*operationEntry
+	// appURL is the externally reachable root of this Grafana instance
+	// (e.g. "https://grafana.example.com"). Used to emit absolute URLs in
+	// llms.txt / llms-full.txt so agents can resolve links without guessing
+	// the hostname. May be empty in tests; relative paths are used as fallback.
+	appURL string
+}
+
+// curatedOpGroup pairs an operation ID with the workflow group it belongs to
+// in the curated llms.txt index.
+type curatedOpGroup struct {
+	id    string
+	group string
+}
+
+// curatedOps is the ordered, curated set of operations shown in llms.txt.
+// Groups are task-centric rather than OpenAPI-tag-centric.
+// If an operation's Deprecated flag is set in the spec it is emitted under
+// the ## Optional section instead of the main index.
+var curatedOps = []curatedOpGroup{
+	// Health & Discovery
+	{"getHealth", "Health & Discovery"},
+	// Data Sources
+	{"getDataSources", "Data Sources"},
+	{"addDataSource", "Data Sources"},
+	{"getDataSourceByUID", "Data Sources"},
+	{"updateDataSourceByUID", "Data Sources"},
+	{"deleteDataSourceByUID", "Data Sources"},
+	{"checkDatasourceHealthWithUID", "Data Sources"},
+	// Query Execution
+	{"queryMetricsWithExpressions", "Query Execution"},
+	// Search
+	{"search", "Search"},
+	// Annotations
+	{"getAnnotations", "Annotations"},
+	{"postAnnotation", "Annotations"},
+	{"updateAnnotation", "Annotations"},
+	{"deleteAnnotationByID", "Annotations"},
+	// Organization
+	{"getCurrentOrg", "Organization"},
+	{"getOrgUsersForCurrentOrg", "Organization"},
+	{"addOrgUserToCurrentOrg", "Organization"},
+	// Users
+	{"getSignedInUser", "Users"},
+	{"searchUsersWithPaging", "Users"},
+	// Teams
+	{"searchTeams", "Teams"},
+	{"createTeam", "Teams"},
+	{"getTeamMembers", "Teams"},
+	{"addTeamMember", "Teams"},
+	// Service Accounts
+	{"searchOrgServiceAccountsWithPaging", "Service Accounts"},
+	{"createServiceAccount", "Service Accounts"},
+	// --- Deprecated: emitted under ## Optional ---
+	{"getDashboardByUID", "Dashboard CRUD (legacy — use /apis/dashboard.grafana.app/)"},
+	{"postDashboard", "Dashboard CRUD (legacy — use /apis/dashboard.grafana.app/)"},
+	{"deleteDashboardByUID", "Dashboard CRUD (legacy — use /apis/dashboard.grafana.app/)"},
+	{"getFolders", "Folder CRUD (legacy — use /apis/folder.grafana.app/)"},
+	{"createFolder", "Folder CRUD (legacy — use /apis/folder.grafana.app/)"},
+	{"getFolderByUID", "Folder CRUD (legacy — use /apis/folder.grafana.app/)"},
+	{"searchPlaylists", "Playlists (legacy — use /apis/playlist.grafana.app/)"},
+	{"createPlaylist", "Playlists (legacy — use /apis/playlist.grafana.app/)"},
+	{"RouteGetAlertRules", "Alerting Provisioning (legacy)"},
+	{"RoutePostAlertRule", "Alerting Provisioning (legacy)"},
+	{"RouteGetAlertRuleGroup", "Alerting Provisioning (legacy)"},
+	{"RoutePutAlertRuleGroup", "Alerting Provisioning (legacy)"},
 }
 
 // registerAPIDocs loads the spec once at startup and, if it's available, wires
@@ -56,6 +121,7 @@ func (hs *HTTPServer) registerAPIDocs(r routing.RouteRegister) {
 		return
 	}
 	state := buildAPIDocsState(doc)
+	state.appURL = strings.TrimRight(hs.Cfg.AppURL, "/")
 
 	r.Get("/llms.txt", routing.Wrap(state.llmsTxtHandler))
 	r.Get("/llms-full.txt", routing.Wrap(state.llmsFullTxtHandler))
@@ -78,59 +144,140 @@ func renderLLMsTxt(s *apiDocsState) string {
 		title = s.spec.Info.Title
 	}
 	fmt.Fprintf(&b, "# %s\n\n", title)
-	if s.spec.Info != nil && s.spec.Info.Description != "" {
-		fmt.Fprintf(&b, "> %s\n\n", oneLine(s.spec.Info.Description))
-	} else {
-		b.WriteString("> Grafana's HTTP API. Per-operation docs for AI/agent consumption.\n\n")
-	}
+
+	// Required by the llms.txt spec: a blockquote immediately after the H1
+	// that gives agents the base URL, authentication guidance, and a link to
+	// human-readable docs.
+	opBase := s.appURL // may be "" in tests — relative URLs are used as fallback
+	baseAPI := opBase + "/api/"
+	fmt.Fprintf(&b, "> The Grafana HTTP API is served at `%s`.\n", baseAPI)
+	b.WriteString("> Authenticate with `Authorization: Bearer <SERVICE_ACCOUNT_TOKEN>` or basic auth (`-u admin:password`).\n")
+	b.WriteString("> Full reference: <https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/>\n\n")
 
 	b.WriteString("## Discovery\n\n")
-	b.WriteString("- [Operations manifest (JSON)](/api-docs/index.json)\n")
-	b.WriteString("- [Full markdown bundle](/llms-full.txt)\n")
-	b.WriteString("- [Swagger UI](/swagger)\n\n")
+	fmt.Fprintf(&b, "- [Operations manifest (JSON)](%s/api-docs/index.json) - JSON index of all operations\n", opBase)
+	fmt.Fprintf(&b, "- [Complete operations index](%s/llms-full.txt) - Index of all %d operations\n", opBase, len(s.ordered))
+	fmt.Fprintf(&b, "- [Swagger UI](%s/swagger) - Human-friendly Swagger UI for the API\n\n", opBase)
 
-	byTag := map[string][]*operationEntry{}
-	for _, e := range s.ordered {
-		if len(e.Tags) == 0 {
-			byTag["(untagged)"] = append(byTag["(untagged)"], e)
+	// Curated operations grouped by workflow task. Each entry is looked up in
+	// the live spec so missing/renamed IDs are silently skipped.
+	mainGroups := map[string][]string{} // group label -> list of markdown lines
+	mainGroupOrder := []string{}
+	optGroups := map[string][]string{}
+	optGroupOrder := []string{}
+
+	for _, c := range curatedOps {
+		e, ok := s.ops[c.id]
+		if !ok {
 			continue
 		}
-		for _, t := range e.Tags {
-			byTag[t] = append(byTag[t], e)
+		summary := e.Summary
+		if summary == "" {
+			summary = oneLine(e.Description)
+		}
+		url := opBase + "/api-docs/operations/" + e.OperationID
+		line := fmt.Sprintf("- [%s %s](%s): %s\n", e.Method, e.Path, url, summary)
+
+		if e.Operation.Deprecated {
+			if _, exists := optGroups[c.group]; !exists {
+				optGroupOrder = append(optGroupOrder, c.group)
+			}
+			optGroups[c.group] = append(optGroups[c.group], line)
+		} else {
+			if _, exists := mainGroups[c.group]; !exists {
+				mainGroupOrder = append(mainGroupOrder, c.group)
+			}
+			mainGroups[c.group] = append(mainGroups[c.group], line)
 		}
 	}
-	tags := make([]string, 0, len(byTag))
-	for t := range byTag {
-		tags = append(tags, t)
-	}
-	sort.Strings(tags)
 
-	for _, t := range tags {
-		fmt.Fprintf(&b, "## %s\n\n", t)
-		for _, e := range byTag[t] {
-			summary := e.Summary
-			if summary == "" {
-				summary = oneLine(e.Description)
-			}
-			fmt.Fprintf(&b, "- [%s %s](/api-docs/operations/%s): %s\n",
-				e.Method, e.Path, e.OperationID, summary)
+	for _, g := range mainGroupOrder {
+		fmt.Fprintf(&b, "## %s\n\n", g)
+		for _, line := range mainGroups[g] {
+			b.WriteString(line)
 		}
 		b.WriteString("\n")
 	}
+
+	// The ## Optional section has special semantics in the llms.txt spec:
+	// agents may skip it to save context window budget.
+	if len(optGroupOrder) > 0 {
+		b.WriteString("## Optional\n\n")
+		b.WriteString("> These endpoints are deprecated and will be removed in a future release.\n")
+		b.WriteString("> Prefer the new-generation `/apis/` surface where available.\n\n")
+		for _, g := range optGroupOrder {
+			fmt.Fprintf(&b, "### %s\n\n", g)
+			for _, line := range optGroups[g] {
+				b.WriteString(line)
+			}
+			b.WriteString("\n")
+		}
+	}
+
 	return b.String()
 }
 
+// renderLLMsFullTxt produces a deduplicated index of every operation in the
+// spec — auth context up front, then all operations grouped by tag with
+// per-operation links. Deprecated operations are annotated inline. Agents that
+// need the full parameter/response detail for a specific operation can follow
+// the link to /api-docs/operations/{operationId}.
 func renderLLMsFullTxt(s *apiDocsState) string {
 	var b strings.Builder
 	title := "Grafana HTTP API"
 	if s.spec.Info != nil && s.spec.Info.Title != "" {
 		title = s.spec.Info.Title
 	}
-	fmt.Fprintf(&b, "# %s — Full Operation Reference\n\n", title)
+	fmt.Fprintf(&b, "# %s — Complete Operations Index\n\n", title)
+
+	opBase := s.appURL
+	baseAPI := opBase + "/api/"
+	fmt.Fprintf(&b, "> The Grafana HTTP API is served at `%s`.\n", baseAPI)
+	b.WriteString("> Authenticate with `Authorization: Bearer <SERVICE_ACCOUNT_TOKEN>` or basic auth (`-u admin:password`).\n")
+	b.WriteString("> Full reference: <https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api.md/>\n\n")
+
+	// Group under the first tag only to avoid duplicating entries that carry
+	// multiple tags (e.g. enterprise operations tagged under both a feature tag
+	// and "enterprise").
+	seen := map[string]bool{}
+	byTag := map[string][]*operationEntry{}
+	tagOrder := []string{}
+
 	for _, e := range s.ordered {
-		b.WriteString(renderOperationMarkdown(e))
-		b.WriteString("\n---\n\n")
+		if seen[e.OperationID] {
+			continue
+		}
+		seen[e.OperationID] = true
+
+		tags := e.Tags
+		if len(tags) == 0 {
+			tags = []string{"(untagged)"}
+		}
+		t := tags[0]
+		if _, exists := byTag[t]; !exists {
+			tagOrder = append(tagOrder, t)
+		}
+		byTag[t] = append(byTag[t], e)
 	}
+	sort.Strings(tagOrder)
+
+	for _, t := range tagOrder {
+		fmt.Fprintf(&b, "## %s\n\n", t)
+		for _, e := range byTag[t] {
+			summary := e.Summary
+			if summary == "" {
+				summary = oneLine(e.Description)
+			}
+			dep := ""
+			if e.Operation.Deprecated {
+				dep = " *(deprecated)*"
+			}
+			url := opBase + "/api-docs/operations/" + e.OperationID
+			fmt.Fprintf(&b, "- [%s %s](%s): %s%s\n", e.Method, e.Path, url, summary, dep)
+		}
+		b.WriteString("\n")
+	}
+
 	return b.String()
 }
 
@@ -176,7 +323,7 @@ func (s *apiDocsState) operationHandler(c *contextmodel.ReqContext) response.Res
 	if !ok {
 		return response.Error(http.StatusNotFound, "unknown operationId: "+opID, nil)
 	}
-	return markdownResponse(http.StatusOK, renderOperationMarkdown(entry))
+	return markdownResponse(http.StatusOK, renderOperationMarkdown(entry, s))
 }
 
 func markdownResponse(status int, body string) response.Response {
@@ -256,7 +403,114 @@ func synthesizeOperationID(method, path string) string {
 	return strings.Trim(string(out), "_")
 }
 
-func renderOperationMarkdown(e *operationEntry) string {
+// operationNotes contains agent-facing behavioral warnings for operations
+// whose semantics are non-obvious or dangerous. Keyed by operation ID.
+// Notes are emitted as a ## Caution block before ## Parameters.
+var operationNotes = map[string]string{
+	"setTeamRoles": "**Replace-all**: Overwrites the complete role list for the team. " +
+		"Any role omitted from the request body is removed. " +
+		"Read the current list with `listTeamRoles` first if you want additive changes.",
+	"setUserRoles": "**Replace-all**: Overwrites the complete role list for the user. " +
+		"Any role omitted from the request body is removed. " +
+		"Read the current list with `listUserRoles` first if you want additive changes.",
+	"setRoleAssignments": "**Replace-all**: Overwrites all role assignments for the specified role. " +
+		"Read `getRoleAssignments` first to avoid unintentional removals.",
+	"setResourcePermissions": "**Replace-all**: Replaces all permissions on the resource. " +
+		"Read `getResourcePermissions` first if you want additive changes.",
+	"setResourcePermissionsForTeam":        "**Replace-all**: Replaces all permissions for this resource/team combination.",
+	"setResourcePermissionsForUser":        "**Replace-all**: Replaces all permissions for this resource/user combination.",
+	"setResourcePermissionsForBuiltInRole": "**Replace-all**: Replaces all permissions for this resource/built-in role combination.",
+	"setTeamMemberships": "**Replace-all**: Replaces the entire team membership list. " +
+		"Any member omitted from the request is removed from the team.",
+	"massDeleteAnnotations": "**Irreversible**: Permanently deletes all annotations matching the filter. " +
+		"There is no undo — verify your filter with `getAnnotations` before calling this.",
+	"RoutePutAlertRuleGroup": "**Replace-all**: Replaces the entire alert rule group, including all its rules. " +
+		"Any rule omitted from the request is deleted. " +
+		"Read the current group with `RouteGetAlertRuleGroup` first.",
+	"RoutePutPolicyTree": "**Replace-all**: Replaces the entire notification policy tree. " +
+		"Any route omitted from the request is deleted. " +
+		"Read the current tree with `RouteGetPolicyTree` first.",
+	"updateDashboardPermissionsByUID": "**Replace-all**: Replaces all dashboard permission ACL entries. " +
+		"Any entry omitted from the request is removed.",
+	"updateFolderPermissions": "**Replace-all**: Replaces all folder permission ACL entries. " +
+		"Any entry omitted from the request is removed.",
+	"postDashboard": "**Upsert**: Creates a new dashboard or updates an existing one. " +
+		"Set `overwrite: true` in the body to replace an existing dashboard; " +
+		"omitting it returns a version-conflict error if the dashboard already exists.",
+	"adminDeleteUser": "**Irreversible**: Permanently deletes the user and revokes all their tokens and sessions.",
+}
+
+// relatedOps returns a capped list of operations that are structurally related
+// to e: same-path peers (different HTTP method), the parent collection path,
+// and direct children (one path segment deeper). Capped at 6 to keep pages
+// focused.
+func relatedOps(e *operationEntry, s *apiDocsState) []*operationEntry {
+	var related []*operationEntry
+	seen := map[string]bool{e.OperationID: true}
+
+	add := func(other *operationEntry) bool {
+		if seen[other.OperationID] {
+			return false
+		}
+		seen[other.OperationID] = true
+		related = append(related, other)
+		return len(related) < 6
+	}
+
+	// 1. Same path, different method (e.g. GET and DELETE on the same resource).
+	for _, other := range s.ordered {
+		if other.Path == e.Path {
+			if !add(other) {
+				return related
+			}
+		}
+	}
+
+	// 2. Parent path: strip the last segment (parameter or named) to find the
+	//    collection endpoint (e.g. /teams/{teamId} → /teams).
+	if parent := parentPath(e.Path); parent != "" {
+		for _, other := range s.ordered {
+			if other.Path == parent {
+				if !add(other) {
+					return related
+				}
+			}
+		}
+	}
+
+	// 3. Direct children: paths that extend this path by exactly one segment.
+	for _, other := range s.ordered {
+		if other.Path == e.Path {
+			continue
+		}
+		if !strings.HasPrefix(other.Path, e.Path+"/") {
+			continue
+		}
+		// Only immediate children (no further slash after the appended segment).
+		rest := other.Path[len(e.Path)+1:]
+		if !strings.Contains(rest, "/") {
+			if !add(other) {
+				return related
+			}
+		}
+	}
+
+	return related
+}
+
+// parentPath strips the last path segment, returning "" when the path has no
+// meaningful parent (i.e. it is already a top-level path).
+func parentPath(p string) string {
+	idx := strings.LastIndex(p, "/")
+	if idx <= 0 {
+		return ""
+	}
+	return p[:idx]
+}
+
+// renderOperationMarkdown produces the per-operation markdown page.
+// s is required for base URL, caution notes, and related-operation links.
+func renderOperationMarkdown(e *operationEntry, s *apiDocsState) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "# %s %s\n\n", e.Method, e.Path)
 	if e.Summary != "" {
@@ -273,6 +527,18 @@ func renderOperationMarkdown(e *operationEntry) string {
 		b.WriteString("- Deprecated: yes\n")
 	}
 	b.WriteString("\n")
+
+	// Base URL and auth context — agents fetching this page in isolation need
+	// this to construct a working curl command.
+	opBase := s.appURL
+	fmt.Fprintf(&b, "> Full URL: `%s %s/api%s`\n", e.Method, opBase, e.Path)
+	b.WriteString("> Authenticate with `Authorization: Bearer <SERVICE_ACCOUNT_TOKEN>` or basic auth (`-u admin:password`).\n\n")
+
+	// Caution block for operations with replace-all or irreversible semantics.
+	if note, ok := operationNotes[e.OperationID]; ok {
+		b.WriteString("## Caution\n\n")
+		fmt.Fprintf(&b, "> %s\n\n", note)
+	}
 
 	if len(e.Operation.Parameters) > 0 {
 		b.WriteString("## Parameters\n\n")
@@ -334,6 +600,12 @@ func renderOperationMarkdown(e *operationEntry) string {
 				codes = append(codes, c)
 			}
 			sort.Strings(codes)
+
+			// Track schema refs whose example has already been rendered in
+			// this responses block so we don't repeat the same JSON object
+			// once per error code.
+			renderedExamples := map[string]bool{}
+
 			for _, code := range codes {
 				rref := resps[code]
 				if rref == nil || rref.Value == nil {
@@ -366,8 +638,20 @@ func renderOperationMarkdown(e *operationEntry) string {
 					if media == nil {
 						continue
 					}
+					// Suppress duplicate examples: same schema ref across
+					// multiple error responses would produce identical JSON.
+					schemaKey := refName(media.Schema.Ref)
+					if schemaKey == "" && media.Schema != nil && media.Schema.Value != nil {
+						schemaKey = schemaType(media.Schema.Value)
+					}
+					if schemaKey != "" && renderedExamples[schemaKey] {
+						continue
+					}
 					if ex := exampleJSON(media.Schema); ex != "" {
 						fmt.Fprintf(&b, "\n  Example (`%s`):\n\n  ```json\n%s\n  ```\n", mt, indentBlock(ex, "  "))
+						if schemaKey != "" {
+							renderedExamples[schemaKey] = true
+						}
 					}
 				}
 			}
@@ -383,6 +667,22 @@ func renderOperationMarkdown(e *operationEntry) string {
 			}
 		}
 		b.WriteString("\n")
+	}
+
+	// Related operations: same-path peers, parent collection, direct children.
+	if s != nil {
+		if rel := relatedOps(e, s); len(rel) > 0 {
+			b.WriteString("## Related Operations\n\n")
+			for _, r := range rel {
+				summary := r.Summary
+				if summary == "" {
+					summary = oneLine(r.Description)
+				}
+				url := s.appURL + "/api-docs/operations/" + r.OperationID
+				fmt.Fprintf(&b, "- [%s %s](%s): %s\n", r.Method, r.Path, url, summary)
+			}
+			b.WriteString("\n")
+		}
 	}
 
 	return b.String()

--- a/pkg/api/apidocs_test.go
+++ b/pkg/api/apidocs_test.go
@@ -205,6 +205,85 @@ func TestApiDocsManifestShape(t *testing.T) {
 	assert.Len(t, ops, 4)
 }
 
+func TestExampleJSON(t *testing.T) {
+	const raw = `{
+		"openapi": "3.0.0",
+		"info": { "title": "T", "version": "1" },
+		"paths": {},
+		"components": {
+			"schemas": {
+				"User": {
+					"type": "object",
+					"properties": {
+						"id":      { "type": "integer" },
+						"email":   { "type": "string", "format": "email" },
+						"created": { "type": "string", "format": "date-time" },
+						"role":    { "type": "string", "enum": ["admin", "viewer"] },
+						"active":  { "type": "boolean", "default": true }
+					}
+				},
+				"UserList": {
+					"type": "array",
+					"items": { "$ref": "#/components/schemas/User" }
+				},
+				"Node": {
+					"type": "object",
+					"properties": {
+						"value": { "type": "string" },
+						"child": { "$ref": "#/components/schemas/Node" }
+					}
+				},
+				"WithExample": {
+					"type": "object",
+					"example": { "literal": "wins" }
+				}
+			}
+		}
+	}`
+
+	loader := openapi3.NewLoader()
+	doc, err := loader.LoadFromData([]byte(raw))
+	require.NoError(t, err)
+
+	userRef := doc.Components.Schemas["User"]
+	out := exampleJSON(userRef)
+	var got map[string]any
+	require.NoError(t, json.Unmarshal([]byte(out), &got))
+	assert.Equal(t, "user@example.com", got["email"])
+	assert.Equal(t, "2025-01-01T00:00:00Z", got["created"])
+	assert.Equal(t, "admin", got["role"], "first enum value should win")
+	assert.Equal(t, true, got["active"], "default should win")
+	assert.Equal(t, float64(0), got["id"])
+
+	listRef := doc.Components.Schemas["UserList"]
+	listOut := exampleJSON(listRef)
+	var gotList []map[string]any
+	require.NoError(t, json.Unmarshal([]byte(listOut), &gotList))
+	assert.Len(t, gotList, 1)
+	assert.Equal(t, "user@example.com", gotList[0]["email"], "items should expand the referenced schema")
+
+	// Recursive schema should terminate and not loop forever.
+	nodeRef := doc.Components.Schemas["Node"]
+	nodeOut := exampleJSON(nodeRef)
+	assert.NotEmpty(t, nodeOut, "recursive schema should still produce output")
+	assert.Less(t, len(nodeOut), 4096, "recursion should be depth-limited")
+
+	// Explicit example field on the schema wins.
+	withExample := doc.Components.Schemas["WithExample"]
+	got2 := exampleJSON(withExample)
+	assert.Contains(t, got2, `"literal": "wins"`)
+}
+
+func TestRenderOperationMarkdownIncludesExamples(t *testing.T) {
+	doc := buildFixtureSpec(t)
+	s := buildAPIDocsState(doc)
+
+	md := renderOperationMarkdown(s.ops["createDashboard"])
+	assert.Contains(t, md, "## Request Body")
+	assert.Contains(t, md, "Example:")
+	assert.Contains(t, md, "```json")
+}
+
 func TestSynthesizeOperationID(t *testing.T) {
 	cases := []struct {
 		method, path, want string

--- a/pkg/api/apidocs_test.go
+++ b/pkg/api/apidocs_test.go
@@ -1,0 +1,220 @@
+package api
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/getkin/kin-openapi/openapi3"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// buildFixtureSpec returns a minimal but representative spec. It exercises
+// operationId, summary, tags, parameters (path + query), request body,
+// responses, an operation missing an operationId, and a deprecated flag.
+func buildFixtureSpec(t *testing.T) *openapi3.T {
+	t.Helper()
+
+	const raw = `{
+		"openapi": "3.0.0",
+		"info": { "title": "Grafana Test API", "version": "0.0.1", "description": "test" },
+		"paths": {
+			"/dashboards/uid/{uid}": {
+				"get": {
+					"operationId": "getDashboardByUID",
+					"summary": "Get dashboard by UID",
+					"tags": ["dashboards"],
+					"parameters": [
+						{
+							"name": "uid",
+							"in": "path",
+							"required": true,
+							"schema": { "type": "string" },
+							"description": "The dashboard UID"
+						}
+					],
+					"responses": {
+						"200": { "description": "OK" },
+						"404": { "description": "Not found" }
+					}
+				},
+				"delete": {
+					"summary": "Delete a dashboard",
+					"tags": ["dashboards"],
+					"deprecated": true,
+					"responses": { "200": { "description": "OK" } }
+				}
+			},
+			"/search": {
+				"get": {
+					"operationId": "searchDashboards",
+					"summary": "Search dashboards",
+					"tags": ["search"],
+					"parameters": [
+						{ "name": "query", "in": "query", "schema": { "type": "string" }, "description": "Free-text query" },
+						{ "name": "limit", "in": "query", "schema": { "type": "integer" } }
+					],
+					"responses": { "200": { "description": "OK" } }
+				}
+			},
+			"/dashboards/db": {
+				"post": {
+					"operationId": "createDashboard",
+					"summary": "Create or update dashboard",
+					"tags": ["dashboards"],
+					"requestBody": {
+						"required": true,
+						"description": "Dashboard model",
+						"content": {
+							"application/json": { "schema": { "type": "object" } }
+						}
+					},
+					"responses": { "200": { "description": "OK" } }
+				}
+			}
+		}
+	}`
+
+	loader := openapi3.NewLoader()
+	doc, err := loader.LoadFromData([]byte(raw))
+	require.NoError(t, err)
+	return doc
+}
+
+func TestBuildAPIDocsState(t *testing.T) {
+	doc := buildFixtureSpec(t)
+	s := buildAPIDocsState(doc)
+
+	assert.Len(t, s.ordered, 4, "expect 4 operations across 3 paths")
+
+	for _, e := range s.ordered {
+		assert.NotEmpty(t, e.OperationID, "every operation should end up with an id")
+		assert.NotEmpty(t, e.Method)
+		assert.NotEmpty(t, e.Path)
+	}
+
+	assert.Contains(t, s.ops, "getDashboardByUID")
+	assert.Contains(t, s.ops, "searchDashboards")
+	assert.Contains(t, s.ops, "createDashboard")
+
+	// The DELETE on /dashboards/uid/{uid} has no operationId; ensure one was synthesized.
+	found := false
+	for id, e := range s.ops {
+		if e.Method == "DELETE" && e.Path == "/dashboards/uid/{uid}" {
+			found = true
+			assert.NotEqual(t, "", id)
+			assert.NotEqual(t, "getDashboardByUID", id)
+		}
+	}
+	assert.True(t, found, "synthesized DELETE entry should exist")
+}
+
+func TestRenderOperationMarkdown(t *testing.T) {
+	doc := buildFixtureSpec(t)
+	s := buildAPIDocsState(doc)
+
+	md := renderOperationMarkdown(s.ops["getDashboardByUID"])
+
+	assert.True(t, strings.HasPrefix(md, "# GET /dashboards/uid/{uid}"), "header line wrong: %q", md[:40])
+	assert.Contains(t, md, "Get dashboard by UID")
+	assert.Contains(t, md, "Operation ID: `getDashboardByUID`")
+	assert.Contains(t, md, "Tags: dashboards")
+	assert.Contains(t, md, "## Parameters")
+	assert.Contains(t, md, "`uid` (path, string, required): The dashboard UID")
+	assert.Contains(t, md, "## Responses")
+	assert.Contains(t, md, "`200`: OK")
+	assert.Contains(t, md, "`404`: Not found")
+
+	// Deprecated DELETE should call that out and not show a request body.
+	var deleteEntry *operationEntry
+	for _, e := range s.ordered {
+		if e.Method == "DELETE" {
+			deleteEntry = e
+			break
+		}
+	}
+	require.NotNil(t, deleteEntry)
+	mdDel := renderOperationMarkdown(deleteEntry)
+	assert.Contains(t, mdDel, "Deprecated: yes")
+	assert.NotContains(t, mdDel, "## Request Body")
+
+	// POST should show the request body block.
+	mdCreate := renderOperationMarkdown(s.ops["createDashboard"])
+	assert.Contains(t, mdCreate, "## Request Body")
+	assert.Contains(t, mdCreate, "Required.")
+	assert.Contains(t, mdCreate, "Content-Type: `application/json`")
+}
+
+func TestRenderLLMsTxt(t *testing.T) {
+	doc := buildFixtureSpec(t)
+	s := buildAPIDocsState(doc)
+	md := renderLLMsTxt(s)
+
+	assert.Contains(t, md, "# Grafana Test API")
+	assert.Contains(t, md, "## Discovery")
+	assert.Contains(t, md, "(/api-docs/index.json)")
+	assert.Contains(t, md, "(/llms-full.txt)")
+
+	// Operations bucketed under their tag with markdown links.
+	assert.Contains(t, md, "## dashboards")
+	assert.Contains(t, md, "## search")
+	assert.Contains(t, md, "(/api-docs/operations/searchDashboards)")
+	assert.Contains(t, md, "(/api-docs/operations/getDashboardByUID)")
+}
+
+func TestRenderLLMsFullTxt(t *testing.T) {
+	doc := buildFixtureSpec(t)
+	s := buildAPIDocsState(doc)
+	md := renderLLMsFullTxt(s)
+
+	assert.Contains(t, md, "Grafana Test API")
+	assert.Contains(t, md, "# GET /dashboards/uid/{uid}")
+	assert.Contains(t, md, "# GET /search")
+	assert.Contains(t, md, "# POST /dashboards/db")
+	assert.True(t, strings.Count(md, "\n---\n") >= 4, "expect a separator after each of the 4 operations")
+}
+
+func TestApiDocsManifestShape(t *testing.T) {
+	doc := buildFixtureSpec(t)
+	s := buildAPIDocsState(doc)
+
+	m := apiDocsManifest{
+		Title:   s.spec.Info.Title,
+		Version: s.spec.Info.Version,
+	}
+	for _, e := range s.ordered {
+		m.Operations = append(m.Operations, apiDocsManifestEntry{
+			OperationID: e.OperationID,
+			Method:      e.Method,
+			Path:        e.Path,
+			Summary:     e.Summary,
+			Tags:        e.Tags,
+			MarkdownURL: "/api-docs/operations/" + e.OperationID,
+		})
+	}
+
+	out, err := json.Marshal(m)
+	require.NoError(t, err)
+
+	var round map[string]any
+	require.NoError(t, json.Unmarshal(out, &round))
+	assert.Equal(t, "Grafana Test API", round["title"])
+	ops, ok := round["operations"].([]any)
+	require.True(t, ok)
+	assert.Len(t, ops, 4)
+}
+
+func TestSynthesizeOperationID(t *testing.T) {
+	cases := []struct {
+		method, path, want string
+	}{
+		{"GET", "/api/dashboards/uid/{uid}", "get_api_dashboards_uid_uid"},
+		{"POST", "/foo/bar", "post_foo_bar"},
+		{"DELETE", "/", "delete"},
+	}
+	for _, tc := range cases {
+		got := synthesizeOperationID(tc.method, tc.path)
+		assert.Equal(t, tc.want, got, "method=%s path=%s", tc.method, tc.path)
+	}
+}

--- a/pkg/api/apidocs_test.go
+++ b/pkg/api/apidocs_test.go
@@ -13,6 +13,8 @@ import (
 // buildFixtureSpec returns a minimal but representative spec. It exercises
 // operationId, summary, tags, parameters (path + query), request body,
 // responses, an operation missing an operationId, and a deprecated flag.
+// It also includes operation IDs present in curatedOps so the llms.txt tests
+// can verify the curated and Optional sections.
 func buildFixtureSpec(t *testing.T) *openapi3.T {
 	t.Helper()
 
@@ -25,6 +27,7 @@ func buildFixtureSpec(t *testing.T) *openapi3.T {
 					"operationId": "getDashboardByUID",
 					"summary": "Get dashboard by UID",
 					"tags": ["dashboards"],
+					"deprecated": true,
 					"parameters": [
 						{
 							"name": "uid",
@@ -72,6 +75,22 @@ func buildFixtureSpec(t *testing.T) *openapi3.T {
 					},
 					"responses": { "200": { "description": "OK" } }
 				}
+			},
+			"/health": {
+				"get": {
+					"operationId": "getHealth",
+					"summary": "Check instance health",
+					"tags": ["health"],
+					"responses": { "200": { "description": "OK" } }
+				}
+			},
+			"/org": {
+				"get": {
+					"operationId": "getCurrentOrg",
+					"summary": "Get current organisation",
+					"tags": ["orgs"],
+					"responses": { "200": { "description": "OK" } }
+				}
 			}
 		}
 	}`
@@ -86,7 +105,7 @@ func TestBuildAPIDocsState(t *testing.T) {
 	doc := buildFixtureSpec(t)
 	s := buildAPIDocsState(doc)
 
-	assert.Len(t, s.ordered, 4, "expect 4 operations across 3 paths")
+	assert.Len(t, s.ordered, 6, "expect 6 operations across 5 paths")
 
 	for _, e := range s.ordered {
 		assert.NotEmpty(t, e.OperationID, "every operation should end up with an id")
@@ -97,6 +116,8 @@ func TestBuildAPIDocsState(t *testing.T) {
 	assert.Contains(t, s.ops, "getDashboardByUID")
 	assert.Contains(t, s.ops, "searchDashboards")
 	assert.Contains(t, s.ops, "createDashboard")
+	assert.Contains(t, s.ops, "getHealth")
+	assert.Contains(t, s.ops, "getCurrentOrg")
 
 	// The DELETE on /dashboards/uid/{uid} has no operationId; ensure one was synthesized.
 	found := false
@@ -113,18 +134,31 @@ func TestBuildAPIDocsState(t *testing.T) {
 func TestRenderOperationMarkdown(t *testing.T) {
 	doc := buildFixtureSpec(t)
 	s := buildAPIDocsState(doc)
+	s.appURL = "https://grafana.example.com"
 
-	md := renderOperationMarkdown(s.ops["getDashboardByUID"])
+	md := renderOperationMarkdown(s.ops["getDashboardByUID"], s)
 
 	assert.True(t, strings.HasPrefix(md, "# GET /dashboards/uid/{uid}"), "header line wrong: %q", md[:40])
 	assert.Contains(t, md, "Get dashboard by UID")
 	assert.Contains(t, md, "Operation ID: `getDashboardByUID`")
 	assert.Contains(t, md, "Tags: dashboards")
+
+	// Base URL blockquote must appear on every operation page.
+	assert.Contains(t, md, "> Full URL: `GET https://grafana.example.com/api/dashboards/uid/{uid}`")
+	assert.Contains(t, md, "> Authenticate with `Authorization: Bearer")
+
 	assert.Contains(t, md, "## Parameters")
 	assert.Contains(t, md, "`uid` (path, string, required): The dashboard UID")
 	assert.Contains(t, md, "## Responses")
 	assert.Contains(t, md, "`200`: OK")
 	assert.Contains(t, md, "`404`: Not found")
+
+	// Related operations: the DELETE on the same path should appear.
+	assert.Contains(t, md, "## Related Operations")
+	assert.Contains(t, md, "/api-docs/operations/")
+
+	// Deprecated GET should show the deprecated flag.
+	assert.Contains(t, md, "Deprecated: yes")
 
 	// Deprecated DELETE should call that out and not show a request body.
 	var deleteEntry *operationEntry
@@ -135,44 +169,150 @@ func TestRenderOperationMarkdown(t *testing.T) {
 		}
 	}
 	require.NotNil(t, deleteEntry)
-	mdDel := renderOperationMarkdown(deleteEntry)
+	mdDel := renderOperationMarkdown(deleteEntry, s)
 	assert.Contains(t, mdDel, "Deprecated: yes")
 	assert.NotContains(t, mdDel, "## Request Body")
 
 	// POST should show the request body block.
-	mdCreate := renderOperationMarkdown(s.ops["createDashboard"])
+	mdCreate := renderOperationMarkdown(s.ops["createDashboard"], s)
 	assert.Contains(t, mdCreate, "## Request Body")
 	assert.Contains(t, mdCreate, "Required.")
 	assert.Contains(t, mdCreate, "Content-Type: `application/json`")
 }
 
+func TestRenderOperationMarkdownCautionAndRelated(t *testing.T) {
+	// Build a minimal spec that exercises the caution note and related-ops logic.
+	const raw = `{
+		"openapi": "3.0.0",
+		"info": { "title": "T", "version": "1" },
+		"paths": {
+			"/teams": {
+				"get": {
+					"operationId": "searchTeams",
+					"summary": "Search teams",
+					"tags": ["teams"],
+					"responses": { "200": { "description": "OK" } }
+				},
+				"post": {
+					"operationId": "createTeam",
+					"summary": "Create team",
+					"tags": ["teams"],
+					"responses": { "200": { "description": "OK" } }
+				}
+			},
+			"/teams/{teamId}": {
+				"get": {
+					"operationId": "getTeamByID",
+					"summary": "Get team by ID",
+					"tags": ["teams"],
+					"responses": { "200": { "description": "OK" } }
+				}
+			},
+			"/teams/{teamId}/roles": {
+				"put": {
+					"operationId": "setTeamRoles",
+					"summary": "Set team roles",
+					"tags": ["teams"],
+					"responses": { "200": { "description": "OK" } }
+				}
+			}
+		}
+	}`
+
+	loader := openapi3.NewLoader()
+	doc, err := loader.LoadFromData([]byte(raw))
+	require.NoError(t, err)
+	s := buildAPIDocsState(doc)
+	s.appURL = "https://grafana.example.com"
+
+	// setTeamRoles should have a Caution block.
+	md := renderOperationMarkdown(s.ops["setTeamRoles"], s)
+	assert.Contains(t, md, "## Caution")
+	assert.Contains(t, md, "Replace-all")
+
+	// getTeamByID: parent is /teams (searchTeams + createTeam), child is /teams/{teamId}/roles.
+	mdGet := renderOperationMarkdown(s.ops["getTeamByID"], s)
+	assert.Contains(t, mdGet, "## Related Operations")
+	assert.Contains(t, mdGet, "/api-docs/operations/searchTeams")
+	assert.Contains(t, mdGet, "/api-docs/operations/createTeam")
+	assert.Contains(t, mdGet, "/api-docs/operations/setTeamRoles")
+
+	// searchTeams: no caution, but createTeam (same path) should be related.
+	mdSearch := renderOperationMarkdown(s.ops["searchTeams"], s)
+	assert.NotContains(t, mdSearch, "## Caution")
+	assert.Contains(t, mdSearch, "## Related Operations")
+	assert.Contains(t, mdSearch, "/api-docs/operations/createTeam")
+}
+
 func TestRenderLLMsTxt(t *testing.T) {
 	doc := buildFixtureSpec(t)
 	s := buildAPIDocsState(doc)
+	s.appURL = "https://grafana.example.com"
 	md := renderLLMsTxt(s)
 
+	// Header and required blockquote (llms.txt spec compliance).
 	assert.Contains(t, md, "# Grafana Test API")
-	assert.Contains(t, md, "## Discovery")
-	assert.Contains(t, md, "(/api-docs/index.json)")
-	assert.Contains(t, md, "(/llms-full.txt)")
+	assert.Contains(t, md, "> The Grafana HTTP API is served at `https://grafana.example.com/api/`.")
+	assert.Contains(t, md, "> Authenticate with `Authorization: Bearer")
+	assert.Contains(t, md, "grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/")
 
-	// Operations bucketed under their tag with markdown links.
-	assert.Contains(t, md, "## dashboards")
-	assert.Contains(t, md, "## search")
-	assert.Contains(t, md, "(/api-docs/operations/searchDashboards)")
-	assert.Contains(t, md, "(/api-docs/operations/getDashboardByUID)")
+	// Discovery section with absolute URLs.
+	assert.Contains(t, md, "## Discovery")
+	assert.Contains(t, md, "(https://grafana.example.com/api-docs/index.json)")
+	assert.Contains(t, md, "(https://grafana.example.com/llms-full.txt)")
+
+	// Curated ops appear under their workflow group with absolute links.
+	assert.Contains(t, md, "## Health & Discovery")
+	assert.Contains(t, md, "(https://grafana.example.com/api-docs/operations/getHealth)")
+	assert.Contains(t, md, "## Organization")
+	assert.Contains(t, md, "(https://grafana.example.com/api-docs/operations/getCurrentOrg)")
+
+	// Deprecated ops land in ## Optional, not in the main body.
+	assert.Contains(t, md, "## Optional")
+	assert.Contains(t, md, "### Dashboard CRUD (legacy")
+	assert.Contains(t, md, "(https://grafana.example.com/api-docs/operations/getDashboardByUID)")
+
+	// searchDashboards is not in the curated list — must NOT appear in llms.txt.
+	assert.NotContains(t, md, "/api-docs/operations/searchDashboards")
+}
+
+func TestRenderLLMsTxtFallbackRelativeURLs(t *testing.T) {
+	doc := buildFixtureSpec(t)
+	s := buildAPIDocsState(doc)
+	// appURL left empty: links should be relative (no hostname prefix).
+	md := renderLLMsTxt(s)
+
+	assert.Contains(t, md, "> The Grafana HTTP API is served at `/api/`.")
+	assert.Contains(t, md, "(/api-docs/index.json)")
+	assert.Contains(t, md, "(/api-docs/operations/getHealth)")
 }
 
 func TestRenderLLMsFullTxt(t *testing.T) {
 	doc := buildFixtureSpec(t)
 	s := buildAPIDocsState(doc)
+	s.appURL = "https://grafana.example.com"
 	md := renderLLMsFullTxt(s)
 
-	assert.Contains(t, md, "Grafana Test API")
-	assert.Contains(t, md, "# GET /dashboards/uid/{uid}")
-	assert.Contains(t, md, "# GET /search")
-	assert.Contains(t, md, "# POST /dashboards/db")
-	assert.True(t, strings.Count(md, "\n---\n") >= 4, "expect a separator after each of the 4 operations")
+	// Header and auth blockquote.
+	assert.Contains(t, md, "# Grafana Test API — Complete Operations Index")
+	assert.Contains(t, md, "> The Grafana HTTP API is served at `https://grafana.example.com/api/`.")
+	assert.Contains(t, md, "> Authenticate with `Authorization: Bearer")
+
+	// All operations appear as index entries (not as full ## GET /path docs).
+	assert.Contains(t, md, "/api-docs/operations/getDashboardByUID")
+	assert.Contains(t, md, "/api-docs/operations/searchDashboards")
+	assert.Contains(t, md, "/api-docs/operations/getHealth")
+
+	// Full operation markdown headers must NOT be present — this is an index.
+	assert.NotContains(t, md, "# GET /dashboards/uid/{uid}")
+	assert.NotContains(t, md, "# GET /search")
+	assert.NotContains(t, md, "\n---\n")
+
+	// Deprecated operations are annotated inline.
+	assert.Contains(t, md, "*(deprecated)*")
+
+	// Each operation should appear only once (deduplication).
+	assert.Equal(t, 1, strings.Count(md, "/api-docs/operations/getDashboardByUID"), "getDashboardByUID should appear exactly once")
 }
 
 func TestApiDocsManifestShape(t *testing.T) {
@@ -202,7 +342,7 @@ func TestApiDocsManifestShape(t *testing.T) {
 	assert.Equal(t, "Grafana Test API", round["title"])
 	ops, ok := round["operations"].([]any)
 	require.True(t, ok)
-	assert.Len(t, ops, 4)
+	assert.Len(t, ops, 6)
 }
 
 func TestExampleJSON(t *testing.T) {
@@ -278,7 +418,7 @@ func TestRenderOperationMarkdownIncludesExamples(t *testing.T) {
 	doc := buildFixtureSpec(t)
 	s := buildAPIDocsState(doc)
 
-	md := renderOperationMarkdown(s.ops["createDashboard"])
+	md := renderOperationMarkdown(s.ops["createDashboard"], s)
 	assert.Contains(t, md, "## Request Body")
 	assert.Contains(t, md, "Example:")
 	assert.Contains(t, md, "```json")

--- a/pkg/api/common_test.go
+++ b/pkg/api/common_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/grafana/grafana/pkg/api/routing"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/fs"
+	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/models/usertoken"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
@@ -301,6 +302,7 @@ func SetupAPITestServer(t *testing.T, opts ...APITestServerOption) *webtest.Serv
 		Features:           featuremgmt.WithFeatures(),
 		QuotaService:       quotatest.New(false, nil),
 		searchUsersService: &searchusers.OSSService{},
+		log:                log.NewNopLogger(),
 		tracer:             tracing.InitializeTracerForTest(),
 	}
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR adds three new endspoints to grafana with the purpose of translating the OpenApi / Swagger docs into something agent readable. This is only the existing /api/ endpoints. I will follow up with /apis/ as well. 

There are 4 new endspoints:

a escape hatch for agents with a /apis-docs/index.json

### /llms.txt - curated index
```
# Grafana HTTP API.

> The Grafana HTTP API is served at `http://localhost:3000/api/`.
> Authenticate with `Authorization: Bearer <SERVICE_ACCOUNT_TOKEN>` or basic auth (`-u admin:password`).
> Full reference: <https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/>

## Discovery

- [Operations manifest (JSON)](http://localhost:3000/api-docs/index.json) - JSON index of all operations
- [Complete operations index](http://localhost:3000/llms-full.txt) - Index of all 321 operations
- [Swagger UI](http://localhost:3000/swagger) - Human-friendly Swagger UI for the API

## Health & Discovery

- [GET /health](http://localhost:3000/api-docs/operations/getHealth): apiHealthHandler will return ok if Grafana's web server is running and it can access the database. If the database cannot be accessed it will return http status code 503.

## Data Sources

- [GET /datasources](http://localhost:3000/api-docs/operations/getDataSources): Get all data sources.
- [POST /datasources](http://localhost:3000/api-docs/operations/addDataSource): Create a data source.
- [GET /datasources/uid/{uid}](http://localhost:3000/api-docs/operations/getDataSourceByUID): Get a single data source by UID.
- [PUT /datasources/uid/{uid}](http://localhost:3000/api-docs/operations/updateDataSourceByUID): Update an existing data source.
- [DELETE /datasources/uid/{uid}](http://localhost:3000/api-docs/operations/deleteDataSourceByUID): Delete an existing data source by UID.
- [GET /datasources/uid/{uid}/health](http://localhost:3000/api-docs/operations/checkDatasourceHealthWithUID): Sends a health check request to the plugin datasource identified by the UID.

## Query Execution

- [POST /ds/query](http://localhost:3000/api-docs/operations/queryMetricsWithExpressions): DataSource query metrics with expressions.

## Search
```

### /llms-full.txt - full index of all operations
<img width="1503" height="852" alt="image" src="https://github.com/user-attachments/assets/5fec67a7-5853-4b34-b3c4-f01b67035bb3" />

### /api-docs/operations/setTeamRoles - details on each endpoint
<img width="1272" height="864" alt="image" src="https://github.com/user-attachments/assets/24d5ffba-83a1-4bde-b5a3-7a6b69c2c575" />


**Why do we need this feature?**

[Add a description of the problem the feature is trying to solve.]

The existing swagger UI is very useful for humans but it is a SPA so it takes extra effort to integrate with and agents to interact with. Markdown is the language du jour for agents because it easy to query ie curl works, it has no noise like html does and it easily grepable. 


**Who is this feature for?**

[Add information on what kind of user the feature is for.]

🤖 

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
