### PR TITLE
Gate remote snapshots by Bleve index format

### DIFF
--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -153,6 +153,9 @@ type bleveBackend struct {
 	// is empty. Guaranteed non-nil when opts.Snapshot.Store is set.
 	runningBuildVersion *semver.Version
 
+	// maxSupportedIndexFormat is the newest Bleve segment format this process can read.
+	maxSupportedIndexFormat string
+
 	bgTasksCancel func()
 	bgTasksWg     sync.WaitGroup
 
@@ -202,10 +205,14 @@ func NewBleveBackend(opts BleveOptions, indexMetrics *resource.BleveIndexMetrics
 	if opts.Snapshot.Store != nil && runningBuildVersion == nil {
 		return nil, fmt.Errorf("bleve backend requires non-empty BuildVersion when snapshot store is configured")
 	}
+	maxSupportedFormat := maxSupportedIndexFormat()
 
 	l := opts.Logger
 	if l == nil {
 		l = log.New("bleve-backend")
+	}
+	if opts.Snapshot.Store != nil && maxSupportedFormat == "" {
+		l.Warn("could not detect bleve index format version; snapshot format compatibility gate disabled")
 	}
 
 	ownFn := opts.OwnsIndex
@@ -215,15 +222,16 @@ func NewBleveBackend(opts BleveOptions, indexMetrics *resource.BleveIndexMetrics
 	}
 
 	be := &bleveBackend{
-		log:                 l,
-		cache:               map[resource.NamespacedResource]*bleveIndex{},
-		opts:                opts,
-		ownsIndexFn:         ownFn,
-		indexMetrics:        indexMetrics,
-		selectableFields:    opts.SelectableFieldsForKinds,
-		runningBuildVersion: runningBuildVersion,
-		lastUploadTime:      map[resource.NamespacedResource]time.Time{},
-		inFlightBuildDirs:   map[string]int{},
+		log:                     l,
+		cache:                   map[resource.NamespacedResource]*bleveIndex{},
+		opts:                    opts,
+		ownsIndexFn:             ownFn,
+		indexMetrics:            indexMetrics,
+		selectableFields:        opts.SelectableFieldsForKinds,
+		runningBuildVersion:     runningBuildVersion,
+		maxSupportedIndexFormat: maxSupportedFormat,
+		lastUploadTime:          map[resource.NamespacedResource]time.Time{},
+		inFlightBuildDirs:       map[string]int{},
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/storage/unified/search/bleve_snapshot.go
+++ b/pkg/storage/unified/search/bleve_snapshot.go
@@ -6,11 +6,15 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/Masterminds/semver"
 	"github.com/blevesearch/bleve/v2"
+	"github.com/blevesearch/bleve/v2/index/scorch"
 	"github.com/oklog/ulid/v2"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -18,6 +22,46 @@ import (
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 )
+
+const zapSegmentType = "zap"
+
+func maxSupportedIndexFormat() string {
+	versions := scorch.SupportedSegmentTypeVersions(zapSegmentType)
+	if len(versions) == 0 {
+		return ""
+	}
+	return indexFormat(zapSegmentType, slices.Max(versions))
+}
+
+func indexFormat(formatType string, version uint32) string {
+	if formatType == "" || version == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%s/%d", formatType, version)
+}
+
+func parseIndexFormat(format string) (string, uint32, bool) {
+	formatType, versionString, ok := strings.Cut(format, "/")
+	if !ok || formatType == "" {
+		return "", 0, false
+	}
+	version, err := strconv.ParseUint(versionString, 10, 32)
+	if err != nil || version == 0 {
+		return "", 0, false
+	}
+	return formatType, uint32(version), true
+}
+
+// isSnapshotIndexFormatUnknownOrSupported treats unknown formats as supported
+// for legacy snapshots uploaded before IndexFormat was added to the manifest.
+func isSnapshotIndexFormatUnknownOrSupported(snapshotFormat, maxSupportedFormat string) bool {
+	if snapshotFormat == "" || maxSupportedFormat == "" {
+		return true
+	}
+	snapshotType, snapshotVersion, ok := parseIndexFormat(snapshotFormat)
+	maxSupportedType, maxSupportedVersion, maxOK := parseIndexFormat(maxSupportedFormat)
+	return ok && maxOK && snapshotType == maxSupportedType && snapshotVersion <= maxSupportedVersion
+}
 
 // Labels for the index_server_snapshot_downloads_total counter.
 const (
@@ -121,7 +165,7 @@ func (b *bleveBackend) tryDownloadFreshSameVersionSnapshot(
 
 	return b.downloadSelectedSnapshot(ctx, key, resourceDir, policy, spanName, logger,
 		func(ctx context.Context) (ulid.ULID, *IndexMeta, error) {
-			k, m, err := findFreshSnapshotByBuildStart(ctx, b.opts.Snapshot.Store, key, notOlderThan, b.opts.BuildVersion)
+			k, m, err := findFreshSnapshotByBuildStart(ctx, b.opts.Snapshot.Store, key, notOlderThan, b.opts.BuildVersion, b.maxSupportedIndexFormat, logger)
 			if err != nil {
 				return ulid.ULID{}, nil, fmt.Errorf("probing for fresh snapshot: %w", err)
 			}
@@ -161,6 +205,7 @@ func (b *bleveBackend) downloadSelectedSnapshot(
 			attrs = append(attrs,
 				attribute.String("snapshot_key", snapKey.String()),
 				attribute.String("snapshot_version", meta.BuildVersion),
+				attribute.String("snapshot_index_format", meta.IndexFormat),
 				attribute.Int64("snapshot_rv", meta.LatestResourceVersion),
 			)
 			// Zero-value BuildTime means the snapshot was uploaded before that
@@ -197,6 +242,7 @@ func (b *bleveBackend) downloadSelectedSnapshot(
 	logFields := []any{
 		"snapshot_key", snapKey.String(),
 		"snapshot_version", meta.BuildVersion,
+		"snapshot_index_format", meta.IndexFormat,
 		"snapshot_rv", meta.LatestResourceVersion,
 		"snapshot_uploaded", meta.UploadTimestamp,
 	}
@@ -268,8 +314,9 @@ func (b *bleveBackend) downloadSelectedSnapshot(
 	return idx, name, rv, nil
 }
 
-// pickBestSnapshot applies hard filters (upload time, unparseable version)
-// and the three-tier preference to pick the best snapshot, if any.
+// pickBestSnapshot applies hard filters (upload time, index format,
+// unparseable version) and the three-tier preference to pick the best
+// snapshot, if any.
 //
 // Tier 0 (ideal): MinBuildVersion <= v <= runningVersion
 // Tier 1 (older, acceptable): v < MinBuildVersion
@@ -280,12 +327,24 @@ func (b *bleveBackend) pickBestSnapshot(all map[ulid.ULID]*IndexMeta, notOlderTh
 	minVersion := b.opts.Snapshot.MinBuildVersion
 	running := b.runningBuildVersion
 
-	var droppedAge, droppedUnparseable int
+	var droppedAge, droppedUnparseable, droppedFormatUnsupported int
 	candidates := make([]snapshotCandidate, 0, len(all))
 	for k, m := range all {
 		// Hard filter: age.
 		if !notOlderThan.IsZero() && m.UploadTimestamp.Before(notOlderThan) {
 			droppedAge++
+			continue
+		}
+		if !isSnapshotIndexFormatUnknownOrSupported(m.IndexFormat, b.maxSupportedIndexFormat) {
+			droppedFormatUnsupported++
+			logger.Debug("index snapshot candidate dropped: unsupported format",
+				"key", k.String(),
+				"snapshot_format", m.IndexFormat,
+				"max_supported_format", b.maxSupportedIndexFormat,
+				"version", m.BuildVersion,
+				"rv", m.LatestResourceVersion,
+				"uploaded", m.UploadTimestamp,
+			)
 			continue
 		}
 		// Hard filter: unparseable version (we can't tier it). Metadata validation
@@ -307,13 +366,15 @@ func (b *bleveBackend) pickBestSnapshot(all map[ulid.ULID]*IndexMeta, notOlderTh
 			"key", c.key.String(),
 			"tier", c.tier,
 			"version", c.version.String(),
+			"snapshot_format", c.meta.IndexFormat,
+			"max_supported_format", b.maxSupportedIndexFormat,
 			"rv", c.meta.LatestResourceVersion,
 			"uploaded", c.meta.UploadTimestamp,
 		)
 	}
 
 	if len(candidates) == 0 {
-		logger.Debug("no index snapshot candidates", "total", len(all), "dropped_age", droppedAge, "dropped_unparseable", droppedUnparseable)
+		logger.Debug("no index snapshot candidates", "total", len(all), "dropped_age", droppedAge, "dropped_unparseable", droppedUnparseable, "dropped_format_unsupported", droppedFormatUnsupported, "max_supported_format", b.maxSupportedIndexFormat)
 		return snapshotCandidate{}, false
 	}
 
@@ -333,9 +394,12 @@ func (b *bleveBackend) pickBestSnapshot(all map[ulid.ULID]*IndexMeta, notOlderTh
 	logger.Debug("selected index snapshot",
 		"key", candidates[0].key.String(),
 		"tier", candidates[0].tier,
+		"snapshot_format", candidates[0].meta.IndexFormat,
+		"max_supported_format", b.maxSupportedIndexFormat,
 		"candidates", len(candidates),
 		"dropped_age", droppedAge,
 		"dropped_unparseable", droppedUnparseable,
+		"dropped_format_unsupported", droppedFormatUnsupported,
 	)
 	return candidates[0], true
 }
@@ -403,9 +467,9 @@ func (b *bleveBackend) recordSnapshotDownloadOutcome(policy, status string) {
 }
 
 // findFreshSnapshotByUploadTime walks namespace snapshots newest-first and
-// returns the first one whose BuildVersion matches runningVersion and
-// whose ULID time is after notOlderThan. Returns a zero key and nil meta when
-// no such snapshot exists.
+// returns the first one whose BuildVersion matches runningVersion, whose
+// index format is not newer than this process can support, and whose ULID time
+// is after notOlderThan. Returns a zero key and nil meta when no such snapshot exists.
 //
 // Walking (rather than checking only the newest) is necessary in mixed-version
 // clusters — either transiently during rolling upgrades, or as a deliberate
@@ -423,8 +487,10 @@ func findFreshSnapshotByUploadTime(
 	ns resource.NamespacedResource,
 	notOlderThan time.Time,
 	runningVersion string,
+	maxSupportedIndexFormat string,
+	logger log.Logger,
 ) (ulid.ULID, *IndexMeta, error) {
-	return findFreshSnapshot(ctx, store, ns, notOlderThan, runningVersion, func(*IndexMeta) bool {
+	return findFreshSnapshot(ctx, store, ns, notOlderThan, runningVersion, maxSupportedIndexFormat, logger, func(*IndexMeta) bool {
 		return true
 	})
 }
@@ -447,8 +513,10 @@ func findFreshSnapshotByBuildStart(
 	ns resource.NamespacedResource,
 	notOlderThan time.Time,
 	runningVersion string,
+	maxSupportedIndexFormat string,
+	logger log.Logger,
 ) (ulid.ULID, *IndexMeta, error) {
-	return findFreshSnapshot(ctx, store, ns, notOlderThan, runningVersion, func(meta *IndexMeta) bool {
+	return findFreshSnapshot(ctx, store, ns, notOlderThan, runningVersion, maxSupportedIndexFormat, logger, func(meta *IndexMeta) bool {
 		return !meta.BuildTime.IsZero() && meta.BuildTime.After(notOlderThan)
 	})
 }
@@ -459,6 +527,8 @@ func findFreshSnapshot(
 	ns resource.NamespacedResource,
 	notOlderThan time.Time,
 	runningVersion string,
+	maxSupportedIndexFormat string,
+	logger log.Logger,
 	isFresh func(*IndexMeta) bool,
 ) (ulid.ULID, *IndexMeta, error) {
 	keys, err := retryRemoteIndexStoreValue(ctx, snapshotStoreOpListIndexKeys, nil, func() ([]ulid.ULID, error) {
@@ -487,6 +557,16 @@ func findFreshSnapshot(
 				continue
 			}
 			return ulid.ULID{}, nil, fmt.Errorf("reading manifest for %s: %w", k, err)
+		}
+
+		if !isSnapshotIndexFormatUnknownOrSupported(meta.IndexFormat, maxSupportedIndexFormat) {
+			logger.Debug("index snapshot candidate dropped: unsupported format",
+				"key", k.String(),
+				"snapshot_format", meta.IndexFormat,
+				"max_supported_format", maxSupportedIndexFormat,
+				"version", meta.BuildVersion,
+			)
+			continue
 		}
 
 		if meta.BuildVersion == runningVersion && isFresh(meta) {

--- a/pkg/storage/unified/search/bleve_snapshot_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_test.go
@@ -73,6 +73,20 @@ func makeULID(t *testing.T, at time.Time) ulid.ULID {
 	return k
 }
 
+func testIndexFormat(t *testing.T) string {
+	t.Helper()
+	format := maxSupportedIndexFormat()
+	require.NotEmpty(t, format)
+	return format
+}
+
+func testIndexFormatDelta(t *testing.T, delta int) string {
+	t.Helper()
+	formatType, version, ok := parseIndexFormat(testIndexFormat(t))
+	require.True(t, ok)
+	return indexFormat(formatType, uint32(int(version)+delta))
+}
+
 func TestSnapshotTier(t *testing.T) {
 	running := semver.MustParse("11.5.0")
 	minV := semver.MustParse("11.4.0")
@@ -111,11 +125,14 @@ func TestPickBestSnapshot(t *testing.T) {
 		}
 	}
 
+	format := testIndexFormat(t)
+
 	newBackend := func(minVersion *semver.Version) *bleveBackend {
 		return &bleveBackend{
-			log:                 log.New("bleve-snapshot-test"),
-			opts:                BleveOptions{Snapshot: SnapshotOptions{MinBuildVersion: minVersion}},
-			runningBuildVersion: running,
+			log:                     log.New("bleve-snapshot-test"),
+			opts:                    BleveOptions{Snapshot: SnapshotOptions{MinBuildVersion: minVersion}},
+			runningBuildVersion:     running,
+			maxSupportedIndexFormat: format,
 		}
 	}
 	cutoff := func(maxAge time.Duration) time.Time { return now.Add(-maxAge) }
@@ -184,6 +201,32 @@ func TestPickBestSnapshot(t *testing.T) {
 		require.True(t, ok)
 		assert.Equal(t, only, c.key)
 		assert.Equal(t, 2, c.tier)
+	})
+
+	t.Run("index format gate", func(t *testing.T) {
+		older := makeULID(t, now.Add(-30*time.Second))
+		same := makeULID(t, now.Add(-20*time.Second))
+		legacy := makeULID(t, now.Add(-10*time.Second))
+		tooNew := makeULID(t, now)
+
+		all := map[ulid.ULID]*IndexMeta{
+			older:  snap("11.5.0", 100, time.Minute),
+			same:   snap("11.5.0", 200, time.Minute),
+			legacy: snap("11.5.0", 300, time.Minute),
+			tooNew: snap("11.5.0", 400, time.Minute),
+		}
+		all[older].IndexFormat = testIndexFormatDelta(t, -1)
+		all[same].IndexFormat = format
+		all[tooNew].IndexFormat = testIndexFormatDelta(t, 1)
+
+		c, ok := newBackend(minV).pickBestSnapshot(all, cutoff(24*time.Hour), log.New("bleve-snapshot-test"))
+		require.True(t, ok)
+		assert.Equal(t, legacy, c.key, "empty legacy format remains compatible and normal tie-breaking still applies")
+
+		delete(all, legacy)
+		c, ok = newBackend(minV).pickBestSnapshot(all, cutoff(24*time.Hour), log.New("bleve-snapshot-test"))
+		require.True(t, ok)
+		assert.Equal(t, same, c.key, "same format should beat older format by RV")
 	})
 
 	t.Run("within tier: version desc, then RV desc, then upload desc", func(t *testing.T) {
@@ -964,7 +1007,7 @@ type probeCase struct {
 	wantErr string
 }
 
-type probeFn func(ctx context.Context, s RemoteIndexStore, ns resource.NamespacedResource, notOlderThan time.Time, v string) (ulid.ULID, *IndexMeta, error)
+type probeFn func(ctx context.Context, s RemoteIndexStore, ns resource.NamespacedResource, notOlderThan time.Time, v string, f string, logger log.Logger) (ulid.ULID, *IndexMeta, error)
 
 func runProbeCases(t *testing.T, probe probeFn, cases []probeCase) {
 	t.Helper()
@@ -973,7 +1016,8 @@ func runProbeCases(t *testing.T, probe probeFn, cases []probeCase) {
 			store := newHookableStore(t)
 			ns := newTestNsResource()
 			want := tc.setup(t, store, ns)
-			k, meta, err := probe(t.Context(), store, ns, time.Now().Add(-time.Hour), "11.5.0")
+			format := testIndexFormat(t)
+			k, meta, err := probe(t.Context(), store, ns, time.Now().Add(-time.Hour), "11.5.0", format, log.New("bleve-snapshot-test"))
 			if tc.wantErr != "" {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), tc.wantErr)
@@ -1011,6 +1055,41 @@ func TestFindFreshSnapshotByUploadTime(t *testing.T) {
 				match := mk(-30 * time.Minute)
 				seedSnapshot(t, t.Context(), s.bucket, ns, match, &IndexMeta{BuildVersion: "11.5.0"})
 				seedSnapshot(t, t.Context(), s.bucket, ns, mk(-50*time.Minute), &IndexMeta{BuildVersion: "11.5.0"})
+				return match
+			},
+		},
+		{
+			name: "uses same index format",
+			setup: func(t *testing.T, s *hookableStore, ns resource.NamespacedResource) ulid.ULID {
+				format := testIndexFormat(t)
+				match := mk(-5 * time.Minute)
+				seedSnapshot(t, t.Context(), s.bucket, ns, match, &IndexMeta{BuildVersion: "11.5.0", IndexFormat: format})
+				return match
+			},
+		},
+		{
+			name: "uses older index format",
+			setup: func(t *testing.T, s *hookableStore, ns resource.NamespacedResource) ulid.ULID {
+				match := mk(-5 * time.Minute)
+				seedSnapshot(t, t.Context(), s.bucket, ns, match, &IndexMeta{BuildVersion: "11.5.0", IndexFormat: testIndexFormatDelta(t, -1)})
+				return match
+			},
+		},
+		{
+			name: "skips newer index format",
+			setup: func(t *testing.T, s *hookableStore, ns resource.NamespacedResource) ulid.ULID {
+				format := testIndexFormat(t)
+				seedSnapshot(t, t.Context(), s.bucket, ns, mk(-5*time.Minute), &IndexMeta{BuildVersion: "11.5.0", IndexFormat: testIndexFormatDelta(t, 1)})
+				match := mk(-10 * time.Minute)
+				seedSnapshot(t, t.Context(), s.bucket, ns, match, &IndexMeta{BuildVersion: "11.5.0", IndexFormat: format})
+				return match
+			},
+		},
+		{
+			name: "uses legacy empty index format",
+			setup: func(t *testing.T, s *hookableStore, ns resource.NamespacedResource) ulid.ULID {
+				match := mk(-5 * time.Minute)
+				seedSnapshot(t, t.Context(), s.bucket, ns, match, &IndexMeta{BuildVersion: "11.5.0"})
 				return match
 			},
 		},

--- a/pkg/storage/unified/search/bleve_snapshot_upload.go
+++ b/pkg/storage/unified/search/bleve_snapshot_upload.go
@@ -2,6 +2,7 @@ package search
 
 import (
 	"context"
+	"encoding/binary"
 	"errors"
 	"fmt"
 	"os"
@@ -9,7 +10,9 @@ import (
 	"time"
 
 	"github.com/blevesearch/bleve/v2"
+	"github.com/blevesearch/bleve/v2/util"
 	"github.com/oklog/ulid/v2"
+	"go.etcd.io/bbolt"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	oteltrace "go.opentelemetry.io/otel/trace"
@@ -73,7 +76,7 @@ func (b *bleveBackend) uploadSnapshot(ctx context.Context, key resource.Namespac
 	// optimisation, not a correctness check.
 	if interval := b.opts.Snapshot.UploadInterval; interval > 0 {
 		notOlderThan := time.Now().Add(-interval)
-		k, _, err := findFreshSnapshotByUploadTime(ctx, b.opts.Snapshot.Store, key, notOlderThan, b.opts.BuildVersion)
+		k, _, err := findFreshSnapshotByUploadTime(ctx, b.opts.Snapshot.Store, key, notOlderThan, b.opts.BuildVersion, b.maxSupportedIndexFormat, logger)
 		if err != nil {
 			logger.Warn("Snapshot upload-time probe failed; proceeding with upload", "err", err)
 		} else if k != (ulid.ULID{}) {
@@ -128,6 +131,11 @@ func (b *bleveBackend) snapshotCopyAndUpload(ctx context.Context, key resource.N
 		return ulid.ULID{}, 0, err
 	}
 
+	indexFormat, err := readSnapshotIndexFormat(stagingDir)
+	if err != nil {
+		return ulid.ULID{}, 0, fmt.Errorf("reading snapshot index format: %w", err)
+	}
+
 	// Read RV/build info from the staged snapshot instead of the live index so
 	// the uploaded metadata matches the copied snapshot contents even if the live
 	// index advanced while CopyTo was running.
@@ -150,6 +158,7 @@ func (b *bleveBackend) snapshotCopyAndUpload(ctx context.Context, key resource.N
 
 	meta := IndexMeta{
 		BuildVersion:          bi.BuildVersion,
+		IndexFormat:           indexFormat,
 		LatestResourceVersion: rv,
 	}
 	// bi.BuildTime is the original index creation time; it survives reopens and
@@ -176,6 +185,50 @@ func (b *bleveBackend) snapshotIndex(idx bleve.Index, destDir string) error {
 		return fmt.Errorf("copying index snapshot: %w", err)
 	}
 	return nil
+}
+
+// readSnapshotIndexFormat reads the segment format Bleve persisted for this
+// snapshot. Bleve uses this metadata internally when opening scorch snapshots,
+// but does not expose it through the public Index API.
+func readSnapshotIndexFormat(indexDir string) (string, error) {
+	db, err := bbolt.Open(filepath.Join(indexDir, "store", "root.bolt"), 0, &bbolt.Options{ReadOnly: true, Timeout: time.Second})
+	if err != nil {
+		return "", err
+	}
+	defer func() { _ = db.Close() }()
+
+	var format string
+	if err := db.View(func(tx *bbolt.Tx) error {
+		snapshots := tx.Bucket(util.BoltSnapshotsBucket)
+		if snapshots == nil {
+			return fmt.Errorf("snapshots bucket missing")
+		}
+		k, _ := snapshots.Cursor().Last()
+		if k == nil {
+			return fmt.Errorf("snapshot metadata missing")
+		}
+		snapshot := snapshots.Bucket(k)
+		if snapshot == nil {
+			return fmt.Errorf("snapshot bucket missing")
+		}
+		meta := snapshot.Bucket(util.BoltMetaDataKey)
+		if meta == nil {
+			return fmt.Errorf("metadata bucket missing")
+		}
+		formatType := string(meta.Get(util.BoltMetaDataSegmentTypeKey))
+		versionBytes := meta.Get(util.BoltMetaDataSegmentVersionKey)
+		if len(versionBytes) < 4 {
+			return fmt.Errorf("segment version missing")
+		}
+		format = indexFormat(formatType, binary.BigEndian.Uint32(versionBytes))
+		if format == "" {
+			return fmt.Errorf("segment format missing")
+		}
+		return nil
+	}); err != nil {
+		return "", err
+	}
+	return format, nil
 }
 
 func (b *bleveBackend) newSnapshotStagingDir(key resource.NamespacedResource) (string, error) {

--- a/pkg/storage/unified/search/bleve_snapshot_upload_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_upload_test.go
@@ -88,6 +88,7 @@ func TestUploadSnapshot_Success(t *testing.T) {
 	uploadedMeta := store.getLastUploadedMeta()
 	assert.Equal(t, int64(42), uploadedMeta.LatestResourceVersion)
 	assert.Equal(t, be.opts.BuildVersion, uploadedMeta.BuildVersion)
+	assert.NotZero(t, uploadedMeta.IndexFormat)
 	assert.Equal(t, be.opts.BuildVersion, store.getLastLockBuildVersion())
 	// BuildTime must be populated from the index's internal build
 	// info (set by newBleveIndex), not left zero. Compare with second-level
@@ -310,8 +311,26 @@ func TestUploadSnapshot_SkipsWhenRecentSameVersionRemoteExists(t *testing.T) {
 	assert.Equal(t, int32(1), store.readManifestCalls.Load())
 }
 
-// TestUploadSnapshot_ProceedsWhenRemoteIsDifferentVersion verifies that the
-// probe does not skip when only different-version snapshots are present.
+// TestUploadSnapshot_ProceedsWhenRemoteHasNewerIndexFormat verifies that the
+// probe does not skip when only too-new index-format snapshots are present.
+func TestUploadSnapshot_ProceedsWhenRemoteHasNewerIndexFormat(t *testing.T) {
+	store := newHookableStore(t)
+	be, _ := newTestBleveBackend(t, SnapshotOptions{Store: store, UploadInterval: time.Hour})
+	require.NotEmpty(t, be.maxSupportedIndexFormat)
+	recent := makeULID(t, time.Now().Add(-5*time.Minute))
+	key := newTestNsResource()
+	formatType, version, ok := parseIndexFormat(be.maxSupportedIndexFormat)
+	require.True(t, ok)
+	seedSnapshot(t, context.Background(), store.bucket, key, recent, &IndexMeta{
+		BuildVersion: "11.5.0",
+		IndexFormat:  indexFormat(formatType, version+1),
+	})
+	idx := newUploadTestIndex(t, be, key, 42)
+
+	require.NoError(t, be.uploadSnapshot(t.Context(), key, idx))
+	assert.Equal(t, int32(1), store.uploadCalls.Load())
+}
+
 func TestUploadSnapshot_ProceedsWhenRemoteIsDifferentVersion(t *testing.T) {
 	store := newHookableStore(t)
 	recent := makeULID(t, time.Now().Add(-5*time.Minute))

--- a/pkg/storage/unified/search/remote_index_store.go
+++ b/pkg/storage/unified/search/remote_index_store.go
@@ -85,6 +85,9 @@ type IndexMeta struct {
 	// Zero-value means "unknown"; readers must not treat it as a freshness
 	// signal.
 	BuildTime time.Time `json:"build_time,omitempty"`
+	// IndexFormat identifies the Bleve segment format that wrote this snapshot
+	// (for example, "zap/16"). Empty on legacy snapshots means "unknown, assume compatible".
+	IndexFormat string `json:"index_format,omitempty"`
 	// LatestResourceVersion is the latest resource version included in the index.
 	LatestResourceVersion int64 `json:"latest_resource_version"`
 	// Files maps relative file paths to their sizes in bytes.


### PR DESCRIPTION
Gate remote index snapshot reads by the Bleve index format recorded in the snapshot manifest.

We observed this during the recent Bleve v2.6.0 rollout and revert: after reverting the Bleve update, pods running the older Bleve could not open snapshots uploaded by pods that had already written the newer on-disk format, logging `opening downloaded snapshot: cannot open index, metadata corrupt`.

Snapshots uploaded before this field existed are treated as compatible. New snapshots record the actual Bleve segment format from the staged snapshot, and readers skip snapshots whose format is newer than they can support.