### PR TITLE
Update usage limits documentation for Git Sync

### DIFF
--- a/docs/sources/as-code/observability-as-code/git-sync/usage-limits.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/usage-limits.md
@@ -58,7 +58,6 @@ If you're an on-prem user, you can customize your limits via configuration setti
 
 - Use `max_repositories` to set the amount of repositories you can sync. Refer to [`max_repositories`](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#max_repositories) in the Configure Grafana section to learn more.
 - Use `max_resources_per_repository` to set the amount of resources per repository to sync. Refer to [`max_resources_per_repository`](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/#max_resources_per_repository) in the Configure Grafana section to learn more.
-  > > > > > > > c2f0b685470 (Docs: Updates to Git Sync limits (#123460))
 
 ## Compatible Git providers
 


### PR DESCRIPTION
Removed outdated commit reference from usage limits documentation.
