### PR TITLE
chore: rename growth-and-onboarding to growth-engineering

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -974,7 +974,7 @@ playwright.storybook.config.ts @grafana/grafana-frontend-platform
 /public/app/features/explore/ @grafana/datapro
 /public/app/features/expressions/ @grafana/datapro
 /public/app/features/folders/ @grafana/grafana-frontend-navigation
-/public/app/features/home/ @grafana/grafana-frontend-navigation @grafana/growth-and-onboarding
+/public/app/features/home/ @grafana/grafana-frontend-navigation @grafana/growth-engineering
 /public/app/features/inspector/ @grafana/dashboards-squad
 /public/app/features/logs/ @grafana/observability-logs
 /public/app/features/live/ @grafana/dashboards-squad


### PR DESCRIPTION
**What is this feature?**

With the move into R&D, the `@grafana/growth-and-onboarding` GitHub team is becoming `@grafana/growth-engineering` instead.

**Why do we need this feature?**

See above.

**Who is this feature for?**

Internal.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Needs https://github.com/grafana/deployment_tools/pull/586196 (🔐) to land to update access for teams.
