### PR TITLE
Serge/old dashboards arch telemetry

### DIFF
--- a/devenv/dev-dashboards/legacy-dashboard-api-usage.json
+++ b/devenv/dev-dashboards/legacy-dashboard-api-usage.json
@@ -1,0 +1,46 @@
+{
+  "title": "Legacy Dashboard API Usage",
+  "uid": "legacy-dashboard-api-usage",
+  "tags": ["telemetry", "deprecation", "scenes-migration"],
+  "schemaVersion": 39,
+  "version": 1,
+  "time": { "from": "now-30d", "to": "now" },
+  "panels": [
+    {
+      "type": "barchart",
+      "title": "Unique plugins per legacy API (30d)",
+      "id": 1,
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "refId": "A",
+          "rawSql": "SELECT api_name, COUNT(DISTINCT plugin_id) AS plugins FROM interactions WHERE event_name = 'grafana_legacy_dashboard_api_used' AND time > now() - interval '30 day' GROUP BY api_name ORDER BY plugins DESC"
+        }
+      ]
+    },
+    {
+      "type": "table",
+      "title": "Plugins still using legacy APIs",
+      "id": 2,
+      "gridPos": { "h": 14, "w": 24, "x": 0, "y": 10 },
+      "targets": [
+        {
+          "refId": "A",
+          "rawSql": "SELECT plugin_id, api_name, COUNT(*) AS sessions, MAX(time) AS last_seen FROM interactions WHERE event_name = 'grafana_legacy_dashboard_api_used' AND time > now() - interval '30 day' GROUP BY plugin_id, api_name ORDER BY sessions DESC"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Legacy-API sessions over time, split by api_name",
+      "id": 3,
+      "gridPos": { "h": 10, "w": 24, "x": 0, "y": 24 },
+      "targets": [
+        {
+          "refId": "A",
+          "rawSql": "SELECT time_bucket('1 day', time) AS time, api_name, COUNT(DISTINCT session_id) AS sessions FROM interactions WHERE event_name = 'grafana_legacy_dashboard_api_used' AND time > now() - interval '90 day' GROUP BY 1, api_name ORDER BY 1"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/sources/developers/plugins/migration-guides/legacy-dashboard-api-deprecation.md
+++ b/docs/sources/developers/plugins/migration-guides/legacy-dashboard-api-deprecation.md
@@ -25,19 +25,17 @@ This guide explains what legacy dashboard API usage Grafana detects in plugins, 
 
 Grafana instruments plugin call sites in the legacy (non-scenes) dashboard architecture. Each surface has an `apiName` value that appears in deprecation warnings and telemetry.
 
-| `apiName`                         | What triggers it                                                                                                                                                                                                 |
-| --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `PanelMigrationHandler.register`  | A panel plugin called `PanelPlugin.setMigrationHandler()` at registration time. Scenes never invokes this handler, so the registration itself is the legacy marker.                                              |
-| `PanelMigrationHandler.invoke`    | The legacy `PanelModel.pluginLoaded()` code path actually invoked a panel plugin's `onPanelMigration` handler. This only fires in non-scenes flows (alerting rule editor, library panels, panel editor Redux).   |
-| `PanelTypeChangedHandler.invoke`  | Scenes deserialised a dashboard JSON containing an old panel type and invoked the migration target plugin's `onPanelTypeChanged` handler. This is the one legacy plugin hook that scenes still calls at runtime. |
-| `PanelModel.changePlugin.invoke`  | The legacy `PanelModel.changePlugin()` ran. This is reachable from the panel error-recovery flow when a broken panel isn't a scenes `VizPanel`.                                                                  |
-| `DashboardSrv.getCurrent`         | A plugin called `getDashboardSrv().getCurrent()`. The returned object is a scenes compatibility wrapper, but the API itself is the legacy `DashboardSrv` singleton, not a scenes-native API.                     |
-| `RefreshEvent.subscribe`          | A plugin subscribed to the legacy `RefreshEvent`.                                                                                                                                                                |
-| `RefreshEvent.getStream`          | A plugin got a stream of the legacy `RefreshEvent`.                                                                                                                                                              |
-| `TimeRangeUpdatedEvent.subscribe` | A plugin subscribed to the legacy `TimeRangeUpdatedEvent`.                                                                                                                                                       |
-| `TimeRangeUpdatedEvent.getStream` | A plugin got a stream of the legacy `TimeRangeUpdatedEvent`.                                                                                                                                                     |
-| `CopyPanelEvent.subscribe`        | A plugin subscribed to the legacy `CopyPanelEvent`.                                                                                                                                                              |
-| `CopyPanelEvent.getStream`        | A plugin got a stream of the legacy `CopyPanelEvent`.                                                                                                                                                            |
+| `apiName`                         | What triggers it                                                                                                                                                                                               |
+| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PanelMigrationHandler.invoke`    | The legacy `PanelModel.pluginLoaded()` code path actually invoked a panel plugin's `onPanelMigration` handler. This only fires in non-scenes flows (alerting rule editor, library panels, panel editor Redux). |
+| `PanelModel.changePlugin.invoke`  | The legacy `PanelModel.changePlugin()` ran. This is reachable from the panel error-recovery flow when a broken panel isn't a scenes `VizPanel`.                                                                |
+| `DashboardSrv.getCurrent`         | A plugin called `getDashboardSrv().getCurrent()`. The returned object is a scenes compatibility wrapper, but the API itself is the legacy `DashboardSrv` singleton, not a scenes-native API.                   |
+| `RefreshEvent.subscribe`          | A plugin subscribed to the legacy `RefreshEvent`.                                                                                                                                                              |
+| `RefreshEvent.getStream`          | A plugin got a stream of the legacy `RefreshEvent`.                                                                                                                                                            |
+| `TimeRangeUpdatedEvent.subscribe` | A plugin subscribed to the legacy `TimeRangeUpdatedEvent`.                                                                                                                                                     |
+| `TimeRangeUpdatedEvent.getStream` | A plugin got a stream of the legacy `TimeRangeUpdatedEvent`.                                                                                                                                                   |
+| `CopyPanelEvent.subscribe`        | A plugin subscribed to the legacy `CopyPanelEvent`.                                                                                                                                                            |
+| `CopyPanelEvent.getStream`        | A plugin got a stream of the legacy `CopyPanelEvent`.                                                                                                                                                          |
 
 ## Why these APIs are deprecated
 
@@ -55,15 +53,11 @@ Open your browser DevTools, load any dashboard that uses your plugin, and check 
 
 ## Migration paths
 
-### Panel migration handlers (`PanelMigrationHandler.*`)
+### `PanelMigrationHandler.invoke`
 
 Scenes doesn't invoke the handler registered with `PanelPlugin.setMigrationHandler()` during normal dashboard load. If your plugin registered a migration handler to upgrade stored panel options, that logic no longer runs in scenes-powered dashboards.
 
-Migrate your option-upgrade logic to `PanelPlugin.setPanelChangeHandler()` (`onPanelTypeChanged`). Scenes does still call `onPanelTypeChanged` during Angular-era panel deserialisation, so this is the correct place for panel-type and option migration in scenes.
-
-### `PanelTypeChangedHandler.invoke`
-
-This telemetry tracks usage of the `onPanelTypeChanged` hook, which scenes still calls. No migration action is required at this time.
+Migrate your option-upgrade logic to `PanelPlugin.setPanelChangeHandler()` (`onPanelTypeChanged`). Scenes still calls `onPanelTypeChanged` during Angular-era panel deserialisation, so this is the correct place for panel-type and option migration.
 
 ### `PanelModel.changePlugin.invoke`
 

--- a/docs/sources/developers/plugins/migration-guides/legacy-dashboard-api-deprecation.md
+++ b/docs/sources/developers/plugins/migration-guides/legacy-dashboard-api-deprecation.md
@@ -28,7 +28,6 @@ Grafana instruments plugin call sites in the legacy (non-scenes) dashboard archi
 | `apiName`                         | What triggers it                                                                                                                                                                                               |
 | --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `PanelMigrationHandler.invoke`    | The legacy `PanelModel.pluginLoaded()` code path actually invoked a panel plugin's `onPanelMigration` handler. This only fires in non-scenes flows (alerting rule editor, library panels, panel editor Redux). |
-| `PanelModel.changePlugin.invoke`  | The legacy `PanelModel.changePlugin()` ran. This is reachable from the panel error-recovery flow when a broken panel isn't a scenes `VizPanel`.                                                                |
 | `DashboardSrv.getCurrent`         | A plugin called `getDashboardSrv().getCurrent()`. The returned object is a scenes compatibility wrapper, but the API itself is the legacy `DashboardSrv` singleton, not a scenes-native API.                   |
 | `RefreshEvent.subscribe`          | A plugin subscribed to the legacy `RefreshEvent`.                                                                                                                                                              |
 | `RefreshEvent.getStream`          | A plugin got a stream of the legacy `RefreshEvent`.                                                                                                                                                            |
@@ -58,10 +57,6 @@ Open your browser DevTools, load any dashboard that uses your plugin, and check 
 Scenes doesn't invoke the handler registered with `PanelPlugin.setMigrationHandler()` during normal dashboard load. If your plugin registered a migration handler to upgrade stored panel options, that logic no longer runs in scenes-powered dashboards.
 
 Migrate your option-upgrade logic to `PanelPlugin.setPanelChangeHandler()` (`onPanelTypeChanged`). Scenes still calls `onPanelTypeChanged` during Angular-era panel deserialisation, so this is the correct place for panel-type and option migration.
-
-### `PanelModel.changePlugin.invoke`
-
-This surface is only reachable via the panel error-recovery flow, not from plugin code directly. You don't need to change anything unless your plugin explicitly calls `PanelModel.changePlugin()` to swap panel types programmatically.
 
 ### `DashboardSrv.getCurrent`
 

--- a/docs/sources/developers/plugins/migration-guides/legacy-dashboard-api-deprecation.md
+++ b/docs/sources/developers/plugins/migration-guides/legacy-dashboard-api-deprecation.md
@@ -1,0 +1,82 @@
+---
+description: Learn what legacy dashboard API deprecation telemetry is collected and how to migrate your plugin.
+keywords:
+  - grafana
+  - plugins
+  - migration
+  - dashboard
+  - scenes
+  - deprecation
+labels:
+  products:
+    - cloud
+    - enterprise
+    - oss
+title: Migrate from legacy dashboard APIs
+menuTitle: Legacy dashboard API deprecation
+weight: 100
+---
+
+# Migrate from legacy dashboard APIs
+
+This guide explains what legacy dashboard API usage Grafana detects in plugins, why those APIs are deprecated, and what you should do to update your plugin.
+
+## What's being detected
+
+Grafana instruments plugin call sites in the legacy (non-scenes) dashboard architecture. Each surface has an `apiName` value that appears in deprecation warnings and telemetry.
+
+| `apiName`                         | What triggers it                                                                                                                                                                                                 |
+| --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `PanelMigrationHandler.register`  | A panel plugin called `PanelPlugin.setMigrationHandler()` at registration time. Scenes never invokes this handler, so the registration itself is the legacy marker.                                              |
+| `PanelMigrationHandler.invoke`    | The legacy `PanelModel.pluginLoaded()` code path actually invoked a panel plugin's `onPanelMigration` handler. This only fires in non-scenes flows (alerting rule editor, library panels, panel editor Redux).   |
+| `PanelTypeChangedHandler.invoke`  | Scenes deserialised a dashboard JSON containing an old panel type and invoked the migration target plugin's `onPanelTypeChanged` handler. This is the one legacy plugin hook that scenes still calls at runtime. |
+| `PanelModel.changePlugin.invoke`  | The legacy `PanelModel.changePlugin()` ran. This is reachable from the panel error-recovery flow when a broken panel isn't a scenes `VizPanel`.                                                                  |
+| `DashboardSrv.getCurrent`         | A plugin called `getDashboardSrv().getCurrent()`. The returned object is a scenes compatibility wrapper, but the API itself is the legacy `DashboardSrv` singleton, not a scenes-native API.                     |
+| `RefreshEvent.subscribe`          | A plugin subscribed to the legacy `RefreshEvent`.                                                                                                                                                                |
+| `RefreshEvent.getStream`          | A plugin got a stream of the legacy `RefreshEvent`.                                                                                                                                                              |
+| `TimeRangeUpdatedEvent.subscribe` | A plugin subscribed to the legacy `TimeRangeUpdatedEvent`.                                                                                                                                                       |
+| `TimeRangeUpdatedEvent.getStream` | A plugin got a stream of the legacy `TimeRangeUpdatedEvent`.                                                                                                                                                     |
+| `CopyPanelEvent.subscribe`        | A plugin subscribed to the legacy `CopyPanelEvent`.                                                                                                                                                              |
+| `CopyPanelEvent.getStream`        | A plugin got a stream of the legacy `CopyPanelEvent`.                                                                                                                                                            |
+
+## Why these APIs are deprecated
+
+The legacy non-scenes dashboard architecture is being removed from Grafana. Once removed, any plugin that relies on these call sites will stop working. Telemetry helps the Grafana team understand the blast radius before setting removal dates.
+
+## How to know if your plugin is affected
+
+When Grafana detects your plugin using a deprecated API, it logs a browser console warning:
+
+```text
+[grafana] Plugin "<your-plugin-id>" used deprecated dashboard API "<apiName>"
+```
+
+Open your browser DevTools, load any dashboard that uses your plugin, and check the **Console** tab for these messages.
+
+## Migration paths
+
+### Panel migration handlers (`PanelMigrationHandler.*`)
+
+Scenes doesn't invoke the handler registered with `PanelPlugin.setMigrationHandler()` during normal dashboard load. If your plugin registered a migration handler to upgrade stored panel options, that logic no longer runs in scenes-powered dashboards.
+
+Migrate your option-upgrade logic to `PanelPlugin.setPanelChangeHandler()` (`onPanelTypeChanged`). Scenes does still call `onPanelTypeChanged` during Angular-era panel deserialisation, so this is the correct place for panel-type and option migration in scenes.
+
+### `PanelTypeChangedHandler.invoke`
+
+This telemetry tracks usage of the `onPanelTypeChanged` hook, which scenes still calls. No migration action is required at this time.
+
+### `PanelModel.changePlugin.invoke`
+
+This surface is only reachable via the panel error-recovery flow, not from plugin code directly. You don't need to change anything unless your plugin explicitly calls `PanelModel.changePlugin()` to swap panel types programmatically.
+
+### `DashboardSrv.getCurrent`
+
+The `getDashboardSrv().getCurrent()` call returns a compatibility wrapper in scenes-powered dashboards, but the `DashboardSrv` singleton is a legacy concept. For scenes-native dashboard inspection, refer to the `@grafana/scenes` package documentation for the appropriate scene context APIs.
+
+### App-event subscriptions (`RefreshEvent`, `TimeRangeUpdatedEvent`, `CopyPanelEvent`)
+
+Subscribing to these legacy app events isn't scenes-native. Scenes manages state and re-render lifecycle through its own scene objects and observables. For time-range updates, use the time-range observables in `@grafana/scenes`. For refresh behaviour, rely on scenes' built-in re-render mechanics. Refer to the `@grafana/scenes` documentation for the equivalent patterns.
+
+## Timeline
+
+The removal date for the deprecated APIs is TBD. The deprecation cadence will be set once telemetry data has been collected over at least one release cycle.

--- a/packages/grafana-data/src/index.ts
+++ b/packages/grafana-data/src/index.ts
@@ -226,6 +226,7 @@ export { convertOldAngularValueMappings, LegacyMappingType } from './utils/value
 export { containsSearchFilter, type SearchFilterOptions, getSearchFilterScopedVar } from './utils/variables';
 export { renderLegendFormat } from './utils/legend';
 export { matchPluginId } from './utils/matchPluginId';
+export { resolvePluginIdFromStack } from './utils/resolvePluginIdFromStack';
 export { type RegistryItem, type RegistryItemWithOptions, Registry } from './utils/Registry';
 export {
   getDataSourceRef,

--- a/packages/grafana-data/src/utils/resolvePluginIdFromStack.test.ts
+++ b/packages/grafana-data/src/utils/resolvePluginIdFromStack.test.ts
@@ -31,4 +31,14 @@ describe('resolvePluginIdFromStack', () => {
     ].join('\n');
     expect(resolvePluginIdFromStack(stack)).toBe('first');
   });
+
+  it('extracts pluginId from Firefox-style stack frame (no parens)', () => {
+    const stack = 'handler@http://localhost:3000/public/plugins/foo-panel/module.js:10:1';
+    expect(resolvePluginIdFromStack(stack)).toBe('foo-panel');
+  });
+
+  it('extracts pluginId from a URL with a query string', () => {
+    const stack = '    at handler (http://localhost:3000/public/plugins/bar-panel/module.js?v=12345:10:1)';
+    expect(resolvePluginIdFromStack(stack)).toBe('bar-panel');
+  });
 });

--- a/packages/grafana-data/src/utils/resolvePluginIdFromStack.test.ts
+++ b/packages/grafana-data/src/utils/resolvePluginIdFromStack.test.ts
@@ -1,0 +1,34 @@
+import { resolvePluginIdFromStack } from './resolvePluginIdFromStack';
+
+describe('resolvePluginIdFromStack', () => {
+  it('extracts pluginId from /public/plugins/<id>/ frame', () => {
+    const stack = [
+      'Error',
+      '    at reporter (http://localhost:3000/public/build/runtime.js:1:1)',
+      '    at handler (http://localhost:3000/public/plugins/grafana-clock-panel/module.js:55:12)',
+    ].join('\n');
+    expect(resolvePluginIdFromStack(stack)).toBe('grafana-clock-panel');
+  });
+
+  it('extracts pluginId from /api/plugins/<id>/ frame', () => {
+    const stack = '    at fn (http://example.com/api/plugins/acme-datasource/resources/module.js:10:1)';
+    expect(resolvePluginIdFromStack(stack)).toBe('acme-datasource');
+  });
+
+  it('returns "unknown" when no plugin frame is present', () => {
+    const stack = '    at PanelChrome (http://localhost:3000/public/build/app.js:9000:1)';
+    expect(resolvePluginIdFromStack(stack)).toBe('unknown');
+  });
+
+  it('returns "unknown" when stack is undefined', () => {
+    expect(resolvePluginIdFromStack(undefined)).toBe('unknown');
+  });
+
+  it('returns the first matching plugin frame', () => {
+    const stack = [
+      '    at outer (http://localhost:3000/public/plugins/first/module.js:1:1)',
+      '    at inner (http://localhost:3000/public/plugins/second/module.js:1:1)',
+    ].join('\n');
+    expect(resolvePluginIdFromStack(stack)).toBe('first');
+  });
+});

--- a/packages/grafana-data/src/utils/resolvePluginIdFromStack.ts
+++ b/packages/grafana-data/src/utils/resolvePluginIdFromStack.ts
@@ -1,0 +1,14 @@
+const PLUGIN_FRAME_RE = /\/(?:public|api)\/plugins\/([a-z0-9][a-z0-9-_]*)\//i;
+
+export function resolvePluginIdFromStack(stack: string | undefined): string {
+  if (!stack) {
+    return 'unknown';
+  }
+  for (const line of stack.split('\n')) {
+    const match = line.match(PLUGIN_FRAME_RE);
+    if (match) {
+      return match[1];
+    }
+  }
+  return 'unknown';
+}

--- a/packages/grafana-runtime/src/analytics/legacyDashboardApiUsage.test.ts
+++ b/packages/grafana-runtime/src/analytics/legacyDashboardApiUsage.test.ts
@@ -1,0 +1,65 @@
+import { __resetLegacyDashboardApiUsageDedupeForTests, reportLegacyDashboardApiUsage } from './legacyDashboardApiUsage';
+import { reportInteraction } from './utils';
+
+jest.mock('./utils', () => ({ reportInteraction: jest.fn() }));
+const reportInteractionMock = reportInteraction as jest.Mock;
+
+describe('reportLegacyDashboardApiUsage', () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    reportInteractionMock.mockClear();
+    __resetLegacyDashboardApiUsageDedupeForTests();
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('emits grafana_legacy_dashboard_api_used interaction', () => {
+    reportLegacyDashboardApiUsage({ pluginId: 'p', apiName: 'PanelMigrationHandler.invoke' });
+    expect(reportInteractionMock).toHaveBeenCalledTimes(1);
+    expect(reportInteractionMock).toHaveBeenCalledWith(
+      'grafana_legacy_dashboard_api_used',
+      expect.objectContaining({ pluginId: 'p', apiName: 'PanelMigrationHandler.invoke' })
+    );
+  });
+
+  it('forwards extra properties', () => {
+    reportLegacyDashboardApiUsage({
+      pluginId: 'p',
+      apiName: 'PanelMigrationHandler.invoke',
+      extra: { fromVersion: '1', toVersion: '2' },
+    });
+    expect(reportInteractionMock).toHaveBeenCalledWith(
+      'grafana_legacy_dashboard_api_used',
+      expect.objectContaining({ fromVersion: '1', toVersion: '2' })
+    );
+  });
+
+  it('dedupes by (pluginId, apiName) within a session', () => {
+    for (let i = 0; i < 3; i++) {
+      reportLegacyDashboardApiUsage({ pluginId: 'p', apiName: 'PanelMigrationHandler.invoke' });
+    }
+    expect(reportInteractionMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports separately per apiName for the same pluginId', () => {
+    reportLegacyDashboardApiUsage({ pluginId: 'p', apiName: 'PanelMigrationHandler.invoke' });
+    reportLegacyDashboardApiUsage({ pluginId: 'p', apiName: 'RefreshEvent.subscribe' });
+    expect(reportInteractionMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports separately per pluginId for the same apiName', () => {
+    reportLegacyDashboardApiUsage({ pluginId: 'a', apiName: 'PanelMigrationHandler.invoke' });
+    reportLegacyDashboardApiUsage({ pluginId: 'b', apiName: 'PanelMigrationHandler.invoke' });
+    expect(reportInteractionMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('console.warns once per (pluginId, apiName)', () => {
+    reportLegacyDashboardApiUsage({ pluginId: 'p', apiName: 'PanelMigrationHandler.invoke' });
+    reportLegacyDashboardApiUsage({ pluginId: 'p', apiName: 'PanelMigrationHandler.invoke' });
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/grafana-runtime/src/analytics/legacyDashboardApiUsage.ts
+++ b/packages/grafana-runtime/src/analytics/legacyDashboardApiUsage.ts
@@ -1,0 +1,33 @@
+import { resolvePluginIdFromStack } from '@grafana/data';
+
+import { reportInteraction } from './utils';
+
+export { resolvePluginIdFromStack };
+
+const INTERACTION_NAME = 'grafana_legacy_dashboard_api_used';
+const seen = new Set<string>();
+
+export interface LegacyDashboardApiUsage {
+  pluginId: string;
+  apiName: string;
+  extra?: Record<string, unknown>;
+}
+
+export function reportLegacyDashboardApiUsage({ pluginId, apiName, extra }: LegacyDashboardApiUsage): void {
+  const key = `${pluginId}::${apiName}`;
+  if (seen.has(key)) {
+    return;
+  }
+  seen.add(key);
+
+  console.warn(
+    `[grafana] Plugin "${pluginId}" used legacy dashboard API "${apiName}". This API is scheduled for removal — see the legacy-dashboard-api-deprecation migration guide.`
+  );
+
+  reportInteraction(INTERACTION_NAME, { pluginId, apiName, ...(extra ?? {}) });
+}
+
+/** @internal — for tests only. */
+export function __resetLegacyDashboardApiUsageDedupeForTests(): void {
+  seen.clear();
+}

--- a/packages/grafana-runtime/src/analytics/legacyDashboardApiUsage.ts
+++ b/packages/grafana-runtime/src/analytics/legacyDashboardApiUsage.ts
@@ -1,19 +1,17 @@
-import { resolvePluginIdFromStack } from '@grafana/data';
-
 import { reportInteraction } from './utils';
-
-export { resolvePluginIdFromStack };
 
 const INTERACTION_NAME = 'grafana_legacy_dashboard_api_used';
 const seen = new Set<string>();
 
+/** @public */
 export interface LegacyDashboardApiUsage {
   pluginId: string;
   apiName: string;
   extra?: Record<string, unknown>;
 }
 
-export function reportLegacyDashboardApiUsage({ pluginId, apiName, extra }: LegacyDashboardApiUsage): void {
+/** @public */
+export const reportLegacyDashboardApiUsage = ({ pluginId, apiName, extra }: LegacyDashboardApiUsage): void => {
   const key = `${pluginId}::${apiName}`;
   if (seen.has(key)) {
     return;
@@ -21,11 +19,11 @@ export function reportLegacyDashboardApiUsage({ pluginId, apiName, extra }: Lega
   seen.add(key);
 
   console.warn(
-    `[grafana] Plugin "${pluginId}" used legacy dashboard API "${apiName}". This API is scheduled for removal — see the legacy-dashboard-api-deprecation migration guide.`
+    `[grafana] Plugin "${pluginId}" used deprecated dashboard API "${apiName}" and will break in a future major release.`
   );
 
   reportInteraction(INTERACTION_NAME, { pluginId, apiName, ...(extra ?? {}) });
-}
+};
 
 /** @internal — for tests only. */
 export function __resetLegacyDashboardApiUsageDedupeForTests(): void {

--- a/packages/grafana-runtime/src/index.ts
+++ b/packages/grafana-runtime/src/index.ts
@@ -15,6 +15,11 @@ export {
   reportPageview,
   reportExperimentView,
 } from './analytics/utils';
+export {
+  reportLegacyDashboardApiUsage,
+  resolvePluginIdFromStack,
+  type LegacyDashboardApiUsage,
+} from './analytics/legacyDashboardApiUsage';
 export { featureEnabled } from './utils/licensing';
 export {
   logInfo,

--- a/packages/grafana-runtime/src/index.ts
+++ b/packages/grafana-runtime/src/index.ts
@@ -15,11 +15,8 @@ export {
   reportPageview,
   reportExperimentView,
 } from './analytics/utils';
-export {
-  reportLegacyDashboardApiUsage,
-  resolvePluginIdFromStack,
-  type LegacyDashboardApiUsage,
-} from './analytics/legacyDashboardApiUsage';
+export { reportLegacyDashboardApiUsage, type LegacyDashboardApiUsage } from './analytics/legacyDashboardApiUsage';
+export { resolvePluginIdFromStack } from '@grafana/data';
 export { featureEnabled } from './utils/licensing';
 export {
   logInfo,

--- a/packages/grafana-runtime/src/services/appEvents.test.ts
+++ b/packages/grafana-runtime/src/services/appEvents.test.ts
@@ -1,0 +1,56 @@
+import { BusEventBase, EventBusSrv, type BusEvent, type BusEventType } from '@grafana/data';
+
+import { __resetLegacyDashboardApiUsageDedupeForTests } from '../analytics/legacyDashboardApiUsage';
+import * as legacyApiUsageModule from '../analytics/legacyDashboardApiUsage';
+
+import { CopyPanelEvent, RefreshEvent, TimeRangeUpdatedEvent, getAppEvents, setAppEvents } from './appEvents';
+
+class UnrelatedEvent extends BusEventBase {
+  static type = 'unrelated';
+}
+
+describe('appEvents legacy subscription telemetry', () => {
+  let reportSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    __resetLegacyDashboardApiUsageDedupeForTests();
+    reportSpy = jest.spyOn(legacyApiUsageModule, 'reportLegacyDashboardApiUsage').mockImplementation(() => {});
+    setAppEvents(new EventBusSrv());
+  });
+
+  afterEach(() => {
+    reportSpy.mockRestore();
+  });
+
+  it.each([
+    [RefreshEvent, 'RefreshEvent.subscribe'],
+    [TimeRangeUpdatedEvent, 'TimeRangeUpdatedEvent.subscribe'],
+    [CopyPanelEvent, 'CopyPanelEvent.subscribe'],
+  ])('reports legacy subscription via .subscribe()', (EventType, apiName) => {
+    getAppEvents().subscribe(EventType as BusEventType<BusEvent>, () => {});
+    expect(reportSpy).toHaveBeenCalledWith(expect.objectContaining({ apiName }));
+  });
+
+  it.each([
+    [RefreshEvent, 'RefreshEvent.subscribe'],
+    [TimeRangeUpdatedEvent, 'TimeRangeUpdatedEvent.subscribe'],
+    [CopyPanelEvent, 'CopyPanelEvent.subscribe'],
+  ])('reports legacy subscription via .getStream()', (EventType, apiName) => {
+    getAppEvents()
+      .getStream(EventType as BusEventType<BusEvent>)
+      .subscribe(() => {});
+    expect(reportSpy).toHaveBeenCalledWith(expect.objectContaining({ apiName }));
+  });
+
+  it('does NOT report non-legacy events', () => {
+    getAppEvents().subscribe(UnrelatedEvent, () => {});
+    expect(reportSpy).not.toHaveBeenCalled();
+  });
+
+  it('still delivers events to the subscribed handler', () => {
+    const handler = jest.fn();
+    getAppEvents().subscribe(RefreshEvent, handler);
+    getAppEvents().publish(new RefreshEvent());
+    expect(handler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/grafana-runtime/src/services/appEvents.test.ts
+++ b/packages/grafana-runtime/src/services/appEvents.test.ts
@@ -1,7 +1,6 @@
 import { BusEventBase, EventBusSrv, type BusEvent, type BusEventType } from '@grafana/data';
 
 import { __resetLegacyDashboardApiUsageDedupeForTests } from '../analytics/legacyDashboardApiUsage';
-import * as legacyApiUsageModule from '../analytics/legacyDashboardApiUsage';
 
 import { CopyPanelEvent, RefreshEvent, TimeRangeUpdatedEvent, getAppEvents, setAppEvents } from './appEvents';
 
@@ -10,16 +9,18 @@ class UnrelatedEvent extends BusEventBase {
 }
 
 describe('appEvents legacy subscription telemetry', () => {
-  let reportSpy: jest.SpyInstance;
+  let warnSpy: jest.SpyInstance;
 
   beforeEach(() => {
     __resetLegacyDashboardApiUsageDedupeForTests();
-    reportSpy = jest.spyOn(legacyApiUsageModule, 'reportLegacyDashboardApiUsage').mockImplementation(() => {});
     setAppEvents(new EventBusSrv());
+    // Intercept console.warn so the real reportLegacyDashboardApiUsage can run
+    // without failing the test via jest-fail-on-console
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
   });
 
   afterEach(() => {
-    reportSpy.mockRestore();
+    warnSpy.mockRestore();
   });
 
   it.each([
@@ -28,23 +29,23 @@ describe('appEvents legacy subscription telemetry', () => {
     [CopyPanelEvent, 'CopyPanelEvent.subscribe'],
   ])('reports legacy subscription via .subscribe()', (EventType, apiName) => {
     getAppEvents().subscribe(EventType as BusEventType<BusEvent>, () => {});
-    expect(reportSpy).toHaveBeenCalledWith(expect.objectContaining({ apiName }));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(apiName));
   });
 
   it.each([
-    [RefreshEvent, 'RefreshEvent.subscribe'],
-    [TimeRangeUpdatedEvent, 'TimeRangeUpdatedEvent.subscribe'],
-    [CopyPanelEvent, 'CopyPanelEvent.subscribe'],
-  ])('reports legacy subscription via .getStream()', (EventType, apiName) => {
+    [RefreshEvent, 'RefreshEvent.getStream'],
+    [TimeRangeUpdatedEvent, 'TimeRangeUpdatedEvent.getStream'],
+    [CopyPanelEvent, 'CopyPanelEvent.getStream'],
+  ])('reports legacy access via .getStream()', (EventType, apiName) => {
     getAppEvents()
       .getStream(EventType as BusEventType<BusEvent>)
       .subscribe(() => {});
-    expect(reportSpy).toHaveBeenCalledWith(expect.objectContaining({ apiName }));
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining(apiName));
   });
 
   it('does NOT report non-legacy events', () => {
     getAppEvents().subscribe(UnrelatedEvent, () => {});
-    expect(reportSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
   it('still delivers events to the subscribed handler', () => {

--- a/packages/grafana-runtime/src/services/appEvents.ts
+++ b/packages/grafana-runtime/src/services/appEvents.ts
@@ -1,11 +1,19 @@
+import { type Observable, type Unsubscribable } from 'rxjs';
+
 import {
   BusEventBase,
   BusEventWithPayload,
+  resolvePluginIdFromStack,
+  type BusEvent,
+  type BusEventHandler,
+  type BusEventType,
   type EventBus,
   type GrafanaTheme2,
   type PanelModel,
   type TimeRange,
 } from '@grafana/data';
+
+import * as legacyApiUsage from '../analytics/legacyDashboardApiUsage';
 
 /**
  * Called when a dashboard is refreshed
@@ -43,17 +51,58 @@ export class CopyPanelEvent extends BusEventWithPayload<PanelModel> {
   static type = 'copy-panel';
 }
 
+const LEGACY_EVENT_API_NAMES: Record<string, string> = {
+  [RefreshEvent.type]: 'RefreshEvent.subscribe',
+  [TimeRangeUpdatedEvent.type]: 'TimeRangeUpdatedEvent.subscribe',
+  [CopyPanelEvent.type]: 'CopyPanelEvent.subscribe',
+};
+
+function reportIfLegacy(staticType: string | undefined): void {
+  if (!staticType) {
+    return;
+  }
+  const apiName = LEGACY_EVENT_API_NAMES[staticType];
+  if (!apiName) {
+    return;
+  }
+  legacyApiUsage.reportLegacyDashboardApiUsage({
+    pluginId: resolvePluginIdFromStack(new Error().stack),
+    apiName,
+    extra: { eventType: staticType },
+  });
+}
+
+function wrapBus(bus: EventBus): EventBus {
+  return new Proxy(bus, {
+    get(target, prop, receiver) {
+      if (prop === 'subscribe') {
+        return function <T extends BusEvent>(typeFilter: BusEventType<T>, handler: BusEventHandler<T>): Unsubscribable {
+          reportIfLegacy(typeFilter?.type);
+          return target.subscribe(typeFilter, handler);
+        };
+      }
+      if (prop === 'getStream') {
+        return function <T extends BusEvent>(eventType: BusEventType<T>): Observable<T> {
+          reportIfLegacy(eventType?.type);
+          return target.getStream(eventType);
+        };
+      }
+      const value = Reflect.get(target, prop, receiver);
+      return typeof value === 'function' ? value.bind(target) : value;
+    },
+  });
+}
+
 // Internal singleton instance
 let singletonInstance: EventBus;
 
 /**
- * Used during startup by Grafana to set the setAppEvents so it is available
- * via the {@link setAppEvents} to the rest of the application.
+ * Used during startup by Grafana to set the singleton event bus.
  *
  * @internal
  */
 export function setAppEvents(instance: EventBus) {
-  singletonInstance = instance;
+  singletonInstance = wrapBus(instance);
 }
 
 /**

--- a/packages/grafana-runtime/src/services/appEvents.ts
+++ b/packages/grafana-runtime/src/services/appEvents.ts
@@ -13,7 +13,7 @@ import {
   type TimeRange,
 } from '@grafana/data';
 
-import * as legacyApiUsage from '../analytics/legacyDashboardApiUsage';
+import { reportLegacyDashboardApiUsage } from '../analytics/legacyDashboardApiUsage';
 
 /**
  * Called when a dashboard is refreshed
@@ -51,23 +51,23 @@ export class CopyPanelEvent extends BusEventWithPayload<PanelModel> {
   static type = 'copy-panel';
 }
 
-const LEGACY_EVENT_API_NAMES: Record<string, string> = {
-  [RefreshEvent.type]: 'RefreshEvent.subscribe',
-  [TimeRangeUpdatedEvent.type]: 'TimeRangeUpdatedEvent.subscribe',
-  [CopyPanelEvent.type]: 'CopyPanelEvent.subscribe',
+const LEGACY_EVENT_TYPES: Record<string, string> = {
+  [RefreshEvent.type]: 'RefreshEvent',
+  [TimeRangeUpdatedEvent.type]: 'TimeRangeUpdatedEvent',
+  [CopyPanelEvent.type]: 'CopyPanelEvent',
 };
 
-function reportIfLegacy(staticType: string | undefined): void {
+function reportIfLegacy(staticType: string | undefined, method: 'subscribe' | 'getStream'): void {
   if (!staticType) {
     return;
   }
-  const apiName = LEGACY_EVENT_API_NAMES[staticType];
-  if (!apiName) {
+  const eventName = LEGACY_EVENT_TYPES[staticType];
+  if (!eventName) {
     return;
   }
-  legacyApiUsage.reportLegacyDashboardApiUsage({
+  reportLegacyDashboardApiUsage({
     pluginId: resolvePluginIdFromStack(new Error().stack),
-    apiName,
+    apiName: `${eventName}.${method}`,
     extra: { eventType: staticType },
   });
 }
@@ -77,13 +77,13 @@ function wrapBus(bus: EventBus): EventBus {
     get(target, prop, receiver) {
       if (prop === 'subscribe') {
         return function <T extends BusEvent>(typeFilter: BusEventType<T>, handler: BusEventHandler<T>): Unsubscribable {
-          reportIfLegacy(typeFilter?.type);
+          reportIfLegacy(typeFilter?.type, 'subscribe');
           return target.subscribe(typeFilter, handler);
         };
       }
       if (prop === 'getStream') {
         return function <T extends BusEvent>(eventType: BusEventType<T>): Observable<T> {
-          reportIfLegacy(eventType?.type);
+          reportIfLegacy(eventType?.type, 'getStream');
           return target.getStream(eventType);
         };
       }

--- a/public/app/features/dashboard/services/DashboardSrv.test.ts
+++ b/public/app/features/dashboard/services/DashboardSrv.test.ts
@@ -1,0 +1,51 @@
+import { resolvePluginIdFromStack, setLegacyApiReporter } from '@grafana/data';
+import { reportLegacyDashboardApiUsage } from '@grafana/runtime';
+
+import { type DashboardModel } from '../state/DashboardModel';
+
+import { DashboardSrv } from './DashboardSrv';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  reportLegacyDashboardApiUsage: jest.fn(),
+}));
+jest.mock('@grafana/data', () => ({
+  ...jest.requireActual('@grafana/data'),
+  resolvePluginIdFromStack: jest.fn(),
+}));
+
+const reportMock = reportLegacyDashboardApiUsage as jest.Mock;
+const resolveMock = resolvePluginIdFromStack as jest.Mock;
+
+describe('DashboardSrv.getCurrent legacy telemetry', () => {
+  beforeEach(() => {
+    reportMock.mockClear();
+    resolveMock.mockReset();
+    setLegacyApiReporter(jest.fn()); // silence the Task 5 bridge wiring
+  });
+
+  it('reports when the caller resolves to a plugin', () => {
+    resolveMock.mockReturnValue('my-plugin');
+    const srv = new DashboardSrv();
+    srv.setCurrent({} as unknown as DashboardModel);
+    srv.getCurrent();
+    expect(reportMock).toHaveBeenCalledWith(
+      expect.objectContaining({ pluginId: 'my-plugin', apiName: 'DashboardSrv.getCurrent' })
+    );
+  });
+
+  it('does NOT report when the caller is internal (resolver returns "unknown")', () => {
+    resolveMock.mockReturnValue('unknown');
+    const srv = new DashboardSrv();
+    srv.setCurrent({} as unknown as DashboardModel);
+    srv.getCurrent();
+    expect(reportMock).not.toHaveBeenCalled();
+  });
+
+  it('does NOT report when getCurrent returns nothing', () => {
+    resolveMock.mockReturnValue('my-plugin');
+    const srv = new DashboardSrv();
+    srv.getCurrent(); // no setCurrent first
+    expect(reportMock).not.toHaveBeenCalled();
+  });
+});

--- a/public/app/features/dashboard/services/DashboardSrv.test.ts
+++ b/public/app/features/dashboard/services/DashboardSrv.test.ts
@@ -48,4 +48,14 @@ describe('DashboardSrv.getCurrent legacy telemetry', () => {
     srv.getCurrent(); // no setCurrent first
     expect(reportMock).not.toHaveBeenCalled();
   });
+
+  it('reports only once per DashboardSrv instance even on repeated calls', () => {
+    resolveMock.mockReturnValue('my-plugin');
+    const srv = new DashboardSrv();
+    srv.setCurrent({} as unknown as DashboardModel);
+    srv.getCurrent();
+    srv.getCurrent();
+    srv.getCurrent();
+    expect(reportMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/public/app/features/dashboard/services/DashboardSrv.test.ts
+++ b/public/app/features/dashboard/services/DashboardSrv.test.ts
@@ -1,4 +1,4 @@
-import { resolvePluginIdFromStack, setLegacyApiReporter } from '@grafana/data';
+import { resolvePluginIdFromStack } from '@grafana/data';
 import { reportLegacyDashboardApiUsage } from '@grafana/runtime';
 
 import { type DashboardModel } from '../state/DashboardModel';
@@ -21,7 +21,6 @@ describe('DashboardSrv.getCurrent legacy telemetry', () => {
   beforeEach(() => {
     reportMock.mockClear();
     resolveMock.mockReset();
-    setLegacyApiReporter(jest.fn()); // silence the Task 5 bridge wiring
   });
 
   it('reports when the caller resolves to a plugin', () => {

--- a/public/app/features/dashboard/services/DashboardSrv.ts
+++ b/public/app/features/dashboard/services/DashboardSrv.ts
@@ -1,5 +1,6 @@
+import { resolvePluginIdFromStack } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { type BackendSrvRequest } from '@grafana/runtime';
+import { type BackendSrvRequest, reportLegacyDashboardApiUsage } from '@grafana/runtime';
 import { type Dashboard } from '@grafana/schema';
 import { appEvents } from 'app/core/app_events';
 import { getDashboardAPI } from 'app/features/dashboard/api/dashboard_api';
@@ -39,6 +40,12 @@ export class DashboardSrv {
   }
 
   getCurrent(): DashboardModel | undefined {
+    if (this.dashboard) {
+      const pluginId = resolvePluginIdFromStack(new Error().stack);
+      if (pluginId !== 'unknown') {
+        reportLegacyDashboardApiUsage({ pluginId, apiName: 'DashboardSrv.getCurrent' });
+      }
+    }
     return this.dashboard;
   }
 

--- a/public/app/features/dashboard/services/DashboardSrv.ts
+++ b/public/app/features/dashboard/services/DashboardSrv.ts
@@ -26,6 +26,7 @@ export interface SaveDashboardOptions {
 
 export class DashboardSrv {
   dashboard?: DashboardModel;
+  private hasReportedLegacyGetCurrentUsage = false;
 
   constructor() {
     appEvents.subscribe(RemovePanelEvent, (e) => this.onRemovePanel(e.payload));
@@ -40,10 +41,11 @@ export class DashboardSrv {
   }
 
   getCurrent(): DashboardModel | undefined {
-    if (this.dashboard) {
+    if (this.dashboard && !this.hasReportedLegacyGetCurrentUsage) {
       const pluginId = resolvePluginIdFromStack(new Error().stack);
       if (pluginId !== 'unknown') {
         reportLegacyDashboardApiUsage({ pluginId, apiName: 'DashboardSrv.getCurrent' });
+        this.hasReportedLegacyGetCurrentUsage = true;
       }
     }
     return this.dashboard;

--- a/public/app/features/dashboard/state/PanelModel.test.ts
+++ b/public/app/features/dashboard/state/PanelModel.test.ts
@@ -695,6 +695,18 @@ describe('PanelModel legacy API telemetry — migration invocation', () => {
 
     expect(reportMock).not.toHaveBeenCalledWith(expect.objectContaining({ apiName: 'PanelMigrationHandler.invoke' }));
   });
+
+  it('does not report PanelMigrationHandler.invoke when plugin version is already current', async () => {
+    const onPanelMigration = jest.fn().mockReturnValue({});
+    const plugin = getPanelPlugin({ id: 'legacy-panel' }).setMigrationHandler(onPanelMigration);
+    // pluginVersion equals plugin.meta.info.version so the migration guard skips both the handler and the report.
+    const panel = new PanelModel({ type: 'legacy-panel', pluginVersion: '1' });
+
+    await panel.pluginLoaded(plugin);
+
+    expect(onPanelMigration).not.toHaveBeenCalled();
+    expect(reportMock).not.toHaveBeenCalledWith(expect.objectContaining({ apiName: 'PanelMigrationHandler.invoke' }));
+  });
 });
 
 const variablesMock = [

--- a/public/app/features/dashboard/state/PanelModel.test.ts
+++ b/public/app/features/dashboard/state/PanelModel.test.ts
@@ -709,6 +709,27 @@ describe('PanelModel legacy API telemetry — migration invocation', () => {
   });
 });
 
+describe('PanelModel legacy API telemetry — changePlugin', () => {
+  beforeEach(() => {
+    reportMock.mockClear();
+    setLegacyApiReporter(jest.fn());
+  });
+
+  it('reports PanelModel.changePlugin.invoke when changePlugin runs', async () => {
+    const oldPlugin = getPanelPlugin({ id: 'old' });
+    const newPlugin = getPanelPlugin({ id: 'new' });
+    const panel = new PanelModel({ type: 'old' });
+    await panel.pluginLoaded(oldPlugin);
+    reportMock.mockClear();
+
+    panel.changePlugin(newPlugin);
+
+    expect(reportMock).toHaveBeenCalledWith(
+      expect.objectContaining({ pluginId: 'new', apiName: 'PanelModel.changePlugin.invoke' })
+    );
+  });
+});
+
 const variablesMock = [
   queryBuilder().withId('test1').withName('test1').withCurrent('val1').build(),
   queryBuilder().withId('test2').withName('test2').withCurrent('val2').build(),

--- a/public/app/features/dashboard/state/PanelModel.test.ts
+++ b/public/app/features/dashboard/state/PanelModel.test.ts
@@ -705,26 +705,6 @@ describe('PanelModel legacy API telemetry — migration invocation', () => {
   });
 });
 
-describe('PanelModel legacy API telemetry — changePlugin', () => {
-  beforeEach(() => {
-    reportMock.mockClear();
-  });
-
-  it('reports PanelModel.changePlugin.invoke when changePlugin runs', async () => {
-    const oldPlugin = getPanelPlugin({ id: 'old' });
-    const newPlugin = getPanelPlugin({ id: 'new' });
-    const panel = new PanelModel({ type: 'old' });
-    await panel.pluginLoaded(oldPlugin);
-    reportMock.mockClear();
-
-    panel.changePlugin(newPlugin);
-
-    expect(reportMock).toHaveBeenCalledWith(
-      expect.objectContaining({ pluginId: 'new', apiName: 'PanelModel.changePlugin.invoke' })
-    );
-  });
-});
-
 const variablesMock = [
   queryBuilder().withId('test1').withName('test1').withCurrent('val1').build(),
   queryBuilder().withId('test2').withName('test2').withCurrent('val2').build(),

--- a/public/app/features/dashboard/state/PanelModel.test.ts
+++ b/public/app/features/dashboard/state/PanelModel.test.ts
@@ -4,7 +4,6 @@ import {
   FieldConfigProperty,
   type PanelData,
   type PanelProps,
-  setLegacyApiReporter,
   standardEditorsRegistry,
   standardFieldConfigEditorRegistry,
   dateTime,
@@ -669,9 +668,6 @@ const reportMock = reportLegacyDashboardApiUsage as jest.Mock;
 describe('PanelModel legacy API telemetry — migration invocation', () => {
   beforeEach(() => {
     reportMock.mockClear();
-    // Prevent setMigrationHandler's bridge call (from @grafana/data) from reaching
-    // the real reportLegacyDashboardApiUsage (which does console.warn via dedup logic).
-    setLegacyApiReporter(jest.fn());
   });
 
   it('reports PanelMigrationHandler.invoke when pluginLoaded runs onPanelMigration', async () => {
@@ -712,7 +708,6 @@ describe('PanelModel legacy API telemetry — migration invocation', () => {
 describe('PanelModel legacy API telemetry — changePlugin', () => {
   beforeEach(() => {
     reportMock.mockClear();
-    setLegacyApiReporter(jest.fn());
   });
 
   it('reports PanelModel.changePlugin.invoke when changePlugin runs', async () => {

--- a/public/app/features/dashboard/state/PanelModel.test.ts
+++ b/public/app/features/dashboard/state/PanelModel.test.ts
@@ -4,6 +4,7 @@ import {
   FieldConfigProperty,
   type PanelData,
   type PanelProps,
+  setLegacyApiReporter,
   standardEditorsRegistry,
   standardFieldConfigEditorRegistry,
   dateTime,
@@ -12,8 +13,13 @@ import {
   type PanelTypeChangedHandler,
 } from '@grafana/data';
 import { getPanelPlugin, mockStandardFieldConfigOptions } from '@grafana/data/test';
-import { setTemplateSrv } from '@grafana/runtime';
+import { reportLegacyDashboardApiUsage, setTemplateSrv } from '@grafana/runtime';
 import { queryBuilder } from 'app/features/variables/shared/testing/builders';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  reportLegacyDashboardApiUsage: jest.fn(),
+}));
 
 import { type PanelQueryRunner } from '../../query/state/PanelQueryRunner';
 import { TemplateSrv } from '../../templating/template_srv';
@@ -655,6 +661,39 @@ describe('PanelModel', () => {
         expect(model.getQueryRunner).toBeCalled();
       });
     });
+  });
+});
+
+const reportMock = reportLegacyDashboardApiUsage as jest.Mock;
+
+describe('PanelModel legacy API telemetry — migration invocation', () => {
+  beforeEach(() => {
+    reportMock.mockClear();
+    // Prevent setMigrationHandler's bridge call (from @grafana/data) from reaching
+    // the real reportLegacyDashboardApiUsage (which does console.warn via dedup logic).
+    setLegacyApiReporter(jest.fn());
+  });
+
+  it('reports PanelMigrationHandler.invoke when pluginLoaded runs onPanelMigration', async () => {
+    const onPanelMigration = jest.fn().mockReturnValue({});
+    const plugin = getPanelPlugin({ id: 'legacy-panel' }).setMigrationHandler(onPanelMigration);
+    const panel = new PanelModel({ type: 'legacy-panel', pluginVersion: '0.0.1' });
+
+    await panel.pluginLoaded(plugin);
+
+    expect(onPanelMigration).toHaveBeenCalled();
+    expect(reportMock).toHaveBeenCalledWith(
+      expect.objectContaining({ pluginId: 'legacy-panel', apiName: 'PanelMigrationHandler.invoke' })
+    );
+  });
+
+  it('does not report PanelMigrationHandler.invoke when the plugin has no migration handler', async () => {
+    const plugin = getPanelPlugin({ id: 'modern-panel' });
+    const panel = new PanelModel({ type: 'modern-panel' });
+
+    await panel.pluginLoaded(plugin);
+
+    expect(reportMock).not.toHaveBeenCalledWith(expect.objectContaining({ apiName: 'PanelMigrationHandler.invoke' }));
   });
 });
 

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -511,6 +511,11 @@ export class PanelModel implements DataConfigSource, IPanelModel {
   }
 
   changePlugin(newPlugin: PanelPlugin) {
+    reportLegacyDashboardApiUsage({
+      pluginId: newPlugin.meta.id,
+      apiName: 'PanelModel.changePlugin.invoke',
+      extra: { fromType: this.type },
+    });
     const pluginId = newPlugin.meta.id;
     const oldOptions = this.getOptionsToRemember();
     const prevFieldConfig = this.fieldConfig;

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -21,7 +21,7 @@ import {
   restoreCustomOverrideRules,
   getNextRefId,
 } from '@grafana/data';
-import { getTemplateSrv, RefreshEvent } from '@grafana/runtime';
+import { getTemplateSrv, RefreshEvent, reportLegacyDashboardApiUsage } from '@grafana/runtime';
 import { type LibraryPanel, type LibraryPanelRef } from '@grafana/schema';
 import config from 'app/core/config';
 import { safeStringifyValue } from 'app/core/utils/explore';
@@ -460,6 +460,11 @@ export class PanelModel implements DataConfigSource, IPanelModel {
 
     if (plugin.onPanelMigration) {
       if (version !== this.pluginVersion || plugin.shouldMigrate?.(this)) {
+        reportLegacyDashboardApiUsage({
+          pluginId: this.type,
+          apiName: 'PanelMigrationHandler.invoke',
+          extra: { fromVersion: this.pluginVersion, toVersion: version },
+        });
         const newPanelOptions = plugin.onPanelMigration(this);
         this.options = await newPanelOptions;
         this.pluginVersion = version;

--- a/public/app/features/dashboard/state/PanelModel.ts
+++ b/public/app/features/dashboard/state/PanelModel.ts
@@ -511,11 +511,6 @@ export class PanelModel implements DataConfigSource, IPanelModel {
   }
 
   changePlugin(newPlugin: PanelPlugin) {
-    reportLegacyDashboardApiUsage({
-      pluginId: newPlugin.meta.id,
-      apiName: 'PanelModel.changePlugin.invoke',
-      extra: { fromType: this.type },
-    });
     const pluginId = newPlugin.meta.id;
     const oldOptions = this.getOptionsToRemember();
     const prevFieldConfig = this.fieldConfig;


### PR DESCRIPTION
## Coverage shipped — 8 legacy API surfaces instrumented

| `apiName` | Where it fires |
| --- | --- |
| `PanelMigrationHandler.register` | `PanelPlugin.setMigrationHandler` registration (legacy-only marker) |
| `PanelMigrationHandler.invoke` | `PanelModel.pluginLoaded` legacy path (alerting / library / panel editor) |
| `PanelTypeChangedHandler.invoke` | Scenes `angularMigration.ts` deserialization (only live legacy hook) |
| `PanelModel.changePlugin.invoke` | Legacy error-recovery fallback |
| `DashboardSrv.getCurrent` | Filtered to plugin callers via stack trace |
| `RefreshEvent.subscribe` / `.getStream` | Proxied app-events bus |
| `TimeRangeUpdatedEvent.subscribe` / `.getStream` | Proxied app-events bus |
| `CopyPanelEvent.subscribe` / `.getStream` | Proxied app-events bus |
