### PR TITLE
IAM: gate service account resource permission mapper behind feature flag

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1111,6 +1111,11 @@ export interface FeatureToggles {
   */
   kubernetesAuthzDatasourceResourcePermissions?: boolean;
   /**
+  * Enables service account resource permissions via the K8s IAM resource permission APIs
+  * @default false
+  */
+  kubernetesAuthzServiceAccountResourcePermissions?: boolean;
+  /**
   * Enables recently viewed dashboards section in the browsing dashboard page
   * @default false
   */

--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -372,6 +372,7 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *ge
 	enableServiceAccountTokensApi := client.Boolean(ctx, featuremgmt.FlagKubernetesServiceAccountTokensApi, false, openfeature.TransactionContext(ctx))
 	enableExternalGroupMappingsApi := client.Boolean(ctx, featuremgmt.FlagKubernetesExternalGroupMappingsApi, false, openfeature.TransactionContext(ctx))
 	enableSsoSettingsApi := client.Boolean(ctx, featuremgmt.FlagKubernetesSsoSettingsApi, false, openfeature.TransactionContext(ctx))
+	enableSaResourcePermissions := client.Boolean(ctx, featuremgmt.FlagKubernetesAuthzServiceAccountResourcePermissions, false, openfeature.TransactionContext(ctx))
 
 	// teams + users must have shorter names because they are often used as part of another name
 	opts.StorageOptsRegister(iamv0.TeamResourceInfo.GroupResource(), apistore.StorageOptions{
@@ -446,6 +447,19 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *ge
 
 	//nolint:staticcheck // not yet migrated to OpenFeature
 	if b.features.IsEnabledGlobally(featuremgmt.FlagKubernetesAuthzResourcePermissionApis) {
+		if enableSaResourcePermissions {
+			// BasicRole is excluded: built-in roles already cover all service accounts globally,
+			// so granting a ResourcePermission to a BasicRole on a specific SA is not permitted.
+			b.mappers.RegisterMapper(
+				schema.GroupResource{Group: "iam.grafana.app", Resource: "serviceaccounts"},
+				resourcepermission.NewMapperWithAttribute("serviceaccounts", []string{"Edit", "Admin"}, resourcepermission.ScopeAttributeID,
+					[]iamv0.ResourcePermissionSpecPermissionKind{
+						iamv0.ResourcePermissionSpecPermissionKindUser,
+						iamv0.ResourcePermissionSpecPermissionKindServiceAccount,
+						iamv0.ResourcePermissionSpecPermissionKindTeam,
+					}), nil,
+			)
+		}
 		if err := b.UpdateResourcePermissionsAPIGroup(apiGroupInfo, opts, storage, enableZanzanaSync); err != nil {
 			return err
 		}

--- a/pkg/registry/apis/iam/resourcepermission/storage_backend.go
+++ b/pkg/registry/apis/iam/resourcepermission/storage_backend.go
@@ -49,17 +49,6 @@ func ProvideStorageBackend(dbProvider legacysql.LegacyDatabaseProvider, mappers 
 		schema.GroupResource{Group: "iam.grafana.app", Resource: "users"},
 		NewIDScopedMapper("users", defaultLevels), nil,
 	)
-	// BasicRole is excluded: built-in roles already cover all service accounts globally,
-	// so granting a ResourcePermission to a BasicRole on a specific SA is not permitted.
-	mappers.RegisterMapper(
-		schema.GroupResource{Group: "iam.grafana.app", Resource: "serviceaccounts"},
-		NewMapperWithAttribute("serviceaccounts", []string{"Edit", "Admin"}, ScopeAttributeID,
-			[]v0alpha1.ResourcePermissionSpecPermissionKind{
-				v0alpha1.ResourcePermissionSpecPermissionKindUser,
-				v0alpha1.ResourcePermissionSpecPermissionKindServiceAccount,
-				v0alpha1.ResourcePermissionSpecPermissionKindTeam,
-			}), nil,
-	)
 	return &ResourcePermSqlBackend{
 		dbProvider:    dbProvider,
 		identityStore: store,

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -1946,6 +1946,15 @@ var (
 			Generate:     Generate{LegacyGo: true, LegacyFrontend: true},
 		},
 		{
+			Name:         "kubernetesAuthzServiceAccountResourcePermissions",
+			Description:  "Enables service account resource permissions via the K8s IAM resource permission APIs",
+			Stage:        FeatureStageExperimental,
+			Owner:        identityAccessTeam,
+			HideFromDocs: true,
+			Expression:   "false",
+			Generate:     Generate{LegacyGo: true, LegacyFrontend: true},
+		},
+		{
 			Name:        "recentlyViewedDashboards",
 			Description: "Enables recently viewed dashboards section in the browsing dashboard page",
 			Stage:       FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -226,6 +226,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-01-12,kubernetesAuthzRoleBindingsApi,experimental,@grafana/identity-access-team,false,false,false
 2026-03-16,kubernetesAuthzRolesAndRoleBindingsRedirect,experimental,@grafana/identity-access-team,false,false,false
 2026-03-17,kubernetesAuthzDatasourceResourcePermissions,experimental,@grafana/identity-access-team,false,false,false
+2026-05-13,kubernetesAuthzServiceAccountResourcePermissions,experimental,@grafana/identity-access-team,false,false,false
 2025-12-10,recentlyViewedDashboards,experimental,@grafana/grafana-frontend-navigation,false,false,true
 2026-01-13,experimentRecentlyViewedDashboards,experimental,@grafana/grafana-frontend-navigation,false,false,true
 2026-02-24,createdByMeSearchFilter,experimental,@grafana/grafana-frontend-navigation,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -638,6 +638,10 @@ const (
 	// Enables datasource resource permissions via the K8s IAM resource permission APIs
 	FlagKubernetesAuthzDatasourceResourcePermissions = "kubernetesAuthzDatasourceResourcePermissions"
 
+	// FlagKubernetesAuthzServiceAccountResourcePermissions
+	// Enables service account resource permissions via the K8s IAM resource permission APIs
+	FlagKubernetesAuthzServiceAccountResourcePermissions = "kubernetesAuthzServiceAccountResourcePermissions"
+
 	// FlagAlertEnrichment
 	// Enable configuration of alert enrichments in Grafana Cloud.
 	FlagAlertEnrichment = "alertEnrichment"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -3484,6 +3484,20 @@
     },
     {
       "metadata": {
+        "name": "kubernetesAuthzServiceAccountResourcePermissions",
+        "resourceVersion": "1778678599530",
+        "creationTimestamp": "2026-05-13T13:23:19Z"
+      },
+      "spec": {
+        "description": "Enables service account resource permissions via the K8s IAM resource permission APIs",
+        "stage": "experimental",
+        "codeowner": "@grafana/identity-access-team",
+        "hideFromDocs": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "kubernetesAuthzTeamLBACRuleApi",
         "resourceVersion": "1771434338561",
         "creationTimestamp": "2026-02-18T17:05:38Z"


### PR DESCRIPTION
## What is this feature?

Adds a new feature flag `kubernetesAuthzServiceAccountResourcePermissions` that gates the registration of the service account mapper in the IAM resource permissions system.

## Why do we need this feature?

The SA mapper was previously registered unconditionally, which meant SA resource permissions were always available regardless of readiness. This PR makes it opt-in behind a flag, consistent with how other resource permission mappers are controlled.

## Who is this feature for?

Internal — part of the SA ResourcePermission K8s API Support epic.

## Which issue(s) does this PR fix?

Part of grafana/identity-access-team#2000

## Special notes for your reviewer

- Flag is `Experimental`, off by default (`Expression: "false"`)
- Registration happens inside `UpdateAPIGroupInfo` using the OpenFeature client (`client.Boolean()`), consistent with all other recently added flags in that function
- The mapper is only active when both `kubernetesAuthzResourcePermissionApis` AND `kubernetesAuthzServiceAccountResourcePermissions` are enabled

Please check that:
- [x] It is behind a feature toggle.