### PR TITLE
Alerting: Expose `alerting.syncExternalAlertmanager` feature flag to frontend

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1676,4 +1676,9 @@ export interface FeatureToggles {
   * @default false
   */
   ['alerting.notificationsAPIV1Beta1']?: boolean;
+  /**
+  * Automatically syncs external Alertmanager datasource configuration as ExtraConfiguration in Grafana
+  * @default false
+  */
+  ['alerting.syncExternalAlertmanager']?: boolean;
 }

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
@@ -43,6 +43,7 @@ declare module "@openfeature/core" {
     | "reporting.anyPageReporting"
     | "assistant.frontend.tools.dashboardTemplates"
     | "grafana.unifiedHomepage"
+    | "alerting.syncExternalAlertmanager"
     | "grafana.enableScopesFirstMode";
   export type NumberFlagKey = never;
   export type StringFlagKey = never;

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -13,6 +13,8 @@ import {
 
 // Flag key constants for programmatic access
 export const FlagKeys = {
+  /** Automatically syncs external Alertmanager datasource configuration as ExtraConfiguration in Grafana */
+  AlertingSyncExternalAlertmanager: "alerting.syncExternalAlertmanager",
   /** Enables new analytics framework */
   AnalyticsFramework: "analyticsFramework",
   /** Enables the template dashboard assistant */
@@ -82,6 +84,17 @@ export const FlagKeys = {
   /** Enables the 'Customize with Assistant' button on suggested dashboard cards */
   SuggestedDashboardsAssistantButton: "suggestedDashboardsAssistantButton",
 } as const;
+
+/**
+ * Automatically syncs external Alertmanager datasource configuration as ExtraConfiguration in Grafana
+ *
+ * **Details:**
+ * - flag key: `alerting.syncExternalAlertmanager`
+ * - default value: `false`
+ */
+export const useFlagAlertingSyncExternalAlertmanager = (options?: ReactFlagEvaluationOptions): boolean => {
+  return useFlag("alerting.syncExternalAlertmanager", false, options).value;
+};
 
 /**
  * Enables new analytics framework

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -3117,7 +3117,7 @@ var (
 			Name:            "alerting.syncExternalAlertmanager",
 			Description:     "Automatically syncs external Alertmanager datasource configuration as ExtraConfiguration in Grafana",
 			Stage:           FeatureStageExperimental,
-			Generate:        Generate{Go: true},
+			Generate:        Generate{Go: true, React: true, LegacyFrontend: true},
 			Owner:           grafanaAlertingSquad,
 			HideFromDocs:    true,
 			RequiresRestart: true,


### PR DESCRIPTION
**What is this feature?**

This PR adds `React: true` and `LegacyFrontend: true` to the `Generate` config of the `alerting.syncExternalAlertmanager` feature toggle (added in #119910). This regenerates `featureToggles.gen.ts` and the OpenFeature manifest so frontend code can read the flag in a type-safe way (`config.featureToggles['alerting.syncExternalAlertmanager']`).

**Why do we need this feature?**

We need this feature flag available to the frontend to gate the UI changes related to the Mimir/Cortex Alertmanager auto-sync UI

**Who is this feature for?**

Alerting users

**Which issue(s) does this PR fix?**:

Relates to https://github.com/grafana/alerting-squad/issues/1608

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
