### PR TITLE
Logs Panel: Add support to copy a log entry with fields/labels as JSON

### DIFF
--- a/public/app/features/logs/components/panel/LogLine.test.tsx
+++ b/public/app/features/logs/components/panel/LogLine.test.tsx
@@ -297,9 +297,9 @@ describe.each(fontSizes)('LogLine', (fontSize: LogListFontSize) => {
           <LogLine {...defaultProps} />
         </LogListContextProvider>
       );
-      expect(screen.queryByText('Copy log line')).not.toBeInTheDocument();
+      expect(screen.queryByRole('menuitem', { name: /Copy log line message/i })).not.toBeInTheDocument();
       await userEvent.click(screen.getByLabelText('Log menu'));
-      expect(screen.getByText('Copy log line')).toBeInTheDocument();
+      expect(screen.getByRole('menuitem', { name: /Copy log line message/i })).toBeInTheDocument();
     });
 
     test('The menu can be clicked', async () => {
@@ -308,9 +308,9 @@ describe.each(fontSizes)('LogLine', (fontSize: LogListFontSize) => {
           <LogLine {...defaultProps} />
         </LogListContextProvider>
       );
-      expect(screen.queryByText('Copy log line')).not.toBeInTheDocument();
+      expect(screen.queryByRole('menuitem', { name: /Copy log line message/i })).not.toBeInTheDocument();
       await userEvent.click(screen.getByRole('button'));
-      expect(screen.getByText('Copy log line')).toBeInTheDocument();
+      expect(screen.getByRole('menuitem', { name: /Copy log line message/i })).toBeInTheDocument();
     });
   });
 

--- a/public/app/features/logs/components/panel/LogLineDetails.test.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.test.tsx
@@ -21,6 +21,7 @@ import { createLokiDatasource } from 'app/plugins/datasource/loki/mocks/datasour
 import { createTempoDatasource } from 'app/plugins/datasource/tempo/test/mocks';
 
 import { DATAPLANE_LABEL_TYPES_NAME, DATAPLANE_LABELS_NAME } from '../../logsFrame';
+import * as logsUtils from '../../utils';
 import { getFieldSelectorWidth } from '../fieldSelector/fieldSelectorUtils';
 import { LOG_LINE_BODY_FIELD_NAME } from '../fieldSelector/logFields';
 import { createLogLine } from '../mocks/logRow';
@@ -154,6 +155,27 @@ describe('LogLineDetails', () => {
           },
         }) as unknown as DataSourceSrv
     );
+  });
+
+  test('Copy log as JSON from header copies structured JSON from the log', async () => {
+    const copyTextSpy = jest.spyOn(logsUtils, 'copyText').mockResolvedValue(undefined);
+
+    await setup(undefined, { labels: { svc: 'api' } });
+
+    await userEvent.click(screen.getByRole('button', { name: /Copy to clipboard/i }));
+    await userEvent.click(screen.getByRole('menuitem', { name: /JSON/i }));
+
+    await waitFor(() => {
+      expect(copyTextSpy).toHaveBeenCalled();
+      const text = copyTextSpy.mock.calls[0][0];
+      const parsed = JSON.parse(text);
+      expect(parsed).toMatchObject({
+        line: expect.any(String),
+        labels: expect.objectContaining({ svc: 'api' }),
+        timeEpochMs: expect.any(Number),
+      });
+    });
+    copyTextSpy.mockRestore();
   });
 
   describe('Toggleable filters', () => {

--- a/public/app/features/logs/components/panel/LogLineDetailsHeader.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsHeader.tsx
@@ -12,7 +12,7 @@ import { LOG_LINE_BODY_FIELD_NAME } from '../fieldSelector/logFields';
 import { useLogDetailsContext } from './LogDetailsContext';
 import { type LogLineDetailsMode } from './LogLineDetails';
 import { useLogIsPinned, useLogListContext } from './LogListContext';
-import { buildLogLineFullJsonString } from './logLineFullJson';
+import { getLogAsJSON } from './export';
 import { type LogListModel } from './processing';
 
 interface Props {
@@ -82,7 +82,7 @@ export const LogLineDetailsHeader = ({
   }, [log.entry, reportInteractionWrapper]);
 
   const copyLogLineAsJson = useCallback(async () => {
-    copyText(await buildLogLineFullJsonString(log), containerRef);
+    copyText(await getLogAsJSON(log), containerRef);
     reportInteractionWrapper('logs_log_line_details_header_copy_json_clicked');
   }, [log, reportInteractionWrapper]);
 
@@ -185,20 +185,17 @@ export const LogLineDetailsHeader = ({
   }, [log, toggleDetails]);
 
   const copyMenu = useMemo(
-      () => (
-        <Menu>
-          <Menu.Item
-            label={t('logs.log-line-details.copy-log-line', 'Copy log line message')}
-            onClick={copyLogLine}
-          />
-          <Menu.Item
-            label={t('logs.log-line-details.copy-log-line-json', 'Copy log contents as JSON')}
-            onClick={copyLogLineAsJson}
-          />
-        </Menu>
-      ),
-      [copyLogLine, copyLogLineAsJson]
-    );
+    () => (
+      <Menu>
+        <Menu.Item label={t('logs.log-line-details.copy-log-line', 'Copy log line message')} onClick={copyLogLine} />
+        <Menu.Item
+          label={t('logs.log-line-details.copy-log-line-json', 'Copy log contents as JSON')}
+          onClick={copyLogLineAsJson}
+        />
+      </Menu>
+    ),
+    [copyLogLine, copyLogLineAsJson]
+  );
 
   return (
     <div className={styles.header} ref={containerRef}>

--- a/public/app/features/logs/components/panel/LogLineDetailsHeader.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsHeader.tsx
@@ -1,10 +1,10 @@
 import { css } from '@emotion/css';
-import { useCallback, useMemo, type MouseEvent, useRef, type ChangeEvent } from 'react';
+import { useCallback, useMemo, useRef, type ChangeEvent, type MouseEvent } from 'react';
 
 import { colorManipulator, type GrafanaTheme2, type LogRowModel, store } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
-import { IconButton, Input, useStyles2 } from '@grafana/ui';
+import { Dropdown, IconButton, Input, Menu, useStyles2 } from '@grafana/ui';
 
 import { copyText, handleOpenLogsContextClick } from '../../utils';
 import { LOG_LINE_BODY_FIELD_NAME } from '../fieldSelector/logFields';
@@ -12,6 +12,7 @@ import { LOG_LINE_BODY_FIELD_NAME } from '../fieldSelector/logFields';
 import { useLogDetailsContext } from './LogDetailsContext';
 import { type LogLineDetailsMode } from './LogLineDetails';
 import { useLogIsPinned, useLogListContext } from './LogListContext';
+import { buildLogLineFullJsonString } from './logLineFullJson';
 import { type LogListModel } from './processing';
 
 interface Props {
@@ -79,6 +80,11 @@ export const LogLineDetailsHeader = ({
     copyText(log.entry, containerRef);
     reportInteractionWrapper('logs_log_line_details_header_copy_clicked');
   }, [log.entry, reportInteractionWrapper]);
+
+  const copyLogLineAsJson = useCallback(async () => {
+    copyText(await buildLogLineFullJsonString(log), containerRef);
+    reportInteractionWrapper('logs_log_line_details_header_copy_json_clicked');
+  }, [log, reportInteractionWrapper]);
 
   const copyLinkToLogLine = useCallback(() => {
     onPermalinkClick?.(log);
@@ -178,6 +184,22 @@ export const LogLineDetailsHeader = ({
     toggleDetails(log);
   }, [log, toggleDetails]);
 
+  const copyMenu = useMemo(
+      () => (
+        <Menu>
+          <Menu.Item
+            label={t('logs.log-line-details.copy-log-line', 'Copy log line message')}
+            onClick={copyLogLine}
+          />
+          <Menu.Item
+            label={t('logs.log-line-details.copy-log-line-json', 'Copy log contents as JSON')}
+            onClick={copyLogLineAsJson}
+          />
+        </Menu>
+      ),
+      [copyLogLine, copyLogLineAsJson]
+    );
+
   return (
     <div className={styles.header} ref={containerRef}>
       <Input
@@ -222,14 +244,15 @@ export const LogLineDetailsHeader = ({
             variant={logLineDisplayed ? 'primary' : undefined}
           />
         )}
-        <IconButton
-          tooltip={t('logs.log-line-details.copy-to-clipboard', 'Copy to clipboard')}
-          tooltipPlacement="top"
-          size="md"
-          name="copy"
-          onClick={copyLogLine}
-          tabIndex={0}
-        />
+        <Dropdown overlay={copyMenu} placement="auto-end">
+          <IconButton
+            tooltip={t('logs.log-line-details.copy-to-clipboard', 'Copy to clipboard')}
+            tooltipPlacement="top"
+            size="md"
+            name="copy"
+            tabIndex={0}
+          />
+        </Dropdown>
         {onPermalinkClick && log.rowId !== undefined && log.uid && (
           <IconButton
             tooltip={t('logs.log-line-details.copy-shortlink', 'Copy shortlink')}

--- a/public/app/features/logs/components/panel/LogLineMenu.test.tsx
+++ b/public/app/features/logs/components/panel/LogLineMenu.test.tsx
@@ -1,8 +1,10 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
 import { CoreApp, createTheme, LogsDedupStrategy, LogsSortOrder } from '@grafana/data';
+import { type DataSourceSrv, getDataSourceSrv } from '@grafana/runtime';
 
+import * as logsUtils from '../../utils';
 import { createLogLine } from '../mocks/logRow';
 
 import { LogDetailsContextProvider } from './LogDetailsContext';
@@ -26,6 +28,7 @@ jest.mock('@grafana/assistant', () => ({
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
   isAssistantAvailable: true,
+  getDataSourceSrv: jest.fn(),
 }));
 
 const theme = createTheme();
@@ -47,13 +50,16 @@ describe('LogLineMenu', () => {
   let log: LogListModel;
   beforeEach(() => {
     log = createLogLine({ labels: { place: 'luna' }, rowId: '1' });
+    jest.mocked(getDataSourceSrv).mockReturnValue({
+      get: jest.fn().mockResolvedValue({}),
+    } as unknown as DataSourceSrv);
   });
 
   test('Renders the component', async () => {
     render(<LogLineMenu log={log} styles={styles} />);
-    expect(screen.queryByText('Copy log line')).not.toBeInTheDocument();
+    expect(screen.queryByRole('menuitem', { name: /Copy log line message/i })).not.toBeInTheDocument();
     await userEvent.click(screen.getByLabelText('Log menu'));
-    expect(screen.getByText('Copy log line')).toBeInTheDocument();
+    expect(screen.getByRole('menuitem', { name: /Copy log line message/i })).toBeInTheDocument();
   });
 
   describe('Options', () => {
@@ -69,7 +75,32 @@ describe('LogLineMenu', () => {
       expect(onPermalinkClick).toHaveBeenCalledTimes(1);
     });
 
-    test('Allows to copy a permalink', async () => {
+    test('Copy log line as JSON copies structured JSON from the log', async () => {
+      const copyTextSpy = jest.spyOn(logsUtils, 'copyText').mockResolvedValue(undefined);
+
+      render(
+        <LogListContextProvider {...contextProps}>
+          <LogLineMenu log={log} styles={styles} />
+        </LogListContextProvider>
+      );
+      await userEvent.click(screen.getByLabelText('Log menu'));
+      const jsonMenuItem = screen.getAllByRole('menuitem').find((el) => /JSON/i.test(el.textContent ?? ''));
+      expect(jsonMenuItem).toBeTruthy();
+      await userEvent.click(jsonMenuItem!);
+
+      await waitFor(() => {
+        expect(copyTextSpy).toHaveBeenCalled();
+        const text = copyTextSpy.mock.calls[0][0] as string;
+        const parsed = JSON.parse(text);
+        expect(parsed).toMatchObject({
+          line: expect.any(String),
+          labels: expect.objectContaining({ place: 'luna' }),
+        });
+      });
+      copyTextSpy.mockRestore();
+    });
+
+    test('Renders custom log line menu items', async () => {
       const customOption1onClick = jest.fn();
       const logLineMenuCustomItems: LogLineMenuCustomItem[] = [
         {

--- a/public/app/features/logs/components/panel/LogLineMenu.tsx
+++ b/public/app/features/logs/components/panel/LogLineMenu.tsx
@@ -2,6 +2,7 @@ import { type MouseEvent, useCallback, useMemo, useRef } from 'react';
 
 import { type LogRowContextOptions, type LogRowModel } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { reportInteraction } from '@grafana/runtime';
 import { type DataQuery } from '@grafana/schema';
 import { Dropdown, IconButton, Menu } from '@grafana/ui';
 
@@ -10,6 +11,7 @@ import { copyText, handleOpenLogsContextClick } from '../../utils';
 import { useLogDetailsContext } from './LogDetailsContext';
 import { type LogLineStyles } from './LogLine';
 import { useLogIsPinned, useLogListContext } from './LogListContext';
+import { getLogAsJSON } from './export';
 import { type LogListModel } from './processing';
 
 export type GetRowContextQueryFn = (
@@ -53,7 +55,13 @@ export const LogLineMenu = ({ active, log, styles }: Props) => {
 
   const copyLogLine = useCallback(() => {
     copyText(log.entry, menuRef);
+    reportInteraction('logs_log_line_menu_header_copy_clicked');
   }, [log.entry]);
+
+  const copyLogLineAsJson = useCallback(async () => {
+    copyText(await getLogAsJSON(log), menuRef);
+    reportInteraction('logs_log_line_menu_header_copy_json_clicked');
+  }, [log]);
 
   const copyLinkToLogLine = useCallback(() => {
     onPermalinkClick?.(log);
@@ -108,7 +116,11 @@ export const LogLineMenu = ({ active, log, styles }: Props) => {
           <Menu.Item onClick={togglePinning} label={t('logs.log-line-menu.unpin-from-outline', 'Unpin log')} />
         )}
         {showFirstDivider && <Menu.Divider />}
-        <Menu.Item onClick={copyLogLine} label={t('logs.log-line-menu.copy-log', 'Copy log line')} />
+        <Menu.Item onClick={copyLogLine} label={t('logs.log-line-menu.copy-log-message', 'Copy log line message')} />
+        <Menu.Item
+          onClick={copyLogLineAsJson}
+          label={t('logs.log-line-menu.copy-log-contents', 'Copy log line contents as JSON')}
+        />
         {onPermalinkClick && log.rowId !== undefined && log.uid && (
           <Menu.Item onClick={copyLinkToLogLine} label={t('logs.log-line-menu.copy-link', 'Copy link to log line')} />
         )}

--- a/public/app/features/logs/components/panel/LogLineMenu.tsx
+++ b/public/app/features/logs/components/panel/LogLineMenu.tsx
@@ -148,6 +148,7 @@ export const LogLineMenu = ({ active, log, styles }: Props) => {
     [
       copyLinkToLogLine,
       copyLogLine,
+      copyLogLineAsJson,
       detailsDisplayed,
       enableLogDetails,
       isAssistantAvailable,

--- a/public/app/features/logs/components/panel/export.test.ts
+++ b/public/app/features/logs/components/panel/export.test.ts
@@ -1,0 +1,288 @@
+import { DataFrameType, FieldType, LogLevel, LogsSortOrder, type DataSourceApi, toDataFrame } from '@grafana/data';
+
+import { createLogLine } from '../mocks/logRow';
+
+import { buildLogLineFullJsonObject, formatGroupedLabelsForJson } from './export';
+
+function typedDs(getLabelDisplayTypeFromFrame: (key: string) => string | null): DataSourceApi {
+  return { getLabelDisplayTypeFromFrame } as unknown as DataSourceApi;
+}
+
+function untypedDs(): DataSourceApi {
+  return {} as DataSourceApi;
+}
+
+describe('formatGroupedLabelsForJson', () => {
+  it('returns a flat map when every label is in the unnamed category', () => {
+    const grouped = {
+      '': [
+        { key: 'z', value: 'last' },
+        { key: 'a', value: 'first' },
+      ],
+    };
+    expect(formatGroupedLabelsForJson(grouped)).toEqual({
+      a: 'first',
+      z: 'last',
+    });
+  });
+
+  it('returns nested objects per category when at least one label has a named type', () => {
+    const grouped = {
+      '': [{ key: 'lonely', value: 'x' }],
+      Indexed: [
+        { key: 'job', value: 'api' },
+        { key: 'instance', value: '1' },
+      ],
+      'Structured metadata': [{ key: 'trace_id', value: 'abc' }],
+    };
+    expect(formatGroupedLabelsForJson(grouped)).toEqual({
+      uncategorized: { lonely: 'x' },
+      Indexed: { instance: '1', job: 'api' },
+      'Structured metadata': { trace_id: 'abc' },
+    });
+  });
+
+  it('parses stringified JSON label values into objects', () => {
+    const grouped = {
+      '': [{ key: 'payload', value: '{"nested":true,"n":1}' }],
+    };
+    expect(formatGroupedLabelsForJson(grouped)).toEqual({
+      payload: { nested: true, n: expect.anything() },
+    });
+    expect((formatGroupedLabelsForJson(grouped) as { payload: { n: unknown } }).payload.n).toEqual(
+      expect.objectContaining({ value: '1' })
+    );
+  });
+});
+
+describe('buildLogLineFullJsonObject', () => {
+  const processOpts = {
+    escape: false,
+    order: LogsSortOrder.Descending,
+    timeZone: 'utc',
+    wrapLogMessage: true,
+  };
+
+  it('exports dataframe fields but omits labels when the row has no labels', () => {
+    const log = createLogLine(
+      {
+        labels: {},
+        entry: 'hello',
+        logLevel: LogLevel.info,
+        entryFieldIndex: 1,
+        dataFrame: toDataFrame({
+          refId: 'A',
+          fields: [
+            { name: 'Time', type: FieldType.time, values: [1000] },
+            { name: 'Line', type: FieldType.string, values: ['hello'] },
+            { name: 'labels', type: FieldType.other, values: [{}] },
+            { name: 'region', type: FieldType.string, values: ['eu-west-1'] },
+          ],
+        }),
+      },
+      processOpts
+    );
+
+    const json = buildLogLineFullJsonObject(log, untypedDs());
+
+    expect(json.labels).toBeUndefined();
+    expect(json.fields).toEqual({ region: 'eu-west-1' });
+    expect(json.line).toBe('hello');
+  });
+
+  it('groups labels by category when the datasource exposes label display types', () => {
+    const log = createLogLine(
+      {
+        labels: { alpha: '1', beta: '2' },
+        entry: 'msg',
+        logLevel: LogLevel.warn,
+        entryFieldIndex: 1,
+        dataFrame: toDataFrame({
+          refId: 'A',
+          fields: [
+            { name: 'Time', type: FieldType.time, values: [2000] },
+            { name: 'Line', type: FieldType.string, values: ['msg'] },
+            { name: 'labels', type: FieldType.other, values: [{ alpha: '1', beta: '2' }] },
+          ],
+        }),
+      },
+      processOpts
+    );
+
+    const ds = typedDs((key) => (key === 'alpha' ? 'Indexed labels' : 'Structured metadata'));
+
+    expect(buildLogLineFullJsonObject(log, ds).labels).toEqual({
+      'Indexed labels': { alpha: '1' },
+      'Structured metadata': { beta: '2' },
+    });
+  });
+
+  it('exports a flat labels object when every label type is empty (uncategorized)', () => {
+    const log = createLogLine(
+      {
+        labels: { service: 'checkout', env: 'prod' },
+        entry: 'msg',
+        logLevel: LogLevel.info,
+        entryFieldIndex: 1,
+        dataFrame: toDataFrame({
+          refId: 'A',
+          fields: [
+            { name: 'Time', type: FieldType.time, values: [3000] },
+            { name: 'Line', type: FieldType.string, values: ['msg'] },
+            {
+              name: 'labels',
+              type: FieldType.other,
+              values: [{ service: 'checkout', env: 'prod' }],
+            },
+          ],
+        }),
+      },
+      processOpts
+    );
+
+    const ds = typedDs(() => null);
+
+    expect(buildLogLineFullJsonObject(log, ds).labels).toEqual({
+      env: 'prod',
+      service: 'checkout',
+    });
+  });
+
+  it('prettifies stringified JSON in log line labels when types are flat', () => {
+    const raw = '{"k":"v"}';
+    const log = createLogLine(
+      {
+        labels: { meta: raw },
+        entry: 'line',
+        logLevel: LogLevel.debug,
+        entryFieldIndex: 1,
+        dataFrame: toDataFrame({
+          refId: 'A',
+          fields: [
+            { name: 'Time', type: FieldType.time, values: [4000] },
+            { name: 'Line', type: FieldType.string, values: ['line'] },
+            { name: 'labels', type: FieldType.other, values: [{ meta: raw }] },
+          ],
+        }),
+      },
+      processOpts
+    );
+
+    const labels = buildLogLineFullJsonObject(
+      log,
+      typedDs(() => null)
+    ).labels as Record<string, unknown>;
+    expect(labels.meta).toEqual({ k: 'v' });
+  });
+
+  it('prettifies a single field value when the field has one stringified JSON value', () => {
+    const log = createLogLine(
+      {
+        labels: {},
+        entry: 'ok',
+        logLevel: LogLevel.info,
+        entryFieldIndex: 1,
+        dataFrame: toDataFrame({
+          refId: 'A',
+          fields: [
+            { name: 'Time', type: FieldType.time, values: [5000] },
+            { name: 'Line', type: FieldType.string, values: ['ok'] },
+            { name: 'labels', type: FieldType.other, values: [{}] },
+            { name: 'ctx', type: FieldType.string, values: ['{"x":1}'] },
+          ],
+        }),
+      },
+      processOpts
+    );
+
+    expect(buildLogLineFullJsonObject(log, untypedDs()).fields).toEqual({
+      ctx: { x: expect.anything() },
+    });
+  });
+
+  it('exports fields with many values as a raw string array (no per-value JSON prettify)', () => {
+    const log = createLogLine(
+      {
+        labels: {},
+        entry: 'e',
+        logLevel: LogLevel.info,
+        entryFieldIndex: 1,
+        dataFrame: toDataFrame({
+          refId: 'A',
+          fields: [
+            { name: 'Time', type: FieldType.time, values: [1] },
+            { name: 'Line', type: FieldType.string, values: ['e'] },
+            { name: 'labels', type: FieldType.other, values: [{}] },
+          ],
+        }),
+      },
+      processOpts
+    );
+
+    const spy = jest
+      .spyOn(log, 'fields', 'get')
+      .mockReturnValue([{ keys: ['tags'], values: ['{"a":1}', '{"b":2}', 'plain'], fieldIndex: 10, links: [] }]);
+
+    expect(buildLogLineFullJsonObject(log, untypedDs()).fields).toEqual({
+      tags: ['{"a":1}', '{"b":2}', 'plain'],
+    });
+
+    spy.mockRestore();
+  });
+
+  it('omits dataframe fields for dataplane LogLines frames (fields come from labels / line only)', () => {
+    const log = createLogLine(
+      {
+        labels: { app: 'store' },
+        entry: 'buy',
+        logLevel: LogLevel.info,
+        entryFieldIndex: 1,
+        dataFrame: toDataFrame({
+          refId: 'A',
+          meta: { type: DataFrameType.LogLines },
+          fields: [
+            { name: 'timestamp', type: FieldType.time, values: [6000] },
+            { name: 'body', type: FieldType.string, values: ['buy'] },
+            { name: 'labels', type: FieldType.other, values: [{ app: 'store' }] },
+            { name: 'extra', type: FieldType.string, values: ['ignored-for-export'] },
+          ],
+        }),
+      },
+      processOpts
+    );
+
+    const out = buildLogLineFullJsonObject(
+      log,
+      typedDs(() => null)
+    );
+    expect(out.fields).toBeUndefined();
+    expect(out.labels).toEqual({ app: 'store' });
+  });
+
+  it('prettifies the log line when the row is detected as JSON', () => {
+    const entry = '{"message":"ping"}';
+    const log = createLogLine(
+      {
+        labels: {},
+        entry,
+        raw: entry,
+        logLevel: LogLevel.info,
+        entryFieldIndex: 1,
+        dataFrame: toDataFrame({
+          refId: 'A',
+          fields: [
+            { name: 'Time', type: FieldType.time, values: [7000] },
+            { name: 'Line', type: FieldType.string, values: [entry] },
+            { name: 'labels', type: FieldType.other, values: [{}] },
+          ],
+        }),
+      },
+      processOpts
+    );
+
+    void log.body;
+    expect(log.isJSON).toBe(true);
+    const line = buildLogLineFullJsonObject(log, untypedDs()).line as Record<string, unknown>;
+    expect(line.message).toBe('ping');
+  });
+});

--- a/public/app/features/logs/components/panel/export.ts
+++ b/public/app/features/logs/components/panel/export.ts
@@ -1,4 +1,5 @@
 import { groupBy } from 'lodash';
+import { parse } from 'lossless-json';
 
 import { DataFrameType, type DataSourceApi, hasLogsLabelTypesSupport, type Labels } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
@@ -17,10 +18,10 @@ function labelsObjectToSortedEntries(labels: Labels): LabelEntry[] {
     .map((key) => ({ key, value: labels[key] }));
 }
 
-function groupLabelsByCategory(log: LogListModel, ds: DataSourceApi): Record<string, LabelEntry[]> {
+function groupLabelsByCategory(log: LogListModel, ds: DataSourceApi): Record<string, LabelEntry[]> | null {
   const labelsWithLinks = labelsObjectToSortedEntries(log.labels);
   if (!labelsWithLinks.length) {
-    return {};
+    return null;
   }
   return groupBy(labelsWithLinks, (label) => {
     if (hasLogsLabelTypesSupport(ds)) {
@@ -34,24 +35,24 @@ function groupLabelsByCategory(log: LogListModel, ds: DataSourceApi): Record<str
  * When every label falls into the unnamed bucket (no datasource or no typed categories),
  * export a single flat map. Otherwise export one nested object per category.
  */
-export function formatGroupedLabelsForJson(groupedLabels: Record<string, LabelEntry[]>): Record<string, unknown> {
+export function formatGroupedLabelsForJson(groupedLabels: Record<string, LabelEntry[]>) {
   const entries = Object.entries(groupedLabels).filter(([, items]) => items.length > 0);
-  const typedCategoryKeys = entries.map(([k]) => k).filter((k) => k !== '');
+  const typedCategoryKeys = entries.map(([key]) => key).filter((key) => key !== '');
   if (typedCategoryKeys.length === 0) {
-    const pairs: Array<[string, string]> = [];
+    const pairs: Array<[string, string | unknown]> = [];
     for (const [, items] of entries) {
       for (const { key, value } of items) {
-        pairs.push([key, value]);
+        pairs.push([key, prettifyIfJson(value)]);
       }
     }
     pairs.sort(([a], [b]) => labelKeyCollator.compare(a, b));
     return Object.fromEntries(pairs);
   }
-  const nested: Record<string, Record<string, string>> = {};
+  const nested: Record<string, Record<string, string | unknown>> = {};
   for (const [group, items] of entries) {
     const groupName = group === '' ? 'uncategorized' : group;
     const sorted = [...items].sort((a, b) => labelKeyCollator.compare(a.key, b.key));
-    nested[groupName] = Object.fromEntries(sorted.map(({ key, value }) => [key, value]));
+    nested[groupName] = Object.fromEntries(sorted.map(({ key, value }) => [key, prettifyIfJson(value)]));
   }
   return nested;
 }
@@ -63,21 +64,29 @@ function fieldDefsWithoutLinks(log: LogListModel) {
   return log.fields.filter((f) => f.links?.length === 0 && f.fieldIndex !== log.entryFieldIndex).sort();
 }
 
-function dataframeFieldsToRecord(log: LogListModel): Record<string, string> {
+function dataframeFieldsToRecord(log: LogListModel): Record<string, string | string[] | unknown> {
   const fields = fieldDefsWithoutLinks(log);
-  const out: Record<string, string> = {};
-  for (const f of fields) {
-    const name = f.keys.join(' | ');
-    out[name] = f.values.join(' | ');
+  const out: Record<string, string | string[] | unknown> = {};
+  for (const field of fields) {
+    const name = field.keys.join(' | ');
+    out[name] = field.values.length === 1 ? prettifyIfJson(field.values[0]) : field.values;
   }
   return out;
 }
 
-export function buildLogLineFullJsonObject(log: LogListModel, ds: DataSourceApi): Record<string, unknown> {
-  const grouped = groupLabelsByCategory(log, ds);
-  const labelsJson = formatGroupedLabelsForJson(grouped);
-  const fieldsJson = dataframeFieldsToRecord(log);
+function prettifyIfJson(raw: string): unknown {
+  const trimmed = raw.trim();
+  if (!trimmed || (trimmed[0] !== '{' && trimmed[0] !== '[')) {
+    return raw;
+  }
+  try {
+    return parse(raw) ?? raw;
+  } catch {
+    return raw;
+  }
+}
 
+export function buildLogLineFullJsonObject(log: LogListModel, ds: DataSourceApi): Record<string, unknown> {
   const payload: Record<string, unknown> = {
     timestamp: log.timestamp,
     timeEpochMs: log.timeEpochMs,
@@ -87,13 +96,16 @@ export function buildLogLineFullJsonObject(log: LogListModel, ds: DataSourceApi)
     timeFromNow: log.timeFromNow,
     logLevel: log.logLevel,
     displayLevel: log.displayLevel,
-    line: log.entry,
+    line: log.isJSON ? prettifyIfJson(log.entry) : log.entry,
   };
 
-  if (Object.keys(labelsJson).length > 0) {
+  const groupedLabels = groupLabelsByCategory(log, ds);
+  if (groupedLabels) {
+    const labelsJson = formatGroupedLabelsForJson(groupedLabels);
     payload.labels = labelsJson;
   }
 
+  const fieldsJson = dataframeFieldsToRecord(log);
   if (Object.keys(fieldsJson).length > 0) {
     payload.fields = fieldsJson;
   }

--- a/public/app/features/logs/components/panel/export.ts
+++ b/public/app/features/logs/components/panel/export.ts
@@ -1,11 +1,6 @@
 import { groupBy } from 'lodash';
 
-import {
-  DataFrameType,
-  type DataSourceApi,
-  hasLogsLabelTypesSupport,
-  type Labels,
-} from '@grafana/data';
+import { DataFrameType, type DataSourceApi, hasLogsLabelTypesSupport, type Labels } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 
 import { getLabelTypeFromRow } from '../../utils';
@@ -78,10 +73,7 @@ function dataframeFieldsToRecord(log: LogListModel): Record<string, string> {
   return out;
 }
 
-export function buildLogLineFullJsonObject(
-  log: LogListModel,
-  ds: DataSourceApi
-): Record<string, unknown> {
+export function buildLogLineFullJsonObject(log: LogListModel, ds: DataSourceApi): Record<string, unknown> {
   const grouped = groupLabelsByCategory(log, ds);
   const labelsJson = formatGroupedLabelsForJson(grouped);
   const fieldsJson = dataframeFieldsToRecord(log);
@@ -109,7 +101,7 @@ export function buildLogLineFullJsonObject(
   return payload;
 }
 
-export async function buildLogLineFullJsonString(log: LogListModel): Promise<string> {
+export async function getLogAsJSON(log: LogListModel): Promise<string> {
   const ds = await getDataSourceSrv().get(log.datasourceUid);
   return JSON.stringify(buildLogLineFullJsonObject(log, ds), null, 2);
 }

--- a/public/app/features/logs/components/panel/logLineFullJson.ts
+++ b/public/app/features/logs/components/panel/logLineFullJson.ts
@@ -1,0 +1,115 @@
+import { groupBy } from 'lodash';
+
+import {
+  DataFrameType,
+  type DataSourceApi,
+  hasLogsLabelTypesSupport,
+  type Labels,
+} from '@grafana/data';
+import { getDataSourceSrv } from '@grafana/runtime';
+
+import { getLabelTypeFromRow } from '../../utils';
+
+import { type LogListModel } from './processing';
+
+const labelKeyCollator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' });
+
+type LabelEntry = { key: string; value: string };
+
+function labelsObjectToSortedEntries(labels: Labels): LabelEntry[] {
+  return Object.keys(labels)
+    .sort((a, b) => labelKeyCollator.compare(a, b))
+    .map((key) => ({ key, value: labels[key] }));
+}
+
+function groupLabelsByCategory(log: LogListModel, ds: DataSourceApi): Record<string, LabelEntry[]> {
+  const labelsWithLinks = labelsObjectToSortedEntries(log.labels);
+  if (!labelsWithLinks.length) {
+    return {};
+  }
+  return groupBy(labelsWithLinks, (label) => {
+    if (hasLogsLabelTypesSupport(ds)) {
+      return ds.getLabelDisplayTypeFromFrame(label.key, log.dataFrame, log.rowIndex) ?? '';
+    }
+    return getLabelTypeFromRow(label.key, log, true) ?? '';
+  });
+}
+
+/**
+ * When every label falls into the unnamed bucket (no datasource or no typed categories),
+ * export a single flat map. Otherwise export one nested object per category.
+ */
+export function formatGroupedLabelsForJson(groupedLabels: Record<string, LabelEntry[]>): Record<string, unknown> {
+  const entries = Object.entries(groupedLabels).filter(([, items]) => items.length > 0);
+  const typedCategoryKeys = entries.map(([k]) => k).filter((k) => k !== '');
+  if (typedCategoryKeys.length === 0) {
+    const pairs: Array<[string, string]> = [];
+    for (const [, items] of entries) {
+      for (const { key, value } of items) {
+        pairs.push([key, value]);
+      }
+    }
+    pairs.sort(([a], [b]) => labelKeyCollator.compare(a, b));
+    return Object.fromEntries(pairs);
+  }
+  const nested: Record<string, Record<string, string>> = {};
+  for (const [group, items] of entries) {
+    const groupName = group === '' ? 'uncategorized' : group;
+    const sorted = [...items].sort((a, b) => labelKeyCollator.compare(a.key, b.key));
+    nested[groupName] = Object.fromEntries(sorted.map(({ key, value }) => [key, value]));
+  }
+  return nested;
+}
+
+function fieldDefsWithoutLinks(log: LogListModel) {
+  if (log.dataFrame.meta?.type === DataFrameType.LogLines) {
+    return [];
+  }
+  return log.fields.filter((f) => f.links?.length === 0 && f.fieldIndex !== log.entryFieldIndex).sort();
+}
+
+function dataframeFieldsToRecord(log: LogListModel): Record<string, string> {
+  const fields = fieldDefsWithoutLinks(log);
+  const out: Record<string, string> = {};
+  for (const f of fields) {
+    const name = f.keys.join(' | ');
+    out[name] = f.values.join(' | ');
+  }
+  return out;
+}
+
+export function buildLogLineFullJsonObject(
+  log: LogListModel,
+  ds: DataSourceApi
+): Record<string, unknown> {
+  const grouped = groupLabelsByCategory(log, ds);
+  const labelsJson = formatGroupedLabelsForJson(grouped);
+  const fieldsJson = dataframeFieldsToRecord(log);
+
+  const payload: Record<string, unknown> = {
+    timestamp: log.timestamp,
+    timeEpochMs: log.timeEpochMs,
+    timeEpochNs: log.timeEpochNs,
+    timeLocal: log.timeLocal,
+    timeUtc: log.timeUtc,
+    timeFromNow: log.timeFromNow,
+    logLevel: log.logLevel,
+    displayLevel: log.displayLevel,
+    line: log.entry,
+  };
+
+  if (Object.keys(labelsJson).length > 0) {
+    payload.labels = labelsJson;
+  }
+
+  if (Object.keys(fieldsJson).length > 0) {
+    payload.fields = fieldsJson;
+  }
+
+  return payload;
+}
+
+export async function buildLogLineFullJsonString(log: LogListModel): Promise<string> {
+  const ds = await getDataSourceSrv().get(log.datasourceUid);
+  return JSON.stringify(buildLogLineFullJsonObject(log, ds), null, 2);
+}

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11350,6 +11350,8 @@
       "clear-search": "Clear",
       "close-inline-details": "Close details for this log",
       "close-sidebar-details": "Close log details sidebar",
+      "copy-log-line": "Copy log line message",
+      "copy-log-line-json": "Copy log contents as JSON",
       "copy-shortlink": "Copy shortlink",
       "copy-to-clipboard": "Copy to clipboard",
       "displayed-fields-section": "Organize displayed fields",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11400,7 +11400,8 @@
     },
     "log-line-menu": {
       "copy-link": "Copy link to log line",
-      "copy-log": "Copy log line",
+      "copy-log-contents": "Copy log line contents as JSON",
+      "copy-log-message": "Copy log line message",
       "hide-details": "Show log details",
       "icon-label": "Log menu",
       "log-line": "Log line",


### PR DESCRIPTION
This PR adds support to copy an entire log entry, including fields or labels, as a JSON structure. Additionally, if the values contain serialized data, they are parsed in the output.

Demo with two different dataframe/logs formats, Elasticsearch and Loki:

https://github.com/user-attachments/assets/fdfd56bf-a565-474c-ae39-5c42347ecfa3

Also available in the Log Line Menu.

<img width="301" height="316" alt="imagen" src="https://github.com/user-attachments/assets/0d9f73fc-92ca-4d37-b11b-ea7a68ef57ab" />


