### PR TITLE
Pyroscope: Bump the Call Tree feature flag to public preview

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md
@@ -110,6 +110,7 @@ Most [generally available](https://grafana.com/docs/release-life-cycle/#general-
 | `transformationsEmptyPlaceholder` | Show transformation quick-start cards in empty transformations state                                   |
 | `profilesExemplars`               | Enables profiles exemplars support in profiles drilldown                                               |
 | `pyroscopeUTF8LabelNames`         | Enables support for UTF-8 label names in Pyroscope label selectors                                     |
+| `flameGraphWithCallTree`          | Enables the new Flame Graph UI containing the Call Tree view                                           |
 | `splashScreen`                    | Enables the splash screen modal for introducing new Grafana features on first session                  |
 
 ## Development feature toggles

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2807,7 +2807,7 @@ var (
 		{
 			Name:        "flameGraphWithCallTree",
 			Description: "Enables the new Flame Graph UI containing the Call Tree view",
-			Stage:       FeatureStageExperimental,
+			Stage:       FeatureStagePublicPreview,
 			Owner:       grafanaObservabilityTracesAndProfilingSquad,
 			Generate:    Generate{LegacyFrontend: true, React: true}, // legacy frontend for old naming convention
 			Expression:  "false",

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -326,7 +326,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-05-06,grafana.scenesFlickeringFix,experimental,@grafana/dashboards-squad,false,false,true
 2026-03-03,datasourcesApiServerEnableHealthEndpointFrontend,experimental,@grafana/grafana-datasources-core-services,false,false,true
 2026-03-26,datasourcesApiServerEnableHealthEndpointRedirect,experimental,@grafana/grafana-datasources-core-services,false,false,false
-2026-03-10,flameGraphWithCallTree,experimental,@grafana/observability-traces-and-profiling,false,false,true
+2026-03-10,flameGraphWithCallTree,preview,@grafana/observability-traces-and-profiling,false,false,true
 2026-03-11,advisorDatasourceIntegration,experimental,@grafana/grafana-catalog,false,false,false
 2026-03-04,inlineLogDetailsNoScrolls,experimental,@grafana/observability-logs,false,false,true
 2026-02-06,colorblindThemes,GA,@grafana/grafana-frontend-platform,false,true,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2590,12 +2590,15 @@
     {
       "metadata": {
         "name": "flameGraphWithCallTree",
-        "resourceVersion": "1773162696077",
-        "creationTimestamp": "2026-03-10T17:11:36Z"
+        "resourceVersion": "1778683818187",
+        "creationTimestamp": "2026-03-10T17:11:36Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-05-13 14:50:18.187266 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Enables the new Flame Graph UI containing the Call Tree view",
-        "stage": "experimental",
+        "stage": "preview",
         "codeowner": "@grafana/observability-traces-and-profiling",
         "frontend": true,
         "expression": "false"


### PR DESCRIPTION
Moving the revamped UI of the Flame Graph component (#118419), including the Call Tree feature, to public preview.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
