### PR TITLE
Correlations: Filter by org id when returning correlation count in get response

### DIFF
--- a/pkg/services/correlations/correlations.go
+++ b/pkg/services/correlations/correlations.go
@@ -130,7 +130,7 @@ func (s CorrelationsService) handleDatasourceDeletion(ctx context.Context, event
 }
 
 func (s *CorrelationsService) Usage(ctx context.Context, scopeParams *quota.ScopeParameters) (*quota.Map, error) {
-	return s.CountCorrelations(ctx)
+	return s.CountCorrelations(ctx, nil)
 }
 
 func readQuotaConfig(cfg *setting.Cfg) (*quota.Map, error) {

--- a/pkg/services/correlations/database.go
+++ b/pkg/services/correlations/database.go
@@ -282,12 +282,15 @@ func (s CorrelationsService) getCorrelation(ctx context.Context, cmd GetCorrelat
 	return correlation, nil
 }
 
-func (s CorrelationsService) CountCorrelations(ctx context.Context) (*quota.Map, error) {
+func (s CorrelationsService) CountCorrelations(ctx context.Context, orgId *int64) (*quota.Map, error) {
 	u := &quota.Map{}
 	var err error
 	count := int64(0)
 	err = s.SQLStore.WithDbSession(ctx, func(sess *db.Session) error {
 		q := sess.Table("correlation")
+		if orgId != nil {
+			q.Where("org_id = ?", orgId)
+		}
 		count, err = q.Count()
 
 		if err != nil {
@@ -354,7 +357,7 @@ func (s CorrelationsService) getCorrelations(ctx context.Context, cmd GetCorrela
 		return GetCorrelationsResponseBody{}, err
 	}
 
-	count, err := s.CountCorrelations(ctx)
+	count, err := s.CountCorrelations(ctx, &cmd.OrgId)
 	if err != nil {
 		return GetCorrelationsResponseBody{}, err
 	}

--- a/pkg/tests/api/correlations/correlations_read_test.go
+++ b/pkg/tests/api/correlations/correlations_read_test.go
@@ -172,6 +172,7 @@ func TestIntegrationReadCorrelation(t *testing.T) {
 
 			require.Len(t, response.Correlations, 1)
 			require.EqualValues(t, correlation, response.Correlations[0])
+			require.EqualValues(t, response.TotalCount, 1)
 
 			require.NoError(t, res.Body.Close())
 		})
@@ -191,6 +192,7 @@ func TestIntegrationReadCorrelation(t *testing.T) {
 			require.NoError(t, err)
 
 			require.Len(t, response.Correlations, 0)
+			require.EqualValues(t, response.TotalCount, 0)
 
 			require.NoError(t, res.Body.Close())
 		})


### PR DESCRIPTION
In https://github.com/grafana/grafana/pull/65241, we returned a total count of correlations for determining the number of pages that should be listed. We did this by using a function that would run a `COUNT()` on correlations that had been introduced in https://github.com/grafana/grafana/pull/65076 for quotas.

Unfortunately, while quotas do not factor in individual orgs in an instance, our total count of correlations does. We would get the total number of correlations across all orgs in the response.

This adds an org filter and skips it for quotas. It also adds tests around the total count.