### PR TITLE
IAM: fix resolveScope for id-scoped mappers and add service account resource permission tests

### DIFF
--- a/pkg/registry/apis/iam/resourcepermission/mapper.go
+++ b/pkg/registry/apis/iam/resourcepermission/mapper.go
@@ -35,6 +35,12 @@ type Mapper interface {
 	// Example: "folders:uid:%" matches "folders:uid:abc", "folders:uid:xyz", etc.
 	ScopePattern() string
 
+	// UIDScope returns the uid-form RBAC scope for a given resource name, regardless of the
+	// mapper's configured ScopeAttribute. Used by the write path to pass a uid-scoped string
+	// to ResolveUIDScopeForWrite for id-scoped resources.
+	// Example: UIDScope("123") returns "serviceaccounts:uid:123".
+	UIDScope(name string) string
+
 	// AllowsKind reports whether the resource type permits assignments to the given permission kind.
 	// Returns true when no kind restriction is configured (all kinds allowed).
 	AllowsKind(kind v0alpha1.ResourcePermissionSpecPermissionKind) bool
@@ -91,6 +97,10 @@ func (m mapper) ActionSets() []string {
 
 func (m mapper) Scope(name string) string {
 	return m.resource + ":" + string(m.scopeAttribute) + ":" + name
+}
+
+func (m mapper) UIDScope(name string) string {
+	return m.resource + ":" + string(ScopeAttributeUID) + ":" + name
 }
 
 func (m mapper) ActionSet(level string) (string, error) {

--- a/pkg/registry/apis/iam/resourcepermission/mapper_test.go
+++ b/pkg/registry/apis/iam/resourcepermission/mapper_test.go
@@ -417,3 +417,19 @@ func TestMapper_AllowsKind_RestrictedList(t *testing.T) {
 	assert.True(t, m.AllowsKind(v0alpha1.ResourcePermissionSpecPermissionKindTeam))
 	assert.False(t, m.AllowsKind(v0alpha1.ResourcePermissionSpecPermissionKindBasicRole))
 }
+
+func TestMapper_ActionSet_ServiceAccount(t *testing.T) {
+	m := NewMapperWithAttribute("serviceaccounts", []string{"Edit", "Admin"}, ScopeAttributeID, nil)
+
+	actionSet, err := m.ActionSet("Edit")
+	require.NoError(t, err)
+	assert.Equal(t, "serviceaccounts:edit", actionSet)
+
+	actionSet, err = m.ActionSet("Admin")
+	require.NoError(t, err)
+	assert.Equal(t, "serviceaccounts:admin", actionSet)
+
+	_, err = m.ActionSet("View")
+	require.Error(t, err)
+	require.ErrorIs(t, err, errInvalidSpec)
+}

--- a/pkg/registry/apis/iam/resourcepermission/sql.go
+++ b/pkg/registry/apis/iam/resourcepermission/sql.go
@@ -24,10 +24,9 @@ import (
 // For id-scoped resources (teams, users, service accounts), translates uid→id via the identity store.
 func resolveScope(ctx context.Context, ns types.NamespaceInfo, store IdentityStore, mapper Mapper, name string) (string, error) {
 	if isIDScoped(mapper) && store != nil {
-		// The resource name (grn.Name) is always a UID. Build a uid-scoped string so
-		// ResolveUIDScopeForWrite can look it up and return the id-based equivalent.
-		resource := strings.TrimSuffix(mapper.ScopePattern(), ":id:%")
-		return legacy.ResolveUIDScopeForWrite(ctx, store, ns, resource+":uid:"+name)
+		// The resource name (grn.Name) is always a UID. UIDScope returns the uid-form
+		// scope so ResolveUIDScopeForWrite can translate it to the id-based equivalent.
+		return legacy.ResolveUIDScopeForWrite(ctx, store, ns, mapper.UIDScope(name))
 	}
 	return mapper.Scope(name), nil
 }

--- a/pkg/registry/apis/iam/resourcepermission/sql.go
+++ b/pkg/registry/apis/iam/resourcepermission/sql.go
@@ -23,11 +23,13 @@ import (
 // resolveScope returns the legacy db scope for the given resource name.
 // For id-scoped resources (teams, users, service accounts), translates uid→id via the identity store.
 func resolveScope(ctx context.Context, ns types.NamespaceInfo, store IdentityStore, mapper Mapper, name string) (string, error) {
-	scope := mapper.Scope(name)
 	if isIDScoped(mapper) && store != nil {
-		return legacy.ResolveUIDScopeForWrite(ctx, store, ns, scope)
+		// The resource name (grn.Name) is always a UID. Build a uid-scoped string so
+		// ResolveUIDScopeForWrite can look it up and return the id-based equivalent.
+		resource := strings.TrimSuffix(mapper.ScopePattern(), ":id:%")
+		return legacy.ResolveUIDScopeForWrite(ctx, store, ns, resource+":uid:"+name)
 	}
-	return scope, nil
+	return mapper.Scope(name), nil
 }
 
 // List

--- a/pkg/registry/apis/iam/resourcepermission/sql_test.go
+++ b/pkg/registry/apis/iam/resourcepermission/sql_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"sync"
 	"testing"
 	"time"
 
@@ -22,7 +21,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/sqlstore/session"
 	"github.com/grafana/grafana/pkg/storage/legacysql"
-	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
@@ -723,13 +721,11 @@ func TestIntegration_ResourcePermSqlBackend_ListDirectPermissionsForSubject(t *t
 	setupTestRoles(t, sql.DB)
 
 	tests := []struct {
-		name        string
-		namespace   string
-		subject     string
-		wantPerms   []v0alpha1.PermissionSpec
-		wantNil     bool
-		setup       func(*testing.T, db.DB)
-		useSAMapper bool
+		name      string
+		namespace string
+		subject   string
+		wantPerms []v0alpha1.PermissionSpec
+		wantNil   bool
 	}{
 		{
 			name:    "empty subject UID returns nil",
@@ -773,44 +769,10 @@ func TestIntegration_ResourcePermSqlBackend_ListDirectPermissionsForSubject(t *t
 			subject:   "user-1", // user-1's role is in org-1 only
 			wantPerms: []v0alpha1.PermissionSpec{},
 		},
-		{
-			name:      "returns serviceaccount permission with uid-based scope",
-			namespace: "default",
-			subject:   "user-1",
-			setup: func(t *testing.T, store db.DB) {
-				t.Helper()
-				sess := store.GetSqlxSession()
-				_, err := sess.Exec(context.Background(),
-					`INSERT INTO permission (role_id, action, scope, created, updated) VALUES (?, ?, ?, ?, ?)`,
-					1, "serviceaccounts:admin", "serviceaccounts:id:3", "2025-09-02", "2025-09-02",
-				)
-				require.NoError(t, err)
-			},
-			wantPerms: []v0alpha1.PermissionSpec{
-				{Action: "folders:view", Scope: "folders:uid:fold1"},
-				{Action: "dashboards:edit", Scope: "dashboards:uid:dash1"},
-				{Action: "serviceaccounts:admin", Scope: "serviceaccounts:uid:sa-1"},
-			},
-			useSAMapper: true,
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if tt.setup != nil {
-				tt.setup(t, sql.DB)
-			}
-			activeBackend := backend
-			if tt.useSAMapper {
-				activeBackend = &ResourcePermSqlBackend{
-					dbProvider:    backend.dbProvider,
-					identityStore: NewFakeIdentityStore(t),
-					logger:        backend.logger,
-					mappers:       saMapper(),
-					subscribers:   make([]chan *resource.WrittenEvent, 0),
-					mutex:         sync.Mutex{},
-				}
-			}
-			result, err := activeBackend.ListDirectPermissionsForSubject(context.Background(), tt.namespace, tt.subject)
+			result, err := backend.ListDirectPermissionsForSubject(context.Background(), tt.namespace, tt.subject)
 			require.NoError(t, err)
 			if tt.wantNil {
 				require.Nil(t, result)
@@ -828,6 +790,45 @@ func TestIntegration_ResourcePermSqlBackend_ListDirectPermissionsForSubject(t *t
 			require.Equal(t, want, got)
 		})
 	}
+}
+
+func TestIntegration_ResourcePermSqlBackend_ListDirectPermissionsForSubject_SAMapper(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	store := db.InitTestDB(t)
+	sqlHelper := &legacysql.LegacyDatabaseHelper{
+		DB:    store,
+		Table: func(name string) string { return name },
+	}
+	dbProvider := func(ctx context.Context) (*legacysql.LegacyDatabaseHelper, error) {
+		return sqlHelper, nil
+	}
+
+	backend := ProvideStorageBackend(dbProvider, saMapper())
+	backend.identityStore = NewFakeIdentityStore(t)
+	setupTestRoles(t, store)
+
+	// Seed a serviceaccounts:id:3 permission onto user-1's role.
+	// The backend should resolve it to serviceaccounts:uid:sa-1 on read.
+	sess := store.GetSqlxSession()
+	_, err := sess.Exec(context.Background(),
+		`INSERT INTO permission (role_id, action, scope, created, updated) VALUES (?, ?, ?, ?, ?)`,
+		1, "serviceaccounts:admin", "serviceaccounts:id:3", "2025-09-02", "2025-09-02",
+	)
+	require.NoError(t, err)
+
+	result, err := backend.ListDirectPermissionsForSubject(context.Background(), "default", "user-1")
+	require.NoError(t, err)
+
+	got := make(map[string]string, len(result))
+	for _, p := range result {
+		got[p.Action] = p.Scope
+	}
+	require.Equal(t, map[string]string{
+		"folders:view":         "folders:uid:fold1",
+		"dashboards:edit":      "dashboards:uid:dash1",
+		"serviceaccounts:admin": "serviceaccounts:uid:sa-1",
+	}, got)
 }
 
 func TestIntegration_UpdateResourcePermission_VerbChange(t *testing.T) {

--- a/pkg/registry/apis/iam/resourcepermission/sql_test.go
+++ b/pkg/registry/apis/iam/resourcepermission/sql_test.go
@@ -825,8 +825,8 @@ func TestIntegration_ResourcePermSqlBackend_ListDirectPermissionsForSubject_SAMa
 		got[p.Action] = p.Scope
 	}
 	require.Equal(t, map[string]string{
-		"folders:view":         "folders:uid:fold1",
-		"dashboards:edit":      "dashboards:uid:dash1",
+		"folders:view":          "folders:uid:fold1",
+		"dashboards:edit":       "dashboards:uid:dash1",
 		"serviceaccounts:admin": "serviceaccounts:uid:sa-1",
 	}, got)
 }

--- a/pkg/registry/apis/iam/resourcepermission/sql_test.go
+++ b/pkg/registry/apis/iam/resourcepermission/sql_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"testing"
 	"time"
 
@@ -21,6 +22,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/sqlstore/session"
 	"github.com/grafana/grafana/pkg/storage/legacysql"
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/tests/testsuite"
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
@@ -721,11 +723,13 @@ func TestIntegration_ResourcePermSqlBackend_ListDirectPermissionsForSubject(t *t
 	setupTestRoles(t, sql.DB)
 
 	tests := []struct {
-		name      string
-		namespace string
-		subject   string
-		wantPerms []v0alpha1.PermissionSpec // action → scope
-		wantNil   bool
+		name        string
+		namespace   string
+		subject     string
+		wantPerms   []v0alpha1.PermissionSpec
+		wantNil     bool
+		setup       func(*testing.T, db.DB)
+		useSAMapper bool
 	}{
 		{
 			name:    "empty subject UID returns nil",
@@ -769,10 +773,44 @@ func TestIntegration_ResourcePermSqlBackend_ListDirectPermissionsForSubject(t *t
 			subject:   "user-1", // user-1's role is in org-1 only
 			wantPerms: []v0alpha1.PermissionSpec{},
 		},
+		{
+			name:      "returns serviceaccount permission with uid-based scope",
+			namespace: "default",
+			subject:   "user-1",
+			setup: func(t *testing.T, store db.DB) {
+				t.Helper()
+				sess := store.GetSqlxSession()
+				_, err := sess.Exec(context.Background(),
+					`INSERT INTO permission (role_id, action, scope, created, updated) VALUES (?, ?, ?, ?, ?)`,
+					1, "serviceaccounts:admin", "serviceaccounts:id:3", "2025-09-02", "2025-09-02",
+				)
+				require.NoError(t, err)
+			},
+			wantPerms: []v0alpha1.PermissionSpec{
+				{Action: "folders:view", Scope: "folders:uid:fold1"},
+				{Action: "dashboards:edit", Scope: "dashboards:uid:dash1"},
+				{Action: "serviceaccounts:admin", Scope: "serviceaccounts:uid:sa-1"},
+			},
+			useSAMapper: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := backend.ListDirectPermissionsForSubject(context.Background(), tt.namespace, tt.subject)
+			if tt.setup != nil {
+				tt.setup(t, sql.DB)
+			}
+			activeBackend := backend
+			if tt.useSAMapper {
+				activeBackend = &ResourcePermSqlBackend{
+					dbProvider:    backend.dbProvider,
+					identityStore: NewFakeIdentityStore(t),
+					logger:        backend.logger,
+					mappers:       saMapper(),
+					subscribers:   make([]chan *resource.WrittenEvent, 0),
+					mutex:         sync.Mutex{},
+				}
+			}
+			result, err := activeBackend.ListDirectPermissionsForSubject(context.Background(), tt.namespace, tt.subject)
 			require.NoError(t, err)
 			if tt.wantNil {
 				require.Nil(t, result)

--- a/pkg/registry/apis/iam/resourcepermission/storage_backend_test.go
+++ b/pkg/registry/apis/iam/resourcepermission/storage_backend_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
@@ -262,6 +263,119 @@ func TestWriteEvent_Add(t *testing.T) {
 			require.Contains(t, err.Error(), errConflict.Error())
 			require.Zero(t, rv)
 		})
+	})
+}
+
+func saMapper() *MappersRegistry {
+	m := NewMappersRegistry()
+	m.RegisterMapper(
+		saGroupResource(),
+		NewMapperWithAttribute("serviceaccounts", []string{"Edit", "Admin"}, ScopeAttributeID,
+			[]v0alpha1.ResourcePermissionSpecPermissionKind{
+				v0alpha1.ResourcePermissionSpecPermissionKindUser,
+				v0alpha1.ResourcePermissionSpecPermissionKindServiceAccount,
+				v0alpha1.ResourcePermissionSpecPermissionKindTeam,
+			}),
+		nil,
+	)
+	return m
+}
+
+func saGroupResource() schema.GroupResource {
+	return schema.GroupResource{Group: "iam.grafana.app", Resource: "serviceaccounts"}
+}
+
+func TestWriteEvent_Add_ServiceAccount(t *testing.T) {
+	store := db.InitTestDB(t)
+
+	timeNow = func() time.Time {
+		return time.Date(2025, 8, 28, 17, 13, 0, 0, time.UTC)
+	}
+
+	sqlHelper := &legacysql.LegacyDatabaseHelper{
+		DB:    store,
+		Table: func(name string) string { return name },
+	}
+	dbProvider := func(ctx context.Context) (*legacysql.LegacyDatabaseHelper, error) {
+		return sqlHelper, nil
+	}
+
+	t.Run("should write serviceaccount permission with user kind", func(t *testing.T) {
+		backend := ProvideStorageBackend(dbProvider, saMapper())
+		backend.identityStore = NewFakeIdentityStore(t)
+
+		resourcePerm, err := utils.MetaAccessor(&v0alpha1.ResourcePermission{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "iam.grafana.app-serviceaccounts-robot",
+				Namespace: "default",
+			},
+			Spec: v0alpha1.ResourcePermissionSpec{
+				Resource: v0alpha1.ResourcePermissionspecResource{
+					ApiGroup: "iam.grafana.app",
+					Resource: "serviceaccounts",
+					Name:     "robot",
+				},
+				Permissions: []v0alpha1.ResourcePermissionspecPermission{
+					{
+						Kind: v0alpha1.ResourcePermissionSpecPermissionKindUser,
+						Name: "captain",
+						Verb: "Edit",
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		gr := v0alpha1.ResourcePermissionInfo.GroupResource()
+		rv, err := backend.WriteEvent(context.Background(), resource.WriteEvent{
+			Type:   resourcepb.WatchEvent_ADDED,
+			Key:    &resourcepb.ResourceKey{Group: gr.Group, Resource: gr.Resource, Name: "iam.grafana.app-serviceaccounts-robot", Namespace: "default"},
+			Object: resourcePerm,
+		})
+		require.NoError(t, err)
+		require.Equal(t, timeNow().UnixMilli(), rv)
+
+		// Verify the permission was written with the ID-based scope
+		sess := store.GetSqlxSession()
+		var scope string
+		err = sess.Get(context.Background(), &scope, "SELECT scope FROM permission WHERE action = ? AND role_id = (SELECT id FROM role WHERE name = ?)", "serviceaccounts:edit", "managed:users:101:permissions")
+		require.NoError(t, err)
+		require.Equal(t, "serviceaccounts:id:201", scope)
+	})
+
+	t.Run("folder with basicRole kind still works after sa mapper registration", func(t *testing.T) {
+		backend := ProvideStorageBackend(dbProvider, saMapper())
+		backend.identityStore = NewFakeIdentityStore(t)
+
+		resourcePerm, err := utils.MetaAccessor(&v0alpha1.ResourcePermission{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "folder.grafana.app-folders-fold1",
+				Namespace: "default",
+			},
+			Spec: v0alpha1.ResourcePermissionSpec{
+				Resource: v0alpha1.ResourcePermissionspecResource{
+					ApiGroup: "folder.grafana.app",
+					Resource: "folders",
+					Name:     "fold1",
+				},
+				Permissions: []v0alpha1.ResourcePermissionspecPermission{
+					{
+						Kind: v0alpha1.ResourcePermissionSpecPermissionKindBasicRole,
+						Name: "Viewer",
+						Verb: "Admin",
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		gr := v0alpha1.ResourcePermissionInfo.GroupResource()
+		_, err = backend.WriteEvent(context.Background(), resource.WriteEvent{
+			Type:   resourcepb.WatchEvent_ADDED,
+			Key:    &resourcepb.ResourceKey{Group: gr.Group, Resource: gr.Resource, Name: "folder.grafana.app-folders-fold1", Namespace: "default"},
+			Object: resourcePerm,
+		})
+		require.NoError(t, err)
 	})
 }
 

--- a/pkg/registry/apis/iam/resourcepermission/storage_backend_test.go
+++ b/pkg/registry/apis/iam/resourcepermission/storage_backend_test.go
@@ -266,6 +266,9 @@ func TestWriteEvent_Add(t *testing.T) {
 	})
 }
 
+// saMapper builds a registry with the default folders/dashboards mappers (from NewMappersRegistry)
+// plus serviceaccounts. The folders/dashboards entries are load-bearing for the useSAMapper case
+// in sql_test.go — do not replace NewMappersRegistry() with a bare registry.
 func saMapper() *MappersRegistry {
 	m := NewMappersRegistry()
 	m.RegisterMapper(

--- a/pkg/services/accesscontrol/resourcepermissions/service_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service_test.go
@@ -690,6 +690,13 @@ func TestMapPermission_ServiceAccount(t *testing.T) {
 		require.Len(t, actions, 1)
 		assert.Equal(t, saOpts.GetActionSetName("Edit"), actions[0])
 	})
+
+	t.Run("invalid level returns ErrInvalidPermission", func(t *testing.T) {
+		svc := &Service{options: saOpts}
+		_, err := svc.mapPermission("View")
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrInvalidPermission)
+	})
 }
 
 func TestIsActionSetEnabledResource_ServiceAccount(t *testing.T) {


### PR DESCRIPTION
## Summary

- Fixes a bug in `resolveScope` where id-scoped mappers (teams, users, service accounts) were passing `resource:id:<uid>` to `ResolveUIDScopeForWrite`, which only recognizes the `resource:uid:` prefix — causing the UID→internal-ID translation to be silently skipped
- Adds tests for the SA resource permission write/read path, mapper validation, and `mapPermission` error handling

## What changed

**Bug fix** (`sql.go`): `resolveScope` now builds the uid-scoped form first (`resource:uid:<name>`) before passing it to `ResolveUIDScopeForWrite`, which correctly resolves it to `resource:id:<int>`. This was latent for existing teams/users mappers (no write tests covered the scope format) and surfaced when the SA mapper was introduced.

**Tests added**:
- `mapper_test.go`: `TestMapper_ActionSet_ServiceAccount` — Edit/Admin succeed, View returns `errInvalidSpec`
- `storage_backend_test.go`: `TestWriteEvent_Add_ServiceAccount` — writes an SA resource permission, asserts `serviceaccounts:id:<int>` scope in DB; regression test for folder+basicRole still working
- `sql_test.go`: SA test case in `TestIntegration_ResourcePermSqlBackend_ListDirectPermissionsForSubject` — seeds an `serviceaccounts:id:3` permission and verifies it comes back as `serviceaccounts:uid:sa-1` after UID resolution on read
- `service_test.go`: `mapPermission("View")` returns `ErrInvalidPermission` for SA service

## Test plan

- [x] All tests pass: `go test ./pkg/registry/apis/iam/resourcepermission/... ./pkg/services/accesscontrol/resourcepermissions/... -short`
- [x] Bug reproduced by the new `TestWriteEvent_Add_ServiceAccount` test (fails without the `sql.go` fix)

## Risks / notes

The `resolveScope` fix also corrects the write path for teams and users resource permissions (they had the same latent bug). No behavior change for UID-scoped mappers (folders, dashboards, datasources).