### PR TITLE
Meticulous: remove unused inline script

### DIFF
--- a/pkg/services/frontend/index.html
+++ b/pkg/services/frontend/index.html
@@ -17,9 +17,6 @@
       nonce="[[.Nonce]]"
       src="https://snippet.meticulous.ai/v1/meticulous.js"
     ></script>
-    <script>
-      window.__METICULOUS_AI_RECORDING_TOKEN__ = '[[.MeticulousAIRecordingToken]]';
-    </script>
     [[end]]
 
     <link rel="icon" id="grafana_favicon" type="image/png" href="[[.Assets.ContentDeliveryURL]]public/build/img/fav32.png" />


### PR DESCRIPTION
Ultimately, this inline script was not needed since we didn't need to use the `__METICULOUS_AI_RECORDING_TOKEN__` elsewhere in the code, and it's being flagged by our CSP anyway since it's missing the nonce. Let's remove it.