### PR TITLE
Create sqlExpressionsCodeMirror feature flag

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -519,6 +519,11 @@ export interface FeatureToggles {
   */
   sqlExpressionsColumnAutoComplete?: boolean;
   /**
+  * Enables CodeMirror editor for SQL Expressions
+  * @default false
+  */
+  sqlExpressionsCodeMirror?: boolean;
+  /**
   * Enable grafana's embedded kube-aggregator
   * @default false
   */

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
@@ -15,6 +15,7 @@ declare module "@openfeature/core" {
     | "provisioningFolderMetadata"
     | "provisioning.readmes"
     | "stateTimeline.nameAboveBars"
+    | "sqlExpressionsCodeMirror"
     | "newSavedQueriesExperience"
     | "grafana.orgDashboardTemplates"
     | "dashboardTemplatesAssistantButton"

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -77,6 +77,8 @@ export const FlagKeys = {
   ReportingAnyPageReporting: "reporting.anyPageReporting",
   /** Enables the splash screen modal for introducing new Grafana features on first session */
   SplashScreen: "splashScreen",
+  /** Enables CodeMirror editor for SQL Expressions */
+  SqlExpressionsCodeMirror: "sqlExpressionsCodeMirror",
   /** Enables option to position series names above bars in the state timeline panel */
   StateTimelineNameAboveBars: "stateTimeline.nameAboveBars",
   /** Enables the 'Customize with Assistant' button on suggested dashboard cards */
@@ -433,6 +435,17 @@ export const useFlagReportingAnyPageReporting = (options?: ReactFlagEvaluationOp
  */
 export const useFlagSplashScreen = (options?: ReactFlagEvaluationOptions): boolean => {
   return useFlag("splashScreen", false, options).value;
+};
+
+/**
+ * Enables CodeMirror editor for SQL Expressions
+ *
+ * **Details:**
+ * - flag key: `sqlExpressionsCodeMirror`
+ * - default value: `false`
+ */
+export const useFlagSqlExpressionsCodeMirror = (options?: ReactFlagEvaluationOptions): boolean => {
+  return useFlag("sqlExpressionsCodeMirror", false, options).value;
 };
 
 /**

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -920,6 +920,14 @@ var (
 			Expression:  "false",
 		},
 		{
+			Name:        "sqlExpressionsCodeMirror",
+			Description: "Enables CodeMirror editor for SQL Expressions",
+			Stage:       FeatureStageExperimental,
+			Generate:    Generate{LegacyFrontend: true, React: true},
+			Owner:       grafanaDataProSquad,
+			Expression:  "false",
+		},
+		{
 			Name:            "kubernetesAggregator",
 			Description:     "Enable grafana's embedded kube-aggregator",
 			Stage:           FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -106,6 +106,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2024-11-11,logQLScope,privatePreview,@grafana/data-sources-plugins,false,false,false
 2024-02-27,sqlExpressions,preview,@grafana/grafana-datasources-core-services,false,false,false
 2025-07-23,sqlExpressionsColumnAutoComplete,experimental,@grafana/datapro,false,false,true
+2026-05-13,sqlExpressionsCodeMirror,experimental,@grafana/datapro,false,false,true
 2024-02-12,kubernetesAggregator,experimental,@grafana/grafana-app-platform-squad,false,true,false
 2025-05-15,kubernetesAggregatorCapTokenAuth,experimental,@grafana/grafana-app-platform-squad,false,true,false
 2024-02-14,groupByVariable,experimental,@grafana/dashboards-squad,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -5835,6 +5835,20 @@
     },
     {
       "metadata": {
+        "name": "sqlExpressionsCodeMirror",
+        "resourceVersion": "1778697735164",
+        "creationTimestamp": "2026-05-13T18:42:15Z"
+      },
+      "spec": {
+        "description": "Enables CodeMirror editor for SQL Expressions",
+        "stage": "experimental",
+        "codeowner": "@grafana/datapro",
+        "frontend": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "sqlExpressionsColumnAutoComplete",
         "resourceVersion": "1771434338561",
         "creationTimestamp": "2025-07-23T21:49:58Z"


### PR DESCRIPTION
**What is this feature?**

Creates a feature flag to enable using the new CodeMirror 6 Sql Editor in SQL Expressions.

**Why do we need this feature?**

We don't want to release the SQL Editor with SQL Expressions when it is not ready for the public.

**Which issue(s) does this PR fix?**:

Fixes #124838

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.