### PR TITLE
IAM: bulk endpoint API redirects to the Team object that stores membership

### DIFF
--- a/pkg/services/accesscontrol/ossaccesscontrol/team.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/team.go
@@ -2,6 +2,7 @@ package ossaccesscontrol
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 
@@ -89,11 +90,18 @@ func ProvideTeamPermissions(
 			case "Admin":
 				return teamimpl.AddOrUpdateTeamMemberHook(session, user.ID, orgID, teamId, user.IsExternal, team.PermissionTypeAdmin)
 			case "":
-				return teamimpl.RemoveTeamMemberHook(session, &team.RemoveTeamMemberCommand{
+				// The Kubernetes Teams redirect path deletes the team_member row via
+				// the dual-writer before this hook runs, so ErrTeamMemberNotFound here
+				// is expected and must not fail the request.
+				err := teamimpl.RemoveTeamMemberHook(session, &team.RemoveTeamMemberCommand{
 					OrgID:  orgID,
 					UserID: user.ID,
 					TeamID: teamId,
 				})
+				if err != nil && !errors.Is(err, team.ErrTeamMemberNotFound) {
+					return err
+				}
+				return nil
 			default:
 				return fmt.Errorf("invalid team permission type %s", permission)
 			}

--- a/pkg/services/accesscontrol/resourcepermissions/api.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"github.com/open-feature/go-sdk/openfeature"
 	"go.opentelemetry.io/otel"
 
 	"github.com/grafana/grafana/pkg/api/dtos"
@@ -617,12 +618,37 @@ func (a *api) setPermissions(c *contextmodel.ReqContext) response.Response {
 		}
 	}
 
+	resp := a.validateTeamResource(c, resourceID)
+	if resp != nil {
+		return resp
+	}
+
 	cmd := setPermissionsCommand{}
 	if err := web.Bind(c.Req, &cmd); err != nil {
 		return response.Error(http.StatusBadRequest, "Bad request data: "+err.Error(), err)
 	}
 
-	if a.shouldUseK8sAPIs() {
+	// Teams-specific dual-write: write user members to Team.Spec.Members via the K8s API,
+	// then always fall through to the legacy path so both systems stay in sync during
+	// migration. Mirrors the single-user path's behavior.
+	if a.service.options.Resource == "teams" && openfeature.NewDefaultClient().Boolean(c.Req.Context(), featuremgmt.FlagKubernetesTeamsRedirect, false, openfeature.TransactionContext(c.Req.Context())) {
+		err := a.setTeamPermissionsInTeamMembers(c, c.Namespace, resourceID, cmd.Permissions)
+		if err != nil {
+			span.RecordError(err)
+			if errors.Is(err, ErrExternalTeamMember) {
+				return response.Err(err)
+			}
+			if errors.Is(err, ErrRestConfigNotAvailable) {
+				a.logger.Debug("k8s API not available for team permissions via team members, continuing with legacy", "error", err, "resourceID", resourceID)
+			} else {
+				a.logger.Warn("Failed to set bulk permissions via team members k8s API, continuing with legacy", "error", err, "resourceID", resourceID)
+			}
+		} else {
+			metrics.MAccessResourcePermissionsBackend.WithLabelValues("k8s", "set_bulk", a.service.options.Resource, "success").Inc()
+		}
+	}
+
+	if a.service.options.Resource != "teams" && a.shouldUseK8sAPIs() {
 		err := a.setResourcePermissionsToK8s(c, c.Namespace, resourceID, cmd.Permissions)
 		if err == nil {
 			metrics.MAccessResourcePermissionsBackend.WithLabelValues("k8s", "set_bulk", a.service.options.Resource, "success").Inc()

--- a/pkg/services/accesscontrol/resourcepermissions/api_adapter.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api_adapter.go
@@ -830,20 +830,19 @@ func (a *api) setTeamMembers(c *contextmodel.ReqContext, dynamicClient dynamic.I
 	}
 
 	// Resolve users + permissions up-front: dedup by UserID (first wins) and
-	// fail before any k8s write so partial bulk writes aren't possible.
-	// Empty permission is skipped, not used for removal: in dual-writer mode
-	// the apiserver Update removes the team_member row before the legacy
-	// RemoveTeamMemberHook runs, and that hook errors on 0 rows affected.
-	// Known divergence from legacy, shared with the single-user redirect.
+	// fail before any k8s write so partial bulk writes aren't possible. An
+	// empty permission marks a removal, matching the single-user redirect and
+	// the legacy bulk path.
 	type desiredMember struct {
 		uid        string
 		permission iamv0.TeamTeamPermission
 	}
 	desired := make([]desiredMember, 0, len(permissions))
 	desiredByUID := make(map[string]iamv0.TeamTeamPermission, len(permissions))
+	removeByUID := make(map[string]struct{}, len(permissions))
 	seenUserID := make(map[int64]struct{}, len(permissions))
 	for _, perm := range permissions {
-		if perm.UserID == 0 || perm.Permission == "" {
+		if perm.UserID == 0 {
 			continue
 		}
 		if _, dup := seenUserID[perm.UserID]; dup {
@@ -859,6 +858,10 @@ func (a *api) setTeamMembers(c *contextmodel.ReqContext, dynamicClient dynamic.I
 		})
 		if err != nil {
 			return fmt.Errorf("failed to get user details: %w", err)
+		}
+		if perm.Permission == "" {
+			removeByUID[signedInUser.UserUID] = struct{}{}
+			continue
 		}
 		memberPerm, err := stringToTeamMemberPermission(perm.Permission)
 		if err != nil {
@@ -892,16 +895,21 @@ func (a *api) setTeamMembers(c *contextmodel.ReqContext, dynamicClient dynamic.I
 			if _, hit := desiredByUID[m.Name]; hit {
 				return ErrExternalTeamMember.Errorf("user %q is externally-synced", m.Name)
 			}
+			if _, hit := removeByUID[m.Name]; hit {
+				return ErrExternalTeamMember.Errorf("user %q is externally-synced", m.Name)
+			}
 		}
 
-		// Upsert: update entries the caller specified, leave entries they didn't
-		// specify alone. Matches the legacy SQL contract (callers like Terraform
-		// rely on partial updates not wiping omitted users).
+		// Upsert: update entries the caller specified, drop entries flagged for
+		// removal, leave the rest alone.
 		applied := make(map[string]bool, len(desired))
 		newMembers := make([]iamv0.TeamTeamMember, 0, len(t.Spec.Members)+len(desired))
 		for _, m := range t.Spec.Members {
 			if m.Kind != subjectKindUser || m.External {
 				newMembers = append(newMembers, m)
+				continue
+			}
+			if _, drop := removeByUID[m.Name]; drop {
 				continue
 			}
 			if perm, ok := desiredByUID[m.Name]; ok {

--- a/pkg/services/accesscontrol/resourcepermissions/api_adapter.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api_adapter.go
@@ -851,7 +851,12 @@ func (a *api) setTeamMembers(c *contextmodel.ReqContext, dynamicClient dynamic.I
 		}
 		seenUserID[perm.UserID] = struct{}{}
 
-		userDetails, err := a.service.userService.GetByID(ctx, &user.GetUserByIDQuery{ID: perm.UserID})
+		// Org-scoped lookup so a caller cannot inject a user from another org
+		// into Spec.Members.
+		signedInUser, err := a.service.userService.GetSignedInUser(ctx, &user.GetSignedInUserQuery{
+			OrgID:  c.GetOrgID(),
+			UserID: perm.UserID,
+		})
 		if err != nil {
 			return fmt.Errorf("failed to get user details: %w", err)
 		}
@@ -859,8 +864,8 @@ func (a *api) setTeamMembers(c *contextmodel.ReqContext, dynamicClient dynamic.I
 		if err != nil {
 			return err
 		}
-		desiredByUID[userDetails.UID] = memberPerm
-		desired = append(desired, desiredMember{uid: userDetails.UID, permission: memberPerm})
+		desiredByUID[signedInUser.UserUID] = memberPerm
+		desired = append(desired, desiredMember{uid: signedInUser.UserUID, permission: memberPerm})
 	}
 
 	teamResource := dynamicClient.Resource(iamv0.TeamResourceInfo.GroupVersionResource()).Namespace(namespace)

--- a/pkg/services/accesscontrol/resourcepermissions/api_adapter.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api_adapter.go
@@ -805,6 +805,141 @@ func teamMemberPermissionToString(p iamv0.TeamTeamPermission) (string, error) {
 	}
 }
 
+func (a *api) setTeamPermissionsInTeamMembers(c *contextmodel.ReqContext, namespace string, resourceID string, permissions []accesscontrol.SetResourcePermissionCommand) error {
+	dynamicClient, err := a.getDynamicClient(c)
+	if err != nil {
+		return err
+	}
+	return a.setTeamMembers(c, dynamicClient, namespace, resourceID, permissions)
+}
+
+func (a *api) setTeamMembers(c *contextmodel.ReqContext, dynamicClient dynamic.Interface, namespace string, resourceID string, permissions []accesscontrol.SetResourcePermissionCommand) error {
+	ctx := c.Req.Context()
+
+	teamID, err := strconv.ParseInt(resourceID, 10, 64)
+	if err != nil {
+		return fmt.Errorf("invalid team resource ID: %w", err)
+	}
+
+	teamDetails, err := a.service.teamService.GetTeamByID(ctx, &team.GetTeamByIDQuery{
+		OrgID: c.GetOrgID(),
+		ID:    teamID,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to get team details: %w", err)
+	}
+
+	// Resolve users + permissions up-front: dedup by UserID (first wins) and
+	// fail before any k8s write so partial bulk writes aren't possible.
+	// Empty permission is skipped, not used for removal: in dual-writer mode
+	// the apiserver Update removes the team_member row before the legacy
+	// RemoveTeamMemberHook runs, and that hook errors on 0 rows affected.
+	// Known divergence from legacy, shared with the single-user redirect.
+	type desiredMember struct {
+		uid        string
+		permission iamv0.TeamTeamPermission
+	}
+	desired := make([]desiredMember, 0, len(permissions))
+	desiredByUID := make(map[string]iamv0.TeamTeamPermission, len(permissions))
+	seenUserID := make(map[int64]struct{}, len(permissions))
+	for _, perm := range permissions {
+		if perm.UserID == 0 || perm.Permission == "" {
+			continue
+		}
+		if _, dup := seenUserID[perm.UserID]; dup {
+			continue
+		}
+		seenUserID[perm.UserID] = struct{}{}
+
+		userDetails, err := a.service.userService.GetByID(ctx, &user.GetUserByIDQuery{ID: perm.UserID})
+		if err != nil {
+			return fmt.Errorf("failed to get user details: %w", err)
+		}
+		memberPerm, err := stringToTeamMemberPermission(perm.Permission)
+		if err != nil {
+			return err
+		}
+		desiredByUID[userDetails.UID] = memberPerm
+		desired = append(desired, desiredMember{uid: userDetails.UID, permission: memberPerm})
+	}
+
+	teamResource := dynamicClient.Resource(iamv0.TeamResourceInfo.GroupVersionResource()).Namespace(namespace)
+
+	// Read-modify-write: spec.members is a slice on the Team object so a
+	// concurrent writer can lose updates if we don't refetch on conflict.
+	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		teamObj, err := teamResource.Get(ctx, teamDetails.UID, metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to get team: %w", err)
+		}
+
+		var t iamv0.Team
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(teamObj.Object, &t); err != nil {
+			return fmt.Errorf("failed to decode team: %w", err)
+		}
+
+		// External members are owned by team-sync. Reject the whole bulk write if it
+		// targets one, matching the single-user path and keeping k8s/SQL in sync.
+		for _, m := range t.Spec.Members {
+			if m.Kind != subjectKindUser || !m.External {
+				continue
+			}
+			if _, hit := desiredByUID[m.Name]; hit {
+				return ErrExternalTeamMember.Errorf("user %q is externally-synced", m.Name)
+			}
+		}
+
+		// Upsert: update entries the caller specified, leave entries they didn't
+		// specify alone. Matches the legacy SQL contract (callers like Terraform
+		// rely on partial updates not wiping omitted users).
+		applied := make(map[string]bool, len(desired))
+		newMembers := make([]iamv0.TeamTeamMember, 0, len(t.Spec.Members)+len(desired))
+		for _, m := range t.Spec.Members {
+			if m.Kind != subjectKindUser || m.External {
+				newMembers = append(newMembers, m)
+				continue
+			}
+			if perm, ok := desiredByUID[m.Name]; ok {
+				newMembers = append(newMembers, iamv0.TeamTeamMember{
+					Kind:       subjectKindUser,
+					Name:       m.Name,
+					Permission: perm,
+					External:   false,
+				})
+				applied[m.Name] = true
+				continue
+			}
+			newMembers = append(newMembers, m)
+		}
+		for _, d := range desired {
+			if applied[d.uid] {
+				continue
+			}
+			newMembers = append(newMembers, iamv0.TeamTeamMember{
+				Kind:       subjectKindUser,
+				Name:       d.uid,
+				Permission: d.permission,
+				External:   false,
+			})
+		}
+
+		if slices.Equal(t.Spec.Members, newMembers) {
+			return nil
+		}
+		t.Spec.Members = newMembers
+
+		updatedObj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&t)
+		if err != nil {
+			return fmt.Errorf("failed to encode team: %w", err)
+		}
+
+		if _, err := teamResource.Update(ctx, &unstructured.Unstructured{Object: updatedObj}, metav1.UpdateOptions{}); err != nil {
+			return fmt.Errorf("failed to update team members: %w", err)
+		}
+		return nil
+	})
+}
+
 func stringToTeamMemberPermission(s string) (iamv0.TeamTeamPermission, error) {
 	switch strings.ToLower(s) {
 	case "admin":

--- a/pkg/services/accesscontrol/resourcepermissions/api_adapter_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api_adapter_test.go
@@ -1637,8 +1637,8 @@ func TestSetTeamMember(t *testing.T) {
 
 // TestSetTeamMembers tests the bulk set path that rewrites Team.Spec.Members.
 func TestSetTeamMembers(t *testing.T) {
-	testUser1 := &user.User{ID: 1, UID: "user-uid-1"}
-	testUser2 := &user.User{ID: 2, UID: "user-uid-2"}
+	signedInUser1 := &user.SignedInUser{UserID: 1, UserUID: "user-uid-1", OrgID: 1}
+	signedInUser2 := &user.SignedInUser{UserID: 2, UserUID: "user-uid-2", OrgID: 1}
 	testTeam := &team.TeamDTO{ID: 10, UID: "team-uid-1"}
 
 	makeTeamObj := func(t *testing.T, members ...iamv0.TeamTeamMember) *unstructured.Unstructured {
@@ -1680,8 +1680,8 @@ func TestSetTeamMembers(t *testing.T) {
 			},
 			userSvc: func() *usertest.MockService {
 				svc := &usertest.MockService{}
-				svc.On("GetByID", mock.Anything, &user.GetUserByIDQuery{ID: int64(1)}).Return(testUser1, nil)
-				svc.On("GetByID", mock.Anything, &user.GetUserByIDQuery{ID: int64(2)}).Return(testUser2, nil)
+				svc.On("GetSignedInUser", mock.Anything, &user.GetSignedInUserQuery{OrgID: 1, UserID: 1}).Return(signedInUser1, nil)
+				svc.On("GetSignedInUser", mock.Anything, &user.GetSignedInUserQuery{OrgID: 1, UserID: 2}).Return(signedInUser2, nil)
 				return svc
 			},
 			fakeResource: func(t *testing.T) *fakeResourceInterface {
@@ -1712,7 +1712,7 @@ func TestSetTeamMembers(t *testing.T) {
 			},
 			userSvc: func() *usertest.MockService {
 				svc := &usertest.MockService{}
-				svc.On("GetByID", mock.Anything, &user.GetUserByIDQuery{ID: int64(1)}).Return(testUser1, nil)
+				svc.On("GetSignedInUser", mock.Anything, &user.GetSignedInUserQuery{OrgID: 1, UserID: 1}).Return(signedInUser1, nil)
 				return svc
 			},
 			fakeResource: func(t *testing.T) *fakeResourceInterface {
@@ -1739,7 +1739,7 @@ func TestSetTeamMembers(t *testing.T) {
 			},
 			userSvc: func() *usertest.MockService {
 				svc := &usertest.MockService{}
-				svc.On("GetByID", mock.Anything, &user.GetUserByIDQuery{ID: int64(1)}).Return(testUser1, nil)
+				svc.On("GetSignedInUser", mock.Anything, &user.GetSignedInUserQuery{OrgID: 1, UserID: 1}).Return(signedInUser1, nil)
 				return svc
 			},
 			fakeResource: func(t *testing.T) *fakeResourceInterface {
@@ -1791,7 +1791,7 @@ func TestSetTeamMembers(t *testing.T) {
 			},
 			userSvc: func() *usertest.MockService {
 				svc := &usertest.MockService{}
-				svc.On("GetByID", mock.Anything, &user.GetUserByIDQuery{ID: int64(1)}).Return(testUser1, nil)
+				svc.On("GetSignedInUser", mock.Anything, &user.GetSignedInUserQuery{OrgID: 1, UserID: 1}).Return(signedInUser1, nil)
 				return svc
 			},
 			fakeResource: func(t *testing.T) *fakeResourceInterface {
@@ -1814,7 +1814,7 @@ func TestSetTeamMembers(t *testing.T) {
 			},
 			userSvc: func() *usertest.MockService {
 				svc := &usertest.MockService{}
-				svc.On("GetByID", mock.Anything, &user.GetUserByIDQuery{ID: int64(1)}).Return(testUser1, nil)
+				svc.On("GetSignedInUser", mock.Anything, &user.GetSignedInUserQuery{OrgID: 1, UserID: 1}).Return(signedInUser1, nil)
 				return svc
 			},
 			fakeResource: func(t *testing.T) *fakeResourceInterface {
@@ -1858,7 +1858,7 @@ func TestSetTeamMembers(t *testing.T) {
 			},
 			userSvc: func() *usertest.MockService {
 				svc := &usertest.MockService{}
-				svc.On("GetByID", mock.Anything, &user.GetUserByIDQuery{ID: int64(1)}).Return(testUser1, nil)
+				svc.On("GetSignedInUser", mock.Anything, &user.GetSignedInUserQuery{OrgID: 1, UserID: 1}).Return(signedInUser1, nil)
 				return svc
 			},
 			fakeResource: func(t *testing.T) *fakeResourceInterface {
@@ -1879,7 +1879,7 @@ func TestSetTeamMembers(t *testing.T) {
 			},
 			userSvc: func() *usertest.MockService {
 				svc := &usertest.MockService{}
-				svc.On("GetByID", mock.Anything, &user.GetUserByIDQuery{ID: int64(1)}).Return(testUser1, nil)
+				svc.On("GetSignedInUser", mock.Anything, &user.GetSignedInUserQuery{OrgID: 1, UserID: 1}).Return(signedInUser1, nil)
 				return svc
 			},
 			fakeResource: func(t *testing.T) *fakeResourceInterface {
@@ -1910,7 +1910,7 @@ func TestSetTeamMembers(t *testing.T) {
 			},
 			userSvc: func() *usertest.MockService {
 				svc := &usertest.MockService{}
-				svc.On("GetByID", mock.Anything, &user.GetUserByIDQuery{ID: int64(1)}).Return(testUser1, nil)
+				svc.On("GetSignedInUser", mock.Anything, &user.GetSignedInUserQuery{OrgID: 1, UserID: 1}).Return(signedInUser1, nil)
 				return svc
 			},
 			fakeResource: func(_ *testing.T) *fakeResourceInterface {
@@ -1926,8 +1926,8 @@ func TestSetTeamMembers(t *testing.T) {
 			},
 			userSvc: func() *usertest.MockService {
 				svc := &usertest.MockService{}
-				svc.On("GetByID", mock.Anything, &user.GetUserByIDQuery{ID: int64(1)}).Return(testUser1, nil)
-				svc.On("GetByID", mock.Anything, &user.GetUserByIDQuery{ID: int64(999)}).Return(nil, fmt.Errorf("user not found"))
+				svc.On("GetSignedInUser", mock.Anything, &user.GetSignedInUserQuery{OrgID: 1, UserID: 1}).Return(signedInUser1, nil)
+				svc.On("GetSignedInUser", mock.Anything, &user.GetSignedInUserQuery{OrgID: 1, UserID: 999}).Return(nil, fmt.Errorf("user not found"))
 				return svc
 			},
 			fakeResource: func(_ *testing.T) *fakeResourceInterface {
@@ -1940,13 +1940,33 @@ func TestSetTeamMembers(t *testing.T) {
 			},
 		},
 		{
+			name: "rejects cross-org user (GetSignedInUser returns ErrUserNotFound)",
+			permissions: []accesscontrol.SetResourcePermissionCommand{
+				{UserID: 42, Permission: "Admin"},
+			},
+			userSvc: func() *usertest.MockService {
+				svc := &usertest.MockService{}
+				// User exists globally but not in org 1; GetSignedInUser returns ErrUserNotFound.
+				svc.On("GetSignedInUser", mock.Anything, &user.GetSignedInUserQuery{OrgID: 1, UserID: 42}).Return(nil, user.ErrUserNotFound)
+				return svc
+			},
+			fakeResource: func(_ *testing.T) *fakeResourceInterface {
+				return &fakeResourceInterface{}
+			},
+			expectedErrMsg: "failed to get user details",
+			validateCalls: func(t *testing.T, getCalls, updateCalls int) {
+				assert.Equal(t, 0, getCalls, "team Get must not run when target user is not in the org")
+				assert.Equal(t, 0, updateCalls, "Spec.Members must not be written for cross-org user IDs")
+			},
+		},
+		{
 			name: "no Update when desired set matches existing with interleaved external members",
 			permissions: []accesscontrol.SetResourcePermissionCommand{
 				{UserID: 1, Permission: "Admin"},
 			},
 			userSvc: func() *usertest.MockService {
 				svc := &usertest.MockService{}
-				svc.On("GetByID", mock.Anything, &user.GetUserByIDQuery{ID: int64(1)}).Return(testUser1, nil)
+				svc.On("GetSignedInUser", mock.Anything, &user.GetSignedInUserQuery{OrgID: 1, UserID: 1}).Return(signedInUser1, nil)
 				return svc
 			},
 			fakeResource: func(t *testing.T) *fakeResourceInterface {

--- a/pkg/services/accesscontrol/resourcepermissions/api_adapter_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api_adapter_test.go
@@ -1635,6 +1635,399 @@ func TestSetTeamMember(t *testing.T) {
 	}
 }
 
+// TestSetTeamMembers tests the bulk set path that rewrites Team.Spec.Members.
+func TestSetTeamMembers(t *testing.T) {
+	testUser1 := &user.User{ID: 1, UID: "user-uid-1"}
+	testUser2 := &user.User{ID: 2, UID: "user-uid-2"}
+	testTeam := &team.TeamDTO{ID: 10, UID: "team-uid-1"}
+
+	makeTeamObj := func(t *testing.T, members ...iamv0.TeamTeamMember) *unstructured.Unstructured {
+		t.Helper()
+		teamObj := iamv0.Team{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: iamv0.TeamResourceInfo.GroupVersion().String(),
+				Kind:       iamv0.TeamResourceInfo.TypeMeta().Kind,
+			},
+			ObjectMeta: metav1.ObjectMeta{Name: "team-uid-1", Namespace: "stacks-123-org-1", ResourceVersion: "42"},
+			Spec:       iamv0.TeamSpec{Members: members},
+		}
+		obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&teamObj)
+		require.NoError(t, err)
+		return &unstructured.Unstructured{Object: obj}
+	}
+	decodeMembers := func(t *testing.T, obj *unstructured.Unstructured) []iamv0.TeamTeamMember {
+		t.Helper()
+		var decoded iamv0.Team
+		require.NoError(t, runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &decoded))
+		return decoded.Spec.Members
+	}
+
+	tests := []struct {
+		name            string
+		permissions     []accesscontrol.SetResourcePermissionCommand
+		userSvc         func() *usertest.MockService
+		fakeResource    func(t *testing.T) *fakeResourceInterface
+		expectedErrMsg  string
+		expectUpdate    bool
+		validateMembers func(t *testing.T, members []iamv0.TeamTeamMember)
+		validateCalls   func(t *testing.T, getCalls, updateCalls int)
+	}{
+		{
+			name: "upserts desired users without dropping omitted ones",
+			permissions: []accesscontrol.SetResourcePermissionCommand{
+				{UserID: 1, Permission: "Admin"},
+				{UserID: 2, Permission: "Member"},
+			},
+			userSvc: func() *usertest.MockService {
+				svc := &usertest.MockService{}
+				svc.On("GetByID", mock.Anything, &user.GetUserByIDQuery{ID: int64(1)}).Return(testUser1, nil)
+				svc.On("GetByID", mock.Anything, &user.GetUserByIDQuery{ID: int64(2)}).Return(testUser2, nil)
+				return svc
+			},
+			fakeResource: func(t *testing.T) *fakeResourceInterface {
+				return &fakeResourceInterface{
+					getFunc: func(_ context.Context, _ string, _ metav1.GetOptions, _ ...string) (*unstructured.Unstructured, error) {
+						return makeTeamObj(t, iamv0.TeamTeamMember{Kind: "User", Name: "old-user", Permission: iamv0.TeamTeamPermissionMember}), nil
+					},
+					updateFunc: func(_ context.Context, obj *unstructured.Unstructured, _ metav1.UpdateOptions, _ ...string) (*unstructured.Unstructured, error) {
+						return obj, nil
+					},
+				}
+			},
+			expectUpdate: true,
+			validateMembers: func(t *testing.T, members []iamv0.TeamTeamMember) {
+				require.Len(t, members, 3, "old-user not in cmd must remain")
+				assert.Equal(t, "old-user", members[0].Name)
+				assert.Equal(t, iamv0.TeamTeamPermissionMember, members[0].Permission)
+				assert.Equal(t, "user-uid-1", members[1].Name)
+				assert.Equal(t, iamv0.TeamTeamPermissionAdmin, members[1].Permission)
+				assert.Equal(t, "user-uid-2", members[2].Name)
+				assert.Equal(t, iamv0.TeamTeamPermissionMember, members[2].Permission)
+			},
+		},
+		{
+			name: "updates existing user's permission in place",
+			permissions: []accesscontrol.SetResourcePermissionCommand{
+				{UserID: 1, Permission: "Admin"},
+			},
+			userSvc: func() *usertest.MockService {
+				svc := &usertest.MockService{}
+				svc.On("GetByID", mock.Anything, &user.GetUserByIDQuery{ID: int64(1)}).Return(testUser1, nil)
+				return svc
+			},
+			fakeResource: func(t *testing.T) *fakeResourceInterface {
+				return &fakeResourceInterface{
+					getFunc: func(_ context.Context, _ string, _ metav1.GetOptions, _ ...string) (*unstructured.Unstructured, error) {
+						return makeTeamObj(t, iamv0.TeamTeamMember{Kind: "User", Name: "user-uid-1", Permission: iamv0.TeamTeamPermissionMember}), nil
+					},
+					updateFunc: func(_ context.Context, obj *unstructured.Unstructured, _ metav1.UpdateOptions, _ ...string) (*unstructured.Unstructured, error) {
+						return obj, nil
+					},
+				}
+			},
+			expectUpdate: true,
+			validateMembers: func(t *testing.T, members []iamv0.TeamTeamMember) {
+				require.Len(t, members, 1)
+				assert.Equal(t, "user-uid-1", members[0].Name)
+				assert.Equal(t, iamv0.TeamTeamPermissionAdmin, members[0].Permission)
+			},
+		},
+		{
+			name: "preserves external and unrelated existing members",
+			permissions: []accesscontrol.SetResourcePermissionCommand{
+				{UserID: 1, Permission: "Admin"},
+			},
+			userSvc: func() *usertest.MockService {
+				svc := &usertest.MockService{}
+				svc.On("GetByID", mock.Anything, &user.GetUserByIDQuery{ID: int64(1)}).Return(testUser1, nil)
+				return svc
+			},
+			fakeResource: func(t *testing.T) *fakeResourceInterface {
+				return &fakeResourceInterface{
+					getFunc: func(_ context.Context, _ string, _ metav1.GetOptions, _ ...string) (*unstructured.Unstructured, error) {
+						return makeTeamObj(t,
+							iamv0.TeamTeamMember{Kind: "User", Name: "ext-user", Permission: iamv0.TeamTeamPermissionMember, External: true},
+							iamv0.TeamTeamMember{Kind: "User", Name: "old-user", Permission: iamv0.TeamTeamPermissionMember},
+						), nil
+					},
+					updateFunc: func(_ context.Context, obj *unstructured.Unstructured, _ metav1.UpdateOptions, _ ...string) (*unstructured.Unstructured, error) {
+						return obj, nil
+					},
+				}
+			},
+			expectUpdate: true,
+			validateMembers: func(t *testing.T, members []iamv0.TeamTeamMember) {
+				require.Len(t, members, 3)
+				assert.Equal(t, "ext-user", members[0].Name)
+				assert.True(t, members[0].External)
+				assert.Equal(t, "old-user", members[1].Name)
+				assert.False(t, members[1].External)
+				assert.Equal(t, "user-uid-1", members[2].Name)
+				assert.False(t, members[2].External)
+			},
+		},
+		{
+			name:        "empty permissions is a no-op",
+			permissions: nil,
+			userSvc:     func() *usertest.MockService { return &usertest.MockService{} },
+			fakeResource: func(t *testing.T) *fakeResourceInterface {
+				return &fakeResourceInterface{
+					getFunc: func(_ context.Context, _ string, _ metav1.GetOptions, _ ...string) (*unstructured.Unstructured, error) {
+						return makeTeamObj(t,
+							iamv0.TeamTeamMember{Kind: "User", Name: "ext-user", Permission: iamv0.TeamTeamPermissionMember, External: true},
+							iamv0.TeamTeamMember{Kind: "User", Name: "old-user", Permission: iamv0.TeamTeamPermissionMember},
+						), nil
+					},
+				}
+			},
+			validateCalls: func(t *testing.T, _, updateCalls int) {
+				assert.Equal(t, 0, updateCalls, "upsert with no entries should not write")
+			},
+		},
+		{
+			name: "rejects when targeting an external member",
+			permissions: []accesscontrol.SetResourcePermissionCommand{
+				{UserID: 1, Permission: "Admin"},
+			},
+			userSvc: func() *usertest.MockService {
+				svc := &usertest.MockService{}
+				svc.On("GetByID", mock.Anything, &user.GetUserByIDQuery{ID: int64(1)}).Return(testUser1, nil)
+				return svc
+			},
+			fakeResource: func(t *testing.T) *fakeResourceInterface {
+				return &fakeResourceInterface{
+					getFunc: func(_ context.Context, _ string, _ metav1.GetOptions, _ ...string) (*unstructured.Unstructured, error) {
+						return makeTeamObj(t, iamv0.TeamTeamMember{Kind: "User", Name: "user-uid-1", Permission: iamv0.TeamTeamPermissionMember, External: true}), nil
+					},
+				}
+			},
+			expectedErrMsg: "externally-synced",
+			validateCalls: func(t *testing.T, _, updateCalls int) {
+				assert.Equal(t, 0, updateCalls)
+			},
+		},
+		{
+			name: "skips entries with empty permission",
+			permissions: []accesscontrol.SetResourcePermissionCommand{
+				{UserID: 1, Permission: "Admin"},
+				{UserID: 2, Permission: ""},
+			},
+			userSvc: func() *usertest.MockService {
+				svc := &usertest.MockService{}
+				svc.On("GetByID", mock.Anything, &user.GetUserByIDQuery{ID: int64(1)}).Return(testUser1, nil)
+				return svc
+			},
+			fakeResource: func(t *testing.T) *fakeResourceInterface {
+				return &fakeResourceInterface{
+					getFunc: func(_ context.Context, _ string, _ metav1.GetOptions, _ ...string) (*unstructured.Unstructured, error) {
+						return makeTeamObj(t), nil
+					},
+					updateFunc: func(_ context.Context, obj *unstructured.Unstructured, _ metav1.UpdateOptions, _ ...string) (*unstructured.Unstructured, error) {
+						return obj, nil
+					},
+				}
+			},
+			expectUpdate: true,
+			validateMembers: func(t *testing.T, members []iamv0.TeamTeamMember) {
+				require.Len(t, members, 1)
+				assert.Equal(t, "user-uid-1", members[0].Name)
+			},
+		},
+		{
+			name: "ignores non-user entries (team/builtin) and leaves existing alone",
+			permissions: []accesscontrol.SetResourcePermissionCommand{
+				{TeamID: 99, Permission: "Admin"},
+				{BuiltinRole: "Editor", Permission: "Admin"},
+			},
+			userSvc: func() *usertest.MockService { return &usertest.MockService{} },
+			fakeResource: func(t *testing.T) *fakeResourceInterface {
+				return &fakeResourceInterface{
+					getFunc: func(_ context.Context, _ string, _ metav1.GetOptions, _ ...string) (*unstructured.Unstructured, error) {
+						return makeTeamObj(t, iamv0.TeamTeamMember{Kind: "User", Name: "old-user", Permission: iamv0.TeamTeamPermissionMember}), nil
+					},
+				}
+			},
+			validateCalls: func(t *testing.T, _, updateCalls int) {
+				assert.Equal(t, 0, updateCalls, "non-user entries produce no user desired set, so no Update")
+			},
+		},
+		{
+			name: "no Update when desired set matches existing",
+			permissions: []accesscontrol.SetResourcePermissionCommand{
+				{UserID: 1, Permission: "Admin"},
+			},
+			userSvc: func() *usertest.MockService {
+				svc := &usertest.MockService{}
+				svc.On("GetByID", mock.Anything, &user.GetUserByIDQuery{ID: int64(1)}).Return(testUser1, nil)
+				return svc
+			},
+			fakeResource: func(t *testing.T) *fakeResourceInterface {
+				return &fakeResourceInterface{
+					getFunc: func(_ context.Context, _ string, _ metav1.GetOptions, _ ...string) (*unstructured.Unstructured, error) {
+						return makeTeamObj(t, iamv0.TeamTeamMember{Kind: "User", Name: "user-uid-1", Permission: iamv0.TeamTeamPermissionAdmin}), nil
+					},
+				}
+			},
+			validateCalls: func(t *testing.T, _, updateCalls int) {
+				assert.Equal(t, 0, updateCalls)
+			},
+		},
+		{
+			name: "retries on conflict and succeeds",
+			permissions: []accesscontrol.SetResourcePermissionCommand{
+				{UserID: 1, Permission: "Admin"},
+			},
+			userSvc: func() *usertest.MockService {
+				svc := &usertest.MockService{}
+				svc.On("GetByID", mock.Anything, &user.GetUserByIDQuery{ID: int64(1)}).Return(testUser1, nil)
+				return svc
+			},
+			fakeResource: func(t *testing.T) *fakeResourceInterface {
+				updates := 0
+				return &fakeResourceInterface{
+					getFunc: func(_ context.Context, _ string, _ metav1.GetOptions, _ ...string) (*unstructured.Unstructured, error) {
+						return makeTeamObj(t), nil
+					},
+					updateFunc: func(_ context.Context, obj *unstructured.Unstructured, _ metav1.UpdateOptions, _ ...string) (*unstructured.Unstructured, error) {
+						updates++
+						if updates == 1 {
+							return nil, k8serrors.NewConflict(schema.GroupResource{}, "team-uid-1", fmt.Errorf("conflict"))
+						}
+						return obj, nil
+					},
+				}
+			},
+			expectUpdate: true,
+			validateCalls: func(t *testing.T, getCalls, updateCalls int) {
+				assert.Equal(t, 2, getCalls)
+				assert.Equal(t, 2, updateCalls)
+			},
+		},
+		{
+			name: "returns error for unsupported permission",
+			permissions: []accesscontrol.SetResourcePermissionCommand{
+				{UserID: 1, Permission: "Bogus"},
+			},
+			userSvc: func() *usertest.MockService {
+				svc := &usertest.MockService{}
+				svc.On("GetByID", mock.Anything, &user.GetUserByIDQuery{ID: int64(1)}).Return(testUser1, nil)
+				return svc
+			},
+			fakeResource: func(_ *testing.T) *fakeResourceInterface {
+				return &fakeResourceInterface{}
+			},
+			expectedErrMsg: "unsupported team permission",
+		},
+		{
+			name: "fails before any k8s call when user lookup errors",
+			permissions: []accesscontrol.SetResourcePermissionCommand{
+				{UserID: 1, Permission: "Admin"},
+				{UserID: 999, Permission: "Admin"},
+			},
+			userSvc: func() *usertest.MockService {
+				svc := &usertest.MockService{}
+				svc.On("GetByID", mock.Anything, &user.GetUserByIDQuery{ID: int64(1)}).Return(testUser1, nil)
+				svc.On("GetByID", mock.Anything, &user.GetUserByIDQuery{ID: int64(999)}).Return(nil, fmt.Errorf("user not found"))
+				return svc
+			},
+			fakeResource: func(_ *testing.T) *fakeResourceInterface {
+				return &fakeResourceInterface{}
+			},
+			expectedErrMsg: "failed to get user details",
+			validateCalls: func(t *testing.T, getCalls, updateCalls int) {
+				assert.Equal(t, 0, getCalls, "team Get should not be called when user lookup fails")
+				assert.Equal(t, 0, updateCalls)
+			},
+		},
+		{
+			name: "no Update when desired set matches existing with interleaved external members",
+			permissions: []accesscontrol.SetResourcePermissionCommand{
+				{UserID: 1, Permission: "Admin"},
+			},
+			userSvc: func() *usertest.MockService {
+				svc := &usertest.MockService{}
+				svc.On("GetByID", mock.Anything, &user.GetUserByIDQuery{ID: int64(1)}).Return(testUser1, nil)
+				return svc
+			},
+			fakeResource: func(t *testing.T) *fakeResourceInterface {
+				return &fakeResourceInterface{
+					getFunc: func(_ context.Context, _ string, _ metav1.GetOptions, _ ...string) (*unstructured.Unstructured, error) {
+						return makeTeamObj(t,
+							iamv0.TeamTeamMember{Kind: "User", Name: "user-uid-1", Permission: iamv0.TeamTeamPermissionAdmin},
+							iamv0.TeamTeamMember{Kind: "User", Name: "ext-user", Permission: iamv0.TeamTeamPermissionMember, External: true},
+						), nil
+					},
+				}
+			},
+			validateCalls: func(t *testing.T, _, updateCalls int) {
+				assert.Equal(t, 0, updateCalls, "position-preserving rebuild must produce a slice equal to the input when nothing changed")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var (
+				lastUpdated *unstructured.Unstructured
+				getCalls    int
+				updateCalls int
+			)
+			fr := tt.fakeResource(t)
+			if fr.getFunc != nil {
+				origGet := fr.getFunc
+				fr.getFunc = func(ctx context.Context, name string, opts metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+					getCalls++
+					return origGet(ctx, name, opts, subresources...)
+				}
+			}
+			if fr.updateFunc != nil {
+				origUpdate := fr.updateFunc
+				fr.updateFunc = func(ctx context.Context, obj *unstructured.Unstructured, opts metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+					updateCalls++
+					lastUpdated = obj
+					return origUpdate(ctx, obj, opts, subresources...)
+				}
+			}
+			fakeClient := &fakeDynamicClient{resourceInterface: fr}
+
+			testApi := &api{
+				cfg:    &setting.Cfg{},
+				logger: log.New("test"),
+				service: &Service{
+					store:       &mockResourcePermissionStore{},
+					teamService: teamtest.NewFakeServiceWithTeamDTO(testTeam),
+					userService: tt.userSvc(),
+					options:     Options{Resource: "teams"},
+				},
+			}
+
+			err := testApi.setTeamMembers(makeReqCtx(), fakeClient, "stacks-123-org-1", "10", tt.permissions)
+
+			if tt.expectedErrMsg != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErrMsg)
+				if tt.validateCalls != nil {
+					tt.validateCalls(t, getCalls, updateCalls)
+				}
+				return
+			}
+			require.NoError(t, err)
+
+			if tt.expectUpdate {
+				require.NotNil(t, lastUpdated, "expected an Update call")
+				if tt.validateMembers != nil {
+					tt.validateMembers(t, decodeMembers(t, lastUpdated))
+				}
+			} else {
+				assert.Nil(t, lastUpdated, "expected no Update call")
+			}
+			if tt.validateCalls != nil {
+				tt.validateCalls(t, getCalls, updateCalls)
+			}
+		})
+	}
+}
+
 // TestTeamMemberWrappers_RestConfigNotAvailable tests that both wrappers return
 // ErrRestConfigNotAvailable when no rest config provider is set, so the caller (api.go)
 // can stop the operation and return the error.
@@ -1654,6 +2047,12 @@ func TestTeamMemberWrappers_RestConfigNotAvailable(t *testing.T) {
 			call: func(a *api) error {
 				_, err := a.getTeamPermissionsFromMembers(makeReqCtx(), "stacks-123-org-1", "10")
 				return err
+			},
+		},
+		{
+			name: "setTeamPermissionsInTeamMembers",
+			call: func(a *api) error {
+				return a.setTeamPermissionsInTeamMembers(makeReqCtx(), "stacks-123-org-1", "10", nil)
 			},
 		},
 	}

--- a/pkg/services/accesscontrol/resourcepermissions/api_adapter_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api_adapter_test.go
@@ -1807,7 +1807,7 @@ func TestSetTeamMembers(t *testing.T) {
 			},
 		},
 		{
-			name: "skips entries with empty permission",
+			name: "removes existing member when permission is empty",
 			permissions: []accesscontrol.SetResourcePermissionCommand{
 				{UserID: 1, Permission: "Admin"},
 				{UserID: 2, Permission: ""},
@@ -1815,12 +1815,15 @@ func TestSetTeamMembers(t *testing.T) {
 			userSvc: func() *usertest.MockService {
 				svc := &usertest.MockService{}
 				svc.On("GetSignedInUser", mock.Anything, &user.GetSignedInUserQuery{OrgID: 1, UserID: 1}).Return(signedInUser1, nil)
+				svc.On("GetSignedInUser", mock.Anything, &user.GetSignedInUserQuery{OrgID: 1, UserID: 2}).Return(signedInUser2, nil)
 				return svc
 			},
 			fakeResource: func(t *testing.T) *fakeResourceInterface {
 				return &fakeResourceInterface{
 					getFunc: func(_ context.Context, _ string, _ metav1.GetOptions, _ ...string) (*unstructured.Unstructured, error) {
-						return makeTeamObj(t), nil
+						return makeTeamObj(t,
+							iamv0.TeamTeamMember{Kind: "User", Name: "user-uid-2", Permission: iamv0.TeamTeamPermissionMember},
+						), nil
 					},
 					updateFunc: func(_ context.Context, obj *unstructured.Unstructured, _ metav1.UpdateOptions, _ ...string) (*unstructured.Unstructured, error) {
 						return obj, nil
@@ -1831,6 +1834,50 @@ func TestSetTeamMembers(t *testing.T) {
 			validateMembers: func(t *testing.T, members []iamv0.TeamTeamMember) {
 				require.Len(t, members, 1)
 				assert.Equal(t, "user-uid-1", members[0].Name)
+				assert.Equal(t, iamv0.TeamTeamPermissionAdmin, members[0].Permission)
+			},
+		},
+		{
+			name: "no Update when removing a non-member",
+			permissions: []accesscontrol.SetResourcePermissionCommand{
+				{UserID: 2, Permission: ""},
+			},
+			userSvc: func() *usertest.MockService {
+				svc := &usertest.MockService{}
+				svc.On("GetSignedInUser", mock.Anything, &user.GetSignedInUserQuery{OrgID: 1, UserID: 2}).Return(signedInUser2, nil)
+				return svc
+			},
+			fakeResource: func(t *testing.T) *fakeResourceInterface {
+				return &fakeResourceInterface{
+					getFunc: func(_ context.Context, _ string, _ metav1.GetOptions, _ ...string) (*unstructured.Unstructured, error) {
+						return makeTeamObj(t, iamv0.TeamTeamMember{Kind: "User", Name: "user-uid-1", Permission: iamv0.TeamTeamPermissionAdmin}), nil
+					},
+				}
+			},
+			validateCalls: func(t *testing.T, _, updateCalls int) {
+				assert.Equal(t, 0, updateCalls, "removing a non-member leaves Spec.Members unchanged, so no Update")
+			},
+		},
+		{
+			name: "rejects when removal targets an external member",
+			permissions: []accesscontrol.SetResourcePermissionCommand{
+				{UserID: 1, Permission: ""},
+			},
+			userSvc: func() *usertest.MockService {
+				svc := &usertest.MockService{}
+				svc.On("GetSignedInUser", mock.Anything, &user.GetSignedInUserQuery{OrgID: 1, UserID: 1}).Return(signedInUser1, nil)
+				return svc
+			},
+			fakeResource: func(t *testing.T) *fakeResourceInterface {
+				return &fakeResourceInterface{
+					getFunc: func(_ context.Context, _ string, _ metav1.GetOptions, _ ...string) (*unstructured.Unstructured, error) {
+						return makeTeamObj(t, iamv0.TeamTeamMember{Kind: "User", Name: "user-uid-1", Permission: iamv0.TeamTeamPermissionMember, External: true}), nil
+					},
+				}
+			},
+			expectedErrMsg: "externally-synced",
+			validateCalls: func(t *testing.T, _, updateCalls int) {
+				assert.Equal(t, 0, updateCalls)
 			},
 		},
 		{

--- a/pkg/services/accesscontrol/resourcepermissions/api_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api_test.go
@@ -602,6 +602,70 @@ func TestIntegrationApi_setUserPermissionForTeams(t *testing.T) {
 	}
 }
 
+func TestIntegrationApi_setBulkPermissionsForTeams(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	type bulkTestCase struct {
+		desc           string
+		permissions    []accesscontrol.Permission
+		body           string
+		expectedStatus int
+		expectedCount  int
+		teamCmd        *team.CreateTeamCommand
+	}
+	tests := []bulkTestCase{
+		{
+			desc:           "should set Member and Admin permissions for two users",
+			expectedStatus: http.StatusOK,
+			expectedCount:  2,
+			permissions: []accesscontrol.Permission{
+				{Action: "teams.permissions:read", Scope: accesscontrol.ScopeTeamsAll},
+				{Action: "teams.permissions:write", Scope: accesscontrol.ScopeTeamsAll},
+				{Action: accesscontrol.ActionOrgUsersRead, Scope: accesscontrol.ScopeUsersAll},
+			},
+			teamCmd: &team.CreateTeamCommand{Name: "test", Email: "test@test.com", OrgID: 1},
+		},
+		{
+			desc:           "should return status 400 for a provisioned team",
+			expectedStatus: http.StatusBadRequest,
+			permissions: []accesscontrol.Permission{
+				{Action: "teams.permissions:read", Scope: accesscontrol.ScopeTeamsAll},
+				{Action: "teams.permissions:write", Scope: accesscontrol.ScopeTeamsAll},
+				{Action: accesscontrol.ActionOrgUsersRead, Scope: accesscontrol.ScopeUsersAll},
+			},
+			teamCmd: &team.CreateTeamCommand{Name: "test", Email: "test@test.com", OrgID: 1, IsProvisioned: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			service, usrSvc, teamSvc := setupTestEnvironment(t, testOptionsForTeams)
+			server := setupTestServer(t, &user.SignedInUser{
+				OrgID:       1,
+				Permissions: map[int64]map[string][]string{1: accesscontrol.GroupScopesByActionContext(context.Background(), tt.permissions)},
+			}, service)
+
+			u1, err := usrSvc.Create(context.Background(), &user.CreateUserCommand{Login: "user1", OrgID: 1})
+			require.NoError(t, err)
+			u2, err := usrSvc.Create(context.Background(), &user.CreateUserCommand{Login: "user2", OrgID: 1})
+			require.NoError(t, err)
+
+			expectedTeam, err := teamSvc.CreateTeam(context.Background(), tt.teamCmd)
+			require.NoError(t, err)
+			resourceID := strconv.Itoa(int(expectedTeam.ID))
+
+			body := fmt.Sprintf(`{"permissions":[{"userId":%d,"permission":"Member"},{"userId":%d,"permission":"Admin"}]}`, u1.ID, u2.ID)
+			recorder := setBulkPermissions(t, server, testOptionsForTeams.Resource, resourceID, body)
+			assert.Equal(t, tt.expectedStatus, recorder.Code)
+
+			if tt.expectedStatus == http.StatusOK {
+				permissions, _ := getPermission(t, server, testOptionsForTeams.Resource, resourceID)
+				require.Len(t, permissions, tt.expectedCount)
+			}
+		})
+	}
+}
+
 func setupTestServer(t *testing.T, user *user.SignedInUser, service *Service) *web.Mux {
 	server := web.New()
 	server.UseMiddleware(web.Renderer("views", "[[", "]]"))
@@ -675,6 +739,15 @@ func setPermission(t *testing.T, server *web.Mux, resource, resourceID, permissi
 	recorder := httptest.NewRecorder()
 	server.ServeHTTP(recorder, req)
 
+	return recorder
+}
+
+func setBulkPermissions(t *testing.T, server *web.Mux, resource, resourceID, body string) *httptest.ResponseRecorder {
+	req, err := http.NewRequest(http.MethodPost, fmt.Sprintf("/api/access-control/%s/%s", resource, resourceID), strings.NewReader(body))
+	require.NoError(t, err)
+	req.Header.Set("Content-Type", "application/json")
+	recorder := httptest.NewRecorder()
+	server.ServeHTTP(recorder, req)
 	return recorder
 }
 

--- a/pkg/services/accesscontrol/resourcepermissions/api_test.go
+++ b/pkg/services/accesscontrol/resourcepermissions/api_test.go
@@ -608,7 +608,6 @@ func TestIntegrationApi_setBulkPermissionsForTeams(t *testing.T) {
 	type bulkTestCase struct {
 		desc           string
 		permissions    []accesscontrol.Permission
-		body           string
 		expectedStatus int
 		expectedCount  int
 		teamCmd        *team.CreateTeamCommand

--- a/pkg/tests/apis/iam/team/team_redirect_integration_test.go
+++ b/pkg/tests/apis/iam/team/team_redirect_integration_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	iamv0alpha1 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
@@ -497,6 +498,249 @@ func TestIntegrationServiceIdentityFallbackToLegacy(t *testing.T) {
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "config provider not initialized")
 	})
+}
+
+type resourcePermissionDTO struct {
+	UserID     int64  `json:"userId"`
+	UserUID    string `json:"userUid"`
+	UserLogin  string `json:"userLogin"`
+	Permission string `json:"permission"`
+	IsManaged  bool   `json:"isManaged"`
+}
+
+// go test -timeout 120s -run ^TestIntegrationResourcePermissionsBulkRedirect$ github.com/grafana/grafana/pkg/tests/apis/iam/team -count=1
+func TestIntegrationResourcePermissionsBulkRedirect(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	helper := setupTeamTestHelper(t)
+
+	adminID, err := helper.Org1.Admin.Identity.GetInternalID()
+	require.NoError(t, err)
+	editorID, err := helper.Org1.Editor.Identity.GetInternalID()
+	require.NoError(t, err)
+	viewerID, err := helper.Org1.Viewer.Identity.GetInternalID()
+	require.NoError(t, err)
+	viewerUID := helper.Org1.Viewer.Identity.GetRawIdentifier()
+
+	// Each subtest creates its own team for isolation, and we toggle the flag back
+	// to false on teardown so the next subtest starts from a known state.
+	newTeam := func(t *testing.T, name string) (int64, string) {
+		t.Helper()
+		setTeamK8sFeatureToggle(t, true)
+		teamID, teamUID := createTeamViaAPI(t, helper, name, name+"@example.com")
+		t.Cleanup(func() {
+			setTeamK8sFeatureToggle(t, false)
+			deleteTeamViaAPI(t, helper, teamID)
+		})
+		return teamID, teamUID
+	}
+
+	t.Run("bulk set persists to Team.Spec.Members", func(t *testing.T) {
+		teamID, teamUID := newTeam(t, "bulk-set-persist")
+
+		rec := setBulkResourcePermissions(t, helper, teamID, []ac.SetResourcePermissionCommand{
+			{UserID: adminID, Permission: "Admin"},
+			{UserID: editorID, Permission: "Member"},
+		})
+		require.Equal(t, http.StatusOK, rec.Response.StatusCode, "body=%s", string(rec.Body))
+
+		members := getTeamMembers(t, helper, teamUID)
+		require.Len(t, members, 2)
+		byName := teamMembersByName(members)
+		require.Contains(t, byName, helper.Org1.Admin.Identity.GetRawIdentifier())
+		require.Contains(t, byName, helper.Org1.Editor.Identity.GetRawIdentifier())
+		assert.Equal(t, "admin", string(byName[helper.Org1.Admin.Identity.GetRawIdentifier()].Permission))
+		assert.Equal(t, "member", string(byName[helper.Org1.Editor.Identity.GetRawIdentifier()].Permission))
+		assert.False(t, byName[helper.Org1.Admin.Identity.GetRawIdentifier()].External)
+
+		perms := getResourcePermissions(t, helper, teamID)
+		assert.Len(t, perms, 2)
+	})
+
+	t.Run("bulk write is upsert: omitted users stay", func(t *testing.T) {
+		teamID, teamUID := newTeam(t, "bulk-set-upsert")
+
+		rec := setBulkResourcePermissions(t, helper, teamID, []ac.SetResourcePermissionCommand{
+			{UserID: adminID, Permission: "Admin"},
+			{UserID: editorID, Permission: "Member"},
+		})
+		require.Equal(t, http.StatusOK, rec.Response.StatusCode)
+
+		// Second POST omits editor. Under upsert semantics editor stays.
+		rec = setBulkResourcePermissions(t, helper, teamID, []ac.SetResourcePermissionCommand{
+			{UserID: adminID, Permission: "Member"},
+		})
+		require.Equal(t, http.StatusOK, rec.Response.StatusCode)
+
+		members := getTeamMembers(t, helper, teamUID)
+		byName := teamMembersByName(members)
+		require.Contains(t, byName, helper.Org1.Admin.Identity.GetRawIdentifier(), "admin (in cmd) updated in place")
+		require.Contains(t, byName, helper.Org1.Editor.Identity.GetRawIdentifier(), "editor (omitted from cmd) must remain")
+		assert.Equal(t, "member", string(byName[helper.Org1.Admin.Identity.GetRawIdentifier()].Permission), "admin permission updated")
+		assert.Equal(t, "member", string(byName[helper.Org1.Editor.Identity.GetRawIdentifier()].Permission), "editor permission unchanged")
+	})
+
+	t.Run("external members preserved across bulk write", func(t *testing.T) {
+		teamID, teamUID := newTeam(t, "bulk-set-external-preserved")
+
+		injectExternalMember(t, helper, teamUID, viewerUID, "member")
+
+		rec := setBulkResourcePermissions(t, helper, teamID, []ac.SetResourcePermissionCommand{
+			{UserID: adminID, Permission: "Admin"},
+		})
+		require.Equal(t, http.StatusOK, rec.Response.StatusCode)
+
+		members := getTeamMembers(t, helper, teamUID)
+		require.Len(t, members, 2)
+		byName := teamMembersByName(members)
+		require.Contains(t, byName, viewerUID, "external viewer member should still be present")
+		require.Contains(t, byName, helper.Org1.Admin.Identity.GetRawIdentifier())
+		assert.True(t, byName[viewerUID].External)
+		assert.Equal(t, "member", string(byName[viewerUID].Permission))
+		assert.False(t, byName[helper.Org1.Admin.Identity.GetRawIdentifier()].External)
+	})
+
+	t.Run("targeting an external member returns 400", func(t *testing.T) {
+		teamID, teamUID := newTeam(t, "bulk-set-external-rejected")
+
+		injectExternalMember(t, helper, teamUID, viewerUID, "member")
+
+		rec := setBulkResourcePermissions(t, helper, teamID, []ac.SetResourcePermissionCommand{
+			{UserID: viewerID, Permission: "Admin"},
+		})
+		assert.Equal(t, http.StatusBadRequest, rec.Response.StatusCode)
+		assert.Contains(t, string(rec.Body), "externally-synced")
+
+		members := getTeamMembers(t, helper, teamUID)
+		byName := teamMembersByName(members)
+		require.Contains(t, byName, viewerUID, "external viewer should still be present after rejected bulk write")
+		assert.True(t, byName[viewerUID].External)
+		assert.Equal(t, "member", string(byName[viewerUID].Permission), "external member's permission must not be mutated")
+	})
+
+	t.Run("empty permissions is a no-op", func(t *testing.T) {
+		teamID, teamUID := newTeam(t, "bulk-set-empty")
+
+		rec := setBulkResourcePermissions(t, helper, teamID, []ac.SetResourcePermissionCommand{
+			{UserID: adminID, Permission: "Admin"},
+			{UserID: editorID, Permission: "Member"},
+		})
+		require.Equal(t, http.StatusOK, rec.Response.StatusCode)
+
+		injectExternalMember(t, helper, teamUID, viewerUID, "admin")
+
+		rec = setBulkResourcePermissions(t, helper, teamID, []ac.SetResourcePermissionCommand{})
+		require.Equal(t, http.StatusOK, rec.Response.StatusCode)
+
+		members := getTeamMembers(t, helper, teamUID)
+		byName := teamMembersByName(members)
+		require.Contains(t, byName, helper.Org1.Admin.Identity.GetRawIdentifier(), "admin must remain — empty POST does nothing")
+		require.Contains(t, byName, helper.Org1.Editor.Identity.GetRawIdentifier(), "editor must remain — empty POST does nothing")
+		require.Contains(t, byName, viewerUID, "external viewer must remain")
+	})
+
+	t.Run("bulk write is visible in legacy SQL via dual-write", func(t *testing.T) {
+		teamID, _ := newTeam(t, "bulk-set-dual-write")
+
+		rec := setBulkResourcePermissions(t, helper, teamID, []ac.SetResourcePermissionCommand{
+			{UserID: adminID, Permission: "Admin"},
+			{UserID: editorID, Permission: "Member"},
+		})
+		require.Equal(t, http.StatusOK, rec.Response.StatusCode)
+
+		// Flip the redirect off so the GET reads from legacy SQL. The dual-write
+		// path must have populated SQL too, otherwise this returns nothing.
+		setTeamK8sFeatureToggle(t, false)
+		perms := getResourcePermissions(t, helper, teamID)
+		assert.Len(t, perms, 2)
+	})
+}
+
+func setBulkResourcePermissions(t *testing.T, helper *apis.K8sTestHelper, teamID int64, items []ac.SetResourcePermissionCommand) apis.K8sResponse[struct{}] {
+	t.Helper()
+	body, err := json.Marshal(map[string]any{"permissions": items})
+	require.NoError(t, err)
+	return apis.DoRequest(helper, apis.RequestParams{
+		User:   helper.Org1.Admin,
+		Method: http.MethodPost,
+		Path:   fmt.Sprintf("/api/access-control/teams/%d", teamID),
+		Body:   body,
+	}, &struct{}{})
+}
+
+func getResourcePermissions(t *testing.T, helper *apis.K8sTestHelper, teamID int64) []resourcePermissionDTO {
+	t.Helper()
+	resp := apis.DoRequest(helper, apis.RequestParams{
+		User:   helper.Org1.Admin,
+		Method: http.MethodGet,
+		Path:   fmt.Sprintf("/api/access-control/teams/%d", teamID),
+	}, &[]resourcePermissionDTO{})
+	require.Equal(t, http.StatusOK, resp.Response.StatusCode, "body=%s", string(resp.Body))
+	return *resp.Result
+}
+
+func getTeamMembers(t *testing.T, helper *apis.K8sTestHelper, teamUID string) []iamv0alpha1.TeamTeamMember {
+	t.Helper()
+	teamClient := helper.GetResourceClient(apis.ResourceClientArgs{
+		User:      helper.Org1.Admin,
+		Namespace: helper.Namespacer(helper.Org1.Admin.Identity.GetOrgID()),
+		GVR:       gvrTeams,
+	})
+	obj, err := teamClient.Resource.Get(context.Background(), teamUID, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	rawMembers, _, err := unstructured.NestedSlice(obj.Object, "spec", "members")
+	require.NoError(t, err)
+
+	members := make([]iamv0alpha1.TeamTeamMember, 0, len(rawMembers))
+	for _, raw := range rawMembers {
+		m, ok := raw.(map[string]any)
+		require.True(t, ok)
+		external, _ := m["external"].(bool)
+		perm, _ := m["permission"].(string)
+		members = append(members, iamv0alpha1.TeamTeamMember{
+			Kind:       fmt.Sprint(m["kind"]),
+			Name:       fmt.Sprint(m["name"]),
+			Permission: iamv0alpha1.TeamTeamPermission(perm),
+			External:   external,
+		})
+	}
+	return members
+}
+
+func teamMembersByName(members []iamv0alpha1.TeamTeamMember) map[string]iamv0alpha1.TeamTeamMember {
+	m := make(map[string]iamv0alpha1.TeamTeamMember, len(members))
+	for _, member := range members {
+		m[member.Name] = member
+	}
+	return m
+}
+
+// injectExternalMember appends an external (team-sync owned) user to Team.Spec.Members
+// directly through the K8s dynamic client, bypassing the access-control handler.
+func injectExternalMember(t *testing.T, helper *apis.K8sTestHelper, teamUID, userUID, permission string) {
+	t.Helper()
+	teamClient := helper.GetResourceClient(apis.ResourceClientArgs{
+		User:      helper.Org1.Admin,
+		Namespace: helper.Namespacer(helper.Org1.Admin.Identity.GetOrgID()),
+		GVR:       gvrTeams,
+	})
+	ctx := context.Background()
+	obj, err := teamClient.Resource.Get(ctx, teamUID, metav1.GetOptions{})
+	require.NoError(t, err)
+
+	existing, _, err := unstructured.NestedSlice(obj.Object, "spec", "members")
+	require.NoError(t, err)
+	existing = append(existing, map[string]any{
+		"kind":       "User",
+		"name":       userUID,
+		"permission": permission,
+		"external":   true,
+	})
+	require.NoError(t, unstructured.SetNestedSlice(obj.Object, existing, "spec", "members"))
+
+	_, err = teamClient.Resource.Update(ctx, obj, metav1.UpdateOptions{})
+	require.NoError(t, err)
 }
 
 func searchTeamsViaAPI(t *testing.T, helper *apis.K8sTestHelper, params url.Values) team.SearchTeamQueryResult {

--- a/pkg/tests/apis/iam/team/team_redirect_integration_test.go
+++ b/pkg/tests/apis/iam/team/team_redirect_integration_test.go
@@ -639,6 +639,43 @@ func TestIntegrationResourcePermissionsBulkRedirect(t *testing.T) {
 		require.Contains(t, byName, viewerUID, "external viewer must remain")
 	})
 
+	t.Run("empty permission removes existing member", func(t *testing.T) {
+		teamID, teamUID := newTeam(t, "bulk-set-remove")
+
+		rec := setBulkResourcePermissions(t, helper, teamID, []ac.SetResourcePermissionCommand{
+			{UserID: adminID, Permission: "Admin"},
+			{UserID: editorID, Permission: "Member"},
+		})
+		require.Equal(t, http.StatusOK, rec.Response.StatusCode)
+
+		rec = setBulkResourcePermissions(t, helper, teamID, []ac.SetResourcePermissionCommand{
+			{UserID: editorID, Permission: ""},
+		})
+		require.Equal(t, http.StatusOK, rec.Response.StatusCode, "body=%s", string(rec.Body))
+
+		members := getTeamMembers(t, helper, teamUID)
+		byName := teamMembersByName(members)
+		require.Contains(t, byName, helper.Org1.Admin.Identity.GetRawIdentifier(), "admin (omitted from cmd) must remain")
+		require.NotContains(t, byName, helper.Org1.Editor.Identity.GetRawIdentifier(), "editor (empty permission) must be removed")
+	})
+
+	t.Run("removal targeting an external member returns 400", func(t *testing.T) {
+		teamID, teamUID := newTeam(t, "bulk-set-remove-external")
+
+		injectExternalMember(t, helper, teamUID, viewerUID, "member")
+
+		rec := setBulkResourcePermissions(t, helper, teamID, []ac.SetResourcePermissionCommand{
+			{UserID: viewerID, Permission: ""},
+		})
+		assert.Equal(t, http.StatusBadRequest, rec.Response.StatusCode)
+		assert.Contains(t, string(rec.Body), "externally-synced")
+
+		members := getTeamMembers(t, helper, teamUID)
+		byName := teamMembersByName(members)
+		require.Contains(t, byName, viewerUID, "external viewer should still be present after rejected removal")
+		assert.True(t, byName[viewerUID].External)
+	})
+
 	t.Run("bulk write is visible in legacy SQL via dual-write", func(t *testing.T) {
 		teamID, _ := newTeam(t, "bulk-set-dual-write")
 


### PR DESCRIPTION
**What is this feature?**

Aligns the bulk resource permissions endpoint (`POST /api/access-control/teams/{teamID}`) with the existing `Team.Spec.Members` redirect that already gates the GET path and the single-user write path. With `kubernetesTeamsRedirect` enabled and `resource=teams`, bulk writes now:

- Write user-permission grants to `Team.Spec.Members` via the K8s apiserver instead of the generic `ResourcePermission` CR.
- Fall through to the legacy SQL `service.SetPermissions` call (dual-write during migration), mirroring the single-user path.
- Use **upsert** semantics (users not named in the request are left alone), matching legacy SQL behavior that callers like Terraform depend on.
- **Empty permission removes the named user**, matching the legacy bulk path and the single-user redirect.
- Preserve external (team-sync owned) members; reject requests that target them (including removal) with 400.
- Reject writes to provisioned teams

**Why do we need this feature?**

Before this PR, the three resource-permissions endpoints for `resource=teams` disagreed about where K8s state lived:

| Endpoint | Pre-PR K8s target |
|---|---|
| GET | `Team.Spec.Members` |
| POST `.../users/{id}` | `Team.Spec.Members` (dual-write) |
| POST `.../{id}` (bulk) | generic `ResourcePermission` CR |

That meant a bulk write set permissions in a different K8s object than a subsequent GET read them from — silent divergence. This PR makes all three agree on `Team.Spec.Members` as the source of truth.

**Who is this feature for?**

External API consumers of the bulk access-control endpoint (Terraform provider, IaC scripts) during the IAM migration to K8s-backed team storage.

**Special notes for your reviewer:**

Behavior changes worth a deliberate read:

1. **Provisioned-team rejection on the bulk endpoint** is the only user-facing 400 that did not exist before this PR. The protection used to live in `RequestValidator` (ran on every endpoint), but #103623 moved it to `validateTeamResource` and called that only from `setUserPermission` — to unblock SCIM membership updates that go through `/api/teams/*`, a different code path. SCIM does not call the bulk access-control endpoint, so adding the check here closes a regression rather than affecting SCIM.

2. **Idempotent `OnSetUser` empty-permission hook** (`ossaccesscontrol/team.go`). To make bulk removal work end-to-end in dual-writer mode, the hook now tolerates `team.ErrTeamMemberNotFound` from `RemoveTeamMemberHook`. The dual-writer's `LegacyStore.Update` already deletes the `team_member` row before the legacy fallthrough's hook runs, so a 0-rows-affected error is expected. Side effect for the flag-off path: removing a user who was never on the team is now a 200 no-op instead of a 4xx error — standard idempotent DELETE semantics. Also fixes a latent same-shape bug in the single-user redirect's remove path (untested today).

Known divergences from legacy SQL that this PR does **not** fix (all pre-exist in the single-user redirect path):

- **Permission name case sensitivity**: legacy is case-sensitive (only `"Admin"` / `"Member"`); K8s accepts any casing. Single-user redirect has the same permissiveness.
- **Non-user cmd entries** (`teamId`, `builtInRole`) on `resource=teams`: legacy writes them; K8s silently ignores them. `Team.Spec.Members` only supports `Kind: "User"` by schema.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle. (gated on `kubernetesTeamsRedirect`)
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc. (no docs change; migration plumbing only)

Test plan:
- [x] `go test ./pkg/services/accesscontrol/resourcepermissions/...`
- [x] `go test ./pkg/tests/apis/iam/team/...`
- [x] New unit cases in `TestSetTeamMembers`: removes existing member when permission is empty / no Update when removing a non-member / rejects when removal targets an external member.
- [x] New integration subtests in `TestIntegrationResourcePermissionsBulkRedirect`:
  - bulk write with `permission: ""` removes the named user from both `Spec.Members` and legacy SQL `team_member` (dual-write check)
  - bulk removal of a non-member returns 200 no-op
  - bulk removal targeting an external member returns 400 and preserves the external row
  - bulk removal from a provisioned team returns 400 and preserves membership
- [x] Manually verified against a local Grafana instance with `kubernetesTeamsRedirect` on, dual-writer Mode 1: bulk write persists to `Spec.Members`, upserts (omitted users stay), preserves externals, rejects external-targeting writes with 400, rejects provisioned teams with 400, and produces no K8s `Update` when the POST is identical to current state.