### PR TITLE
Transformations: Mark Group to nested table as non-beta if v2 is enabled

### DIFF
--- a/public/app/features/transformers/standardTransformers.tsx
+++ b/public/app/features/transformers/standardTransformers.tsx
@@ -674,7 +674,7 @@ export const getStandardTransformers = (): TransformerRegistryItem[] => {
         TransformerCategory.CalculateNewFields,
         TransformerCategory.Reformat,
       ]),
-      state: PluginState.beta,
+      state: config.featureToggles.groupToNestedTableV2 ? undefined : PluginState.beta,
       imageDark: groupToNestedTableDark,
       imageLight: groupToNestedTableLight,
     }),


### PR DESCRIPTION
### Summary

- if the groupToNestedTableV2 flag is enabled, then the "beta" designation is removed from the "Group to nested table" transform.

### Background

This transform has existed since Feb 2024 in https://github.com/grafana/grafana/pull/79952 (presumably as a Grafana 11 feature), so I think we should use the v2 release as an opportunity to remove the beta designation. 