### PR TITLE
SqlExpressions: Avoid boilerplate after clearing expression

### DIFF
--- a/public/app/features/expressions/components/SqlExpressions/SqlExpr.test.tsx
+++ b/public/app/features/expressions/components/SqlExpressions/SqlExpr.test.tsx
@@ -1,3 +1,4 @@
+import { type Props as AutoSizerProps } from 'react-virtualized-auto-sizer';
 import { render, testWithFeatureToggles, userEvent, waitFor } from 'test/test-utils';
 
 import { type AdHocVariableFilter, type DataFrame, type DataQueryRequest, type ScopedVars } from '@grafana/data';
@@ -26,7 +27,19 @@ jest.mock('@grafana/plugin-ui', () => ({
   QueryFormat: {
     Table: 'table',
   },
-  SQLEditor: () => <div data-testid="sql-editor">SQL Editor Mock</div>,
+  SQLEditor: ({ query, onChange }: { query: string; onChange: (query: string) => void }) => (
+    <div>
+      <div data-testid="sql-editor">{query}</div>
+      <button onClick={() => onChange('')}>Clear SQL</button>
+    </div>
+  ),
+}));
+
+jest.mock('react-virtualized-auto-sizer', () => ({
+  __esModule: true,
+  default: ({ children }: AutoSizerProps) => (
+    <div>{children({ width: 800, scaledWidth: 800, height: 600, scaledHeight: 600 })}</div>
+  ),
 }));
 
 const mockBackendSrv = {
@@ -77,6 +90,26 @@ describe('SqlExpr', () => {
     await waitFor(() => {
       expect(query.expression).toBe(existingExpression);
     });
+  });
+
+  it('allows clearing an existing expression without restoring the default query', async () => {
+    const onChange = jest.fn();
+    const refIds = [{ value: 'A' }];
+    const existingExpression = 'SELECT 1 AS foo';
+    const query = { refId: 'expr1', type: 'sql', expression: existingExpression } as ExpressionQuery;
+    const { findByTestId, getByRole, rerender } = render(
+      <SqlExpr onChange={onChange} refIds={refIds} query={query} queries={[]} />
+    );
+
+    expect(await findByTestId('sql-editor')).toHaveTextContent(existingExpression);
+
+    await userEvent.click(getByRole('button', { name: 'Clear SQL' }));
+
+    expect(onChange).toHaveBeenCalledWith(expect.objectContaining({ expression: '' }));
+
+    rerender(<SqlExpr onChange={onChange} refIds={refIds} query={{ ...query, expression: '' }} queries={[]} />);
+
+    expect(await findByTestId('sql-editor')).toBeEmptyDOMElement();
   });
 
   it('adds alerting format when alerting prop is true', async () => {

--- a/public/app/features/expressions/components/SqlExpressions/SqlExpr.tsx
+++ b/public/app/features/expressions/components/SqlExpressions/SqlExpr.tsx
@@ -216,7 +216,7 @@ LIMIT
           {({ width, height }: Size) => (
             <Suspense fallback={null}>
               <SQLEditor
-                query={query.expression || initialQuery}
+                query={query.expression ?? initialQuery}
                 onChange={onEditorChange}
                 language={EDITOR_LANGUAGE_DEFINITION}
                 width={width}


### PR DESCRIPTION
## Description
<!--- A high level description of what this PR is doing -->

This PR closes https://github.com/grafana/grafana/issues/124815. Now when you clear a SQL Expression, the SQL Expression editor is actually cleared, and not replaced by a boilerplate SQL Expression.

## Changes
<!--- Describe your changes in detail -->

Very simple change in the `SQLEditor` props, supported by a unit test.

## Risks
<!--- Describe what risks you've considered i.e. what features are most likely to break -->

I can't think of any.

## Demo
<!--- Attach a demo gif/video or screenshots of the changes if applicable -->

### Before

Clearing the query resulted in boilerplate, which can be frustrating, especially when you're expecting to paste something in after clearing:

https://github.com/user-attachments/assets/ca48360d-fb2a-4efa-90a4-0f2f36670575

### After

We still get the boilerplate when creating the SQL Expression (or duplicating an empty SQL Expression), but clearing a SQL expression no longer adds the boilerplate:

https://github.com/user-attachments/assets/865e8989-881e-4d87-a89d-33349b128d96

## Testing Instructions
<!--- Provide step by step instructions and the dashboard if applicable -->
- Check out the `nickrichmond/dpro-94` branch.
- Run the server (`make start`) and build the front end (`yarn dev` for static, or `yarn start` for watch mode).
- In a dashboard that has a query that uses one of the data sources [supported](https://grafana.com/docs/grafana/latest/visualizations/panels-visualizations/query-transform-data/sql-expressions/#compatible-data-sources) by SQL Expressions, add a SQL Expression and notice that the boilerplate (`SELECT * FROM QUERY_REF_ID LIMIT 10`) still appears, as expected.
- Either clear the boilerplate immediately, or write your own SQL Expression first before clearing, and note that it fully clears and is not replaced by boilerplate.

## Reviewer Checklist
<!--- The reviewer should make sure the following has been done -->
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable