### PR TITLE
Alerting: Add Mimir Alertmanager auto-sync configuration to settings page

### DIFF
--- a/public/app/features/alerting/unified/Settings.test.tsx
+++ b/public/app/features/alerting/unified/Settings.test.tsx
@@ -1,5 +1,5 @@
 import { screen, waitFor, within } from '@testing-library/react';
-import { render } from 'test/test-utils';
+import { render, testWithFeatureToggles } from 'test/test-utils';
 import { byRole, byTestId, byText } from 'testing-library-selector';
 
 import SettingsPage from './Settings';
@@ -8,6 +8,7 @@ import { setupGrafanaManagedServer, withExternalOnlySetting } from './components
 import { setupMswServer } from './mockApi';
 import { grantUserRole } from './mocks';
 import { addSettingsSection, clearSettingsExtensions } from './settings/extensions';
+import { setupDataSources } from './testSetup/datasources';
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
@@ -19,6 +20,7 @@ const server = setupMswServer();
 const ui = {
   builtInAlertmanagerSection: byText('Built-in Alertmanager'),
   otherAlertmanagerSection: byText('Other Alertmanagers'),
+  autoSyncCard: byRole('region', { name: /auto-sync configuration/i }),
 
   alertmanagerCard: (name: string) => byTestId(`alertmanager-card-${name}`),
   builtInAlertmanagerCard: byTestId('alertmanager-card-Grafana built-in'),
@@ -256,5 +258,32 @@ describe('Alerting settings', () => {
     expect(ui.alertmanagerTab.get()).toBeInTheDocument();
     expect(ui.enrichmentTab.query()).not.toBeInTheDocument();
     expect(ui.notificationsTab.query()).not.toBeInTheDocument();
+  });
+
+  it('should not render the auto-sync configuration card when the feature flag is off', async () => {
+    render(<SettingsPage />);
+
+    await waitFor(() => expect(ui.builtInAlertmanagerSection.get()).toBeInTheDocument());
+    expect(ui.autoSyncCard.query()).not.toBeInTheDocument();
+  });
+
+  describe('with alerting.syncExternalAlertmanager feature flag enabled', () => {
+    testWithFeatureToggles({ enable: ['alerting.syncExternalAlertmanager'] });
+
+    it('renders the auto-sync configuration card above the Built-in Alertmanager section', async () => {
+      // DataSourcePicker reads from getDataSourceSrv(); initialise it (empty list is fine here).
+      setupDataSources();
+      render(<SettingsPage />);
+
+      await waitFor(() => expect(ui.builtInAlertmanagerSection.get()).toBeInTheDocument());
+
+      const card = await ui.autoSyncCard.find();
+      expect(card).toBeInTheDocument();
+
+      // The card should precede the Built-in Alertmanager heading in document order.
+      const builtInHeading = ui.builtInAlertmanagerSection.get();
+      // eslint-disable-next-line no-bitwise
+      expect(card.compareDocumentPosition(builtInHeading) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    });
   });
 });

--- a/public/app/features/alerting/unified/Settings.tsx
+++ b/public/app/features/alerting/unified/Settings.tsx
@@ -1,8 +1,10 @@
 import { Trans, t } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
 import { LinkButton, Stack, Text } from '@grafana/ui';
 
 import { AlertingPageWrapper } from './components/AlertingPageWrapper';
 import { WithReturnButton } from './components/WithReturnButton';
+import { AutoSyncConfiguration } from './components/settings/AutoSyncConfiguration';
 import { useEditConfigurationDrawer } from './components/settings/ConfigurationDrawer';
 import { ExternalAlertmanagers } from './components/settings/ExternalAlertmanagers';
 import InternalAlertmanager from './components/settings/InternalAlertmanager';
@@ -21,6 +23,7 @@ function AlertmanagerSettingsPage() {
 function AlertmanagerSettingsContent() {
   const [configurationDrawer, showConfiguration] = useEditConfigurationDrawer();
   const { isLoading } = useSettings();
+  const isAutoSyncEnabled = config.featureToggles['alerting.syncExternalAlertmanager'];
 
   const { navId, pageNav } = useSettingsPageNav();
 
@@ -42,6 +45,7 @@ function AlertmanagerSettingsContent() {
       ]}
     >
       <Stack direction="column" gap={2}>
+        {isAutoSyncEnabled && <AutoSyncConfiguration />}
         {/* Grafana built-in Alertmanager */}
         <Text variant="h5">
           <Trans i18nKey="alerting.settings-content.builtin-alertmanager">Built-in Alertmanager</Trans>

--- a/public/app/features/alerting/unified/api/alertmanagerApi.ts
+++ b/public/app/features/alerting/unified/api/alertmanagerApi.ts
@@ -17,6 +17,7 @@ import {
   type ExternalAlertmanagersStatusResponse,
   type GrafanaAlertingConfiguration,
   type Matcher,
+  type PostableGrafanaAlertingConfiguration,
 } from '../../../../plugins/datasource/alertmanager/types';
 import { withPerformanceLogging } from '../Analytics';
 import { matcherToMatcherField } from '../utils/alertmanager';
@@ -28,7 +29,7 @@ import {
 import { retryWhile } from '../utils/misc';
 import { messageFromError, withSerializedError } from '../utils/redux';
 
-import { alertingApi } from './alertingApi';
+import { type WithNotificationOptions, alertingApi } from './alertingApi';
 import { fetchAlertManagerConfig, fetchStatus } from './alertmanager';
 import { featureDiscoveryApi } from './featureDiscoveryApi';
 
@@ -197,12 +198,16 @@ export const alertmanagerApi = alertingApi.injectEndpoints({
       providesTags: ['AlertmanagerConnectionStatus'],
     }),
 
-    updateGrafanaAlertingConfiguration: build.mutation<{ message: string }, GrafanaAlertingConfiguration>({
-      query: (config) => ({
+    updateGrafanaAlertingConfiguration: build.mutation<
+      { message: string },
+      WithNotificationOptions<PostableGrafanaAlertingConfiguration>
+    >({
+      query: ({ notificationOptions, ...config }) => ({
         url: '/api/v1/ngalert/admin_config',
         method: 'POST',
         data: config,
         showSuccessAlert: false,
+        notificationOptions,
       }),
       invalidatesTags: [...ALERTMANAGER_PROVIDED_ENTITY_TAGS],
     }),

--- a/public/app/features/alerting/unified/components/rules/CloudRules.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/CloudRules.test.tsx
@@ -1,5 +1,5 @@
 import { Provider } from 'react-redux';
-import { render, testWithFeatureToggles, waitFor } from 'test/test-utils';
+import { render, screen, testWithFeatureToggles, waitFor } from 'test/test-utils';
 import { byRole } from 'testing-library-selector';
 
 import { OrgRole } from '@grafana/data';
@@ -20,7 +20,6 @@ setPluginComponentsHook(() => ({ components: [], isLoading: false }));
 const server = setupMswServer();
 
 const ui = {
-  sectionHeading: byRole('heading', { name: /data source-managed/i }),
   // Substring regex — the link's accessible name also includes the "New!" badge text.
   migrateButton: byRole('link', { name: /import to grafana-managed rules/i }),
 };
@@ -54,38 +53,46 @@ describe('CloudRules — Mimir AM auto-sync gate', () => {
   describe('with alertingMigrationUI and alerting.syncExternalAlertmanager enabled', () => {
     testWithFeatureToggles({ enable: ['alertingMigrationUI', 'alerting.syncExternalAlertmanager'] });
 
-    it('hides the data source import button when Mimir AM auto-sync is configured for the org', async () => {
+    it('disables the data source import button with a tooltip when Mimir AM auto-sync is configured', async () => {
       setupAdminConfigGet(server, {
         alertmanagersChoice: AlertmanagerChoice.Internal,
         external_alertmanager_uid: 'mimir-uid',
       });
 
-      renderWithCloudResults();
+      const { user } = renderWithCloudResults();
 
-      // Wait for the section to render so we know the component mounted, then retry the
-      // assertion until the admin_config query has resolved and the button is hidden.
-      expect(await ui.sectionHeading.find()).toBeInTheDocument();
+      // Re-query each tick — the LinkButton re-mounts as `disabled` flips, so a single captured
+      // reference can become stale.
       await waitFor(() => {
-        expect(ui.migrateButton.query()).not.toBeInTheDocument();
+        expect(ui.migrateButton.get()).toHaveAttribute('aria-disabled', 'true');
       });
+
+      // The disabled `<a>` has `pointer-events: none`; the tooltip handlers attach to the wrapping
+      // span. Hover that ancestor so the floating-ui hover registers in jsdom.
+      // eslint-disable-next-line testing-library/no-node-access
+      const tooltipTarget = ui.migrateButton.get().parentElement!;
+      await user.hover(tooltipTarget);
+      expect(await screen.findByRole('tooltip', { name: /auto-sync/i })).toBeInTheDocument();
     });
 
-    it('shows the data source import button when Mimir AM auto-sync is not configured', async () => {
+    it('enables the data source import button when Mimir AM auto-sync is not configured', async () => {
       setupAdminConfigGet(server, { alertmanagersChoice: AlertmanagerChoice.Internal });
 
       renderWithCloudResults();
 
-      expect(await ui.migrateButton.find()).toBeInTheDocument();
+      const btn = await ui.migrateButton.find();
+      expect(btn).not.toHaveAttribute('aria-disabled', 'true');
     });
   });
 
   describe('with alerting.syncExternalAlertmanager feature flag off', () => {
     testWithFeatureToggles({ enable: ['alertingMigrationUI'] });
 
-    it('shows the data source import button regardless of admin_config state', async () => {
+    it('enables the data source import button regardless of admin_config state', async () => {
       renderWithCloudResults();
 
-      expect(await ui.migrateButton.find()).toBeInTheDocument();
+      const btn = await ui.migrateButton.find();
+      expect(btn).not.toHaveAttribute('aria-disabled', 'true');
     });
   });
 });

--- a/public/app/features/alerting/unified/components/rules/CloudRules.test.tsx
+++ b/public/app/features/alerting/unified/components/rules/CloudRules.test.tsx
@@ -1,0 +1,91 @@
+import { Provider } from 'react-redux';
+import { render, testWithFeatureToggles, waitFor } from 'test/test-utils';
+import { byRole } from 'testing-library-selector';
+
+import { OrgRole } from '@grafana/data';
+import { setPluginComponentsHook, setPluginLinksHook } from '@grafana/runtime';
+import { AlertmanagerChoice } from 'app/plugins/datasource/alertmanager/types';
+import { AccessControlAction } from 'app/types/accessControl';
+
+import { setupMswServer } from '../../mockApi';
+import { grantUserPermissions, grantUserRole, mockUnifiedAlertingStore } from '../../mocks';
+import { mimirDataSource } from '../../mocks/server/configure';
+import { setupAdminConfigGet } from '../../mocks/server/configure/admin_config';
+
+import { CloudRules } from './CloudRules';
+
+setPluginLinksHook(() => ({ links: [], isLoading: false }));
+setPluginComponentsHook(() => ({ components: [], isLoading: false }));
+
+const server = setupMswServer();
+
+const ui = {
+  sectionHeading: byRole('heading', { name: /data source-managed/i }),
+  // Substring regex — the link's accessible name also includes the "New!" badge text.
+  migrateButton: byRole('link', { name: /import to grafana-managed rules/i }),
+};
+
+function renderWithCloudResults() {
+  const { dataSource } = mimirDataSource();
+  const store = mockUnifiedAlertingStore({
+    promRules: {
+      [dataSource.name]: { loading: false, dispatched: true, result: [{}] as never },
+    },
+  });
+  return render(
+    <Provider store={store}>
+      <CloudRules namespaces={[]} expandAll={false} />
+    </Provider>
+  );
+}
+
+describe('CloudRules — Mimir AM auto-sync gate', () => {
+  beforeEach(() => {
+    grantUserRole(OrgRole.Admin);
+    grantUserPermissions([
+      // External read is required for getRulesDataSources() to include the Mimir DS.
+      AccessControlAction.AlertingRuleExternalRead,
+      // Both grafana-managed perms are required to enable canMigrateToGMA.
+      AccessControlAction.AlertingRuleCreate,
+      AccessControlAction.AlertingProvisioningSetStatus,
+    ]);
+  });
+
+  describe('with alertingMigrationUI and alerting.syncExternalAlertmanager enabled', () => {
+    testWithFeatureToggles({ enable: ['alertingMigrationUI', 'alerting.syncExternalAlertmanager'] });
+
+    it('hides the data source import button when Mimir AM auto-sync is configured for the org', async () => {
+      setupAdminConfigGet(server, {
+        alertmanagersChoice: AlertmanagerChoice.Internal,
+        external_alertmanager_uid: 'mimir-uid',
+      });
+
+      renderWithCloudResults();
+
+      // Wait for the section to render so we know the component mounted, then retry the
+      // assertion until the admin_config query has resolved and the button is hidden.
+      expect(await ui.sectionHeading.find()).toBeInTheDocument();
+      await waitFor(() => {
+        expect(ui.migrateButton.query()).not.toBeInTheDocument();
+      });
+    });
+
+    it('shows the data source import button when Mimir AM auto-sync is not configured', async () => {
+      setupAdminConfigGet(server, { alertmanagersChoice: AlertmanagerChoice.Internal });
+
+      renderWithCloudResults();
+
+      expect(await ui.migrateButton.find()).toBeInTheDocument();
+    });
+  });
+
+  describe('with alerting.syncExternalAlertmanager feature flag off', () => {
+    testWithFeatureToggles({ enable: ['alertingMigrationUI'] });
+
+    it('shows the data source import button regardless of admin_config state', async () => {
+      renderWithCloudResults();
+
+      expect(await ui.migrateButton.find()).toBeInTheDocument();
+    });
+  });
+});

--- a/public/app/features/alerting/unified/components/rules/CloudRules.tsx
+++ b/public/app/features/alerting/unified/components/rules/CloudRules.tsx
@@ -12,6 +12,7 @@ import { type CombinedRuleNamespace } from 'app/types/unified-alerting';
 
 import { DEFAULT_PER_PAGE_PAGINATION } from '../../../../../core/constants';
 import { AlertingAction, useAlertingAbility } from '../../hooks/useAbilities';
+import { useIsAutoSyncActive } from '../../hooks/useIsAutoSyncActive';
 import { usePagination } from '../../hooks/usePagination';
 import { useUnifiedAlertingSelector } from '../../hooks/useUnifiedAlertingSelector';
 import { getPaginationStyles } from '../../styles/pagination';
@@ -50,9 +51,12 @@ export const CloudRules = ({ namespaces, expandAll }: Props) => {
     DEFAULT_PER_PAGE_PAGINATION
   );
 
+  const isAutoSyncActive = useIsAutoSyncActive();
+
   const canMigrateToGMA =
     hasDataSourcesConfigured &&
     config.featureToggles.alertingMigrationUI &&
+    !isAutoSyncActive &&
     contextSrv.hasPermission(AccessControlAction.AlertingRuleCreate) &&
     contextSrv.hasPermission(AccessControlAction.AlertingProvisioningSetStatus);
 

--- a/public/app/features/alerting/unified/components/rules/CloudRules.tsx
+++ b/public/app/features/alerting/unified/components/rules/CloudRules.tsx
@@ -5,14 +5,24 @@ import { useLocation } from 'react-router-dom-v5-compat';
 import { type GrafanaTheme2, urlUtil } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
-import { Badge, LinkButton, LoadingPlaceholder, Pagination, Spinner, Stack, Text, useStyles2 } from '@grafana/ui';
+import {
+  Badge,
+  LinkButton,
+  LoadingPlaceholder,
+  Pagination,
+  Spinner,
+  Stack,
+  Text,
+  Tooltip,
+  useStyles2,
+} from '@grafana/ui';
 import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction } from 'app/types/accessControl';
 import { type CombinedRuleNamespace } from 'app/types/unified-alerting';
 
 import { DEFAULT_PER_PAGE_PAGINATION } from '../../../../../core/constants';
 import { AlertingAction, useAlertingAbility } from '../../hooks/useAbilities';
-import { useIsAutoSyncActive } from '../../hooks/useIsAutoSyncActive';
+import { useImportEntrypointState } from '../../hooks/useImportEntrypointState';
 import { usePagination } from '../../hooks/usePagination';
 import { useUnifiedAlertingSelector } from '../../hooks/useUnifiedAlertingSelector';
 import { getPaginationStyles } from '../../styles/pagination';
@@ -51,12 +61,11 @@ export const CloudRules = ({ namespaces, expandAll }: Props) => {
     DEFAULT_PER_PAGE_PAGINATION
   );
 
-  const isAutoSyncActive = useIsAutoSyncActive();
+  const { disabled: importDisabled, reason: importDisabledReason } = useImportEntrypointState();
 
   const canMigrateToGMA =
     hasDataSourcesConfigured &&
     config.featureToggles.alertingMigrationUI &&
-    !isAutoSyncActive &&
     contextSrv.hasPermission(AccessControlAction.AlertingRuleCreate) &&
     contextSrv.hasPermission(AccessControlAction.AlertingProvisioningSetStatus);
 
@@ -81,7 +90,9 @@ export const CloudRules = ({ namespaces, expandAll }: Props) => {
               <div />
             )}
             <Stack gap={1}>
-              {canMigrateToGMA && hasSomeResults && <MigrateToGMAButton />}
+              {canMigrateToGMA && hasSomeResults && (
+                <MigrateToGMAButton disabled={importDisabled} disabledReason={importDisabledReason} />
+              )}
               <CreateRecordingRuleButton />
             </Stack>
           </div>
@@ -173,11 +184,16 @@ export function CreateRecordingRuleButton() {
   return null;
 }
 
-function MigrateToGMAButton() {
+interface MigrateToGMAButtonProps {
+  disabled: boolean;
+  disabledReason?: string;
+}
+
+function MigrateToGMAButton({ disabled, disabledReason }: MigrateToGMAButtonProps) {
   const importUrl = createRelativeUrl('/alerting/import-datasource-managed-rules');
 
-  return (
-    <LinkButton variant="secondary" href={importUrl} icon="arrow-up">
+  const button = (
+    <LinkButton variant="secondary" href={importUrl} icon="arrow-up" disabled={disabled}>
       <Stack direction="row" gap={1} alignItems="center">
         <Trans i18nKey="alerting.rule-list.import-to-gma.text">Import to Grafana-managed rules</Trans>
         <Badge
@@ -189,4 +205,16 @@ function MigrateToGMAButton() {
       </Stack>
     </LinkButton>
   );
+
+  // LinkButton applies `pointer-events: none` when disabled, which suppresses tooltip hover.
+  // Wrap in a span so the Tooltip's hover handlers attach to an element that still receives events.
+  if (disabled && disabledReason) {
+    return (
+      <Tooltip content={disabledReason}>
+        <span>{button}</span>
+      </Tooltip>
+    );
+  }
+
+  return button;
 }

--- a/public/app/features/alerting/unified/components/settings/AutoSyncConfiguration.test.tsx
+++ b/public/app/features/alerting/unified/components/settings/AutoSyncConfiguration.test.tsx
@@ -1,0 +1,220 @@
+import { screen, waitFor } from '@testing-library/react';
+import { render } from 'test/test-utils';
+import { byLabelText, byRole, byText } from 'testing-library-selector';
+
+import {
+  type AlertManagerDataSourceJsonData,
+  AlertManagerImplementation,
+  AlertmanagerChoice,
+} from 'app/plugins/datasource/alertmanager/types';
+
+import { setupMswServer } from '../../mockApi';
+import { grantUserRole, mockDataSource } from '../../mocks';
+import {
+  type AdminConfigPostState,
+  setupAdminConfigGet,
+  setupAdminConfigPost,
+  setupAlertmanagersStatus,
+  setupStatefulAdminConfig,
+} from '../../mocks/server/configure/admin_config';
+import { setupDatasourcesEndpoint } from '../../mocks/server/configure/datasources';
+import { setupDataSources } from '../../testSetup/datasources';
+import { DataSourceType } from '../../utils/datasource';
+
+import { AutoSyncConfiguration } from './AutoSyncConfiguration';
+
+const server = setupMswServer();
+
+const MIMIR_DS_UID = 'mimir-uid';
+const MIMIR_DS_NAME = 'Test Mimir Alertmanager';
+
+const MIMIR_DS_PAYLOAD = {
+  id: 1,
+  uid: MIMIR_DS_UID,
+  orgId: 1,
+  name: MIMIR_DS_NAME,
+  type: 'alertmanager',
+  url: 'http://localhost:9009',
+  jsonData: { implementation: 'mimir' },
+};
+
+function registerMimirDataSources(datasources: Array<typeof MIMIR_DS_PAYLOAD> = [MIMIR_DS_PAYLOAD]) {
+  // DataSourcePicker reads from getDataSourceSrv(), so we register the datasources in the
+  // in-memory srv in addition to mocking the HTTP list used by RTK Query.
+  // `meta.alerting: true` is required for the picker's default `getList` filter to surface
+  // them (see DatasourceSrv.getList).
+  setupDataSources(
+    ...datasources.map((ds) =>
+      mockDataSource<AlertManagerDataSourceJsonData>(
+        {
+          uid: ds.uid,
+          name: ds.name,
+          type: DataSourceType.Alertmanager,
+          url: ds.url,
+          jsonData: { implementation: AlertManagerImplementation.mimir },
+        },
+        { alerting: true }
+      )
+    )
+  );
+}
+
+const postState: AdminConfigPostState = { lastPayload: null };
+
+beforeEach(() => {
+  postState.lastPayload = null;
+  grantUserRole('Admin');
+  setupAlertmanagersStatus(server);
+});
+
+const ui = {
+  notConfiguredBadge: byText(/not configured/i),
+  activeBadge: byText(/^active$/i),
+  saveButton: byRole('button', { name: /^save$/i }),
+  disableSyncButton: byRole('button', { name: /^disable sync$/i }),
+  picker: byLabelText(/^datasource$/i),
+  confirmDialog: byRole('dialog', { name: /disable mimir alertmanager auto-sync/i }),
+  confirmDialogDisableButton: byRole('button', { name: /^disable sync$/i }),
+};
+
+const edgeUi = {
+  operatorManagedCallout: byText(/key in grafana\.ini and cannot be changed from the UI/i),
+  orphanWarning: byText(/is not available\. Disable sync or restore the datasource to continue/i),
+  noDatasourcesMessage: byText(/no mimir or cortex datasources available/i),
+  addMimirDatasourceLink: byRole('link', { name: /add mimir datasource/i }),
+};
+
+describe('AutoSyncConfiguration — basic states (cases 1–3)', () => {
+  it('case 1: unconfigured — renders "Not configured" badge and disables Save until a selection is made', async () => {
+    setupAdminConfigGet(server, { alertmanagersChoice: AlertmanagerChoice.Internal });
+    setupDatasourcesEndpoint(server, [MIMIR_DS_PAYLOAD]);
+    registerMimirDataSources();
+
+    render(<AutoSyncConfiguration />);
+
+    expect(await ui.notConfiguredBadge.find()).toBeInTheDocument();
+    expect(ui.saveButton.get()).toBeDisabled();
+    // No "Disable sync" button when nothing is configured.
+    expect(ui.disableSyncButton.query()).not.toBeInTheDocument();
+  });
+
+  it('case 2: save success — sends correct payload and badge flips to Active once the config refetches', async () => {
+    setupStatefulAdminConfig(server, postState);
+    setupDatasourcesEndpoint(server, [MIMIR_DS_PAYLOAD]);
+    registerMimirDataSources();
+
+    const { user } = render(<AutoSyncConfiguration />);
+
+    expect(await ui.notConfiguredBadge.find()).toBeInTheDocument();
+
+    await user.click(ui.picker.get());
+    await user.click(await screen.findByText(MIMIR_DS_NAME));
+
+    await waitFor(() => expect(ui.saveButton.get()).toBeEnabled());
+    await user.click(ui.saveButton.get());
+
+    await waitFor(() => expect(postState.lastPayload).toEqual({ external_alertmanager_uid: MIMIR_DS_UID }));
+    expect(await ui.activeBadge.find()).toBeInTheDocument();
+  });
+
+  it('case 3: configured — Disable sync opens a confirm modal and POSTs an empty string only after confirmation', async () => {
+    setupAdminConfigGet(server, {
+      alertmanagersChoice: AlertmanagerChoice.Internal,
+      external_alertmanager_uid: MIMIR_DS_UID,
+    });
+    setupDatasourcesEndpoint(server, [MIMIR_DS_PAYLOAD]);
+    setupAdminConfigPost(server, postState, 200);
+    registerMimirDataSources();
+
+    const { user } = render(<AutoSyncConfiguration />);
+
+    expect(await ui.activeBadge.find()).toBeInTheDocument();
+    // Save is hidden while sync is active — admin must Disable first, then re-select + Save.
+    expect(ui.saveButton.query()).not.toBeInTheDocument();
+
+    await user.click(ui.disableSyncButton.get());
+
+    // Confirm modal must appear; nothing has been POSTed yet.
+    const dialog = await ui.confirmDialog.find();
+    expect(dialog).toBeInTheDocument();
+    expect(postState.lastPayload).toBeNull();
+
+    await user.click(ui.confirmDialogDisableButton.get(dialog));
+
+    await waitFor(() => expect(postState.lastPayload).toEqual({ external_alertmanager_uid: '' }));
+  });
+});
+
+describe('AutoSyncConfiguration — edge-case states (cases 5–8)', () => {
+  it('case 5: when POST returns 409, UI transitions to operator-managed (badge + info callout)', async () => {
+    // The 409 transition needs configuredUid !== '' so the operator-managed marker matches.
+    // Save is hidden once configured, so trigger the POST via Disable sync instead.
+    setupAdminConfigGet(server, {
+      alertmanagersChoice: AlertmanagerChoice.Internal,
+      external_alertmanager_uid: MIMIR_DS_UID,
+    });
+    setupDatasourcesEndpoint(server, [MIMIR_DS_PAYLOAD]);
+    setupAdminConfigPost(server, postState, 409, { message: 'managed by operator' });
+    registerMimirDataSources();
+
+    const { user } = render(<AutoSyncConfiguration />);
+
+    expect(await ui.activeBadge.find()).toBeInTheDocument();
+
+    await user.click(ui.disableSyncButton.get());
+    const dialog = await ui.confirmDialog.find();
+    await user.click(ui.confirmDialogDisableButton.get(dialog));
+
+    expect(await edgeUi.operatorManagedCallout.find()).toBeInTheDocument();
+    expect(ui.activeBadge.query()).not.toBeInTheDocument();
+  });
+
+  it('case 6: POST 400 — error toast shown, state does not change', async () => {
+    setupAdminConfigGet(server, { alertmanagersChoice: AlertmanagerChoice.Internal });
+    setupDatasourcesEndpoint(server, [MIMIR_DS_PAYLOAD]);
+    setupAdminConfigPost(server, postState, 400, { message: 'invalid datasource' });
+    registerMimirDataSources();
+
+    const { user } = render(<AutoSyncConfiguration />);
+
+    expect(await ui.notConfiguredBadge.find()).toBeInTheDocument();
+
+    await user.click(ui.picker.get());
+    await user.click(await screen.findByText(MIMIR_DS_NAME));
+    await waitFor(() => expect(ui.saveButton.get()).toBeEnabled());
+    await user.click(ui.saveButton.get());
+
+    await waitFor(() => expect(postState.lastPayload).toEqual({ external_alertmanager_uid: MIMIR_DS_UID }));
+
+    expect(ui.notConfiguredBadge.get()).toBeInTheDocument();
+    expect(edgeUi.operatorManagedCallout.query()).not.toBeInTheDocument();
+  });
+
+  it('case 7: no Mimir/Cortex datasources — empty message and "Add Mimir datasource" link rendered', async () => {
+    setupAdminConfigGet(server, { alertmanagersChoice: AlertmanagerChoice.Internal });
+    setupDatasourcesEndpoint(server, []);
+    setupDataSources();
+
+    render(<AutoSyncConfiguration />);
+
+    expect(await edgeUi.noDatasourcesMessage.find()).toBeInTheDocument();
+    expect(edgeUi.addMimirDatasourceLink.get()).toBeInTheDocument();
+    expect(edgeUi.addMimirDatasourceLink.get()).toHaveAttribute('href', '/connections/datasources/alertmanager');
+  });
+
+  it('case 8: orphan UID — warning callout + Disable sync action visible, Save remains available for recovery', async () => {
+    setupAdminConfigGet(server, {
+      alertmanagersChoice: AlertmanagerChoice.Internal,
+      external_alertmanager_uid: 'missing-uid',
+    });
+    setupDatasourcesEndpoint(server, [MIMIR_DS_PAYLOAD]);
+    registerMimirDataSources();
+
+    render(<AutoSyncConfiguration />);
+
+    expect(await edgeUi.orphanWarning.find()).toBeInTheDocument();
+    expect(ui.disableSyncButton.get()).toBeInTheDocument();
+    // Save stays visible in orphan-uid so the admin can recover by picking a real datasource.
+    expect(ui.saveButton.get()).toBeInTheDocument();
+  });
+});

--- a/public/app/features/alerting/unified/components/settings/AutoSyncConfiguration.tsx
+++ b/public/app/features/alerting/unified/components/settings/AutoSyncConfiguration.tsx
@@ -1,0 +1,249 @@
+import { css } from '@emotion/css';
+import { useMemo, useState } from 'react';
+
+import { type GrafanaTheme2, type SelectableValue } from '@grafana/data';
+import { Trans, t } from '@grafana/i18n';
+import {
+  Alert,
+  Badge,
+  Button,
+  Card,
+  ConfirmModal,
+  Field,
+  LinkButton,
+  Select,
+  Stack,
+  Tooltip,
+  useStyles2,
+} from '@grafana/ui';
+
+import {
+  type AutoSyncState,
+  hasConfiguredUid,
+  isOperatorManaged,
+  useAutoSyncConfiguration,
+} from './useAutoSyncConfiguration';
+
+export function AutoSyncConfiguration() {
+  const styles = useStyles2(getStyles);
+  const { state, mimirCortexDatasources, selectedUid, setSelectedUid, save, disableSync, isPending, isLoading } =
+    useAutoSyncConfiguration();
+
+  const [showDisableConfirm, setShowDisableConfirm] = useState(false);
+
+  const options = useMemo<Array<SelectableValue<string>>>(
+    () =>
+      mimirCortexDatasources.map((ds) => ({
+        value: ds.uid,
+        label: ds.name,
+        imgUrl: ds.typeLogoUrl,
+      })),
+    [mimirCortexDatasources]
+  );
+
+  const operatorManaged = isOperatorManaged(state);
+  const showDisableSync = state.kind === 'configured' || state.kind === 'orphan-uid';
+  const showSave = state.kind === 'unconfigured' || state.kind === 'orphan-uid';
+  const savedUid = hasConfiguredUid(state) ? state.uid : '';
+  const saveDisabled = !selectedUid || selectedUid === savedUid;
+  const saveDisabledTooltip = t(
+    'alerting.settings.auto-sync.save-disabled-no-selection',
+    'Select a Mimir or Cortex Alertmanager datasource to enable saving.'
+  );
+
+  const handleDisableConfirm = async () => {
+    setShowDisableConfirm(false);
+    await disableSync();
+  };
+
+  return (
+    <Card
+      noMargin
+      className={styles.cardSpacing}
+      role="region"
+      aria-label={t('alerting.settings.auto-sync.title', 'Auto-sync configuration')}
+    >
+      <Card.Heading>
+        <Stack alignItems="center" gap={1}>
+          <Trans i18nKey="alerting.settings.auto-sync.title">Auto-sync configuration</Trans>
+          <StatusBadge state={state} />
+        </Stack>
+      </Card.Heading>
+      <Card.Description>
+        <Trans i18nKey="alerting.settings.auto-sync.description">
+          Continuously sync alert configuration from a Mimir or Cortex Alertmanager datasource into Grafana.
+        </Trans>
+      </Card.Description>
+      <Card.Meta>
+        <div className={styles.formColumn}>
+          {state.kind === 'orphan-uid' && (
+            <Alert
+              severity="warning"
+              title={t('alerting.settings.auto-sync.orphan-warning-title', 'Configured datasource not found')}
+            >
+              <Trans i18nKey="alerting.settings.auto-sync.orphan-warning" values={{ uid: state.uid }}>
+                The configured datasource UID {'{{uid}}'} is not available. Disable sync or restore the datasource to
+                continue.
+              </Trans>
+            </Alert>
+          )}
+          {operatorManaged && (
+            <Alert
+              severity="info"
+              title={t('alerting.settings.auto-sync.operator-managed-title', 'Managed by operator')}
+            >
+              <Trans i18nKey="alerting.settings.auto-sync.operator-managed-info">
+                This value is set by the <code>[unified_alerting] external_alertmanager_uid</code> key in grafana.ini
+                and cannot be changed from the UI. Edit the configuration file and restart Grafana, or remove the key to
+                manage sync from here.
+              </Trans>
+            </Alert>
+          )}
+          <div className={styles.formRow}>
+            <Field
+              noMargin
+              label={t('alerting.settings.auto-sync.picker-label', 'Datasource')}
+              className={styles.field}
+              htmlFor="auto-sync-datasource-picker"
+            >
+              {state.kind === 'no-datasources' ? (
+                <div className={styles.noDatasourcesRow}>
+                  <span className={styles.muted}>
+                    <Trans i18nKey="alerting.settings.auto-sync.picker-empty">
+                      No Mimir or Cortex datasources available
+                    </Trans>
+                  </span>
+                  <LinkButton
+                    href="/connections/datasources/alertmanager"
+                    icon="plus"
+                    variant="secondary"
+                    fill="outline"
+                  >
+                    <Trans i18nKey="alerting.settings.auto-sync.add-datasource-link">Add Mimir datasource</Trans>
+                  </LinkButton>
+                </div>
+              ) : (
+                <Select
+                  inputId="auto-sync-datasource-picker"
+                  aria-label={t('alerting.settings.auto-sync.picker-label', 'Datasource')}
+                  options={options}
+                  value={selectedUid || null}
+                  onChange={(option) => option?.value && setSelectedUid(option.value)}
+                  disabled={operatorManaged || isLoading}
+                  isLoading={isLoading}
+                  width={50}
+                  placeholder={t(
+                    'alerting.settings.auto-sync.picker-placeholder',
+                    'Select a Mimir or Cortex Alertmanager datasource…'
+                  )}
+                  noOptionsMessage={t(
+                    'alerting.settings.auto-sync.picker-empty',
+                    'No Mimir or Cortex datasources available'
+                  )}
+                />
+              )}
+            </Field>
+            {state.kind !== 'no-datasources' && (
+              <Stack direction="row" gap={1} alignItems="flex-end">
+                {showDisableSync && (
+                  <Button
+                    variant="destructive"
+                    fill="outline"
+                    onClick={() => setShowDisableConfirm(true)}
+                    disabled={isPending}
+                    icon="times"
+                  >
+                    <Trans i18nKey="alerting.settings.auto-sync.action-disable">Disable sync</Trans>
+                  </Button>
+                )}
+                {showSave && (
+                  <Tooltip content={saveDisabled ? saveDisabledTooltip : ''} show={saveDisabled ? undefined : false}>
+                    <span className={styles.tooltipTarget}>
+                      <Button variant="primary" onClick={save} disabled={saveDisabled || isPending}>
+                        <Trans i18nKey="common.save">Save</Trans>
+                      </Button>
+                    </span>
+                  </Tooltip>
+                )}
+              </Stack>
+            )}
+          </div>
+        </div>
+      </Card.Meta>
+      <ConfirmModal
+        isOpen={showDisableConfirm}
+        title={t('alerting.settings.auto-sync.disable-confirm-title', 'Disable Mimir Alertmanager auto-sync?')}
+        body={
+          hasConfiguredUid(state)
+            ? t(
+                'alerting.settings.auto-sync.disable-confirm-body',
+                'Disabling will stop continuous sync from datasource {{uid}}. You can re-enable it later by selecting a datasource again.',
+                { uid: state.uid }
+              )
+            : t(
+                'alerting.settings.auto-sync.disable-confirm-body-generic',
+                'Disabling will stop continuous sync. You can re-enable it later by selecting a datasource again.'
+              )
+        }
+        confirmText={t('alerting.settings.auto-sync.disable-confirm-action', 'Disable sync')}
+        onConfirm={handleDisableConfirm}
+        onDismiss={() => setShowDisableConfirm(false)}
+      />
+    </Card>
+  );
+}
+
+function StatusBadge({ state }: { state: AutoSyncState }) {
+  if (state.kind === 'operator-managed') {
+    return (
+      <Badge
+        text={t('alerting.settings.auto-sync.badge-operator-managed', 'Managed by operator')}
+        color="blue"
+        icon="lock"
+      />
+    );
+  }
+  if (state.kind === 'configured' || state.kind === 'orphan-uid') {
+    return <Badge text={t('alerting.settings.auto-sync.badge-active', 'Active')} color="green" />;
+  }
+  if (state.kind === 'unconfigured') {
+    return <Badge text={t('alerting.settings.auto-sync.badge-not-configured', 'Not configured')} color="blue" />;
+  }
+  return null;
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  cardSpacing: css({
+    '& > * + *': {
+      marginTop: theme.spacing(2),
+    },
+  }),
+  formColumn: css({
+    display: 'flex',
+    flexDirection: 'column',
+    gap: theme.spacing(2),
+    width: '100%',
+  }),
+  formRow: css({
+    display: 'flex',
+    gap: theme.spacing(2),
+    alignItems: 'flex-end',
+    width: '100%',
+  }),
+  field: css({
+    marginBottom: 0,
+  }),
+  noDatasourcesRow: css({
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(2),
+    padding: theme.spacing(1, 0),
+    width: '100%',
+  }),
+  muted: css({
+    color: theme.colors.text.secondary,
+  }),
+  tooltipTarget: css({
+    display: 'inline-flex',
+  }),
+});

--- a/public/app/features/alerting/unified/components/settings/useAutoSyncConfiguration.test.tsx
+++ b/public/app/features/alerting/unified/components/settings/useAutoSyncConfiguration.test.tsx
@@ -1,0 +1,285 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { getWrapper } from 'test/test-utils';
+
+import { AlertmanagerChoice } from 'app/plugins/datasource/alertmanager/types';
+
+import { setupMswServer } from '../../mockApi';
+import {
+  type AdminConfigPostState,
+  setupAdminConfigGet,
+  setupAdminConfigPost,
+  setupAlertmanagersStatus,
+} from '../../mocks/server/configure/admin_config';
+import { setupDatasourcesEndpoint } from '../../mocks/server/configure/datasources';
+
+import { useAutoSyncConfiguration } from './useAutoSyncConfiguration';
+
+const server = setupMswServer();
+const wrapper = () => getWrapper({ renderWithRouter: true });
+
+const MIMIR_DS = {
+  id: 1,
+  uid: 'mimir-uid',
+  orgId: 1,
+  name: 'Mimir Alertmanager',
+  type: 'alertmanager',
+  url: 'http://localhost:9009',
+  jsonData: { implementation: 'mimir' },
+};
+
+const CORTEX_DS = {
+  id: 2,
+  uid: 'cortex-uid',
+  orgId: 1,
+  name: 'Cortex Alertmanager',
+  type: 'alertmanager',
+  url: 'http://localhost:9010',
+  jsonData: { implementation: 'cortex' },
+};
+
+const VANILLA_DS = {
+  id: 3,
+  uid: 'vanilla-uid',
+  orgId: 1,
+  name: 'Vanilla Alertmanager',
+  type: 'alertmanager',
+  url: 'http://localhost:9093',
+  jsonData: { implementation: 'prometheus' },
+};
+
+const postState: AdminConfigPostState = { lastPayload: null };
+
+beforeEach(() => {
+  postState.lastPayload = null;
+  setupAlertmanagersStatus(server);
+});
+
+describe('useAutoSyncConfiguration — state resolution', () => {
+  it('returns `unconfigured` when no UID and Mimir/Cortex datasources exist', async () => {
+    setupAdminConfigGet(server, { alertmanagersChoice: AlertmanagerChoice.Internal });
+    setupDatasourcesEndpoint(server, [MIMIR_DS]);
+
+    const { result } = renderHook(() => useAutoSyncConfiguration(), { wrapper: wrapper() });
+    await waitFor(() => expect(result.current.state.kind).toBe('unconfigured'));
+  });
+
+  it('returns `configured` when UID matches a known Mimir datasource', async () => {
+    setupAdminConfigGet(server, {
+      alertmanagersChoice: AlertmanagerChoice.Internal,
+      external_alertmanager_uid: 'mimir-uid',
+    });
+    setupDatasourcesEndpoint(server, [MIMIR_DS]);
+
+    const { result } = renderHook(() => useAutoSyncConfiguration(), { wrapper: wrapper() });
+    await waitFor(() => expect(result.current.state).toEqual({ kind: 'configured', uid: 'mimir-uid' }));
+  });
+
+  it('returns `configured` when UID matches a Cortex datasource', async () => {
+    setupAdminConfigGet(server, {
+      alertmanagersChoice: AlertmanagerChoice.Internal,
+      external_alertmanager_uid: 'cortex-uid',
+    });
+    setupDatasourcesEndpoint(server, [CORTEX_DS]);
+
+    const { result } = renderHook(() => useAutoSyncConfiguration(), { wrapper: wrapper() });
+    await waitFor(() => expect(result.current.state).toEqual({ kind: 'configured', uid: 'cortex-uid' }));
+  });
+
+  it('returns `orphan-uid` when configured UID does not match any known datasource', async () => {
+    setupAdminConfigGet(server, {
+      alertmanagersChoice: AlertmanagerChoice.Internal,
+      external_alertmanager_uid: 'missing-uid',
+    });
+    setupDatasourcesEndpoint(server, [MIMIR_DS]);
+
+    const { result } = renderHook(() => useAutoSyncConfiguration(), { wrapper: wrapper() });
+    await waitFor(() => expect(result.current.state).toEqual({ kind: 'orphan-uid', uid: 'missing-uid' }));
+  });
+
+  it('returns `orphan-uid` (not `no-datasources`) when configured UID is set but no datasources exist', async () => {
+    setupAdminConfigGet(server, {
+      alertmanagersChoice: AlertmanagerChoice.Internal,
+      external_alertmanager_uid: 'missing-uid',
+    });
+    setupDatasourcesEndpoint(server, []);
+
+    const { result } = renderHook(() => useAutoSyncConfiguration(), { wrapper: wrapper() });
+    await waitFor(() => expect(result.current.state).toEqual({ kind: 'orphan-uid', uid: 'missing-uid' }));
+  });
+
+  it('returns `no-datasources` when no Mimir/Cortex datasources exist and no UID configured', async () => {
+    setupAdminConfigGet(server, { alertmanagersChoice: AlertmanagerChoice.Internal });
+    setupDatasourcesEndpoint(server, [VANILLA_DS]);
+
+    const { result } = renderHook(() => useAutoSyncConfiguration(), { wrapper: wrapper() });
+    await waitFor(() => expect(result.current.state.kind).toBe('no-datasources'));
+  });
+
+  it('treats a Vanilla (prometheus) Alertmanager datasource as not a Mimir/Cortex source', async () => {
+    setupAdminConfigGet(server, { alertmanagersChoice: AlertmanagerChoice.Internal });
+    setupDatasourcesEndpoint(server, [VANILLA_DS]);
+
+    const { result } = renderHook(() => useAutoSyncConfiguration(), { wrapper: wrapper() });
+    await waitFor(() => expect(result.current.state.kind).toBe('no-datasources'));
+    expect(result.current.mimirCortexDatasources).toHaveLength(0);
+  });
+
+  it('returns `unconfigured` when no UID is configured even if 404 is returned from admin_config', async () => {
+    // The backend returns 404 if no admin_config row exists for the org and no ini override.
+    setupAdminConfigGet(server, null);
+    setupDatasourcesEndpoint(server, [MIMIR_DS]);
+
+    const { result } = renderHook(() => useAutoSyncConfiguration(), { wrapper: wrapper() });
+    await waitFor(() => expect(result.current.state.kind).toBe('unconfigured'));
+  });
+});
+
+describe('useAutoSyncConfiguration — selection override', () => {
+  it('selectedUid follows configuredUid until the user changes it', async () => {
+    setupAdminConfigGet(server, {
+      alertmanagersChoice: AlertmanagerChoice.Internal,
+      external_alertmanager_uid: 'mimir-uid',
+    });
+    setupDatasourcesEndpoint(server, [MIMIR_DS]);
+
+    const { result } = renderHook(() => useAutoSyncConfiguration(), { wrapper: wrapper() });
+    await waitFor(() => expect(result.current.selectedUid).toBe('mimir-uid'));
+
+    act(() => result.current.setSelectedUid('other-uid'));
+    expect(result.current.selectedUid).toBe('other-uid');
+  });
+
+  it('does not overwrite user selection on background refetch', async () => {
+    setupAdminConfigGet(server, {
+      alertmanagersChoice: AlertmanagerChoice.Internal,
+      external_alertmanager_uid: 'mimir-uid',
+    });
+    setupDatasourcesEndpoint(server, [MIMIR_DS, CORTEX_DS]);
+
+    const { result, rerender } = renderHook(() => useAutoSyncConfiguration(), { wrapper: wrapper() });
+    await waitFor(() => expect(result.current.selectedUid).toBe('mimir-uid'));
+
+    // Simulate the user picking a different datasource.
+    act(() => result.current.setSelectedUid('cortex-uid'));
+    expect(result.current.selectedUid).toBe('cortex-uid');
+
+    // Rerender (which a refetch / unrelated state update would cause). The selection must hold.
+    rerender();
+    expect(result.current.selectedUid).toBe('cortex-uid');
+  });
+});
+
+describe('useAutoSyncConfiguration — save / disable', () => {
+  it('sends `{external_alertmanager_uid: <uid>}` on save', async () => {
+    setupAdminConfigGet(server, { alertmanagersChoice: AlertmanagerChoice.Internal });
+    setupDatasourcesEndpoint(server, [MIMIR_DS]);
+    setupAdminConfigPost(server, postState, 200);
+
+    const { result } = renderHook(() => useAutoSyncConfiguration(), { wrapper: wrapper() });
+    await waitFor(() => expect(result.current.state.kind).toBe('unconfigured'));
+
+    act(() => result.current.setSelectedUid('mimir-uid'));
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(postState.lastPayload).toEqual({ external_alertmanager_uid: 'mimir-uid' });
+  });
+
+  it('clears the selection override after a successful save so the picker re-syncs to the saved UID', async () => {
+    setupAdminConfigGet(server, {
+      alertmanagersChoice: AlertmanagerChoice.Internal,
+      external_alertmanager_uid: 'mimir-uid',
+    });
+    setupDatasourcesEndpoint(server, [MIMIR_DS, CORTEX_DS]);
+    setupAdminConfigPost(server, postState, 200);
+
+    const { result } = renderHook(() => useAutoSyncConfiguration(), { wrapper: wrapper() });
+    await waitFor(() => expect(result.current.selectedUid).toBe('mimir-uid'));
+
+    act(() => result.current.setSelectedUid('cortex-uid'));
+    expect(result.current.selectedUid).toBe('cortex-uid');
+
+    await act(async () => {
+      await result.current.save();
+    });
+
+    // The override is cleared; selectedUid follows configuredUid again (still 'mimir-uid' here
+    // because our static GET handler doesn't reflect the POST).
+    await waitFor(() => expect(result.current.selectedUid).toBe('mimir-uid'));
+  });
+
+  it('sends `{external_alertmanager_uid: ""}` on disableSync', async () => {
+    setupAdminConfigGet(server, {
+      alertmanagersChoice: AlertmanagerChoice.Internal,
+      external_alertmanager_uid: 'mimir-uid',
+    });
+    setupDatasourcesEndpoint(server, [MIMIR_DS]);
+    setupAdminConfigPost(server, postState, 200);
+
+    const { result } = renderHook(() => useAutoSyncConfiguration(), { wrapper: wrapper() });
+    await waitFor(() => expect(result.current.state.kind).toBe('configured'));
+
+    await act(async () => {
+      await result.current.disableSync();
+    });
+
+    expect(postState.lastPayload).toEqual({ external_alertmanager_uid: '' });
+  });
+
+  it('transitions to `operator-managed` when POST returns 409', async () => {
+    setupAdminConfigGet(server, {
+      alertmanagersChoice: AlertmanagerChoice.Internal,
+      external_alertmanager_uid: 'mimir-uid',
+    });
+    setupDatasourcesEndpoint(server, [MIMIR_DS]);
+    setupAdminConfigPost(server, postState, 409, { message: 'managed by operator' });
+
+    const { result } = renderHook(() => useAutoSyncConfiguration(), { wrapper: wrapper() });
+    await waitFor(() => expect(result.current.state.kind).toBe('configured'));
+
+    act(() => result.current.setSelectedUid('mimir-uid'));
+    await act(async () => {
+      await result.current.save();
+    });
+
+    await waitFor(() => expect(result.current.state).toEqual({ kind: 'operator-managed', uid: 'mimir-uid' }));
+  });
+
+  it('stays in `operator-managed` after subsequent re-renders within the session', async () => {
+    setupAdminConfigGet(server, {
+      alertmanagersChoice: AlertmanagerChoice.Internal,
+      external_alertmanager_uid: 'mimir-uid',
+    });
+    setupDatasourcesEndpoint(server, [MIMIR_DS]);
+    setupAdminConfigPost(server, postState, 409);
+
+    const { result, rerender } = renderHook(() => useAutoSyncConfiguration(), { wrapper: wrapper() });
+    await waitFor(() => expect(result.current.state.kind).toBe('configured'));
+
+    act(() => result.current.setSelectedUid('mimir-uid'));
+    await act(async () => {
+      await result.current.save();
+    });
+    await waitFor(() => expect(result.current.state.kind).toBe('operator-managed'));
+
+    rerender();
+    expect(result.current.state.kind).toBe('operator-managed');
+  });
+
+  it('does not transition to `operator-managed` when POST returns 400 — keeps current state', async () => {
+    setupAdminConfigGet(server, { alertmanagersChoice: AlertmanagerChoice.Internal });
+    setupDatasourcesEndpoint(server, [MIMIR_DS]);
+    setupAdminConfigPost(server, postState, 400, { message: 'invalid datasource' });
+
+    const { result } = renderHook(() => useAutoSyncConfiguration(), { wrapper: wrapper() });
+    await waitFor(() => expect(result.current.state.kind).toBe('unconfigured'));
+
+    act(() => result.current.setSelectedUid('mimir-uid'));
+    await act(async () => {
+      await result.current.save();
+    });
+
+    expect(result.current.state.kind).toBe('unconfigured');
+  });
+});

--- a/public/app/features/alerting/unified/components/settings/useAutoSyncConfiguration.tsx
+++ b/public/app/features/alerting/unified/components/settings/useAutoSyncConfiguration.tsx
@@ -1,0 +1,136 @@
+import { useMemo, useState } from 'react';
+
+import { type DataSourceSettings } from '@grafana/data';
+import { t } from '@grafana/i18n';
+import { useAppNotification } from 'app/core/copy/appNotification';
+import {
+  type AlertManagerDataSourceJsonData,
+  AlertManagerImplementation,
+} from 'app/plugins/datasource/alertmanager/types';
+
+import { alertmanagerApi } from '../../api/alertmanagerApi';
+import { dataSourcesApi } from '../../api/dataSourcesApi';
+import { isAlertmanagerDataSource } from '../../utils/datasource';
+import { stringifyErrorLike } from '../../utils/misc';
+
+export type AutoSyncState =
+  | { kind: 'unconfigured' }
+  | { kind: 'configured'; uid: string }
+  | { kind: 'operator-managed'; uid: string }
+  | { kind: 'no-datasources' }
+  | { kind: 'orphan-uid'; uid: string };
+
+export interface UseAutoSyncConfigurationResult {
+  state: AutoSyncState;
+  mimirCortexDatasources: Array<DataSourceSettings<AlertManagerDataSourceJsonData>>;
+  selectedUid: string;
+  setSelectedUid: (uid: string) => void;
+  save: () => Promise<void>;
+  disableSync: () => Promise<void>;
+  isPending: boolean;
+  isLoading: boolean;
+}
+
+const MIMIR_CORTEX_IMPLEMENTATIONS: AlertManagerImplementation[] = [
+  AlertManagerImplementation.mimir,
+  AlertManagerImplementation.cortex,
+];
+
+function isMimirOrCortex(ds: DataSourceSettings<AlertManagerDataSourceJsonData>): boolean {
+  const impl = ds.jsonData?.implementation ?? AlertManagerImplementation.mimir;
+  return MIMIR_CORTEX_IMPLEMENTATIONS.includes(impl);
+}
+
+export function hasConfiguredUid(state: AutoSyncState): state is Extract<AutoSyncState, { uid: string }> {
+  return state.kind === 'configured' || state.kind === 'orphan-uid' || state.kind === 'operator-managed';
+}
+
+export function isOperatorManaged(state: AutoSyncState): state is Extract<AutoSyncState, { kind: 'operator-managed' }> {
+  return state.kind === 'operator-managed';
+}
+
+export function useAutoSyncConfiguration(): UseAutoSyncConfigurationResult {
+  const { currentData: configuration, isLoading: isLoadingConfig } =
+    alertmanagerApi.endpoints.getGrafanaAlertingConfiguration.useQuery();
+  const { currentData: allDatasources, isLoading: isLoadingDatasources } =
+    dataSourcesApi.endpoints.getAllDataSourceSettings.useQuery(undefined, {
+      refetchOnMountOrArgChange: true,
+    });
+  const [updateConfiguration, updateConfigurationState] =
+    alertmanagerApi.endpoints.updateGrafanaAlertingConfiguration.useMutation();
+
+  const [operatorManagedUid, setOperatorManagedUid] = useState<string | null>(null);
+
+  const mimirCortexDatasources = useMemo(
+    () => (allDatasources ?? []).filter(isAlertmanagerDataSource).filter(isMimirOrCortex),
+    [allDatasources]
+  );
+
+  const configuredUid = configuration?.external_alertmanager_uid ?? '';
+  const hasMatchingDatasource = mimirCortexDatasources.some((ds) => ds.uid === configuredUid);
+
+  // Track user-edited selection separately from the saved value so a background refetch
+  // doesn't overwrite an in-flight choice. Null means "follow the saved value".
+  const [selectedOverride, setSelectedOverride] = useState<string | null>(null);
+  const selectedUid = selectedOverride ?? configuredUid;
+
+  const state: AutoSyncState = useMemo(() => {
+    if (configuredUid && operatorManagedUid === configuredUid) {
+      return { kind: 'operator-managed', uid: configuredUid };
+    }
+    if (configuredUid && hasMatchingDatasource) {
+      return { kind: 'configured', uid: configuredUid };
+    }
+    if (configuredUid) {
+      return { kind: 'orphan-uid', uid: configuredUid };
+    }
+    if (mimirCortexDatasources.length === 0) {
+      return { kind: 'no-datasources' };
+    }
+    return { kind: 'unconfigured' };
+  }, [operatorManagedUid, configuredUid, hasMatchingDatasource, mimirCortexDatasources.length]);
+
+  const notify = useAppNotification();
+
+  const persist = async (uid: string) => {
+    try {
+      await updateConfiguration({
+        external_alertmanager_uid: uid,
+        notificationOptions: { showErrorAlert: false },
+      }).unwrap();
+      notify.success(
+        uid
+          ? t('alerting.settings.auto-sync.save-success', 'Mimir Alertmanager auto-sync enabled')
+          : t('alerting.settings.auto-sync.disable-success', 'Mimir Alertmanager auto-sync disabled')
+      );
+      setSelectedOverride(null);
+    } catch (err) {
+      // 409 means the operator-level ini key is authoritative for this org; the request will
+      // never succeed via the UI, and the user needs to be told via the operator-managed state.
+      if (isStatusCode(err, 409)) {
+        setOperatorManagedUid(configuredUid || uid);
+        return;
+      }
+      notify.error(
+        t('alerting.settings.auto-sync.save-error', 'Failed to save Mimir Alertmanager auto-sync'),
+        stringifyErrorLike(err)
+      );
+    }
+  };
+
+  return {
+    state,
+    mimirCortexDatasources,
+    selectedUid,
+    setSelectedUid: (uid: string) => setSelectedOverride(uid),
+    save: () => persist(selectedUid),
+    // Backend convention: empty string clears the configured UID.
+    disableSync: () => persist(''),
+    isPending: updateConfigurationState.isLoading,
+    isLoading: isLoadingConfig || isLoadingDatasources,
+  };
+}
+
+function isStatusCode(err: unknown, status: number): boolean {
+  return typeof err === 'object' && err !== null && 'status' in err && err.status === status;
+}

--- a/public/app/features/alerting/unified/hooks/useImportEntrypointState.test.ts
+++ b/public/app/features/alerting/unified/hooks/useImportEntrypointState.test.ts
@@ -1,0 +1,69 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { getWrapper, testWithFeatureToggles } from 'test/test-utils';
+
+import { OrgRole } from '@grafana/data';
+import { AlertmanagerChoice } from 'app/plugins/datasource/alertmanager/types';
+
+import { setupMswServer } from '../mockApi';
+import { grantUserRole } from '../mocks';
+import { setupAdminConfigGet } from '../mocks/server/configure/admin_config';
+
+import { useImportEntrypointState } from './useImportEntrypointState';
+
+const server = setupMswServer();
+
+function renderUseImportEntrypointState() {
+  const wrapper = getWrapper({ renderWithRouter: false });
+  return renderHook(() => useImportEntrypointState(), { wrapper });
+}
+
+describe('useImportEntrypointState', () => {
+  beforeEach(() => {
+    grantUserRole(OrgRole.Admin);
+  });
+
+  describe('with alerting.syncExternalAlertmanager feature flag enabled', () => {
+    testWithFeatureToggles({ enable: ['alerting.syncExternalAlertmanager'] });
+
+    it('returns disabled with a localized reason when admin_config has external_alertmanager_uid', async () => {
+      setupAdminConfigGet(server, {
+        alertmanagersChoice: AlertmanagerChoice.Internal,
+        external_alertmanager_uid: 'mimir-uid',
+      });
+
+      const { result } = renderUseImportEntrypointState();
+
+      await waitFor(() => {
+        expect(result.current.disabled).toBe(true);
+      });
+      expect(result.current.reason).toMatch(/auto-sync/i);
+    });
+
+    it('returns not disabled when admin_config has no external_alertmanager_uid', async () => {
+      setupAdminConfigGet(server, { alertmanagersChoice: AlertmanagerChoice.Internal });
+
+      const { result } = renderUseImportEntrypointState();
+
+      // Give the query a chance to resolve before asserting the false case.
+      await waitFor(() => {
+        expect(result.current.disabled).toBe(false);
+      });
+      expect(result.current.reason).toBeUndefined();
+    });
+  });
+
+  describe('with alerting.syncExternalAlertmanager feature flag disabled', () => {
+    it('returns not disabled regardless of admin_config state', () => {
+      setupAdminConfigGet(server, {
+        alertmanagersChoice: AlertmanagerChoice.Internal,
+        external_alertmanager_uid: 'mimir-uid',
+      });
+
+      const { result } = renderUseImportEntrypointState();
+
+      // Feature flag gates the query — the hook should not consider auto-sync active.
+      expect(result.current.disabled).toBe(false);
+      expect(result.current.reason).toBeUndefined();
+    });
+  });
+});

--- a/public/app/features/alerting/unified/hooks/useImportEntrypointState.ts
+++ b/public/app/features/alerting/unified/hooks/useImportEntrypointState.ts
@@ -1,0 +1,22 @@
+import { t } from '@grafana/i18n';
+
+import { useIsAutoSyncActive } from './useIsAutoSyncActive';
+
+export interface ImportEntrypointState {
+  disabled: boolean;
+  reason?: string;
+}
+
+export function useImportEntrypointState(): ImportEntrypointState {
+  const isAutoSyncActive = useIsAutoSyncActive();
+  if (isAutoSyncActive) {
+    return {
+      disabled: true,
+      reason: t(
+        'alerting.rule-list.import-disabled-tooltip.auto-sync',
+        'Imports are unavailable while Mimir Alertmanager auto-sync is active'
+      ),
+    };
+  }
+  return { disabled: false };
+}

--- a/public/app/features/alerting/unified/hooks/useIsAutoSyncActive.ts
+++ b/public/app/features/alerting/unified/hooks/useIsAutoSyncActive.ts
@@ -1,0 +1,18 @@
+import { skipToken } from '@reduxjs/toolkit/query';
+
+import { config } from '@grafana/runtime';
+
+import { alertmanagerApi } from '../api/alertmanagerApi';
+import { isAdmin } from '../utils/misc';
+
+// GET /api/v1/ngalert/admin_config is gated behind ReqOrgAdmin server-side
+// (pkg/services/ngalert/api/authorization.go), so non-admins cannot read sync
+// state and this hook returns false for them. The convert API's
+// IsExternalAMSyncConfiguredForOrg check is the server-side safety net.
+export function useIsAutoSyncActive(): boolean {
+  const flagOn = config.featureToggles['alerting.syncExternalAlertmanager'] === true;
+  const { data } = alertmanagerApi.endpoints.getGrafanaAlertingConfiguration.useQuery(
+    isAdmin() && flagOn ? undefined : skipToken
+  );
+  return Boolean(data?.external_alertmanager_uid);
+}

--- a/public/app/features/alerting/unified/mocks/server/configure/admin_config.ts
+++ b/public/app/features/alerting/unified/mocks/server/configure/admin_config.ts
@@ -1,0 +1,69 @@
+import { HttpResponse, http } from 'msw';
+import { type SetupServer } from 'msw/node';
+
+import {
+  AlertmanagerChoice,
+  type GrafanaAlertingConfiguration,
+  type PostableGrafanaAlertingConfiguration,
+} from 'app/plugins/datasource/alertmanager/types';
+
+const ADMIN_CONFIG_URL = '/api/v1/ngalert/admin_config';
+const ALERTMANAGERS_STATUS_URL = '/api/v1/ngalert/alertmanagers';
+
+export interface AdminConfigPostState {
+  lastPayload: PostableGrafanaAlertingConfiguration | null;
+}
+
+export function setupAdminConfigGet(server: SetupServer, body: GrafanaAlertingConfiguration | null) {
+  server.use(
+    http.get(ADMIN_CONFIG_URL, () => {
+      if (body === null) {
+        return new HttpResponse(null, { status: 404 });
+      }
+      return HttpResponse.json(body);
+    })
+  );
+}
+
+export function setupAdminConfigPost(
+  server: SetupServer,
+  state: AdminConfigPostState,
+  status: number,
+  body: object = { message: 'ok' }
+) {
+  server.use(
+    http.post(ADMIN_CONFIG_URL, async ({ request }) => {
+      state.lastPayload = (await request.json()) as PostableGrafanaAlertingConfiguration;
+      return HttpResponse.json(body, { status });
+    })
+  );
+}
+
+/**
+ * Stateful admin_config handlers: POST writes to a ref, GET reads from it so a refetch after
+ * RTKQ tag invalidation sees the persisted UID without a manual handler swap.
+ */
+export function setupStatefulAdminConfig(
+  server: SetupServer,
+  state: AdminConfigPostState,
+  initial: GrafanaAlertingConfiguration = { alertmanagersChoice: AlertmanagerChoice.Internal }
+) {
+  let stored: PostableGrafanaAlertingConfiguration = { ...initial };
+  server.use(
+    http.get(ADMIN_CONFIG_URL, () => HttpResponse.json(stored)),
+    http.post(ADMIN_CONFIG_URL, async ({ request }) => {
+      const body = (await request.json()) as PostableGrafanaAlertingConfiguration;
+      state.lastPayload = body;
+      stored = { ...stored, ...body };
+      return HttpResponse.json({ message: 'ok' });
+    })
+  );
+}
+
+export function setupAlertmanagersStatus(server: SetupServer) {
+  server.use(
+    http.get(ALERTMANAGERS_STATUS_URL, () =>
+      HttpResponse.json({ data: { activeAlertManagers: [], droppedAlertManagers: [] } })
+    )
+  );
+}

--- a/public/app/features/alerting/unified/mocks/server/configure/datasources.ts
+++ b/public/app/features/alerting/unified/mocks/server/configure/datasources.ts
@@ -1,0 +1,10 @@
+import { HttpResponse, http } from 'msw';
+import { type SetupServer } from 'msw/node';
+
+/**
+ * Generic MSW handler for `/api/datasources`. Use when a test needs to control the datasource
+ * list without going through the full `setupDataSources` test helper.
+ */
+export function setupDatasourcesEndpoint(server: SetupServer, datasources: object[]) {
+  server.use(http.get('/api/datasources', () => HttpResponse.json(datasources)));
+}

--- a/public/app/features/alerting/unified/rule-list/RuleList.v2.test.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleList.v2.test.tsx
@@ -441,7 +441,7 @@ describe('RuleListActions', () => {
     });
   });
 
-  describe('Auto-sync Mimir Alertmanager — hides import menu items', () => {
+  describe('Auto-sync Mimir Alertmanager — disables import menu items', () => {
     testWithFeatureToggles({
       enable: ['alerting.syncExternalAlertmanager', 'alertingMigrationUI', 'alertingMigrationWizardUI'],
     });
@@ -454,7 +454,15 @@ describe('RuleListActions', () => {
       );
     }
 
-    it('hides "Import alert rules" when sync is configured for the org', async () => {
+    async function findDisabledItem(menu: HTMLElement, role: 'importAlertRules' | 'importToGma') {
+      // The menu item renders the disabled reason in its `description` slot, so the accessible
+      // name expands beyond the original label — match via a name regex that ignores the suffix.
+      return await byRole('menuitem', {
+        name: role === 'importAlertRules' ? /import alert rules/i : /import to grafana alerting/i,
+      }).find(menu);
+    }
+
+    it('disables "Import alert rules" with a reason when sync is configured for the org', async () => {
       grantUserRole(OrgRole.Admin);
       grantUserPermissions([
         AccessControlAction.AlertingRuleRead,
@@ -467,10 +475,13 @@ describe('RuleListActions', () => {
       await user.click(ui.moreButton.get());
       const menu = await ui.moreMenu.find();
 
-      expect(ui.menuOptions.importAlertRules.query(menu)).not.toBeInTheDocument();
+      const item = await findDisabledItem(menu, 'importAlertRules');
+      expect(item).toHaveAttribute('aria-disabled', 'true');
+      expect(item).not.toHaveAttribute('href');
+      expect(item).toHaveTextContent(/auto-sync/i);
     });
 
-    it('hides "Import to Grafana Alerting" when sync is configured for the org', async () => {
+    it('disables "Import to Grafana Alerting" with a reason when sync is configured for the org', async () => {
       grantUserRole(OrgRole.Admin);
       grantUserPermissions([AccessControlAction.AlertingRuleRead, AccessControlAction.AlertingNotificationsWrite]);
       mockAdminConfig('mimir-uid');
@@ -479,10 +490,13 @@ describe('RuleListActions', () => {
       await user.click(ui.moreButton.get());
       const menu = await ui.moreMenu.find();
 
-      expect(ui.menuOptions.importToGma.query(menu)).not.toBeInTheDocument();
+      const item = await findDisabledItem(menu, 'importToGma');
+      expect(item).toHaveAttribute('aria-disabled', 'true');
+      expect(item).not.toHaveAttribute('href');
+      expect(item).toHaveTextContent(/auto-sync/i);
     });
 
-    it('leaves import items visible when sync is not configured', async () => {
+    it('leaves import items enabled when sync is not configured', async () => {
       grantUserRole(OrgRole.Admin);
       grantUserPermissions([
         AccessControlAction.AlertingRuleRead,
@@ -496,8 +510,12 @@ describe('RuleListActions', () => {
       await user.click(ui.moreButton.get());
       const menu = await ui.moreMenu.find();
 
-      expect(ui.menuOptions.importAlertRules.get(menu)).toBeInTheDocument();
-      expect(ui.menuOptions.importToGma.get(menu)).toBeInTheDocument();
+      const importItem = ui.menuOptions.importAlertRules.get(menu);
+      const wizardItem = ui.menuOptions.importToGma.get(menu);
+      expect(importItem).toHaveAttribute('href', '/alerting/import-datasource-managed-rules');
+      expect(importItem).not.toHaveAttribute('aria-disabled', 'true');
+      expect(wizardItem).toHaveAttribute('href', '/alerting/import-to-gma');
+      expect(wizardItem).not.toHaveAttribute('aria-disabled', 'true');
     });
   });
 

--- a/public/app/features/alerting/unified/rule-list/RuleList.v2.test.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleList.v2.test.tsx
@@ -1,4 +1,4 @@
-import { HttpResponse } from 'msw';
+import { HttpResponse, http } from 'msw';
 import { render, testWithFeatureToggles, waitFor } from 'test/test-utils';
 import { byRole, byTestId } from 'testing-library-selector';
 
@@ -66,7 +66,7 @@ setPluginComponentsHook(() => ({ components: [], isLoading: false }));
 grantUserPermissions([AccessControlAction.AlertingRuleExternalRead]);
 testWithFeatureToggles({ enable: ['alertingListViewV2'] });
 
-setupMswServer();
+const server = setupMswServer();
 
 alertingFactory.dataSource.build({ name: 'Mimir', uid: 'mimir' });
 alertingFactory.dataSource.build({ name: 'Prometheus', uid: 'prometheus' });
@@ -438,6 +438,66 @@ describe('RuleListActions', () => {
       const menu = await ui.moreMenu.find();
 
       expect(ui.menuOptions.newDataSourceRecordingRule.query(menu)).toBeInTheDocument();
+    });
+  });
+
+  describe('Auto-sync Mimir Alertmanager — hides import menu items', () => {
+    testWithFeatureToggles({
+      enable: ['alerting.syncExternalAlertmanager', 'alertingMigrationUI', 'alertingMigrationWizardUI'],
+    });
+
+    function mockAdminConfig(uid?: string) {
+      server.use(
+        http.get('/api/v1/ngalert/admin_config', () =>
+          HttpResponse.json({ alertmanagersChoice: 'internal', ...(uid ? { external_alertmanager_uid: uid } : {}) })
+        )
+      );
+    }
+
+    it('hides "Import alert rules" when sync is configured for the org', async () => {
+      grantUserRole(OrgRole.Admin);
+      grantUserPermissions([
+        AccessControlAction.AlertingRuleRead,
+        AccessControlAction.AlertingRuleCreate,
+        AccessControlAction.AlertingProvisioningSetStatus,
+      ]);
+      mockAdminConfig('mimir-uid');
+
+      const { user } = render(<RuleListActions />);
+      await user.click(ui.moreButton.get());
+      const menu = await ui.moreMenu.find();
+
+      expect(ui.menuOptions.importAlertRules.query(menu)).not.toBeInTheDocument();
+    });
+
+    it('hides "Import to Grafana Alerting" when sync is configured for the org', async () => {
+      grantUserRole(OrgRole.Admin);
+      grantUserPermissions([AccessControlAction.AlertingRuleRead, AccessControlAction.AlertingNotificationsWrite]);
+      mockAdminConfig('mimir-uid');
+
+      const { user } = render(<RuleListActions />);
+      await user.click(ui.moreButton.get());
+      const menu = await ui.moreMenu.find();
+
+      expect(ui.menuOptions.importToGma.query(menu)).not.toBeInTheDocument();
+    });
+
+    it('leaves import items visible when sync is not configured', async () => {
+      grantUserRole(OrgRole.Admin);
+      grantUserPermissions([
+        AccessControlAction.AlertingRuleRead,
+        AccessControlAction.AlertingRuleCreate,
+        AccessControlAction.AlertingProvisioningSetStatus,
+        AccessControlAction.AlertingNotificationsWrite,
+      ]);
+      mockAdminConfig();
+
+      const { user } = render(<RuleListActions />);
+      await user.click(ui.moreButton.get());
+      const menu = await ui.moreMenu.find();
+
+      expect(ui.menuOptions.importAlertRules.get(menu)).toBeInTheDocument();
+      expect(ui.menuOptions.importToGma.get(menu)).toBeInTheDocument();
     });
   });
 

--- a/public/app/features/alerting/unified/rule-list/RuleList.v2.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleList.v2.tsx
@@ -1,4 +1,3 @@
-import { skipToken } from '@reduxjs/toolkit/query';
 import { useMemo } from 'react';
 import { useToggle } from 'react-use';
 
@@ -8,13 +7,13 @@ import { Box, Button, Dropdown, Icon, LinkButton, Menu, Stack } from '@grafana/u
 import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction } from 'app/types/accessControl';
 
-import { alertmanagerApi } from '../api/alertmanagerApi';
 import { AlertingPageWrapper } from '../components/AlertingPageWrapper';
 import { GrafanaRulesExporter } from '../components/export/GrafanaRulesExporter';
 import { useListViewMode } from '../components/rules/Filter/RulesViewModeSelector';
 import { AIAlertRuleButtonComponent } from '../enterprise-components/AI/AIGenAlertRuleButton/addAIAlertRuleButton';
 import { AlertingAction, useAlertingAbility } from '../hooks/useAbilities';
 import { useRulesFilter } from '../hooks/useFilteredRules';
+import { useIsAutoSyncActive } from '../hooks/useIsAutoSyncActive';
 import { useAlertRulesNav } from '../navigation/useAlertRulesNav';
 import { getRulesDataSources } from '../utils/datasource';
 import { isAdmin } from '../utils/misc';
@@ -74,14 +73,7 @@ export function RuleListActions() {
 
   const canAccessMigrationWizardUI = config.featureToggles.alertingMigrationWizardUI && isAdmin();
 
-  // When Mimir Alertmanager auto-sync is configured for this org, the convert API rejects
-  // manual import requests server-side (via IsExternalAMSyncConfiguredForOrg). Hide the
-  // entry points entirely rather than surfacing a disabled state.
-  const autoSyncFlagOn = config.featureToggles['alerting.syncExternalAlertmanager'] === true;
-  const { data: ngalertAdminConfig } = alertmanagerApi.endpoints.getGrafanaAlertingConfiguration.useQuery(
-    isAdmin() && autoSyncFlagOn ? undefined : skipToken
-  );
-  const isAutoSyncActive = Boolean(ngalertAdminConfig?.external_alertmanager_uid);
+  const isAutoSyncActive = useIsAutoSyncActive();
 
   const [showExportDrawer, toggleShowExportDrawer] = useToggle(false);
 

--- a/public/app/features/alerting/unified/rule-list/RuleList.v2.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleList.v2.tsx
@@ -13,7 +13,7 @@ import { useListViewMode } from '../components/rules/Filter/RulesViewModeSelecto
 import { AIAlertRuleButtonComponent } from '../enterprise-components/AI/AIGenAlertRuleButton/addAIAlertRuleButton';
 import { AlertingAction, useAlertingAbility } from '../hooks/useAbilities';
 import { useRulesFilter } from '../hooks/useFilteredRules';
-import { useIsAutoSyncActive } from '../hooks/useIsAutoSyncActive';
+import { useImportEntrypointState } from '../hooks/useImportEntrypointState';
 import { useAlertRulesNav } from '../navigation/useAlertRulesNav';
 import { getRulesDataSources } from '../utils/datasource';
 import { isAdmin } from '../utils/misc';
@@ -73,7 +73,7 @@ export function RuleListActions() {
 
   const canAccessMigrationWizardUI = config.featureToggles.alertingMigrationWizardUI && isAdmin();
 
-  const isAutoSyncActive = useIsAutoSyncActive();
+  const { disabled: importDisabled, reason: importDisabledReason } = useImportEntrypointState();
 
   const [showExportDrawer, toggleShowExportDrawer] = useToggle(false);
 
@@ -93,18 +93,22 @@ export function RuleListActions() {
               onClick={toggleShowExportDrawer}
             />
           )}
-          {canImportRulesToGMA && !isAutoSyncActive && (
+          {canImportRulesToGMA && (
             <Menu.Item
               label={t('alerting.rule-list-v2.import-to-gma', 'Import alert rules')}
               icon="upload"
               url="/alerting/import-datasource-managed-rules"
+              disabled={importDisabled}
+              description={importDisabled ? importDisabledReason : undefined}
             />
           )}
-          {canAccessMigrationWizardUI && !isAutoSyncActive && (
+          {canAccessMigrationWizardUI && (
             <Menu.Item
               label={t('alerting.rule-list-v2.import-to-gma-tool', 'Import to Grafana Alerting')}
               icon="exchange-alt"
               url="/alerting/import-to-gma"
+              disabled={importDisabled}
+              description={importDisabled ? importDisabledReason : undefined}
             />
           )}
         </Menu.Group>
@@ -133,7 +137,8 @@ export function RuleListActions() {
       canAccessMigrationWizardUI,
       canExportRules,
       toggleShowExportDrawer,
-      isAutoSyncActive,
+      importDisabled,
+      importDisabledReason,
     ]
   );
 

--- a/public/app/features/alerting/unified/rule-list/RuleList.v2.tsx
+++ b/public/app/features/alerting/unified/rule-list/RuleList.v2.tsx
@@ -1,3 +1,4 @@
+import { skipToken } from '@reduxjs/toolkit/query';
 import { useMemo } from 'react';
 import { useToggle } from 'react-use';
 
@@ -7,6 +8,7 @@ import { Box, Button, Dropdown, Icon, LinkButton, Menu, Stack } from '@grafana/u
 import { contextSrv } from 'app/core/services/context_srv';
 import { AccessControlAction } from 'app/types/accessControl';
 
+import { alertmanagerApi } from '../api/alertmanagerApi';
 import { AlertingPageWrapper } from '../components/AlertingPageWrapper';
 import { GrafanaRulesExporter } from '../components/export/GrafanaRulesExporter';
 import { useListViewMode } from '../components/rules/Filter/RulesViewModeSelector';
@@ -72,6 +74,15 @@ export function RuleListActions() {
 
   const canAccessMigrationWizardUI = config.featureToggles.alertingMigrationWizardUI && isAdmin();
 
+  // When Mimir Alertmanager auto-sync is configured for this org, the convert API rejects
+  // manual import requests server-side (via IsExternalAMSyncConfiguredForOrg). Hide the
+  // entry points entirely rather than surfacing a disabled state.
+  const autoSyncFlagOn = config.featureToggles['alerting.syncExternalAlertmanager'] === true;
+  const { data: ngalertAdminConfig } = alertmanagerApi.endpoints.getGrafanaAlertingConfiguration.useQuery(
+    isAdmin() && autoSyncFlagOn ? undefined : skipToken
+  );
+  const isAutoSyncActive = Boolean(ngalertAdminConfig?.external_alertmanager_uid);
+
   const [showExportDrawer, toggleShowExportDrawer] = useToggle(false);
 
   const moreActionsMenu = useMemo(
@@ -90,14 +101,14 @@ export function RuleListActions() {
               onClick={toggleShowExportDrawer}
             />
           )}
-          {canImportRulesToGMA && (
+          {canImportRulesToGMA && !isAutoSyncActive && (
             <Menu.Item
               label={t('alerting.rule-list-v2.import-to-gma', 'Import alert rules')}
               icon="upload"
               url="/alerting/import-datasource-managed-rules"
             />
           )}
-          {canAccessMigrationWizardUI && (
+          {canAccessMigrationWizardUI && !isAutoSyncActive && (
             <Menu.Item
               label={t('alerting.rule-list-v2.import-to-gma-tool', 'Import to Grafana Alerting')}
               icon="exchange-alt"
@@ -130,6 +141,7 @@ export function RuleListActions() {
       canAccessMigrationWizardUI,
       canExportRules,
       toggleShowExportDrawer,
+      isAutoSyncActive,
     ]
   );
 

--- a/public/app/plugins/datasource/alertmanager/types.ts
+++ b/public/app/plugins/datasource/alertmanager/types.ts
@@ -357,7 +357,12 @@ export enum AlertmanagerChoice {
 
 export interface GrafanaAlertingConfiguration {
   alertmanagersChoice: AlertmanagerChoice;
+  // Snake_case mirrors the wire format from /api/v1/ngalert/admin_config.
+  external_alertmanager_uid?: string;
 }
+
+// POST /api/v1/ngalert/admin_config accepts partial updates.
+export type PostableGrafanaAlertingConfiguration = Partial<GrafanaAlertingConfiguration>;
 
 export enum AlertManagerImplementation {
   cortex = 'cortex',

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3260,6 +3260,30 @@
       "tooltip-content": "Not finding the data source you want? Some data sources are not supported for alerting. Click on the icon for more information."
     },
     "settings": {
+      "auto-sync": {
+        "action-disable": "Disable sync",
+        "add-datasource-link": "Add Mimir datasource",
+        "badge-active": "Active",
+        "badge-not-configured": "Not configured",
+        "badge-operator-managed": "Managed by operator",
+        "description": "Continuously sync alert configuration from a Mimir or Cortex Alertmanager datasource into Grafana.",
+        "disable-confirm-action": "Disable sync",
+        "disable-confirm-body": "Disabling will stop continuous sync from datasource {{uid}}. You can re-enable it later by selecting a datasource again.",
+        "disable-confirm-body-generic": "Disabling will stop continuous sync. You can re-enable it later by selecting a datasource again.",
+        "disable-confirm-title": "Disable Mimir Alertmanager auto-sync?",
+        "disable-success": "Mimir Alertmanager auto-sync disabled",
+        "operator-managed-info": "This value is set by the <1>[unified_alerting] external_alertmanager_uid</1> key in grafana.ini and cannot be changed from the UI. Edit the configuration file and restart Grafana, or remove the key to manage sync from here.",
+        "operator-managed-title": "Managed by operator",
+        "orphan-warning": "The configured datasource UID {{uid}} is not available. Disable sync or restore the datasource to continue.",
+        "orphan-warning-title": "Configured datasource not found",
+        "picker-empty": "No Mimir or Cortex datasources available",
+        "picker-label": "Datasource",
+        "picker-placeholder": "Select a Mimir or Cortex Alertmanager datasource…",
+        "save-disabled-no-selection": "Select a Mimir or Cortex Alertmanager datasource to enable saving.",
+        "save-error": "Failed to save Mimir Alertmanager auto-sync",
+        "save-success": "Mimir Alertmanager auto-sync enabled",
+        "title": "Auto-sync configuration"
+      },
       "tabs": {
         "alert-managers": "Alert managers"
       }

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -3006,6 +3006,9 @@
         "results-loading": "Searching – found {{numberOfRules}} rules",
         "results-with-cancellation": "Search cancelled – found {{numberOfRules}} rules"
       },
+      "import-disabled-tooltip": {
+        "auto-sync": "Imports are unavailable while Mimir Alertmanager auto-sync is active"
+      },
       "import-to-gma": {
         "new-badge": "New!",
         "text": "Import to Grafana-managed rules"


### PR DESCRIPTION
**What is this feature?**

This PR adds an Auto-sync configuration card to the Alerting settings page. From this card admins can pick a Mimir or Cortex Alertmanager datasource, save it as the external Alertmanager source, and disable sync later.  The card is gated behind the `alerting.syncExternalAlertmanager` feature toggle.

When auto-sync is active, the rule list UI hides the "Import to Grafana-managed rules" entry points. This applies to the v1 `CloudRules` migrate button and to the v2 rule list actions menu.


https://github.com/user-attachments/assets/0a255893-9f29-4588-b3b1-0072cb9ccfaa

**Why do we need this feature?**

Admins need to manage sync without touching configuration files or API clients, and hiding the GMA import path while sync is active prevents users from setting up conflicting rule sources.

**Who is this feature for?**

Alerting users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/alerting-squad/issues/1608

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
