### PR TITLE
Alerting: remove MergeMatchers from ExtraConfiguration

### DIFF
--- a/pkg/services/ngalert/api/api_convert_prometheus.go
+++ b/pkg/services/ngalert/api/api_convert_prometheus.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/prometheus/alertmanager/pkg/labels"
 	prommodel "github.com/prometheus/common/model"
 	"go.yaml.in/yaml/v3"
 
@@ -55,10 +54,6 @@ const (
 	// notificationSettingsHeader is the header that specifies the notification settings to be used for the rules.
 	// The value should be a JSON-encoded AlertRuleNotificationSettings object.
 	notificationSettingsHeader = "X-Grafana-Alerting-Notification-Settings"
-
-	// mergeMatchersHeader is the header that specifies the merge matchers for imported Alertmanager config.
-	// The value should be comma-separated key=value pairs, e.g., "environment=production,team=alerting".
-	mergeMatchersHeader = "X-Grafana-Alerting-Merge-Matchers"
 
 	// extraLabelsHeader is the header that specifies extra labels to be added to all imported rules.
 	// The value should be comma-separated key=value pairs, e.g., "environment=production,team=alerting".
@@ -631,15 +626,8 @@ func (srv *ConvertPrometheusSrv) RouteConvertPrometheusPostAlertmanagerConfig(c 
 		return errorToResponse(err)
 	}
 
-	mergeMatchers, err := parseMergeMatchersHeader(c)
-	if err != nil {
-		logger.Error("Failed to parse merge matchers header", "error", err, "identifier", identifier)
-		return errorToResponse(err)
-	}
-
 	ec := apimodels.ExtraConfiguration{
 		Identifier:         identifier,
-		MergeMatchers:      mergeMatchers,
 		TemplateFiles:      amCfg.TemplateFiles,
 		AlertmanagerConfig: amCfg.AlertmanagerConfig,
 	}
@@ -731,7 +719,6 @@ func (srv *ConvertPrometheusSrv) RouteConvertPrometheusGetAlertmanagerConfig(c *
 
 	resp := convertPrometheusResponse(c, http.StatusOK, respBody)
 	resp.SetHeader(configIdentifierHeader, extraCfg.Identifier)
-	resp.SetHeader(mergeMatchersHeader, formatMergeMatchers(extraCfg.MergeMatchers))
 
 	return resp
 }
@@ -913,32 +900,6 @@ func parseKeyValuePairs(input string, headerName string) (map[string]string, err
 	return result, nil
 }
 
-// parseMergeMatchersHeader parses the merge matchers header value.
-// Expected format: "key1=value1,key2=value2"
-func parseMergeMatchersHeader(c *contextmodel.ReqContext) (apimodels.Matchers, error) {
-	matchersStr := strings.TrimSpace(c.Req.Header.Get(mergeMatchersHeader))
-
-	if matchersStr == "" {
-		return nil, nil
-	}
-
-	kvPairs, err := parseKeyValuePairs(matchersStr, mergeMatchersHeader)
-	if err != nil {
-		return nil, err
-	}
-
-	matchers := apimodels.Matchers{}
-	for key, value := range kvPairs {
-		matchers = append(matchers, &labels.Matcher{
-			Type:  labels.MatchEqual,
-			Name:  key,
-			Value: value,
-		})
-	}
-
-	return matchers, nil
-}
-
 // parseExtraLabelsHeader parses the extra labels header value.
 // Expected format: "key1=value1,key2=value2"
 func parseExtraLabelsHeader(c *contextmodel.ReqContext) (map[string]string, error) {
@@ -954,16 +915,6 @@ func parseVersionMessageHeader(c *contextmodel.ReqContext) (string, error) {
 		return "", errInvalidHeaderValue(versionMessageHeader, errors.New("must be less than 500 characters"))
 	}
 	return str, nil
-}
-
-func formatMergeMatchers(matchers apimodels.Matchers) string {
-	var pairs []string
-	for _, matcher := range matchers {
-		if matcher.Type == labels.MatchEqual {
-			pairs = append(pairs, fmt.Sprintf("%s=%s", matcher.Name, matcher.Value))
-		}
-	}
-	return strings.Join(pairs, ",")
 }
 
 func readConfigIdentifierHeader(c *contextmodel.ReqContext) string {

--- a/pkg/services/ngalert/api/api_convert_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_convert_prometheus_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prometheus/alertmanager/pkg/labels"
 	prommodel "github.com/prometheus/common/model"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -1995,14 +1994,12 @@ func TestRouteConvertPrometheusPostAlertmanagerConfig(t *testing.T) {
 	t.Run("should parse headers and call SaveAndApplyExtraConfiguration", func(t *testing.T) {
 		mockAM.On("SaveAndApplyExtraConfiguration", mock.Anything, int64(1), mock.Anything, mock.Anything, mock.MatchedBy(func(extraConfig apimodels.ExtraConfiguration) bool {
 			return extraConfig.Identifier == identifier &&
-				len(extraConfig.MergeMatchers) == 2 &&
 				len(extraConfig.TemplateFiles) == 1 &&
 				extraConfig.TemplateFiles["test.tmpl"] == "{{ define \"test\" }}Hello{{ end }}"
 		}), false, false).Return(merge.RenameResources{}, nil).Once()
 
 		rc := createRequestCtx()
 		rc.Req.Header.Set(configIdentifierHeader, identifier)
-		rc.Req.Header.Set(mergeMatchersHeader, "environment=production,team=backend")
 
 		amCfg := apimodels.AlertmanagerUserConfig{
 			AlertmanagerConfig: `{
@@ -2028,7 +2025,6 @@ func TestRouteConvertPrometheusPostAlertmanagerConfig(t *testing.T) {
 
 	t.Run("should use default identifier when header is missing", func(t *testing.T) {
 		rc := createRequestCtx()
-		rc.Req.Header.Set(mergeMatchersHeader, "test=value")
 		mockAM := &mockAlertmanager{}
 		mockAM.On("IsExternalAMSyncConfiguredForOrg", mock.Anything, int64(1)).Return(false, nil).Maybe()
 		mockAM.On("SaveAndApplyExtraConfiguration", mock.Anything, int64(1), mock.Anything, mock.Anything, mock.MatchedBy(func(extraConfig apimodels.ExtraConfiguration) bool {
@@ -2157,22 +2153,9 @@ func TestRouteConvertPrometheusPostAlertmanagerConfig(t *testing.T) {
 		mockAM.AssertExpectations(t)
 	})
 
-	t.Run("should return error when merge matchers header has invalid format", func(t *testing.T) {
-		rc := createRequestCtx()
-		rc.Req.Header.Set(configIdentifierHeader, identifier)
-		rc.Req.Header.Set(mergeMatchersHeader, "invalid-format")
-
-		amCfg := apimodels.AlertmanagerUserConfig{}
-		response := srv.RouteConvertPrometheusPostAlertmanagerConfig(rc, amCfg)
-
-		require.Equal(t, http.StatusBadRequest, response.Status())
-		require.Contains(t, string(response.Body()), "format should be 'key=value,key2=value2'")
-	})
-
 	t.Run("should return error when alertmanager config has empty route", func(t *testing.T) {
 		rc := createRequestCtx()
 		rc.Req.Header.Set(configIdentifierHeader, identifier)
-		rc.Req.Header.Set(mergeMatchersHeader, "env=prod")
 
 		amCfg := apimodels.AlertmanagerUserConfig{
 			AlertmanagerConfig: `{
@@ -2396,83 +2379,6 @@ receivers:
 	})
 }
 
-func TestParseMergeMatchersHeader(t *testing.T) {
-	testCases := []struct {
-		name             string
-		headerValue      string
-		expectedError    bool
-		expectedMatchers apimodels.Matchers
-	}{
-		{
-			name:          "empty header should not return error",
-			headerValue:   "",
-			expectedError: false,
-		},
-		{
-			name:          "single matcher should parse correctly",
-			headerValue:   "env=prod",
-			expectedError: false,
-			expectedMatchers: apimodels.Matchers{
-				{Type: labels.MatchEqual, Name: "env", Value: "prod"},
-			},
-		},
-		{
-			name:          "multiple matchers should be parsed correctly",
-			headerValue:   "env=prod,team=alerting",
-			expectedError: false,
-			expectedMatchers: apimodels.Matchers{
-				{Type: labels.MatchEqual, Name: "env", Value: "prod"},
-				{Type: labels.MatchEqual, Name: "team", Value: "alerting"},
-			},
-		},
-		{
-			name:          "matchers with spaces should be parsed correctly",
-			headerValue:   " env = prod , team = alerting ",
-			expectedError: false,
-			expectedMatchers: apimodels.Matchers{
-				{Type: labels.MatchEqual, Name: "env", Value: "prod"},
-				{Type: labels.MatchEqual, Name: "team", Value: "alerting"},
-			},
-		},
-		{
-			name:          "invalid format without equals should return error",
-			headerValue:   "env:prod",
-			expectedError: true,
-		},
-		{
-			name:          "empty key should return error",
-			headerValue:   "=prod",
-			expectedError: true,
-		},
-		{
-			name:          "empty value should return error",
-			headerValue:   "env=",
-			expectedError: true,
-		},
-		{
-			name:          "missing value should return error",
-			headerValue:   "env",
-			expectedError: true,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			rc := createRequestCtx()
-			rc.Req.Header.Set(mergeMatchersHeader, tc.headerValue)
-
-			matchers, err := parseMergeMatchersHeader(rc)
-
-			if tc.expectedError {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-				require.ElementsMatch(t, tc.expectedMatchers, matchers)
-			}
-		})
-	}
-}
-
 func TestParseConfigIdentifierHeader(t *testing.T) {
 	testCases := []struct {
 		name          string
@@ -2523,42 +2429,6 @@ func TestParseConfigIdentifierHeader(t *testing.T) {
 			}
 		})
 	}
-}
-
-func TestFormatMergeMatchers(t *testing.T) {
-	t.Run("empty matchers should return empty string", func(t *testing.T) {
-		result := formatMergeMatchers(nil)
-		require.Equal(t, "", result)
-	})
-
-	t.Run("single matcher should format correctly", func(t *testing.T) {
-		matchers := apimodels.Matchers{
-			&labels.Matcher{
-				Type:  labels.MatchEqual,
-				Name:  "env",
-				Value: "prod",
-			},
-		}
-		result := formatMergeMatchers(matchers)
-		require.Equal(t, "env=prod", result)
-	})
-
-	t.Run("multiple matchers should format correctly", func(t *testing.T) {
-		matchers := apimodels.Matchers{
-			&labels.Matcher{
-				Type:  labels.MatchEqual,
-				Name:  "env",
-				Value: "prod",
-			},
-			&labels.Matcher{
-				Type:  labels.MatchEqual,
-				Name:  "team",
-				Value: "backend",
-			},
-		}
-		result := formatMergeMatchers(matchers)
-		require.Equal(t, "env=prod,team=backend", result)
-	})
 }
 
 func TestRouteConvertPrometheusDeleteAlertmanagerConfig(t *testing.T) {

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager.go
@@ -10,7 +10,6 @@ import (
 	"github.com/grafana/alerting/definition/compat"
 	amv2 "github.com/prometheus/alertmanager/api/v2/models"
 	"github.com/prometheus/alertmanager/config"
-	"github.com/prometheus/alertmanager/pkg/labels"
 	"go.yaml.in/yaml/v3"
 
 	"github.com/grafana/alerting/definition"
@@ -608,7 +607,6 @@ type DatasourceUIDReference struct {
 
 type ExtraConfiguration struct {
 	Identifier         string            `yaml:"identifier" json:"identifier"`
-	MergeMatchers      config.Matchers   `yaml:"merge_matchers" json:"merge_matchers"`
 	TemplateFiles      map[string]string `yaml:"template_files" json:"template_files"`
 	AlertmanagerConfig string            `yaml:"alertmanager_config" json:"alertmanager_config"`
 }
@@ -654,12 +652,6 @@ func (c *ExtraConfiguration) GetSanitizedAlertmanagerConfigYAML() (string, error
 func (c ExtraConfiguration) Validate() error {
 	if c.Identifier == "" {
 		return errors.New("identifier is required")
-	}
-
-	for _, m := range c.MergeMatchers {
-		if m.Type != labels.MatchEqual {
-			return errInvalidExtraConfiguration(errors.New("only matchers with type equal are supported"))
-		}
 	}
 
 	cfg, err := c.GetAlertmanagerConfig()

--- a/pkg/services/ngalert/api/tooling/definitions/alertmanager_test.go
+++ b/pkg/services/ngalert/api/tooling/definitions/alertmanager_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/grafana/alerting/definition"
 	"github.com/prometheus/alertmanager/config"
-	"github.com/prometheus/alertmanager/pkg/labels"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -339,8 +338,7 @@ func TestExtraConfiguration_Validate(t *testing.T) {
 		{
 			name: "valid configuration",
 			config: ExtraConfiguration{
-				Identifier:    "test-config",
-				MergeMatchers: config.Matchers{{Type: labels.MatchEqual, Name: "env", Value: "prod"}},
+				Identifier: "test-config",
 				AlertmanagerConfig: `route:
   receiver: default
 receivers:
@@ -351,28 +349,14 @@ receivers:
 			name: "empty identifier",
 			config: ExtraConfiguration{
 				Identifier:         "",
-				MergeMatchers:      config.Matchers{{Type: labels.MatchEqual, Name: "env", Value: "prod"}},
 				AlertmanagerConfig: `route: {receiver: default}`,
 			},
 			expectedError: "identifier is required",
 		},
 		{
-			name: "invalid matcher type",
-			config: ExtraConfiguration{
-				Identifier:    "test-config",
-				MergeMatchers: config.Matchers{{Type: labels.MatchNotEqual, Name: "env", Value: "prod"}},
-				AlertmanagerConfig: `route:
-  receiver: default
-receivers:
-  - name: default`,
-			},
-			expectedError: "only matchers with type equal are supported",
-		},
-		{
 			name: "invalid YAML alertmanager config",
 			config: ExtraConfiguration{
 				Identifier:         "test-config",
-				MergeMatchers:      config.Matchers{{Type: labels.MatchEqual, Name: "env", Value: "prod"}},
 				AlertmanagerConfig: `invalid: yaml: content: [`,
 			},
 			expectedError: "failed to parse alertmanager config",
@@ -380,8 +364,7 @@ receivers:
 		{
 			name: "missing route in alertmanager config",
 			config: ExtraConfiguration{
-				Identifier:    "test-config",
-				MergeMatchers: config.Matchers{{Type: labels.MatchEqual, Name: "env", Value: "prod"}},
+				Identifier: "test-config",
 				AlertmanagerConfig: `receivers:
   - name: default`,
 			},
@@ -390,8 +373,7 @@ receivers:
 		{
 			name: "missing receivers in alertmanager config",
 			config: ExtraConfiguration{
-				Identifier:    "test-config",
-				MergeMatchers: config.Matchers{{Type: labels.MatchEqual, Name: "env", Value: "prod"}},
+				Identifier: "test-config",
 				AlertmanagerConfig: `route:
   receiver: default`,
 			},
@@ -401,7 +383,6 @@ receivers:
 			name: "empty alertmanager config",
 			config: ExtraConfiguration{
 				Identifier:         "test-config",
-				MergeMatchers:      config.Matchers{{Type: labels.MatchEqual, Name: "env", Value: "prod"}},
 				AlertmanagerConfig: "",
 			},
 			expectedError: "failed to parse alertmanager config",

--- a/pkg/services/ngalert/api/tooling/definitions/convert_prometheus_api.go
+++ b/pkg/services/ngalert/api/tooling/definitions/convert_prometheus_api.go
@@ -334,12 +334,6 @@ type RouteConvertPrometheusPostAlertmanagerConfigParams struct {
 	// This identifier is used to distinguish between different imported configurations.
 	// in: header
 	Identifier string `json:"x-grafana-alerting-config-identifier"`
-	// Comma-separated list of label matchers in 'key=value' format.
-	// These matchers determine which alerts this configuration should handle.
-	// For example: 'environment=production,team=backend' will only apply this
-	// configuration to alerts matching both environment=production AND team=backend.
-	// in: header
-	MergeMatchers string `json:"x-grafana-alerting-merge-matchers"`
 	// If true, the configuration will replace an existing configuration regardless of its identifier
 	// in: header
 	Replace bool `json:"x-grafana-alerting-config-force-replace"`

--- a/pkg/services/ngalert/models/errors.go
+++ b/pkg/services/ngalert/models/errors.go
@@ -68,10 +68,6 @@ var (
 		errutil.WithPublic("Invalid format of the submitted route: {{.Public.Error}}. Correct the payload and try again."),
 	)
 
-	ErrRouteConflictingMatchers = errutil.BadRequest("alerting.notifications.routes.conflictingMatchers").MustTemplate("Routing tree conflicts with the external configuration",
-		errutil.WithPublic("Cannot add\\update route: matchers conflict with an external routing tree merging matchers {{ .Public.Matchers }}, making the added\\updated route unreachable."),
-	)
-
 	ErrMultipleRoutesNotSupported = errutil.NotImplemented("alerting.notifications.routes.multipleNotSupported", errutil.WithPublicMessage(fmt.Sprintf("Multiple routes are not supported, see feature toggle %q", featuremgmt.FlagAlertingMultiplePolicies)))
 
 	ErrRouteVersionConflict = errutil.Conflict("alerting.notifications.routes.conflict").MustTemplate(
@@ -123,14 +119,6 @@ func MakeErrRouteInvalidFormat(err error) error {
 			"Error": err.Error(),
 		},
 		Error: err,
-	})
-}
-
-func MakeErrRouteConflictingMatchers(matchers string) error {
-	return ErrRouteConflictingMatchers.Build(errutil.TemplateData{
-		Public: map[string]any{
-			"Matchers": matchers,
-		},
 	})
 }
 

--- a/pkg/services/ngalert/notifier/alertmanager_config_test.go
+++ b/pkg/services/ngalert/notifier/alertmanager_config_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/prometheus/alertmanager/pkg/labels"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
@@ -73,7 +72,6 @@ func TestMultiOrgAlertmanager_SaveAndApplyExtraConfiguration(t *testing.T) {
 
 		extraConfig := definitions.ExtraConfiguration{
 			Identifier:    "test-alertmanager-config",
-			MergeMatchers: definitions.Matchers{&labels.Matcher{Type: labels.MatchEqual, Name: "env", Value: "prod"}},
 			TemplateFiles: map[string]string{"test.tmpl": "{{ define \"test\" }}Test{{ end }}"},
 			AlertmanagerConfig: `route:
   receiver: test-receiver
@@ -108,7 +106,6 @@ receivers:
 
 		extraConfig := definitions.ExtraConfiguration{
 			Identifier:    "dry-run-config",
-			MergeMatchers: definitions.Matchers{&labels.Matcher{Type: labels.MatchEqual, Name: "env", Value: "test"}},
 			TemplateFiles: map[string]string{"test.tmpl": "{{ define \"test\" }}Test{{ end }}"},
 			AlertmanagerConfig: `route:
   receiver: test-receiver
@@ -135,8 +132,7 @@ receivers:
 
 		// First add a configuration
 		originalConfig := definitions.ExtraConfiguration{
-			Identifier:    identifier,
-			MergeMatchers: definitions.Matchers{&labels.Matcher{Type: labels.MatchEqual, Name: "env", Value: "original"}},
+			Identifier: identifier,
 			AlertmanagerConfig: `route:
   receiver: original-receiver
 receivers:
@@ -149,7 +145,6 @@ receivers:
 		// Now replace it
 		updatedConfig := definitions.ExtraConfiguration{
 			Identifier:    identifier,
-			MergeMatchers: definitions.Matchers{&labels.Matcher{Type: labels.MatchEqual, Name: "env", Value: "updated"}},
 			TemplateFiles: map[string]string{"updated.tmpl": "{{ define \"updated\" }}Updated{{ end }}"},
 			AlertmanagerConfig: `route:
   receiver: updated-receiver
@@ -174,8 +169,7 @@ receivers:
 		require.NoError(t, mam.LoadAndSyncAlertmanagersForOrgs(ctx))
 
 		firstConfig := definitions.ExtraConfiguration{
-			Identifier:    "first-config",
-			MergeMatchers: definitions.Matchers{&labels.Matcher{Type: labels.MatchEqual, Name: "env", Value: "first"}},
+			Identifier: "first-config",
 			AlertmanagerConfig: `{
 				"route": {
 					"receiver": "first-receiver"
@@ -192,8 +186,7 @@ receivers:
 		require.NoError(t, err)
 
 		secondConfig := definitions.ExtraConfiguration{
-			Identifier:    "second-config",
-			MergeMatchers: definitions.Matchers{&labels.Matcher{Type: labels.MatchEqual, Name: "env", Value: "second"}},
+			Identifier: "second-config",
 			AlertmanagerConfig: `{
 				"route": {
 					"receiver": "second-receiver"
@@ -262,8 +255,7 @@ receivers:
 		require.NoError(t, err)
 
 		originalConfig := definitions.ExtraConfiguration{
-			Identifier:    identifier,
-			MergeMatchers: definitions.Matchers{&labels.Matcher{Type: labels.MatchEqual, Name: "env", Value: "original"}},
+			Identifier: identifier,
 			AlertmanagerConfig: `route:
   receiver: original-receiver
 receivers:
@@ -286,8 +278,7 @@ func TestMultiOrgAlertmanager_DeleteExtraConfiguration(t *testing.T) {
 		identifier := "test-identifier"
 
 		extraConfig := definitions.ExtraConfiguration{
-			Identifier:    identifier,
-			MergeMatchers: definitions.Matchers{&labels.Matcher{Type: labels.MatchEqual, Name: "env", Value: "delete"}},
+			Identifier: identifier,
 			AlertmanagerConfig: `route:
   receiver: test-receiver
 receivers:

--- a/pkg/services/ngalert/notifier/alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/alertmanager_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
-	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/pkg/labels"
 	"github.com/prometheus/client_golang/prometheus"
 	prommodel "github.com/prometheus/common/model"
@@ -102,8 +101,7 @@ func TestAlertmanager_SaveAndApplyExtraConfiguration_WithExternalSecrets(t *test
 	require.NoError(t, err)
 
 	_, err = moa.SaveAndApplyExtraConfiguration(context.Background(), 1, &user.SignedInUser{}, noopExtraConfigAuthz{}, definitions.ExtraConfiguration{
-		Identifier:    "external-prometheus",
-		MergeMatchers: []*labels.Matcher{{Type: labels.MatchEqual, Name: "cluster", Value: "prod"}},
+		Identifier: "external-prometheus",
 		AlertmanagerConfig: `
 route:
   receiver: webhook-receiver
@@ -194,13 +192,6 @@ func TestAlertmanager_ApplyConfig(t *testing.T) {
 				ExtraConfigs: []definitions.ExtraConfiguration{
 					{
 						Identifier: "mimir-prod",
-						MergeMatchers: config.Matchers{
-							{
-								Type:  labels.MatchEqual,
-								Name:  "__mimir__",
-								Value: "true",
-							},
-						},
 						TemplateFiles: map[string]string{
 							"mimir-template": "{{ define \"mimir.title\" }}Mimir Alert{{ end }}",
 						},
@@ -226,8 +217,7 @@ receivers:
 				AlertmanagerConfig: basicConfig(),
 				ExtraConfigs: []definitions.ExtraConfiguration{
 					{
-						Identifier:    "", // invalid: empty identifier
-						MergeMatchers: config.Matchers{},
+						Identifier: "", // invalid: empty identifier
 						AlertmanagerConfig: `route:
   receiver: test-receiver
 receivers:
@@ -357,10 +347,6 @@ func TestAlertmanager_HashStabilityAndChangeDetection(t *testing.T) {
 				cfg.ExtraConfigs = []definitions.ExtraConfiguration{
 					{
 						Identifier: "mimir-prod",
-						MergeMatchers: definitions.Matchers{
-							matcher("cluster", "prod"),
-							matcher("source", "external"),
-						},
 						TemplateFiles: map[string]string{
 							"extra-b.tmpl": "{{ define \"extra.b\" }}b{{ end }}",
 							"extra-a.tmpl": "{{ define \"extra.a\" }}a{{ end }}",
@@ -374,7 +360,7 @@ receivers:
 				return cfg
 			},
 			mutate: func(cfg *definitions.PostableUserConfig, _ map[ngmodels.AlertRuleKey]ngmodels.ContactPointRouting) {
-				cfg.ExtraConfigs[0].MergeMatchers[0].Value = "staging"
+				cfg.ExtraConfigs[0].TemplateFiles["extra-b.tmpl"] = "{{ define \"extra.b\" }}changed{{ end }}"
 			},
 		},
 		{
@@ -444,10 +430,6 @@ receivers:
 				cfg.ExtraConfigs = []definitions.ExtraConfiguration{
 					{
 						Identifier: "mimir-prod",
-						MergeMatchers: definitions.Matchers{
-							matcher("cluster", "prod"),
-							matcher("source", "external"),
-						},
 						TemplateFiles: map[string]string{
 							"extra-b.tmpl": "{{ define \"extra.b\" }}b{{ end }}",
 							"extra-a.tmpl": "{{ define \"extra.a\" }}a{{ end }}",
@@ -467,7 +449,7 @@ receivers:
 				return cfg
 			},
 			mutate: func(cfg *definitions.PostableUserConfig, _ map[ngmodels.AlertRuleKey]ngmodels.ContactPointRouting) {
-				cfg.ExtraConfigs[0].MergeMatchers[0].Value = "staging"
+				cfg.ExtraConfigs[0].TemplateFiles["extra-b.tmpl"] = "{{ define \"extra.b\" }}changed{{ end }}"
 			},
 		},
 	}

--- a/pkg/services/ngalert/notifier/inhibition_rules/service_test.go
+++ b/pkg/services/ngalert/notifier/inhibition_rules/service_test.go
@@ -6,7 +6,6 @@ import (
 
 	"go.yaml.in/yaml/v3"
 
-	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/pkg/labels"
 	"github.com/stretchr/testify/require"
 
@@ -360,7 +359,6 @@ func createTestConfig(t *testing.T, grafanaRules, importedRules []definitions.In
 	cfg.ExtraConfigs = []definitions.ExtraConfiguration{
 		{
 			Identifier:         "test-mimir",
-			MergeMatchers:      config.Matchers{&labels.Matcher{Type: labels.MatchEqual, Name: "__imported", Value: "test"}},
 			AlertmanagerConfig: mimirConfig,
 		},
 	}

--- a/pkg/services/ngalert/notifier/legacy_storage/imported_test.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/imported_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/grafana/alerting/definition"
-	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/pkg/labels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -20,12 +19,6 @@ func TestConfigRevisionImported(t *testing.T) {
 		require.Error(t, err)
 	})
 
-	t.Run("should return imported config if extra config is valid even if it cannot be fully merged", func(t *testing.T) {
-		rev := getConfigRevisionForTest(withExtraConfigAndConflictingMatchers())
-		imported, err := rev.Imported()
-		require.NoError(t, err)
-		require.NotNil(t, imported)
-	})
 	t.Run("should return imported config if extra config is valid", func(t *testing.T) {
 		rev := getConfigRevisionForTest(withExtraConfig(extraConfig(extraConfigurationYaml)))
 
@@ -370,10 +363,7 @@ receivers:
 
 func extraConfig(yamlString string) definitions.ExtraConfiguration {
 	return definitions.ExtraConfiguration{
-		Identifier: "test",
-		MergeMatchers: config.Matchers{
-			&labels.Matcher{Type: labels.MatchEqual, Name: "__imported", Value: "test"},
-		},
+		Identifier:         "test",
 		AlertmanagerConfig: yamlString,
 	}
 }
@@ -382,25 +372,6 @@ func withExtraConfig(extra definitions.ExtraConfiguration) opt {
 	return func(rev *ConfigRevision) {
 		rev.Config.ExtraConfigs = []definitions.ExtraConfiguration{
 			extra,
-		}
-	}
-}
-
-func withExtraConfigAndConflictingMatchers() opt {
-	return func(rev *ConfigRevision) {
-		matcher := &labels.Matcher{Type: labels.MatchEqual, Name: "__imported", Value: "test"}
-		rev.Config.AlertmanagerConfig.Route.Routes = append(rev.Config.AlertmanagerConfig.Route.Routes, &definitions.Route{
-			Matchers: []*labels.Matcher{matcher},
-		})
-		rev.Config.ExtraConfigs = []definitions.ExtraConfiguration{
-			{
-				Identifier: "test",
-				MergeMatchers: config.Matchers{
-					matcher,
-				},
-				TemplateFiles:      nil,
-				AlertmanagerConfig: extraConfigurationYaml,
-			},
 		}
 	}
 }

--- a/pkg/services/ngalert/notifier/merge/merge.go
+++ b/pkg/services/ngalert/notifier/merge/merge.go
@@ -10,42 +10,15 @@ package merge
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"math"
-	"slices"
 	"strings"
 
 	"github.com/grafana/alerting/definition"
 	"github.com/prometheus/alertmanager/config"
-	"github.com/prometheus/alertmanager/dispatch"
-	"github.com/prometheus/alertmanager/pkg/labels"
-	"github.com/prometheus/common/model"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 )
-
-var (
-	ErrInvalidMatchers         = errors.New("only equality matchers are allowed")
-	ErrDuplicateMatchers       = errors.New("matchers should be unique")
-	ErrSubtreeMatchersConflict = errors.New("subtree matchers conflict with existing Grafana routes, merging will break existing notifications")
-)
-
-// ValidateSubtreeMatchers checks that all matchers use the equality operator and have unique names.
-// These are the requirements for matchers used as subtree identifiers when merging configurations.
-func ValidateSubtreeMatchers(matchers config.Matchers) error {
-	seenNames := make(map[string]struct{}, len(matchers))
-	for _, matcher := range matchers {
-		if _, ok := seenNames[matcher.Name]; ok {
-			return ErrDuplicateMatchers
-		}
-		if matcher.Type != labels.MatchEqual {
-			return ErrInvalidMatchers
-		}
-		seenNames[matcher.Name] = struct{}{}
-	}
-	return nil
-}
 
 // MergeResult represents the result of merging two Alertmanager configurations.
 // It contains the unified configuration and maps of renamed receivers and time intervals.
@@ -109,16 +82,11 @@ func (m MergeResult) LogContext() []any {
 //     - The entire routing tree from the extra configuration is inserted as a sub-tree under
 //     the root route of the base configuration
 //     - The sub-tree is positioned as the first route in the list of routes
-//     - The extra configuration's MergeMatchers are added to the root of the imported routing tree
 //     - Default timing settings (GroupWait, GroupInterval, RepeatInterval) are explicitly set
 //     on the imported route to prevent inheriting potentially unwanted defaults from the parent
-//     - If any existing routes in the base configuration would match the MergeMatchers, the merge
-//     will fail with ErrSubtreeMatchersConflict to prevent breaking existing notification flows
 //
 //  3. Inhibit Rule Merging:
 //     - All inhibit rules from the extra configuration are copied to the result
-//     - MergeMatchers are added to both source and target matchers of each copied inhibit rule
-//     to maintain proper context separation
 func MergeExtraConfig(_ context.Context, cfg *definitions.PostableUserConfig) (MergeResult, error) {
 	if len(cfg.ExtraConfigs) == 0 {
 		return MergeResult{Config: *cfg}, nil
@@ -132,23 +100,6 @@ func MergeExtraConfig(_ context.Context, cfg *definitions.PostableUserConfig) (M
 	if err != nil {
 		return MergeResult{}, fmt.Errorf("failed to get mimir alertmanager config: %w", err)
 	}
-	if err := ValidateSubtreeMatchers(mimirCfg.MergeMatchers); err != nil {
-		return MergeResult{}, fmt.Errorf("invalid merge options: %w", err)
-	}
-
-	if len(mimirCfg.MergeMatchers) > 0 {
-		if cfg.AlertmanagerConfig.Route == nil {
-			return MergeResult{}, fmt.Errorf("failed to merge alertmanager config: cannot merge into undefined routing tree")
-		}
-		match, err := checkIfMatchersUsed(mimirCfg.MergeMatchers, cfg.AlertmanagerConfig.Route.Routes)
-		if err != nil {
-			return MergeResult{}, fmt.Errorf("failed to merge alertmanager config: %w", err)
-		}
-		if match {
-			return MergeResult{}, fmt.Errorf("failed to merge alertmanager config: %w: sub tree matchers: %s", ErrSubtreeMatchersConflict, mimirCfg.MergeMatchers)
-		}
-	}
-
 	mergedReceivers, renamedReceivers := MergeReceivers(cfg.AlertmanagerConfig.Receivers, mcfg.Receivers, mimirCfg.Identifier)
 
 	mergedTimeIntervals, renamedTimeIntervals := MergeTimeIntervals(
@@ -169,10 +120,7 @@ func MergeExtraConfig(_ context.Context, cfg *definitions.PostableUserConfig) (M
 
 	route := cfg.AlertmanagerConfig.Route
 	inhibitRules := cfg.AlertmanagerConfig.InhibitRules
-	if len(mimirCfg.MergeMatchers) > 0 {
-		route = MergeRoutes(*route, *mcfg.Route, mimirCfg.MergeMatchers)
-		inhibitRules = MergeInhibitRules(inhibitRules, mcfg.InhibitRules, mimirCfg.MergeMatchers)
-	}
+	// TODO move adding managed routes and managed inhibit rules to cfg here
 
 	mergedConfig := definitions.PostableUserConfig{
 		TemplateFiles: cfg.TemplateFiles,
@@ -270,62 +218,6 @@ func createIndexTimeIntervals(
 	return usedNames
 }
 
-func MergeRoutes(a, b definition.Route, matcher config.Matchers) *definition.Route {
-	// get a and b by value so we get shallow copies of the top level routes, which we can modify.
-	// make sure "b" route has all defaults set explicitly to avoid inheriting "a"'s default route settings.
-	defaultOpts := dispatch.DefaultRouteOpts
-	if b.GroupWait == nil {
-		gw := model.Duration(defaultOpts.GroupWait)
-		b.GroupWait = &gw
-	}
-	if b.GroupInterval == nil {
-		gi := model.Duration(defaultOpts.GroupInterval)
-		b.GroupInterval = &gi
-	}
-	if b.RepeatInterval == nil {
-		ri := model.Duration(defaultOpts.RepeatInterval)
-		b.RepeatInterval = &ri
-	}
-	b.Matchers = append(slices.Clone(b.Matchers), matcher...)
-	a.Routes = append([]*definition.Route{&b}, a.Routes...)
-	return &a
-}
-
-func checkIfMatchersUsed(matchers config.Matchers, routes []*definition.Route) (bool, error) {
-	// matchers are always equality type. So we can confidently convert them to labelsSet
-	// and check if they are contained in any of the routes.
-	ls := make(model.LabelSet, len(matchers))
-	for _, matcher := range matchers {
-		ls[model.LabelName(matcher.Name)] = model.LabelValue(matcher.Value)
-	}
-	for _, r := range routes {
-		if r == nil {
-			continue
-		}
-		m, err := r.AllMatchers()
-		if err != nil {
-			return false, err
-		}
-		if (labels.Matchers(m)).Matches(ls) {
-			return true, nil
-		}
-
-		sameNames := make(labels.Matchers, 0, len(ls))
-		seenNames := make(map[string]struct{}, len(ls))
-		for _, matcher := range m {
-			if _, ok := ls[model.LabelName(matcher.Name)]; ok {
-				sameNames = append(sameNames, matcher)
-				seenNames[matcher.Name] = struct{}{}
-			}
-		}
-		// if the route contains matchers that match ALL labels, then check if sub-matchers will match them.
-		if len(seenNames) == len(ls) && sameNames.Matches(ls) {
-			return true, nil
-		}
-	}
-	return false, nil
-}
-
 // RenameResourceUsagesInRoutes updates the receiver and mute/active time intervals of routes based on the provided rename resources.
 func RenameResourceUsagesInRoutes(routes []*definition.Route, renames RenameResources) {
 	for _, r := range routes {
@@ -349,17 +241,6 @@ func RenameResourceUsagesInRoutes(routes []*definition.Route, renames RenameReso
 		}
 		RenameResourceUsagesInRoutes(r.Routes, renames)
 	}
-}
-
-func MergeInhibitRules(a, b []config.InhibitRule, matcher config.Matchers) []config.InhibitRule {
-	result := make([]config.InhibitRule, 0, len(a)+len(b))
-	result = append(result, a...)
-	for _, rule := range b {
-		rule.SourceMatchers = append(slices.Clone(rule.SourceMatchers), matcher...)
-		rule.TargetMatchers = append(slices.Clone(rule.TargetMatchers), matcher...)
-		result = append(result, rule)
-	}
-	return result
 }
 
 // MergeReceivers merges two lists of PostableApiReceiver objects, ensuring unique names by appending a suffix if necessary.

--- a/pkg/services/ngalert/notifier/merge/merge_test.go
+++ b/pkg/services/ngalert/notifier/merge/merge_test.go
@@ -10,196 +10,14 @@ import (
 	"github.com/grafana/alerting/definition"
 	httpcfg "github.com/grafana/alerting/http/v0mimir"
 	"github.com/prometheus/alertmanager/config"
-	"github.com/prometheus/alertmanager/dispatch"
 	"github.com/prometheus/alertmanager/pkg/labels"
 	commoncfg "github.com/prometheus/common/config"
-	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.yaml.in/yaml/v3"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 )
-
-func TestValidateSubtreeMatchers(t *testing.T) {
-	testCases := []struct {
-		name        string
-		matchers    config.Matchers
-		expectedErr error
-	}{
-		{
-			name:     "no error if subtree matchers are empty",
-			matchers: config.Matchers{},
-		},
-		{
-			name: "error if subtree matchers are not equal",
-			matchers: config.Matchers{
-				{
-					Type:  labels.MatchNotEqual,
-					Name:  "label",
-					Value: "test",
-				},
-			},
-			expectedErr: ErrInvalidMatchers,
-		},
-		{
-			name: "error if subtree matchers are regex",
-			matchers: config.Matchers{
-				{
-					Type:  labels.MatchRegexp,
-					Name:  "label",
-					Value: "test",
-				},
-			},
-			expectedErr: ErrInvalidMatchers,
-		},
-		{
-			name: "error if subtree matchers are not-regex",
-			matchers: config.Matchers{
-				{
-					Type:  labels.MatchNotRegexp,
-					Name:  "label",
-					Value: "test",
-				},
-			},
-			expectedErr: ErrInvalidMatchers,
-		},
-		{
-			name: "error if duplicates",
-			matchers: config.Matchers{
-				{
-					Type:  labels.MatchEqual,
-					Name:  "label",
-					Value: "test",
-				},
-				{
-					Type:  labels.MatchEqual,
-					Name:  "label",
-					Value: "test",
-				},
-			},
-			expectedErr: ErrDuplicateMatchers,
-		},
-		{
-			name: "valid if no duplicates and only equal matchers",
-			matchers: config.Matchers{
-				{
-					Type:  labels.MatchEqual,
-					Name:  "al",
-					Value: "test",
-				},
-				{
-					Type:  labels.MatchEqual,
-					Name:  "bl",
-					Value: "test",
-				},
-			},
-		},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			actual := ValidateSubtreeMatchers(tc.matchers)
-			if tc.expectedErr != nil {
-				assert.ErrorIs(t, actual, tc.expectedErr)
-				return
-			}
-			assert.NoError(t, actual)
-		})
-	}
-}
-
-func TestCheckIfMatchersUsed(t *testing.T) {
-	m := config.Matchers{
-		{
-			Type:  labels.MatchEqual,
-			Name:  "al",
-			Value: "av",
-		},
-		{
-			Type:  labels.MatchEqual,
-			Name:  "bl",
-			Value: "bv",
-		},
-	}
-
-	mustMatcher := func(mt labels.MatchType, n, v string) *labels.Matcher {
-		m, err := labels.NewMatcher(mt, n, v)
-		if err != nil {
-			t.Fatal(err)
-		}
-		return m
-	}
-
-	testCases := []struct {
-		name     string
-		route    *definition.Route
-		expected bool
-	}{
-		{
-			name: "true if the same matchers",
-			route: &definition.Route{
-				Matchers: m,
-			},
-			expected: true,
-		},
-		{
-			name: "true if sub set of matchers",
-			route: &definition.Route{
-				Matchers: config.Matchers{
-					{
-						Type:  labels.MatchEqual,
-						Name:  "al",
-						Value: "av",
-					},
-				},
-			},
-			expected: true,
-		},
-		{
-			name: "true if regex that matches",
-			route: &definition.Route{
-				Matchers: append(m, mustMatcher(labels.MatchRegexp, "al", ".*")),
-			},
-			expected: true,
-		},
-		{
-			name: "true if superset of matchers",
-			route: &definition.Route{
-				Matchers: append(m, &labels.Matcher{
-					Type:  labels.MatchEqual,
-					Name:  "cl",
-					Value: "cv",
-				}),
-			},
-			expected: true,
-		},
-		{
-			name: "false if different matchers",
-			route: &definition.Route{
-				Matchers: config.Matchers{
-					{
-						Type:  labels.MatchEqual,
-						Name:  "al",
-						Value: "test",
-					},
-					{
-						Type:  labels.MatchEqual,
-						Name:  "bl",
-						Value: "bv",
-					},
-				},
-			},
-			expected: false,
-		},
-	}
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			actual, err := checkIfMatchersUsed(m, []*definition.Route{tc.route})
-			require.NoError(t, err)
-			assert.Equal(t, tc.expected, actual)
-		})
-	}
-}
 
 func TestMergeReceivers(t *testing.T) {
 	r := func(name string) *definition.PostableApiReceiver {
@@ -546,10 +364,6 @@ var fullMergedConfig string
 
 func TestMergeExtraConfig(t *testing.T) {
 	identifier := "_mimir-12345"
-	subtreeMatchers := config.Matchers{
-		{Type: labels.MatchEqual, Name: "__datasource_uid__", Value: "12345"},
-		{Type: labels.MatchEqual, Name: "__mimir__", Value: "true"},
-	}
 
 	// withExtra wraps grafana and a raw mimir YAML string into a PostableUserConfig with ExtraConfigs.
 	// Optional mutateFn can adjust the ExtraConfiguration before it's used.
@@ -557,7 +371,6 @@ func TestMergeExtraConfig(t *testing.T) {
 		t.Helper()
 		extra := definitions.ExtraConfiguration{
 			Identifier:         identifier,
-			MergeMatchers:      subtreeMatchers,
 			AlertmanagerConfig: mimirYAML,
 		}
 		for _, fn := range mutateFn {
@@ -602,15 +415,7 @@ func TestMergeExtraConfig(t *testing.T) {
 		require.NoError(t, err)
 
 		assertResult(t, MergeResult{
-			Config: definitions.PostableUserConfig{AlertmanagerConfig: *load(t, fullMergedConfig, func(p *definition.PostableApiAlertingConfig) {
-				p.Global = nil
-				gw := model.Duration(dispatch.DefaultRouteOpts.GroupWait)
-				gi := model.Duration(dispatch.DefaultRouteOpts.GroupInterval)
-				ri := model.Duration(dispatch.DefaultRouteOpts.RepeatInterval)
-				p.Route.Routes[0].GroupWait = &gw
-				p.Route.Routes[0].GroupInterval = &gi
-				p.Route.Routes[0].RepeatInterval = &ri
-			})},
+			Config:     definitions.PostableUserConfig{AlertmanagerConfig: *load(t, fullMergedConfig, func(p *definition.PostableApiAlertingConfig) { p.Global = nil })},
 			Identifier: identifier,
 		}, result)
 	})
@@ -623,10 +428,6 @@ func TestMergeExtraConfig(t *testing.T) {
 		assertResult(t, MergeResult{
 			Config: definitions.PostableUserConfig{AlertmanagerConfig: *load(t, fullMergedConfig, func(p *definition.PostableApiAlertingConfig) {
 				p.Global = nil
-				p.Route.Routes[0].Routes = append(p.Route.Routes[0].Routes, &definition.Route{
-					Receiver: "grafana-default-email" + identifier,
-					Matchers: config.Matchers{{Type: labels.MatchEqual, Name: "label", Value: "test"}},
-				})
 				p.Receivers = append(p.Receivers, &definition.PostableApiReceiver{
 					Receiver: definition.Receiver{Name: "grafana-default-email" + identifier},
 				})
@@ -673,19 +474,11 @@ func TestMergeExtraConfig(t *testing.T) {
 		assertResult(t, MergeResult{
 			Config: definitions.PostableUserConfig{AlertmanagerConfig: *load(t, fullMergedConfig, func(p *definition.PostableApiAlertingConfig) {
 				p.Global = nil
-				// fullMimirSwappedIntervals removed mti-2 from mute_time_intervals, so the
-				// recv2 sub-route no longer has a mute interval.
-				p.Route.Routes[0].Routes[0].MuteTimeIntervals = nil
-				// remove mti-2 that was replaced by ti-1 in fullMimirSwappedIntervals
+				// remove mti-2 (absent from fullMimirSwappedIntervals) and add the renamed intervals
 				expected := p.TimeIntervals[:len(p.TimeIntervals)-1]
 				expected = append(expected, config.TimeInterval{Name: "mti-1" + identifier})
 				expected = append(expected, config.TimeInterval{Name: "ti-1" + identifier})
 				p.TimeIntervals = expected
-				p.Route.Routes[0].Routes = append(p.Route.Routes[0].Routes, &definition.Route{
-					Matchers:            config.Matchers{{Type: labels.MatchEqual, Name: "label", Value: "test"}},
-					MuteTimeIntervals:   []string{"ti-1" + identifier},
-					ActiveTimeIntervals: []string{"mti-1" + identifier},
-				})
 			})},
 			RenameResources: RenameResources{
 				TimeIntervals: map[string]string{
@@ -697,52 +490,12 @@ func TestMergeExtraConfig(t *testing.T) {
 		}, result)
 	})
 
-	t.Run("should fail if merging matchers conflict with Grafana, exact match", func(t *testing.T) {
-		grafana := load(t, fullGrafanaConfig, func(p *definition.PostableApiAlertingConfig) {
-			p.Route.Routes = append(p.Route.Routes, &definition.Route{Matchers: subtreeMatchers})
-		})
-		input := withExtra(t, grafana, fullMimirConfig)
-		_, err := MergeExtraConfig(context.Background(), &input)
-		assert.ErrorIs(t, err, ErrSubtreeMatchersConflict)
-	})
-
-	t.Run("should fail if merging matchers conflict with Grafana, subset match", func(t *testing.T) {
-		grafana := load(t, fullGrafanaConfig, func(p *definition.PostableApiAlertingConfig) {
-			m, err := labels.NewMatcher(labels.MatchEqual, "label", "test")
-			require.NoError(t, err)
-			p.Route.Routes = append(p.Route.Routes, &definition.Route{
-				Matchers: append(subtreeMatchers, m),
-			})
-		})
-		input := withExtra(t, grafana, fullMimirConfig)
-		_, err := MergeExtraConfig(context.Background(), &input)
-		assert.ErrorIs(t, err, ErrSubtreeMatchersConflict)
-	})
-
 	t.Run("should not modify the base Grafana config", func(t *testing.T) {
 		g := load(t, fullGrafanaConfig)
 		input := withExtra(t, g, fullMimirConfig)
 		_, err := MergeExtraConfig(context.Background(), &input)
 		require.NoError(t, err)
 		assert.Equal(t, load(t, fullGrafanaConfig), g)
-	})
-
-	t.Run("should skip merging routes and inhibition rules if matchers are empty", func(t *testing.T) {
-		input := withExtra(t, load(t, fullGrafanaConfig), fullMimirConfig, func(e *definitions.ExtraConfiguration) {
-			e.MergeMatchers = config.Matchers{}
-		})
-		result, err := MergeExtraConfig(context.Background(), &input)
-		require.NoError(t, err)
-
-		full := load(t, fullMergedConfig)
-		full.Route.Routes = full.Route.Routes[1:]
-		full.InhibitRules = load(t, fullGrafanaConfig).InhibitRules
-		full.Global = nil
-
-		assertResult(t, MergeResult{
-			Config:     definitions.PostableUserConfig{AlertmanagerConfig: *full},
-			Identifier: identifier,
-		}, result)
 	})
 
 	t.Run("should return base config unchanged if no extra configs", func(t *testing.T) {
@@ -758,22 +511,5 @@ func TestMergeExtraConfig(t *testing.T) {
 		})
 		_, err := MergeExtraConfig(context.Background(), &input)
 		require.ErrorContains(t, err, "identifier is required")
-	})
-
-	t.Run("should fail if matcher type is not equal", func(t *testing.T) {
-		input := withExtra(t, load(t, fullGrafanaConfig), fullMimirConfig, func(e *definitions.ExtraConfiguration) {
-			e.MergeMatchers = config.Matchers{{Type: labels.MatchNotEqual, Name: "cluster", Value: "prod"}}
-		})
-		_, err := MergeExtraConfig(context.Background(), &input)
-		require.ErrorContains(t, err, "only matchers with type equal are supported")
-	})
-
-	t.Run("should fail if base route is nil and matchers are set", func(t *testing.T) {
-		grafana := load(t, fullGrafanaConfig, func(p *definition.PostableApiAlertingConfig) {
-			p.Route = nil
-		})
-		input := withExtra(t, grafana, fullMimirConfig)
-		_, err := MergeExtraConfig(context.Background(), &input)
-		require.ErrorContains(t, err, "cannot merge into undefined routing tree")
 	})
 }

--- a/pkg/services/ngalert/notifier/merge/testdata/merged_config.yaml
+++ b/pkg/services/ngalert/notifier/merge/testdata/merged_config.yaml
@@ -7,30 +7,6 @@ route:
     group_interval: 1m
     repeat_interval: 1m
     routes:
-        - receiver: recv
-          group_by:
-            - alertname
-            - groupby
-          group_wait: 65s
-          group_interval: 20m
-          repeat_interval: 10h
-          matchers:
-            - __mimir__="true"
-            - __datasource_uid__="12345"
-          routes:
-            - receiver: recv2
-              group_by:
-                - teste
-                - test2f
-              matchers:
-                - team="teamC"
-              mute_time_intervals:
-                - mti-2
-              active_time_intervals:
-                - ti-2
-              group_wait: 0s
-              group_interval: 1m
-              repeat_interval: 1m
         - receiver: test-webhook
           group_by:
             - teste
@@ -101,15 +77,5 @@ inhibit_rules:
       target_matchers:
         - alertname="test2"
         - cluster="test1"
-      equal:
-        - namespace
-    - source_matchers:
-        - alertname="test"
-        - __datasource_uid__="12345"
-        - __mimir__="true"
-      target_matchers:
-        - servicename="test2"
-        - __datasource_uid__="12345"
-        - __mimir__="true"
       equal:
         - namespace

--- a/pkg/services/ngalert/notifier/receiver_svc_test.go
+++ b/pkg/services/ngalert/notifier/receiver_svc_test.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/prometheus/alertmanager/pkg/labels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -1966,7 +1965,6 @@ const defaultAlertmanagerConfigJSON = `
 func getExtraConfig() *definitions.ExtraConfiguration {
 	return &definitions.ExtraConfiguration{
 		Identifier:         "import",
-		MergeMatchers:      []*labels.Matcher{{Type: labels.MatchEqual, Name: "__imported", Value: "true"}},
 		TemplateFiles:      nil,
 		AlertmanagerConfig: defaultExtraConfig,
 	}

--- a/pkg/services/ngalert/notifier/routes/service.go
+++ b/pkg/services/ngalert/notifier/routes/service.go
@@ -2,7 +2,6 @@ package routes
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"go.opentelemetry.io/otel/attribute"
@@ -276,10 +275,6 @@ func (nps *Service) UpdateManagedRoute(ctx context.Context, orgID int64, name st
 
 	_, err = merge.MergeExtraConfig(ctx, revision.Config)
 	if err != nil {
-		if errors.Is(err, merge.ErrSubtreeMatchersConflict) {
-			// TODO temporarily get the conflicting matchers
-			return nil, models.MakeErrRouteConflictingMatchers(fmt.Sprintf("%s", revision.Config.ExtraConfigs[0].MergeMatchers))
-		}
 		nps.log.FromContext(ctx).Warn("Unable to validate the combined routing tree because of an error during merging. This could be a sign of broken external configuration. Skipping", "error", err)
 	}
 

--- a/pkg/services/ngalert/notifier/routes/service.go
+++ b/pkg/services/ngalert/notifier/routes/service.go
@@ -14,7 +14,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage"
-	"github.com/grafana/grafana/pkg/services/ngalert/notifier/merge"
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning/validation"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -273,11 +272,6 @@ func (nps *Service) UpdateManagedRoute(ctx context.Context, orgID int64, name st
 	}
 	updated.Provenance = p
 
-	_, err = merge.MergeExtraConfig(ctx, revision.Config)
-	if err != nil {
-		nps.log.FromContext(ctx).Warn("Unable to validate the combined routing tree because of an error during merging. This could be a sign of broken external configuration. Skipping", "error", err)
-	}
-
 	err = nps.xact.InTransaction(ctx, func(ctx context.Context) error {
 		if err := nps.configStore.Save(ctx, revision, orgID); err != nil {
 			return err
@@ -361,11 +355,6 @@ func (nps *Service) DeleteManagedRoute(ctx context.Context, orgID int64, name st
 		action = "Reset"
 	} else {
 		revision.DeleteManagedRoute(name)
-	}
-
-	_, err = merge.MergeExtraConfig(ctx, revision.Config)
-	if err != nil {
-		return fmt.Errorf("new routing tree is not compatible with extra configuration: %w", err)
 	}
 
 	err = nps.xact.InTransaction(ctx, func(ctx context.Context) error {

--- a/pkg/services/ngalert/notifier/routes/service_test.go
+++ b/pkg/services/ngalert/notifier/routes/service_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 
 	"github.com/grafana/alerting/definition"
-	"github.com/prometheus/alertmanager/config"
-	"github.com/prometheus/alertmanager/pkg/labels"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -82,10 +80,7 @@ func configRevisionWithImportedRoute() *legacy_storage.ConfigRevision {
 			},
 			ExtraConfigs: []definitions.ExtraConfiguration{
 				{
-					Identifier: "imported",
-					MergeMatchers: config.Matchers{
-						&labels.Matcher{Type: labels.MatchEqual, Name: "__imported", Value: "true"},
-					},
+					Identifier:         "imported",
 					AlertmanagerConfig: importedConfigYaml,
 				},
 			},

--- a/pkg/services/ngalert/provisioning/mute_timings_test.go
+++ b/pkg/services/ngalert/provisioning/mute_timings_test.go
@@ -7,8 +7,6 @@ import (
 	"slices"
 	"testing"
 
-	"github.com/prometheus/alertmanager/config"
-	"github.com/prometheus/alertmanager/pkg/labels"
 	"github.com/prometheus/alertmanager/timeinterval"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -1473,7 +1471,6 @@ func createConfigWithImportedIntervals(grafanaIntervals []definitions.AmMuteTime
 		cfg.ExtraConfigs = []definitions.ExtraConfiguration{
 			{
 				Identifier:         "test-mimir",
-				MergeMatchers:      config.Matchers{&labels.Matcher{Type: labels.MatchEqual, Name: "__imported", Value: "test"}},
 				AlertmanagerConfig: mimirConfig,
 			},
 		}

--- a/pkg/services/ngalert/provisioning/notification_policies.go
+++ b/pkg/services/ngalert/provisioning/notification_policies.go
@@ -2,7 +2,6 @@ package provisioning
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
@@ -95,10 +94,6 @@ func (nps *NotificationPolicyService) UpdatePolicyTree(ctx context.Context, orgI
 
 	_, err = merge.MergeExtraConfig(ctx, revision.Config)
 	if err != nil {
-		if errors.Is(err, merge.ErrSubtreeMatchersConflict) {
-			// TODO temporarily get the conflicting matchers
-			return definitions.Route{}, "", models.MakeErrRouteConflictingMatchers(fmt.Sprintf("%s", revision.Config.ExtraConfigs[0].MergeMatchers))
-		}
 		nps.log.Warn("Unable to validate the combined routing tree because of an error during merging. This could be a sign of broken external configuration. Skipping", "error", err)
 	}
 

--- a/pkg/services/ngalert/provisioning/notification_policies_test.go
+++ b/pkg/services/ngalert/provisioning/notification_policies_test.go
@@ -190,59 +190,8 @@ func TestUpdatePolicyTree(t *testing.T) {
 		assert.Equal(t, orgID, prov.Calls[0].Arguments[2].(int64))
 	})
 
-	t.Run("ErrRouteConflictingMatchers if the new route has conflicting matchers ", func(t *testing.T) {
-		rev := getDefaultConfigRevision()
-		rev.Config.ExtraConfigs = append(rev.Config.ExtraConfigs, definitions.ExtraConfiguration{
-			Identifier: "test",
-			MergeMatchers: config.Matchers{
-				{
-					Type:  labels.MatchEqual,
-					Name:  "imported",
-					Value: "true",
-				},
-			},
-			AlertmanagerConfig: `{"route":{"receiver":"mimir-receiver"},"receivers":[{"name":"mimir-receiver"}]}`,
-		})
-
-		route := definitions.Route{
-			Receiver: rev.Config.AlertmanagerConfig.Receivers[0].Name,
-			Routes: []*definitions.Route{
-				{
-					ObjectMatchers: definitions.ObjectMatchers{
-						{
-							Type:  labels.MatchEqual,
-							Name:  "imported",
-							Value: "true",
-						},
-						{
-							Type:  labels.MatchEqual,
-							Name:  "label",
-							Value: "value",
-						},
-					},
-				},
-			},
-		}
-
-		sut, store, _ := createNotificationPolicyServiceSut()
-		store.GetFn = func(ctx context.Context, orgID int64) (*legacy_storage.ConfigRevision, error) {
-			return &rev, nil
-		}
-
-		_, _, err := sut.UpdatePolicyTree(context.Background(), orgID, route, models.ProvenanceAPI, defaultVersion)
-		require.ErrorIs(t, err, models.ErrRouteConflictingMatchers)
-	})
-
 	t.Run("should ignore extra config validation if it is invalid", func(t *testing.T) {
-		extra := definitions.ExtraConfiguration{
-			MergeMatchers: config.Matchers{
-				{
-					Type:  labels.MatchEqual,
-					Name:  "imported",
-					Value: "true",
-				},
-			},
-		}
+		extra := definitions.ExtraConfiguration{}
 		rev := getDefaultConfigRevision()
 		rev.Config.ExtraConfigs = append(rev.Config.ExtraConfigs, extra)
 

--- a/pkg/services/ngalert/remote/alertmanager_test.go
+++ b/pkg/services/ngalert/remote/alertmanager_test.go
@@ -1058,14 +1058,7 @@ func TestApplyConfigWithExtraConfigs(t *testing.T) {
 
 	cfg.ExtraConfigs = []apimodels.ExtraConfiguration{
 		{
-			Identifier: "test-external",
-			MergeMatchers: []*labels.Matcher{
-				{
-					Type:  labels.MatchEqual,
-					Name:  "test",
-					Value: "value",
-				},
-			},
+			Identifier:    "test-external",
 			TemplateFiles: map[string]string{},
 			AlertmanagerConfig: `global:
   smtp_smarthost: localhost:587
@@ -1168,13 +1161,6 @@ func TestCompareAndSendConfigurationWithExtraConfigs(t *testing.T) {
 		ExtraConfigs: []apimodels.ExtraConfiguration{
 			{
 				Identifier: "test-external",
-				MergeMatchers: []*labels.Matcher{
-					{
-						Type:  labels.MatchEqual,
-						Name:  "test",
-						Value: "test",
-					},
-				},
 				AlertmanagerConfig: `global:
   smtp_smarthost: localhost:587
   smtp_from: alerts@grafana.com

--- a/pkg/services/ngalert/remote/test-data/config-with-extra.json
+++ b/pkg/services/ngalert/remote/test-data/config-with-extra.json
@@ -31,7 +31,6 @@
   "extra_config": [
     {
       "identifier": "imported",
-      "merge_matchers": ["imported=\"true\""],
       "template_files":
       {
         "extra_template": "{{ define \"my_message\" }}TEST{{ end }}"

--- a/pkg/tests/api/alerting/api_convert_prometheus_alertmanager_test.go
+++ b/pkg/tests/api/alerting/api_convert_prometheus_alertmanager_test.go
@@ -66,12 +66,10 @@ func TestIntegrationConvertPrometheusAlertmanagerEndpoints(t *testing.T) {
 	t.Run("create and get alertmanager configuration", func(t *testing.T) {
 		identifier := "test-create-get-config"
 		defer cleanup(identifier)
-		mergeMatchers := "environment=production,team=backend"
 
 		headers := map[string]string{
 			"Content-Type":                         "application/yaml",
 			"X-Grafana-Alerting-Config-Identifier": identifier,
-			"X-Grafana-Alerting-Merge-Matchers":    mergeMatchers,
 		}
 
 		amConfig := apimodels.AlertmanagerUserConfig{
@@ -107,12 +105,10 @@ func TestIntegrationConvertPrometheusAlertmanagerEndpoints(t *testing.T) {
 	t.Run("delete alertmanager configuration", func(t *testing.T) {
 		identifier := "test-delete-config"
 		defer cleanup(identifier)
-		mergeMatchers := "environment=production,team=backend"
 
 		headers := map[string]string{
 			"Content-Type":                         "application/yaml",
 			"X-Grafana-Alerting-Config-Identifier": identifier,
-			"X-Grafana-Alerting-Merge-Matchers":    mergeMatchers,
 		}
 
 		amConfig := apimodels.AlertmanagerUserConfig{
@@ -143,8 +139,7 @@ func TestIntegrationConvertPrometheusAlertmanagerEndpoints(t *testing.T) {
 			defer cleanup("")
 
 			headers := map[string]string{
-				"Content-Type":                      "application/yaml",
-				"X-Grafana-Alerting-Merge-Matchers": "environment=test",
+				"Content-Type": "application/yaml",
 			}
 
 			amConfig := apimodels.AlertmanagerUserConfig{
@@ -176,26 +171,10 @@ func TestIntegrationConvertPrometheusAlertmanagerEndpoints(t *testing.T) {
 			requireStatusCode(t, http.StatusBadRequest, status, "")
 		})
 
-		t.Run("POST with invalid merge matchers format should fail", func(t *testing.T) {
-			headers := map[string]string{
-				"Content-Type":                         "application/yaml",
-				"X-Grafana-Alerting-Config-Identifier": "test-invalid-matchers",
-				"X-Grafana-Alerting-Merge-Matchers":    "invalid-no-equals-sign",
-			}
-
-			amConfig := apimodels.AlertmanagerUserConfig{
-				AlertmanagerConfig: string(configYaml),
-			}
-
-			_, status, _ := apiClient.RawConvertPrometheusPostAlertmanagerConfig(t, amConfig, headers)
-			requireStatusCode(t, http.StatusBadRequest, status, "")
-		})
-
 		t.Run("POST with invalid alertmanager configuration should fail", func(t *testing.T) {
 			headers := map[string]string{
 				"Content-Type":                         "application/yaml",
 				"X-Grafana-Alerting-Config-Identifier": "test-invalid-yaml",
-				"X-Grafana-Alerting-Merge-Matchers":    "environment=test",
 			}
 
 			amConfig := apimodels.AlertmanagerUserConfig{
@@ -208,8 +187,7 @@ func TestIntegrationConvertPrometheusAlertmanagerEndpoints(t *testing.T) {
 
 		t.Run("DELETE without config identifier header should use default identifier", func(t *testing.T) {
 			createHeaders := map[string]string{
-				"Content-Type":                      "application/yaml",
-				"X-Grafana-Alerting-Merge-Matchers": "environment=test",
+				"Content-Type": "application/yaml",
 			}
 
 			amConfig := apimodels.AlertmanagerUserConfig{
@@ -237,7 +215,6 @@ func TestIntegrationConvertPrometheusAlertmanagerEndpoints(t *testing.T) {
 		headers := map[string]string{
 			"Content-Type":                         "application/yaml",
 			"X-Grafana-Alerting-Config-Identifier": identifier,
-			"X-Grafana-Alerting-Merge-Matchers":    "environment=production",
 		}
 
 		amConfig1 := apimodels.AlertmanagerUserConfig{
@@ -297,7 +274,6 @@ receivers:
 		firstHeaders := map[string]string{
 			"Content-Type":                         "application/yaml",
 			"X-Grafana-Alerting-Config-Identifier": firstIdentifier,
-			"X-Grafana-Alerting-Merge-Matchers":    "environment=first",
 		}
 
 		amConfig1 := apimodels.AlertmanagerUserConfig{
@@ -315,7 +291,6 @@ receivers:
 		secondHeaders := map[string]string{
 			"Content-Type":                         "application/yaml",
 			"X-Grafana-Alerting-Config-Identifier": secondIdentifier,
-			"X-Grafana-Alerting-Merge-Matchers":    "environment=second",
 		}
 
 		amConfig2 := apimodels.AlertmanagerUserConfig{
@@ -416,7 +391,6 @@ func TestIntegrationConvertPrometheusAlertmanagerEndpoints_FeatureFlagDisabled(t
 	headers := map[string]string{
 		"Content-Type":                         "application/yaml",
 		"X-Grafana-Alerting-Config-Identifier": "test-config",
-		"X-Grafana-Alerting-Merge-Matchers":    "environment=test",
 	}
 	configYaml, err := testData.ReadFile(path.Join("test-data", "mimir-alertmanager-post.yaml"))
 	require.NoError(t, err)

--- a/pkg/tests/api/alerting/api_remote_alertmanager_test.go
+++ b/pkg/tests/api/alerting/api_remote_alertmanager_test.go
@@ -85,7 +85,6 @@ receivers:
 	headers := map[string]string{
 		"Content-Type":                         "application/yaml",
 		"X-Grafana-Alerting-Config-Identifier": "external-system",
-		"X-Grafana-Alerting-Merge-Matchers":    "environment=production,team=backend",
 	}
 
 	amConfig := apimodels.AlertmanagerUserConfig{
@@ -185,7 +184,6 @@ receivers:
 	headers := map[string]string{
 		"Content-Type":                         "application/yaml",
 		"X-Grafana-Alerting-Config-Identifier": "historical-system",
-		"X-Grafana-Alerting-Merge-Matchers":    "environment=test,team=platform",
 	}
 
 	amConfig := apimodels.AlertmanagerUserConfig{

--- a/pkg/tests/apis/alerting/notifications/inhibitionrule/imported_test.go
+++ b/pkg/tests/apis/alerting/notifications/inhibitionrule/imported_test.go
@@ -49,12 +49,10 @@ func TestIntegrationImportedInhibitionRules(t *testing.T) {
 	require.NoError(t, err)
 
 	identifier := "integration-test"
-	mergeMatchers := "_imported=true"
 
 	headers := map[string]string{
 		"Content-Type":                         "application/yaml",
 		"X-Grafana-Alerting-Config-Identifier": identifier,
-		"X-Grafana-Alerting-Merge-Matchers":    mergeMatchers,
 	}
 
 	var amConfig apimodels.AlertmanagerUserConfig

--- a/pkg/tests/apis/alerting/notifications/receivers/imported_test.go
+++ b/pkg/tests/apis/alerting/notifications/receivers/imported_test.go
@@ -46,12 +46,10 @@ func TestIntegrationReadImported_Snapshot(t *testing.T) {
 	require.NoError(t, err)
 
 	identifier := "test-create-get-config"
-	mergeMatchers := "_imported=true"
 
 	headers := map[string]string{
 		"Content-Type":                         "application/yaml",
 		"X-Grafana-Alerting-Config-Identifier": identifier,
-		"X-Grafana-Alerting-Merge-Matchers":    mergeMatchers,
 	}
 
 	amConfig := apimodels.AlertmanagerUserConfig{

--- a/pkg/tests/apis/alerting/notifications/routingtree/imported_test.go
+++ b/pkg/tests/apis/alerting/notifications/routingtree/imported_test.go
@@ -46,12 +46,10 @@ func TestIntegrationReadImported_Snapshot(t *testing.T) {
 	require.NoError(t, err)
 
 	identifier := "test-create-get-config"
-	mergeMatchers := "_imported=true"
 
 	headers := map[string]string{
 		"Content-Type":                         "application/yaml",
 		"X-Grafana-Alerting-Config-Identifier": identifier,
-		"X-Grafana-Alerting-Merge-Matchers":    mergeMatchers,
 	}
 
 	amConfig := apimodels.AlertmanagerUserConfig{

--- a/pkg/tests/apis/alerting/notifications/routingtree/routing_tree_test.go
+++ b/pkg/tests/apis/alerting/notifications/routingtree/routing_tree_test.go
@@ -868,7 +868,6 @@ receivers:
 	headers := map[string]string{
 		"Content-Type":                         "application/yaml",
 		"X-Grafana-Alerting-Config-Identifier": "external-system",
-		"X-Grafana-Alerting-Merge-Matchers":    "imported=true",
 	}
 
 	// Post the configuration to Grafana
@@ -877,28 +876,20 @@ receivers:
 	}, headers)
 	require.Equal(t, "success", response.Status)
 
-	current, err := client.Get(ctx, defaultTreeIdentifier)
-	require.NoError(t, err)
-	updated := current.Copy().(*v1beta1.RoutingTree)
-	updated.Spec.Routes = append(updated.Spec.Routes, v1beta1.RoutingTreeRoute{
-		Matchers: []v1beta1.RoutingTreeMatcher{
-			{
-				Label: "imported",
-				Type:  v1beta1.RoutingTreeMatcherTypeEqual,
-				Value: "true",
-			},
-		},
-	})
-
-	_, err = client.Update(ctx, updated, resource.UpdateOptions{})
+	// The imported route is named after its identifier. Creating a managed route
+	// with the same name must fail while the import exists.
+	_, err = client.Create(ctx, k8sRoute(t, "external-system", &definitions.Route{Receiver: "empty"}), resource.CreateOptions{})
 	require.Error(t, err)
-	require.Truef(t, errors.IsBadRequest(err), "Should get BadRequest error but got: %s", err)
+	require.Truef(t, errors.IsConflict(err), "Should get Conflict error but got: %s", err)
 
-	// Now delete extra config
+	// After removing the imported config the name is free.
 	legacyCli.ConvertPrometheusDeleteAlertmanagerConfig(t, headers)
 
-	// and try again
-	_, err = client.Update(ctx, updated, resource.UpdateOptions{})
+	created, err := client.Create(ctx, k8sRoute(t, "external-system", &definitions.Route{Receiver: "empty"}), resource.CreateOptions{})
+	require.NoError(t, err)
+
+	// Clean up.
+	err = client.Delete(ctx, resource.Identifier{Namespace: apis.DefaultNamespace, Name: created.Name}, resource.DeleteOptions{})
 	require.NoError(t, err)
 }
 

--- a/pkg/tests/apis/alerting/notifications/templategroup/imported_test.go
+++ b/pkg/tests/apis/alerting/notifications/templategroup/imported_test.go
@@ -46,12 +46,10 @@ func TestIntegrationImportedTemplates(t *testing.T) {
 	require.NoError(t, err)
 
 	identifier := "test-create-get-config"
-	mergeMatchers := "_imported=true"
 
 	headers := map[string]string{
 		"Content-Type":                         "application/yaml",
 		"X-Grafana-Alerting-Config-Identifier": identifier,
-		"X-Grafana-Alerting-Merge-Matchers":    mergeMatchers,
 	}
 	var amConfig apimodels.AlertmanagerUserConfig
 	require.NoError(t, yaml.Unmarshal(configYaml, &amConfig))

--- a/pkg/tests/apis/alerting/notifications/timeinterval/imported_test.go
+++ b/pkg/tests/apis/alerting/notifications/timeinterval/imported_test.go
@@ -43,12 +43,10 @@ func TestIntegrationImportedTimeIntervals(t *testing.T) {
 	require.NoError(t, err)
 
 	identifier := "test-imported-time-intervals"
-	mergeMatchers := "_imported=true"
 
 	headers := map[string]string{
 		"Content-Type":                         "application/yaml",
 		"X-Grafana-Alerting-Config-Identifier": identifier,
-		"X-Grafana-Alerting-Merge-Matchers":    mergeMatchers,
 	}
 	var amConfig apimodels.AlertmanagerUserConfig
 	require.NoError(t, yaml.Unmarshal(configYaml, &amConfig))


### PR DESCRIPTION
## Summary

- Removes the `MergeMatchers` field from `ExtraConfiguration` (struct, validation, JSON schema, HTTP param)
- Removes all routing logic that depended on it: `ValidateSubtreeMatchers`, `MergeRoutes`, `MergeInhibitRules`, `checkIfMatchersUsed`, and the related error types (`ErrRouteConflictingMatchers`, `ErrSubtreeMatchersConflict`, etc.)
- Removes the `X-Grafana-Alerting-Merge-Matchers` HTTP header from the Prometheus import API (parse/format helpers, GET echo)
- Updates all tests to remove `MergeMatchers` from fixtures; drops tests that existed solely to cover the removed validation; collapses duplicate `TestApplyConfigWithExtraConfigs` variants

## Test plan

- [ ] Unit tests pass: `go test ./pkg/services/ngalert/...` ✅
- [ ] Integration tests: `api_convert_prometheus_alertmanager_test.go`, `api_remote_alertmanager_test.go`, notifications API tests

Related to https://github.com/grafana/alerting-squad/issues/1393