### PR TITLE
docs(frontend-o11y): adding note to frontend o11y grafana role

### DIFF
--- a/docs/sources/administration/roles-and-permissions/access-control/plugin-role-definitions/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/plugin-role-definitions/index.md
@@ -192,6 +192,10 @@ Plugin ID: `grafana-kowalski-app`
 | `plugins:grafana-kowalski-app:frontend-observability-viewer`             | View access only                                                    |
 | `plugins:grafana-kowalski-app:frontend-observability-sourcemap-uploader` | View access with the ability to read settings and upload sourcemaps |
 
+{{< admonition type="note" >}}
+Deleting custom tabs requires the Grafana **Admin** organization role. Plugin roles, including `frontend-observability-admin`, do not grant this permission.
+{{< /admonition >}}
+
 ## Grafana Assistant plugin
 
 Plugin ID: `grafana-assistant-app`


### PR DESCRIPTION
**What is this feature?**

just a docs change - part of some docs changes for the website [PR I made](https://github.com/grafana/website/pull/30611) 

**Why do we need this feature?**

remove uncertainty regarding the roles required for deleting custom tabs in frontend o11y

**Who is this feature for?**

users seeking info about custom tabs in frontend o11y

**Which issue(s) does this PR fix?**:

no issue, it was part of a support escalation that sought clearer docs

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
