### PR TITLE
unified-storage: fix Badger implementation of `Keys` with desc sort

### DIFF
--- a/pkg/storage/unified/resource/kv/kv.go
+++ b/pkg/storage/unified/resource/kv/kv.go
@@ -367,7 +367,7 @@ func (k *badgerKV) Keys(ctx context.Context, section string, opt ListOptions) it
 
 	isEnd := func(item *badger.Item) bool {
 		if opt.Sort == SortOrderDesc {
-			return string(item.Key()) <= end
+			return string(item.Key()) < end
 		}
 		return string(item.Key()) >= end
 	}
@@ -398,6 +398,9 @@ func (k *badgerKV) Keys(ctx context.Context, section string, opt ListOptions) it
 				return
 			}
 			item := iter.Item()
+			if opt.Sort == SortOrderDesc && string(item.Key()) >= start {
+				continue
+			}
 			if opt.Limit > 0 && count >= opt.Limit {
 				break
 			}

--- a/pkg/storage/unified/testing/kv.go
+++ b/pkg/storage/unified/testing/kv.go
@@ -491,6 +491,19 @@ func runTestKVKeysWithSort(t *testing.T, kv resource.KV, nsPrefix string) {
 		assert.Equal(t, namespacedKeys(nsPrefix, []string{"a2", "a1"}), keys)
 	})
 
+	t.Run("keys descending with range keeps end key exclusive", func(t *testing.T) {
+		var keys []string //nolint:prealloc
+		for k, err := range kv.Keys(ctx, testSection, resource.ListOptions{
+			StartKey: namespacedKey(nsPrefix, "a2"),
+			EndKey:   namespacedKey(nsPrefix, "b2"),
+			Sort:     resource.SortOrderDesc,
+		}) {
+			require.NoError(t, err)
+			keys = append(keys, k)
+		}
+		assert.Equal(t, namespacedKeys(nsPrefix, []string{"b1", "a2"}), keys)
+	})
+
 	t.Run("keys descending with limit", func(t *testing.T) {
 		var keys []string //nolint:prealloc
 		for k, err := range kv.Keys(ctx, testSection, resource.ListOptions{


### PR DESCRIPTION
It would previously _include_ the `EndKey` and not include the `StartKey` when passed `SortOrderDesc`, which is the opposite of that the KV interface expects.