### PR TITLE
unified-storage: add support for leases in storage backend write benchmark

### DIFF
--- a/pkg/storage/unified/sql/test/integration_test.go
+++ b/pkg/storage/unified/sql/test/integration_test.go
@@ -123,7 +123,7 @@ func TestIntegrationSQLStorageAndSQLKVCompatibilityTests(t *testing.T) {
 	t.Cleanup(db.CleanupTestDB)
 
 	newKvBackend := func(ctx context.Context) (resource.StorageBackend, sqldb.DB) {
-		return unitest.NewTestSqlKvBackend(t, ctx, true)
+		return unitest.NewTestSqlKvBackend(t, ctx, unitest.SQLKVBackendModeRVManager)
 	}
 
 	opts := &unitest.TestOptions{

--- a/pkg/storage/unified/testing/storage_backend_sql_compatibility.go
+++ b/pkg/storage/unified/testing/storage_backend_sql_compatibility.go
@@ -26,7 +26,17 @@ import (
 	"github.com/grafana/grafana/pkg/util/testutil"
 )
 
-func NewTestSqlKvBackend(t *testing.T, ctx context.Context, withRvManager bool) (resource.KVBackend, sqldb.DB) {
+type SQLKVBackendMode string
+
+const (
+	SQLKVBackendModeRVManager         SQLKVBackendMode = "rvmanager"
+	SQLKVBackendModeLeases            SQLKVBackendMode = "leases"
+	SQLKVBackendModeOptimisticLocking SQLKVBackendMode = "optimistic-locking"
+)
+
+func NewTestSqlKvBackend(t *testing.T, ctx context.Context, mode SQLKVBackendMode) (resource.KVBackend, sqldb.DB) {
+	t.Helper()
+
 	dbstore := db.InitTestDB(t)
 	eDB, err := dbimpl.ProvideResourceDB(dbstore, setting.NewCfg(), nil)
 	require.NoError(t, err)
@@ -46,7 +56,8 @@ func NewTestSqlKvBackend(t *testing.T, ctx context.Context, withRvManager bool) 
 		kvOpts.UseChannelNotifier = true
 	}
 
-	if withRvManager {
+	switch mode {
+	case SQLKVBackendModeRVManager:
 		dialect := sqltemplate.DialectForDriver(dbConn.DriverName())
 		rvManager, err := rvmanager.NewResourceVersionManager(rvmanager.ResourceManagerOptions{
 			Dialect: dialect,
@@ -55,9 +66,12 @@ func NewTestSqlKvBackend(t *testing.T, ctx context.Context, withRvManager bool) 
 		require.NoError(t, err)
 
 		kvOpts.RvManager = rvManager
-	} else {
+	case SQLKVBackendModeLeases:
 		kvOpts.EnableKVLeases = true
 		kvOpts.Holder = "test-holder-" + uuid.NewString()
+	case SQLKVBackendModeOptimisticLocking:
+	default:
+		require.FailNowf(t, "invalid SQLKV backend mode", "mode: %s", mode)
 	}
 
 	backend, err := resource.NewKVStorageBackend(kvOpts)

--- a/pkg/storage/unified/testing/storage_backend_test.go
+++ b/pkg/storage/unified/testing/storage_backend_test.go
@@ -76,12 +76,12 @@ func TestIntegrationSQLKVConcurrentCreateNoAlreadyExists(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	t.Run("Without RvManager", func(t *testing.T) {
-		backend, _ := NewTestSqlKvBackend(t, t.Context(), false)
+		backend, _ := NewTestSqlKvBackend(t, t.Context(), SQLKVBackendModeLeases)
 		runConcurrentCreateNoAlreadyExists(t, backend, "sqlkv-no-already-exists")
 	})
 
 	t.Run("With RvManager", func(t *testing.T) {
-		backend, _ := NewTestSqlKvBackend(t, t.Context(), true)
+		backend, _ := NewTestSqlKvBackend(t, t.Context(), SQLKVBackendModeRVManager)
 		runConcurrentCreateNoAlreadyExists(t, backend, "sqlkv-rvmanager-no-already-exists")
 	})
 }
@@ -167,25 +167,25 @@ func TestIntegrationSQLKVConcurrentCreateClientRetry(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 
 	t.Run("Without RvManager/Local", func(t *testing.T) {
-		backend, _ := NewTestSqlKvBackend(t, t.Context(), false)
+		backend, _ := NewTestSqlKvBackend(t, t.Context(), SQLKVBackendModeLeases)
 		client := newLocalClient(t, backend)
 		runConcurrentCreateRetry(t, client, "sqlkv-retry-local")
 	})
 
 	t.Run("Without RvManager/Remote", func(t *testing.T) {
-		backend, _ := NewTestSqlKvBackend(t, t.Context(), false)
+		backend, _ := NewTestSqlKvBackend(t, t.Context(), SQLKVBackendModeLeases)
 		client := newRemoteClient(t, backend)
 		runConcurrentCreateRetry(t, client, "sqlkv-retry-remote")
 	})
 
 	t.Run("With RvManager/Local", func(t *testing.T) {
-		backend, _ := NewTestSqlKvBackend(t, t.Context(), true)
+		backend, _ := NewTestSqlKvBackend(t, t.Context(), SQLKVBackendModeRVManager)
 		client := newLocalClient(t, backend)
 		runConcurrentCreateRetry(t, client, "sqlkv-rvmanager-retry-local")
 	})
 
 	t.Run("With RvManager/Remote", func(t *testing.T) {
-		backend, _ := NewTestSqlKvBackend(t, t.Context(), true)
+		backend, _ := NewTestSqlKvBackend(t, t.Context(), SQLKVBackendModeRVManager)
 		client := newRemoteClient(t, backend)
 		runConcurrentCreateRetry(t, client, "sqlkv-rvmanager-retry-remote")
 	})
@@ -319,7 +319,7 @@ func TestIntegrationConcurrentWritesWithLeasesSqlKV(t *testing.T) {
 		testutil.SkipIntegrationTestInShortMode(t)
 
 		runConcurrentWritesWithLeases(t, func() resource.StorageBackend {
-			backend, _ := NewTestSqlKvBackend(t, t.Context(), false)
+			backend, _ := NewTestSqlKvBackend(t, t.Context(), SQLKVBackendModeLeases)
 			return backend
 		}, "sqlkv-leases")
 	})
@@ -449,15 +449,19 @@ func runConcurrentDeletesWithLeases(t *testing.T, backend resource.StorageBacken
 }
 
 func TestIntegrationBenchmarkSQLKVStorageBackend(t *testing.T) {
-	for _, withRvManager := range []bool{true, false} {
-		t.Run(fmt.Sprintf("rvmanager=%t", withRvManager), func(t *testing.T) {
+	for _, mode := range []SQLKVBackendMode{
+		SQLKVBackendModeRVManager,
+		SQLKVBackendModeLeases,
+		SQLKVBackendModeOptimisticLocking,
+	} {
+		t.Run(string(mode), func(t *testing.T) {
 			testutil.SkipIntegrationTestInShortMode(t)
 
 			opts := DefaultBenchmarkOptions(t)
 			if db.IsTestDbSQLite() {
 				opts.Concurrency = 1 // to avoid SQLite database is locked error
 			}
-			backend, dbConn := NewTestSqlKvBackend(t, t.Context(), withRvManager)
+			backend, dbConn := NewTestSqlKvBackend(t, t.Context(), mode)
 			dbConn.SqlDB().SetMaxOpenConns(min(max(10, opts.Concurrency), 100))
 			RunStorageBackendBenchmark(t, backend, opts)
 		})
@@ -465,14 +469,14 @@ func TestIntegrationBenchmarkSQLKVStorageBackend(t *testing.T) {
 }
 
 func TestIntegrationBenchmarkSQLKVStorageAndSearch(t *testing.T) {
-	for _, withRvManager := range []bool{true, false} {
-		t.Run(fmt.Sprintf("rvmanager=%t", withRvManager), func(t *testing.T) {
+	for _, mode := range []SQLKVBackendMode{SQLKVBackendModeRVManager, SQLKVBackendModeLeases} {
+		t.Run(string(mode), func(t *testing.T) {
 			testutil.SkipIntegrationTestInShortMode(t)
 			opts := DefaultBenchmarkOptions(t)
 			if db.IsTestDbSQLite() {
 				t.Skip("concurrency benchmark skipped with sqlite")
 			}
-			backend, _ := NewTestSqlKvBackend(t, t.Context(), withRvManager)
+			backend, _ := NewTestSqlKvBackend(t, t.Context(), mode)
 			searchBackend, err := search.NewBleveBackend(search.BleveOptions{
 				Root:                   t.TempDir(),
 				FileThreshold:          0,
@@ -505,7 +509,7 @@ func TestIntegrationSQLKVStorageBackend(t *testing.T) {
 
 	t.Run("Without RvManager", func(t *testing.T) {
 		RunStorageBackendTest(t, func(ctx context.Context) resource.StorageBackend {
-			backend, _ := NewTestSqlKvBackend(t, ctx, false)
+			backend, _ := NewTestSqlKvBackend(t, ctx, SQLKVBackendModeLeases)
 			return backend
 		}, &TestOptions{
 			NSPrefix:  "sqlkvstoragetest",
@@ -515,7 +519,7 @@ func TestIntegrationSQLKVStorageBackend(t *testing.T) {
 
 	t.Run("With RvManager", func(t *testing.T) {
 		RunStorageBackendTest(t, func(ctx context.Context) resource.StorageBackend {
-			backend, _ := NewTestSqlKvBackend(t, ctx, true)
+			backend, _ := NewTestSqlKvBackend(t, ctx, SQLKVBackendModeRVManager)
 			return backend
 		}, &TestOptions{
 			NSPrefix:  "sqlkvstoragetest-rvmanager",


### PR DESCRIPTION
This PR updates the SQL KV storage benchmarks to add a new variant: the tests can now run with the rvmanager (backwards compatible), with KV leases, and with optimistic locking.

Run with `GRAFANA_TEST_DB=mysql US_BACKEND_BENCH_GROUPS=5 US_BACKEND_BENCH_OPERATIONS=1000`:


**`TestIntegrationBenchmarkSQLKVStorageBackend/rvmanager`**

```
        CREATE:
        Total Duration: 872.585334ms
        Req Count: 1000
        Throughput: 1146.02 reqs/sec
        P50 Latency: 42.546375ms
        P90 Latency: 53.050584ms
        P99 Latency: 66.322875ms


        UPDATE:
        Total Duration: 883.804ms
        Req Count: 1000
        Throughput: 1131.47 reqs/sec
        P50 Latency: 42.85ms
        P90 Latency: 54.432708ms
        P99 Latency: 69.529792ms


        DELETE:
        Total Duration: 850.351083ms
        Req Count: 1000
        Throughput: 1175.98 reqs/sec
        P50 Latency: 41.185ms
        P90 Latency: 52.999917ms
        P99 Latency: 63.1085ms
```

**`TestIntegrationBenchmarkSQLKVStorageBackend/leases`**

```
        CREATE:
        Total Duration: 560.299709ms
        Req Count: 1000
        Throughput: 1784.76 reqs/sec
        P50 Latency: 26.834125ms
        P90 Latency: 34.309833ms
        P99 Latency: 43.7495ms


        UPDATE:
        Total Duration: 615.571792ms
        Req Count: 1000
        Throughput: 1624.51 reqs/sec
        P50 Latency: 29.650167ms
        P90 Latency: 37.234792ms
        P99 Latency: 50.013583ms


        DELETE:
        Total Duration: 560.614375ms
        Req Count: 1000
        Throughput: 1783.76 reqs/sec
        P50 Latency: 26.297667ms
        P90 Latency: 35.986083ms
        P99 Latency: 50.544ms
```

**`TestIntegrationBenchmarkSQLKVStorageBackend/optimistic-locking`**

```
        CREATE:
        Total Duration: 321.974958ms
        Req Count: 1000
        Throughput: 3105.83 reqs/sec
        P50 Latency: 14.510792ms
        P90 Latency: 21.079042ms
        P99 Latency: 29.979542ms


        UPDATE:
        Total Duration: 337.561792ms
        Req Count: 1000
        Throughput: 2962.42 reqs/sec
        P50 Latency: 15.354375ms
        P90 Latency: 22.401584ms
        P99 Latency: 37.227584ms


        DELETE:
        Total Duration: 359.852917ms
        Req Count: 1000
        Throughput: 2778.91 reqs/sec
        P50 Latency: 15.827542ms
        P90 Latency: 27.200667ms
        P99 Latency: 40.243667ms
```

So, in other words, faster than the RV manager, but a lot slower than optimistic locking in the scenario exercised by the benchmark (when there's no contention on the same resource, which is the common case).