### PR TITLE
Live: Drop HA prefix when running in cloud

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -74,11 +74,6 @@ export interface FeatureToggles {
   */
   influxdbBackendMigration?: boolean;
   /**
-  * Registers a live apiserver
-  * @default false
-  */
-  liveAPIServer?: boolean;
-  /**
   * populate star status from apiserver
   * @default false
   */

--- a/pkg/registry/apps/apps.go
+++ b/pkg/registry/apps/apps.go
@@ -85,7 +85,7 @@ func ProvideAppInstallers(
 	}
 
 	//nolint:staticcheck // not yet migrated to OpenFeature
-	if features.IsEnabledGlobally(featuremgmt.FlagLiveAPIServer) {
+	if features.IsEnabledGlobally(featuremgmt.FlagLiveRunAPIServer) {
 		installers = append(installers, liveAppInstaller)
 	}
 

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -115,7 +115,18 @@ var (
 			Owner:           grafanaAppPlatformSquad,
 			RequiresRestart: true,
 			Expression:      "false",
-			Generate:        Generate{LegacyGo: true, LegacyFrontend: true},
+			Generate:        Generate{LegacyGo: true},
+		},
+		{
+			Name:            "liveDropHAPrefixInCloud",
+			Description:     "do not include the HA prefix",
+			Stage:           FeatureStageExperimental,
+			RequiresDevMode: true,
+			HideFromDocs:    true,
+			Owner:           grafanaAppPlatformSquad,
+			RequiresRestart: true,
+			Expression:      "true", // gets applied as the software is deployed, but we can disable if necessary
+			Generate:        Generate{LegacyGo: true},
 		},
 		{
 			Name:         "starsFromAPIServer",

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -107,7 +107,7 @@ var (
 			Expression:  "true", // enabled by default
 		},
 		{
-			Name:            "liveAPIServer",
+			Name:            "live.runAPIServer",
 			Description:     "Registers a live apiserver",
 			Stage:           FeatureStageExperimental,
 			RequiresDevMode: true,
@@ -115,18 +115,17 @@ var (
 			Owner:           grafanaAppPlatformSquad,
 			RequiresRestart: true,
 			Expression:      "false",
-			Generate:        Generate{LegacyGo: true},
+			Generate:        Generate{Go: true},
 		},
 		{
-			Name:            "liveDropHAPrefixInCloud",
+			Name:            "live.dropHAPrefixInCloud",
 			Description:     "do not include the HA prefix",
 			Stage:           FeatureStageExperimental,
-			RequiresDevMode: true,
 			HideFromDocs:    true,
 			Owner:           grafanaAppPlatformSquad,
 			RequiresRestart: true,
 			Expression:      "true", // gets applied as the software is deployed, but we can disable if necessary
-			Generate:        Generate{LegacyGo: true},
+			Generate:        Generate{Go: true},
 		},
 		{
 			Name:         "starsFromAPIServer",

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -118,13 +118,13 @@ var (
 			Generate:        Generate{Go: true},
 		},
 		{
-			Name:            "live.dropHAPrefixInCloud",
-			Description:     "do not include the HA prefix",
+			Name:            "live.keepHAPrefixInCloud",
+			Description:     "keep the prefix (just in case)",
 			Stage:           FeatureStageExperimental,
 			HideFromDocs:    true,
 			Owner:           grafanaAppPlatformSquad,
 			RequiresRestart: true,
-			Expression:      "true", // gets applied as the software is deployed, but we can disable if necessary
+			Expression:      "false",
 			Generate:        Generate{Go: true},
 		},
 		{

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -11,7 +11,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2023-02-09,lokiQuerySplitting,GA,@grafana/observability-logs,false,false,true
 2022-02-09,influxdbBackendMigration,GA,@grafana/data-sources-plugins,false,false,true
 2026-05-14,live.runAPIServer,experimental,@grafana/grafana-app-platform-squad,true,true,false
-2026-05-14,live.dropHAPrefixInCloud,experimental,@grafana/grafana-app-platform-squad,false,true,false
+2026-05-14,live.keepHAPrefixInCloud,experimental,@grafana/grafana-app-platform-squad,false,true,false
 2025-08-29,starsFromAPIServer,experimental,@grafana/grafana-frontend-navigation,false,false,true
 2023-11-29,influxqlStreamingParser,experimental,@grafana/data-sources-plugins,false,false,false
 2024-02-01,influxdbRunQueriesInParallel,privatePreview,@grafana/data-sources-plugins,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -11,6 +11,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2023-02-09,lokiQuerySplitting,GA,@grafana/observability-logs,false,false,true
 2022-02-09,influxdbBackendMigration,GA,@grafana/data-sources-plugins,false,false,true
 2026-02-18,liveAPIServer,experimental,@grafana/grafana-app-platform-squad,true,true,false
+2026-05-14,liveDropHAPrefixInCloud,experimental,@grafana/grafana-app-platform-squad,true,true,false
 2025-08-29,starsFromAPIServer,experimental,@grafana/grafana-frontend-navigation,false,false,true
 2023-11-29,influxqlStreamingParser,experimental,@grafana/data-sources-plugins,false,false,false
 2024-02-01,influxdbRunQueriesInParallel,privatePreview,@grafana/data-sources-plugins,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -10,8 +10,8 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2024-10-23,lokiShardSplitting,experimental,@grafana/observability-logs,false,false,true
 2023-02-09,lokiQuerySplitting,GA,@grafana/observability-logs,false,false,true
 2022-02-09,influxdbBackendMigration,GA,@grafana/data-sources-plugins,false,false,true
-2026-02-18,liveAPIServer,experimental,@grafana/grafana-app-platform-squad,true,true,false
-2026-05-14,liveDropHAPrefixInCloud,experimental,@grafana/grafana-app-platform-squad,true,true,false
+2026-05-14,live.runAPIServer,experimental,@grafana/grafana-app-platform-squad,true,true,false
+2026-05-14,live.dropHAPrefixInCloud,experimental,@grafana/grafana-app-platform-squad,false,true,false
 2025-08-29,starsFromAPIServer,experimental,@grafana/grafana-frontend-navigation,false,false,true
 2023-11-29,influxqlStreamingParser,experimental,@grafana/data-sources-plugins,false,false,false
 2024-02-01,influxdbRunQueriesInParallel,privatePreview,@grafana/data-sources-plugins,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -35,13 +35,13 @@ const (
 	// Sort alert rule groups by folder full path in the Prometheus rules API
 	FlagAlertingRuleGroupSortByFolderFullpath = "alertingRuleGroupSortByFolderFullpath"
 
-	// FlagLiveAPIServer
+	// FlagLiveRunAPIServer
 	// Registers a live apiserver
-	FlagLiveAPIServer = "liveAPIServer"
+	FlagLiveRunAPIServer = "live.runAPIServer"
 
 	// FlagLiveDropHAPrefixInCloud
 	// do not include the HA prefix
-	FlagLiveDropHAPrefixInCloud = "liveDropHAPrefixInCloud"
+	FlagLiveDropHAPrefixInCloud = "live.dropHAPrefixInCloud"
 
 	// FlagInfluxqlStreamingParser
 	// Enable streaming JSON parser for InfluxDB datasource InfluxQL query language

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -39,6 +39,10 @@ const (
 	// Registers a live apiserver
 	FlagLiveAPIServer = "liveAPIServer"
 
+	// FlagLiveDropHAPrefixInCloud
+	// do not include the HA prefix
+	FlagLiveDropHAPrefixInCloud = "liveDropHAPrefixInCloud"
+
 	// FlagInfluxqlStreamingParser
 	// Enable streaming JSON parser for InfluxDB datasource InfluxQL query language
 	FlagInfluxqlStreamingParser = "influxqlStreamingParser"

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -39,9 +39,9 @@ const (
 	// Registers a live apiserver
 	FlagLiveRunAPIServer = "live.runAPIServer"
 
-	// FlagLiveDropHAPrefixInCloud
-	// do not include the HA prefix
-	FlagLiveDropHAPrefixInCloud = "live.dropHAPrefixInCloud"
+	// FlagLiveKeepHAPrefixInCloud
+	// keep the prefix (just in case)
+	FlagLiveKeepHAPrefixInCloud = "live.keepHAPrefixInCloud"
 
 	// FlagInfluxqlStreamingParser
 	// Enable streaming JSON parser for InfluxDB datasource InfluxQL query language

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -3926,9 +3926,41 @@
     },
     {
       "metadata": {
+        "name": "live.dropHAPrefixInCloud",
+        "resourceVersion": "1778740214922",
+        "creationTimestamp": "2026-05-14T06:30:14Z"
+      },
+      "spec": {
+        "description": "do not include the HA prefix",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresRestart": true,
+        "hideFromDocs": true,
+        "expression": "true"
+      }
+    },
+    {
+      "metadata": {
+        "name": "live.runAPIServer",
+        "resourceVersion": "1778740214922",
+        "creationTimestamp": "2026-05-14T06:30:14Z"
+      },
+      "spec": {
+        "description": "Registers a live apiserver",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresDevMode": true,
+        "requiresRestart": true,
+        "hideFromDocs": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "liveAPIServer",
         "resourceVersion": "1771434338561",
-        "creationTimestamp": "2026-02-18T17:05:38Z"
+        "creationTimestamp": "2026-02-18T17:05:38Z",
+        "deletionTimestamp": "2026-05-14T06:30:14Z"
       },
       "spec": {
         "description": "Registers a live apiserver",
@@ -3944,7 +3976,8 @@
       "metadata": {
         "name": "liveDropHAPrefixInCloud",
         "resourceVersion": "1778739143895",
-        "creationTimestamp": "2026-05-14T06:12:23Z"
+        "creationTimestamp": "2026-05-14T06:12:23Z",
+        "deletionTimestamp": "2026-05-14T06:30:14Z"
       },
       "spec": {
         "description": "do not include the HA prefix",

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -3928,7 +3928,8 @@
       "metadata": {
         "name": "live.dropHAPrefixInCloud",
         "resourceVersion": "1778740214922",
-        "creationTimestamp": "2026-05-14T06:30:14Z"
+        "creationTimestamp": "2026-05-14T06:30:14Z",
+        "deletionTimestamp": "2026-05-14T10:08:37Z"
       },
       "spec": {
         "description": "do not include the HA prefix",
@@ -3937,6 +3938,21 @@
         "requiresRestart": true,
         "hideFromDocs": true,
         "expression": "true"
+      }
+    },
+    {
+      "metadata": {
+        "name": "live.keepHAPrefixInCloud",
+        "resourceVersion": "1778753317402",
+        "creationTimestamp": "2026-05-14T10:08:37Z"
+      },
+      "spec": {
+        "description": "keep the prefix (just in case)",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresRestart": true,
+        "hideFromDocs": true,
+        "expression": "false"
       }
     },
     {

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -3942,6 +3942,22 @@
     },
     {
       "metadata": {
+        "name": "liveDropHAPrefixInCloud",
+        "resourceVersion": "1778739143895",
+        "creationTimestamp": "2026-05-14T06:12:23Z"
+      },
+      "spec": {
+        "description": "do not include the HA prefix",
+        "stage": "experimental",
+        "codeowner": "@grafana/grafana-app-platform-squad",
+        "requiresDevMode": true,
+        "requiresRestart": true,
+        "hideFromDocs": true,
+        "expression": "true"
+      }
+    },
+    {
+      "metadata": {
         "name": "localeFormatPreference",
         "resourceVersion": "1771434338561",
         "creationTimestamp": "2025-03-31T13:59:07Z"

--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -90,7 +90,14 @@ func ProvideService(cfg *setting.Cfg, routeRegister routing.RouteRegister, plugC
 	}
 
 	if cfg.LiveHAPrefix != "" {
-		g.keyPrefix = cfg.LiveHAPrefix + ".gf_live"
+		// Once this is deployed across all waves in grafana cloud, we can remove the configured LiveHAPrefix
+		// This is OK because the channel prefix now starts with the full stack identifier
+		// Removing the prefix means we can implement an MT live apiserver, while watching events sent from ST
+		if cfg.StackID != "" && toggles.IsEnabledGlobally("xxx") {
+			// OK, the keys are now
+		} else {
+			g.keyPrefix = cfg.LiveHAPrefix + ".gf_live"
+		}
 	}
 
 	logger.Debug("GrafanaLive initialization", "ha", g.IsHA())

--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -93,9 +93,9 @@ func ProvideService(cfg *setting.Cfg, routeRegister routing.RouteRegister, plugC
 		// Once this is deployed across all waves in grafana cloud, we can remove the configured LiveHAPrefix
 		// This is OK because the channel prefix now starts with the full stack identifier
 		// Removing the prefix means we can implement an MT live apiserver, while watching events sent from ST
-		if cfg.StackID != "" && toggles.IsEnabledGlobally("xxx") {
-			// OK, the keys are now
-		} else {
+		// nolint:staticcheck
+		dropPrefix := cfg.StackID != "" && toggles.IsEnabledGlobally(featuremgmt.FlagLiveDropHAPrefixInCloud)
+		if !dropPrefix {
 			g.keyPrefix = cfg.LiveHAPrefix + ".gf_live"
 		}
 	}

--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -93,7 +93,7 @@ func ProvideService(cfg *setting.Cfg, routeRegister routing.RouteRegister, plugC
 		// Once this is deployed across all waves in grafana cloud, we can remove the configured LiveHAPrefix
 		// This is OK because the channel prefix now starts with the full stack identifier
 		// Removing the prefix means we can implement an MT live apiserver, while watching events sent from ST
-		// nolint:staticcheck
+		// nolint:staticcheck // not yet migrated to OpenFeature
 		dropPrefix := cfg.StackID != "" && toggles.IsEnabledGlobally(featuremgmt.FlagLiveDropHAPrefixInCloud)
 		if !dropPrefix {
 			g.keyPrefix = cfg.LiveHAPrefix + ".gf_live"
@@ -458,7 +458,7 @@ type GrafanaLive struct {
 	pluginStore           pluginstore.Store
 	pluginClient          plugins.Client
 
-	keyPrefix string // HA prefix for grafana cloud (since the org is always 1)
+	keyPrefix string
 
 	node         *centrifuge.Node
 	surveyCaller *survey.Caller

--- a/pkg/services/live/live.go
+++ b/pkg/services/live/live.go
@@ -94,8 +94,8 @@ func ProvideService(cfg *setting.Cfg, routeRegister routing.RouteRegister, plugC
 		// This is OK because the channel prefix now starts with the full stack identifier
 		// Removing the prefix means we can implement an MT live apiserver, while watching events sent from ST
 		// nolint:staticcheck // not yet migrated to OpenFeature
-		dropPrefix := cfg.StackID != "" && toggles.IsEnabledGlobally(featuremgmt.FlagLiveDropHAPrefixInCloud)
-		if !dropPrefix {
+		keepPrefix := cfg.StackID == "" || toggles.IsEnabledGlobally(featuremgmt.FlagLiveKeepHAPrefixInCloud)
+		if keepPrefix {
 			g.keyPrefix = cfg.LiveHAPrefix + ".gf_live"
 		}
 	}


### PR DESCRIPTION
In https://github.com/grafana/grafana/pull/117275 we updated the channel prefix to include the namespace, the result is that every channel is now unique.

To run an MT live APIServer, we want to connect to that same stream; however each stack is currently prefixed by an additional prefix.

This PR removes the prefix (when a stack is defined).  There is a feature toggle that can be *disabled* if this has problems -- if not, we can remove the HA prefix config after this has been deployed to all waves