### PR TITLE
fix(Explore): Fix "Add to dashboard" for dynamic dashboards

### DIFF
--- a/public/app/features/dashboard-scene/addToDashboard/addPanelsOnLoadBehavior.test.ts
+++ b/public/app/features/dashboard-scene/addToDashboard/addPanelsOnLoadBehavior.test.ts
@@ -1,4 +1,5 @@
 import { store } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { SceneGridLayout, SceneTimeRange, VizPanel } from '@grafana/scenes';
 import { DASHBOARD_FROM_LS_KEY, type DashboardDTO } from 'app/types/dashboard';
 
@@ -32,7 +33,14 @@ function buildTestScene(): DashboardScene {
 }
 
 describe('addPanelsOnLoadBehavior', () => {
+  const originalFT = config.featureToggles.dashboardNewLayouts;
+
+  beforeEach(() => {
+    config.featureToggles.dashboardNewLayouts = true;
+  });
+
   afterEach(() => {
+    config.featureToggles.dashboardNewLayouts = originalFT;
     store.delete(DASHBOARD_FROM_LS_KEY);
   });
 

--- a/public/app/features/dashboard-scene/addToDashboard/addPanelsOnLoadBehavior.test.ts
+++ b/public/app/features/dashboard-scene/addToDashboard/addPanelsOnLoadBehavior.test.ts
@@ -47,6 +47,7 @@ describe('addPanelsOnLoadBehavior', () => {
   describe('when there is no data in localStorage', () => {
     it('does not call scene.addPanel and does not throw', () => {
       const scene = buildTestScene();
+      scene.state.editPane.activate();
       const addPanelSpy = jest.spyOn(scene, 'addPanel');
 
       addPanelsOnLoadBehavior(scene);
@@ -60,6 +61,7 @@ describe('addPanelsOnLoadBehavior', () => {
     it('always clears the LS key', () => {
       store.setObject(DASHBOARD_FROM_LS_KEY, buildTestDTO());
       const scene = buildTestScene();
+      scene.state.editPane.activate();
 
       addPanelsOnLoadBehavior(scene);
       expect(store.exists(DASHBOARD_FROM_LS_KEY)).toBe(false);
@@ -97,32 +99,19 @@ describe('addPanelsOnLoadBehavior', () => {
     });
   });
 
-  describe('editPane activation timing', () => {
-    it('adds panels immediately when editPane is already active', () => {
-      store.setObject(DASHBOARD_FROM_LS_KEY, buildTestDTO());
-      const scene = buildTestScene();
-      scene.state.editPane.activate();
-      const addPanelSpy = jest.spyOn(scene, 'addPanel');
+  it('defers panel addition until editPane activates when it is not yet active', () => {
+    store.setObject(DASHBOARD_FROM_LS_KEY, buildTestDTO());
+    const scene = buildTestScene();
+    const addPanelSpy = jest.spyOn(scene, 'addPanel');
 
-      addPanelsOnLoadBehavior(scene);
+    addPanelsOnLoadBehavior(scene);
 
-      expect(addPanelSpy).toHaveBeenCalledTimes(1);
-    });
+    expect(addPanelSpy).not.toHaveBeenCalled();
 
-    it('defers panel addition until editPane activates when it is not yet active', () => {
-      store.setObject(DASHBOARD_FROM_LS_KEY, buildTestDTO());
-      const scene = buildTestScene();
-      const addPanelSpy = jest.spyOn(scene, 'addPanel');
+    scene.state.editPane.activate();
 
-      addPanelsOnLoadBehavior(scene);
-
-      expect(addPanelSpy).not.toHaveBeenCalled();
-
-      scene.state.editPane.activate();
-
-      expect(addPanelSpy).toHaveBeenCalledTimes(1);
-      expect(addPanelSpy).toHaveBeenCalledWith(expect.any(VizPanel));
-    });
+    expect(addPanelSpy).toHaveBeenCalledTimes(1);
+    expect(addPanelSpy).toHaveBeenCalledWith(expect.any(VizPanel));
   });
 
   describe('time range', () => {

--- a/public/app/features/dashboard-scene/addToDashboard/addPanelsOnLoadBehavior.test.ts
+++ b/public/app/features/dashboard-scene/addToDashboard/addPanelsOnLoadBehavior.test.ts
@@ -1,0 +1,146 @@
+import { store } from '@grafana/data';
+import { SceneGridLayout, SceneTimeRange, VizPanel } from '@grafana/scenes';
+import { DASHBOARD_FROM_LS_KEY, type DashboardDTO } from 'app/types/dashboard';
+
+import { DashboardScene } from '../scene/DashboardScene';
+import { DefaultGridLayoutManager } from '../scene/layout-default/DefaultGridLayoutManager';
+
+import { addPanelsOnLoadBehavior } from './addPanelsOnLoadBehavior';
+
+function buildTestDTO(overrides: Partial<DashboardDTO['dashboard']> = {}): DashboardDTO {
+  return {
+    meta: {},
+    dashboard: {
+      title: '',
+      uid: '',
+      schemaVersion: 42,
+      panels: [{ id: 1, type: 'timeseries', title: 'Test Panel', gridPos: { x: 0, y: 0, w: 12, h: 8 } }],
+      ...overrides,
+    },
+  };
+}
+
+function buildTestScene(): DashboardScene {
+  return new DashboardScene({
+    title: 'Test Dashboard',
+    uid: 'test-uid',
+    $timeRange: new SceneTimeRange({}),
+    body: new DefaultGridLayoutManager({
+      grid: new SceneGridLayout({ children: [] }),
+    }),
+  });
+}
+
+describe('addPanelsOnLoadBehavior', () => {
+  afterEach(() => {
+    store.delete(DASHBOARD_FROM_LS_KEY);
+  });
+
+  describe('when there is no data in localStorage', () => {
+    it('does not call scene.addPanel and does not throw', () => {
+      const scene = buildTestScene();
+      const addPanelSpy = jest.spyOn(scene, 'addPanel');
+
+      addPanelsOnLoadBehavior(scene);
+
+      expect(addPanelSpy).not.toHaveBeenCalled();
+      expect(() => addPanelsOnLoadBehavior(scene)).not.toThrow();
+    });
+  });
+
+  describe('when data is present in localStorage', () => {
+    it('always clears the LS key', () => {
+      store.setObject(DASHBOARD_FROM_LS_KEY, buildTestDTO());
+      const scene = buildTestScene();
+
+      addPanelsOnLoadBehavior(scene);
+      expect(store.exists(DASHBOARD_FROM_LS_KEY)).toBe(false);
+    });
+
+    it('adds each panel to the scene via scene.addPanel', () => {
+      store.setObject(DASHBOARD_FROM_LS_KEY, buildTestDTO());
+      const scene = buildTestScene();
+      scene.state.editPane.activate();
+      const addPanelSpy = jest.spyOn(scene, 'addPanel');
+
+      addPanelsOnLoadBehavior(scene);
+
+      expect(addPanelSpy).toHaveBeenCalledTimes(1);
+      expect(addPanelSpy).toHaveBeenCalledWith(expect.any(VizPanel));
+    });
+
+    it('adds multiple panels when DTO contains multiple panels', () => {
+      store.setObject(
+        DASHBOARD_FROM_LS_KEY,
+        buildTestDTO({
+          panels: [
+            { id: 1, type: 'timeseries', title: 'Panel 1', gridPos: { x: 0, y: 0, w: 12, h: 8 } },
+            { id: 2, type: 'table', title: 'Panel 2', gridPos: { x: 0, y: 8, w: 12, h: 8 } },
+          ],
+        })
+      );
+      const scene = buildTestScene();
+      scene.state.editPane.activate();
+      const addPanelSpy = jest.spyOn(scene, 'addPanel');
+
+      addPanelsOnLoadBehavior(scene);
+
+      expect(addPanelSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('editPane activation timing', () => {
+    it('adds panels immediately when editPane is already active', () => {
+      store.setObject(DASHBOARD_FROM_LS_KEY, buildTestDTO());
+      const scene = buildTestScene();
+      scene.state.editPane.activate();
+      const addPanelSpy = jest.spyOn(scene, 'addPanel');
+
+      addPanelsOnLoadBehavior(scene);
+
+      expect(addPanelSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('defers panel addition until editPane activates when it is not yet active', () => {
+      store.setObject(DASHBOARD_FROM_LS_KEY, buildTestDTO());
+      const scene = buildTestScene();
+      const addPanelSpy = jest.spyOn(scene, 'addPanel');
+
+      addPanelsOnLoadBehavior(scene);
+
+      expect(addPanelSpy).not.toHaveBeenCalled();
+
+      scene.state.editPane.activate();
+
+      expect(addPanelSpy).toHaveBeenCalledTimes(1);
+      expect(addPanelSpy).toHaveBeenCalledWith(expect.any(VizPanel));
+    });
+  });
+
+  describe('time range', () => {
+    it('updates the scene time range when the DTO includes time', () => {
+      const dto = buildTestDTO({ time: { from: 'now-6h', to: 'now' } });
+      store.setObject(DASHBOARD_FROM_LS_KEY, dto);
+      const scene = buildTestScene();
+      scene.state.editPane.activate();
+
+      addPanelsOnLoadBehavior(scene);
+
+      expect(scene.state.$timeRange?.state.from).toBe('now-6h');
+      expect(scene.state.$timeRange?.state.to).toBe('now');
+    });
+
+    it('does not modify the scene time range when the DTO has no time', () => {
+      store.setObject(DASHBOARD_FROM_LS_KEY, buildTestDTO());
+      const scene = buildTestScene();
+      scene.state.editPane.activate();
+      const originalFrom = scene.state.$timeRange?.state.from;
+      const originalTo = scene.state.$timeRange?.state.to;
+
+      addPanelsOnLoadBehavior(scene);
+
+      expect(scene.state.$timeRange?.state.from).toBe(originalFrom);
+      expect(scene.state.$timeRange?.state.to).toBe(originalTo);
+    });
+  });
+});

--- a/public/app/features/dashboard-scene/addToDashboard/addPanelsOnLoadBehavior.ts
+++ b/public/app/features/dashboard-scene/addToDashboard/addPanelsOnLoadBehavior.ts
@@ -1,4 +1,5 @@
 import { store } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import { SceneTimeRange } from '@grafana/scenes';
 import { DashboardModel } from 'app/features/dashboard/state/DashboardModel';
 import { DASHBOARD_FROM_LS_KEY, type DashboardDTO } from 'app/types/dashboard';
@@ -34,6 +35,11 @@ export function addPanelsOnLoadBehavior(scene: DashboardScene) {
       }
     }
   };
+
+  if (!config.featureToggles.dashboardNewLayouts) {
+    addPanels();
+    return;
+  }
 
   if (scene.state.editPane.isActive) {
     addPanels();

--- a/public/app/features/dashboard-scene/addToDashboard/addPanelsOnLoadBehavior.ts
+++ b/public/app/features/dashboard-scene/addToDashboard/addPanelsOnLoadBehavior.ts
@@ -8,14 +8,14 @@ import { type DashboardScene } from '../scene/DashboardScene';
 import { buildGridItemForPanel } from '../serialization/transformSaveModelToScene';
 
 export function addPanelsOnLoadBehavior(scene: DashboardScene) {
-  const dto = store.getObject<DashboardDTO>(DASHBOARD_FROM_LS_KEY);
-  if (!dto) {
-    return;
-  }
-
-  store.delete(DASHBOARD_FROM_LS_KEY);
-
   const addPanels = () => {
+    const dto = store.getObject<DashboardDTO>(DASHBOARD_FROM_LS_KEY);
+    if (!dto) {
+      return;
+    }
+
+    store.delete(DASHBOARD_FROM_LS_KEY);
+
     const model = new DashboardModel(dto.dashboard);
 
     for (const panel of model.panels) {

--- a/public/app/features/dashboard-scene/addToDashboard/addPanelsOnLoadBehavior.ts
+++ b/public/app/features/dashboard-scene/addToDashboard/addPanelsOnLoadBehavior.ts
@@ -8,8 +8,13 @@ import { buildGridItemForPanel } from '../serialization/transformSaveModelToScen
 
 export function addPanelsOnLoadBehavior(scene: DashboardScene) {
   const dto = store.getObject<DashboardDTO>(DASHBOARD_FROM_LS_KEY);
+  if (!dto) {
+    return;
+  }
 
-  if (dto) {
+  store.delete(DASHBOARD_FROM_LS_KEY);
+
+  const addPanels = () => {
     const model = new DashboardModel(dto.dashboard);
 
     for (const panel of model.panels) {
@@ -28,7 +33,13 @@ export function addPanelsOnLoadBehavior(scene: DashboardScene) {
         });
       }
     }
-  }
+  };
 
-  store.delete(DASHBOARD_FROM_LS_KEY);
+  if (scene.state.editPane.isActive) {
+    addPanels();
+  } else {
+    scene.state.editPane.addActivationHandler(() => {
+      addPanels();
+    });
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/grafana/grafana/issues/124728

### Problem

When `dashboardNewLayouts` is enabled (now GA and on by default), layout managers (like `DefaultGridLayoutManager.addPanel()`) use the undo/redo-aware `dashboardEditActions.addElement()` path to add a new panel, which publishes a `DashboardEditActionEvent`.

This event must be caught by `DashboardEditPane.handleEditAction()` to execute the actual `perform()` callback that mutates the grid state.

However, `addPanelsOnLoadBehavior`, the Scenes behavior that completes the "Add to Dashboard" user flow by reading the panel from localStorage and inserting it into the target dashboard, runs during `DashboardScene` activation. At that point, `DashboardEditPane` has not yet activated (it activates later via React's `useEffect` when its component mounts). 

The event is published, bubbles up, but no handler catches it — the panel is never added.

### Approach
Defer panel addition until `DashboardEditPane` is active ; if the edit pane is already active, panels are added immediately.

### 🧪 How to test
- Navigate to Explore, select a data source, run a query
- Click "Add" → "Add to Dashboard" → select "New Dashboard" → click "Open Dashboard"
- Expected: new dashboard opens in edit mode with the panel from Explore
- Repeat with "Existing Dashboard" and select a saved dashboard
- Expected: existing dashboard opens in edit mode with the Explore panel appended
- Verify "Open in new tab" variant works for both flows