### PR TITLE
[release-11.6.15] DashboardDS: Fix Mixed panels not updating on time-range change with stale upstreams

### DIFF
--- a/public/app/plugins/datasource/dashboard/datasource.test.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.test.ts
@@ -1,11 +1,14 @@
-import { first } from 'rxjs';
+import { first, ReplaySubject } from 'rxjs';
 
 import {
   arrayToDataFrame,
+  DataFrame,
   DataQueryResponse,
   DataSourceInstanceSettings,
+  dateTime,
   getDefaultTimeRange,
   LoadingState,
+  PanelData,
   standardTransformersRegistry,
 } from '@grafana/data';
 import { getPanelPlugin } from '@grafana/data/test/__mocks__/pluginMocks';
@@ -13,6 +16,7 @@ import { setPluginImportUtils } from '@grafana/runtime';
 import {
   SafeSerializableSceneObject,
   SceneDataNode,
+  SceneDataProviderResult,
   SceneDataTransformer,
   SceneFlexItem,
   SceneFlexLayout,
@@ -102,6 +106,88 @@ describe('DashboardDatasource', () => {
 
     expect(first).not.toHaveBeenCalled();
   });
+
+  it('Should skip the stale Done replayed by the upstream ReplaySubject on time-range change in MixedDS', async () => {
+    // The upstream SceneQueryRunner exposes its results via a ReplaySubject(1)
+    // that synchronously replays the previous range's Done state on subscribe.
+    // The Mixed-DS operator's `first(Done || Error)` used to match that stale
+    // Done and complete the substream before the upstream re-ran for the new
+    // range, so the chain panel rendered with stale data and never re-rendered
+    // when the real Done arrived seconds later.
+    const oldRange = makeRange('2026-05-01T00:00:00Z', '2026-05-08T00:00:00Z');
+    const newRange = makeRange('2026-05-04T00:00:00Z', '2026-05-08T00:00:00Z');
+
+    const { observable, upstreamStream } = setupWithControllableUpstream(
+      { refId: 'A', panelId: 1 },
+      `${MIXED_REQUEST_PREFIX}1`,
+      newRange
+    );
+
+    // Prime the ReplaySubject with the stale Done BEFORE subscribing, so it gets
+    // replayed synchronously on subscribe, matching the production scenario.
+    upstreamStream.next(makeResult(LoadingState.Done, arrayToDataFrame([1]), oldRange));
+
+    const emissions: DataQueryResponse[] = [];
+    observable.subscribe({ next: (data) => emissions.push(data) });
+
+    await waitForDebounce();
+    expect(emissions).toEqual([]);
+
+    // Upstream now re-runs for the new range: Loading then Done.
+    upstreamStream.next(makeResult(LoadingState.Loading, arrayToDataFrame([1]), newRange));
+    upstreamStream.next(makeResult(LoadingState.Done, arrayToDataFrame([2, 3]), newRange));
+
+    await waitForDebounce();
+    expect(emissions).toHaveLength(1);
+    expect(emissions[0].state).toBe(LoadingState.Done);
+    expect(emissions[0].data[0].fields[0].values).toEqual([2, 3]);
+  });
+
+  it('Should still emit the only Done when ranges match (Mixed editor-add path)', async () => {
+    // The filter must not skip the editor-add case: same range, single Done emission.
+    const range = makeRange('2026-05-04T00:00:00Z', '2026-05-08T00:00:00Z');
+
+    const { observable, upstreamStream } = setupWithControllableUpstream(
+      { refId: 'A', panelId: 1 },
+      `${MIXED_REQUEST_PREFIX}1`,
+      range
+    );
+
+    upstreamStream.next(makeResult(LoadingState.Done, arrayToDataFrame([7, 8, 9]), range));
+
+    const emissions: DataQueryResponse[] = [];
+    observable.subscribe({ next: (data) => emissions.push(data) });
+
+    await waitForDebounce();
+    expect(emissions).toHaveLength(1);
+    expect(emissions[0].state).toBe(LoadingState.Done);
+    expect(emissions[0].data[0].fields[0].values).toEqual([7, 8, 9]);
+  });
+
+  it('Should not drop Done when the chain panel has a different range than the upstream (non-Mixed PanelTimeRange override)', async () => {
+    // Regression guard: a chain panel with a PanelTimeRange override (timeFrom,
+    // timeShift, ...) legitimately observes ranges that differ from the upstream.
+    // The range-mismatch filter only runs on the Mixed-DS path; the non-Mixed
+    // path must keep forwarding terminal emissions regardless of range.
+    const chainRange = makeRange('2026-05-04T00:00:00Z', '2026-05-08T00:00:00Z');
+    const upstreamRange = makeRange('2026-04-27T00:00:00Z', '2026-05-04T00:00:00Z');
+
+    const { observable, upstreamStream } = setupWithControllableUpstream(
+      { refId: 'A', panelId: 1 },
+      /* non-Mixed requestId */ 'panel-1',
+      chainRange
+    );
+
+    upstreamStream.next(makeResult(LoadingState.Done, arrayToDataFrame([42]), upstreamRange));
+
+    const emissions: DataQueryResponse[] = [];
+    observable.subscribe({ next: (data) => emissions.push(data) });
+
+    await waitForDebounce();
+    expect(emissions).toHaveLength(1);
+    expect(emissions[0].state).toBe(LoadingState.Done);
+    expect(emissions[0].data[0].fields[0].values).toEqual([42]);
+  });
 });
 
 function setup(query: DashboardQuery, requestId?: string) {
@@ -145,4 +231,85 @@ function setup(query: DashboardQuery, requestId?: string) {
   });
 
   return { observable, sourceData };
+}
+
+function makeRange(fromIso: string, toIso: string) {
+  const from = dateTime(fromIso);
+  const to = dateTime(toIso);
+  return { from, to, raw: { from, to } };
+}
+
+function makeResult(
+  state: LoadingState,
+  frame: DataFrame,
+  range: ReturnType<typeof makeRange>
+): SceneDataProviderResult {
+  const data: PanelData = {
+    series: [frame],
+    state,
+    timeRange: range,
+    request: {
+      requestId: 'upstream-req',
+      interval: '',
+      intervalMs: 0,
+      range,
+      scopedVars: {},
+      targets: [],
+      timezone: 'utc',
+      app: '',
+      startTime: 0,
+    },
+  };
+  return { origin: undefined as unknown as SceneDataProviderResult['origin'], data };
+}
+
+function waitForDebounce() {
+  // datasource.ts uses the Mixed-DS operator which adds an internal 400ms
+  // debounce on the first Done. Wait long enough for it to drain.
+  return new Promise((r) => setTimeout(r, 600));
+}
+
+function setupWithControllableUpstream(query: DashboardQuery, requestId: string, range: ReturnType<typeof makeRange>) {
+  // Match production: upstream SceneQueryRunner exposes a ReplaySubject(1) so
+  // subscribers attaching after the upstream has already emitted Done get the
+  // stale Done replayed synchronously on subscribe.
+  const upstreamStream = new ReplaySubject<SceneDataProviderResult>(1);
+
+  const sourceData = new SceneDataNode({
+    data: {
+      series: [arrayToDataFrame([0])],
+      state: LoadingState.Done,
+      timeRange: getDefaultTimeRange(),
+    },
+  });
+  jest.spyOn(sourceData, 'getResultsStream').mockReturnValue(upstreamStream);
+
+  const scene = new SceneFlexLayout({
+    children: [
+      new SceneFlexItem({
+        body: new VizPanel({
+          key: getVizPanelKeyForPanelId(1),
+          $data: sourceData,
+        }),
+      }),
+    ],
+  });
+
+  const ds = new DashboardDatasource({} as DataSourceInstanceSettings);
+
+  const observable = ds.query({
+    timezone: 'utc',
+    targets: [query],
+    requestId,
+    interval: '',
+    intervalMs: 0,
+    range,
+    scopedVars: {
+      __sceneObject: new SafeSerializableSceneObject(scene),
+    },
+    app: '',
+    startTime: 0,
+  });
+
+  return { observable, upstreamStream, sourceData };
 }

--- a/public/app/plugins/datasource/dashboard/datasource.ts
+++ b/public/app/plugins/datasource/dashboard/datasource.ts
@@ -1,4 +1,4 @@
-import { Observable, debounce, defer, finalize, first, interval, map, of } from 'rxjs';
+import { Observable, debounce, defer, filter, finalize, first, interval, map, of } from 'rxjs';
 
 import {
   DataSourceApi,
@@ -11,6 +11,7 @@ import {
   PanelData,
   DataFrame,
   LoadingState,
+  TimeRange,
 } from '@grafana/data';
 import { SceneDataProvider, SceneDataTransformer, SceneObject } from '@grafana/scenes';
 import {
@@ -22,6 +23,13 @@ import {
 import { MIXED_REQUEST_PREFIX } from '../mixed/MixedDataSource';
 
 import { DashboardQuery } from './types';
+
+function isSameRange(a: TimeRange | undefined, b: TimeRange | undefined): boolean {
+  if (!a?.from || !a?.to || !b?.from || !b?.to) {
+    return false;
+  }
+  return a.from.valueOf() === b.from.valueOf() && a.to.valueOf() === b.to.valueOf();
+}
 
 /**
  * This should not really be called
@@ -77,7 +85,31 @@ export class DashboardDatasource extends DataSourceApi<DashboardQuery> {
 
       const cleanUp = activateSceneObjectAndParentTree(sourceDataProvider!);
 
+      // Only the Mixed-DS path uses `first(Done || Error)` to complete the
+      // substream, so only that path needs to defend against a stale Done
+      // replayed from the upstream SceneQueryRunner's ReplaySubject after a
+      // time-range change. The non-Mixed path stays open and naturally
+      // re-emits when the fresh Done arrives, so adding the filter there
+      // could only hurt: a chain panel with a `PanelTimeRange` override
+      // legitimately observes ranges that differ from the upstream and we
+      // would block its terminal emission indefinitely.
+      const isMixedDs = options.requestId.includes(MIXED_REQUEST_PREFIX);
+
       return sourceDataProvider!.getResultsStream!().pipe(
+        filter((result) => {
+          if (!isMixedDs) {
+            return true;
+          }
+          const state = result.data.state;
+          if (state !== LoadingState.Done && state !== LoadingState.Error) {
+            return true;
+          }
+          const upstreamRange = result.data.request?.range;
+          if (!upstreamRange?.from || !upstreamRange?.to) {
+            return true;
+          }
+          return isSameRange(upstreamRange, options.range);
+        }),
         map((result) => {
           return {
             data: this.getDataFramesForQueryTopic(result.data, query),


### PR DESCRIPTION
Backport a3b051b55b0b8b0f88505d0598e74230d887ea80 from https://github.com/grafana/grafana/pull/124665.

## What this change does

In a Mixed datasource panel where each subquery uses the "-- Dashboard --" datasource, a time-range change could leave the chain panel rendering data from the previous range. The upstream `SceneQueryRunner` exposes its results via a `ReplaySubject(1)` that retains the previous Done state. On time-range change the dashboard datasource subscribes to that stream and immediately receives the stale Done; `emitFirstLoadedDataIfMixedDS` then matches that stale Done with `first(Done || Error)` and completes the substream before the upstream re-runs for the new range. With a slow upstream, the real Done lands after the substream is already closed, so the chain never re-renders.

The fix drops terminal emissions whose upstream request range does not match the chain's request range before the Mixed-DS operator chain runs. The filter is gated to the Mixed-DS path (`requestId.includes(MIXED_REQUEST_PREFIX)`) because the bug only fires there. The non-Mixed path stays open and naturally re-emits when the fresh Done arrives, and a chain panel with a `PanelTimeRange` override (timeFrom, timeShift) legitimately observes ranges that differ from the upstream, so applying the filter outside the Mixed path would leave such panels hanging in Loading forever.

## Affected versions

The buggy operator was introduced in https://github.com/grafana/grafana/pull/97116 (merged 2025-01-13), so every 11.5+ minor is affected. The `emitFirstLoadedDataIfMixedDS` method is byte-identical between `release-11.6.15` and `main`, so the fix lands on the same broken operator. Intermediate changes on `main` that this branch lacks (`debounceTime(50)` from https://github.com/grafana/grafana/pull/102887, AdHoc filtering, lint type-import rule, annotation hide fix) are unrelated to the race semantics.

## Conflict resolution notes

- `datasource.ts`: added the `filter(...)` step + `isSameRange` helper + `isMixedDs` declaration only. Did not pull in `debounceTime(50)`, `type` import prefixes, `adHocFilters` argument, or the `cleanUp` -> `activateCleanUp` rename.
- `datasource.test.ts`: added the three new regression tests + helpers only. Did not pull in the unrelated AdHoc Filtering or Annotation Handling test suites. Updated the `waitForDebounce` comment to reflect that 11.6.x does not have the pipe-level `debounceTime(50)`.

## Verification

- 9/9 jest tests pass locally (6 original + 3 new regression tests).
- eslint clean on both files.
- `tsc --noEmit` clean.
- lefthook (prettier + betterer + lint) passed on commit.
