### PR TITLE
Advisor: Clean up unused checktypes

### DIFF
--- a/apps/advisor/pkg/app/checktyperegisterer/checktyperegisterer.go
+++ b/apps/advisor/pkg/app/checktyperegisterer/checktyperegisterer.go
@@ -213,7 +213,7 @@ func (r *Runner) update(ctx context.Context, log logging.Logger, obj resource.Ob
 
 func isAPIServerShuttingDown(err error, logger logging.Logger) bool {
 	if strings.Contains(err.Error(), "apiserver is shutting down") {
-		logger.Debug("Error creating check type, not retrying", "error", err)
+		logger.Debug("Error operating on check type, not retrying", "error", err)
 		return true
 	}
 	return false

--- a/apps/advisor/pkg/app/checktyperegisterer/checktyperegisterer.go
+++ b/apps/advisor/pkg/app/checktyperegisterer/checktyperegisterer.go
@@ -220,6 +220,7 @@ func isAPIServerShuttingDown(err error, logger logging.Logger) bool {
 }
 
 func (r *Runner) RegisterCheckTypesInNamespace(ctx context.Context, logger logging.Logger, namespace string) error {
+	registeredIDs := make(map[string]struct{}, len(r.checkRegistry.Checks()))
 	for _, t := range r.checkRegistry.Checks() {
 		steps := t.Steps()
 		stepTypes := make([]advisorv0alpha1.CheckTypeStep, len(steps))
@@ -250,6 +251,59 @@ func (r *Runner) RegisterCheckTypesInNamespace(ctx context.Context, logger loggi
 		if err := r.registerCheckType(ctx, logger, t.ID(), obj); err != nil {
 			return fmt.Errorf("failed to register check type %s: %w", t.ID(), err)
 		}
+		registeredIDs[t.ID()] = struct{}{}
+	}
+	if err := r.cleanupStaleCheckTypes(ctx, logger, namespace, registeredIDs); err != nil {
+		return fmt.Errorf("failed to cleanup stale check types in namespace %s: %w", namespace, err)
 	}
 	return nil
+}
+
+// cleanupStaleCheckTypes removes any CheckType resources in the given namespace
+// that are no longer present in the check registry. This keeps the API in sync
+// with the source of truth when a check type is removed from the binary.
+func (r *Runner) cleanupStaleCheckTypes(ctx context.Context, logger logging.Logger, namespace string, registeredIDs map[string]struct{}) error {
+	items, err := r.listAllCheckTypes(ctx, namespace)
+	if err != nil {
+		if isAPIServerShuttingDown(err, logger) {
+			return nil
+		}
+		return fmt.Errorf("error listing check types: %w", err)
+	}
+	for _, item := range items {
+		name := item.GetStaticMetadata().Name
+		if _, ok := registeredIDs[name]; ok {
+			continue
+		}
+		id := item.GetStaticMetadata().Identifier()
+		logger.Debug("Deleting stale check type", "check_type", name, "namespace", namespace)
+		if err := r.client.Delete(context.WithoutCancel(ctx), id, resource.DeleteOptions{}); err != nil {
+			if errors.IsNotFound(err) {
+				continue
+			}
+			if isAPIServerShuttingDown(err, logger) {
+				return nil
+			}
+			logger.Error("Unable to delete stale check type", "check_type", name, "error", err)
+			return fmt.Errorf("failed to delete stale check type %s: %w", name, err)
+		}
+		logger.Debug("Stale check type deleted successfully", "check_type", name)
+	}
+	return nil
+}
+
+func (r *Runner) listAllCheckTypes(ctx context.Context, namespace string) ([]resource.Object, error) {
+	list, err := r.client.List(ctx, namespace, resource.ListOptions{Limit: 1000})
+	if err != nil {
+		return nil, err
+	}
+	items := list.GetItems()
+	for list.GetContinue() != "" {
+		list, err = r.client.List(ctx, namespace, resource.ListOptions{Continue: list.GetContinue(), Limit: 1000})
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, list.GetItems()...)
+	}
+	return items, nil
 }

--- a/apps/advisor/pkg/app/checktyperegisterer/checktyperegisterer_test.go
+++ b/apps/advisor/pkg/app/checktyperegisterer/checktyperegisterer_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/grafana/grafana-app-sdk/logging"
@@ -242,6 +243,140 @@ func TestCheckTypesRegisterer_Run(t *testing.T) {
 	}
 }
 
+func TestCheckTypesRegisterer_CleanupStale(t *testing.T) {
+	registeredCheck := &mockCheck{
+		id: "check1",
+		steps: []checks.Step{
+			&mockStep{id: "step1", title: "Step 1", description: "Description 1"},
+		},
+	}
+	makeCheckType := func(name string) advisorv0alpha1.CheckType {
+		return advisorv0alpha1.CheckType{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "stack-123"},
+			Spec:       advisorv0alpha1.CheckTypeSpec{Name: name},
+		}
+	}
+
+	tests := []struct {
+		name            string
+		registered      []checks.Check
+		existing        []advisorv0alpha1.CheckType
+		listErr         error
+		deleteErr       error
+		expectedDeletes []string
+		expectedErr     string
+	}{
+		{
+			name:            "deletes check types not in registry",
+			registered:      []checks.Check{registeredCheck},
+			existing:        []advisorv0alpha1.CheckType{makeCheckType("check1"), makeCheckType("stale1"), makeCheckType("stale2")},
+			expectedDeletes: []string{"stale1", "stale2"},
+		},
+		{
+			name:            "keeps all check types when registry matches",
+			registered:      []checks.Check{registeredCheck},
+			existing:        []advisorv0alpha1.CheckType{makeCheckType("check1")},
+			expectedDeletes: nil,
+		},
+		{
+			name:            "nothing to delete when no existing types",
+			registered:      []checks.Check{registeredCheck},
+			existing:        nil,
+			expectedDeletes: nil,
+		},
+		{
+			name:            "ignores not found on delete",
+			registered:      []checks.Check{registeredCheck},
+			existing:        []advisorv0alpha1.CheckType{makeCheckType("stale1")},
+			deleteErr:       k8sErrs.NewNotFound(schema.GroupResource{}, "stale1"),
+			expectedDeletes: []string{"stale1"},
+		},
+		{
+			name:        "list error is propagated",
+			registered:  []checks.Check{registeredCheck},
+			listErr:     errors.New("list failure"),
+			expectedErr: "list failure",
+		},
+		{
+			name:            "delete error is propagated",
+			registered:      []checks.Check{registeredCheck},
+			existing:        []advisorv0alpha1.CheckType{makeCheckType("stale1")},
+			deleteErr:       errors.New("delete failure"),
+			expectedDeletes: []string{"stale1"},
+			expectedErr:     "delete failure",
+		},
+		{
+			name:            "shutting down on list is treated as no-op",
+			registered:      []checks.Check{registeredCheck},
+			existing:        []advisorv0alpha1.CheckType{makeCheckType("stale1")},
+			listErr:         errors.New("apiserver is shutting down"),
+			expectedDeletes: nil,
+		},
+		{
+			name:            "shutting down on delete is treated as no-op",
+			registered:      []checks.Check{registeredCheck},
+			existing:        []advisorv0alpha1.CheckType{makeCheckType("stale1"), makeCheckType("stale2")},
+			deleteErr:       errors.New("apiserver is shutting down"),
+			expectedDeletes: []string{"stale1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var deleted []string
+			items := make([]advisorv0alpha1.CheckType, len(tt.existing))
+			copy(items, tt.existing)
+			r := &Runner{
+				checkRegistry: &mockCheckRegistry{checks: tt.registered},
+				client: &mockClient{
+					getFunc: func(ctx context.Context, id resource.Identifier) (resource.Object, error) {
+						return nil, k8sErrs.NewNotFound(schema.GroupResource{}, id.Name)
+					},
+					createFunc: func(ctx context.Context, id resource.Identifier, obj resource.Object, opts resource.CreateOptions) (resource.Object, error) {
+						return obj, nil
+					},
+					listFunc: func(ctx context.Context, namespace string, opts resource.ListOptions) (resource.ListObject, error) {
+						if tt.listErr != nil {
+							return nil, tt.listErr
+						}
+						return &advisorv0alpha1.CheckTypeList{Items: items}, nil
+					},
+					deleteFunc: func(ctx context.Context, id resource.Identifier, opts resource.DeleteOptions) error {
+						deleted = append(deleted, id.Name)
+						return tt.deleteErr
+					},
+				},
+				stackID:       "123",
+				orgService:    &mockOrgService{orgs: []*org.OrgDTO{}},
+				log:           logging.DefaultLogger,
+				retryAttempts: 1,
+				retryDelay:    0,
+			}
+
+			err := r.Run(context.Background())
+			if tt.expectedErr != "" {
+				if err == nil {
+					t.Fatalf("expected error containing %q, got nil", tt.expectedErr)
+				}
+				if !strings.Contains(err.Error(), tt.expectedErr) {
+					t.Fatalf("expected error containing %q, got %v", tt.expectedErr, err)
+				}
+			} else if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(deleted) != len(tt.expectedDeletes) {
+				t.Fatalf("expected %d deletes (%v), got %d (%v)", len(tt.expectedDeletes), tt.expectedDeletes, len(deleted), deleted)
+			}
+			for i, name := range tt.expectedDeletes {
+				if deleted[i] != name {
+					t.Errorf("expected delete[%d] to be %q, got %q", i, name, deleted[i])
+				}
+			}
+		})
+	}
+}
+
 type mockCheckRegistry struct {
 	checks []checks.Check
 }
@@ -311,6 +446,8 @@ type mockClient struct {
 	getFunc    func(ctx context.Context, id resource.Identifier) (resource.Object, error)
 	createFunc func(ctx context.Context, id resource.Identifier, obj resource.Object, opts resource.CreateOptions) (resource.Object, error)
 	updateFunc func(ctx context.Context, id resource.Identifier, obj resource.Object, opts resource.UpdateOptions) (resource.Object, error)
+	listFunc   func(ctx context.Context, namespace string, opts resource.ListOptions) (resource.ListObject, error)
+	deleteFunc func(ctx context.Context, id resource.Identifier, opts resource.DeleteOptions) error
 }
 
 func (m *mockClient) Get(ctx context.Context, id resource.Identifier) (resource.Object, error) {
@@ -332,6 +469,20 @@ func (m *mockClient) Update(ctx context.Context, id resource.Identifier, obj res
 		return m.updateFunc(ctx, id, obj, opts)
 	}
 	return nil, errors.New("not implemented")
+}
+
+func (m *mockClient) List(ctx context.Context, namespace string, opts resource.ListOptions) (resource.ListObject, error) {
+	if m.listFunc != nil {
+		return m.listFunc(ctx, namespace, opts)
+	}
+	return &advisorv0alpha1.CheckTypeList{}, nil
+}
+
+func (m *mockClient) Delete(ctx context.Context, id resource.Identifier, opts resource.DeleteOptions) error {
+	if m.deleteFunc != nil {
+		return m.deleteFunc(ctx, id, opts)
+	}
+	return nil
 }
 
 type mockOrgService struct {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

In Cloud, we are removing some `checktypes` which are not needed there (like `config`). This PR adds a clean-up mechanism so old `checktypes` are cleaned up and not listed.

```verilog
level=debug caller=logger.go:204 msg="Deleting stale check type" app=advisor.app check_type=config traceID=29da7811cfa5d5d9a1514859aa551d0e
level=debug caller=logger.go:204 msg="Stale check type deleted successfully" app=advisor.app check_type=config traceID=29da7811cfa5d5d9a1514859aa551d0e
```
