### PR TITLE
[release-12.3.7] apply security patches 12.3.7

### DIFF
--- a/pkg/api/plugin_resource.go
+++ b/pkg/api/plugin_resource.go
@@ -19,6 +19,8 @@ import (
 	"github.com/grafana/grafana/pkg/web"
 )
 
+const maxResourceBodySize = 128 * 1024 * 1024 // 128 MiB
+
 // CallResource passes a resource call from a plugin to the backend plugin.
 //
 // /api/plugins/:pluginId/resources/*
@@ -97,7 +99,7 @@ func (hs *HTTPServer) pluginResourceRequest(c *contextmodel.ReqContext) (*http.R
 func (hs *HTTPServer) makePluginResourceRequest(w http.ResponseWriter, req *http.Request, pCtx backend.PluginContext) error {
 	proxyutil.PrepareProxyRequest(req)
 
-	body, err := io.ReadAll(req.Body)
+	body, err := io.ReadAll(http.MaxBytesReader(w, req.Body, maxResourceBodySize))
 	if err != nil {
 		return fmt.Errorf("failed to read request body: %w", err)
 	}
@@ -116,6 +118,12 @@ func (hs *HTTPServer) makePluginResourceRequest(w http.ResponseWriter, req *http
 }
 
 func handleCallResourceError(err error, reqCtx *contextmodel.ReqContext) {
+	var maxBytesErr *http.MaxBytesError
+	if errors.As(err, &maxBytesErr) {
+		resp := response.Error(http.StatusRequestEntityTooLarge, "Request body too large", err)
+		resp.WriteTo(reqCtx)
+		return
+	}
 	resp := response.ErrOrFallback(http.StatusInternalServerError, "Failed to call resource", err)
 	resp.WriteTo(reqCtx)
 }

--- a/pkg/api/plugin_resource_test.go
+++ b/pkg/api/plugin_resource_test.go
@@ -213,4 +213,37 @@ func TestIntegrationCallResource(t *testing.T) {
 		require.NoError(t, resp.Body.Close())
 		require.Equal(t, 500, resp.StatusCode)
 	})
+
+	t.Run("Test oversized request body returns 413", func(t *testing.T) {
+		// Send a body that exceeds the limit by 1 byte.
+		oversizedBody := io.LimitReader(zeroReader{}, maxResourceBodySize+1)
+		req := srv.NewPostRequest("/api/plugins/grafana-testdata-datasource/resources/test", oversizedBody)
+		webtest.RequestWithSignedInUser(req, &user.SignedInUser{UserID: 1, OrgID: 1, Permissions: map[int64]map[string][]string{
+			1: accesscontrol.GroupScopesByActionContext(context.Background(), []accesscontrol.Permission{
+				{Action: pluginaccesscontrol.ActionAppAccess, Scope: pluginaccesscontrol.ScopeProvider.GetResourceAllScope()},
+			}),
+		}})
+		resp, err := srv.SendJSON(req)
+		require.NoError(t, err)
+
+		bodyBytes, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		var responseBody struct {
+			Message string `json:"message"`
+		}
+		err = json.Unmarshal(bodyBytes, &responseBody)
+		require.NoError(t, err)
+		require.Equal(t, "Request body too large", responseBody.Message)
+		require.NoError(t, resp.Body.Close())
+		require.Equal(t, 413, resp.StatusCode)
+	})
+}
+
+// zeroReader is an io.Reader that returns an endless stream of zero bytes.
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) {
+	clear(p)
+	return len(p), nil
 }

--- a/pkg/expr/sql/parser_allow.go
+++ b/pkg/expr/sql/parser_allow.go
@@ -16,29 +16,48 @@ func AllowQuery(refID, rawSQL string) (bool, error) {
 		return false, fmt.Errorf("error parsing sql: %s", err.Error())
 	}
 
-	walkSubtree := func(node sqlparser.SQLNode) error {
-		err := sqlparser.Walk(func(node sqlparser.SQLNode) (bool, error) {
+	// walkNodes validates all nodes in the AST against the allowlist.
+	// It supplements sqlparser.Walk to cover fields that upstream walkSubtree
+	// implementations skip. SetOp skips OrderBy/With/Limit, and Select skips
+	// Window, so those subtrees are walked explicitly here. Lock and Into are
+	// handled by rejecting them at the parent Select/SetOp node in allowedNode.
+	var walkNodes func(nodes ...sqlparser.SQLNode) error
+	walkNodes = func(nodes ...sqlparser.SQLNode) error {
+		return sqlparser.Walk(func(node sqlparser.SQLNode) (bool, error) {
 			if !allowedNode(node) {
 				if fT, ok := node.(*sqlparser.FuncExpr); ok {
 					return false, MakeBlockedNodeOrFuncError(refID, fT.Name.String(), true)
 				}
 				return false, MakeBlockedNodeOrFuncError(refID, fmt.Sprintf("%T", node), false)
 			}
-			return true, nil
-		}, node)
 
-		if err != nil {
-			var bn *ErrorWithCategory
-			if !errors.As(err, &bn) {
-				return fmt.Errorf("failed to parse SQL expression: %w", err)
+			// Explicitly walk fields that upstream walkSubtree implementations
+			// skip. Without this, functions placed in these fields bypass the
+			// allowlist entirely.
+			switch v := node.(type) {
+			case *sqlparser.SetOp:
+				// SetOp.walkSubtree only visits Left and Right, skipping
+				// OrderBy, With, Limit
+				if err := walkNodes(v.OrderBy, v.With, v.Limit); err != nil {
+					return false, err
+				}
+			case *sqlparser.Select:
+				// Select.walkSubtree skips Window and Lock.
+				if len(v.Window) > 0 {
+					if err := walkNodes(v.Window); err != nil {
+						return false, err
+					}
+				}
 			}
-			return err
-		}
-
-		return nil
+			return true, nil
+		}, nodes...)
 	}
 
-	if err := walkSubtree(s); err != nil {
+	if err := walkNodes(s); err != nil {
+		var bn *ErrorWithCategory
+		if !errors.As(err, &bn) {
+			return false, fmt.Errorf("failed to parse SQL expression: %w", err)
+		}
 		return false, err
 	}
 
@@ -74,7 +93,20 @@ func allowedNode(node sqlparser.SQLNode) (b bool) {
 	case *sqlparser.CharExpr:
 		return
 
-	case sqlparser.ColIdent, *sqlparser.ColName, sqlparser.Columns, sqlparser.ColumnType:
+	case *sqlparser.ColName:
+		// Reject @@system variables (e.g. @@hostname, @@version, @@secure_file_priv).
+		// These are parsed as ColName with the @@ prefix in Name.val.
+		// Also reject @@global.hostname where @@ is in the Qualifier.
+		name := v.Name.String()
+		if strings.HasPrefix(name, "@@") || strings.HasPrefix(name, "@") {
+			return false
+		}
+		if qual := v.Qualifier.Name.String(); strings.HasPrefix(qual, "@@") {
+			return false
+		}
+		return
+
+	case sqlparser.ColIdent, sqlparser.Columns, sqlparser.ColumnType:
 		return
 
 	case sqlparser.Comments: // TODO: understand why some are pointer vs not
@@ -104,6 +136,9 @@ func allowedNode(node sqlparser.SQLNode) (b bool) {
 	case sqlparser.GroupBy:
 		return
 
+	case *sqlparser.Frame, *sqlparser.FrameExtent, *sqlparser.FrameBound:
+		return
+
 	case *sqlparser.IndexHints:
 		return
 
@@ -124,12 +159,15 @@ func allowedNode(node sqlparser.SQLNode) (b bool) {
 	case *sqlparser.JSONTableExpr, *sqlparser.JSONTableSpec, *sqlparser.JSONTableColDef:
 		return
 
-	case *sqlparser.Select, sqlparser.SelectExprs, *sqlparser.ParenSelect:
+	case *sqlparser.Select:
+		return v.Lock == nil || v.Lock.Type == ""
+
+	case sqlparser.SelectExprs, *sqlparser.ParenSelect:
 		return
 
 	case *sqlparser.SetOp:
 		// SetOp.walkSubtree() does not traverse Into, so reject explicitly.
-		return v.GetInto() == nil
+		return v.GetInto() == nil && (v.Lock == nil || v.Lock.Type == "")
 
 	case *sqlparser.StarExpr:
 		return
@@ -144,6 +182,9 @@ func allowedNode(node sqlparser.SQLNode) (b bool) {
 		return
 
 	case *sqlparser.Over:
+		return
+
+	case sqlparser.Window, *sqlparser.WindowDef:
 		return
 
 	case *sqlparser.ParenExpr:

--- a/pkg/services/accesscontrol/resourcepermissions/service.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service.go
@@ -218,13 +218,21 @@ func (s *Service) SetUserPermission(ctx context.Context, orgID int64, user acces
 		return nil, err
 	}
 
-	return s.store.SetUserResourcePermission(ctx, orgID, user, SetResourcePermissionCommand{
+	result, err := s.store.SetUserResourcePermission(ctx, orgID, user, SetResourcePermissionCommand{
 		Actions:           actions,
 		Permission:        permission,
 		Resource:          s.options.Resource,
 		ResourceID:        resourceID,
 		ResourceAttribute: s.options.ResourceAttribute,
 	}, s.options.OnSetUser)
+
+	if err != nil {
+		return nil, err
+	}
+
+	s.clearUserPermissionCache(orgID, user.ID)
+
+	return result, nil
 }
 
 func (s *Service) SetTeamPermission(ctx context.Context, orgID, teamID int64, resourceID, permission string) (*accesscontrol.ResourcePermission, error) {
@@ -325,11 +333,24 @@ func (s *Service) SetPermissions(
 		})
 	}
 
-	return s.store.SetResourcePermissions(ctx, orgID, dbCommands, ResourceHooks{
+	result, err := s.store.SetResourcePermissions(ctx, orgID, dbCommands, ResourceHooks{
 		User:        s.options.OnSetUser,
 		Team:        s.options.OnSetTeam,
 		BuiltInRole: s.options.OnSetBuiltInRole,
 	})
+	if err != nil {
+		return nil, err
+	}
+
+	clearedUsers := make(map[int64]bool)
+	for _, cmd := range commands {
+		if cmd.UserID != 0 && !clearedUsers[cmd.UserID] {
+			s.clearUserPermissionCache(orgID, cmd.UserID)
+			clearedUsers[cmd.UserID] = true
+		}
+	}
+
+	return result, nil
 }
 
 func (s *Service) MapActions(permission accesscontrol.ResourcePermission) string {
@@ -346,6 +367,21 @@ func (s *Service) DeleteResourcePermissions(ctx context.Context, orgID int64, re
 		Resource:          s.options.Resource,
 		ResourceAttribute: s.options.ResourceAttribute,
 		ResourceID:        resourceID,
+	})
+}
+
+// clearUserPermissionCache invalidates the RBAC permission cache for a user.
+// It clears both regular user and service account cache keys since we don't
+// know the identity type from just the user ID.
+func (s *Service) clearUserPermissionCache(orgID int64, userID int64) {
+	s.service.ClearUserPermissionCache(&user.SignedInUser{
+		OrgID:  orgID,
+		UserID: userID,
+	})
+	s.service.ClearUserPermissionCache(&user.SignedInUser{
+		OrgID:            orgID,
+		UserID:           userID,
+		IsServiceAccount: true,
 	})
 }
 

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -1134,7 +1134,10 @@ func (dr *DashboardServiceImpl) ImportDashboard(ctx context.Context, dto *dashbo
 		return nil, err
 	}
 
-	dr.SetDefaultPermissions(ctx, dto, dash, false)
+	// new dashboard created
+	if dto.Dashboard.ID == 0 {
+		dr.SetDefaultPermissions(ctx, dto, dash, false)
+	}
 
 	return dash, nil
 }

--- a/pkg/services/live/managedstream/runner.go
+++ b/pkg/services/live/managedstream/runner.go
@@ -72,7 +72,9 @@ func (r *Runner) GetManagedChannels(orgID int64) ([]*ManagedChannel, error) {
 		// Enrich with minute rate.
 		channel, _ := live.ParseChannel(managedChannel.Channel)
 		prefix := channel.Scope + "/" + channel.Namespace
+		r.mu.RLock()
 		namespaceStream, ok := r.streams[orgID][prefix]
+		r.mu.RUnlock()
 		if ok {
 			managedChannel.MinuteRate = namespaceStream.minuteRate(channel.Path)
 		}

--- a/pkg/services/live/pushhttp/push.go
+++ b/pkg/services/live/pushhttp/push.go
@@ -59,6 +59,7 @@ func (g *Gateway) Handle(ctx *contextmodel.ReqContext) {
 	urlValues := ctx.Req.URL.Query()
 	frameFormat := pushurl.FrameFormatFromValues(urlValues)
 
+	ctx.Req.Body = http.MaxBytesReader(ctx.Resp, ctx.Req.Body, 500*1024) // 500k for each message
 	body, err := io.ReadAll(ctx.Req.Body)
 	if err != nil {
 		logger.Error("Error reading body", "error", err)

--- a/pkg/tsdb/grafana-postgresql-datasource/macros.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/macros.go
@@ -213,6 +213,9 @@ func (m *postgresMacroEngine) evaluateMacro(timeRange backend.TimeRange, query *
 		if err != nil {
 			return "", fmt.Errorf("error parsing interval %v", args[1])
 		}
+		if interval <= 0 {
+			return "", fmt.Errorf("interval must be positive, got %v", args[1])
+		}
 		if len(args) == 3 {
 			err := sqleng.SetupFillmode(query, interval, args[2])
 			if err != nil {
@@ -256,6 +259,9 @@ func (m *postgresMacroEngine) evaluateMacro(timeRange backend.TimeRange, query *
 		interval, err := gtime.ParseInterval(strings.Trim(args[1], `'`))
 		if err != nil {
 			return "", fmt.Errorf("error parsing interval %v", args[1])
+		}
+		if interval <= 0 {
+			return "", fmt.Errorf("interval must be positive, got %v", args[1])
 		}
 		if len(args) == 3 {
 			err := sqleng.SetupFillmode(query, interval, args[2])

--- a/pkg/tsdb/grafana-postgresql-datasource/pgx/sql_engine.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/pgx/sql_engine.go
@@ -401,7 +401,7 @@ func (e *DataSourceHandler) processFrame(frame *data.Frame, qm *dataQueryModel, 
 				}
 			}
 		}
-		if qm.FillMissing != nil {
+		if qm.FillMissing != nil && qm.Interval > 0 {
 			// we align the start-time
 			startUnixTime := qm.TimeRange.From.Unix() / int64(qm.Interval.Seconds()) * int64(qm.Interval.Seconds())
 			alignedTimeRange := backend.TimeRange{

--- a/pkg/tsdb/grafana-postgresql-datasource/sqleng/sql_engine.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/sqleng/sql_engine.go
@@ -351,7 +351,7 @@ func (e *DataSourceHandler) executeQuery(query backend.DataQuery, wg *sync.WaitG
 				}
 			}
 		}
-		if qm.FillMissing != nil {
+		if qm.FillMissing != nil && qm.Interval > 0 {
 			frame = e.applyFill(frame, qm)
 		}
 	}

--- a/pkg/tsdb/mssql/macros.go
+++ b/pkg/tsdb/mssql/macros.go
@@ -145,7 +145,7 @@ func (m *msSQLMacroEngine) Interpolate(query *backend.DataQuery, timeRange backe
 	return sql, nil
 }
 
-func (m *msSQLMacroEngine) evaluateMacro(timeRange backend.TimeRange, query *backend.DataQuery, name string, args []string) (string, error) {  //nolint:gocyclo
+func (m *msSQLMacroEngine) evaluateMacro(timeRange backend.TimeRange, query *backend.DataQuery, name string, args []string) (string, error) { //nolint:gocyclo
 	switch name {
 	case "__time":
 		if len(args) == 0 {

--- a/pkg/tsdb/mssql/macros.go
+++ b/pkg/tsdb/mssql/macros.go
@@ -145,7 +145,7 @@ func (m *msSQLMacroEngine) Interpolate(query *backend.DataQuery, timeRange backe
 	return sql, nil
 }
 
-func (m *msSQLMacroEngine) evaluateMacro(timeRange backend.TimeRange, query *backend.DataQuery, name string, args []string) (string, error) {
+func (m *msSQLMacroEngine) evaluateMacro(timeRange backend.TimeRange, query *backend.DataQuery, name string, args []string) (string, error) {  //nolint:gocyclo
 	switch name {
 	case "__time":
 		if len(args) == 0 {

--- a/pkg/tsdb/mssql/macros.go
+++ b/pkg/tsdb/mssql/macros.go
@@ -175,6 +175,9 @@ func (m *msSQLMacroEngine) evaluateMacro(timeRange backend.TimeRange, query *bac
 		if err != nil {
 			return "", fmt.Errorf("error parsing interval %v", args[1])
 		}
+		if interval <= 0 {
+			return "", fmt.Errorf("interval must be positive, got %v", args[1])
+		}
 		if len(args) == 3 {
 			err := sqleng.SetupFillmode(query, interval, args[2])
 			if err != nil {
@@ -209,6 +212,9 @@ func (m *msSQLMacroEngine) evaluateMacro(timeRange backend.TimeRange, query *bac
 		interval, err := gtime.ParseInterval(strings.Trim(args[1], `'`))
 		if err != nil {
 			return "", fmt.Errorf("error parsing interval %v", args[1])
+		}
+		if interval <= 0 {
+			return "", fmt.Errorf("interval must be positive, got %v", args[1])
 		}
 		if len(args) == 3 {
 			err := sqleng.SetupFillmode(query, interval, args[2])

--- a/pkg/tsdb/mssql/sqleng/sql_engine.go
+++ b/pkg/tsdb/mssql/sqleng/sql_engine.go
@@ -349,7 +349,7 @@ func (e *DataSourceHandler) executeQuery(query backend.DataQuery, wg *sync.WaitG
 				}
 			}
 		}
-		if qm.FillMissing != nil {
+		if qm.FillMissing != nil && qm.Interval > 0 {
 			frame = e.applyFill(frame, qm)
 		}
 	}

--- a/pkg/tsdb/mysql/macros.go
+++ b/pkg/tsdb/mysql/macros.go
@@ -107,6 +107,9 @@ func (m *mySQLMacroEngine) evaluateMacro(timeRange backend.TimeRange, query *bac
 		if err != nil {
 			return "", fmt.Errorf("error parsing interval %v", args[1])
 		}
+		if interval <= 0 {
+			return "", fmt.Errorf("interval must be positive, got %v", args[1])
+		}
 		if len(args) == 3 {
 			err := sqleng.SetupFillmode(query, interval, args[2])
 			if err != nil {
@@ -141,6 +144,9 @@ func (m *mySQLMacroEngine) evaluateMacro(timeRange backend.TimeRange, query *bac
 		interval, err := gtime.ParseInterval(strings.Trim(args[1], `'`))
 		if err != nil {
 			return "", fmt.Errorf("error parsing interval %v", args[1])
+		}
+		if interval <= 0 {
+			return "", fmt.Errorf("interval must be positive, got %v", args[1])
 		}
 		if len(args) == 3 {
 			err := sqleng.SetupFillmode(query, interval, args[2])

--- a/pkg/tsdb/mysql/sqleng/sql_engine.go
+++ b/pkg/tsdb/mysql/sqleng/sql_engine.go
@@ -348,7 +348,7 @@ func (e *DataSourceHandler) executeQuery(query backend.DataQuery, wg *sync.WaitG
 				}
 			}
 		}
-		if qm.FillMissing != nil {
+		if qm.FillMissing != nil && qm.Interval > 0 {
 			frame = e.applyFill(frame, qm)
 		}
 	}


### PR DESCRIPTION
```
✅ ../grafana-security-patches/release-12.3.6+security-04/734-202604071520.patch: GL-Partner-Ack valid
✅ ../grafana-security-patches/release-12.3.6+security-04/734-202604071520.patch: GL-Partner-Rel valid
✅ ../grafana-security-patches/release-12.3.6+security-04/734-202604071520.patch: GL-Public-After valid
✅ ../grafana-security-patches/release-12.3.6+security-04/759-202603102148.patch: GL-Partner-Ack valid
✅ ../grafana-security-patches/release-12.3.6+security-04/759-202603102148.patch: GL-Partner-Rel valid
✅ ../grafana-security-patches/release-12.3.6+security-04/759-202603102148.patch: GL-Public-After valid
✅ ../grafana-security-patches/release-12.3.6+security-04/765-202603111358.patch: GL-Partner-Ack valid
✅ ../grafana-security-patches/release-12.3.6+security-04/765-202603111358.patch: GL-Partner-Rel valid
✅ ../grafana-security-patches/release-12.3.6+security-04/765-202603111358.patch: GL-Public-After valid
✅ ../grafana-security-patches/release-12.3.6+security-04/768-202603111653.patch: GL-Partner-Ack valid
✅ ../grafana-security-patches/release-12.3.6+security-04/768-202603111653.patch: GL-Partner-Rel valid
✅ ../grafana-security-patches/release-12.3.6+security-04/768-202603111653.patch: GL-Public-After valid
✅ ../grafana-security-patches/release-12.3.6+security-04/779-202603181939.patch: GL-Partner-Ack valid
✅ ../grafana-security-patches/release-12.3.6+security-04/779-202603181939.patch: GL-Partner-Rel valid
✅ ../grafana-security-patches/release-12.3.6+security-04/779-202603181939.patch: GL-Public-After valid
✅ ../grafana-security-patches/release-12.3.6+security-04/786-202603191650.patch: GL-Partner-Ack valid
✅ ../grafana-security-patches/release-12.3.6+security-04/786-202603191650.patch: GL-Partner-Rel valid
✅ ../grafana-security-patches/release-12.3.6+security-04/786-202603191650.patch: GL-Public-After valid
✅ ../grafana-security-patches/release-12.3.6+security-04/793-202603200747.patch: GL-Partner-Ack valid
✅ ../grafana-security-patches/release-12.3.6+security-04/793-202603200747.patch: GL-Partner-Rel valid
✅ ../grafana-security-patches/release-12.3.6+security-04/793-202603200747.patch: GL-Public-After valid
✅ ../grafana-security-patches/release-12.3.6+security-04/826-202603301313.patch: GL-Partner-Ack valid
✅ ../grafana-security-patches/release-12.3.6+security-04/826-202603301313.patch: GL-Partner-Rel valid
✅ ../grafana-security-patches/release-12.3.6+security-04/826-202603301313.patch: GL-Public-After valid
✅ ../grafana-security-patches/release-12.3.6+security-04/830-202603301427.patch: GL-Partner-Ack valid
✅ ../grafana-security-patches/release-12.3.6+security-04/830-202603301427.patch: GL-Partner-Rel valid
✅ ../grafana-security-patches/release-12.3.6+security-04/830-202603301427.patch: GL-Public-After valid
✅ ../grafana-security-patches/release-12.3.6+security-04/840-202604151759.patch: GL-Partner-Ack valid
✅ ../grafana-security-patches/release-12.3.6+security-04/840-202604151759.patch: GL-Partner-Rel valid
✅ ../grafana-security-patches/release-12.3.6+security-04/840-202604151759.patch: GL-Public-After valid
✅ ../grafana-security-patches/release-12.3.6+security-04/844-202604082259.patch: GL-Partner-Ack valid
✅ ../grafana-security-patches/release-12.3.6+security-04/844-202604082259.patch: GL-Partner-Rel valid
✅ ../grafana-security-patches/release-12.3.6+security-04/844-202604082259.patch: GL-Public-After valid
```