### PR TITLE
[release-11.6.15] apply security patches

### DIFF
--- a/pkg/api/accesscontrol.go
+++ b/pkg/api/accesscontrol.go
@@ -361,7 +361,7 @@ func (hs *HTTPServer) declareFixedRoles() error {
 					// Need to leave the permissions as they are, so that the seeder doesn't replace permissions when they have been removed from the basic role by the user
 					// Otherwise we could split this into ac.ScopeAnnotationsTypeOrganization and ac.ScopeAnnotationsTypeDashboard scopes and eventually remove the dashboard scope.
 					// https://github.com/grafana/identity-access-team/issues/524
-					{Action: ac.ActionAnnotationsRead, Scope: ac.ScopeAnnotationsAll},
+					{Action: ac.ActionAnnotationsRead, Scope: ac.ScopeAnnotationsTypeOrganization},
 				},
 			},
 			Grants: []string{string(org.RoleViewer)},
@@ -378,9 +378,9 @@ func (hs *HTTPServer) declareFixedRoles() error {
 					// Need to leave the permissions as they are, so that the seeder doesn't replace permissions when they have been removed from the basic role by the user
 					// Otherwise we could split this into ac.ScopeAnnotationsTypeOrganization and ac.ScopeAnnotationsTypeDashboard scopes and eventually remove the dashboard scope.
 					// https://github.com/grafana/identity-access-team/issues/524
-					{Action: ac.ActionAnnotationsCreate, Scope: ac.ScopeAnnotationsAll},
-					{Action: ac.ActionAnnotationsDelete, Scope: ac.ScopeAnnotationsAll},
-					{Action: ac.ActionAnnotationsWrite, Scope: ac.ScopeAnnotationsAll},
+					{Action: ac.ActionAnnotationsCreate, Scope: ac.ScopeAnnotationsTypeOrganization},
+					{Action: ac.ActionAnnotationsDelete, Scope: ac.ScopeAnnotationsTypeOrganization},
+					{Action: ac.ActionAnnotationsWrite, Scope: ac.ScopeAnnotationsTypeOrganization},
 				},
 			},
 			Grants: []string{string(org.RoleEditor)},

--- a/pkg/api/annotations.go
+++ b/pkg/api/annotations.go
@@ -17,7 +17,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/guardian"
-	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/web"
 )
@@ -539,10 +538,10 @@ func canEditDashboard(c *contextmodel.ReqContext, dashboardID int64) (bool, erro
 	return true, nil
 }
 
-func findAnnotationByID(ctx context.Context, repo annotations.Repository, annotationID int64, user *user.SignedInUser) (*annotations.ItemDTO, response.Response) {
+func findAnnotationByID(ctx context.Context, repo annotations.Repository, annotationID int64, user identity.Requester) (*annotations.ItemDTO, response.Response) {
 	query := &annotations.ItemQuery{
 		AnnotationID: annotationID,
-		OrgID:        user.OrgID,
+		OrgID:        user.GetOrgID(),
 		SignedInUser: user,
 	}
 	items, err := repo.Find(ctx, query)
@@ -602,30 +601,9 @@ func AnnotationTypeScopeResolver(annotationsRepo annotations.Repository, feature
 			return nil, accesscontrol.ErrInvalidScope
 		}
 
-		// tempUser is used to resolve annotation type.
-		// The annotation doesn't get returned to the real user, so real user's permissions don't matter here.
-		tempUser := &user.SignedInUser{
-			OrgID: orgID,
-			Permissions: map[int64]map[string][]string{
-				orgID: {
-					dashboards.ActionDashboardsRead:     {dashboards.ScopeDashboardsAll},
-					accesscontrol.ActionAnnotationsRead: {accesscontrol.ScopeAnnotationsAll},
-				},
-			},
-		}
+		tmpCtx, tempUser := identity.WithServiceIdentity(ctx, orgID)
 
-		if features.IsEnabled(ctx, featuremgmt.FlagAnnotationPermissionUpdate) {
-			tempUser = &user.SignedInUser{
-				OrgID: orgID,
-				Permissions: map[int64]map[string][]string{
-					orgID: {
-						accesscontrol.ActionAnnotationsRead: {accesscontrol.ScopeAnnotationsTypeOrganization, dashboards.ScopeDashboardsAll},
-					},
-				},
-			}
-		}
-
-		annotation, resp := findAnnotationByID(ctx, annotationsRepo, int64(annotationId), tempUser)
+		annotation, resp := findAnnotationByID(tmpCtx, annotationsRepo, int64(annotationId), tempUser)
 		if resp != nil {
 			return nil, errors.New("could not resolve annotation type")
 		}

--- a/pkg/api/dashboard_snapshot.go
+++ b/pkg/api/dashboard_snapshot.go
@@ -225,6 +225,17 @@ func (hs *HTTPServer) DeleteDashboardSnapshot(c *contextmodel.ReqContext) respon
 	// all permissions must be explicit, so the lack of a rule for dashboard 0 means the guardian will reject.
 	dashboardID := queryResult.Dashboard.Get("id").MustInt64()
 
+	// If the UID is set, fetch the dashboard ID from the UID
+	dashboardUID := queryResult.Dashboard.Get("uid").MustString()
+	if dashboardUID != "" {
+		query := &dashboards.GetDashboardQuery{UID: dashboardUID, OrgID: c.SignedInUser.GetOrgID()}
+		dashboard, err := hs.DashboardService.GetDashboard(c.Req.Context(), query)
+		if err != nil {
+			return response.Error(http.StatusInternalServerError, "Failed to get dashboard by UID", err)
+		}
+		dashboardID = dashboard.ID
+	}
+
 	if dashboardID != 0 {
 		g, err := guardian.New(c.Req.Context(), dashboardID, c.SignedInUser.GetOrgID(), c.SignedInUser)
 		if err != nil {

--- a/pkg/api/plugin_resource.go
+++ b/pkg/api/plugin_resource.go
@@ -19,6 +19,8 @@ import (
 	"github.com/grafana/grafana/pkg/web"
 )
 
+const maxResourceBodySize = 128 * 1024 * 1024 // 128 MiB
+
 // CallResource passes a resource call from a plugin to the backend plugin.
 //
 // /api/plugins/:pluginId/resources/*
@@ -97,7 +99,7 @@ func (hs *HTTPServer) pluginResourceRequest(c *contextmodel.ReqContext) (*http.R
 func (hs *HTTPServer) makePluginResourceRequest(w http.ResponseWriter, req *http.Request, pCtx backend.PluginContext) error {
 	proxyutil.PrepareProxyRequest(req)
 
-	body, err := io.ReadAll(req.Body)
+	body, err := io.ReadAll(http.MaxBytesReader(w, req.Body, maxResourceBodySize))
 	if err != nil {
 		return fmt.Errorf("failed to read request body: %w", err)
 	}
@@ -116,6 +118,12 @@ func (hs *HTTPServer) makePluginResourceRequest(w http.ResponseWriter, req *http
 }
 
 func handleCallResourceError(err error, reqCtx *contextmodel.ReqContext) {
+	var maxBytesErr *http.MaxBytesError
+	if errors.As(err, &maxBytesErr) {
+		resp := response.Error(http.StatusRequestEntityTooLarge, "Request body too large", err)
+		resp.WriteTo(reqCtx)
+		return
+	}
 	resp := response.ErrOrFallback(http.StatusInternalServerError, "Failed to call resource", err)
 	resp.WriteTo(reqCtx)
 }

--- a/pkg/api/plugin_resource_test.go
+++ b/pkg/api/plugin_resource_test.go
@@ -210,4 +210,37 @@ func TestCallResource(t *testing.T) {
 		require.NoError(t, resp.Body.Close())
 		require.Equal(t, 500, resp.StatusCode)
 	})
+
+	t.Run("Test oversized request body returns 413", func(t *testing.T) {
+		// Send a body that exceeds the limit by 1 byte.
+		oversizedBody := io.LimitReader(zeroReader{}, maxResourceBodySize+1)
+		req := srv.NewPostRequest("/api/plugins/grafana-testdata-datasource/resources/test", oversizedBody)
+		webtest.RequestWithSignedInUser(req, &user.SignedInUser{UserID: 1, OrgID: 1, Permissions: map[int64]map[string][]string{
+			1: accesscontrol.GroupScopesByActionContext(context.Background(), []accesscontrol.Permission{
+				{Action: pluginaccesscontrol.ActionAppAccess, Scope: pluginaccesscontrol.ScopeProvider.GetResourceAllScope()},
+			}),
+		}})
+		resp, err := srv.SendJSON(req)
+		require.NoError(t, err)
+
+		bodyBytes, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+
+		var responseBody struct {
+			Message string `json:"message"`
+		}
+		err = json.Unmarshal(bodyBytes, &responseBody)
+		require.NoError(t, err)
+		require.Equal(t, "Request body too large", responseBody.Message)
+		require.NoError(t, resp.Body.Close())
+		require.Equal(t, 413, resp.StatusCode)
+	})
+}
+
+// zeroReader is an io.Reader that returns an endless stream of zero bytes.
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) {
+	clear(p)
+	return len(p), nil
 }

--- a/pkg/expr/sql/parser_allow.go
+++ b/pkg/expr/sql/parser_allow.go
@@ -15,26 +15,45 @@ func AllowQuery(rawSQL string) (bool, error) {
 		return false, fmt.Errorf("error parsing sql: %s", err.Error())
 	}
 
-	walkSubtree := func(node sqlparser.SQLNode) error {
-		err := sqlparser.Walk(func(node sqlparser.SQLNode) (bool, error) {
+	// walkNodes validates all nodes in the AST against the allowlist.
+	// It supplements sqlparser.Walk to cover fields that upstream walkSubtree
+	// implementations skip. SetOp skips OrderBy/With/Limit, and Select skips
+	// Window, so those subtrees are walked explicitly here. Lock and Into are
+	// handled by rejecting them at the parent Select/SetOp node in allowedNode.
+	var walkNodes func(nodes ...sqlparser.SQLNode) error
+	walkNodes = func(nodes ...sqlparser.SQLNode) error {
+		return sqlparser.Walk(func(node sqlparser.SQLNode) (bool, error) {
 			if !allowedNode(node) {
 				if fT, ok := node.(*sqlparser.FuncExpr); ok {
 					return false, fmt.Errorf("blocked function %s - not supported in queries", fT.Name)
 				}
 				return false, fmt.Errorf("blocked node %T - not supported in queries", node)
 			}
+
+			// Explicitly walk fields that upstream walkSubtree implementations
+			// skip. Without this, functions placed in these fields bypass the
+			// allowlist entirely.
+			switch v := node.(type) {
+			case *sqlparser.SetOp:
+				// SetOp.walkSubtree only visits Left and Right, skipping
+				// OrderBy, With, Limit
+				if err := walkNodes(v.OrderBy, v.With, v.Limit); err != nil {
+					return false, err
+				}
+			case *sqlparser.Select:
+				// Select.walkSubtree skips Window and Lock.
+				if len(v.Window) > 0 {
+					if err := walkNodes(v.Window); err != nil {
+						return false, err
+					}
+				}
+			}
 			return true, nil
-		}, node)
-
-		if err != nil {
-			return fmt.Errorf("failed to parse SQL expression: %w", err)
-		}
-
-		return nil
+		}, nodes...)
 	}
 
-	if err := walkSubtree(s); err != nil {
-		return false, err
+	if err := walkNodes(s); err != nil {
+		return false, fmt.Errorf("failed to parse SQL expression: %w", err)
 	}
 
 	return true, nil
@@ -63,7 +82,20 @@ func allowedNode(node sqlparser.SQLNode) (b bool) {
 	case sqlparser.BoolVal:
 		return
 
-	case sqlparser.ColIdent, *sqlparser.ColName, sqlparser.Columns:
+	case *sqlparser.ColName:
+		// Reject @@system variables (e.g. @@hostname, @@version, @@secure_file_priv).
+		// These are parsed as ColName with the @@ prefix in Name.val.
+		// Also reject @@global.hostname where @@ is in the Qualifier.
+		name := v.Name.String()
+		if strings.HasPrefix(name, "@@") || strings.HasPrefix(name, "@") {
+			return false
+		}
+		if qual := v.Qualifier.Name.String(); strings.HasPrefix(qual, "@@") {
+			return false
+		}
+		return
+
+	case sqlparser.ColIdent, sqlparser.Columns:
 		return
 
 	case sqlparser.Comments: // TODO: understand why some are pointer vs not
@@ -81,6 +113,9 @@ func allowedNode(node sqlparser.SQLNode) (b bool) {
 	case sqlparser.GroupBy:
 		return
 
+	case *sqlparser.Frame, *sqlparser.FrameExtent, *sqlparser.FrameBound:
+		return
+
 	case *sqlparser.IndexHints:
 		return
 
@@ -92,12 +127,15 @@ func allowedNode(node sqlparser.SQLNode) (b bool) {
 	case *sqlparser.JoinTableExpr, sqlparser.JoinCondition:
 		return
 
-	case *sqlparser.Select, sqlparser.SelectExprs:
+	case *sqlparser.Select:
+		return v.Lock == ""
+
+	case sqlparser.SelectExprs:
 		return
 
 	case *sqlparser.SetOp:
 		// SetOp.walkSubtree() does not traverse Into, so reject explicitly.
-		return v.GetInto() == nil
+		return v.GetInto() == nil && v.Lock == ""
 
 	case *sqlparser.StarExpr:
 		return
@@ -112,6 +150,9 @@ func allowedNode(node sqlparser.SQLNode) (b bool) {
 		return
 
 	case *sqlparser.Over:
+		return
+
+	case sqlparser.Window, *sqlparser.WindowDef:
 		return
 
 	case *sqlparser.ParenExpr:

--- a/pkg/services/accesscontrol/resourcepermissions/service.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service.go
@@ -225,13 +225,21 @@ func (s *Service) SetUserPermission(ctx context.Context, orgID int64, user acces
 		return nil, err
 	}
 
-	return s.store.SetUserResourcePermission(ctx, orgID, user, SetResourcePermissionCommand{
+	result, err := s.store.SetUserResourcePermission(ctx, orgID, user, SetResourcePermissionCommand{
 		Actions:           actions,
 		Permission:        permission,
 		Resource:          s.options.Resource,
 		ResourceID:        resourceID,
 		ResourceAttribute: s.options.ResourceAttribute,
 	}, s.options.OnSetUser)
+
+	if err != nil {
+		return nil, err
+	}
+
+	s.clearUserPermissionCache(orgID, user.ID)
+
+	return result, nil
 }
 
 func (s *Service) SetTeamPermission(ctx context.Context, orgID, teamID int64, resourceID, permission string) (*accesscontrol.ResourcePermission, error) {
@@ -332,11 +340,24 @@ func (s *Service) SetPermissions(
 		})
 	}
 
-	return s.store.SetResourcePermissions(ctx, orgID, dbCommands, ResourceHooks{
+	result, err := s.store.SetResourcePermissions(ctx, orgID, dbCommands, ResourceHooks{
 		User:        s.options.OnSetUser,
 		Team:        s.options.OnSetTeam,
 		BuiltInRole: s.options.OnSetBuiltInRole,
 	})
+	if err != nil {
+		return nil, err
+	}
+
+	clearedUsers := make(map[int64]bool)
+	for _, cmd := range commands {
+		if cmd.UserID != 0 && !clearedUsers[cmd.UserID] {
+			s.clearUserPermissionCache(orgID, cmd.UserID)
+			clearedUsers[cmd.UserID] = true
+		}
+	}
+
+	return result, nil
 }
 
 func (s *Service) MapActions(permission accesscontrol.ResourcePermission) string {
@@ -353,6 +374,21 @@ func (s *Service) DeleteResourcePermissions(ctx context.Context, orgID int64, re
 		Resource:          s.options.Resource,
 		ResourceAttribute: s.options.ResourceAttribute,
 		ResourceID:        resourceID,
+	})
+}
+
+// clearUserPermissionCache invalidates the RBAC permission cache for a user.
+// It clears both regular user and service account cache keys since we don't
+// know the identity type from just the user ID.
+func (s *Service) clearUserPermissionCache(orgID int64, userID int64) {
+	s.service.ClearUserPermissionCache(&user.SignedInUser{
+		OrgID:  orgID,
+		UserID: userID,
+	})
+	s.service.ClearUserPermissionCache(&user.SignedInUser{
+		OrgID:            orgID,
+		UserID:           userID,
+		IsServiceAccount: true,
 	})
 }
 

--- a/pkg/services/authn/clients/proxy.go
+++ b/pkg/services/authn/clients/proxy.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"hash/fnv"
 	"net"
-	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -229,7 +228,17 @@ func parseAcceptList(s string) ([]*net.IPNet, error) {
 func coerceProxyAddress(proxyAddr string) (*net.IPNet, error) {
 	proxyAddr = strings.TrimSpace(proxyAddr)
 	if !strings.Contains(proxyAddr, "/") {
-		proxyAddr = path.Join(proxyAddr, "32")
+		ip := net.ParseIP(proxyAddr)
+		if ip == nil {
+			return nil, fmt.Errorf("could not parse the network: invalid IP address")
+		}
+
+		mask := 32
+		if ip.To4() == nil {
+			mask = 128
+		}
+
+		proxyAddr = fmt.Sprintf("%s/%d", proxyAddr, mask)
 	}
 
 	_, network, err := net.ParseCIDR(proxyAddr)

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -926,7 +926,10 @@ func (dr *DashboardServiceImpl) ImportDashboard(ctx context.Context, dto *dashbo
 		return nil, err
 	}
 
-	dr.setDefaultPermissions(ctx, dto, dash, false)
+	// new dashboard created
+	if dto.Dashboard.ID == 0 {
+		dr.setDefaultPermissions(ctx, dto, dash, false)
+	}
 
 	return dash, nil
 }

--- a/pkg/services/live/managedstream/runner.go
+++ b/pkg/services/live/managedstream/runner.go
@@ -72,7 +72,9 @@ func (r *Runner) GetManagedChannels(orgID int64) ([]*ManagedChannel, error) {
 		// Enrich with minute rate.
 		channel, _ := live.ParseChannel(managedChannel.Channel)
 		prefix := channel.Scope + "/" + channel.Namespace
+		r.mu.RLock()
 		namespaceStream, ok := r.streams[orgID][prefix]
+		r.mu.RUnlock()
 		if ok {
 			managedChannel.MinuteRate = namespaceStream.minuteRate(channel.Path)
 		}

--- a/pkg/services/live/pushhttp/push.go
+++ b/pkg/services/live/pushhttp/push.go
@@ -59,6 +59,7 @@ func (g *Gateway) Handle(ctx *contextmodel.ReqContext) {
 	urlValues := ctx.Req.URL.Query()
 	frameFormat := pushurl.FrameFormatFromValues(urlValues)
 
+	ctx.Req.Body = http.MaxBytesReader(ctx.Resp, ctx.Req.Body, 500*1024) // 500k for each message
 	body, err := io.ReadAll(ctx.Req.Body)
 	if err != nil {
 		logger.Error("Error reading body", "error", err)

--- a/pkg/services/sqlstore/migrations/accesscontrol/scope_migrator.go
+++ b/pkg/services/sqlstore/migrations/accesscontrol/scope_migrator.go
@@ -1,6 +1,8 @@
 package accesscontrol
 
 import (
+	"fmt"
+
 	"xorm.io/xorm"
 
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
@@ -8,7 +10,8 @@ import (
 )
 
 const (
-	AlertingScopeRemovalMigrationID = "removing scope from alert.instances:read action migration"
+	AlertingScopeRemovalMigrationID           = "removing scope from alert.instances:read action migration"
+	AnnotationsAllScopeReplacementMigrationID = "replacing annotations:* scope with annotations:type:organization scope"
 )
 
 func AddAlertingScopeRemovalMigration(mg *migrator.Migrator) {
@@ -29,5 +32,51 @@ func (p *alertingScopeRemovalMigrator) Exec(sess *xorm.Session, migrator *migrat
 	p.sess = sess
 	p.dialect = migrator.Dialect
 	_, err := p.sess.Exec("UPDATE permission SET `scope` = '', `kind` = '', `attribute` = '', `identifier` = '' WHERE action = ?", accesscontrol.ActionAlertingInstanceRead)
+	return err
+}
+
+func AddAnnotationsAllScopeReplacementMigration(mg *migrator.Migrator) {
+	mg.AddMigration(AnnotationsAllScopeReplacementMigrationID, &annotationsAllScopeReplacementMigrator{})
+}
+
+var _ migrator.CodeMigration = new(annotationsAllScopeReplacementMigrator)
+
+type annotationsAllScopeReplacementMigrator struct {
+	permissionMigrator
+}
+
+func (p *annotationsAllScopeReplacementMigrator) SQL(dialect migrator.Dialect) string {
+	return CodeMigrationSQL
+}
+
+func (p *annotationsAllScopeReplacementMigrator) Exec(sess *xorm.Session, migrator *migrator.Migrator) error {
+	p.sess = sess
+	p.dialect = migrator.Dialect
+
+	// Remove annotations:* rows where annotations:type:organization already exists
+	// for the same (action, role_id), to prevent a UNIQUE constraint violation on the UPDATE below.
+	// The derived table wrapper avoids MySQL error 1093 ("can't specify target table in FROM clause").
+	if _, err := p.sess.Exec(`DELETE FROM permission WHERE scope = 'annotations:*' AND action IN (?, ?, ?, ?) AND EXISTS (
+		SELECT 1 FROM (SELECT action, role_id FROM permission WHERE scope = 'annotations:type:organization') AS p2
+		WHERE p2.action = permission.action AND p2.role_id = permission.role_id
+	)`,
+		accesscontrol.ActionAnnotationsRead,
+		accesscontrol.ActionAnnotationsWrite,
+		accesscontrol.ActionAnnotationsCreate,
+		accesscontrol.ActionAnnotationsDelete,
+	); err != nil {
+		return fmt.Errorf("delete annotations:* permissions: %w", err)
+	}
+
+	_, err := p.sess.Exec("UPDATE permission SET `scope` = 'annotations:type:organization' WHERE action IN (?, ?, ?, ?) AND scope = 'annotations:*'",
+		accesscontrol.ActionAnnotationsRead,
+		accesscontrol.ActionAnnotationsWrite,
+		accesscontrol.ActionAnnotationsCreate,
+		accesscontrol.ActionAnnotationsDelete,
+	)
+	if err != nil {
+		return fmt.Errorf("update annotations:* permissions: %w", err)
+	}
+
 	return err
 }

--- a/pkg/services/sqlstore/migrations/migrations.go
+++ b/pkg/services/sqlstore/migrations/migrations.go
@@ -112,6 +112,7 @@ func (oss *OSSMigrations) AddMigration(mg *Migrator) {
 	// https://github.com/grafana/identity-access-team/issues/546: tracks removal of the feature toggle from the annotation permission migration
 	if oss.features != nil && oss.features.IsEnabledGlobally(featuremgmt.FlagAnnotationPermissionUpdate) {
 		accesscontrol.AddManagedDashboardAnnotationActionsMigration(mg)
+		accesscontrol.AddAnnotationsAllScopeReplacementMigration(mg)
 	}
 
 	addCloudMigrationsMigrations(mg)

--- a/pkg/tsdb/grafana-postgresql-datasource/macros.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/macros.go
@@ -114,6 +114,9 @@ func (m *postgresMacroEngine) evaluateMacro(timeRange backend.TimeRange, query *
 		if err != nil {
 			return "", fmt.Errorf("error parsing interval %v", args[1])
 		}
+		if interval <= 0 {
+			return "", fmt.Errorf("interval must be positive, got %v", args[1])
+		}
 		if len(args) == 3 {
 			err := sqleng.SetupFillmode(query, interval, args[2])
 			if err != nil {
@@ -157,6 +160,9 @@ func (m *postgresMacroEngine) evaluateMacro(timeRange backend.TimeRange, query *
 		interval, err := gtime.ParseInterval(strings.Trim(args[1], `'`))
 		if err != nil {
 			return "", fmt.Errorf("error parsing interval %v", args[1])
+		}
+		if interval <= 0 {
+			return "", fmt.Errorf("interval must be positive, got %v", args[1])
 		}
 		if len(args) == 3 {
 			err := sqleng.SetupFillmode(query, interval, args[2])

--- a/pkg/tsdb/grafana-postgresql-datasource/sqleng/sql_engine.go
+++ b/pkg/tsdb/grafana-postgresql-datasource/sqleng/sql_engine.go
@@ -352,7 +352,7 @@ func (e *DataSourceHandler) executeQuery(query backend.DataQuery, wg *sync.WaitG
 				}
 			}
 		}
-		if qm.FillMissing != nil {
+		if qm.FillMissing != nil && qm.Interval > 0 {
 			frame = e.applyFill(frame, qm)
 		}
 	}

--- a/pkg/tsdb/mssql/macros.go
+++ b/pkg/tsdb/mssql/macros.go
@@ -95,6 +95,9 @@ func (m *msSQLMacroEngine) evaluateMacro(timeRange backend.TimeRange, query *bac
 		if err != nil {
 			return "", fmt.Errorf("error parsing interval %v", args[1])
 		}
+		if interval <= 0 {
+			return "", fmt.Errorf("interval must be positive, got %v", args[1])
+		}
 		if len(args) == 3 {
 			err := sqleng.SetupFillmode(query, interval, args[2])
 			if err != nil {
@@ -129,6 +132,9 @@ func (m *msSQLMacroEngine) evaluateMacro(timeRange backend.TimeRange, query *bac
 		interval, err := gtime.ParseInterval(strings.Trim(args[1], `'`))
 		if err != nil {
 			return "", fmt.Errorf("error parsing interval %v", args[1])
+		}
+		if interval <= 0 {
+			return "", fmt.Errorf("interval must be positive, got %v", args[1])
 		}
 		if len(args) == 3 {
 			err := sqleng.SetupFillmode(query, interval, args[2])

--- a/pkg/tsdb/mssql/sqleng/sql_engine.go
+++ b/pkg/tsdb/mssql/sqleng/sql_engine.go
@@ -349,7 +349,7 @@ func (e *DataSourceHandler) executeQuery(query backend.DataQuery, wg *sync.WaitG
 				}
 			}
 		}
-		if qm.FillMissing != nil {
+		if qm.FillMissing != nil && qm.Interval > 0 {
 			frame = e.applyFill(frame, qm)
 		}
 	}

--- a/pkg/tsdb/mysql/macros.go
+++ b/pkg/tsdb/mysql/macros.go
@@ -107,6 +107,9 @@ func (m *mySQLMacroEngine) evaluateMacro(timeRange backend.TimeRange, query *bac
 		if err != nil {
 			return "", fmt.Errorf("error parsing interval %v", args[1])
 		}
+		if interval <= 0 {
+			return "", fmt.Errorf("interval must be positive, got %v", args[1])
+		}
 		if len(args) == 3 {
 			err := sqleng.SetupFillmode(query, interval, args[2])
 			if err != nil {
@@ -141,6 +144,9 @@ func (m *mySQLMacroEngine) evaluateMacro(timeRange backend.TimeRange, query *bac
 		interval, err := gtime.ParseInterval(strings.Trim(args[1], `'`))
 		if err != nil {
 			return "", fmt.Errorf("error parsing interval %v", args[1])
+		}
+		if interval <= 0 {
+			return "", fmt.Errorf("interval must be positive, got %v", args[1])
 		}
 		if len(args) == 3 {
 			err := sqleng.SetupFillmode(query, interval, args[2])

--- a/pkg/tsdb/mysql/sqleng/sql_engine.go
+++ b/pkg/tsdb/mysql/sqleng/sql_engine.go
@@ -348,7 +348,7 @@ func (e *DataSourceHandler) executeQuery(query backend.DataQuery, wg *sync.WaitG
 				}
 			}
 		}
-		if qm.FillMissing != nil {
+		if qm.FillMissing != nil && qm.Interval > 0 {
 			frame = e.applyFill(frame, qm)
 		}
 	}


### PR DESCRIPTION
```
✅ ../grafana-security-patches/release-11.6.14+security-04/737-202604071543.patch: GL-Partner-Ack valid
✅ ../grafana-security-patches/release-11.6.14+security-04/737-202604071543.patch: GL-Partner-Rel valid
✅ ../grafana-security-patches/release-11.6.14+security-04/737-202604071543.patch: GL-Public-After valid
✅ ../grafana-security-patches/release-11.6.14+security-04/756-202603102147.patch: GL-Partner-Ack valid
✅ ../grafana-security-patches/release-11.6.14+security-04/756-202603102147.patch: GL-Partner-Rel valid
✅ ../grafana-security-patches/release-11.6.14+security-04/756-202603102147.patch: GL-Public-After valid
✅ ../grafana-security-patches/release-11.6.14+security-04/762-202603111357.patch: GL-Partner-Ack valid
✅ ../grafana-security-patches/release-11.6.14+security-04/762-202603111357.patch: GL-Partner-Rel valid
✅ ../grafana-security-patches/release-11.6.14+security-04/762-202603111357.patch: GL-Public-After valid
✅ ../grafana-security-patches/release-11.6.14+security-04/771-202603111743.patch: GL-Partner-Ack valid
✅ ../grafana-security-patches/release-11.6.14+security-04/771-202603111743.patch: GL-Partner-Rel valid
✅ ../grafana-security-patches/release-11.6.14+security-04/771-202603111743.patch: GL-Public-After valid
✅ ../grafana-security-patches/release-11.6.14+security-04/783-202603181951.patch: GL-Partner-Ack valid
✅ ../grafana-security-patches/release-11.6.14+security-04/783-202603181951.patch: GL-Partner-Rel valid
✅ ../grafana-security-patches/release-11.6.14+security-04/783-202603181951.patch: GL-Public-After valid
✅ ../grafana-security-patches/release-11.6.14+security-04/789-202603191654.patch: GL-Partner-Ack valid
✅ ../grafana-security-patches/release-11.6.14+security-04/789-202603191654.patch: GL-Partner-Rel valid
✅ ../grafana-security-patches/release-11.6.14+security-04/789-202603191654.patch: GL-Public-After valid
✅ ../grafana-security-patches/release-11.6.14+security-04/790-202603200744.patch: GL-Partner-Ack valid
✅ ../grafana-security-patches/release-11.6.14+security-04/790-202603200744.patch: GL-Partner-Rel valid
✅ ../grafana-security-patches/release-11.6.14+security-04/790-202603200744.patch: GL-Public-After valid
✅ ../grafana-security-patches/release-11.6.14+security-04/829-202603301313.patch: GL-Partner-Ack valid
✅ ../grafana-security-patches/release-11.6.14+security-04/829-202603301313.patch: GL-Partner-Rel valid
✅ ../grafana-security-patches/release-11.6.14+security-04/829-202603301313.patch: GL-Public-After valid
✅ ../grafana-security-patches/release-11.6.14+security-04/833-202603301429.patch: GL-Partner-Ack valid
✅ ../grafana-security-patches/release-11.6.14+security-04/833-202603301429.patch: GL-Partner-Rel valid
✅ ../grafana-security-patches/release-11.6.14+security-04/833-202603301429.patch: GL-Public-After valid
✅ ../grafana-security-patches/release-11.6.14+security-04/847-202604082300.patch: GL-Partner-Ack valid
✅ ../grafana-security-patches/release-11.6.14+security-04/847-202604082300.patch: GL-Partner-Rel valid
✅ ../grafana-security-patches/release-11.6.14+security-04/847-202604082300.patch: GL-Public-After valid
✅ ../grafana-security-patches/release-11.6.14+security-04/853-202604151840.patch: GL-Partner-Ack valid
✅ ../grafana-security-patches/release-11.6.14+security-04/853-202604151840.patch: GL-Partner-Rel valid
```
✅ ../grafana-security-patches/release-11.6.14+security-04/853-202604151840.patch: GL-Public-After valid