### PR TITLE
IAM: Source team search membercount from Team object

### DIFF
--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -506,6 +506,10 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateTeamsAPIGroup(opts builder.AP
 
 	storage[teamResource.StoragePath("members")] = team.NewTeamMembersREST(b.teamGetter, b.tracing, b.features)
 
+	if b.teamSearch != nil {
+		b.teamSearch.teamGetter = b.teamGetter
+	}
+
 	// addmember / removemember mutate a single Spec.Members entry through
 	// the dual-writer storage, so they work uniformly across all modes.
 	storage[teamResource.StoragePath("addmember")] = team.NewTeamAddMemberREST(teamStorage, b.tracing)
@@ -554,9 +558,6 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateTeamBindingsAPIGroup(opts bui
 		storewrapper.WithObserver(storageObserver{}),
 	)
 	storage[teamBindingResource.StoragePath()] = authzWrapper
-	if b.teamSearch != nil {
-		b.teamSearch.teamBindingStore = authzWrapper
-	}
 	return nil
 }
 

--- a/pkg/registry/apis/iam/team_search.go
+++ b/pkg/registry/apis/iam/team_search.go
@@ -14,8 +14,7 @@ import (
 	authlib "github.com/grafana/authlib/types"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
-	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
-	"k8s.io/apimachinery/pkg/fields"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apiserver/pkg/endpoints/request"
 	k8srest "k8s.io/apiserver/pkg/registry/rest"
@@ -61,12 +60,12 @@ var teamAccessControlChecks = []teamAccessControlCheck{
 }
 
 type TeamSearchHandler struct {
-	log              log.Logger
-	client           resourcepb.ResourceIndexClient
-	tracer           trace.Tracer
-	features         featuremgmt.FeatureToggles
-	accessClient     authlib.AccessClient
-	teamBindingStore k8srest.Lister
+	log          log.Logger
+	client       resourcepb.ResourceIndexClient
+	tracer       trace.Tracer
+	features     featuremgmt.FeatureToggles
+	accessClient authlib.AccessClient
+	teamGetter   k8srest.Getter
 }
 
 func NewTeamSearchHandler(tracer trace.Tracer, dual dualwrite.Service, legacyTeamSearcher resourcepb.ResourceIndexClient, resourceClient resource.ResourceClient, features featuremgmt.FeatureToggles, accessClient authlib.AccessClient) *TeamSearchHandler {
@@ -406,7 +405,7 @@ func (s *TeamSearchHandler) DoTeamSearch(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	if queryParams.Get("membercount") == "true" && s.teamBindingStore != nil {
+	if queryParams.Get("membercount") == "true" && s.teamGetter != nil {
 		if err := s.enrichWithMemberCounts(ctx, requester.GetNamespace(), searchResults.Hits); err != nil {
 			errhttp.Write(ctx, err, w)
 			return
@@ -469,7 +468,8 @@ func (s *TeamSearchHandler) stampAccessControl(ctx context.Context, requester id
 	return nil
 }
 
-// enrichWithMemberCounts fetches member counts for each team hit concurrently.
+// enrichWithMemberCounts fetches each team concurrently and sets MemberCount
+// from len(team.Spec.Members) — the team is the source of truth for membership.
 // errgroup is used as a bounded concurrency pool (SetLimit); the first error
 // from any goroutine is propagated to the caller.
 func (s *TeamSearchHandler) enrichWithMemberCounts(ctx context.Context, namespace string, hits []iamv0alpha1.GetSearchTeamsTeamHit) error {
@@ -483,17 +483,15 @@ func (s *TeamSearchHandler) enrichWithMemberCounts(ctx context.Context, namespac
 	for i := range hits {
 		g.Go(func() error {
 			outgoingCtx := request.WithNamespace(ctx, namespace)
-			obj, err := s.teamBindingStore.List(outgoingCtx, &internalversion.ListOptions{
-				FieldSelector: fields.OneTermEqualSelector("spec.teamRef.name", hits[i].Name),
-			})
+			obj, err := s.teamGetter.Get(outgoingCtx, hits[i].Name, &metav1.GetOptions{})
 			if err != nil {
-				return fmt.Errorf("failed to list team bindings for team %s: %w", hits[i].Name, err)
+				return fmt.Errorf("failed to get team %s: %w", hits[i].Name, err)
 			}
-			list, ok := obj.(*iamv0alpha1.TeamBindingList)
+			team, ok := obj.(*iamv0alpha1.Team)
 			if !ok {
-				return fmt.Errorf("unexpected type from team binding list for team %s: %T", hits[i].Name, obj)
+				return fmt.Errorf("unexpected type from team get for team %s: %T", hits[i].Name, obj)
 			}
-			count := int64(len(list.Items))
+			count := int64(len(team.Spec.Members))
 			hits[i].MemberCount = &count
 			return nil
 		})

--- a/pkg/registry/apis/iam/team_search.go
+++ b/pkg/registry/apis/iam/team_search.go
@@ -14,6 +14,7 @@ import (
 	authlib "github.com/grafana/authlib/types"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apiserver/pkg/endpoints/request"
@@ -485,6 +486,9 @@ func (s *TeamSearchHandler) enrichWithMemberCounts(ctx context.Context, namespac
 			outgoingCtx := request.WithNamespace(ctx, namespace)
 			obj, err := s.teamGetter.Get(outgoingCtx, hits[i].Name, &metav1.GetOptions{})
 			if err != nil {
+				if apierrors.IsNotFound(err) {
+					return nil
+				}
 				return fmt.Errorf("failed to get team %s: %w", hits[i].Name, err)
 			}
 			team, ok := obj.(*iamv0alpha1.Team)

--- a/pkg/registry/apis/iam/team_search_test.go
+++ b/pkg/registry/apis/iam/team_search_test.go
@@ -13,9 +13,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
-	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	iamv0alpha1 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
@@ -444,19 +445,21 @@ func TestTeamAccessControl(t *testing.T) {
 }
 
 func TestTeamSearchMemberCount(t *testing.T) {
-	mockLister := &mockTeamBindingLister{
-		listFunc: func(_ context.Context, options *internalversion.ListOptions) (runtime.Object, error) {
-			return &iamv0alpha1.TeamBindingList{Items: make([]iamv0alpha1.TeamBinding, 3)}, nil
+	mockGetter := &mockTeamGetter{
+		getFunc: func(_ context.Context, _ string, _ *metav1.GetOptions) (runtime.Object, error) {
+			return &iamv0alpha1.Team{
+				Spec: iamv0alpha1.TeamSpec{Members: make([]iamv0alpha1.TeamTeamMember, 3)},
+			}, nil
 		},
 	}
 
 	t.Run("membercount absent - no member counts on hits", func(t *testing.T) {
 		searchHandler := &TeamSearchHandler{
-			log:              log.New("grafana-apiserver.teams.search"),
-			client:           mockTeamClientWithHits(),
-			tracer:           tracing.NewNoopTracerService(),
-			features:         featuremgmt.WithFeatures(),
-			teamBindingStore: mockLister,
+			log:        log.New("grafana-apiserver.teams.search"),
+			client:     mockTeamClientWithHits(),
+			tracer:     tracing.NewNoopTracerService(),
+			features:   featuremgmt.WithFeatures(),
+			teamGetter: mockGetter,
 		}
 
 		rr := httptest.NewRecorder()
@@ -478,11 +481,11 @@ func TestTeamSearchMemberCount(t *testing.T) {
 
 	t.Run("membercount=false - no member counts on hits", func(t *testing.T) {
 		searchHandler := &TeamSearchHandler{
-			log:              log.New("grafana-apiserver.teams.search"),
-			client:           mockTeamClientWithHits(),
-			tracer:           tracing.NewNoopTracerService(),
-			features:         featuremgmt.WithFeatures(),
-			teamBindingStore: mockLister,
+			log:        log.New("grafana-apiserver.teams.search"),
+			client:     mockTeamClientWithHits(),
+			tracer:     tracing.NewNoopTracerService(),
+			features:   featuremgmt.WithFeatures(),
+			teamGetter: mockGetter,
 		}
 
 		rr := httptest.NewRecorder()
@@ -504,11 +507,11 @@ func TestTeamSearchMemberCount(t *testing.T) {
 
 	t.Run("membercount=true - member counts populated", func(t *testing.T) {
 		searchHandler := &TeamSearchHandler{
-			log:              log.New("grafana-apiserver.teams.search"),
-			client:           mockTeamClientWithHits(),
-			tracer:           tracing.NewNoopTracerService(),
-			features:         featuremgmt.WithFeatures(),
-			teamBindingStore: mockLister,
+			log:        log.New("grafana-apiserver.teams.search"),
+			client:     mockTeamClientWithHits(),
+			tracer:     tracing.NewNoopTracerService(),
+			features:   featuremgmt.WithFeatures(),
+			teamGetter: mockGetter,
 		}
 
 		rr := httptest.NewRecorder()
@@ -529,19 +532,19 @@ func TestTeamSearchMemberCount(t *testing.T) {
 		}
 	})
 
-	t.Run("membercount=true - lister error returns 500", func(t *testing.T) {
-		errorLister := &mockTeamBindingLister{
-			listFunc: func(_ context.Context, options *internalversion.ListOptions) (runtime.Object, error) {
+	t.Run("membercount=true - getter error returns 500", func(t *testing.T) {
+		errorGetter := &mockTeamGetter{
+			getFunc: func(_ context.Context, _ string, _ *metav1.GetOptions) (runtime.Object, error) {
 				return nil, fmt.Errorf("store unavailable")
 			},
 		}
 
 		searchHandler := &TeamSearchHandler{
-			log:              log.New("grafana-apiserver.teams.search"),
-			client:           mockTeamClientWithHits(),
-			tracer:           tracing.NewNoopTracerService(),
-			features:         featuremgmt.WithFeatures(),
-			teamBindingStore: errorLister,
+			log:        log.New("grafana-apiserver.teams.search"),
+			client:     mockTeamClientWithHits(),
+			tracer:     tracing.NewNoopTracerService(),
+			features:   featuremgmt.WithFeatures(),
+			teamGetter: errorGetter,
 		}
 
 		rr := httptest.NewRecorder()
@@ -557,24 +560,23 @@ func TestTeamSearchMemberCount(t *testing.T) {
 
 func TestEnrichWithMemberCounts(t *testing.T) {
 	t.Run("all succeed - sets correct member counts", func(t *testing.T) {
-		mockLister := &mockTeamBindingLister{
-			listFunc: func(_ context.Context, options *internalversion.ListOptions) (runtime.Object, error) {
-				teamName, _ := options.FieldSelector.RequiresExactMatch("spec.teamRef.name")
-				switch teamName {
+		mockGetter := &mockTeamGetter{
+			getFunc: func(_ context.Context, name string, _ *metav1.GetOptions) (runtime.Object, error) {
+				switch name {
 				case "team-1":
-					return &iamv0alpha1.TeamBindingList{Items: make([]iamv0alpha1.TeamBinding, 3)}, nil
+					return &iamv0alpha1.Team{Spec: iamv0alpha1.TeamSpec{Members: make([]iamv0alpha1.TeamTeamMember, 3)}}, nil
 				case "team-2":
-					return &iamv0alpha1.TeamBindingList{Items: make([]iamv0alpha1.TeamBinding, 0)}, nil
+					return &iamv0alpha1.Team{Spec: iamv0alpha1.TeamSpec{Members: nil}}, nil
 				default:
-					return &iamv0alpha1.TeamBindingList{}, nil
+					return &iamv0alpha1.Team{}, nil
 				}
 			},
 		}
 
 		handler := &TeamSearchHandler{
-			log:              log.New("test"),
-			tracer:           tracing.NewNoopTracerService(),
-			teamBindingStore: mockLister,
+			log:        log.New("test"),
+			tracer:     tracing.NewNoopTracerService(),
+			teamGetter: mockGetter,
 		}
 
 		hits := []iamv0alpha1.GetSearchTeamsTeamHit{
@@ -591,20 +593,19 @@ func TestEnrichWithMemberCounts(t *testing.T) {
 	})
 
 	t.Run("one fails - returns error", func(t *testing.T) {
-		mockLister := &mockTeamBindingLister{
-			listFunc: func(_ context.Context, options *internalversion.ListOptions) (runtime.Object, error) {
-				teamName, _ := options.FieldSelector.RequiresExactMatch("spec.teamRef.name")
-				if teamName == "team-bad" {
-					return nil, fmt.Errorf("teambinding list failed for team-bad")
+		mockGetter := &mockTeamGetter{
+			getFunc: func(_ context.Context, name string, _ *metav1.GetOptions) (runtime.Object, error) {
+				if name == "team-bad" {
+					return nil, fmt.Errorf("team get failed for team-bad")
 				}
-				return &iamv0alpha1.TeamBindingList{Items: make([]iamv0alpha1.TeamBinding, 2)}, nil
+				return &iamv0alpha1.Team{Spec: iamv0alpha1.TeamSpec{Members: make([]iamv0alpha1.TeamTeamMember, 2)}}, nil
 			},
 		}
 
 		handler := &TeamSearchHandler{
-			log:              log.New("test"),
-			tracer:           tracing.NewNoopTracerService(),
-			teamBindingStore: mockLister,
+			log:        log.New("test"),
+			tracer:     tracing.NewNoopTracerService(),
+			teamGetter: mockGetter,
 		}
 
 		hits := []iamv0alpha1.GetSearchTeamsTeamHit{
@@ -619,16 +620,16 @@ func TestEnrichWithMemberCounts(t *testing.T) {
 	})
 
 	t.Run("unexpected type - returns error", func(t *testing.T) {
-		mockLister := &mockTeamBindingLister{
-			listFunc: func(_ context.Context, options *internalversion.ListOptions) (runtime.Object, error) {
+		mockGetter := &mockTeamGetter{
+			getFunc: func(_ context.Context, _ string, _ *metav1.GetOptions) (runtime.Object, error) {
 				return &iamv0alpha1.TeamList{}, nil
 			},
 		}
 
 		handler := &TeamSearchHandler{
-			log:              log.New("test"),
-			tracer:           tracing.NewNoopTracerService(),
-			teamBindingStore: mockLister,
+			log:        log.New("test"),
+			tracer:     tracing.NewNoopTracerService(),
+			teamGetter: mockGetter,
 		}
 
 		hits := []iamv0alpha1.GetSearchTeamsTeamHit{
@@ -641,20 +642,15 @@ func TestEnrichWithMemberCounts(t *testing.T) {
 	})
 }
 
-type mockTeamBindingLister struct {
-	listFunc func(ctx context.Context, options *internalversion.ListOptions) (runtime.Object, error)
+type mockTeamGetter struct {
+	getFunc func(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error)
 }
 
-func (m *mockTeamBindingLister) NewList() runtime.Object {
-	return &iamv0alpha1.TeamBindingList{}
-}
-
-func (m *mockTeamBindingLister) List(ctx context.Context, options *internalversion.ListOptions) (runtime.Object, error) {
-	return m.listFunc(ctx, options)
-}
-
-func (m *mockTeamBindingLister) ConvertToTable(_ context.Context, _ runtime.Object, _ runtime.Object) (*metav1.Table, error) {
-	return nil, nil
+func (m *mockTeamGetter) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
+	if m.getFunc != nil {
+		return m.getFunc(ctx, name, options)
+	}
+	return nil, apierrors.NewNotFound(schema.GroupResource{Resource: "teams"}, name)
 }
 
 type mockTeamAccessClient struct {

--- a/pkg/tests/apis/iam/team/helpers_test.go
+++ b/pkg/tests/apis/iam/team/helpers_test.go
@@ -14,10 +14,3 @@ func createTeamObject(helper *apis.K8sTestHelper, teamName string, title string,
 
 	return teamObj
 }
-
-func createTeamBindingObject(helper *apis.K8sTestHelper, userName, teamName string) *unstructured.Unstructured {
-	obj := helper.LoadYAMLOrJSONFile("../testdata/teambinding-test-create-v0.yaml")
-	obj.Object["spec"].(map[string]interface{})["subject"].(map[string]interface{})["name"] = userName
-	obj.Object["spec"].(map[string]interface{})["teamRef"].(map[string]interface{})["name"] = teamName
-	return obj
-}

--- a/pkg/tests/apis/iam/team/team_search_integration_test.go
+++ b/pkg/tests/apis/iam/team/team_search_integration_test.go
@@ -2,6 +2,7 @@ package team
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -483,12 +484,6 @@ func doTeamSearchMemberCountTests(t *testing.T, helper *apis.K8sTestHelper) {
 		Namespace: namespace,
 		GVR:       gvrUsers,
 	})
-	tbClient := helper.GetResourceClient(apis.ResourceClientArgs{
-		User:      helper.Org1.Admin,
-		Namespace: namespace,
-		GVR:       gvrTeamBindings,
-	})
-
 	// Create teamA with 3 members
 	teamA, err := teamClient.Resource.Create(ctx, createTeamObject(helper, "mc-team-a", "MemberCount Team A", "mc-team-a@example.com"), metav1.CreateOptions{})
 	require.NoError(t, err)
@@ -497,7 +492,11 @@ func doTeamSearchMemberCountTests(t *testing.T, helper *apis.K8sTestHelper) {
 	teamB, err := teamClient.Resource.Create(ctx, createTeamObject(helper, "mc-team-b", "MemberCount Team B", "mc-team-b@example.com"), metav1.CreateOptions{})
 	require.NoError(t, err)
 
-	// Create 3 users and bind them to teamA
+	// Create 3 users and add them to teamA via the addmember subresource
+	// (Spec.Members is the source of truth for membership across all
+	// dual-writer modes; TeamBinding writes don't sync to Spec.Members in
+	// Mode 5).
+	addMemberPath := fmt.Sprintf("/apis/iam.grafana.app/v0alpha1/namespaces/%s/teams/%s/addmember", namespace, teamA.GetName())
 	for i := 1; i <= 3; i++ {
 		uObj := helper.LoadYAMLOrJSONFile("../testdata/user-test-create-v0.yaml")
 		uObj.Object["metadata"].(map[string]any)["name"] = fmt.Sprintf("mc-user-%d", i)
@@ -507,9 +506,19 @@ func doTeamSearchMemberCountTests(t *testing.T, helper *apis.K8sTestHelper) {
 		u, err := userClient.Resource.Create(ctx, uObj, metav1.CreateOptions{})
 		require.NoError(t, err)
 
-		tbObj := createTeamBindingObject(helper, u.GetName(), teamA.GetName())
-		_, err = tbClient.Resource.Create(ctx, tbObj, metav1.CreateOptions{})
+		body, err := json.Marshal(map[string]any{
+			"name":       u.GetName(),
+			"permission": "member",
+			"external":   false,
+		})
 		require.NoError(t, err)
+		rsp := apis.DoRequest(helper, apis.RequestParams{
+			User:   helper.Org1.Admin,
+			Method: http.MethodPost,
+			Path:   addMemberPath,
+			Body:   body,
+		}, &map[string]any{})
+		require.Equal(t, http.StatusCreated, rsp.Response.StatusCode, "addmember for %s: %s", u.GetName(), string(rsp.Body))
 	}
 
 	t.Run("should return correct member counts for teams with and without members", func(t *testing.T) {

--- a/pkg/tests/apis/iam/team/team_test.go
+++ b/pkg/tests/apis/iam/team/team_test.go
@@ -20,12 +20,6 @@ var gvrUsers = schema.GroupVersionResource{
 	Resource: "users",
 }
 
-var gvrTeamBindings = schema.GroupVersionResource{
-	Group:    "iam.grafana.app",
-	Version:  "v0alpha1",
-	Resource: "teambindings",
-}
-
 func TestMain(m *testing.M) {
 	testsuite.Run(m)
 }


### PR DESCRIPTION
## Summary

- Team search's `membercount=true` enrichment now reads from the Team object's `Spec.Members` instead of listing TeamBindings filtered by `spec.teamRef.name`. The Team object is the source of truth for membership, so a single Get per hit replaces a List per hit.
- `TeamSearchHandler.teamBindingStore` (a `k8srest.Lister`) is replaced by `teamGetter` (a `k8srest.Getter`), wired in `UpdateTeamsAPIGroup` where the team storage is built.
- Unit tests updated: `mockTeamBindingLister` → `mockTeamGetter`; cases return `Team` objects with `Spec.Members` populated.

## Test plan

- [ ] `go test ./pkg/registry/apis/iam/... -run TestTeamSearchMemberCount -count=1`
- [ ] `go test ./pkg/registry/apis/iam/... -run TestEnrichWithMemberCounts -count=1`
- [ ] `go test ./pkg/tests/apis/iam/... -count=1 -timeout 600s`
- [ ] Manual: hit the team search endpoint with `membercount=true` and confirm counts match `len(team.spec.members)` for each returned team.