### PR TITLE
fix(grafana-ui): break circular dependency with `@grafana/test-utils`

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -267,6 +267,23 @@ module.exports = [
     },
   },
   {
+    name: 'grafana/grafana-ui-no-test-utils',
+    files: ['packages/grafana-ui/**/*.{ts,tsx}'],
+    rules: {
+      'no-restricted-imports': [
+        'error',
+        withBaseRestrictedImportsConfig({
+          patterns: [
+            {
+              group: ['@grafana/test-utils'],
+              message: "'@grafana/test-utils' creates a circular dependency with '@grafana/ui'",
+            },
+          ],
+        }),
+      ],
+    },
+  },
+  {
     name: 'grafana/story-rules',
     files: ['packages/grafana-ui/src/**/*.story.tsx'],
     rules: {

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -142,7 +142,6 @@
   "devDependencies": {
     "@babel/core": "7.28.0",
     "@faker-js/faker": "^9.0.0",
-    "@grafana/test-utils": "workspace:*",
     "@rollup/plugin-node-resolve": "16.0.1",
     "@storybook/addon-a11y": "10.3.6",
     "@storybook/addon-docs": "10.3.6",

--- a/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
+++ b/packages/grafana-ui/src/components/Combobox/Combobox.test.tsx
@@ -2,8 +2,7 @@ import { act, render, screen, fireEvent, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event';
 import React from 'react';
 
-import { mockComboboxRect } from '@grafana/test-utils';
-
+import { mockComboboxRect } from '../../test-utils/mockDom';
 import { Drawer } from '../Drawer/Drawer';
 import { Field } from '../Forms/Field';
 import { Modal } from '../Modal/Modal';

--- a/packages/grafana-ui/src/components/Combobox/MultiCombobox.test.tsx
+++ b/packages/grafana-ui/src/components/Combobox/MultiCombobox.test.tsx
@@ -2,8 +2,7 @@ import { act, render, screen, waitFor } from '@testing-library/react';
 import userEvent, { type UserEvent } from '@testing-library/user-event';
 import React from 'react';
 
-import { mockComboboxRect } from '@grafana/test-utils';
-
+import { mockComboboxRect } from '../../test-utils/mockDom';
 import { Drawer } from '../Drawer/Drawer';
 import { Modal } from '../Modal/Modal';
 

--- a/packages/grafana-ui/src/components/StatsPicker/StatsPicker.test.tsx
+++ b/packages/grafana-ui/src/components/StatsPicker/StatsPicker.test.tsx
@@ -3,8 +3,8 @@ import userEvent from '@testing-library/user-event';
 import { useCallback, useRef, useState, type ReactElement } from 'react';
 
 import { ReducerID } from '@grafana/data';
-import { mockComboboxRect } from '@grafana/test-utils';
 
+import { mockComboboxRect } from '../../test-utils/mockDom';
 import { Field } from '../Forms/Field';
 
 import { StatsPicker } from './StatsPicker';

--- a/packages/grafana-ui/src/components/uPlot/plugins/XAxisInteractionAreaPlugin.test.tsx
+++ b/packages/grafana-ui/src/components/uPlot/plugins/XAxisInteractionAreaPlugin.test.tsx
@@ -1,8 +1,7 @@
 import { render } from '@testing-library/react';
 import type uPlot from 'uplot';
 
-import { mockBoundingClientRect } from '@grafana/test-utils';
-
+import { mockBoundingClientRect } from '../../../test-utils/mockDom';
 import { UPlotConfigBuilder, type UPlotConfigBuilder as UPlotConfigBuilderType } from '../config/UPlotConfigBuilder';
 
 import { calculatePanRange, setupXAxisPan, XAxisInteractionAreaPlugin } from './XAxisInteractionAreaPlugin';

--- a/packages/grafana-ui/src/test-utils/mockDom.ts
+++ b/packages/grafana-ui/src/test-utils/mockDom.ts
@@ -1,0 +1,33 @@
+export function mockBoundingClientRect(rect: Partial<DOMRect> = {}): void {
+  const defaults: DOMRect = {
+    width: 400,
+    height: 400,
+    top: 0,
+    left: 0,
+    bottom: 400,
+    right: 400,
+    x: 0,
+    y: 0,
+    toJSON: () => {},
+  };
+
+  const merged = { ...defaults, ...rect };
+
+  Object.defineProperty(Element.prototype, 'getBoundingClientRect', {
+    value: () => merged,
+    configurable: true,
+  });
+
+  Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+    get: () => merged.width,
+    configurable: true,
+  });
+  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+    get: () => merged.height,
+    configurable: true,
+  });
+}
+
+export function mockComboboxRect() {
+  mockBoundingClientRect({ width: 120, height: 120 });
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4418,7 +4418,6 @@ __metadata:
     "@grafana/i18n": "npm:13.1.0-pre"
     "@grafana/react-data-grid": "npm:7.0.0-beta.57"
     "@grafana/schema": "npm:13.1.0-pre"
-    "@grafana/test-utils": "workspace:*"
     "@hello-pangea/dnd": "npm:18.0.1"
     "@monaco-editor/react": "npm:4.7.0"
     "@popperjs/core": "npm:2.11.8"


### PR DESCRIPTION
**What is this feature?**

Breaks a circular package dependency: `@grafana/runtime` → `@grafana/ui` → `@grafana/test-utils` → `@grafana/runtime`.

`@grafana/ui` imported two JSDOM test helpers (`mockBoundingClientRect`, `mockComboboxRect`) from `@grafana/test-utils`, which depends on `@grafana/runtime`, which depends on `@grafana/ui`. This inlines those two helpers (~30 lines) into a local test utility within `@grafana/ui` and removes the `@grafana/test-utils` devDependency.

**Why do we need this feature?**

Circular dependencies in the workspace package graph are bad practice and should be removed when the fix is straightforward. [A little copying is better than a little dependency](https://go-proverbs.github.io/).

**Who is this feature for?**

Internal - Grafana developers.

**Special notes for your reviewer:**

No published exports change in any package. `@grafana/test-utils` retains its copy of the helpers for its other internal consumers.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.