### PR TITLE
Datasources: Move default button to list view

### DIFF
--- a/public/app/features/datasources/components/DataSourceDefaultButton.test.tsx
+++ b/public/app/features/datasources/components/DataSourceDefaultButton.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from '@testing-library/react';
+
+import { useDispatch } from 'app/types/store';
+
+import { getMockDataSource } from '../mocks/dataSourcesMocks';
+
+import { DataSourceDefaultButton } from './DataSourceDefaultButton';
+
+jest.mock('app/types/store', () => ({
+  ...jest.requireActual('app/types/store'),
+  useDispatch: jest.fn(),
+}));
+
+const mockDataSource = getMockDataSource({
+  uid: 'test-uid',
+  type: 'prometheus',
+  name: 'Test Prometheus',
+  typeName: 'Prometheus',
+});
+
+const mockDataSourceRights = {
+  hasWriteRights: true,
+  readOnly: false,
+};
+
+jest.mock('../state/hooks', () => ({
+  useDataSource: jest.fn(() => mockDataSource),
+  useDataSourceRights: jest.fn(() => mockDataSourceRights),
+}));
+
+const mockUseDispatch = jest.mocked(useDispatch);
+const mockUseDataSource = jest.mocked(require('../state/hooks').useDataSource);
+const mockUseDataSourceRights = jest.mocked(require('../state/hooks').useDataSourceRights);
+
+describe('DataSourceDefaultButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseDispatch.mockReturnValue(jest.fn());
+    mockUseDataSource.mockReturnValue(mockDataSource);
+    mockUseDataSourceRights.mockReturnValue(mockDataSourceRights);
+  });
+
+  it('should render make default button when data source is not default and editable', () => {
+    mockUseDataSource.mockReturnValue({ ...mockDataSource, isDefault: false });
+
+    render(<DataSourceDefaultButton uid="test-uid" />);
+
+    expect(screen.getByText('Make default')).toBeInTheDocument();
+    expect(screen.queryByText('Remove default')).not.toBeInTheDocument();
+  });
+
+  it('should render remove default button when data source is default and editable', () => {
+    mockUseDataSource.mockReturnValue({ ...mockDataSource, isDefault: true });
+
+    render(<DataSourceDefaultButton uid="test-uid" />);
+
+    expect(screen.getByText('Remove default')).toBeInTheDocument();
+    expect(screen.queryByText('Make default')).not.toBeInTheDocument();
+  });
+
+  it('should not render make default button when data source is not default but not editable', () => {
+    mockUseDataSource.mockReturnValue({ ...mockDataSource, isDefault: false });
+    mockUseDataSourceRights.mockReturnValue({ hasWriteRights: false, readOnly: true });
+
+    render(<DataSourceDefaultButton uid="test-uid" />);
+
+    expect(screen.queryByLabelText('Make default')).not.toBeInTheDocument();
+  });
+
+  it('should not render remove default button when data source is default but not editable', () => {
+    mockUseDataSource.mockReturnValue({ ...mockDataSource, isDefault: true });
+    mockUseDataSourceRights.mockReturnValue({ hasWriteRights: false, readOnly: true });
+
+    render(<DataSourceDefaultButton uid="test-uid" />);
+
+    expect(screen.queryByLabelText('Remove default')).not.toBeInTheDocument();
+  });
+
+  it('should render default badge when data source is default but not editable', () => {
+    mockUseDataSource.mockReturnValue({ ...mockDataSource, isDefault: true });
+    mockUseDataSourceRights.mockReturnValue({ hasWriteRights: true, readOnly: true });
+
+    render(<DataSourceDefaultButton uid="test-uid" />);
+
+    expect(screen.getByText('Default')).toBeInTheDocument();
+  });
+});

--- a/public/app/features/datasources/components/DataSourceDefaultButton.test.tsx
+++ b/public/app/features/datasources/components/DataSourceDefaultButton.test.tsx
@@ -1,14 +1,17 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
 
-import { useDispatch } from 'app/types/store';
+import { configureStore } from 'app/store/configureStore';
 
+import * as api from '../api';
 import { getMockDataSource } from '../mocks/dataSourcesMocks';
+import { initialState } from '../state/reducers';
 
 import { DataSourceDefaultButton } from './DataSourceDefaultButton';
 
-jest.mock('app/types/store', () => ({
-  ...jest.requireActual('app/types/store'),
-  useDispatch: jest.fn(),
+jest.mock('../api', () => ({
+  getDataSourceByUid: jest.fn(),
+  updateDataSource: jest.fn(),
 }));
 
 const mockDataSource = getMockDataSource({
@@ -18,70 +21,58 @@ const mockDataSource = getMockDataSource({
   typeName: 'Prometheus',
 });
 
-const mockDataSourceRights = {
-  hasWriteRights: true,
-  readOnly: false,
+const mockApi = jest.mocked(api);
+
+const setup = (dataSource = mockDataSource) => {
+  const store = configureStore({
+    dataSources: {
+      ...initialState,
+      dataSources: [dataSource],
+      dataSourcesCount: 1,
+    },
+  });
+
+  return {
+    store,
+    ...render(
+      <Provider store={store}>
+        <DataSourceDefaultButton dataSource={dataSource} />
+      </Provider>
+    ),
+  };
 };
-
-jest.mock('../state/hooks', () => ({
-  useDataSource: jest.fn(() => mockDataSource),
-  useDataSourceRights: jest.fn(() => mockDataSourceRights),
-}));
-
-const mockUseDispatch = jest.mocked(useDispatch);
-const mockUseDataSource = jest.mocked(require('../state/hooks').useDataSource);
-const mockUseDataSourceRights = jest.mocked(require('../state/hooks').useDataSourceRights);
 
 describe('DataSourceDefaultButton', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseDispatch.mockReturnValue(jest.fn());
-    mockUseDataSource.mockReturnValue(mockDataSource);
-    mockUseDataSourceRights.mockReturnValue(mockDataSourceRights);
+    mockApi.getDataSourceByUid.mockResolvedValue(mockDataSource);
+    mockApi.updateDataSource.mockResolvedValue(mockDataSource);
   });
 
   it('should render make default button when data source is not default and editable', () => {
-    mockUseDataSource.mockReturnValue({ ...mockDataSource, isDefault: false });
-
-    render(<DataSourceDefaultButton uid="test-uid" />);
+    setup({ ...mockDataSource, isDefault: false });
 
     expect(screen.getByText('Make default')).toBeInTheDocument();
     expect(screen.queryByText('Remove default')).not.toBeInTheDocument();
   });
 
   it('should render remove default button when data source is default and editable', () => {
-    mockUseDataSource.mockReturnValue({ ...mockDataSource, isDefault: true });
-
-    render(<DataSourceDefaultButton uid="test-uid" />);
+    setup({ ...mockDataSource, isDefault: true });
 
     expect(screen.getByText('Remove default')).toBeInTheDocument();
     expect(screen.queryByText('Make default')).not.toBeInTheDocument();
   });
 
-  it('should not render make default button when data source is not default but not editable', () => {
-    mockUseDataSource.mockReturnValue({ ...mockDataSource, isDefault: false });
-    mockUseDataSourceRights.mockReturnValue({ hasWriteRights: false, readOnly: true });
+  it('updates the datasource list state after updating the default flag', async () => {
+    const updatedDataSource = { ...mockDataSource, isDefault: false };
+    const store = setup(updatedDataSource).store;
 
-    render(<DataSourceDefaultButton uid="test-uid" />);
+    fireEvent.click(screen.getByText('Make default'));
 
-    expect(screen.queryByLabelText('Make default')).not.toBeInTheDocument();
-  });
-
-  it('should not render remove default button when data source is default but not editable', () => {
-    mockUseDataSource.mockReturnValue({ ...mockDataSource, isDefault: true });
-    mockUseDataSourceRights.mockReturnValue({ hasWriteRights: false, readOnly: true });
-
-    render(<DataSourceDefaultButton uid="test-uid" />);
-
-    expect(screen.queryByLabelText('Remove default')).not.toBeInTheDocument();
-  });
-
-  it('should render default badge when data source is default but not editable', () => {
-    mockUseDataSource.mockReturnValue({ ...mockDataSource, isDefault: true });
-    mockUseDataSourceRights.mockReturnValue({ hasWriteRights: true, readOnly: true });
-
-    render(<DataSourceDefaultButton uid="test-uid" />);
-
-    expect(screen.getByText('Default')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(mockApi.getDataSourceByUid).toHaveBeenCalledWith(mockDataSource.uid);
+      expect(mockApi.updateDataSource).toHaveBeenCalledWith({ ...mockDataSource, isDefault: true });
+      expect(store.getState().dataSources.dataSources[0].isDefault).toBe(true);
+    });
   });
 });

--- a/public/app/features/datasources/components/DataSourceDefaultButton.tsx
+++ b/public/app/features/datasources/components/DataSourceDefaultButton.tsx
@@ -1,0 +1,91 @@
+import { useState } from 'react';
+
+import { t, Trans } from '@grafana/i18n';
+import { isFetchError } from '@grafana/runtime';
+import { Badge, Tooltip, Button } from '@grafana/ui';
+import { createErrorNotification } from 'app/core/copy/appNotification';
+import { notifyApp } from 'app/core/reducers/appNotification';
+import { useDispatch } from 'app/types/store';
+
+import * as api from '../api';
+import { useDataSource, useDataSourceRights } from '../state/hooks';
+import { setIsDefault } from '../state/reducers';
+
+export const DataSourceDefaultButton = ({ uid }: { uid: string }) => {
+  const [loading, setLoading] = useState(false);
+
+  const dataSource = useDataSource(uid);
+  const rights = useDataSourceRights(uid);
+  const editable = rights.hasWriteRights && !rights.readOnly;
+
+  const dispatch = useDispatch();
+
+  const onChangeDefault = async (value: boolean) => {
+    if (loading) {
+      return;
+    }
+    setLoading(true);
+
+    try {
+      // Make manual API calls to avoid pre-emptively saving other changes from the EditDataSource form
+      const ds = await api.getDataSourceByUid(uid);
+      await api.updateDataSource({ ...ds, isDefault: value });
+      dispatch(setIsDefault(value));
+    } catch (error) {
+      dispatch(
+        notifyApp(
+          createErrorNotification(
+            t('datasources.default-button.error', 'Failed to update default data source'),
+            isFetchError(error) ? error.data.message : error instanceof Error ? error.message : undefined
+          )
+        )
+      );
+    }
+
+    setLoading(false);
+  };
+
+  if (!editable) {
+    return dataSource.isDefault ? (
+      <Badge
+        text={
+          <Tooltip
+            content={[
+              t('datasources.default-button.active', 'This data source is currently set as the default.'),
+              t('datasources.default-button.tooltip', 'The default data source is preselected in new panels.'),
+            ].join(' ')}
+          >
+            <span>
+              <Trans i18nKey="datasources.default-button.label">Default</Trans>
+            </span>
+          </Tooltip>
+        }
+        color="blue"
+      />
+    ) : null;
+  }
+
+  return (
+    <Button
+      variant="secondary"
+      size="sm"
+      tooltip={[
+        dataSource.isDefault &&
+          t('datasources.default-button.active', 'This data source is currently set as the default.'),
+        t('datasources.default-button.tooltip', 'The default data source is preselected in new panels.'),
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      onClick={() => onChangeDefault(!dataSource.isDefault)}
+      icon={loading ? 'spinner' : undefined}
+      iconPlacement="right"
+      disabled={loading}
+    >
+      {dataSource.isDefault ? (
+        <Trans i18nKey="datasources.default-button.remove">Remove default</Trans>
+      ) : (
+        <Trans i18nKey="datasources.default-button.make">Make default</Trans>
+      )}
+    </Button>
+  );
+};

--- a/public/app/features/datasources/components/DataSourceDefaultButton.tsx
+++ b/public/app/features/datasources/components/DataSourceDefaultButton.tsx
@@ -1,22 +1,20 @@
+import { css } from '@emotion/css';
 import { useState } from 'react';
 
+import { type DataSourceSettings, type GrafanaTheme2 } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 import { isFetchError } from '@grafana/runtime';
-import { Badge, Tooltip, Button } from '@grafana/ui';
+import { Button, useStyles2 } from '@grafana/ui';
 import { createErrorNotification } from 'app/core/copy/appNotification';
 import { notifyApp } from 'app/core/reducers/appNotification';
 import { useDispatch } from 'app/types/store';
 
 import * as api from '../api';
-import { useDataSource, useDataSourceRights } from '../state/hooks';
-import { setIsDefault } from '../state/reducers';
+import { setDataSourcesDefault } from '../state/reducers';
 
-export const DataSourceDefaultButton = ({ uid }: { uid: string }) => {
+export const DataSourceDefaultButton = ({ dataSource }: { dataSource: DataSourceSettings }) => {
+  const styles = useStyles2(getStyles);
   const [loading, setLoading] = useState(false);
-
-  const dataSource = useDataSource(uid);
-  const rights = useDataSourceRights(uid);
-  const editable = rights.hasWriteRights && !rights.readOnly;
 
   const dispatch = useDispatch();
 
@@ -27,10 +25,9 @@ export const DataSourceDefaultButton = ({ uid }: { uid: string }) => {
     setLoading(true);
 
     try {
-      // Make manual API calls to avoid pre-emptively saving other changes from the EditDataSource form
-      const ds = await api.getDataSourceByUid(uid);
+      const ds = await api.getDataSourceByUid(dataSource.uid);
       await api.updateDataSource({ ...ds, isDefault: value });
-      dispatch(setIsDefault(value));
+      dispatch(setDataSourcesDefault({ uid: dataSource.uid, isDefault: value }));
     } catch (error) {
       dispatch(
         notifyApp(
@@ -45,30 +42,10 @@ export const DataSourceDefaultButton = ({ uid }: { uid: string }) => {
     setLoading(false);
   };
 
-  if (!editable) {
-    return dataSource.isDefault ? (
-      <Badge
-        text={
-          <Tooltip
-            content={[
-              t('datasources.default-button.active', 'This data source is currently set as the default.'),
-              t('datasources.default-button.tooltip', 'The default data source is preselected in new panels.'),
-            ].join(' ')}
-          >
-            <span>
-              <Trans i18nKey="datasources.default-button.label">Default</Trans>
-            </span>
-          </Tooltip>
-        }
-        color="blue"
-      />
-    ) : null;
-  }
-
   return (
     <Button
-      variant="secondary"
       size="sm"
+      fill="text"
       tooltip={[
         dataSource.isDefault &&
           t('datasources.default-button.active', 'This data source is currently set as the default.'),
@@ -80,6 +57,7 @@ export const DataSourceDefaultButton = ({ uid }: { uid: string }) => {
       icon={loading ? 'spinner' : undefined}
       iconPlacement="right"
       disabled={loading}
+      className={styles.button}
     >
       {dataSource.isDefault ? (
         <Trans i18nKey="datasources.default-button.remove">Remove default</Trans>
@@ -88,4 +66,13 @@ export const DataSourceDefaultButton = ({ uid }: { uid: string }) => {
       )}
     </Button>
   );
+};
+
+const getStyles = (theme: GrafanaTheme2) => {
+  return {
+    button: css({
+      pointerEvents: 'auto',
+      position: 'relative',
+    }),
+  };
 };

--- a/public/app/features/datasources/components/DataSourcesList.test.tsx
+++ b/public/app/features/datasources/components/DataSourcesList.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render } from 'test/test-utils';
 
@@ -183,6 +183,45 @@ describe('<DataSourcesList>', () => {
       expect(screen.getByRole('link', { name: 'dataSource-0' })).toBeInTheDocument();
       expect(screen.getByRole('link', { name: 'dataSource-2' })).toBeInTheDocument();
       expect(screen.queryByRole('link', { name: 'dataSource-1' })).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Default functionality', () => {
+    it('should show "Default" badge on the correct data source', async () => {
+      const dataSources = getMockDataSources(3);
+      dataSources[1].isDefault = true; // Mark the second data source as default
+
+      setup({ dataSources });
+
+      // Ensure the "Default" badge is shown on the correct data source
+      const defaultBadge = await screen.findByText('Default');
+      expect(defaultBadge).toBeInTheDocument();
+      expect(defaultBadge.closest('li')).toHaveTextContent(dataSources[1].name);
+    });
+
+    it('should show "Make default" and "Remove default" buttons based on write rights and read-only status', async () => {
+      const dataSources = getMockDataSources(3);
+      dataSources[0].readOnly = false; // Writable data source
+      dataSources[1].readOnly = true; // Read-only data source
+      dataSources[2].readOnly = false; // Writable data source
+      dataSources[2].isDefault = true; // Mark the third data source as default
+
+      setup({ dataSources, hasWriteRights: true });
+
+      // Ensure "Make default" button is shown for writable, non-default data sources
+      const makeDefaultButton = await screen.findByRole('button', { name: 'Make default' });
+      expect(makeDefaultButton).toBeInTheDocument();
+      expect(makeDefaultButton.closest('li')).toHaveTextContent(dataSources[0].name);
+
+      // Ensure no "Make/Remove default" button is shown for read-only data sources
+      const secondDataSourceLi = (await screen.findByText(dataSources[1].name)).closest('li');
+      expect(within(secondDataSourceLi!).queryByRole('button', { name: 'Make default' })).not.toBeInTheDocument();
+      expect(within(secondDataSourceLi!).queryByRole('button', { name: 'Remove default' })).not.toBeInTheDocument();
+
+      // Ensure "Remove default" button is shown for writable, default data sources
+      const removeDefaultButton = await screen.findByRole('button', { name: 'Remove default' });
+      expect(removeDefaultButton).toBeInTheDocument();
+      expect(removeDefaultButton.closest('li')).toHaveTextContent(dataSources[2].name);
     });
   });
 });

--- a/public/app/features/datasources/components/DataSourcesListCard.tsx
+++ b/public/app/features/datasources/components/DataSourcesListCard.tsx
@@ -2,9 +2,9 @@ import { css } from '@emotion/css';
 import Skeleton from 'react-loading-skeleton';
 
 import { type DataSourceSettings, type GrafanaTheme2 } from '@grafana/data';
-import { Trans } from '@grafana/i18n';
+import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
-import { Card, LinkButton, Stack, Tag, useStyles2 } from '@grafana/ui';
+import { Badge, Card, LinkButton, Stack, useStyles2 } from '@grafana/ui';
 
 import { ROUTES } from '../../connections/constants';
 import { type DatasourceFailureDetails } from '../../connections/hooks/useDatasourceAdvisorChecks';
@@ -12,6 +12,7 @@ import { trackExploreClicked } from '../tracking';
 import { constructDataSourceExploreUrl } from '../utils';
 
 import { BuildDashboardButton } from './BuildDashboardButton';
+import { DataSourceDefaultButton } from './DataSourceDefaultButton';
 import { DataSourceFailureBadge } from './DataSourceFailureBadge';
 
 export interface Props {
@@ -27,7 +28,14 @@ export function DataSourcesListCard({ dataSource, hasWriteRights, hasExploreRigh
 
   return (
     <Card noMargin href={hasWriteRights ? dsLink : undefined}>
-      <Card.Heading>{dataSource.name}</Card.Heading>
+      <Card.Heading>
+        <Stack direction="row" gap={1} alignItems="center">
+          {dataSource.name}
+          {dataSource.isDefault && (
+            <Badge text={t('datasources.data-sources-list-card.default', 'Default')} color="blue" />
+          )}
+        </Stack>
+      </Card.Heading>
       <Card.Figure>
         <img src={dataSource.typeLogoUrl} alt="" height="40px" width="40px" className={styles.logo} />
       </Card.Figure>
@@ -35,7 +43,9 @@ export function DataSourcesListCard({ dataSource, hasWriteRights, hasExploreRigh
         {[
           dataSource.typeName,
           dataSource.url,
-          dataSource.isDefault && <Tag key="default-tag" name={'default'} colorIndex={1} />,
+          hasWriteRights && !dataSource.readOnly && (
+            <DataSourceDefaultButton key="default-button" dataSource={dataSource} />
+          ),
           failure?.severity && (
             <DataSourceFailureBadge key="unhealthy-badge" severity={failure.severity} message={failure.message} />
           ),

--- a/public/app/features/datasources/components/EditDataSourceActions.test.tsx
+++ b/public/app/features/datasources/components/EditDataSourceActions.test.tsx
@@ -3,7 +3,6 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { PluginExtensionTypes, type IconName } from '@grafana/data';
 import { setPluginLinksHook, config, getDataSourceSrv } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
-import { useDispatch } from 'app/types/store';
 
 import { getMockDataSource } from '../mocks/dataSourcesMocks';
 
@@ -11,10 +10,6 @@ import { EditDataSourceActions } from './EditDataSourceActions';
 
 // Mock dependencies
 jest.mock('app/core/services/context_srv');
-jest.mock('app/types/store', () => ({
-  ...jest.requireActual('app/types/store'),
-  useDispatch: jest.fn(),
-}));
 jest.mock('../utils', () => ({
   constructDataSourceExploreUrl: jest.fn(
     () => '/explore?left=%7B%22datasource%22:%22Test%20Prometheus%22,%22context%22:%22explore%22%7D'
@@ -48,6 +43,10 @@ jest.mock('./BuildDashboardButton', () => ({
   ),
 }));
 
+jest.mock('./DataSourceDefaultButton', () => ({
+  DataSourceDefaultButton: () => <div data-testid="datasource-default-button" />,
+}));
+
 // Set default plugin links hook
 setPluginLinksHook(() => ({ links: [], isLoading: false }));
 
@@ -57,7 +56,6 @@ const mockContextSrv = jest.mocked(contextSrv);
 // Mock getDataSourceSrv and favorite hooks
 const mockGetDataSourceSrv = jest.mocked(getDataSourceSrv);
 const mockUseFavoriteDatasources = jest.mocked(require('@grafana/runtime').useFavoriteDatasources);
-const mockUseDispatch = jest.mocked(useDispatch);
 
 // Create mock datasource instance
 const mockDataSourceInstance = {
@@ -109,19 +107,12 @@ const mockDataSource = getMockDataSource({
   typeName: 'Prometheus',
 });
 
-const mockDataSourceRights = {
-  hasWriteRights: true,
-  readOnly: false,
-};
-
 // Mock useDataSource hook
 jest.mock('../state/hooks', () => ({
   useDataSource: jest.fn((uid: string) => (uid === 'not-found' ? {} : mockDataSource)),
-  useDataSourceRights: jest.fn((uid: string) => (uid === 'not-found' ? {} : mockDataSourceRights)),
 }));
 
 const mockUseDataSource = jest.mocked(require('../state/hooks').useDataSource);
-const mockUseDataSourceRights = jest.mocked(require('../state/hooks').useDataSourceRights);
 
 describe('EditDataSourceActions', () => {
   beforeEach(() => {
@@ -150,9 +141,7 @@ describe('EditDataSourceActions', () => {
     config.featureToggles.favoriteDatasources = false;
 
     // Reset default hook mocks
-    mockUseDispatch.mockReturnValue(jest.fn());
     mockUseDataSource.mockImplementation((uid: string) => (uid === 'not-found' ? {} : mockDataSource));
-    mockUseDataSourceRights.mockImplementation((uid: string) => (uid === 'not-found' ? {} : mockDataSourceRights));
   });
 
   describe('Core Actions', () => {
@@ -533,53 +522,6 @@ describe('EditDataSourceActions', () => {
 
       const favoriteButton = screen.getByTestId('favorite-button');
       expect(favoriteButton).toBeDisabled();
-    });
-  });
-
-  describe('Default Actions', () => {
-    it('should render make default button when data source is not default and editable', () => {
-      mockUseDataSource.mockReturnValue({ ...mockDataSource, isDefault: false });
-
-      render(<EditDataSourceActions uid="test-uid" />);
-
-      expect(screen.getByText('Make default')).toBeInTheDocument();
-      expect(screen.queryByText('Remove default')).not.toBeInTheDocument();
-    });
-
-    it('should render remove default button when data source is default and editable', () => {
-      mockUseDataSource.mockReturnValue({ ...mockDataSource, isDefault: true });
-
-      render(<EditDataSourceActions uid="test-uid" />);
-
-      expect(screen.getByText('Remove default')).toBeInTheDocument();
-      expect(screen.queryByText('Make default')).not.toBeInTheDocument();
-    });
-
-    it('should not render make default button when data source is not default but not editable', () => {
-      mockUseDataSource.mockReturnValue({ ...mockDataSource, isDefault: false });
-      mockUseDataSourceRights.mockReturnValue({ hasWriteRights: false, readOnly: true });
-
-      render(<EditDataSourceActions uid="test-uid" />);
-
-      expect(screen.queryByLabelText('Make default')).not.toBeInTheDocument();
-    });
-
-    it('should not render remove default button when data source is default but not editable', () => {
-      mockUseDataSource.mockReturnValue({ ...mockDataSource, isDefault: true });
-      mockUseDataSourceRights.mockReturnValue({ hasWriteRights: false, readOnly: true });
-
-      render(<EditDataSourceActions uid="test-uid" />);
-
-      expect(screen.queryByLabelText('Remove default')).not.toBeInTheDocument();
-    });
-
-    it('should render default badge when data source is default but not editable', () => {
-      mockUseDataSource.mockReturnValue({ ...mockDataSource, isDefault: true });
-      mockUseDataSourceRights.mockReturnValue({ hasWriteRights: true, readOnly: true });
-
-      render(<EditDataSourceActions uid="test-uid" />);
-
-      expect(screen.getByText('Default')).toBeInTheDocument();
     });
   });
 });

--- a/public/app/features/datasources/components/EditDataSourceActions.tsx
+++ b/public/app/features/datasources/components/EditDataSourceActions.tsx
@@ -10,7 +10,6 @@ import { trackDsConfigClicked, trackExploreClicked } from '../tracking';
 import { constructDataSourceExploreUrl } from '../utils';
 
 import { BuildDashboardButton } from './BuildDashboardButton';
-import { DataSourceDefaultButton } from './DataSourceDefaultButton';
 import { INTERACTION_EVENT_NAME, INTERACTION_ITEM } from './picker/DataSourcePicker';
 
 interface Props {
@@ -106,7 +105,6 @@ export function EditDataSourceActions({ uid }: Props) {
   return (
     <>
       <FavoriteButton uid={uid} />
-      <DataSourceDefaultButton uid={uid} />
       {hasExploreRights && (
         <>
           {!hasActions ? (

--- a/public/app/features/datasources/components/EditDataSourceActions.tsx
+++ b/public/app/features/datasources/components/EditDataSourceActions.tsx
@@ -1,29 +1,16 @@
-import { useState } from 'react';
-
 import { PluginExtensionPoints } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import {
-  config,
-  usePluginLinks,
-  useFavoriteDatasources,
-  getDataSourceSrv,
-  reportInteraction,
-  isFetchError,
-} from '@grafana/runtime';
-import { Button, Dropdown, LinkButton, Menu, Icon, IconButton, Badge, Tooltip } from '@grafana/ui';
-import { createErrorNotification } from 'app/core/copy/appNotification';
-import { notifyApp } from 'app/core/reducers/appNotification';
+import { config, usePluginLinks, useFavoriteDatasources, getDataSourceSrv, reportInteraction } from '@grafana/runtime';
+import { Button, Dropdown, LinkButton, Menu, Icon, IconButton } from '@grafana/ui';
 import { contextSrv } from 'app/core/services/context_srv';
-import { useDispatch } from 'app/types/store';
 
-import * as api from '../api';
 import { ALLOWED_DATASOURCE_EXTENSION_PLUGINS } from '../constants';
-import { useDataSource, useDataSourceRights } from '../state/hooks';
-import { setIsDefault } from '../state/reducers';
+import { useDataSource } from '../state/hooks';
 import { trackDsConfigClicked, trackExploreClicked } from '../tracking';
 import { constructDataSourceExploreUrl } from '../utils';
 
 import { BuildDashboardButton } from './BuildDashboardButton';
+import { DataSourceDefaultButton } from './DataSourceDefaultButton';
 import { INTERACTION_EVENT_NAME, INTERACTION_ITEM } from './picker/DataSourcePicker';
 
 interface Props {
@@ -62,94 +49,6 @@ const FavoriteButton = ({ uid }: { uid: string }) => {
         data-testid="favorite-button"
       />
     )
-  );
-};
-
-const DefaultButton = ({ uid }: { uid: string }) => {
-  const [loading, setLoading] = useState(false);
-
-  const dataSource = useDataSource(uid);
-  const rights = useDataSourceRights(uid);
-  const editable = rights.hasWriteRights && !rights.readOnly;
-
-  const dispatch = useDispatch();
-
-  const onChangeDefault = async (value: boolean) => {
-    if (loading) {
-      return;
-    }
-    setLoading(true);
-
-    try {
-      // Make manual API calls to avoid pre-emptively saving other changes from the EditDataSource form
-      const ds = await api.getDataSourceByUid(uid);
-      await api.updateDataSource({ ...ds, isDefault: value });
-      dispatch(setIsDefault(value));
-    } catch (error) {
-      dispatch(
-        notifyApp(
-          createErrorNotification(
-            t('datasources.edit-data-source-actions.default-error', 'Failed to update default data source'),
-            isFetchError(error) ? error.data.message : error instanceof Error ? error.message : undefined
-          )
-        )
-      );
-    }
-
-    setLoading(false);
-  };
-
-  if (!editable) {
-    return dataSource.isDefault ? (
-      <Badge
-        text={
-          <Tooltip
-            content={[
-              t(
-                'datasources.edit-data-source-actions.default-active',
-                'This data source is currently set as the default.'
-              ),
-              t(
-                'datasources.edit-data-source-actions.default-tooltip',
-                'The default data source is preselected in new panels.'
-              ),
-            ].join(' ')}
-          >
-            <span>
-              <Trans i18nKey="datasources.edit-data-source-actions.default-label">Default</Trans>
-            </span>
-          </Tooltip>
-        }
-        color="blue"
-      />
-    ) : null;
-  }
-
-  return (
-    <Button
-      variant="secondary"
-      size="sm"
-      tooltip={[
-        dataSource.isDefault &&
-          t('datasources.edit-data-source-actions.default-active', 'This data source is currently set as the default.'),
-        t(
-          'datasources.edit-data-source-actions.default-tooltip',
-          'The default data source is preselected in new panels.'
-        ),
-      ]
-        .filter(Boolean)
-        .join(' ')}
-      onClick={() => onChangeDefault(!dataSource.isDefault)}
-      icon={loading ? 'spinner' : undefined}
-      iconPlacement="right"
-      disabled={loading}
-    >
-      {dataSource.isDefault ? (
-        <Trans i18nKey="datasources.edit-data-source-actions.default-remove-button">Remove default</Trans>
-      ) : (
-        <Trans i18nKey="datasources.edit-data-source-actions.default-make-button">Make default</Trans>
-      )}
-    </Button>
   );
 };
 
@@ -207,7 +106,7 @@ export function EditDataSourceActions({ uid }: Props) {
   return (
     <>
       <FavoriteButton uid={uid} />
-      <DefaultButton uid={uid} />
+      <DataSourceDefaultButton uid={uid} />
       {hasExploreRights && (
         <>
           {!hasActions ? (

--- a/public/app/features/datasources/state/reducers.test.ts
+++ b/public/app/features/datasources/state/reducers.test.ts
@@ -21,6 +21,7 @@ import {
   setDataSourceName,
   setDataSourcesLayoutMode,
   setDataSourcesSearchQuery,
+  setDataSourcesDefault,
   setDataSourceTypeSearchQuery,
   setIsDefault,
 } from './reducers';
@@ -79,6 +80,28 @@ describe('dataSourcesReducer', () => {
         .givenReducer(dataSourcesReducer, initialState)
         .whenActionIsDispatched(setDataSourcesLayoutMode(layoutMode))
         .thenStateShouldEqual({ ...initialState, layoutMode: LayoutModes.Grid });
+    });
+  });
+
+  describe('when setDataSourcesDefault is dispatched', () => {
+    it('then it updates the list in place', () => {
+      const currentDefault = getMockDataSource({ uid: 'default-uid', isDefault: true, name: 'Default' });
+      const nextDefault = getMockDataSource({ uid: 'next-uid', isDefault: false, name: 'Next' });
+      const state: DataSourcesState = {
+        ...initialState,
+        dataSources: [currentDefault, nextDefault],
+      };
+
+      reducerTester<DataSourcesState>()
+        .givenReducer(dataSourcesReducer, state)
+        .whenActionIsDispatched(setDataSourcesDefault({ uid: nextDefault.uid, isDefault: true }))
+        .thenStateShouldEqual({
+          ...state,
+          dataSources: [
+            { ...currentDefault, isDefault: false },
+            { ...nextDefault, isDefault: true },
+          ],
+        });
     });
   });
 

--- a/public/app/features/datasources/state/reducers.ts
+++ b/public/app/features/datasources/state/reducers.ts
@@ -34,6 +34,9 @@ export const dataSourcePluginsLoaded = createAction<DataSourceTypesLoadedPayload
 );
 export const setDataSourcesSearchQuery = createAction<string>('dataSources/setDataSourcesSearchQuery');
 export const setDataSourcesLayoutMode = createAction<LayoutMode>('dataSources/setDataSourcesLayoutMode');
+export const setDataSourcesDefault = createAction<{ uid: string; isDefault: boolean }>(
+  'dataSources/setDataSourcesDefault'
+);
 export const setDataSourceTypeSearchQuery = createAction<string>('dataSources/setDataSourceTypeSearchQuery');
 export const setDataSourceName = createAction<string>('dataSources/setDataSourceName');
 export const setIsDefault = createAction<boolean>('dataSources/setIsDefault');
@@ -68,6 +71,31 @@ export const dataSourcesReducer = (state: DataSourcesState = initialState, actio
 
   if (setDataSourcesLayoutMode.match(action)) {
     return { ...state, layoutMode: action.payload };
+  }
+
+  if (setDataSourcesDefault.match(action)) {
+    const { uid, isDefault } = action.payload;
+
+    return {
+      ...state,
+      dataSources: state.dataSources.map((dataSource) => {
+        if (dataSource.uid === uid) {
+          return { ...dataSource, isDefault };
+        }
+
+        if (isDefault && dataSource.isDefault) {
+          return { ...dataSource, isDefault: false };
+        }
+
+        return dataSource;
+      }),
+      dataSource:
+        state.dataSource.uid === uid
+          ? { ...state.dataSource, isDefault }
+          : isDefault && state.dataSource.isDefault
+            ? { ...state.dataSource, isDefault: false }
+            : state.dataSource,
+    };
   }
 
   if (dataSourcePluginsLoad.match(action)) {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8144,14 +8144,16 @@
     "data-sources-list-card": {
       "explore": "Explore"
     },
+    "default-button": {
+      "active": "This data source is currently set as the default.",
+      "error": "Failed to update default data source",
+      "label": "Default",
+      "make": "Make default",
+      "remove": "Remove default",
+      "tooltip": "The default data source is preselected in new panels."
+    },
     "edit-data-source-actions": {
       "add-favorite": "Add to favorites",
-      "default-active": "This data source is currently set as the default.",
-      "default-error": "Failed to update default data source",
-      "default-label": "Default",
-      "default-make-button": "Make default",
-      "default-remove-button": "Remove default",
-      "default-tooltip": "The default data source is preselected in new panels.",
       "explore-data": "Explore data",
       "open-in-explore": "Open in Explore View",
       "remove-favorite": "Remove from favorites"

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8142,12 +8142,12 @@
       "aria-label-learn-more": "{{dataSourcePluginName}}, learn more."
     },
     "data-sources-list-card": {
+      "default": "Default",
       "explore": "Explore"
     },
     "default-button": {
       "active": "This data source is currently set as the default.",
       "error": "Failed to update default data source",
-      "label": "Default",
       "make": "Make default",
       "remove": "Remove default",
       "tooltip": "The default data source is preselected in new panels."


### PR DESCRIPTION
**What is this feature?**

Moves the default button introduced in #122847 from the header actions to the main data source list page.

<img width="1620" height="460" alt="image" src="https://github.com/user-attachments/assets/74ed84a9-103a-40b4-8c36-2a2d24dcf447" />

**Why do we need this feature?**

We received some feedback that having it with the actions in the header was breaking folks' muscle memory for the explore button. Given that we already show which is the default on the list view, it made sense for this to also be the place where you can manage which data source is the default.

**Who is this feature for?**

Administrators.

**Which issue(s) does this PR fix?**:

Alternative to, closes #124997.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
