### PR TITLE
Copy Log as JSON: follow up updates

### DIFF
--- a/public/app/features/logs/components/panel/export.test.ts
+++ b/public/app/features/logs/components/panel/export.test.ts
@@ -230,35 +230,6 @@ describe('buildLogLineFullJsonObject', () => {
     spy.mockRestore();
   });
 
-  it('omits dataframe fields for dataplane LogLines frames (fields come from labels / line only)', () => {
-    const log = createLogLine(
-      {
-        labels: { app: 'store' },
-        entry: 'buy',
-        logLevel: LogLevel.info,
-        entryFieldIndex: 1,
-        dataFrame: toDataFrame({
-          refId: 'A',
-          meta: { type: DataFrameType.LogLines },
-          fields: [
-            { name: 'timestamp', type: FieldType.time, values: [6000] },
-            { name: 'body', type: FieldType.string, values: ['buy'] },
-            { name: 'labels', type: FieldType.other, values: [{ app: 'store' }] },
-            { name: 'extra', type: FieldType.string, values: ['ignored-for-export'] },
-          ],
-        }),
-      },
-      processOpts
-    );
-
-    const out = buildLogLineFullJsonObject(
-      log,
-      typedDs(() => null)
-    );
-    expect(out.fields).toBeUndefined();
-    expect(out.labels).toEqual({ app: 'store' });
-  });
-
   it('prettifies the log line when the row is detected as JSON', () => {
     const entry = '{"message":"ping"}';
     const log = createLogLine(

--- a/public/app/features/logs/components/panel/export.test.ts
+++ b/public/app/features/logs/components/panel/export.test.ts
@@ -1,4 +1,4 @@
-import { DataFrameType, FieldType, LogLevel, LogsSortOrder, type DataSourceApi, toDataFrame } from '@grafana/data';
+import { FieldType, LogLevel, LogsSortOrder, type DataSourceApi, toDataFrame } from '@grafana/data';
 
 import { createLogLine } from '../mocks/logRow';
 
@@ -251,9 +251,8 @@ describe('buildLogLineFullJsonObject', () => {
       processOpts
     );
 
-    void log.body;
-    expect(log.isJSON).toBe(true);
     const line = buildLogLineFullJsonObject(log, untypedDs()).line as Record<string, unknown>;
+    expect(log.isJSON).toBe(true);
     expect(line.message).toBe('ping');
   });
 });

--- a/public/app/features/logs/components/panel/export.ts
+++ b/public/app/features/logs/components/panel/export.ts
@@ -1,7 +1,7 @@
 import { groupBy } from 'lodash';
 import { parse, stringify } from 'lossless-json';
 
-import { DataFrameType, type DataSourceApi, hasLogsLabelTypesSupport, type Labels } from '@grafana/data';
+import { type DataSourceApi, hasLogsLabelTypesSupport, type Labels } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 
 import { getLabelTypeFromRow } from '../../utils';
@@ -57,17 +57,9 @@ export function formatGroupedLabelsForJson(groupedLabels: Record<string, LabelEn
   return nested;
 }
 
-function fieldDefsWithoutLinks(log: LogListModel) {
-  if (log.dataFrame.meta?.type === DataFrameType.LogLines) {
-    return [];
-  }
-  return log.fields.filter((f) => f.links?.length === 0 && f.fieldIndex !== log.entryFieldIndex).sort();
-}
-
 function dataframeFieldsToRecord(log: LogListModel): Record<string, string | string[] | unknown> {
-  const fields = fieldDefsWithoutLinks(log);
   const out: Record<string, string | string[] | unknown> = {};
-  for (const field of fields) {
+  for (const field of log.fields) {
     const name = field.keys.join(' | ');
     out[name] = field.values.length === 1 ? prettifyIfJson(field.values[0]) : field.values;
   }

--- a/public/app/features/logs/components/panel/export.ts
+++ b/public/app/features/logs/components/panel/export.ts
@@ -1,7 +1,7 @@
 import { groupBy } from 'lodash';
 import { parse, stringify } from 'lossless-json';
 
-import { type DataSourceApi, hasLogsLabelTypesSupport, type Labels } from '@grafana/data';
+import { DataFrameType, type DataSourceApi, hasLogsLabelTypesSupport, type Labels } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 
 import { getLabelTypeFromRow } from '../../utils';
@@ -79,6 +79,8 @@ function prettifyIfJson(raw: string): unknown {
 }
 
 export function buildLogLineFullJsonObject(log: LogListModel, ds: DataSourceApi): Record<string, unknown> {
+  void log.body;
+
   const payload: Record<string, unknown> = {
     timestamp: log.timestamp,
     timeEpochMs: log.timeEpochMs,

--- a/public/app/features/logs/components/panel/export.ts
+++ b/public/app/features/logs/components/panel/export.ts
@@ -1,5 +1,5 @@
 import { groupBy } from 'lodash';
-import { parse } from 'lossless-json';
+import { parse, stringify } from 'lossless-json';
 
 import { DataFrameType, type DataSourceApi, hasLogsLabelTypesSupport, type Labels } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
@@ -115,5 +115,5 @@ export function buildLogLineFullJsonObject(log: LogListModel, ds: DataSourceApi)
 
 export async function getLogAsJSON(log: LogListModel): Promise<string> {
   const ds = await getDataSourceSrv().get(log.datasourceUid);
-  return JSON.stringify(buildLogLineFullJsonObject(log, ds), null, 2);
+  return stringify(buildLogLineFullJsonObject(log, ds), null, 2) ?? log.entry;
 }

--- a/public/app/features/logs/components/panel/export.ts
+++ b/public/app/features/logs/components/panel/export.ts
@@ -1,7 +1,7 @@
 import { groupBy } from 'lodash';
 import { parse, stringify } from 'lossless-json';
 
-import { DataFrameType, type DataSourceApi, hasLogsLabelTypesSupport, type Labels } from '@grafana/data';
+import { type DataSourceApi, hasLogsLabelTypesSupport, type Labels } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
 
 import { getLabelTypeFromRow } from '../../utils';


### PR DESCRIPTION
Small follow up to https://github.com/grafana/grafana/pull/124816 to make sure we don't lose precision when copying log fields.

- Stringify with losless-json
- Includes exporting derived fields, for example:

```
{
  "timestamp": "2026-05-14 19:51:29.769",
  "timeEpochMs": 1778781089769,
  "timeEpochNs": "1778781089769919260",
  "timeLocal": "2026-05-14 19:51:29",
  "timeUtc": "2026-05-14 17:51:29",
  "timeFromNow": "a few seconds ago",
  "logLevel": "info",
  "displayLevel": "info",
  "line": "level=info msg=\"HTTP client success\" status=200 url=http://db duration=919µs traceID=12ef38af50ec8b26",
  "labels": {
    "Indexed labels": {
      "compose_project": "devenv",
      "compose_service": "app",
      "container_name": "devenv-app-1",
      "filename": "/var/log/docker/f05a936e0c22546a17ffba96fab5e71d04288bf144f49de9fc9b07505b5e4040/json.log",
      "host": "docker-desktop",
      "job": "tns/app",
      "namespace": "tns",
      "service_name": "devenv-app-1",
      "source": "stdout"
    },
    "Structured metadata": {
      "detected_level": "info"
    },
    "Parsed fields": {
      "duration": "919µs",
      "level": "info",
      "msg": "HTTP client success",
      "status": "200",
      "traceID": "12ef38af50ec8b26",
      "url": "http://db"
    }
  },
  "fields": {
    "traceID": "12ef38af50ec8b26",
    "traceID (field)": "12ef38af50ec8b26"
  }
}
```

- Improves parsing of JSON log lines