### PR TITLE
unified-storage: fix `BatchOpUpdate` behaviour in mysql

### DIFF
--- a/pkg/storage/unified/resource/kv/queries.go
+++ b/pkg/storage/unified/resource/kv/queries.go
@@ -23,6 +23,16 @@ func (qb *queryBuilder) buildGetQuery(keyPath string) (string, []interface{}) {
 	return query, []interface{}{keyPath}
 }
 
+func (qb *queryBuilder) buildExistsQuery(keyPath string) (string, []interface{}) {
+	query := fmt.Sprintf(
+		"SELECT 1 FROM %s WHERE %s = %s",
+		qb.dialect.QuoteIdent(qb.tableName),
+		qb.dialect.QuoteIdent("key_path"),
+		qb.dialect.Placeholder(1),
+	)
+	return query, []interface{}{keyPath}
+}
+
 // buildKeysQuery generates SELECT query for listing keys
 func (qb *queryBuilder) buildKeysQuery(startKey, endKey string, sortAsc bool, limit int64) (string, []interface{}) {
 	order := "ASC"

--- a/pkg/storage/unified/resource/kv/sqlkv.go
+++ b/pkg/storage/unified/resource/kv/sqlkv.go
@@ -663,7 +663,7 @@ func isDuplicateKeyError(err error) bool {
 }
 
 // batchUpdate updates the value for an existing key_path.
-// Returns ErrNotFound when the key does not exist (RowsAffected == 0).
+// Returns ErrNotFound when the key does not exist.
 func (k *SqlKV) batchUpdate(ctx context.Context, conn dbtx, qb *queryBuilder, keyPath string, value []byte) error {
 	query, args := qb.buildUpdateDatastoreQuery(keyPath, value)
 	result, err := conn.ExecContext(ctx, query, args...)
@@ -674,8 +674,24 @@ func (k *SqlKV) batchUpdate(ctx context.Context, conn dbtx, qb *queryBuilder, ke
 	if err != nil {
 		return err
 	}
-	if n == 0 {
+	if n > 0 {
+		return nil
+	}
+	if k.dialect.Name() != "mysql" {
 		return ErrNotFound
+	}
+
+	// MySQL reports changed rows by default, not matched rows, so an UPDATE that
+	// sets the same value can return 0 even when the key exists.
+	query, args = qb.buildExistsQuery(keyPath)
+	row := conn.QueryRowContext(ctx, query, args...)
+
+	var exists int
+	if err := row.Scan(&exists); err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ErrNotFound
+		}
+		return err
 	}
 	return nil
 }

--- a/pkg/storage/unified/testing/kv.go
+++ b/pkg/storage/unified/testing/kv.go
@@ -1080,6 +1080,25 @@ func runTestKVBatch(t *testing.T, kv resource.KV, nsPrefix string) {
 		require.NoError(t, err)
 	})
 
+	t.Run("batch update succeeds for existing key with same value", func(t *testing.T) {
+		saveKVHelper(t, kv, ctx, section, nk("update-same-value-key"), strings.NewReader("same-value"))
+
+		ops := []resource.BatchOp{
+			{Mode: kvpkg.BatchOpUpdate, Key: nk("update-same-value-key"), Value: []byte("same-value")},
+		}
+
+		err := kv.Batch(ctx, section, ops)
+		require.NoError(t, err)
+
+		reader, err := kv.Get(ctx, section, nk("update-same-value-key"))
+		require.NoError(t, err)
+		value, err := io.ReadAll(reader)
+		require.NoError(t, err)
+		assert.Equal(t, "same-value", string(value))
+		err = reader.Close()
+		require.NoError(t, err)
+	})
+
 	t.Run("batch update fails for non-existent key", func(t *testing.T) {
 		ops := []resource.BatchOp{
 			{Mode: kvpkg.BatchOpUpdate, Key: nk("update-nonexistent-key"), Value: []byte("new-value")},


### PR DESCRIPTION
MySQL only reports changed rows in `RowsAffected()` so if the caller passed the same value as the one already persisted, the operation would incorrectly return `ErrNotFound`.