### PR TITLE
Provisioning: Pass max file size to NewAPIBuilder

### DIFF
--- a/pkg/registry/apis/provisioning/register.go
+++ b/pkg/registry/apis/provisioning/register.go
@@ -190,6 +190,7 @@ func NewAPIBuilder(
 	folderMetadataEnabled bool,
 	folderAPIVersion string,
 	incrementalPolicy repository.IncrementalSyncPolicy,
+	maxFileSize int64,
 ) (*APIBuilder, error) {
 	var clients resources.ClientFactory
 	if newStandaloneClientFactoryFunc != nil {
@@ -242,10 +243,8 @@ func NewAPIBuilder(
 		folderMetadataEnabled:               folderMetadataEnabled,
 		folderAPIVersion:                    folderAPIVersion,
 		incrementalPolicy:                   incrementalPolicy,
-		// Default cap for the files API. Callers (e.g. RegisterAPIService)
-		// may overwrite b.maxFileSize after construction; any non-positive
-		// value (<=0) disables the cap.
-		maxFileSize: setting.ProvisioningMaxFileSizeDefault,
+		// Per-file cap for the files API. Non-positive (<=0) disables the cap.
+		maxFileSize: maxFileSize,
 	}
 
 	for _, builder := range extraBuilders {
@@ -354,12 +353,12 @@ func RegisterAPIService(
 		folderMetadataEnabled,
 		folderAPIVersion,
 		incrementalPolicy,
+		maxFileSize,
 	)
 	if err != nil {
 		return nil, err
 	}
 	builder.webhookSecretRotationInterval = cfg.ProvisioningWebhookSecretRotationInterval
-	builder.maxFileSize = maxFileSize
 	apiregistration.RegisterAPI(builder)
 
 	// Register v1beta1
@@ -393,12 +392,12 @@ func RegisterAPIService(
 		folderMetadataEnabled,
 		folderAPIVersion,
 		incrementalPolicy,
+		maxFileSize,
 	)
 	if err != nil {
 		return nil, err
 	}
 	v1beta1Builder.webhookSecretRotationInterval = cfg.ProvisioningWebhookSecretRotationInterval
-	v1beta1Builder.maxFileSize = maxFileSize
 	apiregistration.RegisterAPI(v1beta1Builder)
 
 	// Return the preferred (v0alpha1) builder since it runs controllers/workers


### PR DESCRIPTION
**What is this feature?**

Adds a `maxFileSize` parameter to `provisioning.NewAPIBuilder`. Previously the per-file cap was hard-coded to the 5 MB default inside the constructor and only overridable in single-tenant via a post-construction assignment in `RegisterAPIService` (kept that way in #123793 to avoid breaking the enterprise call site).

With the signature change, multi-tenant can configure the cap too. The companion enterprise PR plumbs a new `--provisioning-max-file-size` flag through `pkg/extensions/apiserver/factory.go`.

**Why do we need this feature?**

Follow-up to #123793. Original observation:

> #123793 only involves ST configuration :thinkies:
> `NewAPIBuilder` directly uses `setting.ProvisioningMaxFileSizeDefault` for MT, which is not configurable on our side.
> `RegisterAPIService` is instead called in ST, and that gets the value from cfg.
> We need another PR that makes `NewAPIBuilder` receive also a `maxFileSize`, and use that in `factory.go` in enterprise.

Internal thread: https://raintank-corp.slack.com/archives/C08T7NVBCUA/p1778619270964189

**Who is this feature for?**

Operators of multi-tenant Grafana deployments who need to raise (or disable) the provisioning files API per-file cap.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/1122

**Special notes for your reviewer:**

- Companion enterprise PR: grafana/grafana-enterprise#12031
- Default behavior unchanged: ST keeps reading `cfg.ProvisioningMaxFileSize` (5 MB default); enterprise factory defaults the new flag to `setting.ProvisioningMaxFileSizeDefault` (5 MB) as well.
- Verified end-to-end in a local `mt-tilt` setup: the flag value plumbs through `NewAPIBuilder` and lands on the MT provisioning apiserver's `maxFileSize` field.
- No tests added: pure signature/plumbing change; behavior is covered by the existing `files_test.go` and integration tests in #123793.

PR description authored with Claude Code.