### PR TITLE
AzureMonitor: fix namespace fetch errors in sovereign clouds

### DIFF
--- a/public/app/plugins/datasource/azuremonitor/mocks/instanceSettings.ts
+++ b/public/app/plugins/datasource/azuremonitor/mocks/instanceSettings.ts
@@ -1,11 +1,11 @@
-import { type DataSourceInstanceSettings, PluginType } from '@grafana/data';
+import { PluginType } from '@grafana/data';
 
 import { type AzureMonitorDataSourceInstanceSettings } from '../types/types';
 
 import { type DeepPartial, mapPartialArrayObject } from './utils';
 
 export const createMockInstanceSetttings = (
-  overrides?: DeepPartial<DataSourceInstanceSettings>
+  overrides?: DeepPartial<AzureMonitorDataSourceInstanceSettings>
 ): AzureMonitorDataSourceInstanceSettings => {
   const metaOverrides = overrides?.meta;
   return {

--- a/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.test.ts
+++ b/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.test.ts
@@ -21,8 +21,14 @@ jest.mock('@grafana/runtime', () => ({
   }),
 }));
 
-const createResourcePickerData = (responses: AzureGraphResponse[], noNamespaces?: boolean) => {
-  const instanceSettings = createMockInstanceSetttings();
+const createResourcePickerData = (
+  responses: AzureGraphResponse[],
+  noNamespaces?: boolean,
+  cloudName?: string
+) => {
+  const instanceSettings = createMockInstanceSetttings(
+    cloudName ? { jsonData: { cloudName } } : undefined
+  );
   const azureResourceGraphDatasource = new AzureResourceGraphDatasource(instanceSettings);
   const postResource = jest.fn();
   responses.forEach((res) => {
@@ -658,6 +664,117 @@ describe('AzureMonitor resourcePickerData', () => {
           throw err;
         }
       }
+    });
+
+    it('uses US Government regions when cloud is AzureUSGovernment', async () => {
+      const mockSubscriptionsResponse = createMockARGSubscriptionResponse();
+      const mockResponse = {
+        data: [
+          {
+            id: '/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Compute/virtualMachines/vmname',
+            name: 'vmName',
+            type: 'microsoft.compute/virtualmachines',
+            resourceGroup: 'rgName',
+            subscriptionId: 'subId',
+            location: 'usgovvirginia',
+          },
+        ],
+      };
+      const { resourcePickerData, mockDatasource } = createResourcePickerData(
+        [mockSubscriptionsResponse, mockResponse],
+        false,
+        'govazuremonitor'
+      );
+      await resourcePickerData.search('vmname', 'metrics', emptyFilters);
+      expect(mockDatasource.azureMonitorDatasource.getMetricNamespaces).toHaveBeenCalledWith(
+        { resourceUri: '/subscriptions/1' },
+        false,
+        'usgovvirginia'
+      );
+      expect(mockDatasource.azureMonitorDatasource.getMetricNamespaces).toHaveBeenCalledWith(
+        { resourceUri: '/subscriptions/1' },
+        false,
+        'usgovarizona'
+      );
+      expect(mockDatasource.azureMonitorDatasource.getMetricNamespaces).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        'westeurope'
+      );
+    });
+
+    it('uses China regions when cloud is AzureChinaCloud', async () => {
+      const mockSubscriptionsResponse = createMockARGSubscriptionResponse();
+      const mockResponse = {
+        data: [
+          {
+            id: '/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Compute/virtualMachines/vmname',
+            name: 'vmName',
+            type: 'microsoft.compute/virtualmachines',
+            resourceGroup: 'rgName',
+            subscriptionId: 'subId',
+            location: 'chinanorth3',
+          },
+        ],
+      };
+      const { resourcePickerData, mockDatasource } = createResourcePickerData(
+        [mockSubscriptionsResponse, mockResponse],
+        false,
+        'chinaazuremonitor'
+      );
+      await resourcePickerData.search('vmname', 'metrics', emptyFilters);
+      expect(mockDatasource.azureMonitorDatasource.getMetricNamespaces).toHaveBeenCalledWith(
+        { resourceUri: '/subscriptions/1' },
+        false,
+        'chinanorth3'
+      );
+      expect(mockDatasource.azureMonitorDatasource.getMetricNamespaces).toHaveBeenCalledWith(
+        { resourceUri: '/subscriptions/1' },
+        false,
+        'chinaeast3'
+      );
+      expect(mockDatasource.azureMonitorDatasource.getMetricNamespaces).not.toHaveBeenCalledWith(
+        expect.anything(),
+        expect.anything(),
+        'westeurope'
+      );
+    });
+
+    it('falls back to predefined namespaces when a region fetch throws', async () => {
+      const mockSubscriptionsResponse = createMockARGSubscriptionResponse();
+      const mockResponse = {
+        data: [
+          {
+            id: '/subscriptions/subId/resourceGroups/rgName/providers/Microsoft.Compute/virtualMachines/vmname',
+            name: 'vmName',
+            type: 'microsoft.compute/virtualmachines',
+            resourceGroup: 'rgName',
+            subscriptionId: 'subId',
+            location: 'northeurope',
+          },
+        ],
+      };
+      const instanceSettings = createMockInstanceSetttings();
+      const azureResourceGraphDatasource = new AzureResourceGraphDatasource(instanceSettings);
+      const postResource = jest.fn();
+      [mockSubscriptionsResponse, mockResponse].forEach((res) => {
+        postResource.mockResolvedValueOnce(res);
+      });
+      azureResourceGraphDatasource.postResource = postResource;
+      const mockDatasource = createMockDatasource({ azureResourceGraphDatasource });
+      mockDatasource.azureMonitorDatasource.getMetricNamespaces = jest
+        .fn()
+        .mockRejectedValue(new Error('region not available'));
+
+      const resourcePickerData = new ResourcePickerData(
+        instanceSettings,
+        mockDatasource.azureMonitorDatasource,
+        mockDatasource.azureResourceGraphDatasource
+      );
+
+      await expect(resourcePickerData.search('vmname', 'metrics', emptyFilters)).resolves.not.toThrow();
+      const namespaces = resourcePickerData.supportedMetricNamespaces;
+      expect(namespaces.length).toBeGreaterThan(0);
     });
   });
 

--- a/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.test.ts
+++ b/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.test.ts
@@ -21,14 +21,8 @@ jest.mock('@grafana/runtime', () => ({
   }),
 }));
 
-const createResourcePickerData = (
-  responses: AzureGraphResponse[],
-  noNamespaces?: boolean,
-  cloudName?: string
-) => {
-  const instanceSettings = createMockInstanceSetttings(
-    cloudName ? { jsonData: { cloudName } } : undefined
-  );
+const createResourcePickerData = (responses: AzureGraphResponse[], noNamespaces?: boolean, cloudName?: string) => {
+  const instanceSettings = createMockInstanceSetttings(cloudName ? { jsonData: { cloudName } } : undefined);
   const azureResourceGraphDatasource = new AzureResourceGraphDatasource(instanceSettings);
   const postResource = jest.fn();
   responses.forEach((res) => {

--- a/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.ts
+++ b/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.ts
@@ -1,5 +1,6 @@
 import { uniq } from 'lodash';
 
+import { AzureCloud, getDefaultAzureCloud, resolveLegacyCloudName } from '@grafana/azure-sdk';
 import { DataSourceWithBackend, reportInteraction } from '@grafana/runtime';
 
 import { logsResourceTypes } from '../azureMetadata/logsResourceTypes';
@@ -36,6 +37,7 @@ export default class ResourcePickerData extends DataSourceWithBackend<
   azureMonitorDatasource;
   azureResourceGraphDatasource;
   supportedMetricNamespaces = '';
+  private cloudName: string;
 
   constructor(
     instanceSettings: AzureMonitorDataSourceInstanceSettings,
@@ -45,6 +47,10 @@ export default class ResourcePickerData extends DataSourceWithBackend<
     super(instanceSettings);
     this.azureMonitorDatasource = azureMonitorDatasource;
     this.azureResourceGraphDatasource = azureResourceGraphDatasource;
+    this.cloudName =
+      resolveLegacyCloudName(instanceSettings.jsonData.cloudName) ||
+      instanceSettings.jsonData.cloudName ||
+      getDefaultAzureCloud();
   }
 
   async fetchInitialRows(
@@ -312,6 +318,17 @@ export default class ResourcePickerData extends DataSourceWithBackend<
       : `| where type in (${this.supportedMetricNamespaces})`;
   };
 
+  private getRegionsForCloud(): string[] {
+    switch (this.cloudName) {
+      case AzureCloud.USGovernment:
+        return ['usgovvirginia', 'usgovarizona'];
+      case AzureCloud.China:
+        return ['chinanorth3', 'chinaeast3'];
+      default:
+        return ['westeurope', 'eastus', 'japaneast'];
+    }
+  }
+
   private async fetchAllNamespaces() {
     const subscriptions = await this.getSubscriptions();
     reportInteraction('grafana_ds_azuremonitor_subscriptions_loaded', { subscriptions: subscriptions.length });
@@ -322,21 +339,24 @@ export default class ResourcePickerData extends DataSourceWithBackend<
       supportedMetricNamespaces.add(`"${namespace}"`);
     });
 
-    // We make use of these three regions as they *should* contain every possible namespace
-    const regions = ['westeurope', 'eastus', 'japaneast'];
+    const regions = this.getRegionsForCloud();
     const getNamespacesForRegion = async (region: string) => {
-      const namespaces = await this.azureMonitorDatasource.getMetricNamespaces(
-        {
-          // We only need to run this request against the first available subscription
-          resourceUri: `/subscriptions/${subscriptions[0].id}`,
-        },
-        false,
-        region
-      );
-      if (namespaces) {
-        for (const namespace of namespaces) {
-          supportedMetricNamespaces.add(`"${namespace.value.toLocaleLowerCase()}"`);
+      try {
+        const namespaces = await this.azureMonitorDatasource.getMetricNamespaces(
+          {
+            // We only need to run this request against the first available subscription
+            resourceUri: `/subscriptions/${subscriptions[0].id}`,
+          },
+          false,
+          region
+        );
+        if (namespaces) {
+          for (const namespace of namespaces) {
+            supportedMetricNamespaces.add(`"${namespace.value.toLocaleLowerCase()}"`);
+          }
         }
+      } catch {
+        // Region may not be available in this cloud environment; fall back to predefined namespaces
       }
     };
 

--- a/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.ts
+++ b/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.ts
@@ -355,7 +355,7 @@ export default class ResourcePickerData extends DataSourceWithBackend<
           }
         }
       } catch (e) {
-        console.debug(`Failed to fetch metric namespaces for region ${region}, falling back to predefined list:`, e);
+        console.warn(`Failed to fetch metric namespaces for region ${region}, falling back to predefined list:`, e);
       }
     };
 

--- a/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.ts
+++ b/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.ts
@@ -49,7 +49,7 @@ export default class ResourcePickerData extends DataSourceWithBackend<
     this.azureMonitorDatasource = azureMonitorDatasource;
     this.azureResourceGraphDatasource = azureResourceGraphDatasource;
     const creds = getCredentials(instanceSettings);
-    this.cloudName = ('azureCloud' in creds && creds.azureCloud) ? creds.azureCloud : getDefaultAzureCloud();
+    this.cloudName = 'azureCloud' in creds && creds.azureCloud ? creds.azureCloud : getDefaultAzureCloud();
   }
 
   async fetchInitialRows(

--- a/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.ts
+++ b/public/app/plugins/datasource/azuremonitor/resourcePicker/resourcePickerData.ts
@@ -1,6 +1,6 @@
 import { uniq } from 'lodash';
 
-import { AzureCloud, getDefaultAzureCloud, resolveLegacyCloudName } from '@grafana/azure-sdk';
+import { AzureCloud, getDefaultAzureCloud } from '@grafana/azure-sdk';
 import { DataSourceWithBackend, reportInteraction } from '@grafana/runtime';
 
 import { logsResourceTypes } from '../azureMetadata/logsResourceTypes';
@@ -15,6 +15,7 @@ import {
   parseResourceURI,
   resourceToString,
 } from '../components/ResourcePicker/utils';
+import { getCredentials } from '../credentials';
 import { type AzureMonitorResource } from '../dataquery.gen';
 import { type AzureMonitorQuery } from '../types/query';
 import {
@@ -47,10 +48,8 @@ export default class ResourcePickerData extends DataSourceWithBackend<
     super(instanceSettings);
     this.azureMonitorDatasource = azureMonitorDatasource;
     this.azureResourceGraphDatasource = azureResourceGraphDatasource;
-    this.cloudName =
-      resolveLegacyCloudName(instanceSettings.jsonData.cloudName) ||
-      instanceSettings.jsonData.cloudName ||
-      getDefaultAzureCloud();
+    const creds = getCredentials(instanceSettings);
+    this.cloudName = ('azureCloud' in creds && creds.azureCloud) ? creds.azureCloud : getDefaultAzureCloud();
   }
 
   async fetchInitialRows(
@@ -355,8 +354,8 @@ export default class ResourcePickerData extends DataSourceWithBackend<
             supportedMetricNamespaces.add(`"${namespace.value.toLocaleLowerCase()}"`);
           }
         }
-      } catch {
-        // Region may not be available in this cloud environment; fall back to predefined namespaces
+      } catch (e) {
+        console.debug(`Failed to fetch metric namespaces for region ${region}, falling back to predefined list:`, e);
       }
     };
 


### PR DESCRIPTION
## What's the problem?

When using Azure Monitor in a sovereign cloud (US Government or China), opening the resource picker throws 3 errors because `fetchAllNamespaces` tries to query metric namespaces from hardcoded public Azure regions (`westeurope`, `eastus`, `japaneast`) that simply don't exist in those environments.

Tracked in #124864.

## What changed?

- Added `getRegionsForCloud()` which picks the right regions based on the configured cloud:
  - **US Government** → `usgovvirginia`, `usgovarizona`
  - **China** → `chinanorth3`, `chinaeast3`
  - **Public** → unchanged (`westeurope`, `eastus`, `japaneast`)
- Wrapped per-region fetches in `try/catch` so a failed region request silently falls back to the predefined namespace set instead of surfacing an error to the user.

## How to test

1. Configure Azure Monitor with credentials scoped to US Government or China cloud.
2. Open a panel → Resource Selector.
3. No errors should appear — namespaces load from the correct regions.