### PR TITLE
Snapshots: Fix expire time when using k8s api in mode0

### DIFF
--- a/pkg/registry/apis/dashboard/snapshot/conversions.go
+++ b/pkg/registry/apis/dashboard/snapshot/conversions.go
@@ -113,8 +113,13 @@ func convertK8sResourceToCreateCommand(snap *dashV0.Snapshot, orgID int64, userI
 	}
 
 	// Map expires
-	if snap.Spec.Expires != nil {
-		cmd.Expires = *snap.Spec.Expires
+	// snap.Spec.Expires is an absolute timestamp in milliseconds; cmd.Expires is a
+	// duration in seconds, so convert back to a remaining duration.
+	if snap.Spec.Expires != nil && *snap.Spec.Expires > 0 {
+		remaining := time.Until(time.UnixMilli(*snap.Spec.Expires))
+		if remaining > 0 {
+			cmd.Expires = int64(remaining.Seconds())
+		}
 	}
 
 	// Map external settings

--- a/pkg/registry/apis/dashboard/snapshot/conversions_test.go
+++ b/pkg/registry/apis/dashboard/snapshot/conversions_test.go
@@ -1,0 +1,55 @@
+package snapshot
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	dashV0 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
+	"github.com/grafana/grafana/pkg/services/dashboardsnapshots"
+)
+
+func TestConvertK8sResourceToCreateCommand_Expires(t *testing.T) {
+	const orgID, userID int64 = 1, 2
+	const oneWeekSeconds = int64(7 * 24 * 60 * 60)
+
+	t.Run("converts absolute ms timestamp back to seconds-remaining duration", func(t *testing.T) {
+		oneWeekFromNow := time.Now().Add(7 * 24 * time.Hour).UnixMilli()
+		snap := &dashV0.Snapshot{
+			Spec: dashV0.SnapshotSpec{Expires: &oneWeekFromNow},
+		}
+
+		cmd := convertK8sResourceToCreateCommand(snap, orgID, userID)
+
+		assert.InDelta(t, oneWeekSeconds, cmd.Expires, 5,
+			"cmd.Expires should be ~1 week in seconds, got %d", cmd.Expires)
+	})
+
+	t.Run("leaves Expires zero when spec has no expiration", func(t *testing.T) {
+		snap := &dashV0.Snapshot{Spec: dashV0.SnapshotSpec{}}
+
+		cmd := convertK8sResourceToCreateCommand(snap, orgID, userID)
+
+		assert.Equal(t, int64(0), cmd.Expires)
+	})
+
+	t.Run("leaves Expires zero when spec timestamp is in the past", func(t *testing.T) {
+		past := time.Now().Add(-time.Hour).UnixMilli()
+		snap := &dashV0.Snapshot{Spec: dashV0.SnapshotSpec{Expires: &past}}
+
+		cmd := convertK8sResourceToCreateCommand(snap, orgID, userID)
+
+		assert.Equal(t, int64(0), cmd.Expires)
+	})
+
+	t.Run("round-trip create cmd -> k8s -> create cmd preserves ~1 week", func(t *testing.T) {
+		original := &dashboardsnapshots.CreateDashboardSnapshotCommand{}
+		original.Expires = oneWeekSeconds
+
+		snap := convertCreateCmdToK8sSnapshot(original, "default")
+		got := convertK8sResourceToCreateCommand(snap, orgID, userID)
+
+		assert.InDelta(t, original.Expires, got.Expires, 5)
+	})
+}


### PR DESCRIPTION
**What is this feature?**

When creating a snapshot using the new k8s api with unified storage in mode 0, the expiration time was not being calculated properly. 

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
