### PR TITLE
plugins: add cross-reference from check_for_plugin_updates to public_key_retrieval_disabled

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -326,6 +326,8 @@ check_for_updates = true
 # in some UI views to notify that a plugin update exists.
 # This option does not cause any auto updates, nor send any information
 # only a GET request to https://grafana.com to get the latest versions.
+# Setting this to false also disables dynamic plugin signing key retrieval
+# from the configured Grafana.com API URL.
 check_for_plugin_updates = true
 
 # Google Analytics universal tracking code, only enabled if you specify an id here

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -326,8 +326,7 @@ check_for_updates = true
 # in some UI views to notify that a plugin update exists.
 # This option does not cause any auto updates, nor send any information
 # only a GET request to https://grafana.com to get the latest versions.
-# Setting this to false also disables dynamic plugin signing key retrieval
-# from the configured Grafana.com API URL.
+# To disable dynamic plugin signing key retrieval, use public_key_retrieval_disabled instead.
 check_for_plugin_updates = true
 
 # Google Analytics universal tracking code, only enabled if you specify an id here

--- a/pkg/services/pluginsintegration/keyretriever/dynamic/dynamic_retriever.go
+++ b/pkg/services/pluginsintegration/keyretriever/dynamic/dynamic_retriever.go
@@ -52,8 +52,8 @@ func ProvideService(cfg *setting.Cfg, kv plugins.KeyStore) *KeyRetriever {
 
 // IsDisabled disables dynamic retrieval of public keys from the API server.
 // Also disabled when CheckForPluginUpdates is false, since both require outbound
-// connectivity to grafana.com. Plugin signature verification falls back to the
-// built-in static key when dynamic retrieval is disabled.
+// connectivity to the configured GrafanaComAPIURL. Plugin signature verification
+// falls back to the built-in static key when dynamic retrieval is disabled.
 func (kr *KeyRetriever) IsDisabled() bool {
 	return kr.cfg.PluginSkipPublicKeyDownload || !kr.cfg.CheckForPluginUpdates
 }

--- a/pkg/services/pluginsintegration/keyretriever/dynamic/dynamic_retriever.go
+++ b/pkg/services/pluginsintegration/keyretriever/dynamic/dynamic_retriever.go
@@ -51,8 +51,11 @@ func ProvideService(cfg *setting.Cfg, kv plugins.KeyStore) *KeyRetriever {
 }
 
 // IsDisabled disables dynamic retrieval of public keys from the API server.
+// Also disabled when CheckForPluginUpdates is false, since both require outbound
+// connectivity to grafana.com. Plugin signature verification falls back to the
+// built-in static key when dynamic retrieval is disabled.
 func (kr *KeyRetriever) IsDisabled() bool {
-	return kr.cfg.PluginSkipPublicKeyDownload
+	return kr.cfg.PluginSkipPublicKeyDownload || !kr.cfg.CheckForPluginUpdates
 }
 
 func (kr *KeyRetriever) Run(ctx context.Context) error {

--- a/pkg/services/pluginsintegration/keyretriever/dynamic/dynamic_retriever.go
+++ b/pkg/services/pluginsintegration/keyretriever/dynamic/dynamic_retriever.go
@@ -51,11 +51,8 @@ func ProvideService(cfg *setting.Cfg, kv plugins.KeyStore) *KeyRetriever {
 }
 
 // IsDisabled disables dynamic retrieval of public keys from the API server.
-// Also disabled when CheckForPluginUpdates is false, since both require outbound
-// connectivity to the configured GrafanaComAPIURL. Plugin signature verification
-// falls back to the built-in static key when dynamic retrieval is disabled.
 func (kr *KeyRetriever) IsDisabled() bool {
-	return kr.cfg.PluginSkipPublicKeyDownload || !kr.cfg.CheckForPluginUpdates
+	return kr.cfg.PluginSkipPublicKeyDownload
 }
 
 func (kr *KeyRetriever) Run(ctx context.Context) error {

--- a/pkg/services/pluginsintegration/keyretriever/dynamic/dynamic_retriever_test.go
+++ b/pkg/services/pluginsintegration/keyretriever/dynamic/dynamic_retriever_test.go
@@ -40,22 +40,6 @@ func setFakeAPIServer(t *testing.T, publicKey string, keyID string) (*httptest.S
 		done <- true
 	})), done
 }
-func Test_IsDisabled(t *testing.T) {
-	t.Run("disabled when PluginSkipPublicKeyDownload is true", func(t *testing.T) {
-		kr := ProvideService(&setting.Cfg{PluginSkipPublicKeyDownload: true, CheckForPluginUpdates: true}, nil)
-		require.True(t, kr.IsDisabled())
-	})
-
-	t.Run("disabled when CheckForPluginUpdates is false", func(t *testing.T) {
-		kr := ProvideService(&setting.Cfg{PluginSkipPublicKeyDownload: false, CheckForPluginUpdates: false}, nil)
-		require.True(t, kr.IsDisabled())
-	})
-
-	t.Run("enabled when both flags allow it", func(t *testing.T) {
-		kr := ProvideService(&setting.Cfg{PluginSkipPublicKeyDownload: false, CheckForPluginUpdates: true}, nil)
-		require.False(t, kr.IsDisabled())
-	})
-}
 
 func Test_PublicKeyUpdate(t *testing.T) {
 	t.Run("it should retrieve an API key", func(t *testing.T) {

--- a/pkg/services/pluginsintegration/keyretriever/dynamic/dynamic_retriever_test.go
+++ b/pkg/services/pluginsintegration/keyretriever/dynamic/dynamic_retriever_test.go
@@ -40,6 +40,23 @@ func setFakeAPIServer(t *testing.T, publicKey string, keyID string) (*httptest.S
 		done <- true
 	})), done
 }
+func Test_IsDisabled(t *testing.T) {
+	t.Run("disabled when PluginSkipPublicKeyDownload is true", func(t *testing.T) {
+		kr := ProvideService(&setting.Cfg{PluginSkipPublicKeyDownload: true, CheckForPluginUpdates: true}, nil)
+		require.True(t, kr.IsDisabled())
+	})
+
+	t.Run("disabled when CheckForPluginUpdates is false", func(t *testing.T) {
+		kr := ProvideService(&setting.Cfg{PluginSkipPublicKeyDownload: false, CheckForPluginUpdates: false}, nil)
+		require.True(t, kr.IsDisabled())
+	})
+
+	t.Run("enabled when both flags allow it", func(t *testing.T) {
+		kr := ProvideService(&setting.Cfg{PluginSkipPublicKeyDownload: false, CheckForPluginUpdates: true}, nil)
+		require.False(t, kr.IsDisabled())
+	})
+}
+
 func Test_PublicKeyUpdate(t *testing.T) {
 	t.Run("it should retrieve an API key", func(t *testing.T) {
 		cfg := &setting.Cfg{}


### PR DESCRIPTION
## What does this PR do?

Adds a documentation cross-reference in `conf/defaults.ini` near `check_for_plugin_updates` pointing users to `public_key_retrieval_disabled` — the correct setting for disabling dynamic plugin signing key retrieval in air-gapped or egress-restricted environments.

## Why?

Users in restricted environments sometimes assume `check_for_plugin_updates = false` will also stop the dynamic key downloader from making outbound calls. It does not — `check_for_plugin_updates` is scoped only to plugin update checks. The existing `public_key_retrieval_disabled` setting already handles this case, but it's not easy to discover. This change makes the relationship explicit in the config reference.

## Changes

- `conf/defaults.ini`: adds a comment above `check_for_plugin_updates` pointing to `public_key_retrieval_disabled` for users who want to disable dynamic key retrieval