### PR TITLE
alerting: fix ORM table mapping bug causing SELECT alert_rule columns FROM user on PostgreSQL

### DIFF
--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -605,7 +605,7 @@ func (st DBstore) UpdateAlertRules(ctx context.Context, user *ngmodels.UserUID, 
 				return fmt.Errorf("failed to convert alert rule %s to storage model: %w", r.New.UID, err)
 			}
 			// no way to update multiple rules at once
-			if updated, err := sess.ID(r.Existing.ID).AllCols().Omit("rule_guid").Update(converted); err != nil || updated == 0 {
+			if updated, err := sess.Table(alertRule{}).ID(r.Existing.ID).AllCols().Omit("guid").Update(converted); err != nil || updated == 0 {
 				if err != nil {
 					if st.SQLStore.GetDialect().IsUniqueConstraintViolation(err) {
 						return ngmodels.ErrAlertRuleConflict(r.New.UID, r.New.OrgID, err)
@@ -707,7 +707,7 @@ func (st DBstore) preventIntermediateUniqueConstraintViolations(sess *db.Session
 			uniqueTempTitle = r.Title[:AlertRuleMaxTitleLength-len(u)] + uuid.New().String()
 		}
 
-		if updated, err := sess.ID(r.ID).Cols("title").Update(&alertRule{Title: uniqueTempTitle, Version: r.Version}); err != nil || updated == 0 {
+		if updated, err := sess.Table(alertRule{}).ID(r.ID).Cols("title").Update(&alertRule{Title: uniqueTempTitle, Version: r.Version}); err != nil || updated == 0 {
 			if err != nil {
 				return fmt.Errorf("failed to set temporary rule title [%s] %s: %w", r.UID, r.Title, err)
 			}

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -303,6 +303,45 @@ func TestIntegrationUpdateAlertRules(t *testing.T) {
 		require.NotEmpty(t, updatedRule.FolderFullpath, "FolderFullpath should be populated")
 		assert.Equal(t, folderBTitle, updatedRule.FolderFullpath, "FolderFullpath should be updated to Folder B")
 	})
+
+	t.Run("should preserve guid and use correct table when called inside an outer transaction", func(t *testing.T) {
+		// Regression test for the ORM table inference bug where UpdateAlertRules was
+		// called from callers (UpdateRuleGroup, UpdateAlertRule) that already hold an
+		// outer InTransaction session on the context. A prior query on that shared
+		// session could leave xorm's table state pointing at the wrong model,
+		// causing "SELECT alert_rule columns FROM user" on PostgreSQL.
+		rule := createRule(t, store, gen)
+		require.NotEmpty(t, rule.GUID, "rule must have a guid after insert")
+		originalGUID := rule.GUID
+
+		newRule := models.CopyRule(rule)
+		newRule.Title = util.GenerateShortUID()
+
+		err := sqlStore.InTransaction(context.Background(), func(ctx context.Context) error {
+			// Simulate a prior query on the shared session using a different table,
+			// as would happen when the folder service or provenance store runs on
+			// the same transaction context before UpdateAlertRules is called.
+			_ = sqlStore.WithDbSession(ctx, func(sess *db.Session) error {
+				_, _ = sess.Table("alert_rule_version").Where("1=0").Count()
+				return nil
+			})
+			return store.UpdateAlertRules(ctx, &usr, []models.UpdateRule{{
+				Existing: rule,
+				New:      *newRule,
+			}})
+		})
+		require.NoError(t, err)
+
+		dbrule := &alertRule{}
+		err = sqlStore.WithDbSession(context.Background(), func(sess *db.Session) error {
+			exist, err := sess.Table(alertRule{}).ID(rule.ID).Get(dbrule)
+			require.Truef(t, exist, "rule with ID %d not found after update", rule.ID)
+			return err
+		})
+		require.NoError(t, err)
+		require.Equal(t, originalGUID, dbrule.GUID, "guid must not change on update — it is an immutable identifier")
+		require.Equal(t, newRule.Title, dbrule.Title)
+	})
 }
 
 func TestIntegration_GetAlertRulesForScheduling(t *testing.T) {


### PR DESCRIPTION
## What's the problem?

Fixes #124930.

On PostgreSQL, alert rule provisioning fails on startup with:

```
pq: column "guid" does not exist
pq: current transaction is aborted, commands ignored until end of transaction block
```

The root cause is two bugs introduced when the `guid` column was added to `alert_rule` (PR #101469):

**Bug 1 — Wrong `Omit` column name:**
`UpdateAlertRules` calls `.Omit("rule_guid")` to prevent the immutable `guid` field from being overwritten. But the xorm column name for that field is `"guid"` (tagged `xorm:"guid"`), not `"rule_guid"` (that's in `alertRuleVersion`). So the Omit is a no-op and `guid` was silently included in every UPDATE — setting it to whatever was in memory rather than the stored value.

**Bug 2 — No explicit table binding:**
Both UPDATE calls in `UpdateAlertRules` and `preventIntermediateUniqueConstraintViolations` chain `.ID()` before the bean is passed to `.Update()`. Without an explicit `.Table()`, xorm must infer the table name from the bean — which works under normal circumstances but can break under shared session reuse (when an outer `InTransaction` context is passed in by callers like `UpdateRuleGroup` or `UpdateAlertRule`). Adding `.Table(alertRule{})` pins the table explicitly and eliminates any ambiguity.

## What changed?

- `Omit("rule_guid")` → `Omit("guid")` so the actual `guid` column is protected from updates
- Added explicit `.Table(alertRule{})` to both UPDATE calls so xorm cannot pick up the wrong table from session state

## How to test

1. Deploy Grafana v13.0.1 against PostgreSQL/Aurora
2. Provision alert rules via a Kubernetes ConfigMap
3. Restart Grafana — rules should provision cleanly without `column "guid" does not exist` errors