### PR TITLE
Meticulous: Introduce flag to control production mode for increased collection

### DIFF
--- a/devenv/frontend-service/goff-flags.yaml
+++ b/devenv/frontend-service/goff-flags.yaml
@@ -32,3 +32,10 @@ grafana.meticulousAIRecorder:
     disabled: false
   defaultRule:
     variation: disabled
+
+grafana.meticulousAIRecorderHighVolume:
+  variations:
+    enabled: true
+    disabled: false
+  defaultRule:
+    variation: disabled

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -3076,6 +3076,15 @@ var (
 			Generate:     Generate{Go: true},
 		},
 		{
+			Name:         "grafana.meticulousAIRecorderHighVolume",
+			Description:  "When true, increases the volume of data transferred before abandoning sessions for Meticulous AI session recorder.",
+			Stage:        FeatureStageExperimental,
+			Owner:        grafanaDatavizSquad,
+			Expression:   "false",
+			HideFromDocs: true,
+			Generate:     Generate{Go: true},
+		},
+		{
 			Name:        "datasources.useNewStackInfoToSettingsCache",
 			Description: "Use the new cache for datasource.StackInfoToSettings, backend flag",
 			Stage:       FeatureStageGeneralAvailability,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -358,6 +358,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-04-23,assistant.frontend.tools.dashboardTemplates,experimental,@grafana/sharing-squad,false,false,true
 2026-04-27,grafana.correlationsSkipLegacy,experimental,@grafana/datapro,false,false,false
 2026-04-28,grafana.meticulousAIRecorder,experimental,@grafana/dataviz-squad,false,false,false
+2026-05-14,grafana.meticulousAIRecorderHighVolume,experimental,@grafana/dataviz-squad,false,false,false
 2026-04-30,datasources.useNewStackInfoToSettingsCache,GA,@grafana/grafana-datasources-core-services,false,false,false
 2026-05-06,grafana.unifiedHomepage,experimental,@grafana/grafana-frontend-navigation,false,false,true
 2026-05-06,preferences.rerouteLegacyAPIs,experimental,@grafana/grafana-frontend-platform,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -954,6 +954,10 @@ const (
 	// Enable Meticulous AI session recorder for automated UI test generation
 	FlagGrafanaMeticulousAIRecorder = "grafana.meticulousAIRecorder"
 
+	// FlagGrafanaMeticulousAIRecorderHighVolume
+	// When true, increases the volume of data transferred before abandoning sessions for Meticulous AI session recorder.
+	FlagGrafanaMeticulousAIRecorderHighVolume = "grafana.meticulousAIRecorderHighVolume"
+
 	// FlagDatasourcesUseNewStackInfoToSettingsCache
 	// Use the new cache for datasource.StackInfoToSettings, backend flag
 	FlagDatasourcesUseNewStackInfoToSettingsCache = "datasources.useNewStackInfoToSettingsCache"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2783,6 +2783,20 @@
     },
     {
       "metadata": {
+        "name": "grafana.meticulousAIRecorderHighVolume",
+        "resourceVersion": "1778789600371",
+        "creationTimestamp": "2026-05-14T20:13:20Z"
+      },
+      "spec": {
+        "description": "When true, increases the volume of data transferred before abandoning sessions for Meticulous AI session recorder.",
+        "stage": "experimental",
+        "codeowner": "@grafana/dataviz-squad",
+        "hideFromDocs": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "grafana.newPreferencesPage",
         "resourceVersion": "1775304981849",
         "creationTimestamp": "2026-04-04T12:16:21Z"

--- a/pkg/services/frontend/index.go
+++ b/pkg/services/frontend/index.go
@@ -52,8 +52,10 @@ type IndexViewData struct {
 	// Feature flag for image-renderer to check support for binding calls
 	RenderBindingSupported bool
 
-	MeticulousAIEnabled        bool
-	MeticulousAIRecordingToken string
+	// Options for controlling the inclusion and behavior of the Meticulous AI session recorder script.
+	MeticulousAIEnabled                   bool
+	MeticulousAIRecordingToken            string
+	MeticulousAIProductionEnvironmentFlag bool
 
 	BootScript template.JS
 
@@ -130,20 +132,22 @@ func (p *IndexProvider) HandleRequest(writer http.ResponseWriter, request *http.
 	compiledBootScript, _ := ofClient.BooleanValue(ctx, featuremgmt.FlagCompiledBootScript, false, openfeature.TransactionContext(ctx))
 	grafanaAssetSriChecks, _ := ofClient.BooleanValue(ctx, featuremgmt.FlagGrafanaAssetSriChecks, false, openfeature.TransactionContext(ctx))
 	meticulousAIRecorderEnabled, _ := ofClient.BooleanValue(ctx, featuremgmt.FlagGrafanaMeticulousAIRecorder, false, openfeature.TransactionContext(ctx))
+	meticulousAIRecorderHighVolume, _ := ofClient.BooleanValue(ctx, featuremgmt.FlagGrafanaMeticulousAIRecorderHighVolume, false, openfeature.TransactionContext(ctx))
 
 	data := IndexViewData{
-		AppTitle:                   "Grafana",
-		AppSubUrl:                  p.config.AppSubURL,
-		IsDevelopmentEnv:           p.config.Env == setting.Dev,
-		Assets:                     assetsManifest,
-		DefaultUser:                dtos.CurrentUser{},
-		Nonce:                      reqCtx.RequestNonce,
-		PublicDashboardAccessToken: reqCtx.PublicDashboardAccessToken,
-		Settings:                   fsSettings,
-		RenderBindingSupported:     renderBindingSupported,
-		AssetSriChecksEnabled:      grafanaAssetSriChecks,
-		MeticulousAIEnabled:        meticulousAIRecorderEnabled,
-		MeticulousAIRecordingToken: p.config.MeticulousAIRecordingToken,
+		AppTitle:                              "Grafana",
+		AppSubUrl:                             p.config.AppSubURL,
+		IsDevelopmentEnv:                      p.config.Env == setting.Dev,
+		Assets:                                assetsManifest,
+		DefaultUser:                           dtos.CurrentUser{},
+		Nonce:                                 reqCtx.RequestNonce,
+		PublicDashboardAccessToken:            reqCtx.PublicDashboardAccessToken,
+		Settings:                              fsSettings,
+		RenderBindingSupported:                renderBindingSupported,
+		AssetSriChecksEnabled:                 grafanaAssetSriChecks,
+		MeticulousAIEnabled:                   meticulousAIRecorderEnabled,
+		MeticulousAIRecordingToken:            p.config.MeticulousAIRecordingToken,
+		MeticulousAIProductionEnvironmentFlag: meticulousAIRecorderHighVolume != true,
 	}
 
 	if compiledBootScript {

--- a/pkg/services/frontend/index.go
+++ b/pkg/services/frontend/index.go
@@ -147,7 +147,7 @@ func (p *IndexProvider) HandleRequest(writer http.ResponseWriter, request *http.
 		AssetSriChecksEnabled:                 grafanaAssetSriChecks,
 		MeticulousAIEnabled:                   meticulousAIRecorderEnabled,
 		MeticulousAIRecordingToken:            p.config.MeticulousAIRecordingToken,
-		MeticulousAIProductionEnvironmentFlag: meticulousAIRecorderHighVolume != true,
+		MeticulousAIProductionEnvironmentFlag: !meticulousAIRecorderHighVolume,
 	}
 
 	if compiledBootScript {

--- a/pkg/services/frontend/index.html
+++ b/pkg/services/frontend/index.html
@@ -12,7 +12,7 @@
 
     [[if .MeticulousAIEnabled]]
     <script
-      data-is-production-environment="true"
+      data-is-production-environment="[[.MeticulousAIProductionEnvironmentFlag]]"
       data-recording-token="[[.MeticulousAIRecordingToken]]"
       nonce="[[.Nonce]]"
       src="https://snippet.meticulous.ai/v1/meticulous.js"


### PR DESCRIPTION
### Summary

- introduce a new feature toggle, `grafana.meticulousAIRecorderHighVolume`, which is intended to instruct frontend-service instances whether to enable Meticulous at a higher volume of data collection
- connect the toggle to frontend-service

### Background

Looking at the sessions coming into Meticulous at the moment, most are exited quite early because the production mode behavior is to abandon recording after collecting 1MB of network traffic, which in our case can happen really fast. See https://app.meticulous.ai/docs/how-to/troubleshoot-recorder#i-see-a-warning-about-high-abandon-rate.

The alternative mode goes up to 20MB, which feels a bit high to me, so rather than turn the switch on, I want to put it behind a flag to experiment with enabling it and have the ability to turn it back to 1MB remotely should we find that 20MB is too much.

We also gave the feedback to the Meticulous team that a more finegrained way to control this threshold would be appreciated; I feel like something more in the 5-10MB range is a goldilocks zone for us but it would take some experimentation. Abandoned sessions can ultimately be used for training still, but the sessions abandoned right now are just abandoned before a dashboard is even rendered in many cases because data payload can be quite large.