### PR TITLE
Plugins: Add grafana-dynamodb-datasource to forward_settings_to_plugins

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -1051,7 +1051,7 @@ session_duration = "15m"
 
 # Set the plugins that will receive AWS settings for each request (via plugin context)
 # By default this will include all Grafana Labs owned AWS plugins, or those that make use of AWS settings (ElasticSearch, Prometheus).
-forward_settings_to_plugins = cloudwatch, grafana-athena-datasource, grafana-redshift-datasource, grafana-x-ray-datasource, grafana-timestream-datasource, grafana-iot-sitewise-datasource, grafana-iot-twinmaker-datasource, grafana-opensearch-datasource, aws-datasource-provisioner, elasticsearch, prometheus, grafana-amazonprometheus-datasource, grafana-aurora-datasource
+forward_settings_to_plugins = cloudwatch, grafana-athena-datasource, grafana-redshift-datasource, grafana-x-ray-datasource, grafana-timestream-datasource, grafana-iot-sitewise-datasource, grafana-iot-twinmaker-datasource, grafana-opensearch-datasource, grafana-dynamodb-datasource, aws-datasource-provisioner, elasticsearch, prometheus, grafana-amazonprometheus-datasource, grafana-aurora-datasource
 
 #################################### Azure ###############################
 [azure]

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -998,7 +998,7 @@
 
 # Set the plugins that will receive AWS settings for each request (via plugin context)
 # By default this will include all Grafana Labs owned AWS plugins, or those that make use of AWS settings (ElasticSearch, Prometheus).
-; forward_settings_to_plugins = cloudwatch, grafana-athena-datasource, grafana-redshift-datasource, grafana-x-ray-datasource, grafana-timestream-datasource, grafana-iot-sitewise-datasource, grafana-iot-twinmaker-app, grafana-opensearch-datasource, aws-datasource-provisioner, elasticsearch, prometheus
+; forward_settings_to_plugins = cloudwatch, grafana-athena-datasource, grafana-redshift-datasource, grafana-x-ray-datasource, grafana-timestream-datasource, grafana-iot-sitewise-datasource, grafana-iot-twinmaker-datasource, grafana-opensearch-datasource, grafana-dynamodb-datasource, aws-datasource-provisioner, elasticsearch, prometheus, grafana-amazonprometheus-datasource, grafana-aurora-datasource
 
 #################################### Azure ###############################
 [azure]


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Updates the `conf/defaults.ini` `[aws.forward_settings_to_plugins]` setting to include `grafana-dynamodb-datasource` in the list. `conf/sample.ini` is updated so that it's in sync with the options that are defined in `conf/defaults.ini`.

**Why do we need this feature?**

The DynamoDB data source needs to receive Grafana's AWS auth settings so it can expose and use the Grafana Assume Role authentication option when that capability is enabled for the environment.

Grafana only forwards AWS auth settings to backend plugin requests when the plugin id is present in `forward_settings_to_plugins`: https://github.com/grafana/grafana/blob/bd743644e3bf8522dc435e3bbcfee53bd30d6261/pkg/services/pluginsintegration/pluginconfig/request.go#L64-L78

The Grafana Assume Role relevant settings forwarded there are `AWS_AUTH_AllowedAuthProviders`, which must include `grafana_assume_role`, and `AWS_AUTH_EXTERNAL_ID`.

Without adding `grafana-dynamodb-datasource` to `forward_settings_to_plugins`, the plugin does not receive the forwarded AWS settings and falls back to the default allowed auth providers, which excludes `grafana_assume_role`.

**Who is this feature for?**

Grafana Cloud users configuring the DynamoDB data source with Grafana-managed AWS Assume Role authentication.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

This PR only updates the AWS settings forwarding allow-list for DynamoDB and syncs `conf/sample.ini` with `conf/defaults.ini`.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
