### PR TITLE
plugins: fix silent failures and missing periodic loop in dynamic key retriever

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -326,6 +326,8 @@ check_for_updates = true
 # in some UI views to notify that a plugin update exists.
 # This option does not cause any auto updates, nor send any information
 # only a GET request to https://grafana.com to get the latest versions.
+# Setting this to false also disables dynamic plugin signing key retrieval
+# from the configured Grafana.com API URL.
 check_for_plugin_updates = true
 
 # Google Analytics universal tracking code, only enabled if you specify an id here

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -326,8 +326,6 @@ check_for_updates = true
 # in some UI views to notify that a plugin update exists.
 # This option does not cause any auto updates, nor send any information
 # only a GET request to https://grafana.com to get the latest versions.
-# Setting this to false also disables dynamic plugin signing key retrieval
-# from the configured Grafana.com API URL.
 check_for_plugin_updates = true
 
 # Google Analytics universal tracking code, only enabled if you specify an id here

--- a/pkg/services/pluginsintegration/keyretriever/dynamic/dynamic_retriever.go
+++ b/pkg/services/pluginsintegration/keyretriever/dynamic/dynamic_retriever.go
@@ -68,6 +68,7 @@ func (kr *KeyRetriever) Run(ctx context.Context) error {
 	// calculate initial send delay
 	lastUpdated, err := kr.kv.GetLastUpdated(ctx)
 	if err != nil {
+		kr.log.Error("Error reading last key update time", "error", err)
 		return err
 	}
 	nextSendInterval := time.Until(lastUpdated.Add(publicKeySyncInterval))
@@ -78,22 +79,22 @@ func (kr *KeyRetriever) Run(ctx context.Context) error {
 	downloadKeysTicker := time.NewTicker(nextSendInterval)
 	defer downloadKeysTicker.Stop()
 
-	select {
-	case <-downloadKeysTicker.C:
-		err = kr.updateKeys(ctx)
-		if err != nil {
-			kr.log.Error("Error downloading plugin manifest keys", "error", err)
-		}
+	for {
+		select {
+		case <-downloadKeysTicker.C:
+			err = kr.updateKeys(ctx)
+			if err != nil {
+				kr.log.Error("Error downloading plugin manifest keys", "error", err)
+			}
 
-		if nextSendInterval != publicKeySyncInterval {
-			nextSendInterval = publicKeySyncInterval
-			downloadKeysTicker.Reset(nextSendInterval)
+			if nextSendInterval != publicKeySyncInterval {
+				nextSendInterval = publicKeySyncInterval
+				downloadKeysTicker.Reset(nextSendInterval)
+			}
+		case <-ctx.Done():
+			return ctx.Err()
 		}
-	case <-ctx.Done():
-		return ctx.Err()
 	}
-
-	return ctx.Err()
 }
 
 func (kr *KeyRetriever) updateKeys(ctx context.Context) error {
@@ -188,12 +189,14 @@ func (kr *KeyRetriever) ensureKeys(ctx context.Context) error {
 	}
 	keys, err := kr.kv.ListKeys(ctx)
 	if err != nil {
+		kr.log.Error("Error listing plugin signing keys", "error", err)
 		return err
 	}
 	if len(keys) == 0 {
 		// Populate with the default key
 		err := kr.kv.Set(ctx, statickey.GetDefaultKeyID(), statickey.GetDefaultKey())
 		if err != nil {
+			kr.log.Error("Error storing default plugin signing key", "error", err)
 			return err
 		}
 	}

--- a/pkg/services/pluginsintegration/keyretriever/dynamic/dynamic_retriever.go
+++ b/pkg/services/pluginsintegration/keyretriever/dynamic/dynamic_retriever.go
@@ -52,8 +52,8 @@ func ProvideService(cfg *setting.Cfg, kv plugins.KeyStore) *KeyRetriever {
 
 // IsDisabled disables dynamic retrieval of public keys from the API server.
 // Also disabled when CheckForPluginUpdates is false, since both require outbound
-// connectivity to grafana.com. Plugin signature verification falls back to the
-// built-in static key when dynamic retrieval is disabled.
+// connectivity to the configured GrafanaComAPIURL. Plugin signature verification
+// falls back to the built-in static key when dynamic retrieval is disabled.
 func (kr *KeyRetriever) IsDisabled() bool {
 	return kr.cfg.PluginSkipPublicKeyDownload || !kr.cfg.CheckForPluginUpdates
 }

--- a/pkg/services/pluginsintegration/keyretriever/dynamic/dynamic_retriever.go
+++ b/pkg/services/pluginsintegration/keyretriever/dynamic/dynamic_retriever.go
@@ -51,8 +51,11 @@ func ProvideService(cfg *setting.Cfg, kv plugins.KeyStore) *KeyRetriever {
 }
 
 // IsDisabled disables dynamic retrieval of public keys from the API server.
+// Also disabled when CheckForPluginUpdates is false, since both require outbound
+// connectivity to grafana.com. Plugin signature verification falls back to the
+// built-in static key when dynamic retrieval is disabled.
 func (kr *KeyRetriever) IsDisabled() bool {
-	return kr.cfg.PluginSkipPublicKeyDownload
+	return kr.cfg.PluginSkipPublicKeyDownload || !kr.cfg.CheckForPluginUpdates
 }
 
 func (kr *KeyRetriever) Run(ctx context.Context) error {

--- a/pkg/services/pluginsintegration/keyretriever/dynamic/dynamic_retriever.go
+++ b/pkg/services/pluginsintegration/keyretriever/dynamic/dynamic_retriever.go
@@ -51,11 +51,8 @@ func ProvideService(cfg *setting.Cfg, kv plugins.KeyStore) *KeyRetriever {
 }
 
 // IsDisabled disables dynamic retrieval of public keys from the API server.
-// Also disabled when CheckForPluginUpdates is false, since both require outbound
-// connectivity to the configured GrafanaComAPIURL. Plugin signature verification
-// falls back to the built-in static key when dynamic retrieval is disabled.
 func (kr *KeyRetriever) IsDisabled() bool {
-	return kr.cfg.PluginSkipPublicKeyDownload || !kr.cfg.CheckForPluginUpdates
+	return kr.cfg.PluginSkipPublicKeyDownload
 }
 
 func (kr *KeyRetriever) Run(ctx context.Context) error {

--- a/pkg/services/pluginsintegration/keyretriever/dynamic/dynamic_retriever_test.go
+++ b/pkg/services/pluginsintegration/keyretriever/dynamic/dynamic_retriever_test.go
@@ -105,17 +105,12 @@ func (e *errKeyStore) SetLastUpdated(ctx context.Context) error {
 
 func Test_IsDisabled(t *testing.T) {
 	t.Run("disabled when PluginSkipPublicKeyDownload is true", func(t *testing.T) {
-		kr := ProvideService(&setting.Cfg{PluginSkipPublicKeyDownload: true, CheckForPluginUpdates: true}, nil)
+		kr := ProvideService(&setting.Cfg{PluginSkipPublicKeyDownload: true}, nil)
 		require.True(t, kr.IsDisabled())
 	})
 
-	t.Run("disabled when CheckForPluginUpdates is false", func(t *testing.T) {
-		kr := ProvideService(&setting.Cfg{PluginSkipPublicKeyDownload: false, CheckForPluginUpdates: false}, nil)
-		require.True(t, kr.IsDisabled())
-	})
-
-	t.Run("enabled when both flags allow it", func(t *testing.T) {
-		kr := ProvideService(&setting.Cfg{PluginSkipPublicKeyDownload: false, CheckForPluginUpdates: true}, nil)
+	t.Run("enabled when PluginSkipPublicKeyDownload is false", func(t *testing.T) {
+		kr := ProvideService(&setting.Cfg{PluginSkipPublicKeyDownload: false}, nil)
 		require.False(t, kr.IsDisabled())
 	})
 }

--- a/pkg/services/pluginsintegration/keyretriever/dynamic/dynamic_retriever_test.go
+++ b/pkg/services/pluginsintegration/keyretriever/dynamic/dynamic_retriever_test.go
@@ -3,12 +3,14 @@ package dynamic
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/grafana/grafana/pkg/infra/kvstore"
+	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/keystore"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/stretchr/testify/require"
@@ -40,6 +42,67 @@ func setFakeAPIServer(t *testing.T, publicKey string, keyID string) (*httptest.S
 		done <- true
 	})), done
 }
+
+// errKeyStore is a minimal plugins.KeyStore that returns a fixed error from
+// GetLastUpdated and ListKeys, used to exercise error paths in Run and ensureKeys.
+type errKeyStore struct {
+	getLastUpdatedErr error
+	listKeysErr       error
+	setErr            error
+	inner             plugins.KeyStore
+}
+
+func (e *errKeyStore) Get(ctx context.Context, key string) (string, bool, error) {
+	if e.inner != nil {
+		return e.inner.Get(ctx, key)
+	}
+	return "", false, nil
+}
+
+func (e *errKeyStore) Set(ctx context.Context, key string, value any) error {
+	if e.setErr != nil {
+		return e.setErr
+	}
+	if e.inner != nil {
+		return e.inner.Set(ctx, key, value)
+	}
+	return nil
+}
+
+func (e *errKeyStore) Delete(ctx context.Context, key string) error {
+	if e.inner != nil {
+		return e.inner.Delete(ctx, key)
+	}
+	return nil
+}
+
+func (e *errKeyStore) ListKeys(ctx context.Context) ([]string, error) {
+	if e.listKeysErr != nil {
+		return nil, e.listKeysErr
+	}
+	if e.inner != nil {
+		return e.inner.ListKeys(ctx)
+	}
+	return nil, nil
+}
+
+func (e *errKeyStore) GetLastUpdated(ctx context.Context) (time.Time, error) {
+	if e.getLastUpdatedErr != nil {
+		return time.Time{}, e.getLastUpdatedErr
+	}
+	if e.inner != nil {
+		return e.inner.GetLastUpdated(ctx)
+	}
+	return time.Time{}, nil
+}
+
+func (e *errKeyStore) SetLastUpdated(ctx context.Context) error {
+	if e.inner != nil {
+		return e.inner.SetLastUpdated(ctx)
+	}
+	return nil
+}
+
 func Test_IsDisabled(t *testing.T) {
 	t.Run("disabled when PluginSkipPublicKeyDownload is true", func(t *testing.T) {
 		kr := ProvideService(&setting.Cfg{PluginSkipPublicKeyDownload: true, CheckForPluginUpdates: true}, nil)
@@ -63,10 +126,11 @@ func Test_PublicKeyUpdate(t *testing.T) {
 		expectedKey := "fake"
 		s, done := setFakeAPIServer(t, expectedKey, "7e4d0c6a708866e7")
 		cfg.GrafanaComAPIURL = s.URL + "/api"
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 		v := ProvideService(cfg, keystore.ProvideService(kvstore.NewFakeKVStore()))
 		go func() {
-			err := v.Run(context.Background())
-			require.NoError(t, err)
+			_ = v.Run(ctx)
 		}()
 		<-done
 
@@ -84,10 +148,11 @@ func Test_PublicKeyUpdate(t *testing.T) {
 		expectedKey := "fake"
 		s, done := setFakeAPIServer(t, expectedKey, "7e4d0c6a708866e7")
 		cfg.GrafanaComAPIURL = s.URL + "/api"
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 		v := ProvideService(cfg, keystore.ProvideService(kvstore.NewFakeKVStore()))
 		go func() {
-			err := v.Run(context.Background())
-			require.NoError(t, err)
+			_ = v.Run(ctx)
 		}()
 		<-done
 
@@ -104,10 +169,11 @@ func Test_PublicKeyUpdate(t *testing.T) {
 		expectedKey := "fake"
 		s, done := setFakeAPIServer(t, expectedKey, "other")
 		cfg.GrafanaComAPIURL = s.URL + "/api"
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 		v := ProvideService(cfg, keystore.ProvideService(kvstore.NewFakeKVStore()))
 		go func() {
-			err := v.Run(context.Background())
-			require.NoError(t, err)
+			_ = v.Run(ctx)
 		}()
 		<-done
 
@@ -131,13 +197,14 @@ func Test_PublicKeyUpdate(t *testing.T) {
 		expectedKey := "fake"
 		s, done := setFakeAPIServer(t, expectedKey, "7e4d0c6a708866e7")
 		cfg.GrafanaComAPIURL = s.URL + "/api"
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 		v := ProvideService(cfg, keystore.ProvideService(kvstore.NewFakeKVStore()))
 		// Simulate an updated key
 		err := v.kv.SetLastUpdated(context.Background())
 		require.NoError(t, err)
 		go func() {
-			err := v.Run(context.Background())
-			require.NoError(t, err)
+			_ = v.Run(ctx)
 		}()
 		<-done
 
@@ -148,5 +215,49 @@ func Test_PublicKeyUpdate(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, true, found)
 		require.Equal(t, expectedKey, res)
+	})
+
+	t.Run("it should exit cleanly on context cancellation", func(t *testing.T) {
+		cfg := &setting.Cfg{}
+		s, done := setFakeAPIServer(t, "fake", "7e4d0c6a708866e7")
+		cfg.GrafanaComAPIURL = s.URL + "/api"
+		ctx, cancel := context.WithCancel(context.Background())
+		v := ProvideService(cfg, keystore.ProvideService(kvstore.NewFakeKVStore()))
+
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- v.Run(ctx)
+		}()
+		<-done
+		cancel()
+		err := <-errCh
+		require.ErrorIs(t, err, context.Canceled)
+	})
+
+	t.Run("it should return error when key store is unavailable on startup", func(t *testing.T) {
+		cfg := &setting.Cfg{}
+		storeErr := errors.New("store unavailable")
+		v := ProvideService(cfg, &errKeyStore{getLastUpdatedErr: storeErr})
+		err := v.Run(context.Background())
+		require.ErrorIs(t, err, storeErr)
+	})
+}
+
+func Test_EnsureKeys(t *testing.T) {
+	t.Run("it should return error when listing keys fails", func(t *testing.T) {
+		cfg := &setting.Cfg{}
+		storeErr := errors.New("list error")
+		v := ProvideService(cfg, &errKeyStore{listKeysErr: storeErr})
+		err := v.ensureKeys(context.Background())
+		require.ErrorIs(t, err, storeErr)
+	})
+
+	t.Run("it should return error when storing default key fails", func(t *testing.T) {
+		cfg := &setting.Cfg{}
+		storeErr := errors.New("set error")
+		// listKeysErr is nil so ListKeys returns empty slice, triggering the Set path
+		v := ProvideService(cfg, &errKeyStore{setErr: storeErr})
+		err := v.ensureKeys(context.Background())
+		require.ErrorIs(t, err, storeErr)
 	})
 }

--- a/pkg/services/pluginsintegration/keyretriever/dynamic/dynamic_retriever_test.go
+++ b/pkg/services/pluginsintegration/keyretriever/dynamic/dynamic_retriever_test.go
@@ -40,6 +40,23 @@ func setFakeAPIServer(t *testing.T, publicKey string, keyID string) (*httptest.S
 		done <- true
 	})), done
 }
+func Test_IsDisabled(t *testing.T) {
+	t.Run("disabled when PluginSkipPublicKeyDownload is true", func(t *testing.T) {
+		kr := ProvideService(&setting.Cfg{PluginSkipPublicKeyDownload: true, CheckForPluginUpdates: true}, nil)
+		require.True(t, kr.IsDisabled())
+	})
+
+	t.Run("disabled when CheckForPluginUpdates is false", func(t *testing.T) {
+		kr := ProvideService(&setting.Cfg{PluginSkipPublicKeyDownload: false, CheckForPluginUpdates: false}, nil)
+		require.True(t, kr.IsDisabled())
+	})
+
+	t.Run("enabled when both flags allow it", func(t *testing.T) {
+		kr := ProvideService(&setting.Cfg{PluginSkipPublicKeyDownload: false, CheckForPluginUpdates: true}, nil)
+		require.False(t, kr.IsDisabled())
+	})
+}
+
 func Test_PublicKeyUpdate(t *testing.T) {
 	t.Run("it should retrieve an API key", func(t *testing.T) {
 		cfg := &setting.Cfg{}


### PR DESCRIPTION
## Problem

Fixes #124005

Three issues in `pkg/services/pluginsintegration/keyretriever/dynamic/dynamic_retriever.go`:

1. **Periodic sync stopped after first tick.** `Run()` had a bare `select` with no `for` loop, so the key sync background service exited after the initial interval instead of refreshing keys every 10 days.

2. **`GetLastUpdated` failure caused a silent exit.** The error was returned with no log line, so the only signal was the background service dying with no context.

3. **`ensureKeys` failures were invisible.** `ListKeys` and `Set` errors were returned to the caller without any log output, making it impossible to diagnose why plugin signature verification was failing.

## Fix

- Wrap the ticker `select` in a `for` loop so periodic syncs keep running until context cancellation.
- Log the `GetLastUpdated` error in `Run()` before returning it.
- Log `ListKeys` and `Set` errors in `ensureKeys()` before returning them.

## Tests

- Updated existing tests to use cancelable contexts (required now that `Run()` loops indefinitely).
- Added `it_should_exit_cleanly_on_context_cancellation` to verify `Run()` returns `context.Canceled` on shutdown.
- Added `it_should_return_error_when_key_store_is_unavailable_on_startup` to cover the `GetLastUpdated` error path.
- Added `Test_EnsureKeys` with subtests for `ListKeys` and `Set` failure paths.