### PR TITLE
Docs: remove Fedora repo sslcacert path

### DIFF
--- a/docs/sources/setup-grafana/installation/redhat-rhel-fedora/index.md
+++ b/docs/sources/setup-grafana/installation/redhat-rhel-fedora/index.md
@@ -60,7 +60,6 @@ If you wish to install beta versions of Grafana, substitute the repository URL f
    gpgcheck=1
    gpgkey=https://rpm.grafana.com/gpg.key
    sslverify=1
-   sslcacert=/etc/pki/tls/certs/ca-bundle.crt
    ```
 
 1. To install Grafana OSS, run the following command:


### PR DESCRIPTION
Remove the hard-coded `sslcacert=/etc/pki/tls/certs/ca-bundle.crt` line from the RHEL/Fedora repository example so DNF uses the system CA configuration. This avoids a broken path on Fedora Rawhide while preserving TLS verification with `sslverify=1`.

Fixes #109365

Validation: `git diff --check`