### PR TITLE
Alerting: fix "Show more" requiring multiple clicks in grouped view

### DIFF
--- a/public/app/features/alerting/unified/rule-list/hooks/useLazyLoadPrometheusGroups.tsx
+++ b/public/app/features/alerting/unified/rule-list/hooks/useLazyLoadPrometheusGroups.tsx
@@ -20,7 +20,7 @@ export function useLazyLoadPrometheusGroups<TGroup extends PromRuleGroupDTO>(
   filter?: (group: TGroup) => boolean
 ) {
   const [groups, setGroups] = useState<TGroup[]>([]);
-  const [hasMoreGroups, setHasMoreGroups] = useState<boolean>(true);
+  const [hasMoreGroups, setHasMoreGroups] = useState<boolean>(false);
 
   const [{ execute: fetchMoreGroups }, groupsRequestState] = useAsync(async () => {
     let done = false;
@@ -41,10 +41,7 @@ export function useLazyLoadPrometheusGroups<TGroup extends PromRuleGroupDTO>(
       currentGroups.push(group);
     }
 
-    if (done) {
-      setHasMoreGroups(false);
-    }
-
+    setHasMoreGroups(!done);
     setGroups((groups) => groups.concat(currentGroups));
   });
 


### PR DESCRIPTION
## What

Fixes #124836

## Root cause

`hasMoreGroups` was initialized to `true` in `useLazyLoadPrometheusGroups`, which caused the "Show more" button to render in an enabled state before the initial data fetch even started (`status = 'not-executed'`, so `isLoading = false`).

There is a brief window between the first render and `useEffectOnce` firing where the button is clickable. A click in that window sends two concurrent consumers against the same generator: one from the user click and one from `useEffectOnce`. Both calls consume from the shared generator interleaved, and because `useAsync`'s race-condition guard only protects the status state update (not the internal `setGroups`/`setHasMoreGroups` calls), the first click can complete with zero visible new groups while the second fetch call proceeds normally.

## Fix

- Initialize `hasMoreGroups` to `false` so the button does not render until we have confirmation that more data exists.
- Replace the conditional `if (done) { setHasMoreGroups(false) }` with a single unconditional `setHasMoreGroups(!done)` after every fetch, making the state transition explicit in both directions.

The button now only appears after the first successful load that did not exhaust the generator, eliminating the pre-load enabled window and the concurrent-call race condition.

## Testing

All existing GroupedView and PaginatedGrafanaLoader tests pass without modification.