### PR TITLE
logsModel: improve logs stability when bad data is passed

### DIFF
--- a/public/app/features/logs/logsModel.test.ts
+++ b/public/app/features/logs/logsModel.test.ts
@@ -1395,6 +1395,51 @@ describe('logSeriesToLogsModel', () => {
     ]);
   });
 
+  it('should not produce undefined uid or timeEpochNs when id and tsNs fields have empty value arrays', () => {
+    const logSeries: DataFrame[] = [
+      createDataFrame({
+        fields: [
+          {
+            name: 'time',
+            type: FieldType.time,
+            values: ['2019-04-26T09:28:11.352440161Z', '2019-04-26T14:42:50.991981292Z'],
+          },
+          {
+            name: 'message',
+            type: FieldType.string,
+            values: ['log line 1', 'log line 2'],
+          },
+          {
+            name: 'id',
+            type: FieldType.string,
+            values: [],
+          },
+          {
+            name: 'tsNs',
+            type: FieldType.string,
+            values: [],
+          },
+        ],
+        refId: 'A',
+      }),
+    ];
+
+    const logsModel = logSeriesToLogsModel(logSeries);
+    expect(logsModel?.rows).toHaveLength(2);
+
+    for (const row of logsModel!.rows) {
+      expect(row.uid).not.toBeUndefined();
+      expect(row.uid).not.toContain('undefined');
+      expect(row.timeEpochNs).not.toBeUndefined();
+      expect(row.rowId).toBeUndefined();
+    }
+
+    expect(logsModel!.rows[0].uid).toBe('A_0');
+    expect(logsModel!.rows[1].uid).toBe('A_1');
+    expect(logsModel!.rows[0].timeEpochNs).toBe('1556270891352000000');
+    expect(logsModel!.rows[1].timeEpochNs).toBe('1556289770991000000');
+  });
+
   it('should return empty string if message field is undefined', () => {
     const logSeries: DataFrame[] = [
       toDataFrame({

--- a/public/app/features/logs/logsModel.ts
+++ b/public/app/features/logs/logsModel.ts
@@ -448,12 +448,12 @@ export function logSeriesToLogsModel(
         raw: message,
         labels: labels || {},
         // prepend refId to uid to make it unique across all series in a case when series contain duplicates
-        uid: `${series.refId}_${idField ? idField.values[j] : j.toString()}`,
+        uid: `${series.refId}_${idField?.values[j] ? idField.values[j] : j.toString()}`,
         datasourceType,
         datasourceUid,
       };
 
-      if (idField !== null) {
+      if (idField?.values[j]) {
         row.rowId = idField.values[j];
       }
 

--- a/public/app/features/logs/logsModel.ts
+++ b/public/app/features/logs/logsModel.ts
@@ -326,7 +326,7 @@ function parseTime(
   const time = toUtc(ts);
   const timeEpochMs = time.valueOf();
 
-  if (timeNsField) {
+  if (timeNsField?.values[index]) {
     return { ts, timeEpochMs, timeEpochNs: timeNsField.values[index] };
   }
 


### PR DESCRIPTION
This PR updates logsModel to better handle situations where undefined data is fed to Grafana:

<img width="195" height="211" alt="error" src="https://github.com/user-attachments/assets/6530765c-ddcd-4459-9cd1-2abffbbfc1e4" />

Regression test:

<img width="868" height="253" alt="imagen" src="https://github.com/user-attachments/assets/4a69d113-6379-4d60-939f-5203e0c09dea" />
