### PR TITLE
Docker: Add 'slim' and 'distroless' options

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ FROM alpine:3.23.4 AS alpine-base
 FROM ubuntu:24.04 AS ubuntu-base
 FROM golang:1.26.3-alpine AS go-builder-base
 FROM --platform=${JS_PLATFORM} node:24-alpine AS js-builder-base
+FROM gcr.io/distroless/static-debian12 AS distroless-base
 # Javascript build stage
 FROM --platform=${JS_PLATFORM} ${JS_IMAGE} AS js-builder
 ARG JS_NODE_ENV=production
@@ -125,6 +126,57 @@ RUN mkdir -p data/plugins-bundled
 FROM ${GO_SRC} AS go-src
 FROM ${JS_SRC} AS js-src
 
+# Intermediate filesystem setup for the distroless target.
+# Uses an Alpine shell to create directories, users, and config files
+# since distroless has no shell. No network access required.
+FROM alpine-base AS distroless-prep
+
+ARG GF_UID="472"
+ARG GF_GID="0"
+
+ENV PATH="/usr/share/grafana/bin:$PATH" \
+  GF_PATHS_CONFIG="/etc/grafana/grafana.ini" \
+  GF_PATHS_DATA="/var/lib/grafana" \
+  GF_PATHS_HOME="/usr/share/grafana" \
+  GF_PATHS_LOGS="/var/log/grafana" \
+  GF_PATHS_PLUGINS="/var/lib/grafana/plugins" \
+  GF_PATHS_PROVISIONING="/etc/grafana/provisioning"
+
+WORKDIR $GF_PATHS_HOME
+
+COPY --from=go-src /tmp/grafana/conf ./conf
+COPY --from=go-src /tmp/grafana/bin/grafana* /tmp/grafana/bin/*/grafana* ./bin/
+
+RUN if [ ! "$(getent group "$GF_GID")" ]; then \
+  addgroup -S -g $GF_GID grafana; \
+  fi && \
+  GF_GID_NAME=$(getent group $GF_GID | cut -d':' -f1) && \
+  mkdir -p "$GF_PATHS_HOME/.aws" \
+  "$GF_PATHS_PROVISIONING/datasources" \
+  "$GF_PATHS_PROVISIONING/dashboards" \
+  "$GF_PATHS_PROVISIONING/notifiers" \
+  "$GF_PATHS_PROVISIONING/plugins" \
+  "$GF_PATHS_PROVISIONING/access-control" \
+  "$GF_PATHS_PROVISIONING/alerting" \
+  "$GF_PATHS_LOGS" \
+  "$GF_PATHS_PLUGINS" \
+  "$GF_PATHS_HOME/data/plugins-bundled" \
+  "$GF_PATHS_DATA" \
+  /etc/grafana && \
+  adduser -S -u $GF_UID -G "$GF_GID_NAME" grafana && \
+  cp conf/sample.ini "$GF_PATHS_CONFIG" && \
+  cp conf/ldap.toml /etc/grafana/ldap.toml && \
+  chown -R "grafana:$GF_GID_NAME" "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING" "$GF_PATHS_HOME/data/plugins-bundled" && \
+  chmod -R 777 "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING" "$GF_PATHS_HOME/data/plugins-bundled" && \
+  printf 'root:x:0:0:root:/root:/sbin/nologin\nnobody:x:65534:65534:nobody:/nonexistent:/sbin/nologin\ngrafana:x:%s:0::/usr/share/grafana:/sbin/nologin\n' "$GF_UID" > /tmp/distroless-passwd && \
+  printf 'root:x:0:\nnobody:x:65534:\n' > /tmp/distroless-group && \
+  grafana server --homepath="$GF_PATHS_HOME" -v | sed -e 's/Version //' > /.grafana-version && \
+  chmod 644 /.grafana-version
+
+ARG SLIM=false
+RUN --mount=type=bind,from=go-src,source=/tmp/grafana/data/plugins-bundled,target=/mnt/plugins-bundled \
+  [ "$SLIM" = "true" ] || cp -a /mnt/plugins-bundled/. "$GF_PATHS_HOME/data/plugins-bundled/"
+
 # Alpine final stage
 FROM alpine-base AS final-alpine
 
@@ -190,10 +242,13 @@ RUN if [ ! "$(getent group "$GF_GID")" ]; then \
 COPY --from=go-src /tmp/grafana/bin/grafana* /tmp/grafana/bin/*/grafana* ./bin/
 COPY --from=js-src /tmp/grafana/public ./public
 COPY --from=js-src /tmp/grafana/LICENSE ./
-COPY --from=go-src /tmp/grafana/data/plugins-bundled ./data/plugins-bundled
 
 RUN grafana server -v | sed -e 's/Version //' > /.grafana-version
 RUN chmod 644 /.grafana-version
+
+ARG SLIM=false
+RUN --mount=type=bind,from=go-src,source=/tmp/grafana/data/plugins-bundled,target=/mnt/plugins-bundled \
+  [ "$SLIM" = "true" ] || cp -a /mnt/plugins-bundled/. ./data/plugins-bundled/
 
 EXPOSE 3000
 
@@ -254,10 +309,13 @@ RUN if [ ! "$(getent group "$GF_GID")" ]; then \
 COPY --from=go-src /tmp/grafana/bin/grafana* /tmp/grafana/bin/*/grafana* ./bin/
 COPY --from=js-src /tmp/grafana/public ./public
 COPY --from=js-src /tmp/grafana/LICENSE ./
-COPY --from=go-src /tmp/grafana/data/plugins-bundled ./data/plugins-bundled
 
 RUN grafana server -v | sed -e 's/Version //' > /.grafana-version
 RUN chmod 644 /.grafana-version
+
+ARG SLIM=false
+RUN --mount=type=bind,from=go-src,source=/tmp/grafana/data/plugins-bundled,target=/mnt/plugins-bundled \
+  [ "$SLIM" = "true" ] || cp -a /mnt/plugins-bundled/. ./data/plugins-bundled/
 
 EXPOSE 3000
 
@@ -267,6 +325,53 @@ COPY ${RUN_SH} /run.sh
 
 USER "$GF_UID"
 ENTRYPOINT [ "/run.sh" ]
+
+# Distroless final stage — use --target=final-distroless to select this variant.
+# No shell, no package manager, no OS utilities: significantly reduces CVE surface.
+# Requires a static binary (CGO_ENABLED=0). The run.sh entrypoint is replaced by a
+# direct grafana server invocation, so these run.sh features are unavailable:
+#   - GF_*__FILE secret expansion
+#   - AWS credential file generation from GF_AWS_* env vars
+#   - GF_INSTALL_PLUGINS (deprecated; use GF_PLUGINS_PREINSTALL instead)
+#
+# Filesystem layout (dirs, users, config) is prepared by distroless-prep and
+# binaries/assets are copied directly from go-src/js-src. No Alpine OS packages,
+# libraries, or network downloads are included.
+FROM distroless-base AS final-distroless
+
+LABEL maintainer="Grafana Labs <hello@grafana.com>"
+LABEL org.opencontainers.image.source="https://github.com/grafana/grafana"
+
+ARG GF_UID="472"
+
+ENV PATH="/usr/share/grafana/bin:$PATH" \
+  GF_PATHS_CONFIG="/etc/grafana/grafana.ini" \
+  GF_PATHS_DATA="/var/lib/grafana" \
+  GF_PATHS_HOME="/usr/share/grafana" \
+  GF_PATHS_LOGS="/var/log/grafana" \
+  GF_PATHS_PLUGINS="/var/lib/grafana/plugins" \
+  GF_PATHS_PROVISIONING="/etc/grafana/provisioning"
+
+WORKDIR $GF_PATHS_HOME
+
+COPY --from=distroless-prep /tmp/distroless-passwd /etc/passwd
+COPY --from=distroless-prep /tmp/distroless-group /etc/group
+COPY --from=distroless-prep /etc/grafana /etc/grafana
+COPY --chown=472:0 --from=distroless-prep /var/lib/grafana /var/lib/grafana
+COPY --chown=472:0 --from=distroless-prep /var/log/grafana /var/log/grafana
+COPY --from=distroless-prep /usr/share/grafana/conf /usr/share/grafana/conf
+COPY --chown=472:0 --from=distroless-prep /usr/share/grafana/.aws /usr/share/grafana/.aws
+COPY --chown=472:0 --from=distroless-prep /usr/share/grafana/data /usr/share/grafana/data
+COPY --from=distroless-prep /.grafana-version /.grafana-version
+COPY --chown=472:0 --from=go-src /tmp/grafana/bin/grafana* /tmp/grafana/bin/*/grafana* ./bin/
+COPY --from=js-src /tmp/grafana/public ./public
+COPY --from=js-src /tmp/grafana/LICENSE ./
+
+EXPOSE 3000
+
+USER $GF_UID
+
+ENTRYPOINT ["/usr/share/grafana/bin/grafana", "server", "--homepath=/usr/share/grafana", "--config=/etc/grafana/grafana.ini", "--packaging=docker", "cfg:default.log.mode=console", "cfg:default.paths.data=/var/lib/grafana", "cfg:default.paths.logs=/var/log/grafana", "cfg:default.paths.plugins=/var/lib/grafana/plugins", "cfg:default.paths.provisioning=/etc/grafana/provisioning"]
 
 # Default stage — alpine. Builds without --target produce an alpine image.
 # Use --target=final-ubuntu to build the ubuntu variant instead.

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ FROM alpine:3.23.4 AS alpine-base
 FROM ubuntu:24.04 AS ubuntu-base
 FROM golang:1.26.3-alpine AS go-builder-base
 FROM --platform=${JS_PLATFORM} node:24-alpine AS js-builder-base
-FROM gcr.io/distroless/static-debian12 AS distroless-base
+FROM gcr.io/distroless/static-debian13 AS distroless-base
 # Javascript build stage
 FROM --platform=${JS_PLATFORM} ${JS_IMAGE} AS js-builder
 ARG JS_NODE_ENV=production

--- a/Dockerfile
+++ b/Dockerfile
@@ -168,8 +168,9 @@ RUN if [ ! "$(getent group "$GF_GID")" ]; then \
   cp conf/ldap.toml /etc/grafana/ldap.toml && \
   chown -R "grafana:$GF_GID_NAME" "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING" "$GF_PATHS_HOME/data/plugins-bundled" && \
   chmod -R 777 "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING" "$GF_PATHS_HOME/data/plugins-bundled" && \
-  printf 'root:x:0:0:root:/root:/sbin/nologin\nnobody:x:65534:65534:nobody:/nonexistent:/sbin/nologin\ngrafana:x:%s:0::/usr/share/grafana:/sbin/nologin\n' "$GF_UID" > /tmp/distroless-passwd && \
+  printf 'root:x:0:0:root:/root:/sbin/nologin\nnobody:x:65534:65534:nobody:/nonexistent:/sbin/nologin\ngrafana:x:%s:%s::/usr/share/grafana:/sbin/nologin\n' "$GF_UID" "$GF_GID" > /tmp/distroless-passwd && \
   printf 'root:x:0:\nnobody:x:65534:\n' > /tmp/distroless-group && \
+  if [ "$GF_GID" != "0" ]; then printf 'grafana:x:%s:\n' "$GF_GID" >> /tmp/distroless-group; fi && \
   grafana server --homepath="$GF_PATHS_HOME" -v | sed -e 's/Version //' > /.grafana-version && \
   chmod 644 /.grafana-version
 
@@ -330,9 +331,10 @@ ENTRYPOINT [ "/run.sh" ]
 # No shell, no package manager, no OS utilities: significantly reduces CVE surface.
 # Requires a static binary (CGO_ENABLED=0). The run.sh entrypoint is replaced by a
 # direct grafana server invocation, so these run.sh features are unavailable:
-#   - GF_*__FILE secret expansion
+#   - GF_*__FILE secret expansion (reading config values from mounted secret files)
 #   - AWS credential file generation from GF_AWS_* env vars
 #   - GF_INSTALL_PLUGINS (deprecated; use GF_PLUGINS_PREINSTALL instead)
+# GF_PATHS_* env vars work normally — they are not overridden by cfg: flags in this entrypoint.
 #
 # Filesystem layout (dirs, users, config) is prepared by distroless-prep and
 # binaries/assets are copied directly from go-src/js-src. No Alpine OS packages,
@@ -343,6 +345,7 @@ LABEL maintainer="Grafana Labs <hello@grafana.com>"
 LABEL org.opencontainers.image.source="https://github.com/grafana/grafana"
 
 ARG GF_UID="472"
+ARG GF_GID="0"
 
 ENV PATH="/usr/share/grafana/bin:$PATH" \
   GF_PATHS_CONFIG="/etc/grafana/grafana.ini" \
@@ -357,13 +360,13 @@ WORKDIR $GF_PATHS_HOME
 COPY --from=distroless-prep /tmp/distroless-passwd /etc/passwd
 COPY --from=distroless-prep /tmp/distroless-group /etc/group
 COPY --from=distroless-prep /etc/grafana /etc/grafana
-COPY --chown=472:0 --from=distroless-prep /var/lib/grafana /var/lib/grafana
-COPY --chown=472:0 --from=distroless-prep /var/log/grafana /var/log/grafana
+COPY --chown=${GF_UID}:${GF_GID} --from=distroless-prep /var/lib/grafana /var/lib/grafana
+COPY --chown=${GF_UID}:${GF_GID} --from=distroless-prep /var/log/grafana /var/log/grafana
 COPY --from=distroless-prep /usr/share/grafana/conf /usr/share/grafana/conf
-COPY --chown=472:0 --from=distroless-prep /usr/share/grafana/.aws /usr/share/grafana/.aws
-COPY --chown=472:0 --from=distroless-prep /usr/share/grafana/data /usr/share/grafana/data
+COPY --chown=${GF_UID}:${GF_GID} --from=distroless-prep /usr/share/grafana/.aws /usr/share/grafana/.aws
+COPY --chown=${GF_UID}:${GF_GID} --from=distroless-prep /usr/share/grafana/data /usr/share/grafana/data
 COPY --from=distroless-prep /.grafana-version /.grafana-version
-COPY --chown=472:0 --from=go-src /tmp/grafana/bin/grafana* /tmp/grafana/bin/*/grafana* ./bin/
+COPY --chown=${GF_UID}:${GF_GID} --from=go-src /tmp/grafana/bin/grafana* /tmp/grafana/bin/*/grafana* ./bin/
 COPY --from=js-src /tmp/grafana/public ./public
 COPY --from=js-src /tmp/grafana/LICENSE ./
 
@@ -371,7 +374,7 @@ EXPOSE 3000
 
 USER $GF_UID
 
-ENTRYPOINT ["/usr/share/grafana/bin/grafana", "server", "--homepath=/usr/share/grafana", "--config=/etc/grafana/grafana.ini", "--packaging=docker", "cfg:default.log.mode=console", "cfg:default.paths.data=/var/lib/grafana", "cfg:default.paths.logs=/var/log/grafana", "cfg:default.paths.plugins=/var/lib/grafana/plugins", "cfg:default.paths.provisioning=/etc/grafana/provisioning"]
+ENTRYPOINT ["/usr/share/grafana/bin/grafana", "server", "--homepath=/usr/share/grafana", "--config=/etc/grafana/grafana.ini", "--packaging=docker", "cfg:default.log.mode=console"]
 
 # Default stage — alpine. Builds without --target produce an alpine image.
 # Use --target=final-ubuntu to build the ubuntu variant instead.

--- a/Makefile
+++ b/Makefile
@@ -394,8 +394,11 @@ DEB_PACKAGE_NAME   := $(if $(filter 6,$(ARM)),$(TARGZ_PACKAGE_NAME)-rpi,$(TARGZ_
 TARGZ_FILE         := dist/$(TARGZ_PACKAGE_NAME)_$(BUILD_VERSION)_$(BUILD_NUMBER)_$(OS)_$(ARCH_LABEL).tar.gz
 DEB_FILE           := dist/$(DEB_PACKAGE_NAME)_$(BUILD_VERSION)_$(BUILD_NUMBER)_$(OS)_$(ARCH_LABEL).deb
 RPM_FILE           := dist/$(TARGZ_PACKAGE_NAME)_$(BUILD_VERSION)_$(BUILD_NUMBER)_$(OS)_$(ARCH_LABEL).rpm
-DOCKER_FILE        := dist/$(TARGZ_PACKAGE_NAME)_$(BUILD_VERSION)_$(BUILD_NUMBER)_$(OS)_$(ARCH_LABEL).docker.tar.gz
-DOCKER_UBUNTU_FILE := dist/$(TARGZ_PACKAGE_NAME)_$(BUILD_VERSION)_$(BUILD_NUMBER)_$(OS)_$(ARCH_LABEL).ubuntu.docker.tar.gz
+SLIM                    ?= false
+SLIM_SUFFIX             := $(if $(filter true,$(SLIM)),-slim,)
+DOCKER_FILE             := dist/$(TARGZ_PACKAGE_NAME)_$(BUILD_VERSION)_$(BUILD_NUMBER)_$(OS)_$(ARCH_LABEL)$(SLIM_SUFFIX).docker.tar.gz
+DOCKER_UBUNTU_FILE      := dist/$(TARGZ_PACKAGE_NAME)_$(BUILD_VERSION)_$(BUILD_NUMBER)_$(OS)_$(ARCH_LABEL).ubuntu$(SLIM_SUFFIX).docker.tar.gz
+DOCKER_DISTROLESS_FILE  := dist/$(TARGZ_PACKAGE_NAME)_$(BUILD_VERSION)_$(BUILD_NUMBER)_$(OS)_$(ARCH_LABEL).distroless$(SLIM_SUFFIX).docker.tar.gz
 DOCKER_TAG         ?= $(TARGZ_PACKAGE_NAME):$(BUILD_VERSION)
 
 # Default catalog plugins under data/plugins-bundled. Stamp encodes OS/ARCH so cross-builds refresh.
@@ -472,6 +475,7 @@ $(DOCKER_FILE): $(TARGZ_FILE)
 	--build-arg GRAFANA_TGZ=$(TARGZ_FILE) \
 	--build-arg GO_SRC=tgz-builder \
 	--build-arg JS_SRC=tgz-builder \
+	--build-arg SLIM=$(SLIM) \
 	--target=final-alpine \
 	--tag $(DOCKER_TAG) \
 	--output type=docker,dest=$@ \
@@ -487,7 +491,24 @@ $(DOCKER_UBUNTU_FILE): $(TARGZ_FILE)
 	--build-arg GRAFANA_TGZ=$(TARGZ_FILE) \
 	--build-arg GO_SRC=tgz-builder \
 	--build-arg JS_SRC=tgz-builder \
+	--build-arg SLIM=$(SLIM) \
 	--target=final-ubuntu \
+	--tag $(DOCKER_TAG) \
+	--output type=docker,dest=$@ \
+	.
+
+.PHONY: build-docker-distroless
+build-docker-distroless: $(DOCKER_DISTROLESS_FILE) ## Build a Docker image (distroless) from a tar.gz
+
+$(DOCKER_DISTROLESS_FILE): $(TARGZ_FILE)
+	@echo "building docker image (distroless)"
+	docker buildx build \
+	--platform $(OS)/$(ARCH) \
+	--build-arg GRAFANA_TGZ=$(TARGZ_FILE) \
+	--build-arg GO_SRC=tgz-builder \
+	--build-arg JS_SRC=tgz-builder \
+	--build-arg SLIM=$(SLIM) \
+	--target=final-distroless \
 	--tag $(DOCKER_TAG) \
 	--output type=docker,dest=$@ \
 	.
@@ -670,6 +691,7 @@ build-docker-full: ## Build Docker image for development.
 	--build-arg WIRE_TAGS=$(WIRE_TAGS) \
 	--build-arg COMMIT_SHA=$$(git rev-parse HEAD) \
 	--build-arg BUILD_BRANCH=$$(git rev-parse --abbrev-ref HEAD) \
+	--build-arg SLIM=$(SLIM) \
 	--target=final-alpine \
 	--tag grafana/grafana$(TAG_SUFFIX):dev \
 	$(DOCKER_BUILD_ARGS) \
@@ -689,8 +711,28 @@ build-docker-full-ubuntu: ## Build Docker image based on Ubuntu for development.
 	--build-arg COMMIT_SHA=$$(git rev-parse HEAD) \
 	--build-arg BUILD_BRANCH=$$(git rev-parse --abbrev-ref HEAD) \
 	--build-arg GO_IMAGE=golang:$(GO_VERSION) \
+	--build-arg SLIM=$(SLIM) \
 	--target=final-ubuntu \
 	--tag grafana/grafana$(TAG_SUFFIX):dev-ubuntu \
+	$(DOCKER_BUILD_ARGS) \
+	.
+
+.PHONY: build-docker-full-distroless
+build-docker-full-distroless: ## Build Docker image based on distroless for development.
+	@echo "build docker container mode=($(DOCKER_JS_NODE_ENV_FLAG))"
+	docker buildx build \
+	--platform $(PLATFORM) \
+	--build-arg NODE_ENV=$(DOCKER_JS_NODE_ENV_FLAG) \
+	--build-arg JS_NODE_ENV=$(DOCKER_JS_NODE_ENV_FLAG) \
+	--build-arg JS_YARN_INSTALL_FLAG=$(DOCKER_JS_YARN_INSTALL_FLAG) \
+	--build-arg JS_YARN_BUILD_FLAG=$(DOCKER_JS_YARN_BUILD_FLAG) \
+	--build-arg GO_BUILD_TAGS=$(GO_BUILD_TAGS) \
+	--build-arg WIRE_TAGS=$(WIRE_TAGS) \
+	--build-arg COMMIT_SHA=$$(git rev-parse HEAD) \
+	--build-arg BUILD_BRANCH=$$(git rev-parse --abbrev-ref HEAD) \
+	--build-arg SLIM=$(SLIM) \
+	--target=final-distroless \
+	--tag grafana/grafana$(TAG_SUFFIX):dev-distroless \
 	$(DOCKER_BUILD_ARGS) \
 	.
 


### PR DESCRIPTION
Since data sources are being decoupled from the Grafana codebase we have the opportunity to slim down the Grafana docker image, and also reduce the number of CVEs embedded in each image.

Grafana is also compiled now statically without CGO, so we can start experimenting with distroless or even scratch containers.
  
## Before

  | Variant | Build from source | Build from tarball |
  |---|---|---|
  | Alpine | `make build-docker-full` | `make build-docker OS=linux ARCH=amd64` |
  | Ubuntu | `make build-docker-full-ubuntu` | `make build-docker-ubuntu OS=linux ARCH=amd64` |

  ## After

  | Variant | Build from source | Build from tarball |
  |---|---|---|
  | Alpine | `make build-docker-full DOCKER_BUILD_ARGS=--load` | `make build-docker OS=linux ARCH=amd64` |
  | Alpine slim | `make build-docker-full SLIM=true DOCKER_BUILD_ARGS=--load` | `make build-docker SLIM=true OS=linux ARCH=amd64` |
  | Ubuntu | `make build-docker-full-ubuntu DOCKER_BUILD_ARGS=--load` | `make build-docker-ubuntu OS=linux ARCH=amd64` |
  | Ubuntu slim | `make build-docker-full-ubuntu SLIM=true DOCKER_BUILD_ARGS=--load` | `make build-docker-ubuntu SLIM=true OS=linux ARCH=amd64` |
  | Distroless | `make build-docker-full-distroless DOCKER_BUILD_ARGS=--load` | `make build-docker-distroless OS=linux ARCH=amd64` |
  | Distroless slim | `make build-docker-full-distroless SLIM=true DOCKER_BUILD_ARGS=--load` | `make build-docker-distroless SLIM=true OS=linux ARCH=amd64` |