### PR TITLE
Alerting: Add regression tests for notification preview routing (PR #124697)

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreview.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/NotificationPreview.test.tsx
@@ -15,6 +15,7 @@ import {
   GRAFANA_RULES_SOURCE_NAME,
   useGetAlertManagerDataSourcesByPermissionAndConfig,
 } from '../../../utils/datasource';
+import { NAMED_ROOT_LABEL_NAME } from '../../notification-policies/useNotificationPolicyRoute';
 
 import { NotificationPreview } from './NotificationPreview';
 
@@ -201,6 +202,40 @@ describe('NotificationPreview', () => {
     });
 
     expect(ui.contactPointGroup.query()).not.toBeInTheDocument();
+  });
+
+  // Regression test for bug #3 from PR #124697:
+  // __grafana_managed_route__ is routing infrastructure and must never be shown to users —
+  // neither in the instance label list nor in the "Non-matching labels" section of the route drawer.
+  it('should not display __grafana_managed_route__ label in the notification preview', async () => {
+    mockHasEditPermission(true);
+    mockOneAlertManager();
+    mockPreviewApiResponse(server, [
+      mockAlertmanagerAlert({
+        labels: { tomato: 'red', [NAMED_ROOT_LABEL_NAME]: 'my-policy' },
+      }),
+    ]);
+
+    const { user } = render(
+      <NotificationPreview alertQueries={[alertQuery]} customLabels={[]} condition="A" folder={folder} />
+    );
+
+    await waitFor(async () => {
+      const matchingContactPoint = await ui.contactPointGroup.findAll();
+      expect(matchingContactPoint).toHaveLength(1);
+    });
+
+    // Expand instance list
+    await user.click(await ui.expandButton.find());
+
+    // The internal routing label must not be visible anywhere on the page
+    expect(screen.queryByText(NAMED_ROOT_LABEL_NAME)).not.toBeInTheDocument();
+    expect(screen.queryByText('my-policy')).not.toBeInTheDocument();
+
+    // Open the route drawer and verify the label is absent from "Non-matching labels" too
+    await user.click(await ui.seeDetails.find());
+    const drawer = ui.details.drawer.getAll()[0];
+    expect(within(drawer).queryByText(NAMED_ROOT_LABEL_NAME)).not.toBeInTheDocument();
   });
 
   it('should render details when clicking see details button', async () => {

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/PolicyTreeSelector.integration.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/PolicyTreeSelector.integration.test.tsx
@@ -10,7 +10,12 @@ import { setPluginLinksHook } from '@grafana/runtime';
 import { mockComboboxRect } from '@grafana/test-utils';
 import { contextSrv } from 'app/core/services/context_srv';
 import { setupMswServer } from 'app/features/alerting/unified/mockApi';
-import { grantUserPermissions, mockAlertmanagerAlert, mockDataSource, mockFolder } from 'app/features/alerting/unified/mocks';
+import {
+  grantUserPermissions,
+  mockAlertmanagerAlert,
+  mockDataSource,
+  mockFolder,
+} from 'app/features/alerting/unified/mocks';
 import {
   grafanaRulerGroup,
   grafanaRulerNamespace,
@@ -422,15 +427,11 @@ describe('PolicyTreeSelector - feature toggle ON', () => {
 
     it('forwards the policy name from the __grafana_managed_route__ label to the routing preview', async () => {
       // Simulate the preview API returning an instance so the routing tree fetch is triggered
-      mockPreviewApiResponse(server, [
-        mockAlertmanagerAlert({ labels: { severity: 'critical' } }),
-      ]);
+      mockPreviewApiResponse(server, [mockAlertmanagerAlert({ labels: { severity: 'critical' } })]);
 
       // Capture all GET requests to the k8s routing tree API so we can verify
       // the preview fetched the named policy tree, not the default root.
-      const capture = captureRequests(
-        (r) => r.method === 'GET' && r.url.includes('/routingtrees/')
-      );
+      const capture = captureRequests((r) => r.method === 'GET' && r.url.includes('/routingtrees/'));
 
       renderRuleEditor(grafanaRulerRule.grafana_alert.uid);
 

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/PolicyTreeSelector.integration.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/PolicyTreeSelector.integration.test.tsx
@@ -10,7 +10,7 @@ import { setPluginLinksHook } from '@grafana/runtime';
 import { mockComboboxRect } from '@grafana/test-utils';
 import { contextSrv } from 'app/core/services/context_srv';
 import { setupMswServer } from 'app/features/alerting/unified/mockApi';
-import { grantUserPermissions, mockDataSource, mockFolder } from 'app/features/alerting/unified/mocks';
+import { grantUserPermissions, mockAlertmanagerAlert, mockDataSource, mockFolder } from 'app/features/alerting/unified/mocks';
 import {
   grafanaRulerGroup,
   grafanaRulerNamespace,
@@ -34,6 +34,8 @@ import { NAMED_ROOT_LABEL_NAME } from '../../notification-policies/useNotificati
 jest.mock('app/core/components/AppChrome/AppChromeUpdate', () => ({
   AppChromeUpdate: ({ actions }: { actions: ReactNode }) => <div>{actions}</div>,
 }));
+
+jest.mock('app/features/alerting/unified/useRouteGroupsMatcher');
 
 jest.setTimeout(90 * 1000);
 
@@ -376,6 +378,77 @@ describe('PolicyTreeSelector - feature toggle ON', () => {
       });
       expect(policyTreeUi.policySelector.query()).not.toBeInTheDocument();
       expect(policyTreeUi.resetButton.query()).not.toBeInTheDocument();
+    });
+  });
+
+  // Regression test for bug #1 from PR #124697:
+  // AutomaticRooting passed policyName={undefined} to NotificationPreview when only
+  // alertingMultiplePolicies was enabled (alertingPolicyRoutingSettings OFF).
+  // The selected tree (stored as __grafana_managed_route__ label) was never forwarded,
+  // so routing was always evaluated against the default tree.
+  describe('notification preview routing (alertingPolicyRoutingSettings OFF)', () => {
+    const CUSTOM_POLICY_NAME = 'Managed Policy - Empty Provisioned';
+
+    beforeEach(() => {
+      setFolderResponse(
+        mockFolder({
+          uid: grafanaRulerNamespace.uid,
+          title: grafanaRulerNamespace.name,
+          accessControl: {
+            [AccessControlAction.AlertingRuleUpdate]: true,
+          },
+        })
+      );
+
+      // Rule uses legacy label-based routing (no notification_settings.policy)
+      const ruleWithLabel: RulerGrafanaRuleDTO = {
+        ...grafanaRulerRule,
+        labels: { [NAMED_ROOT_LABEL_NAME]: CUSTOM_POLICY_NAME },
+        grafana_alert: {
+          ...grafanaRulerRule.grafana_alert,
+          notification_settings: undefined,
+        },
+      };
+      const group: RulerRuleGroupDTO<RulerGrafanaRuleDTO> = {
+        ...grafanaRulerGroup,
+        rules: [ruleWithLabel],
+      };
+      server.use(
+        http.get(`/api/ruler/grafana/api/v1/rules/${grafanaRulerNamespace.uid}/${grafanaRulerGroup.name}`, () =>
+          HttpResponse.json(group)
+        )
+      );
+    });
+
+    it('forwards the policy name from the __grafana_managed_route__ label to the routing preview', async () => {
+      // Simulate the preview API returning an instance so the routing tree fetch is triggered
+      mockPreviewApiResponse(server, [
+        mockAlertmanagerAlert({ labels: { severity: 'critical' } }),
+      ]);
+
+      // Capture all GET requests to the k8s routing tree API so we can verify
+      // the preview fetched the named policy tree, not the default root.
+      const capture = captureRequests(
+        (r) => r.method === 'GET' && r.url.includes('/routingtrees/')
+      );
+
+      renderRuleEditor(grafanaRulerRule.grafana_alert.uid);
+
+      // Wait for the form to load with the custom policy pre-selected
+      await waitFor(() => {
+        expect(policyTreeUi.policySelector.get()).toBeEnabled();
+      });
+
+      const requests = await capture;
+
+      // Before the fix, AutomaticRooting passed policyName={undefined} so the preview
+      // hook always fetched the default root tree (ROOT_ROUTE_NAME), never the named one.
+      // After the fix, it derives the name from the __grafana_managed_route__ label and
+      // the k8s API is called with the encoded policy name in the URL.
+      await waitFor(() => {
+        const routingTreeUrls = requests.map((r) => r.url);
+        expect(routingTreeUrls.some((url) => url.includes(encodeURIComponent(CUSTOM_POLICY_NAME)))).toBe(true);
+      });
     });
   });
 

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/useAlertmanagerNotificationRoutingPreview.test.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/useAlertmanagerNotificationRoutingPreview.test.ts
@@ -19,7 +19,7 @@ import { useAlertmanagerNotificationRoutingPreview } from './useAlertmanagerNoti
 // Use the manual __mocks__ version that delegates to routeGroupsMatcher synchronously
 jest.mock('../../../useRouteGroupsMatcher');
 
-const server = setupMswServer();
+setupMswServer();
 
 // A named policy that exists in the default MSW mock routing tree map
 const EXISTING_NAMED_POLICY = 'Managed Policy - Empty Provisioned';
@@ -65,10 +65,9 @@ describe('useAlertmanagerNotificationRoutingPreview', () => {
   it('preserves root object_matchers when no policyName is provided', async () => {
     const instances = [{ team: 'ops' }];
 
-    renderHook(
-      () => useAlertmanagerNotificationRoutingPreview(GRAFANA_RULES_SOURCE_NAME, instances, undefined),
-      { wrapper }
-    );
+    renderHook(() => useAlertmanagerNotificationRoutingPreview(GRAFANA_RULES_SOURCE_NAME, instances, undefined), {
+      wrapper,
+    });
 
     await waitFor(() => {
       expect(matchSpy).toHaveBeenCalled();
@@ -89,10 +88,9 @@ describe('useAlertmanagerNotificationRoutingPreview', () => {
     // Instance carries the named-route label pointing to an existing policy
     const instances = [{ [NAMED_ROOT_LABEL_NAME]: EXISTING_NAMED_POLICY, severity: 'warning' }];
 
-    renderHook(
-      () => useAlertmanagerNotificationRoutingPreview(GRAFANA_RULES_SOURCE_NAME, instances, undefined),
-      { wrapper }
-    );
+    renderHook(() => useAlertmanagerNotificationRoutingPreview(GRAFANA_RULES_SOURCE_NAME, instances, undefined), {
+      wrapper,
+    });
 
     await waitFor(() => {
       expect(matchSpy).toHaveBeenCalled();
@@ -110,10 +108,9 @@ describe('useAlertmanagerNotificationRoutingPreview', () => {
   it('handles the default root route when policyName is ROOT_ROUTE_NAME', async () => {
     const instances = [{ severity: 'critical' }];
 
-    renderHook(
-      () => useAlertmanagerNotificationRoutingPreview(GRAFANA_RULES_SOURCE_NAME, instances, ROOT_ROUTE_NAME),
-      { wrapper }
-    );
+    renderHook(() => useAlertmanagerNotificationRoutingPreview(GRAFANA_RULES_SOURCE_NAME, instances, ROOT_ROUTE_NAME), {
+      wrapper,
+    });
 
     await waitFor(() => {
       expect(matchSpy).toHaveBeenCalled();

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/useAlertmanagerNotificationRoutingPreview.test.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/useAlertmanagerNotificationRoutingPreview.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Regression tests for PR #124697
+ *
+ * Bug: when policyName is explicitly set, the synthetic root object_matchers
+ * (__grafana_managed_route__ = <name>) injected by k8sRouteToRoute blocked every
+ * instance from entering the tree. Strip them so real matching can proceed.
+ */
+import { getWrapper, renderHook, waitFor } from 'test/test-utils';
+
+import { NAMED_ROOT_LABEL_NAME } from 'app/features/alerting/unified/components/notification-policies/useNotificationPolicyRoute';
+import { ROOT_ROUTE_NAME } from 'app/features/alerting/unified/utils/k8s/constants';
+
+import { setupMswServer } from '../../../mockApi';
+import { routeGroupsMatcher } from '../../../routeGroupsMatcher';
+import { GRAFANA_RULES_SOURCE_NAME } from '../../../utils/datasource';
+
+import { useAlertmanagerNotificationRoutingPreview } from './useAlertmanagerNotificationRoutingPreview';
+
+// Use the manual __mocks__ version that delegates to routeGroupsMatcher synchronously
+jest.mock('../../../useRouteGroupsMatcher');
+
+const server = setupMswServer();
+
+// A named policy that exists in the default MSW mock routing tree map
+const EXISTING_NAMED_POLICY = 'Managed Policy - Empty Provisioned';
+
+const wrapper = getWrapper({ renderWithRouter: false });
+
+describe('useAlertmanagerNotificationRoutingPreview', () => {
+  let matchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    matchSpy = jest.spyOn(routeGroupsMatcher, 'matchInstancesToRoutes');
+  });
+
+  afterEach(() => {
+    matchSpy.mockRestore();
+  });
+
+  // Regression test for bug from PR #124697:
+  // When policyName is provided the synthetic root object_matchers must be cleared
+  // so that instances are not rejected at the root before reaching sub-routes.
+  it('clears root object_matchers when policyName is explicitly provided', async () => {
+    const instances = [{ team: 'ops', severity: 'critical' }];
+
+    renderHook(
+      () => useAlertmanagerNotificationRoutingPreview(GRAFANA_RULES_SOURCE_NAME, instances, EXISTING_NAMED_POLICY),
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      expect(matchSpy).toHaveBeenCalled();
+    });
+
+    const [rootRoute] = matchSpy.mock.calls[0];
+
+    // The synthetic root matcher injected by k8sRouteToRoute must be absent so
+    // instances can flow into sub-routes. Before the fix this array retained the
+    // [[NAMED_ROOT_LABEL_NAME, '=', policyName]] matcher, blocking all instances.
+    expect(rootRoute.object_matchers).toEqual([]);
+  });
+
+  // Regression test: when no policyName is given (default tree), the root matchers
+  // must NOT be cleared — they are needed to differentiate trees in the legacy path.
+  it('preserves root object_matchers when no policyName is provided', async () => {
+    const instances = [{ team: 'ops' }];
+
+    renderHook(
+      () => useAlertmanagerNotificationRoutingPreview(GRAFANA_RULES_SOURCE_NAME, instances, undefined),
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      expect(matchSpy).toHaveBeenCalled();
+    });
+
+    const [rootRoute] = matchSpy.mock.calls[0];
+
+    // object_matchers should still be present (non-empty) so that legacy-mode
+    // tree discrimination continues to work.
+    expect(rootRoute.object_matchers).toBeDefined();
+    expect(rootRoute.object_matchers?.length).toBeGreaterThan(0);
+  });
+
+  // Regression test for legacy mode from PR #124697:
+  // When policyName is not set but instances carry __grafana_managed_route__,
+  // the hook should derive routeName from the label and use that tree.
+  it('derives routeName from instance label when policyName is absent (legacy mode)', async () => {
+    // Instance carries the named-route label pointing to an existing policy
+    const instances = [{ [NAMED_ROOT_LABEL_NAME]: EXISTING_NAMED_POLICY, severity: 'warning' }];
+
+    renderHook(
+      () => useAlertmanagerNotificationRoutingPreview(GRAFANA_RULES_SOURCE_NAME, instances, undefined),
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      expect(matchSpy).toHaveBeenCalled();
+    });
+
+    // The hook should attempt matching (not bail out for missing policy)
+    const [rootRoute] = matchSpy.mock.calls[0];
+    // Since no explicit policyName was provided, object_matchers are NOT cleared —
+    // the legacy root matcher is still there.
+    expect(rootRoute.object_matchers).toBeDefined();
+    expect(rootRoute.object_matchers?.length).toBeGreaterThan(0);
+  });
+
+  // Regression test: with policyName set to the default root, routing also works.
+  it('handles the default root route when policyName is ROOT_ROUTE_NAME', async () => {
+    const instances = [{ severity: 'critical' }];
+
+    renderHook(
+      () => useAlertmanagerNotificationRoutingPreview(GRAFANA_RULES_SOURCE_NAME, instances, ROOT_ROUTE_NAME),
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      expect(matchSpy).toHaveBeenCalled();
+    });
+
+    const [rootRoute] = matchSpy.mock.calls[0];
+    // policyName is set (ROOT_ROUTE_NAME) so object_matchers must also be cleared
+    expect(rootRoute.object_matchers).toEqual([]);
+  });
+});


### PR DESCRIPTION
**What is this feature?**

Regression tests for the three bugs fixed in PR #124697.

**Why do we need this feature?**

PR #124697 fixed notification routing preview bugs when `alertingMultiplePolicies` is enabled. These tests ensure the bugs do not regress:

1. **`useAlertmanagerNotificationRoutingPreview`** — When `policyName` is explicitly provided, the synthetic root `object_matchers` (`__grafana_managed_route__ = <name>`) injected by `k8sRouteToRoute` must be cleared so instances can flow into sub-routes. Without the fix, all instances were rejected at the root.

2. **`NotificationPreview`** — `__grafana_managed_route__` is routing infrastructure and must never appear in the instance label display or the "Non-matching labels" section of the route drawer.

3. **`PolicyTreeSelector` (legacy mode)** — When only `alertingMultiplePolicies` is on (`alertingPolicyRoutingSettings` OFF), the selected policy stored as a `__grafana_managed_route__` label must be forwarded to the routing preview hook. Before the fix, `policyName` was always `undefined` in this mode.

**Who is this feature for?**

Future contributors — these are pure test additions with no user-facing changes.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.