### PR TITLE
Docker: Share layers between images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -126,6 +126,28 @@ RUN mkdir -p data/plugins-bundled
 FROM ${GO_SRC} AS go-src
 FROM ${JS_SRC} AS js-src
 
+# Collects all Grafana binaries and frontend assets into one place.
+# Every final stage (alpine, ubuntu, distroless) copies from here with identical
+# instructions, guaranteeing the same layer hash across all variants.
+# plugins-bundled is set to 472:0 777 to match the setup RUN in each final stage
+# so its directory entry is absent from the COPY layer (no metadata diff → shared hash).
+FROM alpine-base AS grafana-assets
+
+ENV GF_PATHS_HOME="/usr/share/grafana"
+WORKDIR $GF_PATHS_HOME
+
+COPY --from=go-src /tmp/grafana/bin/grafana* /tmp/grafana/bin/*/grafana* ./bin/
+COPY --from=js-src /tmp/grafana/public ./public
+COPY --from=js-src /tmp/grafana/LICENSE ./
+
+RUN mkdir -p data/plugins-bundled && \
+  chown 472:0 data/plugins-bundled && \
+  chmod 777 data/plugins-bundled
+
+ARG SLIM=false
+RUN --mount=type=bind,from=go-src,source=/tmp/grafana/data/plugins-bundled,target=/mnt/plugins-bundled \
+  [ "$SLIM" = "true" ] || cp -a /mnt/plugins-bundled/. ./data/plugins-bundled/
+
 # Intermediate filesystem setup for the distroless target.
 # Uses an Alpine shell to create directories, users, and config files
 # since distroless has no shell. No network access required.
@@ -174,10 +196,6 @@ RUN if [ ! "$(getent group "$GF_GID")" ]; then \
   grafana server --homepath="$GF_PATHS_HOME" -v | sed -e 's/Version //' > /.grafana-version && \
   chmod 644 /.grafana-version
 
-ARG SLIM=false
-RUN --mount=type=bind,from=go-src,source=/tmp/grafana/data/plugins-bundled,target=/mnt/plugins-bundled \
-  [ "$SLIM" = "true" ] || cp -a /mnt/plugins-bundled/. "$GF_PATHS_HOME/data/plugins-bundled/"
-
 # Alpine final stage
 FROM alpine-base AS final-alpine
 
@@ -205,7 +223,7 @@ RUN apk add --no-cache ca-certificates bash bubblewrap curl tzdata musl-utils &&
 ARG GLIBC_VERSION=2.40
 
 RUN if [ "$(arch)" = "x86_64" ]; then \
-  wget -qO- "https://dl.grafana.com/glibc/glibc-bin-$GLIBC_VERSION.tar.gz" | tar zxf - -C / \
+  curl -fsSL "https://dl.grafana.com/glibc/glibc-bin-$GLIBC_VERSION.tar.gz" | tar zxf - -C / \
   usr/glibc-compat/lib/ld-linux-x86-64.so.2 \
   usr/glibc-compat/lib/libc.so.6 \
   usr/glibc-compat/lib/libdl.so.2 \
@@ -240,16 +258,10 @@ RUN if [ ! "$(getent group "$GF_GID")" ]; then \
   chown -R "grafana:$GF_GID_NAME" "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING" "$GF_PATHS_HOME/data/plugins-bundled" && \
   chmod -R 777 "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING" "$GF_PATHS_HOME/data/plugins-bundled"
 
-COPY --from=go-src /tmp/grafana/bin/grafana* /tmp/grafana/bin/*/grafana* ./bin/
-COPY --from=js-src /tmp/grafana/public ./public
-COPY --from=js-src /tmp/grafana/LICENSE ./
+COPY --link --from=grafana-assets /usr/share/grafana /usr/share/grafana
 
 RUN grafana server -v | sed -e 's/Version //' > /.grafana-version
 RUN chmod 644 /.grafana-version
-
-ARG SLIM=false
-RUN --mount=type=bind,from=go-src,source=/tmp/grafana/data/plugins-bundled,target=/mnt/plugins-bundled \
-  [ "$SLIM" = "true" ] || cp -a /mnt/plugins-bundled/. ./data/plugins-bundled/
 
 EXPOSE 3000
 
@@ -307,16 +319,10 @@ RUN if [ ! "$(getent group "$GF_GID")" ]; then \
   chown -R "grafana:$GF_GID_NAME" "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING" "$GF_PATHS_HOME/data/plugins-bundled" && \
   chmod -R 777 "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING" "$GF_PATHS_HOME/data/plugins-bundled"
 
-COPY --from=go-src /tmp/grafana/bin/grafana* /tmp/grafana/bin/*/grafana* ./bin/
-COPY --from=js-src /tmp/grafana/public ./public
-COPY --from=js-src /tmp/grafana/LICENSE ./
+COPY --link --from=grafana-assets /usr/share/grafana /usr/share/grafana
 
 RUN grafana server -v | sed -e 's/Version //' > /.grafana-version
 RUN chmod 644 /.grafana-version
-
-ARG SLIM=false
-RUN --mount=type=bind,from=go-src,source=/tmp/grafana/data/plugins-bundled,target=/mnt/plugins-bundled \
-  [ "$SLIM" = "true" ] || cp -a /mnt/plugins-bundled/. ./data/plugins-bundled/
 
 EXPOSE 3000
 
@@ -365,10 +371,8 @@ COPY --chown=${GF_UID}:${GF_GID} --from=distroless-prep /var/log/grafana /var/lo
 COPY --from=distroless-prep /usr/share/grafana/conf /usr/share/grafana/conf
 COPY --chown=${GF_UID}:${GF_GID} --from=distroless-prep /usr/share/grafana/.aws /usr/share/grafana/.aws
 COPY --chown=${GF_UID}:${GF_GID} --from=distroless-prep /usr/share/grafana/data /usr/share/grafana/data
+COPY --link --from=grafana-assets /usr/share/grafana /usr/share/grafana
 COPY --from=distroless-prep /.grafana-version /.grafana-version
-COPY --chown=${GF_UID}:${GF_GID} --from=go-src /tmp/grafana/bin/grafana* /tmp/grafana/bin/*/grafana* ./bin/
-COPY --from=js-src /tmp/grafana/public ./public
-COPY --from=js-src /tmp/grafana/LICENSE ./
 
 EXPOSE 3000
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -126,11 +126,9 @@ RUN mkdir -p data/plugins-bundled
 FROM ${GO_SRC} AS go-src
 FROM ${JS_SRC} AS js-src
 
-# Collects all Grafana binaries and frontend assets into one place.
-# Every final stage (alpine, ubuntu, distroless) copies from here with identical
-# instructions, guaranteeing the same layer hash across all variants.
-# plugins-bundled is set to 472:0 777 to match the setup RUN in each final stage
-# so its directory entry is absent from the COPY layer (no metadata diff → shared hash).
+# Binaries and frontend assets — shared by all 6 variants (full and slim) via COPY --link.
+# No plugins here; keeping this stage SLIM-agnostic ensures the layer hash is identical
+# across every build regardless of the SLIM flag.
 FROM alpine-base AS grafana-assets
 
 ENV GF_PATHS_HOME="/usr/share/grafana"
@@ -139,6 +137,14 @@ WORKDIR $GF_PATHS_HOME
 COPY --from=go-src /tmp/grafana/bin/grafana* /tmp/grafana/bin/*/grafana* ./bin/
 COPY --from=js-src /tmp/grafana/public ./public
 COPY --from=js-src /tmp/grafana/LICENSE ./
+
+# Bundled plugins — shared by the 3 full (non-slim) variants, and by the 3 slim variants
+# among themselves (as an empty directory). Kept separate from grafana-assets so the two
+# groups each get their own shared layer rather than a single mixed one.
+FROM alpine-base AS grafana-plugins
+
+ENV GF_PATHS_HOME="/usr/share/grafana"
+WORKDIR $GF_PATHS_HOME
 
 RUN mkdir -p data/plugins-bundled && \
   chown 472:0 data/plugins-bundled && \
@@ -259,6 +265,7 @@ RUN if [ ! "$(getent group "$GF_GID")" ]; then \
   chmod -R 777 "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING" "$GF_PATHS_HOME/data/plugins-bundled"
 
 COPY --link --from=grafana-assets /usr/share/grafana /usr/share/grafana
+COPY --link --from=grafana-plugins /usr/share/grafana/data/plugins-bundled /usr/share/grafana/data/plugins-bundled
 
 RUN grafana server -v | sed -e 's/Version //' > /.grafana-version
 RUN chmod 644 /.grafana-version
@@ -320,6 +327,7 @@ RUN if [ ! "$(getent group "$GF_GID")" ]; then \
   chmod -R 777 "$GF_PATHS_DATA" "$GF_PATHS_HOME/.aws" "$GF_PATHS_LOGS" "$GF_PATHS_PLUGINS" "$GF_PATHS_PROVISIONING" "$GF_PATHS_HOME/data/plugins-bundled"
 
 COPY --link --from=grafana-assets /usr/share/grafana /usr/share/grafana
+COPY --link --from=grafana-plugins /usr/share/grafana/data/plugins-bundled /usr/share/grafana/data/plugins-bundled
 
 RUN grafana server -v | sed -e 's/Version //' > /.grafana-version
 RUN chmod 644 /.grafana-version
@@ -372,6 +380,7 @@ COPY --from=distroless-prep /usr/share/grafana/conf /usr/share/grafana/conf
 COPY --chown=${GF_UID}:${GF_GID} --from=distroless-prep /usr/share/grafana/.aws /usr/share/grafana/.aws
 COPY --chown=${GF_UID}:${GF_GID} --from=distroless-prep /usr/share/grafana/data /usr/share/grafana/data
 COPY --link --from=grafana-assets /usr/share/grafana /usr/share/grafana
+COPY --link --from=grafana-plugins /usr/share/grafana/data/plugins-bundled /usr/share/grafana/data/plugins-bundled
 COPY --from=distroless-prep /.grafana-version /.grafana-version
 
 EXPOSE 3000


### PR DESCRIPTION
We have always had a problem with our docker images where, despite the artifacts being built form the same tar.gz, registries would independently cache each layer.

The end result now are shared layers between each type of image:

  | Layer | alpine | alpine-slim | ubuntu | ubuntu-slim | distroless | distroless-slim | What |
  |---|:---:|:---:|:---:|:---:|:---:|:---:|---|
  | `sha256:4932825703d2...` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | grafana-assets: bins + frontend (~1 GB) |
  | `sha256:1f541371ea9c...` | ✓ | | ✓ | | ✓ | | grafana-plugins: bundled datasources (~66 MB) |
  | `sha256:b96f159b0cff...` | | ✓ | | ✓ | | ✓ | grafana-plugins: empty dir (slim variants) |