### PR TITLE
Alerting: Match silences by rule title when searching by alertname

### DIFF
--- a/public/app/features/alerting/unified/components/silences/SilencesFilter.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencesFilter.tsx
@@ -126,6 +126,11 @@ export class SilenceFiltersController implements AdHocFiltersController {
 
   async getKeys(_currentKey: string | null): Promise<Array<SelectableValue<string>>> {
     const keys = new Set<string>();
+    // "alertname" is always offered as a filter key because silences can be matched by
+    // rule title (metadata.rule_title) even when no alertname label matcher is present.
+    //
+    // This is used when a user creates a silence for a rule (using UID) but still wants to match it by name.
+    keys.add('alertname');
     for (const silence of this.silencesRef.current ?? []) {
       for (const matcher of silence.matchers ?? []) {
         keys.add(matcher.name);
@@ -137,6 +142,9 @@ export class SilenceFiltersController implements AdHocFiltersController {
   async getValuesFor(filter: AdHocFilterWithLabels): Promise<Array<SelectableValue<string>>> {
     const values = new Set<string>();
     for (const silence of this.silencesRef.current ?? []) {
+      if (filter.key === 'alertname' && silence.metadata?.rule_title) {
+        values.add(silence.metadata.rule_title);
+      }
       for (const matcher of silence.matchers ?? []) {
         if (matcher.name === filter.key) {
           values.add(matcher.value);

--- a/public/app/features/alerting/unified/components/silences/SilencesTable.test.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencesTable.test.tsx
@@ -1,0 +1,177 @@
+import { renderHook } from '@testing-library/react';
+
+import { SilenceState } from 'app/plugins/datasource/alertmanager/types';
+
+import { mockSilence } from '../../mocks';
+
+import { useFilteredSilences } from './SilencesTable';
+
+const mockUseQueryParams = jest.fn();
+jest.mock('app/core/hooks/useQueryParams', () => ({
+  useQueryParams: () => mockUseQueryParams(),
+}));
+
+function setQueryString(queryString: string | null) {
+  const params = queryString ? { queryString } : {};
+  mockUseQueryParams.mockReturnValue([params, jest.fn()]);
+}
+
+describe('useFilteredSilences', () => {
+  beforeEach(() => {
+    setQueryString(null);
+  });
+
+  describe('no query string', () => {
+    it('returns active silences when no filter is set', () => {
+      const silences = [
+        mockSilence({ id: '1', status: { state: SilenceState.Active } }),
+        mockSilence({ id: '2', status: { state: SilenceState.Expired } }),
+      ];
+      const { result } = renderHook(() => useFilteredSilences(silences, false));
+      expect(result.current.map((s) => s.id)).toEqual(['1']);
+    });
+
+    it('returns expired silences when expired=true', () => {
+      const silences = [
+        mockSilence({ id: '1', status: { state: SilenceState.Active } }),
+        mockSilence({ id: '2', status: { state: SilenceState.Expired } }),
+      ];
+      const { result } = renderHook(() => useFilteredSilences(silences, true));
+      expect(result.current.map((s) => s.id)).toEqual(['2']);
+    });
+  });
+
+  describe('label matcher search (existing behaviour)', () => {
+    it('matches a silence whose label matchers satisfy the query exactly', () => {
+      const silences = [
+        mockSilence({ id: '1', matchers: [{ name: 'env', value: 'prod', isEqual: true, isRegex: false }] }),
+        mockSilence({ id: '2', matchers: [{ name: 'env', value: 'staging', isEqual: true, isRegex: false }] }),
+      ];
+      setQueryString('env="prod"');
+      const { result } = renderHook(() => useFilteredSilences(silences, false));
+      expect(result.current.map((s) => s.id)).toEqual(['1']);
+    });
+
+    it('does not match when operator differs', () => {
+      const silences = [
+        // Silence has env!=prod (negated), query searches for env=prod (equals)
+        mockSilence({ id: '1', matchers: [{ name: 'env', value: 'prod', isEqual: false, isRegex: false }] }),
+      ];
+      setQueryString('env="prod"');
+      const { result } = renderHook(() => useFilteredSilences(silences, false));
+      expect(result.current).toHaveLength(0);
+    });
+
+    it('does not match when value differs', () => {
+      const silences = [
+        mockSilence({ id: '1', matchers: [{ name: 'env', value: 'staging', isEqual: true, isRegex: false }] }),
+      ];
+      setQueryString('env="prod"');
+      const { result } = renderHook(() => useFilteredSilences(silences, false));
+      expect(result.current).toHaveLength(0);
+    });
+  });
+
+  describe('alertname search — label matcher path', () => {
+    it('matches a silence with an alertname label matcher equal to the query value', () => {
+      const silences = [
+        mockSilence({ id: '1', matchers: [{ name: 'alertname', value: 'HighCPU', isEqual: true, isRegex: false }] }),
+        mockSilence({ id: '2', matchers: [{ name: 'alertname', value: 'LowDisk', isEqual: true, isRegex: false }] }),
+      ];
+      setQueryString('alertname="HighCPU"');
+      const { result } = renderHook(() => useFilteredSilences(silences, false));
+      expect(result.current.map((s) => s.id)).toEqual(['1']);
+    });
+  });
+
+  describe('alertname search — rule_title fallback (exception)', () => {
+    it('matches a silence whose metadata.rule_title equals the query value', () => {
+      const silences = [
+        mockSilence({ id: '1', matchers: [{ name: 'env', value: 'prod', isEqual: true, isRegex: false }], metadata: { rule_title: 'HighCPU' } }),
+        mockSilence({ id: '2', matchers: [{ name: 'env', value: 'prod', isEqual: true, isRegex: false }], metadata: { rule_title: 'LowDisk' } }),
+      ];
+      setQueryString('alertname="HighCPU"');
+      const { result } = renderHook(() => useFilteredSilences(silences, false));
+      expect(result.current.map((s) => s.id)).toEqual(['1']);
+    });
+
+    it('does not match when rule_title differs from query value', () => {
+      const silences = [
+        mockSilence({ id: '1', matchers: [], metadata: { rule_title: 'LowDisk' } }),
+      ];
+      setQueryString('alertname="HighCPU"');
+      const { result } = renderHook(() => useFilteredSilences(silences, false));
+      expect(result.current).toHaveLength(0);
+    });
+
+    it('matches via rule_title when the silence has no alertname label matcher at all', () => {
+      const silences = [
+        mockSilence({ id: '1', matchers: [{ name: 'env', value: 'prod', isEqual: true, isRegex: false }], metadata: { rule_title: 'HighCPU' } }),
+      ];
+      setQueryString('alertname="HighCPU"');
+      const { result } = renderHook(() => useFilteredSilences(silences, false));
+      expect(result.current.map((s) => s.id)).toEqual(['1']);
+    });
+
+    it('matches via alertname label matcher even when rule_title does not match', () => {
+      const silences = [
+        mockSilence({
+          id: '1',
+          matchers: [{ name: 'alertname', value: 'HighCPU', isEqual: true, isRegex: false }],
+          metadata: { rule_title: 'SomethingElse' },
+        }),
+      ];
+      setQueryString('alertname="HighCPU"');
+      const { result } = renderHook(() => useFilteredSilences(silences, false));
+      expect(result.current.map((s) => s.id)).toEqual(['1']);
+    });
+
+    it('matches via rule_title with a regex operator (anchored, so partial patterns do not match)', () => {
+      const silences = [
+        mockSilence({ id: '1', matchers: [], metadata: { rule_title: 'HighCPU Usage' } }),
+        mockSilence({ id: '2', matchers: [], metadata: { rule_title: 'LowDisk' } }),
+      ];
+      setQueryString('alertname=~"High.*"');
+      const { result } = renderHook(() => useFilteredSilences(silences, false));
+      expect(result.current.map((s) => s.id)).toEqual(['1']);
+    });
+
+    it('does not match rule_title when the regex only matches a substring (anchored)', () => {
+      const silences = [
+        mockSilence({ id: '1', matchers: [], metadata: { rule_title: 'HighCPU Usage' } }),
+      ];
+      // "CPU" without anchors would match as a substring, but anchoring ^(?:CPU)$ requires full-string match
+      setQueryString('alertname=~"CPU"');
+      const { result } = renderHook(() => useFilteredSilences(silences, false));
+      expect(result.current).toHaveLength(0);
+    });
+
+    it('is case-sensitive when matching rule_title', () => {
+      const silences = [
+        mockSilence({ id: '1', matchers: [], metadata: { rule_title: 'HighCPU' } }),
+      ];
+      setQueryString('alertname="highcpu"');
+      const { result } = renderHook(() => useFilteredSilences(silences, false));
+      expect(result.current).toHaveLength(0);
+    });
+
+    it('does not apply the rule_title fallback to non-alertname keys', () => {
+      const silences = [
+        // rule_title happens to equal the searched value, but the key is "env", not "alertname"
+        mockSilence({ id: '1', matchers: [], metadata: { rule_title: 'prod' } }),
+      ];
+      setQueryString('env="prod"');
+      const { result } = renderHook(() => useFilteredSilences(silences, false));
+      expect(result.current).toHaveLength(0);
+    });
+
+    it('skips the rule_title check when metadata is absent', () => {
+      const silences = [
+        mockSilence({ id: '1', matchers: [] }), // no metadata
+      ];
+      setQueryString('alertname="HighCPU"');
+      const { result } = renderHook(() => useFilteredSilences(silences, false));
+      expect(result.current).toHaveLength(0);
+    });
+  });
+});

--- a/public/app/features/alerting/unified/components/silences/SilencesTable.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencesTable.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/css';
 import { useMemo } from 'react';
 
+import { matchLabelsSet } from '@grafana/alerting/unstable';
 import { type GrafanaTheme2, dateMath } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import {
@@ -24,7 +25,8 @@ import { type AlertmanagerAlert, type Silence, SilenceState } from 'app/plugins/
 import { alertmanagerApi } from '../../api/alertmanagerApi';
 import { AlertmanagerAction, useAlertmanagerAbility } from '../../hooks/useAbilities';
 import { useAlertmanager } from '../../state/AlertmanagerContext';
-import { parsePromQLStyleMatcherLooseSafe } from '../../utils/matchers';
+import { matcherToObjectMatcher } from '../../utils/alertmanager';
+import { convertObjectMatcherToAlertingPackageMatcher, parsePromQLStyleMatcherLooseSafe } from '../../utils/matchers';
 import { getSilenceFiltersFromUrlParams, makeAMLink, stringifyErrorLike } from '../../utils/misc';
 import { withPageErrorBoundary } from '../../withPageErrorBoundary';
 import { AlertmanagerPageWrapper } from '../AlertingPageWrapper';
@@ -220,11 +222,11 @@ function SilenceList({
       />
     );
   } else {
-    return <Trans i18nKey="silences.table.no-matching-silences">No matching silences found;</Trans>;
+    return <Trans i18nKey="silences.table.no-matching-silences">No matching silences found</Trans>;
   }
 }
 
-const useFilteredSilences = (silences: Silence[], expired = false) => {
+export const useFilteredSilences = (silences: Silence[], expired = false) => {
   const [queryParams] = useQueryParams();
   return useMemo(() => {
     const { queryString } = getSilenceFiltersFromUrlParams(queryParams);
@@ -238,15 +240,27 @@ const useFilteredSilences = (silences: Silence[], expired = false) => {
       }
       if (queryString) {
         const matchers = parsePromQLStyleMatcherLooseSafe(queryString);
-        const matchersMatch = matchers.every((matcher) =>
-          silence.matchers?.some(
+        // For the "alertname" key we additionally check metadata.rule_title so that
+        // silences targeting a specific alert rule can be found by rule name even when the silence
+        // was not created with an explicit alertname label matcher. The rule_title check uses the
+        // same anchored regex semantics as Alertmanager (=~ is evaluated as ^(?:value)$).
+        const matchersMatch = matchers.every((matcher) => {
+          const labelMatcherMatch = silence.matchers?.some(
             ({ name, value, isEqual, isRegex }) =>
               matcher.name === name &&
               matcher.value === value &&
               matcher.isEqual === isEqual &&
               matcher.isRegex === isRegex
-          )
-        );
+          );
+          if (labelMatcherMatch) {
+            return true;
+          }
+          if (matcher.name === 'alertname' && silence.metadata?.rule_title !== undefined) {
+            const labelMatchers = [convertObjectMatcherToAlertingPackageMatcher(matcherToObjectMatcher(matcher))];
+            return matchLabelsSet(labelMatchers, [['alertname', silence.metadata.rule_title]]);
+          }
+          return false;
+        });
         if (!matchersMatch) {
           return false;
         }

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -14897,7 +14897,7 @@
       "add-silence-button": "Add Silence",
       "edit-button": "Edit",
       "expired-silences": "Expired silences are automatically deleted after 5 days.",
-      "no-matching-silences": "No matching silences found;",
+      "no-matching-silences": "No matching silences found",
       "noConfig": "Create a new contact point to create a configuration using the default values or contact your administrator to set up the Alertmanager.",
       "recreate-button": "Recreate",
       "unsilence-button": "Unsilence",


### PR DESCRIPTION
**What is this feature?**

When searching silences using an `alertname` matcher (e.g. `alertname=HighCPU`), the filter now also matches silences whose `metadata.rule_title` equals the searched name — in addition to the existing behaviour of matching silences that carry a literal `alertname` label matcher.

The `alertname` key is also always available in the AdHocFilters autocomplete, with values sourced from all `metadata.rule_title` fields across the loaded silences.

**Why do we need this feature?**

Silences created for Grafana-managed alert rules are identified by a `__alert_rule_uid__` matcher rather than an `alertname` matcher. This means searching by alert name previously returned no results for those silences, even though the rule title is stored in `metadata.rule_title`. This change makes the silences list searchable by rule name regardless of how the silence was created.

**Who is this feature for?**

Users of Grafana-managed alerting who create silences targeting specific alert rules and want to find them by alert rule name in the silences list.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

- The `alertname` exception only applies to the `alertname` key — all other label keys retain strict structural matching (name + value + operator must be identical).
- Regex matching against `rule_title` uses the same anchored semantics as Alertmanager: `=~` is evaluated as `^(?:value)$`, so patterns must match the full string.
- Matching is case-sensitive, consistent with Alertmanager label matching behaviour.
- `useFilteredSilences` is now exported to enable direct unit testing via `renderHook`.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.