### PR TITLE
Frontend: Deprecate duplicative ConfirmModal confirmButtonVariant prop

### DIFF
--- a/packages/grafana-ui/src/components/Actions/ActionButton.tsx
+++ b/packages/grafana-ui/src/components/Actions/ActionButton.tsx
@@ -65,7 +65,7 @@ export function ActionButton({ action, ...buttonProps }: ActionButtonProps) {
           title={t('grafana-ui.action-editor.button.confirm-action', 'Confirm action')}
           body={action.confirmation(actionVars)}
           confirmText={t('grafana-ui.action-editor.button.confirm', 'Confirm')}
-          confirmButtonVariant="primary"
+          confirmVariant="primary"
           onConfirm={() => {
             setShowConfirm(false);
             action.onClick(new MouseEvent('click'), null, actionVars);

--- a/packages/grafana-ui/src/components/ConfirmModal/ConfirmModal.story.tsx
+++ b/packages/grafana-ui/src/components/ConfirmModal/ConfirmModal.story.tsx
@@ -40,7 +40,7 @@ export const Basic: StoryFn<typeof ConfirmModal> = ({
   body,
   description,
   confirmText,
-  confirmButtonVariant,
+  confirmVariant,
   dismissText,
   isOpen,
 }) => {
@@ -52,7 +52,7 @@ export const Basic: StoryFn<typeof ConfirmModal> = ({
       body={body}
       description={description}
       confirmText={confirmText}
-      confirmButtonVariant={confirmButtonVariant}
+      confirmVariant={confirmVariant}
       dismissText={dismissText}
       onConfirm={onConfirm}
       onDismiss={onDismiss}
@@ -71,7 +71,7 @@ Basic.args = {
   body: 'Are you sure you want to delete this user?',
   description: 'Removing the user will not remove any dashboards the user has created',
   confirmText: 'Delete',
-  confirmButtonVariant: 'destructive',
+  confirmVariant: 'destructive',
   dismissText: 'Cancel',
   isOpen: true,
 };
@@ -104,7 +104,7 @@ export const AlternativeAction: StoryFn<typeof ConfirmModal> = ({
 
 AlternativeAction.parameters = {
   controls: {
-    exclude: [...defaultExcludes, 'confirmationText', 'confirmButtonVariant'],
+    exclude: [...defaultExcludes, 'confirmationText', 'confirmVariant'],
   },
 };
 
@@ -144,7 +144,7 @@ export const WithConfirmation: StoryFn<typeof ConfirmModal> = ({
 
 WithConfirmation.parameters = {
   controls: {
-    exclude: [...defaultExcludes, 'alternativeText', 'confirmButtonVariant'],
+    exclude: [...defaultExcludes, 'alternativeText', 'confirmVariant'],
   },
 };
 

--- a/packages/grafana-ui/src/components/ConfirmModal/ConfirmModal.tsx
+++ b/packages/grafana-ui/src/components/ConfirmModal/ConfirmModal.tsx
@@ -31,7 +31,9 @@ export interface ConfirmModalProps {
   confirmationText?: string;
   /** Text for alternative button */
   alternativeText?: string;
-  /** Confirm button variant */
+  /** Confirm button variant
+   * @deprecated Use `confirmVariant` instead. This prop will be removed in a future release.
+   */
   confirmButtonVariant?: ButtonVariant;
   /** Confirm action callback
    * Return a promise to disable the confirm button until the promise is resolved
@@ -65,7 +67,7 @@ export const ConfirmModal = ({
   onConfirm,
   onDismiss,
   onAlternative,
-  confirmButtonVariant = 'destructive',
+  confirmButtonVariant,
   disabled,
 }: ConfirmModalProps): JSX.Element => {
   const styles = useStyles2(getStyles);
@@ -80,7 +82,7 @@ export const ConfirmModal = ({
         dismissButtonVariant={dismissVariant}
         confirmPromptText={confirmationText}
         alternativeButtonLabel={alternativeText}
-        confirmButtonVariant={confirmButtonVariant}
+        confirmButtonVariant={confirmButtonVariant ?? confirmVariant}
         onConfirm={onConfirm}
         onDismiss={onDismiss}
         onAlternative={onAlternative}

--- a/public/app/core/context/ModalsContextProvider.tsx
+++ b/public/app/core/context/ModalsContextProvider.tsx
@@ -95,7 +95,7 @@ function showConfirmModal({ payload }: ShowConfirmModalEvent, setState: (state: 
 
   const props: ConfirmModalProps = {
     confirmText: yesText,
-    confirmButtonVariant: yesButtonVariant,
+    confirmVariant: yesButtonVariant,
     confirmationText: confirmText,
     title,
     body: text,

--- a/public/app/features/alerting/unified/components/import-to-gma/ConfirmConvertModal.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ConfirmConvertModal.tsx
@@ -228,7 +228,7 @@ export const ConfirmConversionModal = ({ importPayload, isOpen, onDismiss }: Mod
       isOpen={isOpen}
       title={title}
       confirmText={confirmText}
-      confirmButtonVariant="primary"
+      confirmVariant="primary"
       modalClass={styles.modal}
       body={
         <Stack direction="column" gap={2}>

--- a/public/app/features/alerting/unified/components/rule-viewer/tabs/version-history/ConfirmVersionRestoreModal.tsx
+++ b/public/app/features/alerting/unified/components/rule-viewer/tabs/version-history/ConfirmVersionRestoreModal.tsx
@@ -84,7 +84,7 @@ export const ConfirmVersionRestoreModal = ({
       isOpen={isOpen}
       title={title}
       confirmText={confirmText}
-      confirmButtonVariant={!error ? 'destructive' : 'primary'}
+      confirmVariant={!error ? 'destructive' : 'primary'}
       body={
         <Stack direction="column" gap={2}>
           {!error && (

--- a/public/app/features/alerting/unified/components/rules/deleted-rules/ConfirmDeletePermanantlyModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/deleted-rules/ConfirmDeletePermanantlyModal.tsx
@@ -43,7 +43,7 @@ export const ConfirmDeletedPermanentlyModal = ({ isOpen, onDismiss, guid }: Moda
       title={title}
       confirmText={confirmText}
       modalClass={styles.modal}
-      confirmButtonVariant="destructive"
+      confirmVariant="destructive"
       body={
         <Stack direction="column" gap={2}>
           <Trans i18nKey="alerting.deleted-rules.delete-modal.body">

--- a/public/app/features/alerting/unified/components/rules/deleted-rules/ConfirmRestoreDeletedRuleModal.tsx
+++ b/public/app/features/alerting/unified/components/rules/deleted-rules/ConfirmRestoreDeletedRuleModal.tsx
@@ -74,7 +74,7 @@ export const ConfirmRestoreDeletedRuleModal = ({
       title={title}
       confirmText={confirmText}
       modalClass={styles.modal}
-      confirmButtonVariant={!error ? 'destructive' : 'primary'}
+      confirmVariant={!error ? 'destructive' : 'primary'}
       body={
         <Stack direction="column" gap={2}>
           <Trans i18nKey="alerting.deleted-rules.restore-modal.body">

--- a/public/app/features/browse-dashboards/components/RestoreModal.tsx
+++ b/public/app/features/browse-dashboards/components/RestoreModal.tsx
@@ -99,7 +99,7 @@ export const RestoreModal = ({
           ? t('recently-deleted.restore-modal.restore-loading', 'Restoring...')
           : t('recently-deleted.restore-modal.restore-button', 'Restore')
       }
-      confirmButtonVariant="primary"
+      confirmVariant="primary"
       isOpen
       onDismiss={onDismiss}
       onConfirm={onRestore}

--- a/public/app/features/canvas/runtime/element.tsx
+++ b/public/app/features/canvas/runtime/element.tsx
@@ -1046,7 +1046,7 @@ export class ElementState implements LayerElement {
             title={t('grafana-ui.action-editor.button.confirm-action', 'Confirm action')}
             body={action.confirmation(/** TODO: implement actionVars */)}
             confirmText={t('grafana-ui.action-editor.button.confirm', 'Confirm')}
-            confirmButtonVariant="primary"
+            confirmVariant="primary"
             onConfirm={() => {
               this.showActionConfirmation = false;
               action.onClick(new MouseEvent('click'), null, this.actionVars);

--- a/public/app/features/dashboard-scene/scene/layouts-shared/DashboardLayoutSelector.tsx
+++ b/public/app/features/dashboard-scene/scene/layouts-shared/DashboardLayoutSelector.tsx
@@ -112,7 +112,7 @@ export function DashboardLayoutSelector({ layoutManager }: Props) {
           body={t('dashboard.layout.panel.modal.body', 'Changing the layout will reset all panel positions and sizes.')}
           confirmText={t('dashboard.layout.panel.modal.confirm', 'Change layout')}
           dismissText={t('dashboard.layout.panel.modal.dismiss', 'Cancel')}
-          confirmButtonVariant="primary"
+          confirmVariant="primary"
           onConfirm={onConfirmNewLayout}
           onDismiss={onDismissNewLayout}
         />

--- a/public/app/features/dashboard-scene/sharing/public-dashboards/ConfirmModal.tsx
+++ b/public/app/features/dashboard-scene/sharing/public-dashboards/ConfirmModal.tsx
@@ -13,7 +13,6 @@ export class ConfirmModal extends SceneObjectBase<ConfirmModalState> implements 
       confirmVariant: 'destructive',
       dismissText: 'Cancel',
       dismissVariant: 'secondary',
-      confirmButtonVariant: 'destructive',
       ...state,
     });
   }

--- a/public/app/features/plugins/admin/components/UpdateAllModal.tsx
+++ b/public/app/features/plugins/admin/components/UpdateAllModal.tsx
@@ -160,7 +160,7 @@ export const UpdateAllModal = ({ isOpen, onDismiss, isLoading, plugins }: Props)
       onDismiss={onDismissClick}
       disabled={shouldDisableConfirm(inProgress, installsRemaining, pluginsSelected)}
       confirmText={getConfirmationText(installsRemaining, inProgress, pluginsSelected)}
-      confirmButtonVariant="primary"
+      confirmVariant="primary"
     />
   );
 };

--- a/public/app/features/plugins/admin/components/VersionInstallButton.tsx
+++ b/public/app/features/plugins/admin/components/VersionInstallButton.tsx
@@ -130,7 +130,7 @@ export const VersionInstallButton = ({
         onConfirm={onConfirm}
         onDismiss={onDismiss}
         disabled={isInstalling}
-        confirmButtonVariant="primary"
+        confirmVariant="primary"
       />
     </>
   );

--- a/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsManagement.tsx
+++ b/public/app/plugins/datasource/azuremonitor/components/LogsQueryEditor/LogsManagement.tsx
@@ -32,7 +32,7 @@ export function LogsManagement({ query, onQueryChange: onChange }: AzureQueryEdi
           setBasicLogsAckOpen(false);
           onChange(setBasicLogsQuery(query, false));
         }}
-        confirmButtonVariant="primary"
+        confirmVariant="primary"
       />
       <InlineField
         label={t('components.logs-management.label-logs', 'Logs')}


### PR DESCRIPTION
**What is this feature?**

Deprecates the `confirmButtonVariant` prop on `ConfirmModal`, favoring the `confirmVariant` prop.

**Why do we need this feature?**

`ConfirmModal` has both `confirmVariant` and `confirmButtonVariant` props. `confirmVariant` was silently unused and could lead to developer confusion as to why the prop isn't working. `confirmVariant` matches the naming convention that `dismissVariant` has, so I've opted to prefer the `confirmVariant` and deprecate `confirmButtonVariant`.

**Who is this feature for?**

Developers.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
