### PR TITLE
alerting: respect CA cert config when sending alerts to external Alertmanager

### DIFF
--- a/pkg/services/ngalert/sender/router.go
+++ b/pkg/services/ngalert/sender/router.go
@@ -296,10 +296,22 @@ func (d *AlertsRouter) datasourceToExternalAMcfg(ds *datasources.DataSource) (Ex
 
 	insecureSkipVerify := false
 
-	var tlsAuthEnabled bool
+	var tlsAuthEnabled, tlsAuthWithCACert bool
 	if ds.JsonData != nil {
 		insecureSkipVerify = ds.JsonData.Get("tlsSkipVerify").MustBool(false)
 		tlsAuthEnabled = ds.JsonData.Get("tlsAuth").MustBool(false)
+		tlsAuthWithCACert = ds.JsonData.Get("tlsAuthWithCACert").MustBool(false)
+	}
+
+	var tlsCACert string
+	if tlsAuthWithCACert {
+		if ds.SecureJsonData == nil {
+			return ExternalAMcfg{}, errors.New("tlsAuthWithCACert is enabled but CA certificate is not configured")
+		}
+		tlsCACert = d.secretService.GetDecryptedValue(context.Background(), ds.SecureJsonData, "tlsCACert", "")
+		if tlsCACert == "" {
+			return ExternalAMcfg{}, errors.New("tlsAuthWithCACert is enabled but CA certificate is empty")
+		}
 	}
 
 	var tlsClientCert, tlsClientKey string
@@ -321,6 +333,7 @@ func (d *AlertsRouter) datasourceToExternalAMcfg(ds *datasources.DataSource) (Ex
 		URL:                amURL,
 		Headers:            headers,
 		InsecureSkipVerify: insecureSkipVerify,
+		TLSCACert:          tlsCACert,
 		TLSClientCert:      tlsClientCert,
 		TLSClientKey:       tlsClientKey,
 	}, nil

--- a/pkg/services/ngalert/sender/router_test.go
+++ b/pkg/services/ngalert/sender/router_test.go
@@ -823,6 +823,73 @@ func TestDatasourceToExternalAMcfg(t *testing.T) {
 			},
 		},
 		{
+			name: "datasource with CA cert",
+			datasource: &datasources.DataSource{
+				URL:   "https://localhost:9093",
+				OrgID: 1,
+				Type:  datasources.DS_ALERTMANAGER,
+				JsonData: simplejson.NewFromAny(map[string]any{
+					"tlsAuthWithCACert": true,
+				}),
+				SecureJsonData: map[string][]byte{
+					"tlsCACert": []byte("ca-cert-content"),
+				},
+			},
+			expected: ExternalAMcfg{
+				URL:       "https://localhost:9093",
+				TLSCACert: "ca-cert-content",
+			},
+		},
+		{
+			name: "datasource with CA cert and client auth",
+			datasource: &datasources.DataSource{
+				URL:   "https://localhost:9093",
+				OrgID: 1,
+				Type:  datasources.DS_ALERTMANAGER,
+				JsonData: simplejson.NewFromAny(map[string]any{
+					"tlsAuthWithCACert": true,
+					"tlsAuth":           true,
+				}),
+				SecureJsonData: map[string][]byte{
+					"tlsCACert":     []byte("ca-cert-content"),
+					"tlsClientCert": []byte("client-cert-content"),
+					"tlsClientKey":  []byte("client-key-content"),
+				},
+			},
+			expected: ExternalAMcfg{
+				URL:           "https://localhost:9093",
+				TLSCACert:     "ca-cert-content",
+				TLSClientCert: "client-cert-content",
+				TLSClientKey:  "client-key-content",
+			},
+		},
+		{
+			name: "tlsAuthWithCACert enabled but SecureJsonData is nil - should error",
+			datasource: &datasources.DataSource{
+				URL:   "https://localhost:9093",
+				OrgID: 1,
+				Type:  datasources.DS_ALERTMANAGER,
+				JsonData: simplejson.NewFromAny(map[string]any{
+					"tlsAuthWithCACert": true,
+				}),
+				SecureJsonData: nil,
+			},
+			expectError: true,
+		},
+		{
+			name: "tlsAuthWithCACert enabled but tlsCACert is empty - should error",
+			datasource: &datasources.DataSource{
+				URL:   "https://localhost:9093",
+				OrgID: 1,
+				Type:  datasources.DS_ALERTMANAGER,
+				JsonData: simplejson.NewFromAny(map[string]any{
+					"tlsAuthWithCACert": true,
+				}),
+				SecureJsonData: map[string][]byte{},
+			},
+			expectError: true,
+		},
+		{
 			name: "tlsAuth enabled but SecureJsonData is nil - should error",
 			datasource: &datasources.DataSource{
 				URL:   "https://localhost:9093",
@@ -984,6 +1051,7 @@ func TestExternalAMcfg_SHA256(t *testing.T) {
 		},
 		Timeout:            30 * time.Second,
 		InsecureSkipVerify: true,
+		TLSCACert:          "ca-cert-content",
 		TLSClientCert:      "client-cert-content",
 		TLSClientKey:       "client-key-content",
 	}
@@ -1024,6 +1092,14 @@ func TestExternalAMcfg_SHA256(t *testing.T) {
 			name: "mutate InsecureSkipVerify - hash should change",
 			mutateFn: func(cfg ExternalAMcfg) ExternalAMcfg {
 				cfg.InsecureSkipVerify = false
+				return cfg
+			},
+			shouldDiffer: true,
+		},
+		{
+			name: "mutate TLSCACert - hash should change",
+			mutateFn: func(cfg ExternalAMcfg) ExternalAMcfg {
+				cfg.TLSCACert = "different-ca-cert"
 				return cfg
 			},
 			shouldDiffer: true,

--- a/pkg/services/ngalert/sender/sender.go
+++ b/pkg/services/ngalert/sender/sender.go
@@ -52,6 +52,8 @@ type ExternalAMcfg struct {
 	Timeout       time.Duration
 	// InsecureSkipVerify determines whether the server's TLS certificate should be verified.
 	InsecureSkipVerify bool
+	// TLSCACert is the PEM-encoded CA certificate used to verify the server's certificate.
+	TLSCACert string
 	// TLSClientCert specifies the TLS client certificate used for secure communication.
 	TLSClientCert string
 	// TLSClientKey specifies the private key associated with the TLS client certificate for secure communication.
@@ -111,6 +113,7 @@ func (cfg *ExternalAMcfg) SHA256() string {
 		cfg.headerString(),
 		cfg.URL,
 		skipVerify,
+		cfg.TLSCACert,
 		cfg.TLSClientCert,
 		cfg.TLSClientKey,
 	})
@@ -344,9 +347,10 @@ func externalAMcfgToAlertmanagerConfig(am ExternalAMcfg) (*config.AlertmanagerCo
 	}
 
 	// Set TLS configuration if any TLS options are provided
-	if am.InsecureSkipVerify || am.TLSClientCert != "" {
+	if am.InsecureSkipVerify || am.TLSCACert != "" || am.TLSClientCert != "" {
 		amConfig.HTTPClientConfig.TLSConfig = common_config.TLSConfig{
 			InsecureSkipVerify: am.InsecureSkipVerify,
+			CA:                 am.TLSCACert,
 			Cert:               am.TLSClientCert,
 			Key:                common_config.Secret(am.TLSClientKey),
 		}

--- a/pkg/services/ngalert/sender/sender_test.go
+++ b/pkg/services/ngalert/sender/sender_test.go
@@ -434,6 +434,62 @@ func TestExternalAMcfgToAlertmanagerConfig(t *testing.T) {
 			expectError: false,
 		},
 		{
+			name: "configuration with custom CA cert",
+			cfg: ExternalAMcfg{
+				URL:       "https://alertmanager.example.com:9093",
+				TLSCACert: "ca-cert-content",
+			},
+			expected: &config.AlertmanagerConfig{
+				APIVersion: config.AlertmanagerAPIVersionV2,
+				Scheme:     "https",
+				PathPrefix: "",
+				Timeout:    model.Duration(defaultTimeout),
+				ServiceDiscoveryConfigs: discovery.Configs{
+					discovery.StaticConfig{
+						{
+							Targets: []model.LabelSet{{model.AddressLabel: "alertmanager.example.com:9093"}},
+						},
+					},
+				},
+				HTTPClientConfig: common_config.HTTPClientConfig{
+					TLSConfig: common_config.TLSConfig{
+						CA: "ca-cert-content",
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
+			name: "configuration with custom CA cert and client auth",
+			cfg: ExternalAMcfg{
+				URL:           "https://alertmanager.example.com:9093",
+				TLSCACert:     "ca-cert-content",
+				TLSClientCert: "client-cert-content",
+				TLSClientKey:  "client-key-content",
+			},
+			expected: &config.AlertmanagerConfig{
+				APIVersion: config.AlertmanagerAPIVersionV2,
+				Scheme:     "https",
+				PathPrefix: "",
+				Timeout:    model.Duration(defaultTimeout),
+				ServiceDiscoveryConfigs: discovery.Configs{
+					discovery.StaticConfig{
+						{
+							Targets: []model.LabelSet{{model.AddressLabel: "alertmanager.example.com:9093"}},
+						},
+					},
+				},
+				HTTPClientConfig: common_config.HTTPClientConfig{
+					TLSConfig: common_config.TLSConfig{
+						CA:   "ca-cert-content",
+						Cert: "client-cert-content",
+						Key:  "client-key-content",
+					},
+				},
+			},
+			expectError: false,
+		},
+		{
 			name: "TLS client cert provided but key missing - should error",
 			cfg: ExternalAMcfg{
 				URL:           "https://alertmanager.example.com:9093",


### PR DESCRIPTION
Fixes #124980

## Problem

When an Alertmanager datasource is configured with "With CA Cert" (TLS root CA), the custom CA certificate was not used when Grafana sends alerts to that external Alertmanager. The `ExternalAMcfg` struct had no field for the CA cert, and `datasourceToExternalAMcfg` never read `tlsAuthWithCACert`/`tlsCACert` from the datasource config.

The config syncing path (fetching remote Alertmanager config) was not affected because it goes through the datasource service's HTTP transport, which does handle CA certs correctly. Only the alert-sending path was broken.

## Changes

- Add `TLSCACert` field to `ExternalAMcfg` in `sender.go`
- Include `TLSCACert` in the SHA256 hash so config changes are detected
- Read `tlsAuthWithCACert` and `tlsCACert` from the datasource in `datasourceToExternalAMcfg` in `router.go`
- Set `CA` on `common_config.TLSConfig` when building the Alertmanager HTTP client config
- Add tests covering the new CA cert path in both `router_test.go` and `sender_test.go`