### PR TITLE
Fix Connections: render an alert when plugin fails to load in ds config

### DIFF
--- a/public/app/features/datasources/components/DataSourceLoadError.tsx
+++ b/public/app/features/datasources/components/DataSourceLoadError.tsx
@@ -1,5 +1,5 @@
 import { t, Trans } from '@grafana/i18n';
-import { Alert, Button, EmptyState, Link, Stack } from '@grafana/ui';
+import { Alert, Button, EmptyState, Stack } from '@grafana/ui';
 
 import { type DataSourceRights } from '../types';
 

--- a/public/app/features/datasources/components/DataSourceLoadError.tsx
+++ b/public/app/features/datasources/components/DataSourceLoadError.tsx
@@ -1,17 +1,18 @@
 import { t, Trans } from '@grafana/i18n';
-import { Button, EmptyState, Stack } from '@grafana/ui';
+import { Alert, Button, EmptyState, Link, Stack } from '@grafana/ui';
 
 import { type DataSourceRights } from '../types';
 
 import { DataSourceReadOnlyMessage } from './DataSourceReadOnlyMessage';
 
 export type Props = {
+  errorMsg?: string | null;
   dataSourceRights: DataSourceRights;
   onDelete: () => void;
   notFound: boolean;
 };
 
-export function DataSourceLoadError({ dataSourceRights, onDelete, notFound }: Props) {
+export function DataSourceLoadError({ dataSourceRights, onDelete, notFound, errorMsg }: Props) {
   const { readOnly, hasDeleteRights } = dataSourceRights;
   const canDelete = !readOnly && hasDeleteRights;
   const navigateBack = () => window.history.back();
@@ -20,12 +21,21 @@ export function DataSourceLoadError({ dataSourceRights, onDelete, notFound }: Pr
     <>
       {readOnly && <DataSourceReadOnlyMessage />}
       <Stack direction="column">
-        <Stack direction="column" alignItems="center">
-          {notFound && (
+        <Stack direction="column" alignItems={notFound ? 'center' : 'flex-start'}>
+          {notFound ? (
             <EmptyState
               variant="not-found"
               message={t('datasources.data-source-load-error.not-found', 'Data source not found')}
             />
+          ) : (
+            <Alert
+              severity="error"
+              title={t('datasources.data-source-load-error.load-error-title', errorMsg || 'Error loading plugin')}
+            >
+              <Trans i18nKey="datasources.data-source-load-error.check-updates">
+                An unknown error occurred while loading the plugin. Please check for updates.
+              </Trans>
+            </Alert>
           )}
         </Stack>
         <Stack direction="row" gap={2}>

--- a/public/app/features/datasources/components/DataSourceLoadError.tsx
+++ b/public/app/features/datasources/components/DataSourceLoadError.tsx
@@ -30,7 +30,7 @@ export function DataSourceLoadError({ dataSourceRights, onDelete, notFound, erro
           ) : (
             <Alert
               severity="error"
-              title={t('datasources.data-source-load-error.load-error-title', errorMsg || 'Error loading plugin')}
+              title={errorMsg ?? t('datasources.data-source-load-error.load-error-title', 'Error loading plugin')}
             >
               <Trans i18nKey="datasources.data-source-load-error.check-updates">
                 An unknown error occurred while loading the plugin. Please check for updates.

--- a/public/app/features/datasources/components/EditDataSource.tsx
+++ b/public/app/features/datasources/components/EditDataSource.tsx
@@ -216,6 +216,7 @@ export function EditDataSourceView({
     return (
       <DataSourceLoadError
         notFound={!hasDataSource || !dsi}
+        errorMsg={loadError}
         dataSourceRights={dataSourceRights}
         onDelete={() => {
           trackDsConfigClicked('delete');

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8115,7 +8115,9 @@
     },
     "data-source-load-error": {
       "back": "Back",
+      "check-updates": "An unknown error occurred while loading the plugin. Please check for updates.",
       "delete": "Delete",
+      "load-error-title": "Error loading plugin",
       "not-found": "Data source not found"
     },
     "data-source-missing-rights-message": {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

This PR adds back a load error message when a plugin fails to load in datasource config page.

<img width="3584" height="2084" alt="image" src="https://github.com/user-attachments/assets/37efc149-484e-4377-a035-ede512c57b3f" />


**Why do we need this feature?**

So users are informed when a plugin fails to load.

**Who is this feature for?**

Grafana users / admins

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
