### PR TITLE
Packaging: Properly name install directory and re-use it for the service

### DIFF
--- a/packaging/msi/grafana-product.wxs.tpl
+++ b/packaging/msi/grafana-product.wxs.tpl
@@ -32,7 +32,7 @@
     <Directory Id="TARGETDIR" Name="SourceDir">
       <Directory Id="ProgramFiles64Folder">
         <Directory Id="INSTALLDIR" Name="GrafanaLabs">
-          <Directory Id="GrafanaX64Dir" />
+          <Directory Id="GrafanaX64Dir" Name="grafana" />
           <Directory Id="GrafanaServiceX64Dir" Name="svc-${GRAFANA_VERSION}" />
         </Directory>
       </Directory>

--- a/packaging/msi/grafana-service.wxs
+++ b/packaging/msi/grafana-service.wxs
@@ -29,8 +29,8 @@
 
         <RegistryKey Root="HKLM" Key="SYSTEM\CurrentControlSet\Services\Grafana">
           <RegistryKey Key="Parameters">
-            <RegistryValue Name="AppDirectory" Value="[INSTALLDIR]grafana" Type="expandable" />
-            <RegistryValue Name="Application" Value="[INSTALLDIR]grafana\bin\grafana.exe" Type="expandable" />
+            <RegistryValue Name="AppDirectory" Value="[GrafanaX64Dir]" Type="expandable" />
+            <RegistryValue Name="Application" Value="[GrafanaX64Dir]bin\grafana.exe" Type="expandable" />
             <RegistryValue Name="AppParameters" Value='server' Type="expandable" />
 
             <RegistryValue Name="AppEnvironmentExtra" Type="multiString">


### PR DESCRIPTION
Adding `Name` to `GrafanaX64Dir` so it installs Grafana at `C:\Program Files\GrafanaLabs\grafana\` , and re-use that variable/directory for the service initialization.