### PR TITLE
Datasources: Move default button to bottom of form

### DIFF
--- a/packages/grafana-ui/src/components/ConfirmModal/ConfirmContent.tsx
+++ b/packages/grafana-ui/src/components/ConfirmModal/ConfirmContent.tsx
@@ -44,8 +44,6 @@ export interface ConfirmContentProps {
   onAlternative?(): void;
   /** Disable the confirm button and the confirm text input if needed */
   disabled?: boolean;
-  /** Control event propagation on submit */
-  propagate?: boolean;
 }
 
 export const ConfirmContent = ({
@@ -62,7 +60,6 @@ export const ConfirmContent = ({
   description,
   justifyButtons = 'flex-end',
   disabled,
-  propagate = true,
 }: ConfirmContentProps) => {
   const [isDisabled, setIsDisabled] = useState(disabled);
   const styles = useStyles2(getStyles);
@@ -96,9 +93,7 @@ export const ConfirmContent = ({
   const { handleSubmit } = useForm();
   const stopPropagation = (callback: (event: React.FormEvent) => void) => {
     return (event: React.FormEvent) => {
-      if (!propagate) {
-        event.stopPropagation();
-      }
+      event.stopPropagation();
       callback(event);
     };
   };

--- a/packages/grafana-ui/src/components/ConfirmModal/ConfirmContent.tsx
+++ b/packages/grafana-ui/src/components/ConfirmModal/ConfirmContent.tsx
@@ -44,6 +44,8 @@ export interface ConfirmContentProps {
   onAlternative?(): void;
   /** Disable the confirm button and the confirm text input if needed */
   disabled?: boolean;
+  /** Control event propagation on submit */
+  propagate?: boolean;
 }
 
 export const ConfirmContent = ({
@@ -60,6 +62,7 @@ export const ConfirmContent = ({
   description,
   justifyButtons = 'flex-end',
   disabled,
+  propagate = true,
 }: ConfirmContentProps) => {
   const [isDisabled, setIsDisabled] = useState(disabled);
   const styles = useStyles2(getStyles);
@@ -91,11 +94,20 @@ export const ConfirmContent = ({
   };
 
   const { handleSubmit } = useForm();
+  const stopPropagation = (callback: (event: React.FormEvent) => void) => {
+    return (event: React.FormEvent) => {
+      if (!propagate) {
+        event.stopPropagation();
+      }
+      callback(event);
+    };
+  };
+
   const placeholder = t('grafana-ui.confirm-content.placeholder', 'Type "{{confirmPromptText}}" to confirm', {
     confirmPromptText,
   });
   return (
-    <form onSubmit={handleSubmit(onConfirmClick)}>
+    <form onSubmit={stopPropagation(handleSubmit(onConfirmClick))}>
       <div className={styles.text}>
         {body}
         {description ? <div className={styles.description}>{description}</div> : null}

--- a/packages/grafana-ui/src/components/ConfirmModal/ConfirmModal.tsx
+++ b/packages/grafana-ui/src/components/ConfirmModal/ConfirmModal.tsx
@@ -45,8 +45,6 @@ export interface ConfirmModalProps {
   onAlternative?(): void;
   /** Disable the confirm button and the confirm text input if needed */
   disabled?: boolean;
-  /** Control event propagation on submit */
-  propagate?: boolean;
 }
 
 /**
@@ -71,7 +69,6 @@ export const ConfirmModal = ({
   onAlternative,
   confirmButtonVariant,
   disabled,
-  propagate = true,
 }: ConfirmModalProps): JSX.Element => {
   const styles = useStyles2(getStyles);
 
@@ -90,7 +87,6 @@ export const ConfirmModal = ({
         onDismiss={onDismiss}
         onAlternative={onAlternative}
         disabled={disabled}
-        propagate={propagate}
       />
     </Modal>
   );

--- a/packages/grafana-ui/src/components/ConfirmModal/ConfirmModal.tsx
+++ b/packages/grafana-ui/src/components/ConfirmModal/ConfirmModal.tsx
@@ -45,6 +45,8 @@ export interface ConfirmModalProps {
   onAlternative?(): void;
   /** Disable the confirm button and the confirm text input if needed */
   disabled?: boolean;
+  /** Control event propagation on submit */
+  propagate?: boolean;
 }
 
 /**
@@ -69,6 +71,7 @@ export const ConfirmModal = ({
   onAlternative,
   confirmButtonVariant,
   disabled,
+  propagate = true,
 }: ConfirmModalProps): JSX.Element => {
   const styles = useStyles2(getStyles);
 
@@ -87,6 +90,7 @@ export const ConfirmModal = ({
         onDismiss={onDismiss}
         onAlternative={onAlternative}
         disabled={disabled}
+        propagate={propagate}
       />
     </Modal>
   );

--- a/public/app/features/datasources/components/ButtonRow.tsx
+++ b/public/app/features/datasources/components/ButtonRow.tsx
@@ -10,9 +10,10 @@ export interface Props {
   onDelete: (event: React.MouseEvent<HTMLButtonElement>) => void;
   onSubmit: (event: React.MouseEvent<HTMLButtonElement>) => void;
   onTest: (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => void;
+  children?: React.ReactNode;
 }
 
-export function ButtonRow({ canSave, canDelete, onDelete, onSubmit, onTest }: Props) {
+export function ButtonRow({ canSave, canDelete, onDelete, onSubmit, onTest, children }: Props) {
   return (
     <div className="gf-form-button-row">
       <Button
@@ -24,6 +25,9 @@ export function ButtonRow({ canSave, canDelete, onDelete, onSubmit, onTest }: Pr
       >
         <Trans i18nKey="datasources.button-row.delete">Delete</Trans>
       </Button>
+
+      {children}
+
       {canSave && (
         <Button
           type="submit"

--- a/public/app/features/datasources/components/DataSourceDefaultButton.test.tsx
+++ b/public/app/features/datasources/components/DataSourceDefaultButton.test.tsx
@@ -58,30 +58,23 @@ describe('DataSourceDefaultButton', () => {
     expect(screen.queryByText('Make default')).not.toBeInTheDocument();
   });
 
-  it('should not render make default button when data source is not default but not editable', () => {
+  it('should not render either button when data source is not editable', () => {
     mockUseDataSource.mockReturnValue({ ...mockDataSource, isDefault: false });
-    mockUseDataSourceRights.mockReturnValue({ hasWriteRights: false, readOnly: true });
+    mockUseDataSourceRights.mockReturnValue({ ...mockDataSourceRights, readOnly: true });
 
     render(<DataSourceDefaultButton uid="test-uid" />);
 
     expect(screen.queryByLabelText('Make default')).not.toBeInTheDocument();
-  });
-
-  it('should not render remove default button when data source is default but not editable', () => {
-    mockUseDataSource.mockReturnValue({ ...mockDataSource, isDefault: true });
-    mockUseDataSourceRights.mockReturnValue({ hasWriteRights: false, readOnly: true });
-
-    render(<DataSourceDefaultButton uid="test-uid" />);
-
     expect(screen.queryByLabelText('Remove default')).not.toBeInTheDocument();
   });
 
-  it('should render default badge when data source is default but not editable', () => {
-    mockUseDataSource.mockReturnValue({ ...mockDataSource, isDefault: true });
-    mockUseDataSourceRights.mockReturnValue({ hasWriteRights: true, readOnly: true });
+  it('should not render either button when user lacks write permissions', () => {
+    mockUseDataSource.mockReturnValue({ ...mockDataSource, isDefault: false });
+    mockUseDataSourceRights.mockReturnValue({ ...mockDataSourceRights, hasWriteRights: false });
 
     render(<DataSourceDefaultButton uid="test-uid" />);
 
-    expect(screen.getByText('Default')).toBeInTheDocument();
+    expect(screen.queryByLabelText('Make default')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('Remove default')).not.toBeInTheDocument();
   });
 });

--- a/public/app/features/datasources/components/DataSourceDefaultButton.test.tsx
+++ b/public/app/features/datasources/components/DataSourceDefaultButton.test.tsx
@@ -1,0 +1,87 @@
+import { render, screen } from '@testing-library/react';
+
+import { useDispatch } from 'app/types/store';
+
+import { getMockDataSource } from '../mocks/dataSourcesMocks';
+
+import { DataSourceDefaultButton } from './DataSourceDefaultButton';
+
+jest.mock('app/types/store', () => ({
+  ...jest.requireActual('app/types/store'),
+  useDispatch: jest.fn(),
+}));
+
+const mockDataSource = getMockDataSource({
+  uid: 'test-uid',
+  type: 'prometheus',
+  name: 'Test Prometheus',
+  typeName: 'Prometheus',
+});
+
+const mockDataSourceRights = {
+  hasWriteRights: true,
+  readOnly: false,
+};
+
+jest.mock('../state/hooks', () => ({
+  useDataSource: jest.fn(() => mockDataSource),
+  useDataSourceRights: jest.fn(() => mockDataSourceRights),
+}));
+
+const mockUseDispatch = jest.mocked(useDispatch);
+const mockUseDataSource = jest.mocked(require('../state/hooks').useDataSource);
+const mockUseDataSourceRights = jest.mocked(require('../state/hooks').useDataSourceRights);
+
+describe('DataSourceDefaultButton', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseDispatch.mockReturnValue(jest.fn());
+    mockUseDataSource.mockReturnValue(mockDataSource);
+    mockUseDataSourceRights.mockReturnValue(mockDataSourceRights);
+  });
+
+  it('should render make default button when data source is not default and editable', () => {
+    mockUseDataSource.mockReturnValue({ ...mockDataSource, isDefault: false });
+
+    render(<DataSourceDefaultButton uid="test-uid" />);
+
+    expect(screen.getByText('Make default')).toBeInTheDocument();
+    expect(screen.queryByText('Remove default')).not.toBeInTheDocument();
+  });
+
+  it('should render remove default button when data source is default and editable', () => {
+    mockUseDataSource.mockReturnValue({ ...mockDataSource, isDefault: true });
+
+    render(<DataSourceDefaultButton uid="test-uid" />);
+
+    expect(screen.getByText('Remove default')).toBeInTheDocument();
+    expect(screen.queryByText('Make default')).not.toBeInTheDocument();
+  });
+
+  it('should not render make default button when data source is not default but not editable', () => {
+    mockUseDataSource.mockReturnValue({ ...mockDataSource, isDefault: false });
+    mockUseDataSourceRights.mockReturnValue({ hasWriteRights: false, readOnly: true });
+
+    render(<DataSourceDefaultButton uid="test-uid" />);
+
+    expect(screen.queryByLabelText('Make default')).not.toBeInTheDocument();
+  });
+
+  it('should not render remove default button when data source is default but not editable', () => {
+    mockUseDataSource.mockReturnValue({ ...mockDataSource, isDefault: true });
+    mockUseDataSourceRights.mockReturnValue({ hasWriteRights: false, readOnly: true });
+
+    render(<DataSourceDefaultButton uid="test-uid" />);
+
+    expect(screen.queryByLabelText('Remove default')).not.toBeInTheDocument();
+  });
+
+  it('should render default badge when data source is default but not editable', () => {
+    mockUseDataSource.mockReturnValue({ ...mockDataSource, isDefault: true });
+    mockUseDataSourceRights.mockReturnValue({ hasWriteRights: true, readOnly: true });
+
+    render(<DataSourceDefaultButton uid="test-uid" />);
+
+    expect(screen.getByText('Default')).toBeInTheDocument();
+  });
+});

--- a/public/app/features/datasources/components/DataSourceDefaultButton.tsx
+++ b/public/app/features/datasources/components/DataSourceDefaultButton.tsx
@@ -98,7 +98,6 @@ export const DataSourceDefaultButton = ({ uid }: { uid: string }) => {
         dismissText={t('datasources.default-button.cancel', 'Cancel')}
         onConfirm={() => onChangeDefault(!dataSource.isDefault)}
         onDismiss={() => setConfirming(false)}
-        propagate={false}
       />
     </>
   );

--- a/public/app/features/datasources/components/DataSourceDefaultButton.tsx
+++ b/public/app/features/datasources/components/DataSourceDefaultButton.tsx
@@ -1,0 +1,91 @@
+import { useState } from 'react';
+
+import { t, Trans } from '@grafana/i18n';
+import { isFetchError } from '@grafana/runtime';
+import { Badge, Tooltip, Button } from '@grafana/ui';
+import { createErrorNotification } from 'app/core/copy/appNotification';
+import { notifyApp } from 'app/core/reducers/appNotification';
+import { useDispatch } from 'app/types/store';
+
+import * as api from '../api';
+import { useDataSource, useDataSourceRights } from '../state/hooks';
+import { setIsDefault } from '../state/reducers';
+
+export const DataSourceDefaultButton = ({ uid }: { uid: string }) => {
+  const [loading, setLoading] = useState(false);
+
+  const dataSource = useDataSource(uid);
+  const rights = useDataSourceRights(uid);
+  const editable = rights.hasWriteRights && !rights.readOnly;
+
+  const dispatch = useDispatch();
+
+  const onChangeDefault = async (value: boolean) => {
+    if (loading) {
+      return;
+    }
+    setLoading(true);
+
+    try {
+      // Make manual API calls to avoid pre-emptively saving other changes from the EditDataSource form
+      const ds = await api.getDataSourceByUid(uid);
+      await api.updateDataSource({ ...ds, isDefault: value });
+      dispatch(setIsDefault(value));
+    } catch (error) {
+      dispatch(
+        notifyApp(
+          createErrorNotification(
+            t('datasources.default-button.error', 'Failed to update default data source'),
+            isFetchError(error) ? error.data.message : error instanceof Error ? error.message : undefined
+          )
+        )
+      );
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  if (!editable) {
+    return dataSource.isDefault ? (
+      <Badge
+        text={
+          <Tooltip
+            content={[
+              t('datasources.default-button.active', 'This data source is currently set as the default.'),
+              t('datasources.default-button.tooltip', 'The default data source is preselected in new panels.'),
+            ].join(' ')}
+          >
+            <span>
+              <Trans i18nKey="datasources.default-button.label">Default</Trans>
+            </span>
+          </Tooltip>
+        }
+        color="blue"
+      />
+    ) : null;
+  }
+
+  return (
+    <Button
+      variant="secondary"
+      size="sm"
+      tooltip={[
+        dataSource.isDefault &&
+          t('datasources.default-button.active', 'This data source is currently set as the default.'),
+        t('datasources.default-button.tooltip', 'The default data source is preselected in new panels.'),
+      ]
+        .filter(Boolean)
+        .join(' ')}
+      onClick={() => onChangeDefault(!dataSource.isDefault)}
+      icon={loading ? 'spinner' : undefined}
+      iconPlacement="right"
+      disabled={loading}
+    >
+      {dataSource.isDefault ? (
+        <Trans i18nKey="datasources.default-button.remove">Remove default</Trans>
+      ) : (
+        <Trans i18nKey="datasources.default-button.make">Make default</Trans>
+      )}
+    </Button>
+  );
+};

--- a/public/app/features/datasources/components/DataSourceDefaultButton.tsx
+++ b/public/app/features/datasources/components/DataSourceDefaultButton.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import { t, Trans } from '@grafana/i18n';
 import { isFetchError } from '@grafana/runtime';
-import { Badge, Tooltip, Button, ConfirmModal } from '@grafana/ui';
+import { Button, ConfirmModal } from '@grafana/ui';
 import { createErrorNotification } from 'app/core/copy/appNotification';
 import { notifyApp } from 'app/core/reducers/appNotification';
 import { useDispatch } from 'app/types/store';
@@ -48,23 +48,7 @@ export const DataSourceDefaultButton = ({ uid }: { uid: string }) => {
   };
 
   if (!editable) {
-    return dataSource.isDefault ? (
-      <Badge
-        text={
-          <Tooltip
-            content={[
-              t('datasources.default-button.active', 'This data source is currently set as the default.'),
-              t('datasources.default-button.tooltip', 'The default data source is preselected in new panels.'),
-            ].join(' ')}
-          >
-            <span>
-              <Trans i18nKey="datasources.default-button.label">Default</Trans>
-            </span>
-          </Tooltip>
-        }
-        color="blue"
-      />
-    ) : null;
+    return null;
   }
 
   return (

--- a/public/app/features/datasources/components/DataSourceDefaultButton.tsx
+++ b/public/app/features/datasources/components/DataSourceDefaultButton.tsx
@@ -2,7 +2,7 @@ import { useState } from 'react';
 
 import { t, Trans } from '@grafana/i18n';
 import { isFetchError } from '@grafana/runtime';
-import { Badge, Tooltip, Button } from '@grafana/ui';
+import { Badge, Tooltip, Button, ConfirmModal } from '@grafana/ui';
 import { createErrorNotification } from 'app/core/copy/appNotification';
 import { notifyApp } from 'app/core/reducers/appNotification';
 import { useDispatch } from 'app/types/store';
@@ -13,6 +13,7 @@ import { setIsDefault } from '../state/reducers';
 
 export const DataSourceDefaultButton = ({ uid }: { uid: string }) => {
   const [loading, setLoading] = useState(false);
+  const [confirming, setConfirming] = useState(false);
 
   const dataSource = useDataSource(uid);
   const rights = useDataSourceRights(uid);
@@ -21,10 +22,11 @@ export const DataSourceDefaultButton = ({ uid }: { uid: string }) => {
   const dispatch = useDispatch();
 
   const onChangeDefault = async (value: boolean) => {
-    if (loading) {
+    if (loading || !confirming) {
       return;
     }
     setLoading(true);
+    setConfirming(false);
 
     try {
       // Make manual API calls to avoid pre-emptively saving other changes from the EditDataSource form
@@ -66,26 +68,54 @@ export const DataSourceDefaultButton = ({ uid }: { uid: string }) => {
   }
 
   return (
-    <Button
-      variant="secondary"
-      size="sm"
-      tooltip={[
-        dataSource.isDefault &&
-          t('datasources.default-button.active', 'This data source is currently set as the default.'),
-        t('datasources.default-button.tooltip', 'The default data source is preselected in new panels.'),
-      ]
-        .filter(Boolean)
-        .join(' ')}
-      onClick={() => onChangeDefault(!dataSource.isDefault)}
-      icon={loading ? 'spinner' : undefined}
-      iconPlacement="right"
-      disabled={loading}
-    >
-      {dataSource.isDefault ? (
-        <Trans i18nKey="datasources.default-button.remove">Remove default</Trans>
-      ) : (
-        <Trans i18nKey="datasources.default-button.make">Make default</Trans>
-      )}
-    </Button>
+    <>
+      <Button
+        variant="secondary"
+        size="sm"
+        tooltip={[
+          dataSource.isDefault &&
+            t('datasources.default-button.active', 'This data source is currently set as the default.'),
+          t('datasources.default-button.tooltip', 'The default data source is preselected in new panels.'),
+        ]
+          .filter(Boolean)
+          .join(' ')}
+        onClick={() => setConfirming(true)}
+        icon={loading ? 'spinner' : undefined}
+        iconPlacement="right"
+        disabled={loading}
+      >
+        {dataSource.isDefault ? (
+          <Trans i18nKey="datasources.default-button.remove">Remove default</Trans>
+        ) : (
+          <Trans i18nKey="datasources.default-button.make">Make default</Trans>
+        )}
+      </Button>
+
+      <ConfirmModal
+        isOpen={confirming}
+        title={
+          dataSource.isDefault
+            ? t('datasources.default-button.remove', 'Remove default')
+            : t('datasources.default-button.make', 'Make default')
+        }
+        body={[
+          dataSource.isDefault
+            ? t(
+                'datasources.default-button.remove-confirm',
+                'Are you sure you want to remove the default status from this data source for all users?'
+              )
+            : t(
+                'datasources.default-button.make-confirm',
+                'Are you sure you want to set this data source as the default for all users?'
+              ),
+          t('datasources.default-button.tooltip', 'The default data source is preselected in new panels.'),
+        ].join(' ')}
+        confirmText={t('datasources.default-button.confirm', 'Confirm')}
+        confirmVariant={dataSource.isDefault ? 'destructive' : 'primary'}
+        dismissText={t('datasources.default-button.cancel', 'Cancel')}
+        onConfirm={() => onChangeDefault(!dataSource.isDefault)}
+        onDismiss={() => setConfirming(false)}
+      />
+    </>
   );
 };

--- a/public/app/features/datasources/components/DataSourceDefaultButton.tsx
+++ b/public/app/features/datasources/components/DataSourceDefaultButton.tsx
@@ -71,7 +71,6 @@ export const DataSourceDefaultButton = ({ uid }: { uid: string }) => {
     <>
       <Button
         variant="secondary"
-        size="sm"
         tooltip={[
           dataSource.isDefault &&
             t('datasources.default-button.active', 'This data source is currently set as the default.'),
@@ -115,6 +114,7 @@ export const DataSourceDefaultButton = ({ uid }: { uid: string }) => {
         dismissText={t('datasources.default-button.cancel', 'Cancel')}
         onConfirm={() => onChangeDefault(!dataSource.isDefault)}
         onDismiss={() => setConfirming(false)}
+        propagate={false}
       />
     </>
   );

--- a/public/app/features/datasources/components/EditDataSource.tsx
+++ b/public/app/features/datasources/components/EditDataSource.tsx
@@ -35,6 +35,7 @@ import { type DataSourceRights } from '../types';
 
 import { ButtonRow } from './ButtonRow';
 import { CloudInfoBox } from './CloudInfoBox';
+import { DataSourceDefaultButton } from './DataSourceDefaultButton';
 import { DataSourceLoadError } from './DataSourceLoadError';
 import { DataSourceMissingRightsMessage } from './DataSourceMissingRightsMessage';
 import { DataSourcePluginConfigPage } from './DataSourcePluginConfigPage';
@@ -298,7 +299,9 @@ export function EditDataSourceView({
         }}
         canDelete={!readOnly && hasDeleteRights}
         canSave={!readOnly && hasWriteRights}
-      />
+      >
+        <DataSourceDefaultButton uid={dataSource.uid} />
+      </ButtonRow>
     </form>
   );
 }

--- a/public/app/features/datasources/components/EditDataSourceActions.test.tsx
+++ b/public/app/features/datasources/components/EditDataSourceActions.test.tsx
@@ -3,7 +3,6 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { PluginExtensionTypes, type IconName } from '@grafana/data';
 import { setPluginLinksHook, config, getDataSourceSrv } from '@grafana/runtime';
 import { contextSrv } from 'app/core/services/context_srv';
-import { useDispatch } from 'app/types/store';
 
 import { getMockDataSource } from '../mocks/dataSourcesMocks';
 
@@ -11,10 +10,6 @@ import { EditDataSourceActions } from './EditDataSourceActions';
 
 // Mock dependencies
 jest.mock('app/core/services/context_srv');
-jest.mock('app/types/store', () => ({
-  ...jest.requireActual('app/types/store'),
-  useDispatch: jest.fn(),
-}));
 jest.mock('../utils', () => ({
   constructDataSourceExploreUrl: jest.fn(
     () => '/explore?left=%7B%22datasource%22:%22Test%20Prometheus%22,%22context%22:%22explore%22%7D'
@@ -48,6 +43,10 @@ jest.mock('./BuildDashboardButton', () => ({
   ),
 }));
 
+jest.mock('./DataSourceDefaultButton', () => ({
+  DataSourceDefaultButton: () => <div data-testid="datasource-default-button" />,
+}));
+
 // Set default plugin links hook
 setPluginLinksHook(() => ({ links: [], isLoading: false }));
 
@@ -57,7 +56,6 @@ const mockContextSrv = jest.mocked(contextSrv);
 // Mock getDataSourceSrv and favorite hooks
 const mockGetDataSourceSrv = jest.mocked(getDataSourceSrv);
 const mockUseFavoriteDatasources = jest.mocked(require('@grafana/runtime').useFavoriteDatasources);
-const mockUseDispatch = jest.mocked(useDispatch);
 
 // Create mock datasource instance
 const mockDataSourceInstance = {
@@ -109,19 +107,12 @@ const mockDataSource = getMockDataSource({
   typeName: 'Prometheus',
 });
 
-const mockDataSourceRights = {
-  hasWriteRights: true,
-  readOnly: false,
-};
-
 // Mock useDataSource hook
 jest.mock('../state/hooks', () => ({
   useDataSource: jest.fn((uid: string) => (uid === 'not-found' ? {} : mockDataSource)),
-  useDataSourceRights: jest.fn((uid: string) => (uid === 'not-found' ? {} : mockDataSourceRights)),
 }));
 
 const mockUseDataSource = jest.mocked(require('../state/hooks').useDataSource);
-const mockUseDataSourceRights = jest.mocked(require('../state/hooks').useDataSourceRights);
 
 describe('EditDataSourceActions', () => {
   beforeEach(() => {
@@ -150,9 +141,7 @@ describe('EditDataSourceActions', () => {
     config.featureToggles.favoriteDatasources = false;
 
     // Reset default hook mocks
-    mockUseDispatch.mockReturnValue(jest.fn());
     mockUseDataSource.mockImplementation((uid: string) => (uid === 'not-found' ? {} : mockDataSource));
-    mockUseDataSourceRights.mockImplementation((uid: string) => (uid === 'not-found' ? {} : mockDataSourceRights));
   });
 
   describe('Core Actions', () => {
@@ -533,53 +522,6 @@ describe('EditDataSourceActions', () => {
 
       const favoriteButton = screen.getByTestId('favorite-button');
       expect(favoriteButton).toBeDisabled();
-    });
-  });
-
-  describe('Default Actions', () => {
-    it('should render make default button when data source is not default and editable', () => {
-      mockUseDataSource.mockReturnValue({ ...mockDataSource, isDefault: false });
-
-      render(<EditDataSourceActions uid="test-uid" />);
-
-      expect(screen.getByText('Make default')).toBeInTheDocument();
-      expect(screen.queryByText('Remove default')).not.toBeInTheDocument();
-    });
-
-    it('should render remove default button when data source is default and editable', () => {
-      mockUseDataSource.mockReturnValue({ ...mockDataSource, isDefault: true });
-
-      render(<EditDataSourceActions uid="test-uid" />);
-
-      expect(screen.getByText('Remove default')).toBeInTheDocument();
-      expect(screen.queryByText('Make default')).not.toBeInTheDocument();
-    });
-
-    it('should not render make default button when data source is not default but not editable', () => {
-      mockUseDataSource.mockReturnValue({ ...mockDataSource, isDefault: false });
-      mockUseDataSourceRights.mockReturnValue({ hasWriteRights: false, readOnly: true });
-
-      render(<EditDataSourceActions uid="test-uid" />);
-
-      expect(screen.queryByLabelText('Make default')).not.toBeInTheDocument();
-    });
-
-    it('should not render remove default button when data source is default but not editable', () => {
-      mockUseDataSource.mockReturnValue({ ...mockDataSource, isDefault: true });
-      mockUseDataSourceRights.mockReturnValue({ hasWriteRights: false, readOnly: true });
-
-      render(<EditDataSourceActions uid="test-uid" />);
-
-      expect(screen.queryByLabelText('Remove default')).not.toBeInTheDocument();
-    });
-
-    it('should render default badge when data source is default but not editable', () => {
-      mockUseDataSource.mockReturnValue({ ...mockDataSource, isDefault: true });
-      mockUseDataSourceRights.mockReturnValue({ hasWriteRights: true, readOnly: true });
-
-      render(<EditDataSourceActions uid="test-uid" />);
-
-      expect(screen.getByText('Default')).toBeInTheDocument();
     });
   });
 });

--- a/public/app/features/datasources/components/EditDataSourceActions.test.tsx
+++ b/public/app/features/datasources/components/EditDataSourceActions.test.tsx
@@ -43,10 +43,6 @@ jest.mock('./BuildDashboardButton', () => ({
   ),
 }));
 
-jest.mock('./DataSourceDefaultButton', () => ({
-  DataSourceDefaultButton: () => <div data-testid="datasource-default-button" />,
-}));
-
 // Set default plugin links hook
 setPluginLinksHook(() => ({ links: [], isLoading: false }));
 

--- a/public/app/features/datasources/components/EditDataSourceActions.tsx
+++ b/public/app/features/datasources/components/EditDataSourceActions.tsx
@@ -10,7 +10,6 @@ import { trackDsConfigClicked, trackExploreClicked } from '../tracking';
 import { constructDataSourceExploreUrl } from '../utils';
 
 import { BuildDashboardButton } from './BuildDashboardButton';
-import { DataSourceDefaultButton } from './DataSourceDefaultButton';
 import { INTERACTION_EVENT_NAME, INTERACTION_ITEM } from './picker/DataSourcePicker';
 
 interface Props {
@@ -106,7 +105,6 @@ export function EditDataSourceActions({ uid }: Props) {
   return (
     <>
       <FavoriteButton uid={uid} />
-      <DataSourceDefaultButton uid={uid} />
       {hasExploreRights && (
         <>
           {!hasActions ? (

--- a/public/app/features/datasources/components/EditDataSourceActions.tsx
+++ b/public/app/features/datasources/components/EditDataSourceActions.tsx
@@ -1,29 +1,16 @@
-import { useState } from 'react';
-
 import { PluginExtensionPoints } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
-import {
-  config,
-  usePluginLinks,
-  useFavoriteDatasources,
-  getDataSourceSrv,
-  reportInteraction,
-  isFetchError,
-} from '@grafana/runtime';
-import { Button, Dropdown, LinkButton, Menu, Icon, IconButton, Badge, Tooltip } from '@grafana/ui';
-import { createErrorNotification } from 'app/core/copy/appNotification';
-import { notifyApp } from 'app/core/reducers/appNotification';
+import { config, usePluginLinks, useFavoriteDatasources, getDataSourceSrv, reportInteraction } from '@grafana/runtime';
+import { Button, Dropdown, LinkButton, Menu, Icon, IconButton } from '@grafana/ui';
 import { contextSrv } from 'app/core/services/context_srv';
-import { useDispatch } from 'app/types/store';
 
-import * as api from '../api';
 import { ALLOWED_DATASOURCE_EXTENSION_PLUGINS } from '../constants';
-import { useDataSource, useDataSourceRights } from '../state/hooks';
-import { setIsDefault } from '../state/reducers';
+import { useDataSource } from '../state/hooks';
 import { trackDsConfigClicked, trackExploreClicked } from '../tracking';
 import { constructDataSourceExploreUrl } from '../utils';
 
 import { BuildDashboardButton } from './BuildDashboardButton';
+import { DataSourceDefaultButton } from './DataSourceDefaultButton';
 import { INTERACTION_EVENT_NAME, INTERACTION_ITEM } from './picker/DataSourcePicker';
 
 interface Props {
@@ -62,94 +49,6 @@ const FavoriteButton = ({ uid }: { uid: string }) => {
         data-testid="favorite-button"
       />
     )
-  );
-};
-
-const DefaultButton = ({ uid }: { uid: string }) => {
-  const [loading, setLoading] = useState(false);
-
-  const dataSource = useDataSource(uid);
-  const rights = useDataSourceRights(uid);
-  const editable = rights.hasWriteRights && !rights.readOnly;
-
-  const dispatch = useDispatch();
-
-  const onChangeDefault = async (value: boolean) => {
-    if (loading) {
-      return;
-    }
-    setLoading(true);
-
-    try {
-      // Make manual API calls to avoid pre-emptively saving other changes from the EditDataSource form
-      const ds = await api.getDataSourceByUid(uid);
-      await api.updateDataSource({ ...ds, isDefault: value });
-      dispatch(setIsDefault(value));
-    } catch (error) {
-      dispatch(
-        notifyApp(
-          createErrorNotification(
-            t('datasources.edit-data-source-actions.default-error', 'Failed to update default data source'),
-            isFetchError(error) ? error.data.message : error instanceof Error ? error.message : undefined
-          )
-        )
-      );
-    }
-
-    setLoading(false);
-  };
-
-  if (!editable) {
-    return dataSource.isDefault ? (
-      <Badge
-        text={
-          <Tooltip
-            content={[
-              t(
-                'datasources.edit-data-source-actions.default-active',
-                'This data source is currently set as the default.'
-              ),
-              t(
-                'datasources.edit-data-source-actions.default-tooltip',
-                'The default data source is preselected in new panels.'
-              ),
-            ].join(' ')}
-          >
-            <span>
-              <Trans i18nKey="datasources.edit-data-source-actions.default-label">Default</Trans>
-            </span>
-          </Tooltip>
-        }
-        color="blue"
-      />
-    ) : null;
-  }
-
-  return (
-    <Button
-      variant="secondary"
-      size="sm"
-      tooltip={[
-        dataSource.isDefault &&
-          t('datasources.edit-data-source-actions.default-active', 'This data source is currently set as the default.'),
-        t(
-          'datasources.edit-data-source-actions.default-tooltip',
-          'The default data source is preselected in new panels.'
-        ),
-      ]
-        .filter(Boolean)
-        .join(' ')}
-      onClick={() => onChangeDefault(!dataSource.isDefault)}
-      icon={loading ? 'spinner' : undefined}
-      iconPlacement="right"
-      disabled={loading}
-    >
-      {dataSource.isDefault ? (
-        <Trans i18nKey="datasources.edit-data-source-actions.default-remove-button">Remove default</Trans>
-      ) : (
-        <Trans i18nKey="datasources.edit-data-source-actions.default-make-button">Make default</Trans>
-      )}
-    </Button>
   );
 };
 
@@ -207,7 +106,7 @@ export function EditDataSourceActions({ uid }: Props) {
   return (
     <>
       <FavoriteButton uid={uid} />
-      <DefaultButton uid={uid} />
+      <DataSourceDefaultButton uid={uid} />
       {hasExploreRights && (
         <>
           {!hasActions ? (

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8160,10 +8160,14 @@
     },
     "default-button": {
       "active": "This data source is currently set as the default.",
+      "cancel": "Cancel",
+      "confirm": "Confirm",
       "error": "Failed to update default data source",
       "label": "Default",
       "make": "Make default",
+      "make-confirm": "Are you sure you want to set this data source as the default for all users?",
       "remove": "Remove default",
+      "remove-confirm": "Are you sure you want to remove the default status from this data source for all users?",
       "tooltip": "The default data source is preselected in new panels."
     },
     "edit-data-source-actions": {

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8158,14 +8158,16 @@
     "data-sources-list-card": {
       "explore": "Explore"
     },
+    "default-button": {
+      "active": "This data source is currently set as the default.",
+      "error": "Failed to update default data source",
+      "label": "Default",
+      "make": "Make default",
+      "remove": "Remove default",
+      "tooltip": "The default data source is preselected in new panels."
+    },
     "edit-data-source-actions": {
       "add-favorite": "Add to favorites",
-      "default-active": "This data source is currently set as the default.",
-      "default-error": "Failed to update default data source",
-      "default-label": "Default",
-      "default-make-button": "Make default",
-      "default-remove-button": "Remove default",
-      "default-tooltip": "The default data source is preselected in new panels.",
       "explore-data": "Explore data",
       "open-in-explore": "Open in Explore View",
       "remove-favorite": "Remove from favorites"

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -8163,7 +8163,6 @@
       "cancel": "Cancel",
       "confirm": "Confirm",
       "error": "Failed to update default data source",
-      "label": "Default",
       "make": "Make default",
       "make-confirm": "Are you sure you want to set this data source as the default for all users?",
       "remove": "Remove default",


### PR DESCRIPTION
**What is this feature?**

Moves the default button introduced in #122847 from the header actions to the existing button row at the bottom of the form. Also, introduces a modal confirmation before making a change to the default when the user clicks the button.

<img width="426" height="94" alt="image" src="https://github.com/user-attachments/assets/f03759f9-c09c-4633-ae62-e180bfdea9fb" />

**Why do we need this feature?**

We received some feedback that having it with the actions in the header was breaking folks' muscle memory for the explore button. Given we already have other button actions at the bottom of the form, including an existing destructive action, this seems like a good alternative home.

**Who is this feature for?**

Administrators.

**Which issue(s) does this PR fix?**:

Alternative to, closes #124919.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.