### PR TITLE
Docker: Push distroless and slim variants on push to main

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1360,6 +1360,7 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/update-schema-types.yml @grafana/grafana-frontend-platform
 /.github/workflows/defaults-ini-docs-reminder.yml @grafana/docs-tooling @jtvdez
 /.github/workflows/pr-build-grafana.yml @grafana/grafana-backend-services-squad
+/.github/workflows/build-docker-variants.yml @grafana/grafana-backend-services-squad
 
 # Generated files not requiring owner approval
 /packages/grafana-data/src/types/featureToggles.gen.ts @grafanabot

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1254,6 +1254,8 @@ embed.go @grafana/grafana-as-code
 /.github/actions/setup-go/action.yml @grafana/grafana-backend-group
 /.github/actions/report-go-cache-sizes/ @grafana/grafana-backend-group
 /.github/actions/setup-grafana-bench/ @Proximyst
+/.github/actions/build-go @grafana/grafana-backend-services-squad
+/.github/actions/build-targz @grafana/grafana-backend-services-squad
 /.github/actions/change-detection @grafana/grafana-backend-services-squad
 /.github/actions/setup-fpm @grafana/grafana-backend-services-squad
 /.github/actions/setup-node @grafana/grafana-frontend-platform

--- a/.github/actions/build-go/action.yml
+++ b/.github/actions/build-go/action.yml
@@ -1,0 +1,60 @@
+name: Build Go binary
+description: >
+  Compiles the Grafana Go binary for a single OS/arch target.
+  When build-version is omitted the version is derived from package.json
+  by substituting the "pre" placeholder with build-number, matching the
+  release-build convention.
+
+inputs:
+  os:
+    required: false
+    default: linux
+  arch:
+    required: false
+    default: amd64
+  arm:
+    description: GOARM value, e.g. "7". Leave empty for non-ARM targets.
+    required: false
+    default: ''
+  build-number:
+    description: Unique build identifier (github.run_id).
+    required: true
+  build-version:
+    description: >
+      Explicit version string. When empty, computed from package.json as
+      `version | sed s/pre/<build-number>/g`.
+    required: false
+    default: ''
+
+outputs:
+  version:
+    description: The version string used for the build.
+    value: ${{ steps.version.outputs.value }}
+
+runs:
+  using: composite
+  steps:
+    - uses: ./.github/actions/setup-go
+
+    - name: Resolve build version
+      id: version
+      shell: bash
+      env:
+        INPUT_VERSION: ${{ inputs.build-version }}
+        BUILD_NUMBER: ${{ inputs.build-number }}
+      run: |
+        if [ -n "$INPUT_VERSION" ]; then
+          echo "value=$INPUT_VERSION" >> "$GITHUB_OUTPUT"
+        else
+          ver=$(jq -r '.version' package.json | sed "s/pre/${BUILD_NUMBER}/g")
+          echo "value=${ver}" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Build Go binary
+      shell: bash
+      env:
+        CGO_ENABLED: '0'
+        GOOS: ${{ inputs.os }}
+        GOARCH: ${{ inputs.arch }}
+        GOARM: ${{ inputs.arm }}
+      run: make build-go BUILD_VERSION="${{ steps.version.outputs.value }}"

--- a/.github/actions/build-go/action.yml
+++ b/.github/actions/build-go/action.yml
@@ -57,4 +57,5 @@ runs:
         GOOS: ${{ inputs.os }}
         GOARCH: ${{ inputs.arch }}
         GOARM: ${{ inputs.arm }}
-      run: make build-go BUILD_VERSION="${{ steps.version.outputs.value }}"
+        BUILD_VERSION: ${{ steps.version.outputs.value }}
+      run: make build-go BUILD_VERSION="$BUILD_VERSION"

--- a/.github/actions/build-targz/action.yml
+++ b/.github/actions/build-targz/action.yml
@@ -1,0 +1,56 @@
+name: Build tar.gz
+description: >
+  Assembles a Grafana release tarball from pre-built frontend and backend
+  artifacts. Callers are responsible for uploading the output in dist/.
+
+inputs:
+  os:
+    required: false
+    default: linux
+  arch:
+    required: false
+    default: amd64
+  arm:
+    description: GOARM value, e.g. "7". Leave empty for non-ARM targets.
+    required: false
+    default: ''
+  build-number:
+    description: Unique build identifier (github.run_id).
+    required: true
+  build-version:
+    description: Grafana version string used to name the tarball and bundle plugins.
+    required: true
+  frontend-artifact:
+    description: Name of the Actions artifact containing the built frontend (public/).
+    required: true
+  backend-artifact:
+    description: Name of the Actions artifact containing the compiled binary.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+      with:
+        name: ${{ inputs.frontend-artifact }}
+        path: public
+
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+      with:
+        name: ${{ inputs.backend-artifact }}
+        path: bin/${{ inputs.os }}/${{ inputs.arch }}
+
+    - name: Fix backend binary permissions
+      if: inputs.os != 'windows'
+      shell: bash
+      run: chmod +x bin/${{ inputs.os }}/${{ inputs.arch }}/grafana*
+
+    - name: Build tar.gz
+      shell: bash
+      env:
+        GOOS: ${{ inputs.os }}
+        GOARCH: ${{ inputs.arch }}
+        GOARM: ${{ inputs.arm }}
+        BUILD_NUMBER: ${{ inputs.build-number }}
+        BUILD_VERSION: ${{ inputs.build-version }}
+      run: make build-targz BUILD_VERSION="$BUILD_VERSION" BUILD_NUMBER="$BUILD_NUMBER"

--- a/.github/actions/build-targz/action.yml
+++ b/.github/actions/build-targz/action.yml
@@ -43,7 +43,10 @@ runs:
     - name: Fix backend binary permissions
       if: inputs.os != 'windows'
       shell: bash
-      run: chmod +x bin/${{ inputs.os }}/${{ inputs.arch }}/grafana*
+      env:
+        TARGET_OS: ${{ inputs.os }}
+        TARGET_ARCH: ${{ inputs.arch }}
+      run: chmod +x bin/${TARGET_OS}/${TARGET_ARCH}/grafana*
 
     - name: Build tar.gz
       shell: bash

--- a/.github/workflows/build-docker-variants.yml
+++ b/.github/workflows/build-docker-variants.yml
@@ -1,0 +1,163 @@
+name: Build Docker Variants
+
+# Reusable workflow that builds all six Docker variants (alpine, alpine-slim,
+# ubuntu, ubuntu-slim, distroless, distroless-slim) from a pre-built source
+# tarball for a single OS/arch combination.
+#
+# Called from release-build.yml (once per arch, tarball from build-targz) and
+# from pr-test-docker.yml (amd64 only, tarball built from source in the PR).
+
+on:
+  workflow_call:
+    inputs:
+      targz-artifact-name:
+        description: Name of the Actions artifact containing the source tarball
+        type: string
+        required: true
+      name:
+        description: Arch label used in artifact names, e.g. "linux-amd64"
+        type: string
+        required: true
+      os:
+        type: string
+        required: false
+        default: linux
+      arch:
+        type: string
+        required: false
+        default: amd64
+      arch-tag:
+        type: string
+        required: false
+        default: amd64
+      arm:
+        type: string
+        required: false
+        default: ''
+      version:
+        type: string
+        required: false
+        default: '0.0.0-dev'
+      build-number:
+        type: string
+        required: false
+        default: '0'
+      tag-prefix:
+        description: >
+          Docker image tag prefix, e.g. "grafana/grafana-image-tags:".
+          Leave empty to skip tagging (useful in PR builds).
+        type: string
+        required: false
+        default: ''
+
+jobs:
+  build:
+    name: ${{ matrix.variant }}
+    runs-on: ubuntu-x64-large
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: alpine
+            make-target: build-docker
+            slim: false
+            artifact-glob: "dist/*.docker.tar.gz"
+            artifact-name-prefix: artifacts-docker
+            # Tag: VERSION-ARCH  (no variant prefix — matches existing convention)
+            tag-suffix: ""
+          - variant: alpine-slim
+            make-target: build-docker
+            slim: true
+            artifact-glob: "dist/*-slim.docker.tar.gz"
+            artifact-name-prefix: artifacts-docker-alpine-slim
+            tag-suffix: "-slim"
+          - variant: ubuntu
+            make-target: build-docker-ubuntu
+            slim: false
+            artifact-glob: "dist/*.ubuntu.docker.tar.gz"
+            artifact-name-prefix: artifacts-docker-ubuntu
+            tag-suffix: "-ubuntu"
+          - variant: ubuntu-slim
+            make-target: build-docker-ubuntu
+            slim: true
+            artifact-glob: "dist/*.ubuntu-slim.docker.tar.gz"
+            artifact-name-prefix: artifacts-docker-ubuntu-slim
+            tag-suffix: "-ubuntu-slim"
+          - variant: distroless
+            make-target: build-docker-distroless
+            slim: false
+            artifact-glob: "dist/*.distroless.docker.tar.gz"
+            artifact-name-prefix: artifacts-docker-distroless
+            tag-suffix: "-distroless"
+          - variant: distroless-slim
+            make-target: build-docker-distroless
+            slim: true
+            artifact-glob: "dist/*.distroless-slim.docker.tar.gz"
+            artifact-name-prefix: artifacts-docker-distroless-slim
+            tag-suffix: "-distroless-slim"
+    steps:
+      - uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login/v1.0.2
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: ${{ inputs.targz-artifact-name }}
+          path: dist
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@7e10951aea186e886cef2f1a25a7bbf4e593d710
+        with:
+          image: docker.io/tonistiigi/binfmt:qemu-v10.2.1-65
+      - name: Set up Docker Buildx
+        run: docker buildx create --use
+      - name: Build docker image (${{ matrix.variant }})
+        env:
+          GOOS: ${{ inputs.os }}
+          GOARCH: ${{ inputs.arch }}
+          GOARM: ${{ inputs.arm }}
+          BUILD_NUMBER: ${{ inputs.build-number }}
+          BUILD_VERSION: ${{ inputs.version }}
+          ARCH_TAG: ${{ inputs.arch-tag }}
+          TAG_PREFIX: ${{ inputs.tag-prefix }}
+          TAG_SUFFIX: ${{ matrix.tag-suffix }}
+        run: |
+          set -euo pipefail
+          for TARGZ in dist/*.tar.gz; do break; done
+          TAG_VERSION="${BUILD_VERSION//+/-}"
+          EXTRA_ARGS=()
+          if [ -n "$TAG_PREFIX" ]; then
+            EXTRA_ARGS+=("DOCKER_TAG=${TAG_PREFIX}${TAG_VERSION}${TAG_SUFFIX}-${ARCH_TAG}")
+          fi
+          make ${{ matrix.make-target }} \
+            -o "$TARGZ" \
+            BUILD_VERSION="$BUILD_VERSION" \
+            BUILD_NUMBER="$BUILD_NUMBER" \
+            SLIM=${{ matrix.slim }} \
+            "${EXTRA_ARGS[@]}"
+      - name: Generate checksums
+        run: |
+          set -euo pipefail
+          for f in ${{ matrix.artifact-glob }}; do
+            [ -e "$f" ] || continue
+            sha256sum "$f" | awk '{print $1}' > "${f}.sha256"
+          done
+      - name: Stage artifacts for upload
+        env:
+          ARTIFACT_NAME: ${{ matrix.artifact-name-prefix }}-${{ inputs.name }}
+          ARTIFACT_GLOB: ${{ matrix.artifact-glob }}
+        run: |
+          set -euo pipefail
+          mkdir -p "upload/${ARTIFACT_NAME}"
+          for f in ${ARTIFACT_GLOB}; do
+            [ -e "$f" ] || continue
+            cp "$f" "upload/${ARTIFACT_NAME}/"
+            cp "${f}.sha256" "upload/${ARTIFACT_NAME}/"
+          done
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
+        with:
+          name: ${{ matrix.artifact-name-prefix }}-${{ inputs.name }}
+          path: upload/${{ matrix.artifact-name-prefix }}-${{ inputs.name }}
+          retention-days: 1

--- a/.github/workflows/pr-build-grafana.yml
+++ b/.github/workflows/pr-build-grafana.yml
@@ -85,14 +85,10 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: ./.github/actions/setup-go
-      - name: Build Go
-        env:
-          CGO_ENABLED: '0'
-          BUILD_VERSION: ${{ needs.setup.outputs.version }}
-          GOOS: linux
-          GOARCH: amd64
-        run: make build-go BUILD_VERSION="${BUILD_VERSION}"
+      - uses: ./.github/actions/build-go
+        with:
+          build-number: ${{ github.run_id }}
+          build-version: ${{ needs.setup.outputs.version }}
       - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
           name: pr-backend
@@ -101,7 +97,7 @@ jobs:
 
   build-targz:
     name: build targz
-    runs-on: ubuntu-x64-large-io
+    runs-on: ubuntu-x64-large
     needs:
       - setup
       - build-frontend
@@ -112,23 +108,12 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+      - uses: ./.github/actions/build-targz
         with:
-          name: pr-frontend
-          path: public
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: pr-backend
-          path: bin/linux/amd64
-      - name: Fix backend binary permissions
-        run: chmod +x bin/linux/amd64/grafana*
-      - name: Build tar.gz
-        env:
-          GOOS: linux
-          GOARCH: amd64
-          BUILD_NUMBER: ${{ github.run_id }}
-          BUILD_VERSION: ${{ needs.setup.outputs.version }}
-        run: make build-targz BUILD_VERSION="$BUILD_VERSION" BUILD_NUMBER="$BUILD_NUMBER"
+          build-number: ${{ github.run_id }}
+          build-version: ${{ needs.setup.outputs.version }}
+          frontend-artifact: pr-frontend
+          backend-artifact: pr-backend
       - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
           name: pr-targz

--- a/.github/workflows/pr-test-docker.yml
+++ b/.github/workflows/pr-test-docker.yml
@@ -35,7 +35,7 @@ on:
       - .github/workflows/build-docker-variants.yml
 
 jobs:
-  # ── Path 1 ────────────────────────────────────────────────────────────────
+  # Path 1:
   # Full source build inside Docker. Validates that the complete compilation
   # pipeline (go-builder + js-builder + final stage) works end-to-end.
   build-full:
@@ -53,7 +53,7 @@ jobs:
       - name: Build alpine (full source)
         run: make build-docker-full DOCKER_BUILD_ARGS=--load
 
-  # ── Path 2 ────────────────────────────────────────────────────────────────
+  # Path 2:
   # Prod-like build: compile from source → tarball → all 6 Docker variants.
   # Mirrors exactly what release-build.yml does, but builds the tarball here
   # since no pre-built artifact exists in a PR.

--- a/.github/workflows/pr-test-docker.yml
+++ b/.github/workflows/pr-test-docker.yml
@@ -35,12 +35,12 @@ on:
       - .github/workflows/build-docker-variants.yml
 
 jobs:
-  # Path 1:
+  # ── Path 1 ────────────────────────────────────────────────────────────────
   # Full source build inside Docker. Validates that the complete compilation
   # pipeline (go-builder + js-builder + final stage) works end-to-end.
   build-full:
     name: build / full source (alpine)
-    runs-on: ubuntu-x64-large-io
+    runs-on: ubuntu-x64-large
     permissions:
       contents: read
     steps:
@@ -53,49 +53,86 @@ jobs:
       - name: Build alpine (full source)
         run: make build-docker-full DOCKER_BUILD_ARGS=--load
 
-  # Path 2:
-  # Prod-like build: compile from source → tarball → all 6 Docker variants.
-  # Mirrors exactly what release-build.yml does, but builds the tarball here
-  # since no pre-built artifact exists in a PR.
+  # ── Path 2 ────────────────────────────────────────────────────────────────
+  # Prod-like build: compile frontend + backend in parallel → assemble tarball
+  # → build all 6 Docker variants. Mirrors the release-build.yml structure so
+  # the same code paths are exercised on every PR.
 
-  build-source-targz:
-    name: build / source tarball
-    runs-on: ubuntu-x64-large-io
+  build-frontend:
+    name: build / frontend
+    runs-on: ubuntu-x64-large
     permissions:
       contents: read
     steps:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: docker/setup-docker-action@3fb92d6d9c634363128c8cce4bc3b2826526370a # v4
-      - name: Set up Docker Buildx
-        run: docker buildx create --use
-      - name: Compile Go binary
-        run: |
-          docker buildx build \
-            --target=go-builder \
-            --platform linux/amd64 \
-            --output "type=local,dest=_go" \
-            .
+      - uses: ./.github/actions/setup-node
+      - name: Install JS dependencies
+        run: yarn install --immutable
       - name: Build frontend
-        run: |
-          docker buildx build \
-            --target=js-builder \
-            --platform linux/amd64 \
-            --output "type=local,dest=_js" \
-            .
-      - name: Package tarball
-        run: |
-          set -euo pipefail
-          mkdir -p dist _staging/grafana-0.0.0-pr
-          cp -r _go/tmp/grafana/. _staging/grafana-0.0.0-pr/
-          cp -r _js/tmp/grafana/public _staging/grafana-0.0.0-pr/
-          cp _js/tmp/grafana/LICENSE _staging/grafana-0.0.0-pr/
-          tar czf dist/grafana_0.0.0-pr_0_linux_amd64.tar.gz -C _staging .
+        run: yarn build
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
+        with:
+          name: pr-frontend
+          path: public
+          retention-days: 1
+
+  build-backend:
+    name: build / backend (linux-amd64)
+    runs-on: ubuntu-x64-large
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-go
+      - name: Build Go binary
+        env:
+          CGO_ENABLED: '0'
+          GOOS: linux
+          GOARCH: amd64
+        run: make build-go
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
+        with:
+          name: pr-backend-linux-amd64
+          path: bin/linux/amd64
+          retention-days: 1
+
+  build-source-targz:
+    name: build / source tarball
+    runs-on: ubuntu-x64-large
+    needs:
+      - build-frontend
+      - build-backend
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: pr-frontend
+          path: public
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+        with:
+          name: pr-backend-linux-amd64
+          path: bin/linux/amd64
+      - name: Fix backend binary permissions
+        run: chmod +x bin/linux/amd64/grafana*
+      - name: Build tar.gz
+        env:
+          GOOS: linux
+          GOARCH: amd64
+          BUILD_NUMBER: ${{ github.run_id }}
+          BUILD_VERSION: 0.0.0-pr
+        run: make build-targz BUILD_VERSION="$BUILD_VERSION" BUILD_NUMBER="$BUILD_NUMBER"
       - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
           name: pr-source-targz
-          path: dist/grafana_0.0.0-pr_0_linux_amd64.tar.gz
+          path: dist/*.tar.gz
           retention-days: 1
 
   build-docker-variants:

--- a/.github/workflows/pr-test-docker.yml
+++ b/.github/workflows/pr-test-docker.yml
@@ -83,17 +83,16 @@ jobs:
     runs-on: ubuntu-x64-large
     permissions:
       contents: read
+    outputs:
+      version: ${{ steps.build.outputs.version }}
     steps:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: ./.github/actions/setup-go
-      - name: Build Go binary
-        env:
-          CGO_ENABLED: '0'
-          GOOS: linux
-          GOARCH: amd64
-        run: make build-go
+      - id: build
+        uses: ./.github/actions/build-go
+        with:
+          build-number: ${{ github.run_id }}
       - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
           name: pr-backend-linux-amd64
@@ -112,23 +111,12 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+      - uses: ./.github/actions/build-targz
         with:
-          name: pr-frontend
-          path: public
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: pr-backend-linux-amd64
-          path: bin/linux/amd64
-      - name: Fix backend binary permissions
-        run: chmod +x bin/linux/amd64/grafana*
-      - name: Build tar.gz
-        env:
-          GOOS: linux
-          GOARCH: amd64
-          BUILD_NUMBER: ${{ github.run_id }}
-          BUILD_VERSION: 0.0.0-pr
-        run: make build-targz BUILD_VERSION="$BUILD_VERSION" BUILD_NUMBER="$BUILD_NUMBER"
+          build-number: ${{ github.run_id }}
+          build-version: ${{ needs.build-backend.outputs.version }}
+          frontend-artifact: pr-frontend
+          backend-artifact: pr-backend-linux-amd64
       - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
           name: pr-source-targz

--- a/.github/workflows/pr-test-docker.yml
+++ b/.github/workflows/pr-test-docker.yml
@@ -107,6 +107,8 @@ jobs:
       - build-backend
     permissions:
       contents: read
+    outputs:
+      version: ${{ needs.build-backend.outputs.version }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -136,5 +138,5 @@ jobs:
       os: linux
       arch: amd64
       arch-tag: amd64
-      version: '0.0.0-pr'
+      version: ${{ needs.build-source-targz.outputs.version }}
       build-number: ${{ github.run_id }}

--- a/.github/workflows/pr-test-docker.yml
+++ b/.github/workflows/pr-test-docker.yml
@@ -1,5 +1,7 @@
 name: Test Dockerfile
 
+permissions: {}
+
 on:
   pull_request:
     paths:
@@ -21,9 +23,7 @@ on:
       - .yarn/**
       - tsconfig.json
       - '**.js'
-      # We only want the top directory here.
       - '*.ts'
-      # But this one we want all
       - '**.config.ts'
       - scripts/**
       - emails/**
@@ -32,17 +32,84 @@ on:
       - embed.go
       - packaging/docker/**
       - .github/workflows/pr-test-docker.yml
+      - .github/workflows/build-docker-variants.yml
 
 jobs:
-  build-dockerfile:
+  # ── Path 1 ────────────────────────────────────────────────────────────────
+  # Full source build inside Docker. Validates that the complete compilation
+  # pipeline (go-builder + js-builder + final stage) works end-to-end.
+  build-full:
+    name: build / full source (alpine)
     runs-on: ubuntu-x64-large-io
     permissions:
       contents: read
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
+      - uses: actions/checkout@v6
         with:
           persist-credentials: false
       - uses: docker/setup-docker-action@3fb92d6d9c634363128c8cce4bc3b2826526370a # v4
-      - name: Build Dockerfile
-        run: make build-docker-full
+      - name: Set up Docker Buildx
+        run: docker buildx create --use
+      - name: Build alpine (full source)
+        run: make build-docker-full DOCKER_BUILD_ARGS=--load
+
+  # ── Path 2 ────────────────────────────────────────────────────────────────
+  # Prod-like build: compile from source → tarball → all 6 Docker variants.
+  # Mirrors exactly what release-build.yml does, but builds the tarball here
+  # since no pre-built artifact exists in a PR.
+
+  build-source-targz:
+    name: build / source tarball
+    runs-on: ubuntu-x64-large-io
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - uses: docker/setup-docker-action@3fb92d6d9c634363128c8cce4bc3b2826526370a # v4
+      - name: Set up Docker Buildx
+        run: docker buildx create --use
+      - name: Compile Go binary
+        run: |
+          docker buildx build \
+            --target=go-builder \
+            --platform linux/amd64 \
+            --output "type=local,dest=_go" \
+            .
+      - name: Build frontend
+        run: |
+          docker buildx build \
+            --target=js-builder \
+            --platform linux/amd64 \
+            --output "type=local,dest=_js" \
+            .
+      - name: Package tarball
+        run: |
+          set -euo pipefail
+          mkdir -p dist _staging/grafana-0.0.0-pr
+          cp -r _go/tmp/grafana/. _staging/grafana-0.0.0-pr/
+          cp -r _js/tmp/grafana/public _staging/grafana-0.0.0-pr/
+          cp _js/tmp/grafana/LICENSE _staging/grafana-0.0.0-pr/
+          tar czf dist/grafana_0.0.0-pr_0_linux_amd64.tar.gz -C _staging .
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
+        with:
+          name: pr-source-targz
+          path: dist/grafana_0.0.0-pr_0_linux_amd64.tar.gz
+          retention-days: 1
+
+  build-docker-variants:
+    name: build / variants (targz)
+    needs: build-source-targz
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/build-docker-variants.yml
+    with:
+      targz-artifact-name: pr-source-targz
+      name: linux-amd64
+      os: linux
+      arch: amd64
+      arch-tag: amd64
+      version: '0.0.0-pr'
+      build-number: ${{ github.run_id }}

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -23,7 +23,7 @@ permissions:
 #
 # targz:grafana:* (via make build-targz)
 # deb / rpm (via make build-deb / build-rpm, from targz)
-# docker alpine / ubuntu (via make build-docker / build-docker-ubuntu, from targz)
+# docker alpine / alpine-slim / ubuntu / ubuntu-slim / distroless / distroless-slim (via make build-docker*, from targz)
 # zip / msi (Dagger, consuming prebuilt targz from dist)
 #
 # One shared frontend artifact is reused for every targz matrix cell (OSS), so assets-manifest.json matches all
@@ -434,203 +434,75 @@ jobs:
           for PKG in dist/*.rpm; do break; done
           bash scripts/verify-pkg-stig.sh "$PKG"
 
-  build-docker-alpine:
-    name: docker (alpine) / ${{ matrix.name }}
-    runs-on: ubuntu-x64-large
-    needs:
-      - setup
-      - build-targz
+  build-docker-linux-amd64:
+    name: docker / linux-amd64
+    needs: [setup, build-targz]
+    uses: ./.github/workflows/build-docker-variants.yml
     permissions:
       contents: read
       id-token: write
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: linux-amd64
-            os: linux
-            arch: amd64
-            arch-tag: amd64
-          - name: linux-arm64
-            os: linux
-            arch: arm64
-            arch-tag: arm64
-          - name: linux-s390x
-            os: linux
-            arch: s390x
-            arch-tag: s390x
-          - name: linux-armv7
-            os: linux
-            arch: arm
-            arm: '7'
-            arch-tag: armv7
-    steps:
-      - uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login/v1.0.2
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: artifacts-packages-${{ matrix.name }}
-          path: dist
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@7e10951aea186e886cef2f1a25a7bbf4e593d710
-        with:
-          image: docker.io/tonistiigi/binfmt:qemu-v10.2.1-65
-      - name: Set up Docker Buildx
-        run: docker buildx create --use
-      - name: Build docker image (alpine)
-        env:
-          GOOS: ${{ matrix.os }}
-          GOARCH: ${{ matrix.arch }}
-          GOARM: ${{ matrix.arm }}
-          BUILD_NUMBER: ${{ github.run_id }}
-          BUILD_VERSION: ${{ needs.setup.outputs.version }}
-          ARCH_TAG: ${{ matrix.arch-tag }}
-        run: |
-          for TARGZ in dist/*.tar.gz; do break; done
-          TAG_VERSION="${BUILD_VERSION//+/-}"
-          make build-docker \
-            -o "$TARGZ" \
-            BUILD_VERSION="$BUILD_VERSION" \
-            BUILD_NUMBER="$BUILD_NUMBER" \
-            DOCKER_TAG="grafana/grafana-image-tags:${TAG_VERSION}-${ARCH_TAG}"
-      - name: Generate checksums
-        run: |
-          set -euo pipefail
-          for f in dist/*.docker.tar.gz; do
-            [ -e "$f" ] || continue
-            sha256sum "$f" | awk '{print $1}' > "${f}.sha256"
-          done
-      - name: Write artifact list
-        run: |
-          listfile="artifacts-list-docker-${{ matrix.name }}.txt"
-          : > "$listfile"
-          for f in dist/*.docker.tar.gz; do
-            [ -e "$f" ] || continue
-            echo "$f" >> "$listfile"
-            echo "${f}.sha256" >> "$listfile"
-          done
-      - name: Stage artifacts for upload
-        run: |
-          set -euo pipefail
-          mkdir -p "upload/artifacts-list-docker-${{ matrix.name }}"
-          cp "artifacts-list-docker-${{ matrix.name }}.txt" "upload/artifacts-list-docker-${{ matrix.name }}/"
-          mkdir -p "upload/artifacts-docker-${{ matrix.name }}"
-          for f in dist/*.docker.tar.gz; do
-            [ -e "$f" ] || continue
-            cp "$f" "upload/artifacts-docker-${{ matrix.name }}/"
-            cp "${f}.sha256" "upload/artifacts-docker-${{ matrix.name }}/"
-          done
-      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
-        with:
-          name: artifacts-list-docker-${{ matrix.name }}
-          path: upload/artifacts-list-docker-${{ matrix.name }}
-          retention-days: 1
-      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
-        with:
-          name: artifacts-docker-${{ matrix.name }}
-          path: upload/artifacts-docker-${{ matrix.name }}
-          retention-days: 1
+    with:
+      targz-artifact-name: artifacts-packages-linux-amd64
+      name: linux-amd64
+      os: linux
+      arch: amd64
+      arch-tag: amd64
+      version: ${{ needs.setup.outputs.version }}
+      build-number: ${{ github.run_id }}
+      tag-prefix: "grafana/grafana-image-tags:"
 
-  build-docker-ubuntu:
-    name: docker (ubuntu) / ${{ matrix.name }}
-    runs-on: ubuntu-x64-large
-    needs:
-      - setup
-      - build-targz
+  build-docker-linux-arm64:
+    name: docker / linux-arm64
+    needs: [setup, build-targz]
+    uses: ./.github/workflows/build-docker-variants.yml
     permissions:
       contents: read
       id-token: write
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - name: linux-amd64
-            os: linux
-            arch: amd64
-            arch-tag: amd64
-          - name: linux-arm64
-            os: linux
-            arch: arm64
-            arch-tag: arm64
-          - name: linux-s390x
-            os: linux
-            arch: s390x
-            arch-tag: s390x
-          - name: linux-armv7
-            os: linux
-            arch: arm
-            arm: '7'
-            arch-tag: armv7
-    steps:
-      - uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login/v1.0.2
-      - uses: actions/checkout@v6
-        with:
-          persist-credentials: false
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: artifacts-packages-${{ matrix.name }}
-          path: dist
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@7e10951aea186e886cef2f1a25a7bbf4e593d710
-        with:
-          image: docker.io/tonistiigi/binfmt:qemu-v10.2.1-65
-      - name: Set up Docker Buildx
-        run: docker buildx create --use
-      - name: Build docker image (ubuntu)
-        env:
-          GOOS: ${{ matrix.os }}
-          GOARCH: ${{ matrix.arch }}
-          GOARM: ${{ matrix.arm }}
-          BUILD_NUMBER: ${{ github.run_id }}
-          BUILD_VERSION: ${{ needs.setup.outputs.version }}
-          ARCH_TAG: ${{ matrix.arch-tag }}
-        run: |
-          for TARGZ in dist/*.tar.gz; do break; done
-          TAG_VERSION="${BUILD_VERSION//+/-}"
-          make build-docker-ubuntu \
-            -o "$TARGZ" \
-            BUILD_VERSION="$BUILD_VERSION" \
-            BUILD_NUMBER="$BUILD_NUMBER" \
-            DOCKER_TAG="grafana/grafana-image-tags:${TAG_VERSION}-ubuntu-${ARCH_TAG}"
-      - name: Generate checksums
-        run: |
-          set -euo pipefail
-          for f in dist/*.ubuntu.docker.tar.gz; do
-            [ -e "$f" ] || continue
-            sha256sum "$f" | awk '{print $1}' > "${f}.sha256"
-          done
-      - name: Write artifact list
-        run: |
-          listfile="artifacts-list-docker-ubuntu-${{ matrix.name }}.txt"
-          : > "$listfile"
-          for f in dist/*.ubuntu.docker.tar.gz; do
-            [ -e "$f" ] || continue
-            echo "$f" >> "$listfile"
-            echo "${f}.sha256" >> "$listfile"
-          done
-      - name: Stage artifacts for upload
-        run: |
-          set -euo pipefail
-          mkdir -p "upload/artifacts-list-docker-ubuntu-${{ matrix.name }}"
-          cp "artifacts-list-docker-ubuntu-${{ matrix.name }}.txt" "upload/artifacts-list-docker-ubuntu-${{ matrix.name }}/"
-          mkdir -p "upload/artifacts-docker-ubuntu-${{ matrix.name }}"
-          for f in dist/*.ubuntu.docker.tar.gz; do
-            [ -e "$f" ] || continue
-            cp "$f" "upload/artifacts-docker-ubuntu-${{ matrix.name }}/"
-            cp "${f}.sha256" "upload/artifacts-docker-ubuntu-${{ matrix.name }}/"
-          done
-      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
-        with:
-          name: artifacts-list-docker-ubuntu-${{ matrix.name }}
-          path: upload/artifacts-list-docker-ubuntu-${{ matrix.name }}
-          retention-days: 1
-      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
-        with:
-          name: artifacts-docker-ubuntu-${{ matrix.name }}
-          path: upload/artifacts-docker-ubuntu-${{ matrix.name }}
-          retention-days: 1
+    with:
+      targz-artifact-name: artifacts-packages-linux-arm64
+      name: linux-arm64
+      os: linux
+      arch: arm64
+      arch-tag: arm64
+      version: ${{ needs.setup.outputs.version }}
+      build-number: ${{ github.run_id }}
+      tag-prefix: "grafana/grafana-image-tags:"
+
+  build-docker-linux-s390x:
+    name: docker / linux-s390x
+    needs: [setup, build-targz]
+    uses: ./.github/workflows/build-docker-variants.yml
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      targz-artifact-name: artifacts-packages-linux-s390x
+      name: linux-s390x
+      os: linux
+      arch: s390x
+      arch-tag: s390x
+      version: ${{ needs.setup.outputs.version }}
+      build-number: ${{ github.run_id }}
+      tag-prefix: "grafana/grafana-image-tags:"
+
+  build-docker-linux-armv7:
+    name: docker / linux-armv7
+    needs: [setup, build-targz]
+    uses: ./.github/workflows/build-docker-variants.yml
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      targz-artifact-name: artifacts-packages-linux-armv7
+      name: linux-armv7
+      os: linux
+      arch: arm
+      arch-tag: armv7
+      arm: '7'
+      version: ${{ needs.setup.outputs.version }}
+      build-number: ${{ github.run_id }}
+      tag-prefix: "grafana/grafana-image-tags:"
+
 
   verify-targz:
     name: verify targz (linux-amd64)
@@ -645,8 +517,7 @@ jobs:
     name: verify packages (linux-amd64)
     needs:
       - build-deb-rpm
-      - build-docker-alpine
-      - build-docker-ubuntu
+      - build-docker-linux-amd64
     uses: ./.github/workflows/release-verify-packages.yml
     with:
       run-id: ${{ github.run_id }}
@@ -812,10 +683,40 @@ jobs:
       id-token: write
     needs:
       - setup
-      - build-docker-alpine
+      - build-docker-linux-amd64
+      - build-docker-linux-arm64
+      - build-docker-linux-s390x
+      - build-docker-linux-armv7
     with:
       bucket: grafana-prerelease
-      pattern: artifacts-*docker-${{ matrix.target }}
+      pattern: artifacts-docker-${{ matrix.target }}
+      run-id: ${{ github.run_id }}
+      bucket-path: ${{ needs.setup.outputs.version }}_${{ github.run_id }}
+      environment: prod
+      runs-on: ubuntu-x64-small
+
+  publish-docker-alpine-slim:
+    name: Upload docker (alpine-slim) / ${{ matrix.target }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: linux-amd64
+          - target: linux-arm64
+          - target: linux-s390x
+          - target: linux-armv7
+    uses: grafana/grafana/.github/workflows/publish-artifact.yml@main
+    permissions:
+      id-token: write
+    needs:
+      - setup
+      - build-docker-linux-amd64
+      - build-docker-linux-arm64
+      - build-docker-linux-s390x
+      - build-docker-linux-armv7
+    with:
+      bucket: grafana-prerelease
+      pattern: artifacts-docker-alpine-slim-${{ matrix.target }}
       run-id: ${{ github.run_id }}
       bucket-path: ${{ needs.setup.outputs.version }}_${{ github.run_id }}
       environment: prod
@@ -836,10 +737,94 @@ jobs:
       id-token: write
     needs:
       - setup
-      - build-docker-ubuntu
+      - build-docker-linux-amd64
+      - build-docker-linux-arm64
+      - build-docker-linux-s390x
+      - build-docker-linux-armv7
     with:
       bucket: grafana-prerelease
-      pattern: artifacts-*docker-ubuntu-${{ matrix.target }}
+      pattern: artifacts-docker-ubuntu-${{ matrix.target }}
+      run-id: ${{ github.run_id }}
+      bucket-path: ${{ needs.setup.outputs.version }}_${{ github.run_id }}
+      environment: prod
+      runs-on: ubuntu-x64-small
+
+  publish-docker-ubuntu-slim:
+    name: Upload docker (ubuntu-slim) / ${{ matrix.target }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: linux-amd64
+          - target: linux-arm64
+          - target: linux-s390x
+          - target: linux-armv7
+    uses: grafana/grafana/.github/workflows/publish-artifact.yml@main
+    permissions:
+      id-token: write
+    needs:
+      - setup
+      - build-docker-linux-amd64
+      - build-docker-linux-arm64
+      - build-docker-linux-s390x
+      - build-docker-linux-armv7
+    with:
+      bucket: grafana-prerelease
+      pattern: artifacts-docker-ubuntu-slim-${{ matrix.target }}
+      run-id: ${{ github.run_id }}
+      bucket-path: ${{ needs.setup.outputs.version }}_${{ github.run_id }}
+      environment: prod
+      runs-on: ubuntu-x64-small
+
+  publish-docker-distroless:
+    name: Upload docker (distroless) / ${{ matrix.target }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: linux-amd64
+          - target: linux-arm64
+          - target: linux-s390x
+          - target: linux-armv7
+    uses: grafana/grafana/.github/workflows/publish-artifact.yml@main
+    permissions:
+      id-token: write
+    needs:
+      - setup
+      - build-docker-linux-amd64
+      - build-docker-linux-arm64
+      - build-docker-linux-s390x
+      - build-docker-linux-armv7
+    with:
+      bucket: grafana-prerelease
+      pattern: artifacts-docker-distroless-${{ matrix.target }}
+      run-id: ${{ github.run_id }}
+      bucket-path: ${{ needs.setup.outputs.version }}_${{ github.run_id }}
+      environment: prod
+      runs-on: ubuntu-x64-small
+
+  publish-docker-distroless-slim:
+    name: Upload docker (distroless-slim) / ${{ matrix.target }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: linux-amd64
+          - target: linux-arm64
+          - target: linux-s390x
+          - target: linux-armv7
+    uses: grafana/grafana/.github/workflows/publish-artifact.yml@main
+    permissions:
+      id-token: write
+    needs:
+      - setup
+      - build-docker-linux-amd64
+      - build-docker-linux-arm64
+      - build-docker-linux-s390x
+      - build-docker-linux-armv7
+    with:
+      bucket: grafana-prerelease
+      pattern: artifacts-docker-distroless-slim-${{ matrix.target }}
       run-id: ${{ github.run_id }}
       bucket-path: ${{ needs.setup.outputs.version }}_${{ github.run_id }}
       environment: prod
@@ -876,92 +861,97 @@ jobs:
     needs:
       - setup
       - verify-targz
-      - build-docker-alpine
-      - build-docker-ubuntu
+      - build-docker-linux-amd64
+      - build-docker-linux-arm64
+      - build-docker-linux-armv7
       - verify-packages
-    outputs:
-      tag-version: ${{ steps.push.outputs.TAG_VERSION }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: alpine
+            full-artifact: artifacts-docker
+            slim-artifact: artifacts-docker-alpine-slim
+            full-tag-suffix: ""
+            slim-tag-suffix: "-slim"
+          - variant: ubuntu
+            full-artifact: artifacts-docker-ubuntu
+            slim-artifact: artifacts-docker-ubuntu-slim
+            full-tag-suffix: "-ubuntu"
+            slim-tag-suffix: "-ubuntu-slim"
+          - variant: distroless
+            full-artifact: artifacts-docker-distroless
+            slim-artifact: artifacts-docker-distroless-slim
+            full-tag-suffix: "-distroless"
+            slim-tag-suffix: "-distroless-slim"
     steps:
       - uses: grafana/shared-workflows/actions/dockerhub-login@dockerhub-login/v1.0.2
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
-          name: artifacts-list-docker-linux-amd64
-          path: .
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: artifacts-list-docker-linux-arm64
-          path: .
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: artifacts-list-docker-linux-armv7
-          path: .
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: artifacts-list-docker-ubuntu-linux-amd64
-          path: .
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: artifacts-list-docker-ubuntu-linux-arm64
-          path: .
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: artifacts-list-docker-ubuntu-linux-armv7
-          path: .
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: artifacts-docker-linux-amd64
+          name: ${{ matrix.full-artifact }}-linux-amd64
           path: dist
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
-          name: artifacts-docker-linux-arm64
+          name: ${{ matrix.full-artifact }}-linux-arm64
           path: dist
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
-          name: artifacts-docker-linux-armv7
+          name: ${{ matrix.full-artifact }}-linux-armv7
           path: dist
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
-          name: artifacts-docker-ubuntu-linux-amd64
+          name: ${{ matrix.slim-artifact }}-linux-amd64
           path: dist
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
-          name: artifacts-docker-ubuntu-linux-arm64
+          name: ${{ matrix.slim-artifact }}-linux-arm64
           path: dist
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
         with:
-          name: artifacts-docker-ubuntu-linux-armv7
+          name: ${{ matrix.slim-artifact }}-linux-armv7
           path: dist
-      - name: Push to Docker Hub
-        id: push
+      - name: Push ${{ matrix.variant }} + ${{ matrix.variant }}-slim to Docker Hub
         env:
           VERSION: ${{ needs.setup.outputs.version }}
+          FULL_TAG_SUFFIX: ${{ matrix.full-tag-suffix }}
+          SLIM_TAG_SUFFIX: ${{ matrix.slim-tag-suffix }}
         run: |
+          set -euo pipefail
           TAG_VERSION="${VERSION//+/-}"
-          echo "TAG_VERSION=$TAG_VERSION" | tee -a "$GITHUB_OUTPUT"
-          cat artifacts-*.txt > artifacts.txt
-          grep 'docker\.tar\.gz$' artifacts.txt | xargs -I % docker load -i % | sed 's/Loaded image: //g' | tee docker_images
-          while read -r line; do
-            docker push "$line"
-          done < docker_images
-
-          docker manifest create grafana/grafana:main "grafana/grafana-image-tags:${TAG_VERSION}-amd64" "grafana/grafana-image-tags:${TAG_VERSION}-arm64"  "grafana/grafana-image-tags:${TAG_VERSION}-armv7"
-          docker manifest create grafana/grafana:main-ubuntu "grafana/grafana-image-tags:${TAG_VERSION}-ubuntu-amd64" "grafana/grafana-image-tags:${TAG_VERSION}-ubuntu-arm64"  "grafana/grafana-image-tags:${TAG_VERSION}-ubuntu-armv7"
-          docker manifest create "grafana/grafana-dev:${TAG_VERSION}" "grafana/grafana-image-tags:${TAG_VERSION}-amd64" "grafana/grafana-image-tags:${TAG_VERSION}-arm64"  "grafana/grafana-image-tags:${TAG_VERSION}-armv7"
-          docker manifest create "grafana/grafana-dev:${TAG_VERSION}-ubuntu" "grafana/grafana-image-tags:${TAG_VERSION}-ubuntu-amd64" "grafana/grafana-image-tags:${TAG_VERSION}-ubuntu-arm64"  "grafana/grafana-image-tags:${TAG_VERSION}-ubuntu-armv7"
-
-          docker manifest push grafana/grafana:main
-          docker manifest push grafana/grafana:main-ubuntu
-          docker manifest push "grafana/grafana-dev:${TAG_VERSION}"
-          docker manifest push "grafana/grafana-dev:${TAG_VERSION}-ubuntu"
+          for f in dist/*.docker.tar.gz; do docker load -i "$f"; done \
+            | grep "Loaded image:" | sed 's/Loaded image: //' | sort -u | tee docker_images
+          while read -r line; do docker push "$line"; done < docker_images
+          docker manifest create "grafana/grafana:main${FULL_TAG_SUFFIX}" \
+            "grafana/grafana-image-tags:${TAG_VERSION}${FULL_TAG_SUFFIX}-amd64" \
+            "grafana/grafana-image-tags:${TAG_VERSION}${FULL_TAG_SUFFIX}-arm64" \
+            "grafana/grafana-image-tags:${TAG_VERSION}${FULL_TAG_SUFFIX}-armv7"
+          docker manifest create "grafana/grafana:main${SLIM_TAG_SUFFIX}" \
+            "grafana/grafana-image-tags:${TAG_VERSION}${SLIM_TAG_SUFFIX}-amd64" \
+            "grafana/grafana-image-tags:${TAG_VERSION}${SLIM_TAG_SUFFIX}-arm64" \
+            "grafana/grafana-image-tags:${TAG_VERSION}${SLIM_TAG_SUFFIX}-armv7"
+          docker manifest create "grafana/grafana-dev:${TAG_VERSION}${FULL_TAG_SUFFIX}" \
+            "grafana/grafana-image-tags:${TAG_VERSION}${FULL_TAG_SUFFIX}-amd64" \
+            "grafana/grafana-image-tags:${TAG_VERSION}${FULL_TAG_SUFFIX}-arm64" \
+            "grafana/grafana-image-tags:${TAG_VERSION}${FULL_TAG_SUFFIX}-armv7"
+          docker manifest create "grafana/grafana-dev:${TAG_VERSION}${SLIM_TAG_SUFFIX}" \
+            "grafana/grafana-image-tags:${TAG_VERSION}${SLIM_TAG_SUFFIX}-amd64" \
+            "grafana/grafana-image-tags:${TAG_VERSION}${SLIM_TAG_SUFFIX}-arm64" \
+            "grafana/grafana-image-tags:${TAG_VERSION}${SLIM_TAG_SUFFIX}-armv7"
+          docker manifest push "grafana/grafana:main${FULL_TAG_SUFFIX}"
+          docker manifest push "grafana/grafana:main${SLIM_TAG_SUFFIX}"
+          docker manifest push "grafana/grafana-dev:${TAG_VERSION}${FULL_TAG_SUFFIX}"
+          docker manifest push "grafana/grafana-dev:${TAG_VERSION}${SLIM_TAG_SUFFIX}"
 
   run-meticulous-tests:
     if: github.repository == 'grafana/grafana'
-    needs: publish-dockerhub
+    needs:
+      - setup
+      - publish-dockerhub
     name: Run Meticulous tests
     runs-on: ubuntu-x64-small
     continue-on-error: true
     env:
-      IMAGE_TAG: grafana/grafana-dev:${{ needs.publish-dockerhub.outputs.tag-version }}
+      IMAGE_TAG: grafana/grafana-dev:${{ needs.setup.outputs.version }}
     permissions:
       actions: write
       contents: read

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -950,8 +950,6 @@ jobs:
     name: Run Meticulous tests
     runs-on: ubuntu-x64-small
     continue-on-error: true
-    env:
-      IMAGE_TAG: grafana/grafana-dev:${{ needs.setup.outputs.version }}
     permissions:
       actions: write
       contents: read
@@ -965,7 +963,15 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Compute image tag
+        id: tag
+        env:
+          VERSION: ${{ needs.setup.outputs.version }}
+        run: echo "value=grafana/grafana-dev:${VERSION//+/-}" >> "$GITHUB_OUTPUT"
+
       - name: Pull image from Dockerhub
+        env:
+          IMAGE_TAG: ${{ steps.tag.outputs.value }}
         run: docker pull "$IMAGE_TAG"
 
       - name: Get vault secrets
@@ -979,7 +985,7 @@ jobs:
         uses: alwaysmeticulous/report-diffs-action/upload-container@89c6081b30d17cfcc410b5c19c269cd7a4d67cdf # v1
         with:
           api-token: ${{ env.METICULOUS_API_TOKEN }}
-          image-tag: ${{ env.IMAGE_TAG }}
+          image-tag: ${{ steps.tag.outputs.value }}
           container-port: 3000
           container-env: |
             GF_AUTH_ANONYMOUS_ENABLED=true

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -189,16 +189,13 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      - uses: ./.github/actions/setup-go
-      - name: Build Go
-        env:
-          CGO_ENABLED: '0'
-          BUILD_VERSION: ${{ needs.setup.outputs.version }}
-          # Env OS/ARCH are overridden by Makefile unless GOOS/GOARCH are set.
-          GOOS: ${{ matrix.os }}
-          GOARCH: ${{ matrix.arch }}
-          GOARM: ${{ matrix.arm }}
-        run: make build-go BUILD_VERSION="${BUILD_VERSION}"
+      - uses: ./.github/actions/build-go
+        with:
+          os: ${{ matrix.os }}
+          arch: ${{ matrix.arch }}
+          arm: ${{ matrix.arm }}
+          build-number: ${{ github.run_id }}
+          build-version: ${{ needs.setup.outputs.version }}
       - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4
         with:
           name: release-backend-${{ matrix.name }}
@@ -257,26 +254,15 @@ jobs:
       - uses: actions/checkout@v6
         with:
           persist-credentials: false
-      # Artifact paths are relative to public/; extract under public/ so public/build exists for make.
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
+      - uses: ./.github/actions/build-targz
         with:
-          name: release-frontend
-          path: public
-      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c
-        with:
-          name: release-backend-${{ matrix.name }}
-          path: bin/${{ matrix.os }}/${{ matrix.arch }}
-      - name: Fix backend binary permissions
-        if: matrix.os != 'windows'
-        run: chmod +x bin/${{ matrix.os }}/${{ matrix.arch }}/grafana*
-      - name: Build tar.gz
-        env:
-          GOOS: ${{ matrix.os }}
-          GOARCH: ${{ matrix.arch }}
-          GOARM: ${{ matrix.arm }}
-          BUILD_NUMBER: ${{ github.run_id }}
-          BUILD_VERSION: ${{ needs.setup.outputs.version }}
-        run: make build-targz BUILD_VERSION="$BUILD_VERSION" BUILD_NUMBER="$BUILD_NUMBER"
+          os: ${{ matrix.os }}
+          arch: ${{ matrix.arch }}
+          arm: ${{ matrix.arm }}
+          build-number: ${{ github.run_id }}
+          build-version: ${{ needs.setup.outputs.version }}
+          frontend-artifact: release-frontend
+          backend-artifact: release-backend-${{ matrix.name }}
       - name: Generate checksums
         run: |
           set -euo pipefail

--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -207,7 +207,7 @@ jobs:
 
   build-targz:
     name: targz / ${{ matrix.name }}
-    runs-on: ubuntu-x64-large-io
+    runs-on: ubuntu-x64-large
     continue-on-error: ${{ matrix.allow-failure == true }}
     needs:
       - setup

--- a/.policy.yml
+++ b/.policy.yml
@@ -569,6 +569,7 @@ approval_rules:
           - ^embed\.go$
           - ^packaging\/docker\/(?:(?:[^/]*(?:/|$))*)$
           - ^\.github\/workflows\/pr-test-docker\.yml$
+          - ^\.github\/workflows\/build-docker-variants\.yml$
       file_not_deleted:
         paths:
           - ^\.github\/workflows\/pr-test-docker\.yml$


### PR DESCRIPTION
**Note for anyone who happens to stumble upon this**

This PR in no way is a commitment to start shipping slim or distroless variants of Grafana docker images. This is purely for testing.