### PR TITLE
unified-storage: fix lease and sqlkv logging

### DIFF
--- a/pkg/storage/unified/resource/kv/sqlkv.go
+++ b/pkg/storage/unified/resource/kv/sqlkv.go
@@ -31,8 +31,6 @@ const (
 
 var _ KV = &SqlKV{}
 
-var sqlKVLog = logging.DefaultLogger.With("logger", "resource-sqlkv")
-
 // DataImportRow represents a single append-only resource_history row written during bulk import.
 type DataImportRow struct {
 	GUID    string
@@ -62,6 +60,7 @@ type DataImportLegacyFields struct {
 type SqlKV struct {
 	db         *sql.DB
 	dialect    Dialect
+	log        logging.Logger
 	DriverName string // TODO: remove when backwards compatibility is no longer needed.
 }
 
@@ -84,6 +83,7 @@ func NewSQLKV(db *sql.DB, driverName string) (KV, error) {
 	return &SqlKV{
 		db:         db,
 		dialect:    dialect,
+		log:        logging.DefaultLogger.With("logger", "sqlkv"),
 		DriverName: driverName, // for usage in datastore
 	}, nil
 }
@@ -210,7 +210,7 @@ func (k *SqlKV) InsertDataImportBatch(ctx context.Context, rows []DataImportRow)
 			return fmt.Errorf("failed to build data import batch query: %w", err)
 		}
 		if _, err = conn.ExecContext(ctx, query, args...); err != nil {
-			sqlKVLog.Error("sqlkv bulk import insert failed",
+			k.log.Error("sqlkv bulk import insert failed",
 				"error", err,
 				"dialect", k.dialect.Name(),
 				"rows", len(rows),
@@ -231,7 +231,7 @@ func (k *SqlKV) InsertDataImportBatch(ctx context.Context, rows []DataImportRow)
 
 	insertDuration := time.Since(insertStart)
 	if insertDuration > 500*time.Millisecond {
-		sqlKVLog.Warn("slow sqlkv bulk import insert",
+		k.log.Warn("slow sqlkv bulk import insert",
 			"dialect", k.dialect.Name(),
 			"rows", len(rows),
 			"statements", statementCount,
@@ -241,7 +241,7 @@ func (k *SqlKV) InsertDataImportBatch(ctx context.Context, rows []DataImportRow)
 			"insert", insertDuration,
 		)
 	} else {
-		sqlKVLog.Debug("sqlkv bulk import insert timing",
+		k.log.Debug("sqlkv bulk import insert timing",
 			"dialect", k.dialect.Name(),
 			"rows", len(rows),
 			"statements", statementCount,

--- a/pkg/storage/unified/resource/lease/lease.go
+++ b/pkg/storage/unified/resource/lease/lease.go
@@ -52,8 +52,6 @@ var (
 	// already been released, or was superseded by another holder. When
 	// auto-renewal is enabled, this error also triggers the Lost() channel.
 	ErrLeaseLost = errors.New("lease lost")
-
-	log = logging.DefaultLogger.With("logger", "lease-manager")
 )
 
 type Lease struct {
@@ -100,6 +98,7 @@ type Manager struct {
 	holder       string
 	minTTL       time.Duration
 	maxClockSkew time.Duration
+	log          logging.Logger
 }
 
 // NewManager returns a Manager that uses store for persistence and identifies
@@ -110,6 +109,7 @@ func NewManager(store kv.KV, holder string, opts ...ManagerOption) *Manager {
 		holder:       holder,
 		minTTL:       defaultMinTTL,
 		maxClockSkew: defaultMaxClockSkew,
+		log:          logging.DefaultLogger.With("logger", "lease-manager"),
 	}
 	for _, opt := range opts {
 		opt(m)
@@ -337,7 +337,7 @@ func (m *Manager) autoRenewLoop(lease *Lease, expiry time.Time, ttl, renewInterv
 	defer ticker.Stop()
 
 	for {
-		log := log.With("lease", lease.name, "holder", lease.holder, "generation", lease.generation)
+		log := m.log.With("lease", lease.name, "holder", lease.holder, "generation", lease.generation)
 
 		select {
 		case <-lease.stop:


### PR DESCRIPTION
By referencing `grafana-app-sdk`'s `DefaultLogger` in a package-level variable, the underlying logger depends on package import order (as it's updated by `pkg/infra/log` at `init()` time). This commit initializes the `lease` and `sqlkv` loggers in constructors, at which point it's safe to assume that the SDK logger points to the application logger.