### PR TITLE
Home: Add test coverage for Grafana editions

### DIFF
--- a/public/app/features/home/HomePage.test.tsx
+++ b/public/app/features/home/HomePage.test.tsx
@@ -1,10 +1,42 @@
 import { render, screen } from 'test/test-utils';
 
+import { GrafanaEdition } from '@grafana/data/internal';
+import { config } from '@grafana/runtime';
+
 import HomePage from './HomePage';
 
 describe('HomePage', () => {
-  it('renders the placeholder text', () => {
+  const originalBuildInfo = { ...config.buildInfo };
+  const originalNamespace = config.namespace;
+
+  afterEach(() => {
+    config.buildInfo = { ...originalBuildInfo };
+    config.namespace = originalNamespace;
+  });
+
+  it('renders the greeting', () => {
+    render(<HomePage />);
+    expect(screen.getByRole('heading', { name: /^Good \w+\.$/ })).toBeInTheDocument();
+  });
+
+  it('renders the OSS welcome message', () => {
+    config.buildInfo.edition = GrafanaEdition.OpenSource;
+
     render(<HomePage />);
     expect(screen.getByText('Welcome to Grafana.')).toBeInTheDocument();
+  });
+
+  it('renders the Enterprise welcome message', () => {
+    config.buildInfo.edition = GrafanaEdition.Enterprise;
+
+    render(<HomePage />);
+    expect(screen.getByText('Welcome to Grafana Enterprise.')).toBeInTheDocument();
+  });
+
+  it('renders the Cloud welcome message', () => {
+    config.namespace = 'stacks-12345';
+
+    render(<HomePage />);
+    expect(screen.getByText('Welcome to Grafana Cloud.')).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
**What is this feature?**

Adds additional test coverage for the edition greeting introduced in #124604

**Why do we need this feature?**

Tests are good.

**Who is this feature for?**

Developers.

**Which issue(s) does this PR fix?**:

N/A

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
