### PR TITLE
QueryEditor: Fire event for PanelEditNext feedback survey

### DIFF
--- a/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts
@@ -49,7 +49,8 @@ declare module "@openfeature/core" {
     | "alerting.syncExternalAlertmanager"
     | "grafana.enableScopesFirstMode"
     | "grafana.logLevelInference"
-    | "plugins.initDataSourcesAsync";
+    | "plugins.initDataSourcesAsync"
+    | "grafana.panelEditNextFeedbackEvent";
   export type NumberFlagKey = never;
   export type StringFlagKey = never;
   export type ObjectFlagKey = never;

--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -49,6 +49,8 @@ export const FlagKeys = {
   GrafanaNewPreferencesPage: "grafana.newPreferencesPage",
   /** Enables org-defined dashboard templates for enterprise */
   GrafanaOrgDashboardTemplates: "grafana.orgDashboardTemplates",
+  /** Replaces the Intercom survey for PanelEditNext feedback with an event that triggers an in-house survey */
+  GrafanaPanelEditNextFeedbackEvent: "grafana.panelEditNextFeedbackEvent",
   /** Prevents flickering in dashboards */
   GrafanaScenesFlickeringFix: "grafana.scenesFlickeringFix",
   /** Replaces the bundled home dashboard with the unified homepage React page */
@@ -291,6 +293,17 @@ export const useFlagGrafanaNewPreferencesPage = (options?: ReactFlagEvaluationOp
  */
 export const useFlagGrafanaOrgDashboardTemplates = (options?: ReactFlagEvaluationOptions): boolean => {
   return useFlag("grafana.orgDashboardTemplates", false, options).value;
+};
+
+/**
+ * Replaces the Intercom survey for PanelEditNext feedback with an event that triggers an in-house survey
+ *
+ * **Details:**
+ * - flag key: `grafana.panelEditNextFeedbackEvent`
+ * - default value: `false`
+ */
+export const useFlagGrafanaPanelEditNextFeedbackEvent = (options?: ReactFlagEvaluationOptions): boolean => {
+  return useFlag("grafana.panelEditNextFeedbackEvent", false, options).value;
 };
 
 /**

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -3163,6 +3163,15 @@ var (
 			Expression:   "false",
 			Generate:     Generate{Go: true},
 		},
+		{
+			Name:         "grafana.panelEditNextFeedbackEvent",
+			Description:  "Replaces the Intercom survey for PanelEditNext feedback with an event that triggers an in-house survey",
+			Stage:        FeatureStageExperimental,
+			Owner:        grafanaDataProSquad,
+			HideFromDocs: true,
+			Expression:   "false",
+			Generate:     Generate{React: true},
+		},
 		// tl;dr: name your new flag `component.featureName`, specify Go and/or React generation targets, and use with OpenFeature!
 		//
 		// Adding a new feature flag? Be sure to check out the updated docs at /contribute/feature-toggles.md#Steps-to-adding-a-feature-toggle

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -368,3 +368,4 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-05-22,grafana.logLevelInference,deprecated,@grafana/observability-logs,false,false,true
 2026-05-26,plugins.initDataSourcesAsync,experimental,@grafana/grafana-catalog,false,false,true
 2026-05-22,frontendService.reducedBootDataAPI,experimental,@grafana/grafana-frontend-platform,false,false,false
+2026-05-27,grafana.panelEditNextFeedbackEvent,experimental,@grafana/datapro,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2406,6 +2406,21 @@
     },
     {
       "metadata": {
+        "name": "grafana.panelEditNextFeedbackEvent",
+        "resourceVersion": "1779903372415",
+        "creationTimestamp": "2026-05-27T17:36:12Z"
+      },
+      "spec": {
+        "description": "Replaces the Intercom survey for PanelEditNext feedback with an event that triggers an in-house survey",
+        "stage": "experimental",
+        "codeowner": "@grafana/datapro",
+        "frontend": true,
+        "hideFromDocs": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "grafana.scenesFlickeringFix",
         "resourceVersion": "1778737357419",
         "creationTimestamp": "2026-05-06T09:26:24Z",

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/ExperimentalFeedbackButton.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/ExperimentalFeedbackButton.tsx
@@ -5,7 +5,7 @@ import { type GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { Button, Dropdown, Menu, useStyles2 } from '@grafana/ui';
 
-import { startIntercomSurvey } from '../../tracking';
+import { startFeedbackSurvey } from '../../tracking';
 import { useActionsContext, useQueryEditorUIContext } from '../QueryEditorContext';
 
 export function ExperimentalFeedbackButton() {
@@ -28,13 +28,13 @@ export function ExperimentalFeedbackButton() {
       <Menu.Item
         label={t('query-editor-next.experimental-button.give-feedback', 'Give feedback')}
         icon="comment-alt-message"
-        onClick={() => startIntercomSurvey()}
+        onClick={() => startFeedbackSurvey()}
       />
       <Menu.Item
         label={t('query-editor-next.experimental-button.back-to-classic', 'Go back to classic editor')}
         icon="arrow-left"
         onClick={() => {
-          startIntercomSurvey();
+          startFeedbackSurvey();
           onSwitchToClassic?.();
         }}
       />

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/tracking.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/tracking.ts
@@ -1,6 +1,8 @@
 import { debounce } from 'lodash';
 
-import { reportInteraction } from '@grafana/runtime';
+import { getAppEvents, reportInteraction } from '@grafana/runtime';
+import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
+import { PanelEditNextFeedbackEvent } from 'app/types/events';
 
 import { QueryEditorType } from './constants';
 
@@ -187,7 +189,17 @@ function ensureIntercomLoaded(): Promise<void> {
   return intercomLoadPromise;
 }
 
-export function startIntercomSurvey(): void {
+export function startFeedbackSurvey(): void {
+  const isPanelEditNextFeedbackEventEnabled = getFeatureFlagClient().getBooleanValue(
+    FlagKeys.GrafanaPanelEditNextFeedbackEvent,
+    false
+  );
+  if (isPanelEditNextFeedbackEventEnabled) {
+    // Fire an event for grafana-setupguide-app to detect, which replaces Intercom with an in-house survey.
+    getAppEvents().publish(new PanelEditNextFeedbackEvent());
+    return;
+  }
+
   ensureIntercomLoaded()
     .then(() => {
       getIntercom()?.('startSurvey', INTERCOM_SURVEY_ID);

--- a/public/app/features/dashboard-scene/panel-edit/QueryEditorBanner.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/QueryEditorBanner.tsx
@@ -4,7 +4,7 @@ import { type GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { Button, Icon, IconButton, useStyles2 } from '@grafana/ui';
 
-import { startIntercomSurvey, trackBannerDismiss, trackFeedbackClick } from './PanelEditNext/tracking';
+import { startFeedbackSurvey, trackBannerDismiss, trackFeedbackClick } from './PanelEditNext/tracking';
 
 interface Props {
   useQueryExperienceNext: boolean;
@@ -46,7 +46,7 @@ export function QueryEditorBanner({ useQueryExperienceNext, onToggle, onDismiss,
             icon="comment-alt-message"
             onClick={() => {
               trackFeedbackClick();
-              startIntercomSurvey();
+              startFeedbackSurvey();
             }}
           >
             {t('dashboard-scene.query-editor-banner.give-feedback', 'Give feedback')}
@@ -59,7 +59,7 @@ export function QueryEditorBanner({ useQueryExperienceNext, onToggle, onDismiss,
             size="sm"
             icon="arrow-left"
             onClick={() => {
-              startIntercomSurvey();
+              startFeedbackSurvey();
               onToggle();
             }}
           >

--- a/public/app/types/events.ts
+++ b/public/app/types/events.ts
@@ -223,3 +223,7 @@ export class PanelEditEnteredEvent extends BusEventWithPayload<number> {
 export class PanelEditExitedEvent extends BusEventWithPayload<number> {
   static type = 'panel-edit-finished';
 }
+
+export class PanelEditNextFeedbackEvent extends BusEventBase {
+  static type = 'panel-edit-next-feedback';
+}


### PR DESCRIPTION
**What is this feature?**

Replaces loading the Intercom survey with firing an event on the event bus, which will then be picked up by [setupguide's global messaging feature](https://github.com/grafana/grafana-setupguide-app/blob/main/docs/global-messaging.md) (🔐), to show an in-house survey instead.

**Why do we need this feature?**

Intercom is going away, being replaced by the in-house global messaging feature.

**Who is this feature for?**

Editors + admins.

**Which issue(s) does this PR fix?**:

cc https://github.com/grafana/grafana-setupguide-app/pull/1120 (🔐)
cc https://github.com/grafana/OGPM/issues/425 (🔐)

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
