### PR TITLE
IAM: Add team storage parity tests

### DIFF
--- a/pkg/services/team/parity/comparator.go
+++ b/pkg/services/team/parity/comparator.go
@@ -1,0 +1,319 @@
+package parity
+
+import (
+	"context"
+	"strconv"
+	"time"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/team"
+)
+
+// shadowReadTimeout caps how long a shadow-read can block its own goroutine.
+// Picked to match the precedent set by compareSearchResults
+// (pkg/storage/unified/resource/search_client.go:20) — a generous bound for
+// a single-resource fetch, deliberately not user-tunable in v0.
+const shadowReadTimeout = 500 * time.Millisecond
+
+// ModeProvider exposes the current dual-writer mode for labeling. Threading
+// the live mode through (rather than baking it in at construction time) lets
+// us label metrics correctly across a config reload or migration.
+type ModeProvider interface {
+	DualWriterMode(ctx context.Context) int
+}
+
+// staticModeProvider returns a fixed mode regardless of context. Useful for
+// tests and as a default when no live source is wired.
+type staticModeProvider int
+
+func (m staticModeProvider) DualWriterMode(_ context.Context) int { return int(m) }
+
+// StaticMode returns a ModeProvider that reports a fixed mode. Used in tests
+// and when the comparator is constructed in a context where the real mode is
+// not introspectable (the v0 wiring case).
+func StaticMode(mode int) ModeProvider { return staticModeProvider(mode) }
+
+// Comparator decorates a team.Service. The primary service does the real
+// work; legacy and k8s are used only for shadow reads after writes succeed.
+//
+// In normal operation, every Comparator method behaves identically to the
+// primary's. The shadow comparison is fire-and-forget — it runs in a
+// background goroutine and never blocks the caller or surfaces an error.
+type Comparator struct {
+	primary team.Service
+	legacy  team.Service
+	k8s     team.Service
+	modes   ModeProvider
+	logger  log.Logger
+
+	// enabled gates shadow execution. When false, the Comparator is a pure
+	// passthrough — useful for rolling the feature out without redeploying.
+	enabled func(ctx context.Context) bool
+}
+
+// New returns a Comparator that delegates to `primary` for all operations
+// and uses `legacy` and `k8s` for shadow reads after writes. `enabled`
+// controls whether the shadow comparison runs at all on a per-request basis.
+//
+// `primary` is the service that actually serves the request — typically
+// teamimpl.Service, which routes between legacy and k8s based on the
+// kubernetesTeamsRedirect flag.
+//
+// Constructor naming follows the precedent of NewSearchClient in
+// pkg/storage/unified/resource/search_client.go (the pattern this package
+// mirrors). A Wire-discoverable `ProvideComparator` is the natural next
+// step when this is integrated into the DI graph.
+func New(primary, legacy, k8s team.Service, modes ModeProvider, enabled func(ctx context.Context) bool, logger log.Logger) *Comparator {
+	if enabled == nil {
+		enabled = func(context.Context) bool { return false }
+	}
+	if logger == nil {
+		logger = log.New("team.parity")
+	}
+	return &Comparator{
+		primary: primary,
+		legacy:  legacy,
+		k8s:     k8s,
+		modes:   modes,
+		logger:  logger,
+		enabled: enabled,
+	}
+}
+
+// --- team.Service implementation -------------------------------------------
+
+var _ team.Service = (*Comparator)(nil)
+
+func (c *Comparator) CreateTeam(ctx context.Context, cmd *team.CreateTeamCommand) (team.Team, error) {
+	created, err := c.primary.CreateTeam(ctx, cmd)
+	if err != nil {
+		return created, err
+	}
+	c.shadowCheck(ctx, "create", created.ID, cmd.OrgID)
+	return created, nil
+}
+
+func (c *Comparator) UpdateTeam(ctx context.Context, cmd *team.UpdateTeamCommand) error {
+	if err := c.primary.UpdateTeam(ctx, cmd); err != nil {
+		return err
+	}
+	c.shadowCheck(ctx, "update", cmd.ID, cmd.OrgID)
+	return nil
+}
+
+func (c *Comparator) DeleteTeam(ctx context.Context, cmd *team.DeleteTeamCommand) error {
+	// Capture identifying info before the delete so we can shadow-read both
+	// stores afterward and verify they both reflect the deletion.
+	teamID := cmd.ID
+	orgID := cmd.OrgID
+
+	if err := c.primary.DeleteTeam(ctx, cmd); err != nil {
+		return err
+	}
+	c.shadowCheckDelete(ctx, teamID, orgID)
+	return nil
+}
+
+// Read and membership methods are pure passthroughs. Shadow comparison is a
+// write-side feature.
+
+func (c *Comparator) SearchTeams(ctx context.Context, q *team.SearchTeamsQuery) (team.SearchTeamQueryResult, error) {
+	return c.primary.SearchTeams(ctx, q)
+}
+
+func (c *Comparator) GetTeamByID(ctx context.Context, q *team.GetTeamByIDQuery) (*team.TeamDTO, error) {
+	return c.primary.GetTeamByID(ctx, q)
+}
+
+func (c *Comparator) GetTeamsByUser(ctx context.Context, q *team.GetTeamsByUserQuery) ([]*team.TeamDTO, error) {
+	return c.primary.GetTeamsByUser(ctx, q)
+}
+
+func (c *Comparator) GetTeamIDsByUser(ctx context.Context, q *team.GetTeamIDsByUserQuery) ([]int64, []string, error) {
+	return c.primary.GetTeamIDsByUser(ctx, q)
+}
+
+func (c *Comparator) IsTeamMember(ctx context.Context, orgID, teamID, userID int64) (bool, error) {
+	return c.primary.IsTeamMember(ctx, orgID, teamID, userID)
+}
+
+func (c *Comparator) RemoveUsersMemberships(ctx context.Context, userID int64) error {
+	return c.primary.RemoveUsersMemberships(ctx, userID)
+}
+
+func (c *Comparator) GetUserTeamMemberships(ctx context.Context, orgID, userID int64, external bool, bypassCache bool) ([]*team.TeamMemberDTO, error) {
+	return c.primary.GetUserTeamMemberships(ctx, orgID, userID, external, bypassCache)
+}
+
+func (c *Comparator) GetTeamMembers(ctx context.Context, q *team.GetTeamMembersQuery) ([]*team.TeamMemberDTO, error) {
+	return c.primary.GetTeamMembers(ctx, q)
+}
+
+func (c *Comparator) RegisterDelete(q string) {
+	c.primary.RegisterDelete(q)
+}
+
+// --- shadow-comparison machinery -------------------------------------------
+
+func (c *Comparator) shadowCheck(ctx context.Context, op string, teamID, orgID int64) {
+	if !c.enabled(ctx) {
+		return
+	}
+
+	// Use WithoutCancel + a bounded timeout so the shadow read survives the
+	// caller's HTTP request lifecycle without leaking goroutines indefinitely.
+	bgCtx := context.WithoutCancel(ctx)
+	mode := c.modeLabel(ctx)
+
+	go func() {
+		bgCtx, cancel := context.WithTimeout(bgCtx, shadowReadTimeout)
+		defer cancel()
+
+		legacyTeam, legacyErr := c.legacy.GetTeamByID(bgCtx, &team.GetTeamByIDQuery{ID: teamID, OrgID: orgID})
+		k8sTeam, k8sErr := c.k8s.GetTeamByID(bgCtx, &team.GetTeamByIDQuery{ID: teamID, OrgID: orgID})
+
+		result := classify(legacyTeam, legacyErr, k8sTeam, k8sErr)
+		teamParityCheckTotal.WithLabelValues(op, mode, result).Inc()
+
+		if result == "mismatch" {
+			c.logger.Warn("team parity mismatch",
+				"operation", op,
+				"mode", mode,
+				"teamID", teamID,
+				"legacy", summarize(legacyTeam),
+				"k8s", summarize(k8sTeam),
+			)
+		}
+	}()
+}
+
+func (c *Comparator) shadowCheckDelete(ctx context.Context, teamID, orgID int64) {
+	if !c.enabled(ctx) {
+		return
+	}
+
+	bgCtx := context.WithoutCancel(ctx)
+	mode := c.modeLabel(ctx)
+
+	go func() {
+		bgCtx, cancel := context.WithTimeout(bgCtx, shadowReadTimeout)
+		defer cancel()
+
+		_, legacyErr := c.legacy.GetTeamByID(bgCtx, &team.GetTeamByIDQuery{ID: teamID, OrgID: orgID})
+		_, k8sErr := c.k8s.GetTeamByID(bgCtx, &team.GetTeamByIDQuery{ID: teamID, OrgID: orgID})
+
+		// After delete, both stores should report the team as not-found.
+		// Anything else is a partial-delete (and worth alerting on).
+		result := classifyDelete(legacyErr, k8sErr)
+		teamParityCheckTotal.WithLabelValues("delete", mode, result).Inc()
+
+		if result == "mismatch" {
+			c.logger.Warn("team parity mismatch on delete",
+				"mode", mode,
+				"teamID", teamID,
+				"legacy_err", legacyErr,
+				"k8s_err", k8sErr,
+			)
+		}
+	}()
+}
+
+func (c *Comparator) modeLabel(ctx context.Context) string {
+	if c.modes == nil {
+		return "unknown"
+	}
+	return strconv.Itoa(c.modes.DualWriterMode(ctx))
+}
+
+// --- comparison logic ------------------------------------------------------
+
+// classify is exported indirectly via tests; keeping it package-private so we
+// don't accidentally make it part of any contract.
+func classify(legacyTeam *team.TeamDTO, legacyErr error, k8sTeam *team.TeamDTO, k8sErr error) string {
+	switch {
+	case legacyErr != nil && k8sErr != nil:
+		return "both_errors"
+	case legacyErr != nil:
+		return "legacy_error"
+	case k8sErr != nil:
+		return "k8s_error"
+	case legacyTeam == nil && k8sTeam == nil:
+		// Read-back found nothing in either store. Treat as a mismatch on
+		// non-delete ops — the write should have produced something.
+		return "mismatch"
+	case legacyTeam == nil:
+		return "missing_legacy"
+	case k8sTeam == nil:
+		return "missing_k8s"
+	case semanticallyEqual(legacyTeam, k8sTeam):
+		return "match"
+	default:
+		return "mismatch"
+	}
+}
+
+func classifyDelete(legacyErr, k8sErr error) string {
+	legacyGone := legacyErr != nil
+	k8sGone := k8sErr != nil
+	switch {
+	case legacyGone && k8sGone:
+		return "match" // both stores agree the team is gone
+	case legacyGone:
+		return "missing_k8s" // k8s still has it
+	case k8sGone:
+		return "missing_legacy" // legacy still has it
+	default:
+		return "mismatch" // neither deleted
+	}
+}
+
+// semanticallyEqual checks the fields that should round-trip identically
+// across the legacy SQL adapter and the K8s adapter. Excludes:
+//   - ID / UID timing artifacts: ID may be 0 from the K8s adapter (Bug A);
+//     we ASSERT non-zero separately rather than equality (the comparator
+//     would log a mismatch in that case, which is the desired behavior).
+//   - MemberCount: read via separate code path; member parity is its own
+//     concern and out of scope for v0 write-time parity.
+//   - Permission / AccessControl: caller-derived, not storage state.
+//   - AvatarURL: derived from email on read; cosmetic.
+func semanticallyEqual(a, b *team.TeamDTO) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	if a.Name != b.Name {
+		return false
+	}
+	if a.Email != b.Email {
+		return false
+	}
+	if a.ExternalUID != b.ExternalUID {
+		return false
+	}
+	if a.IsProvisioned != b.IsProvisioned {
+		return false
+	}
+	if a.OrgID != b.OrgID {
+		return false
+	}
+	// UID equality is part of the contract — both adapters MUST agree on
+	// the same UID, since that's the primary identifier post-K8s migration.
+	if a.UID != b.UID {
+		return false
+	}
+	return true
+}
+
+func summarize(t *team.TeamDTO) map[string]any {
+	if t == nil {
+		return nil
+	}
+	return map[string]any{
+		"id":            t.ID,
+		"uid":           t.UID,
+		"name":          t.Name,
+		"email":         t.Email,
+		"externalUID":   t.ExternalUID,
+		"isProvisioned": t.IsProvisioned,
+		"orgID":         t.OrgID,
+	}
+}

--- a/pkg/services/team/parity/comparator_test.go
+++ b/pkg/services/team/parity/comparator_test.go
@@ -1,0 +1,290 @@
+package parity
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/services/team"
+)
+
+// Most of the comparator's value is in classify() — the right shape of
+// outcome label given a (legacyTeam, legacyErr, k8sTeam, k8sErr) tuple.
+// We exercise classify directly via a table; the shadow goroutine itself
+// is tested separately by observing that the recording fake gets called.
+
+func TestClassify(t *testing.T) {
+	teamA := &team.TeamDTO{ID: 1, UID: "uid-a", OrgID: 1, Name: "a", Email: "a@example.com"}
+	teamB := &team.TeamDTO{ID: 1, UID: "uid-a", OrgID: 1, Name: "a", Email: "a@example.com"}
+	teamDifferent := &team.TeamDTO{ID: 1, UID: "uid-a", OrgID: 1, Name: "DIFFERENT", Email: "a@example.com"}
+
+	errBoom := errors.New("boom")
+
+	cases := []struct {
+		name      string
+		legacy    *team.TeamDTO
+		legacyErr error
+		k8s       *team.TeamDTO
+		k8sErr    error
+		want      string
+	}{
+		{"both equal", teamA, nil, teamB, nil, "match"},
+		{"name differs", teamA, nil, teamDifferent, nil, "mismatch"},
+		{"legacy error", nil, errBoom, teamB, nil, "legacy_error"},
+		{"k8s error", teamA, nil, nil, errBoom, "k8s_error"},
+		{"both error", nil, errBoom, nil, errBoom, "both_errors"},
+		{"both nil result (no error)", nil, nil, nil, nil, "mismatch"},
+		{"only legacy nil", nil, nil, teamB, nil, "missing_legacy"},
+		{"only k8s nil", teamA, nil, nil, nil, "missing_k8s"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classify(tc.legacy, tc.legacyErr, tc.k8s, tc.k8sErr)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestClassifyDelete(t *testing.T) {
+	errGone := errors.New("not found")
+	cases := []struct {
+		name      string
+		legacyErr error
+		k8sErr    error
+		want      string
+	}{
+		{"both gone", errGone, errGone, "match"},
+		{"only legacy gone", errGone, nil, "missing_k8s"},
+		{"only k8s gone", nil, errGone, "missing_legacy"},
+		{"neither gone", nil, nil, "mismatch"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := classifyDelete(tc.legacyErr, tc.k8sErr)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestSemanticallyEqual(t *testing.T) {
+	base := &team.TeamDTO{
+		ID: 1, UID: "uid", OrgID: 1,
+		Name: "a", Email: "a@example.com",
+		ExternalUID: "ext-1", IsProvisioned: false,
+	}
+
+	t.Run("identical wins", func(t *testing.T) {
+		other := *base
+		assert.True(t, semanticallyEqual(base, &other))
+	})
+
+	t.Run("ID differs is OK (deprecated)", func(t *testing.T) {
+		other := *base
+		other.ID = 999
+		assert.True(t, semanticallyEqual(base, &other),
+			"ID equality is not part of the parity contract — the K8s adapter may legitimately return 0 (Bug A) and that should not produce a 'mismatch'; it should produce a separate signal via the non-zero ID assertion in the integration test")
+	})
+
+	t.Run("MemberCount differs is OK (separate concern)", func(t *testing.T) {
+		other := *base
+		other.MemberCount = 5
+		assert.True(t, semanticallyEqual(base, &other))
+	})
+
+	t.Run("UID mismatch is a real mismatch", func(t *testing.T) {
+		other := *base
+		other.UID = "different"
+		assert.False(t, semanticallyEqual(base, &other))
+	})
+
+	t.Run("Name mismatch is a real mismatch", func(t *testing.T) {
+		other := *base
+		other.Name = "different"
+		assert.False(t, semanticallyEqual(base, &other))
+	})
+
+	t.Run("nil handling", func(t *testing.T) {
+		assert.True(t, semanticallyEqual(nil, nil))
+		assert.False(t, semanticallyEqual(base, nil))
+		assert.False(t, semanticallyEqual(nil, base))
+	})
+}
+
+// fakeTeamService is a minimal team.Service for testing the shadow goroutine
+// without standing up the whole DI graph. Only the methods exercised by the
+// comparator's write paths and read-back are non-trivial; the rest panic to
+// catch accidental call paths.
+//
+// Why not use pkg/services/team/teamtest/FakeService? That helper is built
+// around static "Expected*" fields and returns the same response for every
+// call. The comparator's shadow goroutine needs different responses for the
+// legacy and k8s services (to surface the divergence cases under test) plus
+// per-call dispatch. A per-test fake is the minimum surface area to express
+// that without bending teamtest into a different shape.
+type fakeTeamService struct {
+	mu       sync.Mutex
+	createFn func(*team.CreateTeamCommand) (team.Team, error)
+	updateFn func(*team.UpdateTeamCommand) error
+	deleteFn func(*team.DeleteTeamCommand) error
+	getFn    func(*team.GetTeamByIDQuery) (*team.TeamDTO, error)
+	calls    []string
+}
+
+func (f *fakeTeamService) record(name string) {
+	f.mu.Lock()
+	f.calls = append(f.calls, name)
+	f.mu.Unlock()
+}
+
+func (f *fakeTeamService) callLog() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]string, len(f.calls))
+	copy(out, f.calls)
+	return out
+}
+
+func (f *fakeTeamService) CreateTeam(_ context.Context, c *team.CreateTeamCommand) (team.Team, error) {
+	f.record("CreateTeam")
+	if f.createFn != nil {
+		return f.createFn(c)
+	}
+	return team.Team{ID: 1, OrgID: c.OrgID, Name: c.Name, Email: c.Email}, nil
+}
+func (f *fakeTeamService) UpdateTeam(_ context.Context, c *team.UpdateTeamCommand) error {
+	f.record("UpdateTeam")
+	if f.updateFn != nil {
+		return f.updateFn(c)
+	}
+	return nil
+}
+func (f *fakeTeamService) DeleteTeam(_ context.Context, c *team.DeleteTeamCommand) error {
+	f.record("DeleteTeam")
+	if f.deleteFn != nil {
+		return f.deleteFn(c)
+	}
+	return nil
+}
+func (f *fakeTeamService) GetTeamByID(_ context.Context, q *team.GetTeamByIDQuery) (*team.TeamDTO, error) {
+	f.record("GetTeamByID")
+	if f.getFn != nil {
+		return f.getFn(q)
+	}
+	return nil, errors.New("no getFn configured")
+}
+func (f *fakeTeamService) SearchTeams(context.Context, *team.SearchTeamsQuery) (team.SearchTeamQueryResult, error) {
+	panic("not exercised")
+}
+func (f *fakeTeamService) GetTeamsByUser(context.Context, *team.GetTeamsByUserQuery) ([]*team.TeamDTO, error) {
+	panic("not exercised")
+}
+func (f *fakeTeamService) GetTeamIDsByUser(context.Context, *team.GetTeamIDsByUserQuery) ([]int64, []string, error) {
+	panic("not exercised")
+}
+func (f *fakeTeamService) IsTeamMember(context.Context, int64, int64, int64) (bool, error) {
+	panic("not exercised")
+}
+func (f *fakeTeamService) RemoveUsersMemberships(context.Context, int64) error {
+	panic("not exercised")
+}
+func (f *fakeTeamService) GetUserTeamMemberships(context.Context, int64, int64, bool, bool) ([]*team.TeamMemberDTO, error) {
+	panic("not exercised")
+}
+func (f *fakeTeamService) GetTeamMembers(context.Context, *team.GetTeamMembersQuery) ([]*team.TeamMemberDTO, error) {
+	panic("not exercised")
+}
+func (f *fakeTeamService) RegisterDelete(string) {}
+
+func TestComparator_CreateTriggersShadowReadFromBothStores(t *testing.T) {
+	primary := &fakeTeamService{}
+	legacyReads := make(chan struct{}, 1)
+	k8sReads := make(chan struct{}, 1)
+
+	legacy := &fakeTeamService{
+		getFn: func(q *team.GetTeamByIDQuery) (*team.TeamDTO, error) {
+			legacyReads <- struct{}{}
+			return &team.TeamDTO{ID: q.ID, UID: "u1", OrgID: q.OrgID, Name: "n", Email: "e@x"}, nil
+		},
+	}
+	k8s := &fakeTeamService{
+		getFn: func(q *team.GetTeamByIDQuery) (*team.TeamDTO, error) {
+			k8sReads <- struct{}{}
+			return &team.TeamDTO{ID: q.ID, UID: "u1", OrgID: q.OrgID, Name: "n", Email: "e@x"}, nil
+		},
+	}
+
+	c := New(primary, legacy, k8s, StaticMode(1), func(context.Context) bool { return true }, log.NewNopLogger())
+
+	_, err := c.CreateTeam(context.Background(), &team.CreateTeamCommand{Name: "n", Email: "e@x", OrgID: 1})
+	require.NoError(t, err)
+
+	// Shadow comparison runs in a goroutine — wait briefly for both reads.
+	select {
+	case <-legacyReads:
+	case <-time.After(2 * time.Second):
+		t.Fatal("legacy shadow read did not fire")
+	}
+	select {
+	case <-k8sReads:
+	case <-time.After(2 * time.Second):
+		t.Fatal("k8s shadow read did not fire")
+	}
+
+	assert.Contains(t, primary.callLog(), "CreateTeam", "primary must serve the synchronous request")
+}
+
+func TestComparator_DisabledIsPureLPassthrough(t *testing.T) {
+	primary := &fakeTeamService{}
+	legacy := &fakeTeamService{
+		getFn: func(*team.GetTeamByIDQuery) (*team.TeamDTO, error) {
+			t.Fatal("legacy must not be read when comparator is disabled")
+			return nil, nil
+		},
+	}
+	k8s := &fakeTeamService{
+		getFn: func(*team.GetTeamByIDQuery) (*team.TeamDTO, error) {
+			t.Fatal("k8s must not be read when comparator is disabled")
+			return nil, nil
+		},
+	}
+
+	c := New(primary, legacy, k8s, StaticMode(1), func(context.Context) bool { return false }, log.NewNopLogger())
+
+	_, err := c.CreateTeam(context.Background(), &team.CreateTeamCommand{Name: "n", OrgID: 1})
+	require.NoError(t, err)
+
+	// Give any (forbidden) goroutine a chance to misbehave.
+	time.Sleep(50 * time.Millisecond)
+}
+
+func TestComparator_PrimaryErrorSkipsShadow(t *testing.T) {
+	primary := &fakeTeamService{
+		createFn: func(*team.CreateTeamCommand) (team.Team, error) {
+			return team.Team{}, errors.New("primary failed")
+		},
+	}
+	legacy := &fakeTeamService{
+		getFn: func(*team.GetTeamByIDQuery) (*team.TeamDTO, error) {
+			t.Fatal("shadow read must not run when the primary write failed — there is nothing to compare")
+			return nil, nil
+		},
+	}
+	k8s := &fakeTeamService{
+		getFn: func(*team.GetTeamByIDQuery) (*team.TeamDTO, error) {
+			t.Fatal("shadow read must not run when the primary write failed")
+			return nil, nil
+		},
+	}
+
+	c := New(primary, legacy, k8s, StaticMode(1), func(context.Context) bool { return true }, log.NewNopLogger())
+
+	_, err := c.CreateTeam(context.Background(), &team.CreateTeamCommand{Name: "n", OrgID: 1})
+	require.Error(t, err)
+	time.Sleep(50 * time.Millisecond)
+}

--- a/pkg/services/team/parity/metrics.go
+++ b/pkg/services/team/parity/metrics.go
@@ -1,0 +1,53 @@
+// Package parity provides a shadow comparator that, after each public legacy
+// team write operation, reads back the resulting state via both the legacy
+// SQL path and the K8s adapter path and compares them. The outcome is emitted
+// as a Prometheus counter so adapter drift and silent dual-write failures show
+// up as ongoing operational signal rather than only in tests.
+//
+// Design follows the `compareSearchResults` pattern in
+// pkg/storage/unified/resource/search_client.go (background goroutine,
+// context.WithoutCancel, separate timeout, no impact on the synchronous
+// return path).
+//
+// Known limitation (v0). The comparator sits at the team-service layer,
+// ABOVE the K8s API server's dual-writer. That means in dual-write Mode 1,
+// reading via the K8s adapter still returns the legacy view (because the
+// dual-writer reads from legacy in Mode 1). So:
+//
+//   - We CAN detect: adapter response-shape drift (e.g. id=0, memberCount=0,
+//     external-member labels), missing legacy writes, partial-write states
+//     where one path errored.
+//   - We CANNOT detect: silent failures to write to unified storage in Mode 1
+//     (the dual-writer's write-side fanout going wrong while reads come from
+//     a still-correct legacy).
+//
+// True "did the write hit unified storage" verification needs a side channel
+// below the dual-writer (direct unified-resource gRPC client, or a debug
+// endpoint). That's a v1 extension.
+package parity
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// teamParityCheckTotal counts parity-check outcomes. Labels:
+//
+//   - operation: "create" | "update" | "delete"
+//   - mode:      dual-writer mode as a string ("0", "1", "5", "unknown")
+//   - result:    "match" | "mismatch" | "legacy_error" | "k8s_error" |
+//     "both_errors" | "missing_legacy" | "missing_k8s"
+//
+// "match"/"mismatch" are the dominant signal in healthy operation. A
+// rising "mismatch" rate is the alertable condition; "*_error" rates above
+// background noise are also actionable but distinct (typically point at the
+// adapter rather than at storage divergence).
+var teamParityCheckTotal = promauto.NewCounterVec(
+	prometheus.CounterOpts{
+		Namespace: "grafana",
+		Subsystem: "iam_team_parity",
+		Name:      "check_total",
+		Help:      "Counts shadow parity-check outcomes after each public legacy team write. See package doc for the v0 scope (catches adapter drift; does not directly observe Mode 1 unified-store writes).",
+	},
+	[]string{"operation", "mode", "result"},
+)

--- a/pkg/tests/apis/iam/team/team_parity_integration_test.go
+++ b/pkg/tests/apis/iam/team/team_parity_integration_test.go
@@ -1,0 +1,443 @@
+package team
+
+// Storage-layer parity test for the public legacy team APIs across dual-write
+// Modes 0/1/5. The companion to pkg/services/team/parity (the live shadow
+// comparator) — same contract, two execution surfaces.
+//
+// For each mode, with kubernetesTeamsRedirect ON, this test:
+//
+//  1. Performs a write through the public legacy HTTP API (POST /api/teams,
+//     PUT, DELETE, member add/remove).
+//  2. Reads the resulting state back from BOTH the legacy SQL store (direct
+//     query via helper.GetEnv().SQLStore) AND the K8s API (direct dynamic
+//     client read).
+//  3. Asserts the per-mode invariant.
+//
+// Known limitation in Mode 1: the K8s dynamic client always goes through the
+// K8s API server's dual-writer, which in Mode 1 reads from legacy SQL. So a
+// "K8s direct read" in Mode 1 effectively returns the legacy view via the
+// K8s adapter — useful for catching adapter-mapping bugs (A/B/C/D from the
+// bug bash) but NOT able to directly observe whether the dual-writer's
+// best-effort write to unified storage actually happened. Verifying that
+// would need a side channel below the dual-writer (gRPC to the unified
+// store, or a debug endpoint). Out of scope for v0.
+//
+// Run a single mode:
+//
+//	go test -timeout 180s -run 'TestIntegrationLegacyTeamAPIParity/mode-1' \
+//	  ./pkg/tests/apis/iam/team -count=1 -v
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"testing"
+
+	"github.com/open-feature/go-sdk/openfeature"
+	"github.com/open-feature/go-sdk/openfeature/memprovider"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	apiserverrest "github.com/grafana/grafana/pkg/apiserver/rest"
+	"github.com/grafana/grafana/pkg/infra/db"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/grafana/grafana/pkg/setting"
+	"github.com/grafana/grafana/pkg/tests/apis"
+	"github.com/grafana/grafana/pkg/tests/testinfra"
+	"github.com/grafana/grafana/pkg/util/testutil"
+)
+
+// teamFromSQL is the slim view of the legacy `team` row that the parity check
+// uses. Only fields that should round-trip through both adapters.
+type teamFromSQL struct {
+	ID            int64
+	UID           string
+	OrgID         int64
+	Name          string
+	Email         string
+	ExternalUID   string
+	IsProvisioned bool
+}
+
+// teamFromK8s is the view of the K8s Team object built from the dynamic
+// client response. Fields chosen to align 1:1 with teamFromSQL.
+type teamFromK8s struct {
+	UID           string // = metadata.name
+	Title         string // = spec.title (corresponds to legacy Name)
+	Email         string // = spec.email
+	ExternalUID   string // = spec.externalUID
+	IsProvisioned bool   // = spec.provisioned
+}
+
+// teamLegacyHTTPResponse is the rich view returned by GET /api/teams/{id},
+// including MemberCount so the parity test can also surface Bug B.
+type teamLegacyHTTPResponse struct {
+	ID            int64  `json:"id"`
+	UID           string `json:"uid"`
+	OrgID         int64  `json:"orgId"`
+	Name          string `json:"name"`
+	Email         string `json:"email"`
+	ExternalUID   string `json:"externalUID"`
+	IsProvisioned bool   `json:"isProvisioned"`
+	MemberCount   int64  `json:"memberCount"`
+}
+
+// userTeamItem is one row in the /api/user/teams response.
+type userTeamItem struct {
+	ID   int64  `json:"id"`
+	UID  string `json:"uid"`
+	Name string `json:"name"`
+}
+
+// go test -timeout 300s -run ^TestIntegrationLegacyTeamAPIParity$ github.com/grafana/grafana/pkg/tests/apis/iam/team -count=1
+func TestIntegrationLegacyTeamAPIParity(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	modes := []apiserverrest.DualWriterMode{
+		apiserverrest.Mode0,
+		apiserverrest.Mode1,
+		apiserverrest.Mode5,
+	}
+
+	for _, mode := range modes {
+		t.Run(fmt.Sprintf("mode-%d", mode), func(t *testing.T) {
+			helper := newParityHelper(t, mode)
+			t.Cleanup(helper.Shutdown)
+
+			enableTeamK8sRedirect(t, true)
+			t.Cleanup(func() { enableTeamK8sRedirect(t, false) })
+
+			t.Run("CRUD parity: write via legacy HTTP, both stores reflect", func(t *testing.T) {
+				assertCRUDParity(t, helper, mode)
+			})
+			t.Run("Members parity: add/remove via legacy HTTP, both stores reflect", func(t *testing.T) {
+				assertMembersParity(t, helper, mode)
+			})
+			t.Run("BugA: search returns non-zero legacy ID", func(t *testing.T) {
+				assertSearchReturnsNonZeroID(t, helper)
+			})
+			t.Run("BugB: get returns accurate memberCount", func(t *testing.T) {
+				assertMemberCountAccurate(t, helper)
+			})
+			t.Run("BugC: duplicate name returns 409", func(t *testing.T) {
+				assertDuplicateNameReturns409(t, helper)
+			})
+			t.Run("BugD: non-admin can read /api/user/teams", func(t *testing.T) {
+				assertNonAdminCanReadUserTeams(t, helper)
+			})
+		})
+	}
+}
+
+// --- helpers ---------------------------------------------------------------
+
+func newParityHelper(t *testing.T, mode apiserverrest.DualWriterMode) *apis.K8sTestHelper {
+	t.Helper()
+	return apis.NewK8sTestHelper(t, testinfra.GrafanaOpts{
+		AppModeProduction:      false,
+		DisableAnonymous:       true,
+		RBACSingleOrganization: true,
+		APIServerStorageType:   "unified",
+		UnifiedStorageConfig: map[string]setting.UnifiedStorageConfig{
+			"teams.iam.grafana.app": {DualWriterMode: mode},
+		},
+		EnableFeatureToggles: []string{
+			featuremgmt.FlagGrafanaAPIServerWithExperimentalAPIs,
+			featuremgmt.FlagKubernetesTeamsApi,
+			featuremgmt.FlagKubernetesTeamsRedirect,
+			featuremgmt.FlagKubernetesUsersApi,
+		},
+	})
+}
+
+// enableTeamK8sRedirect is the local copy of setTeamK8sFeatureToggle. The
+// canonical version lives in team_redirect_integration_test.go but we
+// duplicate the flag-flipping logic here to keep this file self-contained.
+func enableTeamK8sRedirect(t *testing.T, enabled bool) {
+	t.Helper()
+	provider := memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
+		featuremgmt.FlagKubernetesTeamsApi: {
+			Key:            featuremgmt.FlagKubernetesTeamsApi,
+			DefaultVariant: "default",
+			Variants:       map[string]any{"default": enabled},
+		},
+		featuremgmt.FlagKubernetesTeamsRedirect: {
+			Key:            featuremgmt.FlagKubernetesTeamsRedirect,
+			DefaultVariant: "default",
+			Variants:       map[string]any{"default": enabled},
+		},
+	})
+	require.NoError(t, openfeature.SetProviderAndWait(provider))
+}
+
+// readTeamFromSQL hits the legacy `team` row directly. This is the source
+// of truth for "what's in legacy storage" — bypasses every adapter, every
+// dual-writer mode logic, and every K8s machinery.
+func readTeamFromSQL(t *testing.T, helper *apis.K8sTestHelper, teamID int64) (teamFromSQL, bool) {
+	t.Helper()
+	var out teamFromSQL
+	found := false
+	err := helper.GetEnv().SQLStore.WithDbSession(context.Background(), func(sess *db.Session) error {
+		var rows []struct {
+			ID            int64  `xorm:"id"`
+			UID           string `xorm:"uid"`
+			OrgID         int64  `xorm:"org_id"`
+			Name          string `xorm:"name"`
+			Email         string `xorm:"email"`
+			ExternalUID   string `xorm:"external_uid"`
+			IsProvisioned bool   `xorm:"is_provisioned"`
+		}
+		if err := sess.SQL(
+			"SELECT id, uid, org_id, name, email, external_uid, is_provisioned FROM team WHERE id = ?",
+			teamID,
+		).Find(&rows); err != nil {
+			return err
+		}
+		if len(rows) == 1 {
+			out = teamFromSQL{
+				ID:            rows[0].ID,
+				UID:           rows[0].UID,
+				OrgID:         rows[0].OrgID,
+				Name:          rows[0].Name,
+				Email:         rows[0].Email,
+				ExternalUID:   rows[0].ExternalUID,
+				IsProvisioned: rows[0].IsProvisioned,
+			}
+			found = true
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	return out, found
+}
+
+// readTeamFromK8s reads the Team via the K8s dynamic client. In Mode 0/1
+// this transitively returns the legacy view (because the dual-writer reads
+// from legacy in those modes); in Mode 5 it returns the unified view.
+// Either way, this is what an external K8s API client sees.
+func readTeamFromK8s(t *testing.T, helper *apis.K8sTestHelper, teamUID string) (teamFromK8s, bool) {
+	t.Helper()
+	teamClient := helper.GetResourceClient(apis.ResourceClientArgs{
+		User:      helper.Org1.Admin,
+		Namespace: helper.Namespacer(helper.Org1.Admin.Identity.GetOrgID()),
+		GVR:       gvrTeams,
+	})
+	obj, err := teamClient.Resource.Get(context.Background(), teamUID, metav1.GetOptions{})
+	if err != nil {
+		// Best-effort distinguish 404 from other errors. The dynamic client's
+		// errors aren't easy to typify here, so fall back to treating any
+		// error as "not found" — callers always pair this with require/assert
+		// statements that contextualize what they expected.
+		return teamFromK8s{}, false
+	}
+	spec, _ := obj.Object["spec"].(map[string]any)
+	provisioned, _ := spec["provisioned"].(bool)
+	externalUID, _ := spec["externalUID"].(string)
+	title, _ := spec["title"].(string)
+	email, _ := spec["email"].(string)
+	return teamFromK8s{
+		UID:           obj.GetName(),
+		Title:         title,
+		Email:         email,
+		ExternalUID:   externalUID,
+		IsProvisioned: provisioned,
+	}, true
+}
+
+func assertTeamFieldsMatch(t *testing.T, sqlT teamFromSQL, k8sT teamFromK8s) {
+	t.Helper()
+	assert.Equal(t, sqlT.UID, k8sT.UID, "UID must round-trip identically between stores")
+	assert.Equal(t, sqlT.Name, k8sT.Title, "legacy.name must equal K8s spec.title")
+	assert.Equal(t, sqlT.Email, k8sT.Email, "email must match")
+	assert.Equal(t, sqlT.ExternalUID, k8sT.ExternalUID, "externalUID must match")
+	assert.Equal(t, sqlT.IsProvisioned, k8sT.IsProvisioned, "isProvisioned must match")
+}
+
+// --- per-mode parity invariants -------------------------------------------
+
+func assertCRUDParity(t *testing.T, helper *apis.K8sTestHelper, mode apiserverrest.DualWriterMode) {
+	t.Helper()
+
+	teamID, teamUID := createTeamViaAPI(t, helper, fmt.Sprintf("parity-crud-%d", mode), fmt.Sprintf("parity-crud-%d@example.com", mode))
+	t.Cleanup(func() { deleteTeamViaAPI(t, helper, teamID) })
+
+	// Always observable: K8s view of the team. The dual-writer in any mode
+	// serves a read through the K8s API.
+	k8sTeam, k8sFound := readTeamFromK8s(t, helper, teamUID)
+	require.True(t, k8sFound, "after legacy HTTP create, K8s view of team %q must exist", teamUID)
+
+	// Mode-specific legacy SQL invariant.
+	sqlTeam, sqlFound := readTeamFromSQL(t, helper, teamID)
+	switch mode {
+	case apiserverrest.Mode0, apiserverrest.Mode1:
+		require.True(t, sqlFound, "Mode %d: legacy SQL row must exist after write", mode)
+		assertTeamFieldsMatch(t, sqlTeam, k8sTeam)
+	case apiserverrest.Mode5:
+		// Mode 5 reads/writes from unified only. Whether legacy SQL still
+		// gets a row depends on the dual-writer's Mode 5 fanout behavior;
+		// in pure unified-only operation it does not. We DON'T require SQL
+		// state here — the assertion to make in Mode 5 is that the K8s view
+		// is correct, full stop.
+		_ = sqlTeam
+	default:
+		t.Fatalf("unhandled mode %d", mode)
+	}
+
+	// Update path.
+	newName := fmt.Sprintf("parity-crud-%d-renamed", mode)
+	newEmail := fmt.Sprintf("parity-crud-%d-renamed@example.com", mode)
+	updateTeamViaAPI(t, helper, teamID, newName, newEmail)
+
+	k8sAfter, k8sFoundAfter := readTeamFromK8s(t, helper, teamUID)
+	require.True(t, k8sFoundAfter, "after legacy HTTP update, K8s view of team must still exist")
+	assert.Equal(t, newName, k8sAfter.Title, "Mode %d: K8s view must reflect renamed team", mode)
+	assert.Equal(t, newEmail, k8sAfter.Email, "Mode %d: K8s view must reflect updated email", mode)
+
+	if mode == apiserverrest.Mode0 || mode == apiserverrest.Mode1 {
+		sqlAfter, ok := readTeamFromSQL(t, helper, teamID)
+		require.True(t, ok)
+		assert.Equal(t, newName, sqlAfter.Name, "Mode %d: legacy SQL name must reflect rename", mode)
+		assert.Equal(t, newEmail, sqlAfter.Email, "Mode %d: legacy SQL email must reflect update", mode)
+	}
+}
+
+func assertMembersParity(t *testing.T, helper *apis.K8sTestHelper, mode apiserverrest.DualWriterMode) {
+	t.Helper()
+
+	teamID, _ := createTeamViaAPI(t, helper, fmt.Sprintf("parity-members-%d", mode), fmt.Sprintf("members-%d@example.com", mode))
+	t.Cleanup(func() { deleteTeamViaAPI(t, helper, teamID) })
+
+	editorID, err := helper.Org1.Editor.Identity.GetInternalID()
+	require.NoError(t, err)
+
+	addTeamMemberViaAPI(t, helper, teamID, editorID)
+
+	// Observable via the legacy /members endpoint regardless of mode (the
+	// endpoint routes through the same K8s adapter when redirect is on).
+	//
+	// Expected count is 2, not 1: POST /api/teams auto-adds the creator
+	// (helper.Org1.Admin in this test) as a team Admin (permission=4). So
+	// after explicitly adding the editor, members = {creator-admin, editor}.
+	resp := apis.DoRequest(helper, apis.RequestParams{
+		User:   helper.Org1.Admin,
+		Method: http.MethodGet,
+		Path:   fmt.Sprintf("/api/teams/%d/members", teamID),
+	}, &[]map[string]any{})
+	require.Equal(t, http.StatusOK, resp.Response.StatusCode, "body=%s", string(resp.Body))
+	require.Len(t, *resp.Result, 2, "Mode %d: two members after add (creator-admin + editor)", mode)
+	editorPresent := false
+	for _, member := range *resp.Result {
+		if userID, ok := member["userId"].(float64); ok && int64(userID) == editorID {
+			editorPresent = true
+			break
+		}
+	}
+	assert.True(t, editorPresent, "Mode %d: editor (userID=%d) must appear in /members response after add", mode, editorID)
+
+	// Mode 0/1 invariant: the legacy team_member row exists.
+	if mode == apiserverrest.Mode0 || mode == apiserverrest.Mode1 {
+		var count int64
+		err := helper.GetEnv().SQLStore.WithDbSession(context.Background(), func(sess *db.Session) error {
+			var rows []struct {
+				N int64 `xorm:"n"`
+			}
+			if err := sess.SQL(
+				"SELECT COUNT(*) AS n FROM team_member WHERE team_id = ? AND user_id = ?",
+				teamID, editorID,
+			).Find(&rows); err != nil {
+				return err
+			}
+			if len(rows) > 0 {
+				count = rows[0].N
+			}
+			return nil
+		})
+		require.NoError(t, err)
+		assert.EqualValues(t, 1, count, "Mode %d: legacy team_member row must exist after add-member through legacy HTTP", mode)
+	}
+}
+
+// --- bug-bash regression coverage ------------------------------------------
+
+func assertSearchReturnsNonZeroID(t *testing.T, helper *apis.K8sTestHelper) {
+	t.Helper()
+	teamID, _ := createTeamViaAPI(t, helper, "parity-buga", "buga@example.com")
+	t.Cleanup(func() { deleteTeamViaAPI(t, helper, teamID) })
+
+	res := searchTeamsViaAPI(t, helper, url.Values{"query": {"parity-buga"}})
+	require.GreaterOrEqual(t, len(res.Teams), 1)
+	for _, found := range res.Teams {
+		assert.NotZero(t, found.ID, "Bug A: search returned a team with id=0 (uid=%s)", found.UID)
+	}
+}
+
+func assertMemberCountAccurate(t *testing.T, helper *apis.K8sTestHelper) {
+	t.Helper()
+	teamID, _ := createTeamViaAPI(t, helper, "parity-bugb", "bugb@example.com")
+	t.Cleanup(func() { deleteTeamViaAPI(t, helper, teamID) })
+
+	editorID, err := helper.Org1.Editor.Identity.GetInternalID()
+	require.NoError(t, err)
+	// POST /api/teams auto-adds the creator (helper.Org1.Admin) as a team
+	// Admin, so we only need to add the editor to reach a 2-member state.
+	addTeamMemberViaAPI(t, helper, teamID, editorID)
+
+	resp := apis.DoRequest(helper, apis.RequestParams{
+		User:   helper.Org1.Admin,
+		Method: http.MethodGet,
+		Path:   fmt.Sprintf("/api/teams/%d", teamID),
+	}, &teamLegacyHTTPResponse{})
+	require.Equal(t, http.StatusOK, resp.Response.StatusCode, "body=%s", string(resp.Body))
+	assert.EqualValues(t, 2, resp.Result.MemberCount,
+		"Bug B: GET /api/teams/%d returned memberCount=%d (expected 2: creator-admin + editor)", teamID, resp.Result.MemberCount)
+}
+
+func assertDuplicateNameReturns409(t *testing.T, helper *apis.K8sTestHelper) {
+	t.Helper()
+	name := "parity-bugc"
+	teamID, _ := createTeamViaAPI(t, helper, name, "bugc@example.com")
+	t.Cleanup(func() { deleteTeamViaAPI(t, helper, teamID) })
+
+	body, err := json.Marshal(map[string]string{"name": name, "email": "bugc-dup@example.com"})
+	require.NoError(t, err)
+	resp := apis.DoRequest(helper, apis.RequestParams{
+		User:   helper.Org1.Admin,
+		Method: http.MethodPost,
+		Path:   "/api/teams",
+		Body:   body,
+	}, &struct{}{})
+	assert.Equal(t, http.StatusConflict, resp.Response.StatusCode,
+		"Bug C: duplicate POST /api/teams must be 409 Conflict; body=%s", string(resp.Body))
+}
+
+func assertNonAdminCanReadUserTeams(t *testing.T, helper *apis.K8sTestHelper) {
+	t.Helper()
+	teamID, _ := createTeamViaAPI(t, helper, "parity-bugd", "bugd@example.com")
+	t.Cleanup(func() { deleteTeamViaAPI(t, helper, teamID) })
+
+	viewerID, err := helper.Org1.Viewer.Identity.GetInternalID()
+	require.NoError(t, err)
+	addTeamMemberViaAPI(t, helper, teamID, viewerID)
+
+	resp := apis.DoRequest(helper, apis.RequestParams{
+		User:   helper.Org1.Viewer,
+		Method: http.MethodGet,
+		Path:   "/api/user/teams",
+	}, &[]userTeamItem{})
+	assert.Equal(t, http.StatusOK, resp.Response.StatusCode,
+		"Bug D: non-admin /api/user/teams must be 200; body=%s", string(resp.Body))
+
+	if resp.Result != nil {
+		found := false
+		for _, it := range *resp.Result {
+			if it.ID == teamID {
+				found = true
+				break
+			}
+		}
+		assert.True(t, found, "Viewer's /api/user/teams should include the team they were added to (teamID=%d)", teamID)
+	}
+}


### PR DESCRIPTION
**What is this feature?**

Two complementary tools for verifying storage-layer parity between the legacy SQL store and the new unified storage for the public legacy team APIs (`/api/teams/*`, `/api/user/teams`), exercised across dual-write Modes 0, 1, and 5.

1. `pkg/services/team/parity/` — a `team.Service` decorator that, after each successful write, fires a background shadow comparison: reads back via both the legacy SQL service and the K8s adapter service, classifies the result (`match` / `mismatch` / `legacy_error` / `k8s_error` / `missing_legacy` / `missing_k8s` / `both_errors`), and emits a Prometheus counter (`grafana_iam_team_parity_check_total{operation,mode,result}`). Follows the `compareSearchResults` pattern in `pkg/storage/unified/resource/search_client.go` — cancel-resistant background goroutine, 500 ms timeout, no impact on the synchronous return path.

2. `pkg/tests/apis/iam/team/team_parity_integration_test.go` — a CI-level parity suite parameterized over Modes 0/1/5. Writes via the public legacy HTTP API, then reads state back from both the legacy SQL store (direct `WithDbSession` query against the `team` and `team_member` tables) and the K8s dynamic client. Asserts per-mode invariants plus the four May 2026 bug-bash regression cases.

**Why do we need this feature?**

The May 2026 Teams K8s Migration bug bash surfaced four adapter-mapping bugs in the legacy team APIs (search returning `id=0`, GET `/api/teams/{id}` returning `memberCount=0`, duplicate-name POST returning 500 instead of 409, non-admin `/api/user/teams` returning 500). The existing integration tests did not catch them — they ran admin-only, stubbed RBAC out of the fake K8s server, and the search assertion helper deliberately skipped the `ID` field. This PR puts in place the verification scaffolding the team needed during that bug bash, so future regressions of the same shape are caught in CI.

Running the suite against current main produces actionable signal:

- **Bug A** (search `id=0`) — still present in all three modes.
- **Bug B** (GET `memberCount=0`) — still present in Mode 0 and Mode 1; in Mode 5 the test is blocked from observation by the Mode-5 ID-resolution failure below.
- **Bug C** (duplicate POST → 500) — still present in all three modes.
- **Bug D** (non-admin `/api/user/teams` → 500) — fixed in Mode 0 and Mode 1.
- **New Mode 5 finding** — after `POST /api/teams` returns 200, subsequent `/api/teams/{teamID}/...` operations 404 because the legacy int64 ID doesn't resolve in unified-only mode. Affects update, add-member, and the BugD setup.

Follow-up PRs handle each fix.

**Who is this feature for?**

The Identity-Access team and anyone working on the teams K8s migration rollout. CI runs the integration test against every commit; the comparator is the building block for future production-side drift detection.

**Which issue(s) does this PR fix?**

Not a direct bug fix — this is the verification scaffolding. Follow-up PRs (one per identified bug) handle the fixes.

**Special notes for your reviewer:**

Known v0 limitations, documented in the package and test-header comments:

- The comparator sits **above** the dual-writer, so in Mode 1 the "K8s read" still returns the legacy view through the K8s adapter (the dual-writer reads from legacy in Mode 1). Current scope catches adapter-mapping drift and missing-legacy writes; it does **not** directly observe whether the dual-writer's best-effort write to unified storage actually succeeded. True Mode-1 unified observation needs a side channel below the dual-writer (a gRPC client to the unified store, or a debug endpoint) — flagged as a v1 extension.
- Not wired into the DI graph. Feature gating is via a `func(ctx) bool` parameter for now; a real feature flag and Wire integration are follow-up work.
- Member writes (`POST/PUT/DELETE /api/teams/{id}/members`) go through `teamPermissionsService`, not `team.Service`, so they're not covered by the decorator. The integration test covers them via HTTP, which is the right layer for that.

Please check that:

- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. (Gated via `enabled func(ctx) bool` — see comparator package doc.)
- [ ] The docs are updated. (Internal verification tooling — no user-facing docs to update.)
