### PR TITLE
Snapshots: Clean not used ST service in k8s API

### DIFF
--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -1286,7 +1286,7 @@ func (b *DashboardsAPIBuilder) GetAPIRoutes(gv schema.GroupVersion) *builder.API
 
 	defs := b.GetOpenAPIDefinitions()(func(path string) spec.Ref { return spec.Ref{} })
 	searchAPIRoutes := b.search.GetAPIRoutes(defs)
-	snapshotAPIRoutes := snapshot.GetRoutes(b.snapshotService, b.snapshotOptions, b.accessControl, defs,
+	snapshotAPIRoutes := snapshot.GetRoutes(b.snapshotOptions, b.accessControl, defs,
 		func() rest.Storage {
 			return b.snapshotStorage
 		}, b.dashboardService)

--- a/pkg/registry/apis/dashboard/snapshot/routes.go
+++ b/pkg/registry/apis/dashboard/snapshot/routes.go
@@ -89,7 +89,7 @@ func createExternalSnapshot(cmd *dashboardsnapshots.CreateDashboardSnapshotComma
 }
 
 // nolint:gocyclo
-func GetRoutes(service dashboardsnapshots.Service, options dashv0.SnapshotSharingOptions, accessControl ac.AccessControl, defs map[string]common.OpenAPIDefinition, storageGetter func() rest.Storage, dashboardService dashboards.DashboardService) *builder.APIRoutes {
+func GetRoutes(options dashv0.SnapshotSharingOptions, accessControl ac.AccessControl, defs map[string]common.OpenAPIDefinition, storageGetter func() rest.Storage, dashboardService dashboards.DashboardService) *builder.APIRoutes {
 	prefix := dashv0.SnapshotResourceInfo.GroupResource().Resource
 	tags := []string{dashv0.SnapshotResourceInfo.GroupVersionKind().Kind}
 

--- a/pkg/registry/apis/dashboard/snapshot/routes_test.go
+++ b/pkg/registry/apis/dashboard/snapshot/routes_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	acmock "github.com/grafana/grafana/pkg/services/accesscontrol/mock"
 	"github.com/grafana/grafana/pkg/services/dashboards"
-	"github.com/grafana/grafana/pkg/services/dashboardsnapshots"
 	"github.com/grafana/grafana/pkg/services/user"
 )
 
@@ -123,12 +122,10 @@ func TestCreateSnapshotDashboardValidation(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			snapshotService := dashboardsnapshots.NewMockService(t)
 			dashboardService := dashboards.NewFakeDashboardService(t)
 			tt.setupDashboardMock(dashboardService)
 
 			routes := GetRoutes(
-				snapshotService,
 				dashv0.SnapshotSharingOptions{SnapshotsEnabled: true},
 				acmock.New().WithPermissions([]accesscontrol.Permission{{Action: dashboards.ActionSnapshotsCreate}}),
 				map[string]common.OpenAPIDefinition{},
@@ -201,7 +198,6 @@ func TestCreateSnapshotPublicMode(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			snapshotService := dashboardsnapshots.NewMockService(t)
 			dashboardService := dashboards.NewFakeDashboardService(t)
 
 			var createdSnapshot *dashv0.Snapshot
@@ -213,7 +209,6 @@ func TestCreateSnapshotPublicMode(t *testing.T) {
 				Return(&dashv0.Snapshot{}, nil)
 
 			routes := GetRoutes(
-				snapshotService,
 				dashv0.SnapshotSharingOptions{SnapshotsEnabled: true, PublicMode: true},
 				acmock.New().WithPermissions([]accesscontrol.Permission{{Action: dashboards.ActionSnapshotsCreate}}),
 				map[string]common.OpenAPIDefinition{},
@@ -252,12 +247,10 @@ func TestCreateSnapshotPublicModeRejectsExternal(t *testing.T) {
 		OrgID:  orgID,
 	}
 
-	snapshotService := dashboardsnapshots.NewMockService(t)
 	dashboardService := dashboards.NewFakeDashboardService(t)
 	mockStorage := grafanarest.NewMockStorage(t)
 
 	routes := GetRoutes(
-		snapshotService,
 		dashv0.SnapshotSharingOptions{SnapshotsEnabled: true, PublicMode: true, ExternalEnabled: true},
 		acmock.New().WithPermissions([]accesscontrol.Permission{{Action: dashboards.ActionSnapshotsCreate}}),
 		map[string]common.OpenAPIDefinition{},
@@ -317,7 +310,6 @@ func TestCreateExternalSnapshot(t *testing.T) {
 			ExternalSnapshotToken: "test-token-123",
 		}
 
-		snapshotService := dashboardsnapshots.NewMockService(t)
 		dashboardService := dashboards.NewFakeDashboardService(t)
 		dashboardService.On("GetDashboard", mock.Anything, &dashboards.GetDashboardQuery{
 			UID:   "dash-1",
@@ -329,7 +321,6 @@ func TestCreateExternalSnapshot(t *testing.T) {
 			Return(&dashv0.Snapshot{}, nil)
 
 		routes := GetRoutes(
-			snapshotService,
 			options,
 			acmock.New().WithPermissions([]accesscontrol.Permission{{Action: dashboards.ActionSnapshotsCreate}}),
 			map[string]common.OpenAPIDefinition{},
@@ -383,7 +374,6 @@ func TestCreateExternalSnapshot(t *testing.T) {
 			ExternalSnapshotToken: "bad-token",
 		}
 
-		snapshotService := dashboardsnapshots.NewMockService(t)
 		dashboardService := dashboards.NewFakeDashboardService(t)
 		dashboardService.On("GetDashboard", mock.Anything, &dashboards.GetDashboardQuery{
 			UID:   "dash-1",
@@ -391,7 +381,6 @@ func TestCreateExternalSnapshot(t *testing.T) {
 		}).Return(&dashboards.Dashboard{UID: "dash-1", OrgID: orgID}, nil)
 
 		routes := GetRoutes(
-			snapshotService,
 			options,
 			acmock.New().WithPermissions([]accesscontrol.Permission{{Action: dashboards.ActionSnapshotsCreate}}),
 			map[string]common.OpenAPIDefinition{},
@@ -429,7 +418,6 @@ func TestCreateExternalSnapshot(t *testing.T) {
 			ExternalSnapshotToken: "test-token",
 		}
 
-		snapshotService := dashboardsnapshots.NewMockService(t)
 		dashboardService := dashboards.NewFakeDashboardService(t)
 		dashboardService.On("GetDashboard", mock.Anything, &dashboards.GetDashboardQuery{
 			UID:   "dash-1",
@@ -437,7 +425,6 @@ func TestCreateExternalSnapshot(t *testing.T) {
 		}).Return(&dashboards.Dashboard{UID: "dash-1", OrgID: orgID}, nil)
 
 		routes := GetRoutes(
-			snapshotService,
 			options,
 			acmock.New().WithPermissions([]accesscontrol.Permission{{Action: dashboards.ActionSnapshotsCreate}}),
 			map[string]common.OpenAPIDefinition{},
@@ -468,10 +455,8 @@ func TestCreateExternalSnapshot(t *testing.T) {
 			ExternalEnabled:  false,
 		}
 
-		snapshotService := dashboardsnapshots.NewMockService(t)
 		dashboardService := dashboards.NewFakeDashboardService(t)
 		routes := GetRoutes(
-			snapshotService,
 			options,
 			acmock.New().WithPermissions([]accesscontrol.Permission{{Action: dashboards.ActionSnapshotsCreate}}),
 			map[string]common.OpenAPIDefinition{},
@@ -512,7 +497,6 @@ func TestCreateExternalSnapshot(t *testing.T) {
 			ExternalSnapshotToken: "",
 		}
 
-		snapshotService := dashboardsnapshots.NewMockService(t)
 		dashboardService := dashboards.NewFakeDashboardService(t)
 		dashboardService.On("GetDashboard", mock.Anything, &dashboards.GetDashboardQuery{
 			UID:   "dash-1",
@@ -524,7 +508,6 @@ func TestCreateExternalSnapshot(t *testing.T) {
 			Return(&dashv0.Snapshot{}, nil)
 
 		routes := GetRoutes(
-			snapshotService,
 			options,
 			acmock.New().WithPermissions([]accesscontrol.Permission{{Action: dashboards.ActionSnapshotsCreate}}),
 			map[string]common.OpenAPIDefinition{},
@@ -578,7 +561,6 @@ func TestHandleDeleteByKey(t *testing.T) {
 			Return(&dashv0.Snapshot{}, true, nil)
 
 		routes := GetRoutes(
-			dashboardsnapshots.NewMockService(t),
 			dashv0.SnapshotSharingOptions{SnapshotsEnabled: true},
 			deletePerms(),
 			map[string]common.OpenAPIDefinition{},
@@ -603,7 +585,6 @@ func TestHandleDeleteByKey(t *testing.T) {
 			Return(&dashv0.SnapshotList{Items: []dashv0.Snapshot{}}, nil)
 
 		routes := GetRoutes(
-			dashboardsnapshots.NewMockService(t),
 			dashv0.SnapshotSharingOptions{SnapshotsEnabled: true},
 			deletePerms(),
 			map[string]common.OpenAPIDefinition{},
@@ -626,7 +607,6 @@ func TestHandleDeleteByKey(t *testing.T) {
 		mockStorage := grafanarest.NewMockStorage(t)
 
 		routes := GetRoutes(
-			dashboardsnapshots.NewMockService(t),
 			dashv0.SnapshotSharingOptions{SnapshotsEnabled: true},
 			acmock.New().WithPermissions([]accesscontrol.Permission{}),
 			map[string]common.OpenAPIDefinition{},


### PR DESCRIPTION
**What is this feature?**

Cleaning up not used ST old snapshot service in the k8s handler.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
