### PR TITLE
Flamegraph: exclude 'other' from top table and show truncation note

### DIFF
--- a/packages/grafana-flamegraph/src/TopTable/FlameGraphTopTableContainer.test.tsx
+++ b/packages/grafana-flamegraph/src/TopTable/FlameGraphTopTableContainer.test.tsx
@@ -96,15 +96,16 @@ describe('buildFilteredTable', () => {
 [3][4]
     `);
 
-    const result = buildFilteredTable(container!);
+    const { table, otherData } = buildFilteredTable(container!);
 
-    expect(result).toEqual({
+    expect(table).toEqual({
       '0': { self: 1, total: 7, totalRight: 0 },
       '1': { self: 0, total: 3, totalRight: 0 },
       '2': { self: 0, total: 3, totalRight: 0 },
       '3': { self: 3, total: 3, totalRight: 0 },
       '4': { self: 3, total: 3, totalRight: 0 },
     });
+    expect(otherData).toBeNull();
   });
 
   it('should sum values for duplicate labels', () => {
@@ -113,9 +114,9 @@ describe('buildFilteredTable', () => {
 [1][1]
     `);
 
-    const result = buildFilteredTable(container!);
+    const { table } = buildFilteredTable(container!);
 
-    expect(result).toEqual({
+    expect(table).toEqual({
       '0': { self: 0, total: 6, totalRight: 0 },
       '1': { self: 6, total: 6, totalRight: 0 },
     });
@@ -129,9 +130,9 @@ describe('buildFilteredTable', () => {
     `);
 
     const matchedLabels = new Set(['1', '3']);
-    const result = buildFilteredTable(container!, matchedLabels);
+    const { table } = buildFilteredTable(container!, matchedLabels);
 
-    expect(result).toEqual({
+    expect(table).toEqual({
       '1': { self: 0, total: 3, totalRight: 0 },
       '3': { self: 3, total: 3, totalRight: 0 },
     });
@@ -145,9 +146,9 @@ describe('buildFilteredTable', () => {
     `);
 
     const matchedLabels = new Set<string>();
-    const result = buildFilteredTable(container!, matchedLabels);
+    const { table } = buildFilteredTable(container!, matchedLabels);
 
-    expect(result).toEqual({});
+    expect(table).toEqual({});
   });
 
   it('should handle data with no matches', () => {
@@ -158,9 +159,9 @@ describe('buildFilteredTable', () => {
     `);
 
     const matchedLabels = new Set(['9']);
-    const result = buildFilteredTable(container!, matchedLabels);
+    const { table } = buildFilteredTable(container!, matchedLabels);
 
-    expect(result).toEqual({});
+    expect(table).toEqual({});
   });
 
   it('should work without matchedLabels filter', () => {
@@ -169,13 +170,14 @@ describe('buildFilteredTable', () => {
 [1]
     `);
 
-    const result = buildFilteredTable(container!);
+    const { table } = buildFilteredTable(container!);
 
-    expect(result).toEqual({
+    expect(table).toEqual({
       '0': { self: 0, total: 3, totalRight: 0 },
       '1': { self: 3, total: 3, totalRight: 0 },
     });
   });
+
   it('should not inflate totals for recursive calls', () => {
     const container = textToDataContainer(`
 [0////]
@@ -184,14 +186,35 @@ describe('buildFilteredTable', () => {
 [0]
     `);
 
-    const result = buildFilteredTable(container!);
+    const { table } = buildFilteredTable(container!);
 
-    expect(result).toEqual({
+    expect(table).toEqual({
       '0': { self: 4, total: 7, totalRight: 0 },
       '1': { self: 0, total: 3, totalRight: 0 },
       '2': { self: 0, total: 3, totalRight: 0 },
       '3': { self: 0, total: 3, totalRight: 0 },
       '4': { self: 3, total: 3, totalRight: 0 },
     });
+  });
+
+  it('should exclude "other" from the table and return it in otherData', () => {
+    const container = textToDataContainer(`
+[0////]
+[1][2]
+    `);
+
+    // Manually inject an 'other' label into the data for testing
+    const rawContainer = container!;
+    const originalGetLabel = rawContainer.getLabel.bind(rawContainer);
+    // Simulate label '2' being named 'other'
+    rawContainer.getLabel = (i: number) => (originalGetLabel(i) === '2' ? 'other' : originalGetLabel(i));
+
+    const { table, otherData } = buildFilteredTable(rawContainer);
+
+    expect(table).not.toHaveProperty('other');
+    expect(table).toHaveProperty('0');
+    expect(table).toHaveProperty('1');
+    expect(otherData).not.toBeNull();
+    expect(otherData!.self).toBeGreaterThan(0);
   });
 });

--- a/packages/grafana-flamegraph/src/TopTable/FlameGraphTopTableContainer.tsx
+++ b/packages/grafana-flamegraph/src/TopTable/FlameGraphTopTableContainer.tsx
@@ -54,49 +54,63 @@ const FlameGraphTopTableContainer = memo(
     onTableSort,
     colorScheme,
   }: Props) => {
-    const table = useMemo(() => buildFilteredTable(data, matchedLabels), [data, matchedLabels]);
+    const { table, otherData } = useMemo(() => buildFilteredTable(data, matchedLabels), [data, matchedLabels]);
 
     const styles = useStyles2(getStyles);
     const theme = useTheme2();
 
     const [sort, setSort] = useState<TableSortByFieldState[]>([{ displayName: 'Self', desc: true }]);
 
+    let otherNote: string | undefined;
+    if (otherData) {
+      const display = data.valueDisplayProcessor(otherData.self);
+      const formatted = `${display.text}${display.suffix ?? ''}`;
+      otherNote = `${formatted} has been truncated and is represented as 'other' in the flamegraph.`;
+    }
+
     return (
       <div className={styles.topTableContainer} data-testid="topTable">
-        <AutoSizer style={{ width: '100%' }}>
-          {({ width, height }) => {
-            if (width < 3 || height < 3) {
-              return null;
-            }
+        <div className={styles.tableWrapper}>
+          <AutoSizer style={{ width: '100%' }}>
+            {({ width, height }) => {
+              if (width < 3 || height < 3) {
+                return null;
+              }
 
-            const frame = buildTableDataFrame(
-              data,
-              table,
-              width,
-              onSymbolClick,
-              onSearch,
-              onSandwich,
-              theme,
-              colorScheme,
-              search,
-              sandwichItem
-            );
-            return (
-              <Table
-                initialSortBy={sort}
-                onSortByChange={(s) => {
-                  if (s && s.length) {
-                    onTableSort?.(s[0].displayName + '_' + (s[0].desc ? 'desc' : 'asc'));
-                  }
-                  setSort(s);
-                }}
-                data={frame}
-                width={width}
-                height={height}
-              />
-            );
-          }}
-        </AutoSizer>
+              const frame = buildTableDataFrame(
+                data,
+                table,
+                width,
+                onSymbolClick,
+                onSearch,
+                onSandwich,
+                theme,
+                colorScheme,
+                search,
+                sandwichItem
+              );
+              return (
+                <Table
+                  initialSortBy={sort}
+                  onSortByChange={(s) => {
+                    if (s && s.length) {
+                      onTableSort?.(s[0].displayName + '_' + (s[0].desc ? 'desc' : 'asc'));
+                    }
+                    setSort(s);
+                  }}
+                  data={frame}
+                  width={width}
+                  height={height}
+                />
+              );
+            }}
+          </AutoSizer>
+        </div>
+        {otherNote && (
+          <p className={styles.otherNote} data-testid="other-note">
+            {otherNote}
+          </p>
+        )}
       </div>
     );
   }
@@ -104,10 +118,16 @@ const FlameGraphTopTableContainer = memo(
 
 FlameGraphTopTableContainer.displayName = 'FlameGraphTopTableContainer';
 
-function buildFilteredTable(data: FlameGraphDataContainer, matchedLabels?: Set<string>) {
+type FilteredTableResult = {
+  table: { [key: string]: TableData };
+  otherData: TableData | null;
+};
+
+function buildFilteredTable(data: FlameGraphDataContainer, matchedLabels?: Set<string>): FilteredTableResult {
   // Group the data by label, we show only one row per label and sum the values
   // TODO: should be by filename + funcName + linenumber?
   let filteredTable: { [key: string]: TableData } = Object.create(null);
+  let otherData: TableData | null = null;
 
   // Track call stack to detect recursive calls
   const callStack: string[] = [];
@@ -127,8 +147,19 @@ function buildFilteredTable(data: FlameGraphDataContainer, matchedLabels?: Set<s
     // Check if this is a recursive call (same label already in call stack)
     const isRecursive = callStack.some((entry) => entry === label);
 
-    // If user is doing text search we filter out labels in the same way we highlight them in flame graph.
-    if (!matchedLabels || matchedLabels.has(label)) {
+    // The 'other' node represents truncated stacktraces and is not actionable in the table.
+    // Accumulate its values separately so a note can be shown below the table.
+    if (label === 'other') {
+      if (!otherData) {
+        otherData = { self: 0, total: 0, totalRight: 0 };
+      }
+      otherData.self += self;
+      if (!isRecursive) {
+        otherData.total += value;
+        otherData.totalRight += valueRight;
+      }
+    } else if (!matchedLabels || matchedLabels.has(label)) {
+      // If user is doing text search we filter out labels in the same way we highlight them in flame graph.
       filteredTable[label] = filteredTable[label] || {};
       filteredTable[label].self = filteredTable[label].self ? filteredTable[label].self + self : self;
 
@@ -145,7 +176,7 @@ function buildFilteredTable(data: FlameGraphDataContainer, matchedLabels?: Set<s
     callStack.push(label);
   }
 
-  return filteredTable;
+  return { table: filteredTable, otherData };
 }
 
 function buildTableDataFrame(
@@ -367,9 +398,23 @@ const getStyles = (theme: GrafanaTheme2) => {
   return {
     topTableContainer: css({
       label: 'topTableContainer',
+      display: 'flex',
+      flexDirection: 'column',
       padding: theme.spacing(1),
       backgroundColor: theme.colors.background.secondary,
       height: '100%',
+    }),
+    tableWrapper: css({
+      label: 'tableWrapper',
+      flex: 1,
+      minHeight: 0,
+    }),
+    otherNote: css({
+      label: 'otherNote',
+      marginTop: theme.spacing(0.5),
+      marginBottom: 0,
+      color: theme.colors.text.secondary,
+      fontSize: theme.typography.bodySmall.fontSize,
     }),
   };
 };


### PR DESCRIPTION
The 'other' node in the flamegraph top table represents truncated stacktraces that Pyroscope collapsed because they individually fell below a display threshold. Showing it as a table row is misleading because it cannot be searched, sandwiched, or acted on like a real symbol.

This change filters 'other' out of the top table and instead displays a small note below the table when truncated data is present, formatted as: "{value} has been truncated and is represented as 'other' in the flamegraph." The value is formatted using the same unit as the rest of the table (samples, bytes, nanoseconds, etc.).

Closes #110677

**How to test:**
1. Open a Pyroscope datasource with a profile that contains an 'other' node in the flamegraph
2. Enable the top table view
3. Confirm 'other' no longer appears as a table row
4. Confirm the truncation note appears below the table with a formatted value

Unit tests updated to reflect the new `buildFilteredTable` return shape (`{ table, otherData }`), and a new test covers the 'other' exclusion behavior.