### PR TITLE
Alerting: include rule labels when expanding annotation templates

### DIFF
--- a/pkg/services/ngalert/state/cache.go
+++ b/pkg/services/ngalert/state/cache.go
@@ -156,7 +156,9 @@ func expandAnnotationsAndLabels(ctx context.Context, log log.Logger, alertRule *
 	// For now, do nothing with these errors as they are already logged in expand.
 	// In the future, we want to show these errors to the user somehow.
 	labels, _ := expand(ctx, log, alertRule.Title, alertRule.Labels, templateData, externalURL, result.EvaluatedAt)
-	annotations, _ := expand(ctx, log, alertRule.Title, alertRule.Annotations, templateData, externalURL, result.EvaluatedAt)
+	// Include the expanded rule labels so annotation templates can access them via $labels.
+	annotationTemplateData := template.NewData(mergeLabels(mergeLabels(extraLabels, resultLabels), labels), result)
+	annotations, _ := expand(ctx, log, alertRule.Title, alertRule.Annotations, annotationTemplateData, externalURL, result.EvaluatedAt)
 
 	// If the result contains an error, we want to add the ref_id and datasource_uid labels
 	// to the new state if the alert rule should be in the ErrorErrState.

--- a/pkg/services/ngalert/state/cache_test.go
+++ b/pkg/services/ngalert/state/cache_test.go
@@ -135,6 +135,54 @@ func Test_expand(t *testing.T) {
 	})
 }
 
+func Test_expandAnnotationsAndLabels(t *testing.T) {
+	ctx := context.Background()
+	logger := log.NewNopLogger()
+
+	t.Run("rule labels are visible in annotation templates via $labels", func(t *testing.T) {
+		rule := &models.AlertRule{
+			Title:       "test",
+			Labels:      map[string]string{"environment": "production"},
+			Annotations: map[string]string{"summary": "{{ $labels.environment }} is alerting"},
+		}
+		result := eval.Result{}
+
+		_, annotations := expandAnnotationsAndLabels(ctx, logger, rule, result, nil, nil)
+
+		require.Equal(t, "production is alerting", annotations["summary"])
+	})
+
+	t.Run("result instance labels are visible in annotation templates via $labels", func(t *testing.T) {
+		rule := &models.AlertRule{
+			Title:       "test",
+			Labels:      map[string]string{},
+			Annotations: map[string]string{"summary": "instance {{ $labels.instance }} down"},
+		}
+		result := eval.Result{
+			Instance: data.Labels{"instance": "host1"},
+		}
+
+		_, annotations := expandAnnotationsAndLabels(ctx, logger, rule, result, nil, nil)
+
+		require.Equal(t, "instance host1 down", annotations["summary"])
+	})
+
+	t.Run("both rule labels and result labels are visible in annotation templates", func(t *testing.T) {
+		rule := &models.AlertRule{
+			Title:       "test",
+			Labels:      map[string]string{"environment": "production"},
+			Annotations: map[string]string{"summary": "{{ $labels.environment }} {{ $labels.instance }}"},
+		}
+		result := eval.Result{
+			Instance: data.Labels{"instance": "host1"},
+		}
+
+		_, annotations := expandAnnotationsAndLabels(ctx, logger, rule, result, nil, nil)
+
+		require.Equal(t, "production host1", annotations["summary"])
+	})
+}
+
 func Test_mergeLabels(t *testing.T) {
 	t.Run("merges two maps", func(t *testing.T) {
 		a := models.GenerateAlertLabels(5, "set1-")


### PR DESCRIPTION
When an alert rule has statically defined labels (set in the rule editor), those labels are not available in annotation templates via `{{ $labels }}`. The annotation template data is built from extra (system) labels and the evaluation result labels, but the rule's own expanded labels are excluded. This means a label like `environment: production` set directly on the rule will not appear when `{{ $labels }}` is used in the alert description or summary.

The fix rebuilds the template data after expanding rule labels, merging the expanded rule labels in so they are accessible to annotation templates via `$labels`. The label precedence order is preserved: extra labels > rule labels > result labels.

Three tests cover the fix: rule labels only, result labels only (regression check), and both combined.

Fixes #116074