### PR TITLE
Traceview: wrap long span attribute values to avoid horizontal scrolling

### DIFF
--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
@@ -78,7 +78,8 @@ export const getStyles = (theme: GrafanaTheme2) => {
       fontWeight: 'bold',
     }),
     jsonTable: css({
-      display: 'inline-block',
+      display: 'block',
+      wordBreak: 'break-word',
     }),
   };
 };


### PR DESCRIPTION
Span attribute values that contain long unbroken strings (URLs, base64 data, trace IDs, etc.) are rendered in an `inline-block` div, which lets them stretch the table cell to match the full content width. This forces the user to scroll horizontally across the entire span detail panel to read the value.

Changing `display` from `inline-block` to `block` makes the value container fill the available column width instead of growing with its content. Adding `word-break: break-word` ensures long strings without natural break points (spaces, slashes) wrap to the next line rather than overflow.

Code block values (`type: 'code'`) are wrapped in a `<pre>` element whose no-wrap behaviour is intentional, so those are not affected.

Fixes #124671