### PR TITLE
Correlations: Rerender actions list when correlations data changes

### DIFF
--- a/public/app/features/correlations/CorrelationsPage.tsx
+++ b/public/app/features/correlations/CorrelationsPage.tsx
@@ -83,6 +83,8 @@ export default function CorrelationsPage(props: CorrelationsPageProps) {
   };
 
   const canWriteCorrelations = contextSrv.hasPermission(AccessControlAction.DataSourcesWrite);
+  const corrData = correlations?.correlations ?? [];
+  const hasWritable = corrData.some(negate(isCorrelationsReadOnly));
 
   const handleAdded = useCallback(() => {
     reportInteraction('grafana_correlations_added');
@@ -164,13 +166,12 @@ export default function CorrelationsPage(props: CorrelationsPageProps) {
         id: 'actions',
         cell: RowActions,
         disableGrow: true,
-        visible: (data) => canWriteCorrelations && data.some(negate(isCorrelationsReadOnly)),
+        visible: (data) => canWriteCorrelations && hasWritable,
       },
     ],
-    [RowActions, canWriteCorrelations]
+    [RowActions, canWriteCorrelations, hasWritable]
   );
 
-  const corrData = correlations?.correlations ?? [];
   const showEmptyListCTA = corrData.length === 0 && !isAdding && !error;
   const addButton = canWriteCorrelations && corrData.length !== 0 && !isAdding && (
     <Button icon="plus" onClick={() => setIsAdding(true)}>


### PR DESCRIPTION
In the correlations list, there is a column on the table to show actions that can be performed on the correlation. Currently, the only action here is the ability to delete a correlation.

In the scenario where there are multiple pages, and previous pages were all read only, going to a page with a non read only correlation would not re-trigger the logic to decide if this column should show, and as a result, the ability to delete that correlation wasn't possible.

Since the correlation list is now at 100 correlations, and all of them would have to have been provisioned, this bug was never found.

Repro steps
Use the instructions here to fake-limit the page size to 10, and add the correlations via provisioning
https://github.com/grafana/grafana/pull/124867 

Ensure `kubernetesCorrelations = false` as we want to use the legacy data for this (provisioning only currently works with legacy). 

You will end up with 4 pages of correlations. Add one manually, with any data.

The delete button will not be there, even on a page refresh, before this change.