### PR TITLE
Heatmap: fix off-by-one error in tooltip header for numeric x-axis

### DIFF
--- a/public/app/plugins/panel/heatmap/HeatmapTooltip.test.tsx
+++ b/public/app/plugins/panel/heatmap/HeatmapTooltip.test.tsx
@@ -488,7 +488,7 @@ describe('HeatmapTooltip', () => {
       expect(screen.getByText(/1970-01-01/)).toBeVisible();
     });
 
-    it('uses string fallback when x field has no display and is not time type', () => {
+    it('uses xBucketMin for tooltip header when x field is numeric (not time)', () => {
       const heatmap = createDataFrame({
         meta: { type: DataFrameType.HeatmapCells },
         fields: [
@@ -510,7 +510,8 @@ describe('HeatmapTooltip', () => {
       render(<HeatmapTooltip {...defaultProps} dataRef={dataRef} dataIdxs={[0, 0, 0]} />);
 
       expect(screen.getByTestId(selectors.components.Panels.Visualization.Tooltip.Wrapper)).toBeVisible();
-      expect(screen.getByText('200')).toBeVisible();
+      // numeric x-axis uses xBucketMin to avoid off-by-one (xBucketMin=100, xBucketMax=200)
+      expect(screen.getByText('100')).toBeVisible();
     });
   });
 

--- a/public/app/plugins/panel/heatmap/HeatmapTooltip.tsx
+++ b/public/app/plugins/panel/heatmap/HeatmapTooltip.tsx
@@ -358,7 +358,7 @@ const HeatmapHoverCell = ({
 
   const headerItem: VizTooltipItem = {
     label: '',
-    value: xDisp(xBucketMax!)!,
+    value: xField?.type === FieldType.time ? xDisp(xBucketMax!)! : xDisp(xBucketMin!)!,
   };
 
   let customContent: ReactElement[] = [];


### PR DESCRIPTION
When a heatmap panel uses a numeric (non-time) x-axis, the tooltip header was showing `xBucketMax` — the upper bound of the hovered cell's x range — instead of `xBucketMin`. For ordinal data like port numbers or indices, this causes an off-by-one mismatch between the tooltip value and the axis label.

The fix uses `xBucketMin` for the header when the x field is not a time type. Time-based heatmaps are unaffected and continue to show `xBucketMax` (the end of the time bucket), which is the expected behavior for time series data.

The existing test that covered this code path was updated to reflect the correct expected value.

Fixes #123991.