### PR TITLE
RadialGauge: fix gradient stops out of order for negative thresholds

### DIFF
--- a/packages/grafana-ui/src/components/RadialGauge/colors.test.ts
+++ b/packages/grafana-ui/src/components/RadialGauge/colors.test.ts
@@ -110,6 +110,27 @@ describe('RadialGauge color utils', () => {
         )
       ).toMatchSnapshot();
     });
+
+    it('should produce ascending gradient stops when thresholds span negative values', () => {
+      const field = createField(FieldColorModeId.Thresholds);
+      const fieldDisplay = buildFieldDisplay(field, {
+        field: {
+          min: -100,
+          max: 100,
+          thresholds: {
+            mode: ThresholdsMode.Absolute,
+            steps: [
+              { value: -Infinity, color: 'green' },
+              { value: -50, color: 'yellow' },
+              { value: 0, color: 'red' },
+            ],
+          },
+        },
+      });
+      const stops = buildGradientColors(createTheme(), fieldDisplay);
+      const percents = stops.map((s) => s.percent);
+      expect(percents).toEqual([...percents].sort((a, b) => a - b));
+    });
   });
 
   describe('colorAtGradientPercent', () => {

--- a/packages/grafana-ui/src/components/RadialGauge/utils.ts
+++ b/packages/grafana-ui/src/components/RadialGauge/utils.ts
@@ -332,7 +332,7 @@ export function getFormattedThresholds(
     }
     const prev = steps[i - 1];
     formatted.push({
-      value: isFinite(step.value) ? step.value : 0,
+      value: isFinite(step.value) ? step.value : min,
       color: theme.visualization.getColorByName((offsetColor ? prev : step).color),
     });
     if (step === last) {


### PR DESCRIPTION
Traced the broken gradient to `getFormattedThresholds` in `utils.ts`. When the base threshold (value: -Infinity) gets formatted, it was hardcoded to `0` instead of the field's actual minimum. For a field with a negative range (like min=-100, max=100), that puts the first gradient stop at the 50% mark instead of 0%, so all the negative-range colors stack up incorrectly and the gradient looks broken.

One-line fix: use `min` instead of `0` for non-finite threshold values. Added a test covering a field where min is negative to confirm stops come out in ascending order.

Fixes #123592