### PR TITLE
Flamegraph: move 'other' out of TOP table and explain it

### DIFF
--- a/packages/grafana-flamegraph/src/TopTable/FlameGraphTopTableContainer.test.tsx
+++ b/packages/grafana-flamegraph/src/TopTable/FlameGraphTopTableContainer.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import userEvents from '@testing-library/user-event';
 
-import { createDataFrame } from '@grafana/data';
+import { createDataFrame, FieldType } from '@grafana/data';
 import { mockBoundingClientRect } from '@grafana/test-utils';
 
 import { FlameGraphDataContainer } from '../FlameGraph/dataTransform';
@@ -10,6 +10,20 @@ import { textToDataContainer } from '../FlameGraph/testHelpers';
 import { ColorScheme } from '../types';
 
 import FlameGraphTopTableContainer, { buildFilteredTable } from './FlameGraphTopTableContainer';
+
+function createTestDataWithOther() {
+  return new FlameGraphDataContainer(
+    createDataFrame({
+      fields: [
+        { name: 'level', type: FieldType.number, values: [0, 1, 2, 1, 2] },
+        { name: 'value', type: FieldType.number, values: [100, 50, 30, 50, 20] },
+        { name: 'self', type: FieldType.number, values: [0, 20, 30, 30, 20] },
+        { name: 'label', type: FieldType.string, values: ['root', 'func1', 'func2', 'other', 'func3'] },
+      ],
+    }),
+    { collapsing: false }
+  );
+}
 
 describe('FlameGraphTopTableContainer', () => {
   const setup = () => {
@@ -92,15 +106,16 @@ describe('buildFilteredTable', () => {
 [3][4]
     `);
 
-    const result = buildFilteredTable(container!);
+    const { table, otherData } = buildFilteredTable(container!);
 
-    expect(result).toEqual({
+    expect(table).toEqual({
       '0': { self: 1, total: 7, totalRight: 0 },
       '1': { self: 0, total: 3, totalRight: 0 },
       '2': { self: 0, total: 3, totalRight: 0 },
       '3': { self: 3, total: 3, totalRight: 0 },
       '4': { self: 3, total: 3, totalRight: 0 },
     });
+    expect(otherData).toBeUndefined();
   });
 
   it('should sum values for duplicate labels', () => {
@@ -109,12 +124,13 @@ describe('buildFilteredTable', () => {
 [1][1]
     `);
 
-    const result = buildFilteredTable(container!);
+    const { table, otherData } = buildFilteredTable(container!);
 
-    expect(result).toEqual({
+    expect(table).toEqual({
       '0': { self: 0, total: 6, totalRight: 0 },
       '1': { self: 6, total: 6, totalRight: 0 },
     });
+    expect(otherData).toBeUndefined();
   });
 
   it('should filter by matchedLabels when provided', () => {
@@ -125,12 +141,13 @@ describe('buildFilteredTable', () => {
     `);
 
     const matchedLabels = new Set(['1', '3']);
-    const result = buildFilteredTable(container!, matchedLabels);
+    const { table, otherData } = buildFilteredTable(container!, matchedLabels);
 
-    expect(result).toEqual({
+    expect(table).toEqual({
       '1': { self: 0, total: 3, totalRight: 0 },
       '3': { self: 3, total: 3, totalRight: 0 },
     });
+    expect(otherData).toBeUndefined();
   });
 
   it('should handle empty matchedLabels set', () => {
@@ -141,9 +158,9 @@ describe('buildFilteredTable', () => {
     `);
 
     const matchedLabels = new Set<string>();
-    const result = buildFilteredTable(container!, matchedLabels);
+    const { table } = buildFilteredTable(container!, matchedLabels);
 
-    expect(result).toEqual({});
+    expect(table).toEqual({});
   });
 
   it('should handle data with no matches', () => {
@@ -154,9 +171,9 @@ describe('buildFilteredTable', () => {
     `);
 
     const matchedLabels = new Set(['9']);
-    const result = buildFilteredTable(container!, matchedLabels);
+    const { table } = buildFilteredTable(container!, matchedLabels);
 
-    expect(result).toEqual({});
+    expect(table).toEqual({});
   });
 
   it('should work without matchedLabels filter', () => {
@@ -165,12 +182,13 @@ describe('buildFilteredTable', () => {
 [1]
     `);
 
-    const result = buildFilteredTable(container!);
+    const { table, otherData } = buildFilteredTable(container!);
 
-    expect(result).toEqual({
+    expect(table).toEqual({
       '0': { self: 0, total: 3, totalRight: 0 },
       '1': { self: 3, total: 3, totalRight: 0 },
     });
+    expect(otherData).toBeUndefined();
   });
   it('should not inflate totals for recursive calls', () => {
     const container = textToDataContainer(`
@@ -180,14 +198,52 @@ describe('buildFilteredTable', () => {
 [0]
     `);
 
-    const result = buildFilteredTable(container!);
+    const { table, otherData } = buildFilteredTable(container!);
 
-    expect(result).toEqual({
+    expect(table).toEqual({
       '0': { self: 4, total: 7, totalRight: 0 },
       '1': { self: 0, total: 3, totalRight: 0 },
       '2': { self: 0, total: 3, totalRight: 0 },
       '3': { self: 0, total: 3, totalRight: 0 },
       '4': { self: 3, total: 3, totalRight: 0 },
     });
+    expect(otherData).toBeUndefined();
+  });
+
+  it('should extract "other" label from table and return it separately', () => {
+    const container = createTestDataWithOther();
+
+    const { table, otherData } = buildFilteredTable(container);
+
+    expect(table['root']).toBeDefined();
+    expect(table['func1']).toBeDefined();
+    expect(table['func2']).toBeDefined();
+    expect(table['func3']).toBeDefined();
+    expect(table['other']).toBeUndefined();
+    expect(otherData).toBeDefined();
+    expect(otherData?.self).toBe(30);
+    expect(otherData?.total).toBe(50);
+  });
+});
+
+describe('FlameGraphTopTableContainer with other', () => {
+  it('should render other section when data contains other label', async () => {
+    mockBoundingClientRect({ width: 500, height: 500 });
+    const container = createTestDataWithOther();
+
+    render(
+      <FlameGraphTopTableContainer
+        data={container}
+        onSymbolClick={jest.fn()}
+        onSearch={jest.fn()}
+        onSandwich={jest.fn()}
+        colorScheme={ColorScheme.ValueBased}
+      />
+    );
+
+    const otherSection = screen.getByTestId('other-section');
+    expect(otherSection).toBeInTheDocument();
+    expect(otherSection.textContent).toContain('truncated');
+    expect(otherSection.textContent).toContain('other');
   });
 });

--- a/packages/grafana-flamegraph/src/TopTable/FlameGraphTopTableContainer.tsx
+++ b/packages/grafana-flamegraph/src/TopTable/FlameGraphTopTableContainer.tsx
@@ -11,6 +11,7 @@ import {
   type GrafanaTheme2,
   MappingType,
   escapeStringForRegex,
+  formattedValueToString,
 } from '@grafana/data';
 import {
   IconButton,
@@ -25,7 +26,7 @@ import {
 
 import { diffColorBlindColors, diffDefaultColors } from '../FlameGraph/colors';
 import { type FlameGraphDataContainer } from '../FlameGraph/dataTransform';
-import { TOP_TABLE_COLUMN_WIDTH } from '../constants';
+import { OTHER_LABEL, TOP_TABLE_COLUMN_WIDTH } from '../constants';
 import { type ColorScheme, ColorSchemeDiff, type TableData } from '../types';
 
 type Props = {
@@ -54,12 +55,42 @@ const FlameGraphTopTableContainer = memo(
     onTableSort,
     colorScheme,
   }: Props) => {
-    const table = useMemo(() => buildFilteredTable(data, matchedLabels), [data, matchedLabels]);
+    const { table, otherData } = useMemo(() => buildFilteredTable(data, matchedLabels), [data, matchedLabels]);
 
     const styles = useStyles2(getStyles);
     const theme = useTheme2();
 
     const [sort, setSort] = useState<TableSortByFieldState[]>([{ displayName: 'Self', desc: true }]);
+
+    const minTotalValue = useMemo(() => {
+      if (!otherData) {
+        return undefined;
+      }
+      let min = Infinity;
+      for (const key in table) {
+        if (table[key].total < min) {
+          min = table[key].total;
+        }
+      }
+      return min === Infinity ? undefined : min;
+    }, [table, otherData]);
+
+    const otherExplanation = useMemo(() => {
+      if (!otherData || otherData.self === 0) {
+        return null;
+      }
+      const formattedTotal = formattedValueToString(data.valueDisplayProcessor(otherData.self));
+      const formattedMinThreshold = minTotalValue !== undefined
+        ? formattedValueToString(data.valueDisplayProcessor(minTotalValue))
+        : undefined;
+
+      return {
+        totalValue: formattedTotal,
+        minThreshold: formattedMinThreshold,
+      };
+    }, [otherData, minTotalValue, data]);
+
+    const otherSectionHeight = otherExplanation ? 70 : 0;
 
     return (
       <div className={styles.topTableContainer} data-testid="topTable">
@@ -68,6 +99,8 @@ const FlameGraphTopTableContainer = memo(
             if (width < 3 || height < 3) {
               return null;
             }
+
+            const tableHeight = height - otherSectionHeight;
 
             const frame = buildTableDataFrame(
               data,
@@ -82,18 +115,29 @@ const FlameGraphTopTableContainer = memo(
               sandwichItem
             );
             return (
-              <Table
-                initialSortBy={sort}
-                onSortByChange={(s) => {
-                  if (s && s.length) {
-                    onTableSort?.(s[0].displayName + '_' + (s[0].desc ? 'desc' : 'asc'));
-                  }
-                  setSort(s);
-                }}
-                data={frame}
-                width={width}
-                height={height}
-              />
+              <>
+                <Table
+                  initialSortBy={sort}
+                  onSortByChange={(s) => {
+                    if (s && s.length) {
+                      onTableSort?.(s[0].displayName + '_' + (s[0].desc ? 'desc' : 'asc'));
+                    }
+                    setSort(s);
+                  }}
+                  data={frame}
+                  width={width}
+                  height={tableHeight > 0 ? tableHeight : height}
+                />
+                {otherExplanation && (
+                  <OtherSection
+                    explanation={otherExplanation}
+                    onSearch={onSearch}
+                    onSandwich={onSandwich}
+                    search={search}
+                    sandwichItem={sandwichItem}
+                  />
+                )}
+              </>
             );
           }}
         </AutoSizer>
@@ -104,7 +148,12 @@ const FlameGraphTopTableContainer = memo(
 
 FlameGraphTopTableContainer.displayName = 'FlameGraphTopTableContainer';
 
-function buildFilteredTable(data: FlameGraphDataContainer, matchedLabels?: Set<string>) {
+type FilteredTableResult = {
+  table: { [key: string]: TableData };
+  otherData: TableData | undefined;
+};
+
+function buildFilteredTable(data: FlameGraphDataContainer, matchedLabels?: Set<string>): FilteredTableResult {
   // Group the data by label, we show only one row per label and sum the values
   // TODO: should be by filename + funcName + linenumber?
   let filteredTable: { [key: string]: TableData } = Object.create(null);
@@ -145,7 +194,13 @@ function buildFilteredTable(data: FlameGraphDataContainer, matchedLabels?: Set<s
     callStack.push(label);
   }
 
-  return filteredTable;
+  // Extract "other" from the table if present
+  const otherData = filteredTable[OTHER_LABEL];
+  if (otherData) {
+    delete filteredTable[OTHER_LABEL];
+  }
+
+  return { table: filteredTable, otherData };
 }
 
 function buildTableDataFrame(
@@ -362,6 +417,87 @@ function ActionCell(props: ActionCellProps) {
     </div>
   );
 }
+
+type OtherSectionProps = {
+  explanation: {
+    totalValue: string;
+    minThreshold: string | undefined;
+  };
+  search?: string;
+  sandwichItem?: string;
+  onSearch: (symbol: string) => void;
+  onSandwich: (symbol?: string) => void;
+};
+
+function OtherSection({ explanation, onSearch, onSandwich, search, sandwichItem }: OtherSectionProps) {
+  const styles = useStyles2(getStylesOtherSection);
+  const isSearched = search === `^${escapeStringForRegex(OTHER_LABEL)}$`;
+  const isSandwiched = sandwichItem === OTHER_LABEL;
+
+  return (
+    <div className={styles.container} data-testid="other-section">
+      <div className={styles.content}>
+        <div className={styles.actions}>
+          <IconButton
+            name={'search'}
+            variant={isSearched ? 'primary' : 'secondary'}
+            tooltip={isSearched ? 'Clear from search' : 'Highlight in flamegraph'}
+            aria-label={isSearched ? 'Clear from search' : 'Highlight in flamegraph'}
+            onClick={() => {
+              onSearch(isSearched ? '' : OTHER_LABEL);
+            }}
+          />
+          <IconButton
+            name={'gf-show-context'}
+            tooltip={isSandwiched ? 'Remove from sandwich view' : 'Show in sandwich view'}
+            variant={isSandwiched ? 'primary' : 'secondary'}
+            aria-label={isSandwiched ? 'Remove from sandwich view' : 'Show in sandwich view'}
+            onClick={() => {
+              onSandwich(isSandwiched ? undefined : OTHER_LABEL);
+            }}
+          />
+        </div>
+        <div className={styles.text}>
+          A total of <strong>{explanation.totalValue}</strong> has been truncated and is represented by{' '}
+          <strong>&quot;other&quot;</strong> in the flamegraph.
+          {explanation.minThreshold && (
+            <> Each truncated stacktrace had a total resource consumption below {explanation.minThreshold}.</>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+const getStylesOtherSection = (theme: GrafanaTheme2) => {
+  return {
+    container: css({
+      label: 'otherSectionContainer',
+      marginTop: theme.spacing(1),
+      padding: theme.spacing(1),
+      backgroundColor: theme.colors.background.primary,
+      borderRadius: theme.shape.radius.default,
+      border: `1px solid ${theme.colors.border.weak}`,
+    }),
+    content: css({
+      label: 'otherSectionContent',
+      display: 'flex',
+      alignItems: 'flex-start',
+      gap: theme.spacing(1),
+    }),
+    actions: css({
+      label: 'otherSectionActions',
+      display: 'flex',
+      flexShrink: 0,
+    }),
+    text: css({
+      label: 'otherSectionText',
+      fontSize: theme.typography.bodySmall.fontSize,
+      color: theme.colors.text.secondary,
+      lineHeight: 1.5,
+    }),
+  };
+};
 
 const getStyles = (theme: GrafanaTheme2) => {
   return {

--- a/packages/grafana-flamegraph/src/constants.ts
+++ b/packages/grafana-flamegraph/src/constants.ts
@@ -13,3 +13,4 @@ export const MIN_WIDTH_FOR_SPLIT_VIEW = 800;
 export const MIN_WIDTH_TO_SHOW_SPLIT_PANE_SELECTORS = 1100;
 export const TOP_TABLE_COLUMN_WIDTH = 120;
 export const FLAMEGRAPH_CONTAINER_HEIGHT = 800;
+export const OTHER_LABEL = 'other';


### PR DESCRIPTION
When profiling larger deployments or querying over wider time windows, the 'other' node often becomes the biggest self contributor in the TOP table. This is mathematically correct but not helpful - it aggregates truncated stacktraces that fell below the maxNodes threshold, so it doesn't point to actionable resource consumption.

I moved 'other' out of the table and into a separate section below it. The explanation tells users how much was truncated and gives a rough idea of the threshold per stacktrace. The highlight and sandwich view buttons are still there so you can locate 'other' in the flamegraph if needed.

The wording follows the issue request - showing the total truncated value and explaining that each truncated stacktrace had consumption below the minimum value shown in the table.

**Testing:**
- Verified the TOP table no longer includes 'other' when present in the data
- The explanation section appears with the truncation details
- Both action buttons (search and sandwich) work as expected
- When there's no 'other' in the data, the section doesn't appear