### PR TITLE
Variables: avoid matching formats as dependencies

### DIFF
--- a/public/app/features/variables/utils.test.ts
+++ b/public/app/features/variables/utils.test.ts
@@ -191,6 +191,17 @@ describe('containsVariable', () => {
   `('when called with value:$value then result should be:$expected', ({ value, expected }) => {
     expect(containsVariable(value, 'var')).toEqual(expected);
   });
+
+  it.each`
+    value                             | variableName
+    ${'[[other:csv]]'}                | ${'csv'}
+    ${'${other:json}'}                | ${'json'}
+    ${'${other.host}'}                | ${'host'}
+    ${'${other.host:raw}'}            | ${'host'}
+    ${{ query: '${other.name:text}' }} | ${'name'}
+  `('does not match $variableName when it is a format or field path in $value', ({ value, variableName }) => {
+    expect(containsVariable(value, variableName)).toBe(false);
+  });
 });
 
 describe('getVariablesFromUrl', () => {

--- a/public/app/features/variables/utils.ts
+++ b/public/app/features/variables/utils.ts
@@ -48,7 +48,10 @@ export function containsVariable(...args: any[]) {
     matches !== null
       ? matches.find((match) => {
           const varMatch = variableRegexExec(match);
-          return varMatch !== null && varMatch.indexOf(variableName) > -1;
+          return (
+            varMatch !== null &&
+            (varMatch[1] === variableName || varMatch[2] === variableName || varMatch[4] === variableName)
+          );
         })
       : false;
 


### PR DESCRIPTION
Fixes #125036

This updates `containsVariable()` so dependency checks only compare the capture groups that contain variable names. Format specifiers and field paths such as `json`, `csv`, or `host` are no longer treated as referenced variables.

Validation:
- `corepack yarn jest --no-watch public/app/features/variables/utils.test.ts`
- `corepack yarn eslint public/app/features/variables/utils.ts public/app/features/variables/utils.test.ts`
- `git diff --check`