### PR TITLE
Dashboards: use render endpoint for image export requests

### DIFF
--- a/public/app/features/dashboard-scene/sharing/ExportButton/utils.test.ts
+++ b/public/app/features/dashboard-scene/sharing/ExportButton/utils.test.ts
@@ -23,15 +23,17 @@ jest.mock('@grafana/runtime', () => ({
 jest.mock('app/features/dashboard-scene/utils/getDashboardUrl', () => ({
   getDashboardUrl: jest
     .fn()
-    .mockImplementation((params: { updateQuery?: Record<string, string | number | boolean> }) => {
-      const url = new URL('http://test-url');
-      if (params.updateQuery) {
-        Object.entries(params.updateQuery).forEach(([key, value]) => {
-          url.searchParams.append(key, String(value));
-        });
+    .mockImplementation(
+      (params: { absolute?: boolean; uid?: string; updateQuery?: Record<string, string | number | boolean> }) => {
+        const url = new URL(`/render/d/${params.uid}`, 'http://test-url');
+        if (params.updateQuery) {
+          Object.entries(params.updateQuery).forEach(([key, value]) => {
+            url.searchParams.append(key, String(value));
+          });
+        }
+        return params.absolute ? url.toString() : `${url.pathname}${url.search}`;
       }
-      return url.toString();
-    }),
+    ),
 }));
 
 describe('Dashboard Export Image Utils', () => {
@@ -115,7 +117,9 @@ describe('Dashboard Export Image Utils', () => {
       expect(result.blob).toBe(mockBlob);
       expect(fetchMock).toHaveBeenCalledWith(
         expect.objectContaining({
-          url: expect.stringMatching(/height=-1.*scale=2.*kiosk=true.*hideNav=true.*fullPageImage=true/),
+          url: expect.stringMatching(
+            /^\/render\/d\/test-uid\?height=-1.*scale=2.*kiosk=true.*hideNav=true.*fullPageImage=true/
+          ),
           responseType: 'blob',
         })
       );
@@ -123,7 +127,6 @@ describe('Dashboard Export Image Utils', () => {
         uid: 'test-uid',
         currentQueryParams: '',
         render: true,
-        absolute: true,
         updateQuery: {
           height: -1,
           width: 1280,
@@ -164,7 +167,6 @@ describe('Dashboard Export Image Utils', () => {
         uid: 'test-uid',
         currentQueryParams: '',
         render: true,
-        absolute: true,
         updateQuery: {
           height: -1,
           width: 1500, // Should use config value

--- a/public/app/features/dashboard-scene/sharing/ExportButton/utils.ts
+++ b/public/app/features/dashboard-scene/sharing/ExportButton/utils.ts
@@ -44,7 +44,6 @@ export async function generateDashboardImage({
       uid: dashboard.state.uid,
       currentQueryParams: window.location.search,
       render: true,
-      absolute: true,
       updateQuery: {
         height: -1, // image renderer will scroll through the dashboard and set the appropriate height
         width: window.innerWidth || config.rendererDefaultImageWidth || 1000,

--- a/public/app/features/dashboard-scene/sharing/ShareLinkTab.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareLinkTab.tsx
@@ -34,8 +34,8 @@ export interface ShareLinkConfiguration {
 interface ShareOptions extends ShareLinkConfiguration {
   shareUrl: string;
   imageUrl: string;
+  absoluteImageUrl: string;
   isBuildUrlLoading: boolean;
-  useAbsoluteImageUrl: boolean;
 }
 
 export class ShareLinkTab extends SceneObjectBase<ShareLinkTabState> implements ShareView {
@@ -51,8 +51,8 @@ export class ShareLinkTab extends SceneObjectBase<ShareLinkTabState> implements 
       selectedTheme: state.selectedTheme ?? 'current',
       shareUrl: '',
       imageUrl: '',
+      absoluteImageUrl: '',
       isBuildUrlLoading: false,
-      useAbsoluteImageUrl: state.useAbsoluteImageUrl ?? true,
     });
 
     this.addActivationHandler(() => {
@@ -66,13 +66,7 @@ export class ShareLinkTab extends SceneObjectBase<ShareLinkTabState> implements 
 
   buildUrl = async (queryOptions?: UrlQueryMap) => {
     this.setState({ isBuildUrlLoading: true });
-    const {
-      panelRef,
-      useLockedTime: useAbsoluteTimeRange,
-      useShortUrl,
-      selectedTheme,
-      useAbsoluteImageUrl,
-    } = this.state;
+    const { panelRef, useLockedTime: useAbsoluteTimeRange, useShortUrl, selectedTheme } = this.state;
     const dashboard = getDashboardSceneFor(this);
     const panel = panelRef?.resolve();
 
@@ -105,13 +99,14 @@ export class ShareLinkTab extends SceneObjectBase<ShareLinkTabState> implements 
       uid: dashboard.state.uid,
       currentQueryParams: window.location.search,
       updateQuery: { ...urlParamsUpdate, ...queryOptions, panelId: panel?.getPathId() },
-      absolute: useAbsoluteImageUrl,
+      absolute: false,
       soloRoute: true,
       render: true,
       timeZone: getRenderTimeZone(timeRange.getTimeZone()),
     });
+    const absoluteImageUrl = config.appUrl + imageUrl.replace(/^\//, '');
 
-    this.setState({ shareUrl, imageUrl, isBuildUrlLoading: false });
+    this.setState({ shareUrl, imageUrl, absoluteImageUrl, isBuildUrlLoading: false });
   };
 
   public getTabLabel() {
@@ -159,7 +154,7 @@ function ShareLinkTabRenderer({ model }: SceneComponentProps<ShareLinkTab>) {
   const timeRange = sceneGraph.getTimeRange(panel ?? dashboard);
   const isRelativeTime = timeRange.state.to === 'now' ? true : false;
 
-  const { useLockedTime, useShortUrl, selectedTheme, shareUrl, imageUrl } = state;
+  const { useLockedTime, useShortUrl, selectedTheme, shareUrl, absoluteImageUrl } = state;
 
   const selectors = e2eSelectors.pages.SharePanelModal;
   const isDashboardSaved = Boolean(dashboard.state.uid);
@@ -209,7 +204,7 @@ function ShareLinkTabRenderer({ model }: SceneComponentProps<ShareLinkTab>) {
         <>
           {isDashboardSaved && (
             <div className="gf-form">
-              <a href={imageUrl} target="_blank" rel="noreferrer" aria-label={selectors.linkToRenderedImage}>
+              <a href={absoluteImageUrl} target="_blank" rel="noreferrer" aria-label={selectors.linkToRenderedImage}>
                 <Icon name="camera" />
                 &nbsp;
                 <Trans i18nKey="share-modal.link.rendered-image">Direct link rendered image</Trans>

--- a/public/app/features/dashboard-scene/sharing/ShareLinkTab.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareLinkTab.tsx
@@ -35,6 +35,7 @@ interface ShareOptions extends ShareLinkConfiguration {
   shareUrl: string;
   imageUrl: string;
   isBuildUrlLoading: boolean;
+  useAbsoluteImageUrl: boolean;
 }
 
 export class ShareLinkTab extends SceneObjectBase<ShareLinkTabState> implements ShareView {
@@ -51,6 +52,7 @@ export class ShareLinkTab extends SceneObjectBase<ShareLinkTabState> implements 
       shareUrl: '',
       imageUrl: '',
       isBuildUrlLoading: false,
+      useAbsoluteImageUrl: state.useAbsoluteImageUrl ?? true,
     });
 
     this.addActivationHandler(() => {
@@ -64,7 +66,8 @@ export class ShareLinkTab extends SceneObjectBase<ShareLinkTabState> implements 
 
   buildUrl = async (queryOptions?: UrlQueryMap) => {
     this.setState({ isBuildUrlLoading: true });
-    const { panelRef, useLockedTime: useAbsoluteTimeRange, useShortUrl, selectedTheme } = this.state;
+    const { panelRef, useLockedTime: useAbsoluteTimeRange, useShortUrl, selectedTheme, useAbsoluteImageUrl } =
+      this.state;
     const dashboard = getDashboardSceneFor(this);
     const panel = panelRef?.resolve();
 
@@ -97,7 +100,7 @@ export class ShareLinkTab extends SceneObjectBase<ShareLinkTabState> implements 
       uid: dashboard.state.uid,
       currentQueryParams: window.location.search,
       updateQuery: { ...urlParamsUpdate, ...queryOptions, panelId: panel?.getPathId() },
-      absolute: true,
+      absolute: useAbsoluteImageUrl,
       soloRoute: true,
       render: true,
       timeZone: getRenderTimeZone(timeRange.getTimeZone()),

--- a/public/app/features/dashboard-scene/sharing/ShareLinkTab.tsx
+++ b/public/app/features/dashboard-scene/sharing/ShareLinkTab.tsx
@@ -66,8 +66,13 @@ export class ShareLinkTab extends SceneObjectBase<ShareLinkTabState> implements 
 
   buildUrl = async (queryOptions?: UrlQueryMap) => {
     this.setState({ isBuildUrlLoading: true });
-    const { panelRef, useLockedTime: useAbsoluteTimeRange, useShortUrl, selectedTheme, useAbsoluteImageUrl } =
-      this.state;
+    const {
+      panelRef,
+      useLockedTime: useAbsoluteTimeRange,
+      useShortUrl,
+      selectedTheme,
+      useAbsoluteImageUrl,
+    } = this.state;
     const dashboard = getDashboardSceneFor(this);
     const panel = panelRef?.resolve();
 

--- a/public/app/features/dashboard-scene/sharing/panel-share/SharePanelInternally.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/panel-share/SharePanelInternally.test.tsx
@@ -77,7 +77,7 @@ describe('SharePanelInternally', () => {
 
     await waitFor(() => expect(tab.state.imageUrl).toMatch(/^\/render\/d-solo\/dash-1\?/));
     expect(tab.state.imageUrl).not.toMatch(/^https?:\/\//);
-    expect(tab.state.imageUrl).toContain('panelId=A$panel-12');
+    expect(tab.state.imageUrl).toContain('panelId=panel-12');
   });
 });
 

--- a/public/app/features/dashboard-scene/sharing/panel-share/SharePanelInternally.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/panel-share/SharePanelInternally.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 
 import { getPanelPlugin } from '@grafana/data/test';
 import { config, setPluginImportUtils } from '@grafana/runtime';
@@ -69,6 +69,15 @@ describe('SharePanelInternally', () => {
     await userEvent.click(copyImageLinkButton);
 
     expect(document.execCommand).toHaveBeenCalledWith('copy');
+  });
+
+  it('should build relative render image URL for panel image actions', async () => {
+    config.rendererAvailable = true;
+    const tab = buildAndRenderScenario();
+
+    await waitFor(() => expect(tab.state.imageUrl).toMatch(/^\/render\/d-solo\/dash-1\?/));
+    expect(tab.state.imageUrl).not.toMatch(/^https?:\/\//);
+    expect(tab.state.imageUrl).toContain('panelId=A$panel-12');
   });
 });
 

--- a/public/app/features/dashboard-scene/sharing/panel-share/SharePanelInternally.test.tsx
+++ b/public/app/features/dashboard-scene/sharing/panel-share/SharePanelInternally.test.tsx
@@ -71,13 +71,16 @@ describe('SharePanelInternally', () => {
     expect(document.execCommand).toHaveBeenCalledWith('copy');
   });
 
-  it('should build relative render image URL for panel image actions', async () => {
+  it('should build relative render image URL for fetch and absolute image URL for sharing', async () => {
+    config.appUrl = 'http://dashboards.grafana.com/grafana/';
     config.rendererAvailable = true;
     const tab = buildAndRenderScenario();
 
     await waitFor(() => expect(tab.state.imageUrl).toMatch(/^\/render\/d-solo\/dash-1\?/));
     expect(tab.state.imageUrl).not.toMatch(/^https?:\/\//);
     expect(tab.state.imageUrl).toContain('panelId=panel-12');
+    expect(tab.state.absoluteImageUrl).toBe(config.appUrl + tab.state.imageUrl.replace(/^\//, ''));
+    expect(tab.state.absoluteImageUrl).toMatch(/^http:\/\/dashboards\.grafana\.com\/grafana\/render\/d-solo\/dash-1\?/);
   });
 });
 

--- a/public/app/features/dashboard-scene/sharing/panel-share/SharePanelInternally.tsx
+++ b/public/app/features/dashboard-scene/sharing/panel-share/SharePanelInternally.tsx
@@ -5,17 +5,12 @@ import { Alert, ClipboardButton, Divider, Stack, Text, TextLink } from '@grafana
 
 import { getDashboardSceneFor } from '../../utils/utils';
 import ShareInternallyConfiguration from '../ShareInternallyConfiguration';
-import { ShareLinkTab, type ShareLinkTabState } from '../ShareLinkTab';
+import { ShareLinkTab } from '../ShareLinkTab';
 
 import { SharePanelPreview } from './SharePanelPreview';
 
 export class SharePanelInternally extends ShareLinkTab {
   static Component = SharePanelInternallyRenderer;
-
-  constructor(state: Partial<ShareLinkTabState>) {
-    // Panel image actions should call Grafana through the same-origin render endpoint.
-    super({ ...state, useAbsoluteImageUrl: false });
-  }
 
   public getTabLabel() {
     return t('share-panel.drawer.share-link-title', 'Link settings');
@@ -23,7 +18,8 @@ export class SharePanelInternally extends ShareLinkTab {
 }
 
 function SharePanelInternallyRenderer({ model }: SceneComponentProps<SharePanelInternally>) {
-  const { useLockedTime, useShortUrl, selectedTheme, isBuildUrlLoading, imageUrl, panelRef } = model.useState();
+  const { useLockedTime, useShortUrl, selectedTheme, isBuildUrlLoading, imageUrl, absoluteImageUrl, panelRef } =
+    model.useState();
 
   const panelTitle = panelRef?.resolve().state.title;
   const dashboard = getDashboardSceneFor(model);
@@ -86,6 +82,7 @@ function SharePanelInternallyRenderer({ model }: SceneComponentProps<SharePanelI
           title={panelTitle || ''}
           buildUrl={model.buildUrl}
           imageUrl={imageUrl}
+          absoluteImageUrl={absoluteImageUrl}
           disabled={!isDashboardSaved}
           theme={selectedTheme}
         />

--- a/public/app/features/dashboard-scene/sharing/panel-share/SharePanelInternally.tsx
+++ b/public/app/features/dashboard-scene/sharing/panel-share/SharePanelInternally.tsx
@@ -13,7 +13,8 @@ export class SharePanelInternally extends ShareLinkTab {
   static Component = SharePanelInternallyRenderer;
 
   constructor(state: Partial<ShareLinkTabState>) {
-    super(state);
+    // Panel image actions should call Grafana through the same-origin render endpoint.
+    super({ ...state, useAbsoluteImageUrl: false });
   }
 
   public getTabLabel() {

--- a/public/app/features/dashboard-scene/sharing/panel-share/SharePanelPreview.tsx
+++ b/public/app/features/dashboard-scene/sharing/panel-share/SharePanelPreview.tsx
@@ -23,11 +23,12 @@ type Props = {
   title: string;
   buildUrl: (urlParams: UrlQueryMap) => void;
   imageUrl: string;
+  absoluteImageUrl: string;
   disabled: boolean;
   theme: string;
 };
 
-export function SharePanelPreview({ title, imageUrl, buildUrl, disabled, theme }: Props) {
+export function SharePanelPreview({ title, imageUrl, absoluteImageUrl, buildUrl, disabled, theme }: Props) {
   const styles = useStyles2(getStyles);
 
   const {
@@ -201,7 +202,7 @@ export function SharePanelPreview({ title, imageUrl, buildUrl, disabled, theme }
                 variant="secondary"
                 disabled={disabled || !isValid}
                 aria-describedby={disabled || !isValid ? 'copy-image-link-disabled-help' : undefined}
-                getText={() => imageUrl}
+                getText={() => absoluteImageUrl}
                 onClipboardCopy={() => DashboardInteractions.copyImageUrlClicked({ shareResource: 'panel' })}
               >
                 <Trans i18nKey="link.share-panel.copy-image-link">Copy image link</Trans>


### PR DESCRIPTION
**What is this feature?**

Use the dashboard render route as a relative URL when exporting a dashboard image from the dashboard scenes export button.

**Why do we need this feature?**

The export flow was building an absolute browser URL, which meant deployments relying on the renderer callback URL could still send the export request through the public root URL path instead of the Grafana backend render endpoint.

**Who is this feature for?**

Grafana users exporting dashboard images in environments where the image renderer is configured with a separate callback URL.

**Which issue(s) does this PR fix?**:

Fixes #125034

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a notable improvement, it is added to the release notes when needed.

Validation:
- `yarn jest public/app/features/dashboard-scene/sharing/ExportButton/utils.test.ts --runInBand --ci`
- `yarn eslint public/app/features/dashboard-scene/sharing/ExportButton/utils.ts public/app/features/dashboard-scene/sharing/ExportButton/utils.test.ts --no-error-on-unmatched-pattern`
- `git diff --check origin/main...HEAD`