### PR TITLE
Logs: show documented trace and unknown levels

### DIFF
--- a/public/app/features/logs/components/panel/LogLine.tsx
+++ b/public/app/features/logs/components/panel/LogLine.tsx
@@ -697,6 +697,12 @@ export const getStyles = (
       '&.level-debug': {
         color: colors.debug,
       },
+      '&.level-trace': {
+        color: colors.trace,
+      },
+      '&.level-unknown': {
+        color: colors.metadata,
+      },
     }),
     loadMoreButton: css({
       background: 'transparent',

--- a/public/app/features/logs/components/panel/processing.test.ts
+++ b/public/app/features/logs/components/panel/processing.test.ts
@@ -399,15 +399,22 @@ Value"
     expect(logs[1].displayLevel).toBe('unknown');
   });
 
-  test('Keeps inferred unknown levels hidden when no level label is present', () => {
-    const logs = preProcessLogs([createLogRow({ uid: 'fallback', logLevel: LogLevel.unknown })], {
-      escape: false,
-      order: LogsSortOrder.Ascending,
-      timeZone: 'browser',
-      wrapLogMessage: true,
-    });
+  test('Keeps inferred unknown levels hidden when no level label is present or empty', () => {
+    const logs = preProcessLogs(
+      [
+        createLogRow({ uid: 'fallback', logLevel: LogLevel.unknown }),
+        createLogRow({ uid: 'empty', labels: { level: '' }, logLevel: LogLevel.unknown }),
+      ],
+      {
+        escape: false,
+        order: LogsSortOrder.Ascending,
+        timeZone: 'browser',
+        wrapLogMessage: true,
+      }
+    );
 
     expect(logs[0].displayLevel).toBe('');
+    expect(logs[1].displayLevel).toBe('');
   });
 
   test('Sets the log fields links', () => {

--- a/public/app/features/logs/components/panel/processing.test.ts
+++ b/public/app/features/logs/components/panel/processing.test.ts
@@ -381,6 +381,35 @@ Value"
     expect(processedLogs[2].displayLevel).toBe('error');
   });
 
+  test('Keeps documented trace and explicit unknown levels visible', () => {
+    const logs = preProcessLogs(
+      [
+        createLogRow({ uid: 'trace', logLevel: LogLevel.trace }),
+        createLogRow({ uid: 'unknown', labels: { level: 'unknown' }, logLevel: LogLevel.unknown }),
+      ],
+      {
+        escape: false,
+        order: LogsSortOrder.Ascending,
+        timeZone: 'browser',
+        wrapLogMessage: true,
+      }
+    );
+
+    expect(logs[0].displayLevel).toBe('trace');
+    expect(logs[1].displayLevel).toBe('unknown');
+  });
+
+  test('Keeps inferred unknown levels hidden when no level label is present', () => {
+    const logs = preProcessLogs([createLogRow({ uid: 'fallback', logLevel: LogLevel.unknown })], {
+      escape: false,
+      order: LogsSortOrder.Ascending,
+      timeZone: 'browser',
+      wrapLogMessage: true,
+    });
+
+    expect(logs[0].displayLevel).toBe('');
+  });
+
   test('Sets the log fields links', () => {
     expect(processedLogs[0].fields).toEqual([
       {

--- a/public/app/features/logs/components/panel/processing.ts
+++ b/public/app/features/logs/components/panel/processing.ts
@@ -108,7 +108,7 @@ export class LogListModel implements LogRowModel {
     this.uniqueLabels = log.uniqueLabels;
 
     // LogListModel
-    this.displayLevel = logLevelToDisplayLevel(log.logLevel);
+    this.displayLevel = logLevelToDisplayLevel(log);
     this._getFieldLinks = getFieldLinks;
     this._grammar = grammar;
     this._prettifyJSON = Boolean(prettifyJSON);
@@ -343,17 +343,22 @@ const preProcessLog = (log: LogRowModel, options: PreProcessLogOptions): LogList
   return new LogListModel(log, options);
 };
 
-function logLevelToDisplayLevel(level = '') {
-  switch (level) {
+function logLevelToDisplayLevel(log: LogRowModel) {
+  switch (log.logLevel) {
     case LogLevel.critical:
       return 'crit';
     case LogLevel.warning:
       return 'warn';
     case LogLevel.unknown:
-      return '';
+      return hasExplicitUnknownLevel(log.labels) ? LogLevel.unknown : '';
     default:
-      return level;
+      return log.logLevel;
   }
+}
+
+function hasExplicitUnknownLevel(labels: Labels) {
+  const level = labels.level ?? labels.detected_level ?? labels.lvl ?? labels.loglevel;
+  return typeof level === 'string' && level.toLowerCase() === LogLevel.unknown;
 }
 
 function countNewLines(log: string, limit = Infinity) {


### PR DESCRIPTION
**What is this feature?**

Shows the documented `unknown` log level in wrapped log rows and applies explicit text colors for `trace` and `unknown` level badges.

**Why do we need this feature?**

Log rows with `level="unknown"` currently render an empty level column, and `trace` falls back to the default text color because the level badge styles do not define a trace class.

**Who is this feature for?**

Users viewing Loki logs in Explore or the Logs panel with level labels such as `unknown` or `trace`.

**Which issue(s) does this PR fix?**:

Fixes #125037

**Special notes for your reviewer:**

Validation:
- `yarn jest public/app/features/logs/components/panel/processing.test.ts --runInBand --ci`
- `yarn eslint public/app/features/logs/components/panel/processing.ts public/app/features/logs/components/panel/LogLine.tsx public/app/features/logs/components/panel/processing.test.ts --no-error-on-unmatched-pattern`
- `git diff --check`

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a notable improvement, it is added to the What's New doc. Not applicable: this aligns rendering with existing documented log levels.