### PR TITLE
Dashboard: use panel editor context for query editors

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.test.tsx
@@ -5,6 +5,7 @@ import {
   type DataQueryError,
   DataSourceApi,
   type DataSourceJsonData,
+  CoreApp,
   type DataQueryResponse,
   getDefaultTimeRange,
   LoadingState,
@@ -125,6 +126,22 @@ describe('QueryEditorRenderer', () => {
     } finally {
       consoleErrorSpy.mockRestore();
     }
+  });
+
+  it('renders datasource query editors with panel editor app context', () => {
+    const QueryEditor = jest.fn(({ query }: { query: DataQuery }) => (
+      <div data-testid="query-editor-app">{getLegendFormat(query)}</div>
+    ));
+    const datasource = new MockDataSourceApi({ QueryEditor });
+
+    renderRenderer(queryA, {
+      selectedQueryDsData: {
+        datasource,
+        dsSettings: ds1SettingsMock,
+      },
+    });
+
+    expect(QueryEditor.mock.calls[0][0]).toEqual(expect.objectContaining({ app: CoreApp.PanelEditor }));
   });
 
   it('remounts the query editor when switching queries, resetting uncontrolled input state', () => {


### PR DESCRIPTION
**What is this feature?**

Passes `CoreApp.PanelEditor` to datasource query editor components rendered by the PanelEditNext query editor.

**Why do we need this feature?**

PanelEditNext was rendering datasource query editors with `CoreApp.Dashboard`, which can hide panel-editor-only query options. For Prometheus queries with both `range` and `instant` enabled, that excludes the `both` query type option and can crash when the editor reads its label.

**Who is this feature for?**

Dashboard users editing panels with datasource query editors that vary behavior by Grafana app context.

**Which issue(s) does this PR fix?**:

Fixes #125011

**Special notes for your reviewer:**

Validation:
- `yarn jest public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.test.tsx --runInBand --ci`
- `yarn eslint public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.tsx public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.test.tsx --no-error-on-unmatched-pattern`
- `git diff --check`

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. Not applicable: existing PanelEditNext path.
- [x] The docs are updated, and if this is a notable improvement, it is added to the What's New doc. Not applicable: bug fix only.