### PR TITLE
Dashboard: keep boolean series in legend isolation

### DIFF
--- a/public/app/features/dashboard/dashgrid/SeriesVisibilityConfigFactory.test.ts
+++ b/public/app/features/dashboard/dashgrid/SeriesVisibilityConfigFactory.test.ts
@@ -1,0 +1,194 @@
+import { ByNamesMatcherMode, FieldMatcherID, FieldType, type FieldConfigSource, toDataFrame } from '@grafana/data';
+import { SeriesVisibilityChangeMode } from '@grafana/ui';
+
+import { seriesVisibilityConfigFactory } from './SeriesVisibilityConfigFactory';
+
+describe('seriesVisibilityConfigFactory', () => {
+  it('keeps boolean series hidden when appending numeric series to an isolated selection', () => {
+    const data = [
+      toDataFrame({
+        fields: [
+          { name: 'time', type: FieldType.time, values: [1, 2] },
+          { name: 'Number1', type: FieldType.number, values: [1, 2] },
+          { name: 'Number2', type: FieldType.number, values: [3, 4] },
+          { name: 'Boolean1', type: FieldType.boolean, values: [true, false] },
+          { name: 'Boolean2', type: FieldType.boolean, values: [false, true] },
+        ],
+      }),
+    ];
+
+    const isolated = seriesVisibilityConfigFactory(
+      'Number1',
+      SeriesVisibilityChangeMode.ToggleSelection,
+      emptyFieldConfig(),
+      data
+    );
+
+    const next = seriesVisibilityConfigFactory('Number2', SeriesVisibilityChangeMode.AppendToSelection, isolated, data);
+
+    expect(next.overrides).toHaveLength(1);
+    expect(next.overrides[0].matcher).toEqual({
+      id: FieldMatcherID.byNames,
+      options: {
+        mode: ByNamesMatcherMode.exclude,
+        names: ['Number1', 'Number2'],
+        prefix: 'All except:',
+        readOnly: true,
+      },
+    });
+  });
+
+  it('keeps enum series hidden when appending numeric series to an isolated selection', () => {
+    const data = [
+      toDataFrame({
+        fields: [
+          { name: 'time', type: FieldType.time, values: [1, 2] },
+          { name: 'Number1', type: FieldType.number, values: [1, 2] },
+          { name: 'Number2', type: FieldType.number, values: [3, 4] },
+          {
+            name: 'Enum1',
+            type: FieldType.enum,
+            values: [0, 1],
+            config: { type: { enum: { text: ['Low', 'High'] } } },
+          },
+          {
+            name: 'Enum2',
+            type: FieldType.enum,
+            values: [1, 0],
+            config: { type: { enum: { text: ['Stopped', 'Running'] } } },
+          },
+        ],
+      }),
+    ];
+
+    const isolated = seriesVisibilityConfigFactory(
+      'Number1',
+      SeriesVisibilityChangeMode.ToggleSelection,
+      emptyFieldConfig(),
+      data
+    );
+
+    const next = seriesVisibilityConfigFactory('Number2', SeriesVisibilityChangeMode.AppendToSelection, isolated, data);
+
+    expect(next.overrides).toHaveLength(1);
+    expect(next.overrides[0].matcher).toEqual({
+      id: FieldMatcherID.byNames,
+      options: {
+        mode: ByNamesMatcherMode.exclude,
+        names: ['Number1', 'Number2'],
+        prefix: 'All except:',
+        readOnly: true,
+      },
+    });
+  });
+
+  it('keeps enum series visible when appending enum series to an isolated selection', () => {
+    const data = [
+      toDataFrame({
+        fields: [
+          { name: 'time', type: FieldType.time, values: [1, 2] },
+          { name: 'Number1', type: FieldType.number, values: [1, 2] },
+          {
+            name: 'Enum1',
+            type: FieldType.enum,
+            values: [0, 1],
+            config: { type: { enum: { text: ['Low', 'High'] } } },
+          },
+          {
+            name: 'Enum2',
+            type: FieldType.enum,
+            values: [1, 0],
+            config: { type: { enum: { text: ['Stopped', 'Running'] } } },
+          },
+        ],
+      }),
+    ];
+
+    const isolated = seriesVisibilityConfigFactory(
+      'Enum1',
+      SeriesVisibilityChangeMode.ToggleSelection,
+      emptyFieldConfig(),
+      data
+    );
+
+    const next = seriesVisibilityConfigFactory('Enum2', SeriesVisibilityChangeMode.AppendToSelection, isolated, data);
+
+    expect(next.overrides).toHaveLength(1);
+    expect(next.overrides[0].matcher).toEqual({
+      id: FieldMatcherID.byNames,
+      options: {
+        mode: ByNamesMatcherMode.exclude,
+        names: ['Enum1', 'Enum2'],
+        prefix: 'All except:',
+        readOnly: true,
+      },
+    });
+  });
+
+  it('keeps numeric, boolean, and enum series in the isolated selection', () => {
+    const data = [
+      toDataFrame({
+        fields: [
+          { name: 'time', type: FieldType.time, values: [1, 2] },
+          { name: 'Number1', type: FieldType.number, values: [1, 2] },
+          { name: 'Number2', type: FieldType.number, values: [3, 4] },
+          { name: 'Boolean1', type: FieldType.boolean, values: [true, false] },
+          {
+            name: 'Enum1',
+            type: FieldType.enum,
+            values: [0, 1],
+            config: { type: { enum: { text: ['Low', 'High'] } } },
+          },
+        ],
+      }),
+    ];
+
+    const isolated = seriesVisibilityConfigFactory(
+      'Number1',
+      SeriesVisibilityChangeMode.ToggleSelection,
+      emptyFieldConfig(),
+      data
+    );
+
+    const next = seriesVisibilityConfigFactory('Number2', SeriesVisibilityChangeMode.AppendToSelection, isolated, data);
+
+    expect(next.overrides).toHaveLength(1);
+    expect(next.overrides[0].matcher).toEqual({
+      id: FieldMatcherID.byNames,
+      options: {
+        mode: ByNamesMatcherMode.exclude,
+        names: ['Number1', 'Number2'],
+        prefix: 'All except:',
+        readOnly: true,
+      },
+    });
+  });
+
+  it('does not count time or string fields as series when all numeric series are visible', () => {
+    const data = [
+      toDataFrame({
+        fields: [
+          { name: 'time', type: FieldType.time, values: [1, 2] },
+          { name: 'Number1', type: FieldType.number, values: [1, 2] },
+          { name: 'Number2', type: FieldType.number, values: [3, 4] },
+          { name: 'Label', type: FieldType.string, values: ['a', 'b'] },
+        ],
+      }),
+    ];
+
+    const isolated = seriesVisibilityConfigFactory(
+      'Number1',
+      SeriesVisibilityChangeMode.ToggleSelection,
+      emptyFieldConfig(),
+      data
+    );
+
+    const next = seriesVisibilityConfigFactory('Number2', SeriesVisibilityChangeMode.AppendToSelection, isolated, data);
+
+    expect(next.overrides).toHaveLength(0);
+  });
+});
+
+function emptyFieldConfig(): FieldConfigSource {
+  return { defaults: {}, overrides: [] };
+}

--- a/public/app/features/dashboard/dashgrid/SeriesVisibilityConfigFactory.ts
+++ b/public/app/features/dashboard/dashgrid/SeriesVisibilityConfigFactory.ts
@@ -160,7 +160,7 @@ const getDisplayNames = (data: DataFrame[], excludeName?: string): string[] => {
 
   for (const frame of data) {
     for (const field of frame.fields) {
-      if (field.type !== FieldType.number) {
+      if (!isSeriesField(field.type)) {
         continue;
       }
 
@@ -189,7 +189,7 @@ const getNamesOfHiddenFields = (overrides: ConfigOverrideRule[], data: DataFrame
 
       for (const frame of data) {
         for (const field of frame.fields) {
-          if (field.type !== FieldType.number) {
+          if (!isSeriesField(field.type)) {
             continue;
           }
 
@@ -205,3 +205,7 @@ const getNamesOfHiddenFields = (overrides: ConfigOverrideRule[], data: DataFrame
 
   return names;
 };
+
+function isSeriesField(type: FieldType): boolean {
+  return type === FieldType.number || type === FieldType.boolean || type === FieldType.enum;
+}


### PR DESCRIPTION
**What is this feature?**

Includes boolean fields when calculating time series legend isolation overrides.

**Why do we need this feature?**

Legend isolation applies a temporary hide override to every field except the selected series. The cleanup logic only counted numeric fields, so appending a second numeric series could remove the override while boolean series were still meant to stay hidden.

**Who is this feature for?**

Dashboard users with time series panels that mix numeric and boolean series.

**Which issue(s) does this PR fix?**:

Fixes #124866

**Special notes for your reviewer:**

Validation:
- `yarn jest public/app/features/dashboard/dashgrid/SeriesVisibilityConfigFactory.test.ts --runInBand --ci`
- `yarn eslint public/app/features/dashboard/dashgrid/SeriesVisibilityConfigFactory.ts public/app/features/dashboard/dashgrid/SeriesVisibilityConfigFactory.test.ts --no-error-on-unmatched-pattern`
- `git diff --check`

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. Not applicable: existing legend behavior.
- [x] The docs are updated, and if this is a notable improvement, it is added to the What's New doc. Not applicable: bug fix only.