### PR TITLE
RemoteCache: Fix database backend cache stuck after clock skew

### DIFF
--- a/pkg/infra/remotecache/database_storage.go
+++ b/pkg/infra/remotecache/database_storage.go
@@ -67,7 +67,10 @@ func (dc *databaseCache) Get(ctx context.Context, key string) ([]byte, error) {
 		}
 
 		if cacheHit.Expires > 0 {
-			existedButExpired := getTime().Unix()-cacheHit.CreatedAt >= cacheHit.Expires
+			age := getTime().Unix() - cacheHit.CreatedAt
+			// age < 0 covers clock skew where CreatedAt is in the future,
+			// otherwise such entries would never expire and stick in the cache.
+			existedButExpired := age < 0 || age >= cacheHit.Expires
 			if existedButExpired {
 				err = dc.Delete(ctx, key) // ignore this error since we will return `ErrCacheItemNotFound` anyway
 				if err != nil {

--- a/pkg/infra/remotecache/database_storage_test.go
+++ b/pkg/infra/remotecache/database_storage_test.go
@@ -61,6 +61,30 @@ func TestIntegrationDatabaseStorageGarbageCollection(t *testing.T) {
 	assert.Equal(t, err, nil)
 }
 
+func TestIntegrationDatabaseStorageGetClockSkew(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	sqlstore := db.InitTestDB(t)
+
+	db := &databaseCache{
+		SQLStore: sqlstore,
+		log:      log.New("remotecache.database"),
+	}
+
+	obj := []byte("foolbar")
+
+	// simulate clock skew: insert an entry while the clock is 2 days ahead
+	getTime = func() time.Time { return time.Now().AddDate(0, 0, 2) }
+	err := db.Set(context.Background(), "future-key", obj, 1000*time.Second)
+	assert.Equal(t, err, nil)
+
+	// clock is corrected back to real time
+	getTime = time.Now
+
+	_, err = db.Get(context.Background(), "future-key")
+	assert.Equal(t, err, ErrCacheItemNotFound)
+}
+
 func TestIntegrationSecondSet(t *testing.T) {
 	testutil.SkipIntegrationTestInShortMode(t)
 


### PR DESCRIPTION
**What is this feature?**

- treat database remote-cache entries with a future `created_at` as expired so they don't get stuck after a clock correction

**Why do we need this feature?**

- when the system clock moves backwards (e.g. NTP correcting a VM that booted ahead), `getTime().Unix() - cacheHit.CreatedAt` becomes negative and the `>= Expires` check is never true, so stale internal id-tokens stay cached forever

**Who is this feature for?**

- operators running Grafana with the default `database` remote-cache backend on hosts whose clock can move backwards

**Which issue(s) does this PR fix?**

Fixes #121015