### PR TITLE
Variables: Fix non-ASCII option search casing

### DIFF
--- a/public/app/features/variables/pickers/OptionsPicker/reducer.test.ts
+++ b/public/app/features/variables/pickers/OptionsPicker/reducer.test.ts
@@ -798,7 +798,7 @@ describe('optionsPickerReducer', () => {
         value: v,
       }));
 
-      const expect: VariableOption[] = 'C CD AC BC'.split(' ').map((v) => ({
+      const expected: VariableOption[] = 'C CD AC BC'.split(' ').map((v) => ({
         selected: false,
         text: v,
         value: v,
@@ -813,7 +813,7 @@ describe('optionsPickerReducer', () => {
         .whenActionIsDispatched(updateOptionsAndFilter(options))
         .thenStateShouldEqual({
           ...cloneDeep(initialState),
-          options: expect,
+          options: expected,
           selectedValues: [],
           queryValue: 'C',
           highlightIndex: 0,
@@ -829,7 +829,7 @@ describe('optionsPickerReducer', () => {
         value: v,
       }));
 
-      const expect: VariableOption[] = [
+      const expected: VariableOption[] = [
         {
           selected: false,
           text: '> ' + searchQuery,
@@ -852,7 +852,7 @@ describe('optionsPickerReducer', () => {
         .whenActionIsDispatched(updateOptionsAndFilter(options))
         .thenStateShouldEqual({
           ...cloneDeep(initialState),
-          options: expect,
+          options: expected,
           selectedValues: [],
           queryValue: searchQuery,
           highlightIndex: 1,
@@ -870,7 +870,7 @@ describe('optionsPickerReducer', () => {
         value: v,
       }));
 
-      const expect: VariableOption[] = [
+      const expected: VariableOption[] = [
         {
           selected: false,
           text: '> ' + searchQuery,
@@ -893,7 +893,128 @@ describe('optionsPickerReducer', () => {
         .whenActionIsDispatched(updateOptionsAndFilter(options))
         .thenStateShouldEqual({
           ...cloneDeep(initialState),
-          options: expect,
+          options: expected,
+          selectedValues: [],
+          queryValue: searchQuery,
+          highlightIndex: 1,
+        });
+    });
+
+    it('should match non-latin chars without requiring exact case', () => {
+      const searchQuery = 'åle';
+
+      const options: VariableOption[] = ['Ålesund', 'Maqv-Å', 'Oslo'].map((v) => ({
+        selected: false,
+        text: v,
+        value: v,
+      }));
+
+      const expected: VariableOption[] = [
+        {
+          selected: false,
+          text: '> ' + searchQuery,
+          value: searchQuery,
+        },
+        {
+          selected: false,
+          text: 'Ålesund',
+          value: 'Ålesund',
+        },
+      ];
+
+      const { initialState } = getVariableTestContext({
+        queryValue: searchQuery,
+      });
+
+      reducerTester<OptionsPickerState>()
+        .givenReducer(optionsPickerReducer, cloneDeep(initialState))
+        .whenActionIsDispatched(updateOptionsAndFilter(options))
+        .thenStateShouldEqual({
+          ...cloneDeep(initialState),
+          options: expected,
+          selectedValues: [],
+          queryValue: searchQuery,
+          highlightIndex: 1,
+        });
+    });
+
+    it('should match non-latin chars in array text options', () => {
+      const searchQuery = 'åle';
+
+      const options: VariableOption[] = [
+        {
+          selected: false,
+          text: ['City', 'Ålesund'],
+          value: 'alesund',
+        },
+        {
+          selected: false,
+          text: ['City', 'Oslo'],
+          value: 'oslo',
+        },
+      ];
+
+      const expected: VariableOption[] = [
+        {
+          selected: false,
+          text: '> ' + searchQuery,
+          value: searchQuery,
+        },
+        {
+          selected: false,
+          text: ['City', 'Ålesund'],
+          value: 'alesund',
+        },
+      ];
+
+      const { initialState } = getVariableTestContext({
+        queryValue: searchQuery,
+      });
+
+      reducerTester<OptionsPickerState>()
+        .givenReducer(optionsPickerReducer, cloneDeep(initialState))
+        .whenActionIsDispatched(updateOptionsAndFilter(options))
+        .thenStateShouldEqual({
+          ...cloneDeep(initialState),
+          options: expected,
+          selectedValues: [],
+          queryValue: searchQuery,
+          highlightIndex: 1,
+        });
+    });
+
+    it('should match uppercase non-latin search text', () => {
+      const searchQuery = 'ÅLE';
+
+      const options: VariableOption[] = ['Ålesund', 'Oslo'].map((v) => ({
+        selected: false,
+        text: v,
+        value: v,
+      }));
+
+      const expected: VariableOption[] = [
+        {
+          selected: false,
+          text: '> ' + searchQuery,
+          value: searchQuery,
+        },
+        {
+          selected: false,
+          text: 'Ålesund',
+          value: 'Ålesund',
+        },
+      ];
+
+      const { initialState } = getVariableTestContext({
+        queryValue: searchQuery,
+      });
+
+      reducerTester<OptionsPickerState>()
+        .givenReducer(optionsPickerReducer, cloneDeep(initialState))
+        .whenActionIsDispatched(updateOptionsAndFilter(options))
+        .thenStateShouldEqual({
+          ...cloneDeep(initialState),
+          options: expected,
           selectedValues: [],
           queryValue: searchQuery,
           highlightIndex: 1,

--- a/public/app/features/variables/pickers/OptionsPicker/reducer.ts
+++ b/public/app/features/variables/pickers/OptionsPicker/reducer.ts
@@ -45,6 +45,11 @@ const ufuzzy = new uFuzzy({
   intraDel: 1,
 });
 
+const optionTextIncludes = (option: VariableOption, normalizedNeedle: string) => {
+  const text = Array.isArray(option.text) ? option.text.toString() : option.text;
+  return text.toLowerCase().includes(normalizedNeedle);
+};
+
 const optionsToRecord = (options: VariableOption[]): Record<string, VariableOption> => {
   if (!Array.isArray(options)) {
     return {};
@@ -255,7 +260,8 @@ const optionsPickerSlice = createSlice({
       if (needle === '') {
         opts = action.payload;
       } else if (REGEXP_NON_ASCII.test(needle)) {
-        opts = action.payload.filter((o) => o.text.includes(needle));
+        const normalizedNeedle = needle.toLowerCase();
+        opts = action.payload.filter((option) => optionTextIncludes(option, normalizedNeedle));
       } else {
         // with current API, not seeing a way to cache this on state using action.payload's uniqueness
         // since it's recreated and includes selected state on each item :(


### PR DESCRIPTION
**What is this feature?**

Makes dashboard variable option filtering case-insensitive when the search text contains non-ASCII characters.

**Why do we need this feature?**

The non-ASCII fallback path skipped fuzzy matching but used a case-sensitive substring check. Values such as `Ålesund` were not returned for lowercase searches like `åle`, which made variable search inconsistent for users with characters such as æ, ø, å, umlauts, or Cyrillic letters.

**Who is this feature for?**

Dashboard users filtering variable values that include non-ASCII characters.

**Which issue(s) does this PR fix?**:

Fixes #109506

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. Not applicable.
- [x] The docs are updated, and if this is a notable improvement, it's added to What's New. Not applicable; this is a bug fix.

Validation:
- `NODE_PATH=/Users/mehmet.turac/Documents/grafana-125036/node_modules ../grafana-125036/node_modules/.bin/jest public/app/features/variables/pickers/OptionsPicker/reducer.test.ts --runInBand --no-coverage`
- `NODE_PATH=/Users/mehmet.turac/Documents/grafana-125036/node_modules ../grafana-125036/node_modules/.bin/eslint public/app/features/variables/pickers/OptionsPicker/reducer.ts public/app/features/variables/pickers/OptionsPicker/reducer.test.ts --no-error-on-unmatched-pattern`
- `NODE_PATH=/Users/mehmet.turac/Documents/grafana-125036/node_modules ../grafana-125036/node_modules/.bin/prettier --check --list-different=false --log-level=warn public/app/features/variables/pickers/OptionsPicker/reducer.ts public/app/features/variables/pickers/OptionsPicker/reducer.test.ts`
