### PR TITLE
Unified Storage: document delegated gRPC surface and verify PutBlob authz

### DIFF
--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -1890,6 +1890,9 @@ func (s *server) GetStats(ctx context.Context, req *resourcepb.ResourceStatsRequ
 	return s.search.GetStats(ctx, req)
 }
 
+// ListManagedObjects implements ManagedObjectIndexServer.
+// NOTE: This request only expects calls delegated from other services -- it is not directly accessible to end users
+// The access control must be handled in the exposed service
 func (s *server) ListManagedObjects(ctx context.Context, req *resourcepb.ListManagedObjectsRequest) (*resourcepb.ListManagedObjectsResponse, error) {
 	if s.search == nil {
 		return nil, fmt.Errorf("search index not configured")
@@ -1898,6 +1901,9 @@ func (s *server) ListManagedObjects(ctx context.Context, req *resourcepb.ListMan
 	return s.search.ListManagedObjects(ctx, req)
 }
 
+// CountManagedObjects implements ManagedObjectIndexServer.
+// NOTE: This request only expects calls delegated from other services -- it is not directly accessible to end users
+// The access control must be handled in the exposed service
 func (s *server) CountManagedObjects(ctx context.Context, req *resourcepb.CountManagedObjectsRequest) (*resourcepb.CountManagedObjectsResponse, error) {
 	if s.search == nil {
 		return nil, fmt.Errorf("search index not configured")
@@ -2021,6 +2027,8 @@ func (s *server) getPartialObject(ctx context.Context, key *resourcepb.ResourceK
 }
 
 // GetBlob implements BlobStore.
+// NOTE: This request only expects calls delegated from other services -- it is not directly accessible to end users
+// The access control must be handled in the exposed service
 func (s *server) GetBlob(ctx context.Context, req *resourcepb.GetBlobRequest) (*resourcepb.GetBlobResponse, error) {
 	if s.blob == nil {
 		return &resourcepb.GetBlobResponse{Error: &resourcepb.ErrorResult{
@@ -2105,6 +2113,9 @@ func (s *server) runInQueue(ctx context.Context, tenantID string, runnable func(
 	}
 }
 
+// RebuildIndexes implements ResourceIndexServer.
+// NOTE: This request only expects calls delegated from other services -- it is not directly accessible to end users
+// The access control must be handled in the exposed service
 func (s *server) RebuildIndexes(ctx context.Context, req *resourcepb.RebuildIndexesRequest) (*resourcepb.RebuildIndexesResponse, error) {
 	if s.search == nil {
 		return nil, fmt.Errorf("search index not configured")

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -1891,8 +1891,8 @@ func (s *server) GetStats(ctx context.Context, req *resourcepb.ResourceStatsRequ
 }
 
 // ListManagedObjects implements ManagedObjectIndexServer.
-// NOTE: This request only expects calls delegated from other services -- it is not directly accessible to end users
-// The access control must be handled in the exposed service
+// NOTE: Internal RPC -- callers are responsible for authorizing the originating user request.
+// Do not route end-user traffic here directly.
 func (s *server) ListManagedObjects(ctx context.Context, req *resourcepb.ListManagedObjectsRequest) (*resourcepb.ListManagedObjectsResponse, error) {
 	if s.search == nil {
 		return nil, fmt.Errorf("search index not configured")
@@ -1902,8 +1902,8 @@ func (s *server) ListManagedObjects(ctx context.Context, req *resourcepb.ListMan
 }
 
 // CountManagedObjects implements ManagedObjectIndexServer.
-// NOTE: This request only expects calls delegated from other services -- it is not directly accessible to end users
-// The access control must be handled in the exposed service
+// NOTE: Internal RPC -- callers are responsible for authorizing the originating user request.
+// Do not route end-user traffic here directly.
 func (s *server) CountManagedObjects(ctx context.Context, req *resourcepb.CountManagedObjectsRequest) (*resourcepb.CountManagedObjectsResponse, error) {
 	if s.search == nil {
 		return nil, fmt.Errorf("search index not configured")
@@ -1918,8 +1918,9 @@ func (s *server) IsHealthy(ctx context.Context, req *resourcepb.HealthCheckReque
 }
 
 // PutBlob implements BlobStore.
-// NOTE: This request only expects calls delegated from other services -- it is not directly accessible to end users
-// The access control must be handled in the exposed service
+// NOTE: Internal RPC -- callers are responsible for authorizing the originating user request.
+// Do not route end-user traffic here directly.
+// PutBlob additionally checks that the caller has "update" on the parent resource as defense in depth.
 func (s *server) PutBlob(ctx context.Context, req *resourcepb.PutBlobRequest) (*resourcepb.PutBlobResponse, error) {
 	if s.blob == nil {
 		return &resourcepb.PutBlobResponse{Error: &resourcepb.ErrorResult{
@@ -2027,8 +2028,8 @@ func (s *server) getPartialObject(ctx context.Context, key *resourcepb.ResourceK
 }
 
 // GetBlob implements BlobStore.
-// NOTE: This request only expects calls delegated from other services -- it is not directly accessible to end users
-// The access control must be handled in the exposed service
+// NOTE: Internal RPC -- callers are responsible for authorizing the originating user request.
+// Do not route end-user traffic here directly.
 func (s *server) GetBlob(ctx context.Context, req *resourcepb.GetBlobRequest) (*resourcepb.GetBlobResponse, error) {
 	if s.blob == nil {
 		return &resourcepb.GetBlobResponse{Error: &resourcepb.ErrorResult{
@@ -2114,8 +2115,8 @@ func (s *server) runInQueue(ctx context.Context, tenantID string, runnable func(
 }
 
 // RebuildIndexes implements ResourceIndexServer.
-// NOTE: This request only expects calls delegated from other services -- it is not directly accessible to end users
-// The access control must be handled in the exposed service
+// NOTE: Internal RPC -- callers are responsible for authorizing the originating user request.
+// Do not route end-user traffic here directly.
 func (s *server) RebuildIndexes(ctx context.Context, req *resourcepb.RebuildIndexesRequest) (*resourcepb.RebuildIndexesResponse, error) {
 	if s.search == nil {
 		return nil, fmt.Errorf("search index not configured")

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -1911,13 +1911,49 @@ func (s *server) IsHealthy(ctx context.Context, req *resourcepb.HealthCheckReque
 	return s.diagnostics.IsHealthy(ctx, req) //nolint:staticcheck
 }
 
-// GetBlob implements BlobStore.
+// PutBlob implements BlobStore.
+// NOTE: This request only expects calls delegated from other services -- it is not directly accessible to end users
+// The access control must be handled in the exposed service
 func (s *server) PutBlob(ctx context.Context, req *resourcepb.PutBlobRequest) (*resourcepb.PutBlobResponse, error) {
 	if s.blob == nil {
 		return &resourcepb.PutBlobResponse{Error: &resourcepb.ErrorResult{
 			Message: "blob store not configured",
 			Code:    http.StatusNotImplemented,
 		}}, nil
+	}
+
+	user, ok := claims.AuthInfoFrom(ctx)
+	if !ok || user == nil {
+		return &resourcepb.PutBlobResponse{
+			Error: &resourcepb.ErrorResult{
+				Message: "no user found in context",
+				Code:    http.StatusUnauthorized,
+			}}, nil
+	}
+
+	key := req.Resource
+	rr := s.backend.ReadResource(ctx, &resourcepb.ReadRequest{Key: key})
+	if rr == nil || rr.Error != nil {
+		return &resourcepb.PutBlobResponse{Error: &resourcepb.ErrorResult{
+			Message: "unable to read parent resource",
+			Code:    http.StatusNotFound,
+		}}, nil
+	}
+
+	// Check that the user also has permissions to update the parent object
+	checkresult, err := s.access.Check(ctx, user, claims.CheckRequest{
+		Verb:      utils.VerbUpdate,
+		Group:     key.Group,
+		Resource:  key.Resource,
+		Namespace: key.Namespace,
+		Name:      key.Name,
+	}, rr.Folder)
+	if err != nil || !checkresult.Allowed {
+		return &resourcepb.PutBlobResponse{
+			Error: &resourcepb.ErrorResult{
+				Message: "not allowed to post blob",
+				Code:    http.StatusUnauthorized,
+			}}, nil
 	}
 
 	rsp, err := s.blob.PutResourceBlob(ctx, req)

--- a/pkg/storage/unified/resource/server_test.go
+++ b/pkg/storage/unified/resource/server_test.go
@@ -1833,3 +1833,169 @@ func TestFolderDeletePermissionChecks(t *testing.T) {
 		require.NotEqual(t, folderName, capturedFolder)
 	})
 }
+
+// stubBlobSupport records whether PutResourceBlob was reached. Tests use it to
+// confirm that PutBlob's authorization gate either delegates to the blob backend
+// or short-circuits before it.
+type stubBlobSupport struct {
+	putReached bool
+}
+
+func (s *stubBlobSupport) SupportsSignedURLs() bool { return false }
+
+func (s *stubBlobSupport) PutResourceBlob(_ context.Context, _ *resourcepb.PutBlobRequest) (*resourcepb.PutBlobResponse, error) {
+	s.putReached = true
+	return &resourcepb.PutBlobResponse{Uid: "blob-uid"}, nil
+}
+
+func (s *stubBlobSupport) GetResourceBlob(_ context.Context, _ *resourcepb.ResourceKey, _ *utils.BlobInfo, _ bool) (*resourcepb.GetBlobResponse, error) {
+	return &resourcepb.GetBlobResponse{}, nil
+}
+
+func TestPutBlobPermissionChecks(t *testing.T) {
+	user := &identity.StaticRequester{
+		Type:      authlib.TypeUser,
+		Login:     "testuser",
+		UserID:    123,
+		UserUID:   "u123",
+		OrgRole:   identity.RoleEditor,
+		Namespace: "default",
+	}
+	ctxWithUser := authlib.WithAuthInfo(context.Background(), user)
+
+	const (
+		group     = "playlist.grafana.app"
+		resource  = "playlists"
+		namespace = "default"
+		name      = "test-resource"
+	)
+
+	key := &resourcepb.ResourceKey{
+		Group:     group,
+		Resource:  resource,
+		Namespace: namespace,
+		Name:      name,
+	}
+
+	value := []byte(`{"apiVersion":"playlist.grafana.app/v0alpha1","kind":"Playlist","metadata":{"name":"` + name + `","uid":"test-uid","namespace":"` + namespace + `"},"spec":{"title":"t","interval":"5m","items":[]}}`)
+
+	newServer := func(t *testing.T, ac authlib.AccessClient, blob BlobSupport) *server {
+		t.Helper()
+		db, err := badger.Open(badger.DefaultOptions("").WithInMemory(true).WithLogger(nil))
+		require.NoError(t, err)
+		t.Cleanup(func() { _ = db.Close() })
+
+		kvStore := NewBadgerKV(db)
+		store, err := NewKVStorageBackend(KVBackendOptions{KvStore: kvStore})
+		require.NoError(t, err)
+
+		srv, err := NewResourceServer(ResourceServerOptions{
+			Backend:      store,
+			AccessClient: ac,
+			Blob:         BlobConfig{Backend: blob},
+		})
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			stopCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			_ = srv.Stop(stopCtx)
+		})
+		return srv
+	}
+
+	// createParentResource seeds the parent so that ReadResource inside PutBlob
+	// returns successfully. The ACL is flipped to allow during creation, then
+	// the caller is free to switch ac.fn before calling PutBlob.
+	createParentResource := func(t *testing.T, srv *server, ac *callbackAccessClient) {
+		t.Helper()
+		ac.fn = func(_ authlib.CheckRequest, _ string) (authlib.CheckResponse, error) { return allow() }
+		rsp, err := srv.Create(ctxWithUser, &resourcepb.CreateRequest{Key: key, Value: value})
+		require.NoError(t, err)
+		require.Nil(t, rsp.Error)
+	}
+
+	t.Run("rejects when no user in context", func(t *testing.T) {
+		ac := &callbackAccessClient{fn: func(authlib.CheckRequest, string) (authlib.CheckResponse, error) { return allow() }}
+		blob := &stubBlobSupport{}
+		srv := newServer(t, ac, blob)
+
+		rsp, err := srv.PutBlob(context.Background(), &resourcepb.PutBlobRequest{Resource: key})
+		require.NoError(t, err)
+		require.NotNil(t, rsp.Error)
+		require.Equal(t, int32(http.StatusUnauthorized), rsp.Error.Code)
+		require.False(t, blob.putReached, "must not delegate to blob backend without a user")
+	})
+
+	t.Run("returns 404 when parent resource does not exist", func(t *testing.T) {
+		ac := &callbackAccessClient{fn: func(authlib.CheckRequest, string) (authlib.CheckResponse, error) { return allow() }}
+		blob := &stubBlobSupport{}
+		srv := newServer(t, ac, blob)
+
+		// No createParentResource — the backend has nothing under key.
+		rsp, err := srv.PutBlob(ctxWithUser, &resourcepb.PutBlobRequest{Resource: key})
+		require.NoError(t, err)
+		require.NotNil(t, rsp.Error)
+		require.Equal(t, int32(http.StatusNotFound), rsp.Error.Code)
+		require.False(t, blob.putReached, "must not delegate when parent resource is missing")
+	})
+
+	t.Run("rejects when access.Check denies update on parent", func(t *testing.T) {
+		ac := &callbackAccessClient{}
+		blob := &stubBlobSupport{}
+		srv := newServer(t, ac, blob)
+		createParentResource(t, srv, ac)
+
+		ac.fn = func(authlib.CheckRequest, string) (authlib.CheckResponse, error) { return deny() }
+
+		rsp, err := srv.PutBlob(ctxWithUser, &resourcepb.PutBlobRequest{Resource: key})
+		require.NoError(t, err)
+		require.NotNil(t, rsp.Error)
+		require.Equal(t, int32(http.StatusUnauthorized), rsp.Error.Code)
+		require.False(t, blob.putReached, "must not delegate when caller lacks update on parent")
+	})
+
+	t.Run("rejects when access.Check returns an error", func(t *testing.T) {
+		ac := &callbackAccessClient{}
+		blob := &stubBlobSupport{}
+		srv := newServer(t, ac, blob)
+		createParentResource(t, srv, ac)
+
+		ac.fn = func(authlib.CheckRequest, string) (authlib.CheckResponse, error) {
+			return authlib.CheckResponse{}, errors.New("authz backend unavailable")
+		}
+
+		rsp, err := srv.PutBlob(ctxWithUser, &resourcepb.PutBlobRequest{Resource: key})
+		require.NoError(t, err)
+		require.NotNil(t, rsp.Error)
+		require.Equal(t, int32(http.StatusUnauthorized), rsp.Error.Code)
+		require.False(t, blob.putReached, "must not delegate when the access check errors out")
+	})
+
+	t.Run("delegates to blob backend when access.Check allows update on parent", func(t *testing.T) {
+		ac := &callbackAccessClient{}
+		blob := &stubBlobSupport{}
+		srv := newServer(t, ac, blob)
+		createParentResource(t, srv, ac)
+
+		var capturedReq authlib.CheckRequest
+		var capturedFolder string
+		ac.fn = func(req authlib.CheckRequest, folder string) (authlib.CheckResponse, error) {
+			capturedReq, capturedFolder = req, folder
+			return allow()
+		}
+
+		rsp, err := srv.PutBlob(ctxWithUser, &resourcepb.PutBlobRequest{Resource: key})
+		require.NoError(t, err)
+		require.Nil(t, rsp.Error)
+		require.True(t, blob.putReached, "must delegate to blob backend on allow")
+
+		// Authz must be asked about "update" on the parent's group/resource/name.
+		require.Equal(t, utils.VerbUpdate, capturedReq.Verb)
+		require.Equal(t, group, capturedReq.Group)
+		require.Equal(t, resource, capturedReq.Resource)
+		require.Equal(t, namespace, capturedReq.Namespace)
+		require.Equal(t, name, capturedReq.Name)
+		// Test resource has no folder annotation, so the folder passed to Check is empty.
+		require.Equal(t, "", capturedFolder)
+	})
+}


### PR DESCRIPTION
## Summary

- Mark `GetBlob`, `ListManagedObjects`, `CountManagedObjects`, and `RebuildIndexes` on the resource server with the same NOTE that already lives on `PutBlob`: these RPCs are not directly user-facing — they expect calls delegated from another service, which is responsible for the resource-level access control.
- Add `TestPutBlobPermissionChecks` covering the defense-in-depth gate added in the previous commit (parent `ReadResource` + `access.Check(verb=update)`):
  - rejects when no user is in context
  - returns 404 when the parent resource does not exist
  - rejects when `access.Check` denies
  - rejects when `access.Check` errors
  - delegates to the blob backend when allowed, and asserts the `Check` was for `update` on the parent's GVRN with the parent's folder

## Test plan

- [x] `go test ./pkg/storage/unified/resource/ -run TestPutBlobPermissionChecks -count=1 -v`
- [x] `go test ./pkg/storage/unified/resource/ -count=1` (full package, no regressions)
- [x] `go vet ./pkg/storage/unified/resource/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)