### PR TITLE
fix: Enable anonymous users to use section variables

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/add-new/AddVariable.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/add-new/AddVariable.tsx
@@ -2,6 +2,7 @@ import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { useCallback } from 'react';
 
 import { t } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
 import { type SceneObject } from '@grafana/scenes';
 
 import { type DashboardScene } from '../../scene/DashboardScene';
@@ -18,7 +19,12 @@ export function AddVariable({
   dashboardScene: DashboardScene;
   selectedElement: SceneObject | undefined;
 }) {
-  const sectionVariablesEnabled = useBooleanFlagValue('dashboardSectionVariables', false);
+  // OpenFeature is not initialized for anonymous users, so fall back to
+  // the static feature toggle to ensure section variables work without auth.
+  const sectionVariablesEnabled = useBooleanFlagValue(
+    'dashboardSectionVariables',
+    Boolean(config.featureToggles.dashboardSectionVariables)
+  );
 
   const onAddVariableClick = useCallback(() => {
     const sectionOwner = sectionVariablesEnabled ? dashboardSceneGraph.findSectionOwner(selectedElement) : undefined;

--- a/public/app/features/dashboard-scene/scene/DashboardControls.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardControls.tsx
@@ -5,7 +5,7 @@ import { type GrafanaTheme2, VariableHide } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
-import { getFeatureFlagClient } from '@grafana/runtime/internal';
+import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
 import {
   type SceneObjectState,
   SceneObjectBase,
@@ -185,7 +185,12 @@ export class DashboardControls extends SceneObjectBase<DashboardControlsState> {
 
   public hasControls(): boolean {
     const dashboard = getDashboardSceneFor(this);
-    const sectionVariablesEnabled = getFeatureFlagClient().getBooleanValue('dashboardSectionVariables', false);
+    // OpenFeature is not initialized for anonymous users, so fall back to
+    // the static feature toggle to ensure section variables work without auth.
+    const sectionVariablesEnabled = getFeatureFlagClient().getBooleanValue(
+      FlagKeys.DashboardSectionVariables,
+      Boolean(config.featureToggles.dashboardSectionVariables)
+    );
     const panelEditVariables = getPanelEditVariables(dashboard, sectionVariablesEnabled);
     const variables = panelEditVariables ?? sceneGraph.getVariables(this)?.state.variables ?? [];
     const hasVariables = variables.some((v) => v.state.hide !== VariableHide.hideVariable);
@@ -217,7 +222,12 @@ function DashboardControlsRenderer({ model }: SceneComponentProps<DashboardContr
   const styles = useStyles2(getStyles, isQueryEditorNext);
   const showDebugger = window.location.search.includes('scene-debugger');
   const hasDashboardControls = useHasDashboardControls(dashboard);
-  const sectionVariablesEnabled = getFeatureFlagClient().getBooleanValue('dashboardSectionVariables', false);
+  // OpenFeature is not initialized for anonymous users, so fall back to
+  // the static feature toggle to ensure section variables work without auth.
+  const sectionVariablesEnabled = getFeatureFlagClient().getBooleanValue(
+    FlagKeys.DashboardSectionVariables,
+    Boolean(config.featureToggles.dashboardSectionVariables)
+  );
   const panelEditVariables = getPanelEditVariables(dashboard, sectionVariablesEnabled);
   const { chrome } = useGrafana();
   const { kioskMode } = chrome.useState();

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItem.tsx
@@ -118,7 +118,12 @@ export class RowItem
     const layoutChildren = this.state.layout.getOutlineChildren();
     if (
       isEditing &&
-      getFeatureFlagClient().getBooleanValue(FlagKeys.DashboardSectionVariables, false) &&
+      // OpenFeature is not initialized for anonymous users, so fall back to
+      // the static feature toggle to ensure section variables work without auth.
+      getFeatureFlagClient().getBooleanValue(
+        FlagKeys.DashboardSectionVariables,
+        Boolean(config.featureToggles.dashboardSectionVariables)
+      ) &&
       this.state.$variables
     ) {
       return [

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemEditor.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemEditor.tsx
@@ -75,7 +75,12 @@ export function useEditOptions(this: RowItem, isNewElement: boolean): OptionsPan
 
   const layoutCategory = useLayoutCategory(layout);
 
-  const sectionVariablesEnabled = useBooleanFlagValue('dashboardSectionVariables', false);
+  // OpenFeature is not initialized for anonymous users, so fall back to
+  // the static feature toggle to ensure section variables work without auth.
+  const sectionVariablesEnabled = useBooleanFlagValue(
+    'dashboardSectionVariables',
+    Boolean(config.featureToggles.dashboardSectionVariables)
+  );
   const sectionVariablesCategory = useMemo(() => {
     const category = new OptionsPaneCategoryDescriptor({
       title: t('dashboard.rows-layout.row-options.section-variables.title', 'Variables'),

--- a/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-rows/RowItemRenderer.tsx
@@ -6,6 +6,7 @@ import { useCallback, useState } from 'react';
 import { type GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
 import { type SceneComponentProps } from '@grafana/scenes';
 import { clearButtonStyles, Icon, Tooltip, useElementSelection, usePointerDistance, useStyles2 } from '@grafana/ui';
 
@@ -45,7 +46,12 @@ export function RowItemRenderer({ model }: SceneComponentProps<RowItem>) {
   const isTopLevel = model.parent?.parent instanceof DashboardScene;
   const pointerDistance = usePointerDistance();
   const soloPanelContext = useSoloPanelContext();
-  const sectionVariablesEnabled = useBooleanFlagValue('dashboardSectionVariables', false);
+  // OpenFeature is not initialized for anonymous users, so fall back to
+  // the static feature toggle to ensure section variables work without auth.
+  const sectionVariablesEnabled = useBooleanFlagValue(
+    'dashboardSectionVariables',
+    Boolean(config.featureToggles.dashboardSectionVariables)
+  );
   const rowVariablesSet = model.state.$variables;
 
   const myIndex = rows.findIndex((row) => row === model);

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItem.tsx
@@ -118,7 +118,12 @@ export class TabItem
     const layoutChildren = this.state.layout.getOutlineChildren();
     if (
       isEditing &&
-      getFeatureFlagClient().getBooleanValue(FlagKeys.DashboardSectionVariables, false) &&
+      // OpenFeature is not initialized for anonymous users, so fall back to
+      // the static feature toggle to ensure section variables work without auth.
+      getFeatureFlagClient().getBooleanValue(
+        FlagKeys.DashboardSectionVariables,
+        Boolean(config.featureToggles.dashboardSectionVariables)
+      ) &&
       this.state.$variables
     ) {
       return [

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItemEditor.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItemEditor.tsx
@@ -59,7 +59,12 @@ export function useEditOptions(this: TabItem, isNewElement: boolean): OptionsPan
 
   const layoutCategory = useLayoutCategory(layout);
 
-  const sectionVariablesEnabled = useBooleanFlagValue('dashboardSectionVariables', false);
+  // OpenFeature is not initialized for anonymous users, so fall back to
+  // the static feature toggle to ensure section variables work without auth.
+  const sectionVariablesEnabled = useBooleanFlagValue(
+    'dashboardSectionVariables',
+    Boolean(config.featureToggles.dashboardSectionVariables)
+  );
   const sectionVariablesCategory = useMemo(() => {
     const category = new OptionsPaneCategoryDescriptor({
       title: t('dashboard.tabs-layout.tab-options.section-variables.title', 'Variables'),

--- a/public/app/features/dashboard-scene/scene/layout-tabs/TabItemRenderer.tsx
+++ b/public/app/features/dashboard-scene/scene/layout-tabs/TabItemRenderer.tsx
@@ -5,7 +5,7 @@ import { useLocation } from 'react-router';
 
 import { type GrafanaTheme2, locationUtil, textUtil } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { locationService } from '@grafana/runtime';
+import { locationService, config } from '@grafana/runtime';
 import { type SceneComponentProps } from '@grafana/scenes';
 import { Box, Icon, Tab, TabContent, Tooltip, useElementSelection, usePointerDistance, useStyles2 } from '@grafana/ui';
 
@@ -150,7 +150,12 @@ export function TabItemLayoutRenderer({ tab, isEditing }: TabItemLayoutRendererP
   const [_, conditionalRenderingClass, conditionalRenderingOverlay] = useIsConditionallyHidden(
     tab.state.conditionalRendering
   );
-  const sectionVariablesEnabled = useBooleanFlagValue('dashboardSectionVariables', false);
+  // OpenFeature is not initialized for anonymous users, so fall back to
+  // the static feature toggle to ensure section variables work without auth.
+  const sectionVariablesEnabled = useBooleanFlagValue(
+    'dashboardSectionVariables',
+    Boolean(config.featureToggles.dashboardSectionVariables)
+  );
   const tabVariablesSet = tab.state.$variables;
 
   return (

--- a/public/app/features/dashboard-scene/serialization/layoutSerializers/sectionVariables.ts
+++ b/public/app/features/dashboard-scene/serialization/layoutSerializers/sectionVariables.ts
@@ -1,3 +1,4 @@
+import { config } from '@grafana/runtime';
 import { FlagKeys, getFeatureFlagClient } from '@grafana/runtime/internal';
 import { type SceneVariables, SceneVariableSet } from '@grafana/scenes';
 import { type VariableKind } from '@grafana/schema/apis/dashboard.grafana.app/v2';
@@ -15,14 +16,18 @@ export function serializeSectionVariables(variableSet?: SceneVariables): Variabl
 }
 
 export function deserializeSectionVariables(variables?: VariableKind[]): SceneVariableSet | undefined {
-  const sectionVariablesEnabled = getFeatureFlagClient().getBooleanValue(FlagKeys.DashboardSectionVariables, false);
+  // OpenFeature is not initialized for anonymous users, so fall back to
+  // the static feature toggle to ensure section variables work without auth.
+  const sectionVariablesEnabled = getFeatureFlagClient().getBooleanValue(
+    FlagKeys.DashboardSectionVariables,
+    Boolean(config.featureToggles.dashboardSectionVariables)
+  );
   if (!variables || variables.length === 0 || !sectionVariablesEnabled) {
     return undefined;
   }
 
   // VariableKind is structurally identical to TypedVariableModelV2
   const sceneVariables = variables.map((variable) => createSceneVariableFromVariableModel(variable));
-
   if (sceneVariables.length === 0) {
     return undefined;
   }


### PR DESCRIPTION
**What is this feature?**

Fixes tab/row-level (section) variables not rendering for anonymous users by falling back to the static feature toggle when OpenFeature is unavailable.

**Why do we need this feature?**

OpenFeature is only initialized for signed-in users (`contextSrv.user.isSignedIn`). Anonymous users never get the provider set up, so all `dashboardSectionVariables` evaluations fell back to the hardcoded default of false, silently disabling section variables even though the feature is GA and enabled server-side.

**Who is this feature for?**

Users who access dashboards with tab/row-level variables via anonymous auth.

**Which issue(s) does this PR fix?:**

Fixes https://github.com/grafana/grafana/issues/123495

**Special notes for your reviewer:**

The root cause is a two-part problem: 
1. `initOpenFeature()` is skipped for anonymous sessions, and
2. All call sites passed false as the fallback default instead of using `config.featureToggles.dashboardSectionVariables`.

This PR addresses the 2nd point by using the static toggle as fallback, which is safe because the flag is GA with `Expression: "true"` in the registry. A broader fix for the 1st point would benefit other OpenFeature-gated features but has a larger blast radius.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
