### PR TITLE
Search: clean up Bleve title mappings

### DIFF
--- a/pkg/storage/unified/resource/bleve_index_metrics.go
+++ b/pkg/storage/unified/resource/bleve_index_metrics.go
@@ -9,19 +9,18 @@ import (
 )
 
 type BleveIndexMetrics struct {
-	IndexLatency            *prometheus.HistogramVec
-	IndexSize               prometheus.Gauge
-	IndexedKinds            *prometheus.GaugeVec
-	IndexCreationTime       *prometheus.HistogramVec
-	OpenIndexes             *prometheus.GaugeVec
-	IndexBuilds             *prometheus.CounterVec
-	IndexBuildFailures      prometheus.Counter
-	IndexBuildSkipped       prometheus.Counter
-	UpdateLatency           prometheus.Histogram
-	UpdatedDocuments        prometheus.Summary
-	SearchUpdateWaitTime    *prometheus.HistogramVec
-	RebuildQueueLength      prometheus.Gauge
-	SearchLegacyQueryFields prometheus.Counter
+	IndexLatency         *prometheus.HistogramVec
+	IndexSize            prometheus.Gauge
+	IndexedKinds         *prometheus.GaugeVec
+	IndexCreationTime    *prometheus.HistogramVec
+	OpenIndexes          *prometheus.GaugeVec
+	IndexBuilds          *prometheus.CounterVec
+	IndexBuildFailures   prometheus.Counter
+	IndexBuildSkipped    prometheus.Counter
+	UpdateLatency        prometheus.Histogram
+	UpdatedDocuments     prometheus.Summary
+	SearchUpdateWaitTime *prometheus.HistogramVec
+	RebuildQueueLength   prometheus.Gauge
 
 	IndexSnapshotDownloads                *prometheus.CounterVec
 	IndexSnapshotDownloadDuration         prometheus.Histogram
@@ -98,10 +97,6 @@ func ProvideIndexMetrics(reg prometheus.Registerer) *BleveIndexMetrics {
 		RebuildQueueLength: promauto.With(reg).NewGauge(prometheus.GaugeOpts{
 			Name: "index_server_rebuild_queue_length",
 			Help: "Number of indexes waiting for rebuild",
-		}),
-		SearchLegacyQueryFields: promauto.With(reg).NewCounter(prometheus.CounterOpts{
-			Name: "index_server_search_legacy_query_fields_total",
-			Help: "Search requests using query fields without title_ngram. Used to monitor when it is safe to remove ngram from title.",
 		}),
 		IndexSnapshotDownloads: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "index_server_snapshot_downloads_total",

--- a/pkg/storage/unified/resource/document.go
+++ b/pkg/storage/unified/resource/document.go
@@ -341,9 +341,9 @@ const (
 	SEARCH_FIELD_NAMESPACE          = "namespace"
 	SEARCH_FIELD_NAME               = "name"
 	SEARCH_FIELD_RV                 = "rv"
-	SEARCH_FIELD_TITLE              = "title"
-	SEARCH_FIELD_TITLE_PHRASE       = "title_phrase" // filtering/sorting on title by full phrase
-	SEARCH_FIELD_TITLE_NGRAM        = "title_ngram"  // ngram analysis for partial/prefix matching on title
+	SEARCH_FIELD_TITLE              = "title"        // standard-analyzed title for full-token search; indexed terms are lowercased by the analyzer
+	SEARCH_FIELD_TITLE_PHRASE       = "title_phrase" // keyword-analyzed title for exact matching/sorting; value is lowercased in UpdateCopyFields
+	SEARCH_FIELD_TITLE_NGRAM        = "title_ngram"  // ngram-analyzed title for partial matching; indexed terms are lowercased by the analyzer
 	SEARCH_FIELD_DESCRIPTION        = "description"
 	SEARCH_FIELD_TAGS               = "tags"
 	SEARCH_FIELD_LABELS             = "labels" // All labels, not a specific one

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -1918,7 +1918,7 @@ func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resourcepb.R
 			}
 			queries = append(queries, disjoin)
 		} else {
-			// When using a
+			// Free-text search uses explicit query fields so each title field can use the query type that matches its analyzer.
 			searchrequest.Fields = append(searchrequest.Fields, resource.SEARCH_FIELD_SCORE)
 			disjoin := bleve.NewDisjunctionQuery()
 			queries = append(queries, disjoin)
@@ -1940,19 +1940,6 @@ func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resourcepb.R
 						Boost: 1, // ngram analyzer (partial/prefix matching)
 					},
 				}
-			} else if b.indexMetrics != nil && b.indexMetrics.SearchLegacyQueryFields != nil {
-				// Track requests from clients that don't yet include title_ngram in their query fields.
-				// When this counter stops incrementing, it is safe to remove the ngram mapping from the title field.
-				hasNgram := false
-				for _, f := range queryFields {
-					if f.Name == resource.SEARCH_FIELD_TITLE_NGRAM {
-						hasNgram = true
-						break
-					}
-				}
-				if !hasNgram {
-					b.indexMetrics.SearchLegacyQueryFields.Inc()
-				}
 			}
 
 			for _, field := range queryFields {
@@ -1966,12 +1953,14 @@ func (b *bleveIndex) toBleveSearchRequest(ctx context.Context, req *resourcepb.R
 					disjoin.AddQuery(q)
 
 				case resourcepb.QueryFieldType_KEYWORD:
+					// Bleve TermQuery is an exact token lookup: it does not analyze or lowercase the query.
 					q := bleve.NewTermQuery(strings.ToLower(req.Query))
 					q.SetBoost(float64(field.Boost))
 					q.SetField(field.Name)
 					disjoin.AddQuery(q)
 
 				case resourcepb.QueryFieldType_PHRASE:
+					// Bleve phrase queries are different from our title_phrase field: they match adjacent analyzed tokens.
 					q := bleve.NewMatchPhraseQuery(req.Query)
 					q.SetBoost(float64(field.Boost))
 					q.SetField(field.Name)
@@ -2256,9 +2245,13 @@ var textSortFields = map[string]string{
 	resource.SEARCH_FIELD_TITLE: resource.SEARCH_FIELD_TITLE_PHRASE,
 }
 
-const lowerCase = "phrase"
+const (
+	lowerCase            = "phrase"
+	whitespaceCharacters = " \t\r\n"
+)
 
-// termField fields to use termQuery for filtering
+// termFields are fields where filter values with separators are split and matched token-by-token.
+// This is unrelated to Bleve TermQuery, which is an exact lookup of one indexed token.
 var termFields = []string{
 	resource.SEARCH_FIELD_TITLE,
 }
@@ -2301,12 +2294,12 @@ func requirementQuery(req *resourcepb.Requirement, prefix string) (query.Query, 
 
 		if len(req.Values) == 1 {
 			filter := filterValue(req.Key, req.Values[0])
-			return newQuery(req.Key, filter, prefix), nil
+			return newFilterQuery(req.Key, filter, prefix), nil
 		}
 
 		conjuncts := []query.Query{}
 		for _, v := range req.Values {
-			q := newQuery(req.Key, filterValue(req.Key, v), prefix)
+			q := newFilterQuery(req.Key, filterValue(req.Key, v), prefix)
 			conjuncts = append(conjuncts, q)
 		}
 
@@ -2321,7 +2314,7 @@ func requirementQuery(req *resourcepb.Requirement, prefix string) (query.Query, 
 			if useExactTermQuery {
 				return newExactTermsQuery(req.Key, req.Values[0], prefix), nil
 			}
-			q := newQuery(req.Key, filterValue(req.Key, req.Values[0]), prefix)
+			q := newFilterQuery(req.Key, filterValue(req.Key, req.Values[0]), prefix)
 			return q, nil
 		}
 
@@ -2331,7 +2324,7 @@ func requirementQuery(req *resourcepb.Requirement, prefix string) (query.Query, 
 			if useExactTermQuery {
 				q = newExactTermsQuery(req.Key, v, prefix)
 			} else {
-				q = newQuery(req.Key, filterValue(req.Key, v), prefix)
+				q = newFilterQuery(req.Key, filterValue(req.Key, v), prefix)
 			}
 			disjuncts = append(disjuncts, q)
 		}
@@ -2343,7 +2336,7 @@ func requirementQuery(req *resourcepb.Requirement, prefix string) (query.Query, 
 
 		var mustNotQueries []query.Query
 		for _, value := range req.Values {
-			q := newQuery(req.Key, filterValue(req.Key, value), prefix)
+			q := newFilterQuery(req.Key, filterValue(req.Key, value), prefix)
 			mustNotQueries = append(mustNotQueries, q)
 		}
 		boolQuery.AddMustNot(mustNotQueries...)
@@ -2371,6 +2364,12 @@ func requirementQuery(req *resourcepb.Requirement, prefix string) (query.Query, 
 // matches word-level wildcards like "hell*") and "title_phrase" (keyword-analyzed,
 // matches full-phrase wildcards like "*grafana dev overview*").
 func addWildcardQueries(disjoin *query.DisjunctionQuery, pattern string, field string) {
+	if field == resource.SEARCH_FIELD_TITLE {
+		// Bleve does not analyze wildcard patterns. The title field is lowercased by the standard analyzer,
+		// and title_phrase is lowercased when the document is prepared.
+		pattern = strings.ToLower(pattern)
+	}
+
 	wq := bleve.NewWildcardQuery(pattern)
 	wq.SetField(field)
 	disjoin.AddQuery(wq)
@@ -2380,6 +2379,40 @@ func addWildcardQueries(disjoin *query.DisjunctionQuery, pattern string, field s
 		wPhrase.SetField(resource.SEARCH_FIELD_TITLE_PHRASE)
 		disjoin.AddQuery(wPhrase)
 	}
+}
+
+func newFilterQuery(key string, value string, prefix string) query.Query {
+	if key != resource.SEARCH_FIELD_TITLE {
+		return newQuery(key, value, prefix)
+	}
+
+	// Title exact matching and partial matching live in separate index fields,
+	// but the title filter API predates those internal fields.
+	queries := []query.Query{
+		newExactTermsQuery(resource.SEARCH_FIELD_TITLE_PHRASE, strings.ToLower(value), prefix),
+		newQuery(resource.SEARCH_FIELD_TITLE, value, prefix),
+	}
+	// Only use title_ngram for single-token title filters. Multi-word filters are handled by title_phrase/title;
+	// adding title_ngram can broaden them after removeSmallTerms drops short words, for example "what\"s up" becomes "what".
+	if !strings.ContainsAny(value, whitespaceCharacters) {
+		queries = append(queries, newTitleNgramQuery(value, prefix))
+	}
+	return bleve.NewDisjunctionQuery(queries...)
+}
+
+func newTitleNgramQuery(value string, prefix string) query.Query {
+	q := bleve.NewMatchQuery(removeSmallTerms(splitTermCharacters(value)))
+	q.SetField(prefix + resource.SEARCH_FIELD_TITLE_NGRAM)
+	q.Analyzer = TITLE_ANALYZER
+	q.Operator = query.MatchQueryOperatorAnd
+	return q
+}
+
+func splitTermCharacters(value string) string {
+	for _, c := range TermCharacters {
+		value = strings.ReplaceAll(value, c, " ")
+	}
+	return value
 }
 
 // newQuery will create a query that will match the value or the tokens of the value
@@ -2393,7 +2426,7 @@ func newQuery(key string, value string, prefix string) query.Query {
 		q.SetField(prefix + key)
 		return q
 	}
-	delimiter, ok := hasTerms(value)
+	delimiter, ok := firstTermSeparator(value)
 	if slices.Contains(termFields, key) && ok {
 		return newTermsQuery(key, value, delimiter, prefix)
 	}
@@ -2411,7 +2444,8 @@ func newTermsQuery(key string, value string, delimiter string, prefix string) qu
 	return bleve.NewDisjunctionQuery(q, cq)
 }
 
-// newExactTermsQuery will create a query that will match on term without any extra queries
+// newExactTermsQuery uses Bleve TermQuery for exact token matching.
+// The input must already match how the field was indexed; TermQuery does not run an analyzer.
 func newExactTermsQuery(key string, value string, prefix string) query.Query {
 	// won't match with ending space
 	value = strings.TrimSuffix(value, " ")
@@ -2425,7 +2459,7 @@ func newExactTermsQuery(key string, value string, prefix string) query.Query {
 func newMatchAllTokensQuery(tokens []string, key string, prefix string) query.Query {
 	cq := bleve.NewConjunctionQuery()
 	for _, token := range tokens {
-		_, ok := hasTerms(token)
+		_, ok := firstTermSeparator(token)
 		if ok {
 			tq := bleve.NewTermQuery(token)
 			tq.SetField(prefix + key)
@@ -2848,8 +2882,9 @@ func (s *batchAuthzSearcher) Weight() float64 {
 	return s.searcher.Weight()
 }
 
-// hasTerms - any value that will be split into multiple tokens
-var hasTerms = func(v string) (string, bool) {
+// firstTermSeparator returns the first configured separator found in v.
+// Title filters use the returned separator to preserve legacy token-by-token matching for values like "foo-bar".
+func firstTermSeparator(v string) (string, bool) {
 	for _, c := range TermCharacters {
 		if strings.Contains(v, c) {
 			return c, true

--- a/pkg/storage/unified/search/bleve_mappings.go
+++ b/pkg/storage/unified/search/bleve_mappings.go
@@ -38,7 +38,7 @@ func getBleveDocMappings(fields resource.SearchableDocumentFields, selectableFie
 	}
 	mapper.AddFieldMappingsAt(resource.SEARCH_FIELD_NAME, nameMapping)
 
-	// for sorting by title full phrase
+	// for exact title matching and sorting. Keyword mapping means Bleve indexes the whole value as one token.
 	titlePhraseMapping := bleve.NewKeywordFieldMapping()
 	titlePhraseMapping.Store = false // already stored in title
 	titlePhraseMapping.IncludeTermVectors = false
@@ -53,30 +53,13 @@ func getBleveDocMappings(fields resource.SearchableDocumentFields, selectableFie
 	titleNgramMapping.IncludeTermVectors = false
 	mapper.AddFieldMappingsAt(resource.SEARCH_FIELD_TITLE_NGRAM, titleNgramMapping)
 
-	// for searching by title - uses ngram token filter
-	// TODO: remove this once all clients query title_ngram directly
-	titleSearchMapping := bleve.NewTextFieldMapping()
-	titleSearchMapping.Analyzer = TITLE_ANALYZER
-	titleSearchMapping.Store = false // already stored in title
-	titleSearchMapping.DocValues = false
-	titleSearchMapping.IncludeTermVectors = false
-
-	// mapping for title to search on words/tokens larger than the ngram size
-	titleWordMapping := bleve.NewTextFieldMapping()
-	titleWordMapping.Analyzer = standard.Name
-	titleWordMapping.Store = true
-	titleWordMapping.DocValues = false
-	titleWordMapping.IncludeTermVectors = false
-
-	// separate keyword mapping for title (no DocValues — only the standalone title_phrase needs them)
-	titleKeywordMapping := bleve.NewKeywordFieldMapping()
-	titleKeywordMapping.Store = false
-	titleKeywordMapping.DocValues = false
-	titleKeywordMapping.IncludeTermVectors = false
-	titleKeywordMapping.SkipFreqNorm = true
-
-	// NOTE: this causes 3 title fields in the response
-	mapper.AddFieldMappingsAt(resource.SEARCH_FIELD_TITLE, titleWordMapping, titleSearchMapping, titleKeywordMapping)
+	// for full-token title search; partial matches use title_ngram
+	titleMapping := bleve.NewTextFieldMapping()
+	titleMapping.Analyzer = standard.Name
+	titleMapping.Store = true
+	titleMapping.DocValues = false
+	titleMapping.IncludeTermVectors = false
+	mapper.AddFieldMappingsAt(resource.SEARCH_FIELD_TITLE, titleMapping)
 
 	descriptionMapping := &mapping.FieldMapping{
 		Name:               resource.SEARCH_FIELD_DESCRIPTION,

--- a/pkg/storage/unified/search/bleve_mappings_test.go
+++ b/pkg/storage/unified/search/bleve_mappings_test.go
@@ -56,7 +56,7 @@ func TestDocumentMapping(t *testing.T) {
 
 	fmt.Printf("DOC: fields %d\n", len(doc.Fields))
 	fmt.Printf("DOC: size %d\n", doc.Size())
-	require.Equal(t, 21, len(doc.Fields))
+	require.Equal(t, 19, len(doc.Fields))
 	require.False(t, doc.HasComposite(), "_all composite field should be disabled")
 }
 
@@ -101,11 +101,11 @@ func TestTermVectorsAndFreqNorm(t *testing.T) {
 
 	// Text fields that use MatchQuery with BM25 scoring must NOT skip freq/norm.
 	mustNotSkipFreqNorm := map[string]bool{
+		resource.SEARCH_FIELD_TITLE:       true,
 		resource.SEARCH_FIELD_TITLE_NGRAM: true,
 	}
 
 	// Fields excluded from SkipFreqNorm check:
-	// - "title" has mixed mappings (text for scoring + keyword for exact match)
 	// - "labels.*" uses dynamic mapping (separate issue)
 
 	for _, f := range doc.Fields {

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -248,10 +248,8 @@ func TestCanSearchByTitle(t *testing.T) {
 }
 
 // TestTitleNgramFieldSearch queries exclusively against the title_ngram field
-// (via explicit QueryFields) to prove the dedicated ngram index mapping works
-// independently of the ngram mapping still present on the title field.
-// Once all instances have this mapping, the ngram mapping on title can be
-// removed and partial/prefix matching will rely entirely on title_ngram.
+// (via explicit QueryFields) to prove partial/prefix matching works without
+// relying on the title field mapping.
 func TestTitleNgramFieldSearch(t *testing.T) {
 	key := resource.NamespacedResource{
 		Namespace: "default",
@@ -335,8 +333,7 @@ func TestWildcardQuery(t *testing.T) {
 		})
 
 		checkSearchQuery(t, index, newTestQuery("hell*"), []string{"name1"})
-		// title field also has a keyword mapping that preserves original case,
-		// so capitalized wildcards also match
+		// Title wildcard search is case-insensitive because title fields are indexed lowercased.
 		checkSearchQuery(t, index, newTestQuery("Hell*"), []string{"name1"})
 	})
 
@@ -391,6 +388,8 @@ func TestWildcardQuery(t *testing.T) {
 		checkSearchQuery(t, index, newTestQuery("*grafana dev overview*"), []string{"name1"})
 		// Partial multi-word match
 		checkSearchQuery(t, index, newTestQuery("*dev overview*"), []string{"name1"})
+		// Wildcard matching is case-insensitive for title_phrase.
+		checkSearchQuery(t, index, newTestQuery("*Dev Overview*"), []string{"name1"})
 	})
 
 	t.Run("default wildcard searches email and login fields", func(t *testing.T) {

--- a/pkg/storage/unified/testing/benchmark.go
+++ b/pkg/storage/unified/testing/benchmark.go
@@ -535,7 +535,7 @@ func runStorageAndSearchBenchmark(
 				Query: job.title,
 				QueryFields: []*resourcepb.ResourceSearchRequest_QueryField{
 					{
-						Name: "title",
+						Name: resource.SEARCH_FIELD_TITLE_PHRASE,
 						Type: resourcepb.QueryFieldType_KEYWORD,
 					},
 				},

--- a/pkg/tests/apis/dashboard/testdata/searchV0/t01-query-single-word.json
+++ b/pkg/tests/apis/dashboard/testdata/searchV0/t01-query-single-word.json
@@ -3,17 +3,6 @@
   "hits": [
     {
       "resource": "dashboards",
-      "name": "timeseries-stacking",
-      "title": "Panel Tests - TimeSeries - stacking",
-      "tags": [
-        "gdev",
-        "panel-tests",
-        "graph-ng"
-      ],
-      "score": 0.15
-    },
-    {
-      "resource": "dashboards",
       "name": "timeseries-stacking2",
       "title": "TimeSeries \u0026 BarChart Stacking",
       "tags": [
@@ -21,8 +10,19 @@
         "panel-tests",
         "graph-ng"
       ],
-      "score": 0.144
+      "score": 0.16
+    },
+    {
+      "resource": "dashboards",
+      "name": "timeseries-stacking",
+      "title": "Panel Tests - TimeSeries - stacking",
+      "tags": [
+        "gdev",
+        "panel-tests",
+        "graph-ng"
+      ],
+      "score": 0.155
     }
   ],
-  "maxScore": 0.15
+  "maxScore": 0.16
 }

--- a/pkg/tests/apis/dashboard/testdata/searchV0/t02-query-multiple-words.json
+++ b/pkg/tests/apis/dashboard/testdata/searchV0/t02-query-multiple-words.json
@@ -10,8 +10,8 @@
         "panel-tests",
         "graph-ng"
       ],
-      "score": 0.211
+      "score": 0.226
     }
   ],
-  "maxScore": 0.211
+  "maxScore": 0.226
 }

--- a/pkg/tests/apis/dashboard/testdata/searchV0/t04-title-ngram-prefix.json
+++ b/pkg/tests/apis/dashboard/testdata/searchV0/t04-title-ngram-prefix.json
@@ -10,8 +10,8 @@
         "panel-tests",
         "graph-ng"
       ],
-      "score": 0.253
+      "score": 0.065
     }
   ],
-  "maxScore": 0.253
+  "maxScore": 0.065
 }

--- a/pkg/tests/apis/dashboard/testdata/searchV0/t05-title-ngram-middle-word.json
+++ b/pkg/tests/apis/dashboard/testdata/searchV0/t05-title-ngram-middle-word.json
@@ -10,8 +10,8 @@
         "panel-tests",
         "graph-ng"
       ],
-      "score": 0.253
+      "score": 0.065
     }
   ],
-  "maxScore": 0.253
+  "maxScore": 0.065
 }


### PR DESCRIPTION
Remove the temporary keyword and ngram mappings from the Bleve `title` field now that clients use `title_ngram` for partial title matching.

`title` is now standard-analyzed only, while `title_ngram` handles partial matches and `title_phrase` handles exact matching/sorting. Title filters still preserve the old fuzzy behavior by querying the appropriate internal title fields.

This also keeps title wildcard search case-insensitive by lowercasing wildcard patterns before querying lowercased title fields, and removes the legacy `index_server_search_legacy_query_fields_total` metric.
