### PR TITLE
AlertList: Support template variables in datasource option (#79046)

### DIFF
--- a/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
+++ b/public/app/plugins/panel/alertlist/UnifiedAlertList.tsx
@@ -137,8 +137,9 @@ function UnifiedAlertList(props: PanelProps<UnifiedAlertListOptions>) {
 
   const stateList = useMemo(() => getStateList(props.options.stateFilter), [props.options.stateFilter]);
   const { options, replaceVariables } = props;
+  const resolvedDatasource = options.datasource ? replaceVariables(options.datasource) : options.datasource;
   const dataSourceName =
-    options.datasource === GRAFANA_DATASOURCE_NAME ? GRAFANA_RULES_SOURCE_NAME : options.datasource;
+    resolvedDatasource === GRAFANA_DATASOURCE_NAME ? GRAFANA_RULES_SOURCE_NAME : resolvedDatasource;
   const parsedOptions: UnifiedAlertListOptions = {
     ...props.options,
     alertName: replaceVariables(options.alertName),
@@ -391,12 +392,13 @@ function filterRules(props: PanelProps<UnifiedAlertListOptions>, rules: Combined
     });
   }
   if (options.datasource) {
-    const isGrafanaDS = options.datasource === GRAFANA_DATASOURCE_NAME;
+    const resolvedDatasource = replaceVariables(options.datasource);
+    const isGrafanaDS = resolvedDatasource === GRAFANA_DATASOURCE_NAME;
 
     filteredRules = filteredRules.filter(
       isGrafanaDS
         ? ({ dataSourceName }) => dataSourceName === GRAFANA_RULES_SOURCE_NAME
-        : ({ dataSourceName }) => dataSourceName === options.datasource
+        : ({ dataSourceName }) => dataSourceName === resolvedDatasource
     );
   }
 

--- a/public/app/plugins/panel/alertlist/module.tsx
+++ b/public/app/plugins/panel/alertlist/module.tsx
@@ -139,6 +139,7 @@ const unifiedAlertList = new PanelPlugin<UnifiedAlertListOptions>(UnifiedAlertLi
                 inputId={id}
                 type={SUPPORTED_RULE_SOURCE_TYPES}
                 noDefault
+                variables
                 current={props.value}
                 onChange={(ds: DataSourceInstanceSettings) => {
                   if (ds.uid !== 'grafana') {


### PR DESCRIPTION
**What is this feature?**

Apply replaceVariables() to the datasource option so that dashboard template variables like $datasource or ${datasource} are resolved at runtime, matching the behavior of alertName and alertInstanceLabelFilter fields.

Show datasource variables in datasource picker 

    Add the `variables` prop to the DataSourcePicker in the AlertList panel
    editor so users can select template variables of type "datasource"
    directly from the dropdown.

<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->



**Why do we need this feature?**

To have a dashboard containing AlertList visualisation with variable containing a datasource picker


**Who is this feature for?**


Users of Grafana UI

**Which issue(s) does this PR fix?**:

Fixes #79046 
<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->


**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
