### PR TITLE
Alerting: Fix import API sync 409 test by enabling required feature flag

### DIFF
--- a/pkg/services/ngalert/api/api_convert_prometheus_test.go
+++ b/pkg/services/ngalert/api/api_convert_prometheus_test.go
@@ -2174,9 +2174,7 @@ func TestRouteConvertPrometheusPostAlertmanagerConfig(t *testing.T) {
 	})
 
 	t.Run("should return 409 when external alertmanager sync is configured for the org", func(t *testing.T) {
-		t.Skip("flaky test")
-
-		ft := featuremgmt.WithFeatures(featuremgmt.FlagAlertingImportAlertmanagerAPI)
+		ft := featuremgmt.WithFeatures(featuremgmt.FlagAlertingMultiplePolicies, featuremgmt.FlagAlertingImportAlertmanagerAPI)
 		mockAM := &mockAlertmanager{}
 		mockAM.On("IsExternalAMSyncConfiguredForOrg", mock.Anything, int64(1)).Return(true, nil).Once()
 


### PR DESCRIPTION
The 409 subtest for the alertmanager import handler missed `FlagAlertingMultiplePolicies`, which the handler now also requires alongside `FlagAlertingImportAlertmanagerAPI`. Without it, the handler short-circuits to 501 before reaching the sync-configured branch.

Enables the missing flag and unskips the test (skipped in #124672).