### PR TITLE
Plugins: Forward X-Grafana-Caller-Id header to plugins

### DIFF
--- a/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware.go
@@ -48,6 +48,7 @@ func (m *TracingHeaderMiddleware) applyHeaders(ctx context.Context, req backend.
 		query.HeaderPanelPluginId,
 		query.HeaderDashboardTitle,
 		query.HeaderPanelTitle,
+		query.HeaderCallerID,
 	}
 
 	for _, headerName := range headersList {

--- a/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware_test.go
+++ b/pkg/services/pluginsintegration/clientmiddleware/tracing_header_middleware_test.go
@@ -114,6 +114,7 @@ func TestTracingHeaderMiddleware(t *testing.T) {
 		req.Header[`X-Panel-Id`] = []string{"2"}
 		req.Header[`X-Query-Group-Id`] = []string{"d26e337d-cb53-481a-9212-0112537b3c1a"}
 		req.Header[`X-Grafana-From-Expr`] = []string{"true"}
+		req.Header[`X-Grafana-Caller-Id`] = []string{"grafana-assistant-app"}
 
 		pluginCtx := backend.PluginContext{
 			DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{},
@@ -134,13 +135,14 @@ func TestTracingHeaderMiddleware(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.Len(t, cdt.QueryDataReq.GetHTTPHeaders(), 6)
+			require.Len(t, cdt.QueryDataReq.GetHTTPHeaders(), 7)
 			require.Equal(t, `lN53lOcVk`, cdt.QueryDataReq.GetHTTPHeader(`X-Dashboard-Uid`))
 			require.Equal(t, `aIyC_OcVz`, cdt.QueryDataReq.GetHTTPHeader(`X-Datasource-Uid`))
 			require.Equal(t, `1`, cdt.QueryDataReq.GetHTTPHeader(`X-Grafana-Org-Id`))
 			require.Equal(t, `2`, cdt.QueryDataReq.GetHTTPHeader(`X-Panel-Id`))
 			require.Equal(t, `d26e337d-cb53-481a-9212-0112537b3c1a`, cdt.QueryDataReq.GetHTTPHeader(`X-Query-Group-Id`))
 			require.Equal(t, `true`, cdt.QueryDataReq.GetHTTPHeader(`X-Grafana-From-Expr`))
+			require.Equal(t, `grafana-assistant-app`, cdt.QueryDataReq.GetHTTPHeader(`X-Grafana-Caller-Id`))
 		})
 
 		t.Run("tracing headers are set for health check", func(t *testing.T) {
@@ -158,13 +160,14 @@ func TestTracingHeaderMiddleware(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.Len(t, cdt.CheckHealthReq.GetHTTPHeaders(), 6)
+			require.Len(t, cdt.CheckHealthReq.GetHTTPHeaders(), 7)
 			require.Equal(t, `lN53lOcVk`, cdt.CheckHealthReq.GetHTTPHeader(`X-Dashboard-Uid`))
 			require.Equal(t, `aIyC_OcVz`, cdt.CheckHealthReq.GetHTTPHeader(`X-Datasource-Uid`))
 			require.Equal(t, `1`, cdt.CheckHealthReq.GetHTTPHeader(`X-Grafana-Org-Id`))
 			require.Equal(t, `2`, cdt.CheckHealthReq.GetHTTPHeader(`X-Panel-Id`))
 			require.Equal(t, `d26e337d-cb53-481a-9212-0112537b3c1a`, cdt.CheckHealthReq.GetHTTPHeader(`X-Query-Group-Id`))
 			require.Equal(t, `true`, cdt.CheckHealthReq.GetHTTPHeader(`X-Grafana-From-Expr`))
+			require.Equal(t, `grafana-assistant-app`, cdt.CheckHealthReq.GetHTTPHeader(`X-Grafana-Caller-Id`))
 		})
 
 		t.Run("tracing headers are set for subscribe stream", func(t *testing.T) {
@@ -182,13 +185,14 @@ func TestTracingHeaderMiddleware(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.Len(t, cdt.SubscribeStreamReq.GetHTTPHeaders(), 6)
+			require.Len(t, cdt.SubscribeStreamReq.GetHTTPHeaders(), 7)
 			require.Equal(t, `lN53lOcVk`, cdt.SubscribeStreamReq.GetHTTPHeader(`X-Dashboard-Uid`))
 			require.Equal(t, `aIyC_OcVz`, cdt.SubscribeStreamReq.GetHTTPHeader(`X-Datasource-Uid`))
 			require.Equal(t, `1`, cdt.SubscribeStreamReq.GetHTTPHeader(`X-Grafana-Org-Id`))
 			require.Equal(t, `2`, cdt.SubscribeStreamReq.GetHTTPHeader(`X-Panel-Id`))
 			require.Equal(t, `d26e337d-cb53-481a-9212-0112537b3c1a`, cdt.SubscribeStreamReq.GetHTTPHeader(`X-Query-Group-Id`))
 			require.Equal(t, `true`, cdt.SubscribeStreamReq.GetHTTPHeader(`X-Grafana-From-Expr`))
+			require.Equal(t, `grafana-assistant-app`, cdt.SubscribeStreamReq.GetHTTPHeader(`X-Grafana-Caller-Id`))
 		})
 
 		t.Run("tracing headers are set for publish stream", func(t *testing.T) {
@@ -206,13 +210,14 @@ func TestTracingHeaderMiddleware(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			require.Len(t, cdt.PublishStreamReq.GetHTTPHeaders(), 6)
+			require.Len(t, cdt.PublishStreamReq.GetHTTPHeaders(), 7)
 			require.Equal(t, `lN53lOcVk`, cdt.PublishStreamReq.GetHTTPHeader(`X-Dashboard-Uid`))
 			require.Equal(t, `aIyC_OcVz`, cdt.PublishStreamReq.GetHTTPHeader(`X-Datasource-Uid`))
 			require.Equal(t, `1`, cdt.PublishStreamReq.GetHTTPHeader(`X-Grafana-Org-Id`))
 			require.Equal(t, `2`, cdt.PublishStreamReq.GetHTTPHeader(`X-Panel-Id`))
 			require.Equal(t, `d26e337d-cb53-481a-9212-0112537b3c1a`, cdt.PublishStreamReq.GetHTTPHeader(`X-Query-Group-Id`))
 			require.Equal(t, `true`, cdt.PublishStreamReq.GetHTTPHeader(`X-Grafana-From-Expr`))
+			require.Equal(t, `grafana-assistant-app`, cdt.PublishStreamReq.GetHTTPHeader(`X-Grafana-Caller-Id`))
 		})
 
 		t.Run("tracing headers are set for run stream", func(t *testing.T) {
@@ -230,13 +235,14 @@ func TestTracingHeaderMiddleware(t *testing.T) {
 			}, &backend.StreamSender{})
 			require.NoError(t, err)
 
-			require.Len(t, cdt.RunStreamReq.GetHTTPHeaders(), 6)
+			require.Len(t, cdt.RunStreamReq.GetHTTPHeaders(), 7)
 			require.Equal(t, `lN53lOcVk`, cdt.RunStreamReq.GetHTTPHeader(`X-Dashboard-Uid`))
 			require.Equal(t, `aIyC_OcVz`, cdt.RunStreamReq.GetHTTPHeader(`X-Datasource-Uid`))
 			require.Equal(t, `1`, cdt.RunStreamReq.GetHTTPHeader(`X-Grafana-Org-Id`))
 			require.Equal(t, `2`, cdt.RunStreamReq.GetHTTPHeader(`X-Panel-Id`))
 			require.Equal(t, `d26e337d-cb53-481a-9212-0112537b3c1a`, cdt.RunStreamReq.GetHTTPHeader(`X-Query-Group-Id`))
 			require.Equal(t, `true`, cdt.RunStreamReq.GetHTTPHeader(`X-Grafana-From-Expr`))
+			require.Equal(t, `grafana-assistant-app`, cdt.RunStreamReq.GetHTTPHeader(`X-Grafana-Caller-Id`))
 		})
 
 		t.Run("sanitizes header values to printable ASCII for gRPC", func(t *testing.T) {

--- a/pkg/services/query/query.go
+++ b/pkg/services/query/query.go
@@ -41,6 +41,7 @@ const (
 	HeaderPanelPluginId  = "X-Panel-Plugin-Id"
 	HeaderQueryGroupID   = "X-Query-Group-Id"    // mainly useful for finding related queries with query chunking
 	HeaderFromExpression = "X-Grafana-From-Expr" // used by datasources to identify expression queries
+	HeaderCallerID       = "X-Grafana-Caller-Id" // identifies the caller that initiated this query (e.g. an app plugin id or external tool name)
 )
 
 func ProvideService(


### PR DESCRIPTION
## Summary

Adds a new `X-Grafana-Caller-Id` request header to `TracingHeaderMiddleware`'s forwarding allowlist, so an inbound header on the unified query path (`/api/ds/query`) is propagated onto `QueryDataRequest.Headers` and, for plugins that enable `ForwardHTTPHeaders`, onto their outbound HTTP calls.

## Motivation

The unified query path forwards only an explicit allowlist of headers, so a caller has no way to identify itself end-to-end. This blocks attribution for traffic that doesn't originate from dashboards/expressions:

- **Grafana Assistant chat** issues `datasource.query()` calls through `/api/ds/query`; today they reach upstream datasources with no signal of who initiated them.
- **gcx** uses the unified query API for Loki/Prometheus; User-Agent detection works on the legacy data-source proxy but doesn't survive this path.

The name is intentionally generic (`Caller-Id`, not `App-Plugin-Id`) so both app plugins and non-plugin callers can share it.

Companion PRs complete the chain: grafana/grafana#125095 and grafana/grafana-pyroscope-datasource#16 enable `ForwardHTTPHeaders` on Pyroscope; grafana/backend-enterprise#12591 reads the header at the gateway.

## Security

The value is client-controlled, like the other allowlisted headers. It flows through the existing `sanitizeHTTPHeaderValueForGRPC` path, and Go's `net/http` rejects invalid header values on outbound writes. So no header/CRLF injection.

## Test plan

- [x] `go test ./pkg/services/pluginsintegration/clientmiddleware/ -run TestTracingHeaderMiddleware` passes.

## Header name

`X-Grafana-Caller-Id` is just a proposal, since it becomes a shared, generic header, happy to rename if the team prefers something else. Suggestions welcome.
