### PR TITLE
Pyroscope: Forward HTTP headers from QueryDataRequest to outbound requests

### DIFF
--- a/pkg/tsdb/grafana-pyroscope-datasource/instance.go
+++ b/pkg/tsdb/grafana-pyroscope-datasource/instance.go
@@ -53,6 +53,9 @@ func NewPyroscopeDatasource(ctx context.Context, httpClientProvider httpclient.P
 	if err != nil {
 		return nil, backend.DownstreamErrorf("failed to get HTTP client options: %w. function: %s", err, logEntrypoint())
 	}
+
+	opt.ForwardHTTPHeaders = true
+
 	httpClient, err := httpClientProvider.New(opt)
 	if err != nil {
 		return nil, backend.DownstreamErrorf("failed to create HTTP client: %w. function: %s", err, logEntrypoint())


### PR DESCRIPTION
## Summary

Sets `opt.ForwardHTTPHeaders = true` on the Pyroscope plugin's HTTP client, matching Tempo (`pkg/tsdb/tempo/tempo.go:73`) and Loki (`pkg/tsdb/loki/loki.go:106`).

## Motivation

Without it, headers on `QueryDataRequest.Headers` (populated by `TracingHeaderMiddleware`)  e.g. `X-Dashboard-Uid`, `X-Panel-Id`, and the new `X-Grafana-Caller-Id` (#125091) reach the plugin but are never propagated by the SDK's `headerMiddleware` onto its outbound HTTP / Connect-Go requests. Loki and Tempo already opt in; Pyroscope is the outlier.
