### PR TITLE
Add search ring replica extension setting

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -689,6 +689,7 @@ type Cfg struct {
 	MemberlistClusterLabel                     string
 	MemberlistClusterLabelVerificationDisabled bool
 	SearchRingReplicationFactor                int
+	SearchRingExtendReplicaSet                 bool
 	InstanceID                                 string
 	SprinklesApiServer                         string
 	SprinklesApiServerPageLimit                int

--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -196,6 +196,7 @@ func (cfg *Cfg) setUnifiedStorageConfig() {
 	cfg.MemberlistClusterLabel = section.Key("memberlist_cluster_label").String()
 	cfg.MemberlistClusterLabelVerificationDisabled = section.Key("memberlist_cluster_label_verification_disabled").MustBool(false)
 	cfg.SearchRingReplicationFactor = section.Key("search_ring_replication_factor").MustInt(1)
+	cfg.SearchRingExtendReplicaSet = section.Key("search_ring_extend_replica_set").MustBool(true)
 	cfg.InstanceID = section.Key("instance_id").String()
 	cfg.IndexFileThreshold = section.Key("index_file_threshold").MustInt(10)
 	cfg.IndexMinCount = section.Key("index_min_count").MustInt(1)

--- a/pkg/setting/setting_unified_storage_test.go
+++ b/pkg/setting/setting_unified_storage_test.go
@@ -78,6 +78,31 @@ func TestCfg_setUnifiedStorageConfig(t *testing.T) {
 		assert.Equal(t, 5, cfg.IndexMinCount)
 	})
 
+	t.Run("search_ring_extend_replica_set", func(t *testing.T) {
+		setSectionKey := func(cfg *Cfg, value string) {
+			section := cfg.Raw.Section("unified_storage")
+			_, err := section.NewKey("search_ring_extend_replica_set", value)
+			assert.NoError(t, err)
+		}
+
+		t.Run("defaults to true", func(t *testing.T) {
+			cfg := NewCfg()
+			err := cfg.Load(CommandLineArgs{HomePath: "../../", Config: "../../conf/defaults.ini"})
+			assert.NoError(t, err)
+			cfg.setUnifiedStorageConfig()
+			assert.True(t, cfg.SearchRingExtendReplicaSet)
+		})
+
+		t.Run("reads configured value", func(t *testing.T) {
+			cfg := NewCfg()
+			err := cfg.Load(CommandLineArgs{HomePath: "../../", Config: "../../conf/defaults.ini"})
+			assert.NoError(t, err)
+			setSectionKey(cfg, "false")
+			cfg.setUnifiedStorageConfig()
+			assert.False(t, cfg.SearchRingExtendReplicaSet)
+		})
+	})
+
 	t.Run("search_inject_failures_percent", func(t *testing.T) {
 		setSectionKey := func(cfg *Cfg, key, value string) {
 			section := cfg.Raw.Section("unified_storage")

--- a/pkg/storage/unified/resource/search_server_distributor.go
+++ b/pkg/storage/unified/resource/search_server_distributor.go
@@ -37,10 +37,11 @@ var (
 
 func ProvideSearchDistributorServer(tracer trace.Tracer, cfg *setting.Cfg, ring *ring.Ring, ringClientPool *ringclient.Pool, provider grpcserver.Provider) (UnifiedStorageGrpcService, error) {
 	s := &distributorServer{
-		log:        log.New("index-server-distributor"),
-		ring:       ring,
-		clientPool: ringClientPool,
-		tracing:    tracer,
+		log:            log.New("index-server-distributor"),
+		ring:           ring,
+		searchRingRead: newSearchRingReadOp(cfg.SearchRingExtendReplicaSet),
+		clientPool:     ringClientPool,
+		tracing:        tracer,
 	}
 
 	srv := provider.GetServer()
@@ -90,18 +91,24 @@ const RingNumTokens = 128
 
 type distributorServer struct {
 	*services.BasicService
-	clientPool *ringclient.Pool
-	ring       *ring.Ring
-	log        log.Logger
-	tracing    trace.Tracer
+	clientPool     *ringclient.Pool
+	ring           *ring.Ring
+	searchRingRead ring.Operation
+	log            log.Logger
+	tracing        trace.Tracer
 }
 
-var (
-	// operation used by the distributor to select only ACTIVE instances to handle search-related requests
-	searchRingRead = ring.NewOp([]ring.InstanceState{ring.ACTIVE}, func(s ring.InstanceState) bool {
-		return s != ring.ACTIVE
-	})
-)
+func newSearchRingReadOp(extendReplicaSet bool) ring.Operation {
+	// The distributor routes search-related requests only to ACTIVE instances.
+	// Replica-set extension is configurable to avoid forcing replacement pods to open large local indexes during rollouts.
+	var shouldExtendReplicaSet func(ring.InstanceState) bool
+	if extendReplicaSet {
+		shouldExtendReplicaSet = func(s ring.InstanceState) bool {
+			return s != ring.ACTIVE
+		}
+	}
+	return ring.NewOp([]ring.InstanceState{ring.ACTIVE}, shouldExtendReplicaSet)
+}
 
 func (ds *distributorServer) Search(ctx context.Context, r *resourcepb.ResourceSearchRequest) (*resourcepb.ResourceSearchResponse, error) {
 	ctx, span := ds.tracing.Start(ctx, "distributor.Search")
@@ -131,7 +138,7 @@ func (ds *distributorServer) VectorSearch(ctx context.Context, r *resourcepb.Vec
 
 	// No per-namespace locality — every search pod hits the same pgvector
 	// backend — so pick any healthy instance.
-	rs, err := ds.ring.GetAllHealthy(searchRingRead)
+	rs, err := ds.ring.GetAllHealthy(ds.searchRingRead)
 	if err != nil || len(rs.Instances) == 0 {
 		return nil, fmt.Errorf("no healthy search instances available: %w", err)
 	}
@@ -163,7 +170,7 @@ func (ds *distributorServer) RebuildIndexes(ctx context.Context, r *resourcepb.R
 
 	// distribute the request to all search pods to minimize risk of stale index
 	// it will not rebuild on those which don't have the index open
-	rs, err := ds.ring.GetAllHealthy(searchRingRead)
+	rs, err := ds.ring.GetAllHealthy(ds.searchRingRead)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get all healthy instances from the ring")
 	}
@@ -300,7 +307,7 @@ func (ds *distributorServer) getClientToDistributeRequest(ctx context.Context, n
 		return ctx, nil, err
 	}
 
-	rs, err := ds.ring.GetWithOptions(ringHasher.Sum32(), searchRingRead, ring.WithReplicationFactor(ds.ring.ReplicationFactor()))
+	rs, err := ds.ring.GetWithOptions(ringHasher.Sum32(), ds.searchRingRead, ring.WithReplicationFactor(ds.ring.ReplicationFactor()))
 	if err != nil {
 		ds.log.Debug("error getting replication set from ring", "err", err, "namespace", namespace)
 		return ctx, nil, err

--- a/pkg/storage/unified/resource/search_server_distributor_test.go
+++ b/pkg/storage/unified/resource/search_server_distributor_test.go
@@ -1,0 +1,124 @@
+package resource
+
+import (
+	"context"
+	"slices"
+	"testing"
+	"time"
+
+	gokitlog "github.com/go-kit/log"
+	"github.com/grafana/dskit/kv"
+	"github.com/grafana/dskit/kv/consul"
+	"github.com/grafana/dskit/ring"
+	"github.com/grafana/dskit/services"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSearchRingReadOpReplicaSetExtension(t *testing.T) {
+	t.Run("replication factor 1", func(t *testing.T) {
+		for _, state := range []ring.InstanceState{ring.LEAVING, ring.JOINING} {
+			t.Run(state.String(), func(t *testing.T) {
+				testRing, store := newSearchRingForTest(t, 1, ring.ACTIVE)
+
+				requireSearchReplicaSetIDs(t, testRing, true, []string{"instance-a"})
+				requireSearchReplicaSetIDs(t, testRing, false, []string{"instance-a"})
+
+				updateSearchRingForTest(t, store, state)
+
+				require.EventuallyWithT(t, func(c *assert.CollectT) {
+					extendedIDs, err := searchReplicaSetIDs(testRing, true)
+					require.NoError(c, err)
+					require.Equal(c, []string{"instance-b"}, extendedIDs)
+
+					_, err = searchReplicaSetIDs(testRing, false)
+					require.ErrorContains(c, err, "at least 1 healthy replica required, could only find 0")
+				}, time.Second, 10*time.Millisecond)
+			})
+		}
+	})
+
+	t.Run("replication factor 2", func(t *testing.T) {
+		testRing, store := newSearchRingForTest(t, 2, ring.ACTIVE)
+
+		requireSearchReplicaSetIDs(t, testRing, true, []string{"instance-a", "instance-b"})
+		requireSearchReplicaSetIDs(t, testRing, false, []string{"instance-a", "instance-b"})
+
+		for _, state := range []ring.InstanceState{ring.LEAVING, ring.JOINING} {
+			t.Run(state.String(), func(t *testing.T) {
+				updateSearchRingForTest(t, store, state)
+
+				require.EventuallyWithT(t, func(c *assert.CollectT) {
+					extendedIDs, err := searchReplicaSetIDs(testRing, true)
+					require.NoError(c, err)
+					require.Equal(c, []string{"instance-b", "instance-c"}, extendedIDs)
+
+					noExtensionIDs, err := searchReplicaSetIDs(testRing, false)
+					require.NoError(c, err)
+					require.Equal(c, []string{"instance-b"}, noExtensionIDs)
+				}, time.Second, 10*time.Millisecond)
+			})
+		}
+	})
+}
+
+func requireSearchReplicaSetIDs(t *testing.T, testRing *ring.Ring, extendReplicaSet bool, expectedIDs []string) {
+	t.Helper()
+
+	ids, err := searchReplicaSetIDs(testRing, extendReplicaSet)
+	require.NoError(t, err)
+	require.Equal(t, expectedIDs, ids)
+}
+
+func searchReplicaSetIDs(testRing *ring.Ring, extendReplicaSet bool) ([]string, error) {
+	rs, err := testRing.GetWithOptions(50, newSearchRingReadOp(extendReplicaSet), ring.WithReplicationFactor(testRing.ReplicationFactor()))
+	if err != nil {
+		return nil, err
+	}
+	ids := rs.GetIDs()
+	slices.Sort(ids)
+	return ids, nil
+}
+
+func newSearchRingForTest(t *testing.T, replicationFactor int, firstInstanceState ring.InstanceState) (*ring.Ring, kv.Client) {
+	t.Helper()
+
+	logger := gokitlog.NewNopLogger()
+	store, closer := consul.NewInMemoryClient(ring.GetCodec(), logger, prometheus.NewRegistry())
+	t.Cleanup(func() {
+		require.NoError(t, closer.Close())
+	})
+
+	updateSearchRingForTest(t, store, firstInstanceState)
+
+	testRing, err := ring.NewWithStoreClientAndStrategy(ring.Config{
+		HeartbeatTimeout:  time.Minute,
+		ReplicationFactor: replicationFactor,
+	}, RingName, RingKey, store, ring.NewIgnoreUnhealthyInstancesReplicationStrategy(), prometheus.NewRegistry(), logger)
+	require.NoError(t, err)
+
+	require.NoError(t, services.StartAndAwaitRunning(t.Context(), testRing))
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.WithoutCancel(t.Context()), time.Second)
+		defer cancel()
+		require.NoError(t, services.StopAndAwaitTerminated(ctx, testRing))
+	})
+
+	return testRing, store
+}
+
+func updateSearchRingForTest(t *testing.T, store kv.Client, firstInstanceState ring.InstanceState) {
+	t.Helper()
+
+	desc := ring.NewDesc()
+	now := time.Now()
+	desc.AddIngester("instance-a", "instance-a", "", []uint32{100}, firstInstanceState, now, false, time.Time{}, nil)
+	desc.AddIngester("instance-b", "instance-b", "", []uint32{200}, ring.ACTIVE, now, false, time.Time{}, nil)
+	desc.AddIngester("instance-c", "instance-c", "", []uint32{300}, ring.ACTIVE, now, false, time.Time{}, nil)
+
+	err := store.CAS(t.Context(), RingKey, func(interface{}) (interface{}, bool, error) {
+		return desc, false, nil
+	})
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Add a unified storage setting to control whether the search distributor extends the ring replica set when a namespace owner is not ACTIVE.

The default preserves existing behavior. When disabled, the distributor still routes only to ACTIVE instances, but it does not pick additional replacement instances for JOINING or LEAVING owners. This lets deployments avoid routing search traffic to replacement pods during rollouts, which can otherwise force short-lived local index opens.

Tests cover config parsing and ring selection behavior for RF=1 and RF=2.