### PR TITLE
Add adaptive Bleve index build promotion

### DIFF
--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -647,8 +647,8 @@ type preparedBuildIndex struct {
 
 // BuildIndex builds an index from scratch or retrieves it from the filesystem.
 // If built successfully, the new index replaces the old index in the cache (if there was any).
-// Existing index in the file system is reused, if it exists, and if docCount indicates that we should use file-based index,
-// and lastImportTime check passes (if the index was built before lastImportTime, it will be rebuilt).
+// Existing index in the file system is reused, if it exists, and lastImportTime
+// check passes (if the index was built before lastImportTime, it will be rebuilt).
 // The return value of "builder" should be the RV returned from List. This will be stored as the index RV.
 //
 // maxFreshSnapshotAge is the maximum age (by BuildTime) of a remote snapshot
@@ -656,6 +656,8 @@ type preparedBuildIndex struct {
 // rebuild path. Zero disables the strict same-version fast path; the snapshot
 // store, if configured, is still consulted on the initial-startup path via
 // pickBestSnapshot.
+//
+//nolint:gocyclo
 func (b *bleveBackend) BuildIndex(
 	ctx context.Context,
 	key resource.NamespacedResource,
@@ -1002,9 +1004,6 @@ func (b *bleveBackend) createEmptyFileIndex(resourceDir string, mapper mapping.I
 
 		idx, err := newBleveIndex(indexDir, mapper, time.Now(), b.opts.BuildVersion, selectableFields)
 		if errors.Is(err, bleve.ErrorIndexPathExists) {
-			if idx != nil {
-				_ = idx.Close()
-			}
 			continue
 		}
 		if err != nil {
@@ -1084,7 +1083,7 @@ func (a *adaptiveBuildIndex) BulkIndex(req *resource.BulkIndexRequest) error {
 		return nil
 	}
 
-	count, err := a.bleveIndex.index.DocCount()
+	count, err := a.index.DocCount()
 	if err != nil {
 		return err
 	}

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -765,6 +765,9 @@ func (b *bleveBackend) BuildIndex(
 
 		buildErr := b.buildIndexFromScratch(buildTarget, indexBuildReason, builder, logWithDetails)
 		if adaptive != nil {
+			// If the adaptive wrapper promoted the index, copy the final file-backed
+			// delegate and directory metadata back into prepared so the normal cache,
+			// cleanup, and in-flight unregister paths handle the promoted index.
 			idx, prepared.fileIndexName, prepared.cleanupDir = adaptive.finalState()
 			prepared.index = idx.index
 			prepared.indexStorage = idx.indexStorage
@@ -1004,14 +1007,15 @@ func (b *bleveBackend) createEmptyFileIndex(resourceDir string, mapper mapping.I
 
 		idx, err := newBleveIndex(indexDir, mapper, time.Now(), b.opts.BuildVersion, selectableFields)
 		if errors.Is(err, bleve.ErrorIndexPathExists) {
+			b.unregisterInFlightBuildDir(indexDir)
 			continue
 		}
 		if err != nil {
+			b.unregisterInFlightBuildDir(indexDir)
 			return preparedBuildIndex{}, fmt.Errorf("error creating new bleve index: %s %w", indexDir, err)
 		}
 
 		logger.Info("Building index using filesystem", "directory", indexDir)
-		b.registerInFlightBuildDir(indexDir)
 		return preparedBuildIndex{
 			index:         idx,
 			fileIndexName: fileIndexName,
@@ -1132,7 +1136,6 @@ func (b *bleveBackend) promoteBuildIndexToFile(
 	if err != nil {
 		return nil, "", "", err
 	}
-	b.registerInFlightBuildDir(indexDir)
 	cleanup := true
 	defer func() {
 		if cleanup {
@@ -1292,6 +1295,34 @@ func (b *bleveBackend) cleanOldIndexes(resourceDir string, skipName string) {
 	}
 }
 
+// reserveIndexDir returns an absolute path (and its base name) inside
+// resourceDir that does not exist yet. It reserves the not-yet-created path in
+// inFlightBuildDirs before returning, and bumps the timestamp if a collision
+// happens.
+func (b *bleveBackend) reserveIndexDir(resourceDir string) (string, string, error) {
+	if err := os.MkdirAll(resourceDir, 0o750); err != nil {
+		return "", "", err
+	}
+
+	t := time.Now()
+	for {
+		name := formatIndexName(t)
+		dir := filepath.Join(resourceDir, name)
+		if !isPathWithinRoot(dir, b.opts.Root) {
+			return "", "", fmt.Errorf("invalid path %s", dir)
+		}
+		if _, err := os.Stat(dir); err != nil {
+			if !errors.Is(err, os.ErrNotExist) {
+				return "", "", err
+			}
+			if b.tryReserveInFlightBuildDir(dir) {
+				return dir, name, nil
+			}
+		}
+		t = t.Add(time.Second)
+	}
+}
+
 // registerInFlightBuildDir marks an absolute directory path as actively used
 // by an in-flight BuildIndex call. cleanOldIndexes will skip such paths.
 // Must be paired with a call to unregisterInFlightBuildDir; the refcount
@@ -1304,6 +1335,21 @@ func (b *bleveBackend) registerInFlightBuildDir(path string) {
 	b.inFlightBuildDirsMu.Lock()
 	defer b.inFlightBuildDirsMu.Unlock()
 	b.inFlightBuildDirs[path]++
+}
+
+// tryReserveInFlightBuildDir registers path only if no in-process build is
+// already using it. It is used before the directory exists on disk.
+func (b *bleveBackend) tryReserveInFlightBuildDir(path string) bool {
+	if path == "" {
+		return false
+	}
+	b.inFlightBuildDirsMu.Lock()
+	defer b.inFlightBuildDirsMu.Unlock()
+	if _, ok := b.inFlightBuildDirs[path]; ok {
+		return false
+	}
+	b.inFlightBuildDirs[path] = 1
+	return true
 }
 
 func (b *bleveBackend) unregisterInFlightBuildDir(path string) {

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -994,25 +994,33 @@ func (b *bleveBackend) createEmptyBuildIndex(resourceDir string, mapper mapping.
 }
 
 func (b *bleveBackend) createEmptyFileIndex(resourceDir string, mapper mapping.IndexMapping, selectableFields []string, logger log.Logger) (preparedBuildIndex, error) {
-	indexDir, fileIndexName, err := b.reserveIndexDir(resourceDir)
-	if err != nil {
-		return preparedBuildIndex{}, err
-	}
+	for {
+		indexDir, fileIndexName, err := b.reserveIndexDir(resourceDir)
+		if err != nil {
+			return preparedBuildIndex{}, err
+		}
 
-	idx, err := newBleveIndex(indexDir, mapper, time.Now(), b.opts.BuildVersion, selectableFields)
-	if err != nil {
-		return preparedBuildIndex{}, fmt.Errorf("error creating new bleve index: %s %w", indexDir, err)
-	}
+		idx, err := newBleveIndex(indexDir, mapper, time.Now(), b.opts.BuildVersion, selectableFields)
+		if errors.Is(err, bleve.ErrorIndexPathExists) {
+			if idx != nil {
+				_ = idx.Close()
+			}
+			continue
+		}
+		if err != nil {
+			return preparedBuildIndex{}, fmt.Errorf("error creating new bleve index: %s %w", indexDir, err)
+		}
 
-	logger.Info("Building index using filesystem", "directory", indexDir)
-	b.registerInFlightBuildDir(indexDir)
-	return preparedBuildIndex{
-		index:         idx,
-		fileIndexName: fileIndexName,
-		indexStorage:  indexStorageFile,
-		source:        buildIndexSourceNew,
-		cleanupDir:    indexDir,
-	}, nil
+		logger.Info("Building index using filesystem", "directory", indexDir)
+		b.registerInFlightBuildDir(indexDir)
+		return preparedBuildIndex{
+			index:         idx,
+			fileIndexName: fileIndexName,
+			indexStorage:  indexStorageFile,
+			source:        buildIndexSourceNew,
+			cleanupDir:    indexDir,
+		}, nil
+	}
 }
 
 func (b *bleveBackend) createEmptyMemoryIndex(mapper mapping.IndexMapping, selectableFields []string, logger log.Logger) (preparedBuildIndex, error) {
@@ -1044,10 +1052,13 @@ type adaptiveBuildIndex struct {
 	// Embed the current delegate so this build-only wrapper implements resource.ResourceIndex.
 	*bleveIndex
 
-	mu        sync.Mutex
 	threshold int64
 	promote   promoteBuildIndexFunc
 
+	// mu protects promotion state below. Other ResourceIndex methods are only delegated
+	// through the embedded bleveIndex while the builder is running; builders are
+	// expected to call BulkIndex only.
+	mu            sync.Mutex
 	fileIndexName string
 	cleanupDir    string
 }

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -675,7 +675,6 @@ func (b *bleveBackend) BuildIndex(
 		attribute.String("namespace", key.Namespace),
 		attribute.String("group", key.Group),
 		attribute.String("resource", key.Resource),
-		attribute.Int64("doc_count", docCount),
 		attribute.String("reason", indexBuildReason),
 	)
 
@@ -693,22 +692,28 @@ func (b *bleveBackend) BuildIndex(
 		return nil, err
 	}
 
-	logWithDetails := b.log.FromContext(ctx).New("namespace", key.Namespace, "group", key.Group, "resource", key.Resource, "doc_count", docCount, "reason", indexBuildReason)
+	logWithDetails := b.log.FromContext(ctx).New("namespace", key.Namespace, "group", key.Group, "resource", key.Resource, "reason", indexBuildReason)
 	resourceDir := b.getResourceDir(key)
+	snapshotEnabled := b.opts.Snapshot.Store != nil && docCount >= b.opts.Snapshot.MinDocCount
 
-	prepared, err := b.prepareIndex(ctx, key, docCount, mapper, selectableFields, rebuild, lastImportTime, maxFreshSnapshotAge, resourceDir, logWithDetails)
+	prepared, err := b.prepareIndex(ctx, key, snapshotEnabled, mapper, selectableFields, rebuild, lastImportTime, maxFreshSnapshotAge, resourceDir, logWithDetails)
 	if err != nil {
 		return nil, err
 	}
 
 	// prepareIndex's helpers register the working directory before returning;
 	// release that registration when BuildIndex returns, regardless of success
-	// or failure path. cleanOldIndexes still runs before this defer fires, so
-	// our own dir is protected via skipName during the cleanup.
+	// or failure path. Adaptive promotion can also register a directory while
+	// the builder is running, so keep this path mutable.
+	var inFlightDir string
 	if prepared.fileIndexName != "" {
-		inFlightDir := filepath.Join(resourceDir, prepared.fileIndexName)
-		defer b.unregisterInFlightBuildDir(inFlightDir)
+		inFlightDir = filepath.Join(resourceDir, prepared.fileIndexName)
 	}
+	defer func() {
+		if inFlightDir != "" {
+			b.unregisterInFlightBuildDir(inFlightDir)
+		}
+	}()
 
 	if prepared.coldStartLeaderLock != nil {
 		defer func() {
@@ -746,8 +751,27 @@ func (b *bleveBackend) BuildIndex(
 	idx := b.newBleveIndex(key, prepared.index, prepared.indexStorage, fields, allFields, standardSearchFields, updater, b.log.New("namespace", key.Namespace, "group", key.Group, "resource", key.Resource))
 
 	if prepared.source.needsBuild() {
-		if err := b.buildIndexFromScratch(idx, indexBuildReason, builder, logWithDetails); err != nil {
-			return nil, err
+		// Type-convert so buildIndexFromScratch can call updateResourceVersion after the builder returns.
+		buildTarget := buildResourceIndex(idx)
+		var adaptive *adaptiveBuildIndex
+		if prepared.indexStorage == indexStorageMemory && b.opts.FileThreshold > 0 {
+			adaptive = newAdaptiveBuildIndex(idx, b.opts.FileThreshold, func(delegate *bleveIndex) (*bleveIndex, string, string, error) {
+				return b.promoteBuildIndexToFile(delegate, key, resourceDir, fields, allFields, standardSearchFields, updater, logWithDetails)
+			})
+			buildTarget = adaptive
+		}
+
+		buildErr := b.buildIndexFromScratch(buildTarget, indexBuildReason, builder, logWithDetails)
+		if adaptive != nil {
+			idx, prepared.fileIndexName, prepared.cleanupDir = adaptive.finalState()
+			prepared.index = idx.index
+			prepared.indexStorage = idx.indexStorage
+			if prepared.fileIndexName != "" {
+				inFlightDir = filepath.Join(resourceDir, prepared.fileIndexName)
+			}
+		}
+		if buildErr != nil {
+			return nil, buildErr
 		}
 		if prepared.coldStartLeaderLock != nil {
 			b.uploadColdStartLeaderSnapshot(ctx, key, idx, prepared.coldStartLeaderLock, logWithDetails)
@@ -812,7 +836,7 @@ func (b *bleveBackend) BuildIndex(
 func (b *bleveBackend) prepareIndex(
 	ctx context.Context,
 	key resource.NamespacedResource,
-	docCount int64,
+	snapshotEnabled bool,
 	mapper mapping.IndexMapping,
 	selectableFields []string,
 	rebuild bool,
@@ -821,11 +845,6 @@ func (b *bleveBackend) prepareIndex(
 	resourceDir string,
 	logger log.Logger,
 ) (preparedBuildIndex, error) {
-	if docCount < b.opts.FileThreshold {
-		return b.createEmptyMemoryIndex(mapper, selectableFields, logger)
-	}
-
-	snapshotEnabled := b.opts.Snapshot.Store != nil && docCount >= b.opts.Snapshot.MinDocCount
 	cachedIndex := b.getCachedIndex(key, time.Now())
 
 	// We only check for the existing file-based index if we don't already have an open index for this key,
@@ -862,7 +881,7 @@ func (b *bleveBackend) prepareIndex(
 		}
 	}
 
-	return b.createEmptyFileIndex(resourceDir, mapper, selectableFields, logger)
+	return b.createEmptyBuildIndex(resourceDir, mapper, selectableFields, logger)
 }
 
 func (b *bleveBackend) prepareUncachedFileIndex(
@@ -890,7 +909,7 @@ func (b *bleveBackend) prepareUncachedFileIndex(
 	}
 
 	if !snapshotEnabled {
-		return b.createEmptyFileIndex(resourceDir, mapper, selectableFields, logger)
+		return b.createEmptyBuildIndex(resourceDir, mapper, selectableFields, logger)
 	}
 
 	idx, name, rv, err = b.tryDownloadRemoteSnapshot(ctx, key, resourceDir, logger)
@@ -924,7 +943,7 @@ func (b *bleveBackend) prepareUncachedFileIndex(
 			source:        buildIndexSourceDownloadedSnapshot,
 		}, nil
 	} else if lock != nil {
-		prepared, err := b.createEmptyFileIndex(resourceDir, mapper, selectableFields, logger)
+		prepared, err := b.createEmptyBuildIndex(resourceDir, mapper, selectableFields, logger)
 		if err != nil {
 			if releaseErr := lock.Release(); releaseErr != nil {
 				logger.Warn("Releasing cold-start build lock", "err", releaseErr)
@@ -935,7 +954,7 @@ func (b *bleveBackend) prepareUncachedFileIndex(
 		return prepared, nil
 	}
 
-	return b.createEmptyFileIndex(resourceDir, mapper, selectableFields, logger)
+	return b.createEmptyBuildIndex(resourceDir, mapper, selectableFields, logger)
 }
 
 func (b *bleveBackend) tryReuseFileIndex(resourceDir string, lastImportTime time.Time, logger log.Logger) (bleve.Index, string, int64, error) {
@@ -967,28 +986,22 @@ func (b *bleveBackend) tryReuseFileIndex(resourceDir string, lastImportTime time
 	return nil, "", 0, nil
 }
 
-func (b *bleveBackend) createEmptyFileIndex(resourceDir string, mapper mapping.IndexMapping, selectableFields []string, logger log.Logger) (preparedBuildIndex, error) {
-	indexDir := ""
-	var idx bleve.Index
-	var err error
-	now := time.Now()
-	fileIndexName := ""
-	for idx == nil {
-		fileIndexName = formatIndexName(now)
-		indexDir = filepath.Join(resourceDir, fileIndexName)
-		if !isPathWithinRoot(indexDir, b.opts.Root) {
-			return preparedBuildIndex{}, fmt.Errorf("invalid path %s", indexDir)
-		}
+func (b *bleveBackend) createEmptyBuildIndex(resourceDir string, mapper mapping.IndexMapping, selectableFields []string, logger log.Logger) (preparedBuildIndex, error) {
+	if b.opts.FileThreshold <= 0 {
+		return b.createEmptyFileIndex(resourceDir, mapper, selectableFields, logger)
+	}
+	return b.createEmptyMemoryIndex(mapper, selectableFields, logger)
+}
 
-		idx, err = newBleveIndex(indexDir, mapper, time.Now(), b.opts.BuildVersion, selectableFields)
-		if errors.Is(err, bleve.ErrorIndexPathExists) {
-			now = now.Add(time.Second) // Bump time for next try
-			idx = nil                  // Bleve actually returns non-nil value with ErrorIndexPathExists
-			continue
-		}
-		if err != nil {
-			return preparedBuildIndex{}, fmt.Errorf("error creating new bleve index: %s %w", indexDir, err)
-		}
+func (b *bleveBackend) createEmptyFileIndex(resourceDir string, mapper mapping.IndexMapping, selectableFields []string, logger log.Logger) (preparedBuildIndex, error) {
+	indexDir, fileIndexName, err := b.reserveIndexDir(resourceDir)
+	if err != nil {
+		return preparedBuildIndex{}, err
+	}
+
+	idx, err := newBleveIndex(indexDir, mapper, time.Now(), b.opts.BuildVersion, selectableFields)
+	if err != nil {
+		return preparedBuildIndex{}, fmt.Errorf("error creating new bleve index: %s %w", indexDir, err)
 	}
 
 	logger.Info("Building index using filesystem", "directory", indexDir)
@@ -1015,7 +1028,140 @@ func (b *bleveBackend) createEmptyMemoryIndex(mapper mapping.IndexMapping, selec
 	}, nil
 }
 
-func (b *bleveBackend) buildIndexFromScratch(idx *bleveIndex, indexBuildReason string, builder resource.BuildFn, logger log.Logger) error {
+type buildResourceIndex interface {
+	resource.ResourceIndex
+	updateResourceVersion(rv int64) error
+}
+
+type promoteBuildIndexFunc func(*bleveIndex) (*bleveIndex, string, string, error)
+
+// adaptiveBuildIndex is used only while a from-scratch build is running. It
+// starts with a memory-backed delegate and promotes that delegate to a
+// filesystem-backed index once the successful build writes enough documents to
+// cross FileThreshold. The cached index is the final delegate, not this wrapper,
+// so incremental updates never trigger promotion.
+type adaptiveBuildIndex struct {
+	// Embed the current delegate so this build-only wrapper implements resource.ResourceIndex.
+	*bleveIndex
+
+	mu        sync.Mutex
+	threshold int64
+	promote   promoteBuildIndexFunc
+
+	fileIndexName string
+	cleanupDir    string
+}
+
+var _ resource.ResourceIndex = &adaptiveBuildIndex{}
+
+func newAdaptiveBuildIndex(delegate *bleveIndex, threshold int64, promote promoteBuildIndexFunc) *adaptiveBuildIndex {
+	return &adaptiveBuildIndex{
+		bleveIndex: delegate,
+		threshold:  threshold,
+		promote:    promote,
+	}
+}
+
+func (a *adaptiveBuildIndex) BulkIndex(req *resource.BulkIndexRequest) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if err := a.bleveIndex.BulkIndex(req); err != nil {
+		return err
+	}
+	if a.fileIndexName != "" {
+		return nil
+	}
+
+	count, err := a.bleveIndex.index.DocCount()
+	if err != nil {
+		return err
+	}
+	if int64(count) < a.threshold {
+		return nil
+	}
+
+	promoted, fileIndexName, cleanupDir, err := a.promote(a.bleveIndex)
+	if err != nil {
+		return err
+	}
+	a.bleveIndex = promoted
+	a.fileIndexName = fileIndexName
+	a.cleanupDir = cleanupDir
+	return nil
+}
+
+func (a *adaptiveBuildIndex) updateResourceVersion(rv int64) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.bleveIndex.updateResourceVersion(rv)
+}
+
+func (a *adaptiveBuildIndex) finalState() (*bleveIndex, string, string) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.bleveIndex, a.fileIndexName, a.cleanupDir
+}
+
+func (b *bleveBackend) promoteBuildIndexToFile(
+	delegate *bleveIndex,
+	key resource.NamespacedResource,
+	resourceDir string,
+	fields resource.SearchableDocumentFields,
+	allFields []*resourcepb.ResourceTableColumnDefinition,
+	standardSearchFields resource.SearchableDocumentFields,
+	updater resource.UpdateFn,
+	logger log.Logger,
+) (*bleveIndex, string, string, error) {
+	copyable, ok := delegate.index.(bleve.IndexCopyable)
+	if !ok {
+		return nil, "", "", fmt.Errorf("index does not support copy")
+	}
+
+	indexDir, fileIndexName, err := b.reserveIndexDir(resourceDir)
+	if err != nil {
+		return nil, "", "", err
+	}
+	b.registerInFlightBuildDir(indexDir)
+	cleanup := true
+	defer func() {
+		if cleanup {
+			b.unregisterInFlightBuildDir(indexDir)
+			if removeErr := os.RemoveAll(indexDir); removeErr != nil {
+				logger.Error("Failed to remove promoted index directory after promotion failure", "directory", indexDir, "err", removeErr)
+			}
+		}
+	}()
+
+	if err := copyable.CopyTo(bleve.FileSystemDirectory(indexDir)); err != nil {
+		return nil, "", "", fmt.Errorf("copying index to filesystem: %w", err)
+	}
+
+	fileIndex, err := bleve.OpenUsing(indexDir, map[string]interface{}{"bolt_timeout": boltTimeout})
+	if err != nil {
+		return nil, "", "", fmt.Errorf("opening promoted filesystem index: %w", err)
+	}
+
+	promoted := b.newBleveIndex(key, fileIndex, indexStorageFile, fields, allFields, standardSearchFields, updater, delegate.logger)
+	promoted.resourceVersion.Store(delegate.resourceVersion.Load())
+	cleanup = false
+
+	if err := delegate.index.Close(); err != nil {
+		logger.Warn("Failed to close memory index after promotion", "err", err)
+	}
+	logger.Info("Promoted index build to filesystem", "directory", indexDir, "doc_count", countDocsForLog(fileIndex))
+	return promoted, fileIndexName, indexDir, nil
+}
+
+func countDocsForLog(index bleve.Index) uint64 {
+	count, err := index.DocCount()
+	if err != nil {
+		return 0
+	}
+	return count
+}
+
+func (b *bleveBackend) buildIndexFromScratch(idx buildResourceIndex, indexBuildReason string, builder resource.BuildFn, logger log.Logger) error {
 	if b.indexMetrics != nil {
 		b.indexMetrics.IndexBuilds.WithLabelValues(indexBuildReason).Inc()
 	}

--- a/pkg/storage/unified/search/bleve_lifecycle_test.go
+++ b/pkg/storage/unified/search/bleve_lifecycle_test.go
@@ -266,7 +266,7 @@ func dashboardSearchLifecycleSeed(t *testing.T) int64 {
 func newFileBackedDashboardIndex(t *testing.T, key resource.NamespacedResource, docCount int64) *bleveIndex {
 	t.Helper()
 
-	backend, _ := setupBleveBackend(t, withFileThreshold(1))
+	backend, _ := setupBleveBackend(t, withFileThreshold(0))
 	ctx := identity.WithRequester(t.Context(), &user.SignedInUser{Namespace: key.Namespace})
 
 	info, err := builders.DashboardBuilder(func(ctx context.Context, namespace string, blob resource.BlobSupport) (resource.DocumentBuilder, error) {

--- a/pkg/storage/unified/search/bleve_performance_test.go
+++ b/pkg/storage/unified/search/bleve_performance_test.go
@@ -7,8 +7,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/services/store/kind/dashboard"
+	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+	"github.com/grafana/grafana/pkg/storage/unified/search"
+	"github.com/grafana/grafana/pkg/storage/unified/search/builders"
 
 	"github.com/stretchr/testify/require"
 )
@@ -34,6 +39,63 @@ const verbose = false
 func BenchmarkBleveQuery(b *testing.B) {
 	testIndex := setupIndex(b)
 	runBenchmark(b, testIndex)
+}
+
+// BenchmarkBleveBuildIndexStorageSelection compares direct filesystem builds
+// with adaptive memory-to-filesystem builds. It is intended to catch obvious
+// regressions in adaptive promotion overhead, not to model end-to-end search
+// server build latency.
+func BenchmarkBleveBuildIndexStorageSelection(b *testing.B) {
+	for _, docs := range []int{100, 1000} {
+		b.Run(fmt.Sprintf("docs=%d", docs), func(b *testing.B) {
+			b.Run("direct-file", func(b *testing.B) {
+				benchmarkBuildIndex(b, docs, 0)
+			})
+			b.Run("adaptive", func(b *testing.B) {
+				benchmarkBuildIndex(b, docs, 50)
+			})
+		})
+	}
+}
+
+func benchmarkBuildIndex(b *testing.B, docs int, fileThreshold int64) {
+	backend, err := search.NewBleveBackend(search.BleveOptions{
+		Root:          b.TempDir(),
+		FileThreshold: fileThreshold,
+		BuildVersion:  "12.3.45-789",
+	}, nil)
+	require.NoError(b, err)
+	defer backend.Stop()
+
+	ctx := identity.WithRequester(context.Background(), &user.SignedInUser{Namespace: "ns"})
+	key := resource.NamespacedResource{
+		Namespace: "default",
+		Group:     "dashboard.grafana.app",
+		Resource:  "dashboards",
+	}
+	info, err := builders.DashboardBuilder(func(ctx context.Context, namespace string, blob resource.BlobSupport) (resource.DocumentBuilder, error) {
+		return &builders.DashboardDocumentBuilder{
+			Namespace:        namespace,
+			Blob:             blob,
+			Stats:            make(map[string]map[string]int64),
+			DatasourceLookup: dashboard.CreateDatasourceLookup([]*dashboard.DatasourceQueryResult{{}}),
+		}, nil
+	})
+	require.NoError(b, err)
+	writer := newTestWriter(docs, docs)
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		idx, err := backend.BuildIndex(ctx, key, int64(docs), info.Fields, "benchmark", writer, nil, true, time.Time{}, 0)
+		require.NoError(b, err)
+
+		b.StopTimer()
+		count, err := idx.DocCount(ctx, "", nil)
+		require.NoError(b, err)
+		require.Equal(b, int64(docs), count)
+		b.StartTimer()
+	}
 }
 
 func runBenchmark(b *testing.B, testIndex resource.ResourceIndex) {

--- a/pkg/storage/unified/search/bleve_snapshot.go
+++ b/pkg/storage/unified/search/bleve_snapshot.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"slices"
 	"sort"
 	"strconv"
@@ -251,20 +250,18 @@ func (b *bleveBackend) downloadSelectedSnapshot(
 	}
 	logger = logger.New(logFields...)
 
-	// Pick a fresh destination directory name. DownloadIndexSnapshot refuses to
-	// overwrite an existing destDir; the bump-on-exists loop mirrors what
-	// BuildIndex does when creating new file-based indexes.
+	// Pick and reserve a fresh destination directory name. DownloadIndexSnapshot
+	// refuses to overwrite an existing destDir, so reserveIndexDir protects the
+	// not-yet-created path from other in-process builds while we download.
 	destDir, name, err := b.reserveIndexDir(resourceDir)
 	if err != nil {
 		outcome = snapshotStatusDownloadError
 		return nil, "", 0, fmt.Errorf("reserving local snapshot dir: %w", err)
 	}
 
-	// Protect destDir from cleanOldIndexes for the duration of the download
-	// and validation. On success, ownership of the registration transfers to
-	// the caller (BuildIndex unregisters via its own defer); on any failure
-	// path below, this defer releases it.
-	b.registerInFlightBuildDir(destDir)
+	// On success, ownership of the reservation transfers to the caller
+	// (BuildIndex unregisters via its own defer); on any failure path below,
+	// this defer releases it.
 	defer func() {
 		if retErr != nil {
 			b.unregisterInFlightBuildDir(destDir)
@@ -416,31 +413,6 @@ func snapshotTier(v, minVersion, running *semver.Version) int {
 		return 1 // below preferred floor
 	}
 	return 0
-}
-
-// reserveIndexDir returns an absolute path (and its base name) inside
-// resourceDir that does not exist yet. It bumps the timestamp if a collision
-// happens.
-func (b *bleveBackend) reserveIndexDir(resourceDir string) (string, string, error) {
-	if err := os.MkdirAll(resourceDir, 0o750); err != nil {
-		return "", "", err
-	}
-
-	t := time.Now()
-	for {
-		name := formatIndexName(t)
-		dir := filepath.Join(resourceDir, name)
-		if !isPathWithinRoot(dir, b.opts.Root) {
-			return "", "", fmt.Errorf("invalid path %s", dir)
-		}
-		if _, err := os.Stat(dir); err != nil {
-			if errors.Is(err, os.ErrNotExist) {
-				return dir, name, nil
-			}
-			return "", "", err
-		}
-		t = t.Add(time.Second)
-	}
 }
 
 // validateDownloadedIndex reads the internal RV + buildInfo from the opened

--- a/pkg/storage/unified/search/bleve_snapshot.go
+++ b/pkg/storage/unified/search/bleve_snapshot.go
@@ -254,7 +254,7 @@ func (b *bleveBackend) downloadSelectedSnapshot(
 	// Pick a fresh destination directory name. DownloadIndexSnapshot refuses to
 	// overwrite an existing destDir; the bump-on-exists loop mirrors what
 	// BuildIndex does when creating new file-based indexes.
-	destDir, name, err := b.reserveSnapshotDir(resourceDir)
+	destDir, name, err := b.reserveIndexDir(resourceDir)
 	if err != nil {
 		outcome = snapshotStatusDownloadError
 		return nil, "", 0, fmt.Errorf("reserving local snapshot dir: %w", err)
@@ -418,10 +418,10 @@ func snapshotTier(v, minVersion, running *semver.Version) int {
 	return 0
 }
 
-// reserveSnapshotDir returns an absolute path (and its base name) inside
+// reserveIndexDir returns an absolute path (and its base name) inside
 // resourceDir that does not exist yet. It bumps the timestamp if a collision
-// happens, mirroring the fresh-build naming in BuildIndex.
-func (b *bleveBackend) reserveSnapshotDir(resourceDir string) (string, string, error) {
+// happens.
+func (b *bleveBackend) reserveIndexDir(resourceDir string) (string, string, error) {
 	if err := os.MkdirAll(resourceDir, 0o750); err != nil {
 		return "", "", err
 	}

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -1497,6 +1497,26 @@ func TestCleanOldIndexes(t *testing.T) {
 	})
 }
 
+func TestReserveIndexDirSkipsInFlightReservation(t *testing.T) {
+	dir := t.TempDir()
+	b, _ := setupBleveBackend(t, withRootDir(dir))
+	resourceDir := filepath.Join(dir, "resource")
+
+	firstDir, firstName, err := b.reserveIndexDir(resourceDir)
+	require.NoError(t, err)
+	defer b.unregisterInFlightBuildDir(firstDir)
+
+	secondDir, secondName, err := b.reserveIndexDir(resourceDir)
+	require.NoError(t, err)
+	defer b.unregisterInFlightBuildDir(secondDir)
+
+	require.NotEqual(t, firstName, secondName)
+	require.NotEqual(t, firstDir, secondDir)
+	require.NoDirExists(t, firstDir)
+	require.NoDirExists(t, secondDir)
+	require.Len(t, b.inFlightBuildDirs, 2)
+}
+
 func dirEntryNames(t *testing.T, dir string) []string {
 	t.Helper()
 	entries, err := os.ReadDir(dir)

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -934,6 +934,84 @@ func withIndexMinUpdateInterval(d time.Duration) setupOption {
 	}
 }
 
+func TestMemoryBleveIndexCanBeCopiedToFilesystem(t *testing.T) {
+	mapper, err := GetBleveMappings(nil, nil)
+	require.NoError(t, err)
+
+	buildTime := time.Date(2026, 5, 18, 10, 0, 0, 0, time.UTC)
+	selectableFields := []string{"team"}
+	source, err := newBleveIndex("", mapper, buildTime, buildVersion, selectableFields)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, source.Close()) }()
+
+	key := &resourcepb.ResourceKey{
+		Namespace: "default",
+		Group:     "dashboard.grafana.app",
+		Resource:  "dashboards",
+		Name:      "dash-1",
+	}
+	wrapped := &bleveIndex{index: source}
+	require.NoError(t, wrapped.BulkIndex(&resource.BulkIndexRequest{Items: []*resource.BulkIndexItem{
+		{
+			Action: resource.ActionIndex,
+			Doc: &resource.IndexableDocument{
+				Key:   key,
+				Name:  key.Name,
+				Title: "Production Overview",
+			},
+		},
+		{
+			Action: resource.ActionIndex,
+			Doc: &resource.IndexableDocument{
+				Key: &resourcepb.ResourceKey{
+					Namespace: key.Namespace,
+					Group:     key.Group,
+					Resource:  key.Resource,
+					Name:      "dash-2",
+				},
+				Name:  "dash-2",
+				Title: "Staging Overview",
+			},
+		},
+	}}))
+	require.NoError(t, setRV(source, 42))
+
+	copyable, ok := source.(bleve.IndexCopyable)
+	require.True(t, ok)
+
+	destDir := filepath.Join(t.TempDir(), "filesystem-index")
+	require.NoError(t, copyable.CopyTo(bleve.FileSystemDirectory(destDir)))
+
+	copied, err := bleve.OpenUsing(destDir, map[string]interface{}{"bolt_timeout": boltTimeout})
+	require.NoError(t, err)
+	defer func() { require.NoError(t, copied.Close()) }()
+
+	count, err := copied.DocCount()
+	require.NoError(t, err)
+	assert.Equal(t, uint64(2), count)
+
+	query := bleve.NewTermQuery("production overview")
+	query.SetField(resource.SEARCH_FIELD_TITLE_PHRASE)
+	result, err := copied.Search(bleve.NewSearchRequest(query))
+	require.NoError(t, err)
+	require.Len(t, result.Hits, 1)
+	assert.Equal(t, resource.SearchID(key), result.Hits[0].ID)
+
+	rv, err := getRV(copied)
+	require.NoError(t, err)
+	assert.Equal(t, int64(42), rv)
+
+	buildInfo, err := getBuildInfo(copied)
+	require.NoError(t, err)
+	assert.Equal(t, buildTime.Unix(), buildInfo.BuildTime)
+	assert.Equal(t, buildVersion, buildInfo.BuildVersion)
+	assert.Equal(t, selectableFields, buildInfo.SelectableFields)
+
+	snapshotMutationCount, err := readSnapshotMutationCount(copied)
+	require.NoError(t, err)
+	assert.Equal(t, int64(2), snapshotMutationCount)
+}
+
 func TestBuildIndexExpiration(t *testing.T) {
 	ns := resource.NamespacedResource{
 		Namespace: "test",

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -1065,11 +1065,11 @@ func TestBuildIndexExpiration(t *testing.T) {
 				return tc.owned, tc.ownedCheckError
 			}))
 
-			size := int64(1)
+			docs := 1
 			if !tc.inMemory {
-				size = 100 // above defaultFileTreshold
+				docs = defaultFileThreshold
 			}
-			builtIndex, err := backend.BuildIndex(context.Background(), ns, size, nil, "test", indexTestDocs(ns, 1, 100), nil, false, time.Time{}, 0)
+			builtIndex, err := backend.BuildIndex(context.Background(), ns, int64(docs), nil, "test", indexTestDocs(ns, docs, 100), nil, false, time.Time{}, 0)
 			require.NoError(t, err)
 
 			// Evict indexes.
@@ -1090,7 +1090,7 @@ func TestBuildIndexExpiration(t *testing.T) {
 
 				cnt, err := builtIndex.DocCount(context.Background(), "", nil)
 				require.NoError(t, err)
-				require.Equal(t, int64(1), cnt)
+				require.Equal(t, int64(docs), cnt)
 
 				// Verify that index is still open
 				if tc.inMemory {
@@ -1119,7 +1119,7 @@ func TestCloseAllIndexes(t *testing.T) {
 	backend1, reg := setupBleveBackend(t, withRootDir(tmpDir))
 	_, err := backend1.BuildIndex(context.Background(), ns, 10 /* file based */, nil, "test", indexTestDocs(ns, 10, 100), nil, false, time.Time{}, 0)
 	require.NoError(t, err)
-	_, err = backend1.BuildIndex(context.Background(), ns2, 1 /* memory based */, nil, "test", indexTestDocs(ns, 10, 100), nil, false, time.Time{}, 0)
+	_, err = backend1.BuildIndex(context.Background(), ns2, 1 /* memory based */, nil, "test", indexTestDocs(ns2, 1, 100), nil, false, time.Time{}, 0)
 	require.NoError(t, err)
 
 	// Verify two open indexes.
@@ -1180,6 +1180,107 @@ func TestBuildIndex(t *testing.T) {
 	}
 }
 
+func TestBuildIndexAdaptivePromotion(t *testing.T) {
+	ns := resource.NamespacedResource{
+		Namespace: "test",
+		Group:     "group",
+		Resource:  "resource",
+	}
+
+	t.Run("small build stays in memory", func(t *testing.T) {
+		backend, reg := setupBleveBackend(t, withFileThreshold(5))
+
+		idx, err := backend.BuildIndex(t.Context(), ns, 100, nil, "test", indexTestDocs(ns, 4, 100), nil, false, time.Time{}, 0)
+		require.NoError(t, err)
+
+		bleveIdx := idx.(*bleveIndex)
+		assert.Equal(t, indexStorageMemory, bleveIdx.indexStorage)
+		assert.False(t, bleveIdx.expiration.IsZero())
+		verifyDirEntriesCount(t, backend.getResourceDir(ns), 0)
+		checkOpenIndexes(t, reg, 1, 0)
+	})
+
+	t.Run("build crossing threshold promotes to filesystem", func(t *testing.T) {
+		backend, reg := setupBleveBackend(t, withFileThreshold(5))
+
+		idx, err := backend.BuildIndex(t.Context(), ns, 1, nil, "test", indexTestDocs(ns, 5, 100), nil, false, time.Time{}, 0)
+		require.NoError(t, err)
+
+		bleveIdx := idx.(*bleveIndex)
+		assert.Equal(t, indexStorageFile, bleveIdx.indexStorage)
+		assert.True(t, bleveIdx.expiration.IsZero())
+		verifyDirEntriesCount(t, backend.getResourceDir(ns), 1)
+		checkOpenIndexes(t, reg, 0, 1)
+
+		cnt, err := idx.DocCount(t.Context(), "", nil)
+		require.NoError(t, err)
+		assert.Equal(t, int64(5), cnt)
+
+		resp := searchTitle(t, idx, "Document", 10, ns)
+		assert.Equal(t, int64(5), resp.TotalHits)
+
+		assert.Equal(t, int64(100), bleveIdx.resourceVersion.Load())
+		rv, err := getRV(bleveIdx.index)
+		require.NoError(t, err)
+		assert.Equal(t, int64(100), rv)
+
+		buildInfo, err := getBuildInfo(bleveIdx.index)
+		require.NoError(t, err)
+		assert.Equal(t, buildVersion, buildInfo.BuildVersion)
+		assert.NotZero(t, buildInfo.BuildTime)
+
+		mutationCount, err := bleveIdx.getSnapshotMutationCount()
+		require.NoError(t, err)
+		assert.Equal(t, int64(5), mutationCount)
+	})
+
+	t.Run("incremental update does not promote memory index", func(t *testing.T) {
+		backend, reg := setupBleveBackend(t, withFileThreshold(5))
+
+		idx, err := backend.BuildIndex(t.Context(), ns, 1, nil, "test", indexTestDocs(ns, 1, 100), updateTestDocs(ns, 5), false, time.Time{}, 0)
+		require.NoError(t, err)
+		bleveIdx := idx.(*bleveIndex)
+		require.Equal(t, indexStorageMemory, bleveIdx.indexStorage)
+
+		_, err = idx.UpdateIndex(t.Context())
+		require.NoError(t, err)
+
+		assert.Equal(t, indexStorageMemory, bleveIdx.indexStorage)
+		verifyDirEntriesCount(t, backend.getResourceDir(ns), 0)
+		checkOpenIndexes(t, reg, 1, 0)
+
+		cnt, err := idx.DocCount(t.Context(), "", nil)
+		require.NoError(t, err)
+		assert.Equal(t, int64(5), cnt)
+	})
+
+	t.Run("build failure before promotion leaves no filesystem directory", func(t *testing.T) {
+		backend, _ := setupBleveBackend(t, withFileThreshold(5))
+
+		idx, err := backend.BuildIndex(t.Context(), ns, 100, nil, "test", func(resource.ResourceIndex) (int64, error) {
+			return 0, errors.New("fail before promotion")
+		}, nil, false, time.Time{}, 0)
+		require.Error(t, err)
+		require.Nil(t, idx)
+		verifyDirEntriesCount(t, backend.getResourceDir(ns), 0)
+		require.Empty(t, backend.inFlightBuildDirs)
+	})
+
+	t.Run("build failure after promotion removes filesystem directory", func(t *testing.T) {
+		backend, _ := setupBleveBackend(t, withFileThreshold(5))
+
+		idx, err := backend.BuildIndex(t.Context(), ns, 100, nil, "test", func(index resource.ResourceIndex) (int64, error) {
+			_, buildErr := indexTestDocs(ns, 5, 100)(index)
+			require.NoError(t, buildErr)
+			return 0, errors.New("fail after promotion")
+		}, nil, false, time.Time{}, 0)
+		require.Error(t, err)
+		require.Nil(t, idx)
+		verifyDirEntriesCount(t, backend.getResourceDir(ns), 0)
+		require.Empty(t, backend.inFlightBuildDirs)
+	})
+}
+
 func TestRebuildingIndexClosesPreviousCachedIndex(t *testing.T) {
 	ns := resource.NamespacedResource{
 		Namespace: "test",
@@ -1199,11 +1300,11 @@ func TestRebuildingIndexClosesPreviousCachedIndex(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			backend, reg := setupBleveBackend(t, withIndexCacheTTL(time.Nanosecond))
 
-			firstSize := 100
+			firstDocs := 100
 			if testCase.firstInMemory {
-				firstSize = 1
+				firstDocs = 1
 			}
-			firstIndex, err := backend.BuildIndex(context.Background(), ns, int64(firstSize), nil, "test", indexTestDocs(ns, firstSize, 100), nil, false, time.Time{}, 0)
+			firstIndex, err := backend.BuildIndex(context.Background(), ns, int64(firstDocs), nil, "test", indexTestDocs(ns, firstDocs, 100), nil, false, time.Time{}, 0)
 			require.NoError(t, err)
 
 			if testCase.firstInMemory {
@@ -1214,12 +1315,12 @@ func TestRebuildingIndexClosesPreviousCachedIndex(t *testing.T) {
 
 			openInMemoryIndexes := 0
 
-			secondSize := 100
+			secondDocs := 100
 			if testCase.secondInMemory {
-				secondSize = 1
+				secondDocs = 1
 				openInMemoryIndexes = 1
 			}
-			secondIndex, err := backend.BuildIndex(context.Background(), ns, int64(secondSize), nil, "test", indexTestDocs(ns, secondSize, 100), nil, false, time.Time{}, 0)
+			secondIndex, err := backend.BuildIndex(context.Background(), ns, int64(secondDocs), nil, "test", indexTestDocs(ns, secondDocs, 100), nil, false, time.Time{}, 0)
 			require.NoError(t, err)
 
 			if testCase.secondInMemory {
@@ -1236,7 +1337,7 @@ func TestRebuildingIndexClosesPreviousCachedIndex(t *testing.T) {
 
 			cnt, err := secondIndex.DocCount(context.Background(), "", nil)
 			require.NoError(t, err)
-			require.Equal(t, int64(secondSize), cnt)
+			require.Equal(t, int64(secondDocs), cnt)
 
 			checkOpenIndexes(t, reg, openInMemoryIndexes, 1-openInMemoryIndexes)
 		})
@@ -1422,21 +1523,30 @@ func TestBuildIndexConcurrentBuildsForSameKeyDoNotDeleteEachOthersDirs(t *testin
 	// the cold-start reuse path (which would otherwise collide on the bolt
 	// lock of the already-open initial index).
 	_, err := backend.BuildIndex(t.Context(), ns, 100, nil, "init",
-		func(_ resource.ResourceIndex) (int64, error) { return 1, nil },
+		indexTestDocs(ns, 1, 1),
 		nil, false, time.Time{}, 0)
 	require.NoError(t, err)
 	initDirs := dirEntryNames(t, resourceDir)
 	require.Len(t, initDirs, 1)
 
-	// Start build A and park its builder, so A's directory is on disk and
-	// registered as in-flight while B runs.
+	// Start build A and park its builder after promotion, so A's directory is on
+	// disk and registered as in-flight while B runs.
 	aEntered := make(chan struct{})
 	aRelease := make(chan struct{})
 	aDone := make(chan struct{})
 	go func() {
 		defer close(aDone)
 		_, _ = backend.BuildIndex(t.Context(), ns, 100, nil, "build-a",
-			func(_ resource.ResourceIndex) (int64, error) {
+			func(index resource.ResourceIndex) (int64, error) {
+				if err := index.BulkIndex(&resource.BulkIndexRequest{Items: []*resource.BulkIndexItem{{
+					Action: resource.ActionIndex,
+					Doc: &resource.IndexableDocument{
+						Key:   &resourcepb.ResourceKey{Namespace: ns.Namespace, Group: ns.Group, Resource: ns.Resource, Name: "doc-a"},
+						Title: "Document A",
+					},
+				}}}); err != nil {
+					return 0, err
+				}
 				close(aEntered)
 				<-aRelease
 				return 1, nil
@@ -1456,7 +1566,7 @@ func TestBuildIndexConcurrentBuildsForSameKeyDoNotDeleteEachOthersDirs(t *testin
 
 	// Run B to completion. B's cleanOldIndexes runs while A is still in flight.
 	_, err = backend.BuildIndex(t.Context(), ns, 100, nil, "build-b",
-		func(_ resource.ResourceIndex) (int64, error) { return 2, nil },
+		indexTestDocs(ns, 1, 2),
 		nil, true, time.Time{}, 0)
 	require.NoError(t, err)
 
@@ -1526,18 +1636,21 @@ func testBleveIndexWithFailures(t *testing.T, fileBased bool) {
 		Resource:  "resource",
 	}
 
-	size := int64(1)
+	docs := 1
 	if fileBased {
-		// size=100 is above FileThreshold (5), make it a file-based index.
-		size = 100
+		docs = defaultFileThreshold
 	}
-	_, err := backend.BuildIndex(context.Background(), ns, size, nil, "test", func(index resource.ResourceIndex) (int64, error) {
+	_, err := backend.BuildIndex(context.Background(), ns, int64(docs), nil, "test", func(index resource.ResourceIndex) (int64, error) {
+		if fileBased {
+			_, buildErr := indexTestDocs(ns, docs, 100)(index)
+			require.NoError(t, buildErr)
+		}
 		return 0, fmt.Errorf("fail")
 	}, nil, false, time.Time{}, 0)
 	require.Error(t, err)
 
 	// Even though previous build of the index failed, new building of the index should work.
-	_, err = backend.BuildIndex(context.Background(), ns, size, nil, "test", indexTestDocs(ns, int(size), 100), nil, false, time.Time{}, 0)
+	_, err = backend.BuildIndex(context.Background(), ns, int64(docs), nil, "test", indexTestDocs(ns, docs, 100), nil, false, time.Time{}, 0)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
Add adaptive initial-build promotion for Bleve search indexes.

New from-scratch builds now start in memory and promote to a filesystem-backed index once the indexed document count reaches `FileThreshold`. The cached index is the final concrete `bleveIndex`, so later incremental updates do not trigger promotion.

This is a step toward removing `GetResourceStats` calls from index builds. Those calls can be expensive and slow, and we should not need them just to choose the index storage type.

A focused Bleve build benchmark shows no regression from adaptive promotion on my machine:

```
BenchmarkBleveBuildIndexStorageSelection/docs=100/direct-file-15     52.2ms/op
BenchmarkBleveBuildIndexStorageSelection/docs=100/adaptive-15        27.2ms/op
BenchmarkBleveBuildIndexStorageSelection/docs=1000/direct-file-15    125.0ms/op
BenchmarkBleveBuildIndexStorageSelection/docs=1000/adaptive-15       96.7ms/op
```