### PR TITLE
CI: update frontend coverage job to use updated access pattern for tokens from GitHub App

### DIFF
--- a/.github/workflows/check-frontend-test-coverage.yml
+++ b/.github/workflows/check-frontend-test-coverage.yml
@@ -93,12 +93,14 @@ jobs:
       - name: Generate GitHub App token
         id: generate_token
         uses: actions/create-github-app-token@v1
+        continue-on-error: true
         with:
           app-id: ${{ env.GITHUB_APP_ID }}
           private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
 
       - name: Delete coverage comment for ${{ matrix.codeowner }}
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        if: steps.generate_token.outcome == 'success'
         with:
           header: coverage-report-${{ matrix.codeowner }}
           delete: true
@@ -124,12 +126,14 @@ jobs:
       - name: Generate GitHub App token
         id: generate_token
         uses: actions/create-github-app-token@v1
+        continue-on-error: true
         with:
           app-id: ${{ env.GITHUB_APP_ID }}
           private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
 
       - name: Generate skip message
         id: skip-message
+        if: steps.generate_token.outcome == 'success'
         run: |
           TEAMS='${{ needs.setup.outputs.opted-in-teams }}'
           TEAM_LIST=$(echo "$TEAMS" | jq -r '.[] | "- `" + . + "`"' | tr '\n' '\n')
@@ -148,6 +152,7 @@ jobs:
 
       - name: Post skip warning comment
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        if: steps.generate_token.outcome == 'success'
         with:
           header: coverage-skip-warning
           message: ${{ steps.skip-message.outputs.message }}
@@ -172,12 +177,14 @@ jobs:
       - name: Generate GitHub App token
         id: generate_token
         uses: actions/create-github-app-token@v1
+        continue-on-error: true
         with:
           app-id: ${{ env.GITHUB_APP_ID }}
           private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
 
       - name: Delete skip warning comment
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        if: steps.generate_token.outcome == 'success'
         with:
           header: coverage-skip-warning
           delete: true
@@ -237,13 +244,14 @@ jobs:
       - name: Generate GitHub App token
         if: github.event.pull_request.head.repo.fork == false
         id: generate_token
+        continue-on-error: true
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ env.GITHUB_APP_ID }}
           private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
 
       - name: Delete old coverage comment if not affected
-        if: steps.check-affected.outputs.affected == 'false' && github.event.pull_request.head.repo.fork == false
+        if: steps.generate_token.outcome == 'success' && steps.check-affected.outputs.affected == 'false' && github.event.pull_request.head.repo.fork == false
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: coverage-report-${{ matrix.codeowner }}
@@ -343,7 +351,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Post PR comment
-        if: steps.check-affected.outputs.affected == 'true' && github.event.pull_request.head.repo.fork == false
+        if: steps.generate_token.outcome == 'success' &&  steps.check-affected.outputs.affected == 'true' && github.event.pull_request.head.repo.fork == false
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: coverage-report-${{ matrix.codeowner }}

--- a/.github/workflows/check-frontend-test-coverage.yml
+++ b/.github/workflows/check-frontend-test-coverage.yml
@@ -206,7 +206,7 @@ jobs:
           github_app: grafana-ci-bot
 
       - name: Delete old coverage comment if not affected
-        if: steps.generate_token.outcome == 'success' && steps.check-affected.outputs.affected == 'false' && github.event.pull_request.head.repo.fork == false
+        if: steps.check-affected.outputs.affected == 'false' && github.event.pull_request.head.repo.fork == false
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: coverage-report-${{ matrix.codeowner }}

--- a/.github/workflows/check-frontend-test-coverage.yml
+++ b/.github/workflows/check-frontend-test-coverage.yml
@@ -82,21 +82,11 @@ jobs:
       matrix:
         codeowner: ${{ fromJSON(needs.setup.outputs.opted-in-teams) }}
     steps:
-      - name: Get Vault secrets
-        id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
-        with:
-          repo_secrets: |
-            GITHUB_APP_ID=grafana_pr_automation_app:app_id
-            GITHUB_APP_PRIVATE_KEY=grafana_pr_automation_app:app_pem
-
-      - name: Generate GitHub App token
+      - name: Get GitHub App token
         id: generate_token
-        uses: actions/create-github-app-token@v1
-        continue-on-error: true
+        uses: grafana/shared-workflows/actions/create-github-app-token@e5b7989c92b55fe3ac6dd006d6de49082ba8c507 # create-github-app-token (github-script/v9)
         with:
-          app-id: ${{ env.GITHUB_APP_ID }}
-          private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
+          github_app: grafana-ci-bot
 
       - name: Delete coverage comment for ${{ matrix.codeowner }}
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
@@ -115,25 +105,14 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - name: Get Vault secrets
-        id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
-        with:
-          repo_secrets: |
-            GITHUB_APP_ID=grafana_pr_automation_app:app_id
-            GITHUB_APP_PRIVATE_KEY=grafana_pr_automation_app:app_pem
-
-      - name: Generate GitHub App token
+      - name: Get GitHub App token
         id: generate_token
-        uses: actions/create-github-app-token@v1
-        continue-on-error: true
+        uses: grafana/shared-workflows/actions/create-github-app-token@e5b7989c92b55fe3ac6dd006d6de49082ba8c507 # create-github-app-token (github-script/v9)
         with:
-          app-id: ${{ env.GITHUB_APP_ID }}
-          private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
+          github_app: grafana-ci-bot
 
       - name: Generate skip message
         id: skip-message
-        if: steps.generate_token.outcome == 'success'
         run: |
           TEAMS='${{ needs.setup.outputs.opted-in-teams }}'
           TEAM_LIST=$(echo "$TEAMS" | jq -r '.[] | "- `" + . + "`"' | tr '\n' '\n')
@@ -152,7 +131,6 @@ jobs:
 
       - name: Post skip warning comment
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
-        if: steps.generate_token.outcome == 'success'
         with:
           header: coverage-skip-warning
           message: ${{ steps.skip-message.outputs.message }}
@@ -166,25 +144,14 @@ jobs:
       pull-requests: write
       id-token: write
     steps:
-      - name: Get Vault secrets
-        id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
-        with:
-          repo_secrets: |
-            GITHUB_APP_ID=grafana_pr_automation_app:app_id
-            GITHUB_APP_PRIVATE_KEY=grafana_pr_automation_app:app_pem
-
-      - name: Generate GitHub App token
+      - name: Get GitHub App token
         id: generate_token
-        uses: actions/create-github-app-token@v1
-        continue-on-error: true
+        uses: grafana/shared-workflows/actions/create-github-app-token@e5b7989c92b55fe3ac6dd006d6de49082ba8c507 # create-github-app-token (github-script/v9)
         with:
-          app-id: ${{ env.GITHUB_APP_ID }}
-          private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
+          github_app: grafana-ci-bot
 
       - name: Delete skip warning comment
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
-        if: steps.generate_token.outcome == 'success'
         with:
           header: coverage-skip-warning
           delete: true
@@ -232,23 +199,11 @@ jobs:
           echo "affected=$AFFECTED" >> "$GITHUB_OUTPUT"
           echo "Codeowner ${{ matrix.codeowner }} affected: $AFFECTED"
 
-      - name: Get Vault secrets
-        if: github.event.pull_request.head.repo.fork == false
-        id: get-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main
-        with:
-          repo_secrets: |
-            GITHUB_APP_ID=grafana_pr_automation_app:app_id
-            GITHUB_APP_PRIVATE_KEY=grafana_pr_automation_app:app_pem
-
-      - name: Generate GitHub App token
-        if: github.event.pull_request.head.repo.fork == false
+      - name: Get GitHub App token
         id: generate_token
-        continue-on-error: true
-        uses: actions/create-github-app-token@v1
+        uses: grafana/shared-workflows/actions/create-github-app-token@e5b7989c92b55fe3ac6dd006d6de49082ba8c507 # create-github-app-token (github-script/v9)
         with:
-          app-id: ${{ env.GITHUB_APP_ID }}
-          private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
+          github_app: grafana-ci-bot
 
       - name: Delete old coverage comment if not affected
         if: steps.generate_token.outcome == 'success' && steps.check-affected.outputs.affected == 'false' && github.event.pull_request.head.repo.fork == false
@@ -351,7 +306,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Post PR comment
-        if: steps.generate_token.outcome == 'success' &&  steps.check-affected.outputs.affected == 'true' && github.event.pull_request.head.repo.fork == false
+        if: steps.check-affected.outputs.affected == 'true' && github.event.pull_request.head.repo.fork == false
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: coverage-report-${{ matrix.codeowner }}


### PR DESCRIPTION
Since all of the PRs will fail on this job for now since a token will not be possible to create via the Github App, we need to update the workflow to use the updated shared job to un-break things.