### PR TITLE
Logs Table Panel: replaceVariables with getTemplateSrv()

### DIFF
--- a/public/app/features/explore/Logs/ExploreLogsTable.tsx
+++ b/public/app/features/explore/Logs/ExploreLogsTable.tsx
@@ -10,6 +10,7 @@ import {
   store,
   urlUtil,
 } from '@grafana/data';
+import { getTemplateSrv } from '@grafana/runtime';
 import { type AdHocFilterItem, PanelContextProvider } from '@grafana/ui';
 import { FILTER_FOR_OPERATOR, FILTER_OUT_OPERATOR } from '@grafana/ui/internal';
 import { LogsTable } from 'app/plugins/panel/logstable/LogsTable';
@@ -177,6 +178,7 @@ export function ExploreLogsTable(props: Props) {
         eventBus={props.eventBus}
         onOptionsChange={onOptionsChange}
         onFieldConfigChange={handleFieldConfigChange}
+        replaceVariables={getTemplateSrv().replace.bind(getTemplateSrv())}
         onChangeTimeRange={props.onChangeTimeRange}
       />
     </PanelContextProvider>

--- a/public/app/features/explore/Logs/ExploreLogsTable.tsx
+++ b/public/app/features/explore/Logs/ExploreLogsTable.tsx
@@ -10,7 +10,6 @@ import {
   store,
   urlUtil,
 } from '@grafana/data';
-import { getTemplateSrv } from '@grafana/runtime';
 import { type AdHocFilterItem, PanelContextProvider } from '@grafana/ui';
 import { FILTER_FOR_OPERATOR, FILTER_OUT_OPERATOR } from '@grafana/ui/internal';
 import { LogsTable } from 'app/plugins/panel/logstable/LogsTable';
@@ -178,7 +177,6 @@ export function ExploreLogsTable(props: Props) {
         eventBus={props.eventBus}
         onOptionsChange={onOptionsChange}
         onFieldConfigChange={handleFieldConfigChange}
-        replaceVariables={getTemplateSrv().replace}
         onChangeTimeRange={props.onChangeTimeRange}
       />
     </PanelContextProvider>

--- a/public/app/plugins/panel/logstable/LogsTable.tsx
+++ b/public/app/plugins/panel/logstable/LogsTable.tsx
@@ -212,7 +212,7 @@ export const LogsTable = ({
   );
 
   // Extract fields transform
-  const { extractedFrame } = useExtractFields({ rawTableFrame, fieldConfig, timeZone });
+  const { extractedFrame } = useExtractFields({ rawTableFrame, fieldConfig, timeZone, replaceVariables });
 
   // Organize fields transform
   const { organizedFrame } = useOrganizeFields({

--- a/public/app/plugins/panel/logstable/hooks/useExtractFields.test.ts
+++ b/public/app/plugins/panel/logstable/hooks/useExtractFields.test.ts
@@ -1,12 +1,16 @@
 import { renderHook, waitFor } from '@testing-library/react';
 
 import { DataFrameType, FieldMatcherID, FieldType, standardEditorsRegistry, toDataFrame } from '@grafana/data';
+import { setTemplateSrv } from '@grafana/runtime';
 import { getAllOptionEditors } from 'app/core/components/OptionsUI/registry';
+import { type ContextSrv, setContextSrv } from 'app/core/services/context_srv';
 import { LOGS_DATAPLANE_BODY_NAME, LOGS_DATAPLANE_TIMESTAMP_NAME } from 'app/features/logs/logsFrame';
+import { setLinkSrv } from 'app/features/panel/panellinks/link_srv';
 import { extractFieldsTransformer } from 'app/features/transformers/extractFields/extractFields';
 
 // Internal package imports, but not exposed to end users, how do we expect plugin developers to test anything that contains a transform?
 import { mockTransformationsRegistry } from '../../../../../../packages/grafana-data/src/utils/tests/mockTransformationsRegistry';
+import { initTemplateSrv } from '../../../../../test/helpers/initTemplateSrv';
 
 import { useExtractFields } from './useExtractFields';
 
@@ -29,6 +33,42 @@ const testLogsDataFrame = [
     ],
   }),
 ];
+
+const traceLinkTestFrame = toDataFrame({
+  meta: {
+    type: DataFrameType.LogLines,
+  },
+  fields: [
+    { name: LOGS_DATAPLANE_TIMESTAMP_NAME, type: FieldType.time, values: [1, 2] },
+    { name: LOGS_DATAPLANE_BODY_NAME, type: FieldType.string, values: ['log 1', 'log 2'] },
+    {
+      name: 'labels',
+      type: FieldType.other,
+      values: [
+        { service: 'frontend', level: 'info' },
+        { service: 'backend', level: 'error' },
+      ],
+    },
+    {
+      name: 'traceID',
+      type: FieldType.string,
+      values: ['65e722de9921ef61e4cc0b26f1ba3fef', '65e722de9921ef61e4cc0b26f1ba3fef'],
+      config: {
+        links: [
+          {
+            title: 'Trace',
+            url: '',
+            internal: {
+              datasourceUid: 'tempo-ds',
+              datasourceName: 'Tempo',
+              query: { query: '${__value.raw}', queryType: 'traceql' },
+            },
+          },
+        ],
+      },
+    },
+  ],
+});
 
 describe('useExtractFields', () => {
   beforeAll(() => {
@@ -83,4 +123,44 @@ describe('useExtractFields', () => {
       expect(service?.config.custom?.width).toBe(89);
     });
   });
+
+  test('interpolates ${__value.raw} in internal trace links instead of LogQL variable escape', async () => {
+    setTemplateSrv(initTemplateSrv('key', []));
+    setContextSrv({
+      hasAccessToExplore: () => true,
+    } as ContextSrv);
+    setLinkSrv({
+      getDataLinkUIModel() {
+        return { href: '', title: '', target: '_blank' };
+      },
+      getAnchorInfo(link) {
+        return { ...link, href: link.url ?? '' };
+      },
+      getLinkUrl(link) {
+        return link.url ?? '';
+      },
+    });
+
+    const traceId = '65e722de9921ef61e4cc0b26f1ba3fef';
+    const { result } = renderHook(() =>
+      useExtractFields({
+        rawTableFrame: traceLinkTestFrame,
+        timeZone: 'utc',
+        fieldConfig: {
+          defaults: {},
+          overrides: [],
+        },
+      })
+    );
+
+    await waitFor(() => {
+      const traceField = result.current.extractedFrame?.fields.find((f) => f.name === 'traceID');
+      expect(traceField?.getLinks).toBeDefined();
+      const links = traceField?.getLinks!({ valueRowIndex: 0 });
+      expect(links?.length).toBe(1);
+      expect(links![0].href).toContain(traceId);
+      expect(links![0].href).not.toContain('__V_');
+    });
+  });
+
 });

--- a/public/app/plugins/panel/logstable/hooks/useExtractFields.test.ts
+++ b/public/app/plugins/panel/logstable/hooks/useExtractFields.test.ts
@@ -1,6 +1,14 @@
 import { renderHook, waitFor } from '@testing-library/react';
 
-import { DataFrameType, FieldMatcherID, FieldType, standardEditorsRegistry, toDataFrame } from '@grafana/data';
+import {
+  type DataLink,
+  DataFrameType,
+  FieldMatcherID,
+  FieldType,
+  type InterpolateFunction,
+  standardEditorsRegistry,
+  toDataFrame,
+} from '@grafana/data';
 import { setTemplateSrv } from '@grafana/runtime';
 import { getAllOptionEditors } from 'app/core/components/OptionsUI/registry';
 import { type ContextSrv, setContextSrv } from 'app/core/services/context_srv';
@@ -130,8 +138,13 @@ describe('useExtractFields', () => {
       hasAccessToExplore: () => true,
     } as ContextSrv);
     setLinkSrv({
-      getDataLinkUIModel() {
-        return { href: '', title: '', target: '_blank' };
+      getDataLinkUIModel(link: DataLink, _replaceVariables: InterpolateFunction | undefined, origin) {
+        return {
+          href: link.url,
+          title: link.title,
+          target: '_blank',
+          origin,
+        };
       },
       getAnchorInfo(link) {
         return { ...link, href: link.url ?? '' };

--- a/public/app/plugins/panel/logstable/hooks/useExtractFields.test.ts
+++ b/public/app/plugins/panel/logstable/hooks/useExtractFields.test.ts
@@ -162,5 +162,4 @@ describe('useExtractFields', () => {
       expect(links![0].href).not.toContain('__V_');
     });
   });
-
 });

--- a/public/app/plugins/panel/logstable/hooks/useExtractFields.ts
+++ b/public/app/plugins/panel/logstable/hooks/useExtractFields.ts
@@ -21,7 +21,7 @@ interface Props {
   rawTableFrame: DataFrame | null;
   fieldConfig?: FieldConfigSource;
   timeZone: TimeZone;
-  replaceVariables: InterpolateFunction;
+  replaceVariables?: InterpolateFunction;
 }
 
 export function useExtractFields({ rawTableFrame, fieldConfig, timeZone, replaceVariables }: Props) {

--- a/public/app/plugins/panel/logstable/hooks/useExtractFields.ts
+++ b/public/app/plugins/panel/logstable/hooks/useExtractFields.ts
@@ -6,6 +6,7 @@ import {
   applyFieldOverrides,
   type DataFrame,
   type FieldConfigSource,
+  type InterpolateFunction,
   type TimeZone,
   transformDataFrame,
   useDataLinksContext,
@@ -20,9 +21,10 @@ interface Props {
   rawTableFrame: DataFrame | null;
   fieldConfig?: FieldConfigSource;
   timeZone: TimeZone;
+  replaceVariables: InterpolateFunction;
 }
 
-export function useExtractFields({ rawTableFrame, fieldConfig, timeZone }: Props) {
+export function useExtractFields({ rawTableFrame, fieldConfig, timeZone, replaceVariables }: Props) {
   const dataLinksContext = useDataLinksContext();
   const isMounted = useMountedState();
   const dataLinkPostProcessor = dataLinksContext.dataLinkPostProcessor;
@@ -47,7 +49,7 @@ export function useExtractFields({ rawTableFrame, fieldConfig, timeZone }: Props
           data,
           fieldConfig,
           fieldConfigRegistry: getLogsTableFieldConfigRegistry(),
-          replaceVariables: getTemplateSrv().replace.bind(getTemplateSrv()),
+          replaceVariables: replaceVariables ?? getTemplateSrv().replace.bind(getTemplateSrv()),
           theme,
           timeZone,
           dataLinkPostProcessor,
@@ -61,7 +63,7 @@ export function useExtractFields({ rawTableFrame, fieldConfig, timeZone }: Props
       });
     // @todo hook re-renders unexpectedly when data frame isn't changing if we add `rawTableFrame` as dependency, so we check for changes in the timestamps instead
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dataLinkPostProcessor, fieldConfig, rawTableFrame?.fields[1]?.values, theme, timeZone]);
+  }, [dataLinkPostProcessor, fieldConfig, rawTableFrame?.fields[1]?.values, replaceVariables, theme, timeZone]);
 
   return { extractedFrame };
 }

--- a/public/app/plugins/panel/logstable/hooks/useExtractFields.ts
+++ b/public/app/plugins/panel/logstable/hooks/useExtractFields.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import useMountedState from 'react-use/lib/useMountedState';
 import { lastValueFrom } from 'rxjs';
 
@@ -12,7 +12,6 @@ import {
 } from '@grafana/data';
 import { getTemplateSrv } from '@grafana/runtime';
 import { useTheme2 } from '@grafana/ui';
-import { replaceVariables } from '@grafana-plugins/loki/querybuilder/parsingUtils';
 
 import { getLogsTableFieldConfigRegistry } from '../logsTableFieldConfig';
 import { extractLogsFieldsTransform } from '../transforms/extractLogsFieldsTransform';
@@ -48,7 +47,7 @@ export function useExtractFields({ rawTableFrame, fieldConfig, timeZone }: Props
           data,
           fieldConfig,
           fieldConfigRegistry: getLogsTableFieldConfigRegistry(),
-          replaceVariables: replaceVariables ?? getTemplateSrv().replace.bind(getTemplateSrv()),
+          replaceVariables: getTemplateSrv().replace.bind(getTemplateSrv()),
           theme,
           timeZone,
           dataLinkPostProcessor,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.


-->

# Fixes 

Fixes Logs Table Panel Clicking on a traceID in explore logs takes users to a broken page in Tempo.
<img width="4162" height="1372" alt="image (2)" src="https://github.com/user-attachments/assets/e5998954-bccd-42b1-a197-beb0b23c0b20" />

Updated 
<img width="1341" height="655" alt="Screenshot 2026-05-18 at 6 54 42 PM" src="https://github.com/user-attachments/assets/cb0aa4f7-238c-47d6-8678-16e3ed1b11b9" />
<img width="1852" height="932" alt="Screenshot 2026-05-18 at 6 54 28 PM" src="https://github.com/user-attachments/assets/8ca48a7d-caf8-4583-b9d7-6b0a33005a78" />

# Testing

- Run Logs Drilldown and Grafana
- Open tempo-distributor
- Switch to the table view
- Click on the trace-id column links
- Note that the trace id populates the query 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
