### PR TITLE
Provisioning: Return early for errors on resource creation in Parser

### DIFF
--- a/pkg/registry/apis/provisioning/resources/parser.go
+++ b/pkg/registry/apis/provisioning/resources/parser.go
@@ -462,6 +462,12 @@ func (f *ParsedResource) Run(ctx context.Context) error {
 		if err == nil {
 			return nil // it worked, return
 		}
+		// Only fall through to Update when the resource was already created. 
+		// For validation, permission, or any other non-conflict errors, return immediately.
+		// Retrying with a different HTTP method won't help.
+		if !apierrors.IsAlreadyExists(err) {
+			return err
+		}
 	}
 
 	// Try update, otherwise create

--- a/pkg/registry/apis/provisioning/resources/parser.go
+++ b/pkg/registry/apis/provisioning/resources/parser.go
@@ -462,7 +462,7 @@ func (f *ParsedResource) Run(ctx context.Context) error {
 		if err == nil {
 			return nil // it worked, return
 		}
-		// Only fall through to Update when the resource was already created. 
+		// Only fall through to Update when the resource was already created.
 		// For validation, permission, or any other non-conflict errors, return immediately.
 		// Retrying with a different HTTP method won't help.
 		if !apierrors.IsAlreadyExists(err) {

--- a/pkg/registry/apis/provisioning/resources/parser_test.go
+++ b/pkg/registry/apis/provisioning/resources/parser_test.go
@@ -502,3 +502,262 @@ func TestDryRunDeletePopulatesExisting(t *testing.T) {
 		require.Equal(t, "team-a", parsed.ExistingFolder())
 	})
 }
+
+func newParsedResource(client *MockDynamicResourceInterface, opts ...func(*ParsedResource)) *ParsedResource {
+	obj := &unstructured.Unstructured{Object: map[string]any{
+		"apiVersion": "dashboard.grafana.app/v1",
+		"kind":       "Dashboard",
+		"metadata":   map[string]any{"name": "my-dash", "namespace": "default"},
+	}}
+	meta, _ := utils.MetaAccessor(obj)
+	p := &ParsedResource{
+		Obj:    obj,
+		Meta:   meta,
+		Client: client,
+		Repo:   testRepoInfo(),
+		GVR:    DashboardResource,
+	}
+	for _, fn := range opts {
+		fn(p)
+	}
+	return p
+}
+
+func withDryRun() func(*ParsedResource) {
+	return func(p *ParsedResource) {
+		p.DryRunResponse = &unstructured.Unstructured{}
+	}
+}
+
+func withExisting(obj *unstructured.Unstructured) func(*ParsedResource) {
+	return func(p *ParsedResource) {
+		p.Existing = obj
+	}
+}
+
+func withAction(action provisioning.ResourceAction) func(*ParsedResource) {
+	return func(p *ParsedResource) {
+		p.Action = action
+	}
+}
+
+func TestParsedResource_Run(t *testing.T) {
+	successObj := &unstructured.Unstructured{Object: map[string]any{
+		"metadata": map[string]any{"name": "my-dash", "namespace": "default"},
+	}}
+	badRequestErr := apierrors.NewBadRequest("uid too long, max 40 characters")
+	forbiddenErr := apierrors.NewForbidden(schema.GroupResource{Resource: "dashboards"}, "my-dash", fmt.Errorf("quota reached"))
+	alreadyExistsErr := apierrors.NewAlreadyExists(schema.GroupResource{Resource: "dashboards"}, "my-dash")
+	notFoundErr := apierrors.NewNotFound(schema.GroupResource{Resource: "dashboards"}, "my-dash")
+	internalErr := apierrors.NewInternalError(fmt.Errorf("something broke"))
+
+	t.Run("nil client returns error", func(t *testing.T) {
+		parsed := &ParsedResource{
+			Obj: &unstructured.Unstructured{Object: map[string]any{
+				"metadata": map[string]any{"name": "x", "namespace": "default"},
+			}},
+		}
+		err := parsed.Run(context.Background())
+		require.ErrorContains(t, err, "unable to find client")
+	})
+
+	// --- Create path (DryRun + no Existing) ---
+
+	t.Run("create succeeds on first attempt", func(t *testing.T) {
+		mc := &MockDynamicResourceInterface{}
+		mc.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(successObj, nil)
+
+		parsed := newParsedResource(mc, withDryRun())
+		err := parsed.Run(context.Background())
+
+		require.NoError(t, err)
+		require.Equal(t, provisioning.ResourceActionCreate, parsed.Action)
+		mc.AssertNumberOfCalls(t, "Create", 1)
+		mc.AssertNotCalled(t, "Update")
+	})
+
+	t.Run("create validation error returns immediately without update", func(t *testing.T) {
+		mc := &MockDynamicResourceInterface{}
+		mc.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, badRequestErr)
+
+		parsed := newParsedResource(mc, withDryRun())
+		err := parsed.Run(context.Background())
+
+		require.True(t, apierrors.IsBadRequest(err))
+		mc.AssertNumberOfCalls(t, "Create", 1)
+		mc.AssertNotCalled(t, "Update")
+	})
+
+	t.Run("create forbidden error returns immediately without update", func(t *testing.T) {
+		mc := &MockDynamicResourceInterface{}
+		mc.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, forbiddenErr)
+
+		parsed := newParsedResource(mc, withDryRun())
+		err := parsed.Run(context.Background())
+
+		require.True(t, apierrors.IsForbidden(err))
+		mc.AssertNotCalled(t, "Update")
+	})
+
+	t.Run("create internal error returns immediately without update", func(t *testing.T) {
+		mc := &MockDynamicResourceInterface{}
+		mc.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, internalErr)
+
+		parsed := newParsedResource(mc, withDryRun())
+		err := parsed.Run(context.Background())
+
+		require.True(t, apierrors.IsInternalError(err))
+		mc.AssertNotCalled(t, "Update")
+	})
+
+	t.Run("create AlreadyExists falls through to update", func(t *testing.T) {
+		mc := &MockDynamicResourceInterface{}
+		mc.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, alreadyExistsErr)
+		mc.On("Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(successObj, nil)
+
+		parsed := newParsedResource(mc, withDryRun())
+		err := parsed.Run(context.Background())
+
+		require.NoError(t, err)
+		require.Equal(t, provisioning.ResourceActionUpdate, parsed.Action)
+		mc.AssertNumberOfCalls(t, "Create", 1)
+		mc.AssertNumberOfCalls(t, "Update", 1)
+	})
+
+	// --- Update path (no DryRun, fetches existing) ---
+
+	t.Run("update succeeds when existing resource found", func(t *testing.T) {
+		existing := managedGrafanaObj("my-dash", "default", nil)
+		mc := &MockDynamicResourceInterface{}
+		mc.On("Get", mock.Anything, "my-dash", mock.Anything, mock.Anything).Return(existing, nil)
+		mc.On("Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(successObj, nil)
+
+		parsed := newParsedResource(mc)
+		err := parsed.Run(context.Background())
+
+		require.NoError(t, err)
+		require.Equal(t, provisioning.ResourceActionUpdate, parsed.Action)
+		mc.AssertNotCalled(t, "Create")
+	})
+
+	t.Run("update validation error returns immediately without create fallback", func(t *testing.T) {
+		existing := managedGrafanaObj("my-dash", "default", nil)
+		mc := &MockDynamicResourceInterface{}
+		mc.On("Get", mock.Anything, "my-dash", mock.Anything, mock.Anything).Return(existing, nil)
+		mc.On("Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, badRequestErr)
+
+		parsed := newParsedResource(mc)
+		err := parsed.Run(context.Background())
+
+		require.True(t, apierrors.IsBadRequest(err))
+		mc.AssertNotCalled(t, "Create")
+	})
+
+	t.Run("update NotFound falls through to create", func(t *testing.T) {
+		mc := &MockDynamicResourceInterface{}
+		mc.On("Get", mock.Anything, "my-dash", mock.Anything, mock.Anything).Return(nil, notFoundErr)
+		mc.On("Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, notFoundErr)
+		mc.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(successObj, nil)
+
+		parsed := newParsedResource(mc)
+		err := parsed.Run(context.Background())
+
+		require.NoError(t, err)
+		require.Equal(t, provisioning.ResourceActionCreate, parsed.Action)
+		mc.AssertNumberOfCalls(t, "Update", 1)
+		mc.AssertNumberOfCalls(t, "Create", 1)
+	})
+
+	t.Run("update NotFound then create also fails returns create error", func(t *testing.T) {
+		mc := &MockDynamicResourceInterface{}
+		mc.On("Get", mock.Anything, "my-dash", mock.Anything, mock.Anything).Return(nil, notFoundErr)
+		mc.On("Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, notFoundErr)
+		mc.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, forbiddenErr)
+
+		parsed := newParsedResource(mc)
+		err := parsed.Run(context.Background())
+
+		require.True(t, apierrors.IsForbidden(err))
+	})
+
+	// --- Delete path ---
+
+	t.Run("delete succeeds", func(t *testing.T) {
+		existing := managedGrafanaObj("my-dash", "default", nil)
+		mc := &MockDynamicResourceInterface{}
+		mc.On("Delete", mock.Anything, "my-dash", mock.Anything, mock.Anything).Return(nil)
+
+		parsed := newParsedResource(mc, withAction(provisioning.ResourceActionDelete), withDryRun(), withExisting(existing))
+		err := parsed.Run(context.Background())
+
+		require.NoError(t, err)
+		require.NotNil(t, parsed.Upsert)
+	})
+
+	t.Run("delete without dry run fetches existing first", func(t *testing.T) {
+		existing := managedGrafanaObj("my-dash", "default", nil)
+		mc := &MockDynamicResourceInterface{}
+		mc.On("Get", mock.Anything, "my-dash", mock.Anything, mock.Anything).Return(existing, nil)
+		mc.On("Delete", mock.Anything, "my-dash", mock.Anything, mock.Anything).Return(nil)
+
+		parsed := newParsedResource(mc, withAction(provisioning.ResourceActionDelete))
+		err := parsed.Run(context.Background())
+
+		require.NoError(t, err)
+		mc.AssertNumberOfCalls(t, "Get", 1)
+	})
+
+	t.Run("delete resource not found returns nil", func(t *testing.T) {
+		mc := &MockDynamicResourceInterface{}
+		mc.On("Get", mock.Anything, "my-dash", mock.Anything, mock.Anything).Return(nil, notFoundErr)
+
+		parsed := newParsedResource(mc, withAction(provisioning.ResourceActionDelete))
+		err := parsed.Run(context.Background())
+
+		require.NoError(t, err)
+		mc.AssertNotCalled(t, "Delete")
+	})
+
+	t.Run("delete already deleted returns nil", func(t *testing.T) {
+		existing := managedGrafanaObj("my-dash", "default", nil)
+		mc := &MockDynamicResourceInterface{}
+		mc.On("Delete", mock.Anything, "my-dash", mock.Anything, mock.Anything).Return(notFoundErr)
+
+		parsed := newParsedResource(mc, withAction(provisioning.ResourceActionDelete), withDryRun(), withExisting(existing))
+		err := parsed.Run(context.Background())
+
+		require.NoError(t, err)
+	})
+
+	t.Run("delete other error returns error", func(t *testing.T) {
+		existing := managedGrafanaObj("my-dash", "default", nil)
+		mc := &MockDynamicResourceInterface{}
+		mc.On("Delete", mock.Anything, "my-dash", mock.Anything, mock.Anything).Return(internalErr)
+
+		parsed := newParsedResource(mc, withAction(provisioning.ResourceActionDelete), withDryRun(), withExisting(existing))
+		err := parsed.Run(context.Background())
+
+		require.True(t, apierrors.IsInternalError(err))
+	})
+
+	// --- Ownership checks ---
+
+	t.Run("ownership conflict on upsert returns error", func(t *testing.T) {
+		otherOwner := managedGrafanaObj("my-dash", "default", nil)
+		otherMeta, _ := utils.MetaAccessor(otherOwner)
+		otherMeta.SetManagerProperties(utils.ManagerProperties{
+			Kind:     utils.ManagerKindRepo,
+			Identity: "other-repo",
+		})
+
+		mc := &MockDynamicResourceInterface{}
+		mc.On("Get", mock.Anything, "my-dash", mock.Anything, mock.Anything).Return(otherOwner, nil)
+
+		parsed := newParsedResource(mc)
+		err := parsed.Run(context.Background())
+
+		require.Error(t, err)
+		mc.AssertNotCalled(t, "Create")
+		mc.AssertNotCalled(t, "Update")
+	})
+}

--- a/pkg/registry/apis/provisioning/resources/parser_test.go
+++ b/pkg/registry/apis/provisioning/resources/parser_test.go
@@ -557,7 +557,7 @@ func TestParsedResource_Run(t *testing.T) {
 				"metadata": map[string]any{"name": "x", "namespace": "default"},
 			}},
 		}
-		err := parsed.Run(context.Background())
+		err := parsed.Run(t.Context())
 		require.ErrorContains(t, err, "unable to find client")
 	})
 
@@ -568,7 +568,7 @@ func TestParsedResource_Run(t *testing.T) {
 		mc.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(successObj, nil)
 
 		parsed := newParsedResource(mc, withDryRun())
-		err := parsed.Run(context.Background())
+		err := parsed.Run(t.Context())
 
 		require.NoError(t, err)
 		require.Equal(t, provisioning.ResourceActionCreate, parsed.Action)
@@ -581,7 +581,7 @@ func TestParsedResource_Run(t *testing.T) {
 		mc.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, badRequestErr)
 
 		parsed := newParsedResource(mc, withDryRun())
-		err := parsed.Run(context.Background())
+		err := parsed.Run(t.Context())
 
 		require.True(t, apierrors.IsBadRequest(err))
 		mc.AssertNumberOfCalls(t, "Create", 1)
@@ -593,7 +593,7 @@ func TestParsedResource_Run(t *testing.T) {
 		mc.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, forbiddenErr)
 
 		parsed := newParsedResource(mc, withDryRun())
-		err := parsed.Run(context.Background())
+		err := parsed.Run(t.Context())
 
 		require.True(t, apierrors.IsForbidden(err))
 		mc.AssertNotCalled(t, "Update")
@@ -604,7 +604,7 @@ func TestParsedResource_Run(t *testing.T) {
 		mc.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, internalErr)
 
 		parsed := newParsedResource(mc, withDryRun())
-		err := parsed.Run(context.Background())
+		err := parsed.Run(t.Context())
 
 		require.True(t, apierrors.IsInternalError(err))
 		mc.AssertNotCalled(t, "Update")
@@ -616,7 +616,7 @@ func TestParsedResource_Run(t *testing.T) {
 		mc.On("Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(successObj, nil)
 
 		parsed := newParsedResource(mc, withDryRun())
-		err := parsed.Run(context.Background())
+		err := parsed.Run(t.Context())
 
 		require.NoError(t, err)
 		require.Equal(t, provisioning.ResourceActionUpdate, parsed.Action)
@@ -633,7 +633,7 @@ func TestParsedResource_Run(t *testing.T) {
 		mc.On("Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(successObj, nil)
 
 		parsed := newParsedResource(mc)
-		err := parsed.Run(context.Background())
+		err := parsed.Run(t.Context())
 
 		require.NoError(t, err)
 		require.Equal(t, provisioning.ResourceActionUpdate, parsed.Action)
@@ -647,7 +647,7 @@ func TestParsedResource_Run(t *testing.T) {
 		mc.On("Update", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, badRequestErr)
 
 		parsed := newParsedResource(mc)
-		err := parsed.Run(context.Background())
+		err := parsed.Run(t.Context())
 
 		require.True(t, apierrors.IsBadRequest(err))
 		mc.AssertNotCalled(t, "Create")
@@ -660,7 +660,7 @@ func TestParsedResource_Run(t *testing.T) {
 		mc.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(successObj, nil)
 
 		parsed := newParsedResource(mc)
-		err := parsed.Run(context.Background())
+		err := parsed.Run(t.Context())
 
 		require.NoError(t, err)
 		require.Equal(t, provisioning.ResourceActionCreate, parsed.Action)
@@ -675,7 +675,7 @@ func TestParsedResource_Run(t *testing.T) {
 		mc.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, forbiddenErr)
 
 		parsed := newParsedResource(mc)
-		err := parsed.Run(context.Background())
+		err := parsed.Run(t.Context())
 
 		require.True(t, apierrors.IsForbidden(err))
 	})
@@ -688,7 +688,7 @@ func TestParsedResource_Run(t *testing.T) {
 		mc.On("Delete", mock.Anything, "my-dash", mock.Anything, mock.Anything).Return(nil)
 
 		parsed := newParsedResource(mc, withAction(provisioning.ResourceActionDelete), withDryRun(), withExisting(existing))
-		err := parsed.Run(context.Background())
+		err := parsed.Run(t.Context())
 
 		require.NoError(t, err)
 		require.NotNil(t, parsed.Upsert)
@@ -701,7 +701,7 @@ func TestParsedResource_Run(t *testing.T) {
 		mc.On("Delete", mock.Anything, "my-dash", mock.Anything, mock.Anything).Return(nil)
 
 		parsed := newParsedResource(mc, withAction(provisioning.ResourceActionDelete))
-		err := parsed.Run(context.Background())
+		err := parsed.Run(t.Context())
 
 		require.NoError(t, err)
 		mc.AssertNumberOfCalls(t, "Get", 1)
@@ -712,7 +712,7 @@ func TestParsedResource_Run(t *testing.T) {
 		mc.On("Get", mock.Anything, "my-dash", mock.Anything, mock.Anything).Return(nil, notFoundErr)
 
 		parsed := newParsedResource(mc, withAction(provisioning.ResourceActionDelete))
-		err := parsed.Run(context.Background())
+		err := parsed.Run(t.Context())
 
 		require.NoError(t, err)
 		mc.AssertNotCalled(t, "Delete")
@@ -724,7 +724,7 @@ func TestParsedResource_Run(t *testing.T) {
 		mc.On("Delete", mock.Anything, "my-dash", mock.Anything, mock.Anything).Return(notFoundErr)
 
 		parsed := newParsedResource(mc, withAction(provisioning.ResourceActionDelete), withDryRun(), withExisting(existing))
-		err := parsed.Run(context.Background())
+		err := parsed.Run(t.Context())
 
 		require.NoError(t, err)
 	})
@@ -735,7 +735,7 @@ func TestParsedResource_Run(t *testing.T) {
 		mc.On("Delete", mock.Anything, "my-dash", mock.Anything, mock.Anything).Return(internalErr)
 
 		parsed := newParsedResource(mc, withAction(provisioning.ResourceActionDelete), withDryRun(), withExisting(existing))
-		err := parsed.Run(context.Background())
+		err := parsed.Run(t.Context())
 
 		require.True(t, apierrors.IsInternalError(err))
 	})
@@ -754,7 +754,7 @@ func TestParsedResource_Run(t *testing.T) {
 		mc.On("Get", mock.Anything, "my-dash", mock.Anything, mock.Anything).Return(otherOwner, nil)
 
 		parsed := newParsedResource(mc)
-		err := parsed.Run(context.Background())
+		err := parsed.Run(t.Context())
 
 		require.Error(t, err)
 		mc.AssertNotCalled(t, "Create")


### PR DESCRIPTION
## Summary

Fixes https://github.com/grafana/git-ui-sync-project/issues/1133

When the provisioning sync job creates a resource via the K8s API and the request fails with a non-retryable error (e.g. `BadRequest` for UID > 40 characters), the `ParsedResource.Run()` method was falling through from Create to Update (and then a fallback Create), making up to 3 redundant API calls for the same invalid resource. Each call goes through the full admission chain (mutation + validation), wasting time on work that will always fail.

This PR adds an early return when Create fails with any error other than `AlreadyExists`. The `AlreadyExists` case is the only legitimate reason to fall through — it means another writer created the resource between the DryRun check and the actual Create.

### Changes

- **`pkg/registry/apis/provisioning/resources/parser.go`**: In `Run()`, return immediately when Create fails with a non-`AlreadyExists` error instead of falling through to the Update path
- **`pkg/registry/apis/provisioning/resources/parser_test.go`**: Add 17 unit tests covering all `Run()` branches — create, update, delete, ownership conflicts, and fallback paths

### Side effect fix

Before this change, a Create validation error would fall through and overwrite `f.Action` to `ResourceActionUpdate`, causing the error to be reported as `action: updated` instead of `action: created`. Now the action label is correct.

## Test plan

- [x] Create succeeds → returns immediately, no Update call
- [x] Create → BadRequest → returns immediately, no Update call
- [x] Create → Forbidden → returns immediately, no Update call
- [x] Create → InternalError → returns immediately, no Update call
- [x] Create → AlreadyExists → falls through to Update
- [x] Update succeeds → no Create fallback
- [x] Update → BadRequest → returns immediately, no Create fallback
- [x] Update → NotFound → falls through to Create
- [x] Update → NotFound → Create fails → returns Create error
- [x] Delete paths (with/without DryRun, NotFound, already deleted, errors)
- [x] Ownership conflict → returns error without Create/Update
- [x] `make gofmt` clean
- [x] `make lint-go-diff` zero issues