### PR TITLE
fix: enforce access escalation check on update validation

### DIFF
--- a/pkg/registry/apis/folders/register.go
+++ b/pkg/registry/apis/folders/register.go
@@ -53,7 +53,6 @@ type FolderAPIBuilder struct {
 	storage              grafanarest.Storage
 	permissionStore      PermissionStore
 	accessClient         authlib.AccessClient
-	accessControl        accesscontrol.AccessControl
 	parents              parentsGetter
 	searcher             resourcepb.ResourceIndexClient
 	maxNestedFolderDepth int
@@ -72,7 +71,6 @@ func RegisterAPIService(cfg *setting.Cfg,
 	apiregistration builder.APIRegistrar,
 	folderPermissionsSvc accesscontrol.FolderPermissionsService,
 	accessClient authlib.AccessClient,
-	accessControl accesscontrol.AccessControl,
 	registerer prometheus.Registerer,
 	unified resource.ResourceClient,
 	zanzanaClient zanzana.Client,
@@ -81,7 +79,6 @@ func RegisterAPIService(cfg *setting.Cfg,
 		namespacer:           request.GetNamespaceMapper(cfg),
 		folderPermissionsSvc: folderPermissionsSvc,
 		accessClient:         accessClient,
-		accessControl:        accessControl,
 		permissionsOnCreate:  cfg.RBAC.PermissionsOnCreation("folder"),
 		useZanzana:           features.IsEnabledGlobally(featuremgmt.FlagZanzana), //nolint:staticcheck
 		searcher:             unified,
@@ -414,7 +411,7 @@ func (b *FolderAPIBuilder) Validate(ctx context.Context, a admission.Attributes,
 		if err := validateOwnerReferencesOnManagedFolder(f, old); err != nil {
 			return err
 		}
-		return validateOnUpdate(ctx, f, old, b.storage, b.parents, b.searcher, b.accessControl, b.maxNestedFolderDepth)
+		return validateOnUpdate(ctx, f, old, b.storage, b.parents, b.searcher, b.accessClient, b.maxNestedFolderDepth)
 	default:
 		return nil
 	}

--- a/pkg/registry/apis/folders/register.go
+++ b/pkg/registry/apis/folders/register.go
@@ -53,6 +53,7 @@ type FolderAPIBuilder struct {
 	storage              grafanarest.Storage
 	permissionStore      PermissionStore
 	accessClient         authlib.AccessClient
+	accessControl        accesscontrol.AccessControl
 	parents              parentsGetter
 	searcher             resourcepb.ResourceIndexClient
 	maxNestedFolderDepth int
@@ -71,6 +72,7 @@ func RegisterAPIService(cfg *setting.Cfg,
 	apiregistration builder.APIRegistrar,
 	folderPermissionsSvc accesscontrol.FolderPermissionsService,
 	accessClient authlib.AccessClient,
+	accessControl accesscontrol.AccessControl,
 	registerer prometheus.Registerer,
 	unified resource.ResourceClient,
 	zanzanaClient zanzana.Client,
@@ -79,6 +81,7 @@ func RegisterAPIService(cfg *setting.Cfg,
 		namespacer:           request.GetNamespaceMapper(cfg),
 		folderPermissionsSvc: folderPermissionsSvc,
 		accessClient:         accessClient,
+		accessControl:        accessControl,
 		permissionsOnCreate:  cfg.RBAC.PermissionsOnCreation("folder"),
 		useZanzana:           features.IsEnabledGlobally(featuremgmt.FlagZanzana), //nolint:staticcheck
 		searcher:             unified,
@@ -411,7 +414,7 @@ func (b *FolderAPIBuilder) Validate(ctx context.Context, a admission.Attributes,
 		if err := validateOwnerReferencesOnManagedFolder(f, old); err != nil {
 			return err
 		}
-		return validateOnUpdate(ctx, f, old, b.storage, b.parents, b.searcher, b.maxNestedFolderDepth)
+		return validateOnUpdate(ctx, f, old, b.storage, b.parents, b.searcher, b.accessControl, b.maxNestedFolderDepth)
 	default:
 		return nil
 	}

--- a/pkg/registry/apis/folders/validate.go
+++ b/pkg/registry/apis/folders/validate.go
@@ -180,26 +180,6 @@ func validateOnUpdate(ctx context.Context,
 		return folder.ErrFolderCannotBeMovedToK6.Errorf("k6 project may not be moved")
 	}
 
-	// Resolve the destination's ancestor chain for the depth and circular
-	// reference checks below. Access checks rely on Zanzana for inheritance
-	// and don't need this chain enumerated.
-	var destinationAncestors []folders.FolderInfo
-	if newParent != folder.RootFolderUID {
-		parentObj, err := getter.Get(ctx, newParent, &metav1.GetOptions{})
-		if err != nil {
-			return fmt.Errorf("move target not found %w", err)
-		}
-		parent, ok := parentObj.(*folders.Folder)
-		if !ok {
-			return fmt.Errorf("expected folder, found %T", parentObj)
-		}
-		info, err := parents(ctx, parent)
-		if err != nil {
-			return err
-		}
-		destinationAncestors = info.Items
-	}
-
 	if err := checkMoveAccess(ctx, obj.Namespace, obj.Name, oldFolder.GetFolder(), newParent, accessClient); err != nil {
 		return err
 	}
@@ -381,7 +361,7 @@ func checkMoveAccess(
 	}
 	if !writeRes.Allowed {
 		destLabel := newParentUID
-		if destLabel == folder.RootFolderUID {
+		if folder.IsRootFolderUID(destLabel) {
 			destLabel = folder.GeneralFolderUID
 		}
 		return folder.ErrMoveAccessDenied.Errorf("user does not have permissions to move a folder to folder with UID %s", destLabel)

--- a/pkg/registry/apis/folders/validate.go
+++ b/pkg/registry/apis/folders/validate.go
@@ -269,6 +269,7 @@ func validateOnUpdate(ctx context.Context,
 var escalationVerbs = []string{
 	utils.VerbGet,
 	utils.VerbUpdate,
+	utils.VerbPatch,
 	utils.VerbDelete,
 	utils.VerbCreate,
 	utils.VerbSetPermissions,
@@ -303,18 +304,17 @@ func checkMoveAccess(
 	}
 
 	gvr := folders.FolderResourceInfo.GroupVersionResource()
-	newParentFolder := folderFieldFor(newParentUID)
-	oldParentFolder := folderFieldFor(oldParentUID)
 
 	// Destination-write: can the user create a child folder under the new
 	// parent? Zanzana resolves inheritance, so a single Check on the parent
-	// folder (empty string for root) is sufficient.
+	// folder (folder.RootFolderUID is "", which authlib treats as root) is
+	// sufficient.
 	writeResp, err := accessClient.Check(ctx, user, authlib.CheckRequest{
 		Verb:      utils.VerbCreate,
 		Group:     gvr.Group,
 		Resource:  gvr.Resource,
 		Namespace: namespace,
-	}, newParentFolder)
+	}, newParentUID)
 	if err != nil {
 		return err
 	}
@@ -336,7 +336,7 @@ func checkMoveAccess(
 				Group:         gvr.Group,
 				Resource:      gvr.Resource,
 				Name:          sourceUID,
-				Folder:        newParentFolder,
+				Folder:        newParentUID,
 			},
 			authlib.BatchCheckItem{
 				CorrelationID: oldPrefix + verb,
@@ -344,7 +344,7 @@ func checkMoveAccess(
 				Group:         gvr.Group,
 				Resource:      gvr.Resource,
 				Name:          sourceUID,
-				Folder:        oldParentFolder,
+				Folder:        oldParentUID,
 			},
 		)
 	}
@@ -360,8 +360,11 @@ func checkMoveAccess(
 	for _, verb := range escalationVerbs {
 		newState, nOk := batchResp.Results[newPrefix+verb]
 		oldState, oOk := batchResp.Results[oldPrefix+verb]
+		// Fail closed: we built both correlation IDs ourselves, so a missing
+		// result indicates an authlib bug or transport problem rather than a
+		// "no opinion" answer. Skipping would silently disable the guard.
 		if !nOk || !oOk {
-			continue
+			return fmt.Errorf("access escalation check returned no result for verb %q", verb)
 		}
 		if newState.Error != nil {
 			return newState.Error
@@ -374,16 +377,6 @@ func checkMoveAccess(
 		}
 	}
 	return nil
-}
-
-// folderFieldFor returns the folder UID to use as the authlib `folder`
-// argument: RootFolderUID is the empty-string sentinel for root, but authlib
-// expects the literal empty string for resources at the root.
-func folderFieldFor(parentUID string) string {
-	if parentUID == folder.RootFolderUID {
-		return ""
-	}
-	return parentUID
 }
 
 // canSkipChildrenCheck determines if we can skip the expensive children depth check.

--- a/pkg/registry/apis/folders/validate.go
+++ b/pkg/registry/apis/folders/validate.go
@@ -15,7 +15,6 @@ import (
 
 	authlib "github.com/grafana/authlib/types"
 	"github.com/grafana/grafana-app-sdk/logging"
-	dashv1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
 	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
@@ -263,13 +262,48 @@ func validateOnUpdate(ctx context.Context,
 	return checkSubtreeDepth(ctx, searcher, obj.Namespace, obj.Name, allowedDepth, maxDepth)
 }
 
-var escalationVerbs = []string{
-	utils.VerbGet,
-	utils.VerbUpdate,
-	utils.VerbPatch,
-	utils.VerbDelete,
-	utils.VerbCreate,
-	utils.VerbSetPermissions,
+// folderTier is the Viewer/Editor/Admin level used by the /access subresource.
+// Comparing tiers across the move catches role-level escalations without
+// firing on per-verb churn.
+//
+// Only the folder tier is compared. Built-in roles bundle dashboard, library
+// panel, alert, and annotation actions with the folder tier, so a folder-tier
+// jump catches them transitively. Custom roles that grant sub-resource
+// actions directly at folder scope without folder access are not caught here.
+type folderTier int
+
+const (
+	tierNone folderTier = iota
+	tierViewer
+	tierEditor
+	tierAdmin
+)
+
+// tierProbes are the verbs we ask Zanzana about to resolve a tier. setperms
+// signals Admin, the Editor verbs (create/update/delete) collectively signal
+// Editor, and get alone signals Viewer.
+var tierProbes = []struct {
+	suffix string
+	verb   string
+}{
+	{"get", utils.VerbGet},
+	{"create", utils.VerbCreate},
+	{"update", utils.VerbUpdate},
+	{"delete", utils.VerbDelete},
+	{"setperms", utils.VerbSetPermissions},
+}
+
+func resolveTier(allowed map[string]bool) folderTier {
+	switch {
+	case allowed["setperms"]:
+		return tierAdmin
+	case allowed["create"] || allowed["update"] || allowed["delete"]:
+		return tierEditor
+	case allowed["get"]:
+		return tierViewer
+	default:
+		return tierNone
+	}
 }
 
 func checkMoveAccess(
@@ -290,17 +324,14 @@ func checkMoveAccess(
 	}
 
 	folderGVR := folders.FolderResourceInfo.GroupVersionResource()
-	dashGVR := dashv1.DashboardResourceInfo.GroupVersionResource()
 
 	const (
-		writeDestKey     = "writeDest"
-		newFolderPrefix  = "newFolder|"
-		oldFolderPrefix  = "oldFolder|"
-		newDashPrefix    = "newDash|"
-		sourceDashPrefix = "sourceDash|"
+		writeDestKey    = "writeDest"
+		newFolderPrefix = "newFolder|"
+		oldFolderPrefix = "oldFolder|"
 	)
 
-	checks := make([]authlib.BatchCheckItem, 0, 1+4*len(escalationVerbs))
+	checks := make([]authlib.BatchCheckItem, 0, 1+2*len(tierProbes))
 
 	// Destination-write check: can the user create folders under newParentUID?
 	checks = append(checks, authlib.BatchCheckItem{
@@ -311,43 +342,24 @@ func checkMoveAccess(
 		Folder:        newParentUID,
 	})
 
-	for _, verb := range escalationVerbs {
-		// Folder escalation: source folder permissions under new vs old parent.
+	// Folder escalation context: source folder permissions under new vs old parent.
+	for _, p := range tierProbes {
 		checks = append(checks,
 			authlib.BatchCheckItem{
-				CorrelationID: newFolderPrefix + verb,
-				Verb:          verb,
+				CorrelationID: newFolderPrefix + p.suffix,
+				Verb:          p.verb,
 				Group:         folderGVR.Group,
 				Resource:      folderGVR.Resource,
 				Name:          sourceUID,
 				Folder:        newParentUID,
 			},
 			authlib.BatchCheckItem{
-				CorrelationID: oldFolderPrefix + verb,
-				Verb:          verb,
+				CorrelationID: oldFolderPrefix + p.suffix,
+				Verb:          p.verb,
 				Group:         folderGVR.Group,
 				Resource:      folderGVR.Resource,
 				Name:          sourceUID,
 				Folder:        oldParentUID,
-			},
-		)
-		// Dashboard escalation: dashboards inside source inherit from the
-		// destination post-move, so flag if the user gains a permission they
-		// don't already hold inside the source folder today.
-		checks = append(checks,
-			authlib.BatchCheckItem{
-				CorrelationID: newDashPrefix + verb,
-				Verb:          verb,
-				Group:         dashGVR.Group,
-				Resource:      dashGVR.Resource,
-				Folder:        newParentUID,
-			},
-			authlib.BatchCheckItem{
-				CorrelationID: sourceDashPrefix + verb,
-				Verb:          verb,
-				Group:         dashGVR.Group,
-				Resource:      dashGVR.Resource,
-				Folder:        sourceUID,
 			},
 		)
 	}
@@ -375,26 +387,28 @@ func checkMoveAccess(
 		return folder.ErrMoveAccessDenied.Errorf("user does not have permissions to move a folder to folder with UID %s", destLabel)
 	}
 
-	for _, verb := range escalationVerbs {
-		newFolderState, nfOk := batchResp.Results[newFolderPrefix+verb]
-		oldFolderState, ofOk := batchResp.Results[oldFolderPrefix+verb]
-		newDashState, ndOk := batchResp.Results[newDashPrefix+verb]
-		sourceDashState, sdOk := batchResp.Results[sourceDashPrefix+verb]
-		// Fail closed on missing result: we built all correlation IDs ourselves.
-		if !nfOk || !ofOk || !ndOk || !sdOk {
-			return fmt.Errorf("access escalation check returned no result for verb %q", verb)
+	// Fail closed on any missing result — we built every correlation ID
+	// ourselves, so an absent key is a server bug.
+	newFolder := make(map[string]bool, len(tierProbes))
+	oldFolder := make(map[string]bool, len(tierProbes))
+	for _, p := range tierProbes {
+		nf, nfOk := batchResp.Results[newFolderPrefix+p.suffix]
+		of, ofOk := batchResp.Results[oldFolderPrefix+p.suffix]
+		if !nfOk || !ofOk {
+			return fmt.Errorf("access escalation check returned no result for verb %q", p.verb)
 		}
-		for _, state := range []authlib.BatchCheckResult{newFolderState, oldFolderState, newDashState, sourceDashState} {
-			if state.Error != nil {
-				return state.Error
-			}
+		if nf.Error != nil {
+			return nf.Error
 		}
-		if newFolderState.Allowed && !oldFolderState.Allowed {
-			return folder.ErrAccessEscalation.Errorf("user cannot move a folder to another folder where they have higher permissions")
+		if of.Error != nil {
+			return of.Error
 		}
-		if newDashState.Allowed && !sourceDashState.Allowed {
-			return folder.ErrAccessEscalation.Errorf("user cannot move a folder to another folder where they have higher permissions")
-		}
+		newFolder[p.suffix] = nf.Allowed
+		oldFolder[p.suffix] = of.Allowed
+	}
+
+	if resolveTier(newFolder) > resolveTier(oldFolder) {
+		return folder.ErrAccessEscalation.Errorf("user cannot move a folder to another folder where they have higher permissions")
 	}
 
 	return nil

--- a/pkg/registry/apis/folders/validate.go
+++ b/pkg/registry/apis/folders/validate.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apiserver/pkg/registry/rest"
 
+	authlib "github.com/grafana/authlib/types"
 	"github.com/grafana/grafana-app-sdk/logging"
 	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
@@ -140,7 +141,7 @@ func validateOnUpdate(ctx context.Context,
 	getter rest.Getter,
 	parents parentsGetter,
 	searcher resourcepb.ResourceIndexClient,
-	accessControl accesscontrol.AccessControl,
+	accessClient authlib.AccessClient,
 	maxDepth int,
 ) error {
 	folderObj, err := utils.MetaAccessor(obj)
@@ -179,8 +180,9 @@ func validateOnUpdate(ctx context.Context,
 		return folder.ErrFolderCannotBeMovedToK6.Errorf("k6 project may not be moved")
 	}
 
-	// Resolve the destination's ancestor chain once — reused for the
-	// escalation check below and the depth/circular checks further down.
+	// Resolve the destination's ancestor chain for the depth and circular
+	// reference checks below. Access checks rely on Zanzana for inheritance
+	// and don't need this chain enumerated.
 	var destinationAncestors []folders.FolderInfo
 	if newParent != folder.RootFolderUID {
 		parentObj, err := getter.Get(ctx, newParent, &metav1.GetOptions{})
@@ -198,7 +200,7 @@ func validateOnUpdate(ctx context.Context,
 		destinationAncestors = info.Items
 	}
 
-	if err := checkMoveAccess(ctx, obj.Name, newParent, destinationAncestors, accessControl); err != nil {
+	if err := checkMoveAccess(ctx, obj.Namespace, obj.Name, oldFolder.GetFolder(), newParent, accessClient); err != nil {
 		return err
 	}
 
@@ -260,19 +262,38 @@ func validateOnUpdate(ctx context.Context,
 	return checkSubtreeDepth(ctx, searcher, obj.Namespace, obj.Name, allowedDepth, maxDepth)
 }
 
+// escalationVerbs are the folder-resource verbs the access-escalation guard
+// compares between source and destination. If the user can perform any of
+// these on the destination but not the source, the move would grant them new
+// capabilities and is rejected.
+var escalationVerbs = []string{
+	utils.VerbGet,
+	utils.VerbUpdate,
+	utils.VerbDelete,
+	utils.VerbCreate,
+	utils.VerbSetPermissions,
+}
+
 // checkMoveAccess enforces destination-write permission and the
-// access-escalation guard. destinationAncestors must contain the new parent
-// followed by its ancestors up to and including the root entry, or nil when
-// moving to root. A nil accessControl makes this a no-op so the cloud
-// apiserver path (where the service is not wired) is unchanged.
+// access-escalation guard via authlib (Zanzana in MT, legacy-backed in
+// single-tenant). A nil accessClient makes this a no-op for callers that have
+// not wired one yet.
+//
+// The escalation guard asks, for each verb in escalationVerbs: "would moving
+// source under newParent grant the user a capability on source that they
+// don't currently have?" Concretely, we Check(Name=source) twice — once with
+// Folder=oldParent (current state) and once with Folder=newParent
+// (hypothetical post-move state) — and reject the move if any verb is allowed
+// under the new parent but not the current one.
 func checkMoveAccess(
 	ctx context.Context,
+	namespace string,
 	sourceUID string,
+	oldParentUID string,
 	newParentUID string,
-	destinationAncestors []folders.FolderInfo,
-	accessControl accesscontrol.AccessControl,
+	accessClient authlib.AccessClient,
 ) error {
-	if accessControl == nil {
+	if accessClient == nil {
 		return nil
 	}
 
@@ -281,55 +302,88 @@ func checkMoveAccess(
 		return err
 	}
 
-	destinationParentUID := newParentUID
-	if destinationParentUID == folder.RootFolderUID {
-		destinationParentUID = folder.GeneralFolderUID
+	gvr := folders.FolderResourceInfo.GroupVersionResource()
+	newParentFolder := folderFieldFor(newParentUID)
+	oldParentFolder := folderFieldFor(oldParentUID)
+
+	// Destination-write: can the user create a child folder under the new
+	// parent? Zanzana resolves inheritance, so a single Check on the parent
+	// folder (empty string for root) is sufficient.
+	writeResp, err := accessClient.Check(ctx, user, authlib.CheckRequest{
+		Verb:      utils.VerbCreate,
+		Group:     gvr.Group,
+		Resource:  gvr.Resource,
+		Namespace: namespace,
+	}, newParentFolder)
+	if err != nil {
+		return err
+	}
+	if !writeResp.Allowed {
+		destLabel := newParentUID
+		if destLabel == folder.RootFolderUID {
+			destLabel = folder.GeneralFolderUID
+		}
+		return folder.ErrMoveAccessDenied.Errorf("user does not have permissions to move a folder to folder with UID %s", destLabel)
 	}
 
-	var writeEvaluator accesscontrol.Evaluator
-	if newParentUID == folder.RootFolderUID {
-		writeEvaluator = accesscontrol.EvalPermission(folder.ActionFoldersCreate, folder.ScopeFoldersProvider.GetResourceScopeUID(folder.GeneralFolderUID))
-	} else {
-		writeEvaluator = accesscontrol.EvalAny(
-			accesscontrol.EvalPermission(folder.ActionFoldersWrite, folder.ScopeFoldersProvider.GetResourceScopeUID(newParentUID)),
-			accesscontrol.EvalPermission(folder.ActionFoldersCreate, folder.ScopeFoldersProvider.GetResourceScopeUID(newParentUID)),
+	const newPrefix, oldPrefix = "new|", "old|"
+	checks := make([]authlib.BatchCheckItem, 0, 2*len(escalationVerbs))
+	for _, verb := range escalationVerbs {
+		checks = append(checks,
+			authlib.BatchCheckItem{
+				CorrelationID: newPrefix + verb,
+				Verb:          verb,
+				Group:         gvr.Group,
+				Resource:      gvr.Resource,
+				Name:          sourceUID,
+				Folder:        newParentFolder,
+			},
+			authlib.BatchCheckItem{
+				CorrelationID: oldPrefix + verb,
+				Verb:          verb,
+				Group:         gvr.Group,
+				Resource:      gvr.Resource,
+				Name:          sourceUID,
+				Folder:        oldParentFolder,
+			},
 		)
 	}
-	if hasAccess, err := accessControl.Evaluate(ctx, user, writeEvaluator); err != nil {
+
+	batchResp, err := accessClient.BatchCheck(ctx, user, authlib.BatchCheckRequest{
+		Namespace: namespace,
+		Checks:    checks,
+	})
+	if err != nil {
 		return err
-	} else if !hasAccess {
-		return folder.ErrMoveAccessDenied.Errorf("user does not have permissions to move a folder to folder with UID %s", destinationParentUID)
 	}
 
-	scopes := []string{folder.ScopeFoldersProvider.GetResourceScopeUID(destinationParentUID)}
-	for _, ancestor := range destinationAncestors {
-		if ancestor.Name == "" || ancestor.Name == destinationParentUID || ancestor.Name == folder.RootFolderUID {
+	for _, verb := range escalationVerbs {
+		newState, nOk := batchResp.Results[newPrefix+verb]
+		oldState, oOk := batchResp.Results[oldPrefix+verb]
+		if !nOk || !oOk {
 			continue
 		}
-		scopes = append(scopes, folder.ScopeFoldersProvider.GetResourceScopeUID(ancestor.Name))
-	}
-
-	permissions := user.GetPermissions()
-	currentFolderScope := folder.ScopeFoldersProvider.GetResourceScopeUID(sourceUID)
-	var requiredOnSource []accesscontrol.Evaluator
-	for action, userScopes := range permissions {
-		for _, scope := range scopes {
-			if slices.Contains(userScopes, scope) {
-				requiredOnSource = append(requiredOnSource, accesscontrol.EvalPermission(action, currentFolderScope))
-				break
-			}
+		if newState.Error != nil {
+			return newState.Error
+		}
+		if oldState.Error != nil {
+			return oldState.Error
+		}
+		if newState.Allowed && !oldState.Allowed {
+			return folder.ErrAccessEscalation.Errorf("user cannot move a folder to another folder where they have higher permissions")
 		}
 	}
-
-	if len(requiredOnSource) == 0 {
-		return nil
-	}
-	if hasAccess, err := accessControl.Evaluate(ctx, user, accesscontrol.EvalAll(requiredOnSource...)); err != nil {
-		return err
-	} else if !hasAccess {
-		return folder.ErrAccessEscalation.Errorf("user cannot move a folder to another folder where they have higher permissions")
-	}
 	return nil
+}
+
+// folderFieldFor returns the folder UID to use as the authlib `folder`
+// argument: RootFolderUID is the empty-string sentinel for root, but authlib
+// expects the literal empty string for resources at the root.
+func folderFieldFor(parentUID string) string {
+	if parentUID == folder.RootFolderUID {
+		return ""
+	}
+	return parentUID
 }
 
 // canSkipChildrenCheck determines if we can skip the expensive children depth check.

--- a/pkg/registry/apis/folders/validate.go
+++ b/pkg/registry/apis/folders/validate.go
@@ -15,6 +15,7 @@ import (
 
 	authlib "github.com/grafana/authlib/types"
 	"github.com/grafana/grafana-app-sdk/logging"
+	dashv1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
 	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
@@ -262,10 +263,6 @@ func validateOnUpdate(ctx context.Context,
 	return checkSubtreeDepth(ctx, searcher, obj.Namespace, obj.Name, allowedDepth, maxDepth)
 }
 
-// escalationVerbs are the folder-resource verbs the access-escalation guard
-// compares between source and destination. If the user can perform any of
-// these on the destination but not the source, the move would grant them new
-// capabilities and is rejected.
 var escalationVerbs = []string{
 	utils.VerbGet,
 	utils.VerbUpdate,
@@ -275,17 +272,6 @@ var escalationVerbs = []string{
 	utils.VerbSetPermissions,
 }
 
-// checkMoveAccess enforces destination-write permission and the
-// access-escalation guard via authlib (Zanzana in MT, legacy-backed in
-// single-tenant). A nil accessClient makes this a no-op for callers that have
-// not wired one yet.
-//
-// The escalation guard asks, for each verb in escalationVerbs: "would moving
-// source under newParent grant the user a capability on source that they
-// don't currently have?" Concretely, we Check(Name=source) twice — once with
-// Folder=oldParent (current state) and once with Folder=newParent
-// (hypothetical post-move state) — and reject the move if any verb is allowed
-// under the new parent but not the current one.
 func checkMoveAccess(
 	ctx context.Context,
 	namespace string,
@@ -303,16 +289,12 @@ func checkMoveAccess(
 		return err
 	}
 
-	gvr := folders.FolderResourceInfo.GroupVersionResource()
+	folderGVR := folders.FolderResourceInfo.GroupVersionResource()
 
-	// Destination-write: can the user create a child folder under the new
-	// parent? Zanzana resolves inheritance, so a single Check on the parent
-	// folder (folder.RootFolderUID is "", which authlib treats as root) is
-	// sufficient.
 	writeResp, err := accessClient.Check(ctx, user, authlib.CheckRequest{
 		Verb:      utils.VerbCreate,
-		Group:     gvr.Group,
-		Resource:  gvr.Resource,
+		Group:     folderGVR.Group,
+		Resource:  folderGVR.Resource,
 		Namespace: namespace,
 	}, newParentUID)
 	if err != nil {
@@ -333,16 +315,16 @@ func checkMoveAccess(
 			authlib.BatchCheckItem{
 				CorrelationID: newPrefix + verb,
 				Verb:          verb,
-				Group:         gvr.Group,
-				Resource:      gvr.Resource,
+				Group:         folderGVR.Group,
+				Resource:      folderGVR.Resource,
 				Name:          sourceUID,
 				Folder:        newParentUID,
 			},
 			authlib.BatchCheckItem{
 				CorrelationID: oldPrefix + verb,
 				Verb:          verb,
-				Group:         gvr.Group,
-				Resource:      gvr.Resource,
+				Group:         folderGVR.Group,
+				Resource:      folderGVR.Resource,
 				Name:          sourceUID,
 				Folder:        oldParentUID,
 			},
@@ -360,9 +342,7 @@ func checkMoveAccess(
 	for _, verb := range escalationVerbs {
 		newState, nOk := batchResp.Results[newPrefix+verb]
 		oldState, oOk := batchResp.Results[oldPrefix+verb]
-		// Fail closed: we built both correlation IDs ourselves, so a missing
-		// result indicates an authlib bug or transport problem rather than a
-		// "no opinion" answer. Skipping would silently disable the guard.
+		// Fail closed on missing result: we built both correlation IDs ourselves.
 		if !nOk || !oOk {
 			return fmt.Errorf("access escalation check returned no result for verb %q", verb)
 		}
@@ -376,6 +356,36 @@ func checkMoveAccess(
 			return folder.ErrAccessEscalation.Errorf("user cannot move a folder to another folder where they have higher permissions")
 		}
 	}
+
+	// Dashboards inside source inherit from the destination post-move.
+	dashGVR := dashv1.DashboardResourceInfo.GroupVersionResource()
+	for _, verb := range escalationVerbs {
+		newResp, err := accessClient.Check(ctx, user, authlib.CheckRequest{
+			Verb:      verb,
+			Group:     dashGVR.Group,
+			Resource:  dashGVR.Resource,
+			Namespace: namespace,
+		}, newParentUID)
+		if err != nil {
+			return err
+		}
+		if !newResp.Allowed {
+			continue
+		}
+		todayResp, err := accessClient.Check(ctx, user, authlib.CheckRequest{
+			Verb:      verb,
+			Group:     dashGVR.Group,
+			Resource:  dashGVR.Resource,
+			Namespace: namespace,
+		}, sourceUID)
+		if err != nil {
+			return err
+		}
+		if !todayResp.Allowed {
+			return folder.ErrAccessEscalation.Errorf("user cannot move a folder to another folder where they have higher permissions")
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/registry/apis/folders/validate.go
+++ b/pkg/registry/apis/folders/validate.go
@@ -16,6 +16,7 @@ import (
 	"github.com/grafana/grafana-app-sdk/logging"
 	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	"github.com/grafana/grafana/pkg/services/dashboards"
@@ -139,6 +140,7 @@ func validateOnUpdate(ctx context.Context,
 	getter rest.Getter,
 	parents parentsGetter,
 	searcher resourcepb.ResourceIndexClient,
+	accessControl accesscontrol.AccessControl,
 	maxDepth int,
 ) error {
 	folderObj, err := utils.MetaAccessor(obj)
@@ -171,6 +173,34 @@ func validateOnUpdate(ctx context.Context,
 
 	// Validate the move operation
 	newParent := folderObj.GetFolder()
+
+	// folder cannot be moved to a k6 folder
+	if newParent == accesscontrol.K6FolderUID {
+		return folder.ErrFolderCannotBeMovedToK6.Errorf("k6 project may not be moved")
+	}
+
+	// Resolve the destination's ancestor chain once — reused for the
+	// escalation check below and the depth/circular checks further down.
+	var destinationAncestors []folders.FolderInfo
+	if newParent != folder.RootFolderUID {
+		parentObj, err := getter.Get(ctx, newParent, &metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("move target not found %w", err)
+		}
+		parent, ok := parentObj.(*folders.Folder)
+		if !ok {
+			return fmt.Errorf("expected folder, found %T", parentObj)
+		}
+		info, err := parents(ctx, parent)
+		if err != nil {
+			return err
+		}
+		destinationAncestors = info.Items
+	}
+
+	if err := checkMoveAccess(ctx, obj.Name, newParent, destinationAncestors, accessControl); err != nil {
+		return err
+	}
 
 	// If we move to root, we don't need to validate the depth, because the folder already existed
 	// before and wasn't too deep. This move will make it more shallow.
@@ -228,6 +258,78 @@ func validateOnUpdate(ctx context.Context,
 	}
 
 	return checkSubtreeDepth(ctx, searcher, obj.Namespace, obj.Name, allowedDepth, maxDepth)
+}
+
+// checkMoveAccess enforces destination-write permission and the
+// access-escalation guard. destinationAncestors must contain the new parent
+// followed by its ancestors up to and including the root entry, or nil when
+// moving to root. A nil accessControl makes this a no-op so the cloud
+// apiserver path (where the service is not wired) is unchanged.
+func checkMoveAccess(
+	ctx context.Context,
+	sourceUID string,
+	newParentUID string,
+	destinationAncestors []folders.FolderInfo,
+	accessControl accesscontrol.AccessControl,
+) error {
+	if accessControl == nil {
+		return nil
+	}
+
+	user, err := identity.GetRequester(ctx)
+	if err != nil {
+		return err
+	}
+
+	destinationParentUID := newParentUID
+	if destinationParentUID == folder.RootFolderUID {
+		destinationParentUID = folder.GeneralFolderUID
+	}
+
+	var writeEvaluator accesscontrol.Evaluator
+	if newParentUID == folder.RootFolderUID {
+		writeEvaluator = accesscontrol.EvalPermission(folder.ActionFoldersCreate, folder.ScopeFoldersProvider.GetResourceScopeUID(folder.GeneralFolderUID))
+	} else {
+		writeEvaluator = accesscontrol.EvalAny(
+			accesscontrol.EvalPermission(folder.ActionFoldersWrite, folder.ScopeFoldersProvider.GetResourceScopeUID(newParentUID)),
+			accesscontrol.EvalPermission(folder.ActionFoldersCreate, folder.ScopeFoldersProvider.GetResourceScopeUID(newParentUID)),
+		)
+	}
+	if hasAccess, err := accessControl.Evaluate(ctx, user, writeEvaluator); err != nil {
+		return err
+	} else if !hasAccess {
+		return folder.ErrMoveAccessDenied.Errorf("user does not have permissions to move a folder to folder with UID %s", destinationParentUID)
+	}
+
+	scopes := []string{folder.ScopeFoldersProvider.GetResourceScopeUID(destinationParentUID)}
+	for _, ancestor := range destinationAncestors {
+		if ancestor.Name == "" || ancestor.Name == destinationParentUID || ancestor.Name == folder.RootFolderUID {
+			continue
+		}
+		scopes = append(scopes, folder.ScopeFoldersProvider.GetResourceScopeUID(ancestor.Name))
+	}
+
+	permissions := user.GetPermissions()
+	currentFolderScope := folder.ScopeFoldersProvider.GetResourceScopeUID(sourceUID)
+	var requiredOnSource []accesscontrol.Evaluator
+	for action, userScopes := range permissions {
+		for _, scope := range scopes {
+			if slices.Contains(userScopes, scope) {
+				requiredOnSource = append(requiredOnSource, accesscontrol.EvalPermission(action, currentFolderScope))
+				break
+			}
+		}
+	}
+
+	if len(requiredOnSource) == 0 {
+		return nil
+	}
+	if hasAccess, err := accessControl.Evaluate(ctx, user, accesscontrol.EvalAll(requiredOnSource...)); err != nil {
+		return err
+	} else if !hasAccess {
+		return folder.ErrAccessEscalation.Errorf("user cannot move a folder to another folder where they have higher permissions")
+	}
+	return nil
 }
 
 // canSkipChildrenCheck determines if we can skip the expensive children depth check.

--- a/pkg/registry/apis/folders/validate.go
+++ b/pkg/registry/apis/folders/validate.go
@@ -290,30 +290,32 @@ func checkMoveAccess(
 	}
 
 	folderGVR := folders.FolderResourceInfo.GroupVersionResource()
+	dashGVR := dashv1.DashboardResourceInfo.GroupVersionResource()
 
-	writeResp, err := accessClient.Check(ctx, user, authlib.CheckRequest{
-		Verb:      utils.VerbCreate,
-		Group:     folderGVR.Group,
-		Resource:  folderGVR.Resource,
-		Namespace: namespace,
-	}, newParentUID)
-	if err != nil {
-		return err
-	}
-	if !writeResp.Allowed {
-		destLabel := newParentUID
-		if destLabel == folder.RootFolderUID {
-			destLabel = folder.GeneralFolderUID
-		}
-		return folder.ErrMoveAccessDenied.Errorf("user does not have permissions to move a folder to folder with UID %s", destLabel)
-	}
+	const (
+		writeDestKey     = "writeDest"
+		newFolderPrefix  = "newFolder|"
+		oldFolderPrefix  = "oldFolder|"
+		newDashPrefix    = "newDash|"
+		sourceDashPrefix = "sourceDash|"
+	)
 
-	const newPrefix, oldPrefix = "new|", "old|"
-	checks := make([]authlib.BatchCheckItem, 0, 2*len(escalationVerbs))
+	checks := make([]authlib.BatchCheckItem, 0, 1+4*len(escalationVerbs))
+
+	// Destination-write check: can the user create folders under newParentUID?
+	checks = append(checks, authlib.BatchCheckItem{
+		CorrelationID: writeDestKey,
+		Verb:          utils.VerbCreate,
+		Group:         folderGVR.Group,
+		Resource:      folderGVR.Resource,
+		Folder:        newParentUID,
+	})
+
 	for _, verb := range escalationVerbs {
+		// Folder escalation: source folder permissions under new vs old parent.
 		checks = append(checks,
 			authlib.BatchCheckItem{
-				CorrelationID: newPrefix + verb,
+				CorrelationID: newFolderPrefix + verb,
 				Verb:          verb,
 				Group:         folderGVR.Group,
 				Resource:      folderGVR.Resource,
@@ -321,12 +323,31 @@ func checkMoveAccess(
 				Folder:        newParentUID,
 			},
 			authlib.BatchCheckItem{
-				CorrelationID: oldPrefix + verb,
+				CorrelationID: oldFolderPrefix + verb,
 				Verb:          verb,
 				Group:         folderGVR.Group,
 				Resource:      folderGVR.Resource,
 				Name:          sourceUID,
 				Folder:        oldParentUID,
+			},
+		)
+		// Dashboard escalation: dashboards inside source inherit from the
+		// destination post-move, so flag if the user gains a permission they
+		// don't already hold inside the source folder today.
+		checks = append(checks,
+			authlib.BatchCheckItem{
+				CorrelationID: newDashPrefix + verb,
+				Verb:          verb,
+				Group:         dashGVR.Group,
+				Resource:      dashGVR.Resource,
+				Folder:        newParentUID,
+			},
+			authlib.BatchCheckItem{
+				CorrelationID: sourceDashPrefix + verb,
+				Verb:          verb,
+				Group:         dashGVR.Group,
+				Resource:      dashGVR.Resource,
+				Folder:        sourceUID,
 			},
 		)
 	}
@@ -339,49 +360,39 @@ func checkMoveAccess(
 		return err
 	}
 
-	for _, verb := range escalationVerbs {
-		newState, nOk := batchResp.Results[newPrefix+verb]
-		oldState, oOk := batchResp.Results[oldPrefix+verb]
-		// Fail closed on missing result: we built both correlation IDs ourselves.
-		if !nOk || !oOk {
-			return fmt.Errorf("access escalation check returned no result for verb %q", verb)
+	writeRes, ok := batchResp.Results[writeDestKey]
+	if !ok {
+		return fmt.Errorf("access check returned no result for destination write")
+	}
+	if writeRes.Error != nil {
+		return writeRes.Error
+	}
+	if !writeRes.Allowed {
+		destLabel := newParentUID
+		if destLabel == folder.RootFolderUID {
+			destLabel = folder.GeneralFolderUID
 		}
-		if newState.Error != nil {
-			return newState.Error
-		}
-		if oldState.Error != nil {
-			return oldState.Error
-		}
-		if newState.Allowed && !oldState.Allowed {
-			return folder.ErrAccessEscalation.Errorf("user cannot move a folder to another folder where they have higher permissions")
-		}
+		return folder.ErrMoveAccessDenied.Errorf("user does not have permissions to move a folder to folder with UID %s", destLabel)
 	}
 
-	// Dashboards inside source inherit from the destination post-move.
-	dashGVR := dashv1.DashboardResourceInfo.GroupVersionResource()
 	for _, verb := range escalationVerbs {
-		newResp, err := accessClient.Check(ctx, user, authlib.CheckRequest{
-			Verb:      verb,
-			Group:     dashGVR.Group,
-			Resource:  dashGVR.Resource,
-			Namespace: namespace,
-		}, newParentUID)
-		if err != nil {
-			return err
+		newFolderState, nfOk := batchResp.Results[newFolderPrefix+verb]
+		oldFolderState, ofOk := batchResp.Results[oldFolderPrefix+verb]
+		newDashState, ndOk := batchResp.Results[newDashPrefix+verb]
+		sourceDashState, sdOk := batchResp.Results[sourceDashPrefix+verb]
+		// Fail closed on missing result: we built all correlation IDs ourselves.
+		if !nfOk || !ofOk || !ndOk || !sdOk {
+			return fmt.Errorf("access escalation check returned no result for verb %q", verb)
 		}
-		if !newResp.Allowed {
-			continue
+		for _, state := range []authlib.BatchCheckResult{newFolderState, oldFolderState, newDashState, sourceDashState} {
+			if state.Error != nil {
+				return state.Error
+			}
 		}
-		todayResp, err := accessClient.Check(ctx, user, authlib.CheckRequest{
-			Verb:      verb,
-			Group:     dashGVR.Group,
-			Resource:  dashGVR.Resource,
-			Namespace: namespace,
-		}, sourceUID)
-		if err != nil {
-			return err
+		if newFolderState.Allowed && !oldFolderState.Allowed {
+			return folder.ErrAccessEscalation.Errorf("user cannot move a folder to another folder where they have higher permissions")
 		}
-		if !todayResp.Allowed {
+		if newDashState.Allowed && !sourceDashState.Allowed {
 			return folder.ErrAccessEscalation.Errorf("user cannot move a folder to another folder where they have higher permissions")
 		}
 	}

--- a/pkg/registry/apis/folders/validate_test.go
+++ b/pkg/registry/apis/folders/validate_test.go
@@ -1440,10 +1440,10 @@ func TestCheckMoveAccess(t *testing.T) {
 			allows:    []allow{canCreateInNew},
 		},
 		{
-			name:      "verb allowed on source only under new parent is escalation",
-			newParent: newParentUID,
-			oldParent: oldParentUID,
-			allows:    []allow{canCreateInNew, canUpdateOnSourceUnderNew},
+			name:        "verb allowed on source only under new parent is escalation",
+			newParent:   newParentUID,
+			oldParent:   oldParentUID,
+			allows:      []allow{canCreateInNew, canUpdateOnSourceUnderNew},
 			expectedErr: "folders.accessEscalation",
 		},
 		{
@@ -1459,9 +1459,9 @@ func TestCheckMoveAccess(t *testing.T) {
 			allows:    []allow{{verb: utils.VerbCreate, folder: ""}},
 		},
 		{
-			name:      "move to root denied without create at root",
-			newParent: folder.RootFolderUID,
-			oldParent: oldParentUID,
+			name:        "move to root denied without create at root",
+			newParent:   folder.RootFolderUID,
+			oldParent:   oldParentUID,
 			expectedErr: "folders.forbiddenMove",
 		},
 	}

--- a/pkg/registry/apis/folders/validate_test.go
+++ b/pkg/registry/apis/folders/validate_test.go
@@ -11,7 +11,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	authlib "github.com/grafana/authlib/types"
-	dashv1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
 	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
@@ -1406,12 +1405,8 @@ func TestCheckMoveAccess(t *testing.T) {
 	)
 
 	folderGVR := folders.FolderResourceInfo.GroupVersionResource()
-	dashGVR := dashv1.DashboardResourceInfo.GroupVersionResource()
 	allowFolder := func(verb, name, folderUID string) allow {
 		return allow{group: folderGVR.Group, resource: folderGVR.Resource, verb: verb, name: name, folder: folderUID}
-	}
-	allowDash := func(verb, name, folderUID string) allow {
-		return allow{group: dashGVR.Group, resource: dashGVR.Resource, verb: verb, name: name, folder: folderUID}
 	}
 
 	// Common allows: user can update source under its current parent (so the
@@ -1475,33 +1470,52 @@ func TestCheckMoveAccess(t *testing.T) {
 			expectedErr: "folders.forbiddenMove",
 		},
 		{
-			name:      "dashboards read on new parent only is escalation",
+			// Tier model: gaining a *different* verb at the same tier is not
+			// escalation. Old=update (Editor), new=delete (Editor) → no jump.
+			name:      "same-tier verb swap (update→delete) is not escalation",
 			newParent: newParentUID,
 			oldParent: oldParentUID,
 			allows: []allow{
 				canCreateFolderInNew,
-				allowDash(utils.VerbGet, "", newParentUID),
+				allowFolder(utils.VerbUpdate, sourceUID, oldParentUID),
+				allowFolder(utils.VerbDelete, sourceUID, newParentUID),
+			},
+		},
+		{
+			// Tier model: losing capability at the destination is never
+			// escalation. Old=Admin (setperms), new=Editor (update only).
+			name:      "tier downgrade Admin→Editor is not escalation",
+			newParent: newParentUID,
+			oldParent: oldParentUID,
+			allows: []allow{
+				canCreateFolderInNew,
+				allowFolder(utils.VerbSetPermissions, sourceUID, oldParentUID),
+				allowFolder(utils.VerbUpdate, sourceUID, newParentUID),
+			},
+		},
+		{
+			// Tier model: gaining Admin (setperms) where the user only had
+			// Editor (update) before is a tier jump → escalation.
+			name:      "tier upgrade Editor→Admin on folder is escalation",
+			newParent: newParentUID,
+			oldParent: oldParentUID,
+			allows: []allow{
+				canCreateFolderInNew,
+				canUpdateOnSourceUnderOld,
+				canUpdateOnSourceUnderNew,
+				allowFolder(utils.VerbSetPermissions, sourceUID, newParentUID),
 			},
 			expectedErr: "folders.accessEscalation",
 		},
 		{
-			name:      "dashboards read on source folder today is not escalation",
+			// Tier model: gaining View (None → Viewer) is a tier jump on its
+			// own → escalation. Catches read-only access gained by the move.
+			name:      "tier upgrade None→Viewer is escalation",
 			newParent: newParentUID,
 			oldParent: oldParentUID,
 			allows: []allow{
 				canCreateFolderInNew,
-				allowDash(utils.VerbGet, "", newParentUID),
-				// direct grant on source folder, unaffected by the move
-				allowDash(utils.VerbGet, "", sourceUID),
-			},
-		},
-		{
-			name:      "dashboards write on new parent only is escalation",
-			newParent: newParentUID,
-			oldParent: oldParentUID,
-			allows: []allow{
-				canCreateFolderInNew,
-				allowDash(utils.VerbUpdate, "", newParentUID),
+				allowFolder(utils.VerbGet, sourceUID, newParentUID),
 			},
 			expectedErr: "folders.accessEscalation",
 		},

--- a/pkg/registry/apis/folders/validate_test.go
+++ b/pkg/registry/apis/folders/validate_test.go
@@ -11,6 +11,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	authlib "github.com/grafana/authlib/types"
+	dashv1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
 	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
@@ -1391,9 +1392,9 @@ func (m *mockSearchClient) Search(ctx context.Context, req *resourcepb.ResourceS
 	return resp, nil
 }
 
-// allow is a single (verb, name, folder) tuple the mock authlib client treats
-// as Allowed; everything else is denied.
-type allow struct{ verb, name, folder string }
+// allow is a single (group, resource, verb, name, folder) tuple the mock
+// authlib client treats as Allowed; everything else is denied.
+type allow struct{ group, resource, verb, name, folder string }
 
 func TestCheckMoveAccess(t *testing.T) {
 	const (
@@ -1404,13 +1405,22 @@ func TestCheckMoveAccess(t *testing.T) {
 		newParentUID = "newParent"
 	)
 
+	folderGVR := folders.FolderResourceInfo.GroupVersionResource()
+	dashGVR := dashv1.DashboardResourceInfo.GroupVersionResource()
+	allowFolder := func(verb, name, folderUID string) allow {
+		return allow{group: folderGVR.Group, resource: folderGVR.Resource, verb: verb, name: name, folder: folderUID}
+	}
+	allowDash := func(verb, name, folderUID string) allow {
+		return allow{group: dashGVR.Group, resource: dashGVR.Resource, verb: verb, name: name, folder: folderUID}
+	}
+
 	// Common allows: user can update source under its current parent (so the
 	// escalation check passes for "update" when present), and can create
 	// folders in the new parent (so destination-write passes). Tests override
 	// these via additionalAllows / nilClient / no destination-write entry.
-	canCreateInNew := allow{verb: utils.VerbCreate, folder: newParentUID}
-	canUpdateOnSourceUnderOld := allow{verb: utils.VerbUpdate, name: sourceUID, folder: oldParentUID}
-	canUpdateOnSourceUnderNew := allow{verb: utils.VerbUpdate, name: sourceUID, folder: newParentUID}
+	canCreateFolderInNew := allowFolder(utils.VerbCreate, "", newParentUID)
+	canUpdateOnSourceUnderOld := allowFolder(utils.VerbUpdate, sourceUID, oldParentUID)
+	canUpdateOnSourceUnderNew := allowFolder(utils.VerbUpdate, sourceUID, newParentUID)
 
 	tests := []struct {
 		name        string
@@ -1430,39 +1440,70 @@ func TestCheckMoveAccess(t *testing.T) {
 			name:      "no create on new parent denies the move",
 			newParent: newParentUID,
 			oldParent: oldParentUID,
-			// no canCreateInNew → destination-write fails
+			// no canCreateFolderInNew → destination-write fails
 			expectedErr: "folders.forbiddenMove",
 		},
 		{
 			name:      "create on new parent and no extra capabilities is allowed",
 			newParent: newParentUID,
 			oldParent: oldParentUID,
-			allows:    []allow{canCreateInNew},
+			allows:    []allow{canCreateFolderInNew},
 		},
 		{
-			name:        "verb allowed on source only under new parent is escalation",
+			name:        "folder verb allowed on source only under new parent is escalation",
 			newParent:   newParentUID,
 			oldParent:   oldParentUID,
-			allows:      []allow{canCreateInNew, canUpdateOnSourceUnderNew},
+			allows:      []allow{canCreateFolderInNew, canUpdateOnSourceUnderNew},
 			expectedErr: "folders.accessEscalation",
 		},
 		{
-			name:      "verb allowed on source under both parents is not escalation",
+			name:      "folder verb allowed on source under both parents is not escalation",
 			newParent: newParentUID,
 			oldParent: oldParentUID,
-			allows:    []allow{canCreateInNew, canUpdateOnSourceUnderNew, canUpdateOnSourceUnderOld},
+			allows:    []allow{canCreateFolderInNew, canUpdateOnSourceUnderNew, canUpdateOnSourceUnderOld},
 		},
 		{
 			name:      "move to root requires create at root",
 			newParent: folder.RootFolderUID,
 			oldParent: oldParentUID,
-			allows:    []allow{{verb: utils.VerbCreate, folder: ""}},
+			allows:    []allow{allowFolder(utils.VerbCreate, "", "")},
 		},
 		{
 			name:        "move to root denied without create at root",
 			newParent:   folder.RootFolderUID,
 			oldParent:   oldParentUID,
 			expectedErr: "folders.forbiddenMove",
+		},
+		{
+			name:      "dashboards read on new parent only is escalation",
+			newParent: newParentUID,
+			oldParent: oldParentUID,
+			allows: []allow{
+				canCreateFolderInNew,
+				allowDash(utils.VerbGet, "", newParentUID),
+			},
+			expectedErr: "folders.accessEscalation",
+		},
+		{
+			name:      "dashboards read on source folder today is not escalation",
+			newParent: newParentUID,
+			oldParent: oldParentUID,
+			allows: []allow{
+				canCreateFolderInNew,
+				allowDash(utils.VerbGet, "", newParentUID),
+				// direct grant on source folder, unaffected by the move
+				allowDash(utils.VerbGet, "", sourceUID),
+			},
+		},
+		{
+			name:      "dashboards write on new parent only is escalation",
+			newParent: newParentUID,
+			oldParent: oldParentUID,
+			allows: []allow{
+				canCreateFolderInNew,
+				allowDash(utils.VerbUpdate, "", newParentUID),
+			},
+			expectedErr: "folders.accessEscalation",
 		},
 	}
 
@@ -1502,14 +1543,14 @@ func newMockAccessClient(allows []allow) *mockAccessClient {
 }
 
 func (m *mockAccessClient) Check(_ context.Context, _ authlib.AuthInfo, req authlib.CheckRequest, folder string) (authlib.CheckResponse, error) {
-	_, ok := m.allowed[allow{verb: req.Verb, name: req.Name, folder: folder}]
+	_, ok := m.allowed[allow{group: req.Group, resource: req.Resource, verb: req.Verb, name: req.Name, folder: folder}]
 	return authlib.CheckResponse{Allowed: ok, Zookie: authlib.NoopZookie{}}, nil
 }
 
 func (m *mockAccessClient) BatchCheck(_ context.Context, _ authlib.AuthInfo, req authlib.BatchCheckRequest) (authlib.BatchCheckResponse, error) {
 	results := make(map[string]authlib.BatchCheckResult, len(req.Checks))
 	for _, c := range req.Checks {
-		_, ok := m.allowed[allow{verb: c.Verb, name: c.Name, folder: c.Folder}]
+		_, ok := m.allowed[allow{group: c.Group, resource: c.Resource, verb: c.Verb, name: c.Name, folder: c.Folder}]
 		results[c.CorrelationID] = authlib.BatchCheckResult{Allowed: ok}
 	}
 	return authlib.BatchCheckResponse{Results: results}, nil

--- a/pkg/registry/apis/folders/validate_test.go
+++ b/pkg/registry/apis/folders/validate_test.go
@@ -10,14 +10,12 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	authlib "github.com/grafana/authlib/types"
 	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
-	"github.com/grafana/grafana/pkg/services/accesscontrol"
-	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
 	"github.com/grafana/grafana/pkg/services/dashboards"
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
@@ -1393,128 +1391,94 @@ func (m *mockSearchClient) Search(ctx context.Context, req *resourcepb.ResourceS
 	return resp, nil
 }
 
+// allow is a single (verb, name, folder) tuple the mock authlib client treats
+// as Allowed; everything else is denied.
+type allow struct{ verb, name, folder string }
+
 func TestCheckMoveAccess(t *testing.T) {
-	const orgID int64 = 1
-	scope := folder.ScopeFoldersProvider.GetResourceScopeUID
 	const (
-		sourceUID     = "source"
-		destUID       = "dest"
-		destParentUID = "destParent"
+		namespace    = "default"
+		orgID        = int64(1)
+		sourceUID    = "source"
+		oldParentUID = "oldParent"
+		newParentUID = "newParent"
 	)
-	destAncestors := []folders.FolderInfo{
-		{Name: destUID, Parent: destParentUID},
-		{Name: destParentUID, Parent: folder.GeneralFolderUID},
-		{Name: folder.GeneralFolderUID},
-	}
+
+	// Common allows: user can update source under its current parent (so the
+	// escalation check passes for "update" when present), and can create
+	// folders in the new parent (so destination-write passes). Tests override
+	// these via additionalAllows / nilClient / no destination-write entry.
+	canCreateInNew := allow{verb: utils.VerbCreate, folder: newParentUID}
+	canUpdateOnSourceUnderOld := allow{verb: utils.VerbUpdate, name: sourceUID, folder: oldParentUID}
+	canUpdateOnSourceUnderNew := allow{verb: utils.VerbUpdate, name: sourceUID, folder: newParentUID}
 
 	tests := []struct {
-		name         string
-		newParentUID string
-		ancestors    []folders.FolderInfo
-		permissions  map[string][]string
-		accessNil    bool
-		expectedErr  string
+		name        string
+		newParent   string
+		oldParent   string
+		nilClient   bool
+		allows      []allow
+		expectedErr string
 	}{
 		{
-			name:         "nil accessControl is a no-op",
-			newParentUID: destUID,
-			ancestors:    destAncestors,
-			accessNil:    true,
+			name:      "nil accessClient is a no-op",
+			newParent: newParentUID,
+			oldParent: oldParentUID,
+			nilClient: true,
 		},
 		{
-			name:         "write on destination matches on source, no escalation",
-			newParentUID: destUID,
-			ancestors:    destAncestors,
-			permissions: map[string][]string{
-				folder.ActionFoldersWrite: {scope(destUID), scope(sourceUID)},
-			},
-		},
-		{
-			name:         "create on destination matches on source, no escalation",
-			newParentUID: destUID,
-			ancestors:    destAncestors,
-			permissions: map[string][]string{
-				folder.ActionFoldersCreate: {scope(destUID), scope(sourceUID)},
-			},
-		},
-		{
-			name:         "move to root requires create on general folder",
-			newParentUID: folder.RootFolderUID,
-			permissions: map[string][]string{
-				folder.ActionFoldersCreate: {scope(folder.GeneralFolderUID), scope(sourceUID)},
-			},
-		},
-		{
-			name:         "move to root denied without create on general",
-			newParentUID: folder.RootFolderUID,
-			permissions: map[string][]string{
-				folder.ActionFoldersWrite: {scope(folder.GeneralFolderUID)},
-			},
+			name:      "no create on new parent denies the move",
+			newParent: newParentUID,
+			oldParent: oldParentUID,
+			// no canCreateInNew → destination-write fails
 			expectedErr: "folders.forbiddenMove",
 		},
 		{
-			name:         "no write or create on destination",
-			newParentUID: destUID,
-			ancestors:    destAncestors,
-			permissions: map[string][]string{
-				folder.ActionFoldersRead: {scope(destUID)},
-			},
+			name:      "create on new parent and no extra capabilities is allowed",
+			newParent: newParentUID,
+			oldParent: oldParentUID,
+			allows:    []allow{canCreateInNew},
+		},
+		{
+			name:      "verb allowed on source only under new parent is escalation",
+			newParent: newParentUID,
+			oldParent: oldParentUID,
+			allows:    []allow{canCreateInNew, canUpdateOnSourceUnderNew},
+			expectedErr: "folders.accessEscalation",
+		},
+		{
+			name:      "verb allowed on source under both parents is not escalation",
+			newParent: newParentUID,
+			oldParent: oldParentUID,
+			allows:    []allow{canCreateInNew, canUpdateOnSourceUnderNew, canUpdateOnSourceUnderOld},
+		},
+		{
+			name:      "move to root requires create at root",
+			newParent: folder.RootFolderUID,
+			oldParent: oldParentUID,
+			allows:    []allow{{verb: utils.VerbCreate, folder: ""}},
+		},
+		{
+			name:      "move to root denied without create at root",
+			newParent: folder.RootFolderUID,
+			oldParent: oldParentUID,
 			expectedErr: "folders.forbiddenMove",
-		},
-		{
-			name:         "escalation via permission on destination only",
-			newParentUID: destUID,
-			ancestors:    destAncestors,
-			permissions: map[string][]string{
-				folder.ActionFoldersWrite: {scope(destUID)},
-				folder.ActionFoldersRead:  {scope(destUID)},
-			},
-			expectedErr: "folders.accessEscalation",
-		},
-		{
-			name:         "escalation via permission on destination ancestor",
-			newParentUID: destUID,
-			ancestors:    destAncestors,
-			permissions: map[string][]string{
-				folder.ActionFoldersWrite: {scope(destUID)},
-				folder.ActionFoldersRead:  {scope(destParentUID)},
-			},
-			expectedErr: "folders.accessEscalation",
-		},
-		{
-			name:         "matching permission on source prevents escalation",
-			newParentUID: destUID,
-			ancestors:    destAncestors,
-			permissions: map[string][]string{
-				folder.ActionFoldersWrite: {scope(destUID), scope(sourceUID)},
-				folder.ActionFoldersRead:  {scope(destUID), scope(sourceUID)},
-			},
-		},
-		{
-			name:         "wildcard on every action satisfies escalation check",
-			newParentUID: destUID,
-			ancestors:    destAncestors,
-			permissions: map[string][]string{
-				folder.ActionFoldersWrite: {folder.ScopeFoldersAll},
-				folder.ActionFoldersRead:  {folder.ScopeFoldersAll},
-			},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := identity.WithRequester(context.Background(), &user.SignedInUser{
-				UserID:      1,
-				OrgID:       orgID,
-				Permissions: map[int64]map[string][]string{orgID: tt.permissions},
+				UserID: 1,
+				OrgID:  orgID,
 			})
 
-			var ac accesscontrol.AccessControl
-			if !tt.accessNil {
-				ac = acimpl.ProvideAccessControl(featuremgmt.WithFeatures())
+			var client authlib.AccessClient
+			if !tt.nilClient {
+				client = newMockAccessClient(tt.allows)
 			}
 
-			err := checkMoveAccess(ctx, sourceUID, tt.newParentUID, tt.ancestors, ac)
+			err := checkMoveAccess(ctx, namespace, sourceUID, tt.oldParent, tt.newParent, client)
 			if tt.expectedErr == "" {
 				require.NoError(t, err)
 				return
@@ -1523,6 +1487,36 @@ func TestCheckMoveAccess(t *testing.T) {
 			require.Contains(t, err.Error(), tt.expectedErr)
 		})
 	}
+}
+
+type mockAccessClient struct {
+	allowed map[allow]struct{}
+}
+
+func newMockAccessClient(allows []allow) *mockAccessClient {
+	m := &mockAccessClient{allowed: make(map[allow]struct{}, len(allows))}
+	for _, a := range allows {
+		m.allowed[a] = struct{}{}
+	}
+	return m
+}
+
+func (m *mockAccessClient) Check(_ context.Context, _ authlib.AuthInfo, req authlib.CheckRequest, folder string) (authlib.CheckResponse, error) {
+	_, ok := m.allowed[allow{verb: req.Verb, name: req.Name, folder: folder}]
+	return authlib.CheckResponse{Allowed: ok, Zookie: authlib.NoopZookie{}}, nil
+}
+
+func (m *mockAccessClient) BatchCheck(_ context.Context, _ authlib.AuthInfo, req authlib.BatchCheckRequest) (authlib.BatchCheckResponse, error) {
+	results := make(map[string]authlib.BatchCheckResult, len(req.Checks))
+	for _, c := range req.Checks {
+		_, ok := m.allowed[allow{verb: c.Verb, name: c.Name, folder: c.Folder}]
+		results[c.CorrelationID] = authlib.BatchCheckResult{Allowed: ok}
+	}
+	return authlib.BatchCheckResponse{Results: results}, nil
+}
+
+func (m *mockAccessClient) Compile(_ context.Context, _ authlib.AuthInfo, _ authlib.ListRequest) (authlib.ItemChecker, authlib.Zookie, error) {
+	return func(string, string) bool { return false }, authlib.NoopZookie{}, nil
 }
 
 // RebuildIndexes implements resourcepb.ResourceIndexClient.

--- a/pkg/registry/apis/folders/validate_test.go
+++ b/pkg/registry/apis/folders/validate_test.go
@@ -1515,23 +1515,58 @@ func TestCheckMoveAccess(t *testing.T) {
 			})
 
 			var client authlib.AccessClient
+			var mock *mockAccessClient
 			if !tt.nilClient {
-				client = newMockAccessClient(tt.allows)
+				mock = newMockAccessClient(tt.allows)
+				client = mock
 			}
 
 			err := checkMoveAccess(ctx, namespace, sourceUID, tt.oldParent, tt.newParent, client)
 			if tt.expectedErr == "" {
 				require.NoError(t, err)
-				return
+			} else {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), tt.expectedErr)
 			}
-			require.Error(t, err)
-			require.Contains(t, err.Error(), tt.expectedErr)
+
+			// All access checks must be batched into one BatchCheck round-trip.
+			if mock != nil {
+				require.Equal(t, 1, mock.batchCheckCall, "expected exactly one BatchCheck call")
+			}
 		})
 	}
+
+	t.Run("surfaces BatchCheck transport error", func(t *testing.T) {
+		ctx := identity.WithRequester(context.Background(), &user.SignedInUser{UserID: 1, OrgID: orgID})
+		mock := newMockAccessClient(nil)
+		mock.batchCheckErr = fmt.Errorf("boom")
+		err := checkMoveAccess(ctx, namespace, sourceUID, oldParentUID, newParentUID, mock)
+		require.ErrorContains(t, err, "boom")
+		require.Equal(t, 1, mock.batchCheckCall)
+	})
+
+	t.Run("fails closed when BatchCheck omits the write-destination result", func(t *testing.T) {
+		ctx := identity.WithRequester(context.Background(), &user.SignedInUser{UserID: 1, OrgID: orgID})
+		mock := newMockAccessClient([]allow{canCreateFolderInNew})
+		mock.dropResultFor = "writeDest"
+		err := checkMoveAccess(ctx, namespace, sourceUID, oldParentUID, newParentUID, mock)
+		require.ErrorContains(t, err, "no result for destination write")
+	})
+
+	t.Run("fails closed when BatchCheck omits an escalation verb result", func(t *testing.T) {
+		ctx := identity.WithRequester(context.Background(), &user.SignedInUser{UserID: 1, OrgID: orgID})
+		mock := newMockAccessClient([]allow{canCreateFolderInNew})
+		mock.dropResultFor = "newFolder|" + utils.VerbGet
+		err := checkMoveAccess(ctx, namespace, sourceUID, oldParentUID, newParentUID, mock)
+		require.ErrorContains(t, err, "no result for verb")
+	})
 }
 
 type mockAccessClient struct {
-	allowed map[allow]struct{}
+	allowed        map[allow]struct{}
+	batchCheckCall int
+	batchCheckErr  error
+	dropResultFor  string // CorrelationID to omit from BatchCheckResponse, simulating a bad server
 }
 
 func newMockAccessClient(allows []allow) *mockAccessClient {
@@ -1548,8 +1583,15 @@ func (m *mockAccessClient) Check(_ context.Context, _ authlib.AuthInfo, req auth
 }
 
 func (m *mockAccessClient) BatchCheck(_ context.Context, _ authlib.AuthInfo, req authlib.BatchCheckRequest) (authlib.BatchCheckResponse, error) {
+	m.batchCheckCall++
+	if m.batchCheckErr != nil {
+		return authlib.BatchCheckResponse{}, m.batchCheckErr
+	}
 	results := make(map[string]authlib.BatchCheckResult, len(req.Checks))
 	for _, c := range req.Checks {
+		if c.CorrelationID == m.dropResultFor {
+			continue
+		}
 		_, ok := m.allowed[allow{group: c.Group, resource: c.Resource, verb: c.Verb, name: c.Name, folder: c.Folder}]
 		results[c.CorrelationID] = authlib.BatchCheckResult{Allowed: ok}
 	}

--- a/pkg/registry/apis/folders/validate_test.go
+++ b/pkg/registry/apis/folders/validate_test.go
@@ -1459,13 +1459,13 @@ func TestCheckMoveAccess(t *testing.T) {
 		},
 		{
 			name:      "move to root requires create at root",
-			newParent: folder.RootFolderUID,
+			newParent: folder.GeneralFolderUID,
 			oldParent: oldParentUID,
-			allows:    []allow{allowFolder(utils.VerbCreate, "", "")},
+			allows:    []allow{allowFolder(utils.VerbCreate, "", folder.GeneralFolderUID)},
 		},
 		{
 			name:        "move to root denied without create at root",
-			newParent:   folder.RootFolderUID,
+			newParent:   folder.GeneralFolderUID,
 			oldParent:   oldParentUID,
 			expectedErr: "folders.forbiddenMove",
 		},

--- a/pkg/registry/apis/folders/validate_test.go
+++ b/pkg/registry/apis/folders/validate_test.go
@@ -11,10 +11,15 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/accesscontrol/acimpl"
 	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder"
+	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
@@ -845,6 +850,7 @@ func TestValidateUpdate(t *testing.T) {
 					return tt.parents, tt.parentsError
 				},
 				&mockSearchClient{folders: tt.allFolders},
+				nil,
 				maxDepth)
 
 			if tt.expectedErr == "" {
@@ -1385,6 +1391,138 @@ func (m *mockSearchClient) Search(ctx context.Context, req *resourcepb.ResourceS
 		resp.TotalHits = total
 	}
 	return resp, nil
+}
+
+func TestCheckMoveAccess(t *testing.T) {
+	const orgID int64 = 1
+	scope := folder.ScopeFoldersProvider.GetResourceScopeUID
+	const (
+		sourceUID     = "source"
+		destUID       = "dest"
+		destParentUID = "destParent"
+	)
+	destAncestors := []folders.FolderInfo{
+		{Name: destUID, Parent: destParentUID},
+		{Name: destParentUID, Parent: folder.GeneralFolderUID},
+		{Name: folder.GeneralFolderUID},
+	}
+
+	tests := []struct {
+		name         string
+		newParentUID string
+		ancestors    []folders.FolderInfo
+		permissions  map[string][]string
+		accessNil    bool
+		expectedErr  string
+	}{
+		{
+			name:         "nil accessControl is a no-op",
+			newParentUID: destUID,
+			ancestors:    destAncestors,
+			accessNil:    true,
+		},
+		{
+			name:         "write on destination matches on source, no escalation",
+			newParentUID: destUID,
+			ancestors:    destAncestors,
+			permissions: map[string][]string{
+				folder.ActionFoldersWrite: {scope(destUID), scope(sourceUID)},
+			},
+		},
+		{
+			name:         "create on destination matches on source, no escalation",
+			newParentUID: destUID,
+			ancestors:    destAncestors,
+			permissions: map[string][]string{
+				folder.ActionFoldersCreate: {scope(destUID), scope(sourceUID)},
+			},
+		},
+		{
+			name:         "move to root requires create on general folder",
+			newParentUID: folder.RootFolderUID,
+			permissions: map[string][]string{
+				folder.ActionFoldersCreate: {scope(folder.GeneralFolderUID), scope(sourceUID)},
+			},
+		},
+		{
+			name:         "move to root denied without create on general",
+			newParentUID: folder.RootFolderUID,
+			permissions: map[string][]string{
+				folder.ActionFoldersWrite: {scope(folder.GeneralFolderUID)},
+			},
+			expectedErr: "folders.forbiddenMove",
+		},
+		{
+			name:         "no write or create on destination",
+			newParentUID: destUID,
+			ancestors:    destAncestors,
+			permissions: map[string][]string{
+				folder.ActionFoldersRead: {scope(destUID)},
+			},
+			expectedErr: "folders.forbiddenMove",
+		},
+		{
+			name:         "escalation via permission on destination only",
+			newParentUID: destUID,
+			ancestors:    destAncestors,
+			permissions: map[string][]string{
+				folder.ActionFoldersWrite: {scope(destUID)},
+				folder.ActionFoldersRead:  {scope(destUID)},
+			},
+			expectedErr: "folders.accessEscalation",
+		},
+		{
+			name:         "escalation via permission on destination ancestor",
+			newParentUID: destUID,
+			ancestors:    destAncestors,
+			permissions: map[string][]string{
+				folder.ActionFoldersWrite: {scope(destUID)},
+				folder.ActionFoldersRead:  {scope(destParentUID)},
+			},
+			expectedErr: "folders.accessEscalation",
+		},
+		{
+			name:         "matching permission on source prevents escalation",
+			newParentUID: destUID,
+			ancestors:    destAncestors,
+			permissions: map[string][]string{
+				folder.ActionFoldersWrite: {scope(destUID), scope(sourceUID)},
+				folder.ActionFoldersRead:  {scope(destUID), scope(sourceUID)},
+			},
+		},
+		{
+			name:         "wildcard on every action satisfies escalation check",
+			newParentUID: destUID,
+			ancestors:    destAncestors,
+			permissions: map[string][]string{
+				folder.ActionFoldersWrite: {folder.ScopeFoldersAll},
+				folder.ActionFoldersRead:  {folder.ScopeFoldersAll},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := identity.WithRequester(context.Background(), &user.SignedInUser{
+				UserID:      1,
+				OrgID:       orgID,
+				Permissions: map[int64]map[string][]string{orgID: tt.permissions},
+			})
+
+			var ac accesscontrol.AccessControl
+			if !tt.accessNil {
+				ac = acimpl.ProvideAccessControl(featuremgmt.WithFeatures())
+			}
+
+			err := checkMoveAccess(ctx, sourceUID, tt.newParentUID, tt.ancestors, ac)
+			if tt.expectedErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			require.Contains(t, err.Error(), tt.expectedErr)
+		})
+	}
 }
 
 // RebuildIndexes implements resourcepb.ResourceIndexClient.

--- a/pkg/server/wire_gen.go
+++ b/pkg/server/wire_gen.go
@@ -939,7 +939,7 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts Options, apiOpts api
 	if err != nil {
 		return nil, err
 	}
-	folderAPIBuilder := folders.RegisterAPIService(cfg, featureToggles, apiserverService, folderPermissionsService, accessClient, accessControl, registerer, resourceClient, zanzanaClient)
+	folderAPIBuilder := folders.RegisterAPIService(cfg, featureToggles, apiserverService, folderPermissionsService, accessClient, registerer, resourceClient, zanzanaClient)
 	roleApiInstaller := iam.ProvideNoopRoleApiInstaller()
 	globalRoleApiInstaller := inmemory.ProvideInMemoryGlobalRoleApiInstaller(acimplService)
 	teamLBACApiInstaller := iam.ProvideNoopTeamLBACApiInstaller()
@@ -1668,7 +1668,7 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	if err != nil {
 		return nil, err
 	}
-	folderAPIBuilder := folders.RegisterAPIService(cfg, featureToggles, apiserverService, folderPermissionsService, accessClient, accessControl, registerer, resourceClient, zanzanaClient)
+	folderAPIBuilder := folders.RegisterAPIService(cfg, featureToggles, apiserverService, folderPermissionsService, accessClient, registerer, resourceClient, zanzanaClient)
 	roleApiInstaller := iam.ProvideNoopRoleApiInstaller()
 	globalRoleApiInstaller := inmemory.ProvideInMemoryGlobalRoleApiInstaller(acimplService)
 	teamLBACApiInstaller := iam.ProvideNoopTeamLBACApiInstaller()

--- a/pkg/server/wire_gen.go
+++ b/pkg/server/wire_gen.go
@@ -939,7 +939,7 @@ func Initialize(ctx context.Context, cfg *setting.Cfg, opts Options, apiOpts api
 	if err != nil {
 		return nil, err
 	}
-	folderAPIBuilder := folders.RegisterAPIService(cfg, featureToggles, apiserverService, folderPermissionsService, accessClient, registerer, resourceClient, zanzanaClient)
+	folderAPIBuilder := folders.RegisterAPIService(cfg, featureToggles, apiserverService, folderPermissionsService, accessClient, accessControl, registerer, resourceClient, zanzanaClient)
 	roleApiInstaller := iam.ProvideNoopRoleApiInstaller()
 	globalRoleApiInstaller := inmemory.ProvideInMemoryGlobalRoleApiInstaller(acimplService)
 	teamLBACApiInstaller := iam.ProvideNoopTeamLBACApiInstaller()
@@ -1668,7 +1668,7 @@ func InitializeForTest(ctx context.Context, t sqlutil.ITestDB, testingT interfac
 	if err != nil {
 		return nil, err
 	}
-	folderAPIBuilder := folders.RegisterAPIService(cfg, featureToggles, apiserverService, folderPermissionsService, accessClient, registerer, resourceClient, zanzanaClient)
+	folderAPIBuilder := folders.RegisterAPIService(cfg, featureToggles, apiserverService, folderPermissionsService, accessClient, accessControl, registerer, resourceClient, zanzanaClient)
 	roleApiInstaller := iam.ProvideNoopRoleApiInstaller()
 	globalRoleApiInstaller := inmemory.ProvideInMemoryGlobalRoleApiInstaller(acimplService)
 	teamLBACApiInstaller := iam.ProvideNoopTeamLBACApiInstaller()


### PR DESCRIPTION
Refactor `checkMoveAccess` to use folder-tier comparison instead of per-verb gates.

- Resolve the user's tier (`Viewer`/`Editor`/`Admin`) at the source folder under the old vs new parent via one `BatchCheck`.
- Escalation = `tier(new) > tier(old)`. Sub-resource actions (dashboards, library panels, alerts, annotations) are bundled with the folder tier in built-in roles, so a folder-tier jump catches them transitively.
- Same model the `/access` subresource uses.

> ⚠️ Custom roles that grant a sub-resource action (e.g. `library.panels:write`) directly at folder scope without the corresponding folder permission are no longer flagged — legacy `folderimpl.canMove` catches these via its full permission scan. Built-in Viewer/Editor/Admin roles are unaffected. Documented in the `folderTier` comment.


Ticket: https://github.com/grafana/search-and-storage-team/issues/794