### PR TITLE
[release-13.0.2] DateTime: Skip dateTimeFormat (regionalFormatPreference) tests 

### DIFF
--- a/packages/grafana-data/src/datetime/formatter.test.ts
+++ b/packages/grafana-data/src/datetime/formatter.test.ts
@@ -7,7 +7,7 @@ import { dateTimeFormat, dateTimeFormatTimeAgo, dateTimeFormatWithAbbrevation, t
 // Default time zone ("browser") is set to Pacific/Easter in jest.config.js
 const referenceDate = '2020-04-17T12:36:15.779Z';
 
-describe('dateTimeFormat (regionalFormatPreference)', () => {
+describe.skip('dateTimeFormat (regionalFormatPreference)', () => {
   let mockGetFeatureToggle: jest.SpyInstance;
 
   beforeAll(() => {


### PR DESCRIPTION
Backport from #122333