### PR TITLE
Dashboards: Make the sidebar hide-able on desktop

### DIFF
--- a/e2e-playwright/dashboard-new-layouts/dashboard-hide-sidebar.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboard-hide-sidebar.spec.ts
@@ -1,0 +1,112 @@
+import { test, expect } from '@grafana/plugin-e2e';
+
+test.use({
+  featureToggles: {
+    dashboardNewLayouts: true,
+  },
+  viewport: { width: 1920, height: 1080 },
+});
+
+const PAGE_UNDER_TEST = '5SdHCadmz/panel-tests-graph';
+
+test.describe(
+  'Dashboard hide sidebar',
+  {
+    tag: ['@dashboards'],
+  },
+  () => {
+    test('hide button is available in view mode on desktop', async ({ gotoDashboardPage, selectors, page }) => {
+      await gotoDashboardPage({ uid: PAGE_UNDER_TEST });
+
+      const container = page.getByTestId(selectors.components.Sidebar.container);
+      await expect(container).toBeVisible();
+
+      const hideButton = container.getByTestId(selectors.components.Sidebar.showHideToggle);
+      await expect(hideButton).toBeVisible();
+    });
+
+    test('hide button is available in edit mode on desktop', async ({ gotoDashboardPage, selectors, page }) => {
+      const dashboardPage = await gotoDashboardPage({ uid: PAGE_UNDER_TEST });
+
+      await dashboardPage.getByGrafanaSelector(selectors.components.NavToolbar.editDashboard.editButton).click();
+
+      const container = page.getByTestId(selectors.components.Sidebar.container);
+      await expect(container).toBeVisible();
+
+      const hideButton = container.getByTestId(selectors.components.Sidebar.showHideToggle);
+      await expect(hideButton).toBeVisible();
+    });
+
+    test('clicking hide in view mode hides the sidebar and shows the toggle', async ({
+      gotoDashboardPage,
+      selectors,
+      page,
+    }) => {
+      await gotoDashboardPage({ uid: PAGE_UNDER_TEST });
+
+      const container = page.getByTestId(selectors.components.Sidebar.container);
+      await container.getByTestId(selectors.components.Sidebar.showHideToggle).click();
+
+      await expect(container).not.toBeVisible();
+      // The show toggle (rendered when hidden) remains so the user can re-show
+      await expect(page.getByTestId(selectors.components.Sidebar.showHideToggle)).toBeVisible();
+    });
+
+    test('clicking show re-displays the sidebar after hiding it', async ({ gotoDashboardPage, selectors, page }) => {
+      await gotoDashboardPage({ uid: PAGE_UNDER_TEST });
+
+      const container = page.getByTestId(selectors.components.Sidebar.container);
+      await container.getByTestId(selectors.components.Sidebar.showHideToggle).click();
+      await expect(container).not.toBeVisible();
+
+      await page.getByTestId(selectors.components.Sidebar.showHideToggle).click();
+      await expect(container).toBeVisible();
+    });
+
+    test('hidden state is shared between view mode and edit mode', async ({ gotoDashboardPage, selectors, page }) => {
+      const dashboardPage = await gotoDashboardPage({ uid: PAGE_UNDER_TEST });
+
+      // Hide in view mode
+      const container = page.getByTestId(selectors.components.Sidebar.container);
+      await container.getByTestId(selectors.components.Sidebar.showHideToggle).click();
+      await expect(container).not.toBeVisible();
+
+      // Enter edit mode — sidebar should still be hidden
+      await dashboardPage.getByGrafanaSelector(selectors.components.NavToolbar.editDashboard.editButton).click();
+      await expect(container).not.toBeVisible();
+      await expect(page.getByTestId(selectors.components.Sidebar.showHideToggle)).toBeVisible();
+    });
+
+    test('selecting a panel while hidden temporarily shows the sidebar and de-selecting re-hides it', async ({
+      gotoDashboardPage,
+      selectors,
+      page,
+    }) => {
+      const dashboardPage = await gotoDashboardPage({ uid: PAGE_UNDER_TEST });
+
+      // Enter edit mode
+      await dashboardPage.getByGrafanaSelector(selectors.components.NavToolbar.editDashboard.editButton).click();
+
+      const container = page.getByTestId(selectors.components.Sidebar.container);
+      await expect(container).toBeVisible();
+
+      // Hide the sidebar
+      await container.getByTestId(selectors.components.Sidebar.showHideToggle).click();
+      await expect(container).not.toBeVisible();
+
+      // Select a panel — sidebar should reappear temporarily
+      const firstPanel = dashboardPage.getByGrafanaSelector(selectors.components.Panels.Panel.headerContainer).first();
+      await firstPanel.click();
+
+      await expect(container).toBeVisible();
+      // The dock toggle is hidden during temp-show — the user shouldn't dock from this state
+      await expect(container.getByTestId(selectors.components.Sidebar.dockToggle)).not.toBeVisible();
+
+      // Close the pane (de-select) via the X button — sidebar should re-hide
+      await container.getByTestId(selectors.components.Sidebar.closePane).click();
+
+      await expect(container).not.toBeVisible();
+      await expect(page.getByTestId(selectors.components.Sidebar.showHideToggle)).toBeVisible();
+    });
+  }
+);

--- a/packages/grafana-ui/src/components/Sidebar/Sidebar.test.tsx
+++ b/packages/grafana-ui/src/components/Sidebar/Sidebar.test.tsx
@@ -44,14 +44,14 @@ describe('Sidebar', () => {
   });
 
   it('Can persist docked state', async () => {
-    const { unmount } = render(<TestSetup persistanceKey="test" />);
+    const { unmount } = render(<TestSetup persistenceKey="test" />);
 
     act(() => screen.getByLabelText('Settings').click());
     act(() => screen.getByLabelText('Dock').click());
 
     unmount();
 
-    render(<TestSetup persistanceKey="test" />);
+    render(<TestSetup persistenceKey="test" />);
 
     act(() => screen.getByLabelText('Settings').click());
     expect(screen.getByLabelText('Undock')).toBeInTheDocument();
@@ -82,14 +82,14 @@ describe('Sidebar', () => {
     });
 
     it('persists the un-hidden state across remounts', () => {
-      const { unmount } = render(<TestSetup defaultIsHidden persistanceKey="hidden-persist" />);
+      const { unmount } = render(<TestSetup defaultIsHidden persistenceKey="hidden-persist" />);
 
       act(() => screen.getByTestId(selectors.components.Sidebar.showHideToggle).click());
       expect(screen.getByTestId(selectors.components.Sidebar.container)).toBeInTheDocument();
 
       unmount();
 
-      render(<TestSetup defaultIsHidden persistanceKey="hidden-persist" />);
+      render(<TestSetup defaultIsHidden persistenceKey="hidden-persist" />);
       expect(screen.getByTestId(selectors.components.Sidebar.container)).toBeInTheDocument();
     });
 
@@ -121,8 +121,8 @@ describe('Sidebar', () => {
       expect(screen.getByTestId(selectors.components.Sidebar.showHideToggle)).toBeInTheDocument();
     });
 
-    it('shares hidden state across instances via hiddenPersistanceKey', () => {
-      const { unmount } = render(<TestSetup persistanceKey="mode-x" hiddenPersistanceKey="shared-hide" />);
+    it('shares hidden state across instances via hiddenPersistenceKey', () => {
+      const { unmount } = render(<TestSetup persistenceKey="mode-x" hiddenPersistenceKey="shared-hide" />);
 
       // Hide the sidebar (defaults to visible)
       act(() => screen.getByLabelText('Hide').click());
@@ -130,9 +130,9 @@ describe('Sidebar', () => {
 
       unmount();
 
-      // A different consumer with a different persistanceKey but the same hiddenPersistanceKey
+      // A different consumer with a different persistenceKey but the same hiddenPersistenceKey
       // observes the shared hidden state.
-      render(<TestSetup persistanceKey="mode-y" hiddenPersistanceKey="shared-hide" />);
+      render(<TestSetup persistenceKey="mode-y" hiddenPersistenceKey="shared-hide" />);
       expect(screen.getByTestId(selectors.components.Sidebar.showHideToggle)).toBeInTheDocument();
     });
   });
@@ -167,18 +167,18 @@ describe('Sidebar', () => {
 });
 
 interface TestSetupProps {
-  persistanceKey?: string;
+  persistenceKey?: string;
   defaultIsHidden?: boolean;
-  hiddenPersistanceKey?: string;
+  hiddenPersistenceKey?: string;
 }
 
-function TestSetup({ persistanceKey, defaultIsHidden, hiddenPersistanceKey }: TestSetupProps) {
+function TestSetup({ persistenceKey, defaultIsHidden, hiddenPersistenceKey }: TestSetupProps) {
   const [openPane, setOpenPane] = React.useState('');
   const contextValue = useSidebar({
     position: 'right',
     hasOpenPane: openPane !== '',
-    persistanceKey,
-    hiddenPersistanceKey,
+    persistenceKey,
+    hiddenPersistenceKey,
     onClosePane: () => setOpenPane(''),
     defaultIsHidden,
   });

--- a/packages/grafana-ui/src/components/Sidebar/Sidebar.test.tsx
+++ b/packages/grafana-ui/src/components/Sidebar/Sidebar.test.tsx
@@ -154,13 +154,14 @@ describe('Sidebar', () => {
       expect(screen.queryByTestId(selectors.components.Sidebar.dockToggle)).not.toBeInTheDocument();
     });
 
-    it('forces docked layout without user interaction', () => {
+    it('renders the open pane as an undocked overlay (does not push content)', () => {
       render(<TestSetup />);
 
       act(() => screen.getByLabelText('Settings').click());
 
       const wrapper = screen.getByTestId('sidebar-test-wrapper');
-      expect(wrapper).toHaveStyle('padding-right: 312px');
+      // Only the toolbar reserves space; the pane floats over the content as an overlay
+      expect(wrapper).toHaveStyle('padding-right: 72px');
     });
   });
 });

--- a/packages/grafana-ui/src/components/Sidebar/Sidebar.test.tsx
+++ b/packages/grafana-ui/src/components/Sidebar/Sidebar.test.tsx
@@ -92,6 +92,49 @@ describe('Sidebar', () => {
       render(<TestSetup defaultIsHidden persistanceKey="hidden-persist" />);
       expect(screen.getByTestId(selectors.components.Sidebar.container)).toBeInTheDocument();
     });
+
+    it('renders the sidebar temporarily when hidden and a pane opens', () => {
+      render(<TestSetup defaultIsHidden />);
+
+      // Sidebar is hidden — only the show toggle is rendered
+      expect(screen.queryByTestId(selectors.components.Sidebar.container)).not.toBeInTheDocument();
+
+      // Open a pane externally (simulating selecting an element while hidden)
+      act(() => screen.getByLabelText('Open settings externally').click());
+
+      // Sidebar appears with the pane visible
+      expect(screen.getByTestId(selectors.components.Sidebar.container)).toBeInTheDocument();
+      expect(screen.getByTestId(selectors.components.Sidebar.headerTitle)).toBeInTheDocument();
+    });
+
+    it('re-hides the sidebar when the temporarily-opened pane closes', () => {
+      render(<TestSetup defaultIsHidden />);
+
+      act(() => screen.getByLabelText('Open settings externally').click());
+      expect(screen.getByTestId(selectors.components.Sidebar.container)).toBeInTheDocument();
+
+      // Close the pane via the X button
+      act(() => screen.getByLabelText('Close').click());
+
+      // Sidebar disappears again — back to the persisted-hidden state
+      expect(screen.queryByTestId(selectors.components.Sidebar.container)).not.toBeInTheDocument();
+      expect(screen.getByTestId(selectors.components.Sidebar.showHideToggle)).toBeInTheDocument();
+    });
+
+    it('shares hidden state across instances via hiddenPersistanceKey', () => {
+      const { unmount } = render(<TestSetup persistanceKey="mode-x" hiddenPersistanceKey="shared-hide" />);
+
+      // Hide the sidebar (defaults to visible)
+      act(() => screen.getByLabelText('Hide').click());
+      expect(screen.getByTestId(selectors.components.Sidebar.showHideToggle)).toBeInTheDocument();
+
+      unmount();
+
+      // A different consumer with a different persistanceKey but the same hiddenPersistanceKey
+      // observes the shared hidden state.
+      render(<TestSetup persistanceKey="mode-y" hiddenPersistanceKey="shared-hide" />);
+      expect(screen.getByTestId(selectors.components.Sidebar.showHideToggle)).toBeInTheDocument();
+    });
   });
 
   describe('mobile viewport', () => {
@@ -125,20 +168,26 @@ describe('Sidebar', () => {
 interface TestSetupProps {
   persistanceKey?: string;
   defaultIsHidden?: boolean;
+  hiddenPersistanceKey?: string;
 }
 
-function TestSetup({ persistanceKey, defaultIsHidden }: TestSetupProps) {
+function TestSetup({ persistanceKey, defaultIsHidden, hiddenPersistanceKey }: TestSetupProps) {
   const [openPane, setOpenPane] = React.useState('');
   const contextValue = useSidebar({
     position: 'right',
     hasOpenPane: openPane !== '',
     persistanceKey,
+    hiddenPersistanceKey,
     onClosePane: () => setOpenPane(''),
     defaultIsHidden,
   });
 
   return (
     <div {...contextValue.outerWrapperProps} data-testid="sidebar-test-wrapper">
+      {/* Button outside the sidebar to simulate opening a pane programmatically (e.g. element selection) */}
+      <button onClick={() => setOpenPane('settings')} aria-label="Open settings externally">
+        external
+      </button>
       <Sidebar contextValue={contextValue}>
         {openPane === 'settings' && (
           <Sidebar.OpenPane>
@@ -149,6 +198,7 @@ function TestSetup({ persistanceKey, defaultIsHidden }: TestSetupProps) {
           <Sidebar.Button icon="cog" title="Settings" onClick={() => setOpenPane('settings')} />
           <Sidebar.Button icon="process" title="Data" tooltip="Data transformations" />
           <Sidebar.Button icon="bell" title="Alerts" />
+          <Sidebar.Button icon="arrow-to-right" title="Hide" onClick={() => contextValue.setIsHidden(true)} />
         </Sidebar.Toolbar>
       </Sidebar>
     </div>

--- a/packages/grafana-ui/src/components/Sidebar/Sidebar.tsx
+++ b/packages/grafana-ui/src/components/Sidebar/Sidebar.tsx
@@ -210,7 +210,7 @@ export const getStyles = (theme: GrafanaTheme2) => {
     }),
     showButton: css({
       position: 'fixed',
-      top: '50%',
+      bottom: theme.spacing(2),
       zIndex: theme.zIndex.navbarFixed,
       padding: theme.spacing(1),
       backgroundColor: theme.colors.background.secondary,

--- a/packages/grafana-ui/src/components/Sidebar/useSidebar.test.tsx
+++ b/packages/grafana-ui/src/components/Sidebar/useSidebar.test.tsx
@@ -32,12 +32,12 @@ jest.mock('@grafana/data', () => ({
 
 const mockedStore = jest.mocked(store, { shallow: true });
 
-describe('useSidebarSavedState(persistanceKey, subKey, defaultValue)', () => {
+describe('useSidebarSavedState(persistenceKey, subKey, defaultValue)', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  describe('when persistanceKey is not passed', () => {
+  describe('when persistenceKey is not passed', () => {
     test('returns the default value', () => {
       const { result } = renderHook(() => useSidebarSavedState(undefined, 'subKey1', 1));
 
@@ -50,10 +50,10 @@ describe('useSidebarSavedState(persistanceKey, subKey, defaultValue)', () => {
     test('reads a boolean value from the store', () => {
       mockedStore.getBool.mockReturnValue(true);
 
-      const [persistanceKey, subKey, defaultValue] = ['persistanceKey2', 'subKey2', false];
-      const { result } = renderHook(() => useSidebarSavedState(persistanceKey, subKey, defaultValue));
+      const [persistenceKey, subKey, defaultValue] = ['persistenceKey2', 'subKey2', false];
+      const { result } = renderHook(() => useSidebarSavedState(persistenceKey, subKey, defaultValue));
 
-      expect(mockedStore.getBool).toHaveBeenCalledWith(`grafana.ui.sidebar.${persistanceKey}.${subKey}`, defaultValue);
+      expect(mockedStore.getBool).toHaveBeenCalledWith(`grafana.ui.sidebar.${persistenceKey}.${subKey}`, defaultValue);
 
       const [state] = result.current;
       expect(state).toBe(true);
@@ -64,10 +64,10 @@ describe('useSidebarSavedState(persistanceKey, subKey, defaultValue)', () => {
     test('converts the value read from the store to an integer', () => {
       mockedStore.get.mockReturnValue('7');
 
-      const [persistanceKey, subKey, defaultValue] = ['persistanceKey3', 'subKey3', 3];
-      const { result } = renderHook(() => useSidebarSavedState(persistanceKey, subKey, defaultValue));
+      const [persistenceKey, subKey, defaultValue] = ['persistenceKey3', 'subKey3', 3];
+      const { result } = renderHook(() => useSidebarSavedState(persistenceKey, subKey, defaultValue));
 
-      expect(mockedStore.get).toHaveBeenCalledWith(`grafana.ui.sidebar.${persistanceKey}.${subKey}`);
+      expect(mockedStore.get).toHaveBeenCalledWith(`grafana.ui.sidebar.${persistenceKey}.${subKey}`);
 
       const [state] = result.current;
       expect(state).toBe(7);
@@ -76,10 +76,10 @@ describe('useSidebarSavedState(persistanceKey, subKey, defaultValue)', () => {
     test('returns defaultValue when the conversion fails', () => {
       mockedStore.get.mockReturnValue('seven');
 
-      const [persistanceKey, subKey, defaultValue] = ['persistanceKey4', 'subKey4', 4];
-      const { result } = renderHook(() => useSidebarSavedState(persistanceKey, subKey, defaultValue));
+      const [persistenceKey, subKey, defaultValue] = ['persistenceKey4', 'subKey4', 4];
+      const { result } = renderHook(() => useSidebarSavedState(persistenceKey, subKey, defaultValue));
 
-      expect(mockedStore.get).toHaveBeenCalledWith(`grafana.ui.sidebar.${persistanceKey}.${subKey}`);
+      expect(mockedStore.get).toHaveBeenCalledWith(`grafana.ui.sidebar.${persistenceKey}.${subKey}`);
 
       const [state] = result.current;
       expect(state).toBe(4);
@@ -88,8 +88,8 @@ describe('useSidebarSavedState(persistanceKey, subKey, defaultValue)', () => {
 
   describe('if defaultValue is neither a boolean nor a number', () => {
     test('returns the default value', () => {
-      const [persistanceKey, subKey, defaultValue] = ['persistanceKey5', 'subKey5', { test: 'five' }];
-      const { result } = renderHook(() => useSidebarSavedState(persistanceKey, subKey, defaultValue));
+      const [persistenceKey, subKey, defaultValue] = ['persistenceKey5', 'subKey5', { test: 'five' }];
+      const { result } = renderHook(() => useSidebarSavedState(persistenceKey, subKey, defaultValue));
 
       expect(mockedStore.get).not.toHaveBeenCalled();
 
@@ -98,31 +98,31 @@ describe('useSidebarSavedState(persistanceKey, subKey, defaultValue)', () => {
     });
   });
 
-  describe('when persistanceKey or subKey changes across re-renders', () => {
+  describe('when persistenceKey or subKey changes across re-renders', () => {
     test('re-reads the value from the store using the new key', () => {
       mockedStore.get.mockImplementation((key: string) => {
         const storeValues: Record<string, string> = {
-          'grafana.ui.sidebar.persistanceKey6.subKeyA': '10',
-          'grafana.ui.sidebar.persistanceKey7.subKeyA': '20',
-          'grafana.ui.sidebar.persistanceKey7.subKeyB': '30',
+          'grafana.ui.sidebar.persistenceKey6.subKeyA': '10',
+          'grafana.ui.sidebar.persistenceKey7.subKeyA': '20',
+          'grafana.ui.sidebar.persistenceKey7.subKeyB': '30',
         };
         return storeValues[key];
       });
 
-      const initialProps = { persistanceKey: 'persistanceKey6', subKey: 'subKeyA', defaultValue: 42 };
+      const initialProps = { persistenceKey: 'persistenceKey6', subKey: 'subKeyA', defaultValue: 42 };
 
       const { result, rerender } = renderHook(
-        (props) => useSidebarSavedState(props.persistanceKey, props.subKey, props.defaultValue),
+        (props) => useSidebarSavedState(props.persistenceKey, props.subKey, props.defaultValue),
         { initialProps }
       );
 
       expect(result.current[0]).toBe(10);
 
-      rerender({ ...initialProps, persistanceKey: 'persistanceKey7' });
+      rerender({ ...initialProps, persistenceKey: 'persistenceKey7' });
 
       expect(result.current[0]).toBe(20);
 
-      rerender({ ...initialProps, persistanceKey: 'persistanceKey7', subKey: 'subKeyB' });
+      rerender({ ...initialProps, persistenceKey: 'persistenceKey7', subKey: 'subKeyB' });
 
       expect(result.current[0]).toBe(30);
     });
@@ -226,8 +226,8 @@ describe('useSidebar', () => {
     });
   });
 
-  describe('hiddenPersistanceKey', () => {
-    test('reads the hidden state from the override key, not persistanceKey', () => {
+  describe('hiddenPersistenceKey', () => {
+    test('reads the hidden state from the override key, not persistenceKey', () => {
       mockedStore.getBool.mockImplementation((key: string, defaultValue: boolean) => {
         if (key === 'grafana.ui.sidebar.shared.hidden') {
           return true;
@@ -235,20 +235,20 @@ describe('useSidebar', () => {
         return defaultValue;
       });
 
-      const { result } = renderHook(() => useSidebar({ persistanceKey: 'mode-a', hiddenPersistanceKey: 'shared' }));
+      const { result } = renderHook(() => useSidebar({ persistenceKey: 'mode-a', hiddenPersistenceKey: 'shared' }));
 
       expect(result.current.isHidden).toBe(true);
     });
 
     test('writes the hidden state under the override key', () => {
-      const { result } = renderHook(() => useSidebar({ persistanceKey: 'mode-a', hiddenPersistanceKey: 'shared' }));
+      const { result } = renderHook(() => useSidebar({ persistenceKey: 'mode-a', hiddenPersistenceKey: 'shared' }));
 
       act(() => result.current.setIsHidden(true));
 
       expect(mockedStore.set).toHaveBeenCalledWith('grafana.ui.sidebar.shared.hidden', 'true');
     });
 
-    test('different persistanceKey consumers share hidden state via hiddenPersistanceKey', () => {
+    test('different persistenceKey consumers share hidden state via hiddenPersistenceKey', () => {
       const storeState: Record<string, string> = {};
       mockedStore.getBool.mockImplementation(
         (key: string, defaultValue: boolean) => (storeState[key] ?? String(defaultValue)) === 'true'
@@ -259,20 +259,20 @@ describe('useSidebar', () => {
 
       // First consumer hides the sidebar
       const { result: firstResult } = renderHook(() =>
-        useSidebar({ persistanceKey: 'mode-a', hiddenPersistanceKey: 'shared' })
+        useSidebar({ persistenceKey: 'mode-a', hiddenPersistenceKey: 'shared' })
       );
       act(() => firstResult.current.setIsHidden(true));
       expect(firstResult.current.isHidden).toBe(true);
 
-      // A second consumer with a different persistanceKey but the same hiddenPersistanceKey
+      // A second consumer with a different persistenceKey but the same hiddenPersistenceKey
       // should observe the shared hidden state.
       const { result: secondResult } = renderHook(() =>
-        useSidebar({ persistanceKey: 'mode-b', hiddenPersistanceKey: 'shared' })
+        useSidebar({ persistenceKey: 'mode-b', hiddenPersistenceKey: 'shared' })
       );
       expect(secondResult.current.isHidden).toBe(true);
     });
 
-    test('falls back to persistanceKey when hiddenPersistanceKey is not provided', () => {
+    test('falls back to persistenceKey when hiddenPersistenceKey is not provided', () => {
       mockedStore.getBool.mockImplementation((key: string, defaultValue: boolean) => {
         if (key === 'grafana.ui.sidebar.fallback.hidden') {
           return true;
@@ -280,7 +280,7 @@ describe('useSidebar', () => {
         return defaultValue;
       });
 
-      const { result } = renderHook(() => useSidebar({ persistanceKey: 'fallback' }));
+      const { result } = renderHook(() => useSidebar({ persistenceKey: 'fallback' }));
 
       expect(result.current.isHidden).toBe(true);
     });

--- a/packages/grafana-ui/src/components/Sidebar/useSidebar.test.tsx
+++ b/packages/grafana-ui/src/components/Sidebar/useSidebar.test.tsx
@@ -297,27 +297,23 @@ describe('useSidebar', () => {
       restore();
     });
 
-    test('forces isDocked to true regardless of defaultToDocked', () => {
-      const { result } = renderHook(() => useSidebar({ defaultToDocked: false }));
-      expect(result.current.isDocked).toBe(true);
+    test('forces isDocked to false regardless of defaultToDocked', () => {
+      const { result } = renderHook(() => useSidebar({ defaultToDocked: true }));
+      expect(result.current.isDocked).toBe(false);
     });
 
-    test('keeps isDocked true even after onToggleDock is called', () => {
-      const { result } = renderHook(() => useSidebar({ defaultToDocked: false }));
-
-      expect(result.current.isDocked).toBe(true);
-
-      act(() => result.current.onToggleDock?.());
-
-      expect(result.current.isDocked).toBe(true);
+    test('does not expose onToggleDock so the user cannot dock on mobile', () => {
+      const { result } = renderHook(() => useSidebar({ defaultToDocked: true }));
+      expect(result.current.onToggleDock).toBeUndefined();
     });
 
-    test('includes pane width in outerWrapperProps when a pane is open', () => {
-      const { result } = renderHook(() => useSidebar({ hasOpenPane: true }));
+    test('does not push the body content when a pane is open (undocked overlay)', () => {
+      const { result } = renderHook(() => useSidebar({ hasOpenPane: true, defaultToDocked: true }));
 
       const style = result.current.outerWrapperProps.style as Record<string, number>;
       const paneWidth = result.current.paneWidth;
-      expect(style?.paddingRight).toBeGreaterThan(paneWidth);
+      // Only the toolbar reserves space; the pane floats over the content as an overlay
+      expect(style?.paddingRight).toBeLessThan(paneWidth);
     });
   });
 });

--- a/packages/grafana-ui/src/components/Sidebar/useSidebar.test.tsx
+++ b/packages/grafana-ui/src/components/Sidebar/useSidebar.test.tsx
@@ -168,6 +168,124 @@ describe('useSidebar', () => {
     expect(result.current.outerWrapperProps).toHaveProperty('style');
   });
 
+  test('setIsHidden sets the persisted hidden value', () => {
+    const { result } = renderHook(() => useSidebar({ defaultIsHidden: false }));
+    expect(result.current.isHidden).toBe(false);
+
+    act(() => result.current.setIsHidden(true));
+    expect(result.current.isHidden).toBe(true);
+
+    // Idempotent — setting the same value again keeps it
+    act(() => result.current.setIsHidden(true));
+    expect(result.current.isHidden).toBe(true);
+
+    act(() => result.current.setIsHidden(false));
+    expect(result.current.isHidden).toBe(false);
+  });
+
+  describe('temporary-show on open pane', () => {
+    test('shows the sidebar undocked when persisted hidden but a pane is open', () => {
+      const { result, rerender } = renderHook(
+        ({ hasOpenPane }: { hasOpenPane: boolean }) =>
+          useSidebar({ defaultIsHidden: true, defaultToDocked: true, hasOpenPane }),
+        { initialProps: { hasOpenPane: false } }
+      );
+
+      // No pane open — sidebar effectively hidden
+      expect(result.current.isHidden).toBe(true);
+
+      // Pane opens — sidebar effectively shown, forced undocked
+      rerender({ hasOpenPane: true });
+      expect(result.current.isHidden).toBe(false);
+      expect(result.current.isDocked).toBe(false);
+      // Dock toggle is hidden during temporary show
+      expect(result.current.onToggleDock).toBeUndefined();
+
+      // Pane closes — sidebar re-hides, persisted state was never flipped
+      rerender({ hasOpenPane: false });
+      expect(result.current.isHidden).toBe(true);
+    });
+
+    test('does not push body when temporarily shown', () => {
+      const { result } = renderHook(() =>
+        useSidebar({ defaultIsHidden: true, defaultToDocked: true, hasOpenPane: true })
+      );
+
+      // The body should not reserve space — the temp-shown sidebar floats over content
+      expect(result.current.outerWrapperProps).toEqual({});
+    });
+
+    test('does not affect the not-hidden case', () => {
+      const { result } = renderHook(() =>
+        useSidebar({ defaultIsHidden: false, defaultToDocked: true, hasOpenPane: true })
+      );
+
+      expect(result.current.isHidden).toBe(false);
+      expect(result.current.isDocked).toBe(true);
+      expect(result.current.onToggleDock).toBeDefined();
+    });
+  });
+
+  describe('hiddenPersistanceKey', () => {
+    test('reads the hidden state from the override key, not persistanceKey', () => {
+      mockedStore.getBool.mockImplementation((key: string, defaultValue: boolean) => {
+        if (key === 'grafana.ui.sidebar.shared.hidden') {
+          return true;
+        }
+        return defaultValue;
+      });
+
+      const { result } = renderHook(() => useSidebar({ persistanceKey: 'mode-a', hiddenPersistanceKey: 'shared' }));
+
+      expect(result.current.isHidden).toBe(true);
+    });
+
+    test('writes the hidden state under the override key', () => {
+      const { result } = renderHook(() => useSidebar({ persistanceKey: 'mode-a', hiddenPersistanceKey: 'shared' }));
+
+      act(() => result.current.setIsHidden(true));
+
+      expect(mockedStore.set).toHaveBeenCalledWith('grafana.ui.sidebar.shared.hidden', 'true');
+    });
+
+    test('different persistanceKey consumers share hidden state via hiddenPersistanceKey', () => {
+      const storeState: Record<string, string> = {};
+      mockedStore.getBool.mockImplementation(
+        (key: string, defaultValue: boolean) => (storeState[key] ?? String(defaultValue)) === 'true'
+      );
+      mockedStore.set.mockImplementation((key, value) => {
+        storeState[key] = String(value);
+      });
+
+      // First consumer hides the sidebar
+      const { result: firstResult } = renderHook(() =>
+        useSidebar({ persistanceKey: 'mode-a', hiddenPersistanceKey: 'shared' })
+      );
+      act(() => firstResult.current.setIsHidden(true));
+      expect(firstResult.current.isHidden).toBe(true);
+
+      // A second consumer with a different persistanceKey but the same hiddenPersistanceKey
+      // should observe the shared hidden state.
+      const { result: secondResult } = renderHook(() =>
+        useSidebar({ persistanceKey: 'mode-b', hiddenPersistanceKey: 'shared' })
+      );
+      expect(secondResult.current.isHidden).toBe(true);
+    });
+
+    test('falls back to persistanceKey when hiddenPersistanceKey is not provided', () => {
+      mockedStore.getBool.mockImplementation((key: string, defaultValue: boolean) => {
+        if (key === 'grafana.ui.sidebar.fallback.hidden') {
+          return true;
+        }
+        return defaultValue;
+      });
+
+      const { result } = renderHook(() => useSidebar({ persistanceKey: 'fallback' }));
+
+      expect(result.current.isHidden).toBe(true);
+    });
+  });
+
   describe('on mobile viewport', () => {
     let restore: () => void;
 

--- a/packages/grafana-ui/src/components/Sidebar/useSidebar.tsx
+++ b/packages/grafana-ui/src/components/Sidebar/useSidebar.tsx
@@ -20,7 +20,7 @@ export interface SidebarContextValue {
   edgeMargin: number;
   contentMargin: number;
   isHidden: boolean;
-  isHiddenValue: boolean;
+  isHiddenPreference: boolean;
   canGoBack?: boolean;
   onToggleDock?: () => void;
   onResize: (diff: number) => void;
@@ -60,17 +60,17 @@ export interface UseSideBarOptions {
   onGoBack?: () => void;
   /**
    * Optional key to use for persisting sidebar state (docked / compact / size)
-   * Can only be app name as the final local storag key will be `grafana.ui.sidebar.{persistanceKey}.{docked|compact|size}`
+   * Can only be app name as the final local storag key will be `grafana.ui.sidebar.{persistenceKey}.{docked|compact|size}`
    */
-  persistanceKey?: string;
+  persistenceKey?: string;
   /** Whether the sidebar is hidden by default */
   defaultIsHidden?: boolean;
   /**
    * Optional override for the persistance key used to store the hidden state.
    * Allows the hidden preference to be shared across consumers that otherwise use different
-   * persistanceKeys (e.g. dashboard view vs edit mode share a single hide preference).
+   * persistenceKeys (e.g. dashboard view vs edit mode share a single hide preference).
    */
-  hiddenPersistanceKey?: string;
+  hiddenPersistenceKey?: string;
 }
 
 export const SIDE_BAR_WIDTH_ICON_ONLY = 5;
@@ -85,19 +85,19 @@ export function useSidebar({
   bottomMargin = 2,
   edgeMargin = 2,
   contentMargin = 2,
-  persistanceKey,
+  persistenceKey,
   onClosePane,
   onGoBack,
   canGoBack,
   defaultIsHidden = false,
-  hiddenPersistanceKey,
+  hiddenPersistenceKey,
 }: UseSideBarOptions): SidebarContextValue {
   const theme = useTheme2();
-  const [isDocked, setIsDocked] = useSidebarSavedState(persistanceKey, 'docked', defaultToDocked);
-  const [compact, setCompact] = useSidebarSavedState(persistanceKey, 'compact', defaultToCompact);
-  const [paneWidth, setPaneWidth] = useSidebarSavedState(persistanceKey, 'size', 240);
+  const [isDocked, setIsDocked] = useSidebarSavedState(persistenceKey, 'docked', defaultToDocked);
+  const [compact, setCompact] = useSidebarSavedState(persistenceKey, 'compact', defaultToCompact);
+  const [paneWidth, setPaneWidth] = useSidebarSavedState(persistenceKey, 'size', 240);
   const [isHidden, setIsHidden] = useSidebarSavedState(
-    hiddenPersistanceKey ?? persistanceKey,
+    hiddenPersistenceKey ?? persistenceKey,
     'hidden',
     defaultIsHidden
   );
@@ -175,7 +175,7 @@ export function useSidebar({
     bottomMargin,
     contentMargin,
     isHidden: effectiveIsHidden,
-    isHiddenValue: isHidden,
+    isHiddenPreference: isHidden,
     onClosePane,
     onGoBack,
     canGoBack,
@@ -184,18 +184,18 @@ export function useSidebar({
   };
 }
 
-function readFromStore<T>(persistanceKey: string | undefined, subKey: string, defaultValue: T): T {
-  if (!persistanceKey) {
+function readFromStore<T>(persistenceKey: string | undefined, subKey: string, defaultValue: T): T {
+  if (!persistenceKey) {
     return defaultValue;
   }
 
   if (typeof defaultValue === 'boolean') {
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-    return store.getBool(`grafana.ui.sidebar.${persistanceKey}.${subKey}`, defaultValue) as T;
+    return store.getBool(`grafana.ui.sidebar.${persistenceKey}.${subKey}`, defaultValue) as T;
   }
 
   if (typeof defaultValue === 'number') {
-    const value = Number.parseInt(store.get(`grafana.ui.sidebar.${persistanceKey}.${subKey}`), 10);
+    const value = Number.parseInt(store.get(`grafana.ui.sidebar.${persistenceKey}.${subKey}`), 10);
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
     return Number.isNaN(value) ? defaultValue : (value as T);
   }
@@ -204,36 +204,36 @@ function readFromStore<T>(persistanceKey: string | undefined, subKey: string, de
 }
 
 export function useSidebarSavedState<T = number | boolean>(
-  persistanceKey: string | undefined,
+  persistenceKey: string | undefined,
   subKey: string,
   defaultValue: T
 ) {
-  const [state, setState] = React.useState<T>(() => readFromStore(persistanceKey, subKey, defaultValue));
+  const [state, setState] = React.useState<T>(() => readFromStore(persistenceKey, subKey, defaultValue));
 
   useEffect(() => {
-    setState(readFromStore(persistanceKey, subKey, defaultValue));
+    setState(readFromStore(persistenceKey, subKey, defaultValue));
     // Re-read from storage when the persistence key changes, but not when defaultValue changes
     // to avoid overriding a user-persisted value.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [persistanceKey, subKey]);
+  }, [persistenceKey, subKey]);
 
   const setPersisted = useCallback(
     (cb: (prevState: T) => T) => {
       setState((prevState) => {
         const newState = cb(prevState);
 
-        if (!persistanceKey) {
+        if (!persistenceKey) {
           return newState;
         }
 
-        if (persistanceKey) {
-          store.set(`grafana.ui.sidebar.${persistanceKey}.${subKey}`, String(newState));
+        if (persistenceKey) {
+          store.set(`grafana.ui.sidebar.${persistenceKey}.${subKey}`, String(newState));
         }
 
         return newState;
       });
     },
-    [persistanceKey, subKey]
+    [persistenceKey, subKey]
   );
 
   return [state, setPersisted] as const;

--- a/packages/grafana-ui/src/components/Sidebar/useSidebar.tsx
+++ b/packages/grafana-ui/src/components/Sidebar/useSidebar.tsx
@@ -20,6 +20,7 @@ export interface SidebarContextValue {
   edgeMargin: number;
   contentMargin: number;
   isHidden: boolean;
+  isHiddenValue: boolean;
   canGoBack?: boolean;
   onToggleDock?: () => void;
   onResize: (diff: number) => void;
@@ -174,6 +175,7 @@ export function useSidebar({
     bottomMargin,
     contentMargin,
     isHidden: effectiveIsHidden,
+    isHiddenValue: isHidden,
     onClosePane,
     onGoBack,
     canGoBack,

--- a/packages/grafana-ui/src/components/Sidebar/useSidebar.tsx
+++ b/packages/grafana-ui/src/components/Sidebar/useSidebar.tsx
@@ -28,6 +28,7 @@ export interface SidebarContextValue {
   /** Open previous pane */
   onGoBack?: () => void;
   onToggleIsHidden: () => void;
+  setIsHidden: (value: boolean) => void;
 }
 
 export const SidebarContext: React.Context<SidebarContextValue | undefined> = React.createContext<
@@ -63,6 +64,12 @@ export interface UseSideBarOptions {
   persistanceKey?: string;
   /** Whether the sidebar is hidden by default */
   defaultIsHidden?: boolean;
+  /**
+   * Optional override for the persistance key used to store the hidden state.
+   * Allows the hidden preference to be shared across consumers that otherwise use different
+   * persistanceKeys (e.g. dashboard view vs edit mode share a single hide preference).
+   */
+  hiddenPersistanceKey?: string;
 }
 
 export const SIDE_BAR_WIDTH_ICON_ONLY = 5;
@@ -82,15 +89,22 @@ export function useSidebar({
   onGoBack,
   canGoBack,
   defaultIsHidden = false,
+  hiddenPersistanceKey,
 }: UseSideBarOptions): SidebarContextValue {
   const theme = useTheme2();
   const [isDocked, setIsDocked] = useSidebarSavedState(persistanceKey, 'docked', defaultToDocked);
   const [compact, setCompact] = useSidebarSavedState(persistanceKey, 'compact', defaultToCompact);
   const [paneWidth, setPaneWidth] = useSidebarSavedState(persistanceKey, 'size', 240);
-  const [isHidden, setIsHidden] = useSidebarSavedState(persistanceKey, 'hidden', defaultIsHidden);
+  const [isHidden, setIsHidden] = useSidebarSavedState(
+    hiddenPersistanceKey ?? persistanceKey,
+    'hidden',
+    defaultIsHidden
+  );
   const isMobile = useMedia(`(max-width: ${theme.breakpoints.values.sm}px)`);
+  const isTemporarilyShown = isHidden && Boolean(hasOpenPane);
+  const effectiveIsHidden = isHidden && !isTemporarilyShown;
   /** Undocked/floating sidebar is not used on small viewports; keep layout and behavior docked. */
-  const effectiveIsDocked = Boolean(isMobile) || isDocked;
+  const effectiveIsDocked = !isTemporarilyShown && (Boolean(isMobile) || isDocked);
 
   // Used to accumulate drag distance to know when to change compact mode
   const [_, setCompactDrag] = React.useState(0);
@@ -105,13 +119,14 @@ export function useSidebar({
     ((compact ? SIDE_BAR_WIDTH_ICON_ONLY : SIDE_BAR_WIDTH_WITH_TEXT) + edgeMargin + contentMargin) *
     theme.spacing.gridSize;
 
-  const outerWrapperProps = isHidden
-    ? {}
-    : {
-        style: {
-          [prop]: effectiveIsDocked && hasOpenPane ? paneWidth + toolbarWidth : toolbarWidth,
-        },
-      };
+  const outerWrapperProps =
+    effectiveIsHidden || isTemporarilyShown
+      ? {}
+      : {
+          style: {
+            [prop]: effectiveIsDocked && hasOpenPane ? paneWidth + toolbarWidth : toolbarWidth,
+          },
+        };
 
   const onResize = useCallback(
     (diff: number) => {
@@ -142,10 +157,11 @@ export function useSidebar({
   );
 
   const onToggleIsHidden = useCallback(() => setIsHidden((prev) => !prev), [setIsHidden]);
+  const setIsHiddenValue = useCallback((value: boolean) => setIsHidden(() => value), [setIsHidden]);
 
   return {
     isDocked: effectiveIsDocked,
-    onToggleDock: isMobile ? undefined : onToggleDock,
+    onToggleDock: isMobile || isTemporarilyShown ? undefined : onToggleDock,
     onResize,
     outerWrapperProps,
     position,
@@ -156,11 +172,12 @@ export function useSidebar({
     edgeMargin,
     bottomMargin,
     contentMargin,
-    isHidden,
+    isHidden: effectiveIsHidden,
     onClosePane,
     onGoBack,
     canGoBack,
     onToggleIsHidden,
+    setIsHidden: setIsHiddenValue,
   };
 }
 

--- a/packages/grafana-ui/src/components/Sidebar/useSidebar.tsx
+++ b/packages/grafana-ui/src/components/Sidebar/useSidebar.tsx
@@ -103,8 +103,9 @@ export function useSidebar({
   const isMobile = useMedia(`(max-width: ${theme.breakpoints.values.sm}px)`);
   const isTemporarilyShown = isHidden && Boolean(hasOpenPane);
   const effectiveIsHidden = isHidden && !isTemporarilyShown;
-  /** Undocked/floating sidebar is not used on small viewports; keep layout and behavior docked. */
-  const effectiveIsDocked = !isTemporarilyShown && (Boolean(isMobile) || isDocked);
+  // On small viewports the sidebar is always rendered as an undocked overlay so it doesn't
+  // permanently steal horizontal space — docking only applies on larger viewports.
+  const effectiveIsDocked = !isTemporarilyShown && !isMobile && isDocked;
 
   // Used to accumulate drag distance to know when to change compact mode
   const [_, setCompactDrag] = React.useState(0);

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.test.tsx
@@ -76,10 +76,14 @@ export function buildTestScene() {
 describe('DashboardEditPaneRenderer', () => {
   beforeEach(() => {
     config.featureToggles.dashboardNewLayouts = true;
+    // Sidebar state is persisted to localStorage — clear between tests so each test
+    // starts with the default visibility/dock state.
+    window.localStorage.clear();
   });
 
   afterEach(() => {
     jest.clearAllMocks();
+    window.localStorage.clear();
   });
 
   it('Should render sidebar', async () => {
@@ -123,6 +127,74 @@ describe('DashboardEditPaneRenderer', () => {
       const outlineButton = screen.getByTestId(selectors.pages.Dashboard.Sidebar.outlineButton);
       await user.click(outlineButton);
       expect(DashboardInteractions.dashboardOutlineClicked).toHaveBeenCalled();
+    });
+  });
+
+  describe('hide button', () => {
+    it('renders the hide button in view mode', async () => {
+      const scene = buildTestScene();
+      scene.setState({ isEditing: false });
+      act(() => activateFullSceneTree(scene));
+
+      render(<DashboardEditPaneSplitter dashboard={scene} />);
+
+      const hideButton = await screen.findByTestId(selectors.components.Sidebar.showHideToggle);
+      expect(hideButton).toBeInTheDocument();
+    });
+
+    it('renders the hide button in edit mode', async () => {
+      const scene = buildTestScene();
+      act(() => activateFullSceneTree(scene));
+
+      render(<DashboardEditPaneSplitter dashboard={scene} isEditing />);
+
+      const hideButton = await screen.findByTestId(selectors.components.Sidebar.showHideToggle);
+      expect(hideButton).toBeInTheDocument();
+    });
+
+    it('hides the sidebar and clears any open pane on click', async () => {
+      const user = userEvent.setup();
+      const scene = buildTestScene();
+      act(() => activateFullSceneTree(scene));
+
+      render(<DashboardEditPaneSplitter dashboard={scene} isEditing />);
+
+      // Open the outline pane first
+      await user.click(screen.getByTestId(selectors.pages.Dashboard.Sidebar.outlineButton));
+      expect(scene.state.editPane.state.openPane).toBeDefined();
+
+      // Click hide
+      await user.click(screen.getByTestId(selectors.components.Sidebar.showHideToggle));
+
+      // Pane should be cleared
+      expect(scene.state.editPane.state.openPane).toBeUndefined();
+      // The sidebar container should no longer be rendered (only the show toggle remains)
+      expect(screen.queryByTestId(selectors.components.Sidebar.container)).not.toBeInTheDocument();
+    });
+
+    it('temporarily shows the sidebar undocked when selecting a panel while hidden', async () => {
+      const user = userEvent.setup();
+      const scene = buildTestScene();
+      act(() => activateFullSceneTree(scene));
+
+      render(<DashboardEditPaneSplitter dashboard={scene} isEditing />);
+
+      // Hide the sidebar
+      await user.click(screen.getByTestId(selectors.components.Sidebar.showHideToggle));
+      expect(screen.queryByTestId(selectors.components.Sidebar.container)).not.toBeInTheDocument();
+
+      // Select the panel programmatically (clicking a panel in real UX)
+      const panel = scene.state.body.getVizPanels()[0];
+      act(() => scene.state.editPane.selectObject(panel));
+
+      // Sidebar pops up — effective isDocked is false during temp-show
+      expect(screen.getByTestId(selectors.components.Sidebar.container)).toBeInTheDocument();
+      expect(scene.state.editPane.state.isDocked).toBe(false);
+
+      // De-selecting closes the pane and re-hides the sidebar
+      act(() => scene.state.editPane.clearSelection(true));
+
+      expect(screen.queryByTestId(selectors.components.Sidebar.container)).not.toBeInTheDocument();
     });
   });
 });

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.tsx
@@ -1,13 +1,12 @@
 import { css } from '@emotion/css';
 import { useCallback, useEffect } from 'react';
-import { useMedia } from 'react-use';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { sceneGraph, type SceneVariable, useSceneObjectState } from '@grafana/scenes';
-import { Sidebar, useStyles2, useSidebarContext, useTheme2 } from '@grafana/ui';
+import { Sidebar, useStyles2, useSidebarContext } from '@grafana/ui';
 import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 
 import { type DashboardScene } from '../scene/DashboardScene';
@@ -42,15 +41,14 @@ export function DashboardEditPaneRenderer({ editPane, dashboard }: Props) {
   const hasUid = Boolean(uid);
   const isEmbedded = meta.isEmbedded;
   const selectedObject = editPane.getSelectedObject();
-  const theme = useTheme2();
-  const isMobile = useMedia(`(max-width: ${theme.breakpoints.values.sm}px)`);
   const sidebarContext = useSidebarContext();
   const onClickHideSidebar: React.MouseEventHandler<HTMLButtonElement> = useCallback(
     (e) => {
-      sidebarContext?.onToggleIsHidden();
+      editPane.closePane();
+      sidebarContext?.setIsHidden(true);
       e.currentTarget.blur();
     },
-    [sidebarContext]
+    [editPane, sidebarContext]
   );
 
   /**
@@ -156,17 +154,13 @@ export function DashboardEditPaneRenderer({ editPane, dashboard }: Props) {
               onClick={() => onOpenSnapshotOriginalDashboard(dashboard.getSnapshotUrl())}
             />
           )}
-          {isMobile && !isEditing && (
-            <>
-              <Sidebar.Divider />
-              <Sidebar.Button
-                icon={'arrow-to-right'}
-                onClick={onClickHideSidebar}
-                title={t('grafana-ui.sidebar.hide', 'Hide')}
-                data-testid={selectors.components.Sidebar.showHideToggle}
-              />
-            </>
-          )}
+          <Sidebar.Divider />
+          <Sidebar.Button
+            icon={'arrow-to-right'}
+            onClick={onClickHideSidebar}
+            title={t('grafana-ui.sidebar.hide', 'Hide')}
+            data-testid={selectors.components.Sidebar.showHideToggle}
+          />
         </div>
       </Sidebar.Toolbar>
     </>

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
@@ -198,7 +198,7 @@ function DashboardEditPaneSplitterNewLayouts({ dashboard, isEditing, body, contr
         {...sidebarContext.outerWrapperProps}
       >
         <div
-          className={cx(styles.scrollContainer, sidebarContext.isHidden && styles.scrollContainerNoSidebar)}
+          className={cx(styles.scrollContainer, sidebarContext.isHiddenValue && styles.scrollContainerNoSidebar)}
           ref={onBodyRef}
           onPointerDown={onClearSelection}
           data-testid={selectors.components.DashboardEditPaneSplitter.bodyContainer}

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
@@ -198,7 +198,7 @@ function DashboardEditPaneSplitterNewLayouts({ dashboard, isEditing, body, contr
         {...sidebarContext.outerWrapperProps}
       >
         <div
-          className={styles.scrollContainer}
+          className={cx(styles.scrollContainer, sidebarContext.isHidden && styles.scrollContainerNoSidebar)}
           ref={onBodyRef}
           onPointerDown={onClearSelection}
           data-testid={selectors.components.DashboardEditPaneSplitter.bodyContainer}

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
@@ -145,6 +145,7 @@ function DashboardEditPaneSplitterNewLayouts({ dashboard, isEditing, body, contr
     contentMargin: 1,
     position: 'right',
     persistanceKey: isEditing ? 'dashboard' : 'dashboard-view',
+    hiddenPersistanceKey: 'dashboard',
     defaultToDocked: isEditing ? true : false,
     onClosePane: () => editPane.closePane(),
     onGoBack: () => editPane.goBackToPrevious(),

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneSplitter.tsx
@@ -144,8 +144,8 @@ function DashboardEditPaneSplitterNewLayouts({ dashboard, isEditing, body, contr
     hasOpenPane: Boolean(openPane),
     contentMargin: 1,
     position: 'right',
-    persistanceKey: isEditing ? 'dashboard' : 'dashboard-view',
-    hiddenPersistanceKey: 'dashboard',
+    persistenceKey: isEditing ? 'dashboard' : 'dashboard-view',
+    hiddenPersistenceKey: 'dashboard',
     defaultToDocked: isEditing ? true : false,
     onClosePane: () => editPane.closePane(),
     onGoBack: () => editPane.goBackToPrevious(),
@@ -198,7 +198,7 @@ function DashboardEditPaneSplitterNewLayouts({ dashboard, isEditing, body, contr
         {...sidebarContext.outerWrapperProps}
       >
         <div
-          className={cx(styles.scrollContainer, sidebarContext.isHiddenValue && styles.scrollContainerNoSidebar)}
+          className={cx(styles.scrollContainer, sidebarContext.isHiddenPreference && styles.scrollContainerNoSidebar)}
           ref={onBodyRef}
           onPointerDown={onClearSelection}
           data-testid={selectors.components.DashboardEditPaneSplitter.bodyContainer}


### PR DESCRIPTION
**What is this feature?**

This PR brings hiding the sidebar on desktop as well.

The changes contained in this PR are:
- on mobile the sidebar is always undocked
- we bring the "hide sidebar" button on desktop as well
- in edit mode, if the user selects something, the sidebar is shown temporarily on the screen and disappears after de-selecting the "thing"

**Why do we need this feature?**

-

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

Fixes #125130

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
