### PR TITLE
ci: dont use npm/yarn caches during npm publish

### DIFF
--- a/.github/actions/yarn-install/action.yml
+++ b/.github/actions/yarn-install/action.yml
@@ -31,6 +31,10 @@ inputs:
     description: 'Add a specific cache-prefix'
     required: false
     default: 'default'
+  cache-download-cache:
+    description: 'Cache yarn download cache folder (invalidated on lock/os/node-version)'
+    required: false
+    default: 'true'
   cache-npm-cache:
     description: 'Cache npm global cache folder often used by node-gyp, prebuild binaries (invalidated on lock/os/node-version)'
     required: false
@@ -77,6 +81,7 @@ runs:
     - name: Restore yarn cache
       uses: actions/cache@v5
       id: yarn-download-cache
+      if: inputs.cache-download-cache == 'true'
       with:
         path: ${{ steps.yarn-config.outputs.CACHE_FOLDER }}
         key: yarn-download-cache-${{ inputs.cache-prefix }}-${{ hashFiles(format('{0}/yarn.lock', inputs.cwd), format('{0}/.yarnrc.yml', inputs.cwd)) }}

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -98,6 +98,8 @@ jobs:
 
       - name: Setup Node
         uses: ./.github/actions/setup-node
+        with:
+          cache: 'false'
 
       # Trusted Publishing is only available in npm v11.5.1 and later
       - name: Update npm
@@ -107,6 +109,8 @@ jobs:
         uses: ./.github/actions/yarn-install
         with:
           hardened-mode: 'true'
+          cache-download-cache: 'false'
+          cache-npm-cache: 'false'
 
       - name: Typecheck packages
         run: yarn run packages:typecheck


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Disables all gh yarn/npm related caches to defend against a poisoned cache artefact tampering with the NPM packages in this repo during publish

**Why do we need this feature?**

To help defend against publishing tampered packages that could impact consumers.

**Who is this feature for?**

Plugin developers / consumers of the @grafana/* npm packages in this repo.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
