### PR TITLE
feat(assistant): register active dashboard as Assistant page context

### DIFF
--- a/public/app/features/dashboard-scene/hooks/useDashboardPageContext.test.ts
+++ b/public/app/features/dashboard-scene/hooks/useDashboardPageContext.test.ts
@@ -1,0 +1,162 @@
+import { act, renderHook } from '@testing-library/react';
+
+import { type DashboardScene } from '../scene/DashboardScene';
+
+import { useDashboardPageContext } from './useDashboardPageContext';
+
+// Capture the latest setter handed back by `useProvidePageContext` so
+// each test can inspect what the hook published into page context.
+const setContext = jest.fn();
+
+jest.mock('@grafana/assistant', () => ({
+  __esModule: true,
+  useProvidePageContext: jest.fn(() => setContext),
+  // Mirror just enough of the real `createAssistantContextItem('dashboard', …)`
+  // shape that the assertions below can pin the wire contract without
+  // pulling in the SDK's class hierarchy.
+  createAssistantContextItem: jest.fn((type: string, params: unknown) => ({ type, params })),
+}));
+
+interface SceneStub {
+  state: DashboardScene['state'];
+  subscribeToState: jest.Mock;
+  // Test helper — not part of the real DashboardScene surface.
+  __emit: (next: Partial<DashboardScene['state']>) => void;
+}
+
+function makeSceneStub(initial: Partial<DashboardScene['state']> = {}): SceneStub {
+  const listeners = new Set<(state: DashboardScene['state']) => void>();
+  const stub: SceneStub = {
+    state: {
+      title: 'Checkout Overview',
+      uid: 'checkout-overview',
+      meta: {},
+      links: [],
+      body: {} as DashboardScene['state']['body'],
+      ...initial,
+    } as DashboardScene['state'],
+    subscribeToState: jest.fn((cb: (state: DashboardScene['state']) => void) => {
+      listeners.add(cb);
+      return { unsubscribe: () => listeners.delete(cb) };
+    }),
+    __emit: (next) => {
+      stub.state = { ...stub.state, ...next } as DashboardScene['state'];
+      for (const cb of listeners) {
+        cb(stub.state);
+      }
+    },
+  };
+  return stub;
+}
+
+describe('useDashboardPageContext', () => {
+  beforeEach(() => {
+    setContext.mockClear();
+  });
+
+  it('publishes a dashboard context item when uid and title are available', () => {
+    const dashboard = makeSceneStub({
+      uid: 'checkout-overview',
+      title: 'Checkout Overview',
+      meta: { folderUid: 'fld-checkout', folderTitle: 'Checkout' },
+    });
+
+    renderHook(() => useDashboardPageContext(dashboard as unknown as DashboardScene));
+
+    expect(setContext).toHaveBeenLastCalledWith([
+      {
+        type: 'dashboard',
+        params: {
+          dashboardUid: 'checkout-overview',
+          dashboardTitle: 'Checkout Overview',
+          folderUid: 'fld-checkout',
+          folderTitle: 'Checkout',
+        },
+      },
+    ]);
+  });
+
+  it('clears the context when no dashboard is provided', () => {
+    renderHook(() => useDashboardPageContext(undefined));
+
+    // The hook always clears on the "no record" path so a stale
+    // registration from a previous page doesn't leak into the chat.
+    expect(setContext).toHaveBeenLastCalledWith([]);
+  });
+
+  it('skips registration for snapshots and embedded dashboards', () => {
+    const snapshot = makeSceneStub({
+      uid: 'snap-1',
+      title: 'Snapshot',
+      meta: { isSnapshot: true },
+    });
+
+    renderHook(() => useDashboardPageContext(snapshot as unknown as DashboardScene));
+    expect(setContext).toHaveBeenLastCalledWith([]);
+
+    setContext.mockClear();
+
+    const embedded = makeSceneStub({
+      uid: 'emb-1',
+      title: 'Embedded',
+      meta: { isEmbedded: true },
+    });
+
+    renderHook(() => useDashboardPageContext(embedded as unknown as DashboardScene));
+    expect(setContext).toHaveBeenLastCalledWith([]);
+  });
+
+  it('skips registration when uid is missing (new/unsaved dashboard)', () => {
+    const newDashboard = makeSceneStub({
+      uid: undefined,
+      title: 'New dashboard',
+      meta: {},
+    });
+
+    renderHook(() => useDashboardPageContext(newDashboard as unknown as DashboardScene));
+
+    expect(setContext).toHaveBeenLastCalledWith([]);
+  });
+
+  it('re-publishes when the dashboard title changes (rename/save)', () => {
+    const dashboard = makeSceneStub({
+      uid: 'checkout-overview',
+      title: 'Checkout Overview',
+      meta: {},
+    });
+
+    renderHook(() => useDashboardPageContext(dashboard as unknown as DashboardScene));
+
+    expect(setContext).toHaveBeenLastCalledWith([
+      expect.objectContaining({
+        type: 'dashboard',
+        params: expect.objectContaining({ dashboardTitle: 'Checkout Overview' }),
+      }),
+    ]);
+
+    act(() => {
+      dashboard.__emit({ title: 'Checkout — production' });
+    });
+
+    expect(setContext).toHaveBeenLastCalledWith([
+      expect.objectContaining({
+        type: 'dashboard',
+        params: expect.objectContaining({ dashboardTitle: 'Checkout — production' }),
+      }),
+    ]);
+  });
+
+  it('unsubscribes from the scene on unmount', () => {
+    const dashboard = makeSceneStub();
+
+    const { unmount } = renderHook(() => useDashboardPageContext(dashboard as unknown as DashboardScene));
+
+    expect(dashboard.subscribeToState).toHaveBeenCalledTimes(1);
+    const subscription = dashboard.subscribeToState.mock.results[0].value;
+    const unsubscribeSpy = jest.spyOn(subscription, 'unsubscribe');
+
+    unmount();
+
+    expect(unsubscribeSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/public/app/features/dashboard-scene/hooks/useDashboardPageContext.ts
+++ b/public/app/features/dashboard-scene/hooks/useDashboardPageContext.ts
@@ -1,0 +1,105 @@
+import { useEffect, useState } from 'react';
+
+import { createAssistantContextItem, useProvidePageContext } from '@grafana/assistant';
+
+import { type DashboardScene } from '../scene/DashboardScene';
+
+interface RegistrationFields {
+  uid: string;
+  title: string;
+  folderUid?: string;
+  folderTitle?: string;
+  isSnapshot: boolean;
+  isEmbedded: boolean;
+}
+
+/**
+ * Registers the active dashboard as Grafana Assistant page context so
+ * the assistant chat surface can pick it up without the user having
+ * to `@`-mention the dashboard by name.
+ *
+ * Why this lives here rather than inside the Assistant SDK:
+ *  - the dashboard scene state (uid, title, folder) is only available
+ *    inside the dashboard runtime; nothing else should reach in.
+ *  - the URL scope (`/^\/d\//`) is the dashboard route shape this
+ *    application owns. Other dashboard surfaces (snapshots, public
+ *    dashboards) live at different paths and are intentionally
+ *    excluded so they don't get auto-grounded.
+ *
+ * What downstream uses it for:
+ *  - the Grafana Assistant app (`grafana-assistant-app`) reads this
+ *    context via `usePageContext()` in its grounding hook
+ *    (`useDashboardIntentGrounding`) and auto-injects the dashboard's
+ *    intent into chat without an explicit pill — so a chat opened
+ *    while viewing a dashboard already knows what that dashboard is
+ *    meant to monitor.
+ *
+ * Snapshots and embedded dashboards have no useful intent context to
+ * inject (no stable UID on the wire, no per-tenant ownership), so we
+ * skip registering for those even when they happen to render via the
+ * same scene. Dashboards without a UID (new / unsaved) are skipped
+ * for the same reason — there's nothing for downstream consumers to
+ * key off.
+ */
+export function useDashboardPageContext(dashboard: DashboardScene | undefined): void {
+  // Scope the registration to the dashboard route family. Other
+  // assistant-aware pages (Explore, Drilldown, etc.) own their own
+  // regex and we don't want to clobber theirs by registering at the
+  // root.
+  const setContext = useProvidePageContext(/^\/d\//);
+
+  // Track the fields we care about with a local snapshot so we can
+  // subscribe manually to the scene without violating React's rules of
+  // hooks (the scene reference can be undefined on the first render
+  // path, so we can't call `dashboard.useState()` conditionally).
+  const [fields, setFields] = useState<RegistrationFields | undefined>(() => extractFields(dashboard));
+
+  useEffect(() => {
+    if (!dashboard) {
+      setFields(undefined);
+      return;
+    }
+
+    setFields(extractFields(dashboard));
+
+    const sub = dashboard.subscribeToState(() => {
+      setFields(extractFields(dashboard));
+    });
+
+    return () => sub.unsubscribe();
+  }, [dashboard]);
+
+  useEffect(() => {
+    if (!fields || fields.isSnapshot || fields.isEmbedded) {
+      setContext([]);
+      return;
+    }
+
+    setContext([
+      createAssistantContextItem('dashboard', {
+        dashboardUid: fields.uid,
+        dashboardTitle: fields.title,
+        folderUid: fields.folderUid,
+        folderTitle: fields.folderTitle,
+      }),
+    ]);
+  }, [fields, setContext]);
+}
+
+function extractFields(dashboard: DashboardScene | undefined): RegistrationFields | undefined {
+  if (!dashboard) {
+    return undefined;
+  }
+  const { uid, title, meta } = dashboard.state;
+  if (!uid || !title) {
+    return undefined;
+  }
+  return {
+    uid,
+    title,
+    folderUid: meta.folderUid,
+    folderTitle: meta.folderTitle,
+    isSnapshot: Boolean(meta.isSnapshot),
+    isEmbedded: Boolean(meta.isEmbedded),
+  };
+}

--- a/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
+++ b/public/app/features/dashboard-scene/pages/DashboardScenePage.tsx
@@ -25,6 +25,7 @@ import { DashboardRoutes } from 'app/types/dashboard';
 
 import { DashboardConversionWarningBanner } from '../components/DashboardConversionWarningBanner';
 import { SuggestedDashboardsBanner } from '../components/SuggestedDashboardsBanner';
+import { useDashboardPageContext } from '../hooks/useDashboardPageContext';
 import { DashboardPrompt } from '../saving/DashboardPrompt';
 import { preserveDashboardSceneStateInLocalStorage } from '../utils/dashboardSessionState';
 import { useScenesFlickeringFix } from '../utils/utils';
@@ -49,6 +50,11 @@ export function DashboardScenePage({ route, queryParams, location }: Props) {
   const prevParams = useRef<Params<string>>(params);
 
   useScenesFlickeringFix();
+  // Register the active dashboard as Grafana Assistant page context so
+  // the assistant chat surface can auto-ground without an `@` mention.
+  // Called at the top so the registration's cleanup runs on unmount
+  // regardless of which render branch the page takes below.
+  useDashboardPageContext(dashboard);
 
   useEffect(() => {
     if (route.routeName === DashboardRoutes.Normal && type === 'snapshot') {


### PR DESCRIPTION
## Summary

- Adds `useDashboardPageContext` hook in `public/app/features/dashboard-scene/hooks/` that registers the active dashboard (uid, title, folder) as Grafana Assistant page context via `useProvidePageContext(/^\/d\//)` from `@grafana/assistant`.
- Wires the hook into `DashboardScenePage` so it fires on every normal dashboard route, including late-loading title/folder updates (via scene subscription) and renames/saves.
- Skips registration for snapshots, embedded dashboards, and unsaved (no-uid) dashboards — nothing for downstream consumers to key off.
- Mirrors the existing `useExplorePageContext` pattern.

**Why this matters:** the Grafana Assistant app (`grafana-assistant-app`) reads this context via `usePageContext()` in its `useDashboardIntentGrounding` hook and auto-injects dashboard intent into chat — so opening the assistant while viewing a dashboard works without manually `@`-mentioning it.

## Test plan

- [ ] Unit tests: `yarn jest public/app/features/dashboard-scene/hooks/useDashboardPageContext.test.ts` — 6 tests, all pass
- [ ] Typecheck: `yarn typecheck` — clean across all 14 nx projects
- [ ] ESLint: clean on touched files
- [ ] Manual: navigate to any dashboard, open assistant chat — "Dashboard Intent" pill appears automatically without `@` mention
- [ ] Manual: navigate away from dashboard — pill clears
- [ ] Manual: snapshot/embedded dashboard — pill does not appear

Made with [Cursor](https://cursor.com)