### PR TITLE
TimeSeriesPanel: Migrate graph legend sort options

### DIFF
--- a/public/app/plugins/panel/timeseries/migrations.test.ts
+++ b/public/app/plugins/panel/timeseries/migrations.test.ts
@@ -230,6 +230,48 @@ describe('Graph Migrations', () => {
       expect(panel.options.legend.width).toBe(200);
     });
 
+    test('with sortBy and sortDesc', () => {
+      const old = {
+        angular: {
+          legend: {
+            alignAsTable: true,
+            show: true,
+            values: true,
+            avg: true,
+            max: true,
+            min: true,
+            sortBy: 'Mean',
+            sortDesc: true,
+          },
+        },
+      };
+      const panel = {} as PanelModel;
+      panel.options = graphPanelChangedHandler(panel, 'graph', old, prevFieldConfig);
+      expect(panel.options.legend.sortBy).toBe('Mean');
+      expect(panel.options.legend.sortDesc).toBe(true);
+    });
+
+    test('with sort field (avg)', () => {
+      const old = {
+        angular: {
+          legend: {
+            alignAsTable: true,
+            show: true,
+            values: true,
+            avg: true,
+            max: true,
+            min: true,
+            sort: 'avg',
+            sortDesc: true,
+          },
+        },
+      };
+      const panel = {} as PanelModel;
+      panel.options = graphPanelChangedHandler(panel, 'graph', old, prevFieldConfig);
+      expect(panel.options.legend.sortBy).toBe('Mean');
+      expect(panel.options.legend.sortDesc).toBe(true);
+    });
+
     test('hide allZeros', () => {
       const old = {
         angular: {

--- a/public/app/plugins/panel/timeseries/migrations.ts
+++ b/public/app/plugins/panel/timeseries/migrations.ts
@@ -720,7 +720,7 @@ function getReducersFromLegend(obj: Record<string, unknown>): string[] {
 }
 
 /** Maps legacy graph legend sort keys to VizLegend table column titles (fieldReducer.name). */
-function mapLegendSortKey(sortKey: string): string | undefined {
+function mapLegendSortKey(sortKey: string): string {
   const reducer = fieldReducers.getIfExists(sortKey);
   if (reducer) {
     return reducer.name;

--- a/public/app/plugins/panel/timeseries/migrations.ts
+++ b/public/app/plugins/panel/timeseries/migrations.ts
@@ -402,6 +402,18 @@ export function graphToTimeseriesOptions(angular: any): {
     if (legendConfig.hideEmpty) {
       overrides.push(getLegendHideFromOverride(ReducerID.allIsNull));
     }
+
+    const sortKey = legendConfig.sortBy ?? legendConfig.sort;
+    if (sortKey != null && sortKey !== '') {
+      const mapped = mapLegendSortKey(String(sortKey));
+      if (mapped) {
+        options.legend.sortBy = mapped;
+      }
+    }
+
+    if (legendConfig.sortDesc != null) {
+      options.legend.sortDesc = legendConfig.sortDesc;
+    }
   }
 
   // timeRegions migration
@@ -705,6 +717,25 @@ function getReducersFromLegend(obj: Record<string, unknown>): string[] {
     }
   }
   return ids;
+}
+
+/** Maps legacy graph legend sort keys to VizLegend table column titles (fieldReducer.name). */
+function mapLegendSortKey(sortKey: string): string | undefined {
+  const reducer = fieldReducers.getIfExists(sortKey);
+  if (reducer) {
+    return reducer.name;
+  }
+
+  const legacy: Record<string, string> = {
+    avg: 'Mean',
+    mean: 'Mean',
+    max: 'Max',
+    min: 'Min',
+    total: 'Total',
+    current: 'Last',
+  };
+
+  return legacy[sortKey.toLowerCase()] ?? sortKey;
 }
 
 function migrateHideFrom(panel: {


### PR DESCRIPTION
**What is this feature?**

Migrates legend sort settings when converting deprecated graph panels to the time series panel, including `sortBy`, `sortDesc`, and the legacy `sort` field (e.g. `avg` → `Mean`).

**Why do we need this feature?**

The graph → time series migration already copies legend display mode, placement, and value calculations, but it omitted sort options. Dashboards that relied on table legends sorted by average lose that ordering after migration until the user re-sorts manually.

**Who is this feature for?**

Users opening dashboards that still use `type: graph` panels (auto-migrated to time series in Grafana 12+) and anyone maintaining provisioned dashboards with legend sort in the old schema.

**Special notes for your reviewer:**
- Tests cover `sortBy: 'Mean'` and legacy `sort: 'avg'`.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to What's New.