### PR TITLE
Alerting: remove alertingUIUseBackendFilters and alertingUIUseFullyCompatBackendFilters feature toggles

### DIFF
--- a/public/app/features/alerting/unified/featureToggles.ts
+++ b/public/app/features/alerting/unified/featureToggles.ts
@@ -24,11 +24,6 @@ export const shouldAllowRecoveringDeletedRules = () =>
 export const shouldAllowPermanentlyDeletingRules = () =>
   (shouldAllowRecoveringDeletedRules() && config.featureToggles.alertingRulePermanentlyDelete) ?? false;
 
-export const shouldUseBackendFilters = () => config.featureToggles.alertingUIUseBackendFilters ?? false;
-
-export const shouldUseFullyCompatibleBackendFilters = () =>
-  config.featureToggles.alertingUIUseFullyCompatBackendFilters ?? false;
-
 /**
  * Alerts Activity Banner - shows a promotional banner on the Rule List page
  * directing users to try the new Alerts Activity (triage) view.

--- a/public/app/features/alerting/unified/rule-list/hooks/grafanaFilter.test.ts
+++ b/public/app/features/alerting/unified/rule-list/hooks/grafanaFilter.test.ts
@@ -1,5 +1,3 @@
-import { testWithFeatureToggles } from 'test/test-utils';
-
 import { USER_DEFINED_TREE_NAME } from '@grafana/alerting';
 import { setAppPluginMetas } from '@grafana/runtime/internal';
 import {
@@ -35,120 +33,7 @@ getDatasourceAPIUidMock.mockImplementation((ruleSourceName) => {
 });
 
 describe('grafana-managed rules', () => {
-  describe('groupFilter', () => {
-    it('should filter by namespace (file path)', () => {
-      const group: PromRuleGroupDTO = {
-        name: 'Test Group',
-        file: 'production/alerts',
-        rules: [],
-        interval: 60,
-      };
-
-      const { frontendFilter } = getGrafanaFilter(getFilter({ namespace: 'production' }));
-      expect(frontendFilter.groupMatches(group)).toBe(true);
-
-      const { frontendFilter: frontendFilter2 } = getGrafanaFilter(getFilter({ namespace: 'staging' }));
-      expect(frontendFilter2.groupMatches(group)).toBe(false);
-    });
-
-    it('should filter by group name', () => {
-      const group: PromRuleGroupDTO = {
-        name: 'CPU Usage Alerts',
-        file: 'production/alerts',
-        rules: [],
-        interval: 60,
-      };
-
-      const { frontendFilter } = getGrafanaFilter(getFilter({ groupName: 'cpu' }));
-      expect(frontendFilter.groupMatches(group)).toBe(true);
-
-      const { frontendFilter: frontendFilter2 } = getGrafanaFilter(getFilter({ groupName: 'memory' }));
-      expect(frontendFilter2.groupMatches(group)).toBe(false);
-    });
-
-    it('should return true when no filters are applied', () => {
-      const group: PromRuleGroupDTO = {
-        name: 'Test Group',
-        file: 'production/alerts',
-        rules: [],
-        interval: 60,
-      };
-
-      const { frontendFilter } = getGrafanaFilter(getFilter({}));
-      expect(frontendFilter.groupMatches(group)).toBe(true);
-    });
-  });
-
-  describe('ruleFilter - frontend filters', () => {
-    it('should filter by free form words in rule name', () => {
-      const rule = mockGrafanaPromAlertingRule({ name: 'High CPU Usage' });
-
-      const { frontendFilter } = getGrafanaFilter(getFilter({ freeFormWords: ['cpu'] }));
-      expect(frontendFilter.ruleMatches(rule)).toBe(true);
-
-      const { frontendFilter: frontendFilter2 } = getGrafanaFilter(getFilter({ freeFormWords: ['memory'] }));
-      expect(frontendFilter2.ruleMatches(rule)).toBe(false);
-    });
-
-    it('should filter by rule name', () => {
-      const rule = mockGrafanaPromAlertingRule({ name: 'High CPU Usage' });
-
-      const { frontendFilter } = getGrafanaFilter(getFilter({ ruleName: 'cpu' }));
-      expect(frontendFilter.ruleMatches(rule)).toBe(true);
-
-      const { frontendFilter: frontendFilter2 } = getGrafanaFilter(getFilter({ ruleName: 'memory' }));
-      expect(frontendFilter2.ruleMatches(rule)).toBe(false);
-    });
-
-    it('should filter by labels', () => {
-      const rule = mockGrafanaPromAlertingRule({
-        labels: { severity: 'critical', team: 'ops' },
-        alerts: [],
-      });
-
-      const { frontendFilter } = getGrafanaFilter(getFilter({ labels: ['severity=critical'] }));
-      expect(frontendFilter.ruleMatches(rule)).toBe(true);
-
-      const { frontendFilter: frontendFilter2 } = getGrafanaFilter(getFilter({ labels: ['severity=warning'] }));
-      expect(frontendFilter2.ruleMatches(rule)).toBe(false);
-
-      const { frontendFilter: frontendFilter3 } = getGrafanaFilter(getFilter({ labels: ['team=ops'] }));
-      expect(frontendFilter3.ruleMatches(rule)).toBe(true);
-    });
-
-    it('should filter by rule type', () => {
-      const alertingRule = mockGrafanaPromAlertingRule({ name: 'Test Alert' });
-      const recordingRule = mockPromRecordingRule({ name: 'Test Recording' });
-
-      const { frontendFilter } = getGrafanaFilter(getFilter({ ruleType: PromRuleType.Alerting }));
-      expect(frontendFilter.ruleMatches(alertingRule)).toBe(true);
-      expect(frontendFilter.ruleMatches(recordingRule)).toBe(false);
-
-      const { frontendFilter: frontendFilter2 } = getGrafanaFilter(getFilter({ ruleType: PromRuleType.Recording }));
-      expect(frontendFilter2.ruleMatches(alertingRule)).toBe(false);
-      expect(frontendFilter2.ruleMatches(recordingRule)).toBe(true);
-    });
-
-    it('should filter by dashboard UID', () => {
-      const ruleDashboardA = mockGrafanaPromAlertingRule({
-        name: 'Dashboard A Rule',
-        annotations: { [Annotation.dashboardUID]: 'dashboard-a' },
-      });
-
-      const ruleDashboardB = mockGrafanaPromAlertingRule({
-        name: 'Dashboard B Rule',
-        annotations: { [Annotation.dashboardUID]: 'dashboard-b' },
-      });
-
-      const { frontendFilter } = getGrafanaFilter(getFilter({ dashboardUid: 'dashboard-a' }));
-      expect(frontendFilter.ruleMatches(ruleDashboardA)).toBe(true);
-      expect(frontendFilter.ruleMatches(ruleDashboardB)).toBe(false);
-
-      const { frontendFilter: frontendFilter2 } = getGrafanaFilter(getFilter({ dashboardUid: 'dashboard-b' }));
-      expect(frontendFilter2.ruleMatches(ruleDashboardA)).toBe(false);
-      expect(frontendFilter2.ruleMatches(ruleDashboardB)).toBe(true);
-    });
-
+  describe('ruleFilter - policy filter (frontend-only)', () => {
     it('should filter by policy routing', () => {
       const ruleWithPolicy = mockGrafanaPromAlertingRule({
         name: 'Rule with Policy',
@@ -191,26 +76,6 @@ describe('grafana-managed rules', () => {
       expect(frontendFilter.ruleMatches(ruleWithExplicitUserDefinedPolicy)).toBe(true);
       expect(frontendFilter.ruleMatches(ruleWithContactPoint)).toBe(false);
       expect(frontendFilter.ruleMatches(ruleWithExplicitPolicy)).toBe(false);
-    });
-
-    describe('dataSourceNames filter', () => {
-      it('should match rules that use the filtered datasource', () => {
-        const ruleWithMatchingDatasource = mockGrafanaPromAlertingRule({
-          queriedDatasourceUIDs: ['datasource-uid-1'],
-        });
-
-        const { frontendFilter } = getGrafanaFilter(getFilter({ dataSourceNames: ['prometheus'] }));
-        expect(frontendFilter.ruleMatches(ruleWithMatchingDatasource)).toBe(true);
-      });
-
-      it("should filter out rules that don't use the filtered datasource", () => {
-        const ruleWithoutMatchingDatasource = mockGrafanaPromAlertingRule({
-          queriedDatasourceUIDs: ['datasource-uid-1', 'datasource-uid-2'],
-        });
-
-        const { frontendFilter } = getGrafanaFilter(getFilter({ dataSourceNames: ['loki'] }));
-        expect(frontendFilter.ruleMatches(ruleWithoutMatchingDatasource)).toBe(false);
-      });
     });
   });
 
@@ -319,643 +184,224 @@ describe('grafana-managed rules', () => {
     });
   });
 
-  describe('backend filtering with alertingUIUseBackendFilters feature toggle', () => {
-    describe('when alertingUIUseBackendFilters is enabled', () => {
-      testWithFeatureToggles({ enable: ['alertingUIUseBackendFilters'] });
+  describe('backend filtering', () => {
+    it('should include datasources in backend filter when valid data source names are provided', () => {
+      const { backendFilter, hasInvalidDataSourceNames } = getGrafanaFilter(
+        getFilter({ dataSourceNames: ['prometheus', 'loki'] })
+      );
 
-      it('should include datasources in backend filter when valid data source names are provided', () => {
-        const { backendFilter, hasInvalidDataSourceNames } = getGrafanaFilter(
-          getFilter({ dataSourceNames: ['prometheus', 'loki'] })
-        );
-
-        expect(backendFilter.datasources).toEqual(['datasource-uid-1', 'datasource-uid-3']);
-        expect(hasInvalidDataSourceNames).toBe(false);
-      });
-
-      it('should detect invalid data source names and set hasInvalidDataSourceNames flag', () => {
-        const { backendFilter, hasInvalidDataSourceNames } = getGrafanaFilter(
-          getFilter({ dataSourceNames: ['non-existent-datasource'] })
-        );
-
-        expect(backendFilter.datasources).toEqual([]);
-        expect(hasInvalidDataSourceNames).toBe(true);
-      });
-
-      it('should include only valid datasource UIDs when some names are invalid', () => {
-        const { backendFilter, hasInvalidDataSourceNames } = getGrafanaFilter(
-          getFilter({ dataSourceNames: ['prometheus', 'non-existent-datasource'] })
-        );
-
-        expect(backendFilter.datasources).toEqual(['datasource-uid-1']);
-        expect(hasInvalidDataSourceNames).toBe(false); // Not all are invalid
-      });
-
-      it('should skip dataSourceNames filtering on frontend when backend filtering is enabled', () => {
-        const rule = mockGrafanaPromAlertingRule({
-          queriedDatasourceUIDs: ['datasource-uid-1'],
-        });
-
-        const { frontendFilter } = getGrafanaFilter(getFilter({ dataSourceNames: ['loki'] }));
-        // Should return true because dataSourceNames filter is null (handled by backend).
-        expect(frontendFilter.ruleMatches(rule)).toBe(true);
-      });
-
-      it('should include title in backend filter when freeFormWords are provided', () => {
-        const { backendFilter } = getGrafanaFilter(getFilter({ freeFormWords: ['cpu', 'usage'] }));
-
-        expect(backendFilter.title).toBe('cpu usage');
-      });
-
-      it('should include title in backend filter when ruleName is provided', () => {
-        const { backendFilter } = getGrafanaFilter(getFilter({ ruleName: 'high cpu' }));
-
-        expect(backendFilter.title).toBe('high cpu');
-      });
-
-      it('should combine ruleName and freeFormWords in title', () => {
-        const { backendFilter } = getGrafanaFilter(getFilter({ ruleName: 'alert', freeFormWords: ['cpu'] }));
-
-        expect(backendFilter.title).toBe('alert cpu');
-      });
-
-      it('should not include title when no title filters are provided', () => {
-        const { backendFilter } = getGrafanaFilter(getFilter({ ruleState: PromAlertingRuleState.Firing }));
-
-        expect(backendFilter.title).toBeUndefined();
-      });
-
-      it('should skip freeFormWords filtering on frontend when backend filtering is enabled', () => {
-        const rule = mockGrafanaPromAlertingRule({ name: 'High CPU Usage' });
-
-        const { frontendFilter } = getGrafanaFilter(getFilter({ freeFormWords: ['memory'] }));
-        // Should return true because freeFormWords filter is null (handled by backend)
-        expect(frontendFilter.ruleMatches(rule)).toBe(true);
-      });
-
-      it('should skip ruleName filtering on frontend when backend filtering is enabled', () => {
-        const rule = mockGrafanaPromAlertingRule({ name: 'High CPU Usage' });
-
-        const { frontendFilter } = getGrafanaFilter(getFilter({ ruleName: 'memory' }));
-        // Should return true because ruleName filter is null (handled by backend)
-        expect(frontendFilter.ruleMatches(rule)).toBe(true);
-      });
-
-      it('should include ruleType in backend filter when provided', () => {
-        const { backendFilter } = getGrafanaFilter(getFilter({ ruleType: PromRuleType.Alerting }));
-
-        expect(backendFilter.type).toBe(PromRuleType.Alerting);
-      });
-
-      it('should not include ruleType in backend filter when not provided', () => {
-        const { backendFilter } = getGrafanaFilter(getFilter({}));
-
-        expect(backendFilter.type).toBeUndefined();
-      });
-
-      it('should skip ruleType filtering on frontend when backend filtering is enabled', () => {
-        const alertingRule = mockGrafanaPromAlertingRule({ name: 'Test Alert' });
-        const recordingRule = mockPromRecordingRule({ name: 'Test Recording' });
-
-        const { frontendFilter } = getGrafanaFilter(getFilter({ ruleType: PromRuleType.Alerting }));
-        // Should return true for both because ruleType filter is null (handled by backend)
-        expect(frontendFilter.ruleMatches(alertingRule)).toBe(true);
-        expect(frontendFilter.ruleMatches(recordingRule)).toBe(true);
-      });
-
-      it('should include dashboardUid in backend filter when provided', () => {
-        const { backendFilter } = getGrafanaFilter(getFilter({ dashboardUid: 'dashboard-123' }));
-
-        expect(backendFilter.dashboardUid).toBe('dashboard-123');
-      });
-
-      it('should not include dashboardUid in backend filter when not provided', () => {
-        const { backendFilter } = getGrafanaFilter(getFilter({}));
-
-        expect(backendFilter.dashboardUid).toBeUndefined();
-      });
-
-      it('should skip dashboardUid filtering on frontend when backend filtering is enabled', () => {
-        const ruleWithDashboard = mockGrafanaPromAlertingRule({
-          name: 'Dashboard Rule',
-          annotations: { [Annotation.dashboardUID]: 'dashboard-a' },
-        });
-
-        const { frontendFilter } = getGrafanaFilter(getFilter({ dashboardUid: 'dashboard-b' }));
-        // Should return true because dashboardUid filter is null (handled by backend)
-        expect(frontendFilter.ruleMatches(ruleWithDashboard)).toBe(true);
-      });
-
-      it('should include searchGroupName in backend filter when provided', () => {
-        const { backendFilter } = getGrafanaFilter(getFilter({ groupName: 'my-group' }));
-
-        expect(backendFilter.searchGroupName).toBe('my-group');
-      });
-
-      it('should not include searchGroupName in backend filter when not provided', () => {
-        const { backendFilter } = getGrafanaFilter(getFilter({}));
-
-        expect(backendFilter.searchGroupName).toBeUndefined();
-      });
-
-      it('should skip groupName filtering on frontend when backend filtering is enabled', () => {
-        const group: PromRuleGroupDTO = {
-          name: 'CPU Usage Alerts',
-          file: 'production/alerts',
-          rules: [],
-          interval: 60,
-        };
-
-        const { frontendFilter } = getGrafanaFilter(getFilter({ groupName: 'memory' }));
-        // Should return true because groupName filter is null (handled by backend)
-        expect(frontendFilter.groupMatches(group)).toBe(true);
-      });
-
-      it('should include ruleMatchers in backend filter when labels are provided', () => {
-        const { backendFilter } = getGrafanaFilter(getFilter({ labels: ['severity=critical'] }));
-
-        expect(backendFilter.ruleMatchers).toBeDefined();
-        expect(backendFilter.ruleMatchers).toHaveLength(1);
-        expect(backendFilter.ruleMatchers).toEqual([
-          '{"name":"severity","value":"critical","isRegex":false,"isEqual":true}',
-        ]);
-      });
-
-      it('should include plugins in backend filter and skip frontend filtering', () => {
-        // Set up test plugin as installed
-        setAppPluginMetas({ [SupportedPlugin.Slo]: pluginMetaToPluginConfig(pluginMeta[SupportedPlugin.Slo]) });
-
-        const regularRule = mockGrafanaPromAlertingRule({
-          name: 'High CPU Usage',
-          labels: { severity: 'critical', team: 'ops' },
-          alerts: [],
-        });
-
-        const pluginRule = mockGrafanaPromAlertingRule({
-          name: 'Plugin Rule',
-          labels: { __grafana_origin: `plugin/${SupportedPlugin.Slo}` },
-          alerts: [],
-        });
-
-        // Plugins filter should be handled by backend
-        const { backendFilter, frontendFilter } = getGrafanaFilter(getFilter({ plugins: 'hide' }));
-
-        // Backend filter should include plugins parameter
-        expect(backendFilter.plugins).toBe('hide');
-
-        // Frontend filter should pass through all rules (no filtering)
-        expect(frontendFilter.ruleMatches(regularRule)).toBe(true);
-        expect(frontendFilter.ruleMatches(pluginRule)).toBe(true);
-      });
-
-      it('should include searchFolder in backend filter when namespace is provided', () => {
-        const { backendFilter } = getGrafanaFilter(getFilter({ namespace: 'my-folder' }));
-
-        expect(backendFilter.searchFolder).toBe('my-folder');
-      });
-
-      it('should skip namespace filtering on frontend when backend filtering is enabled', () => {
-        const group: PromRuleGroupDTO = {
-          name: 'Test Group',
-          file: 'production/alerts',
-          rules: [],
-          interval: 60,
-        };
-
-        const { frontendFilter } = getGrafanaFilter(getFilter({ namespace: 'staging' }));
-        // Should return true because namespace filter is null (handled by backend)
-        expect(frontendFilter.groupMatches(group)).toBe(true);
-      });
+      expect(backendFilter.datasources).toEqual(['datasource-uid-1', 'datasource-uid-3']);
+      expect(hasInvalidDataSourceNames).toBe(false);
     });
 
-    describe('when alertingUIUseBackendFilters is disabled', () => {
-      testWithFeatureToggles({ disable: ['alertingUIUseBackendFilters'] });
+    it('should detect invalid data source names and set hasInvalidDataSourceNames flag', () => {
+      const { backendFilter, hasInvalidDataSourceNames } = getGrafanaFilter(
+        getFilter({ dataSourceNames: ['non-existent-datasource'] })
+      );
 
-      it('should not include title in backend filter', () => {
-        const { backendFilter } = getGrafanaFilter(getFilter({ freeFormWords: ['cpu'] }));
-
-        expect(backendFilter.title).toBeUndefined();
-      });
-
-      it('should perform freeFormWords filtering on frontend', () => {
-        const rule = mockGrafanaPromAlertingRule({ name: 'High CPU Usage' });
-
-        const { frontendFilter } = getGrafanaFilter(getFilter({ freeFormWords: ['cpu'] }));
-        expect(frontendFilter.ruleMatches(rule)).toBe(true);
-
-        const { frontendFilter: frontendFilter2 } = getGrafanaFilter(getFilter({ freeFormWords: ['memory'] }));
-        expect(frontendFilter2.ruleMatches(rule)).toBe(false);
-      });
-
-      it('should perform ruleName filtering on frontend', () => {
-        const rule = mockGrafanaPromAlertingRule({ name: 'High CPU Usage' });
-
-        const { frontendFilter } = getGrafanaFilter(getFilter({ ruleName: 'cpu' }));
-        expect(frontendFilter.ruleMatches(rule)).toBe(true);
-
-        const { frontendFilter: frontendFilter2 } = getGrafanaFilter(getFilter({ ruleName: 'memory' }));
-        expect(frontendFilter2.ruleMatches(rule)).toBe(false);
-      });
-
-      it('should not include ruleType in backend filter', () => {
-        const { backendFilter } = getGrafanaFilter(getFilter({ ruleType: PromRuleType.Alerting }));
-
-        expect(backendFilter.type).toBeUndefined();
-      });
-
-      it('should perform ruleType filtering on frontend', () => {
-        const alertingRule = mockGrafanaPromAlertingRule({ name: 'Test Alert' });
-        const recordingRule = mockPromRecordingRule({ name: 'Test Recording' });
-
-        const { frontendFilter } = getGrafanaFilter(getFilter({ ruleType: PromRuleType.Alerting }));
-        expect(frontendFilter.ruleMatches(alertingRule)).toBe(true);
-        expect(frontendFilter.ruleMatches(recordingRule)).toBe(false);
-
-        const { frontendFilter: frontendFilter2 } = getGrafanaFilter(getFilter({ ruleType: PromRuleType.Recording }));
-        expect(frontendFilter2.ruleMatches(alertingRule)).toBe(false);
-        expect(frontendFilter2.ruleMatches(recordingRule)).toBe(true);
-      });
-
-      it('should not include dashboardUid in backend filter', () => {
-        const { backendFilter } = getGrafanaFilter(getFilter({ dashboardUid: 'dashboard-123' }));
-
-        expect(backendFilter.dashboardUid).toBeUndefined();
-      });
-
-      it('should perform dashboardUid filtering on frontend', () => {
-        const ruleDashboardA = mockGrafanaPromAlertingRule({
-          name: 'Dashboard A Rule',
-          annotations: { [Annotation.dashboardUID]: 'dashboard-a' },
-        });
-
-        const ruleDashboardB = mockGrafanaPromAlertingRule({
-          name: 'Dashboard B Rule',
-          annotations: { [Annotation.dashboardUID]: 'dashboard-b' },
-        });
-
-        const { frontendFilter } = getGrafanaFilter(getFilter({ dashboardUid: 'dashboard-a' }));
-        expect(frontendFilter.ruleMatches(ruleDashboardA)).toBe(true);
-        expect(frontendFilter.ruleMatches(ruleDashboardB)).toBe(false);
-
-        const { frontendFilter: frontendFilter2 } = getGrafanaFilter(getFilter({ dashboardUid: 'dashboard-b' }));
-        expect(frontendFilter2.ruleMatches(ruleDashboardA)).toBe(false);
-        expect(frontendFilter2.ruleMatches(ruleDashboardB)).toBe(true);
-      });
-
-      it('should not include searchGroupName in backend filter', () => {
-        const { backendFilter } = getGrafanaFilter(getFilter({ groupName: 'my-group' }));
-
-        expect(backendFilter.searchGroupName).toBeUndefined();
-      });
-
-      it('should not include searchFolder in backend filter', () => {
-        const { backendFilter } = getGrafanaFilter(getFilter({ namespace: 'my-folder' }));
-
-        expect(backendFilter.searchFolder).toBeUndefined();
-      });
-
-      it('should perform groupName filtering on frontend', () => {
-        const group: PromRuleGroupDTO = {
-          name: 'CPU Usage Alerts',
-          file: 'production/alerts',
-          rules: [],
-          interval: 60,
-        };
-
-        const { frontendFilter } = getGrafanaFilter(getFilter({ groupName: 'cpu' }));
-        expect(frontendFilter.groupMatches(group)).toBe(true);
-
-        const { frontendFilter: frontendFilter2 } = getGrafanaFilter(getFilter({ groupName: 'memory' }));
-        expect(frontendFilter2.groupMatches(group)).toBe(false);
-      });
+      expect(backendFilter.datasources).toEqual([]);
+      expect(hasInvalidDataSourceNames).toBe(true);
     });
 
-    describe('when alertingUIUseFullyCompatBackendFilters is enabled', () => {
-      testWithFeatureToggles({ enable: ['alertingUIUseFullyCompatBackendFilters'] });
+    it('should include only valid datasource UIDs when some names are invalid', () => {
+      const { backendFilter, hasInvalidDataSourceNames } = getGrafanaFilter(
+        getFilter({ dataSourceNames: ['prometheus', 'non-existent-datasource'] })
+      );
 
-      it('should populate backend filters correctly (ruleType, dashboardUid)', () => {
-        // Fully compatible filters should be in backend
-        const { backendFilter } = getGrafanaFilter(
-          getFilter({
-            ruleType: PromRuleType.Alerting,
-            dashboardUid: 'dashboard-123',
-            freeFormWords: ['cpu'],
-            groupName: 'my-group',
-          })
-        );
-
-        expect(backendFilter.type).toBe(PromRuleType.Alerting);
-        expect(backendFilter.dashboardUid).toBe('dashboard-123');
-
-        // Non-compatible filters should NOT be in backend
-        expect(backendFilter.title).toBeUndefined();
-        expect(backendFilter.searchGroupName).toBeUndefined();
-
-        // Empty state
-        const { backendFilter: emptyFilter } = getGrafanaFilter(getFilter({}));
-        expect(emptyFilter.type).toBeUndefined();
-        expect(emptyFilter.dashboardUid).toBeUndefined();
-      });
-
-      it('should apply frontend filters correctly', () => {
-        const alertingRule = mockGrafanaPromAlertingRule({
-          name: 'High CPU Usage',
-          labels: { severity: 'critical' },
-          queriedDatasourceUIDs: ['datasource-uid-1'],
-          annotations: { [Annotation.dashboardUID]: 'dashboard-a' },
-          alerts: [],
-        });
-        const recordingRule = mockPromRecordingRule({ name: 'Test Recording' });
-
-        // Backend-handled filters (ruleType, dashboardUid) should skip frontend filtering
-        const { frontendFilter: backendHandledFilter } = getGrafanaFilter(
-          getFilter({ ruleType: PromRuleType.Recording, dashboardUid: 'dashboard-b' })
-        );
-        expect(backendHandledFilter.ruleMatches(alertingRule)).toBe(true);
-        expect(backendHandledFilter.ruleMatches(recordingRule)).toBe(true);
-
-        // Frontend-handled filters (freeFormWords, ruleName) should work
-        const { frontendFilter: freeFormMatch } = getGrafanaFilter(getFilter({ freeFormWords: ['cpu'] }));
-        expect(freeFormMatch.ruleMatches(alertingRule)).toBe(true);
-
-        const { frontendFilter: freeFormNoMatch } = getGrafanaFilter(getFilter({ freeFormWords: ['memory'] }));
-        expect(freeFormNoMatch.ruleMatches(alertingRule)).toBe(false);
-
-        const { frontendFilter: ruleNameMatch } = getGrafanaFilter(getFilter({ ruleName: 'cpu' }));
-        expect(ruleNameMatch.ruleMatches(alertingRule)).toBe(true);
-
-        const { frontendFilter: ruleNameNoMatch } = getGrafanaFilter(getFilter({ ruleName: 'memory' }));
-        expect(ruleNameNoMatch.ruleMatches(alertingRule)).toBe(false);
-
-        // Group name filtering
-        const group: PromRuleGroupDTO = {
-          name: 'CPU Usage Alerts',
-          file: 'production/alerts',
-          rules: [],
-          interval: 60,
-        };
-
-        const { frontendFilter: groupMatch } = getGrafanaFilter(getFilter({ groupName: 'cpu' }));
-        expect(groupMatch.groupMatches(group)).toBe(true);
-
-        const { frontendFilter: groupNoMatch } = getGrafanaFilter(getFilter({ groupName: 'memory' }));
-        expect(groupNoMatch.groupMatches(group)).toBe(false);
-
-        // Always-frontend filters (labels, namespace) should work.
-        const { frontendFilter: labelsMatch } = getGrafanaFilter(getFilter({ labels: ['severity=critical'] }));
-        expect(labelsMatch.ruleMatches(alertingRule)).toBe(true);
-
-        const { frontendFilter: labelsNoMatch } = getGrafanaFilter(getFilter({ labels: ['severity=warning'] }));
-        expect(labelsNoMatch.ruleMatches(alertingRule)).toBe(false);
-
-        const { frontendFilter: nsMatch } = getGrafanaFilter(getFilter({ namespace: 'production' }));
-        expect(nsMatch.groupMatches(group)).toBe(true);
-
-        const { frontendFilter: nsNoMatch } = getGrafanaFilter(getFilter({ namespace: 'staging' }));
-        expect(nsNoMatch.groupMatches(group)).toBe(false);
-      });
-
-      it('should skip dataSourceNames filtering on frontend (handled by backend)', () => {
-        const alertingRule = mockGrafanaPromAlertingRule({
-          queriedDatasourceUIDs: ['datasource-uid-1'],
-        });
-
-        // DataSourceNames is backend-filtered when feature toggle is enabled.
-        const { frontendFilter: dsMatch } = getGrafanaFilter(getFilter({ dataSourceNames: ['prometheus'] }));
-        expect(dsMatch.ruleMatches(alertingRule)).toBe(true);
-
-        const { frontendFilter: dsNoMatch } = getGrafanaFilter(getFilter({ dataSourceNames: ['loki'] }));
-        expect(dsNoMatch.ruleMatches(alertingRule)).toBe(true);
-      });
+      expect(backendFilter.datasources).toEqual(['datasource-uid-1']);
+      expect(hasInvalidDataSourceNames).toBe(false); // Not all are invalid
     });
 
-    describe('when both alertingUIUseBackendFilters and alertingUIUseFullyCompatBackendFilters are enabled', () => {
-      testWithFeatureToggles({ enable: ['alertingUIUseBackendFilters', 'alertingUIUseFullyCompatBackendFilters'] });
-
-      it('should include all backend filters (title, ruleType, dashboardUid, searchGroupName)', () => {
-        const { backendFilter } = getGrafanaFilter(
-          getFilter({
-            freeFormWords: ['cpu'],
-            ruleName: 'alert',
-            ruleType: PromRuleType.Alerting,
-            dashboardUid: 'dashboard-123',
-            groupName: 'my-group',
-          })
-        );
-
-        expect(backendFilter.title).toBe('alert cpu');
-        expect(backendFilter.type).toBe(PromRuleType.Alerting);
-        expect(backendFilter.dashboardUid).toBe('dashboard-123');
-        expect(backendFilter.searchGroupName).toBe('my-group');
+    it('should skip dataSourceNames filtering on frontend when backend filtering is enabled', () => {
+      const rule = mockGrafanaPromAlertingRule({
+        queriedDatasourceUIDs: ['datasource-uid-1'],
       });
 
-      it('should skip all backend-handled filters on frontend', () => {
-        const alertingRule = mockGrafanaPromAlertingRule({
-          name: 'High CPU Usage',
-          annotations: { [Annotation.dashboardUID]: 'dashboard-a' },
-        });
-        const recordingRule = mockPromRecordingRule({ name: 'Test Recording' });
+      const { frontendFilter } = getGrafanaFilter(getFilter({ dataSourceNames: ['loki'] }));
+      // Should return true because dataSourceNames filter is null (handled by backend).
+      expect(frontendFilter.ruleMatches(rule)).toBe(true);
+    });
 
-        const { frontendFilter } = getGrafanaFilter(
-          getFilter({
-            freeFormWords: ['memory'],
-            ruleName: 'memory',
-            ruleType: PromRuleType.Recording,
-            dashboardUid: 'dashboard-b',
-          })
-        );
+    it('should include title in backend filter when freeFormWords are provided', () => {
+      const { backendFilter } = getGrafanaFilter(getFilter({ freeFormWords: ['cpu', 'usage'] }));
 
-        // All these filters are handled by backend, so frontend should return true
-        expect(frontendFilter.ruleMatches(alertingRule)).toBe(true);
-        expect(frontendFilter.ruleMatches(recordingRule)).toBe(true);
+      expect(backendFilter.title).toBe('cpu usage');
+    });
+
+    it('should include title in backend filter when ruleName is provided', () => {
+      const { backendFilter } = getGrafanaFilter(getFilter({ ruleName: 'high cpu' }));
+
+      expect(backendFilter.title).toBe('high cpu');
+    });
+
+    it('should combine ruleName and freeFormWords in title', () => {
+      const { backendFilter } = getGrafanaFilter(getFilter({ ruleName: 'alert', freeFormWords: ['cpu'] }));
+
+      expect(backendFilter.title).toBe('alert cpu');
+    });
+
+    it('should not include title when no title filters are provided', () => {
+      const { backendFilter } = getGrafanaFilter(getFilter({ ruleState: PromAlertingRuleState.Firing }));
+
+      expect(backendFilter.title).toBeUndefined();
+    });
+
+    it('should skip freeFormWords filtering on frontend when backend filtering is enabled', () => {
+      const rule = mockGrafanaPromAlertingRule({ name: 'High CPU Usage' });
+
+      const { frontendFilter } = getGrafanaFilter(getFilter({ freeFormWords: ['memory'] }));
+      // Should return true because freeFormWords filter is null (handled by backend)
+      expect(frontendFilter.ruleMatches(rule)).toBe(true);
+    });
+
+    it('should skip ruleName filtering on frontend when backend filtering is enabled', () => {
+      const rule = mockGrafanaPromAlertingRule({ name: 'High CPU Usage' });
+
+      const { frontendFilter } = getGrafanaFilter(getFilter({ ruleName: 'memory' }));
+      // Should return true because ruleName filter is null (handled by backend)
+      expect(frontendFilter.ruleMatches(rule)).toBe(true);
+    });
+
+    it('should include ruleType in backend filter when provided', () => {
+      const { backendFilter } = getGrafanaFilter(getFilter({ ruleType: PromRuleType.Alerting }));
+
+      expect(backendFilter.type).toBe(PromRuleType.Alerting);
+    });
+
+    it('should not include ruleType in backend filter when not provided', () => {
+      const { backendFilter } = getGrafanaFilter(getFilter({}));
+
+      expect(backendFilter.type).toBeUndefined();
+    });
+
+    it('should skip ruleType filtering on frontend when backend filtering is enabled', () => {
+      const alertingRule = mockGrafanaPromAlertingRule({ name: 'Test Alert' });
+      const recordingRule = mockPromRecordingRule({ name: 'Test Recording' });
+
+      const { frontendFilter } = getGrafanaFilter(getFilter({ ruleType: PromRuleType.Alerting }));
+      // Should return true for both because ruleType filter is null (handled by backend)
+      expect(frontendFilter.ruleMatches(alertingRule)).toBe(true);
+      expect(frontendFilter.ruleMatches(recordingRule)).toBe(true);
+    });
+
+    it('should include dashboardUid in backend filter when provided', () => {
+      const { backendFilter } = getGrafanaFilter(getFilter({ dashboardUid: 'dashboard-123' }));
+
+      expect(backendFilter.dashboardUid).toBe('dashboard-123');
+    });
+
+    it('should not include dashboardUid in backend filter when not provided', () => {
+      const { backendFilter } = getGrafanaFilter(getFilter({}));
+
+      expect(backendFilter.dashboardUid).toBeUndefined();
+    });
+
+    it('should skip dashboardUid filtering on frontend when backend filtering is enabled', () => {
+      const ruleWithDashboard = mockGrafanaPromAlertingRule({
+        name: 'Dashboard Rule',
+        annotations: { [Annotation.dashboardUID]: 'dashboard-a' },
       });
 
-      it('should skip groupName filtering on frontend', () => {
-        const group: PromRuleGroupDTO = {
-          name: 'CPU Usage Alerts',
-          file: 'production/alerts',
-          rules: [],
-          interval: 60,
-        };
+      const { frontendFilter } = getGrafanaFilter(getFilter({ dashboardUid: 'dashboard-b' }));
+      // Should return true because dashboardUid filter is null (handled by backend)
+      expect(frontendFilter.ruleMatches(ruleWithDashboard)).toBe(true);
+    });
 
-        const { frontendFilter } = getGrafanaFilter(getFilter({ groupName: 'memory' }));
-        // Should return true because groupName filter is null (handled by backend)
-        expect(frontendFilter.groupMatches(group)).toBe(true);
+    it('should include searchGroupName in backend filter when provided', () => {
+      const { backendFilter } = getGrafanaFilter(getFilter({ groupName: 'my-group' }));
+
+      expect(backendFilter.searchGroupName).toBe('my-group');
+    });
+
+    it('should not include searchGroupName in backend filter when not provided', () => {
+      const { backendFilter } = getGrafanaFilter(getFilter({}));
+
+      expect(backendFilter.searchGroupName).toBeUndefined();
+    });
+
+    it('should skip groupName filtering on frontend when backend filtering is enabled', () => {
+      const group: PromRuleGroupDTO = {
+        name: 'CPU Usage Alerts',
+        file: 'production/alerts',
+        rules: [],
+        interval: 60,
+      };
+
+      const { frontendFilter } = getGrafanaFilter(getFilter({ groupName: 'memory' }));
+      // Should return true because groupName filter is null (handled by backend)
+      expect(frontendFilter.groupMatches(group)).toBe(true);
+    });
+
+    it('should include ruleMatchers in backend filter when labels are provided', () => {
+      const { backendFilter } = getGrafanaFilter(getFilter({ labels: ['severity=critical'] }));
+
+      expect(backendFilter.ruleMatchers).toBeDefined();
+      expect(backendFilter.ruleMatchers).toHaveLength(1);
+      expect(backendFilter.ruleMatchers).toEqual([
+        '{"name":"severity","value":"critical","isRegex":false,"isEqual":true}',
+      ]);
+    });
+
+    it('should include plugins in backend filter and skip frontend filtering', () => {
+      // Set up test plugin as installed
+      setAppPluginMetas({ [SupportedPlugin.Slo]: pluginMetaToPluginConfig(pluginMeta[SupportedPlugin.Slo]) });
+
+      const regularRule = mockGrafanaPromAlertingRule({
+        name: 'High CPU Usage',
+        labels: { severity: 'critical', team: 'ops' },
+        alerts: [],
       });
 
-      it('should skip namespace filtering on frontend', () => {
-        // Namespace filter should be handled by backend
-        const group: PromRuleGroupDTO = {
-          name: 'Test Group',
-          file: 'production/alerts',
-          rules: [],
-          interval: 60,
-        };
-
-        const { frontendFilter: nsFilter } = getGrafanaFilter(getFilter({ namespace: 'production' }));
-        expect(nsFilter.groupMatches(group)).toBe(true);
-
-        const { frontendFilter: nsFilter2 } = getGrafanaFilter(getFilter({ namespace: 'staging' }));
-        expect(nsFilter2.groupMatches(group)).toBe(true);
+      const pluginRule = mockGrafanaPromAlertingRule({
+        name: 'Plugin Rule',
+        labels: { __grafana_origin: `plugin/${SupportedPlugin.Slo}` },
+        alerts: [],
       });
 
-      it('should skip dataSourceNames filtering on frontend (handled by backend)', () => {
-        const rule = mockGrafanaPromAlertingRule({
-          queriedDatasourceUIDs: ['datasource-uid-1'],
-        });
+      // Plugins filter should be handled by backend
+      const { backendFilter, frontendFilter } = getGrafanaFilter(getFilter({ plugins: 'hide' }));
 
-        // DataSourceNames is backend-filtered when both feature toggles are enabled.
-        const { frontendFilter: dsFilter } = getGrafanaFilter(getFilter({ dataSourceNames: ['prometheus'] }));
-        expect(dsFilter.ruleMatches(rule)).toBe(true);
+      // Backend filter should include plugins parameter
+      expect(backendFilter.plugins).toBe('hide');
 
-        const { frontendFilter: dsFilter2 } = getGrafanaFilter(getFilter({ dataSourceNames: ['loki'] }));
-        expect(dsFilter2.ruleMatches(rule)).toBe(true);
-      });
+      // Frontend filter should pass through all rules (no filtering)
+      expect(frontendFilter.ruleMatches(regularRule)).toBe(true);
+      expect(frontendFilter.ruleMatches(pluginRule)).toBe(true);
+    });
+
+    it('should include searchFolder in backend filter when namespace is provided', () => {
+      const { backendFilter } = getGrafanaFilter(getFilter({ namespace: 'my-folder' }));
+
+      expect(backendFilter.searchFolder).toBe('my-folder');
+    });
+
+    it('should skip namespace filtering on frontend when backend filtering is enabled', () => {
+      const group: PromRuleGroupDTO = {
+        name: 'Test Group',
+        file: 'production/alerts',
+        rules: [],
+        interval: 60,
+      };
+
+      const { frontendFilter } = getGrafanaFilter(getFilter({ namespace: 'staging' }));
+      // Should return true because namespace filter is null (handled by backend)
+      expect(frontendFilter.groupMatches(group)).toBe(true);
     });
   });
 
   describe('hasGrafanaClientSideFilters', () => {
-    describe('when alertingUIUseBackendFilters is disabled', () => {
-      testWithFeatureToggles({ disable: ['alertingUIUseBackendFilters'] });
-
-      it('should return false when no filters are applied', () => {
-        expect(hasGrafanaClientSideFilters(getFilter({}))).toBe(false);
-      });
-
-      it('should return true for title-related filters (freeFormWords, ruleName)', () => {
-        expect(hasGrafanaClientSideFilters(getFilter({ freeFormWords: ['cpu'] }))).toBe(true);
-        expect(hasGrafanaClientSideFilters(getFilter({ ruleName: 'alert' }))).toBe(true);
-      });
-
-      it('should return true for ruleType filter', () => {
-        expect(hasGrafanaClientSideFilters(getFilter({ ruleType: PromRuleType.Alerting }))).toBe(true);
-      });
-
-      it('should return true for dashboardUid filter', () => {
-        expect(hasGrafanaClientSideFilters(getFilter({ dashboardUid: 'test-dashboard' }))).toBe(true);
-      });
-
-      it('should return true for groupName filter', () => {
-        expect(hasGrafanaClientSideFilters(getFilter({ groupName: 'test-group' }))).toBe(true);
-      });
-
-      it('should return true for client-side only filters', () => {
-        expect(hasGrafanaClientSideFilters(getFilter({ namespace: 'production' }))).toBe(true);
-        expect(hasGrafanaClientSideFilters(getFilter({ dataSourceNames: ['prometheus'] }))).toBe(true);
-        expect(hasGrafanaClientSideFilters(getFilter({ labels: ['severity=critical'] }))).toBe(true);
-      });
-
-      it('should return false for backend-only filters (state, health, contactPoint)', () => {
-        expect(hasGrafanaClientSideFilters(getFilter({ ruleState: PromAlertingRuleState.Firing }))).toBe(false);
-        expect(hasGrafanaClientSideFilters(getFilter({ ruleHealth: RuleHealth.Ok }))).toBe(false);
-        expect(hasGrafanaClientSideFilters(getFilter({ contactPoint: 'my-contact-point' }))).toBe(false);
-      });
-
-      it('should return true for policy filter (always client-side)', () => {
-        expect(hasGrafanaClientSideFilters(getFilter({ policy: 'my-policy' }))).toBe(true);
-      });
+    it('returns false when no policy filter is set', () => {
+      expect(hasGrafanaClientSideFilters(getFilter({}))).toBe(false);
+      expect(hasGrafanaClientSideFilters(getFilter({ ruleName: 'foo' }))).toBe(false);
+      expect(hasGrafanaClientSideFilters(getFilter({ ruleType: PromRuleType.Alerting }))).toBe(false);
+      expect(hasGrafanaClientSideFilters(getFilter({ freeFormWords: ['cpu'] }))).toBe(false);
+      expect(hasGrafanaClientSideFilters(getFilter({ ruleState: PromAlertingRuleState.Firing }))).toBe(false);
+      expect(hasGrafanaClientSideFilters(getFilter({ ruleHealth: RuleHealth.Ok }))).toBe(false);
+      expect(hasGrafanaClientSideFilters(getFilter({ contactPoint: 'my-contact-point' }))).toBe(false);
     });
 
-    describe('when alertingUIUseBackendFilters is enabled', () => {
-      testWithFeatureToggles({ enable: ['alertingUIUseBackendFilters'] });
-
-      it('should return false when no filters are applied', () => {
-        expect(hasGrafanaClientSideFilters(getFilter({}))).toBe(false);
-      });
-
-      it('should return false for title-related filters (handled by backend)', () => {
-        expect(hasGrafanaClientSideFilters(getFilter({ freeFormWords: ['cpu'] }))).toBe(false);
-        expect(hasGrafanaClientSideFilters(getFilter({ ruleName: 'alert' }))).toBe(false);
-      });
-
-      it('should return false for ruleType filter (handled by backend)', () => {
-        expect(hasGrafanaClientSideFilters(getFilter({ ruleType: PromRuleType.Alerting }))).toBe(false);
-      });
-
-      it('should return false for dashboardUid filter (handled by backend)', () => {
-        expect(hasGrafanaClientSideFilters(getFilter({ dashboardUid: 'test-dashboard' }))).toBe(false);
-      });
-
-      it('should return false for groupName filter (handled by backend)', () => {
-        expect(hasGrafanaClientSideFilters(getFilter({ groupName: 'test-group' }))).toBe(false);
-      });
-
-      it('should return false for dataSourceNames (handled by backend when feature toggle is enabled)', () => {
-        expect(hasGrafanaClientSideFilters(getFilter({ dataSourceNames: ['prometheus'] }))).toBe(false);
-      });
-
-      it('should return false for labels (handled by backend when feature toggle is enabled)', () => {
-        expect(hasGrafanaClientSideFilters(getFilter({ labels: ['severity=critical'] }))).toBe(false);
-      });
-
-      it('should return false for namespace filter (handled by backend)', () => {
-        expect(hasGrafanaClientSideFilters(getFilter({ namespace: 'production' }))).toBe(false);
-      });
-
-      it('should return false for plugins filter (handled by backend when feature toggle is enabled)', () => {
-        expect(hasGrafanaClientSideFilters(getFilter({ plugins: 'hide' }))).toBe(false);
-      });
-
-      it('should return false for backend-only filters (state, health, contactPoint)', () => {
-        expect(hasGrafanaClientSideFilters(getFilter({ ruleState: PromAlertingRuleState.Firing }))).toBe(false);
-        expect(hasGrafanaClientSideFilters(getFilter({ ruleHealth: RuleHealth.Ok }))).toBe(false);
-        expect(hasGrafanaClientSideFilters(getFilter({ contactPoint: 'my-contact-point' }))).toBe(false);
-      });
-
-      it('should return true for policy filter (always client-side, even when backend filters are on)', () => {
-        expect(hasGrafanaClientSideFilters(getFilter({ policy: 'my-policy' }))).toBe(true);
-      });
-    });
-
-    describe('when alertingUIUseFullyCompatBackendFilters is enabled', () => {
-      testWithFeatureToggles({ enable: ['alertingUIUseFullyCompatBackendFilters'] });
-
-      it('should return correct values for all filter types', () => {
-        // Should return false for: empty, backend-handled (ruleType, dashboardUid, dataSourceNames), and backend-only filters
-        expect(hasGrafanaClientSideFilters(getFilter({}))).toBe(false);
-        expect(hasGrafanaClientSideFilters(getFilter({ ruleType: PromRuleType.Alerting }))).toBe(false);
-        expect(hasGrafanaClientSideFilters(getFilter({ dashboardUid: 'test-dashboard' }))).toBe(false);
-        expect(hasGrafanaClientSideFilters(getFilter({ dataSourceNames: ['prometheus'] }))).toBe(false);
-        expect(hasGrafanaClientSideFilters(getFilter({ ruleState: PromAlertingRuleState.Firing }))).toBe(false);
-        expect(hasGrafanaClientSideFilters(getFilter({ ruleHealth: RuleHealth.Ok }))).toBe(false);
-        expect(hasGrafanaClientSideFilters(getFilter({ contactPoint: 'my-contact-point' }))).toBe(false);
-
-        // Should return true for: frontend-handled filters (labels, namespace)
-        expect(hasGrafanaClientSideFilters(getFilter({ freeFormWords: ['cpu'] }))).toBe(true);
-        expect(hasGrafanaClientSideFilters(getFilter({ ruleName: 'alert' }))).toBe(true);
-        expect(hasGrafanaClientSideFilters(getFilter({ groupName: 'test-group' }))).toBe(true);
-        expect(hasGrafanaClientSideFilters(getFilter({ namespace: 'production' }))).toBe(true);
-        expect(hasGrafanaClientSideFilters(getFilter({ labels: ['severity=critical'] }))).toBe(true);
-
-        // plugins is backend-handled when alertingUIUseFullyCompatBackendFilters is enabled
-        expect(hasGrafanaClientSideFilters(getFilter({ plugins: 'hide' }))).toBe(false);
-      });
-    });
-
-    describe('when both alertingUIUseBackendFilters and alertingUIUseFullyCompatBackendFilters are enabled', () => {
-      testWithFeatureToggles({ enable: ['alertingUIUseBackendFilters', 'alertingUIUseFullyCompatBackendFilters'] });
-
-      it('should return correct values for all filter types', () => {
-        // Should return false for: empty, all backend-handled filters, and backend-only filters
-        expect(hasGrafanaClientSideFilters(getFilter({}))).toBe(false);
-        expect(hasGrafanaClientSideFilters(getFilter({ freeFormWords: ['cpu'] }))).toBe(false);
-        expect(hasGrafanaClientSideFilters(getFilter({ ruleName: 'alert' }))).toBe(false);
-        expect(hasGrafanaClientSideFilters(getFilter({ ruleType: PromRuleType.Alerting }))).toBe(false);
-        expect(hasGrafanaClientSideFilters(getFilter({ dashboardUid: 'test-dashboard' }))).toBe(false);
-        expect(hasGrafanaClientSideFilters(getFilter({ groupName: 'test-group' }))).toBe(false);
-        expect(hasGrafanaClientSideFilters(getFilter({ ruleState: PromAlertingRuleState.Firing }))).toBe(false);
-        expect(hasGrafanaClientSideFilters(getFilter({ ruleHealth: RuleHealth.Ok }))).toBe(false);
-        expect(hasGrafanaClientSideFilters(getFilter({ contactPoint: 'my-contact-point' }))).toBe(false);
-
-        // Should return false for: namespace (handled by backend)
-        expect(hasGrafanaClientSideFilters(getFilter({ namespace: 'production' }))).toBe(false);
-
-        // plugins is backend-handled when both feature toggles are enabled
-        expect(hasGrafanaClientSideFilters(getFilter({ plugins: 'hide' }))).toBe(false);
-
-        // Should return false for: backend-handled filters when both feature toggles are enabled
-        expect(hasGrafanaClientSideFilters(getFilter({ dataSourceNames: ['prometheus'] }))).toBe(false);
-        expect(hasGrafanaClientSideFilters(getFilter({ labels: ['severity=critical'] }))).toBe(false);
-      });
+    it('returns true when a policy filter is set', () => {
+      expect(hasGrafanaClientSideFilters(getFilter({ policy: 'my-policy' }))).toBe(true);
     });
   });
 });

--- a/public/app/features/alerting/unified/rule-list/hooks/grafanaFilter.ts
+++ b/public/app/features/alerting/unified/rule-list/hooks/grafanaFilter.ts
@@ -3,146 +3,65 @@ import { attempt, isError } from 'lodash';
 import { type PromRuleDTO, type PromRuleGroupDTO } from 'app/types/unified-alerting-dto';
 
 import { type GrafanaPromRulesOptions } from '../../api/prometheusApi';
-import { shouldUseBackendFilters, shouldUseFullyCompatibleBackendFilters } from '../../featureToggles';
 import { type RulesFilter } from '../../search/rulesSearchParser';
 import { parseMatcher } from '../../utils/matchers';
 
 import { buildTitleSearch, normalizeFilterState } from './filterNormalization';
-import {
-  type GroupFilterConfig,
-  type RuleFilterConfig,
-  dashboardUidFilter,
-  dataSourceNamesFilter,
-  freeFormFilter,
-  groupMatches,
-  groupNameFilter,
-  labelsFilter,
-  mapDataSourceNamesToUids,
-  namespaceFilter,
-  pluginsFilter,
-  policyFilter,
-  ruleMatches,
-  ruleNameFilter,
-  ruleTypeFilter,
-} from './filterPredicates';
+import { mapDataSourceNamesToUids, policyFilter } from './filterPredicates';
 
 /**
  * Determines if client-side filtering is needed for Grafana-managed rules.
+ * All filters except `policy` are handled by the backend; policy filtering is always client-side
+ * as the backend API does not support it.
  */
 export function hasGrafanaClientSideFilters(filterState: Partial<RulesFilter>): boolean {
-  const { ruleFilterConfig, groupFilterConfig } = buildGrafanaFilterConfigs();
-
-  // Check each rule filter: if the config has a non-null handler AND the filter state has a value, we need client-side filtering
-  const hasActiveRuleFilters =
-    (ruleFilterConfig.freeFormWords !== null && Boolean(filterState?.freeFormWords?.length)) ||
-    (ruleFilterConfig.ruleName !== null && Boolean(filterState?.ruleName)) ||
-    (ruleFilterConfig.ruleState !== null && Boolean(filterState?.ruleState)) ||
-    (ruleFilterConfig.ruleType !== null && Boolean(filterState?.ruleType)) ||
-    (ruleFilterConfig.dataSourceNames !== null && Boolean(filterState?.dataSourceNames?.length)) ||
-    (ruleFilterConfig.labels !== null && Boolean(filterState?.labels?.length)) ||
-    (ruleFilterConfig.ruleHealth !== null && Boolean(filterState?.ruleHealth)) ||
-    (ruleFilterConfig.dashboardUid !== null && Boolean(filterState?.dashboardUid)) ||
-    (ruleFilterConfig.plugins !== null && Boolean(filterState?.plugins)) ||
-    (ruleFilterConfig.contactPoint !== null && Boolean(filterState?.contactPoint)) ||
-    (ruleFilterConfig.policy !== null && Boolean(filterState?.policy));
-
-  // Check each group filter: if the config has a non-null handler AND the filter state has a value, we need client-side filtering
-  const hasActiveGroupFilters =
-    (groupFilterConfig.namespace !== null && Boolean(filterState?.namespace)) ||
-    (groupFilterConfig.groupName !== null && Boolean(filterState?.groupName));
-
-  return hasActiveRuleFilters || hasActiveGroupFilters;
+  return Boolean(filterState.policy);
 }
 
 /**
- * Builds a combined filter configuration for Grafana-managed alert rules.
+ * Builds a combined filter for Grafana-managed alert rules.
  *
- * Constructs both backend and frontend filter objects based on the provided filter state.
- * The backend filter is used for server-side filtering when `shouldUseBackendFilters()` is enabled,
- * while the frontend filter provides client-side matching functions for rules and groups.
+ * All filters are passed to the backend except `policy`, which the backend API does not support
+ * and is applied client-side.
  */
 export function getGrafanaFilter(filterState: Partial<RulesFilter>) {
   const normalizedFilterState = normalizeFilterState(filterState);
 
-  const { ruleFilterConfig, groupFilterConfig } = buildGrafanaFilterConfigs();
-
-  // Build title search for backend filtering
   const titleSearch = buildTitleSearch(normalizedFilterState);
 
-  // Check if data source names were provided but none are valid.
   let hasInvalidDataSourceNames = false;
   let datasourceUids: string[] | undefined = undefined;
 
-  // Only map datasources if data source filter should be applied on backend (when ruleFilterConfig.dataSourceNames is null).
-  if (ruleFilterConfig.dataSourceNames === null && normalizedFilterState.dataSourceNames.length > 0) {
+  if (normalizedFilterState.dataSourceNames.length > 0) {
     datasourceUids = mapDataSourceNamesToUids(normalizedFilterState.dataSourceNames);
-    // If names were provided but no valid UIDs were found, all names are invalid.
     hasInvalidDataSourceNames = datasourceUids.length === 0;
   }
 
-  // Convert labels to JSON-encoded matchers for backend filtering
   const ruleMatchersBackendFilter: string[] | undefined =
-    ruleFilterConfig.labels || normalizedFilterState.labels.length === 0
-      ? undefined
-      : labelMatchersToBackendFormat(normalizedFilterState.labels);
+    normalizedFilterState.labels.length === 0 ? undefined : labelMatchersToBackendFormat(normalizedFilterState.labels);
 
   const backendFilter: GrafanaPromRulesOptions = {
     state: normalizedFilterState.ruleState ? [normalizedFilterState.ruleState] : [],
     health: normalizedFilterState.ruleHealth ? [normalizedFilterState.ruleHealth] : [],
     contactPoint: normalizedFilterState.contactPoint ?? undefined,
-    // If FE filter is defined, don't include the backend filter
-    title: ruleFilterConfig.ruleName ? undefined : titleSearch,
-    type: ruleFilterConfig.ruleType ? undefined : normalizedFilterState.ruleType,
-    dashboardUid: ruleFilterConfig.dashboardUid ? undefined : normalizedFilterState.dashboardUid,
-    searchGroupName: groupFilterConfig.groupName ? undefined : normalizedFilterState.groupName,
-    datasources: ruleFilterConfig.dataSourceNames ? undefined : datasourceUids,
+    title: titleSearch,
+    type: normalizedFilterState.ruleType,
+    dashboardUid: normalizedFilterState.dashboardUid,
+    searchGroupName: normalizedFilterState.groupName,
+    datasources: datasourceUids,
     ruleMatchers: ruleMatchersBackendFilter,
-    plugins: ruleFilterConfig.plugins ? undefined : normalizedFilterState.plugins,
-    searchFolder: groupFilterConfig.namespace ? undefined : normalizedFilterState.namespace,
+    plugins: normalizedFilterState.plugins,
+    searchFolder: normalizedFilterState.namespace,
   };
 
   return {
     backendFilter,
     frontendFilter: {
-      groupMatches: (group: PromRuleGroupDTO) => groupMatches(group, normalizedFilterState, groupFilterConfig),
-      ruleMatches: (rule: PromRuleDTO) => ruleMatches(rule, normalizedFilterState, ruleFilterConfig),
+      groupMatches: (_group: PromRuleGroupDTO) => true,
+      ruleMatches: (rule: PromRuleDTO) => policyFilter(rule, normalizedFilterState),
     },
     hasInvalidDataSourceNames,
   };
-}
-
-/**
- * Builds filter configurations for Grafana rules and groups.
- *
- * Determines which filters are applied on the backend vs. client-side based on
- * the `shouldUseBackendFilters()` flag. When backend filtering is enabled, certain
- * filters are set to null to prevent duplicate filtering.
- */
-function buildGrafanaFilterConfigs() {
-  const useBackendFilters = shouldUseBackendFilters();
-  const useFullyCompatibleBackendFilters = shouldUseFullyCompatibleBackendFilters();
-
-  const ruleFilterConfig: RuleFilterConfig = {
-    // When backend filtering is enabled, these filters are handled by the backend
-    freeFormWords: useBackendFilters ? null : freeFormFilter,
-    ruleName: useBackendFilters ? null : ruleNameFilter,
-    ruleState: null,
-    ruleType: useBackendFilters || useFullyCompatibleBackendFilters ? null : ruleTypeFilter,
-    dataSourceNames: useBackendFilters || useFullyCompatibleBackendFilters ? null : dataSourceNamesFilter,
-    labels: useBackendFilters ? null : labelsFilter,
-    ruleHealth: null,
-    dashboardUid: useBackendFilters || useFullyCompatibleBackendFilters ? null : dashboardUidFilter,
-    plugins: useBackendFilters || useFullyCompatibleBackendFilters ? null : pluginsFilter,
-    contactPoint: null,
-    policy: policyFilter,
-  };
-
-  const groupFilterConfig: GroupFilterConfig = {
-    namespace: useBackendFilters ? null : namespaceFilter,
-    groupName: useBackendFilters ? null : groupNameFilter,
-  };
-
-  return { ruleFilterConfig, groupFilterConfig };
 }
 
 /**

--- a/public/app/features/alerting/unified/rule-list/paginationLimits.test.ts
+++ b/public/app/features/alerting/unified/rule-list/paginationLimits.test.ts
@@ -1,5 +1,3 @@
-import { testWithFeatureToggles } from 'test/test-utils';
-
 import { PromAlertingRuleState, PromRuleType } from 'app/types/unified-alerting-dto';
 
 import { RuleHealth, type RulesFilter } from '../search/rulesSearchParser';
@@ -14,151 +12,42 @@ import {
 
 describe('paginationLimits', () => {
   describe('getFilteredRulesLimits', () => {
-    describe('when backend filters are disabled', () => {
-      testWithFeatureToggles({ disable: ['alertingUIUseBackendFilters', 'alertingUIUseFullyCompatBackendFilters'] });
+    it('should return rule limit for grafana + default limit for datasource when no filters are applied', () => {
+      const { grafanaManagedLimit, datasourceManagedLimit } = getFilteredRulesLimits(getFilter({}));
 
-      it('should return small limits when no filters are applied', () => {
-        const { grafanaManagedLimit, datasourceManagedLimit } = getFilteredRulesLimits(getFilter({}));
-
-        expect(grafanaManagedLimit).toEqual({ groupLimit: FILTERED_GROUPS_SMALL_API_PAGE_SIZE });
-        expect(datasourceManagedLimit).toEqual({ groupLimit: FILTERED_GROUPS_SMALL_API_PAGE_SIZE });
-      });
-
-      it.each<Partial<RulesFilter>>([
-        { ruleState: PromAlertingRuleState.Firing },
-        { ruleHealth: RuleHealth.Ok },
-        { contactPoint: 'slack' },
-      ])('should return small grafana limit + large datasource limit for backend-only filter: %p', (filterState) => {
-        const { grafanaManagedLimit, datasourceManagedLimit } = getFilteredRulesLimits(getFilter(filterState));
-
-        expect(grafanaManagedLimit).toEqual({ groupLimit: FILTERED_GROUPS_SMALL_API_PAGE_SIZE });
-        expect(datasourceManagedLimit).toEqual({ groupLimit: FILTERED_GROUPS_LARGE_API_PAGE_SIZE });
-      });
-
-      it.each<Partial<RulesFilter>>([
-        { freeFormWords: ['cpu'] },
-        { ruleName: 'alert' },
-        { ruleType: PromRuleType.Alerting },
-        { dataSourceNames: ['prometheus'] },
-        { labels: ['severity=critical'] },
-        { dashboardUid: 'test-dashboard' },
-        { plugins: 'hide' as const },
-        { namespace: 'production' },
-        { groupName: 'test-group' },
-        { namespace: 'production', freeFormWords: ['cpu'] },
-      ])('should return large limits for both when frontend filters are used: %p', (filterState) => {
-        const { grafanaManagedLimit, datasourceManagedLimit } = getFilteredRulesLimits(getFilter(filterState));
-
-        expect(grafanaManagedLimit).toEqual({ groupLimit: FILTERED_GROUPS_LARGE_API_PAGE_SIZE });
-        expect(datasourceManagedLimit).toEqual({ groupLimit: FILTERED_GROUPS_LARGE_API_PAGE_SIZE });
-      });
+      expect(grafanaManagedLimit).toEqual({ ruleLimit: RULE_LIMIT_WITH_BACKEND_FILTERS });
+      expect(datasourceManagedLimit).toEqual({ groupLimit: FILTERED_GROUPS_SMALL_API_PAGE_SIZE });
     });
 
-    describe('when alertingUIUseBackendFilters is enabled', () => {
-      testWithFeatureToggles({ enable: ['alertingUIUseBackendFilters'] });
-
-      it('should return rule limit for grafana + default limit for datasource when no filters are applied', () => {
-        const { grafanaManagedLimit, datasourceManagedLimit } = getFilteredRulesLimits(getFilter({}));
-
-        expect(grafanaManagedLimit).toEqual({ ruleLimit: RULE_LIMIT_WITH_BACKEND_FILTERS });
-        expect(datasourceManagedLimit).toEqual({ groupLimit: FILTERED_GROUPS_SMALL_API_PAGE_SIZE });
-      });
-
-      it.each<Partial<RulesFilter>>([
-        { freeFormWords: ['cpu'] },
-        { ruleName: 'alert' },
-        { ruleType: PromRuleType.Alerting },
-        { dashboardUid: 'test-dashboard' },
-        { groupName: 'test-group' },
-        { ruleState: PromAlertingRuleState.Firing },
-        { ruleHealth: RuleHealth.Ok },
-        { contactPoint: 'slack' },
-        { dataSourceNames: ['prometheus'] },
-        { labels: ['severity=critical'] },
-        { namespace: 'production' },
-      ])(
-        'should return rule limit for grafana + large limit for datasource when only backend filters are used: %p',
-        (filterState) => {
-          const { grafanaManagedLimit, datasourceManagedLimit } = getFilteredRulesLimits(getFilter(filterState));
-
-          expect(grafanaManagedLimit).toEqual({ ruleLimit: RULE_LIMIT_WITH_BACKEND_FILTERS });
-          expect(datasourceManagedLimit).toEqual({ groupLimit: FILTERED_GROUPS_LARGE_API_PAGE_SIZE });
-        }
-      );
-    });
-
-    describe('when alertingUIUseFullyCompatBackendFilters is enabled', () => {
-      testWithFeatureToggles({ enable: ['alertingUIUseFullyCompatBackendFilters'] });
-
-      it('should return rule limit for grafana + default limit for datasource when no filters are applied', () => {
-        const { grafanaManagedLimit, datasourceManagedLimit } = getFilteredRulesLimits(getFilter({}));
-
-        expect(grafanaManagedLimit).toEqual({ ruleLimit: RULE_LIMIT_WITH_BACKEND_FILTERS });
-        expect(datasourceManagedLimit).toEqual({ groupLimit: FILTERED_GROUPS_SMALL_API_PAGE_SIZE });
-      });
-
-      it.each<Partial<RulesFilter>>([
-        { ruleType: PromRuleType.Alerting },
-        { dashboardUid: 'test-dashboard' },
-        { ruleState: PromAlertingRuleState.Firing },
-        { ruleHealth: RuleHealth.Ok },
-        { contactPoint: 'slack' },
-        { dataSourceNames: ['prometheus'] },
-      ])(
-        'should return rule limit for grafana + large limit for datasource when only backend filters are used: %p',
-        (filterState) => {
-          const { grafanaManagedLimit, datasourceManagedLimit } = getFilteredRulesLimits(getFilter(filterState));
-
-          expect(grafanaManagedLimit).toEqual({ ruleLimit: RULE_LIMIT_WITH_BACKEND_FILTERS });
-          expect(datasourceManagedLimit).toEqual({ groupLimit: FILTERED_GROUPS_LARGE_API_PAGE_SIZE });
-        }
-      );
-
-      it.each<Partial<RulesFilter>>([
-        { freeFormWords: ['cpu'] },
-        { ruleName: 'alert' },
-        { groupName: 'test-group' },
-        { namespace: 'production' },
-        { labels: ['severity=critical'] },
-      ])('should return large limits for both when frontend filters are used: %p', (filterState) => {
+    it.each<Partial<RulesFilter>>([
+      { freeFormWords: ['cpu'] },
+      { ruleName: 'alert' },
+      { ruleType: PromRuleType.Alerting },
+      { dashboardUid: 'test-dashboard' },
+      { groupName: 'test-group' },
+      { ruleState: PromAlertingRuleState.Firing },
+      { ruleHealth: RuleHealth.Ok },
+      { contactPoint: 'slack' },
+      { dataSourceNames: ['prometheus'] },
+      { labels: ['severity=critical'] },
+      { namespace: 'production' },
+    ])(
+      'should return rule limit for grafana + large limit for datasource when only backend filters are used: %p',
+      (filterState) => {
         const { grafanaManagedLimit, datasourceManagedLimit } = getFilteredRulesLimits(getFilter(filterState));
 
-        expect(grafanaManagedLimit).toEqual({ groupLimit: FILTERED_GROUPS_LARGE_API_PAGE_SIZE });
-        expect(datasourceManagedLimit).toEqual({ groupLimit: FILTERED_GROUPS_LARGE_API_PAGE_SIZE });
-      });
-    });
-
-    describe('when both backend filter toggles are enabled', () => {
-      testWithFeatureToggles({ enable: ['alertingUIUseBackendFilters', 'alertingUIUseFullyCompatBackendFilters'] });
-
-      it('should return rule limit for grafana + default limit for datasource when no filters are applied', () => {
-        const { grafanaManagedLimit, datasourceManagedLimit } = getFilteredRulesLimits(getFilter({}));
-
         expect(grafanaManagedLimit).toEqual({ ruleLimit: RULE_LIMIT_WITH_BACKEND_FILTERS });
-        expect(datasourceManagedLimit).toEqual({ groupLimit: FILTERED_GROUPS_SMALL_API_PAGE_SIZE });
-      });
+        expect(datasourceManagedLimit).toEqual({ groupLimit: FILTERED_GROUPS_LARGE_API_PAGE_SIZE });
+      }
+    );
 
-      it.each<Partial<RulesFilter>>([
-        { freeFormWords: ['cpu'] },
-        { ruleName: 'alert' },
-        { ruleType: PromRuleType.Alerting },
-        { dashboardUid: 'test-dashboard' },
-        { groupName: 'test-group' },
-        { ruleState: PromAlertingRuleState.Firing },
-        { ruleHealth: RuleHealth.Ok },
-        { contactPoint: 'slack' },
-        { dataSourceNames: ['prometheus'] },
-        { labels: ['severity=critical'] },
-        { namespace: 'production' },
-      ])(
-        'should return rule limit for grafana + large limit for datasource when only backend filters are used: %p',
-        (filterState) => {
-          const { grafanaManagedLimit, datasourceManagedLimit } = getFilteredRulesLimits(getFilter(filterState));
-
-          expect(grafanaManagedLimit).toEqual({ ruleLimit: RULE_LIMIT_WITH_BACKEND_FILTERS });
-          expect(datasourceManagedLimit).toEqual({ groupLimit: FILTERED_GROUPS_LARGE_API_PAGE_SIZE });
-        }
+    it('should return large grafana group limit when policy filter (frontend-only) is used', () => {
+      const { grafanaManagedLimit, datasourceManagedLimit } = getFilteredRulesLimits(
+        getFilter({ policy: 'my-policy' })
       );
+
+      expect(grafanaManagedLimit).toEqual({ groupLimit: FILTERED_GROUPS_LARGE_API_PAGE_SIZE });
+      expect(datasourceManagedLimit).toEqual({ groupLimit: FILTERED_GROUPS_SMALL_API_PAGE_SIZE });
     });
   });
 });

--- a/public/app/features/alerting/unified/rule-list/paginationLimits.ts
+++ b/public/app/features/alerting/unified/rule-list/paginationLimits.ts
@@ -1,4 +1,3 @@
-import { shouldUseBackendFilters, shouldUseFullyCompatibleBackendFilters } from '../featureToggles';
 import { type RulesFilter } from '../search/rulesSearchParser';
 
 import { hasDatasourceClientSideFilters } from './hooks/datasourceFilter';
@@ -35,14 +34,9 @@ export function getFilteredRulesLimits(filterState: RulesFilter): FetchGroupsLim
 }
 
 function getGrafanaFilterLimits(filterState: RulesFilter) {
-  const backendFiltersEnabled = shouldUseFullyCompatibleBackendFilters() || shouldUseBackendFilters();
-
-  const frontendFiltersInUse = hasGrafanaClientSideFilters(filterState);
-  const onlyBackendFiltersInUse = frontendFiltersInUse === false;
-
-  if (backendFiltersEnabled && onlyBackendFiltersInUse) {
+  if (!hasGrafanaClientSideFilters(filterState)) {
     return { ruleLimit: RULE_LIMIT_WITH_BACKEND_FILTERS };
   }
 
-  return { groupLimit: getSearchApiGroupPageSize(frontendFiltersInUse) };
+  return { groupLimit: getSearchApiGroupPageSize(true) };
 }


### PR DESCRIPTION
## What

Removes two frontend feature toggle helper functions and all associated conditional logic in the Grafana-managed alert rule filter layer:

- `alertingUIUseBackendFilters` — removed from `featureToggles.ts` and all call sites
- `alertingUIUseFullyCompatBackendFilters` — removed from `featureToggles.ts` and all call sites

## Why

- `alertingUIUseBackendFilters` was deployed to all 4 waves at 100% rollout — it was always `true`. All filters already went to the backend unconditionally.
- `alertingUIUseFullyCompatBackendFilters` was never deployed anywhere — it was always `false`.

Both toggle helper functions were dead code. Removing them eliminates significant conditional branching that had no effect in production.

## What changed

- `featureToggles.ts` — removed 2 toggle helper functions
- `grafanaFilter.ts` — removed `buildGrafanaFilterConfigs` entirely, simplified `getGrafanaFilter` and `hasGrafanaClientSideFilters` (no more toggle-based branching)
- `paginationLimits.ts` — simplified `getGrafanaFilterLimits` (no more toggle-based branching)
- `grafanaFilter.test.ts` — removed ~757 lines of toggle-variant test permutations
- `paginationLimits.test.ts` — removed toggle-variant test permutations

Net result: ~757 lines of test code and significant production branching logic removed.

## Notes

The `policy` filter remains client-side for now — the backend API does not support it yet. This is tracked as a follow-up task.