### PR TITLE
Folders: align Folder Server API force delete with legacy forceDeleteRules flag via gracePeriodSeconds=0

### DIFF
--- a/pkg/registry/apis/folders/cascade_delete.go
+++ b/pkg/registry/apis/folders/cascade_delete.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
+	"github.com/open-feature/go-sdk/openfeature"
 )
 
 // kubernetesFolderCascadeDeleteEnabled is the master switch for folder.grafana.app cascade
@@ -13,9 +14,11 @@ import (
 // Until that reconciliation exists, allowing non-empty delete only skips admission validation;
 // the folder CR is removed and dashboards, nested folders, library elements, and alert rules
 // in the tree remain as orphan resources.
-func kubernetesFolderCascadeDeleteEnabled(ctx context.Context, features featuremgmt.FeatureToggles) bool {
-	if features == nil {
-		return false
-	}
-	return features.IsEnabled(ctx, featuremgmt.FlagKubernetesFolderCascadeDelete)
+func kubernetesFolderCascadeDeleteEnabled(ctx context.Context) bool {
+	return openfeature.NewDefaultClient().Boolean(
+		ctx,
+		featuremgmt.FlagKubernetesFolderCascadeDelete,
+		false,
+		openfeature.TransactionContext(ctx),
+	)
 }

--- a/pkg/registry/apis/folders/cascade_delete.go
+++ b/pkg/registry/apis/folders/cascade_delete.go
@@ -11,6 +11,10 @@ import (
 // kubernetesFolderCascadeDeleteEnabled is the master switch for folder.grafana.app cascade
 // deletion: opt-in non-empty delete via DeleteOptions.gracePeriodSeconds=0, and (when
 // implemented) finalizer-backed cleanup of child folders and contained resources.
+//
+// Until that reconciliation exists, allowing non-empty delete only skips admission validation;
+// the folder CR is removed and dashboards, nested folders, library elements, and alert rules
+// in the tree remain as orphan resources.
 func kubernetesFolderCascadeDeleteEnabled(ctx context.Context, features featuremgmt.FeatureToggles) bool {
 	if features == nil {
 		return false
@@ -18,8 +22,9 @@ func kubernetesFolderCascadeDeleteEnabled(ctx context.Context, features featurem
 	return features.IsEnabled(ctx, featuremgmt.FlagKubernetesFolderCascadeDelete)
 }
 
-// clientRequestedCascadeDelete reports whether the delete request opts into cascade deletion
-// of a non-empty folder (gracePeriodSeconds=0). Requires kubernetesFolderCascadeDelete.
+// clientRequestedCascadeDelete reports whether the delete request opts into deleting a
+// non-empty folder (gracePeriodSeconds=0). Requires kubernetesFolderCascadeDelete. Child
+// resources are not deleted automatically until cascade reconciliation is implemented.
 func clientRequestedCascadeDelete(options *metav1.DeleteOptions) bool {
 	return forceDeleteFromDeleteOptions(options)
 }

--- a/pkg/registry/apis/folders/cascade_delete.go
+++ b/pkg/registry/apis/folders/cascade_delete.go
@@ -1,0 +1,25 @@
+package folders
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+)
+
+// kubernetesFolderCascadeDeleteEnabled is the master switch for folder.grafana.app cascade
+// deletion: opt-in non-empty delete via DeleteOptions.gracePeriodSeconds=0, and (when
+// implemented) finalizer-backed cleanup of child folders and contained resources.
+func kubernetesFolderCascadeDeleteEnabled(ctx context.Context, features featuremgmt.FeatureToggles) bool {
+	if features == nil {
+		return false
+	}
+	return features.IsEnabled(ctx, featuremgmt.FlagKubernetesFolderCascadeDelete)
+}
+
+// clientRequestedCascadeDelete reports whether the delete request opts into cascade deletion
+// of a non-empty folder (gracePeriodSeconds=0). Requires kubernetesFolderCascadeDelete.
+func clientRequestedCascadeDelete(options *metav1.DeleteOptions) bool {
+	return forceDeleteFromDeleteOptions(options)
+}

--- a/pkg/registry/apis/folders/cascade_delete.go
+++ b/pkg/registry/apis/folders/cascade_delete.go
@@ -3,8 +3,6 @@ package folders
 import (
 	"context"
 
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 )
 
@@ -20,11 +18,4 @@ func kubernetesFolderCascadeDeleteEnabled(ctx context.Context, features featurem
 		return false
 	}
 	return features.IsEnabled(ctx, featuremgmt.FlagKubernetesFolderCascadeDelete)
-}
-
-// clientRequestedCascadeDelete reports whether the delete request opts into deleting a
-// non-empty folder (gracePeriodSeconds=0). Requires kubernetesFolderCascadeDelete. Child
-// resources are not deleted automatically until cascade reconciliation is implemented.
-func clientRequestedCascadeDelete(options *metav1.DeleteOptions) bool {
-	return forceDeleteFromDeleteOptions(options)
 }

--- a/pkg/registry/apis/folders/cascade_delete_test.go
+++ b/pkg/registry/apis/folders/cascade_delete_test.go
@@ -2,22 +2,35 @@ package folders
 
 import (
 	"context"
+	"os"
 	"testing"
 
 	"github.com/open-feature/go-sdk/openfeature"
 	"github.com/open-feature/go-sdk/openfeature/memprovider"
+	oftesting "github.com/open-feature/go-sdk/openfeature/testing"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 )
 
+var featureFlagsProvider = oftesting.NewTestProvider()
+
+func TestMain(m *testing.M) {
+	if err := openfeature.SetProvider(featureFlagsProvider); err != nil {
+		panic(err)
+	}
+	os.Exit(m.Run())
+}
+
+// setKubernetesFolderCascadeDeleteToggle scopes the kubernetesFolderCascadeDelete flag to t.
+// Flag state is per-test (routed by goroutine), so this is safe under t.Parallel.
 func setKubernetesFolderCascadeDeleteToggle(t *testing.T, enabled bool) {
 	t.Helper()
 	variant := "off"
 	if enabled {
 		variant = "on"
 	}
-	require.NoError(t, openfeature.SetProviderAndWait(memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
+	featureFlagsProvider.UsingFlags(t, map[string]memprovider.InMemoryFlag{
 		featuremgmt.FlagKubernetesFolderCascadeDelete: {
 			Key:            featuremgmt.FlagKubernetesFolderCascadeDelete,
 			DefaultVariant: variant,
@@ -26,14 +39,13 @@ func setKubernetesFolderCascadeDeleteToggle(t *testing.T, enabled bool) {
 				"off": false,
 			},
 		},
-	})))
-	t.Cleanup(func() {
-		require.NoError(t, openfeature.SetProviderAndWait(openfeature.NoopProvider{}))
 	})
+	t.Cleanup(featureFlagsProvider.Cleanup)
 }
 
 func TestKubernetesFolderCascadeDeleteEnabled(t *testing.T) {
-	t.Run("disabled by default", func(t *testing.T) {
+	t.Run("disabled when toggle off", func(t *testing.T) {
+		setKubernetesFolderCascadeDeleteToggle(t, false)
 		require.False(t, kubernetesFolderCascadeDeleteEnabled(context.Background()))
 	})
 	t.Run("enabled when toggle on", func(t *testing.T) {

--- a/pkg/registry/apis/folders/cascade_delete_test.go
+++ b/pkg/registry/apis/folders/cascade_delete_test.go
@@ -13,9 +13,6 @@ import (
 
 func setKubernetesFolderCascadeDeleteToggle(t *testing.T, enabled bool) {
 	t.Helper()
-	if !enabled {
-		return
-	}
 	variant := "off"
 	if enabled {
 		variant = "on"
@@ -31,7 +28,7 @@ func setKubernetesFolderCascadeDeleteToggle(t *testing.T, enabled bool) {
 		},
 	})))
 	t.Cleanup(func() {
-		_ = openfeature.SetProviderAndWait(openfeature.NoopProvider{})
+		require.NoError(t, openfeature.SetProviderAndWait(openfeature.NoopProvider{}))
 	})
 }
 

--- a/pkg/registry/apis/folders/cascade_delete_test.go
+++ b/pkg/registry/apis/folders/cascade_delete_test.go
@@ -1,0 +1,46 @@
+package folders
+
+import (
+	"context"
+	"testing"
+
+	"github.com/open-feature/go-sdk/openfeature"
+	"github.com/open-feature/go-sdk/openfeature/memprovider"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
+)
+
+func setKubernetesFolderCascadeDeleteToggle(t *testing.T, enabled bool) {
+	t.Helper()
+	if !enabled {
+		return
+	}
+	variant := "off"
+	if enabled {
+		variant = "on"
+	}
+	require.NoError(t, openfeature.SetProviderAndWait(memprovider.NewInMemoryProvider(map[string]memprovider.InMemoryFlag{
+		featuremgmt.FlagKubernetesFolderCascadeDelete: {
+			Key:            featuremgmt.FlagKubernetesFolderCascadeDelete,
+			DefaultVariant: variant,
+			Variants: map[string]any{
+				"on":  true,
+				"off": false,
+			},
+		},
+	})))
+	t.Cleanup(func() {
+		_ = openfeature.SetProviderAndWait(openfeature.NoopProvider{})
+	})
+}
+
+func TestKubernetesFolderCascadeDeleteEnabled(t *testing.T) {
+	t.Run("disabled by default", func(t *testing.T) {
+		require.False(t, kubernetesFolderCascadeDeleteEnabled(context.Background()))
+	})
+	t.Run("enabled when toggle on", func(t *testing.T) {
+		setKubernetesFolderCascadeDeleteToggle(t, true)
+		require.True(t, kubernetesFolderCascadeDeleteEnabled(context.Background()))
+	})
+}

--- a/pkg/registry/apis/folders/delete_options.go
+++ b/pkg/registry/apis/folders/delete_options.go
@@ -1,0 +1,14 @@
+package folders
+
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+// forceDeleteFromDeleteOptions reports whether the client opted into cascade deletion of a
+// non-empty folder. Matches dashboard delete validation in pkg/registry/apis/dashboard.
+//
+// Use gracePeriodSeconds=0, e.g. kubectl delete folders.folder.grafana.app my-folder --grace-period=0
+func forceDeleteFromDeleteOptions(options *metav1.DeleteOptions) bool {
+	if options == nil || options.GracePeriodSeconds == nil {
+		return false
+	}
+	return *options.GracePeriodSeconds == 0
+}

--- a/pkg/registry/apis/folders/delete_options.go
+++ b/pkg/registry/apis/folders/delete_options.go
@@ -2,8 +2,9 @@ package folders
 
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-// forceDeleteFromDeleteOptions reports whether the client opted into cascade deletion of a
-// non-empty folder. Matches dashboard delete validation in pkg/registry/apis/dashboard.
+// forceDeleteFromDeleteOptions reports whether the client set DeleteOptions.gracePeriodSeconds=0.
+// Used with kubernetesFolderCascadeDelete to opt into deleting a non-empty folder.
+// Matches dashboard delete validation in pkg/registry/apis/dashboard.
 //
 // Use gracePeriodSeconds=0, e.g. kubectl delete folders.folder.grafana.app my-folder --grace-period=0
 func forceDeleteFromDeleteOptions(options *metav1.DeleteOptions) bool {

--- a/pkg/registry/apis/folders/delete_options.go
+++ b/pkg/registry/apis/folders/delete_options.go
@@ -4,10 +4,9 @@ import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 // forceDeleteFromDeleteOptions reports whether the client set DeleteOptions.gracePeriodSeconds=0.
 // Used with kubernetesFolderCascadeDelete to opt into deleting a non-empty folder. Does not delete
-// child resources; without cascade reconciliation they become orphans. Matches dashboard delete
-// validation in pkg/registry/apis/dashboard.
+// child resources; without cascade reconciliation they become orphans.
 //
-// Use gracePeriodSeconds=0, e.g. kubectl delete folders.folder.grafana.app my-folder --grace-period=0
+// Use gracePeriodSeconds=0, e.g. kubectl delete folders.folder.grafana.app my-folder --grace-period=0 --force
 func forceDeleteFromDeleteOptions(options *metav1.DeleteOptions) bool {
 	if options == nil || options.GracePeriodSeconds == nil {
 		return false

--- a/pkg/registry/apis/folders/delete_options.go
+++ b/pkg/registry/apis/folders/delete_options.go
@@ -3,8 +3,9 @@ package folders
 import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 // forceDeleteFromDeleteOptions reports whether the client set DeleteOptions.gracePeriodSeconds=0.
-// Used with kubernetesFolderCascadeDelete to opt into deleting a non-empty folder.
-// Matches dashboard delete validation in pkg/registry/apis/dashboard.
+// Used with kubernetesFolderCascadeDelete to opt into deleting a non-empty folder. Does not delete
+// child resources; without cascade reconciliation they become orphans. Matches dashboard delete
+// validation in pkg/registry/apis/dashboard.
 //
 // Use gracePeriodSeconds=0, e.g. kubectl delete folders.folder.grafana.app my-folder --grace-period=0
 func forceDeleteFromDeleteOptions(options *metav1.DeleteOptions) bool {

--- a/pkg/registry/apis/folders/delete_options_test.go
+++ b/pkg/registry/apis/folders/delete_options_test.go
@@ -1,0 +1,30 @@
+package folders
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestForceDeleteFromDeleteOptions(t *testing.T) {
+	zero := int64(0)
+	one := int64(1)
+
+	tests := []struct {
+		name    string
+		options *metav1.DeleteOptions
+		want    bool
+	}{
+		{name: "nil options", options: nil, want: false},
+		{name: "nil grace period", options: &metav1.DeleteOptions{}, want: false},
+		{name: "grace period zero", options: &metav1.DeleteOptions{GracePeriodSeconds: &zero}, want: true},
+		{name: "grace period non-zero", options: &metav1.DeleteOptions{GracePeriodSeconds: &one}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, forceDeleteFromDeleteOptions(tt.options))
+		})
+	}
+}

--- a/pkg/registry/apis/folders/register.go
+++ b/pkg/registry/apis/folders/register.go
@@ -59,7 +59,6 @@ type FolderAPIBuilder struct {
 	// Flags
 	useZanzana          bool // features.IsEnabledGlobally(featuremgmt.FlagZanzana)
 	permissionsOnCreate bool // cfg.RBAC.PermissionsOnCreation("folder")
-	features            featuremgmt.FeatureToggles
 
 	// Legacy services -- these will not exist in the MT environment
 	resourcePermissionsSvc *dynamic.NamespaceableResourceInterface
@@ -81,7 +80,6 @@ func RegisterAPIService(cfg *setting.Cfg,
 		accessClient:         accessClient,
 		permissionsOnCreate:  cfg.RBAC.PermissionsOnCreation("folder"),
 		useZanzana:           features.IsEnabledGlobally(featuremgmt.FlagZanzana), //nolint:staticcheck
-		features:             features,
 		searcher:             unified,
 		permissionStore:      NewZanzanaPermissionStore(zanzanaClient),
 		maxNestedFolderDepth: cfg.MaxNestedFolderDepth,
@@ -98,7 +96,6 @@ func NewAPIService(ac authlib.AccessClient, searcher resource.ResourceClient, fe
 		resourcePermissionsSvc: resourcePermissionsSvc,
 		maxNestedFolderDepth:   maxNestedFolderDepth,
 		useZanzana:             features.IsEnabledGlobally(featuremgmt.FlagZanzana), //nolint:staticcheck
-		features:               features,
 	}
 }
 
@@ -413,7 +410,7 @@ func (b *FolderAPIBuilder) Validate(ctx context.Context, a admission.Attributes,
 		if !ok {
 			return fmt.Errorf("expected v1.DeleteOptions")
 		}
-		return validateOnDelete(ctx, f, b.searcher, deleteOptions, kubernetesFolderCascadeDeleteEnabled(ctx, b.features))
+		return validateOnDelete(ctx, f, b.searcher, deleteOptions, kubernetesFolderCascadeDeleteEnabled(ctx))
 	case admission.Update:
 		old, ok := a.GetOldObject().(*foldersv1.Folder)
 		if !ok {

--- a/pkg/registry/apis/folders/register.go
+++ b/pkg/registry/apis/folders/register.go
@@ -59,6 +59,7 @@ type FolderAPIBuilder struct {
 	// Flags
 	useZanzana          bool // features.IsEnabledGlobally(featuremgmt.FlagZanzana)
 	permissionsOnCreate bool // cfg.RBAC.PermissionsOnCreation("folder")
+	features            featuremgmt.FeatureToggles
 
 	// Legacy services -- these will not exist in the MT environment
 	resourcePermissionsSvc *dynamic.NamespaceableResourceInterface
@@ -80,6 +81,7 @@ func RegisterAPIService(cfg *setting.Cfg,
 		accessClient:         accessClient,
 		permissionsOnCreate:  cfg.RBAC.PermissionsOnCreation("folder"),
 		useZanzana:           features.IsEnabledGlobally(featuremgmt.FlagZanzana), //nolint:staticcheck
+		features:             features,
 		searcher:             unified,
 		permissionStore:      NewZanzanaPermissionStore(zanzanaClient),
 		maxNestedFolderDepth: cfg.MaxNestedFolderDepth,
@@ -96,6 +98,7 @@ func NewAPIService(ac authlib.AccessClient, searcher resource.ResourceClient, fe
 		resourcePermissionsSvc: resourcePermissionsSvc,
 		maxNestedFolderDepth:   maxNestedFolderDepth,
 		useZanzana:             features.IsEnabledGlobally(featuremgmt.FlagZanzana), //nolint:staticcheck
+		features:               features,
 	}
 }
 
@@ -410,7 +413,7 @@ func (b *FolderAPIBuilder) Validate(ctx context.Context, a admission.Attributes,
 		if !ok {
 			return fmt.Errorf("expected v1.DeleteOptions")
 		}
-		return validateOnDelete(ctx, f, b.searcher, deleteOptions)
+		return validateOnDelete(ctx, f, b.searcher, deleteOptions, kubernetesFolderCascadeDeleteEnabled(ctx, b.features))
 	case admission.Update:
 		old, ok := a.GetOldObject().(*foldersv1.Folder)
 		if !ok {

--- a/pkg/registry/apis/folders/register.go
+++ b/pkg/registry/apis/folders/register.go
@@ -356,18 +356,24 @@ func (b *FolderAPIBuilder) GetAuthorizer() authorizer.Authorizer {
 	return grafanaauthorizer.NewServiceAuthorizer()
 }
 
-func (b *FolderAPIBuilder) Mutate(ctx context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {
-	verb := a.GetOperation()
-	if verb == admission.Create || verb == admission.Update {
+func (b *FolderAPIBuilder) Mutate(ctx context.Context, a admission.Attributes, oi admission.ObjectInterfaces) error {
+	switch a.GetOperation() {
+	case admission.Create, admission.Update:
 		obj := a.GetObject()
+		if obj == nil {
+			return nil
+		}
 		f, ok := obj.(*foldersv1.Folder)
 		if !ok {
 			return fmt.Errorf("obj is not folders.Folder")
 		}
 		f.Spec.Title = strings.Trim(f.Spec.Title, " ")
 		return nil
+	case admission.Delete:
+		return nil
+	default:
+		return nil
 	}
-	return nil
 }
 
 func (b *FolderAPIBuilder) Validate(ctx context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {
@@ -400,7 +406,11 @@ func (b *FolderAPIBuilder) Validate(ctx context.Context, a admission.Attributes,
 		}
 		return validateOnCreate(ctx, f, b.parents, b.maxNestedFolderDepth)
 	case admission.Delete:
-		return validateOnDelete(ctx, f, b.searcher)
+		deleteOptions, ok := a.GetOperationOptions().(*metav1.DeleteOptions)
+		if !ok {
+			return fmt.Errorf("expected v1.DeleteOptions")
+		}
+		return validateOnDelete(ctx, f, b.searcher, deleteOptions)
 	case admission.Update:
 		old, ok := a.GetOldObject().(*foldersv1.Folder)
 		if !ok {

--- a/pkg/registry/apis/folders/register.go
+++ b/pkg/registry/apis/folders/register.go
@@ -356,24 +356,18 @@ func (b *FolderAPIBuilder) GetAuthorizer() authorizer.Authorizer {
 	return grafanaauthorizer.NewServiceAuthorizer()
 }
 
-func (b *FolderAPIBuilder) Mutate(ctx context.Context, a admission.Attributes, oi admission.ObjectInterfaces) error {
-	switch a.GetOperation() {
-	case admission.Create, admission.Update:
+func (b *FolderAPIBuilder) Mutate(ctx context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {
+	verb := a.GetOperation()
+	if verb == admission.Create || verb == admission.Update {
 		obj := a.GetObject()
-		if obj == nil {
-			return nil
-		}
 		f, ok := obj.(*foldersv1.Folder)
 		if !ok {
 			return fmt.Errorf("obj is not folders.Folder")
 		}
 		f.Spec.Title = strings.Trim(f.Spec.Title, " ")
 		return nil
-	case admission.Delete:
-		return nil
-	default:
-		return nil
 	}
+	return nil
 }
 
 func (b *FolderAPIBuilder) Validate(ctx context.Context, a admission.Attributes, _ admission.ObjectInterfaces) error {

--- a/pkg/registry/apis/folders/register.go
+++ b/pkg/registry/apis/folders/register.go
@@ -400,10 +400,7 @@ func (b *FolderAPIBuilder) Validate(ctx context.Context, a admission.Attributes,
 		}
 		return validateOnCreate(ctx, f, b.parents, b.maxNestedFolderDepth)
 	case admission.Delete:
-		deleteOptions, ok := a.GetOperationOptions().(*metav1.DeleteOptions)
-		if !ok {
-			return fmt.Errorf("expected v1.DeleteOptions")
-		}
+		deleteOptions, _ := a.GetOperationOptions().(*metav1.DeleteOptions)
 		return validateOnDelete(ctx, f, b.searcher, deleteOptions, kubernetesFolderCascadeDeleteEnabled(ctx))
 	case admission.Update:
 		old, ok := a.GetOldObject().(*foldersv1.Folder)

--- a/pkg/registry/apis/folders/register_test.go
+++ b/pkg/registry/apis/folders/register_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
@@ -183,10 +184,11 @@ func TestFolderAPIBuilder_Validate_Delete(t *testing.T) {
 	zeroGrace := int64(0)
 
 	tests := []struct {
-		name          string
-		statsResponse []*resourcepb.ResourceStatsResponse_Stats
-		deleteOptions *metav1.DeleteOptions
-		wantErr       bool
+		name                 string
+		statsResponse        []*resourcepb.ResourceStatsResponse_Stats
+		deleteOptions        *metav1.DeleteOptions
+		cascadeDeleteEnabled bool
+		wantErr              bool
 	}{
 		{
 			name: "should allow deletion when folder is empty",
@@ -265,6 +267,23 @@ func TestFolderAPIBuilder_Validate_Delete(t *testing.T) {
 			statsResponse: []*resourcepb.ResourceStatsResponse_Stats{},
 			wantErr:       false,
 		},
+		{
+			name: "should reject force delete when cascade gate disabled",
+			statsResponse: []*resourcepb.ResourceStatsResponse_Stats{
+				{Resource: "folders", Count: 1, Group: "folders.grafana.app"},
+			},
+			deleteOptions:        &metav1.DeleteOptions{GracePeriodSeconds: &zeroGrace},
+			cascadeDeleteEnabled: false,
+			wantErr:              true,
+		},
+		{
+			name: "should allow force delete when cascade gate enabled",
+			statsResponse: []*resourcepb.ResourceStatsResponse_Stats{
+				{Resource: "folders", Count: 1, Group: "folders.grafana.app"},
+			},
+			deleteOptions:        &metav1.DeleteOptions{GracePeriodSeconds: &zeroGrace},
+			cascadeDeleteEnabled: true,
+		},
 	}
 
 	obj := &folders.Folder{
@@ -283,17 +302,24 @@ func TestFolderAPIBuilder_Validate_Delete(t *testing.T) {
 			sm := resource.NewMockResourceClient(t)
 
 			deleteOptions := tt.deleteOptions
-			if !forceDeleteFromDeleteOptions(deleteOptions) {
+			shortCircuit := tt.cascadeDeleteEnabled && forceDeleteFromDeleteOptions(deleteOptions)
+			if !shortCircuit {
 				sm.On("GetStats", mock.Anything, &resourcepb.ResourceStatsRequest{Namespace: obj.Namespace, Kinds: countedKinds, Folder: []string{obj.Name}}).Return(
 					&resourcepb.ResourceStatsResponse{Stats: tt.statsResponse},
 					nil,
 				).Once()
 			}
 
+			features := featuremgmt.WithFeatures()
+			if tt.cascadeDeleteEnabled {
+				features = featuremgmt.WithFeatures(featuremgmt.FlagKubernetesFolderCascadeDelete)
+			}
+
 			b := &FolderAPIBuilder{
 				namespacer: func(_ int64) string { return "123" },
 				storage:    us,
 				searcher:   sm,
+				features:   features,
 			}
 
 			err := b.Validate(context.Background(), admission.NewAttributesRecord(
@@ -319,33 +345,6 @@ func TestFolderAPIBuilder_Validate_Delete(t *testing.T) {
 		})
 	}
 
-	t.Run("should allow deletion of non-empty folder when gracePeriodSeconds=0", func(t *testing.T) {
-		us := grafanarest.NewMockStorage(t)
-		sm := resource.NewMockResourceClient(t)
-
-		b := &FolderAPIBuilder{
-			namespacer: func(_ int64) string { return "123" },
-			storage:    us,
-			searcher:   sm,
-		}
-
-		err := b.Validate(context.Background(), admission.NewAttributesRecord(
-			nil,
-			obj,
-			folders.SchemeGroupVersion.WithKind("folder"),
-			obj.Namespace,
-			obj.Name,
-			folders.SchemeGroupVersion.WithResource("folders"),
-			"",
-			admission.Delete,
-			&metav1.DeleteOptions{GracePeriodSeconds: &zeroGrace},
-			true,
-			&user.SignedInUser{},
-		),
-			nil)
-
-		require.NoError(t, err)
-	})
 }
 
 func TestFolderAPIBuilder_Validate_Update(t *testing.T) {

--- a/pkg/registry/apis/folders/register_test.go
+++ b/pkg/registry/apis/folders/register_test.go
@@ -299,10 +299,7 @@ func TestFolderAPIBuilder_Validate_Delete(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			us := grafanarest.NewMockStorage(t)
 			sm := resource.NewMockResourceClient(t)
-
-			deleteOptions := tt.deleteOptions
-			shortCircuit := tt.cascadeDeleteEnabled && forceDeleteFromDeleteOptions(deleteOptions)
-			if !shortCircuit {
+			if !tt.cascadeDeleteEnabled || !forceDeleteFromDeleteOptions(tt.deleteOptions) {
 				sm.On("GetStats", mock.Anything, &resourcepb.ResourceStatsRequest{Namespace: obj.Namespace, Kinds: countedKinds, Folder: []string{obj.Name}}).Return(
 					&resourcepb.ResourceStatsResponse{Stats: tt.statsResponse},
 					nil,
@@ -326,7 +323,7 @@ func TestFolderAPIBuilder_Validate_Delete(t *testing.T) {
 				folders.SchemeGroupVersion.WithResource("folders"),
 				"",
 				admission.Delete,
-				deleteOptions,
+				tt.deleteOptions,
 				true,
 				&user.SignedInUser{},
 			),

--- a/pkg/registry/apis/folders/register_test.go
+++ b/pkg/registry/apis/folders/register_test.go
@@ -180,9 +180,12 @@ func TestFolderAPIBuilder_Validate_Create(t *testing.T) {
 }
 
 func TestFolderAPIBuilder_Validate_Delete(t *testing.T) {
+	zeroGrace := int64(0)
+
 	tests := []struct {
 		name          string
 		statsResponse []*resourcepb.ResourceStatsResponse_Stats
+		deleteOptions *metav1.DeleteOptions
 		wantErr       bool
 	}{
 		{
@@ -278,10 +281,14 @@ func TestFolderAPIBuilder_Validate_Delete(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			us := grafanarest.NewMockStorage(t)
 			sm := resource.NewMockResourceClient(t)
-			sm.On("GetStats", mock.Anything, &resourcepb.ResourceStatsRequest{Namespace: obj.Namespace, Kinds: countedKinds, Folder: []string{obj.Name}}).Return(
-				&resourcepb.ResourceStatsResponse{Stats: tt.statsResponse},
-				nil,
-			).Once()
+
+			deleteOptions := tt.deleteOptions
+			if !forceDeleteFromDeleteOptions(deleteOptions) {
+				sm.On("GetStats", mock.Anything, &resourcepb.ResourceStatsRequest{Namespace: obj.Namespace, Kinds: countedKinds, Folder: []string{obj.Name}}).Return(
+					&resourcepb.ResourceStatsResponse{Stats: tt.statsResponse},
+					nil,
+				).Once()
+			}
 
 			b := &FolderAPIBuilder{
 				namespacer: func(_ int64) string { return "123" },
@@ -297,8 +304,8 @@ func TestFolderAPIBuilder_Validate_Delete(t *testing.T) {
 				obj.Name,
 				folders.SchemeGroupVersion.WithResource("folders"),
 				"",
-				"DELETE",
-				nil,
+				admission.Delete,
+				deleteOptions,
 				true,
 				&user.SignedInUser{},
 			),
@@ -311,6 +318,34 @@ func TestFolderAPIBuilder_Validate_Delete(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+
+	t.Run("should allow deletion of non-empty folder when gracePeriodSeconds=0", func(t *testing.T) {
+		us := grafanarest.NewMockStorage(t)
+		sm := resource.NewMockResourceClient(t)
+
+		b := &FolderAPIBuilder{
+			namespacer: func(_ int64) string { return "123" },
+			storage:    us,
+			searcher:   sm,
+		}
+
+		err := b.Validate(context.Background(), admission.NewAttributesRecord(
+			nil,
+			obj,
+			folders.SchemeGroupVersion.WithKind("folder"),
+			obj.Namespace,
+			obj.Name,
+			folders.SchemeGroupVersion.WithResource("folders"),
+			"",
+			admission.Delete,
+			&metav1.DeleteOptions{GracePeriodSeconds: &zeroGrace},
+			true,
+			&user.SignedInUser{},
+		),
+			nil)
+
+		require.NoError(t, err)
+	})
 }
 
 func TestFolderAPIBuilder_Validate_Update(t *testing.T) {

--- a/pkg/registry/apis/folders/register_test.go
+++ b/pkg/registry/apis/folders/register_test.go
@@ -336,7 +336,6 @@ func TestFolderAPIBuilder_Validate_Delete(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
-
 }
 
 func TestFolderAPIBuilder_Validate_Update(t *testing.T) {

--- a/pkg/registry/apis/folders/register_test.go
+++ b/pkg/registry/apis/folders/register_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
-	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
@@ -310,16 +309,12 @@ func TestFolderAPIBuilder_Validate_Delete(t *testing.T) {
 				).Once()
 			}
 
-			features := featuremgmt.WithFeatures()
-			if tt.cascadeDeleteEnabled {
-				features = featuremgmt.WithFeatures(featuremgmt.FlagKubernetesFolderCascadeDelete)
-			}
+			setKubernetesFolderCascadeDeleteToggle(t, tt.cascadeDeleteEnabled)
 
 			b := &FolderAPIBuilder{
 				namespacer: func(_ int64) string { return "123" },
 				storage:    us,
 				searcher:   sm,
-				features:   features,
 			}
 
 			err := b.Validate(context.Background(), admission.NewAttributesRecord(

--- a/pkg/registry/apis/folders/validate.go
+++ b/pkg/registry/apis/folders/validate.go
@@ -367,7 +367,7 @@ func validateOnDelete(ctx context.Context,
 	// Non-empty folder delete is opt-in via gracePeriodSeconds=0 when kubernetesFolderCascadeDelete
 	// is enabled (same pattern as dashboard delete validation). This only bypasses the empty-folder
 	// check; until cascade reconciliation runs, child resources are left orphaned.
-	if cascadeDeleteEnabled && clientRequestedCascadeDelete(deleteOptions) {
+	if cascadeDeleteEnabled && forceDeleteFromDeleteOptions(deleteOptions) {
 		return nil
 	}
 

--- a/pkg/registry/apis/folders/validate.go
+++ b/pkg/registry/apis/folders/validate.go
@@ -364,8 +364,9 @@ func validateOnDelete(ctx context.Context,
 	deleteOptions *metav1.DeleteOptions,
 	cascadeDeleteEnabled bool,
 ) error {
-	// Non-empty folder cascade delete is opt-in via gracePeriodSeconds=0 when
-	// kubernetesFolderCascadeDelete is enabled (same pattern as dashboard delete validation).
+	// Non-empty folder delete is opt-in via gracePeriodSeconds=0 when kubernetesFolderCascadeDelete
+	// is enabled (same pattern as dashboard delete validation). This only bypasses the empty-folder
+	// check; until cascade reconciliation runs, child resources are left orphaned.
 	if cascadeDeleteEnabled && clientRequestedCascadeDelete(deleteOptions) {
 		return nil
 	}

--- a/pkg/registry/apis/folders/validate.go
+++ b/pkg/registry/apis/folders/validate.go
@@ -362,10 +362,11 @@ func validateOnDelete(ctx context.Context,
 	f *folders.Folder,
 	searcher resourcepb.ResourceIndexClient,
 	deleteOptions *metav1.DeleteOptions,
+	cascadeDeleteEnabled bool,
 ) error {
-	// Cascade delete of non-empty folders is opt-in via DeleteOptions.gracePeriodSeconds=0
-	// (same pattern as dashboard delete validation; works with kubectl --grace-period=0).
-	if forceDeleteFromDeleteOptions(deleteOptions) {
+	// Non-empty folder cascade delete is opt-in via gracePeriodSeconds=0 when
+	// kubernetesFolderCascadeDelete is enabled (same pattern as dashboard delete validation).
+	if cascadeDeleteEnabled && clientRequestedCascadeDelete(deleteOptions) {
 		return nil
 	}
 

--- a/pkg/registry/apis/folders/validate.go
+++ b/pkg/registry/apis/folders/validate.go
@@ -361,7 +361,14 @@ func getChildrenBatch(ctx context.Context, searcher resourcepb.ResourceIndexClie
 func validateOnDelete(ctx context.Context,
 	f *folders.Folder,
 	searcher resourcepb.ResourceIndexClient,
+	deleteOptions *metav1.DeleteOptions,
 ) error {
+	// Cascade delete of non-empty folders is opt-in via DeleteOptions.gracePeriodSeconds=0
+	// (same pattern as dashboard delete validation; works with kubectl --grace-period=0).
+	if forceDeleteFromDeleteOptions(deleteOptions) {
+		return nil
+	}
+
 	resp, err := searcher.GetStats(ctx, &resourcepb.ResourceStatsRequest{Namespace: f.Namespace, Kinds: countedKinds, Folder: []string{f.Name}})
 	if err != nil {
 		return err

--- a/pkg/registry/apis/folders/validate.go
+++ b/pkg/registry/apis/folders/validate.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apiserver/pkg/registry/rest"
 
+	"github.com/grafana/grafana-app-sdk/logging"
 	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
@@ -368,6 +369,11 @@ func validateOnDelete(ctx context.Context,
 	// is enabled (same pattern as dashboard delete validation). This only bypasses the empty-folder
 	// check; until cascade reconciliation runs, child resources are left orphaned.
 	if cascadeDeleteEnabled && forceDeleteFromDeleteOptions(deleteOptions) {
+		logging.FromContext(ctx).Warn(
+			"folder force-delete bypassing empty check; cascade deletion is not yet wired up so sub-folders, dashboards, alert rules, and library elements under this folder will be orphaned. This is a temporary state during the cascade delete rollout.",
+			"folder", f.Name,
+			"namespace", f.Namespace,
+		)
 		return nil
 	}
 

--- a/pkg/registry/apis/folders/validate_test.go
+++ b/pkg/registry/apis/folders/validate_test.go
@@ -676,12 +676,12 @@ func TestValidateDelete(t *testing.T) {
 	zeroGrace := int64(0)
 
 	tests := []struct {
-		name               string
-		folder             *folders.Folder
-		searcher           *mockSearchClient
-		deleteOptions      *metav1.DeleteOptions
+		name                 string
+		folder               *folders.Folder
+		searcher             *mockSearchClient
+		deleteOptions        *metav1.DeleteOptions
 		cascadeDeleteEnabled bool
-		expectedErr        string
+		expectedErr          string
 	}{{
 		name: "simple delete",
 		folder: &folders.Folder{
@@ -750,7 +750,7 @@ func TestValidateDelete(t *testing.T) {
 				},
 			},
 		},
-		deleteOptions:      &metav1.DeleteOptions{GracePeriodSeconds: &zeroGrace},
+		deleteOptions:        &metav1.DeleteOptions{GracePeriodSeconds: &zeroGrace},
 		cascadeDeleteEnabled: true,
 	}, {
 		name: "folder not empty with gracePeriodSeconds=0 is blocked when feature is disabled",
@@ -770,9 +770,9 @@ func TestValidateDelete(t *testing.T) {
 				},
 			},
 		},
-		deleteOptions:      &metav1.DeleteOptions{GracePeriodSeconds: &zeroGrace},
+		deleteOptions:        &metav1.DeleteOptions{GracePeriodSeconds: &zeroGrace},
 		cascadeDeleteEnabled: false,
-		expectedErr:        "[folder.not-empty]",
+		expectedErr:          "[folder.not-empty]",
 	}, {
 		name: "folder not empty - contains dashboards",
 		folder: &folders.Folder{

--- a/pkg/registry/apis/folders/validate_test.go
+++ b/pkg/registry/apis/folders/validate_test.go
@@ -676,11 +676,12 @@ func TestValidateDelete(t *testing.T) {
 	zeroGrace := int64(0)
 
 	tests := []struct {
-		name          string
-		folder        *folders.Folder
-		searcher      *mockSearchClient
-		deleteOptions *metav1.DeleteOptions
-		expectedErr   string
+		name               string
+		folder             *folders.Folder
+		searcher           *mockSearchClient
+		deleteOptions      *metav1.DeleteOptions
+		cascadeDeleteEnabled bool
+		expectedErr        string
 	}{{
 		name: "simple delete",
 		folder: &folders.Folder{
@@ -749,7 +750,29 @@ func TestValidateDelete(t *testing.T) {
 				},
 			},
 		},
-		deleteOptions: &metav1.DeleteOptions{GracePeriodSeconds: &zeroGrace},
+		deleteOptions:      &metav1.DeleteOptions{GracePeriodSeconds: &zeroGrace},
+		cascadeDeleteEnabled: true,
+	}, {
+		name: "folder not empty with gracePeriodSeconds=0 is blocked when feature is disabled",
+		folder: &folders.Folder{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "nnn",
+			},
+		},
+		searcher: &mockSearchClient{
+			stats: &resourcepb.ResourceStatsResponse{
+				Stats: []*resourcepb.ResourceStatsResponse_Stats{
+					{
+						Group:    "folders.grafana.app",
+						Resource: "folders",
+						Count:    2,
+					},
+				},
+			},
+		},
+		deleteOptions:      &metav1.DeleteOptions{GracePeriodSeconds: &zeroGrace},
+		cascadeDeleteEnabled: false,
+		expectedErr:        "[folder.not-empty]",
 	}, {
 		name: "folder not empty - contains dashboards",
 		folder: &folders.Folder{
@@ -877,7 +900,7 @@ func TestValidateDelete(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateOnDelete(context.Background(), tt.folder, tt.searcher, tt.deleteOptions)
+			err := validateOnDelete(context.Background(), tt.folder, tt.searcher, tt.deleteOptions, tt.cascadeDeleteEnabled)
 
 			if tt.expectedErr == "" {
 				require.NoError(t, err)

--- a/pkg/registry/apis/folders/validate_test.go
+++ b/pkg/registry/apis/folders/validate_test.go
@@ -673,11 +673,14 @@ func TestValidateUpdate(t *testing.T) {
 }
 
 func TestValidateDelete(t *testing.T) {
+	zeroGrace := int64(0)
+
 	tests := []struct {
-		name        string
-		folder      *folders.Folder
-		searcher    *mockSearchClient
-		expectedErr string
+		name          string
+		folder        *folders.Folder
+		searcher      *mockSearchClient
+		deleteOptions *metav1.DeleteOptions
+		expectedErr   string
 	}{{
 		name: "simple delete",
 		folder: &folders.Folder{
@@ -728,6 +731,25 @@ func TestValidateDelete(t *testing.T) {
 			},
 		},
 		expectedErr: "could not verify if folder is empty",
+	}, {
+		name: "folder not empty with gracePeriodSeconds=0 is allowed",
+		folder: &folders.Folder{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "nnn",
+			},
+		},
+		searcher: &mockSearchClient{
+			stats: &resourcepb.ResourceStatsResponse{
+				Stats: []*resourcepb.ResourceStatsResponse_Stats{
+					{
+						Group:    "folders.grafana.app",
+						Resource: "folders",
+						Count:    2,
+					},
+				},
+			},
+		},
+		deleteOptions: &metav1.DeleteOptions{GracePeriodSeconds: &zeroGrace},
 	}, {
 		name: "folder not empty - contains dashboards",
 		folder: &folders.Folder{
@@ -855,7 +877,7 @@ func TestValidateDelete(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := validateOnDelete(context.Background(), tt.folder, tt.searcher)
+			err := validateOnDelete(context.Background(), tt.folder, tt.searcher, tt.deleteOptions)
 
 			if tt.expectedErr == "" {
 				require.NoError(t, err)

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -382,7 +382,7 @@ var (
 		},
 		{
 			Name:         "kubernetesFolderCascadeDelete",
-			Description:  "Enable folder.grafana.app cascade deletion: opt-in non-empty delete via gracePeriodSeconds=0 and asynchronous cleanup of child folders and contained resources",
+			Description:  "Enable folder.grafana.app cascade deletion: opt-in non-empty delete via gracePeriodSeconds=0. Until cascade reconciliation exists, deleting a non-empty folder removes only the folder and leaves child dashboards, nested folders, and other contained resources orphaned",
 			Stage:        FeatureStageExperimental,
 			Owner:        grafanaSearchAndStorageSquad,
 			HideFromDocs: true,

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -381,6 +381,15 @@ var (
 			Generate:        Generate{LegacyGo: true, LegacyFrontend: true},
 		},
 		{
+			Name:         "kubernetesFolderCascadeDelete",
+			Description:  "Enable folder.grafana.app cascade deletion: opt-in non-empty delete via gracePeriodSeconds=0 and asynchronous cleanup of child folders and contained resources",
+			Stage:        FeatureStageExperimental,
+			Owner:        grafanaSearchAndStorageSquad,
+			HideFromDocs: true,
+			Expression:   "false",
+			Generate:     Generate{LegacyGo: true},
+		},
+		{
 			Name:            "kubernetesAnnotationsClient",
 			Description:     "Enables usage of the new annotations API client",
 			Stage:           FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -42,6 +42,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2023-09-28,externalServiceAccounts,preview,@grafana/identity-access-team,false,false,false
 2023-12-05,kubernetesSnapshots,experimental,@grafana/grafana-app-platform-squad,false,true,false
 2025-06-25,kubernetesLibraryPanels,experimental,@grafana/grafana-app-platform-squad,false,true,false
+2026-05-19,kubernetesFolderCascadeDelete,experimental,@grafana/search-and-storage,false,false,false
 2026-05-07,kubernetesAnnotationsClient,experimental,@grafana/dashboards-squad,false,false,false
 2025-07-31,kubernetesShortURLs,GA,@grafana/grafana-app-platform-squad,false,true,false
 2025-08-29,useKubernetesShortURLsAPI,GA,@grafana/sharing-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -131,6 +131,10 @@ const (
 	// Routes library panel requests from /api to the /apis endpoint
 	FlagKubernetesLibraryPanels = "kubernetesLibraryPanels"
 
+	// FlagKubernetesFolderCascadeDelete
+	// Enable folder.grafana.app cascade deletion: opt-in non-empty delete via gracePeriodSeconds=0 and asynchronous cleanup of child folders and contained resources
+	FlagKubernetesFolderCascadeDelete = "kubernetesFolderCascadeDelete"
+
 	// FlagKubernetesAnnotationsClient
 	// Enables usage of the new annotations API client
 	FlagKubernetesAnnotationsClient = "kubernetesAnnotationsClient"

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -132,7 +132,7 @@ const (
 	FlagKubernetesLibraryPanels = "kubernetesLibraryPanels"
 
 	// FlagKubernetesFolderCascadeDelete
-	// Enable folder.grafana.app cascade deletion: opt-in non-empty delete via gracePeriodSeconds=0 and asynchronous cleanup of child folders and contained resources
+	// Enable folder.grafana.app cascade deletion: opt-in non-empty delete via gracePeriodSeconds=0. Until cascade reconciliation exists, deleting a non-empty folder removes only the folder and leaves child dashboards, nested folders, and other contained resources orphaned
 	FlagKubernetesFolderCascadeDelete = "kubernetesFolderCascadeDelete"
 
 	// FlagKubernetesAnnotationsClient

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -3685,6 +3685,20 @@
     },
     {
       "metadata": {
+        "name": "kubernetesFolderCascadeDelete",
+        "resourceVersion": "1779199630323",
+        "creationTimestamp": "2026-05-19T14:07:10Z"
+      },
+      "spec": {
+        "description": "Enable folder.grafana.app cascade deletion: opt-in non-empty delete via gracePeriodSeconds=0 and asynchronous cleanup of child folders and contained resources",
+        "stage": "experimental",
+        "codeowner": "@grafana/search-and-storage",
+        "hideFromDocs": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "kubernetesLibraryPanels",
         "resourceVersion": "1771434338561",
         "creationTimestamp": "2025-06-25T22:21:56Z"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -3686,11 +3686,14 @@
     {
       "metadata": {
         "name": "kubernetesFolderCascadeDelete",
-        "resourceVersion": "1779199630323",
-        "creationTimestamp": "2026-05-19T14:07:10Z"
+        "resourceVersion": "1779200031641",
+        "creationTimestamp": "2026-05-19T14:07:10Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-05-19 14:13:51.641875451 +0000 UTC"
+        }
       },
       "spec": {
-        "description": "Enable folder.grafana.app cascade deletion: opt-in non-empty delete via gracePeriodSeconds=0 and asynchronous cleanup of child folders and contained resources",
+        "description": "Enable folder.grafana.app cascade deletion: opt-in non-empty delete via gracePeriodSeconds=0. Until cascade reconciliation exists, deleting a non-empty folder removes only the folder and leaves child dashboards, nested folders, and other contained resources orphaned",
         "stage": "experimental",
         "codeowner": "@grafana/search-and-storage",
         "hideFromDocs": true,


### PR DESCRIPTION
### Summary

- Allow deleting non-empty folders through `folder.grafana.app` when the client sets `DeleteOptions.gracePeriodSeconds=0` (e.g. `kubectl delete … --grace-period=0`), matching the **dashboard** API delete pattern (`pkg/registry/apis/dashboard`).
- **`gracePeriodSeconds=0` is the K8s-native analogue of the legacy HTTP opt-in:** on `DELETE /api/folders/:uid`, clients use `?forceDeleteRules=true` to force deletion when the folder would otherwise be rejected (e.g. because it contains alert rules). On the Folder API Server, the same “force delete despite contents” intent is expressed with `gracePeriodSeconds=0` instead of a query parameter—consistent with how other `/apis` resources use `DeleteOptions`.
- Gate this behind the experimental **`kubernetesFolderCascadeDelete`** feature toggle (Search & Storage), intended as the master switch for the full folder cascade-deletion story.
- **Important:** cascade reconciliation is **not** implemented yet. This change only skips the `GetStats` / `folder.not-empty` admission check. Deleting a non-empty folder removes the folder CR and **orphans** child dashboards, nested folders, library elements, and alert rules until a reconciler exists.
- Omitting `gracePeriodSeconds` (or leaving the toggle off) keeps the existing strict empty-folder check.

| Legacy HTTP | Folder API Server |
|-------------|-------------------|
| `DELETE /api/folders/:uid?forceDeleteRules=true` | `DELETE` folder with `gracePeriodSeconds: 0` |
| Opt-in force delete (alert rules documented in HTTP API) | Opt-in force delete (non-empty check via stats) |
| Synchronous cascade in `folderimpl` when used | Admission bypass only today; cascade TBD |

### Test plan

- [x] `go test ./pkg/registry/apis/folders/...`
- [ ] With `kubernetesFolderCascadeDelete = true`, verify K8s delete with `--grace-period=0` on a non-empty folder passes admission
- [ ] Verify delete without grace period (or with toggle off) still returns `folder.not-empty` for non-empty folders
- [ ] Compare behavior with legacy `DELETE /api/folders/:uid` with and without `forceDeleteRules=true` for alert-rule-in-folder scenarios (optional)