### PR TITLE
Auth: Add disable_forgot_password config option to hide "Forgot your password?" link

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -754,6 +754,10 @@ disable_login_form = false
 # Set to true to disable the sign out link in the side menu. Useful if you use auth.proxy or auth.jwt.
 disable_signout_menu = false
 
+# Set to true to hide the "Forgot your password?" link on the login page.
+# Useful when passwords are managed by an external provider (e.g. LDAP, OAuth, SAML).
+disable_forgot_password = false
+
 # URL to redirect the user to after sign out
 signout_redirect_url =
 

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -774,6 +774,10 @@ disable_login_form = false
 # Set to true to disable the sign out link in the side menu. Useful if you use auth.proxy or auth.jwt.
 disable_signout_menu = false
 
+# Set to true to hide the "Forgot your password?" link on the login page.
+# Useful when passwords are managed by an external provider (e.g. LDAP, OAuth, SAML).
+disable_forgot_password = false
+
 # URL to redirect the user to after sign out
 signout_redirect_url =
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -658,6 +658,9 @@
 # Set to true to disable the sign out link in the side menu. Useful if you use auth.proxy or auth.jwt, defaults to false
 ;disable_signout_menu = false
 
+# Set to true to hide the "Forgot your password?" link on the login page, defaults to false
+;disable_forgot_password = false
+
 # URL to redirect the user to after sign out
 ;signout_redirect_url =
 

--- a/conf/sample.ini
+++ b/conf/sample.ini
@@ -665,6 +665,9 @@
 # Set to true to disable the sign out link in the side menu. Useful if you use auth.proxy or auth.jwt, defaults to false
 ;disable_signout_menu = false
 
+# Set to true to hide the "Forgot your password?" link on the login page, defaults to false
+;disable_forgot_password = false
+
 # URL to redirect the user to after sign out
 ;signout_redirect_url =
 

--- a/docs/sources/setup-grafana/configure-access/configure-authentication/grafana/index.md
+++ b/docs/sources/setup-grafana/configure-access/configure-authentication/grafana/index.md
@@ -57,3 +57,14 @@ disable_login_form = true
 ```
 
 This can be helpful in setups where authentication is handled entirely through external mechanisms or single sign-on (SSO).
+
+## Hide the forgot password link
+
+To hide the **Forgot your password?** link on the login page, use the following configuration setting:
+
+```bash
+[auth]
+disable_forgot_password = true
+```
+
+This is useful in mixed authentication environments, such as when LDAP is enabled for regular users alongside basic authentication for admin accounts. In such setups, LDAP users cannot reset their passwords through Grafana, so hiding the link reduces confusion.

--- a/docs/sources/setup-grafana/configure-access/configure-authentication/grafana/index.md
+++ b/docs/sources/setup-grafana/configure-access/configure-authentication/grafana/index.md
@@ -57,3 +57,16 @@ disable_login_form = true
 ```
 
 This can be helpful in setups where authentication is handled entirely through external mechanisms or single sign-on (SSO).
+
+## Hide the forgot password link
+
+To hide the **Forgot your password?** link on the login page, use the following configuration setting:
+
+```bash
+[auth]
+disable_forgot_password = true
+```
+
+This is useful in mixed authentication environments, such as when LDAP is enabled for regular users alongside basic authentication for admin accounts. In such setups, LDAP users cannot reset their passwords through Grafana, so hiding the link reduces confusion.
+
+This setting only hides the link. The password reset endpoint stays available, so local accounts that still need it, such as an admin account, can reach it directly. To block password resets entirely, use `disable_login_form` instead.

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1083,6 +1083,10 @@ Set to `true` to disable (hide) the login form, useful if you use OAuth 2.0. Def
 
 Set to `true` to disable the sign out link in the side menu. This is useful if you use `auth.proxy`. Default is `false`.
 
+#### `disable_forgot_password`
+
+Set to `true` to hide the **Forgot your password?** link on the login page. This is useful when passwords are managed by an external provider, such as LDAP or an OAuth provider. Default is `false`.
+
 #### `signout_redirect_url`
 
 The URL the user is redirected to upon signing out. To support [OpenID Connect RP-Initiated Logout](https://openid.net/specs/openid-connect-rpinitiated-1_0.html), the user must add `post_logout_redirect_uri` to the `signout_redirect_url`.

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -1099,6 +1099,10 @@ Set to `true` to disable (hide) the login form, useful if you use OAuth 2.0. Def
 
 Set to `true` to disable the sign out link in the side menu. This is useful if you use `auth.proxy`. Default is `false`.
 
+#### `disable_forgot_password`
+
+Set to `true` to hide the **Forgot your password?** link on the login page. This is useful when passwords are managed by an external provider, such as LDAP or an OAuth provider. This setting only affects the login page, and it doesn't disable the password reset endpoint. Default is `false`.
+
 #### `signout_redirect_url`
 
 The URL the user is redirected to upon signing out. To support [OpenID Connect RP-Initiated Logout](https://openid.net/specs/openid-connect-rpinitiated-1_0.html), the user must add `post_logout_redirect_uri` to the `signout_redirect_url`.

--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -384,4 +384,5 @@ export interface AuthSettings {
   disableLogin?: boolean;
   basicAuthStrongPasswordPolicy?: boolean;
   disableSignoutMenu?: boolean;
+  disableForgotPassword?: boolean;
 }

--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -388,4 +388,5 @@ export interface AuthSettings {
   disableLogin?: boolean;
   basicAuthStrongPasswordPolicy?: boolean;
   disableSignoutMenu?: boolean;
+  disableForgotPassword?: boolean;
 }

--- a/pkg/api/bootdata.go
+++ b/pkg/api/bootdata.go
@@ -203,6 +203,7 @@ func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.Fro
 		DisableLogin:                  hs.Cfg.DisableLogin,
 		BasicAuthStrongPasswordPolicy: hs.Cfg.BasicAuthStrongPasswordPolicy,
 		DisableSignoutMenu:            hs.Cfg.DisableSignoutMenu,
+		DisableForgotPassword:         hs.Cfg.DisableForgotPassword,
 	}
 
 	frontendSettings.Namespace = hs.namespacer(c.OrgID)

--- a/pkg/api/bootdata.go
+++ b/pkg/api/bootdata.go
@@ -207,6 +207,7 @@ func (hs *HTTPServer) getFrontendSettings(c *contextmodel.ReqContext) (*dtos.Fro
 		DisableLogin:                  hs.Cfg.DisableLogin,
 		BasicAuthStrongPasswordPolicy: hs.Cfg.BasicAuthStrongPasswordPolicy,
 		DisableSignoutMenu:            hs.Cfg.DisableSignoutMenu,
+		DisableForgotPassword:         hs.Cfg.DisableForgotPassword,
 	}
 
 	frontendSettings.Namespace = hs.namespacer(c.OrgID)

--- a/pkg/api/dtos/frontend_settings.go
+++ b/pkg/api/dtos/frontend_settings.go
@@ -34,6 +34,7 @@ type FrontendSettingsAuthDTO struct {
 	DisableLogin                  bool `json:"disableLogin"`
 	BasicAuthStrongPasswordPolicy bool `json:"basicAuthStrongPasswordPolicy"`
 	DisableSignoutMenu            bool `json:"disableSignoutMenu"`
+	DisableForgotPassword         bool `json:"disableForgotPassword"`
 }
 
 type FrontendSettingsBuildInfoDTO struct {

--- a/pkg/api/password.go
+++ b/pkg/api/password.go
@@ -19,6 +19,10 @@ func (hs *HTTPServer) SendResetPasswordEmail(c *contextmodel.ReqContext) respons
 		return response.Error(http.StatusUnauthorized, "Not allowed to reset password when login form is disabled", nil)
 	}
 
+	if hs.Cfg.DisableForgotPassword {
+		return response.Error(http.StatusUnauthorized, "Not allowed to reset password when password reset is disabled", nil)
+	}
+
 	c.Req.Body = http.MaxBytesReader(c.Resp, c.Req.Body, maxPreAuthFormBodySize)
 
 	form := dtos.SendResetPasswordEmailForm{}
@@ -59,6 +63,10 @@ func (hs *HTTPServer) ResetPassword(c *contextmodel.ReqContext) response.Respons
 	if hs.Cfg.DisableLoginForm || hs.Cfg.DisableLogin {
 		return response.Error(http.StatusUnauthorized,
 			"Not allowed to reset password when grafana authentication is disabled", nil)
+	}
+
+	if hs.Cfg.DisableForgotPassword {
+		return response.Error(http.StatusUnauthorized, "Not allowed to reset password when password reset is disabled", nil)
 	}
 
 	c.Req.Body = http.MaxBytesReader(c.Resp, c.Req.Body, maxPreAuthFormBodySize)

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -344,6 +344,7 @@ type Cfg struct {
 	DisableLogin                      bool
 	AdminEmail                        string
 	DisableLoginForm                  bool
+	DisableForgotPassword             bool
 	SignoutRedirectUrl                string
 	IDResponseHeaderEnabled           bool
 	IDResponseHeaderPrefix            string
@@ -2122,6 +2123,7 @@ func readAuthSettings(iniFile *ini.File, cfg *Cfg) (err error) {
 
 	cfg.DisableLoginForm = auth.Key("disable_login_form").MustBool(false)
 	cfg.DisableSignoutMenu = auth.Key("disable_signout_menu").MustBool(false)
+	cfg.DisableForgotPassword = auth.Key("disable_forgot_password").MustBool(false)
 
 	// Deprecated
 	cfg.OAuthAutoLogin = auth.Key("oauth_auto_login").MustBool(false)

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -349,6 +349,7 @@ type Cfg struct {
 	DisableLogin                      bool
 	AdminEmail                        string
 	DisableLoginForm                  bool
+	DisableForgotPassword             bool
 	SignoutRedirectUrl                string
 	IDResponseHeaderEnabled           bool
 	IDResponseHeaderPrefix            string
@@ -2128,6 +2129,7 @@ func readAuthSettings(iniFile *ini.File, cfg *Cfg) (err error) {
 
 	cfg.DisableLoginForm = auth.Key("disable_login_form").MustBool(false)
 	cfg.DisableSignoutMenu = auth.Key("disable_signout_menu").MustBool(false)
+	cfg.DisableForgotPassword = auth.Key("disable_forgot_password").MustBool(false)
 
 	// Deprecated
 	cfg.OAuthAutoLogin = auth.Key("oauth_auto_login").MustBool(false)

--- a/public/app/core/components/Login/LoginPage.test.tsx
+++ b/public/app/core/components/Login/LoginPage.test.tsx
@@ -16,6 +16,7 @@ setupMockServer();
 
 const originalOauth = config.oauth;
 const originalLoginError = config.loginError;
+const originalDisableForgotPassword = config.auth.disableForgotPassword;
 
 const mockLocationAssign = jest.fn();
 const originalLocation = window.location;
@@ -32,6 +33,7 @@ afterEach(() => {
   mockLocationAssign.mockClear();
   config.oauth = originalOauth;
   config.loginError = originalLoginError;
+  config.auth.disableForgotPassword = originalDisableForgotPassword;
 });
 
 describe('Login Page', () => {
@@ -51,6 +53,15 @@ describe('Login Page', () => {
 
     expect(screen.getByRole('link', { name: 'Sign up' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: 'Sign up' })).toHaveAttribute('href', '/signup');
+  });
+
+  it('hides the forgot password link when disableForgotPassword is set', () => {
+    config.auth.disableForgotPassword = true;
+
+    render(<LoginPage />);
+
+    expect(screen.queryByRole('link', { name: 'Forgot your password?' })).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Log in' })).toBeInTheDocument();
   });
 
   it('should pass validation checks for username field', async () => {

--- a/public/app/core/components/Login/LoginPage.tsx
+++ b/public/app/core/components/Login/LoginPage.tsx
@@ -55,7 +55,7 @@ const LoginPage = () => {
                     isLoggingIn={isLoggingIn}
                   >
                     <Stack justifyContent="flex-end">
-                      {!config.auth.disableLogin && (
+                      {!config.auth.disableLogin && !config.auth.disableForgotPassword && (
                         <LinkButton
                           className={styles.forgottenPassword}
                           fill="text"


### PR DESCRIPTION
**What is this feature?**

A new `[auth]` setting that hides the "Forgot your password?" link on the login page:

```ini
[auth]
disable_forgot_password = true
```

It defaults to `false`, so nothing changes for existing installations. The setting only affects the login page. The password reset endpoint keeps working, so a local account that still needs a reset can reach it directly.

**Why do we need this feature?**

With mixed authentication, say basic auth for the admin account and LDAP for everyone else, the link shows up for every user. LDAP users click it, the reset doesn't do anything for them, and someone has to explain why. #79895 already hides the link when LDAP is the only auth method, but not when basic auth is enabled alongside it, which is the common setup when you need a local admin account.

**Who is this feature for?**

Administrators running Grafana against an external identity provider such as LDAP, AD, OAuth, or SAML, who keep one or two local accounts for admin access.

**Which issue(s) does this PR fix?**:

Fixes #113075

**Special notes for your reviewer:**

The wiring follows `disable_signout_menu`: read the key in `readAuthSettings`, add it to `FrontendSettingsAuthDTO`, pass it through `bootdata.go`, add it to `AuthSettings` in `@grafana/data`, and check it in `LoginPage.tsx`. Ten files, +41/-1, and most of that is config samples and docs.

The setting is independent of `disable_login_form` and `disable_login`, so you can keep the login form visible and hide only the reset link. `AddChangePasswordLink()` is untouched, since that link is for users who are already signed in.

One design note. I originally had this return 401 from `SendResetPasswordEmail` and `ResetPassword` as well, on the theory that hiding a link is easy to bypass. I've dropped that. #113075 asks for the endpoint to stay reachable, and blocking it breaks the exact setup the issue describes, where the single local admin among LDAP users would lose password reset along with everyone else. This setting is about removing a confusing link, not about locking down the reset flow, and `disable_login_form` already covers the latter. The docs now say so in both places. Happy to add the block back if you'd rather have it.

Please check that:

- [x] It works as expected from a user's perspective.
- [x] Default behavior is unchanged.
- [x] The docs are updated in the configuration reference and on the Grafana authentication page.
