### PR TITLE
Alerting: Remote Alertmanager to use config status API

### DIFF
--- a/pkg/services/ngalert/remote/alertmanager.go
+++ b/pkg/services/ngalert/remote/alertmanager.go
@@ -716,14 +716,14 @@ func (am *Alertmanager) shouldSendConfig(ctx context.Context, newCfg remoteClien
 	if newCfg.Hash == "" { // empty hash means that something went wrong while calculating it. In this case, always send the config.
 		return true
 	}
-	rc, err := am.mimirClient.GetGrafanaAlertmanagerConfig(ctx)
+	rc, err := am.mimirClient.GetGrafanaAlertmanagerConfigStatus(ctx)
 	if err != nil {
 		// Log the error and return true so we try to upload our config anyway.
 		am.log.Warn("Unable to get the remote Alertmanager configuration for comparison, sending the configuration without comparing", "err", err)
 		return true
 	}
 	if rc.Hash != newCfg.Hash {
-		am.log.Debug("Hash of the remote Alertmanager configuration is different, sending the configuration", "remoteHash", rc.Hash, "hash", newCfg.Hash)
+		am.log.Info("Hash of the remote Alertmanager configuration is different, sending the configuration", "remoteHash", rc.Hash, "remoteCreatedAt", rc.CreatedAt, "hash", newCfg.Hash, "createdAt", newCfg.CreatedAt)
 		return true
 	}
 	return false

--- a/pkg/services/ngalert/remote/client/alertmanager_configuration.go
+++ b/pkg/services/ngalert/remote/client/alertmanager_configuration.go
@@ -11,8 +11,9 @@ import (
 )
 
 const (
-	grafanaAlertmanagerConfigPath    = "/api/v1/grafana/config"
-	grafanaAlertmanagerReceiversPath = "/api/v1/grafana/receivers"
+	grafanaAlertmanagerConfigPath       = "/api/v1/grafana/config"
+	grafanaAlertmanagerConfigStatusPath = "/api/v1/grafana/config/status"
+	grafanaAlertmanagerReceiversPath    = "/api/v1/grafana/receivers"
 )
 
 type GrafanaAlertmanagerConfig struct {
@@ -41,6 +42,30 @@ type UserGrafanaConfig struct {
 	ExternalURL               string                    `json:"external_url"`
 	SmtpConfig                SmtpConfig                `json:"smtp_config"`
 	RuntimeConfig             RuntimeConfig             `json:"runtime_config"`
+}
+
+type GrafanaAlertmanagerConfigStatus struct {
+	Hash      string `json:"configuration_hash"`
+	CreatedAt int64  `json:"created"`
+}
+
+func (mc *Mimir) GetGrafanaAlertmanagerConfigStatus(ctx context.Context) (*GrafanaAlertmanagerConfigStatus, error) {
+	status := &GrafanaAlertmanagerConfigStatus{}
+	response := successResponse{
+		Data: status,
+	}
+	// nolint:bodyclose
+	// closed within `do`
+	_, err := mc.do(ctx, grafanaAlertmanagerConfigStatusPath, http.MethodGet, nil, &response)
+	if err != nil {
+		return nil, err
+	}
+
+	if response.Status != "success" {
+		return nil, fmt.Errorf("returned non-success `status` from the MimirAPI: %s", response.Status)
+	}
+
+	return status, nil
 }
 
 func (mc *Mimir) GetGrafanaAlertmanagerConfig(ctx context.Context) (*UserGrafanaConfig, error) {

--- a/pkg/services/ngalert/remote/client/mimir.go
+++ b/pkg/services/ngalert/remote/client/mimir.go
@@ -33,6 +33,7 @@ type MimirClient interface {
 	DeleteGrafanaAlertmanagerState(ctx context.Context) error
 
 	GetGrafanaAlertmanagerConfig(ctx context.Context) (*UserGrafanaConfig, error)
+	GetGrafanaAlertmanagerConfigStatus(ctx context.Context) (*GrafanaAlertmanagerConfigStatus, error)
 	CreateGrafanaAlertmanagerConfig(ctx context.Context, config *UserGrafanaConfig) error
 	DeleteGrafanaAlertmanagerConfig(ctx context.Context) error
 


### PR DESCRIPTION
---

**What is this feature?**

This update changes the approach for checking remote configuration hashes by using the config status API to directly compare hashes, rather than retrieving the entire configuration.

**Why do we need this feature?**

It provides a more efficient method for validating configuration changes, reducing overhead and enhancing performance.

**Who is this feature for?**

This feature is for developers and system administrators who need a streamlined mechanism for validating remote configurations.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

Related to https://github.com/grafana/grafana/pull/108554 and https://github.com/grafana/mimir/pull/12129