### PR TITLE
Homepage: Add extension points for extra content

### DIFF
--- a/packages/grafana-data/src/types/pluginExtensions.ts
+++ b/packages/grafana-data/src/types/pluginExtensions.ts
@@ -239,6 +239,8 @@ export enum PluginExtensionPoints {
   AdvisorRetryCheck = 'grafana/advisor/retry-check/v1',
   NavRightButton = 'grafana/singletopbar/nav-right-button/v1',
   HomepageTabs = 'grafana/homepage/tabs/v1',
+  HomepagePre = 'grafana/homepage/pre/v1',
+  HomepageExtra = 'grafana/homepage/extra/v1',
 }
 
 // Don't use directly in a plugin!

--- a/packages/grafana-runtime/src/services/pluginExtensions/utils.tsx
+++ b/packages/grafana-runtime/src/services/pluginExtensions/utils.tsx
@@ -81,11 +81,13 @@ export function renderLimitedComponents<Props extends {}>({
   components,
   limit,
   pluginId,
+  wrapper: Wrapper,
 }: {
   props: Props;
   components: Array<ComponentTypeWithExtensionMeta<Props>>;
   limit?: number;
   pluginId?: string | string[] | RegExp;
+  wrapper?: (props: { children: React.ReactNode }) => React.ReactNode;
 }) {
   const limitedComponents = getLimitedComponentsToRender({ props, components, limit, pluginId });
 
@@ -95,9 +97,15 @@ export function renderLimitedComponents<Props extends {}>({
 
   return (
     <>
-      {limitedComponents.map((Component) => (
-        <Component key={Component.meta.id} {...props} />
-      ))}
+      {limitedComponents.map((Component) =>
+        Wrapper ? (
+          <Wrapper key={Component.meta.id}>
+            <Component {...props} />
+          </Wrapper>
+        ) : (
+          <Component key={Component.meta.id} {...props} />
+        )
+      )}
     </>
   );
 }

--- a/public/app/core/components/AppChrome/AppChromeExtensionPoint.tsx
+++ b/public/app/core/components/AppChrome/AppChromeExtensionPoint.tsx
@@ -2,6 +2,7 @@ import type { JSX } from 'react';
 
 import { PluginExtensionPoints } from '@grafana/data';
 import { config, renderLimitedComponents, usePluginComponents } from '@grafana/runtime';
+import { SETUPGUIDE_PLUGIN_ID } from 'app/core/constants';
 import { useGrafana } from 'app/core/context/GrafanaContext';
 
 export function AppChromeExtensionPoint(): JSX.Element | null {
@@ -32,6 +33,6 @@ function InternalAppChromeExtensionPoint(): JSX.Element | null {
   return renderLimitedComponents({
     props: {},
     components: components,
-    pluginId: 'grafana-setupguide-app',
+    pluginId: SETUPGUIDE_PLUGIN_ID,
   });
 }

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuExtensionPoint.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuExtensionPoint.tsx
@@ -1,5 +1,6 @@
 import { PluginExtensionPoints } from '@grafana/data';
 import { renderLimitedComponents } from '@grafana/runtime';
+import { SETUPGUIDE_PLUGIN_ID } from 'app/core/constants';
 import { usePluginComponents } from 'app/features/plugins/extensions/usePluginComponents';
 
 /**
@@ -20,6 +21,6 @@ export function MegaMenuExtensionPoint() {
     props: {},
     components: components,
     limit: 1,
-    pluginId: 'grafana-setupguide-app',
+    pluginId: SETUPGUIDE_PLUGIN_ID,
   });
 }

--- a/public/app/core/components/AppChrome/TopBar/InviteUserButton.tsx
+++ b/public/app/core/components/AppChrome/TopBar/InviteUserButton.tsx
@@ -5,6 +5,7 @@ import { t } from '@grafana/i18n';
 import { renderLimitedComponents } from '@grafana/runtime';
 import { ToolbarButton } from '@grafana/ui';
 import { useGetCurrentOrgQuotaQuery } from 'app/api/clients/legacy';
+import { SETUPGUIDE_PLUGIN_ID } from 'app/core/constants';
 import { useMediaQueryMinWidth } from 'app/core/hooks/useMediaQueryMinWidth';
 import { usePluginComponents } from 'app/features/plugins/extensions/usePluginComponents';
 
@@ -27,7 +28,7 @@ export function NavRightButton() {
       props: {},
       components,
       limit: 1,
-      pluginId: 'grafana-setupguide-app',
+      pluginId: SETUPGUIDE_PLUGIN_ID,
     }) ?? <InviteUserButton />
   );
 }

--- a/public/app/core/components/AppChrome/TopBar/TopBarExtensionPoint.tsx
+++ b/public/app/core/components/AppChrome/TopBar/TopBarExtensionPoint.tsx
@@ -1,5 +1,6 @@
 import { PluginExtensionPoints } from '@grafana/data';
 import { renderLimitedComponents } from '@grafana/runtime';
+import { SETUPGUIDE_PLUGIN_ID } from 'app/core/constants';
 import { usePluginComponents } from 'app/features/plugins/extensions/usePluginComponents';
 
 /**
@@ -20,6 +21,6 @@ export function TopBarExtensionPoint() {
     props: {},
     components: components,
     limit: 1,
-    pluginId: 'grafana-setupguide-app',
+    pluginId: SETUPGUIDE_PLUGIN_ID,
   });
 }

--- a/public/app/core/constants.ts
+++ b/public/app/core/constants.ts
@@ -20,3 +20,8 @@ export const DEFAULT_PER_PAGE_PAGINATION = 40;
 
 export const LS_VISUALIZATION_SELECT_TAB_KEY = 'VisualizationSelectPane.ListMode';
 export const MEGA_MENU_TOGGLE_ID = 'mega-menu-toggle';
+
+/**
+ * grafana-setupguide-app plugin ID, used in extension points to provide Cloud-only UI functionality.
+ */
+export const SETUPGUIDE_PLUGIN_ID = 'grafana-setupguide-app';

--- a/public/app/features/dashboard/dashgrid/DashboardEmpty/DashboardEmptyExtensionPoint.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardEmpty/DashboardEmptyExtensionPoint.tsx
@@ -3,6 +3,7 @@ import type { JSX } from 'react';
 import { PluginExtensionPoints } from '@grafana/data';
 import { config, renderLimitedComponents, usePluginComponents } from '@grafana/runtime';
 import PageLoader from 'app/core/components/PageLoader/PageLoader';
+import { SETUPGUIDE_PLUGIN_ID } from 'app/core/constants';
 
 interface DashboardEmptyExtensionPointProps {
   renderDefaultUI: () => JSX.Element;
@@ -36,7 +37,7 @@ function InternalDashboardEmptyExtensionPoint(props: DashboardEmptyExtensionPoin
       // We only ever want one component to replace the default empty state UI (so that we don't end up with two competing/default UIs being rendered).
       // And, currently, we only want to allow setupguide-app to be able to do this.
       limit: 1,
-      pluginId: 'grafana-setupguide-app',
+      pluginId: SETUPGUIDE_PLUGIN_ID,
     }) ?? props.renderDefaultUI()
   );
 }

--- a/public/app/features/home/DashboardTabs/DashboardTabs.test.tsx
+++ b/public/app/features/home/DashboardTabs/DashboardTabs.test.tsx
@@ -1,14 +1,18 @@
 import { http, HttpResponse } from 'msw';
+import { useEffect, type ReactNode } from 'react';
 import { render, screen, waitFor } from 'test/test-utils';
 
 import { type DashboardHit } from '@grafana/api-clients/rtkq/dashboard/v0alpha1';
+import { type ComponentTypeWithExtensionMeta, PluginExtensionPoints } from '@grafana/data';
 import { setBackendSrv, setPluginComponentsHook } from '@grafana/runtime';
 import { getCustomSearchHandler } from '@grafana/test-utils/handlers';
 import server, { setupMockServer } from '@grafana/test-utils/server';
 import { backendSrv } from 'app/core/services/backend_srv';
 import { contextSrv } from 'app/core/services/context_srv';
+import { createComponentWithMeta } from 'app/features/plugins/extensions/usePluginComponents';
 
 import { DashboardTabs } from './DashboardTabs';
+import { type HomepageTabExtensionProps } from './types';
 
 setBackendSrv(backendSrv);
 setupMockServer();
@@ -47,6 +51,25 @@ beforeEach(() => {
   window.localStorage.removeItem(impressionKey);
   seedStars([]);
 });
+
+const createDashboardTabsExtensionComponent = (
+  pluginId: string,
+  id: string,
+  label: string,
+  content: ReactNode,
+  href?: string
+): ComponentTypeWithExtensionMeta<{}> =>
+  createComponentWithMeta(
+    {
+      pluginId,
+      title: label,
+      component: (({ register, active }: HomepageTabExtensionProps) => {
+        useEffect(() => register({ id, label, href }), [register]);
+        return active ? <div>{content}</div> : null;
+      }) as React.ComponentType,
+    },
+    PluginExtensionPoints.HomepageTabs
+  );
 
 describe('DashboardTabs', () => {
   it('renders Recent tab as active by default and shows recent dashboards', async () => {
@@ -128,5 +151,39 @@ describe('DashboardTabs', () => {
     await waitFor(() => {
       expect(screen.getByText('Starred Dashboard 1')).toBeInTheDocument();
     });
+  });
+
+  it('renders extension tabs from plugins', async () => {
+    const extensionComponents = [
+      createDashboardTabsExtensionComponent(
+        'grafana-setupguide-app',
+        'tab-1',
+        'Plugin Tab 1',
+        <div>Content for Plugin Tab 1</div>
+      ),
+      createDashboardTabsExtensionComponent('grafana-setupguide-app', 'tab-2', 'Plugin Tab 2', null, '/test'),
+      createDashboardTabsExtensionComponent(
+        'grafana-untrusted-app',
+        'tab-3',
+        'Plugin Tab 3',
+        <div>Content for Plugin Tab 3</div>
+      ),
+    ];
+
+    setPluginComponentsHook(() => ({
+      components: extensionComponents,
+      isLoading: false,
+    }));
+
+    const { user } = render(<DashboardTabs />);
+
+    expect(await screen.findByRole('tab', { name: 'Plugin Tab 1' })).toBeInTheDocument();
+    expect(await screen.findByRole('tab', { name: 'Plugin Tab 2' })).toBeInTheDocument();
+    expect(screen.queryByRole('tab', { name: 'Plugin Tab 3' })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('tab', { name: 'Plugin Tab 1' }));
+    expect(await screen.findByText('Content for Plugin Tab 1')).toBeInTheDocument();
+
+    expect(screen.getByRole('tab', { name: 'Plugin Tab 2' })).toHaveAttribute('href', '/test');
   });
 });

--- a/public/app/features/home/DashboardTabs/DashboardTabs.test.tsx
+++ b/public/app/features/home/DashboardTabs/DashboardTabs.test.tsx
@@ -178,6 +178,8 @@ describe('DashboardTabs', () => {
     const { user } = render(<DashboardTabs />);
 
     expect(await screen.findByRole('tab', { name: 'Plugin Tab 1' })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: 'Plugin Tab 1' })).toHaveAttribute('aria-selected', 'true');
+
     expect(await screen.findByRole('tab', { name: 'Plugin Tab 2' })).toBeInTheDocument();
     expect(screen.queryByRole('tab', { name: 'Plugin Tab 3' })).not.toBeInTheDocument();
 

--- a/public/app/features/home/DashboardTabs/DashboardTabs.tsx
+++ b/public/app/features/home/DashboardTabs/DashboardTabs.tsx
@@ -5,7 +5,7 @@ import { useAsyncRetry } from 'react-use';
 import { type GrafanaTheme2, PluginExtensionPoints } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { usePluginComponents } from '@grafana/runtime';
-import { Box, ScrollContainer, Tab, TabContent, TabsBar, useStyles2 } from '@grafana/ui';
+import { ScrollContainer, Stack, Tab, TabContent, TabsBar, useStyles2 } from '@grafana/ui';
 import { getRecentlyViewedDashboards } from 'app/features/browse-dashboards/api/recentlyViewed';
 import { useDashboardLocationInfo } from 'app/features/search/hooks/useDashboardLocationInfo';
 import { getGrafanaSearcher } from 'app/features/search/service/searcher';
@@ -99,7 +99,7 @@ export function DashboardTabs() {
   const linkTabs = extensionTabs.filter((tab) => tab.href);
 
   return (
-    <Box backgroundColor="primary" borderRadius="default" padding={3} direction="column" display="flex" gap={2}>
+    <Stack direction="column" gap={2}>
       <TabsBar>
         {contentTabs.map((tab) => {
           const isActive = activeTab === tab.id;
@@ -150,13 +150,14 @@ export function DashboardTabs() {
       {extensionComponents.map((Component, i) => (
         <Component key={i} registerTab={registerTab} />
       ))}
-    </Box>
+    </Stack>
   );
 }
 
 const getStyles = (theme: GrafanaTheme2) => ({
   tabContent: css({
     padding: 0,
+    borderRadius: theme.shape.radius.default,
   }),
   linkTabsSpacer: css({
     flex: 1,

--- a/public/app/features/home/DashboardTabs/DashboardTabs.tsx
+++ b/public/app/features/home/DashboardTabs/DashboardTabs.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useAsyncRetry } from 'react-use';
 
-import { type GrafanaTheme2, PluginExtensionPoints } from '@grafana/data';
+import { type ComponentTypeWithExtensionMeta, PluginExtensionPoints, type GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { usePluginComponents } from '@grafana/runtime';
 import { ScrollContainer, Stack, Tab, TabContent, TabsBar, useStyles2 } from '@grafana/ui';
@@ -12,15 +12,41 @@ import { getGrafanaSearcher } from 'app/features/search/service/searcher';
 
 import { RecentDashboardsTab } from './RecentDashboardsTab';
 import { StarredDashboardsTab } from './StarredDashboardsTab';
-import { type HomepageTab } from './types';
+import { type HomepageTabExtensionProps, isHomepageTab, type HomepageTab } from './types';
 
 const RECENT_TAB_ID = 'recent';
 const STARRED_TAB_ID = 'starred';
 const MAX_RECENT = 20;
 const MAX_STARRED = 30;
 
-interface HomepageTabExtensionProps {
-  registerTab: (tab: HomepageTab) => void;
+function DashboardExtensionTab({
+  Component,
+  registerTab,
+  activeTab,
+}: {
+  Component: ComponentTypeWithExtensionMeta<HomepageTabExtensionProps>;
+  registerTab: (tab: HomepageTab) => () => void;
+  activeTab: string;
+}) {
+  const [id, setId] = useState<string | null>(null);
+  const register = useCallback(
+    (tab: unknown) => {
+      if (!isHomepageTab(tab)) {
+        throw new Error(`Invalid tab object returned from extension: ${JSON.stringify(tab)}`);
+      }
+
+      setId(tab.id);
+      const unregister = registerTab(tab);
+
+      return () => {
+        setId(null);
+        unregister();
+      };
+    },
+    [registerTab]
+  );
+
+  return <Component register={register} active={activeTab === id} />;
 }
 
 export function DashboardTabs() {
@@ -54,12 +80,8 @@ export function DashboardTabs() {
   });
 
   const registerTab = useCallback((tab: HomepageTab) => {
-    setExtensionTabs((prev) => {
-      if (prev.some((t) => t.id === tab.id)) {
-        return prev;
-      }
-      return [...prev, tab];
-    });
+    setExtensionTabs((prev) => [...prev, tab]);
+    return () => setExtensionTabs((prev) => prev.filter((t) => t !== tab));
   }, []);
 
   // Auto-switch to the non-empty tab when initial data finishes loading
@@ -95,7 +117,7 @@ export function DashboardTabs() {
     },
   ];
 
-  const contentTabs = [...builtInTabs, ...extensionTabs.filter((tab) => tab.content)];
+  const contentTabs = [...builtInTabs, ...extensionTabs.filter((tab) => !tab.href)];
   const linkTabs = extensionTabs.filter((tab) => tab.href);
 
   return (
@@ -118,38 +140,38 @@ export function DashboardTabs() {
           <Tab key={tab.id} label={tab.label} icon={tab.icon} href={tab.href!} />
         ))}
       </TabsBar>
-      <TabContent className={styles.tabContent}>
-        <ScrollContainer showScrollIndicators maxHeight="256px" minHeight="256px">
-          {activeTab === RECENT_TAB_ID && (
-            <RecentDashboardsTab
-              dashboards={recentDashboards ?? []}
-              loading={recentLoading}
-              error={recentError}
-              retry={recentRetry}
-              foldersByUid={foldersByUid}
-            />
-          )}
-          {activeTab === STARRED_TAB_ID && (
-            <StarredDashboardsTab
-              dashboards={starredDashboards ?? []}
-              loading={starredLoading}
-              error={starredError}
-              retry={starredRetry}
-              foldersByUid={foldersByUid}
-            />
-          )}
-          {extensionTabs
-            .filter((tab) => tab.content && activeTab === tab.id)
-            .map((tab) => (
-              <div key={tab.id}>{tab.content}</div>
-            ))}
-        </ScrollContainer>
-      </TabContent>
 
-      {/* Render extension components (they return null, just register tabs) */}
-      {extensionComponents.map((Component, i) => (
-        <Component key={i} registerTab={registerTab} />
-      ))}
+      {(activeTab === RECENT_TAB_ID || activeTab === STARRED_TAB_ID) && (
+        <TabContent className={styles.tabContent}>
+          <ScrollContainer showScrollIndicators maxHeight="256px" minHeight="256px">
+            {activeTab === RECENT_TAB_ID && (
+              <RecentDashboardsTab
+                dashboards={recentDashboards ?? []}
+                loading={recentLoading}
+                error={recentError}
+                retry={recentRetry}
+                foldersByUid={foldersByUid}
+              />
+            )}
+            {activeTab === STARRED_TAB_ID && (
+              <StarredDashboardsTab
+                dashboards={starredDashboards ?? []}
+                loading={starredLoading}
+                error={starredError}
+                retry={starredRetry}
+                foldersByUid={foldersByUid}
+              />
+            )}
+          </ScrollContainer>
+        </TabContent>
+      )}
+
+      {/* Render extension component tabs without background + scroller */}
+      {extensionComponents
+        .filter((Component) => Component.meta.pluginId === 'grafana-setupguide-app')
+        .map((Component, i) => (
+          <DashboardExtensionTab key={i} Component={Component} registerTab={registerTab} activeTab={activeTab} />
+        ))}
     </Stack>
   );
 }

--- a/public/app/features/home/DashboardTabs/DashboardTabs.tsx
+++ b/public/app/features/home/DashboardTabs/DashboardTabs.tsx
@@ -90,17 +90,31 @@ export function DashboardTabs() {
     if (didAutoSwitch.current || recentLoading || starredLoading) {
       return;
     }
-    didAutoSwitch.current = true;
 
     const recentEmpty = !recentDashboards?.length;
     const starredEmpty = !starredDashboards?.length;
 
     if (activeTab === RECENT_TAB_ID && recentEmpty && !starredEmpty) {
       setActiveTab(STARRED_TAB_ID);
-    } else if (activeTab === STARRED_TAB_ID && starredEmpty && !recentEmpty) {
-      setActiveTab(RECENT_TAB_ID);
+      didAutoSwitch.current = true;
+      return;
     }
-  }, [recentLoading, starredLoading, recentDashboards, starredDashboards, activeTab]);
+
+    if (activeTab === STARRED_TAB_ID && starredEmpty && !recentEmpty) {
+      setActiveTab(RECENT_TAB_ID);
+      didAutoSwitch.current = true;
+      return;
+    }
+
+    if ((activeTab === RECENT_TAB_ID || activeTab === STARRED_TAB_ID) && recentEmpty && starredEmpty) {
+      const extensionTab = extensionTabs.find((tab) => !tab.href);
+      if (extensionTab) {
+        setActiveTab(extensionTab.id);
+        didAutoSwitch.current = true;
+        return;
+      }
+    }
+  }, [recentLoading, starredLoading, recentDashboards, starredDashboards, extensionTabs, activeTab]);
 
   const builtInTabs: HomepageTab[] = [
     {

--- a/public/app/features/home/DashboardTabs/DashboardTabs.tsx
+++ b/public/app/features/home/DashboardTabs/DashboardTabs.tsx
@@ -6,6 +6,7 @@ import { type ComponentTypeWithExtensionMeta, PluginExtensionPoints, type Grafan
 import { t } from '@grafana/i18n';
 import { usePluginComponents } from '@grafana/runtime';
 import { ScrollContainer, Stack, Tab, TabContent, TabsBar, useStyles2 } from '@grafana/ui';
+import { SETUPGUIDE_PLUGIN_ID } from 'app/core/constants';
 import { getRecentlyViewedDashboards } from 'app/features/browse-dashboards/api/recentlyViewed';
 import { useDashboardLocationInfo } from 'app/features/search/hooks/useDashboardLocationInfo';
 import { getGrafanaSearcher } from 'app/features/search/service/searcher';
@@ -182,7 +183,7 @@ export function DashboardTabs() {
 
       {/* Render extension component tabs without background + scroller */}
       {extensionComponents
-        .filter((Component) => Component.meta.pluginId === 'grafana-setupguide-app')
+        .filter((Component) => Component.meta.pluginId === SETUPGUIDE_PLUGIN_ID)
         .map((Component, i) => (
           <DashboardExtensionTab key={i} Component={Component} registerTab={registerTab} activeTab={activeTab} />
         ))}

--- a/public/app/features/home/DashboardTabs/DashboardTabs.tsx
+++ b/public/app/features/home/DashboardTabs/DashboardTabs.tsx
@@ -13,7 +13,7 @@ import { getGrafanaSearcher } from 'app/features/search/service/searcher';
 
 import { RecentDashboardsTab } from './RecentDashboardsTab';
 import { StarredDashboardsTab } from './StarredDashboardsTab';
-import { type HomepageTabExtensionProps, isHomepageTab, type HomepageTab } from './types';
+import { type HomepageTabExtensionProps, type HomepageTab, validateHomepageTab } from './types';
 
 const RECENT_TAB_ID = 'recent';
 const STARRED_TAB_ID = 'starred';
@@ -32,9 +32,7 @@ function DashboardExtensionTab({
   const [id, setId] = useState<string | null>(null);
   const register = useCallback(
     (tab: unknown) => {
-      if (!isHomepageTab(tab)) {
-        throw new Error(`Invalid tab object returned from extension: ${JSON.stringify(tab)}`);
-      }
+      validateHomepageTab(tab);
 
       setId(tab.id);
       const unregister = registerTab(tab);

--- a/public/app/features/home/DashboardTabs/RecentDashboardsTab.tsx
+++ b/public/app/features/home/DashboardTabs/RecentDashboardsTab.tsx
@@ -118,7 +118,7 @@ const getStyles = (theme: GrafanaTheme2) => ({
 
     svg: {
       position: 'relative',
-      top: 1,
+      top: 0.5,
     },
   }),
 });

--- a/public/app/features/home/DashboardTabs/RecentDashboardsTab.tsx
+++ b/public/app/features/home/DashboardTabs/RecentDashboardsTab.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
-import { Alert, Button, EmptyState, LinkButton, useStyles2 } from '@grafana/ui';
+import { Alert, Button, EmptyState, LinkButton, Stack, useStyles2 } from '@grafana/ui';
 import PageLoader from 'app/core/components/PageLoader/PageLoader';
 import { contextSrv } from 'app/core/services/context_srv';
 import impressionSrv from 'app/core/services/impression_srv';
@@ -27,15 +27,19 @@ export function RecentDashboardsTab({ dashboards, loading, error, retry, folders
 
   if (error) {
     return (
-      <Alert
-        severity="warning"
-        title={t('home.recent-dashboards-tab.error-title', 'Could not load recently viewed dashboards')}
-        action={
-          <Button onClick={retry} variant="secondary" size="sm">
-            <Trans i18nKey="home.recent-dashboards-tab.retry">Retry</Trans>
-          </Button>
-        }
-      />
+      <Stack grow={1} direction="column" alignItems="center" justifyContent="center">
+        <div>
+          <Alert
+            severity="warning"
+            title={t('home.recent-dashboards-tab.error-title', 'Could not load recently viewed dashboards')}
+            action={
+              <Button onClick={retry} variant="secondary" size="sm">
+                <Trans i18nKey="home.recent-dashboards-tab.retry">Retry</Trans>
+              </Button>
+            }
+          />
+        </div>
+      </Stack>
     );
   }
 
@@ -43,27 +47,29 @@ export function RecentDashboardsTab({ dashboards, loading, error, retry, folders
     const canCreate = contextSrv.hasPermission(AccessControlAction.DashboardsCreate);
 
     return (
-      <EmptyState
-        hideImage
-        variant="call-to-action"
-        message={t('home.recent-dashboards-tab.empty', "Dashboards you've recently viewed will appear here.")}
-        button={
-          canCreate ? (
-            <LinkButton icon="plus" href="/dashboard/new">
-              <Trans i18nKey="home.recent-dashboards-tab.create">Create your first dashboard</Trans>
-            </LinkButton>
-          ) : (
-            <LinkButton icon="apps" href="/dashboards" variant="secondary">
-              <Trans i18nKey="home.recent-dashboards-tab.browse">Browse dashboards</Trans>
-            </LinkButton>
-          )
-        }
-      >
-        <Trans i18nKey="home.recent-dashboards-tab.empty-description">
-          After you&apos;ve connected data, you can use dashboards to query and visualize your data with charts, stats
-          and tables or create lists, markdowns and other widgets.
-        </Trans>
-      </EmptyState>
+      <Stack grow={1} direction="column" alignItems="center" justifyContent="center">
+        <EmptyState
+          hideImage
+          variant="call-to-action"
+          message={t('home.recent-dashboards-tab.empty', "Dashboards you've recently viewed will appear here.")}
+          button={
+            canCreate ? (
+              <LinkButton icon="plus" href="/dashboard/new">
+                <Trans i18nKey="home.recent-dashboards-tab.create">Create your first dashboard</Trans>
+              </LinkButton>
+            ) : (
+              <LinkButton icon="apps" href="/dashboards" variant="secondary">
+                <Trans i18nKey="home.recent-dashboards-tab.browse">Browse dashboards</Trans>
+              </LinkButton>
+            )
+          }
+        >
+          <Trans i18nKey="home.recent-dashboards-tab.empty-description">
+            After you&apos;ve connected data, you can use dashboards to query and visualize your data with charts, stats
+            and tables or create lists, markdowns and other widgets.
+          </Trans>
+        </EmptyState>
+      </Stack>
     );
   }
 
@@ -73,7 +79,7 @@ export function RecentDashboardsTab({ dashboards, loading, error, retry, folders
   };
 
   return (
-    <div className={styles.wrapper}>
+    <Stack grow={1} direction="column">
       <ul className={styles.list}>
         {dashboards.map((dash) => (
           <li key={dash.uid}>
@@ -93,16 +99,11 @@ export function RecentDashboardsTab({ dashboards, loading, error, retry, folders
           <Trans i18nKey="home.recent-dashboards-tab.clear">Clear history</Trans>
         </Button>
       </div>
-    </div>
+    </Stack>
   );
 }
 
 const getStyles = (theme: GrafanaTheme2) => ({
-  wrapper: css({
-    display: 'flex',
-    flexDirection: 'column',
-    flex: 1,
-  }),
   list: css({
     listStyle: 'none',
     padding: 0,

--- a/public/app/features/home/DashboardTabs/RecentDashboardsTab.tsx
+++ b/public/app/features/home/DashboardTabs/RecentDashboardsTab.tsx
@@ -28,6 +28,7 @@ export function RecentDashboardsTab({ dashboards, loading, error, retry, folders
   if (error) {
     return (
       <Stack grow={1} direction="column" alignItems="center" justifyContent="center">
+        {/* Extra div as Alert will flex-grow by default, but we want it centered */}
         <div>
           <Alert
             severity="warning"

--- a/public/app/features/home/DashboardTabs/RecentDashboardsTab.tsx
+++ b/public/app/features/home/DashboardTabs/RecentDashboardsTab.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/css';
 
+import { type GrafanaTheme2 } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 import { Alert, Button, EmptyState, LinkButton, useStyles2 } from '@grafana/ui';
 import PageLoader from 'app/core/components/PageLoader/PageLoader';
@@ -88,7 +89,7 @@ export function RecentDashboardsTab({ dashboards, loading, error, retry, folders
         ))}
       </ul>
       <div className={styles.clearButton}>
-        <Button icon="times" size="xs" variant="secondary" fill="text" onClick={handleClearHistory}>
+        <Button icon="times" size="sm" variant="secondary" fill="text" onClick={handleClearHistory}>
           <Trans i18nKey="home.recent-dashboards-tab.clear">Clear history</Trans>
         </Button>
       </div>
@@ -96,7 +97,7 @@ export function RecentDashboardsTab({ dashboards, loading, error, retry, folders
   );
 }
 
-const getStyles = () => ({
+const getStyles = (theme: GrafanaTheme2) => ({
   wrapper: css({
     display: 'flex',
     flexDirection: 'column',
@@ -110,7 +111,12 @@ const getStyles = () => ({
   clearButton: css({
     display: 'flex',
     justifyContent: 'flex-end',
-    paddingTop: 4,
+    padding: theme.spacing(1),
     marginTop: 'auto',
+
+    svg: {
+      position: 'relative',
+      top: 1,
+    },
   }),
 });

--- a/public/app/features/home/DashboardTabs/StarredDashboardsTab.tsx
+++ b/public/app/features/home/DashboardTabs/StarredDashboardsTab.tsx
@@ -24,6 +24,7 @@ export function StarredDashboardsTab({ dashboards, loading, error, retry, folder
   if (error) {
     return (
       <Stack grow={1} direction="column" alignItems="center" justifyContent="center">
+        {/* Extra div as Alert will flex-grow by default, but we want it centered */}
         <div>
           <Alert
             severity="warning"

--- a/public/app/features/home/DashboardTabs/StarredDashboardsTab.tsx
+++ b/public/app/features/home/DashboardTabs/StarredDashboardsTab.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
 
 import { t, Trans } from '@grafana/i18n';
-import { Alert, Button, EmptyState, Icon, useStyles2 } from '@grafana/ui';
+import { Alert, Button, EmptyState, Icon, Stack, useStyles2 } from '@grafana/ui';
 import PageLoader from 'app/core/components/PageLoader/PageLoader';
 import { type DashboardQueryResult, type LocationInfo } from 'app/features/search/service/types';
 import { DashListItem } from 'app/plugins/panel/dashlist/DashListItem';
@@ -23,29 +23,35 @@ export function StarredDashboardsTab({ dashboards, loading, error, retry, folder
 
   if (error) {
     return (
-      <Alert
-        severity="warning"
-        title={t('home.starred-dashboards-tab.error-title', 'Could not load starred dashboards')}
-        action={
-          <Button onClick={retry} variant="secondary" size="sm">
-            <Trans i18nKey="home.starred-dashboards-tab.retry">Retry</Trans>
-          </Button>
-        }
-      />
+      <Stack grow={1} direction="column" alignItems="center" justifyContent="center">
+        <div>
+          <Alert
+            severity="warning"
+            title={t('home.starred-dashboards-tab.error-title', 'Could not load starred dashboards')}
+            action={
+              <Button onClick={retry} variant="secondary" size="sm">
+                <Trans i18nKey="home.starred-dashboards-tab.retry">Retry</Trans>
+              </Button>
+            }
+          />
+        </div>
+      </Stack>
     );
   }
 
   if (dashboards.length === 0) {
     return (
-      <EmptyState
-        hideImage
-        variant="completed"
-        message={t('home.starred-dashboards-tab.empty', 'Your starred dashboards will appear here.')}
-      >
-        <Trans i18nKey="home.starred-dashboards-tab.empty-description">
-          You can star your favorite dashboards by clicking the <Icon name="star" /> from the dashboard page.
-        </Trans>
-      </EmptyState>
+      <Stack grow={1} direction="column" alignItems="center" justifyContent="center">
+        <EmptyState
+          hideImage
+          variant="completed"
+          message={t('home.starred-dashboards-tab.empty', 'Your starred dashboards will appear here.')}
+        >
+          <Trans i18nKey="home.starred-dashboards-tab.empty-description">
+            You can star your favorite dashboards by clicking the <Icon name="star" /> from the dashboard page.
+          </Trans>
+        </EmptyState>
+      </Stack>
     );
   }
 

--- a/public/app/features/home/DashboardTabs/types.ts
+++ b/public/app/features/home/DashboardTabs/types.ts
@@ -1,49 +1,28 @@
-import { type IconName } from '@grafana/data';
+import { z } from 'zod';
 
-export interface HomepageTab {
-  id: string;
-  label: string;
-  activeLabel?: string;
-  icon?: IconName;
+import { isIconName } from '@grafana/data';
+
+const HomepageTabSchema = z.object({
+  id: z.string(),
+  label: z.string(),
+  activeLabel: z.string().optional(),
+  icon: z.string().refine(isIconName, { error: 'Unknown icon' }).optional(),
   /** Tab is a link (rendered right-aligned) */
-  href?: string;
+  href: z.string().optional(),
   /** Item count shown as badge on the tab */
-  counter?: number;
+  counter: z.number().optional(),
+});
+
+export type HomepageTab = z.infer<typeof HomepageTabSchema>;
+
+export function validateHomepageTab(value: unknown): asserts value is HomepageTab {
+  const result = HomepageTabSchema.safeParse(value);
+  if (!result.success) {
+    throw new Error(`Invalid tab object returned from extension: ${z.prettifyError(result.error)}`);
+  }
 }
 
 export interface HomepageTabExtensionProps {
   active: boolean;
   register: (tab: HomepageTab) => () => void;
 }
-
-export const isHomepageTab = (obj: unknown): obj is HomepageTab => {
-  if (typeof obj !== 'object' || obj === null) {
-    return false;
-  }
-
-  if (!('id' in obj) || typeof obj.id !== 'string') {
-    return false;
-  }
-
-  if (!('label' in obj) || typeof obj.label !== 'string') {
-    return false;
-  }
-
-  if ('activeLabel' in obj && obj.activeLabel !== undefined && typeof obj.activeLabel !== 'string') {
-    return false;
-  }
-
-  if ('icon' in obj && obj.icon !== undefined && typeof obj.icon !== 'string') {
-    return false;
-  }
-
-  if ('href' in obj && obj.href !== undefined && typeof obj.href !== 'string') {
-    return false;
-  }
-
-  if ('counter' in obj && obj.counter !== undefined && typeof obj.counter !== 'number') {
-    return false;
-  }
-
-  return true;
-};

--- a/public/app/features/home/DashboardTabs/types.ts
+++ b/public/app/features/home/DashboardTabs/types.ts
@@ -1,5 +1,3 @@
-import { type ReactNode } from 'react';
-
 import { type IconName } from '@grafana/data';
 
 export interface HomepageTab {
@@ -7,10 +5,45 @@ export interface HomepageTab {
   label: string;
   activeLabel?: string;
   icon?: IconName;
-  /** Tab renders content inline */
-  content?: ReactNode;
   /** Tab is a link (rendered right-aligned) */
   href?: string;
   /** Item count shown as badge on the tab */
   counter?: number;
 }
+
+export interface HomepageTabExtensionProps {
+  active: boolean;
+  register: (tab: HomepageTab) => () => void;
+}
+
+export const isHomepageTab = (obj: unknown): obj is HomepageTab => {
+  if (typeof obj !== 'object' || obj === null) {
+    return false;
+  }
+
+  if (!('id' in obj) || typeof obj.id !== 'string') {
+    return false;
+  }
+
+  if (!('label' in obj) || typeof obj.label !== 'string') {
+    return false;
+  }
+
+  if ('activeLabel' in obj && obj.activeLabel !== undefined && typeof obj.activeLabel !== 'string') {
+    return false;
+  }
+
+  if ('icon' in obj && obj.icon !== undefined && typeof obj.icon !== 'string') {
+    return false;
+  }
+
+  if ('href' in obj && obj.href !== undefined && typeof obj.href !== 'string') {
+    return false;
+  }
+
+  if ('counter' in obj && obj.counter !== undefined && typeof obj.counter !== 'number') {
+    return false;
+  }
+
+  return true;
+};

--- a/public/app/features/home/HomePage.test.tsx
+++ b/public/app/features/home/HomePage.test.tsx
@@ -1,9 +1,11 @@
 import { render, screen } from 'test/test-utils';
 
+import { type ComponentTypeWithExtensionMeta, PluginExtensionPoints } from '@grafana/data';
 import { GrafanaEdition } from '@grafana/data/internal';
 import { config, setBackendSrv, setPluginComponentsHook } from '@grafana/runtime';
 import { setupMockServer } from '@grafana/test-utils/server';
 import { backendSrv } from 'app/core/services/backend_srv';
+import { createComponentWithMeta } from 'app/features/plugins/extensions/usePluginComponents';
 
 import HomePage from './HomePage';
 
@@ -13,6 +15,20 @@ setupMockServer();
 beforeEach(() => {
   setPluginComponentsHook(() => ({ components: [], isLoading: false }));
 });
+
+const createHomepageExtensionComponent = (
+  pluginId: string,
+  content: string,
+  extensionPointId: PluginExtensionPoints
+): ComponentTypeWithExtensionMeta<{}> =>
+  createComponentWithMeta(
+    {
+      pluginId,
+      title: content,
+      component: () => <div>{content}</div>,
+    },
+    extensionPointId
+  );
 
 describe('HomePage', () => {
   const originalBuildInfo = { ...config.buildInfo };
@@ -57,5 +73,63 @@ describe('HomePage', () => {
 
     render(<HomePage />);
     expect(await screen.findByText('Welcome to Grafana Cloud.')).toBeInTheDocument();
+  });
+
+  it('renders homepage pre extension components', async () => {
+    setPluginComponentsHook(({ extensionPointId }) => ({
+      isLoading: false,
+      components:
+        extensionPointId === PluginExtensionPoints.HomepagePre
+          ? [
+              createHomepageExtensionComponent(
+                'grafana-setupguide-app',
+                'Homepage pre extension',
+                PluginExtensionPoints.HomepagePre
+              ),
+              createHomepageExtensionComponent(
+                'grafana-untrusted-app',
+                'Untrusted homepage pre extension',
+                PluginExtensionPoints.HomepagePre
+              ),
+            ]
+          : [],
+    }));
+
+    render(<HomePage />);
+
+    expect(await screen.findByText('Homepage pre extension')).toBeInTheDocument();
+    expect(screen.queryByText('Untrusted homepage pre extension')).not.toBeInTheDocument();
+  });
+
+  it('renders homepage extra extension components', async () => {
+    setPluginComponentsHook(({ extensionPointId }) => ({
+      isLoading: false,
+      components:
+        extensionPointId === PluginExtensionPoints.HomepageExtra
+          ? [
+              createHomepageExtensionComponent(
+                'grafana-setupguide-app',
+                'Homepage extra extension 1',
+                PluginExtensionPoints.HomepageExtra
+              ),
+              createHomepageExtensionComponent(
+                'grafana-setupguide-app',
+                'Homepage extra extension 2',
+                PluginExtensionPoints.HomepageExtra
+              ),
+              createHomepageExtensionComponent(
+                'grafana-untrusted-app',
+                'Untrusted homepage extra extension',
+                PluginExtensionPoints.HomepageExtra
+              ),
+            ]
+          : [],
+    }));
+
+    render(<HomePage />);
+
+    expect(await screen.findByText('Homepage extra extension 1')).toBeInTheDocument();
+    expect(await screen.findByText('Homepage extra extension 2')).toBeInTheDocument();
+    expect(screen.queryByText('Untrusted homepage extra extension')).not.toBeInTheDocument();
   });
 });

--- a/public/app/features/home/HomePage.tsx
+++ b/public/app/features/home/HomePage.tsx
@@ -6,6 +6,7 @@ import { t } from '@grafana/i18n';
 import { config, renderLimitedComponents, usePluginComponents } from '@grafana/runtime';
 import { Box, Stack, useStyles2 } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
+import { SETUPGUIDE_PLUGIN_ID } from 'app/core/constants';
 import { isOnPrem } from 'app/core/utils/isOnPrem';
 
 import { DashboardTabs } from './DashboardTabs/DashboardTabs';
@@ -51,7 +52,7 @@ export default function HomePage() {
             {renderLimitedComponents({
               props: {},
               components: preComponents,
-              pluginId: 'grafana-setupguide-app',
+              pluginId: SETUPGUIDE_PLUGIN_ID,
             })}
             <DashboardTabs />
           </Box>
@@ -59,7 +60,7 @@ export default function HomePage() {
           {renderLimitedComponents({
             props: {},
             components: extraComponents,
-            pluginId: 'grafana-setupguide-app',
+            pluginId: SETUPGUIDE_PLUGIN_ID,
             wrapper: ({ children }) => (
               <div className={styles.extra}>
                 <Box backgroundColor="canvas" borderRadius="default" padding={4}>

--- a/public/app/features/home/HomePage.tsx
+++ b/public/app/features/home/HomePage.tsx
@@ -1,8 +1,10 @@
+import { css } from '@emotion/css';
+
 import { PageLayoutType, PluginExtensionPoints } from '@grafana/data';
 import { GrafanaEdition } from '@grafana/data/internal';
 import { t } from '@grafana/i18n';
 import { config, renderLimitedComponents, usePluginComponents } from '@grafana/runtime';
-import { Box, Stack } from '@grafana/ui';
+import { Box, Stack, useStyles2 } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import { isOnPrem } from 'app/core/utils/isOnPrem';
 
@@ -22,6 +24,7 @@ const getEdition = () => {
 };
 
 export default function HomePage() {
+  const styles = useStyles2(getStyles);
   const greeting = useHomeGreeting();
 
   const { components: preComponents } = usePluginComponents({
@@ -57,15 +60,28 @@ export default function HomePage() {
             props: {},
             components: extraComponents,
             pluginId: 'grafana-setupguide-app',
-            wrapper: ({ children }) =>
-              children && (
+            wrapper: ({ children }) => (
+              <div className={styles.extra}>
                 <Box backgroundColor="canvas" borderRadius="default" padding={4}>
                   {children}
                 </Box>
-              ),
+              </div>
+            ),
           })}
         </Stack>
       </Page.Contents>
     </Page>
   );
 }
+
+const getStyles = () => ({
+  extra: css({
+    display: 'contents',
+
+    '> div': {
+      '&:empty': {
+        display: 'none',
+      },
+    },
+  }),
+});

--- a/public/app/features/home/HomePage.tsx
+++ b/public/app/features/home/HomePage.tsx
@@ -1,8 +1,8 @@
-import { PageLayoutType } from '@grafana/data';
+import { PageLayoutType, PluginExtensionPoints } from '@grafana/data';
 import { GrafanaEdition } from '@grafana/data/internal';
 import { t } from '@grafana/i18n';
-import { config } from '@grafana/runtime';
-import { Box } from '@grafana/ui';
+import { config, renderLimitedComponents, usePluginComponents } from '@grafana/runtime';
+import { Box, Stack } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import { isOnPrem } from 'app/core/utils/isOnPrem';
 
@@ -24,6 +24,14 @@ const getEdition = () => {
 export default function HomePage() {
   const greeting = useHomeGreeting();
 
+  const { components: preComponents } = usePluginComponents({
+    extensionPointId: PluginExtensionPoints.HomepagePre,
+  });
+
+  const { components: extraComponents } = usePluginComponents({
+    extensionPointId: PluginExtensionPoints.HomepageExtra,
+  });
+
   return (
     <Page
       navId="home"
@@ -35,9 +43,28 @@ export default function HomePage() {
       layout={PageLayoutType.Home}
     >
       <Page.Contents>
-        <Box backgroundColor="canvas" borderRadius="default" padding={4}>
-          <DashboardTabs />
-        </Box>
+        <Stack direction="column" gap={2}>
+          <Box backgroundColor="canvas" borderRadius="default" padding={4} direction="column" display="flex" gap={2}>
+            {renderLimitedComponents({
+              props: {},
+              components: preComponents,
+              pluginId: 'grafana-setupguide-app',
+            })}
+            <DashboardTabs />
+          </Box>
+
+          {renderLimitedComponents({
+            props: {},
+            components: extraComponents,
+            pluginId: 'grafana-setupguide-app',
+            wrapper: ({ children }) =>
+              children && (
+                <Box backgroundColor="canvas" borderRadius="default" padding={4}>
+                  {children}
+                </Box>
+              ),
+          })}
+        </Stack>
       </Page.Contents>
     </Page>
   );

--- a/public/app/features/home/HomePage.tsx
+++ b/public/app/features/home/HomePage.tsx
@@ -2,6 +2,7 @@ import { PageLayoutType } from '@grafana/data';
 import { GrafanaEdition } from '@grafana/data/internal';
 import { t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
+import { Box } from '@grafana/ui';
 import { Page } from 'app/core/components/Page/Page';
 import { isOnPrem } from 'app/core/utils/isOnPrem';
 
@@ -34,7 +35,9 @@ export default function HomePage() {
       layout={PageLayoutType.Home}
     >
       <Page.Contents>
-        <DashboardTabs />
+        <Box backgroundColor="canvas" borderRadius="default" padding={4}>
+          <DashboardTabs />
+        </Box>
       </Page.Contents>
     </Page>
   );


### PR DESCRIPTION
**What is this feature?**

Introduces restricted extension points into the new homepage to allow additional content to be injected. Also, aligns the design with what is currently in place on the Cloud homepage.

**Why do we need this feature?**

To allow Grafana Cloud to reuse the OSS homepage with additional Cloud-only content injected.

**Who is this feature for?**

Developers.

**Which issue(s) does this PR fix?**:

Resolves #124142

**Special notes for your reviewer:**

Hooked up locally in https://github.com/grafana/grafana-setupguide-app/pull/1126 (🔐) and appears to be working!

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
