### PR TITLE
[authn-service] return failed auth error code

### DIFF
--- a/pkg/services/authn/authnserver/service.go
+++ b/pkg/services/authn/authnserver/service.go
@@ -62,7 +62,7 @@ func (s *Service) Authenticate(ctx context.Context, req *authnv1.AuthenticateReq
 		s.log.Error("Authenticate request error", "error", errExpectedNamespace)
 		return &authnv1.AuthenticateResponse{
 			Code: authnv1.AuthenticateCode_AUTHENTICATE_CODE_FAILED,
-		}, errExpectedNamespace
+		}, nil
 	}
 
 	ctx = request.WithNamespace(ctx, req.Namespace)
@@ -80,6 +80,10 @@ func (s *Service) Authenticate(ctx context.Context, req *authnv1.AuthenticateReq
 		resp, err := c.Authenticate(ctx, req)
 		if err != nil {
 			s.log.Error("Client authentication error", "client", c.Name(), "error", err)
+			if resp != nil && resp.Code != authnv1.AuthenticateCode_AUTHENTICATE_CODE_UNSPECIFIED {
+				grpclog.AddFields(ctx, grpclog.Fields{"authn.client", c.Name(), "authn.code", resp.Code.String(), "authn.namespace", req.GetNamespace()})
+				return resp, nil
+			}
 			grpclog.AddFields(ctx, grpclog.Fields{"authn.client", c.Name(), "authn.namespace", req.GetNamespace()})
 			return nil, err
 		}

--- a/pkg/services/authn/authnserver/service.go
+++ b/pkg/services/authn/authnserver/service.go
@@ -80,11 +80,14 @@ func (s *Service) Authenticate(ctx context.Context, req *authnv1.AuthenticateReq
 		resp, err := c.Authenticate(ctx, req)
 		if err != nil {
 			s.log.Error("Client authentication error", "client", c.Name(), "error", err)
+			fields := grpclog.Fields{"authn.client", c.Name(), "authn.namespace", req.GetNamespace()}
+			if resp != nil {
+				fields = append(fields, "authn.code", resp.Code.String())
+			}
+			grpclog.AddFields(ctx, fields)
 			if resp != nil && resp.Code != authnv1.AuthenticateCode_AUTHENTICATE_CODE_UNSPECIFIED {
-				grpclog.AddFields(ctx, grpclog.Fields{"authn.client", c.Name(), "authn.code", resp.Code.String(), "authn.namespace", req.GetNamespace()})
 				return resp, nil
 			}
-			grpclog.AddFields(ctx, grpclog.Fields{"authn.client", c.Name(), "authn.namespace", req.GetNamespace()})
 			return nil, err
 		}
 


### PR DESCRIPTION
while testing, i noticed that auth failures would result in an unknown code. it would seem that when there's an error returned, the grpc response message is not sent. our code appears to be split-brained about this. it often returns the message with some code as well as an error resulting the code being thrown out and the error being returned. this pr opts for logging the error and returning the code. 

thoughts? 

the other option is to reverse this and respond with a grpc error response and no grpc message. with the current behavior, i will admit, the returned error message is more helpful, but we could add that error message along side the api code. for example, [here](https://github.com/grafana/authlib/blob/main/authn/proto/v1/authn.proto#L27), we could add a `string failureMessage` which is only present with the failure code, 2.