### PR TITLE
Alerting: External Alertmanager sender to use stable fingerprint for Alert

### DIFF
--- a/pkg/services/ngalert/sender/notifier.go
+++ b/pkg/services/ngalert/sender/notifier.go
@@ -75,11 +75,6 @@ func (a *Alert) Name() string {
 	return a.Labels.Get(labels.AlertName)
 }
 
-// Hash returns a hash over the alert. It is equivalent to the alert labels hash.
-func (a *Alert) Hash() uint64 {
-	return a.Labels.Hash()
-}
-
 func (a *Alert) String() string {
 	s := fmt.Sprintf("%s[%s]", a.Name(), fmt.Sprintf("%016x", a.Hash())[:7])
 	if a.Resolved() {

--- a/pkg/services/ngalert/sender/notifier_ext.go
+++ b/pkg/services/ngalert/sender/notifier_ext.go
@@ -18,12 +18,25 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/model"
 	"github.com/prometheus/prometheus/config"
 	"github.com/prometheus/prometheus/discovery/targetgroup"
 	"github.com/prometheus/prometheus/model/labels"
 
 	"github.com/grafana/grafana/pkg/util/httpclient"
 )
+
+// Hash returns a stable, deterministic hash over the alert's label set.
+// Extension: replaces upstream's Labels.Hash() (xxhash, non-stable across runs) with
+// model.LabelSet.Fingerprint() (FNV-1A over sorted label pairs), matching the fingerprint
+// used by Prometheus Alertmanager so that ruler and AM logs can be correlated directly.
+func (a *Alert) Hash() uint64 {
+	ls := make(model.LabelSet, a.Labels.Len())
+	a.Labels.Range(func(l labels.Label) {
+		ls[model.LabelName(l.Name)] = model.LabelValue(l.Value)
+	})
+	return uint64(ls.Fingerprint())
+}
 
 // String constants for instrumentation.
 const (

--- a/pkg/services/ngalert/sender/notifier_ext_test.go
+++ b/pkg/services/ngalert/sender/notifier_ext_test.go
@@ -1,0 +1,61 @@
+package sender
+
+import (
+	"testing"
+
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/model/labels"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAlertHash_StableAndMatchesModelFingerprint(t *testing.T) {
+	lbls := labels.FromStrings(
+		"alertname", "TestAlert",
+		"env", "prod",
+		"job", "grafana",
+		"severity", "critical",
+	)
+
+	alert := &Alert{Labels: lbls}
+
+	// Hash must be stable across repeated calls.
+	h1 := alert.Hash()
+	h2 := alert.Hash()
+	require.Equal(t, h1, h2, "Hash() must be deterministic")
+
+	// Hash must equal model.LabelSet.Fingerprint() for the same label set.
+	ls := make(model.LabelSet, lbls.Len())
+	lbls.Range(func(l labels.Label) {
+		ls[model.LabelName(l.Name)] = model.LabelValue(l.Value)
+	})
+	want := uint64(ls.Fingerprint())
+	require.Equal(t, want, h1, "Hash() must match model.LabelSet.Fingerprint()")
+}
+
+func TestAlertHash_EmptyLabels(t *testing.T) {
+	alert := &Alert{Labels: labels.EmptyLabels()}
+	h1 := alert.Hash()
+	h2 := alert.Hash()
+	require.Equal(t, h1, h2)
+}
+
+func TestAlertHash_DifferentLabelSetsProduceDifferentHashes(t *testing.T) {
+	a1 := &Alert{Labels: labels.FromStrings("alertname", "A")}
+	a2 := &Alert{Labels: labels.FromStrings("alertname", "B")}
+	require.NotEqual(t, a1.Hash(), a2.Hash())
+}
+
+func BenchmarkAlertHash(b *testing.B) {
+	lbls := labels.FromStrings(
+		"alertname", "TestAlert",
+		"env", "prod",
+		"job", "grafana",
+		"namespace", "default",
+		"severity", "critical",
+	)
+	alert := &Alert{Labels: lbls}
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = alert.Hash()
+	}
+}


### PR DESCRIPTION
## Summary

- Replaces `Alert.Hash()` (which used xxhash via `labels.Labels.Hash()`, non-stable across runs) with `model.LabelSet.Fingerprint()` — FNV-1A over sorted label name/value pairs
- Moves the override to `notifier_ext.go` following the existing extension pattern, keeping `notifier.go` closer to upstream
- The new hash matches the fingerprint Prometheus Alertmanager uses for the same alert, so the 7-char identifier in ruler `"Sending alert"` logs can be directly correlated with alertmanager-side `"Received alert"` / `"flushing"` logs

Fixes #125115

## Test plan

- [ ] New unit tests in `notifier_ext_test.go` verify: hash is stable across calls, matches `model.LabelSet.Fingerprint()` for the same label set, empty labels handled, distinct label sets produce distinct hashes
- [ ] Full sender package test suite passes: `go test ./pkg/services/ngalert/sender/...`