### PR TITLE
Alerting: add backend support for notification policy filter in rule list

### DIFF
--- a/pkg/services/ngalert/api/prometheus/api_prometheus.go
+++ b/pkg/services/ngalert/api/prometheus/api_prometheus.go
@@ -504,6 +504,7 @@ type paginationContext struct {
 	panelID            int64
 	ruleGroups         []string
 	receiverName       string
+	routingPolicy      string
 	dataSourceUIDs     []string
 	title              string
 	searchRuleGroup    string
@@ -543,17 +544,18 @@ func (ctx *paginationContext) fetchAndFilterPage(log log.Logger, store ListAlert
 
 	byGroupQuery := ngmodels.ListAlertRulesExtendedQuery{
 		ListAlertRulesQuery: ngmodels.ListAlertRulesQuery{
-			OrgID:           ctx.opts.OrgID,
-			NamespaceUIDs:   ctx.namespaceUIDs,
-			RuleUIDs:        ctx.ruleUIDs,
-			DashboardUID:    ctx.dashboardUID,
-			PanelID:         ctx.panelID,
-			RuleGroups:      ctx.ruleGroups,
-			ReceiverName:    ctx.receiverName,
-			DataSourceUIDs:  ctx.dataSourceUIDs,
-			SearchTitle:     ctx.title,
-			SearchRuleGroup: ctx.searchRuleGroup,
-			LabelMatchers:   storeMatchers,
+			OrgID:              ctx.opts.OrgID,
+			NamespaceUIDs:      ctx.namespaceUIDs,
+			RuleUIDs:           ctx.ruleUIDs,
+			DashboardUID:       ctx.dashboardUID,
+			PanelID:            ctx.panelID,
+			RuleGroups:         ctx.ruleGroups,
+			ReceiverName:       ctx.receiverName,
+			RoutingPolicyExact: ctx.routingPolicy,
+			DataSourceUIDs:     ctx.dataSourceUIDs,
+			SearchTitle:        ctx.title,
+			SearchRuleGroup:    ctx.searchRuleGroup,
+			LabelMatchers:      storeMatchers,
 		},
 		RuleType:           ctx.ruleType,
 		PluginOriginFilter: ctx.pluginOriginFilter,
@@ -854,6 +856,9 @@ func PrepareRuleGroupStatusesV2(log log.Logger, store ListAlertRulesStoreV2, opt
 	receiverName := opts.Query.Get("receiver_name")
 	span.SetAttributes(attribute.Bool("receiver_name_set", receiverName != ""))
 
+	routingPolicy := opts.Query.Get("routing_policy")
+	span.SetAttributes(attribute.Bool("routing_policy_set", routingPolicy != ""))
+
 	title := opts.Query.Get("search.rule_name")
 	span.SetAttributes(attribute.Bool("search_rule_name_set", title != ""))
 
@@ -931,6 +936,7 @@ func PrepareRuleGroupStatusesV2(log log.Logger, store ListAlertRulesStoreV2, opt
 		panelID:            panelID,
 		ruleGroups:         ruleGroups,
 		receiverName:       receiverName,
+		routingPolicy:      routingPolicy,
 		title:              title,
 		dataSourceUIDs:     dataSourceUIDs,
 		searchRuleGroup:    searchRuleGroup,

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -1216,7 +1216,7 @@ func (st DBstore) buildListAlertRulesQuery(sess *db.Session, query *ngmodels.Lis
 			// 'user-defined' is the default notification policy tree. Rules pointing to it are
 			// stored with alert_routing_policy = NULL (PolicyRouting.Validate prevents storing
 			// the sentinel value explicitly). Match rules with no routing override at all.
-			q = q.Where("alert_routing_policy IS NULL AND (notification_settings IS NULL OR notification_settings = '' OR notification_settings = 'null' OR notification_settings = '[]')")
+			q = q.Where("alert_routing_policy IS NULL AND " + sqlNotificationSettingsUnset)
 		} else {
 			q = q.Where("alert_routing_policy = ?", query.RoutingPolicyExact)
 		}
@@ -1796,18 +1796,21 @@ func (st DBstore) filterByContentInNotificationSettings(value string, sess *xorm
 	return sess.And(sql, param), nil
 }
 
+// sqlNotificationSettingsUnset is a SQL predicate that matches rules with no contact-point
+// (SimplifiedRouting) settings: rows where notification_settings is NULL or empty.
+const sqlNotificationSettingsUnset = "(notification_settings IS NULL OR notification_settings = '' OR notification_settings = 'null' OR notification_settings = '[]')"
+
 // notificationSettingsTypeClause returns a SQL predicate matching rules whose effective
 // notification settings type equals t. Effective type is SimplifiedRouting when
 // notification_settings is set, otherwise NamedRoutingTree when alert_routing_policy is set.
 // SimplifiedRouting takes precedence on rules that have both columns populated.
 func notificationSettingsTypeClause(t ngmodels.NotificationSettingsType) (string, error) {
 	const simplifiedSet = "notification_settings IS NOT NULL AND notification_settings <> '' AND notification_settings <> 'null' AND notification_settings <> '[]'"
-	const simplifiedUnset = "(notification_settings IS NULL OR notification_settings = '' OR notification_settings = 'null' OR notification_settings = '[]')"
 	switch t {
 	case ngmodels.NotificationSettingsTypeSimplifiedRouting:
 		return simplifiedSet, nil
 	case ngmodels.NotificationSettingsTypeNamedRoutingTree:
-		return "alert_routing_policy IS NOT NULL AND " + simplifiedUnset, nil
+		return "alert_routing_policy IS NOT NULL AND " + sqlNotificationSettingsUnset, nil
 	default:
 		return "", fmt.Errorf("unsupported notification settings type %q", t)
 	}

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -1212,13 +1212,10 @@ func (st DBstore) buildListAlertRulesQuery(sess *db.Session, query *ngmodels.Lis
 		q = q.Where("NOT (" + clause + ")")
 	}
 	if query.RoutingPolicyExact != "" {
-		if query.RoutingPolicyExact == ngmodels.DefaultRoutingTreeName {
-			// 'user-defined' is the default notification policy tree. Rules pointing to it are
-			// stored with alert_routing_policy = NULL (PolicyRouting.Validate prevents storing
-			// the sentinel value explicitly). Match rules with no routing override at all.
-			q = q.Where("alert_routing_policy IS NULL AND " + sqlNotificationSettingsUnset)
-		} else {
-			q = q.Where("alert_routing_policy = ?", query.RoutingPolicyExact)
+		var err error
+		q, err = st.filterByRoutingPolicyExact(query.RoutingPolicyExact, q)
+		if err != nil {
+			return nil, groupsSet, err
 		}
 	}
 	if query.ExcludeRoutingPolicy != "" {
@@ -1794,6 +1791,37 @@ func (st DBstore) filterByContentInNotificationSettings(value string, sess *xorm
 	}
 	sql, param := st.SQLStore.GetDialect().LikeOperator("notification_settings", true, search, true)
 	return sess.And(sql, param), nil
+}
+
+// filterByRoutingPolicyExact matches rules routed to the given named policy tree.
+// Rules may store the policy in alert_routing_policy (alertingPolicyRoutingSettings) or, in legacy
+// mode, in the __grafana_managed_route__ label.
+func (st DBstore) filterByRoutingPolicyExact(policy string, sess *xorm.Session) (*xorm.Session, error) {
+	if policy == ngmodels.DefaultRoutingTreeName {
+		// 'user-defined' is the default notification policy tree. Rules pointing to it are
+		// stored with alert_routing_policy = NULL (PolicyRouting.Validate prevents storing
+		// the sentinel value explicitly). Match rules with no routing override at all.
+		labelMatcher, err := labels.NewMatcher(labels.MatchEqual, ngmodels.NamedRouteLabel, "")
+		if err != nil {
+			return nil, err
+		}
+		labelSQL, labelArgs, err := buildLabelMatcherCondition(st.SQLStore.GetDialect(), "labels", labelMatcher)
+		if err != nil {
+			return nil, err
+		}
+		return sess.Where("(alert_routing_policy IS NULL AND "+sqlNotificationSettingsUnset+" AND ("+labelSQL+"))", labelArgs...), nil
+	}
+
+	labelMatcher, err := labels.NewMatcher(labels.MatchEqual, ngmodels.NamedRouteLabel, policy)
+	if err != nil {
+		return nil, err
+	}
+	labelSQL, labelArgs, err := buildLabelMatcherCondition(st.SQLStore.GetDialect(), "labels", labelMatcher)
+	if err != nil {
+		return nil, err
+	}
+	args := append([]any{policy}, labelArgs...)
+	return sess.Where("(alert_routing_policy = ? OR ("+labelSQL+"))", args...), nil
 }
 
 // sqlNotificationSettingsUnset is a SQL predicate that matches rules with no contact-point

--- a/pkg/services/ngalert/store/alert_rule.go
+++ b/pkg/services/ngalert/store/alert_rule.go
@@ -1212,7 +1212,14 @@ func (st DBstore) buildListAlertRulesQuery(sess *db.Session, query *ngmodels.Lis
 		q = q.Where("NOT (" + clause + ")")
 	}
 	if query.RoutingPolicyExact != "" {
-		q = q.Where("alert_routing_policy = ?", query.RoutingPolicyExact)
+		if query.RoutingPolicyExact == ngmodels.DefaultRoutingTreeName {
+			// 'user-defined' is the default notification policy tree. Rules pointing to it are
+			// stored with alert_routing_policy = NULL (PolicyRouting.Validate prevents storing
+			// the sentinel value explicitly). Match rules with no routing override at all.
+			q = q.Where("alert_routing_policy IS NULL AND (notification_settings IS NULL OR notification_settings = '' OR notification_settings = 'null' OR notification_settings = '[]')")
+		} else {
+			q = q.Where("alert_routing_policy = ?", query.RoutingPolicyExact)
+		}
 	}
 	if query.ExcludeRoutingPolicy != "" {
 		// alert_routing_policy is nullable; NULL should satisfy `!=` to match k8s field-selector semantics.

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/grafana/grafana-plugin-sdk-go/data"
+
 	"github.com/grafana/grafana/pkg/bus"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/log/logtest"
@@ -3644,6 +3646,11 @@ func TestIntegration_ListAlertRulesPaginatedFilters(t *testing.T) {
 		// Rules with an explicit routing override — should not match
 		createRule(t, store, contactPointGen)
 		createRule(t, store, namedPolicyGen)
+		legacyPolicyGen := ruleGen.With(
+			ruleGen.WithNoNotificationSettings(),
+			ruleGen.WithLabels(data.Labels{models.NamedRouteLabel: "my-team"}),
+		)
+		createRule(t, store, legacyPolicyGen)
 
 		query := &models.ListAlertRulesExtendedQuery{
 			ListAlertRulesQuery: models.ListAlertRulesQuery{
@@ -3692,6 +3699,36 @@ func TestIntegration_ListAlertRulesPaginatedFilters(t *testing.T) {
 			gotUIDs = append(gotUIDs, r.UID)
 		}
 		require.ElementsMatch(t, []string{p1.UID, p2.UID}, gotUIDs)
+	})
+
+	t.Run("RoutingPolicyExact with legacy named route label matches label-routed rules", func(t *testing.T) {
+		sqlStore := db.InitTestDB(t)
+		folderService := setupFolderService(t, sqlStore, cfg, featuremgmt.WithFeatures())
+		store := createTestStore(sqlStore, folderService, &logtest.Fake{}, cfg.UnifiedAlerting, b)
+
+		matchPolicy := "konrad-policy"
+		legacyGen := ruleGen.With(
+			ruleGen.WithNoNotificationSettings(),
+			ruleGen.WithLabels(data.Labels{models.NamedRouteLabel: matchPolicy}),
+		)
+		otherLegacyGen := ruleGen.With(
+			ruleGen.WithNoNotificationSettings(),
+			ruleGen.WithLabels(data.Labels{models.NamedRouteLabel: "other-policy"}),
+		)
+
+		legacyRule := createRule(t, store, legacyGen)
+		createRule(t, store, otherLegacyGen)
+
+		query := &models.ListAlertRulesExtendedQuery{
+			ListAlertRulesQuery: models.ListAlertRulesQuery{
+				OrgID:              orgID,
+				RoutingPolicyExact: matchPolicy,
+			},
+		}
+		result, _, err := store.ListAlertRulesPaginated(context.Background(), query)
+		require.NoError(t, err)
+		require.Len(t, result, 1)
+		require.Equal(t, legacyRule.UID, result[0].UID)
 	})
 
 	t.Run("ExcludeRoutingPolicy includes rules with no policy", func(t *testing.T) {

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -3629,6 +3629,38 @@ func TestIntegration_ListAlertRulesPaginatedFilters(t *testing.T) {
 		require.ElementsMatch(t, []string{p1.UID, p2.UID}, gotUIDs)
 	})
 
+	t.Run("RoutingPolicyExact with DefaultRoutingTreeName matches rules with no routing override", func(t *testing.T) {
+		sqlStore := db.InitTestDB(t)
+		folderService := setupFolderService(t, sqlStore, cfg, featuremgmt.WithFeatures())
+		store := createTestStore(sqlStore, folderService, &logtest.Fake{}, cfg.UnifiedAlerting, b)
+
+		noOverrideGen := ruleGen.With(ruleGen.WithNoNotificationSettings())
+		contactPointGen := ruleGen.With(ruleGen.WithContactPointRouting(models.NewDefaultContactPointRouting("recv-1")))
+		namedPolicyGen := ruleGen.With(ruleGen.WithPolicyRouting(models.PolicyRouting{Policy: "my-team"}))
+
+		// Rules with no routing override — should match
+		n1 := createRule(t, store, noOverrideGen)
+		n2 := createRule(t, store, noOverrideGen)
+		// Rules with an explicit routing override — should not match
+		createRule(t, store, contactPointGen)
+		createRule(t, store, namedPolicyGen)
+
+		query := &models.ListAlertRulesExtendedQuery{
+			ListAlertRulesQuery: models.ListAlertRulesQuery{
+				OrgID:              orgID,
+				RoutingPolicyExact: models.DefaultRoutingTreeName,
+			},
+		}
+		result, _, err := store.ListAlertRulesPaginated(context.Background(), query)
+		require.NoError(t, err)
+		require.Len(t, result, 2)
+		gotUIDs := make([]string, 0, len(result))
+		for _, r := range result {
+			gotUIDs = append(gotUIDs, r.UID)
+		}
+		require.ElementsMatch(t, []string{n1.UID, n2.UID}, gotUIDs)
+	})
+
 	t.Run("ExcludeRoutingPolicy includes rules with no policy", func(t *testing.T) {
 		sqlStore := db.InitTestDB(t)
 		folderService := setupFolderService(t, sqlStore, cfg, featuremgmt.WithFeatures())

--- a/pkg/services/ngalert/store/alert_rule_test.go
+++ b/pkg/services/ngalert/store/alert_rule_test.go
@@ -3661,6 +3661,39 @@ func TestIntegration_ListAlertRulesPaginatedFilters(t *testing.T) {
 		require.ElementsMatch(t, []string{n1.UID, n2.UID}, gotUIDs)
 	})
 
+	t.Run("RoutingPolicyExact with named policy excludes rules without matching policy", func(t *testing.T) {
+		sqlStore := db.InitTestDB(t)
+		folderService := setupFolderService(t, sqlStore, cfg, featuremgmt.WithFeatures())
+		store := createTestStore(sqlStore, folderService, &logtest.Fake{}, cfg.UnifiedAlerting, b)
+
+		matchPolicy := "my-team"
+		matchGen := ruleGen.With(ruleGen.WithPolicyRouting(models.PolicyRouting{Policy: matchPolicy}))
+		otherPolicyGen := ruleGen.With(ruleGen.WithPolicyRouting(models.PolicyRouting{Policy: "other-team"}))
+		noOverrideGen := ruleGen.With(ruleGen.WithNoNotificationSettings())
+		contactPointGen := ruleGen.With(ruleGen.WithContactPointRouting(models.NewDefaultContactPointRouting("recv-1")))
+
+		p1 := createRule(t, store, matchGen)
+		p2 := createRule(t, store, matchGen)
+		createRule(t, store, otherPolicyGen)
+		createRule(t, store, noOverrideGen)
+		createRule(t, store, contactPointGen)
+
+		query := &models.ListAlertRulesExtendedQuery{
+			ListAlertRulesQuery: models.ListAlertRulesQuery{
+				OrgID:              orgID,
+				RoutingPolicyExact: matchPolicy,
+			},
+		}
+		result, _, err := store.ListAlertRulesPaginated(context.Background(), query)
+		require.NoError(t, err)
+		require.Len(t, result, 2)
+		gotUIDs := make([]string, 0, len(result))
+		for _, r := range result {
+			gotUIDs = append(gotUIDs, r.UID)
+		}
+		require.ElementsMatch(t, []string{p1.UID, p2.UID}, gotUIDs)
+	})
+
 	t.Run("ExcludeRoutingPolicy includes rules with no policy", func(t *testing.T) {
 		sqlStore := db.InitTestDB(t)
 		folderService := setupFolderService(t, sqlStore, cfg, featuremgmt.WithFeatures())

--- a/public/app/features/alerting/unified/api/prometheusApi.ts
+++ b/public/app/features/alerting/unified/api/prometheusApi.ts
@@ -50,6 +50,7 @@ export type GrafanaPromRulesOptions = Omit<PromRulesOptions, 'ruleSource' | 'nam
   type?: 'alerting' | 'recording';
   ruleMatchers?: string[];
   plugins?: 'hide' | 'only';
+  policy?: string;
 };
 
 export const prometheusApi = alertingApi.injectEndpoints({
@@ -108,6 +109,7 @@ export const prometheusApi = alertingApi.injectEndpoints({
         dashboardUid,
         ruleMatchers,
         plugins,
+        policy,
       }) => ({
         url: `api/prometheus/grafana/api/v1/rules`,
         params: {
@@ -115,6 +117,7 @@ export const prometheusApi = alertingApi.injectEndpoints({
           rule_group: groupName,
           rule_name: ruleName,
           receiver_name: contactPoint,
+          routing_policy: policy,
           health: health,
           state: state,
           rule_type: type,

--- a/public/app/features/alerting/unified/rule-list/hooks/grafanaFilter.test.ts
+++ b/public/app/features/alerting/unified/rule-list/hooks/grafanaFilter.test.ts
@@ -149,7 +149,7 @@ describe('grafana-managed rules', () => {
       expect(frontendFilter2.ruleMatches(ruleDashboardB)).toBe(true);
     });
 
-    it('should filter by policy routing', () => {
+    it('should NOT filter by policy routing in frontend (returns true regardless)', () => {
       const ruleWithPolicy = mockGrafanaPromAlertingRule({
         name: 'Rule with Policy',
         notificationSettings: { policy: 'team-a-policy' },
@@ -163,13 +163,14 @@ describe('grafana-managed rules', () => {
         notificationSettings: { receiver: 'slack' },
       });
 
+      // Frontend filter should return true for all rules since backend handles this
       const { frontendFilter } = getGrafanaFilter(getFilter({ policy: 'team-a-policy' }));
       expect(frontendFilter.ruleMatches(ruleWithPolicy)).toBe(true);
-      expect(frontendFilter.ruleMatches(ruleWithDifferentPolicy)).toBe(false);
-      expect(frontendFilter.ruleMatches(ruleWithContactPoint)).toBe(false);
+      expect(frontendFilter.ruleMatches(ruleWithDifferentPolicy)).toBe(true);
+      expect(frontendFilter.ruleMatches(ruleWithContactPoint)).toBe(true);
     });
 
-    it('should match rules using the default policy when filtering by user-defined', () => {
+    it('should NOT filter by default policy (user-defined) in frontend (returns true regardless)', () => {
       const ruleWithNoSettings = mockGrafanaPromAlertingRule({
         name: 'Rule with no notification settings',
       });
@@ -181,16 +182,12 @@ describe('grafana-managed rules', () => {
         name: 'Rule with Explicit Policy',
         notificationSettings: { policy: 'team-a-policy' },
       });
-      const ruleWithExplicitUserDefinedPolicy = mockGrafanaPromAlertingRule({
-        name: 'Rule explicitly set to user-defined policy',
-        notificationSettings: { policy: USER_DEFINED_TREE_NAME },
-      });
 
+      // Frontend filter should return true for all rules since backend handles this
       const { frontendFilter } = getGrafanaFilter(getFilter({ policy: USER_DEFINED_TREE_NAME }));
       expect(frontendFilter.ruleMatches(ruleWithNoSettings)).toBe(true);
-      expect(frontendFilter.ruleMatches(ruleWithExplicitUserDefinedPolicy)).toBe(true);
-      expect(frontendFilter.ruleMatches(ruleWithContactPoint)).toBe(false);
-      expect(frontendFilter.ruleMatches(ruleWithExplicitPolicy)).toBe(false);
+      expect(frontendFilter.ruleMatches(ruleWithContactPoint)).toBe(true);
+      expect(frontendFilter.ruleMatches(ruleWithExplicitPolicy)).toBe(true);
     });
 
     describe('dataSourceNames filter', () => {
@@ -304,12 +301,25 @@ describe('grafana-managed rules', () => {
       expect(backendFilter.contactPoint).toBe('my-contact-point');
     });
 
+    it('should include policy in backend filter', () => {
+      const { backendFilter } = getGrafanaFilter(getFilter({ policy: 'team-a-policy' }));
+
+      expect(backendFilter.policy).toBe('team-a-policy');
+    });
+
+    it('should include user-defined policy sentinel in backend filter', () => {
+      const { backendFilter } = getGrafanaFilter(getFilter({ policy: USER_DEFINED_TREE_NAME }));
+
+      expect(backendFilter.policy).toBe(USER_DEFINED_TREE_NAME);
+    });
+
     it('should handle empty backend filters', () => {
       const { backendFilter } = getGrafanaFilter(getFilter({}));
 
       expect(backendFilter.state).toEqual([]);
       expect(backendFilter.health).toEqual([]);
       expect(backendFilter.contactPoint).toBeUndefined();
+      expect(backendFilter.policy).toBeUndefined();
     });
 
     it('should not set hasInvalidDataSourceNames flag when no data source names are provided', () => {
@@ -850,8 +860,8 @@ describe('grafana-managed rules', () => {
         expect(hasGrafanaClientSideFilters(getFilter({ contactPoint: 'my-contact-point' }))).toBe(false);
       });
 
-      it('should return true for policy filter (always client-side)', () => {
-        expect(hasGrafanaClientSideFilters(getFilter({ policy: 'my-policy' }))).toBe(true);
+      it('should return false for policy filter (handled by backend)', () => {
+        expect(hasGrafanaClientSideFilters(getFilter({ policy: 'my-policy' }))).toBe(false);
       });
     });
 
@@ -901,8 +911,8 @@ describe('grafana-managed rules', () => {
         expect(hasGrafanaClientSideFilters(getFilter({ contactPoint: 'my-contact-point' }))).toBe(false);
       });
 
-      it('should return true for policy filter (always client-side, even when backend filters are on)', () => {
-        expect(hasGrafanaClientSideFilters(getFilter({ policy: 'my-policy' }))).toBe(true);
+      it('should return false for policy filter (handled by backend)', () => {
+        expect(hasGrafanaClientSideFilters(getFilter({ policy: 'my-policy' }))).toBe(false);
       });
     });
 

--- a/public/app/features/alerting/unified/rule-list/hooks/grafanaFilter.ts
+++ b/public/app/features/alerting/unified/rule-list/hooks/grafanaFilter.ts
@@ -20,7 +20,6 @@ import {
   mapDataSourceNamesToUids,
   namespaceFilter,
   pluginsFilter,
-  policyFilter,
   ruleMatches,
   ruleNameFilter,
   ruleTypeFilter,
@@ -90,6 +89,7 @@ export function getGrafanaFilter(filterState: Partial<RulesFilter>) {
     state: normalizedFilterState.ruleState ? [normalizedFilterState.ruleState] : [],
     health: normalizedFilterState.ruleHealth ? [normalizedFilterState.ruleHealth] : [],
     contactPoint: normalizedFilterState.contactPoint ?? undefined,
+    policy: normalizedFilterState.policy ?? undefined,
     // If FE filter is defined, don't include the backend filter
     title: ruleFilterConfig.ruleName ? undefined : titleSearch,
     type: ruleFilterConfig.ruleType ? undefined : normalizedFilterState.ruleType,
@@ -134,7 +134,7 @@ function buildGrafanaFilterConfigs() {
     dashboardUid: useBackendFilters || useFullyCompatibleBackendFilters ? null : dashboardUidFilter,
     plugins: useBackendFilters || useFullyCompatibleBackendFilters ? null : pluginsFilter,
     contactPoint: null,
-    policy: policyFilter,
+    policy: null,
   };
 
   const groupFilterConfig: GroupFilterConfig = {

--- a/public/app/features/alerting/unified/rule-list/paginationLimits.test.ts
+++ b/public/app/features/alerting/unified/rule-list/paginationLimits.test.ts
@@ -85,6 +85,16 @@ describe('paginationLimits', () => {
           expect(datasourceManagedLimit).toEqual({ groupLimit: FILTERED_GROUPS_LARGE_API_PAGE_SIZE });
         }
       );
+
+      it('should return rule limit for grafana + small limit for datasource when only policy filter is used', () => {
+        // policy only filters Grafana-managed rules (datasource rules have no notification settings)
+        const { grafanaManagedLimit, datasourceManagedLimit } = getFilteredRulesLimits(
+          getFilter({ policy: 'my-policy' })
+        );
+
+        expect(grafanaManagedLimit).toEqual({ ruleLimit: RULE_LIMIT_WITH_BACKEND_FILTERS });
+        expect(datasourceManagedLimit).toEqual({ groupLimit: FILTERED_GROUPS_SMALL_API_PAGE_SIZE });
+      });
     });
 
     describe('when alertingUIUseFullyCompatBackendFilters is enabled', () => {


### PR DESCRIPTION
## What

Wires the `policy` (notification routing policy) filter through to the backend API so all rule list filtering is now fully server-side.

A new `routing_policy` query parameter is parsed in `PrepareRuleGroupStatusesV2`, passed through the pagination context, and applied via the existing `RoutingPolicyExact` store filter.

## Why

Previously the policy filter was the only remaining frontend-only filter — the browser had to download all matching rules before applying it. Moving it to the backend reduces payload size and is consistent with how every other filter (name, state, label, folder, etc.) already works.

## Notable implementation detail

The `'user-defined'` sentinel value (representing rules with **no** routing override) cannot be stored literally in the `alert_routing_policy` column because `PolicyRouting.Validate()` rejects it. The store filter therefore maps this sentinel to a SQL NULL + empty `notification_settings` check, catching rules that have no routing override at all.

## Changes

**Backend (Go)**
- `pkg/services/ngalert/api/prometheus/api_prometheus.go` — parse `routing_policy` query param, add `routingPolicy` field to `paginationContext`, wire through to store query via `RoutingPolicyExact`
- `pkg/services/ngalert/store/alert_rule.go` — extend `RoutingPolicyExact` to handle the `'user-defined'` sentinel with a NULL-check
- `pkg/services/ngalert/store/alert_rule_test.go` — integration test for the `user-defined` sentinel case

**Frontend (TypeScript)**
- `public/app/features/alerting/unified/api/prometheusApi.ts` — add `policy?: string` to `GrafanaPromRulesOptions`, mapped to `routing_policy` backend param
- `public/app/features/alerting/unified/rule-list/hooks/grafanaFilter.ts` — set `policy: null` in `buildGrafanaFilterConfigs` (no longer filtered client-side), add `policy` to `backendFilter`, remove unused `policyFilter` import
- `public/app/features/alerting/unified/rule-list/hooks/grafanaFilter.test.ts` — frontend filter now returns `true` for all rules when policy is set (backend handles it); added `backendFilter.policy` assertions
- `public/app/features/alerting/unified/rule-list/paginationLimits.test.ts` — policy filter uses rule-based limit for Grafana (backend filter) but small limit for datasource rules (policy doesn't apply to non-Grafana rules)

## Note for reviewers

This PR is intended to be merged after #125139 (which removes the `alertingUIUseBackendFilters` / `alertingUIUseFullyCompatBackendFilters` feature toggles). Both PRs are independent — the policy filter works correctly regardless of toggle state — but the ordering avoids unnecessary churn.