### PR TITLE
Datasource Proxy: Restrict full access to setting.Cfg

### DIFF
--- a/pkg/api/pluginproxy/ds_auth_provider.go
+++ b/pkg/api/pluginproxy/ds_auth_provider.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/grafana/grafana/pkg/plugins"
-	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 )
 
@@ -23,7 +22,7 @@ type DSInfo struct {
 
 // ApplyRoute should use the plugin route data to set auth headers and custom headers.
 func ApplyRoute(ctx context.Context, req *http.Request, proxyPath string, route *plugins.Route,
-	ds DSInfo, cfg *setting.Cfg) {
+	ds DSInfo, settings *DataSourceProxySettings) {
 	proxyPath = strings.TrimPrefix(proxyPath, route.Path)
 	data := templateData{
 		URL:            ds.URL,
@@ -70,7 +69,7 @@ func ApplyRoute(ctx context.Context, req *http.Request, proxyPath string, route 
 		ctxLogger.Error("Failed to set plugin route body content", "error", err)
 	}
 
-	if tokenProvider, err := getTokenProvider(ctx, cfg, ds, route, data); err != nil {
+	if tokenProvider, err := getTokenProvider(ctx, settings, ds, route, data); err != nil {
 		ctxLogger.Error("Failed to resolve auth token provider", "error", err)
 	} else if tokenProvider != nil {
 		if token, err := tokenProvider.GetAccessToken(); err != nil {
@@ -80,12 +79,12 @@ func ApplyRoute(ctx context.Context, req *http.Request, proxyPath string, route 
 		}
 	}
 
-	if cfg.DataProxyLogging {
+	if settings.DataProxyLogging {
 		ctxLogger.Debug("Requesting", "url", req.URL.String())
 	}
 }
 
-func getTokenProvider(ctx context.Context, cfg *setting.Cfg, ds DSInfo, pluginRoute *plugins.Route,
+func getTokenProvider(ctx context.Context, settings *DataSourceProxySettings, ds DSInfo, pluginRoute *plugins.Route,
 	data templateData) (accessTokenProvider, error) {
 	authType := pluginRoute.AuthType
 
@@ -108,7 +107,7 @@ func getTokenProvider(ctx context.Context, cfg *setting.Cfg, ds DSInfo, pluginRo
 		if tokenAuth == nil {
 			return nil, fmt.Errorf("'tokenAuth' not configured for authentication type '%s'", authType)
 		}
-		return newAzureAccessTokenProvider(ctx, cfg, tokenAuth)
+		return newAzureAccessTokenProvider(ctx, settings, tokenAuth)
 
 	case "gce":
 		if jwtTokenAuth == nil {

--- a/pkg/api/pluginproxy/ds_proxy.go
+++ b/pkg/api/pluginproxy/ds_proxy.go
@@ -24,7 +24,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/oauthtoken"
 	pluginac "github.com/grafana/grafana/pkg/services/pluginsintegration/pluginaccesscontrol"
-	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/util"
 	"github.com/grafana/grafana/pkg/util/proxyutil"
 )
@@ -47,7 +46,7 @@ type DataSourceProxy struct {
 	proxyPath          string
 	matchedRoute       *plugins.Route
 	pluginRoutes       []*plugins.Route
-	cfg                *setting.Cfg
+	settings           *DataSourceProxySettings
 	clientProvider     httpclient.Provider
 	oAuthTokenService  oauthtoken.OAuthTokenService
 	dataSourcesService datasources.DataSourceService
@@ -61,7 +60,7 @@ type httpClient interface {
 
 // NewDataSourceProxy creates a new Datasource proxy
 func NewDataSourceProxy(ds *datasources.DataSource, pluginRoutes []*plugins.Route, ctx *contextmodel.ReqContext,
-	proxyPath string, cfg *setting.Cfg, clientProvider httpclient.Provider,
+	proxyPath string, settings *DataSourceProxySettings, clientProvider httpclient.Provider,
 	oAuthTokenService oauthtoken.OAuthTokenService, dsService datasources.DataSourceService,
 	tracer tracing.Tracer, features featuremgmt.FeatureToggles,
 ) (*DataSourceProxy, error) {
@@ -76,7 +75,7 @@ func NewDataSourceProxy(ds *datasources.DataSource, pluginRoutes []*plugins.Rout
 		ctx:                ctx,
 		proxyPath:          proxyPath,
 		targetUrl:          targetURL,
-		cfg:                cfg,
+		settings:           settings,
 		clientProvider:     clientProvider,
 		oAuthTokenService:  oAuthTokenService,
 		dataSourcesService: dsService,
@@ -237,11 +236,11 @@ func (proxy *DataSourceProxy) director(req *http.Request) {
 		req.Header.Set("Authorization", dsAuth)
 	}
 
-	proxyutil.ApplyUserHeader(proxy.cfg.SendUserHeader, req, proxy.ctx.SignedInUser)
+	proxyutil.ApplyUserHeader(proxy.settings.SendUserHeader, req, proxy.ctx.SignedInUser)
 
-	proxyutil.ClearCookieHeader(req, proxy.ds.AllowedCookies(), []string{proxy.cfg.LoginCookieName})
-	ua := proxy.cfg.DataProxyUserAgent
-	if proxy.cfg.DataProxyForwardUserAgent {
+	proxyutil.ClearCookieHeader(req, proxy.ds.AllowedCookies(), []string{proxy.settings.LoginCookieName})
+	ua := proxy.settings.DataProxyUserAgent
+	if proxy.settings.DataProxyForwardUserAgent {
 		if originalUA := req.Header.Get("User-Agent"); originalUA != "" {
 			if len(originalUA) > maxForwardedUserAgentLen {
 				originalUA = originalUA[:maxForwardedUserAgentLen]
@@ -277,7 +276,7 @@ func (proxy *DataSourceProxy) director(req *http.Request) {
 			Updated:                 proxy.ds.Updated,
 			JSONData:                jsonData,
 			DecryptedSecureJSONData: decryptedValues,
-		}, proxy.cfg)
+		}, proxy.settings)
 	}
 
 	if proxy.oAuthTokenService.IsOAuthPassThruEnabled(proxy.ds) {
@@ -384,7 +383,7 @@ func (proxy *DataSourceProxy) hasAccessToRoute(route *plugins.Route) bool {
 }
 
 func (proxy *DataSourceProxy) logRequest() {
-	if !proxy.cfg.DataProxyLogging {
+	if !proxy.settings.DataProxyLogging {
 		return
 	}
 
@@ -417,8 +416,8 @@ func (proxy *DataSourceProxy) logRequest() {
 }
 
 func (proxy *DataSourceProxy) checkWhiteList() bool {
-	if proxy.targetUrl.Host != "" && len(proxy.cfg.DataProxyWhiteList) > 0 {
-		if _, exists := proxy.cfg.DataProxyWhiteList[proxy.targetUrl.Host]; !exists {
+	if proxy.targetUrl.Host != "" && len(proxy.settings.DataProxyWhiteList) > 0 {
+		if _, exists := proxy.settings.DataProxyWhiteList[proxy.targetUrl.Host]; !exists {
 			proxy.ctx.JsonApiErr(403, "Data proxy hostname and ip are not included in whitelist", nil)
 			return false
 		}

--- a/pkg/api/pluginproxy/ds_proxy_test.go
+++ b/pkg/api/pluginproxy/ds_proxy_test.go
@@ -163,7 +163,7 @@ func TestIntegrationDataSourceProxy_routeRule(t *testing.T) {
 			proxy, err := setupDSProxyTest(t, ctx, ds, routes, "api/v4/some/method")
 			require.NoError(t, err)
 			proxy.matchedRoute = routes[0]
-			ApplyRoute(proxy.ctx.Req.Context(), req, proxy.proxyPath, proxy.matchedRoute, dsInfo, proxy.cfg)
+			ApplyRoute(proxy.ctx.Req.Context(), req, proxy.proxyPath, proxy.matchedRoute, dsInfo, proxy.settings)
 
 			assert.Equal(t, "https://www.google.com/some/method", req.URL.String())
 			assert.Equal(t, "my secret 123", req.Header.Get("x-header"))
@@ -174,7 +174,7 @@ func TestIntegrationDataSourceProxy_routeRule(t *testing.T) {
 			proxy, err := setupDSProxyTest(t, ctx, ds, routes, "api/common/some/method")
 			require.NoError(t, err)
 			proxy.matchedRoute = routes[3]
-			ApplyRoute(proxy.ctx.Req.Context(), req, proxy.proxyPath, proxy.matchedRoute, dsInfo, proxy.cfg)
+			ApplyRoute(proxy.ctx.Req.Context(), req, proxy.proxyPath, proxy.matchedRoute, dsInfo, proxy.settings)
 
 			assert.Equal(t, "https://dynamic.grafana.com/some/method?apiKey=123", req.URL.String())
 			assert.Equal(t, "my secret 123", req.Header.Get("x-header"))
@@ -185,7 +185,7 @@ func TestIntegrationDataSourceProxy_routeRule(t *testing.T) {
 			proxy, err := setupDSProxyTest(t, ctx, ds, routes, "")
 			require.NoError(t, err)
 			proxy.matchedRoute = routes[4]
-			ApplyRoute(proxy.ctx.Req.Context(), req, proxy.proxyPath, proxy.matchedRoute, dsInfo, proxy.cfg)
+			ApplyRoute(proxy.ctx.Req.Context(), req, proxy.proxyPath, proxy.matchedRoute, dsInfo, proxy.settings)
 
 			assert.Equal(t, "http://localhost/asd", req.URL.String())
 		})
@@ -214,7 +214,7 @@ func TestIntegrationDataSourceProxy_routeRule(t *testing.T) {
 				},
 				URL: "https://dynamic.grafana.com",
 			}
-			ApplyRoute(proxy.ctx.Req.Context(), req, proxy.proxyPath, proxy.matchedRoute, dsInfo, proxy.cfg)
+			ApplyRoute(proxy.ctx.Req.Context(), req, proxy.proxyPath, proxy.matchedRoute, dsInfo, proxy.settings)
 
 			assert.Equal(t, "https://dynamic.grafana.com/some/method?apiKey=123", req.URL.String())
 			assert.Equal(t, "my secret 123", req.Header.Get("x-header"))
@@ -225,7 +225,7 @@ func TestIntegrationDataSourceProxy_routeRule(t *testing.T) {
 			proxy, err := setupDSProxyTest(t, ctx, ds, routes, "api/body")
 			require.NoError(t, err)
 			proxy.matchedRoute = routes[5]
-			ApplyRoute(proxy.ctx.Req.Context(), req, proxy.proxyPath, proxy.matchedRoute, dsInfo, proxy.cfg)
+			ApplyRoute(proxy.ctx.Req.Context(), req, proxy.proxyPath, proxy.matchedRoute, dsInfo, proxy.settings)
 
 			content, err := io.ReadAll(req.Body)
 			require.NoError(t, err)
@@ -237,7 +237,7 @@ func TestIntegrationDataSourceProxy_routeRule(t *testing.T) {
 			proxy, err := setupDSProxyTest(t, ctx, ds, routes, "mypath/some-route/")
 			require.NoError(t, err)
 			proxy.matchedRoute = routes[6]
-			ApplyRoute(proxy.ctx.Req.Context(), req, proxy.proxyPath, proxy.matchedRoute, dsInfo, proxy.cfg)
+			ApplyRoute(proxy.ctx.Req.Context(), req, proxy.proxyPath, proxy.matchedRoute, dsInfo, proxy.settings)
 
 			assert.Equal(t, "https://example.com/api/v1/some-route/", req.URL.String())
 		})
@@ -247,7 +247,7 @@ func TestIntegrationDataSourceProxy_routeRule(t *testing.T) {
 			proxy, err := setupDSProxyTest(t, ctx, ds, routes, "/our%20devices")
 			require.NoError(t, err)
 			proxy.matchedRoute = routes[9]
-			ApplyRoute(proxy.ctx.Req.Context(), req, proxy.proxyPath, proxy.matchedRoute, dsInfo, proxy.cfg)
+			ApplyRoute(proxy.ctx.Req.Context(), req, proxy.proxyPath, proxy.matchedRoute, dsInfo, proxy.settings)
 
 			assert.Equal(t, "http://encoded.com/our%20devices", req.URL.String())
 		})
@@ -402,7 +402,7 @@ func TestIntegrationDataSourceProxy_routeRule(t *testing.T) {
 
 				proxy, err := setupDSProxyTest(t, ctx, ds, routes, "pathwithtoken1")
 				require.NoError(t, err)
-				ApplyRoute(proxy.ctx.Req.Context(), req, proxy.proxyPath, routes[0], dsInfo, proxy.cfg)
+				ApplyRoute(proxy.ctx.Req.Context(), req, proxy.proxyPath, routes[0], dsInfo, proxy.settings)
 
 				authorizationHeaderCall1 = req.Header.Get("Authorization")
 				assert.Equal(t, "https://api.nr1.io/some/path", req.URL.String())
@@ -419,7 +419,7 @@ func TestIntegrationDataSourceProxy_routeRule(t *testing.T) {
 					proxy, err := setupDSProxyTest(t, ctx, ds, routes, "pathwithtoken2")
 					require.NoError(t, err)
 
-					ApplyRoute(proxy.ctx.Req.Context(), req, proxy.proxyPath, routes[1], dsInfo, proxy.cfg)
+					ApplyRoute(proxy.ctx.Req.Context(), req, proxy.proxyPath, routes[1], dsInfo, proxy.settings)
 
 					authorizationHeaderCall2 = req.Header.Get("Authorization")
 
@@ -436,7 +436,7 @@ func TestIntegrationDataSourceProxy_routeRule(t *testing.T) {
 
 						proxy, err := setupDSProxyTest(t, ctx, ds, routes, "pathwithtoken1")
 						require.NoError(t, err)
-						ApplyRoute(proxy.ctx.Req.Context(), req, proxy.proxyPath, routes[0], dsInfo, proxy.cfg)
+						ApplyRoute(proxy.ctx.Req.Context(), req, proxy.proxyPath, routes[0], dsInfo, proxy.settings)
 
 						authorizationHeaderCall3 := req.Header.Get("Authorization")
 						assert.Equal(t, "https://api.nr1.io/some/path", req.URL.String())
@@ -455,7 +455,7 @@ func TestIntegrationDataSourceProxy_routeRule(t *testing.T) {
 		ctx := &contextmodel.ReqContext{}
 
 		proxy, err := setupDSProxyTest(t, ctx, ds, routes, "/render", func(proxy *DataSourceProxy) {
-			proxy.cfg = &setting.Cfg{BuildVersion: "5.3.0"}
+			proxy.settings = &DataSourceProxySettings{}
 		})
 		require.NoError(t, err)
 		req, err := http.NewRequest(http.MethodGet, "http://grafana.com/sub", nil)
@@ -619,7 +619,7 @@ func TestIntegrationDataSourceProxy_routeRule(t *testing.T) {
 					UserID:       1,
 				},
 			},
-			&setting.Cfg{SendUserHeader: true},
+			&DataSourceProxySettings{SendUserHeader: true},
 		)
 		assert.Equal(t, "test_user", req.Header.Get("X-Grafana-User"))
 	})
@@ -632,7 +632,7 @@ func TestIntegrationDataSourceProxy_routeRule(t *testing.T) {
 					Login: "test_user",
 				},
 			},
-			&setting.Cfg{SendUserHeader: false},
+			&DataSourceProxySettings{SendUserHeader: false},
 		)
 		// Get will return empty string even if header is not set
 		assert.Empty(t, req.Header.Get("X-Grafana-User"))
@@ -644,7 +644,7 @@ func TestIntegrationDataSourceProxy_routeRule(t *testing.T) {
 			&contextmodel.ReqContext{
 				SignedInUser: &user.SignedInUser{IsAnonymous: true},
 			},
-			&setting.Cfg{SendUserHeader: true},
+			&DataSourceProxySettings{SendUserHeader: true},
 		)
 		// Get will return empty string even if header is not set
 		assert.Empty(t, req.Header.Get("X-Grafana-User"))
@@ -770,8 +770,7 @@ func TestDataSourceProxy_userAgentHeader(t *testing.T) {
 	t.Run("When DataProxyForwardUserAgent config is disabled", func(t *testing.T) {
 		ctx := &contextmodel.ReqContext{}
 		proxy, err := setupDSProxyTest(t, ctx, ds, routes, "/render", func(p *DataSourceProxy) {
-			p.cfg = &setting.Cfg{
-				BuildVersion:              "5.3.0",
+			p.settings = &DataSourceProxySettings{
 				DataProxyUserAgent:        "Grafana/5.3.0",
 				DataProxyForwardUserAgent: false,
 			}
@@ -790,8 +789,7 @@ func TestDataSourceProxy_userAgentHeader(t *testing.T) {
 	t.Run("When DataProxyForwardUserAgent config is enabled", func(t *testing.T) {
 		ctx := &contextmodel.ReqContext{}
 		proxy, err := setupDSProxyTest(t, ctx, ds, routes, "/render", func(p *DataSourceProxy) {
-			p.cfg = &setting.Cfg{
-				BuildVersion:              "5.3.0",
+			p.settings = &DataSourceProxySettings{
 				DataProxyUserAgent:        "Grafana/5.3.0",
 				DataProxyForwardUserAgent: true,
 			}
@@ -810,8 +808,7 @@ func TestDataSourceProxy_userAgentHeader(t *testing.T) {
 	t.Run("When DataProxyForwardUserAgent config is enabled but the client User-Agent is empty", func(t *testing.T) {
 		ctx := &contextmodel.ReqContext{}
 		proxy, err := setupDSProxyTest(t, ctx, ds, routes, "/render", func(p *DataSourceProxy) {
-			p.cfg = &setting.Cfg{
-				BuildVersion:              "5.3.0",
+			p.settings = &DataSourceProxySettings{
 				DataProxyUserAgent:        "Grafana/5.3.0",
 				DataProxyForwardUserAgent: true,
 			}
@@ -830,8 +827,7 @@ func TestDataSourceProxy_userAgentHeader(t *testing.T) {
 	t.Run("When DataProxyForwardUserAgent config is enabled with a custom DataProxyUserAgent", func(t *testing.T) {
 		ctx := &contextmodel.ReqContext{}
 		proxy, err := setupDSProxyTest(t, ctx, ds, routes, "/render", func(p *DataSourceProxy) {
-			p.cfg = &setting.Cfg{
-				BuildVersion:              "5.3.0",
+			p.settings = &DataSourceProxySettings{
 				DataProxyUserAgent:        "MyCorp/1.0",
 				DataProxyForwardUserAgent: true,
 			}
@@ -850,8 +846,7 @@ func TestDataSourceProxy_userAgentHeader(t *testing.T) {
 	t.Run("When DataProxyForwardUserAgent config is enabled and DataProxyUserAgent is empty", func(t *testing.T) {
 		ctx := &contextmodel.ReqContext{}
 		proxy, err := setupDSProxyTest(t, ctx, ds, routes, "/render", func(p *DataSourceProxy) {
-			p.cfg = &setting.Cfg{
-				BuildVersion:              "5.3.0",
+			p.settings = &DataSourceProxySettings{
 				DataProxyUserAgent:        "",
 				DataProxyForwardUserAgent: true,
 			}
@@ -870,8 +865,7 @@ func TestDataSourceProxy_userAgentHeader(t *testing.T) {
 	t.Run("When DataProxyForwardUserAgent is enabled and the client User-Agent exceeds the length cap, it is truncated", func(t *testing.T) {
 		ctx := &contextmodel.ReqContext{}
 		proxy, err := setupDSProxyTest(t, ctx, ds, routes, "/render", func(p *DataSourceProxy) {
-			p.cfg = &setting.Cfg{
-				BuildVersion:              "5.3.0",
+			p.settings = &DataSourceProxySettings{
 				DataProxyUserAgent:        "Grafana/5.3.0",
 				DataProxyForwardUserAgent: true,
 			}
@@ -892,8 +886,7 @@ func TestDataSourceProxy_userAgentHeader(t *testing.T) {
 	t.Run("When DataProxyForwardUserAgent is enabled and the client User-Agent is exactly the cap, it is forwarded unchanged", func(t *testing.T) {
 		ctx := &contextmodel.ReqContext{}
 		proxy, err := setupDSProxyTest(t, ctx, ds, routes, "/render", func(p *DataSourceProxy) {
-			p.cfg = &setting.Cfg{
-				BuildVersion:              "5.3.0",
+			p.settings = &DataSourceProxySettings{
 				DataProxyUserAgent:        "Grafana/5.3.0",
 				DataProxyForwardUserAgent: true,
 			}
@@ -1151,7 +1144,7 @@ func TestNewDataSourceProxy_MSSQL(t *testing.T) {
 }
 
 // getDatasourceProxiedRequest is a helper for easier setup of tests based on global config and ReqContext.
-func getDatasourceProxiedRequest(t *testing.T, ctx *contextmodel.ReqContext, cfg *setting.Cfg) *http.Request {
+func getDatasourceProxiedRequest(t *testing.T, ctx *contextmodel.ReqContext, proxyCfg *DataSourceProxySettings) *http.Request {
 	ds := &datasources.DataSource{
 		Type: "custom",
 		URL:  "http://host/root/",
@@ -1159,6 +1152,7 @@ func getDatasourceProxiedRequest(t *testing.T, ctx *contextmodel.ReqContext, cfg
 	tracer := tracing.InitializeTracerForTest()
 
 	var routes []*plugins.Route
+	cfg := setting.NewCfg()
 	sqlStore := db.InitTestDB(t)
 	secretsService := secretsmng.SetupTestService(t, fakes.NewFakeSecretsStore())
 	secretsStore := secretskvs.NewSQLSecretsKVStore(sqlStore, secretsService, log.New("test.logger"))
@@ -1169,7 +1163,7 @@ func getDatasourceProxiedRequest(t *testing.T, ctx *contextmodel.ReqContext, cfg
 		&actest.FakePermissionsService{}, quotaService, &pluginstore.FakePluginStore{}, &pluginfakes.FakePluginClient{},
 		plugincontext.ProvideBaseService(cfg, pluginconfig.NewFakePluginRequestConfigProvider()), dsRetriever)
 	require.NoError(t, err)
-	proxy, err := NewDataSourceProxy(ds, routes, ctx, "", cfg, httpclient.NewProvider(), &oauthtoken.Service{}, dsService, tracer, features)
+	proxy, err := NewDataSourceProxy(ds, routes, ctx, "", proxyCfg, httpclient.NewProvider(), &oauthtoken.Service{}, dsService, tracer, features)
 	require.NoError(t, err)
 	req, err := http.NewRequest(http.MethodGet, "http://grafana.com/sub", nil)
 	require.NoError(t, err)
@@ -1296,7 +1290,7 @@ func runDatasourceAuthTest(t *testing.T,
 		&actest.FakePermissionsService{}, quotaService, &pluginstore.FakePluginStore{}, &pluginfakes.FakePluginClient{},
 		plugincontext.ProvideBaseService(cfg, pluginconfig.NewFakePluginRequestConfigProvider()), dsRetriever)
 	require.NoError(t, err)
-	proxy, err := NewDataSourceProxy(test.datasource, routes, ctx, "", &setting.Cfg{}, httpclient.NewProvider(), &oauthtoken.Service{}, dsService, tracer, features)
+	proxy, err := NewDataSourceProxy(test.datasource, routes, ctx, "", &DataSourceProxySettings{}, httpclient.NewProvider(), &oauthtoken.Service{}, dsService, tracer, features)
 	require.NoError(t, err)
 
 	req, err := http.NewRequest(http.MethodGet, "http://grafana.com/sub", nil)
@@ -1357,7 +1351,7 @@ func setupDSProxyTest(t *testing.T, ctx *contextmodel.ReqContext, ds *datasource
 
 	tracer := tracing.InitializeTracerForTest()
 
-	proxy, err := NewDataSourceProxy(ds, routes, ctx, path, cfg, httpclient.NewProvider(), &oauthtoken.Service{}, dsService, tracer, features)
+	proxy, err := NewDataSourceProxy(ds, routes, ctx, path, &DataSourceProxySettings{}, httpclient.NewProvider(), &oauthtoken.Service{}, dsService, tracer, features)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/api/pluginproxy/settings.go
+++ b/pkg/api/pluginproxy/settings.go
@@ -1,0 +1,36 @@
+package pluginproxy
+
+import (
+	"context"
+
+	"github.com/grafana/grafana-azure-sdk-go/v2/azsettings"
+
+	"github.com/grafana/grafana/pkg/setting"
+)
+
+type DataSourceProxySettings struct {
+	SendUserHeader            bool
+	DataProxyUserAgent        string
+	DataProxyForwardUserAgent bool
+	LoginCookieName           string
+	DataProxyLogging          bool
+	DataProxyWhiteList        map[string]bool
+
+	// Load azure settings (avoid fetching the settings unless we are running azure)
+	GetAzureSettings func(context.Context) (*azsettings.AzureSettings, error)
+}
+
+func NewDataSourceProxySettings(cfg *setting.Cfg) *DataSourceProxySettings {
+	return &DataSourceProxySettings{
+		SendUserHeader:            cfg.SendUserHeader,
+		DataProxyUserAgent:        cfg.DataProxyUserAgent,
+		DataProxyForwardUserAgent: cfg.DataProxyForwardUserAgent,
+		LoginCookieName:           cfg.LoginCookieName,
+		DataProxyLogging:          cfg.DataProxyLogging,
+		DataProxyWhiteList:        cfg.DataProxyWhiteList,
+
+		GetAzureSettings: func(context.Context) (*azsettings.AzureSettings, error) {
+			return cfg.Azure, nil
+		},
+	}
+}

--- a/pkg/api/pluginproxy/token_provider_azure.go
+++ b/pkg/api/pluginproxy/token_provider_azure.go
@@ -2,6 +2,7 @@ package pluginproxy
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/grafana/grafana-azure-sdk-go/v2/azcredentials"
@@ -9,7 +10,6 @@ import (
 	"github.com/grafana/grafana-azure-sdk-go/v2/aztokenprovider"
 
 	"github.com/grafana/grafana/pkg/plugins"
-	"github.com/grafana/grafana/pkg/setting"
 )
 
 type azureAccessTokenProvider struct {
@@ -18,9 +18,16 @@ type azureAccessTokenProvider struct {
 	scopes        []string
 }
 
-func newAzureAccessTokenProvider(ctx context.Context, cfg *setting.Cfg, authParams *plugins.JWTTokenAuth) (*azureAccessTokenProvider, error) {
-	credentials := getAzureCredentials(cfg.Azure, authParams)
-	tokenProvider, err := aztokenprovider.NewAzureAccessTokenProvider(cfg.Azure, credentials, false)
+func newAzureAccessTokenProvider(ctx context.Context, settings *DataSourceProxySettings, authParams *plugins.JWTTokenAuth) (*azureAccessTokenProvider, error) {
+	if settings.GetAzureSettings == nil {
+		return nil, fmt.Errorf("missing azure settings")
+	}
+	azureSettings, err := settings.GetAzureSettings(ctx)
+	if err != nil {
+		return nil, err
+	}
+	credentials := getAzureCredentials(azureSettings, authParams)
+	tokenProvider, err := aztokenprovider.NewAzureAccessTokenProvider(azureSettings, credentials, false)
 	if err != nil {
 		return nil, err
 	}
@@ -49,13 +56,12 @@ func getAzureCredentials(settings *azsettings.AzureSettings, authParams *plugins
 
 	if isManagedIdentity {
 		return &azcredentials.AzureManagedIdentityCredentials{}
-	} else {
-		return &azcredentials.AzureClientSecretCredentials{
-			AzureCloud:   authParams.Params["azure_cloud"],
-			Authority:    authParams.Url,
-			TenantId:     authParams.Params["tenant_id"],
-			ClientId:     authParams.Params["client_id"],
-			ClientSecret: authParams.Params["client_secret"],
-		}
+	}
+	return &azcredentials.AzureClientSecretCredentials{
+		AzureCloud:   authParams.Params["azure_cloud"],
+		Authority:    authParams.Url,
+		TenantId:     authParams.Params["tenant_id"],
+		ClientId:     authParams.Params["client_id"],
+		ClientSecret: authParams.Params["client_secret"],
 	}
 }

--- a/pkg/services/datasourceproxy/datasourceproxy.go
+++ b/pkg/services/datasourceproxy/datasourceproxy.go
@@ -35,7 +35,7 @@ func ProvideService(dataSourceCache datasources.CacheService, datasourceReqValid
 		DataSourceCache:            dataSourceCache,
 		DataSourceRequestValidator: datasourceReqValidator,
 		pluginStore:                pluginStore,
-		Cfg:                        cfg,
+		proxyCfg:                   pluginproxy.NewDataSourceProxySettings(cfg),
 		HTTPClientProvider:         httpClientProvider,
 		OAuthTokenService:          oauthTokenService,
 		DataSourcesService:         dsService,
@@ -49,7 +49,7 @@ type DataSourceProxyService struct {
 	DataSourceCache            datasources.CacheService
 	DataSourceRequestValidator validations.DataSourceRequestValidator
 	pluginStore                pluginstore.Store
-	Cfg                        *setting.Cfg
+	proxyCfg                   *pluginproxy.DataSourceProxySettings
 	HTTPClientProvider         httpclient.Provider
 	OAuthTokenService          *oauthtoken.Service
 	DataSourcesService         datasources.DataSourceService
@@ -125,7 +125,7 @@ func (p *DataSourceProxyService) proxyDatasourceRequest(c *contextmodel.ReqConte
 	}
 
 	proxyPath := getProxyPath(c)
-	proxy, err := pluginproxy.NewDataSourceProxy(ds, plugin.Routes, c, proxyPath, p.Cfg, p.HTTPClientProvider,
+	proxy, err := pluginproxy.NewDataSourceProxy(ds, plugin.Routes, c, proxyPath, p.proxyCfg, p.HTTPClientProvider,
 		p.OAuthTokenService, p.DataSourcesService, p.tracer, p.features)
 	if err != nil {
 		var urlValidationError datasource.URLValidationError


### PR DESCRIPTION
This is a first baby step towards refactoring the plugin proxy so it can be references from datasource APIservers.  This PR avoids having full access to `*setting.Cfg` deep in the proxy code.

## Summary

- The data source proxy only uses a handful of fields from `*setting.Cfg`. Introduce a focused `DataSourceProxySettings` struct in `pkg/api/pluginproxy/settings.go` exposing just those fields, and pass it through the datasource proxy service in place of the full Grafana config.
- Load Azure settings lazily via a `GetAzureSettings` resolver callback so the proxy avoids touching Azure configuration unless an Azure-authenticated route is matched.
- Tidy up along the way: rename the struct field from `cfg` to `settings`, and simplify `setupDSProxyTest` to construct settings inline instead of routing through `NewDataSourceProxySettings(setting.NewCfg())`.

## Test plan

- [ ] `go build ./pkg/api/pluginproxy/... ./pkg/services/datasourceproxy/...` passes
- [ ] `go vet ./pkg/api/pluginproxy/... ./pkg/services/datasourceproxy/...` passes
- [ ] `go test -count=1 -short ./pkg/api/pluginproxy/...` passes
- [ ] CI is green