### PR TITLE
fix: use search on /children call

### DIFF
--- a/pkg/registry/apis/folders/register.go
+++ b/pkg/registry/apis/folders/register.go
@@ -208,8 +208,8 @@ func (b *FolderAPIBuilder) storageForVersion(
 
 	// Adds a path to return children of a given folder
 	storage[folders.StoragePath("children")] = &subChildrenREST{
-		getter: b.storage,
-		lister: b.storage,
+		getter:   b.storage,
+		searcher: b.searcher,
 	}
 
 	apiGroupInfo.VersionedResourcesStorageMap[folders.GroupVersion().Version] = storage

--- a/pkg/registry/apis/folders/sub_children.go
+++ b/pkg/registry/apis/folders/sub_children.go
@@ -54,12 +54,10 @@ func (r *subChildrenREST) NewConnectOptions() (runtime.Object, bool, string) {
 }
 
 func (r *subChildrenREST) Connect(ctx context.Context, name string, _ runtime.Object, responder rest.Responder) (http.Handler, error) {
-	if _, err := r.getter.Get(ctx, name, &v1.GetOptions{}); err != nil {
-		return nil, err
-	}
-
 	if name == folder.GeneralFolderUID {
 		name = ""
+	} else if _, err := r.getter.Get(ctx, name, &v1.GetOptions{}); err != nil {
+		return nil, err
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {

--- a/pkg/registry/apis/folders/sub_children.go
+++ b/pkg/registry/apis/folders/sub_children.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	childrenDefaultLimit = 100
+	childrenDefaultLimit = 500
 	childrenMaxLimit     = 500
 )
 
@@ -96,11 +96,14 @@ func (r *subChildrenREST) Connect(ctx context.Context, name string, _ runtime.Ob
 			return
 		}
 		if resp.Error != nil {
-			responder.Error(fmt.Errorf("search error: %s", resp.Error.Message))
+			responder.Error(resource.GetError(resp.Error))
 			return
 		}
 
 		children := &folders.FolderList{Items: []folders.Folder{}}
+		if resp.ResourceVersion > 0 {
+			children.ResourceVersion = strconv.FormatInt(resp.ResourceVersion, 10)
+		}
 		if resp.Results != nil {
 			titleIdx := -1
 			for i, col := range resp.Results.Columns {
@@ -115,6 +118,9 @@ func (r *subChildrenREST) Connect(ctx context.Context, name string, _ runtime.Ob
 				f := folders.Folder{}
 				f.Name = row.Key.Name
 				f.Namespace = row.Key.Namespace
+				if row.ResourceVersion > 0 {
+					f.ResourceVersion = strconv.FormatInt(row.ResourceVersion, 10)
+				}
 				if titleIdx >= 0 && titleIdx < len(row.Cells) {
 					f.Spec.Title = string(row.Cells[titleIdx])
 				}
@@ -122,9 +128,7 @@ func (r *subChildrenREST) Connect(ctx context.Context, name string, _ runtime.Ob
 			}
 
 			total := resp.TotalHits
-			if resp.Results.NextPageToken != "" {
-				children.Continue = resp.Results.NextPageToken
-			} else if offset+int64(len(resp.Results.Rows)) < total {
+			if offset+int64(len(resp.Results.Rows)) < total {
 				children.Continue = strconv.FormatInt(offset+int64(len(resp.Results.Rows)), 10)
 			}
 			if total > 0 {
@@ -139,6 +143,8 @@ func (r *subChildrenREST) Connect(ctx context.Context, name string, _ runtime.Ob
 	}), nil
 }
 
+// The continue token is a raw decimal offset, not an opaque k8s token.
+// Offset paging over a live index may skip or duplicate items across pages.
 func parseChildrenPaging(req *http.Request) (int64, int64, error) {
 	q := req.URL.Query()
 	limit := int64(childrenDefaultLimit)

--- a/pkg/registry/apis/folders/sub_children.go
+++ b/pkg/registry/apis/folders/sub_children.go
@@ -4,20 +4,27 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strconv"
 
-	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
 
 	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
-	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	"github.com/grafana/grafana/pkg/services/folder"
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+)
+
+const (
+	childrenDefaultLimit = 100
+	childrenMaxLimit     = 500
 )
 
 type subChildrenREST struct {
-	getter rest.Getter
-	lister rest.Lister
+	getter   rest.Getter
+	searcher resourcepb.ResourceIndexClient
 }
 
 var _ = rest.Connecter(&subChildrenREST{})
@@ -43,46 +50,120 @@ func (r *subChildrenREST) ConnectMethods() []string {
 }
 
 func (r *subChildrenREST) NewConnectOptions() (runtime.Object, bool, string) {
-	return nil, false, "" // true means you can use the trailing path as a variable
+	return nil, false, ""
 }
 
-func (r *subChildrenREST) Connect(ctx context.Context, name string, opts runtime.Object, responder rest.Responder) (http.Handler, error) {
+func (r *subChildrenREST) Connect(ctx context.Context, name string, _ runtime.Object, responder rest.Responder) (http.Handler, error) {
 	if _, err := r.getter.Get(ctx, name, &v1.GetOptions{}); err != nil {
 		return nil, err
 	}
 
-	obj, err := r.lister.List(ctx, &internalversion.ListOptions{
-		Limit: 500,
-		// TODO, field selector
-	})
-	if err != nil {
-		return nil, err
-	}
-	allFolders, ok := obj.(*folders.FolderList)
-	if !ok {
-		return nil, fmt.Errorf("could not list folders")
-	}
-	if allFolders.Continue != "" {
-		return nil, fmt.Errorf("found too many folders to process")
-	}
-
 	if name == folder.GeneralFolderUID {
-		name = "" // general is empty
+		name = ""
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		ns, err := request.NamespaceInfoFrom(ctx, true)
+		if err != nil {
+			responder.Error(err)
+			return
+		}
+
+		limit, offset, err := parseChildrenPaging(req)
+		if err != nil {
+			responder.Error(err)
+			return
+		}
+
+		gvr := folders.FolderResourceInfo.GroupVersionResource()
+		resp, err := r.searcher.Search(ctx, &resourcepb.ResourceSearchRequest{
+			Options: &resourcepb.ListOptions{
+				Key: &resourcepb.ResourceKey{
+					Namespace: ns.Value,
+					Group:     gvr.Group,
+					Resource:  gvr.Resource,
+				},
+				Fields: []*resourcepb.Requirement{{
+					Key:      resource.SEARCH_FIELD_FOLDER,
+					Operator: "=",
+					Values:   []string{name},
+				}},
+			},
+			Fields: []string{resource.SEARCH_FIELD_TITLE},
+			Limit:  limit,
+			Offset: offset,
+		})
+		if err != nil {
+			responder.Error(err)
+			return
+		}
+		if resp.Error != nil {
+			responder.Error(fmt.Errorf("search error: %s", resp.Error.Message))
+			return
+		}
+
 		children := &folders.FolderList{}
-		for _, folder := range allFolders.Items {
-			v, err := utils.MetaAccessor(folder)
-			if err != nil {
-				continue
+		if resp.Results != nil {
+			titleIdx := -1
+			for i, col := range resp.Results.Columns {
+				if col.Name == resource.SEARCH_FIELD_TITLE {
+					titleIdx = i
+				}
+			}
+			for _, row := range resp.Results.Rows {
+				if row.Key == nil {
+					continue
+				}
+				f := folders.Folder{}
+				f.Name = row.Key.Name
+				f.Namespace = row.Key.Namespace
+				if titleIdx >= 0 && titleIdx < len(row.Cells) {
+					f.Spec.Title = string(row.Cells[titleIdx])
+				}
+				children.Items = append(children.Items, f)
 			}
 
-			if name == v.GetFolder() {
-				children.Items = append(children.Items, folder)
+			total := resp.TotalHits
+			if resp.Results.NextPageToken != "" {
+				children.Continue = resp.Results.NextPageToken
+			} else if offset+int64(len(resp.Results.Rows)) < total {
+				children.Continue = strconv.FormatInt(offset+int64(len(resp.Results.Rows)), 10)
+			}
+			if total > 0 {
+				remaining := total - (offset + int64(len(resp.Results.Rows)))
+				if remaining > 0 {
+					children.RemainingItemCount = &remaining
+				}
 			}
 		}
 
 		responder.Object(http.StatusOK, children)
 	}), nil
+}
+
+func parseChildrenPaging(req *http.Request) (int64, int64, error) {
+	q := req.URL.Query()
+	limit := int64(childrenDefaultLimit)
+	if v := q.Get("limit"); v != "" {
+		parsed, err := strconv.ParseInt(v, 10, 64)
+		if err != nil || parsed < 0 {
+			return 0, 0, fmt.Errorf("invalid limit: %q", v)
+		}
+		if parsed > 0 {
+			limit = parsed
+		}
+	}
+	if limit > childrenMaxLimit {
+		limit = childrenMaxLimit
+	}
+
+	var offset int64
+	if v := q.Get("continue"); v != "" {
+		parsed, err := strconv.ParseInt(v, 10, 64)
+		if err != nil || parsed < 0 {
+			return 0, 0, fmt.Errorf("invalid continue token: %q", v)
+		}
+		offset = parsed
+	}
+	return limit, offset, nil
 }

--- a/pkg/registry/apis/folders/sub_children.go
+++ b/pkg/registry/apis/folders/sub_children.go
@@ -100,7 +100,7 @@ func (r *subChildrenREST) Connect(ctx context.Context, name string, _ runtime.Ob
 			return
 		}
 
-		children := &folders.FolderList{}
+		children := &folders.FolderList{Items: []folders.Folder{}}
 		if resp.Results != nil {
 			titleIdx := -1
 			for i, col := range resp.Results.Columns {

--- a/pkg/registry/apis/folders/sub_children_test.go
+++ b/pkg/registry/apis/folders/sub_children_test.go
@@ -1,0 +1,225 @@
+package folders
+
+import (
+	"context"
+	"errors"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	apirequest "k8s.io/apiserver/pkg/endpoints/request"
+
+	folders "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
+	"github.com/grafana/grafana/pkg/services/folder"
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+)
+
+type stubGetter struct {
+	obj runtime.Object
+	err error
+}
+
+func (s *stubGetter) Get(ctx context.Context, name string, options *metav1.GetOptions) (runtime.Object, error) {
+	return s.obj, s.err
+}
+
+type capturingSearchClient struct {
+	resp *resourcepb.ResourceSearchResponse
+	err  error
+
+	mu      sync.Mutex
+	lastReq *resourcepb.ResourceSearchRequest
+}
+
+func (c *capturingSearchClient) Search(ctx context.Context, in *resourcepb.ResourceSearchRequest, opts ...grpc.CallOption) (*resourcepb.ResourceSearchResponse, error) {
+	c.mu.Lock()
+	c.lastReq = in
+	c.mu.Unlock()
+	return c.resp, c.err
+}
+func (c *capturingSearchClient) GetStats(ctx context.Context, in *resourcepb.ResourceStatsRequest, opts ...grpc.CallOption) (*resourcepb.ResourceStatsResponse, error) {
+	return nil, nil
+}
+func (c *capturingSearchClient) RebuildIndexes(ctx context.Context, in *resourcepb.RebuildIndexesRequest, opts ...grpc.CallOption) (*resourcepb.RebuildIndexesResponse, error) {
+	return nil, nil
+}
+func (c *capturingSearchClient) VectorSearch(ctx context.Context, in *resourcepb.VectorSearchRequest, opts ...grpc.CallOption) (*resourcepb.VectorSearchResponse, error) {
+	return nil, nil
+}
+
+type recordingResponder struct {
+	obj    runtime.Object
+	status int
+	err    error
+}
+
+func (r *recordingResponder) Object(statusCode int, obj runtime.Object) {
+	r.status = statusCode
+	r.obj = obj
+}
+func (r *recordingResponder) Error(err error) {
+	r.err = err
+}
+
+func childrenResponseWith(rows []*resourcepb.ResourceTableRow, total int64) *resourcepb.ResourceSearchResponse {
+	return &resourcepb.ResourceSearchResponse{
+		Results: &resourcepb.ResourceTable{
+			Columns: []*resourcepb.ResourceTableColumnDefinition{
+				{Name: resource.SEARCH_FIELD_TITLE},
+			},
+			Rows: rows,
+		},
+		TotalHits: total,
+	}
+}
+
+func childRow(uid, title string) *resourcepb.ResourceTableRow {
+	return &resourcepb.ResourceTableRow{
+		Key:   &resourcepb.ResourceKey{Name: uid, Namespace: "default"},
+		Cells: [][]byte{[]byte(title)},
+	}
+}
+
+func newChildrenCtx() context.Context {
+	return apirequest.WithNamespace(context.Background(), "default")
+}
+
+func TestSubChildren_GeneralFolderSkipsGetterAndFiltersOnEmptyParent(t *testing.T) {
+	getter := &stubGetter{err: errors.New("should not be called")}
+	search := &capturingSearchClient{
+		resp: childrenResponseWith([]*resourcepb.ResourceTableRow{
+			childRow("a", "Alpha"),
+		}, 1),
+	}
+	rest := &subChildrenREST{getter: getter, searcher: search}
+
+	handler, err := rest.Connect(newChildrenCtx(), folder.GeneralFolderUID, nil, &recordingResponder{})
+	require.NoError(t, err)
+	require.NotNil(t, handler)
+
+	resp := &recordingResponder{}
+	handler, err = rest.Connect(newChildrenCtx(), folder.GeneralFolderUID, nil, resp)
+	require.NoError(t, err)
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/general/children", nil))
+
+	require.NoError(t, resp.err)
+	require.NotNil(t, search.lastReq)
+	require.Len(t, search.lastReq.Options.Fields, 1)
+	require.Equal(t, resource.SEARCH_FIELD_FOLDER, search.lastReq.Options.Fields[0].Key)
+	require.Equal(t, []string{""}, search.lastReq.Options.Fields[0].Values)
+
+	list, ok := resp.obj.(*folders.FolderList)
+	require.True(t, ok)
+	require.Len(t, list.Items, 1)
+	require.Equal(t, "a", list.Items[0].Name)
+	require.Equal(t, "Alpha", list.Items[0].Spec.Title)
+}
+
+func TestSubChildren_NamedFolderHitsGetterAndFiltersOnUID(t *testing.T) {
+	getter := &stubGetter{obj: &folders.Folder{ObjectMeta: metav1.ObjectMeta{Name: "parent"}}}
+	search := &capturingSearchClient{
+		resp: childrenResponseWith([]*resourcepb.ResourceTableRow{
+			childRow("c1", "Child One"),
+			childRow("c2", "Child Two"),
+		}, 2),
+	}
+	rest := &subChildrenREST{getter: getter, searcher: search}
+
+	resp := &recordingResponder{}
+	handler, err := rest.Connect(newChildrenCtx(), "parent", nil, resp)
+	require.NoError(t, err)
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/parent/children", nil))
+
+	require.NoError(t, resp.err)
+	require.Equal(t, []string{"parent"}, search.lastReq.Options.Fields[0].Values)
+	require.Equal(t, "=", search.lastReq.Options.Fields[0].Operator)
+
+	list := resp.obj.(*folders.FolderList)
+	require.Len(t, list.Items, 2)
+	require.Equal(t, "c1", list.Items[0].Name)
+	require.Equal(t, "Child Two", list.Items[1].Spec.Title)
+	require.Empty(t, list.Continue)
+}
+
+func TestSubChildren_GetterErrorPropagates(t *testing.T) {
+	getter := &stubGetter{err: errors.New("not found")}
+	rest := &subChildrenREST{getter: getter, searcher: &capturingSearchClient{}}
+
+	handler, err := rest.Connect(newChildrenCtx(), "missing", nil, &recordingResponder{})
+	require.Error(t, err)
+	require.Nil(t, handler)
+}
+
+func TestSubChildren_PaginationProducesContinue(t *testing.T) {
+	getter := &stubGetter{obj: &folders.Folder{ObjectMeta: metav1.ObjectMeta{Name: "parent"}}}
+	search := &capturingSearchClient{
+		resp: childrenResponseWith([]*resourcepb.ResourceTableRow{
+			childRow("c1", "A"),
+			childRow("c2", "B"),
+		}, 7),
+	}
+	rest := &subChildrenREST{getter: getter, searcher: search}
+
+	resp := &recordingResponder{}
+	handler, err := rest.Connect(newChildrenCtx(), "parent", nil, resp)
+	require.NoError(t, err)
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/parent/children?limit=2&continue=3", nil))
+
+	require.NoError(t, resp.err)
+	require.Equal(t, int64(2), search.lastReq.Limit)
+	require.Equal(t, int64(3), search.lastReq.Offset)
+
+	list := resp.obj.(*folders.FolderList)
+	require.Equal(t, "5", list.Continue)
+	require.NotNil(t, list.RemainingItemCount)
+	require.Equal(t, int64(2), *list.RemainingItemCount)
+}
+
+func TestSubChildren_InvalidContinueRejected(t *testing.T) {
+	getter := &stubGetter{obj: &folders.Folder{ObjectMeta: metav1.ObjectMeta{Name: "parent"}}}
+	rest := &subChildrenREST{getter: getter, searcher: &capturingSearchClient{}}
+
+	resp := &recordingResponder{}
+	handler, err := rest.Connect(newChildrenCtx(), "parent", nil, resp)
+	require.NoError(t, err)
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/parent/children?continue=not-a-number", nil))
+
+	require.Error(t, resp.err)
+	require.Nil(t, resp.obj)
+}
+
+func TestSubChildren_SearchErrorSurfaces(t *testing.T) {
+	getter := &stubGetter{obj: &folders.Folder{ObjectMeta: metav1.ObjectMeta{Name: "parent"}}}
+	search := &capturingSearchClient{err: errors.New("boom")}
+	rest := &subChildrenREST{getter: getter, searcher: search}
+
+	resp := &recordingResponder{}
+	handler, err := rest.Connect(newChildrenCtx(), "parent", nil, resp)
+	require.NoError(t, err)
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/parent/children", nil))
+
+	require.Error(t, resp.err)
+	require.Nil(t, resp.obj)
+}
+
+func TestSubChildren_EmptyResults(t *testing.T) {
+	getter := &stubGetter{obj: &folders.Folder{ObjectMeta: metav1.ObjectMeta{Name: "parent"}}}
+	search := &capturingSearchClient{resp: childrenResponseWith(nil, 0)}
+	rest := &subChildrenREST{getter: getter, searcher: search}
+
+	resp := &recordingResponder{}
+	handler, err := rest.Connect(newChildrenCtx(), "parent", nil, resp)
+	require.NoError(t, err)
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/parent/children", nil))
+
+	require.NoError(t, resp.err)
+	list := resp.obj.(*folders.FolderList)
+	require.Empty(t, list.Items)
+	require.Empty(t, list.Continue)
+	require.Nil(t, list.RemainingItemCount)
+}

--- a/pkg/registry/apis/folders/sub_children_test.go
+++ b/pkg/registry/apis/folders/sub_children_test.go
@@ -98,13 +98,10 @@ func TestSubChildren_GeneralFolderSkipsGetterAndFiltersOnEmptyParent(t *testing.
 	}
 	rest := &subChildrenREST{getter: getter, searcher: search}
 
-	handler, err := rest.Connect(newChildrenCtx(), folder.GeneralFolderUID, nil, &recordingResponder{})
+	resp := &recordingResponder{}
+	handler, err := rest.Connect(newChildrenCtx(), folder.GeneralFolderUID, nil, resp)
 	require.NoError(t, err)
 	require.NotNil(t, handler)
-
-	resp := &recordingResponder{}
-	handler, err = rest.Connect(newChildrenCtx(), folder.GeneralFolderUID, nil, resp)
-	require.NoError(t, err)
 	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest("GET", "/general/children", nil))
 
 	require.NoError(t, resp.err)


### PR DESCRIPTION
Use search for finding the children. It enables us to go beyond the previously hard-coded 500 folders limit by paginating through the search call.

<img width="487" height="392" alt="Screenshot 2026-05-21 at 12 14 24" src="https://github.com/user-attachments/assets/af67b271-9df5-4822-9413-926aa9a98d75" />



`/apis/folder.grafana.app/v1beta1/namespaces/default/folders/ac-parity-parent/children`:
```json
{
  "kind": "FolderList",
  "apiVersion": "folder.grafana.app/v1beta1",
  "metadata": {
    "resourceVersion": "1779293169991986"
  },
  "items": [
    {
      "metadata": {
        "name": "ac-parity-child",
        "namespace": "default"
      },
      "spec": {
        "title": "AC parity — child"
      }
    },
    {
      "metadata": {
        "name": "cfmnbyzibthc0b",
        "namespace": "default"
      },
      "spec": {
        "title": "AC parity — child2"
      }
    }
  ]
}
```

Ticket: https://github.com/grafana/search-and-storage-team/issues/794