### PR TITLE
AuthN: increase SA token query limit from 300 to 1000

### DIFF
--- a/pkg/services/serviceaccounts/database/token_store.go
+++ b/pkg/services/serviceaccounts/database/token_store.go
@@ -11,7 +11,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/serviceaccounts"
 )
 
-const maxRetrievedTokens = 300
+const maxRetrievedTokens = 1000
 
 func (s *ServiceAccountsStoreImpl) ListTokens(
 	ctx context.Context, query *serviceaccounts.GetSATokensQuery,


### PR DESCRIPTION
This PR bumps the hard-coded service account token query limit from 300 to 1000 as a stopgap until the new endpoint that supports pagination lands. This allows users who have created more than 300 tokens on a single service account to retrieve info for those tokens via the UI and API.