### PR TITLE
PanelEditNext: Add missing error boundary for v2 query editor

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.test.tsx
@@ -1,10 +1,11 @@
 import { act, render, screen } from '@testing-library/react';
-import { useEffect, useRef, useState } from 'react';
+import { type ReactElement, useEffect, useRef, useState } from 'react';
 
 import {
   type DataQueryError,
   type DataSourceApi,
   type DataSourceJsonData,
+  type QueryEditorProps,
   getDefaultTimeRange,
   LoadingState,
 } from '@grafana/data';
@@ -41,6 +42,12 @@ interface TestQuery extends DataQuery {
 function UncontrolledQueryEditor({ query }: { query: TestQuery }) {
   const [legend] = useState(query.legendFormat ?? '');
   return <div data-testid="query-editor-legend">{legend}</div>;
+}
+
+function ThrowingQueryEditor(
+  _props: QueryEditorProps<DataSourceApi<DataQuery, DataSourceJsonData>, DataQuery, DataSourceJsonData>
+): ReactElement {
+  throw new Error('Query editor failed to render');
 }
 
 const mockDatasource: Partial<DataSourceApi<DataQuery, DataSourceJsonData>> = {
@@ -85,6 +92,27 @@ describe('QueryEditorRenderer', () => {
   it('renders the query editor for the selected query', () => {
     renderRenderer(queryA);
     expect(screen.getByTestId('query-editor-legend')).toHaveTextContent('series-a');
+  });
+
+  it('shows an error boundary alert when the datasource query editor throws', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const throwingDatasource: Partial<DataSourceApi<DataQuery, DataSourceJsonData>> = {
+      components: { QueryEditor: ThrowingQueryEditor },
+    };
+
+    try {
+      renderRenderer(queryA, {
+        selectedQueryDsData: {
+          datasource: throwingDatasource as DataSourceApi,
+          dsSettings: ds1SettingsMock,
+        },
+      });
+
+      expect(await screen.findByText('An unexpected error happened')).toBeInTheDocument();
+      expect(screen.getByText(/Query editor failed to render/)).toBeInTheDocument();
+    } finally {
+      consoleSpy.mockRestore();
+    }
   });
 
   it('remounts the query editor when switching queries, resetting uncontrolled input state', () => {

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.tsx
@@ -3,7 +3,7 @@ import { useCallback, useMemo } from 'react';
 import { CoreApp, DataSourcePluginContextProvider } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 import { type DataQuery } from '@grafana/schema';
-import { Alert, Spinner, Stack, Text } from '@grafana/ui';
+import { Alert, ErrorBoundaryAlert, Spinner, Stack, Text } from '@grafana/ui';
 import { filterPanelDataToQuery } from 'app/features/query/components/QueryEditorRow';
 import { QueryErrorAlert } from 'app/features/query/components/QueryErrorAlert';
 
@@ -73,18 +73,20 @@ export function QueryEditorRenderer() {
   return (
     <>
       <DataSourcePluginContextProvider instanceSettings={dsSettings}>
-        <QueryEditorComponent
-          key={selectedQuery.refId}
-          app={CoreApp.Dashboard}
-          data={filteredData}
-          datasource={datasource}
-          onAddQuery={addQuery}
-          onChange={handleChange}
-          onRunQuery={runQueries}
-          queries={queries}
-          query={selectedQuery}
-          range={filteredData?.timeRange}
-        />
+        <ErrorBoundaryAlert boundaryName="query-editor-renderer">
+          <QueryEditorComponent
+            key={selectedQuery.refId}
+            app={CoreApp.Dashboard}
+            data={filteredData}
+            datasource={datasource}
+            onAddQuery={addQuery}
+            onChange={handleChange}
+            onRunQuery={runQueries}
+            queries={queries}
+            query={selectedQuery}
+            range={filteredData?.timeRange}
+          />
+        </ErrorBoundaryAlert>
       </DataSourcePluginContextProvider>
       {error && <QueryErrorAlert error={error} />}
     </>


### PR DESCRIPTION
**What is this feature?**

Adds a missing error boundary in the v2 feature flow to ensure runtime errors are properly caught and rendered through the expected boundary UI.

**Why do we need this feature?**

Without this boundary, errors occurring in the v2 flow were not handled by the expected error boundary, which could result in uncaught rendering failures and inconsistent error handling behavior.

This PR ensures the v2 flow behaves consistently with the intended error handling architecture.

**Who is this feature for?**

Developers and users working with the v2 feature flow, particularly when runtime errors occur inside the affected component tree.

**Which issue(s) does this PR fix?**:

Fixes  #125024 

**Special notes for your reviewer:**

* Manually tested by enabling the v2 feature toggle and verifying the correct error boundary is rendered.
* Added automated test coverage for the missing boundary case.
* Included before/after screenshots showing the correct boundary behavior.

Before:
<img width="1912" height="920" alt="Screenshot 2026-05-20 171258" src="https://github.com/user-attachments/assets/7538eedb-33df-47b3-baa4-b1179212c8d8" />

After:
<img width="1906" height="929" alt="Screenshot 2026-05-20 171208" src="https://github.com/user-attachments/assets/b09be449-0ca1-496e-a056-13bf75b61c07" />

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
