### PR TITLE
TestUtils: MeasureText mock

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -73,6 +73,8 @@ module.exports = {
     '@bsull/augurs': '<rootDir>/public/test/mocks/augurs.ts',
     // Mock @grafana/assistant to prevent initialization errors in tests
     '^@grafana/assistant$': '<rootDir>/public/test/mocks/assistant.ts',
+    // Mock measureText to prevent invalid calculations with uPlot
+    '^@grafana/ui/src/utils/measureText$': '<rootDir>/packages/grafana-ui/src/utils/measureText.ts',
   },
   // Log the test results with dynamic Loki tags. Drone CI only
   reporters: ['default', ['<rootDir>/public/test/log-reporter.js', { enable: process.env.DRONE === 'true' }]],

--- a/packages/grafana-test-utils/README.md
+++ b/packages/grafana-test-utils/README.md
@@ -22,3 +22,24 @@ Tests that an Observable emits the expected values in the correct order. This ma
 ### `toEmitValuesWith`
 
 Tests that an Observable emits values that satisfy custom expectations. This matcher collects all emitted values and passes them to a callback function where you can perform custom assertions.
+
+## Canvas snapshot tests & uPlot
+
+uPlot axis layout uses `measureText` from `@grafana/ui`. In JSDOM, `jest-canvas-mock` reports `TextMetrics.width === text.length`, which breaks axis sizing compared to the browser. Use `@grafana/test-utils/canvas` in `*.canvas.test.ts(x)` files:
+
+```ts
+import { measureText as uPlotAxisMeasureText } from '@grafana/ui';
+import { applyDefaultUPlotAxisMeasureTextMock } from '@grafana/test-utils/canvas';
+
+jest.mock('@grafana/ui/src/utils/measureText', () =>
+  require('@grafana/test-utils/canvas').createGrafanaUiMeasureTextJestMock()
+);
+
+beforeEach(() => {
+  applyDefaultUPlotAxisMeasureTextMock(uPlotAxisMeasureText as jest.MockedFunction<typeof uPlotAxisMeasureText>);
+});
+```
+
+Override widths in a single test with `uPlotAxisMeasureText.mockImplementationOnce(...)`; the default is restored in `beforeEach`.
+
+Inside `packages/grafana-ui`, mock the same relative path the component uses (e.g. `'../../../../utils/measureText'`) and pass it to `createGrafanaUiMeasureTextJestMock`.

--- a/packages/grafana-test-utils/package.json
+++ b/packages/grafana-test-utils/package.json
@@ -45,6 +45,10 @@
       "types": "./src/matchers/index.ts",
       "import": "./src/matchers/index.ts",
       "require": "./src/matchers/index.ts"
+    },
+    "./canvas": {
+      "import": "./src/canvas/index.ts",
+      "require": "./src/canvas/index.ts"
     }
   },
   "scripts": {

--- a/packages/grafana-test-utils/src/canvas/index.ts
+++ b/packages/grafana-test-utils/src/canvas/index.ts
@@ -1,0 +1,7 @@
+export {
+  applyDefaultUPlotAxisMeasureTextMock,
+  createGrafanaUiMeasureTextJestMock,
+  defaultAxisTextWidthForCanvasTests,
+  GRAFANA_UI_MEASURE_TEXT_MODULE,
+  type GrafanaUiMeasureTextFn,
+} from './measureText';

--- a/packages/grafana-test-utils/src/canvas/measureText.test.ts
+++ b/packages/grafana-test-utils/src/canvas/measureText.test.ts
@@ -1,0 +1,13 @@
+import { defaultAxisTextWidthForCanvasTests } from './measureText';
+
+describe('defaultAxisTextWidthForCanvasTests', () => {
+  it('scales with character count and font size', () => {
+    expect(defaultAxisTextWidthForCanvasTests('ab', 12)).toBe(14.4);
+    expect(defaultAxisTextWidthForCanvasTests('ab', 24)).toBe(28.8);
+  });
+
+  it('enforces a minimum width', () => {
+    expect(defaultAxisTextWidthForCanvasTests('', 12)).toBe(8);
+    expect(defaultAxisTextWidthForCanvasTests(null, 12)).toBe(8);
+  });
+});

--- a/packages/grafana-test-utils/src/canvas/measureText.ts
+++ b/packages/grafana-test-utils/src/canvas/measureText.ts
@@ -1,0 +1,53 @@
+/**
+ * Deterministic `measureText` helpers for uPlot canvas snapshot tests.
+ *
+ * jest-canvas-mock reports `TextMetrics.width === text.length`, which breaks Y/X axis
+ * layout compared to the browser. Use {@link createGrafanaUiMeasureTextJestMock} with
+ * `jest.mock` and {@link applyDefaultUPlotAxisMeasureTextMock} in `beforeEach`.
+ *
+ * @example
+ * ```ts
+ * import { measureText as uPlotAxisMeasureText } from '@grafana/ui';
+ * import { applyDefaultUPlotAxisMeasureTextMock } from '@grafana/test-utils/canvas';
+ *
+ * jest.mock('@grafana/ui/src/utils/measureText', () =>
+ *   require('@grafana/test-utils/canvas').createGrafanaUiMeasureTextJestMock()
+ * );
+ *
+ * beforeEach(() => {
+ *   applyDefaultUPlotAxisMeasureTextMock(uPlotAxisMeasureText as jest.MockedFunction<typeof uPlotAxisMeasureText>);
+ * });
+ * ```
+ */
+
+/** Use as the `jest.mock()` module string (must be written literally at the call site). */
+export const GRAFANA_UI_MEASURE_TEXT_MODULE = '@grafana/ui/src/utils/measureText';
+
+const AXIS_TEXT_WIDTH_PER_CHAR = 7.2;
+
+/** Width scale matched roughly to 12px Inter. */
+export function defaultAxisTextWidthForCanvasTests(text: string | null, fontSize: number): number {
+  const w = (text?.length ?? 1) * AXIS_TEXT_WIDTH_PER_CHAR * (fontSize / 12);
+  return Math.max(8, w);
+}
+
+export type GrafanaUiMeasureTextFn = (text: string, fontSize: number, fontWeight?: number) => TextMetrics;
+
+/**
+ * Factory for `jest.mock(…, () => …)`.
+ * Call via `require('@grafana/test-utils/canvas')` inside the mock factory so Jest hoisting works.
+ */
+export function createGrafanaUiMeasureTextJestMock() {
+  const actual = jest.requireActual(GRAFANA_UI_MEASURE_TEXT_MODULE);
+  return { ...actual, measureText: jest.fn() };
+}
+
+/**
+ * Applies browser-like axis label widths. Re-run in `beforeEach` after `mockImplementationOnce`.
+ */
+export function applyDefaultUPlotAxisMeasureTextMock(measureTextMock: jest.MockedFunction<GrafanaUiMeasureTextFn>) {
+  measureTextMock.mockImplementation(
+    (text, fontSize, _fontWeight = 400) =>
+      ({ width: defaultAxisTextWidthForCanvasTests(text, fontSize) }) as TextMetrics
+  );
+}

--- a/public/app/plugins/panel/heatmap/HeatmapPanel.canvas.test.tsx
+++ b/public/app/plugins/panel/heatmap/HeatmapPanel.canvas.test.tsx
@@ -17,6 +17,7 @@ import {
 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { AxisPlacement, HeatmapCellLayout, ScaleDistribution, TooltipDisplayMode } from '@grafana/schema';
+import { applyDefaultUPlotAxisMeasureTextMock } from '@grafana/test-utils/canvas';
 import { measureText as uPlotAxisMeasureText, type UPlotConfigBuilder } from '@grafana/ui';
 import { LinearBucketData, LinearBucketTimeRange } from 'app/plugins/panel/heatmap/mocks/LinearBucketData';
 
@@ -33,34 +34,9 @@ const height = 378;
 /** Minimal viewport for snapshots that only need a few cells drawn (smaller canvas event payloads). */
 const compactCanvas = { width: 260, height: 140 } as const;
 
-/**
- * Without mocking measureText, the text width is always measured incorrectly, resulting in test behavior which does not match expected behavior in the browser.
- * uPlot Y/X axis layout uses `measureText` from @grafana/ui (not `useMeasure` on the panel).
- * jest-canvas-mock reports `TextMetrics.width === text.length`, which starves the Y axis and
- * clips tick labels. This mock provides deterministic, ~browser-like widths for axis sizing.
- * Override in a test: `uPlotAxisMeasureText.mockImplementationOnce(...)`; default is re-applied in `beforeEach`.
- *
- * Using relative import since measureText is not exported from grafana/ui, we could override this in jest config e.g.:
- *   '^@grafana/ui/src/utils/measureText$': '<rootDir>/packages/grafana-ui/src/utils/measureText.ts',
- */
-jest.mock('../../../../../packages/grafana-ui/src/utils/measureText', () => {
-  const actual = jest.requireActual('../../../../../packages/grafana-ui/src/utils/measureText');
-  return { ...actual, measureText: jest.fn() };
-});
-
-/** Width scale matched roughly to 12px Inter. */
-function defaultAxisTextWidthForTests(text: string | null, fontSize: number): number {
-  const AXIS_TEXT_WIDTH_PER_CHAR = 7.2;
-  const w = (text?.length ?? 1) * AXIS_TEXT_WIDTH_PER_CHAR * (fontSize / 12);
-  return Math.max(8, w);
-}
-
-function applyDefaultUPlotAxisMeasureTextMock() {
-  (uPlotAxisMeasureText as jest.Mock).mockImplementation(
-    (text: string, fontSize: number, _fontWeight = 400) =>
-      ({ width: defaultAxisTextWidthForTests(text, fontSize) }) as ReturnType<CanvasRenderingContext2D['measureText']>
-  );
-}
+jest.mock('@grafana/ui/src/utils/measureText', () =>
+  require('@grafana/test-utils/canvas').createGrafanaUiMeasureTextJestMock()
+);
 
 /**
  * Generates a 2D array of heatmap bucket values for testing.
@@ -260,7 +236,7 @@ describe('HeatmapPanel (canvas)', () => {
   };
 
   beforeEach(() => {
-    applyDefaultUPlotAxisMeasureTextMock();
+    applyDefaultUPlotAxisMeasureTextMock(uPlotAxisMeasureText as jest.MockedFunction<typeof uPlotAxisMeasureText>);
     // VizLayout always calls `useMeasure`; when legend is hidden the result is unused. Zeros match an unmeasured rect.
     prepConfigSpy = jest.spyOn(heatmapUtils, 'prepConfig').mockImplementation((opts) => {
       const builder: UPlotConfigBuilder = realPrepConfig(opts);

--- a/public/app/plugins/panel/xychart/XYChartPanel.canvas.test.tsx
+++ b/public/app/plugins/panel/xychart/XYChartPanel.canvas.test.tsx
@@ -20,6 +20,7 @@ import {
 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { SortOrder, TooltipDisplayMode } from '@grafana/schema';
+import { applyDefaultUPlotAxisMeasureTextMock } from '@grafana/test-utils/canvas';
 import { measureText as uPlotAxisMeasureText, type UPlotConfigBuilder } from '@grafana/ui';
 import { XYChartPanel2 } from 'app/plugins/panel/xychart/XYChartPanel';
 import {
@@ -32,20 +33,9 @@ import {
 
 import * as utils from './scatter';
 
-/**
- * Without mocking measureText, the text width is always measured incorrectly, resulting in test behavior which does not match expected behavior in the browser.
- * uPlot Y/X axis layout uses `measureText` from @grafana/ui (not `useMeasure` on the panel).
- * jest-canvas-mock reports `TextMetrics.width === text.length`, which starves the Y axis and
- * clips tick labels. This mock provides deterministic, ~browser-like widths for axis sizing.
- * Override in a test: `uPlotAxisMeasureText.mockImplementationOnce(...)`; default is re-applied in `beforeEach`.
- *
- * Using relative import since measureText is not exported from grafana/ui, we could override this in jest config e.g.:
- *   '^@grafana/ui/src/utils/measureText$': '<rootDir>/packages/grafana-ui/src/utils/measureText.ts',
- */
-jest.mock('../../../../../packages/grafana-ui/src/utils/measureText', () => {
-  const actual = jest.requireActual('../../../../../packages/grafana-ui/src/utils/measureText');
-  return { ...actual, measureText: jest.fn() };
-});
+jest.mock('@grafana/ui/src/utils/measureText', () =>
+  require('@grafana/test-utils/canvas').createGrafanaUiMeasureTextJestMock()
+);
 
 const height = 400;
 const width = 600;
@@ -277,19 +267,6 @@ const setUp = (propsOverrides?: PanelOverrides, seriesOverride?: DataFrame[], ti
   return { result: render(component), props };
 };
 
-function defaultAxisTextWidthForTests(text: string | null, fontSize: number): number {
-  const AXIS_TEXT_WIDTH_PER_CHAR = 7.2;
-  const w = (text?.length ?? 1) * AXIS_TEXT_WIDTH_PER_CHAR * (fontSize / 12);
-  return Math.max(8, w);
-}
-
-function applyDefaultUPlotAxisMeasureTextMock() {
-  (uPlotAxisMeasureText as jest.Mock).mockImplementation(
-    (text: string, fontSize: number, _fontWeight = 400) =>
-      ({ width: defaultAxisTextWidthForTests(text, fontSize) }) as ReturnType<CanvasRenderingContext2D['measureText']>
-  );
-}
-
 describe('XYChartPanel2', () => {
   let prepConfigSpy: jest.SpyInstance;
   const { prepConfig: realPrepConfig } = jest.requireActual('./scatter');
@@ -313,7 +290,7 @@ describe('XYChartPanel2', () => {
   };
 
   beforeEach(() => {
-    applyDefaultUPlotAxisMeasureTextMock();
+    applyDefaultUPlotAxisMeasureTextMock(uPlotAxisMeasureText as jest.MockedFunction<typeof uPlotAxisMeasureText>);
     // VizLayout always calls `useMeasure`; when legend is hidden the result is unused. Zeros match an unmeasured rect.
     prepConfigSpy = jest.spyOn(utils, 'prepConfig').mockImplementation((opts, theme) => {
       const result = realPrepConfig(opts, theme);


### PR DESCRIPTION
**What is this feature?**

Adding a small helper for canvas tests to mock measureText used in uPlot

**Why do we need this feature?**

To centralize the solution instead of reinventing the wheel in each test.

**Who is this feature for?**

Developers writing uPlot canvas tests.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
