### PR TITLE
Alerting: use unified AdHocFiltersVariable (enableGroupBy) in triage

### DIFF
--- a/public/app/features/alerting/unified/triage/constants.ts
+++ b/public/app/features/alerting/unified/triage/constants.ts
@@ -1,7 +1,6 @@
 import { config } from '@grafana/runtime';
 
 export const VARIABLES = {
-  groupBy: 'groupBy',
   filters: 'filters',
 };
 
@@ -11,7 +10,6 @@ export const VARIABLES = {
  */
 export const URL_PARAMS = {
   filters: 'var-filters',
-  groupBy: 'var-groupBy',
   timeFrom: 'from',
   timeTo: 'to',
 } as const;
@@ -20,12 +18,7 @@ export const URL_PARAMS = {
  * All URL parameters that define the triage page state for saved searches.
  * Used to serialize/deserialize saved search state.
  */
-export const TRIAGE_STATE_URL_PARAMS = [
-  URL_PARAMS.filters,
-  URL_PARAMS.groupBy,
-  URL_PARAMS.timeFrom,
-  URL_PARAMS.timeTo,
-] as const;
+export const TRIAGE_STATE_URL_PARAMS = [URL_PARAMS.filters, URL_PARAMS.timeFrom, URL_PARAMS.timeTo] as const;
 
 export const DATASOURCE_UID = config.unifiedAlerting.stateHistory?.prometheusTargetDatasourceUID;
 export const METRIC_NAME = config.unifiedAlerting.stateHistory?.prometheusMetricName ?? 'GRAFANA_ALERTS';

--- a/public/app/features/alerting/unified/triage/hooks/useApplyDefaultTriageSearch.test.tsx
+++ b/public/app/features/alerting/unified/triage/hooks/useApplyDefaultTriageSearch.test.tsx
@@ -106,17 +106,18 @@ describe('useApplyDefaultTriageSearch', () => {
     expect(applySavedSearchMock).not.toHaveBeenCalled();
   });
 
-  it('should not apply default search when groupBy is active', async () => {
+  it('should not apply default search when groupBy is active (encoded as var-filters key|groupBy)', async () => {
     const mockDefaultSearch = {
       id: '1',
       name: 'Default Search',
-      query: 'var-groupBy=severity',
+      query: 'var-filters=grafana_folder|groupBy',
       isDefault: true,
       createdAt: Date.now(),
     };
 
     loadDefaultTriageSavedSearchMock.mockResolvedValue(mockDefaultSearch);
-    serializeCurrentStateMock.mockReturnValue('var-groupBy=severity'); // Active groupBy
+    // GroupBy entries live in var-filters now (e.g. grafana_folder|groupBy)
+    serializeCurrentStateMock.mockReturnValue('var-filters=grafana_folder%7CgroupBy');
 
     renderHook(() => useApplyDefaultTriageSearch(), { wrapper: createWrapper() });
 

--- a/public/app/features/alerting/unified/triage/hooks/useApplyDefaultTriageSearch.ts
+++ b/public/app/features/alerting/unified/triage/hooks/useApplyDefaultTriageSearch.ts
@@ -12,11 +12,10 @@ import { loadDefaultTriageSavedSearch, trackTriageSavedSearchAutoApply } from '.
 const SESSION_VISITED_KEY = 'grafana.alerting.triagePage.visited';
 
 /**
- * Check if the triage page has active filters, groupBy, or non-default time range.
+ * Check if the triage page has active filters (including groupBy entries) or non-default time range.
  *
  * This uses the URL parameters to determine if filters are active:
- * - var-filters: Ad-hoc filters
- * - var-groupBy: Group by selection
+ * - var-filters: Ad-hoc filters and groupBy selections (unified into one param)
  *
  * Time range (from/to) is not considered when checking for active filters,
  * since the default time range is always applied.
@@ -31,11 +30,8 @@ function hasActiveTriageFilters(): boolean {
 
   const params = new URLSearchParams(currentState);
 
-  // Check for filters or groupBy - these indicate user has active selections
-  const hasFilters = params.has('var-filters');
-  const hasGroupBy = params.has('var-groupBy') && params.get('var-groupBy') !== '';
-
-  return hasFilters || hasGroupBy;
+  // var-filters contains both regular filters and groupBy entries (key|groupBy format)
+  return params.has('var-filters');
 }
 
 /**

--- a/public/app/features/alerting/unified/triage/scene/TriageSavedSearchesControl.tsx
+++ b/public/app/features/alerting/unified/triage/scene/TriageSavedSearchesControl.tsx
@@ -7,7 +7,7 @@ import {
   type SceneObjectState,
   sceneGraph,
 } from '@grafana/scenes';
-import { useTimeRange, useVariableValues } from '@grafana/scenes-react';
+import { useTimeRange } from '@grafana/scenes-react';
 
 import { SavedSearches } from '../../components/saved-searches/SavedSearches';
 import { type SavedSearch, validateSearchName } from '../../components/saved-searches/savedSearchesSchema';
@@ -70,21 +70,22 @@ function TriageSavedSearchesControlRenderer({ model }: SceneComponentProps<Triag
 
   // Use Scene-aware hooks to get current state (triggers re-render on state change)
   const [timeRange] = useTimeRange();
-  const [groupBy = []] = useVariableValues<string>(VARIABLES.groupBy);
 
-  // Get the AdHocFiltersVariable directly to access raw filter objects
-  // This is needed because useVariableValues returns the interpolated expression string,
-  // not the individual filter objects we need for serialization
+  // Get the AdHocFiltersVariable directly to access raw filter objects.
+  // The unified variable holds both regular filters and groupBy entries (operator: 'groupBy').
+  // This is needed because useVariableValue returns the interpolated expression string,
+  // not the individual filter objects we need for serialization.
   const filtersVar = sceneGraph.lookupVariable(VARIABLES.filters, model);
 
   // Use useState() for reactive access to filter state (triggers re-render on filter change)
   const filtersState = filtersVar instanceof AdHocFiltersVariable ? filtersVar.useState() : undefined;
   const filters = filtersState?.filters;
 
-  // Serialize Scene state to a query string (reactive to changes)
+  // Serialize Scene state to a query string (reactive to changes).
+  // filters contains both regular filters and groupBy entries — serializeTriageState handles both.
   const currentSearchQuery = useMemo(() => {
-    return serializeTriageState(filters ?? [], groupBy, timeRange.raw);
-  }, [timeRange, filters, groupBy]);
+    return serializeTriageState(filters ?? [], timeRange.raw);
+  }, [timeRange, filters]);
 
   /**
    * Apply a saved search by programmatically updating Scene variables.

--- a/public/app/features/alerting/unified/triage/scene/TriageScene.tsx
+++ b/public/app/features/alerting/unified/triage/scene/TriageScene.tsx
@@ -1,7 +1,6 @@
 import { DashboardCursorSync } from '@grafana/data';
 import {
   AdHocFiltersVariable,
-  GroupByVariable,
   SceneControlsSpacer,
   SceneFlexLayout,
   SceneReactObject,
@@ -56,22 +55,14 @@ export const triageScene = new EmbeddedSceneWithContext({
         allowCustomValue: true,
         useQueriesAsFilterForOptions: true,
         supportsMultiValueOperators: true,
+        enableGroupBy: true,
+        groupByInputPlaceholder: 'Group by',
         filters: [],
         baseFilters: [],
         expressionBuilder: prometheusExpressionBuilder,
         getTagKeysProvider: getAdHocTagKeysProvider,
         getTagValuesProvider: getAdHocTagValuesProvider,
-      }),
-      new GroupByVariable({
-        name: 'groupBy',
-        label: 'Group by',
-        datasource: {
-          type: 'prometheus',
-          uid: DATASOURCE_UID,
-        },
-        allowCustomValue: true,
-        applyMode: 'manual',
-        getTagKeysProvider: getGroupByTagKeysProvider,
+        getGroupByKeysProvider: getGroupByTagKeysProvider,
       }),
     ],
   }),

--- a/public/app/features/alerting/unified/triage/scene/Workbench.tsx
+++ b/public/app/features/alerting/unified/triage/scene/Workbench.tsx
@@ -1,15 +1,21 @@
 import { useEffect, useState, useTransition } from 'react';
 
 import { type DataFrame } from '@grafana/data';
-import { SceneObjectBase, type SceneObjectState, sceneGraph, sceneUtils } from '@grafana/scenes';
-import { useQueryRunner, useTimeRange, useVariableValues } from '@grafana/scenes-react';
+import {
+  AdHocFiltersVariable,
+  SceneObjectBase,
+  type SceneObjectState,
+  isGroupByFilter,
+  sceneGraph,
+} from '@grafana/scenes';
+import { useQueryRunner, useTimeRange } from '@grafana/scenes-react';
 
 import { Workbench } from '../Workbench';
 import { DEFAULT_FIELDS, VARIABLES } from '../constants';
 
 import { convertToWorkbenchRows } from './dataTransform';
 import { getWorkbenchQueries } from './queries';
-import { convertTimeRangeToDomain, useQueryFilter } from './utils';
+import { convertTimeRangeToDomain, useGroupByKeys, useQueryFilter } from './utils';
 
 export class WorkbenchSceneObject extends SceneObjectBase<SceneObjectState> {
   public static Component = WorkbenchRenderer;
@@ -19,7 +25,7 @@ export function WorkbenchRenderer() {
   const [timeRange] = useTimeRange();
   const domain = convertTimeRangeToDomain(timeRange);
 
-  const [groupByKeys = []] = useVariableValues<string>(VARIABLES.groupBy);
+  const groupByKeys = useGroupByKeys();
   const countBy = [...DEFAULT_FIELDS, ...groupByKeys].join(',');
   const queryFilter = useQueryFilter();
 
@@ -43,15 +49,14 @@ export function WorkbenchRenderer() {
         return;
       }
 
-      // Get the groupBy from the scene directly to avoid having groupByVariable in the dependency array
+      // Get the groupBy keys from the unified AdHocFiltersVariable directly,
+      // avoiding groupByKeys in the dependency array.
       let currentGroupByKeys: string[] = [];
-      const groupByVariable = sceneGraph.lookupVariable(VARIABLES.groupBy, runner);
-
-      if (groupByVariable && sceneUtils.isGroupByVariable(groupByVariable)) {
-        const value = groupByVariable.getValue();
-        if (Array.isArray(value)) {
-          currentGroupByKeys = value.map((value) => String(value));
-        }
+      const filtersVar = sceneGraph.lookupVariable(VARIABLES.filters, runner);
+      if (filtersVar instanceof AdHocFiltersVariable) {
+        currentGroupByKeys = filtersVar.state.filters
+          .filter((f) => isGroupByFilter(f) && !f.dismissedGroupBy)
+          .map((f) => f.key);
       }
 
       const { series } = newState.data;

--- a/public/app/features/alerting/unified/triage/scene/tagKeysProviders.test.ts
+++ b/public/app/features/alerting/unified/triage/scene/tagKeysProviders.test.ts
@@ -1,12 +1,6 @@
 import { type DataSourceApi, type MetricFindValue } from '@grafana/data';
 import { getDataSourceSrv } from '@grafana/runtime';
-import {
-  AdHocFiltersVariable,
-  EmbeddedScene,
-  GroupByVariable,
-  SceneTimeRange,
-  SceneVariableSet,
-} from '@grafana/scenes';
+import { AdHocFiltersVariable, EmbeddedScene, SceneTimeRange, SceneVariableSet } from '@grafana/scenes';
 
 import { getAdHocTagKeysProvider, getAdHocTagValuesProvider, getGroupByTagKeysProvider } from './tagKeysProviders';
 
@@ -26,7 +20,7 @@ function mockGetDataSourceSrv(dsOverrides: Partial<DataSourceApi> = {}) {
   } as ReturnType<typeof getDataSourceSrv>);
 }
 
-function activateWithScene(variable: GroupByVariable | AdHocFiltersVariable) {
+function activateWithScene(variable: AdHocFiltersVariable) {
   const scene = new EmbeddedScene({
     $timeRange: new SceneTimeRange({ from: 'now-1h', to: 'now' }),
     $variables: new SceneVariableSet({ variables: [variable] }),
@@ -49,7 +43,7 @@ describe('tagKeysProviders', () => {
         ] satisfies MetricFindValue[]),
       });
 
-      const variable = new GroupByVariable({ name: 'groupBy', datasource: { uid: 'test' } });
+      const variable = new AdHocFiltersVariable({ name: 'groupBy', datasource: { uid: 'test' } });
       activateWithScene(variable);
 
       const result = await getGroupByTagKeysProvider(variable, null);
@@ -69,7 +63,7 @@ describe('tagKeysProviders', () => {
         getTagKeys: jest.fn().mockResolvedValue([] satisfies MetricFindValue[]),
       });
 
-      const variable = new GroupByVariable({ name: 'groupBy', datasource: { uid: 'test' } });
+      const variable = new AdHocFiltersVariable({ name: 'groupBy', datasource: { uid: 'test' } });
       activateWithScene(variable);
 
       const result = await getGroupByTagKeysProvider(variable, null);
@@ -297,7 +291,7 @@ describe('tagKeysProviders', () => {
     it('should return promoted labels only when DS lacks getTagKeys', async () => {
       mockGetDataSourceSrv({});
 
-      const variable = new GroupByVariable({ name: 'groupBy', datasource: { uid: 'test' } });
+      const variable = new AdHocFiltersVariable({ name: 'groupBy', datasource: { uid: 'test' } });
       activateWithScene(variable);
 
       const result = await getGroupByTagKeysProvider(variable, null);

--- a/public/app/features/alerting/unified/triage/scene/tagKeysProviders.ts
+++ b/public/app/features/alerting/unified/triage/scene/tagKeysProviders.ts
@@ -1,12 +1,7 @@
 import { type MetricFindValue, type TimeRange } from '@grafana/data';
 import { type PromQuery } from '@grafana/prometheus';
 import { getDataSourceSrv } from '@grafana/runtime';
-import {
-  type AdHocFilterWithLabels,
-  type AdHocFiltersVariable,
-  type GroupByVariable,
-  sceneGraph,
-} from '@grafana/scenes';
+import { type AdHocFilterWithLabels, type AdHocFiltersVariable, sceneGraph } from '@grafana/scenes';
 
 import { COMBINED_FILTER_LABEL_KEYS, DATASOURCE_UID, METRIC_NAME } from '../constants';
 
@@ -98,10 +93,10 @@ async function buildTagKeysResult(
 }
 
 /**
- * Provider for the GroupBy variable.
+ * Provider for the groupBy keys inside the unified AdHocFiltersVariable.
  * Shows promoted labels first, then remaining datasource labels alphabetically.
  */
-export function getGroupByTagKeysProvider(variable: GroupByVariable, _currentKey: string | null) {
+export function getGroupByTagKeysProvider(variable: AdHocFiltersVariable, _currentKey?: string | null) {
   const timeRange = sceneGraph.getTimeRange(variable).state.value;
   return buildTagKeysResult(timeRange, GROUPBY_PROMOTED);
 }

--- a/public/app/features/alerting/unified/triage/scene/triageSavedSearchUtils.test.ts
+++ b/public/app/features/alerting/unified/triage/scene/triageSavedSearchUtils.test.ts
@@ -52,8 +52,9 @@ describe('triageSavedSearchUtils', () => {
       const params = new URLSearchParams(result);
       expect(params.get('from')).toBe('now-1h');
       expect(params.get('to')).toBe('now');
-      expect(params.getAll('var-groupBy')).toEqual(['grafana_folder']);
-      expect(params.has('var-filters')).toBe(true);
+      // groupBy is encoded inside var-filters as key|groupBy
+      expect(params.getAll('var-filters')).toContain('grafana_folder|groupBy');
+      expect(params.has('var-groupBy')).toBe(false);
     });
 
     it('builds query string with DateTime time range', () => {
@@ -86,39 +87,61 @@ describe('triageSavedSearchUtils', () => {
       const query = 'var-filters=alertname%7C%3D%7Ctest&var-filters=severity%7C!%3D%7Cwarning';
       const result = extractFilterObjects(query);
       expect(result).toEqual([
-        { key: 'alertname', operator: '=', value: 'test', values: ['test'] },
-        { key: 'severity', operator: '!=', value: 'warning', values: ['warning'] },
+        { key: 'alertname', operator: '=', value: 'test' },
+        { key: 'severity', operator: '!=', value: 'warning' },
+      ]);
+    });
+
+    it('should extract groupBy entries encoded as key|groupBy in var-filters', () => {
+      const query = 'var-filters=alertname%7C%3D%7Ctest&var-filters=grafana_folder%7CgroupBy';
+      const result = extractFilterObjects(query);
+      expect(result).toEqual([
+        { key: 'alertname', operator: '=', value: 'test' },
+        { key: 'grafana_folder', operator: 'groupBy', value: '' },
       ]);
     });
 
     it('should return empty array if no filters', () => {
-      const query = 'var-groupBy=severity&from=now-1h&to=now';
+      const query = 'from=now-1h&to=now';
       const result = extractFilterObjects(query);
       expect(result).toEqual([]);
+    });
+
+    it('should migrate legacy var-groupBy entries to groupBy filter objects', () => {
+      const query = 'var-groupBy=severity&from=now-1h&to=now';
+      const result = extractFilterObjects(query);
+      expect(result).toEqual([{ key: 'severity', operator: 'groupBy', value: '' }]);
     });
 
     it('should handle filters with pipes in values (__gfp__ escaped)', () => {
       const query = 'var-filters=alertname%7C%3D~%7Ccritical__gfp__warning';
       const result = extractFilterObjects(query);
-      expect(result).toEqual([
-        { key: 'alertname', operator: '=~', value: 'critical|warning', values: ['critical|warning'] },
-      ]);
+      expect(result).toEqual([{ key: 'alertname', operator: '=~', value: 'critical|warning' }]);
     });
 
     it('should filter out invalid filter strings', () => {
       const query = 'var-filters=alertname%7C%3D%7Ctest&var-filters=invalid&var-filters=severity%7C%3D%7Ccritical';
       const result = extractFilterObjects(query);
       expect(result).toEqual([
-        { key: 'alertname', operator: '=', value: 'test', values: ['test'] },
-        { key: 'severity', operator: '=', value: 'critical', values: ['critical'] },
+        { key: 'alertname', operator: '=', value: 'test' },
+        { key: 'severity', operator: '=', value: 'critical' },
+      ]);
+    });
+
+    it('should handle combined query with both legacy var-groupBy and var-filters', () => {
+      const query = 'var-filters=alertname%7C%3D%7Ctest&var-groupBy=severity';
+      const result = extractFilterObjects(query);
+      expect(result).toEqual([
+        { key: 'alertname', operator: '=', value: 'test' },
+        { key: 'severity', operator: 'groupBy', value: '' },
       ]);
     });
   });
 
   describe('generateTriageUrl', () => {
     it('should generate URL with query', () => {
-      const query = 'var-filters=test&var-groupBy=severity';
-      expect(generateTriageUrl(query)).toBe('/alerting/alerts?var-filters=test&var-groupBy=severity');
+      const query = 'var-filters=test&var-filters=grafana_folder%7CgroupBy';
+      expect(generateTriageUrl(query)).toBe('/alerting/alerts?var-filters=test&var-filters=grafana_folder%7CgroupBy');
     });
 
     it('should return base path for empty query', () => {
@@ -132,15 +155,18 @@ describe('triageSavedSearchUtils', () => {
   });
 
   describe('serializeCurrentState', () => {
-    it('should serialize URL params', () => {
-      const params = new URLSearchParams('var-filters=alertname%7C%3D%7Ctest&var-groupBy=severity&from=now-1h&to=now');
+    it('should serialize var-filters and time range params', () => {
+      const params = new URLSearchParams(
+        'var-filters=alertname%7C%3D%7Ctest&var-filters=grafana_folder%7CgroupBy&from=now-1h&to=now'
+      );
       mockGetSearch.mockReturnValueOnce(params);
 
       const result = serializeCurrentSearchState();
       expect(result).toContain('var-filters=');
-      expect(result).toContain('var-groupBy=severity');
       expect(result).toContain('from=now-1h');
       expect(result).toContain('to=now');
+      // groupBy is in var-filters, not var-groupBy
+      expect(result).not.toContain('var-groupBy');
     });
 
     it('should handle multiple var-filters', () => {
@@ -160,12 +186,13 @@ describe('triageSavedSearchUtils', () => {
       expect(result).toBe('');
     });
 
-    it('should ignore non-triage params', () => {
+    it('should ignore non-triage params and legacy var-groupBy', () => {
       const params = new URLSearchParams('unrelated=param&var-groupBy=severity');
       mockGetSearch.mockReturnValueOnce(params);
 
       const result = serializeCurrentSearchState();
-      expect(result).toBe('var-groupBy=severity');
+      // var-groupBy is no longer in TRIAGE_STATE_URL_PARAMS; groupBy now lives in var-filters
+      expect(result).toBe('');
       expect(result).not.toContain('unrelated');
     });
   });
@@ -225,17 +252,11 @@ describe('triageSavedSearchUtils', () => {
 
   describe('applySavedSearch', () => {
     it('should call locationService.push with saved search params', () => {
-      const query = 'var-filters=alertname%7C%3D%7Ctest&var-groupBy=severity&from=now-1h&to=now';
+      const query = 'var-filters=alertname%7C%3D%7Ctest&var-filters=grafana_folder%7CgroupBy&from=now-1h&to=now';
 
       applySavedSearch(query);
 
       expect(locationService.push).toHaveBeenCalledWith(`/alerting/alerts?${query}`);
-    });
-
-    it('should call locationService.push with correct URL', () => {
-      applySavedSearch('var-groupBy=severity');
-
-      expect(locationService.push).toHaveBeenCalledWith('/alerting/alerts?var-groupBy=severity');
     });
 
     it('should handle empty query by navigating to base path', () => {

--- a/public/app/features/alerting/unified/triage/scene/triageSavedSearchUtils.ts
+++ b/public/app/features/alerting/unified/triage/scene/triageSavedSearchUtils.ts
@@ -3,13 +3,16 @@
  *
  * These functions handle the conversion between URL parameters and saved search
  * query strings, preserving filters, groupBy selections, and time range.
+ *
+ * GroupBy keys are stored as entries in the same `var-filters` URL parameter using the
+ * `key|groupBy` 2-part format defined by Scenes' AdHocFiltersVariable URL sync handler.
  */
 
 import { type AdHocVariableFilter, type RawTimeRange, dateMath, makeTimeRange } from '@grafana/data';
 import { locationService } from '@grafana/runtime';
-import { AdHocFiltersVariable, GroupByVariable, type SceneObject, sceneGraph } from '@grafana/scenes';
+import { AdHocFiltersVariable, GROUP_BY_OPERATOR, type SceneObject, sceneGraph } from '@grafana/scenes';
 
-import { toFilters, toUrl } from '../../../../variables/adhoc/urlParser';
+import { toUrl } from '../../../../variables/adhoc/urlParser';
 import { type SavedSearch } from '../../components/saved-searches/savedSearchesSchema';
 import { TRIAGE_STATE_URL_PARAMS, URL_PARAMS, VARIABLES } from '../constants';
 
@@ -46,6 +49,9 @@ export interface TriageFilterInput {
  * Builds a triage saved search query string from filters, groupBy, and time range.
  * Shared by serializeTriageState (Scene state) and triagePredefinedSearches (static definitions).
  * Uses URL_PARAMS and toUrl so format stays in sync across all triage saved searches.
+ *
+ * GroupBy keys are appended to var-filters as `key|groupBy` (2-part, no value), matching
+ * the Scenes AdHocFiltersVariable URL sync format.
  */
 export function buildTriageQueryStringFromParts(input: {
   filters?: TriageFilterInput[];
@@ -60,8 +66,9 @@ export function buildTriageQueryStringFromParts(input: {
     });
   }
 
+  // Encode groupBy keys as `key|groupBy` filter entries (Scenes AdHocFiltersVariable URL format).
   input.groupBy.filter(Boolean).forEach((key) => {
-    params.append(URL_PARAMS.groupBy, key);
+    params.append(URL_PARAMS.filters, `${key}|${GROUP_BY_OPERATOR}`);
   });
 
   const fromValue =
@@ -79,12 +86,12 @@ export function buildTriageQueryStringFromParts(input: {
  * This function reads the current URL parameters that define the triage view state
  * and returns them as a serialized query string suitable for storage.
  *
- * @returns Serialized query string containing filters, groupBy, and time range
+ * @returns Serialized query string containing filters (including groupBy entries) and time range
  *
  * @example
- * // URL: /alerting/alerts?var-filters=alertname|=|test&var-groupBy=severity&from=now-1h&to=now
+ * // URL: /alerting/alerts?var-filters=alertname|=|test&var-filters=grafana_folder|groupBy&from=now-1h&to=now
  * serializeCurrentSearchState()
- * // Returns: "var-filters=alertname%7C%3D%7Ctest&var-groupBy=severity&from=now-1h&to=now"
+ * // Returns: "var-filters=alertname%7C%3D%7Ctest&var-filters=grafana_folder%7CgroupBy&from=now-1h&to=now"
  */
 export function serializeCurrentSearchState(): string {
   const currentParams = locationService.getSearch();
@@ -103,31 +110,43 @@ export function serializeCurrentSearchState(): string {
  * Serializes triage state (filters, groupBy, time range) into a query string.
  * This is used by the component to serialize the current Scene state for saved searches.
  *
- * @param filters - Array of AdHocVariableFilter objects
- * @param groupBy - Array of groupBy keys (or single string)
+ * @param filters - Array of AdHocVariableFilter objects (both regular filters and groupBy entries)
  * @param timeRange - Raw time range with from/to as strings, Date, or DateTime objects
  * @returns Serialized query string
  */
-export function serializeTriageState(
-  filters: AdHocVariableFilter[],
-  groupBy: string | string[],
-  timeRange: RawTimeRange
-): string {
-  const groupByArray = Array.isArray(groupBy) ? groupBy : [groupBy].filter(Boolean);
-  return buildTriageQueryStringFromParts({
-    filters: filters.map((f) => ({ key: f.key, operator: f.operator, value: f.value })),
-    groupBy: groupByArray,
-    timeRange,
+export function serializeTriageState(filters: AdHocVariableFilter[], timeRange: RawTimeRange): string {
+  const params = new URLSearchParams();
+
+  filters.forEach((f) => {
+    if (f.operator === GROUP_BY_OPERATOR) {
+      // GroupBy entry: serialize as key|groupBy (2-part, no value)
+      params.append(URL_PARAMS.filters, `${f.key}|${GROUP_BY_OPERATOR}`);
+    } else {
+      // Regular filter: use standard toUrl serialization
+      toUrl([f]).forEach((filterStr) => {
+        params.append(URL_PARAMS.filters, filterStr);
+      });
+    }
   });
+
+  const fromValue = typeof timeRange.from === 'string' ? timeRange.from : timeRange.from.toISOString();
+  const toValue = typeof timeRange.to === 'string' ? timeRange.to : timeRange.to.toISOString();
+  params.set(URL_PARAMS.timeFrom, fromValue);
+  params.set(URL_PARAMS.timeTo, toValue);
+
+  return params.toString();
 }
 
 /**
  * Applies a saved search query to Scene variables.
- * Updates filters, groupBy, and time range by directly calling variable methods.
+ * Updates filters (including groupBy entries) and time range by directly calling variable methods.
  *
  * This uses direct state updates instead of URL navigation because Scenes' URL sync
  * has a limitation: updateFromUrl() only receives CHANGED values. When a parameter
  * is absent from the saved search (e.g., to clear groupBy), it won't trigger an update.
+ *
+ * Backward compatibility: also reads legacy `var-groupBy` params and converts them to
+ * groupBy filter entries, so searches saved before the unified variable migration still work.
  *
  * @param scene - The scene object containing the variables
  * @param query - The saved search query string
@@ -135,16 +154,10 @@ export function serializeTriageState(
 export function applyTriageSavedSearchState(scene: SceneObject, query: string): void {
   const params = new URLSearchParams(query);
 
-  // Update filters
+  // Update filters (includes groupBy entries encoded as key|groupBy)
   const filtersVar = sceneGraph.lookupVariable(VARIABLES.filters, scene);
   if (filtersVar instanceof AdHocFiltersVariable) {
     filtersVar.updateFilters(extractFilterObjects(query));
-  }
-
-  // Update groupBy (explicitly set to empty array if absent)
-  const groupByVar = sceneGraph.lookupVariable(VARIABLES.groupBy, scene);
-  if (groupByVar instanceof GroupByVariable) {
-    groupByVar.changeValueTo(params.getAll(URL_PARAMS.groupBy).filter(Boolean));
   }
 
   // Update time range
@@ -160,24 +173,62 @@ export function applyTriageSavedSearchState(scene: SceneObject, query: string): 
 }
 
 /**
- * Extracts and parses filter values from a saved search query into filter objects.
- * Uses the standard toFilters utility which properly handles __gfp__ escaped pipes.
- * Converts to AdHocVariableFilter format with values array for Scenes compatibility.
+ * Parses a saved search query string into AdHocVariableFilter objects.
+ * Handles both regular 3-part filter entries (`key|operator|value`) and 2-part groupBy
+ * entries (`key|groupBy`) from the unified var-filters param.
+ *
+ * Also migrates legacy `var-groupBy` entries (saved before the unified variable migration)
+ * by converting them to groupBy filter objects.
  *
  * @param query - The saved search query string
- * @returns Array of filter objects compatible with AdHocFiltersVariable
+ * @returns Array of filter objects compatible with AdHocFiltersVariable.updateFilters()
  */
 export function extractFilterObjects(query: string): AdHocVariableFilter[] {
   const params = new URLSearchParams(query);
-  const filterValues = params.getAll(URL_PARAMS.filters);
-  const filters = toFilters(filterValues);
 
-  // Add values array for Scenes URL sync compatibility
-  // Scenes expects both value (for single operators) and values (for multi-value operators)
-  return filters.map((filter) => ({
-    ...filter,
-    values: [filter.value],
+  const filterEntries: AdHocVariableFilter[] = params
+    .getAll(URL_PARAMS.filters)
+    .map(parseFilterEntry)
+    .filter((f): f is AdHocVariableFilter => f !== null);
+
+  // Backward compat: migrate legacy var-groupBy entries (written before the unified variable).
+  const legacyGroupByKeys = params.getAll('var-groupBy').filter(Boolean);
+  const legacyGroupByFilters: AdHocVariableFilter[] = legacyGroupByKeys.map((key) => ({
+    key,
+    operator: GROUP_BY_OPERATOR,
+    value: '',
   }));
+
+  return [...filterEntries, ...legacyGroupByFilters];
+}
+
+/**
+ * Parses a single URL filter entry string into an AdHocVariableFilter.
+ * Handles both 3-part regular filters (`key|operator|value`) and 2-part groupBy
+ * entries (`key|groupBy`) — the latter have no value segment.
+ */
+function parseFilterEntry(raw: string): AdHocVariableFilter | null {
+  if (!raw) {
+    return null;
+  }
+
+  const parts = raw.split('|').map(unescapeDelimiter);
+
+  if (parts.length === 2 && parts[1] === GROUP_BY_OPERATOR) {
+    // GroupBy entry: key|groupBy
+    return { key: parts[0], operator: GROUP_BY_OPERATOR, value: '' };
+  }
+
+  if (parts.length >= 3) {
+    // Regular filter: key|operator|value
+    return { key: parts[0], operator: parts[1], value: parts[2] };
+  }
+
+  return null;
+}
+
+function unescapeDelimiter(value: string): string {
+  return value.replace(/__gfp__/g, '|');
 }
 
 /**
@@ -209,7 +260,7 @@ export function generateTriageUrl(query: string, basePath = '/alerting/alerts'):
  *
  * @example
  * // Apply a saved search
- * applySavedSearch("var-filters=alertname%7C%3D%7Ctest&var-groupBy=severity&from=now-1h&to=now");
+ * applySavedSearch("var-filters=alertname%7C%3D%7Ctest&var-filters=grafana_folder%7CgroupBy&from=now-1h&to=now");
  * // URL is updated and Scene variables are synced
  */
 export function applySavedSearch(query: string): void {

--- a/public/app/features/alerting/unified/triage/scene/triageSavedSearchUtils.ts
+++ b/public/app/features/alerting/unified/triage/scene/triageSavedSearchUtils.ts
@@ -12,7 +12,7 @@ import { type AdHocVariableFilter, type RawTimeRange, dateMath, makeTimeRange } 
 import { locationService } from '@grafana/runtime';
 import { AdHocFiltersVariable, GROUP_BY_OPERATOR, type SceneObject, sceneGraph } from '@grafana/scenes';
 
-import { toUrl } from '../../../../variables/adhoc/urlParser';
+import { toFilter, toUrl } from '../../../../variables/adhoc/urlParser';
 import { type SavedSearch } from '../../components/saved-searches/savedSearchesSchema';
 import { TRIAGE_STATE_URL_PARAMS, URL_PARAMS, VARIABLES } from '../constants';
 
@@ -202,33 +202,15 @@ export function extractFilterObjects(query: string): AdHocVariableFilter[] {
   return [...filterEntries, ...legacyGroupByFilters];
 }
 
-/**
- * Parses a single URL filter entry string into an AdHocVariableFilter.
- * Handles both 3-part regular filters (`key|operator|value`) and 2-part groupBy
- * entries (`key|groupBy`) — the latter have no value segment.
- */
 function parseFilterEntry(raw: string): AdHocVariableFilter | null {
-  if (!raw) {
+  if (!raw || raw.split('|').length < 2) {
     return null;
   }
 
-  const parts = raw.split('|').map(unescapeDelimiter);
-
-  if (parts.length === 2 && parts[1] === GROUP_BY_OPERATOR) {
-    // GroupBy entry: key|groupBy
-    return { key: parts[0], operator: GROUP_BY_OPERATOR, value: '' };
-  }
-
-  if (parts.length >= 3) {
-    // Regular filter: key|operator|value
-    return { key: parts[0], operator: parts[1], value: parts[2] };
-  }
-
-  return null;
-}
-
-function unescapeDelimiter(value: string): string {
-  return value.replace(/__gfp__/g, '|');
+  // Normalize 2-part entries (e.g. key|groupBy) to 3-part (key|groupBy|)
+  // so toFilter can parse all formats uniformly.
+  const normalized = raw.split('|').length === 2 ? raw + '|' : raw;
+  return toFilter(normalized);
 }
 
 /**

--- a/public/app/features/alerting/unified/triage/scene/utils.ts
+++ b/public/app/features/alerting/unified/triage/scene/utils.ts
@@ -1,6 +1,12 @@
 import { type TimeRange } from '@grafana/data';
 import { PrometheusDatasource } from '@grafana/prometheus';
-import { AdHocFiltersVariable, type SceneDataQuery, type SceneObject, sceneGraph } from '@grafana/scenes';
+import {
+  AdHocFiltersVariable,
+  type SceneDataQuery,
+  type SceneObject,
+  isGroupByFilter,
+  sceneGraph,
+} from '@grafana/scenes';
 import { useSceneContext, useVariableValue } from '@grafana/scenes-react';
 import { type DataSourceRef } from '@grafana/schema';
 
@@ -98,12 +104,14 @@ export function removeFilter(sceneContext: SceneObject, key: string) {
 export function clearAllFilters(sceneContext: SceneObject) {
   const filtersVariable = sceneGraph.lookupVariable(VARIABLES.filters, sceneContext);
   if (filtersVariable instanceof AdHocFiltersVariable) {
-    filtersVariable.setState({ filters: [] });
+    // Preserve groupBy entries — only clear regular (non-groupBy) filters.
+    filtersVariable.setState({ filters: filtersVariable.state.filters.filter(isGroupByFilter) });
   }
 }
 
 /**
  * Returns the structured filters array from the AdHocFiltersVariable, reactively.
+ * Excludes groupBy entries — use useGroupByKeys() to access those.
  */
 function useAdHocFilters() {
   const sceneContext = useSceneContext();
@@ -112,11 +120,11 @@ function useAdHocFilters() {
     return [];
   }
   // .useState() subscribes to state changes and triggers re-renders
-  return filtersVariable.useState().filters;
+  return filtersVariable.useState().filters.filter((f) => !isGroupByFilter(f));
 }
 
 /**
- * Returns whether any filters are active, and a function to clear all of them.
+ * Returns whether any (non-groupBy) filters are active, and a function to clear all of them.
  */
 export function useClearAllFilters(): { hasActiveFilters: boolean; clearAllFilters: () => void } {
   const sceneContext = useSceneContext();
@@ -125,6 +133,24 @@ export function useClearAllFilters(): { hasActiveFilters: boolean; clearAllFilte
     hasActiveFilters: filters.length > 0,
     clearAllFilters: () => clearAllFilters(sceneContext),
   };
+}
+
+/**
+ * Returns the current groupBy keys from the unified AdHocFiltersVariable, reactively.
+ * Re-renders when groupBy entries change (AdHocFiltersVariable fires SceneVariableValueChangedEvent
+ * for both filter and groupBy mutations).
+ */
+export function useGroupByKeys(): string[] {
+  // useVariableValue subscribes to the variable and triggers re-renders on any change,
+  // including when groupBy entries are added or removed.
+  useVariableValue(VARIABLES.filters);
+
+  const sceneContext = useSceneContext();
+  const filtersVar = sceneGraph.lookupVariable(VARIABLES.filters, sceneContext);
+  if (!(filtersVar instanceof AdHocFiltersVariable)) {
+    return [];
+  }
+  return filtersVar.state.filters.filter((f) => isGroupByFilter(f) && !f.dismissedGroupBy).map((f) => f.key);
 }
 
 /**

--- a/public/app/features/alerting/unified/triage/triagePredefinedSearches.test.ts
+++ b/public/app/features/alerting/unified/triage/triagePredefinedSearches.test.ts
@@ -30,26 +30,36 @@ describe('triagePredefinedSearches', () => {
     it('first search has filter firing and groupBy folder', () => {
       const first = getTriagePredefinedSearches()[0];
       const params = new URLSearchParams(first.query);
-      expect(params.getAll('var-groupBy')).toEqual(['grafana_folder']);
+      // groupBy is encoded in var-filters as grafana_folder|groupBy
+      expect(params.getAll('var-filters')).toContain('grafana_folder|groupBy');
+      expect(params.has('var-groupBy')).toBe(false);
       const filters = extractFilterObjects(first.query);
-      expect(filters).toHaveLength(1);
-      expect(filters[0]).toMatchObject({ key: 'alertstate', value: 'firing' });
+      const regularFilters = filters.filter((f) => f.operator !== 'groupBy');
+      expect(regularFilters).toHaveLength(1);
+      expect(regularFilters[0]).toMatchObject({ key: 'alertstate', value: 'firing' });
     });
 
     it('second search has filter firing only (no groupBy)', () => {
       const second = getTriagePredefinedSearches()[1];
       const params = new URLSearchParams(second.query);
-      expect(params.getAll('var-groupBy')).toEqual([]);
+      expect(params.has('var-groupBy')).toBe(false);
       const filters = extractFilterObjects(second.query);
-      expect(filters).toHaveLength(1);
-      expect(filters[0]).toMatchObject({ key: 'alertstate', value: 'firing' });
+      const groupByFilters = filters.filter((f) => f.operator === 'groupBy');
+      const regularFilters = filters.filter((f) => f.operator !== 'groupBy');
+      expect(groupByFilters).toHaveLength(0);
+      expect(regularFilters).toHaveLength(1);
+      expect(regularFilters[0]).toMatchObject({ key: 'alertstate', value: 'firing' });
     });
 
-    it('third search has groupBy folder only', () => {
+    it('third search has groupBy folder only (no regular filters)', () => {
       const third = getTriagePredefinedSearches()[2];
       const params = new URLSearchParams(third.query);
-      expect(params.getAll('var-groupBy')).toEqual(['grafana_folder']);
-      expect(params.has('var-filters')).toBe(false);
+      // groupBy is now in var-filters as grafana_folder|groupBy
+      expect(params.getAll('var-filters')).toContain('grafana_folder|groupBy');
+      expect(params.has('var-groupBy')).toBe(false);
+      const filters = extractFilterObjects(third.query);
+      const regularFilters = filters.filter((f) => f.operator !== 'groupBy');
+      expect(regularFilters).toHaveLength(0);
     });
 
     it('default predefined search is folder-firing (firing, grouped by folder)', () => {
@@ -59,10 +69,12 @@ describe('triagePredefinedSearches', () => {
       expect(defaultSearch).toBeDefined();
       expect(defaultSearch!.isDefault).toBe(true);
       const params = new URLSearchParams(defaultSearch!.query);
-      expect(params.getAll('var-groupBy')).toEqual(['grafana_folder']);
+      expect(params.getAll('var-filters')).toContain('grafana_folder|groupBy');
+      expect(params.has('var-groupBy')).toBe(false);
       const filters = extractFilterObjects(defaultSearch!.query);
-      expect(filters).toHaveLength(1);
-      expect(filters[0]).toMatchObject({ key: 'alertstate', value: 'firing' });
+      const regularFilters = filters.filter((f) => f.operator !== 'groupBy');
+      expect(regularFilters).toHaveLength(1);
+      expect(regularFilters[0]).toMatchObject({ key: 'alertstate', value: 'firing' });
     });
   });
 

--- a/public/app/features/variables/adhoc/urlParser.ts
+++ b/public/app/features/variables/adhoc/urlParser.ts
@@ -36,7 +36,7 @@ function toArray(filter: AdHocVariableFilter): string[] {
   return [filter.key, filter.operator, filter.value];
 }
 
-function toFilter(value: string | number | boolean | undefined | null): AdHocVariableFilter | null {
+export function toFilter(value: string | number | boolean | undefined | null): AdHocVariableFilter | null {
   if (!isString(value) || value.length === 0) {
     return null;
   }


### PR DESCRIPTION
**What is this feature?**

Replace the separate `AdHocFiltersVariable` + `GroupByVariable` pair in the Alert Activity (Triage) scene with a single `AdHocFiltersVariable` with `enableGroupBy: true`. This gives users a unified filter+groupBy control in the toolbar instead of two separate inputs.

**Why do we need this feature?**

Issue #117781 identified that having filters and groupBy as separate controls creates friction — users frequently need to switch between them. The `@grafana/scenes` library (v8.2.5) already supports the unified control pattern via `AdHocFiltersVariable.enableGroupBy` and `getGroupByKeysProvider`. This PR adopts that pattern in the Triage feature, aligning it with the `dashboardUnifiedDrilldownControls` approach used in dashboard-scene.

<img width="805" height="185" alt="image" src="https://github.com/user-attachments/assets/3783fece-50e8-4174-a082-12d2452fdb84" />


**Who is this feature for?**

Users of the Alert Activity (Triage) page who filter and group alerts.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Key implementation details:
- **Backward compat**: `extractFilterObjects` migrates legacy `var-groupBy=key` URL params (from stored saved searches) to `{ operator: 'groupBy' }` filter objects automatically

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.