### PR TITLE
Search: clean up Bleve filter query helpers

### DIFF
--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -2452,14 +2452,8 @@ const (
 	whitespaceCharacters = " \t\r\n"
 )
 
-// termFields are fields where filter values with separators are split and matched token-by-token.
-// This is unrelated to Bleve TermQuery, which is an exact lookup of one indexed token.
-var termFields = []string{
-	resource.SEARCH_FIELD_TITLE,
-}
-
-// exactTermFields fields to use termQuery for filtering without any extra queries
-var exactTermFields = []string{
+// exactTermQueryFields are fields where filters use Bleve TermQuery directly.
+var exactTermQueryFields = []string{
 	resource.SEARCH_FIELD_OWNER_REFERENCES,
 	resource.SEARCH_FIELD_CREATED_BY,
 	// FIXME: special case for login and email to use term query only because those fields are using keyword analyzer
@@ -2470,7 +2464,7 @@ var exactTermFields = []string{
 
 // Convert a "requirement" into a bleve query
 func requirementQuery(req *resourcepb.Requirement, prefix string) (query.Query, *resourcepb.ErrorResult) {
-	useExactTermQuery := slices.Contains(exactTermFields, req.Key) || strings.HasPrefix(req.Key, resource.SEARCH_SELECTABLE_FIELDS_PREFIX)
+	useExactTermQuery := slices.Contains(exactTermQueryFields, req.Key) || strings.HasPrefix(req.Key, resource.SEARCH_SELECTABLE_FIELDS_PREFIX)
 	switch selection.Operator(req.Operator) {
 	case selection.DoubleEquals:
 		// DoubleEquals does exact matching via TermQuery (single value only).
@@ -2482,63 +2476,31 @@ func requirementQuery(req *resourcepb.Requirement, prefix string) (query.Query, 
 				key = resource.SEARCH_FIELD_TITLE_PHRASE
 				value = strings.ToLower(value)
 			}
-			return newExactTermsQuery(key, value, prefix), nil
+			return exactFieldTermQuery(key, value, prefix), nil
 		}
 
 	case selection.Equals:
-		if len(req.Values) == 0 {
-			return query.NewMatchAllQuery(), nil
-		}
-
-		if len(req.Values) == 1 && useExactTermQuery {
-			return newExactTermsQuery(req.Key, req.Values[0], prefix), nil
-		}
-
-		if len(req.Values) == 1 {
-			filter := filterValue(req.Key, req.Values[0])
-			return newFilterQuery(req.Key, filter, prefix), nil
-		}
-
-		conjuncts := []query.Query{}
-		for _, v := range req.Values {
-			q := newFilterQuery(req.Key, filterValue(req.Key, v), prefix)
-			conjuncts = append(conjuncts, q)
-		}
-
-		return query.NewConjunctionQuery(conjuncts), nil
+		return allRequirementValuesQuery(req.Values, func(v string) query.Query {
+			if useExactTermQuery {
+				return exactFieldTermQuery(req.Key, v, prefix)
+			}
+			return fieldFilterQuery(req.Key, filterValue(req.Key, v), prefix)
+		}), nil
 
 	case selection.In:
-		if len(req.Values) == 0 {
-			return query.NewMatchAllQuery(), nil
-		}
-
-		if len(req.Values) == 1 {
+		return anyRequirementValueQuery(req.Values, func(v string) query.Query {
 			if useExactTermQuery {
-				return newExactTermsQuery(req.Key, req.Values[0], prefix), nil
+				return exactFieldTermQuery(req.Key, v, prefix)
 			}
-			q := newFilterQuery(req.Key, filterValue(req.Key, req.Values[0]), prefix)
-			return q, nil
-		}
-
-		disjuncts := []query.Query{}
-		for _, v := range req.Values {
-			var q query.Query
-			if useExactTermQuery {
-				q = newExactTermsQuery(req.Key, v, prefix)
-			} else {
-				q = newFilterQuery(req.Key, filterValue(req.Key, v), prefix)
-			}
-			disjuncts = append(disjuncts, q)
-		}
-
-		return query.NewDisjunctionQuery(disjuncts), nil
+			return fieldFilterQuery(req.Key, filterValue(req.Key, v), prefix)
+		}), nil
 
 	case selection.NotIn:
 		boolQuery := bleve.NewBooleanQuery()
 
 		var mustNotQueries []query.Query
 		for _, value := range req.Values {
-			q := newFilterQuery(req.Key, filterValue(req.Key, value), prefix)
+			q := fieldFilterQuery(req.Key, filterValue(req.Key, value), prefix)
 			mustNotQueries = append(mustNotQueries, q)
 		}
 		boolQuery.AddMustNot(mustNotQueries...)
@@ -2559,6 +2521,38 @@ func requirementQuery(req *resourcepb.Requirement, prefix string) (query.Query, 
 	return nil, resource.NewBadRequestError(
 		fmt.Sprintf("unsupported query operation (%s %s %v)", req.Key, req.Operator, req.Values),
 	)
+}
+
+// allRequirementValuesQuery preserves selector semantics where multiple "=" values are combined with AND.
+func allRequirementValuesQuery(values []string, valueQuery func(string) query.Query) query.Query {
+	if len(values) == 0 {
+		return query.NewMatchAllQuery()
+	}
+	if len(values) == 1 {
+		return valueQuery(values[0])
+	}
+
+	queries := make([]query.Query, 0, len(values))
+	for _, v := range values {
+		queries = append(queries, valueQuery(v))
+	}
+	return query.NewConjunctionQuery(queries)
+}
+
+// anyRequirementValueQuery preserves selector semantics where multiple "in" values are combined with OR.
+func anyRequirementValueQuery(values []string, valueQuery func(string) query.Query) query.Query {
+	if len(values) == 0 {
+		return query.NewMatchAllQuery()
+	}
+	if len(values) == 1 {
+		return valueQuery(values[0])
+	}
+
+	queries := make([]query.Query, 0, len(values))
+	for _, v := range values {
+		queries = append(queries, valueQuery(v))
+	}
+	return query.NewDisjunctionQuery(queries)
 }
 
 // addWildcardQueries adds wildcard queries for the given field to the disjunction.
@@ -2583,26 +2577,53 @@ func addWildcardQueries(disjoin *query.DisjunctionQuery, pattern string, field s
 	}
 }
 
-func newFilterQuery(key string, value string, prefix string) query.Query {
-	if key != resource.SEARCH_FIELD_TITLE {
-		return newQuery(key, value, prefix)
+// fieldFilterQuery builds the query for one field-filter value after requirementQuery has handled the selector operator.
+// It applies public field semantics, so a title filter can expand to multiple internal title fields.
+func fieldFilterQuery(key string, value string, prefix string) query.Query {
+	if key == resource.SEARCH_FIELD_TITLE {
+		return titleFieldFilterQuery(value, prefix)
 	}
+	if value == "*" {
+		return bleve.NewMatchAllQuery()
+	}
+	if strings.Contains(value, "*") {
+		return fieldWildcardQuery(key, value, prefix)
+	}
+	return fieldMatchQuery(key, value, prefix)
+}
 
+// titleFieldFilterQuery expands the public title filter across the internal title fields.
+func titleFieldFilterQuery(value string, prefix string) query.Query {
 	// Title exact matching and partial matching live in separate index fields,
 	// but the title filter API predates those internal fields.
 	queries := []query.Query{
-		newExactTermsQuery(resource.SEARCH_FIELD_TITLE_PHRASE, strings.ToLower(value), prefix),
-		newQuery(resource.SEARCH_FIELD_TITLE, value, prefix),
+		exactFieldTermQuery(resource.SEARCH_FIELD_TITLE_PHRASE, strings.ToLower(value), prefix),
+		titleFieldTokenQuery(value, prefix),
 	}
 	// Only use title_ngram for single-token title filters. Multi-word filters are handled by title_phrase/title;
 	// adding title_ngram can broaden them after removeSmallTerms drops short words, for example "what\"s up" becomes "what".
 	if !strings.ContainsAny(value, whitespaceCharacters) {
-		queries = append(queries, newTitleNgramQuery(value, prefix))
+		queries = append(queries, titleFieldNgramQuery(value, prefix))
 	}
 	return bleve.NewDisjunctionQuery(queries...)
 }
 
-func newTitleNgramQuery(value string, prefix string) query.Query {
+// titleFieldTokenQuery builds the part of title filtering that targets the standard-analyzed title field.
+func titleFieldTokenQuery(value string, prefix string) query.Query {
+	if value == "*" {
+		return bleve.NewMatchAllQuery()
+	}
+	if strings.Contains(value, "*") {
+		return fieldWildcardQuery(resource.SEARCH_FIELD_TITLE, value, prefix)
+	}
+	if delimiter, ok := firstTermSeparator(value); ok {
+		return fieldAllTokensQuery(resource.SEARCH_FIELD_TITLE, strings.Split(value, delimiter), prefix)
+	}
+	return fieldMatchQuery(resource.SEARCH_FIELD_TITLE, value, prefix)
+}
+
+// titleFieldNgramQuery builds the partial-match part of title filtering against title_ngram.
+func titleFieldNgramQuery(value string, prefix string) query.Query {
 	q := bleve.NewMatchQuery(removeSmallTerms(splitTermCharacters(value)))
 	q.SetField(prefix + resource.SEARCH_FIELD_TITLE_NGRAM)
 	q.Analyzer = TITLE_ANALYZER
@@ -2610,6 +2631,7 @@ func newTitleNgramQuery(value string, prefix string) query.Query {
 	return q
 }
 
+// splitTermCharacters normalizes punctuation separators before sending a title filter value through the ngram analyzer.
 func splitTermCharacters(value string) string {
 	for _, c := range TermCharacters {
 		value = strings.ReplaceAll(value, c, " ")
@@ -2617,38 +2639,24 @@ func splitTermCharacters(value string) string {
 	return value
 }
 
-// newQuery will create a query that will match the value or the tokens of the value
-func newQuery(key string, value string, prefix string) query.Query {
-	if value == "*" {
-		return bleve.NewMatchAllQuery()
-	}
-	if strings.Contains(value, "*") {
-		// wildcard query is expensive - should be used with caution
-		q := bleve.NewWildcardQuery(value)
-		q.SetField(prefix + key)
-		return q
-	}
-	delimiter, ok := firstTermSeparator(value)
-	if slices.Contains(termFields, key) && ok {
-		return newTermsQuery(key, value, delimiter, prefix)
-	}
+// fieldWildcardQuery builds a wildcard query against one concrete Bleve field.
+func fieldWildcardQuery(key string, value string, prefix string) query.Query {
+	// wildcard query is expensive - should be used with caution
+	q := bleve.NewWildcardQuery(value)
+	q.SetField(prefix + key)
+	return q
+}
+
+// fieldMatchQuery builds an analyzed match query against one concrete Bleve field.
+func fieldMatchQuery(key string, value string, prefix string) query.Query {
 	q := bleve.NewMatchQuery(value)
 	q.SetField(prefix + key)
 	return q
 }
 
-// newTermsQuery will create a query that will match on term or tokens
-func newTermsQuery(key string, value string, delimiter string, prefix string) query.Query {
-	q := newExactTermsQuery(key, value, prefix)
-
-	tokens := strings.Split(value, delimiter)
-	cq := newMatchAllTokensQuery(tokens, key, prefix)
-	return bleve.NewDisjunctionQuery(q, cq)
-}
-
-// newExactTermsQuery uses Bleve TermQuery for exact token matching.
+// exactFieldTermQuery uses Bleve TermQuery for exact token matching.
 // The input must already match how the field was indexed; TermQuery does not run an analyzer.
-func newExactTermsQuery(key string, value string, prefix string) query.Query {
+func exactFieldTermQuery(key string, value string, prefix string) query.Query {
 	// won't match with ending space
 	value = strings.TrimSuffix(value, " ")
 
@@ -2657,10 +2665,13 @@ func newExactTermsQuery(key string, value string, prefix string) query.Query {
 	return q
 }
 
-// newMatchAllTokensQuery will create a query that will match on all tokens
-func newMatchAllTokensQuery(tokens []string, key string, prefix string) query.Query {
+// fieldAllTokensQuery requires every token from a split filter value to match the same concrete Bleve field.
+func fieldAllTokensQuery(key string, tokens []string, prefix string) query.Query {
 	cq := bleve.NewConjunctionQuery()
 	for _, token := range tokens {
+		if token == "" {
+			continue
+		}
 		_, ok := firstTermSeparator(token)
 		if ok {
 			tq := bleve.NewTermQuery(token)
@@ -2668,9 +2679,7 @@ func newMatchAllTokensQuery(tokens []string, key string, prefix string) query.Qu
 			cq.AddQuery(tq)
 			continue
 		}
-		mq := bleve.NewMatchQuery(token)
-		mq.SetField(prefix + key)
-		cq.AddQuery(mq)
+		cq.AddQuery(fieldMatchQuery(key, token, prefix))
 	}
 	return cq
 }

--- a/pkg/storage/unified/search/bleve_search_test.go
+++ b/pkg/storage/unified/search/bleve_search_test.go
@@ -177,6 +177,17 @@ func TestCanSearchByTitle(t *testing.T) {
 		checkSearchQuery(t, index, newTestQuery("A01"), nil)
 	})
 
+	t.Run("title filter ignores empty tokens from split values", func(t *testing.T) {
+		index := newTestDashboardsIndex(t, threshold, 2, noop)
+		indexDocumentsWithTitles(t, index, key, map[string]string{
+			"name1": "foo bar",
+			"name2": "baz",
+		})
+
+		checkSearchQuery(t, index, newQueryByTitle("foo "), []string{"name1"})
+		checkSearchQuery(t, index, newQueryByTitle("foo-"), []string{"name1"})
+	})
+
 	t.Run("title search with character will match one document", func(t *testing.T) {
 		index := newTestDashboardsIndex(t, threshold, 2, noop)
 		indexDocumentsWithTitles(t, index, key, map[string]string{

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -300,6 +300,22 @@ func testBleveBackend(t *testing.T, backend *bleveBackend) {
 		require.Equal(t, int64(1), rsp.TotalHits)
 		require.Equal(t, "bbb", rsp.Results.Rows[0].Key.Name)
 
+		// search by owner reference - multiple values with Equals (AND)
+		rsp, err = index.Search(ctx, NewStubAccessClient(map[string]bool{"dashboards": true}), &resourcepb.ResourceSearchRequest{
+			Options: &resourcepb.ListOptions{
+				Key: key,
+				Fields: []*resourcepb.Requirement{{
+					Key:      resource.SEARCH_FIELD_OWNER_REFERENCES,
+					Operator: "=",
+					Values:   []string{"iam.grafana.app/Team/marketing", "iam.grafana.app/User/admin"},
+				}},
+			},
+			Limit: 100000,
+		}, nil, nil)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), rsp.TotalHits)
+		require.Equal(t, "bbb", rsp.Results.Rows[0].Key.Name)
+
 		// search by owner reference - multiple values (OR)
 		rsp, err = index.Search(ctx, NewStubAccessClient(map[string]bool{"dashboards": true}), &resourcepb.ResourceSearchRequest{
 			Options: &resourcepb.ListOptions{


### PR DESCRIPTION
Follow-up to #125081, after `title` was simplified to standard-analyzed only and partial matching moved to `title_ngram`.

Clean up Bleve field-filter query helpers without changing normal search behavior.

The main change is splitting helper names by responsibility:
- `requirementQuery` handles selector operators like `=`, `in`, `notin`, and `==`
- `fieldFilterQuery` builds the query for one field-filter value
- title-specific helpers expand the public `title` filter across `title_phrase`, `title`, and `title_ngram`
- low-level helpers build concrete Bleve field queries (`fieldMatchQuery`, `fieldWildcardQuery`, `exactFieldTermQuery`)

This also removes the dead exact `TermQuery(title, value)` branch. Since `title` is now standard-analyzed only, it no longer indexes the original full string as one token; token matching is still preserved through `fieldAllTokensQuery`.

## Behavior verification

| Path | Old | New | Equivalent? |
|---|---|---|---|
| `DoubleEquals`, title key | `newExactTermsQuery(title_phrase, lower(value))` | `exactFieldTermQuery(title_phrase, lower(value))` | yes |
| `DoubleEquals`, other keys | `newExactTermsQuery(key, value)` | `exactFieldTermQuery(key, value)` | yes |
| `Equals`, 0 values | `MatchAll` | `allRequirementValuesQuery` → `MatchAll` | yes |
| `Equals`, 1 value, exact-term field | `newExactTermsQuery` | `exactFieldTermQuery` | yes |
| `Equals`, 1 value, other field | `newFilterQuery(filterValue(...))` | `fieldFilterQuery(filterValue(...))` | yes |
| `Equals`, multiple values, non-exact field | conjunction of `newFilterQuery(...)` | `allRequirementValuesQuery` → conjunction of `fieldFilterQuery(...)` | yes |
| `Equals`, multiple values, exact-term field | conjunction of analyzed filter queries | conjunction of exact `TermQuery`s | intentional consistency fix |
| `In`, 0 values | `MatchAll` | `anyRequirementValueQuery` → `MatchAll` | yes |
| `In`, 1/N values, exact-term field | exact-term query per value, OR for N | `exactFieldTermQuery` per value, OR for N | yes |
| `In`, 1/N values, other field | filter query per value, OR for N | `fieldFilterQuery` per value, OR for N | yes |
| `NotIn` | `newFilterQuery` inside `must_not` | `fieldFilterQuery` inside `must_not` | yes |
| non-title field filter | `newQuery`: match-all / wildcard / match | `fieldFilterQuery`: match-all / wildcard / match | yes |
| title filter expansion | `title_phrase` + `title` + optional `title_ngram` | same via `titleFieldFilterQuery` | yes |
| title token query with separators | `newTermsQuery`: dead exact title term OR all-token match | `fieldAllTokensQuery`: all-token match | dead branch removed |
| empty tokens from split title values | could add `Match("")` and break conjunction | empty tokens skipped | intentional bug fix |
| `title_ngram` query | `newTitleNgramQuery` | `titleFieldNgramQuery` | yes |
| exact term helper | `newExactTermsQuery` | `exactFieldTermQuery` | yes |

The only intentional behavior changes are:
- multi-value `=` on exact-term fields now uses exact matching consistently with single-value `=` and `in`
- empty tokens produced by splitting title filter values are ignored, so values like `foo ` or `foo-` no longer add a `Match("")` clause
