### PR TITLE
Advisor: Adds a checkscheduler for the MT scenario

### DIFF
--- a/apps/advisor/go.mod
+++ b/apps/advisor/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/grafana/grafana/pkg/plugins v0.0.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/stretchr/testify v1.11.1
+	golang.org/x/sync v0.21.0
 	k8s.io/apimachinery v0.36.1
 	k8s.io/apiserver v0.36.0
 	k8s.io/client-go v0.36.1
@@ -313,7 +314,6 @@ require (
 	golang.org/x/mod v0.37.0 // indirect
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/oauth2 v0.36.0 // indirect
-	golang.org/x/sync v0.21.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/telemetry v0.0.0-20260610154732-fb80ec83bdd9 // indirect
 	golang.org/x/term v0.44.0 // indirect

--- a/apps/advisor/pkg/app/app.go
+++ b/apps/advisor/pkg/app/app.go
@@ -68,7 +68,7 @@ func New(cfg app.Config) (app.App, error) {
 		return nil, err
 	}
 
-	csch, err := checkscheduler.New(cfg, log)
+	csch, err := checkscheduler.New(cfg, log, ctr)
 	if err != nil {
 		return nil, err
 	}

--- a/apps/advisor/pkg/app/checkscheduler/checkscheduler.go
+++ b/apps/advisor/pkg/app/checkscheduler/checkscheduler.go
@@ -2,8 +2,9 @@ package checkscheduler
 
 import (
 	"context"
+	"crypto/rand"
 	"fmt"
-	"math/rand"
+	"math/big"
 	"sort"
 	"strconv"
 	"time"
@@ -16,8 +17,11 @@ import (
 	advisorv0alpha1 "github.com/grafana/grafana/apps/advisor/pkg/apis/advisor/v0alpha1"
 	"github.com/grafana/grafana/apps/advisor/pkg/app/checkregistry"
 	"github.com/grafana/grafana/apps/advisor/pkg/app/checks"
+	"github.com/grafana/grafana/apps/advisor/pkg/app/checktyperegisterer"
 	"github.com/grafana/grafana/pkg/services/org"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/metadata"
 )
 
 const defaultEvaluationInterval = 7 * 24 * time.Hour // 7 days
@@ -35,7 +39,9 @@ var (
 type Runner struct {
 	checkRegistry       checkregistry.CheckService
 	checksClient        resource.Client
+	checksMetadata      metadata.Getter
 	typesClient         resource.Client
+	checkTypeSyncer     checktyperegisterer.CheckTypeSyncer
 	defaultEvalInterval time.Duration
 	maxHistory          int
 	log                 logging.Logger
@@ -44,7 +50,7 @@ type Runner struct {
 }
 
 // NewRunner creates a new Runner.
-func New(cfg app.Config, log logging.Logger) (app.Runnable, error) {
+func New(cfg app.Config, log logging.Logger, checkTypeSyncer checktyperegisterer.CheckTypeSyncer) (app.Runnable, error) {
 	// Read config
 	specificConfig, ok := cfg.SpecificConfig.(checkregistry.AdvisorAppConfig)
 	if !ok {
@@ -71,11 +77,23 @@ func New(cfg app.Config, log logging.Logger) (app.Runnable, error) {
 	if err != nil {
 		return nil, err
 	}
+	metadataClient, err := metadata.NewForConfig(&cfg.KubeConfig)
+	if err != nil {
+		return nil, err
+	}
+	checkGVR := schema.GroupVersionResource{
+		Group:    advisorv0alpha1.CheckKind().Group(),
+		Version:  advisorv0alpha1.CheckKind().Version(),
+		Resource: advisorv0alpha1.CheckKind().Plural(),
+	}
+	checksMetadata := metadataClient.Resource(checkGVR)
 
 	return &Runner{
 		checkRegistry:       checkRegistry,
 		checksClient:        client,
 		typesClient:         typesClient,
+		checksMetadata:      checksMetadata,
+		checkTypeSyncer:     checkTypeSyncer,
 		defaultEvalInterval: evalInterval,
 		maxHistory:          maxHistory,
 		log:                 log.With("runner", "advisor.checkscheduler"),
@@ -84,13 +102,25 @@ func New(cfg app.Config, log logging.Logger) (app.Runnable, error) {
 	}, nil
 }
 
+// isMT reports whether the runner has neither a stack ID nor an org
+// service configured. In that mode the scheduler discovers namespaces from
+// the apiserver (see runMT in mtcheckscheduler.go) instead of resolving them
+// from local config.
+func (r *Runner) isMT() bool {
+	return r.stackID == "" && r.orgService == nil
+}
+
 func (r *Runner) Run(ctx context.Context) error {
 	logger := r.log.WithContext(ctx)
-	if r.stackID == "" && r.orgService == nil {
-		logger.Debug("Check scheduler disabled")
-		return nil
+	if r.isMT() {
+		return r.runMT(ctx, logger)
 	}
+	return r.runST(ctx, logger)
+}
 
+// runST runs the single-tenant scheduler loop, where namespaces are resolved
+// from the configured stack ID or org service and work is done serially.
+func (r *Runner) runST(ctx context.Context, logger logging.Logger) error {
 	// We still need the context to eventually be cancelled to exit this function
 	// but we don't want the requests to fail because of it
 	ctxWithoutCancel := context.WithoutCancel(ctx)
@@ -150,6 +180,10 @@ func (r *Runner) Run(ctx context.Context) error {
 				// If there are checks already created and they are older than the evaluation interval
 				// then we can automatically create more
 				if !lastCreated.IsZero() && lastCreated.Before(time.Now().Add(-r.defaultEvalInterval)) {
+					if err := r.waitForCheckTypesRegistered(ctx, nsLogger, namespace, len(r.checkRegistry.Checks())); err != nil {
+						nsLogger.Error("Error waiting for check types to be registered", "error", err)
+						return err
+					}
 					err = r.createChecks(ctx, nsLogger, namespace)
 					if err != nil {
 						nsLogger.Error("Error creating new check reports", "error", err)
@@ -197,13 +231,37 @@ func (r *Runner) listChecks(ctx context.Context, logger logging.Logger, namespac
 	return checks, nil
 }
 
+// listChecksMetadata lists Check object metadata (PartialObjectMetadata) for a
+// namespace, paginating as needed. Passing metav1.NamespaceAll lists across all
+// namespaces (used by the MT scheduler for cluster-wide discovery). Only object
+// metadata is fetched (no spec/status), which keeps these list calls cheap when
+// callers just need fields like the creation timestamp.
+func (r *Runner) listChecksMetadata(ctx context.Context, logger logging.Logger, namespace string) ([]metav1.PartialObjectMetadata, error) {
+	client := r.checksMetadata.Namespace(namespace)
+	list, err := client.List(ctx, metav1.ListOptions{
+		Limit: 1000, // Avoid pagination for normal use cases, which is a costly operation
+	})
+	if err != nil {
+		return nil, err
+	}
+	items := list.Items
+	for list.GetContinue() != "" {
+		logger.Debug("List has continue token, listing next page", "continue", list.GetContinue())
+		list, err = client.List(ctx, metav1.ListOptions{Continue: list.GetContinue(), Limit: 1000})
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, list.Items...)
+	}
+	return items, nil
+}
+
 // checkLastCreated returns the creation time of the last check created for a specific namespace.
 // This assumes that the checks are created in batches so a batch will have a similar creation time.
-// In case it finds an unprocessed check from a previous run, it will set it to error.
 func (r *Runner) checkLastCreated(ctx context.Context, log logging.Logger, namespaces []string) (map[string]time.Time, error) {
 	lastCreated := map[string]time.Time{}
 	for _, namespace := range namespaces {
-		checkList, err := r.listChecks(ctx, log, namespace)
+		checkList, err := r.listChecksMetadata(ctx, log, namespace)
 		if err != nil {
 			return nil, err
 		}
@@ -235,48 +293,48 @@ func (r *Runner) markUnprocessedChecks(ctx context.Context, log logging.Logger, 
 	return nil
 }
 
-// createChecks creates a new check for each check type in the registry.
+// createChecks creates a new check for each check type known to this
+// process's in-process registry. The registry is the source of truth for
+// what this process can run; CheckType resources in the apiserver can lag
+// behind, especially in MT where per-tenant CheckType registration is
+// asynchronous relative to the global registry.
 func (r *Runner) createChecks(ctx context.Context, logger logging.Logger, namespace string) error {
-	// List existing CheckType objects
-	list, err := r.typesClient.List(ctx, namespace, resource.ListOptions{})
-	if err != nil {
-		return fmt.Errorf("error listing check types: %w", err)
-	}
-	// This may be run before the check types are registered, so we need to wait for them to be registered.
-	allChecksRegistered := len(list.GetItems()) == len(r.checkRegistry.Checks())
-	retryCount := 0
-	for !allChecksRegistered && retryCount < waitMaxRetries {
-		logger.Info("Waiting for all check types to be registered", "retryCount", retryCount, "waitInterval", waitInterval)
-		time.Sleep(waitInterval)
-		list, err = r.typesClient.List(ctx, namespace, resource.ListOptions{})
-		if err != nil {
-			return fmt.Errorf("error listing check types: %w", err)
-		}
-		allChecksRegistered = len(list.GetItems()) == len(r.checkRegistry.Checks())
-		retryCount++
-	}
-
-	// Create checks for each CheckType
-	for _, item := range list.GetItems() {
-		checkType, ok := item.(*advisorv0alpha1.CheckType)
-		if !ok {
-			continue
-		}
-
+	for _, check := range r.checkRegistry.Checks() {
 		obj := &advisorv0alpha1.Check{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName: "check-",
 				Namespace:    namespace,
 				Labels: map[string]string{
-					checks.TypeLabel: checkType.Spec.Name,
+					checks.TypeLabel: check.ID(),
 				},
 			},
 			Spec: advisorv0alpha1.CheckSpec{},
 		}
 		id := obj.GetStaticMetadata().Identifier()
-		_, err := r.checksClient.Create(ctx, id, obj, resource.CreateOptions{})
-		if err != nil {
+		if _, err := r.checksClient.Create(ctx, id, obj, resource.CreateOptions{}); err != nil {
 			return fmt.Errorf("error creating check: %w", err)
+		}
+	}
+	return nil
+}
+
+// waitForCheckTypesRegistered polls the CheckType list in the given namespace
+// until it contains at least `expected` items or waitMaxRetries is exhausted.
+// At process startup the registerer can still be in-flight, so this gives
+// downstream consumers a chance to see consistent CheckType + Check
+// resources. Running out of retries is tolerated: a slow startup must not
+// permanently block check creation.
+func (r *Runner) waitForCheckTypesRegistered(ctx context.Context, logger logging.Logger, namespace string, expected int) error {
+	list, err := r.typesClient.List(ctx, namespace, resource.ListOptions{})
+	if err != nil {
+		return fmt.Errorf("error listing check types: %w", err)
+	}
+	for retry := 0; len(list.GetItems()) < expected && retry < waitMaxRetries; retry++ {
+		logger.Info("Waiting for all check types to be registered", "retryCount", retry, "waitInterval", waitInterval)
+		time.Sleep(waitInterval)
+		list, err = r.typesClient.List(ctx, namespace, resource.ListOptions{})
+		if err != nil {
+			return fmt.Errorf("error listing check types: %w", err)
 		}
 	}
 	return nil
@@ -355,8 +413,7 @@ func (r *Runner) getNextEvalTime(defaultEvaluationInterval time.Duration, lastCr
 
 	// Calculate the next evaluation time and add random variation
 	nextEvalTime = time.Until(baseTime.Add(nextEvalTime))
-	randomVariation := time.Duration(rand.Int63n(evalIntervalRandomVariation.Nanoseconds()))
-	nextEvalTime += randomVariation
+	nextEvalTime += randomJitter(evalIntervalRandomVariation)
 
 	// Ensure we always return a positive duration to avoid ticker panics
 	if nextEvalTime <= 0 {
@@ -364,6 +421,21 @@ func (r *Runner) getNextEvalTime(defaultEvaluationInterval time.Duration, lastCr
 	}
 
 	return nextEvalTime
+}
+
+// randomJitter returns a uniformly distributed duration in [0, max) drawn from
+// crypto/rand. The value only spreads scheduler ticks so a CSPRNG isn't strictly
+// required, but using one keeps us off math/rand. On the effectively impossible
+// error path (or a non-positive max) it returns 0, i.e. no jitter.
+func randomJitter(max time.Duration) time.Duration {
+	if max <= 0 {
+		return 0
+	}
+	n, err := rand.Int(rand.Reader, big.NewInt(max.Nanoseconds()))
+	if err != nil {
+		return 0
+	}
+	return time.Duration(n.Int64())
 }
 
 func getMaxHistory(pluginConfig map[string]string) (int, error) {

--- a/apps/advisor/pkg/app/checkscheduler/checkscheduler_test.go
+++ b/apps/advisor/pkg/app/checkscheduler/checkscheduler_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/metadata"
 )
 
 func init() {
@@ -281,7 +282,7 @@ func TestRunner_Run_Pagination(t *testing.T) {
 	})
 }
 
-// Helper functions
+// Shared test helpers and mocks
 
 // runAndTimeout runs a runner with a short timeout for testing purposes.
 // This is used to terminate the runner's infinite loop in tests that don't specifically test timeout behavior.
@@ -291,12 +292,13 @@ func runAndTimeout(runner *Runner) error {
 	return runner.Run(ctx)
 }
 
-// createTestRunner creates a test runner with mock clients
+// createTestRunner returns a single-tenant Runner with mock clients.
 func createTestRunner(checkClient, typesClient *MockClient) *Runner {
 	return createTestRunnerWithRegistry(checkClient, typesClient, &MockCheckService{checks: []checks.Check{}})
 }
 
-// createTestRunnerWithRegistry creates a test runner with mock clients and custom registry
+// createTestRunnerWithRegistry returns a single-tenant Runner with mock
+// clients and a caller-supplied check registry.
 func createTestRunnerWithRegistry(checkClient, typesClient *MockClient, checkRegistry checkregistry.CheckService) *Runner {
 	// Ensure mock clients have default implementations
 	if checkClient.listFunc == nil {
@@ -330,6 +332,7 @@ func createTestRunnerWithRegistry(checkClient, typesClient *MockClient, checkReg
 	return &Runner{
 		checkRegistry:       checkRegistry,
 		checksClient:        checkClient,
+		checksMetadata:      metadataGetterFromClient(checkClient),
 		typesClient:         typesClient,
 		defaultEvalInterval: 5 * time.Millisecond,
 		maxHistory:          defaultMaxHistory,
@@ -363,6 +366,59 @@ func (m *MockClient) Delete(ctx context.Context, identifier resource.Identifier,
 
 func (m *MockClient) PatchInto(ctx context.Context, identifier resource.Identifier, patch resource.PatchRequest, options resource.PatchOptions, into resource.Object) error {
 	return m.patchFunc(ctx, identifier, patch, options, into)
+}
+
+// fakeMetadataGetter is a function-backed metadata.Getter for tests. Only the
+// namespace-scoped List path used by Runner.listChecksMetadata is implemented;
+// other methods fall through to the embedded nil interface and would panic if
+// called.
+type fakeMetadataGetter struct {
+	metadata.Getter
+	listFunc func(ctx context.Context, namespace string, opts metav1.ListOptions) (*metav1.PartialObjectMetadataList, error)
+}
+
+func (f *fakeMetadataGetter) Namespace(ns string) metadata.ResourceInterface {
+	return &fakeMetadataResource{namespace: ns, listFunc: f.listFunc}
+}
+
+type fakeMetadataResource struct {
+	metadata.ResourceInterface
+	namespace string
+	listFunc  func(ctx context.Context, namespace string, opts metav1.ListOptions) (*metav1.PartialObjectMetadataList, error)
+}
+
+func (f *fakeMetadataResource) List(ctx context.Context, opts metav1.ListOptions) (*metav1.PartialObjectMetadataList, error) {
+	return f.listFunc(ctx, f.namespace, opts)
+}
+
+// metadataGetterFromClient adapts a MockClient's List into a metadata.Getter,
+// so existing fixtures used for full Check lists also drive the metadata
+// listing both schedulers now use (PartialObjectMetadataList).
+func metadataGetterFromClient(c *MockClient) metadata.Getter {
+	return &fakeMetadataGetter{
+		listFunc: func(ctx context.Context, namespace string, opts metav1.ListOptions) (*metav1.PartialObjectMetadataList, error) {
+			list, err := c.listFunc(ctx, namespace, resource.ListOptions{
+				Limit:    int(opts.Limit),
+				Continue: opts.Continue,
+			})
+			if err != nil {
+				return nil, err
+			}
+			out := &metav1.PartialObjectMetadataList{
+				ListMeta: metav1.ListMeta{Continue: list.GetContinue()},
+			}
+			for _, item := range list.GetItems() {
+				out.Items = append(out.Items, metav1.PartialObjectMetadata{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:         item.GetNamespace(),
+						Name:              item.GetName(),
+						CreationTimestamp: item.GetCreationTimestamp(),
+					},
+				})
+			}
+			return out, nil
+		},
+	}
 }
 
 type MockCheckService struct {

--- a/apps/advisor/pkg/app/checkscheduler/mtcheckscheduler.go
+++ b/apps/advisor/pkg/app/checkscheduler/mtcheckscheduler.go
@@ -1,0 +1,254 @@
+package checkscheduler
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"sync/atomic"
+	"time"
+
+	"github.com/grafana/authlib/types"
+	"github.com/grafana/grafana-app-sdk/logging"
+	"github.com/grafana/grafana/apps/advisor/pkg/app/metrics"
+	"golang.org/x/sync/errgroup"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const maxConcurrency = 10
+
+// runMT runs the multi-tenant scheduler loop. Namespaces and their lastCreated
+// timestamps are rediscovered cluster-wide from existing Check resources on
+// every tick, and per-namespace work is fanned out under maxConcurrency.
+func (r *Runner) runMT(ctx context.Context, logger logging.Logger) error {
+	logger = logger.With("mode", "mt")
+	ctxWithoutCancel := context.WithoutCancel(ctx)
+
+	namespaces, lastCreatedMap, err := r.discoverNamespaces(ctxWithoutCancel, logger)
+	if err != nil {
+		logger.Debug("checkscheduler step failed", "step", "discoverNamespaces.initial", "error", err)
+		return fmt.Errorf("failed to discover namespaces (cluster-wide checks list): %w", err)
+	}
+	logger.Debug("checkscheduler step", "step", "discoverNamespaces.initial", "length_namespaces", len(namespaces))
+
+	r.runInitialCleanupParallelMT(ctx, logger, namespaces, lastCreatedMap)
+	// Eagerly run a tick so any tenants whose last check is already stale at
+	// startup get processed now instead of waiting up to defaultEvalInterval.
+	// The MT ticker fires on a fixed cadence (see mtTickInterval), so without
+	// this we'd be relying on the next tick — which can be a full evaluation
+	// interval away — to catch up stale tenants discovered at boot.
+	r.runTickParallelMT(ctx, logger, namespaces, lastCreatedMap)
+
+	nextEvalTime := r.mtTickInterval()
+	logger.Debug("checkscheduler initial ticker interval", "next_eval", nextEvalTime)
+	ticker := time.NewTicker(nextEvalTime)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ticker.C:
+			logger.Debug("checkscheduler step", "step", "discoverNamespaces.tick", "detail", "cluster-wide Check list")
+			namespaces, lastCreatedMap, err = r.discoverNamespaces(ctxWithoutCancel, logger)
+			if err != nil {
+				// A discovery failure mid-loop signals a real problem (RBAC, apiserver
+				// reachability, etc.) that the runner shouldn't silently retry through:
+				// tear down so the app-sdk runtime can surface it and restart us.
+				logger.Error("Error discovering namespaces, stopping scheduler", "error", err)
+				return fmt.Errorf("failed to discover namespaces (cluster-wide checks list): %w", err)
+			}
+			r.runTickParallelMT(ctx, logger, namespaces, lastCreatedMap)
+
+			nextEvalTime = r.mtTickInterval()
+			logger.Debug("checkscheduler tick complete", "next_eval", nextEvalTime)
+			ticker.Reset(nextEvalTime)
+		case <-ctx.Done():
+			logger.Debug("checkscheduler stopping", "reason", "context_done")
+			return ctx.Err()
+		}
+	}
+}
+
+// mtTickInterval returns the MT scheduler tick interval.
+//
+// We deliberately don't use getNextEvalTime in MT: lastCreated is aggregated
+// across many tenants and the oldest entry is almost always older than
+// defaultEvalInterval, which collapses that calculation to ~0 and turns the
+// ticker into a busy loop bounded only by evalIntervalRandomVariation.
+// Instead we fire on a fixed cadence and let tickNamespace skip per-namespace
+// work that isn't stale yet.
+func (r *Runner) mtTickInterval() time.Duration {
+	jitter := randomJitter(evalIntervalRandomVariation)
+	return r.defaultEvalInterval + jitter
+}
+
+// discoverNamespaces lists Check objects cluster-wide (namespace ""), paginates, and returns
+// every cloud-stack namespace that has at least one check, plus the latest creation time per namespace.
+func (r *Runner) discoverNamespaces(ctx context.Context, log logging.Logger) ([]string, map[string]time.Time, error) {
+	start := time.Now()
+	var discoveryErr error
+	defer func() {
+		metrics.MTSchedulerDiscoveryDurationSeconds.Observe(time.Since(start).Seconds())
+		if discoveryErr != nil {
+			metrics.MTSchedulerDiscoveriesTotal.WithLabelValues("error").Inc()
+		} else {
+			metrics.MTSchedulerDiscoveriesTotal.WithLabelValues("success").Inc()
+		}
+	}()
+
+	// List Check metadata cluster-wide (namespace ""); discovery only reads
+	// each Check's namespace and creation timestamp.
+	items, err := r.listChecksMetadata(ctx, log, metav1.NamespaceAll)
+	if err != nil {
+		log.Debug("checkscheduler discoverNamespaces cluster-wide Check list failed", "error", err)
+		discoveryErr = err
+		return nil, nil, err
+	}
+
+	lastCreated := make(map[string]time.Time)
+	skipped := 0
+	for i := range items {
+		ns := items[i].GetNamespace()
+		info, parseErr := types.ParseNamespace(ns)
+		if parseErr != nil || info.StackID == 0 {
+			skipped++
+			continue
+		}
+		itemCreated := items[i].GetCreationTimestamp().Time
+		if itemCreated.After(lastCreated[ns]) {
+			lastCreated[ns] = itemCreated
+		}
+	}
+
+	namespaces := make([]string, 0, len(lastCreated))
+	for ns := range lastCreated {
+		namespaces = append(namespaces, ns)
+	}
+	sort.Strings(namespaces)
+	metrics.MTSchedulerNamespacesDiscovered.Set(float64(len(namespaces)))
+	log.Debug("checkscheduler discoverNamespaces complete", "checks_total", len(items),
+		"skipped_non_stack", skipped, "stack_namespace_count", len(namespaces))
+	return namespaces, lastCreated, nil
+}
+
+// runInitialCleanupParallelMT cleans up stale checks and marks unprocessed
+// checks as errored for every discovered namespace with at least one existing
+// check, in parallel, bounded by r.maxConcurrency.
+func (r *Runner) runInitialCleanupParallelMT(ctx context.Context, logger logging.Logger, namespaces []string, lastCreated map[string]time.Time) {
+	toClean := 0
+	for _, ns := range namespaces {
+		if !lastCreated[ns].IsZero() {
+			toClean++
+		}
+	}
+	logger.Debug("checkscheduler MT initial cleanup start", "namespaces_total", len(namespaces), "with_existing_checks", toClean, "max_concurrency", maxConcurrency)
+
+	var g errgroup.Group
+	g.SetLimit(maxConcurrency)
+	for _, namespace := range namespaces {
+		namespace := namespace
+		if lastCreated[namespace].IsZero() {
+			continue
+		}
+		g.Go(func() error {
+			nsLogger := logger.With("namespace", namespace)
+			nsLogger.Debug("checkscheduler MT initial cleanup namespace", "step", "begin")
+			if err := r.cleanupChecks(ctx, nsLogger, namespace); err != nil {
+				nsLogger.Error("Error cleaning up old check reports", "error", err)
+				return nil
+			}
+			if err := r.markUnprocessedChecks(ctx, nsLogger, namespace); err != nil {
+				nsLogger.Error("Error marking unprocessed checks", "error", err)
+				return nil
+			}
+			nsLogger.Debug("checkscheduler MT initial cleanup namespace", "step", "done")
+			return nil
+		})
+	}
+	_ = g.Wait()
+	logger.Debug("checkscheduler MT initial cleanup finished")
+}
+
+// runTickParallelMT processes a scheduler tick across all discovered
+// namespaces in parallel. Per-namespace errors are swallowed (and logged) so
+// one bad tenant can't stop the whole tick.
+//
+// lastCreatedMap is read-only here: it's rebuilt from a fresh cluster-wide
+// discovery on every tick (see runMT), so per-namespace updates don't need to
+// be persisted back into it. We only count them for the completion log.
+func (r *Runner) runTickParallelMT(ctx context.Context, logger logging.Logger, namespaces []string, lastCreatedMap map[string]time.Time) {
+	logger.Debug("checkscheduler MT tick start", "namespaces", len(namespaces), "max_concurrency", maxConcurrency)
+	var updated atomic.Int64
+	var g errgroup.Group
+	g.SetLimit(maxConcurrency)
+	for _, namespace := range namespaces {
+		last := lastCreatedMap[namespace]
+		g.Go(func() error {
+			nsLogger := logger.With("namespace", namespace)
+			newLast, err := r.tickNamespace(ctx, nsLogger, namespace, last)
+			if err != nil {
+				nsLogger.Error("Error during scheduled check tick", "error", err)
+				return nil
+			}
+			if newLast.Equal(last) {
+				return nil
+			}
+			updated.Add(1)
+			return nil
+		})
+	}
+	_ = g.Wait()
+	logger.Debug("checkscheduler MT tick finished", "updated_namespaces", updated.Load())
+}
+
+// tickNamespace creates new checks and cleans up when the last batch is older
+// than the evaluation interval. Returns the new "last created" time, or the
+// input lastCreated if no work was needed.
+func (r *Runner) tickNamespace(ctx context.Context, log logging.Logger, namespace string, lastCreated time.Time) (time.Time, error) {
+	start := time.Now()
+	var tickResult string
+	var observeDuration bool
+	defer func() {
+		metrics.MTSchedulerNamespaceTicksTotal.WithLabelValues(tickResult).Inc()
+		if observeDuration {
+			metrics.MTSchedulerNamespaceTickDurationSeconds.Observe(time.Since(start).Seconds())
+		}
+	}()
+
+	if lastCreated.IsZero() {
+		log.Debug("checkscheduler tickNamespace skip", "reason", "no_existing_checks", "last_created_zero", true)
+		tickResult = "skipped_no_checks"
+		return lastCreated, nil
+	}
+	deadline := time.Now().Add(-r.defaultEvalInterval)
+	if !lastCreated.Before(deadline) {
+		log.Debug("checkscheduler tickNamespace skip", "reason", "not_stale_yet",
+			"last_created", lastCreated, "eval_deadline", deadline, "eval_interval", r.defaultEvalInterval)
+		tickResult = "skipped_not_stale"
+		return lastCreated, nil
+	}
+	observeDuration = true
+	// In MT, CheckType registration is on-demand (the "/register" endpoint),
+	// so this namespace can hold a stale CheckType set if check types were
+	// added to or removed from the binary since the tenant last registered.
+	// Sync them first so every Check created below has a matching CheckType.
+	log.Debug("checkscheduler tickNamespace run", "step", "syncCheckTypes")
+	if err := r.checkTypeSyncer.RegisterCheckTypesInNamespace(ctx, log, namespace); err != nil {
+		log.Debug("checkscheduler tickNamespace failed", "step", "syncCheckTypes", "error", err)
+		tickResult = "error"
+		return lastCreated, err
+	}
+	log.Debug("checkscheduler tickNamespace run", "step", "createChecks", "last_created", lastCreated)
+	if err := r.createChecks(ctx, log, namespace); err != nil {
+		log.Debug("checkscheduler tickNamespace failed", "step", "createChecks", "error", err)
+		tickResult = "error"
+		return lastCreated, err
+	}
+	log.Debug("checkscheduler tickNamespace run", "step", "cleanupChecks")
+	if err := r.cleanupChecks(ctx, log, namespace); err != nil {
+		log.Debug("checkscheduler tickNamespace failed", "step", "cleanupChecks", "error", err)
+		tickResult = "error"
+		return lastCreated, err
+	}
+	log.Debug("checkscheduler tickNamespace done", "new_last_created", time.Now())
+	tickResult = "success"
+	return time.Now(), nil
+}

--- a/apps/advisor/pkg/app/checkscheduler/mtcheckscheduler_test.go
+++ b/apps/advisor/pkg/app/checkscheduler/mtcheckscheduler_test.go
@@ -1,0 +1,498 @@
+package checkscheduler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/grafana/grafana-app-sdk/logging"
+	"github.com/grafana/grafana-app-sdk/resource"
+	advisorv0alpha1 "github.com/grafana/grafana/apps/advisor/pkg/apis/advisor/v0alpha1"
+	"github.com/grafana/grafana/apps/advisor/pkg/app/checkregistry"
+	"github.com/grafana/grafana/apps/advisor/pkg/app/checks"
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestRunner_MT_DiscoveryTwoNamespaces(t *testing.T) {
+	var createdNS []string
+	var mu sync.Mutex
+
+	old := metav1.NewTime(time.Now().Add(-15 * 24 * time.Hour))
+	mockClient := &MockClient{
+		listFunc: func(ctx context.Context, namespace string, options resource.ListOptions) (resource.ListObject, error) {
+			if namespace == "" {
+				return &advisorv0alpha1.CheckList{
+					Items: []advisorv0alpha1.Check{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace:         "stacks-1",
+								Name:              "c1",
+								CreationTimestamp: old,
+								Labels:            map[string]string{checks.TypeLabel: "test-check"},
+								Annotations:       map[string]string{checks.StatusAnnotation: checks.StatusAnnotationProcessed},
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace:         "stacks-2",
+								Name:              "c2",
+								CreationTimestamp: old,
+								Labels:            map[string]string{checks.TypeLabel: "test-check"},
+								Annotations:       map[string]string{checks.StatusAnnotation: checks.StatusAnnotationProcessed},
+							},
+						},
+					},
+				}, nil
+			}
+			return &advisorv0alpha1.CheckList{
+				Items: []advisorv0alpha1.Check{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace:         namespace,
+							Name:              "c1",
+							CreationTimestamp: old,
+							Labels:            map[string]string{checks.TypeLabel: "test-check"},
+							Annotations:       map[string]string{checks.StatusAnnotation: checks.StatusAnnotationProcessed},
+						},
+					},
+				},
+			}, nil
+		},
+		createFunc: func(ctx context.Context, id resource.Identifier, obj resource.Object, opts resource.CreateOptions) (resource.Object, error) {
+			mu.Lock()
+			createdNS = append(createdNS, obj.GetNamespace())
+			mu.Unlock()
+			return obj, nil
+		},
+	}
+	mockTypes := &MockClient{
+		listFunc: func(ctx context.Context, namespace string, options resource.ListOptions) (resource.ListObject, error) {
+			return &advisorv0alpha1.CheckTypeList{
+				Items: []advisorv0alpha1.CheckType{
+					{
+						ObjectMeta: metav1.ObjectMeta{Name: "test-check"},
+						Spec:       advisorv0alpha1.CheckTypeSpec{Name: "test-check"},
+					},
+				},
+			}, nil
+		},
+	}
+	reg := &MockCheckService{checks: []checks.Check{&mockCheck{id: "test-check"}}}
+	runner := createTestMTRunner(mockClient, mockTypes, reg)
+
+	err := runAndTimeout(runner)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Contains(t, createdNS, "stacks-1")
+	assert.Contains(t, createdNS, "stacks-2")
+}
+
+func TestDiscoverNamespaces_Pagination(t *testing.T) {
+	var listCalls atomic.Int32
+	old := metav1.NewTime(time.Now().Add(-15 * 24 * time.Hour))
+
+	mockClient := &MockClient{
+		listFunc: func(ctx context.Context, namespace string, options resource.ListOptions) (resource.ListObject, error) {
+			assert.Equal(t, resource.NamespaceAll, namespace)
+			n := listCalls.Add(1)
+			if n == 1 {
+				assert.Equal(t, "", options.Continue, "first cluster list should have empty continue")
+				return &advisorv0alpha1.CheckList{
+					ListMeta: metav1.ListMeta{Continue: "page-2"},
+					Items: []advisorv0alpha1.Check{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace:         "stacks-1",
+								Name:              "a",
+								CreationTimestamp: old,
+								Labels:            map[string]string{checks.TypeLabel: "x"},
+							},
+						},
+					},
+				}, nil
+			}
+			assert.Equal(t, "page-2", options.Continue, "second cluster list must pass continue token")
+			return &advisorv0alpha1.CheckList{
+				Items: []advisorv0alpha1.Check{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace:         "stacks-2",
+							Name:              "b",
+							CreationTimestamp: old,
+							Labels:            map[string]string{checks.TypeLabel: "x"},
+						},
+					},
+				},
+			}, nil
+		},
+	}
+	r := &Runner{
+		checksMetadata: metadataGetterFromClient(mockClient),
+		log:            &logging.NoOpLogger{},
+	}
+	ns, last, err := r.discoverNamespaces(context.Background(), &logging.NoOpLogger{})
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"stacks-1", "stacks-2"}, ns)
+	assert.Len(t, last, 2)
+	assert.Equal(t, int32(2), listCalls.Load())
+}
+
+func TestDiscoverNamespaces_IgnoresNonStacksNamespaces(t *testing.T) {
+	old := metav1.NewTime(time.Now().Add(-15 * 24 * time.Hour))
+	mockClient := &MockClient{
+		listFunc: func(ctx context.Context, namespace string, options resource.ListOptions) (resource.ListObject, error) {
+			return &advisorv0alpha1.CheckList{
+				Items: []advisorv0alpha1.Check{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace:         "stacks-42",
+							Name:              "a",
+							CreationTimestamp: old,
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace:         "default",
+							Name:              "b",
+							CreationTimestamp: old,
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace:         "grafana",
+							Name:              "c",
+							CreationTimestamp: old,
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace:         "stacks-not-a-number",
+							Name:              "d",
+							CreationTimestamp: old,
+						},
+					},
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace:         "org-2",
+							Name:              "e",
+							CreationTimestamp: old,
+						},
+					},
+				},
+			}, nil
+		},
+	}
+	r := &Runner{
+		checksMetadata: metadataGetterFromClient(mockClient),
+		log:            &logging.NoOpLogger{},
+	}
+	ns, last, err := r.discoverNamespaces(context.Background(), &logging.NoOpLogger{})
+	assert.NoError(t, err)
+	assert.Equal(t, []string{"stacks-42"}, ns)
+	assert.Len(t, last, 1)
+	assert.Equal(t, old.Time, last["stacks-42"])
+}
+
+func TestRunner_MT_ErrorIsolation(t *testing.T) {
+	old := metav1.NewTime(time.Now().Add(-15 * 24 * time.Hour))
+	var mu sync.Mutex
+	var created []string
+
+	mockClient := &MockClient{
+		listFunc: func(ctx context.Context, namespace string, options resource.ListOptions) (resource.ListObject, error) {
+			if namespace == "" {
+				return &advisorv0alpha1.CheckList{
+					Items: []advisorv0alpha1.Check{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: "stacks-1", Name: "a", CreationTimestamp: old,
+								Labels:      map[string]string{checks.TypeLabel: "test-check"},
+								Annotations: map[string]string{checks.StatusAnnotation: checks.StatusAnnotationProcessed},
+							},
+						},
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Namespace: "stacks-2", Name: "b", CreationTimestamp: old,
+								Labels:      map[string]string{checks.TypeLabel: "test-check"},
+								Annotations: map[string]string{checks.StatusAnnotation: checks.StatusAnnotationProcessed},
+							},
+						},
+					},
+				}, nil
+			}
+			return &advisorv0alpha1.CheckList{
+				Items: []advisorv0alpha1.Check{
+					{
+						ObjectMeta: metav1.ObjectMeta{
+							Namespace: namespace, Name: "c", CreationTimestamp: old,
+							Labels:      map[string]string{checks.TypeLabel: "test-check"},
+							Annotations: map[string]string{checks.StatusAnnotation: checks.StatusAnnotationProcessed},
+						},
+					},
+				},
+			}, nil
+		},
+		createFunc: func(ctx context.Context, id resource.Identifier, obj resource.Object, opts resource.CreateOptions) (resource.Object, error) {
+			ns := obj.GetNamespace()
+			if ns == "stacks-2" {
+				return nil, errors.New("simulated create failure")
+			}
+			mu.Lock()
+			created = append(created, ns)
+			mu.Unlock()
+			return obj, nil
+		},
+	}
+	mockTypes := &MockClient{
+		listFunc: func(ctx context.Context, namespace string, options resource.ListOptions) (resource.ListObject, error) {
+			return &advisorv0alpha1.CheckTypeList{
+				Items: []advisorv0alpha1.CheckType{
+					{ObjectMeta: metav1.ObjectMeta{Name: "test-check"}, Spec: advisorv0alpha1.CheckTypeSpec{Name: "test-check"}},
+				},
+			}, nil
+		},
+	}
+	reg := &MockCheckService{checks: []checks.Check{&mockCheck{id: "test-check"}}}
+	runner := createTestMTRunner(mockClient, mockTypes, reg)
+	err := runAndTimeout(runner)
+	assert.ErrorIs(t, err, context.DeadlineExceeded)
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Contains(t, created, "stacks-1")
+	assert.NotContains(t, created, "stacks-2")
+}
+
+// TestRunTickParallelMT_TicksAllStaleNamespaces exercises the parallel tick
+// fan-out with many namespaces and a low concurrency cap so that worker
+// goroutines run simultaneously (with -race, this also guards against
+// concurrent access to the shared maps). Every namespace starts stale, so we
+// assert that createChecks ran for each one — the observable effect of a tick,
+// rather than a mutation of the caller's read-only timestamps map.
+func TestRunTickParallelMT_TicksAllStaleNamespaces(t *testing.T) {
+	const namespaceCount = 200
+	stale := time.Now().Add(-30 * 24 * time.Hour)
+
+	var mu sync.Mutex
+	created := make(map[string]bool, namespaceCount)
+	mockClient := &MockClient{
+		listFunc: func(ctx context.Context, namespace string, options resource.ListOptions) (resource.ListObject, error) {
+			return &advisorv0alpha1.CheckList{Items: []advisorv0alpha1.Check{}}, nil
+		},
+		createFunc: func(ctx context.Context, id resource.Identifier, obj resource.Object, opts resource.CreateOptions) (resource.Object, error) {
+			mu.Lock()
+			created[obj.GetNamespace()] = true
+			mu.Unlock()
+			return obj, nil
+		},
+		deleteFunc: func(ctx context.Context, id resource.Identifier, opts resource.DeleteOptions) error {
+			return nil
+		},
+	}
+	mockTypes := &MockClient{
+		listFunc: func(ctx context.Context, namespace string, options resource.ListOptions) (resource.ListObject, error) {
+			return &advisorv0alpha1.CheckTypeList{Items: []advisorv0alpha1.CheckType{}}, nil
+		},
+	}
+	reg := &MockCheckService{checks: []checks.Check{&mockCheck{id: "test-check"}}}
+	runner := createTestMTRunnerWithConcurrency(mockClient, mockTypes, reg)
+
+	namespaces := make([]string, 0, namespaceCount)
+	lastCreated := make(map[string]time.Time, namespaceCount)
+	for i := 0; i < namespaceCount; i++ {
+		ns := fmt.Sprintf("stacks-%d", i)
+		namespaces = append(namespaces, ns)
+		lastCreated[ns] = stale
+	}
+
+	runner.runTickParallelMT(context.Background(), &logging.NoOpLogger{}, namespaces, lastCreated)
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, ns := range namespaces {
+		assert.True(t, created[ns], "expected createChecks to run for %s", ns)
+	}
+}
+
+// TestRunner_MT_InitialDiscoveryFailure verifies that a failure on the
+// boot-time cluster-wide Check list tears down the runner with the underlying
+// error wrapped, so the app-sdk runtime can surface it rather than letting the
+// scheduler silently keep running with no namespaces.
+func TestRunner_MT_InitialDiscoveryFailure(t *testing.T) {
+	bootErr := errors.New("boom")
+	mockClient := &MockClient{
+		listFunc: func(ctx context.Context, namespace string, options resource.ListOptions) (resource.ListObject, error) {
+			return nil, bootErr
+		},
+	}
+	mockTypes := &MockClient{}
+	runner := createTestMTRunner(mockClient, mockTypes, &MockCheckService{checks: []checks.Check{}})
+
+	err := runAndTimeout(runner)
+	assert.ErrorIs(t, err, bootErr)
+	assert.NotErrorIs(t, err, context.DeadlineExceeded)
+}
+
+// TestTickNamespace_SkipsWhenNotStale verifies that tickNamespace does no work
+// (no Create call) when the namespace's last check is newer than the
+// evaluation interval, and returns the input lastCreated unchanged so the
+// caller does not overwrite it.
+func TestTickNamespace_SkipsWhenNotStale(t *testing.T) {
+	var createCalled atomic.Bool
+	mockClient := &MockClient{
+		listFunc: func(ctx context.Context, namespace string, options resource.ListOptions) (resource.ListObject, error) {
+			return &advisorv0alpha1.CheckList{Items: []advisorv0alpha1.Check{}}, nil
+		},
+		createFunc: func(ctx context.Context, id resource.Identifier, obj resource.Object, opts resource.CreateOptions) (resource.Object, error) {
+			createCalled.Store(true)
+			return obj, nil
+		},
+	}
+	r := &Runner{
+		checksClient:        mockClient,
+		defaultEvalInterval: 1 * time.Hour,
+		log:                 &logging.NoOpLogger{},
+	}
+	recent := time.Now().Add(-1 * time.Minute)
+	newLast, err := r.tickNamespace(context.Background(), &logging.NoOpLogger{}, "stacks-1", recent)
+	assert.NoError(t, err)
+	assert.Equal(t, recent, newLast)
+	assert.False(t, createCalled.Load(), "tickNamespace must not create checks when not stale")
+}
+
+// TestTickNamespace_SyncsCheckTypesBeforeCreatingChecks verifies that a stale
+// namespace gets its CheckTypes synced with the in-process registry before any
+// Check is created. In MT, CheckType registration is otherwise on-demand (the
+// "register" endpoint), so without this ordering a tick could create Checks
+// for types whose CheckType resource doesn't exist yet in the namespace.
+func TestTickNamespace_SyncsCheckTypesBeforeCreatingChecks(t *testing.T) {
+	var order []string
+	var mu sync.Mutex
+	mockClient := &MockClient{
+		listFunc: func(ctx context.Context, namespace string, options resource.ListOptions) (resource.ListObject, error) {
+			return &advisorv0alpha1.CheckList{Items: []advisorv0alpha1.Check{}}, nil
+		},
+		createFunc: func(ctx context.Context, id resource.Identifier, obj resource.Object, opts resource.CreateOptions) (resource.Object, error) {
+			mu.Lock()
+			order = append(order, "create")
+			mu.Unlock()
+			return obj, nil
+		},
+	}
+	r := &Runner{
+		checkRegistry: &MockCheckService{checks: []checks.Check{&mockCheck{id: "test-check"}}},
+		checksClient:  mockClient,
+		checkTypeSyncer: &mockCheckTypeSyncer{
+			syncFunc: func(ctx context.Context, logger logging.Logger, namespace string) error {
+				mu.Lock()
+				order = append(order, "sync:"+namespace)
+				mu.Unlock()
+				return nil
+			},
+		},
+		defaultEvalInterval: 1 * time.Hour,
+		maxHistory:          defaultMaxHistory,
+		log:                 &logging.NoOpLogger{},
+	}
+	stale := time.Now().Add(-2 * time.Hour)
+	_, err := r.tickNamespace(context.Background(), &logging.NoOpLogger{}, "stacks-1", stale)
+	assert.NoError(t, err)
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Equal(t, []string{"sync:stacks-1", "create"}, order)
+}
+
+// TestTickNamespace_SyncFailureAbortsCheckCreation verifies that a CheckType
+// sync failure aborts the tick before any Check is created, returning the
+// input lastCreated so the namespace is retried on the next tick.
+func TestTickNamespace_SyncFailureAbortsCheckCreation(t *testing.T) {
+	var createCalled atomic.Bool
+	mockClient := &MockClient{
+		createFunc: func(ctx context.Context, id resource.Identifier, obj resource.Object, opts resource.CreateOptions) (resource.Object, error) {
+			createCalled.Store(true)
+			return obj, nil
+		},
+	}
+	syncErr := errors.New("sync failed")
+	r := &Runner{
+		checkRegistry: &MockCheckService{checks: []checks.Check{&mockCheck{id: "test-check"}}},
+		checksClient:  mockClient,
+		checkTypeSyncer: &mockCheckTypeSyncer{
+			syncFunc: func(ctx context.Context, logger logging.Logger, namespace string) error {
+				return syncErr
+			},
+		},
+		defaultEvalInterval: 1 * time.Hour,
+		maxHistory:          defaultMaxHistory,
+		log:                 &logging.NoOpLogger{},
+	}
+	stale := time.Now().Add(-2 * time.Hour)
+	newLast, err := r.tickNamespace(context.Background(), &logging.NoOpLogger{}, "stacks-1", stale)
+	assert.ErrorIs(t, err, syncErr)
+	assert.Equal(t, stale, newLast)
+	assert.False(t, createCalled.Load(), "tickNamespace must not create checks when CheckType sync fails")
+}
+
+// MT test helpers
+
+// createTestMTRunner returns a Runner with no stackID and no orgService,
+// which routes Run() to the multi-tenant scheduler path.
+func createTestMTRunner(checkClient, typesClient *MockClient, checkRegistry checkregistry.CheckService) *Runner {
+	return createTestMTRunnerWithConcurrency(checkClient, typesClient, checkRegistry)
+}
+
+func createTestMTRunnerWithConcurrency(checkClient, typesClient *MockClient, checkRegistry checkregistry.CheckService) *Runner {
+	if checkClient.listFunc == nil {
+		checkClient.listFunc = func(ctx context.Context, namespace string, options resource.ListOptions) (resource.ListObject, error) {
+			return &advisorv0alpha1.CheckList{Items: []advisorv0alpha1.Check{}}, nil
+		}
+	}
+	if checkClient.createFunc == nil {
+		checkClient.createFunc = func(ctx context.Context, id resource.Identifier, obj resource.Object, opts resource.CreateOptions) (resource.Object, error) {
+			return obj, nil
+		}
+	}
+	if checkClient.deleteFunc == nil {
+		checkClient.deleteFunc = func(ctx context.Context, id resource.Identifier, opts resource.DeleteOptions) error {
+			return nil
+		}
+	}
+	if checkClient.patchFunc == nil {
+		checkClient.patchFunc = func(ctx context.Context, id resource.Identifier, patch resource.PatchRequest, opts resource.PatchOptions, into resource.Object) error {
+			return nil
+		}
+	}
+	if typesClient.listFunc == nil {
+		typesClient.listFunc = func(ctx context.Context, namespace string, options resource.ListOptions) (resource.ListObject, error) {
+			return &advisorv0alpha1.CheckTypeList{Items: []advisorv0alpha1.CheckType{}}, nil
+		}
+	}
+	return &Runner{
+		checkRegistry:       checkRegistry,
+		checksClient:        checkClient,
+		checksMetadata:      metadataGetterFromClient(checkClient),
+		typesClient:         typesClient,
+		checkTypeSyncer:     &mockCheckTypeSyncer{},
+		defaultEvalInterval: 5 * time.Millisecond,
+		maxHistory:          defaultMaxHistory,
+		log:                 &logging.NoOpLogger{},
+		orgService:          nil,
+		stackID:             "",
+	}
+}
+
+type mockCheckTypeSyncer struct {
+	syncFunc func(ctx context.Context, logger logging.Logger, namespace string) error
+}
+
+func (m *mockCheckTypeSyncer) RegisterCheckTypesInNamespace(ctx context.Context, logger logging.Logger, namespace string) error {
+	if m.syncFunc != nil {
+		return m.syncFunc(ctx, logger, namespace)
+	}
+	return nil
+}

--- a/apps/advisor/pkg/app/checktyperegisterer/checktyperegisterer.go
+++ b/apps/advisor/pkg/app/checktyperegisterer/checktyperegisterer.go
@@ -22,6 +22,13 @@ import (
 	"github.com/grafana/grafana/pkg/services/org"
 )
 
+// CheckTypeSyncer syncs the CheckType resources stored in a namespace with
+// the in-process check registry, creating, updating and deleting CheckTypes
+// as needed.
+type CheckTypeSyncer interface {
+	RegisterCheckTypesInNamespace(ctx context.Context, logger logging.Logger, namespace string) error
+}
+
 // Runner is a "runnable" app used to be able to expose and API endpoint
 // with the existing checks types. This does not need to be a CRUD resource, but it is
 // the only way existing at the moment to expose the check types.

--- a/apps/advisor/pkg/app/metrics/metrics.go
+++ b/apps/advisor/pkg/app/metrics/metrics.go
@@ -60,6 +60,55 @@ var (
 		},
 		[]string{"step_id"},
 	)
+
+	// MTSchedulerDiscoveriesTotal counts cluster-wide namespace discovery attempts by the MT scheduler.
+	MTSchedulerDiscoveriesTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "mt_scheduler_discoveries_total",
+			Help:      "Total cluster-wide namespace discovery attempts by the MT scheduler",
+		},
+		[]string{"status"},
+	)
+
+	// MTSchedulerDiscoveryDurationSeconds is the duration of MT scheduler namespace discovery.
+	MTSchedulerDiscoveryDurationSeconds = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: namespace,
+			Name:      "mt_scheduler_discovery_duration_seconds",
+			Help:      "Duration of MT scheduler namespace discovery in seconds",
+			Buckets:   prometheus.DefBuckets,
+		},
+	)
+
+	// MTSchedulerNamespacesDiscovered is the number of namespaces from the most recent successful MT discovery.
+	MTSchedulerNamespacesDiscovered = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Name:      "mt_scheduler_namespaces_discovered",
+			Help:      "Number of namespaces discovered in the most recent successful MT discovery",
+		},
+	)
+
+	// MTSchedulerNamespaceTicksTotal counts per-namespace tick outcomes in the MT scheduler.
+	MTSchedulerNamespaceTicksTotal = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "mt_scheduler_namespace_ticks_total",
+			Help:      "Total per-namespace tick outcomes in the MT scheduler",
+		},
+		[]string{"result"},
+	)
+
+	// MTSchedulerNamespaceTickDurationSeconds is the duration of per-namespace MT scheduler ticks that performed work.
+	MTSchedulerNamespaceTickDurationSeconds = prometheus.NewHistogram(
+		prometheus.HistogramOpts{
+			Namespace: namespace,
+			Name:      "mt_scheduler_namespace_tick_duration_seconds",
+			Help:      "Duration of per-namespace MT scheduler ticks that performed work",
+			Buckets:   prometheus.DefBuckets,
+		},
+	)
 )
 
 // MustRegister registers all metrics with the given registerer. No-op if registerer is nil.
@@ -73,6 +122,11 @@ func MustRegister(registerer prometheus.Registerer) {
 		CheckRegistrationTotal,
 		OrgIDErrorsTotal,
 		StepPanicsTotal,
+		MTSchedulerDiscoveriesTotal,
+		MTSchedulerDiscoveryDurationSeconds,
+		MTSchedulerNamespacesDiscovered,
+		MTSchedulerNamespaceTicksTotal,
+		MTSchedulerNamespaceTickDurationSeconds,
 	}
 	for _, metric := range metricsToRegister {
 		if err := registerer.Register(metric); err != nil {

--- a/apps/advisor/pkg/app/utils.go
+++ b/apps/advisor/pkg/app/utils.go
@@ -49,6 +49,14 @@ func processCheck(ctx context.Context, log logging.Logger, client resource.Clien
 	if !ok {
 		return fmt.Errorf("invalid object type")
 	}
+	// processCheck is invoked from the validating admission webhook in a
+	// goroutine, so it can race with the apiserver finishing the write of
+	// the Check resource. Wait for the object to be persisted before any
+	// PATCH below (including the SetStatusAnnotation calls in the error
+	// paths) can hit a "not found" against the in-flight create.
+	if err := waitForItem(ctx, log, client, obj); err != nil {
+		return err
+	}
 	// Get the items to check
 	err := check.Init(ctx)
 	if err != nil {
@@ -83,11 +91,6 @@ func processCheck(ctx context.Context, log logging.Logger, client resource.Clien
 			return setErr
 		}
 		return fmt.Errorf("error running steps: %w", err)
-	}
-	// Wait for the item to be persisted before patching the object
-	err = waitForItem(ctx, log, client, obj)
-	if err != nil {
-		return err
 	}
 	report := &advisorv0alpha1.CheckReport{
 		Failures: failures,


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Adds a multi-namespace (MT) mode to the advisor's check scheduler. When a Runner is constructed without a stack ID or org service (the new isMT() condition), instead of bailing out as "disabled" it now runs a cluster-wide scheduler loop that discovers namespaces from existing Check resources and fans out work across them.

**Backend changes** (`apps/advisor/pkg/app/`):

  - `checkscheduler/checkscheduler.go` — Split Run into runST (existing single-tenant path) and the new runMT. Refactored `createChecks` to drive off the in-process `checkRegistry` instead of listing `CheckType` from the apiserver (which lags behind in MT). The wait-for-registration logic moved to a new `waitForCheckTypesRegistered` helper that's now called explicitly before re-creating checks in runST.
  - `checkscheduler/mtcheckscheduler.go` (new) — MT loop: cluster-wide paginated Check discovery scoped to `stacks-*` namespaces, in-memory `lastCreated` tracking per namespace, eager initial tick at boot, fixed-cadence ticker with jitter (deliberately not reusing `getNextEvalTime`, which collapses to ~0 across many namespaces), and per-namespace fan-out bounded by `maxConcurrency = 10` via `errgroup`. Per-namespace errors are logged but don't stop the tick.
  - `metrics/metrics.go` — Five new Prometheus metrics for the MT path: discovery count/duration/namespace gauge, and per-namespace tick count/duration.
  - `app/utils.go` — In `processCheck`, moved the `waitForItem` call to the top of the function so the error-path `SetStatusAnnotation` PATCHes can't race the in-flight create from the admission webhook.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes https://github.com/grafana/grafana-catalog-team/issues/895

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
