### PR TITLE
Provisioning: Size limited `ReadWriter` should also satisfy `RepositoryWithURLs`

### DIFF
--- a/apps/provisioning/pkg/repository/size_limit.go
+++ b/apps/provisioning/pkg/repository/size_limit.go
@@ -16,28 +16,46 @@ type sizeLimitedReaderWriter struct {
 	maxBytes int64
 }
 
-// sizeLimitedVersionedReaderWriter mirrors sizeLimitedReaderWriter but also
-// satisfies Versioned, so wrapping a versioned repository does not strip the
-// interface from downstream callers (e.g. the sync worker, which falls back
-// to full sync when the repo no longer reports as Versioned).
+// Combo wrappers preserve optional interfaces that downstream code discovers
+// via type assertion (same pattern as net/http middleware preserving Flusher/Hijacker).
 type sizeLimitedVersionedReaderWriter struct {
 	sizeLimitedReaderWriter
 	Versioned
 }
 
+type sizeLimitedURLsReaderWriter struct {
+	sizeLimitedReaderWriter
+	RepositoryWithURLs
+}
+
+type sizeLimitedVersionedURLsReaderWriter struct {
+	sizeLimitedReaderWriter
+	Versioned
+	RepositoryWithURLs
+}
+
 // NewSizeLimitedReaderWriter wraps rw so its Read method enforces the given
-// byte cap. The wrapper preserves the Versioned interface when the inner
-// repository implements it. When maxBytes <= 0 the original rw is returned
-// unchanged.
+// byte cap. The wrapper preserves Versioned and RepositoryWithURLs interfaces
+// when the inner repository implements them. When maxBytes <= 0 the original
+// rw is returned unchanged.
 func NewSizeLimitedReaderWriter(rw ReaderWriter, maxBytes int64) ReaderWriter {
 	if maxBytes <= 0 {
 		return rw
 	}
-	limitedRw := sizeLimitedReaderWriter{ReaderWriter: rw, maxBytes: maxBytes}
-	if v, ok := rw.(Versioned); ok {
-		return &sizeLimitedVersionedReaderWriter{sizeLimitedReaderWriter: limitedRw, Versioned: v}
+	base := sizeLimitedReaderWriter{ReaderWriter: rw, maxBytes: maxBytes}
+	v, isVersioned := rw.(Versioned)
+	u, isURLs := rw.(RepositoryWithURLs)
+
+	switch {
+	case isVersioned && isURLs:
+		return &sizeLimitedVersionedURLsReaderWriter{base, v, u}
+	case isVersioned:
+		return &sizeLimitedVersionedReaderWriter{base, v}
+	case isURLs:
+		return &sizeLimitedURLsReaderWriter{base, u}
+	default:
+		return &base
 	}
-	return &limitedRw
 }
 
 func (s *sizeLimitedReaderWriter) Read(ctx context.Context, path, ref string) (*FileInfo, error) {

--- a/apps/provisioning/pkg/repository/size_limit_test.go
+++ b/apps/provisioning/pkg/repository/size_limit_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 )
 
 func TestSizeLimitedReaderWriter_Read(t *testing.T) {
@@ -72,4 +74,80 @@ func TestSizeLimitedReaderWriter_PreservesVersioned(t *testing.T) {
 
 	_, isCombined := rw.(versionedReaderWriter)
 	assert.True(t, isCombined, "wrapped repository must still satisfy ReaderWriter+Versioned")
+}
+
+// mockReadWriterWithURLs implements ReaderWriter and RepositoryWithURLs.
+// It is created manually here to avoid the ambiguous implementation of the
+// ReaderWriter and RepositoryWithURLs mocks, as they both implement Config and Test.
+type mockReadWriterWithURLs struct {
+	ReaderWriter
+	RepositoryWithURLs
+}
+
+func (m mockReadWriterWithURLs) Config() *provisioning.Repository {
+	return m.ReaderWriter.Config()
+}
+
+func (m mockReadWriterWithURLs) Test(ctx context.Context) (*provisioning.TestResults, error) {
+	return m.ReaderWriter.Test(ctx)
+}
+
+func TestSizeLimitedReaderWriter_PreservesRepositoryWithURLs(t *testing.T) {
+	inner := mockReadWriterWithURLs{
+		ReaderWriter:       NewMockReaderWriter(t),
+		RepositoryWithURLs: NewMockRepositoryWithURLs(t),
+	}
+
+	rw := NewSizeLimitedReaderWriter(inner, 1024)
+
+	_, hasURLs := rw.(RepositoryWithURLs)
+	assert.True(t, hasURLs, "wrapped repository must still satisfy RepositoryWithURLs")
+
+	_, isVersioned := rw.(Versioned)
+	assert.False(t, isVersioned, "should not satisfy Versioned when inner does not")
+}
+
+// mockReadWriterWithURLs implements ReaderWriter, Versioned and RepositoryWithURLs.
+// It is created manually here to avoid the ambiguous implementation of the
+// ReaderWriter and RepositoryWithURLs mocks, as they both implement Config and Test.
+type mockReadWriterVersionedWithURLs struct {
+	Versioned
+	ReaderWriter
+	RepositoryWithURLs
+}
+
+func (m mockReadWriterVersionedWithURLs) Config() *provisioning.Repository {
+	return m.ReaderWriter.Config()
+}
+
+func (m mockReadWriterVersionedWithURLs) Test(ctx context.Context) (*provisioning.TestResults, error) {
+	return m.ReaderWriter.Test(ctx)
+}
+
+func TestSizeLimitedReaderWriter_PreservesAllInterfaces(t *testing.T) {
+	inner := mockReadWriterVersionedWithURLs{
+		Versioned:          NewMockVersioned(t),
+		ReaderWriter:       NewMockReaderWriter(t),
+		RepositoryWithURLs: NewMockRepositoryWithURLs(t),
+	}
+
+	rw := NewSizeLimitedReaderWriter(inner, 1024)
+
+	_, isVersioned := rw.(Versioned)
+	assert.True(t, isVersioned, "wrapped repository must still satisfy Versioned")
+
+	_, hasURLs := rw.(RepositoryWithURLs)
+	assert.True(t, hasURLs, "wrapped repository must still satisfy RepositoryWithURLs")
+}
+
+func TestSizeLimitedReaderWriter_NoOptionalInterfaces(t *testing.T) {
+	inner := NewMockReaderWriter(t)
+
+	rw := NewSizeLimitedReaderWriter(inner, 1024)
+
+	_, isVersioned := rw.(Versioned)
+	assert.False(t, isVersioned, "should not satisfy Versioned when inner does not")
+
+	_, hasURLs := rw.(RepositoryWithURLs)
+	assert.False(t, hasURLs, "should not satisfy RepositoryWithURLs when inner does not")
 }


### PR DESCRIPTION
## Summary

- Fix `NewSizeLimitedReaderWriter` stripping the `RepositoryWithURLs` interface from wrapped repositories, which caused PR/compare URLs to disappear from file endpoint responses
- The "Create PR" button in the UI stopped working because the `urls` field was always empty in the response
- Add combo wrapper structs (same pattern as `net/http` middleware preserving `Flusher`/`Hijacker`) to preserve both `Versioned` and `RepositoryWithURLs` when present

## Root cause

Introduced in #124729 which added `NewSizeLimitedReaderWriter`. The wrapper only preserved the `Versioned` interface but not `RepositoryWithURLs`. When the parser and `DualReadWriter` type-assert the wrapped repo to `RepositoryWithURLs` to build PR/compare/source URLs, the assertion fails silently and URLs are omitted from the response.

## Test plan

- [x] Unit tests for all 4 interface combinations (neither, Versioned only, RepositoryWithURLs only, both)
- [x] `make gofmt` clean
- [x] `make lint-go-diff` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)