### PR TITLE
Coordinate periodic index rebuilds

### DIFF
--- a/pkg/storage/unified/resource/bleve_index_metrics.go
+++ b/pkg/storage/unified/resource/bleve_index_metrics.go
@@ -26,7 +26,7 @@ type BleveIndexMetrics struct {
 	IndexSnapshotDownloadDuration         prometheus.Histogram
 	IndexSnapshotUploads                  *prometheus.CounterVec
 	IndexSnapshotUploadDuration           prometheus.Histogram
-	IndexSnapshotColdStarts               *prometheus.CounterVec
+	IndexSnapshotBuildCoordinations       *prometheus.CounterVec
 	IndexSnapshotNamespaceCleanups        *prometheus.CounterVec
 	IndexSnapshotDeleted                  *prometheus.CounterVec
 	IndexSnapshotIncompleteUploadsCleaned prometheus.Counter
@@ -122,10 +122,10 @@ func ProvideIndexMetrics(reg prometheus.Registerer) *BleveIndexMetrics {
 			NativeHistogramMaxBucketNumber:  160,
 			NativeHistogramMinResetDuration: time.Hour,
 		}),
-		IndexSnapshotColdStarts: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
-			Name: "index_server_snapshot_cold_start_total",
-			Help: "Number of cold-start build coordination outcomes, by outcome.",
-		}, []string{"outcome"}), // outcome: acquired_lock, downloaded_after_wait, wait_timed_out, lock_error, context_canceled
+		IndexSnapshotBuildCoordinations: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "index_server_snapshot_build_coordinations_total",
+			Help: "Number of snapshot build coordination outcomes, by flow and outcome.",
+		}, []string{"flow", "outcome"}), // flow: cold_start, rebuild. outcome: acquired_lock, downloaded_after_wait, wait_timed_out, lock_error, context_canceled
 		IndexSnapshotNamespaceCleanups: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
 			Name: "index_server_snapshot_namespace_cleanups_total",
 			Help: "Number of namespace-level remote index snapshot cleanup attempts, by outcome.",
@@ -170,11 +170,13 @@ func (m *BleveIndexMetrics) InitSnapshotMetrics() {
 	m.IndexSnapshotUploads.WithLabelValues("skip_recent_remote").Add(0)
 	m.IndexSnapshotUploads.WithLabelValues("skip_not_owner").Add(0)
 	m.IndexSnapshotUploads.WithLabelValues("error").Add(0)
-	m.IndexSnapshotColdStarts.WithLabelValues("acquired_lock").Add(0)
-	m.IndexSnapshotColdStarts.WithLabelValues("downloaded_after_wait").Add(0)
-	m.IndexSnapshotColdStarts.WithLabelValues("wait_timed_out").Add(0)
-	m.IndexSnapshotColdStarts.WithLabelValues("lock_error").Add(0)
-	m.IndexSnapshotColdStarts.WithLabelValues("context_canceled").Add(0)
+	for _, flow := range []string{"cold_start", "rebuild"} {
+		m.IndexSnapshotBuildCoordinations.WithLabelValues(flow, "acquired_lock").Add(0)
+		m.IndexSnapshotBuildCoordinations.WithLabelValues(flow, "downloaded_after_wait").Add(0)
+		m.IndexSnapshotBuildCoordinations.WithLabelValues(flow, "wait_timed_out").Add(0)
+		m.IndexSnapshotBuildCoordinations.WithLabelValues(flow, "lock_error").Add(0)
+		m.IndexSnapshotBuildCoordinations.WithLabelValues(flow, "context_canceled").Add(0)
+	}
 	m.IndexSnapshotNamespaceCleanups.WithLabelValues("success").Add(0)
 	m.IndexSnapshotNamespaceCleanups.WithLabelValues("error").Add(0)
 	m.IndexSnapshotNamespaceCleanups.WithLabelValues("skip_lock_held").Add(0)

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -867,13 +867,12 @@ func (b *bleveBackend) prepareIndex(
 		// with same-version replicas and accept only a snapshot fresh enough to serve
 		// as a drop-in replacement. There is no tiered fallback here because we
 		// already have a working index.
+		// coordinateRebuild only returns err on ctx cancellation; propagate it directly.
 		idx, name, rv, lock, err := b.coordinateRebuild(ctx, key, resourceDir, lastImportTime, maxFreshSnapshotAge, logger)
 		if err != nil {
-			if ctxErr := ctx.Err(); ctxErr != nil {
-				return preparedBuildIndex{}, ctxErr
-			}
-			logger.Warn("Rebuild coordination failed, will rebuild from scratch", "err", err)
-		} else if idx != nil {
+			return preparedBuildIndex{}, err
+		}
+		if idx != nil {
 			return preparedBuildIndex{
 				index:         idx,
 				indexRV:       rv,
@@ -942,13 +941,12 @@ func (b *bleveBackend) prepareUncachedFileIndex(
 		}, nil
 	}
 
+	// coordinateColdStartBuild only returns err on ctx cancellation; propagate it directly.
 	idx, name, rv, lock, err := b.coordinateColdStartBuild(ctx, key, resourceDir, lastImportTime, logger)
 	if err != nil {
-		if ctxErr := ctx.Err(); ctxErr != nil {
-			return preparedBuildIndex{}, ctxErr
-		}
-		logger.Warn("Cold-start coordination failed, will build alone", "err", err)
-	} else if idx != nil {
+		return preparedBuildIndex{}, err
+	}
+	if idx != nil {
 		return preparedBuildIndex{
 			index:         idx,
 			indexRV:       rv,

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -620,7 +620,7 @@ func (s buildIndexSource) needsBuild() bool {
 
 // preparedBuildIndex carries the opened index from prepareIndex into the
 // build/cache phase. BuildIndex owns every value returned here: it closes index
-// on failure, removes cleanupDir on failure, and releases coldStartLeaderLock
+// on failure, removes cleanupDir on failure, and releases snapshotBuildLock
 // after the optional leader upload.
 type preparedBuildIndex struct {
 	// index is the opened Bleve index. It may be empty, reused from disk, or
@@ -640,9 +640,11 @@ type preparedBuildIndex struct {
 	// cleanupDir is deleted if BuildIndex returns before storing the index in the
 	// cache. It is set for newly-created file indexes only.
 	cleanupDir string
-	// coldStartLeaderLock is held when this instance won cold-start coordination.
+	// snapshotBuildLock is held when this instance won snapshot build coordination.
 	// BuildIndex must keep it through the build and immediate snapshot upload.
-	coldStartLeaderLock IndexStoreLock
+	snapshotBuildLock IndexStoreLock
+	// snapshotBuildFlow identifies the coordination path that supplied snapshotBuildLock.
+	snapshotBuildFlow string
 }
 
 // BuildIndex builds an index from scratch or retrieves it from the filesystem.
@@ -717,10 +719,10 @@ func (b *bleveBackend) BuildIndex(
 		}
 	}()
 
-	if prepared.coldStartLeaderLock != nil {
+	if prepared.snapshotBuildLock != nil {
 		defer func() {
-			if releaseErr := prepared.coldStartLeaderLock.Release(); releaseErr != nil {
-				logWithDetails.Warn("Releasing cold-start build lock", "err", releaseErr)
+			if releaseErr := prepared.snapshotBuildLock.Release(); releaseErr != nil {
+				logWithDetails.Warn("Releasing snapshot build lock", "flow", prepared.snapshotBuildFlow, "err", releaseErr)
 			}
 		}()
 	}
@@ -778,8 +780,8 @@ func (b *bleveBackend) BuildIndex(
 		if buildErr != nil {
 			return nil, buildErr
 		}
-		if prepared.coldStartLeaderLock != nil {
-			b.uploadColdStartLeaderSnapshot(ctx, key, idx, prepared.coldStartLeaderLock, logWithDetails)
+		if prepared.snapshotBuildLock != nil {
+			b.uploadSnapshotBuildLeader(ctx, key, idx, prepared.snapshotBuildLock, prepared.snapshotBuildFlow, logWithDetails)
 		}
 	} else {
 		logWithDetails.Info("Skipping index build, using existing index")
@@ -861,20 +863,16 @@ func (b *bleveBackend) prepareIndex(
 	}
 
 	if rebuild && snapshotEnabled && maxFreshSnapshotAge > 0 {
-		// Rebuild path: before paying the cost of a from-scratch rebuild, check
-		// whether the remote index store holds a same-version snapshot fresh enough
-		// to serve as a drop-in replacement. On miss, fall through to rebuild — no
-		// tiered fallback because we already have a working index.
-		idx, name, rv, err := b.tryDownloadFreshSameVersionSnapshot(
-			ctx, key, resourceDir, lastImportTime, maxFreshSnapshotAge,
-			snapshotPolicySameVersion, "search.remote_index_snapshot.download_fresh",
-			logger,
-		)
+		// Rebuild path: before paying the cost of a from-scratch rebuild, coordinate
+		// with same-version replicas and accept only a snapshot fresh enough to serve
+		// as a drop-in replacement. There is no tiered fallback here because we
+		// already have a working index.
+		idx, name, rv, lock, err := b.coordinateRebuild(ctx, key, resourceDir, lastImportTime, maxFreshSnapshotAge, logger)
 		if err != nil {
 			if ctxErr := ctx.Err(); ctxErr != nil {
 				return preparedBuildIndex{}, ctxErr
 			}
-			logger.Warn("Failed to download fresh remote snapshot, will rebuild from scratch", "err", err)
+			logger.Warn("Rebuild coordination failed, will rebuild from scratch", "err", err)
 		} else if idx != nil {
 			return preparedBuildIndex{
 				index:         idx,
@@ -883,6 +881,17 @@ func (b *bleveBackend) prepareIndex(
 				indexStorage:  indexStorageFile,
 				source:        buildIndexSourceDownloadedSnapshot,
 			}, nil
+		} else if lock != nil {
+			prepared, err := b.createEmptyBuildIndex(resourceDir, mapper, selectableFields, logger)
+			if err != nil {
+				if releaseErr := lock.Release(); releaseErr != nil {
+					logger.Warn("Releasing rebuild build lock", "err", releaseErr)
+				}
+				return preparedBuildIndex{}, err
+			}
+			prepared.snapshotBuildLock = lock
+			prepared.snapshotBuildFlow = snapshotBuildFlowRebuild
+			return prepared, nil
 		}
 	}
 
@@ -955,7 +964,8 @@ func (b *bleveBackend) prepareUncachedFileIndex(
 			}
 			return preparedBuildIndex{}, err
 		}
-		prepared.coldStartLeaderLock = lock
+		prepared.snapshotBuildLock = lock
+		prepared.snapshotBuildFlow = snapshotBuildFlowColdStart
 		return prepared, nil
 	}
 
@@ -1202,34 +1212,38 @@ func (b *bleveBackend) buildIndexFromScratch(idx buildResourceIndex, indexBuildR
 	return nil
 }
 
-func (b *bleveBackend) uploadColdStartLeaderSnapshot(ctx context.Context, key resource.NamespacedResource, idx *bleveIndex, lock IndexStoreLock, logger log.Logger) {
+// uploadSnapshotBuildLeader uploads a snapshot immediately after this instance
+// has rebuilt an index while holding the remote build lock. The upload lets
+// other replicas waiting on the same lock download the fresh snapshot instead
+// of rebuilding the same index locally.
+func (b *bleveBackend) uploadSnapshotBuildLeader(ctx context.Context, key resource.NamespacedResource, idx *bleveIndex, lock IndexStoreLock, flow string, logger log.Logger) {
 	if checkSnapshotLock(lock) != nil {
 		// Lock lost during the build. Another replica may already be uploading;
 		// skip and let the periodic tick reconcile.
-		logger.Warn("Cold-start leader lock lost during build; skipping immediate upload")
+		logger.Warn("Snapshot build leader lock lost during build; skipping immediate upload", "flow", flow)
 		b.recordSnapshotUploadStatus(snapshotUploadStatusSkipLockLost)
 		return
 	}
 
 	baselineMutations, mErr := idx.getSnapshotMutationCount()
 	if mErr != nil {
-		logger.Warn("Failed to read snapshot mutation baseline for leader upload", "err", mErr)
+		logger.Warn("Failed to read snapshot mutation baseline for leader upload", "flow", flow, "err", mErr)
 	}
 	uploadKey, uploadRV, upErr := b.snapshotCopyAndUpload(ctx, key, idx, lock)
 	if upErr != nil {
-		logger.Warn("Cold-start leader immediate snapshot upload failed", "err", upErr)
+		logger.Warn("Snapshot build leader immediate snapshot upload failed", "flow", flow, "err", upErr)
 		b.recordSnapshotUploadStatus(snapshotUploadStatusError)
 		return
 	}
 
 	if mErr == nil {
 		if subErr := idx.subtractSnapshotMutationCount(baselineMutations); subErr != nil {
-			logger.Warn("Failed to advance snapshot mutation baseline after leader upload", "err", subErr)
+			logger.Warn("Failed to advance snapshot mutation baseline after leader upload", "flow", flow, "err", subErr)
 		}
 	}
 	b.setUploadTracking(key, time.Now())
 	b.recordSnapshotUploadStatus(snapshotUploadStatusSuccess)
-	logger.Info("Cold-start leader uploaded freshly-built snapshot", "snapshot_key", uploadKey.String(), "snapshot_rv", uploadRV)
+	logger.Info("Snapshot build leader uploaded freshly-built snapshot", "flow", flow, "snapshot_key", uploadKey.String(), "snapshot_rv", uploadRV)
 }
 
 func (b *bleveBackend) getResourceDir(key resource.NamespacedResource) string {

--- a/pkg/storage/unified/search/bleve_snapshot.go
+++ b/pkg/storage/unified/search/bleve_snapshot.go
@@ -554,7 +554,7 @@ const (
 	snapshotBuildFlowRebuild   = "rebuild"
 )
 
-// Outcome labels for the IndexSnapshotColdStarts metric and the rebuild
+// Outcome labels for the IndexSnapshotBuildCoordinations metric and the
 // coordination span. Kept compatible with the metric label values.
 const (
 	snapshotBuildOutcomeAcquiredLock        = "acquired_lock"
@@ -727,7 +727,9 @@ func (b *bleveBackend) coordinateColdStartBuild(
 		probe: func(ctx context.Context) (bleve.Index, string, int64, error) {
 			return b.tryDownloadColdStartSnapshot(ctx, key, resourceDir, lastImportTime, probeMaxAge, logger)
 		},
-		recordOutcome: b.recordColdStartOutcome,
+		recordOutcome: func(outcome string) {
+			b.recordBuildCoordinationOutcome(snapshotBuildFlowColdStart, outcome)
+		},
 	}, logger)
 }
 
@@ -790,6 +792,9 @@ func (b *bleveBackend) coordinateRebuild(
 		probe: func(ctx context.Context) (bleve.Index, string, int64, error) {
 			return b.tryDownloadRebuildSnapshot(ctx, key, resourceDir, lastImportTime, maxFreshSnapshotAge, logger)
 		},
+		recordOutcome: func(outcome string) {
+			b.recordBuildCoordinationOutcome(snapshotBuildFlowRebuild, outcome)
+		},
 	}, logger)
 }
 
@@ -820,9 +825,9 @@ func (b *bleveBackend) tryDownloadRebuildSnapshot(
 	return idx, name, rv, nil
 }
 
-func (b *bleveBackend) recordColdStartOutcome(outcome string) {
+func (b *bleveBackend) recordBuildCoordinationOutcome(flow, outcome string) {
 	if b.indexMetrics == nil {
 		return
 	}
-	b.indexMetrics.IndexSnapshotColdStarts.WithLabelValues(outcome).Inc()
+	b.indexMetrics.IndexSnapshotBuildCoordinations.WithLabelValues(flow, outcome).Inc()
 }

--- a/pkg/storage/unified/search/bleve_snapshot.go
+++ b/pkg/storage/unified/search/bleve_snapshot.go
@@ -554,101 +554,126 @@ const (
 	snapshotBuildFlowRebuild   = "rebuild"
 )
 
-// Outcome labels for the IndexSnapshotColdStarts metric.
+// Outcome labels for the IndexSnapshotColdStarts metric and the rebuild
+// coordination span. Kept compatible with the metric label values.
 const (
-	coldStartOutcomeAcquiredLock        = "acquired_lock"
-	coldStartOutcomeDownloadedAfterWait = "downloaded_after_wait"
-	coldStartOutcomeWaitTimedOut        = "wait_timed_out"
-	coldStartOutcomeLockError           = "lock_error"
-	coldStartOutcomeContextCanceled     = "context_canceled"
+	snapshotBuildOutcomeAcquiredLock        = "acquired_lock"
+	snapshotBuildOutcomeDownloadedAfterWait = "downloaded_after_wait"
+	snapshotBuildOutcomeWaitTimedOut        = "wait_timed_out"
+	snapshotBuildOutcomeLockError           = "lock_error"
+	snapshotBuildOutcomeContextCanceled     = "context_canceled"
 )
 
 // Wait-for-leader timing. Package-level vars so tests can shrink them.
 var (
-	coldStartPollInterval           = 30 * time.Second
-	coldStartTotalWait              = 15 * time.Minute
-	rebuildCoordinationPollInterval = 30 * time.Second
+	snapshotBuildPollInterval = 30 * time.Second
+	coldStartTotalWait        = 15 * time.Minute
 )
 
-// coordinateColdStartBuild coordinates from-scratch index builds across
-// same-version replicas. Called when BuildIndex has no usable local index
-// and the tiered remote selection found nothing.
+// snapshotBuildCoordinationOpts configures coordinateSnapshotBuild.
+type snapshotBuildCoordinationOpts struct {
+	// flow identifies the caller for logs and span attributes.
+	flow string
+	// spanName is the tracer span name for the coordination loop.
+	spanName string
+	// pollInterval is how long to wait between probe/lock attempts.
+	pollInterval time.Duration
+	// totalWait caps how long to wait for a leader before giving up. Zero
+	// means "wait until ctx cancellation": used by the rebuild path where
+	// an existing index is already serving search, so waiting indefinitely
+	// is preferable to running a duplicate rebuild.
+	totalWait time.Duration
+	// probe is called once per iteration to look for an acceptable same-
+	// version snapshot. Probe errors other than ctx cancellation should be
+	// swallowed and returned as (nil, "", 0, nil).
+	probe func(ctx context.Context) (bleve.Index, string, int64, error)
+	// recordOutcome is invoked once after the loop returns. May be nil.
+	recordOutcome func(outcome string)
+}
+
+// coordinateSnapshotBuild coordinates from-scratch index builds across same-
+// version replicas using the existing remote build lock. Shared between the
+// cold-start path (no usable local index) and the periodic rebuild path.
 //
 // Outcomes:
-//   - (idx, name, rv, nil, nil) -- another replica's snapshot was downloaded; caller skips build.
-//   - (nil, "", 0, lock, nil)   -- caller is the leader; build, upload immediately, then release lock.
-//   - (nil, "", 0, nil, nil)    --  no snapshot and no leader slot in time; caller builds alone.
-//   - (nil, "", 0, nil, err)    -- context canceled mid-coordination.
+//   - idx != nil:           another replica's snapshot was downloaded; caller skips build.
+//   - lock != nil:          caller is the leader; build, upload immediately, then release lock.
+//   - both nil, err == nil: lock backend failed or wait timed out; caller builds alone.
+//   - err != nil:           context canceled mid-coordination.
 //
-// Each iteration, up to coldStartTotalWait:
+// Each iteration:
 //  1. Probe for a usable same-version snapshot. If found, download it.
 //  2. Try to acquire LockBuildIndex (no waiting). If acquired, return as
 //     leader (lock held for the whole build).
-//  3. Wait coldStartPollInterval and try again.
+//  3. Wait pollInterval and try again, until totalWait elapses or ctx is canceled.
 //
-// Probe runs before tryAcquire so that we download a leader's just-
-// uploaded snapshot instead of becoming a duplicate leader after the
-// leader releases the lock (the leader uploads then releases; by the
-// time the lock is free the snapshot is in the store).
+// Probe runs before tryAcquire so that we download a leader's just-uploaded
+// snapshot instead of becoming a duplicate leader after the leader releases
+// the lock (the leader uploads then releases; by the time the lock is free the
+// snapshot is in the store).
 //
 // The lock prevents duplicate expensive builds but is not a correctness
-// primitive: lock loss, leader death, or wait timeout all degrade to
-// duplicate work. ULID-keyed snapshots are immutable and cleanup reaps
-// duplicates.
-func (b *bleveBackend) coordinateColdStartBuild(
+// primitive: lock loss, leader death, or wait timeout all degrade to duplicate
+// work. ULID-keyed snapshots are immutable and cleanup reaps duplicates.
+func (b *bleveBackend) coordinateSnapshotBuild(
 	ctx context.Context,
 	key resource.NamespacedResource,
-	resourceDir string,
-	lastImportTime time.Time,
+	opts snapshotBuildCoordinationOpts,
 	logger log.Logger,
 ) (_ bleve.Index, _ string, _ int64, _ IndexStoreLock, retErr error) {
-	ctx, span := tracer.Start(ctx, "search.remote_index_snapshot.cold_start")
+	ctx, span := tracer.Start(ctx, opts.spanName)
 	start := time.Now()
-	outcome := coldStartOutcomeWaitTimedOut
+	outcome := snapshotBuildOutcomeWaitTimedOut
 	defer func() {
 		span.SetAttributes(
 			attribute.String("namespace", key.Namespace),
 			attribute.String("group", key.Group),
 			attribute.String("resource", key.Resource),
+			attribute.String("flow", opts.flow),
 			attribute.String("outcome", outcome),
 		)
 		if retErr != nil {
 			span.RecordError(retErr)
 			span.SetStatus(codes.Error, retErr.Error())
 		}
-		b.recordColdStartOutcome(outcome)
-		logger.Info("Cold-start coordination completed", "elapsed", time.Since(start), "outcome", outcome)
+		if opts.recordOutcome != nil {
+			opts.recordOutcome(outcome)
+		}
+		logger.Info("Snapshot build coordination completed",
+			"flow", opts.flow, "elapsed", time.Since(start), "outcome", outcome)
 		span.End()
 	}()
-	// Probe freshness window: Snapshot.MaxIndexAge, the same hard age
-	// filter the tiered selection applies. We don't reuse the rebuild
-	// path's tighter maxFreshSnapshotAge — on a cold start any
-	// same-version snapshot beats rebuilding, so we want the loosest
-	// threshold. Zero means "no age limit": the probe still runs and
-	// accepts any same-version snapshot.
-	probeMaxAge := b.opts.Snapshot.MaxIndexAge
-	logger.Info("Cold-start coordination started", "probe_max_age", probeMaxAge, "last_import_time", lastImportTime)
 
-	ticker := time.NewTicker(coldStartPollInterval)
+	logger.Info("Snapshot build coordination started",
+		"flow", opts.flow,
+		"poll_interval", opts.pollInterval,
+		"total_wait", opts.totalWait,
+	)
+
+	ticker := time.NewTicker(opts.pollInterval)
 	defer ticker.Stop()
-	deadline := time.NewTimer(coldStartTotalWait)
-	defer deadline.Stop()
+	var deadlineC <-chan time.Time
+	if opts.totalWait > 0 {
+		deadline := time.NewTimer(opts.totalWait)
+		defer deadline.Stop()
+		deadlineC = deadline.C
+	}
 
 	for {
-		idx, name, rv, err := b.tryDownloadColdStartSnapshot(ctx, key, resourceDir, lastImportTime, probeMaxAge, logger)
+		idx, name, rv, err := opts.probe(ctx)
 		if err != nil {
-			outcome = coldStartOutcomeContextCanceled
+			outcome = snapshotBuildOutcomeContextCanceled
 			return nil, "", 0, nil, err
 		}
 		if idx != nil {
-			outcome = coldStartOutcomeDownloadedAfterWait
+			outcome = snapshotBuildOutcomeDownloadedAfterWait
 			return idx, name, rv, nil, nil
 		}
 
 		lock, err := b.opts.Snapshot.Store.LockBuildIndex(ctx, key, b.opts.BuildVersion)
 		switch {
 		case err == nil:
-			outcome = coldStartOutcomeAcquiredLock
+			outcome = snapshotBuildOutcomeAcquiredLock
 			return nil, "", 0, lock, nil
 		case errors.Is(err, errLockHeld):
 			// keep waiting
@@ -656,24 +681,54 @@ func (b *bleveBackend) coordinateColdStartBuild(
 			// Propagate context cancellation so callers can abort cleanly
 			// instead of falling through to a from-scratch build.
 			if ctxErr := ctx.Err(); ctxErr != nil {
-				outcome = coldStartOutcomeContextCanceled
+				outcome = snapshotBuildOutcomeContextCanceled
 				return nil, "", 0, nil, ctxErr
 			}
-			logger.Warn("Cold-start lock acquire failed; will build alone", "err", err)
-			outcome = coldStartOutcomeLockError
+			logger.Warn("Snapshot build coordination lock acquire failed; will build alone",
+				"flow", opts.flow, "err", err)
+			outcome = snapshotBuildOutcomeLockError
 			return nil, "", 0, nil, nil
 		}
 
 		select {
 		case <-ctx.Done():
-			outcome = coldStartOutcomeContextCanceled
+			outcome = snapshotBuildOutcomeContextCanceled
 			return nil, "", 0, nil, ctx.Err()
-		case <-deadline.C:
-			outcome = coldStartOutcomeWaitTimedOut
+		case <-deadlineC:
+			// deadlineC is nil when totalWait == 0; this branch never fires in that case.
+			outcome = snapshotBuildOutcomeWaitTimedOut
 			return nil, "", 0, nil, nil
 		case <-ticker.C:
 		}
 	}
+}
+
+// coordinateColdStartBuild coordinates from-scratch index builds across
+// same-version replicas. Called when BuildIndex has no usable local index
+// and the tiered remote selection found nothing.
+func (b *bleveBackend) coordinateColdStartBuild(
+	ctx context.Context,
+	key resource.NamespacedResource,
+	resourceDir string,
+	lastImportTime time.Time,
+	logger log.Logger,
+) (bleve.Index, string, int64, IndexStoreLock, error) {
+	// Probe freshness window: Snapshot.MaxIndexAge, the same hard age filter
+	// the tiered selection applies. We don't reuse the rebuild path's tighter
+	// maxFreshSnapshotAge — on a cold start any same-version snapshot beats
+	// rebuilding, so we want the loosest threshold. Zero means "no age limit":
+	// the probe still runs and accepts any same-version snapshot.
+	probeMaxAge := b.opts.Snapshot.MaxIndexAge
+	return b.coordinateSnapshotBuild(ctx, key, snapshotBuildCoordinationOpts{
+		flow:         snapshotBuildFlowColdStart,
+		spanName:     "search.remote_index_snapshot.cold_start",
+		pollInterval: snapshotBuildPollInterval,
+		totalWait:    coldStartTotalWait,
+		probe: func(ctx context.Context) (bleve.Index, string, int64, error) {
+			return b.tryDownloadColdStartSnapshot(ctx, key, resourceDir, lastImportTime, probeMaxAge, logger)
+		},
+		recordOutcome: b.recordColdStartOutcome,
+	}, logger)
 }
 
 // tryDownloadColdStartSnapshot checks whether a usable same-version
@@ -717,13 +772,9 @@ func (b *bleveBackend) tryDownloadColdStartSnapshot(
 // coordinateRebuild coordinates periodic rebuilds across same-version replicas.
 // It uses the same remote build lock as cold-start coordination, but probes
 // with the rebuild freshness window so waiting replicas only accept snapshots
-// fresh enough to satisfy the rebuild condition.
-//
-// Outcomes:
-//   - (idx, name, rv, nil, nil) -- another replica's fresh snapshot was downloaded; caller skips build.
-//   - (nil, "", 0, lock, nil)   -- caller is the leader; build, upload immediately, then release lock.
-//   - (nil, "", 0, nil, nil)    -- lock backend failed; caller falls back to building alone.
-//   - (nil, "", 0, nil, err)    -- context canceled mid-coordination.
+// fresh enough to satisfy the rebuild condition. The rebuild path passes no
+// totalWait: the existing index is still serving search, so waiting for a
+// leader is preferable to running a duplicate rebuild.
 func (b *bleveBackend) coordinateRebuild(
 	ctx context.Context,
 	key resource.NamespacedResource,
@@ -731,65 +782,15 @@ func (b *bleveBackend) coordinateRebuild(
 	lastImportTime time.Time,
 	maxFreshSnapshotAge time.Duration,
 	logger log.Logger,
-) (_ bleve.Index, _ string, _ int64, _ IndexStoreLock, retErr error) {
-	ctx, span := tracer.Start(ctx, "search.remote_index_snapshot.rebuild_coordination")
-	start := time.Now()
-	outcome := "fallback"
-	defer func() {
-		span.SetAttributes(
-			attribute.String("namespace", key.Namespace),
-			attribute.String("group", key.Group),
-			attribute.String("resource", key.Resource),
-			attribute.String("outcome", outcome),
-		)
-		if retErr != nil {
-			span.RecordError(retErr)
-			span.SetStatus(codes.Error, retErr.Error())
-		}
-		logger.Info("Rebuild coordination completed", "elapsed", time.Since(start), "outcome", outcome)
-		span.End()
-	}()
-
-	logger.Info("Rebuild coordination started", "max_fresh_snapshot_age", maxFreshSnapshotAge, "last_import_time", lastImportTime)
-
-	ticker := time.NewTicker(rebuildCoordinationPollInterval)
-	defer ticker.Stop()
-
-	for {
-		idx, name, rv, err := b.tryDownloadRebuildSnapshot(ctx, key, resourceDir, lastImportTime, maxFreshSnapshotAge, logger)
-		if err != nil {
-			outcome = "context_canceled"
-			return nil, "", 0, nil, err
-		}
-		if idx != nil {
-			outcome = "downloaded_after_wait"
-			return idx, name, rv, nil, nil
-		}
-
-		lock, err := b.opts.Snapshot.Store.LockBuildIndex(ctx, key, b.opts.BuildVersion)
-		switch {
-		case err == nil:
-			outcome = "acquired_lock"
-			return nil, "", 0, lock, nil
-		case errors.Is(err, errLockHeld):
-			logger.Debug("Rebuild coordination waiting for snapshot build lock")
-		default:
-			if ctxErr := ctx.Err(); ctxErr != nil {
-				outcome = "context_canceled"
-				return nil, "", 0, nil, ctxErr
-			}
-			logger.Warn("Rebuild coordination lock acquire failed; will build alone", "err", err)
-			outcome = "lock_error"
-			return nil, "", 0, nil, nil
-		}
-
-		select {
-		case <-ctx.Done():
-			outcome = "context_canceled"
-			return nil, "", 0, nil, ctx.Err()
-		case <-ticker.C:
-		}
-	}
+) (bleve.Index, string, int64, IndexStoreLock, error) {
+	return b.coordinateSnapshotBuild(ctx, key, snapshotBuildCoordinationOpts{
+		flow:         snapshotBuildFlowRebuild,
+		spanName:     "search.remote_index_snapshot.rebuild_coordination",
+		pollInterval: snapshotBuildPollInterval,
+		probe: func(ctx context.Context) (bleve.Index, string, int64, error) {
+			return b.tryDownloadRebuildSnapshot(ctx, key, resourceDir, lastImportTime, maxFreshSnapshotAge, logger)
+		},
+	}, logger)
 }
 
 // tryDownloadRebuildSnapshot checks whether a fresh same-version snapshot

--- a/pkg/storage/unified/search/bleve_snapshot.go
+++ b/pkg/storage/unified/search/bleve_snapshot.go
@@ -601,6 +601,15 @@ type snapshotBuildCoordinationOpts struct {
 //   - both nil, err == nil: lock backend failed or wait timed out; caller builds alone.
 //   - err != nil:           context canceled mid-coordination.
 //
+// Error contract: coordination is best-effort. Only context cancellation is
+// returned to the caller. Probe failures (list/download/manifest read) and
+// non-contention lock backend failures are logged and converted to outcomes
+// ("lock_error", "wait_timed_out", ...) on the IndexSnapshotBuildCoordinations
+// metric, then the caller is told to build alone or to keep waiting. This
+// keeps callers simple: a flaky storage or lock backend should never fail an
+// index build, just degrade coordination quality. For debugging, inspect the
+// warn logs from this function and from the probe helpers, plus the metric.
+//
 // Each iteration:
 //  1. Probe for a usable same-version snapshot. If found, download it.
 //  2. Try to acquire LockBuildIndex (no waiting). If acquired, return as

--- a/pkg/storage/unified/search/bleve_snapshot.go
+++ b/pkg/storage/unified/search/bleve_snapshot.go
@@ -549,6 +549,11 @@ func findFreshSnapshot(
 	return ulid.ULID{}, nil, nil
 }
 
+const (
+	snapshotBuildFlowColdStart = "cold_start"
+	snapshotBuildFlowRebuild   = "rebuild"
+)
+
 // Outcome labels for the IndexSnapshotColdStarts metric.
 const (
 	coldStartOutcomeAcquiredLock        = "acquired_lock"
@@ -560,8 +565,9 @@ const (
 
 // Wait-for-leader timing. Package-level vars so tests can shrink them.
 var (
-	coldStartPollInterval = 30 * time.Second
-	coldStartTotalWait    = 15 * time.Minute
+	coldStartPollInterval           = 30 * time.Second
+	coldStartTotalWait              = 15 * time.Minute
+	rebuildCoordinationPollInterval = 30 * time.Second
 )
 
 // coordinateColdStartBuild coordinates from-scratch index builds across
@@ -703,6 +709,111 @@ func (b *bleveBackend) tryDownloadColdStartSnapshot(
 			return nil, "", 0, ctxErr
 		}
 		logger.Warn("Cold-start probe failed; will keep coordinating", "err", err)
+		return nil, "", 0, nil
+	}
+	return idx, name, rv, nil
+}
+
+// coordinateRebuild coordinates periodic rebuilds across same-version replicas.
+// It uses the same remote build lock as cold-start coordination, but probes
+// with the rebuild freshness window so waiting replicas only accept snapshots
+// fresh enough to satisfy the rebuild condition.
+//
+// Outcomes:
+//   - (idx, name, rv, nil, nil) -- another replica's fresh snapshot was downloaded; caller skips build.
+//   - (nil, "", 0, lock, nil)   -- caller is the leader; build, upload immediately, then release lock.
+//   - (nil, "", 0, nil, nil)    -- lock backend failed; caller falls back to building alone.
+//   - (nil, "", 0, nil, err)    -- context canceled mid-coordination.
+func (b *bleveBackend) coordinateRebuild(
+	ctx context.Context,
+	key resource.NamespacedResource,
+	resourceDir string,
+	lastImportTime time.Time,
+	maxFreshSnapshotAge time.Duration,
+	logger log.Logger,
+) (_ bleve.Index, _ string, _ int64, _ IndexStoreLock, retErr error) {
+	ctx, span := tracer.Start(ctx, "search.remote_index_snapshot.rebuild_coordination")
+	start := time.Now()
+	outcome := "fallback"
+	defer func() {
+		span.SetAttributes(
+			attribute.String("namespace", key.Namespace),
+			attribute.String("group", key.Group),
+			attribute.String("resource", key.Resource),
+			attribute.String("outcome", outcome),
+		)
+		if retErr != nil {
+			span.RecordError(retErr)
+			span.SetStatus(codes.Error, retErr.Error())
+		}
+		logger.Info("Rebuild coordination completed", "elapsed", time.Since(start), "outcome", outcome)
+		span.End()
+	}()
+
+	logger.Info("Rebuild coordination started", "max_fresh_snapshot_age", maxFreshSnapshotAge, "last_import_time", lastImportTime)
+
+	ticker := time.NewTicker(rebuildCoordinationPollInterval)
+	defer ticker.Stop()
+
+	for {
+		idx, name, rv, err := b.tryDownloadRebuildSnapshot(ctx, key, resourceDir, lastImportTime, maxFreshSnapshotAge, logger)
+		if err != nil {
+			outcome = "context_canceled"
+			return nil, "", 0, nil, err
+		}
+		if idx != nil {
+			outcome = "downloaded_after_wait"
+			return idx, name, rv, nil, nil
+		}
+
+		lock, err := b.opts.Snapshot.Store.LockBuildIndex(ctx, key, b.opts.BuildVersion)
+		switch {
+		case err == nil:
+			outcome = "acquired_lock"
+			return nil, "", 0, lock, nil
+		case errors.Is(err, errLockHeld):
+			logger.Debug("Rebuild coordination waiting for snapshot build lock")
+		default:
+			if ctxErr := ctx.Err(); ctxErr != nil {
+				outcome = "context_canceled"
+				return nil, "", 0, nil, ctxErr
+			}
+			logger.Warn("Rebuild coordination lock acquire failed; will build alone", "err", err)
+			outcome = "lock_error"
+			return nil, "", 0, nil, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			outcome = "context_canceled"
+			return nil, "", 0, nil, ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+// tryDownloadRebuildSnapshot checks whether a fresh same-version snapshot
+// exists for the rebuild path, and downloads it if so. Probe failures are
+// treated as "no hit" so coordination can still elect a leader and rebuild;
+// only context cancellation aborts the loop.
+func (b *bleveBackend) tryDownloadRebuildSnapshot(
+	ctx context.Context,
+	key resource.NamespacedResource,
+	resourceDir string,
+	lastImportTime time.Time,
+	maxFreshSnapshotAge time.Duration,
+	logger log.Logger,
+) (bleve.Index, string, int64, error) {
+	idx, name, rv, err := b.tryDownloadFreshSameVersionSnapshot(
+		ctx, key, resourceDir, lastImportTime, maxFreshSnapshotAge,
+		snapshotPolicySameVersion, "search.remote_index_snapshot.download_fresh",
+		logger,
+	)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, "", 0, ctxErr
+		}
+		logger.Warn("Rebuild coordination probe failed; will keep coordinating", "err", err)
 		return nil, "", 0, nil
 	}
 	return idx, name, rv, nil

--- a/pkg/storage/unified/search/bleve_snapshot_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_test.go
@@ -685,6 +685,7 @@ func TestBuildIndex_RebuildLeaderUploads(t *testing.T) {
 	assert.Equal(t, int32(1), store.uploadCalls.Load(), "leader must upload immediately")
 	assert.Equal(t, int32(1), store.lockReleaseCalls.Load(), "leader must release the build lock")
 	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotUploads.WithLabelValues(snapshotUploadStatusSuccess)))
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotBuildCoordinations.WithLabelValues(snapshotBuildFlowRebuild, snapshotBuildOutcomeAcquiredLock)))
 }
 
 // TestBuildIndex_RebuildLeaderLockLostDuringBuild verifies that if the rebuild
@@ -765,6 +766,54 @@ func TestBuildIndex_RebuildWaiterDownloadsFreshSnapshot(t *testing.T) {
 
 	assert.Zero(t, builderCalled.Load(), "waiter must not rebuild when a fresh snapshot appears")
 	assert.Positive(t, store.downloadCalls.Load(), "waiter must download the fresh snapshot")
+}
+
+// TestBuildIndex_RebuildWaiterRecordsDownloadedAfterWait verifies that the
+// rebuild waiter records the downloaded_after_wait outcome under the rebuild
+// flow on the shared build-coordination metric.
+func TestBuildIndex_RebuildWaiterRecordsDownloadedAfterWait(t *testing.T) {
+	store := newHookableStore(t)
+	ns := newTestNsResource()
+	be, metrics := newTestBleveBackend(t, SnapshotOptions{
+		Store:       store,
+		MinDocCount: 1,
+		MaxIndexAge: 24 * time.Hour,
+	})
+	withSnapshotBuildPollInterval(t, 5*time.Millisecond)
+
+	heldLock, err := store.inner.LockBuildIndex(t.Context(), ns, "11.5.0")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, heldLock.Release()) }()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+
+	type buildResult struct {
+		idx resource.ResourceIndex
+		err error
+	}
+	resultCh := make(chan buildResult, 1)
+	go func() {
+		idx, err := be.BuildIndex(ctx, ns, 10, nil, "rebuild",
+			func(resource.ResourceIndex) (int64, error) { return 1, nil },
+			nil, true /*rebuild*/, time.Time{}, time.Hour /*maxFreshSnapshotAge*/)
+		resultCh <- buildResult{idx: idx, err: err}
+	}()
+
+	require.Eventually(t, func() bool {
+		return store.lockAcquireCalls.Load() > 0
+	}, time.Second, 5*time.Millisecond)
+	seedDownloadableSnapshot(t, t.Context(), store.bucket, ns, makeULID(t, time.Now()), freshSnapshot(time.Minute))
+
+	select {
+	case result := <-resultCh:
+		require.NoError(t, result.err)
+		require.NotNil(t, result.idx)
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for rebuild waiter")
+	}
+
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotBuildCoordinations.WithLabelValues(snapshotBuildFlowRebuild, snapshotBuildOutcomeDownloadedAfterWait)))
 }
 
 // TestBuildIndex_RebuildSkipsFastPathWhenDisabled verifies that passing
@@ -1388,7 +1437,7 @@ func (ct coldStartTest) coordinate(ctx context.Context, lastImportTime time.Time
 }
 
 func (ct coldStartTest) coldStartCounter(outcome string) float64 {
-	return testutil.ToFloat64(ct.metrics.IndexSnapshotColdStarts.WithLabelValues(outcome))
+	return testutil.ToFloat64(ct.metrics.IndexSnapshotBuildCoordinations.WithLabelValues(snapshotBuildFlowColdStart, outcome))
 }
 
 func TestColdStart_BecameLeader(t *testing.T) {
@@ -1586,7 +1635,7 @@ func TestBuildIndex_ColdStartLeaderUploads(t *testing.T) {
 	assert.Equal(t, int32(1), builderCalled.Load(), "builder must run on the leader path")
 	assert.Equal(t, int32(1), store.uploadCalls.Load(), "leader must upload immediately")
 	assert.Equal(t, int32(1), store.lockReleaseCalls.Load(), "leader must release the build lock")
-	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotColdStarts.WithLabelValues(snapshotBuildOutcomeAcquiredLock)))
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotBuildCoordinations.WithLabelValues(snapshotBuildFlowColdStart, snapshotBuildOutcomeAcquiredLock)))
 	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotUploads.WithLabelValues(snapshotUploadStatusSuccess)))
 }
 
@@ -1622,7 +1671,7 @@ func TestBuildIndex_ColdStartTimeoutBuildsAlone(t *testing.T) {
 
 	assert.Equal(t, int32(1), builderCalled.Load(), "build alone after timeout")
 	assert.Zero(t, store.uploadCalls.Load(), "no leader upload on timeout path")
-	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotColdStarts.WithLabelValues(snapshotBuildOutcomeWaitTimedOut)))
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotBuildCoordinations.WithLabelValues(snapshotBuildFlowColdStart, snapshotBuildOutcomeWaitTimedOut)))
 }
 
 // TestBuildIndex_ColdStartRunsWhenMaxIndexAgeZero verifies that
@@ -1651,7 +1700,7 @@ func TestBuildIndex_ColdStartRunsWhenMaxIndexAgeZero(t *testing.T) {
 	assert.Equal(t, int32(1), store.lockAcquireCalls.Load(), "cold-start must attempt the lock even when MaxIndexAge=0")
 	assert.Equal(t, int32(1), store.uploadCalls.Load(), "leader must upload immediately")
 	assert.Equal(t, int32(1), store.lockReleaseCalls.Load(), "leader must release the build lock")
-	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotColdStarts.WithLabelValues(snapshotBuildOutcomeAcquiredLock)))
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotBuildCoordinations.WithLabelValues(snapshotBuildFlowColdStart, snapshotBuildOutcomeAcquiredLock)))
 	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotUploads.WithLabelValues(snapshotUploadStatusSuccess)))
 }
 

--- a/pkg/storage/unified/search/bleve_snapshot_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_test.go
@@ -658,6 +658,115 @@ func TestBuildIndex_RebuildFallsBackToBuilder(t *testing.T) {
 	assert.Zero(t, store.downloadCalls.Load(), "older snapshot must not be downloaded on the rebuild path")
 }
 
+// TestBuildIndex_RebuildLeaderUploads verifies that a periodic rebuild leader
+// holds the remote build lock through the rebuild and uploads the fresh snapshot
+// immediately so waiting replicas can download it.
+func TestBuildIndex_RebuildLeaderUploads(t *testing.T) {
+	store := newHookableStore(t)
+	ns := newTestNsResource()
+	be, metrics := newTestBleveBackend(t, SnapshotOptions{
+		Store:       store,
+		MinDocCount: 1,
+		MaxIndexAge: 24 * time.Hour,
+	})
+
+	builderCalled := atomic.Int32{}
+	idx, err := be.BuildIndex(t.Context(), ns, 10, nil, "rebuild",
+		func(index resource.ResourceIndex) (int64, error) {
+			builderCalled.Add(1)
+			return 7, nil
+		},
+		nil, true /*rebuild*/, time.Time{}, time.Hour /*maxFreshSnapshotAge*/)
+	require.NoError(t, err)
+	require.NotNil(t, idx)
+
+	assert.Equal(t, int32(1), builderCalled.Load(), "builder must run on the leader path")
+	assert.Equal(t, int32(1), store.lockAcquireCalls.Load(), "leader must acquire the build lock")
+	assert.Equal(t, int32(1), store.uploadCalls.Load(), "leader must upload immediately")
+	assert.Equal(t, int32(1), store.lockReleaseCalls.Load(), "leader must release the build lock")
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotUploads.WithLabelValues(snapshotUploadStatusSuccess)))
+}
+
+// TestBuildIndex_RebuildWaiterDownloadsFreshSnapshot verifies that a periodic
+// rebuild waits behind an existing build lock and downloads the fresh snapshot
+// instead of rebuilding locally.
+func TestBuildIndex_RebuildLeaderLockLostDuringBuild(t *testing.T) {
+	store := newHookableStore(t)
+	ns := newTestNsResource()
+	be, metrics := newTestBleveBackend(t, SnapshotOptions{
+		Store:       store,
+		MinDocCount: 1,
+		MaxIndexAge: 24 * time.Hour,
+	})
+
+	builderCalled := atomic.Int32{}
+	idx, err := be.BuildIndex(t.Context(), ns, 10, nil, "rebuild",
+		func(resource.ResourceIndex) (int64, error) {
+			builderCalled.Add(1)
+			store.signalLockLost()
+			return 7, nil
+		},
+		nil, true /*rebuild*/, time.Time{}, time.Hour /*maxFreshSnapshotAge*/)
+	require.NoError(t, err)
+	require.NotNil(t, idx)
+
+	assert.Equal(t, int32(1), builderCalled.Load(), "builder must run on the leader path")
+	assert.Zero(t, store.uploadCalls.Load(), "leader must skip immediate upload after lock loss")
+	assert.Equal(t, int32(1), store.lockReleaseCalls.Load(), "leader still releases the build lock")
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotUploads.WithLabelValues(snapshotUploadStatusSkipLockLost)))
+	assert.Zero(t, testutil.ToFloat64(metrics.IndexSnapshotUploads.WithLabelValues(snapshotUploadStatusSuccess)))
+}
+
+func TestBuildIndex_RebuildWaiterDownloadsFreshSnapshot(t *testing.T) {
+	store := newHookableStore(t)
+	ns := newTestNsResource()
+	be, _ := newTestBleveBackend(t, SnapshotOptions{
+		Store:       store,
+		MinDocCount: 1,
+		MaxIndexAge: 24 * time.Hour,
+	})
+	withRebuildCoordinationPollInterval(t, 5*time.Millisecond)
+
+	heldLock, err := store.inner.LockBuildIndex(t.Context(), ns, "11.5.0")
+	require.NoError(t, err)
+	defer func() { require.NoError(t, heldLock.Release()) }()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 2*time.Second)
+	defer cancel()
+
+	builderCalled := atomic.Int32{}
+	type buildResult struct {
+		idx resource.ResourceIndex
+		err error
+	}
+	resultCh := make(chan buildResult, 1)
+	go func() {
+		idx, err := be.BuildIndex(ctx, ns, 10, nil, "rebuild",
+			func(resource.ResourceIndex) (int64, error) {
+				builderCalled.Add(1)
+				return 1, nil
+			},
+			nil, true /*rebuild*/, time.Time{}, time.Hour /*maxFreshSnapshotAge*/)
+		resultCh <- buildResult{idx: idx, err: err}
+	}()
+
+	require.Eventually(t, func() bool {
+		return store.lockAcquireCalls.Load() > 0
+	}, time.Second, 5*time.Millisecond)
+	seedDownloadableSnapshot(t, t.Context(), store.bucket, ns, makeULID(t, time.Now()), freshSnapshot(time.Minute))
+
+	select {
+	case result := <-resultCh:
+		require.NoError(t, result.err)
+		require.NotNil(t, result.idx)
+	case <-ctx.Done():
+		t.Fatal("timed out waiting for rebuild waiter")
+	}
+
+	assert.Zero(t, builderCalled.Load(), "waiter must not rebuild when a fresh snapshot appears")
+	assert.Positive(t, store.downloadCalls.Load(), "waiter must download the fresh snapshot")
+}
+
 // TestBuildIndex_RebuildSkipsFastPathWhenDisabled verifies that passing
 // maxFreshSnapshotAge=0 disables the rebuild-path fast path entirely (no
 // list/get calls against the store).
@@ -682,6 +791,7 @@ func TestBuildIndex_RebuildSkipsFastPathWhenDisabled(t *testing.T) {
 	require.NotNil(t, idx)
 	assert.Equal(t, int32(1), builderCalled.Load())
 	assert.Zero(t, store.downloadCalls.Load())
+	assert.Zero(t, store.lockAcquireCalls.Load())
 }
 
 // TestBuildIndex_SkipsDownloadBelowMinDocCount ensures ListIndexSnapshots is not called
@@ -1223,6 +1333,15 @@ func withColdStartTimings(t *testing.T, poll, total time.Duration) {
 	t.Cleanup(func() {
 		coldStartPollInterval = prevPoll
 		coldStartTotalWait = prevTotal
+	})
+}
+
+func withRebuildCoordinationPollInterval(t *testing.T, poll time.Duration) {
+	t.Helper()
+	prev := rebuildCoordinationPollInterval
+	rebuildCoordinationPollInterval = poll
+	t.Cleanup(func() {
+		rebuildCoordinationPollInterval = prev
 	})
 }
 

--- a/pkg/storage/unified/search/bleve_snapshot_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_test.go
@@ -687,9 +687,9 @@ func TestBuildIndex_RebuildLeaderUploads(t *testing.T) {
 	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotUploads.WithLabelValues(snapshotUploadStatusSuccess)))
 }
 
-// TestBuildIndex_RebuildWaiterDownloadsFreshSnapshot verifies that a periodic
-// rebuild waits behind an existing build lock and downloads the fresh snapshot
-// instead of rebuilding locally.
+// TestBuildIndex_RebuildLeaderLockLostDuringBuild verifies that if the rebuild
+// leader's lock is lost during the build, the immediate upload is skipped but
+// the rebuild itself still completes — lock-lost is coordination, not fatal.
 func TestBuildIndex_RebuildLeaderLockLostDuringBuild(t *testing.T) {
 	store := newHookableStore(t)
 	ns := newTestNsResource()
@@ -725,7 +725,7 @@ func TestBuildIndex_RebuildWaiterDownloadsFreshSnapshot(t *testing.T) {
 		MinDocCount: 1,
 		MaxIndexAge: 24 * time.Hour,
 	})
-	withRebuildCoordinationPollInterval(t, 5*time.Millisecond)
+	withSnapshotBuildPollInterval(t, 5*time.Millisecond)
 
 	heldLock, err := store.inner.LockBuildIndex(t.Context(), ns, "11.5.0")
 	require.NoError(t, err)
@@ -1323,25 +1323,26 @@ func TestFindFreshSnapshotByBuildStart(t *testing.T) {
 	})
 }
 
-// withColdStartTimings overrides the package-level wait-loop timings for the
+// withSnapshotBuildPollInterval overrides snapshotBuildPollInterval for the
 // duration of the test. Restored via t.Cleanup.
-func withColdStartTimings(t *testing.T, poll, total time.Duration) {
+func withSnapshotBuildPollInterval(t *testing.T, poll time.Duration) {
 	t.Helper()
-	prevPoll, prevTotal := coldStartPollInterval, coldStartTotalWait
-	coldStartPollInterval = poll
-	coldStartTotalWait = total
+	prev := snapshotBuildPollInterval
+	snapshotBuildPollInterval = poll
 	t.Cleanup(func() {
-		coldStartPollInterval = prevPoll
-		coldStartTotalWait = prevTotal
+		snapshotBuildPollInterval = prev
 	})
 }
 
-func withRebuildCoordinationPollInterval(t *testing.T, poll time.Duration) {
+// withColdStartTimings overrides the cold-start wait-loop timings for the
+// duration of the test. Restored via t.Cleanup.
+func withColdStartTimings(t *testing.T, poll, total time.Duration) {
 	t.Helper()
-	prev := rebuildCoordinationPollInterval
-	rebuildCoordinationPollInterval = poll
+	withSnapshotBuildPollInterval(t, poll)
+	prev := coldStartTotalWait
+	coldStartTotalWait = total
 	t.Cleanup(func() {
-		rebuildCoordinationPollInterval = prev
+		coldStartTotalWait = prev
 	})
 }
 
@@ -1399,7 +1400,7 @@ func TestColdStart_BecameLeader(t *testing.T) {
 	assert.Equal(t, "leader", role)
 	require.NotNil(t, lock)
 	assert.Equal(t, int32(1), store.lockAcquireCalls.Load())
-	assert.Equal(t, 1.0, ct.coldStartCounter(coldStartOutcomeAcquiredLock))
+	assert.Equal(t, 1.0, ct.coldStartCounter(snapshotBuildOutcomeAcquiredLock))
 
 	require.NoError(t, lock.Release())
 	assert.Equal(t, int32(1), store.lockReleaseCalls.Load(),
@@ -1437,7 +1438,7 @@ func TestColdStart_WaitedForLeader(t *testing.T) {
 	// zero (no Release was invoked because no Acquire ever succeeded).
 	assert.Zero(t, store.lockReleaseCalls.Load(),
 		"waiter must not acquire the lock when a snapshot becomes available")
-	assert.Equal(t, 1.0, ct.coldStartCounter(coldStartOutcomeDownloadedAfterWait))
+	assert.Equal(t, 1.0, ct.coldStartCounter(snapshotBuildOutcomeDownloadedAfterWait))
 }
 
 func TestColdStart_WaitTimeout(t *testing.T) {
@@ -1450,7 +1451,7 @@ func TestColdStart_WaitTimeout(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "build_alone", role)
 	assert.Nil(t, lock)
-	assert.Equal(t, 1.0, ct.coldStartCounter(coldStartOutcomeWaitTimedOut))
+	assert.Equal(t, 1.0, ct.coldStartCounter(snapshotBuildOutcomeWaitTimedOut))
 	// We retried the lock at least a couple times before giving up.
 	assert.GreaterOrEqual(t, store.lockAcquireCalls.Load(), int32(2))
 }
@@ -1474,7 +1475,7 @@ func TestColdStart_AcquiresLockAfterLeaderRelease(t *testing.T) {
 	assert.Equal(t, "leader", role)
 	require.NotNil(t, lock)
 	t.Cleanup(func() { _ = lock.Release() })
-	assert.Equal(t, 1.0, ct.coldStartCounter(coldStartOutcomeAcquiredLock))
+	assert.Equal(t, 1.0, ct.coldStartCounter(snapshotBuildOutcomeAcquiredLock))
 }
 
 func TestColdStart_LockBackendErrorBuildsAlone(t *testing.T) {
@@ -1486,7 +1487,7 @@ func TestColdStart_LockBackendErrorBuildsAlone(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "build_alone", role)
 	assert.Nil(t, lock)
-	assert.Equal(t, 1.0, ct.coldStartCounter(coldStartOutcomeLockError))
+	assert.Equal(t, 1.0, ct.coldStartCounter(snapshotBuildOutcomeLockError))
 }
 
 // TestColdStart_LockBackendContextErrorPropagates verifies that a context
@@ -1502,9 +1503,9 @@ func TestColdStart_LockBackendContextErrorPropagates(t *testing.T) {
 
 	_, _, err := ct.coordinate(ctx, time.Time{})
 	require.ErrorIs(t, err, context.Canceled)
-	assert.Zero(t, ct.coldStartCounter(coldStartOutcomeLockError), "context cancel must not be recorded as lock_error")
-	assert.Zero(t, ct.coldStartCounter(coldStartOutcomeWaitTimedOut), "context cancel must not be recorded as wait_timed_out")
-	assert.Equal(t, 1.0, ct.coldStartCounter(coldStartOutcomeContextCanceled))
+	assert.Zero(t, ct.coldStartCounter(snapshotBuildOutcomeLockError), "context cancel must not be recorded as lock_error")
+	assert.Zero(t, ct.coldStartCounter(snapshotBuildOutcomeWaitTimedOut), "context cancel must not be recorded as wait_timed_out")
+	assert.Equal(t, 1.0, ct.coldStartCounter(snapshotBuildOutcomeContextCanceled))
 }
 
 func TestColdStart_ContextCancelInWaitLoop(t *testing.T) {
@@ -1521,8 +1522,8 @@ func TestColdStart_ContextCancelInWaitLoop(t *testing.T) {
 
 	_, _, err := ct.coordinate(ctx, time.Time{})
 	require.ErrorIs(t, err, context.Canceled)
-	assert.Zero(t, ct.coldStartCounter(coldStartOutcomeWaitTimedOut), "context cancel must not be recorded as wait_timed_out")
-	assert.Equal(t, 1.0, ct.coldStartCounter(coldStartOutcomeContextCanceled))
+	assert.Zero(t, ct.coldStartCounter(snapshotBuildOutcomeWaitTimedOut), "context cancel must not be recorded as wait_timed_out")
+	assert.Equal(t, 1.0, ct.coldStartCounter(snapshotBuildOutcomeContextCanceled))
 }
 
 // runBuildIndexColdStart wires a bleveBackend around store and calls
@@ -1585,7 +1586,7 @@ func TestBuildIndex_ColdStartLeaderUploads(t *testing.T) {
 	assert.Equal(t, int32(1), builderCalled.Load(), "builder must run on the leader path")
 	assert.Equal(t, int32(1), store.uploadCalls.Load(), "leader must upload immediately")
 	assert.Equal(t, int32(1), store.lockReleaseCalls.Load(), "leader must release the build lock")
-	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotColdStarts.WithLabelValues(coldStartOutcomeAcquiredLock)))
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotColdStarts.WithLabelValues(snapshotBuildOutcomeAcquiredLock)))
 	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotUploads.WithLabelValues(snapshotUploadStatusSuccess)))
 }
 
@@ -1621,7 +1622,7 @@ func TestBuildIndex_ColdStartTimeoutBuildsAlone(t *testing.T) {
 
 	assert.Equal(t, int32(1), builderCalled.Load(), "build alone after timeout")
 	assert.Zero(t, store.uploadCalls.Load(), "no leader upload on timeout path")
-	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotColdStarts.WithLabelValues(coldStartOutcomeWaitTimedOut)))
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotColdStarts.WithLabelValues(snapshotBuildOutcomeWaitTimedOut)))
 }
 
 // TestBuildIndex_ColdStartRunsWhenMaxIndexAgeZero verifies that
@@ -1650,7 +1651,7 @@ func TestBuildIndex_ColdStartRunsWhenMaxIndexAgeZero(t *testing.T) {
 	assert.Equal(t, int32(1), store.lockAcquireCalls.Load(), "cold-start must attempt the lock even when MaxIndexAge=0")
 	assert.Equal(t, int32(1), store.uploadCalls.Load(), "leader must upload immediately")
 	assert.Equal(t, int32(1), store.lockReleaseCalls.Load(), "leader must release the build lock")
-	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotColdStarts.WithLabelValues(coldStartOutcomeAcquiredLock)))
+	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotColdStarts.WithLabelValues(snapshotBuildOutcomeAcquiredLock)))
 	assert.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexSnapshotUploads.WithLabelValues(snapshotUploadStatusSuccess)))
 }
 


### PR DESCRIPTION
Coordinate periodic index rebuilds across replicas when remote index snapshots are enabled.

The replica that gets the existing snapshot build lock rebuilds and uploads a fresh snapshot immediately. Other same-version replicas wait and download that snapshot instead of rebuilding the same index locally.

Avoids duplicate expensive periodic rebuilds for the same resource across replicas.

https://github.com/grafana/search-and-storage-team/issues/803