### PR TITLE
CI: Skip patch check for now

### DIFF
--- a/.policy.yml
+++ b/.policy.yml
@@ -35,7 +35,6 @@ policy:
             - Workflow .github/workflows/pr-go-workspace-check.yml succeeded or skipped
             - Workflow .github/workflows/pr-k8s-codegen-check.yml succeeded or skipped
             - Workflow .github/workflows/pr-mt-service-compatibility.yml succeeded or skipped
-            - Workflow .github/workflows/pr-patch-check.yml succeeded or skipped
             - Workflow .github/workflows/pr-test-docker.yml succeeded or skipped
             - Workflow .github/workflows/pr-test-integration-pgvector.yml succeeded or skipped
             - Workflow .github/workflows/pr-test-integration.yml succeeded or skipped

--- a/Makefile
+++ b/Makefile
@@ -850,6 +850,6 @@ GENERATE_POLICY_BOT_CONFIG_SHA := sha256:d05ff5c7d4247da155c85f8c6f1f9f7c6d013d1
 # We don't want the patch workflow to be run. This is exclusively useful for the security-mirror. It won't work in OSS.
 	sed -i.bak '/- Workflow \.github\/workflows\/create-security-patch-from-security-mirror/d' .policy.yml; rm -f .policy.yml.bak
 # Skip pr-patch-check-event until it is working again.
-	sed -i.bak '/- Workflow \.github\/workflows\/pr-patch-check-event/d' .policy.yml; rm -f .policy.yml.bak
+	sed -i.bak '/- Workflow \.github\/workflows\/pr-patch-check/d' .policy.yml; rm -f .policy.yml.bak
 # Make govulncheck non-blocking - accept failure so it doesn't prevent merge
 	sed -i.bak '/name: Workflow \.github\/workflows\/govulncheck\.yml/,/workflows:/{s/- success/- success\n            - failure/;}' .policy.yml; rm -f .policy.yml.bak


### PR DESCRIPTION
In https://github.com/grafana/grafana/pull/125181 we renamed the PR patch check workflow to `pr-patch-check.yml` when simplifying it.

It's not yet passing until we get some other changes, so this removes it from the policy bot to prevent it blocking PRs.