### PR TITLE
[release-12.3.7] TimeSeries: Fix y-scale ranging of extremely small data ranges

### DIFF
--- a/packages/grafana-ui/src/components/uPlot/config/UPlotScaleBuilder.ts
+++ b/packages/grafana-ui/src/components/uPlot/config/UPlotScaleBuilder.ts
@@ -253,6 +253,20 @@ export class UPlotScaleBuilder extends PlotConfigBuilder<ScaleProps, Scale> {
         }
       }
 
+      // for tiny ranges like 0.999999999811111, 1, uPlot's rangeNum may return [1,1]
+      if (minMax[0]! === minMax[1]! && minMax[0]! !== 0) {
+        // only applies to linear scales
+        if (scale.distr === 1) {
+          if (minMax[0] < 0) {
+            minMax[0] *= 2;
+            minMax[1] = 0;
+          } else {
+            minMax[1] *= 2;
+            minMax[0] = 0;
+          }
+        }
+      }
+
       // guard against invalid y ranges
       if (minMax[0]! >= minMax[1]!) {
         minMax[0] = scale.distr === 3 ? 1 : 0;


### PR DESCRIPTION
Manual backport of https://github.com/grafana/grafana/pull/122057 into 12.3.7

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
