### PR TITLE
PanelEditNext: Add ErrorBoundary to editor

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.test.tsx
@@ -3,10 +3,12 @@ import { useEffect, useRef, useState } from 'react';
 
 import {
   type DataQueryError,
-  type DataSourceApi,
+  DataSourceApi,
   type DataSourceJsonData,
+  type DataQueryResponse,
   getDefaultTimeRange,
   LoadingState,
+  type TestDataSourceResponse,
 } from '@grafana/data';
 import { VizPanel } from '@grafana/scenes';
 import { type DataQuery } from '@grafana/schema';
@@ -36,19 +38,34 @@ interface TestQuery extends DataQuery {
   legendFormat?: string;
 }
 
+function getLegendFormat(query: DataQuery): string {
+  return 'legendFormat' in query && typeof query.legendFormat === 'string' ? query.legendFormat : '';
+}
+
 // Fake query editor that simulates an uncontrolled input — it initialises its
 // display value from props.query on mount and never syncs again.
-function UncontrolledQueryEditor({ query }: { query: TestQuery }) {
-  const [legend] = useState(query.legendFormat ?? '');
+function UncontrolledQueryEditor({ query }: { query: DataQuery }) {
+  const [legend] = useState(getLegendFormat(query));
   return <div data-testid="query-editor-legend">{legend}</div>;
 }
 
-const mockDatasource: Partial<DataSourceApi<DataQuery, DataSourceJsonData>> = {
-  components: { QueryEditor: UncontrolledQueryEditor },
-};
+class MockDataSourceApi extends DataSourceApi<DataQuery, DataSourceJsonData> {
+  constructor(components: DataSourceApi<DataQuery, DataSourceJsonData>['components']) {
+    super(ds1SettingsMock);
+    this.components = components;
+  }
+
+  query(): Promise<DataQueryResponse> {
+    return Promise.resolve({ data: [] });
+  }
+
+  testDatasource(): Promise<TestDataSourceResponse> {
+    return Promise.resolve({ status: 'success', message: 'OK' });
+  }
+}
 
 const selectedQueryDsData = {
-  datasource: mockDatasource as DataSourceApi,
+  datasource: new MockDataSourceApi({ QueryEditor: UncontrolledQueryEditor }),
   dsSettings: ds1SettingsMock,
 };
 
@@ -85,6 +102,28 @@ describe('QueryEditorRenderer', () => {
   it('renders the query editor for the selected query', () => {
     renderRenderer(queryA);
     expect(screen.getByTestId('query-editor-legend')).toHaveTextContent('series-a');
+  });
+
+  it('contains errors thrown by the datasource query editor', () => {
+    const consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation();
+
+    function ThrowingQueryEditor(): never {
+      throw new Error('Query editor crashed');
+    }
+
+    try {
+      renderRenderer(queryA, {
+        selectedQueryDsData: {
+          datasource: new MockDataSourceApi({ QueryEditor: ThrowingQueryEditor }),
+          dsSettings: ds1SettingsMock,
+        },
+      });
+
+      expect(screen.getByText('An unexpected error happened')).toBeInTheDocument();
+      expect(screen.getByText(/Query editor crashed/)).toBeInTheDocument();
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
   });
 
   it('remounts the query editor when switching queries, resetting uncontrolled input state', () => {
@@ -157,8 +196,8 @@ describe('QueryEditorRenderer', () => {
     const updateSelectedQuery = jest.fn();
 
     // Editor that flushes a pending edit via onChange in its unmount cleanup.
-    function CleanupOnChangeEditor({ query, onChange }: { query: TestQuery; onChange: (q: DataQuery) => void }) {
-      const pendingEdit = { ...query, legendFormat: `${query.legendFormat}-edited` };
+    function CleanupOnChangeEditor({ query, onChange }: { query: DataQuery; onChange: (q: DataQuery) => void }) {
+      const pendingEdit = { ...query, legendFormat: `${getLegendFormat(query)}-edited` };
       const pendingEditRef = useRef(pendingEdit);
       pendingEditRef.current = pendingEdit;
       const onChangeRef = useRef(onChange);
@@ -168,12 +207,10 @@ describe('QueryEditorRenderer', () => {
         return () => onChangeRef.current(pendingEditRef.current);
       }, []);
 
-      return <div data-testid="cleanup-editor">{query.legendFormat}</div>;
+      return <div data-testid="cleanup-editor">{getLegendFormat(query)}</div>;
     }
 
-    const mockDatasourceWithCleanup: Partial<DataSourceApi<DataQuery, DataSourceJsonData>> = {
-      components: { QueryEditor: CleanupOnChangeEditor },
-    };
+    const mockDatasourceWithCleanup = new MockDataSourceApi({ QueryEditor: CleanupOnChangeEditor });
 
     function buildJsx(selectedQuery: DataQuery) {
       return (
@@ -191,7 +228,7 @@ describe('QueryEditorRenderer', () => {
             setSelectedAlert: jest.fn(),
             queryOptions: mockQueryOptionsState,
             selectedQueryDsData: {
-              datasource: mockDatasourceWithCleanup as DataSourceApi,
+              datasource: mockDatasourceWithCleanup,
               dsSettings: ds1SettingsMock,
             },
             selectedQueryDsLoading: false,

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.tsx
@@ -73,20 +73,20 @@ export function QueryEditorRenderer() {
   return (
     <>
       <DataSourcePluginContextProvider instanceSettings={dsSettings}>
-        {/* <ErrorBoundaryAlert boundaryName="query-editor-renderer"> */}
-        <QueryEditorComponent
-          key={selectedQuery.refId}
-          app={CoreApp.Dashboard}
-          data={filteredData}
-          datasource={datasource}
-          onAddQuery={addQuery}
-          onChange={handleChange}
-          onRunQuery={runQueries}
-          queries={queries}
-          query={selectedQuery}
-          range={filteredData?.timeRange}
-        />
-        {/* </ErrorBoundaryAlert> */}
+        <ErrorBoundaryAlert boundaryName="query-editor-renderer">
+          <QueryEditorComponent
+            key={selectedQuery.refId}
+            app={CoreApp.Dashboard}
+            data={filteredData}
+            datasource={datasource}
+            onAddQuery={addQuery}
+            onChange={handleChange}
+            onRunQuery={runQueries}
+            queries={queries}
+            query={selectedQuery}
+            range={filteredData?.timeRange}
+          />
+        </ErrorBoundaryAlert>
       </DataSourcePluginContextProvider>
       {error && <QueryErrorAlert error={error} />}
     </>

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/QueryEditorRenderer.tsx
@@ -3,7 +3,7 @@ import { useCallback, useMemo } from 'react';
 import { CoreApp, DataSourcePluginContextProvider } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 import { type DataQuery } from '@grafana/schema';
-import { Alert, Spinner, Stack, Text } from '@grafana/ui';
+import { Alert, ErrorBoundaryAlert, Spinner, Stack, Text } from '@grafana/ui';
 import { filterPanelDataToQuery } from 'app/features/query/components/QueryEditorRow';
 import { QueryErrorAlert } from 'app/features/query/components/QueryErrorAlert';
 
@@ -73,6 +73,7 @@ export function QueryEditorRenderer() {
   return (
     <>
       <DataSourcePluginContextProvider instanceSettings={dsSettings}>
+        {/* <ErrorBoundaryAlert boundaryName="query-editor-renderer"> */}
         <QueryEditorComponent
           key={selectedQuery.refId}
           app={CoreApp.Dashboard}
@@ -85,6 +86,7 @@ export function QueryEditorRenderer() {
           query={selectedQuery}
           range={filteredData?.timeRange}
         />
+        {/* </ErrorBoundaryAlert> */}
       </DataSourcePluginContextProvider>
       {error && <QueryErrorAlert error={error} />}
     </>


### PR DESCRIPTION
## Description
Adds an error boundary around the PanelEditNext datasource query editor so errors thrown by plugin query editors are contained instead of crashing the full panel edit UI.

## Changes
* Wrapped `QueryEditorComponent` in `ErrorBoundaryAlert` with `boundaryName="query-editor-renderer"`.
* Added a regression test that verifies a crashing datasource query editor renders the boundary fallback.

## Risks
* Low risk. This only changes the error path around datasource query editor rendering.

## Demo
#### Before Error Boundary
<img width="1728" height="972" alt="image" src="https://github.com/user-attachments/assets/de888c96-8e97-4c36-8884-0171e852f51a" />

#### After Error Boundary
<img width="1386" height="379" alt="image" src="https://github.com/user-attachments/assets/0ef29c09-bb59-4111-9fc2-ae49610b5ec9" />

## Testing Instructions
* If you want, you can follow the reproduction steps from DPRO-97 to get the error to show up.
* Then you can test with/without the error boundary

## Reviewer Checklist
- [x] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [x] Code is meaningfully improved if applicable