### PR TITLE
Alerting: migrate AMConfigV1 templateFiles map to v1.TemplateGroup model

### DIFF
--- a/pkg/registry/apps/alerting/notifications/templategroup/conversions.go
+++ b/pkg/registry/apps/alerting/notifications/templategroup/conversions.go
@@ -1,20 +1,19 @@
 package templategroup
 
 import (
-	"github.com/grafana/alerting/definition"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
 
 	model "github.com/grafana/grafana/apps/alerting/notifications/pkg/apis/alertingnotifications/v1beta1"
 	gapiutil "github.com/grafana/grafana/pkg/services/apiserver/utils"
+	v1 "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
 
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
-	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
-func convertToK8sResources(orgID int64, list []definitions.NotificationTemplate, namespacer request.NamespaceMapper, selector fields.Selector) (*model.TemplateGroupList, error) {
+func convertToK8sResources(orgID int64, list []v1.TemplateGroup, namespacer request.NamespaceMapper, selector fields.Selector) (*model.TemplateGroupList, error) {
 	result := &model.TemplateGroupList{}
 	for _, t := range list {
 		item := convertToK8sResource(orgID, t, namespacer)
@@ -26,7 +25,7 @@ func convertToK8sResources(orgID int64, list []definitions.NotificationTemplate,
 	return result, nil
 }
 
-func convertToK8sResource(orgID int64, template definitions.NotificationTemplate, namespacer request.NamespaceMapper) *model.TemplateGroup {
+func convertToK8sResource(orgID int64, template v1.TemplateGroup, namespacer request.NamespaceMapper) *model.TemplateGroup {
 	result := &model.TemplateGroup{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: kind.GroupVersionKind().GroupVersion().String(),
@@ -34,13 +33,13 @@ func convertToK8sResource(orgID int64, template definitions.NotificationTemplate
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			UID:             types.UID(template.UID),
-			Name:            template.UID,
+			Name:            string(template.UID),
 			Namespace:       namespacer(orgID),
-			ResourceVersion: template.ResourceVersion,
+			ResourceVersion: template.Version,
 		},
 		Spec: model.TemplateGroupSpec{
-			Title:   template.Name,
-			Content: template.Template,
+			Title:   template.Title,
+			Content: template.Content,
 			Kind:    model.TemplateGroupTemplateKind(template.Kind),
 		},
 	}
@@ -49,17 +48,19 @@ func convertToK8sResource(orgID int64, template definitions.NotificationTemplate
 	return result
 }
 
-func convertToDomainModel(template *model.TemplateGroup) (definitions.NotificationTemplate, error) {
+func convertToDomainModel(template *model.TemplateGroup) (v1.TemplateGroup, error) {
 	prov, err := ngmodels.ProvenanceFromString(template.GetProvenanceStatus())
 	if err != nil {
-		return definitions.NotificationTemplate{}, err
+		return v1.TemplateGroup{}, err
 	}
-	return definitions.NotificationTemplate{
-		UID:             template.Name,
-		Name:            template.Spec.Title,
-		Template:        template.Spec.Content,
-		ResourceVersion: template.ResourceVersion,
-		Provenance:      definitions.Provenance(prov),
-		Kind:            definition.TemplateKind(template.Spec.Kind),
+	return v1.TemplateGroup{
+		ResourceMetadata: v1.ResourceMetadata{
+			UID:        v1.ResourceUID(template.Name),
+			Version:    template.ResourceVersion,
+			Provenance: prov,
+		},
+		Title:   template.Spec.Title,
+		Content: template.Spec.Content,
+		Kind:    v1.TemplateKind(template.Spec.Kind),
 	}, nil
 }

--- a/pkg/registry/apps/alerting/notifications/templategroup/legacy_storage.go
+++ b/pkg/registry/apps/alerting/notifications/templategroup/legacy_storage.go
@@ -15,7 +15,6 @@ import (
 	model "github.com/grafana/grafana/apps/alerting/notifications/pkg/apis/alertingnotifications/v1beta1"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
-	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
 	v1 "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
 )
@@ -29,7 +28,7 @@ type TemplateService interface {
 	GetTemplates(ctx context.Context, orgID int64) ([]v1.TemplateGroup, error)
 	CreateTemplate(ctx context.Context, orgID int64, tmpl v1.TemplateGroup) (v1.TemplateGroup, error)
 	UpdateTemplate(ctx context.Context, orgID int64, tmpl v1.TemplateGroup) (v1.TemplateGroup, error)
-	DeleteTemplate(ctx context.Context, orgID int64, nameOrUid string, provenance models.Provenance, version string) error
+	DeleteTemplate(ctx context.Context, orgID int64, nameOrUid string, provenance ngmodels.Provenance, version string) error
 }
 
 type legacyStorage struct {
@@ -226,7 +225,7 @@ func (s *legacyStorage) defaultTemplate() (v1.TemplateGroup, error) {
 		Title: model.DefaultTemplateTitle, // User friendly name.
 		ResourceMetadata: v1.ResourceMetadata{
 			UID:        v1.ResourceUID(defaultTemplate.Name),
-			Provenance: models.Provenance("system"),
+			Provenance: ngmodels.Provenance("system"),
 		},
 		Content: defaultTemplate.Template,
 		Kind:    v1.TemplateKindGrafana,

--- a/pkg/registry/apps/alerting/notifications/templategroup/legacy_storage.go
+++ b/pkg/registry/apps/alerting/notifications/templategroup/legacy_storage.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/grafana/alerting/definition"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/internalversion"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,8 +15,9 @@ import (
 	model "github.com/grafana/grafana/apps/alerting/notifications/pkg/apis/alertingnotifications/v1beta1"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
-	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
+	v1 "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
 )
 
 var (
@@ -25,11 +25,11 @@ var (
 )
 
 type TemplateService interface {
-	GetTemplate(ctx context.Context, orgID int64, nameOrUid string) (definitions.NotificationTemplate, error)
-	GetTemplates(ctx context.Context, orgID int64) ([]definitions.NotificationTemplate, error)
-	CreateTemplate(ctx context.Context, orgID int64, tmpl definitions.NotificationTemplate) (definitions.NotificationTemplate, error)
-	UpdateTemplate(ctx context.Context, orgID int64, tmpl definitions.NotificationTemplate) (definitions.NotificationTemplate, error)
-	DeleteTemplate(ctx context.Context, orgID int64, nameOrUid string, provenance definitions.Provenance, version string) error
+	GetTemplate(ctx context.Context, orgID int64, nameOrUid string) (v1.TemplateGroup, error)
+	GetTemplates(ctx context.Context, orgID int64) ([]v1.TemplateGroup, error)
+	CreateTemplate(ctx context.Context, orgID int64, tmpl v1.TemplateGroup) (v1.TemplateGroup, error)
+	UpdateTemplate(ctx context.Context, orgID int64, tmpl v1.TemplateGroup) (v1.TemplateGroup, error)
+	DeleteTemplate(ctx context.Context, orgID int64, nameOrUid string, provenance models.Provenance, version string) error
 }
 
 type legacyStorage struct {
@@ -80,7 +80,7 @@ func (s *legacyStorage) List(ctx context.Context, opts *internalversion.ListOpti
 		return nil, err
 	}
 
-	return convertToK8sResources(orgId, append([]definitions.NotificationTemplate{defaultTemplate}, res...), s.namespacer, opts.FieldSelector)
+	return convertToK8sResources(orgId, append([]v1.TemplateGroup{defaultTemplate}, res...), s.namespacer, opts.FieldSelector)
 }
 
 func (s *legacyStorage) Get(ctx context.Context, name string, _ *metav1.GetOptions) (runtime.Object, error) {
@@ -211,23 +211,25 @@ func (s *legacyStorage) Delete(ctx context.Context, name string, deleteValidatio
 	if err != nil {
 		return nil, false, errors.NewBadRequest(err.Error())
 	}
-	err = s.service.DeleteTemplate(ctx, info.OrgID, name, definitions.Provenance(prov), version) // TODO add support for dry-run option
-	return old, false, err                                                                       // false - will be deleted async
+	err = s.service.DeleteTemplate(ctx, info.OrgID, name, prov, version) // TODO add support for dry-run option
+	return old, false, err                                               // false - will be deleted async
 }
 
-func (s *legacyStorage) defaultTemplate() (definitions.NotificationTemplate, error) {
+func (s *legacyStorage) defaultTemplate() (v1.TemplateGroup, error) {
 	// Omit some templates that we do not want to use to see.
 	defaultTemplate, err := templates.DefaultTemplate(templates.DefaultTemplatesToOmit)
 	if err != nil {
-		return definitions.NotificationTemplate{}, err
+		return v1.TemplateGroup{}, err
 	}
 
-	dto := definitions.NotificationTemplate{
-		Name:       model.DefaultTemplateTitle, // User friendly name.
-		UID:        defaultTemplate.Name,
-		Provenance: definitions.Provenance("system"),
-		Template:   defaultTemplate.Template,
-		Kind:       definition.GrafanaTemplateKind,
+	dto := v1.TemplateGroup{
+		Title: model.DefaultTemplateTitle, // User friendly name.
+		ResourceMetadata: v1.ResourceMetadata{
+			UID:        v1.ResourceUID(defaultTemplate.Name),
+			Provenance: models.Provenance("system"),
+		},
+		Content: defaultTemplate.Template,
+		Kind:    v1.TemplateKindGrafana,
 	}
 
 	return dto, nil

--- a/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt_alerts.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt_alerts.go
@@ -64,9 +64,9 @@ func (s *Service) getNotificationTemplates(ctx context.Context, signedInUser *us
 
 	for _, template := range templates {
 		notificationTemplates = append(notificationTemplates, notificationTemplate{
-			UID:      template.UID,
-			Name:     template.Name,
-			Template: template.Template,
+			UID:      string(template.UID),
+			Name:     template.Title,
+			Template: template.Content,
 		})
 	}
 

--- a/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt_alerts_test.go
+++ b/pkg/services/cloudmigration/cloudmigrationimpl/snapshot_mgmt_alerts_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	v1 "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/setting"
 )
@@ -73,7 +74,7 @@ func TestGetNotificationTemplates(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, notificationTemplates)
 		require.Len(t, notificationTemplates, 1)
-		require.Equal(t, createdTemplate.Name, notificationTemplates[0].Name)
+		require.Equal(t, createdTemplate.Title, notificationTemplates[0].Name)
 	})
 }
 
@@ -321,12 +322,12 @@ func createMuteTiming(t *testing.T, ctx context.Context, service *Service, user 
 	return createdTiming
 }
 
-func createNotificationTemplate(t *testing.T, ctx context.Context, service *Service, user *user.SignedInUser) definitions.NotificationTemplate {
+func createNotificationTemplate(t *testing.T, ctx context.Context, service *Service, user *user.SignedInUser) v1.TemplateGroup {
 	t.Helper()
 
-	tmpl := definitions.NotificationTemplate{
-		Name:     "MyTestNotificationTemplate",
-		Template: "This is a test template\n{{ .ExternalURL }}",
+	tmpl := v1.TemplateGroup{
+		Title:   "MyTestNotificationTemplate",
+		Content: "This is a test template\n{{ .ExternalURL }}",
 	}
 
 	createdTemplate, err := service.ngAlert.Api.Templates.CreateTemplate(ctx, user.GetOrgID(), tmpl)

--- a/pkg/services/ngalert/api/api_alertmanager_test.go
+++ b/pkg/services/ngalert/api/api_alertmanager_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/accesscontrol"
+	v1 "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
 
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/infra/log"
@@ -605,7 +606,7 @@ func setContactPointProvenance(t *testing.T, orgID int64, UID string, ps provisi
 // setTemplateProvenance marks a template as provisioned.
 func setTemplateProvenance(t *testing.T, orgID int64, name string, ps provisioning.ProvisioningStore) {
 	t.Helper()
-	err := ps.SetProvenance(context.Background(), &apimodels.NotificationTemplate{Name: name}, orgID, ngmodels.ProvenanceAPI)
+	err := ps.SetProvenance(context.Background(), &v1.TemplateGroup{Title: name}, orgID, ngmodels.ProvenanceAPI)
 	require.NoError(t, err)
 }
 

--- a/pkg/services/ngalert/api/api_provisioning.go
+++ b/pkg/services/ngalert/api/api_provisioning.go
@@ -20,6 +20,7 @@ import (
 	alerting_models "github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage"
+	v1 "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/util"
@@ -48,10 +49,10 @@ type ContactPointService interface {
 }
 
 type TemplateService interface {
-	GetTemplates(ctx context.Context, orgID int64) ([]definitions.NotificationTemplate, error)
-	GetTemplate(ctx context.Context, orgID int64, nameOrUid string) (definitions.NotificationTemplate, error)
-	UpsertTemplate(ctx context.Context, orgID int64, tmpl definitions.NotificationTemplate) (definitions.NotificationTemplate, error)
-	DeleteTemplate(ctx context.Context, orgID int64, nameOrUid string, provenance definitions.Provenance, version string) error
+	GetTemplates(ctx context.Context, orgID int64) ([]v1.TemplateGroup, error)
+	GetTemplate(ctx context.Context, orgID int64, nameOrUid string) (v1.TemplateGroup, error)
+	UpsertTemplate(ctx context.Context, orgID int64, tmpl v1.TemplateGroup) (v1.TemplateGroup, error)
+	DeleteTemplate(ctx context.Context, orgID int64, nameOrUid string, provenance alerting_models.Provenance, version string) error
 }
 
 type NotificationPolicyService interface {
@@ -226,7 +227,7 @@ func (srv *ProvisioningSrv) RouteGetTemplates(c *contextmodel.ReqContext) respon
 	if err != nil {
 		return response.ErrOrFallback(http.StatusInternalServerError, "", err)
 	}
-	return response.JSON(http.StatusOK, templates)
+	return response.JSON(http.StatusOK, ModelToNotificationTemplates(templates))
 }
 
 func (srv *ProvisioningSrv) RouteGetTemplate(c *contextmodel.ReqContext, nameOrUid string) response.Response {
@@ -234,26 +235,29 @@ func (srv *ProvisioningSrv) RouteGetTemplate(c *contextmodel.ReqContext, nameOrU
 	if err != nil {
 		return response.ErrOrFallback(http.StatusInternalServerError, "", err)
 	}
-	return response.JSON(http.StatusOK, template)
+	return response.JSON(http.StatusOK, ModelToNotificationTemplate(template))
 }
 
 func (srv *ProvisioningSrv) RoutePutTemplate(c *contextmodel.ReqContext, body definitions.NotificationTemplateContent, name string) response.Response {
-	tmpl := definitions.NotificationTemplate{
-		Name:            name,
-		Template:        body.Template,
-		Provenance:      determineProvenance(c),
-		ResourceVersion: body.ResourceVersion,
+	tmpl := v1.TemplateGroup{
+		Title:   name,
+		Content: body.Template,
+		Kind:    v1.TemplateKindGrafana,
+		ResourceMetadata: v1.ResourceMetadata{
+			Provenance: alerting_models.Provenance(determineProvenance(c)),
+			Version:    body.ResourceVersion,
+		},
 	}
 	modified, err := srv.templates.UpsertTemplate(c.Req.Context(), c.GetOrgID(), tmpl)
 	if err != nil {
 		return response.ErrOrFallback(http.StatusInternalServerError, "", err)
 	}
-	return response.JSON(http.StatusAccepted, modified)
+	return response.JSON(http.StatusAccepted, ModelToNotificationTemplate(modified))
 }
 
 func (srv *ProvisioningSrv) RouteDeleteTemplate(c *contextmodel.ReqContext, nameOrUid string) response.Response {
 	version := c.Query("version")
-	err := srv.templates.DeleteTemplate(c.Req.Context(), c.GetOrgID(), nameOrUid, determineProvenance(c), version)
+	err := srv.templates.DeleteTemplate(c.Req.Context(), c.GetOrgID(), nameOrUid, alerting_models.Provenance(determineProvenance(c)), version)
 	if err != nil {
 		return response.ErrOrFallback(http.StatusInternalServerError, "", err)
 	}

--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -2152,10 +2152,13 @@ func TestApiGetSnapshots(t *testing.T) {
 	cfg.AlertmanagerConfig.Route = legacy_storage.WithManagedRoutes(cfg.AlertmanagerConfig.Route, cfg.ManagedRoutes)
 
 	// Templates
-	cfg.TemplateFiles = map[string]string{
-		"templateA": "{{ define \"templateA\" }}A{{ end }}",
-		"templateB": "{{ define \"templateB\" }}B{{ end }}",
-		"templateC": "{{ define \"templateC\" }}C{{ end }}",
+	t1 := v1.NewTemplateGroup("templateA", "{{ define \"templateA\" }}A{{ end }}", v1.TemplateKindGrafana, models.ProvenanceAPI)
+	t2 := v1.NewTemplateGroup("templateB", "{{ define \"templateB\" }}B{{ end }}", v1.TemplateKindGrafana, models.ProvenanceAPI)
+	t3 := v1.NewTemplateGroup("templateC", "{{ define \"templateC\" }}C{{ end }}", v1.TemplateKindGrafana, models.ProvenanceAPI)
+	cfg.Templates = map[v1.ResourceUID]v1.TemplateGroup{
+		t1.UID: t1,
+		t2.UID: t2,
+		t3.UID: t3,
 	}
 
 	// Contact Points

--- a/pkg/services/ngalert/api/compat_templates.go
+++ b/pkg/services/ngalert/api/compat_templates.go
@@ -1,0 +1,27 @@
+package api
+
+import (
+	"github.com/grafana/alerting/definition"
+
+	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	v1 "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
+)
+
+func ModelToNotificationTemplates(tmpls []v1.TemplateGroup) []definitions.NotificationTemplate {
+	out := make([]definitions.NotificationTemplate, 0, len(tmpls))
+	for _, tmpl := range tmpls {
+		out = append(out, ModelToNotificationTemplate(tmpl))
+	}
+	return out
+}
+
+func ModelToNotificationTemplate(tmpl v1.TemplateGroup) definitions.NotificationTemplate {
+	return definitions.NotificationTemplate{
+		UID:             string(tmpl.UID),
+		Name:            tmpl.Title,
+		Template:        tmpl.Content,
+		Provenance:      definitions.Provenance(tmpl.Provenance),
+		ResourceVersion: tmpl.Version,
+		Kind:            definition.TemplateKind(tmpl.Kind),
+	}
+}

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_templates.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_templates.go
@@ -96,11 +96,3 @@ type NotificationTemplateHeaders struct {
 	// in:header
 	XDisableProvenance string `json:"X-Disable-Provenance"`
 }
-
-func (t *NotificationTemplate) ResourceType() string {
-	return "template"
-}
-
-func (t *NotificationTemplate) ResourceID() string {
-	return t.Name
-}

--- a/pkg/services/ngalert/notifier/alertmanager_config.go
+++ b/pkg/services/ngalert/notifier/alertmanager_config.go
@@ -319,7 +319,6 @@ func (moa *MultiOrgAlertmanager) gettableUserConfigFromAMConfigString(ctx contex
 	}
 
 	alertmanagerConfig := cfg.AlertmanagerConfig
-	templateFiles := cfg.TemplateFiles
 
 	if withAutogen {
 		// We validate the notification settings in a similar way to when we POST.
@@ -333,7 +332,7 @@ func (moa *MultiOrgAlertmanager) gettableUserConfigFromAMConfigString(ctx contex
 	}
 
 	result := definitions.GettableUserConfig{
-		TemplateFiles: templateFiles,
+		TemplateFiles: v1.TemplatesToTemplateFiles(cfg.Templates),
 		AlertmanagerConfig: definitions.GettableApiAlertingConfig{
 			Config: PostableApiAlertingConfigToAPI(alertmanagerConfig).Config,
 		},
@@ -556,8 +555,7 @@ func (moa *MultiOrgAlertmanager) mergeProvenance(ctx context.Context, config def
 		}
 	}
 
-	tmpl := definitions.NotificationTemplate{}
-	tmplProvs, err := moa.ProvStore.GetProvenances(ctx, org, tmpl.ResourceType())
+	tmplProvs, err := moa.ProvStore.GetProvenances(ctx, org, (&v1.TemplateGroup{}).ResourceType())
 	if err != nil {
 		return definitions.GettableUserConfig{}, nil
 	}

--- a/pkg/services/ngalert/notifier/alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/alertmanager_test.go
@@ -269,8 +269,8 @@ func TestAlertmanager_HashStabilityAndChangeDetection(t *testing.T) {
 		}
 		return &v1.AMConfigV1{
 			Templates: map[v1.ResourceUID]v1.TemplateGroup{
-				"a-template.tmpl": {Title: "a-template.tmpl", Content: "{{ define \"a\" }}a{{ end }}"},
-				"b-template.tmpl": {Title: "b-template.tmpl", Content: "{{ define \"b\" }}b{{ end }}"},
+				v1.TemplateUID(v1.TemplateKindGrafana, "a-template.tmpl"): {Title: "a-template.tmpl", Content: "{{ define \"a\" }}a{{ end }}", Kind: v1.TemplateKindGrafana},
+				v1.TemplateUID(v1.TemplateKindGrafana, "b-template.tmpl"): {Title: "b-template.tmpl", Content: "{{ define \"b\" }}b{{ end }}", Kind: v1.TemplateKindGrafana},
 			},
 			AlertmanagerConfig: v1.PostableApiAlertingConfig{
 				Config: v1.Config{
@@ -327,7 +327,8 @@ func TestAlertmanager_HashStabilityAndChangeDetection(t *testing.T) {
 				return baseConfig("default-receiver", "extra-receiver")
 			},
 			mutate: func(cfg *v1.AMConfigV1, _ map[ngmodels.AlertRuleKey]ngmodels.ContactPointRouting) {
-				cfg.Templates["new.tmpl"] = v1.TemplateGroup{Title: "new.tmpl", Content: "{{ define \"new\" }}b{{ end }}"}
+				tmpl := v1.NewTemplateGroup("new.tmpl", "{{ define \"new\" }}b{{ end }}", v1.TemplateKindGrafana, ngmodels.ProvenanceNone)
+				cfg.Templates[tmpl.UID] = tmpl
 			},
 		},
 		{

--- a/pkg/services/ngalert/notifier/alertmanager_test.go
+++ b/pkg/services/ngalert/notifier/alertmanager_test.go
@@ -168,6 +168,7 @@ func TestAlertmanager_ApplyConfig(t *testing.T) {
 		}
 	}
 
+	grafanaTmpl := v1.NewTemplateGroup("grafana-template", "{{ define \"grafana.title\" }}Alert{{ end }}", v1.TemplateKindGrafana, ngmodels.ProvenanceNone)
 	testCases := []struct {
 		name          string
 		config        *v1.AMConfigV1
@@ -178,8 +179,8 @@ func TestAlertmanager_ApplyConfig(t *testing.T) {
 			name: "basic config",
 			config: &v1.AMConfigV1{
 				AlertmanagerConfig: basicConfig(),
-				TemplateFiles: map[string]string{
-					"grafana-template": "{{ define \"grafana.title\" }}Alert{{ end }}",
+				Templates: map[v1.ResourceUID]v1.TemplateGroup{
+					grafanaTmpl.UID: grafanaTmpl,
 				},
 			},
 			skipInvalid: false,
@@ -188,8 +189,8 @@ func TestAlertmanager_ApplyConfig(t *testing.T) {
 			name: "with mimir config",
 			config: &v1.AMConfigV1{
 				AlertmanagerConfig: basicConfig(),
-				TemplateFiles: map[string]string{
-					"grafana-template": "{{ define \"grafana.title\" }}Grafana Alert{{ end }}",
+				Templates: map[v1.ResourceUID]v1.TemplateGroup{
+					grafanaTmpl.UID: grafanaTmpl,
 				},
 				ExtraConfigs: []v1.ExtraConfiguration{
 					{
@@ -247,8 +248,8 @@ receivers:
 			} else {
 				require.NoError(t, err)
 
-				templateDefs := tc.config.GetMergedTemplateDefinitions()
-				expectedTemplateCount := len(tc.config.TemplateFiles)
+				templateDefs := tc.config.SortedTemplates(true)
+				expectedTemplateCount := len(tc.config.Templates)
 				if len(tc.config.ExtraConfigs) > 0 {
 					expectedTemplateCount += len(tc.config.ExtraConfigs[0].TemplateFiles)
 				}
@@ -267,9 +268,9 @@ func TestAlertmanager_HashStabilityAndChangeDetection(t *testing.T) {
 			})
 		}
 		return &v1.AMConfigV1{
-			TemplateFiles: map[string]string{
-				"a-template.tmpl": "{{ define \"a\" }}a{{ end }}",
-				"b-template.tmpl": "{{ define \"b\" }}b{{ end }}",
+			Templates: map[v1.ResourceUID]v1.TemplateGroup{
+				"a-template.tmpl": {Title: "a-template.tmpl", Content: "{{ define \"a\" }}a{{ end }}"},
+				"b-template.tmpl": {Title: "b-template.tmpl", Content: "{{ define \"b\" }}b{{ end }}"},
 			},
 			AlertmanagerConfig: v1.PostableApiAlertingConfig{
 				Config: v1.Config{
@@ -326,7 +327,7 @@ func TestAlertmanager_HashStabilityAndChangeDetection(t *testing.T) {
 				return baseConfig("default-receiver", "extra-receiver")
 			},
 			mutate: func(cfg *v1.AMConfigV1, _ map[ngmodels.AlertRuleKey]ngmodels.ContactPointRouting) {
-				cfg.TemplateFiles["new.tmpl"] = "{{ define \"new\" }}b{{ end }}"
+				cfg.Templates["new.tmpl"] = v1.TemplateGroup{Title: "new.tmpl", Content: "{{ define \"new\" }}b{{ end }}"}
 			},
 		},
 		{
@@ -481,9 +482,9 @@ receivers:
 				require.NoError(t, err)
 				diff := cmp.Diff(firstApplied, base.AppliedConfig(), cmpopts.IgnoreUnexported(definition.Route{}, labels.Matcher{}))
 				if diff != "" {
-					t.Errorf("Unexpected change in applied config: %v", diff)
+					t.Errorf("Unexpected change in applied config after %d runs: %v", i, diff)
 				}
-				require.Falsef(t, changed, "applyConfig should not return changed=true after first run, diff:\n%s", diff)
+				require.Falsef(t, changed, "applyConfig should not return changed=true after first run, runs: %d, diff:\n%s", i, diff)
 				require.Equal(t, firstHash, am.(*alertmanager).appliedHash)
 			}
 

--- a/pkg/services/ngalert/notifier/compat.go
+++ b/pkg/services/ngalert/notifier/compat.go
@@ -67,7 +67,7 @@ func PostableAPIConfigToNotificationsConfiguration(c *v1.AMConfigV1, limits aler
 		InhibitRules:      c.AlertmanagerConfig.InhibitRules,
 		MuteTimeIntervals: ModelToMuteTimeIntervals(c.AlertmanagerConfig.MuteTimeIntervals),
 		TimeIntervals:     ModelToTimeIntervals(c.AlertmanagerConfig.TimeIntervals),
-		Templates:         alertingNotify.PostableAPITemplatesToTemplateDefinitions(c.GetMergedTemplateDefinitions()),
+		Templates:         ModelToTemplateDefinitions(c.SortedTemplates(true)),
 		Receivers:         receivers,
 		Limits:            limits,
 	}, nil
@@ -120,6 +120,25 @@ func ModelToMuteTimeIntervals(in []v1.MuteTimeInterval) []alertingNotify.MuteTim
 		})
 	}
 	return out
+}
+
+func ModelToTemplateDefinitions(ts []v1.TemplateGroup) []templates.TemplateDefinition {
+	defs := make([]templates.TemplateDefinition, 0, len(ts))
+	for _, t := range ts {
+		var kind templates.Kind
+		switch t.Kind {
+		case v1.TemplateKindGrafana:
+			kind = templates.GrafanaKind
+		case v1.TemplateKindMimir:
+			kind = templates.MimirKind
+		}
+		defs = append(defs, templates.TemplateDefinition{
+			Name:     t.Title,
+			Template: t.Content,
+			Kind:     kind,
+		})
+	}
+	return defs
 }
 
 // TODO: Temporary until DB model and API model separate. Doing it this way makes caller intent clearer.

--- a/pkg/services/ngalert/notifier/config_test.go
+++ b/pkg/services/ngalert/notifier/config_test.go
@@ -6,13 +6,16 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
+	v1 "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
 )
 
 func TestLoad(t *testing.T) {
 	tc := []struct {
 		name              string
 		rawConfig         string
-		expectedTemplates map[string]string
+		expectedTemplates map[v1.ResourceUID]v1.TemplateGroup
 		expectedError     error
 	}{
 		{
@@ -37,7 +40,7 @@ func TestLoad(t *testing.T) {
   }
 }
 `,
-			expectedTemplates: map[string]string{"email.template": "something with a pretty good content"},
+			expectedTemplates: map[v1.ResourceUID]v1.TemplateGroup{v1.TemplateUID(v1.TemplateKindGrafana, "email.template"): v1.NewTemplateGroup("email.template", "something with a pretty good content", v1.TemplateKindGrafana, ngmodels.ProvenanceNone)},
 		},
 		{
 			name:          "with an empty configuration, it is not valid.",
@@ -55,8 +58,8 @@ func TestLoad(t *testing.T) {
 				assert.Equal(t, tt.expectedError.Error(), err.Error())
 			} else {
 				require.NoError(t, err)
-				assert.NotNil(t, c.TemplateFiles)
-				assert.Equal(t, tt.expectedTemplates, c.TemplateFiles)
+				assert.NotNil(t, c.Templates)
+				assert.Equal(t, tt.expectedTemplates, c.Templates)
 			}
 		})
 	}

--- a/pkg/services/ngalert/notifier/legacy_storage/templates.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/templates.go
@@ -1,0 +1,24 @@
+package legacy_storage
+
+import v1 "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
+
+func (rev *ConfigRevision) HasTemplateWithTitle(title string) bool {
+	for _, tmpl := range rev.Config.Templates {
+		if tmpl.Title == title {
+			return true
+		}
+	}
+	return false
+}
+
+func (rev *ConfigRevision) SetTemplate(tmpl v1.TemplateGroup) v1.TemplateGroup {
+	// Ensure template UID and Version are valid and set.
+	tmpl.UID = v1.TemplateUID(tmpl.Kind, tmpl.Title)
+	tmpl.Version = v1.CalculateTemplateFingerprint(tmpl)
+	rev.Config.Templates[tmpl.UID] = tmpl
+	return tmpl
+}
+
+func (rev *ConfigRevision) DeleteTemplate(uid v1.ResourceUID) {
+	delete(rev.Config.Templates, uid)
+}

--- a/pkg/services/ngalert/notifier/legacy_storage/templates.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/templates.go
@@ -12,6 +12,9 @@ func (rev *ConfigRevision) HasTemplateWithTitle(title string) bool {
 }
 
 func (rev *ConfigRevision) SetTemplate(tmpl v1.TemplateGroup) v1.TemplateGroup {
+	if rev.Config.Templates == nil {
+		rev.Config.Templates = make(map[v1.ResourceUID]v1.TemplateGroup, 1)
+	}
 	// Ensure template UID and Version are valid and set.
 	tmpl.UID = v1.TemplateUID(tmpl.Kind, tmpl.Title)
 	tmpl.Version = v1.CalculateTemplateFingerprint(tmpl)

--- a/pkg/services/ngalert/notifier/legacy_storage/v1/common.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/v1/common.go
@@ -1,0 +1,11 @@
+package v1
+
+import "github.com/grafana/grafana/pkg/services/ngalert/models"
+
+type ResourceUID string
+
+type ResourceMetadata struct {
+	UID        ResourceUID
+	Version    string
+	Provenance models.Provenance
+}

--- a/pkg/services/ngalert/notifier/legacy_storage/v1/compat.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/v1/compat.go
@@ -15,7 +15,7 @@ func ToModel(in *definitions.PostableUserConfig) *AMConfigV1 {
 		return nil
 	}
 	return &AMConfigV1{
-		TemplateFiles:          maps.Clone(in.TemplateFiles),
+		Templates:              TemplateFilesToTemplates(in.TemplateFiles, TemplateKindGrafana),
 		AlertmanagerConfig:     PostableApiAlertingConfigToModel(in.AlertmanagerConfig),
 		ExtraConfigs:           ExtraConfigsToModel(in.ExtraConfigs),
 		ManagedRoutes:          ManagedRoutesToModel(in.ManagedRoutes),
@@ -197,7 +197,7 @@ func ToDBModel(in *AMConfigV1) *AMConfigDB {
 		return nil
 	}
 	return &AMConfigDB{
-		TemplateFiles:          maps.Clone(in.TemplateFiles),
+		TemplateFiles:          TemplatesToTemplateFiles(in.Templates),
 		AlertmanagerConfig:     PostableApiAlertingConfigToDB(in.AlertmanagerConfig),
 		ExtraConfigs:           ExtraConfigsToDB(in.ExtraConfigs),
 		ManagedRoutes:          ManagedRoutesToDB(in.ManagedRoutes),

--- a/pkg/services/ngalert/notifier/legacy_storage/v1/model.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/v1/model.go
@@ -1,6 +1,7 @@
 package v1
 
 import (
+	"cmp"
 	"errors"
 	"fmt"
 	"hash/fnv"
@@ -24,20 +25,32 @@ type AMConfigDB = definitions.PostableUserConfig // TODO: Define type explicitly
 
 // AMConfigV1 is an exact structural copy of PostableUserConfig without json tags.
 type AMConfigV1 struct {
-	TemplateFiles          map[string]string
+	Templates              map[ResourceUID]TemplateGroup
 	AlertmanagerConfig     PostableApiAlertingConfig
 	ExtraConfigs           []ExtraConfiguration
 	ManagedRoutes          ManagedRoutes
 	ManagedInhibitionRules ManagedInhibitionRules
 }
 
-// GetMergedTemplateDefinitions converts the given PostableUserConfig's TemplateFiles to a slice of Templates.
-func (c *AMConfigV1) GetMergedTemplateDefinitions() []definition.PostableApiTemplate {
-	out := definition.TemplatesMapToPostableAPITemplates(c.TemplateFiles, definition.GrafanaTemplateKind)
-	if len(c.ExtraConfigs) == 0 || len(c.ExtraConfigs[0].TemplateFiles) == 0 {
-		return out
+// SortedTemplates returns templates ordered by kind and title.
+func (c *AMConfigV1) SortedTemplates(includeImported bool) []TemplateGroup {
+	res := make([]TemplateGroup, 0, len(c.Templates))
+	for _, t := range c.Templates {
+		res = append(res, t)
 	}
-	return append(out, definition.TemplatesMapToPostableAPITemplates(c.ExtraConfigs[0].TemplateFiles, definition.MimirTemplateKind)...)
+
+	if includeImported && len(c.ExtraConfigs) > 0 {
+		for name, content := range c.ExtraConfigs[0].TemplateFiles {
+			res = append(res, NewTemplateGroup(name, content, TemplateKindMimir, models.ProvenanceConvertedPrometheus)) // Provenance shouldn't be used regardless.
+		}
+	}
+
+	return slices.SortedFunc(slices.Values(res), func(a TemplateGroup, b TemplateGroup) int {
+		return cmp.Or(
+			cmp.Compare(a.Kind, b.Kind),
+			cmp.Compare(a.Title, b.Title),
+		)
+	})
 }
 
 // GetGrafanaReceiverMap returns a map that associates UUIDs to grafana receivers

--- a/pkg/services/ngalert/notifier/legacy_storage/v1/templates.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/v1/templates.go
@@ -1,0 +1,131 @@
+package v1
+
+import (
+	"fmt"
+	"hash/fnv"
+	"regexp"
+	"strings"
+	"unsafe"
+
+	"github.com/grafana/alerting/definition"
+	"github.com/grafana/alerting/notify"
+
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+)
+
+type TemplateGroup struct {
+	ResourceMetadata
+
+	Title   string
+	Content string
+	Kind    TemplateKind
+}
+
+func (t *TemplateGroup) ResourceType() string {
+	return "template"
+}
+
+func (t *TemplateGroup) ResourceID() string {
+	return t.Title
+}
+
+type TemplateKind string
+
+const (
+	TemplateKindGrafana TemplateKind = "grafana"
+	TemplateKindMimir   TemplateKind = "mimir"
+)
+
+func (t *TemplateGroup) Validate() error {
+	if t.Title == "" {
+		return fmt.Errorf("template must have a name")
+	}
+	if t.Content == "" {
+		return fmt.Errorf("template must have content")
+	}
+
+	content := strings.TrimSpace(t.Content)
+	found, err := regexp.MatchString(`\{\{\s*define`, content)
+	if err != nil {
+		return fmt.Errorf("failed to match regex: %w", err)
+	}
+	if !found {
+		lines := strings.Split(content, "\n")
+		for i, s := range lines {
+			lines[i] = "  " + s
+		}
+		content = strings.Join(lines, "\n")
+		content = fmt.Sprintf("{{ define \"%s\" }}\n%s\n{{ end }}", t.Title, content)
+	}
+	t.Content = content
+	if t.Kind == "" {
+		t.Kind = TemplateKindGrafana
+	}
+	postable := definition.PostableApiTemplate{
+		Name:    t.Title,
+		Content: t.Content,
+		Kind:    definition.TemplateKind(t.Kind),
+	}
+	if err := postable.Validate(); err != nil {
+		return err
+	}
+	def := notify.PostableAPITemplateToTemplateDefinition(postable)
+	return def.Validate()
+}
+
+func NewTemplateGroup(name, content string, kind TemplateKind, provenance models.Provenance) TemplateGroup {
+	uid := TemplateUID(kind, name)
+	return TemplateGroup{
+		ResourceMetadata: ResourceMetadata{
+			UID:        uid,
+			Version:    calculateTemplateFingerprint(content),
+			Provenance: provenance,
+		},
+		Title:   name,
+		Content: content,
+		Kind:    kind,
+	}
+}
+
+// TemplateFilesToTemplates converts a map of template files to a map of TemplateGroups.
+// UIDs are generated deterministically based on the template name.
+func TemplateFilesToTemplates(templateFiles map[string]string, kind TemplateKind) map[ResourceUID]TemplateGroup {
+	if templateFiles == nil {
+		return nil
+	}
+
+	templates := make(map[ResourceUID]TemplateGroup, len(templateFiles))
+	for name, content := range templateFiles {
+		tmpl := NewTemplateGroup(name, content, kind, models.ProvenanceNone)
+		templates[tmpl.UID] = tmpl
+	}
+	return templates
+}
+
+// TemplatesToTemplateFiles converts a map of TemplateGroups to a map of template files.
+func TemplatesToTemplateFiles(templates map[ResourceUID]TemplateGroup) map[string]string {
+	if templates == nil {
+		return nil
+	}
+
+	templateFiles := make(map[string]string, len(templates))
+	for _, tg := range templates {
+		templateFiles[tg.Title] = tg.Content
+	}
+	return templateFiles
+}
+
+// TemplateUID generates a deterministic UID for a template based on its name.
+func TemplateUID(kind TemplateKind, name string) ResourceUID {
+	return ResourceUID(models.NameToUid(fmt.Sprintf("%s|%s", string(kind), name)))
+}
+
+func CalculateTemplateFingerprint(tmpl TemplateGroup) string {
+	return calculateTemplateFingerprint(tmpl.Content)
+}
+
+func calculateTemplateFingerprint(t string) string {
+	sum := fnv.New64()
+	_, _ = sum.Write(unsafe.Slice(unsafe.StringData(t), len(t))) //nolint:gosec
+	return fmt.Sprintf("%016x", sum.Sum64())
+}

--- a/pkg/services/ngalert/notifier/merge/merge.go
+++ b/pkg/services/ngalert/notifier/merge/merge.go
@@ -122,7 +122,7 @@ func MergeExtraConfig(_ context.Context, cfg *v1.AMConfigV1) (MergeResult, error
 	// TODO move adding managed routes and managed inhibit rules to cfg here
 
 	mergedConfig := v1.AMConfigV1{
-		TemplateFiles: cfg.TemplateFiles,
+		Templates: cfg.Templates,
 		AlertmanagerConfig: v1.PostableApiAlertingConfig{
 			Config: v1.Config{
 				Global:            nil, // Grafana does not have global.

--- a/pkg/services/ngalert/provisioning/errors.go
+++ b/pkg/services/ngalert/provisioning/errors.go
@@ -6,6 +6,7 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/errutil"
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	v1 "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
 )
 
 var ErrValidation = fmt.Errorf("invalid object specification")
@@ -115,8 +116,8 @@ func MakeErrContactPointUidExists(uid, name string) error {
 	})
 }
 
-func makeErrTemplateOrigin(t definitions.NotificationTemplate, action string) error {
-	return ErrTemplateOrigin.Build(errutil.TemplateData{Public: map[string]interface{}{"Action": action, "Name": t.Name}})
+func makeErrTemplateOrigin(t v1.TemplateGroup, action string) error {
+	return ErrTemplateOrigin.Build(errutil.TemplateData{Public: map[string]interface{}{"Action": action, "Name": t.Title}})
 }
 
 func makeErrMuteTimeIntervalOrigin(mt definitions.MuteTimeInterval, action string) error {

--- a/pkg/services/ngalert/provisioning/mute_timings_test.go
+++ b/pkg/services/ngalert/provisioning/mute_timings_test.go
@@ -379,7 +379,7 @@ func TestCreateMuteTimings(t *testing.T) {
 
 	initialConfig := func() *v1.AMConfigV1 {
 		return &v1.AMConfigV1{
-			TemplateFiles: nil,
+			Templates: nil,
 			AlertmanagerConfig: v1.PostableApiAlertingConfig{
 				Config: v1.Config{
 					MuteTimeIntervals: []v1.MuteTimeInterval{
@@ -559,7 +559,7 @@ func TestUpdateMuteTimings(t *testing.T) {
 	originalVersion := calculateMuteTimeIntervalFingerprint(original)
 	initialConfig := func() *v1.AMConfigV1 {
 		return &v1.AMConfigV1{
-			TemplateFiles: nil,
+			Templates: nil,
 			AlertmanagerConfig: v1.PostableApiAlertingConfig{
 				Config: v1.Config{
 					MuteTimeIntervals: []v1.MuteTimeInterval{
@@ -1092,7 +1092,7 @@ func TestDeleteMuteTimings(t *testing.T) {
 	usedActiveTiming := "used-active-timing"
 	initialConfig := func() *v1.AMConfigV1 {
 		return &v1.AMConfigV1{
-			TemplateFiles: nil,
+			Templates: nil,
 			AlertmanagerConfig: v1.PostableApiAlertingConfig{
 				Config: v1.Config{
 					Route: &v1.Route{

--- a/pkg/services/ngalert/provisioning/notification_policies_test.go
+++ b/pkg/services/ngalert/provisioning/notification_policies_test.go
@@ -295,8 +295,8 @@ func TestResetPolicyTree(t *testing.T) {
 	currentRevision.Config.AlertmanagerConfig.Route = &v1.Route{
 		Receiver: "receiver",
 	}
-	currentRevision.Config.TemplateFiles = map[string]string{
-		"test": "test",
+	currentRevision.Config.Templates = map[v1.ResourceUID]v1.TemplateGroup{
+		v1.TemplateUID(v1.TemplateKindGrafana, "test"): v1.NewTemplateGroup("test", "test", v1.TemplateKindGrafana, models.ProvenanceNone),
 	}
 	currentRevision.Config.AlertmanagerConfig.TimeIntervals = []v1.TimeInterval{
 		{

--- a/pkg/services/ngalert/provisioning/templates.go
+++ b/pkg/services/ngalert/provisioning/templates.go
@@ -1,21 +1,15 @@
 package provisioning
 
 import (
+	"cmp"
 	"context"
 	"errors"
-	"fmt"
-	"hash/fnv"
-	"maps"
 	"slices"
-	"sort"
-	"unsafe"
-
-	"github.com/grafana/alerting/definition"
 
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage"
+	v1 "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning/validation"
 )
 
@@ -66,215 +60,218 @@ func (t *TemplateService) WithLimitsProvider(limits LimitsProvider) *TemplateSer
 	}
 }
 
-func (t *TemplateService) GetTemplates(ctx context.Context, orgID int64) ([]definitions.NotificationTemplate, error) {
+func (t *TemplateService) GetTemplates(ctx context.Context, orgID int64) ([]v1.TemplateGroup, error) {
 	revision, err := t.configStore.Get(ctx, orgID)
 	if err != nil {
 		return nil, err
 	}
 
-	var templates []definitions.NotificationTemplate
-
-	if len(revision.Config.TemplateFiles) > 0 {
-		provenances, err := t.provenanceStore.GetProvenances(ctx, orgID, (&definitions.NotificationTemplate{}).ResourceType())
+	var templates []v1.TemplateGroup
+	if len(revision.Config.Templates) > 0 {
+		provenances, err := t.provenanceStore.GetProvenances(ctx, orgID, (&v1.TemplateGroup{}).ResourceType())
 		if err != nil {
 			return nil, err
 		}
-		templates = make([]definitions.NotificationTemplate, 0, len(revision.Config.TemplateFiles))
-		names := slices.Collect(maps.Keys(revision.Config.TemplateFiles))
-		sort.Strings(names)
-		for _, name := range names {
-			content := revision.Config.TemplateFiles[name]
-			provenance, ok := provenances[(&definitions.NotificationTemplate{Name: name}).ResourceID()]
+		templates = make([]v1.TemplateGroup, 0, len(revision.Config.Templates))
+
+		for _, tmpl := range revision.Config.Templates {
+			provenance, ok := provenances[tmpl.ResourceID()]
 			if !ok {
 				provenance = models.ProvenanceNone
 			}
-			templates = append(templates, newNotificationTemplate(name, content, provenance, definition.GrafanaTemplateKind))
+
+			tmpl.Provenance = provenance
+			templates = append(templates, tmpl)
 		}
 	}
 
-	var importedTemplates []definitions.NotificationTemplate
 	if t.includeImported && len(revision.Config.ExtraConfigs) > 0 && len(revision.Config.ExtraConfigs[0].TemplateFiles) > 0 {
-		imported := revision.Config.ExtraConfigs[0].TemplateFiles
-		importedTemplates = make([]definitions.NotificationTemplate, 0, len(imported))
-		names := slices.Collect(maps.Keys(imported))
-		sort.Strings(names)
-		for _, name := range names {
-			content := imported[name]
-			templates = append(templates, newNotificationTemplate(name, content, models.ProvenanceConvertedPrometheus, definition.MimirTemplateKind))
+		for name, content := range revision.Config.ExtraConfigs[0].TemplateFiles {
+			templates = append(templates, v1.NewTemplateGroup(name, content, v1.TemplateKindMimir, models.ProvenanceConvertedPrometheus))
 		}
 	}
-	return append(templates, importedTemplates...), nil
+
+	// Sort templates by kind then name.
+	return slices.SortedFunc(slices.Values(templates), func(a v1.TemplateGroup, b v1.TemplateGroup) int {
+		return cmp.Or(
+			cmp.Compare(a.Kind, b.Kind),
+			cmp.Compare(a.Title, b.Title),
+		)
+	}), nil
 }
 
-func (t *TemplateService) GetTemplate(ctx context.Context, orgID int64, nameOrUid string) (definitions.NotificationTemplate, error) {
+func (t *TemplateService) GetTemplate(ctx context.Context, orgID int64, nameOrUid string) (v1.TemplateGroup, error) {
 	revision, err := t.configStore.Get(ctx, orgID)
 	if err != nil {
-		return definitions.NotificationTemplate{}, err
+		return v1.TemplateGroup{}, err
 	}
 	result, found, err := t.getTemplateByName(ctx, revision, orgID, nameOrUid)
 	if err != nil {
-		return definitions.NotificationTemplate{}, err
+		return v1.TemplateGroup{}, err
 	}
 	if found {
 		return result, nil
 	}
 	result, found, err = t.getTemplateByUID(ctx, revision, orgID, nameOrUid)
 	if err != nil {
-		return definitions.NotificationTemplate{}, err
+		return v1.TemplateGroup{}, err
 	}
 	if found {
 		return result, nil
 	}
-	return definitions.NotificationTemplate{}, ErrTemplateNotFound.Errorf("")
+	return v1.TemplateGroup{}, ErrTemplateNotFound.Errorf("")
 }
 
-func (t *TemplateService) UpsertTemplate(ctx context.Context, orgID int64, tmpl definitions.NotificationTemplate) (definitions.NotificationTemplate, error) {
+// UpsertTemplate is used by the legacy provisioning API and matches by Name/Title only as the legacy provisioning API
+// does not support UIDs.
+func (t *TemplateService) UpsertTemplate(ctx context.Context, orgID int64, tmpl v1.TemplateGroup) (v1.TemplateGroup, error) {
 	err := tmpl.Validate()
 	if err != nil {
-		return definitions.NotificationTemplate{}, MakeErrTemplateInvalid(err)
+		return v1.TemplateGroup{}, MakeErrTemplateInvalid(err)
 	}
 
 	revision, err := t.configStore.Get(ctx, orgID)
 	if err != nil {
-		return definitions.NotificationTemplate{}, err
+		return v1.TemplateGroup{}, err
 	}
 
-	d, err := t.updateTemplate(ctx, revision, orgID, tmpl)
+	// Find the UID for the template with the given Title.
+	existing, found, err := t.getTemplateByName(ctx, revision, orgID, tmpl.Title)
 	if err != nil {
-		if !errors.Is(err, ErrTemplateNotFound) {
-			return d, err
-		}
-		// If template was not found, this is assumed to be a create operation except for two cases:
-		// - If a ResourceVersion is provided: we should assume that this was meant to be a conditional update operation.
-		// - If UID is provided: custom UID for templates is not currently supported, so this was meant to be an update
-		// operation without a ResourceVersion.
-		if tmpl.ResourceVersion != "" || tmpl.UID != "" {
-			return definitions.NotificationTemplate{}, ErrTemplateNotFound.Errorf("")
-		}
-		return t.createTemplate(ctx, revision, orgID, tmpl)
+		return v1.TemplateGroup{}, err
 	}
-	return d, err
+
+	if found {
+		// Update the existing template.
+		tmpl.UID = existing.UID
+		return t.updateTemplate(ctx, revision, orgID, tmpl)
+	}
+
+	// If template was not found, this is assumed to be a create operation except for two cases:
+	// - If a ResourceVersion is provided: we should assume that this was meant to be a conditional update operation.
+	// - If UID is provided: custom UID for templates is not currently supported, so this was meant to be an update
+	// operation without a ResourceVersion.
+	if tmpl.Version != "" || tmpl.UID != "" {
+		return v1.TemplateGroup{}, ErrTemplateNotFound.Errorf("")
+	}
+
+	return t.createTemplate(ctx, revision, orgID, tmpl)
 }
 
-func (t *TemplateService) CreateTemplate(ctx context.Context, orgID int64, tmpl definitions.NotificationTemplate) (definitions.NotificationTemplate, error) {
+func (t *TemplateService) CreateTemplate(ctx context.Context, orgID int64, tmpl v1.TemplateGroup) (v1.TemplateGroup, error) {
 	err := tmpl.Validate()
 	if err != nil {
-		return definitions.NotificationTemplate{}, MakeErrTemplateInvalid(err)
+		return v1.TemplateGroup{}, MakeErrTemplateInvalid(err)
 	}
-	if tmpl.Kind == definition.MimirTemplateKind {
-		return definitions.NotificationTemplate{}, MakeErrTemplateInvalid(errors.New("templates of kind 'Mimir' cannot be created"))
+	if tmpl.Kind == v1.TemplateKindMimir {
+		return v1.TemplateGroup{}, MakeErrTemplateInvalid(errors.New("templates of kind 'Mimir' cannot be created"))
 	}
-	if err := t.validator(ctx, models.ProvenanceNone, models.Provenance(tmpl.Provenance)); err != nil {
-		return definitions.NotificationTemplate{}, err
+	if err := t.validator(ctx, models.ProvenanceNone, tmpl.Provenance); err != nil {
+		return v1.TemplateGroup{}, err
 	}
 
 	revision, err := t.configStore.Get(ctx, orgID)
 	if err != nil {
-		return definitions.NotificationTemplate{}, err
+		return v1.TemplateGroup{}, err
 	}
 	return t.createTemplate(ctx, revision, orgID, tmpl)
 }
 
-func (t *TemplateService) createTemplate(ctx context.Context, revision *legacy_storage.ConfigRevision, orgID int64, tmpl definitions.NotificationTemplate) (definitions.NotificationTemplate, error) {
-	if tmpl.Kind == definition.MimirTemplateKind {
-		return definitions.NotificationTemplate{}, MakeErrTemplateInvalid(errors.New("templates of kind 'Mimir' cannot be created"))
+func (t *TemplateService) createTemplate(ctx context.Context, revision *legacy_storage.ConfigRevision, orgID int64, tmpl v1.TemplateGroup) (v1.TemplateGroup, error) {
+	if tmpl.Kind == v1.TemplateKindMimir {
+		return v1.TemplateGroup{}, MakeErrTemplateInvalid(errors.New("templates of kind 'Mimir' cannot be created"))
 	}
 
-	if revision.Config.TemplateFiles == nil {
-		revision.Config.TemplateFiles = map[string]string{}
+	if revision.Config.Templates == nil {
+		revision.Config.Templates = make(map[v1.ResourceUID]v1.TemplateGroup)
 	}
 
-	_, found := revision.Config.TemplateFiles[tmpl.Name]
-	if found {
-		return definitions.NotificationTemplate{}, ErrTemplateExists.Errorf("")
+	if revision.HasTemplateWithTitle(tmpl.Title) {
+		return v1.TemplateGroup{}, ErrTemplateExists.Errorf("")
 	}
 
 	// Validate template limits before creating (check both count and size)
-	if err := t.validateTemplateLimits(ctx, len(revision.Config.TemplateFiles), len(tmpl.Template), true); err != nil {
-		return definitions.NotificationTemplate{}, err
+	if err := t.validateTemplateLimits(ctx, len(revision.Config.Templates), len(tmpl.Content), true); err != nil {
+		return v1.TemplateGroup{}, err
 	}
 
-	revision.Config.TemplateFiles[tmpl.Name] = tmpl.Template
-
+	created := revision.SetTemplate(tmpl)
 	err := t.xact.InTransaction(ctx, func(ctx context.Context) error {
 		if err := t.configStore.Save(ctx, revision, orgID); err != nil {
 			return err
 		}
-		return t.provenanceStore.SetProvenance(ctx, &tmpl, orgID, models.Provenance(tmpl.Provenance))
+		return t.provenanceStore.SetProvenance(ctx, &created, orgID, created.Provenance)
 	})
 	if err != nil {
-		return definitions.NotificationTemplate{}, err
+		return v1.TemplateGroup{}, err
 	}
 
-	return newNotificationTemplate(tmpl.Name, tmpl.Template, models.Provenance(tmpl.Provenance), tmpl.Kind), nil
+	return created, nil
 }
 
-func (t *TemplateService) UpdateTemplate(ctx context.Context, orgID int64, tmpl definitions.NotificationTemplate) (definitions.NotificationTemplate, error) {
+func (t *TemplateService) UpdateTemplate(ctx context.Context, orgID int64, tmpl v1.TemplateGroup) (v1.TemplateGroup, error) {
 	err := tmpl.Validate()
 	if err != nil {
-		return definitions.NotificationTemplate{}, MakeErrTemplateInvalid(err)
+		return v1.TemplateGroup{}, MakeErrTemplateInvalid(err)
 	}
 
 	revision, err := t.configStore.Get(ctx, orgID)
 	if err != nil {
-		return definitions.NotificationTemplate{}, err
+		return v1.TemplateGroup{}, err
 	}
 	return t.updateTemplate(ctx, revision, orgID, tmpl)
 }
 
-func (t *TemplateService) updateTemplate(ctx context.Context, revision *legacy_storage.ConfigRevision, orgID int64, tmpl definitions.NotificationTemplate) (definitions.NotificationTemplate, error) {
-	if revision.Config.TemplateFiles == nil {
-		revision.Config.TemplateFiles = map[string]string{}
+func (t *TemplateService) updateTemplate(ctx context.Context, revision *legacy_storage.ConfigRevision, orgID int64, tmpl v1.TemplateGroup) (v1.TemplateGroup, error) {
+	if revision.Config.Templates == nil {
+		revision.Config.Templates = make(map[v1.ResourceUID]v1.TemplateGroup)
 	}
 
-	var found bool
-	var err error
-	var existing definitions.NotificationTemplate
-	// if UID is specified, look by UID.
-	if tmpl.UID != "" {
-		existing, found, err = t.getTemplateByUID(ctx, revision, orgID, tmpl.UID)
-	} else {
-		existing, found, err = t.getTemplateByName(ctx, revision, orgID, tmpl.Name)
+	if tmpl.UID == "" {
+		// Not sure if we should allow Updates from k8s API without a UID, but some existing tests indirectly verify this behaviour, so I'll leave it in for now.
+		tmpl.UID = v1.TemplateUID(tmpl.Kind, tmpl.Title)
 	}
+
+	existing, found, err := t.getTemplateByUID(ctx, revision, orgID, string(tmpl.UID))
 	if err != nil {
-		return definitions.NotificationTemplate{}, err
+		return v1.TemplateGroup{}, err
 	}
 	if !found {
-		return definitions.NotificationTemplate{}, ErrTemplateNotFound.Errorf("")
+		return v1.TemplateGroup{}, ErrTemplateNotFound.Errorf("")
 	}
 
-	if existing.Name != tmpl.Name { // if template is renamed, check if this name is already taken
-		_, ok := revision.Config.TemplateFiles[tmpl.Name]
-		if ok {
+	if existing.Title != tmpl.Title { // if template is renamed, check if this name is already taken
+		if revision.HasTemplateWithTitle(tmpl.Title) {
 			// return error if template is being renamed to one that already exists
-			return definitions.NotificationTemplate{}, ErrTemplateExists.Errorf("")
+			return v1.TemplateGroup{}, ErrTemplateExists.Errorf("")
 		}
 	}
 	if existing.Kind != tmpl.Kind {
-		return definitions.NotificationTemplate{}, MakeErrTemplateInvalid(errors.New("cannot change template kind"))
+		return v1.TemplateGroup{}, MakeErrTemplateInvalid(errors.New("cannot change template kind"))
 	}
-	if existing.Provenance == definitions.Provenance(models.ProvenanceConvertedPrometheus) {
-		return definitions.NotificationTemplate{}, makeErrTemplateOrigin(existing, "update")
+	if existing.Provenance == models.ProvenanceConvertedPrometheus {
+		return v1.TemplateGroup{}, makeErrTemplateOrigin(existing, "update")
 	}
-	if err := t.validator(ctx, models.Provenance(existing.Provenance), models.Provenance(tmpl.Provenance)); err != nil {
-		return definitions.NotificationTemplate{}, err
+	if err := t.validator(ctx, existing.Provenance, tmpl.Provenance); err != nil {
+		return v1.TemplateGroup{}, err
 	}
 
-	err = t.checkOptimisticConcurrency(existing.Name, existing.Template, models.Provenance(tmpl.Provenance), tmpl.ResourceVersion, "update")
+	err = t.checkOptimisticConcurrency(existing, tmpl.Provenance, tmpl.Version, "update")
 	if err != nil {
-		return definitions.NotificationTemplate{}, err
+		return v1.TemplateGroup{}, err
 	}
 
 	// Validate size limits before updating (count validation not needed for updates)
-	if err := t.validateTemplateLimits(ctx, 0, len(tmpl.Template), false); err != nil {
-		return definitions.NotificationTemplate{}, err
+	if err := t.validateTemplateLimits(ctx, 0, len(tmpl.Content), false); err != nil {
+		return v1.TemplateGroup{}, err
 	}
 
-	revision.Config.TemplateFiles[tmpl.Name] = tmpl.Template
+	updated := revision.SetTemplate(tmpl)
 
 	err = t.xact.InTransaction(ctx, func(ctx context.Context) error {
-		if existing.Name != tmpl.Name { // if template by was found by UID and it's name is different, then this is the rename operation. Delete old resources.
-			delete(revision.Config.TemplateFiles, existing.Name)
+		if existing.Title != updated.Title { // if template by was found by UID and it's name is different, then this is the rename operation. Delete old resources.
+			// Remove old entry. This is only needed because UID is currently computed from the title.
+			delete(revision.Config.Templates, existing.UID)
 			err := t.provenanceStore.DeleteProvenance(ctx, &existing, orgID)
 			if err != nil {
 				return err
@@ -284,17 +281,16 @@ func (t *TemplateService) updateTemplate(ctx context.Context, revision *legacy_s
 		if err := t.configStore.Save(ctx, revision, orgID); err != nil {
 			return err
 		}
-		return t.provenanceStore.SetProvenance(ctx, &tmpl, orgID, models.Provenance(tmpl.Provenance))
+		return t.provenanceStore.SetProvenance(ctx, &updated, orgID, updated.Provenance)
 	})
 	if err != nil {
-		return definitions.NotificationTemplate{}, err
+		return v1.TemplateGroup{}, err
 	}
 
-	// if name was changed, this UID needs to be recalculated
-	return newNotificationTemplate(tmpl.Name, tmpl.Template, models.Provenance(tmpl.Provenance), tmpl.Kind), nil
+	return updated, nil
 }
 
-func (t *TemplateService) DeleteTemplate(ctx context.Context, orgID int64, nameOrUid string, provenance definitions.Provenance, version string) error {
+func (t *TemplateService) DeleteTemplate(ctx context.Context, orgID int64, nameOrUid string, provenance models.Provenance, version string) error {
 	revision, err := t.configStore.Get(ctx, orgID)
 	if err != nil {
 		return err
@@ -312,21 +308,20 @@ func (t *TemplateService) DeleteTemplate(ctx context.Context, orgID int64, nameO
 	if !found {
 		return nil
 	}
-	if existing.Provenance == definitions.Provenance(models.ProvenanceConvertedPrometheus) {
+	if existing.Provenance == models.ProvenanceConvertedPrometheus {
 		return makeErrTemplateOrigin(existing, "delete")
 	}
 
-	err = t.checkOptimisticConcurrency(existing.Name, existing.Template, models.Provenance(provenance), version, "delete")
+	err = t.checkOptimisticConcurrency(existing, provenance, version, "delete")
 	if err != nil {
 		return err
 	}
 
-	if err = t.validator(ctx, models.Provenance(existing.Provenance), models.Provenance(provenance)); err != nil {
+	if err = t.validator(ctx, existing.Provenance, provenance); err != nil {
 		return err
 	}
 
-	delete(revision.Config.TemplateFiles, existing.Name)
-
+	revision.DeleteTemplate(existing.UID)
 	return t.xact.InTransaction(ctx, func(ctx context.Context) error {
 		if err := t.configStore.Save(ctx, revision, orgID); err != nil {
 			return err
@@ -335,81 +330,60 @@ func (t *TemplateService) DeleteTemplate(ctx context.Context, orgID int64, nameO
 	})
 }
 
-func (t *TemplateService) checkOptimisticConcurrency(name, currentContent string, provenance models.Provenance, desiredVersion string, action string) error {
+func (t *TemplateService) checkOptimisticConcurrency(existing v1.TemplateGroup, provenance models.Provenance, desiredVersion string, action string) error {
 	if desiredVersion == "" {
 		if provenance != models.ProvenanceFile {
 			// if version is not specified and it's not a file provisioning, emit a log message to reflect that optimistic concurrency is disabled for this request
-			t.log.Debug("ignoring optimistic concurrency check because version was not provided", "template", name, "operation", action)
+			t.log.Debug("ignoring optimistic concurrency check because version was not provided", "template", existing.Title, "operation", action)
 		}
 		return nil
 	}
-	currentVersion := calculateTemplateFingerprint(currentContent)
+	currentVersion := v1.CalculateTemplateFingerprint(existing)
 	if currentVersion != desiredVersion {
-		return ErrVersionConflict.Errorf("provided version %s of template %s does not match current version %s", desiredVersion, name, currentVersion)
+		return ErrVersionConflict.Errorf("provided version %s of template %s does not match current version %s", desiredVersion, existing.Title, currentVersion)
 	}
 	return nil
 }
 
-func calculateTemplateFingerprint(t string) string {
-	sum := fnv.New64()
-	_, _ = sum.Write(unsafe.Slice(unsafe.StringData(t), len(t))) //nolint:gosec
-	return fmt.Sprintf("%016x", sum.Sum64())
-}
-
-func newNotificationTemplate(name, content string, provenance models.Provenance, kind definition.TemplateKind) definitions.NotificationTemplate {
-	tmpl := definitions.NotificationTemplate{
-		UID:        templateUID(kind, name),
-		Name:       name,
-		Template:   content,
-		Provenance: definitions.Provenance(provenance),
-		Kind:       kind,
-	}
-	tmpl.ResourceVersion = calculateTemplateFingerprint(content)
-	return tmpl
-}
-
-func (t *TemplateService) getTemplateByName(ctx context.Context, revision *legacy_storage.ConfigRevision, orgID int64, name string) (definitions.NotificationTemplate, bool, error) {
-	existingContent, ok := revision.Config.TemplateFiles[name]
+func (t *TemplateService) getTemplateByName(ctx context.Context, revision *legacy_storage.ConfigRevision, orgID int64, name string) (v1.TemplateGroup, bool, error) {
+	existingContent, ok := revision.Config.Templates[v1.TemplateUID(v1.TemplateKindGrafana, name)]
 	if !ok {
-		return definitions.NotificationTemplate{}, false, nil
+		return v1.TemplateGroup{}, false, nil
 	}
-	provenance, err := t.provenanceStore.GetProvenance(ctx, &definitions.NotificationTemplate{Name: name}, orgID)
+	provenance, err := t.provenanceStore.GetProvenance(ctx, &existingContent, orgID)
 	if err != nil {
-		return definitions.NotificationTemplate{}, false, err
+		return v1.TemplateGroup{}, false, err
 	}
-	return newNotificationTemplate(name, existingContent, provenance, definition.GrafanaTemplateKind), true, nil
+	existingContent.Provenance = provenance
+	return existingContent, true, nil
 }
 
-func (t *TemplateService) getTemplateByUID(ctx context.Context, revision *legacy_storage.ConfigRevision, orgID int64, uid string) (definitions.NotificationTemplate, bool, error) {
-	find := func(templates map[string]string, uid string, kind definition.TemplateKind) (string, string, bool) {
+func (t *TemplateService) getTemplateByUID(ctx context.Context, revision *legacy_storage.ConfigRevision, orgID int64, uid string) (v1.TemplateGroup, bool, error) {
+	find := func(templates map[string]string, uid v1.ResourceUID, kind v1.TemplateKind) (string, string, bool) {
 		for n, tmpl := range templates {
-			if templateUID(kind, n) == uid {
+			if v1.TemplateUID(kind, n) == uid {
 				return n, tmpl, true
 			}
 		}
 		return "", "", false
 	}
-	var provenance models.Provenance
-	name, content, ok := find(revision.Config.TemplateFiles, uid, definition.GrafanaTemplateKind)
-	if !ok {
-		if t.includeImported && len(revision.Config.ExtraConfigs) > 0 {
-			name, content, ok = find(revision.Config.ExtraConfigs[0].TemplateFiles, uid, definition.MimirTemplateKind)
-			if ok {
-				return newNotificationTemplate(name, content, models.ProvenanceConvertedPrometheus, definition.MimirTemplateKind), true, nil
-			}
-		}
-		return definitions.NotificationTemplate{}, false, nil
-	}
-	var err error
-	provenance, err = t.provenanceStore.GetProvenance(ctx, &definitions.NotificationTemplate{Name: name}, orgID)
-	if err != nil {
-		return definitions.NotificationTemplate{}, false, err
-	}
-	return newNotificationTemplate(name, content, provenance, definition.GrafanaTemplateKind), true, nil
-}
 
-func templateUID(kind definition.TemplateKind, name string) string {
-	return legacy_storage.NameToUid(fmt.Sprintf("%s|%s", string(kind), name))
+	if tmpl, ok := revision.Config.Templates[v1.ResourceUID(uid)]; ok {
+		provenance, err := t.provenanceStore.GetProvenance(ctx, &tmpl, orgID)
+		if err != nil {
+			return v1.TemplateGroup{}, false, err
+		}
+		tmpl.Provenance = provenance
+		return tmpl, true, nil
+	}
+
+	if t.includeImported && len(revision.Config.ExtraConfigs) > 0 {
+		if name, content, ok := find(revision.Config.ExtraConfigs[0].TemplateFiles, v1.ResourceUID(uid), v1.TemplateKindMimir); ok {
+			return v1.NewTemplateGroup(name, content, v1.TemplateKindMimir, models.ProvenanceConvertedPrometheus), true, nil
+		}
+	}
+
+	return v1.TemplateGroup{}, false, nil
 }
 
 // validateTemplateLimits checks if creating or updating a template would exceed configured limits.

--- a/pkg/services/ngalert/provisioning/templates_test.go
+++ b/pkg/services/ngalert/provisioning/templates_test.go
@@ -6,13 +6,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/grafana/alerting/definition"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage"
 	v1 "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
@@ -25,11 +23,11 @@ func TestGetTemplates(t *testing.T) {
 	orgID := int64(1)
 	revision := &legacy_storage.ConfigRevision{
 		Config: &v1.AMConfigV1{
-			TemplateFiles: map[string]string{
+			Templates: generateTemplates(map[string]string{
 				"template1": "test1",
 				"template2": "test2",
 				"template3": "test3",
-			},
+			}, v1.TemplateKindGrafana),
 			ExtraConfigs: []v1.ExtraConfiguration{
 				{
 					Identifier: "1234",
@@ -56,30 +54,30 @@ func TestGetTemplates(t *testing.T) {
 		result, err := sut.GetTemplates(context.Background(), orgID)
 		require.NoError(t, err)
 
-		expected := []definitions.NotificationTemplate{
-			newNotificationTemplate(
+		expected := []v1.TemplateGroup{
+			v1.NewTemplateGroup(
 				"template1",
 				"test1",
+				v1.TemplateKindGrafana,
 				models.ProvenanceAPI,
-				definition.GrafanaTemplateKind,
 			),
-			newNotificationTemplate(
+			v1.NewTemplateGroup(
 				"template2",
 				"test2",
+				v1.TemplateKindGrafana,
 				models.ProvenanceFile,
-				definition.GrafanaTemplateKind,
 			),
-			newNotificationTemplate(
+			v1.NewTemplateGroup(
 				"template3",
 				"test3",
+				v1.TemplateKindGrafana,
 				models.ProvenanceNone,
-				definition.GrafanaTemplateKind,
 			),
 		}
 
 		require.EqualValues(t, expected, result)
 
-		prov.AssertCalled(t, "GetProvenances", mock.Anything, orgID, (&definitions.NotificationTemplate{}).ResourceType())
+		prov.AssertCalled(t, "GetProvenances", mock.Anything, orgID, (&v1.TemplateGroup{}).ResourceType())
 		prov.AssertExpectations(t)
 	})
 
@@ -113,42 +111,42 @@ func TestGetTemplates(t *testing.T) {
 		result, err := sut.GetTemplates(context.Background(), orgID)
 		require.NoError(t, err)
 
-		expected := []definitions.NotificationTemplate{
-			newNotificationTemplate(
+		expected := []v1.TemplateGroup{
+			v1.NewTemplateGroup(
 				"template1",
 				"test1",
+				v1.TemplateKindGrafana,
 				models.ProvenanceAPI,
-				definition.GrafanaTemplateKind,
 			),
-			newNotificationTemplate(
+			v1.NewTemplateGroup(
 				"template2",
 				"test2",
+				v1.TemplateKindGrafana,
 				models.ProvenanceFile,
-				definition.GrafanaTemplateKind,
 			),
-			newNotificationTemplate(
+			v1.NewTemplateGroup(
 				"template3",
 				"test3",
+				v1.TemplateKindGrafana,
 				models.ProvenanceNone,
-				definition.GrafanaTemplateKind,
 			),
-			newNotificationTemplate(
+			v1.NewTemplateGroup(
 				"template1",
 				"imported-test1",
+				v1.TemplateKindMimir,
 				models.ProvenanceConvertedPrometheus,
-				definition.MimirTemplateKind,
 			),
-			newNotificationTemplate(
+			v1.NewTemplateGroup(
 				"template4",
 				"imported-test4",
+				v1.TemplateKindMimir,
 				models.ProvenanceConvertedPrometheus,
-				definition.MimirTemplateKind,
 			),
 		}
 
 		require.EqualValues(t, expected, result)
 
-		prov.AssertCalled(t, "GetProvenances", mock.Anything, orgID, (&definitions.NotificationTemplate{}).ResourceType())
+		prov.AssertCalled(t, "GetProvenances", mock.Anything, orgID, (&v1.TemplateGroup{}).ResourceType())
 		prov.AssertExpectations(t)
 	})
 
@@ -194,9 +192,9 @@ func TestGetTemplate(t *testing.T) {
 	importedTemplateContent := "imported"
 	revision := &legacy_storage.ConfigRevision{
 		Config: &v1.AMConfigV1{
-			TemplateFiles: map[string]string{
+			Templates: generateTemplates(map[string]string{
 				templateName: templateContent,
-			},
+			}, v1.TemplateKindGrafana),
 			ExtraConfigs: []v1.ExtraConfiguration{
 				{
 					Identifier: "1234",
@@ -219,17 +217,17 @@ func TestGetTemplate(t *testing.T) {
 		result, err := sut.GetTemplate(context.Background(), orgID, templateName)
 		require.NoError(t, err)
 
-		expected := newNotificationTemplate(
+		expected := v1.NewTemplateGroup(
 			templateName,
 			templateContent,
+			v1.TemplateKindGrafana,
 			models.ProvenanceAPI,
-			definition.GrafanaTemplateKind,
 		)
 
 		require.Equal(t, expected, result)
 
-		prov.AssertCalled(t, "GetProvenance", mock.Anything, mock.MatchedBy(func(t *definitions.NotificationTemplate) bool {
-			return t.Name == expected.Name
+		prov.AssertCalled(t, "GetProvenance", mock.Anything, mock.MatchedBy(func(t *v1.TemplateGroup) bool {
+			return t.Title == expected.Title
 		}), orgID)
 		prov.AssertExpectations(t)
 	})
@@ -252,14 +250,14 @@ func TestGetTemplate(t *testing.T) {
 		}
 		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceNone, nil)
 
-		result, err := sut.GetTemplate(context.Background(), orgID, templateUID(definition.GrafanaTemplateKind, templateName))
+		result, err := sut.GetTemplate(context.Background(), orgID, string(v1.TemplateUID(v1.TemplateKindGrafana, templateName)))
 		require.NoError(t, err)
 
-		expected := newNotificationTemplate(
+		expected := v1.NewTemplateGroup(
 			templateName,
 			templateContent,
+			v1.TemplateKindGrafana,
 			models.ProvenanceNone,
-			definition.GrafanaTemplateKind,
 		)
 		require.Equal(t, expected, result)
 	})
@@ -271,7 +269,7 @@ func TestGetTemplate(t *testing.T) {
 			return revision, nil
 		}
 
-		uid := templateUID(definition.MimirTemplateKind, importedTemplateName)
+		uid := string(v1.TemplateUID(v1.TemplateKindMimir, importedTemplateName))
 		t.Run("should be not found without flag enabled", func(t *testing.T) {
 			_, err := sut.GetTemplate(context.Background(), orgID, uid)
 			require.ErrorIs(t, err, ErrTemplateNotFound)
@@ -280,11 +278,11 @@ func TestGetTemplate(t *testing.T) {
 		result, err := sut.WithIncludeImported().GetTemplate(context.Background(), orgID, uid)
 		require.NoError(t, err)
 
-		expected := newNotificationTemplate(
+		expected := v1.NewTemplateGroup(
 			importedTemplateName,
 			importedTemplateContent,
+			v1.TemplateKindMimir,
 			models.ProvenanceConvertedPrometheus,
-			definition.MimirTemplateKind,
 		)
 		require.Equal(t, expected, result)
 		prov.AssertExpectations(t)
@@ -337,11 +335,12 @@ func TestUpsertTemplate(t *testing.T) {
 	templateName := "template1"
 	currentTemplateContent := "test1"
 	amConfigToken := util.GenerateShortUID()
+	currentTemplate := v1.NewTemplateGroup(templateName, currentTemplateContent, v1.TemplateKindGrafana, models.ProvenanceNone)
 	revision := func() *legacy_storage.ConfigRevision {
 		return &legacy_storage.ConfigRevision{
 			Config: &v1.AMConfigV1{
-				TemplateFiles: map[string]string{
-					templateName: currentTemplateContent,
+				Templates: map[v1.ResourceUID]v1.TemplateGroup{
+					currentTemplate.UID: currentTemplate,
 				},
 			},
 			ConcurrencyToken: amConfigToken,
@@ -365,22 +364,24 @@ func TestUpsertTemplate(t *testing.T) {
 			assertInTransaction(t, ctx)
 		}).Return(nil)
 
-		tmpl := definitions.NotificationTemplate{
-			Name:            "new-template",
-			Template:        "{{ define \"test\"}} test {{ end }}",
-			Provenance:      definitions.Provenance(models.ProvenanceAPI),
-			ResourceVersion: "",
-			Kind:            definition.GrafanaTemplateKind,
+		tmpl := v1.TemplateGroup{
+			Title:   "new-template",
+			Content: "{{ define \"test\"}} test {{ end }}",
+			ResourceMetadata: v1.ResourceMetadata{
+				Provenance: models.ProvenanceAPI,
+				Version:    "",
+			},
+			Kind: v1.TemplateKindGrafana,
 		}
 
 		result, err := sut.UpsertTemplate(context.Background(), orgID, tmpl)
 
 		require.NoError(t, err)
-		require.Equal(t, newNotificationTemplate(
-			tmpl.Name,
-			tmpl.Template,
-			models.Provenance(tmpl.Provenance),
+		require.Equal(t, v1.NewTemplateGroup(
+			tmpl.Title,
+			tmpl.Content,
 			tmpl.Kind,
+			tmpl.Provenance,
 		), result)
 
 		require.Len(t, store.Calls, 2)
@@ -388,11 +389,11 @@ func TestUpsertTemplate(t *testing.T) {
 		require.Equal(t, "Save", store.Calls[1].Method)
 		saved := store.Calls[1].Args[1].(*legacy_storage.ConfigRevision)
 		assert.Equal(t, amConfigToken, saved.ConcurrencyToken)
-		assert.Contains(t, saved.Config.TemplateFiles, tmpl.Name)
-		assert.Equal(t, tmpl.Template, saved.Config.TemplateFiles[tmpl.Name])
+		assert.Contains(t, saved.Config.Templates, result.UID)
+		assert.Equal(t, result, saved.Config.Templates[result.UID])
 
-		prov.AssertCalled(t, "SetProvenance", mock.Anything, mock.MatchedBy(func(t *definitions.NotificationTemplate) bool {
-			return t.Name == tmpl.Name
+		prov.AssertCalled(t, "SetProvenance", mock.Anything, mock.MatchedBy(func(t *v1.TemplateGroup) bool {
+			return t.Title == tmpl.Title
 		}), orgID, models.ProvenanceAPI)
 	})
 
@@ -407,30 +408,32 @@ func TestUpsertTemplate(t *testing.T) {
 				assertInTransaction(t, ctx)
 			}).Return(nil)
 
-			tmpl := definitions.NotificationTemplate{
-				Name:            templateName,
-				Template:        "{{ define \"test\"}} test {{ end }}",
-				Provenance:      definitions.Provenance(models.ProvenanceAPI),
-				ResourceVersion: calculateTemplateFingerprint("test1"),
-				Kind:            definition.GrafanaTemplateKind,
+			tmpl := v1.TemplateGroup{
+				Title:   templateName,
+				Content: "{{ define \"test\"}} test {{ end }}",
+				ResourceMetadata: v1.ResourceMetadata{
+					Provenance: models.ProvenanceAPI,
+					Version:    currentTemplate.Version,
+				},
+				Kind: v1.TemplateKindGrafana,
 			}
 
 			result, err := sut.UpsertTemplate(context.Background(), orgID, tmpl)
 
 			require.NoError(t, err)
-			assert.Equal(t, newNotificationTemplate(
-				tmpl.Name,
-				tmpl.Template,
-				models.Provenance(tmpl.Provenance),
+			assert.Equal(t, v1.NewTemplateGroup(
+				tmpl.Title,
+				tmpl.Content,
 				tmpl.Kind,
+				tmpl.Provenance,
 			), result)
 
 			require.Len(t, store.Calls, 2)
 			require.Equal(t, "Save", store.Calls[1].Method)
 			saved := store.Calls[1].Args[1].(*legacy_storage.ConfigRevision)
 			assert.Equal(t, amConfigToken, saved.ConcurrencyToken)
-			assert.Contains(t, saved.Config.TemplateFiles, tmpl.Name)
-			assert.Equal(t, tmpl.Template, saved.Config.TemplateFiles[tmpl.Name])
+			assert.Contains(t, saved.Config.Templates, result.UID)
+			assert.Equal(t, result, saved.Config.Templates[result.UID])
 
 			prov.AssertExpectations(t)
 		})
@@ -444,28 +447,30 @@ func TestUpsertTemplate(t *testing.T) {
 				assertInTransaction(t, ctx)
 			}).Return(nil)
 
-			tmpl := definitions.NotificationTemplate{
-				Name:            templateName,
-				Template:        "{{ define \"test\"}} test {{ end }}",
-				Provenance:      definitions.Provenance(models.ProvenanceAPI),
-				ResourceVersion: "",
+			tmpl := v1.TemplateGroup{
+				Title:   templateName,
+				Content: "{{ define \"test\"}} test {{ end }}",
+				ResourceMetadata: v1.ResourceMetadata{
+					Provenance: models.ProvenanceAPI,
+					Version:    "",
+				},
 			}
 
 			result, err := sut.UpsertTemplate(context.Background(), orgID, tmpl)
 
 			require.NoError(t, err)
-			assert.Equal(t, newNotificationTemplate(
-				tmpl.Name,
-				tmpl.Template,
-				models.Provenance(tmpl.Provenance),
-				definition.GrafanaTemplateKind,
+			assert.Equal(t, v1.NewTemplateGroup(
+				tmpl.Title,
+				tmpl.Content,
+				v1.TemplateKindGrafana,
+				tmpl.Provenance,
 			), result)
 
 			require.Equal(t, "Save", store.Calls[1].Method)
 			saved := store.Calls[1].Args[1].(*legacy_storage.ConfigRevision)
 			assert.Equal(t, amConfigToken, saved.ConcurrencyToken)
-			assert.Contains(t, saved.Config.TemplateFiles, tmpl.Name)
-			assert.Equal(t, tmpl.Template, saved.Config.TemplateFiles[tmpl.Name])
+			assert.Contains(t, saved.Config.Templates, result.UID)
+			assert.Equal(t, result, saved.Config.Templates[result.UID])
 		})
 	})
 
@@ -478,22 +483,24 @@ func TestUpsertTemplate(t *testing.T) {
 		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceNone, nil)
 		prov.EXPECT().SaveSucceeds()
 
-		tmpl := definitions.NotificationTemplate{
-			Name:            templateName,
-			Template:        "content",
-			Provenance:      definitions.Provenance(models.ProvenanceNone),
-			ResourceVersion: calculateTemplateFingerprint(currentTemplateContent),
-			Kind:            definition.GrafanaTemplateKind,
+		tmpl := v1.TemplateGroup{
+			Title:   templateName,
+			Content: "content",
+			ResourceMetadata: v1.ResourceMetadata{
+				Provenance: models.ProvenanceNone,
+				Version:    currentTemplate.Version,
+			},
+			Kind: v1.TemplateKindGrafana,
 		}
 
 		result, _ := sut.UpsertTemplate(context.Background(), orgID, tmpl)
 
 		expectedContent := fmt.Sprintf("{{ define \"%s\" }}\n  content\n{{ end }}", templateName)
-		require.Equal(t, newNotificationTemplate(
-			tmpl.Name,
+		require.Equal(t, v1.NewTemplateGroup(
+			tmpl.Title,
 			expectedContent,
-			models.Provenance(tmpl.Provenance),
 			tmpl.Kind,
+			tmpl.Provenance,
 		), result)
 	})
 
@@ -506,9 +513,9 @@ func TestUpsertTemplate(t *testing.T) {
 		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceNone, nil)
 		prov.EXPECT().SaveSucceeds()
 
-		tmpl := definitions.NotificationTemplate{
-			Name:     "name",
-			Template: "{{ .NotAField }}",
+		tmpl := v1.TemplateGroup{
+			Title:   "name",
+			Content: "{{ .NotAField }}",
 		}
 		_, err := sut.UpsertTemplate(context.Background(), 1, tmpl)
 
@@ -519,18 +526,18 @@ func TestUpsertTemplate(t *testing.T) {
 		sut, store, prov := createTemplateServiceSut()
 
 		t.Run("empty content", func(t *testing.T) {
-			tmpl := definitions.NotificationTemplate{
-				Name:     "",
-				Template: "",
+			tmpl := v1.TemplateGroup{
+				Title:   "",
+				Content: "",
 			}
 			_, err := sut.UpsertTemplate(context.Background(), orgID, tmpl)
 			require.ErrorIs(t, err, ErrTemplateInvalid)
 		})
 
 		t.Run("invalid content", func(t *testing.T) {
-			tmpl := definitions.NotificationTemplate{
-				Name:     "",
-				Template: "{{ .MyField }",
+			tmpl := v1.TemplateGroup{
+				Title:   "",
+				Content: "{{ .MyField }",
 			}
 			_, err := sut.UpsertTemplate(context.Background(), orgID, tmpl)
 			require.ErrorIs(t, err, ErrTemplateInvalid)
@@ -555,11 +562,11 @@ func TestUpsertTemplate(t *testing.T) {
 			return expectedErr
 		}
 
-		template := definitions.NotificationTemplate{
-			Name:     "template1",
-			Template: "asdf-new",
+		template := v1.TemplateGroup{
+			Title:   "template1",
+			Content: "asdf-new",
 		}
-		template.Provenance = definitions.Provenance(models.ProvenanceNone)
+		template.Provenance = models.ProvenanceNone
 
 		_, err := sut.UpsertTemplate(context.Background(), orgID, template)
 
@@ -573,11 +580,13 @@ func TestUpsertTemplate(t *testing.T) {
 		}
 		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceNone, nil)
 
-		template := definitions.NotificationTemplate{
-			Name:            "template1",
-			Template:        "asdf-new",
-			ResourceVersion: "bad-version",
-			Provenance:      definitions.Provenance(models.ProvenanceNone),
+		template := v1.TemplateGroup{
+			Title:   "template1",
+			Content: "asdf-new",
+			ResourceMetadata: v1.ResourceMetadata{
+				Version:    "bad-version",
+				Provenance: models.ProvenanceNone,
+			},
 		}
 
 		_, err := sut.UpsertTemplate(context.Background(), orgID, template)
@@ -591,11 +600,13 @@ func TestUpsertTemplate(t *testing.T) {
 		store.GetFn = func(ctx context.Context, org int64) (*legacy_storage.ConfigRevision, error) {
 			return revision(), nil
 		}
-		template := definitions.NotificationTemplate{
-			Name:            "template2",
-			Template:        "asdf-new",
-			ResourceVersion: "version",
-			Provenance:      definitions.Provenance(models.ProvenanceNone),
+		template := v1.TemplateGroup{
+			Title:   "template2",
+			Content: "asdf-new",
+			ResourceMetadata: v1.ResourceMetadata{
+				Version:    "version",
+				Provenance: models.ProvenanceNone,
+			},
 		}
 		_, err := sut.UpsertTemplate(context.Background(), orgID, template)
 		require.ErrorIs(t, err, ErrTemplateNotFound)
@@ -606,11 +617,13 @@ func TestUpsertTemplate(t *testing.T) {
 		store.GetFn = func(ctx context.Context, org int64) (*legacy_storage.ConfigRevision, error) {
 			return revision(), nil
 		}
-		template := definitions.NotificationTemplate{
-			UID:        "new-template",
-			Name:       "template2",
-			Template:   "asdf-new",
-			Provenance: definitions.Provenance(models.ProvenanceNone),
+		template := v1.TemplateGroup{
+			Title:   "template2",
+			Content: "asdf-new",
+			ResourceMetadata: v1.ResourceMetadata{
+				UID:        "new-template",
+				Provenance: models.ProvenanceNone,
+			},
 		}
 		_, err := sut.UpsertTemplate(context.Background(), orgID, template)
 		require.ErrorIs(t, err, ErrTemplateNotFound)
@@ -621,21 +634,25 @@ func TestUpsertTemplate(t *testing.T) {
 		store.GetFn = func(ctx context.Context, org int64) (*legacy_storage.ConfigRevision, error) {
 			return revision(), nil
 		}
-		template := definitions.NotificationTemplate{
-			Name:       "template2",
-			Template:   "asdf-new",
-			Provenance: definitions.Provenance(models.ProvenanceNone),
-			Kind:       definition.MimirTemplateKind,
+		template := v1.TemplateGroup{
+			Title:   "template2",
+			Content: "asdf-new",
+			ResourceMetadata: v1.ResourceMetadata{
+				Provenance: models.ProvenanceNone,
+			},
+			Kind: v1.TemplateKindMimir,
 		}
 		_, err := sut.UpsertTemplate(context.Background(), orgID, template)
 		require.ErrorIs(t, err, ErrTemplateInvalid)
 	})
 
 	t.Run("propagates errors", func(t *testing.T) {
-		tmpl := definitions.NotificationTemplate{
-			Name:       templateName,
-			Template:   "content",
-			Provenance: definitions.Provenance(models.ProvenanceNone),
+		tmpl := v1.TemplateGroup{
+			Title:   templateName,
+			Content: "content",
+			ResourceMetadata: v1.ResourceMetadata{
+				Provenance: models.ProvenanceNone,
+			},
 		}
 		t.Run("when unable to read config", func(t *testing.T) {
 			sut, store, _ := createTemplateServiceSut()
@@ -700,11 +717,13 @@ func TestCreateTemplate(t *testing.T) {
 	orgID := int64(1)
 	amConfigToken := util.GenerateShortUID()
 
-	tmpl := definitions.NotificationTemplate{
-		Name:       "new-template",
-		Template:   "{{ define \"test\"}} test {{ end }}",
-		Provenance: definitions.Provenance(models.ProvenanceAPI),
-		Kind:       definition.GrafanaTemplateKind,
+	tmpl := v1.TemplateGroup{
+		Title:   "new-template",
+		Content: "{{ define \"test\"}} test {{ end }}",
+		ResourceMetadata: v1.ResourceMetadata{
+			Provenance: models.ProvenanceAPI,
+		},
+		Kind: v1.TemplateKindGrafana,
 	}
 
 	revision := func() *legacy_storage.ConfigRevision {
@@ -731,11 +750,11 @@ func TestCreateTemplate(t *testing.T) {
 		result, err := sut.CreateTemplate(context.Background(), orgID, tmpl)
 
 		require.NoError(t, err)
-		require.Equal(t, newNotificationTemplate(
-			tmpl.Name,
-			tmpl.Template,
-			models.Provenance(tmpl.Provenance),
+		require.Equal(t, v1.NewTemplateGroup(
+			tmpl.Title,
+			tmpl.Content,
 			tmpl.Kind,
+			tmpl.Provenance,
 		), result)
 
 		require.Len(t, store.Calls, 2)
@@ -743,11 +762,11 @@ func TestCreateTemplate(t *testing.T) {
 		require.Equal(t, "Save", store.Calls[1].Method)
 		saved := store.Calls[1].Args[1].(*legacy_storage.ConfigRevision)
 		assert.Equal(t, amConfigToken, saved.ConcurrencyToken)
-		assert.Contains(t, saved.Config.TemplateFiles, tmpl.Name)
-		assert.Equal(t, tmpl.Template, saved.Config.TemplateFiles[tmpl.Name])
+		assert.Contains(t, saved.Config.Templates, result.UID)
+		assert.Equal(t, result, saved.Config.Templates[result.UID])
 
-		prov.AssertCalled(t, "SetProvenance", mock.Anything, mock.MatchedBy(func(t *definitions.NotificationTemplate) bool {
-			return t.Name == tmpl.Name
+		prov.AssertCalled(t, "SetProvenance", mock.Anything, mock.MatchedBy(func(t *v1.TemplateGroup) bool {
+			return t.Title == tmpl.Title
 		}), orgID, models.ProvenanceAPI)
 	})
 
@@ -757,8 +776,8 @@ func TestCreateTemplate(t *testing.T) {
 			assert.Equal(t, orgID, org)
 			return &legacy_storage.ConfigRevision{
 				Config: &v1.AMConfigV1{
-					TemplateFiles: map[string]string{
-						tmpl.Name: "test",
+					Templates: map[v1.ResourceUID]v1.TemplateGroup{
+						tmpl.UID: tmpl,
 					},
 				},
 				ConcurrencyToken: amConfigToken,
@@ -774,28 +793,28 @@ func TestCreateTemplate(t *testing.T) {
 		sut, store, prov := createTemplateServiceSut()
 
 		t.Run("empty content", func(t *testing.T) {
-			tmpl := definitions.NotificationTemplate{
-				Name:     "",
-				Template: "",
+			tmpl := v1.TemplateGroup{
+				Title:   "",
+				Content: "",
 			}
 			_, err := sut.CreateTemplate(context.Background(), orgID, tmpl)
 			require.ErrorIs(t, err, ErrTemplateInvalid)
 		})
 
 		t.Run("invalid content", func(t *testing.T) {
-			tmpl := definitions.NotificationTemplate{
-				Name:     "",
-				Template: "{{ .MyField }",
+			tmpl := v1.TemplateGroup{
+				Title:   "",
+				Content: "{{ .MyField }",
 			}
 			_, err := sut.CreateTemplate(context.Background(), orgID, tmpl)
 			require.ErrorIs(t, err, ErrTemplateInvalid)
 		})
 
 		t.Run("invalid kind", func(t *testing.T) {
-			tmpl := definitions.NotificationTemplate{
-				Name:     "new-template",
-				Template: "{{ define \"test\"}} test {{ end }}",
-				Kind:     "unknown",
+			tmpl := v1.TemplateGroup{
+				Title:   "new-template",
+				Content: "{{ define \"test\"}} test {{ end }}",
+				Kind:    "unknown",
 			}
 			_, err := sut.CreateTemplate(context.Background(), orgID, tmpl)
 			require.ErrorIs(t, err, ErrTemplateInvalid)
@@ -808,10 +827,10 @@ func TestCreateTemplate(t *testing.T) {
 	t.Run("rejects templates with mimir kind", func(t *testing.T) {
 		sut, _, _ := createTemplateServiceSut()
 
-		tmpl := definitions.NotificationTemplate{
-			Name:     "new-template",
-			Template: "{{ define \"test\"}} test {{ end }}",
-			Kind:     definition.MimirTemplateKind,
+		tmpl := v1.TemplateGroup{
+			Title:   "new-template",
+			Content: "{{ define \"test\"}} test {{ end }}",
+			Kind:    v1.TemplateKindMimir,
 		}
 
 		_, err := sut.CreateTemplate(context.Background(), orgID, tmpl)
@@ -866,21 +885,23 @@ func TestUpdateTemplate(t *testing.T) {
 	orgID := int64(1)
 	currentTemplateContent := "test1"
 
-	tmpl := definitions.NotificationTemplate{
-		Name:            "template1",
-		Template:        "{{ define \"test\"}} test {{ end }}",
-		Provenance:      definitions.Provenance(models.ProvenanceAPI),
-		ResourceVersion: "",
-		Kind:            definition.GrafanaTemplateKind,
+	tmpl := v1.TemplateGroup{
+		Title:   "template1",
+		Content: "{{ define \"test\"}} test {{ end }}",
+		ResourceMetadata: v1.ResourceMetadata{
+			Provenance: models.ProvenanceAPI,
+			Version:    "",
+		},
+		Kind: v1.TemplateKindGrafana,
 	}
 
 	amConfigToken := util.GenerateShortUID()
 	revision := func() *legacy_storage.ConfigRevision {
 		return &legacy_storage.ConfigRevision{
 			Config: &v1.AMConfigV1{
-				TemplateFiles: map[string]string{
-					tmpl.Name: currentTemplateContent,
-				},
+				Templates: generateTemplates(map[string]string{
+					tmpl.Title: currentTemplateContent,
+				}, v1.TemplateKindGrafana),
 			},
 			ConcurrencyToken: amConfigToken,
 		}
@@ -909,10 +930,10 @@ func TestUpdateTemplate(t *testing.T) {
 			assert.Equal(t, orgID, org)
 			return &legacy_storage.ConfigRevision{
 				Config: &v1.AMConfigV1{
-					TemplateFiles: map[string]string{
+					Templates: generateTemplates(map[string]string{
 						"not-found": "test", // create a template with name that matches UID to make sure we do not search by name
-						tmpl.Name:   "test",
-					},
+						tmpl.Title:  "test",
+					}, v1.TemplateKindGrafana),
 				},
 				ConcurrencyToken: amConfigToken,
 			}, nil
@@ -929,7 +950,7 @@ func TestUpdateTemplate(t *testing.T) {
 
 	testcases := []struct {
 		name        string
-		templateUid string
+		templateUid v1.ResourceUID
 	}{
 		{
 			name:        "by name",
@@ -937,7 +958,7 @@ func TestUpdateTemplate(t *testing.T) {
 		},
 		{
 			name:        "by uid",
-			templateUid: templateUID(tmpl.Kind, tmpl.Name),
+			templateUid: v1.TemplateUID(tmpl.Kind, tmpl.Title),
 		},
 	}
 
@@ -957,19 +978,19 @@ func TestUpdateTemplate(t *testing.T) {
 				result, err := sut.UpdateTemplate(context.Background(), orgID, tmpl)
 
 				require.NoError(t, err)
-				assert.Equal(t, newNotificationTemplate(
-					tmpl.Name,
-					tmpl.Template,
-					models.Provenance(tmpl.Provenance),
+				assert.Equal(t, v1.NewTemplateGroup(
+					tmpl.Title,
+					tmpl.Content,
 					tmpl.Kind,
+					tmpl.Provenance,
 				), result)
 
 				require.Len(t, store.Calls, 2)
 				require.Equal(t, "Save", store.Calls[1].Method)
 				saved := store.Calls[1].Args[1].(*legacy_storage.ConfigRevision)
 				assert.Equal(t, amConfigToken, saved.ConcurrencyToken)
-				assert.Contains(t, saved.Config.TemplateFiles, tmpl.Name)
-				assert.Equal(t, tmpl.Template, saved.Config.TemplateFiles[tmpl.Name])
+				assert.Contains(t, saved.Config.Templates, result.UID)
+				assert.Equal(t, result, saved.Config.Templates[result.UID])
 
 				prov.AssertExpectations(t)
 			})
@@ -986,18 +1007,18 @@ func TestUpdateTemplate(t *testing.T) {
 				result, err := sut.UpdateTemplate(context.Background(), orgID, tmpl)
 
 				require.NoError(t, err)
-				assert.Equal(t, newNotificationTemplate(
-					tmpl.Name,
-					tmpl.Template,
-					models.Provenance(tmpl.Provenance),
+				assert.Equal(t, v1.NewTemplateGroup(
+					tmpl.Title,
+					tmpl.Content,
 					tmpl.Kind,
+					tmpl.Provenance,
 				), result)
 
 				require.Equal(t, "Save", store.Calls[1].Method)
 				saved := store.Calls[1].Args[1].(*legacy_storage.ConfigRevision)
 				assert.Equal(t, amConfigToken, saved.ConcurrencyToken)
-				assert.Contains(t, saved.Config.TemplateFiles, tmpl.Name)
-				assert.Equal(t, tmpl.Template, saved.Config.TemplateFiles[tmpl.Name])
+				assert.Contains(t, saved.Config.Templates, result.UID)
+				assert.Equal(t, result, saved.Config.Templates[result.UID])
 			})
 		})
 	}
@@ -1015,30 +1036,30 @@ func TestUpdateTemplate(t *testing.T) {
 			assertInTransaction(t, ctx)
 		}).Return(nil)
 
-		oldName := tmpl.Name
+		oldName := tmpl.Title
 		tmpl := tmpl
-		tmpl.UID = templateUID(tmpl.Kind, tmpl.Name) // UID matches the current template
-		tmpl.Name = "new-template-name"              // but name is different
+		tmpl.UID = v1.TemplateUID(tmpl.Kind, tmpl.Title) // UID matches the current template
+		tmpl.Title = "new-template-name"                 // but name is different
 		result, err := sut.UpdateTemplate(context.Background(), orgID, tmpl)
 
 		require.NoError(t, err)
-		assert.Equal(t, newNotificationTemplate(
-			tmpl.Name,
-			tmpl.Template,
-			models.Provenance(tmpl.Provenance),
+		assert.Equal(t, v1.NewTemplateGroup(
+			tmpl.Title,
+			tmpl.Content,
 			tmpl.Kind,
+			tmpl.Provenance,
 		), result)
 
 		require.Len(t, store.Calls, 2)
 		require.Equal(t, "Save", store.Calls[1].Method)
 		saved := store.Calls[1].Args[1].(*legacy_storage.ConfigRevision)
 		assert.Equal(t, amConfigToken, saved.ConcurrencyToken)
-		assert.Contains(t, saved.Config.TemplateFiles, tmpl.Name)
-		assert.Equal(t, tmpl.Template, saved.Config.TemplateFiles[tmpl.Name])
-		assert.NotContains(t, saved.Config.TemplateFiles, oldName)
+		assert.Contains(t, saved.Config.Templates, result.UID)
+		assert.Equal(t, result, saved.Config.Templates[result.UID])
+		assert.NotContains(t, saved.Config.Templates, v1.TemplateUID(tmpl.Kind, oldName))
 
-		prov.AssertCalled(t, "DeleteProvenance", mock.Anything, mock.MatchedBy(func(t *definitions.NotificationTemplate) bool {
-			return t.Name == oldName
+		prov.AssertCalled(t, "DeleteProvenance", mock.Anything, mock.MatchedBy(func(t *v1.TemplateGroup) bool {
+			return t.Title == oldName
 		}), mock.Anything)
 		prov.AssertExpectations(t)
 	})
@@ -1049,18 +1070,18 @@ func TestUpdateTemplate(t *testing.T) {
 		store.GetFn = func(ctx context.Context, org int64) (*legacy_storage.ConfigRevision, error) {
 			return &legacy_storage.ConfigRevision{
 				Config: &v1.AMConfigV1{
-					TemplateFiles: map[string]string{
-						tmpl.Name:           currentTemplateContent,
+					Templates: generateTemplates(map[string]string{
+						tmpl.Title:          currentTemplateContent,
 						"new-template-name": "test",
-					},
+					}, v1.TemplateKindGrafana),
 				},
 				ConcurrencyToken: amConfigToken,
 			}, nil
 		}
 
 		tmpl := tmpl
-		tmpl.UID = templateUID(tmpl.Kind, tmpl.Name) // UID matches the current template
-		tmpl.Name = "new-template-name"              // but name matches another existing template
+		tmpl.UID = v1.TemplateUID(tmpl.Kind, tmpl.Title) // UID matches the current template
+		tmpl.Title = "new-template-name"                 // but name matches another existing template
 		_, err := sut.UpdateTemplate(context.Background(), orgID, tmpl)
 
 		require.ErrorIs(t, err, ErrTemplateExists)
@@ -1072,28 +1093,28 @@ func TestUpdateTemplate(t *testing.T) {
 		sut, store, prov := createTemplateServiceSut()
 
 		t.Run("empty content", func(t *testing.T) {
-			tmpl := definitions.NotificationTemplate{
-				Name:     "",
-				Template: "",
+			tmpl := v1.TemplateGroup{
+				Title:   "",
+				Content: "",
 			}
 			_, err := sut.UpdateTemplate(context.Background(), orgID, tmpl)
 			require.ErrorIs(t, err, ErrTemplateInvalid)
 		})
 
 		t.Run("invalid content", func(t *testing.T) {
-			tmpl := definitions.NotificationTemplate{
-				Name:     "",
-				Template: "{{ .MyField }",
+			tmpl := v1.TemplateGroup{
+				Title:   "",
+				Content: "{{ .MyField }",
 			}
 			_, err := sut.UpdateTemplate(context.Background(), orgID, tmpl)
 			require.ErrorIs(t, err, ErrTemplateInvalid)
 		})
 
 		t.Run("invalid kind", func(t *testing.T) {
-			tmpl := definitions.NotificationTemplate{
-				Name:     "",
-				Template: "",
-				Kind:     "unknown",
+			tmpl := v1.TemplateGroup{
+				Title:   "",
+				Content: "",
+				Kind:    "unknown",
 			}
 			_, err := sut.UpdateTemplate(context.Background(), orgID, tmpl)
 			require.ErrorIs(t, err, ErrTemplateInvalid)
@@ -1118,11 +1139,11 @@ func TestUpdateTemplate(t *testing.T) {
 			return expectedErr
 		}
 
-		template := definitions.NotificationTemplate{
-			Name:     "template1",
-			Template: "asdf-new",
+		template := v1.TemplateGroup{
+			Title:   "template1",
+			Content: "asdf-new",
 		}
-		template.Provenance = definitions.Provenance(models.ProvenanceNone)
+		template.Provenance = models.ProvenanceNone
 
 		_, err := sut.UpdateTemplate(context.Background(), orgID, template)
 
@@ -1136,11 +1157,13 @@ func TestUpdateTemplate(t *testing.T) {
 		}
 		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceNone, nil)
 
-		template := definitions.NotificationTemplate{
-			Name:            "template1",
-			Template:        "asdf-new",
-			ResourceVersion: "bad-version",
-			Provenance:      definitions.Provenance(models.ProvenanceNone),
+		template := v1.TemplateGroup{
+			Title:   "template1",
+			Content: "asdf-new",
+			ResourceMetadata: v1.ResourceMetadata{
+				Version:    "bad-version",
+				Provenance: models.ProvenanceNone,
+			},
 		}
 
 		_, err := sut.UpdateTemplate(context.Background(), orgID, template)
@@ -1156,12 +1179,15 @@ func TestUpdateTemplate(t *testing.T) {
 		}
 		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceNone, nil)
 
-		template := definitions.NotificationTemplate{
-			Name:            "template1",
-			Template:        "asdf-new",
-			ResourceVersion: "bad-version",
-			Provenance:      definitions.Provenance(models.ProvenanceNone),
-			Kind:            definition.MimirTemplateKind,
+		template := v1.TemplateGroup{
+			Title:   "template1",
+			Content: "asdf-new",
+			ResourceMetadata: v1.ResourceMetadata{
+				UID:        v1.TemplateUID(v1.TemplateKindGrafana, "template1"),
+				Version:    "bad-version",
+				Provenance: models.ProvenanceNone,
+			},
+			Kind: v1.TemplateKindMimir,
 		}
 
 		_, err := sut.UpdateTemplate(context.Background(), orgID, template)
@@ -1234,13 +1260,14 @@ func TestDeleteTemplate(t *testing.T) {
 	orgID := int64(1)
 	templateName := "template1"
 	templateContent := "test-1"
-	templateVersion := calculateTemplateFingerprint(templateContent)
+	tmplToDelete := v1.NewTemplateGroup(templateName, templateContent, v1.TemplateKindGrafana, models.ProvenanceNone)
+	templateVersion := tmplToDelete.Version
 	amConfigToken := util.GenerateShortUID()
 	revision := func() *legacy_storage.ConfigRevision {
 		return &legacy_storage.ConfigRevision{
 			Config: &v1.AMConfigV1{
-				TemplateFiles: map[string]string{
-					templateName: templateContent,
+				Templates: map[v1.ResourceUID]v1.TemplateGroup{
+					tmplToDelete.UID: tmplToDelete,
 				},
 			},
 			ConcurrencyToken: amConfigToken,
@@ -1257,7 +1284,7 @@ func TestDeleteTemplate(t *testing.T) {
 		},
 		{
 			name:              "by uid",
-			templateNameOrUid: templateUID(definition.GrafanaTemplateKind, templateName),
+			templateNameOrUid: string(tmplToDelete.UID),
 		},
 	}
 	for _, tt := range testCase {
@@ -1272,7 +1299,7 @@ func TestDeleteTemplate(t *testing.T) {
 					assertInTransaction(t, ctx)
 				}).Return(nil)
 
-				err := sut.DeleteTemplate(context.Background(), orgID, tt.templateNameOrUid, definitions.Provenance(models.ProvenanceFile), templateVersion)
+				err := sut.DeleteTemplate(context.Background(), orgID, tt.templateNameOrUid, models.ProvenanceFile, templateVersion)
 
 				require.NoError(t, err)
 
@@ -1281,10 +1308,10 @@ func TestDeleteTemplate(t *testing.T) {
 				require.Equal(t, "Save", store.Calls[1].Method)
 				saved := store.Calls[1].Args[1].(*legacy_storage.ConfigRevision)
 				assert.Equal(t, amConfigToken, saved.ConcurrencyToken)
-				assert.NotContains(t, saved.Config.TemplateFiles, templateName)
+				assert.NotContains(t, saved.Config.Templates, tmplToDelete.UID)
 
-				prov.AssertCalled(t, "DeleteProvenance", mock.Anything, mock.MatchedBy(func(t *definitions.NotificationTemplate) bool {
-					return t.Name == templateName
+				prov.AssertCalled(t, "DeleteProvenance", mock.Anything, mock.MatchedBy(func(t *v1.TemplateGroup) bool {
+					return t.Title == templateName
 				}), orgID)
 
 				prov.AssertExpectations(t)
@@ -1300,7 +1327,7 @@ func TestDeleteTemplate(t *testing.T) {
 					assertInTransaction(t, ctx)
 				}).Return(nil)
 
-				err := sut.DeleteTemplate(context.Background(), orgID, tt.templateNameOrUid, definitions.Provenance(models.ProvenanceFile), "")
+				err := sut.DeleteTemplate(context.Background(), orgID, tt.templateNameOrUid, models.ProvenanceFile, "")
 
 				require.NoError(t, err)
 				require.Len(t, store.Calls, 2)
@@ -1308,10 +1335,10 @@ func TestDeleteTemplate(t *testing.T) {
 				require.Equal(t, "Save", store.Calls[1].Method)
 				saved := store.Calls[1].Args[1].(*legacy_storage.ConfigRevision)
 				assert.Equal(t, amConfigToken, saved.ConcurrencyToken)
-				assert.NotContains(t, saved.Config.TemplateFiles, templateName)
+				assert.NotContains(t, saved.Config.Templates, tmplToDelete.UID)
 
-				prov.AssertCalled(t, "DeleteProvenance", mock.Anything, mock.MatchedBy(func(t *definitions.NotificationTemplate) bool {
-					return t.Name == templateName
+				prov.AssertCalled(t, "DeleteProvenance", mock.Anything, mock.MatchedBy(func(t *v1.TemplateGroup) bool {
+					return t.Title == templateName
 				}), orgID)
 
 				prov.AssertExpectations(t)
@@ -1320,14 +1347,16 @@ func TestDeleteTemplate(t *testing.T) {
 	}
 
 	t.Run("should look by name before uid", func(t *testing.T) {
-		expectedToDelete := templateUID(definition.GrafanaTemplateKind, templateName)
+		expectedToKeep := v1.NewTemplateGroup(templateName, templateContent, v1.TemplateKindGrafana, models.ProvenanceNone)
+		// This template has a name that is the UID of expectedToKeep.
+		expectedToDelete := v1.NewTemplateGroup(string(v1.TemplateUID(v1.TemplateKindGrafana, templateName)), templateContent, v1.TemplateKindGrafana, models.ProvenanceNone)
 		sut, store, prov := createTemplateServiceSut()
 		store.GetFn = func(ctx context.Context, orgID int64) (*legacy_storage.ConfigRevision, error) {
 			return &legacy_storage.ConfigRevision{
 				Config: &v1.AMConfigV1{
-					TemplateFiles: map[string]string{
-						templateName:     templateContent,
-						expectedToDelete: templateContent,
+					Templates: map[v1.ResourceUID]v1.TemplateGroup{
+						expectedToKeep.UID:   expectedToKeep,
+						expectedToDelete.UID: expectedToDelete,
 					},
 				},
 				ConcurrencyToken: amConfigToken,
@@ -1338,7 +1367,7 @@ func TestDeleteTemplate(t *testing.T) {
 			assertInTransaction(t, ctx)
 		}).Return(nil)
 
-		err := sut.DeleteTemplate(context.Background(), orgID, expectedToDelete, definitions.Provenance(models.ProvenanceFile), templateVersion)
+		err := sut.DeleteTemplate(context.Background(), orgID, expectedToDelete.Title, models.ProvenanceFile, templateVersion)
 
 		require.NoError(t, err)
 
@@ -1347,11 +1376,11 @@ func TestDeleteTemplate(t *testing.T) {
 		require.Equal(t, "Save", store.Calls[1].Method)
 		saved := store.Calls[1].Args[1].(*legacy_storage.ConfigRevision)
 		assert.Equal(t, amConfigToken, saved.ConcurrencyToken)
-		assert.NotContains(t, saved.Config.TemplateFiles, expectedToDelete)
-		assert.Contains(t, saved.Config.TemplateFiles, templateName)
+		assert.NotContains(t, saved.Config.Templates, expectedToDelete.UID)
+		assert.Contains(t, saved.Config.Templates, expectedToKeep.UID)
 
-		prov.AssertCalled(t, "DeleteProvenance", mock.Anything, mock.MatchedBy(func(t *definitions.NotificationTemplate) bool {
-			return t.Name == expectedToDelete
+		prov.AssertCalled(t, "DeleteProvenance", mock.Anything, mock.MatchedBy(func(t *v1.TemplateGroup) bool {
+			return t.Title == expectedToDelete.Title
 		}), orgID)
 
 		prov.AssertExpectations(t)
@@ -1363,7 +1392,7 @@ func TestDeleteTemplate(t *testing.T) {
 			return revision(), nil
 		}
 
-		err := sut.DeleteTemplate(context.Background(), orgID, "not-found", definitions.Provenance(models.ProvenanceNone), "")
+		err := sut.DeleteTemplate(context.Background(), orgID, "not-found", models.ProvenanceNone, "")
 
 		require.NoError(t, err)
 
@@ -1384,7 +1413,7 @@ func TestDeleteTemplate(t *testing.T) {
 			return expectedErr
 		}
 
-		err := sut.DeleteTemplate(context.Background(), 1, templateName, definitions.Provenance(models.ProvenanceNone), "")
+		err := sut.DeleteTemplate(context.Background(), 1, templateName, models.ProvenanceNone, "")
 
 		require.ErrorIs(t, err, expectedErr)
 
@@ -1398,7 +1427,7 @@ func TestDeleteTemplate(t *testing.T) {
 		}
 		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceAPI, nil)
 
-		err := sut.DeleteTemplate(context.Background(), 1, templateName, definitions.Provenance(models.ProvenanceNone), "bad-version")
+		err := sut.DeleteTemplate(context.Background(), 1, templateName, models.ProvenanceNone, "bad-version")
 
 		require.ErrorIs(t, err, ErrVersionConflict)
 	})
@@ -1411,7 +1440,7 @@ func TestDeleteTemplate(t *testing.T) {
 				return nil, expectedErr
 			}
 
-			err := sut.DeleteTemplate(context.Background(), orgID, templateName, definitions.Provenance(models.ProvenanceNone), templateVersion)
+			err := sut.DeleteTemplate(context.Background(), orgID, templateName, models.ProvenanceNone, templateVersion)
 
 			require.ErrorIs(t, err, expectedErr)
 
@@ -1426,7 +1455,7 @@ func TestDeleteTemplate(t *testing.T) {
 			expectedErr := errors.New("test")
 			prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceNone, expectedErr)
 
-			err := sut.DeleteTemplate(context.Background(), orgID, templateName, definitions.Provenance(models.ProvenanceNone), templateVersion)
+			err := sut.DeleteTemplate(context.Background(), orgID, templateName, models.ProvenanceNone, templateVersion)
 
 			require.ErrorIs(t, err, expectedErr)
 
@@ -1442,7 +1471,7 @@ func TestDeleteTemplate(t *testing.T) {
 			prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceNone, nil)
 			prov.EXPECT().DeleteProvenance(mock.Anything, mock.Anything, mock.Anything).Return(expectedErr)
 
-			err := sut.DeleteTemplate(context.Background(), orgID, templateName, definitions.Provenance(models.ProvenanceNone), templateVersion)
+			err := sut.DeleteTemplate(context.Background(), orgID, templateName, models.ProvenanceNone, templateVersion)
 
 			require.ErrorIs(t, err, expectedErr)
 
@@ -1460,7 +1489,7 @@ func TestDeleteTemplate(t *testing.T) {
 			}
 			prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceNone, nil)
 
-			err := sut.DeleteTemplate(context.Background(), orgID, templateName, definitions.Provenance(models.ProvenanceNone), templateVersion)
+			err := sut.DeleteTemplate(context.Background(), orgID, templateName, models.ProvenanceNone, templateVersion)
 
 			require.ErrorIs(t, err, expectedErr)
 		})
@@ -1484,21 +1513,17 @@ func TestTemplateService_LimitsValidation(t *testing.T) {
 	orgID := int64(1)
 	amConfigToken := util.GenerateShortUID()
 
-	tmpl := definitions.NotificationTemplate{
-		Name:       "new-template",
-		Template:   "{{ define \"test\"}} test {{ end }}",
-		Provenance: definitions.Provenance(models.ProvenanceAPI),
-		Kind:       definition.GrafanaTemplateKind,
-	}
+	newTmpl := v1.NewTemplateGroup("new-template", "{{ define \"test\"}} test {{ end }}", v1.TemplateKindGrafana, models.ProvenanceAPI)
 
 	revision := func(existingCount int) *legacy_storage.ConfigRevision {
-		templates := make(map[string]string, existingCount)
+		templates := make(map[v1.ResourceUID]v1.TemplateGroup, existingCount)
 		for i := 0; i < existingCount; i++ {
-			templates[fmt.Sprintf("existing-%d", i)] = "content"
+			tmpl := v1.NewTemplateGroup(fmt.Sprintf("existing-%d", i), "content", v1.TemplateKindGrafana, models.ProvenanceNone)
+			templates[tmpl.UID] = tmpl
 		}
 		return &legacy_storage.ConfigRevision{
 			Config: &v1.AMConfigV1{
-				TemplateFiles: templates,
+				Templates: templates,
 			},
 			ConcurrencyToken: amConfigToken,
 		}
@@ -1518,7 +1543,7 @@ func TestTemplateService_LimitsValidation(t *testing.T) {
 			return revision(5), nil // Already at the limit
 		}
 
-		_, err := sut.CreateTemplate(context.Background(), orgID, tmpl)
+		_, err := sut.CreateTemplate(context.Background(), orgID, newTmpl)
 
 		require.ErrorIs(t, err, ErrTemplateLimitExceeded)
 	})
@@ -1537,8 +1562,8 @@ func TestTemplateService_LimitsValidation(t *testing.T) {
 			return revision(0), nil
 		}
 
-		largeTmpl := tmpl
-		largeTmpl.Template = "{{ define \"test\"}} this is a very long template content {{ end }}"
+		largeTmpl := newTmpl
+		largeTmpl.Content = "{{ define \"test\"}} this is a very long template content {{ end }}"
 
 		_, err := sut.CreateTemplate(context.Background(), orgID, largeTmpl)
 
@@ -1560,7 +1585,7 @@ func TestTemplateService_LimitsValidation(t *testing.T) {
 		}
 		prov.EXPECT().SetProvenance(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-		_, err := sut.CreateTemplate(context.Background(), orgID, tmpl)
+		_, err := sut.CreateTemplate(context.Background(), orgID, newTmpl)
 
 		require.NoError(t, err)
 	})
@@ -1575,7 +1600,7 @@ func TestTemplateService_LimitsValidation(t *testing.T) {
 		}
 		prov.EXPECT().SetProvenance(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-		_, err := sut.CreateTemplate(context.Background(), orgID, tmpl)
+		_, err := sut.CreateTemplate(context.Background(), orgID, newTmpl)
 
 		require.NoError(t, err)
 	})
@@ -1595,7 +1620,7 @@ func TestTemplateService_LimitsValidation(t *testing.T) {
 		}
 		prov.EXPECT().SetProvenance(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-		_, err := sut.CreateTemplate(context.Background(), orgID, tmpl)
+		_, err := sut.CreateTemplate(context.Background(), orgID, newTmpl)
 
 		require.NoError(t, err)
 	})
@@ -1610,7 +1635,7 @@ func TestTemplateService_LimitsValidation(t *testing.T) {
 		}
 		prov.EXPECT().SetProvenance(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-		_, err := sut.CreateTemplate(context.Background(), orgID, tmpl)
+		_, err := sut.CreateTemplate(context.Background(), orgID, newTmpl)
 
 		require.NoError(t, err)
 	})
@@ -1629,18 +1654,18 @@ func TestTemplateService_LimitsValidation(t *testing.T) {
 		store.GetFn = func(ctx context.Context, org int64) (*legacy_storage.ConfigRevision, error) {
 			return &legacy_storage.ConfigRevision{
 				Config: &v1.AMConfigV1{
-					TemplateFiles: map[string]string{
+					Templates: generateTemplates(map[string]string{
 						existingTemplateName: "short",
-					},
+					}, v1.TemplateKindGrafana),
 				},
 				ConcurrencyToken: amConfigToken,
 			}, nil
 		}
 		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceNone, nil)
 
-		largeTmpl := definitions.NotificationTemplate{
-			Name:     existingTemplateName,
-			Template: "{{ define \"test\"}} this is a very long template content that exceeds the limit {{ end }}",
+		largeTmpl := v1.TemplateGroup{
+			Title:   existingTemplateName,
+			Content: "{{ define \"test\"}} this is a very long template content that exceeds the limit {{ end }}",
 		}
 
 		_, err := sut.UpdateTemplate(context.Background(), orgID, largeTmpl)
@@ -1650,7 +1675,7 @@ func TestTemplateService_LimitsValidation(t *testing.T) {
 
 	t.Run("UpdateTemplate does not check count limit", func(t *testing.T) {
 		sut, store, prov := createTemplateServiceSut()
-		existingTemplateName := "existing-template"
+		existingTemplateName := "existing-1"
 		sut.limitsProvider = &mockLimitsProvider{
 			limits: &client.TenantLimits{
 				Templates: &client.TemplateLimits{
@@ -1660,25 +1685,15 @@ func TestTemplateService_LimitsValidation(t *testing.T) {
 			},
 		}
 		// Create a revision with many templates (over the count limit)
-		templates := make(map[string]string, 100)
-		templates[existingTemplateName] = "short"
-		for i := 0; i < 99; i++ {
-			templates[fmt.Sprintf("template-%d", i)] = "content"
-		}
 		store.GetFn = func(ctx context.Context, org int64) (*legacy_storage.ConfigRevision, error) {
-			return &legacy_storage.ConfigRevision{
-				Config: &v1.AMConfigV1{
-					TemplateFiles: templates,
-				},
-				ConcurrencyToken: amConfigToken,
-			}, nil
+			return revision(99), nil
 		}
 		prov.EXPECT().GetProvenance(mock.Anything, mock.Anything, mock.Anything).Return(models.ProvenanceNone, nil)
 		prov.EXPECT().SetProvenance(mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
-		updateTmpl := definitions.NotificationTemplate{
-			Name:     existingTemplateName,
-			Template: "{{ define \"test\"}} updated content {{ end }}",
+		updateTmpl := v1.TemplateGroup{
+			Title:   existingTemplateName,
+			Content: "{{ define \"test\"}} updated content {{ end }}",
 		}
 
 		// Update should succeed because count limit doesn't apply to updates
@@ -1696,4 +1711,13 @@ type mockLimitsProvider struct {
 
 func (m *mockLimitsProvider) GetLimits(_ context.Context) (*client.TenantLimits, error) {
 	return m.limits, m.err
+}
+
+func generateTemplates(templates map[string]string, kind v1.TemplateKind) map[v1.ResourceUID]v1.TemplateGroup {
+	templatesUIDs := make(map[v1.ResourceUID]v1.TemplateGroup, len(templates))
+	for name, content := range templates {
+		tmpl := v1.NewTemplateGroup(name, content, kind, models.ProvenanceNone)
+		templatesUIDs[tmpl.UID] = tmpl
+	}
+	return templatesUIDs
 }

--- a/pkg/services/provisioning/alerting/text_templates.go
+++ b/pkg/services/provisioning/alerting/text_templates.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/grafana/grafana/pkg/infra/log"
-	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	"github.com/grafana/grafana/pkg/services/ngalert/provisioning"
 )
@@ -31,7 +30,7 @@ func (c *defaultTextTemplateProvisioner) Provision(ctx context.Context,
 	files []*AlertingFile) error {
 	for _, file := range files {
 		for _, template := range file.Templates {
-			template.Data.Provenance = definitions.Provenance(models.ProvenanceFile)
+			template.Data.Provenance = models.ProvenanceFile
 			_, err := c.templateService.UpsertTemplate(ctx, template.OrgID, template.Data)
 			if err != nil {
 				return err
@@ -45,7 +44,7 @@ func (c *defaultTextTemplateProvisioner) Unprovision(ctx context.Context,
 	files []*AlertingFile) error {
 	for _, file := range files {
 		for _, deleteTemplate := range file.DeleteTemplates {
-			err := c.templateService.DeleteTemplate(ctx, deleteTemplate.OrgID, deleteTemplate.Name, definitions.Provenance(models.ProvenanceFile), "")
+			err := c.templateService.DeleteTemplate(ctx, deleteTemplate.OrgID, deleteTemplate.Name, models.ProvenanceFile, "")
 			if err != nil {
 				return err
 			}

--- a/pkg/services/provisioning/alerting/text_templates_types.go
+++ b/pkg/services/provisioning/alerting/text_templates_types.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	alerting_models "github.com/grafana/grafana/pkg/services/ngalert/models"
+	v1 "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
 	"github.com/grafana/grafana/pkg/services/provisioning/values"
 )
 
@@ -13,20 +15,27 @@ type TemplateV1 struct {
 	Template definitions.NotificationTemplate `json:",inline" yaml:",inline"`
 }
 
-func (v1 *TemplateV1) mapToModel() Template {
-	orgID := v1.OrgID.Value()
+func (t *TemplateV1) mapToModel() Template {
+	orgID := t.OrgID.Value()
 	if orgID < 1 {
 		orgID = 1
 	}
 	return Template{
-		Data:  v1.Template,
+		Data: v1.TemplateGroup{
+			Title:   t.Template.Name,
+			Content: t.Template.Template,
+			Kind:    v1.TemplateKindGrafana,
+			ResourceMetadata: v1.ResourceMetadata{
+				Provenance: alerting_models.ProvenanceFile,
+			},
+		},
 		OrgID: orgID,
 	}
 }
 
 type Template struct {
 	OrgID int64
-	Data  definitions.NotificationTemplate
+	Data  v1.TemplateGroup
 }
 
 type DeleteTemplateV1 struct {

--- a/pkg/tests/apis/alerting/notifications/templategroup/templates_group_test.go
+++ b/pkg/tests/apis/alerting/notifications/templategroup/templates_group_test.go
@@ -23,8 +23,8 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol/resourcepermissions"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/folder/foldertest"
-	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	ngmodels "github.com/grafana/grafana/pkg/services/ngalert/models"
+	v1model "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
 	"github.com/grafana/grafana/pkg/services/ngalert/store"
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/tests/apis"
@@ -723,8 +723,8 @@ func TestIntegrationListSelector(t *testing.T) {
 	ac := acimpl.ProvideAccessControl(env.FeatureToggles)
 	db, err := store.ProvideDBStore(env.Cfg, env.FeatureToggles, env.SQLStore, &foldertest.FakeService{}, &dashboards.FakeDashboardService{}, ac, bus.ProvideBus(tracing.InitializeTracerForTest()))
 	require.NoError(t, err)
-	require.NoError(t, db.SetProvenance(ctx, &definitions.NotificationTemplate{
-		Name: template2.Spec.Title,
+	require.NoError(t, db.SetProvenance(ctx, &v1model.TemplateGroup{
+		Title: template2.Spec.Title,
 	}, helper.Org1.Admin.Identity.GetOrgID(), "API"))
 	template2, err = adminClient.Get(ctx, template2.GetStaticMetadata().Identifier())
 


### PR DESCRIPTION
## Summary

This refactors notification template handling in ngalert from a flat `map[string]string` domain representation to a structured `TemplateGroup` model.

`TemplateGroup` carries template metadata alongside the template content, including `UID`, `Version`, and `Provenance`. Provisioning API and DB representations are unchanged from the existing `template_files` format.

## Changes

- Add `v1.TemplateGroup` and conversion helpers between `template_files` and domain templates.
- Update template provisioning services to operate on `TemplateGroup`.
- Preserve deterministic template UIDs based on kind and title.
- Keep optimistic concurrency based on template content fingerprint/version.
- Update legacy provisioning API and app-platform templategroup conversions.
- Update file provisioning, cloud migration, notifier, and related tests for the new model.