### PR TITLE
Heatmap: Minor wording fix in UI

### DIFF
--- a/public/app/plugins/panel/heatmap/module.tsx
+++ b/public/app/plugins/panel/heatmap/module.tsx
@@ -109,7 +109,7 @@ export const plugin = new PanelPlugin<Options, GraphFieldConfig>(HeatmapPanel)
       builder.addCustomEditor({
         id: 'rowsFrame-yBucketScale',
         path: 'rowsFrame.yBucketScale',
-        name: t('heatmap.name-y-bucket-scale', 'Y bucket scale'),
+        name: t('heatmap.name-y-bucket-scale', 'Y Bucket scale'),
         category,
         editor: YBucketScaleEditor,
         defaultValue: undefined,

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -10750,7 +10750,7 @@
     "name-unit": "Unit",
     "name-value-name": "Value name",
     "name-y-axis-scale": "Y axis scale",
-    "name-y-bucket-scale": "Y bucket scale",
+    "name-y-bucket-scale": "Y Bucket scale",
     "placeholder-axis-label": "Auto",
     "placeholder-axis-width": "Auto",
     "placeholder-decimals": "Auto",


### PR DESCRIPTION
Simple fix to make capitalization consistent across heatmap y bucket options.