### PR TITLE
Alerting: debounce alert name in notification preview to avoid re-renders on keystrokes

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/NotificationsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/NotificationsStep.tsx
@@ -1,6 +1,7 @@
 import { css } from '@emotion/css';
 import { useState } from 'react';
 import { useFormContext } from 'react-hook-form';
+import { useDebounce } from 'react-use';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
@@ -241,6 +242,17 @@ function AutomaticRooting({ alertUid }: AutomaticRootingProps) {
   ]);
   const selectedPolicy = watch('selectedPolicy');
 
+  // Debounce the alert name so NotificationPreview doesn't re-render on every keystroke.
+  // Other watched fields (labels, condition, folder) affect routing directly and are not debounced.
+  const [debouncedAlertName, setDebouncedAlertName] = useState(alertName);
+  useDebounce(
+    () => {
+      setDebouncedAlertName(alertName);
+    },
+    500,
+    [alertName]
+  );
+
   const multiplePoliciesEnabled = config.featureToggles.alertingMultiplePolicies ?? false;
   const policyRoutingSettingsEnabled = config.featureToggles.alertingPolicyRoutingSettings ?? false;
 
@@ -252,7 +264,7 @@ function AutomaticRooting({ alertUid }: AutomaticRootingProps) {
         customLabels={labels}
         condition={condition}
         folder={folder}
-        alertName={alertName}
+        alertName={debouncedAlertName}
         alertUid={alertUid}
         policyName={policyRoutingSettingsEnabled ? selectedPolicy : undefined}
       />


### PR DESCRIPTION
**What is this feature?**

Debounces the `alertName` prop passed to `NotificationPreview` in `AutomaticRooting` with a 500ms delay.

**Why do we need this feature?**

`AutomaticRooting` subscribes to the `name` form field via `watch(['labels', 'queries', 'condition', 'folder', 'name', 'manualRouting'])`. This causes `AutomaticRooting` to re-render on every keystroke when the user types in the alert rule name field. Each re-render passes a new `alertName` prop to `NotificationPreview`, triggering unnecessary child re-renders in a relatively heavy component tree (includes lazy-loaded `NotificationPreviewForGrafanaManaged` / `NotificationPreviewByAlertManager`).

The debounce ensures `NotificationPreview` only receives updated name props after the user pauses typing for 500ms, matching the intent of the `useEffectOnce` initial-trigger pattern already in place.

**Who is this feature for?**

Users creating or editing Grafana-managed alert rules who use notification policy routing.

**Which issue(s) does this PR fix?**:

Fixes #100989

**Special notes for your reviewer:**

- Only `alertName` is debounced — other watched fields (`labels`, `condition`, `folder`, `queries`) affect routing label matching directly and should not be debounced.
- `useDebounce` from `react-use` is already used in the codebase and available in the dependency tree.
- The initial name value is passed directly as `useState` initializer so the preview is correct on first render.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.