### PR TITLE
poc: UserActionsService + declarative undo/redo for addVariable

### DIFF
--- a/public/app/features/dashboard-scene/edit-pane/shared.ts
+++ b/public/app/features/dashboard-scene/edit-pane/shared.ts
@@ -280,12 +280,21 @@ export const dashboardEditActions = {
     const dashboard = getDashboardSceneFor(source);
     const variableKind = createVariableKindFromSceneVariable(addedObject);
     const position = source.state.variables.length;
-    dashboard.userActionsService.execute(new AddVariableCommand(dashboard, variableKind, position));
+    const result = dashboard.userActionsService.execute(new AddVariableCommand(dashboard, variableKind, position));
+    if (!result.success) {
+      // TODO(POC): surface to UI as toast/banner. For now, log so the failure isn't silent.
+      console.warn('addVariable failed', { error: result.error, locked: result.locked });
+    }
   },
   removeVariable({ source, removedObject }: RemoveVariableActionHelperProps) {
     const dashboard = getDashboardSceneFor(source);
     const variableKind = createVariableKindFromSceneVariable(removedObject);
-    dashboard.userActionsService.execute(new RemoveVariableCommand(dashboard, removedObject.state.name, variableKind));
+    const result = dashboard.userActionsService.execute(
+      new RemoveVariableCommand(dashboard, removedObject.state.name, variableKind)
+    );
+    if (!result.success) {
+      console.warn('removeVariable failed', { error: result.error, locked: result.locked });
+    }
   },
   changeVariableType({ source, oldVariable, newVariable }: ChangeVariableTypeActionHelperProps) {
     const varsBeforeChange = [...source.state.variables];

--- a/public/app/features/dashboard-scene/edit-pane/shared.ts
+++ b/public/app/features/dashboard-scene/edit-pane/shared.ts
@@ -14,6 +14,7 @@ import {
 } from '@grafana/scenes';
 import { type ElementSelectionContextItem } from '@grafana/ui';
 
+import { createVariableKindFromSceneVariable } from '../mutation-api/commands/variableUtils';
 import { DashboardDataLayerSet } from '../scene/DashboardDataLayerSet';
 import { DashboardScene } from '../scene/DashboardScene';
 import { SceneGridRowEditableElement } from '../scene/layout-default/SceneGridRowEditableElement';
@@ -34,6 +35,9 @@ import {
   VariableTypeChangeEditableElement,
 } from '../settings/variables/VariableTypeSelectionPane';
 import { isSceneVariable } from '../settings/variables/utils';
+import { AddVariableCommand } from '../user-actions/commands/AddVariableCommand';
+import { RemoveVariableCommand } from '../user-actions/commands/RemoveVariableCommand';
+import { getDashboardSceneFor } from '../utils/utils';
 
 import { type DashboardEditPane } from './DashboardEditPane';
 import { MultiSelectedObjectsEditableElement } from './MultiSelectedObjectsEditableElement';
@@ -273,32 +277,15 @@ export const dashboardEditActions = {
   }),
 
   addVariable({ source, addedObject }: AddVariableActionHelperProps) {
-    const varsBeforeAddition = [...(source.state.variables ?? [])];
-
-    dashboardEditActions.addElement({
-      source,
-      addedObject,
-      perform() {
-        source.setState({ variables: [...varsBeforeAddition, addedObject] });
-      },
-      undo() {
-        source.setState({ variables: [...varsBeforeAddition] });
-      },
-    });
+    const dashboard = getDashboardSceneFor(source);
+    const variableKind = createVariableKindFromSceneVariable(addedObject, source);
+    const position = source.state.variables.length;
+    dashboard.userActionsService.execute(new AddVariableCommand(dashboard, variableKind, position));
   },
   removeVariable({ source, removedObject }: RemoveVariableActionHelperProps) {
-    const varsBeforeRemoval = [...source.state.variables];
-
-    dashboardEditActions.removeElement({
-      source,
-      removedObject,
-      perform() {
-        source.setState({ variables: varsBeforeRemoval.filter((v) => v !== removedObject) });
-      },
-      undo() {
-        source.setState({ variables: varsBeforeRemoval });
-      },
-    });
+    const dashboard = getDashboardSceneFor(source);
+    const variableKind = createVariableKindFromSceneVariable(removedObject, source);
+    dashboard.userActionsService.execute(new RemoveVariableCommand(dashboard, removedObject.state.name, variableKind));
   },
   changeVariableType({ source, oldVariable, newVariable }: ChangeVariableTypeActionHelperProps) {
     const varsBeforeChange = [...source.state.variables];

--- a/public/app/features/dashboard-scene/edit-pane/shared.ts
+++ b/public/app/features/dashboard-scene/edit-pane/shared.ts
@@ -14,7 +14,6 @@ import {
 } from '@grafana/scenes';
 import { type ElementSelectionContextItem } from '@grafana/ui';
 
-import { createVariableKindFromSceneVariable } from '../mutation-api/commands/variableUtils';
 import { DashboardDataLayerSet } from '../scene/DashboardDataLayerSet';
 import { DashboardScene } from '../scene/DashboardScene';
 import { SceneGridRowEditableElement } from '../scene/layout-default/SceneGridRowEditableElement';
@@ -35,9 +34,6 @@ import {
   VariableTypeChangeEditableElement,
 } from '../settings/variables/VariableTypeSelectionPane';
 import { isSceneVariable } from '../settings/variables/utils';
-import { AddVariableCommand } from '../user-actions/commands/AddVariableCommand';
-import { RemoveVariableCommand } from '../user-actions/commands/RemoveVariableCommand';
-import { getDashboardSceneFor } from '../utils/utils';
 
 import { type DashboardEditPane } from './DashboardEditPane';
 import { MultiSelectedObjectsEditableElement } from './MultiSelectedObjectsEditableElement';
@@ -277,15 +273,32 @@ export const dashboardEditActions = {
   }),
 
   addVariable({ source, addedObject }: AddVariableActionHelperProps) {
-    const dashboard = getDashboardSceneFor(source);
-    const variableKind = createVariableKindFromSceneVariable(addedObject, source);
-    const position = source.state.variables.length;
-    dashboard.userActionsService.execute(new AddVariableCommand(dashboard, variableKind, position));
+    const varsBeforeAddition = [...(source.state.variables ?? [])];
+
+    dashboardEditActions.addElement({
+      source,
+      addedObject,
+      perform() {
+        source.setState({ variables: [...varsBeforeAddition, addedObject] });
+      },
+      undo() {
+        source.setState({ variables: [...varsBeforeAddition] });
+      },
+    });
   },
   removeVariable({ source, removedObject }: RemoveVariableActionHelperProps) {
-    const dashboard = getDashboardSceneFor(source);
-    const variableKind = createVariableKindFromSceneVariable(removedObject, source);
-    dashboard.userActionsService.execute(new RemoveVariableCommand(dashboard, removedObject.state.name, variableKind));
+    const varsBeforeRemoval = [...source.state.variables];
+
+    dashboardEditActions.removeElement({
+      source,
+      removedObject,
+      perform() {
+        source.setState({ variables: varsBeforeRemoval.filter((v) => v !== removedObject) });
+      },
+      undo() {
+        source.setState({ variables: varsBeforeRemoval });
+      },
+    });
   },
   changeVariableType({ source, oldVariable, newVariable }: ChangeVariableTypeActionHelperProps) {
     const varsBeforeChange = [...source.state.variables];

--- a/public/app/features/dashboard-scene/edit-pane/shared.ts
+++ b/public/app/features/dashboard-scene/edit-pane/shared.ts
@@ -14,6 +14,7 @@ import {
 } from '@grafana/scenes';
 import { type ElementSelectionContextItem } from '@grafana/ui';
 
+import { createVariableKindFromSceneVariable } from '../mutation-api/commands/variableUtils';
 import { DashboardDataLayerSet } from '../scene/DashboardDataLayerSet';
 import { DashboardScene } from '../scene/DashboardScene';
 import { SceneGridRowEditableElement } from '../scene/layout-default/SceneGridRowEditableElement';
@@ -34,6 +35,9 @@ import {
   VariableTypeChangeEditableElement,
 } from '../settings/variables/VariableTypeSelectionPane';
 import { isSceneVariable } from '../settings/variables/utils';
+import { AddVariableCommand } from '../user-actions/commands/AddVariableCommand';
+import { RemoveVariableCommand } from '../user-actions/commands/RemoveVariableCommand';
+import { getDashboardSceneFor } from '../utils/utils';
 
 import { type DashboardEditPane } from './DashboardEditPane';
 import { MultiSelectedObjectsEditableElement } from './MultiSelectedObjectsEditableElement';
@@ -273,32 +277,15 @@ export const dashboardEditActions = {
   }),
 
   addVariable({ source, addedObject }: AddVariableActionHelperProps) {
-    const varsBeforeAddition = [...(source.state.variables ?? [])];
-
-    dashboardEditActions.addElement({
-      source,
-      addedObject,
-      perform() {
-        source.setState({ variables: [...varsBeforeAddition, addedObject] });
-      },
-      undo() {
-        source.setState({ variables: [...varsBeforeAddition] });
-      },
-    });
+    const dashboard = getDashboardSceneFor(source);
+    const variableKind = createVariableKindFromSceneVariable(addedObject);
+    const position = source.state.variables.length;
+    dashboard.userActionsService.execute(new AddVariableCommand(dashboard, variableKind, position));
   },
   removeVariable({ source, removedObject }: RemoveVariableActionHelperProps) {
-    const varsBeforeRemoval = [...source.state.variables];
-
-    dashboardEditActions.removeElement({
-      source,
-      removedObject,
-      perform() {
-        source.setState({ variables: varsBeforeRemoval.filter((v) => v !== removedObject) });
-      },
-      undo() {
-        source.setState({ variables: varsBeforeRemoval });
-      },
-    });
+    const dashboard = getDashboardSceneFor(source);
+    const variableKind = createVariableKindFromSceneVariable(removedObject);
+    dashboard.userActionsService.execute(new RemoveVariableCommand(dashboard, removedObject.state.name, variableKind));
   },
   changeVariableType({ source, oldVariable, newVariable }: ChangeVariableTypeActionHelperProps) {
     const varsBeforeChange = [...source.state.variables];

--- a/public/app/features/dashboard-scene/mutation-api/Client.ts
+++ b/public/app/features/dashboard-scene/mutation-api/Client.ts
@@ -1,0 +1,28 @@
+import type { DashboardScene } from '../scene/DashboardScene';
+import type { UserActionsService } from '../user-actions/UserActionsService';
+
+import type { ClientCommand, ClientCommandContext, ClientCommandResult } from './ClientCommand';
+
+/**
+ * Agent-facing entry point for dashboard mutations.
+ *
+ * Receives a ClientCommand and a raw payload, then delegates to the command's
+ * handler which validates, maps, and routes into UserActionsService.
+ */
+export class MutationApiClient {
+  private scene: DashboardScene;
+  private userActionsService: UserActionsService;
+
+  constructor(scene: DashboardScene, userActionsService: UserActionsService) {
+    this.scene = scene;
+    this.userActionsService = userActionsService;
+  }
+
+  async execute<T>(clientCommand: ClientCommand<T>, payload: T): Promise<ClientCommandResult> {
+    const context: ClientCommandContext = {
+      scene: this.scene,
+      userActionsService: this.userActionsService,
+    };
+    return clientCommand.handler(payload, context);
+  }
+}

--- a/public/app/features/dashboard-scene/mutation-api/ClientCommand.ts
+++ b/public/app/features/dashboard-scene/mutation-api/ClientCommand.ts
@@ -1,0 +1,31 @@
+import type { DashboardScene } from '../scene/DashboardScene';
+import type { UserActionExecuteResult, UserActionsService } from '../user-actions/UserActionsService';
+
+export interface ClientCommandContext {
+  scene: DashboardScene;
+  userActionsService: UserActionsService;
+}
+
+export interface ClientCommandResult {
+  success: boolean;
+  error?: string;
+  locked?: boolean;
+}
+
+/**
+ * Agent-facing command interface.
+ *
+ * Each ClientCommand is responsible for:
+ *   1. Validating the raw JSON payload (Zod).
+ *   2. Mapping JSON to UserActionCommand inputs (JSON-to-Scene conversion).
+ *   3. Delegating execution to UserActionsService.
+ *
+ * ClientCommands never mutate Scene state directly.
+ */
+export interface ClientCommand<T = unknown> {
+  handler(payload: T, context: ClientCommandContext): Promise<ClientCommandResult>;
+}
+
+export function toClientResult(result: UserActionExecuteResult): ClientCommandResult {
+  return { success: result.success, error: result.error, locked: result.locked };
+}

--- a/public/app/features/dashboard-scene/mutation-api/commands/AddVariableClientCommand.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/AddVariableClientCommand.ts
@@ -1,0 +1,32 @@
+import { AddVariableCommand } from '../../user-actions/commands/AddVariableCommand';
+import {
+  type ClientCommand,
+  type ClientCommandContext,
+  type ClientCommandResult,
+  toClientResult,
+} from '../ClientCommand';
+
+import { addVariablePayloadSchema } from './schemas';
+
+/**
+ * Agent-facing ADD_VARIABLE client command.
+ *
+ * Responsibilities:
+ *   1. Validate the raw JSON payload against the Zod schema.
+ *   2. Map the validated JSON (VariableKind) to AddVariableCommand inputs.
+ *   3. Delegate execution to UserActionsService.
+ *
+ * Does not mutate Scene state directly.
+ */
+export class AddVariableClientCommand implements ClientCommand {
+  async handler(payload: unknown, context: ClientCommandContext): Promise<ClientCommandResult> {
+    const validation = addVariablePayloadSchema.safeParse(payload);
+    if (!validation.success) {
+      return { success: false, error: validation.error.message };
+    }
+
+    const { variable, position } = validation.data;
+    const cmd = new AddVariableCommand(context.scene, variable, position);
+    return toClientResult(context.userActionsService.execute(cmd));
+  }
+}

--- a/public/app/features/dashboard-scene/mutation-api/commands/RemoveVariableClientCommand.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/RemoveVariableClientCommand.ts
@@ -1,0 +1,43 @@
+import { sceneGraph } from '@grafana/scenes';
+
+import { RemoveVariableCommand } from '../../user-actions/commands/RemoveVariableCommand';
+import {
+  type ClientCommand,
+  type ClientCommandContext,
+  type ClientCommandResult,
+  toClientResult,
+} from '../ClientCommand';
+
+import { removeVariablePayloadSchema } from './schemas';
+import { createVariableKindFromSceneVariable } from './variableUtils';
+
+/**
+ * Agent-facing REMOVE_VARIABLE client command.
+ *
+ * Responsibilities:
+ *   1. Validate the raw JSON payload against the Zod schema.
+ *   2. Look up the SceneVariable by name, convert it back to a VariableKind
+ *      (so the undo can recreate it without holding a Scene reference).
+ *   3. Delegate execution to UserActionsService.
+ *
+ * Does not mutate Scene state directly.
+ */
+export class RemoveVariableClientCommand implements ClientCommand {
+  async handler(payload: unknown, context: ClientCommandContext): Promise<ClientCommandResult> {
+    const validation = removeVariablePayloadSchema.safeParse(payload);
+    if (!validation.success) {
+      return { success: false, error: validation.error.message };
+    }
+
+    const { name } = validation.data;
+    const varSet = sceneGraph.getVariables(context.scene);
+    const existing = varSet.state.variables.find((v) => v.state.name === name);
+    if (!existing) {
+      return { success: false, error: `Variable '${name}' not found` };
+    }
+
+    const variableKind = createVariableKindFromSceneVariable(existing, context.scene);
+    const cmd = new RemoveVariableCommand(context.scene, name, variableKind);
+    return toClientResult(context.userActionsService.execute(cmd));
+  }
+}

--- a/public/app/features/dashboard-scene/mutation-api/commands/addVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/addVariable.ts
@@ -6,14 +6,10 @@
 
 import { type z } from 'zod';
 
-import { sceneGraph } from '@grafana/scenes';
-import type { VariableKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
-
-import { createSceneVariableFromVariableModel } from '../../serialization/transformSaveModelSchemaV2ToScene';
+import { AddVariableCommand } from '../../user-actions/commands/AddVariableCommand';
 
 import { payloads } from './schemas';
 import { enterEditModeIfNeeded, requiresEdit, type MutationCommand } from './types';
-import { replaceVariableSet } from './variableUtils';
 
 export const addVariablePayloadSchema = payloads.addVariable;
 
@@ -31,43 +27,18 @@ export const addVariableCommand: MutationCommand<AddVariablePayload> = {
     const { scene } = context;
     enterEditModeIfNeeded(scene);
 
-    try {
-      const { variable: variableKind, position } = payload;
-      const name = variableKind.spec.name;
+    const { variable, position } = payload;
 
-      const existingVariables = scene.state.$variables;
-      if (existingVariables) {
-        const existing = existingVariables.state.variables.find((v) => v.state.name === name);
-        if (existing) {
-          throw new Error(`Variable '${name}' already exists`);
-        }
-      }
+    const result = scene.userActionsService.execute(new AddVariableCommand(scene, variable, position));
 
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Zod output is structurally compatible with VariableKind
-      const sceneVariable = createSceneVariableFromVariableModel(variableKind as VariableKind);
-
-      const varSet = sceneGraph.getVariables(scene);
-      const currentVariables = [...varSet.state.variables];
-
-      if (position !== undefined && position >= 0 && position < currentVariables.length) {
-        currentVariables.splice(position, 0, sceneVariable);
-      } else {
-        currentVariables.push(sceneVariable);
-      }
-
-      replaceVariableSet(scene, currentVariables);
-
-      return {
-        success: true,
-        data: { variable: variableKind },
-        changes: [{ path: `/variables/${name}`, previousValue: null, newValue: variableKind }],
-      };
-    } catch (error) {
-      return {
-        success: false,
-        error: error instanceof Error ? error.message : String(error),
-        changes: [],
-      };
+    if (!result.success) {
+      return { success: false, error: result.error ?? 'Unknown error', changes: [] };
     }
+
+    return {
+      success: true,
+      data: { variable },
+      changes: [{ path: `/variables/${variable.spec.name}`, previousValue: null, newValue: variable }],
+    };
   },
 };

--- a/public/app/features/dashboard-scene/mutation-api/commands/addVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/addVariable.ts
@@ -1,13 +1,15 @@
 /**
  * ADD_VARIABLE command
  *
- * Add a template variable to the dashboard using v2beta1 VariableKind format.
+ * Agent-facing ADD_VARIABLE handler. Goes through the layered architecture:
+ *   ClientCommand (validate + map) -> UserActionsService.execute -> AddVariableCommand
  */
 
 import { type z } from 'zod';
 
-import { AddVariableCommand } from '../../user-actions/commands/AddVariableCommand';
+import { MutationApiClient } from '../Client';
 
+import { AddVariableClientCommand } from './AddVariableClientCommand';
 import { payloads } from './schemas';
 import { enterEditModeIfNeeded, requiresEdit, type MutationCommand } from './types';
 
@@ -27,18 +29,22 @@ export const addVariableCommand: MutationCommand<AddVariablePayload> = {
     const { scene } = context;
     enterEditModeIfNeeded(scene);
 
-    const { variable, position } = payload;
-
-    const result = scene.userActionsService.execute(new AddVariableCommand(scene, variable, position));
+    const client = new MutationApiClient(scene, scene.userActionsService);
+    const result = await client.execute(new AddVariableClientCommand(), payload);
 
     if (!result.success) {
-      return { success: false, error: result.error ?? 'Unknown error', changes: [] };
+      return {
+        success: false,
+        error: result.error ?? 'Unknown error',
+        changes: [],
+        ...(result.locked ? { locked: true } : {}),
+      };
     }
 
     return {
       success: true,
-      data: { variable },
-      changes: [{ path: `/variables/${variable.spec.name}`, previousValue: null, newValue: variable }],
+      data: { variable: payload.variable },
+      changes: [{ path: `/variables/${payload.variable.spec.name}`, previousValue: null, newValue: payload.variable }],
     };
   },
 };

--- a/public/app/features/dashboard-scene/mutation-api/commands/removeVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/removeVariable.ts
@@ -1,14 +1,17 @@
 /**
  * REMOVE_VARIABLE command
  *
- * Remove a template variable from the dashboard by name.
+ * Agent-facing REMOVE_VARIABLE handler. Goes through the layered architecture:
+ *   ClientCommand (validate + look up + map) -> UserActionsService.execute -> RemoveVariableCommand
  */
 
 import { type z } from 'zod';
 
+import { MutationApiClient } from '../Client';
+
+import { RemoveVariableClientCommand } from './RemoveVariableClientCommand';
 import { payloads } from './schemas';
 import { enterEditModeIfNeeded, requiresEdit, type MutationCommand } from './types';
-import { replaceVariableSet } from './variableUtils';
 
 export const removeVariablePayloadSchema = payloads.removeVariable;
 
@@ -24,36 +27,24 @@ export const removeVariableCommand: MutationCommand<RemoveVariablePayload> = {
 
   handler: async (payload, context) => {
     const { scene } = context;
-    const { name } = payload;
     enterEditModeIfNeeded(scene);
 
-    try {
-      const variables = scene.state.$variables;
-      if (!variables) {
-        throw new Error('Dashboard has no variable set');
-      }
+    const client = new MutationApiClient(scene, scene.userActionsService);
+    const result = await client.execute(new RemoveVariableClientCommand(), payload);
 
-      const variable = variables.getByName(name);
-      if (!variable) {
-        throw new Error(`Variable '${name}' not found`);
-      }
-
-      const previousState = variable.state;
-
-      const updatedVariables = variables.state.variables.filter((v) => v.state.name !== name);
-      replaceVariableSet(scene, updatedVariables);
-
-      return {
-        success: true,
-        data: { name },
-        changes: [{ path: `/variables/${name}`, previousValue: previousState, newValue: null }],
-      };
-    } catch (error) {
+    if (!result.success) {
       return {
         success: false,
-        error: error instanceof Error ? error.message : String(error),
+        error: result.error ?? 'Unknown error',
         changes: [],
+        ...(result.locked ? { locked: true } : {}),
       };
     }
+
+    return {
+      success: true,
+      data: { name: payload.name },
+      changes: [{ path: `/variables/${payload.name}`, previousValue: 'removed', newValue: null }],
+    };
   },
 };

--- a/public/app/features/dashboard-scene/mutation-api/commands/variableUtils.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/variableUtils.ts
@@ -4,15 +4,37 @@
  * Contains helpers used across add/remove/update variable commands.
  */
 
-import { sceneUtils, SceneVariableSet, type SceneVariable, type sceneGraph } from '@grafana/scenes';
+import { config } from '@grafana/runtime';
+import { type sceneGraph, SceneVariableSet, sceneUtils, type SceneVariable } from '@grafana/scenes';
 import {
-  defaultVariableHide,
+  type AdhocVariableKind,
+  type ConstantVariableKind,
   type CustomVariableKind,
+  type DataQueryKind,
+  type DatasourceVariableKind,
+  type GroupByVariableKind,
+  type IntervalVariableKind,
   type QueryVariableKind,
+  type SwitchVariableKind,
   type TextVariableKind,
   type VariableKind,
   type VariableOption,
+  defaultDataQueryKind,
+  defaultIntervalVariableSpec,
+  defaultVariableHide,
 } from '@grafana/schema/apis/dashboard.grafana.app/v2';
+import { getDefaultDatasource } from 'app/features/dashboard/api/ResponseTransformers';
+
+import { getDataSourceForQuery } from '../../serialization/layoutSerializers/utils';
+import { validateFiltersOrigin } from '../../serialization/sceneVariablesSetToVariables';
+import { getDataQueryKind, getElementDatasource } from '../../serialization/transformSceneToSaveModelSchemaV2';
+import {
+  LEGACY_STRING_VALUE_KEY,
+  transformSortVariableToEnum,
+  transformVariableHideToEnum,
+  transformVariableRefreshToEnum,
+} from '../../serialization/transformToV2TypesUtils';
+import { getIntervalsQueryFromNewIntervalModel } from '../../utils/utils';
 
 /**
  * Replace the dashboard's variable set with a new set containing the given variables.
@@ -29,40 +51,85 @@ export function replaceVariableSet(
 }
 
 /**
- * Convert a SceneVariable instance back to a v2beta1 VariableKind.
+ * Convert a single SceneVariable into a v2beta1 VariableKind.
  *
- * POC-scope implementation: handles QueryVariable, CustomVariable, and
- * TextBoxVariable (the types the variable editor produces by default in
- * the canonical undo demo). Other types throw; full implementation is on
- * the Proposal 1 branch (feat/mutation-api-variable-ui-pilot) and should
- * be ported wholesale when this architecture moves out of POC.
+ * Full implementation covering all editable variable types. Originally
+ * authored on the Proposal 1 branch (feat/mutation-api-variable-ui-pilot);
+ * ported here verbatim so the UI path can construct UserActionCommands
+ * for every variable type the editor produces.
+ *
+ * The parent set is optional -- when provided, it is used to resolve datasource
+ * references for QueryVariable. When omitted, datasource resolution is skipped.
  */
-export function createVariableKindFromSceneVariable(variable: SceneVariable): VariableKind {
+export function createVariableKindFromSceneVariable(
+  variable: SceneVariable,
+  parentSet?: Parameters<typeof sceneGraph.getVariables>[0]
+): VariableKind {
   const commonProperties = {
     name: variable.state.name,
     label: variable.state.label,
     description: variable.state.description ?? undefined,
     skipUrlSync: Boolean(variable.state.skipUrlSync),
-    hide: defaultVariableHide(),
+    hide: transformVariableHideToEnum(variable.state.hide) || defaultVariableHide(),
   };
 
-  // @ts-expect-error -- SceneVariable value/text not typed on base state
-  const currentVariableOption: VariableOption = { value: variable.state.value, text: variable.state.text };
+  const currentVariableOption: VariableOption = {
+    // @ts-expect-error -- SceneVariable value/text not typed on base state
+    value: variable.state.value,
+    // @ts-expect-error
+    text: variable.state.text,
+  };
 
   if (sceneUtils.isQueryVariable(variable)) {
+    const query = variable.state.query;
+    let dataQuery: DataQueryKind | string;
+
+    const datasource = parentSet
+      ? getElementDatasource(
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+          parentSet as Parameters<typeof getElementDatasource>[0],
+          variable,
+          'variable'
+        )
+      : undefined;
+
+    if (typeof query !== 'string') {
+      dataQuery = {
+        kind: 'DataQuery',
+        version: defaultDataQueryKind().version,
+        group: datasource?.type || getDataQueryKind(query),
+        ...(datasource?.uid && { datasource: { name: datasource.uid } }),
+        spec: query,
+      };
+    } else {
+      const spec: Record<string, string> = {};
+      if (query) {
+        spec[LEGACY_STRING_VALUE_KEY] = query;
+      }
+      dataQuery = {
+        kind: 'DataQuery',
+        version: defaultDataQueryKind().version,
+        group: datasource?.type || getDataQueryKind(query),
+        ...(datasource?.uid && { datasource: { name: datasource.uid } }),
+        spec,
+      };
+    }
+
     const result: QueryVariableKind = {
       kind: 'QueryVariable',
       spec: {
         ...commonProperties,
         current: currentVariableOption,
         options: [],
-        query: { kind: 'DataQuery', spec: {}, group: 'prometheus', version: 'v0' },
-        definition: variable.state.definition ?? '',
-        sort: 'disabled',
-        refresh: 'never',
+        query: dataQuery,
+        definition: variable.state.definition,
+        sort: transformSortVariableToEnum(variable.state.sort),
+        refresh: transformVariableRefreshToEnum(variable.state.refresh),
         regex: variable.state.regex ?? '',
+        allValue: variable.state.allValue,
         includeAll: variable.state.includeAll || false,
         multi: variable.state.isMulti || false,
+        skipUrlSync: variable.state.skipUrlSync || false,
         allowCustomValue: variable.state.allowCustomValue ?? true,
       },
     };
@@ -87,10 +154,29 @@ export function createVariableKindFromSceneVariable(variable: SceneVariable): Va
     return result;
   }
 
-  if (sceneUtils.isTextBoxVariable(variable)) {
-    const value = variable.state.value ?? '';
-    const result: TextVariableKind = {
-      kind: 'TextVariable',
+  if (sceneUtils.isDataSourceVariable(variable)) {
+    const result: DatasourceVariableKind = {
+      kind: 'DatasourceVariable',
+      spec: {
+        ...commonProperties,
+        current: currentVariableOption,
+        options: [],
+        regex: variable.state.regex ?? '',
+        refresh: 'onDashboardLoad',
+        pluginId: variable.state.pluginId ?? getDefaultDatasource().type,
+        multi: variable.state.isMulti || false,
+        includeAll: variable.state.includeAll || false,
+        allowCustomValue: variable.state.allowCustomValue ?? true,
+        ...(variable.state.allValue !== undefined && { allValue: variable.state.allValue }),
+      },
+    };
+    return result;
+  }
+
+  if (sceneUtils.isConstantVariable(variable)) {
+    const value = variable.state.value ? String(variable.state.value) : '';
+    const result: ConstantVariableKind = {
+      kind: 'ConstantVariable',
       spec: {
         ...commonProperties,
         current: { text: value, value },
@@ -100,7 +186,125 @@ export function createVariableKindFromSceneVariable(variable: SceneVariable): Va
     return result;
   }
 
-  throw new Error(
-    `createVariableKindFromSceneVariable: unsupported variable type '${variable.state.type}' (POC scope)`
-  );
+  if (sceneUtils.isIntervalVariable(variable)) {
+    const intervals = getIntervalsQueryFromNewIntervalModel(variable.state.intervals);
+    const result: IntervalVariableKind = {
+      kind: 'IntervalVariable',
+      spec: {
+        ...commonProperties,
+        current: {
+          ...currentVariableOption,
+          text: variable.state.value,
+        },
+        query: intervals,
+        refresh: defaultIntervalVariableSpec().refresh,
+        options: variable.state.intervals.map((interval) => ({
+          value: interval,
+          text: interval,
+          selected: interval === variable.state.value,
+        })),
+        auto: variable.state.autoEnabled ?? defaultIntervalVariableSpec().auto,
+        auto_min: variable.state.autoMinInterval ?? defaultIntervalVariableSpec().auto_min,
+        auto_count: variable.state.autoStepCount ?? defaultIntervalVariableSpec().auto_count,
+      },
+    };
+    return result;
+  }
+
+  if (sceneUtils.isTextBoxVariable(variable)) {
+    const current = {
+      text: variable.state.value ?? '',
+      value: variable.state.value ?? '',
+    };
+    const result: TextVariableKind = {
+      kind: 'TextVariable',
+      spec: {
+        ...commonProperties,
+        current,
+        query: variable.state.value ?? '',
+      },
+    };
+    return result;
+  }
+
+  if (sceneUtils.isGroupByVariable(variable) && config.featureToggles.groupByVariable) {
+    // @ts-expect-error
+    const defaultVariableOptionValue: VariableOption | undefined = variable.state.defaultValue
+      ? {
+          value: variable.state.defaultValue.value,
+          text: variable.state.defaultValue.text,
+        }
+      : undefined;
+
+    const ds = getDataSourceForQuery(
+      variable.state.datasource,
+      variable.state.datasource?.type || getDefaultDatasource().type!
+    );
+
+    const result: GroupByVariableKind = {
+      kind: 'GroupByVariable',
+      group: ds.type!,
+      datasource: { name: ds.uid },
+      spec: {
+        ...commonProperties,
+        options:
+          variable.state.defaultOptions?.map((option) => ({
+            text: option.text,
+            value: String(option.value),
+          })) || [],
+        current: currentVariableOption,
+        defaultValue: defaultVariableOptionValue,
+        multi: variable.state.isMulti || false,
+      },
+    };
+    return result;
+  }
+
+  if (sceneUtils.isAdHocVariable(variable)) {
+    const ds = getDataSourceForQuery(
+      variable.state.datasource,
+      variable.state.datasource?.type || getDefaultDatasource().type!
+    );
+    const result: AdhocVariableKind = {
+      kind: 'AdhocVariable',
+      group: ds.type!,
+      datasource: { name: ds.uid },
+      spec: {
+        ...commonProperties,
+        baseFilters: validateFiltersOrigin(variable.state.baseFilters) || [],
+        filters: [
+          ...validateFiltersOrigin(variable.getOriginalFilters()).map(
+            ({ key, operator, value, values, keyLabel, valueLabels, origin }) => ({
+              key,
+              origin,
+              value,
+              values,
+              valueLabels,
+              keyLabel,
+              operator,
+            })
+          ),
+          ...validateFiltersOrigin(variable.state.filters),
+        ],
+        defaultKeys: variable.state.defaultKeys || [],
+        allowCustomValue: variable.state.allowCustomValue ?? true,
+      },
+    };
+    return result;
+  }
+
+  if (sceneUtils.isSwitchVariable(variable)) {
+    const result: SwitchVariableKind = {
+      kind: 'SwitchVariable',
+      spec: {
+        ...commonProperties,
+        current: variable.state.value,
+        enabledValue: variable.state.enabledValue,
+        disabledValue: variable.state.disabledValue,
+      },
+    };
+    return result;
+  }
+
+  throw new Error(`Unsupported variable type: ${variable.state.type}`);
 }

--- a/public/app/features/dashboard-scene/mutation-api/commands/variableUtils.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/variableUtils.ts
@@ -4,7 +4,15 @@
  * Contains helpers used across add/remove/update variable commands.
  */
 
-import { type sceneGraph, SceneVariableSet } from '@grafana/scenes';
+import { sceneUtils, SceneVariableSet, type SceneVariable, type sceneGraph } from '@grafana/scenes';
+import {
+  defaultVariableHide,
+  type CustomVariableKind,
+  type QueryVariableKind,
+  type TextVariableKind,
+  type VariableKind,
+  type VariableOption,
+} from '@grafana/schema/apis/dashboard.grafana.app/v2';
 
 /**
  * Replace the dashboard's variable set with a new set containing the given variables.
@@ -18,4 +26,81 @@ export function replaceVariableSet(
   scene.setState({ $variables: newVarSet });
   newVarSet.activate();
   return newVarSet;
+}
+
+/**
+ * Convert a SceneVariable instance back to a v2beta1 VariableKind.
+ *
+ * POC-scope implementation: handles QueryVariable, CustomVariable, and
+ * TextBoxVariable (the types the variable editor produces by default in
+ * the canonical undo demo). Other types throw; full implementation is on
+ * the Proposal 1 branch (feat/mutation-api-variable-ui-pilot) and should
+ * be ported wholesale when this architecture moves out of POC.
+ */
+export function createVariableKindFromSceneVariable(variable: SceneVariable): VariableKind {
+  const commonProperties = {
+    name: variable.state.name,
+    label: variable.state.label,
+    description: variable.state.description ?? undefined,
+    skipUrlSync: Boolean(variable.state.skipUrlSync),
+    hide: defaultVariableHide(),
+  };
+
+  // @ts-expect-error -- SceneVariable value/text not typed on base state
+  const currentVariableOption: VariableOption = { value: variable.state.value, text: variable.state.text };
+
+  if (sceneUtils.isQueryVariable(variable)) {
+    const result: QueryVariableKind = {
+      kind: 'QueryVariable',
+      spec: {
+        ...commonProperties,
+        current: currentVariableOption,
+        options: [],
+        query: { kind: 'DataQuery', spec: {}, group: 'prometheus', version: 'v0' },
+        definition: variable.state.definition ?? '',
+        sort: 'disabled',
+        refresh: 'never',
+        regex: variable.state.regex ?? '',
+        includeAll: variable.state.includeAll || false,
+        multi: variable.state.isMulti || false,
+        allowCustomValue: variable.state.allowCustomValue ?? true,
+      },
+    };
+    return result;
+  }
+
+  if (sceneUtils.isCustomVariable(variable)) {
+    const result: CustomVariableKind = {
+      kind: 'CustomVariable',
+      spec: {
+        ...commonProperties,
+        current: currentVariableOption,
+        options: [],
+        query: variable.state.query,
+        multi: variable.state.isMulti || false,
+        allValue: variable.state.allValue,
+        includeAll: variable.state.includeAll ?? false,
+        allowCustomValue: variable.state.allowCustomValue ?? true,
+        valuesFormat: variable.state.valuesFormat ?? 'csv',
+      },
+    };
+    return result;
+  }
+
+  if (sceneUtils.isTextBoxVariable(variable)) {
+    const value = variable.state.value ?? '';
+    const result: TextVariableKind = {
+      kind: 'TextVariable',
+      spec: {
+        ...commonProperties,
+        current: { text: value, value },
+        query: value,
+      },
+    };
+    return result;
+  }
+
+  throw new Error(
+    `createVariableKindFromSceneVariable: unsupported variable type '${variable.state.type}' (POC scope)`
+  );
 }

--- a/public/app/features/dashboard-scene/mutation-api/types.ts
+++ b/public/app/features/dashboard-scene/mutation-api/types.ts
@@ -24,6 +24,12 @@ export interface MutationResult {
   changes: MutationChange[];
   warnings?: string[];
   data?: unknown;
+  /**
+   * True when the targeted object is currently write-locked. The agent should
+   * wait and retry. Absent / false means the mutation was either applied or
+   * failed for a non-lock reason.
+   */
+  locked?: boolean;
 }
 
 export interface MutationChange {

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -241,12 +241,30 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
    */
   private _changeTracker: DashboardSceneChangeTracker;
   private _userActionsService?: UserActionsService;
+  private _writeLocks = new Set<string>();
 
   public get userActionsService(): UserActionsService {
     if (!this._userActionsService) {
       this._userActionsService = new UserActionsService(this);
     }
     return this._userActionsService;
+  }
+
+  /**
+   * Acquire a write lock for the given target identifier (e.g. 'variables').
+   * Subsequent mutations against the same target return locked:true until released.
+   * Reads via Scenes subscriptions are unaffected.
+   */
+  public acquireWriteLock(target: string): void {
+    this._writeLocks.add(target);
+  }
+
+  public releaseWriteLock(target: string): void {
+    this._writeLocks.delete(target);
+  }
+
+  public isWriteLocked(target: string): boolean {
+    return this._writeLocks.has(target);
   }
 
   /**

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -84,6 +84,7 @@ import { gridItemToPanel } from '../serialization/transformSceneToSaveModel';
 import { normalizeTransformation } from '../serialization/transformationCompat';
 import { JsonModelEditView } from '../settings/JsonModelEditView';
 import { type DashboardEditView } from '../settings/utils';
+import { UserActionsService } from '../user-actions/UserActionsService';
 import { DashboardModelCompatibilityWrapper } from '../utils/DashboardModelCompatibilityWrapper';
 import { isRepeatCloneOrChildOf } from '../utils/clone';
 import { dashboardSceneGraph } from '../utils/dashboardSceneGraph';
@@ -239,6 +240,14 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
    * Dashboard changes tracker
    */
   private _changeTracker: DashboardSceneChangeTracker;
+  private _userActionsService?: UserActionsService;
+
+  public get userActionsService(): UserActionsService {
+    if (!this._userActionsService) {
+      this._userActionsService = new UserActionsService(this);
+    }
+    return this._userActionsService;
+  }
 
   /**
    * Remember scroll position when going into panel edit

--- a/public/app/features/dashboard-scene/user-actions/UserActionCommand.ts
+++ b/public/app/features/dashboard-scene/user-actions/UserActionCommand.ts
@@ -8,6 +8,12 @@
 export interface UserActionCommand {
   /** Human-readable label for undo/redo UI buttons (e.g. "Add variable 'env'"). */
   title: string;
+  /**
+   * Optional write-lock target this command operates against (e.g. 'variables').
+   * If the target is locked at execute() time, UserActionsService short-circuits
+   * with { success: false, locked: true } without calling perform().
+   */
+  lockTarget?: string;
   /** Apply the mutation to the Scene. */
   perform(): void;
   /** Reverse the mutation using stored data, not Scene references. */

--- a/public/app/features/dashboard-scene/user-actions/UserActionCommand.ts
+++ b/public/app/features/dashboard-scene/user-actions/UserActionCommand.ts
@@ -1,0 +1,15 @@
+/**
+ * A reversible user action that can be performed and undone.
+ *
+ * Inverse mutations must be declarative: `undo()` uses stored primitives
+ * (name, index, VariableKind) rather than captured Scene-object references,
+ * so redo remains safe even when surrounding state has changed.
+ */
+export interface UserActionCommand {
+  /** Human-readable label for undo/redo UI buttons (e.g. "Add variable 'env'"). */
+  title: string;
+  /** Apply the mutation to the Scene. */
+  perform(): void;
+  /** Reverse the mutation using stored data, not Scene references. */
+  undo(): void;
+}

--- a/public/app/features/dashboard-scene/user-actions/UserActionsService.test.ts
+++ b/public/app/features/dashboard-scene/user-actions/UserActionsService.test.ts
@@ -1,0 +1,199 @@
+import { sceneGraph, SceneVariableSet, TestVariable, type SceneVariable } from '@grafana/scenes';
+import type { VariableKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+
+import type { DashboardScene } from '../scene/DashboardScene';
+
+import { UserActionsService } from './UserActionsService';
+import { AddVariableCommand } from './commands/AddVariableCommand';
+import { RemoveVariableCommand } from './commands/RemoveVariableCommand';
+
+function replaceVariableSet(scene: DashboardScene, variables: SceneVariable[]): void {
+  const newVarSet = new SceneVariableSet({ variables });
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  (scene as unknown as { setState: (s: object) => void }).setState({ $variables: newVarSet });
+  newVarSet.activate();
+}
+
+function buildMockScene(options: { editable?: boolean } = {}): DashboardScene {
+  const { editable = true } = options;
+  const state: Record<string, unknown> = {
+    uid: 'test-dash',
+    isEditing: true,
+    $variables: new SceneVariableSet({ variables: [] }),
+  };
+  const scene: Record<string, unknown> = {
+    state,
+    canEditDashboard: jest.fn(() => editable),
+    forceRender: jest.fn(),
+    setState: jest.fn((partial: Record<string, unknown>) => {
+      Object.assign(state, partial);
+      const vars = partial.$variables;
+      if (vars && typeof (vars as SceneVariableSet).activate === 'function') {
+        (vars as SceneVariableSet).activate();
+      }
+    }),
+  };
+
+  scene.addVariable = (variable: VariableKind, position?: number) => {
+    const name = variable.spec.name;
+    const varSet = sceneGraph.getVariables(scene as unknown as DashboardScene);
+    const existing = varSet.state.variables.find((v) => v.state.name === name);
+    if (existing) {
+      throw new Error(`Variable '${name}' already exists`);
+    }
+    // Use TestVariable to avoid pulling in the heavy serialization import chain.
+    const sceneVar = new TestVariable({ name, query: '', value: '' });
+    const current = [...varSet.state.variables];
+    if (position !== undefined && position >= 0 && position < current.length) {
+      current.splice(position, 0, sceneVar);
+    } else {
+      current.push(sceneVar);
+    }
+    replaceVariableSet(scene as unknown as DashboardScene, current);
+  };
+
+  scene.removeVariable = (name: string) => {
+    const varSet = sceneGraph.getVariables(scene as unknown as DashboardScene);
+    const existing = varSet.state.variables.find((v) => v.state.name === name);
+    if (!existing) {
+      throw new Error(`Variable '${name}' not found`);
+    }
+    replaceVariableSet(
+      scene as unknown as DashboardScene,
+      varSet.state.variables.filter((v) => v.state.name !== name)
+    );
+  };
+
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  return scene as unknown as DashboardScene;
+}
+
+function makeVar(name: string): VariableKind {
+  return {
+    kind: 'QueryVariable',
+    spec: {
+      name,
+      label: name,
+      hide: 'dontHide',
+      skipUrlSync: false,
+      current: { value: '', text: '' },
+      options: [],
+      query: { kind: 'DataQuery', spec: {}, group: 'prometheus', version: 'v0' },
+      definition: '',
+      sort: 'disabled',
+      refresh: 'never',
+      regex: '',
+      includeAll: false,
+      multi: false,
+      allowCustomValue: true,
+    },
+  };
+}
+
+function getVariableNames(scene: DashboardScene): string[] {
+  return sceneGraph.getVariables(scene).state.variables.map((v) => v.state.name);
+}
+
+describe('UserActionsService', () => {
+  // TestVariable instances trigger a Scenes lifecycle warning when moved between
+  // SceneVariableSets in the mock. Suppress it here — the real DashboardScene
+  // and replaceVariableSet handle activation correctly.
+  let consoleWarnSpy: jest.SpyInstance;
+  beforeEach(() => {
+    consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  describe('execute', () => {
+    it('rejects when dashboard is not editable', () => {
+      const scene = buildMockScene({ editable: false });
+      const service = new UserActionsService(scene);
+      const result = service.execute(new AddVariableCommand(scene, makeVar('x')));
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/permission/);
+    });
+
+    it('adds a variable and calls forceRender', () => {
+      const scene = buildMockScene();
+      const service = new UserActionsService(scene);
+      service.execute(new AddVariableCommand(scene, makeVar('env')));
+      expect(getVariableNames(scene)).toEqual(['env']);
+      expect(scene.forceRender).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears the redo stack on a new action', () => {
+      const scene = buildMockScene();
+      const service = new UserActionsService(scene);
+      service.execute(new AddVariableCommand(scene, makeVar('a')));
+      service.undo();
+      service.execute(new AddVariableCommand(scene, makeVar('b')));
+      expect(service.redo()).toBe(false);
+    });
+  });
+
+  describe('canonical undo test — remove middle of three, redo restores at the right index', () => {
+    it('restores index 1 after undo, re-removes on redo', () => {
+      const scene = buildMockScene();
+      const service = new UserActionsService(scene);
+
+      const varA = makeVar('a');
+      const varB = makeVar('b');
+      const varC = makeVar('c');
+
+      service.execute(new AddVariableCommand(scene, varA));
+      service.execute(new AddVariableCommand(scene, varB));
+      service.execute(new AddVariableCommand(scene, varC));
+      expect(getVariableNames(scene)).toEqual(['a', 'b', 'c']);
+
+      // Remove the middle variable (b is at index 1)
+      service.execute(new RemoveVariableCommand(scene, 'b', varB));
+      expect(getVariableNames(scene)).toEqual(['a', 'c']);
+
+      // Undo: b should be restored at index 1
+      service.undo();
+      expect(getVariableNames(scene)).toEqual(['a', 'b', 'c']);
+
+      // Redo: b should be removed again
+      service.redo();
+      expect(getVariableNames(scene)).toEqual(['a', 'c']);
+    });
+  });
+
+  describe('multiplayer composition — mutations apply against latest state', () => {
+    it('two sequential execute calls each read the latest scene state', () => {
+      const scene = buildMockScene();
+      const service = new UserActionsService(scene);
+
+      service.execute(new AddVariableCommand(scene, makeVar('first')));
+      // second call must see 'first' already present
+      service.execute(new AddVariableCommand(scene, makeVar('second')));
+
+      expect(getVariableNames(scene)).toEqual(['first', 'second']);
+
+      // Undo twice in reverse order
+      service.undo();
+      expect(getVariableNames(scene)).toEqual(['first']);
+      service.undo();
+      expect(getVariableNames(scene)).toEqual([]);
+    });
+  });
+
+  describe('peekUndoTitle / peekRedoTitle', () => {
+    it('returns the title of the last command on each stack', () => {
+      const scene = buildMockScene();
+      const service = new UserActionsService(scene);
+
+      expect(service.peekUndoTitle()).toBeUndefined();
+
+      service.execute(new AddVariableCommand(scene, makeVar('env')));
+      expect(service.peekUndoTitle()).toBe("Add variable 'env'");
+      expect(service.peekRedoTitle()).toBeUndefined();
+
+      service.undo();
+      expect(service.peekUndoTitle()).toBeUndefined();
+      expect(service.peekRedoTitle()).toBe("Add variable 'env'");
+    });
+  });
+});

--- a/public/app/features/dashboard-scene/user-actions/UserActionsService.test.ts
+++ b/public/app/features/dashboard-scene/user-actions/UserActionsService.test.ts
@@ -22,10 +22,15 @@ function buildMockScene(options: { editable?: boolean } = {}): DashboardScene {
     isEditing: true,
     $variables: new SceneVariableSet({ variables: [] }),
   };
+  const writeLocks = new Set<string>();
   const scene: Record<string, unknown> = {
     state,
     canEditDashboard: jest.fn(() => editable),
     forceRender: jest.fn(),
+    publishEvent: jest.fn(),
+    acquireWriteLock: (t: string) => writeLocks.add(t),
+    releaseWriteLock: (t: string) => writeLocks.delete(t),
+    isWriteLocked: (t: string) => writeLocks.has(t),
     setState: jest.fn((partial: Record<string, unknown>) => {
       Object.assign(state, partial);
       const vars = partial.$variables;
@@ -101,6 +106,24 @@ describe('UserActionsService', () => {
       const result = service.execute(new AddVariableCommand(scene, makeVar('env')));
       expect(result.success).toBe(false);
       expect(result.error).toMatch(/already exists/);
+    });
+
+    it('returns locked:true when the target is write-locked, without mutating state', () => {
+      const scene = buildMockScene();
+      const service = new UserActionsService(scene);
+
+      scene.acquireWriteLock('variables');
+      const result = service.execute(new AddVariableCommand(scene, makeVar('env')));
+      expect(result.success).toBe(false);
+      expect(result.locked).toBe(true);
+      expect(result.error).toMatch(/locked/);
+      expect(getVariableNames(scene)).toEqual([]);
+
+      scene.releaseWriteLock('variables');
+      const result2 = service.execute(new AddVariableCommand(scene, makeVar('env')));
+      expect(result2.success).toBe(true);
+      expect(result2.locked).toBe(false);
+      expect(getVariableNames(scene)).toEqual(['env']);
     });
 
     it('clears the redo stack on a new action', () => {

--- a/public/app/features/dashboard-scene/user-actions/UserActionsService.test.ts
+++ b/public/app/features/dashboard-scene/user-actions/UserActionsService.test.ts
@@ -1,4 +1,4 @@
-import { sceneGraph, SceneVariableSet, TestVariable, type SceneVariable } from '@grafana/scenes';
+import { sceneGraph, SceneVariableSet, TestVariable } from '@grafana/scenes';
 import type { VariableKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 
 import type { DashboardScene } from '../scene/DashboardScene';
@@ -7,12 +7,13 @@ import { UserActionsService } from './UserActionsService';
 import { AddVariableCommand } from './commands/AddVariableCommand';
 import { RemoveVariableCommand } from './commands/RemoveVariableCommand';
 
-function replaceVariableSet(scene: DashboardScene, variables: SceneVariable[]): void {
-  const newVarSet = new SceneVariableSet({ variables });
-  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-  (scene as unknown as { setState: (s: object) => void }).setState({ $variables: newVarSet });
-  newVarSet.activate();
-}
+// Avoid pulling the heavy serialization import chain into the test runtime.
+// The commands need a VariableKind -> SceneVariable converter; here a TestVariable
+// keyed by name is enough to exercise stack mechanics and index ordering.
+jest.mock('../serialization/transformSaveModelSchemaV2ToScene', () => ({
+  createSceneVariableFromVariableModel: (variable: { spec: { name: string } }) =>
+    new TestVariable({ name: variable.spec.name, query: '', value: '' }),
+}));
 
 function buildMockScene(options: { editable?: boolean } = {}): DashboardScene {
   const { editable = true } = options;
@@ -32,36 +33,6 @@ function buildMockScene(options: { editable?: boolean } = {}): DashboardScene {
         (vars as SceneVariableSet).activate();
       }
     }),
-  };
-
-  scene.addVariable = (variable: VariableKind, position?: number) => {
-    const name = variable.spec.name;
-    const varSet = sceneGraph.getVariables(scene as unknown as DashboardScene);
-    const existing = varSet.state.variables.find((v) => v.state.name === name);
-    if (existing) {
-      throw new Error(`Variable '${name}' already exists`);
-    }
-    // Use TestVariable to avoid pulling in the heavy serialization import chain.
-    const sceneVar = new TestVariable({ name, query: '', value: '' });
-    const current = [...varSet.state.variables];
-    if (position !== undefined && position >= 0 && position < current.length) {
-      current.splice(position, 0, sceneVar);
-    } else {
-      current.push(sceneVar);
-    }
-    replaceVariableSet(scene as unknown as DashboardScene, current);
-  };
-
-  scene.removeVariable = (name: string) => {
-    const varSet = sceneGraph.getVariables(scene as unknown as DashboardScene);
-    const existing = varSet.state.variables.find((v) => v.state.name === name);
-    if (!existing) {
-      throw new Error(`Variable '${name}' not found`);
-    }
-    replaceVariableSet(
-      scene as unknown as DashboardScene,
-      varSet.state.variables.filter((v) => v.state.name !== name)
-    );
   };
 
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
@@ -96,7 +67,7 @@ function getVariableNames(scene: DashboardScene): string[] {
 
 describe('UserActionsService', () => {
   // TestVariable instances trigger a Scenes lifecycle warning when moved between
-  // SceneVariableSets in the mock. Suppress it here — the real DashboardScene
+  // SceneVariableSets in the mock. Suppress it here -- the real DashboardScene
   // and replaceVariableSet handle activation correctly.
   let consoleWarnSpy: jest.SpyInstance;
   beforeEach(() => {
@@ -123,6 +94,15 @@ describe('UserActionsService', () => {
       expect(scene.forceRender).toHaveBeenCalledTimes(1);
     });
 
+    it('returns success: false when perform() throws (duplicate name)', () => {
+      const scene = buildMockScene();
+      const service = new UserActionsService(scene);
+      service.execute(new AddVariableCommand(scene, makeVar('env')));
+      const result = service.execute(new AddVariableCommand(scene, makeVar('env')));
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/already exists/);
+    });
+
     it('clears the redo stack on a new action', () => {
       const scene = buildMockScene();
       const service = new UserActionsService(scene);
@@ -133,7 +113,7 @@ describe('UserActionsService', () => {
     });
   });
 
-  describe('canonical undo test — remove middle of three, redo restores at the right index', () => {
+  describe('canonical undo test -- remove middle of three, redo restores at the right index', () => {
     it('restores index 1 after undo, re-removes on redo', () => {
       const scene = buildMockScene();
       const service = new UserActionsService(scene);
@@ -161,7 +141,7 @@ describe('UserActionsService', () => {
     });
   });
 
-  describe('multiplayer composition — mutations apply against latest state', () => {
+  describe('multiplayer composition -- mutations apply against latest state', () => {
     it('two sequential execute calls each read the latest scene state', () => {
       const scene = buildMockScene();
       const service = new UserActionsService(scene);

--- a/public/app/features/dashboard-scene/user-actions/UserActionsService.ts
+++ b/public/app/features/dashboard-scene/user-actions/UserActionsService.ts
@@ -1,3 +1,4 @@
+import { DashboardEditActionEvent } from '../edit-pane/events';
 import type { DashboardScene } from '../scene/DashboardScene';
 
 import type { UserActionCommand } from './UserActionCommand';
@@ -6,18 +7,22 @@ export interface UserActionExecuteResult {
   success: boolean;
   error?: string;
   /**
-   * Future locking signal. When true the targeted object is under concurrent
-   * use and the caller should wait and retry. Always false in this POC.
+   * True when the targeted object is currently write-locked. Caller should
+   * wait and retry. Reads via Scenes subscriptions are not affected.
    */
-  locked: false;
+  locked: boolean;
 }
 
 /**
  * Central service for all reversible dashboard mutations.
  *
  * Owns the undo/redo stack. Both the UI (direct calls) and the agent
- * (via MutationApiClient → ClientCommand) funnel through this service,
- * making it the single permission-check and locking choke point.
+ * (via MutationApiClient -> ClientCommand) funnel through this service,
+ * making it the single permission-check + lock + locking choke point.
+ *
+ * Bridges to DashboardEditActionEvent so the existing toolbar undo/redo
+ * button continues to function while DashboardEditPane is gradually migrated
+ * to read from this service directly.
  */
 export class UserActionsService {
   private scene: DashboardScene;
@@ -37,6 +42,14 @@ export class UserActionsService {
       };
     }
 
+    if (cmd.lockTarget && this.scene.isWriteLocked(cmd.lockTarget)) {
+      return {
+        success: false,
+        locked: true,
+        error: `Target '${cmd.lockTarget}' is locked`,
+      };
+    }
+
     try {
       cmd.perform();
     } catch (error) {
@@ -46,9 +59,31 @@ export class UserActionsService {
         locked: false,
       };
     }
+
     this._undoStack.push(cmd);
     this._redoStack = [];
     this.scene.forceRender();
+
+    // Bridge to the existing toolbar undo stack via DashboardEditActionEvent.
+    // The mutation has already been applied here, so on the initial publish the
+    // perform callback is a no-op; on redo (the second time perform is called)
+    // it re-applies cmd.perform().
+    let firstPerform = true;
+    this.scene.publishEvent(
+      new DashboardEditActionEvent({
+        source: this.scene,
+        description: cmd.title,
+        perform: () => {
+          if (firstPerform) {
+            firstPerform = false;
+            return;
+          }
+          cmd.perform();
+        },
+        undo: () => cmd.undo(),
+      }),
+      true
+    );
 
     return { success: true, locked: false };
   }

--- a/public/app/features/dashboard-scene/user-actions/UserActionsService.ts
+++ b/public/app/features/dashboard-scene/user-actions/UserActionsService.ts
@@ -37,7 +37,15 @@ export class UserActionsService {
       };
     }
 
-    cmd.perform();
+    try {
+      cmd.perform();
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : String(error),
+        locked: false,
+      };
+    }
     this._undoStack.push(cmd);
     this._redoStack = [];
     this.scene.forceRender();

--- a/public/app/features/dashboard-scene/user-actions/UserActionsService.ts
+++ b/public/app/features/dashboard-scene/user-actions/UserActionsService.ts
@@ -1,0 +1,77 @@
+import type { DashboardScene } from '../scene/DashboardScene';
+
+import type { UserActionCommand } from './UserActionCommand';
+
+export interface UserActionExecuteResult {
+  success: boolean;
+  error?: string;
+  /**
+   * Future locking signal. When true the targeted object is under concurrent
+   * use and the caller should wait and retry. Always false in this POC.
+   */
+  locked: false;
+}
+
+/**
+ * Central service for all reversible dashboard mutations.
+ *
+ * Owns the undo/redo stack. Both the UI (direct calls) and the agent
+ * (via MutationApiClient → ClientCommand) funnel through this service,
+ * making it the single permission-check and locking choke point.
+ */
+export class UserActionsService {
+  private scene: DashboardScene;
+  private _undoStack: UserActionCommand[] = [];
+  private _redoStack: UserActionCommand[] = [];
+
+  constructor(scene: DashboardScene) {
+    this.scene = scene;
+  }
+
+  execute(cmd: UserActionCommand): UserActionExecuteResult {
+    if (!this.scene.canEditDashboard()) {
+      return {
+        success: false,
+        error: 'Cannot edit dashboard: insufficient permissions or dashboard is a snapshot',
+        locked: false,
+      };
+    }
+
+    cmd.perform();
+    this._undoStack.push(cmd);
+    this._redoStack = [];
+    this.scene.forceRender();
+
+    return { success: true, locked: false };
+  }
+
+  undo(): boolean {
+    const cmd = this._undoStack.pop();
+    if (!cmd) {
+      return false;
+    }
+    cmd.undo();
+    this._redoStack.push(cmd);
+    this.scene.forceRender();
+    return true;
+  }
+
+  redo(): boolean {
+    const cmd = this._redoStack.pop();
+    if (!cmd) {
+      return false;
+    }
+    cmd.perform();
+    this._undoStack.push(cmd);
+    this.scene.forceRender();
+    return true;
+  }
+
+  peekUndoTitle(): string | undefined {
+    return this._undoStack[this._undoStack.length - 1]?.title;
+  }
+
+  peekRedoTitle(): string | undefined {
+    return this._redoStack[this._redoStack.length - 1]?.title;
+  }
+}

--- a/public/app/features/dashboard-scene/user-actions/commands/AddVariableCommand.ts
+++ b/public/app/features/dashboard-scene/user-actions/commands/AddVariableCommand.ts
@@ -1,13 +1,17 @@
+import { sceneGraph } from '@grafana/scenes';
 import type { VariableKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 
+import { replaceVariableSet } from '../../mutation-api/commands/variableUtils';
 import type { DashboardScene } from '../../scene/DashboardScene';
+import { createSceneVariableFromVariableModel } from '../../serialization/transformSaveModelSchemaV2ToScene';
 import type { UserActionCommand } from '../UserActionCommand';
 
 /**
  * Adds a variable to the dashboard at the given position.
  *
- * Undo is declarative: uses the stored variable name to remove it.
- * No Scene-object references are captured in closures.
+ * Stores only declarative data (VariableKind + position): no SceneVariable
+ * references are held in the command, so redo recomputes a fresh SceneVariable
+ * each time and stays safe against intervening state changes.
  */
 export class AddVariableCommand implements UserActionCommand {
   title: string;
@@ -24,11 +28,31 @@ export class AddVariableCommand implements UserActionCommand {
   }
 
   perform(): void {
-    this.scene.addVariable(this.variableKind, this.position);
+    const name = this.variableKind.spec.name;
+    const varSet = sceneGraph.getVariables(this.scene);
+    const existing = varSet.state.variables.find((v) => v.state.name === name);
+    if (existing) {
+      throw new Error(`Variable '${name}' already exists`);
+    }
+
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- structurally compatible
+    const sceneVariable = createSceneVariableFromVariableModel(this.variableKind as VariableKind);
+    const current = [...varSet.state.variables];
+    if (this.position !== undefined && this.position >= 0 && this.position < current.length) {
+      current.splice(this.position, 0, sceneVariable);
+    } else {
+      current.push(sceneVariable);
+    }
+    replaceVariableSet(this.scene, current);
   }
 
   undo(): void {
     // Declarative inverse: remove by name. No Scene reference held.
-    this.scene.removeVariable(this.variableKind.spec.name);
+    const name = this.variableKind.spec.name;
+    const varSet = sceneGraph.getVariables(this.scene);
+    replaceVariableSet(
+      this.scene,
+      varSet.state.variables.filter((v) => v.state.name !== name)
+    );
   }
 }

--- a/public/app/features/dashboard-scene/user-actions/commands/AddVariableCommand.ts
+++ b/public/app/features/dashboard-scene/user-actions/commands/AddVariableCommand.ts
@@ -15,6 +15,7 @@ import type { UserActionCommand } from '../UserActionCommand';
  */
 export class AddVariableCommand implements UserActionCommand {
   title: string;
+  lockTarget = 'variables';
 
   private scene: DashboardScene;
   private variableKind: VariableKind;

--- a/public/app/features/dashboard-scene/user-actions/commands/AddVariableCommand.ts
+++ b/public/app/features/dashboard-scene/user-actions/commands/AddVariableCommand.ts
@@ -1,0 +1,34 @@
+import type { VariableKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+
+import type { DashboardScene } from '../../scene/DashboardScene';
+import type { UserActionCommand } from '../UserActionCommand';
+
+/**
+ * Adds a variable to the dashboard at the given position.
+ *
+ * Undo is declarative: uses the stored variable name to remove it.
+ * No Scene-object references are captured in closures.
+ */
+export class AddVariableCommand implements UserActionCommand {
+  title: string;
+
+  private scene: DashboardScene;
+  private variableKind: VariableKind;
+  private position: number | undefined;
+
+  constructor(scene: DashboardScene, variableKind: VariableKind, position?: number) {
+    this.scene = scene;
+    this.variableKind = variableKind;
+    this.position = position;
+    this.title = `Add variable '${variableKind.spec.name}'`;
+  }
+
+  perform(): void {
+    this.scene.addVariable(this.variableKind, this.position);
+  }
+
+  undo(): void {
+    // Declarative inverse: remove by name. No Scene reference held.
+    this.scene.removeVariable(this.variableKind.spec.name);
+  }
+}

--- a/public/app/features/dashboard-scene/user-actions/commands/RemoveVariableCommand.ts
+++ b/public/app/features/dashboard-scene/user-actions/commands/RemoveVariableCommand.ts
@@ -1,15 +1,17 @@
 import { sceneGraph } from '@grafana/scenes';
 import type { VariableKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 
+import { replaceVariableSet } from '../../mutation-api/commands/variableUtils';
 import type { DashboardScene } from '../../scene/DashboardScene';
+import { createSceneVariableFromVariableModel } from '../../serialization/transformSaveModelSchemaV2ToScene';
 import type { UserActionCommand } from '../UserActionCommand';
 
 /**
  * Removes a variable from the dashboard.
  *
- * Undo is declarative: records the index at perform() time (a primitive),
- * then re-inserts the stored VariableKind at that index.
- * No Scene-object references are captured in closures.
+ * Undo is declarative: records the removed index at perform() time (a number),
+ * then re-creates a SceneVariable from the stored VariableKind and inserts it
+ * at that index. No SceneVariable references are captured in closures.
  */
 export class RemoveVariableCommand implements UserActionCommand {
   title: string;
@@ -27,13 +29,27 @@ export class RemoveVariableCommand implements UserActionCommand {
   }
 
   perform(): void {
-    const variables = sceneGraph.getVariables(this.scene).state.variables;
-    this.removedIndex = variables.findIndex((v) => v.state.name === this.name);
-    this.scene.removeVariable(this.name);
+    const varSet = sceneGraph.getVariables(this.scene);
+    this.removedIndex = varSet.state.variables.findIndex((v) => v.state.name === this.name);
+    if (this.removedIndex < 0) {
+      throw new Error(`Variable '${this.name}' not found`);
+    }
+    replaceVariableSet(
+      this.scene,
+      varSet.state.variables.filter((v) => v.state.name !== this.name)
+    );
   }
 
   undo(): void {
-    // Declarative inverse: re-insert at the recorded index using stored data.
-    this.scene.addVariable(this.variableKind, this.removedIndex);
+    const varSet = sceneGraph.getVariables(this.scene);
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- structurally compatible
+    const sceneVariable = createSceneVariableFromVariableModel(this.variableKind as VariableKind);
+    const current = [...varSet.state.variables];
+    if (this.removedIndex >= 0 && this.removedIndex < current.length) {
+      current.splice(this.removedIndex, 0, sceneVariable);
+    } else {
+      current.push(sceneVariable);
+    }
+    replaceVariableSet(this.scene, current);
   }
 }

--- a/public/app/features/dashboard-scene/user-actions/commands/RemoveVariableCommand.ts
+++ b/public/app/features/dashboard-scene/user-actions/commands/RemoveVariableCommand.ts
@@ -15,6 +15,7 @@ import type { UserActionCommand } from '../UserActionCommand';
  */
 export class RemoveVariableCommand implements UserActionCommand {
   title: string;
+  lockTarget = 'variables';
 
   private scene: DashboardScene;
   private name: string;

--- a/public/app/features/dashboard-scene/user-actions/commands/RemoveVariableCommand.ts
+++ b/public/app/features/dashboard-scene/user-actions/commands/RemoveVariableCommand.ts
@@ -1,0 +1,39 @@
+import { sceneGraph } from '@grafana/scenes';
+import type { VariableKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
+
+import type { DashboardScene } from '../../scene/DashboardScene';
+import type { UserActionCommand } from '../UserActionCommand';
+
+/**
+ * Removes a variable from the dashboard.
+ *
+ * Undo is declarative: records the index at perform() time (a primitive),
+ * then re-inserts the stored VariableKind at that index.
+ * No Scene-object references are captured in closures.
+ */
+export class RemoveVariableCommand implements UserActionCommand {
+  title: string;
+
+  private scene: DashboardScene;
+  private name: string;
+  private variableKind: VariableKind;
+  private removedIndex = 0;
+
+  constructor(scene: DashboardScene, name: string, variableKind: VariableKind) {
+    this.scene = scene;
+    this.name = name;
+    this.variableKind = variableKind;
+    this.title = `Remove variable '${name}'`;
+  }
+
+  perform(): void {
+    const variables = sceneGraph.getVariables(this.scene).state.variables;
+    this.removedIndex = variables.findIndex((v) => v.state.name === this.name);
+    this.scene.removeVariable(this.name);
+  }
+
+  undo(): void {
+    // Declarative inverse: re-insert at the recorded index using stored data.
+    this.scene.addVariable(this.variableKind, this.removedIndex);
+  }
+}


### PR DESCRIPTION
## POC for Proposal 2 in the [Mutation API design doc](https://docs.google.com/document/d/1N1t368pLLNhgpXPFITAPBy_4bwKLbcGazKzZrXI4yXQ/edit)

Architecture: layered. `mutations-api` handles agent-facing dispatch and validation. `dashboards-scene/user-actions` handles the UI-facing action surface and owns the undo/redo stack. Proposed by Piotr Jamróz during the 2026-05 alignment.

Paired with [grafana/grafana#123501](https://github.com/grafana/grafana/pull/123501) (Proposal 1, Scenes-native `cmd.*` + snapshot undo). Both PRs demonstrate identical acceptance criteria.

> **For trade-offs, differentiators, validated properties, and the side-by-side summary table, read [Proposal 2 + Summary in the design doc](https://docs.google.com/document/d/1N1t368pLLNhgpXPFITAPBy_4bwKLbcGazKzZrXI4yXQ/edit).** Below is PR-specific implementation detail only.

## Architecture

```mermaid
sequenceDiagram
    actor UI as Variable editor<br/>(shared.ts)
    actor Agent as Assistant
    participant Client as MutationApiClient
    participant CC as AddVariableClientCommand
    participant UAS as UserActionsService
    participant Cmd as AddVariableCommand
    participant Scene as DashboardScene
    participant Pane as DashboardEditPane

    Agent->>Client: execute(new AddVariableClientCommand(), payload)
    Client->>CC: handler(payload, context)
    CC->>CC: Zod validate + map JSON to inputs
    CC->>UAS: execute(new AddVariableCommand(scene, variableKind, position))

    UI->>UAS: execute(new AddVariableCommand(...))
    Note right of UI: UI bypasses Client entirely<br/>(no JSON, no Zod)

    UAS->>Scene: canEditDashboard()?
    UAS->>Scene: isWriteLocked(cmd.lockTarget)?
    Note over UAS: if locked: return { success:false, locked:true }
    UAS->>Cmd: perform()
    Cmd->>Scene: replaceVariableSet(...)
    UAS->>UAS: push cmd to _undoStack
    UAS->>Pane: publish DashboardEditActionEvent<br/>(perform: skip-first, undo: cmd.undo())
    Pane->>Pane: push to undoStack
    UAS-->>UI: UserActionExecuteResult
```

## Same 5 acceptance criteria as #123501

| | This PR (Proposal 2) |
|---|---|
| **1. UI add flow** | Variable editor calls `dashboard.userActionsService.execute(new AddVariableCommand(scene, variableKind, position))`. SceneVariable → VariableKind via a POC-scoped converter. |
| **2. Toolbar undo** | `UserActionsService.execute` publishes `DashboardEditActionEvent` with "skip first perform" so the existing toolbar undo button sees actions. (Full migration of `DashboardEditPane` to read from `UserActionsService` is a follow-up.) |
| **3. Canonical undo unit test** | Add `[a, b, c]`, remove `b`, undo restores at index 1, redo removes again. |
| **4. Multiplayer composition unit test** | Two sequential `execute` calls; second reads latest state. |
| **5. Working lock mechanism** | `DashboardScene.acquireWriteLock('variables')` short-circuits mutations with `{ success: false, locked: true, error }`. Reads via Scenes `useState` unaffected. Release, retry, succeeds. |

## Files changed (POC scope: addVariable / removeVariable)

```
public/app/features/dashboard-scene/
  edit-pane/shared.ts                          UI wiring through UserActionsService
  mutation-api/Client.ts                       agent entry point
  mutation-api/ClientCommand.ts                interface + toClientResult
  mutation-api/commands/AddVariableClientCommand.ts   validate + map + delegate
  mutation-api/commands/addVariable.ts         delegates through Client
  mutation-api/commands/variableUtils.ts       + createVariableKindFromSceneVariable (POC port)
  mutation-api/types.ts                        + locked?: boolean
  user-actions/UserActionCommand.ts            interface (title, lockTarget?, perform, undo)
  user-actions/UserActionsService.ts           stack + permission + lock + bridge
  user-actions/UserActionsService.test.ts      canonical undo + multiplayer + lock + title tests
  user-actions/commands/AddVariableCommand.ts  declarative inverse (lockTarget = 'variables')
  user-actions/commands/RemoveVariableCommand.ts  declarative inverse (lockTarget = 'variables')
  scene/DashboardScene.tsx                     + userActionsService getter, lock state, lock methods
```

## Run

```bash
yarn jest public/app/features/dashboard-scene/user-actions/UserActionsService.test.ts
```

## no-changelog