### PR TITLE
CI: Use non-event variant in mirroring workflow

### DIFF
--- a/.github/workflows/sync-mirror-event.yml
+++ b/.github/workflows/sync-mirror-event.yml
@@ -41,7 +41,7 @@ jobs:
             await github.rest.actions.createWorkflowDispatch({
                 owner: 'grafana',
                 repo: 'security-patch-actions',
-                workflow_id: 'mirror-branch-and-apply-patches-event.yml',
+                workflow_id: 'mirror-branch-and-apply-patches.yml',
                 ref: 'main',
                 inputs: {
                   src_ref: REF_NAME,


### PR DESCRIPTION
these were basically duplicates.