### PR TITLE
Grafana CLI: workflow to verify migrator snapshot is up to date

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -79,6 +79,7 @@
 /scripts/ci/generate-enterprise-imports @grafana/grafana-operator-experience-squad
 /scripts/catalog-plugins-defaults @grafana/grafana-datasources-core-services @kminehart
 /scripts/download-catalog-plugins.sh @grafana/grafana-datasources-core-services @kminehart
+/scripts/schema-dump/ @grafana/grafana-search-and-storage
 /hack/ @grafana/grafana-app-platform-squad
 /.air.toml @macabu
 
@@ -316,6 +317,7 @@
 /devenv/docker/blocks/mysql/ @grafana/data-sources-plugins
 /devenv/docker/blocks/mysql_exporter/ @grafana/data-sources-plugins
 /devenv/docker/blocks/mysql_opendata/ @grafana/data-sources-plugins
+/devenv/docker/blocks/mysql_schema_dump/ @grafana/grafana-search-and-storage
 /devenv/docker/blocks/mysql_tests/ @grafana/data-sources-plugins
 /devenv/docker/blocks/opentsdb/ @grafana/data-sources-plugins
 /devenv/docker/blocks/pgvector/ @grafana/grafana-search-and-storage
@@ -1300,6 +1302,7 @@ embed.go @grafana/grafana-as-code
 /.github/workflows/pr-external-labelling.yml @Proximyst
 /.github/workflows/pr-patch-check.yml @grafana/grafana-backend-services-squad
 /.github/workflows/pr-test-integration-pgvector.yml @grafana/grafana-search-and-storage
+/.github/workflows/pr-verify-schema.yml @grafana/grafana-search-and-storage
 /.github/workflows/pr-test-integration.yml @grafana/grafana-backend-group
 /.github/workflows/reject-gh-secrets.yml @grafana/grafana-backend-services-squad
 /.github/workflows/sync-mirror-event.yml @grafana/grafana-backend-services-squad

--- a/.github/workflows/pr-verify-schema.yml
+++ b/.github/workflows/pr-verify-schema.yml
@@ -1,0 +1,59 @@
+name: Verify schema dump
+
+# The job runs `cli admin db-migrate` + `grafana server` boot against MySQL,
+# dumps the schema, and diffs it against the committed baseline.
+#
+# To fix a failing run locally:
+#   make devenv sources=mysql_schema_dump
+#   make schema-dump
+#   # commit the updated pkg/services/sqlstore/migrator/snapshot/ files
+
+on:
+  pull_request:
+    paths:
+      - 'pkg/services/sqlstore/migrations/**'
+      - 'pkg/services/sqlstore/migrator/**'
+      - 'pkg/storage/unified/migrations/**'
+      - 'scripts/schema-dump/**'
+      - 'devenv/docker/blocks/mysql_schema_dump/**'
+      - '.github/workflows/pr-verify-schema.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+  verify-schema:
+    name: Verify migrator snapshot
+    runs-on: ubuntu-latest
+    services:
+      mysql:
+        # Pin to the same image the committed snapshot was generated with
+        # (see pkg/services/sqlstore/migrator/snapshot/*.sql headers).
+        image: mysql:8.4.9
+        env:
+          MYSQL_ROOT_PASSWORD: rootpass
+          MYSQL_DATABASE: grafana
+          MYSQL_INITDB_SKIP_TZINFO: "true"
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping --silent" --health-interval=10s --health-timeout=5s --health-retries=10
+    env:
+      GF_DATABASE_HOST: 127.0.0.1:3306
+      GF_DATABASE_NAME: grafana
+      GF_DATABASE_PASSWORD: rootpass
+      MYSQL_CLIENT_IMAGE: mysql:8.4.9
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
+      - name: Install mysql client
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends mysql-client
+      - name: Verify schema snapshot
+        run: make schema-dump-verify

--- a/.policy.yml
+++ b/.policy.yml
@@ -38,6 +38,7 @@ policy:
             - Workflow .github/workflows/pr-test-docker.yml succeeded or skipped
             - Workflow .github/workflows/pr-test-integration-pgvector.yml succeeded or skipped
             - Workflow .github/workflows/pr-test-integration.yml succeeded or skipped
+            - Workflow .github/workflows/pr-verify-schema.yml succeeded or skipped
             - Workflow .github/workflows/reject-gh-secrets.yml succeeded or skipped
             - Workflow .github/workflows/run-schema-v2-e2e.yml succeeded or skipped
             - Workflow .github/workflows/shellcheck.yml succeeded or skipped
@@ -634,6 +635,27 @@ approval_rules:
             - success
           workflows:
             - .github/workflows/pr-test-integration.yml
+  - name: Workflow .github/workflows/pr-verify-schema.yml succeeded or skipped
+    if:
+      changed_files:
+        paths:
+          - ^pkg\/services\/sqlstore\/migrations\/(?:(?:[^/]*(?:/|$))*)$
+          - ^pkg\/services\/sqlstore\/migrator\/(?:(?:[^/]*(?:/|$))*)$
+          - ^pkg\/storage\/unified\/migrations\/(?:(?:[^/]*(?:/|$))*)$
+          - ^scripts\/schema-dump\/(?:(?:[^/]*(?:/|$))*)$
+          - ^devenv\/docker\/blocks\/mysql_schema_dump\/(?:(?:[^/]*(?:/|$))*)$
+          - ^\.github\/workflows\/pr-verify-schema\.yml$
+      file_not_deleted:
+        paths:
+          - ^\.github\/workflows\/pr-verify-schema\.yml$
+    requires:
+      conditions:
+        has_workflow_result:
+          conclusions:
+            - skipped
+            - success
+          workflows:
+            - .github/workflows/pr-verify-schema.yml
   - name: Workflow .github/workflows/reject-gh-secrets.yml succeeded or skipped
     if:
       file_not_deleted:

--- a/Makefile
+++ b/Makefile
@@ -615,6 +615,14 @@ test-go-integration-memcached: ## Run integration tests for memcached cache.
 	MEMCACHED_HOSTS=localhost:11211 $(GO) test $(GO_RACE_FLAG) $(GO_TEST_FLAGS) -run IntegrationMemcached -covermode=atomic -timeout=2m \
 		$(shell ./scripts/ci/backend-tests/pkgs-with-tests-named.sh -b TestIntegration | ./scripts/ci/backend-tests/shard.sh -n$(SHARD) -m$(SHARDS) -d - -s)
 
+.PHONY: schema-dump
+schema-dump: ## Regenerate pkg/services/sqlstore/migrator/snapshot/ from a fresh MySQL (run `make devenv sources=mysql_schema_dump` first).
+	@./scripts/schema-dump/dump.sh
+
+.PHONY: schema-dump-verify
+schema-dump-verify: ## Verify the committed snapshot still matches what the migrator produces.
+	@./scripts/schema-dump/verify.sh
+
 .PHONY: test-js
 test-js: ## Run tests for frontend.
 	@echo "test frontend"

--- a/devenv/docker/blocks/mysql_schema_dump/.env
+++ b/devenv/docker/blocks/mysql_schema_dump/.env
@@ -1,0 +1,1 @@
+mysql_schema_dump_version=8.4.9

--- a/devenv/docker/blocks/mysql_schema_dump/docker-compose.yaml
+++ b/devenv/docker/blocks/mysql_schema_dump/docker-compose.yaml
@@ -1,0 +1,13 @@
+  mysql_schema_dump:
+    image: mysql:${mysql_schema_dump_version}
+    platform: linux/amd64
+    environment:
+      MYSQL_DATABASE: grafana
+      MYSQL_ROOT_PASSWORD: rootpass
+      MYSQL_INITDB_SKIP_TZINFO: "true"
+    ports:
+      - "3306:3306"
+    tmpfs: /var/lib/mysql:rw
+    command:
+      - mysqld
+      - --explicit-defaults-for-timestamp=ON

--- a/pkg/services/sqlstore/migrator/snapshot/00-schema.sql
+++ b/pkg/services/sqlstore/migrator/snapshot/00-schema.sql
@@ -1,8 +1,8 @@
--- MySQL dump 10.13  Distrib 8.4.5, for Linux (x86_64)
+-- MySQL dump 10.13  Distrib 8.4.9, for Linux (x86_64)
 --
 -- Host: localhost    Database: grafana
 -- ------------------------------------------------------
--- Server version	8.4.5
+-- Server version	8.4.9
 
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;

--- a/pkg/services/sqlstore/migrator/snapshot/95-unifiedstorage_migration_log.sql
+++ b/pkg/services/sqlstore/migrator/snapshot/95-unifiedstorage_migration_log.sql
@@ -1,8 +1,8 @@
--- MySQL dump 10.13  Distrib 8.4.5, for Linux (x86_64)
+-- MySQL dump 10.13  Distrib 8.4.9, for Linux (x86_64)
 --
 -- Host: localhost    Database: grafana
 -- ------------------------------------------------------
--- Server version	8.4.5
+-- Server version	8.4.9
 /*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
 /*!40103 SET TIME_ZONE='+00:00' */;
 /*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;

--- a/pkg/services/sqlstore/migrator/snapshot/96-secret_migration_log.sql
+++ b/pkg/services/sqlstore/migrator/snapshot/96-secret_migration_log.sql
@@ -1,8 +1,8 @@
--- MySQL dump 10.13  Distrib 8.4.5, for Linux (x86_64)
+-- MySQL dump 10.13  Distrib 8.4.9, for Linux (x86_64)
 --
 -- Host: localhost    Database: grafana
 -- ------------------------------------------------------
--- Server version	8.4.5
+-- Server version	8.4.9
 /*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
 /*!40103 SET TIME_ZONE='+00:00' */;
 /*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;

--- a/pkg/services/sqlstore/migrator/snapshot/97-resource_migration_log.sql
+++ b/pkg/services/sqlstore/migrator/snapshot/97-resource_migration_log.sql
@@ -1,8 +1,8 @@
--- MySQL dump 10.13  Distrib 8.4.5, for Linux (x86_64)
+-- MySQL dump 10.13  Distrib 8.4.9, for Linux (x86_64)
 --
 -- Host: localhost    Database: grafana
 -- ------------------------------------------------------
--- Server version	8.4.5
+-- Server version	8.4.9
 /*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
 /*!40103 SET TIME_ZONE='+00:00' */;
 /*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;

--- a/pkg/services/sqlstore/migrator/snapshot/98-data.sql
+++ b/pkg/services/sqlstore/migrator/snapshot/98-data.sql
@@ -1,8 +1,8 @@
--- MySQL dump 10.13  Distrib 8.4.5, for Linux (x86_64)
+-- MySQL dump 10.13  Distrib 8.4.9, for Linux (x86_64)
 --
 -- Host: localhost    Database: grafana
 -- ------------------------------------------------------
--- Server version	8.4.5
+-- Server version	8.4.9
 /*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
 /*!40103 SET TIME_ZONE='+00:00' */;
 /*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;

--- a/pkg/services/sqlstore/migrator/snapshot/99-migration_log.sql
+++ b/pkg/services/sqlstore/migrator/snapshot/99-migration_log.sql
@@ -1,8 +1,8 @@
--- MySQL dump 10.13  Distrib 8.4.5, for Linux (x86_64)
+-- MySQL dump 10.13  Distrib 8.4.9, for Linux (x86_64)
 --
 -- Host: localhost    Database: grafana
 -- ------------------------------------------------------
--- Server version	8.4.5
+-- Server version	8.4.9
 /*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
 /*!40103 SET TIME_ZONE='+00:00' */;
 /*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;

--- a/scripts/schema-dump/README.md
+++ b/scripts/schema-dump/README.md
@@ -1,0 +1,57 @@
+# MySQL schema snapshot
+
+Tooling that regenerates and verifies `pkg/services/sqlstore/migrator/snapshot/`,
+the embedded baseline `MySQLDialect.CreateDatabaseFromSnapshot` uses as the
+fresh-database fast-path.
+
+The CI workflow at `.github/workflows/pr-verify-schema.yml` runs
+`make schema-dump-verify` on every PR that touches a migration. If a developer
+adds a migration but forgets to regenerate the snapshot, the workflow fails
+with a diff.
+
+## How to update the snapshot
+
+Updates should be done when you add or modify a schema migration in
+`pkg/services/sqlstore/migrations/`, `pkg/services/sqlstore/migrator/`, or
+`pkg/storage/unified/migrations/`.
+
+**Note:** Before regenerating these SQL files, double-check your own
+migrations for any new `INSERT INTO ... VALUES ...` rows. The dump excludes
+several data tables by default
+(see `--ignore-table=` lines in `scripts/schema-dump/dump.sh`); if your
+migration relies on seeded data, either remove the table from the ignore list
+or dump it separately.
+
+1. Start the bundled MySQL devenv:
+
+   ```console
+   $ make devenv sources=mysql_schema_dump
+   ```
+
+   This brings up an empty `mysql:8.4.9` container on port 3306, configured to
+   match the version the snapshot is generated with.
+
+2. Regenerate the snapshot:
+
+   ```console
+   $ make schema-dump
+   ```
+
+   This builds the grafana binary, runs `cli admin db-migrate` plus a brief
+   `grafana server` boot against the devenv MySQL, then dumps the resulting
+   schema into `pkg/services/sqlstore/migrator/snapshot/`.
+
+3. Verify the new files make sense — diff them against the previous versions.
+   Migration log entries may appear in different orders because Grafana
+   migrations are non-deterministic between versions.
+
+4. Open a PR with the updated snapshot files. CI will run
+   `make schema-dump-verify` against your branch to confirm the snapshot
+   matches what the migrator now produces.
+
+## Files
+
+| Path        | What it does                                                                                                                   |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `dump.sh`   | The end-to-end pipeline. Reads env vars (see top of file) so the same script works locally and in CI's `services.mysql` block. |
+| `verify.sh` | Runs `dump.sh` into a temp dir and diffs against the committed snapshot. Used by `make schema-dump-verify`.                    |

--- a/scripts/schema-dump/dump.sh
+++ b/scripts/schema-dump/dump.sh
@@ -1,0 +1,233 @@
+#!/usr/bin/env bash
+#
+# Regenerates the committed migrator snapshot
+# (pkg/services/sqlstore/migrator/snapshot/) by running the branch's grafana
+# binary against MySQL and dumping the resulting schema.
+#
+# Expects a MySQL instance to already be reachable. Locally:
+#   make devenv sources=mysql_schema_dump
+# In CI: a `services.mysql:` block.
+#
+# Env vars (all optional):
+#   GF_DATABASE_HOST        default 127.0.0.1:3306
+#   GF_DATABASE_NAME        default grafana
+#   GF_DATABASE_USER        default root
+#   GF_DATABASE_PASSWORD    default rootpass
+#   OUT_DIR                 default pkg/services/sqlstore/migrator/snapshot
+#   MYSQL_CLIENT_IMAGE      default mysql:8.4.9
+#   KEEP_TMP                if non-empty, keep the temp scratch dir
+
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "$0")/../.." && pwd)
+cd "$ROOT_DIR"
+
+export GF_DATABASE_TYPE=mysql
+export GF_DATABASE_HOST="${GF_DATABASE_HOST:-127.0.0.1:3306}"
+export GF_DATABASE_NAME="${GF_DATABASE_NAME:-grafana}"
+export GF_DATABASE_USER="${GF_DATABASE_USER:-root}"
+export GF_DATABASE_PASSWORD="${GF_DATABASE_PASSWORD:-rootpass}"
+export GF_LOG_LEVEL=warn
+
+OUT_DIR=${OUT_DIR:-pkg/services/sqlstore/migrator/snapshot}
+# Pin the mysql client so dump output is byte-stable across hosts. Keep this
+# in sync with the workflow image and the mysql_schema_dump devenv block.
+MYSQL_CLIENT_IMAGE=${MYSQL_CLIENT_IMAGE:-mysql:8.4.9}
+
+# MYSQL_PWD avoids the "Using a password on the command line interface is
+# insecure" warning the `-p<password>` form emits.
+export MYSQL_PWD="$GF_DATABASE_PASSWORD"
+
+# Parse host:port for the mysql client tools.
+MYSQL_HOST="${GF_DATABASE_HOST%:*}"
+MYSQL_PORT="${GF_DATABASE_HOST##*:}"
+
+# Resolve mysqldump and mysql commands once. Use docker if available so the
+# client version is pinned; otherwise fall back to whatever is on $PATH.
+if command -v docker >/dev/null; then
+    DOCKER_NET=${DOCKER_NET:-host}
+    # -e MYSQL_PWD forwards the var into the container without exposing the
+    # password on docker's argv.
+    MYSQLDUMP=(docker run --rm --network "$DOCKER_NET" -e MYSQL_PWD "$MYSQL_CLIENT_IMAGE" mysqldump)
+    MYSQL_CLI=(docker run --rm --network "$DOCKER_NET" -e MYSQL_PWD "$MYSQL_CLIENT_IMAGE" mysql)
+    MYSQLADMIN=(docker run --rm --network "$DOCKER_NET" -e MYSQL_PWD "$MYSQL_CLIENT_IMAGE" mysqladmin)
+else
+    MYSQLDUMP=(mysqldump)
+    MYSQL_CLI=(mysql)
+    MYSQLADMIN=(mysqladmin)
+fi
+
+mkdir -p "$OUT_DIR"
+
+# ---- 1. Build the grafana binary from the current branch ----
+echo "=== Building grafana binary..."
+make build-go >/dev/null
+
+GOOS=$(go env GOOS)
+GOARCH=$(go env GOARCH)
+GRAFANA_BIN="$ROOT_DIR/bin/$GOOS-$GOARCH/grafana"
+if [[ ! -x "$GRAFANA_BIN" ]]; then
+    # Some make build-go invocations land at bin/grafana without the OS/ARCH dir.
+    GRAFANA_BIN="$ROOT_DIR/bin/grafana"
+fi
+if [[ ! -x "$GRAFANA_BIN" ]]; then
+    echo >&2 "Could not locate the grafana binary under bin/."
+    exit 1
+fi
+
+# ---- 2. Wait for MySQL ----
+echo "=== Waiting for MySQL at $GF_DATABASE_HOST..."
+maxTries=30
+while (( maxTries > 0 )) && ! "${MYSQLADMIN[@]}" ping -h "$MYSQL_HOST" -P "$MYSQL_PORT" \
+        -u "$GF_DATABASE_USER" --silent >/dev/null 2>&1; do
+    sleep 1
+    maxTries=$((maxTries - 1))
+done
+if (( maxTries == 0 )); then
+    echo >&2 "MySQL never became reachable."
+    exit 1
+fi
+
+# ---- 3. Sanity-check the target DB exists and is empty ----
+echo "=== Checking database $GF_DATABASE_NAME is reachable and empty..."
+existing_tables=$("${MYSQL_CLI[@]}" -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$GF_DATABASE_USER" \
+    -N -B -e "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema='$GF_DATABASE_NAME';" 2>/dev/null \
+    | tr -d '[:space:]')
+if [[ ! "$existing_tables" =~ ^[0-9]+$ ]]; then
+    echo >&2 "Could not query $GF_DATABASE_NAME (got: '$existing_tables')."
+    exit 1
+fi
+if [[ "$existing_tables" -ne 0 ]]; then
+    echo >&2 "Database $GF_DATABASE_NAME is not empty ($existing_tables tables). Drop it before running this script."
+    exit 1
+fi
+
+# ---- 4. Per-run scratch dir for grafana's data/log/plugin paths so we don't
+#         pollute the repo's data/ directory. ----
+RUNTIME_DIR=$(mktemp -d)
+if [[ -z "${KEEP_TMP:-}" ]]; then
+    trap 'rm -rf "$RUNTIME_DIR"' EXIT
+fi
+
+CFG_OVERRIDES=(
+    cfg:default.paths.data="$RUNTIME_DIR"
+    cfg:default.paths.logs="$RUNTIME_DIR/log"
+    cfg:default.paths.plugins="$RUNTIME_DIR/plugins"
+)
+
+# ---- 5. Run db-migrate (validates the new subcommand + applies main migrations) ----
+echo "=== Running grafana cli admin db-migrate..."
+"$GRAFANA_BIN" cli --homepath "$ROOT_DIR" admin db-migrate "${CFG_OVERRIDES[@]}"
+
+# ---- 6. Briefly boot grafana server to trigger the remaining migration subsystems
+#         (unified storage, resource backend, secret keepers). ----
+echo "=== Booting grafana server to flush remaining migrations..."
+SERVER_LOG="$RUNTIME_DIR/server.log"
+"$GRAFANA_BIN" server --homepath "$ROOT_DIR" "${CFG_OVERRIDES[@]}" >"$SERVER_LOG" 2>&1 &
+SERVER_PID=$!
+trap 'kill $SERVER_PID 2>/dev/null || true; [[ -z "${KEEP_TMP:-}" ]] && rm -rf "$RUNTIME_DIR"' EXIT
+
+# Wait for HTTP readiness (means apiserver registry has seeded resources too).
+maxTries=60
+while (( maxTries > 0 )) && ! curl -sf -o /dev/null http://127.0.0.1:3000/api/health; do
+    sleep 1
+    maxTries=$((maxTries - 1))
+    if ! kill -0 $SERVER_PID 2>/dev/null; then
+        echo >&2 "grafana server exited unexpectedly. Tail of log:"
+        tail -n 40 "$SERVER_LOG" >&2 || true
+        exit 1
+    fi
+done
+if (( maxTries == 0 )); then
+    echo >&2 "grafana server never became ready. Tail of log:"
+    tail -n 40 "$SERVER_LOG" >&2 || true
+    exit 1
+fi
+
+kill $SERVER_PID 2>/dev/null || true
+wait $SERVER_PID 2>/dev/null || true
+
+# ---- 7. Dump schema + per-subsystem migration logs ----
+MYSQLDUMP_OPTS=(
+    -h "$MYSQL_HOST" -P "$MYSQL_PORT"
+    -u "$GF_DATABASE_USER"
+    --skip-disable-keys --skip-add-drop-table --skip-add-locks
+)
+
+echo "=== Dumping schema..."
+"${MYSQLDUMP[@]}" "${MYSQLDUMP_OPTS[@]}" --no-data "$GF_DATABASE_NAME" \
+    > "$OUT_DIR/00-schema.sql"
+
+dump_log_table() {
+    local table=$1 outfile=$2
+    if ! "${MYSQL_CLI[@]}" -h "$MYSQL_HOST" -P "$MYSQL_PORT" -u "$GF_DATABASE_USER" -N -e \
+            "SELECT 1 FROM information_schema.tables WHERE table_schema='$GF_DATABASE_NAME' AND table_name='$table' LIMIT 1;" \
+            | grep -q 1; then
+        rm -f "$outfile"
+        return
+    fi
+    "${MYSQLDUMP[@]}" "${MYSQLDUMP_OPTS[@]}" --skip-set-charset \
+        --no-create-info --complete-insert --extended-insert \
+        "$GF_DATABASE_NAME" "$table" > "$outfile"
+}
+
+dump_log_table migration_log              "$OUT_DIR/99-migration_log.sql"
+dump_log_table secret_migration_log       "$OUT_DIR/96-secret_migration_log.sql"
+dump_log_table resource_migration_log     "$OUT_DIR/97-resource_migration_log.sql"
+dump_log_table unifiedstorage_migration_log "$OUT_DIR/95-unifiedstorage_migration_log.sql"
+
+# Data dump
+echo "=== Dumping data..."
+"${MYSQLDUMP[@]}" "${MYSQLDUMP_OPTS[@]}" --skip-set-charset \
+    --no-create-info --complete-insert --extended-insert \
+    --ignore-table="$GF_DATABASE_NAME".alert_configuration \
+    --ignore-table="$GF_DATABASE_NAME".alert_configuration_history \
+    --ignore-table="$GF_DATABASE_NAME".builtin_role \
+    --ignore-table="$GF_DATABASE_NAME".kv_store \
+    --ignore-table="$GF_DATABASE_NAME".migration_log \
+    --ignore-table="$GF_DATABASE_NAME".org \
+    --ignore-table="$GF_DATABASE_NAME".org_user \
+    --ignore-table="$GF_DATABASE_NAME".permission \
+    --ignore-table="$GF_DATABASE_NAME".resource \
+    --ignore-table="$GF_DATABASE_NAME".resource_history \
+    --ignore-table="$GF_DATABASE_NAME".resource_last_import_time \
+    --ignore-table="$GF_DATABASE_NAME".resource_migration_log \
+    --ignore-table="$GF_DATABASE_NAME".resource_version \
+    --ignore-table="$GF_DATABASE_NAME".role \
+    --ignore-table="$GF_DATABASE_NAME".secret_migration_log \
+    --ignore-table="$GF_DATABASE_NAME".seed_assignment \
+    --ignore-table="$GF_DATABASE_NAME".server_lock \
+    --ignore-table="$GF_DATABASE_NAME".unifiedstorage_migration_log \
+    --ignore-table="$GF_DATABASE_NAME".user \
+    "$GF_DATABASE_NAME" > "$OUT_DIR/98-data.sql"
+
+# ---- 8. Normalise output. ----
+echo "=== Normalising dumps..."
+for f in "$OUT_DIR"/*.sql; do
+    [[ -f "$f" ]] || continue
+    sed -i.bak \
+        -e '/^-- Dump completed on/d' \
+        -e 's/^-- Host: [^ ]*/-- Host: localhost/' \
+        -e 's/^\(.*\) AUTO_INCREMENT=[0-9]* \(.*\)$/\1 \2/' \
+        -e 's/\([^ ]\)20[0-9][0-9]-[0-1][0-9]-[0-3][0-9] [0-2][0-9]:[0-5][0-9]:[0-5][0-9]/\12022-01-01 00:00:00/g' \
+        -e 's/VALUES (/VALUES\n  (/g' \
+        -e 's/),(/),\n  (/g' \
+        "$f"
+    rm -f "$f.bak"
+done
+
+# Strip the auto-increment `id` column from `*_migration_log` dumps so the
+# snapshot replays correctly on a fresh DB (AUTO_INCREMENT regenerates them).
+for table in migration_log secret_migration_log resource_migration_log unifiedstorage_migration_log; do
+    file_glob="$OUT_DIR/*${table}.sql"
+    for f in $file_glob; do
+        [[ -f "$f" ]] || continue
+        sed -i.bak \
+            -e "s/^INSERT INTO \`$table\` (\`id\`, /INSERT INTO \`$table\` (/" \
+            -e 's/^  ([0-9][0-9]*,/  (/' \
+            "$f"
+        rm -f "$f.bak"
+    done
+done
+
+echo "=== Done. Snapshot written to $OUT_DIR"

--- a/scripts/schema-dump/verify.sh
+++ b/scripts/schema-dump/verify.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+#
+# Runs scripts/schema-dump/dump.sh into a temp dir and diffs it against the
+# committed snapshot. Fails if they don't match.
+#
+# Reuses the same env knobs as dump.sh — see that script for details.
+
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "$0")/../.." && pwd)
+BASELINE="$ROOT_DIR/pkg/services/sqlstore/migrator/snapshot"
+SCRATCH=$(mktemp -d)
+trap 'rm -rf "$SCRATCH"' EXIT
+
+OUT_DIR="$SCRATCH" "$ROOT_DIR/scripts/schema-dump/dump.sh"
+
+if diff -r "$BASELINE" "$SCRATCH" >/dev/null; then
+    echo "Schema snapshot matches the committed baseline."
+    exit 0
+fi
+
+echo >&2
+echo >&2 "============================================================"
+echo >&2 "Schema snapshot drift detected."
+echo >&2 ""
+echo >&2 "The migrator+server now produces a schema that differs from"
+echo >&2 "pkg/services/sqlstore/migrator/snapshot/. If you added or"
+echo >&2 "modified a migration this is expected — regenerate locally:"
+echo >&2 ""
+echo >&2 "    make devenv sources=mysql_schema_dump"
+echo >&2 "    make schema-dump"
+echo >&2 ""
+echo >&2 "Then commit the updated snapshot files."
+echo >&2 "============================================================"
+echo >&2
+
+diff -r "$BASELINE" "$SCRATCH" || true
+exit 1


### PR DESCRIPTION
**What is this feature?**

Adds a CI workflow that boots MySQL, runs `cli admin db-migrate` plus a brief `grafana server` boot against it, dumps the schema with mysqldump, and diffs the result against `pkg/services/sqlstore/migrator/snapshot/`. Catches PRs that add or modify a migration but forget to regenerate the embedded snapshot.

First commit: adds workflow and updates to MySQL 8.4.9 to purposefully fail the verification (since it was generated with 8.4.5).
Second commit: updates snapshot using 8.4.9 with new `make schema-dump`.

Example failed job (from first commit): https://github.com/grafana/grafana/actions/runs/26223704242/job/77165051864?pr=125257

Example passed job (from second commit): https://github.com/grafana/grafana/actions/runs/26226045997/job/77173241829?pr=125257

**Why do we need this feature?**

Today the snapshot is hand-regenerated via hg_init. There's no automation that catches "I added a migration but didn't update the snapshot", so drift accumulates silently and the `CreateDatabaseFromSnapshot` fast-path falls increasingly out of sync with what the migrator actually produces. This workflow surfaces drift on the PR that introduced it.

**Who is this feature for?**

Anyone touching `pkg/services/sqlstore/migrations/**` or the other migration subsystems (`pkg/services/sqlstore/migrator/**`, `pkg/storage/unified/migrations/**`).

**Which issue(s) does this PR fix?**

https://github.com/grafana/search-and-storage-team/issues/804

**Special notes for your reviewer:**

- **The PR check on this commit alone is expected to fail.** A follow-up commit on this branch will regenerate the snapshot for `mysql:8.4.9` (the version this workflow pins); once that lands the check passes. This is intentional — it demonstrates the workflow detecting real drift end to end.
- New developer entry points:
    - `make devenv sources=mysql_schema_dump` — empty `mysql:8.4.9` on port 3306 with the same flags hg_init's `dbdump.sh` uses.
    - `make schema-dump` — regenerate the committed snapshot.
    - `make schema-dump-verify` — what CI runs.
- mysqldump is run via `docker run --rm --network host mysql:8.4.9` so client output is byte-stable regardless of the host's `mysqldump` (which may be MariaDB's on macOS).

Please check that:
- [X] It works as expected from a user's perspective.
- [X] If this is a pre-GA feature, it is behind a feature toggle.
- [X] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.