### PR TITLE
Operator: Support selecting operator name from cli/ini.

### DIFF
--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2452,3 +2452,9 @@ public_root_url =
 # If empty, defaults to "<data_dir>/unified-search/bleve" (see [paths] section).
 # Please note that sharing the same index_path between multiple running Grafana instances is not supported.
 index_path =
+
+#################################### Operator ###########################################
+[operator]
+# Selects which registered operator to run when the target includes the operator module.
+# Leave empty to disable the operator.
+name =

--- a/pkg/server/module_server.go
+++ b/pkg/server/module_server.go
@@ -390,9 +390,9 @@ func (s *ModuleServer) initUnifiedVectorBackend(storageServerEnabled bool) func(
 }
 
 func (s *ModuleServer) initOperatorServer() (services.Service, error) {
-	operatorName := os.Getenv("GF_OPERATOR_NAME")
+	operatorName := s.cfg.Operator.Name
 	if operatorName == "" {
-		s.log.Debug("GF_OPERATOR_NAME environment variable empty or unset, can't start operator")
+		s.log.Debug("operator.name config empty or unset, can't start operator")
 		return nil, nil
 	}
 

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -565,6 +565,8 @@ type Cfg struct {
 
 	Search SearchSettings
 
+	Operator OperatorSettings
+
 	// MaxNestedFolderDepth is the hard ceiling for folder nesting depth.
 	// The SQL query builders use this value to generate JOIN chains.
 	MaxNestedFolderDepth int
@@ -1476,6 +1478,7 @@ func (cfg *Cfg) parseINIFile(iniFile *ini.File) error {
 	if Target != "" {
 		cfg.Target = util.SplitString(Target)
 	}
+	cfg.Operator = readOperatorSettings(iniFile)
 	cfg.Env = valueAsString(iniFile.Section(""), "app_mode", "development")
 	cfg.StackID = valueAsString(iniFile.Section("environment"), "stack_id", "")
 	cfg.Slug = valueAsString(iniFile.Section("environment"), "stack_slug", "")

--- a/pkg/setting/setting_operator.go
+++ b/pkg/setting/setting_operator.go
@@ -1,0 +1,15 @@
+package setting
+
+import (
+	"gopkg.in/ini.v1"
+)
+
+type OperatorSettings struct {
+	Name string
+}
+
+func readOperatorSettings(iniFile *ini.File) OperatorSettings {
+	s := OperatorSettings{}
+	s.Name = valueAsString(iniFile.Section("operator"), "name", "")
+	return s
+}


### PR DESCRIPTION
This lets us use command line args for the operator name whilst maintaining
backwards compatibility with the environment variable. Allows for example:

```
./bin/grafana server target cfg:target=operator cfg:operator.name=foo
```

