### PR TITLE
[main] Chore(deps): Upgrade uuid to 14.0.0

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -34,6 +34,7 @@ const esModules = [
   'earcut',
   'pbf',
   'geotiff',
+  'uuid',
 ].join('|');
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -439,7 +439,7 @@
     "tween-functions": "^1.2.0",
     "type-fest": "^4.18.2",
     "uplot": "1.6.32",
-    "uuid": "11.1.0",
+    "uuid": "14.0.0",
     "vis-data": "^8.0.0",
     "vis-network": "10.0.2",
     "whatwg-fetch": "3.6.20"

--- a/packages/grafana-plugin-configs/jest/utils.js
+++ b/packages/grafana-plugin-configs/jest/utils.js
@@ -28,4 +28,5 @@ export const grafanaESModules = [
   '@grafana/react-data-grid',
   '@grafana/llm',
   'pkce-challenge',
+  'uuid',
 ];

--- a/packages/grafana-runtime/package.json
+++ b/packages/grafana-runtime/package.json
@@ -72,7 +72,7 @@
     "react-use": "17.6.0",
     "rxjs": "7.8.2",
     "tslib": "2.8.1",
-    "uuid": "11.1.0"
+    "uuid": "14.0.0"
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "16.0.1",

--- a/packages/grafana-sql/package.json
+++ b/packages/grafana-sql/package.json
@@ -57,7 +57,7 @@
     "rxjs": "7.8.2",
     "sql-formatter-plus": "1.3.6",
     "tslib": "2.8.1",
-    "uuid": "11.1.0"
+    "uuid": "14.0.0"
   },
   "devDependencies": {
     "@rollup/plugin-dynamic-import-vars": "2.1.5",

--- a/public/app/plugins/datasource/grafana-testdata-datasource/package.json
+++ b/public/app/plugins/datasource/grafana-testdata-datasource/package.json
@@ -18,7 +18,7 @@
     "react-use": "17.6.0",
     "rxjs": "7.8.2",
     "tslib": "2.8.1",
-    "uuid": "11.1.0"
+    "uuid": "14.0.0"
   },
   "devDependencies": {
     "@grafana/e2e-selectors": "13.1.0-pre",

--- a/public/app/plugins/datasource/graphite/package.json
+++ b/public/app/plugins/datasource/graphite/package.json
@@ -20,7 +20,7 @@
     "rxjs": "7.8.2",
     "semver": "7.7.3",
     "tslib": "2.8.1",
-    "uuid": "11.1.0"
+    "uuid": "14.0.0"
   },
   "devDependencies": {
     "@grafana/e2e-selectors": "13.1.0-pre",

--- a/public/app/plugins/datasource/jaeger/package.json
+++ b/public/app/plugins/datasource/jaeger/package.json
@@ -20,7 +20,7 @@
     "rxjs": "7.8.2",
     "stream-browserify": "3.0.0",
     "tslib": "2.8.1",
-    "uuid": "11.1.0"
+    "uuid": "14.0.0"
   },
   "devDependencies": {
     "@grafana/plugin-configs": "workspace:*",

--- a/public/app/plugins/datasource/loki/package.json
+++ b/public/app/plugins/datasource/loki/package.json
@@ -22,7 +22,7 @@
     "react-use": "17.6.0",
     "rxjs": "7.8.2",
     "tslib": "2.8.1",
-    "uuid": "11.1.0"
+    "uuid": "14.0.0"
   },
   "devDependencies": {
     "@grafana/e2e-selectors": "13.1.0-pre",

--- a/public/app/plugins/datasource/opentsdb/package.json
+++ b/public/app/plugins/datasource/opentsdb/package.json
@@ -17,7 +17,7 @@
     "react-use": "17.6.0",
     "rxjs": "7.8.2",
     "tslib": "2.8.1",
-    "uuid": "11.1.0"
+    "uuid": "14.0.0"
   },
   "devDependencies": {
     "@grafana/e2e-selectors": "workspace:*",

--- a/public/app/plugins/datasource/tempo/package.json
+++ b/public/app/plugins/datasource/tempo/package.json
@@ -36,7 +36,7 @@
     "stream-browserify": "3.0.0",
     "string_decoder": "1.3.0",
     "tslib": "2.8.1",
-    "uuid": "11.1.0"
+    "uuid": "14.0.0"
   },
   "devDependencies": {
     "@grafana/plugin-configs": "13.1.0-pre",

--- a/public/test/jest-resolver.js
+++ b/public/test/jest-resolver.js
@@ -4,26 +4,10 @@ module.exports = (path, options) => {
     ...options,
     // Use packageFilter to process parsed `package.json` before the resolution (see https://www.npmjs.com/package/resolve#resolveid-opts-cb)
     packageFilter: (pkg) => {
-      // see https://github.com/microsoft/accessibility-insights-web/pull/5421#issuecomment-1109168149
-      // see https://github.com/uuidjs/uuid/pull/616
-      //
       // jest-environment-jsdom 28+ tries to use browser exports instead of default exports,
-      // but uuid/react-colorful only offers an ESM browser export and not a CommonJS one. Jest does not yet
-      // support ESM modules natively, so this causes a Jest error related to trying to parse
-      // "export" syntax.
-      //
-      // This workaround prevents Jest from considering uuid/react-colorful's module-based exports at all;
-      // it falls back to uuid's CommonJS+node "main" property.
-      //
-      // Once we're able to migrate our Jest config to ESM and a browser crypto
-      // implementation is available for the browser+ESM version of uuid to use (eg, via
-      // https://github.com/jsdom/jsdom/pull/3352 or a similar polyfill), this can go away.
-      //
-      // How to test if this is needed anymore:
-      // - comment it out
-      // - run `yarn test`
-      // - if all the tests pass, it means the workaround is no longer needed
-      if (pkg.name === 'uuid' || pkg.name === 'react-colorful') {
+      // but react-colorful only offers an ESM browser export and not a CommonJS one.
+      // Deleting exports forces fallback to the CommonJS "main" entry.
+      if (pkg.name === 'react-colorful') {
         delete pkg['exports'];
         delete pkg['module'];
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3148,7 +3148,7 @@ __metadata:
     ts-node: "npm:10.9.2"
     tslib: "npm:2.8.1"
     typescript: "npm:6.0.2"
-    uuid: "npm:11.1.0"
+    uuid: "npm:14.0.0"
     webpack: "npm:^5.105.0"
   peerDependencies:
     "@grafana/runtime": "*"
@@ -3191,7 +3191,7 @@ __metadata:
     ts-node: "npm:10.9.2"
     tslib: "npm:2.8.1"
     typescript: "npm:6.0.2"
-    uuid: "npm:11.1.0"
+    uuid: "npm:14.0.0"
     webpack: "npm:^5.105.0"
   peerDependencies:
     "@grafana/runtime": "*"
@@ -3271,7 +3271,7 @@ __metadata:
     ts-node: "npm:10.9.2"
     tslib: "npm:2.8.1"
     typescript: "npm:6.0.2"
-    uuid: "npm:11.1.0"
+    uuid: "npm:14.0.0"
     webpack: "npm:^5.105.0"
   peerDependencies:
     "@grafana/runtime": "*"
@@ -3316,7 +3316,7 @@ __metadata:
     ts-node: "npm:10.9.2"
     tslib: "npm:2.8.1"
     typescript: "npm:6.0.2"
-    uuid: "npm:11.1.0"
+    uuid: "npm:14.0.0"
     webpack: "npm:^5.105.0"
   peerDependencies:
     "@grafana/runtime": "*"
@@ -3421,7 +3421,7 @@ __metadata:
     ts-node: "npm:10.9.2"
     tslib: "npm:2.8.1"
     typescript: "npm:6.0.2"
-    uuid: "npm:11.1.0"
+    uuid: "npm:14.0.0"
     webpack: "npm:^5.105.0"
   peerDependencies:
     "@grafana/runtime": "*"
@@ -3563,7 +3563,7 @@ __metadata:
     ts-node: "npm:10.9.2"
     tslib: "npm:2.8.1"
     typescript: "npm:6.0.2"
-    uuid: "npm:11.1.0"
+    uuid: "npm:14.0.0"
     webpack: "npm:^5.105.0"
   peerDependencies:
     "@grafana/runtime": "*"
@@ -4222,7 +4222,7 @@ __metadata:
     ts-morph: "npm:^27.0.2"
     tslib: "npm:2.8.1"
     typescript: "npm:6.0.2"
-    uuid: "npm:11.1.0"
+    uuid: "npm:14.0.0"
   peerDependencies:
     react: ^18.0.0
     react-dom: ^18.0.0
@@ -4373,7 +4373,7 @@ __metadata:
     ts-node: "npm:10.9.2"
     tslib: "npm:2.8.1"
     typescript: "npm:6.0.2"
-    uuid: "npm:11.1.0"
+    uuid: "npm:14.0.0"
   peerDependencies:
     "@grafana/data": ">=10.4.0"
     "@grafana/runtime": ">=10.4.0"
@@ -20711,7 +20711,7 @@ __metadata:
     type-fest: "npm:^4.18.2"
     typescript: "npm:6.0.2"
     uplot: "npm:1.6.32"
-    uuid: "npm:11.1.0"
+    uuid: "npm:14.0.0"
     vis-data: "npm:^8.0.0"
     vis-network: "npm:10.0.2"
     webpack: "npm:^5.105.0"
@@ -34923,21 +34923,21 @@ __metadata:
   languageName: node
   linkType: hard
 
+"uuid@npm:14.0.0, uuid@npm:^14.0.0":
+  version: 14.0.0
+  resolution: "uuid@npm:14.0.0"
+  bin:
+    uuid: dist-node/bin/uuid
+  checksum: 10/8ee9b98f9650e25555515f7a28d3c3ae9364e72f7bb19b9e08b681bc135338beba5509b2830f6ae1cfaba4d45401da0d16d4d109b977097bc3d6ba0c5583341b
+  languageName: node
+  linkType: hard
+
 "uuid@npm:^13.0.0":
   version: 13.0.0
   resolution: "uuid@npm:13.0.0"
   bin:
     uuid: dist-node/bin/uuid
   checksum: 10/2742b24d1e00257e60612572e4d28679423469998cafbaf1fe9f1482e3edf9c40754b31bfdb3d08d71b29239f227a304588f75210b3b48f2609f0673f1feccef
-  languageName: node
-  linkType: hard
-
-"uuid@npm:^14.0.0":
-  version: 14.0.0
-  resolution: "uuid@npm:14.0.0"
-  bin:
-    uuid: dist-node/bin/uuid
-  checksum: 10/8ee9b98f9650e25555515f7a28d3c3ae9364e72f7bb19b9e08b681bc135338beba5509b2830f6ae1cfaba4d45401da0d16d4d109b977097bc3d6ba0c5583341b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## What

Pin `uuid` to `14.0.0` (exact, no caret) across the root workspace and 8 plugin/package workspaces:

- `grafana` (root)
- `@grafana/runtime`, `@grafana/sql`
- `@grafana-plugins/grafana-testdata-datasource`, `graphite`, `jaeger`, `loki`, `opentsdb`, `tempo`

## Why

Fixes [CVE-2026-41907](https://nvd.nist.gov/vuln/detail/CVE-2026-41907) — bounds-check flaw in `uuid` v3/v5/v6 when the caller passes an external output buffer. Fixed in `uuid@14.0.0`.

### Exposure assessment

Grafana has 37 `uuid` imports; 36 use `v4` (unaffected). The single `v5` call site (`public/app/plugins/datasource/loki/liveStreamsResultTransformer.ts:56`) uses the 2-arg form `uuidv5(name, namespace)` with no external buffer, so the flaw is **not reachable** in this code. This PR addresses the SCA flag and brings owned code onto the patched version.

### Not addressed in this PR

Transitive `uuid` versions remain (`8.3.2`, `9.0.1`, `11.1.0`, `13.0.0`) via `@grafana/scenes`, `@grafana/plugin-ui`, `@grafana/prometheus`, `@grafana/llm@1.0.3`, `lerna`, `@storybook/test-runner`, etc. Forcing them via `resolutions` would conflict with `vis-data` (which declares `uuid` ranges that exclude 14.x) and risks runtime breakage. Recommend handling those separately once parents publish a uuid-14-compatible release.

## Special notes for your reviewer

- Versions pinned exact per repo convention.
- No other code changes required — all current Grafana uuid usage is API-compatible with v14.

## Test plan

- [ ] CI passes
- [ ] `yarn why uuid --recursive` confirms all direct deps resolve to `14.0.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code) and [/cve-direct-upgrade](https://github.com/grafana/grafana-frontend-platform/blob/main/.claude/skills/cve-direct-upgrade/SKILL.md)
