### PR TITLE
Dashboards: Fix timeshift showing right time

### DIFF
--- a/public/app/features/dashboard-scene/scene/panel-timerange/PanelTimeRange.test.tsx
+++ b/public/app/features/dashboard-scene/scene/panel-timerange/PanelTimeRange.test.tsx
@@ -46,6 +46,14 @@ describe('PanelTimeRange', () => {
     expect(panelTime.state.timeInfo).toBe('Timeshift -2h');
   });
 
+  it('should preserve uppercase unit characters in timeshift label', () => {
+    const panelTime = new PanelTimeRange({ timeShift: '1M' });
+
+    buildAndActivateSceneFor(panelTime);
+
+    expect(panelTime.state.timeInfo).toBe('Timeshift -1M');
+  });
+
   it('should apply both relative time and time shift', () => {
     const panelTime = new PanelTimeRange({ timeFrom: '2h', timeShift: '2h' });
 

--- a/public/app/features/dashboard-scene/scene/panel-timerange/PanelTimeRange.tsx
+++ b/public/app/features/dashboard-scene/scene/panel-timerange/PanelTimeRange.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { capitalize } from 'lodash';
+import { upperFirst } from 'lodash';
 
 import {
   type DataQueryRequest,
@@ -232,7 +232,7 @@ export class PanelTimeRange extends SceneTimeRangeTransformerBase<PanelTimeRange
       infoBlocks.push(text);
     }
 
-    newTimeData.timeInfo = capitalize(infoBlocks.join(' + '));
+    newTimeData.timeInfo = upperFirst(infoBlocks.join(' + '));
     return newTimeData;
   }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fixes the way the timeshift appears in the panel time range -- for month usage (e.g.: `1M`) the visualized value is lowercased to `1m`. This PR fixes this.

The actual timeshift is applied properly to `1M`, so this PR only fixes the visual appearing on the panel header.

**Why do we need this feature?**

Fixes a visual bug

**Who is this feature for?**

Everyone

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
