### PR TITLE
Chore: bypass yarn min age gate for scenes and plugin-e2e

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -14,10 +14,11 @@ nodeLinker: node-modules
 
 # 1 day in minutes
 npmMinimalAgeGate: 1440
-# Exclude scenes and plugin-e2e from the minimal age gate
+# Exclude scenes and plugin-e2e from the minimal age gate to make development easier.
+# Do not add packages to this list that are not `@grafana` scoped, as it would be a security risk.
 npmPreapprovedPackages:
-  - '@grafana/scenes@*'
-  - '@grafana/plugin-e2e@*'
+  - "@grafana/scenes@*"
+  - "@grafana/plugin-e2e@*"
 
 packageExtensions:
   croact-css-styled@1.1.9:
@@ -33,9 +34,9 @@ packageExtensions:
 
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-outdated.cjs
-    spec: 'https://mskelton.dev/yarn-outdated/v2'
+    spec: "https://mskelton.dev/yarn-outdated/v2"
   - checksum: 374f735053958b77583ef7b70e56a59540d1d9c681f04b8ab7a600f4325301d2e1fb67c51d34ba75bbbc4e71f8c003fbc52b1f22d7daa30dca655f1a1bf205a1
     path: .yarn/plugins/@yarnpkg/plugin-licenses.cjs
-    spec: 'https://raw.githubusercontent.com/mhassan1/yarn-plugin-licenses/v0.15.0/bundles/@yarnpkg/plugin-licenses.js'
+    spec: "https://raw.githubusercontent.com/mhassan1/yarn-plugin-licenses/v0.15.0/bundles/@yarnpkg/plugin-licenses.js"
 
 yarnPath: .yarn/releases/yarn-4.15.0.cjs

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -14,6 +14,10 @@ nodeLinker: node-modules
 
 # 1 day in minutes
 npmMinimalAgeGate: 1440
+# Exclude scenes and plugin-e2e from the minimal age gate
+npmPreapprovedPackages:
+  - '@grafana/scenes@*'
+  - '@grafana/plugin-e2e@*'
 
 packageExtensions:
   croact-css-styled@1.1.9:
@@ -29,9 +33,9 @@ packageExtensions:
 
 plugins:
   - path: .yarn/plugins/@yarnpkg/plugin-outdated.cjs
-    spec: "https://mskelton.dev/yarn-outdated/v2"
+    spec: 'https://mskelton.dev/yarn-outdated/v2'
   - checksum: 374f735053958b77583ef7b70e56a59540d1d9c681f04b8ab7a600f4325301d2e1fb67c51d34ba75bbbc4e71f8c003fbc52b1f22d7daa30dca655f1a1bf205a1
     path: .yarn/plugins/@yarnpkg/plugin-licenses.cjs
-    spec: "https://raw.githubusercontent.com/mhassan1/yarn-plugin-licenses/v0.15.0/bundles/@yarnpkg/plugin-licenses.js"
+    spec: 'https://raw.githubusercontent.com/mhassan1/yarn-plugin-licenses/v0.15.0/bundles/@yarnpkg/plugin-licenses.js'
 
 yarnPath: .yarn/releases/yarn-4.15.0.cjs


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Bypass yarn age gate for specific grafana packages

**Why do we need this feature?**

Grafana maintainers regularly need to update scenes and plugin-e2e packages in this repo once merged and released.

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
