### PR TITLE
try this: minWidth to prevent min-content from doing the wrong thing

### DIFF
--- a/packages/grafana-ui/src/components/VizLayout/VizLayout.tsx
+++ b/packages/grafana-ui/src/components/VizLayout/VizLayout.tsx
@@ -114,6 +114,9 @@ export const getVizStyles = (theme: GrafanaTheme2) => {
   return {
     viz: css({
       flexGrow: 2,
+      // without this, minWidth becomes `min-content`, which means the canvas will
+      // never collapse down below its initial size. this means that the legend can never scale up in size
+      minWidth: 0,
       borderRadius: theme.shape.radius.default,
       '&:focus-visible': getFocusStyles(theme),
     }),


### PR DESCRIPTION
Claude said:

> In [VizLayout.tsx:105](vscode-webview://1q1o5sr7hslq0fl6tg433na32crkk5keb58ndmipnhebdtmjj9n4/packages/grafana-ui/src/components/VizLayout/VizLayout.tsx#L105) you do:
> 
> ```ts
> <div className={styles.viz}>{size && children(size.width, size.height)}</div>
> ```
> 
> …and the children render with `width: ${size.width}px` set inline (every viz does this). That inline pixel width becomes the viz flex item's intrinsic min-content. Because [VizLayout.tsx:116](vscode-webview://1q1o5sr7hslq0fl6tg433na32crkk5keb58ndmipnhebdtmjj9n4/packages/grafana-ui/src/components/VizLayout/VizLayout.tsx#L116) only sets `flexGrow: 2` (no `min-width: 0`), `min-width` defaults to `auto`, which equals `min-content`. So the viz cannot shrink below whatever its children last rendered at.