### PR TITLE
Heatmap: Rendering workaround for NHCB heatmaps

### DIFF
--- a/public/app/plugins/panel/heatmap/utils.test.ts
+++ b/public/app/plugins/panel/heatmap/utils.test.ts
@@ -11,6 +11,7 @@ import {
   boundedMinMax,
   calculateBucketExpansionFactor,
   calculateYSizeDivisor,
+  findFiniteBucketBounds,
   heatmapPathsDense,
   heatmapPathsPoints,
   heatmapPathsSparse,
@@ -1868,6 +1869,83 @@ describe('calculateBucketExpansionFactor', () => {
       const yMaxValues = [10, 20, 30, 40];
       const factor = calculateBucketExpansionFactor(yMinValues, yMaxValues);
       expect(factor).toBe(2); // Uses second bucket: 20/10 = 2
+    });
+  });
+});
+
+describe('findFiniteBucketBounds', () => {
+  it('returns the smallest finite yMin and largest finite yMax', () => {
+    const yMins = [1, 10, 100, 1000];
+    const yMaxs = [10, 100, 1000, 10000];
+    expect(findFiniteBucketBounds(yMins, yMaxs)).toEqual({
+      finiteMin: 1,
+      finiteMax: 10000,
+      hasUnboundedLower: false,
+      hasUnboundedUpper: false,
+    });
+  });
+
+  it('flags an unbounded lower tail (NHCB (-Inf, first])', () => {
+    const yMins = [-Infinity, 1, 10, 100];
+    const yMaxs = [1, 10, 100, 1000];
+    expect(findFiniteBucketBounds(yMins, yMaxs)).toEqual({
+      finiteMin: 1,
+      finiteMax: 1000,
+      hasUnboundedLower: true,
+      hasUnboundedUpper: false,
+    });
+  });
+
+  it('flags an unbounded upper tail (NHCB (last, +Inf])', () => {
+    const yMins = [1, 10, 100, 1000];
+    const yMaxs = [10, 100, 1000, Infinity];
+    expect(findFiniteBucketBounds(yMins, yMaxs)).toEqual({
+      finiteMin: 1,
+      finiteMax: 1000,
+      hasUnboundedLower: false,
+      hasUnboundedUpper: true,
+    });
+  });
+
+  it('flags both unbounded tails', () => {
+    const yMins = [-Infinity, 1, 10, 100];
+    const yMaxs = [1, 10, 100, Infinity];
+    expect(findFiniteBucketBounds(yMins, yMaxs)).toEqual({
+      finiteMin: 1,
+      finiteMax: 100,
+      hasUnboundedLower: true,
+      hasUnboundedUpper: true,
+    });
+  });
+
+  it('returns nulls when no finite bounds exist', () => {
+    const yMins = [-Infinity];
+    const yMaxs = [Infinity];
+    expect(findFiniteBucketBounds(yMins, yMaxs)).toEqual({
+      finiteMin: null,
+      finiteMax: null,
+      hasUnboundedLower: true,
+      hasUnboundedUpper: true,
+    });
+  });
+
+  it('returns nulls for empty input', () => {
+    expect(findFiniteBucketBounds([], [])).toEqual({
+      finiteMin: null,
+      finiteMax: null,
+      hasUnboundedLower: false,
+      hasUnboundedUpper: false,
+    });
+  });
+
+  it('skips non-number values', () => {
+    const yMins = [null, undefined, 'x', 1, 10];
+    const yMaxs = [null, undefined, 'x', 10, 100];
+    expect(findFiniteBucketBounds(yMins, yMaxs)).toEqual({
+      finiteMin: 1,
+      finiteMax: 100,
+      hasUnboundedLower: false,
+      hasUnboundedUpper: false,
     });
   });
 });

--- a/public/app/plugins/panel/heatmap/utils.test.ts
+++ b/public/app/plugins/panel/heatmap/utils.test.ts
@@ -1938,6 +1938,24 @@ describe('findFiniteBucketBounds', () => {
     });
   });
 
+  it('recovers boundaries from yMax when middle buckets are empty (sparse NHCB)', () => {
+    // Empty (1,10] and (10,100] buckets are omitted by NHCB's sparse encoding.
+    // The remaining samples are:
+    //   bucket A: yMin=-Inf, yMax=1   ← only place that yields finite boundary 1
+    //   bucket B: yMin=100,  yMax=1000
+    //   bucket C: yMin=1000, yMax=10000
+    // The smallest finite boundary (1) is only present in yMax, so a function
+    // that only considers yMin would incorrectly return finiteMin=100.
+    const yMins = [-Infinity, 100, 1000];
+    const yMaxs = [1, 1000, 10000];
+    expect(findFiniteBucketBounds(yMins, yMaxs)).toEqual({
+      finiteMin: 1,
+      finiteMax: 10000,
+      hasUnboundedLower: true,
+      hasUnboundedUpper: false,
+    });
+  });
+
   it('skips non-number values', () => {
     const yMins = [null, undefined, 'x', 1, 10];
     const yMaxs = [null, undefined, 'x', 10, 100];

--- a/public/app/plugins/panel/heatmap/utils.ts
+++ b/public/app/plugins/panel/heatmap/utils.ts
@@ -453,7 +453,53 @@ export function prepConfig(opts: PrepConfigOpts) {
           }
           return splits;
         }
-      : undefined,
+      : isSparseHeatmap
+        ? (self: uPlot) => {
+            // Render bucket boundaries as y-axis ticks so the visualization
+            // mirrors the classic histogram heatmap (which is ordinal and
+            // labels each le= row). For NHCB the boundaries are exactly the
+            // explicit values in yMin/yMax; for exponential native histograms
+            // they're the discrete base^k step points. Thinning happens via
+            // the values callback below.
+            const yMinData = self.data[1]?.[1];
+            const yMaxData = self.data[1]?.[2];
+            const yMinVals = Array.isArray(yMinData) ? yMinData : [];
+            const yMaxVals = Array.isArray(yMaxData) ? yMaxData : [];
+            const bounds = findFiniteBucketBounds(yMinVals, yMaxVals);
+            const factor = calculateBucketExpansionFactor(yMinVals, yMaxVals);
+
+            const finite = new Set<number>();
+            for (const v of yMinVals) {
+              if (typeof v === 'number' && Number.isFinite(v)) {
+                finite.add(v);
+              }
+            }
+            for (const v of yMaxVals) {
+              if (typeof v === 'number' && Number.isFinite(v)) {
+                finite.add(v);
+              }
+            }
+            let splits = [...finite].sort((a, b) => a - b);
+
+            if (bounds.hasUnboundedLower && bounds.finiteMin != null && factor > 1) {
+              splits.unshift(bounds.finiteMin / factor);
+            }
+            if (bounds.hasUnboundedUpper && bounds.finiteMax != null && factor > 1) {
+              splits.push(bounds.finiteMax * factor);
+            }
+
+            // Thin labels when the y-axis is too short to fit them all.
+            if (self.height < 60 && splits.length > 2) {
+              splits = [splits[0], splits[splits.length - 1]];
+            } else {
+              while (splits.length > 3 && (self.height - 15) / splits.length < 10) {
+                splits = splits.filter((_v, idx) => idx % 2 === 0);
+              }
+            }
+
+            return splits;
+          }
+        : undefined,
     values: isOrdinalY
       ? (self: uPlot, splits) => {
           const meta = readHeatmapRowsCustomMeta(dataRef.current?.heatmap);
@@ -466,7 +512,38 @@ export function prepConfig(opts: PrepConfigOpts) {
           }
           return splits;
         }
-      : undefined,
+      : isSparseHeatmap
+        ? (self: uPlot, splits) => {
+            // Label synthetic axis bounds (introduced for unbounded NHCB
+            // tails) as the conventional "0" / "+Inf" used by the classic
+            // histogram heatmap; finite bucket boundaries use the normal
+            // display formatter.
+            const yMinData = self.data[1]?.[1];
+            const yMaxData = self.data[1]?.[2];
+            const yMinVals = Array.isArray(yMinData) ? yMinData : [];
+            const yMaxVals = Array.isArray(yMaxData) ? yMaxData : [];
+            const bounds = findFiniteBucketBounds(yMinVals, yMaxVals);
+            const factor = calculateBucketExpansionFactor(yMinVals, yMaxVals);
+            const syntheticLower =
+              bounds.hasUnboundedLower && bounds.finiteMin != null && factor > 1
+                ? bounds.finiteMin / factor
+                : null;
+            const syntheticUpper =
+              bounds.hasUnboundedUpper && bounds.finiteMax != null && factor > 1
+                ? bounds.finiteMax * factor
+                : null;
+
+            return splits.map((v) => {
+              if (syntheticLower != null && v === syntheticLower) {
+                return '0';
+              }
+              if (syntheticUpper != null && v === syntheticUpper) {
+                return '+Inf';
+              }
+              return formattedValueToString(dispY(v, undefined));
+            });
+          }
+        : undefined,
   });
 
   const pathBuilder = isSparseHeatmap ? heatmapPathsSparse : heatmapPathsDense;

--- a/public/app/plugins/panel/heatmap/utils.ts
+++ b/public/app/plugins/panel/heatmap/utils.ts
@@ -426,6 +426,12 @@ export function prepConfig(opts: PrepConfigOpts) {
     label: yAxisConfig.axisLabel,
     theme: theme,
     formatValue: (v, decimals) => formattedValueToString(dispY(v, decimals)),
+    // Sparse heatmaps already do their own height-aware tick thinning in the
+    // splits callback (and need every remaining split labeled to match the
+    // classic histogram heatmap's row layout). Drop uPlot's default
+    // calculateSpace-based collision filter so it doesn't re-drop labels we
+    // explicitly asked for.
+    space: isSparseHeatmap ? 1 : undefined,
     splits: isOrdinalY
       ? (self: uPlot) => {
           const meta = readHeatmapRowsCustomMeta(dataRef.current?.heatmap);

--- a/public/app/plugins/panel/heatmap/utils.ts
+++ b/public/app/plugins/panel/heatmap/utils.ts
@@ -1014,28 +1014,34 @@ export function heatmapPathsSparse(opts: PathbuilderOpts) {
  * @param yMaxValues - Array of yMax bucket boundary values
  */
 export function findFiniteBucketBounds(yMinValues: unknown[], yMaxValues: unknown[]) {
+  // Every bucket boundary appears as either the yMin of one sample or the yMax
+  // of another (or both). For sparse encodings — NHCB omits empty buckets —
+  // some boundaries appear only in yMax (e.g., the upper bound of the lowest
+  // populated bucket when the bucket immediately above it is empty). Combine
+  // both fields when computing the smallest / largest finite boundary so we
+  // don't miss those.
   let finiteMin = Infinity;
   let finiteMax = -Infinity;
   let hasUnboundedLower = false;
   let hasUnboundedUpper = false;
 
+  const consider = (v: unknown, position: 'min' | 'max') => {
+    if (typeof v !== 'number') {
+      return;
+    }
+    if (Number.isFinite(v)) {
+      finiteMin = Math.min(finiteMin, v);
+      finiteMax = Math.max(finiteMax, v);
+    } else if (position === 'min') {
+      hasUnboundedLower = true;
+    } else {
+      hasUnboundedUpper = true;
+    }
+  };
+
   for (let i = 0; i < yMinValues.length; i++) {
-    const yMin = yMinValues[i];
-    const yMax = yMaxValues[i];
-    if (typeof yMin === 'number') {
-      if (Number.isFinite(yMin)) {
-        finiteMin = Math.min(finiteMin, yMin);
-      } else {
-        hasUnboundedLower = true;
-      }
-    }
-    if (typeof yMax === 'number') {
-      if (Number.isFinite(yMax)) {
-        finiteMax = Math.max(finiteMax, yMax);
-      } else {
-        hasUnboundedUpper = true;
-      }
-    }
+    consider(yMinValues[i], 'min');
+    consider(yMaxValues[i], 'max');
   }
 
   return {

--- a/public/app/plugins/panel/heatmap/utils.ts
+++ b/public/app/plugins/panel/heatmap/utils.ts
@@ -252,7 +252,27 @@ export function prepConfig(opts: PrepConfigOpts) {
             // uPlot auto-ranges from the yMin facet data, so we grow by one bucket factor.
             // When yMin values are all 0, multiplicative expansion stays 0; fall back to max(yMax).
             const bucketFactor = calculateBucketExpansionFactor(yMinValues, yMaxValues);
-            dataMax *= bucketFactor;
+
+            // Native histograms with custom bounds (NHCB) can carry unbounded
+            // tail buckets such as (-Inf, first] and (last, +Inf]. uPlot's
+            // dataMin/dataMax can be ±Inf in that case, which breaks the
+            // downstream log-scale math. Substitute the finite bucket extrema
+            // and give each unbounded end one geometric bucket of room.
+            const bounds = findFiniteBucketBounds(yMinValues, yMaxValues);
+            if (bounds.finiteMin != null) {
+              dataMin = bounds.finiteMin;
+            }
+            if (bounds.finiteMax != null) {
+              dataMax = bounds.finiteMax;
+            }
+            if (bounds.hasUnboundedLower && bounds.finiteMin != null && bucketFactor > 1) {
+              dataMin = bounds.finiteMin / bucketFactor;
+            }
+            if (bounds.hasUnboundedUpper && bounds.finiteMax != null && bucketFactor > 1) {
+              dataMax = bounds.finiteMax * bucketFactor;
+            } else {
+              dataMax *= bucketFactor;
+            }
             if (dataMax <= 0) {
               dataMax = yMaxValues.reduce<number>((acc, v) => (typeof v === 'number' && v > acc ? v : acc), 1);
             }
@@ -827,6 +847,16 @@ export function heatmapPathsSparse(opts: PathbuilderOpts) {
         let xOffs = new Map();
         let yOffs = new Map();
 
+        // Native histograms with custom bounds (NHCB) can carry unbounded
+        // tail buckets, surfacing yMin = -Infinity or yMax = +Infinity.
+        // valToPosY of a non-finite value on a log scale returns NaN, which
+        // would otherwise silently drop the cell (Canvas2D rect with NaN
+        // dimensions is a no-op). Substitute the scale's resolved bounds —
+        // these are finite by construction, since the range callback above
+        // computes scaleMin/scaleMax from the finite bucket extrema.
+        const scaleYMin = scaleY.min!;
+        const scaleYMax = scaleY.max!;
+
         for (let i = 0; i < xMaxs.length; i++) {
           let xMax = xMaxs[i];
           let yMin = yMins[i];
@@ -837,11 +867,13 @@ export function heatmapPathsSparse(opts: PathbuilderOpts) {
           }
 
           if (!yOffs.has(yMin)) {
-            yOffs.set(yMin, round(valToPosY(yMin, scaleY, yDim, yOff)));
+            const yMinSafe = Number.isFinite(yMin) ? yMin : scaleYMin;
+            yOffs.set(yMin, round(valToPosY(yMinSafe, scaleY, yDim, yOff)));
           }
 
           if (!yOffs.has(yMax)) {
-            yOffs.set(yMax, round(valToPosY(yMax, scaleY, yDim, yOff)));
+            const yMaxSafe = Number.isFinite(yMax) ? yMax : scaleYMax;
+            yOffs.set(yMax, round(valToPosY(yMaxSafe, scaleY, yDim, yOff)));
           }
         }
 
@@ -893,6 +925,47 @@ export function heatmapPathsSparse(opts: PathbuilderOpts) {
     );
 
     return null;
+  };
+}
+
+/**
+ * Returns the smallest finite yMin, the largest finite yMax, and whether
+ * either tail of the bucket sequence is unbounded (e.g., NHCB's (-Inf, first]
+ * and (last, +Inf] tail buckets).
+ *
+ * @param yMinValues - Array of yMin bucket boundary values
+ * @param yMaxValues - Array of yMax bucket boundary values
+ */
+export function findFiniteBucketBounds(yMinValues: unknown[], yMaxValues: unknown[]) {
+  let finiteMin = Infinity;
+  let finiteMax = -Infinity;
+  let hasUnboundedLower = false;
+  let hasUnboundedUpper = false;
+
+  for (let i = 0; i < yMinValues.length; i++) {
+    const yMin = yMinValues[i];
+    const yMax = yMaxValues[i];
+    if (typeof yMin === 'number') {
+      if (Number.isFinite(yMin)) {
+        finiteMin = Math.min(finiteMin, yMin);
+      } else {
+        hasUnboundedLower = true;
+      }
+    }
+    if (typeof yMax === 'number') {
+      if (Number.isFinite(yMax)) {
+        finiteMax = Math.max(finiteMax, yMax);
+      } else {
+        hasUnboundedUpper = true;
+      }
+    }
+  }
+
+  return {
+    finiteMin: Number.isFinite(finiteMin) ? finiteMin : null,
+    finiteMax: Number.isFinite(finiteMax) ? finiteMax : null,
+    hasUnboundedLower,
+    hasUnboundedUpper,
   };
 }
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Fixes rendering of Prometheus Native Histograms with Custom Buckets (NHCB) in the Heatmap panel. 
Brings their visualization to parity with the classic histogram heatmap:

- Renders the cells at the unbounded (−∞, first] and (last, +∞) tails, which previously vanished because 
their ±Infinity bounds mapped to NaN pixel positions on the log y-axis.
- Labels the y-axis at the actual bucket boundary values (and "0" / "+Inf" at the synthetic floor/ceiling), instead of uPlot's default log2 ticks which don't align with the data.
- Correctly recovers all bucket boundaries when middle buckets are empty (sparse encoding omits them, so some boundaries appear only in yMax).
- Prevents uPlot's collision-based label thinning from dropping ticks we explicitly placed at bucket boundaries.

**Why do we need this feature?**

When a Prometheus pipeline converts classic histograms to NHCB (e.g., via Alloy's convert_classic_histograms_to_nhcb, or via prometheus.exporter.unix / direct OTLP ingestion), the Heatmap panel silently drops data:

- The bottom and top buckets disappear entirely whenever the histogram has unbounded tails — meaning a non-trivial fraction of observations (in our staging deployment, ~11% of response-size samples fell in (−∞, 1 byte]) becomes invisible.
- Y-axis labels are unrelated to the data's actual buckets, making it hard to read the chart and impossible to compare against the same metric rendered as a classic histogram on another panel.
- The same data viewed via classic _bucket{le=...} series renders correctly, so this is purely a regression of NHCB rendering vs. the equivalent classic shape.

**Who is this feature for?**

Anyone deploying Prometheus or Mimir with native histograms with custom buckets (NHCB) and visualizing them in the Heatmap panel or via Metrics Drilldown (which embeds the same panel). In practice that's:

- Teams that have migrated from classic to native histograms for cardinality reasons.
- Anyone using Alloy/Prometheus features that emit NHCB (convert_classic_histograms_to_nhcb, OTLP ingestion of OpenTelemetry explicit-bucket histograms).
- Metrics Drilldown users — the drilldown's histogram panels go through this same heatmap rendering path.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #125186

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
