### PR TITLE
Docs: Tempo: Document default search filter chips via provisioning

### DIFF
--- a/docs/sources/datasources/tempo/configure-tempo-data-source/additional-settings.md
+++ b/docs/sources/datasources/tempo/configure-tempo-data-source/additional-settings.md
@@ -66,6 +66,47 @@ The **Search** setting configures [Tempo search](https://grafana.com/docs/tempo/
 
 You can configure the **Hide search** setting to hide the search query option in **Explore** if search is not configured in the Tempo instance.
 
+### Default filter chips
+
+The **Static filters** setting controls which filter chips are pinned in the Search tab of the query editor.
+Pinning a filter makes its tag a first-class chip in the **Search** row, so users don't have to add it manually for every query.
+
+By default, the Search tab pins **Service Name** (`service.name`) and **Span Name** (`name`).
+You can add or remove filters from the data source settings UI, or set them through [provisioning](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/datasources/tempo/configure-tempo-data-source/provision/) using the `search.filters` field.
+
+Each filter accepts the following properties:
+
+| Property   | Description                                                                                                   |
+| ---------- | ------------------------------------------------------------------------------------------------------------- |
+| `id`       | A unique identifier for the filter. Used internally to track the filter and prevent duplicates.               |
+| `tag`      | The tag the filter applies to, for example `service.name`, `http.status_code`, or `trace:id`.                 |
+| `scope`    | The TraceQL scope. One of `resource`, `span`, `intrinsic`, `event`, `instrumentation`, `link`, or `unscoped`. |
+| `operator` | The default operator, for example `=`, `!=`, or `=~`.                                                         |
+
+The following example pins **Trace ID**, **HTTP status code**, **Service Name**, and a tenant-specific tag as default filter chips:
+
+```yaml
+jsonData:
+  search:
+    filters:
+      - id: 'trace-id'
+        tag: 'trace:id'
+        scope: 'intrinsic'
+        operator: '='
+      - id: 'http-status-code'
+        tag: 'http.status_code'
+        scope: 'span'
+        operator: '='
+      - id: 'service-name'
+        tag: 'service.name'
+        scope: 'resource'
+        operator: '='
+      - id: 'customer-id'
+        tag: 'customer.id'
+        scope: 'span'
+        operator: '='
+```
+
 ## TraceID query
 
 The **TraceID query** setting modifies how TraceID queries are run.

--- a/docs/sources/datasources/tempo/configure-tempo-data-source/provision.md
+++ b/docs/sources/datasources/tempo/configure-tempo-data-source/provision.md
@@ -87,6 +87,15 @@ datasources:
         enabled: true
       search:
         hide: false
+        filters:
+          - id: 'service-name'
+            tag: 'service.name'
+            scope: 'resource'
+            operator: '='
+          - id: 'span-name'
+            tag: 'name'
+            scope: 'span'
+            operator: '='
       traceQuery:
         timeShiftEnabled: true
         spanStartTimeShift: '-1h'

--- a/public/app/plugins/datasource/tempo/datasource.ts
+++ b/public/app/plugins/datasource/tempo/datasource.ts
@@ -110,6 +110,7 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
   search?: {
     hide?: boolean;
     filters?: TraceqlFilter[];
+    defaultFilters?: TraceqlFilter[];
   };
   nodeGraph?: NodeGraphOptions;
   traceQuery?: {
@@ -143,6 +144,14 @@ export class TempoDatasource extends DataSourceWithBackend<TempoQuery, TempoJson
     this.streamingEnabled = instanceSettings.jsonData.streamingEnabled;
     this.timeRangeForTags = instanceSettings.jsonData.timeRangeForTags;
     this.languageProvider = new TempoLanguageProvider(this);
+
+    // Support defaultFilters as an alias for filters
+    if (this.search?.defaultFilters && !this.search.filters) {
+      this.search = {
+        ...this.search,
+        filters: this.search.defaultFilters
+      };
+    }
 
     if (!this.search?.filters) {
       this.search = {

--- a/public/app/plugins/datasource/tempo/types.ts
+++ b/public/app/plugins/datasource/tempo/types.ts
@@ -11,6 +11,7 @@ export interface TempoJsonData extends DataSourceJsonData {
   search?: {
     hide?: boolean;
     filters?: TraceqlFilter[];
+    defaultFilters?: TraceqlFilter[];
   };
   nodeGraph?: NodeGraphOptions;
   spanBar?: {


### PR DESCRIPTION
**What is this feature?**

Documents the `search.filters` field in the Tempo data source `jsonData`. This field already lets operators pin filter chips in the Search tab  including the trace ID intrinsic, span/resource tags, and custom tenant attributes  but it was missing from the reference and provisioning docs.

- Adds a "Default filter chips" subsection under **Tempo search** in the additional settings reference, with a property table and an example covering `trace:id`, `http.status_code`, `service.name`, and a custom span tag.
- Adds `search.filters` to the example provisioning YAML so the defaults (`service.name` and `name`) are visible in the standard reference.

**Why do we need this feature?**

Users on the Search tab today see only the built-in chips (Service Name, Span Name, Status, Duration, Tags). Adding `trace:id` or dataset-specific attributes like `http.status_code` and `customer.id` requires either the "Add tag" affordance every time, or knowing about the data source's Static filters UI. The capability to pin these as defaults already exists in `jsonData.search.filters`, it just wasn't documented anywhere. This PR closes that gap so operators can configure their search experience through provisioning.

**Who is this feature for?**

Operators and admins who provision Tempo (or Tempo-compatible) data sources via YAML, and teams migrating from vendors where attribute-driven search is the default  they can now pin the chips that match their data without telling every user to add the same tag manually.

**Which issue(s) does this PR fix?**:

Fixes grafana/grafana-tempo-datasource#145

**Special notes for your reviewer:**

This is a docs-only change. No code or schema modifications.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle. (N/A  docs only)
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
