### PR TITLE
fix: dashboard move to restricted folder

### DIFF
--- a/pkg/registry/apis/dashboard/dashboard_storage.go
+++ b/pkg/registry/apis/dashboard/dashboard_storage.go
@@ -2,10 +2,12 @@ package dashboard
 
 import (
 	"context"
+	"fmt"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/apiserver/pkg/warning"
 
 	"github.com/grafana/grafana-app-sdk/logging"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
@@ -40,8 +42,14 @@ func (d dashboardStorageWrapper) Update(ctx context.Context, name string, objInf
 		return nil, false, err
 	}
 
-	obj, created, err := d.Storage.Update(ctx, name, objInfo, createValidation, updateValidation, forceAllowCreate, options)
-	if err == nil && ns.OrgID > 0 && d.live != nil {
+	tracker := &folderChangeTracker{inner: objInfo}
+
+	obj, created, err := d.Storage.Update(ctx, name, tracker, createValidation, updateValidation, forceAllowCreate, options)
+	if err != nil {
+		return obj, created, err
+	}
+
+	if ns.OrgID > 0 && d.live != nil {
 		m, err := utils.MetaAccessor(obj)
 		if err == nil {
 			if err := d.live.DashboardSaved(ns.Value, name, m.GetResourceVersion()); err != nil {
@@ -49,7 +57,46 @@ func (d dashboardStorageWrapper) Update(ctx context.Context, name string, objInf
 			}
 		}
 	}
-	return obj, created, err
+
+	// Clear direct grants on move so principals don't keep access in a more restrictive parent.
+	if !created && tracker.folderChanged() && ns.OrgID > 0 && d.dashboardPermissionsSvc != nil {
+		if accessErr := d.dashboardPermissionsSvc.DeleteResourcePermissions(ctx, ns.OrgID, name); accessErr != nil {
+			return obj, created, accessErr
+		}
+		warning.AddWarning(ctx, "", fmt.Sprintf("Directly assigned permissions on dashboard %q were cleared because its parent folder changed (from %q to %q). Inherited folder permissions still apply.", name, tracker.oldFolder, tracker.newFolder))
+	}
+
+	return obj, created, nil
+}
+
+type folderChangeTracker struct {
+	inner     rest.UpdatedObjectInfo
+	captured  bool
+	oldFolder string
+	newFolder string
+}
+
+func (t *folderChangeTracker) Preconditions() *metav1.Preconditions {
+	return t.inner.Preconditions()
+}
+
+func (t *folderChangeTracker) UpdatedObject(ctx context.Context, oldObj runtime.Object) (runtime.Object, error) {
+	newObj, err := t.inner.UpdatedObject(ctx, oldObj)
+	if err != nil {
+		return newObj, err
+	}
+	if oldMeta, mErr := utils.MetaAccessor(oldObj); mErr == nil {
+		t.oldFolder = oldMeta.GetFolder()
+	}
+	if newMeta, mErr := utils.MetaAccessor(newObj); mErr == nil {
+		t.newFolder = newMeta.GetFolder()
+	}
+	t.captured = true
+	return newObj, nil
+}
+
+func (t *folderChangeTracker) folderChanged() bool {
+	return t.captured && t.oldFolder != t.newFolder
 }
 
 func (d dashboardStorageWrapper) Delete(ctx context.Context, name string, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions) (runtime.Object, bool, error) {

--- a/pkg/registry/apis/dashboard/dashboard_storage_test.go
+++ b/pkg/registry/apis/dashboard/dashboard_storage_test.go
@@ -1,0 +1,156 @@
+package dashboard
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	k8srequest "k8s.io/apiserver/pkg/endpoints/request"
+	"k8s.io/apiserver/pkg/registry/rest"
+	"k8s.io/apiserver/pkg/warning"
+
+	dashv1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1beta1"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+)
+
+type recordingPermissionsService struct {
+	accesscontrol.PermissionsService
+	mu        sync.Mutex
+	calls     []recordingDeleteCall
+	returnErr error
+}
+
+type recordingDeleteCall struct {
+	orgID      int64
+	resourceID string
+}
+
+func (r *recordingPermissionsService) DeleteResourcePermissions(_ context.Context, orgID int64, resourceID string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.calls = append(r.calls, recordingDeleteCall{orgID: orgID, resourceID: resourceID})
+	return r.returnErr
+}
+
+type recordingWarnings struct {
+	mu       sync.Mutex
+	warnings []string
+}
+
+func (r *recordingWarnings) AddWarning(_ string, text string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.warnings = append(r.warnings, text)
+}
+
+func newDashboardWithFolder(name, folder string) *unstructured.Unstructured {
+	u := &unstructured.Unstructured{}
+	u.SetGroupVersionKind(dashv1.DashboardResourceInfo.GroupVersionKind())
+	u.SetName(name)
+	u.SetNamespace("default")
+	annotations := map[string]string{}
+	if folder != "" {
+		annotations[utils.AnnoKeyFolder] = folder
+	}
+	u.SetAnnotations(annotations)
+	return u
+}
+
+type fakeStorage struct {
+	grafanarest.Storage
+	old runtime.Object
+	err error
+}
+
+func (f *fakeStorage) Update(ctx context.Context, _ string, objInfo rest.UpdatedObjectInfo, _ rest.ValidateObjectFunc, _ rest.ValidateObjectUpdateFunc, _ bool, _ *metav1.UpdateOptions) (runtime.Object, bool, error) {
+	if f.err != nil {
+		return nil, false, f.err
+	}
+	newObj, err := objInfo.UpdatedObject(ctx, f.old)
+	if err != nil {
+		return nil, false, err
+	}
+	return newObj, false, nil
+}
+
+func newUpdateCtx() context.Context {
+	return k8srequest.WithNamespace(context.Background(), "default")
+}
+
+func TestDashboardStorageWrapperUpdate_FolderUnchanged_NoPermissionDelete(t *testing.T) {
+	const uid = "abc"
+	permSvc := &recordingPermissionsService{}
+	recorder := &recordingWarnings{}
+
+	ctx := warning.WithWarningRecorder(newUpdateCtx(), recorder)
+
+	old := newDashboardWithFolder(uid, "folder-a")
+	updated := newDashboardWithFolder(uid, "folder-a")
+
+	wrapper := dashboardStorageWrapper{
+		Storage:                 &fakeStorage{old: old},
+		dashboardPermissionsSvc: permSvc,
+	}
+
+	_, _, err := wrapper.Update(ctx, uid, rest.DefaultUpdatedObjectInfo(updated), nil, nil, false, &metav1.UpdateOptions{})
+	require.NoError(t, err)
+	require.Empty(t, permSvc.calls, "permissions must not be deleted when folder is unchanged")
+	require.Empty(t, recorder.warnings, "no warning expected when folder is unchanged")
+}
+
+func TestDashboardStorageWrapperUpdate_FolderChanged_DeletesPermissionsAndWarns(t *testing.T) {
+	const uid = "abc"
+	permSvc := &recordingPermissionsService{}
+	recorder := &recordingWarnings{}
+
+	ctx := warning.WithWarningRecorder(newUpdateCtx(), recorder)
+
+	old := newDashboardWithFolder(uid, "")           // was at root
+	updated := newDashboardWithFolder(uid, "secret") // moved into a restricted folder
+
+	wrapper := dashboardStorageWrapper{
+		Storage:                 &fakeStorage{old: old},
+		dashboardPermissionsSvc: permSvc,
+	}
+
+	_, _, err := wrapper.Update(ctx, uid, rest.DefaultUpdatedObjectInfo(updated), nil, nil, false, &metav1.UpdateOptions{})
+	require.NoError(t, err)
+
+	require.Len(t, permSvc.calls, 1, "permissions must be cleared on folder change")
+	require.Equal(t, int64(1), permSvc.calls[0].orgID)
+	require.Equal(t, uid, permSvc.calls[0].resourceID)
+
+	require.Len(t, recorder.warnings, 1)
+	require.True(t, strings.Contains(recorder.warnings[0], uid), "warning should reference the dashboard uid")
+	require.True(t, strings.Contains(recorder.warnings[0], "secret"), "warning should reference the new folder")
+}
+
+func TestDashboardStorageWrapperUpdate_PermissionDeleteErrorPropagates(t *testing.T) {
+	const uid = "abc"
+	deleteErr := errors.New("rbac store offline")
+	permSvc := &recordingPermissionsService{returnErr: deleteErr}
+	recorder := &recordingWarnings{}
+
+	ctx := warning.WithWarningRecorder(newUpdateCtx(), recorder)
+
+	old := newDashboardWithFolder(uid, "folder-a")
+	updated := newDashboardWithFolder(uid, "folder-b")
+
+	wrapper := dashboardStorageWrapper{
+		Storage:                 &fakeStorage{old: old},
+		dashboardPermissionsSvc: permSvc,
+	}
+
+	_, _, err := wrapper.Update(ctx, uid, rest.DefaultUpdatedObjectInfo(updated), nil, nil, false, &metav1.UpdateOptions{})
+	require.ErrorIs(t, err, deleteErr, "delete-permissions error must propagate so the caller knows cleanup failed")
+	require.Len(t, permSvc.calls, 1)
+	require.Empty(t, recorder.warnings)
+}


### PR DESCRIPTION
**Test script:**
```bash
#!/usr/bin/env bash
set -euo pipefail

BASE=${BASE:-http://localhost:3000}
ADMIN=${ADMIN:-admin:admin}

VIEWER_LOGIN=viewer1
VIEWER_PASS=viewer1pass
VIEWER_EMAIL=viewer1@local

FOLDER_VIEWER_LOGIN=folderviewer1
FOLDER_VIEWER_PASS=folderviewer1pass
FOLDER_VIEWER_EMAIL=folderviewer1@local

DASH_UID=victim-dash-test
FOLDER_UID=restrictedftest

assert_eq() {
  if [[ "$2" != "$3" ]]; then
    echo "FAIL: $1  expected=$3  got=$2"; exit 1
  fi
  echo "OK:   $1 ($2)"
}

note() { echo "== $*"; }

extract_id() { sed -n 's/.*"id":\([0-9]*\).*/\1/p' | head -1; }

delete_user_by_login() {
  local login=$1
  local id
  id=$(curl -fsS -u "$ADMIN" "$BASE/api/users/lookup?loginOrEmail=$login" 2>/dev/null | extract_id || true)
  if [[ -n "${id:-}" ]]; then
    curl -fsS -u "$ADMIN" -X DELETE "$BASE/api/admin/users/$id" >/dev/null 2>&1 || true
  fi
}

cleanup() {
  note "Cleanup"
  curl -fsS -u "$ADMIN" -X DELETE \
    "$BASE/apis/dashboard.grafana.app/v1beta1/namespaces/default/dashboards/$DASH_UID" >/dev/null 2>&1 || true
  curl -fsS -u "$ADMIN" -X DELETE "$BASE/api/folders/$FOLDER_UID" >/dev/null 2>&1 || true
  delete_user_by_login "$VIEWER_LOGIN"
  delete_user_by_login "$FOLDER_VIEWER_LOGIN"
}
trap cleanup EXIT
cleanup

note "Create viewer1 (will hold a direct dashboard grant)"
viewer_id=$(curl -fsS -u "$ADMIN" -X POST -H "Content-Type: application/json" \
  "$BASE/api/admin/users" \
  -d "{\"name\":\"Viewer One\",\"email\":\"$VIEWER_EMAIL\",\"login\":\"$VIEWER_LOGIN\",\"password\":\"$VIEWER_PASS\"}" \
  | extract_id)
[[ -n "$viewer_id" ]] || { echo "could not create viewer1"; exit 1; }

note "Create folderviewer1 (will get folder-level View on the restricted folder)"
folder_viewer_id=$(curl -fsS -u "$ADMIN" -X POST -H "Content-Type: application/json" \
  "$BASE/api/admin/users" \
  -d "{\"name\":\"Folder Viewer\",\"email\":\"$FOLDER_VIEWER_EMAIL\",\"login\":\"$FOLDER_VIEWER_LOGIN\",\"password\":\"$FOLDER_VIEWER_PASS\"}" \
  | extract_id)
[[ -n "$folder_viewer_id" ]] || { echo "could not create folderviewer1"; exit 1; }

note "Create restricted folder, grant Admin + folderviewer1 View"
curl -fsS -u "$ADMIN" -X POST -H "Content-Type: application/json" "$BASE/api/folders" \
  -d "{\"uid\":\"$FOLDER_UID\",\"title\":\"restricted-test\"}" >/dev/null
curl -fsS -u "$ADMIN" -X POST -H "Content-Type: application/json" \
  "$BASE/api/folders/$FOLDER_UID/permissions" \
  -d "{\"items\":[{\"role\":\"Admin\",\"permission\":4},{\"userId\":$folder_viewer_id,\"permission\":1}]}" >/dev/null

note "Create dashboard in root via k8s API"
curl -fsS -u "$ADMIN" -X POST -H "Content-Type: application/json" \
  "$BASE/apis/dashboard.grafana.app/v1beta1/namespaces/default/dashboards" \
  -d "{\"apiVersion\":\"dashboard.grafana.app/v1beta1\",\"kind\":\"Dashboard\",\"metadata\":{\"name\":\"$DASH_UID\"},\"spec\":{\"title\":\"Victim\",\"schemaVersion\":41}}" \
  >/dev/null

note "Grant viewer1 direct View on dashboard"
curl -fsS -u "$ADMIN" -X POST -H "Content-Type: application/json" \
  "$BASE/api/dashboards/uid/$DASH_UID/permissions" \
  -d "{\"items\":[{\"userId\":$viewer_id,\"permission\":1}]}" >/dev/null

note "viewer1 reads dashboard BEFORE move (expect 200)"
code=$(curl -s -o /dev/null -w '%{http_code}' -u "$VIEWER_LOGIN:$VIEWER_PASS" \
  "$BASE/apis/dashboard.grafana.app/v1beta1/namespaces/default/dashboards/$DASH_UID")
assert_eq "viewer1 GET before move" "$code" "200"

note "Move dashboard into restricted folder"
hdrs=$(curl -s -D - -o /dev/null -u "$ADMIN" -X PATCH \
  -H "Content-Type: application/merge-patch+json" \
  "$BASE/apis/dashboard.grafana.app/v1beta1/namespaces/default/dashboards/$DASH_UID" \
  -d "{\"metadata\":{\"annotations\":{\"grafana.app/folder\":\"$FOLDER_UID\"}}}")

if grep -qi '^Warning:.*parent folder changed' <<<"$hdrs"; then
  echo "OK:   Warning header present"
  grep -i '^Warning:' <<<"$hdrs" | sed 's/^/      /'
else
  echo "FAIL: Warning header missing"
  printf '%s\n' "$hdrs"
  exit 1
fi

note "Direct permissions list should be empty"
perms=$(curl -fsS -u "$ADMIN" "$BASE/api/dashboards/uid/$DASH_UID/permissions")
assert_eq "direct permissions" "$perms" "[]"

note "Admin GET (post-move, restricted folder) expect 200"
code=$(curl -s -o /dev/null -w '%{http_code}' -u "$ADMIN" \
  "$BASE/apis/dashboard.grafana.app/v1beta1/namespaces/default/dashboards/$DASH_UID")
assert_eq "admin GET after move" "$code" "200"

note "Poll viewer1 until access-control cache expires (~60s TTL)"
deadline=$((SECONDS + 120))
code=""
while (( SECONDS < deadline )); do
  code=$(curl -s -o /dev/null -w '%{http_code}' -u "$VIEWER_LOGIN:$VIEWER_PASS" \
    "$BASE/apis/dashboard.grafana.app/v1beta1/namespaces/default/dashboards/$DASH_UID")
  [[ "$code" == "403" ]] && break
  sleep 5
done
assert_eq "viewer1 GET after move + cache flush" "$code" "403"

note "folderviewer1 GET (inherits View from folder) expect 200"
code=$(curl -s -o /dev/null -w '%{http_code}' -u "$FOLDER_VIEWER_LOGIN:$FOLDER_VIEWER_PASS" \
  "$BASE/apis/dashboard.grafana.app/v1beta1/namespaces/default/dashboards/$DASH_UID")
assert_eq "folderviewer1 GET after move" "$code" "200"

echo "All assertions passed."

```

**Result:**
```bash
== Cleanup
== Create viewer1 (will hold a direct dashboard grant)
== Create folderviewer1 (will get folder-level View on the restricted folder)
== Create restricted folder, grant Admin + folderviewer1 View
== Create dashboard in root via k8s API
== Grant viewer1 direct View on dashboard
== viewer1 reads dashboard BEFORE move (expect 200)
OK:   viewer1 GET before move (200)
== Move dashboard into restricted folder
OK:   Warning header present
      Warning: 299 - "Directly assigned permissions on dashboard \"victim-dash-test\" were cleared because its parent folder changed (from \"\" to \"restrictedftest\"). Inherited folder permissions still apply."
== Direct permissions list should be empty
OK:   direct permissions ([])
== Admin GET (post-move, restricted folder) expect 200
OK:   admin GET after move (200)
== Poll viewer1 until access-control cache expires (~60s TTL)
OK:   viewer1 GET after move + cache flush (403)
== folderviewer1 GET (inherits View from folder) expect 200
OK:   folderviewer1 GET after move (200)
All assertions passed.
== Cleanup
```