### PR TITLE
Provisioning: signed commit support (GPG, SSH, S/MIME)

### DIFF
--- a/apps/provisioning/pkg/repository/git/extra.go
+++ b/apps/provisioning/pkg/repository/git/extra.go
@@ -39,13 +39,21 @@ func (e *extra) Build(ctx context.Context, r *provisioning.Repository) (reposito
 		return nil, fmt.Errorf("unable to decrypt token: %w", err)
 	}
 
+	signingKey, err := secure.CommitSigningKey(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("unable to decrypt signing key: %w", err)
+	}
+
 	return NewRepository(ctx, r, RepositoryConfig{
-		URL:           cfg.URL,
-		Branch:        cfg.Branch,
-		Path:          cfg.Path,
-		TokenUser:     cfg.TokenUser,
-		Token:         token,
-		SkipGitSuffix: true,
+		URL:              cfg.URL,
+		Branch:           cfg.Branch,
+		Path:             cfg.Path,
+		TokenUser:        cfg.TokenUser,
+		Token:            token,
+		CommitSigningKey: signingKey,
+		SigningMethod:    SigningMethodFromSpec(r),
+		SMIMECertificate: SMIMECertificateFromSpec(r),
+		SkipGitSuffix:    true,
 	})
 }
 

--- a/apps/provisioning/pkg/repository/git/repository.go
+++ b/apps/provisioning/pkg/repository/git/repository.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
@@ -33,19 +34,23 @@ import (
 var ErrNoBranches = errors.New("no branches found in repository")
 
 type RepositoryConfig struct {
-	URL           string
-	Branch        string
-	TokenUser     string
-	Token         common.RawSecureValue
-	Path          string
-	SkipGitSuffix bool
+	URL              string
+	Branch           string
+	TokenUser        string
+	Token            common.RawSecureValue
+	CommitSigningKey common.RawSecureValue
+	SigningMethod    provisioning.SigningMethod
+	SMIMECertificate string
+	Path             string
+	SkipGitSuffix    bool
 }
 
 // Make sure all public functions of this struct call the (*gitRepository).logger function, to ensure the Git repo details are included.
 type gitRepository struct {
-	config    *provisioning.Repository
-	gitConfig RepositoryConfig
-	client    nanogit.Client
+	config        *provisioning.Repository
+	gitConfig     RepositoryConfig
+	client        nanogit.Client
+	writerOptions []nanogit.WriterOption
 }
 
 func NewRepository(
@@ -71,10 +76,23 @@ func NewRepository(
 		return nil, fmt.Errorf("create nanogit client: %w", err)
 	}
 
+	var writerOptions []nanogit.WriterOption
+	if gitConfig.SigningMethod != "" {
+		if gitConfig.CommitSigningKey.IsZero() {
+			return nil, fmt.Errorf("signing method %q requires secure.commitSigningKey", gitConfig.SigningMethod)
+		}
+		signer, err := signingOption(gitConfig)
+		if err != nil {
+			return nil, fmt.Errorf("configure commit signing: %w", err)
+		}
+		writerOptions = append(writerOptions, signer)
+	}
+
 	return &gitRepository{
-		config:    config,
-		gitConfig: gitConfig,
-		client:    client,
+		config:        config,
+		gitConfig:     gitConfig,
+		client:        client,
+		writerOptions: writerOptions,
 	}, nil
 }
 
@@ -452,7 +470,7 @@ func (r *gitRepository) Create(ctx context.Context, path, ref string, data []byt
 		return err
 	}
 
-	writer, err := r.client.NewStagedWriter(ctx, branchRef)
+	writer, err := r.client.NewStagedWriter(ctx, branchRef, r.writerOptions...)
 	if err != nil {
 		return fmt.Errorf("create staged writer: %w", mapNanogitError(err))
 	}
@@ -504,7 +522,7 @@ func (r *gitRepository) Update(ctx context.Context, path, ref string, data []byt
 		return err
 	}
 	// Create a staged writer
-	writer, err := r.client.NewStagedWriter(ctx, branchRef)
+	writer, err := r.client.NewStagedWriter(ctx, branchRef, r.writerOptions...)
 	if err != nil {
 		return fmt.Errorf("create staged writer: %w", mapNanogitError(err))
 	}
@@ -542,7 +560,7 @@ func (r *gitRepository) Write(ctx context.Context, path string, ref string, data
 	ctx, logger := r.withGitContext(ctx, ref)
 	logger.Info("write repository path", "path", path)
 	info, err := r.Read(ctx, path, ref)
-	if err != nil && !(errors.Is(err, repository.ErrFileNotFound)) {
+	if err != nil && !errors.Is(err, repository.ErrFileNotFound) {
 		return fmt.Errorf("check if file exists before writing: %w", err)
 	}
 	if err == nil {
@@ -568,7 +586,7 @@ func (r *gitRepository) Delete(ctx context.Context, path, ref, comment string) e
 		return err
 	}
 	// Create a staged writer
-	writer, err := r.client.NewStagedWriter(ctx, branchRef)
+	writer, err := r.client.NewStagedWriter(ctx, branchRef, r.writerOptions...)
 	if err != nil {
 		return fmt.Errorf("create staged writer: %w", mapNanogitError(err))
 	}
@@ -593,7 +611,7 @@ func (r *gitRepository) Move(ctx context.Context, oldPath, newPath, ref, comment
 	}
 
 	// Create a staged writer
-	writer, err := r.client.NewStagedWriter(ctx, branchRef)
+	writer, err := r.client.NewStagedWriter(ctx, branchRef, r.writerOptions...)
 	if err != nil {
 		return fmt.Errorf("create staged writer: %w", mapNanogitError(err))
 	}
@@ -935,7 +953,9 @@ func (r *gitRepository) ensureBranchExists(ctx context.Context, branchName strin
 }
 
 // createSignature creates author and committer signatures using the context signature if available,
-// falling back to default Grafana signature
+// falling back to default Grafana signature. The committer is overridden by
+// spec.commit.signerName/Email when set; that identity must match the signing
+// key for providers to mark commits as Verified.
 func (r *gitRepository) createSignature(ctx context.Context) (nanogit.Author, nanogit.Committer) {
 	author := nanogit.Author{
 		Name:  "Grafana",
@@ -960,8 +980,13 @@ func (r *gitRepository) createSignature(ctx context.Context) (nanogit.Author, na
 		author.Time = time.Now()
 	}
 
-	// Author and committer are always the same (for now)
-	return author, nanogit.Committer(author)
+	committer := nanogit.Committer(author)
+	if commit := r.config.Spec.Commit; commit != nil && (commit.SignerName != "" || commit.SignerEmail != "") {
+		committer.Name = cmp.Or(commit.SignerName, "Grafana")
+		committer.Email = cmp.Or(commit.SignerEmail, "noreply@grafana.com")
+	}
+
+	return author, committer
 }
 
 func (r *gitRepository) commit(ctx context.Context, writer nanogit.StagedWriter, comment string) error {

--- a/apps/provisioning/pkg/repository/git/repository_test.go
+++ b/apps/provisioning/pkg/repository/git/repository_test.go
@@ -2163,8 +2163,8 @@ func TestGitRepository_createSignature(t *testing.T) {
 		require.False(t, author.Time.IsZero())
 
 		require.Equal(t, "Grafana", committer.Name)
-		require.Equal(t, sig.Email, author.Email)
-		require.False(t, author.Time.IsZero())
+		require.Equal(t, sig.Email, committer.Email)
+		require.False(t, committer.Time.IsZero())
 	})
 
 	t.Run("should use current time when signature time is zero", func(t *testing.T) {
@@ -2189,14 +2189,78 @@ func TestGitRepository_createSignature(t *testing.T) {
 		require.True(t, committer.Time.After(before.Add(-time.Second)))
 		require.True(t, committer.Time.Before(after.Add(time.Second)))
 	})
+
+	t.Run("should set committer from spec while author stays default", func(t *testing.T) {
+		repo := &gitRepository{
+			config: &provisioning.Repository{
+				Spec: provisioning.RepositorySpec{
+					Type: provisioning.GitHubRepositoryType,
+					Commit: &provisioning.CommitOptions{
+						SignerName:  "Bot Signer",
+						SignerEmail: "signer@example.com",
+					},
+				},
+			},
+		}
+
+		author, committer := repo.createSignature(context.Background())
+
+		require.Equal(t, "Grafana", author.Name)
+		require.Equal(t, "noreply@grafana.com", author.Email)
+		require.Equal(t, "Bot Signer", committer.Name)
+		require.Equal(t, "signer@example.com", committer.Email)
+	})
+
+	t.Run("should default committer email when only signer name is set", func(t *testing.T) {
+		repo := &gitRepository{
+			config: &provisioning.Repository{
+				Spec: provisioning.RepositorySpec{
+					Type:   provisioning.GitHubRepositoryType,
+					Commit: &provisioning.CommitOptions{SignerName: "Bot Signer"},
+				},
+			},
+		}
+
+		author, committer := repo.createSignature(context.Background())
+
+		require.Equal(t, "Grafana", author.Name)
+		require.Equal(t, "Bot Signer", committer.Name)
+		require.Equal(t, "noreply@grafana.com", committer.Email)
+	})
+
+	t.Run("should keep committer independent from a context author override", func(t *testing.T) {
+		repo := &gitRepository{
+			config: &provisioning.Repository{
+				Spec: provisioning.RepositorySpec{
+					Type: provisioning.GitHubRepositoryType,
+					Commit: &provisioning.CommitOptions{
+						SignerName:  "Bot Signer",
+						SignerEmail: "signer@example.com",
+					},
+				},
+			},
+		}
+		ctx := repository.WithAuthorSignature(context.Background(), repository.CommitSignature{
+			Name:  "John Doe",
+			Email: "john@example.com",
+		})
+
+		author, committer := repo.createSignature(ctx)
+
+		require.Equal(t, "John Doe", author.Name)
+		require.Equal(t, "john@example.com", author.Email)
+		require.Equal(t, "Bot Signer", committer.Name)
+		require.Equal(t, "signer@example.com", committer.Email)
+	})
 }
 
 func TestNewGitRepository(t *testing.T) {
 	tests := []struct {
-		name      string
-		gitConfig RepositoryConfig
-		wantError bool
-		expectURL string
+		name          string
+		gitConfig     RepositoryConfig
+		wantError     bool
+		expectURL     string
+		expectSigning bool
 	}{
 		{
 			name: "success - with token",
@@ -2208,6 +2272,30 @@ func TestNewGitRepository(t *testing.T) {
 			},
 			wantError: false,
 			expectURL: "https://git.example.com/owner/repo.git",
+		},
+		{
+			name: "success - with commit signing",
+			gitConfig: RepositoryConfig{
+				URL:              "https://git.example.com/owner/repo.git",
+				Branch:           "main",
+				Token:            "plain-token",
+				SigningMethod:    provisioning.SSHSigningMethod,
+				CommitSigningKey: "ssh-key",
+			},
+			wantError:     false,
+			expectURL:     "https://git.example.com/owner/repo.git",
+			expectSigning: true,
+		},
+		{
+			name: "error - smime signing without certificate",
+			gitConfig: RepositoryConfig{
+				URL:              "https://git.example.com/owner/repo.git",
+				Branch:           "main",
+				Token:            "plain-token",
+				SigningMethod:    provisioning.SMIMESigningMethod,
+				CommitSigningKey: "smime-key",
+			},
+			wantError: true,
 		},
 	}
 
@@ -2232,6 +2320,11 @@ func TestNewGitRepository(t *testing.T) {
 				require.Equal(t, tt.expectURL, gitRepo.URL())
 				require.Equal(t, tt.gitConfig.Branch, gitRepo.Branch())
 				require.Equal(t, config, gitRepo.Config())
+				if tt.expectSigning {
+					require.Len(t, gitRepo.(*gitRepository).writerOptions, 1)
+				} else {
+					require.Empty(t, gitRepo.(*gitRepository).writerOptions)
+				}
 			}
 		})
 	}

--- a/apps/provisioning/pkg/repository/git/sign.go
+++ b/apps/provisioning/pkg/repository/git/sign.go
@@ -1,0 +1,40 @@
+package git
+
+import (
+	"fmt"
+
+	"github.com/grafana/nanogit"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+)
+
+func SigningMethodFromSpec(r *provisioning.Repository) provisioning.SigningMethod {
+	if r.Spec.Commit != nil {
+		return r.Spec.Commit.SigningMethod
+	}
+	return ""
+}
+
+func SMIMECertificateFromSpec(r *provisioning.Repository) string {
+	if r.Spec.Commit != nil {
+		return r.Spec.Commit.SMIMECertificate
+	}
+	return ""
+}
+
+func signingOption(cfg RepositoryConfig) (nanogit.WriterOption, error) {
+	key := []byte(cfg.CommitSigningKey)
+	switch cfg.SigningMethod {
+	case provisioning.SSHSigningMethod:
+		return nanogit.WithSSHSigner(key), nil
+	case provisioning.SMIMESigningMethod:
+		if cfg.SMIMECertificate == "" {
+			return nil, fmt.Errorf("smime signing requires spec.commit.smimeCertificate")
+		}
+		return nanogit.WithSMIMESigner(key, []byte(cfg.SMIMECertificate)), nil
+	case provisioning.GPGSigningMethod:
+		return nanogit.WithGPGSigner(key), nil
+	default:
+		return nil, fmt.Errorf("unsupported signing method %q", cfg.SigningMethod)
+	}
+}

--- a/apps/provisioning/pkg/repository/git/sign_test.go
+++ b/apps/provisioning/pkg/repository/git/sign_test.go
@@ -1,0 +1,71 @@
+package git
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+)
+
+func TestSigningOption(t *testing.T) {
+	tests := []struct {
+		name          string
+		gitConfig     RepositoryConfig
+		expectedError string
+	}{
+		{
+			name: "ssh",
+			gitConfig: RepositoryConfig{
+				SigningMethod:    provisioning.SSHSigningMethod,
+				CommitSigningKey: "ssh-key",
+			},
+		},
+		{
+			name: "gpg",
+			gitConfig: RepositoryConfig{
+				SigningMethod:    provisioning.GPGSigningMethod,
+				CommitSigningKey: "gpg-key",
+			},
+		},
+		{
+			name: "smime with certificate",
+			gitConfig: RepositoryConfig{
+				SigningMethod:    provisioning.SMIMESigningMethod,
+				CommitSigningKey: "smime-key",
+				SMIMECertificate: "smime-cert",
+			},
+		},
+		{
+			name: "smime missing certificate",
+			gitConfig: RepositoryConfig{
+				SigningMethod:    provisioning.SMIMESigningMethod,
+				CommitSigningKey: "smime-key",
+			},
+			expectedError: "smime signing requires spec.commit.smimeCertificate",
+		},
+		{
+			name: "unsupported method",
+			gitConfig: RepositoryConfig{
+				SigningMethod:    provisioning.SigningMethod("unknown"),
+				CommitSigningKey: "key",
+			},
+			expectedError: `unsupported signing method "unknown"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opt, err := signingOption(tt.gitConfig)
+
+			if tt.expectedError != "" {
+				require.Error(t, err)
+				require.ErrorContains(t, err, tt.expectedError)
+				require.Nil(t, opt)
+			} else {
+				require.NoError(t, err)
+				require.NotNil(t, opt)
+			}
+		})
+	}
+}

--- a/apps/provisioning/pkg/repository/git/staged.go
+++ b/apps/provisioning/pkg/repository/git/staged.go
@@ -36,7 +36,7 @@ func NewStagedGitRepository(ctx context.Context, repo *gitRepository, opts repos
 		return nil, fmt.Errorf("ensure branch exists: %w", err)
 	}
 
-	writer, err := repo.client.NewStagedWriter(ctx, ref)
+	writer, err := repo.client.NewStagedWriter(ctx, ref, repo.writerOptions...)
 	if err != nil {
 		return nil, fmt.Errorf("build staged writer: %w", err)
 	}

--- a/apps/provisioning/pkg/repository/github/extra.go
+++ b/apps/provisioning/pkg/repository/github/extra.go
@@ -55,11 +55,19 @@ func (e *extra) Build(ctx context.Context, r *provisioning.Repository) (reposito
 		return nil, fmt.Errorf("unable to decrypt token: %w", err)
 	}
 
+	signingKey, err := secure.CommitSigningKey(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("unable to decrypt signing key: %w", err)
+	}
+
 	gitRepo, err := git.NewRepository(ctx, r, git.RepositoryConfig{
-		URL:    r.Spec.GitHub.URL,
-		Branch: r.Spec.GitHub.Branch,
-		Path:   r.Spec.GitHub.Path,
-		Token:  token,
+		URL:              r.Spec.GitHub.URL,
+		Branch:           r.Spec.GitHub.Branch,
+		Path:             r.Spec.GitHub.Path,
+		Token:            token,
+		CommitSigningKey: signingKey,
+		SigningMethod:    git.SigningMethodFromSpec(r),
+		SMIMECertificate: git.SMIMECertificateFromSpec(r),
 	})
 	if err != nil {
 		return nil, fmt.Errorf("error creating git repository: %w", err)

--- a/apps/provisioning/pkg/repository/github/extra_test.go
+++ b/apps/provisioning/pkg/repository/github/extra_test.go
@@ -21,6 +21,8 @@ type mockSecureValues struct {
 	tokenErr      error
 	webhookSecret common.RawSecureValue
 	webhookErr    error
+	signingKey    common.RawSecureValue
+	signingErr    error
 }
 
 func (m *mockSecureValues) Token(_ context.Context) (common.RawSecureValue, error) {
@@ -29,6 +31,10 @@ func (m *mockSecureValues) Token(_ context.Context) (common.RawSecureValue, erro
 
 func (m *mockSecureValues) WebhookSecret(_ context.Context) (common.RawSecureValue, error) {
 	return m.webhookSecret, m.webhookErr
+}
+
+func (m *mockSecureValues) CommitSigningKey(_ context.Context) (common.RawSecureValue, error) {
+	return m.signingKey, m.signingErr
 }
 
 func TestExtra_Type(t *testing.T) {
@@ -222,6 +228,68 @@ func TestExtra_Build(t *testing.T) {
 				return mockWebhook
 			},
 			expectedError: "decrypt webhookSecret",
+		},
+		{
+			name: "error decrypting signing key",
+			repo: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-repo",
+					Namespace: "default",
+				},
+				Spec: provisioning.RepositorySpec{
+					Type: provisioning.GitHubRepositoryType,
+					GitHub: &provisioning.GitHubRepositoryConfig{
+						URL:    "https://github.com/test/repo",
+						Branch: "main",
+					},
+					Commit: &provisioning.CommitOptions{
+						SigningMethod: provisioning.SSHSigningMethod,
+					},
+				},
+			},
+			setupDecrypter: func() repository.Decrypter {
+				return func(r *provisioning.Repository) repository.SecureValues {
+					return &mockSecureValues{
+						token:      common.RawSecureValue("test-token"),
+						signingErr: errors.New("signing key decryption failed"),
+					}
+				}
+			},
+			setupWebhook:  func(t *testing.T, repo *provisioning.Repository) github.WebhookURLBuilder { return nil },
+			expectedError: "unable to decrypt signing key",
+		},
+		{
+			name: "success with commit signing",
+			repo: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-repo",
+					Namespace: "default",
+				},
+				Spec: provisioning.RepositorySpec{
+					Type: provisioning.GitHubRepositoryType,
+					GitHub: &provisioning.GitHubRepositoryConfig{
+						URL:    "https://github.com/test/repo",
+						Branch: "main",
+					},
+					Commit: &provisioning.CommitOptions{
+						SigningMethod: provisioning.SSHSigningMethod,
+					},
+				},
+			},
+			setupDecrypter: func() repository.Decrypter {
+				return func(r *provisioning.Repository) repository.SecureValues {
+					return &mockSecureValues{
+						token:      common.RawSecureValue("test-token"),
+						signingKey: common.RawSecureValue("ssh-key"),
+					}
+				}
+			},
+			setupWebhook: func(t *testing.T, repo *provisioning.Repository) github.WebhookURLBuilder {
+				return nil
+			},
+			validateResult: func(t *testing.T, repo repository.Repository) {
+				assert.NotNil(t, repo)
+			},
 		},
 		{
 			name: "success with custom path",

--- a/apps/provisioning/pkg/repository/mutator.go
+++ b/apps/provisioning/pkg/repository/mutator.go
@@ -82,6 +82,9 @@ func CopySecureValues(new, old *provisioning.Repository) {
 	if new.Secure.WebhookSecret.IsZero() {
 		new.Secure.WebhookSecret = old.Secure.WebhookSecret
 	}
+	if new.Secure.CommitSigningKey.IsZero() {
+		new.Secure.CommitSigningKey = old.Secure.CommitSigningKey
+	}
 }
 
 func RequiresNewTokenForURLChange(new, old *provisioning.Repository) bool {

--- a/apps/provisioning/pkg/repository/mutator_test.go
+++ b/apps/provisioning/pkg/repository/mutator_test.go
@@ -323,11 +323,12 @@ func TestAdmissionMutator_Mutate(t *testing.T) {
 
 func TestCopySecureValues(t *testing.T) {
 	tests := []struct {
-		name       string
-		new        *provisioning.Repository
-		old        *provisioning.Repository
-		wantToken  common.InlineSecureValue
-		wantSecret common.InlineSecureValue
+		name           string
+		new            *provisioning.Repository
+		old            *provisioning.Repository
+		wantToken      common.InlineSecureValue
+		wantSecret     common.InlineSecureValue
+		wantSigningKey common.InlineSecureValue
 	}{
 		{
 			name: "copies token from old to new when new is zero",
@@ -348,6 +349,16 @@ func TestCopySecureValues(t *testing.T) {
 				},
 			},
 			wantSecret: common.InlineSecureValue{Name: "old-secret"},
+		},
+		{
+			name: "copies commit signing key from old to new when new is zero",
+			new:  &provisioning.Repository{},
+			old: &provisioning.Repository{
+				Secure: provisioning.SecureValues{
+					CommitSigningKey: common.InlineSecureValue{Name: "old-signing-key"},
+				},
+			},
+			wantSigningKey: common.InlineSecureValue{Name: "old-signing-key"},
 		},
 		{
 			name: "does not overwrite existing token in new",
@@ -382,6 +393,7 @@ func TestCopySecureValues(t *testing.T) {
 			CopySecureValues(tt.new, tt.old)
 			assert.Equal(t, tt.wantToken, tt.new.Secure.Token)
 			assert.Equal(t, tt.wantSecret, tt.new.Secure.WebhookSecret)
+			assert.Equal(t, tt.wantSigningKey, tt.new.Secure.CommitSigningKey)
 		})
 	}
 }

--- a/apps/provisioning/pkg/repository/secure.go
+++ b/apps/provisioning/pkg/repository/secure.go
@@ -13,8 +13,9 @@ import (
 type secretTypeLabel string
 
 const (
-	secretTypeToken         secretTypeLabel = "token"
-	secretTypeWebhookSecret secretTypeLabel = "webhook_secret"
+	secretTypeToken            secretTypeLabel = "token"
+	secretTypeWebhookSecret    secretTypeLabel = "webhook_secret"
+	secretTypeCommitSigningKey secretTypeLabel = "commit_signing_key"
 )
 
 type Decrypter = func(r *provisioning.Repository) SecureValues
@@ -22,6 +23,7 @@ type Decrypter = func(r *provisioning.Repository) SecureValues
 type SecureValues interface {
 	Token(ctx context.Context) (common.RawSecureValue, error)
 	WebhookSecret(ctx context.Context) (common.RawSecureValue, error)
+	CommitSigningKey(ctx context.Context) (common.RawSecureValue, error)
 }
 
 type secureValues struct {
@@ -71,6 +73,10 @@ func (s *secureValues) Token(ctx context.Context) (common.RawSecureValue, error)
 
 func (s *secureValues) WebhookSecret(ctx context.Context) (common.RawSecureValue, error) {
 	return s.get(ctx, s.names.WebhookSecret, secretTypeWebhookSecret)
+}
+
+func (s *secureValues) CommitSigningKey(ctx context.Context) (common.RawSecureValue, error) {
+	return s.get(ctx, s.names.CommitSigningKey, secretTypeCommitSigningKey)
 }
 
 func ProvideDecrypter(svc decrypt.DecryptService, metrics *DecryptMetrics) Decrypter {

--- a/apps/provisioning/pkg/repository/secure_test.go
+++ b/apps/provisioning/pkg/repository/secure_test.go
@@ -20,11 +20,12 @@ func TestRepositorySecureValues(t *testing.T) {
 	}
 
 	tests := []struct {
-		name    string
-		config  *provisioning.Repository
-		decrypt decryptFn
-		token   expectedDecryptedResult
-		webhook expectedDecryptedResult
+		name       string
+		config     *provisioning.Repository
+		decrypt    decryptFn
+		token      expectedDecryptedResult
+		webhook    expectedDecryptedResult
+		signingKey expectedDecryptedResult
 	}{
 		{
 			name: "referenced by name",
@@ -124,6 +125,59 @@ func TestRepositorySecureValues(t *testing.T) {
 				error: "failed to call decrypt service",
 			},
 		},
+		{
+			name: "commit signing key referenced by name",
+			config: &provisioning.Repository{
+				Secure: provisioning.SecureValues{
+					CommitSigningKey: v0alpha1.InlineSecureValue{
+						Name: "secret",
+					},
+				},
+			},
+			decrypt: func(t *testing.T, names ...string) (map[string]decrypt.DecryptResult, error) {
+				require.Equal(t, []string{"secret"}, names)
+				val := secretv1beta1.NewExposedSecureValue(names[0])
+				return map[string]decrypt.DecryptResult{
+					names[0]: decrypt.NewDecryptResultValue(&val),
+				}, nil
+			},
+			signingKey: expectedDecryptedResult{
+				value: "secret",
+			},
+		},
+		{
+			name: "commit signing key with create set",
+			config: &provisioning.Repository{
+				Secure: provisioning.SecureValues{
+					CommitSigningKey: v0alpha1.InlineSecureValue{
+						Create: "secret",
+					},
+				},
+			},
+			decrypt: func(t *testing.T, names ...string) (map[string]decrypt.DecryptResult, error) {
+				t.Fatal("decrypt should not be called when Create is set")
+				return nil, nil
+			},
+			signingKey: expectedDecryptedResult{
+				value: "secret",
+			},
+		},
+		{
+			name: "commit signing key decrypt service error",
+			config: &provisioning.Repository{
+				Secure: provisioning.SecureValues{
+					CommitSigningKey: v0alpha1.InlineSecureValue{
+						Name: "secret",
+					},
+				},
+			},
+			decrypt: func(t *testing.T, names ...string) (map[string]decrypt.DecryptResult, error) {
+				return nil, fmt.Errorf("explode")
+			},
+			signingKey: expectedDecryptedResult{
+				error: "failed to call decrypt service",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -144,6 +198,14 @@ func TestRepositorySecureValues(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tt.webhook.value, string(webhook))
+			}
+
+			signingKey, err := decrypted.CommitSigningKey(context.Background())
+			if tt.signingKey.error != "" {
+				require.ErrorContains(t, err, tt.signingKey.error)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.signingKey.value, string(signingKey))
 			}
 		})
 	}


### PR DESCRIPTION
**What is this feature?**

Adds optional commit signing to Git Sync. When a signing key is configured on a repository, commits are signed so the Git provider marks them as Verified. GPG, SSH, and S/MIME keys are supported. Repositories without a signing key keep producing unsigned commits.

This is a backend-only change, but has been tested alongside frontend
- https://github.com/grafana/grafana/pull/126023

**Why do we need this feature?**

Some customers enforce verified signatures on commits through branch protection rules, which Git Sync could not satisfy because it only wrote unsigned commits.
- https://github.com/grafana/support-escalations/issues/21934#issuecomment-4400871730
- https://github.com/grafana/git-ui-sync-project/issues/1143

**Who is this feature for?**

Git Sync users whose repositories require verified commits.



Ref: https://github.com/grafana/git-ui-sync-project/issues/1203