### PR TITLE
FeatureToggles: Promote clearPreviousFieldValues to GA and enable by default

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -1612,7 +1612,7 @@ export interface FeatureToggles {
   tracesDrilldownTimeSeeker?: boolean;
   /**
   * Mitigates React fiber's retention of previous props/state, causing 2x memory use: https://github.com/facebook/react/issues/36176
-  * @default false
+  * @default true
   */
   clearPreviousFieldValues?: boolean;
   /**

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -2912,10 +2912,10 @@ var (
 		{
 			Name:         "clearPreviousFieldValues",
 			Description:  "Mitigates React fiber's retention of previous props/state, causing 2x memory use: https://github.com/facebook/react/issues/36176",
-			Stage:        FeatureStageExperimental,
+			Stage:        FeatureStageGeneralAvailability,
 			Generate:     Generate{LegacyFrontend: true},
 			Owner:        grafanaDatavizSquad,
-			Expression:   "false",
+			Expression:   "true",
 			HideFromDocs: true,
 		},
 		{

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -338,7 +338,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-03-16,queryFetchConfigFromSettingsService,experimental,@grafana/grafana-datasources-core-services,false,false,false
 2026-04-16,profilesHeatmap,experimental,@grafana/observability-traces-and-profiling,false,false,false
 2026-04-01,tracesDrilldownTimeSeeker,experimental,@grafana/observability-traces-and-profiling,false,false,true
-2026-04-01,clearPreviousFieldValues,experimental,@grafana/dataviz-squad,false,false,true
+2026-04-01,clearPreviousFieldValues,GA,@grafana/dataviz-squad,false,false,true
 2026-04-02,enableColorblindSafePanelOptions,experimental,@grafana/dataviz-squad,false,false,true
 2026-04-03,cacheConfigUnifiedStorageMigration,experimental,@grafana/grafana-operator-experience-squad,false,true,false
 2026-04-10,querycaching.redirectToK8SApi,experimental,@grafana/grafana-operator-experience-squad,false,false,false

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1403,16 +1403,19 @@
     {
       "metadata": {
         "name": "clearPreviousFieldValues",
-        "resourceVersion": "1775070445977",
-        "creationTimestamp": "2026-04-01T19:07:25Z"
+        "resourceVersion": "1779387149898",
+        "creationTimestamp": "2026-04-01T19:07:25Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-05-21 18:12:29.898776 +0000 UTC"
+        }
       },
       "spec": {
         "description": "Mitigates React fiber's retention of previous props/state, causing 2x memory use: https://github.com/facebook/react/issues/36176",
-        "stage": "experimental",
+        "stage": "GA",
         "codeowner": "@grafana/dataviz-squad",
         "frontend": true,
         "hideFromDocs": true,
-        "expression": "false"
+        "expression": "true"
       }
     },
     {


### PR DESCRIPTION
Promotes the `clearPreviousFieldValues` feature toggle to General Availability and sets it enabled by default (`expression: true`).

This toggle mitigates React fiber's retention of previous props/state causing 2x memory use (https://github.com/facebook/react/issues/36176).

The toggle retains `HideFromDocs: true` so it does not appear in public documentation.