### PR TITLE
unified-storage: add metrics to kv leases

### DIFF
--- a/pkg/storage/unified/resource/lease/gc.go
+++ b/pkg/storage/unified/resource/lease/gc.go
@@ -44,19 +44,21 @@ type gcMetadata struct {
 // garbageCollector implements garbage collection of leases acquired using the
 // lease manager's `Acquire()` function.
 type garbageCollector struct {
-	store kv.KV
-	stop  context.CancelFunc
-	done  chan struct{}
-	log   logging.Logger
-	now   func() time.Time
+	store   kv.KV
+	stop    context.CancelFunc
+	done    chan struct{}
+	log     logging.Logger
+	now     func() time.Time
+	metrics *Metrics
 }
 
-func newGarbageCollector(store kv.KV, log logging.Logger, now func() time.Time) *garbageCollector {
+func newGarbageCollector(store kv.KV, log logging.Logger, now func() time.Time, metrics *Metrics) *garbageCollector {
 	gc := &garbageCollector{
-		store: store,
-		done:  make(chan struct{}),
-		log:   log.With("gc", true),
-		now:   now,
+		store:   store,
+		done:    make(chan struct{}),
+		log:     log.With("gc", true),
+		now:     now,
+		metrics: metrics,
 	}
 
 	return gc
@@ -119,6 +121,12 @@ func (gc *garbageCollector) loop(ctx context.Context) {
 }
 
 func (gc *garbageCollector) runOnce(ctx context.Context) (int, error) {
+	start := time.Now()
+	outcome := outcomeError
+	defer func() {
+		gc.metrics.observeGCDuration(time.Since(start), outcome)
+	}()
+
 	metadata, err := gc.readInternalKey(ctx)
 	if err != nil && !errors.Is(err, kv.ErrNotFound) {
 		return 0, fmt.Errorf("reading internal key: %w", err)
@@ -128,6 +136,7 @@ func (gc *garbageCollector) runOnce(ctx context.Context) (int, error) {
 		// Internal key exists: check if it's expired.
 		if gc.now().Before(time.Unix(0, metadata.Expires)) {
 			// Some other instance of GC is already running.
+			outcome = outcomeSkipped
 			return 0, nil
 		}
 
@@ -145,12 +154,18 @@ func (gc *garbageCollector) runOnce(ctx context.Context) (int, error) {
 	}
 
 	if !created {
+		outcome = outcomeSkipped
 		return 0, nil
 	}
 
+	outcome = outcomeExecuted
+
 	cycleCtx, stop := context.WithTimeout(ctx, gcMaxCycleDuration)
-	deleted, cycleErr := gc.runCycle(cycleCtx)
+	scanned, deleted, cycleErr := gc.runCycle(cycleCtx)
 	stop()
+
+	gc.metrics.addGCKeysScanned(scanned)
+	gc.metrics.addGCKeysDeleted(deleted)
 
 	deleteErr := gc.deleteInternalKey(ctx)
 	return deleted, errors.Join(cycleErr, deleteErr)
@@ -199,11 +214,12 @@ func (gc *garbageCollector) deleteInternalKey(ctx context.Context) error {
 
 // runCycle runs a single garbage collection cycle. It iterates over the leases
 // section in descending key order and deletes leases that have been released
-// or expired for longer than `gcGracePeriod`.
-func (gc *garbageCollector) runCycle(ctx context.Context) (int, error) {
+// or expired for longer than `gcGracePeriod`. It returns the total number of
+// keys scanned and deleted across all pages.
+func (gc *garbageCollector) runCycle(ctx context.Context) (int, int, error) {
 	var endKey string
 	now := gc.now()
-	var totalDeleted int
+	var totalScanned, totalDeleted int
 
 	for {
 		opts := kv.ListOptions{
@@ -217,7 +233,7 @@ func (gc *garbageCollector) runCycle(ctx context.Context) (int, error) {
 		keys := make([]string, 0, batchSize)
 		for key, err := range gc.store.Keys(ctx, kv.LeasesSection, opts) {
 			if err != nil {
-				return totalDeleted, err
+				return totalScanned, totalDeleted, err
 			}
 			if isInternal(key) {
 				continue
@@ -226,8 +242,10 @@ func (gc *garbageCollector) runCycle(ctx context.Context) (int, error) {
 		}
 
 		if len(keys) == 0 {
-			return totalDeleted, nil
+			return totalScanned, totalDeleted, nil
 		}
+
+		totalScanned += len(keys)
 
 		// In a descending listing the last key is the smallest; pagination
 		// continues by fetching keys strictly less than it (EndKey is exclusive).
@@ -236,7 +254,7 @@ func (gc *garbageCollector) runCycle(ctx context.Context) (int, error) {
 		var toDelete []string
 		for item, err := range gc.store.BatchGet(ctx, kv.LeasesSection, keys) {
 			if err != nil {
-				return totalDeleted, err
+				return totalScanned, totalDeleted, err
 			}
 
 			var meta leaseMetadata

--- a/pkg/storage/unified/resource/lease/lease.go
+++ b/pkg/storage/unified/resource/lease/lease.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/grafana/grafana-app-sdk/logging"
+	"github.com/prometheus/client_golang/prometheus"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	otelcodes "go.opentelemetry.io/otel/codes"
@@ -135,6 +136,7 @@ type Manager struct {
 	log              logging.Logger
 	garbageCollector *garbageCollector
 	now              func() time.Time
+	metrics          *Metrics
 }
 
 // NewManager returns a Manager that uses store for persistence and identifies
@@ -148,7 +150,7 @@ func NewManager(store kv.KV, holder string, opts ...ManagerOption) *Manager {
 		log:          logging.DefaultLogger.With("logger", "lease-manager"),
 		now:          time.Now,
 	}
-	m.garbageCollector = newGarbageCollector(store, m.log, m.now)
+	m.garbageCollector = newGarbageCollector(store, m.log, m.now, m.metrics)
 	for _, opt := range opts {
 		opt(m)
 	}
@@ -193,6 +195,24 @@ func WithGarbageCollectionDisabled(m *Manager) {
 	m.garbageCollector = nil
 }
 
+// WithRegisterer registers Prometheus metrics for the Manager (and its
+// background garbage collector, if enabled) with reg. When the option is not
+// supplied, no metrics are recorded.
+func WithRegisterer(reg prometheus.Registerer) ManagerOption {
+	return WithMetrics(NewMetrics(reg))
+}
+
+// WithMetrics attaches an existing *Metrics to the Manager. Useful for tests
+// that want to inspect specific collectors after exercising the Manager.
+func WithMetrics(metrics *Metrics) ManagerOption {
+	return func(m *Manager) {
+		m.metrics = metrics
+		if m.garbageCollector != nil {
+			m.garbageCollector.metrics = metrics
+		}
+	}
+}
+
 // AcquireOption configures a single Acquire call.
 type AcquireOption func(*acquireOptions)
 
@@ -222,6 +242,7 @@ func WithAutoRenew() AcquireOption {
 // an unexpired lease for name is currently owned by some holder (including
 // possibly the caller).
 func (m *Manager) Acquire(ctx context.Context, name string, opts ...AcquireOption) (lease *Lease, retErr error) {
+	start := time.Now()
 	ctx, span := tracer.Start(ctx, "lease.Manager.Acquire", trace.WithAttributes(
 		attribute.String("lease.name", name),
 		attribute.String("lease.holder", m.holder),
@@ -231,6 +252,8 @@ func (m *Manager) Acquire(ctx context.Context, name string, opts ...AcquireOptio
 		recordSpanError(span, retErr)
 		span.SetAttributes(attribute.Int("attempts", attempts))
 		span.End()
+		m.metrics.observeAcquireRetries(attempts)
+		m.metrics.observeAcquireDuration(time.Since(start), acquireOutcome(retErr))
 	}()
 
 	if err := validateLeaseName(name); err != nil {
@@ -342,6 +365,7 @@ func (m *Manager) Acquire(ctx context.Context, name string, opts ...AcquireOptio
 // Release releases lease. It is not idempotent: releasing a lease that has
 // already been released — or one that has expired — returns ErrLeaseLost.
 func (m *Manager) Release(ctx context.Context, lease *Lease) (retErr error) {
+	start := time.Now()
 	ctx, span := tracer.Start(ctx, "lease.Manager.Release", trace.WithAttributes(
 		attribute.String("lease.name", lease.key.name),
 		attribute.String("lease.holder", lease.holder),
@@ -349,6 +373,7 @@ func (m *Manager) Release(ctx context.Context, lease *Lease) (retErr error) {
 	defer func() {
 		recordSpanError(span, retErr)
 		span.End()
+		m.metrics.observeReleaseDuration(time.Since(start), releaseOutcome(retErr))
 	}()
 
 	lease.stopOnce.Do(func() { close(lease.stop) })
@@ -394,7 +419,7 @@ func (m *Manager) Stop() {
 // RunGarbageCollection runs one garbage collection attempt synchronously.
 // Used for testing.
 func (m *Manager) RunGarbageCollection(ctx context.Context) (int, error) {
-	return newGarbageCollector(m.store, m.log, m.now).runOnce(ctx)
+	return newGarbageCollector(m.store, m.log, m.now, m.metrics).runOnce(ctx)
 }
 
 func (m *Manager) extendGeneration(ctx context.Context, lease *Lease, ttl time.Duration) (time.Time, error) {
@@ -450,6 +475,7 @@ func (m *Manager) expiryLoop(lease *Lease, remaining time.Duration) {
 	case <-lease.stop:
 		return
 	case <-timer.C:
+		m.metrics.recordLoss(lossReasonExpired)
 		lease.notifyLoss()
 	}
 }
@@ -469,18 +495,21 @@ func (m *Manager) autoRenewLoop(lease *Lease, expiry time.Time, ttl, renewInterv
 			newExpiry, err := m.renewOnce(lease, ttl, renewInterval)
 			if errors.Is(err, ErrLeaseLost) {
 				log.Warn("lease lost to another holder during renewal", "err", err)
+				m.metrics.recordLoss(lossReasonLost)
 				lease.notifyLoss()
 				return
 			}
 			if err != nil {
 				if m.now().After(expiry) {
 					log.Error("lease lost: renewal retries exhausted before expiry", "err", err)
+					m.metrics.recordLoss(lossReasonError)
 					lease.notifyLoss()
 					return
 				}
 				log.Warn("lease renewal failed, will retry", "time_until_expiry", expiry.Sub(m.now()), "err", err)
 				continue
 			}
+			m.metrics.recordRenewal()
 			expiry = newExpiry
 		}
 	}

--- a/pkg/storage/unified/resource/lease/metrics.go
+++ b/pkg/storage/unified/resource/lease/metrics.go
@@ -1,0 +1,198 @@
+package lease
+
+import (
+	"errors"
+	"time"
+
+	"github.com/grafana/dskit/instrument"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const metricsNamespace = "lease_manager"
+
+// Outcome labels.
+const (
+	outcomeSuccess     = "success"
+	outcomeError       = "error"
+	outcomeAlreadyHeld = "already_held"
+	outcomeLost        = "lost"
+	outcomeExecuted    = "executed"
+	outcomeSkipped     = "skipped"
+
+	lossReasonExpired = "expired"
+	lossReasonLost    = "lost"
+	lossReasonError   = "error"
+)
+
+// Metrics holds Prometheus collectors for the lease manager and its
+// background garbage collector. All recording methods are nil-safe so that
+// callers can omit metrics wiring (e.g. in tests) without sprinkling
+// conditionals at the call sites.
+type Metrics struct {
+	AcquireDuration    *prometheus.HistogramVec
+	AcquireRetries     prometheus.Histogram
+	ReleaseDuration    *prometheus.HistogramVec
+	RenewalsTotal      prometheus.Counter
+	LossesTotal        *prometheus.CounterVec
+	GCDurationSeconds  *prometheus.HistogramVec
+	GCKeysScannedTotal prometheus.Counter
+	GCKeysDeletedTotal prometheus.Counter
+}
+
+// NewMetrics creates and registers the lease manager metrics with reg. A nil
+// registerer is accepted and causes the collectors to be unregistered (useful
+// for tests).
+func NewMetrics(reg prometheus.Registerer) *Metrics {
+	m := &Metrics{
+		AcquireDuration: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+			Namespace:                       metricsNamespace,
+			Name:                            "acquire_duration_seconds",
+			Help:                            "Time (in seconds) spent in Acquire calls, labeled by outcome.",
+			Buckets:                         instrument.DefBuckets,
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  160,
+			NativeHistogramMinResetDuration: time.Hour,
+		}, []string{"outcome"}),
+		AcquireRetries: promauto.With(reg).NewHistogram(prometheus.HistogramOpts{
+			Namespace: metricsNamespace,
+			Name:      "acquire_retries",
+			Help:      "Number of retries performed by Acquire calls that needed at least one retry.",
+			Buckets:   []float64{1, 2, 3},
+		}),
+		ReleaseDuration: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+			Namespace:                       metricsNamespace,
+			Name:                            "release_duration_seconds",
+			Help:                            "Time (in seconds) spent in Release calls, labeled by outcome.",
+			Buckets:                         instrument.DefBuckets,
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  160,
+			NativeHistogramMinResetDuration: time.Hour,
+		}, []string{"outcome"}),
+		RenewalsTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "renewals_total",
+			Help:      "Total number of successful auto-renewals.",
+		}),
+		LossesTotal: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "losses_total",
+			Help:      "Total number of leases lost involuntarily, labeled by reason (expired, lost, error).",
+		}, []string{"reason"}),
+		GCDurationSeconds: promauto.With(reg).NewHistogramVec(prometheus.HistogramOpts{
+			Namespace:                       metricsNamespace,
+			Name:                            "gc_duration_seconds",
+			Help:                            "Wall-clock duration (in seconds) of a single garbage collection run, labeled by outcome.",
+			Buckets:                         instrument.DefBuckets,
+			NativeHistogramBucketFactor:     1.1,
+			NativeHistogramMaxBucketNumber:  160,
+			NativeHistogramMinResetDuration: time.Hour,
+		}, []string{"outcome"}),
+		GCKeysScannedTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "gc_keys_scanned_total",
+			Help:      "Total number of lease keys scanned by garbage collection.",
+		}),
+		GCKeysDeletedTotal: promauto.With(reg).NewCounter(prometheus.CounterOpts{
+			Namespace: metricsNamespace,
+			Name:      "gc_keys_deleted_total",
+			Help:      "Total number of lease keys deleted by garbage collection.",
+		}),
+	}
+
+	// Pre-initialise label series so they're always present in scrapes.
+	m.AcquireDuration.WithLabelValues(outcomeSuccess)
+	m.AcquireDuration.WithLabelValues(outcomeAlreadyHeld)
+	m.AcquireDuration.WithLabelValues(outcomeError)
+	m.ReleaseDuration.WithLabelValues(outcomeSuccess)
+	m.ReleaseDuration.WithLabelValues(outcomeLost)
+	m.ReleaseDuration.WithLabelValues(outcomeError)
+	m.LossesTotal.WithLabelValues(lossReasonExpired).Add(0)
+	m.LossesTotal.WithLabelValues(lossReasonLost).Add(0)
+	m.LossesTotal.WithLabelValues(lossReasonError).Add(0)
+	m.GCDurationSeconds.WithLabelValues(outcomeExecuted)
+	m.GCDurationSeconds.WithLabelValues(outcomeSkipped)
+	m.GCDurationSeconds.WithLabelValues(outcomeError)
+
+	return m
+}
+
+func (m *Metrics) observeAcquireDuration(d time.Duration, outcome string) {
+	if m == nil {
+		return
+	}
+	m.AcquireDuration.WithLabelValues(outcome).Observe(d.Seconds())
+}
+
+func (m *Metrics) observeAcquireRetries(attempts int) {
+	if m == nil || attempts <= 0 {
+		return
+	}
+	m.AcquireRetries.Observe(float64(attempts))
+}
+
+func (m *Metrics) observeReleaseDuration(d time.Duration, outcome string) {
+	if m == nil {
+		return
+	}
+	m.ReleaseDuration.WithLabelValues(outcome).Observe(d.Seconds())
+}
+
+func (m *Metrics) recordRenewal() {
+	if m == nil {
+		return
+	}
+	m.RenewalsTotal.Inc()
+}
+
+func (m *Metrics) recordLoss(reason string) {
+	if m == nil {
+		return
+	}
+	m.LossesTotal.WithLabelValues(reason).Inc()
+}
+
+func (m *Metrics) addGCKeysScanned(n int) {
+	if m == nil || n == 0 {
+		return
+	}
+	m.GCKeysScannedTotal.Add(float64(n))
+}
+
+func (m *Metrics) addGCKeysDeleted(n int) {
+	if m == nil || n == 0 {
+		return
+	}
+	m.GCKeysDeletedTotal.Add(float64(n))
+}
+
+func (m *Metrics) observeGCDuration(d time.Duration, outcome string) {
+	if m == nil {
+		return
+	}
+	m.GCDurationSeconds.WithLabelValues(outcome).Observe(d.Seconds())
+}
+
+// acquireOutcome returns the outcome label for an Acquire result.
+func acquireOutcome(err error) string {
+	switch {
+	case err == nil:
+		return outcomeSuccess
+	case errors.Is(err, ErrLeaseAlreadyHeld):
+		return outcomeAlreadyHeld
+	default:
+		return outcomeError
+	}
+}
+
+// releaseOutcome returns the outcome label for a Release result.
+func releaseOutcome(err error) string {
+	switch {
+	case err == nil:
+		return outcomeSuccess
+	case errors.Is(err, ErrLeaseLost):
+		return outcomeLost
+	default:
+		return outcomeError
+	}
+}

--- a/pkg/storage/unified/resource/lease/metrics_test.go
+++ b/pkg/storage/unified/resource/lease/metrics_test.go
@@ -1,0 +1,363 @@
+package lease_test
+
+import (
+	"context"
+	"fmt"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/storage/unified/resource/kv"
+	"github.com/grafana/grafana/pkg/storage/unified/resource/lease"
+)
+
+func TestMetricsNilSafe(t *testing.T) {
+	// Manager constructed without metrics must work end-to-end without
+	// panicking. Existing tests already exercise this path; this is an
+	// explicit smoke test for the documented invariant.
+	m := lease.NewManager(newMapKV(), "holder-nil", lease.WithGarbageCollectionDisabled)
+
+	l, err := m.Acquire(t.Context(), "metrics/nil-safe")
+	require.NoError(t, err)
+	require.NoError(t, m.Release(t.Context(), l))
+
+	_, err = m.RunGarbageCollection(t.Context())
+	require.NoError(t, err)
+}
+
+func TestMetricsAcquireRelease(t *testing.T) {
+	metrics := lease.NewMetrics(prometheus.NewRegistry())
+	m := lease.NewManager(newMapKV(), "holder-ar",
+		lease.WithGarbageCollectionDisabled,
+		lease.WithMetrics(metrics),
+	)
+
+	l, err := m.Acquire(t.Context(), "metrics/acquire-release")
+	require.NoError(t, err)
+	require.NoError(t, m.Release(t.Context(), l))
+
+	// Total acquire/release call counts are derived from the duration
+	// histograms' _count series.
+	require.Equal(t, uint64(1), histogramVecCount(t, metrics.AcquireDuration, "success"))
+	require.Equal(t, uint64(0), histogramVecCount(t, metrics.AcquireDuration, "already_held"))
+	require.Equal(t, uint64(0), histogramVecCount(t, metrics.AcquireDuration, "error"))
+	require.Equal(t, uint64(1), histogramVecCount(t, metrics.ReleaseDuration, "success"))
+	require.Equal(t, uint64(0), histogramVecCount(t, metrics.ReleaseDuration, "lost"))
+	require.Equal(t, uint64(0), histogramVecCount(t, metrics.ReleaseDuration, "error"))
+
+	// No retries observed when no contention occurred.
+	require.Equal(t, uint64(0), histogramCount(t, metrics.AcquireRetries))
+
+	// Graceful release must NOT count as a loss under any reason.
+	requireNoLosses(t, metrics)
+}
+
+func TestMetricsAcquireErrorOutcome(t *testing.T) {
+	metrics := lease.NewMetrics(prometheus.NewRegistry())
+	m := lease.NewManager(newMapKV(), "holder-err",
+		lease.WithGarbageCollectionDisabled,
+		lease.WithMetrics(metrics),
+	)
+
+	// Invalid name → Acquire returns before the retry loop. Duration is still
+	// observed with outcome=error.
+	_, err := m.Acquire(t.Context(), "")
+	require.Error(t, err)
+
+	require.Equal(t, uint64(0), histogramVecCount(t, metrics.AcquireDuration, "success"))
+	require.Equal(t, uint64(0), histogramVecCount(t, metrics.AcquireDuration, "already_held"))
+	require.Equal(t, uint64(1), histogramVecCount(t, metrics.AcquireDuration, "error"))
+}
+
+func TestMetricsAcquireAlreadyHeldOutcome(t *testing.T) {
+	metrics := lease.NewMetrics(prometheus.NewRegistry())
+	m := lease.NewManager(newMapKV(), "holder-already-held",
+		lease.WithGarbageCollectionDisabled,
+		lease.WithMetrics(metrics),
+	)
+
+	// First acquire succeeds; second acquire of the same name returns
+	// ErrLeaseAlreadyHeld.
+	l, err := m.Acquire(t.Context(), "metrics/already-held")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = m.Release(t.Context(), l) })
+
+	_, err = m.Acquire(t.Context(), "metrics/already-held")
+	require.ErrorIs(t, err, lease.ErrLeaseAlreadyHeld)
+
+	require.Equal(t, uint64(1), histogramVecCount(t, metrics.AcquireDuration, "success"))
+	require.Equal(t, uint64(1), histogramVecCount(t, metrics.AcquireDuration, "already_held"))
+	require.Equal(t, uint64(0), histogramVecCount(t, metrics.AcquireDuration, "error"))
+}
+
+func TestMetricsReleaseLostOutcome(t *testing.T) {
+	const ttl = 50 * time.Millisecond
+
+	metrics := lease.NewMetrics(prometheus.NewRegistry())
+	m := lease.NewManager(newMapKV(), "holder-release-lost",
+		lease.WithGarbageCollectionDisabled,
+		lease.WithInternalMinTTL(ttl),
+		lease.WithMetrics(metrics),
+	)
+
+	l, err := m.Acquire(t.Context(), "metrics/release-lost", lease.WithTTL(ttl))
+	require.NoError(t, err)
+
+	// Wait for the lease to expire so Release returns ErrLeaseLost.
+	select {
+	case <-l.Lost():
+	case <-time.After(ttl + 2*time.Second):
+		t.Fatal("Lost() did not fire after expiry")
+	}
+
+	err = m.Release(t.Context(), l)
+	require.ErrorIs(t, err, lease.ErrLeaseLost)
+
+	require.Equal(t, uint64(0), histogramVecCount(t, metrics.ReleaseDuration, "success"))
+	require.Equal(t, uint64(1), histogramVecCount(t, metrics.ReleaseDuration, "lost"))
+	require.Equal(t, uint64(0), histogramVecCount(t, metrics.ReleaseDuration, "error"))
+}
+
+func TestMetricsAcquireRetries(t *testing.T) {
+	metrics := lease.NewMetrics(prometheus.NewRegistry())
+	failing := &retryKV{KV: newMapKV()}
+	m := lease.NewManager(failing, "holder-retry",
+		lease.WithGarbageCollectionDisabled,
+		lease.WithMetrics(metrics),
+	)
+
+	// First Batch call fails with ErrKeyAlreadyExists, forcing the loop to
+	// retry exactly once.
+	l, err := m.Acquire(t.Context(), "metrics/retry")
+	require.NoError(t, err)
+	require.NoError(t, m.Release(t.Context(), l))
+
+	require.Equal(t, uint64(1), histogramCount(t, metrics.AcquireRetries))
+	require.Equal(t, 1.0, histogramSum(t, metrics.AcquireRetries))
+}
+
+func TestMetricsLossOnExpiry(t *testing.T) {
+	const ttl = 50 * time.Millisecond
+
+	metrics := lease.NewMetrics(prometheus.NewRegistry())
+	m := lease.NewManager(newMapKV(), "holder-loss",
+		lease.WithGarbageCollectionDisabled,
+		lease.WithInternalMinTTL(ttl),
+		lease.WithMetrics(metrics),
+	)
+
+	l, err := m.Acquire(t.Context(), "metrics/loss", lease.WithTTL(ttl))
+	require.NoError(t, err)
+
+	select {
+	case <-l.Lost():
+	case <-time.After(ttl + 2*time.Second):
+		t.Fatal("Lost() did not fire after expiry")
+	}
+
+	require.Equal(t, 1.0, testutil.ToFloat64(metrics.LossesTotal.WithLabelValues("expired")))
+	require.Equal(t, 0.0, testutil.ToFloat64(metrics.LossesTotal.WithLabelValues("lost")))
+	require.Equal(t, 0.0, testutil.ToFloat64(metrics.LossesTotal.WithLabelValues("error")))
+}
+
+func TestMetricsRenewalSuccess(t *testing.T) {
+	const ttl = 100 * time.Millisecond
+
+	metrics := lease.NewMetrics(prometheus.NewRegistry())
+	m := lease.NewManager(newMapKV(), "holder-renew",
+		lease.WithGarbageCollectionDisabled,
+		lease.WithInternalMinTTL(ttl),
+		lease.WithMetrics(metrics),
+	)
+
+	l, err := m.Acquire(t.Context(), "metrics/renew", lease.WithTTL(ttl), lease.WithAutoRenew())
+	require.NoError(t, err)
+
+	// renewInterval = ttl/3, so we should see at least one renewal quickly.
+	require.Eventually(t, func() bool {
+		return testutil.ToFloat64(metrics.RenewalsTotal) >= 1
+	}, ttl*5, ttl/3)
+
+	require.NoError(t, m.Release(t.Context(), l))
+
+	requireNoLosses(t, metrics)
+}
+
+func TestMetricsRenewalFailureLost(t *testing.T) {
+	const ttl = 100 * time.Millisecond
+
+	store := newMapKV()
+	metrics := lease.NewMetrics(prometheus.NewRegistry())
+	a := lease.NewManager(store, "holder-a",
+		lease.WithGarbageCollectionDisabled,
+		lease.WithInternalMinTTL(ttl),
+		lease.WithMetrics(metrics),
+	)
+
+	l, err := a.Acquire(t.Context(), "metrics/renew-lost", lease.WithTTL(ttl), lease.WithAutoRenew())
+	require.NoError(t, err)
+
+	// b uses a clock far in the future so it sees a's (still actively renewed)
+	// lease as expired and can steal the next generation slot. The next time
+	// a's renewal goroutine ticks it tries to create the same generation key
+	// and fails with ErrLeaseLost.
+	future := func() time.Time { return time.Now().Add(time.Hour) }
+	b := lease.NewManager(store, "holder-b",
+		lease.WithGarbageCollectionDisabled,
+		lease.WithInternalMinTTL(ttl),
+		lease.WithInternalNowFunc(future),
+	)
+	_, err = b.Acquire(t.Context(), "metrics/renew-lost", lease.WithTTL(ttl))
+	require.NoError(t, err)
+
+	select {
+	case <-l.Lost():
+	case <-time.After(ttl + 2*time.Second):
+		t.Fatal("Lost() did not fire after stolen lease")
+	}
+
+	require.Equal(t, 1.0, testutil.ToFloat64(metrics.LossesTotal.WithLabelValues("lost")))
+	require.Equal(t, 0.0, testutil.ToFloat64(metrics.LossesTotal.WithLabelValues("expired")))
+	require.Equal(t, 0.0, testutil.ToFloat64(metrics.LossesTotal.WithLabelValues("error")))
+}
+
+func TestMetricsGCExecuted(t *testing.T) {
+	metrics := lease.NewMetrics(prometheus.NewRegistry())
+	m := lease.NewManager(newMapKV(), "holder-gc-exec",
+		lease.WithGarbageCollectionDisabled,
+		lease.WithMetrics(metrics),
+	)
+
+	_, err := m.RunGarbageCollection(t.Context())
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(1), histogramVecCount(t, metrics.GCDurationSeconds, "executed"))
+	require.Equal(t, uint64(0), histogramVecCount(t, metrics.GCDurationSeconds, "skipped"))
+	require.Equal(t, uint64(0), histogramVecCount(t, metrics.GCDurationSeconds, "error"))
+}
+
+func TestMetricsGCSkipped(t *testing.T) {
+	store := newMapKV()
+	// Simulate another GC instance currently holding the internal key.
+	writeGCInternalKey(t, store, time.Now().Add(time.Minute))
+
+	metrics := lease.NewMetrics(prometheus.NewRegistry())
+	m := lease.NewManager(store, "holder-gc-skip",
+		lease.WithGarbageCollectionDisabled,
+		lease.WithMetrics(metrics),
+	)
+
+	_, err := m.RunGarbageCollection(t.Context())
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(0), histogramVecCount(t, metrics.GCDurationSeconds, "executed"))
+	require.Equal(t, uint64(1), histogramVecCount(t, metrics.GCDurationSeconds, "skipped"))
+	require.Equal(t, uint64(0), histogramVecCount(t, metrics.GCDurationSeconds, "error"))
+}
+
+func TestMetricsGCScannedAndDeleted(t *testing.T) {
+	const shortTTL = time.Millisecond
+	ctx := t.Context()
+
+	store := newMapKV()
+	base := time.Now().Add(-10 * time.Minute)
+	now := base
+	nowFunc := func() time.Time { return now }
+
+	metrics := lease.NewMetrics(prometheus.NewRegistry())
+	m := lease.NewManager(store, "holder-gc-counts",
+		lease.WithGarbageCollectionDisabled,
+		lease.WithInternalMinTTL(shortTTL),
+		lease.WithInternalNowFunc(nowFunc),
+		lease.WithMetrics(metrics),
+	)
+
+	// One released lease and one expired lease, both well in the past.
+	released, err := m.Acquire(ctx, "metrics/gc/released")
+	require.NoError(t, err)
+	require.NoError(t, m.Release(ctx, released))
+
+	_, err = m.Acquire(ctx, "metrics/gc/expired", lease.WithTTL(shortTTL))
+	require.NoError(t, err)
+
+	// Advance the clock past the GC grace period.
+	now = time.Now()
+
+	deleted, err := m.RunGarbageCollection(ctx)
+	require.NoError(t, err)
+	require.Equal(t, 2, deleted)
+
+	require.Equal(t, 2.0, testutil.ToFloat64(metrics.GCKeysScannedTotal))
+	require.Equal(t, 2.0, testutil.ToFloat64(metrics.GCKeysDeletedTotal))
+}
+
+// requireNoLosses asserts that no loss-reason label has been incremented.
+func requireNoLosses(t *testing.T, metrics *lease.Metrics) {
+	t.Helper()
+	for _, reason := range []string{"expired", "lost", "error"} {
+		require.Equal(t, 0.0, testutil.ToFloat64(metrics.LossesTotal.WithLabelValues(reason)),
+			"unexpected loss recorded with reason=%q", reason)
+	}
+}
+
+// retryKV wraps a KV and rejects the first Batch call with
+// kv.ErrKeyAlreadyExists, forcing Acquire's retry loop to spin once.
+type retryKV struct {
+	kv.KV
+	failed atomic.Bool
+}
+
+func (r *retryKV) Batch(ctx context.Context, section string, ops []kv.BatchOp) error {
+	if !r.failed.Swap(true) {
+		return kv.ErrKeyAlreadyExists
+	}
+	return r.KV.Batch(ctx, section, ops)
+}
+
+// writeGCInternalKey writes a fake lease-internal/gc key directly into the
+// store so that a subsequent runOnce sees another instance "holding" the GC
+// lock and takes the skip path.
+func writeGCInternalKey(t *testing.T, store kv.KV, expires time.Time) {
+	t.Helper()
+	data := []byte(fmt.Sprintf(`{"expires":%d}`, expires.UnixNano()))
+	w, err := store.Save(t.Context(), kv.LeasesSection, "lease-internal/gc")
+	require.NoError(t, err)
+	_, err = w.Write(data)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+}
+
+// histogramCount returns the sample count of a Histogram by writing it to a
+// protobuf metric.
+func histogramCount(t *testing.T, h prometheus.Histogram) uint64 {
+	t.Helper()
+	return writeHistogram(t, h).GetSampleCount()
+}
+
+// histogramSum returns the cumulative sum of observations in a Histogram.
+func histogramSum(t *testing.T, h prometheus.Histogram) float64 {
+	t.Helper()
+	return writeHistogram(t, h).GetSampleSum()
+}
+
+// histogramVecCount returns the sample count of a single label combination in
+// a HistogramVec.
+func histogramVecCount(t *testing.T, vec *prometheus.HistogramVec, labelValues ...string) uint64 {
+	t.Helper()
+	obs, err := vec.GetMetricWithLabelValues(labelValues...)
+	require.NoError(t, err)
+	return histogramCount(t, obs.(prometheus.Histogram))
+}
+
+func writeHistogram(t *testing.T, h prometheus.Histogram) *dto.Histogram {
+	t.Helper()
+	var m dto.Metric
+	require.NoError(t, h.Write(&m))
+	require.NotNil(t, m.Histogram)
+	return m.Histogram
+}

--- a/pkg/storage/unified/resource/storage_backend.go
+++ b/pkg/storage/unified/resource/storage_backend.go
@@ -246,7 +246,7 @@ func NewKVStorageBackend(opts KVBackendOptions) (KVBackend, error) {
 			cancel()
 			return nil, errors.New("holder is required when enable_kv_leases is true")
 		}
-		leaseManager = lease.NewManager(kv, opts.Holder)
+		leaseManager = lease.NewManager(kv, opts.Holder, lease.WithRegisterer(opts.Reg))
 	}
 
 	backend := &kvStorageBackend{


### PR DESCRIPTION
Adds metrics to help us keep track of the overhead of `Acquire` and `Release` calls, as well as GC-related metrics such as the number of keys scanned and deleted in each cycle.