### PR TITLE
Apiservers: create custom http handler chain

### DIFF
--- a/pkg/services/apiserver/builder/custom_handler_chain.go
+++ b/pkg/services/apiserver/builder/custom_handler_chain.go
@@ -1,0 +1,116 @@
+// THIS FILE IS MOSTLY COPY/PASTA FROM k8s
+// PLEASE EDIT WITH GREAT CARE TO MINIMIZE FORK
+// SEE COMMENTS BELOW FOR MORE DETAILS
+
+package builder
+
+import (
+	"net/http"
+
+	"k8s.io/apiserver/pkg/endpoints/filterlatency"
+	genericapifilters "k8s.io/apiserver/pkg/endpoints/filters"
+	"k8s.io/apiserver/pkg/endpoints/filters/impersonation"
+	genericfeatures "k8s.io/apiserver/pkg/features"
+	genericapiserver "k8s.io/apiserver/pkg/server"
+	genericfilters "k8s.io/apiserver/pkg/server/filters"
+	"k8s.io/apiserver/pkg/server/routine"
+	flowcontrolrequest "k8s.io/apiserver/pkg/util/flowcontrol/request"
+)
+
+// CustomBuildHandlerChain is a Grafana-specific variant of k8s
+// genericapiserver.DefaultBuildHandlerChain. It differs in three ways, all of
+// which are deliberate:
+//
+//  1. It omits genericapifilters.WithTracing. k8s wraps the chain with
+//     otelhttp configured as a public endpoint for non-system:privileged
+//     callers, which severs the upstream trace context — every request gets a
+//     fresh root span linked (not parented) to the caller. Our embedded
+//     apiservers only receive requests from trusted internal services,
+//     and the outer WithTracing in GetDefaultBuildHandlerChainFunc already
+//     creates the KubernetesAPI span with proper parent-child propagation.
+//
+//  2. It omits the WithRetryAfter and WithWatchTerminationDuringShutdown
+//     filters as these filteres depend on an unexported Config.lifecycleSignals
+//     field. Both are gated upstream on Config fields (ShutdownSendRetryAfter,
+//     ShutdownWatchTerminationGracePeriod) that Grafana never sets,
+//     so the filters were dead code. Dropping them lets us avoid reflection
+//     + unsafe.Pointer to reach into k8s internals.
+//
+//  3. It omits WithMuxAndDiscoveryComplete. That filter exists upstream to
+//     keep k8s GC/namespace controllers from acting on stray 404s during
+//     mux installation. Grafana apiservers are not consulted by those
+//     controllers, so the protection is unnecessary. Same lifecycleSignals
+//     reasoning as above.
+//
+// Maintenance: when bumping k8s, diff genericapiserver.DefaultBuildHandlerChain
+// (k8s.io/apiserver/pkg/server/config.go) against this function and reconcile
+// any new filters that appear.
+func CustomBuildHandlerChain(apiHandler http.Handler, c *genericapiserver.Config) http.Handler {
+	handler := apiHandler
+
+	handler = filterlatency.TrackCompleted(handler)
+	handler = genericapifilters.WithAuthorization(handler, c.Authorization.Authorizer, c.Serializer)
+	handler = filterlatency.TrackStarted(handler, c.TracerProvider, "authorization")
+
+	if c.FlowControl != nil {
+		workEstimatorCfg := flowcontrolrequest.DefaultWorkEstimatorConfig()
+		requestWorkEstimator := flowcontrolrequest.NewWorkEstimator(
+			c.StorageObjectCountTracker.Get, c.FlowControl.GetInterestedWatchCount, workEstimatorCfg, c.FlowControl.GetMaxSeats)
+		handler = filterlatency.TrackCompleted(handler)
+		handler = genericfilters.WithPriorityAndFairness(handler, c.LongRunningFunc, c.FlowControl, requestWorkEstimator, c.RequestTimeout/4)
+		handler = filterlatency.TrackStarted(handler, c.TracerProvider, "priorityandfairness")
+	} else {
+		handler = genericfilters.WithMaxInFlightLimit(handler, c.MaxRequestsInFlight, c.MaxMutatingRequestsInFlight, c.LongRunningFunc)
+	}
+
+	handler = filterlatency.TrackCompleted(handler)
+	if c.FeatureGate.Enabled(genericfeatures.ConstrainedImpersonation) {
+		handler = impersonation.WithConstrainedImpersonation(handler, c.Authorization.Authorizer, c.Serializer)
+		handler = filterlatency.TrackStarted(handler, c.TracerProvider, "constrainedimpersonation")
+	} else {
+		handler = impersonation.WithImpersonation(handler, c.Authorization.Authorizer, c.Serializer)
+		handler = filterlatency.TrackStarted(handler, c.TracerProvider, "impersonation")
+	}
+
+	handler = filterlatency.TrackCompleted(handler)
+	handler = genericapifilters.WithAudit(handler, c.AuditBackend, c.AuditPolicyRuleEvaluator, c.LongRunningFunc)
+	handler = filterlatency.TrackStarted(handler, c.TracerProvider, "audit")
+
+	failedHandler := genericapifilters.Unauthorized(c.Serializer)
+	failedHandler = genericapifilters.WithFailedAuthenticationAudit(failedHandler, c.AuditBackend, c.AuditPolicyRuleEvaluator)
+
+	// OMITTED: genericapifilters.WithTracing — see function header (1).
+
+	failedHandler = filterlatency.TrackCompleted(failedHandler)
+	handler = filterlatency.TrackCompleted(handler)
+	handler = genericapifilters.WithAuthentication(handler, c.Authentication.Authenticator, failedHandler, c.Authentication.APIAudiences, c.Authentication.RequestHeaderConfig)
+	handler = filterlatency.TrackStarted(handler, c.TracerProvider, "authentication")
+
+	handler = genericfilters.WithCORS(handler, c.CorsAllowedOriginList, nil, nil, nil, "true")
+
+	handler = genericapifilters.WithWarningRecorder(handler)
+
+	handler = genericfilters.WithTimeoutForNonLongRunningRequests(handler, c.LongRunningFunc)
+
+	handler = genericapifilters.WithRequestDeadline(handler, c.AuditBackend, c.AuditPolicyRuleEvaluator,
+		c.LongRunningFunc, c.Serializer, c.RequestTimeout)
+	handler = genericfilters.WithWaitGroup(handler, c.LongRunningFunc, c.NonLongRunningRequestWaitGroup)
+	// OMITTED: genericfilters.WithWatchTerminationDuringShutdown — see function header (2).
+	if c.SecureServing != nil && !c.SecureServing.DisableHTTP2 && c.GoawayChance > 0 {
+		handler = genericfilters.WithProbabilisticGoaway(handler, c.GoawayChance)
+	}
+	handler = genericapifilters.WithCacheControl(handler)
+	handler = genericfilters.WithHSTS(handler, c.HSTSDirectives)
+	// OMITTED: genericfilters.WithRetryAfter — see function header (2).
+	handler = genericfilters.WithHTTPLogging(handler)
+	handler = genericapifilters.WithLatencyTrackers(handler)
+	if c.FeatureGate.Enabled(genericfeatures.APIServingWithRoutine) {
+		handler = routine.WithRoutine(handler, c.LongRunningFunc)
+	}
+	handler = genericapifilters.WithRequestInfo(handler, c.RequestInfoResolver)
+	handler = genericapifilters.WithRequestReceivedTimestamp(handler)
+	// OMITTED: genericapifilters.WithMuxAndDiscoveryComplete — see function header (3).
+	handler = genericfilters.WithPanicRecovery(handler, c.RequestInfoResolver)
+	handler = genericapifilters.WithAuditInit(handler)
+	return handler
+}

--- a/pkg/services/apiserver/builder/helper.go
+++ b/pkg/services/apiserver/builder/helper.go
@@ -98,10 +98,10 @@ func GetDefaultBuildHandlerChainFunc(builders []APIGroupBuilder, reg prometheus.
 		// filters.WithRequester needs to be after the K8s chain because it depends on the K8s user in context
 		handler = filters.WithRequester(handler)
 
-		// Call DefaultBuildHandlerChain on the main entrypoint http.Handler
-		// See https://github.com/kubernetes/apiserver/blob/v0.28.0/pkg/server/config.go#L906
-		// DefaultBuildHandlerChain provides many things, notably CORS, HSTS, cache-control, authz and latency tracking
-		handler = genericapiserver.DefaultBuildHandlerChain(handler, c)
+		// CustomBuildHandlerChain mirrors DefaultBuildHandlerChain but omits the
+		// inner WithTracing filter, which otherwise treats most callers as public
+		// endpoints and severs the upstream trace context. See custom_handler_chain.go.
+		handler = CustomBuildHandlerChain(handler, c)
 
 		handler = filters.WithAcceptHeader(handler)
 		handler = filters.WithPathRewriters(handler, PathRewriters)


### PR DESCRIPTION
**What is this feature?**

Adds a custom http handler chain for our apiservers that is ALMOST like the k8s one we were using, but does not force traces to be root spans

**Why do we need this feature?**

- Our apiservers [call](https://github.com/grafana/grafana-enterprise/blob/f2e9d89490deeb603a5684b4c92abdfdaf726a19/src/pkg/extensions/apiserver/factory.go#L798) this k8s function “DefaultBuildHandlerChain”  in part of their http handlers
- DefaultBuildHandlerChain in k8s [calls](https://github.com/kubernetes/apiserver/blob/7dbcf77519abaf55336d51af2aa90bc33a68b468/pkg/server/config.go#L1072) a function WithTracing
- WithTracing [calls](https://github.com/kubernetes/apiserver/blob/master/pkg/endpoints/filters/traces.go#L36) this function WithPublicEndpointFn
- WithPublicEndpointFn then [creates a new root](https://github.com/open-telemetry/opentelemetry-go-contrib/blob/instrumentation/net/http/otelhttp/v0.68.0/instrumentation/net/http/otelhttp/handler.go#L103-L109)

The end result is all of our traces in our apiservers assume they are the parent span, which is so far never the case to my knowledge. This is not an ideal solution as we will now have to maintain this forked function, but it seems like a decent patch for now until we can create another idea? 

I also explored manually creating child spans from headers in another pr, both at a [per service level](https://github.com/grafana/grafana/pull/125232/changes/2d3718f9d71da4c8b61ca1a851817b1b1b98a797) and then at a [higher apiservice](https://github.com/grafana/grafana/pull/125232/changes/6560bd9a7bfa2176cb3f37b147e29fcdbaa4bfa2) level but those solutions felt brittle to me, it also had the unpleasant side effect of making the query service traces look like siblings of a generic query service span rather than children of it. Where as this approach puts the spans where they belong

Additional internal information can be found https://docs.google.com/document/d/13CfQuJ9CByh9DX3sQTI1aauR3-5vPGz4SjD5qbvHTsQ/edit?tab=t.0

**Who is this feature for?**

grafana devs

Fixes https://github.com/grafana/grafana-enterprise/issues/12099

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.



TODO: 
- test on dev