### PR TITLE
unified-storage: skip resource stats call for unenforced resources

### DIFF
--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -2095,6 +2095,12 @@ func (s *server) checkQuota(ctx context.Context, nsr NamespacedResource) error {
 		return nil
 	}
 
+	// Don't compute resource stats for unenforced resources, as that's an
+	// expensive operation.
+	if !s.quotasConfig.ShouldEnforce(nsr.Group, nsr.Resource) {
+		return nil
+	}
+
 	quota, err := s.overridesService.GetQuota(ctx, nsr)
 	if err != nil {
 		s.log.FromContext(ctx).Error("failed to get quota for resource", "namespace", nsr.Namespace, "group", nsr.Group, "resource", nsr.Resource, "error", err)
@@ -2114,13 +2120,11 @@ func (s *server) checkQuota(ctx context.Context, nsr NamespacedResource) error {
 
 	if len(stats) > 0 && stats[0].Count >= int64(quota.Limit) {
 		s.log.FromContext(ctx).Info("Quota exceeded on create", "namespace", nsr.Namespace, "group", nsr.Group, "resource", nsr.Resource, "quota", quota.Limit, "count", stats[0].Count, "stats_resource", stats[0].Resource)
-		if s.quotasConfig.ShouldEnforce(nsr.Group, nsr.Resource) {
-			return QuotaExceededError{
-				Resource:       nsr.Resource,
-				Used:           stats[0].Count,
-				Limit:          quota.Limit,
-				SupportMessage: s.quotasConfig.SupportMessage,
-			}
+		return QuotaExceededError{
+			Resource:       nsr.Resource,
+			Used:           stats[0].Count,
+			Limit:          quota.Limit,
+			SupportMessage: s.quotasConfig.SupportMessage,
 		}
 	}
 


### PR DESCRIPTION
Computing resource stats can be pretty expensive, so we skip it unless the quota needs to be enforced.