### PR TITLE
unified-storage: fix race when reading lease key with auto-renewals

### DIFF
--- a/pkg/storage/unified/resource/lease/lease.go
+++ b/pkg/storage/unified/resource/lease/lease.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/grafana/grafana-app-sdk/logging"
@@ -63,7 +64,7 @@ var (
 )
 
 type Lease struct {
-	key      leaseKey
+	key      atomic.Pointer[leaseKey]
 	holder   string
 	lostCh   chan struct{}
 	lostOnce sync.Once
@@ -345,12 +346,12 @@ func (m *Manager) Acquire(ctx context.Context, name string, opts ...AcquireOptio
 		}
 
 		l := &Lease{
-			key:    key,
 			holder: m.holder,
 			lostCh: make(chan struct{}),
 			stop:   make(chan struct{}),
 			done:   make(chan struct{}),
 		}
+		l.key.Store(&key)
 
 		if cfg.autoRenew {
 			renewInterval := cfg.ttl / 3
@@ -366,8 +367,9 @@ func (m *Manager) Acquire(ctx context.Context, name string, opts ...AcquireOptio
 // already been released — or one that has expired — returns ErrLeaseLost.
 func (m *Manager) Release(ctx context.Context, lease *Lease) (retErr error) {
 	start := time.Now()
+	key := lease.key.Load()
 	ctx, span := tracer.Start(ctx, "lease.Manager.Release", trace.WithAttributes(
-		attribute.String("lease.name", lease.key.name),
+		attribute.String("lease.name", key.name),
 		attribute.String("lease.holder", lease.holder),
 	))
 	defer func() {
@@ -380,12 +382,16 @@ func (m *Manager) Release(ctx context.Context, lease *Lease) (retErr error) {
 	<-lease.done
 	defer lease.notifyLoss()
 
-	meta, err := m.read(ctx, lease.key)
+	// Reload after the auto-renew goroutine has exited so we release the
+	// latest generation rather than one that the renewer may have just
+	// tombstoned.
+	key = lease.key.Load()
+	meta, err := m.read(ctx, *key)
 	if err != nil {
 		if errors.Is(err, kv.ErrNotFound) {
-			return fmt.Errorf("releasing %s~%d: %w (not found)", lease.key.name, lease.key.generation, ErrLeaseLost)
+			return fmt.Errorf("releasing %s~%d: %w (not found)", key.name, key.generation, ErrLeaseLost)
 		}
-		return fmt.Errorf("releasing %s~%d: %w", lease.key.name, lease.key.generation, err)
+		return fmt.Errorf("releasing %s~%d: %w", key.name, key.generation, err)
 	}
 
 	// Note that we're not guaranteed to return ErrLeaseLost if two managers for
@@ -396,13 +402,13 @@ func (m *Manager) Release(ctx context.Context, lease *Lease) (retErr error) {
 	// at this time.
 	now := m.now()
 	if meta.Holder != m.holder || !meta.ValidAsOf(now) {
-		return fmt.Errorf("releasing %s~%d: %w", lease.key.name, lease.key.generation, ErrLeaseLost)
+		return fmt.Errorf("releasing %s~%d: %w", key.name, key.generation, ErrLeaseLost)
 	}
 
 	meta.Deleted = true
 	meta.ReleasedAt = now.UnixNano()
-	if err := m.save(ctx, lease.key, meta); err != nil {
-		return fmt.Errorf("releasing %s~%d: %w", lease.key.name, lease.key.generation, err)
+	if err := m.save(ctx, *key, meta); err != nil {
+		return fmt.Errorf("releasing %s~%d: %w", key.name, key.generation, err)
 	}
 
 	return nil
@@ -423,17 +429,18 @@ func (m *Manager) RunGarbageCollection(ctx context.Context) (int, error) {
 }
 
 func (m *Manager) extendGeneration(ctx context.Context, lease *Lease, ttl time.Duration) (time.Time, error) {
-	meta, err := m.read(ctx, lease.key)
+	key := lease.key.Load()
+	meta, err := m.read(ctx, *key)
 	if err != nil {
-		return time.Time{}, fmt.Errorf("extending %s~%d: %w", lease.key.name, lease.key.generation, err)
+		return time.Time{}, fmt.Errorf("extending %s~%d: %w", key.name, key.generation, err)
 	}
 
 	now := m.now()
 	if meta.Holder != m.holder || !meta.ValidAsOf(now) {
-		return time.Time{}, fmt.Errorf("extending %s~%d: %w", lease.key.name, lease.key.generation, ErrLeaseLost)
+		return time.Time{}, fmt.Errorf("extending %s~%d: %w", key.name, key.generation, ErrLeaseLost)
 	}
 
-	newGeneration := lease.key.generation + 1
+	newGeneration := key.generation + 1
 	expires := now.Add(ttl)
 	state := leaseMetadata{
 		Holder:  m.holder,
@@ -451,19 +458,19 @@ func (m *Manager) extendGeneration(ctx context.Context, lease *Lease, ttl time.D
 		return time.Time{}, err
 	}
 
-	newKey := newLeaseKey(lease.key.name, newGeneration)
+	newKey := newLeaseKey(key.name, newGeneration)
 	err = m.store.Batch(ctx, kv.LeasesSection, []kv.BatchOp{
 		{Mode: kv.BatchOpCreate, Key: newKey.String(), Value: value},
-		{Mode: kv.BatchOpUpdate, Key: lease.key.String(), Value: tombstone},
+		{Mode: kv.BatchOpUpdate, Key: key.String(), Value: tombstone},
 	})
 	if errors.Is(err, kv.ErrKeyAlreadyExists) {
-		return time.Time{}, fmt.Errorf("extending %s~%d: %w", lease.key.name, lease.key.generation, ErrLeaseLost)
+		return time.Time{}, fmt.Errorf("extending %s~%d: %w", key.name, key.generation, ErrLeaseLost)
 	}
 	if err != nil {
-		return time.Time{}, fmt.Errorf("extending %s~%d: %w", lease.key.name, lease.key.generation, err)
+		return time.Time{}, fmt.Errorf("extending %s~%d: %w", key.name, key.generation, err)
 	}
 
-	lease.key = newKey
+	lease.key.Store(&newKey)
 	return expires, nil
 }
 
@@ -486,7 +493,8 @@ func (m *Manager) autoRenewLoop(lease *Lease, expiry time.Time, ttl, renewInterv
 	defer ticker.Stop()
 
 	for {
-		log := m.log.With("lease", lease.key.name, "holder", lease.holder, "generation", lease.key.generation)
+		key := lease.key.Load()
+		log := m.log.With("lease", key.name, "holder", lease.holder, "generation", key.generation)
 
 		select {
 		case <-lease.stop:


### PR DESCRIPTION
Fixes a race reading `lease.key` during `Release` (to annotate the tracing span) while the auto-renew loop could also be renewing that lease and setting a new generation on the same key.

`go test -race` now passes on the `lease` package.