### PR TITLE
chore(deps): replace `classnames` with `clsx`

### DIFF
--- a/package.json
+++ b/package.json
@@ -316,7 +316,7 @@
     "@welldone-software/why-did-you-render": "8.0.3",
     "ansicolor": "2.0.3",
     "centrifuge": "5.5.3",
-    "classnames": "2.5.1",
+    "clsx": "^2.1.1",
     "combokeys": "^3.0.0",
     "comlink": "4.4.2",
     "common-tags": "1.8.2",

--- a/packages/grafana-ui/package.json
+++ b/packages/grafana-ui/package.json
@@ -95,7 +95,6 @@
     "@uiw/codemirror-theme-vscode": "^4.25.9",
     "@uiw/react-codemirror": "^4.25.9",
     "calculate-size": "^1.1.1",
-    "classnames": "^2.5.1",
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "downshift": "^9.0.6",

--- a/packages/grafana-ui/src/components/FormLabel/FormLabel.tsx
+++ b/packages/grafana-ui/src/components/FormLabel/FormLabel.tsx
@@ -1,4 +1,4 @@
-import classNames from 'classnames';
+import classNames from 'clsx';
 import { type ReactNode } from 'react';
 
 import { Icon } from '../Icon/Icon';

--- a/packages/grafana-ui/src/components/Forms/Legacy/Input/Input.tsx
+++ b/packages/grafana-ui/src/components/Forms/Legacy/Input/Input.tsx
@@ -1,4 +1,4 @@
-import classNames from 'classnames';
+import classNames from 'clsx';
 import { PureComponent, ChangeEvent } from 'react';
 import * as React from 'react';
 

--- a/packages/grafana-ui/src/components/Forms/Legacy/Select/Select.tsx
+++ b/packages/grafana-ui/src/components/Forms/Legacy/Select/Select.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import classNames from 'classnames';
+import classNames from 'clsx';
 import { PureComponent } from 'react';
 import * as React from 'react';
 import { default as ReactSelect, components, MenuListProps } from 'react-select';

--- a/packages/grafana-ui/src/components/QueryField/QueryField.tsx
+++ b/packages/grafana-ui/src/components/QueryField/QueryField.tsx
@@ -1,5 +1,5 @@
 import { css, cx } from '@emotion/css';
-import classnames from 'classnames';
+import classnames from 'clsx';
 import { debounce } from 'lodash';
 import { PureComponent } from 'react';
 import * as React from 'react';

--- a/packages/grafana-ui/src/components/ThemeDemos/EmotionPerfTest.tsx
+++ b/packages/grafana-ui/src/components/ThemeDemos/EmotionPerfTest.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable @grafana/i18n/no-untranslated-strings */
 /** @jsxImportSource @emotion/react */
 import { css, cx } from '@emotion/css';
-import classnames from 'classnames';
+import classnames from 'clsx';
 import React, { Profiler, type ProfilerOnRenderCallback, useState, type FC } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';

--- a/public/app/core/components/AppChrome/AppChrome.tsx
+++ b/public/app/core/components/AppChrome/AppChrome.tsx
@@ -1,6 +1,6 @@
 import { css, cx } from '@emotion/css';
 import { useBooleanFlagValue } from '@openfeature/react-sdk';
-import classNames from 'classnames';
+import classNames from 'clsx';
 import { Resizable } from 're-resizable';
 import { type PropsWithChildren, useEffect } from 'react';
 

--- a/public/app/features/alerting/unified/components/HoverCard.tsx
+++ b/public/app/features/alerting/unified/components/HoverCard.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { type Placement } from '@popperjs/core';
-import classnames from 'classnames';
+import classnames from 'clsx';
 import { type ReactElement, type ReactNode, cloneElement, useRef } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';

--- a/public/app/features/dashboard-scene/scene/PanelSearchLayout.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelSearchLayout.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import classNames from 'classnames';
+import classNames from 'clsx';
 import { useMemo } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';

--- a/public/app/features/dashboard-scene/settings/ProvisionedControlsSection.tsx
+++ b/public/app/features/dashboard-scene/settings/ProvisionedControlsSection.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import classNames from 'classnames';
+import classNames from 'clsx';
 import { type ReactNode, useMemo, useState } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';

--- a/public/app/features/dashboard-scene/settings/variables/VariableEditorList.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/VariableEditorList.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/css';
 import { DragDropContext, Droppable, type DropResult } from '@hello-pangea/dnd';
-import classNames from 'classnames';
+import classNames from 'clsx';
 import { type ReactElement } from 'react';
 
 import { selectors } from '@grafana/e2e-selectors';

--- a/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/ModalAlerts/UnsupportedDataSourcesAlert.tsx
+++ b/public/app/features/dashboard/components/ShareModal/SharePublicDashboard/ModalAlerts/UnsupportedDataSourcesAlert.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import cx from 'classnames';
+import cx from 'clsx';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { selectors as e2eSelectors } from '@grafana/e2e-selectors';

--- a/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/Scrubber.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/Scrubber.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { css } from '@emotion/css';
-import cx from 'classnames';
+import cx from 'clsx';
 import * as React from 'react';
 
 import { useStyles2 } from '@grafana/ui';

--- a/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/ViewingLayer.tsx
+++ b/public/app/features/explore/TraceView/components/TracePageHeader/SpanGraph/ViewingLayer.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { css } from '@emotion/css';
-import cx from 'classnames';
+import cx from 'clsx';
 import * as React from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanBar.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanBar.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { css } from '@emotion/css';
-import cx from 'classnames';
+import cx from 'clsx';
 import { groupBy as _groupBy } from 'lodash';
 import { useState } from 'react';
 import * as React from 'react';

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanBarRow.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanBarRow.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { css, keyframes } from '@emotion/css';
-import cx from 'classnames';
+import cx from 'clsx';
 import * as React from 'react';
 
 import { type GrafanaTheme2, type TraceKeyValuePair } from '@grafana/data';

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/AccordianKeyValues.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/AccordianKeyValues.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { css } from '@emotion/css';
-import cx from 'classnames';
+import cx from 'clsx';
 import * as React from 'react';
 
 import { type GrafanaTheme2, type TraceKeyValuePair } from '@grafana/data';

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/KeyValuesTable.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { css } from '@emotion/css';
-import cx from 'classnames';
+import cx from 'clsx';
 import DOMPurify from 'dompurify';
 import { type PropsWithChildren } from 'react';
 

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/TextList.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanDetail/TextList.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { css } from '@emotion/css';
-import cx from 'classnames';
+import cx from 'clsx';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { useStyles2 } from '@grafana/ui';

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanTreeOffset.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/SpanTreeOffset.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { css } from '@emotion/css';
-import cx from 'classnames';
+import cx from 'clsx';
 import { get as _get } from 'lodash';
 import * as React from 'react';
 

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/Ticks.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/Ticks.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { css } from '@emotion/css';
-import cx from 'classnames';
+import cx from 'clsx';
 import * as React from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/TimelineHeaderRow/TimelineColumnResizer.test.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/TimelineHeaderRow/TimelineColumnResizer.test.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { fireEvent, render, screen } from '@testing-library/react';
-import cx from 'classnames';
+import cx from 'clsx';
 
 import TimelineColumnResizer, { getStyles, type TimelineColumnResizerProps } from './TimelineColumnResizer';
 

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/TimelineHeaderRow/TimelineColumnResizer.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/TimelineHeaderRow/TimelineColumnResizer.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { css } from '@emotion/css';
-import cx from 'classnames';
+import cx from 'clsx';
 import * as React from 'react';
 
 import type TNil from '../../types/TNil';

--- a/public/app/features/explore/TraceView/components/TraceTimelineViewer/TimelineRow.tsx
+++ b/public/app/features/explore/TraceView/components/TraceTimelineViewer/TimelineRow.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { css } from '@emotion/css';
-import cx from 'classnames';
+import cx from 'clsx';
 import * as React from 'react';
 
 import { useStyles2 } from '@grafana/ui';

--- a/public/app/features/explore/TraceView/components/common/CopyIcon.tsx
+++ b/public/app/features/explore/TraceView/components/common/CopyIcon.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { css } from '@emotion/css';
-import cx from 'classnames';
+import cx from 'clsx';
 import { useState } from 'react';
 
 import { t } from '@grafana/i18n';

--- a/public/app/features/explore/TraceView/components/common/LabeledList.tsx
+++ b/public/app/features/explore/TraceView/components/common/LabeledList.tsx
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 import { css } from '@emotion/css';
-import cx from 'classnames';
+import cx from 'clsx';
 import * as React from 'react';
 
 import { type GrafanaTheme2, type IconName } from '@grafana/data';

--- a/public/app/features/query/components/QueryEditorRow.tsx
+++ b/public/app/features/query/components/QueryEditorRow.tsx
@@ -1,4 +1,4 @@
-import classNames from 'classnames';
+import classNames from 'clsx';
 import { cloneDeep, filter, uniqBy, uniqueId } from 'lodash';
 import pluralize from 'pluralize';
 import { PureComponent, type ReactNode, type JSX, createRef } from 'react';

--- a/public/app/plugins/panel/nodeGraph/Node.tsx
+++ b/public/app/plugins/panel/nodeGraph/Node.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import cx from 'classnames';
+import cx from 'clsx';
 import { type MouseEvent, memo } from 'react';
 import tinycolor from 'tinycolor2';
 

--- a/public/app/plugins/panel/nodeGraph/NodeGraph.tsx
+++ b/public/app/plugins/panel/nodeGraph/NodeGraph.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import cx from 'classnames';
+import cx from 'clsx';
 import { memo, type MouseEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import useMeasure from 'react-use/lib/useMeasure';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2974,7 +2974,6 @@ __metadata:
     "@uiw/react-codemirror": "npm:^4.25.9"
     calculate-size: "npm:^1.1.1"
     chance: "npm:^1.1.13"
-    classnames: "npm:^2.5.1"
     clsx: "npm:^2.1.1"
     common-tags: "npm:1.8.2"
     css-loader: "npm:7.1.2"
@@ -13246,7 +13245,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"classnames@npm:2.5.1, classnames@npm:^2.3.1, classnames@npm:^2.3.2, classnames@npm:^2.5.1":
+"classnames@npm:^2.3.1, classnames@npm:^2.3.2, classnames@npm:^2.5.1":
   version: 2.5.1
   resolution: "classnames@npm:2.5.1"
   checksum: 10/58eb394e8817021b153bb6e7d782cfb667e4ab390cb2e9dac2fc7c6b979d1cc2b2a733093955fc5c94aa79ef5c8c89f11ab77780894509be6afbb91dddd79d15
@@ -18457,7 +18456,7 @@ __metadata:
     browserslist: "npm:^4.21.4"
     centrifuge: "npm:5.5.3"
     chance: "npm:^1.1.13"
-    classnames: "npm:2.5.1"
+    clsx: "npm:^2.1.1"
     combokeys: "npm:^3.0.0"
     comlink: "npm:4.4.2"
     common-tags: "npm:1.8.2"


### PR DESCRIPTION
**What is this feature?**

Replace all `classnames` imports with `clsx` across 31 files and remove the `classnames` dependency.

**Why do we need this feature?**

`clsx` is already a dependency of `@grafana/ui` and serves the same purpose as `classnames`. Having both is redundant. `clsx` is smaller (330B vs 729B min+gzip) and already established in the codebase. No `.bind()` usage exists, so the swap
  is drop-in — only the import specifier changes, local aliases (`cx`, `classNames`, `classnames`) are preserved.

**Who is this feature for?**

Grafana developers - reduces dependency surface and aligns on a single class-string utility.

**Special notes for your reviewer:**

- 31 files changed: `from 'classnames'` → `from 'clsx'`, no call-site changes
- `classnames` removed from root and `@grafana/ui` `package.json`
- `clsx` added to root `package.json` (already present in `@grafana/ui`)
- Enterprise repo has zero `classnames` imports - no matching branch needed

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.