### PR TITLE
i18n: move plural defaults of t() calls into options object

### DIFF
--- a/packages/grafana-data/src/datetime/rangeutil.ts
+++ b/packages/grafana-data/src/datetime/rangeutil.ts
@@ -31,72 +31,82 @@ const spans: { [key: string]: { display: string; section?: number } } = {
 };
 
 const getLastNMinutesDisplay = (count: number) => {
-  return t('grafana-data.datetime.rangeutils.lastNMinutes', 'Last {{count}} minutes', {
+  return t('grafana-data.datetime.rangeutils.lastNMinutes', '', {
     count,
     defaultValue_one: 'Last {{count}} minute',
+    defaultValue_other: 'Last {{count}} minutes',
   });
 };
 
 const getLastNHoursDisplay = (count: number) => {
-  return t('grafana-data.datetime.rangeutils.lastNHours', 'Last {{count}} hours', {
+  return t('grafana-data.datetime.rangeutils.lastNHours', '', {
     count,
     defaultValue_one: 'Last {{count}} hour',
+    defaultValue_other: 'Last {{count}} hours',
   });
 };
 
 const getLastNDaysDisplay = (count: number) => {
-  return t('grafana-data.datetime.rangeutils.lastNDays', 'Last {{count}} days', {
+  return t('grafana-data.datetime.rangeutils.lastNDays', '', {
     count,
     defaultValue_one: 'Last {{count}} day',
+    defaultValue_other: 'Last {{count}} days',
   });
 };
 
 const getLastNMonthsDisplay = (count: number) => {
-  return t('grafana-data.datetime.rangeutils.lastNMonths', 'Last {{count}} months', {
+  return t('grafana-data.datetime.rangeutils.lastNMonths', '', {
     count,
     defaultValue_one: 'Last {{count}} month',
+    defaultValue_other: 'Last {{count}} months',
   });
 };
 
 const getLastNYearsDisplay = (count: number) => {
-  return t('grafana-data.datetime.rangeutils.lastNYears', 'Last {{count}} years', {
+  return t('grafana-data.datetime.rangeutils.lastNYears', '', {
     count,
     defaultValue_one: 'Last {{count}} year',
+    defaultValue_other: 'Last {{count}} years',
   });
 };
 
 const getNextNMinutesDisplay = (count: number) => {
-  return t('grafana-data.datetime.rangeutils.nextNMinutes', 'Next {{count}} minutes', {
+  return t('grafana-data.datetime.rangeutils.nextNMinutes', '', {
     count,
     defaultValue_one: 'Next {{count}} minute',
+    defaultValue_other: 'Next {{count}} minutes',
   });
 };
 
 const getNextNHoursDisplay = (count: number) => {
-  return t('grafana-data.datetime.rangeutils.nextNHours', 'Next {{count}} hours', {
+  return t('grafana-data.datetime.rangeutils.nextNHours', '', {
     count,
     defaultValue_one: 'Next {{count}} hour',
+    defaultValue_other: 'Next {{count}} hours',
   });
 };
 
 const getNextNDaysDisplay = (count: number) => {
-  return t('grafana-data.datetime.rangeutils.nextNDays', 'Next {{count}} days', {
+  return t('grafana-data.datetime.rangeutils.nextNDays', '', {
     count,
     defaultValue_one: 'Next {{count}} day',
+    defaultValue_other: 'Next {{count}} days',
   });
 };
 
 const getNextNMonthsDisplay = (count: number) => {
-  return t('grafana-data.datetime.rangeutils.nextNMonths', 'Next {{count}} months', {
+  return t('grafana-data.datetime.rangeutils.nextNMonths', '', {
     count,
     defaultValue_one: 'Next {{count}} month',
+    defaultValue_other: 'Next {{count}} months',
   });
 };
 
 const getNextNYearsDisplay = (count: number) => {
-  return t('grafana-data.datetime.rangeutils.nextNYears', 'Next {{count}} years', {
+  return t('grafana-data.datetime.rangeutils.nextNYears', '', {
     count,
     defaultValue_one: 'Next {{count}} year',
+    defaultValue_other: 'Next {{count}} years',
   });
 };
 

--- a/public/app/features/alerting/unified/components/contact-points/ContactPointHeader.tsx
+++ b/public/app/features/alerting/unified/components/contact-points/ContactPointHeader.tsx
@@ -173,12 +173,16 @@ export const ContactPointHeader = ({ contactPoint, onDelete }: ContactPointHeade
     );
   }
 
-  const referencedByPoliciesText = t('alerting.contact-points.used-by', 'Used by {{count}} notification policies', {
+  const referencedByPoliciesText = t('alerting.contact-points.used-by', '', {
     count: numberOfPolicies,
+    defaultValue_one: 'Used by {{count}} notification policies',
+    defaultValue_other: 'Used by {{count}} notification policies',
   });
 
-  const referencedByRulesText = t('alerting.contact-points.used-by-rules', 'Used by {{count}} alert rules', {
+  const referencedByRulesText = t('alerting.contact-points.used-by-rules', '', {
     count: numberOfRules,
+    defaultValue_one: 'Used by {{count}} alert rules',
+    defaultValue_other: 'Used by {{count}} alert rules',
   });
 
   // TOOD: Tidy up/consolidate logic for working out id for contact point. This requires some unravelling of

--- a/public/app/features/alerting/unified/components/import-to-gma/CollapsibleRenameList.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/CollapsibleRenameList.tsx
@@ -69,14 +69,18 @@ export function RenamedResourcesList({ renamedReceivers, renamedTimeIntervals }:
   return (
     <Stack direction="column" gap={1}>
       <CollapsibleRenameList
-        label={t('alerting.import-to-gma.renamed-receivers', '{{count}} contact points will be renamed', {
+        label={t('alerting.import-to-gma.renamed-receivers', '', {
           count: renamedReceivers.length,
+          defaultValue_one: '{{count}} contact points will be renamed',
+          defaultValue_other: '{{count}} contact points will be renamed',
         })}
         items={renamedReceivers}
       />
       <CollapsibleRenameList
-        label={t('alerting.import-to-gma.renamed-intervals', '{{count}} time intervals will be renamed', {
+        label={t('alerting.import-to-gma.renamed-intervals', '', {
           count: renamedTimeIntervals.length,
+          defaultValue_one: '{{count}} time intervals will be renamed',
+          defaultValue_other: '{{count}} time intervals will be renamed',
         })}
         items={renamedTimeIntervals}
       />

--- a/public/app/features/alerting/unified/components/import-to-gma/ImportToGMA.tsx
+++ b/public/app/features/alerting/unified/components/import-to-gma/ImportToGMA.tsx
@@ -760,8 +760,10 @@ function ReviewStep({ formData, onStartImport, onCancel, dryRunResult, rulesFrom
               {willImportRules && (
                 <button type="button" className={styles.badgeWithIcon} onClick={handlePreviewRules}>
                   {rulesCount > 0
-                    ? t('alerting.import-to-gma.review.will-import-rules-count', 'Will import {{count}} rules', {
+                    ? t('alerting.import-to-gma.review.will-import-rules-count', '', {
                         count: rulesCount,
+                        defaultValue_one: 'Will import {{count}} rules',
+                        defaultValue_other: 'Will import {{count}} rules',
                       })
                     : t('alerting.import-to-gma.review.will-import-rules', 'Will import rules')}
                   <Icon name="eye" size="sm" />

--- a/public/app/features/alerting/unified/components/notification-policies/AlertGroupsSummary.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/AlertGroupsSummary.tsx
@@ -20,7 +20,11 @@ export const AlertGroupsSummary = ({ active = 0, suppressed = 0, unprocessed = 0
       <Badge
         color="red"
         key="firing"
-        text={t('alerting.alert-groups-summary.text-firing', '{{count}} firing', { count: active })}
+        text={t('alerting.alert-groups-summary.text-firing', '', {
+          count: active,
+          defaultValue_one: '{{count}} firing',
+          defaultValue_other: '{{count}} firing',
+        })}
       />
     );
   }
@@ -30,7 +34,11 @@ export const AlertGroupsSummary = ({ active = 0, suppressed = 0, unprocessed = 0
       <Badge
         color="blue"
         key="suppressed"
-        text={t('alerting.alert-groups-summary.text-suppressed', '{{count}} suppressed', { count: suppressed })}
+        text={t('alerting.alert-groups-summary.text-suppressed', '', {
+          count: suppressed,
+          defaultValue_one: '{{count}} suppressed',
+          defaultValue_other: '{{count}} suppressed',
+        })}
       />
     );
   }
@@ -40,7 +48,11 @@ export const AlertGroupsSummary = ({ active = 0, suppressed = 0, unprocessed = 0
       <Badge
         color="orange"
         key="unprocessed"
-        text={t('alerting.alert-groups-summary.text-unprocessed', '{{count}} unprocessed', { count: unprocessed })}
+        text={t('alerting.alert-groups-summary.text-unprocessed', '', {
+          count: unprocessed,
+          defaultValue_one: '{{count}} unprocessed',
+          defaultValue_other: '{{count}} unprocessed',
+        })}
       />
     );
   }

--- a/public/app/features/alerting/unified/components/rules/CloudRules.tsx
+++ b/public/app/features/alerting/unified/components/rules/CloudRules.tsx
@@ -67,8 +67,10 @@ export const CloudRules = ({ namespaces, expandAll }: Props) => {
             {dataSourcesLoading.length ? (
               <LoadingPlaceholder
                 className={styles.loader}
-                text={t('alerting.list-view.section.loading-rules', 'Loading rules from {{count}} sources', {
+                text={t('alerting.list-view.section.loading-rules', '', {
                   count: dataSourcesLoading.length,
+                  defaultValue_one: 'Loading rules from {{count}} sources',
+                  defaultValue_other: 'Loading rules from {{count}} sources',
                 })}
               />
             ) : (

--- a/public/app/features/alerting/unified/components/rules/RuleStats.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleStats.tsx
@@ -128,7 +128,11 @@ export function getComponentsFromStats(
       <Badge
         color="red"
         key="errors"
-        text={t('alerting.rule-stats.error', `{{count}} errors`, { count: stats.error })}
+        text={t('alerting.rule-stats.error', '', {
+          count: stats.error,
+          defaultValue_one: '{{count}} errors',
+          defaultValue_other: '{{count}} errors',
+        })}
       />
     );
   }

--- a/public/app/features/alerting/unified/notifications/NotificationDetailHeader.tsx
+++ b/public/app/features/alerting/unified/notifications/NotificationDetailHeader.tsx
@@ -29,8 +29,10 @@ export function NotificationHeader({ notification }: NotificationHeaderProps) {
           ·
         </Text>
         <Text variant="bodySmall" color="secondary">
-          {t('alerting.notification-detail.alert-count-inline', '{{count}} alert(s)', {
+          {t('alerting.notification-detail.alert-count-inline', '', {
             count: notification.alertCount,
+            defaultValue_one: '{{count}} alert(s)',
+            defaultValue_other: '{{count}} alert(s)',
           })}
         </Text>
       </Stack>

--- a/public/app/features/alerting/unified/notifications/RelatedNotificationsSidebar.tsx
+++ b/public/app/features/alerting/unified/notifications/RelatedNotificationsSidebar.tsx
@@ -109,16 +109,20 @@ export function RelatedNotificationsSidebar({
               <Text variant="bodySmall" color="secondary">
                 {batch.notifications.length === 1
                   ? t('alerting.notification-detail.batch-count-one', '1 delivery')
-                  : t('alerting.notification-detail.batch-count-many', '{{count}} deliveries', {
+                  : t('alerting.notification-detail.batch-count-many', '', {
                       count: batch.notifications.length,
+                      defaultValue_one: '{{count}} deliveries',
+                      defaultValue_other: '{{count}} deliveries',
                     })}
               </Text>
               {batch.failedCount > 0 ? (
                 <Stack direction="row" gap={0.5} alignItems="center">
                   <Icon name="exclamation-circle" size="sm" className={styles.errorIcon} />
                   <Text variant="bodySmall" color="error">
-                    {t('alerting.notification-detail.batch-failed', '{{count}} failed', {
+                    {t('alerting.notification-detail.batch-failed', '', {
                       count: batch.failedCount,
+                      defaultValue_one: '{{count}} failed',
+                      defaultValue_other: '{{count}} failed',
                     })}
                   </Text>
                 </Stack>

--- a/public/app/features/alerting/unified/triage/instance-details/InstanceTimeline.tsx
+++ b/public/app/features/alerting/unified/triage/instance-details/InstanceTimeline.tsx
@@ -309,8 +309,10 @@ function NotificationStatusGroup({
   const receiverLabel =
     uniqueReceivers.length === 1
       ? uniqueReceivers[0]
-      : t('alerting.instance-details.timeline-n-uniqueReceivers', '{{count}} uniqueReceivers', {
+      : t('alerting.instance-details.timeline-n-uniqueReceivers', '', {
           count: uniqueReceivers.length,
+          defaultValue_one: '{{count}} uniqueReceivers',
+          defaultValue_other: '{{count}} uniqueReceivers',
         });
 
   let deliveryLabel: string | undefined;

--- a/public/app/features/browse-dashboards/components/BrowseActions/utils.test.ts
+++ b/public/app/features/browse-dashboards/components/BrowseActions/utils.test.ts
@@ -2,19 +2,17 @@ import { buildBreakdownString } from './utils';
 
 describe('browse-dashboards utils', () => {
   describe('buildBreakdownString', () => {
-    // note: pluralisation is handled as part of the i18n framework
-    // in tests, only the fallback singular message is used
     it.each`
       folderCount | dashboardCount | libraryPanelCount | alertRuleCount | expected
-      ${0}        | ${0}           | ${0}              | ${0}           | ${'0 item'}
+      ${0}        | ${0}           | ${0}              | ${0}           | ${'0 items'}
       ${1}        | ${0}           | ${0}              | ${0}           | ${'1 item: 1 folder'}
-      ${2}        | ${0}           | ${0}              | ${0}           | ${'2 item: 2 folder'}
+      ${2}        | ${0}           | ${0}              | ${0}           | ${'2 items: 2 folders'}
       ${0}        | ${1}           | ${0}              | ${0}           | ${'1 item: 1 dashboard'}
-      ${0}        | ${2}           | ${0}              | ${0}           | ${'2 item: 2 dashboard'}
-      ${1}        | ${0}           | ${1}              | ${1}           | ${'3 item: 1 folder, 1 library panel, 1 alert rule'}
-      ${2}        | ${0}           | ${3}              | ${4}           | ${'9 item: 2 folder, 3 library panel, 4 alert rule'}
-      ${1}        | ${1}           | ${1}              | ${1}           | ${'4 item: 1 folder, 1 dashboard, 1 library panel, 1 alert rule'}
-      ${1}        | ${2}           | ${3}              | ${4}           | ${'10 item: 1 folder, 2 dashboard, 3 library panel, 4 alert rule'}
+      ${0}        | ${2}           | ${0}              | ${0}           | ${'2 items: 2 dashboards'}
+      ${1}        | ${0}           | ${1}              | ${1}           | ${'3 items: 1 folder, 1 library panel, 1 alert rule'}
+      ${2}        | ${0}           | ${3}              | ${4}           | ${'9 items: 2 folders, 3 library panels, 4 alert rules'}
+      ${1}        | ${1}           | ${1}              | ${1}           | ${'4 items: 1 folder, 1 dashboard, 1 library panel, 1 alert rule'}
+      ${1}        | ${2}           | ${3}              | ${4}           | ${'10 items: 1 folder, 2 dashboards, 3 library panels, 4 alert rules'}
     `(
       'returns the correct message for the various inputs',
       ({ folderCount, dashboardCount, libraryPanelCount, alertRuleCount, expected }) => {

--- a/public/app/features/browse-dashboards/components/BrowseActions/utils.ts
+++ b/public/app/features/browse-dashboards/components/BrowseActions/utils.ts
@@ -9,18 +9,46 @@ export function buildBreakdownString(
   const total = folderCount + dashboardCount + libraryPanelCount + alertRuleCount;
   const parts = [];
   if (folderCount) {
-    parts.push(t('browse-dashboards.counts.folder', '{{count}} folder', { count: folderCount }));
+    parts.push(
+      t('browse-dashboards.counts.folder', '', {
+        count: folderCount,
+        defaultValue_one: '{{count}} folder',
+        defaultValue_other: '{{count}} folders',
+      })
+    );
   }
   if (dashboardCount) {
-    parts.push(t('browse-dashboards.counts.dashboard', '{{count}} dashboard', { count: dashboardCount }));
+    parts.push(
+      t('browse-dashboards.counts.dashboard', '', {
+        count: dashboardCount,
+        defaultValue_one: '{{count}} dashboard',
+        defaultValue_other: '{{count}} dashboards',
+      })
+    );
   }
   if (libraryPanelCount) {
-    parts.push(t('browse-dashboards.counts.libraryPanel', '{{count}} library panel', { count: libraryPanelCount }));
+    parts.push(
+      t('browse-dashboards.counts.libraryPanel', '', {
+        count: libraryPanelCount,
+        defaultValue_one: '{{count}} library panel',
+        defaultValue_other: '{{count}} library panels',
+      })
+    );
   }
   if (alertRuleCount) {
-    parts.push(t('browse-dashboards.counts.alertRule', '{{count}} alert rule', { count: alertRuleCount }));
+    parts.push(
+      t('browse-dashboards.counts.alertRule', '', {
+        count: alertRuleCount,
+        defaultValue_one: '{{count}} alert rule',
+        defaultValue_other: '{{count}} alert rules',
+      })
+    );
   }
-  let breakdownString = t('browse-dashboards.counts.total', '{{count}} item', { count: total });
+  let breakdownString = t('browse-dashboards.counts.total', '', {
+    count: total,
+    defaultValue_one: '{{count}} item',
+    defaultValue_other: '{{count}} items',
+  });
   if (parts.length > 0) {
     breakdownString += `: ${parts.join(', ')}`;
   }

--- a/public/app/features/browse-dashboards/utils/notifications.ts
+++ b/public/app/features/browse-dashboards/utils/notifications.ts
@@ -46,8 +46,10 @@ export function getRestoreNotificationData(
   }
 
   // Generate count-aware success message (reused in multiple cases)
-  const successMessage = t('browse-dashboards.restore.success-count', '{{count}} dashboard restored successfully', {
+  const successMessage = t('browse-dashboards.restore.success-count', '', {
     count: successCount,
+    defaultValue_one: '{{count}} dashboard restored successfully',
+    defaultValue_other: '{{count}} dashboard restored successfully',
   });
 
   // Helper to append first error message if present
@@ -62,8 +64,10 @@ export function getRestoreNotificationData(
 
   // Partial success case
   if (successCount > 0) {
-    const failedMessage = t('browse-dashboards.restore.failed-count', '{{count}} dashboard failed', {
+    const failedMessage = t('browse-dashboards.restore.failed-count', '', {
       count: failedCount,
+      defaultValue_one: '{{count}} dashboard failed',
+      defaultValue_other: '{{count}} dashboard failed',
     });
     return {
       kind: 'event',
@@ -80,8 +84,10 @@ export function getRestoreNotificationData(
     data: {
       alertType: AppEvents.alertError.name,
       message: appendError(
-        t('browse-dashboards.restore.all-failed', 'Failed to restore {{count}} dashboard.', {
+        t('browse-dashboards.restore.all-failed', '', {
           count: failedCount,
+          defaultValue_one: 'Failed to restore {{count}} dashboard.',
+          defaultValue_other: 'Failed to restore {{count}} dashboard.',
         })
       ),
     },

--- a/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardAnnotationsList.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardAnnotationsList.tsx
@@ -101,32 +101,32 @@ export function DashboardAnnotationsList({ dataLayerSet }: { dataLayerSet: Dashb
         <DraggableList
           items={visible}
           droppableId={ID_VISIBLE_LIST}
-          title={t(
-            'dashboard-scene.dashboard-annotations-list.title-above-dashboard-count',
-            'Above dashboard ({{count}})',
-            { count: visible.length }
-          )}
+          title={t('dashboard-scene.dashboard-annotations-list.title-above-dashboard-count', '', {
+            count: visible.length,
+            defaultValue_one: 'Above dashboard ({{count}})',
+            defaultValue_other: 'Above dashboard ({{count}})',
+          })}
           onClickItem={onClickAnnotation}
           renderItemLabel={renderItemLabel}
         />
         <DraggableList
           items={controlsMenu}
           droppableId={ID_CONTROLS_MENU_LIST}
-          title={t(
-            'dashboard-scene.dashboard-annotations-list.title-controls-menu-count',
-            'Controls menu ({{count}})',
-            {
-              count: controlsMenu.length,
-            }
-          )}
+          title={t('dashboard-scene.dashboard-annotations-list.title-controls-menu-count', '', {
+            count: controlsMenu.length,
+            defaultValue_one: 'Controls menu ({{count}})',
+            defaultValue_other: 'Controls menu ({{count}})',
+          })}
           onClickItem={onClickAnnotation}
           renderItemLabel={renderItemLabel}
         />
         <DraggableList
           items={hidden}
           droppableId={ID_HIDDEN_LIST}
-          title={t('dashboard-scene.dashboard-annotations-list.title-hidden-count', 'Hidden ({{count}})', {
+          title={t('dashboard-scene.dashboard-annotations-list.title-hidden-count', '', {
             count: hidden.length,
+            defaultValue_one: 'Hidden ({{count}})',
+            defaultValue_other: 'Hidden ({{count}})',
           })}
           onClickItem={onClickAnnotation}
           renderItemLabel={renderItemLabel}

--- a/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardFiltersList.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardFiltersList.tsx
@@ -58,8 +58,10 @@ export function DashboardFiltersList({ variableSet }: { variableSet: SceneVariab
       <DraggableList
         items={visible}
         droppableId={ID_FILTERS_VISIBLE_LIST}
-        title={t('dashboard-scene.filters-list.title-above-dashboard', 'Above dashboard ({{count}})', {
+        title={t('dashboard-scene.filters-list.title-above-dashboard', '', {
           count: visible.length,
+          defaultValue_one: 'Above dashboard ({{count}})',
+          defaultValue_other: 'Above dashboard ({{count}})',
         })}
         onClickItem={onClickFilter}
         renderItemLabel={renderItemLabel}
@@ -67,8 +69,10 @@ export function DashboardFiltersList({ variableSet }: { variableSet: SceneVariab
       <DraggableList
         items={controlsMenu}
         droppableId={ID_FILTERS_CONTROLS_MENU_LIST}
-        title={t('dashboard-scene.filters-list.title-controls-menu', 'Controls menu ({{count}})', {
+        title={t('dashboard-scene.filters-list.title-controls-menu', '', {
           count: controlsMenu.length,
+          defaultValue_one: 'Controls menu ({{count}})',
+          defaultValue_other: 'Controls menu ({{count}})',
         })}
         onClickItem={onClickFilter}
         renderItemLabel={renderItemLabel}
@@ -76,7 +80,11 @@ export function DashboardFiltersList({ variableSet }: { variableSet: SceneVariab
       <DraggableList
         items={hidden}
         droppableId={ID_FILTERS_HIDDEN_LIST}
-        title={t('dashboard-scene.filters-list.title-hidden', 'Hidden ({{count}})', { count: hidden.length })}
+        title={t('dashboard-scene.filters-list.title-hidden', '', {
+          count: hidden.length,
+          defaultValue_one: 'Hidden ({{count}})',
+          defaultValue_other: 'Hidden ({{count}})',
+        })}
         onClickItem={onClickFilter}
         renderItemLabel={renderItemLabel}
       />

--- a/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardLinksList.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardLinksList.tsx
@@ -82,8 +82,10 @@ export function DashboardLinksList({ dashboard }: { dashboard: DashboardScene })
       <DraggableList
         items={visible}
         droppableId={ID_VISIBLE_LIST}
-        title={t('dashboard-scene.links-list.title-above-dashboard', 'Above dashboard ({{count}})', {
+        title={t('dashboard-scene.links-list.title-above-dashboard', '', {
           count: visible.length,
+          defaultValue_one: 'Above dashboard ({{count}})',
+          defaultValue_other: 'Above dashboard ({{count}})',
         })}
         onClickItem={onClickLink}
         renderItemLabel={renderItemLabel}
@@ -91,8 +93,10 @@ export function DashboardLinksList({ dashboard }: { dashboard: DashboardScene })
       <DraggableList
         items={controlsMenu}
         droppableId={ID_CONTROLS_MENU_LIST}
-        title={t('dashboard-scene.links-list.title-controls-menu', 'Controls menu ({{count}})', {
+        title={t('dashboard-scene.links-list.title-controls-menu', '', {
           count: controlsMenu.length,
+          defaultValue_one: 'Controls menu ({{count}})',
+          defaultValue_other: 'Controls menu ({{count}})',
         })}
         onClickItem={onClickLink}
         renderItemLabel={renderItemLabel}

--- a/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardVariablesList.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/dashboard/DashboardVariablesList.tsx
@@ -66,8 +66,10 @@ export function DashboardVariablesList({ variableSet }: { variableSet: SceneVari
       <DraggableList
         items={visible}
         droppableId={ID_VISIBLE_LIST}
-        title={t('dashboard-scene.variables-list.title-above-dashboard', 'Above dashboard ({{count}})', {
+        title={t('dashboard-scene.variables-list.title-above-dashboard', '', {
           count: visible.length,
+          defaultValue_one: 'Above dashboard ({{count}})',
+          defaultValue_other: 'Above dashboard ({{count}})',
         })}
         onClickItem={onClickVariable}
         renderItemLabel={renderItemLabel}
@@ -75,8 +77,10 @@ export function DashboardVariablesList({ variableSet }: { variableSet: SceneVari
       <DraggableList
         items={controlsMenu}
         droppableId={ID_CONTROLS_MENU_LIST}
-        title={t('dashboard-scene.variables-list.title-controls-menu', 'Controls menu ({{count}})', {
+        title={t('dashboard-scene.variables-list.title-controls-menu', '', {
           count: controlsMenu.length,
+          defaultValue_one: 'Controls menu ({{count}})',
+          defaultValue_other: 'Controls menu ({{count}})',
         })}
         onClickItem={onClickVariable}
         renderItemLabel={renderItemLabel}
@@ -84,7 +88,11 @@ export function DashboardVariablesList({ variableSet }: { variableSet: SceneVari
       <DraggableList
         items={hidden}
         droppableId={ID_HIDDEN_LIST}
-        title={t('dashboard-scene.variables-list.title-hidden', 'Hidden ({{count}})', { count: hidden.length })}
+        title={t('dashboard-scene.variables-list.title-hidden', '', {
+          count: hidden.length,
+          defaultValue_one: 'Hidden ({{count}})',
+          defaultValue_other: 'Hidden ({{count}})',
+        })}
         onClickItem={onClickVariable}
         renderItemLabel={renderItemLabel}
       />

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/BulkActionsBar.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/BulkActionsBar.tsx
@@ -127,8 +127,10 @@ function BulkQueryActions({ barWidth }: BulkQueryActionsProps) {
 
       <ConfirmModal
         isOpen={showDeleteConfirm}
-        title={t('query-editor-next.bulk-actions.delete-confirm-title', 'Delete {{count}} items?', {
+        title={t('query-editor-next.bulk-actions.delete-confirm-title', '', {
           count: selectedQueryRefIds.length,
+          defaultValue_one: 'Delete {{count}} item?',
+          defaultValue_other: 'Delete {{count}} items?',
         })}
         body={undefined}
         description={t('query-editor-next.bulk-actions.delete-confirm-body', 'This action cannot be undone.')}
@@ -185,11 +187,11 @@ function BulkTransformationActions({ barWidth }: BulkTransformationActionsProps)
 
       <ConfirmModal
         isOpen={showDeleteConfirm}
-        title={t(
-          'query-editor-next.bulk-actions.delete-transformations-confirm-title',
-          'Delete {{count}} transformations?',
-          { count: selectedTransformationIds.length }
-        )}
+        title={t('query-editor-next.bulk-actions.delete-transformations-confirm-title', '', {
+          count: selectedTransformationIds.length,
+          defaultValue_one: 'Delete {{count}} transformation?',
+          defaultValue_other: 'Delete {{count}} transformations?',
+        })}
         body={undefined}
         description={t('query-editor-next.bulk-actions.delete-confirm-body', 'This action cannot be undone.')}
         confirmText={t('query-editor-next.bulk-actions.delete', 'Delete')}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Footer/SidebarFooter.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Footer/SidebarFooter.tsx
@@ -32,8 +32,16 @@ export function SidebarFooter() {
   const visible = total - hidden;
 
   const suffixText = isAlertView
-    ? t('query-editor-next.sidebar.footer-items-alert', '{{count}} alerts', { count: total })
-    : t('query-editor-next.sidebar.footer-items', '{{count}} items', { count: total });
+    ? t('query-editor-next.sidebar.footer-items-alert', '', {
+        count: total,
+        defaultValue_one: '{{count}} alerts',
+        defaultValue_other: '{{count}} alerts',
+      })
+    : t('query-editor-next.sidebar.footer-items', '', {
+        count: total,
+        defaultValue_one: '{{count}} items',
+        defaultValue_other: '{{count}} items',
+      });
 
   // Render the bar OR the counts — never both. Keeping both in the DOM at
   // once would leave the obscured count Stack (incl. the Select… button) in

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Sidebar.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Sidebar/Sidebar.tsx
@@ -35,7 +35,11 @@ export const Sidebar = memo(function Sidebar({ sidebarSize, setSidebarSize }: Si
 
   const alertsLabel = loading
     ? t('query-editor-next.sidebar.alerts-loading', 'Alerts')
-    : t('query-editor-next.sidebar.alerts', 'Alerts ({{count}})', { count: alertRules.length });
+    : t('query-editor-next.sidebar.alerts', '', {
+        count: alertRules.length,
+        defaultValue_one: 'Alerts ({{count}})',
+        defaultValue_other: 'Alerts ({{count}})',
+      });
 
   const viewOptions: SegmentedToggleProps<QueryEditorType>['options'] = [
     { value: QueryEditorType.Query, label: t('query-editor-next.sidebar.data', 'Data'), icon: 'database' },

--- a/public/app/features/dashboard/components/PanelEditor/OptionsPaneOptions.tsx
+++ b/public/app/features/dashboard/components/PanelEditor/OptionsPaneOptions.tsx
@@ -145,9 +145,11 @@ export function renderSearchHits(
     <div key="search results">
       <OptionsPaneCategory
         id="Found options"
-        title={t('dashboard.options-pane-options.title-matched', 'Matched {{count}}/{{totalCount}} options', {
+        title={t('dashboard.options-pane-options.title-matched', '', {
           count: optionHits.length,
           totalCount,
+          defaultValue_one: 'Matched {{count}}/{{totalCount}} options',
+          defaultValue_other: 'Matched {{count}}/{{totalCount}} options',
         })}
         key="Normal options"
         forceOpen={true}

--- a/public/app/features/logs/utils.ts
+++ b/public/app/features/logs/utils.ts
@@ -438,11 +438,23 @@ function getDataSourceLabelType(labelType: string, datasourceType: string | unde
     case 'loki':
       switch (labelType) {
         case 'I':
-          return t('logs.fields.type.loki.indexed-label', 'Indexed labels', { count: plural ? 2 : 1 });
+          return t('logs.fields.type.loki.indexed-label', '', {
+            count: plural ? 2 : 1,
+            defaultValue_one: 'Indexed labels',
+            defaultValue_other: 'Indexed labels',
+          });
         case 'S':
-          return t('logs.fields.type.loki.structured-metadata', 'Structured metadata', { count: plural ? 2 : 1 });
+          return t('logs.fields.type.loki.structured-metadata', '', {
+            count: plural ? 2 : 1,
+            defaultValue_one: 'Structured metadata',
+            defaultValue_other: 'Structured metadata',
+          });
         case 'P':
-          return t('logs.fields.type.loki.parsedl-label', 'Parsed fields', { count: plural ? 2 : 1 });
+          return t('logs.fields.type.loki.parsedl-label', '', {
+            count: plural ? 2 : 1,
+            defaultValue_one: 'Parsed fields',
+            defaultValue_other: 'Parsed fields',
+          });
         default:
           return null;
       }

--- a/public/app/features/provisioning/Wizard/hooks/useResourceStats.ts
+++ b/public/app/features/provisioning/Wizard/hooks/useResourceStats.ts
@@ -45,11 +45,23 @@ function getResourceCount(stats?: ResourceCount[], managed?: ManagerStats[]) {
       case 'folders':
       case 'folder.grafana.app':
         resourceCount += stat.count;
-        counts.push(t('provisioning.bootstrap-step.folders-count', '{{count}} folder', { count: stat.count }));
+        counts.push(
+          t('provisioning.bootstrap-step.folders-count', '', {
+            count: stat.count,
+            defaultValue_one: '{{count}} folder',
+            defaultValue_other: '{{count}} folder',
+          })
+        );
         break;
       case 'dashboard.grafana.app':
         resourceCount += stat.count;
-        counts.push(t('provisioning.bootstrap-step.dashboards-count', '{{count}} dashboard', { count: stat.count }));
+        counts.push(
+          t('provisioning.bootstrap-step.dashboards-count', '', {
+            count: stat.count,
+            defaultValue_one: '{{count}} dashboard',
+            defaultValue_other: '{{count}} dashboard',
+          })
+        );
         break;
     }
   });
@@ -61,12 +73,22 @@ function getResourceCount(stats?: ResourceCount[], managed?: ManagerStats[]) {
           case 'folders':
           case 'folder.grafana.app':
             resourceCount += stat.count;
-            counts.push(t('provisioning.bootstrap-step.folders-count', '{{count}} folder', { count: stat.count }));
+            counts.push(
+              t('provisioning.bootstrap-step.folders-count', '', {
+                count: stat.count,
+                defaultValue_one: '{{count}} folder',
+                defaultValue_other: '{{count}} folder',
+              })
+            );
             break;
           case 'dashboard.grafana.app':
             resourceCount += stat.count;
             counts.push(
-              t('provisioning.bootstrap-step.dashboards-count', '{{count}} dashboard', { count: stat.count })
+              t('provisioning.bootstrap-step.dashboards-count', '', {
+                count: stat.count,
+                defaultValue_one: '{{count}} dashboard',
+                defaultValue_other: '{{count}} dashboard',
+              })
             );
             break;
         }
@@ -149,7 +171,11 @@ export function useResourceStats(
     resourceCount > 0 ? resourceCountString : t('provisioning.bootstrap-step.empty', 'Empty');
   const fileCountDisplay =
     fileCount > 0
-      ? t('provisioning.bootstrap-step.files-count', '{{count}} files', { count: fileCount })
+      ? t('provisioning.bootstrap-step.files-count', '', {
+          count: fileCount,
+          defaultValue_one: '{{count}} files',
+          defaultValue_other: '{{count}} files',
+        })
       : t('provisioning.bootstrap-step.empty', 'Empty');
 
   return {

--- a/public/app/features/provisioning/hooks/useConnectionOptions.ts
+++ b/public/app/features/provisioning/hooks/useConnectionOptions.ts
@@ -80,10 +80,12 @@ export function useConnectionOptions(enabled: boolean) {
         const remaining = repos.length - maxToShow;
         const repoText =
           remaining > 0
-            ? t('provisioning.connection-options.repos-truncated', '{{shown}} +{{count}} more', {
+            ? t('provisioning.connection-options.repos-truncated', '', {
                 shown,
                 count: remaining,
                 interpolation: { escapeValue: false },
+                defaultValue_one: '{{shown}} +{{count}} more',
+                defaultValue_other: '{{shown}} +{{count}} more',
               })
             : shown;
         descriptionParts.push(repoText);

--- a/public/app/features/serviceaccounts/ServiceAccountsListPage.tsx
+++ b/public/app/features/serviceaccounts/ServiceAccountsListPage.tsx
@@ -271,14 +271,14 @@ export const ServiceAccountsListPageUnconnected = ({
               isOpen={isRemoveModalOpen}
               body={
                 !!currentServiceAccount.tokens
-                  ? t(
-                      'serviceaccounts.service-accounts-list-page-unconnected.body-delete',
-                      'Are you sure you want to delete {{serviceAccountName}} and {{count}} accompanying tokens?',
-                      {
-                        serviceAccountName: currentServiceAccount.name,
-                        count: currentServiceAccount.tokens,
-                      }
-                    )
+                  ? t('serviceaccounts.service-accounts-list-page-unconnected.body-delete', '', {
+                      serviceAccountName: currentServiceAccount.name,
+                      count: currentServiceAccount.tokens,
+                      defaultValue_one:
+                        'Are you sure you want to delete {{serviceAccountName}} and {{count}} accompanying tokens?',
+                      defaultValue_other:
+                        'Are you sure you want to delete {{serviceAccountName}} and {{count}} accompanying tokens?',
+                    })
                   : t(
                       'serviceaccounts.service-accounts-list-page-unconnected.body-delete-with-tokens',
                       'Are you sure you want to delete {{serviceAccountName}}?',

--- a/public/app/plugins/panel/nodeGraph/Marker.tsx
+++ b/public/app/plugins/panel/nodeGraph/Marker.tsx
@@ -60,7 +60,11 @@ export const Marker = memo(function Marker(props: {
             <span>
               {marker.count > 100
                 ? t('nodeGraph.marker.100-node-count', '>100 nodes')
-                : t('nodeGraph.marker.node-count', '{{count}} nodes', { count: marker.count })}
+                : t('nodeGraph.marker.node-count', '', {
+                    count: marker.count,
+                    defaultValue_one: '{{count}} nodes',
+                    defaultValue_other: '{{count}} nodes',
+                  })}
             </span>
           </div>
         </foreignObject>


### PR DESCRIPTION

> [!NOTE]  
> There is an Enterprise PR here: https://github.com/grafana/grafana-enterprise/pull/12105


**What is this feature?**

This PR moves the plural defaults of `t()` calls from the positional `defaultValue` argument into `defaultValue_one` and `defaultValue_other` keys inside the options object, for every key in `grafana.json` that has both `_one` and `_other` forms.

Before:

```ts
t('browse-dashboards.counts.folder', '{{count}} folder', { count: folderCount });
```

After:

```ts
t('browse-dashboards.counts.folder', '', {
  count: folderCount,
  defaultValue_one: '{{count}} folder',
  defaultValue_other: '{{count}} folders',
});
```

`i18next` picks the suffix from `count` + CLDR rules at runtime and `i18next-cli` emits the matching `<key>_<suffix>` entries on extract, so `grafana.json` stays byte-identical.

`Trans` component usages are out of scope and will be handled in a follow-up PR.

**Why do we need this feature?**

This will eventually help use to minimize the load of 500kb default `en-US` resources by supplying correct plural defaults in the shipped code. 

**Who is this feature for?**

Grafana devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

25 files touched but every change is the same mechanical transform. `yarn i18n-extract` is a no-op against `grafana.json` after this PR, which is the load-bearing check that the migration is semantically equivalent.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
