### PR TITLE
i18n: move plural defaults of Trans components into tOptions

### DIFF
--- a/public/app/features/admin/UserListPublicDashboardPage/UserListPublicDashboardPage.tsx
+++ b/public/app/features/admin/UserListPublicDashboardPage/UserListPublicDashboardPage.tsx
@@ -63,6 +63,10 @@ export const UserListPublicDashboardPage = () => {
                     <Trans
                       i18nKey="public-dashboard-users-access-list.table-body.dashboard-count"
                       count={user.totalDashboards}
+                      tOptions={{
+                        defaultValue_one: '{{count}} dashboards',
+                        defaultValue_other: '{{count}} dashboards',
+                      }}
                     >
                       {{ count: user.totalDashboards }} dashboards
                     </Trans>

--- a/public/app/features/alerting/unified/components/notification-policies/Policy.tsx
+++ b/public/app/features/alerting/unified/components/notification-policies/Policy.tsx
@@ -431,7 +431,14 @@ const Policy = (props: PolicyComponentProps) => {
                 className={styles.moreButtons}
                 onClick={() => setVisibleChildPolicies(visibleChildPolicies + POLICIES_PER_PAGE)}
               >
-                <Trans i18nKey="alerting.policies.n-more-policies" count={moreCount}>
+                <Trans
+                  i18nKey="alerting.policies.n-more-policies"
+                  count={moreCount}
+                  tOptions={{
+                    defaultValue_one: '{{count}} additional policies',
+                    defaultValue_other: '{{count}} additional policies',
+                  }}
+                >
                   {{ count: moreCount }} additional policies
                 </Trans>
               </Button>
@@ -511,7 +518,14 @@ export function MetadataRow({
           >
             <Text color="primary">{numberOfAlertInstances ?? '-'}</Text>
             <span>
-              <Trans i18nKey="alerting.policies.metadata.n-instances" count={numberOfAlertInstances ?? 0}>
+              <Trans
+                i18nKey="alerting.policies.metadata.n-instances"
+                count={numberOfAlertInstances ?? 0}
+                tOptions={{
+                  defaultValue_one: 'instance',
+                  defaultValue_other: 'instance',
+                }}
+              >
                 instance
               </Trans>
             </span>
@@ -798,7 +812,14 @@ export const DefaultPolicyIndicator: FC<DefaultPolicyIndicatorProps> = ({ route 
       {isFinite(routeCount) && (
         <Text variant="bodySmall" color="secondary">
           ・{' '}
-          <Trans i18nKey="alerting.policies.default-policy.route-count" count={routeCount}>
+          <Trans
+            i18nKey="alerting.policies.default-policy.route-count"
+            count={routeCount}
+            tOptions={{
+              defaultValue_one: '{{count}} routes',
+              defaultValue_other: '{{count}} routes',
+            }}
+          >
             {{ count: routeCount }} routes
           </Trans>
         </Text>

--- a/public/app/features/alerting/unified/components/rules/AlertInstanceNotificationAction.tsx
+++ b/public/app/features/alerting/unified/components/rules/AlertInstanceNotificationAction.tsx
@@ -157,14 +157,28 @@ export const AlertInstanceNotificationAction = ({
             }
           >
             <Button fill="text" variant="primary" size="sm">
-              <Trans i18nKey="alerting.alert-instance-extension-point.n-contact-points" count={policyReceivers.length}>
+              <Trans
+                i18nKey="alerting.alert-instance-extension-point.n-contact-points"
+                count={policyReceivers.length}
+                tOptions={{
+                  defaultValue_one: '{{count}} contact point',
+                  defaultValue_other: '{{count}} contact points',
+                }}
+              >
                 {'{{count}}'} contact point
               </Trans>
             </Button>
           </PopupCard>
         )}
         <Button fill="outline" variant="secondary" size="sm" onClick={() => setIsOpen(true)}>
-          <Trans i18nKey="alerting.alert-instance-extension-point.view-route" count={journeys.length}>
+          <Trans
+            i18nKey="alerting.alert-instance-extension-point.view-route"
+            count={journeys.length}
+            tOptions={{
+              defaultValue_one: 'View route',
+              defaultValue_other: 'View routes',
+            }}
+          >
             View route
           </Trans>
         </Button>

--- a/public/app/features/alerting/unified/components/rules/RuleListErrors.tsx
+++ b/public/app/features/alerting/unified/components/rules/RuleListErrors.tsx
@@ -124,7 +124,14 @@ export function RuleListErrors(): ReactElement {
                   size="sm"
                   onClick={() => setExpanded(true)}
                 >
-                  <Trans i18nKey="alerting.rule-list-errors.more-errors" count={errors.length - 1}>
+                  <Trans
+                    i18nKey="alerting.rule-list-errors.more-errors"
+                    count={errors.length - 1}
+                    tOptions={{
+                      defaultValue_one: '{{count}} more errors',
+                      defaultValue_other: '{{count}} more errors',
+                    }}
+                  >
                     {'{{count}}'} more errors
                   </Trans>
                 </Button>
@@ -152,7 +159,14 @@ const ErrorSummaryButton: FC<ErrorSummaryProps> = ({ count, onClick }) => {
         placement="bottom"
       >
         <Button fill="text" variant="destructive" icon="exclamation-triangle" onClick={onClick}>
-          <Trans i18nKey="alerting.rule-list-errors.button-errors" count={count}>
+          <Trans
+            i18nKey="alerting.rule-list-errors.button-errors"
+            count={count}
+            tOptions={{
+              defaultValue_one: '{{count}} errors',
+              defaultValue_other: '{{count}} errors',
+            }}
+          >
             {'{{count}}'} errors
           </Trans>
         </Button>

--- a/public/app/features/alerting/unified/triage/Workbench.tsx
+++ b/public/app/features/alerting/unified/triage/Workbench.tsx
@@ -254,7 +254,14 @@ export function Workbench({
                     style={{ position: 'absolute', right: `calc(100% - ${leftColumnWidth}px)`, textAlign: 'right' }}
                   >
                     <Text variant="bodySmall" color="secondary">
-                      <Trans i18nKey="alerting.triage.showing-groups-count" values={{ count: data.length }}>
+                      <Trans
+                        i18nKey="alerting.triage.showing-groups-count"
+                        values={{ count: data.length }}
+                        tOptions={{
+                          defaultValue_one: 'Showing {{count}} groups',
+                          defaultValue_other: 'Showing {{count}} groups',
+                        }}
+                      >
                         {'Showing {{count}} groups'}
                       </Trans>
                     </Text>

--- a/public/app/features/alerting/unified/triage/scene/filters/LabelsContent.tsx
+++ b/public/app/features/alerting/unified/triage/scene/filters/LabelsContent.tsx
@@ -108,6 +108,10 @@ export function AllLabelsContent({ allLabels, onFilterAdded, labelFilter = '' }:
             i18nKey="alerting.triage.show-all-labels"
             values={{ count: allLabels.length }}
             defaults={'Show all ({{ count }})'}
+            tOptions={{
+              defaultValue_one: 'Show all ({{ count }})',
+              defaultValue_other: 'Show all ({{ count }})',
+            }}
           />
         </Button>
       )}
@@ -181,6 +185,10 @@ function LabelValuesList({ labelKey, values, onValueClick, valueHits }: LabelVal
             i18nKey="alerting.triage.show-all-values"
             values={{ count: matchedValues.length }}
             defaults={'Show all ({{ count }})'}
+            tOptions={{
+              defaultValue_one: 'Show all ({{ count }})',
+              defaultValue_other: 'Show all ({{ count }})',
+            }}
           />
         </Button>
       )}

--- a/public/app/features/browse-dashboards/components/RestoreModal.tsx
+++ b/public/app/features/browse-dashboards/components/RestoreModal.tsx
@@ -77,13 +77,27 @@ export const RestoreModal = ({
       body={
         <>
           <Text element="p">
-            <Trans i18nKey="recently-deleted.restore-modal.text" count={numberOfDashboards}>
+            <Trans
+              i18nKey="recently-deleted.restore-modal.text"
+              count={numberOfDashboards}
+              tOptions={{
+                defaultValue_one: 'This action will restore {{numberOfDashboards}} dashboards.',
+                defaultValue_other: 'This action will restore {{numberOfDashboards}} dashboards.',
+              }}
+            >
               This action will restore {{ numberOfDashboards }} dashboards.
             </Trans>
           </Text>
           <Space v={3} />
           <Text element="p">
-            <Trans i18nKey="recently-deleted.restore-modal.folder-picker-text" count={numberOfDashboards}>
+            <Trans
+              i18nKey="recently-deleted.restore-modal.folder-picker-text"
+              count={numberOfDashboards}
+              tOptions={{
+                defaultValue_one: 'Please choose a folder where your dashboards will be restored.',
+                defaultValue_other: 'Please choose a folder where your dashboards will be restored.',
+              }}
+            >
               Please choose a folder where your dashboards will be restored.
             </Trans>
           </Text>

--- a/public/app/features/dashboard-scene/panel-edit/LibraryVizPanelInfo.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/LibraryVizPanelInfo.tsx
@@ -23,7 +23,14 @@ export const LibraryVizPanelInfo = ({ libraryPanel }: Props) => {
   return (
     <div className={styles.info}>
       <div className={styles.libraryPanelInfo}>
-        <Trans i18nKey="dashboard-scene.library-viz-panel-info.usage-count" count={meta.connectedDashboards}>
+        <Trans
+          i18nKey="dashboard-scene.library-viz-panel-info.usage-count"
+          count={meta.connectedDashboards}
+          tOptions={{
+            defaultValue_one: 'Used on {{count}} dashboards',
+            defaultValue_other: 'Used on {{count}} dashboards',
+          }}
+        >
           Used on {'{{count}}'} dashboards
         </Trans>
       </div>

--- a/public/app/features/dashboard-scene/panel-edit/SaveLibraryVizPanelModal.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/SaveLibraryVizPanelModal.tsx
@@ -56,6 +56,12 @@ export const SaveLibraryVizPanelModal = ({ libraryPanel, isUnsavedPrompt, onDism
           <Trans
             i18nKey="dashboard-scene.save-library-viz-panel-modal.affected-dashboards"
             count={libraryPanel.state._loadedPanel?.meta?.connectedDashboards}
+            tOptions={{
+              defaultValue_one:
+                'This update will affect <1>{{count}} dashboards.</1> The following dashboards using the panel will be affected:',
+              defaultValue_other:
+                'This update will affect <1>{{count}} dashboards.</1> The following dashboards using the panel will be affected:',
+            }}
           >
             This update will affect <strong>{'{{count}}'} dashboards.</strong> The following dashboards using the panel
             will be affected:

--- a/public/app/features/dashboard-scene/settings/variables/components/VariableValuesPreview.tsx
+++ b/public/app/features/dashboard-scene/settings/variables/components/VariableValuesPreview.tsx
@@ -71,7 +71,14 @@ export const VariableValuesPreview = ({ options, staticOptions }: VariableValues
   return (
     <div className={styles.previewContainer} style={{ gap: '8px' }}>
       <Text variant="bodySmall" weight="medium">
-        <Trans i18nKey="dashboard-scene.variable-values-preview.preview-of-values" values={{ count: options.length }}>
+        <Trans
+          i18nKey="dashboard-scene.variable-values-preview.preview-of-values"
+          values={{ count: options.length }}
+          tOptions={{
+            defaultValue_one: 'Preview of values ({{count}})',
+            defaultValue_other: 'Preview of values ({{count}})',
+          }}
+        >
           Preview of values ({'{{count}}'})
         </Trans>
         {hasOptions && displayMultiPropsPreview && (

--- a/public/app/features/dashboard/dashgrid/DashboardLibrary/CommunityDashboardMappingForm.tsx
+++ b/public/app/features/dashboard/dashgrid/DashboardLibrary/CommunityDashboardMappingForm.tsx
@@ -167,7 +167,14 @@ export const CommunityDashboardMappingForm = ({
           <Alert title="" severity="info">
             <Stack direction="column" gap={1}>
               <Text>
-                <Trans i18nKey="dashboard-library.community-mapping-form.auto-mapped" count={existingMappings.length}>
+                <Trans
+                  i18nKey="dashboard-library.community-mapping-form.auto-mapped"
+                  count={existingMappings.length}
+                  tOptions={{
+                    defaultValue_one: '{{count}} datasources were automatically configured:',
+                    defaultValue_other: '{{count}} datasources were automatically configured:',
+                  }}
+                >
                   {{ count: existingMappings.length }} datasources were automatically configured:
                 </Trans>
               </Text>

--- a/public/app/features/explore/RichHistory/RichHistoryQueriesTab.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryQueriesTab.tsx
@@ -268,12 +268,20 @@ export function RichHistoryQueriesTab(props: RichHistoryQueriesTabProps) {
                         i18nKey="explore.rich-history-queries-tab.displaying-partial-queries"
                         defaults="Displaying {{ count }} queries"
                         values={{ count: mappedQueriesToHeadings[heading].length }}
+                        tOptions={{
+                          defaultValue_one: 'Displaying {{ count }} queries',
+                          defaultValue_other: 'Displaying {{ count }} queries',
+                        }}
                       />
                     ) : (
                       <Trans
                         i18nKey="explore.rich-history-queries-tab.displaying-queries"
                         defaults="{{ count }} queries"
                         values={{ count: mappedQueriesToHeadings[heading].length }}
+                        tOptions={{
+                          defaultValue_one: '{{ count }} queries',
+                          defaultValue_other: '{{ count }} queries',
+                        }}
                       />
                     )}
                   </span>

--- a/public/app/features/inspector/QueryInspector.tsx
+++ b/public/app/features/inspector/QueryInspector.tsx
@@ -208,13 +208,27 @@ export class QueryInspector extends PureComponent<Props, State> {
                 <span className={styles.refId}>{info.refId}:</span>
                 {info.frames > 1 && (
                   <span>
-                    <Trans i18nKey="inspector.query-inspector.count-frames" count={info.frames}>
+                    <Trans
+                      i18nKey="inspector.query-inspector.count-frames"
+                      count={info.frames}
+                      tOptions={{
+                        defaultValue_one: '{{count}} frames, ',
+                        defaultValue_other: '{{count}} frames, ',
+                      }}
+                    >
                       {'{{count}}'} frames,{' '}
                     </Trans>
                   </span>
                 )}
                 <span>
-                  <Trans i18nKey="inspector.query-inspector.count-rows" count={info.rows}>
+                  <Trans
+                    i18nKey="inspector.query-inspector.count-rows"
+                    count={info.rows}
+                    tOptions={{
+                      defaultValue_one: '{{count}} rows',
+                      defaultValue_other: '{{count}} rows',
+                    }}
+                  >
                     {'{{count}}'} rows
                   </Trans>
                 </span>

--- a/public/app/features/library-panels/components/LibraryPanelInfo/LibraryPanelInfo.tsx
+++ b/public/app/features/library-panels/components/LibraryPanelInfo/LibraryPanelInfo.tsx
@@ -22,7 +22,14 @@ export const LibraryPanelInformation = ({ panel, formatDate }: Props) => {
   return (
     <div className={styles.info}>
       <div className={styles.libraryPanelInfo}>
-        <Trans i18nKey="library-panels.library-panel-info.usage-count" count={meta.connectedDashboards}>
+        <Trans
+          i18nKey="library-panels.library-panel-info.usage-count"
+          count={meta.connectedDashboards}
+          tOptions={{
+            defaultValue_one: 'Used on {{count}} dashboards',
+            defaultValue_other: 'Used on {{count}} dashboards',
+          }}
+        >
           Used on {'{{count}}'} dashboards
         </Trans>
       </div>

--- a/public/app/features/library-panels/components/OpenLibraryPanelModal/OpenLibraryPanelModal.tsx
+++ b/public/app/features/library-panels/components/OpenLibraryPanelModal/OpenLibraryPanelModal.tsx
@@ -55,7 +55,16 @@ export function OpenLibraryPanelModal({ libraryPanel, onDismiss }: OpenLibraryPa
         {connected > 0 ? (
           <>
             <p>
-              <Trans i18nKey="library-panels.modal.body" count={connected}>
+              <Trans
+                i18nKey="library-panels.modal.body"
+                count={connected}
+                tOptions={{
+                  defaultValue_one:
+                    'This panel is being used in {{count}} dashboard. Please choose which dashboard to view the panel in:',
+                  defaultValue_other:
+                    'This panel is being used in {{count}} dashboard. Please choose which dashboard to view the panel in:',
+                }}
+              >
                 This panel is being used in {{ count: connected }} dashboard. Please choose which dashboard to view the
                 panel in:
               </Trans>

--- a/public/app/features/library-panels/components/SaveLibraryPanelModal/SaveLibraryPanelModal.tsx
+++ b/public/app/features/library-panels/components/SaveLibraryPanelModal/SaveLibraryPanelModal.tsx
@@ -66,6 +66,10 @@ export const SaveLibraryPanelModal = ({
           <Trans
             i18nKey="library-panels.save-library-panel-modal.num-affected"
             count={panel.libraryPanel.meta?.connectedDashboards}
+            tOptions={{
+              defaultValue_one: 'This update will affect <1>{{count}} dashboards.</1>',
+              defaultValue_other: 'This update will affect <1>{{count}} dashboards.</1>',
+            }}
           >
             This update will affect <strong>{'{{count}}'} dashboards.</strong>
           </Trans>

--- a/public/app/features/provisioning/Shared/QuotaLimitMessage.tsx
+++ b/public/app/features/provisioning/Shared/QuotaLimitMessage.tsx
@@ -73,19 +73,47 @@ function LimitText({
     case 'both':
       return onPrem ? (
         <>
-          <Trans i18nKey="provisioning.quota-limit.message-both-repositories-onprem" count={maxRepositories}>
+          <Trans
+            i18nKey="provisioning.quota-limit.message-both-repositories-onprem"
+            count={maxRepositories}
+            tOptions={{
+              defaultValue_one: 'Your instance is limited to {{count}} connected repositories',
+              defaultValue_other: 'Your instance is limited to {{count}} connected repositories',
+            }}
+          >
             Your instance is limited to {{ count: maxRepositories }} connected repositories
           </Trans>{' '}
-          <Trans i18nKey="provisioning.quota-limit.message-both-resources-onprem" count={maxResourcesPerRepository}>
+          <Trans
+            i18nKey="provisioning.quota-limit.message-both-resources-onprem"
+            count={maxResourcesPerRepository}
+            tOptions={{
+              defaultValue_one: 'and {{count}} synced resources per repository.',
+              defaultValue_other: 'and {{count}} synced resources per repository.',
+            }}
+          >
             and {{ count: maxResourcesPerRepository }} synced resources per repository.
           </Trans>
         </>
       ) : (
         <>
-          <Trans i18nKey="provisioning.quota-limit.message-both-repositories" count={maxRepositories}>
+          <Trans
+            i18nKey="provisioning.quota-limit.message-both-repositories"
+            count={maxRepositories}
+            tOptions={{
+              defaultValue_one: 'Your account is limited to {{count}} connected repositories',
+              defaultValue_other: 'Your account is limited to {{count}} connected repositories',
+            }}
+          >
             Your account is limited to {{ count: maxRepositories }} connected repositories
           </Trans>{' '}
-          <Trans i18nKey="provisioning.quota-limit.message-both-resources" count={maxResourcesPerRepository}>
+          <Trans
+            i18nKey="provisioning.quota-limit.message-both-resources"
+            count={maxResourcesPerRepository}
+            tOptions={{
+              defaultValue_one: 'and {{count}} synced resources per repository.',
+              defaultValue_other: 'and {{count}} synced resources per repository.',
+            }}
+          >
             and {{ count: maxResourcesPerRepository }} synced resources per repository.
           </Trans>
         </>
@@ -93,22 +121,50 @@ function LimitText({
 
     case 'resource':
       return onPrem ? (
-        <Trans i18nKey="provisioning.quota-limit.message-resource-onprem" count={maxResourcesPerRepository}>
+        <Trans
+          i18nKey="provisioning.quota-limit.message-resource-onprem"
+          count={maxResourcesPerRepository}
+          tOptions={{
+            defaultValue_one: 'Your instance is limited to {{count}} synced resources per repository.',
+            defaultValue_other: 'Your instance is limited to {{count}} synced resources per repository.',
+          }}
+        >
           Your instance is limited to {{ count: maxResourcesPerRepository }} synced resources per repository.
         </Trans>
       ) : (
-        <Trans i18nKey="provisioning.quota-limit.message-resource" count={maxResourcesPerRepository}>
+        <Trans
+          i18nKey="provisioning.quota-limit.message-resource"
+          count={maxResourcesPerRepository}
+          tOptions={{
+            defaultValue_one: 'Your account is limited to {{count}} synced resources per repository.',
+            defaultValue_other: 'Your account is limited to {{count}} synced resources per repository.',
+          }}
+        >
           Your account is limited to {{ count: maxResourcesPerRepository }} synced resources per repository.
         </Trans>
       );
 
     case 'repository':
       return onPrem ? (
-        <Trans i18nKey="provisioning.quota-limit.message-repository-onprem" count={maxRepositories}>
+        <Trans
+          i18nKey="provisioning.quota-limit.message-repository-onprem"
+          count={maxRepositories}
+          tOptions={{
+            defaultValue_one: 'Your instance is limited to {{count}} connected repositories.',
+            defaultValue_other: 'Your instance is limited to {{count}} connected repositories.',
+          }}
+        >
           Your instance is limited to {{ count: maxRepositories }} connected repositories.
         </Trans>
       ) : (
-        <Trans i18nKey="provisioning.quota-limit.message-repository" count={maxRepositories}>
+        <Trans
+          i18nKey="provisioning.quota-limit.message-repository"
+          count={maxRepositories}
+          tOptions={{
+            defaultValue_one: 'Your account is limited to {{count}} connected repositories.',
+            defaultValue_other: 'Your account is limited to {{count}} connected repositories.',
+          }}
+        >
           Your account is limited to {{ count: maxRepositories }} connected repositories.
         </Trans>
       );

--- a/public/app/features/provisioning/Shared/RepositoryList.tsx
+++ b/public/app/features/provisioning/Shared/RepositoryList.tsx
@@ -42,7 +42,14 @@ export function RepositoryList({ items }: Props) {
         <Box marginBottom={2}>
           <Stack alignItems="center">
             <Icon name="check" color="green" />
-            <Trans i18nKey="provisioning.folder-repository-list.all-resources-managed" count={resourceCount}>
+            <Trans
+              i18nKey="provisioning.folder-repository-list.all-resources-managed"
+              count={resourceCount}
+              tOptions={{
+                defaultValue_one: 'All {{count}} resources are managed',
+                defaultValue_other: 'All {{count}} resources are managed',
+              }}
+            >
               All {{ count: resourceCount }} resources are managed
             </Trans>
           </Stack>
@@ -63,7 +70,14 @@ export function RepositoryList({ items }: Props) {
             {unmanagedCount > 0 && (
               <>
                 {' '}
-                <Trans i18nKey="provisioning.folder-repository-list.unmanaged-resources" count={unmanagedCount}>
+                <Trans
+                  i18nKey="provisioning.folder-repository-list.unmanaged-resources"
+                  count={unmanagedCount}
+                  tOptions={{
+                    defaultValue_one: "{{count}} resources aren't managed by Git sync.",
+                    defaultValue_other: "{{count}} resources aren't managed by Git sync.",
+                  }}
+                >
                   {{ count: unmanagedCount }} resources aren&apos;t managed by Git sync.
                 </Trans>
               </>

--- a/public/app/plugins/panel/nodeGraph/NodeGraph.tsx
+++ b/public/app/plugins/panel/nodeGraph/NodeGraph.tsx
@@ -348,7 +348,14 @@ export function NodeGraph({ getLinks, dataFrames, nodeLimit, panelId, zoomMode, 
           style={{ top: panelId ? '0px' : '40px' }} // panelId is undefined in Explore
           aria-label={t('nodeGraph.node-graph.aria-label-nodes-hidden-warning', 'Nodes hidden warning')}
         >
-          <Trans i18nKey="nodeGraph.node-graph.hidden-nodes" count={hiddenNodesCount}>
+          <Trans
+            i18nKey="nodeGraph.node-graph.hidden-nodes"
+            count={hiddenNodesCount}
+            tOptions={{
+              defaultValue_one: '<0></0> {{count}} nodes are hidden for performance reasons.',
+              defaultValue_other: '<0></0> {{count}} nodes are hidden for performance reasons.',
+            }}
+          >
             <Icon size="sm" name={'info-circle'} /> {'{{count}}'} nodes are hidden for performance reasons.
           </Trans>
         </div>
@@ -363,7 +370,14 @@ export function NodeGraph({ getLinks, dataFrames, nodeLimit, panelId, zoomMode, 
             'Layered layout performance warning'
           )}
         >
-          <Trans i18nKey="nodeGraph.node-graph.processed-nodes" count={processed.nodes.length}>
+          <Trans
+            i18nKey="nodeGraph.node-graph.processed-nodes"
+            count={processed.nodes.length}
+            tOptions={{
+              defaultValue_one: '<0></0> Layered layout may be slow with {{count}} nodes.',
+              defaultValue_other: '<0></0> Layered layout may be slow with {{count}} nodes.',
+            }}
+          >
             <Icon size="sm" name={'exclamation-triangle'} /> Layered layout may be slow with {'{{count}}'} nodes.
           </Trans>
         </div>

--- a/public/app/plugins/panel/status-history/StatusHistoryPanel.tsx
+++ b/public/app/plugins/panel/status-history/StatusHistoryPanel.tsx
@@ -81,7 +81,16 @@ export const StatusHistoryPanel = ({
     return (
       <div className="panel-empty">
         <p>
-          <Trans i18nKey="status-history.status-history-panel.too-many-points" count={paginatedFrames[0].length}>
+          <Trans
+            i18nKey="status-history.status-history-panel.too-many-points"
+            count={paginatedFrames[0].length}
+            tOptions={{
+              defaultValue_one:
+                'Too many points to visualize properly. <br/>Update the query to return fewer points. <br/>({{count}} points received)',
+              defaultValue_other:
+                'Too many points to visualize properly. <br/>Update the query to return fewer points. <br/>({{count}} points received)',
+            }}
+          >
             Too many points to visualize properly. <br />
             Update the query to return fewer points. <br />({'{{count}}'} points received)
           </Trans>


### PR DESCRIPTION

> [!NOTE]  
> There is an Enterprise PR here: https://github.com/grafana/grafana-enterprise/pull/12106


**What is this feature?**

This PR is the `<Trans>` counterpart to #125312. For every key in `grafana.json` that has both `_one` and `_other` forms and is used via the `<Trans>` component, it adds a `tOptions` prop with explicit `defaultValue_one` and `defaultValue_other` defaults from `grafana.json`.

Before:

```tsx
<Trans i18nKey="alerting.alert-instance-extension-point.view-route" count={journeys.length}>
  View route
</Trans>
```

After:

```tsx
<Trans
  i18nKey="alerting.alert-instance-extension-point.view-route"
  count={journeys.length}
  tOptions={{
    defaultValue_one: 'View route',
    defaultValue_other: 'View routes',
  }}
>
  View route
</Trans>
```

Children stay in place because they carry the JSX structure that `<n>` placeholders in the JSON values map back to at render time (e.g. `<strong>`, `<br/>`, `<Icon />`). `i18next-cli` emits the matching `<key>_<suffix>` entries on extract, so `grafana.json` stays byte-identical.

**Why do we need this feature?**

This will eventually help use to minimize the load of 500kb default `en-US` resources by supplying correct plural defaults in the shipped code. 

**Who is this feature for?**

Grafana devs

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Follow-up to #125312. Same mechanical transform, just for `<Trans>` instead of `t()`. `yarn i18n-extract` is a no-op against `grafana.json` after this PR — that's the load-bearing check that the migration is semantically equivalent.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
