### PR TITLE
Folders: Add frontend helpers to resolve the "general" folder

### DIFF
--- a/public/app/api/clients/folder/v1beta1/hooks.ts
+++ b/public/app/api/clients/folder/v1beta1/hooks.ts
@@ -43,7 +43,7 @@ import {
 } from '../../../../features/apiserver/types';
 import { PAGE_SIZE } from '../../../../features/browse-dashboards/api/constants';
 import { refetchChildren, refreshParents } from '../../../../features/browse-dashboards/state/actions';
-import { GENERAL_FOLDER_UID } from '../../../../features/search/constants';
+import { isRootFolderUID } from '../../../../features/search/constants';
 import { deletedDashboardsCache } from '../../../../features/search/service/deletedDashboardsCache';
 import { useDispatch } from '../../../../types/store';
 
@@ -120,7 +120,10 @@ const combineFolderResponses = (
 };
 
 export async function getFolderByUidFacade(uid: string) {
-  const isVirtualFolder = uid && [GENERAL_FOLDER_UID, config.sharedWithMeFolderUID].includes(uid);
+  // Root-parented requests carry "" or "general" — serve the virtual root
+  // folder for either rather than fetching a folder resource that doesn't exist.
+  const isRoot = isRootFolderUID(uid);
+  const isVirtualFolder = uid && (isRoot || uid === config.sharedWithMeFolderUID);
   const shouldUseAppPlatformAPI = Boolean(config.featureToggles.foldersAppPlatformAPI);
 
   // We need the legacy API call regardless, for now
@@ -135,7 +138,7 @@ export async function getFolderByUidFacade(uid: string) {
   if (shouldUseAppPlatformAPI) {
     let virtualFolderResponse;
     if (isVirtualFolder) {
-      virtualFolderResponse = GENERAL_FOLDER_UID === uid ? rootFolder : sharedWithMeFolder;
+      virtualFolderResponse = isRoot ? rootFolder : sharedWithMeFolder;
     }
 
     const responses = await Promise.all([
@@ -191,7 +194,10 @@ export async function getFolderByUidFacade(uid: string) {
  */
 export function useGetFolderQueryFacade(uid?: string) {
   const shouldUseAppPlatformAPI = Boolean(config.featureToggles.foldersAppPlatformAPI);
-  const isVirtualFolder = uid && [GENERAL_FOLDER_UID, config.sharedWithMeFolderUID].includes(uid);
+  // "" / undefined and "general" both mean the synthetic root folder —
+  // neither is a real folder resource.
+  const isRoot = isRootFolderUID(uid);
+  const isVirtualFolder = uid && (isRoot || uid === config.sharedWithMeFolderUID);
   const params = !uid ? skipToken : { name: uid };
 
   // This may look weird that we call the legacy folder anyway all the time, but the issue is we don't have good API
@@ -234,8 +240,8 @@ export function useGetFolderQueryFacade(uid?: string) {
       isSuccess: true,
       isLoading: false,
       isFetching: false,
-      data: GENERAL_FOLDER_UID === uid ? rootFolder : sharedWithMeFolder,
-      currentData: GENERAL_FOLDER_UID === uid ? rootFolder : sharedWithMeFolder,
+      data: isRoot ? rootFolder : sharedWithMeFolder,
+      currentData: isRoot ? rootFolder : sharedWithMeFolder,
     };
   }
 
@@ -592,9 +598,8 @@ const appPlatformFolderToLegacyFolder = (
     id: parseInt(labels?.[DeprecatedInternalId] || '0', 10) || 0,
     uid: name,
     title,
-    // general folder does not come with url
-    // see https://github.com/grafana/grafana/blob/8a05378ef3ae5545c6f7429eae5c174d3c0edbfe/pkg/services/folder/folderimpl/folder_unifiedstorage.go#L88
-    url: name === GENERAL_FOLDER_UID ? '' : getFolderUrl(name, title),
+    // the root folder has no url — the backend leaves it blank
+    url: isRootFolderUID(name) ? '' : getFolderUrl(name, title),
     created: creationTimestamp || '0001-01-01T00:00:00Z',
     updated: annotations?.[AnnoKeyUpdatedTimestamp] || '0001-01-01T00:00:00Z',
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions

--- a/public/app/features/browse-dashboards/api/services.ts
+++ b/public/app/features/browse-dashboards/api/services.ts
@@ -3,7 +3,7 @@ import { config, getBackendSrv } from '@grafana/runtime';
 import { dashboardAPIv0alpha1 } from 'app/api/clients/dashboard/v0alpha1';
 import { legacyAPI } from 'app/api/clients/legacy';
 import { contextSrv } from 'app/core/services/context_srv';
-import { GENERAL_FOLDER_UID, TEAM_FOLDERS_UID } from 'app/features/search/constants';
+import { TEAM_FOLDERS_UID, isRootFolderUID } from 'app/features/search/constants';
 import { getGrafanaSearcher } from 'app/features/search/service/searcher';
 import { type DashboardQueryResult, type NestedFolderDTO } from 'app/features/search/service/types';
 import { extractManagerKind, queryResultToViewItem } from 'app/features/search/service/utils';
@@ -131,9 +131,10 @@ export async function listDashboards(parentUID?: string, page = 1, pageSize = PA
   return dashboardsResults.view.map((item) => {
     const viewItem = queryResultToViewItem(item, dashboardsResults.view);
 
-    // TODO: Once we remove nestedFolders feature flag, undo this and prevent the 'general'
-    // parentUID from being set in searcher
-    if (viewItem.parentUID === GENERAL_FOLDER_UID) {
+    // TODO: Once we remove nestedFolders feature flag, undo this and prevent
+    // the "general" parentUID from being set in searcher. Until then, treat
+    // any root sentinel ("" or "general") as "no parent" for the UI.
+    if (isRootFolderUID(viewItem.parentUID)) {
       viewItem.parentUID = undefined;
     }
 

--- a/public/app/features/browse-dashboards/components/RecentlyDeletedActions.tsx
+++ b/public/app/features/browse-dashboards/components/RecentlyDeletedActions.tsx
@@ -8,7 +8,7 @@ import { buildNotificationButton } from 'app/core/components/AppNotifications/No
 import { createSuccessNotification } from 'app/core/copy/appNotification';
 import { notifyApp } from 'app/core/reducers/appNotification';
 import { AnnoKeyFolder } from 'app/features/apiserver/types';
-import { GENERAL_FOLDER_UID } from 'app/features/search/constants';
+import { isRootFolderUID } from 'app/features/search/constants';
 import { useDispatch } from 'app/types/store';
 
 import { deletedDashboardsCache } from '../../search/service/deletedDashboardsCache';
@@ -46,11 +46,11 @@ export function RecentlyDeletedActions() {
         return undefined;
       }
 
-      // Searcher changes the location from empty string to 'general' for items with no parent,
-      // but the restore API doesn't work with 'general' folder UID, so we need to convert it back
-      // to an empty string
+      // Searcher reports root-parented items with the "general" UID, but the
+      // restore API doesn't accept it — convert back to "" so the dashboard
+      // is restored to the root.
       const location = searchState.result.view.fields.location.values[index];
-      const fixedLocation = location === GENERAL_FOLDER_UID ? '' : location;
+      const fixedLocation = isRootFolderUID(location) ? '' : location;
 
       if (originCandidate === undefined) {
         originCandidate = fixedLocation;
@@ -136,9 +136,9 @@ export function RecentlyDeletedActions() {
       if (!foundItem) {
         continue;
       }
-      // Search API returns items with no parent with a location of 'general', so we
-      // need to convert that back to undefined
-      const folderUID = foundItem.location === GENERAL_FOLDER_UID ? undefined : foundItem.location;
+      // Search API reports root-parented items with the "general" UID —
+      // convert that back to undefined.
+      const folderUID = isRootFolderUID(foundItem.location) ? undefined : foundItem.location;
       parentUIDs.add(folderUID);
     }
     dispatch(clearFolders(Array.from(parentUIDs)));

--- a/public/app/features/browse-dashboards/state/actions.ts
+++ b/public/app/features/browse-dashboards/state/actions.ts
@@ -1,4 +1,4 @@
-import { GENERAL_FOLDER_UID, TEAM_FOLDERS_UID } from 'app/features/search/constants';
+import { TEAM_FOLDERS_UID, isRootFolderUID } from 'app/features/search/constants';
 import { type DashboardViewItem, type DashboardViewItemKind } from 'app/features/search/types';
 import { createAsyncThunk } from 'app/types/store';
 
@@ -80,7 +80,7 @@ export const refetchChildren = createAsyncThunk(
     }
 
     const strippedUID = parentUID ? removeTeamFolderPrefix(parentUID) : parentUID;
-    const uid = strippedUID === GENERAL_FOLDER_UID ? undefined : strippedUID;
+    const uid = isRootFolderUID(strippedUID) ? undefined : strippedUID;
 
     // At the moment this will just clear out all loaded children and refetch the first page.
     // If user has scrolled beyond the first page, then InfiniteLoader will probably trigger
@@ -141,10 +141,10 @@ export const fetchNextChildrenPage = createAsyncThunk(
     const loadDashboards = !excludeKinds.includes('dashboard');
 
     const strippedUID = parentUID ? removeTeamFolderPrefix(parentUID) : parentUID;
-    const uid = strippedUID === GENERAL_FOLDER_UID ? undefined : strippedUID;
+    const uid = isRootFolderUID(strippedUID) ? undefined : strippedUID;
 
     const state = thunkAPI.getState().browseDashboards;
-    const collectionKey = parentUID === GENERAL_FOLDER_UID ? undefined : parentUID;
+    const collectionKey = isRootFolderUID(parentUID) ? undefined : parentUID;
     const collection = collectionKey ? state.childrenByParentUID[collectionKey] : state.rootItems;
 
     let page = 1;

--- a/public/app/features/browse-dashboards/state/reducers.ts
+++ b/public/app/features/browse-dashboards/state/reducers.ts
@@ -2,7 +2,7 @@ import { type PayloadAction } from '@reduxjs/toolkit';
 
 import { type DashboardViewItem, type DashboardViewItemKind } from 'app/features/search/types';
 
-import { GENERAL_FOLDER_UID } from '../../search/constants';
+import { isRootFolderUID } from '../../search/constants';
 import { type BrowseDashboardsState } from '../types';
 import { isSharedWithMe, isVirtualTeamFolder } from '../utils/dashboards';
 
@@ -24,7 +24,7 @@ export function refetchChildrenFulfilled(state: BrowseDashboardsState, action: R
     isFullyLoaded: kind === 'dashboard' && lastPageOfKind,
   };
 
-  if (parentUID && parentUID !== GENERAL_FOLDER_UID) {
+  if (parentUID && !isRootFolderUID(parentUID)) {
     state.childrenByParentUID[parentUID] = newCollection;
   } else {
     state.rootItems = newCollection;

--- a/public/app/features/browse-dashboards/utils/notifications.ts
+++ b/public/app/features/browse-dashboards/utils/notifications.ts
@@ -1,7 +1,7 @@
 import { AppEvents } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
-import { GENERAL_FOLDER_UID } from 'app/features/search/constants';
+import { isRootFolderUID } from 'app/features/search/constants';
 
 import { type RestoreNotificationData } from '../types';
 
@@ -38,7 +38,7 @@ export function getRestoreNotificationData(
         targetUrl:
           successCount === 1
             ? `${config.appSubUrl}/d/${successful[0]}`
-            : !restoreTarget || restoreTarget === GENERAL_FOLDER_UID
+            : isRootFolderUID(restoreTarget)
               ? `${config.appSubUrl}/dashboards`
               : `${config.appSubUrl}/dashboards/f/${restoreTarget}`,
       },

--- a/public/app/features/dashboard/api/v1.ts
+++ b/public/app/features/dashboard/api/v1.ts
@@ -23,6 +23,7 @@ import {
 import { getDashboardUrl } from 'app/features/dashboard-scene/utils/getDashboardUrl';
 import { type DeleteDashboardResponse } from 'app/features/manage-dashboards/types';
 import { buildSourceLink, removeExistingSourceLinks } from 'app/features/provisioning/utils/sourceLink';
+import { isRootFolderUID } from 'app/features/search/constants';
 import { type DashboardDataDTO, type DashboardDTO, type SaveDashboardResponseDTO } from 'app/types/dashboard';
 
 import { type SaveDashboardCommand } from '../components/SaveDashboard/types';
@@ -200,9 +201,13 @@ export class K8sDashboardAPI implements DashboardAPI<DashboardDTO, Dashboard> {
         result.dashboard.id = parseInt(dash.metadata.labels[DeprecatedInternalId], 10);
       }
 
-      if (dash.metadata.annotations?.[AnnoKeyFolder]) {
+      const folderAnnotation = dash.metadata.annotations?.[AnnoKeyFolder];
+      // Root-parented dashboards carry "" or "general" — there is no folder
+      // resource to fetch. Leave folder fields unset so the UI renders the
+      // dashboard at the root.
+      if (folderAnnotation && !isRootFolderUID(folderAnnotation)) {
         try {
-          const folder = await getFolderByUidFacade(dash.metadata.annotations[AnnoKeyFolder]);
+          const folder = await getFolderByUidFacade(folderAnnotation);
           result.meta.folderTitle = folder.title;
           result.meta.folderUrl = folder.url;
           result.meta.folderUid = folder.uid;
@@ -214,7 +219,7 @@ export class K8sDashboardAPI implements DashboardAPI<DashboardDTO, Dashboard> {
           }
           // we still want to save the folder uid so that we can properly handle disabling the folder picker in Settings -> General
           // this is an edge case when user has edit access to a dashboard but doesn't have access to the folder
-          result.meta.folderUid = dash.metadata.annotations?.[AnnoKeyFolder];
+          result.meta.folderUid = folderAnnotation;
         }
       }
 

--- a/public/app/features/dashboard/api/v2.ts
+++ b/public/app/features/dashboard/api/v2.ts
@@ -20,6 +20,7 @@ import { convertSpecToWireFormat } from 'app/features/dashboard-scene/serializat
 import { getDashboardUrl } from 'app/features/dashboard-scene/utils/getDashboardUrl';
 import { type DeleteDashboardResponse } from 'app/features/manage-dashboards/types';
 import { buildSourceLink, removeExistingSourceLinks } from 'app/features/provisioning/utils/sourceLink';
+import { isRootFolderUID } from 'app/features/search/constants';
 import { type DashboardDTO, type SaveDashboardResponseDTO } from 'app/types/dashboard';
 
 import { type SaveDashboardCommand } from '../components/SaveDashboard/types';
@@ -62,10 +63,14 @@ export class K8sDashboardV2API
         throw new DashboardVersionError(dashboard.status.conversion.storedVersion, dashboard.status.conversion.error);
       }
 
-      // load folder info if available
-      if (dashboard.metadata.annotations && dashboard.metadata.annotations[AnnoKeyFolder]) {
+      // Load folder info for non-root dashboards. Root-parented dashboards
+      // ("", "general", or missing annotation) have no folder resource to
+      // fetch — normalise the annotation to "" so NestedFolderPicker treats
+      // them as living at the root.
+      const folderAnnotation = dashboard.metadata.annotations?.[AnnoKeyFolder];
+      if (dashboard.metadata.annotations && folderAnnotation && !isRootFolderUID(folderAnnotation)) {
         try {
-          const folder = await getFolderByUidFacade(dashboard.metadata.annotations[AnnoKeyFolder]);
+          const folder = await getFolderByUidFacade(folderAnnotation);
           dashboard.metadata.annotations[AnnoKeyFolderTitle] = folder.title;
           dashboard.metadata.annotations[AnnoKeyFolderUrl] = folder.url;
         } catch (e) {
@@ -74,10 +79,7 @@ export class K8sDashboardV2API
             throw new Error('Failed to load folder');
           }
         }
-      } else if (dashboard.metadata.annotations && !dashboard.metadata.annotations[AnnoKeyFolder]) {
-        // Set AnnoKeyFolder to empty string for top-level dashboards
-        // This ensures NestedFolderPicker correctly identifies it as being in the "Dashboard" root folder
-        // AnnoKeyFolder undefined -> top-level dashboard -> empty string
+      } else if (dashboard.metadata.annotations) {
         dashboard.metadata.annotations[AnnoKeyFolder] = '';
       }
 

--- a/public/app/features/provisioning/components/BulkActions/BulkDeleteProvisionedResource.tsx
+++ b/public/app/features/provisioning/components/BulkActions/BulkDeleteProvisionedResource.tsx
@@ -10,7 +10,7 @@ import { DescendantCount } from 'app/features/browse-dashboards/components/Brows
 import { collectSelectedItems } from 'app/features/browse-dashboards/utils/dashboards';
 import { JobStatus } from 'app/features/provisioning/Job/JobStatus';
 import { useGetResourceRepositoryView } from 'app/features/provisioning/hooks/useGetResourceRepositoryView';
-import { GENERAL_FOLDER_UID } from 'app/features/search/constants';
+import { isRootFolderUID } from 'app/features/search/constants';
 
 import { ProvisioningAlert } from '../../Shared/ProvisioningAlert';
 import { type StepStatusInfo } from '../../Wizard/types';
@@ -140,7 +140,7 @@ export function BulkDeleteProvisionedResource({
   onDismiss,
 }: BulkActionProvisionResourceProps) {
   // Check if we're on the root browser dashboards page
-  const isRootPage = !folderUid || folderUid === GENERAL_FOLDER_UID;
+  const isRootPage = isRootFolderUID(folderUid);
   const { selectedItemsRepoUID } = useSelectionRepoValidation(selectedItems);
 
   // Capture the repo UID so it survives selection state changes during/after job execution

--- a/public/app/features/provisioning/components/BulkActions/BulkMoveProvisionedResource.tsx
+++ b/public/app/features/provisioning/components/BulkActions/BulkMoveProvisionedResource.tsx
@@ -18,7 +18,7 @@ import {
   getDefaultWorkflow,
 } from 'app/features/provisioning/components/defaults';
 import { useGetResourceRepositoryView } from 'app/features/provisioning/hooks/useGetResourceRepositoryView';
-import { GENERAL_FOLDER_UID } from 'app/features/search/constants';
+import { isRootFolderUID } from 'app/features/search/constants';
 
 import { ProvisioningAlert } from '../../Shared/ProvisioningAlert';
 import { type StepStatusInfo } from '../../Wizard/types';
@@ -219,7 +219,7 @@ function FormContent({
 
 export function BulkMoveProvisionedResource({ folderUid, selectedItems, onDismiss }: BulkActionProvisionResourceProps) {
   // Check if we're on the root browser dashboards page
-  const isRootPage = !folderUid || folderUid === GENERAL_FOLDER_UID;
+  const isRootPage = isRootFolderUID(folderUid);
   const { selectedItemsRepoUID } = useSelectionRepoValidation(selectedItems);
 
   // Capture the repo UID so it survives selection state changes during/after job execution

--- a/public/app/features/search/constants.ts
+++ b/public/app/features/search/constants.ts
@@ -10,6 +10,19 @@ export const SEARCH_EXPANDED_FOLDER_STORAGE_KEY = 'grafana.search.expanded-folde
 export const GENERAL_FOLDER_ID = 0;
 export const GENERAL_FOLDER_UID = 'general';
 export const GENERAL_FOLDER_TITLE = 'Dashboards';
+
+/**
+ * Returns true when `uid` identifies the synthetic root folder. Two sentinels
+ * mean "root" across the codebase:
+ *   - "" / undefined (legacy empty folder annotation)
+ *   - "general" (canonical root UID)
+ *
+ * Mirrors the backend folder.IsRootFolderUID helper.
+ */
+export function isRootFolderUID(uid?: string): boolean {
+  return !uid || uid === GENERAL_FOLDER_UID;
+}
+
 export const SEARCH_PANELS_LOCAL_STORAGE_KEY = 'grafana.search.include.panels';
 export const SEARCH_SELECTED_LAYOUT = 'grafana.search.layout';
 export const SEARCH_SELECTED_LAYOUT_DELETED = 'grafana.search.layout.recently-deleted';

--- a/public/app/features/search/service/unified.ts
+++ b/public/app/features/search/service/unified.ts
@@ -22,6 +22,8 @@ import { contextSrv } from 'app/core/services/context_srv';
 import kbn from 'app/core/utils/kbn';
 import { dispatch } from 'app/store/store';
 
+import { isRootFolderUID } from '../constants';
+
 import { deletedDashboardsCache } from './deletedDashboardsCache';
 import {
   type DashboardQueryResult,
@@ -265,7 +267,10 @@ export class UnifiedSearcher implements GrafanaSearcher {
 
     const locationInfo = await this.locationInfo;
     const hits = rsp.hits.map((hit) => {
-      if (hit.folder === undefined) {
+      // Root-parented hits arrive with "" or "general" — neither lives in
+      // locationInfo, since the root folder is synthetic. Collapse to
+      // "general" so the UI renders the hit under the root.
+      if (isRootFolderUID(hit.folder)) {
         return { ...hit, folder: 'general' };
       }
 
@@ -284,7 +289,12 @@ export class UnifiedSearcher implements GrafanaSearcher {
   async isFolderCacheStale(hits: SearchHit[]): Promise<boolean> {
     const locationInfo = await this.locationInfo;
     return hits.some((hit) => {
-      return hit.folder !== undefined && locationInfo[hit.folder] === undefined;
+      // Root-parented hits ("" or "general") never appear in locationInfo —
+      // skip them so we don't reload the cache and remap them to "Shared with me".
+      if (isRootFolderUID(hit.folder)) {
+        return false;
+      }
+      return locationInfo[hit.folder] === undefined;
     });
   }
 
@@ -403,10 +413,11 @@ export function toDashboardResults(rsp: SearchAPIResponse, sort: string): DataFr
     return { fields: [], length: 0 };
   }
   const dashboardHits = hits.map((hit) => {
-    let location = hit.folder;
-    if (hit.resource === 'dashboards' && isEmpty(location)) {
-      location = 'general';
-    }
+    // Collapse root-parented dashboards ("" or "general") into the "general"
+    // UID the rest of the search UI uses as the parent for root items.
+    const isRoot = hit.resource === 'dashboards' && isRootFolderUID(hit.folder);
+    const location = isRoot ? 'general' : hit.folder;
+    const folder = isRoot ? 'general' : hit.folder || 'general';
 
     // display null field values as "-"
     const field = Object.fromEntries(
@@ -420,7 +431,7 @@ export function toDashboardResults(rsp: SearchAPIResponse, sort: string): DataFr
       // Sort tags so we aren't reliant on the backend having done this for us
       // Sorting order can be different between APIs/search implementations
       tags: (hit.tags || []).sort(),
-      folder: hit.folder || 'general',
+      folder,
       location,
       name: hit.title, // 🤯 FIXME hit.name is k8s name, eg grafana dashboards UID
       kind: hit.resource.substring(0, hit.resource.length - 1), // dashboard "kind" is not plural

--- a/public/app/features/search/service/utils.ts
+++ b/public/app/features/search/service/utils.ts
@@ -6,6 +6,7 @@ import { getDashboardSrv } from 'app/features/dashboard/services/DashboardSrv';
 import { type DashboardDataDTO } from 'app/types/dashboard';
 
 import { AnnoKeyFolder, AnnoKeyUpdatedBy, type ManagerKind, type ResourceList } from '../../apiserver/types';
+import { isRootFolderUID } from '../constants';
 import {
   type DashboardSearchHit,
   DashboardSearchItemType,
@@ -180,18 +181,19 @@ export function resourceToSearchResult(
       field.deletedBy = deletedByDisplayMap?.get(deletedByUid) ?? DELETED_BY_UNKNOWN;
     }
 
-    const hit = {
+    // Collapse root-parented items ("" or "general") into the "general" UID
+    // the rest of the search UI uses for the synthetic root folder.
+    const folderAnno = item?.metadata?.annotations?.[AnnoKeyFolder] ?? '';
+    const folder = isRootFolderUID(folderAnno) ? 'general' : folderAnno;
+    const hit: SearchHit = {
       resource: 'dashboards',
       name: item.metadata.name,
       title: item.spec?.title,
-      folder: item?.metadata?.annotations?.[AnnoKeyFolder] ?? 'general',
+      folder,
       tags: item.spec?.tags || [],
       field,
       url: '',
     };
-    if (!hit.folder) {
-      return { ...hit, folder: 'general' };
-    }
 
     return hit;
   });
@@ -209,7 +211,7 @@ export function searchHitsToDashboardSearchHits(searchHits: SearchHit[]): Dashbo
       sortMeta: 0, // Default value for deleted items
     };
 
-    if (hit.folder && hit.folder !== 'general') {
+    if (!isRootFolderUID(hit.folder)) {
       dashboardHit.folderUid = hit.folder;
     }
 


### PR DESCRIPTION
In an effort to always return a folder property when folders are supported (see https://github.com/grafana/grafana/pull/124623) we will need to behave the same in the frontend if you get `general` or `""` as the folder.

We already mostly do that.

This PR adds helpers and cleans up our existing behavior and does not include any backend changes