### PR TITLE
Browse Dashboards: Refresh old parent folder on save dashboard

### DIFF
--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.test.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.test.ts
@@ -1,7 +1,7 @@
-import { configureStore } from '@reduxjs/toolkit';
+import { configureStore, type Middleware, isAnyOf } from '@reduxjs/toolkit';
 import { http, HttpResponse } from 'msw';
 import { type Store } from 'redux';
-import { testWithFeatureToggles } from 'test/test-utils';
+import { testWithFeatureToggles, waitFor } from 'test/test-utils';
 
 import { folderAPIVersionResolver } from '@grafana/api-clients/rtkq/folder/v1beta1';
 import * as quotasAPI from '@grafana/api-clients/rtkq/quotas/v0alpha1';
@@ -414,6 +414,137 @@ describe('browseDashboardsAPI', () => {
       await store.dispatch(browseDashboardsAPI.endpoints.deleteFolders.initiate({ folderUIDs: ['folder-1'] }));
 
       expect(deleteSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('saveDashboard refreshes folder children', () => {
+    const dashboardUid = 'dash-1';
+    const oldFolderUid = 'folder-old';
+    const newFolderUid = 'folder-new';
+
+    const createStoreWithRefetchSpy = () => {
+      const refetchPendingArgs: Array<{ parentUID: string | undefined }> = [];
+      const recorder: Middleware = () => (next) => (action) => {
+        if (isAnyOf(refetchChildren.pending)(action)) {
+          refetchPendingArgs.push({ parentUID: action.meta.arg.parentUID });
+        }
+        return next(action);
+      };
+
+      const store = configureStore({
+        reducer: {
+          [browseDashboardsAPI.reducerPath]: browseDashboardsAPI.reducer,
+          [folderAPIv1beta1.reducerPath]: folderAPIv1beta1.reducer,
+          browseDashboards: browseDashboardsReducer,
+        },
+        middleware: (getDefaultMiddleware) =>
+          getDefaultMiddleware().concat(browseDashboardsAPI.middleware, folderAPIv1beta1.middleware, recorder),
+      });
+      setStore(store as unknown as Store);
+      return { store, refetchPendingArgs };
+    };
+
+    const seedDashboardInFolder = (store: ReturnType<typeof createStoreWithRefetchSpy>['store']) => {
+      // Populate childrenByParentUID[oldFolderUid] with the dashboard so getDashboardFolder finds it.
+      store.dispatch(
+        refetchChildren.fulfilled(
+          {
+            children: [
+              {
+                kind: 'dashboard',
+                uid: dashboardUid,
+                title: 'Test dashboard',
+                parentUID: oldFolderUid,
+              },
+            ],
+            kind: 'dashboard',
+            page: 1,
+            lastPageOfKind: true,
+          },
+          'test-request-id',
+          { parentUID: oldFolderUid, pageSize: PAGE_SIZE }
+        )
+      );
+    };
+
+    beforeEach(() => {
+      getDashboardAPIMock.mockImplementation(() =>
+        createMockDashboardAPI(jest.fn().mockResolvedValue({ uid: dashboardUid }))
+      );
+    });
+
+    it('refetches both new and previous parent folder when a v1 dashboard is moved', async () => {
+      const { store, refetchPendingArgs } = createStoreWithRefetchSpy();
+      seedDashboardInFolder(store);
+      // Drop the seed action from the recorder so we only assert on saveDashboard's dispatches.
+      refetchPendingArgs.length = 0;
+
+      const cmd: SaveDashboardCommand<Dashboard> = {
+        dashboard: { uid: dashboardUid, title: 'V1', panels: [], schemaVersion: 1 } as unknown as Dashboard,
+        folderUid: newFolderUid,
+      };
+
+      await store.dispatch(browseDashboardsAPI.endpoints.saveDashboard.initiate(cmd));
+
+      await waitFor(() => {
+        const parents = refetchPendingArgs.map((a) => a.parentUID);
+        expect(parents).toHaveLength(2);
+        expect(parents).toEqual(expect.arrayContaining([newFolderUid, oldFolderUid]));
+      });
+    });
+
+    it('refetches both new and previous parent folder when a v2 dashboard is moved (uid from k8s.name)', async () => {
+      const { store, refetchPendingArgs } = createStoreWithRefetchSpy();
+      seedDashboardInFolder(store);
+      refetchPendingArgs.length = 0;
+
+      const v2Dashboard: DashboardV2Spec = { title: 'V2', elements: [] } as unknown as DashboardV2Spec;
+      const cmd: SaveDashboardCommand<DashboardV2Spec> = {
+        dashboard: v2Dashboard,
+        folderUid: newFolderUid,
+        k8s: { name: dashboardUid },
+      };
+
+      await store.dispatch(browseDashboardsAPI.endpoints.saveDashboard.initiate(cmd));
+
+      await waitFor(() => {
+        const parents = refetchPendingArgs.map((a) => a.parentUID);
+        expect(parents).toHaveLength(2);
+        expect(parents).toEqual(expect.arrayContaining([newFolderUid, oldFolderUid]));
+      });
+    });
+
+    it('only refetches the target folder when the dashboard is saved to the same folder', async () => {
+      const { store, refetchPendingArgs } = createStoreWithRefetchSpy();
+      seedDashboardInFolder(store);
+      refetchPendingArgs.length = 0;
+
+      const cmd: SaveDashboardCommand<Dashboard> = {
+        dashboard: { uid: dashboardUid, title: 'V1', panels: [], schemaVersion: 1 } as unknown as Dashboard,
+        folderUid: oldFolderUid,
+      };
+
+      await store.dispatch(browseDashboardsAPI.endpoints.saveDashboard.initiate(cmd));
+
+      await waitFor(() => {
+        expect(refetchPendingArgs).toEqual([{ parentUID: oldFolderUid }]);
+      });
+    });
+
+    it('does not look up a previous folder when the dashboard is unknown to the store', async () => {
+      const { store, refetchPendingArgs } = createStoreWithRefetchSpy();
+      // No seedDashboardInFolder — store has no record of dashboardUid.
+
+      const cmd: SaveDashboardCommand<Dashboard> = {
+        dashboard: { uid: dashboardUid, title: 'V1', panels: [], schemaVersion: 1 } as unknown as Dashboard,
+        folderUid: newFolderUid,
+      };
+
+      await store.dispatch(browseDashboardsAPI.endpoints.saveDashboard.initiate(cmd));
+
+      await waitFor(() => {
+        expect(refetchPendingArgs).toEqual([{ parentUID: newFolderUid }]);
+      });
     });
   });
 });

--- a/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
+++ b/public/app/features/browse-dashboards/api/browseDashboardsAPI.ts
@@ -22,7 +22,7 @@ import { isDashboardV2Resource, isV1DashboardCommand, isV2DashboardCommand } fro
 import { type SaveDashboardCommand } from 'app/features/dashboard/components/SaveDashboard/types';
 import { dashboardWatcher } from 'app/features/live/dashboard/dashboardWatcher';
 import { TEAM_FOLDERS_UID } from 'app/features/search/constants';
-import { dispatch } from 'app/store/store';
+import { dispatch, getState } from 'app/store/store';
 import { type PermissionLevel } from 'app/types/acl';
 import { type ImportDashboardResponseDTO, type SaveDashboardResponseDTO } from 'app/types/dashboard';
 import {
@@ -35,6 +35,7 @@ import {
 import { getDashboardScenePageStateManager } from '../../dashboard-scene/pages/DashboardScenePageStateManager';
 import { deletedDashboardsCache } from '../../search/service/deletedDashboardsCache';
 import { refetchChildren, refreshParents } from '../state/actions';
+import { findItem } from '../state/utils';
 
 import { PAGE_SIZE } from './constants';
 import { isProvisionedDashboard } from './isProvisioned';
@@ -486,8 +487,18 @@ export const browseDashboardsAPI = createApi({
         }
       },
 
-      onQueryStarted: ({ folderUid, dashboard }, { queryFulfilled, dispatch }) => {
+      onQueryStarted: (cmd, { queryFulfilled, dispatch }) => {
+        const { folderUid, dashboard } = cmd;
         dashboardWatcher.ignoreNextSave();
+        const dashboardUid = isV1DashboardCommand(cmd) ? cmd.dashboard.uid : cmd.k8s?.name;
+
+        // Capture the dashboard's previous folder from the cache before save, so that
+        // if the user is moving it to a different folder we can invalidate the source
+        // folder's children cache. Without this, childrenByParentUID[previousFolderUid]
+        // stays stale and folder-select cascades in the list view incorrectly include
+        // the moved-out dashboard.
+        const previousFolderUid = getDashboardFolder(dashboardUid);
+
         queryFulfilled.then(async ({ data }) => {
           try {
             await contextSrv.fetchUserPermissions();
@@ -500,6 +511,15 @@ export const browseDashboardsAPI = createApi({
               pageSize: PAGE_SIZE,
             })
           );
+          // If the dashboard was moved, also refetch old parent folder
+          if (previousFolderUid !== undefined && previousFolderUid !== folderUid) {
+            dispatch(
+              refetchChildren({
+                parentUID: previousFolderUid,
+                pageSize: PAGE_SIZE,
+              })
+            );
+          }
           // version 1 means a newly created dashboard — only then does the resource count change
           if (data.version === 1) {
             invalidateQuotaUsage(dispatch);
@@ -616,6 +636,19 @@ export const browseDashboardsAPI = createApi({
     }),
   }),
 });
+
+/**
+ * Gets a parent folder of a dashboard from the cache in the store.
+ * @param dashboardUid
+ */
+function getDashboardFolder(dashboardUid?: string) {
+  if (dashboardUid) {
+    const { browseDashboards } = getState();
+    const item = findItem(browseDashboards.rootItems?.items ?? [], browseDashboards.childrenByParentUID, dashboardUid);
+    return item?.parentUID;
+  }
+  return undefined;
+}
 
 export const {
   endpoints,

--- a/public/app/features/browse-dashboards/state/utils.ts
+++ b/public/app/features/browse-dashboards/state/utils.ts
@@ -2,6 +2,13 @@ import { type DashboardViewItem } from 'app/features/search/types';
 
 import { type BrowseDashboardsState } from '../types';
 
+/**
+ * Finds item with the specific uid either in the root items or childrenByUID. This is just a convenience as browse
+ * dashboards store all the items in two separate structures.
+ * @param rootItems
+ * @param childrenByUID
+ * @param uid
+ */
 export function findItem(
   rootItems: DashboardViewItem[],
   childrenByUID: BrowseDashboardsState['childrenByParentUID'],


### PR DESCRIPTION
Fixes: https://github.com/grafana/grafana/issues/125322

Adds an old parent folder refresh to the save dashboard API call in case the save also moves the dashboard to a new folder.