### PR TITLE
Operators: Cleanup shutdown mechanisms.

### DIFF
--- a/pkg/operators/provisioning/connection_operator.go
+++ b/pkg/operators/provisioning/connection_operator.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"os/signal"
-	"syscall"
 
 	"github.com/grafana/grafana-app-sdk/logging"
 	"k8s.io/client-go/tools/cache"
@@ -19,7 +17,7 @@ import (
 )
 
 // RunConnectionController starts the connection controller operator.
-func RunConnectionController(deps server.OperatorDependencies) error {
+func RunConnectionController(ctx context.Context, deps server.OperatorDependencies) error {
 	logger := logging.NewSLogLogger(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 		Level: slog.LevelDebug,
 	})).With("logger", "provisioning-connection-controller")
@@ -29,17 +27,6 @@ func RunConnectionController(deps server.OperatorDependencies) error {
 	if err != nil {
 		return fmt.Errorf("failed to setup config: %w", err)
 	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
-	go func() {
-		<-sigChan
-		fmt.Println("Received shutdown signal, stopping controllers")
-		cancel()
-	}()
 
 	provisioningClient, err := controllerCfg.ProvisioningClient()
 	if err != nil {

--- a/pkg/operators/provisioning/jobqueue_operator.go
+++ b/pkg/operators/provisioning/jobqueue_operator.go
@@ -5,9 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"os/signal"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/grafana/grafana-app-sdk/logging"
@@ -21,7 +19,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-func RunJobQueueController(deps server.OperatorDependencies) error {
+func RunJobQueueController(ctx context.Context, deps server.OperatorDependencies) error {
 	logger := logging.NewSLogLogger(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 		Level: slog.LevelDebug,
 	})).With("logger", "provisioning-jobqueue-controller")
@@ -36,17 +34,6 @@ func RunJobQueueController(deps server.OperatorDependencies) error {
 	if err != nil {
 		return fmt.Errorf("failed to provide tracing service: %w", err)
 	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
-	go func() {
-		<-sigChan
-		logger.Info("Received shutdown signal, stopping controllers")
-		cancel()
-	}()
 
 	provisioningClient, err := controllerCfg.ProvisioningClient()
 	if err != nil {

--- a/pkg/operators/provisioning/jobs_operator.go
+++ b/pkg/operators/provisioning/jobs_operator.go
@@ -5,9 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"os/signal"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/grafana/grafana-app-sdk/logging"
@@ -21,7 +19,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 )
 
-func RunJobController(deps server.OperatorDependencies) error {
+func RunJobController(ctx context.Context, deps server.OperatorDependencies) error {
 	logger := logging.NewSLogLogger(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 		Level: slog.LevelDebug,
 	})).With("logger", "provisioning-job-controller")
@@ -36,17 +34,6 @@ func RunJobController(deps server.OperatorDependencies) error {
 	if err != nil {
 		return fmt.Errorf("failed to provide tracing service: %w", err)
 	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
-	go func() {
-		<-sigChan
-		logger.Info("Received shutdown signal, stopping controllers")
-		cancel()
-	}()
 
 	provisioningClient, err := controllerCfg.ProvisioningClient()
 	if err != nil {

--- a/pkg/operators/provisioning/repo_operator.go
+++ b/pkg/operators/provisioning/repo_operator.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
-	"os/signal"
-	"syscall"
 	"time"
 
 	"github.com/grafana/grafana-app-sdk/logging"
@@ -23,7 +21,7 @@ import (
 	informer "github.com/grafana/grafana/apps/provisioning/pkg/generated/informers/externalversions"
 )
 
-func RunRepoController(deps server.OperatorDependencies) error {
+func RunRepoController(ctx context.Context, deps server.OperatorDependencies) error {
 	logger := logging.NewSLogLogger(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
 		Level: slog.LevelDebug,
 	})).With("logger", "provisioning-repo-controller")
@@ -33,17 +31,6 @@ func RunRepoController(deps server.OperatorDependencies) error {
 	if err != nil {
 		return fmt.Errorf("failed to setup provisioning controller: %w", err)
 	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
-	go func() {
-		<-sigChan
-		fmt.Println("Received shutdown signal, stopping controllers")
-		cancel()
-	}()
 
 	provisioningClient, err := controllerCfg.ProvisioningClient()
 	if err != nil {

--- a/pkg/server/module_server.go
+++ b/pkg/server/module_server.go
@@ -413,7 +413,7 @@ func (s *ModuleServer) initOperatorServer() (services.Service, error) {
 						Registerer:     s.registerer,
 						HealthNotifier: s.healthNotifier,
 					}
-					return op.RunFunc(deps)
+					return op.RunFunc(ctx, deps)
 				},
 				nil,
 			).WithName("operator"), nil

--- a/pkg/server/operator.go
+++ b/pkg/server/operator.go
@@ -1,6 +1,8 @@
 package server
 
 import (
+	"context"
+
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/grafana/grafana/pkg/services/apiserver/standalone"
@@ -21,7 +23,7 @@ type OperatorDependencies struct {
 type Operator struct {
 	Name        string
 	Description string
-	RunFunc     func(deps OperatorDependencies) error
+	RunFunc     func(ctx context.Context, deps OperatorDependencies) error
 }
 
 var operatorsRegistry []Operator


### PR DESCRIPTION
Currently each of the operators listens for signals to shutdown, but this is
not necessary as they are run from dskit services which provide a Context which
will be cancelled on shutdown. Propagate this and use it instead.
