### PR TITLE
CI: Update ephemeral-instances-pr-comment

### DIFF
--- a/.github/workflows/ephemeral-instances-pr-comment.yml
+++ b/.github/workflows/ephemeral-instances-pr-comment.yml
@@ -26,7 +26,7 @@ jobs:
         id: generate_token
         uses: grafana/shared-workflows/actions/create-github-app-token@ae92934a14a48b94494dbc06d74a81d47fe08a40 # create-github-app-token/v0.2.2
         with:
-          github_app: grafana-releases-oss
+          github_app: ephemeral-instances-bot
 
       - name: Dispatch (comment)
         if: github.event_name == 'issue_comment'


### PR DESCRIPTION
Use the new bot for triggering the `gh workflow run` command, which needs `actions:write`