### PR TITLE
PublicDashboards: Close plugin list response body

### DIFF
--- a/pkg/services/publicdashboards/internal/commands/generate_datasources/generate.go
+++ b/pkg/services/publicdashboards/internal/commands/generate_datasources/generate.go
@@ -61,6 +61,8 @@ func getDatasourcePluginSlugs(baseUrl string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = resp.Body.Close() }()
+
 	res := &listPluginResponse{}
 	err = json.NewDecoder(resp.Body).Decode(res)
 	if err != nil {
@@ -70,7 +72,6 @@ func getDatasourcePluginSlugs(baseUrl string) ([]string, error) {
 	for _, meta := range res.Items {
 		slugs = append(slugs, meta.Slug)
 	}
-	_ = resp.Body.Close()
 	return slugs, nil
 }
 

--- a/pkg/services/publicdashboards/internal/commands/generate_datasources/main_test.go
+++ b/pkg/services/publicdashboards/internal/commands/generate_datasources/main_test.go
@@ -1,14 +1,32 @@
 package generate_datasources
 
 import (
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (fn roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return fn(req)
+}
+
+type closeTrackingBody struct {
+	io.Reader
+	closed *bool
+}
+
+func (b *closeTrackingBody) Close() error {
+	*b.closed = true
+	return nil
+}
 
 func TestCanGetCompatibleDatasources(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -42,4 +60,28 @@ func TestCanGetCompatibleDatasources(t *testing.T) {
 	for i := range expectedDatasources {
 		assert.Equal(t, expectedDatasources[i], datasources[i])
 	}
+}
+
+func TestGetDatasourcePluginSlugsClosesBodyOnDecodeError(t *testing.T) {
+	originalTransport := http.DefaultTransport
+	t.Cleanup(func() {
+		http.DefaultTransport = originalTransport
+	})
+
+	closed := false
+	http.DefaultTransport = roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body: &closeTrackingBody{
+				Reader: strings.NewReader("{"),
+				closed: &closed,
+			},
+			Header: make(http.Header),
+		}, nil
+	})
+
+	_, err := getDatasourcePluginSlugs("http://example.com")
+
+	require.Error(t, err)
+	require.True(t, closed)
 }


### PR DESCRIPTION
**What is this feature?**

  Closes the plugin list response body with a defer in `getDatasourcePluginSlugs`.

  **Why do we need this feature?**

  The response body was closed on the successful path, but a JSON decode error returned before the close. Moving it into a defer keeps the existing behavior and also releases the body on that error path.

  **Who is this feature for?**

  Anyone running the public dashboard datasource generation command.

  **Which issue(s) does this PR fix?**:

  Fixes #125275

  **Special notes for your reviewer:**

  Added a regression test for the decode-error path.

  Tested with:
  - `go test -v ./pkg/services/publicdashboards/internal/commands/generate_datasources`
  - `$env:GOMAXPROCS='2'; go test -p 1 ./pkg/services/publicdashboards/...`

  Please check that:
  - [x] It works as expected from a user's perspective.
  - [ ] If this is a pre-GA feature, it is behind a feature toggle.
  - [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.