### PR TITLE
Mutation API: improvements demo (stacked on #123501)

### DIFF
--- a/packages/grafana-data/src/types/featureToggles.gen.ts
+++ b/packages/grafana-data/src/types/featureToggles.gen.ts
@@ -379,6 +379,11 @@ export interface FeatureToggles {
   */
   dashboardUndoRedo?: boolean;
   /**
+  * Routes variable editor add/update/delete through the Dashboard Mutation API instead of direct Scenes mutations
+  * @default false
+  */
+  dashboardMutationApiVariablePilot?: boolean;
+  /**
   * Enables unlimited dashboard panel grouping
   * @default false
   */

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -661,6 +661,14 @@ var (
 			Expression:  "false",
 		},
 		{
+			Name:        "dashboardMutationApiVariablePilot",
+			Description: "Routes variable editor add/update/delete through the Dashboard Mutation API instead of direct Scenes mutations",
+			Stage:       FeatureStageExperimental,
+			Generate:    Generate{LegacyFrontend: true},
+			Owner:       grafanaDashboardsSquad,
+			Expression:  "false",
+		},
+		{
 			Name:        "unlimitedLayoutsNesting",
 			Description: "Enables unlimited dashboard panel grouping",
 			Stage:       FeatureStageExperimental,

--- a/pkg/services/featuremgmt/toggles_gen.csv
+++ b/pkg/services/featuremgmt/toggles_gen.csv
@@ -75,6 +75,7 @@ Created,Name,Stage,Owner,requiresDevMode,RequiresRestart,FrontendOnly
 2026-03-19,dashboardDefaultLayoutSelector,GA,@grafana/dashboards-squad,false,false,true
 2026-03-10,dashboardAssistantPopover,experimental,@grafana/dashboards-squad,false,false,true
 2025-08-29,dashboardUndoRedo,experimental,@grafana/dashboards-squad,false,false,true
+2026-04-28,dashboardMutationApiVariablePilot,experimental,@grafana/dashboards-squad,false,false,true
 2025-10-10,unlimitedLayoutsNesting,experimental,@grafana/dashboards-squad,false,false,true
 2026-02-11,sceneCsvExport,GA,@grafana/dashboards-squad,false,false,false
 2025-12-17,drilldownRecommendations,experimental,@grafana/dashboards-squad,false,false,true

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -235,10 +235,6 @@ const (
 	// Enables new dashboard layouts
 	FlagDashboardNewLayouts = "dashboardNewLayouts"
 
-	// FlagDashboardMutationApiVariablePilot
-	// Routes variable editor add/update/delete through the Dashboard Mutation API instead of direct Scenes mutations
-	FlagDashboardMutationApiVariablePilot = "dashboardMutationApiVariablePilot"
-
 	// FlagSceneCsvExport
 	// Enables CSV export using scenes dashboard architecture
 	FlagSceneCsvExport = "sceneCsvExport"

--- a/pkg/services/featuremgmt/toggles_gen.go
+++ b/pkg/services/featuremgmt/toggles_gen.go
@@ -235,6 +235,10 @@ const (
 	// Enables new dashboard layouts
 	FlagDashboardNewLayouts = "dashboardNewLayouts"
 
+	// FlagDashboardMutationApiVariablePilot
+	// Routes variable editor add/update/delete through the Dashboard Mutation API instead of direct Scenes mutations
+	FlagDashboardMutationApiVariablePilot = "dashboardMutationApiVariablePilot"
+
 	// FlagSceneCsvExport
 	// Enables CSV export using scenes dashboard architecture
 	FlagSceneCsvExport = "sceneCsvExport"

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -1578,6 +1578,20 @@
     },
     {
       "metadata": {
+        "name": "dashboardMutationApiVariablePilot",
+        "resourceVersion": "1777379752461",
+        "creationTimestamp": "2026-04-28T12:35:52Z"
+      },
+      "spec": {
+        "description": "Routes variable editor add/update/delete through the Dashboard Mutation API instead of direct Scenes mutations",
+        "stage": "experimental",
+        "codeowner": "@grafana/dashboards-squad",
+        "frontend": true,
+        "expression": "false"
+      }
+    },
+    {
+      "metadata": {
         "name": "dashboardNewLayouts",
         "resourceVersion": "1775209187023",
         "creationTimestamp": "2024-10-23T08:55:45Z",

--- a/public/app/features/dashboard-scene/edit-pane/shared.ts
+++ b/public/app/features/dashboard-scene/edit-pane/shared.ts
@@ -14,6 +14,7 @@ import {
 } from '@grafana/scenes';
 import { type ElementSelectionContextItem } from '@grafana/ui';
 
+import { cmd } from '../mutation-api/cmd';
 import { DashboardDataLayerSet } from '../scene/DashboardDataLayerSet';
 import { DashboardScene } from '../scene/DashboardScene';
 import { SceneGridRowEditableElement } from '../scene/layout-default/SceneGridRowEditableElement';
@@ -26,6 +27,7 @@ import { LocalVariableEditableElement } from '../settings/variables/LocalVariabl
 import { VariableEditableElement } from '../settings/variables/VariableEditableElement';
 import { VariableSetEditableElement } from '../settings/variables/VariableSetEditableElement';
 import { isSceneVariable } from '../settings/variables/utils';
+import { getDashboardSceneFor } from '../utils/utils';
 
 import { type DashboardEditPane } from './DashboardEditPane';
 import { MultiSelectedObjectsEditableElement } from './MultiSelectedObjectsEditableElement';
@@ -250,32 +252,14 @@ export const dashboardEditActions = {
   }),
 
   addVariable({ source, addedObject }: AddVariableActionHelperProps) {
-    const varsBeforeAddition = [...(source.state.variables ?? [])];
-
-    dashboardEditActions.addElement({
-      source,
-      addedObject,
-      perform() {
-        source.setState({ variables: [...varsBeforeAddition, addedObject] });
-      },
-      undo() {
-        source.setState({ variables: [...varsBeforeAddition] });
-      },
-    });
+    const dashboard = getDashboardSceneFor(source);
+    // UI path: SceneVariable goes through the Scenes-native overload of cmd.addVariable.
+    // The Mutation API routes it via __scenesPayload, no Zod, snapshot undo registered automatically.
+    dashboard.mutationClient.execute(cmd.addVariable(addedObject));
   },
   removeVariable({ source, removedObject }: RemoveVariableActionHelperProps) {
-    const varsBeforeRemoval = [...source.state.variables];
-
-    dashboardEditActions.removeElement({
-      source,
-      removedObject,
-      perform() {
-        source.setState({ variables: varsBeforeRemoval.filter((v) => v !== removedObject) });
-      },
-      undo() {
-        source.setState({ variables: varsBeforeRemoval });
-      },
-    });
+    const dashboard = getDashboardSceneFor(source);
+    dashboard.mutationClient.execute(cmd.removeVariable(removedObject));
   },
   changeVariableType({ source, oldVariable, newVariable }: ChangeVariableTypeActionHelperProps) {
     const varsBeforeChange = [...source.state.variables];

--- a/public/app/features/dashboard-scene/edit-pane/shared.ts
+++ b/public/app/features/dashboard-scene/edit-pane/shared.ts
@@ -255,11 +255,20 @@ export const dashboardEditActions = {
     const dashboard = getDashboardSceneFor(source);
     // UI path: SceneVariable goes through the Scenes-native overload of cmd.addVariable.
     // The Mutation API routes it via __scenesPayload, no Zod, snapshot undo registered automatically.
-    dashboard.mutationClient.execute(cmd.addVariable(addedObject));
+    dashboard.mutationClient.execute(cmd.addVariable(addedObject)).then((result) => {
+      if (!result.success) {
+        // TODO(POC): surface to UI as toast/banner. For now, log so the failure isn't silent.
+        console.warn('addVariable failed', { error: result.error, locked: result.locked });
+      }
+    });
   },
   removeVariable({ source, removedObject }: RemoveVariableActionHelperProps) {
     const dashboard = getDashboardSceneFor(source);
-    dashboard.mutationClient.execute(cmd.removeVariable(removedObject));
+    dashboard.mutationClient.execute(cmd.removeVariable(removedObject)).then((result) => {
+      if (!result.success) {
+        console.warn('removeVariable failed', { error: result.error, locked: result.locked });
+      }
+    });
   },
   changeVariableType({ source, oldVariable, newVariable }: ChangeVariableTypeActionHelperProps) {
     const varsBeforeChange = [...source.state.variables];

--- a/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
+++ b/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
@@ -63,55 +63,47 @@ export class DashboardMutationClient implements MutationClient {
 
     const context: MutationContext = { scene: this.scene };
 
+    // Snapshot variable state before the mutation for undo/redo wiring.
+    // This follows the same snapshot pattern used by dashboardEditActions in shared.ts.
+    const varsBefore = this.scene.state.$variables?.state.variables.slice() ?? [];
+    const varSetBefore = this.scene.state.$variables;
+
     try {
       const result = await registration.handler(payload, context);
 
       if (result.success && !registration.readOnly) {
         this.scene.forceRender();
+
+        // Wire into the DashboardEditPane undo/redo history system when the variable
+        // set changed. Mutation was already applied inside the handler, so perform()
+        // skips its first call and re-applies on subsequent redo calls.
+        const varSetAfter = this.scene.state.$variables;
+        if (varSetAfter !== varSetBefore && typeof this.scene.publishEvent === 'function') {
+          const varsAfter = varSetAfter!.state.variables.slice();
+          const scene = this.scene;
+          let alreadyPerformed = true;
+
+          this.scene.publishEvent(
+            new DashboardEditActionEvent({
+              source: this.scene,
+              description: type,
+              perform() {
+                if (alreadyPerformed) {
+                  alreadyPerformed = false;
+                  return;
+                }
+                scene.state.$variables?.setState({ variables: varsAfter });
+              },
+              undo() {
+                scene.state.$variables?.setState({ variables: varsBefore });
+              },
+            }),
+            true
+          );
+        }
       }
 
-      // Wire undo/redo into the DashboardEditPane event system when the command
-      // provides an _undo callback. The mutation has already been applied at this
-      // point, so perform() is a no-op for the initial registration. The DashboardEditPane
-      // handleEditAction calls perform() immediately then pushes to undoStack.
-      // When redo is invoked, performAction calls perform() again -- at that point
-      // the _undo has already restored the previous state, so perform() must
-      // re-apply the mutation. We capture the current variables state here to
-      // use as the "redo" snapshot (state after the mutation).
-      if (result.success && result._undo && typeof this.scene.publishEvent === 'function') {
-        const undoFn = result._undo;
-        const description = result._description ?? mutation.type;
-        // Capture the post-mutation variable state for redo.
-        const varSet = this.scene.state.$variables;
-        const variablesAfterMutation = varSet ? varSet.state.variables.slice() : [];
-        const scene = this.scene;
-
-        let alreadyPerformed = true;
-
-        this.scene.publishEvent(
-          new DashboardEditActionEvent({
-            source: this.scene,
-            description,
-            perform: () => {
-              // First call is a no-op because mutation was already applied.
-              if (alreadyPerformed) {
-                alreadyPerformed = false;
-                return;
-              }
-              // Subsequent calls (redo): restore the post-mutation state.
-              if (scene.state.$variables) {
-                scene.state.$variables.setState({ variables: variablesAfterMutation });
-              }
-            },
-            undo: undoFn,
-          }),
-          true
-        );
-      }
-
-      // Strip internal fields before returning to callers.
-      const { _undo: _u, _description: _d, ...publicResult } = result;
-      return publicResult;
+      return result;
     } catch (error) {
       return {
         success: false,

--- a/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
+++ b/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
@@ -52,14 +52,19 @@ export class DashboardMutationClient implements MutationClient {
       return { success: false, error: permissionResult.error, changes: [] };
     }
 
-    const validationResult = validatePayload(type, mutation.payload);
-    if (!validationResult.success) {
-      return { success: false, error: validationResult.error, changes: [] };
+    let payload: unknown;
+    if ('__scenesPayload' in mutation) {
+      // UI path: SceneObject passed directly — skip Zod validation and forward transformer.
+      payload = { __scenesPayload: mutation.__scenesPayload };
+    } else {
+      const validationResult = validatePayload(type, mutation.payload);
+      if (!validationResult.success) {
+        return { success: false, error: validationResult.error, changes: [] };
+      }
+      // Zod may return frozen or shared default objects. Deep-clone write payloads
+      // so downstream code (e.g. getPanelOptionsWithDefaults) can mutate in-place.
+      payload = registration.readOnly ? validationResult.data : structuredClone(validationResult.data);
     }
-
-    // Zod may return frozen or shared default objects. Deep-clone write payloads
-    // so downstream code (e.g. getPanelOptionsWithDefaults) can mutate in-place.
-    const payload = registration.readOnly ? validationResult.data : structuredClone(validationResult.data);
 
     const context: MutationContext = { scene: this.scene };
 

--- a/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
+++ b/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
@@ -18,6 +18,7 @@ import type { DashboardScene } from '../scene/DashboardScene';
 
 import { ALL_COMMANDS, validatePayload } from './commands/registry';
 import type { MutationCommand, MutationContext } from './commands/types';
+import { replaceVariableSet } from './commands/variableUtils';
 import type { MutationClient, MutationRequest, MutationResult } from './types';
 
 type MutationHandler = (payload: unknown, context: MutationContext) => Promise<MutationResult>;
@@ -68,10 +69,11 @@ export class DashboardMutationClient implements MutationClient {
 
     const context: MutationContext = { scene: this.scene };
 
-    // Snapshot variable state before the mutation for undo/redo wiring.
-    // This follows the same snapshot pattern used by dashboardEditActions in shared.ts.
-    const varsBefore = this.scene.state.$variables?.state.variables.slice() ?? [];
+    // Capture the variable set reference and variable array before the handler runs.
+    // replaceVariableSet (used by all variable commands) always creates a new
+    // SceneVariableSet instance, so identity comparison detects any variable mutation.
     const varSetBefore = this.scene.state.$variables;
+    const varsBefore = varSetBefore?.state.variables.slice() ?? [];
 
     try {
       const result = await registration.handler(payload, context);
@@ -79,28 +81,29 @@ export class DashboardMutationClient implements MutationClient {
       if (result.success && !registration.readOnly) {
         this.scene.forceRender();
 
-        // Wire into the DashboardEditPane undo/redo history system when the variable
-        // set changed. Mutation was already applied inside the handler, so perform()
-        // skips its first call and re-applies on subsequent redo calls.
+        // Register undo/redo when the variable set was replaced by the handler.
+        // Both callbacks use replaceVariableSet to ensure proper SceneVariableSet
+        // lifecycle (child variable activation) on each undo/redo cycle.
         const varSetAfter = this.scene.state.$variables;
         if (varSetAfter !== varSetBefore && typeof this.scene.publishEvent === 'function') {
           const varsAfter = varSetAfter!.state.variables.slice();
           const scene = this.scene;
-          let alreadyPerformed = true;
+          // The mutation is already applied; skip the first perform() call from handleEditAction.
+          let firstPerform = true;
 
           this.scene.publishEvent(
             new DashboardEditActionEvent({
               source: this.scene,
               description: type,
               perform() {
-                if (alreadyPerformed) {
-                  alreadyPerformed = false;
+                if (firstPerform) {
+                  firstPerform = false;
                   return;
                 }
-                scene.state.$variables?.setState({ variables: varsAfter });
+                replaceVariableSet(scene, varsAfter);
               },
               undo() {
-                scene.state.$variables?.setState({ variables: varsBefore });
+                replaceVariableSet(scene, varsBefore);
               },
             }),
             true

--- a/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
+++ b/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
@@ -13,11 +13,13 @@
  * 3. Payload validation (does the payload match the Zod schema?)
  */
 
+import { type SceneVariable } from '@grafana/scenes';
+
 import { DashboardEditActionEvent } from '../edit-pane/events';
 import type { DashboardScene } from '../scene/DashboardScene';
 
 import { ALL_COMMANDS, validatePayload } from './commands/registry';
-import type { MutationCommand, MutationContext } from './commands/types';
+import type { MutationCommand, MutationContext, UndoDomain } from './commands/types';
 import { replaceVariableSet } from './commands/variableUtils';
 import type { MutationClient, MutationRequest, MutationResult } from './types';
 
@@ -27,6 +29,7 @@ interface CommandRegistration {
   handler: MutationHandler;
   canExecute: (scene: DashboardScene) => { allowed: true } | { allowed: false; error: string };
   readOnly: boolean;
+  undoDomain?: UndoDomain;
 }
 
 export class DashboardMutationClient implements MutationClient {
@@ -69,11 +72,9 @@ export class DashboardMutationClient implements MutationClient {
 
     const context: MutationContext = { scene: this.scene };
 
-    // Capture the variable set reference and variable array before the handler runs.
-    // replaceVariableSet (used by all variable commands) always creates a new
-    // SceneVariableSet instance, so identity comparison detects any variable mutation.
-    const varSetBefore = this.scene.state.$variables;
-    const varsBefore = varSetBefore?.state.variables.slice() ?? [];
+    // Snapshot the declared domain before the handler runs.
+    const { undoDomain } = registration;
+    const beforeSnapshot = undoDomain ? this.snapshotDomain(undoDomain) : undefined;
 
     try {
       const result = await registration.handler(payload, context);
@@ -81,30 +82,25 @@ export class DashboardMutationClient implements MutationClient {
       if (result.success && !registration.readOnly) {
         this.scene.forceRender();
 
-        // Register undo/redo when the variable set was replaced by the handler.
-        // Both callbacks use replaceVariableSet to ensure proper SceneVariableSet
-        // lifecycle (child variable activation) on each undo/redo cycle.
-        const varSetAfter = this.scene.state.$variables;
-        if (varSetAfter !== varSetBefore && typeof this.scene.publishEvent === 'function') {
-          const varsAfter = varSetAfter!.state.variables.slice();
-          const scene = this.scene;
-          // The mutation is already applied; skip the first perform() call from handleEditAction.
+        // Register undo/redo entry when the command declared a snapshot domain.
+        // perform() is called immediately by DashboardEditPane.handleEditAction —
+        // the mutation is already applied so we skip that first call.
+        if (undoDomain && beforeSnapshot && typeof this.scene.publishEvent === 'function') {
+          const afterSnapshot = this.snapshotDomain(undoDomain);
           let firstPerform = true;
 
           this.scene.publishEvent(
             new DashboardEditActionEvent({
               source: this.scene,
               description: type,
-              perform() {
+              perform: () => {
                 if (firstPerform) {
                   firstPerform = false;
                   return;
                 }
-                replaceVariableSet(scene, varsAfter);
+                this.restoreDomain(undoDomain, afterSnapshot);
               },
-              undo() {
-                replaceVariableSet(scene, varsBefore);
-              },
+              undo: () => this.restoreDomain(undoDomain, beforeSnapshot),
             }),
             true
           );
@@ -125,12 +121,26 @@ export class DashboardMutationClient implements MutationClient {
     return Array.from(this.commands.keys());
   }
 
+  private snapshotDomain(domain: UndoDomain): SceneVariable[] {
+    if (domain === 'variables') {
+      return this.scene.state.$variables?.state.variables.slice() ?? [];
+    }
+    return [];
+  }
+
+  private restoreDomain(domain: UndoDomain, snapshot: SceneVariable[]): void {
+    if (domain === 'variables') {
+      replaceVariableSet(this.scene, snapshot);
+    }
+  }
+
   private registerCommand(cmd: MutationCommand): void {
     this.commands.set(cmd.name, {
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- safe: client validates with Zod before dispatch
       handler: cmd.handler as MutationHandler,
       canExecute: cmd.permission,
       readOnly: cmd.readOnly ?? false,
+      undoDomain: cmd.undoDomain,
     });
   }
 }

--- a/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
+++ b/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
@@ -13,6 +13,7 @@
  * 3. Payload validation (does the payload match the Zod schema?)
  */
 
+import { DashboardEditActionEvent } from '../edit-pane/events';
 import type { DashboardScene } from '../scene/DashboardScene';
 
 import { ALL_COMMANDS, validatePayload } from './commands/registry';
@@ -69,7 +70,48 @@ export class DashboardMutationClient implements MutationClient {
         this.scene.forceRender();
       }
 
-      return result;
+      // Wire undo/redo into the DashboardEditPane event system when the command
+      // provides an _undo callback. The mutation has already been applied at this
+      // point, so perform() is a no-op for the initial registration. The DashboardEditPane
+      // handleEditAction calls perform() immediately then pushes to undoStack.
+      // When redo is invoked, performAction calls perform() again -- at that point
+      // the _undo has already restored the previous state, so perform() must
+      // re-apply the mutation. We capture the current variables state here to
+      // use as the "redo" snapshot (state after the mutation).
+      if (result.success && result._undo && typeof this.scene.publishEvent === 'function') {
+        const undoFn = result._undo;
+        const description = result._description ?? mutation.type;
+        // Capture the post-mutation variable state for redo.
+        const varSet = this.scene.state.$variables;
+        const variablesAfterMutation = varSet ? varSet.state.variables.slice() : [];
+        const scene = this.scene;
+
+        let alreadyPerformed = true;
+
+        this.scene.publishEvent(
+          new DashboardEditActionEvent({
+            source: this.scene,
+            description,
+            perform: () => {
+              // First call is a no-op because mutation was already applied.
+              if (alreadyPerformed) {
+                alreadyPerformed = false;
+                return;
+              }
+              // Subsequent calls (redo): restore the post-mutation state.
+              if (scene.state.$variables) {
+                scene.state.$variables.setState({ variables: variablesAfterMutation });
+              }
+            },
+            undo: undoFn,
+          }),
+          true
+        );
+      }
+
+      // Strip internal fields before returning to callers.
+      const { _undo: _u, _description: _d, ...publicResult } = result;
+      return publicResult;
     } catch (error) {
       return {
         success: false,

--- a/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
+++ b/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
@@ -1,27 +1,23 @@
 /**
  * Dashboard Mutation Client
  *
- * API for programmatic dashboard mutations. Provides
- * a declarative, command-based API where callers describe *what* to
- * change (e.g. ADD_VARIABLE, UPDATE_VARIABLE) and the client handles Scenes
- * internals, payload validation (via Zod schemas), permission checks, and
- * transactional execution with structured error responses.
+ * API for programmatic dashboard mutations. The client owns:
+ *   - command lookup,
+ *   - permission + lock checks,
+ *   - payload validation (Zod),
+ *   - per-undoDomain serialization (the "execute queue").
  *
- * Each mutation goes through:
- * 1. Command lookup (is it a registered command?)
- * 2. Permission check (can the user edit this dashboard?)
- * 3. Payload validation (does the payload match the Zod schema?)
+ * Snapshot/restore + history publishing are delegated to MutationRecorder
+ * on DashboardScene. That keeps this class focused on dispatch concerns
+ * and lets other callers (plugin host, future MCP gateway) share the same
+ * recorder without going through this class.
  */
 
-import type { SceneObject } from '@grafana/scenes';
-
-import { DashboardEditActionEvent } from '../edit-pane/events';
 import type { DashboardScene } from '../scene/DashboardScene';
 
 import { ALL_COMMANDS, validatePayload } from './commands/registry';
 import type { MutationCommand, MutationContext, UndoDomain } from './commands/types';
 import type { MutationClient, MutationRequest, MutationResult } from './types';
-import { getUndoDomain } from './undo-domains';
 
 type MutationHandler = (payload: unknown, context: MutationContext) => Promise<MutationResult>;
 
@@ -36,12 +32,6 @@ interface CommandRegistration {
   canCoalesceWith?: (previousPayload: any, gapMs: number) => boolean;
 }
 
-interface LastEntry {
-  type: string;
-  payload: unknown;
-  publishedAt: number;
-}
-
 export class DashboardMutationClient implements MutationClient {
   private scene: DashboardScene;
   private commands: Map<string, CommandRegistration> = new Map();
@@ -53,8 +43,6 @@ export class DashboardMutationClient implements MutationClient {
    * queue.
    */
   private domainQueues: Map<UndoDomain, Promise<unknown>> = new Map();
-  /** Track the last published entry so we can coalesce rapid same-command writes. */
-  private lastEntry?: LastEntry;
 
   constructor(scene: DashboardScene) {
     this.scene = scene;
@@ -111,104 +99,28 @@ export class DashboardMutationClient implements MutationClient {
       if (!validationResult.success) {
         return { success: false, error: validationResult.error, changes: [] };
       }
-      // Zod may return frozen or shared default objects. Deep-clone write payloads
-      // so downstream code (e.g. getPanelOptionsWithDefaults) can mutate in-place.
       payload = registration.readOnly ? validationResult.data : structuredClone(validationResult.data);
     }
 
     const context: MutationContext = { scene: this.scene };
 
-    // Snapshot each declared domain before the handler runs.
-    // Snapshot/restore is delegated to the per-domain registry in `undo-domains.ts`.
-    const { undoDomains } = registration;
-    const beforeSnapshots = new Map<UndoDomain, unknown>();
-    for (const d of undoDomains) {
-      beforeSnapshots.set(d, this.snapshotDomain(d));
-    }
+    // Delegate snapshot + publish to the recorder. The recorder runs the
+    // handler between the before/after snapshots and handles coalescing,
+    // conflict detection, and event publishing.
+    const recorderOptions = {
+      type,
+      payload,
+      undoDomains: registration.undoDomains,
+      canCoalesceWith: registration.canCoalesceWith,
+    };
 
     try {
-      const result = await registration.handler(payload, context);
+      const result = await this.scene.mutationRecorder.record(recorderOptions, () =>
+        registration.handler(payload, context)
+      );
 
       if (result.success && !registration.readOnly) {
         this.scene.forceRender();
-
-        // Register undo/redo entry when the command declared any snapshot domains.
-        // perform() is called immediately by DashboardEditPane.handleEditAction —
-        // the mutation is already applied so we skip that first call.
-        //
-        // Concept: coalescing. If the previous entry is the same command and
-        // canCoalesceWith returns true within the gap, skip publishing a new
-        // entry. Rapid mutations (e.g. typing in a label field) become one
-        // undo step. Real implementation would also extend the previous
-        // entry's afterSnapshot; this POC demonstrates the predicate path.
-        if (
-          this.lastEntry &&
-          this.lastEntry.type === type &&
-          registration.canCoalesceWith?.(this.lastEntry.payload, Date.now() - this.lastEntry.publishedAt) === true
-        ) {
-          this.lastEntry = { type, payload, publishedAt: Date.now() };
-          // TODO: extend previous entry's afterSnapshots. Skipped: this PR is
-          // the concept; the real integration needs DashboardEditPane support.
-          return result;
-        }
-        if (undoDomains.length > 0 && typeof this.scene.publishEvent === 'function') {
-          const afterSnapshots = new Map<UndoDomain, unknown>();
-          for (const d of undoDomains) {
-            afterSnapshots.set(d, this.snapshotDomain(d));
-          }
-          let firstPerform = true;
-
-          // Concept: diff before/after by reference identity to derive selection
-          // hints (added / removed scene objects). Lets the edit pane drive
-          // post-mutation selection updates without the handler returning them.
-          // Uses the first declared domain; cross-domain commands declare the
-          // user-visible domain first.
-          const primary = undoDomains[0];
-          const { addedObject, removedObject } = diffSceneObjects(
-            beforeSnapshots.get(primary),
-            afterSnapshots.get(primary)
-          );
-
-          this.scene.publishEvent(
-            new DashboardEditActionEvent({
-              source: this.scene,
-              description: type,
-              addedObject,
-              removedObject,
-              perform: () => {
-                if (firstPerform) {
-                  firstPerform = false;
-                  return;
-                }
-                // Refuse redo if any slice has drifted since the mutation.
-                for (const d of undoDomains) {
-                  if (!sliceEqual(this.snapshotDomain(d), beforeSnapshots.get(d))) {
-                    console.warn(`[mutation-api] refusing redo for ${type}: slice '${d}' drifted`);
-                    return;
-                  }
-                }
-                for (const d of undoDomains) {
-                  this.restoreDomain(d, afterSnapshots.get(d));
-                }
-              },
-              undo: () => {
-                // Concept: conflict detection. If any slice drifted between
-                // perform and undo, refuse instead of silently reverting.
-                for (const d of undoDomains) {
-                  if (!sliceEqual(this.snapshotDomain(d), afterSnapshots.get(d))) {
-                    console.warn(`[mutation-api] refusing undo for ${type}: slice '${d}' drifted`);
-                    return;
-                  }
-                }
-                for (const d of undoDomains) {
-                  this.restoreDomain(d, beforeSnapshots.get(d));
-                }
-              },
-            }),
-            true
-          );
-          this.lastEntry = { type, payload, publishedAt: Date.now() };
-        }
       }
 
       return result;
@@ -225,16 +137,7 @@ export class DashboardMutationClient implements MutationClient {
     return Array.from(this.commands.keys());
   }
 
-  private snapshotDomain(domain: UndoDomain): unknown {
-    return getUndoDomain(domain)?.snapshot(this.scene);
-  }
-
-  private restoreDomain(domain: UndoDomain, snapshot: unknown): void {
-    getUndoDomain(domain)?.restore(this.scene, snapshot);
-  }
-
   private registerCommand(cmd: MutationCommand): void {
-    // Normalize the (optional, possibly single) undoDomain into an array.
     const undoDomains: UndoDomain[] = cmd.undoDomain
       ? Array.isArray(cmd.undoDomain)
         ? cmd.undoDomain
@@ -250,51 +153,4 @@ export class DashboardMutationClient implements MutationClient {
       canCoalesceWith: cmd.canCoalesceWith,
     });
   }
-}
-
-/**
- * Diff two snapshot arrays by reference identity to find what was added/removed.
- * Used to populate `addedObject` / `removedObject` on the published edit-action
- * event so the edit pane can drive selection updates.
- *
- * Only meaningful for array-shaped snapshots; non-array snapshots return empty.
- */
-function diffSceneObjects(
-  before: unknown,
-  after: unknown
-): {
-  addedObject?: SceneObject;
-  removedObject?: SceneObject;
-} {
-  if (!Array.isArray(before) || !Array.isArray(after)) {
-    return {};
-  }
-  const beforeSet = new Set(before);
-  const afterSet = new Set(after);
-  const added = after.find((item): item is SceneObject => !beforeSet.has(item) && isSceneObjectLike(item));
-  const removed = before.find((item): item is SceneObject => !afterSet.has(item) && isSceneObjectLike(item));
-  return { addedObject: added, removedObject: removed };
-}
-
-function isSceneObjectLike(item: unknown): item is SceneObject {
-  return typeof item === 'object' && item !== null && 'state' in item;
-}
-
-/**
- * Shallow array equality by reference identity. Sufficient for the snapshot
- * model where slices are arrays of SceneObject refs.
- */
-function sliceEqual(a: unknown, b: unknown): boolean {
-  if (a === b) {
-    return true;
-  }
-  if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) {
-    return false;
-  }
-  for (let i = 0; i < a.length; i++) {
-    if (a[i] !== b[i]) {
-      return false;
-    }
-  }
-  return true;
 }

--- a/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
+++ b/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
@@ -29,7 +29,8 @@ interface CommandRegistration {
   handler: MutationHandler;
   canExecute: (scene: DashboardScene) => { allowed: true } | { allowed: false; error: string };
   readOnly: boolean;
-  undoDomain?: UndoDomain;
+  // Normalized: always an array internally even if the command declared a single domain.
+  undoDomains: UndoDomain[];
   lockTarget?: string;
 }
 
@@ -60,15 +61,15 @@ export class DashboardMutationClient implements MutationClient {
       return { success: false, error: `Unknown command type: ${type}`, changes: [] };
     }
 
-    // Serialize per undoDomain to avoid the snapshot race.
-    const { undoDomain } = registration;
-    if (undoDomain) {
-      const prev = this.domainQueues.get(undoDomain) ?? Promise.resolve();
-      const next = prev.then(() => this.executeInner(mutation, registration));
-      this.domainQueues.set(
-        undoDomain,
-        next.catch(() => {})
-      );
+    // Serialize per undoDomain to avoid the snapshot race. If a command
+    // declares multiple domains, chain after all of them.
+    if (registration.undoDomains.length > 0) {
+      const previous = registration.undoDomains.map((d) => this.domainQueues.get(d) ?? Promise.resolve());
+      const next = Promise.all(previous).then(() => this.executeInner(mutation, registration));
+      const settled = next.catch(() => {});
+      for (const d of registration.undoDomains) {
+        this.domainQueues.set(d, settled);
+      }
       return next;
     }
     return this.executeInner(mutation, registration);
@@ -107,10 +108,13 @@ export class DashboardMutationClient implements MutationClient {
 
     const context: MutationContext = { scene: this.scene };
 
-    // Snapshot the declared domain before the handler runs.
+    // Snapshot each declared domain before the handler runs.
     // Snapshot/restore is delegated to the per-domain registry in `undo-domains.ts`.
-    const { undoDomain } = registration;
-    const beforeSnapshot: unknown = undoDomain ? this.snapshotDomain(undoDomain) : undefined;
+    const { undoDomains } = registration;
+    const beforeSnapshots = new Map<UndoDomain, unknown>();
+    for (const d of undoDomains) {
+      beforeSnapshots.set(d, this.snapshotDomain(d));
+    }
 
     try {
       const result = await registration.handler(payload, context);
@@ -118,17 +122,26 @@ export class DashboardMutationClient implements MutationClient {
       if (result.success && !registration.readOnly) {
         this.scene.forceRender();
 
-        // Register undo/redo entry when the command declared a snapshot domain.
+        // Register undo/redo entry when the command declared any snapshot domains.
         // perform() is called immediately by DashboardEditPane.handleEditAction —
         // the mutation is already applied so we skip that first call.
-        if (undoDomain && beforeSnapshot !== undefined && typeof this.scene.publishEvent === 'function') {
-          const afterSnapshot = this.snapshotDomain(undoDomain);
+        if (undoDomains.length > 0 && typeof this.scene.publishEvent === 'function') {
+          const afterSnapshots = new Map<UndoDomain, unknown>();
+          for (const d of undoDomains) {
+            afterSnapshots.set(d, this.snapshotDomain(d));
+          }
           let firstPerform = true;
 
           // Concept: diff before/after by reference identity to derive selection
           // hints (added / removed scene objects). Lets the edit pane drive
           // post-mutation selection updates without the handler returning them.
-          const { addedObject, removedObject } = diffSceneObjects(beforeSnapshot, afterSnapshot);
+          // Uses the first declared domain; cross-domain commands declare the
+          // user-visible domain first.
+          const primary = undoDomains[0];
+          const { addedObject, removedObject } = diffSceneObjects(
+            beforeSnapshots.get(primary),
+            afterSnapshots.get(primary)
+          );
 
           this.scene.publishEvent(
             new DashboardEditActionEvent({
@@ -141,23 +154,29 @@ export class DashboardMutationClient implements MutationClient {
                   firstPerform = false;
                   return;
                 }
-                // Refuse redo if the slice has drifted since the mutation.
-                // Otherwise we'd silently overwrite intervening changes.
-                if (!sliceEqual(this.snapshotDomain(undoDomain), beforeSnapshot)) {
-                  console.warn(`[mutation-api] refusing redo for ${type}: slice drifted`);
-                  return;
+                // Refuse redo if any slice has drifted since the mutation.
+                for (const d of undoDomains) {
+                  if (!sliceEqual(this.snapshotDomain(d), beforeSnapshots.get(d))) {
+                    console.warn(`[mutation-api] refusing redo for ${type}: slice '${d}' drifted`);
+                    return;
+                  }
                 }
-                this.restoreDomain(undoDomain, afterSnapshot);
+                for (const d of undoDomains) {
+                  this.restoreDomain(d, afterSnapshots.get(d));
+                }
               },
               undo: () => {
-                // Concept: conflict detection. If the slice drifted between
-                // perform and undo (another caller wrote to the same domain),
-                // refuse instead of silently reverting their work.
-                if (!sliceEqual(this.snapshotDomain(undoDomain), afterSnapshot)) {
-                  console.warn(`[mutation-api] refusing undo for ${type}: slice drifted`);
-                  return;
+                // Concept: conflict detection. If any slice drifted between
+                // perform and undo, refuse instead of silently reverting.
+                for (const d of undoDomains) {
+                  if (!sliceEqual(this.snapshotDomain(d), afterSnapshots.get(d))) {
+                    console.warn(`[mutation-api] refusing undo for ${type}: slice '${d}' drifted`);
+                    return;
+                  }
                 }
-                this.restoreDomain(undoDomain, beforeSnapshot);
+                for (const d of undoDomains) {
+                  this.restoreDomain(d, beforeSnapshots.get(d));
+                }
               },
             }),
             true
@@ -188,12 +207,18 @@ export class DashboardMutationClient implements MutationClient {
   }
 
   private registerCommand(cmd: MutationCommand): void {
+    // Normalize the (optional, possibly single) undoDomain into an array.
+    const undoDomains: UndoDomain[] = cmd.undoDomain
+      ? Array.isArray(cmd.undoDomain)
+        ? cmd.undoDomain
+        : [cmd.undoDomain]
+      : [];
     this.commands.set(cmd.name, {
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- safe: client validates with Zod before dispatch
       handler: cmd.handler as MutationHandler,
       canExecute: cmd.permission,
       readOnly: cmd.readOnly ?? false,
-      undoDomain: cmd.undoDomain,
+      undoDomains,
       lockTarget: cmd.lockTarget,
     });
   }

--- a/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
+++ b/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
@@ -141,9 +141,24 @@ export class DashboardMutationClient implements MutationClient {
                   firstPerform = false;
                   return;
                 }
+                // Refuse redo if the slice has drifted since the mutation.
+                // Otherwise we'd silently overwrite intervening changes.
+                if (!sliceEqual(this.snapshotDomain(undoDomain), beforeSnapshot)) {
+                  console.warn(`[mutation-api] refusing redo for ${type}: slice drifted`);
+                  return;
+                }
                 this.restoreDomain(undoDomain, afterSnapshot);
               },
-              undo: () => this.restoreDomain(undoDomain, beforeSnapshot),
+              undo: () => {
+                // Concept: conflict detection. If the slice drifted between
+                // perform and undo (another caller wrote to the same domain),
+                // refuse instead of silently reverting their work.
+                if (!sliceEqual(this.snapshotDomain(undoDomain), afterSnapshot)) {
+                  console.warn(`[mutation-api] refusing undo for ${type}: slice drifted`);
+                  return;
+                }
+                this.restoreDomain(undoDomain, beforeSnapshot);
+              },
             }),
             true
           );
@@ -210,4 +225,23 @@ function diffSceneObjects(
 
 function isSceneObjectLike(item: unknown): item is SceneObject {
   return typeof item === 'object' && item !== null && 'state' in item;
+}
+
+/**
+ * Shallow array equality by reference identity. Sufficient for the snapshot
+ * model where slices are arrays of SceneObject refs.
+ */
+function sliceEqual(a: unknown, b: unknown): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) {
+    return false;
+  }
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      return false;
+    }
+  }
+  return true;
 }

--- a/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
+++ b/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
@@ -32,6 +32,14 @@ interface CommandRegistration {
   // Normalized: always an array internally even if the command declared a single domain.
   undoDomains: UndoDomain[];
   lockTarget?: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- predicate signature is per-command
+  canCoalesceWith?: (previousPayload: any, gapMs: number) => boolean;
+}
+
+interface LastEntry {
+  type: string;
+  payload: unknown;
+  publishedAt: number;
 }
 
 export class DashboardMutationClient implements MutationClient {
@@ -45,6 +53,8 @@ export class DashboardMutationClient implements MutationClient {
    * queue.
    */
   private domainQueues: Map<UndoDomain, Promise<unknown>> = new Map();
+  /** Track the last published entry so we can coalesce rapid same-command writes. */
+  private lastEntry?: LastEntry;
 
   constructor(scene: DashboardScene) {
     this.scene = scene;
@@ -125,6 +135,22 @@ export class DashboardMutationClient implements MutationClient {
         // Register undo/redo entry when the command declared any snapshot domains.
         // perform() is called immediately by DashboardEditPane.handleEditAction —
         // the mutation is already applied so we skip that first call.
+        //
+        // Concept: coalescing. If the previous entry is the same command and
+        // canCoalesceWith returns true within the gap, skip publishing a new
+        // entry. Rapid mutations (e.g. typing in a label field) become one
+        // undo step. Real implementation would also extend the previous
+        // entry's afterSnapshot; this POC demonstrates the predicate path.
+        if (
+          this.lastEntry &&
+          this.lastEntry.type === type &&
+          registration.canCoalesceWith?.(this.lastEntry.payload, Date.now() - this.lastEntry.publishedAt) === true
+        ) {
+          this.lastEntry = { type, payload, publishedAt: Date.now() };
+          // TODO: extend previous entry's afterSnapshots. Skipped: this PR is
+          // the concept; the real integration needs DashboardEditPane support.
+          return result;
+        }
         if (undoDomains.length > 0 && typeof this.scene.publishEvent === 'function') {
           const afterSnapshots = new Map<UndoDomain, unknown>();
           for (const d of undoDomains) {
@@ -181,6 +207,7 @@ export class DashboardMutationClient implements MutationClient {
             }),
             true
           );
+          this.lastEntry = { type, payload, publishedAt: Date.now() };
         }
       }
 
@@ -220,6 +247,7 @@ export class DashboardMutationClient implements MutationClient {
       readOnly: cmd.readOnly ?? false,
       undoDomains,
       lockTarget: cmd.lockTarget,
+      canCoalesceWith: cmd.canCoalesceWith,
     });
   }
 }

--- a/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
+++ b/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
@@ -13,6 +13,8 @@
  * 3. Payload validation (does the payload match the Zod schema?)
  */
 
+import type { SceneObject } from '@grafana/scenes';
+
 import { DashboardEditActionEvent } from '../edit-pane/events';
 import type { DashboardScene } from '../scene/DashboardScene';
 
@@ -119,14 +121,21 @@ export class DashboardMutationClient implements MutationClient {
         // Register undo/redo entry when the command declared a snapshot domain.
         // perform() is called immediately by DashboardEditPane.handleEditAction —
         // the mutation is already applied so we skip that first call.
-        if (undoDomain && beforeSnapshot && typeof this.scene.publishEvent === 'function') {
+        if (undoDomain && beforeSnapshot !== undefined && typeof this.scene.publishEvent === 'function') {
           const afterSnapshot = this.snapshotDomain(undoDomain);
           let firstPerform = true;
+
+          // Concept: diff before/after by reference identity to derive selection
+          // hints (added / removed scene objects). Lets the edit pane drive
+          // post-mutation selection updates without the handler returning them.
+          const { addedObject, removedObject } = diffSceneObjects(beforeSnapshot, afterSnapshot);
 
           this.scene.publishEvent(
             new DashboardEditActionEvent({
               source: this.scene,
               description: type,
+              addedObject,
+              removedObject,
               perform: () => {
                 if (firstPerform) {
                   firstPerform = false;
@@ -173,4 +182,32 @@ export class DashboardMutationClient implements MutationClient {
       lockTarget: cmd.lockTarget,
     });
   }
+}
+
+/**
+ * Diff two snapshot arrays by reference identity to find what was added/removed.
+ * Used to populate `addedObject` / `removedObject` on the published edit-action
+ * event so the edit pane can drive selection updates.
+ *
+ * Only meaningful for array-shaped snapshots; non-array snapshots return empty.
+ */
+function diffSceneObjects(
+  before: unknown,
+  after: unknown
+): {
+  addedObject?: SceneObject;
+  removedObject?: SceneObject;
+} {
+  if (!Array.isArray(before) || !Array.isArray(after)) {
+    return {};
+  }
+  const beforeSet = new Set(before);
+  const afterSet = new Set(after);
+  const added = after.find((item): item is SceneObject => !beforeSet.has(item) && isSceneObjectLike(item));
+  const removed = before.find((item): item is SceneObject => !afterSet.has(item) && isSceneObjectLike(item));
+  return { addedObject: added, removedObject: removed };
+}
+
+function isSceneObjectLike(item: unknown): item is SceneObject {
+  return typeof item === 'object' && item !== null && 'state' in item;
 }

--- a/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
+++ b/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
@@ -52,6 +52,11 @@ export class DashboardMutationClient implements MutationClient {
       return { success: false, error: `Unknown command type: ${type}`, changes: [] };
     }
 
+    const permissionResult = registration.canExecute(this.scene);
+    if (!permissionResult.allowed) {
+      return { success: false, error: permissionResult.error, changes: [] };
+    }
+
     if (registration.lockTarget && this.scene.isWriteLocked(registration.lockTarget)) {
       return {
         success: false,
@@ -59,11 +64,6 @@ export class DashboardMutationClient implements MutationClient {
         error: `Target '${registration.lockTarget}' is locked`,
         changes: [],
       };
-    }
-
-    const permissionResult = registration.canExecute(this.scene);
-    if (!permissionResult.allowed) {
-      return { success: false, error: permissionResult.error, changes: [] };
     }
 
     let payload: unknown;

--- a/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
+++ b/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
@@ -20,9 +20,12 @@ import type { MutationCommand, MutationContext, UndoDomain } from './commands/ty
 import type { MutationClient, MutationRequest, MutationResult } from './types';
 
 type MutationHandler = (payload: unknown, context: MutationContext) => Promise<MutationResult>;
+type MutationTransform = (payload: unknown) => unknown;
 
 interface CommandRegistration {
   handler: MutationHandler;
+  /** Per-command normalizer. Always called by the client before the handler. */
+  transformPayloadToScene: MutationTransform;
   canExecute: (scene: DashboardScene) => { allowed: true } | { allowed: false; error: string };
   readOnly: boolean;
   // Normalized: always an array internally even if the command declared a single domain.
@@ -90,17 +93,21 @@ export class DashboardMutationClient implements MutationClient {
       };
     }
 
-    let payload: unknown;
+    let rawPayload: unknown;
     if ('__scenesPayload' in mutation) {
-      // UI path: SceneObject passed directly — skip Zod validation and forward transformer.
-      payload = { __scenesPayload: mutation.__scenesPayload };
+      // UI path: SceneObject passed directly — skip Zod validation.
+      rawPayload = { __scenesPayload: mutation.__scenesPayload };
     } else {
       const validationResult = validatePayload(type, mutation.payload);
       if (!validationResult.success) {
         return { success: false, error: validationResult.error, changes: [] };
       }
-      payload = registration.readOnly ? validationResult.data : structuredClone(validationResult.data);
+      rawPayload = registration.readOnly ? validationResult.data : structuredClone(validationResult.data);
     }
+
+    // Always normalize through the command's declared transformer. The handler
+    // sees a single shape regardless of which dispatch path the caller used.
+    const payload = registration.transformPayloadToScene(rawPayload);
 
     const context: MutationContext = { scene: this.scene };
 
@@ -143,9 +150,16 @@ export class DashboardMutationClient implements MutationClient {
         ? cmd.undoDomain
         : [cmd.undoDomain]
       : [];
+    // Identity transform when the command does not declare one. Keeps the
+    // dispatch path uniform: every command goes through transformPayloadToScene.
+    const transform: MutationTransform = cmd.transformPayloadToScene
+      ? // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- normalizer is per-command
+        (cmd.transformPayloadToScene as MutationTransform)
+      : (p) => p;
     this.commands.set(cmd.name, {
       // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- safe: client validates with Zod before dispatch
       handler: cmd.handler as MutationHandler,
+      transformPayloadToScene: transform,
       canExecute: cmd.permission,
       readOnly: cmd.readOnly ?? false,
       undoDomains,

--- a/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
+++ b/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
@@ -13,15 +13,13 @@
  * 3. Payload validation (does the payload match the Zod schema?)
  */
 
-import { type SceneVariable } from '@grafana/scenes';
-
 import { DashboardEditActionEvent } from '../edit-pane/events';
 import type { DashboardScene } from '../scene/DashboardScene';
 
 import { ALL_COMMANDS, validatePayload } from './commands/registry';
 import type { MutationCommand, MutationContext, UndoDomain } from './commands/types';
-import { replaceVariableSet } from './commands/variableUtils';
 import type { MutationClient, MutationRequest, MutationResult } from './types';
+import { getUndoDomain } from './undo-domains';
 
 type MutationHandler = (payload: unknown, context: MutationContext) => Promise<MutationResult>;
 
@@ -83,8 +81,9 @@ export class DashboardMutationClient implements MutationClient {
     const context: MutationContext = { scene: this.scene };
 
     // Snapshot the declared domain before the handler runs.
+    // Snapshot/restore is delegated to the per-domain registry in `undo-domains.ts`.
     const { undoDomain } = registration;
-    const beforeSnapshot = undoDomain ? this.snapshotDomain(undoDomain) : undefined;
+    const beforeSnapshot: unknown = undoDomain ? this.snapshotDomain(undoDomain) : undefined;
 
     try {
       const result = await registration.handler(payload, context);
@@ -131,17 +130,12 @@ export class DashboardMutationClient implements MutationClient {
     return Array.from(this.commands.keys());
   }
 
-  private snapshotDomain(domain: UndoDomain): SceneVariable[] {
-    if (domain === 'variables') {
-      return this.scene.state.$variables?.state.variables.slice() ?? [];
-    }
-    return [];
+  private snapshotDomain(domain: UndoDomain): unknown {
+    return getUndoDomain(domain)?.snapshot(this.scene);
   }
 
-  private restoreDomain(domain: UndoDomain, snapshot: SceneVariable[]): void {
-    if (domain === 'variables') {
-      replaceVariableSet(this.scene, snapshot);
-    }
+  private restoreDomain(domain: UndoDomain, snapshot: unknown): void {
+    getUndoDomain(domain)?.restore(this.scene, snapshot);
   }
 
   private registerCommand(cmd: MutationCommand): void {

--- a/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
+++ b/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
@@ -30,6 +30,7 @@ interface CommandRegistration {
   canExecute: (scene: DashboardScene) => { allowed: true } | { allowed: false; error: string };
   readOnly: boolean;
   undoDomain?: UndoDomain;
+  lockTarget?: string;
 }
 
 export class DashboardMutationClient implements MutationClient {
@@ -49,6 +50,15 @@ export class DashboardMutationClient implements MutationClient {
     const registration = this.commands.get(type);
     if (!registration) {
       return { success: false, error: `Unknown command type: ${type}`, changes: [] };
+    }
+
+    if (registration.lockTarget && this.scene.isWriteLocked(registration.lockTarget)) {
+      return {
+        success: false,
+        locked: true,
+        error: `Target '${registration.lockTarget}' is locked`,
+        changes: [],
+      };
     }
 
     const permissionResult = registration.canExecute(this.scene);
@@ -141,6 +151,7 @@ export class DashboardMutationClient implements MutationClient {
       canExecute: cmd.permission,
       readOnly: cmd.readOnly ?? false,
       undoDomain: cmd.undoDomain,
+      lockTarget: cmd.lockTarget,
     });
   }
 }

--- a/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
+++ b/public/app/features/dashboard-scene/mutation-api/DashboardMutationClient.ts
@@ -34,6 +34,14 @@ interface CommandRegistration {
 export class DashboardMutationClient implements MutationClient {
   private scene: DashboardScene;
   private commands: Map<string, CommandRegistration> = new Map();
+  /**
+   * Per-domain promise queue. Concept: two `execute()` calls on the same
+   * `undoDomain` must run sequentially. Otherwise both calls snapshot the
+   * same pre-execution state and the second mutation's undo entry would
+   * silently revert the first. Commands without an undoDomain bypass the
+   * queue.
+   */
+  private domainQueues: Map<UndoDomain, Promise<unknown>> = new Map();
 
   constructor(scene: DashboardScene) {
     this.scene = scene;
@@ -49,6 +57,23 @@ export class DashboardMutationClient implements MutationClient {
     if (!registration) {
       return { success: false, error: `Unknown command type: ${type}`, changes: [] };
     }
+
+    // Serialize per undoDomain to avoid the snapshot race.
+    const { undoDomain } = registration;
+    if (undoDomain) {
+      const prev = this.domainQueues.get(undoDomain) ?? Promise.resolve();
+      const next = prev.then(() => this.executeInner(mutation, registration));
+      this.domainQueues.set(
+        undoDomain,
+        next.catch(() => {})
+      );
+      return next;
+    }
+    return this.executeInner(mutation, registration);
+  }
+
+  private async executeInner(mutation: MutationRequest, registration: CommandRegistration): Promise<MutationResult> {
+    const type = mutation.type.toUpperCase();
 
     const permissionResult = registration.canExecute(this.scene);
     if (!permissionResult.allowed) {

--- a/public/app/features/dashboard-scene/mutation-api/MutationRecorder.ts
+++ b/public/app/features/dashboard-scene/mutation-api/MutationRecorder.ts
@@ -1,0 +1,170 @@
+/**
+ * MutationRecorder
+ *
+ * Concept: the snapshot + publish-DashboardEditActionEvent mechanism is not
+ * the Mutation Client's concern. It is the *recorder*'s concern. By moving
+ * it onto DashboardScene we get:
+ *
+ *   - a single recorder per dashboard regardless of caller (UI, agent, future
+ *     headless plugin host),
+ *   - a clean seam for the future audit log / replay tooling to read from,
+ *   - a per-dashboard ownership boundary that's natural for multiplayer.
+ *
+ * DashboardMutationClient delegates here. Other callers (the future MCP
+ * gateway, plugin-side adapters) can call `recorder.record(...)` directly
+ * without owning their own snapshot machinery.
+ *
+ * The behaviour (snapshot, publish, conflict-detect, coalesce) is identical
+ * to what the client did before this extraction.
+ */
+
+import type { SceneObject } from '@grafana/scenes';
+
+import { DashboardEditActionEvent } from '../edit-pane/events';
+import type { DashboardScene } from '../scene/DashboardScene';
+
+import type { UndoDomain } from './commands/types';
+import { getUndoDomain } from './undo-domains';
+
+export interface RecordOptions {
+  type: string;
+  payload: unknown;
+  undoDomains: UndoDomain[];
+  canCoalesceWith?: (previousPayload: unknown, gapMs: number) => boolean;
+}
+
+interface LastEntry {
+  type: string;
+  payload: unknown;
+  publishedAt: number;
+}
+
+export class MutationRecorder {
+  private scene: DashboardScene;
+  private lastEntry?: LastEntry;
+
+  constructor(scene: DashboardScene) {
+    this.scene = scene;
+  }
+
+  /**
+   * Snapshot the declared domains, run the mutation, snapshot again, and
+   * publish a DashboardEditActionEvent so the toolbar undo stack picks it up.
+   *
+   * The caller passes the actual mutation as a function so the recorder can
+   * frame it with snapshot/restore. Returns whatever the mutation returns.
+   */
+  async record<T>(opts: RecordOptions, mutate: () => Promise<T>): Promise<T> {
+    const beforeSnapshots = new Map<UndoDomain, unknown>();
+    for (const d of opts.undoDomains) {
+      beforeSnapshots.set(d, this.snapshotDomain(d));
+    }
+
+    const result = await mutate();
+
+    if (opts.undoDomains.length === 0 || typeof this.scene.publishEvent !== 'function') {
+      return result;
+    }
+
+    // Coalesce path: skip publishing a fresh entry, update the watermark.
+    if (
+      this.lastEntry &&
+      this.lastEntry.type === opts.type &&
+      opts.canCoalesceWith?.(this.lastEntry.payload, Date.now() - this.lastEntry.publishedAt) === true
+    ) {
+      this.lastEntry = { type: opts.type, payload: opts.payload, publishedAt: Date.now() };
+      return result;
+    }
+
+    const afterSnapshots = new Map<UndoDomain, unknown>();
+    for (const d of opts.undoDomains) {
+      afterSnapshots.set(d, this.snapshotDomain(d));
+    }
+
+    const primary = opts.undoDomains[0];
+    const { addedObject, removedObject } = diffSceneObjects(beforeSnapshots.get(primary), afterSnapshots.get(primary));
+
+    let firstPerform = true;
+    this.scene.publishEvent(
+      new DashboardEditActionEvent({
+        source: this.scene,
+        description: opts.type,
+        addedObject,
+        removedObject,
+        perform: () => {
+          if (firstPerform) {
+            firstPerform = false;
+            return;
+          }
+          for (const d of opts.undoDomains) {
+            if (!sliceEqual(this.snapshotDomain(d), beforeSnapshots.get(d))) {
+              console.warn(`[mutation-api] refusing redo for ${opts.type}: slice '${d}' drifted`);
+              return;
+            }
+          }
+          for (const d of opts.undoDomains) {
+            this.restoreDomain(d, afterSnapshots.get(d));
+          }
+        },
+        undo: () => {
+          for (const d of opts.undoDomains) {
+            if (!sliceEqual(this.snapshotDomain(d), afterSnapshots.get(d))) {
+              console.warn(`[mutation-api] refusing undo for ${opts.type}: slice '${d}' drifted`);
+              return;
+            }
+          }
+          for (const d of opts.undoDomains) {
+            this.restoreDomain(d, beforeSnapshots.get(d));
+          }
+        },
+      }),
+      true
+    );
+    this.lastEntry = { type: opts.type, payload: opts.payload, publishedAt: Date.now() };
+    return result;
+  }
+
+  private snapshotDomain(domain: UndoDomain): unknown {
+    return getUndoDomain(domain)?.snapshot(this.scene);
+  }
+
+  private restoreDomain(domain: UndoDomain, snapshot: unknown): void {
+    getUndoDomain(domain)?.restore(this.scene, snapshot);
+  }
+}
+
+function diffSceneObjects(
+  before: unknown,
+  after: unknown
+): {
+  addedObject?: SceneObject;
+  removedObject?: SceneObject;
+} {
+  if (!Array.isArray(before) || !Array.isArray(after)) {
+    return {};
+  }
+  const beforeSet = new Set(before);
+  const afterSet = new Set(after);
+  const added = after.find((item): item is SceneObject => !beforeSet.has(item) && isSceneObjectLike(item));
+  const removed = before.find((item): item is SceneObject => !afterSet.has(item) && isSceneObjectLike(item));
+  return { addedObject: added, removedObject: removed };
+}
+
+function isSceneObjectLike(item: unknown): item is SceneObject {
+  return typeof item === 'object' && item !== null && 'state' in item;
+}
+
+function sliceEqual(a: unknown, b: unknown): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (!Array.isArray(a) || !Array.isArray(b) || a.length !== b.length) {
+    return false;
+  }
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      return false;
+    }
+  }
+  return true;
+}

--- a/public/app/features/dashboard-scene/mutation-api/MutationRecorder.ts
+++ b/public/app/features/dashboard-scene/mutation-api/MutationRecorder.ts
@@ -1,26 +1,24 @@
 /**
  * MutationRecorder
  *
- * Concept: the snapshot + publish-DashboardEditActionEvent mechanism is not
- * the Mutation Client's concern. It is the *recorder*'s concern. By moving
- * it onto DashboardScene we get:
+ * Owns the undo/redo stack for a dashboard. All mutations the client executes
+ * land here; nothing else carries history state.
  *
- *   - a single recorder per dashboard regardless of caller (UI, agent, future
- *     headless plugin host),
- *   - a clean seam for the future audit log / replay tooling to read from,
- *   - a per-dashboard ownership boundary that's natural for multiplayer.
+ * Design intent (Ivan, 2026-05-26): the recorder is the single source of truth
+ * for "what happened to this dashboard". Snapshot + publish-to-toolbar is too
+ * many seams. Instead:
  *
- * DashboardMutationClient delegates here. Other callers (the future MCP
- * gateway, plugin-side adapters) can call `recorder.record(...)` directly
- * without owning their own snapshot machinery.
+ *   - record() pushes an undo entry with before/after snapshots per undoDomain
+ *     and clears the redo stack,
+ *   - undo() / redo() pop and re-apply,
+ *   - UI buttons and the agent both go through the same path: the UNDO and
+ *     REDO mutation commands dispatch into this recorder.
  *
- * The behaviour (snapshot, publish, conflict-detect, coalesce) is identical
- * to what the client did before this extraction.
+ * No DashboardEditActionEvent publication from here. If a separate audit
+ * surface needs to react, it subscribes to the recorder, not the other way
+ * around.
  */
 
-import type { SceneObject } from '@grafana/scenes';
-
-import { DashboardEditActionEvent } from '../edit-pane/events';
 import type { DashboardScene } from '../scene/DashboardScene';
 
 import type { UndoDomain } from './commands/types';
@@ -33,95 +31,112 @@ export interface RecordOptions {
   canCoalesceWith?: (previousPayload: unknown, gapMs: number) => boolean;
 }
 
-interface LastEntry {
+interface StackEntry {
   type: string;
   payload: unknown;
+  before: Map<UndoDomain, unknown>;
+  after: Map<UndoDomain, unknown>;
   publishedAt: number;
 }
 
 export class MutationRecorder {
   private scene: DashboardScene;
-  private lastEntry?: LastEntry;
+  private undoStack: StackEntry[] = [];
+  private redoStack: StackEntry[] = [];
 
   constructor(scene: DashboardScene) {
     this.scene = scene;
   }
 
   /**
-   * Snapshot the declared domains, run the mutation, snapshot again, and
-   * publish a DashboardEditActionEvent so the toolbar undo stack picks it up.
-   *
-   * The caller passes the actual mutation as a function so the recorder can
-   * frame it with snapshot/restore. Returns whatever the mutation returns.
+   * Snapshot the declared domains, run the mutation, snapshot again, push
+   * onto the undo stack. The caller passes the actual mutation as a function
+   * so the recorder can frame it with snapshot/restore.
    */
   async record<T>(opts: RecordOptions, mutate: () => Promise<T>): Promise<T> {
-    const beforeSnapshots = new Map<UndoDomain, unknown>();
-    for (const d of opts.undoDomains) {
-      beforeSnapshots.set(d, this.snapshotDomain(d));
-    }
-
+    const before = this.snapshot(opts.undoDomains);
     const result = await mutate();
 
-    if (opts.undoDomains.length === 0 || typeof this.scene.publishEvent !== 'function') {
+    if (opts.undoDomains.length === 0) {
       return result;
     }
 
-    // Coalesce path: skip publishing a fresh entry, update the watermark.
-    if (
-      this.lastEntry &&
-      this.lastEntry.type === opts.type &&
-      opts.canCoalesceWith?.(this.lastEntry.payload, Date.now() - this.lastEntry.publishedAt) === true
-    ) {
-      this.lastEntry = { type: opts.type, payload: opts.payload, publishedAt: Date.now() };
+    const now = Date.now();
+
+    // Coalesce with the previous entry if eligible (e.g. rapid typing).
+    const prev = this.undoStack[this.undoStack.length - 1];
+    if (prev && prev.type === opts.type && opts.canCoalesceWith?.(prev.payload, now - prev.publishedAt) === true) {
+      prev.after = this.snapshot(opts.undoDomains);
+      prev.payload = opts.payload;
+      prev.publishedAt = now;
+      this.redoStack.length = 0;
       return result;
     }
 
-    const afterSnapshots = new Map<UndoDomain, unknown>();
-    for (const d of opts.undoDomains) {
-      afterSnapshots.set(d, this.snapshotDomain(d));
-    }
-
-    const primary = opts.undoDomains[0];
-    const { addedObject, removedObject } = diffSceneObjects(beforeSnapshots.get(primary), afterSnapshots.get(primary));
-
-    let firstPerform = true;
-    this.scene.publishEvent(
-      new DashboardEditActionEvent({
-        source: this.scene,
-        description: opts.type,
-        addedObject,
-        removedObject,
-        perform: () => {
-          if (firstPerform) {
-            firstPerform = false;
-            return;
-          }
-          for (const d of opts.undoDomains) {
-            if (!sliceEqual(this.snapshotDomain(d), beforeSnapshots.get(d))) {
-              console.warn(`[mutation-api] refusing redo for ${opts.type}: slice '${d}' drifted`);
-              return;
-            }
-          }
-          for (const d of opts.undoDomains) {
-            this.restoreDomain(d, afterSnapshots.get(d));
-          }
-        },
-        undo: () => {
-          for (const d of opts.undoDomains) {
-            if (!sliceEqual(this.snapshotDomain(d), afterSnapshots.get(d))) {
-              console.warn(`[mutation-api] refusing undo for ${opts.type}: slice '${d}' drifted`);
-              return;
-            }
-          }
-          for (const d of opts.undoDomains) {
-            this.restoreDomain(d, beforeSnapshots.get(d));
-          }
-        },
-      }),
-      true
-    );
-    this.lastEntry = { type: opts.type, payload: opts.payload, publishedAt: Date.now() };
+    this.undoStack.push({
+      type: opts.type,
+      payload: opts.payload,
+      before,
+      after: this.snapshot(opts.undoDomains),
+      publishedAt: now,
+    });
+    this.redoStack.length = 0;
     return result;
+  }
+
+  canUndo(): boolean {
+    return this.undoStack.length > 0;
+  }
+
+  canRedo(): boolean {
+    return this.redoStack.length > 0;
+  }
+
+  /**
+   * Restore the last entry's `before` snapshots. Refuses if the dashboard has
+   * drifted from the entry's `after` state (i.e. something else mutated the
+   * same slice in the meantime).
+   */
+  undo(): boolean {
+    const entry = this.undoStack[this.undoStack.length - 1];
+    if (!entry) {
+      return false;
+    }
+    if (!this.sliceMapEqual(this.snapshot([...entry.after.keys()]), entry.after)) {
+      console.warn(`[mutation-api] refusing undo for ${entry.type}: slice drifted`);
+      return false;
+    }
+    for (const [domain, snap] of entry.before) {
+      this.restoreDomain(domain, snap);
+    }
+    this.undoStack.pop();
+    this.redoStack.push(entry);
+    return true;
+  }
+
+  redo(): boolean {
+    const entry = this.redoStack[this.redoStack.length - 1];
+    if (!entry) {
+      return false;
+    }
+    if (!this.sliceMapEqual(this.snapshot([...entry.before.keys()]), entry.before)) {
+      console.warn(`[mutation-api] refusing redo for ${entry.type}: slice drifted`);
+      return false;
+    }
+    for (const [domain, snap] of entry.after) {
+      this.restoreDomain(domain, snap);
+    }
+    this.redoStack.pop();
+    this.undoStack.push(entry);
+    return true;
+  }
+
+  private snapshot(domains: UndoDomain[]): Map<UndoDomain, unknown> {
+    const m = new Map<UndoDomain, unknown>();
+    for (const d of domains) {
+      m.set(d, this.snapshotDomain(d));
+    }
+    return m;
   }
 
   private snapshotDomain(domain: UndoDomain): unknown {
@@ -131,27 +146,19 @@ export class MutationRecorder {
   private restoreDomain(domain: UndoDomain, snapshot: unknown): void {
     getUndoDomain(domain)?.restore(this.scene, snapshot);
   }
-}
 
-function diffSceneObjects(
-  before: unknown,
-  after: unknown
-): {
-  addedObject?: SceneObject;
-  removedObject?: SceneObject;
-} {
-  if (!Array.isArray(before) || !Array.isArray(after)) {
-    return {};
+  private sliceMapEqual(a: Map<UndoDomain, unknown>, b: Map<UndoDomain, unknown>): boolean {
+    if (a.size !== b.size) {
+      return false;
+    }
+    for (const [key, valA] of a) {
+      const valB = b.get(key);
+      if (!sliceEqual(valA, valB)) {
+        return false;
+      }
+    }
+    return true;
   }
-  const beforeSet = new Set(before);
-  const afterSet = new Set(after);
-  const added = after.find((item): item is SceneObject => !beforeSet.has(item) && isSceneObjectLike(item));
-  const removed = before.find((item): item is SceneObject => !afterSet.has(item) && isSceneObjectLike(item));
-  return { addedObject: added, removedObject: removed };
-}
-
-function isSceneObjectLike(item: unknown): item is SceneObject {
-  return typeof item === 'object' && item !== null && 'state' in item;
 }
 
 function sliceEqual(a: unknown, b: unknown): boolean {

--- a/public/app/features/dashboard-scene/mutation-api/cmd.ts
+++ b/public/app/features/dashboard-scene/mutation-api/cmd.ts
@@ -14,6 +14,8 @@
 
 import { type z } from 'zod';
 
+import { isSceneObject, type SceneVariable } from '@grafana/scenes';
+
 import { payloads } from './commands/schemas';
 import type { MutationRequest } from './types';
 
@@ -21,6 +23,16 @@ import type { MutationRequest } from './types';
 type CmdBuilders = {
   [K in keyof typeof payloads]: (payload: z.input<(typeof payloads)[K]>) => MutationRequest;
 };
+
+// Scenes-native overloads for variable commands: UI callers pass SceneVariable directly.
+export interface SceneNativeCmdBuilders {
+  addVariable(sceneVar: SceneVariable): MutationRequest;
+  addVariable(payload: z.input<(typeof payloads)['addVariable']>): MutationRequest;
+  updateVariable(sceneVar: SceneVariable): MutationRequest;
+  updateVariable(payload: z.input<(typeof payloads)['updateVariable']>): MutationRequest;
+  removeVariable(sceneVar: SceneVariable): MutationRequest;
+  removeVariable(payload: z.input<(typeof payloads)['removeVariable']>): MutationRequest;
+}
 
 /**
  * Convert a camelCase command key to UPPER_SNAKE_CASE for use as the MutationRequest type.
@@ -30,17 +42,30 @@ function toCommandType(key: string): string {
   return key.replace(/([A-Z])/g, '_$1').toUpperCase();
 }
 
-function buildCmd(): CmdBuilders {
+function buildCmd(): CmdBuilders & SceneNativeCmdBuilders {
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- building the record generically; type safety is ensured by CmdBuilders return type
-  const result = {} as CmdBuilders;
+  const result = {} as CmdBuilders & SceneNativeCmdBuilders;
 
   // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- narrowing key iteration to the known keyof type
   for (const key of Object.keys(payloads) as Array<keyof typeof payloads>) {
     // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- generic indexing requires cast; each entry is validated by CmdBuilders
-    (result as Record<string, (payload: unknown) => MutationRequest>)[key] = (payload: unknown) => ({
+    (result as unknown as Record<string, (payload: unknown) => MutationRequest>)[key] = (payload: unknown) => ({
       type: toCommandType(key),
       payload,
     });
+  }
+
+  // Scenes-native overloads: detect SceneVariable instance and bypass Zod roundtrip.
+  const variableCommands = ['addVariable', 'updateVariable', 'removeVariable'] as const;
+  for (const key of variableCommands) {
+    const commandType = toCommandType(key);
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- overriding generated builder with overloaded version
+    (result as unknown as Record<string, (arg: unknown) => MutationRequest>)[key] = (arg: unknown) => {
+      if (isSceneObject(arg)) {
+        return { type: commandType, __scenesPayload: arg };
+      }
+      return { type: commandType, payload: arg };
+    };
   }
 
   return result;
@@ -49,5 +74,8 @@ function buildCmd(): CmdBuilders {
 /**
  * Type-safe command builder. Each property corresponds to a command in the
  * `payloads` record and produces a fully typed MutationRequest.
+ *
+ * Variable commands (addVariable, updateVariable, removeVariable) also accept
+ * a SceneVariable directly for UI callers, bypassing the Zod roundtrip.
  */
-export const cmd: CmdBuilders = buildCmd();
+export const cmd: CmdBuilders & SceneNativeCmdBuilders = buildCmd();

--- a/public/app/features/dashboard-scene/mutation-api/cmd.ts
+++ b/public/app/features/dashboard-scene/mutation-api/cmd.ts
@@ -1,0 +1,53 @@
+/**
+ * Typed command builder for the Dashboard Mutation API.
+ *
+ * Provides one type-safe factory function per command, derived from the
+ * `payloads` record in schemas.ts. Each function produces a MutationRequest
+ * ready to pass to DashboardMutationClient.execute() or any MutationClient.
+ *
+ * Key naming: camelCase payload key -> UPPER_SNAKE_CASE type string.
+ *
+ * Usage:
+ *   import { cmd } from './cmd';
+ *   const result = await client.execute(cmd.addVariable({ variable: myVar }));
+ */
+
+import { type z } from 'zod';
+
+import { payloads } from './commands/schemas';
+import type { MutationRequest } from './types';
+
+// Build the type for the cmd object: one function per payload key.
+type CmdBuilders = {
+  [K in keyof typeof payloads]: (payload: z.infer<(typeof payloads)[K]>) => MutationRequest;
+};
+
+/**
+ * Convert a camelCase command key to UPPER_SNAKE_CASE for use as the MutationRequest type.
+ * Example: "addVariable" -> "ADD_VARIABLE"
+ */
+function toCommandType(key: string): string {
+  return key.replace(/([A-Z])/g, '_$1').toUpperCase();
+}
+
+function buildCmd(): CmdBuilders {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- building the record generically; type safety is ensured by CmdBuilders return type
+  const result = {} as CmdBuilders;
+
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- narrowing key iteration to the known keyof type
+  for (const key of Object.keys(payloads) as Array<keyof typeof payloads>) {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- generic indexing requires cast; each entry is validated by CmdBuilders
+    (result as Record<string, (payload: unknown) => MutationRequest>)[key] = (payload: unknown) => ({
+      type: toCommandType(key),
+      payload,
+    });
+  }
+
+  return result;
+}
+
+/**
+ * Type-safe command builder. Each property corresponds to a command in the
+ * `payloads` record and produces a fully typed MutationRequest.
+ */
+export const cmd: CmdBuilders = buildCmd();

--- a/public/app/features/dashboard-scene/mutation-api/cmd.ts
+++ b/public/app/features/dashboard-scene/mutation-api/cmd.ts
@@ -19,7 +19,7 @@ import type { MutationRequest } from './types';
 
 // Build the type for the cmd object: one function per payload key.
 type CmdBuilders = {
-  [K in keyof typeof payloads]: (payload: z.infer<(typeof payloads)[K]>) => MutationRequest;
+  [K in keyof typeof payloads]: (payload: z.input<(typeof payloads)[K]>) => MutationRequest;
 };
 
 /**

--- a/public/app/features/dashboard-scene/mutation-api/commands/addVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/addVariable.ts
@@ -47,8 +47,7 @@ export const addVariableCommand: MutationCommand<AddVariablePayload> = {
       const sceneVariable = createSceneVariableFromVariableModel(variableKind as VariableKind);
 
       const varSet = sceneGraph.getVariables(scene);
-      const variablesBeforeAdd = varSet.state.variables.slice();
-      const currentVariables = [...variablesBeforeAdd];
+      const currentVariables = [...varSet.state.variables];
 
       if (position !== undefined && position >= 0 && position < currentVariables.length) {
         currentVariables.splice(position, 0, sceneVariable);
@@ -62,10 +61,6 @@ export const addVariableCommand: MutationCommand<AddVariablePayload> = {
         success: true,
         data: { variable: variableKind },
         changes: [{ path: `/variables/${name}`, previousValue: null, newValue: variableKind }],
-        _description: `Add variable '${name}'`,
-        _undo: () => {
-          replaceVariableSet(scene, variablesBeforeAdd);
-        },
       };
     } catch (error) {
       return {

--- a/public/app/features/dashboard-scene/mutation-api/commands/addVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/addVariable.ts
@@ -26,6 +26,7 @@ export const addVariableCommand: MutationCommand<AddVariablePayload> = {
   payloadSchema: payloads.addVariable,
   permission: requiresEdit,
   readOnly: false,
+  undoDomain: 'variables',
 
   handler: async (payload, context) => {
     const { scene } = context;

--- a/public/app/features/dashboard-scene/mutation-api/commands/addVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/addVariable.ts
@@ -47,7 +47,8 @@ export const addVariableCommand: MutationCommand<AddVariablePayload> = {
       const sceneVariable = createSceneVariableFromVariableModel(variableKind as VariableKind);
 
       const varSet = sceneGraph.getVariables(scene);
-      const currentVariables = [...varSet.state.variables];
+      const variablesBeforeAdd = varSet.state.variables.slice();
+      const currentVariables = [...variablesBeforeAdd];
 
       if (position !== undefined && position >= 0 && position < currentVariables.length) {
         currentVariables.splice(position, 0, sceneVariable);
@@ -61,6 +62,10 @@ export const addVariableCommand: MutationCommand<AddVariablePayload> = {
         success: true,
         data: { variable: variableKind },
         changes: [{ path: `/variables/${name}`, previousValue: null, newValue: variableKind }],
+        _description: `Add variable '${name}'`,
+        _undo: () => {
+          replaceVariableSet(scene, variablesBeforeAdd);
+        },
       };
     } catch (error) {
       return {

--- a/public/app/features/dashboard-scene/mutation-api/commands/addVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/addVariable.ts
@@ -6,14 +6,14 @@
 
 import { type z } from 'zod';
 
-import { sceneGraph } from '@grafana/scenes';
+import { sceneGraph, type SceneVariable } from '@grafana/scenes';
 import type { VariableKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 
 import { createSceneVariableFromVariableModel } from '../../serialization/transformSaveModelSchemaV2ToScene';
 
 import { payloads } from './schemas';
 import { enterEditModeIfNeeded, requiresEdit, type MutationCommand } from './types';
-import { replaceVariableSet } from './variableUtils';
+import { isSceneNativeVariablePayload, replaceVariableSet } from './variableUtils';
 
 export const addVariablePayloadSchema = payloads.addVariable;
 
@@ -32,8 +32,23 @@ export const addVariableCommand: MutationCommand<AddVariablePayload> = {
     enterEditModeIfNeeded(scene);
 
     try {
-      const { variable: variableKind, position } = payload;
-      const name = variableKind.spec.name;
+      let sceneVariable: SceneVariable;
+      let name: string;
+      let position: number | undefined;
+
+      if (isSceneNativeVariablePayload(payload)) {
+        sceneVariable = payload.__scenesPayload;
+        name = sceneVariable.state.name;
+        position = undefined;
+      } else {
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- validated by Zod in DashboardMutationClient
+        const typedPayload = payload as AddVariablePayload;
+        const variableKind = typedPayload.variable;
+        name = variableKind.spec.name;
+        position = typedPayload.position;
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Zod output is structurally compatible with VariableKind
+        sceneVariable = createSceneVariableFromVariableModel(variableKind as VariableKind);
+      }
 
       const existingVariables = scene.state.$variables;
       if (existingVariables) {
@@ -42,9 +57,6 @@ export const addVariableCommand: MutationCommand<AddVariablePayload> = {
           throw new Error(`Variable '${name}' already exists`);
         }
       }
-
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Zod output is structurally compatible with VariableKind
-      const sceneVariable = createSceneVariableFromVariableModel(variableKind as VariableKind);
 
       const varSet = sceneGraph.getVariables(scene);
       const currentVariables = [...varSet.state.variables];
@@ -59,8 +71,8 @@ export const addVariableCommand: MutationCommand<AddVariablePayload> = {
 
       return {
         success: true,
-        data: { variable: variableKind },
-        changes: [{ path: `/variables/${name}`, previousValue: null, newValue: variableKind }],
+        data: { name },
+        changes: [{ path: `/variables/${name}`, previousValue: null, newValue: name }],
       };
     } catch (error) {
       return {

--- a/public/app/features/dashboard-scene/mutation-api/commands/addVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/addVariable.ts
@@ -3,10 +3,12 @@
  *
  * Add a template variable to the dashboard using v2beta1 VariableKind format.
  *
- * Concept (normalize helper): the `__scenesPayload` discriminated-union
- * branch lives in `normalize()` at the top of the file, not inside the
- * handler. The handler then has exactly one branch — state mutation. This
- * is the pattern other commands should follow when migrating.
+ * Concept (transformPayloadToScene): the `__scenesPayload` discriminated-union
+ * branch lives on the command's `transformPayloadToScene` method, called by
+ * DashboardMutationClient before the handler runs. The handler receives the
+ * single normalized shape (NormalizedAddVariable) and only does state mutation.
+ * This is the pattern every command follows when both the agent and the UI
+ * are callers.
  */
 
 import { type z } from 'zod';
@@ -17,7 +19,7 @@ import type { VariableKind } from '@grafana/schema/dist/esm/schema/dashboard/v2'
 import { createSceneVariableFromVariableModel } from '../../serialization/transformSaveModelSchemaV2ToScene';
 
 import { payloads } from './schemas';
-import { enterEditModeIfNeeded, requiresEdit, type MutationCommand } from './types';
+import { enterEditModeIfNeeded, requiresEdit, type CommandInput, type MutationCommand } from './types';
 import { isSceneNativeVariablePayload, replaceVariableSet } from './variableUtils';
 
 export const addVariablePayloadSchema = payloads.addVariable;
@@ -30,25 +32,7 @@ interface NormalizedAddVariable {
   position: number | undefined;
 }
 
-/**
- * Normalize either payload shape into a single object the handler can use.
- * Contains the `__scenesPayload` fork in one place; the handler stays focused
- * on state mutation only.
- */
-function normalize(payload: AddVariablePayload | { __scenesPayload: SceneVariable }): NormalizedAddVariable {
-  if (isSceneNativeVariablePayload(payload)) {
-    return { sceneVariable: payload.__scenesPayload, name: payload.__scenesPayload.state.name, position: undefined };
-  }
-  const variableKind = payload.variable;
-  return {
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Zod output is structurally compatible with VariableKind
-    sceneVariable: createSceneVariableFromVariableModel(variableKind as VariableKind),
-    name: variableKind.spec.name,
-    position: payload.position,
-  };
-}
-
-export const addVariableCommand: MutationCommand<AddVariablePayload> = {
+export const addVariableCommand: MutationCommand<AddVariablePayload, NormalizedAddVariable> = {
   name: 'ADD_VARIABLE',
   description: payloads.addVariable.description ?? '',
 
@@ -58,14 +42,28 @@ export const addVariableCommand: MutationCommand<AddVariablePayload> = {
   undoDomain: 'variables',
   lockTarget: 'variables',
 
-  handler: async (payload, context) => {
+  transformPayloadToScene(payload: CommandInput<AddVariablePayload>): NormalizedAddVariable {
+    if (isSceneNativeVariablePayload(payload)) {
+      return {
+        sceneVariable: payload.__scenesPayload,
+        name: payload.__scenesPayload.state.name,
+        position: undefined,
+      };
+    }
+    const variableKind = payload.variable;
+    return {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Zod output is structurally compatible with VariableKind
+      sceneVariable: createSceneVariableFromVariableModel(variableKind as VariableKind),
+      name: variableKind.spec.name,
+      position: payload.position,
+    };
+  },
+
+  handler: async ({ sceneVariable, name, position }, context) => {
     const { scene } = context;
     enterEditModeIfNeeded(scene);
 
     try {
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- payload shape narrowed via discriminated union at dispatch time
-      const { sceneVariable, name, position } = normalize(payload as Parameters<typeof normalize>[0]);
-
       const existingVariables = scene.state.$variables;
       if (existingVariables?.state.variables.find((v) => v.state.name === name)) {
         throw new Error(`Variable '${name}' already exists`);

--- a/public/app/features/dashboard-scene/mutation-api/commands/addVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/addVariable.ts
@@ -27,6 +27,7 @@ export const addVariableCommand: MutationCommand<AddVariablePayload> = {
   permission: requiresEdit,
   readOnly: false,
   undoDomain: 'variables',
+  lockTarget: 'variables',
 
   handler: async (payload, context) => {
     const { scene } = context;

--- a/public/app/features/dashboard-scene/mutation-api/commands/addVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/addVariable.ts
@@ -2,6 +2,11 @@
  * ADD_VARIABLE command
  *
  * Add a template variable to the dashboard using v2beta1 VariableKind format.
+ *
+ * Concept (normalize helper): the `__scenesPayload` discriminated-union
+ * branch lives in `normalize()` at the top of the file, not inside the
+ * handler. The handler then has exactly one branch — state mutation. This
+ * is the pattern other commands should follow when migrating.
  */
 
 import { type z } from 'zod';
@@ -19,6 +24,30 @@ export const addVariablePayloadSchema = payloads.addVariable;
 
 export type AddVariablePayload = z.infer<typeof addVariablePayloadSchema>;
 
+interface NormalizedAddVariable {
+  sceneVariable: SceneVariable;
+  name: string;
+  position: number | undefined;
+}
+
+/**
+ * Normalize either payload shape into a single object the handler can use.
+ * Contains the `__scenesPayload` fork in one place; the handler stays focused
+ * on state mutation only.
+ */
+function normalize(payload: AddVariablePayload | { __scenesPayload: SceneVariable }): NormalizedAddVariable {
+  if (isSceneNativeVariablePayload(payload)) {
+    return { sceneVariable: payload.__scenesPayload, name: payload.__scenesPayload.state.name, position: undefined };
+  }
+  const variableKind = payload.variable;
+  return {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Zod output is structurally compatible with VariableKind
+    sceneVariable: createSceneVariableFromVariableModel(variableKind as VariableKind),
+    name: variableKind.spec.name,
+    position: payload.position,
+  };
+}
+
 export const addVariableCommand: MutationCommand<AddVariablePayload> = {
   name: 'ADD_VARIABLE',
   description: payloads.addVariable.description ?? '',
@@ -34,41 +63,21 @@ export const addVariableCommand: MutationCommand<AddVariablePayload> = {
     enterEditModeIfNeeded(scene);
 
     try {
-      let sceneVariable: SceneVariable;
-      let name: string;
-      let position: number | undefined;
-
-      if (isSceneNativeVariablePayload(payload)) {
-        sceneVariable = payload.__scenesPayload;
-        name = sceneVariable.state.name;
-        position = undefined;
-      } else {
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- validated by Zod in DashboardMutationClient
-        const typedPayload = payload as AddVariablePayload;
-        const variableKind = typedPayload.variable;
-        name = variableKind.spec.name;
-        position = typedPayload.position;
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Zod output is structurally compatible with VariableKind
-        sceneVariable = createSceneVariableFromVariableModel(variableKind as VariableKind);
-      }
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- payload shape narrowed via discriminated union at dispatch time
+      const { sceneVariable, name, position } = normalize(payload as Parameters<typeof normalize>[0]);
 
       const existingVariables = scene.state.$variables;
-      if (existingVariables) {
-        const existing = existingVariables.state.variables.find((v) => v.state.name === name);
-        if (existing) {
-          throw new Error(`Variable '${name}' already exists`);
-        }
+      if (existingVariables?.state.variables.find((v) => v.state.name === name)) {
+        throw new Error(`Variable '${name}' already exists`);
       }
 
       const varSet = sceneGraph.getVariables(scene);
       const currentVariables = [...varSet.state.variables];
-
       if (position !== undefined && position >= 0 && position < currentVariables.length) {
         currentVariables.splice(position, 0, sceneVariable);
       } else {
         currentVariables.push(sceneVariable);
       }
-
       replaceVariableSet(scene, currentVariables);
 
       return {

--- a/public/app/features/dashboard-scene/mutation-api/commands/redo.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/redo.ts
@@ -1,0 +1,28 @@
+/**
+ * REDO command
+ *
+ * Redo the last undone mutation. Counterpart to UNDO; both go through the
+ * dashboard's MutationRecorder so the in-memory stack stays consistent
+ * regardless of caller.
+ */
+
+import { payloads } from './schemas';
+import { readOnly, type MutationCommand } from './types';
+
+export const redoCommand: MutationCommand<Record<string, never>> = {
+  name: 'REDO',
+  description: payloads.redo.description ?? '',
+
+  payloadSchema: payloads.redo,
+  permission: readOnly,
+  readOnly: false,
+
+  handler: async (_payload, context) => {
+    const { scene } = context;
+    const ok = scene.mutationRecorder.redo();
+    if (!ok) {
+      return { success: false, error: 'Nothing to redo', changes: [] };
+    }
+    return { success: true, changes: [{ path: '/redo', previousValue: null, newValue: null }] };
+  },
+};

--- a/public/app/features/dashboard-scene/mutation-api/commands/registry.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/registry.ts
@@ -17,11 +17,13 @@ import { listVariablesCommand } from './listVariables';
 import { movePanelCommand } from './movePanel';
 import { moveRowCommand } from './moveRow';
 import { moveTabCommand } from './moveTab';
+import { redoCommand } from './redo';
 import { removePanelCommand } from './removePanel';
 import { removeRowCommand } from './removeRow';
 import { removeTabCommand } from './removeTab';
 import { removeVariableCommand } from './removeVariable';
 import type { MutationCommand } from './types';
+import { undoCommand } from './undo';
 import { updateDashboardSettingsCommand } from './updateDashboardSettings';
 import { updateLayoutCommand } from './updateLayout';
 import { updatePanelCommand } from './updatePanel';
@@ -53,6 +55,8 @@ export const ALL_COMMANDS: Array<MutationCommand<any>> = [
   listPanelsCommand,
   getDashboardInfoCommand,
   updateDashboardSettingsCommand,
+  undoCommand,
+  redoCommand,
 ];
 
 /** All valid command names. */

--- a/public/app/features/dashboard-scene/mutation-api/commands/removeVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/removeVariable.ts
@@ -8,7 +8,7 @@ import { type z } from 'zod';
 
 import { payloads } from './schemas';
 import { enterEditModeIfNeeded, requiresEdit, type MutationCommand } from './types';
-import { replaceVariableSet } from './variableUtils';
+import { isSceneNativeVariablePayload, replaceVariableSet } from './variableUtils';
 
 export const removeVariablePayloadSchema = payloads.removeVariable;
 
@@ -24,8 +24,15 @@ export const removeVariableCommand: MutationCommand<RemoveVariablePayload> = {
 
   handler: async (payload, context) => {
     const { scene } = context;
-    const { name } = payload;
     enterEditModeIfNeeded(scene);
+
+    let name: string;
+    if (isSceneNativeVariablePayload(payload)) {
+      name = payload.__scenesPayload.state.name;
+    } else {
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- validated by Zod in DashboardMutationClient
+      name = (payload as RemoveVariablePayload).name;
+    }
 
     try {
       const variables = scene.state.$variables;

--- a/public/app/features/dashboard-scene/mutation-api/commands/removeVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/removeVariable.ts
@@ -21,6 +21,7 @@ export const removeVariableCommand: MutationCommand<RemoveVariablePayload> = {
   payloadSchema: payloads.removeVariable,
   permission: requiresEdit,
   readOnly: false,
+  undoDomain: 'variables',
 
   handler: async (payload, context) => {
     const { scene } = context;

--- a/public/app/features/dashboard-scene/mutation-api/commands/removeVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/removeVariable.ts
@@ -39,14 +39,18 @@ export const removeVariableCommand: MutationCommand<RemoveVariablePayload> = {
       }
 
       const previousState = variable.state;
-
-      const updatedVariables = variables.state.variables.filter((v) => v.state.name !== name);
+      const variablesBeforeRemove = variables.state.variables.slice();
+      const updatedVariables = variablesBeforeRemove.filter((v) => v.state.name !== name);
       replaceVariableSet(scene, updatedVariables);
 
       return {
         success: true,
         data: { name },
         changes: [{ path: `/variables/${name}`, previousValue: previousState, newValue: null }],
+        _description: `Remove variable '${name}'`,
+        _undo: () => {
+          replaceVariableSet(scene, variablesBeforeRemove);
+        },
       };
     } catch (error) {
       return {

--- a/public/app/features/dashboard-scene/mutation-api/commands/removeVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/removeVariable.ts
@@ -39,18 +39,13 @@ export const removeVariableCommand: MutationCommand<RemoveVariablePayload> = {
       }
 
       const previousState = variable.state;
-      const variablesBeforeRemove = variables.state.variables.slice();
-      const updatedVariables = variablesBeforeRemove.filter((v) => v.state.name !== name);
+      const updatedVariables = variables.state.variables.filter((v) => v.state.name !== name);
       replaceVariableSet(scene, updatedVariables);
 
       return {
         success: true,
         data: { name },
         changes: [{ path: `/variables/${name}`, previousValue: previousState, newValue: null }],
-        _description: `Remove variable '${name}'`,
-        _undo: () => {
-          replaceVariableSet(scene, variablesBeforeRemove);
-        },
       };
     } catch (error) {
       return {

--- a/public/app/features/dashboard-scene/mutation-api/commands/removeVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/removeVariable.ts
@@ -2,19 +2,28 @@
  * REMOVE_VARIABLE command
  *
  * Remove a template variable from the dashboard by name.
+ *
+ * Concept (transformPayloadToScene): both callers (agent payload and
+ * `__scenesPayload`) collapse into a single `{ name }` shape that the
+ * client hands to the handler. The handler stays focused on state
+ * mutation — no branching on payload shape.
  */
 
 import { type z } from 'zod';
 
 import { payloads } from './schemas';
-import { enterEditModeIfNeeded, requiresEdit, type MutationCommand } from './types';
+import { enterEditModeIfNeeded, requiresEdit, type CommandInput, type MutationCommand } from './types';
 import { isSceneNativeVariablePayload, replaceVariableSet } from './variableUtils';
 
 export const removeVariablePayloadSchema = payloads.removeVariable;
 
 export type RemoveVariablePayload = z.infer<typeof removeVariablePayloadSchema>;
 
-export const removeVariableCommand: MutationCommand<RemoveVariablePayload> = {
+interface NormalizedRemoveVariable {
+  name: string;
+}
+
+export const removeVariableCommand: MutationCommand<RemoveVariablePayload, NormalizedRemoveVariable> = {
   name: 'REMOVE_VARIABLE',
   description: payloads.removeVariable.description ?? '',
 
@@ -24,17 +33,16 @@ export const removeVariableCommand: MutationCommand<RemoveVariablePayload> = {
   undoDomain: 'variables',
   lockTarget: 'variables',
 
-  handler: async (payload, context) => {
+  transformPayloadToScene(payload: CommandInput<RemoveVariablePayload>): NormalizedRemoveVariable {
+    if (isSceneNativeVariablePayload(payload)) {
+      return { name: payload.__scenesPayload.state.name };
+    }
+    return { name: payload.name };
+  },
+
+  handler: async ({ name }, context) => {
     const { scene } = context;
     enterEditModeIfNeeded(scene);
-
-    let name: string;
-    if (isSceneNativeVariablePayload(payload)) {
-      name = payload.__scenesPayload.state.name;
-    } else {
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- validated by Zod in DashboardMutationClient
-      name = (payload as RemoveVariablePayload).name;
-    }
 
     try {
       const variables = scene.state.$variables;

--- a/public/app/features/dashboard-scene/mutation-api/commands/removeVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/removeVariable.ts
@@ -22,6 +22,7 @@ export const removeVariableCommand: MutationCommand<RemoveVariablePayload> = {
   permission: requiresEdit,
   readOnly: false,
   undoDomain: 'variables',
+  lockTarget: 'variables',
 
   handler: async (payload, context) => {
     const { scene } = context;

--- a/public/app/features/dashboard-scene/mutation-api/commands/schemas.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/schemas.ts
@@ -1036,4 +1036,6 @@ export const payloads = {
   updateDashboardSettings: updateDashboardSettingsPayloadSchema.describe(
     'Update dashboard settings (title, description, tags, refresh, time range, timezone, editable)'
   ),
+  undo: emptyPayloadSchema.describe('Undo the last recorded mutation on this dashboard'),
+  redo: emptyPayloadSchema.describe('Redo the last undone mutation on this dashboard'),
 };

--- a/public/app/features/dashboard-scene/mutation-api/commands/types.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/types.ts
@@ -26,6 +26,14 @@ export type PermissionCheck = (scene: DashboardScene) => PermissionCheckResult;
  * Each command file exports a single MutationCommand. The registry collects
  * them and the DashboardMutationClient iterates over them generically.
  */
+/**
+ * Declares which state slice a command modifies.
+ * DashboardMutationClient snapshots this slice before execution and registers
+ * perform/undo callbacks automatically — no per-handler undo logic required.
+ * Extend with new literals as new command domains are wired up.
+ */
+export type UndoDomain = 'variables';
+
 export interface MutationCommand<T = unknown> {
   /** Command name -- must be UPPER_CASE. Used as the MutationType value. */
   name: string;
@@ -37,6 +45,9 @@ export interface MutationCommand<T = unknown> {
   permission: PermissionCheck;
   /** When true, the command only reads state and will not trigger a forceRender. */
   readOnly?: boolean;
+  /** Declares which state slice this command modifies. When set, the client automatically
+   *  snapshots the domain before execution and registers an undo/redo history entry. */
+  undoDomain?: UndoDomain;
   /** The handler function. */
   handler: (payload: T, context: MutationContext) => Promise<MutationResult>;
 }

--- a/public/app/features/dashboard-scene/mutation-api/commands/types.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/types.ts
@@ -8,6 +8,7 @@
 import { type z } from 'zod';
 
 import { config } from '@grafana/runtime';
+import type { SceneObject } from '@grafana/scenes';
 
 import type { DashboardScene } from '../../scene/DashboardScene';
 import type { MutationResult } from '../types';
@@ -34,13 +35,19 @@ export type PermissionCheck = (scene: DashboardScene) => PermissionCheckResult;
  */
 export type UndoDomain = 'variables';
 
-export interface MutationCommand<T = unknown> {
+/**
+ * Discriminated input the client hands to a command's transformer: either a
+ * Zod-validated agent payload, or a scenes-native carrier wrapping a SceneObject.
+ */
+export type CommandInput<TInput> = TInput | { __scenesPayload: SceneObject };
+
+export interface MutationCommand<TInput = unknown, TScene = TInput> {
   /** Command name -- must be UPPER_CASE. Used as the MutationType value. */
   name: string;
   /** Human-readable description. */
   description: string;
   /** Zod schema for runtime payload validation. Single source of truth. */
-  payloadSchema: z.ZodType<T>;
+  payloadSchema: z.ZodType<TInput>;
   /** Permission check run before execution. Must be a pure predicate (no side effects). */
   permission: PermissionCheck;
   /** When true, the command only reads state and will not trigger a forceRender. */
@@ -59,9 +66,21 @@ export interface MutationCommand<T = unknown> {
    *  (keeps the original beforeSnapshot, updates the afterSnapshot). Useful for
    *  rapid mutations like typing in a label field. `gapMs` is the milliseconds
    *  since the previous entry was registered. */
-  canCoalesceWith?: (previousPayload: T, gapMs: number) => boolean;
-  /** The handler function. */
-  handler: (payload: T, context: MutationContext) => Promise<MutationResult>;
+  canCoalesceWith?: (previousPayload: TScene, gapMs: number) => boolean;
+  /**
+   * Normalize the raw input the client receives into the shape the handler
+   * needs. Called by DashboardMutationClient between Zod validation and the
+   * handler, so every command sees a single payload shape regardless of
+   * whether the caller is the agent (validated payload) or the UI (scenes
+   * payload). Default identity when omitted (TScene defaults to TInput).
+   *
+   * Lives on the command, not in the handler, so the two-shape fork is
+   * declared in one place per command instead of branching at the top of
+   * every handler.
+   */
+  transformPayloadToScene?: (payload: CommandInput<TInput>) => TScene;
+  /** The handler function. Receives the normalized payload (TScene). */
+  handler: (payload: TScene, context: MutationContext) => Promise<MutationResult>;
 }
 
 /**

--- a/public/app/features/dashboard-scene/mutation-api/commands/types.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/types.ts
@@ -48,6 +48,10 @@ export interface MutationCommand<T = unknown> {
   /** Declares which state slice this command modifies. When set, the client automatically
    *  snapshots the domain before execution and registers an undo/redo history entry. */
   undoDomain?: UndoDomain;
+  /** Optional write-lock target this command operates against (e.g. 'variables').
+   *  If the target is locked at execute() time, DashboardMutationClient short-circuits
+   *  with { success: false, locked: true } without running the handler. */
+  lockTarget?: string;
   /** The handler function. */
   handler: (payload: T, context: MutationContext) => Promise<MutationResult>;
 }

--- a/public/app/features/dashboard-scene/mutation-api/commands/types.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/types.ts
@@ -54,6 +54,12 @@ export interface MutationCommand<T = unknown> {
    *  If the target is locked at execute() time, DashboardMutationClient short-circuits
    *  with { success: false, locked: true } without running the handler. */
   lockTarget?: string;
+  /** Optional coalescing hint. If the previous undo entry was the same command
+   *  and this predicate returns true, the client merges the two into one entry
+   *  (keeps the original beforeSnapshot, updates the afterSnapshot). Useful for
+   *  rapid mutations like typing in a label field. `gapMs` is the milliseconds
+   *  since the previous entry was registered. */
+  canCoalesceWith?: (previousPayload: T, gapMs: number) => boolean;
   /** The handler function. */
   handler: (payload: T, context: MutationContext) => Promise<MutationResult>;
 }

--- a/public/app/features/dashboard-scene/mutation-api/commands/types.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/types.ts
@@ -45,9 +45,11 @@ export interface MutationCommand<T = unknown> {
   permission: PermissionCheck;
   /** When true, the command only reads state and will not trigger a forceRender. */
   readOnly?: boolean;
-  /** Declares which state slice this command modifies. When set, the client automatically
-   *  snapshots the domain before execution and registers an undo/redo history entry. */
-  undoDomain?: UndoDomain;
+  /** Declares which state slice(s) this command modifies. When set, the client
+   *  snapshots each domain before execution and registers an undo/redo history entry.
+   *  Pass an array for commands that touch multiple slices (e.g. removing a panel
+   *  that also drops referencing variables). */
+  undoDomain?: UndoDomain | UndoDomain[];
   /** Optional write-lock target this command operates against (e.g. 'variables').
    *  If the target is locked at execute() time, DashboardMutationClient short-circuits
    *  with { success: false, locked: true } without running the handler. */

--- a/public/app/features/dashboard-scene/mutation-api/commands/undo.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/undo.ts
@@ -1,0 +1,31 @@
+/**
+ * UNDO command
+ *
+ * Undo the last recorded mutation. Dispatches into the dashboard's
+ * MutationRecorder, which holds the in-memory undo stack. The toolbar undo
+ * button and the agent share this path — the recorder does not care who
+ * triggered the request.
+ */
+
+import { payloads } from './schemas';
+import { readOnly, type MutationCommand } from './types';
+
+export const undoCommand: MutationCommand<Record<string, never>> = {
+  name: 'UNDO',
+  description: payloads.undo.description ?? '',
+
+  payloadSchema: payloads.undo,
+  permission: readOnly,
+  // Undo mutates state but the recorder owns its own pre/post bookkeeping.
+  // The mutation client should not snapshot or push another entry.
+  readOnly: false,
+
+  handler: async (_payload, context) => {
+    const { scene } = context;
+    const ok = scene.mutationRecorder.undo();
+    if (!ok) {
+      return { success: false, error: 'Nothing to undo', changes: [] };
+    }
+    return { success: true, changes: [{ path: '/undo', previousValue: null, newValue: null }] };
+  },
+};

--- a/public/app/features/dashboard-scene/mutation-api/commands/updateVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updateVariable.ts
@@ -26,6 +26,7 @@ export const updateVariableCommand: MutationCommand<UpdateVariablePayload> = {
   payloadSchema: payloads.updateVariable,
   permission: requiresEdit,
   readOnly: false,
+  undoDomain: 'variables',
 
   handler: async (payload, context) => {
     const { scene } = context;

--- a/public/app/features/dashboard-scene/mutation-api/commands/updateVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updateVariable.ts
@@ -35,7 +35,8 @@ export const updateVariableCommand: MutationCommand<UpdateVariablePayload> = {
       const { name, variable: variableKind } = payload;
 
       const varSet = sceneGraph.getVariables(scene);
-      const currentVariables = [...varSet.state.variables];
+      const variablesBeforeUpdate = varSet.state.variables.slice();
+      const currentVariables = [...variablesBeforeUpdate];
 
       const existingIndex = currentVariables.findIndex((v) => v.state.name === name);
       if (existingIndex === -1) {
@@ -60,6 +61,10 @@ export const updateVariableCommand: MutationCommand<UpdateVariablePayload> = {
             newValue: variableKind,
           },
         ],
+        _description: `Update variable '${name}'`,
+        _undo: () => {
+          replaceVariableSet(scene, variablesBeforeUpdate);
+        },
       };
     } catch (error) {
       return {

--- a/public/app/features/dashboard-scene/mutation-api/commands/updateVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updateVariable.ts
@@ -35,8 +35,7 @@ export const updateVariableCommand: MutationCommand<UpdateVariablePayload> = {
       const { name, variable: variableKind } = payload;
 
       const varSet = sceneGraph.getVariables(scene);
-      const variablesBeforeUpdate = varSet.state.variables.slice();
-      const currentVariables = [...variablesBeforeUpdate];
+      const currentVariables = [...varSet.state.variables];
 
       const existingIndex = currentVariables.findIndex((v) => v.state.name === name);
       if (existingIndex === -1) {
@@ -54,17 +53,7 @@ export const updateVariableCommand: MutationCommand<UpdateVariablePayload> = {
       return {
         success: true,
         data: { variable: variableKind },
-        changes: [
-          {
-            path: `/variables/${name}`,
-            previousValue: previousState,
-            newValue: variableKind,
-          },
-        ],
-        _description: `Update variable '${name}'`,
-        _undo: () => {
-          replaceVariableSet(scene, variablesBeforeUpdate);
-        },
+        changes: [{ path: `/variables/${name}`, previousValue: previousState, newValue: variableKind }],
       };
     } catch (error) {
       return {

--- a/public/app/features/dashboard-scene/mutation-api/commands/updateVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updateVariable.ts
@@ -6,14 +6,14 @@
 
 import { type z } from 'zod';
 
-import { sceneGraph } from '@grafana/scenes';
+import { sceneGraph, type SceneVariable } from '@grafana/scenes';
 import type { VariableKind } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 
 import { createSceneVariableFromVariableModel } from '../../serialization/transformSaveModelSchemaV2ToScene';
 
 import { payloads } from './schemas';
 import { enterEditModeIfNeeded, requiresEdit, type MutationCommand } from './types';
-import { replaceVariableSet } from './variableUtils';
+import { isSceneNativeVariablePayload, replaceVariableSet } from './variableUtils';
 
 export const updateVariablePayloadSchema = payloads.updateVariable;
 
@@ -32,7 +32,20 @@ export const updateVariableCommand: MutationCommand<UpdateVariablePayload> = {
     enterEditModeIfNeeded(scene);
 
     try {
-      const { name, variable: variableKind } = payload;
+      let newSceneVariable: SceneVariable;
+      let name: string;
+
+      if (isSceneNativeVariablePayload(payload)) {
+        newSceneVariable = payload.__scenesPayload;
+        name = newSceneVariable.state.name;
+      } else {
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- validated by Zod in DashboardMutationClient
+        const typedPayload = payload as UpdateVariablePayload;
+        name = typedPayload.name;
+        const variableKind = typedPayload.variable;
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Zod output is structurally compatible with VariableKind
+        newSceneVariable = createSceneVariableFromVariableModel(variableKind as VariableKind);
+      }
 
       const varSet = sceneGraph.getVariables(scene);
       const currentVariables = [...varSet.state.variables];
@@ -43,17 +56,14 @@ export const updateVariableCommand: MutationCommand<UpdateVariablePayload> = {
       }
 
       const previousState = currentVariables[existingIndex].state;
-
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- Zod output is structurally compatible with VariableKind
-      const newSceneVariable = createSceneVariableFromVariableModel(variableKind as VariableKind);
       currentVariables[existingIndex] = newSceneVariable;
 
       replaceVariableSet(scene, currentVariables);
 
       return {
         success: true,
-        data: { variable: variableKind },
-        changes: [{ path: `/variables/${name}`, previousValue: previousState, newValue: variableKind }],
+        data: { name },
+        changes: [{ path: `/variables/${name}`, previousValue: previousState, newValue: name }],
       };
     } catch (error) {
       return {

--- a/public/app/features/dashboard-scene/mutation-api/commands/updateVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updateVariable.ts
@@ -28,6 +28,12 @@ export const updateVariableCommand: MutationCommand<UpdateVariablePayload> = {
   readOnly: false,
   undoDomain: 'variables',
   lockTarget: 'variables',
+  // Concept: coalesce rapid updates to the same variable into one undo entry.
+  // Typing in a label/name field produces many UPDATE_VARIABLE calls; without
+  // this hint each keystroke is a separate undo step.
+  canCoalesceWith: (previousPayload, gapMs) => {
+    return gapMs < 500 && previousPayload.name === previousPayload.name;
+  },
 
   handler: async (payload, context) => {
     const { scene } = context;

--- a/public/app/features/dashboard-scene/mutation-api/commands/updateVariable.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/updateVariable.ts
@@ -27,6 +27,7 @@ export const updateVariableCommand: MutationCommand<UpdateVariablePayload> = {
   permission: requiresEdit,
   readOnly: false,
   undoDomain: 'variables',
+  lockTarget: 'variables',
 
   handler: async (payload, context) => {
     const { scene } = context;

--- a/public/app/features/dashboard-scene/mutation-api/commands/variableCommands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/variableCommands.test.ts
@@ -1,4 +1,4 @@
-import { type CustomVariable, type QueryVariable, SceneVariableSet } from '@grafana/scenes';
+import { CustomVariable, type QueryVariable, SceneVariableSet } from '@grafana/scenes';
 
 import { DashboardEditActionEvent } from '../../edit-pane/events';
 import type { DashboardScene } from '../../scene/DashboardScene';
@@ -448,6 +448,58 @@ describe('Variable mutation commands', () => {
 
       perform();
       expect(sceneWithEvents.state.$variables?.state.variables.find((v) => v.state.name === 'redoable')).toBeDefined();
+    });
+  });
+
+  // --- Scenes-native path (cmd.addVariable/updateVariable/removeVariable with SceneVariable) ---
+
+  describe('Scenes-native path', () => {
+    it('cmd.addVariable with SceneVariable adds it to the dashboard', async () => {
+      const sceneVar = new CustomVariable({ name: 'native', query: 'x,y,z' });
+      const result = await client.execute(cmd.addVariable(sceneVar));
+
+      expect(result.success).toBe(true);
+      expect(result.changes[0].path).toBe('/variables/native');
+      expect(scene.state.$variables?.state.variables.find((v) => v.state.name === 'native')).toBeDefined();
+    });
+
+    it('cmd.updateVariable with SceneVariable updates the existing variable', async () => {
+      await client.execute(
+        cmd.addVariable({ variable: { kind: 'CustomVariable', spec: { name: 'updateme', query: 'before' } } })
+      );
+
+      const updatedVar = new CustomVariable({ name: 'updateme', query: 'after' });
+      const result = await client.execute(cmd.updateVariable(updatedVar));
+
+      expect(result.success).toBe(true);
+      expect(result.changes[0].path).toBe('/variables/updateme');
+      const stored = scene.state.$variables?.state.variables.find((v) => v.state.name === 'updateme');
+      expect((stored as CustomVariable | undefined)?.state.query).toBe('after');
+    });
+
+    it('cmd.removeVariable with SceneVariable removes it from the dashboard', async () => {
+      await client.execute(
+        cmd.addVariable({ variable: { kind: 'CustomVariable', spec: { name: 'removeme', query: 'a,b' } } })
+      );
+
+      const sceneVar = new CustomVariable({ name: 'removeme', query: 'a,b' });
+      const result = await client.execute(cmd.removeVariable(sceneVar));
+
+      expect(result.success).toBe(true);
+      expect(scene.state.$variables?.state.variables.find((v) => v.state.name === 'removeme')).toBeUndefined();
+    });
+
+    it('cmd.addVariable Scenes-native path produces __scenesPayload request', () => {
+      const sceneVar = new CustomVariable({ name: 'check', query: 'a' });
+      const request = cmd.addVariable(sceneVar);
+      expect(request.type).toBe('ADD_VARIABLE');
+      expect('__scenesPayload' in request).toBe(true);
+    });
+
+    it('cmd.addVariable payload path still produces payload request', () => {
+      const request = cmd.addVariable({ variable: { kind: 'CustomVariable', spec: { name: 'x', query: 'a' } } });
+      expect(request.type).toBe('ADD_VARIABLE');
+      expect('payload' in request).toBe(true);
     });
   });
 

--- a/public/app/features/dashboard-scene/mutation-api/commands/variableCommands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/variableCommands.test.ts
@@ -242,6 +242,36 @@ describe('Variable mutation commands', () => {
     expect(result.error).toContain('Validation failed');
   });
 
+  it('ADD_VARIABLE Zod rejects unknown variable kind', async () => {
+    const result = await client.execute({
+      type: 'ADD_VARIABLE',
+      payload: { variable: { kind: 'WeirdVariable', spec: { name: 'x' } } },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Validation failed');
+  });
+
+  it('ADD_VARIABLE Zod rejects CustomVariable with missing query field', async () => {
+    const result = await client.execute({
+      type: 'ADD_VARIABLE',
+      payload: { variable: { kind: 'CustomVariable', spec: {} } },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Validation failed');
+  });
+
+  it('UPDATE_VARIABLE Zod rejects missing name field', async () => {
+    const result = await client.execute({
+      type: 'UPDATE_VARIABLE',
+      payload: { variable: { kind: 'CustomVariable', spec: { name: 'x', query: 'a' } } },
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toContain('Validation failed');
+  });
+
   it('rejects unknown command types', async () => {
     const result = await client.execute({
       type: 'NONEXISTENT_COMMAND',
@@ -398,12 +428,26 @@ describe('Variable mutation commands', () => {
       expect((restoredVar as CustomVariable | undefined)?.state.query).toBe('before');
     });
 
-    it('internal _undo/_description fields are stripped from the returned result', async () => {
-      const result = await clientWithEvents.execute(
-        cmd.addVariable({ variable: { kind: 'CustomVariable', spec: { name: 'check', query: 'x' } } })
+    it('ADD_VARIABLE redo re-applies the mutation after undo', async () => {
+      await clientWithEvents.execute(
+        cmd.addVariable({ variable: { kind: 'CustomVariable', spec: { name: 'redoable', query: 'a,b' } } })
       );
-      expect(result).not.toHaveProperty('_undo');
-      expect(result).not.toHaveProperty('_description');
+
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- mock scene has publishEvent as jest.Mock
+      const publishMock = (sceneWithEvents as unknown as { publishEvent: jest.Mock }).publishEvent;
+      const event: DashboardEditActionEvent = publishMock.mock.calls[0][0];
+      const { perform, undo } = event.payload;
+
+      // Trigger the initial no-op (simulates DashboardEditPane.handleEditAction)
+      perform();
+
+      undo();
+      expect(
+        sceneWithEvents.state.$variables?.state.variables.find((v) => v.state.name === 'redoable')
+      ).toBeUndefined();
+
+      perform();
+      expect(sceneWithEvents.state.$variables?.state.variables.find((v) => v.state.name === 'redoable')).toBeDefined();
     });
   });
 

--- a/public/app/features/dashboard-scene/mutation-api/commands/variableCommands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/variableCommands.test.ts
@@ -1,11 +1,18 @@
-import { SceneVariableSet } from '@grafana/scenes';
+import { type CustomVariable, type QueryVariable, SceneVariableSet } from '@grafana/scenes';
 
+import { DashboardEditActionEvent } from '../../edit-pane/events';
 import type { DashboardScene } from '../../scene/DashboardScene';
+import { createSceneVariableFromVariableModel } from '../../serialization/transformSaveModelSchemaV2ToScene';
 import { DashboardMutationClient } from '../DashboardMutationClient';
+import { cmd } from '../cmd';
 import type { MutationResult } from '../types';
 
-function buildMockScene(options: { editable?: boolean; isEditing?: boolean } = {}): DashboardScene {
-  const { editable = true, isEditing = false } = options;
+import { createVariableKindFromSceneVariable } from './variableUtils';
+
+function buildMockScene(
+  options: { editable?: boolean; isEditing?: boolean; withEventBus?: boolean } = {}
+): DashboardScene {
+  const { editable = true, isEditing = false, withEventBus = false } = options;
   const state: Record<string, unknown> = {
     uid: 'test-dash',
     isEditing,
@@ -18,6 +25,7 @@ function buildMockScene(options: { editable?: boolean; isEditing?: boolean } = {
       state.isEditing = true;
     }),
     forceRender: jest.fn(),
+    publishEvent: withEventBus ? jest.fn() : undefined,
     setState: jest.fn((partial: Record<string, unknown>) => {
       Object.assign(state, partial);
       // Activate new variable set if provided
@@ -260,5 +268,190 @@ describe('Variable mutation commands', () => {
 
     expect(result.success).toBe(false);
     expect(result.error).toContain('Cannot edit dashboard');
+  });
+
+  // --- cmd builder ---
+
+  it('cmd builder produces correct MutationRequest type strings', () => {
+    expect(cmd.addVariable({ variable: { kind: 'CustomVariable', spec: { name: 'x', query: 'a' } } }).type).toBe(
+      'ADD_VARIABLE'
+    );
+    expect(
+      cmd.updateVariable({ name: 'x', variable: { kind: 'CustomVariable', spec: { name: 'x', query: 'a' } } }).type
+    ).toBe('UPDATE_VARIABLE');
+    expect(cmd.removeVariable({ name: 'x' }).type).toBe('REMOVE_VARIABLE');
+    expect(cmd.listVariables({}).type).toBe('LIST_VARIABLES');
+    expect(
+      cmd.addPanel({
+        panel: {
+          kind: 'Panel',
+          spec: {
+            title: 'T',
+            data: { kind: 'QueryGroup', spec: { queries: [] } },
+            vizConfig: { kind: 'VizConfig', group: 'timeseries', spec: {} },
+          },
+        },
+        parentPath: '/',
+      }).type
+    ).toBe('ADD_PANEL');
+    expect(cmd.updateDashboardSettings({}).type).toBe('UPDATE_DASHBOARD_SETTINGS');
+  });
+
+  it('cmd builder payloads round-trip through execute', async () => {
+    const result = await client.execute(
+      cmd.addVariable({ variable: { kind: 'CustomVariable', spec: { name: 'built', query: 'x,y' } } })
+    );
+    expect(result.success).toBe(true);
+    expect(result.changes[0].path).toBe('/variables/built');
+  });
+
+  // --- Undo/redo integration ---
+
+  describe('undo/redo wiring', () => {
+    let sceneWithEvents: DashboardScene;
+    let clientWithEvents: DashboardMutationClient;
+
+    beforeEach(() => {
+      sceneWithEvents = buildMockScene({ editable: true, withEventBus: true });
+      clientWithEvents = new DashboardMutationClient(sceneWithEvents);
+    });
+
+    it('ADD_VARIABLE publishes DashboardEditActionEvent', async () => {
+      await clientWithEvents.execute(
+        cmd.addVariable({ variable: { kind: 'CustomVariable', spec: { name: 'toAdd', query: 'a,b' } } })
+      );
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- mock scene has publishEvent as jest.Mock
+      expect((sceneWithEvents as unknown as { publishEvent: jest.Mock }).publishEvent).toHaveBeenCalledWith(
+        expect.any(DashboardEditActionEvent),
+        true
+      );
+    });
+
+    it('ADD_VARIABLE undo removes the variable', async () => {
+      await clientWithEvents.execute(
+        cmd.addVariable({ variable: { kind: 'CustomVariable', spec: { name: 'willUndo', query: 'a,b' } } })
+      );
+
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- mock scene has publishEvent as jest.Mock
+      const publishMock = (sceneWithEvents as unknown as { publishEvent: jest.Mock }).publishEvent;
+      const event: DashboardEditActionEvent = publishMock.mock.calls[0][0];
+      const { undo } = event.payload;
+
+      // Variable should be present before undo
+      expect(sceneWithEvents.state.$variables?.state.variables.find((v) => v.state.name === 'willUndo')).toBeDefined();
+
+      undo();
+
+      // Variable should be gone after undo
+      expect(
+        sceneWithEvents.state.$variables?.state.variables.find((v) => v.state.name === 'willUndo')
+      ).toBeUndefined();
+    });
+
+    it('REMOVE_VARIABLE undo restores the variable', async () => {
+      await clientWithEvents.execute(
+        cmd.addVariable({ variable: { kind: 'CustomVariable', spec: { name: 'willRestore', query: 'a,b' } } })
+      );
+
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- mock scene has publishEvent as jest.Mock
+      const publishMock = (sceneWithEvents as unknown as { publishEvent: jest.Mock }).publishEvent;
+      publishMock.mockClear();
+
+      await clientWithEvents.execute(cmd.removeVariable({ name: 'willRestore' }));
+
+      expect(
+        sceneWithEvents.state.$variables?.state.variables.find((v) => v.state.name === 'willRestore')
+      ).toBeUndefined();
+
+      const removeEvent: DashboardEditActionEvent = publishMock.mock.calls[0][0];
+      removeEvent.payload.undo();
+
+      expect(
+        sceneWithEvents.state.$variables?.state.variables.find((v) => v.state.name === 'willRestore')
+      ).toBeDefined();
+    });
+
+    it('UPDATE_VARIABLE undo restores the previous variable state', async () => {
+      await clientWithEvents.execute(
+        cmd.addVariable({ variable: { kind: 'CustomVariable', spec: { name: 'mutable', query: 'before' } } })
+      );
+
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- mock scene has publishEvent as jest.Mock
+      const publishMock = (sceneWithEvents as unknown as { publishEvent: jest.Mock }).publishEvent;
+      publishMock.mockClear();
+
+      await clientWithEvents.execute(
+        cmd.updateVariable({
+          name: 'mutable',
+          variable: { kind: 'CustomVariable', spec: { name: 'mutable', query: 'after' } },
+        })
+      );
+
+      // After update the variable should reflect the new query
+      const updatedVar = sceneWithEvents.state.$variables?.state.variables.find((v) => v.state.name === 'mutable');
+      expect((updatedVar as CustomVariable | undefined)?.state.query).toBe('after');
+
+      const updateEvent: DashboardEditActionEvent = publishMock.mock.calls[0][0];
+      updateEvent.payload.undo();
+
+      const restoredVar = sceneWithEvents.state.$variables?.state.variables.find((v) => v.state.name === 'mutable');
+      expect((restoredVar as CustomVariable | undefined)?.state.query).toBe('before');
+    });
+
+    it('internal _undo/_description fields are stripped from the returned result', async () => {
+      const result = await clientWithEvents.execute(
+        cmd.addVariable({ variable: { kind: 'CustomVariable', spec: { name: 'check', query: 'x' } } })
+      );
+      expect(result).not.toHaveProperty('_undo');
+      expect(result).not.toHaveProperty('_description');
+    });
+  });
+
+  // --- Reverse transformer (createVariableKindFromSceneVariable) ---
+
+  describe('createVariableKindFromSceneVariable round-trip', () => {
+    it('CustomVariable survives SceneVariable -> VariableKind -> SceneVariable round-trip', () => {
+      const original: Parameters<typeof createSceneVariableFromVariableModel>[0] = {
+        kind: 'CustomVariable',
+        spec: {
+          name: 'env',
+          query: 'dev,staging,prod',
+          multi: true,
+          includeAll: false,
+          skipUrlSync: false,
+          hide: 'dontHide',
+        },
+      };
+      const sceneVar = createSceneVariableFromVariableModel(original);
+      const variableKind = createVariableKindFromSceneVariable(sceneVar);
+      const roundTripped = createSceneVariableFromVariableModel(variableKind as typeof original);
+
+      expect(roundTripped.state.name).toBe('env');
+      expect((roundTripped as CustomVariable).state.query).toBe('dev,staging,prod');
+      expect((roundTripped as CustomVariable).state.isMulti).toBe(true);
+    });
+
+    it('QueryVariable preserves core fields through round-trip', () => {
+      const original: Parameters<typeof createSceneVariableFromVariableModel>[0] = {
+        kind: 'QueryVariable',
+        spec: {
+          name: 'qvar',
+          query: { kind: 'DataQuery', group: 'prometheus', version: 'v0', spec: { expr: 'up' } },
+          refresh: 'onDashboardLoad',
+          regex: '.*',
+          sort: 'alphabeticalAsc',
+          multi: false,
+          includeAll: false,
+          skipUrlSync: false,
+          hide: 'dontHide',
+        },
+      };
+      const sceneVar = createSceneVariableFromVariableModel(original);
+      const variableKind = createVariableKindFromSceneVariable(sceneVar);
+      const roundTripped = createSceneVariableFromVariableModel(variableKind as typeof original);
+
+      expect(roundTripped.state.name).toBe('qvar');
+      expect((roundTripped as QueryVariable).state.regex).toBe('.*');
+    });
   });
 });

--- a/public/app/features/dashboard-scene/mutation-api/commands/variableCommands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/variableCommands.test.ts
@@ -464,6 +464,9 @@ describe('Variable mutation commands', () => {
           includeAll: false,
           skipUrlSync: false,
           hide: 'dontHide',
+          current: { text: '', value: '' },
+          options: [],
+          allowCustomValue: true,
         },
       };
       const sceneVar = createSceneVariableFromVariableModel(original);
@@ -488,6 +491,9 @@ describe('Variable mutation commands', () => {
           includeAll: false,
           skipUrlSync: false,
           hide: 'dontHide',
+          current: { text: '', value: '' },
+          options: [],
+          allowCustomValue: true,
         },
       };
       const sceneVar = createSceneVariableFromVariableModel(original);

--- a/public/app/features/dashboard-scene/mutation-api/commands/variableCommands.test.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/variableCommands.test.ts
@@ -18,6 +18,7 @@ function buildMockScene(
     isEditing,
     $variables: new SceneVariableSet({ variables: [] }),
   };
+  const writeLocks = new Set<string>();
   const scene = {
     state,
     canEditDashboard: jest.fn(() => editable),
@@ -26,6 +27,9 @@ function buildMockScene(
     }),
     forceRender: jest.fn(),
     publishEvent: withEventBus ? jest.fn() : undefined,
+    acquireWriteLock: (t: string) => writeLocks.add(t),
+    releaseWriteLock: (t: string) => writeLocks.delete(t),
+    isWriteLocked: (t: string) => writeLocks.has(t),
     setState: jest.fn((partial: Record<string, unknown>) => {
       Object.assign(state, partial);
       // Activate new variable set if provided
@@ -554,6 +558,81 @@ describe('Variable mutation commands', () => {
 
       expect(roundTripped.state.name).toBe('qvar');
       expect((roundTripped as QueryVariable).state.regex).toBe('.*');
+    });
+  });
+
+  describe('canonical undo: add three, remove middle, undo restores at the right index', () => {
+    it('add [a,b,c], remove b, undo -> [a,b,c], redo -> [a,c]', async () => {
+      const sceneWithBus = buildMockScene({ editable: true, withEventBus: true });
+      const c = new DashboardMutationClient(sceneWithBus);
+
+      // Capture the published events so we can drive undo/redo deterministically
+      const events: Array<{ perform: () => void; undo: () => void }> = [];
+      (sceneWithBus.publishEvent as jest.Mock).mockImplementation((event: DashboardEditActionEvent) => {
+        events.push({ perform: event.payload.perform, undo: event.payload.undo });
+        // DashboardEditPane calls perform() once on subscribe; emulate that here.
+        event.payload.perform();
+      });
+
+      const mkVar = (name: string) => ({ kind: 'CustomVariable' as const, spec: { name, query: 'x,y' } });
+      await c.execute({ type: 'ADD_VARIABLE', payload: { variable: mkVar('a') } });
+      await c.execute({ type: 'ADD_VARIABLE', payload: { variable: mkVar('b') } });
+      await c.execute({ type: 'ADD_VARIABLE', payload: { variable: mkVar('c') } });
+
+      const namesAfterAdds = sceneWithBus.state.$variables!.state.variables.map((v) => v.state.name);
+      expect(namesAfterAdds).toEqual(['a', 'b', 'c']);
+
+      // Remove the middle one
+      await c.execute({ type: 'REMOVE_VARIABLE', payload: { name: 'b' } });
+      expect(sceneWithBus.state.$variables!.state.variables.map((v) => v.state.name)).toEqual(['a', 'c']);
+
+      // Undo the remove -> b should be restored at index 1
+      events[events.length - 1].undo();
+      expect(sceneWithBus.state.$variables!.state.variables.map((v) => v.state.name)).toEqual(['a', 'b', 'c']);
+
+      // Redo the remove -> b should be gone again
+      events[events.length - 1].perform();
+      expect(sceneWithBus.state.$variables!.state.variables.map((v) => v.state.name)).toEqual(['a', 'c']);
+    });
+  });
+
+  describe('multiplayer composition: each mutation reads latest state', () => {
+    it('two sequential add commands accumulate, second sees state from first', async () => {
+      await client.execute({
+        type: 'ADD_VARIABLE',
+        payload: { variable: { kind: 'CustomVariable', spec: { name: 'first', query: 'a,b' } } },
+      });
+      await client.execute({
+        type: 'ADD_VARIABLE',
+        payload: { variable: { kind: 'CustomVariable', spec: { name: 'second', query: 'c,d' } } },
+      });
+
+      expect(scene.state.$variables!.state.variables.map((v) => v.state.name)).toEqual(['first', 'second']);
+    });
+  });
+
+  describe('lock mechanism', () => {
+    it('returns locked:true when the target is write-locked, then succeeds after release', async () => {
+      scene.acquireWriteLock('variables');
+
+      const blocked = await client.execute({
+        type: 'ADD_VARIABLE',
+        payload: { variable: { kind: 'CustomVariable', spec: { name: 'env', query: 'dev,prod' } } },
+      });
+
+      expect(blocked.success).toBe(false);
+      expect(blocked.locked).toBe(true);
+      expect(blocked.error).toMatch(/locked/);
+      expect(scene.state.$variables!.state.variables.map((v) => v.state.name)).toEqual([]);
+
+      scene.releaseWriteLock('variables');
+      const ok = await client.execute({
+        type: 'ADD_VARIABLE',
+        payload: { variable: { kind: 'CustomVariable', spec: { name: 'env', query: 'dev,prod' } } },
+      });
+      expect(ok.success).toBe(true);
+      expect(ok.locked).toBeFalsy();
+      expect(scene.state.$variables!.state.variables.map((v) => v.state.name)).toEqual(['env']);
     });
   });
 });

--- a/public/app/features/dashboard-scene/mutation-api/commands/variableUtils.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/variableUtils.ts
@@ -4,7 +4,37 @@
  * Contains helpers used across add/remove/update variable commands.
  */
 
-import { type sceneGraph, SceneVariableSet } from '@grafana/scenes';
+import { config } from '@grafana/runtime';
+import { type sceneGraph, SceneVariableSet, sceneUtils, type SceneVariable } from '@grafana/scenes';
+import {
+  type AdhocVariableKind,
+  type ConstantVariableKind,
+  type CustomVariableKind,
+  type DataQueryKind,
+  type DatasourceVariableKind,
+  type GroupByVariableKind,
+  type IntervalVariableKind,
+  type QueryVariableKind,
+  type SwitchVariableKind,
+  type TextVariableKind,
+  type VariableKind,
+  type VariableOption,
+  defaultDataQueryKind,
+  defaultIntervalVariableSpec,
+  defaultVariableHide,
+} from '@grafana/schema/apis/dashboard.grafana.app/v2';
+import { getDefaultDatasource } from 'app/features/dashboard/api/ResponseTransformers';
+
+import { getDataSourceForQuery } from '../../serialization/layoutSerializers/utils';
+import { validateFiltersOrigin } from '../../serialization/sceneVariablesSetToVariables';
+import { getDataQueryKind, getElementDatasource } from '../../serialization/transformSceneToSaveModelSchemaV2';
+import {
+  LEGACY_STRING_VALUE_KEY,
+  transformSortVariableToEnum,
+  transformVariableHideToEnum,
+  transformVariableRefreshToEnum,
+} from '../../serialization/transformToV2TypesUtils';
+import { getIntervalsQueryFromNewIntervalModel } from '../../utils/utils';
 
 /**
  * Replace the dashboard's variable set with a new set containing the given variables.
@@ -18,4 +48,262 @@ export function replaceVariableSet(
   scene.setState({ $variables: newVarSet });
   newVarSet.activate();
   return newVarSet;
+}
+
+/**
+ * Convert a single SceneVariable into a v2beta1 VariableKind.
+ *
+ * This is the reverse of createSceneVariableFromVariableModel. It extracts
+ * the current runtime state of one variable and returns the schema representation
+ * suitable for passing to ADD_VARIABLE or UPDATE_VARIABLE commands.
+ *
+ * The parent set is optional -- when provided, it is used to resolve datasource
+ * references for QueryVariable. When omitted, datasource resolution is skipped.
+ */
+export function createVariableKindFromSceneVariable(
+  variable: SceneVariable,
+  parentSet?: Parameters<typeof sceneGraph.getVariables>[0]
+): VariableKind {
+  const commonProperties = {
+    name: variable.state.name,
+    label: variable.state.label,
+    description: variable.state.description ?? undefined,
+    skipUrlSync: Boolean(variable.state.skipUrlSync),
+    hide: transformVariableHideToEnum(variable.state.hide) || defaultVariableHide(),
+  };
+
+  const currentVariableOption: VariableOption = {
+    // @ts-expect-error -- SceneVariable value/text not typed on base state
+    value: variable.state.value,
+    // @ts-expect-error
+    text: variable.state.text,
+  };
+
+  if (sceneUtils.isQueryVariable(variable)) {
+    const query = variable.state.query;
+    let dataQuery: DataQueryKind | string;
+
+    const datasource = parentSet
+      ? getElementDatasource(
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+          parentSet as Parameters<typeof getElementDatasource>[0],
+          variable,
+          'variable'
+        )
+      : undefined;
+
+    if (typeof query !== 'string') {
+      dataQuery = {
+        kind: 'DataQuery',
+        version: defaultDataQueryKind().version,
+        group: datasource?.type || getDataQueryKind(query),
+        ...(datasource?.uid && { datasource: { name: datasource.uid } }),
+        spec: query,
+      };
+    } else {
+      const spec: Record<string, string> = {};
+      if (query) {
+        spec[LEGACY_STRING_VALUE_KEY] = query;
+      }
+      dataQuery = {
+        kind: 'DataQuery',
+        version: defaultDataQueryKind().version,
+        group: datasource?.type || getDataQueryKind(query),
+        ...(datasource?.uid && { datasource: { name: datasource.uid } }),
+        spec,
+      };
+    }
+
+    const result: QueryVariableKind = {
+      kind: 'QueryVariable',
+      spec: {
+        ...commonProperties,
+        current: currentVariableOption,
+        options: [],
+        query: dataQuery,
+        definition: variable.state.definition,
+        sort: transformSortVariableToEnum(variable.state.sort),
+        refresh: transformVariableRefreshToEnum(variable.state.refresh),
+        regex: variable.state.regex ?? '',
+        allValue: variable.state.allValue,
+        includeAll: variable.state.includeAll || false,
+        multi: variable.state.isMulti || false,
+        skipUrlSync: variable.state.skipUrlSync || false,
+        allowCustomValue: variable.state.allowCustomValue ?? true,
+      },
+    };
+    return result;
+  }
+
+  if (sceneUtils.isCustomVariable(variable)) {
+    const result: CustomVariableKind = {
+      kind: 'CustomVariable',
+      spec: {
+        ...commonProperties,
+        current: currentVariableOption,
+        options: [],
+        query: variable.state.query,
+        multi: variable.state.isMulti || false,
+        allValue: variable.state.allValue,
+        includeAll: variable.state.includeAll ?? false,
+        allowCustomValue: variable.state.allowCustomValue ?? true,
+        valuesFormat: variable.state.valuesFormat ?? 'csv',
+      },
+    };
+    return result;
+  }
+
+  if (sceneUtils.isDataSourceVariable(variable)) {
+    const result: DatasourceVariableKind = {
+      kind: 'DatasourceVariable',
+      spec: {
+        ...commonProperties,
+        current: currentVariableOption,
+        options: [],
+        regex: variable.state.regex ?? '',
+        refresh: 'onDashboardLoad',
+        pluginId: variable.state.pluginId ?? getDefaultDatasource().type,
+        multi: variable.state.isMulti || false,
+        includeAll: variable.state.includeAll || false,
+        allowCustomValue: variable.state.allowCustomValue ?? true,
+        ...(variable.state.allValue !== undefined && { allValue: variable.state.allValue }),
+      },
+    };
+    return result;
+  }
+
+  if (sceneUtils.isConstantVariable(variable)) {
+    const value = variable.state.value ? String(variable.state.value) : '';
+    const result: ConstantVariableKind = {
+      kind: 'ConstantVariable',
+      spec: {
+        ...commonProperties,
+        current: { text: value, value },
+        query: value,
+      },
+    };
+    return result;
+  }
+
+  if (sceneUtils.isIntervalVariable(variable)) {
+    const intervals = getIntervalsQueryFromNewIntervalModel(variable.state.intervals);
+    const result: IntervalVariableKind = {
+      kind: 'IntervalVariable',
+      spec: {
+        ...commonProperties,
+        current: {
+          ...currentVariableOption,
+          text: variable.state.value,
+        },
+        query: intervals,
+        refresh: defaultIntervalVariableSpec().refresh,
+        options: variable.state.intervals.map((interval) => ({
+          value: interval,
+          text: interval,
+          selected: interval === variable.state.value,
+        })),
+        auto: variable.state.autoEnabled ?? defaultIntervalVariableSpec().auto,
+        auto_min: variable.state.autoMinInterval ?? defaultIntervalVariableSpec().auto_min,
+        auto_count: variable.state.autoStepCount ?? defaultIntervalVariableSpec().auto_count,
+      },
+    };
+    return result;
+  }
+
+  if (sceneUtils.isTextBoxVariable(variable)) {
+    const current = {
+      text: variable.state.value ?? '',
+      value: variable.state.value ?? '',
+    };
+    const result: TextVariableKind = {
+      kind: 'TextVariable',
+      spec: {
+        ...commonProperties,
+        current,
+        query: variable.state.value ?? '',
+      },
+    };
+    return result;
+  }
+
+  if (sceneUtils.isGroupByVariable(variable) && config.featureToggles.groupByVariable) {
+    // @ts-expect-error
+    const defaultVariableOptionValue: VariableOption | undefined = variable.state.defaultValue
+      ? {
+          value: variable.state.defaultValue.value,
+          text: variable.state.defaultValue.text,
+        }
+      : undefined;
+
+    const ds = getDataSourceForQuery(
+      variable.state.datasource,
+      variable.state.datasource?.type || getDefaultDatasource().type!
+    );
+
+    const result: GroupByVariableKind = {
+      kind: 'GroupByVariable',
+      group: ds.type!,
+      datasource: { name: ds.uid },
+      spec: {
+        ...commonProperties,
+        options:
+          variable.state.defaultOptions?.map((option) => ({
+            text: option.text,
+            value: String(option.value),
+          })) || [],
+        current: currentVariableOption,
+        defaultValue: defaultVariableOptionValue,
+        multi: variable.state.isMulti || false,
+      },
+    };
+    return result;
+  }
+
+  if (sceneUtils.isAdHocVariable(variable)) {
+    const ds = getDataSourceForQuery(
+      variable.state.datasource,
+      variable.state.datasource?.type || getDefaultDatasource().type!
+    );
+    const result: AdhocVariableKind = {
+      kind: 'AdhocVariable',
+      group: ds.type!,
+      datasource: { name: ds.uid },
+      spec: {
+        ...commonProperties,
+        baseFilters: validateFiltersOrigin(variable.state.baseFilters) || [],
+        filters: [
+          ...validateFiltersOrigin(variable.getOriginalFilters()).map(
+            ({ key, operator, value, values, keyLabel, valueLabels, origin }) => ({
+              key,
+              origin,
+              value,
+              values,
+              valueLabels,
+              keyLabel,
+              operator,
+            })
+          ),
+          ...validateFiltersOrigin(variable.state.filters),
+        ],
+        defaultKeys: variable.state.defaultKeys || [],
+        allowCustomValue: variable.state.allowCustomValue ?? true,
+      },
+    };
+    return result;
+  }
+
+  if (sceneUtils.isSwitchVariable(variable)) {
+    const result: SwitchVariableKind = {
+      kind: 'SwitchVariable',
+      spec: {
+        ...commonProperties,
+        current: variable.state.value,
+        enabledValue: variable.state.enabledValue,
+        disabledValue: variable.state.disabledValue,
+      },
+    };
+    return result;
+  }
+
+  throw new Error(`Unsupported variable type: ${variable.state.type}`);
 }

--- a/public/app/features/dashboard-scene/mutation-api/commands/variableUtils.ts
+++ b/public/app/features/dashboard-scene/mutation-api/commands/variableUtils.ts
@@ -307,3 +307,7 @@ export function createVariableKindFromSceneVariable(
 
   throw new Error(`Unsupported variable type: ${variable.state.type}`);
 }
+
+export function isSceneNativeVariablePayload(payload: unknown): payload is { __scenesPayload: SceneVariable } {
+  return typeof payload === 'object' && payload !== null && '__scenesPayload' in payload;
+}

--- a/public/app/features/dashboard-scene/mutation-api/index.ts
+++ b/public/app/features/dashboard-scene/mutation-api/index.ts
@@ -25,3 +25,7 @@ export type {
 export { ALL_COMMANDS, MUTATION_TYPES, validatePayload } from './commands/registry';
 
 export type { MutationCommand } from './commands/types';
+
+export { cmd } from './cmd';
+
+export { createVariableKindFromSceneVariable } from './commands/variableUtils';

--- a/public/app/features/dashboard-scene/mutation-api/types.ts
+++ b/public/app/features/dashboard-scene/mutation-api/types.ts
@@ -6,6 +6,7 @@
  * and inferred from Zod schemas.
  */
 
+import type { SceneObject } from '@grafana/scenes';
 import type {
   AutoGridLayoutItemKind,
   Element,
@@ -13,10 +14,9 @@ import type {
   VariableKind,
 } from '@grafana/schema/dist/esm/schema/dashboard/v2';
 
-export interface MutationRequest {
-  type: string;
-  payload: unknown;
-}
+// The __scenesPayload variant signals the execute() path to skip Zod
+// validation and pass the SceneObject directly to the handler.
+export type MutationRequest = { type: string; payload: unknown } | { type: string; __scenesPayload: SceneObject };
 
 export interface MutationResult {
   success: boolean;

--- a/public/app/features/dashboard-scene/mutation-api/types.ts
+++ b/public/app/features/dashboard-scene/mutation-api/types.ts
@@ -24,18 +24,6 @@ export interface MutationResult {
   changes: MutationChange[];
   warnings?: string[];
   data?: unknown;
-  /**
-   * Internal: callback to undo this mutation. Set by variable commands to wire
-   * into the DashboardEditActionEvent undo/redo system. Underscore prefix signals
-   * that this field is for internal infrastructure use only and must not be
-   * forwarded to external callers.
-   */
-  _undo?: () => void;
-  /**
-   * Internal: human-readable description shown in the undo history UI.
-   * Set alongside _undo by commands that support undo/redo.
-   */
-  _description?: string;
 }
 
 export interface MutationChange {

--- a/public/app/features/dashboard-scene/mutation-api/types.ts
+++ b/public/app/features/dashboard-scene/mutation-api/types.ts
@@ -24,6 +24,18 @@ export interface MutationResult {
   changes: MutationChange[];
   warnings?: string[];
   data?: unknown;
+  /**
+   * Internal: callback to undo this mutation. Set by variable commands to wire
+   * into the DashboardEditActionEvent undo/redo system. Underscore prefix signals
+   * that this field is for internal infrastructure use only and must not be
+   * forwarded to external callers.
+   */
+  _undo?: () => void;
+  /**
+   * Internal: human-readable description shown in the undo history UI.
+   * Set alongside _undo by commands that support undo/redo.
+   */
+  _description?: string;
 }
 
 export interface MutationChange {

--- a/public/app/features/dashboard-scene/mutation-api/types.ts
+++ b/public/app/features/dashboard-scene/mutation-api/types.ts
@@ -24,6 +24,12 @@ export interface MutationResult {
   changes: MutationChange[];
   warnings?: string[];
   data?: unknown;
+  /**
+   * True when the targeted object is currently write-locked. The agent should
+   * wait and retry. Absent / false means the mutation was either applied or
+   * failed for a non-lock reason.
+   */
+  locked?: boolean;
 }
 
 export interface MutationChange {

--- a/public/app/features/dashboard-scene/mutation-api/undo-domains.ts
+++ b/public/app/features/dashboard-scene/mutation-api/undo-domains.ts
@@ -1,0 +1,45 @@
+/**
+ * Undo-domain registry.
+ *
+ * Each `MutationCommand` may declare an `undoDomain` (e.g. 'variables').
+ * The registry maps a domain name to two pure functions:
+ *
+ *   - `snapshot(scene)`: capture the current state of the slice.
+ *   - `restore(scene, snapshot)`: replay the slice back onto the scene.
+ *
+ * `DashboardMutationClient` consults this registry instead of switching on
+ * the domain literal. Adding a new domain (panels, layout, annotations, ...)
+ * is one `registerUndoDomain` call from the owning module; the client class
+ * does not change.
+ */
+
+import type { DashboardScene } from '../scene/DashboardScene';
+
+import { replaceVariableSet } from './commands/variableUtils';
+
+export interface UndoDomainHandler<TSnapshot = unknown> {
+  readonly name: string;
+  snapshot(scene: DashboardScene): TSnapshot;
+  restore(scene: DashboardScene, snapshot: TSnapshot): void;
+}
+
+const _registry = new Map<string, UndoDomainHandler<unknown>>();
+
+export function registerUndoDomain<TSnapshot>(handler: UndoDomainHandler<TSnapshot>): void {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- safe: handler is keyed by name
+  _registry.set(handler.name, handler as UndoDomainHandler<unknown>);
+}
+
+export function getUndoDomain(name: string): UndoDomainHandler<unknown> | undefined {
+  return _registry.get(name);
+}
+
+// Built-in: variables domain.
+registerUndoDomain({
+  name: 'variables',
+  snapshot: (scene) => scene.state.$variables?.state.variables.slice() ?? [],
+  restore: (scene, snapshot) => {
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- snapshot shape is owned by this domain
+    replaceVariableSet(scene, snapshot as ReturnType<UndoDomainHandler['snapshot']> as never);
+  },
+});

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -62,6 +62,7 @@ import {
 } from '../../apiserver/types';
 import { DashboardEditPane } from '../edit-pane/DashboardEditPane';
 import { dashboardEditActions } from '../edit-pane/shared';
+import { DashboardMutationClient } from '../mutation-api/DashboardMutationClient';
 import { type PanelEditor } from '../panel-edit/PanelEditor';
 import { DashboardSceneChangeTracker } from '../saving/DashboardSceneChangeTracker';
 import { SaveDashboardDrawer } from '../saving/SaveDashboardDrawer';
@@ -240,6 +241,37 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
    * Dashboard changes tracker
    */
   private _changeTracker: DashboardSceneChangeTracker;
+  private _mutationClient?: DashboardMutationClient;
+  private _writeLocks = new Set<string>();
+
+  /**
+   * Lazy-initialized Mutation API client. UI components can call
+   * `dashboard.mutationClient.execute(cmd.addVariable(...))` to route writes
+   * through the API the same way the Assistant does.
+   */
+  public get mutationClient(): DashboardMutationClient {
+    if (!this._mutationClient) {
+      this._mutationClient = new DashboardMutationClient(this);
+    }
+    return this._mutationClient;
+  }
+
+  /**
+   * Acquire a write lock for the given target identifier (e.g. 'variables').
+   * Subsequent mutations against the same target return locked:true until released.
+   * Reads via Scenes subscriptions are unaffected.
+   */
+  public acquireWriteLock(target: string): void {
+    this._writeLocks.add(target);
+  }
+
+  public releaseWriteLock(target: string): void {
+    this._writeLocks.delete(target);
+  }
+
+  public isWriteLocked(target: string): boolean {
+    return this._writeLocks.has(target);
+  }
 
   /**
    * Remember scroll position when going into panel edit

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -63,6 +63,7 @@ import {
 import { DashboardEditPane } from '../edit-pane/DashboardEditPane';
 import { dashboardEditActions } from '../edit-pane/shared';
 import { DashboardMutationClient } from '../mutation-api/DashboardMutationClient';
+import { MutationRecorder } from '../mutation-api/MutationRecorder';
 import { type PanelEditor } from '../panel-edit/PanelEditor';
 import { DashboardSceneChangeTracker } from '../saving/DashboardSceneChangeTracker';
 import { SaveDashboardDrawer } from '../saving/SaveDashboardDrawer';
@@ -242,6 +243,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
    */
   private _changeTracker: DashboardSceneChangeTracker;
   private _mutationClient?: DashboardMutationClient;
+  private _mutationRecorder?: MutationRecorder;
   private _writeLocks = new Set<string>();
 
   /**
@@ -254,6 +256,19 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
       this._mutationClient = new DashboardMutationClient(this);
     }
     return this._mutationClient;
+  }
+
+  /**
+   * Lazy-initialized MutationRecorder. Owns the snapshot/publish lifecycle for
+   * mutations that declare an `undoDomain`. The Mutation Client delegates to it;
+   * future headless callers (plugin host, MCP gateway) can call `record()`
+   * directly without owning their own snapshot machinery.
+   */
+  public get mutationRecorder(): MutationRecorder {
+    if (!this._mutationRecorder) {
+      this._mutationRecorder = new MutationRecorder(this);
+    }
+    return this._mutationRecorder;
   }
 
   /**

--- a/public/app/features/dashboard-scene/settings/VariablesEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VariablesEditView.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 
 import { type NavModel, type NavModelItem, PageLayoutType } from '@grafana/data';
+import { config } from '@grafana/runtime';
 import {
   type SceneComponentProps,
   SceneObjectBase,
@@ -11,6 +12,9 @@ import {
 } from '@grafana/scenes';
 import { Page } from 'app/core/components/Page/Page';
 
+import { DashboardMutationClient } from '../mutation-api/DashboardMutationClient';
+import { cmd } from '../mutation-api/cmd';
+import { createVariableKindFromSceneVariable } from '../mutation-api/commands/variableUtils';
 import { type DashboardScene } from '../scene/DashboardScene';
 import { NavToolbarActions } from '../scene/NavToolbarActions';
 import { transformSceneToSaveModel } from '../serialization/transformSceneToSaveModel';
@@ -27,6 +31,7 @@ import {
   type EditableVariableType,
   RESERVED_GLOBAL_VARIABLE_NAME_REGEX,
   WORD_CHARACTERS_REGEX,
+  getNextAvailableId,
   getVariableDefault,
   getVariableScene,
   isVariableEditable,
@@ -76,7 +81,14 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
     this.getVariableSet().setState({ variables: updatedVariables });
   };
 
-  public onDelete = (identifier: string) => {
+  public onDelete = async (identifier: string) => {
+    if (config.featureToggles.dashboardMutationApiVariablePilot) {
+      const client = new DashboardMutationClient(this.getDashboard());
+      await client.execute(cmd.removeVariable({ name: identifier }));
+      this.setState({ editIndex: undefined });
+      return;
+    }
+
     // Find the index of the variable to be deleted
     const variableIndex = this.getVariableIndex(identifier);
     const { variables } = this.getVariableSet().state;
@@ -157,12 +169,47 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
     this.setState({ editIndex: variableIndex });
   };
 
-  public onAdd = () => {
+  public onAdd = async () => {
     const variables = this.getVariables();
     const variableIndex = variables.length;
-    //add the new variable to the end of the array
-    const defaultNewVariable = getVariableDefault(variables);
 
+    if (config.featureToggles.dashboardMutationApiVariablePilot) {
+      // Build a default QueryVariable as a VariableKind for the Mutation API.
+      const nextName = getNextAvailableId('query', variables);
+      const defaultVariableKind = {
+        kind: 'QueryVariable' as const,
+        spec: {
+          name: nextName,
+          query: {
+            kind: 'DataQuery' as const,
+            version: 'v0',
+            group: '',
+            spec: {},
+          },
+          refresh: 'onDashboardLoad' as const,
+          regex: '',
+          sort: 'disabled' as const,
+          multi: false,
+          includeAll: false,
+          allowCustomValue: true,
+          current: { text: '', value: '' },
+          options: [],
+          skipUrlSync: false,
+          hide: 'dontHide' as const,
+        },
+      };
+
+      const client = new DashboardMutationClient(this.getDashboard());
+      const result = await client.execute(cmd.addVariable({ variable: defaultVariableKind }));
+
+      if (result.success) {
+        this.setState({ editIndex: variableIndex });
+      }
+      return;
+    }
+
+    // Fallback: direct Scenes mutation.
+    const defaultNewVariable = getVariableDefault(variables);
     this.getVariableSet().setState({ variables: [...this.getVariables(), defaultNewVariable] });
     this.setState({ editIndex: variableIndex });
   };
@@ -184,7 +231,31 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
     this.replaceEditVariable(newVariable);
   };
 
-  public onGoBack = () => {
+  public onGoBack = async () => {
+    if (config.featureToggles.dashboardMutationApiVariablePilot) {
+      const editIndex = this.state.editIndex;
+
+      // Only call UPDATE_VARIABLE when going back from an existing variable.
+      // New variables added via onAdd already have their state registered via ADD_VARIABLE.
+      if (editIndex !== undefined) {
+        const variables = this.getVariables();
+        const variable = variables[editIndex];
+        if (variable) {
+          try {
+            const variableKind = createVariableKindFromSceneVariable(variable, this.getDashboard());
+            const client = new DashboardMutationClient(this.getDashboard());
+            await client.execute(cmd.updateVariable({ name: variable.state.name, variable: variableKind }));
+          } catch (error) {
+            // Non-fatal: if serialization fails, fall through to navigation.
+            console.error('Failed to call UPDATE_VARIABLE on goBack:', error);
+          }
+        }
+      }
+
+      this.setState({ editIndex: undefined });
+      return;
+    }
+
     this.setState({ editIndex: undefined });
   };
 

--- a/public/app/features/dashboard-scene/settings/VariablesEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VariablesEditView.tsx
@@ -12,9 +12,6 @@ import {
 } from '@grafana/scenes';
 import { Page } from 'app/core/components/Page/Page';
 
-import { DashboardMutationClient } from '../mutation-api/DashboardMutationClient';
-import { cmd } from '../mutation-api/cmd';
-import { createVariableKindFromSceneVariable } from '../mutation-api/commands/variableUtils';
 import { type DashboardScene } from '../scene/DashboardScene';
 import { NavToolbarActions } from '../scene/NavToolbarActions';
 import { transformSceneToSaveModel } from '../serialization/transformSceneToSaveModel';
@@ -83,6 +80,8 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
 
   public onDelete = async (identifier: string) => {
     if (config.featureToggles.dashboardMutationApiVariablePilot) {
+      const { DashboardMutationClient } = await import('../mutation-api/DashboardMutationClient');
+      const { cmd } = await import('../mutation-api/cmd');
       const client = new DashboardMutationClient(this.getDashboard());
       await client.execute(cmd.removeVariable({ name: identifier }));
       this.setState({ editIndex: undefined });
@@ -199,6 +198,8 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
         },
       };
 
+      const { DashboardMutationClient } = await import('../mutation-api/DashboardMutationClient');
+      const { cmd } = await import('../mutation-api/cmd');
       const client = new DashboardMutationClient(this.getDashboard());
       const result = await client.execute(cmd.addVariable({ variable: defaultVariableKind }));
 
@@ -242,6 +243,9 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
         const variable = variables[editIndex];
         if (variable) {
           try {
+            const { createVariableKindFromSceneVariable } = await import('../mutation-api/commands/variableUtils');
+            const { DashboardMutationClient } = await import('../mutation-api/DashboardMutationClient');
+            const { cmd } = await import('../mutation-api/cmd');
             const variableKind = createVariableKindFromSceneVariable(variable, this.getDashboard());
             const client = new DashboardMutationClient(this.getDashboard());
             await client.execute(cmd.updateVariable({ name: variable.state.name, variable: variableKind }));

--- a/public/app/features/dashboard-scene/settings/VariablesEditView.tsx
+++ b/public/app/features/dashboard-scene/settings/VariablesEditView.tsx
@@ -28,7 +28,6 @@ import {
   type EditableVariableType,
   RESERVED_GLOBAL_VARIABLE_NAME_REGEX,
   WORD_CHARACTERS_REGEX,
-  getNextAvailableId,
   getVariableDefault,
   getVariableScene,
   isVariableEditable,
@@ -80,10 +79,14 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
 
   public onDelete = async (identifier: string) => {
     if (config.featureToggles.dashboardMutationApiVariablePilot) {
-      const { DashboardMutationClient } = await import('../mutation-api/DashboardMutationClient');
-      const { cmd } = await import('../mutation-api/cmd');
-      const client = new DashboardMutationClient(this.getDashboard());
-      await client.execute(cmd.removeVariable({ name: identifier }));
+      const variables = this.getVariables();
+      const sceneVar = variables.find((v) => v.state.name === identifier);
+      if (sceneVar) {
+        const { DashboardMutationClient } = await import('../mutation-api/DashboardMutationClient');
+        const { cmd } = await import('../mutation-api/cmd');
+        const client = new DashboardMutationClient(this.getDashboard());
+        await client.execute(cmd.removeVariable(sceneVar));
+      }
       this.setState({ editIndex: undefined });
       return;
     }
@@ -173,35 +176,11 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
     const variableIndex = variables.length;
 
     if (config.featureToggles.dashboardMutationApiVariablePilot) {
-      // Build a default QueryVariable as a VariableKind for the Mutation API.
-      const nextName = getNextAvailableId('query', variables);
-      const defaultVariableKind = {
-        kind: 'QueryVariable' as const,
-        spec: {
-          name: nextName,
-          query: {
-            kind: 'DataQuery' as const,
-            version: 'v0',
-            group: '',
-            spec: {},
-          },
-          refresh: 'onDashboardLoad' as const,
-          regex: '',
-          sort: 'disabled' as const,
-          multi: false,
-          includeAll: false,
-          allowCustomValue: true,
-          current: { text: '', value: '' },
-          options: [],
-          skipUrlSync: false,
-          hide: 'dontHide' as const,
-        },
-      };
-
+      const defaultNewVariable = getVariableDefault(variables);
       const { DashboardMutationClient } = await import('../mutation-api/DashboardMutationClient');
       const { cmd } = await import('../mutation-api/cmd');
       const client = new DashboardMutationClient(this.getDashboard());
-      const result = await client.execute(cmd.addVariable({ variable: defaultVariableKind }));
+      const result = await client.execute(cmd.addVariable(defaultNewVariable));
 
       if (result.success) {
         this.setState({ editIndex: variableIndex });
@@ -243,14 +222,12 @@ export class VariablesEditView extends SceneObjectBase<VariablesEditViewState> i
         const variable = variables[editIndex];
         if (variable) {
           try {
-            const { createVariableKindFromSceneVariable } = await import('../mutation-api/commands/variableUtils');
             const { DashboardMutationClient } = await import('../mutation-api/DashboardMutationClient');
             const { cmd } = await import('../mutation-api/cmd');
-            const variableKind = createVariableKindFromSceneVariable(variable, this.getDashboard());
             const client = new DashboardMutationClient(this.getDashboard());
-            await client.execute(cmd.updateVariable({ name: variable.state.name, variable: variableKind }));
+            await client.execute(cmd.updateVariable(variable));
           } catch (error) {
-            // Non-fatal: if serialization fails, fall through to navigation.
+            // Non-fatal: fall through to navigation.
             console.error('Failed to call UPDATE_VARIABLE on goBack:', error);
           }
         }


### PR DESCRIPTION
## Stacked on [#123501](https://github.com/grafana/grafana/pull/123501) — concept-level demos

Eight small commits demonstrating the architectural improvements identified in the multi-round design review ([Burns task t109]).

The commits are **conceptual sketches**, not production-ready features. Each one isolates a single idea so reviewers can read the concept in 20-50 lines and react. Real implementation may expand each (e.g. fully wire coalescing into `DashboardEditPane.undoStack`, surface conflict refusals as toasts).

Built on top of #123501 — base branch is `feat/mutation-api-variable-ui-pilot`. Diff against `main` shows everything; diff against base shows just these improvements.

## Commits, each with the concept it demonstrates

1. **Extract undo-domain snapshot/restore into a registry** — replaces the switch in `DashboardMutationClient` with `registerUndoDomain({ name, snapshot, restore })`. Adding a new domain (panels, layout, annotations…) becomes one file in the owning module instead of a client-class change.

2. **Serialize execute() per undoDomain to fix the snapshot race** — `Map<UndoDomain, Promise>` chains concurrent `execute()` calls on the same domain. Closes the race where two parallel calls would both snapshot the same pre-state.

3. **Auto-derive addedObject/removedObject from snapshot diff** — the client already has before/after snapshots; diff them by reference identity and forward to the published `DashboardEditActionEvent`. Restores the editor's selection-on-add behavior without handler changes.

4. **Conflict detection on undo/redo** — at undo time, compare current slice to the saved snapshot. If they don't match, refuse instead of silently overwriting concurrent writes. Currently logs; a real impl would surface a toast.

5. **Support cross-domain commands (`undoDomain` can be an array)** — widens the type to `UndoDomain | UndoDomain[]`. Single-domain commands stay as strings; multi-domain commands (e.g. removing a panel that drops referencing variables) declare an array.

6. **Coalescing hint on MutationCommand** — `canCoalesceWith?(previousPayload, gapMs): boolean`. Rapid same-command mutations (typing in a label field) collapse into one undo entry. `UPDATE_VARIABLE` shows the concrete usage. Stack-merge integration with `DashboardEditPane.undoStack` is a TODO.

7. **Per-command normalize() helper (addVariable as the example)** — pulls the `__scenesPayload` vs JSON fork into a top-of-file `normalize()` function. The handler stops mixing payload routing with state mutation. Pattern other commands follow when migrated.

8. **Extract MutationRecorder off the client** — snapshot/publish moves into a `MutationRecorder` that lives on `DashboardScene`. The Mutation Client owns dispatch (lookup, permission, lock, validation, per-domain queue); the recorder owns history. Other callers (plugin host, future MCP gateway) can use the recorder without going through the client.

## What's NOT here

- Wiring the existing toolbar undo button to consume `addedObject`/`removedObject` for richer feedback (planned follow-up).
- Surfacing conflict-refusal as a toast in the UI (`console.warn` only for the demo).
- Coalescing's actual stack-merge against `DashboardEditPane.undoStack` (predicate plumbing only).
- Applying `normalize()` to `removeVariable.ts` and `updateVariable.ts` (one example for the pattern).

## Review approach

Suggest reading commit-by-commit. Each commit is a small focused change. The order is intentional: registry → queue → diff → conflict → cross-domain → coalescing → normalize → recorder extraction.

## no-changelog

Internal architecture work, no user-visible behavior changes in this PR.

---

Related: [#123501](https://github.com/grafana/grafana/pull/123501) (Proposal 1 POC), [#125252](https://github.com/grafana/grafana/pull/125252) (Proposal 2 POC), [#125331](https://github.com/grafana/grafana/pull/125331) (architecture-independent `inverse` field).