### PR TITLE
CI: Remove fsperfbaseline from the perf tests

### DIFF
--- a/.github/workflows/frontend-perf-tests.yaml
+++ b/.github/workflows/frontend-perf-tests.yaml
@@ -25,8 +25,6 @@ jobs:
             PROMETHEUS_URL=frontend_perf_tests:prometheus_push_url
             PROMETHEUS_USER=frontend_perf_tests:prometheus_user
             PROMETHEUS_TOKEN=frontend_perf_tests:prometheus_token
-            FSPERFBASELINE_USERNAME=frontend_perf_tests:fsperfbaseline_username
-            FSPERFBASELINE_PASSWORD=frontend_perf_tests:fsperfbaseline_password
             FSPERF_USERNAME=frontend_perf_tests:fsperf_username
             FSPERF_PASSWORD=frontend_perf_tests:fsperf_password
 
@@ -45,17 +43,6 @@ jobs:
       - name: Install Playwright browsers
         run: yarn playwright install chromium --with-deps
 
-      - name: Run Playwright tests (fsperfbaseline)
-        id: pw-fsperfbaseline
-        continue-on-error: true
-        env:
-          PLAYWRIGHT_JSON_OUTPUT_NAME: ./fsperfbaseline-pw-results.json
-          METRICS_OUTPUT_PATH: ./fsperfbaseline-metrics.txt
-          GRAFANA_URL: https://fsperfbaseline.grafana-dev.net
-          GRAFANA_ADMIN_USER: ${{ env.FSPERFBASELINE_USERNAME }}
-          GRAFANA_ADMIN_PASSWORD: ${{ env.FSPERFBASELINE_PASSWORD }}
-        run: yarn e2e:playwright --grep @performance --reporter json
-
       - name: Run Playwright tests (fsperf)
         id: pw-fsperf
         continue-on-error: true
@@ -66,31 +53,6 @@ jobs:
           GRAFANA_ADMIN_USER: ${{ env.FSPERF_USERNAME }}
           GRAFANA_ADMIN_PASSWORD: ${{ env.FSPERF_PASSWORD }}
         run: yarn e2e:playwright --grep @performance --reporter json
-
-      - name: Bench report (fsperfbaseline)
-        id: bench-fsperfbaseline
-        if: always()
-        continue-on-error: true
-        run: |
-          docker run \
-            --rm \
-            --volume="./fsperfbaseline-pw-results.json:/pw-results.json" \
-            --volume="./fsperfbaseline-metrics.txt:/metrics.txt" \
-            -e PROMETHEUS_URL="$PROMETHEUS_URL" \
-            -e PROMETHEUS_USER="$PROMETHEUS_USER" \
-            -e PROMETHEUS_PASSWORD="$PROMETHEUS_TOKEN" \
-            us-docker.pkg.dev/grafanalabs-global/docker-grafana-bench-prod/grafana-bench:v1.0.2 report \
-              --service grafana \
-              --service-url "https://fsperfbaseline.grafana-dev.net" \
-              --service-version "rrc-instant" \
-              --suite-name "FrontendPerfTests" \
-              --report-input playwright \
-              --report-output log \
-              --prometheus-metrics \
-              --run-metrics-file "/metrics.txt" \
-              --run-stage rrc \
-              --log-level DEBUG \
-              /pw-results.json
 
       - name: Bench report (fsperf)
         id: bench-fsperf
@@ -120,17 +82,13 @@ jobs:
       - name: Check status
         env:
           FSPERF_PW_OUTCOME: ${{ steps.pw-fsperf.outcome }}
-          FSPERF_PW_BASELINE_OUTCOME: ${{ steps.pw-fsperfbaseline.outcome }}
           FSPERF_BENCH_OUTCOME: ${{ steps.bench-fsperf.outcome }}
-          FSPERF_BENCH_BASELINE_OUTCOME: ${{ steps.bench-fsperfbaseline.outcome }}
 
         run: |
           echo "FSPERF_PW_OUTCOME: $FSPERF_PW_OUTCOME"
-          echo "FSPERF_PW_BASELINE_OUTCOME: $FSPERF_PW_BASELINE_OUTCOME"
           echo "FSPERF_BENCH_OUTCOME: $FSPERF_BENCH_OUTCOME"
-          echo "FSPERF_BENCH_BASELINE_OUTCOME: $FSPERF_BENCH_BASELINE_OUTCOME"
 
-          if [[ "$FSPERF_PW_OUTCOME" != "success" || "$FSPERF_PW_BASELINE_OUTCOME" != "success" || "$FSPERF_BENCH_OUTCOME" != "success" || "$FSPERF_BENCH_BASELINE_OUTCOME" != "success" ]]; then
+          if [[ "$FSPERF_PW_OUTCOME" != "success" || "$FSPERF_BENCH_OUTCOME" != "success" ]]; then
             echo "One or more test steps failed."
             exit 1
           fi


### PR DESCRIPTION
We no longer get any value in running these performance tests/metrics from the fsperfbaseline instance as it doesn't represent what we're deploying anymore.