### PR TITLE
alerting: move functions from legacy_storage to more specific packages

### DIFF
--- a/pkg/services/ngalert/notifier/alertmanager_config.go
+++ b/pkg/services/ngalert/notifier/alertmanager_config.go
@@ -102,7 +102,7 @@ func (moa *MultiOrgAlertmanager) PrepareConfig(
 		if !recv.HasMimirIntegrations() {
 			continue
 		}
-		grafana, err := legacy_storage.PostableMimirReceiverToPostableGrafanaReceiver(recv)
+		grafana, err := v1.PostableMimirReceiverToPostableGrafanaReceiver(recv)
 		if err != nil {
 			moa.logger.Warn("Failed to convert Mimir receiver to Grafana receiver. Ignoring receiver ", "identifier", mergeResult.Identifier, "receiver", recv.Name, "err", err)
 			failed++

--- a/pkg/services/ngalert/notifier/alertmanager_config.go
+++ b/pkg/services/ngalert/notifier/alertmanager_config.go
@@ -136,7 +136,7 @@ func (moa *MultiOrgAlertmanager) PrepareConfig(
 			} else {
 				managedRoutes[mergeResult.Identifier] = mergeResult.ExtraRoute
 
-				importedRules, err := legacy_storage.BuildManagedInhibitionRules(mergeResult.Identifier, mergeResult.ExtraInhibitRules)
+				importedRules, err := merge.BuildManagedInhibitionRules(mergeResult.Identifier, mergeResult.ExtraInhibitRules)
 				if err != nil {
 					moa.logger.Warn("failed to build managed inhibition rules for imported configuration", "identifier", mergeResult.Identifier, "err", err)
 				} else {

--- a/pkg/services/ngalert/notifier/inhibition_rules/service.go
+++ b/pkg/services/ngalert/notifier/inhibition_rules/service.go
@@ -112,7 +112,7 @@ func (svc *Service) CreateInhibitionRule(ctx context.Context, rule v1.Inhibition
 		return v1.InhibitionRule{}, err
 	}
 
-	created, err := legacy_storage.InhibitRuleToInhibitionRule(rule.Name, rule.InhibitRule, rule.Provenance)
+	created, err := v1.InhibitRuleToInhibitionRule(rule.Name, rule.InhibitRule, rule.Provenance)
 	if err != nil {
 		return v1.InhibitionRule{}, models.MakeErrInhibitionRuleInvalid(err)
 	}
@@ -171,7 +171,7 @@ func (svc *Service) UpdateInhibitionRule(ctx context.Context, name string, rule 
 		delete(revision.Config.ManagedInhibitionRules, existing.Name)
 	}
 
-	updated, err := legacy_storage.InhibitRuleToInhibitionRule(rule.Name, rule.InhibitRule, rule.Provenance)
+	updated, err := v1.InhibitRuleToInhibitionRule(rule.Name, rule.InhibitRule, rule.Provenance)
 	if err != nil {
 		return v1.InhibitionRule{}, models.MakeErrInhibitionRuleInvalid(err)
 	}

--- a/pkg/services/ngalert/notifier/inhibition_rules/service_test.go
+++ b/pkg/services/ngalert/notifier/inhibition_rules/service_test.go
@@ -210,7 +210,7 @@ func TestService_UpdateInhibitionRule(t *testing.T) {
 			expRule: func() v1.InhibitionRule {
 				r := testGrafanaRule
 				r.Equal = []string{"instance", "job"}
-				updated, err := legacy_storage.InhibitRuleToInhibitionRule(r.Name, r.InhibitRule, r.Provenance)
+				updated, err := v1.InhibitRuleToInhibitionRule(r.Name, r.InhibitRule, r.Provenance)
 				require.Nil(t, err)
 				return *updated
 			}(),
@@ -228,7 +228,7 @@ func TestService_UpdateInhibitionRule(t *testing.T) {
 			expRule: func() v1.InhibitionRule {
 				r := testGrafanaRule
 				r.Name = "managed-rule-1-renamed"
-				updated, err := legacy_storage.InhibitRuleToInhibitionRule(r.Name, r.InhibitRule, r.Provenance)
+				updated, err := v1.InhibitRuleToInhibitionRule(r.Name, r.InhibitRule, r.Provenance)
 				require.Nil(t, err)
 				return *updated
 			}(),

--- a/pkg/services/ngalert/notifier/legacy_storage/compat.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/compat.go
@@ -4,14 +4,12 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"hash/fnv"
 	"maps"
 
 	alertingNotify "github.com/grafana/alerting/notify"
 	"github.com/grafana/alerting/receivers/schema"
 	"github.com/prometheus/common/model"
 
-	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	v1 "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
 )
@@ -72,7 +70,7 @@ func ReceiverToPostableApiReceiver(r *models.Receiver) (*v1.PostableApiReceiver,
 
 func PostableApiReceiverToReceiver(postable *v1.PostableApiReceiver, provenance models.Provenance, origin models.ResourceOrigin) (*models.Receiver, error) {
 	if postable.HasMimirIntegrations() {
-		p, err := PostableMimirReceiverToPostableGrafanaReceiver(postable)
+		p, err := v1.PostableMimirReceiverToPostableGrafanaReceiver(postable)
 		if err != nil {
 			return nil, err
 		}
@@ -126,65 +124,6 @@ func PostableGrafanaReceiversToIntegrations(postables []*v1.PostableGrafanaRecei
 	}
 
 	return integrations, nil
-}
-
-// PostableMimirReceiverToPostableGrafanaReceiver converts all legacy models to apimodels.PostableGrafanaReceiver.
-// If receiver does not have any legacy receivers, returns the original receiver.
-// Otherwise, returns a copy that contains converted integrations (and shallow copy of existing Grafana integrations).
-func PostableMimirReceiverToPostableGrafanaReceiver(r *v1.PostableApiReceiver) (*v1.PostableApiReceiver, error) {
-	if !r.HasMimirIntegrations() {
-		return r, nil
-	}
-	v0, err := alertingNotify.ConfigReceiverToMimirIntegrations(r.Receiver)
-	if err != nil {
-		return nil, fmt.Errorf("failed to convert v0 receiver to integrations: %w", err)
-	}
-	result := &v1.PostableApiReceiver{
-		Receiver: apimodels.Receiver{
-			Name: r.Name,
-		},
-		PostableGrafanaReceivers: v1.PostableGrafanaReceivers{
-			GrafanaManagedReceivers: make([]*v1.PostableGrafanaReceiver, 0, len(v0)+len(r.GrafanaManagedReceivers)),
-		},
-	}
-	result.GrafanaManagedReceivers = append(result.GrafanaManagedReceivers, r.GrafanaManagedReceivers...)
-	typeCount := make(map[string]int)
-	for _, config := range v0 {
-		integrationType := string(config.Schema.Type())
-		idx := typeCount[integrationType]
-		typeCount[integrationType]++
-		integration, err := MimirIntegrationConfigToPostableGrafanaReceiver(config, r.Name, idx)
-		if err != nil {
-			return nil, fmt.Errorf("failed to convert Mimir integration config to PostableGrafanaReceiver: %w", err)
-		}
-		result.GrafanaManagedReceivers = append(result.GrafanaManagedReceivers, integration)
-	}
-	return result, nil
-}
-
-// MimirIntegrationConfigToPostableGrafanaReceiver Converts a Mimir integration configuration to a PostableGrafanaReceiver. All settings are unencrypted. Needs to be encrypted later.
-func MimirIntegrationConfigToPostableGrafanaReceiver(config alertingNotify.MimirIntegrationConfig, receiverName string, idx int) (*v1.PostableGrafanaReceiver, error) {
-	raw, err := config.ConfigJSON()
-	if err != nil {
-		return nil, err
-	}
-
-	return &v1.PostableGrafanaReceiver{
-		// mimirIntegrationUID generates a stable, fixed-length UID for a converted Mimir integration that passes ValidateUID, 40-char limit for long names in particular
-		UID:                   mimirIntegrationUID(receiverName, string(config.Schema.Type()), idx),
-		Name:                  receiverName,
-		Type:                  string(config.Schema.Type()),
-		Version:               string(config.Schema.Version),
-		DisableResolveMessage: false, // V0 ignore this flag as they have their own SendResolved one.
-		Settings:              raw,
-		SecureSettings:        nil,
-	}, nil
-}
-
-func mimirIntegrationUID(receiverName string, integrationType string, idx int) string {
-	h := fnv.New64a()
-	_, _ = fmt.Fprintf(h, "%s-%s-%d", receiverName, integrationType, idx)
-	return fmt.Sprintf("%016x", h.Sum64())
 }
 
 func PostableMimirReceiverToIntegrations(r alertingNotify.ConfigReceiver) ([]*models.Integration, error) {

--- a/pkg/services/ngalert/notifier/legacy_storage/compat.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/compat.go
@@ -6,18 +6,14 @@ import (
 	"fmt"
 	"hash/fnv"
 	"maps"
-	"strings"
 
 	alertingNotify "github.com/grafana/alerting/notify"
 	"github.com/grafana/alerting/receivers/schema"
-	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/common/model"
-	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 
 	apimodels "github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	v1 "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
-	"github.com/grafana/grafana/pkg/services/sqlstore/migrations/ualert"
 )
 
 var NameToUid = models.NameToUid
@@ -280,29 +276,4 @@ func ToGroupBy(groupByStr ...string) (groupByAll bool, groupBy []model.LabelName
 		}
 	}
 	return false, groupBy
-}
-
-func InhibitRuleToInhibitionRule(name string, rule config.InhibitRule, provenance v1.Provenance) (*v1.InhibitionRule, error) {
-	if name = strings.TrimSpace(name); name == "" {
-		return nil, fmt.Errorf("inhibition rule name must not be empty")
-	}
-
-	if strings.Contains(name, ":") {
-		return nil, fmt.Errorf("inhibition rule name cannot contain invalid character ':'")
-	}
-
-	if errs := k8svalidation.IsDNS1123Subdomain(name); len(errs) > 0 {
-		return nil, fmt.Errorf("inhibition rule name must be a valid DNS subdomain: %s", strings.Join(errs, ", "))
-	}
-
-	// imported inhibition rules have purposefully long names to ensure no conflict with non-imported ones
-	if models.Provenance(provenance) != models.ProvenanceConvertedPrometheus && len(name) > ualert.UIDMaxLength {
-		return nil, fmt.Errorf("inhibition rule name is too long (exceeds %d characters)", ualert.UIDMaxLength)
-	}
-
-	return &v1.InhibitionRule{
-		Name:        name,
-		InhibitRule: rule,
-		Provenance:  provenance,
-	}, nil
 }

--- a/pkg/services/ngalert/notifier/legacy_storage/compat_test.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/compat_test.go
@@ -9,109 +9,15 @@ import (
 	"github.com/grafana/alerting/definition"
 	"github.com/grafana/alerting/notify"
 	"github.com/grafana/alerting/notify/notifytest"
-	emailV0 "github.com/grafana/alerting/receivers/email/v0mimir1"
 	"github.com/grafana/alerting/receivers/schema"
 	"github.com/grafana/alerting/receivers/teams"
-	webhookV0 "github.com/grafana/alerting/receivers/webhook/v0mimir1"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	v1 "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
 )
-
-func TestPostableMimirReceiverToPostableGrafanaReceiver(t *testing.T) {
-	t.Run("returns original pointer when receiver has only Grafana integrations", func(t *testing.T) {
-		receiver := &v1.PostableApiReceiver{
-			Receiver: definitions.Receiver{Name: "test"},
-			PostableGrafanaReceivers: v1.PostableGrafanaReceivers{
-				GrafanaManagedReceivers: []*v1.PostableGrafanaReceiver{
-					{UID: "grafana-uid", Name: "test", Type: "email"},
-				},
-			},
-		}
-		result, err := PostableMimirReceiverToPostableGrafanaReceiver(receiver)
-		require.NoError(t, err)
-		assert.Same(t, receiver, result)
-	})
-
-	t.Run("converts Mimir integrations to Grafana integrations", func(t *testing.T) {
-		wh := webhookV0.GetFullValidConfig()
-		receiver := &v1.PostableApiReceiver{
-			Receiver: definitions.Receiver{
-				Name:           "test-receiver",
-				WebhookConfigs: []*webhookV0.Config{&wh},
-			},
-		}
-
-		mimirConfigs, err := notify.ConfigReceiverToMimirIntegrations(receiver.Receiver)
-		require.NoError(t, err)
-		require.Len(t, mimirConfigs, 1)
-		expectedJSON, err := mimirConfigs[0].ConfigJSON()
-		require.NoError(t, err)
-
-		result, err := PostableMimirReceiverToPostableGrafanaReceiver(receiver)
-		require.NoError(t, err)
-		require.NotNil(t, result)
-		assert.NotSame(t, receiver, result)
-		require.Len(t, result.GrafanaManagedReceivers, 1)
-
-		converted := result.GrafanaManagedReceivers[0]
-		assert.Equal(t, "test-receiver", result.Name)
-		assert.Equal(t, "test-receiver", converted.Name)
-		assert.Equal(t, mimirIntegrationUID("test-receiver", "webhook", 0), converted.UID)
-		assert.JSONEq(t, string(expectedJSON), string(converted.Settings))
-		assert.False(t, converted.DisableResolveMessage)
-		assert.Nil(t, converted.SecureSettings)
-		assert.False(t, result.HasMimirIntegrations())
-	})
-
-	t.Run("existing Grafana integrations appear before converted Mimir ones", func(t *testing.T) {
-		wh := webhookV0.GetFullValidConfig()
-		grafanaRecv := &v1.PostableGrafanaReceiver{
-			UID:  "existing-uid",
-			Name: "existing",
-			Type: "email",
-		}
-		receiver := &v1.PostableApiReceiver{
-			Receiver: definitions.Receiver{
-				Name:           "mixed-receiver",
-				WebhookConfigs: []*webhookV0.Config{&wh},
-			},
-			PostableGrafanaReceivers: v1.PostableGrafanaReceivers{
-				GrafanaManagedReceivers: []*v1.PostableGrafanaReceiver{grafanaRecv},
-			},
-		}
-
-		result, err := PostableMimirReceiverToPostableGrafanaReceiver(receiver)
-		require.NoError(t, err)
-		require.Len(t, result.GrafanaManagedReceivers, 2)
-		assert.Same(t, grafanaRecv, result.GrafanaManagedReceivers[0])
-		assert.Equal(t, "webhook", result.GrafanaManagedReceivers[1].Type)
-	})
-
-	t.Run("assigns per-type UIDs to converted Mimir integrations", func(t *testing.T) {
-		// UIDs are indexed per integration type, so each type starts at 0.
-		em := emailV0.GetFullValidConfig()
-		wh := webhookV0.GetFullValidConfig()
-		receiver := &v1.PostableApiReceiver{
-			Receiver: definitions.Receiver{
-				Name:           "multi-receiver",
-				EmailConfigs:   []*emailV0.Config{&em},
-				WebhookConfigs: []*webhookV0.Config{&wh},
-			},
-		}
-
-		result, err := PostableMimirReceiverToPostableGrafanaReceiver(receiver)
-		require.NoError(t, err)
-		require.Len(t, result.GrafanaManagedReceivers, 2)
-
-		assert.Equal(t, mimirIntegrationUID("multi-receiver", "email", 0), result.GrafanaManagedReceivers[0].UID)
-		assert.Equal(t, mimirIntegrationUID("multi-receiver", "webhook", 0), result.GrafanaManagedReceivers[1].UID)
-	})
-}
 
 func TestPostableMimirReceiverToIntegrations(t *testing.T) {
 	t.Run("can convert all known types", func(t *testing.T) {

--- a/pkg/services/ngalert/notifier/legacy_storage/compat_test.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/compat_test.go
@@ -1,7 +1,6 @@
 package legacy_storage
 
 import (
-	"errors"
 	"fmt"
 	"reflect"
 	"strings"
@@ -14,8 +13,6 @@ import (
 	"github.com/grafana/alerting/receivers/schema"
 	"github.com/grafana/alerting/receivers/teams"
 	webhookV0 "github.com/grafana/alerting/receivers/webhook/v0mimir1"
-	"github.com/prometheus/alertmanager/config"
-	"github.com/prometheus/alertmanager/pkg/labels"
 	"github.com/prometheus/common/model"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -185,94 +182,4 @@ func TestManagedRouteToRoute(t *testing.T) {
 	assert.Equal(t, &ri, route.RepeatInterval)
 	assert.Len(t, route.Routes, 1)
 	assert.EqualValues(t, v1.Provenance("test"), route.Provenance)
-}
-
-func Test_InhibitRuleToInhibitionRule(t *testing.T) {
-	testRule := config.InhibitRule{
-		SourceMatchers: config.Matchers{
-			{
-				Type:  labels.MatchEqual,
-				Name:  "instance",
-				Value: "alertmanager-1",
-			},
-		},
-		TargetMatchers: config.Matchers{
-			{
-				Type:  labels.MatchEqual,
-				Name:  "instance",
-				Value: "alertmanager-2",
-			},
-		},
-		Equal: []string{
-			"service",
-		},
-	}
-
-	tt := []struct {
-		name        string
-		ruleName    string
-		provenance  v1.Provenance
-		inhibitRule config.InhibitRule
-		origin      models.ResourceOrigin
-		exp         *v1.InhibitionRule
-		expErr      error
-	}{
-		{
-			name:     "fails when name is empty",
-			ruleName: "  ",
-			expErr:   errors.New("inhibition rule name must not be empty"),
-		},
-		{
-			name:     "fails when name contains ':'",
-			ruleName: "a:b",
-			expErr:   errors.New("inhibition rule name cannot contain invalid character ':'"),
-		},
-		{
-			name:     "fails when name is not a valid dns 1123 subdomain",
-			ruleName: "_some_name",
-			expErr:   errors.New("inhibition rule name must be a valid DNS subdomain: a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')"),
-		},
-		{
-			name:     "fails when length of non-imported rule name is over UIDMaxLength limit",
-			ruleName: "some-really-long-inhibition-rule-name-001",
-			origin:   models.ResourceOriginGrafana,
-			expErr:   errors.New("inhibition rule name is too long (exceeds 40 characters)"),
-		},
-		{
-			name:        "allows length of imported rule name to be over UIDMaxLength limit",
-			ruleName:    "some-really-long-inhibition-rule-name-001",
-			provenance:  v1.Provenance(models.ProvenanceConvertedPrometheus),
-			origin:      models.ResourceOriginImported,
-			inhibitRule: testRule,
-			exp: &v1.InhibitionRule{
-				Name:        "some-really-long-inhibition-rule-name-001",
-				InhibitRule: testRule,
-				Provenance:  v1.Provenance(models.ProvenanceConvertedPrometheus),
-			},
-		},
-		{
-			name:        "converts model correctly when all validations passes",
-			ruleName:    "inhibition-rule-1",
-			origin:      models.ResourceOriginGrafana,
-			provenance:  v1.Provenance(models.ProvenanceNone),
-			inhibitRule: testRule,
-			exp: &v1.InhibitionRule{
-				Name:        "inhibition-rule-1",
-				InhibitRule: testRule,
-				Provenance:  v1.Provenance(models.ProvenanceNone),
-			},
-		},
-	}
-
-	for _, tc := range tt {
-		t.Run(tc.name, func(t *testing.T) {
-			got, gotErr := InhibitRuleToInhibitionRule(tc.ruleName, tc.inhibitRule, tc.provenance)
-			if tc.expErr != nil {
-				require.EqualError(t, gotErr, tc.expErr.Error())
-			} else {
-				require.Nil(t, gotErr)
-			}
-			require.Equal(t, tc.exp, got)
-		})
-	}
 }

--- a/pkg/services/ngalert/notifier/legacy_storage/imported.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/imported.go
@@ -38,7 +38,7 @@ func (e ImportedConfigRevision) GetReceivers(uids []string) ([]*models.Receiver,
 		return nil, nil
 	}
 	original := e.rev.Config.AlertmanagerConfig.GetReceivers()
-	merged, _ := merge.MergeReceivers(original, e.importedConfig.GetReceivers(), e.identifier)
+	merged, _ := merge.Receivers(original, e.importedConfig.GetReceivers(), e.identifier)
 
 	capacity := len(uids)
 	if capacity == 0 {
@@ -78,7 +78,7 @@ func (e ImportedConfigRevision) GetMuteTimeIntervals() ([]v1.MuteTimeInterval, e
 	grafanaTime := e.rev.Config.AlertmanagerConfig.TimeIntervals
 
 	// Merge to get the renames map (only renamed if name collision occurs)
-	_, renames := merge.MergeTimeIntervals(
+	_, renames := merge.TimeIntervals(
 		grafanaMute,
 		grafanaTime,
 		importedMute,
@@ -114,7 +114,7 @@ func (e ImportedConfigRevision) ReceiverUseByName() map[string]int {
 	}
 	m := make(map[string]int)
 	receiverUseCounts([]*v1.Route{e.importedConfig.Route}, m)
-	_, renames := merge.MergeReceivers(e.rev.Config.AlertmanagerConfig.GetReceivers(), e.importedConfig.GetReceivers(), e.identifier)
+	_, renames := merge.Receivers(e.rev.Config.AlertmanagerConfig.GetReceivers(), e.importedConfig.GetReceivers(), e.identifier)
 	for original, renamed := range renames {
 		if cnt, ok := m[original]; ok {
 			delete(m, original)

--- a/pkg/services/ngalert/notifier/legacy_storage/imported.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/imported.go
@@ -168,7 +168,7 @@ func BuildManagedInhibitionRules(identifier string, rules []config.InhibitRule) 
 		}
 		name := fmt.Sprintf(namePrefix+intFmt, i)
 
-		ir, err := InhibitRuleToInhibitionRule(name, rule, v1.Provenance(models.ProvenanceConvertedPrometheus))
+		ir, err := v1.InhibitRuleToInhibitionRule(name, rule, v1.Provenance(models.ProvenanceConvertedPrometheus))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/services/ngalert/notifier/legacy_storage/imported.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/imported.go
@@ -4,12 +4,9 @@ import (
 	"fmt"
 	"slices"
 
-	"github.com/prometheus/alertmanager/config"
-
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	v1 "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
 	"github.com/grafana/grafana/pkg/services/ngalert/notifier/merge"
-	"github.com/grafana/grafana/pkg/services/sqlstore/migrations/ualert"
 )
 
 type ImportedConfigRevision struct {
@@ -152,51 +149,5 @@ func (e ImportedConfigRevision) GetInhibitRules() (v1.ManagedInhibitionRules, er
 		return nil, nil
 	}
 
-	return BuildManagedInhibitionRules(e.identifier, importedRules)
-}
-
-func BuildManagedInhibitionRules(identifier string, rules []config.InhibitRule) (v1.ManagedInhibitionRules, error) {
-	scopedRules := applyManagedRouteMatcher(identifier, rules)
-
-	res := make(v1.ManagedInhibitionRules, len(scopedRules))
-	for i, rule := range scopedRules {
-		namePrefix := fmt.Sprintf("%s-imported-inhibition-rule-", identifier)
-
-		intFmt := "%d"
-		if padLength := ualert.UIDMaxLength - len(namePrefix); padLength >= 0 {
-			intFmt = fmt.Sprintf("%%0%dd", padLength+1)
-		}
-		name := fmt.Sprintf(namePrefix+intFmt, i)
-
-		ir, err := v1.InhibitRuleToInhibitionRule(name, rule, v1.Provenance(models.ProvenanceConvertedPrometheus))
-		if err != nil {
-			return nil, err
-		}
-		res[name] = ir
-	}
-
-	return res, nil
-}
-
-func applyManagedRouteMatcher(identifier string, rules []config.InhibitRule) []config.InhibitRule {
-	result := make([]config.InhibitRule, 0, len(rules))
-	matcher := managedRouteMatcher(identifier)
-
-	for _, rule := range rules {
-		sm := make(config.Matchers, 0, len(rule.SourceMatchers)+1)
-		sm = append(sm, matcher)
-		sm = append(sm, rule.SourceMatchers...)
-
-		tm := make(config.Matchers, 0, len(rule.TargetMatchers)+1)
-		tm = append(tm, matcher)
-		tm = append(tm, rule.TargetMatchers...)
-
-		result = append(result, config.InhibitRule{
-			SourceMatchers: sm,
-			TargetMatchers: tm,
-			Equal:          slices.Clone(rule.Equal),
-		})
-	}
-
-	return result
+	return merge.BuildManagedInhibitionRules(e.identifier, importedRules)
 }

--- a/pkg/services/ngalert/notifier/legacy_storage/v1/compat.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/v1/compat.go
@@ -2,11 +2,13 @@ package v1
 
 import (
 	"fmt"
+	"hash/fnv"
 	"maps"
 	"slices"
 	"strings"
 
 	"github.com/grafana/alerting/definition"
+	alertingNotify "github.com/grafana/alerting/notify"
 	"github.com/prometheus/alertmanager/config"
 	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 
@@ -400,4 +402,63 @@ func InhibitRuleToInhibitionRule(name string, rule config.InhibitRule, provenanc
 		InhibitRule: rule,
 		Provenance:  provenance,
 	}, nil
+}
+
+// PostableMimirReceiverToPostableGrafanaReceiver converts all legacy models to PostableGrafanaReceiver.
+// If receiver does not have any legacy receivers, returns the original receiver.
+// Otherwise, returns a copy that contains converted integrations (and shallow copy of existing Grafana integrations).
+func PostableMimirReceiverToPostableGrafanaReceiver(r *PostableApiReceiver) (*PostableApiReceiver, error) {
+	if !r.HasMimirIntegrations() {
+		return r, nil
+	}
+	v0, err := alertingNotify.ConfigReceiverToMimirIntegrations(r.Receiver)
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert v0 receiver to integrations: %w", err)
+	}
+	result := &PostableApiReceiver{
+		Receiver: definition.Receiver{
+			Name: r.Name,
+		},
+		PostableGrafanaReceivers: PostableGrafanaReceivers{
+			GrafanaManagedReceivers: make([]*PostableGrafanaReceiver, 0, len(v0)+len(r.GrafanaManagedReceivers)),
+		},
+	}
+	result.GrafanaManagedReceivers = append(result.GrafanaManagedReceivers, r.GrafanaManagedReceivers...)
+	typeCount := make(map[string]int)
+	for _, cfg := range v0 {
+		integrationType := string(cfg.Schema.Type())
+		idx := typeCount[integrationType]
+		typeCount[integrationType]++
+		integration, err := MimirIntegrationConfigToPostableGrafanaReceiver(cfg, r.Name, idx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert Mimir integration config to PostableGrafanaReceiver: %w", err)
+		}
+		result.GrafanaManagedReceivers = append(result.GrafanaManagedReceivers, integration)
+	}
+	return result, nil
+}
+
+// MimirIntegrationConfigToPostableGrafanaReceiver converts a Mimir integration configuration to a PostableGrafanaReceiver. All settings are unencrypted. Needs to be encrypted later.
+func MimirIntegrationConfigToPostableGrafanaReceiver(cfg alertingNotify.MimirIntegrationConfig, receiverName string, idx int) (*PostableGrafanaReceiver, error) {
+	raw, err := cfg.ConfigJSON()
+	if err != nil {
+		return nil, err
+	}
+
+	return &PostableGrafanaReceiver{
+		// mimirIntegrationUID generates a stable, fixed-length UID for a converted Mimir integration that passes ValidateUID, 40-char limit for long names in particular
+		UID:                   mimirIntegrationUID(receiverName, string(cfg.Schema.Type()), idx),
+		Name:                  receiverName,
+		Type:                  string(cfg.Schema.Type()),
+		Version:               string(cfg.Schema.Version),
+		DisableResolveMessage: false, // V0 ignores this flag as they have their own SendResolved one.
+		Settings:              raw,
+		SecureSettings:        nil,
+	}, nil
+}
+
+func mimirIntegrationUID(receiverName string, integrationType string, idx int) string {
+	h := fnv.New64a()
+	_, _ = fmt.Fprintf(h, "%s-%s-%d", receiverName, integrationType, idx)
+	return fmt.Sprintf("%016x", h.Sum64())
 }

--- a/pkg/services/ngalert/notifier/legacy_storage/v1/compat.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/v1/compat.go
@@ -1,13 +1,18 @@
 package v1
 
 import (
+	"fmt"
 	"maps"
 	"slices"
+	"strings"
 
 	"github.com/grafana/alerting/definition"
 	"github.com/prometheus/alertmanager/config"
+	k8svalidation "k8s.io/apimachinery/pkg/util/validation"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/api/tooling/definitions"
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 func ToModel(in *definitions.PostableUserConfig) *AMConfigV1 {
@@ -370,4 +375,29 @@ func ExtraConfigToDB(in ExtraConfiguration) definitions.ExtraConfiguration {
 		TemplateFiles:      maps.Clone(in.TemplateFiles),
 		AlertmanagerConfig: in.AlertmanagerConfig,
 	}
+}
+
+func InhibitRuleToInhibitionRule(name string, rule config.InhibitRule, provenance Provenance) (*InhibitionRule, error) {
+	if name = strings.TrimSpace(name); name == "" {
+		return nil, fmt.Errorf("inhibition rule name must not be empty")
+	}
+
+	if strings.Contains(name, ":") {
+		return nil, fmt.Errorf("inhibition rule name cannot contain invalid character ':'")
+	}
+
+	if errs := k8svalidation.IsDNS1123Subdomain(name); len(errs) > 0 {
+		return nil, fmt.Errorf("inhibition rule name must be a valid DNS subdomain: %s", strings.Join(errs, ", "))
+	}
+
+	// imported inhibition rules have purposefully long names to ensure no conflict with non-imported ones
+	if models.Provenance(provenance) != models.ProvenanceConvertedPrometheus && len(name) > util.MaxUIDLength {
+		return nil, fmt.Errorf("inhibition rule name is too long (exceeds %d characters)", util.MaxUIDLength)
+	}
+
+	return &InhibitionRule{
+		Name:        name,
+		InhibitRule: rule,
+		Provenance:  provenance,
+	}, nil
 }

--- a/pkg/services/ngalert/notifier/legacy_storage/v1/compat_test.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/v1/compat_test.go
@@ -8,8 +8,12 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/grafana/alerting/definition"
+	alertingNotify "github.com/grafana/alerting/notify"
+	emailV0 "github.com/grafana/alerting/receivers/email/v0mimir1"
+	webhookV0 "github.com/grafana/alerting/receivers/webhook/v0mimir1"
 	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/pkg/labels"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -292,4 +296,95 @@ func Test_InhibitRuleToInhibitionRule(t *testing.T) {
 			require.Equal(t, tc.exp, got)
 		})
 	}
+}
+
+func TestPostableMimirReceiverToPostableGrafanaReceiver(t *testing.T) {
+	t.Run("returns original pointer when receiver has only Grafana integrations", func(t *testing.T) {
+		receiver := &PostableApiReceiver{
+			Receiver: definition.Receiver{Name: "test"},
+			PostableGrafanaReceivers: PostableGrafanaReceivers{
+				GrafanaManagedReceivers: []*PostableGrafanaReceiver{
+					{UID: "grafana-uid", Name: "test", Type: "email"},
+				},
+			},
+		}
+		result, err := PostableMimirReceiverToPostableGrafanaReceiver(receiver)
+		require.NoError(t, err)
+		assert.Same(t, receiver, result)
+	})
+
+	t.Run("converts Mimir integrations to Grafana integrations", func(t *testing.T) {
+		wh := webhookV0.GetFullValidConfig()
+		receiver := &PostableApiReceiver{
+			Receiver: definition.Receiver{
+				Name:           "test-receiver",
+				WebhookConfigs: []*webhookV0.Config{&wh},
+			},
+		}
+
+		mimirConfigs, err := alertingNotify.ConfigReceiverToMimirIntegrations(receiver.Receiver)
+		require.NoError(t, err)
+		require.Len(t, mimirConfigs, 1)
+		expectedJSON, err := mimirConfigs[0].ConfigJSON()
+		require.NoError(t, err)
+
+		result, err := PostableMimirReceiverToPostableGrafanaReceiver(receiver)
+		require.NoError(t, err)
+		require.NotNil(t, result)
+		assert.NotSame(t, receiver, result)
+		require.Len(t, result.GrafanaManagedReceivers, 1)
+
+		converted := result.GrafanaManagedReceivers[0]
+		assert.Equal(t, "test-receiver", result.Name)
+		assert.Equal(t, "test-receiver", converted.Name)
+		assert.Equal(t, mimirIntegrationUID("test-receiver", "webhook", 0), converted.UID)
+		assert.JSONEq(t, string(expectedJSON), string(converted.Settings))
+		assert.False(t, converted.DisableResolveMessage)
+		assert.Nil(t, converted.SecureSettings)
+		assert.False(t, result.HasMimirIntegrations())
+	})
+
+	t.Run("existing Grafana integrations appear before converted Mimir ones", func(t *testing.T) {
+		wh := webhookV0.GetFullValidConfig()
+		grafanaRecv := &PostableGrafanaReceiver{
+			UID:  "existing-uid",
+			Name: "existing",
+			Type: "email",
+		}
+		receiver := &PostableApiReceiver{
+			Receiver: definition.Receiver{
+				Name:           "mixed-receiver",
+				WebhookConfigs: []*webhookV0.Config{&wh},
+			},
+			PostableGrafanaReceivers: PostableGrafanaReceivers{
+				GrafanaManagedReceivers: []*PostableGrafanaReceiver{grafanaRecv},
+			},
+		}
+
+		result, err := PostableMimirReceiverToPostableGrafanaReceiver(receiver)
+		require.NoError(t, err)
+		require.Len(t, result.GrafanaManagedReceivers, 2)
+		assert.Same(t, grafanaRecv, result.GrafanaManagedReceivers[0])
+		assert.Equal(t, "webhook", result.GrafanaManagedReceivers[1].Type)
+	})
+
+	t.Run("assigns per-type UIDs to converted Mimir integrations", func(t *testing.T) {
+		// UIDs are indexed per integration type, so each type starts at 0.
+		em := emailV0.GetFullValidConfig()
+		wh := webhookV0.GetFullValidConfig()
+		receiver := &PostableApiReceiver{
+			Receiver: definition.Receiver{
+				Name:           "multi-receiver",
+				EmailConfigs:   []*emailV0.Config{&em},
+				WebhookConfigs: []*webhookV0.Config{&wh},
+			},
+		}
+
+		result, err := PostableMimirReceiverToPostableGrafanaReceiver(receiver)
+		require.NoError(t, err)
+		require.Len(t, result.GrafanaManagedReceivers, 2)
+
+		assert.Equal(t, mimirIntegrationUID("multi-receiver", "email", 0), result.GrafanaManagedReceivers[0].UID)
+		assert.Equal(t, mimirIntegrationUID("multi-receiver", "webhook", 0), result.GrafanaManagedReceivers[1].UID)
+	})
 }

--- a/pkg/services/ngalert/notifier/legacy_storage/v1/compat_test.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/v1/compat_test.go
@@ -2,13 +2,17 @@ package v1
 
 import (
 	"encoding/json"
+	"errors"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/grafana/alerting/definition"
+	"github.com/prometheus/alertmanager/config"
 	"github.com/prometheus/alertmanager/pkg/labels"
 	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
 )
 
 func TestRoundTripConversion(t *testing.T) {
@@ -198,4 +202,94 @@ func TestRoundTripConversion(t *testing.T) {
 
 	require.JSONEq(t, configJSON, string(convertedJSON),
 		"Round-trip conversion should be lossless")
+}
+
+func Test_InhibitRuleToInhibitionRule(t *testing.T) {
+	testRule := config.InhibitRule{
+		SourceMatchers: config.Matchers{
+			{
+				Type:  labels.MatchEqual,
+				Name:  "instance",
+				Value: "alertmanager-1",
+			},
+		},
+		TargetMatchers: config.Matchers{
+			{
+				Type:  labels.MatchEqual,
+				Name:  "instance",
+				Value: "alertmanager-2",
+			},
+		},
+		Equal: []string{
+			"service",
+		},
+	}
+
+	tt := []struct {
+		name        string
+		ruleName    string
+		provenance  Provenance
+		inhibitRule config.InhibitRule
+		origin      models.ResourceOrigin
+		exp         *InhibitionRule
+		expErr      error
+	}{
+		{
+			name:     "fails when name is empty",
+			ruleName: "  ",
+			expErr:   errors.New("inhibition rule name must not be empty"),
+		},
+		{
+			name:     "fails when name contains ':'",
+			ruleName: "a:b",
+			expErr:   errors.New("inhibition rule name cannot contain invalid character ':'"),
+		},
+		{
+			name:     "fails when name is not a valid dns 1123 subdomain",
+			ruleName: "_some_name",
+			expErr:   errors.New("inhibition rule name must be a valid DNS subdomain: a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')"),
+		},
+		{
+			name:     "fails when length of non-imported rule name is over UIDMaxLength limit",
+			ruleName: "some-really-long-inhibition-rule-name-001",
+			origin:   models.ResourceOriginGrafana,
+			expErr:   errors.New("inhibition rule name is too long (exceeds 40 characters)"),
+		},
+		{
+			name:        "allows length of imported rule name to be over UIDMaxLength limit",
+			ruleName:    "some-really-long-inhibition-rule-name-001",
+			provenance:  Provenance(models.ProvenanceConvertedPrometheus),
+			origin:      models.ResourceOriginImported,
+			inhibitRule: testRule,
+			exp: &InhibitionRule{
+				Name:        "some-really-long-inhibition-rule-name-001",
+				InhibitRule: testRule,
+				Provenance:  Provenance(models.ProvenanceConvertedPrometheus),
+			},
+		},
+		{
+			name:        "converts model correctly when all validations passes",
+			ruleName:    "inhibition-rule-1",
+			origin:      models.ResourceOriginGrafana,
+			provenance:  Provenance(models.ProvenanceNone),
+			inhibitRule: testRule,
+			exp: &InhibitionRule{
+				Name:        "inhibition-rule-1",
+				InhibitRule: testRule,
+				Provenance:  Provenance(models.ProvenanceNone),
+			},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			got, gotErr := InhibitRuleToInhibitionRule(tc.ruleName, tc.inhibitRule, tc.provenance)
+			if tc.expErr != nil {
+				require.EqualError(t, gotErr, tc.expErr.Error())
+			} else {
+				require.Nil(t, gotErr)
+			}
+			require.Equal(t, tc.exp, got)
+		})
+	}
 }

--- a/pkg/services/ngalert/notifier/merge/merge.go
+++ b/pkg/services/ngalert/notifier/merge/merge.go
@@ -12,11 +12,15 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"slices"
 	"strings"
 
 	"github.com/prometheus/alertmanager/config"
+	"github.com/prometheus/alertmanager/pkg/labels"
 
+	"github.com/grafana/grafana/pkg/services/ngalert/models"
 	v1 "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
+	"github.com/grafana/grafana/pkg/util"
 )
 
 // MergeResult represents the result of merging two Alertmanager configurations.
@@ -278,6 +282,55 @@ func createIndexReceivers(existing, incoming []*v1.PostableApiReceiver) map[stri
 		}
 	}
 	return usedNames
+}
+
+func BuildManagedInhibitionRules(identifier string, rules []config.InhibitRule) (v1.ManagedInhibitionRules, error) {
+	scopedRules := applyManagedRouteMatcher(identifier, rules)
+
+	res := make(v1.ManagedInhibitionRules, len(scopedRules))
+	for i, rule := range scopedRules {
+		namePrefix := fmt.Sprintf("%s-imported-inhibition-rule-", identifier)
+
+		intFmt := "%d"
+		if padLength := util.MaxUIDLength - len(namePrefix); padLength >= 0 {
+			intFmt = fmt.Sprintf("%%0%dd", padLength+1)
+		}
+		name := fmt.Sprintf(namePrefix+intFmt, i)
+
+		ir, err := v1.InhibitRuleToInhibitionRule(name, rule, v1.Provenance(models.ProvenanceConvertedPrometheus))
+		if err != nil {
+			return nil, err
+		}
+		res[name] = ir
+	}
+
+	return res, nil
+}
+
+func applyManagedRouteMatcher(identifier string, rules []config.InhibitRule) []config.InhibitRule {
+	result := make([]config.InhibitRule, 0, len(rules))
+	matcher := &labels.Matcher{
+		Type:  labels.MatchEqual,
+		Name:  models.NamedRouteLabel,
+		Value: identifier,
+	}
+
+	for _, rule := range rules {
+		sm := make(config.Matchers, 0, len(rule.SourceMatchers)+1)
+		sm = append(sm, matcher)
+		sm = append(sm, rule.SourceMatchers...)
+
+		tm := make(config.Matchers, 0, len(rule.TargetMatchers)+1)
+		tm = append(tm, matcher)
+		tm = append(tm, rule.TargetMatchers...)
+
+		result = append(result, config.InhibitRule{
+			SourceMatchers: sm,
+			TargetMatchers: tm,
+			Equal:          slices.Clone(rule.Equal),
+		})
+	}
+	return result
 }
 
 func getUniqueName[T any](name string, suffix string, usedNames map[string]T) string {

--- a/pkg/services/ngalert/notifier/merge/merge.go
+++ b/pkg/services/ngalert/notifier/merge/merge.go
@@ -103,9 +103,9 @@ func MergeExtraConfig(_ context.Context, cfg *v1.AMConfigV1) (MergeResult, error
 	if err != nil {
 		return MergeResult{}, fmt.Errorf("failed to get mimir alertmanager config: %w", err)
 	}
-	mergedReceivers, renamedReceivers := MergeReceivers(cfg.AlertmanagerConfig.Receivers, mcfg.Receivers, mimirCfg.Identifier)
+	mergedReceivers, renamedReceivers := Receivers(cfg.AlertmanagerConfig.Receivers, mcfg.Receivers, mimirCfg.Identifier)
 
-	mergedTimeIntervals, renamedTimeIntervals := MergeTimeIntervals(
+	mergedTimeIntervals, renamedTimeIntervals := TimeIntervals(
 		cfg.AlertmanagerConfig.MuteTimeIntervals,
 		cfg.AlertmanagerConfig.TimeIntervals,
 		mcfg.MuteTimeIntervals,
@@ -153,9 +153,9 @@ func MergeExtraConfig(_ context.Context, cfg *v1.AMConfigV1) (MergeResult, error
 
 // DeduplicateResources merges existing and incoming resources (receivers and time intervals) and ensures unique names by applying suffixes. Returns renamed resources for tracking adjustments made.
 func DeduplicateResources(a, b v1.PostableApiAlertingConfig, suffix string) RenameResources {
-	_, renamedReceivers := MergeReceivers(a.Receivers, b.Receivers, suffix)
+	_, renamedReceivers := Receivers(a.Receivers, b.Receivers, suffix)
 
-	_, renamedTimeIntervals := MergeTimeIntervals(
+	_, renamedTimeIntervals := TimeIntervals(
 		a.MuteTimeIntervals,
 		a.TimeIntervals,
 		b.MuteTimeIntervals,
@@ -168,9 +168,9 @@ func DeduplicateResources(a, b v1.PostableApiAlertingConfig, suffix string) Rena
 	}
 }
 
-// MergeTimeIntervals merges existing and incoming time intervals and mute intervals, ensuring unique names by applying suffixes.
+// TimeIntervals merges existing and incoming time intervals and mute intervals, ensuring unique names by applying suffixes.
 // It returns a merged list of time intervals and a map of renamed interval names for tracking adjustments made. Mute time intervals are converted to time intervals.
-func MergeTimeIntervals(
+func TimeIntervals(
 	existingMuteIntervals []v1.MuteTimeInterval,
 	existingTimeIntervals []v1.TimeInterval,
 	incomingMuteIntervals []v1.MuteTimeInterval,
@@ -246,11 +246,11 @@ func RenameResourceUsagesInRoutes(routes []*v1.Route, renames RenameResources) {
 	}
 }
 
-// MergeReceivers merges two lists of PostableApiReceiver objects, ensuring unique names by appending a suffix if necessary.
+// Receivers merges two lists of PostableApiReceiver objects, ensuring unique names by appending a suffix if necessary.
 // It returns the combined list of receivers and a map of renamed original names to their new unique names.
 // The items of the existing list are added to the result list as is whereas the items of incoming list are copied (shallow copy)
 // and renamed if necessary.
-func MergeReceivers(existing, incoming []*v1.PostableApiReceiver, suffix string) ([]*v1.PostableApiReceiver, map[string]string) {
+func Receivers(existing, incoming []*v1.PostableApiReceiver, suffix string) ([]*v1.PostableApiReceiver, map[string]string) {
 	result := make([]*v1.PostableApiReceiver, 0, len(existing)+len(incoming))
 	result = append(result, existing...)
 	usedNames := createIndexReceivers(existing, incoming)

--- a/pkg/services/ngalert/notifier/merge/merge_test.go
+++ b/pkg/services/ngalert/notifier/merge/merge_test.go
@@ -18,7 +18,7 @@ import (
 	v1 "github.com/grafana/grafana/pkg/services/ngalert/notifier/legacy_storage/v1"
 )
 
-func TestMergeReceivers(t *testing.T) {
+func TestReceivers(t *testing.T) {
 	r := func(name string) *v1.PostableApiReceiver {
 		return &v1.PostableApiReceiver{
 			Receiver: definition.Receiver{
@@ -122,7 +122,7 @@ func TestMergeReceivers(t *testing.T) {
 				incomingNames = append(incomingNames, r.Name)
 			}
 
-			actual, actualRenames := MergeReceivers(tc.existing, tc.incoming, suffix)
+			actual, actualRenames := Receivers(tc.existing, tc.incoming, suffix)
 			require.Len(t, actual, len(tc.expected))
 			assert.EqualValues(t, tc.expectedRenames, actualRenames)
 			for i := range tc.expected {
@@ -151,7 +151,7 @@ func TestMergeReceivers(t *testing.T) {
 	}
 }
 
-func TestMergeTimeIntervals(t *testing.T) {
+func TestTimeIntervals(t *testing.T) {
 	ti := func(name string) v1.TimeInterval {
 		return v1.TimeInterval{
 			Name: name,
@@ -305,7 +305,7 @@ func TestMergeTimeIntervals(t *testing.T) {
 				incomingNames = append(incomingNames, r.Name)
 			}
 
-			actualTimeIntervals, actualRenames := MergeTimeIntervals(tc.existingMuteIntervals, tc.existingTimeIntervals, tc.incomingMuteIntervals, tc.incomingTimeIntervals, suffix)
+			actualTimeIntervals, actualRenames := TimeIntervals(tc.existingMuteIntervals, tc.existingTimeIntervals, tc.incomingMuteIntervals, tc.incomingTimeIntervals, suffix)
 			assert.Equal(t, tc.expected, actualTimeIntervals)
 			assert.EqualValues(t, tc.expectedRenames, actualRenames)
 


### PR DESCRIPTION
## Summary

Refactoring-only PR — no behaviour change. Moves functions closer to the packages that own the types they operate on, and cleans up names in the `merge` package.

- Move `InhibitRuleToInhibitionRule` from `legacy_storage` to `legacy_storage/v1` (operates on `v1.InhibitionRule` / `v1.Provenance`)
- Move `PostableMimirReceiverToPostableGrafanaReceiver` + helpers from `legacy_storage` to `legacy_storage/v1` (operates on `v1.PostableApiReceiver`)
- Move `BuildManagedInhibitionRules` + `applyManagedRouteMatcher` from `legacy_storage` to `merge` (used exclusively during config merging)
- Rename `merge.MergeReceivers` → `merge.Receivers` and `merge.MergeTimeIntervals` → `merge.TimeIntervals` (drop redundant prefix)

Each move is a separate commit; tests and callers are updated in the same commit as the moved function.

## Test plan

- [ ] All existing unit tests pass — no logic changed, only package location and names
- [ ] `go build ./pkg/services/ngalert/notifier/...` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)