### PR TITLE
Dashboard: Skip flaky tabs scroll Playwright test

### DIFF
--- a/e2e-playwright/dashboard-new-layouts/dashboard-tabs-scroll.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboard-tabs-scroll.spec.ts
@@ -72,7 +72,7 @@ test.describe(
     tag: ['@dashboards'],
   },
   () => {
-    test('shows scroll buttons and supports paged scrolling', async ({ gotoDashboardPage, selectors, page }) => {
+    test.skip('shows scroll buttons and supports paged scrolling', async ({ gotoDashboardPage, selectors, page }) => {
       const dashboardPage = await gotoDashboardPage({});
       const { firstTab, lastTab } = await buildOverflowTabs(page, dashboardPage, selectors);
 


### PR DESCRIPTION
## What is this feature?

Marks the `shows scroll buttons and supports paged scrolling` test in `e2e-playwright/dashboard-new-layouts/dashboard-tabs-scroll.spec.ts` as `.skip` so it no longer runs in CI.

## Why do we need this feature?

The test has been flaky. Skipping it unblocks CI while the underlying flakiness is investigated.

## Who is this feature for?

Engineers maintaining the dashboard new layouts area and anyone affected by flaky CI runs caused by this test.

## Which issue(s) does this PR fix?

N/A

## Special notes for your reviewer

- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to What's New.

Note: this is a temporary skip. A follow-up should re-enable the test once the flakiness is fixed.