### PR TITLE
Alerting: Make provisioning alert rule delete idempotent for non-admin users

### DIFF
--- a/pkg/services/ngalert/provisioning/alert_rules.go
+++ b/pkg/services/ngalert/provisioning/alert_rules.go
@@ -1051,12 +1051,14 @@ func (service *AlertRuleService) DeleteAlertRule(ctx context.Context, user ident
 	if !can {
 		delta, err := store.CalculateRuleDelete(ctx, service.ruleStore, rule.GetKey())
 		if err != nil {
-			if !errors.Is(err, models.ErrAlertRuleNotFound) {
-				return err
+			if errors.Is(err, models.ErrAlertRuleNotFound) {
+				// Rule already gone; return early so non-admin users
+				// get the same idempotent behaviour as admins.
+				return nil
 			}
-			// Rule already gone; fall through to the idempotent delete below
-			// so non-admin users get the same 204 behaviour as admins.
-		} else if err = service.authz.AuthorizeRuleGroupWrite(ctx, user, delta); err != nil {
+			return err
+		}
+		if err = service.authz.AuthorizeRuleGroupWrite(ctx, user, delta); err != nil {
 			return err
 		}
 	}

--- a/pkg/services/ngalert/provisioning/alert_rules.go
+++ b/pkg/services/ngalert/provisioning/alert_rules.go
@@ -1051,9 +1051,12 @@ func (service *AlertRuleService) DeleteAlertRule(ctx context.Context, user ident
 	if !can {
 		delta, err := store.CalculateRuleDelete(ctx, service.ruleStore, rule.GetKey())
 		if err != nil {
-			return err
-		}
-		if err = service.authz.AuthorizeRuleGroupWrite(ctx, user, delta); err != nil {
+			if !errors.Is(err, models.ErrAlertRuleNotFound) {
+				return err
+			}
+			// Rule already gone; fall through to the idempotent delete below
+			// so non-admin users get the same 204 behaviour as admins.
+		} else if err = service.authz.AuthorizeRuleGroupWrite(ctx, user, delta); err != nil {
 			return err
 		}
 	}

--- a/pkg/services/ngalert/provisioning/alert_rules_test.go
+++ b/pkg/services/ngalert/provisioning/alert_rules_test.go
@@ -1544,6 +1544,22 @@ func TestDeleteAlertRule(t *testing.T) {
 			deletes := getDeleteQueries(ruleStore)
 			require.Empty(t, deletes)
 		})
+		t.Run("delete of non-existent rule is idempotent", func(t *testing.T) {
+			service, ruleStore, _, ac := initServiceWithData(t)
+
+			ac.CanWriteAllRulesFunc = func(ctx context.Context, user identity.Requester) (bool, error) {
+				return false, nil
+			}
+
+			err := service.DeleteAlertRule(context.Background(), u, "nonexistent-uid", groupProvenance)
+			require.NoError(t, err, "non-admin delete of non-existent rule should be idempotent")
+
+			require.Len(t, ac.Calls, 1)
+			assert.Equal(t, "CanWriteAllRules", ac.Calls[0].Method)
+
+			deletes := getDeleteQueries(ruleStore)
+			require.Len(t, deletes, 1, "deleteRules should still be called")
+		})
 	})
 
 	// NoGroup-specific behaviors

--- a/pkg/services/ngalert/provisioning/alert_rules_test.go
+++ b/pkg/services/ngalert/provisioning/alert_rules_test.go
@@ -1558,7 +1558,7 @@ func TestDeleteAlertRule(t *testing.T) {
 			assert.Equal(t, "CanWriteAllRules", ac.Calls[0].Method)
 
 			deletes := getDeleteQueries(ruleStore)
-			require.Len(t, deletes, 1, "deleteRules should still be called")
+			require.Empty(t, deletes, "no store delete when rule already gone")
 		})
 	})
 


### PR DESCRIPTION
**What is this feature?**

When a non-admin user calls `DELETE /api/v1/provisioning/alert-rules/{UID}` for a rule that doesn't exist, skip the authorization check and fall through to the idempotent delete, matching admin behavior (204).

**Why do we need this feature?**

Admin users bypass `CalculateRuleDelete` (via `CanWriteAllRules`), so deleting a non-existent rule silently succeeds with 204. Non-admin users hit `CalculateRuleDelete`, which returns `ErrAlertRuleNotFound`, a bare `fmt.Errorf` that `ErrOrFallback` cannot extract a status from, producing HTTP 500.

This surfaces in Terraform workflows where a destroy plan re-runs against a rule that was already removed.

**Who is this feature for?**

Users managing alert rules via the provisioning API with service accounts that don't have full provisioning-write permissions.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.