### PR TITLE
Home: Fix flaky DashboardTabs extension tabs test

### DIFF
--- a/public/app/features/home/DashboardTabs/DashboardTabs.test.tsx
+++ b/public/app/features/home/DashboardTabs/DashboardTabs.test.tsx
@@ -178,7 +178,9 @@ describe('DashboardTabs', () => {
     const { user } = render(<DashboardTabs />);
 
     expect(await screen.findByRole('tab', { name: 'Plugin Tab 1' })).toBeInTheDocument();
-    expect(screen.getByRole('tab', { name: 'Plugin Tab 1' })).toHaveAttribute('aria-selected', 'true');
+    await waitFor(() => {
+      expect(screen.getByRole('tab', { name: 'Plugin Tab 1' })).toHaveAttribute('aria-selected', 'true');
+    });
 
     expect(await screen.findByRole('tab', { name: 'Plugin Tab 2' })).toBeInTheDocument();
     expect(screen.queryByRole('tab', { name: 'Plugin Tab 3' })).not.toBeInTheDocument();


### PR DESCRIPTION
## Summary

- The `DashboardTabs > renders extension tabs from plugins` test was flaky. It asserted `aria-selected="true"` on the first plugin tab synchronously after `findByRole` returned, but the auto-switch effect that promotes the first non-href extension tab to active only runs after the async recent/starred data loading completes.
- Wrap the `aria-selected` assertion in `waitFor` so it retries until the auto-switch effect has run. No production code changes.

## Test plan

- [x] `yarn jest --no-watch public/app/features/home/DashboardTabs/DashboardTabs.test.tsx` (ran 3x consecutively, all 7 tests pass each time)


Made with [Cursor](https://cursor.com)