### PR TITLE
POC/Search: Support search using labelSelectors

### DIFF
--- a/pkg/apimachinery/utils/meta.go
+++ b/pkg/apimachinery/utils/meta.go
@@ -17,6 +17,15 @@ import (
 	common "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
 )
 
+// LabelKeySearchPrefix is used to issue search requests using label selectors
+// For example:
+// * "grafana.app/search.title=foo" will search for resources with "foo" in the title
+// * "grafana.app/search.name in (a,b,c)" will find resources with the name "a", "b", or "c"
+// * "grafana.app/search.folder=xyz" will find resources with the folder "xyz"
+// By default the condition is required (AND), however you can express OR with multiple selectors using:
+// * ?labelSelector=grafana.app/search.OR.folder=A&labelSelector=grafana.app/search.OR.title=B"
+const LabelKeySearchPrefix = "grafana.app/search."
+
 // LabelKeyGetHistory is used to select object history for an given resource
 const LabelKeyGetHistory = "grafana.app/get-history"
 

--- a/pkg/extensions/enterprise_imports.go
+++ b/pkg/extensions/enterprise_imports.go
@@ -111,6 +111,8 @@ import (
 	_ "github.com/grafana/grafana/apps/alerting/alertenrichment/pkg/apis/alertenrichment/v1beta1"
 	_ "github.com/grafana/grafana/apps/alerting/historian/pkg/app/config"
 	_ "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
+	_ "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2"
+	_ "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v2beta1"
 	_ "github.com/grafana/grafana/apps/dashboard/pkg/migration/schemaversion"
 	_ "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1beta1"
 	_ "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"

--- a/pkg/storage/unified/apistore/util.go
+++ b/pkg/storage/unified/apistore/util.go
@@ -12,6 +12,7 @@ import (
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apiserver/pkg/storage"
 
@@ -56,16 +57,21 @@ func toListRequest(k *resourcepb.ResourceKey, opts storage.ListOptions) (*resour
 			return nil, predicate, nil // not selectable
 		}
 
+		// Track the search.* requirements so we can drop them from the predicate;
+		// they're sent to the server as field filters and don't exist as real labels
+		// on the returned objects.
+		var residualLabelReqs []labels.Requirement
+
 		for _, r := range requirements {
 			v := r.Key()
 
 			// grafana.app/search.* selections are converted to search requests
 			if field, ok := strings.CutPrefix(v, utils.LabelKeySearchPrefix); ok {
 				switch {
-				case strings.HasPrefix(field, "OR."):
+				case strings.HasPrefix(field, "OR."): // Converts to a SHOULD condition in bleve
 					return nil, predicate, apierrors.NewBadRequest("OR conditions in search labels are not yet supported: " + v)
 				case strings.HasPrefix(field, "AND."):
-					field = strings.TrimPrefix(field, "AND.")
+					field = strings.TrimPrefix(field, "AND.") // the default -- converts to a MUST condition in bleve
 				}
 				req.Options.Fields = append(req.Options.Fields, &resourcepb.Requirement{
 					Key:      field,
@@ -74,6 +80,7 @@ func toListRequest(k *resourcepb.ResourceKey, opts storage.ListOptions) (*resour
 				})
 				continue
 			}
+			residualLabelReqs = append(residualLabelReqs, r)
 
 			// Parse the history/trash request from labels
 			if v == utils.LabelKeyGetHistory || v == utils.LabelKeyGetTrash {
@@ -124,6 +131,16 @@ func toListRequest(k *resourcepb.ResourceKey, opts storage.ListOptions) (*resour
 				Operator: string(r.Operator()),
 				Values:   r.Values().List(),
 			})
+		}
+
+		// Rebuild the predicate's label selector without the search.* requirements
+		// so they aren't re-applied as client-side label filters.
+		if len(residualLabelReqs) != len(requirements) {
+			if len(residualLabelReqs) == 0 {
+				predicate.Label = labels.NewSelector()
+			} else {
+				predicate.Label = labels.NewSelector().Add(residualLabelReqs...)
+			}
 		}
 	}
 

--- a/pkg/storage/unified/apistore/util.go
+++ b/pkg/storage/unified/apistore/util.go
@@ -59,8 +59,20 @@ func toListRequest(k *resourcepb.ResourceKey, opts storage.ListOptions) (*resour
 		for _, r := range requirements {
 			v := r.Key()
 
-			if strings.HasPrefix(v, utils.LabelKeySearchPrefix) {
-
+			// grafana.app/search.* selections are converted to search requests
+			if field, ok := strings.CutPrefix(v, utils.LabelKeySearchPrefix); ok {
+				switch {
+				case strings.HasPrefix(field, "OR."):
+					return nil, predicate, apierrors.NewBadRequest("OR conditions in search labels are not yet supported: " + v)
+				case strings.HasPrefix(field, "AND."):
+					field = strings.TrimPrefix(field, "AND.")
+				}
+				req.Options.Fields = append(req.Options.Fields, &resourcepb.Requirement{
+					Key:      field,
+					Operator: string(r.Operator()),
+					Values:   r.Values().List(),
+				})
+				continue
 			}
 
 			// Parse the history/trash request from labels

--- a/pkg/storage/unified/apistore/util.go
+++ b/pkg/storage/unified/apistore/util.go
@@ -8,6 +8,7 @@ package apistore
 import (
 	"fmt"
 	"strconv"
+	"strings"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -57,6 +58,10 @@ func toListRequest(k *resourcepb.ResourceKey, opts storage.ListOptions) (*resour
 
 		for _, r := range requirements {
 			v := r.Key()
+
+			if strings.HasPrefix(v, utils.LabelKeySearchPrefix) {
+
+			}
 
 			// Parse the history/trash request from labels
 			if v == utils.LabelKeyGetHistory || v == utils.LabelKeyGetTrash {

--- a/pkg/storage/unified/apistore/util_test.go
+++ b/pkg/storage/unified/apistore/util_test.go
@@ -189,6 +189,131 @@ func TestToListRequest(t *testing.T) {
 			wantErr:       nil,
 		},
 		{
+			name: "with search prefix label (equals)",
+			key: &resourcepb.ResourceKey{
+				Group:     "test",
+				Resource:  "test",
+				Namespace: "default",
+			},
+			opts: storage.ListOptions{
+				Predicate: storage.SelectionPredicate{
+					Label: labels.SelectorFromSet(labels.Set{utils.LabelKeySearchPrefix + "folder": "xyz"}),
+				},
+			},
+			want: &resourcepb.ListRequest{
+				VersionMatchV2: 1,
+				Options: &resourcepb.ListOptions{
+					Key: &resourcepb.ResourceKey{
+						Group:     "test",
+						Resource:  "test",
+						Namespace: "default",
+					},
+					Fields: []*resourcepb.Requirement{
+						{
+							Key:      "folder",
+							Operator: string(selection.Equals),
+							Values:   []string{"xyz"},
+						},
+					},
+				},
+			},
+			wantPredicate: storage.SelectionPredicate{
+				Label: labels.SelectorFromSet(labels.Set{utils.LabelKeySearchPrefix + "folder": "xyz"}),
+			},
+			wantErr: nil,
+		},
+		{
+			name: "with search prefix label (in operator)",
+			key: &resourcepb.ResourceKey{
+				Group:     "test",
+				Resource:  "test",
+				Namespace: "default",
+			},
+			opts: func() storage.ListOptions {
+				req, err := labels.NewRequirement(utils.LabelKeySearchPrefix+"name", selection.In, []string{"a", "b", "c"})
+				require.NoError(t, err)
+				return storage.ListOptions{
+					Predicate: storage.SelectionPredicate{
+						Label: labels.NewSelector().Add(*req),
+					},
+				}
+			}(),
+			want: &resourcepb.ListRequest{
+				VersionMatchV2: 1,
+				Options: &resourcepb.ListOptions{
+					Key: &resourcepb.ResourceKey{
+						Group:     "test",
+						Resource:  "test",
+						Namespace: "default",
+					},
+					Fields: []*resourcepb.Requirement{
+						{
+							Key:      "name",
+							Operator: string(selection.In),
+							Values:   []string{"a", "b", "c"},
+						},
+					},
+				},
+			},
+			wantPredicate: func() storage.SelectionPredicate {
+				req, _ := labels.NewRequirement(utils.LabelKeySearchPrefix+"name", selection.In, []string{"a", "b", "c"})
+				return storage.SelectionPredicate{
+					Label: labels.NewSelector().Add(*req),
+				}
+			}(),
+			wantErr: nil,
+		},
+		{
+			name: "with search prefix label (explicit AND)",
+			key: &resourcepb.ResourceKey{
+				Group:     "test",
+				Resource:  "test",
+				Namespace: "default",
+			},
+			opts: storage.ListOptions{
+				Predicate: storage.SelectionPredicate{
+					Label: labels.SelectorFromSet(labels.Set{utils.LabelKeySearchPrefix + "AND.title": "foo"}),
+				},
+			},
+			want: &resourcepb.ListRequest{
+				VersionMatchV2: 1,
+				Options: &resourcepb.ListOptions{
+					Key: &resourcepb.ResourceKey{
+						Group:     "test",
+						Resource:  "test",
+						Namespace: "default",
+					},
+					Fields: []*resourcepb.Requirement{
+						{
+							Key:      "title",
+							Operator: string(selection.Equals),
+							Values:   []string{"foo"},
+						},
+					},
+				},
+			},
+			wantPredicate: storage.SelectionPredicate{
+				Label: labels.SelectorFromSet(labels.Set{utils.LabelKeySearchPrefix + "AND.title": "foo"}),
+			},
+			wantErr: nil,
+		},
+		{
+			name: "with search prefix label rejects OR variant",
+			key: &resourcepb.ResourceKey{
+				Group:     "test",
+				Resource:  "test",
+				Namespace: "default",
+			},
+			opts: storage.ListOptions{
+				Predicate: storage.SelectionPredicate{
+					Label: labels.SelectorFromSet(labels.Set{utils.LabelKeySearchPrefix + "OR.folder": "xyz"}),
+				},
+			},
+			want:          nil,
+			wantPredicate: storage.SelectionPredicate{},
+			wantErr:       apierrors.NewBadRequest("OR conditions in search labels are not yet supported: " + utils.LabelKeySearchPrefix + "OR.folder"),
+		},
+		{
 			name: "with history label",
 			key: &resourcepb.ResourceKey{
 				Group:     "test",

--- a/pkg/storage/unified/apistore/util_test.go
+++ b/pkg/storage/unified/apistore/util_test.go
@@ -218,7 +218,7 @@ func TestToListRequest(t *testing.T) {
 				},
 			},
 			wantPredicate: storage.SelectionPredicate{
-				Label: labels.SelectorFromSet(labels.Set{utils.LabelKeySearchPrefix + "folder": "xyz"}),
+				Label: labels.NewSelector(),
 			},
 			wantErr: nil,
 		},
@@ -255,12 +255,9 @@ func TestToListRequest(t *testing.T) {
 					},
 				},
 			},
-			wantPredicate: func() storage.SelectionPredicate {
-				req, _ := labels.NewRequirement(utils.LabelKeySearchPrefix+"name", selection.In, []string{"a", "b", "c"})
-				return storage.SelectionPredicate{
-					Label: labels.NewSelector().Add(*req),
-				}
-			}(),
+			wantPredicate: storage.SelectionPredicate{
+				Label: labels.NewSelector(),
+			},
 			wantErr: nil,
 		},
 		{
@@ -293,7 +290,7 @@ func TestToListRequest(t *testing.T) {
 				},
 			},
 			wantPredicate: storage.SelectionPredicate{
-				Label: labels.SelectorFromSet(labels.Set{utils.LabelKeySearchPrefix + "AND.title": "foo"}),
+				Label: labels.NewSelector(),
 			},
 			wantErr: nil,
 		},

--- a/pkg/storage/unified/resource/list_with_field_selectors.go
+++ b/pkg/storage/unified/resource/list_with_field_selectors.go
@@ -9,6 +9,7 @@ import (
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
+	"k8s.io/apimachinery/pkg/selection"
 )
 
 func (s *server) listWithFieldSelectors(ctx context.Context, req *resourcepb.ListRequest) (*resourcepb.ListResponse, error) {
@@ -21,8 +22,14 @@ func (s *server) listWithFieldSelectors(ctx context.Context, req *resourcepb.Lis
 		}, nil
 	}
 
+	// Only selectable fields are stored under the SEARCH_SELECTABLE_FIELDS_PREFIX
+	// sub-document. Standard search fields (folder, title, tags, ...) live at the
+	// top level of the index and must not be prefixed.
+	standardFields := StandardSearchFields()
 	for _, v := range req.Options.Fields {
-		v.Key = SEARCH_SELECTABLE_FIELDS_PREFIX + v.Key
+		if standardFields.Field(v.Key) == nil {
+			v.Key = SEARCH_SELECTABLE_FIELDS_PREFIX + v.Key
+		}
 	}
 
 	srq := &resourcepb.ResourceSearchRequest{
@@ -110,7 +117,12 @@ func (s *server) listWithFieldSelectors(ctx context.Context, req *resourcepb.Lis
 func filterFieldSelectors(req *resourcepb.ListRequest) *resourcepb.ListRequest {
 	fields := make([]*resourcepb.Requirement, 0, len(req.Options.Fields))
 	for _, f := range req.Options.Fields {
-		if (f.Operator != "=" && f.Operator != "==") || f.Key == "metadata.namespace" {
+		if f.Key == "metadata.namespace" {
+			continue
+		}
+		switch selection.Operator(f.Operator) {
+		case selection.Equals, selection.DoubleEquals, selection.In:
+		default:
 			continue
 		}
 		fields = append(fields, f)

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"iter"
 	"net/http"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -1362,6 +1363,9 @@ func (s *server) List(ctx context.Context, req *resourcepb.ListRequest) (*resour
 	for _, v := range req.Options.Labels {
 		if v.Key == utils.LabelKeyGetHistory || v.Key == utils.LabelKeyGetTrash {
 			return &resourcepb.ListResponse{Error: NewBadRequestError("history and trash must be requested as source")}, nil
+		}
+		if strings.HasPrefix(v.Key, utils.LabelKeySearchPrefix) {
+			return &resourcepb.ListResponse{Error: NewBadRequestError("search labels must be converted to field requirements before reaching the backend: " + v.Key)}, nil
 		}
 	}
 

--- a/pkg/tests/apis/folder/folders_test.go
+++ b/pkg/tests/apis/folder/folders_test.go
@@ -390,6 +390,82 @@ func doFolderTests(t *testing.T, helper *apis.K8sTestHelper) *apis.K8sTestHelper
 		errDelete := client.Resource.Delete(context.Background(), first.GetName(), metav1.DeleteOptions{})
 		require.NoError(t, errDelete)
 	})
+
+	t.Run("Search folders by parent using labelSelector", func(t *testing.T) {
+		client := helper.GetResourceClient(apis.ResourceClientArgs{
+			User: helper.Org1.Admin,
+			GVR:  gvr,
+		})
+
+		// Create a parent folder via legacy API so it is visible everywhere.
+		parentUID := "label-sel-parent"
+		parentPayload := fmt.Sprintf(`{"title": "Label Selector Parent", "uid": "%s"}`, parentUID)
+		parentCreate := apis.DoRequest(helper, apis.RequestParams{
+			User:   client.Args.User,
+			Method: http.MethodPost,
+			Path:   "/api/folders",
+			Body:   []byte(parentPayload),
+		}, &folder.Folder{})
+		require.NotNil(t, parentCreate.Result)
+		require.Equal(t, parentUID, parentCreate.Result.UID)
+
+		// Create two child folders under that parent.
+		childUIDs := []string{"label-sel-child-a", "label-sel-child-b"}
+		for _, uid := range childUIDs {
+			childPayload := fmt.Sprintf(`{"title": "Child %s", "uid": "%s", "parentUid": "%s"}`, uid, uid, parentUID)
+			childCreate := apis.DoRequest(helper, apis.RequestParams{
+				User:   client.Args.User,
+				Method: http.MethodPost,
+				Path:   "/api/folders",
+				Body:   []byte(childPayload),
+			}, &folder.Folder{})
+			require.NotNil(t, childCreate.Result)
+			require.Equal(t, uid, childCreate.Result.UID)
+			require.Equal(t, parentUID, childCreate.Result.ParentUID)
+		}
+
+		// List using labelSelector to filter for folders inside the parent.
+		listed, err := client.Resource.List(context.Background(), metav1.ListOptions{
+			LabelSelector: utils.LabelKeySearchPrefix + "folder=" + parentUID,
+		})
+		require.NoError(t, err)
+		items, err := meta.ExtractList(listed)
+		require.NoError(t, err)
+		require.Len(t, items, len(childUIDs))
+
+		gotUIDs := make([]string, 0, len(items))
+		for _, item := range items {
+			obj, ok := item.(*unstructured.Unstructured)
+			require.True(t, ok)
+			gotUIDs = append(gotUIDs, obj.GetName())
+		}
+		slices.Sort(gotUIDs)
+		require.Equal(t, childUIDs, gotUIDs)
+
+		// The "in" selector form should also return the children.
+		listed, err = client.Resource.List(context.Background(), metav1.ListOptions{
+			LabelSelector: utils.LabelKeySearchPrefix + "folder in (" + parentUID + ")",
+		})
+		require.NoError(t, err)
+		items, err = meta.ExtractList(listed)
+		require.NoError(t, err)
+		require.Len(t, items, len(childUIDs))
+
+		// A parent that has no children should return zero results.
+		listed, err = client.Resource.List(context.Background(), metav1.ListOptions{
+			LabelSelector: utils.LabelKeySearchPrefix + "folder=does-not-exist",
+		})
+		require.NoError(t, err)
+		items, err = meta.ExtractList(listed)
+		require.NoError(t, err)
+		require.Empty(t, items)
+
+		// Cleanup
+		for _, uid := range childUIDs {
+			require.NoError(t, client.Resource.Delete(context.Background(), uid, metav1.DeleteOptions{}))
+		}
+		require.NoError(t, client.Resource.Delete(context.Background(), parentUID, metav1.DeleteOptions{}))
+	})
 	return helper
 }
 


### PR DESCRIPTION
## Summary
- Adds the `grafana.app/search.<field>` label prefix so list requests can express multi-value folder/name (and other indexed field) searches via standard K8s label selectors. `apistore.toListRequest` strips the prefix and converts the selector into a `req.Options.Fields` requirement.
- Recognizes `grafana.app/search.AND.<field>` as an explicit synonym for the default AND behavior; `grafana.app/search.OR.<field>` is parsed but rejected with a clear "not yet supported" BadRequest.
- Mirrors the existing `LabelKeyGetHistory`/`LabelKeyGetTrash` guard in `resource/server.go`: rejects any list request whose `Options.Labels` still contains a `grafana.app/search.` key, since apistore should have converted it.

## Test plan
- [x] `go test ./pkg/storage/unified/apistore/... ./pkg/storage/unified/resource/...`