### PR TITLE
Chore: Remove gf-form from DataSourceTestingStatus

### DIFF
--- a/eslint-suppressions.json
+++ b/eslint-suppressions.json
@@ -2080,11 +2080,6 @@
       "count": 3
     }
   },
-  "public/app/features/datasources/components/DataSourceTestingStatus.tsx": {
-    "@grafana/no-gf-form": {
-      "count": 1
-    }
-  },
   "public/app/features/datasources/components/EditDataSourceActions.test.tsx": {
     "@grafana/no-plain-links": {
       "count": 1

--- a/public/app/features/datasources/components/DataSourceTestingStatus.tsx
+++ b/public/app/features/datasources/components/DataSourceTestingStatus.tsx
@@ -264,7 +264,7 @@ export function DataSourceTestingStatus({ testingStatus, exploreUrl, dataSource 
 
   if (message) {
     return (
-      <div className={cx('gf-form-group', styles.container)}>
+      <div className={styles.container}>
         <Alert severity={severity} title={message} data-testid={e2eSelectors.pages.DataSource.alert}>
           {testingStatus?.details && (
             <>
@@ -352,6 +352,7 @@ export function DataSourceTestingStatus({ testingStatus, exploreUrl, dataSource 
 const getTestingStatusStyles = (theme: GrafanaTheme2) => ({
   container: css({
     paddingTop: theme.spacing(3),
+    marginBottom: theme.spacing(5),
   }),
   moreLink: css({
     marginBlock: theme.spacing(1),


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Removes the usage of `gf-form` classname from `DataSourceTestingStatus`.

**Which issue(s) does this PR fix?**:

https://github.com/grafana/grafana/issues/65513

**Screenshots**

| Before | After |
|  ------ | ----- |
|  <img width="1312" height="781" alt="image" src="https://github.com/user-attachments/assets/cb70b49c-fa68-4473-9ce7-cfff590b918c" /> | <img width="1312" height="781" alt="image" src="https://github.com/user-attachments/assets/322a5e58-ad2d-4efe-8408-06cf641bbffc" /> |