### PR TITLE
Dependencies: Replace github: resolutions with patched npm versions

### DIFF
--- a/.yarn/patches/@mapbox-jsonlint-lines-primitives-npm-2.0.2-f48e04c479.patch
+++ b/.yarn/patches/@mapbox-jsonlint-lines-primitives-npm-2.0.2-f48e04c479.patch
@@ -1,0 +1,27 @@
+diff --git a/LICENSE b/LICENSE
+new file mode 100644
+index 0000000000000000000000000000000000000000..22415e6ef90e85f56e19ab14e0e74e01a35c2de9
+--- /dev/null
++++ b/LICENSE
+@@ -0,0 +1,9 @@
++MIT License
++
++Copyright (C) 2012 Zachary Carter
++
++Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
++
++The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
++
++THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+diff --git a/package.json b/package.json
+index 4a98576c4aebbb28f710f1a22386d67a42ce1764..6cf09cbf79f103bef2d6656c4662c877b5fa9525 100644
+--- a/package.json
++++ b/package.json
+@@ -30,5 +30,6 @@
+   "scripts": {
+     "test": "node test/all-tests.js"
+   },
+-  "optionalDependencies": {}
++  "optionalDependencies": {},
++  "license": "MIT"
+ }

--- a/.yarn/patches/get-document-npm-1.0.0-9fe09104f6.patch
+++ b/.yarn/patches/get-document-npm-1.0.0-9fe09104f6.patch
@@ -1,0 +1,40 @@
+diff --git a/LICENSE b/LICENSE
+new file mode 100644
+index 0000000000000000000000000000000000000000..23af93e8e6d7e0bed9c4d9bce4b526df86360e2f
+--- /dev/null
++++ b/LICENSE
+@@ -0,0 +1,22 @@
++Copyright (c) 2014 Nathan Rajlich <n@n8.io>
++
++Permission is hereby granted, free of charge, to any person
++obtaining a copy of this software and associated documentation
++files (the "Software"), to deal in the Software without
++restriction, including without limitation the rights to use,
++copy, modify, merge, publish, distribute, sublicense, and/or sell
++copies of the Software, and to permit persons to whom the
++Software is furnished to do so, subject to the following
++conditions:
++
++The above copyright notice and this permission notice shall be
++included in all copies or substantial portions of the Software.
++
++THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
++EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
++OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
++NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
++HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
++WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
++FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
++OTHER DEALINGS IN THE SOFTWARE.
+diff --git a/package.json b/package.json
+index c242a0064a4645628ecb99ee4db58ca72a86a4c7..bc534cee851514fea39342c8f37be03a09ffbdc7 100644
+--- a/package.json
++++ b/package.json
+@@ -25,5 +25,6 @@
+   },
+   "devDependencies": {
+     "zuul": "~1.16.5"
+-  }
++  },
++  "license": "MIT"
+ }

--- a/package.json
+++ b/package.json
@@ -460,8 +460,6 @@
     "@grafana/scenes-react/@grafana/e2e-selectors": "workspace:*",
     "swagger-ui-react/dompurify": "3.4.0",
     "refractor/prismjs": "^1.27.0",
-    "@mapbox/jsonlint-lines-primitives": "github:mapbox/jsonlint#commit=e31b7289baedf3e1000d7ae7edd42268212c9954",
-    "get-document": "github:webmodules/get-document#commit=a04ccb499d6e0433a368c3bb150b4899b698461f",
     "gitconfiglocal": "2.1.0",
     "tmp@npm:^0.0.33": "~0.2.1",
     "js-yaml@npm:4.1.0": "^4.1.0",
@@ -470,7 +468,9 @@
     "storybook@npm:10.3.6": "patch:storybook@npm%3A10.3.6#~/.yarn/patches/storybook-npm-10.3.6-8a0644ac0b.patch",
     "protobufjs@npm:8.0.0": "8.0.1",
     "@types/slate/immutable": "^4.0.0",
-    "@types/slate-react/immutable": "^4.0.0"
+    "@types/slate-react/immutable": "^4.0.0",
+    "@mapbox/jsonlint-lines-primitives@npm:~2.0.2": "patch:@mapbox/jsonlint-lines-primitives@npm%3A2.0.2#~/.yarn/patches/@mapbox-jsonlint-lines-primitives-npm-2.0.2-f48e04c479.patch",
+    "get-document@npm:1": "patch:get-document@npm%3A1.0.0#~/.yarn/patches/get-document-npm-1.0.0-9fe09104f6.patch"
   },
   "workspaces": {
     "packages": [

--- a/yarn.lock
+++ b/yarn.lock
@@ -6371,10 +6371,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@mapbox/jsonlint-lines-primitives@github:mapbox/jsonlint#commit=e31b7289baedf3e1000d7ae7edd42268212c9954":
+"@mapbox/jsonlint-lines-primitives@npm:2.0.2":
   version: 2.0.2
-  resolution: "@mapbox/jsonlint-lines-primitives@https://github.com/mapbox/jsonlint.git#commit=e31b7289baedf3e1000d7ae7edd42268212c9954"
-  checksum: 10/660bd93beac97f0f4bdcfbbded3282efaf2ab4debb99da55f7fb7b27250e0dfa7dd572a9040802fdc008c71d0bb5ff7e565a7426177fda6c3d17e9bf1598bbaf
+  resolution: "@mapbox/jsonlint-lines-primitives@npm:2.0.2"
+  checksum: 10/6d8e64d34d912ebf29fead0d1917c8d8ad86e96f69b6100a9764af8cba391609474cdce7f7e4a2d579ccea58a142d1454257b795403179e9133a09af13101068
+  languageName: node
+  linkType: hard
+
+"@mapbox/jsonlint-lines-primitives@patch:@mapbox/jsonlint-lines-primitives@npm%3A2.0.2#~/.yarn/patches/@mapbox-jsonlint-lines-primitives-npm-2.0.2-f48e04c479.patch":
+  version: 2.0.2
+  resolution: "@mapbox/jsonlint-lines-primitives@patch:@mapbox/jsonlint-lines-primitives@npm%3A2.0.2#~/.yarn/patches/@mapbox-jsonlint-lines-primitives-npm-2.0.2-f48e04c479.patch::version=2.0.2&hash=556ff3"
+  checksum: 10/d5cc9e25a1b687d00bfe94c7d83db90b4c398b2ad8ab5d076db98bf0e0978fc14da551dc81d56fc44683c72b3d33d27df66df4347a1664d4f63b38f2011578f2
   languageName: node
   linkType: hard
 
@@ -19860,10 +19867,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-document@github:webmodules/get-document#commit=a04ccb499d6e0433a368c3bb150b4899b698461f":
+"get-document@npm:1.0.0":
   version: 1.0.0
-  resolution: "get-document@https://github.com/webmodules/get-document.git#commit=a04ccb499d6e0433a368c3bb150b4899b698461f"
-  checksum: 10/5ec51321f3a5257a08c3ea9ac1984d64302a34c786f5d5691ae1ee00aba189eedac63f401e0cf746b0c77fb84091a4d2a9b66ac23dc0e872cbac860e5e0c5245
+  resolution: "get-document@npm:1.0.0"
+  checksum: 10/94312db44ea9d070cca8cc14272582d04c7638494d6b5c9c0d6f1d949ef2605b4102ee52f0ded11e571357aba45e9fcc98a5b0467d61e4943a66002167eb6e7a
+  languageName: node
+  linkType: hard
+
+"get-document@patch:get-document@npm%3A1.0.0#~/.yarn/patches/get-document-npm-1.0.0-9fe09104f6.patch":
+  version: 1.0.0
+  resolution: "get-document@patch:get-document@npm%3A1.0.0#~/.yarn/patches/get-document-npm-1.0.0-9fe09104f6.patch::version=1.0.0&hash=c96dbf"
+  checksum: 10/889105d9cea13ea95b3723350adbbbb48bd5ee07500e61f7595da02492683aa8f6f57c821534bd31bb80187c9ca19640b62736bd04b522505a2cd326379259f6
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**What is this feature?**

Replaces the two `github:` protocol entries in `package.json` `resolutions` with `patch:` resolutions that overlay `LICENSE` files onto the npm tarballs. Same content, but every dep now resolves through the npm registry with integrity hashes instead of cloning from `github.com` at install time.

**Why do we need this feature?**

So all transitive deps come from a single trusted source (npm registry) with checksums and provenance, consistent with the policy already stated in `.yarnrc.yml` that explicitly forbids `approvedGitRepositories`.

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Keeps the license-compliance reason behind #107559 — both patches add the upstream MIT `LICENSE` (Zachary Carter for jsonlint, Nathan Rajlich for get-document) and set `"license": "MIT"` in the package.json. Verified `node_modules/@mapbox/jsonlint-lines-primitives/LICENSE` and `node_modules/get-document/LICENSE` are present after install, and the geomap test suite (159 tests, consumer of jsonlint via maplibre-gl-style-spec) still passes.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
