### PR TITLE
DataSourcePicker: mark filtered current source invalid

### DIFF
--- a/packages/grafana-runtime/src/components/DataSourcePicker.test.tsx
+++ b/packages/grafana-runtime/src/components/DataSourcePicker.test.tsx
@@ -16,6 +16,36 @@ jest.mock('../services/dataSourceSrv', () => ({
   }),
 }));
 
+function createDataSource(name: string, uid: string, type: string): DataSourceInstanceSettings {
+  return {
+    uid,
+    name,
+    type,
+    meta: {
+      id: type,
+      name: type,
+      type: 'datasource',
+      info: {
+        logos: {
+          small: `${type}_logo.svg`,
+          large: `${type}_logo.svg`,
+        },
+        author: { name: 'Grafana Labs' },
+        description: `${type} data source`,
+        links: [],
+        screenshots: [],
+        updated: '2021-01-01',
+        version: '1.0.0',
+      },
+      module: `core:plugin/${type}`,
+      baseUrl: '',
+    } as DataSourcePluginMeta,
+    readOnly: false,
+    jsonData: {},
+    access: 'proxy',
+  };
+}
+
 describe('DataSourcePicker', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -27,33 +57,7 @@ describe('DataSourcePicker', () => {
     it('should display full datasource name without truncation when current is passed as UID', () => {
       const longDatasourceName = 'grafanacloud-demokitcloudamersandbox-prom';
       const currentUid = 'grafanacloud-prom';
-      const mockDs: DataSourceInstanceSettings = {
-        uid: currentUid,
-        name: longDatasourceName,
-        type: 'prometheus',
-        meta: {
-          id: 'prometheus',
-          name: 'Prometheus',
-          type: 'datasource',
-          info: {
-            logos: {
-              small: 'prometheus_logo.svg',
-              large: 'prometheus_logo.svg',
-            },
-            author: { name: 'Grafana Labs' },
-            description: 'Prometheus data source',
-            links: [],
-            screenshots: [],
-            updated: '2021-01-01',
-            version: '1.0.0',
-          },
-          module: 'core:plugin/prometheus',
-          baseUrl: '',
-        } as DataSourcePluginMeta,
-        readOnly: false,
-        jsonData: {},
-        access: 'proxy',
-      };
+      const mockDs = createDataSource(longDatasourceName, currentUid, 'prometheus');
 
       mockGetInstanceSettings.mockReturnValue(mockDs);
       mockGetList.mockReturnValue([mockDs]);
@@ -62,6 +66,27 @@ describe('DataSourcePicker', () => {
 
       // The full name should be visible in the select value
       expect(screen.getByText(longDatasourceName)).toBeInTheDocument();
+    });
+  });
+
+  describe('current data source validation', () => {
+    it('should not display a current data source that is excluded by the picker filter as valid', () => {
+      const tempoDs = createDataSource('tempo', 'tempo-uid', 'tempo');
+      const prometheusDs = createDataSource('prometheus', 'prometheus-uid', 'prometheus');
+
+      mockGetInstanceSettings.mockReturnValue(tempoDs);
+      mockGetList.mockReturnValue([prometheusDs]);
+
+      render(
+        <DataSourcePicker
+          current={tempoDs.uid}
+          onChange={jest.fn()}
+          filter={(dataSource) => dataSource.type === 'prometheus'}
+        />
+      );
+
+      expect(screen.queryByText('tempo')).not.toBeInTheDocument();
+      expect(screen.getByText('tempo-uid - invalid')).toBeInTheDocument();
     });
   });
 

--- a/packages/grafana-runtime/src/components/DataSourcePicker.tsx
+++ b/packages/grafana-runtime/src/components/DataSourcePicker.tsx
@@ -1,5 +1,5 @@
 // Libraries
-import { memo, useEffect, useState } from 'react';
+import { memo, useEffect, useMemo, useState } from 'react';
 
 // Components
 import {
@@ -86,13 +86,34 @@ export const DataSourcePicker = memo(function DataSourcePicker({
 }: DataSourcePickerProps) {
   const dataSourceSrv = getDataSourceSrv();
   const [error, setError] = useState<string | undefined>(undefined);
+  const filters = useMemo(
+    () => ({
+      alerting,
+      tracing,
+      metrics,
+      logs,
+      dashboard,
+      mixed,
+      variables,
+      annotations,
+      pluginId,
+      filter,
+      type,
+    }),
+    [alerting, tracing, metrics, logs, dashboard, mixed, variables, annotations, pluginId, filter, type]
+  );
+  const dataSources = useMemo(() => dataSourceSrv.getList(filters), [dataSourceSrv, filters]);
 
   useEffect(() => {
     const dsSettings = dataSourceSrv.getInstanceSettings(current);
     if (!dsSettings) {
       setError('Could not find data source ' + current);
+    } else if (!isDataSourceSelectable(dsSettings, dataSources)) {
+      setError('Invalid data source ' + current);
+    } else {
+      setError(undefined);
     }
-  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [current, dataSourceSrv, dataSources]);
 
   function handleChange(item: SelectableValue<string>, actionMeta: ActionMeta) {
     if (actionMeta.action === 'clear' && onClear) {
@@ -112,6 +133,16 @@ export const DataSourcePicker = memo(function DataSourcePicker({
     }
     const ds = dataSourceSrv.getInstanceSettings(current);
     if (ds) {
+      if (!isDataSourceSelectable(ds, dataSources)) {
+        const uid = getDataSourceUID(current);
+        return {
+          label: (uid ?? ds.name) + ' - invalid',
+          value: uid ?? undefined,
+          imgUrl: '',
+          hideText: hideTextValue,
+        };
+      }
+
       return {
         label: ds.name,
         value: ds.uid,
@@ -133,14 +164,12 @@ export const DataSourcePicker = memo(function DataSourcePicker({
   }
 
   function getDataSourceOptions() {
-    return dataSourceSrv
-      .getList({ alerting, tracing, metrics, logs, dashboard, mixed, variables, annotations, pluginId, filter, type })
-      .map((ds) => ({
-        value: ds.name,
-        label: `${ds.name}${ds.isDefault ? ' (default)' : ''}`,
-        imgUrl: ds.meta.info.logos.small,
-        meta: ds.meta,
-      }));
+    return dataSources.map((ds) => ({
+      value: ds.name,
+      label: `${ds.name}${ds.isDefault ? ' (default)' : ''}`,
+      imgUrl: ds.meta.info.logos.small,
+      meta: ds.meta,
+    }));
   }
 
   const options = getDataSourceOptions();
@@ -184,3 +213,10 @@ export const DataSourcePicker = memo(function DataSourcePicker({
     </div>
   );
 });
+
+function isDataSourceSelectable(
+  current: DataSourceInstanceSettings,
+  selectableDataSources: DataSourceInstanceSettings[]
+): boolean {
+  return selectableDataSources.some((ds) => ds.uid === current.uid || ds.name === current.name);
+}


### PR DESCRIPTION
### What this PR does

Updates DataSourcePicker so a current data source that exists globally but is excluded by the picker's filters is shown as invalid instead of appearing as a valid selected value.

### Why

When current points to a data source that does not match the picker filter, the picker should not display that data source as selectable/valid. This can otherwise hide configuration mismatches, for example when a Tempo data source is passed to a Prometheus-only picker.

### Tests

- Added regression coverage for a filtered-out current data source.
- git diff --check passed.
- yarn.cmd jest packages/grafana-runtime/src/components/DataSourcePicker.test.tsx --runInBand could not complete locally because the checkout dependencies were incomplete; yarn.cmd install --immutable stayed in the link step until the command timed out.