### PR TITLE
Dashboard E2E: Reduce timeout for scroll to fix flaky test

### DIFF
--- a/e2e-playwright/dashboard-new-layouts/dashboard-tabs-scroll.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboard-tabs-scroll.spec.ts
@@ -72,9 +72,7 @@ test.describe(
     tag: ['@dashboards'],
   },
   () => {
-    // Flaky on CI since PR #123251 introduced the test (May 22, 2026):
-    // `scrollLeftButton` intermittently stays visible after scrolling to start.
-    test.skip('shows scroll buttons and supports paged scrolling', async ({ gotoDashboardPage, selectors, page }) => {
+    test('shows scroll buttons and supports paged scrolling', async ({ gotoDashboardPage, selectors, page }) => {
       const dashboardPage = await gotoDashboardPage({});
       const { firstTab, lastTab } = await buildOverflowTabs(page, dashboardPage, selectors);
 
@@ -95,7 +93,7 @@ test.describe(
         if (await scrollLeftButton.isVisible()) {
           await scrollLeftButton.click();
         }
-        await expect(scrollLeftButton).toBeHidden();
+        await expect(scrollLeftButton).toBeHidden({ timeout: 2_000 });
       }).toPass();
 
       // At the start of the list the first tab is in view and only the right


### PR DESCRIPTION
I think the reason this was flaky is because the assertion `await expect(scrollLeftButton).toBeHidden()` inside the `.toPass()` block was using the default timeout from the playwright config, which is 10s. So sometimes there weren't enough clicks on the arrow and time to assert actual hidden until the test as a whole timed out. Changing the default timeout just makes sure the polling doesn't spend too much time asserting and that it  fails fast, then does another pass