### PR TITLE
Dashboards: Persist the state of the outline

### DIFF
--- a/e2e-playwright/dashboard-new-layouts/dashboard-outline.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboard-outline.spec.ts
@@ -35,5 +35,51 @@ test.describe(
       await dashboardPage.getByGrafanaSelector(selectors.components.PanelEditor.Outline.item('Panel #48')).click();
       await expect(page.getByText('Dashboard panel 48')).toBeInViewport();
     });
+
+    test('outline expanded state persists after closing and reopening the pane', async ({
+      gotoDashboardPage,
+      selectors,
+      page,
+    }) => {
+      const dashboardPage = await gotoDashboardPage({ uid: PAGE_UNDER_TEST });
+
+      await dashboardPage.getByGrafanaSelector(selectors.components.NavToolbar.editDashboard.editButton).click();
+      await dashboardPage.getByGrafanaSelector(selectors.pages.Dashboard.Sidebar.outlineButton).click();
+
+      const outlineTree = page.getByRole('tree');
+      const emptyIndicator = outlineTree.getByText('(empty)').first();
+
+      await expect(emptyIndicator).not.toBeVisible();
+      await dashboardPage.getByGrafanaSelector(selectors.components.PanelEditor.Outline.node('Variables')).click();
+      await expect(emptyIndicator).toBeVisible();
+      await dashboardPage.getByGrafanaSelector(selectors.pages.Dashboard.Sidebar.outlineButton).click();
+      await expect(outlineTree).not.toBeVisible();
+      await dashboardPage.getByGrafanaSelector(selectors.pages.Dashboard.Sidebar.outlineButton).click();
+      await expect(emptyIndicator).toBeVisible();
+    });
+
+    test('outline expanded state persists after discarding edit mode changes', async ({
+      gotoDashboardPage,
+      selectors,
+      page,
+    }) => {
+      const dashboardPage = await gotoDashboardPage({ uid: PAGE_UNDER_TEST });
+
+      await dashboardPage.getByGrafanaSelector(selectors.components.NavToolbar.editDashboard.editButton).click();
+      await dashboardPage.getByGrafanaSelector(selectors.pages.Dashboard.Sidebar.outlineButton).click();
+
+      const outlineTree = page.getByRole('tree');
+
+      await dashboardPage.getByGrafanaSelector(selectors.components.PanelEditor.Outline.node('Variables')).click();
+      await expect(outlineTree.getByText('(empty)').first()).toBeVisible();
+
+      await dashboardPage
+        .getByGrafanaSelector(selectors.components.NavToolbar.editDashboard.backToDashboardButton)
+        .click();
+
+      await dashboardPage.getByGrafanaSelector(selectors.components.NavToolbar.editDashboard.editButton).click();
+      await dashboardPage.getByGrafanaSelector(selectors.pages.Dashboard.Sidebar.outlineButton).click();
+      await expect(outlineTree.getByText('(empty)').first()).toBeVisible();
+    });
   }
 );

--- a/e2e-playwright/dashboard-new-layouts/dashboard-outline.spec.ts
+++ b/e2e-playwright/dashboard-new-layouts/dashboard-outline.spec.ts
@@ -73,10 +73,10 @@ test.describe(
       await dashboardPage.getByGrafanaSelector(selectors.components.PanelEditor.Outline.node('Variables')).click();
       await expect(outlineTree.getByText('(empty)').first()).toBeVisible();
 
-      await dashboardPage
-        .getByGrafanaSelector(selectors.components.NavToolbar.editDashboard.backToDashboardButton)
-        .click();
+      // Exit edit mode
+      await dashboardPage.getByGrafanaSelector(selectors.components.NavToolbar.editDashboard.editButton).click();
 
+      // Re-enter edit mode
       await dashboardPage.getByGrafanaSelector(selectors.components.NavToolbar.editDashboard.editButton).click();
       await dashboardPage.getByGrafanaSelector(selectors.pages.Dashboard.Sidebar.outlineButton).click();
       await expect(outlineTree.getByText('(empty)').first()).toBeVisible();

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPane.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPane.test.tsx
@@ -216,6 +216,24 @@ describe('DashboardEditPane', () => {
     expect(cloned.state.undoStack).toHaveLength(0);
   });
 
+  it('clone should preserve the outline collapsed state', () => {
+    const scene = buildTestScene();
+    const editPane = scene.state.editPane;
+    const outlinePane = editPane.state.outlinePane!;
+
+    outlinePane.setNodeCollapsed('some-key', false);
+    outlinePane.setNodeCollapsed('another-key', true);
+
+    const cloned = editPane.clone({});
+    const clonedOutline = cloned.state.outlinePane!;
+
+    expect(clonedOutline.isNodeCollapsed('some-key', true)).toBe(false);
+    expect(clonedOutline.isNodeCollapsed('another-key', false)).toBe(true);
+
+    clonedOutline.setNodeCollapsed('new-key', false);
+    expect(outlinePane.isNodeCollapsed('new-key', true)).toBe(false);
+  });
+
   it('keeps the variable selected when undoing and redoing variable type changes', () => {
     const variable = new TestVariable({
       name: 'service',

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPane.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPane.tsx
@@ -13,6 +13,7 @@ import { getRepeatCloneSourceKey } from '../utils/clone';
 import { DashboardInteractions } from '../utils/interactions';
 import { getDefaultVizPanel, getLayoutForObject, getDashboardSceneFor } from '../utils/utils';
 
+import { DashboardOutline } from './DashboardOutline';
 import { ElementEditPane } from './ElementEditPane';
 import {
   ConditionalRenderingChangedEvent,
@@ -32,6 +33,7 @@ export interface DashboardEditPaneState extends SceneObjectState {
 
   undoStack: DashboardEditActionEventPayload[];
   redoStack: DashboardEditActionEventPayload[];
+  outlinePane?: DashboardOutline;
   openPane?: DashboardSidebarPane;
   /** Temp hack for Link and LinkSet that are not part of the scene but need to be selected for now  */
   selectedDisconnectedObject?: SceneObject;
@@ -43,7 +45,7 @@ export interface DashboardEditPaneState extends SceneObjectState {
 }
 
 export class DashboardEditPane extends SceneObjectBase<DashboardEditPaneState> implements EditPaneSelectionActions {
-  public constructor() {
+  public constructor(state?: Partial<DashboardEditPaneState>) {
     super({
       selectionContext: {
         enabled: false,
@@ -54,6 +56,7 @@ export class DashboardEditPane extends SceneObjectBase<DashboardEditPaneState> i
       isNewElement: false,
       undoStack: [],
       redoStack: [],
+      outlinePane: state?.outlinePane ?? new DashboardOutline({}),
     });
 
     this.addActivationHandler(this.onActivate.bind(this));

--- a/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardEditPaneRenderer.tsx
@@ -34,7 +34,7 @@ export interface Props {
  * Making the EditPane rendering completely standalone (not using editPane.Component) in order to pass custom react props
  */
 export function DashboardEditPaneRenderer({ editPane, dashboard }: Props) {
-  const { openPane, selectionContext } = useSceneObjectState(editPane, {
+  const { openPane, selectionContext, outlinePane } = useSceneObjectState(editPane, {
     shouldActivateOrKeepAlive: true,
   });
   const { isEditing, meta, uid } = dashboard.useState();
@@ -133,7 +133,7 @@ export function DashboardEditPaneRenderer({ editPane, dashboard }: Props) {
             icon="list-ui-alt"
             onClick={() => {
               DashboardInteractions.dashboardOutlineClicked();
-              editPane.openPane(new DashboardOutline({}));
+              editPane.openPane(outlinePane!);
             }}
             title={t('dashboard.sidebar.outline.title', 'Outline')}
             tooltip={t('dashboard.sidebar.outline.tooltip', 'Content outline')}

--- a/public/app/features/dashboard-scene/edit-pane/DashboardOutline.test.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardOutline.test.tsx
@@ -100,6 +100,97 @@ describe('DashboardOutline', () => {
     jest.clearAllMocks();
   });
 
+  describe('collapsed state persistence', () => {
+    it('should retain expanded/collapsed state when the pane is closed and reopened', async () => {
+      const user = userEvent.setup();
+      const scene = buildTestScene();
+      const editPane = scene.state.editPane;
+      const outlinePane = editPane.state.outlinePane!;
+
+      scene.onEnterEditMode();
+      editPane.enableSelection();
+      editPane.openPane(outlinePane);
+
+      const { unmount } = render(
+        <ElementSelectionContext.Provider value={editPane.state.selectionContext}>
+          <WrapSidebar>
+            <outlinePane.Component model={outlinePane} />
+          </WrapSidebar>
+        </ElementSelectionContext.Provider>
+      );
+
+      await user.click(screen.getByTestId(selectors.components.PanelEditor.Outline.node('Row level 1')));
+      expect(screen.getByTestId(selectors.components.PanelEditor.Outline.item('Row level 2'))).toBeInTheDocument();
+
+      unmount();
+
+      render(
+        <ElementSelectionContext.Provider value={editPane.state.selectionContext}>
+          <WrapSidebar>
+            <outlinePane.Component model={outlinePane} />
+          </WrapSidebar>
+        </ElementSelectionContext.Provider>
+      );
+
+      expect(screen.getByTestId(selectors.components.PanelEditor.Outline.item('Row level 2'))).toBeInTheDocument();
+    });
+
+    it('should share collapsed state across clones', () => {
+      const outline = new DashboardOutline();
+
+      outline.setNodeCollapsed('node-1', false);
+      outline.setNodeCollapsed('node-2', true);
+
+      const cloned = outline.clone();
+
+      expect(cloned.isNodeCollapsed('node-1', true)).toBe(false);
+      expect(cloned.isNodeCollapsed('node-2', false)).toBe(true);
+
+      cloned.setNodeCollapsed('node-3', false);
+      expect(outline.isNodeCollapsed('node-3', true)).toBe(false);
+    });
+
+    it('should preserve collapsed state after entering and exiting edit mode', async () => {
+      const user = userEvent.setup();
+      const scene = buildTestScene();
+      const editPane = scene.state.editPane;
+      const outlinePane = editPane.state.outlinePane!;
+
+      editPane.enableSelection();
+      editPane.openPane(outlinePane);
+
+      const { unmount } = render(
+        <ElementSelectionContext.Provider value={editPane.state.selectionContext}>
+          <WrapSidebar>
+            <outlinePane.Component model={outlinePane} />
+          </WrapSidebar>
+        </ElementSelectionContext.Provider>
+      );
+
+      await user.click(screen.getByTestId(selectors.components.PanelEditor.Outline.node('Row level 1')));
+      expect(screen.getByTestId(selectors.components.PanelEditor.Outline.item('Row level 2'))).toBeInTheDocument();
+
+      unmount();
+
+      scene.onEnterEditMode();
+      scene.exitEditMode({ skipConfirm: true });
+
+      const newOutlinePane = scene.state.editPane.state.outlinePane!;
+      scene.state.editPane.enableSelection();
+      scene.state.editPane.openPane(newOutlinePane);
+
+      render(
+        <ElementSelectionContext.Provider value={scene.state.editPane.state.selectionContext}>
+          <WrapSidebar>
+            <newOutlinePane.Component model={newOutlinePane} />
+          </WrapSidebar>
+        </ElementSelectionContext.Provider>
+      );
+
+      expect(screen.getByTestId(selectors.components.PanelEditor.Outline.item('Row level 2'))).toBeInTheDocument();
+    });
+  });
+
   describe('outline item interactions tracking', () => {
     it('should call DashboardInteractions.outlineItemClicked with correct parameters when clicking on items', async () => {
       const user = userEvent.setup();

--- a/public/app/features/dashboard-scene/edit-pane/DashboardOutline.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardOutline.tsx
@@ -50,7 +50,7 @@ export class DashboardOutline extends SceneObjectBase<DashboardOutlineState> {
     }
   }
 
-  public clone(withState?: Partial<SceneObjectState>): this {
+  public clone(withState?: Partial<DashboardOutlineState>): this {
     const cloned = super.clone({ ...withState, collapsedState: this.state.collapsedState });
     return cloned;
   }

--- a/public/app/features/dashboard-scene/edit-pane/DashboardOutline.tsx
+++ b/public/app/features/dashboard-scene/edit-pane/DashboardOutline.tsx
@@ -4,7 +4,7 @@ import React, { useMemo, useState } from 'react';
 import { type GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
 import { Trans, t } from '@grafana/i18n';
-import { type SceneComponentProps, SceneObjectBase, type SceneObject } from '@grafana/scenes';
+import { type SceneComponentProps, SceneObjectBase, type SceneObject, type SceneObjectState } from '@grafana/scenes';
 import { Box, Icon, ScrollContainer, Sidebar, Text, Tooltip, useElementSelection, useStyles2 } from '@grafana/ui';
 
 import { DashboardLinksSet } from '../settings/links/DashboardLinksSet';
@@ -19,10 +19,40 @@ import { type DashboardEditPane } from './DashboardEditPane';
 import { getEditableElementFor } from './shared';
 import { useOutlineRename } from './useOutlineRename';
 
-export class DashboardOutline extends SceneObjectBase {
+interface DashboardOutlineState extends SceneObjectState {
+  collapsedState: Map<string, boolean>;
+}
+
+export class DashboardOutline extends SceneObjectBase<DashboardOutlineState> {
   public static Component = DashboardOutlineRenderer;
+
+  constructor(state?: Partial<DashboardOutlineState>) {
+    super({
+      ...state,
+      collapsedState: state?.collapsedState ?? new Map<string, boolean>(),
+    });
+  }
+
   public getId() {
     return 'outline' as const;
+  }
+
+  public isNodeCollapsed(key: string | undefined, defaultCollapsed: boolean): boolean {
+    if (key === undefined) {
+      return defaultCollapsed;
+    }
+    return this.state.collapsedState.get(key) ?? defaultCollapsed;
+  }
+
+  public setNodeCollapsed(key: string | undefined, collapsed: boolean): void {
+    if (key !== undefined) {
+      this.state.collapsedState.set(key, collapsed);
+    }
+  }
+
+  public clone(withState?: Partial<SceneObjectState>): this {
+    const cloned = super.clone({ ...withState, collapsedState: this.state.collapsedState });
+    return cloned;
   }
 }
 
@@ -39,6 +69,7 @@ export function DashboardOutlineRenderer({ model }: SceneComponentProps<Dashboar
             sceneObject={dashboard}
             isEditing={isEditing}
             editPane={dashboard.state.editPane}
+            outline={model}
             depth={0}
             index={0}
           />
@@ -51,15 +82,16 @@ export function DashboardOutlineRenderer({ model }: SceneComponentProps<Dashboar
 interface DashboardOutlineNodeProps {
   sceneObject: SceneObject;
   editPane: DashboardEditPane;
+  outline: DashboardOutline;
   isEditing: boolean | undefined;
   depth: number;
   index: number;
 }
 
-function DashboardOutlineNode({ sceneObject, editPane, isEditing, depth, index }: DashboardOutlineNodeProps) {
+function DashboardOutlineNode({ sceneObject, editPane, outline, isEditing, depth, index }: DashboardOutlineNodeProps) {
   const styles = useStyles2(getStyles);
   const key = sceneObject.state.key;
-  const [isCollapsed, setIsCollapsed] = useState(depth > 0);
+  const [isCollapsed, setIsCollapsed] = useState(() => outline.isNodeCollapsed(key, depth > 0));
   const { isSelected, onSelect } = useElementSelection(key);
   const isCloned = useMemo(() => isRepeatCloneOrChildOf(sceneObject), [sceneObject]);
   const editableElement = useMemo(() => getEditableElementFor(sceneObject)!, [sceneObject]);
@@ -99,7 +131,9 @@ function DashboardOutlineNode({ sceneObject, editPane, isEditing, depth, index }
 
   const onToggleCollapse = (evt: React.MouseEvent) => {
     evt.stopPropagation();
-    setIsCollapsed(!isCollapsed);
+    const newCollapsed = !isCollapsed;
+    setIsCollapsed(newCollapsed);
+    outline.setNodeCollapsed(key, newCollapsed);
   };
 
   if (elementInfo.isHidden && !isEditing) {
@@ -180,6 +214,7 @@ function DashboardOutlineNode({ sceneObject, editPane, isEditing, depth, index }
                 key={child.state.key}
                 sceneObject={child}
                 editPane={editPane}
+                outline={outline}
                 depth={depth + 1}
                 isEditing={isEditing}
                 index={i}


### PR DESCRIPTION
**What is this feature?**

Persist the state of dashboard outline between closing/opening the side pane as well as going from view to edit modes or vice versa.

**Why do we need this feature?**

QoL improvement.

**Who is this feature for?**

-

**Which issue(s) does this PR fix?**:

Fixes #125074

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
