### PR TITLE
unified-storage: remove references to 'go.uber.org/atomic'

### DIFF
--- a/pkg/services/sqlstore/migrator/migrator.go
+++ b/pkg/services/sqlstore/migrator/migrator.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/grafana/dskit/backoff"
@@ -16,7 +17,6 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/trace"
-	"go.uber.org/atomic"
 
 	"github.com/grafana/grafana/pkg/util/sqlite"
 

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/Masterminds/semver"
@@ -27,7 +28,6 @@ import (
 	bolterrors "go.etcd.io/bbolt/errors"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
-	"go.uber.org/atomic"
 	"k8s.io/apimachinery/pkg/selection"
 
 	"github.com/grafana/grafana/pkg/services/dashboards/dashboardaccess"

--- a/pkg/storage/unified/search/bleve_test.go
+++ b/pkg/storage/unified/search/bleve_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -19,7 +20,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	bolterrors "go.etcd.io/bbolt/errors"
-	"go.uber.org/atomic"
 	"go.uber.org/goleak"
 	"k8s.io/apimachinery/pkg/selection"
 
@@ -1435,11 +1435,11 @@ func updateTestDocs(ns resource.NamespacedResource, docs int) resource.UpdateFn 
 
 func updateTestDocsReturningMillisTimestamp(ns resource.NamespacedResource, docs int) (resource.UpdateFn, *atomic.Int64) {
 	cnt := 0
-	updateCalls := atomic.NewInt64(0)
+	var updateCalls atomic.Int64
 
 	return func(context context.Context, index resource.ResourceIndex, sinceRV int64) (newRV int64, updatedDocs int, _ error) {
 		now := time.Now()
-		updateCalls.Inc()
+		updateCalls.Add(1)
 
 		cnt++
 
@@ -1461,7 +1461,7 @@ func updateTestDocsReturningMillisTimestamp(ns resource.NamespacedResource, docs
 
 		err := index.BulkIndex(&resource.BulkIndexRequest{Items: items})
 		return now.UnixMilli(), docs, err
-	}, updateCalls
+	}, &updateCalls
 }
 
 func TestCleanOldIndexes(t *testing.T) {
@@ -1783,9 +1783,7 @@ func TestConcurrentIndexUpdateSearchAndRebuild(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	rebuilds := atomic.NewInt64(0)
-	updates := atomic.NewInt64(0)
-	searches := atomic.NewInt64(0)
+	var rebuilds, updates, searches atomic.Int64
 	const searchConcurrency = 25
 	for i := range searchConcurrency {
 		wg.Add(1)
@@ -1807,7 +1805,7 @@ func TestConcurrentIndexUpdateSearchAndRebuild(t *testing.T) {
 					}
 					require.NoError(t, err)
 				}
-				updates.Inc()
+				updates.Add(1)
 
 				resp, err := idx.Search(ctx, nil, &resourcepb.ResourceSearchRequest{
 					Options: &resourcepb.ListOptions{
@@ -1828,7 +1826,7 @@ func TestConcurrentIndexUpdateSearchAndRebuild(t *testing.T) {
 					require.NoError(t, err)
 				}
 				require.Equal(t, int64(10), resp.TotalHits)
-				searches.Inc()
+				searches.Add(1)
 			}
 		}()
 	}
@@ -1839,7 +1837,7 @@ func TestConcurrentIndexUpdateSearchAndRebuild(t *testing.T) {
 		for ctx.Err() == nil {
 			_, err := be.BuildIndex(t.Context(), ns, 10, nil, "test", indexTestDocs(ns, 10, 100), updateTestDocs(ns, 5), false, time.Time{}, 0)
 			require.NoError(t, err)
-			rebuilds.Inc()
+			rebuilds.Add(1)
 		}
 	}()
 
@@ -1927,7 +1925,7 @@ func TestConcurrentIndexUpdateAndSearchWithIndexMinUpdateInterval(t *testing.T) 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	attemptedUpdates := atomic.NewInt64(0)
+	var attemptedUpdates atomic.Int64
 
 	// Verify that each returned RV (unix timestamp in millis) is either the same as before, or at least minInterval later.
 	const searchConcurrency = 10
@@ -1938,7 +1936,7 @@ func TestConcurrentIndexUpdateAndSearchWithIndexMinUpdateInterval(t *testing.T) 
 
 			var collectedRVs []int64
 			for ctx.Err() == nil {
-				attemptedUpdates.Inc()
+				attemptedUpdates.Add(1)
 
 				// We use t.Context() here to avoid getting errors from context cancellation.
 				rv, err := idx.UpdateIndex(t.Context())

--- a/pkg/storage/unified/sql/backend.go
+++ b/pkg/storage/unified/sql/backend.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/fullstorydev/grpchan/inprocgrpc"
@@ -25,7 +26,6 @@ import (
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
-	"go.uber.org/atomic"
 	"google.golang.org/protobuf/proto"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 
@@ -372,7 +372,7 @@ type backend struct {
 
 	// Fields to control the cleanup of "lastImportTime" rows (used to find indexes to rebuild)
 	lastImportTimeMaxAge       time.Duration
-	lastImportTimeDeletionTime atomic.Time
+	lastImportTimeDeletionTime atomic.Pointer[time.Time]
 }
 
 func (b *backend) Init(ctx context.Context) error {
@@ -1430,7 +1430,8 @@ func (b *backend) GetResourceLastImportTimes(ctx context.Context) iter.Seq2[reso
 	queryDB := b.lastImportTimeDB(ctx)
 
 	// Delete old entries, if configured, and if enough time has passed since last deletion.
-	if b.lastImportTimeMaxAge > 0 && time.Since(b.lastImportTimeDeletionTime.Load()) > limitLastImportTimesDeletion {
+	last := b.lastImportTimeDeletionTime.Load()
+	if b.lastImportTimeMaxAge > 0 && (last == nil || time.Since(*last) > limitLastImportTimesDeletion) {
 		now := time.Now()
 
 		res, err := dbutil.Exec(ctx, queryDB, sqlResourceLastImportTimeDelete, &sqlResourceLastImportTimeDeleteRequest{
@@ -1449,7 +1450,7 @@ func (b *backend) GetResourceLastImportTimes(ctx context.Context) iter.Seq2[reso
 			b.log.Info("Deleted old last import times", "rows", aff)
 		}
 
-		b.lastImportTimeDeletionTime.Store(now)
+		b.lastImportTimeDeletionTime.Store(&now)
 	}
 
 	rows, err := dbutil.QueryRows(ctx, queryDB, sqlResourceLastImportTimeQuery, &sqlResourceLastImportTimeQueryRequest{


### PR DESCRIPTION
The few use-cases we had can now use the standard library implementation.