### PR TITLE
chore(deps): remove protobufjs resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -469,7 +469,6 @@
     "js-yaml@npm:=4.1.0": "^4.1.0",
     "nodemailer": "8.0.7",
     "storybook@npm:10.3.6": "patch:storybook@npm%3A10.3.6#~/.yarn/patches/storybook-npm-10.3.6-8a0644ac0b.patch",
-    "protobufjs@npm:8.0.0": "8.0.1",
     "@types/slate/immutable": "^4.0.0",
     "@types/slate-react/immutable": "^4.0.0"
   },


### PR DESCRIPTION
**What is this feature?**

Removes the `protobufjs@npm:8.0.0` → `8.0.1` resolution from `package.json`.

**Why do we need this feature?**

The pinned resolution is no longer needed and was left behind after the underlying issue was resolved.

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
