### PR TITLE
Provisioning: Independent fixes for import flow foundations

### DIFF
--- a/public/app/features/dashboard/api/DashboardAPIVersionResolver.ts
+++ b/public/app/features/dashboard/api/DashboardAPIVersionResolver.ts
@@ -12,7 +12,7 @@ export interface ResolvedDashboardVersions {
   v2: DashboardV2Version;
 }
 
-const DASHBOARD_API_GROUP = 'dashboard.grafana.app';
+export const DASHBOARD_API_GROUP = 'dashboard.grafana.app';
 const BETA_V1: DashboardV1Version = 'v1beta1';
 const BETA_V2: DashboardV2Version = 'v2beta1';
 

--- a/public/app/features/provisioning/hooks/PushSuccessMessage.test.tsx
+++ b/public/app/features/provisioning/hooks/PushSuccessMessage.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+
+import { PushSuccessMessage } from './PushSuccessMessage';
+
+describe('PushSuccessMessage', () => {
+  it('should render branch as a link when url is provided', () => {
+    render(<PushSuccessMessage branch="main" url="https://github.com/org/repo/tree/main/dashboards" />);
+
+    const link = screen.getByRole('link', { name: 'main' });
+    expect(link).toHaveAttribute('href', 'https://github.com/org/repo/tree/main/dashboards');
+  });
+
+  it('should render branch as plain text when url is not provided', () => {
+    render(<PushSuccessMessage branch="main" />);
+
+    expect(screen.queryByRole('link')).not.toBeInTheDocument();
+    // Branch text is rendered inline next to the Trans text, so match within the container
+    expect(screen.getByText(/main/)).toBeInTheDocument();
+  });
+});

--- a/public/app/features/provisioning/hooks/PushSuccessMessage.tsx
+++ b/public/app/features/provisioning/hooks/PushSuccessMessage.tsx
@@ -3,15 +3,15 @@ import { TextLink } from '@grafana/ui';
 
 export interface PushSuccessMessageProps {
   branch: string;
-  repositoryURL?: string;
+  url?: string;
 }
 
-export function PushSuccessMessage({ branch, repositoryURL }: PushSuccessMessageProps) {
+export function PushSuccessMessage({ branch, url }: PushSuccessMessageProps) {
   return (
     <span>
       <Trans i18nKey="provisioned-request.push-success.prefix">Changes successfully pushed to</Trans>{' '}
-      {repositoryURL ? (
-        <TextLink href={repositoryURL} external>
+      {url ? (
+        <TextLink href={url} external>
           {branch}
         </TextLink>
       ) : (

--- a/public/app/features/provisioning/hooks/useGetResourceRepositoryView.test.ts
+++ b/public/app/features/provisioning/hooks/useGetResourceRepositoryView.test.ts
@@ -1,3 +1,4 @@
+import { skipToken } from '@reduxjs/toolkit/query/react';
 import { renderHook } from '@testing-library/react';
 
 import { config } from '@grafana/runtime';
@@ -293,11 +294,19 @@ describe('useGetResourceRepositoryView', () => {
       const instanceRepo = repoView({ name: 'instance-repo', target: 'instance' });
       setupMocks({ settingsItems: [instanceRepo] });
 
-      const { result } = renderHook(() => useGetResourceRepositoryView({ folderName: '' }));
+      const { result } = renderHook(() => useGetResourceRepositoryView({ folderName: '', includeInstance: true }));
 
       expect(result.current.status).toBe(RepoViewStatus.Ready);
       expect(result.current.repository).toBe(instanceRepo);
       expect(result.current.isInstanceManaged).toBe(true);
+    });
+
+    it('skips settings query when no name, folderName, or includeInstance is provided', () => {
+      setupMocks();
+
+      renderHook(() => useGetResourceRepositoryView({ folderName: '' }));
+
+      expect(mockUseGetFrontendSettingsQuery).toHaveBeenCalledWith(skipToken);
     });
   });
 });

--- a/public/app/features/provisioning/hooks/useGetResourceRepositoryView.test.ts
+++ b/public/app/features/provisioning/hooks/useGetResourceRepositoryView.test.ts
@@ -288,5 +288,16 @@ describe('useGetResourceRepositoryView', () => {
       expect(result.current.repository).toBeUndefined();
       expect(result.current.isInstanceManaged).toBe(false);
     });
+
+    it('returns instance repo when both name and folderName are empty (root import)', () => {
+      const instanceRepo = repoView({ name: 'instance-repo', target: 'instance' });
+      setupMocks({ settingsItems: [instanceRepo] });
+
+      const { result } = renderHook(() => useGetResourceRepositoryView({ folderName: '' }));
+
+      expect(result.current.status).toBe(RepoViewStatus.Ready);
+      expect(result.current.repository).toBe(instanceRepo);
+      expect(result.current.isInstanceManaged).toBe(true);
+    });
   });
 });

--- a/public/app/features/provisioning/hooks/useGetResourceRepositoryView.ts
+++ b/public/app/features/provisioning/hooks/useGetResourceRepositoryView.ts
@@ -41,7 +41,7 @@ export const useGetResourceRepositoryView = ({
   skipQuery,
 }: GetResourceRepositoryArgs): RepositoryViewData => {
   const provisioningEnabled = config.featureToggles.provisioning;
-  const shouldSkipSettings = !provisioningEnabled || skipQuery || (!name && !folderName);
+  const shouldSkipSettings = !provisioningEnabled || skipQuery;
   const settingsQueryArg = shouldSkipSettings ? skipToken : undefined;
 
   const {

--- a/public/app/features/provisioning/hooks/useGetResourceRepositoryView.ts
+++ b/public/app/features/provisioning/hooks/useGetResourceRepositoryView.ts
@@ -12,6 +12,7 @@ interface GetResourceRepositoryArgs {
   name?: string; // the repository name
   folderName?: string; // folder we are targeting
   skipQuery?: boolean;
+  includeInstance?: boolean;
 }
 
 export enum RepoViewStatus {
@@ -39,9 +40,13 @@ export const useGetResourceRepositoryView = ({
   name,
   folderName,
   skipQuery,
+  includeInstance,
 }: GetResourceRepositoryArgs): RepositoryViewData => {
   const provisioningEnabled = config.featureToggles.provisioning;
-  const shouldSkipSettings = !provisioningEnabled || skipQuery;
+  // Skip when caller has no target. This query is shared across many
+  // components, so a failing fetch would cycle all of them through retries.
+  // `includeInstance` overrides the skip for root-level instance lookups.
+  const shouldSkipSettings = !provisioningEnabled || skipQuery || (!name && !folderName && !includeInstance);
   const settingsQueryArg = shouldSkipSettings ? skipToken : undefined;
 
   const {

--- a/public/app/features/provisioning/hooks/useProvisionedRequestHandler.test.ts
+++ b/public/app/features/provisioning/hooks/useProvisionedRequestHandler.test.ts
@@ -129,7 +129,46 @@ describe('useProvisionedRequestHandler', () => {
       expect(mockPublish).not.toHaveBeenCalledWith(expect.objectContaining({ type: AppEvents.alertSuccess.name }));
     });
 
-    it('should show push success with branch link when repository info is available', () => {
+    it('should show push success with branch link pointing to configured path', () => {
+      const { request, handlers } = setup({
+        requestOverrides: {
+          isError: false,
+          isSuccess: true,
+          data: createMockResourceWrapper({
+            urls: { repositoryURL: 'https://github.com/org/repo' },
+          }),
+        },
+      });
+
+      renderHook(() =>
+        useProvisionedRequestHandler({
+          request,
+          workflow: 'write',
+          resourceType: 'dashboard',
+          repository: {
+            type: 'github',
+            name: 'test-repo',
+            target: 'folder',
+            title: 'Test Repository',
+            workflows: [],
+            branch: 'main',
+            url: 'https://github.com/org/repo',
+            path: 'dashboards',
+          },
+          handlers,
+        })
+      );
+
+      const component = mockDispatch.mock.calls[0][0].payload.component;
+      expect(component.props).toEqual(
+        expect.objectContaining({
+          branch: 'main',
+          url: 'https://github.com/org/repo/tree/main/dashboards',
+        })
+      );
+    });
+
+    it('should fall back to repositoryURL when no path is configured', () => {
       const { request, handlers } = setup({
         requestOverrides: {
           isError: false,
@@ -158,11 +197,11 @@ describe('useProvisionedRequestHandler', () => {
         })
       );
 
-      expect(mockDispatch).toHaveBeenCalledWith(
+      const component = mockDispatch.mock.calls[0][0].payload.component;
+      expect(component.props).toEqual(
         expect.objectContaining({
-          payload: expect.objectContaining({
-            component: expect.anything(),
-          }),
+          branch: 'main',
+          url: 'https://github.com/org/repo',
         })
       );
     });

--- a/public/app/features/provisioning/hooks/useProvisionedRequestHandler.ts
+++ b/public/app/features/provisioning/hooks/useProvisionedRequestHandler.ts
@@ -16,6 +16,8 @@ import { refetchChildren } from 'app/features/browse-dashboards/state/actions';
 import { type RepoType } from 'app/features/provisioning/Wizard/types';
 import { useDispatch } from 'app/types/store';
 
+import { getRepoFileUrl } from '../utils/git';
+
 import { PushSuccessMessage } from './PushSuccessMessage';
 import { useLastBranch } from './useLastBranch';
 
@@ -123,12 +125,24 @@ export function useProvisionedRequestHandler<T>({
       // which navigates to a preview page with its own PR banner)
       if (workflow !== 'branch') {
         const branch = ref || selectedBranch || repository?.branch;
-        const repoURL = urls?.repositoryURL || repository?.url;
+        // Link to the configured path (e.g. /tree/main/dashboards) so users
+        // land where their resources live, not the repo root.
+        const linkUrl =
+          (repository?.path
+            ? getRepoFileUrl({
+                repoType: repository.type,
+                url: repository.url,
+                branch,
+                filePath: repository.path.endsWith('/') ? repository.path : `${repository.path}/`,
+              })
+            : undefined) ||
+          urls?.repositoryURL ||
+          repository?.url;
 
         if (branch) {
           // Uses dispatch(notifyApp(...)) instead of getAppEvents().publish() because AlertPayload only accepts strings
           // and notifyApp supports a React component for rendering the branch name as a clickable link.
-          const component = createElement(PushSuccessMessage, { branch, repositoryURL: repoURL });
+          const component = createElement(PushSuccessMessage, { branch, url: linkUrl });
           dispatch(notifyApp(createSuccessNotification('', '', undefined, component)));
         } else {
           const message = successMessage || t('provisioned-request.saved-success', 'Changes saved successfully');

--- a/public/app/features/provisioning/hooks/useProvisionedRequestHandler.ts
+++ b/public/app/features/provisioning/hooks/useProvisionedRequestHandler.ts
@@ -16,6 +16,7 @@ import { refetchChildren } from 'app/features/browse-dashboards/state/actions';
 import { type RepoType } from 'app/features/provisioning/Wizard/types';
 import { useDispatch } from 'app/types/store';
 
+import { ensureFolderPathTrailingSlash } from '../components/utils/path';
 import { getRepoFileUrl } from '../utils/git';
 
 import { PushSuccessMessage } from './PushSuccessMessage';
@@ -127,17 +128,15 @@ export function useProvisionedRequestHandler<T>({
         const branch = ref || selectedBranch || repository?.branch;
         // Link to the configured path (e.g. /tree/main/dashboards) so users
         // land where their resources live, not the repo root.
-        const linkUrl =
-          (repository?.path
-            ? getRepoFileUrl({
-                repoType: repository.type,
-                url: repository.url,
-                branch,
-                filePath: repository.path.endsWith('/') ? repository.path : `${repository.path}/`,
-              })
-            : undefined) ||
-          urls?.repositoryURL ||
-          repository?.url;
+        const repoFileUrl = repository?.path
+          ? getRepoFileUrl({
+              repoType: repository.type,
+              url: repository.url,
+              branch,
+              filePath: ensureFolderPathTrailingSlash(repository.path),
+            })
+          : undefined;
+        const linkUrl = repoFileUrl || urls?.repositoryURL || repository?.url;
 
         if (branch) {
           // Uses dispatch(notifyApp(...)) instead of getAppEvents().publish() because AlertPayload only accepts strings

--- a/public/app/features/provisioning/utils/git.test.ts
+++ b/public/app/features/provisioning/utils/git.test.ts
@@ -248,6 +248,17 @@ describe('getRepoFileUrl', () => {
       })
     ).toBe('https://bitbucket.org/workspace/repo/src/main/docs');
   });
+
+  it('treats githubEnterprise the same as github', () => {
+    expect(
+      getRepoFileUrl({
+        repoType: 'githubEnterprise',
+        url: 'https://ghe.example.com/owner/repo',
+        branch: 'main',
+        filePath: 'dashboards/team-a/',
+      })
+    ).toBe('https://ghe.example.com/owner/repo/tree/main/dashboards/team-a');
+  });
 });
 
 describe('getRepoEditFileUrl', () => {

--- a/public/app/features/provisioning/utils/git.ts
+++ b/public/app/features/provisioning/utils/git.ts
@@ -145,6 +145,7 @@ export function getRepoFileUrl({
   const isDir = fullPath.endsWith('/');
 
   switch (repoType) {
+    case 'githubEnterprise':
     case 'github':
       return buildRepoUrl({
         baseUrl: url,


### PR DESCRIPTION
**What is this feature?**

Independent fixes in the provisioning surface that enable the upcoming provisioned dashboard import flow:

1. Export `DASHBOARD_API_GROUP` from `DashboardAPIVersionResolver` for downstream hooks
2. Fix `useGetResourceRepositoryView` skip condition so provisioning view loads for root-level imports
3. Rename `repositoryURL → url` in `PushSuccessMessage` for consistency + add unit tests
4. Link push-success message to the configured tree path via `getRepoFileUrl()` instead of the repo root
5. Handle `githubEnterprise` in `getRepoFileUrl` (same URL shape as `github`) so the tree-path link works for GHE customers

**Special notes for your reviewer:**

PR 1/4 in a stacked PR series: `main ← #125414 ← #125415 ← #125416 ← #125417`.

Part of https://github.com/grafana/git-ui-sync-project/issues/1070