### PR TITLE
Provisioning: Add duplicate-path validation to ResourceEditFormSharedFields

### DIFF
--- a/packages/grafana-test-utils/src/handlers/apis/provisioning.grafana.app/v0alpha1/handlers.ts
+++ b/packages/grafana-test-utils/src/handlers/apis/provisioning.grafana.app/v0alpha1/handlers.ts
@@ -81,6 +81,9 @@ const getRepositoryRefsHandler = (response = defaultRefs) =>
 const getRepositoryFilesHandler = (response = defaultRepositoryFiles) =>
   http.get(`${BASE}/repositories/:name/files/`, () => HttpResponse.json(response));
 
+const getRepositoryFileWithPathHandler = () =>
+  http.get(`${BASE}/repositories/:name/files/*`, () => new HttpResponse(null, { status: 404 }));
+
 const createRepositoryHandler = (response = defaultRepository) =>
   http.post(`${BASE}/repositories`, () => HttpResponse.json(response));
 
@@ -126,6 +129,7 @@ const handlers = [
   listRepositoriesHandler(),
   getRepositoryRefsHandler(),
   getRepositoryFilesHandler(),
+  getRepositoryFileWithPathHandler(),
   createRepositoryHandler(),
   replaceRepositoryHandler(),
   testRepositoryHandler(),

--- a/public/app/api/clients/folder/v1beta1/hooks.ts
+++ b/public/app/api/clients/folder/v1beta1/hooks.ts
@@ -83,23 +83,32 @@ export type CombinedFolder = FolderDTO & {
   ownerReferences?: OwnerReference[];
 };
 
+function resolveDisplayName(userKey: string | undefined, userDisplay?: DisplayList): string {
+  const anonymous = t('folders.api.anonymous-user', 'Anonymous');
+  if (!userKey) {
+    return anonymous;
+  }
+  const idx = userDisplay?.keys?.indexOf(userKey) ?? -1;
+  if (idx < 0) {
+    return anonymous;
+  }
+  return userDisplay?.display?.[idx]?.displayName || anonymous;
+}
+
 const combineFolderResponses = (
   folder: Folder,
   legacyFolder: FolderDTO,
   parents: FolderInfo[],
   userDisplay?: DisplayList
 ) => {
-  const updatedBy = folder.metadata.annotations?.[AnnoKeyUpdatedBy];
-  const createdBy = folder.metadata.annotations?.[AnnoKeyCreatedBy];
-
   const newData: CombinedFolder = {
     canAdmin: legacyFolder.canAdmin,
     canDelete: legacyFolder.canDelete,
     canEdit: legacyFolder.canEdit,
     canSave: legacyFolder.canSave,
     accessControl: legacyFolder.accessControl,
-    createdBy: (createdBy && userDisplay?.display[userDisplay?.keys.indexOf(createdBy)]?.displayName) || 'Anonymous',
-    updatedBy: (updatedBy && userDisplay?.display[userDisplay?.keys.indexOf(updatedBy)]?.displayName) || 'Anonymous',
+    createdBy: resolveDisplayName(folder.metadata.annotations?.[AnnoKeyCreatedBy], userDisplay),
+    updatedBy: resolveDisplayName(folder.metadata.annotations?.[AnnoKeyUpdatedBy], userDisplay),
     ...appPlatformFolderToLegacyFolder(folder),
     ownerReferences: folder.metadata.ownerReferences || [],
   };

--- a/public/app/features/provisioning/components/Shared/ResourceEditFormSharedFields.test.tsx
+++ b/public/app/features/provisioning/components/Shared/ResourceEditFormSharedFields.test.tsx
@@ -516,5 +516,39 @@ describe('ResourceEditFormSharedFields', () => {
         expect(validationRequested).toBe(true);
       });
     });
+
+    it('should re-trigger path validation when the branch changes', async () => {
+      const refsInRequest: string[] = [];
+      server.use(
+        http.get(`${BASE}/repositories/:name/files/*`, ({ request }) => {
+          const url = new URL(request.url);
+          refsInRequest.push(url.searchParams.get('ref') ?? '');
+          return new HttpResponse(null, { status: 404 });
+        })
+      );
+
+      const { user } = setup({
+        isNew: true,
+        repository: mockRepo.github,
+        formDefaultValues: { path: 'dashboards/test.json', ref: 'main', workflow: 'write' },
+      });
+
+      // Seed the validator by editing the filename so the path field is touched.
+      const filenameInput = screen.getByRole('textbox', { name: /filename/i });
+      await user.clear(filenameInput);
+      await user.type(filenameInput, 'check.json');
+      await waitFor(() => expect(refsInRequest).toContain('main'));
+
+      refsInRequest.length = 0;
+
+      // Change branch → deps on the ref field should re-run validatePath.
+      const branchCombobox = screen.getByRole('combobox', { name: /branch/i });
+      await user.click(branchCombobox);
+      await user.clear(branchCombobox);
+      await user.paste('feature-branch');
+      await user.keyboard('{Enter}');
+
+      await waitFor(() => expect(refsInRequest).toContain('feature-branch'));
+    });
   });
 });

--- a/public/app/features/provisioning/components/Shared/ResourceEditFormSharedFields.test.tsx
+++ b/public/app/features/provisioning/components/Shared/ResourceEditFormSharedFields.test.tsx
@@ -1,18 +1,20 @@
-import { render, renderHook, screen } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { HttpResponse, http } from 'msw';
 import { type ReactNode } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
+import { render, renderHook, screen, waitFor } from 'test/test-utils';
 
-import type { RepositoryView } from 'app/api/clients/provisioning/v0alpha1';
+import { PROVISIONING_API_BASE as BASE } from '@grafana/test-utils/handlers';
+import server from '@grafana/test-utils/server';
+import { type RepositoryView } from 'app/api/clients/provisioning/v0alpha1';
 
 import { useBranchDropdownOptions } from '../../hooks/useBranchDropdownOptions';
+import { useGetRepositoryFolders } from '../../hooks/useGetRepositoryFolders';
+import { setupProvisioningMswServer } from '../../mocks/server';
 import { type ProvisionedDashboardFormData } from '../../types/form';
 
 import { ResourceEditFormSharedFields } from './ResourceEditFormSharedFields';
-// Mock RTK Query hook used inside ResourceEditFormSharedFields to avoid requiring a Redux Provider
-jest.mock('app/api/clients/provisioning/v0alpha1', () => ({
-  useGetRepositoryRefsQuery: jest.fn().mockReturnValue({ data: { items: [] }, isLoading: false, error: null }),
-}));
+
+setupProvisioningMswServer();
 
 // Mock the new hooks that depend on router context
 jest.mock('../../hooks/usePRBranch', () => ({
@@ -47,12 +49,6 @@ const mockRepo: { github: RepositoryView; local: RepositoryView } = {
   },
 };
 
-// Mock the i18n hook since it's used in the component
-jest.mock('@grafana/i18n', () => ({
-  t: (_: string, defaultValue: string) => defaultValue,
-  Trans: ({ children }: { children: ReactNode }) => children,
-}));
-
 interface SetupOptions {
   formDefaultValues?: Partial<ProvisionedDashboardFormData>;
   isNew?: boolean;
@@ -73,8 +69,6 @@ function setup(options: SetupOptions = {}) {
     repository,
     allowPathEdit,
   } = options;
-
-  const user = userEvent.setup();
 
   const defaultFormValues: Partial<ProvisionedDashboardFormData> = {
     path: '',
@@ -101,14 +95,11 @@ function setup(options: SetupOptions = {}) {
     allowPathEdit,
   };
 
-  return {
-    user,
-    ...render(
-      <FormWrapper>
-        <ResourceEditFormSharedFields {...componentProps} resourceType="dashboard" />
-      </FormWrapper>
-    ),
-  };
+  return render(
+    <FormWrapper>
+      <ResourceEditFormSharedFields {...componentProps} resourceType="dashboard" />
+    </FormWrapper>
+  );
 }
 
 describe('ResourceEditFormSharedFields', () => {
@@ -349,8 +340,7 @@ describe('ResourceEditFormSharedFields', () => {
         );
       };
 
-      const user = userEvent.setup();
-      render(<TestComponent />);
+      const { user } = render(<TestComponent />);
 
       const filenameInput = screen.getByRole('textbox', { name: /filename/i });
       const commentTextarea = screen.getByRole('textbox', { name: /comment/i });
@@ -379,8 +369,7 @@ describe('ResourceEditFormSharedFields', () => {
         );
       };
 
-      const user = userEvent.setup();
-      render(<TestComponent />);
+      const { user } = render(<TestComponent />);
 
       // Verify initial split
       expect(screen.getByRole('combobox', { name: /folder/i })).toHaveValue('dashboards');
@@ -413,6 +402,119 @@ describe('ResourceEditFormSharedFields', () => {
 
       // Check if validation error appears
       expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+  });
+
+  describe('Path validation for new dashboards', () => {
+    let validationRequested: boolean;
+
+    beforeEach(() => {
+      validationRequested = false;
+      // Default: file does not exist (404) — prevents MSW "unhandled request" warnings
+      // for tests that render with isNew but don't care about the validation outcome.
+      server.use(
+        http.get(`${BASE}/repositories/:name/files/*`, () => {
+          validationRequested = true;
+          return new HttpResponse(null, { status: 404 });
+        })
+      );
+    });
+
+    it('should show error when file already exists at path', async () => {
+      server.use(
+        http.get(`${BASE}/repositories/:name/files/*`, () => {
+          validationRequested = true;
+          return HttpResponse.json({ path: 'existing.json' });
+        })
+      );
+
+      const { user } = setup({
+        isNew: true,
+        repository: mockRepo.github,
+        formDefaultValues: { path: 'dashboards/existing.json' },
+      });
+
+      const filenameInput = screen.getByRole('textbox', { name: /filename/i });
+      await user.clear(filenameInput);
+      await user.type(filenameInput, 'test.json');
+
+      await waitFor(() => {
+        expect(screen.getByText('A file with this name already exists at this path')).toBeInTheDocument();
+      });
+    });
+
+    it('should not show error when file does not exist (404)', async () => {
+      const { user } = setup({
+        isNew: true,
+        repository: mockRepo.github,
+        formDefaultValues: { path: 'dashboards/new-file.json' },
+      });
+
+      const filenameInput = screen.getByRole('textbox', { name: /filename/i });
+      await user.clear(filenameInput);
+      await user.type(filenameInput, 'test.json');
+
+      await waitFor(() => {
+        expect(validationRequested).toBe(true);
+      });
+
+      expect(screen.queryByText('A file with this name already exists at this path')).not.toBeInTheDocument();
+    });
+
+    it('should not validate path when not a new dashboard', () => {
+      setup({
+        isNew: false,
+        repository: mockRepo.github,
+        formDefaultValues: { path: 'dashboards/existing.json' },
+      });
+
+      expect(validationRequested).toBe(false);
+    });
+
+    it('should not validate path when isNew is not set', () => {
+      setup({
+        repository: mockRepo.github,
+        formDefaultValues: { path: 'dashboards/existing.json' },
+      });
+
+      expect(validationRequested).toBe(false);
+    });
+
+    it('should trigger path validation when folder changes', async () => {
+      // File exists at the new path → validation should fire and show error
+      server.use(
+        http.get(`${BASE}/repositories/:name/files/*`, () => {
+          validationRequested = true;
+          return HttpResponse.json({ path: 'existing.json' });
+        })
+      );
+
+      // Provide folder options so the combobox has selectable items
+      jest.mocked(useGetRepositoryFolders).mockReturnValue({
+        hint: null,
+        options: [{ label: 'other-folder', value: 'other-folder' }],
+        loading: false,
+        error: null,
+      });
+
+      const { user } = setup({
+        isNew: true,
+        repository: mockRepo.github,
+        formDefaultValues: { path: 'dashboards/test.json' },
+      });
+
+      validationRequested = false;
+
+      // Change folder via combobox
+      const folderCombobox = screen.getByRole('combobox', { name: /folder/i });
+      await user.clear(folderCombobox);
+      await user.type(folderCombobox, 'other-folder');
+      await user.keyboard('{Enter}');
+
+      // shouldValidate: true means the path validator reruns after folder change
+      await waitFor(() => {
+        expect(validationRequested).toBe(true);
+      });
     });
   });
 });

--- a/public/app/features/provisioning/components/Shared/ResourceEditFormSharedFields.tsx
+++ b/public/app/features/provisioning/components/Shared/ResourceEditFormSharedFields.tsx
@@ -51,7 +51,7 @@ export const ResourceEditFormSharedFields = memo<DashboardEditFormSharedFieldsPr
         }
         const ref = watch('ref');
         try {
-          await checkFile({ name: repository.name, path, ref: ref || undefined }, true).unwrap();
+          await checkFile({ name: repository.name, path, ref: ref || undefined }).unwrap();
           return t(
             'provisioned-resource-form.save-or-delete-resource-shared-fields.path-exists',
             'A file with this name already exists at this path'
@@ -142,7 +142,12 @@ export const ResourceEditFormSharedFields = memo<DashboardEditFormSharedFieldsPr
               <Controller
                 name="ref"
                 control={control}
-                rules={{ validate: validateBranchName }}
+                rules={{
+                  validate: validateBranchName,
+                  // When the branch changes, re-run path validation: a file may exist on one
+                  // branch but not another, so the previous result is stale on the new ref.
+                  deps: shouldValidatePath ? ['path'] : undefined,
+                }}
                 render={({ field: { ref, onChange, ...field } }) => (
                   <>
                     {canOnlyPushToConfiguredBranch ? (
@@ -185,9 +190,7 @@ export const ResourceEditFormSharedFields = memo<DashboardEditFormSharedFieldsPr
           <Controller
             name="path"
             control={control}
-            // deps: ['ref'] re-runs validatePath when the branch changes — a file
-            // might exist on one branch but not another, so cached results are stale.
-            rules={shouldValidatePath ? { validate: validatePath, deps: ['ref'] } : undefined}
+            rules={shouldValidatePath ? { validate: validatePath } : undefined}
             render={({ field: { ref: _ref, onChange, value } }) => {
               const { directory: dir, filename: file } = splitPath(value || '');
               return (

--- a/public/app/features/provisioning/components/Shared/ResourceEditFormSharedFields.tsx
+++ b/public/app/features/provisioning/components/Shared/ResourceEditFormSharedFields.tsx
@@ -1,10 +1,14 @@
 import { skipToken } from '@reduxjs/toolkit/query/react';
-import { memo } from 'react';
+import { memo, useCallback } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 
 import { t } from '@grafana/i18n';
 import { Combobox, Field, Input, TextArea } from '@grafana/ui';
-import { type RepositoryView, useGetRepositoryRefsQuery } from 'app/api/clients/provisioning/v0alpha1';
+import {
+  type RepositoryView,
+  useGetRepositoryRefsQuery,
+  useLazyGetRepositoryFilesWithPathQuery,
+} from 'app/api/clients/provisioning/v0alpha1';
 import { BranchValidationError } from 'app/features/provisioning/Shared/BranchValidationError';
 import { validateBranchName } from 'app/features/provisioning/utils/git';
 import { isGitProvider } from 'app/features/provisioning/utils/repositoryTypes';
@@ -13,6 +17,7 @@ import { useBranchDropdownOptions } from '../../hooks/useBranchDropdownOptions';
 import { useGetRepositoryFolders } from '../../hooks/useGetRepositoryFolders';
 import { useLastBranch } from '../../hooks/useLastBranch';
 import { usePRBranch } from '../../hooks/usePRBranch';
+import { type BaseProvisionedFormData } from '../../types/form';
 import { joinPath, splitPath } from '../utils/path';
 
 type SharedFieldName = 'path' | 'comment';
@@ -35,7 +40,30 @@ export const ResourceEditFormSharedFields = memo<DashboardEditFormSharedFieldsPr
       formState: { errors },
       setValue,
       watch,
-    } = useFormContext();
+    } = useFormContext<BaseProvisionedFormData>();
+
+    const [checkFile] = useLazyGetRepositoryFilesWithPathQuery();
+
+    const validatePath = useCallback(
+      async (path: string) => {
+        if (!path || !repository?.name) {
+          return true;
+        }
+        const ref = watch('ref');
+        try {
+          await checkFile({ name: repository.name, path, ref: ref || undefined }, true).unwrap();
+          return t(
+            'provisioned-resource-form.save-or-delete-resource-shared-fields.path-exists',
+            'A file with this name already exists at this path'
+          );
+        } catch {
+          return true;
+        }
+      },
+      [checkFile, repository?.name, watch]
+    );
+
+    const shouldValidatePath = isNew && resourceType === 'dashboard';
 
     const canPushToNonConfiguredBranch = repository?.workflows?.includes('branch');
     const canOnlyPushToConfiguredBranch = canPushToConfiguredBranch && !canPushToNonConfiguredBranch;
@@ -157,7 +185,10 @@ export const ResourceEditFormSharedFields = memo<DashboardEditFormSharedFieldsPr
           <Controller
             name="path"
             control={control}
-            render={({ field: { ref, onChange, value } }) => {
+            // deps: ['ref'] re-runs validatePath when the branch changes — a file
+            // might exist on one branch but not another, so cached results are stale.
+            rules={shouldValidatePath ? { validate: validatePath, deps: ['ref'] } : undefined}
+            render={({ field: { ref: _ref, onChange, value } }) => {
               const { directory: dir, filename: file } = splitPath(value || '');
               return (
                 <>
@@ -174,9 +205,10 @@ export const ResourceEditFormSharedFields = memo<DashboardEditFormSharedFieldsPr
                       id="folder-path"
                       value={dir}
                       onChange={(option) => {
-                        // setValue (not onChange) so folder picks don't dirty the path field,
-                        // preserving title→filename auto-sync until the filename is edited.
-                        setValue('path', joinPath(option?.value ?? '', file), { shouldDirty: !isNew });
+                        setValue('path', joinPath(option?.value ?? '', file), {
+                          shouldDirty: !isNew,
+                          shouldValidate: true,
+                        });
                       }}
                       options={folderOptions}
                       loading={isFoldersLoading}
@@ -199,6 +231,8 @@ export const ResourceEditFormSharedFields = memo<DashboardEditFormSharedFieldsPr
                       'provisioned-resource-form.save-or-delete-resource-shared-fields.description-filename',
                       'File name for the dashboard (.json or .yaml)'
                     )}
+                    invalid={!!errors.path}
+                    error={errors?.path?.message}
                   >
                     <Input
                       id="dashboard-filename"

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13201,6 +13201,7 @@
       "label-filename": "Filename",
       "label-folder": "Folder",
       "label-path": "Path",
+      "path-exists": "A file with this name already exists at this path",
       "placeholder-branch": "Select or enter branch name",
       "placeholder-folder": "Select or enter folder path",
       "suffix-configured-branch": "Synchronized branch",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -9155,6 +9155,7 @@
   },
   "folders": {
     "api": {
+      "anonymous-user": "Anonymous",
       "folder-delete-error-provisioned": "Cannot delete provisioned folder. To remove it, delete it from the repository and synchronise to apply the changes.",
       "folder-deleted-success": "Folder deleted",
       "folder-move-error-provisioned": "Cannot move provisioned folder. To move it, move it in the repository and synchronise to apply the changes.",


### PR DESCRIPTION
**What is this feature?**

Adds async path validation to `ResourceEditFormSharedFields` that checks whether a file already exists at the target repository path before saving. Shows an inline error on duplicate paths. Validation re-runs on branch change (`deps: ["ref"]`) and folder selection (`shouldValidate: true`).

**Special notes for your reviewer:**

- MSW handler for `files/:path` returns 404 by default — backs tests where "file does not exist" is the normal case
- Tests migrated from manual mocks to MSW for consistency with the provisioning test suite
- Depends on #125414. Stack: `main ← #125414 ← **#125415** ← #125416 ← #125417`.

Part of https://github.com/grafana/git-ui-sync-project/issues/1070