### PR TITLE
fix: ignore levitate reviewers for now

### DIFF
--- a/.github/workflows/detect-breaking-changes-levitate.yml
+++ b/.github/workflows/detect-breaking-changes-levitate.yml
@@ -345,6 +345,8 @@ jobs:
       - name: Add "grafana/grafana-frontend-platform" as a reviewer
         if: steps.levitate-run.outputs.exit_code == 1
         uses: actions/github-script@v8
+        # FIXME: GATB doesn't seem to grant us necessary pull_requests write permissions
+        continue-on-error: true
         env:
           PR_NUMBER: ${{ steps.levitate-run.outputs.pr_number }}
         with:
@@ -362,6 +364,8 @@ jobs:
       - name: Remove "grafana/grafana-frontend-platform" from the list of reviewers
         if: steps.levitate-run.outputs.exit_code == 0
         uses: actions/github-script@v8
+        # FIXME: GATB doesn't seem to grant us necessary pull_requests write permissions
+        continue-on-error: true
         env:
           PR_NUMBER: ${{ steps.levitate-run.outputs.pr_number }}
         with:


### PR DESCRIPTION
Something is making GATB not grant us necessary permissions, or [GitHub's docs](https://docs.github.com/en/rest/pulls/review-requests?apiVersion=2026-03-10#remove-requested-reviewers-from-a-pull-request) are wrong. We can't assign/unassign reviewers.

To unblock PRs, let's ignore not being able to manipulate reviewers.