### PR TITLE
docs(alerting): add note about alert rules versions

### DIFF
--- a/docs/sources/alerting/monitor-status/view-alert-rules.md
+++ b/docs/sources/alerting/monitor-status/view-alert-rules.md
@@ -72,9 +72,7 @@ On the Alert rule's Versions page you can view, compare and restore the previous
 
 {{< admonition type="note" >}}
 
-- The version of an alert rule does not always increase sequentially in the version history table.
-
-  When any alert rule in an evaluation group changes, the version number increases for all alert rules in that group. However, the version history table only displays a new entry when the alert rule itself had meaningful changes.
+- The alert rule does not guarantee sequential version increases.
 
 - In Grafana OSS and Enterprise, the number of alert rule versions can be limited using the [`rule_version_record_limit` option](/docs/grafana/latest/setup-grafana/configure-grafana/#rule_version_record_limit). In Grafana Cloud, free users are allowed a maximum of 10 alert rule versions, while paid users have a maximum of 100 stored alert rule versions.
   {{< /admonition >}}

--- a/docs/sources/alerting/monitor-status/view-alert-rules.md
+++ b/docs/sources/alerting/monitor-status/view-alert-rules.md
@@ -77,7 +77,7 @@ On the Alert rule's Versions page you can view, compare and restore the previous
   When any alert rule in an evaluation group changes, the version number increases for all alert rules in that group. However, the version history table only displays a new entry when the alert rule itself had meaningful changes.
 
 - In Grafana OSS and Enterprise, the number of alert rule versions can be limited using the [`rule_version_record_limit` option](/docs/grafana/latest/setup-grafana/configure-grafana/#rule_version_record_limit). In Grafana Cloud, free users are allowed a maximum of 10 alert rule versions, while paid users have a maximum of 100 stored alert rule versions.
-{{< /admonition >}}
+  {{< /admonition >}}
 
 ## Bulk pause or resume alert rules evaluations within a folder
 

--- a/docs/sources/alerting/monitor-status/view-alert-rules.md
+++ b/docs/sources/alerting/monitor-status/view-alert-rules.md
@@ -59,13 +59,7 @@ For details on how rule states and alert instance states are displayed, refer to
 
 ## View, compare and restore alert rules versions.
 
-You can view, compare, and restore previous alert rule versions.
-
-{{< admonition type="note" >}}
-In Grafana OSS and Enterprise, the number of alert rule versions is limited. Free users are allowed a maximum of 10 alert rule versions, while paid users have a maximum of 100 stored alert rule versions.
-{{< /admonition >}}
-
-To view or restore previous versions for an alert rule, complete the following steps.
+To view, compare, or restore previous versions for an alert rule, complete the following steps.
 
 1. Navigate to **Alerts & IRM** -> **Alerting** -> **Alert rules**.
 1. Select an alert rule and click **View**.
@@ -73,7 +67,17 @@ To view or restore previous versions for an alert rule, complete the following s
    The page displays a list of the previous rule versions.
 
 On the Alert rule's Versions page you can view, compare and restore the previous rule versions.
+
 {{< figure src="/media/docs/alerting/screenshot-grafana-alerting-version-history-v3.png" max-width="750px" alt="View alert rule history to compare and restore previous alert rules." >}}
+
+{{< admonition type="note" >}}
+
+- The version of an alert rule does not always increase sequentially in the version history table.
+
+  When any alert rule in an evaluation group changes, the version number increases for all alert rules in that group. However, the version history table only displays a new entry when the alert rule itself had meaningful changes.
+
+- In Grafana OSS and Enterprise, the number of alert rule versions can be limited using the [`rule_version_record_limit` option](/docs/grafana/latest/setup-grafana/configure-grafana/#rule_version_record_limit). In Grafana Cloud, free users are allowed a maximum of 10 alert rule versions, while paid users have a maximum of 100 stored alert rule versions.
+{{< /admonition >}}
 
 ## Bulk pause or resume alert rules evaluations within a folder
 

--- a/docs/sources/alerting/monitor-status/view-alert-state.md
+++ b/docs/sources/alerting/monitor-status/view-alert-state.md
@@ -56,7 +56,7 @@ refs:
 
 An alert rule and its corresponding alert instances can transition through distinct states during the alert rule evaluation.
 
-{{< figure src="/media/docs/alerting/alert-state-diagram2.png" alt="A diagram of the distinct alert instance states and transitions." max-width="750px" >}}
+{{< figure src="/media/docs/alerting/alert-rule-evaluation-full-statediagram_v3.svg" alt="A diagram of the distinct alert instance states and transitions." max-width="750px" >}}
 
 There are three key components that helps us understand the behavior of our alerts:
 


### PR DESCRIPTION
PR changes:

- Add note about alert rules versions (⭐ [Preview](https://deploy-preview-grafana-125424-zb444pucvq-vp.a.run.app/docs/grafana/latest/alerting/monitor-status/view-alert-rules/#view-compare-and-restore-alert-rules-versions))
- Update an outdated alert state diagram (⭐ [Preview](https://deploy-preview-grafana-125424-zb444pucvq-vp.a.run.app/docs/grafana/latest/alerting/monitor-status/view-alert-state/))

Related [internal thread](https://raintank-corp.slack.com/archives/C01LJ5F8NRX/p1779279668014909).