### PR TITLE
Provisioning: Warn instead of error when resource is not found in delete job

### DIFF
--- a/pkg/registry/apis/provisioning/jobs/delete/worker.go
+++ b/pkg/registry/apis/provisioning/jobs/delete/worker.go
@@ -167,8 +167,8 @@ func (w *Worker) deleteFiles(ctx context.Context, rw repository.ReaderWriter, pr
 }
 
 // resolveResourcesToPaths converts ResourceRef entries to file paths, recording errors for individual resources
-func (w *Worker) resolveResourcesToPaths(ctx context.Context, rw repository.ReaderWriter, progress jobs.JobProgressRecorder, resources []provisioning.ResourceRef) ([]string, error) {
-	if len(resources) == 0 {
+func (w *Worker) resolveResourcesToPaths(ctx context.Context, rw repository.ReaderWriter, progress jobs.JobProgressRecorder, resourceRefs []provisioning.ResourceRef) ([]string, error) {
+	if len(resourceRefs) == 0 {
 		return nil, nil
 	}
 
@@ -178,8 +178,8 @@ func (w *Worker) resolveResourcesToPaths(ctx context.Context, rw repository.Read
 		return nil, fmt.Errorf("create repository resources client: %w", err)
 	}
 
-	resolvedPaths := make([]string, 0, len(resources))
-	for _, resource := range resources {
+	resolvedPaths := make([]string, 0, len(resourceRefs))
+	for _, resource := range resourceRefs {
 		gvk := schema.GroupVersionKind{
 			Group: resource.Group,
 			Kind:  resource.Kind,
@@ -190,6 +190,12 @@ func (w *Worker) resolveResourcesToPaths(ctx context.Context, rw repository.Read
 		progress.SetMessage(ctx, fmt.Sprintf("Finding path for resource %s/%s/%s", resource.Group, resource.Kind, resource.Name))
 		resourcePath, err := repositoryResources.FindResourcePath(ctx, resource.Name, gvk)
 		if err != nil {
+			if errors.Is(err, resources.ErrResourceNotFound) {
+				resultBuilder.WithWarning(fmt.Errorf("resource %s/%s/%s not found", resource.Group, resource.Kind, resource.Name))
+				progress.Record(ctx, resultBuilder.Build())
+				continue
+			}
+
 			resultBuilder.WithError(fmt.Errorf("find path for resource %s/%s/%s: %w", resource.Group, resource.Kind, resource.Name, err))
 			progress.Record(ctx, resultBuilder.Build())
 			// Continue with next resource instead of failing fast

--- a/pkg/registry/apis/provisioning/jobs/delete/worker_test.go
+++ b/pkg/registry/apis/provisioning/jobs/delete/worker_test.go
@@ -3,6 +3,7 @@ package delete
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 	"time"
 
@@ -359,6 +360,12 @@ func TestDeleteWorker_deleteFiles(t *testing.T) {
 			deleteResults: []error{repository.ErrFileNotFound, nil},
 			expectedCalls: 2,
 		},
+		{
+			name:          "file not found does not count as error for TooManyErrors",
+			paths:         []string{"test/file1.yaml"},
+			deleteResults: []error{repository.ErrFileNotFound},
+			expectedCalls: 1,
+		},
 	}
 
 	for _, tt := range tests {
@@ -401,6 +408,165 @@ func TestDeleteWorker_deleteFiles(t *testing.T) {
 			mockProgress.AssertExpectations(t)
 		})
 	}
+}
+
+func TestDeleteWorker_Process_FileNotFoundIsWarning(t *testing.T) {
+	job := v0alpha1.Job{
+		Spec: v0alpha1.JobSpec{
+			Action: v0alpha1.JobActionDelete,
+			Delete: &v0alpha1.DeleteJobOptions{
+				Paths: []string{"test/nonexistent.yaml"},
+				Ref:   "main",
+			},
+		},
+	}
+
+	mockRepo := &mockReaderWriter{
+		MockRepository: repository.NewMockRepository(t),
+	}
+	mockProgress := jobs.NewMockJobProgressRecorder(t)
+	mockWrapFn := repository.NewMockWrapWithStageFn(t)
+
+	mockWrapFn.On("Execute", mock.Anything, mockRepo, mock.Anything, mock.Anything).Return(func(ctx context.Context, repo repository.Repository, stageOptions repository.StageOptions, fn func(repository.Repository, bool) error) error {
+		return fn(mockRepo, false)
+	})
+
+	mockProgress.On("SetTotal", mock.Anything, 1).Return()
+	mockProgress.On("StrictMaxErrors", 1).Return()
+	mockProgress.On("SetMessage", mock.Anything, "Deleting test/nonexistent.yaml").Return()
+	mockProgress.On("TooManyErrors").Return(nil)
+	mockProgress.On("Complete", mock.Anything, mock.Anything).Return(v0alpha1.JobStatus{})
+
+	mockRepo.On("Delete", mock.Anything, "test/nonexistent.yaml", "main", "Delete test/nonexistent.yaml").Return(repository.ErrFileNotFound)
+
+	// Result must have Warning set and no Error
+	mockProgress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
+		return result.Path() == "test/nonexistent.yaml" &&
+			result.Action() == repository.FileActionDeleted &&
+			result.Warning() != nil &&
+			errors.Is(result.Warning(), repository.ErrFileNotFound) &&
+			result.Error() == nil
+	})).Return()
+
+	worker := NewWorker(nil, mockWrapFn.Execute, nil, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
+	err := worker.Process(context.Background(), mockRepo, job, mockProgress)
+	require.NoError(t, err)
+	mockRepo.AssertExpectations(t)
+	mockProgress.AssertExpectations(t)
+}
+
+func TestDeleteWorker_Process_ResourceNotFoundIsWarning(t *testing.T) {
+	job := v0alpha1.Job{
+		Spec: v0alpha1.JobSpec{
+			Action: v0alpha1.JobActionDelete,
+			Delete: &v0alpha1.DeleteJobOptions{
+				Resources: []v0alpha1.ResourceRef{
+					{
+						Name:  "missing-dashboard",
+						Kind:  "Dashboard",
+						Group: "dashboard.grafana.app",
+					},
+				},
+				Ref: "main",
+			},
+		},
+	}
+
+	mockRepo := &mockReaderWriter{
+		MockRepository: repository.NewMockRepository(t),
+	}
+	mockProgress := jobs.NewMockJobProgressRecorder(t)
+	mockWrapFn := repository.NewMockWrapWithStageFn(t)
+	mockResourcesFactory := resources.NewMockRepositoryResourcesFactory(t)
+	mockRepositoryResources := resources.NewMockRepositoryResources(t)
+
+	mockResourcesFactory.On("Client", mock.Anything, mockRepo).Return(mockRepositoryResources, nil)
+	mockRepositoryResources.On("FindResourcePath", mock.Anything, "missing-dashboard", schema.GroupVersionKind{
+		Group: "dashboard.grafana.app",
+		Kind:  "Dashboard",
+	}).Return("", fmt.Errorf("dashboard.grafana.app/dashboards/missing-dashboard: %w", resources.ErrResourceNotFound))
+
+	mockWrapFn.On("Execute", mock.Anything, mockRepo, mock.Anything, mock.Anything).Return(func(ctx context.Context, repo repository.Repository, stageOptions repository.StageOptions, fn func(repository.Repository, bool) error) error {
+		return fn(mockRepo, false)
+	})
+
+	mockProgress.On("SetTotal", mock.Anything, 1).Return()
+	mockProgress.On("StrictMaxErrors", 1).Return()
+	mockProgress.On("SetMessage", mock.Anything, "Resolving resource paths").Return()
+	mockProgress.On("SetMessage", mock.Anything, "Finding path for resource dashboard.grafana.app/Dashboard/missing-dashboard").Return()
+	mockProgress.On("Complete", mock.Anything, mock.Anything).Return(v0alpha1.JobStatus{})
+
+	// Warning recorded, no Error — ErrResourceNotFound is a warn-only condition.
+	// TooManyErrors is NOT called: warnings don't count as errors.
+	mockProgress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
+		return result.Name() == "missing-dashboard" &&
+			result.Action() == repository.FileActionDeleted &&
+			result.Warning() != nil &&
+			result.Error() == nil
+	})).Return()
+
+	worker := NewWorker(nil, mockWrapFn.Execute, mockResourcesFactory, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
+	err := worker.Process(context.Background(), mockRepo, job, mockProgress)
+	require.NoError(t, err)
+	mockRepositoryResources.AssertExpectations(t)
+	mockProgress.AssertExpectations(t)
+}
+
+func TestDeleteWorker_deleteFilesFileNotFoundIsWarning(t *testing.T) {
+	mockRepo := &mockReaderWriter{
+		MockRepository: repository.NewMockRepository(t),
+	}
+	mockProgress := jobs.NewMockJobProgressRecorder(t)
+
+	opts := v0alpha1.DeleteJobOptions{Ref: "main"}
+	path := "test/nonexistent.yaml"
+
+	mockRepo.On("Delete", mock.Anything, path, "main", "Delete "+path).Return(repository.ErrFileNotFound)
+	mockProgress.On("SetMessage", mock.Anything, "Deleting "+path).Return()
+	mockProgress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
+		return result.Path() == path &&
+			result.Action() == repository.FileActionDeleted &&
+			result.Warning() != nil &&
+			errors.Is(result.Warning(), repository.ErrFileNotFound) &&
+			result.Error() == nil
+	})).Return()
+	mockProgress.On("TooManyErrors").Return(nil)
+
+	worker := NewWorker(nil, nil, nil, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
+	err := worker.deleteFiles(context.Background(), mockRepo, mockProgress, opts, path)
+
+	require.NoError(t, err)
+	mockRepo.AssertExpectations(t)
+	mockProgress.AssertExpectations(t)
+}
+
+func TestDeleteWorker_deleteFilesOtherErrorIsNotWarning(t *testing.T) {
+	mockRepo := &mockReaderWriter{
+		MockRepository: repository.NewMockRepository(t),
+	}
+	mockProgress := jobs.NewMockJobProgressRecorder(t)
+
+	opts := v0alpha1.DeleteJobOptions{Ref: "main"}
+	path := "test/file.yaml"
+	deleteError := errors.New("permission denied")
+
+	mockRepo.On("Delete", mock.Anything, path, "main", "Delete "+path).Return(deleteError)
+	mockProgress.On("SetMessage", mock.Anything, "Deleting "+path).Return()
+	mockProgress.On("Record", mock.Anything, mock.MatchedBy(func(result jobs.JobResourceResult) bool {
+		return result.Path() == path &&
+			result.Action() == repository.FileActionDeleted &&
+			result.Error() != nil &&
+			errors.Is(result.Error(), deleteError) &&
+			result.Warning() == nil
+	})).Return()
+	mockProgress.On("TooManyErrors").Return(nil)
+
+	worker := NewWorker(nil, nil, nil, jobs.RegisterJobMetrics(prometheus.NewPedanticRegistry()))
+	err := worker.deleteFiles(context.Background(), mockRepo, mockProgress, opts, path)
+
+	require.NoError(t, err)
+	mockRepo.AssertExpectations(t)
+	mockProgress.AssertExpectations(t)
 }
 
 func TestDeleteWorker_ProcessWithResourceRefs(t *testing.T) {

--- a/pkg/registry/apis/provisioning/resources/errors.go
+++ b/pkg/registry/apis/provisioning/resources/errors.go
@@ -447,3 +447,25 @@ func IsFolderValidationAPIError(err error) bool {
 
 	return false
 }
+
+// ErrResourceNotFound is the sentinel for a resource that does not exist in
+// Grafana. Use errors.Is(err, ErrResourceNotFound) to detect it.
+var ErrResourceNotFound = errors.New("resource not found")
+
+// ResourceNotFoundError is returned by FindResourcePath when the Kubernetes API
+// returns a 404 for the requested resource. It carries the API group, resource
+// type, and name so callers can surface a human-readable message, while still
+// supporting errors.Is(err, ErrResourceNotFound) via Unwrap.
+type ResourceNotFoundError struct {
+	Group    string
+	Resource string
+	Name     string
+}
+
+func (e *ResourceNotFoundError) Error() string {
+	return fmt.Sprintf("resource not found: %s/%s/%s", e.Group, e.Resource, e.Name)
+}
+
+func (e *ResourceNotFoundError) Unwrap() error {
+	return ErrResourceNotFound
+}

--- a/pkg/registry/apis/provisioning/resources/repository.go
+++ b/pkg/registry/apis/provisioning/resources/repository.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -14,6 +15,10 @@ import (
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
 	"github.com/grafana/grafana/apps/provisioning/pkg/safepath"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
+)
+
+var (
+	ErrResourceNotFound = errors.New("resource not found")
 )
 
 //go:generate mockery --name RepositoryResourcesFactory --structname MockRepositoryResourcesFactory --inpackage --filename repository_resources_factory_mock.go --with-expecter
@@ -93,7 +98,7 @@ func (r *repositoryResources) FindResourcePath(ctx context.Context, name string,
 	obj, err := client.Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return "", fmt.Errorf("resource not found: %s/%s/%s", gvr.Group, gvr.Resource, name)
+			return "", fmt.Errorf("%s/%s/%s: %w", gvr.Group, gvr.Resource, name, ErrResourceNotFound)
 		}
 		return "", fmt.Errorf("failed to get resource %s/%s/%s: %w", gvr.Group, gvr.Resource, name, err)
 	}

--- a/pkg/registry/apis/provisioning/resources/repository.go
+++ b/pkg/registry/apis/provisioning/resources/repository.go
@@ -2,7 +2,6 @@ package resources
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -17,9 +16,6 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 )
 
-var (
-	ErrResourceNotFound = errors.New("resource not found")
-)
 
 //go:generate mockery --name RepositoryResourcesFactory --structname MockRepositoryResourcesFactory --inpackage --filename repository_resources_factory_mock.go --with-expecter
 type RepositoryResourcesFactory interface {
@@ -98,7 +94,7 @@ func (r *repositoryResources) FindResourcePath(ctx context.Context, name string,
 	obj, err := client.Get(ctx, name, metav1.GetOptions{})
 	if err != nil {
 		if apierrors.IsNotFound(err) {
-			return "", fmt.Errorf("%s/%s/%s: %w", gvr.Group, gvr.Resource, name, ErrResourceNotFound)
+			return "", &ResourceNotFoundError{Group: gvr.Group, Resource: gvr.Resource, Name: name}
 		}
 		return "", fmt.Errorf("failed to get resource %s/%s/%s: %w", gvr.Group, gvr.Resource, name, err)
 	}

--- a/pkg/registry/apis/provisioning/resources/repository.go
+++ b/pkg/registry/apis/provisioning/resources/repository.go
@@ -16,7 +16,6 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 )
 
-
 //go:generate mockery --name RepositoryResourcesFactory --structname MockRepositoryResourcesFactory --inpackage --filename repository_resources_factory_mock.go --with-expecter
 type RepositoryResourcesFactory interface {
 	Client(ctx context.Context, repo repository.ReaderWriter, opts ...RepositoryResourcesOption) (RepositoryResources, error)

--- a/pkg/registry/apis/provisioning/resources/repository_test.go
+++ b/pkg/registry/apis/provisioning/resources/repository_test.go
@@ -20,15 +20,16 @@ import (
 
 func TestRepositoryResources_FindResourcePath(t *testing.T) {
 	tests := []struct {
-		name          string
-		resourceName  string
-		gvk           schema.GroupVersionKind
-		expectedGVR   schema.GroupVersionResource
-		forKindError  error
-		getError      error
-		resourceObj   *unstructured.Unstructured
-		expectedPath  string
-		expectedError string
+		name             string
+		resourceName     string
+		gvk              schema.GroupVersionKind
+		expectedGVR      schema.GroupVersionResource
+		forKindError     error
+		getError         error
+		resourceObj      *unstructured.Unstructured
+		expectedPath     string
+		expectedError    string
+		expectedSentinel error // if set, asserts errors.Is(err, expectedSentinel)
 	}{
 		{
 			name:         "dashboard found successfully",
@@ -91,7 +92,7 @@ func TestRepositoryResources_FindResourcePath(t *testing.T) {
 			expectedError: "get client for kind Dashboard: kind not found",
 		},
 		{
-			name:         "resource not found",
+			name:         "resource not found wraps ErrResourceNotFound sentinel",
 			resourceName: "nonexistent-dashboard",
 			gvk: schema.GroupVersionKind{
 				Group: "dashboard.grafana.app",
@@ -102,8 +103,9 @@ func TestRepositoryResources_FindResourcePath(t *testing.T) {
 				Version:  "v0alpha1",
 				Resource: "dashboards",
 			},
-			getError:      apierrors.NewNotFound(schema.GroupResource{Group: "dashboard.grafana.app", Resource: "dashboards"}, "nonexistent-dashboard"),
-			expectedError: "resource not found: dashboard.grafana.app/dashboards/nonexistent-dashboard",
+			getError:         apierrors.NewNotFound(schema.GroupResource{Group: "dashboard.grafana.app", Resource: "dashboards"}, "nonexistent-dashboard"),
+			expectedError:    "resource not found",
+			expectedSentinel: ErrResourceNotFound,
 		},
 		{
 			name:         "Get operation fails with other error",
@@ -332,6 +334,10 @@ func TestRepositoryResources_FindResourcePath(t *testing.T) {
 				require.Error(t, err)
 				require.Contains(t, err.Error(), tt.expectedError)
 				require.Empty(t, result)
+				if tt.expectedSentinel != nil {
+					require.True(t, errors.Is(err, tt.expectedSentinel),
+						"expected errors.Is(err, %v) but err was: %v", tt.expectedSentinel, err)
+				}
 			} else {
 				require.NoError(t, err)
 				require.Equal(t, tt.expectedPath, result)

--- a/pkg/registry/apis/provisioning/resources/repository_test.go
+++ b/pkg/registry/apis/provisioning/resources/repository_test.go
@@ -104,7 +104,7 @@ func TestRepositoryResources_FindResourcePath(t *testing.T) {
 				Resource: "dashboards",
 			},
 			getError:         apierrors.NewNotFound(schema.GroupResource{Group: "dashboard.grafana.app", Resource: "dashboards"}, "nonexistent-dashboard"),
-			expectedError:    "resource not found",
+			expectedError:    "resource not found: dashboard.grafana.app/dashboards/nonexistent-dashboard",
 			expectedSentinel: ErrResourceNotFound,
 		},
 		{

--- a/pkg/tests/apis/provisioning/jobs/deletejob_test.go
+++ b/pkg/tests/apis/provisioning/jobs/deletejob_test.go
@@ -339,8 +339,8 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 			require.True(t, apierrors.IsNotFound(err), "should be not found error")
 		})
 
-		t.Run("delete non-existent resource by reference", func(t *testing.T) {
-			// Create delete job for non-existent resource
+		t.Run("delete non-existent resource by reference warns", func(t *testing.T) {
+			// Deleting a resource that doesn't exist should warn, not fail — idempotent delete.
 			spec := provisioning.JobSpec{
 				Action: provisioning.JobActionDelete,
 				Delete: &provisioning.DeleteJobOptions{
@@ -356,58 +356,51 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 
 			job := helper.TriggerJobAndWaitForComplete(t, repo, spec)
 			state := common.MustNestedString(job.Object, "status", "state")
-			assert.Equal(t, "error", state, "delete job should have failed due to non-existent file")
+			assert.Equal(t, string(provisioning.JobStateWarning), state, "delete job for non-existent resource should complete with warning, not error")
 		})
 	})
 
-	t.Run("delete non-existent file is rejected", func(t *testing.T) {
-		body := common.AsJSON(provisioning.JobSpec{
+	t.Run("delete non-existent file warns", func(t *testing.T) {
+		// Deleting a file that doesn't exist is idempotent — should warn, not fail.
+		spec := provisioning.JobSpec{
 			Action: provisioning.JobActionDelete,
 			Delete: &provisioning.DeleteJobOptions{
 				Paths: []string{"non-existent.json"},
 			},
-		})
+		}
 
-		result := helper.AdminREST.Post().
-			Namespace("default").
-			Resource("repositories").
-			Name(repo).
-			SubResource("jobs").
-			Body(body).
-			SetHeader("Content-Type", "application/json").
-			Do(ctx)
-
-		require.Error(t, result.Error(), "delete job for non-existent file should be rejected at creation")
+		job := helper.TriggerJobAndWaitForComplete(t, repo, spec)
+		state := common.MustNestedString(job.Object, "status", "state")
+		assert.Equal(t, string(provisioning.JobStateWarning), state, "delete job for non-existent file should complete with warning, not error")
 	})
 
-	t.Run("delete mixed existing and non-existent file is rejected", func(t *testing.T) {
+	t.Run("delete mixed existing and non-existent file: existing deleted, non-existent warns", func(t *testing.T) {
 		helper.CopyToProvisioningPath(t, "../testdata/all-panels.json", "test-delete-mixed.json")
 		helper.SyncAndWait(t, repo, nil)
 
-		body := common.AsJSON(provisioning.JobSpec{
+		spec := provisioning.JobSpec{
 			Action: provisioning.JobActionDelete,
 			Delete: &provisioning.DeleteJobOptions{
 				Paths: []string{
-					"test-delete-mixed.json", // This exists
-					"non-existent-file.json", // This doesn't exist
+					"test-delete-mixed.json", // exists — should be deleted
+					"non-existent-file.json", // does not exist — should warn
 				},
 			},
-		})
+		}
 
-		result := helper.AdminREST.Post().
-			Namespace("default").
-			Resource("repositories").
-			Name(repo).
-			SubResource("jobs").
-			Body(body).
-			SetHeader("Content-Type", "application/json").
-			Do(ctx)
+		job := helper.TriggerJobAndWaitForComplete(t, repo, spec)
+		state := common.MustNestedString(job.Object, "status", "state")
+		assert.Equal(t, string(provisioning.JobStateWarning), state, "job should complete with warning (non-existent file), not error")
 
-		require.Error(t, result.Error(), "delete job with any non-existent file should be rejected at creation")
+		// Existing file must have been deleted
+		_, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "test-delete-mixed.json")
+		require.Error(t, err, "test-delete-mixed.json should have been deleted")
+		require.True(t, apierrors.IsNotFound(err))
 	})
 
-	t.Run("delete multiple non-existent files is rejected", func(t *testing.T) {
-		body := common.AsJSON(provisioning.JobSpec{
+	t.Run("delete multiple non-existent files warns", func(t *testing.T) {
+		// All paths missing — all warn, job completes with warning state.
+		spec := provisioning.JobSpec{
 			Action: provisioning.JobActionDelete,
 			Delete: &provisioning.DeleteJobOptions{
 				Paths: []string{
@@ -416,17 +409,10 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 					"does-not-exist-3.json",
 				},
 			},
-		})
+		}
 
-		result := helper.AdminREST.Post().
-			Namespace("default").
-			Resource("repositories").
-			Name(repo).
-			SubResource("jobs").
-			Body(body).
-			SetHeader("Content-Type", "application/json").
-			Do(ctx)
-
-		require.Error(t, result.Error(), "delete job for all non-existent files should be rejected at creation")
+		job := helper.TriggerJobAndWaitForComplete(t, repo, spec)
+		state := common.MustNestedString(job.Object, "status", "state")
+		assert.Equal(t, string(provisioning.JobStateWarning), state, "delete job for all non-existent files should complete with warning, not error")
 	})
 }

--- a/pkg/tests/apis/provisioning/jobs/deletejob_test.go
+++ b/pkg/tests/apis/provisioning/jobs/deletejob_test.go
@@ -339,8 +339,8 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 			require.True(t, apierrors.IsNotFound(err), "should be not found error")
 		})
 
-		t.Run("delete non-existent resource by reference warns", func(t *testing.T) {
-			// Deleting a resource that doesn't exist should warn, not fail — idempotent delete.
+		t.Run("delete non-existent resource by reference", func(t *testing.T) {
+			// Create delete job for non-existent resource
 			spec := provisioning.JobSpec{
 				Action: provisioning.JobActionDelete,
 				Delete: &provisioning.DeleteJobOptions{
@@ -356,51 +356,58 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 
 			job := helper.TriggerJobAndWaitForComplete(t, repo, spec)
 			state := common.MustNestedString(job.Object, "status", "state")
-			assert.Equal(t, string(provisioning.JobStateWarning), state, "delete job for non-existent resource should complete with warning, not error")
+			assert.Equal(t, string(provisioning.JobStateWarning), state, "delete job should have warned due to non-existent file")
 		})
 	})
 
-	t.Run("delete non-existent file warns", func(t *testing.T) {
-		// Deleting a file that doesn't exist is idempotent — should warn, not fail.
-		spec := provisioning.JobSpec{
+	t.Run("delete non-existent file is rejected", func(t *testing.T) {
+		body := common.AsJSON(provisioning.JobSpec{
 			Action: provisioning.JobActionDelete,
 			Delete: &provisioning.DeleteJobOptions{
 				Paths: []string{"non-existent.json"},
 			},
-		}
+		})
 
-		job := helper.TriggerJobAndWaitForComplete(t, repo, spec)
-		state := common.MustNestedString(job.Object, "status", "state")
-		assert.Equal(t, string(provisioning.JobStateWarning), state, "delete job for non-existent file should complete with warning, not error")
+		result := helper.AdminREST.Post().
+			Namespace("default").
+			Resource("repositories").
+			Name(repo).
+			SubResource("jobs").
+			Body(body).
+			SetHeader("Content-Type", "application/json").
+			Do(ctx)
+
+		require.Error(t, result.Error(), "delete job for non-existent file should be rejected at creation")
 	})
 
-	t.Run("delete mixed existing and non-existent file: existing deleted, non-existent warns", func(t *testing.T) {
+	t.Run("delete mixed existing and non-existent file is rejected", func(t *testing.T) {
 		helper.CopyToProvisioningPath(t, "../testdata/all-panels.json", "test-delete-mixed.json")
 		helper.SyncAndWait(t, repo, nil)
 
-		spec := provisioning.JobSpec{
+		body := common.AsJSON(provisioning.JobSpec{
 			Action: provisioning.JobActionDelete,
 			Delete: &provisioning.DeleteJobOptions{
 				Paths: []string{
-					"test-delete-mixed.json", // exists — should be deleted
-					"non-existent-file.json", // does not exist — should warn
+					"test-delete-mixed.json", // This exists
+					"non-existent-file.json", // This doesn't exist
 				},
 			},
-		}
+		})
 
-		job := helper.TriggerJobAndWaitForComplete(t, repo, spec)
-		state := common.MustNestedString(job.Object, "status", "state")
-		assert.Equal(t, string(provisioning.JobStateWarning), state, "job should complete with warning (non-existent file), not error")
+		result := helper.AdminREST.Post().
+			Namespace("default").
+			Resource("repositories").
+			Name(repo).
+			SubResource("jobs").
+			Body(body).
+			SetHeader("Content-Type", "application/json").
+			Do(ctx)
 
-		// Existing file must have been deleted
-		_, err := helper.Repositories.Resource.Get(ctx, repo, metav1.GetOptions{}, "files", "test-delete-mixed.json")
-		require.Error(t, err, "test-delete-mixed.json should have been deleted")
-		require.True(t, apierrors.IsNotFound(err))
+		require.Error(t, result.Error(), "delete job with any non-existent file should be rejected at creation")
 	})
 
-	t.Run("delete multiple non-existent files warns", func(t *testing.T) {
-		// All paths missing — all warn, job completes with warning state.
-		spec := provisioning.JobSpec{
+	t.Run("delete multiple non-existent files is rejected", func(t *testing.T) {
+		body := common.AsJSON(provisioning.JobSpec{
 			Action: provisioning.JobActionDelete,
 			Delete: &provisioning.DeleteJobOptions{
 				Paths: []string{
@@ -409,10 +416,17 @@ func TestIntegrationProvisioning_DeleteJob(t *testing.T) {
 					"does-not-exist-3.json",
 				},
 			},
-		}
+		})
 
-		job := helper.TriggerJobAndWaitForComplete(t, repo, spec)
-		state := common.MustNestedString(job.Object, "status", "state")
-		assert.Equal(t, string(provisioning.JobStateWarning), state, "delete job for all non-existent files should complete with warning, not error")
+		result := helper.AdminREST.Post().
+			Namespace("default").
+			Resource("repositories").
+			Name(repo).
+			SubResource("jobs").
+			Body(body).
+			SetHeader("Content-Type", "application/json").
+			Do(ctx)
+
+		require.Error(t, result.Error(), "delete job for all non-existent files should be rejected at creation")
 	})
 }


### PR DESCRIPTION
**What is this feature?**

When a delete job targets a resource reference that no longer exists in Grafana, `resolveResourcesToPaths` now records a warning and continues processing instead of treating it as an error. The job completes successfully with warning state.

**Why do we need this feature?**

Deleting a resource that does not exist is an idempotent operation: the desired end state (resource absent) is already achieved. Treating this as an error made delete jobs non-idempotent and fragile — a job that succeeded once could not be safely re-run, and race conditions (e.g. concurrent deletes, stale job submissions) would cause unnecessary failures.

**Which issue(s) does this PR fix?**

Fixes https://github.com/grafana/git-ui-sync-project/issues/1159