### PR TITLE
Provisioning: Harden frontend against XSS, URL injection, and input validation issues

### DIFF
--- a/public/app/features/provisioning/File/FileHistoryPage.test.tsx
+++ b/public/app/features/provisioning/File/FileHistoryPage.test.tsx
@@ -1,0 +1,39 @@
+import { getAuthorProfileUrl } from './FileHistoryPage';
+
+describe('getAuthorProfileUrl', () => {
+  it('returns GitHub URL for github type', () => {
+    expect(getAuthorProfileUrl('github', 'octocat')).toBe('https://github.com/octocat');
+  });
+
+  it('returns GitHub URL for githubEnterprise type', () => {
+    expect(getAuthorProfileUrl('githubEnterprise', 'octocat')).toBe('https://github.com/octocat');
+  });
+
+  it('returns GitLab URL for gitlab type', () => {
+    expect(getAuthorProfileUrl('gitlab', 'user')).toBe('https://gitlab.com/user');
+  });
+
+  it('returns Bitbucket URL for bitbucket type', () => {
+    expect(getAuthorProfileUrl('bitbucket', 'user')).toBe('https://bitbucket.org/user');
+  });
+
+  it('returns undefined for git type', () => {
+    expect(getAuthorProfileUrl('git', 'user')).toBeUndefined();
+  });
+
+  it('returns undefined for local type', () => {
+    expect(getAuthorProfileUrl('local', 'user')).toBeUndefined();
+  });
+
+  it('returns undefined for undefined type', () => {
+    expect(getAuthorProfileUrl(undefined, 'user')).toBeUndefined();
+  });
+
+  it('encodes special characters in username', () => {
+    expect(getAuthorProfileUrl('github', 'user name&special')).toBe('https://github.com/user%20name%26special');
+  });
+
+  it('encodes slashes in username', () => {
+    expect(getAuthorProfileUrl('gitlab', 'org/user')).toBe('https://gitlab.com/org%2Fuser');
+  });
+});

--- a/public/app/features/provisioning/File/FileHistoryPage.tsx
+++ b/public/app/features/provisioning/File/FileHistoryPage.tsx
@@ -56,9 +56,9 @@ export default function FileHistoryPage() {
             </TextLink>
           </EmptyState>
         ) : (
-          //@ts-expect-error TODO fix history response types
           <div>
             {history.data ? (
+              //@ts-expect-error TODO fix history response types
               <HistoryView history={history.data} path={path} repo={name} repoType={repoType ?? undefined} />
             ) : (
               <Spinner />

--- a/public/app/features/provisioning/File/FileHistoryPage.tsx
+++ b/public/app/features/provisioning/File/FileHistoryPage.tsx
@@ -57,7 +57,13 @@ export default function FileHistoryPage() {
           </EmptyState>
         ) : (
           //@ts-expect-error TODO fix history response types
-          <div>{history.data ? <HistoryView history={history.data} path={path} repo={name} /> : <Spinner />}</div>
+          <div>
+            {history.data ? (
+              <HistoryView history={history.data} path={path} repo={name} repoType={repoType ?? undefined} />
+            ) : (
+              <Spinner />
+            )}
+          </div>
         )}
       </Page.Contents>
     </Page>
@@ -68,9 +74,10 @@ interface Props {
   history: HistoryListResponse;
   path: string;
   repo: string;
+  repoType?: string;
 }
 
-function HistoryView({ history, path, repo }: Props) {
+function HistoryView({ history, path, repo, repoType }: Props) {
   if (!history.items) {
     return <Trans i18nKey="provisioning.history-view.not-found">Not found</Trans>;
   }
@@ -78,31 +85,59 @@ function HistoryView({ history, path, repo }: Props) {
   return (
     <Stack direction={'column'}>
       {history.items.map((item) => (
-        <Card noMargin href={`${PROVISIONING_URL}/${repo}/file/${path}?ref=${item.ref}`} key={item.ref}>
+        <Card
+          noMargin
+          href={`${PROVISIONING_URL}/${encodeURIComponent(repo)}/file/${path}?${new URLSearchParams({ ref: item.ref }).toString()}`}
+          key={item.ref}
+        >
           <Card.Heading>{item.message}</Card.Heading>
           <Card.Meta>
             <span>{formatTimestamp(item.createdAt)}</span>
           </Card.Meta>
           <Card.Description>
             <Stack>
-              {item.authors.map((a) => (
-                <span key={a.username} style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
-                  {a.avatarURL && (
-                    <UserIcon
-                      userView={{
-                        user: { name: a.name, avatarUrl: a.avatarURL },
-                        lastActiveAt: new Date().toISOString(),
-                      }}
-                      showTooltip={false}
-                    />
-                  )}
-                  <a href={`https://github.com/${a.username}`}>{a.name}</a>
-                </span>
-              ))}
+              {item.authors.map((a) => {
+                const profileUrl = getAuthorProfileUrl(repoType, a.username);
+                return (
+                  <span key={a.username} style={{ display: 'flex', alignItems: 'center', gap: '4px' }}>
+                    {a.avatarURL && (
+                      <UserIcon
+                        userView={{
+                          user: { name: a.name, avatarUrl: a.avatarURL },
+                          lastActiveAt: new Date().toISOString(),
+                        }}
+                        showTooltip={false}
+                      />
+                    )}
+                    {profileUrl ? (
+                      <TextLink href={profileUrl} external>
+                        {a.name}
+                      </TextLink>
+                    ) : (
+                      <Text>{a.name}</Text>
+                    )}
+                  </span>
+                );
+              })}
             </Stack>
           </Card.Description>
         </Card>
       ))}
     </Stack>
   );
+}
+
+export function getAuthorProfileUrl(repoType: string | undefined, username: string): string | undefined {
+  const encoded = encodeURIComponent(username);
+  switch (repoType) {
+    case 'github':
+    case 'githubEnterprise':
+      return `https://github.com/${encoded}`;
+    case 'gitlab':
+      return `https://gitlab.com/${encoded}`;
+    case 'bitbucket':
+      return `https://bitbucket.org/${encoded}`;
+    default:
+      return undefined;
+  }
 }

--- a/public/app/features/provisioning/Repository/PullRequestButtons.test.tsx
+++ b/public/app/features/provisioning/Repository/PullRequestButtons.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from 'test/test-utils';
+
+import { PullRequestButtons } from './PullRequestButtons';
+
+describe('PullRequestButtons', () => {
+  it('sanitizes javascript: URLs from server', () => {
+    render(
+      <PullRequestButtons
+        urls={{
+          newPullRequestURL: 'javascript:alert(1)',
+          compareURL: 'javascript:alert(2)',
+          sourceURL: 'javascript:alert(3)',
+        }}
+      />
+    );
+
+    const links = screen.getAllByRole('link');
+    for (const link of links) {
+      expect(link).not.toHaveAttribute('href', expect.stringContaining('javascript:'));
+    }
+  });
+
+  it('preserves valid URLs', () => {
+    render(
+      <PullRequestButtons
+        urls={{
+          newPullRequestURL: 'https://github.com/org/repo/compare/main...branch',
+          compareURL: 'https://github.com/org/repo/compare/main...branch',
+          sourceURL: 'https://github.com/org/repo/tree/branch',
+        }}
+      />
+    );
+
+    const links = screen.getAllByRole('link');
+    expect(links[0]).toHaveAttribute('href', 'https://github.com/org/repo/tree/branch');
+    expect(links[1]).toHaveAttribute('href', 'https://github.com/org/repo/compare/main...branch');
+    expect(links[2]).toHaveAttribute('href', 'https://github.com/org/repo/compare/main...branch');
+  });
+
+  it('returns null for sync job type', () => {
+    const { container } = render(
+      <PullRequestButtons jobType="sync" urls={{ newPullRequestURL: 'https://example.com' }} />
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/public/app/features/provisioning/Repository/PullRequestButtons.tsx
+++ b/public/app/features/provisioning/Repository/PullRequestButtons.tsx
@@ -1,3 +1,4 @@
+import { textUtil } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { LinkButton, Stack } from '@grafana/ui';
 import { type RepositoryUrLs } from 'app/api/clients/provisioning/v0alpha1';
@@ -9,9 +10,9 @@ interface Props {
   urls?: RepositoryUrLs;
 }
 export function PullRequestButtons({ urls, jobType }: Props) {
-  const pullRequestURL = urls?.newPullRequestURL;
-  const compareURL = urls?.compareURL;
-  const branchURL = urls?.sourceURL;
+  const pullRequestURL = urls?.newPullRequestURL ? textUtil.sanitizeUrl(urls.newPullRequestURL) : undefined;
+  const compareURL = urls?.compareURL ? textUtil.sanitizeUrl(urls.compareURL) : undefined;
+  const branchURL = urls?.sourceURL ? textUtil.sanitizeUrl(urls.sourceURL) : undefined;
 
   if (jobType === 'sync') {
     return null;

--- a/public/app/features/provisioning/Repository/RepositoryActions.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryActions.tsx
@@ -1,3 +1,4 @@
+import { textUtil } from '@grafana/data';
 import { t, Trans } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
 import { Badge, Button, LinkButton, Stack } from '@grafana/ui';
@@ -17,7 +18,8 @@ interface RepositoryActionsProps {
 
 export function RepositoryActions({ repository }: RepositoryActionsProps) {
   const name = repository.metadata?.name ?? '';
-  const repoHref = getRepoHrefForProvider(repository.spec);
+  const rawRepoHref = getRepoHrefForProvider(repository.spec);
+  const repoHref = rawRepoHref ? textUtil.sanitizeUrl(rawRepoHref) : undefined;
   const connectionName = repository.spec?.connection?.name;
 
   const repoType = repository.spec?.type;

--- a/public/app/features/provisioning/Repository/RepositoryOverview.tsx
+++ b/public/app/features/provisioning/Repository/RepositoryOverview.tsx
@@ -2,7 +2,7 @@ import { css, cx } from '@emotion/css';
 import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { useMemo } from 'react';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import { textUtil, type GrafanaTheme2 } from '@grafana/data';
 import { Trans } from '@grafana/i18n';
 import { Box, Card, type CellProps, Grid, InteractiveTable, LinkButton, Stack, Text, useStyles2 } from '@grafana/ui';
 import { type Repository, type ResourceCount } from 'app/api/clients/provisioning/v0alpha1';
@@ -214,7 +214,7 @@ const getStyles = (theme: GrafanaTheme2) => {
 function getWebhookURL(repo: Repository) {
   const { status, spec } = repo;
   if (spec?.type === 'github' && status?.webhook?.url && spec.github?.url) {
-    return `${spec.github.url}/settings/hooks/${status.webhook?.id}`;
+    return textUtil.sanitizeUrl(`${spec.github.url}/settings/hooks/${status.webhook?.id}`);
   }
   return undefined;
 }

--- a/public/app/features/provisioning/Repository/ResourceTreeView.tsx
+++ b/public/app/features/provisioning/Repository/ResourceTreeView.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/css';
 import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { useMemo, useState } from 'react';
 
-import { type GrafanaTheme2 } from '@grafana/data';
+import { textUtil, type GrafanaTheme2 } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import {
   type CellProps,
@@ -161,13 +161,14 @@ export function ResourceTreeView({ repo }: ResourceTreeViewProps) {
             const spec = repo.spec;
             const config = spec.github || spec.gitlab || spec.bitbucket;
             if (config) {
-              sourceLink = getRepoFileUrl({
+              const rawSourceLink = getRepoFileUrl({
                 repoType: spec.type,
                 url: config.url,
                 branch: config.branch,
                 filePath: item.path,
                 pathPrefix: config.path,
               });
+              sourceLink = rawSourceLink ? textUtil.sanitizeUrl(rawSourceLink) : undefined;
             }
           }
 

--- a/public/app/features/provisioning/components/Dashboards/DashboardPreviewBanner.test.tsx
+++ b/public/app/features/provisioning/components/Dashboards/DashboardPreviewBanner.test.tsx
@@ -52,7 +52,7 @@ interface PullRequestParamReturn {
   prURL?: string;
   newPrURL?: string;
   repoURL?: string;
-  repoType?: string;
+  repoType?: 'github' | 'githubEnterprise' | 'gitlab' | 'bitbucket' | 'git' | 'local';
 }
 
 interface FileQueryData {

--- a/public/app/features/provisioning/components/Folders/FolderReadmePanel.test.tsx
+++ b/public/app/features/provisioning/components/Folders/FolderReadmePanel.test.tsx
@@ -215,4 +215,17 @@ describe('FolderReadmePanel', () => {
     expect(screen.getByRole('link', { name: /Edit README/i })).toBeInTheDocument();
     expect(screen.queryByRole('link', { name: /Add README/i })).not.toBeInTheDocument();
   });
+
+  it('sanitizes mXSS payloads in README markdown', () => {
+    setReadmeResult({
+      markdownContent: '<div><svg><style><img src=x onerror=alert(1)></style></svg></div>',
+    });
+
+    const { container } = setup();
+    const markdownDiv = container.querySelector('.markdown-html');
+    expect(markdownDiv).not.toBeNull();
+    // DOMPurify strips the dangerous elements
+    expect(markdownDiv!.querySelector('img[onerror]')).toBeNull();
+    expect(markdownDiv!.innerHTML).not.toContain('onerror');
+  });
 });

--- a/public/app/features/provisioning/components/Folders/FolderReadmePanel.tsx
+++ b/public/app/features/provisioning/components/Folders/FolderReadmePanel.tsx
@@ -3,7 +3,7 @@ import { useBooleanFlagValue } from '@openfeature/react-sdk';
 import { useEffect, useRef } from 'react';
 import { useIntersection } from 'react-use';
 
-import { type GrafanaTheme2, renderMarkdown } from '@grafana/data';
+import { type GrafanaTheme2, renderMarkdown, textUtil } from '@grafana/data';
 import { Trans, t } from '@grafana/i18n';
 import { Alert, Button, Icon, LinkButton, Stack, Text, useStyles2 } from '@grafana/ui';
 import { type RepositoryView } from 'app/api/clients/provisioning/v0alpha1';
@@ -172,6 +172,7 @@ function RenderedMarkdown({
 }) {
   const html = renderMarkdown(markdown);
   const rewritten = rewriteRelativeMarkdownLinks(html, { repository, baseDirInRepo });
+  const safe = textUtil.sanitize(rewritten);
   const containerRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -188,7 +189,7 @@ function RenderedMarkdown({
     return () => el.removeEventListener('click', handleClick);
   }, [repositoryType]);
 
-  return <div ref={containerRef} className="markdown-html" dangerouslySetInnerHTML={{ __html: rewritten }} />;
+  return <div ref={containerRef} className="markdown-html" dangerouslySetInnerHTML={{ __html: safe }} />;
 }
 
 /**

--- a/public/app/features/provisioning/hooks/usePullRequestParam.test.ts
+++ b/public/app/features/provisioning/hooks/usePullRequestParam.test.ts
@@ -1,0 +1,103 @@
+import { renderHook } from 'test/test-utils';
+
+import { useUrlParams } from 'app/core/navigation/hooks';
+
+import { usePullRequestParam } from './usePullRequestParam';
+
+jest.mock('app/core/navigation/hooks');
+
+const mockUseUrlParams = useUrlParams as jest.MockedFunction<typeof useUrlParams>;
+
+function setParams(params: Record<string, string>) {
+  const searchParams = new URLSearchParams(params);
+  mockUseUrlParams.mockReturnValue([searchParams, jest.fn()]);
+}
+
+describe('usePullRequestParam', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setParams({});
+  });
+
+  describe('repoType', () => {
+    it('returns valid repo type', () => {
+      setParams({ repo_type: 'github' });
+      const { result } = renderHook(() => usePullRequestParam());
+      expect(result.current.repoType).toBe('github');
+    });
+
+    it('returns undefined for invalid repo type', () => {
+      setParams({ repo_type: 'javascript:alert(1)' });
+      const { result } = renderHook(() => usePullRequestParam());
+      expect(result.current.repoType).toBeUndefined();
+    });
+
+    it('returns undefined for empty repo type', () => {
+      setParams({});
+      const { result } = renderHook(() => usePullRequestParam());
+      expect(result.current.repoType).toBeUndefined();
+    });
+  });
+
+  describe('resourcePushedTo', () => {
+    it('returns valid k8s name', () => {
+      setParams({ resource_pushed_to: 'my-repo-123' });
+      const { result } = renderHook(() => usePullRequestParam());
+      expect(result.current.resourcePushedTo).toBe('my-repo-123');
+    });
+
+    it('rejects names with invalid characters', () => {
+      setParams({ resource_pushed_to: 'INVALID_NAME' });
+      const { result } = renderHook(() => usePullRequestParam());
+      expect(result.current.resourcePushedTo).toBeUndefined();
+    });
+
+    it('rejects names starting with hyphen', () => {
+      setParams({ resource_pushed_to: '-bad-name' });
+      const { result } = renderHook(() => usePullRequestParam());
+      expect(result.current.resourcePushedTo).toBeUndefined();
+    });
+
+    it('returns undefined when param is missing', () => {
+      setParams({});
+      const { result } = renderHook(() => usePullRequestParam());
+      expect(result.current.resourcePushedTo).toBeUndefined();
+    });
+  });
+
+  describe('URL fields', () => {
+    it('sanitizes javascript: URLs', () => {
+      setParams({
+        pull_request_url: 'javascript:alert(1)',
+        new_pull_request_url: 'javascript:alert(2)',
+        repo_url: 'javascript:alert(3)',
+      });
+      const { result } = renderHook(() => usePullRequestParam());
+      expect(result.current.prURL).toBe('about:blank');
+      expect(result.current.newPrURL).toBe('about:blank');
+      expect(result.current.repoURL).toBe('about:blank');
+    });
+
+    it('preserves valid URLs', () => {
+      setParams({
+        pull_request_url: 'https://github.com/org/repo/pull/1',
+      });
+      const { result } = renderHook(() => usePullRequestParam());
+      expect(result.current.prURL).toBe('https://github.com/org/repo/pull/1');
+    });
+  });
+
+  describe('action', () => {
+    it('accepts valid actions', () => {
+      setParams({ action: 'create' });
+      const { result } = renderHook(() => usePullRequestParam());
+      expect(result.current.action).toBe('create');
+    });
+
+    it('rejects invalid actions', () => {
+      setParams({ action: 'malicious' });
+      const { result } = renderHook(() => usePullRequestParam());
+      expect(result.current.action).toBeUndefined();
+    });
+  });
+});

--- a/public/app/features/provisioning/hooks/usePullRequestParam.ts
+++ b/public/app/features/provisioning/hooks/usePullRequestParam.ts
@@ -1,6 +1,10 @@
 import { textUtil } from '@grafana/data';
 import { useUrlParams } from 'app/core/navigation/hooks';
 
+import { isValidRepoType } from '../guards';
+
+const K8S_NAME_RE = /^[a-z0-9][a-z0-9-]{0,252}$/;
+
 export const usePullRequestParam = () => {
   const [params] = useUrlParams();
   const prParam = params.get('pull_request_url');
@@ -9,14 +13,16 @@ export const usePullRequestParam = () => {
   const repoType = params.get('repo_type');
   const resourcePushedTo = params.get('resource_pushed_to');
   const actionParam = params.get('action');
+  const decodedRepoType = repoType ? decodeURIComponent(repoType) : undefined;
+  const decodedResourcePushedTo = resourcePushedTo ? decodeURIComponent(resourcePushedTo) : undefined;
 
   return {
     prURL: prParam ? textUtil.sanitizeUrl(decodeURIComponent(prParam)) : undefined,
     newPrURL: newPrParam ? textUtil.sanitizeUrl(decodeURIComponent(newPrParam)) : undefined,
     repoURL: repoUrl ? textUtil.sanitizeUrl(decodeURIComponent(repoUrl)) : undefined,
-    repoType: repoType ? textUtil.sanitizeUrl(decodeURIComponent(repoType)) : undefined,
-    // Repository name the resource was pushed to, used to link to its status overview page
-    resourcePushedTo: resourcePushedTo ? textUtil.sanitizeUrl(decodeURIComponent(resourcePushedTo)) : undefined,
+    repoType: isValidRepoType(decodedRepoType) ? decodedRepoType : undefined,
+    resourcePushedTo:
+      decodedResourcePushedTo && K8S_NAME_RE.test(decodedResourcePushedTo) ? decodedResourcePushedTo : undefined,
     action: actionParam === 'create' || actionParam === 'delete' || actionParam === 'update' ? actionParam : undefined,
   };
 };


### PR DESCRIPTION
**What is this feature?**

Hardens the provisioning frontend (`public/app/features/provisioning/`) against five security findings: mXSS in README rendering, unsanitized URLs flowing into `LinkButton`/`window.open`, a hardcoded GitHub profile link that is wrong for non-GitHub providers, URL parameters interpolated without encoding, and `sanitizeUrl` misapplied to non-URL values.

**Special notes for your reviewer:**

Five findings addressed in a single commit, grouped for defense-in-depth review:

1. **P0 — mXSS in README rendering** (`FolderReadmePanel.tsx`): Added `textUtil.sanitize()` (DOMPurify) after `rewriteRelativeMarkdownLinks()` to re-sanitize HTML before `dangerouslySetInnerHTML`. The existing `renderMarkdown()` sanitizes via the `xss` lib, but the subsequent DOM round-trip through `rewriteRelativeMarkdownLinks` can mutate HTML into executable content.

2. **P0 — Unsanitized URLs in LinkButton/window.open** (4 files): Wrapped server-sourced URLs with `textUtil.sanitizeUrl()` in `PullRequestButtons`, `RepositoryOverview` (webhook URL), `RepositoryActions` (repo href via `window.open`), and `ResourceTreeView` (source link).

3. **P1 — Hardcoded GitHub profile link** (`FileHistoryPage.tsx`): Replaced the hardcoded `github.com/{username}` link with a provider-aware helper (`getAuthorProfileUrl`) that returns the correct profile URL for GitHub/GitLab/Bitbucket, encodes the username, and falls back to plain text for unknown providers. Uses `TextLink` (auto-sanitizes) instead of raw `<a>`.

4. **P2 — URL params without encoding** (`FileHistoryPage.tsx`): `item.ref` is now encoded via `URLSearchParams` and `repo` via `encodeURIComponent`.

5. **P2 — sanitizeUrl on non-URLs** (`usePullRequestParam.ts`): `repoType` is now validated with `isValidRepoType()` guard. `resourcePushedTo` is validated against a k8s resource name regex. URL fields still use `sanitizeUrl`.
