### PR TITLE
storage/unified: migrate Masterminds/semver v1 to v3

### DIFF
--- a/apps/quotas/go.mod
+++ b/apps/quotas/go.mod
@@ -79,7 +79,6 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.55.0 // indirect
 	github.com/Machiel/slugify v1.0.1 // indirect
 	github.com/Masterminds/goutils v1.1.1 // indirect
-	github.com/Masterminds/semver v1.5.0 // indirect
 	github.com/Masterminds/semver/v3 v3.4.0 // indirect
 	github.com/Masterminds/sprig/v3 v3.3.0 // indirect
 	github.com/ProtonMail/go-crypto v1.4.1 // indirect

--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/hashicorp/golang-lru/v2/expirable"
 	gocache "github.com/patrickmn/go-cache"
 	"go.opentelemetry.io/otel/attribute"

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/grafana/authlib/types"

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -11,7 +11,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/bwmarrin/snowflake"
 	"github.com/google/uuid"
 	"github.com/prometheus/client_golang/prometheus"

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -17,7 +17,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/blevesearch/bleve/v2"
 	"github.com/blevesearch/bleve/v2/analysis/analyzer/standard"
 	"github.com/blevesearch/bleve/v2/mapping"

--- a/pkg/storage/unified/search/bleve_snapshot.go
+++ b/pkg/storage/unified/search/bleve_snapshot.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/blevesearch/bleve/v2"
 	"github.com/blevesearch/bleve/v2/index/scorch"
 	"github.com/oklog/ulid/v2"

--- a/pkg/storage/unified/search/bleve_snapshot_test.go
+++ b/pkg/storage/unified/search/bleve_snapshot_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/blevesearch/bleve/v2"
 	"github.com/oklog/ulid/v2"
 	"github.com/prometheus/client_golang/prometheus"

--- a/pkg/storage/unified/search/options.go
+++ b/pkg/storage/unified/search/options.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/oklog/ulid/v2"
 	"gocloud.dev/blob"
 

--- a/pkg/storage/unified/search/options_test.go
+++ b/pkg/storage/unified/search/options_test.go
@@ -33,6 +33,11 @@ func TestBuildVersionParsing(t *testing.T) {
 		{input: "11.5.0+meta", wantOK: true, wantNorm: "11.5.0+meta"},
 		{input: "v11.5.0", wantOK: true, wantNorm: "11.5.0"}, // v-prefix is stripped
 		{input: "11.5", wantOK: true, wantNorm: "11.5.0"},    // missing patch is filled in
+		// Real build versions seen in production.
+		{input: "13.1.0-ephemeral-enterprise-11758-10265-1", wantOK: true, wantNorm: "13.1.0-ephemeral-enterprise-11758-10265-1"},
+		{input: "13.1.0-ephemeral-oss-123137-102418-1", wantOK: true, wantNorm: "13.1.0-ephemeral-oss-123137-102418-1"},
+		{input: "13.0.0-23069273608.patch13", wantOK: true, wantNorm: "13.0.0-23069273608.patch13"},
+		{input: "13.1.0-25901809875", wantOK: true, wantNorm: "13.1.0-25901809875"},
 		{input: "dev", wantOK: false},
 		{input: "main", wantOK: false},
 		{input: "a1b2c3d4", wantOK: false}, // git SHA-like

--- a/pkg/storage/unified/search/options_test.go
+++ b/pkg/storage/unified/search/options_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -15,6 +16,40 @@ import (
 	"github.com/grafana/grafana/pkg/setting"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
 )
+
+// Anchors what semver.NewVersion accepts for the strings we feed it from
+// cfg.BuildVersion / cfg.MinFileIndexBuildVersion (options.go) and from snapshot
+// metadata (bleve_snapshot.go, remote_index_cleanup.go). Parsing failures are
+// not fatal at call sites — they fall back to nil — but a change here would
+// quietly hide or expose snapshots, so it's worth pinning.
+func TestBuildVersionParsing(t *testing.T) {
+	tests := []struct {
+		input    string
+		wantOK   bool
+		wantNorm string // expected v.String() when wantOK
+	}{
+		{input: "11.5.0", wantOK: true, wantNorm: "11.5.0"},
+		{input: "11.5.0-pre1", wantOK: true, wantNorm: "11.5.0-pre1"},
+		{input: "11.5.0+meta", wantOK: true, wantNorm: "11.5.0+meta"},
+		{input: "v11.5.0", wantOK: true, wantNorm: "11.5.0"}, // v-prefix is stripped
+		{input: "11.5", wantOK: true, wantNorm: "11.5.0"},    // missing patch is filled in
+		{input: "dev", wantOK: false},
+		{input: "main", wantOK: false},
+		{input: "a1b2c3d4", wantOK: false}, // git SHA-like
+	}
+	for _, tc := range tests {
+		t.Run(tc.input, func(t *testing.T) {
+			v, err := semver.NewVersion(tc.input)
+			if tc.wantOK {
+				require.NoError(t, err)
+				require.NotNil(t, v)
+				assert.Equal(t, tc.wantNorm, v.String())
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}
 
 func TestSnapshotLockHeartbeat(t *testing.T) {
 	tests := []struct {

--- a/pkg/storage/unified/search/remote_index_cleanup.go
+++ b/pkg/storage/unified/search/remote_index_cleanup.go
@@ -9,7 +9,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/oklog/ulid/v2"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"

--- a/pkg/storage/unified/search/remote_index_cleanup_test.go
+++ b/pkg/storage/unified/search/remote_index_cleanup_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Masterminds/semver"
+	"github.com/Masterminds/semver/v3"
 	"github.com/oklog/ulid/v2"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/testutil"


### PR DESCRIPTION
Switches `pkg/storage/unified/search` and `pkg/storage/unified/resource` from `github.com/Masterminds/semver` (v1) to `github.com/Masterminds/semver/v3`. The API surface we use (`NewVersion`, `MustParse`, `Version`, `Compare`, `String`) is source-compatible, so no call-site code was touched — just the import path.

Both packages move together because `resource` exports types (`IndexBuildInfo.BuildVersion`, `BleveOptions.MinBuildVersion`/`BuildVersion`) that `search` consumes.

v3 is slightly stricter than v1 around parsing. The string-input call sites (`cfg.BuildVersion`, `cfg.MinFileIndexBuildVersion`, and `BuildVersion` from snapshot metadata) already fall back to `nil` on parse error, so the worst case is an older snapshot with an oddly-formatted build version becoming invisible to the picker. Added `TestBuildVersionParsing` to pin the accept/reject behaviour for the input shapes we realistically see.

The v1 require line stays in `go.mod` because `pkg/services/pluginsintegration/pluginchecker` and `pkg/services/rendering/capabilities` still import it. Happy to file a follow-up issue for their owners.