### PR TITLE
Unified storage: add fuzz tests for dashboard parsers and Bleve query builder

### DIFF
--- a/pkg/services/store/kind/dashboard/fuzz_test.go
+++ b/pkg/services/store/kind/dashboard/fuzz_test.go
@@ -1,0 +1,63 @@
+package dashboard
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// fuzzNopLookup is a do-nothing DatasourceLookup. Returning nil from both
+// methods is safe for the parser: the few call sites that consume the
+// result check for nil. We don't need real datasource resolution to
+// exercise the JSON walker.
+type fuzzNopLookup struct{}
+
+func (fuzzNopLookup) ByRef(*DataSourceRef) *DataSourceRef { return nil }
+func (fuzzNopLookup) ByType(string) []DataSourceRef       { return nil }
+
+// FuzzReadDashboard fuzzes the streaming dashboard JSON walker. The walker
+// type-switches on every field and accepts several polymorphic shapes, so
+// the goal is to flush out panics, unbounded recursion, and divergence
+// bugs on adversarial input.
+//
+// Invariant: must not panic. Any error is acceptable.
+func FuzzReadDashboard(f *testing.F) {
+	seedDirs := []string{
+		"testdata",
+		"../../../../storage/unified/search/testdata",
+		"../../../../storage/unified/search/embed/dashboard/testdata",
+	}
+	for _, dir := range seedDirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if e.IsDir() || filepath.Ext(e.Name()) != ".json" {
+				continue
+			}
+			// *-info.json files are golden outputs from existing tests,
+			// not parser inputs.
+			if strings.HasSuffix(e.Name(), "-info.json") {
+				continue
+			}
+			data, err := os.ReadFile(filepath.Join(dir, e.Name()))
+			if err != nil {
+				continue
+			}
+			f.Add(data)
+		}
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		// Cap input size. Real dashboards are well under a megabyte and an
+		// uncapped fuzzer happily spends time on multi-MB inputs that
+		// don't exercise new paths.
+		if len(data) > 1<<20 {
+			t.Skip()
+		}
+		_, _ = ReadDashboard(bytes.NewReader(data), fuzzNopLookup{})
+	})
+}

--- a/pkg/services/store/kind/dashboard/fuzz_test.go
+++ b/pkg/services/store/kind/dashboard/fuzz_test.go
@@ -29,6 +29,7 @@ func FuzzReadDashboard(f *testing.F) {
 		"../../../../storage/unified/search/testdata",
 		"../../../../storage/unified/search/embed/dashboard/testdata",
 	}
+	seedCount := 0
 	for _, dir := range seedDirs {
 		entries, err := os.ReadDir(dir)
 		if err != nil {
@@ -43,12 +44,19 @@ func FuzzReadDashboard(f *testing.F) {
 			if strings.HasSuffix(e.Name(), "-info.json") {
 				continue
 			}
+			// nolint:gosec // G304: paths come from a hard-coded list of
+			// seed directories joined with names read from those
+			// directories, not user input.
 			data, err := os.ReadFile(filepath.Join(dir, e.Name()))
 			if err != nil {
 				continue
 			}
 			f.Add(data)
+			seedCount++
 		}
+	}
+	if seedCount == 0 {
+		f.Fatalf("no seeds loaded; seed paths may have moved: %v", seedDirs)
 	}
 
 	f.Fuzz(func(t *testing.T, data []byte) {

--- a/pkg/services/store/kind/dashboard/fuzz_test.go
+++ b/pkg/services/store/kind/dashboard/fuzz_test.go
@@ -33,7 +33,7 @@ func FuzzReadDashboard(f *testing.F) {
 	for _, dir := range seedDirs {
 		entries, err := os.ReadDir(dir)
 		if err != nil {
-			continue
+			f.Fatalf("read seed dir %q: %v (did seed paths move?)", dir, err)
 		}
 		for _, e := range entries {
 			if e.IsDir() || filepath.Ext(e.Name()) != ".json" {

--- a/pkg/services/store/kind/dashboard/fuzz_test.go
+++ b/pkg/services/store/kind/dashboard/fuzz_test.go
@@ -23,6 +23,17 @@ func (fuzzNopLookup) ByType(string) []DataSourceRef       { return nil }
 // bugs on adversarial input.
 //
 // Invariant: must not panic. Any error is acceptable.
+//
+// Coverage caveat: Go's built-in fuzzer is format-agnostic and mutates
+// inputs at the byte level. On a deeply structured format like dashboard
+// JSON, most mutations break the document early and the parser bails
+// before reading any field, so deep grammar paths (panels, datasources,
+// template variables, v1/v2 polymorphism, recursive spec descent) are
+// rarely reached. This target is most useful for catching panics on
+// shallow inputs and as a regression harness against the seed corpus.
+// Comprehensive deep-grammar coverage would need a structure-aware
+// mutator (e.g. gosentry) or hand-written dashboard generators, tracked
+// as follow-ups.
 func FuzzReadDashboard(f *testing.F) {
 	seedDirs := []string{
 		"testdata",

--- a/pkg/storage/unified/search/embed/dashboard/fuzz_test.go
+++ b/pkg/storage/unified/search/embed/dashboard/fuzz_test.go
@@ -26,7 +26,7 @@ func FuzzExtractDashboard(f *testing.F) {
 	for _, dir := range seedDirs {
 		entries, err := os.ReadDir(dir)
 		if err != nil {
-			continue
+			f.Fatalf("read seed dir %q: %v (did seed paths move?)", dir, err)
 		}
 		for _, e := range entries {
 			if e.IsDir() || filepath.Ext(e.Name()) != ".json" {

--- a/pkg/storage/unified/search/embed/dashboard/fuzz_test.go
+++ b/pkg/storage/unified/search/embed/dashboard/fuzz_test.go
@@ -16,6 +16,13 @@ import (
 // the streaming ReadDashboard parser.
 //
 // Invariant: must not panic. Any error is acceptable.
+//
+// Coverage caveat: same as FuzzReadDashboard. Go's built-in fuzzer
+// mutates at the byte level, so most inputs fail to deserialize and the
+// deeper walker paths are rarely reached. This target is most useful for
+// catching panics on shallow inputs and as a regression harness against
+// the seed corpus. Structure-aware mutation (e.g. gosentry) is tracked
+// as a follow-up.
 func FuzzExtractDashboard(f *testing.F) {
 	seedDirs := []string{
 		"testdata",

--- a/pkg/storage/unified/search/embed/dashboard/fuzz_test.go
+++ b/pkg/storage/unified/search/embed/dashboard/fuzz_test.go
@@ -22,6 +22,7 @@ func FuzzExtractDashboard(f *testing.F) {
 		"../../testdata",
 		"../../../../../services/store/kind/dashboard/testdata",
 	}
+	seedCount := 0
 	for _, dir := range seedDirs {
 		entries, err := os.ReadDir(dir)
 		if err != nil {
@@ -34,12 +35,19 @@ func FuzzExtractDashboard(f *testing.F) {
 			if strings.HasSuffix(e.Name(), "-info.json") {
 				continue
 			}
+			// nolint:gosec // G304: paths come from a hard-coded list of
+			// seed directories joined with names read from those
+			// directories, not user input.
 			data, err := os.ReadFile(filepath.Join(dir, e.Name()))
 			if err != nil {
 				continue
 			}
 			f.Add(data)
+			seedCount++
 		}
+	}
+	if seedCount == 0 {
+		f.Fatalf("no seeds loaded; seed paths may have moved: %v", seedDirs)
 	}
 
 	e := New()

--- a/pkg/storage/unified/search/embed/dashboard/fuzz_test.go
+++ b/pkg/storage/unified/search/embed/dashboard/fuzz_test.go
@@ -1,0 +1,57 @@
+package dashboard
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+)
+
+// FuzzExtractDashboard fuzzes the second, independent dashboard JSON
+// parser used to build embeddings. It walks v1 and v2 dashboard shapes
+// via map[string]any and jsonpath helpers; a different bug surface than
+// the streaming ReadDashboard parser.
+//
+// Invariant: must not panic. Any error is acceptable.
+func FuzzExtractDashboard(f *testing.F) {
+	seedDirs := []string{
+		"testdata",
+		"../../testdata",
+		"../../../../../services/store/kind/dashboard/testdata",
+	}
+	for _, dir := range seedDirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if e.IsDir() || filepath.Ext(e.Name()) != ".json" {
+				continue
+			}
+			if strings.HasSuffix(e.Name(), "-info.json") {
+				continue
+			}
+			data, err := os.ReadFile(filepath.Join(dir, e.Name()))
+			if err != nil {
+				continue
+			}
+			f.Add(data)
+		}
+	}
+
+	e := New()
+	key := &resourcepb.ResourceKey{
+		Namespace: "default",
+		Name:      "fuzz",
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		if len(data) > 1<<20 {
+			t.Skip()
+		}
+		_, _ = e.Extract(context.Background(), key, data, "")
+	})
+}

--- a/pkg/storage/unified/search/fuzz_test.go
+++ b/pkg/storage/unified/search/fuzz_test.go
@@ -1,0 +1,61 @@
+package search
+
+import (
+	"testing"
+
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
+)
+
+// FuzzBleveRequirementQuery exercises the Bleve query construction path
+// for selector requirements. The function has branchy handling around
+// operator dispatch, wildcards, term splitting, title-vs-other fields,
+// and value-list semantics, so it is a good target for coverage-guided
+// fuzzing.
+//
+// Invariants:
+//   - Must not panic.
+//   - Each return path produces exactly one of (query, error). The fuzzer
+//     fails if both are nil or both are non-nil.
+func FuzzBleveRequirementQuery(f *testing.F) {
+	// Seed with shapes that cover the main switch arms.
+	seeds := []struct {
+		key, op, v1, v2, prefix string
+		n                       byte
+	}{
+		{"title", "=", "hello", "", "", 1},
+		{"title", "==", "hello world", "", "", 1},
+		{"title", "=", "hell*", "", "", 1},
+		{"title", "=", "*grafana*", "", "", 1},
+		{"title", "in", "a", "b", "", 2},
+		{"title", "notin", "a", "b", "", 2},
+		{"folder", "=", "general", "", "tenant-", 1},
+		{"tags", "=", "prod", "", "", 1},
+		{"login", "=", "user", "", "", 1},
+		{"email", "=", "u@x", "", "", 1},
+		{"title", "=", "a b c d", "", "", 1},
+		{"", "", "", "", "", 0},
+	}
+	for _, s := range seeds {
+		f.Add(s.key, s.op, s.v1, s.v2, s.prefix, s.n)
+	}
+
+	f.Fuzz(func(t *testing.T, key, op, v1, v2, prefix string, n byte) {
+		var values []string
+		switch n % 3 {
+		case 1:
+			values = []string{v1}
+		case 2:
+			values = []string{v1, v2}
+		}
+		req := &resourcepb.Requirement{
+			Key:      key,
+			Operator: op,
+			Values:   values,
+		}
+		q, errRes := requirementQuery(req, prefix)
+		if (q == nil) == (errRes == nil) {
+			t.Fatalf("query/err invariant violated: query=%v err=%v for req=%+v prefix=%q",
+				q, errRes, req, prefix)
+		}
+	})
+}


### PR DESCRIPTION
Adds three Go stdlib fuzz targets for high-value parsers in unified storage. Each one runs its seed corpus as a normal test under `go test`, so it costs nothing in CI; coverage-guided fuzzing is opt-in via `-fuzz=...`.

**What's fuzzed**

- `FuzzReadDashboard` (`pkg/services/store/kind/dashboard`) — the streaming `jsoniter` dashboard walker used by the indexer. Invariant: no panic.
- `FuzzExtractDashboard` (`pkg/storage/unified/search/embed/dashboard`) — the independent `map[string]any` walker used to build embeddings. Different bug surface from the streaming parser. Invariant: no panic.
- `FuzzBleveRequirementQuery` (`pkg/storage/unified/search`) — selector-`Requirement` to Bleve `query.Query` translation, including wildcard / term-splitting / title-field branches. Invariant: every return path produces exactly one of `(query, error)`.

Seed corpora are built from the existing `testdata/` directories under each package, so the seeds are realistic dashboards and golden inputs we already trust.

**How it runs**

- `go test ./...` — runs the seed corpora as regression tests. No extra CI wiring needed.
- `go test -fuzz=FuzzReadDashboard -fuzztime=5m ./pkg/services/store/kind/dashboard/` — coverage-guided run. Same shape for the other two targets.
- Any failing input gets saved by Go under `testdata/fuzz/<FuncName>/` and becomes a permanent regression seed.

**Validation**

Each target ran for 5 minutes locally with no crashes and no new corpus entries.

Additional targets (continue-token, snapshot manifest validation, key parsers, differential dashboard fuzzer) will follow in separate PRs.
