### PR TITLE
Tests: Make frontend test coverage CI check optional according to policy-bot

### DIFF
--- a/.policy.yml
+++ b/.policy.yml
@@ -151,6 +151,7 @@ approval_rules:
           conclusions:
             - skipped
             - success
+            - failure
           workflows:
             - .github/workflows/check-frontend-test-coverage.yml
   - name: Workflow .github/workflows/codeowners-validator.yml succeeded or skipped

--- a/Makefile
+++ b/Makefile
@@ -851,3 +851,5 @@ GENERATE_POLICY_BOT_CONFIG_SHA := sha256:d05ff5c7d4247da155c85f8c6f1f9f7c6d013d1
 	sed -i.bak '/- Workflow \.github\/workflows\/create-security-patch-from-security-mirror/d' .policy.yml; rm -f .policy.yml.bak
 # Make govulncheck non-blocking - accept failure so it doesn't prevent merge
 	sed -i.bak '/name: Workflow \.github\/workflows\/govulncheck\.yml/,/workflows:/{s/- success/- success\n            - failure/;}' .policy.yml; rm -f .policy.yml.bak
+# Make check-frontend-test-coverage non-blocking - accept failure so it doesn't prevent merge
+	sed -i.bak '/name: Workflow \.github\/workflows\/check-frontend-test-coverage\.yml/,/workflows:/{s/- success/- success\n            - failure/;}' .policy.yml; rm -f .policy.yml.bak


### PR DESCRIPTION
This change makes the frontend test coverage CI check optional instead of mandatory according to  our policy bot.