### PR TITLE
search: periodic on-disk cleanup of stale bleve index folders

### DIFF
--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -678,6 +678,9 @@ type Cfg struct {
 	IndexSnapshotThreshold                     int           // Min doc count to use remote snapshots (must be >= IndexFileThreshold, default: 5000)
 	IndexSnapshotMaxAge                        time.Duration // Max snapshot age before deletion (must be >= MaxFileIndexAge, default: 7d)
 	IndexSnapshotCleanupGracePeriod            time.Duration // Time a new snapshot must exist before its predecessor in the same Grafana-version group is eligible for cleanup (default: 30m)
+	DiskIndexCleanupInterval                   time.Duration // How often to scan the bleve index root for folders to reclaim. Zero disables the loop (default: 0).
+	DiskIndexCleanupGracePeriod                time.Duration // Minimum age a candidate folder must have before disk cleanup is allowed to delete it (default: 1h).
+	DiskIndexCleanupUnopenedGracePeriod        time.Duration // Longer grace applied to the newest on-disk index of a resource this pod owns but has not opened. Lets cold-start BuildIndex reuse it instead of rebuilding from scratch (default: 24h).
 	EnableSharding                             bool
 	QOSEnabled                                 bool
 	QOSNumberWorker                            int

--- a/pkg/setting/setting_unified_storage.go
+++ b/pkg/setting/setting_unified_storage.go
@@ -273,6 +273,16 @@ func (cfg *Cfg) setUnifiedStorageConfig() {
 	}
 	cfg.IndexSnapshotCleanupGracePeriod = section.Key("index_snapshot_cleanup_grace_period").MustDuration(30 * time.Minute)
 
+	// Periodic on-disk cleanup of leftover bleve index folders.
+	// disk_index_cleanup_interval = 0 disables the loop (default).
+	cfg.DiskIndexCleanupInterval = section.Key("disk_index_cleanup_interval").MustDuration(0)
+	cfg.DiskIndexCleanupGracePeriod = section.Key("disk_index_cleanup_grace_period").MustDuration(time.Hour)
+	// disk_index_cleanup_unopened_grace_period only applies to the newest on-disk
+	// index for a resource this pod owns but has not opened in this process.
+	// Keeping it longer lets a later BuildIndex for that resource reuse the
+	// existing index instead of rebuilding from scratch.
+	cfg.DiskIndexCleanupUnopenedGracePeriod = section.Key("disk_index_cleanup_unopened_grace_period").MustDuration(24 * time.Hour)
+
 	// Vector storage (separate pgvector database)
 	vectorSection := cfg.Raw.Section("database_vector")
 	cfg.VectorDBHost = vectorSection.Key("db_host").String()

--- a/pkg/storage/unified/resource/bleve_index_metrics.go
+++ b/pkg/storage/unified/resource/bleve_index_metrics.go
@@ -30,6 +30,9 @@ type BleveIndexMetrics struct {
 	IndexSnapshotNamespaceCleanups        *prometheus.CounterVec
 	IndexSnapshotDeleted                  *prometheus.CounterVec
 	IndexSnapshotIncompleteUploadsCleaned prometheus.Counter
+
+	IndexDiskCleanupRuns        *prometheus.CounterVec
+	IndexDiskCleanupDirsDeleted *prometheus.CounterVec
 }
 
 var IndexCreationBuckets = []float64{1, 5, 10, 25, 50, 75, 100, 200, 300, 400, 500, 600, 700, 800, 900, 1000}
@@ -138,6 +141,14 @@ func ProvideIndexMetrics(reg prometheus.Registerer) *BleveIndexMetrics {
 			Name: "index_server_snapshot_incomplete_uploads_cleaned_total",
 			Help: "Number of incomplete (partial) index snapshots deleted by cleanup.",
 		}),
+		IndexDiskCleanupRuns: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "index_server_disk_cleanup_runs_total",
+			Help: "Number of on-disk index cleanup pass attempts, by outcome.",
+		}, []string{"outcome"}), // outcome: success, error
+		IndexDiskCleanupDirsDeleted: promauto.With(reg).NewCounterVec(prometheus.CounterOpts{
+			Name: "index_server_disk_cleanup_dirs_deleted_total",
+			Help: "Number of on-disk directories the disk cleanup pass attempted to delete, by kind and outcome.",
+		}, []string{"kind", "outcome"}), // kind: index, snapshot_staging. outcome: success, error
 	}
 
 	// Always-on label series. Snapshot-specific series are initialised separately
@@ -184,4 +195,20 @@ func (m *BleveIndexMetrics) InitSnapshotMetrics() {
 	m.IndexSnapshotDeleted.WithLabelValues("success").Add(0)
 	m.IndexSnapshotDeleted.WithLabelValues("error").Add(0)
 	m.IndexSnapshotIncompleteUploadsCleaned.Add(0)
+}
+
+// InitDiskCleanupMetrics zero-initialises the per-label series of the disk
+// cleanup counters. Call once at startup only when the disk cleanup loop is
+// configured to run on this instance, so disabled instances don't emit
+// permanently-zero `index_server_disk_cleanup_*` series.
+func (m *BleveIndexMetrics) InitDiskCleanupMetrics() {
+	if m == nil {
+		return
+	}
+	m.IndexDiskCleanupRuns.WithLabelValues("success").Add(0)
+	m.IndexDiskCleanupRuns.WithLabelValues("error").Add(0)
+	for _, kind := range []string{"index", "snapshot_staging"} {
+		m.IndexDiskCleanupDirsDeleted.WithLabelValues(kind, "success").Add(0)
+		m.IndexDiskCleanupDirsDeleted.WithLabelValues(kind, "error").Add(0)
+	}
 }

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -90,6 +90,29 @@ type BleveOptions struct {
 	// Snapshot configures remote index snapshot download at build time.
 	// If Snapshot.Store is nil, the feature is disabled and BuildIndex behaves exactly as before.
 	Snapshot SnapshotOptions
+
+	// DiskCleanupInterval is how often the background on-disk cleanup pass runs.
+	// The first run after start is jittered uniformly in [0, DiskCleanupInterval)
+	// so the sweep doesn't run immediately at startup, when the instance is still
+	// busy opening or rebuilding indexes. Zero disables the loop (the goroutine
+	// is not started).
+	DiskCleanupInterval time.Duration
+
+	// DiskCleanupGracePeriod is the minimum age a candidate directory must have
+	// before it is eligible for deletion. Applied as a two-step mtime gate so a
+	// directory that is still being written to (active scorch index, in-flight
+	// snapshot CopyTo) is always preserved. Only consulted when
+	// DiskCleanupInterval > 0.
+	DiskCleanupGracePeriod time.Duration
+
+	// DiskCleanupUnopenedGracePeriod is a longer grace period applied only to
+	// the newest on-disk index of a resource this pod owns but has not opened
+	// in this process. A pod owning a resource it has not been queried for
+	// keeps the most recent on-disk index for this duration, so a later
+	// BuildIndex call can hand it to findPreviousFileBasedIndex and skip a full
+	// rebuild. Older siblings under the same resource still use
+	// DiskCleanupGracePeriod. Only consulted when DiskCleanupInterval > 0.
+	DiskCleanupUnopenedGracePeriod time.Duration
 }
 
 // SnapshotOptions configures remote index snapshot handling in BuildIndex and
@@ -254,6 +277,15 @@ func NewBleveBackend(opts BleveOptions, indexMetrics *resource.BleveIndexMetrics
 			be.bgTasksWg.Add(1)
 			go be.cleanupSnapshotsPeriodically(ctx)
 		}
+	}
+
+	if opts.DiskCleanupInterval > 0 {
+		// Same rationale as InitSnapshotMetrics: only emit the
+		// index_server_disk_cleanup_* series on instances where the feature is
+		// enabled.
+		be.indexMetrics.InitDiskCleanupMetrics()
+		be.bgTasksWg.Add(1)
+		go be.cleanupDiskPeriodically(ctx)
 	}
 
 	if be.indexMetrics != nil {

--- a/pkg/storage/unified/search/bleve_snapshot_upload.go
+++ b/pkg/storage/unified/search/bleve_snapshot_upload.go
@@ -118,7 +118,13 @@ func (b *bleveBackend) snapshotCopyAndUpload(ctx context.Context, key resource.N
 	if err != nil {
 		return ulid.ULID{}, 0, fmt.Errorf("creating snapshot staging dir: %w", err)
 	}
-	defer func() { _ = os.RemoveAll(stagingDir) }()
+	// Pair the on-disk cleanup with the in-flight unregister installed by
+	// newSnapshotStagingDir. RemoveAll first so the disk cleanup loop can
+	// never observe the directory unregistered but still present.
+	defer func() {
+		_ = os.RemoveAll(stagingDir)
+		b.unregisterInFlightBuildDir(stagingDir)
+	}()
 
 	if err := b.snapshotIndex(idx.index, stagingDir); err != nil {
 		return ulid.ULID{}, 0, err
@@ -231,15 +237,33 @@ func readSnapshotIndexFormat(indexDir string) (string, error) {
 	return format, nil
 }
 
+// newSnapshotStagingDir creates the upload-* staging directory for one
+// snapshotCopyAndUpload call and registers it with inFlightBuildDirs so the
+// disk cleanup loop's in-flight check (see sweepSnapshotResource) protects an
+// in-progress CopyTo even if the mtime gate would otherwise let it through
+// — e.g. on a filesystem where mtime updates are unreliable, or on a sweep
+// triggered shortly after CopyTo began but before any segment file landed.
+// The matching unregister is owned by snapshotCopyAndUpload, paired with the
+// RemoveAll that tears the staging dir down.
+// snapshotsDirName is the top-level child of the bleve root that holds
+// snapshot upload staging directories. Shared with disk_cleanup.go so a
+// rename of one side can't drift from the other.
+const snapshotsDirName = "snapshots"
+
 func (b *bleveBackend) newSnapshotStagingDir(key resource.NamespacedResource) (string, error) {
-	parent := filepath.Join(b.opts.Root, "snapshots", resourceSubPath(key))
+	parent := filepath.Join(b.opts.Root, snapshotsDirName, resourceSubPath(key))
 	if !isPathWithinRoot(parent, b.opts.Root) {
 		return "", fmt.Errorf("invalid path %s", parent)
 	}
 	if err := os.MkdirAll(parent, 0o700); err != nil {
 		return "", err
 	}
-	return os.MkdirTemp(parent, "upload-*")
+	dir, err := os.MkdirTemp(parent, "upload-*")
+	if err != nil {
+		return "", err
+	}
+	b.registerInFlightBuildDir(dir)
+	return dir, nil
 }
 
 func checkSnapshotLock(lock IndexStoreLock) error {

--- a/pkg/storage/unified/search/disk_cleanup.go
+++ b/pkg/storage/unified/search/disk_cleanup.go
@@ -1,0 +1,489 @@
+package search
+
+import (
+	"context"
+	"io/fs"
+	"math/rand/v2"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
+)
+
+// Disk cleanup outcomes and kinds. Mirror the snapshot cleanup labels so
+// operators have a consistent vocabulary across the two cleanup loops.
+const (
+	diskCleanupOutcomeSuccess = "success"
+	diskCleanupOutcomeError   = "error"
+
+	diskCleanupKindIndex           = "index"
+	diskCleanupKindSnapshotStaging = "snapshot_staging"
+)
+
+// cleanupDiskPeriodically runs runDiskCleanup on a fixed DiskCleanupInterval,
+// with a uniformly jittered initial delay in [0, DiskCleanupInterval). The
+// delay keeps the sweep from running immediately at startup, when the pod is
+// still busy opening or rebuilding indexes.
+func (b *bleveBackend) cleanupDiskPeriodically(ctx context.Context) {
+	defer b.bgTasksWg.Done()
+
+	// Caller (NewBleveBackend) only starts this goroutine when DiskCleanupInterval > 0.
+	interval := b.opts.DiskCleanupInterval
+	initialDelay := time.Duration(rand.Int64N(int64(interval)))
+	select {
+	case <-ctx.Done():
+		return
+	case <-time.After(initialDelay):
+	}
+
+	b.runDiskCleanup(ctx)
+
+	t := time.NewTicker(interval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+			b.runDiskCleanup(ctx)
+		}
+	}
+}
+
+// diskCleanupStats is the per-run counter set, used for the structured log
+// line and trace attributes. Per-decision breakdown lives here rather than in
+// metrics to keep cardinality low.
+type diskCleanupStats struct {
+	scanned         int
+	deletedIndex    int
+	deletedSnapshot int
+	keptInFlight    int
+	keptActive      int
+	keptGrace       int
+	deleteFailures  int
+	ownershipErrors int
+	errors          int
+}
+
+// runDiskCleanup walks the on-disk bleve root once and deletes folders that
+// are not owned by this pod and not in use by an in-flight BuildIndex call.
+// Decision order per candidate directory: in-flight refcount first (never
+// touched), then the active-index check and the cold-start reuse selection
+// in sweepResource, then the two-step mtime gate in hasFreshActivity
+// (safety net) with the per-candidate grace chosen by sweepResource.
+//
+// All filesystem access is anchored through an os.Root opened on b.opts.Root,
+// so the sweep cannot escape its configured root (symlinks, "..", or
+// otherwise). That removes the need for the isPathWithinRoot string-prefix
+// guard used elsewhere in this package.
+func (b *bleveBackend) runDiskCleanup(ctx context.Context) {
+	ctx, span := tracer.Start(ctx, "search.disk_cleanup")
+	defer span.End()
+
+	start := time.Now()
+
+	b.log.Info("Disk index cleanup started")
+
+	root, err := os.OpenRoot(b.opts.Root)
+	if err != nil {
+		span.RecordError(err)
+		b.recordDiskCleanupRun(diskCleanupOutcomeError)
+		b.log.Warn("Disk index cleanup failed: opening root", "root", b.opts.Root, "err", err)
+		return
+	}
+	defer func() { _ = root.Close() }()
+
+	stats := diskCleanupStats{}
+	entries, err := fs.ReadDir(root.FS(), ".")
+	if err != nil {
+		stats.errors++
+		span.RecordError(err)
+		b.recordDiskCleanupRun(diskCleanupOutcomeError)
+		b.log.Warn("Disk index cleanup failed: reading root", "root", b.opts.Root, "err", err)
+		return
+	}
+
+	for _, entry := range entries {
+		if ctx.Err() != nil {
+			break
+		}
+		if !entry.IsDir() {
+			continue
+		}
+		if entry.Name() == snapshotsDirName {
+			b.sweepSnapshotsTree(ctx, root, snapshotsDirName, &stats)
+			continue
+		}
+		b.sweepNamespace(ctx, root, entry.Name(), &stats)
+	}
+
+	outcome := diskCleanupOutcomeSuccess
+	if stats.errors > 0 {
+		outcome = diskCleanupOutcomeError
+	}
+	b.recordDiskCleanupRun(outcome)
+	span.SetAttributes(
+		attribute.String("outcome", outcome),
+		attribute.Int("dirs_scanned", stats.scanned),
+		attribute.Int("dirs_deleted_index", stats.deletedIndex),
+		attribute.Int("dirs_deleted_snapshot_staging", stats.deletedSnapshot),
+		attribute.Int("dirs_kept_in_flight", stats.keptInFlight),
+		attribute.Int("dirs_kept_active", stats.keptActive),
+		attribute.Int("dirs_kept_grace", stats.keptGrace),
+		attribute.Int("delete_failures", stats.deleteFailures),
+		attribute.Int("ownership_errors", stats.ownershipErrors),
+	)
+	b.log.Info("Disk index cleanup completed",
+		"elapsed", time.Since(start),
+		"outcome", outcome,
+		"dirs_scanned", stats.scanned,
+		"dirs_deleted_index", stats.deletedIndex,
+		"dirs_deleted_snapshot_staging", stats.deletedSnapshot,
+		"dirs_kept_in_flight", stats.keptInFlight,
+		"dirs_kept_active", stats.keptActive,
+		"dirs_kept_grace", stats.keptGrace,
+		"delete_failures", stats.deleteFailures,
+		"ownership_errors", stats.ownershipErrors,
+	)
+}
+
+// iterDirs reads the directory children of rel relative to root. Files and
+// other non-directory entries are filtered out. Missing rel is treated as
+// empty (no error, no stat bump). Any other read error is logged and bumps
+// stats.errors so the run's outcome flips to error. Entries are returned in
+// fs.ReadDir order, i.e. sorted by filename.
+func (b *bleveBackend) iterDirs(root *os.Root, rel string, stats *diskCleanupStats) []fs.DirEntry {
+	entries, err := fs.ReadDir(root.FS(), rel)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			b.log.Warn("Disk index cleanup: reading dir", "dir", joinRoot(root, rel), "err", err)
+			stats.errors++
+		}
+		return nil
+	}
+	dirs := make([]fs.DirEntry, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() {
+			dirs = append(dirs, e)
+		}
+	}
+	return dirs
+}
+
+// tryRemoveCandidate is the shared gate-and-delete sequence used by every
+// candidate directory:
+//
+//  1. in-flight refcount — reservations from BuildIndex or
+//     newSnapshotStagingDir are never touched;
+//  2. mtime gate — protects writes whose timing we can't infer from
+//     structure alone;
+//  3. RemoveAll — deletes the directory and updates metrics tagged with kind.
+//
+// kind controls the metric label and which `deleted*` counter is bumped.
+// The grace value lets callers vary how strict the mtime gate is per
+// candidate (e.g. sweepResource hands the newest unopened index a longer
+// grace than the older siblings under the same resource).
+//
+// Race note: the in-flight check is best-effort. BuildIndex and
+// newSnapshotStagingDir both register their directories "as soon as they
+// own them" (immediately after bleve.OpenUsing / os.MkdirTemp), but there
+// is a tiny window where the directory is open or just-created and not yet
+// registered. The mtime gate covers that window in practice — a freshly
+// opened bolt store or just-created MkdirTemp dir has fresh mtimes. The
+// re-check immediately before RemoveAll narrows the already-narrow window
+// further: anything registered between the first check and the syscall is
+// honoured.
+func (b *bleveBackend) tryRemoveCandidate(root *os.Root, rel, kind string, grace time.Duration, stats *diskCleanupStats) {
+	abs := joinRoot(root, rel)
+	if b.isInFlightBuildDir(abs) {
+		stats.keptInFlight++
+		return
+	}
+	if hasFreshActivity(root, rel, time.Now(), grace) {
+		stats.keptGrace++
+		return
+	}
+	// Re-check after the (potentially slow) mtime gate. A BuildIndex that
+	// started while hasFreshActivity was walking the candidate has had time
+	// to register by now; honour that.
+	if b.isInFlightBuildDir(abs) {
+		stats.keptInFlight++
+		return
+	}
+	if err := root.RemoveAll(rel); err != nil {
+		b.log.Warn("Disk index cleanup: removing dir", "kind", kind, "dir", abs, "err", err)
+		b.recordDiskCleanupDirsDeleted(kind, diskCleanupOutcomeError)
+		stats.deleteFailures++
+		stats.errors++
+		return
+	}
+	b.log.Info("Disk index cleanup: removed dir", "kind", kind, "dir", abs)
+	b.recordDiskCleanupDirsDeleted(kind, diskCleanupOutcomeSuccess)
+	switch kind {
+	case diskCleanupKindIndex:
+		stats.deletedIndex++
+	case diskCleanupKindSnapshotStaging:
+		stats.deletedSnapshot++
+	}
+}
+
+// sweepNamespace processes <root>/<namespace>/ and tries to remove empty
+// <resource>.<group> children plus the namespace dir itself after their last
+// content is gone. namespace is both the root-relative path (it is always a
+// top-level child of the root) and the value used to build the per-resource
+// ownership key.
+func (b *bleveBackend) sweepNamespace(ctx context.Context, root *os.Root, namespace string, stats *diskCleanupStats) {
+	for _, resEntry := range b.iterDirs(root, namespace, stats) {
+		if ctx.Err() != nil {
+			return
+		}
+		resName := resEntry.Name()
+		res, group, ok := splitResourceGroup(resName)
+		if !ok {
+			// Doesn't match <resource>.<group>; leave it alone rather than risk
+			// deleting something we don't recognise.
+			continue
+		}
+		resGroupRel := path.Join(namespace, resName)
+		key := resource.NamespacedResource{Namespace: namespace, Resource: res, Group: group}
+		b.sweepResource(ctx, root, resGroupRel, key, stats)
+		b.tryRemoveIfEmpty(root, resGroupRel, stats)
+	}
+	b.tryRemoveIfEmpty(root, namespace, stats)
+}
+
+// splitResourceGroup splits a "<resource>.<group>" directory name into its
+// components. The resource short name (e.g. "dashboards") does not contain
+// dots, so the split point is the first '.'.
+func splitResourceGroup(name string) (string, string, bool) {
+	idx := strings.IndexByte(name, '.')
+	if idx <= 0 || idx == len(name)-1 {
+		return "", "", false
+	}
+	return name[:idx], name[idx+1:], true
+}
+
+// sweepResource dispatches each timestamp directory inside one resource
+// folder into one of three buckets:
+//
+//   - active index (owned + currently cached): always kept, no gate.
+//   - newest sibling we own but haven't opened: gated with the longer
+//     unopened-grace so a later BuildIndex can reuse it on cold start.
+//   - everything else (older siblings, anything under an unowned resource):
+//     gated with the normal grace.
+//
+// Failures are best-effort: we log and continue so one bad directory doesn't
+// block the rest of the sweep.
+func (b *bleveBackend) sweepResource(ctx context.Context, root *os.Root, resourceRel string, key resource.NamespacedResource, stats *diskCleanupStats) {
+	entries := b.iterDirs(root, resourceRel, stats)
+	if len(entries) == 0 {
+		return
+	}
+
+	// Snapshot ownership and the cached active index name once per resource.
+	owned, ownErr := b.ownsIndexFn(key)
+	if ownErr != nil {
+		// Fail safe: keep every candidate in this resource until the next pass
+		// resolves ownership. Mirrors how findPreviousFileBasedIndex treats
+		// transient open errors.
+		b.log.Warn("Disk index cleanup: ownership probe failed", "key", key, "err", ownErr)
+		stats.ownershipErrors++
+		stats.errors++
+		return
+	}
+
+	// iterDirs returns entries sorted by filename. Bleve timestamp names
+	// (YYYYMMDD-HHMMSS) sort chronologically, so the last entry is the newest
+	// sibling.
+	newest := entries[len(entries)-1].Name()
+
+	for _, ent := range entries {
+		if ctx.Err() != nil {
+			return
+		}
+		name := ent.Name()
+		candidateRel := path.Join(resourceRel, name)
+		stats.scanned++
+
+		// Re-read on every iteration so a BuildIndex that completes
+		// mid-sweep — promoting a new index into the cache and then
+		// unregistering its in-flight dir — still gets the active-index
+		// keep on the subsequent candidates.
+		cachedName := b.cachedFileIndexName(key)
+
+		// Active index: the directory we currently have open. Keep
+		// unconditionally — deleting it would close-and-lose the live index.
+		if owned && cachedName != "" && name == cachedName {
+			stats.keptActive++
+			continue
+		}
+
+		// Newest sibling of an owned resource we haven't opened: use the
+		// longer unopened-grace so cold-start BuildIndex can still pick it up.
+		// Older siblings under the same resource fall through to the normal
+		// grace below. Unowned resources never get the longer grace.
+		candidateGrace := b.opts.DiskCleanupGracePeriod
+		if owned && cachedName == "" && name == newest {
+			candidateGrace = b.opts.DiskCleanupUnopenedGracePeriod
+		}
+
+		b.tryRemoveCandidate(root, candidateRel, diskCleanupKindIndex, candidateGrace, stats)
+	}
+}
+
+// cachedFileIndexName returns the basename of the currently cached file-based
+// index directory for key, or "" if no file-based index is cached. The bleve
+// Index.Name() returns the absolute path passed to NewUsing/OpenUsing, which
+// we slice down to the timestamp leaf.
+func (b *bleveBackend) cachedFileIndexName(key resource.NamespacedResource) string {
+	b.cacheMx.RLock()
+	defer b.cacheMx.RUnlock()
+	idx := b.cache[key]
+	if idx == nil || idx.indexStorage != indexStorageFile {
+		return ""
+	}
+	return filepath.Base(idx.index.Name())
+}
+
+// sweepSnapshotsTree handles <root>/snapshots/<ns>/<res>.<group>/upload-*.
+// Snapshot staging dirs are never owned and never reused, so the only gates
+// are the in-flight refcount installed by newSnapshotStagingDir (defense in
+// depth against unreliable mtimes) and the mtime gate that catches
+// everything else (in-flight CopyTo writes, recently finished uploads that
+// haven't yet been removed by their deferred cleanup).
+func (b *bleveBackend) sweepSnapshotsTree(ctx context.Context, root *os.Root, snapshotsRel string, stats *diskCleanupStats) {
+	for _, nsEnt := range b.iterDirs(root, snapshotsRel, stats) {
+		if ctx.Err() != nil {
+			return
+		}
+		nsRel := path.Join(snapshotsRel, nsEnt.Name())
+		for _, resEnt := range b.iterDirs(root, nsRel, stats) {
+			if ctx.Err() != nil {
+				return
+			}
+			resourceRel := path.Join(nsRel, resEnt.Name())
+			b.sweepSnapshotResource(ctx, root, resourceRel, stats)
+			b.tryRemoveIfEmpty(root, resourceRel, stats)
+		}
+		b.tryRemoveIfEmpty(root, nsRel, stats)
+	}
+	// Leave snapshotsRel itself in place; newSnapshotStagingDir would just
+	// recreate it on the next upload.
+}
+
+func (b *bleveBackend) sweepSnapshotResource(ctx context.Context, root *os.Root, resourceRel string, stats *diskCleanupStats) {
+	for _, ent := range b.iterDirs(root, resourceRel, stats) {
+		if ctx.Err() != nil {
+			return
+		}
+		candidateRel := path.Join(resourceRel, ent.Name())
+		stats.scanned++
+		b.tryRemoveCandidate(root, candidateRel, diskCleanupKindSnapshotStaging, b.opts.DiskCleanupGracePeriod, stats)
+	}
+}
+
+// hasFreshActivity reports whether anything inside rel has been written to
+// recently enough that we should leave it alone. The check has two steps:
+//
+// Step 1 (fast path): stat the candidate and its store/ subdir. POSIX-compliant
+// filesystems bump directory mtime when entries are added or removed, which
+// covers scorch segment churn and snapshot CopyTo — the common cases.
+//
+// Step 2 (slow path): if both stats above are stale, walk the candidate and
+// short-circuit on the first file or directory entry whose mtime is fresh.
+// File mtime is universally bumped by write(2), so the slow path's
+// correctness does not depend on directory mtime semantics.
+//
+// grace <= 0 disables the gate. The caller never passes 0 in production (the
+// goroutine is only started when DiskCleanupInterval > 0 and we configure a
+// non-zero default), but tests find the explicit short-circuit useful.
+func hasFreshActivity(root *os.Root, rel string, now time.Time, grace time.Duration) bool {
+	if grace <= 0 {
+		return false
+	}
+	fresh := func(info os.FileInfo) bool {
+		return info != nil && now.Sub(info.ModTime()) <= grace
+	}
+	if info, err := root.Stat(rel); err == nil && fresh(info) {
+		return true
+	}
+	if info, err := root.Stat(path.Join(rel, "store")); err == nil && fresh(info) {
+		return true
+	}
+
+	found := false
+	_ = fs.WalkDir(root.FS(), rel, func(_ string, d fs.DirEntry, err error) error {
+		if err != nil {
+			// Transient errors don't tell us anything about freshness; keep
+			// walking. If the directory has truly disappeared we'll exit
+			// naturally.
+			return nil
+		}
+		info, infoErr := d.Info()
+		if infoErr != nil {
+			return nil
+		}
+		if fresh(info) {
+			found = true
+			return fs.SkipAll
+		}
+		return nil
+	})
+	return found
+}
+
+// tryRemoveIfEmpty removes rel within root if it has no children. It is the
+// best-effort tail of every sweep: a missing or non-empty directory is fine
+// (no-op), while a real failure (permission, IO) is logged and taints the
+// run's outcome so it doesn't disappear silently.
+func (b *bleveBackend) tryRemoveIfEmpty(root *os.Root, rel string, stats *diskCleanupStats) {
+	f, err := root.Open(rel)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			b.log.Warn("Disk index cleanup: removing empty dir", "dir", joinRoot(root, rel), "err", err)
+			stats.errors++
+		}
+		return
+	}
+	names, _ := f.Readdirnames(1)
+	_ = f.Close()
+	if len(names) > 0 {
+		return
+	}
+	if err := root.Remove(rel); err != nil && !os.IsNotExist(err) {
+		b.log.Warn("Disk index cleanup: removing empty dir", "dir", joinRoot(root, rel), "err", err)
+		stats.errors++
+	}
+}
+
+// joinRoot combines an os.Root with a root-relative path (slash-separated,
+// as used by os.Root.FS()) into the OS-native path of that entry. Going
+// through root.Name() keeps these strings tied to the FD we are actually
+// operating on, instead of re-reading b.opts.Root.
+//
+// In our flow the returned path is also absolute, because NewBleveBackend
+// runs filepath.Abs on opts.Root before opening it. joinRoot does NOT
+// re-resolve it: callers that pass the returned path to inFlightBuildDirs
+// (which keys on absolute paths) rely on that precondition.
+func joinRoot(root *os.Root, rel string) string {
+	return filepath.Join(root.Name(), filepath.FromSlash(rel))
+}
+
+func (b *bleveBackend) recordDiskCleanupRun(outcome string) {
+	if b.indexMetrics == nil {
+		return
+	}
+	b.indexMetrics.IndexDiskCleanupRuns.WithLabelValues(outcome).Inc()
+}
+
+func (b *bleveBackend) recordDiskCleanupDirsDeleted(kind, outcome string) {
+	if b.indexMetrics == nil {
+		return
+	}
+	b.indexMetrics.IndexDiskCleanupDirsDeleted.WithLabelValues(kind, outcome).Inc()
+}

--- a/pkg/storage/unified/search/disk_cleanup_test.go
+++ b/pkg/storage/unified/search/disk_cleanup_test.go
@@ -42,14 +42,25 @@ func mkdirOld(t *testing.T, root string, parts ...string) string {
 	t.Helper()
 	dir := filepath.Join(append([]string{root}, parts...)...)
 	require.NoError(t, os.MkdirAll(dir, 0o750))
-	old := time.Now().Add(-24 * time.Hour)
-	require.NoError(t, filepath.WalkDir(dir, func(p string, _ fs.DirEntry, err error) error {
+	chtimesRecursive(t, dir, time.Now().Add(-24*time.Hour))
+	return dir
+}
+
+// chtimesRecursive rewinds the mtime/atime of every entry under dir. It uses
+// os.Root-anchored APIs so gosec G122 (which forbids race-prone
+// filepath.WalkDir callbacks) is satisfied — same posture the production
+// sweep uses.
+func chtimesRecursive(t *testing.T, dir string, when time.Time) {
+	t.Helper()
+	root, err := os.OpenRoot(dir)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = root.Close() })
+	require.NoError(t, fs.WalkDir(root.FS(), ".", func(p string, _ fs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		return os.Chtimes(p, old, old)
+		return root.Chtimes(p, when, when)
 	}))
-	return dir
 }
 
 // mkdirFresh creates a directory tree and leaves every entry's mtime current
@@ -136,13 +147,7 @@ func TestRunDiskCleanup_OwnedResource_KeepsCachedActive(t *testing.T) {
 
 	// Force the active dir to look stale on disk so we know the
 	// active-index check — not the mtime gate — is what's saving it.
-	old := time.Now().Add(-24 * time.Hour)
-	require.NoError(t, filepath.WalkDir(activeDir, func(p string, _ fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		return os.Chtimes(p, old, old)
-	}))
+	chtimesRecursive(t, activeDir, time.Now().Add(-24*time.Hour))
 
 	b.runDiskCleanup(t.Context())
 
@@ -224,13 +229,7 @@ func TestRunDiskCleanup_SnapshotStaging_OldDeleted(t *testing.T) {
 	writeFileOld(t, filepath.Join(stale, "store"), "root.bolt")
 	// Force the staging directory itself (and store/) to look old after the
 	// nested files were written.
-	old := time.Now().Add(-24 * time.Hour)
-	require.NoError(t, filepath.WalkDir(stale, func(p string, _ fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		return os.Chtimes(p, old, old)
-	}))
+	chtimesRecursive(t, stale, time.Now().Add(-24*time.Hour))
 
 	b.runDiskCleanup(t.Context())
 

--- a/pkg/storage/unified/search/disk_cleanup_test.go
+++ b/pkg/storage/unified/search/disk_cleanup_test.go
@@ -1,0 +1,342 @@
+package search
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
+)
+
+// setupDiskCleanupBackend wires a minimal bleveBackend that runDiskCleanup can
+// drive directly, without starting any background goroutines. ownsFn defaults
+// to "everything owned" when nil. The unopened-grace defaults to the same
+// value as grace; tests that exercise the longer-grace branch override
+// b.opts.DiskCleanupUnopenedGracePeriod explicitly.
+func setupDiskCleanupBackend(t *testing.T, grace time.Duration, ownsFn func(resource.NamespacedResource) (bool, error)) (*bleveBackend, *resource.BleveIndexMetrics) {
+	t.Helper()
+	opts := []setupOption{
+		withFileThreshold(5),
+	}
+	if ownsFn != nil {
+		opts = append(opts, withOwnsIndexFn(ownsFn))
+	}
+	b, _ := setupBleveBackend(t, opts...)
+	b.opts.DiskCleanupInterval = time.Hour // value is not used; just non-zero for completeness
+	b.opts.DiskCleanupGracePeriod = grace
+	b.opts.DiskCleanupUnopenedGracePeriod = grace
+	// Register the cleanup metric label set the way the production startup
+	// path would.
+	b.indexMetrics.InitDiskCleanupMetrics()
+	return b, b.indexMetrics
+}
+
+// mkdirOld creates a directory tree and rewinds every entry's mtime so the
+// fast and slow paths of the mtime gate both see it as stale.
+func mkdirOld(t *testing.T, root string, parts ...string) string {
+	t.Helper()
+	dir := filepath.Join(append([]string{root}, parts...)...)
+	require.NoError(t, os.MkdirAll(dir, 0o750))
+	old := time.Now().Add(-24 * time.Hour)
+	require.NoError(t, filepath.WalkDir(dir, func(p string, _ fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		return os.Chtimes(p, old, old)
+	}))
+	return dir
+}
+
+// mkdirFresh creates a directory tree and leaves every entry's mtime current
+// so the fast path keeps it.
+func mkdirFresh(t *testing.T, root string, parts ...string) string {
+	t.Helper()
+	dir := filepath.Join(append([]string{root}, parts...)...)
+	require.NoError(t, os.MkdirAll(dir, 0o750))
+	return dir
+}
+
+// writeFileOld writes a file under dir and stamps it with an old mtime so the
+// slow-path walk also sees stale entries.
+func writeFileOld(t *testing.T, dir, name string) {
+	t.Helper()
+	require.NoError(t, os.MkdirAll(dir, 0o750))
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, []byte("x"), 0o600))
+	old := time.Now().Add(-24 * time.Hour)
+	require.NoError(t, os.Chtimes(path, old, old))
+	require.NoError(t, os.Chtimes(dir, old, old))
+}
+
+func TestRunDiskCleanup_UnownedResource_OldDirsDeleted(t *testing.T) {
+	owns := func(_ resource.NamespacedResource) (bool, error) { return false, nil }
+	b, metrics := setupDiskCleanupBackend(t, time.Minute, owns)
+
+	root := b.opts.Root
+	dirA := mkdirOld(t, root, "ns1", "dashboards.dashboard.grafana.app", "20240101-000000")
+	writeFileOld(t, dirA, "root.bolt")
+
+	b.runDiskCleanup(t.Context())
+
+	require.NoDirExists(t, dirA)
+	// Parent dirs cleared up too (leak cause E).
+	require.NoDirExists(t, filepath.Join(root, "ns1", "dashboards.dashboard.grafana.app"))
+	require.NoDirExists(t, filepath.Join(root, "ns1"))
+
+	require.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexDiskCleanupDirsDeleted.WithLabelValues("index", "success")))
+	require.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexDiskCleanupRuns.WithLabelValues("success")))
+}
+
+func TestRunDiskCleanup_UnownedResource_FreshDirKept(t *testing.T) {
+	owns := func(_ resource.NamespacedResource) (bool, error) { return false, nil }
+	b, metrics := setupDiskCleanupBackend(t, time.Hour, owns)
+
+	root := b.opts.Root
+	dir := mkdirFresh(t, root, "ns1", "dashboards.dashboard.grafana.app", "20240101-000000")
+
+	b.runDiskCleanup(t.Context())
+
+	require.DirExists(t, dir)
+	require.Equal(t, 0.0, testutil.ToFloat64(metrics.IndexDiskCleanupDirsDeleted.WithLabelValues("index", "success")))
+}
+
+func TestRunDiskCleanup_OwnedResource_KeepsCachedActive(t *testing.T) {
+	b, _ := setupDiskCleanupBackend(t, time.Minute, nil)
+
+	ns := resource.NamespacedResource{Namespace: "ns1", Group: "dashboard.grafana.app", Resource: "dashboards"}
+	resourceDir := b.getResourceDir(ns)
+	require.NoError(t, os.MkdirAll(resourceDir, 0o750))
+
+	// The active index is a real bleve index so cachedFileIndexName can read
+	// its Name() like it would in production. Sibling "20240101-000000" stays
+	// a bare directory — it would normally be a stale leftover that the sweep
+	// is meant to clean up.
+	mapper, err := GetBleveMappings(nil, nil)
+	require.NoError(t, err)
+	activeDir := filepath.Join(resourceDir, "20240301-120000")
+	activeIdx, err := newBleveIndex(activeDir, mapper, time.Now(), buildVersion, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = activeIdx.Close() })
+	older := mkdirOld(t, resourceDir, "20240101-000000")
+	writeFileOld(t, older, "root.bolt")
+
+	b.cacheMx.Lock()
+	b.cache[ns] = &bleveIndex{key: ns, index: activeIdx, indexStorage: indexStorageFile}
+	b.cacheMx.Unlock()
+	t.Cleanup(func() {
+		b.cacheMx.Lock()
+		delete(b.cache, ns)
+		b.cacheMx.Unlock()
+	})
+
+	// Force the active dir to look stale on disk so we know the
+	// active-index check — not the mtime gate — is what's saving it.
+	old := time.Now().Add(-24 * time.Hour)
+	require.NoError(t, filepath.WalkDir(activeDir, func(p string, _ fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		return os.Chtimes(p, old, old)
+	}))
+
+	b.runDiskCleanup(t.Context())
+
+	require.DirExists(t, activeDir)
+	require.NoDirExists(t, older)
+}
+
+func TestRunDiskCleanup_OwnedResource_KeepsNewestSiblingWhenNotCached(t *testing.T) {
+	// Normal grace is short so the older sibling falls through to delete.
+	// Unopened grace is generous so the newest — stale by 24h on disk —
+	// survives the mtime gate as the cold-start reuse candidate.
+	b, _ := setupDiskCleanupBackend(t, time.Minute, nil)
+	b.opts.DiskCleanupUnopenedGracePeriod = 48 * time.Hour
+	root := b.opts.Root
+
+	resourceDir := filepath.Join(root, "ns1", "dashboards.dashboard.grafana.app")
+	older := mkdirOld(t, resourceDir, "20240101-000000")
+	newer := mkdirOld(t, resourceDir, "20240301-120000")
+
+	b.runDiskCleanup(t.Context())
+
+	require.DirExists(t, newer)
+	require.NoDirExists(t, older)
+}
+
+func TestRunDiskCleanup_OwnedResource_NewestSiblingDeletedWhenUnopenedGraceExpires(t *testing.T) {
+	// Both siblings are well past unopened-grace, so even the newest gets
+	// reclaimed. This is the "truly idle owned resource" path.
+	b, _ := setupDiskCleanupBackend(t, time.Minute, nil)
+	b.opts.DiskCleanupUnopenedGracePeriod = time.Hour
+	root := b.opts.Root
+
+	resourceDir := filepath.Join(root, "ns1", "dashboards.dashboard.grafana.app")
+	older := mkdirOld(t, resourceDir, "20240101-000000")
+	newer := mkdirOld(t, resourceDir, "20240301-120000")
+	writeFileOld(t, older, "root.bolt")
+	writeFileOld(t, newer, "root.bolt")
+
+	b.runDiskCleanup(t.Context())
+
+	require.NoDirExists(t, newer)
+	require.NoDirExists(t, older)
+}
+
+func TestRunDiskCleanup_InFlightBuildDirNeverDeleted(t *testing.T) {
+	owns := func(_ resource.NamespacedResource) (bool, error) { return false, nil }
+	b, _ := setupDiskCleanupBackend(t, time.Minute, owns)
+	root := b.opts.Root
+
+	dir := mkdirOld(t, root, "ns1", "dashboards.dashboard.grafana.app", "20240101-000000")
+	b.registerInFlightBuildDir(dir)
+	t.Cleanup(func() { b.unregisterInFlightBuildDir(dir) })
+
+	b.runDiskCleanup(t.Context())
+
+	require.DirExists(t, dir, "in-flight registered directory must survive the sweep")
+}
+
+func TestRunDiskCleanup_EmptyParentDirsRemoved(t *testing.T) {
+	owns := func(_ resource.NamespacedResource) (bool, error) { return false, nil }
+	b, _ := setupDiskCleanupBackend(t, time.Minute, owns)
+	root := b.opts.Root
+
+	mkdirOld(t, root, "ns1", "dashboards.dashboard.grafana.app", "20240101-000000")
+	mkdirOld(t, root, "ns1", "folders.folder.grafana.app", "20240101-000000")
+
+	b.runDiskCleanup(t.Context())
+
+	require.NoDirExists(t, filepath.Join(root, "ns1", "dashboards.dashboard.grafana.app"))
+	require.NoDirExists(t, filepath.Join(root, "ns1", "folders.folder.grafana.app"))
+	require.NoDirExists(t, filepath.Join(root, "ns1"))
+}
+
+func TestRunDiskCleanup_SnapshotStaging_OldDeleted(t *testing.T) {
+	b, metrics := setupDiskCleanupBackend(t, time.Minute, nil)
+	root := b.opts.Root
+
+	stale := mkdirOld(t, root, "snapshots", "ns1", "dashboards.dashboard.grafana.app", "upload-1234567890")
+	writeFileOld(t, filepath.Join(stale, "store"), "root.bolt")
+	// Force the staging directory itself (and store/) to look old after the
+	// nested files were written.
+	old := time.Now().Add(-24 * time.Hour)
+	require.NoError(t, filepath.WalkDir(stale, func(p string, _ fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		return os.Chtimes(p, old, old)
+	}))
+
+	b.runDiskCleanup(t.Context())
+
+	require.NoDirExists(t, stale)
+	require.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexDiskCleanupDirsDeleted.WithLabelValues("snapshot_staging", "success")))
+}
+
+func TestRunDiskCleanup_SnapshotStaging_FreshKept(t *testing.T) {
+	b, _ := setupDiskCleanupBackend(t, time.Hour, nil)
+	root := b.opts.Root
+
+	fresh := mkdirFresh(t, root, "snapshots", "ns1", "dashboards.dashboard.grafana.app", "upload-1234567890")
+	require.NoError(t, os.MkdirAll(filepath.Join(fresh, "store"), 0o750))
+	require.NoError(t, os.WriteFile(filepath.Join(fresh, "store", "root.bolt"), []byte("x"), 0o600))
+
+	b.runDiskCleanup(t.Context())
+
+	require.DirExists(t, fresh, "in-flight CopyTo staging directory must survive when fresh")
+}
+
+func TestRunDiskCleanup_OwnershipErrorFailsSafe(t *testing.T) {
+	owns := func(_ resource.NamespacedResource) (bool, error) {
+		return false, fs.ErrInvalid
+	}
+	b, metrics := setupDiskCleanupBackend(t, time.Minute, owns)
+	root := b.opts.Root
+
+	dir := mkdirOld(t, root, "ns1", "dashboards.dashboard.grafana.app", "20240101-000000")
+
+	b.runDiskCleanup(t.Context())
+
+	require.DirExists(t, dir, "ownership errors must fail safe (keep directories)")
+	require.Equal(t, 0.0, testutil.ToFloat64(metrics.IndexDiskCleanupDirsDeleted.WithLabelValues("index", "success")))
+	// One failing ownership probe taints the whole run as "error".
+	require.Equal(t, 1.0, testutil.ToFloat64(metrics.IndexDiskCleanupRuns.WithLabelValues("error")))
+}
+
+func TestRunDiskCleanup_UnknownNamespaceLayoutIgnored(t *testing.T) {
+	owns := func(_ resource.NamespacedResource) (bool, error) { return false, nil }
+	b, _ := setupDiskCleanupBackend(t, time.Minute, owns)
+	root := b.opts.Root
+
+	// Directory whose name does not parse as <resource>.<group>: never touched.
+	weird := mkdirOld(t, root, "ns1", "not-a-resource-group", "20240101-000000")
+
+	b.runDiskCleanup(t.Context())
+
+	require.DirExists(t, weird, "directories that don't match <resource>.<group> are left alone")
+}
+
+func TestSplitResourceGroup(t *testing.T) {
+	cases := map[string]struct {
+		in    string
+		res   string
+		group string
+		ok    bool
+	}{
+		"normal":         {"dashboards.dashboard.grafana.app", "dashboards", "dashboard.grafana.app", true},
+		"no dot":         {"resourcename", "", "", false},
+		"leading dot":    {".group", "", "", false},
+		"trailing dot":   {"res.", "", "", false},
+		"single segment": {"res.group", "res", "group", true},
+	}
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			res, group, ok := splitResourceGroup(c.in)
+			require.Equal(t, c.ok, ok)
+			require.Equal(t, c.res, res)
+			require.Equal(t, c.group, group)
+		})
+	}
+}
+
+func TestHasFreshActivity(t *testing.T) {
+	root, err := os.OpenRoot(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = root.Close() })
+	t.Run("disabled when grace is zero", func(t *testing.T) {
+		require.NoError(t, root.Mkdir("disabled", 0o750))
+		require.False(t, hasFreshActivity(root, "disabled", time.Now(), 0))
+	})
+	t.Run("fast path keeps directory whose mtime is fresh", func(t *testing.T) {
+		require.NoError(t, root.Mkdir("fresh", 0o750))
+		require.True(t, hasFreshActivity(root, "fresh", time.Now(), time.Hour))
+	})
+	t.Run("slow path finds fresh file under stale parent", func(t *testing.T) {
+		require.NoError(t, root.Mkdir("slow", 0o750))
+		f, err := root.Create("slow/fresh.txt")
+		require.NoError(t, err)
+		_, err = f.WriteString("x")
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+		old := time.Now().Add(-24 * time.Hour)
+		require.NoError(t, root.Chtimes("slow", old, old))
+		require.True(t, hasFreshActivity(root, "slow", time.Now(), time.Hour))
+	})
+	t.Run("all stale returns false", func(t *testing.T) {
+		require.NoError(t, root.Mkdir("stale", 0o750))
+		f, err := root.Create("stale/old.txt")
+		require.NoError(t, err)
+		_, err = f.WriteString("x")
+		require.NoError(t, err)
+		require.NoError(t, f.Close())
+		old := time.Now().Add(-24 * time.Hour)
+		require.NoError(t, root.Chtimes("stale/old.txt", old, old))
+		require.NoError(t, root.Chtimes("stale", old, old))
+		require.False(t, hasFreshActivity(root, "stale", time.Now(), time.Hour))
+	})
+}

--- a/pkg/storage/unified/search/options.go
+++ b/pkg/storage/unified/search/options.go
@@ -82,14 +82,17 @@ func NewSearchOptions(
 		}
 
 		bleve, err := NewBleveBackend(BleveOptions{
-			Root:                     root,
-			FileThreshold:            int64(cfg.IndexFileThreshold), // fewer than X items will use a memory index
-			IndexCacheTTL:            cfg.IndexCacheTTL,             // How long to keep the index cache in memory
-			BuildVersion:             cfg.BuildVersion,
-			OwnsIndex:                ownsIndexFn,
-			IndexMinUpdateInterval:   cfg.IndexMinUpdateInterval,
-			SelectableFieldsForKinds: resource.SelectableFields(),
-			Snapshot:                 snapshot,
+			Root:                           root,
+			FileThreshold:                  int64(cfg.IndexFileThreshold), // fewer than X items will use a memory index
+			IndexCacheTTL:                  cfg.IndexCacheTTL,             // How long to keep the index cache in memory
+			BuildVersion:                   cfg.BuildVersion,
+			OwnsIndex:                      ownsIndexFn,
+			IndexMinUpdateInterval:         cfg.IndexMinUpdateInterval,
+			SelectableFieldsForKinds:       resource.SelectableFields(),
+			Snapshot:                       snapshot,
+			DiskCleanupInterval:            cfg.DiskIndexCleanupInterval,
+			DiskCleanupGracePeriod:         cfg.DiskIndexCleanupGracePeriod,
+			DiskCleanupUnopenedGracePeriod: cfg.DiskIndexCleanupUnopenedGracePeriod,
 		}, indexMetrics)
 
 		if err != nil {


### PR DESCRIPTION
Adds an opt-in background sweep that walks the bleve index root every `disk_index_cleanup_interval` and removes folders this pod doesn't own or doesn't need. Today these leak after ring rebalances, snapshot upload crashes, and failed `BuildIndex` calls — `cleanOldIndexes` only runs at the tail of a successful build, so anything we never rebuild stays forever.

Per candidate timestamp dir, in order:
1. In-flight reservations (`BuildIndex`, `newSnapshotStagingDir`) are never touched.
2. The currently cached file index is always kept.
3. The newest sibling of an owned but unopened resource gets a longer grace (default 24h) so a later `BuildIndex` can reuse it on cold start.
4. Everything else falls through a two-step mtime gate (stat candidate + `store/`, then a short-circuit walk) with the normal grace (default 1h).

Snapshot staging dirs use the same sweep with the in-flight + mtime gates only; `newSnapshotStagingDir` now registers its `upload-*` dir so the in-flight check has a real signal during `CopyTo`. Empty parent dirs are reaped.

All I/O goes through `os.OpenRoot(b.opts.Root)`, so the sweep cannot escape the configured root.

Config under `[unified_storage]`: `disk_index_cleanup_interval` (0 disables, default), `disk_index_cleanup_grace_period` (1h), `disk_index_cleanup_unopened_grace_period` (24h).

Default off.