### PR TITLE
Docs: Presets GA

### DIFF
--- a/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/_index.md
+++ b/docs/sources/visualizations/dashboards/build-dashboards/create-dashboard/_index.md
@@ -122,10 +122,6 @@ To create a dashboard, follow these steps:
 
 1. (Optional) If the panel supports it, choose an option from the **Panel styles** section in the panel editor sidebar. Each style shows a live preview of how it changes the visualization. Clicking a style applies it to the panel.
 
-   {{< admonition type="note" >}}
-   Panel styles is currently in [public preview](https://grafana.com/docs/release-life-cycle/). Grafana Labs offers limited support, and breaking changes might occur prior to the feature being made generally available. Enable the `vizPresets` [feature toggle](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles/) to use this feature.
-   {{< /admonition >}}
-
    For more information about Panel styles, refer to the [Panel editor documentation](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/visualizations/panels-visualizations/panel-editor-overview/#panel-styles).
 
 1. Refer to the following documentation for ways you can adjust panel settings.

--- a/docs/sources/visualizations/panels-visualizations/panel-editor-overview/index.md
+++ b/docs/sources/visualizations/panels-visualizations/panel-editor-overview/index.md
@@ -80,10 +80,6 @@ For more information about individual visualizations, refer to [Visualizations o
 
 ### Panel styles
 
-{{< admonition type="note" >}}
-Panel styles is currently in [public preview](https://grafana.com/docs/release-life-cycle/). Grafana Labs offers limited support, and breaking changes might occur prior to the feature being made generally available. Enable the `vizPresets` [feature toggle](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/setup-grafana/configure-grafana/feature-toggles/) to use this feature.
-{{< /admonition >}}
-
 While visualization suggestions help you choose _which_ panel type to use, panel styles help you decide _how_ that panel should look. The **Panel styles** section of the panel editor sidebar contains preconfigured options for the currently selected visualization. It appears after you've selected a visualization and the panel has data.
 
 ![Panel styles example for time series visualization](/media/docs/grafana/panels-visualizations/visualization-presets-13.png)


### PR DESCRIPTION
Removes the feature toggle reference for `vizPresets` from the docs.


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
