### PR TITLE
Dashboard: Added last 10 year date filter

### DIFF
--- a/packages/grafana-ui/src/components/DateTimePickers/options.ts
+++ b/packages/grafana-ui/src/components/DateTimePickers/options.ts
@@ -40,6 +40,11 @@ export const getQuickOptions: () => TimeOption[] = () => [
   { from: 'now-1y', to: 'now', display: t('grafana-ui.date-time-pickers.quick-options.last-1-year', 'Last 1 year') },
   { from: 'now-2y', to: 'now', display: t('grafana-ui.date-time-pickers.quick-options.last-2-years', 'Last 2 years') },
   { from: 'now-5y', to: 'now', display: t('grafana-ui.date-time-pickers.quick-options.last-5-years', 'Last 5 years') },
+  {
+    from: 'now-10y',
+    to: 'now',
+    display: t('grafana-ui.date-time-pickers.quick-options.last-10-years', 'Last 10 years'),
+  },
   { from: 'now-1d/d', to: 'now-1d/d', display: t('grafana-ui.date-time-pickers.quick-options.yesterday', 'Yesterday') },
   {
     from: 'now-2d/d',
@@ -117,7 +122,7 @@ export const getQuickOptions: () => TimeOption[] = () => [
     display: t('grafana-ui.date-time-pickers.quick-options.this-fiscal-year', 'This fiscal year'),
   },
 ];
-
+console.log('test');
 export const getMonthOptions: () => Array<ComboboxOption<number>> = () => [
   { label: t('grafana-ui.date-time-pickers.month-options.label-january', 'January'), value: 0 },
   { label: t('grafana-ui.date-time-pickers.month-options.label-february', 'February'), value: 1 },


### PR DESCRIPTION

**What is this feature?**

Add "Last 10 years" Quick Range Preset to Time Picker

**Why do we need this feature?**

Requested last week at #125128 

**Which issue(s) does this PR fix?**:
#125128 

**Special notes for your reviewer:**
- [ X] It works as expected from a user's perspective.
- [N/A] If this is a pre-GA feature, it is behind a feature toggle.
- [ N/A] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.