### PR TITLE
Provisioning: Cleanup dual writing logic

### DIFF
--- a/pkg/services/provisioning/dashboards/dashboard.go
+++ b/pkg/services/provisioning/dashboards/dashboard.go
@@ -7,8 +7,6 @@ import (
 	"os"
 	"time"
 
-	dashboardV1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
-	folderV1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/serverlock"
 	"github.com/grafana/grafana/pkg/services/dashboards"
@@ -16,7 +14,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/org"
 	"github.com/grafana/grafana/pkg/services/provisioning/utils"
 	"github.com/grafana/grafana/pkg/setting"
-	"github.com/grafana/grafana/pkg/storage/legacysql/dualwrite"
 )
 
 // DashboardProvisioner is responsible for syncing dashboard from disk to
@@ -31,7 +28,7 @@ type DashboardProvisioner interface {
 }
 
 // DashboardProvisionerFactory creates DashboardProvisioners based on input
-type DashboardProvisionerFactory func(context.Context, string, dashboards.DashboardProvisioningService, *setting.Cfg, org.Service, utils.DashboardStore, folder.Service, dualwrite.Service, *serverlock.ServerLockService) (DashboardProvisioner, error)
+type DashboardProvisionerFactory func(context.Context, string, dashboards.DashboardProvisioningService, *setting.Cfg, org.Service, utils.DashboardStore, folder.Service, *serverlock.ServerLockService) (DashboardProvisioner, error)
 
 // Provisioner is responsible for syncing dashboard from disk to Grafana's database.
 type Provisioner struct {
@@ -40,7 +37,6 @@ type Provisioner struct {
 	configs            []*config
 	duplicateValidator duplicateValidator
 	provisioner        dashboards.DashboardProvisioningService
-	dual               dualwrite.Service
 	serverLock         *serverlock.ServerLockService
 	cfg                *setting.Cfg
 }
@@ -50,7 +46,7 @@ func (provider *Provisioner) HasDashboardSources() bool {
 }
 
 // New returns a new DashboardProvisioner
-func New(ctx context.Context, configDirectory string, provisioner dashboards.DashboardProvisioningService, cfg *setting.Cfg, orgService org.Service, dashboardStore utils.DashboardStore, folderService folder.Service, dual dualwrite.Service, serverLockService *serverlock.ServerLockService) (DashboardProvisioner, error) {
+func New(ctx context.Context, configDirectory string, provisioner dashboards.DashboardProvisioningService, cfg *setting.Cfg, orgService org.Service, dashboardStore utils.DashboardStore, folderService folder.Service, serverLockService *serverlock.ServerLockService) (DashboardProvisioner, error) {
 	logger := log.New("provisioning.dashboard")
 	cfgReader := &configReader{path: configDirectory, log: logger, orgExists: utils.NewOrgExistsChecker(orgService)}
 	configs, err := cfgReader.readConfig(ctx)
@@ -63,22 +59,12 @@ func New(ctx context.Context, configDirectory string, provisioner dashboards.Das
 		return nil, fmt.Errorf("%v: %w", "Failed to initialize file readers", err)
 	}
 
-	if dual != nil {
-		foldersInUnified, _ := dual.ReadFromUnified(context.Background(), folderV1.FolderResourceInfo.GroupResource())
-		if foldersInUnified {
-			for _, reader := range fileReaders {
-				reader.foldersInUnified = true
-			}
-		}
-	}
-
 	d := &Provisioner{
 		log:                logger,
 		fileReaders:        fileReaders,
 		configs:            configs,
 		duplicateValidator: newDuplicateValidator(logger, fileReaders),
 		provisioner:        provisioner,
-		dual:               dual,
 		serverLock:         serverLockService,
 		cfg:                cfg,
 	}
@@ -89,15 +75,6 @@ func New(ctx context.Context, configDirectory string, provisioner dashboards.Das
 // Provision scans the disk for dashboards and updates
 // the database with the latest versions of those dashboards.
 func (provider *Provisioner) Provision(ctx context.Context) error {
-	// skip provisioning during migrations to prevent multi-replica instances from crashing when another replica is migrating
-	if provider.dual != nil {
-		status, _ := provider.dual.Status(context.Background(), dashboardV1.DashboardResourceInfo.GroupResource())
-		if status.Migrating > 0 {
-			provider.log.Info("dashboard migrations are running, skipping provisioning", "elapsed", time.Since(time.UnixMilli(status.Migrating)))
-			return nil
-		}
-	}
-
 	var errProvisioning error
 
 	// retry obtaining the lock for 20 attempts

--- a/pkg/services/provisioning/dashboards/file_reader.go
+++ b/pkg/services/provisioning/dashboards/file_reader.go
@@ -63,7 +63,6 @@ type FileReader struct {
 	dashboardStore               utils.DashboardStore
 	FoldersFromFilesStructure    bool
 	folderService                folder.Service
-	foldersInUnified             bool
 	settingCfg                   *setting.Cfg
 
 	mux                     sync.RWMutex
@@ -447,9 +446,7 @@ func (fr *FileReader) getOrCreateFolderInternal(ctx context.Context, orgID int64
 		return 0, "", folder.ErrInvalidUID
 	}
 
-	// When we expect folders in unified storage, they should have a manager indicated.
-	// NOTE: when everything has been running in mode5 for a while, this check can be removed.
-	if err == nil && result != nil && result.ManagedBy == "" && fr.foldersInUnified {
+	if err == nil && result != nil && result.ManagedBy == "" {
 		result, err = fr.dashboardProvisioningService.UpdateFolderWithManagedByAnnotation(ctx, result, fr.Cfg.Name)
 		if err != nil {
 			return 0, "", fmt.Errorf("unable to update provisioned folder")

--- a/pkg/services/provisioning/dashboards/file_reader_test.go
+++ b/pkg/services/provisioning/dashboards/file_reader_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
@@ -438,6 +439,13 @@ func TestIntegrationDashboardFileReader(t *testing.T) {
 
 			fakeService.On("GetProvisionedDashboardData", mock.Anything, configName).Return(nil, nil).Twice()
 			// Folders are pre-seeded in the fake with non-hash UIDs; provisioning must not create folders.
+			// UpdateFolderWithManagedByAnnotation is called for each pre-existing folder that lacks ManagedBy.
+			fakeService.On("UpdateFolderWithManagedByAnnotation", mock.Anything, mock.Anything, configName).
+				Return(func(ctx context.Context, f *folder.Folder, name string) (*folder.Folder, error) {
+					updated := *f
+					updated.ManagedBy = utils.ManagerKind(name)
+					return &updated, nil
+				})
 			fakeService.On("SaveProvisionedDashboard", mock.Anything, mock.Anything, mock.Anything).Return(&dashboards.Dashboard{}, nil).Times(10)
 
 			reader, err := NewDashboardFileReader(cfg, logger, fakeService, fakeStore, folderServiceWithPreexistingFilesStructureHierarchy(), cfgT)

--- a/pkg/services/provisioning/provisioning.go
+++ b/pkg/services/provisioning/provisioning.go
@@ -172,7 +172,7 @@ func (ps *ProvisioningServiceImpl) running(ctx context.Context) error {
 
 func (ps *ProvisioningServiceImpl) setDashboardProvisioner() error {
 	dashboardPath := filepath.Join(ps.Cfg.ProvisioningPath, "dashboards")
-	dashProvisioner, err := ps.newDashboardProvisioner(context.Background(), dashboardPath, ps.dashboardProvisioningService, ps.Cfg, ps.orgService, ps.dashboardService, ps.folderService, ps.dual, ps.serverLock)
+	dashProvisioner, err := ps.newDashboardProvisioner(context.Background(), dashboardPath, ps.dashboardProvisioningService, ps.Cfg, ps.orgService, ps.dashboardService, ps.folderService, ps.serverLock)
 	if err != nil {
 		return fmt.Errorf("%v: %w", "Failed to create provisioner", err)
 	}

--- a/pkg/services/provisioning/provisioning_test.go
+++ b/pkg/services/provisioning/provisioning_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/provisioning/datasources"
 	"github.com/grafana/grafana/pkg/services/provisioning/utils"
 	"github.com/grafana/grafana/pkg/setting"
-	"github.com/grafana/grafana/pkg/storage/legacysql/dualwrite"
 )
 
 func TestProvisioningServiceImpl(t *testing.T) {
@@ -159,7 +158,7 @@ func setup(t *testing.T) *serviceTestStruct {
 	}
 
 	service, err := newProvisioningServiceImpl(
-		func(context.Context, string, dashboardstore.DashboardProvisioningService, *setting.Cfg, org.Service, utils.DashboardStore, folder.Service, dualwrite.Service, *serverlock.ServerLockService) (dashboards.DashboardProvisioner, error) {
+		func(context.Context, string, dashboardstore.DashboardProvisioningService, *setting.Cfg, org.Service, utils.DashboardStore, folder.Service, *serverlock.ServerLockService) (dashboards.DashboardProvisioner, error) {
 			serviceTest.dashboardProvisionerInstantiations++
 			return serviceTest.mock, nil
 		},


### PR DESCRIPTION
This PR cleans up no longer used code in the file based provisioning:
- Folders are now permanently in unified storage - so we no longer need to do any `foldersInUnified` checks
- The migrating logic is also dead code - [status](https://github.com/grafana/grafana/blob/e452353940aa2044f6e7fe862722cf1f745c344b/pkg/storage/legacysql/dualwrite/storage_service.go#L97) does not return a `Migrating` field anymore.

