### PR TITLE
Fix documentation CI build

### DIFF
--- a/.github/workflows/documentation-ci.yml
+++ b/.github/workflows/documentation-ci.yml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   vale:
-    runs-on: ubuntu-x86
+    runs-on: ubuntu-x64-small
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/documentation-ci.yml
+++ b/.github/workflows/documentation-ci.yml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   vale:
-    runs-on: ubuntu-arm64
+    runs-on: ubuntu-x86
     permissions:
       contents: read
       pull-requests: write


### PR DESCRIPTION
There's an architecture mismatch with our use of an alpine based image and the shift to self hosted runners:

https://github.com/grafana/grafana/actions/runs/26466920881/job/77946721741?pr=125474

```
Run actions/checkout@v5
/usr/bin/docker exec  126e8f326612767e3d5ae9299a9e386a755844a795235ed35ff658bbf0e95066 sh -c "cat /etc/*release | grep ^ID"
Error: JavaScript Actions in Alpine containers are only supported on x64 Linux runners. Detected Linux Arm64
```
