### PR TITLE
Candlestick: Stabilize bar width across refreshes

### DIFF
--- a/public/app/plugins/panel/candlestick/utils.test.ts
+++ b/public/app/plugins/panel/candlestick/utils.test.ts
@@ -1,0 +1,51 @@
+import { representativeDelta } from './utils';
+
+describe('representativeDelta', () => {
+  it('returns the spacing for uniform data', () => {
+    expect(representativeDelta([1000, 2000, 3000, 4000], [1, 1, 1, 1])).toBe(1000);
+  });
+
+  it('ignores a small first gap from a partial edge bucket', () => {
+    // gaps: 250, 1000, 1000, 1000 -> drop edges -> [1000, 1000] -> 1000, not 250
+    expect(representativeDelta([0, 250, 1250, 2250, 3250], [1, 1, 1, 1, 1])).toBe(1000);
+  });
+
+  it('ignores a small last gap from a partial edge bucket', () => {
+    // gaps: 1000, 1000, 1000, 100 -> drop edges -> [1000, 1000] -> 1000
+    expect(representativeDelta([0, 1000, 2000, 3000, 3100], [1, 1, 1, 1, 1])).toBe(1000);
+  });
+
+  it('is not dominated by an interior outlier gap (missing bucket)', () => {
+    // one missing bucket at 4000 -> gaps 1000,1000,1000,2000,1000,1000
+    // interior (drop edges) 1000,1000,2000,1000 -> median 1000, not the 2000 outlier
+    expect(representativeDelta([0, 1000, 2000, 3000, 5000, 6000, 7000], [1, 1, 1, 1, 1, 1, 1])).toBe(1000);
+  });
+
+  it('stays stable under timestamp jitter where a mode would degenerate', () => {
+    // gaps: 1000, 1001, 998, 1001 (all distinct) -> interior [1001, 998] -> median 999.5
+    expect(representativeDelta([0, 1000, 2001, 2999, 4000], [1, 1, 1, 1, 1])).toBe(999.5);
+  });
+
+  it('skips null and undefined y values', () => {
+    // valid points at x = 0, 2000, 3000 -> gaps 2000, 1000 -> median 1500
+    expect(representativeDelta([0, 1000, 2000, 3000], [1, null, 1, 1])).toBe(1500);
+    expect(representativeDelta([0, 1000, 2000, 3000], [1, undefined, 1, 1])).toBe(1500);
+  });
+
+  it('skips non-positive and non-finite deltas', () => {
+    // duplicate timestamp (delta 0) and NaN x are dropped -> only the 1000 gap remains
+    expect(representativeDelta([1000, 1000, 2000], [1, 1, 1])).toBe(1000);
+    expect(representativeDelta([1000, NaN, 2000, 3000], [1, 1, 1, 1])).toBe(1000);
+  });
+
+  it('handles short series without edge exclusion', () => {
+    expect(representativeDelta([1000, 2000], [1, 1])).toBe(1000); // one gap
+    expect(representativeDelta([0, 1000, 4000], [1, 1, 1])).toBe(2000); // two gaps -> median
+  });
+
+  it('returns null with fewer than two valid points', () => {
+    expect(representativeDelta([], [])).toBeNull();
+    expect(representativeDelta([1000], [1])).toBeNull();
+    expect(representativeDelta([1000, 2000], [null, 1])).toBeNull();
+  });
+});

--- a/public/app/plugins/panel/candlestick/utils.ts
+++ b/public/app/plugins/panel/candlestick/utils.ts
@@ -8,6 +8,45 @@ const { alpha } = colorManipulator;
 
 export type FieldIndices = Record<string, number>;
 
+/**
+ * Computes a representative spacing (in x-axis units) between adjacent points, used to
+ * derive candle/bar width. Returns null when there are fewer than two valid points.
+ *
+ * The first and last gaps are excluded because, on a sliding relative time range, the
+ * edge buckets are partial and produce gaps smaller than the real interval. Driving the
+ * width off the global minimum (the old behavior) made every bar shrink whenever such an
+ * edge gap appeared, so widths changed "randomly" on each refresh. The median of the
+ * remaining gaps is robust to those outliers, to missing buckets, and to timestamp
+ * jitter (where a mode would degenerate back toward the minimum).
+ */
+export function representativeDelta(dataX: ArrayLike<number>, dataY: ArrayLike<number | null | undefined>) {
+  let gaps: number[] = [];
+  let prevIdx: number | null = null;
+
+  for (let i = 0; i < dataX.length; i++) {
+    if (dataY[i] != null) {
+      if (prevIdx != null) {
+        let delta = dataX[i] - dataX[prevIdx];
+        if (Number.isFinite(delta) && delta > 0) {
+          gaps.push(delta);
+        }
+      }
+      prevIdx = i;
+    }
+  }
+
+  if (gaps.length === 0) {
+    return null;
+  }
+
+  // drop the partial edge buckets; keep all when too short to have interior gaps
+  let core = gaps.length >= 3 ? gaps.slice(1, -1) : gaps;
+  core.sort((a, b) => a - b);
+
+  let mid = Math.floor(core.length / 2);
+  return core.length % 2 !== 0 ? core[mid] : (core[mid - 1] + core[mid]) / 2;
+}
+
 interface RendererOpts {
   mode: VizDisplayMode;
   candleStyle: CandleStyle;
@@ -78,26 +117,11 @@ export function drawMarkers(opts: RendererOpts) {
 
     let colWidth = u.bbox.width;
 
-    if (dataX.length > 1) {
-      // prior index with non-undefined y data
-      let prevIdx = null;
-
-      // scan full dataset for smallest adjacent delta
-      // will not work properly for non-linear x scales, since does not do expensive valToPosX calcs till end
-      for (let i = 0, minDelta = Infinity; i < dataX.length; i++) {
-        if (dataY[i] !== undefined) {
-          if (prevIdx != null) {
-            let delta = Math.abs(dataX[i] - dataX[prevIdx]);
-
-            if (delta < minDelta) {
-              minDelta = delta;
-              colWidth = Math.abs(u.valToPos(dataX[i], 'x', true) - u.valToPos(dataX[prevIdx], 'x', true));
-            }
-          }
-
-          prevIdx = i;
-        }
-      }
+    let repDelta = representativeDelta(dataX, dataY);
+    if (repDelta != null) {
+      // assumes a linear x scale (true for time series); convert the representative
+      // delta to pixels once instead of probing every adjacent pair
+      colWidth = Math.abs(u.valToPos(dataX[0] + repDelta, 'x', true) - u.valToPos(dataX[0], 'x', true));
     }
 
     let barWidth = Math.round(0.6 * colWidth);


### PR DESCRIPTION
## What this PR does / why we need it

Fixes #125362. Candlestick bar widths changed "randomly" on every dashboard refresh.

The width of every bar was derived from the **single smallest** adjacent time delta found by scanning the whole dataset. On a sliding relative range, the partial first/last buckets occasionally produce a sub-interval gap, so that minimum — and therefore every bar's width — jumped on each refresh.

This replaces the min-delta scan with a `representativeDelta()` helper that:
- excludes the first and last gaps (the partial edge buckets), then
- takes the **median** of the remaining gaps.

Median is robust to timestamp jitter (where a mode would degenerate back to the minimum) and to occasional missing buckets. For uniform data it equals the previous minimum, so correct rendering is unchanged — the existing canvas snapshots pass without modification.

## Which issue(s) this PR fixes

Fixes #125362

## Special notes for your reviewer

- `representativeDelta` is extracted as a pure, exported function with focused unit tests (uniform spacing, small first/last edge gaps, interior missing-bucket outlier, timestamp jitter, null/undefined and non-finite/duplicate timestamps, short series).
- Trade-off: bars may overlap on genuinely irregular data where neighbours are closer than the median — accepted as a better failure mode than the previous "invisible 1px bars" on regular data.
- Assumes a linear x scale (time series), matching the pre-existing assumption in this renderer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)