### PR TITLE
CI: Update auto-milestone to use x64 runners

### DIFF
--- a/.github/workflows/auto-milestone.yml
+++ b/.github/workflows/auto-milestone.yml
@@ -13,7 +13,7 @@ permissions: {}
 # so it must not run untrusted code (such as checking out the pull request)
 jobs:
   main:
-    runs-on: ubuntu-arm64-small
+    runs-on: ubuntu-x64-small
     permissions:
       # contents: read is needed to read package.json from the PR's base branch.
       contents: read


### PR DESCRIPTION
It cannot run under ARM64


