### PR TITLE
Unified Storage: Restrict tenant_watcher_allow_insecure_tls to development mode

### DIFF
--- a/pkg/storage/unified/resource/tenant_watcher.go
+++ b/pkg/storage/unified/resource/tenant_watcher.go
@@ -110,12 +110,19 @@ func NewTenantWatcherConfig(cfg *setting.Cfg) *TenantWatcherConfig {
 	}
 
 	grpcSection := cfg.SectionWithEnvOverrides("grpc_client_authentication")
+	allowInsecure := cfg.TenantWatcherAllowInsecureTLS
+	if allowInsecure && cfg.Env != setting.Dev {
+		logger.Error("tenant_watcher_allow_insecure_tls is set but app_mode is not 'development'; ignoring and enforcing TLS verification. Provide a CA via tenant_watcher_ca_file or set app_mode=development.",
+			"app_mode", cfg.Env)
+		allowInsecure = false
+	}
+
 	tenantWatcherCfg := &TenantWatcherConfig{
 		TenantAPIServerURL: strings.TrimSpace(cfg.TenantApiServerAddress),
 		Token:              strings.TrimSpace(grpcSection.Key("token").MustString("")),
 		TokenExchangeURL:   strings.TrimSpace(grpcSection.Key("token_exchange_url").MustString("")),
 		CAFile:             strings.TrimSpace(cfg.TenantWatcherCAFile),
-		AllowInsecure:      cfg.TenantWatcherAllowInsecureTLS,
+		AllowInsecure:      allowInsecure,
 		UsePolling:         cfg.TenantWatcherUsePolling,
 		PollInterval:       cfg.TenantWatcherPollInterval,
 		Log:                logger,

--- a/pkg/storage/unified/resource/tenant_watcher_test.go
+++ b/pkg/storage/unified/resource/tenant_watcher_test.go
@@ -64,6 +64,22 @@ func TestNewTenantWatcherConfig(t *testing.T) {
 		cfg.SectionWithEnvOverrides("grpc_client_authentication").Key("token_exchange_url").SetValue("")
 		require.Nil(t, NewTenantWatcherConfig(cfg))
 	})
+
+	t.Run("ignores allow_insecure_tls outside development", func(t *testing.T) {
+		cfg := newCfg()
+		cfg.Env = setting.Prod
+		tenantWatcherCfg := NewTenantWatcherConfig(cfg)
+		require.NotNil(t, tenantWatcherCfg)
+		require.False(t, tenantWatcherCfg.AllowInsecure, "AllowInsecure must be forced off when app_mode is not development")
+	})
+
+	t.Run("honours allow_insecure_tls in development", func(t *testing.T) {
+		cfg := newCfg()
+		cfg.Env = setting.Dev
+		tenantWatcherCfg := NewTenantWatcherConfig(cfg)
+		require.NotNil(t, tenantWatcherCfg)
+		require.True(t, tenantWatcherCfg.AllowInsecure)
+	})
 }
 
 func TestTenantAddPendingDeleted(t *testing.T) {


### PR DESCRIPTION
## Summary
- `NewTenantWatcherConfig` forces `AllowInsecure` off (with an error log) when `app_mode` is not `development`.

## Test plan
- [x] `go test -run TestNewTenantWatcherConfig ./pkg/storage/unified/resource/`