### PR TITLE
[release-12.3.7] Datasources: return 400 when payload UID does not match URL UID in PUT /api/datasources/uid/:uid

### DIFF
--- a/pkg/api/datasources.go
+++ b/pkg/api/datasources.go
@@ -491,7 +491,12 @@ func (hs *HTTPServer) UpdateDataSourceByUID(c *contextmodel.ReqContext) response
 		return response.Error(http.StatusBadRequest, "Failed to update datasource", err)
 	}
 
-	ds, err := hs.getRawDataSourceByUID(c.Req.Context(), web.Params(c.Req)[":uid"], c.GetOrgID())
+	urlUID := web.Params(c.Req)[":uid"]
+	if cmd.UID != "" && cmd.UID != urlUID {
+		return response.Error(http.StatusBadRequest, "UID in the payload must match the UID in the URL", nil)
+	}
+
+	ds, err := hs.getRawDataSourceByUID(c.Req.Context(), urlUID, c.GetOrgID())
 	if err != nil {
 		if errors.Is(err, datasources.ErrDataSourceNotFound) {
 			return response.Error(http.StatusNotFound, "Data source not found", nil)

--- a/pkg/api/datasources_test.go
+++ b/pkg/api/datasources_test.go
@@ -341,6 +341,33 @@ func TestUpdateDataSourceByID_DataSourceNameExists(t *testing.T) {
 	require.Equal(t, http.StatusConflict, sc.resp.Code)
 }
 
+func TestUpdateDataSourceByUID_UIDMismatch(t *testing.T) {
+	hs := &HTTPServer{
+		DataSourcesService: &dataSourcesServiceMock{
+			expectedDatasource: &datasources.DataSource{},
+		},
+		Cfg:                  setting.NewCfg(),
+		AccessControl:        acimpl.ProvideAccessControl(featuremgmt.WithFeatures()),
+		accesscontrolService: actest.FakeService{},
+	}
+	sc := setupScenarioContext(t, "/api/datasources/uid/url-uid")
+
+	sc.m.Put(sc.url, routing.Wrap(func(c *contextmodel.ReqContext) response.Response {
+		c.Req = web.SetURLParams(c.Req, map[string]string{":uid": "url-uid"})
+		c.Req.Body = mockRequestBody(datasources.UpdateDataSourceCommand{
+			UID:    "different-uid",
+			Access: "proxy",
+			Type:   "test",
+			Name:   "test",
+		})
+		return hs.UpdateDataSourceByUID(c)
+	}))
+
+	sc.fakeReqWithParams("PUT", sc.url, map[string]string{}).exec()
+
+	require.Equal(t, http.StatusBadRequest, sc.resp.Code)
+}
+
 func TestAPI_datasources_AccessControl(t *testing.T) {
 	type testCase struct {
 		desc         string


### PR DESCRIPTION
Backport e99df4816b6 from #125398

---

## Summary

`PUT /api/datasources/uid/:uid` was silently ignoring a mismatched UID in the JSON payload — the mismatch would eventually cause a `500 Internal Server Error` from the service layer. This adds an explicit `400 Bad Request` when the payload UID differs from the URL UID.

## Changes

- `pkg/api/datasources.go`: validate payload UID against URL param before datasource lookup
- `pkg/api/datasources_test.go`: add `TestUpdateDataSourceByUID_UIDMismatch`