### PR TITLE
Provisioning: Require new token when provisioning URL changes

### DIFF
--- a/apps/provisioning/pkg/repository/mutator.go
+++ b/apps/provisioning/pkg/repository/mutator.go
@@ -83,3 +83,7 @@ func CopySecureValues(new, old *provisioning.Repository) {
 		new.Secure.WebhookSecret = old.Secure.WebhookSecret
 	}
 }
+
+func RequiresNewTokenForURLChange(new, old *provisioning.Repository) bool {
+	return old != nil && new.URL() != old.URL() && new.Secure.Token.IsZero()
+}

--- a/apps/provisioning/pkg/repository/validator.go
+++ b/apps/provisioning/pkg/repository/validator.go
@@ -255,6 +255,14 @@ func (v *AdmissionValidator) Validate(ctx context.Context, a admission.Attribute
 	// Copy previous values if they exist
 	if a.GetOldObject() != nil {
 		if oldRepo, ok := a.GetOldObject().(*provisioning.Repository); ok {
+			if a.GetOperation() == admission.Update && RequiresNewTokenForURLChange(r, oldRepo) {
+				return invalidRepositoryError(a.GetName(), field.ErrorList{
+					field.Forbidden(
+						field.NewPath("secure", "token"),
+						"a new token is required when changing the repository URL",
+					),
+				})
+			}
 			CopySecureValues(r, oldRepo)
 		}
 	}

--- a/apps/provisioning/pkg/repository/validator_test.go
+++ b/apps/provisioning/pkg/repository/validator_test.go
@@ -744,6 +744,87 @@ func TestAdmissionValidator_CopiesSecureValuesOnUpdate(t *testing.T) {
 	assert.Equal(t, "old-secret", newRepo.Secure.WebhookSecret.Name)
 }
 
+func TestAdmissionValidator_RequiresNewTokenWhenURLChanges(t *testing.T) {
+	tests := []struct {
+		name            string
+		oldURL          string
+		newURL          string
+		newToken        common.InlineSecureValue
+		wantErr         bool
+		wantErrContains string
+	}{
+		{
+			name:            "rejects url change without new token",
+			oldURL:          "https://github.com/grafana/old",
+			newURL:          "https://github.com/grafana/new",
+			wantErr:         true,
+			wantErrContains: "secure.token",
+		},
+		{
+			name:     "allows url change with new token",
+			oldURL:   "https://github.com/grafana/old",
+			newURL:   "https://github.com/grafana/new",
+			newToken: common.InlineSecureValue{Create: "new-token"},
+			wantErr:  false,
+		},
+		{
+			name:    "allows unchanged url without new token",
+			oldURL:  "https://github.com/grafana/repo",
+			newURL:  "https://github.com/grafana/repo",
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockFactory := NewMockFactory(t)
+			mockFactory.EXPECT().Validate(mock.Anything, mock.Anything).Return(field.ErrorList{}).Maybe()
+
+			validator := NewValidator(false, mockFactory)
+			admissionValidator := NewAdmissionValidator(
+				[]provisioning.SyncTargetType{provisioning.SyncTargetTypeFolder},
+				validator,
+			)
+
+			oldRepo := newGitHubRepositoryForURLChangeTest(tt.oldURL)
+			oldRepo.Secure.Token = common.InlineSecureValue{Name: "old-token"}
+
+			newRepo := newGitHubRepositoryForURLChangeTest(tt.newURL)
+			newRepo.Secure.Token = tt.newToken
+
+			attr := newAdmissionValidatorTestAttributes(newRepo, oldRepo, admission.Update)
+
+			err := admissionValidator.Validate(context.Background(), attr, nil)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrContains)
+				assert.True(t, newRepo.Secure.Token.IsZero(), "old token should not be copied after rejection")
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+func newGitHubRepositoryForURLChangeTest(url string) *provisioning.Repository {
+	return &provisioning.Repository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "test",
+			Finalizers: []string{CleanFinalizer},
+		},
+		Spec: provisioning.RepositorySpec{
+			Title: "Test Repo",
+			Type:  provisioning.GitHubRepositoryType,
+			GitHub: &provisioning.GitHubRepositoryConfig{
+				URL:    url,
+				Branch: "main",
+			},
+			Sync: provisioning.SyncOptions{IntervalSeconds: 60},
+		},
+	}
+}
+
 // mockValidator implements Validator for testing
 type mockValidator struct {
 	called bool

--- a/pkg/registry/apis/provisioning/test.go
+++ b/pkg/registry/apis/provisioning/test.go
@@ -134,6 +134,12 @@ func (s *testConnector) Connect(ctx context.Context, name string, _ runtime.Obje
 					old, _ := s.repoGetter.GetRepository(ctx, name)
 					if old != nil {
 						oldCfg := old.Config()
+						if repository.RequiresNewTokenForURLChange(&cfg, oldCfg) {
+							responder.Error(k8serrors.NewBadRequest(
+								"a new token is required when changing the repository URL",
+							))
+							return
+						}
 						repository.CopySecureValues(&cfg, oldCfg)
 
 						// Copying previous finalizers

--- a/pkg/registry/apis/provisioning/test_test.go
+++ b/pkg/registry/apis/provisioning/test_test.go
@@ -1,0 +1,192 @@
+package provisioning
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apiserver/pkg/endpoints/request"
+
+	provisioningv0alpha1 "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/apps/provisioning/pkg/connection"
+	appcontroller "github.com/grafana/grafana/apps/provisioning/pkg/controller"
+	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
+	common "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
+	provisioningcontroller "github.com/grafana/grafana/pkg/registry/apis/provisioning/controller"
+)
+
+func TestTestConnector_RequiresNewTokenWhenURLChanges(t *testing.T) {
+	oldRepo := &staticTestRepository{
+		cfg: testGitHubRepository("test", "default", "https://github.com/grafana/old"),
+	}
+	oldRepo.cfg.Secure.Token = common.InlineSecureValue{Name: "old-token"}
+
+	repoFactory := repository.NewMockFactory(t)
+	connector := NewTestConnector(
+		&testConnectorDeps{repo: oldRepo, repoFactory: repoFactory},
+		repository.NewTester(),
+	)
+
+	responder := &testResponder{}
+	handler, err := connector.Connect(request.WithNamespace(context.Background(), "default"), "test", nil, responder)
+	require.NoError(t, err)
+
+	body := `{"spec":{"title":"Test Repo","type":"github","github":{"url":"https://github.com/grafana/new","branch":"main"}}}`
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(body)))
+
+	require.Error(t, responder.err)
+	status := responder.err.(apierrors.APIStatus).Status()
+	assert.Equal(t, int32(http.StatusBadRequest), status.Code)
+	assert.Contains(t, status.Message, "a new token is required when changing the repository URL")
+}
+
+func TestTestConnector_AllowsURLChangeWithNewToken(t *testing.T) {
+	oldRepo := &staticTestRepository{
+		cfg: testGitHubRepository("test", "default", "https://github.com/grafana/old"),
+	}
+	oldRepo.cfg.Secure.Token = common.InlineSecureValue{Name: "old-token"}
+
+	tmpRepo := &staticTestRepository{
+		cfg: testGitHubRepository("test", "default", "https://github.com/grafana/new"),
+		rsp: &provisioningv0alpha1.TestResults{Success: true, Code: http.StatusOK},
+	}
+
+	repoFactory := repository.NewMockFactory(t)
+	repoFactory.EXPECT().Build(mock.Anything, mock.MatchedBy(func(cfg *provisioningv0alpha1.Repository) bool {
+		return cfg.URL() == "https://github.com/grafana/new" &&
+			cfg.Secure.Token.Create == common.RawSecureValue("new-token")
+	})).Return(tmpRepo, nil).Once()
+
+	responder := &testResponder{}
+	connector := NewTestConnector(
+		&testConnectorDeps{repo: oldRepo, repoFactory: repoFactory},
+		repository.NewTester(),
+	)
+	handler, err := connector.Connect(request.WithNamespace(context.Background(), "default"), "test", nil, responder)
+	require.NoError(t, err)
+
+	body := `{"spec":{"title":"Test Repo","type":"github","github":{"url":"https://github.com/grafana/new","branch":"main"}},"secure":{"token":{"create":"new-token"}}}`
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(body)))
+
+	require.NoError(t, responder.err)
+	assert.Equal(t, http.StatusOK, responder.statusCode)
+	assert.True(t, tmpRepo.testCalled)
+}
+
+func TestTestConnector_AllowsUnchangedURLWithoutNewToken(t *testing.T) {
+	oldRepo := &staticTestRepository{
+		cfg: testGitHubRepository("test", "default", "https://github.com/grafana/repo"),
+	}
+	oldRepo.cfg.Secure.Token = common.InlineSecureValue{Name: "old-token"}
+
+	tmpRepo := &staticTestRepository{
+		cfg: testGitHubRepository("test", "default", "https://github.com/grafana/repo"),
+		rsp: &provisioningv0alpha1.TestResults{Success: true, Code: http.StatusOK},
+	}
+
+	repoFactory := repository.NewMockFactory(t)
+	repoFactory.EXPECT().Build(mock.Anything, mock.MatchedBy(func(cfg *provisioningv0alpha1.Repository) bool {
+		return cfg.URL() == "https://github.com/grafana/repo" &&
+			cfg.Secure.Token.Name == "old-token"
+	})).Return(tmpRepo, nil).Once()
+
+	responder := &testResponder{}
+	connector := NewTestConnector(
+		&testConnectorDeps{repo: oldRepo, repoFactory: repoFactory},
+		repository.NewTester(),
+	)
+	handler, err := connector.Connect(request.WithNamespace(context.Background(), "default"), "test", nil, responder)
+	require.NoError(t, err)
+
+	body := `{"spec":{"title":"Updated Title","type":"github","github":{"url":"https://github.com/grafana/repo","branch":"main"}}}`
+	handler.ServeHTTP(httptest.NewRecorder(), httptest.NewRequest(http.MethodPost, "/test", strings.NewReader(body)))
+
+	require.NoError(t, responder.err)
+	assert.Equal(t, http.StatusOK, responder.statusCode)
+	assert.True(t, tmpRepo.testCalled)
+}
+
+type testResponder struct {
+	statusCode int
+	object     runtime.Object
+	err        error
+}
+
+func (r *testResponder) Object(statusCode int, obj runtime.Object) {
+	r.statusCode = statusCode
+	r.object = obj
+}
+
+func (r *testResponder) Error(err error) {
+	r.err = err
+}
+
+type testConnectorDeps struct {
+	repo        repository.Repository
+	repoFactory repository.Factory
+}
+
+func (d *testConnectorDeps) GetRepository(_ context.Context, _ string) (repository.Repository, error) {
+	return d.repo, nil
+}
+
+func (d *testConnectorDeps) GetHealthyRepository(_ context.Context, _ string) (repository.Repository, error) {
+	return d.repo, nil
+}
+
+func (d *testConnectorDeps) GetConnection(_ context.Context, _ string) (connection.Connection, error) {
+	return nil, nil
+}
+
+func (d *testConnectorDeps) GetStatusPatcher() *appcontroller.RepositoryStatusPatcher {
+	return nil
+}
+
+func (d *testConnectorDeps) GetHealthChecker() *provisioningcontroller.RepositoryHealthChecker {
+	return nil
+}
+
+func (d *testConnectorDeps) GetRepoFactory() repository.Factory {
+	return d.repoFactory
+}
+
+type staticTestRepository struct {
+	cfg        *provisioningv0alpha1.Repository
+	rsp        *provisioningv0alpha1.TestResults
+	testCalled bool
+}
+
+func (r *staticTestRepository) Config() *provisioningv0alpha1.Repository {
+	return r.cfg
+}
+
+func (r *staticTestRepository) Test(context.Context) (*provisioningv0alpha1.TestResults, error) {
+	r.testCalled = true
+	return r.rsp, nil
+}
+
+func testGitHubRepository(name, namespace, url string) *provisioningv0alpha1.Repository {
+	return &provisioningv0alpha1.Repository{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       name,
+			Namespace:  namespace,
+			Finalizers: []string{repository.CleanFinalizer},
+		},
+		Spec: provisioningv0alpha1.RepositorySpec{
+			Title: "Test Repo",
+			Type:  provisioningv0alpha1.GitHubRepositoryType,
+			GitHub: &provisioningv0alpha1.GitHubRepositoryConfig{
+				URL:    url,
+				Branch: "main",
+			},
+		},
+	}
+}

--- a/pkg/tests/apis/provisioning/git/url_token_test.go
+++ b/pkg/tests/apis/provisioning/git/url_token_test.go
@@ -34,7 +34,7 @@ func TestIntegrationProvisioning_GitRequiresNewTokenWhenRepositoryURLChanges(t *
 			updated := common.MustToUnstructured(t, repo)
 			require.NoError(collect, unstructured.SetNestedField(updated.Object, "https://some-new-url/", "spec", "git", "url"))
 			unstructured.RemoveNestedField(updated.Object, "secure", "token")
-			
+
 			_, err = helper.Repositories.Resource.Update(ctx, updated, metav1.UpdateOptions{})
 			require.Error(collect, err)
 			require.True(collect, apierrors.IsInvalid(err), "expected invalid repository update, got %v", err)
@@ -51,16 +51,16 @@ func TestIntegrationProvisioning_GitRequiresNewTokenWhenRepositoryURLChanges(t *
 			require.NoError(collect, err)
 
 			repoObj := common.MustFromUnstructured[provisioning.Repository](t, repo)
-     		repoObj.Spec.Git.URL = changedRemote.URL
-     		repoObj.Spec.Git.TokenUser = changedUser.Username
-     		repoObj.Secure.Token = apicommon.InlineSecureValue{Create: apicommon.RawSecureValue(changedUser.Password)}
-     
-     		result, err := helper.Repositories.Resource.Update(ctx, common.MustToUnstructured(t, repoObj), metav1.UpdateOptions{})
-     		require.NoError(collect, err)
-     
-     		updatedRepo := common.MustFromUnstructured[provisioning.Repository](t, result)
-     		require.Equal(collect, changedRemote.URL, updatedRepo.Spec.Git.URL)
-     		require.NotEmpty(collect, updatedRepo.Secure.Token.Name)
+			repoObj.Spec.Git.URL = changedRemote.URL
+			repoObj.Spec.Git.TokenUser = changedUser.Username
+			repoObj.Secure.Token = apicommon.InlineSecureValue{Create: apicommon.RawSecureValue(changedUser.Password)}
+
+			result, err := helper.Repositories.Resource.Update(ctx, common.MustToUnstructured(t, repoObj), metav1.UpdateOptions{})
+			require.NoError(collect, err)
+
+			updatedRepo := common.MustFromUnstructured[provisioning.Repository](t, result)
+			require.Equal(collect, changedRemote.URL, updatedRepo.Spec.Git.URL)
+			require.NotEmpty(collect, updatedRepo.Secure.Token.Name)
 		}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
 	})
 

--- a/pkg/tests/apis/provisioning/git/url_token_test.go
+++ b/pkg/tests/apis/provisioning/git/url_token_test.go
@@ -1,0 +1,164 @@
+package git
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	apicommon "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
+	"github.com/grafana/nanogit/gittest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+)
+
+func TestIntegrationProvisioning_GitRequiresNewTokenWhenRepositoryURLChanges(t *testing.T) {
+	helper := sharedGitHelper(t)
+	ctx := context.Background()
+
+	repoName := "git-url-change-test"
+	helper.CreateGitRepo(t, repoName, map[string][]byte{
+		"dashboard.json": common.DashboardJSON(repoName+"-dashboard", "Dashboard", 1),
+	}, "write")
+
+	t.Run("update rejects url change without a new token", func(t *testing.T) {
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			repo, err := helper.Repositories.Resource.Get(ctx, repoName, metav1.GetOptions{})
+			require.NoError(collect, err)
+			updated := common.MustToUnstructured(t, repo)
+			require.NoError(collect, unstructured.SetNestedField(updated.Object, "https://some-new-url/", "spec", "git", "url"))
+			unstructured.RemoveNestedField(updated.Object, "secure", "token")
+			
+			_, err = helper.Repositories.Resource.Update(ctx, updated, metav1.UpdateOptions{})
+			require.Error(collect, err)
+			require.True(collect, apierrors.IsInvalid(err), "expected invalid repository update, got %v", err)
+			require.ErrorContains(collect, err, "secure.token")
+			require.ErrorContains(collect, err, "a new token is required when changing the repository URL")
+		}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
+	})
+
+	t.Run("update allows url change with a new token", func(t *testing.T) {
+		changedRemote, changedUser := createEmptyGitRepo(t, helper, "git-url-change-new-token-new")
+
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			repo, err := helper.Repositories.Resource.Get(ctx, repoName, metav1.GetOptions{})
+			require.NoError(collect, err)
+
+			repoObj := common.MustFromUnstructured[provisioning.Repository](t, repo)
+     		repoObj.Spec.Git.URL = changedRemote.URL
+     		repoObj.Spec.Git.TokenUser = changedUser.Username
+     		repoObj.Secure.Token = apicommon.InlineSecureValue{Create: apicommon.RawSecureValue(changedUser.Password)}
+     
+     		result, err := helper.Repositories.Resource.Update(ctx, common.MustToUnstructured(t, repoObj), metav1.UpdateOptions{})
+     		require.NoError(collect, err)
+     
+     		updatedRepo := common.MustFromUnstructured[provisioning.Repository](t, result)
+     		require.Equal(collect, changedRemote.URL, updatedRepo.Spec.Git.URL)
+     		require.NotEmpty(collect, updatedRepo.Secure.Token.Name)
+		}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
+	})
+
+	t.Run("test subresource rejects url change without a new token", func(t *testing.T) {
+		changedRemote, changedUser := createEmptyGitRepo(t, helper, "git-url-change-test-no-token-new")
+
+		repoConfig := map[string]any{
+			"apiVersion": "provisioning.grafana.app/v0alpha1",
+			"kind":       "Repository",
+			"spec": map[string]any{
+				"title": "Changed Git Repo URL",
+				"type":  "git",
+				"git": map[string]any{
+					"url":       changedRemote.URL,
+					"branch":    "main",
+					"tokenUser": changedUser.Username,
+				},
+				"sync": map[string]any{
+					"enabled":         false,
+					"target":          "instance",
+					"intervalSeconds": 60,
+				},
+				"workflows": []string{},
+			},
+		}
+
+		configBytes, err := json.Marshal(repoConfig)
+		require.NoError(t, err)
+
+		var statusCode int
+		result := helper.AdminREST.Post().
+			Namespace("default").
+			Resource("repositories").
+			Name(repoName).
+			SubResource("test").
+			Body(configBytes).
+			SetHeader("Content-Type", "application/json").
+			Do(ctx).StatusCode(&statusCode)
+
+		require.Error(t, result.Error())
+		require.Equal(t, http.StatusBadRequest, statusCode)
+		require.True(t, apierrors.IsBadRequest(result.Error()), "expected bad request, got %v", result.Error())
+		require.ErrorContains(t, result.Error(), "a new token is required when changing the repository URL")
+	})
+
+	t.Run("test subresource allows url change with a new token", func(t *testing.T) {
+		changedRemote, changedUser := createEmptyGitRepo(t, helper, "git-url-change-test-no-token-new")
+
+		local, err := gittest.NewLocalRepo(ctx)
+		require.NoError(t, err, "failed to create local repository")
+		t.Cleanup(func() {
+			if err := local.Cleanup(); err != nil {
+				t.Logf("failed to cleanup local repo: %v", err)
+			}
+		})
+
+		_, err = local.InitWithRemote(changedUser, changedRemote)
+		require.NoError(t, err, "failed to initialize local repo with remote")
+
+		repoConfig := map[string]any{
+			"apiVersion": "provisioning.grafana.app/v0alpha1",
+			"kind":       "Repository",
+			"spec": map[string]any{
+				"title": "Changed Git Repo URL",
+				"type":  "git",
+				"git": map[string]any{
+					"url":       changedRemote.URL,
+					"branch":    "main",
+					"tokenUser": changedUser.Username,
+				},
+				"sync": map[string]any{
+					"enabled":         false,
+					"target":          "instance",
+					"intervalSeconds": 60,
+				},
+				"workflows": []string{},
+			},
+			"secure": map[string]any{
+				"token": map[string]any{
+					"create": changedUser.Password,
+				},
+			},
+		}
+
+		configBytes, err := json.Marshal(repoConfig)
+		require.NoError(t, err)
+
+		var statusCode int
+		result := helper.AdminREST.Post().
+			Namespace("default").
+			Resource("repositories").
+			Name(repoName).
+			SubResource("test").
+			Body(configBytes).
+			SetHeader("Content-Type", "application/json").
+			Do(ctx).StatusCode(&statusCode)
+
+		require.NoError(t, result.Error())
+		require.Equal(t, http.StatusOK, statusCode)
+	})
+}

--- a/pkg/tests/apis/provisioning/repository/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository/repository_test.go
@@ -28,7 +28,6 @@ import (
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	clientset "github.com/grafana/grafana/apps/provisioning/pkg/generated/clientset/versioned"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
-	apicommon "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/extensions"
 	"github.com/grafana/grafana/pkg/infra/usagestats"
@@ -877,105 +876,6 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 			require.Contains(collect, updatedRepo.Finalizers, repository.CleanFinalizer, "should contain CleanFinalizer")
 		}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
 	})
-}
-
-func TestIntegrationProvisioning_RequiresNewTokenWhenRepositoryURLChanges(t *testing.T) {
-	helper := sharedHelper(t)
-	ctx := context.Background()
-
-	t.Run("update rejects url change without a new token", func(t *testing.T) {
-		repoName := "repo-url-change-no-token"
-		created := createGitHubRepositoryWithToken(t, helper, repoName, "https://github.com/grafana/original")
-
-		updated := created.DeepCopy()
-		require.NoError(t, unstructured.SetNestedField(updated.Object, "https://github.com/grafana/changed", "spec", "github", "url"))
-		unstructured.RemoveNestedField(updated.Object, "secure", "token")
-
-		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			_, err := helper.Repositories.Resource.Update(ctx, updated, metav1.UpdateOptions{})
-			require.Error(collect, err)
-			require.True(collect, apierrors.IsInvalid(err), "expected invalid repository update, got %v", err)
-			require.ErrorContains(collect, err, "secure.token")
-			require.ErrorContains(collect, err, "a new token is required when changing the repository URL")
-		}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
-	})
-
-	t.Run("update allows url change with a new token", func(t *testing.T) {
-		repoName := "repo-url-change-new-token"
-		created := createGitHubRepositoryWithToken(t, helper, repoName, "https://github.com/grafana/original")
-
-		repo := common.MustFromUnstructured[provisioning.Repository](t, created)
-		repo.Spec.GitHub.URL = "https://github.com/grafana/changed"
-		repo.Secure.Token = apicommon.InlineSecureValue{Create: "new-token"}
-
-		require.EventuallyWithT(t, func(collect *assert.CollectT) {
-			result, err := helper.Repositories.Resource.Update(ctx, common.MustToUnstructured(t, repo), metav1.UpdateOptions{})
-			require.NoError(collect, err)
-
-			updatedRepo := common.MustFromUnstructured[provisioning.Repository](t, result)
-			require.Equal(collect, "https://github.com/grafana/changed", updatedRepo.Spec.GitHub.URL)
-			require.NotEmpty(collect, updatedRepo.Secure.Token.Name)
-		}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
-	})
-
-	t.Run("test subresource rejects url change without a new token", func(t *testing.T) {
-		repoName := "repo-url-change-test-no-token"
-		createGitHubRepositoryWithToken(t, helper, repoName, "https://github.com/grafana/original")
-
-		repoConfig := map[string]any{
-			"apiVersion": "provisioning.grafana.app/v0alpha1",
-			"kind":       "Repository",
-			"spec": map[string]any{
-				"title": "Changed Repo URL",
-				"type":  "github",
-				"github": map[string]any{
-					"url":    "https://github.com/grafana/changed",
-					"branch": "main",
-				},
-				"sync": map[string]any{
-					"enabled":         false,
-					"target":          "folder",
-					"intervalSeconds": 60,
-				},
-				"workflows": []string{},
-			},
-		}
-
-		configBytes, err := json.Marshal(repoConfig)
-		require.NoError(t, err)
-
-		var statusCode int
-		result := helper.AdminREST.Post().
-			Namespace("default").
-			Resource("repositories").
-			Name(repoName).
-			SubResource("test").
-			Body(configBytes).
-			SetHeader("Content-Type", "application/json").
-			Do(ctx).StatusCode(&statusCode)
-
-		require.Error(t, result.Error())
-		require.Equal(t, http.StatusBadRequest, statusCode)
-		require.True(t, apierrors.IsBadRequest(result.Error()), "expected bad request, got %v", result.Error())
-		require.ErrorContains(t, result.Error(), "a new token is required when changing the repository URL")
-	})
-}
-
-func createGitHubRepositoryWithToken(t *testing.T, helper *common.ProvisioningTestHelper, name, url string) *unstructured.Unstructured {
-	t.Helper()
-
-	input := helper.RenderObject(t, common.TestdataPath("github.json.tmpl"), map[string]any{
-		"Name":          name,
-		"URL":           url,
-		"Branch":        "main",
-		"SyncEnabled":   false,
-		"WorkflowsJSON": `[]`,
-		"Token":         "test-token",
-	})
-
-	created, err := helper.Repositories.Resource.Create(context.Background(), input, metav1.CreateOptions{})
-	require.NoError(t, err)
-	return created
 }
 
 func TestIntegrationProvisioning_FailInvalidSchema(t *testing.T) {

--- a/pkg/tests/apis/provisioning/repository/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository/repository_test.go
@@ -891,11 +891,13 @@ func TestIntegrationProvisioning_RequiresNewTokenWhenRepositoryURLChanges(t *tes
 		require.NoError(t, unstructured.SetNestedField(updated.Object, "https://github.com/grafana/changed", "spec", "github", "url"))
 		unstructured.RemoveNestedField(updated.Object, "secure", "token")
 
-		_, err := helper.Repositories.Resource.Update(ctx, updated, metav1.UpdateOptions{})
-		require.Error(t, err)
-		require.True(t, apierrors.IsInvalid(err), "expected invalid repository update, got %v", err)
-		require.ErrorContains(t, err, "secure.token")
-		require.ErrorContains(t, err, "a new token is required when changing the repository URL")
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			_, err := helper.Repositories.Resource.Update(ctx, updated, metav1.UpdateOptions{})
+			require.Error(collect, err)
+			require.True(collect, apierrors.IsInvalid(err), "expected invalid repository update, got %v", err)
+			require.ErrorContains(collect, err, "secure.token")
+			require.ErrorContains(collect, err, "a new token is required when changing the repository URL")
+		}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
 	})
 
 	t.Run("update allows url change with a new token", func(t *testing.T) {
@@ -906,12 +908,14 @@ func TestIntegrationProvisioning_RequiresNewTokenWhenRepositoryURLChanges(t *tes
 		repo.Spec.GitHub.URL = "https://github.com/grafana/changed"
 		repo.Secure.Token = apicommon.InlineSecureValue{Create: "new-token"}
 
-		result, err := helper.Repositories.Resource.Update(ctx, common.MustToUnstructured(t, repo), metav1.UpdateOptions{})
-		require.NoError(t, err)
+		require.EventuallyWithT(t, func(collect *assert.CollectT) {
+			result, err := helper.Repositories.Resource.Update(ctx, common.MustToUnstructured(t, repo), metav1.UpdateOptions{})
+			require.NoError(collect, err)
 
-		updatedRepo := common.MustFromUnstructured[provisioning.Repository](t, result)
-		require.Equal(t, "https://github.com/grafana/changed", updatedRepo.Spec.GitHub.URL)
-		require.NotEmpty(t, updatedRepo.Secure.Token.Name)
+			updatedRepo := common.MustFromUnstructured[provisioning.Repository](t, result)
+			require.Equal(collect, "https://github.com/grafana/changed", updatedRepo.Spec.GitHub.URL)
+			require.NotEmpty(collect, updatedRepo.Secure.Token.Name)
+		}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
 	})
 
 	t.Run("test subresource rejects url change without a new token", func(t *testing.T) {

--- a/pkg/tests/apis/provisioning/repository/repository_test.go
+++ b/pkg/tests/apis/provisioning/repository/repository_test.go
@@ -28,6 +28,7 @@ import (
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	clientset "github.com/grafana/grafana/apps/provisioning/pkg/generated/clientset/versioned"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
+	apicommon "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/extensions"
 	"github.com/grafana/grafana/pkg/infra/usagestats"
@@ -876,6 +877,101 @@ func TestIntegrationProvisioning_RepositoryValidation(t *testing.T) {
 			require.Contains(collect, updatedRepo.Finalizers, repository.CleanFinalizer, "should contain CleanFinalizer")
 		}, common.WaitTimeoutDefault, common.WaitIntervalDefault)
 	})
+}
+
+func TestIntegrationProvisioning_RequiresNewTokenWhenRepositoryURLChanges(t *testing.T) {
+	helper := sharedHelper(t)
+	ctx := context.Background()
+
+	t.Run("update rejects url change without a new token", func(t *testing.T) {
+		repoName := "repo-url-change-no-token"
+		created := createGitHubRepositoryWithToken(t, helper, repoName, "https://github.com/grafana/original")
+
+		updated := created.DeepCopy()
+		require.NoError(t, unstructured.SetNestedField(updated.Object, "https://github.com/grafana/changed", "spec", "github", "url"))
+		unstructured.RemoveNestedField(updated.Object, "secure", "token")
+
+		_, err := helper.Repositories.Resource.Update(ctx, updated, metav1.UpdateOptions{})
+		require.Error(t, err)
+		require.True(t, apierrors.IsInvalid(err), "expected invalid repository update, got %v", err)
+		require.ErrorContains(t, err, "secure.token")
+		require.ErrorContains(t, err, "a new token is required when changing the repository URL")
+	})
+
+	t.Run("update allows url change with a new token", func(t *testing.T) {
+		repoName := "repo-url-change-new-token"
+		created := createGitHubRepositoryWithToken(t, helper, repoName, "https://github.com/grafana/original")
+
+		repo := common.MustFromUnstructured[provisioning.Repository](t, created)
+		repo.Spec.GitHub.URL = "https://github.com/grafana/changed"
+		repo.Secure.Token = apicommon.InlineSecureValue{Create: "new-token"}
+
+		result, err := helper.Repositories.Resource.Update(ctx, common.MustToUnstructured(t, repo), metav1.UpdateOptions{})
+		require.NoError(t, err)
+
+		updatedRepo := common.MustFromUnstructured[provisioning.Repository](t, result)
+		require.Equal(t, "https://github.com/grafana/changed", updatedRepo.Spec.GitHub.URL)
+		require.NotEmpty(t, updatedRepo.Secure.Token.Name)
+	})
+
+	t.Run("test subresource rejects url change without a new token", func(t *testing.T) {
+		repoName := "repo-url-change-test-no-token"
+		createGitHubRepositoryWithToken(t, helper, repoName, "https://github.com/grafana/original")
+
+		repoConfig := map[string]any{
+			"apiVersion": "provisioning.grafana.app/v0alpha1",
+			"kind":       "Repository",
+			"spec": map[string]any{
+				"title": "Changed Repo URL",
+				"type":  "github",
+				"github": map[string]any{
+					"url":    "https://github.com/grafana/changed",
+					"branch": "main",
+				},
+				"sync": map[string]any{
+					"enabled":         false,
+					"target":          "folder",
+					"intervalSeconds": 60,
+				},
+				"workflows": []string{},
+			},
+		}
+
+		configBytes, err := json.Marshal(repoConfig)
+		require.NoError(t, err)
+
+		var statusCode int
+		result := helper.AdminREST.Post().
+			Namespace("default").
+			Resource("repositories").
+			Name(repoName).
+			SubResource("test").
+			Body(configBytes).
+			SetHeader("Content-Type", "application/json").
+			Do(ctx).StatusCode(&statusCode)
+
+		require.Error(t, result.Error())
+		require.Equal(t, http.StatusBadRequest, statusCode)
+		require.True(t, apierrors.IsBadRequest(result.Error()), "expected bad request, got %v", result.Error())
+		require.ErrorContains(t, result.Error(), "a new token is required when changing the repository URL")
+	})
+}
+
+func createGitHubRepositoryWithToken(t *testing.T, helper *common.ProvisioningTestHelper, name, url string) *unstructured.Unstructured {
+	t.Helper()
+
+	input := helper.RenderObject(t, common.TestdataPath("github.json.tmpl"), map[string]any{
+		"Name":          name,
+		"URL":           url,
+		"Branch":        "main",
+		"SyncEnabled":   false,
+		"WorkflowsJSON": `[]`,
+		"Token":         "test-token",
+	})
+
+	created, err := helper.Repositories.Resource.Create(context.Background(), input, metav1.CreateOptions{})
+	require.NoError(t, err)
+	return created
 }
 
 func TestIntegrationProvisioning_FailInvalidSchema(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

This prevents repository updates and `/test` requests from reusing an existing stored token when the repository URL changes unless a new token is provided.

**Why do we need this feature?**

We are currently working towards improving the security checks when a `Repository` resource gets updated by the owners. 

**Who is this feature for?**

Grafana admins and operators using Git Sync repository provisioning.

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/git-ui-sync-project/issues/1150

**Special notes for your reviewer:**

Validated with:

- `go test ./apps/provisioning/pkg/repository`
- `go test ./pkg/registry/apis/provisioning`
- `go test -tags=enterprise ./pkg/tests/apis/provisioning/repository -run '^TestIntegrationProvisioning_RequiresNewTokenWhenRepositoryURLChanges$'`