### PR TITLE
CI: Attempt fix Dependabot make update-workspace workflow

### DIFF
--- a/.github/workflows/pr-dependabot-update-go-workspace.yml
+++ b/.github/workflows/pr-dependabot-update-go-workspace.yml
@@ -16,35 +16,16 @@ jobs:
   update:
     runs-on: ubuntu-arm64
     permissions:
-      # Pushes use the app token explicitly in the git push URL; GITHUB_TOKEN needs only OIDC for Vault.
-      contents: read
-      id-token: write
+      contents: write # GITHUB_TOKEN needs to push a commit to the branch
+
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository }}
     continue-on-error: true
     steps:
-    - name: Retrieve GitHub App secrets
-      id: get-secrets
-      uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.0.1 # zizmor: ignore[unpinned-uses]
-      with:
-        repo_secrets: |
-          APP_ID=grafana-go-workspace-bot:app-id
-          APP_INSTALLATION_ID=grafana-go-workspace-bot:app-installation-id
-          PRIVATE_KEY=grafana-go-workspace-bot:private-key
-
-    - name: Generate GitHub App token
-      id: generate_token
-      uses: actions/create-github-app-token@v1
-      with:
-        app-id: ${{ env.APP_ID }}
-        installation-id: ${{ env.APP_INSTALLATION_ID }}
-        private-key: ${{ env.PRIVATE_KEY }}
-
     - name: Checkout repository
       uses: actions/checkout@v5
       with:
         repository: ${{ github.event.pull_request.head.repo.full_name }}
         ref: ${{ github.event.pull_request.head.ref }}
-        token: ${{ steps.generate_token.outputs.token }}
         persist-credentials: false
 
     - name: Setup Go
@@ -52,18 +33,13 @@ jobs:
       with:
         cache-build: 'false'
 
-    - name: Configure Git
-      run: |
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
-
     - name: Update workspace
       run: make update-workspace
 
     - name: Commit and push workspace changes
       env:
         BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-        GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         if ! git diff --exit-code --quiet; then
           echo "Committing and pushing workspace changes"


### PR DESCRIPTION
In theory we only need `contents:write` to be able to push a commit to a Dependabot PR after running `make update-workspace` !