### PR TITLE
Search: split snapshot store interface into file + manifest methods

### DIFF
--- a/pkg/storage/unified/search/remote_index_cleanup_test.go
+++ b/pkg/storage/unified/search/remote_index_cleanup_test.go
@@ -3,7 +3,7 @@ package search
 import (
 	"context"
 	"errors"
-	"io"
+	"os"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -508,11 +508,17 @@ func (s *recordingStore) DeleteIndex(ctx context.Context, r resource.NamespacedR
 func (s *recordingStore) LockBuildIndex(ctx context.Context, r resource.NamespacedResource, buildVersion string) (IndexStoreLock, error) {
 	return s.inner.LockBuildIndex(ctx, r, buildVersion)
 }
-func (s *recordingStore) WriteSnapshotFile(ctx context.Context, r resource.NamespacedResource, k ulid.ULID, relPath string, in io.Reader) error {
-	return s.inner.WriteSnapshotFile(ctx, r, k, relPath, in)
+func (s *recordingStore) WriteSnapshotFile(ctx context.Context, r resource.NamespacedResource, k ulid.ULID, relPath string, src *os.File) error {
+	return s.inner.WriteSnapshotFile(ctx, r, k, relPath, src)
 }
-func (s *recordingStore) ReadSnapshotFile(ctx context.Context, r resource.NamespacedResource, k ulid.ULID, relPath string, out io.Writer) error {
-	return s.inner.ReadSnapshotFile(ctx, r, k, relPath, out)
+func (s *recordingStore) ReadSnapshotFile(ctx context.Context, r resource.NamespacedResource, k ulid.ULID, relPath string, dst *os.File, expectedSize int64) error {
+	return s.inner.ReadSnapshotFile(ctx, r, k, relPath, dst, expectedSize)
+}
+func (s *recordingStore) WriteSnapshotManifest(ctx context.Context, r resource.NamespacedResource, k ulid.ULID, manifest []byte) error {
+	return s.inner.WriteSnapshotManifest(ctx, r, k, manifest)
+}
+func (s *recordingStore) ReadSnapshotManifest(ctx context.Context, r resource.NamespacedResource, k ulid.ULID) ([]byte, error) {
+	return s.inner.ReadSnapshotManifest(ctx, r, k)
 }
 
 func TestRunCleanup_OwnershipFilter_NamespaceLevel(t *testing.T) {
@@ -624,11 +630,17 @@ func (s *controllableLockStore) DeleteIndex(ctx context.Context, r resource.Name
 func (s *controllableLockStore) LockBuildIndex(ctx context.Context, r resource.NamespacedResource, buildVersion string) (IndexStoreLock, error) {
 	return s.inner.LockBuildIndex(ctx, r, buildVersion)
 }
-func (s *controllableLockStore) WriteSnapshotFile(ctx context.Context, r resource.NamespacedResource, k ulid.ULID, relPath string, in io.Reader) error {
-	return s.inner.WriteSnapshotFile(ctx, r, k, relPath, in)
+func (s *controllableLockStore) WriteSnapshotFile(ctx context.Context, r resource.NamespacedResource, k ulid.ULID, relPath string, src *os.File) error {
+	return s.inner.WriteSnapshotFile(ctx, r, k, relPath, src)
 }
-func (s *controllableLockStore) ReadSnapshotFile(ctx context.Context, r resource.NamespacedResource, k ulid.ULID, relPath string, out io.Writer) error {
-	return s.inner.ReadSnapshotFile(ctx, r, k, relPath, out)
+func (s *controllableLockStore) ReadSnapshotFile(ctx context.Context, r resource.NamespacedResource, k ulid.ULID, relPath string, dst *os.File, expectedSize int64) error {
+	return s.inner.ReadSnapshotFile(ctx, r, k, relPath, dst, expectedSize)
+}
+func (s *controllableLockStore) WriteSnapshotManifest(ctx context.Context, r resource.NamespacedResource, k ulid.ULID, manifest []byte) error {
+	return s.inner.WriteSnapshotManifest(ctx, r, k, manifest)
+}
+func (s *controllableLockStore) ReadSnapshotManifest(ctx context.Context, r resource.NamespacedResource, k ulid.ULID) ([]byte, error) {
+	return s.inner.ReadSnapshotManifest(ctx, r, k)
 }
 
 func TestRunCleanup_LockLossAbortsNamespace(t *testing.T) {

--- a/pkg/storage/unified/search/remote_index_store.go
+++ b/pkg/storage/unified/search/remote_index_store.go
@@ -122,20 +122,33 @@ type RemoteIndexStore interface {
 	// in-flight upload for any resource in the namespace.
 	LockNamespaceForCleanup(ctx context.Context, namespace string) (IndexStoreLock, error)
 
-	// WriteSnapshotFile writes one file at relPath under the snapshot
-	// identified by (nsResource, indexKey).
-	//
-	// Backends treat relPath as opaque: they do not know which file is the
-	// snapshot manifest, and never introspect IndexMeta or JSON. The
-	// snapshot manifest is the completion signal: a snapshot is considered
-	// complete once a file at snapshotManifestFile exists at the prefix.
-	WriteSnapshotFile(ctx context.Context, nsResource resource.NamespacedResource, indexKey ulid.ULID, relPath string, in io.Reader) error
+	// WriteSnapshotFile writes one data file at relPath under the snapshot
+	// identified by (nsResource, indexKey). Backends that need the file size
+	// (e.g. to plan chunked writes) can obtain it via src.Stat(). The
+	// manifest is not written through this method — use
+	// WriteSnapshotManifest, whose presence is the completion signal.
+	WriteSnapshotFile(ctx context.Context, nsResource resource.NamespacedResource, indexKey ulid.ULID, relPath string, src *os.File) error
 
-	// ReadSnapshotFile streams the contents of one file in the snapshot at
-	// (nsResource, indexKey) into out, including the manifest at the
-	// well-known path. Returns ErrSnapshotNotFound if the snapshot or file
-	// does not exist.
-	ReadSnapshotFile(ctx context.Context, nsResource resource.NamespacedResource, indexKey ulid.ULID, relPath string, out io.Writer) error
+	// ReadSnapshotFile streams the contents of one data file in the snapshot
+	// at (nsResource, indexKey) into dst. expectedSize is the size declared
+	// in the manifest; backends must fail if the stored object exceeds it,
+	// so a misadvertised or grown-out-of-band object cannot transfer
+	// unbounded data to disk. Returns ErrSnapshotNotFound if the snapshot
+	// or file does not exist.
+	ReadSnapshotFile(ctx context.Context, nsResource resource.NamespacedResource, indexKey ulid.ULID, relPath string, dst *os.File, expectedSize int64) error
+
+	// WriteSnapshotManifest writes the snapshot manifest for
+	// (nsResource, indexKey). It is written last during upload and serves as
+	// the completion signal: a snapshot is considered complete once its
+	// manifest exists. The well-known filename used for storage is a backend
+	// detail and callers never name it.
+	WriteSnapshotManifest(ctx context.Context, nsResource resource.NamespacedResource, indexKey ulid.ULID, manifest []byte) error
+
+	// ReadSnapshotManifest returns the raw manifest bytes for
+	// (nsResource, indexKey). Returns ErrSnapshotNotFound if the manifest
+	// does not exist, or an error wrapping ErrInvalidManifest if the stored
+	// manifest exceeds the backend's enforced size cap.
+	ReadSnapshotManifest(ctx context.Context, nsResource resource.NamespacedResource, indexKey ulid.ULID) ([]byte, error)
 
 	// ListNamespaces returns the namespaces currently known to the store.
 	ListNamespaces(ctx context.Context) ([]string, error)
@@ -331,28 +344,65 @@ func (s *BucketRemoteIndexStore) lockConfig(key string, opts LockOptions) object
 	}
 }
 
-// WriteSnapshotFile streams in into the object at relPath under the
-// snapshot (nsResource, indexKey) prefix.
-func (s *BucketRemoteIndexStore) WriteSnapshotFile(ctx context.Context, nsResource resource.NamespacedResource, indexKey ulid.ULID, relPath string, in io.Reader) error {
+// WriteSnapshotFile streams src into the object at relPath under the
+// snapshot (nsResource, indexKey) prefix. The bucket backend streams to
+// EOF and ignores size.
+func (s *BucketRemoteIndexStore) WriteSnapshotFile(ctx context.Context, nsResource resource.NamespacedResource, indexKey ulid.ULID, relPath string, src *os.File) error {
 	objectKey := indexPrefix(nsResource, indexKey.String()) + relPath
-	return s.bucket.Upload(ctx, objectKey, in, &blob.WriterOptions{
+	return s.bucket.Upload(ctx, objectKey, src, &blob.WriterOptions{
 		ContentType: "application/octet-stream",
 	})
 }
 
 // ReadSnapshotFile streams the contents of the object at relPath under the
-// snapshot (nsResource, indexKey) prefix into out. Translates bucket
-// not-found errors into ErrSnapshotNotFound so callers can branch on a
-// stable sentinel without depending on gocloud's gcerrors codes.
-func (s *BucketRemoteIndexStore) ReadSnapshotFile(ctx context.Context, nsResource resource.NamespacedResource, indexKey ulid.ULID, relPath string, out io.Writer) error {
+// snapshot (nsResource, indexKey) prefix into dst, capping the transfer at
+// expectedSize+1 bytes so a misadvertised size or an object that's grown
+// out of band fails fast. Translates bucket not-found errors into
+// ErrSnapshotNotFound so callers can branch on a stable sentinel without
+// depending on gocloud's gcerrors codes.
+func (s *BucketRemoteIndexStore) ReadSnapshotFile(ctx context.Context, nsResource resource.NamespacedResource, indexKey ulid.ULID, relPath string, dst *os.File, expectedSize int64) error {
 	objectKey := indexPrefix(nsResource, indexKey.String()) + relPath
-	if err := s.bucket.Download(ctx, objectKey, out, nil); err != nil {
+	lw := &resource.LimitedWriter{W: dst, N: expectedSize + 1}
+	if err := s.bucket.Download(ctx, objectKey, lw, nil); err != nil {
+		if errors.Is(err, resource.ErrWriteLimitExceeded) {
+			return fmt.Errorf("remote object exceeds expected size %d: %w", expectedSize, err)
+		}
 		if gcerrors.Code(err) == gcerrors.NotFound {
 			return ErrSnapshotNotFound
 		}
 		return err
 	}
 	return nil
+}
+
+// WriteSnapshotManifest writes the snapshot manifest for (nsResource,
+// indexKey). The manifest is small and fits in memory; the backend writes
+// it as a single object at the well-known path.
+func (s *BucketRemoteIndexStore) WriteSnapshotManifest(ctx context.Context, nsResource resource.NamespacedResource, indexKey ulid.ULID, manifest []byte) error {
+	objectKey := indexPrefix(nsResource, indexKey.String()) + snapshotManifestFile
+	return s.bucket.Upload(ctx, objectKey, bytes.NewReader(manifest), &blob.WriterOptions{
+		ContentType: "application/json",
+	})
+}
+
+// ReadSnapshotManifest reads the snapshot manifest for (nsResource,
+// indexKey) from the well-known path and returns its raw bytes. Enforces
+// maxSnapshotManifestSize so a corrupt or oversized object cannot transfer
+// unbounded data. Translates bucket not-found into ErrSnapshotNotFound.
+func (s *BucketRemoteIndexStore) ReadSnapshotManifest(ctx context.Context, nsResource resource.NamespacedResource, indexKey ulid.ULID) ([]byte, error) {
+	objectKey := indexPrefix(nsResource, indexKey.String()) + snapshotManifestFile
+	var buf bytes.Buffer
+	lw := &resource.LimitedWriter{W: &buf, N: maxSnapshotManifestSize}
+	if err := s.bucket.Download(ctx, objectKey, lw, nil); err != nil {
+		if gcerrors.Code(err) == gcerrors.NotFound {
+			return nil, ErrSnapshotNotFound
+		}
+		if errors.Is(err, resource.ErrWriteLimitExceeded) {
+			return nil, fmt.Errorf("%w: oversized snapshot manifest: %v", ErrInvalidManifest, err)
+		}
+		return nil, err
+	}
+	return buf.Bytes(), nil
 }
 
 // listSubdirs runs a delimited bucket list at prefix and returns the parsed
@@ -540,7 +590,7 @@ func UploadIndexSnapshot(ctx context.Context, store RemoteIndexStore, nsResource
 		return ulid.ULID{}, fmt.Errorf("marshaling snapshot manifest: %w", err)
 	}
 	if err := retryRemoteIndexStore(ctx, snapshotStoreOpUploadManifest, logger, func() error {
-		return store.WriteSnapshotFile(ctx, nsResource, indexKey, snapshotManifestFile, bytes.NewReader(metaBytes))
+		return store.WriteSnapshotManifest(ctx, nsResource, indexKey, metaBytes)
 	}); err != nil {
 		return ulid.ULID{}, fmt.Errorf("uploading snapshot manifest: %w", err)
 	}
@@ -630,21 +680,18 @@ func DownloadIndexSnapshot(ctx context.Context, store RemoteIndexStore, nsResour
 }
 
 // downloadSnapshotFileToDisk creates relPath under root and streams the remote
-// object into it, capping the transfer at expectedSize+1 bytes so a
-// misadvertised size or a bucket object that's grown out of band fails fast
-// before we transfer unbounded data.
+// object into it. The size cap is the backend's responsibility (it gets
+// expectedSize and must refuse to transfer more than that). The post-write
+// Stat check in DownloadIndexSnapshot still verifies the final on-disk size
+// as belt-and-braces.
 func downloadSnapshotFileToDisk(ctx context.Context, store RemoteIndexStore, ns resource.NamespacedResource, indexKey ulid.ULID, relPath string, root *os.Root, expectedSize int64) error {
 	return retryRemoteIndexStore(ctx, snapshotStoreOpDownloadFile, nil, func() error {
 		f, err := root.Create(filepath.FromSlash(relPath))
 		if err != nil {
 			return err
 		}
-		lw := &resource.LimitedWriter{W: f, N: expectedSize + 1}
-		if err := store.ReadSnapshotFile(ctx, ns, indexKey, relPath, lw); err != nil {
+		if err := store.ReadSnapshotFile(ctx, ns, indexKey, relPath, f, expectedSize); err != nil {
 			_ = f.Close()
-			if errors.Is(err, resource.ErrWriteLimitExceeded) {
-				return fmt.Errorf("remote object exceeds expected size %d: %w", expectedSize, err)
-			}
 			return err
 		}
 		return f.Close()
@@ -656,23 +703,14 @@ func downloadSnapshotFileToDisk(ctx context.Context, store RemoteIndexStore, ns 
 // wrapping ErrInvalidManifest if the manifest is structurally invalid
 // (oversized, unparseable, empty file list, or non-canonical paths).
 func ReadIndexSnapshotManifest(ctx context.Context, store RemoteIndexStore, nsResource resource.NamespacedResource, indexKey ulid.ULID) (*IndexMeta, error) {
-	var manifest []byte
-	if err := retryRemoteIndexStore(ctx, snapshotStoreOpReadManifest, nil, func() error {
-		var buf bytes.Buffer
-		lw := &resource.LimitedWriter{W: &buf, N: maxSnapshotManifestSize}
-		if err := store.ReadSnapshotFile(ctx, nsResource, indexKey, snapshotManifestFile, lw); err != nil {
-			if errors.Is(err, ErrSnapshotNotFound) {
-				return err
-			}
-			if errors.Is(err, resource.ErrWriteLimitExceeded) {
-				return fmt.Errorf("%w: oversized snapshot manifest: %v", ErrInvalidManifest, err)
-			}
-			return fmt.Errorf("reading snapshot manifest: %w", err)
+	manifest, err := retryRemoteIndexStoreValue(ctx, snapshotStoreOpReadManifest, nil, func() ([]byte, error) {
+		return store.ReadSnapshotManifest(ctx, nsResource, indexKey)
+	})
+	if err != nil {
+		if errors.Is(err, ErrSnapshotNotFound) || errors.Is(err, ErrInvalidManifest) {
+			return nil, err
 		}
-		manifest = append(manifest[:0], buf.Bytes()...)
-		return nil
-	}); err != nil {
-		return nil, err
+		return nil, fmt.Errorf("reading snapshot manifest: %w", err)
 	}
 	var meta IndexMeta
 	if err := json.Unmarshal(manifest, &meta); err != nil {

--- a/pkg/storage/unified/search/remote_index_store_test.go
+++ b/pkg/storage/unified/search/remote_index_store_test.go
@@ -1160,11 +1160,12 @@ func TestRemoteIndexStore_BuildAndCleanupLockTTLsWiredIndependently(t *testing.T
 // mid-call callbacks, and controllable lock loss.
 //
 // Error injection and counters are at the interface-method level
-// (WriteSnapshotFile, ReadSnapshotFile, ListIndexKeys, ...). Test setters
-// like setUploadErr / setDownloadErr are spelled in terms of the
-// higher-level intent ("fail the upload") but plumb into the underlying
-// method-level field; this keeps test code readable without coupling it to
-// the exact interface shape.
+// (WriteSnapshotFile, ReadSnapshotFile, WriteSnapshotManifest,
+// ReadSnapshotManifest, ListIndexKeys, ...). Test setters like setUploadErr
+// / setDownloadErr are spelled in terms of the higher-level intent ("fail
+// the upload") but plumb into the underlying method-level fields; this
+// keeps test code readable without coupling it to the exact interface
+// shape.
 //
 // Tests seed snapshots by writing directly to the bucket via seedSnapshot or
 // seedDownloadableSnapshot, which lets them pin manifest fields independent
@@ -1178,9 +1179,9 @@ type hookableStore struct {
 	lockBuildErr         error
 	lockCleanupErr       error
 	listKeysErr          error
-	writeSnapshotFileErr error               // fires on any WriteSnapshotFile call
-	readSnapshotFileErr  error               // fires on non-manifest ReadSnapshotFile (data-file phase of a download)
-	readManifestErrs     map[ulid.ULID]error // fires on ReadSnapshotFile(manifest) for the keyed snapshot
+	writeSnapshotFileErr error               // fires on WriteSnapshotFile (data files) and WriteSnapshotManifest
+	readSnapshotFileErr  error               // fires on ReadSnapshotFile (data-file phase of a download)
+	readManifestErrs     map[ulid.ULID]error // fires on ReadSnapshotManifest for the keyed snapshot
 
 	onUpload func() error
 
@@ -1188,9 +1189,9 @@ type hookableStore struct {
 	lockAcquireCalls  atomic.Int32
 	lockReleaseCalls  atomic.Int32
 	listKeyCalls      atomic.Int32 // ListIndexKeys
-	readManifestCalls atomic.Int32 // ReadSnapshotFile(manifest)
-	downloadCalls     atomic.Int32 // ReadSnapshotFile(non-manifest)
-	uploadCalls       atomic.Int32 // WriteSnapshotFile(manifest) succeeded — upload complete
+	readManifestCalls atomic.Int32 // ReadSnapshotManifest
+	downloadCalls     atomic.Int32 // ReadSnapshotFile (data files)
+	uploadCalls       atomic.Int32 // WriteSnapshotManifest succeeded — upload complete
 
 	// Last-upload captures. Reset when a write for a new indexKey arrives.
 	lastUploadedMeta     IndexMeta
@@ -1245,9 +1246,7 @@ func (s *hookableStore) LockNamespaceForCleanup(ctx context.Context, namespace s
 	return s.inner.LockNamespaceForCleanup(ctx, namespace)
 }
 
-func (s *hookableStore) WriteSnapshotFile(ctx context.Context, ns resource.NamespacedResource, indexKey ulid.ULID, relPath string, in io.Reader) error {
-	isManifest := relPath == snapshotManifestFile
-
+func (s *hookableStore) WriteSnapshotFile(ctx context.Context, ns resource.NamespacedResource, indexKey ulid.ULID, relPath string, src *os.File) error {
 	s.mu.Lock()
 	// Reset per-upload captures when we see a write for a new key.
 	if s.lastUploadedKey != indexKey {
@@ -1255,72 +1254,72 @@ func (s *hookableStore) WriteSnapshotFile(ctx context.Context, ns resource.Names
 		s.lastUploadedFiles = nil
 		s.lastUploadedMeta = IndexMeta{}
 	}
+	s.lastUploadedFiles = append(s.lastUploadedFiles, relPath)
+	injected := s.writeSnapshotFileErr
+	s.mu.Unlock()
+
+	if injected != nil {
+		return injected
+	}
+	return s.inner.WriteSnapshotFile(ctx, ns, indexKey, relPath, src)
+}
+
+func (s *hookableStore) WriteSnapshotManifest(ctx context.Context, ns resource.NamespacedResource, indexKey ulid.ULID, manifest []byte) error {
+	s.mu.Lock()
+	if s.lastUploadedKey != indexKey {
+		s.lastUploadedKey = indexKey
+		s.lastUploadedFiles = nil
+		s.lastUploadedMeta = IndexMeta{}
+	}
+	var meta IndexMeta
+	_ = json.Unmarshal(manifest, &meta) // best-effort; tests inspect what they wrote
+	s.lastUploadedMeta = meta
 	onUpload := s.onUpload
 	injected := s.writeSnapshotFileErr
 	s.mu.Unlock()
 
-	if isManifest {
-		// Capture the manifest by reading in into a buffer; re-supply via a
-		// fresh Reader so the inner store sees the original bytes.
-		data, err := io.ReadAll(in)
-		if err != nil {
+	// onUpload fires between the data-file writes and the manifest
+	// write — a deterministic point where the upload is on the verge of
+	// being marked complete.
+	if onUpload != nil {
+		if err := onUpload(); err != nil {
 			return err
 		}
-		var meta IndexMeta
-		_ = json.Unmarshal(data, &meta) // best-effort; tests inspect what they wrote
-		s.mu.Lock()
-		s.lastUploadedMeta = meta
-		s.mu.Unlock()
-		in = bytes.NewReader(data)
-
-		// onUpload fires between the data-file writes and the manifest
-		// write — a deterministic point where the upload is on the verge of
-		// being marked complete.
-		if onUpload != nil {
-			if err := onUpload(); err != nil {
-				return err
-			}
-		}
-	} else {
-		s.mu.Lock()
-		s.lastUploadedFiles = append(s.lastUploadedFiles, relPath)
-		s.mu.Unlock()
 	}
-
 	if injected != nil {
 		return injected
 	}
-	if err := s.inner.WriteSnapshotFile(ctx, ns, indexKey, relPath, in); err != nil {
+	if err := s.inner.WriteSnapshotManifest(ctx, ns, indexKey, manifest); err != nil {
 		return err
 	}
-	if isManifest {
-		s.uploadCalls.Add(1)
-	}
+	s.uploadCalls.Add(1)
 	return nil
 }
 
-func (s *hookableStore) ReadSnapshotFile(ctx context.Context, ns resource.NamespacedResource, indexKey ulid.ULID, relPath string, out io.Writer) error {
-	isManifest := relPath == snapshotManifestFile
-
+func (s *hookableStore) ReadSnapshotFile(ctx context.Context, ns resource.NamespacedResource, indexKey ulid.ULID, relPath string, dst *os.File, expectedSize int64) error {
 	s.mu.Lock()
-	var injected error
-	if isManifest {
-		injected = s.readManifestErrs[indexKey]
-	} else {
-		injected = s.readSnapshotFileErr
-	}
+	injected := s.readSnapshotFileErr
 	s.mu.Unlock()
 
-	if isManifest {
-		s.readManifestCalls.Add(1)
-	} else {
-		s.downloadCalls.Add(1)
-	}
+	s.downloadCalls.Add(1)
 
 	if injected != nil {
 		return injected
 	}
-	return s.inner.ReadSnapshotFile(ctx, ns, indexKey, relPath, out)
+	return s.inner.ReadSnapshotFile(ctx, ns, indexKey, relPath, dst, expectedSize)
+}
+
+func (s *hookableStore) ReadSnapshotManifest(ctx context.Context, ns resource.NamespacedResource, indexKey ulid.ULID) ([]byte, error) {
+	s.mu.Lock()
+	injected := s.readManifestErrs[indexKey]
+	s.mu.Unlock()
+
+	s.readManifestCalls.Add(1)
+
+	if injected != nil {
+		return nil, injected
+	}
+	return s.inner.ReadSnapshotManifest(ctx, ns, indexKey)
 }
 
 func (s *hookableStore) ListNamespaces(ctx context.Context) ([]string, error) {
@@ -1361,15 +1360,16 @@ func (s *hookableStore) setListKeysErr(err error) {
 	s.mu.Unlock()
 }
 
-// setUploadErr makes the next WriteSnapshotFile call (data file or
-// manifest) return err. Used to simulate "the upload fails partway".
+// setUploadErr makes the next WriteSnapshotFile (data file) or
+// WriteSnapshotManifest call return err. Used to simulate "the upload
+// fails partway".
 func (s *hookableStore) setUploadErr(err error) {
 	s.mu.Lock()
 	s.writeSnapshotFileErr = err
 	s.mu.Unlock()
 }
 
-// setDownloadErr makes data-file ReadSnapshotFile calls return err.
+// setDownloadErr makes ReadSnapshotFile (data file) calls return err.
 // Manifest reads are not affected, so probes / ReadIndexSnapshotManifest still succeed;
 // only the actual file-streaming phase of DownloadIndexSnapshot fails.
 func (s *hookableStore) setDownloadErr(err error) {
@@ -1403,11 +1403,11 @@ func (s *hookableStore) getLastLockBuildVersion() string {
 	return s.lastLockBuildVersion
 }
 
-// setReadManifestErr installs an error to return on the next manifest read for
-// indexKey — i.e. ReadSnapshotFile(ns, indexKey, snapshotManifestFile, w).
-// Existing snapshot data in the bucket is left in place; only the manifest
-// read for this key fails. Used to simulate ErrSnapshotNotFound /
-// ErrInvalidManifest at a specific key without disturbing the bucket.
+// setReadManifestErr installs an error to return on the next
+// ReadSnapshotManifest call for indexKey. Existing snapshot data in the
+// bucket is left in place; only the manifest read for this key fails. Used
+// to simulate ErrSnapshotNotFound / ErrInvalidManifest at a specific key
+// without disturbing the bucket.
 func (s *hookableStore) setReadManifestErr(indexKey ulid.ULID, err error) {
 	s.mu.Lock()
 	if s.readManifestErrs == nil {
@@ -1417,11 +1417,12 @@ func (s *hookableStore) setReadManifestErr(indexKey ulid.ULID, err error) {
 	s.mu.Unlock()
 }
 
-// setOnUpload installs a callback fired inside WriteSnapshotFile just
-// before the manifest write — i.e. after all data files have been
-// uploaded, but before the upload is marked complete. The callback's
-// returned error short-circuits the upload. Used to trigger races (e.g.
-// concurrent mutations during upload) at a deterministic point.
+// setOnUpload installs a callback fired inside WriteSnapshotManifest just
+// before the manifest is written to the inner store — i.e. after all data
+// files have been uploaded, but before the upload is marked complete. The
+// callback's returned error short-circuits the upload. Used to trigger
+// races (e.g. concurrent mutations during upload) at a deterministic
+// point.
 func (s *hookableStore) setOnUpload(fn func() error) {
 	s.mu.Lock()
 	s.onUpload = fn


### PR DESCRIPTION
Refactor `RemoteIndexStore` ahead of adding a KV-backed implementation that chunks large files.

Data-file methods now take `*os.File` directly instead of `io.Reader`/`io.Writer`, so a chunking backend can call `ReadAt`/`WriteAt` for parallel chunk I/O. The snapshot manifest moves to dedicated `WriteSnapshotManifest([]byte)` / `ReadSnapshotManifest() ([]byte, error)` methods so backends no longer have to recognise the manifest by filename, and the well-known filename becomes a backend-private detail.

```go
WriteSnapshotFile(ctx, ns, key, relPath string, src *os.File) error
ReadSnapshotFile(ctx, ns, key, relPath string, dst *os.File, expectedSize int64) error
WriteSnapshotManifest(ctx, ns, key, manifest []byte) error
ReadSnapshotManifest(ctx, ns, key) ([]byte, error)
```

The size cap on reads moves from the helper into the backend: `ReadSnapshotFile` enforces `expectedSize` and `ReadSnapshotManifest` enforces the manifest size limit internally. Two reasons for putting the check there instead of in the helper:

- `dst` is a real `*os.File` so the chunking backend can `WriteAt` parallel chunks. Wrapping it in a `LimitedWriter` in the helper would defeat that. For the chunking backend the size check falls out of the protocol anyway (list chunk keys, total bytes must equal `expectedSize`).
- For the manifest, putting the cap in the helper would mean streaming an unbounded object into memory before refusing it. A shared constant inside each backend is cheaper.

The post-write `Stat().Size() == expectedSize` check in `DownloadIndexSnapshot` stays as a final safety check.

No behaviour change. All existing tests pass; tests that implement the interface directly (`hookableStore`, `recordingStore`, `controllableLockStore`) updated for the new signatures.

First of three PRs for grafana/search-and-storage-team#810. Follow-ups add the KV-backed implementation (PR 2) and internal chunking with parallel chunk I/O (PR 3).
