### PR TITLE
Provisioning: fix isPublicURL host detection

### DIFF
--- a/pkg/registry/apis/provisioning/webhooks/register.go
+++ b/pkg/registry/apis/provisioning/webhooks/register.go
@@ -3,6 +3,8 @@ package webhooks
 import (
 	"context"
 	"fmt"
+	"net"
+	"net/url"
 	"strings"
 
 	"k8s.io/apiserver/pkg/authorization/authorizer"
@@ -55,14 +57,62 @@ func buildWebhookURL(baseURL string, r *provisioning.Repository) string {
 	)
 }
 
-// HACK: assume that the URL is public if it starts with "https://" and does not contain any local IP ranges
-func isPublicURL(url string) bool {
-	return strings.HasPrefix(url, "https://") &&
-		!strings.Contains(url, "localhost") &&
-		!strings.HasPrefix(url, "https://127.") &&
-		!strings.HasPrefix(url, "https://192.") &&
-		!strings.HasPrefix(url, "https://10.") &&
-		!strings.HasPrefix(url, "https://172.16.")
+// privateNetworks are CIDR ranges that are not reachable from the public
+// internet. Webhook providers (e.g. GitHub) cannot deliver to addresses in
+// these ranges, so URLs resolving to them must not be treated as public.
+var privateNetworks = func() []*net.IPNet {
+	cidrs := []string{
+		"127.0.0.0/8",    // loopback
+		"10.0.0.0/8",     // RFC1918
+		"172.16.0.0/12",  // RFC1918
+		"192.168.0.0/16", // RFC1918
+		"169.254.0.0/16", // link-local / cloud metadata
+		"100.64.0.0/10",  // CGNAT
+		"::1/128",        // IPv6 loopback
+		"fe80::/10",      // IPv6 link-local
+		"fc00::/7",       // IPv6 unique local
+	}
+	nets := make([]*net.IPNet, 0, len(cidrs))
+	for _, c := range cidrs {
+		_, n, err := net.ParseCIDR(c)
+		if err != nil {
+			panic(fmt.Sprintf("invalid CIDR %q: %v", c, err))
+		}
+		nets = append(nets, n)
+	}
+	return nets
+}()
+
+// isPublicURL reports whether rawURL is reachable from the public internet.
+// It requires https, rejects localhost and Kubernetes-internal DNS suffixes,
+// and rejects IP literals that fall inside any private/reserved range.
+func isPublicURL(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Scheme != "https" {
+		return false
+	}
+
+	host := u.Hostname()
+	if host == "" || host == "localhost" {
+		return false
+	}
+
+	if strings.HasSuffix(host, ".svc") || strings.HasSuffix(host, ".cluster.local") {
+		return false
+	}
+
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return true
+	}
+
+	for _, network := range privateNetworks {
+		if network.Contains(ip) {
+			return false
+		}
+	}
+
+	return true
 }
 
 func ProvideWebhooksWithImages(

--- a/pkg/registry/apis/provisioning/webhooks/register_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/register_test.go
@@ -164,13 +164,42 @@ func TestIsPublicURL(t *testing.T) {
 		url      string
 		expected bool
 	}{
+		// Public
 		{"https://grafana.example.com/", true},
+		{"https://grafana.example.com:8443/path", true},
+		{"https://notlocalhost.grafana.com/", true},
+		{"https://172.15.0.1/", true},  // just outside 172.16.0.0/12
+		{"https://172.32.0.1/", true},  // just outside 172.16.0.0/12
+		{"https://8.8.8.8/", true},     // public IPv4
+		{"https://[2001:db8::1]/", true},
+
+		// Scheme
 		{"http://grafana.example.com/", false},
+		{"ftp://grafana.example.com/", false},
+		{"://broken", false},
+
+		// Hostnames
 		{"https://localhost:3000/", false},
+		{"https://my-svc.default.svc/", false},
+		{"https://my-svc.default.svc.cluster.local/", false},
+
+		// IPv4 RFC1918 / reserved
 		{"https://127.0.0.1:3000/", false},
-		{"https://192.168.1.1:3000/", false},
 		{"https://10.0.0.1:3000/", false},
+		{"https://192.168.1.1:3000/", false},
 		{"https://172.16.0.1:3000/", false},
+		{"https://172.17.0.1/", false},
+		{"https://172.20.5.10/", false},
+		{"https://172.31.255.254/", false},
+		{"https://169.254.169.254/", false}, // cloud metadata
+		{"https://100.64.0.1/", false},      // CGNAT
+		{"https://100.127.255.254/", false}, // CGNAT upper bound
+
+		// IPv6 reserved
+		{"https://[::1]/", false},
+		{"https://[fe80::1]/", false},
+		{"https://[fc00::1]/", false},
+		{"https://[fd12:3456:789a::1]/", false},
 	}
 
 	for _, tt := range tests {

--- a/pkg/registry/apis/provisioning/webhooks/register_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/register_test.go
@@ -168,9 +168,9 @@ func TestIsPublicURL(t *testing.T) {
 		{"https://grafana.example.com/", true},
 		{"https://grafana.example.com:8443/path", true},
 		{"https://notlocalhost.grafana.com/", true},
-		{"https://172.15.0.1/", true},  // just outside 172.16.0.0/12
-		{"https://172.32.0.1/", true},  // just outside 172.16.0.0/12
-		{"https://8.8.8.8/", true},     // public IPv4
+		{"https://172.15.0.1/", true}, // just outside 172.16.0.0/12
+		{"https://172.32.0.1/", true}, // just outside 172.16.0.0/12
+		{"https://8.8.8.8/", true},    // public IPv4
 		{"https://[2001:db8::1]/", true},
 
 		// Scheme


### PR DESCRIPTION
## Summary

`isPublicURL` (`pkg/registry/apis/provisioning/webhooks/register.go`) gates webhook registration based on whether Grafana's callback URL is reachable from the public internet. The previous implementation used naive string prefix matching with several gaps:

- **Incomplete RFC1918 coverage**: Only `172.16.` was checked, missing `172.17`–`172.31`. Grafana in a typical Kubernetes pod CIDR would silently register webhooks the provider can never deliver.
- **Other missed reserved ranges**: `169.254.0.0/16` (link-local / cloud metadata), `100.64.0.0/10` (CGNAT), IPv6 `::1/128`, `fe80::/10`, `fc00::/7`.
- **Kubernetes-internal DNS not handled**: `*.svc`, `*.cluster.local`.
- **`strings.Contains(url, \"localhost\")` false negative**: A legitimate public host like `https://notlocalhost.grafana.com` was incorrectly classified as non-public and had its webhook registration silently disabled.

## Changes

- Parse the URL with `net/url`, require `https` scheme, and use `u.Hostname()` so ports don't interfere with matching.
- Exact-match `localhost` instead of substring match.
- Reject `.svc` and `.cluster.local` hostname suffixes.
- For IP literals, check membership against the full set of private/reserved CIDRs (IPv4 + IPv6) using `net.ParseCIDR`. Networks are parsed once at package init.

## Testing

Expanded `TestIsPublicURL` from 7 to 27 cases covering every acceptance-criterion range plus boundary cases (`172.15`/`172.32`, `100.127`, IPv6 reserved, `.svc`/`.cluster.local`, `notlocalhost.grafana.com`, non-https schemes, malformed URL). All tests pass:

```
go test ./pkg/registry/apis/provisioning/webhooks/ -run TestIsPublicURL -v
```

Closes https://github.com/grafana/git-ui-sync-project/issues/1154