### PR TITLE
Provisioning: Fix nil pointer dereference in webhook updateLastEvent

### DIFF
--- a/pkg/registry/apis/provisioning/webhooks/webhook.go
+++ b/pkg/registry/apis/provisioning/webhooks/webhook.go
@@ -195,6 +195,11 @@ func (s *webhookConnector) Connect(ctx context.Context, name string, opts runtim
 	}), 30*time.Second), nil
 }
 
+// statusPatcher is the subset of the status patcher API used by updateLastEvent.
+type statusPatcher interface {
+	Patch(ctx context.Context, repo *provisioning.Repository, patchOperations ...map[string]interface{}) error
+}
+
 // updateLastEvent updates the last event time for the webhook
 // This is to provide some visibility that the webhook is still active and working
 // It's not a good idea to update the webhook status too often, so we only update it if it's been a while
@@ -205,19 +210,27 @@ func (s *webhookConnector) updateLastEvent(ctx context.Context, repo repository.
 		return fmt.Errorf("status patcher is nil")
 	}
 
-	lastEvent := time.UnixMilli(repo.Config().Status.Webhook.LastEvent)
-	eventAge := time.Since(lastEvent)
+	return updateLastEvent(ctx, repo.Config(), patcher)
+}
 
-	if repo.Config().Status.Webhook != nil && (eventAge > time.Minute) {
-		patchOp := map[string]any{
-			"op":    "replace",
-			"path":  "/status/webhook/lastEvent",
-			"value": time.Now().UnixMilli(),
-		}
+func updateLastEvent(ctx context.Context, cfg *provisioning.Repository, patcher statusPatcher) error {
+	if cfg.Status.Webhook == nil {
+		return nil
+	}
 
-		if err := patcher.Patch(ctx, repo.Config(), patchOp); err != nil {
-			return fmt.Errorf("patch status: %w", err)
-		}
+	lastEvent := time.UnixMilli(cfg.Status.Webhook.LastEvent)
+	if time.Since(lastEvent) <= time.Minute {
+		return nil
+	}
+
+	patchOp := map[string]any{
+		"op":    "replace",
+		"path":  "/status/webhook/lastEvent",
+		"value": time.Now().UnixMilli(),
+	}
+
+	if err := patcher.Patch(ctx, cfg, patchOp); err != nil {
+		return fmt.Errorf("patch status: %w", err)
 	}
 
 	return nil

--- a/pkg/registry/apis/provisioning/webhooks/webhook_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/webhook_test.go
@@ -1,0 +1,86 @@
+package webhooks
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+)
+
+type fakeStatusPatcher struct {
+	called bool
+	err    error
+}
+
+func (f *fakeStatusPatcher) Patch(_ context.Context, _ *provisioning.Repository, _ ...map[string]interface{}) error {
+	f.called = true
+	return f.err
+}
+
+func TestUpdateLastEvent(t *testing.T) {
+	t.Run("nil Webhook returns early without panicking or patching", func(t *testing.T) {
+		patcher := &fakeStatusPatcher{}
+		cfg := &provisioning.Repository{
+			ObjectMeta: metav1.ObjectMeta{Name: "repo", Namespace: "default"},
+			Status:     provisioning.RepositoryStatus{Webhook: nil},
+		}
+
+		require.NotPanics(t, func() {
+			err := updateLastEvent(context.Background(), cfg, patcher)
+			assert.NoError(t, err)
+		})
+		assert.False(t, patcher.called, "patcher must not be called when Webhook is nil")
+	})
+
+	t.Run("recent LastEvent skips patch", func(t *testing.T) {
+		patcher := &fakeStatusPatcher{}
+		cfg := &provisioning.Repository{
+			Status: provisioning.RepositoryStatus{
+				Webhook: &provisioning.WebhookStatus{
+					LastEvent: time.Now().UnixMilli(),
+				},
+			},
+		}
+
+		err := updateLastEvent(context.Background(), cfg, patcher)
+		assert.NoError(t, err)
+		assert.False(t, patcher.called, "patcher must not be called when LastEvent is recent")
+	})
+
+	t.Run("stale LastEvent triggers patch", func(t *testing.T) {
+		patcher := &fakeStatusPatcher{}
+		cfg := &provisioning.Repository{
+			Status: provisioning.RepositoryStatus{
+				Webhook: &provisioning.WebhookStatus{
+					LastEvent: time.Now().Add(-2 * time.Minute).UnixMilli(),
+				},
+			},
+		}
+
+		err := updateLastEvent(context.Background(), cfg, patcher)
+		assert.NoError(t, err)
+		assert.True(t, patcher.called, "patcher must be called when LastEvent is stale")
+	})
+
+	t.Run("patch error is wrapped", func(t *testing.T) {
+		patcher := &fakeStatusPatcher{err: errors.New("boom")}
+		cfg := &provisioning.Repository{
+			Status: provisioning.RepositoryStatus{
+				Webhook: &provisioning.WebhookStatus{
+					LastEvent: time.Now().Add(-2 * time.Minute).UnixMilli(),
+				},
+			},
+		}
+
+		err := updateLastEvent(context.Background(), cfg, patcher)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "patch status")
+		assert.ErrorContains(t, err, "boom")
+	})
+}


### PR DESCRIPTION
## Summary

`updateLastEvent` dereferenced `repo.Config().Status.Webhook.LastEvent` before the nil guard on `Status.Webhook`, causing a panic when the webhook had not yet been initialized. Go's HTTP server recovered the panic, but the request still failed with a 500 and no useful error.

This PR moves the nil check before any access to `Webhook` fields, so a nil `Webhook` is a graceful no-op.

Fixes grafana/git-ui-sync-project#1151

## Changes

- `pkg/registry/apis/provisioning/webhooks/webhook.go`: check `Status.Webhook == nil` before dereferencing `LastEvent`. Extracted the core logic into a package-private `updateLastEvent(ctx, cfg, patcher)` function that accepts a small `statusPatcher` interface, so the nil path can be unit-tested without constructing an `APIBuilder`.
- `pkg/registry/apis/provisioning/webhooks/webhook_test.go`: new tests for `updateLastEvent` covering:
  - nil `Webhook` returns early without panicking or patching (regression case)
  - recent `LastEvent` skips the patch
  - stale `LastEvent` triggers the patch
  - patch errors are wrapped

## Testing

- [x] `go test ./pkg/registry/apis/provisioning/webhooks/...` passes
- [x] `go build ./pkg/registry/apis/provisioning/...` clean
- [x] No behavior change when `Webhook` is non-nil

## Checklist

- [x] Tests added covering the nil-Webhook path
- [x] No breaking changes
- [ ] Backport considered

🤖 Generated with [Claude Code](https://claude.com/claude-code)