### PR TITLE
Badge: align icon with first line when text wraps

### DIFF
--- a/packages/grafana-ui/src/components/Badge/Badge.story.tsx
+++ b/packages/grafana-ui/src/components/Badge/Badge.story.tsx
@@ -47,4 +47,14 @@ export const Examples: StoryFn<typeof Badge> = () => (
   </Stack>
 );
 
+export const LongTextWrapping: StoryFn<typeof Badge> = () => (
+  <div style={{ width: 180 }}>
+    <Badge
+      text="Badge label that is long enough to wrap to a second line to demonstrate the alignment of the icon"
+      color="blue"
+      icon="clock-nine"
+    />
+  </div>
+);
+
 export default meta;

--- a/packages/grafana-ui/src/components/Badge/Badge.tsx
+++ b/packages/grafana-ui/src/components/Badge/Badge.tsx
@@ -26,7 +26,11 @@ const BadgeComponent = React.memo<BadgeProps>(({ icon, color, text, tooltip, cla
   const styles = useStyles2(getStyles, color);
   const badge = (
     <div className={cx(styles.wrapper, className)} {...otherProps}>
-      {icon && <Icon name={icon} size="sm" />}
+      {icon && (
+        <span className={styles.iconWrap}>
+          <Icon name={icon} size="sm" />
+        </span>
+      )}
       {text}
     </div>
   );
@@ -94,7 +98,12 @@ const getStyles = (theme: GrafanaTheme2, color: BadgeColor) => {
       gap: theme.spacing(0.5),
       fontSize: theme.typography.bodySmall.fontSize,
       lineHeight: theme.typography.bodySmall.lineHeight,
+      alignItems: 'flex-start',
+    }),
+    iconWrap: css({
+      display: 'inline-flex',
       alignItems: 'center',
+      height: '1lh',
     }),
   };
 };


### PR DESCRIPTION
**What is this feature?**

- wraps the icon in a `<span>` sized to `1lh` so it occupies exactly one line of text
- switches the badge wrapper from `align-items: center` to `align-items: flex-start`
- adds a `LongTextWrapping` story to make the change visible in Storybook

**Why do we need this feature?**

- when badge text wraps to multiple lines, the icon previously centered against the full multi-line block instead of sitting with the first line, which resulted in the component looking visually misaligned
- the new layout keeps the icon on the first row regardless of how many lines the text wraps to
- for single-line badges the rendering is unchanged: the wrapper is exactly one line tall, so `flex-start` and `center` produce identical results

| BEFORE | AFTER |
|--------|--------|
| <img width="281" height="126" alt="localhost_9001__path=_story_information-badge--long-text-wrapping (3)" src="https://github.com/user-attachments/assets/72020ff0-ecb0-4fd9-86fa-adb8db79cde0" /> | <img width="281" height="126" alt="localhost_9001__path=_story_information-badge--long-text-wrapping (2)" src="https://github.com/user-attachments/assets/102040e3-ed5f-49a4-8d94-02bd9727544b" /> |



**Who is this feature for?**

- anyone consuming `Badge` from `@grafana/ui` where the text can wrap (narrow containers, table cells, dynamic labels)

**Special notes for your reviewer:**

- The `1lh` unit is supported in Chrome 99+, Firefox 110+, Safari 16.4+ — fine for Grafana's browser matrix.
- `Icon` itself sets `line-height: 0` on the SVG (for Safari alignment), which is why the `1lh` lives on a wrapper span rather than on the SVG directly.

Please check that:
- [x] It works as expected from a user's perspective.
