### PR TITLE
[release-13.0.2] Provisioning: Remove GET method from webhook connector

### DIFF
--- a/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
+++ b/packages/grafana-api-clients/src/clients/rtkq/provisioning/v0alpha1/endpoints.gen.ts
@@ -543,10 +543,6 @@ const injectedRtkApi = api
         query: (queryArg) => ({ url: `/repositories/${queryArg.name}/test`, method: 'POST', body: queryArg.body }),
         invalidatesTags: ['Repository'],
       }),
-      getRepositoryWebhook: build.query<GetRepositoryWebhookApiResponse, GetRepositoryWebhookApiArg>({
-        query: (queryArg) => ({ url: `/repositories/${queryArg.name}/webhook` }),
-        providesTags: ['Repository'],
-      }),
       createRepositoryWebhook: build.mutation<CreateRepositoryWebhookApiResponse, CreateRepositoryWebhookApiArg>({
         query: (queryArg) => ({ url: `/repositories/${queryArg.name}/webhook`, method: 'POST' }),
         invalidatesTags: ['Repository'],
@@ -1292,11 +1288,6 @@ export type CreateRepositoryTestApiArg = {
     spec?: any;
     status?: any;
   };
-};
-export type GetRepositoryWebhookApiResponse = /** status 200 OK */ WebhookResponse;
-export type GetRepositoryWebhookApiArg = {
-  /** name of the WebhookResponse */
-  name: string;
 };
 export type CreateRepositoryWebhookApiResponse = /** status 200 OK */ WebhookResponse;
 export type CreateRepositoryWebhookApiArg = {
@@ -2219,8 +2210,6 @@ export const {
   useReplaceRepositoryStatusMutation,
   useUpdateRepositoryStatusMutation,
   useCreateRepositoryTestMutation,
-  useGetRepositoryWebhookQuery,
-  useLazyGetRepositoryWebhookQuery,
   useCreateRepositoryWebhookMutation,
   useGetFrontendSettingsQuery,
   useLazyGetFrontendSettingsQuery,

--- a/packages/grafana-openapi/src/apis/provisioning.grafana.app-v0alpha1.json
+++ b/packages/grafana-openapi/src/apis/provisioning.grafana.app-v0alpha1.json
@@ -3661,29 +3661,6 @@
       ]
     },
     "/repositories/{name}/webhook": {
-      "get": {
-        "tags": ["Repository"],
-        "description": "connect GET requests to webhook of Repository",
-        "operationId": "getRepositoryWebhook",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/WebhookResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-kubernetes-action": "connect",
-        "x-kubernetes-group-version-kind": {
-          "group": "provisioning.grafana.app",
-          "version": "v0alpha1",
-          "kind": "WebhookResponse"
-        }
-      },
       "post": {
         "tags": ["Repository"],
         "description": "Currently only supports github webhooks",

--- a/packages/grafana-openapi/src/apis/provisioning.grafana.app-v1beta1.json
+++ b/packages/grafana-openapi/src/apis/provisioning.grafana.app-v1beta1.json
@@ -3661,29 +3661,6 @@
       ]
     },
     "/repositories/{name}/webhook": {
-      "get": {
-        "tags": ["Repository"],
-        "description": "connect GET requests to webhook of Repository",
-        "operationId": "getRepositoryWebhook",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/WebhookResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-kubernetes-action": "connect",
-        "x-kubernetes-group-version-kind": {
-          "group": "provisioning.grafana.app",
-          "version": "v1beta1",
-          "kind": "WebhookResponse"
-        }
-      },
       "post": {
         "tags": ["Repository"],
         "description": "Currently only supports github webhooks",

--- a/pkg/registry/apis/provisioning/webhooks/webhook.go
+++ b/pkg/registry/apis/provisioning/webhooks/webhook.go
@@ -73,10 +73,7 @@ func (*webhookConnector) ProducesObject(verb string) any {
 }
 
 func (*webhookConnector) ConnectMethods() []string {
-	return []string{
-		http.MethodPost,
-		http.MethodGet, // only useful for browser testing, should be removed
-	}
+	return []string{http.MethodPost}
 }
 
 func (*webhookConnector) NewConnectOptions() (runtime.Object, bool, string) {
@@ -103,8 +100,11 @@ func (s *webhookConnector) PostProcessOpenAPI(oas *spec3.OpenAPI) error {
 	root := "/apis/" + s.core.GetGroupVersion().String() + "/"
 	repoprefix := root + "namespaces/{namespace}/repositories/{name}"
 	sub := oas.Paths.Paths[repoprefix+"/webhook"]
-	if sub != nil && sub.Get != nil {
-		sub.Post.Description = "Currently only supports github webhooks"
+	if sub != nil {
+		sub.Get = nil
+		if sub.Post != nil {
+			sub.Post.Description = "Currently only supports github webhooks"
+		}
 	}
 
 	return nil

--- a/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
+++ b/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v0alpha1.json
@@ -3943,31 +3943,6 @@
       ]
     },
     "/apis/provisioning.grafana.app/v0alpha1/namespaces/{namespace}/repositories/{name}/webhook": {
-      "get": {
-        "tags": [
-          "Repository"
-        ],
-        "description": "connect GET requests to webhook of Repository",
-        "operationId": "getRepositoryWebhook",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.provisioning.pkg.apis.provisioning.v0alpha1.WebhookResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-kubernetes-action": "connect",
-        "x-kubernetes-group-version-kind": {
-          "group": "provisioning.grafana.app",
-          "version": "v0alpha1",
-          "kind": "WebhookResponse"
-        }
-      },
       "post": {
         "tags": [
           "Repository"

--- a/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v1beta1.json
+++ b/pkg/tests/apis/openapi_snapshots/provisioning.grafana.app-v1beta1.json
@@ -3943,31 +3943,6 @@
       ]
     },
     "/apis/provisioning.grafana.app/v1beta1/namespaces/{namespace}/repositories/{name}/webhook": {
-      "get": {
-        "tags": [
-          "Repository"
-        ],
-        "description": "connect GET requests to webhook of Repository",
-        "operationId": "getRepositoryWebhook",
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "*/*": {
-                "schema": {
-                  "$ref": "#/components/schemas/com.github.grafana.grafana.apps.provisioning.pkg.apis.provisioning.v1beta1.WebhookResponse"
-                }
-              }
-            }
-          }
-        },
-        "x-kubernetes-action": "connect",
-        "x-kubernetes-group-version-kind": {
-          "group": "provisioning.grafana.app",
-          "version": "v1beta1",
-          "kind": "WebhookResponse"
-        }
-      },
       "post": {
         "tags": [
           "Repository"


### PR DESCRIPTION
Backport of #125539 to `release-13.0.2`.

## Summary

Removes `http.MethodGet` from `webhookConnector.ConnectMethods` so the webhook subresource only accepts `POST`.

The webhook's `Authorize` method returns `DecisionAllow` unconditionally (by design — GitHub delivers webhooks as an anonymous caller). With `GET` registered, unauthenticated callers could distinguish existing vs. non-existing repositories and webhook configuration state via response code differences:

- `GET /repos/existing-repo/webhook` → **401** (repo exists, has webhook, HMAC fails)
- `GET /repos/nonexistent-repo/webhook` → **404**
- `GET /repos/existing-repo-no-webhook/webhook` → **400** ("repository does not support webhooks")

Closes https://github.com/grafana/git-ui-sync-project/issues/1157

## Cherry-pick

Cherry-picked from main commit `fbbb8162d4f25903a5e1da1218efcaf5699cd38a` (squash-merge of #125539). Applied cleanly — no conflicts.

## Changes

- `pkg/registry/apis/provisioning/webhooks/webhook.go`: drop `http.MethodGet` from `ConnectMethods()`; fix latent `PostProcessOpenAPI` guard (was checking `sub.Get != nil` but assigning to `sub.Post.Description`).
- Updated OpenAPI snapshots and published specs (`packages/grafana-openapi/src/apis/*.json`, `pkg/tests/apis/openapi_snapshots/*.json`).
- Removed unused `getRepositoryWebhook` query, types, and hooks from the generated RTK Query client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)