### PR TITLE
Dashboards: Show error when importing dashboard with unknown schema

### DIFF
--- a/public/app/features/manage-dashboards/import/components/ImportOverview.tsx
+++ b/public/app/features/manage-dashboards/import/components/ImportOverview.tsx
@@ -1,4 +1,6 @@
+import { Trans, t } from '@grafana/i18n';
 import { locationService } from '@grafana/runtime';
+import { Alert } from '@grafana/ui';
 import { isDashboardV1Spec, isDashboardV2Spec } from 'app/features/dashboard/api/utils';
 
 import { type DashboardInputs, type DashboardSource } from '../../types';
@@ -46,5 +48,14 @@ export function ImportOverview({ dashboard, dashboardUid, inputs, meta, source, 
     );
   }
 
-  return null;
+  return (
+    <Alert
+      severity="error"
+      title={t('manage-dashboards.import-overview.invalid-schema-title', 'Invalid or unknown dashboard schema')}
+    >
+      <Trans i18nKey="manage-dashboards.import-overview.invalid-schema-body">
+        The dashboard could not be imported because its schema is not a recognized version.
+      </Trans>
+    </Alert>
+  );
 }

--- a/public/app/features/manage-dashboards/import/components/ImportOverview.tsx
+++ b/public/app/features/manage-dashboards/import/components/ImportOverview.tsx
@@ -52,6 +52,10 @@ export function ImportOverview({ dashboard, dashboardUid, inputs, meta, source, 
     <Alert
       severity="error"
       title={t('manage-dashboards.import-overview.invalid-schema-title', 'Invalid or unknown dashboard schema')}
+      onRemove={onCancel}
+      buttonContent={
+        <Trans i18nKey="manage-dashboards.import-overview.invalid-schema-action">Try another dashboard</Trans>
+      }
     >
       <Trans i18nKey="manage-dashboards.import-overview.invalid-schema-body">
         The dashboard could not be imported because its schema is not a recognized version.

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11700,6 +11700,7 @@
       "updated-on": "Updated on"
     },
     "import-overview": {
+      "invalid-schema-action": "Try another dashboard",
       "invalid-schema-body": "The dashboard could not be imported because its schema is not a recognized version.",
       "invalid-schema-title": "Invalid or unknown dashboard schema"
     },

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -11699,6 +11699,10 @@
       "published-by": "Published by",
       "updated-on": "Updated on"
     },
+    "import-overview": {
+      "invalid-schema-body": "The dashboard could not be imported because its schema is not a recognized version.",
+      "invalid-schema-title": "Invalid or unknown dashboard schema"
+    },
     "snapshot-list-table": {
       "body-delete": "Are you sure you want to delete '{{snapshotToRemove}}'?",
       "confirmText-delete": "Delete",


### PR DESCRIPTION
**What is this feature?**

Renders an error on the dashboard import page when the loaded dashboard matches neither the v1 nor v2 schema, instead of silently rendering nothing.




https://github.com/user-attachments/assets/c86cb1c5-21aa-461d-b8a6-6eb37d354850



