### PR TITLE
[release-13.0.2] Provisioning: fix isPublicURL host detection

### DIFF
--- a/pkg/registry/apis/provisioning/webhooks/register.go
+++ b/pkg/registry/apis/provisioning/webhooks/register.go
@@ -3,6 +3,8 @@ package webhooks
 import (
 	"context"
 	"fmt"
+	"net"
+	"net/url"
 	"strings"
 
 	"k8s.io/apiserver/pkg/authorization/authorizer"
@@ -55,14 +57,62 @@ func buildWebhookURL(baseURL string, r *provisioning.Repository) string {
 	)
 }
 
-// HACK: assume that the URL is public if it starts with "https://" and does not contain any local IP ranges
-func isPublicURL(url string) bool {
-	return strings.HasPrefix(url, "https://") &&
-		!strings.Contains(url, "localhost") &&
-		!strings.HasPrefix(url, "https://127.") &&
-		!strings.HasPrefix(url, "https://192.") &&
-		!strings.HasPrefix(url, "https://10.") &&
-		!strings.HasPrefix(url, "https://172.16.")
+// privateNetworks are CIDR ranges that are not reachable from the public
+// internet. Webhook providers (e.g. GitHub) cannot deliver to addresses in
+// these ranges, so URLs resolving to them must not be treated as public.
+var privateNetworks = func() []*net.IPNet {
+	cidrs := []string{
+		"127.0.0.0/8",    // loopback
+		"10.0.0.0/8",     // RFC1918
+		"172.16.0.0/12",  // RFC1918
+		"192.168.0.0/16", // RFC1918
+		"169.254.0.0/16", // link-local / cloud metadata
+		"100.64.0.0/10",  // CGNAT
+		"::1/128",        // IPv6 loopback
+		"fe80::/10",      // IPv6 link-local
+		"fc00::/7",       // IPv6 unique local
+	}
+	nets := make([]*net.IPNet, 0, len(cidrs))
+	for _, c := range cidrs {
+		_, n, err := net.ParseCIDR(c)
+		if err != nil {
+			panic(fmt.Sprintf("invalid CIDR %q: %v", c, err))
+		}
+		nets = append(nets, n)
+	}
+	return nets
+}()
+
+// isPublicURL reports whether rawURL is reachable from the public internet.
+// It requires https, rejects localhost and Kubernetes-internal DNS suffixes,
+// and rejects IP literals that fall inside any private/reserved range.
+func isPublicURL(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Scheme != "https" {
+		return false
+	}
+
+	host := u.Hostname()
+	if host == "" || host == "localhost" {
+		return false
+	}
+
+	if strings.HasSuffix(host, ".svc") || strings.HasSuffix(host, ".cluster.local") {
+		return false
+	}
+
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return true
+	}
+
+	for _, network := range privateNetworks {
+		if network.Contains(ip) {
+			return false
+		}
+	}
+
+	return true
 }
 
 func ProvideWebhooksWithImages(

--- a/pkg/registry/apis/provisioning/webhooks/register_test.go
+++ b/pkg/registry/apis/provisioning/webhooks/register_test.go
@@ -164,13 +164,42 @@ func TestIsPublicURL(t *testing.T) {
 		url      string
 		expected bool
 	}{
+		// Public
 		{"https://grafana.example.com/", true},
+		{"https://grafana.example.com:8443/path", true},
+		{"https://notlocalhost.grafana.com/", true},
+		{"https://172.15.0.1/", true}, // just outside 172.16.0.0/12
+		{"https://172.32.0.1/", true}, // just outside 172.16.0.0/12
+		{"https://8.8.8.8/", true},    // public IPv4
+		{"https://[2001:db8::1]/", true},
+
+		// Scheme
 		{"http://grafana.example.com/", false},
+		{"ftp://grafana.example.com/", false},
+		{"://broken", false},
+
+		// Hostnames
 		{"https://localhost:3000/", false},
+		{"https://my-svc.default.svc/", false},
+		{"https://my-svc.default.svc.cluster.local/", false},
+
+		// IPv4 RFC1918 / reserved
 		{"https://127.0.0.1:3000/", false},
-		{"https://192.168.1.1:3000/", false},
 		{"https://10.0.0.1:3000/", false},
+		{"https://192.168.1.1:3000/", false},
 		{"https://172.16.0.1:3000/", false},
+		{"https://172.17.0.1/", false},
+		{"https://172.20.5.10/", false},
+		{"https://172.31.255.254/", false},
+		{"https://169.254.169.254/", false}, // cloud metadata
+		{"https://100.64.0.1/", false},      // CGNAT
+		{"https://100.127.255.254/", false}, // CGNAT upper bound
+
+		// IPv6 reserved
+		{"https://[::1]/", false},
+		{"https://[fe80::1]/", false},
+		{"https://[fc00::1]/", false},
+		{"https://[fd12:3456:789a::1]/", false},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Backport of #125548 to `release-13.0.2`.

Cherry-picked commit: 1c189bcecdcbc2bdcbd6d6256257e712d9c7d6fd

## Summary

Replace prefix-matching in `isPublicURL` with proper URL parsing and CIDR range checks so webhook registration is gated correctly. Fixes incomplete RFC1918 coverage (172.17–172.31), missed reserved ranges (169.254/16, 100.64/10, IPv6 loopback/link-local/ULA), Kubernetes-internal DNS (`.svc`, `.cluster.local`), and the `notlocalhost.grafana.com` substring false negative.

Fixes https://github.com/grafana/git-ui-sync-project/issues/1154

## Testing

`go test ./pkg/registry/apis/provisioning/webhooks/ -run TestIsPublicURL` — all 27 cases pass on the release branch.