### PR TITLE
Notifications: Onboard frontend-platform team

### DIFF
--- a/.github/team-notifications-config.json
+++ b/.github/team-notifications-config.json
@@ -30,6 +30,21 @@
         "fr_notify": false,
         "fr_weekly": true
       }
+    },
+    {
+      "name": "frontend-platform",
+      "kickoff_date": "2026-05-27",
+      "adoption_date": "2025-05-27",
+      "codeowners_teams": [
+        "@grafana/grafana-frontend-platform"
+      ],
+      "area_labels": ["area/internationalization", "area/panel/text"],
+      "enabled": {
+        "pr_notify": true,
+        "pr_weekly": true,
+        "fr_notify": true,
+        "fr_weekly": true
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

Onboards the frontend-platform team to the community notifications system.

- Codeowners: `@grafana/grafana-frontend-platform`
- Area labels: `area/internationalization`, `area/panel/text`
- All four notification types enabled (PR real-time, PR weekly, FR real-time, FR weekly)

## Follow-up

After merge, a vault admin needs to add the team entry to the `slack-channels` / `map` secret so notifications can be routed to `#grafana-frontend-platform`. The channel ID will be shared in `#proj-community-contributions`.

## Test plan

- [ ] Config validates as JSON
- [ ] Vault entry added post-merge
- [ ] Bot invited to `#grafana-frontend-platform`