### PR TITLE
Docs: Value mapping for multiline strings

### DIFF
--- a/docs/sources/visualizations/panels-visualizations/configure-value-mappings/index.md
+++ b/docs/sources/visualizations/panels-visualizations/configure-value-mappings/index.md
@@ -187,9 +187,9 @@ The following image shows a table visualization with value mappings. If you want
 
 If your data source returns multiline strings—such as Windows event log entries that contain `\r\n` line breaks—a regular expression pattern using `.` won't match across those line breaks. Use `[\s\S]` to match any character including newlines.
 
-| Pattern | Matches |
-| --- | --- |
-| `.*` | Single-line text only |
+| Pattern   | Matches                        |
+| --------- | ------------------------------ |
+| `.*`      | Single-line text only          |
 | `[\s\S]*` | Single-line and multiline text |
 
 For example, to map any multiline log entry that starts with `ERROR` to the display text **Error**, use the pattern:

--- a/docs/sources/visualizations/panels-visualizations/configure-value-mappings/index.md
+++ b/docs/sources/visualizations/panels-visualizations/configure-value-mappings/index.md
@@ -145,7 +145,7 @@ A **Regex** mapping maps regular expressions to text and a color. For example, i
 ![A regular expression used to truncate full URLs to the text wwww](/media/docs/grafana/panels-visualizations/screenshot-map-regex-v10.4.png)
 
 {{< admonition type="note" >}}
-The `.` metacharacter doesn't match newline characters `\n` and `\r` by default.
+The character `.` doesn't match newline characters `\n` and `\r` by default.
 If your data contains multiline strings, use `[\s\S]` in place of `.` to match any character including newlines.
 For more detailed information, refer to the [Multiline regular expression example](#multiline-regular-expression-example).
 {{< /admonition >}}
@@ -192,13 +192,14 @@ If your data source returns multiline strings—such as Windows event log entrie
 | `.*`      | Single-line text only          |
 | `[\s\S]*` | Single-line and multiline text |
 
-For example, to map any multiline log entry that starts with `ERROR` to the display text **Error**, use the pattern:
+For example, if you wanted to map any multiline log entry that starts with `ERROR` to the display text **Error**, using `ERROR.*` would only match text up to the first newline and would fail to map the full entry.
+
+Instead, you should use the pattern:
 
 ```text
 ERROR[\s\S]*
 ```
 
-Using `ERROR.*` instead would only match text up to the first newline and would fail to map the full entry.
 
 ## Add a value mapping
 

--- a/docs/sources/visualizations/panels-visualizations/configure-value-mappings/index.md
+++ b/docs/sources/visualizations/panels-visualizations/configure-value-mappings/index.md
@@ -144,6 +144,10 @@ A **Range** mapping maps numerical ranges to text and a color. For example, if a
 A **Regex** mapping maps regular expressions to text and a color. For example, if a value is `www.example.com`, you can configure a regular expression value mapping so that Grafana displays **www** and truncates the domain. Use the **Regex** mapping when you want to format the text and color of a regular expression value.
 ![A regular expression used to truncate full URLs to the text wwww](/media/docs/grafana/panels-visualizations/screenshot-map-regex-v10.4.png)
 
+{{< admonition type="note" >}}
+The `.` metacharacter does not match newline characters `\n` and `\r` by default. If your data contains multiline strings, use `[\s\S]` in place of `.` to match any character including newlines.
+{{< /admonition >}}
+
 ### Special
 
 A **Special** mapping maps special values like `Null`, `NaN` (not a number), and boolean values like `true` and `false` to text and color. For example, you can configure a special value mapping so that `null` values appear as **N/A**. Use the **Special** mapping when you want to format uncommon, boolean, or empty values.
@@ -176,6 +180,23 @@ The following image shows a bar gauge visualization with value mappings. Note th
 The following image shows a table visualization with value mappings. If you want value mapping colors displayed on the table, then set the cell display mode to **Color text** or **Color background**.
 
 ![Value mappings table example](/static/img/docs/value-mappings/value-mappings-table-example-8-0.png)
+
+### Multiline regular expression example
+
+If your data source returns multiline strings—such as Windows event log entries that contain `\r\n` line breaks—a regex pattern using `.` will not match across those line breaks. Use `[\s\S]` to match any character including newlines.
+
+| Pattern | Matches |
+|---|---|
+| `.*` | Single-line text only |
+| `[\s\S]*` | Single-line and multiline text |
+
+For example, to map any multiline log entry that starts with `ERROR` to the display text **Error** with a red color, use the pattern:
+
+```
+ERROR[\s\S]*
+```
+
+Using `ERROR.*` instead would only match text up to the first newline and would fail to map the full entry.
 
 ## Add a value mapping
 

--- a/docs/sources/visualizations/panels-visualizations/configure-value-mappings/index.md
+++ b/docs/sources/visualizations/panels-visualizations/configure-value-mappings/index.md
@@ -200,7 +200,6 @@ Instead, you should use the pattern:
 ERROR[\s\S]*
 ```
 
-
 ## Add a value mapping
 
 1. Navigate to the panel you want to update.

--- a/docs/sources/visualizations/panels-visualizations/configure-value-mappings/index.md
+++ b/docs/sources/visualizations/panels-visualizations/configure-value-mappings/index.md
@@ -145,7 +145,9 @@ A **Regex** mapping maps regular expressions to text and a color. For example, i
 ![A regular expression used to truncate full URLs to the text wwww](/media/docs/grafana/panels-visualizations/screenshot-map-regex-v10.4.png)
 
 {{< admonition type="note" >}}
-The `.` metacharacter does not match newline characters `\n` and `\r` by default. If your data contains multiline strings, use `[\s\S]` in place of `.` to match any character including newlines.
+The `.` metacharacter doesn't match newline characters `\n` and `\r` by default.
+If your data contains multiline strings, use `[\s\S]` in place of `.` to match any character including newlines.
+For more detailed information, refer to the [Multiline regular expression example](#multiline-regular-expression-example).
 {{< /admonition >}}
 
 ### Special
@@ -183,16 +185,16 @@ The following image shows a table visualization with value mappings. If you want
 
 ### Multiline regular expression example
 
-If your data source returns multiline strings—such as Windows event log entries that contain `\r\n` line breaks—a regex pattern using `.` will not match across those line breaks. Use `[\s\S]` to match any character including newlines.
+If your data source returns multiline strings—such as Windows event log entries that contain `\r\n` line breaks—a regular expression pattern using `.` won't match across those line breaks. Use `[\s\S]` to match any character including newlines.
 
 | Pattern | Matches |
-|---|---|
+| --- | --- |
 | `.*` | Single-line text only |
 | `[\s\S]*` | Single-line and multiline text |
 
-For example, to map any multiline log entry that starts with `ERROR` to the display text **Error** with a red color, use the pattern:
+For example, to map any multiline log entry that starts with `ERROR` to the display text **Error**, use the pattern:
 
-```
+```text
 ERROR[\s\S]*
 ```
 


### PR DESCRIPTION
This PR clarifies that the character `.` does not match newlines by default and that `[\s\S]` should be used for multiline strings.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

