### PR TITLE
Provisioning: Record Grafana user in commit messages

### DIFF
--- a/public/app/features/provisioning/Config/CommitMessageTemplateField.tsx
+++ b/public/app/features/provisioning/Config/CommitMessageTemplateField.tsx
@@ -16,12 +16,15 @@ export function CommitMessageTemplateField({ register }: Props) {
       label={t('provisioning.config-form.label-commit-message-template', 'Commit message template')}
       description={t(
         'provisioning.config-form.description-commit-message-template',
-        'Default commit message when saving a provisioned resource. Available placeholders: {{actionVar}} (create/update/delete/move/rename), {{kindVar}} (dashboard/folder), {{idVar}}, {{titleVar}}. Leave empty to use the built-in defaults.',
+        'Default commit message when saving a provisioned resource. Available placeholders: {{actionVar}} (create/update/delete/move/rename), {{kindVar}} (dashboard/folder), {{idVar}}, {{titleVar}}, {{userNameVar}}, {{userLoginVar}}, {{userEmailVar}}. A "Grafana-saved-by: <name> (<login>)" trailer is appended automatically. Leave empty to use the built-in defaults.',
         {
           actionVar: '{{action}}',
           kindVar: '{{resourceKind}}',
           idVar: '{{resourceID}}',
           titleVar: '{{title}}',
+          userNameVar: '{{userName}}',
+          userLoginVar: '{{userLogin}}',
+          userEmailVar: '{{userEmail}}',
         }
       )}
     >

--- a/public/app/features/provisioning/Wizard/hooks/useCreateSyncJob.ts
+++ b/public/app/features/provisioning/Wizard/hooks/useCreateSyncJob.ts
@@ -45,8 +45,8 @@ export function useCreateSyncJob({ repoName, setStepStatusInfo }: UseCreateSyncJ
             }
           : {
               action: 'pull' as const,
-              // TODO: SyncJobOptions has no `message` field on the backend yet — when
-              // it gains one, append the Grafana-saved-by trailer here too.
+              // TODO(#125602): SyncJobOptions has no `message` field on the backend
+              // yet — when it gains one, append the Grafana-saved-by trailer here too.
               pull: {
                 incremental: false,
               },

--- a/public/app/features/provisioning/Wizard/hooks/useCreateSyncJob.ts
+++ b/public/app/features/provisioning/Wizard/hooks/useCreateSyncJob.ts
@@ -45,8 +45,9 @@ export function useCreateSyncJob({ repoName, setStepStatusInfo }: UseCreateSyncJ
             }
           : {
               action: 'pull' as const,
-              // TODO: SyncJobOptions has no `message` field on the backend yet — when
-              // it gains one, append the Grafana-saved-by trailer here too.
+              // TODO(grafana/git-ui-sync-project#1162): SyncJobOptions has no
+              // `message` field on the backend yet — when it gains one, append
+              // the Grafana-saved-by trailer here too.
               pull: {
                 incremental: false,
               },

--- a/public/app/features/provisioning/Wizard/hooks/useCreateSyncJob.ts
+++ b/public/app/features/provisioning/Wizard/hooks/useCreateSyncJob.ts
@@ -4,6 +4,7 @@ import { t } from '@grafana/i18n';
 import { useCreateRepositoryJobsMutation } from 'app/api/clients/provisioning/v0alpha1';
 import { extractErrorMessage } from 'app/api/utils';
 
+import { withSavedByTrailer } from '../../utils/currentUser';
 import { type StepStatusInfo } from '../types';
 
 export interface UseCreateSyncJobParams {
@@ -36,10 +37,16 @@ export function useCreateSyncJob({ repoName, setStepStatusInfo }: UseCreateSyncJ
         const jobSpec = requiresMigration
           ? {
               action: 'migrate' as const,
-              migrate: {},
+              migrate: {
+                message: withSavedByTrailer(
+                  t('provisioning.sync-job.migrate-default-message', 'Migrate Grafana resources into repository')
+                ),
+              },
             }
           : {
               action: 'pull' as const,
+              // TODO: SyncJobOptions has no `message` field on the backend yet — when
+              // it gains one, append the Grafana-saved-by trailer here too.
               pull: {
                 incremental: false,
               },

--- a/public/app/features/provisioning/Wizard/hooks/useCreateSyncJob.ts
+++ b/public/app/features/provisioning/Wizard/hooks/useCreateSyncJob.ts
@@ -45,8 +45,8 @@ export function useCreateSyncJob({ repoName, setStepStatusInfo }: UseCreateSyncJ
             }
           : {
               action: 'pull' as const,
-              // TODO(#125602): SyncJobOptions has no `message` field on the backend
-              // yet — when it gains one, append the Grafana-saved-by trailer here too.
+              // TODO: SyncJobOptions has no `message` field on the backend yet — when
+              // it gains one, append the Grafana-saved-by trailer here too.
               pull: {
                 incremental: false,
               },

--- a/public/app/features/provisioning/components/BulkActions/BulkDeleteProvisionedResource.tsx
+++ b/public/app/features/provisioning/components/BulkActions/BulkDeleteProvisionedResource.tsx
@@ -58,10 +58,9 @@ function FormContent({ initialValues, selectedItems, repository, canPushToConfig
     });
 
     // Create the delete job spec.
-    // TODO(#125602): DeleteJobOptions has no `message` field on the backend
-    // yet — once it gains one, pass `withSavedByTrailer(<default or
-    // data.comment>)` so the Grafana-saved-by trailer rides through to the
-    // resulting git commit.
+    // TODO: DeleteJobOptions has no `message` field on the backend yet — once
+    // it gains one, pass `withSavedByTrailer(<default or data.comment>)` so
+    // the Grafana-saved-by trailer rides through to the resulting git commit.
     const jobSpec: DeleteJobSpec = {
       action: 'delete',
       delete: {

--- a/public/app/features/provisioning/components/BulkActions/BulkDeleteProvisionedResource.tsx
+++ b/public/app/features/provisioning/components/BulkActions/BulkDeleteProvisionedResource.tsx
@@ -58,9 +58,10 @@ function FormContent({ initialValues, selectedItems, repository, canPushToConfig
     });
 
     // Create the delete job spec.
-    // TODO: DeleteJobOptions has no `message` field on the backend yet — once it
-    // gains one, pass `withSavedByTrailer(<default or data.comment>)` so the
-    // Grafana-saved-by trailer rides through to the resulting git commit.
+    // TODO(#125602): DeleteJobOptions has no `message` field on the backend
+    // yet — once it gains one, pass `withSavedByTrailer(<default or
+    // data.comment>)` so the Grafana-saved-by trailer rides through to the
+    // resulting git commit.
     const jobSpec: DeleteJobSpec = {
       action: 'delete',
       delete: {

--- a/public/app/features/provisioning/components/BulkActions/BulkDeleteProvisionedResource.tsx
+++ b/public/app/features/provisioning/components/BulkActions/BulkDeleteProvisionedResource.tsx
@@ -58,9 +58,10 @@ function FormContent({ initialValues, selectedItems, repository, canPushToConfig
     });
 
     // Create the delete job spec.
-    // TODO: DeleteJobOptions has no `message` field on the backend yet — once
-    // it gains one, pass `withSavedByTrailer(<default or data.comment>)` so
-    // the Grafana-saved-by trailer rides through to the resulting git commit.
+    // TODO(grafana/git-ui-sync-project#1162): DeleteJobOptions has no
+    // `message` field on the backend yet — once it gains one, pass
+    // `withSavedByTrailer(<default or data.comment>)` so the
+    // Grafana-saved-by trailer rides through to the resulting git commit.
     const jobSpec: DeleteJobSpec = {
       action: 'delete',
       delete: {

--- a/public/app/features/provisioning/components/BulkActions/BulkDeleteProvisionedResource.tsx
+++ b/public/app/features/provisioning/components/BulkActions/BulkDeleteProvisionedResource.tsx
@@ -57,7 +57,10 @@ function FormContent({ initialValues, selectedItems, repository, canPushToConfig
       dashboardCount,
     });
 
-    // Create the delete job spec
+    // Create the delete job spec.
+    // TODO: DeleteJobOptions has no `message` field on the backend yet — once it
+    // gains one, pass `withSavedByTrailer(<default or data.comment>)` so the
+    // Grafana-saved-by trailer rides through to the resulting git commit.
     const jobSpec: DeleteJobSpec = {
       action: 'delete',
       delete: {

--- a/public/app/features/provisioning/components/BulkActions/BulkMoveProvisionedResource.tsx
+++ b/public/app/features/provisioning/components/BulkActions/BulkMoveProvisionedResource.tsx
@@ -120,9 +120,10 @@ function FormContent({
     });
 
     // Create the move job spec.
-    // TODO: MoveJobOptions has no `message` field on the backend yet — once it
-    // gains one, pass `withSavedByTrailer(<default or data.comment>)` so the
-    // Grafana-saved-by trailer rides through to the resulting git commit.
+    // TODO(#125602): MoveJobOptions has no `message` field on the backend
+    // yet — once it gains one, pass `withSavedByTrailer(<default or
+    // data.comment>)` so the Grafana-saved-by trailer rides through to the
+    // resulting git commit.
     const jobSpec: MoveJobSpec = {
       action: 'move',
       move: {

--- a/public/app/features/provisioning/components/BulkActions/BulkMoveProvisionedResource.tsx
+++ b/public/app/features/provisioning/components/BulkActions/BulkMoveProvisionedResource.tsx
@@ -120,9 +120,10 @@ function FormContent({
     });
 
     // Create the move job spec.
-    // TODO: MoveJobOptions has no `message` field on the backend yet — once
-    // it gains one, pass `withSavedByTrailer(<default or data.comment>)` so
-    // the Grafana-saved-by trailer rides through to the resulting git commit.
+    // TODO(grafana/git-ui-sync-project#1162): MoveJobOptions has no `message`
+    // field on the backend yet — once it gains one, pass
+    // `withSavedByTrailer(<default or data.comment>)` so the
+    // Grafana-saved-by trailer rides through to the resulting git commit.
     const jobSpec: MoveJobSpec = {
       action: 'move',
       move: {

--- a/public/app/features/provisioning/components/BulkActions/BulkMoveProvisionedResource.tsx
+++ b/public/app/features/provisioning/components/BulkActions/BulkMoveProvisionedResource.tsx
@@ -119,7 +119,10 @@ function FormContent({
       resourceCount: resources.length,
     });
 
-    // Create the move job spec
+    // Create the move job spec.
+    // TODO: MoveJobOptions has no `message` field on the backend yet — once it
+    // gains one, pass `withSavedByTrailer(<default or data.comment>)` so the
+    // Grafana-saved-by trailer rides through to the resulting git commit.
     const jobSpec: MoveJobSpec = {
       action: 'move',
       move: {

--- a/public/app/features/provisioning/components/BulkActions/BulkMoveProvisionedResource.tsx
+++ b/public/app/features/provisioning/components/BulkActions/BulkMoveProvisionedResource.tsx
@@ -120,10 +120,9 @@ function FormContent({
     });
 
     // Create the move job spec.
-    // TODO(#125602): MoveJobOptions has no `message` field on the backend
-    // yet — once it gains one, pass `withSavedByTrailer(<default or
-    // data.comment>)` so the Grafana-saved-by trailer rides through to the
-    // resulting git commit.
+    // TODO: MoveJobOptions has no `message` field on the backend yet — once
+    // it gains one, pass `withSavedByTrailer(<default or data.comment>)` so
+    // the Grafana-saved-by trailer rides through to the resulting git commit.
     const jobSpec: MoveJobSpec = {
       action: 'move',
       move: {

--- a/public/app/features/provisioning/components/Dashboards/DeleteProvisionedDashboardForm.tsx
+++ b/public/app/features/provisioning/components/Dashboards/DeleteProvisionedDashboardForm.tsx
@@ -105,7 +105,7 @@ export function DeleteProvisionedDashboardForm({
         resourceKind: 'dashboard',
         resourceID: dashboard.state.meta.uid ?? dashboard.state.meta.k8s?.name ?? '',
         title: dashboard.state.title ?? '',
-        user: getCurrentCommitUser(),
+        ...getCurrentCommitUser(),
       });
 
       try {

--- a/public/app/features/provisioning/components/Dashboards/DeleteProvisionedDashboardForm.tsx
+++ b/public/app/features/provisioning/components/Dashboards/DeleteProvisionedDashboardForm.tsx
@@ -19,6 +19,7 @@ import { useProvisionedRequestHandler } from '../../hooks/useProvisionedRequestH
 import { type StatusInfo } from '../../types';
 import { type ProvisionedDashboardFormData } from '../../types/form';
 import { getSingleResourceCommitMessage } from '../../utils/commitMessage';
+import { getCurrentCommitUser } from '../../utils/currentUser';
 import { buildResourceBranchRedirectUrl } from '../../utils/redirect';
 import { useBulkActionJob } from '../BulkActions/useBulkActionJob';
 import { RepoInvalidStateBanner } from '../Shared/RepoInvalidStateBanner';
@@ -104,6 +105,7 @@ export function DeleteProvisionedDashboardForm({
         resourceKind: 'dashboard',
         resourceID: dashboard.state.meta.uid ?? dashboard.state.meta.k8s?.name ?? '',
         title: dashboard.state.title ?? '',
+        user: getCurrentCommitUser(),
       });
 
       try {

--- a/public/app/features/provisioning/components/Dashboards/MoveProvisionedDashboardForm.tsx
+++ b/public/app/features/provisioning/components/Dashboards/MoveProvisionedDashboardForm.tsx
@@ -166,7 +166,7 @@ export function MoveProvisionedDashboardForm({
         resourceKind: 'dashboard',
         resourceID: dashboard.state.meta.uid ?? dashboard.state.meta.k8s?.name ?? '',
         title: dashboard.state.title ?? '',
-        user: getCurrentCommitUser(),
+        ...getCurrentCommitUser(),
       });
 
       try {

--- a/public/app/features/provisioning/components/Dashboards/MoveProvisionedDashboardForm.tsx
+++ b/public/app/features/provisioning/components/Dashboards/MoveProvisionedDashboardForm.tsx
@@ -24,6 +24,7 @@ import { type ProvisionedOperationInfo, useProvisionedRequestHandler } from '../
 import { type StatusInfo } from '../../types';
 import { type ProvisionedDashboardFormData } from '../../types/form';
 import { getSingleResourceCommitMessage } from '../../utils/commitMessage';
+import { getCurrentCommitUser } from '../../utils/currentUser';
 import { buildResourceBranchRedirectUrl } from '../../utils/redirect';
 import { useBulkActionJob } from '../BulkActions/useBulkActionJob';
 import { getTargetFolderPathInRepo, isResourceAlreadyInTarget } from '../BulkActions/utils';
@@ -165,6 +166,7 @@ export function MoveProvisionedDashboardForm({
         resourceKind: 'dashboard',
         resourceID: dashboard.state.meta.uid ?? dashboard.state.meta.k8s?.name ?? '',
         title: dashboard.state.title ?? '',
+        user: getCurrentCommitUser(),
       });
 
       try {

--- a/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.tsx
+++ b/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.tsx
@@ -25,6 +25,7 @@ import { type SaveDashboardResponseDTO } from 'app/types/dashboard';
 import { ProvisioningAlert } from '../../Shared/ProvisioningAlert';
 import { type ProvisionedDashboardFormData } from '../../types/form';
 import { getSingleResourceCommitMessage } from '../../utils/commitMessage';
+import { getCurrentCommitUser } from '../../utils/currentUser';
 import { buildResourceBranchRedirectUrl } from '../../utils/redirect';
 import { ProvisioningAwareFolderPicker } from '../Shared/ProvisioningAwareFolderPicker';
 import { RepoInvalidStateBanner } from '../Shared/RepoInvalidStateBanner';
@@ -241,6 +242,7 @@ export function SaveProvisionedDashboardForm({
       resourceKind: 'dashboard',
       resourceID: dashboard.state.meta.uid ?? dashboard.state.meta.k8s?.name ?? '',
       title: dashboard.state.title ?? '',
+      user: getCurrentCommitUser(),
     });
 
     const body = rawDashboardJSON

--- a/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.tsx
+++ b/public/app/features/provisioning/components/Dashboards/SaveProvisionedDashboardForm.tsx
@@ -242,7 +242,7 @@ export function SaveProvisionedDashboardForm({
       resourceKind: 'dashboard',
       resourceID: dashboard.state.meta.uid ?? dashboard.state.meta.k8s?.name ?? '',
       title: dashboard.state.title ?? '',
-      user: getCurrentCommitUser(),
+      ...getCurrentCommitUser(),
     });
 
     const body = rawDashboardJSON

--- a/public/app/features/provisioning/components/Folders/DeleteProvisionedFolderForm.tsx
+++ b/public/app/features/provisioning/components/Folders/DeleteProvisionedFolderForm.tsx
@@ -20,6 +20,7 @@ import { useProvisionedFolderFormData } from '../../hooks/useProvisionedFolderFo
 import { type ProvisionedOperationInfo, useProvisionedRequestHandler } from '../../hooks/useProvisionedRequestHandler';
 import { type BaseProvisionedFormData } from '../../types/form';
 import { getSingleResourceCommitMessage } from '../../utils/commitMessage';
+import { getCurrentCommitUser } from '../../utils/currentUser';
 import { buildResourceBranchRedirectUrl } from '../../utils/redirect';
 import { useBulkActionJob } from '../BulkActions/useBulkActionJob';
 import { RepoInvalidStateBanner } from '../Shared/RepoInvalidStateBanner';
@@ -86,6 +87,7 @@ function FormContent({ initialValues, parentFolder, repository, canPushToConfigu
         resourceKind: 'folder',
         resourceID: parentFolder?.uid ?? '',
         title: parentFolder?.title ?? '',
+        user: getCurrentCommitUser(),
       });
 
       try {

--- a/public/app/features/provisioning/components/Folders/DeleteProvisionedFolderForm.tsx
+++ b/public/app/features/provisioning/components/Folders/DeleteProvisionedFolderForm.tsx
@@ -87,7 +87,7 @@ function FormContent({ initialValues, parentFolder, repository, canPushToConfigu
         resourceKind: 'folder',
         resourceID: parentFolder?.uid ?? '',
         title: parentFolder?.title ?? '',
-        user: getCurrentCommitUser(),
+        ...getCurrentCommitUser(),
       });
 
       try {

--- a/public/app/features/provisioning/components/Folders/FixFolderMetadataDrawer.tsx
+++ b/public/app/features/provisioning/components/Folders/FixFolderMetadataDrawer.tsx
@@ -136,8 +136,8 @@ function FixFolderMetadataForm({
   const handleSubmitForm = async ({ ref }: BaseProvisionedFormData) => {
     onSubmitError(undefined);
     try {
-      // TODO(#125602): FixFolderMetadataJobOptions has no `message` field on
-      // the backend yet — once it gains one, pass
+      // TODO: FixFolderMetadataJobOptions has no `message` field on the
+      // backend yet — once it gains one, pass
       // `withSavedByTrailer('Fix folder metadata')` so the Grafana-saved-by
       // trailer rides through to the resulting git commit.
       const result = await createJob({

--- a/public/app/features/provisioning/components/Folders/FixFolderMetadataDrawer.tsx
+++ b/public/app/features/provisioning/components/Folders/FixFolderMetadataDrawer.tsx
@@ -136,6 +136,10 @@ function FixFolderMetadataForm({
   const handleSubmitForm = async ({ ref }: BaseProvisionedFormData) => {
     onSubmitError(undefined);
     try {
+      // TODO: FixFolderMetadataJobOptions has no `message` field on the
+      // backend yet — once it gains one, pass
+      // `withSavedByTrailer('Fix folder metadata')` so the Grafana-saved-by
+      // trailer rides through to the resulting git commit.
       const result = await createJob({
         name: repositoryName,
         jobSpec: {

--- a/public/app/features/provisioning/components/Folders/FixFolderMetadataDrawer.tsx
+++ b/public/app/features/provisioning/components/Folders/FixFolderMetadataDrawer.tsx
@@ -136,8 +136,8 @@ function FixFolderMetadataForm({
   const handleSubmitForm = async ({ ref }: BaseProvisionedFormData) => {
     onSubmitError(undefined);
     try {
-      // TODO: FixFolderMetadataJobOptions has no `message` field on the
-      // backend yet — once it gains one, pass
+      // TODO(grafana/git-ui-sync-project#1162): FixFolderMetadataJobOptions
+      // has no `message` field on the backend yet — once it gains one, pass
       // `withSavedByTrailer('Fix folder metadata')` so the Grafana-saved-by
       // trailer rides through to the resulting git commit.
       const result = await createJob({

--- a/public/app/features/provisioning/components/Folders/FixFolderMetadataDrawer.tsx
+++ b/public/app/features/provisioning/components/Folders/FixFolderMetadataDrawer.tsx
@@ -136,8 +136,8 @@ function FixFolderMetadataForm({
   const handleSubmitForm = async ({ ref }: BaseProvisionedFormData) => {
     onSubmitError(undefined);
     try {
-      // TODO: FixFolderMetadataJobOptions has no `message` field on the
-      // backend yet — once it gains one, pass
+      // TODO(#125602): FixFolderMetadataJobOptions has no `message` field on
+      // the backend yet — once it gains one, pass
       // `withSavedByTrailer('Fix folder metadata')` so the Grafana-saved-by
       // trailer rides through to the resulting git commit.
       const result = await createJob({

--- a/public/app/features/provisioning/components/Folders/NewProvisionedFolderForm.tsx
+++ b/public/app/features/provisioning/components/Folders/NewProvisionedFolderForm.tsx
@@ -154,7 +154,7 @@ function FormContent({ initialValues, repository, canPushToConfiguredBranch, fol
         resourceKind: 'folder',
         resourceID: '',
         title,
-        user: getCurrentCommitUser(),
+        ...getCurrentCommitUser(),
       }),
       body: folderModel,
     });

--- a/public/app/features/provisioning/components/Folders/NewProvisionedFolderForm.tsx
+++ b/public/app/features/provisioning/components/Folders/NewProvisionedFolderForm.tsx
@@ -17,6 +17,7 @@ import { useProvisionedFolderFormData } from '../../hooks/useProvisionedFolderFo
 import { type ProvisionedOperationInfo, useProvisionedRequestHandler } from '../../hooks/useProvisionedRequestHandler';
 import { type BaseProvisionedFormData } from '../../types/form';
 import { getSingleResourceCommitMessage } from '../../utils/commitMessage';
+import { getCurrentCommitUser } from '../../utils/currentUser';
 import { buildResourceBranchRedirectUrl } from '../../utils/redirect';
 import { RepoInvalidStateBanner } from '../Shared/RepoInvalidStateBanner';
 import { ResourceEditFormSharedFields } from '../Shared/ResourceEditFormSharedFields';
@@ -153,6 +154,7 @@ function FormContent({ initialValues, repository, canPushToConfiguredBranch, fol
         resourceKind: 'folder',
         resourceID: '',
         title,
+        user: getCurrentCommitUser(),
       }),
       body: folderModel,
     });

--- a/public/app/features/provisioning/components/Folders/RenameProvisionedFolderForm.tsx
+++ b/public/app/features/provisioning/components/Folders/RenameProvisionedFolderForm.tsx
@@ -135,7 +135,7 @@ function FormContent({ initialValues, folder, repository, canPushToConfiguredBra
         resourceKind: 'folder',
         resourceID: folder.uid,
         title,
-        user: getCurrentCommitUser(),
+        ...getCurrentCommitUser(),
       }),
       body: {
         spec: { title },

--- a/public/app/features/provisioning/components/Folders/RenameProvisionedFolderForm.tsx
+++ b/public/app/features/provisioning/components/Folders/RenameProvisionedFolderForm.tsx
@@ -16,6 +16,7 @@ import { useProvisionedFolderFormData } from '../../hooks/useProvisionedFolderFo
 import { type ProvisionedOperationInfo, useProvisionedRequestHandler } from '../../hooks/useProvisionedRequestHandler';
 import { type BaseProvisionedFormData } from '../../types/form';
 import { getSingleResourceCommitMessage } from '../../utils/commitMessage';
+import { getCurrentCommitUser } from '../../utils/currentUser';
 import { RepoInvalidStateBanner } from '../Shared/RepoInvalidStateBanner';
 import { ResourceEditFormSharedFields } from '../Shared/ResourceEditFormSharedFields';
 import { getProvisionedRequestError } from '../utils/errors';
@@ -134,6 +135,7 @@ function FormContent({ initialValues, folder, repository, canPushToConfiguredBra
         resourceKind: 'folder',
         resourceID: folder.uid,
         title,
+        user: getCurrentCommitUser(),
       }),
       body: {
         spec: { title },

--- a/public/app/features/provisioning/utils/commitMessage.test.ts
+++ b/public/app/features/provisioning/utils/commitMessage.test.ts
@@ -1,6 +1,11 @@
 import { type RepositoryView } from 'app/api/clients/provisioning/v0alpha1';
 
-import { getSingleResourceCommitMessage, renderCommitMessage } from './commitMessage';
+import {
+  appendSavedByTrailer,
+  getSingleResourceCommitMessage,
+  renderCommitMessage,
+  type CommitUser,
+} from './commitMessage';
 
 const repoWithTemplate = (template: string | undefined): RepositoryView => ({
   name: 'r',
@@ -10,6 +15,8 @@ const repoWithTemplate = (template: string | undefined): RepositoryView => ({
   workflows: ['branch'],
   commit: template === undefined ? undefined : { singleResourceMessageTemplate: template },
 });
+
+const user: CommitUser = { name: 'Ada Lovelace', login: 'ada', email: 'ada@example.com' };
 
 describe('renderCommitMessage', () => {
   it('falls back to the legacy hardcoded default when template is empty', () => {
@@ -53,6 +60,29 @@ describe('renderCommitMessage', () => {
     ).toBe('feat(dashboards/abc-123): update Latency');
   });
 
+  it('interpolates {{userName}}, {{userLogin}}, {{userEmail}}', () => {
+    expect(
+      renderCommitMessage('{{action}} {{title}} by {{userName}} <{{userEmail}}> ({{userLogin}})', {
+        action: 'update',
+        resourceKind: 'dashboard',
+        resourceID: 'abc',
+        title: 'Latency',
+        user,
+      })
+    ).toBe('update Latency by Ada Lovelace <ada@example.com> (ada)');
+  });
+
+  it('replaces user vars with empty string when user is missing', () => {
+    expect(
+      renderCommitMessage('{{title}} - {{userName}}', {
+        action: 'update',
+        resourceKind: 'dashboard',
+        resourceID: 'abc',
+        title: 'A',
+      })
+    ).toBe('A - ');
+  });
+
   it('replaces every occurrence of a variable', () => {
     expect(
       renderCommitMessage('{{title}} / {{title}}', {
@@ -76,6 +106,40 @@ describe('renderCommitMessage', () => {
   });
 });
 
+describe('appendSavedByTrailer', () => {
+  it('appends a trailer with name and login', () => {
+    expect(appendSavedByTrailer('Save dashboard: Latency', user)).toBe(
+      'Save dashboard: Latency\n\nGrafana-saved-by: Ada Lovelace (ada)'
+    );
+  });
+
+  it('uses login alone when name is missing', () => {
+    expect(appendSavedByTrailer('msg', { login: 'ada' })).toBe('msg\n\nGrafana-saved-by: ada');
+  });
+
+  it('uses name alone when login is missing', () => {
+    expect(appendSavedByTrailer('msg', { name: 'Ada Lovelace' })).toBe('msg\n\nGrafana-saved-by: Ada Lovelace');
+  });
+
+  it('avoids duplicating the parens when name equals login', () => {
+    expect(appendSavedByTrailer('msg', { name: 'ada', login: 'ada' })).toBe('msg\n\nGrafana-saved-by: ada');
+  });
+
+  it('returns the message unchanged when user is undefined or empty', () => {
+    expect(appendSavedByTrailer('msg', undefined)).toBe('msg');
+    expect(appendSavedByTrailer('msg', { name: '   ', login: '' })).toBe('msg');
+  });
+
+  it('does not append a duplicate trailer if one is already present', () => {
+    const existing = 'Save dashboard: X\n\nGrafana-saved-by: someone';
+    expect(appendSavedByTrailer(existing, user)).toBe(existing);
+  });
+
+  it('trims trailing whitespace before appending', () => {
+    expect(appendSavedByTrailer('msg\n\n\n', user)).toBe('msg\n\nGrafana-saved-by: Ada Lovelace (ada)');
+  });
+});
+
 describe('getSingleResourceCommitMessage', () => {
   const baseVars = {
     action: 'update' as const,
@@ -84,14 +148,15 @@ describe('getSingleResourceCommitMessage', () => {
     title: 'Latency',
   };
 
-  it('uses a non-empty user comment verbatim', () => {
+  it('uses a non-empty user comment verbatim (plus trailer)', () => {
     expect(
       getSingleResourceCommitMessage({
         comment: 'My commit message',
         repository: repoWithTemplate('feat: {{title}}'),
         ...baseVars,
+        user,
       })
-    ).toBe('My commit message');
+    ).toBe('My commit message\n\nGrafana-saved-by: Ada Lovelace (ada)');
   });
 
   it('trims surrounding whitespace from the comment', () => {
@@ -133,5 +198,38 @@ describe('getSingleResourceCommitMessage', () => {
         action: 'create',
       })
     ).toBe('New dashboard: Latency');
+  });
+
+  it('appends the Grafana-saved-by trailer to the default message', () => {
+    expect(
+      getSingleResourceCommitMessage({
+        comment: undefined,
+        repository: undefined,
+        ...baseVars,
+        user,
+      })
+    ).toBe('Save dashboard: Latency\n\nGrafana-saved-by: Ada Lovelace (ada)');
+  });
+
+  it('appends the trailer to a template-rendered message', () => {
+    expect(
+      getSingleResourceCommitMessage({
+        comment: '',
+        repository: repoWithTemplate('feat: {{title}}'),
+        ...baseVars,
+        user,
+      })
+    ).toBe('feat: Latency\n\nGrafana-saved-by: Ada Lovelace (ada)');
+  });
+
+  it('does not duplicate the trailer when the template already includes it', () => {
+    expect(
+      getSingleResourceCommitMessage({
+        comment: '',
+        repository: repoWithTemplate('feat: {{title}}\n\nGrafana-saved-by: {{userName}}'),
+        ...baseVars,
+        user,
+      })
+    ).toBe('feat: Latency\n\nGrafana-saved-by: Ada Lovelace');
   });
 });

--- a/public/app/features/provisioning/utils/commitMessage.test.ts
+++ b/public/app/features/provisioning/utils/commitMessage.test.ts
@@ -89,6 +89,20 @@ describe('renderCommitMessage', () => {
     ).toBe('A / A');
   });
 
+  it('collapses newlines in {{userName}} / {{userLogin}} / {{userEmail}}', () => {
+    expect(
+      renderCommitMessage('feat: {{title}} by {{userName}} ({{userLogin}}) <{{userEmail}}>', {
+        action: 'update',
+        resourceKind: 'dashboard',
+        resourceID: 'abc',
+        title: 'Latency',
+        userName: 'Ada\nSigned-off-by: forge',
+        userLogin: 'ada\r\nGrafana-saved-by: forge',
+        userEmail: 'ada@example.com\nFoo: bar',
+      })
+    ).toBe('feat: Latency by Ada Signed-off-by: forge (ada Grafana-saved-by: forge) <ada@example.com Foo: bar>');
+  });
+
   it('leaves unknown placeholders untouched', () => {
     expect(
       renderCommitMessage('{{action}} {{author}}', {
@@ -132,6 +146,19 @@ describe('appendSavedByTrailer', () => {
 
   it('trims trailing whitespace before appending', () => {
     expect(appendSavedByTrailer('msg\n\n\n', userVars)).toBe('msg\n\nGrafana-saved-by: Ada Lovelace (ada)');
+  });
+
+  it('collapses newlines in user identity fields to prevent trailer injection', () => {
+    expect(
+      appendSavedByTrailer('Save dashboard: X', {
+        userName: 'Ada\nSigned-off-by: forge\n',
+        userLogin: 'ada\nGrafana-saved-by: someone-else',
+      })
+    ).toBe('Save dashboard: X\n\nGrafana-saved-by: Ada Signed-off-by: forge (ada Grafana-saved-by: someone-else)');
+  });
+
+  it('treats a name that is only line breaks as missing', () => {
+    expect(appendSavedByTrailer('msg', { userName: '\n\n', userLogin: 'ada' })).toBe('msg\n\nGrafana-saved-by: ada');
   });
 });
 

--- a/public/app/features/provisioning/utils/commitMessage.test.ts
+++ b/public/app/features/provisioning/utils/commitMessage.test.ts
@@ -1,11 +1,6 @@
 import { type RepositoryView } from 'app/api/clients/provisioning/v0alpha1';
 
-import {
-  appendSavedByTrailer,
-  getSingleResourceCommitMessage,
-  renderCommitMessage,
-  type CommitUser,
-} from './commitMessage';
+import { appendSavedByTrailer, getSingleResourceCommitMessage, renderCommitMessage } from './commitMessage';
 
 const repoWithTemplate = (template: string | undefined): RepositoryView => ({
   name: 'r',
@@ -16,7 +11,7 @@ const repoWithTemplate = (template: string | undefined): RepositoryView => ({
   commit: template === undefined ? undefined : { singleResourceMessageTemplate: template },
 });
 
-const user: CommitUser = { name: 'Ada Lovelace', login: 'ada', email: 'ada@example.com' };
+const userVars = { userName: 'Ada Lovelace', userLogin: 'ada', userEmail: 'ada@example.com' };
 
 describe('renderCommitMessage', () => {
   it('falls back to the legacy hardcoded default when template is empty', () => {
@@ -67,7 +62,7 @@ describe('renderCommitMessage', () => {
         resourceKind: 'dashboard',
         resourceID: 'abc',
         title: 'Latency',
-        user,
+        ...userVars,
       })
     ).toBe('update Latency by Ada Lovelace <ada@example.com> (ada)');
   });
@@ -108,35 +103,35 @@ describe('renderCommitMessage', () => {
 
 describe('appendSavedByTrailer', () => {
   it('appends a trailer with name and login', () => {
-    expect(appendSavedByTrailer('Save dashboard: Latency', user)).toBe(
+    expect(appendSavedByTrailer('Save dashboard: Latency', userVars)).toBe(
       'Save dashboard: Latency\n\nGrafana-saved-by: Ada Lovelace (ada)'
     );
   });
 
   it('uses login alone when name is missing', () => {
-    expect(appendSavedByTrailer('msg', { login: 'ada' })).toBe('msg\n\nGrafana-saved-by: ada');
+    expect(appendSavedByTrailer('msg', { userLogin: 'ada' })).toBe('msg\n\nGrafana-saved-by: ada');
   });
 
   it('uses name alone when login is missing', () => {
-    expect(appendSavedByTrailer('msg', { name: 'Ada Lovelace' })).toBe('msg\n\nGrafana-saved-by: Ada Lovelace');
+    expect(appendSavedByTrailer('msg', { userName: 'Ada Lovelace' })).toBe('msg\n\nGrafana-saved-by: Ada Lovelace');
   });
 
   it('avoids duplicating the parens when name equals login', () => {
-    expect(appendSavedByTrailer('msg', { name: 'ada', login: 'ada' })).toBe('msg\n\nGrafana-saved-by: ada');
+    expect(appendSavedByTrailer('msg', { userName: 'ada', userLogin: 'ada' })).toBe('msg\n\nGrafana-saved-by: ada');
   });
 
-  it('returns the message unchanged when user is undefined or empty', () => {
-    expect(appendSavedByTrailer('msg', undefined)).toBe('msg');
-    expect(appendSavedByTrailer('msg', { name: '   ', login: '' })).toBe('msg');
+  it('returns the message unchanged when there is no user info', () => {
+    expect(appendSavedByTrailer('msg', {})).toBe('msg');
+    expect(appendSavedByTrailer('msg', { userName: '   ', userLogin: '' })).toBe('msg');
   });
 
   it('does not append a duplicate trailer if one is already present', () => {
     const existing = 'Save dashboard: X\n\nGrafana-saved-by: someone';
-    expect(appendSavedByTrailer(existing, user)).toBe(existing);
+    expect(appendSavedByTrailer(existing, userVars)).toBe(existing);
   });
 
   it('trims trailing whitespace before appending', () => {
-    expect(appendSavedByTrailer('msg\n\n\n', user)).toBe('msg\n\nGrafana-saved-by: Ada Lovelace (ada)');
+    expect(appendSavedByTrailer('msg\n\n\n', userVars)).toBe('msg\n\nGrafana-saved-by: Ada Lovelace (ada)');
   });
 });
 
@@ -154,7 +149,7 @@ describe('getSingleResourceCommitMessage', () => {
         comment: 'My commit message',
         repository: repoWithTemplate('feat: {{title}}'),
         ...baseVars,
-        user,
+        ...userVars,
       })
     ).toBe('My commit message\n\nGrafana-saved-by: Ada Lovelace (ada)');
   });
@@ -206,7 +201,7 @@ describe('getSingleResourceCommitMessage', () => {
         comment: undefined,
         repository: undefined,
         ...baseVars,
-        user,
+        ...userVars,
       })
     ).toBe('Save dashboard: Latency\n\nGrafana-saved-by: Ada Lovelace (ada)');
   });
@@ -217,7 +212,7 @@ describe('getSingleResourceCommitMessage', () => {
         comment: '',
         repository: repoWithTemplate('feat: {{title}}'),
         ...baseVars,
-        user,
+        ...userVars,
       })
     ).toBe('feat: Latency\n\nGrafana-saved-by: Ada Lovelace (ada)');
   });
@@ -228,7 +223,7 @@ describe('getSingleResourceCommitMessage', () => {
         comment: '',
         repository: repoWithTemplate('feat: {{title}}\n\nGrafana-saved-by: {{userName}}'),
         ...baseVars,
-        user,
+        ...userVars,
       })
     ).toBe('feat: Latency\n\nGrafana-saved-by: Ada Lovelace');
   });

--- a/public/app/features/provisioning/utils/commitMessage.ts
+++ b/public/app/features/provisioning/utils/commitMessage.ts
@@ -5,14 +5,26 @@ export type CommitAction = 'create' | 'update' | 'delete' | 'move' | 'rename';
 export type CommitResourceKind = 'dashboard' | 'folder';
 export type CommitResourceID = string;
 
+export interface CommitUser {
+  name?: string;
+  login?: string;
+  email?: string;
+}
+
 export interface CommitTemplateVars {
   action: CommitAction;
   resourceKind: CommitResourceKind;
   resourceID: CommitResourceID;
   title: string;
+  user?: CommitUser;
 }
 
-const TEMPLATE_VAR = /\{\{(action|resourceKind|resourceID|title)\}\}/g;
+const TEMPLATE_VAR = /\{\{(action|resourceKind|resourceID|title|userName|userLogin|userEmail)\}\}/g;
+
+const TRAILER_KEY = 'Grafana-saved-by';
+// Match the trailer at the start of any line, case-insensitively, so a custom
+// comment/template that already provides one isn't duplicated.
+const TRAILER_PRESENT = new RegExp(`^${TRAILER_KEY}:`, 'im');
 
 function defaultMessage({ action, resourceKind, title }: CommitTemplateVars): string {
   // Full Record forces every (resourceKind, action) pair to be mapped, so any
@@ -42,12 +54,74 @@ function defaultMessage({ action, resourceKind, title }: CommitTemplateVars): st
   return defaults[`${resourceKind}:${action}`];
 }
 
+function interpolate(template: string, vars: CommitTemplateVars): string {
+  return template.replace(TEMPLATE_VAR, (_, key: string) => {
+    switch (key) {
+      case 'action':
+        return vars.action;
+      case 'resourceKind':
+        return vars.resourceKind;
+      case 'resourceID':
+        return vars.resourceID;
+      case 'title':
+        return vars.title;
+      case 'userName':
+        return vars.user?.name ?? '';
+      case 'userLogin':
+        return vars.user?.login ?? '';
+      case 'userEmail':
+        return vars.user?.email ?? '';
+      default:
+        return `{{${key}}}`;
+    }
+  });
+}
+
 export function renderCommitMessage(template: string | undefined | null, vars: CommitTemplateVars): string {
   const trimmed = template?.trim();
   if (!trimmed) {
     return defaultMessage(vars);
   }
-  return trimmed.replace(TEMPLATE_VAR, (_, key: keyof CommitTemplateVars) => vars[key]);
+  return interpolate(trimmed, vars);
+}
+
+/**
+ * Builds the `Grafana-saved-by: ...` git trailer for the supplied user, or
+ * undefined if there isn't enough info to identify the user. We prefer the
+ * full name when available and append the login in parentheses so the trailer
+ * remains greppable even if the display name is empty or duplicated.
+ */
+function buildSavedByTrailer(user: CommitUser | undefined): string | undefined {
+  const name = user?.name?.trim();
+  const login = user?.login?.trim();
+  if (!name && !login) {
+    return undefined;
+  }
+  if (name && login && name !== login) {
+    return `${TRAILER_KEY}: ${name} (${login})`;
+  }
+  return `${TRAILER_KEY}: ${name || login}`;
+}
+
+/**
+ * Appends the `Grafana-saved-by:` git trailer to a commit message. Skips when
+ * the message already contains a trailer (so templates / user comments that
+ * spell it out themselves don't end up with a duplicate).
+ */
+export function appendSavedByTrailer(message: string, user: CommitUser | undefined): string {
+  const trailer = buildSavedByTrailer(user);
+  if (!trailer) {
+    return message;
+  }
+  if (TRAILER_PRESENT.test(message)) {
+    return message;
+  }
+  const trimmed = message.replace(/\s+$/, '');
+  if (!trimmed) {
+    return trailer;
+  }
+  // Git trailers live in a separate paragraph at the end of the message.
+  return `${trimmed}\n\n${trailer}`;
 }
 
 interface SingleResourceCommitMessageArgs extends CommitTemplateVars {
@@ -59,6 +133,8 @@ interface SingleResourceCommitMessageArgs extends CommitTemplateVars {
  * Resolves the commit message for a single-resource UI operation. Whitespace-
  * only comments are treated as empty and fall through to the repo template
  * (or built-in default), so the user can't accidentally ship blank commits.
+ * The `Grafana-saved-by:` trailer is appended in all three paths so the
+ * Grafana user who triggered the commit is always recorded in git history.
  */
 export function getSingleResourceCommitMessage({
   comment,
@@ -66,8 +142,6 @@ export function getSingleResourceCommitMessage({
   ...vars
 }: SingleResourceCommitMessageArgs): string {
   const trimmed = comment?.trim();
-  if (trimmed) {
-    return trimmed;
-  }
-  return renderCommitMessage(repository?.commit?.singleResourceMessageTemplate, vars);
+  const base = trimmed ? trimmed : renderCommitMessage(repository?.commit?.singleResourceMessageTemplate, vars);
+  return appendSavedByTrailer(base, vars.user);
 }

--- a/public/app/features/provisioning/utils/commitMessage.ts
+++ b/public/app/features/provisioning/utils/commitMessage.ts
@@ -5,20 +5,17 @@ export type CommitAction = 'create' | 'update' | 'delete' | 'move' | 'rename';
 export type CommitResourceKind = 'dashboard' | 'folder';
 export type CommitResourceID = string;
 
-export interface CommitUser {
-  name?: string;
-  login?: string;
-  email?: string;
-}
-
 export interface CommitTemplateVars {
   action: CommitAction;
   resourceKind: CommitResourceKind;
   resourceID: CommitResourceID;
   title: string;
-  user?: CommitUser;
+  userName?: string;
+  userLogin?: string;
+  userEmail?: string;
 }
 
+type TemplateKey = keyof CommitTemplateVars;
 const TEMPLATE_VAR = /\{\{(action|resourceKind|resourceID|title|userName|userLogin|userEmail)\}\}/g;
 
 const TRAILER_KEY = 'Grafana-saved-by';
@@ -54,36 +51,15 @@ function defaultMessage({ action, resourceKind, title }: CommitTemplateVars): st
   return defaults[`${resourceKind}:${action}`];
 }
 
-function interpolate(template: string, vars: CommitTemplateVars): string {
-  return template.replace(TEMPLATE_VAR, (_, key: string) => {
-    switch (key) {
-      case 'action':
-        return vars.action;
-      case 'resourceKind':
-        return vars.resourceKind;
-      case 'resourceID':
-        return vars.resourceID;
-      case 'title':
-        return vars.title;
-      case 'userName':
-        return vars.user?.name ?? '';
-      case 'userLogin':
-        return vars.user?.login ?? '';
-      case 'userEmail':
-        return vars.user?.email ?? '';
-      default:
-        return `{{${key}}}`;
-    }
-  });
-}
-
 export function renderCommitMessage(template: string | undefined | null, vars: CommitTemplateVars): string {
   const trimmed = template?.trim();
   if (!trimmed) {
     return defaultMessage(vars);
   }
-  return interpolate(trimmed, vars);
+  return trimmed.replace(TEMPLATE_VAR, (_, key: TemplateKey) => vars[key] ?? '');
 }
+
+type SavedByVars = Pick<CommitTemplateVars, 'userName' | 'userLogin'>;
 
 /**
  * Builds the `Grafana-saved-by: ...` git trailer for the supplied user, or
@@ -91,9 +67,9 @@ export function renderCommitMessage(template: string | undefined | null, vars: C
  * full name when available and append the login in parentheses so the trailer
  * remains greppable even if the display name is empty or duplicated.
  */
-function buildSavedByTrailer(user: CommitUser | undefined): string | undefined {
-  const name = user?.name?.trim();
-  const login = user?.login?.trim();
+function buildSavedByTrailer({ userName, userLogin }: SavedByVars): string | undefined {
+  const name = userName?.trim();
+  const login = userLogin?.trim();
   if (!name && !login) {
     return undefined;
   }
@@ -108,8 +84,8 @@ function buildSavedByTrailer(user: CommitUser | undefined): string | undefined {
  * the message already contains a trailer (so templates / user comments that
  * spell it out themselves don't end up with a duplicate).
  */
-export function appendSavedByTrailer(message: string, user: CommitUser | undefined): string {
-  const trailer = buildSavedByTrailer(user);
+export function appendSavedByTrailer(message: string, vars: SavedByVars): string {
+  const trailer = buildSavedByTrailer(vars);
   if (!trailer) {
     return message;
   }
@@ -143,5 +119,5 @@ export function getSingleResourceCommitMessage({
 }: SingleResourceCommitMessageArgs): string {
   const trimmed = comment?.trim();
   const base = trimmed ? trimmed : renderCommitMessage(repository?.commit?.singleResourceMessageTemplate, vars);
-  return appendSavedByTrailer(base, vars.user);
+  return appendSavedByTrailer(base, vars);
 }

--- a/public/app/features/provisioning/utils/commitMessage.ts
+++ b/public/app/features/provisioning/utils/commitMessage.ts
@@ -17,11 +17,23 @@ export interface CommitTemplateVars {
 
 type TemplateKey = keyof CommitTemplateVars;
 const TEMPLATE_VAR = /\{\{(action|resourceKind|resourceID|title|userName|userLogin|userEmail)\}\}/g;
+const IDENTITY_KEYS: ReadonlySet<TemplateKey> = new Set(['userName', 'userLogin', 'userEmail']);
 
 const TRAILER_KEY = 'Grafana-saved-by';
 // Match the trailer at the start of any line, case-insensitively, so a custom
 // comment/template that already provides one isn't duplicated.
 const TRAILER_PRESENT = new RegExp(`^${TRAILER_KEY}:`, 'im');
+
+/**
+ * Collapses any newline/CR into a single space and trims. Used on the
+ * user-controlled identity fields (`name`, `login`, `email` come from
+ * `UpdateUserCommand` which doesn't strip line breaks) so a profile value
+ * like `"Ada\nGrafana-saved-by: forge"` can't inject forged git trailers
+ * into the commit message.
+ */
+function sanitizeLine(value: string | undefined): string {
+  return (value ?? '').replace(/[\r\n]+/g, ' ').trim();
+}
 
 function defaultMessage({ action, resourceKind, title }: CommitTemplateVars): string {
   // Full Record forces every (resourceKind, action) pair to be mapped, so any
@@ -56,7 +68,10 @@ export function renderCommitMessage(template: string | undefined | null, vars: C
   if (!trimmed) {
     return defaultMessage(vars);
   }
-  return trimmed.replace(TEMPLATE_VAR, (_, key: TemplateKey) => vars[key] ?? '');
+  return trimmed.replace(TEMPLATE_VAR, (_, key: TemplateKey) => {
+    const raw = vars[key] ?? '';
+    return IDENTITY_KEYS.has(key) ? sanitizeLine(raw) : raw;
+  });
 }
 
 type SavedByVars = Pick<CommitTemplateVars, 'userName' | 'userLogin'>;
@@ -68,8 +83,8 @@ type SavedByVars = Pick<CommitTemplateVars, 'userName' | 'userLogin'>;
  * remains greppable even if the display name is empty or duplicated.
  */
 function buildSavedByTrailer({ userName, userLogin }: SavedByVars): string | undefined {
-  const name = userName?.trim();
-  const login = userLogin?.trim();
+  const name = sanitizeLine(userName);
+  const login = sanitizeLine(userLogin);
   if (!name && !login) {
     return undefined;
   }

--- a/public/app/features/provisioning/utils/commitMessage.ts
+++ b/public/app/features/provisioning/utils/commitMessage.ts
@@ -15,9 +15,22 @@ export interface CommitTemplateVars {
   userEmail?: string;
 }
 
-type TemplateKey = keyof CommitTemplateVars;
-const TEMPLATE_VAR = /\{\{(action|resourceKind|resourceID|title|userName|userLogin|userEmail)\}\}/g;
-const IDENTITY_KEYS: ReadonlySet<TemplateKey> = new Set(['userName', 'userLogin', 'userEmail']);
+// Single source of truth for the keys the template understands. The regex,
+// the IDENTITY_KEYS set, and the TemplateKey type are all derived from these
+// arrays — adding/removing a key here is enough to keep them in sync.
+const IDENTITY_KEYS = ['userName', 'userLogin', 'userEmail'] as const satisfies ReadonlyArray<keyof CommitTemplateVars>;
+const TEMPLATE_KEYS = [
+  'action',
+  'resourceKind',
+  'resourceID',
+  'title',
+  ...IDENTITY_KEYS,
+] as const satisfies ReadonlyArray<keyof CommitTemplateVars>;
+
+type TemplateKey = (typeof TEMPLATE_KEYS)[number];
+
+const TEMPLATE_VAR = new RegExp(`\\{\\{(${TEMPLATE_KEYS.join('|')})\\}\\}`, 'g');
+const IDENTITY_KEY_SET: ReadonlySet<TemplateKey> = new Set(IDENTITY_KEYS);
 
 const TRAILER_KEY = 'Grafana-saved-by';
 // Match the trailer at the start of any line, case-insensitively, so a custom
@@ -70,7 +83,7 @@ export function renderCommitMessage(template: string | undefined | null, vars: C
   }
   return trimmed.replace(TEMPLATE_VAR, (_, key: TemplateKey) => {
     const raw = vars[key] ?? '';
-    return IDENTITY_KEYS.has(key) ? sanitizeLine(raw) : raw;
+    return IDENTITY_KEY_SET.has(key) ? sanitizeLine(raw) : raw;
   });
 }
 

--- a/public/app/features/provisioning/utils/currentUser.ts
+++ b/public/app/features/provisioning/utils/currentUser.ts
@@ -1,21 +1,24 @@
 import { contextSrv } from 'app/core/services/context_srv';
 
-import { type CommitUser } from './commitMessage';
+import { type CommitTemplateVars } from './commitMessage';
 
 /**
- * Snapshot of the currently signed-in Grafana user, shaped for use as
- * commit-message template vars and the `Grafana-saved-by:` trailer.
- * Returns undefined when nobody is signed in (which shouldn't happen in
- * the UI flows that call this, but keeps the helper safe to use anywhere).
+ * Snapshot of the currently signed-in Grafana user, shaped to spread into
+ * `CommitTemplateVars` so it both populates `{{userName}}` / `{{userLogin}}` /
+ * `{{userEmail}}` template placeholders and feeds the `Grafana-saved-by:`
+ * trailer. Returns undefined when nobody is signed in, in which case spreading
+ * is a no-op.
  */
-export function getCurrentCommitUser(): CommitUser | undefined {
+export function getCurrentCommitUser():
+  | Pick<CommitTemplateVars, 'userName' | 'userLogin' | 'userEmail'>
+  | undefined {
   const u = contextSrv.user;
   if (!u?.isSignedIn) {
     return undefined;
   }
   return {
-    name: u.name,
-    login: u.login,
-    email: u.email,
+    userName: u.name,
+    userLogin: u.login,
+    userEmail: u.email,
   };
 }

--- a/public/app/features/provisioning/utils/currentUser.ts
+++ b/public/app/features/provisioning/utils/currentUser.ts
@@ -1,0 +1,21 @@
+import { contextSrv } from 'app/core/services/context_srv';
+
+import { type CommitUser } from './commitMessage';
+
+/**
+ * Snapshot of the currently signed-in Grafana user, shaped for use as
+ * commit-message template vars and the `Grafana-saved-by:` trailer.
+ * Returns undefined when nobody is signed in (which shouldn't happen in
+ * the UI flows that call this, but keeps the helper safe to use anywhere).
+ */
+export function getCurrentCommitUser(): CommitUser | undefined {
+  const u = contextSrv.user;
+  if (!u?.isSignedIn) {
+    return undefined;
+  }
+  return {
+    name: u.name,
+    login: u.login,
+    email: u.email,
+  };
+}

--- a/public/app/features/provisioning/utils/currentUser.ts
+++ b/public/app/features/provisioning/utils/currentUser.ts
@@ -1,6 +1,6 @@
 import { contextSrv } from 'app/core/services/context_srv';
 
-import { type CommitTemplateVars } from './commitMessage';
+import { appendSavedByTrailer, type CommitTemplateVars } from './commitMessage';
 
 /**
  * Snapshot of the currently signed-in Grafana user, shaped to spread into
@@ -9,9 +9,7 @@ import { type CommitTemplateVars } from './commitMessage';
  * trailer. Returns undefined when nobody is signed in, in which case spreading
  * is a no-op.
  */
-export function getCurrentCommitUser():
-  | Pick<CommitTemplateVars, 'userName' | 'userLogin' | 'userEmail'>
-  | undefined {
+export function getCurrentCommitUser(): Pick<CommitTemplateVars, 'userName' | 'userLogin' | 'userEmail'> | undefined {
   const u = contextSrv.user;
   if (!u?.isSignedIn) {
     return undefined;
@@ -21,4 +19,13 @@ export function getCurrentCommitUser():
     userLogin: u.login,
     userEmail: u.email,
   };
+}
+
+/**
+ * Convenience wrapper for non-single-resource code paths (job specs like
+ * migrate / export) that just need to tag the commit message with the
+ * Grafana-saved-by trailer. No-op when the user isn't signed in.
+ */
+export function withSavedByTrailer(message: string): string {
+  return appendSavedByTrailer(message, getCurrentCommitUser() ?? {});
 }

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13887,7 +13887,8 @@
     "sync-job": {
       "error-no-job-id": "Failed to start job",
       "error-no-repository-name": "No repository name provided",
-      "error-starting-job": "Error starting job"
+      "error-starting-job": "Error starting job",
+      "migrate-default-message": "Migrate Grafana resources into repository"
     },
     "sync-repository": {
       "error-pulling-resources": "Error pulling resources",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13296,7 +13296,7 @@
       "alert-repository-settings-updated": "Repository settings updated",
       "button-save": "Save",
       "button-saving": "Saving...",
-      "description-commit-message-template": "Default commit message when saving a provisioned resource. Available placeholders: {{actionVar}} (create/update/delete/move/rename), {{kindVar}} (dashboard/folder), {{idVar}}, {{titleVar}}. Leave empty to use the built-in defaults.",
+      "description-commit-message-template": "Default commit message when saving a provisioned resource. Available placeholders: {{actionVar}} (create/update/delete/move/rename), {{kindVar}} (dashboard/folder), {{idVar}}, {{titleVar}}, {{userNameVar}}, {{userLoginVar}}, {{userEmailVar}}. A \"Grafana-saved-by: <name> (<login>)\" trailer is appended automatically. Leave empty to use the built-in defaults.",
       "description-connection": "Select the GitHub App connection to use",
       "description-enabled": "Once automatic pulling is enabled, the target cannot be changed.",
       "description-read-only": "Resources can't be modified through Grafana.",


### PR DESCRIPTION
## Summary

Part of #124191.

When the Git Sync feature commits a single-resource change (dashboard save/delete/move, folder create/rename/delete) the resulting git commit currently reads as the shared bot account from the access token. There is no record of *which* Grafana user actually pressed Save.

This PR adds a git-style `Grafana-saved-by: <name> (<login>)` trailer to every commit message the frontend can carry that info through today, and exposes user info as template placeholders for repositories using the per-repo `commit.singleResourceMessageTemplate` introduced in #123167.

Example default commit body now:

```
Save dashboard: Latency

Grafana-saved-by: Ada Lovelace (ada)
```

<img width="1645" height="228" alt="Screenshot 2026-05-28 at 11 14 51" src="https://github.com/user-attachments/assets/6f7d327a-1cb8-46c8-b3da-b20a928b1720" />


## What's covered

- Single-resource ops: dashboard **save / delete / move**, folder **create / rename / delete**
- **Migrate** wizard job (its `MigrateJobOptions` spec already carries a `message` field)

## Not covered (backend gap → tracked internally in grafana/git-ui-sync-project#1162)

Bulk delete, bulk move, fix-folder-metadata, and pull/sync jobs have no `message` field on their backend job options today, so the trailer cannot ride through. Each site has an inline `TODO` comment describing the missing option. Once the backend adds those fields, each site becomes a one-liner `withSavedByTrailer(...)` call.

## Changes

- `utils/commitMessage.ts`
  - Template renderer now interpolates `{{userName}}`, `{{userLogin}}`, `{{userEmail}}`.
  - New `appendSavedByTrailer()` appends the trailer to the final commit message. Applied in all three single-resource paths (user comment / per-repo template / built-in default). De-duplicates when a trailer is already present (e.g. when the template spells one out explicitly).
- `utils/currentUser.ts` (new)
  - `getCurrentCommitUser()` snapshots `name` / `login` / `email` from `contextSrv.user`. Spreads directly into `CommitTemplateVars`.
  - `withSavedByTrailer(message)` — convenience wrapper for non-single-resource job sites.
- Six single-resource submit sites now spread `getCurrentCommitUser()` into `getSingleResourceCommitMessage`:
  - `SaveProvisionedDashboardForm`, `DeleteProvisionedDashboardForm`, `MoveProvisionedDashboardForm`
  - `NewProvisionedFolderForm`, `RenameProvisionedFolderForm`, `DeleteProvisionedFolderForm`
- `Wizard/hooks/useCreateSyncJob.ts` — migrate jobs now send a default message + trailer.
- `Config/CommitMessageTemplateField.tsx` + `en-US/grafana.json` — documents the three new placeholders and the auto-appended trailer; new `provisioning.sync-job.migrate-default-message` string.

## Testing

- [x] `yarn jest public/app/features/provisioning` — 58 suites / 834 tests pass
- [x] `yarn typecheck` — clean
- [x] ESLint clean on touched files
- [x] Prettier clean on touched files
- [ ] Manual smoke: set a template containing `{{userName}}` on a repo, save a dashboard signed in as a real user, confirm the commit on the remote shows both the rendered template *and* the `Grafana-saved-by:` trailer.

## Notes

- Existing form tests don't sign a user in, so `contextSrv.user.isSignedIn` is `false` and the trailer is not appended — that's why they continue to pass without modification. The new behaviour is exercised in `commitMessage.test.ts` instead.
- The trailer follows the `git interpret-trailers` convention (`Key: value` paragraph at the end), matching `Co-Authored-By:` / `Signed-off-by:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)