### PR TITLE
unified-storage: validate request key consistently in resource server

### DIFF
--- a/pkg/storage/unified/resource/list_with_field_selectors_test.go
+++ b/pkg/storage/unified/resource/list_with_field_selectors_test.go
@@ -28,7 +28,7 @@ func TestUseFieldSelectorSearch(t *testing.T) {
 			req: &resourcepb.ListRequest{
 				Source: resourcepb.ListRequest_STORE,
 				Options: &resourcepb.ListOptions{
-					Key:    &resourcepb.ResourceKey{Namespace: "ns"},
+					Key:    &resourcepb.ResourceKey{Namespace: "nsx"},
 					Fields: []*resourcepb.Requirement{{Key: "spec.foo"}},
 				},
 			},
@@ -38,7 +38,7 @@ func TestUseFieldSelectorSearch(t *testing.T) {
 			req: &resourcepb.ListRequest{
 				Source: resourcepb.ListRequest_HISTORY,
 				Options: &resourcepb.ListOptions{
-					Key:    &resourcepb.ResourceKey{Namespace: "ns"},
+					Key:    &resourcepb.ResourceKey{Namespace: "nsx"},
 					Fields: []*resourcepb.Requirement{{Key: "spec.foo"}},
 				},
 			},
@@ -48,7 +48,7 @@ func TestUseFieldSelectorSearch(t *testing.T) {
 			req: &resourcepb.ListRequest{
 				Source: resourcepb.ListRequest_STORE,
 				Options: &resourcepb.ListOptions{
-					Key: &resourcepb.ResourceKey{Namespace: "ns"},
+					Key: &resourcepb.ResourceKey{Namespace: "nsx"},
 				},
 			},
 			expectedAllowed: false,
@@ -58,7 +58,7 @@ func TestUseFieldSelectorSearch(t *testing.T) {
 				Source:         resourcepb.ListRequest_STORE,
 				VersionMatchV2: resourcepb.ResourceVersionMatchV2_Exact,
 				Options: &resourcepb.ListOptions{
-					Key:    &resourcepb.ResourceKey{Namespace: "ns"},
+					Key:    &resourcepb.ResourceKey{Namespace: "nsx"},
 					Fields: []*resourcepb.Requirement{{Key: "spec.foo"}},
 				},
 			},
@@ -69,7 +69,7 @@ func TestUseFieldSelectorSearch(t *testing.T) {
 				Source:         resourcepb.ListRequest_STORE,
 				VersionMatchV2: resourcepb.ResourceVersionMatchV2_NotOlderThan,
 				Options: &resourcepb.ListOptions{
-					Key:    &resourcepb.ResourceKey{Namespace: "ns"},
+					Key:    &resourcepb.ResourceKey{Namespace: "nsx"},
 					Fields: []*resourcepb.Requirement{{Key: "spec.foo"}},
 				},
 			},
@@ -79,7 +79,7 @@ func TestUseFieldSelectorSearch(t *testing.T) {
 			req: &resourcepb.ListRequest{
 				Source: resourcepb.ListRequest_STORE,
 				Options: &resourcepb.ListOptions{
-					Key:    &resourcepb.ResourceKey{Namespace: "ns", Group: "advisor.grafana.app"},
+					Key:    &resourcepb.ResourceKey{Namespace: "nsx", Group: "advisor.grafana.app"},
 					Fields: []*resourcepb.Requirement{{Key: "spec.foo"}},
 				},
 			},
@@ -89,7 +89,7 @@ func TestUseFieldSelectorSearch(t *testing.T) {
 			req: &resourcepb.ListRequest{
 				Source: resourcepb.ListRequest_STORE,
 				Options: &resourcepb.ListOptions{
-					Key:    &resourcepb.ResourceKey{Namespace: "ns", Group: "provisioning.grafana.app"},
+					Key:    &resourcepb.ResourceKey{Namespace: "nsx", Group: "provisioning.grafana.app"},
 					Fields: []*resourcepb.Requirement{{Key: "spec.foo"}},
 				},
 			},
@@ -117,7 +117,7 @@ func TestFilterFieldSelectors(t *testing.T) {
 		"removes metadata.namespace and keep valid field": {
 			req: &resourcepb.ListRequest{
 				Options: &resourcepb.ListOptions{
-					Key: &resourcepb.ResourceKey{Namespace: "ns"},
+					Key: &resourcepb.ResourceKey{Namespace: "nsx"},
 					Fields: []*resourcepb.Requirement{
 						{Key: "metadata.namespace", Operator: "=", Values: []string{"ns"}},
 						{Key: "spec.foo", Operator: "="},
@@ -129,7 +129,7 @@ func TestFilterFieldSelectors(t *testing.T) {
 		"removes multiple unsupported fields": {
 			req: &resourcepb.ListRequest{
 				Options: &resourcepb.ListOptions{
-					Key: &resourcepb.ResourceKey{Namespace: "ns"},
+					Key: &resourcepb.ResourceKey{Namespace: "nsx"},
 					Fields: []*resourcepb.Requirement{
 						{Key: "metadata.namespace", Operator: "=", Values: []string{"ns", "other"}},
 						{Key: "spec.foo", Operator: "!="},
@@ -164,7 +164,7 @@ func TestListWithFieldSelectors(t *testing.T) {
 				Results: &resourcepb.ResourceTable{
 					Rows: []*resourcepb.ResourceTableRow{
 						{
-							Key:             &resourcepb.ResourceKey{Namespace: "ns", Group: "g", Resource: "r", Name: "a"},
+							Key:             &resourcepb.ResourceKey{Namespace: "nsx", Group: "grp", Resource: "res", Name: "a"},
 							ResourceVersion: 1,
 							SortFields:      []string{"s1"},
 						},
@@ -176,7 +176,7 @@ func TestListWithFieldSelectors(t *testing.T) {
 		req := &resourcepb.ListRequest{
 			Limit: 10,
 			Options: &resourcepb.ListOptions{
-				Key:    &resourcepb.ResourceKey{Namespace: "ns"},
+				Key:    &resourcepb.ResourceKey{Namespace: "nsx"},
 				Fields: []*resourcepb.Requirement{{Key: "spec.foo"}},
 			},
 		}
@@ -197,12 +197,12 @@ func TestListWithFieldSelectors(t *testing.T) {
 				Results: &resourcepb.ResourceTable{
 					Rows: []*resourcepb.ResourceTableRow{
 						{
-							Key:             &resourcepb.ResourceKey{Namespace: "ns", Group: "g", Resource: "r", Name: "a"},
+							Key:             &resourcepb.ResourceKey{Namespace: "nsx", Group: "grp", Resource: "res", Name: "a"},
 							ResourceVersion: 1,
 							SortFields:      []string{"s1"},
 						},
 						{
-							Key:             &resourcepb.ResourceKey{Namespace: "ns", Group: "g", Resource: "r", Name: "b"},
+							Key:             &resourcepb.ResourceKey{Namespace: "nsx", Group: "grp", Resource: "res", Name: "b"},
 							ResourceVersion: 2,
 							SortFields:      []string{"s2"},
 						},
@@ -222,7 +222,7 @@ func TestListWithFieldSelectors(t *testing.T) {
 		req := &resourcepb.ListRequest{
 			Limit: 10,
 			Options: &resourcepb.ListOptions{
-				Key:    &resourcepb.ResourceKey{Namespace: "ns"},
+				Key:    &resourcepb.ResourceKey{Namespace: "nsx"},
 				Fields: []*resourcepb.Requirement{{Key: "spec.foo"}},
 			},
 		}
@@ -242,12 +242,12 @@ func TestListWithFieldSelectors(t *testing.T) {
 				Results: &resourcepb.ResourceTable{
 					Rows: []*resourcepb.ResourceTableRow{
 						{
-							Key:             &resourcepb.ResourceKey{Namespace: "ns", Group: "g", Resource: "r", Name: "a"},
+							Key:             &resourcepb.ResourceKey{Namespace: "nsx", Group: "grp", Resource: "res", Name: "a"},
 							ResourceVersion: 1,
 							SortFields:      []string{"s1"},
 						},
 						{
-							Key:             &resourcepb.ResourceKey{Namespace: "ns", Group: "g", Resource: "r", Name: "b"},
+							Key:             &resourcepb.ResourceKey{Namespace: "nsx", Group: "grp", Resource: "res", Name: "b"},
 							ResourceVersion: 2,
 							SortFields:      []string{"s2"},
 						},
@@ -259,7 +259,7 @@ func TestListWithFieldSelectors(t *testing.T) {
 		req := &resourcepb.ListRequest{
 			Limit: 1,
 			Options: &resourcepb.ListOptions{
-				Key:    &resourcepb.ResourceKey{Namespace: "ns"},
+				Key:    &resourcepb.ResourceKey{Namespace: "nsx"},
 				Fields: []*resourcepb.Requirement{{Key: "spec.foo"}},
 			},
 		}
@@ -288,12 +288,12 @@ func TestListWithFieldSelectors(t *testing.T) {
 				Results: &resourcepb.ResourceTable{
 					Rows: []*resourcepb.ResourceTableRow{
 						{
-							Key:             &resourcepb.ResourceKey{Namespace: "ns", Group: "g", Resource: "r", Name: "b"},
+							Key:             &resourcepb.ResourceKey{Namespace: "nsx", Group: "grp", Resource: "res", Name: "b"},
 							ResourceVersion: 2,
 							SortFields:      []string{"s2"},
 						},
 						{
-							Key:             &resourcepb.ResourceKey{Namespace: "ns", Group: "g", Resource: "r", Name: "c"},
+							Key:             &resourcepb.ResourceKey{Namespace: "nsx", Group: "grp", Resource: "res", Name: "c"},
 							ResourceVersion: 2,
 							SortFields:      []string{"s3"},
 						},
@@ -306,7 +306,7 @@ func TestListWithFieldSelectors(t *testing.T) {
 			Limit:         1,
 			NextPageToken: continueToken,
 			Options: &resourcepb.ListOptions{
-				Key:    &resourcepb.ResourceKey{Namespace: "ns"},
+				Key:    &resourcepb.ResourceKey{Namespace: "nsx"},
 				Fields: []*resourcepb.Requirement{{Key: "spec.foo"}},
 			},
 		}
@@ -339,12 +339,12 @@ func TestListWithFieldSelectors(t *testing.T) {
 				Results: &resourcepb.ResourceTable{
 					Rows: []*resourcepb.ResourceTableRow{
 						{
-							Key:             &resourcepb.ResourceKey{Namespace: "ns", Group: "g", Resource: "r", Name: "a"},
+							Key:             &resourcepb.ResourceKey{Namespace: "nsx", Group: "grp", Resource: "res", Name: "a"},
 							ResourceVersion: 1,
 							SortFields:      []string{"s1"},
 						},
 						{
-							Key:             &resourcepb.ResourceKey{Namespace: "ns", Group: "g", Resource: "r", Name: "b"},
+							Key:             &resourcepb.ResourceKey{Namespace: "nsx", Group: "grp", Resource: "res", Name: "b"},
 							ResourceVersion: 2,
 							SortFields:      []string{"s2"},
 						},
@@ -356,7 +356,7 @@ func TestListWithFieldSelectors(t *testing.T) {
 		req := &resourcepb.ListRequest{
 			Limit: 10,
 			Options: &resourcepb.ListOptions{
-				Key:    &resourcepb.ResourceKey{Namespace: "ns"},
+				Key:    &resourcepb.ResourceKey{Namespace: "nsx"},
 				Fields: []*resourcepb.Requirement{{Key: "spec.foo"}},
 			},
 		}

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -984,7 +984,7 @@ func (s *server) Create(ctx context.Context, req *resourcepb.CreateRequest) (*re
 	defer s.inflight.Done()
 
 	if r := verifyRequestKey(req.Key); r != nil {
-		return nil, fmt.Errorf("invalid request key: %s", r.Message)
+		return nil, status.Error(codes.InvalidArgument, r.Message)
 	}
 
 	rsp := &resourcepb.CreateResponse{}
@@ -1108,6 +1108,10 @@ func (s *server) Update(ctx context.Context, req *resourcepb.UpdateRequest) (*re
 	}
 	defer s.inflight.Done()
 
+	if r := verifyRequestKey(req.Key); r != nil {
+		return nil, status.Error(codes.InvalidArgument, r.Message)
+	}
+
 	rsp := &resourcepb.UpdateResponse{}
 	user, ok := claims.AuthInfoFrom(ctx)
 	if !ok || user == nil {
@@ -1200,6 +1204,10 @@ func (s *server) Delete(ctx context.Context, req *resourcepb.DeleteRequest) (*re
 		return nil, errStopping
 	}
 	defer s.inflight.Done()
+
+	if r := verifyRequestKey(req.Key); r != nil {
+		return nil, status.Error(codes.InvalidArgument, r.Message)
+	}
 
 	rsp := &resourcepb.DeleteResponse{}
 	user, ok := claims.AuthInfoFrom(ctx)
@@ -1317,8 +1325,8 @@ func (s *server) Read(ctx context.Context, req *resourcepb.ReadRequest) (*resour
 			}}, nil
 	}
 
-	if req.Key.Resource == "" {
-		return &resourcepb.ReadResponse{Error: NewBadRequestError("missing resource")}, nil
+	if r := verifyRequestKey(req.Key); r != nil {
+		return nil, status.Error(codes.InvalidArgument, r.Message)
 	}
 
 	var (
@@ -1374,8 +1382,15 @@ func (s *server) read(ctx context.Context, user claims.AuthInfo, req *resourcepb
 
 func (s *server) List(ctx context.Context, req *resourcepb.ListRequest) (*resourcepb.ListResponse, error) {
 	ctx, span := tracer.Start(ctx, "resource.server.List")
-	span.SetAttributes(attribute.String("group", req.Options.Key.Group), attribute.String("resource", req.Options.Key.Resource))
 	defer span.End()
+
+	if req.Options == nil {
+		return nil, status.Error(codes.InvalidArgument, "missing list options")
+	}
+	if r := verifyRequestKeyCollection(req.Options.Key); r != nil {
+		return nil, status.Error(codes.InvalidArgument, r.Message)
+	}
+	span.SetAttributes(attribute.String("group", req.Options.Key.Group), attribute.String("resource", req.Options.Key.Resource))
 
 	// The history + trash queries do not yet support additional filters
 	if req.Source != resourcepb.ListRequest_STORE {
@@ -1687,6 +1702,13 @@ func (s *server) Watch(req *resourcepb.WatchRequest, srv resourcepb.ResourceStor
 	user, ok := claims.AuthInfoFrom(ctx)
 	if !ok || user == nil {
 		return apierrors.NewUnauthorized("no user found in context")
+	}
+
+	if req.Options == nil {
+		return status.Error(codes.InvalidArgument, "missing watch options")
+	}
+	if r := verifyRequestKeyCollection(req.Options.Key); r != nil {
+		return status.Error(codes.InvalidArgument, r.Message)
 	}
 
 	key := req.Options.Key

--- a/pkg/storage/unified/resource/server.go
+++ b/pkg/storage/unified/resource/server.go
@@ -1325,7 +1325,11 @@ func (s *server) Read(ctx context.Context, req *resourcepb.ReadRequest) (*resour
 			}}, nil
 	}
 
-	if r := verifyRequestKey(req.Key); r != nil {
+	// Don't validate the name format here: a lookup with an odd or
+	// invalid-looking name should fall through to the backend and surface as
+	// NotFound, matching K8s Get semantics. Strict name validation belongs on
+	// writes (Create/Update/Delete).
+	if r := verifyRequestKeyCollection(req.Key); r != nil {
 		return nil, status.Error(codes.InvalidArgument, r.Message)
 	}
 

--- a/pkg/storage/unified/resource/server_test.go
+++ b/pkg/storage/unified/resource/server_test.go
@@ -21,7 +21,9 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/metadata"
+	"google.golang.org/grpc/status"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	authlib "github.com/grafana/authlib/types"
@@ -280,6 +282,7 @@ func TestSimpleServer(t *testing.T) {
 		})
 		require.Error(t, err)
 		require.Nil(t, created)
+		require.Equal(t, codes.InvalidArgument, status.Code(err))
 
 		// invalid resource
 		key = &resourcepb.ResourceKey{
@@ -295,6 +298,7 @@ func TestSimpleServer(t *testing.T) {
 		})
 		require.Error(t, err)
 		require.Nil(t, created)
+		require.Equal(t, codes.InvalidArgument, status.Code(err))
 
 		// invalid namespace
 		key = &resourcepb.ResourceKey{
@@ -310,6 +314,7 @@ func TestSimpleServer(t *testing.T) {
 		})
 		require.Error(t, err)
 		require.Nil(t, created)
+		require.Equal(t, codes.InvalidArgument, status.Code(err))
 
 		// invalid name
 		key = &resourcepb.ResourceKey{
@@ -325,6 +330,7 @@ func TestSimpleServer(t *testing.T) {
 		})
 		require.Error(t, err)
 		require.Nil(t, created)
+		require.Equal(t, codes.InvalidArgument, status.Code(err))
 
 		// legacy name - valid
 		key = &resourcepb.ResourceKey{
@@ -397,6 +403,7 @@ func TestSimpleServer(t *testing.T) {
 
 			require.Error(t, err)
 			require.Nil(t, created)
+			require.Equal(t, codes.InvalidArgument, status.Code(err))
 		}
 
 		// resource
@@ -415,6 +422,7 @@ func TestSimpleServer(t *testing.T) {
 
 			require.Error(t, err)
 			require.Nil(t, created)
+			require.Equal(t, codes.InvalidArgument, status.Code(err))
 		}
 
 		// namespace
@@ -438,6 +446,7 @@ func TestSimpleServer(t *testing.T) {
 
 			require.Error(t, err)
 			require.Nil(t, created)
+			require.Equal(t, codes.InvalidArgument, status.Code(err))
 		}
 	})
 


### PR DESCRIPTION
A misconfigured client sending a nil request key could lead the storage-api server to crash without the validation. No current callers exist, this is a prevention measure.