### PR TITLE
DashboardScene: Fix missing breadcrumb on provisioning preview route

### DIFF
--- a/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.test.tsx
@@ -3,6 +3,7 @@ import {
   type GrafanaConfig,
   LiveChannelEventType,
   LoadingState,
+  type NavIndex,
   getDefaultTimeRange,
   locationUtil,
   store,
@@ -2693,6 +2694,48 @@ describe('DashboardScene', () => {
 
       expect(sceneGraph.getVariables(scene).state.variables.length).toBe(existingVarCount + 1);
       expect(scene.state.links.length).toBe(existingLinkCount + 1);
+    });
+  });
+
+  describe('getPageNav', () => {
+    describe('provisioning preview', () => {
+      // Regression test: when previewing a provisioned dashboard, meta.url and meta.slug are unset,
+      // which makes getDashboardUrl treat the dashboard as the home dashboard and return "/".
+      // buildBreadcrumbs then suppresses both the title and the "Dashboards" section crumb
+      // (only "View panel" was rendered). The parent crumb must point back to the preview path instead.
+      it('uses the preview pathname as the parent crumb url when viewing a panel, preserving the ref query param', () => {
+        const scene = buildTestScene({ meta: {}, viewPanel: '2' });
+        const location = {
+          pathname: '/dashboard/provisioning/my-repo/preview/path/to/dash.json',
+          search: '?ref=feature&viewPanel=2',
+          hash: '',
+          state: null,
+          key: '',
+        };
+
+        const pageNav = scene.getPageNav(location, {} as NavIndex);
+
+        expect(pageNav.text).toBe('View panel');
+        expect(pageNav.parentItem?.text).toBe('hello');
+        expect(pageNav.parentItem?.url).toBe(
+          '/subUrl/dashboard/provisioning/my-repo/preview/path/to/dash.json?ref=feature'
+        );
+      });
+
+      it('does not fabricate a ref query param when none is present', () => {
+        const scene = buildTestScene({ meta: {}, viewPanel: '2' });
+        const location = {
+          pathname: '/dashboard/provisioning/my-repo/preview/path/to/dash.json',
+          search: '?viewPanel=2',
+          hash: '',
+          state: null,
+          key: '',
+        };
+
+        const pageNav = scene.getPageNav(location, {} as NavIndex);
+
+        expect(pageNav.parentItem?.url).toBe('/subUrl/dashboard/provisioning/my-repo/preview/path/to/dash.json');
+      });
     });
   });
 });

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -48,6 +48,7 @@ import { PanelModel } from 'app/features/dashboard/state/PanelModel';
 import { type DecoratedRevisionModel } from 'app/features/dashboard/types/revisionModels';
 import { dashboardWatcher } from 'app/features/live/dashboard/dashboardWatcher';
 import { type DashboardJson } from 'app/features/manage-dashboards/types';
+import { PROVISIONING_PREVIEW_URL } from 'app/features/provisioning/constants';
 import { VariablesChanged } from 'app/features/variables/types';
 import { type DashboardDTO, type DashboardMeta, type SaveDashboardResponseDTO } from 'app/types/dashboard';
 import { DashboardDiscardedEvent, ShowConfirmModalEvent } from 'app/types/events';
@@ -616,17 +617,28 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
   public getPageNav(location: H.Location, navIndex: NavIndex) {
     const { meta, viewPanel, editPanel, title, uid } = this.state;
     const isNew = !Boolean(uid);
+    const isProvisioningPreview = location.pathname.startsWith(PROVISIONING_PREVIEW_URL + '/');
+    const clearPanelView = {
+      viewPanel: null,
+      inspect: null,
+      editview: null,
+      editPanel: null,
+      tab: null,
+      shareView: null,
+    };
 
     let pageNav: NavModelItem = {
       text: title,
-      url: getDashboardUrl({
-        uid,
-        slug: meta.slug,
-        currentQueryParams: location.search,
-        updateQuery: { viewPanel: null, inspect: null, editview: null, editPanel: null, tab: null, shareView: null },
-        isHomeDashboard: !meta.url && !meta.slug && !isNew && !meta.isSnapshot,
-        isSnapshot: meta.isSnapshot,
-      }),
+      url: isProvisioningPreview
+        ? locationUtil.getUrlForPartial(location, clearPanelView)
+        : getDashboardUrl({
+            uid,
+            slug: meta.slug,
+            currentQueryParams: location.search,
+            updateQuery: clearPanelView,
+            isHomeDashboard: !meta.url && !meta.slug && !isNew && !meta.isSnapshot,
+            isSnapshot: meta.isSnapshot,
+          }),
     };
 
     const { folderUid } = meta;

--- a/public/app/features/dashboard-scene/scene/DashboardScene.tsx
+++ b/public/app/features/dashboard-scene/scene/DashboardScene.tsx
@@ -617,6 +617,7 @@ export class DashboardScene extends SceneObjectBase<DashboardSceneState> impleme
   public getPageNav(location: H.Location, navIndex: NavIndex) {
     const { meta, viewPanel, editPanel, title, uid } = this.state;
     const isNew = !Boolean(uid);
+    // Trailing slash enforces a path-segment match so unrelated prefixes (e.g. `/dashboard/provisioning-foo/...`) don't match.
     const isProvisioningPreview = location.pathname.startsWith(PROVISIONING_PREVIEW_URL + '/');
     const clearPanelView = {
       viewPanel: null,


### PR DESCRIPTION
**What is this feature?**

In `DashboardScene` -> `getPageNav`, detect the provisioning preview route via `location.pathname.startsWith(PROVISIONING_PREVIEW_URL + '/')`. When on that route, build the title breadcrumb URL with `locationUtil.getUrlForPartial(location, ...)` (stripping `viewPanel`, `inspect`, `editview`, `editPanel`, `tab`, `shareView`) instead of `getDashboardUrl`.

**After fix:**  

https://github.com/user-attachments/assets/e1a666f3-4b42-43d6-8eb1-fb964634fb55




**Why do we need this feature?**

On provisioning preview route, dashboards have no `meta.url`/`meta.slug`, so `getDashboardUrl` resolves to `/`. `buildBreadcrumbs` matches that against `homeNav.url`, sets `foundHome = true`, and drops both the dashboard title crumb and the "Dashboards" section crumb, leaving only "View panel" visible.

**Who is this feature for?**

Git sync users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana/issues/125541

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
