### PR TITLE
[main] Chore(deps): Upgrade brace-expansion to >= 5.0.6 (CVE-2026-45149)

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -13263,11 +13263,11 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^5.0.2, brace-expansion@npm:^5.0.5":
-  version: 5.0.5
-  resolution: "brace-expansion@npm:5.0.5"
+  version: 5.0.6
+  resolution: "brace-expansion@npm:5.0.6"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10/f259b2ddf04489da9512ad637ba6b4ef2d77abd4445d20f7f1714585f153435200a53fa6a2e4a5ee974df14ddad4cd16421f6f803e96e8b452bd48598878d0ee
+  checksum: 10/a7acf120fefa79e9d7c9c92898114f57c07596a3920197f3c5917e6a628b04220a5f7f9618c30bdd973a6576a32113b99f9c3f1c8245ccc399dd2a9a718d81d8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Fixes CVE-2026-45149 (brace-expansion DoS via large numeric range that defeats the `max` protection), fixed version `5.0.6`.
- Semver-compatible upgrade: `yarn up -R brace-expansion`. Both parent ranges (`^5.0.2` from `i18next-cli@1.48.0`, `^5.0.5` from `minimatch@10.2.5` via `glob@13.0.6`) already permit `5.0.6`, so the lockfile was just stale — no resolution override needed.
- Only `yarn.lock` changed.

## Notes on remaining versions
`yarn.lock` still contains `brace-expansion@1.1.14` and `brace-expansion@2.1.0` after this change. Those are unrelated major-version lines pulled by older `minimatch` chains (jest's test-exclude/glob@7, swagger-api, etc.) and were **not flagged** by the scanner for CVE-2026-45149 — they are separate package release lines from `5.x`. A different CVE on the 1.x line (CVE-2025-5889) is already covered by exception #193.

## Test plan
- [ ] CI passes
- [ ] `yarn why brace-expansion` shows `5.0.6` (no `5.0.5`)

🤖 Generated with [Claude Code](https://claude.com/claude-code) and [/cve-semver-upgrade](https://github.com/grafana/grafana/blob/main/.claude/skills/cve-semver-upgrade/SKILL.md)