### PR TITLE
Frontend: migrate useCopyToClipboard to @grafana/data/unstable

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -570,6 +570,7 @@ i18next.config.ts @grafana/grafana-frontend-platform
 /packages/grafana-data/src/events/ @grafana/grafana-frontend-platform
 /packages/grafana-data/src/field/ @grafana/dashboards-squad
 /packages/grafana-data/src/geo/ @grafana/dataviz-squad
+/packages/grafana-data/src/hooks/ @grafana/grafana-frontend-platform
 /packages/grafana-data/src/monaco/ @grafana/data-sources-plugins
 /packages/grafana-data/src/panel/ @grafana/dashboards-squad
 /packages/grafana-data/src/panel/suggestions/ @grafana/dataviz-squad

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -73,6 +73,11 @@ const baseImportConfig = {
       importNames: ['useDispatch', 'useSelector'],
       message: 'Please import from app/types/store instead.',
     },
+    {
+      name: 'react-use',
+      importNames: ['useObservable'],
+      message: 'react-use is being phased out. Import useObservable from @grafana/data/unstable instead.',
+    },
   ],
 };
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -75,8 +75,8 @@ const baseImportConfig = {
     },
     {
       name: 'react-use',
-      importNames: ['useObservable'],
-      message: 'react-use is being phased out. Import useObservable from @grafana/data/unstable instead.',
+      importNames: ['useObservable', 'useCopyToClipboard'],
+      message: 'react-use is being phased out. Import the equivalent hook from @grafana/data/unstable instead.',
     },
   ],
 };

--- a/jest.config.js
+++ b/jest.config.js
@@ -35,6 +35,8 @@ const esModules = [
   'pbf',
   'geotiff',
   'uuid',
+  '@react-hookz/web',
+  '@ver0/deep-equal',
 ].join('|');
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -321,6 +321,7 @@
     "@react-aria/overlays": "3.30.0",
     "@react-aria/utils": "3.31.0",
     "@react-awesome-query-builder/ui": "6.6.15",
+    "@react-hookz/web": "^25.2.0",
     "@reduxjs/toolkit": "2.10.1",
     "@visx/event": "3.12.0",
     "@visx/gradient": "3.12.0",

--- a/packages/grafana-data/package.json
+++ b/packages/grafana-data/package.json
@@ -67,6 +67,7 @@
     "@grafana/i18n": "13.1.0-pre",
     "@grafana/schema": "13.1.0-pre",
     "@leeoniya/ufuzzy": "1.0.19",
+    "@react-hookz/web": "^25.2.0",
     "@types/d3-interpolate": "^3.0.0",
     "@types/string-hash": "1.1.3",
     "@types/systemjs": "6.15.3",

--- a/packages/grafana-data/src/hooks/useCopyToClipboard.test.ts
+++ b/packages/grafana-data/src/hooks/useCopyToClipboard.test.ts
@@ -1,0 +1,73 @@
+import { renderHook } from '@testing-library/react';
+
+import { useCopyToClipboard } from './useCopyToClipboard';
+
+const originalIsSecureContext = window.isSecureContext;
+const originalClipboard = navigator.clipboard;
+
+afterEach(() => {
+  Object.defineProperty(window, 'isSecureContext', { configurable: true, value: originalIsSecureContext });
+  Object.defineProperty(navigator, 'clipboard', { configurable: true, value: originalClipboard });
+  jest.restoreAllMocks();
+});
+
+it('writes to the modern Clipboard API when available in a secure context', async () => {
+  const writeText = jest.fn().mockResolvedValue(undefined);
+  Object.defineProperty(window, 'isSecureContext', { configurable: true, value: true });
+  Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } });
+
+  const { result } = renderHook(() => useCopyToClipboard());
+  await result.current('hello');
+
+  expect(writeText).toHaveBeenCalledTimes(1);
+  expect(writeText).toHaveBeenCalledWith('hello');
+});
+
+it('falls back to a textarea + execCommand when the secure-context API is unavailable', async () => {
+  Object.defineProperty(window, 'isSecureContext', { configurable: true, value: false });
+  Object.defineProperty(navigator, 'clipboard', { configurable: true, value: undefined });
+
+  // jsdom doesn't implement document.execCommand, so attach a stub before spying.
+  const execCommand = jest.fn().mockReturnValue(true);
+  Object.defineProperty(document, 'execCommand', { configurable: true, value: execCommand });
+
+  const initialTextareaCount = document.body.querySelectorAll('textarea').length;
+
+  const { result } = renderHook(() => useCopyToClipboard());
+  await result.current('hello');
+
+  expect(execCommand).toHaveBeenCalledWith('copy');
+  // The fallback textarea is appended to document.body and removed before the function returns.
+  expect(document.body.querySelectorAll('textarea').length).toBe(initialTextareaCount);
+});
+
+it('returns a stable callback across renders', () => {
+  const { result, rerender } = renderHook(() => useCopyToClipboard());
+  const first = result.current;
+  rerender();
+  expect(result.current).toBe(first);
+});
+
+it('appends the fallback textarea to the provided ref element when given', async () => {
+  Object.defineProperty(window, 'isSecureContext', { configurable: true, value: false });
+  Object.defineProperty(navigator, 'clipboard', { configurable: true, value: undefined });
+  Object.defineProperty(document, 'execCommand', {
+    configurable: true,
+    value: jest.fn().mockReturnValue(true),
+  });
+
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const ref = { current: container };
+  const appendSpy = jest.spyOn(container, 'appendChild');
+
+  const { result } = renderHook(() => useCopyToClipboard(ref));
+  await result.current('hello');
+
+  expect(appendSpy).toHaveBeenCalledTimes(1);
+  expect(appendSpy.mock.calls[0][0]).toBeInstanceOf(HTMLTextAreaElement);
+  // Cleanup: ref-targeted textarea is also removed before the function returns.
+  expect(container.querySelectorAll('textarea').length).toBe(0);
+
+  container.remove();
+});

--- a/packages/grafana-data/src/hooks/useCopyToClipboard.ts
+++ b/packages/grafana-data/src/hooks/useCopyToClipboard.ts
@@ -1,0 +1,30 @@
+import { type RefObject, useCallback } from 'react';
+
+/**
+ * Copy text to the clipboard. Uses the modern Clipboard API in secure contexts and falls back
+ * to a hidden `<textarea>` + `document.execCommand('copy')` otherwise.
+ *
+ * If `fallbackRef` is provided, the fallback textarea is appended to that element rather than
+ * `document.body` — useful when copying from inside a focus-managed region (e.g. react-aria's
+ * `FocusScope`) where elements outside the managed subtree can't receive focus.
+ */
+export function useCopyToClipboard(fallbackRef?: RefObject<HTMLElement | null>): (text: string) => Promise<void> {
+  return useCallback(
+    async (text: string) => {
+      if (navigator.clipboard && window.isSecureContext) {
+        await navigator.clipboard.writeText(text);
+        return;
+      }
+
+      const textarea = document.createElement('textarea');
+      const parent = fallbackRef?.current ?? document.body;
+      parent.appendChild(textarea);
+      textarea.value = text;
+      textarea.focus();
+      textarea.select();
+      document.execCommand('copy');
+      textarea.remove();
+    },
+    [fallbackRef]
+  );
+}

--- a/packages/grafana-data/src/hooks/useObservable.test.ts
+++ b/packages/grafana-data/src/hooks/useObservable.test.ts
@@ -1,0 +1,122 @@
+import { useIsomorphicLayoutEffect } from '@react-hookz/web';
+import { act, renderHook } from '@testing-library/react';
+import { Subject, type Observable } from 'rxjs';
+
+import { useObservable } from './useObservable';
+
+jest.mock('@react-hookz/web', () => {
+  const actual = jest.requireActual('@react-hookz/web');
+  return {
+    ...actual,
+    useIsomorphicLayoutEffect: jest.fn(actual.useIsomorphicLayoutEffect),
+  };
+});
+
+const useIsomorphicLayoutEffectMock = useIsomorphicLayoutEffect as jest.Mock;
+
+beforeEach(() => {
+  useIsomorphicLayoutEffectMock.mockClear();
+});
+
+const setUp = <T>(observable: Observable<T>, initialValue?: T) =>
+  renderHook(() => useObservable(observable, initialValue as T));
+
+it('should init to initial value provided', () => {
+  const subject$ = new Subject<number>();
+  const { result } = setUp(subject$, 123);
+
+  expect(result.current).toBe(123);
+});
+
+it('should init to undefined if not initial value provided', () => {
+  const subject$ = new Subject<number>();
+  const { result } = setUp(subject$);
+
+  expect(result.current).toBeUndefined();
+});
+
+it('should return latest value of observables', () => {
+  const subject$ = new Subject<number>();
+  const { result } = setUp(subject$, 123);
+
+  act(() => {
+    subject$.next(125);
+  });
+  expect(result.current).toBe(125);
+
+  act(() => {
+    subject$.next(300);
+    subject$.next(400);
+  });
+  expect(result.current).toBe(400);
+});
+
+it('should use layout effect to subscribe synchronously', () => {
+  const subject$ = new Subject<number>();
+
+  expect(useIsomorphicLayoutEffectMock).toHaveBeenCalledTimes(0);
+
+  setUp(subject$, 123);
+
+  expect(useIsomorphicLayoutEffectMock).toHaveBeenCalledTimes(1);
+});
+
+it('should subscribe to observable only once', () => {
+  const subject$ = new Subject<string>();
+  const spy = jest.spyOn(subject$, 'subscribe');
+  expect(spy).not.toHaveBeenCalled();
+
+  setUp(subject$, 'init');
+
+  expect(spy).toHaveBeenCalledTimes(1);
+
+  act(() => {
+    subject$.next('a');
+  });
+
+  act(() => {
+    subject$.next('b');
+  });
+
+  expect(spy).toHaveBeenCalledTimes(1);
+});
+
+it('should return updated value when observable changes', () => {
+  const subject$ = new Subject<string>();
+  const { result } = setUp(subject$);
+  expect(result.current).toBeUndefined();
+
+  act(() => {
+    subject$.next('foo');
+  });
+  expect(result.current).toBe('foo');
+
+  act(() => {
+    subject$.next('bar');
+  });
+  expect(result.current).toBe('bar');
+});
+
+it('should unsubscribe from observable', () => {
+  const subject$ = new Subject<string>();
+  const unsubscribeMock = jest.fn();
+  subject$.subscribe = jest.fn().mockReturnValue({
+    unsubscribe: unsubscribeMock,
+  });
+
+  const { unmount } = setUp(subject$);
+  expect(unsubscribeMock).not.toHaveBeenCalled();
+
+  act(() => {
+    subject$.next('foo');
+  });
+  expect(unsubscribeMock).not.toHaveBeenCalled();
+
+  act(() => {
+    subject$.next('bar');
+  });
+  expect(unsubscribeMock).not.toHaveBeenCalled();
+
+  unmount();
+  expect(unsubscribeMock).toHaveBeenCalledTimes(1);
+});

--- a/packages/grafana-data/src/hooks/useObservable.ts
+++ b/packages/grafana-data/src/hooks/useObservable.ts
@@ -1,0 +1,16 @@
+import { useIsomorphicLayoutEffect } from '@react-hookz/web';
+import { useState } from 'react';
+import { type Observable } from 'rxjs';
+
+export function useObservable<T>(observable$: Observable<T>): T | undefined;
+export function useObservable<T>(observable$: Observable<T>, initialValue: T): T;
+export function useObservable<T>(observable$: Observable<T>, initialValue?: T): T | undefined {
+  const [value, setValue] = useState<T | undefined>(initialValue);
+
+  useIsomorphicLayoutEffect(() => {
+    const subscription = observable$.subscribe(setValue);
+    return () => subscription.unsubscribe();
+  }, [observable$]);
+
+  return value;
+}

--- a/packages/grafana-data/src/unstable.ts
+++ b/packages/grafana-data/src/unstable.ts
@@ -9,4 +9,5 @@
  * and be subject to the standard policies
  */
 
+export { useCopyToClipboard } from './hooks/useCopyToClipboard';
 export { useObservable } from './hooks/useObservable';

--- a/packages/grafana-data/src/unstable.ts
+++ b/packages/grafana-data/src/unstable.ts
@@ -9,4 +9,4 @@
  * and be subject to the standard policies
  */
 
-export {};
+export { useObservable } from './hooks/useObservable';

--- a/packages/grafana-plugin-configs/jest/utils.js
+++ b/packages/grafana-plugin-configs/jest/utils.js
@@ -29,4 +29,6 @@ export const grafanaESModules = [
   '@grafana/llm',
   'pkce-challenge',
   'uuid',
+  '@react-hookz/web',
+  '@ver0/deep-equal',
 ];

--- a/packages/grafana-runtime/src/services/ScopesContext.ts
+++ b/packages/grafana-runtime/src/services/ScopesContext.ts
@@ -1,8 +1,8 @@
 import { createContext, useContext, useMemo } from 'react';
-import { useObservable } from 'react-use';
 import { Observable } from 'rxjs';
 
 import { type Scope } from '@grafana/data';
+import { useObservable } from '@grafana/data/unstable';
 
 export interface ScopesContextValueState {
   // Whether the drawer with the related dashboards is open

--- a/packages/grafana-sql/src/components/QueryHeader.tsx
+++ b/packages/grafana-sql/src/components/QueryHeader.tsx
@@ -1,8 +1,8 @@
 import { useCallback, useId, useState } from 'react';
-import { useCopyToClipboard } from 'react-use';
 
 import { QueryWithAssistantButton } from '@grafana/assistant';
 import { CoreApp, type DataSourceInstanceSettings, type SelectableValue } from '@grafana/data';
+import { useCopyToClipboard } from '@grafana/data/unstable';
 import { selectors } from '@grafana/e2e-selectors';
 import { t, Trans } from '@grafana/i18n';
 import { EditorField, EditorHeader, EditorMode, EditorRow, FlexItem, InlineSelect } from '@grafana/plugin-ui';
@@ -55,7 +55,7 @@ export function QueryHeader({
   app,
 }: QueryHeaderProps) {
   const { editorMode } = query;
-  const [_, copyToClipboard] = useCopyToClipboard();
+  const copyToClipboard = useCopyToClipboard();
   const [showConfirm, setShowConfirm] = useState(false);
   const toRawSql = db.toRawSql;
 

--- a/packages/grafana-sql/src/components/visual-query-builder/Preview.tsx
+++ b/packages/grafana-sql/src/components/visual-query-builder/Preview.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
-import { useCopyToClipboard } from 'react-use';
 
 import { type GrafanaTheme2 } from '@grafana/data';
+import { useCopyToClipboard } from '@grafana/data/unstable';
 import { Trans, t } from '@grafana/i18n';
 import { reportInteraction } from '@grafana/runtime';
 import { CodeEditor, Field, IconButton, useStyles2 } from '@grafana/ui';
@@ -14,8 +14,7 @@ type PreviewProps = {
 };
 
 export function Preview({ rawSql, datasourceType }: PreviewProps) {
-  // TODO: use zero index to give feedback about copy success
-  const [_, copyToClipboard] = useCopyToClipboard();
+  const copyToClipboard = useCopyToClipboard();
   const styles = useStyles2(getStyles);
 
   const copyPreview = (rawSql: string) => {

--- a/packages/grafana-ui/src/components/ClipboardButton/ClipboardButton.tsx
+++ b/packages/grafana-ui/src/components/ClipboardButton/ClipboardButton.tsx
@@ -1,8 +1,8 @@
 import { css, cx } from '@emotion/css';
 import { useCallback, useRef, useState, useEffect } from 'react';
-import * as React from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
+import { useCopyToClipboard } from '@grafana/data/unstable';
 import { t } from '@grafana/i18n';
 
 import { useStyles2 } from '../../themes/ThemeContext';
@@ -53,17 +53,18 @@ export function ClipboardButton({
   }, [showCopySuccess]);
 
   const buttonRef = useRef<null | HTMLButtonElement>(null);
+  const copyToClipboard = useCopyToClipboard(buttonRef);
   const copyTextCallback = useCallback(async () => {
     const textToCopy = getText();
 
     try {
-      await copyText(textToCopy, buttonRef);
+      await copyToClipboard(textToCopy);
       setShowCopySuccess(true);
       onClipboardCopy?.(textToCopy);
     } catch (e) {
       onClipboardError?.(textToCopy, e);
     }
-  }, [getText, onClipboardCopy, onClipboardError]);
+  }, [copyToClipboard, getText, onClipboardCopy, onClipboardError]);
 
   const copiedText = t('clipboard-button.inline-toast.success', 'Copied');
   return (
@@ -93,26 +94,6 @@ export function ClipboardButton({
     </>
   );
 }
-
-const copyText = async (text: string, buttonRef: React.MutableRefObject<HTMLButtonElement | null>) => {
-  if (navigator.clipboard && window.isSecureContext) {
-    return navigator.clipboard.writeText(text);
-  } else {
-    // Use a fallback method for browsers/contexts that don't support the Clipboard API.
-    // See https://web.dev/async-clipboard/#feature-detection.
-    // Use textarea so the user can copy multi-line content.
-    const textarea = document.createElement('textarea');
-    // Normally we'd append this to the body. However if we're inside a focus manager
-    // from react-aria, we can't focus anything outside of the managed area.
-    // Instead, let's append it to the button. Then we're guaranteed to be able to focus + copy.
-    buttonRef.current?.appendChild(textarea);
-    textarea.value = text;
-    textarea.focus();
-    textarea.select();
-    document.execCommand('copy');
-    textarea.remove();
-  }
-};
 
 const getStyles = (theme: GrafanaTheme2) => {
   return {

--- a/public/app/core/components/AppChrome/AppChromeService.tsx
+++ b/public/app/core/components/AppChrome/AppChromeService.tsx
@@ -1,7 +1,7 @@
-import { useObservable } from 'react-use';
 import { BehaviorSubject } from 'rxjs';
 
 import { AppEvents, type NavModel, type NavModelItem, PageLayoutType, store, type UrlQueryValue } from '@grafana/data';
+import { useObservable } from '@grafana/data/unstable';
 import { t } from '@grafana/i18n';
 import { config, locationService, reportInteraction } from '@grafana/runtime';
 import { appEvents } from 'app/core/app_events';

--- a/public/app/features/alerting/unified/components/receivers/form/fields/TemplateSelector.tsx
+++ b/public/app/features/alerting/unified/components/receivers/form/fields/TemplateSelector.tsx
@@ -1,10 +1,10 @@
 import { css, cx } from '@emotion/css';
 import { type PropsWithChildren, useEffect, useMemo, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
-import { useCopyToClipboard } from 'react-use';
 
 import { type TemplateGroupTemplateKind } from '@grafana/api-clients/rtkq/notifications.alerting/v0alpha1';
 import { type GrafanaTheme2, type SelectableValue } from '@grafana/data';
+import { useCopyToClipboard } from '@grafana/data/unstable';
 import { Trans, t } from '@grafana/i18n';
 import {
   Button,
@@ -142,7 +142,7 @@ export function TemplateSelector({ onSelect, onClose, option, valueInForm, filte
   const [templateOption, setTemplateOption] = useState<TemplateFieldOption | undefined>(
     valueInFormIsCustom ? 'Custom' : 'Existing'
   );
-  const [_, copyToClipboard] = useCopyToClipboard();
+  const copyToClipboard = useCopyToClipboard();
 
   const templateOptions: Array<SelectableValue<TemplateFieldOption>> = [
     {

--- a/public/app/features/canvas/elements/metricValue.tsx
+++ b/public/app/features/canvas/elements/metricValue.tsx
@@ -1,6 +1,5 @@
 import { css } from '@emotion/css';
 import { useCallback } from 'react';
-import { useObservable } from 'react-use';
 import { of } from 'rxjs';
 
 import {
@@ -9,6 +8,7 @@ import {
   type GrafanaTheme2,
   type StandardEditorsRegistryItem,
 } from '@grafana/data';
+import { useObservable } from '@grafana/data/unstable';
 import { t } from '@grafana/i18n';
 import { TextDimensionMode } from '@grafana/schema';
 import { usePanelContext, useStyles2 } from '@grafana/ui';

--- a/public/app/features/canvas/elements/text.tsx
+++ b/public/app/features/canvas/elements/text.tsx
@@ -1,10 +1,10 @@
 import { css } from '@emotion/css';
 import { useCallback, useEffect, useRef } from 'react';
 import * as React from 'react';
-import { useObservable } from 'react-use';
 import { of } from 'rxjs';
 
 import { type DataFrame, type GrafanaTheme2 } from '@grafana/data';
+import { useObservable } from '@grafana/data/unstable';
 import { t } from '@grafana/i18n';
 import { Input, usePanelContext, useStyles2 } from '@grafana/ui';
 import { type DimensionContext } from 'app/features/dimensions/context';

--- a/public/app/features/commandPalette/scopes/recentScopesActions.ts
+++ b/public/app/features/commandPalette/scopes/recentScopesActions.ts
@@ -1,6 +1,6 @@
-import { useObservable } from 'react-use';
 import { Observable } from 'rxjs';
 
+import { useObservable } from '@grafana/data/unstable';
 import { t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { useScopesServices } from 'app/features/scopes/ScopesContextProvider';

--- a/public/app/features/commandPalette/scopes/scopesUtils.test.ts
+++ b/public/app/features/commandPalette/scopes/scopesUtils.test.ts
@@ -1,9 +1,9 @@
 import { renderHook } from '@testing-library/react';
 import { setIn } from 'immutable';
-import { useObservable } from 'react-use';
 import { Observable, of } from 'rxjs';
 
 import { type Scope, type ScopeNode } from '@grafana/data';
+import { useObservable } from '@grafana/data/unstable';
 
 import { useScopesServices } from '../../scopes/ScopesContextProvider';
 import { type ScopesSelectorServiceState } from '../../scopes/selector/ScopesSelectorService';
@@ -16,8 +16,8 @@ jest.mock('../../scopes/ScopesContextProvider', () => ({
   useScopesServices: jest.fn(),
 }));
 
-jest.mock('react-use', () => {
-  const actual = jest.requireActual('react-use');
+jest.mock('@grafana/data/unstable', () => {
+  const actual = jest.requireActual('@grafana/data/unstable');
   return {
     ...actual,
     useObservable: jest.fn(),
@@ -247,7 +247,7 @@ describe('useScopeServicesState', () => {
     jest.clearAllMocks();
     // Reset useObservable to use actual implementation by default
     (useObservable as jest.Mock).mockImplementation((...args) => {
-      const actual = jest.requireActual('react-use');
+      const actual = jest.requireActual('@grafana/data/unstable');
       return actual.useObservable(...args);
     });
   });

--- a/public/app/features/commandPalette/scopes/scopesUtils.ts
+++ b/public/app/features/commandPalette/scopes/scopesUtils.ts
@@ -1,7 +1,7 @@
-import { useObservable } from 'react-use';
 import { Observable } from 'rxjs';
 
 import { type ScopeNode } from '@grafana/data';
+import { useObservable } from '@grafana/data/unstable';
 import { t } from '@grafana/i18n';
 
 import { useScopesServices } from '../../scopes/ScopesContextProvider';

--- a/public/app/features/explore/PrometheusListView/RawListItem.tsx
+++ b/public/app/features/explore/PrometheusListView/RawListItem.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/css';
-import { useCopyToClipboard } from 'react-use';
 
 import { type Field, type GrafanaTheme2 } from '@grafana/data';
+import { useCopyToClipboard } from '@grafana/data/unstable';
 import { t } from '@grafana/i18n';
 import { isValidLegacyName, utf8Support } from '@grafana/prometheus';
 import { reportInteraction } from '@grafana/runtime';
@@ -98,7 +98,7 @@ const RawListItem = ({ listItemData, listKey, totalNumberOfValues, valueLabels, 
   const { __name__, ...allLabels } = listItemData;
   // We must know whether it is a utf8 metric name or not
   const isLegacyMetric = isValidLegacyName(__name__ ?? '');
-  const [_, copyToClipboard] = useCopyToClipboard();
+  const copyToClipboard = useCopyToClipboard();
   const displayLength = valueLabels?.length ?? totalNumberOfValues;
   const styles = useStyles2(getStyles, displayLength, isExpandedView);
 

--- a/public/app/features/explore/RichHistory/RichHistoryQueriesTab.test.tsx
+++ b/public/app/features/explore/RichHistory/RichHistoryQueriesTab.test.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen } from '@testing-library/react';
+// eslint-disable-next-line no-restricted-imports -- wildcard is used to spy on `useAsync`, not `useObservable`
 import * as reactUse from 'react-use';
 import { TestProvider } from 'test/helpers/TestProvider';
 import { MockDataSourceApi } from 'test/mocks/datasource_srv';

--- a/public/app/features/plugins/extensions/registry/useRegistrySlice.tsx
+++ b/public/app/features/plugins/extensions/registry/useRegistrySlice.tsx
@@ -1,5 +1,6 @@
 import { useMemo } from 'react';
-import { useObservable } from 'react-use';
+
+import { useObservable } from '@grafana/data/unstable';
 
 import {
   useAddedComponentsRegistry,

--- a/public/app/features/scopes/dashboards/ScopesDashboards.tsx
+++ b/public/app/features/scopes/dashboards/ScopesDashboards.tsx
@@ -1,8 +1,8 @@
 import { css } from '@emotion/css';
-import { useObservable } from 'react-use';
 import { Observable } from 'rxjs';
 
 import { type GrafanaTheme2 } from '@grafana/data';
+import { useObservable } from '@grafana/data/unstable';
 import { Trans, t } from '@grafana/i18n';
 import { useScopes } from '@grafana/runtime';
 import { Button, LoadingPlaceholder, ScrollContainer, useStyles2 } from '@grafana/ui';

--- a/public/app/features/scopes/selector/ScopesSelector.tsx
+++ b/public/app/features/scopes/selector/ScopesSelector.tsx
@@ -1,9 +1,9 @@
 import { css } from '@emotion/css';
 import { useEffect } from 'react';
-import { useObservable } from 'react-use';
 import { Observable } from 'rxjs';
 
 import { type GrafanaTheme2 } from '@grafana/data';
+import { useObservable } from '@grafana/data/unstable';
 import { Trans, t } from '@grafana/i18n';
 import { useScopes } from '@grafana/runtime';
 import { Button, Drawer, ErrorBoundary, ErrorWithStack, Spinner, Text, useStyles2 } from '@grafana/ui';

--- a/public/app/plugins/panel/canvas/editor/element/PlacementEditor.tsx
+++ b/public/app/plugins/panel/canvas/editor/element/PlacementEditor.tsx
@@ -1,7 +1,7 @@
-import { useObservable } from 'react-use';
 import { Subject } from 'rxjs';
 
 import { type SelectableValue, type StandardEditorProps } from '@grafana/data';
+import { useObservable } from '@grafana/data/unstable';
 import { Trans, t } from '@grafana/i18n';
 import { Field, Icon, InlineField, InlineFieldRow, Select, Stack } from '@grafana/ui';
 import { NumberInput } from 'app/core/components/OptionsUI/NumberInput';

--- a/public/app/plugins/panel/canvas/editor/inline/InlineEditBody.tsx
+++ b/public/app/plugins/panel/canvas/editor/inline/InlineEditBody.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/css';
 import { get as lodashGet } from 'lodash';
 import { useMemo, useState } from 'react';
-import { useObservable } from 'react-use';
 
 import {
   type DataFrame,
@@ -10,6 +9,7 @@ import {
   type StandardEditorContext,
 } from '@grafana/data';
 import { type NestedValueAccess, type PanelOptionsSupplier } from '@grafana/data/internal';
+import { useObservable } from '@grafana/data/unstable';
 import { Trans, t } from '@grafana/i18n';
 import { useStyles2 } from '@grafana/ui';
 import { AddLayerButton } from 'app/core/components/Layers/AddLayerButton';

--- a/public/app/plugins/panel/geomap/components/MarkersLegend.tsx
+++ b/public/app/plugins/panel/geomap/components/MarkersLegend.tsx
@@ -1,7 +1,6 @@
 import { css, cx } from '@emotion/css';
 import type BaseLayer from 'ol/layer/Base';
 import { useMemo } from 'react';
-import { useObservable } from 'react-use';
 import { of } from 'rxjs';
 
 import {
@@ -11,6 +10,7 @@ import {
   getFieldColorModeForField,
   type GrafanaTheme2,
 } from '@grafana/data';
+import { useObservable } from '@grafana/data/unstable';
 import { t } from '@grafana/i18n';
 import { config } from '@grafana/runtime';
 import { useStyles2, type VizLegendItem } from '@grafana/ui';

--- a/public/app/plugins/panel/geomap/editor/StyleEditor.tsx
+++ b/public/app/plugins/panel/geomap/editor/StyleEditor.tsx
@@ -1,6 +1,5 @@
 import { capitalize } from 'lodash';
 import { useId, useMemo } from 'react';
-import { useObservable } from 'react-use';
 import { type Observable, of } from 'rxjs';
 
 import {
@@ -9,6 +8,7 @@ import {
   type StandardEditorsRegistryItem,
   type FrameMatcher,
 } from '@grafana/data';
+import { useObservable } from '@grafana/data/unstable';
 import { t } from '@grafana/i18n';
 import {
   type ScaleDimensionConfig,

--- a/public/app/plugins/panel/geomap/editor/StyleRuleEditor.tsx
+++ b/public/app/plugins/panel/geomap/editor/StyleRuleEditor.tsx
@@ -1,7 +1,6 @@
 import { css } from '@emotion/css';
 import { type FeatureLike } from 'ol/Feature';
 import { useCallback, useMemo } from 'react';
-import { useObservable } from 'react-use';
 import { type Observable } from 'rxjs';
 
 import {
@@ -10,6 +9,7 @@ import {
   type StandardEditorProps,
   type StandardEditorsRegistryItem,
 } from '@grafana/data';
+import { useObservable } from '@grafana/data/unstable';
 import { t } from '@grafana/i18n';
 import { ComparisonOperation } from '@grafana/schema';
 import { Button, InlineField, InlineFieldRow, Select, useStyles2 } from '@grafana/ui';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2437,6 +2437,7 @@ __metadata:
     "@grafana/scenes": "npm:^8.2.6"
     "@grafana/schema": "npm:13.1.0-pre"
     "@leeoniya/ufuzzy": "npm:1.0.19"
+    "@react-hookz/web": "npm:^25.2.0"
     "@rollup/plugin-json": "npm:6.1.0"
     "@rollup/plugin-node-resolve": "npm:16.0.1"
     "@testing-library/react": "npm:16.3.0"
@@ -7161,6 +7162,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@react-hookz/web@npm:^25.2.0":
+  version: 25.2.0
+  resolution: "@react-hookz/web@npm:25.2.0"
+  dependencies:
+    "@ver0/deep-equal": "npm:^1.0.0"
+  peerDependencies:
+    js-cookie: ^3.0.5
+    react: ^16.8 || ^17 || ^18 || ^19
+    react-dom: ^16.8 || ^17 || ^18 || ^19
+  peerDependenciesMeta:
+    js-cookie:
+      optional: true
+  checksum: 10/c23a10a1028760951318df440d1c314b0a1d848fc4a80968f5c31a1c832b388cb300e4a7f9f4edf0b80e81274f53ca2adfe5fe0ea97cac92bd8fb1b94a15bae0
+  languageName: node
+  linkType: hard
+
 "@react-stately/flags@npm:^3.1.2":
   version: 3.1.2
   resolution: "@react-stately/flags@npm:3.1.2"
@@ -11621,6 +11638,13 @@ __metadata:
   version: 1.11.1
   resolution: "@unrs/resolver-binding-win32-x64-msvc@npm:1.11.1"
   conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@ver0/deep-equal@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "@ver0/deep-equal@npm:1.0.1"
+  checksum: 10/7ab3679eaecdee998335e7873ac06b1d2121b8587f75bb4b25a0ece7c525754146ee9d3ef490705b00858990c9e369909e73bdfc858d1095113de637e3d03526
   languageName: node
   linkType: hard
 
@@ -19110,6 +19134,7 @@ __metadata:
     "@react-aria/overlays": "npm:3.30.0"
     "@react-aria/utils": "npm:3.31.0"
     "@react-awesome-query-builder/ui": "npm:6.6.15"
+    "@react-hookz/web": "npm:^25.2.0"
     "@react-types/button": "npm:3.13.0"
     "@react-types/menu": "npm:3.10.3"
     "@react-types/overlays": "npm:3.9.0"


### PR DESCRIPTION
**What is this feature?**

Migrates `useCopyToClipboard` off `react-use`. New hook lives in `@grafana/data` at `packages/grafana-data/src/hooks/useCopyToClipboard.ts`, exported from `@grafana/data/unstable`.

```ts
// before
import { useCopyToClipboard } from 'react-use';
const [_, copyToClipboard] = useCopyToClipboard();

// after
import { useCopyToClipboard } from '@grafana/data/unstable';
const copyToClipboard = useCopyToClipboard();
```

All 4 call-sites discarded the state half of the tuple, so the new hook just returns the copy function. Accepts an optional `RefObject<HTMLElement | null>` — when provided, the non-secure-context `<textarea>` fallback is appended to that element instead of `document.body`, which keeps the fallback working inside react-aria's `FocusScope`.

Also collapses the private `copyText` helper inside `ClipboardButton` into a call to the new hook with `buttonRef` passed through. One implementation, two consumers.

**Why do we need this feature?**

So we can phase out the unmaintained `react-use` package one hook at a time and stop maintaining two parallel clipboard helpers.

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

For #125595 and #125598

**Special notes for your reviewer:**

Stacked on top of [#125606](https://github.com/grafana/grafana/pull/125606) — please review and land that one first. The `useCopyToClipboard` hook only lands cleanly once `@grafana/data/unstable` exists.

ESLint regression guard updated: `useCopyToClipboard` is now in the `react-use` ban list alongside `useObservable`, both pointing to `@grafana/data/unstable`.

Please check that:

- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
