### PR TITLE
Folders: Remove unused namespacer field

### DIFF
--- a/pkg/registry/apis/folders/register.go
+++ b/pkg/registry/apis/folders/register.go
@@ -32,7 +32,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/accesscontrol"
 	grafanaauthorizer "github.com/grafana/grafana/pkg/services/apiserver/auth/authorizer"
 	"github.com/grafana/grafana/pkg/services/apiserver/builder"
-	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
 	"github.com/grafana/grafana/pkg/services/authz/zanzana"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
 	"github.com/grafana/grafana/pkg/services/folder"
@@ -49,7 +48,6 @@ var (
 
 // This is used just so wire has something unique to return
 type FolderAPIBuilder struct {
-	namespacer           request.NamespaceMapper
 	storage              grafanarest.Storage
 	permissionStore      PermissionStore
 	accessClient         authlib.AccessClient
@@ -76,7 +74,6 @@ func RegisterAPIService(cfg *setting.Cfg,
 	zanzanaClient zanzana.Client,
 ) *FolderAPIBuilder {
 	builder := &FolderAPIBuilder{
-		namespacer:           request.GetNamespaceMapper(cfg),
 		folderPermissionsSvc: folderPermissionsSvc,
 		accessClient:         accessClient,
 		permissionsOnCreate:  cfg.RBAC.PermissionsOnCreation("folder"),

--- a/pkg/registry/apis/folders/register_test.go
+++ b/pkg/registry/apis/folders/register_test.go
@@ -142,7 +142,6 @@ func TestFolderAPIBuilder_Validate_Create(t *testing.T) {
 			us := grafanarest.NewMockStorage(t)
 
 			b := &FolderAPIBuilder{
-				namespacer:           func(_ int64) string { return "123" },
 				storage:              us,
 				parents:              newParentsGetter(us, 2),
 				maxNestedFolderDepth: setting.NewCfg().MaxNestedFolderDepth,
@@ -309,9 +308,8 @@ func TestFolderAPIBuilder_Validate_Delete(t *testing.T) {
 			setKubernetesFolderCascadeDeleteToggle(t, tt.cascadeDeleteEnabled)
 
 			b := &FolderAPIBuilder{
-				namespacer: func(_ int64) string { return "123" },
-				storage:    us,
-				searcher:   sm,
+				storage:  us,
+				searcher: sm,
 			}
 
 			err := b.Validate(context.Background(), admission.NewAttributesRecord(
@@ -498,10 +496,9 @@ func TestFolderAPIBuilder_Validate_Update(t *testing.T) {
 			}
 
 			b := &FolderAPIBuilder{
-				namespacer: func(_ int64) string { return "123" },
-				storage:    us,
-				searcher:   sm,
-				parents:    newParentsGetter(us, setting.NewCfg().MaxNestedFolderDepth),
+				storage:  us,
+				searcher: sm,
+				parents:  newParentsGetter(us, setting.NewCfg().MaxNestedFolderDepth),
 			}
 
 			err := b.Validate(context.Background(), admission.NewAttributesRecord(
@@ -591,10 +588,9 @@ func TestFolderAPIBuilder_Mutate_Create(t *testing.T) {
 			us := grafanarest.NewMockStorage(t)
 			sm := resource.NewMockResourceClient(t)
 			b := &FolderAPIBuilder{
-				namespacer: func(_ int64) string { return "123" },
-				storage:    us,
-				searcher:   sm,
-				parents:    newParentsGetter(us, setting.NewCfg().MaxNestedFolderDepth),
+				storage:  us,
+				searcher: sm,
+				parents:  newParentsGetter(us, setting.NewCfg().MaxNestedFolderDepth),
 			}
 			admAttr := admission.NewAttributesRecord(
 				tt.input,
@@ -696,10 +692,9 @@ func TestFolderAPIBuilder_Mutate_Update(t *testing.T) {
 	us := grafanarest.NewMockStorage(t)
 	sm := resource.NewMockResourceClient(t)
 	b := &FolderAPIBuilder{
-		namespacer: func(_ int64) string { return "123" },
-		storage:    us,
-		searcher:   sm,
-		parents:    newParentsGetter(us, setting.NewCfg().MaxNestedFolderDepth),
+		storage:  us,
+		searcher: sm,
+		parents:  newParentsGetter(us, setting.NewCfg().MaxNestedFolderDepth),
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

- `FolderAPIBuilder.namespacer` was set in `RegisterAPIService` and in tests but never read anywhere on the builder.
- Drops the field, its initialization, the matching test setup in 5 cases, and the now-unused `pkg/services/apiserver/endpoints/request` import.
- The conversion helpers in `conversions.go` already take `namespacer` as a function parameter, so they're unaffected.

## Test plan

- [x] `go build ./pkg/registry/apis/folders/...`
- [x] `go vet ./pkg/registry/apis/folders/...`
- [ ] `go test ./pkg/registry/apis/folders/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)