### PR TITLE
Search: add KV-backed RemoteIndexStore (no chunking yet)

### DIFF
--- a/pkg/storage/unified/search/kv_remote_index_store.go
+++ b/pkg/storage/unified/search/kv_remote_index_store.go
@@ -354,7 +354,8 @@ func (s *KVRemoteIndexStore) ListIndexKeys(ctx context.Context, nsResource resou
 		ulidStr := strings.TrimPrefix(key, prefix)
 		u, err := ulid.Parse(ulidStr)
 		if err != nil {
-			// Defensive: skip non-ULID keys. Should not occur in practice.
+			// Shouldn't occur in practice; log so it doesn't disappear silently.
+			s.log.Warn("skipping non-ULID key in manifest section", "key", key, "err", err)
 			continue
 		}
 		result = append(result, u)
@@ -505,15 +506,12 @@ type kvIndexStoreLock struct {
 // Release stops the auto-renewal goroutine and tombstones the underlying
 // lease. After Lost() has been signaled, Release is best-effort cleanup; a
 // nil return does not mean the caller retained ownership until release.
+// Callers that care about the lost-lease case can branch on
+// lease.ErrLeaseLost via errors.Is.
 func (l *kvIndexStoreLock) Release() error {
 	ctx, cancel := context.WithTimeout(context.Background(), l.releaseTimeout)
 	defer cancel()
 	if err := l.mgr.Release(ctx, l.lease); err != nil {
-		// Releasing a lost lease is expected — surface it without wrapping
-		// so callers can branch on lease.ErrLeaseLost when they care.
-		if errors.Is(err, lease.ErrLeaseLost) {
-			return err
-		}
 		return fmt.Errorf("releasing lease: %w", err)
 	}
 	return nil

--- a/pkg/storage/unified/search/kv_remote_index_store.go
+++ b/pkg/storage/unified/search/kv_remote_index_store.go
@@ -1,0 +1,524 @@
+package search
+
+import (
+	"bytes"
+	"cmp"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/oklog/ulid/v2"
+
+	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/grafana/grafana/pkg/storage/unified/resource/kv"
+	"github.com/grafana/grafana/pkg/storage/unified/resource/lease"
+)
+
+const (
+	// IndexSnapshotManifestSection is the KV section under which
+	// KVRemoteIndexStore stores snapshot manifests. Separate from the
+	// data section so listing complete snapshots only requires scanning
+	// manifest keys (one per snapshot) rather than every data file key.
+	IndexSnapshotManifestSection = "index-snapshot-manifest"
+
+	// IndexSnapshotDataSection is the KV section under which
+	// KVRemoteIndexStore stores per-file snapshot data.
+	IndexSnapshotDataSection = "index-snapshot-data"
+
+	// defaultKVLockTTL matches BucketRemoteIndexStore's default lock TTL.
+	defaultKVLockTTL = 3 * time.Minute
+
+	// defaultKVReleaseTimeout bounds the lease release call when the caller
+	// invokes Release() on an IndexStoreLock without an explicit timeout.
+	defaultKVReleaseTimeout = 30 * time.Second
+
+	// kvDeleteBatchSize matches kv.MaxBatchOps. BatchDelete itself is not
+	// atomic on most backends, but we still chunk to keep individual calls
+	// small.
+	kvDeleteBatchSize = kv.MaxBatchOps
+)
+
+// KVRemoteIndexStoreConfig configures NewKVRemoteIndexStore.
+type KVRemoteIndexStoreConfig struct {
+	// KV is the store used for snapshot data and manifests. Required.
+	KV kv.KV
+
+	// LeaseManager is used to acquire build and cleanup locks. The store does
+	// not own the manager: callers wire a single manager per process and pass
+	// it in here. Required.
+	LeaseManager *lease.Manager
+
+	// BuildLock / CleanupLock control the lease TTL and shutdown timing of
+	// build and cleanup locks. Zero values fall back to defaults.
+	BuildLock   LockOptions
+	CleanupLock LockOptions
+}
+
+// KVRemoteIndexStore implements RemoteIndexStore on top of a kv.KV.
+//
+// Data and manifests live in separate KV sections
+// (IndexSnapshotManifestSection and IndexSnapshotDataSection) so that
+// per-resource listing of complete snapshots (ListIndexKeys) can scan one
+// key per snapshot rather than every data-file key. Discovery of
+// namespaces and resources (ListNamespaces, ListNamespaceResources)
+// still scans the data section so namespaces or resources whose only
+// snapshots are incomplete uploads remain visible to the cleanup pass.
+//
+// Layout:
+//
+//	IndexSnapshotManifestSection
+//	    <namespace>/<resource>.<group>/<index-key>
+//	    One value per snapshot; written last. Its presence is the
+//	    snapshot completion signal, matching BucketRemoteIndexStore's
+//	    contract.
+//
+//	IndexSnapshotDataSection
+//	    <namespace>/<resource>.<group>/<index-key>/<relPath>
+//	    One value per data file.
+//
+// Locks live in kv.LeasesSection (managed by lease.Manager), so snapshot
+// keys and lease keys never overlap.
+//
+// Each data file is stored as a single KV value. Transparent chunking for
+// files larger than the backend's per-value limit is not yet implemented.
+//
+// Known limitation: because ListIndexKeys lists only the manifest section,
+// CleanupIncompleteIndexSnapshots cannot detect incomplete uploads (data
+// files written without a manifest) on this backend. Detection of incomplete
+// uploads will eventually move into the backend so the helper can work
+// correctly here too.
+type KVRemoteIndexStore struct {
+	store           kv.KV
+	leaseMgr        *lease.Manager
+	buildLockOpts   LockOptions
+	cleanupLockOpts LockOptions
+	log             log.Logger
+}
+
+// NewKVRemoteIndexStore creates a KVRemoteIndexStore from cfg. Returns an
+// error if any required field is missing.
+func NewKVRemoteIndexStore(cfg KVRemoteIndexStoreConfig) (*KVRemoteIndexStore, error) {
+	if cfg.KV == nil {
+		return nil, fmt.Errorf("kv store is required")
+	}
+	if cfg.LeaseManager == nil {
+		return nil, fmt.Errorf("lease manager is required")
+	}
+	return &KVRemoteIndexStore{
+		store:           cfg.KV,
+		leaseMgr:        cfg.LeaseManager,
+		buildLockOpts:   cfg.BuildLock,
+		cleanupLockOpts: cfg.CleanupLock,
+		log:             log.New("kv-remote-index-store"),
+	}, nil
+}
+
+// kvResourceSubPath returns the per-resource path used as a prefix in both
+// snapshot KV sections. Unlike the bucket store's resourceSubPath (which
+// applies cleanFileSegment for filesystem safety), this version preserves
+// the input verbatim so namespaces and groups round-trip exactly through
+// listing. Inputs are guarded by validateNsResource at the public boundary.
+func kvResourceSubPath(ns resource.NamespacedResource) string {
+	return ns.Namespace + "/" + ns.Resource + "." + ns.Group
+}
+
+// kvDataPrefix returns the data-section key prefix shared by all files of a
+// single snapshot.
+func kvDataPrefix(ns resource.NamespacedResource, indexKey ulid.ULID) string {
+	return kvResourceSubPath(ns) + "/" + indexKey.String() + "/"
+}
+
+// kvResourcePrefix returns the key prefix (used in either section) under
+// which all snapshots for a namespaced resource live.
+func kvResourcePrefix(ns resource.NamespacedResource) string {
+	return kvResourceSubPath(ns) + "/"
+}
+
+// kvNamespacePrefix returns the key prefix (used in either section) under
+// which all resources for a namespace live.
+func kvNamespacePrefix(namespace string) string {
+	return namespace + "/"
+}
+
+func (s *KVRemoteIndexStore) dataKey(ns resource.NamespacedResource, indexKey ulid.ULID, relPath string) string {
+	return kvDataPrefix(ns, indexKey) + relPath
+}
+
+// manifestKey returns the key for a snapshot's manifest in the manifest
+// section. Note: no `/manifest` suffix is needed because the manifest
+// section stores one value per snapshot.
+func (s *KVRemoteIndexStore) manifestKey(ns resource.NamespacedResource, indexKey ulid.ULID) string {
+	return kvResourceSubPath(ns) + "/" + indexKey.String()
+}
+
+// validateNamespace ensures namespace is safe to embed as a single KV path
+// segment: non-empty, KV-key-safe, and free of characters that would
+// confuse the path parser (`/`) or collide with the lease package's
+// generation separator (`~`).
+func validateNamespace(namespace string) error {
+	if namespace == "" {
+		return fmt.Errorf("namespace must not be empty")
+	}
+	if strings.ContainsAny(namespace, "/~") {
+		return fmt.Errorf("namespace %q must not contain '/' or '~'", namespace)
+	}
+	if !kv.IsValidKey(namespace) {
+		return fmt.Errorf("namespace %q contains characters not allowed in KV keys", namespace)
+	}
+	return nil
+}
+
+// validateNsResource ensures the namespaced resource fields can be embedded
+// in KV keys with exact round-trip. The layout uses '/' as the path
+// separator and splits <resource>.<group> on the first '.', so resource
+// must not contain '.', and neither resource nor group may contain '/' or
+// '~'.
+func validateNsResource(ns resource.NamespacedResource) error {
+	if err := validateNamespace(ns.Namespace); err != nil {
+		return err
+	}
+	if ns.Resource == "" {
+		return fmt.Errorf("resource must not be empty")
+	}
+	if strings.ContainsAny(ns.Resource, "/.~") {
+		return fmt.Errorf("resource %q must not contain '/', '.', or '~'", ns.Resource)
+	}
+	if ns.Group == "" {
+		return fmt.Errorf("group must not be empty")
+	}
+	if strings.ContainsAny(ns.Group, "/~") {
+		return fmt.Errorf("group %q must not contain '/' or '~'", ns.Group)
+	}
+	if !kv.IsValidKey(ns.Resource + "." + ns.Group) {
+		return fmt.Errorf("resource %q and group %q contain characters not allowed in KV keys", ns.Resource, ns.Group)
+	}
+	return nil
+}
+
+// WriteSnapshotFile streams src into a single KV value at the per-file key
+// in the data section. Chunking for large files is not yet implemented.
+func (s *KVRemoteIndexStore) WriteSnapshotFile(ctx context.Context, nsResource resource.NamespacedResource, indexKey ulid.ULID, relPath string, src *os.File) error {
+	if err := validateNsResource(nsResource); err != nil {
+		return err
+	}
+	w, err := s.store.Save(ctx, IndexSnapshotDataSection, s.dataKey(nsResource, indexKey, relPath))
+	if err != nil {
+		return fmt.Errorf("opening kv writer for %s: %w", relPath, err)
+	}
+	if _, err := io.Copy(w, src); err != nil {
+		_ = w.Close()
+		return fmt.Errorf("writing snapshot file %s: %w", relPath, err)
+	}
+	if err := w.Close(); err != nil {
+		return fmt.Errorf("closing kv writer for %s: %w", relPath, err)
+	}
+	return nil
+}
+
+// ReadSnapshotFile streams the KV value at the per-file key in the data
+// section into dst, capping the transfer at expectedSize+1 bytes so a
+// misadvertised size cannot transfer unbounded data. Returns
+// ErrSnapshotNotFound if the key is absent.
+func (s *KVRemoteIndexStore) ReadSnapshotFile(ctx context.Context, nsResource resource.NamespacedResource, indexKey ulid.ULID, relPath string, dst *os.File, expectedSize int64) error {
+	if err := validateNsResource(nsResource); err != nil {
+		return err
+	}
+	rc, err := s.store.Get(ctx, IndexSnapshotDataSection, s.dataKey(nsResource, indexKey, relPath))
+	if err != nil {
+		if errors.Is(err, kv.ErrNotFound) {
+			return ErrSnapshotNotFound
+		}
+		return fmt.Errorf("reading snapshot file %s: %w", relPath, err)
+	}
+	defer func() { _ = rc.Close() }()
+
+	// Read one extra byte so we can detect oversized objects without a
+	// second round trip.
+	n, err := io.Copy(dst, io.LimitReader(rc, expectedSize+1))
+	if err != nil {
+		return fmt.Errorf("copying snapshot file %s: %w", relPath, err)
+	}
+	if n > expectedSize {
+		return fmt.Errorf("remote object %s exceeds expected size %d: %w", relPath, expectedSize, resource.ErrWriteLimitExceeded)
+	}
+	return nil
+}
+
+// WriteSnapshotManifest stores the manifest as a single KV value in the
+// manifest section. Its presence is the snapshot completion signal.
+func (s *KVRemoteIndexStore) WriteSnapshotManifest(ctx context.Context, nsResource resource.NamespacedResource, indexKey ulid.ULID, manifest []byte) error {
+	if err := validateNsResource(nsResource); err != nil {
+		return err
+	}
+	w, err := s.store.Save(ctx, IndexSnapshotManifestSection, s.manifestKey(nsResource, indexKey))
+	if err != nil {
+		return fmt.Errorf("opening kv writer for manifest: %w", err)
+	}
+	if _, err := w.Write(manifest); err != nil {
+		_ = w.Close()
+		return fmt.Errorf("writing manifest: %w", err)
+	}
+	if err := w.Close(); err != nil {
+		return fmt.Errorf("closing kv writer for manifest: %w", err)
+	}
+	return nil
+}
+
+// ReadSnapshotManifest returns the manifest bytes for the given snapshot.
+// Returns ErrSnapshotNotFound if the manifest is absent, or an error
+// wrapping ErrInvalidManifest if it exceeds maxSnapshotManifestSize.
+func (s *KVRemoteIndexStore) ReadSnapshotManifest(ctx context.Context, nsResource resource.NamespacedResource, indexKey ulid.ULID) ([]byte, error) {
+	if err := validateNsResource(nsResource); err != nil {
+		return nil, err
+	}
+	rc, err := s.store.Get(ctx, IndexSnapshotManifestSection, s.manifestKey(nsResource, indexKey))
+	if err != nil {
+		if errors.Is(err, kv.ErrNotFound) {
+			return nil, ErrSnapshotNotFound
+		}
+		return nil, fmt.Errorf("reading manifest: %w", err)
+	}
+	defer func() { _ = rc.Close() }()
+
+	var buf bytes.Buffer
+	n, err := io.Copy(&buf, io.LimitReader(rc, maxSnapshotManifestSize+1))
+	if err != nil {
+		return nil, fmt.Errorf("copying manifest: %w", err)
+	}
+	if n > maxSnapshotManifestSize {
+		return nil, fmt.Errorf("%w: oversized snapshot manifest (>%d bytes)", ErrInvalidManifest, maxSnapshotManifestSize)
+	}
+	return buf.Bytes(), nil
+}
+
+// ListNamespaces returns the distinct namespaces that have any snapshot
+// data, complete or incomplete. Scans the data section so the cleanup
+// pass can reach a namespace whose only snapshots are partial uploads.
+func (s *KVRemoteIndexStore) ListNamespaces(ctx context.Context) ([]string, error) {
+	return listDistinctSegments(ctx, s.store, IndexSnapshotDataSection, "", func(seg string) (string, bool) {
+		return seg, seg != ""
+	})
+}
+
+// ListNamespaceResources returns the resources under the given namespace
+// that have any snapshot data, complete or incomplete. Scans the data
+// section so the cleanup pass can reach a resource whose only snapshots
+// are partial uploads.
+func (s *KVRemoteIndexStore) ListNamespaceResources(ctx context.Context, namespace string) ([]resource.NamespacedResource, error) {
+	if err := validateNamespace(namespace); err != nil {
+		return nil, err
+	}
+	return listDistinctSegments(ctx, s.store, IndexSnapshotDataSection, kvNamespacePrefix(namespace), func(seg string) (resource.NamespacedResource, bool) {
+		// `<resource>.<group>` — split on the first dot only; group may
+		// contain further dots (e.g. `dashboard.grafana.app`).
+		res, group, ok := strings.Cut(seg, ".")
+		if !ok || res == "" || group == "" {
+			return resource.NamespacedResource{}, false
+		}
+		return resource.NamespacedResource{
+			Namespace: namespace,
+			Resource:  res,
+			Group:     group,
+		}, true
+	})
+}
+
+// ListIndexKeys returns the ULID keys of all complete snapshots under
+// nsResource. Scans the manifest section directly, so incomplete uploads
+// (data files written without a manifest) are not surfaced.
+//
+// Note: this is a deliberate divergence from the contract documented on
+// RemoteIndexStore.ListIndexKeys ("may include incomplete uploads"). As a
+// consequence, CleanupIncompleteIndexSnapshots cannot detect incomplete
+// uploads on this backend until incomplete-upload detection is moved into
+// the backend itself.
+func (s *KVRemoteIndexStore) ListIndexKeys(ctx context.Context, nsResource resource.NamespacedResource) ([]ulid.ULID, error) {
+	if err := validateNsResource(nsResource); err != nil {
+		return nil, err
+	}
+	prefix := kvResourcePrefix(nsResource)
+	end := kv.PrefixRangeEnd(prefix)
+
+	var result []ulid.ULID
+	for key, err := range s.store.Keys(ctx, IndexSnapshotManifestSection, kv.ListOptions{StartKey: prefix, EndKey: end}) {
+		if err != nil {
+			return nil, err
+		}
+		// Manifest keys are flat: `<resourceSubPath>/<ULID>`, no trailing path.
+		ulidStr := strings.TrimPrefix(key, prefix)
+		u, err := ulid.Parse(ulidStr)
+		if err != nil {
+			// Defensive: skip non-ULID keys. Should not occur in practice.
+			continue
+		}
+		result = append(result, u)
+	}
+	return result, nil
+}
+
+// listDistinctSegments scans the given KV section for keys with the given
+// prefix and returns the distinct first path segment after prefix,
+// transformed via parse. Entries for which parse returns ok=false are
+// dropped.
+func listDistinctSegments[T any](ctx context.Context, store kv.KV, section, prefix string, parse func(seg string) (T, bool)) ([]T, error) {
+	opts := kv.ListOptions{StartKey: prefix}
+	if prefix != "" {
+		opts.EndKey = kv.PrefixRangeEnd(prefix)
+	}
+
+	seen := make(map[string]struct{})
+	var result []T
+	for key, err := range store.Keys(ctx, section, opts) {
+		if err != nil {
+			return nil, err
+		}
+		rest := strings.TrimPrefix(key, prefix)
+		seg, _, _ := strings.Cut(rest, "/")
+		if seg == "" {
+			continue
+		}
+		if _, ok := seen[seg]; ok {
+			continue
+		}
+		seen[seg] = struct{}{}
+		v, ok := parse(seg)
+		if !ok {
+			continue
+		}
+		result = append(result, v)
+	}
+	return result, nil
+}
+
+// DeleteIndex deletes the manifest first (so the snapshot stops being
+// listed as complete by ListIndexKeys), then batch-deletes the data files.
+func (s *KVRemoteIndexStore) DeleteIndex(ctx context.Context, nsResource resource.NamespacedResource, indexKey ulid.ULID) error {
+	if err := validateNsResource(nsResource); err != nil {
+		return err
+	}
+	if err := s.store.Delete(ctx, IndexSnapshotManifestSection, s.manifestKey(nsResource, indexKey)); err != nil {
+		return fmt.Errorf("deleting snapshot manifest: %w", err)
+	}
+
+	prefix := kvDataPrefix(nsResource, indexKey)
+	end := kv.PrefixRangeEnd(prefix)
+
+	// Collect all data-file keys first; iterating and deleting at the same
+	// time would invalidate the iterator on some backends.
+	var keys []string
+	for key, err := range s.store.Keys(ctx, IndexSnapshotDataSection, kv.ListOptions{StartKey: prefix, EndKey: end}) {
+		if err != nil {
+			return fmt.Errorf("listing keys for delete: %w", err)
+		}
+		keys = append(keys, key)
+	}
+
+	for batch := range slices.Chunk(keys, kvDeleteBatchSize) {
+		if err := s.store.BatchDelete(ctx, IndexSnapshotDataSection, batch); err != nil {
+			return fmt.Errorf("batch deleting snapshot files: %w", err)
+		}
+	}
+	return nil
+}
+
+// --- Locking ---
+
+// LockBuildIndex acquires the build/upload lease for the given resource and
+// build version. The lease is automatically renewed in the background while
+// it is held; if renewal fails (e.g. another holder takes over), Lost() is
+// signaled and Release() returns ErrLeaseLost.
+func (s *KVRemoteIndexStore) LockBuildIndex(ctx context.Context, nsResource resource.NamespacedResource, buildVersion string) (IndexStoreLock, error) {
+	if err := validateNsResource(nsResource); err != nil {
+		return nil, err
+	}
+	if buildVersion == "" {
+		return nil, fmt.Errorf("build version must not be empty")
+	}
+	return s.acquireLock(ctx, kvBuildLeaseName(nsResource, buildVersion), s.buildLockOpts)
+}
+
+// LockNamespaceForCleanup acquires the cleanup lease for the given namespace.
+// Uses a distinct key from LockBuildIndex so cleanup never blocks an in-flight
+// upload for any resource in the namespace.
+func (s *KVRemoteIndexStore) LockNamespaceForCleanup(ctx context.Context, namespace string) (IndexStoreLock, error) {
+	if err := validateNamespace(namespace); err != nil {
+		return nil, err
+	}
+	return s.acquireLock(ctx, kvCleanupLeaseName(namespace), s.cleanupLockOpts)
+}
+
+// Lease names use prefixes that identify what each lease is for. Listing
+// lease.Manager's section shows snapshot leases distinctly from other
+// users of the same KV (e.g. the storage backend's per-resource write
+// leases).
+const (
+	kvBuildLeasePrefix   = "index-snapshot-build"
+	kvCleanupLeasePrefix = "index-snapshot-cleanup"
+)
+
+// kvBuildLeaseName returns the lease name for a build/upload lock. The
+// build version is base64-encoded so version strings containing '/' or
+// other unusual characters don't break the lease-name shape.
+func kvBuildLeaseName(ns resource.NamespacedResource, buildVersion string) string {
+	return kvBuildLeasePrefix + "/" + kvResourceSubPath(ns) + "/" + versionLockSegment(buildVersion)
+}
+
+// kvCleanupLeaseName returns the lease name for a per-namespace cleanup lock.
+func kvCleanupLeaseName(namespace string) string {
+	return kvCleanupLeasePrefix + "/" + namespace
+}
+
+func (s *KVRemoteIndexStore) acquireLock(ctx context.Context, name string, opts LockOptions) (IndexStoreLock, error) {
+	ttl := cmp.Or(opts.TTL, defaultKVLockTTL)
+	releaseTimeout := cmp.Or(opts.ReleaseDeleteTimeout, defaultKVReleaseTimeout)
+
+	l, err := s.leaseMgr.Acquire(ctx, name, lease.WithTTL(ttl), lease.WithAutoRenew())
+	if err != nil {
+		return nil, fmt.Errorf("acquiring lease %q: %w", name, err)
+	}
+	return &kvIndexStoreLock{
+		mgr:            s.leaseMgr,
+		lease:          l,
+		releaseTimeout: releaseTimeout,
+	}, nil
+}
+
+// kvIndexStoreLock adapts *lease.Lease to the IndexStoreLock interface.
+//
+// Release uses a bounded background context so cancellation of the original
+// acquire context does not prevent a best-effort tombstone of the lease.
+// Lost() is forwarded directly from the underlying lease, which signals when
+// the lease has been observed as taken by another holder during auto-renew
+// or when the TTL has elapsed without successful renewal.
+type kvIndexStoreLock struct {
+	mgr            *lease.Manager
+	lease          *lease.Lease
+	releaseTimeout time.Duration
+}
+
+// Release stops the auto-renewal goroutine and tombstones the underlying
+// lease. After Lost() has been signaled, Release is best-effort cleanup; a
+// nil return does not mean the caller retained ownership until release.
+func (l *kvIndexStoreLock) Release() error {
+	ctx, cancel := context.WithTimeout(context.Background(), l.releaseTimeout)
+	defer cancel()
+	if err := l.mgr.Release(ctx, l.lease); err != nil {
+		// Releasing a lost lease is expected — surface it without wrapping
+		// so callers can branch on lease.ErrLeaseLost when they care.
+		if errors.Is(err, lease.ErrLeaseLost) {
+			return err
+		}
+		return fmt.Errorf("releasing lease: %w", err)
+	}
+	return nil
+}
+
+func (l *kvIndexStoreLock) Lost() <-chan struct{} {
+	return l.lease.Lost()
+}

--- a/pkg/storage/unified/search/kv_remote_index_store_test.go
+++ b/pkg/storage/unified/search/kv_remote_index_store_test.go
@@ -1,0 +1,753 @@
+package search
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/blevesearch/bleve/v2"
+	badger "github.com/dgraph-io/badger/v4"
+	"github.com/oklog/ulid/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/grafana/grafana/pkg/storage/unified/resource/kv"
+	"github.com/grafana/grafana/pkg/storage/unified/resource/lease"
+)
+
+// kvTestMinTTL is the lease TTL used by KV-store tests. Short enough that
+// lock contention tests don't waste real time, long enough that the
+// auto-renew loop's TTL/3 interval doesn't generate too much churn.
+const kvTestMinTTL = 200 * time.Millisecond
+
+func newTestBadgerKV(t *testing.T) kv.KV {
+	t.Helper()
+	db, err := badger.Open(badger.DefaultOptions("").WithInMemory(true).WithLogger(nil))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+	return kv.NewBadgerKV(db)
+}
+
+func newTestLeaseManager(t *testing.T, store kv.KV, holder string) *lease.Manager {
+	t.Helper()
+	mgr := lease.NewManager(store, holder, nil,
+		lease.WithInternalMinTTL(kvTestMinTTL),
+		lease.WithGarbageCollectionDisabled,
+	)
+	t.Cleanup(func() { mgr.Stop() })
+	return mgr
+}
+
+func newTestKVRemoteIndexStore(t *testing.T) *KVRemoteIndexStore {
+	t.Helper()
+	return newTestKVRemoteIndexStoreWithOwner(t, "test-owner")
+}
+
+func newTestKVRemoteIndexStoreWithOwner(t *testing.T, owner string) *KVRemoteIndexStore {
+	t.Helper()
+	store := newTestBadgerKV(t)
+	return newTestKVRemoteIndexStoreOn(t, store, owner)
+}
+
+func newTestKVRemoteIndexStoreOn(t *testing.T, store kv.KV, owner string) *KVRemoteIndexStore {
+	t.Helper()
+	mgr := newTestLeaseManager(t, store, owner)
+	s, err := NewKVRemoteIndexStore(KVRemoteIndexStoreConfig{
+		KV:           store,
+		LeaseManager: mgr,
+		BuildLock:    LockOptions{TTL: kvTestMinTTL},
+		CleanupLock:  LockOptions{TTL: kvTestMinTTL},
+	})
+	require.NoError(t, err)
+	return s
+}
+
+func TestKVRemoteIndexStore_New_RejectsInvalidConfig(t *testing.T) {
+	store := newTestBadgerKV(t)
+	mgr := newTestLeaseManager(t, store, "owner")
+
+	_, err := NewKVRemoteIndexStore(KVRemoteIndexStoreConfig{LeaseManager: mgr})
+	require.ErrorContains(t, err, "kv store is required")
+
+	_, err = NewKVRemoteIndexStore(KVRemoteIndexStoreConfig{KV: store})
+	require.ErrorContains(t, err, "lease manager is required")
+}
+
+// TestKVRemoteIndexStore_SectionsAreDistinct guards against accidentally
+// editing IndexSnapshotManifestSection / IndexSnapshotDataSection to the
+// same value, or to collide with kv.LeasesSection (which would let snapshot
+// data trample lease metadata).
+func TestKVRemoteIndexStore_SectionsAreDistinct(t *testing.T) {
+	sections := []string{
+		IndexSnapshotManifestSection,
+		IndexSnapshotDataSection,
+		kv.LeasesSection,
+	}
+	seen := map[string]struct{}{}
+	for _, s := range sections {
+		require.NotEmpty(t, s)
+		_, dup := seen[s]
+		require.False(t, dup, "section %q must be unique across snapshot and lease use", s)
+		seen[s] = struct{}{}
+	}
+}
+
+func TestKVRemoteIndexStore_UploadDownloadBleveIndex(t *testing.T) {
+	store := newTestKVRemoteIndexStore(t)
+	ctx := t.Context()
+	ns := newTestNsResource()
+
+	srcDir := createTestBleveIndex(t)
+	buildStart := time.Now().Add(-2 * time.Hour).UTC().Truncate(time.Second)
+	meta := IndexMeta{
+		BuildVersion:          "11.0.0",
+		LatestResourceVersion: 99,
+		BuildTime:             buildStart,
+	}
+
+	indexKey, err := UploadIndexSnapshot(ctx, store, ns, srcDir, meta, testLogger)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = store.DeleteIndex(ctx, ns, indexKey) })
+
+	destDir := filepath.Join(t.TempDir(), "downloaded")
+	gotMeta, err := DownloadIndexSnapshot(ctx, store, ns, indexKey, destDir)
+	require.NoError(t, err)
+	assert.Equal(t, meta.BuildVersion, gotMeta.BuildVersion)
+	assert.Equal(t, meta.LatestResourceVersion, gotMeta.LatestResourceVersion)
+	assert.True(t, gotMeta.BuildTime.Equal(buildStart))
+
+	// Open and query the downloaded index to confirm the data round-tripped.
+	idx, err := bleve.Open(destDir)
+	require.NoError(t, err)
+	count, err := idx.DocCount()
+	require.NoError(t, err)
+	assert.Equal(t, uint64(3), count)
+	result, err := idx.Search(bleve.NewSearchRequest(bleve.NewMatchQuery("Production")))
+	require.NoError(t, err)
+	assert.Equal(t, uint64(1), result.Total)
+	require.NoError(t, idx.Close())
+}
+
+func TestKVRemoteIndexStore_ListAndDeleteIndexes(t *testing.T) {
+	store := newTestKVRemoteIndexStore(t)
+	ctx := t.Context()
+	ns := newTestNsResource()
+
+	keys := make([]ulid.ULID, 0, 3)
+	for range 3 {
+		srcDir := createTestBleveIndex(t)
+		meta := IndexMeta{BuildVersion: "11.0.0", LatestResourceVersion: 10}
+		key, err := UploadIndexSnapshot(ctx, store, ns, srcDir, meta, testLogger)
+		require.NoError(t, err)
+		keys = append(keys, key)
+	}
+
+	indexes, err := ListIndexSnapshots(ctx, store, ns, testLogger)
+	require.NoError(t, err)
+	assert.Len(t, indexes, 3)
+	for _, key := range keys {
+		assert.Contains(t, indexes, key)
+	}
+
+	for _, key := range keys {
+		require.NoError(t, store.DeleteIndex(ctx, ns, key))
+	}
+
+	indexes, err = ListIndexSnapshots(ctx, store, ns, testLogger)
+	require.NoError(t, err)
+	assert.Empty(t, indexes)
+
+	// Confirm nothing was left behind under the snapshot prefix in either
+	// section for any of the keys.
+	for _, key := range keys {
+		assertNoDataKeys(t, store, ns, key)
+		assertNoManifestKey(t, store, ns, key)
+	}
+}
+
+func TestKVRemoteIndexStore_DeleteIndex_LargeFileCount(t *testing.T) {
+	// Exercises the BatchDelete chunking path: more files than kvDeleteBatchSize.
+	store := newTestKVRemoteIndexStore(t)
+	ctx := t.Context()
+	ns := newTestNsResource()
+	key := ulid.Make()
+
+	const fileCount = kvDeleteBatchSize*2 + 5
+	files := make(map[string]int64, fileCount)
+	for i := range fileCount {
+		rel := fmt.Sprintf("store/file-%03d", i)
+		files[rel] = 4
+		writeKVValue(t, store.store, IndexSnapshotDataSection, store.dataKey(ns, key, rel), []byte("data"))
+	}
+	metaBytes, err := json.Marshal(IndexMeta{BuildVersion: "11.0.0", Files: files})
+	require.NoError(t, err)
+	require.NoError(t, store.WriteSnapshotManifest(ctx, ns, key, metaBytes))
+
+	require.NoError(t, store.DeleteIndex(ctx, ns, key))
+	assertNoDataKeys(t, store, ns, key)
+	assertNoManifestKey(t, store, ns, key)
+}
+
+func TestKVRemoteIndexStore_ReadSnapshotManifest_MissingReturnsNotFound(t *testing.T) {
+	store := newTestKVRemoteIndexStore(t)
+	_, err := store.ReadSnapshotManifest(t.Context(), newTestNsResource(), ulid.Make())
+	require.ErrorIs(t, err, ErrSnapshotNotFound)
+}
+
+func TestKVRemoteIndexStore_ReadSnapshotFile_MissingReturnsNotFound(t *testing.T) {
+	store := newTestKVRemoteIndexStore(t)
+	err := store.ReadSnapshotFile(t.Context(), newTestNsResource(), ulid.Make(), "store/missing", newTempOSFile(t), 100)
+	require.ErrorIs(t, err, ErrSnapshotNotFound)
+}
+
+func TestKVRemoteIndexStore_ReadSnapshotFile_OversizedFails(t *testing.T) {
+	store := newTestKVRemoteIndexStore(t)
+	ns := newTestNsResource()
+	key := ulid.Make()
+
+	// Plant a 100-byte value but advertise it as 10.
+	const advertised = 10
+	writeKVValue(t, store.store, IndexSnapshotDataSection, store.dataKey(ns, key, "store/root.bolt"), bytes.Repeat([]byte("x"), 100))
+
+	err := store.ReadSnapshotFile(t.Context(), ns, key, "store/root.bolt", newTempOSFile(t), advertised)
+	require.Error(t, err)
+	require.ErrorIs(t, err, resource.ErrWriteLimitExceeded)
+}
+
+func TestKVRemoteIndexStore_DownloadRejectsOversizedFile(t *testing.T) {
+	// End-to-end version: an oversized data file must fail through the
+	// DownloadIndexSnapshot helper, exposing ErrWriteLimitExceeded.
+	store := newTestKVRemoteIndexStore(t)
+	ctx := t.Context()
+	ns := newTestNsResource()
+	key := ulid.Make()
+
+	const advertised = 10
+	meta := IndexMeta{
+		BuildVersion: "11.0.0",
+		Files:        map[string]int64{"store/root.bolt": advertised},
+	}
+	metaBytes, err := json.Marshal(meta)
+	require.NoError(t, err)
+	require.NoError(t, store.WriteSnapshotManifest(ctx, ns, key, metaBytes))
+
+	writeKVValue(t, store.store, IndexSnapshotDataSection, store.dataKey(ns, key, "store/root.bolt"), bytes.Repeat([]byte("x"), advertised*1000))
+
+	_, err = DownloadIndexSnapshot(ctx, store, ns, key, filepath.Join(t.TempDir(), "dl"))
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "exceeds expected size")
+}
+
+func TestKVRemoteIndexStore_ListNamespaces(t *testing.T) {
+	store := newTestKVRemoteIndexStore(t)
+	ctx := t.Context()
+
+	for _, ns := range []string{"stack-1", "stack-2", "stack-3"} {
+		nsRes := resource.NamespacedResource{Namespace: ns, Group: "dashboard.grafana.app", Resource: "dashboards"}
+		_, err := UploadIndexSnapshot(ctx, store, nsRes, createTestBleveIndex(t),
+			IndexMeta{BuildVersion: "11.0.0", LatestResourceVersion: 1}, testLogger)
+		require.NoError(t, err)
+	}
+
+	got, err := store.ListNamespaces(ctx)
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"stack-1", "stack-2", "stack-3"}, got)
+}
+
+func TestKVRemoteIndexStore_ListNamespaces_Empty(t *testing.T) {
+	store := newTestKVRemoteIndexStore(t)
+	got, err := store.ListNamespaces(t.Context())
+	require.NoError(t, err)
+	assert.Empty(t, got)
+}
+
+func TestKVRemoteIndexStore_ListNamespaceResources(t *testing.T) {
+	store := newTestKVRemoteIndexStore(t)
+	ctx := t.Context()
+
+	resources := []resource.NamespacedResource{
+		{Namespace: "stack-1", Group: "dashboard.grafana.app", Resource: "dashboards"},
+		{Namespace: "stack-1", Group: "folder.grafana.app", Resource: "folders"},
+		{Namespace: "stack-2", Group: "dashboard.grafana.app", Resource: "dashboards"},
+	}
+	for _, r := range resources {
+		_, err := UploadIndexSnapshot(ctx, store, r, createTestBleveIndex(t),
+			IndexMeta{BuildVersion: "11.0.0", LatestResourceVersion: 1}, testLogger)
+		require.NoError(t, err)
+	}
+
+	got, err := store.ListNamespaceResources(ctx, "stack-1")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []resource.NamespacedResource{
+		{Namespace: "stack-1", Group: "dashboard.grafana.app", Resource: "dashboards"},
+		{Namespace: "stack-1", Group: "folder.grafana.app", Resource: "folders"},
+	}, got)
+
+	got, err = store.ListNamespaceResources(ctx, "stack-2")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []resource.NamespacedResource{
+		{Namespace: "stack-2", Group: "dashboard.grafana.app", Resource: "dashboards"},
+	}, got)
+}
+
+func TestKVRemoteIndexStore_ListIndexKeys_SkipsNonULID(t *testing.T) {
+	store := newTestKVRemoteIndexStore(t)
+	ctx := t.Context()
+	ns := newTestNsResource()
+
+	indexKey, err := UploadIndexSnapshot(ctx, store, ns, createTestBleveIndex(t),
+		IndexMeta{BuildVersion: "11.0.0", LatestResourceVersion: 1}, testLogger)
+	require.NoError(t, err)
+
+	// Plant a sibling in the manifest section whose final segment is not a
+	// ULID. Shouldn't occur in production, but we want ListIndexKeys to be
+	// defensive: parse failures must not abort the listing.
+	writeKVValue(t, store.store, IndexSnapshotManifestSection, kvResourcePrefix(ns)+"not-a-ulid", []byte("x"))
+
+	keys, err := store.ListIndexKeys(ctx, ns)
+	require.NoError(t, err)
+	assert.Equal(t, []ulid.ULID{indexKey}, keys)
+}
+
+// TestKVRemoteIndexStore_ListingSemantics pins down the divergent semantics
+// of the two listing paths:
+//
+//   - ListIndexKeys reads the manifest section and returns ONLY complete
+//     snapshots (deliberate divergence from the bucket store's "may include
+//     incomplete" contract).
+//   - ListNamespaces / ListNamespaceResources read the data section and
+//     return ALL namespaces / resources that have any snapshot data
+//     (complete or incomplete), so the cleanup pass can still reach
+//     namespaces whose only snapshots are partial uploads.
+//
+// Two scenarios cover the cases that matter: a namespace with both kinds
+// of snapshots, and a namespace with only incomplete uploads.
+func TestKVRemoteIndexStore_ListingSemantics(t *testing.T) {
+	store := newTestKVRemoteIndexStore(t)
+	ctx := t.Context()
+
+	nsMixed := newTestNsResource()
+	completeKey, err := UploadIndexSnapshot(ctx, store, nsMixed, createTestBleveIndex(t),
+		IndexMeta{BuildVersion: "11.0.0", LatestResourceVersion: 1}, testLogger)
+	require.NoError(t, err)
+	seedIncompleteSnapshot(t, store, nsMixed, ulid.Make())
+
+	nsOrphansOnly := resource.NamespacedResource{
+		Namespace: "orphans-only",
+		Group:     "dashboard.grafana.app",
+		Resource:  "dashboards",
+	}
+	seedIncompleteSnapshot(t, store, nsOrphansOnly, ulid.Make())
+
+	t.Run("ListIndexKeys returns only complete snapshots", func(t *testing.T) {
+		keys, err := store.ListIndexKeys(ctx, nsMixed)
+		require.NoError(t, err)
+		assert.Equal(t, []ulid.ULID{completeKey}, keys)
+
+		keys, err = store.ListIndexKeys(ctx, nsOrphansOnly)
+		require.NoError(t, err)
+		assert.Empty(t, keys, "a namespace with only incomplete uploads must not surface any ULIDs")
+	})
+
+	t.Run("ListNamespaces includes namespaces with only incomplete uploads", func(t *testing.T) {
+		namespaces, err := store.ListNamespaces(ctx)
+		require.NoError(t, err)
+		assert.Contains(t, namespaces, nsMixed.Namespace)
+		assert.Contains(t, namespaces, nsOrphansOnly.Namespace)
+	})
+
+	t.Run("ListNamespaceResources includes resources with only incomplete uploads", func(t *testing.T) {
+		resources, err := store.ListNamespaceResources(ctx, nsMixed.Namespace)
+		require.NoError(t, err)
+		assert.Contains(t, resources, nsMixed)
+
+		resources, err = store.ListNamespaceResources(ctx, nsOrphansOnly.Namespace)
+		require.NoError(t, err)
+		assert.Contains(t, resources, nsOrphansOnly)
+	})
+}
+
+// TestKVRemoteIndexStore_CleanupIncompleteIndexSnapshots_KnownBroken
+// documents a known limitation of the KV backend:
+// CleanupIncompleteIndexSnapshots cannot detect incomplete uploads because
+// ListIndexKeys only lists the manifest section. Once incomplete-upload
+// detection moves into the backend, this test should be replaced with a
+// real cleanup test.
+func TestKVRemoteIndexStore_CleanupIncompleteIndexSnapshots_KnownBroken(t *testing.T) {
+	store := newTestKVRemoteIndexStore(t)
+	ns := newTestNsResource()
+
+	incompleteKey := ulid.Make()
+	planted := seedIncompleteSnapshot(t, store, ns, incompleteKey)
+
+	cleaned, err := CleanupIncompleteIndexSnapshots(t.Context(), store, ns, time.Now(), testLogger)
+	require.NoError(t, err)
+	assert.Equal(t, 0, cleaned, "incomplete uploads are not currently detected on the KV backend")
+
+	leftover := collectDataKeys(t, store, ns, incompleteKey)
+	assert.Len(t, leftover, len(planted), "orphaned data files remain on the KV backend; cleanup of incomplete uploads is not yet implemented here")
+}
+
+// --- Locking ---
+
+func TestKVRemoteIndexStore_LockBuildIndex_AcquireRelease(t *testing.T) {
+	store := newTestKVRemoteIndexStore(t)
+
+	lock, err := store.LockBuildIndex(t.Context(), newTestNsResource(), "11.5.0")
+	require.NoError(t, err)
+	select {
+	case <-lock.Lost():
+		t.Fatal("lock should not be lost")
+	default:
+	}
+	require.NoError(t, lock.Release())
+}
+
+func TestKVRemoteIndexStore_LockBuildIndex_Contention(t *testing.T) {
+	backing := newTestBadgerKV(t)
+	ctx := t.Context()
+	ns := newTestNsResource()
+
+	store1 := newTestKVRemoteIndexStoreOn(t, backing, "instance-1")
+	store2 := newTestKVRemoteIndexStoreOn(t, backing, "instance-2")
+
+	lock1, err := store1.LockBuildIndex(ctx, ns, "11.5.0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = lock1.Release() })
+
+	_, err = store2.LockBuildIndex(ctx, ns, "11.5.0")
+	require.Error(t, err)
+	require.ErrorIs(t, err, lease.ErrLeaseAlreadyHeld)
+
+	require.NoError(t, lock1.Release())
+
+	// After release, the next acquisition succeeds. The lease key is updated
+	// (the tombstoned entry is still present, but Acquire sees it as not
+	// valid as-of now), so we expect a fresh lock.
+	lock2, err := store2.LockBuildIndex(ctx, ns, "11.5.0")
+	require.NoError(t, err)
+	require.NoError(t, lock2.Release())
+}
+
+func TestKVRemoteIndexStore_LockBuildIndex_VersionScoped(t *testing.T) {
+	backing := newTestBadgerKV(t)
+	ctx := t.Context()
+	ns := newTestNsResource()
+
+	store1 := newTestKVRemoteIndexStoreOn(t, backing, "instance-1")
+	store2 := newTestKVRemoteIndexStoreOn(t, backing, "instance-2")
+
+	lock1, err := store1.LockBuildIndex(ctx, ns, "11.5.0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = lock1.Release() })
+
+	// Different build version is a distinct key, so it's acquirable.
+	lock2, err := store2.LockBuildIndex(ctx, ns, "11.6.0")
+	require.NoError(t, err)
+	require.NoError(t, lock2.Release())
+}
+
+func TestKVRemoteIndexStore_LockBuildIndex_RequiresBuildVersion(t *testing.T) {
+	store := newTestKVRemoteIndexStore(t)
+	_, err := store.LockBuildIndex(t.Context(), newTestNsResource(), "")
+	require.Error(t, err)
+}
+
+func TestKVRemoteIndexStore_LockNamespaceForCleanup_DistinctFromBuildLock(t *testing.T) {
+	store := newTestKVRemoteIndexStore(t)
+	ctx := t.Context()
+	ns := newTestNsResource()
+
+	cleanupLock, err := store.LockNamespaceForCleanup(ctx, ns.Namespace)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = cleanupLock.Release() })
+
+	buildLock, err := store.LockBuildIndex(ctx, ns, "11.5.0")
+	require.NoError(t, err)
+	require.NoError(t, buildLock.Release())
+}
+
+func TestKVRemoteIndexStore_LockNamespaceForCleanup_Contention(t *testing.T) {
+	backing := newTestBadgerKV(t)
+	ctx := t.Context()
+
+	store1 := newTestKVRemoteIndexStoreOn(t, backing, "instance-1")
+	store2 := newTestKVRemoteIndexStoreOn(t, backing, "instance-2")
+
+	lock1, err := store1.LockNamespaceForCleanup(ctx, "stack-1")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = lock1.Release() })
+
+	_, err = store2.LockNamespaceForCleanup(ctx, "stack-1")
+	require.ErrorIs(t, err, lease.ErrLeaseAlreadyHeld)
+
+	// Different namespace must be acquirable independently.
+	lock2, err := store2.LockNamespaceForCleanup(ctx, "stack-2")
+	require.NoError(t, err)
+	require.NoError(t, lock2.Release())
+}
+
+// TestKVRemoteIndexStore_LockBuildIndex_LossOnExpiry confirms that an
+// expired auto-renewed lease (here, because a competing holder takes over)
+// is surfaced through the IndexStoreLock's Lost() channel.
+func TestKVRemoteIndexStore_LockBuildIndex_LossOnExpiry(t *testing.T) {
+	backing := newTestBadgerKV(t)
+	ctx := t.Context()
+	ns := newTestNsResource()
+
+	// Two managers sharing the same KV — distinct holders.
+	mgr1 := newTestLeaseManager(t, backing, "instance-1")
+	mgr2 := newTestLeaseManager(t, backing, "instance-2")
+
+	// Acquire via mgr1 without auto-renew so we can let it expire and have
+	// mgr2 take over. We bypass the store's helper and use mgr1 directly so
+	// we control auto-renew. The store's lock plumbing is exercised by the
+	// other tests; here we're verifying Lost() wiring on a kvIndexStoreLock
+	// wrapping a real lost lease.
+	name := buildIndexLockKey(ns, "11.5.0")
+	l1, err := mgr1.Acquire(ctx, name, lease.WithTTL(kvTestMinTTL))
+	require.NoError(t, err)
+
+	// Wait until the lease expires from mgr1's perspective.
+	time.Sleep(kvTestMinTTL * 3 / 2)
+
+	// mgr2 acquires the same lease, with auto-renew. Wrap it in our adapter
+	// to confirm Lost() is plumbed through.
+	l2, err := mgr2.Acquire(ctx, name, lease.WithTTL(kvTestMinTTL), lease.WithAutoRenew())
+	require.NoError(t, err)
+	adapter := &kvIndexStoreLock{
+		mgr:            mgr2,
+		lease:          l2,
+		releaseTimeout: defaultKVReleaseTimeout,
+	}
+	t.Cleanup(func() { _ = adapter.Release() })
+
+	// mgr1's lease was expired before mgr2 took over; releasing it should
+	// return ErrLeaseLost (no auto-renew, so notifyLoss happens on Release).
+	err = mgr1.Release(ctx, l1)
+	require.ErrorIs(t, err, lease.ErrLeaseLost)
+
+	// adapter (mgr2) is still healthy.
+	select {
+	case <-adapter.Lost():
+		t.Fatal("mgr2's lock should not be lost yet")
+	default:
+	}
+}
+
+// TestKVIndexStoreLock_Release_AfterRevocation confirms the adapter's
+// Release surfaces ErrLeaseLost when the underlying lease has been
+// revoked out-of-band.
+func TestKVIndexStoreLock_Release_AfterRevocation(t *testing.T) {
+	backing := newTestBadgerKV(t)
+	ctx := t.Context()
+
+	mgr1 := newTestLeaseManager(t, backing, "instance-1")
+	mgr2 := newTestLeaseManager(t, backing, "instance-2")
+
+	name := "test/revoke"
+
+	l1, err := mgr1.Acquire(ctx, name, lease.WithTTL(kvTestMinTTL))
+	require.NoError(t, err)
+	adapter := &kvIndexStoreLock{
+		mgr:            mgr1,
+		lease:          l1,
+		releaseTimeout: defaultKVReleaseTimeout,
+	}
+
+	// Wait out the TTL, then have mgr2 take over.
+	time.Sleep(kvTestMinTTL * 3 / 2)
+	l2, err := mgr2.Acquire(ctx, name, lease.WithTTL(kvTestMinTTL))
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = mgr2.Release(ctx, l2) })
+
+	// Releasing the original adapter returns ErrLeaseLost, unwrapped.
+	err = adapter.Release()
+	require.ErrorIs(t, err, lease.ErrLeaseLost)
+}
+
+// TestKVLeaseNames_Valid confirms that the KV store's lease-name helpers
+// produce names accepted by lease.Manager.Acquire. The lease package rejects
+// names that fail kv.IsValidKey, contain `~`, or start with `lease-internal/`.
+func TestKVLeaseNames_Valid(t *testing.T) {
+	store := newTestKVRemoteIndexStore(t)
+
+	buildTests := []struct {
+		name         string
+		ns           resource.NamespacedResource
+		buildVersion string
+	}{
+		{"plain", newTestNsResource(), "11.5.0"},
+		{"semver with plus and slash", newTestNsResource(), "v11.5.0+security/branch"},
+		{"dotted group", resource.NamespacedResource{
+			Namespace: "stack-1",
+			Group:     "alerting.notifications.grafana.app",
+			Resource:  "templates",
+		}, "11.5.0"},
+	}
+	for _, tt := range buildTests {
+		t.Run("build/"+tt.name, func(t *testing.T) {
+			name := kvBuildLeaseName(tt.ns, tt.buildVersion)
+			assert.True(t, kv.IsValidKey(name), "lease name %q must satisfy kv.IsValidKey", name)
+			assert.NotContains(t, name, "~", "lease name %q must not contain ~", name)
+			assert.True(t, strings.HasPrefix(name, kvBuildLeasePrefix+"/"), "lease name %q should be identifiable by prefix", name)
+
+			// Must round-trip through Acquire successfully.
+			lock, err := store.LockBuildIndex(t.Context(), tt.ns, tt.buildVersion)
+			require.NoError(t, err)
+			require.NoError(t, lock.Release())
+		})
+	}
+
+	for _, ns := range []string{"stack-1", "default"} {
+		t.Run("cleanup/"+ns, func(t *testing.T) {
+			name := kvCleanupLeaseName(ns)
+			assert.True(t, kv.IsValidKey(name), "lease name %q must satisfy kv.IsValidKey", name)
+			assert.NotContains(t, name, "~", "lease name %q must not contain ~", name)
+			assert.True(t, strings.HasPrefix(name, kvCleanupLeasePrefix+"/"), "lease name %q should be identifiable by prefix", name)
+		})
+	}
+}
+
+// TestKVRemoteIndexStore_RejectsInvalidNsResource pins the validation at
+// public-method entry points: namespaces, resources, and groups that would
+// produce ambiguous or lossy KV keys must be rejected.
+func TestKVRemoteIndexStore_RejectsInvalidNsResource(t *testing.T) {
+	store := newTestKVRemoteIndexStore(t)
+	ctx := t.Context()
+
+	bad := []struct {
+		name string
+		ns   resource.NamespacedResource
+	}{
+		{"empty namespace", resource.NamespacedResource{Group: "g.app", Resource: "r"}},
+		{"slash in namespace", resource.NamespacedResource{Namespace: "a/b", Group: "g.app", Resource: "r"}},
+		{"tilde in namespace", resource.NamespacedResource{Namespace: "a~b", Group: "g.app", Resource: "r"}},
+		{"empty resource", resource.NamespacedResource{Namespace: "ns", Group: "g.app"}},
+		{"dot in resource", resource.NamespacedResource{Namespace: "ns", Resource: "a.b", Group: "g.app"}},
+		{"slash in resource", resource.NamespacedResource{Namespace: "ns", Resource: "a/b", Group: "g.app"}},
+		{"empty group", resource.NamespacedResource{Namespace: "ns", Resource: "r"}},
+		{"slash in group", resource.NamespacedResource{Namespace: "ns", Resource: "r", Group: "a/b"}},
+	}
+	for _, tt := range bad {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := store.ListIndexKeys(ctx, tt.ns)
+			require.Error(t, err)
+			_, err = store.ReadSnapshotManifest(ctx, tt.ns, ulid.Make())
+			require.Error(t, err)
+			err = store.DeleteIndex(ctx, tt.ns, ulid.Make())
+			require.Error(t, err)
+			_, err = store.LockBuildIndex(ctx, tt.ns, "11.0.0")
+			require.Error(t, err)
+		})
+	}
+
+	t.Run("slash in namespace via LockNamespaceForCleanup", func(t *testing.T) {
+		_, err := store.LockNamespaceForCleanup(ctx, "a/b")
+		require.Error(t, err)
+	})
+	t.Run("empty namespace via ListNamespaceResources", func(t *testing.T) {
+		_, err := store.ListNamespaceResources(ctx, "")
+		require.Error(t, err)
+	})
+}
+
+func TestIsRetryableSnapshotStoreError_KVErrRetryable(t *testing.T) {
+	// kv.ErrRetryable wraps a backend's transient error. Confirm
+	// isRetryableSnapshotStoreError treats both the sentinel itself and an
+	// error wrapping it as retryable.
+	ctx := t.Context()
+
+	assert.True(t, isRetryableSnapshotStoreError(ctx, kv.ErrRetryable))
+	assert.True(t, isRetryableSnapshotStoreError(ctx,
+		fmt.Errorf("fetching snapshot file: %w", kv.ErrRetryable)))
+
+	// Sanity-check that non-retryable errors still aren't retryable.
+	assert.False(t, isRetryableSnapshotStoreError(ctx, ErrSnapshotNotFound))
+	assert.False(t, isRetryableSnapshotStoreError(ctx, errors.New("plain error")))
+
+	// Cancelled context disables retries regardless of error.
+	cancelled, cancel := context.WithCancel(ctx)
+	cancel()
+	assert.False(t, isRetryableSnapshotStoreError(cancelled, kv.ErrRetryable))
+}
+
+// --- helpers ---
+
+// newTempOSFile returns a freshly-created *os.File in t.TempDir, closed by
+// t.Cleanup. Used as the destination for ReadSnapshotFile in tests.
+func newTempOSFile(t *testing.T) *os.File {
+	t.Helper()
+	f, err := os.CreateTemp(t.TempDir(), "kv-test-*")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = f.Close() })
+	return f
+}
+
+// writeKVValue stores data at (section, key) via the KV store's Save API.
+// Used by tests that need to plant values directly, bypassing the
+// RemoteIndexStore methods.
+func writeKVValue(t *testing.T, store kv.KV, section, key string, data []byte) {
+	t.Helper()
+	w, err := store.Save(t.Context(), section, key)
+	require.NoError(t, err)
+	_, err = w.Write(data)
+	require.NoError(t, err)
+	require.NoError(t, w.Close())
+}
+
+// orphanedSnapshotFiles is the canonical set of fake data-file paths used
+// by tests that simulate an interrupted upload.
+var orphanedSnapshotFiles = []string{"store/root.bolt", "store/00000001.zap"}
+
+// seedIncompleteSnapshot writes a few fake data files (no manifest) under
+// the given (ns, key) prefix, simulating an upload that crashed before the
+// completion signal was written. Returns the relative paths planted.
+func seedIncompleteSnapshot(t *testing.T, s *KVRemoteIndexStore, ns resource.NamespacedResource, key ulid.ULID) []string {
+	t.Helper()
+	for _, rel := range orphanedSnapshotFiles {
+		writeKVValue(t, s.store, IndexSnapshotDataSection, s.dataKey(ns, key, rel), []byte("orphaned"))
+	}
+	return orphanedSnapshotFiles
+}
+
+// collectDataKeys returns every key remaining under the given snapshot's
+// data-section prefix.
+func collectDataKeys(t *testing.T, s *KVRemoteIndexStore, ns resource.NamespacedResource, key ulid.ULID) []string {
+	t.Helper()
+	prefix := kvDataPrefix(ns, key)
+	var got []string
+	for k, err := range s.store.Keys(t.Context(), IndexSnapshotDataSection, kv.ListOptions{
+		StartKey: prefix,
+		EndKey:   kv.PrefixRangeEnd(prefix),
+	}) {
+		require.NoError(t, err)
+		got = append(got, k)
+	}
+	return got
+}
+
+// assertNoDataKeys fails the test if any key remains under the snapshot's
+// data-section prefix.
+func assertNoDataKeys(t *testing.T, s *KVRemoteIndexStore, ns resource.NamespacedResource, key ulid.ULID) {
+	t.Helper()
+	if got := collectDataKeys(t, s, ns, key); len(got) > 0 {
+		t.Fatalf("unexpected leftover data keys: %v", got)
+	}
+}
+
+// assertNoManifestKey fails the test if the manifest for the given snapshot
+// is still present.
+func assertNoManifestKey(t *testing.T, s *KVRemoteIndexStore, ns resource.NamespacedResource, key ulid.ULID) {
+	t.Helper()
+	_, err := s.store.Get(t.Context(), IndexSnapshotManifestSection, s.manifestKey(ns, key))
+	require.ErrorIs(t, err, kv.ErrNotFound, "manifest still present for %s", key)
+}

--- a/pkg/storage/unified/search/kv_remote_index_store_test.go
+++ b/pkg/storage/unified/search/kv_remote_index_store_test.go
@@ -357,14 +357,14 @@ func TestKVRemoteIndexStore_ListingSemantics(t *testing.T) {
 		assert.Empty(t, keys, "a namespace with only incomplete uploads must not surface any ULIDs")
 	})
 
-	t.Run("ListNamespaces includes namespaces with only incomplete uploads", func(t *testing.T) {
+	t.Run("ListNamespaces returns namespaces with complete or incomplete snapshots", func(t *testing.T) {
 		namespaces, err := store.ListNamespaces(ctx)
 		require.NoError(t, err)
 		assert.Contains(t, namespaces, nsMixed.Namespace)
 		assert.Contains(t, namespaces, nsOrphansOnly.Namespace)
 	})
 
-	t.Run("ListNamespaceResources includes resources with only incomplete uploads", func(t *testing.T) {
+	t.Run("ListNamespaceResources returns resources with complete or incomplete snapshots", func(t *testing.T) {
 		resources, err := store.ListNamespaceResources(ctx, nsMixed.Namespace)
 		require.NoError(t, err)
 		assert.Contains(t, resources, nsMixed)

--- a/pkg/storage/unified/search/remote_index_store.go
+++ b/pkg/storage/unified/search/remote_index_store.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/storage/unified/resource"
+	"github.com/grafana/grafana/pkg/storage/unified/resource/kv"
 )
 
 const (
@@ -261,6 +262,12 @@ func isRetryableSnapshotStoreError(ctx context.Context, err error) bool {
 	}
 	if errors.Is(err, ErrSnapshotNotFound) || errors.Is(err, ErrInvalidManifest) || errors.Is(err, resource.ErrWriteLimitExceeded) {
 		return false
+	}
+
+	// kv.ErrRetryable marks transient errors from KV backends (e.g. gRPC
+	// status codes, retryable filesystem errors) wrapped by KVRemoteIndexStore.
+	if errors.Is(err, kv.ErrRetryable) {
+		return true
 	}
 
 	switch gcerrors.Code(err) {


### PR DESCRIPTION
Part of the work to test index snapshots on a KV store; follow-up to #125531 (interface refactor).

Adds `KVRemoteIndexStore`, a `RemoteIndexStore` implementation backed by `kv.KV` (`pkg/storage/unified/resource/kv`) with build/cleanup locks via `lease.Manager` (`pkg/storage/unified/resource/lease`). Unit-tested against in-memory `badgerKV`. Not wired into production yet.

Each data file is stored as a single KV value. Transparent chunking comes in the next PR.

## Layout

Two KV sections so listing complete snapshots scans one key per snapshot:

- `index-snapshot-manifest`: `<namespace>/<resource>.<group>/<index-key>` → manifest bytes (written last; presence is the completion signal)
- `index-snapshot-data`: `<namespace>/<resource>.<group>/<index-key>/<relPath>` → one value per file

Lease names are prefixed (`index-snapshot-build/...`, `index-snapshot-cleanup/...`) so snapshot leases are identifiable alongside other `lease.Manager` users in `kv.LeasesSection`.

## Listing semantics

- `ListIndexKeys` scans the manifest section → only complete snapshots. Deliberate divergence from the bucket store's "may include incomplete" contract.
- `ListNamespaces` / `ListNamespaceResources` scan the data section so namespaces with only partial uploads stay visible to the cleanup loop.

## Known limitation

`CleanupIncompleteIndexSnapshots` cannot detect incomplete uploads on this backend, because per-resource cleanup goes through `ListIndexKeys` (manifests only). A follow-up PR will move incomplete-upload detection into the backend. Pinned by `TestKVRemoteIndexStore_CleanupIncompleteIndexSnapshots_KnownBroken`.

## Other

Namespace, resource, and group inputs are validated at every public entry point — anything that would produce lossy or ambiguous KV keys is rejected. `isRetryableSnapshotStoreError` now treats `kv.ErrRetryable` as retryable (folded in here since this is the first file in the package to import `kv`).
