### PR TITLE
[release-13.0.2] Provisioning: validate ref query parameter on files and history endpoints

### DIFF
--- a/apps/provisioning/pkg/repository/git/branch.go
+++ b/apps/provisioning/pkg/repository/git/branch.go
@@ -9,6 +9,22 @@ import (
 // it does not cover all cases as positive lookaheads are not supported in Go's regexp
 var basicGitBranchNameRegex = regexp.MustCompile(`^[a-zA-Z0-9\-\_\/\.]+$`)
 
+// commitHashRegex matches a 7–40 character hex string covering short and full git SHAs.
+var commitHashRegex = regexp.MustCompile(`^[0-9a-fA-F]{7,40}$`)
+
+// IsValidRef reports whether ref is a valid git ref to forward to a backend.
+// An empty ref is considered valid: callers default it to the configured branch.
+// A non-empty ref must be either a valid git branch name or a 7–40 char commit SHA.
+func IsValidRef(ref string) bool {
+	if ref == "" {
+		return true
+	}
+	if commitHashRegex.MatchString(ref) {
+		return true
+	}
+	return IsValidGitBranchName(ref)
+}
+
 // IsValidGitBranchName checks if a branch name is valid.
 // It uses the following regexp `^[a-zA-Z0-9\-\_\/\.]+$` to validate the branch name with some additional checks that must satisfy the following rules:
 // 1. The branch name must have at least one character and must not be empty.

--- a/apps/provisioning/pkg/repository/git/branch_test.go
+++ b/apps/provisioning/pkg/repository/git/branch_test.go
@@ -1,10 +1,74 @@
 package git
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
+
+func TestIsValidRef(t *testing.T) {
+	tests := []struct {
+		name string
+		ref  string
+		want bool
+	}{
+		// Empty: callers default to the configured branch downstream.
+		{"empty", "", true},
+
+		// Valid branch names.
+		{"simple branch", "main", true},
+		{"branch with slash", "feature/my-branch", true},
+		{"branch with hyphen", "feature-x", true},
+		{"branch with underscore", "feature_x", true},
+		{"branch with dot", "v1.0", true},
+		{"release branch", "release/v2.10.3", true},
+
+		// Valid commit SHAs.
+		{"short sha 7 chars", "abc1234", true},
+		{"sha 8 chars", "abc12345", true},
+		{"full sha 40 chars", "abcdef0123456789abcdef0123456789abcdef01", true},
+		{"upper case sha", "ABCDEF0123456789ABCDEF0123456789ABCDEF01", true},
+		{"mixed case sha", "AbCdEf0123456789", true},
+
+		// Invalid: shell metacharacters and other dangerous chars.
+		{"shell injection semicolon", "main; rm -rf /", false},
+		{"shell injection pipe", "main|cat", false},
+		{"shell injection backtick", "main`whoami`", false},
+		{"shell injection dollar", "main$(whoami)", false},
+		{"shell injection ampersand", "main&", false},
+		{"space", "main branch", false},
+		{"colon", "main:foo", false},
+		{"question mark", "main?", false},
+		{"asterisk", "main*", false},
+		{"tilde", "main~1", false},
+		{"caret", "main^", false},
+		{"left bracket", "main[", false},
+		{"backslash", "main\\branch", false},
+
+		// Invalid: git branch naming rules.
+		{"leading slash", "/main", false},
+		{"trailing slash", "main/", false},
+		{"trailing dot", "main.", false},
+		{"double dots", "feature/..bad", false},
+		{"double slashes", "feature//bad", false},
+		{"trailing .lock", "feature.lock", false},
+
+		// Hex strings shorter than the SHA minimum still pass branch-name validation,
+		// so they are accepted as branches (callers cannot tell the difference and
+		// the backend resolves the ambiguity).
+		{"6-char hex is valid branch", "abcdef", true},
+		{"41-char hex is valid branch", strings.Repeat("a", 41), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsValidRef(tt.ref); got != tt.want {
+				t.Errorf("IsValidRef(%q) = %v, want %v", tt.ref, got, tt.want)
+			}
+		})
+	}
+}
 
 func TestIsValidGitBranchName(t *testing.T) {
 	tests := []struct {

--- a/apps/provisioning/pkg/repository/github/repository_test.go
+++ b/apps/provisioning/pkg/repository/github/repository_test.go
@@ -489,6 +489,78 @@ func TestGitHubRepositoryHistory(t *testing.T) {
 			},
 			expectedError: errors.New("get commits: API error"),
 		},
+		{
+			name: "valid branch name with slashes is accepted",
+			config: &provisioning.Repository{
+				Spec: provisioning.RepositorySpec{
+					GitHub: &provisioning.GitHubRepositoryConfig{
+						Branch: "main",
+						Path:   "dashboards",
+					},
+				},
+			},
+			path: "dashboard.json",
+			ref:  "feature/my-branch",
+			mockSetup: func(m *MockClient) {
+				m.On("Commits", mock.Anything, "grafana", "grafana", "dashboards/dashboard.json", "feature/my-branch").
+					Return([]Commit{}, nil)
+			},
+			expectedResult: []provisioning.HistoryItem{},
+		},
+		{
+			name: "valid short commit SHA is accepted",
+			config: &provisioning.Repository{
+				Spec: provisioning.RepositorySpec{
+					GitHub: &provisioning.GitHubRepositoryConfig{
+						Branch: "main",
+						Path:   "dashboards",
+					},
+				},
+			},
+			path: "dashboard.json",
+			ref:  "abc1234",
+			mockSetup: func(m *MockClient) {
+				m.On("Commits", mock.Anything, "grafana", "grafana", "dashboards/dashboard.json", "abc1234").
+					Return([]Commit{}, nil)
+			},
+			expectedResult: []provisioning.HistoryItem{},
+		},
+		{
+			name: "valid full commit SHA is accepted",
+			config: &provisioning.Repository{
+				Spec: provisioning.RepositorySpec{
+					GitHub: &provisioning.GitHubRepositoryConfig{
+						Branch: "main",
+						Path:   "dashboards",
+					},
+				},
+			},
+			path: "dashboard.json",
+			ref:  "abcdef0123456789abcdef0123456789abcdef01",
+			mockSetup: func(m *MockClient) {
+				m.On("Commits", mock.Anything, "grafana", "grafana", "dashboards/dashboard.json", "abcdef0123456789abcdef0123456789abcdef01").
+					Return([]Commit{}, nil)
+			},
+			expectedResult: []provisioning.HistoryItem{},
+		},
+		{
+			name: "6-char hex ref is treated as a valid branch name and forwarded",
+			config: &provisioning.Repository{
+				Spec: provisioning.RepositorySpec{
+					GitHub: &provisioning.GitHubRepositoryConfig{
+						Branch: "main",
+						Path:   "dashboards",
+					},
+				},
+			},
+			path: "dashboard.json",
+			ref:  "abcdef",
+			mockSetup: func(m *MockClient) {
+				m.On("Commits", mock.Anything, "grafana", "grafana", "dashboards/dashboard.json", "abcdef").
+					Return([]Commit{}, nil)
+			},
+			expectedResult: []provisioning.HistoryItem{},
+		},
 	}
 
 	for _, tt := range tests {

--- a/apps/provisioning/pkg/repository/repository.go
+++ b/apps/provisioning/pkg/repository/repository.go
@@ -76,6 +76,9 @@ var ErrTooManyItems error = &apierrors.StatusError{ErrStatus: metav1.Status{
 	Message: "maximum number of items exceeded",
 }}
 
+// ErrInvalidRef indicates that a provided git ref (branch or commit SHA) failed validation.
+var ErrInvalidRef = apierrors.NewBadRequest("invalid ref")
+
 type FileInfo struct {
 	// Path to the file on disk.
 	// No leading or trailing slashes will be contained within.

--- a/pkg/registry/apis/provisioning/files.go
+++ b/pkg/registry/apis/provisioning/files.go
@@ -17,6 +17,7 @@ import (
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/quotas"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
+	"github.com/grafana/grafana/apps/provisioning/pkg/repository/git"
 	"github.com/grafana/grafana/apps/provisioning/pkg/safepath"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/resources"
@@ -189,6 +190,12 @@ func (c *filesConnector) parseRequestOptions(r *http.Request, name string, repo 
 		SkipDryRun:   query.Get("skipDryRun") == "true",
 		OriginalPath: query.Get("originalPath"),
 		Branch:       repo.Config().Branch(),
+	}
+
+	// Reject unvalidated refs before they reach any backend. Empty is allowed and
+	// is defaulted to the configured branch downstream.
+	if !git.IsValidRef(opts.Ref) {
+		return opts, repository.ErrInvalidRef
 	}
 
 	path, err := pathAfterPrefix(r.URL.Path, fmt.Sprintf("/%s/files", name))

--- a/pkg/registry/apis/provisioning/files_test.go
+++ b/pkg/registry/apis/provisioning/files_test.go
@@ -322,3 +322,50 @@ func TestHandleMethodRequest_PutDirectoryRouting(t *testing.T) {
 		assert.True(t, apierrors.IsMethodNotSupported(err), "expected MethodNotSupported, got: %v", err)
 	})
 }
+
+func TestParseRequestOptionsRefValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		ref     string
+		wantErr bool
+	}{
+		{name: "empty ref is allowed", ref: ""},
+		{name: "valid branch name", ref: "main"},
+		{name: "valid branch with slash", ref: "feature/my-branch"},
+		{name: "valid short commit SHA", ref: "abc1234"},
+		{name: "valid full commit SHA", ref: "abcdef0123456789abcdef0123456789abcdef01"},
+		{name: "invalid ref with semicolon", ref: "main; rm -rf /", wantErr: true},
+		{name: "invalid ref with space", ref: "main branch", wantErr: true},
+		{name: "invalid ref with backtick", ref: "main`whoami`", wantErr: true},
+		{name: "invalid ref with double dots", ref: "feature/..bad", wantErr: true},
+		{name: "invalid ref with newline", ref: "main\nfoo", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockRepo := repository.NewMockRepository(t)
+			mockRepo.On("Config").Return(&provisioningapi.Repository{
+				Spec: provisioningapi.RepositorySpec{
+					Title: "test-repo",
+				},
+			}).Maybe()
+
+			connector := &filesConnector{}
+			r := httptest.NewRequest(http.MethodGet, "/test-repo/files/dashboard.json", nil)
+			if tt.ref != "" {
+				q := r.URL.Query()
+				q.Set("ref", tt.ref)
+				r.URL.RawQuery = q.Encode()
+			}
+
+			_, err := connector.parseRequestOptions(r, "test-repo", mockRepo)
+
+			if tt.wantErr {
+				require.Error(t, err)
+				require.ErrorIs(t, err, repository.ErrInvalidRef)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}

--- a/pkg/registry/apis/provisioning/history.go
+++ b/pkg/registry/apis/provisioning/history.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/grafana-app-sdk/logging"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
+	"github.com/grafana/grafana/apps/provisioning/pkg/repository/git"
 	"github.com/grafana/grafana/apps/provisioning/pkg/safepath"
 )
 
@@ -61,14 +62,21 @@ func (h *historySubresource) Connect(ctx context.Context, name string, opts runt
 	}
 
 	return WithTimeout(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		query := r.URL.Query()
+		ref := query.Get("ref")
+
+		// Reject unvalidated refs before they reach any backend. Empty is allowed
+		// and defaulted by the backend to the configured branch.
+		if !git.IsValidRef(ref) {
+			responder.Error(repository.ErrInvalidRef)
+			return
+		}
+
 		versioned, ok := repo.(repository.Versioned)
 		if !ok {
 			responder.Error(apierrors.NewBadRequest("this repository does not support history"))
 			return
 		}
-
-		query := r.URL.Query()
-		ref := query.Get("ref")
 
 		filePath, err := pathAfterPrefix(r.URL.Path, fmt.Sprintf("/%s/history/", name))
 		if err != nil {

--- a/pkg/registry/apis/provisioning/history_test.go
+++ b/pkg/registry/apis/provisioning/history_test.go
@@ -1,0 +1,85 @@
+package provisioning
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	provisioningapi "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
+	"github.com/grafana/grafana/apps/provisioning/pkg/repository"
+)
+
+// versionedFakeRepo embeds MockRepository and adds a History method so the
+// connector's `repo.(repository.Versioned)` assertion succeeds. We track
+// whether History was called to assert backend invocation order.
+type versionedFakeRepo struct {
+	*repository.MockRepository
+	historyCalled bool
+}
+
+func (v *versionedFakeRepo) History(_ context.Context, _, _ string) ([]provisioningapi.HistoryItem, error) {
+	v.historyCalled = true
+	return []provisioningapi.HistoryItem{}, nil
+}
+
+func (v *versionedFakeRepo) LatestRef(_ context.Context) (string, error) { return "", nil }
+func (v *versionedFakeRepo) ListRefs(_ context.Context) ([]provisioningapi.RefItem, error) {
+	return nil, nil
+}
+func (v *versionedFakeRepo) CompareFiles(_ context.Context, _, _ string) ([]repository.VersionedFileChange, error) {
+	return nil, nil
+}
+
+func TestHistorySubresource_RefValidation(t *testing.T) {
+	tests := []struct {
+		name              string
+		ref               string
+		wantInvalidRefErr bool
+		wantHistoryCalled bool
+	}{
+		{name: "empty ref forwarded", ref: "", wantHistoryCalled: true},
+		{name: "valid branch", ref: "main", wantHistoryCalled: true},
+		{name: "valid branch with slash", ref: "feature/my-branch", wantHistoryCalled: true},
+		{name: "valid short SHA", ref: "abc1234", wantHistoryCalled: true},
+		{name: "valid full SHA", ref: "abcdef0123456789abcdef0123456789abcdef01", wantHistoryCalled: true},
+		{name: "invalid ref with semicolon", ref: "main; rm -rf /", wantInvalidRefErr: true},
+		{name: "invalid ref with backtick", ref: "main`whoami`", wantInvalidRefErr: true},
+		{name: "invalid ref with double dots", ref: "feature/..bad", wantInvalidRefErr: true},
+		{name: "invalid ref with space", ref: "main branch", wantInvalidRefErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockRepo := repository.NewMockRepository(t)
+			mockRepo.On("Config").Return(&provisioningapi.Repository{}).Maybe()
+			fakeRepo := &versionedFakeRepo{MockRepository: mockRepo}
+
+			h := &historySubresource{repoGetter: &fakeRepoGetter{repo: fakeRepo}}
+			responder := &fakeResponder{}
+
+			handler, err := h.Connect(context.Background(), "test-repo", nil, responder)
+			require.NoError(t, err)
+
+			req := httptest.NewRequest(http.MethodGet, "/test-repo/history/dashboard.json", nil)
+			if tt.ref != "" {
+				q := req.URL.Query()
+				q.Set("ref", tt.ref)
+				req.URL.RawQuery = q.Encode()
+			}
+			handler.ServeHTTP(httptest.NewRecorder(), req)
+
+			if tt.wantInvalidRefErr {
+				require.Error(t, responder.err)
+				require.True(t, apierrors.IsBadRequest(responder.err), "expected BadRequest, got %v", responder.err)
+				require.False(t, fakeRepo.historyCalled, "backend History must not be called for invalid ref")
+			} else {
+				require.NoError(t, responder.err)
+				require.Equal(t, tt.wantHistoryCalled, fakeRepo.historyCalled)
+			}
+		})
+	}
+}

--- a/pkg/tests/apis/provisioning/files_test.go
+++ b/pkg/tests/apis/provisioning/files_test.go
@@ -1073,3 +1073,141 @@ func TestIntegrationProvisioning_FilesAuthorization(t *testing.T) {
 			Do(ctx)
 	})
 }
+
+// TestIntegrationProvisioning_RefValidation exercises ref-parameter validation
+// on both the files and history endpoints. Invalid refs must be rejected at
+// the connector layer with HTTP 400 before any backend (local or git) is
+// asked to resolve them. This prevents arbitrary strings from being forwarded
+// to e.g. the GitHub REST API.
+func TestIntegrationProvisioning_RefValidation(t *testing.T) {
+	helper := sharedHelper(t)
+	ctx := context.Background()
+
+	const repo = "ref-validation-repo"
+	helper.CreateRepo(t, common.TestRepo{
+		Name:               repo,
+		Target:             "instance",
+		ExpectedDashboards: 0,
+		ExpectedFolders:    0,
+	})
+
+	invalidRefs := []struct {
+		name string
+		ref  string
+	}{
+		{"shell injection semicolon", "main; rm -rf /"},
+		{"shell injection backtick", "main`whoami`"},
+		{"shell injection dollar", "main$(whoami)"},
+		{"path traversal double dots", "feature/..bad"},
+		{"contains space", "main branch"},
+		{"contains colon", "main:foo"},
+		{"contains question mark", "main?"},
+		{"contains asterisk", "main*"},
+		{"contains tilde", "main~1"},
+		{"leading slash", "/main"},
+		{"trailing slash", "main/"},
+		{"trailing dot", "main."},
+		{"double slashes", "feature//bad"},
+		{"trailing .lock", "feature.lock"},
+	}
+
+	validRefs := []struct {
+		name string
+		ref  string
+	}{
+		{"valid branch", "main"},
+		{"valid branch with slash", "feature/my-branch"},
+		{"valid short SHA", "abc1234"},
+		{"valid full SHA", "abcdef0123456789abcdef0123456789abcdef01"},
+	}
+
+	t.Run("files GET", func(t *testing.T) {
+		for _, tc := range invalidRefs {
+			t.Run("invalid ref rejected: "+tc.name, func(t *testing.T) {
+				var statusCode int
+				result := helper.AdminREST.Get().
+					Namespace("default").
+					Resource("repositories").
+					Name(repo).
+					SubResource("files", "dashboard.json").
+					Param("ref", tc.ref).
+					Do(ctx).StatusCode(&statusCode)
+
+				require.Error(t, result.Error(), "invalid ref %q should be rejected", tc.ref)
+				require.True(t, apierrors.IsBadRequest(result.Error()) || statusCode == http.StatusBadRequest,
+					"invalid ref %q should return BadRequest, got status=%d err=%v", tc.ref, statusCode, result.Error())
+			})
+		}
+
+		for _, tc := range validRefs {
+			t.Run("valid ref accepted (not BadRequest): "+tc.name, func(t *testing.T) {
+				var statusCode int
+				result := helper.AdminREST.Get().
+					Namespace("default").
+					Resource("repositories").
+					Name(repo).
+					SubResource("files", "dashboard.json").
+					Param("ref", tc.ref).
+					Do(ctx).StatusCode(&statusCode)
+
+				// The file/branch may not exist (NotFound) or the backend may not
+				// support the ref, but the response must not be BadRequest from
+				// ref validation. We accept any non-400 status, plus 400 errors
+				// whose message is not the ref-invalid one.
+				if result.Error() != nil && apierrors.IsBadRequest(result.Error()) {
+					require.NotContains(t, result.Error().Error(), "invalid ref",
+						"valid ref %q must not be rejected as invalid", tc.ref)
+				}
+			})
+		}
+	})
+
+	t.Run("files DELETE", func(t *testing.T) {
+		// DELETE is admin-only and exercises a write path. Invalid refs must
+		// be rejected before the connector ever asks the backend to delete.
+		for _, tc := range invalidRefs {
+			t.Run("invalid ref rejected: "+tc.name, func(t *testing.T) {
+				var statusCode int
+				result := helper.AdminREST.Delete().
+					Namespace("default").
+					Resource("repositories").
+					Name(repo).
+					SubResource("files", "dashboard.json").
+					Param("ref", tc.ref).
+					Do(ctx).StatusCode(&statusCode)
+
+				require.Error(t, result.Error(), "invalid ref %q should be rejected", tc.ref)
+				require.True(t, apierrors.IsBadRequest(result.Error()) || statusCode == http.StatusBadRequest,
+					"invalid ref %q should return BadRequest, got status=%d err=%v", tc.ref, statusCode, result.Error())
+			})
+		}
+	})
+
+	t.Run("history endpoint", func(t *testing.T) {
+		// Local repositories don't implement Versioned, but ref validation
+		// runs *before* that check, so invalid refs must still return 400.
+		for _, tc := range invalidRefs {
+			t.Run("invalid ref rejected: "+tc.name, func(t *testing.T) {
+				var statusCode int
+				result := helper.AdminREST.Get().
+					Namespace("default").
+					Resource("repositories").
+					Name(repo).
+					SubResource("history", "dashboard.json").
+					Param("ref", tc.ref).
+					Do(ctx).StatusCode(&statusCode)
+
+				require.Error(t, result.Error(), "invalid ref %q should be rejected", tc.ref)
+				require.True(t, apierrors.IsBadRequest(result.Error()) || statusCode == http.StatusBadRequest,
+					"invalid ref %q should return BadRequest, got status=%d err=%v", tc.ref, statusCode, result.Error())
+				if result.Error() != nil {
+					// The error must come from ref validation, not from the
+					// "does not support history" branch, which would mask the
+					// real check.
+					require.Contains(t, result.Error().Error(), "invalid ref",
+						"invalid ref %q should fail ref validation, not history-not-supported", tc.ref)
+				}
+			})
+		}
+	})
+}


### PR DESCRIPTION
Backport of #125551 to `release-13.0.2`.

## Summary

The `history` and `files` subresources read the `ref` query parameter and forwarded it directly to the backend without validation. In the GitHub implementation, `ref` is passed as the `SHA` field to the GitHub REST API, so any string reached `api.github.com` as a query parameter with no prior sanitisation.

This change validates `ref` at the connector layer (`files.go`, `history.go`) so invalid values are rejected with HTTP 400 *before* any backend call is made.

Closes grafana/git-ui-sync-project#1148.

## Conflict resolution

- `apps/provisioning/pkg/repository/repository.go` — release-13.0.2 doesn't yet have `ErrRepositoryMismatch`; resolved by adding only `ErrInvalidRef`.
- `pkg/registry/apis/provisioning/files_test.go` — release-13.0.2 doesn't yet have `TestParseRequestOptionsPathValidation`/`TestHandleGetRawFile`/`TestIsRawFile`; resolved by adding only the new `TestParseRequestOptionsRefValidation`.
- `pkg/tests/apis/provisioning/files_test.go` — adapted the integration test to release-13.0.2's `common.TestRepo` shape (`Target` instead of `SyncTarget`/`LocalPath`/`Workflows`; `CreateRepo` instead of `CreateLocalRepo`).

## Testing

- `go test ./apps/provisioning/pkg/repository/... ./pkg/registry/apis/provisioning/` — pass.
- `golangci-lint` on changed packages — 0 issues.
- Integration test `TestIntegrationProvisioning_RefValidation` discovered and compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)