### PR TITLE
feat: add kernel/user space coloring

### DIFF
--- a/packages/grafana-flamegraph/src/ColorSchemeButton.tsx
+++ b/packages/grafana-flamegraph/src/ColorSchemeButton.tsx
@@ -3,7 +3,13 @@ import { css, cx } from '@emotion/css';
 import { type GrafanaTheme2 } from '@grafana/data';
 import { Button, Dropdown, Menu, useStyles2 } from '@grafana/ui';
 
-import { byPackageGradient, byValueGradient, diffColorBlindGradient, diffDefaultGradient } from './FlameGraph/colors';
+import {
+  byPackageGradient,
+  bySpaceGradient,
+  byValueGradient,
+  diffColorBlindGradient,
+  diffDefaultGradient
+} from './FlameGraph/colors';
 import { ColorScheme, ColorSchemeDiff } from './types';
 
 type ColorSchemeButtonProps = {
@@ -18,6 +24,7 @@ export function ColorSchemeButton(props: ColorSchemeButtonProps) {
     <Menu>
       <Menu.Item label="By package name" onClick={() => props.onChange(ColorScheme.PackageBased)} />
       <Menu.Item label="By value" onClick={() => props.onChange(ColorScheme.ValueBased)} />
+      <Menu.Item label="By kernel/user space" onClick={() => props.onChange(ColorScheme.SpaceBased)} />
     </Menu>
   );
 
@@ -26,6 +33,7 @@ export function ColorSchemeButton(props: ColorSchemeButtonProps) {
     {
       [ColorScheme.ValueBased]: styles.colorDotByValue,
       [ColorScheme.PackageBased]: styles.colorDotByPackage,
+      [ColorScheme.SpaceBased]: styles.colorDotBySpace,
       [ColorSchemeDiff.DiffColorBlind]: styles.colorDotDiffColorBlind,
       [ColorSchemeDiff.Default]: styles.colorDotDiffDefault,
     }[props.value] || styles.colorDotByValue;
@@ -99,6 +107,10 @@ const getStyles = (theme: GrafanaTheme2) => ({
   colorDotByPackage: css({
     label: 'colorDotByPackage',
     background: byPackageGradient,
+  }),
+  colorDotBySpace: css({
+    label: 'colorDotBySpace',
+    background: bySpaceGradient,
   }),
   colorDotDiffDefault: css({
     label: 'colorDotDiffDefault',

--- a/packages/grafana-flamegraph/src/FlameGraph/colors.ts
+++ b/packages/grafana-flamegraph/src/FlameGraph/colors.ts
@@ -3,7 +3,7 @@ import color from 'tinycolor2';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 
-import { ColorSchemeDiff } from '../types';
+import { ColorSchemeDiff, FrameType } from '../types';
 
 import murmurhash3_32_gc from './murmur3';
 
@@ -38,8 +38,13 @@ const packageColors = [
 
 const byValueMinColor = getBarColorByValue(1, 100, 0, 1);
 const byValueMaxColor = getBarColorByValue(100, 100, 0, 1);
-export const byValueGradient = `linear-gradient(90deg, ${byValueMinColor} 0%, ${byValueMaxColor} 100%)`;
 
+const kernelSpace = color({ r: 231, g: 161, b: 81 })
+const userSpace = color({ r: 231, g: 231, b: 81 });
+const unknownSpace = color({ r: 255, g: 182, b: 193 })
+
+export const byValueGradient = `linear-gradient(90deg, ${byValueMinColor} 0%, ${byValueMaxColor} 100%)`;
+export const bySpaceGradient = `linear-gradient(90deg, ${kernelSpace} 0%, ${userSpace} 100%)`;
 // Handpicked some vaguely rainbow-ish colors
 export const byPackageGradient = `linear-gradient(90deg, ${packageColors[0]} 0%, ${packageColors[2]} 30%, ${packageColors[6]} 50%, ${packageColors[7]} 70%, ${packageColors[8]} 100%)`;
 
@@ -62,6 +67,17 @@ export function getBarColorByPackage(label: string, theme: GrafanaTheme2) {
     packageColor = packageColor.brighten(15);
   }
   return packageColor;
+}
+
+export function getBarColorBySpace(frameType: FrameType) {
+  switch (frameType) {
+    case FrameType.Kernel:
+      return kernelSpace.clone();
+    case FrameType.User:
+      return userSpace.clone();
+    default:
+      return unknownSpace.clone();
+  }
 }
 
 // green to red

--- a/packages/grafana-flamegraph/src/FlameGraph/dataTransform.ts
+++ b/packages/grafana-flamegraph/src/FlameGraph/dataTransform.ts
@@ -8,9 +8,9 @@ import {
   type GrafanaTheme2,
 } from '@grafana/data';
 
-import { SampleUnit } from '../types';
+import {DataSourceType, FrameType, SampleUnit} from '../types';
 
-import { mergeParentSubtrees, mergeSubtrees } from './treeTransforms';
+import {mergeParentSubtrees, mergeSubtrees} from './treeTransforms';
 
 export type LevelItem = {
   // Offset from the start of the level.
@@ -269,6 +269,8 @@ export class FlameGraphDataContainer {
   levelField: Field;
   valueField: Field;
   selfField: Field;
+  filenameField?: Field;
+  frameTypeField?: Field;
 
   // Optional fields for diff view
   valueRightField?: Field;
@@ -281,10 +283,13 @@ export class FlameGraphDataContainer {
   private levels: LevelItem[][] | undefined;
   private uniqueLabelsMap: Record<string, LevelItem[]> | undefined;
   private collapsedMap: CollapsedMap | undefined;
+  private dataSource: DataSourceType;
 
-  constructor(data: DataFrame, options: Options, theme: GrafanaTheme2 = createTheme()) {
+
+  constructor(data: DataFrame, options: Options, theme: GrafanaTheme2 = createTheme(), dataSource: DataSourceType = DataSourceType.Unknown) {
     this.data = data;
     this.options = options;
+    this.dataSource = dataSource;
 
     const wrongFields = checkFields(data);
     if (wrongFields) {
@@ -295,6 +300,8 @@ export class FlameGraphDataContainer {
     this.levelField = data.fields.find((f) => f.name === 'level')!;
     this.valueField = data.fields.find((f) => f.name === 'value')!;
     this.selfField = data.fields.find((f) => f.name === 'self')!;
+    this.filenameField = data.fields.find((f) => f.name === 'filename');
+    this.frameTypeField = data.fields.find((f) => f.name === 'frameType');
 
     this.valueRightField = data.fields.find((f) => f.name === 'valueRight')!;
     this.selfRightField = data.fields.find((f) => f.name === 'selfRight')!;
@@ -332,6 +339,17 @@ export class FlameGraphDataContainer {
 
   getLabel(index: number) {
     return this.labelDisplayProcessor(this.labelField.values[index]).text;
+  }
+
+  getFilename(index: number) {
+    return this.filenameField?.values[index] ?? '';
+  }
+
+  getFrameType(index: number): FrameType {
+    if (this.dataSource == DataSourceType.PprofPyroscope) {
+      return getFrameTypeByFilename(this.filenameField!.values[index])
+    }
+    return this.frameTypeField?.values[index] ?? FrameType.Unknown;
   }
 
   getLevel(index: number) {
@@ -421,4 +439,14 @@ function fieldAccessor(field: Field | undefined, index: number | number[]) {
   return indexArray.reduce((acc, index) => {
     return acc + field.values[index];
   }, 0);
+}
+
+function getFrameTypeByFilename(filename: string): FrameType {
+  if (!filename) {
+    return FrameType.Unknown;
+  }
+  if (filename.startsWith('[kernel]')) {
+    return FrameType.Kernel;
+  }
+  return FrameType.User;
 }

--- a/packages/grafana-flamegraph/src/FlameGraph/rendering.test.ts
+++ b/packages/grafana-flamegraph/src/FlameGraph/rendering.test.ts
@@ -41,7 +41,7 @@ describe('walkTree', () => {
       1,
       100,
       container.getCollapsedMap(),
-      (item, x, y, width, height, label, collapsed) => {
+      (item, x, y, width, height, label, filename, collapsed) => {
         expect(item).toEqual(root);
         expect(x).toEqual(0);
         expect(y).toEqual(0);
@@ -78,7 +78,7 @@ describe('walkTree', () => {
       1,
       100,
       container.getCollapsedMap(),
-      (item, x, y, width, height, label, muted) => {
+      (item, x, y, width, height, label, filename, muted) => {
         renderData.push({ item, x, y, width, height, label, muted });
       }
     );
@@ -114,7 +114,7 @@ describe('walkTree', () => {
       1,
       100,
       container.getCollapsedMap(),
-      (item, x, y, width, height, label, muted) => {
+      (item, x, y, width, height, label, filename, muted) => {
         renderData.push({ item, x, y, width, height, label, muted });
       }
     );
@@ -150,7 +150,7 @@ describe('walkTree', () => {
       1,
       100,
       container.getCollapsedMap(),
-      (item, x, y, width, height, label, muted) => {
+      (item, x, y, width, height, label, filename, muted) => {
         renderData.push({ item, x, y, width, height, label, muted });
       }
     );
@@ -176,7 +176,7 @@ describe('walkTree', () => {
       1,
       14,
       container.getCollapsedMap(),
-      (item, x, y, width, height, label, muted) => {
+      (item, x, y, width, height, label, filename, muted) => {
         renderData.push({ item, x, y, width, height, label, muted });
       }
     );

--- a/packages/grafana-flamegraph/src/FlameGraph/rendering.ts
+++ b/packages/grafana-flamegraph/src/FlameGraph/rendering.ts
@@ -16,9 +16,9 @@ import {
   GROUP_STRIP_MARGIN_LEFT,
   GROUP_TEXT_OFFSET,
 } from '../constants';
-import { type ClickedItemData, ColorScheme, ColorSchemeDiff, type TextAlign } from '../types';
+import { type ClickedItemData, ColorScheme, ColorSchemeDiff, FrameType, type TextAlign } from '../types';
 
-import { getBarColorByDiff, getBarColorByPackage, getBarColorByValue } from './colors';
+import { getBarColorByDiff, getBarColorByPackage, getBarColorByValue, getBarColorBySpace } from './colors';
 import { type CollapseConfig, type CollapsedMap, type FlameGraphDataContainer, type LevelItem } from './dataTransform';
 
 type RenderOptions = {
@@ -115,13 +115,13 @@ export function useFlameRender(options: RenderOptions) {
       rangeMax,
       wrapperWidth,
       collapsedMap,
-      (item, x, y, width, height, label, muted) => {
+      (item, x, y, width, height, label, frameType, muted) => {
         if (muted) {
           // We do a bit of optimization for muted regions, and we render them all in single fill later on as they don't
           // have labels and are the same color.
           mutedPath2D.rect(x, y, width, height);
         } else {
-          renderFunc(item, x, y, width, height, label);
+          renderFunc(item, x, y, width, height, label, frameType);
         }
       }
     );
@@ -144,7 +144,7 @@ export function useFlameRender(options: RenderOptions) {
   ]);
 }
 
-type RenderFunc = (item: LevelItem, x: number, y: number, width: number, height: number, label: string) => void;
+type RenderFunc = (item: LevelItem, x: number, y: number, width: number, height: number, label: string, frameType: FrameType) => void;
 
 type RenderFuncWrap = (
   item: LevelItem,
@@ -153,6 +153,7 @@ type RenderFuncWrap = (
   width: number,
   height: number,
   label: string,
+  frameType: FrameType,
   muted: boolean
 ) => void;
 
@@ -167,7 +168,7 @@ type RenderFuncWrap = (
 function useRenderFunc(
   ctx: CanvasRenderingContext2D | undefined,
   data: FlameGraphDataContainer,
-  getBarColor: (item: LevelItem, label: string, muted: boolean) => string,
+  getBarColor: (item: LevelItem, label: string, frameType: FrameType, muted: boolean) => string,
   textAlign: TextAlign,
   collapsedMap: CollapsedMap
 ) {
@@ -176,10 +177,10 @@ function useRenderFunc(
       return () => {};
     }
 
-    const renderFunc: RenderFunc = (item, x, y, width, height, label) => {
+    const renderFunc: RenderFunc = (item, x, y, width, height, label, frameType) => {
       ctx.beginPath();
       ctx.rect(x + BAR_BORDER_WIDTH, y, width, height);
-      ctx.fillStyle = getBarColor(item, label, false);
+      ctx.fillStyle = getBarColor(item, label, frameType, false);
       ctx.stroke();
       ctx.fill();
 
@@ -320,11 +321,12 @@ export function walkTree(
       const barY = (item.level + levelOffset) * PIXELS_PER_LEVEL;
 
       let label = data.getLabel(item.itemIndexes[0]);
+      let frameType = data.getFrameType(item.itemIndexes[0]);
       if (isCollapsedItem) {
         collapsedItemRendered = item;
       }
 
-      renderFunc(item, barX, barY, width, height, label, muted);
+      renderFunc(item, barX, barY, width, height, label, frameType, muted);
     }
 
     const nextList = direction === 'children' ? item.children : item.parents;
@@ -346,7 +348,7 @@ function useColorFunction(
   topLevel: number
 ) {
   return useCallback(
-    function getColor(item: LevelItem, label: string, muted: boolean) {
+    function getColor(item: LevelItem, label: string, frameType: FrameType, muted: boolean) {
       // If collapsed and no search we can quickly return the muted color
       if (muted && !matchedLabels) {
         // Collapsed are always grayed
@@ -359,7 +361,9 @@ function useColorFunction(
           ? getBarColorByDiff(item.value, item.valueRight!, totalTicks, totalTicksRight!, colorScheme)
           : colorScheme === ColorScheme.ValueBased
             ? getBarColorByValue(item.value, totalTicks, rangeMin, rangeMax)
-            : getBarColorByPackage(label, theme);
+            : colorScheme === ColorScheme.SpaceBased
+              ? getBarColorBySpace(frameType)
+              : getBarColorByPackage(label, theme);
 
       if (matchedLabels) {
         // Means we are searching, we use color for matches and gray the rest

--- a/packages/grafana-flamegraph/src/FlameGraphContainer.tsx
+++ b/packages/grafana-flamegraph/src/FlameGraphContainer.tsx
@@ -19,7 +19,7 @@ import {
   FLAMEGRAPH_CONTAINER_HEIGHT,
 } from './constants';
 import { useColorScheme } from './hooks';
-import { type ClickedItemData, PaneView, SelectedView, type TextAlign, ViewMode } from './types';
+import { type ClickedItemData, PaneView, SelectedView, type TextAlign, ViewMode, DataSourceType } from './types';
 import { getAssistantContextFromDataFrame } from './utils';
 
 const ufuzzy = new uFuzzy();
@@ -97,6 +97,12 @@ export type Props = {
    * Enable the new pane-based UI with call tree support.
    */
   enableNewUI?: boolean;
+
+  /**
+   * Specifies the flame graph data source type.
+   * Affects frame classification rules (e.g. kernel vs user-space detection for Pyroscope).
+   */
+  dataSource?: DataSourceType;
 };
 
 const FlameGraphContainer = ({
@@ -115,8 +121,10 @@ const FlameGraphContainer = ({
   getExtraContextMenuButtons,
   showAnalyzeWithAssistant = true,
   enableNewUI,
+  dataSource,
 }: Props) => {
   const theme = useMemo(() => getTheme(), [getTheme]);
+
 
   if (enableNewUI) {
     return (
@@ -135,6 +143,7 @@ const FlameGraphContainer = ({
         keepFocusOnDataChange={keepFocusOnDataChange}
         getExtraContextMenuButtons={getExtraContextMenuButtons}
         showAnalyzeWithAssistant={showAnalyzeWithAssistant}
+        dataSource={dataSource}
       />
     );
   }
@@ -155,6 +164,7 @@ const FlameGraphContainer = ({
       keepFocusOnDataChange={keepFocusOnDataChange}
       getExtraContextMenuButtons={getExtraContextMenuButtons}
       showAnalyzeWithAssistant={showAnalyzeWithAssistant}
+      dataSource={dataSource}
     />
   );
 };
@@ -174,6 +184,7 @@ type InternalProps = {
   keepFocusOnDataChange?: boolean;
   getExtraContextMenuButtons?: GetExtraContextMenuButtonsFunction;
   showAnalyzeWithAssistant: boolean;
+  dataSource?: DataSourceType;
 };
 
 const LegacyContainer = ({
@@ -191,6 +202,7 @@ const LegacyContainer = ({
   keepFocusOnDataChange,
   getExtraContextMenuButtons,
   showAnalyzeWithAssistant,
+  dataSource
 }: InternalProps) => {
   const [focusedItemData, setFocusedItemData] = useState<ClickedItemData>();
 
@@ -216,11 +228,10 @@ const LegacyContainer = ({
     if (!data) {
       return;
     }
-
-    const container = new FlameGraphDataContainer(data, { collapsing: !disableCollapsing }, theme);
+    const container = new FlameGraphDataContainer(data, { collapsing: !disableCollapsing }, theme, dataSource);
     setCollapsedMap(container.getCollapsedMap());
     return container;
-  }, [data, theme, disableCollapsing]);
+  }, [data, theme, disableCollapsing, dataSource]);
   const [colorScheme, setColorScheme] = useColorScheme(dataContainer);
   const styles = getStyles(theme);
   const matchedLabels = useLabelSearch(search, dataContainer);
@@ -444,6 +455,7 @@ const NewUIContainer = ({
   keepFocusOnDataChange,
   getExtraContextMenuButtons,
   showAnalyzeWithAssistant,
+  dataSource
 }: InternalProps) => {
   const [search, setSearch] = useState('');
   const [viewMode, setViewMode] = useState<ViewMode>(ViewMode.Split);
@@ -484,8 +496,7 @@ const NewUIContainer = ({
     if (!data) {
       return;
     }
-
-    return new FlameGraphDataContainer(data, { collapsing: !disableCollapsing }, theme);
+    return new FlameGraphDataContainer(data, { collapsing: !disableCollapsing }, theme, dataSource);
   }, [data, theme, disableCollapsing]);
 
   const styles = getStyles(theme);

--- a/packages/grafana-flamegraph/src/types.ts
+++ b/packages/grafana-flamegraph/src/types.ts
@@ -44,6 +44,7 @@ export interface TableData {
 export enum ColorScheme {
   ValueBased = 'valueBased',
   PackageBased = 'packageBased',
+  SpaceBased = 'spaceBased',
 }
 
 export enum ColorSchemeDiff {
@@ -52,3 +53,14 @@ export enum ColorSchemeDiff {
 }
 
 export type TextAlign = 'left' | 'right';
+
+export enum FrameType {
+  Kernel = 'kernel',
+  User = 'user',
+  Unknown = 'unknown',
+}
+
+export enum DataSourceType {
+  PprofPyroscope = 'pprof-pyroscope',
+  Unknown = 'unknown',
+}

--- a/pkg/tsdb/grafana-pyroscope-datasource/pyroscopeClient.go
+++ b/pkg/tsdb/grafana-pyroscope-datasource/pyroscopeClient.go
@@ -33,6 +33,7 @@ type Flamebearer struct {
 	Levels  []*Level
 	Total   int64
 	MaxSelf int64
+	MappingNames []string
 }
 
 type Level struct {
@@ -375,6 +376,7 @@ func profileQuery(flamegraph *querierv1.FlameGraph, profileTypeID string) (*Prof
 			Levels:  levels,
 			Total:   flamegraph.Total,
 			MaxSelf: flamegraph.MaxSelf,
+			MappingNames: flamegraph.MappingNames,
 		},
 		Units: getUnits(profileTypeID),
 	}, nil

--- a/pkg/tsdb/grafana-pyroscope-datasource/query.go
+++ b/pkg/tsdb/grafana-pyroscope-datasource/query.go
@@ -300,7 +300,7 @@ func (d *PyroscopeDatasource) queryHeatmap(ctx context.Context, span trace.Span,
 // [level, value, label] columns and by ordering the items in a depth first traversal order we can recreate the whole
 // tree back.
 func responseToDataFrames(resp *ProfileResponse, stepDurationSec float64, profileTypeID string) *data.Frame {
-	tree := levelsToTree(resp.Flamebearer.Levels, resp.Flamebearer.Names)
+	tree := levelsToTree(resp.Flamebearer.Levels, resp.Flamebearer.Names, resp.Flamebearer.MappingNames)
 	return treeToNestedSetDataFrame(tree, resp.Units, stepDurationSec, profileTypeID)
 }
 
@@ -325,22 +325,32 @@ type ProfileTree struct {
 	Self  int64
 	Level int
 	Name  string
+	Mapping string
 	Nodes []*ProfileTree
+}
+
+func getMapping(mappingNames []string, idx int64) string {
+    if int(idx) < len(mappingNames) {
+        return mappingNames[int(idx)]
+    }
+    return ""
 }
 
 // levelsToTree converts flamebearer format into a tree. This is needed to then convert it into nested set format
 // dataframe. This should be temporary, and ideally we should get some sort of tree struct directly from Pyroscope API.
-func levelsToTree(levels []*Level, names []string) *ProfileTree {
+func levelsToTree(levels []*Level, names []string, mappingNames []string) *ProfileTree {
 	if len(levels) == 0 {
 		return nil
 	}
 
+	nameIndex := levels[0].Values[0]
 	tree := &ProfileTree{
 		Start: 0,
 		Value: levels[0].Values[VALUE_OFFSET],
 		Self:  levels[0].Values[SELF_OFFSET],
 		Level: 0,
-		Name:  names[levels[0].Values[0]],
+		Name:    names[nameIndex],
+		Mapping: getMapping(mappingNames, nameIndex),
 	}
 
 	parentsStack := []*ProfileTree{tree}
@@ -371,12 +381,14 @@ func levelsToTree(levels []*Level, names []string) *ProfileTree {
 
 			if itemStart >= currentParent.Start && itemEnd <= parentEnd {
 				// We have an item that is in the bounds of current parent item, so it should be its child
+				nameIndex := levels[currentLevel].Values[itemIndex+NAME_OFFSET]
 				treeItem := &ProfileTree{
 					Start: itemStart,
 					Value: itemValue,
 					Self:  selfValue,
 					Level: currentLevel,
-					Name:  names[levels[currentLevel].Values[itemIndex+NAME_OFFSET]],
+					Name:  names[nameIndex],
+					Mapping: getMapping(mappingNames, nameIndex),
 				}
 				// Add to parent
 				currentParent.Nodes = append(currentParent.Nodes, treeItem)
@@ -470,11 +482,12 @@ func treeToNestedSetDataFrame(tree *ProfileTree, unit string, stepDurationSec fl
 	levelField := data.NewField("level", nil, []int64{})
 	valueField := data.NewField("value", nil, []int64{})
 	selfField := data.NewField("self", nil, []int64{})
+	filenameField := data.NewField("filename", nil, []string{})
 
 	// profileTypeID should encode the type of the profile with unit being the 3rd part
 	valueField.Config = &data.FieldConfig{Unit: unit}
 	selfField.Config = &data.FieldConfig{Unit: unit}
-	frame.Fields = data.Fields{levelField, valueField, selfField}
+	frame.Fields = data.Fields{levelField, valueField, selfField, filenameField}
 
 	labelField := NewEnumField("label", nil)
 
@@ -486,6 +499,7 @@ func treeToNestedSetDataFrame(tree *ProfileTree, unit string, stepDurationSec fl
 			valueField.Append(tree.Value)
 			selfField.Append(tree.Self)
 			labelField.Append(tree.Name)
+			filenameField.Append(tree.Mapping)
 		})
 	}
 

--- a/pkg/tsdb/grafana-pyroscope-datasource/query_test.go
+++ b/pkg/tsdb/grafana-pyroscope-datasource/query_test.go
@@ -132,17 +132,19 @@ func Test_profileToDataFrame(t *testing.T) {
 			},
 			Total:   987,
 			MaxSelf: 123,
+			MappingNames: []string{"file1", "file2", "file3"},
 		},
 		Units: "short",
 	}
 	frame := responseToDataFrames(profile, 15.0, "goroutine:goroutine:count:goroutine:count")
-	require.Equal(t, 4, len(frame.Fields))
+	require.Equal(t, 5, len(frame.Fields))
 	require.Equal(t, data.NewField("level", nil, []int64{0, 1, 1}), frame.Fields[0])
 	require.Equal(t, data.NewField("value", nil, []int64{20, 10, 5}).SetConfig(&data.FieldConfig{Unit: "short"}), frame.Fields[1])
 	require.Equal(t, data.NewField("self", nil, []int64{1, 3, 5}).SetConfig(&data.FieldConfig{Unit: "short"}), frame.Fields[2])
-	require.Equal(t, "label", frame.Fields[3].Name)
-	require.Equal(t, []data.EnumItemIndex{0, 1, 2}, fieldValues[data.EnumItemIndex](frame.Fields[3]))
-	require.Equal(t, []string{"func1", "func2", "func3"}, frame.Fields[3].Config.TypeConfig.Enum.Text)
+	require.Equal(t, data.NewField("filename", nil, []string{"file1", "file2", "file3"}), frame.Fields[3])
+	require.Equal(t, "label", frame.Fields[4].Name)
+	require.Equal(t, []data.EnumItemIndex{0, 1, 2}, fieldValues[data.EnumItemIndex](frame.Fields[4]))
+	require.Equal(t, []string{"func1", "func2", "func3"}, frame.Fields[4].Config.TypeConfig.Enum.Text)
 }
 
 // This is where the tests for the datasource backend live.
@@ -154,15 +156,15 @@ func Test_levelsToTree(t *testing.T) {
 			{Values: []int64{0, 15, 0, 3}},
 		}
 
-		tree := levelsToTree(levels, []string{"root", "func1", "func2", "func1:func3"})
+		tree := levelsToTree(levels, []string{"root", "func1", "func2", "func1:func3"}, []string{"", "file1", "file2", "file1"})
 		require.Equal(t, &ProfileTree{
-			Start: 0, Value: 100, Level: 0, Name: "root", Nodes: []*ProfileTree{
+			Start: 0, Value: 100, Level: 0, Name: "root", Mapping: "", Nodes: []*ProfileTree{
 				{
-					Start: 0, Value: 40, Level: 1, Name: "func1", Nodes: []*ProfileTree{
-						{Start: 0, Value: 15, Level: 2, Name: "func1:func3"},
+					Start: 0, Value: 40, Level: 1, Name: "func1", Mapping: "file1", Nodes: []*ProfileTree{
+						{Start: 0, Value: 15, Level: 2, Name: "func1:func3", Mapping: "file1"},
 					},
 				},
-				{Start: 40, Value: 30, Level: 1, Name: "func2"},
+				{Start: 40, Value: 30, Level: 1, Name: "func2", Mapping: "file2"},
 			},
 		}, tree)
 	})
@@ -174,18 +176,19 @@ func Test_levelsToTree(t *testing.T) {
 			{Values: []int64{0, 20, 0, 4, 50, 10, 0, 5}},
 		}
 
-		tree := levelsToTree(levels, []string{"root", "func1", "func2", "func3", "func1:func4", "func3:func5"})
+		tree := levelsToTree(levels, []string{"root", "func1", "func2", "func3", "func1:func4", "func3:func5"},
+							[]string{"", "file1", "file2", "file3", "file1", "file3"})
 		require.Equal(t, &ProfileTree{
-			Start: 0, Value: 100, Level: 0, Name: "root", Nodes: []*ProfileTree{
+			Start: 0, Value: 100, Level: 0, Name: "root", Mapping: "", Nodes: []*ProfileTree{
 				{
-					Start: 0, Value: 40, Level: 1, Name: "func1", Nodes: []*ProfileTree{
-						{Start: 0, Value: 20, Level: 2, Name: "func1:func4"},
+					Start: 0, Value: 40, Level: 1, Name: "func1", Mapping: "file1", Nodes: []*ProfileTree{
+						{Start: 0, Value: 20, Level: 2, Name: "func1:func4", Mapping: "file1"},
 					},
 				},
-				{Start: 40, Value: 30, Level: 1, Name: "func2"},
+				{Start: 40, Value: 30, Level: 1, Name: "func2", Mapping: "file2"},
 				{
-					Start: 70, Value: 30, Level: 1, Name: "func3", Nodes: []*ProfileTree{
-						{Start: 70, Value: 10, Level: 2, Name: "func3:func5"},
+					Start: 70, Value: 30, Level: 1, Name: "func3", Mapping: "file3", Nodes: []*ProfileTree{
+						{Start: 70, Value: 10, Level: 2, Name: "func3:func5", Mapping: "file3"},
 					},
 				},
 			},
@@ -196,13 +199,13 @@ func Test_levelsToTree(t *testing.T) {
 func Test_treeToNestedDataFrame(t *testing.T) {
 	t.Run("sample profile tree", func(t *testing.T) {
 		tree := &ProfileTree{
-			Value: 100, Level: 0, Self: 1, Name: "root", Nodes: []*ProfileTree{
+			Value: 100, Level: 0, Self: 1, Name: "root", Mapping: "", Nodes: []*ProfileTree{
 				{
-					Value: 40, Level: 1, Self: 2, Name: "func1",
+					Value: 40, Level: 1, Self: 2, Name: "func1", Mapping: "file1",
 				},
-				{Value: 30, Level: 1, Self: 3, Name: "func2", Nodes: []*ProfileTree{
-					{Value: 15, Level: 2, Self: 4, Name: "func1:func3"},
-					{Value: 10, Level: 2, Self: 4, Name: "func1"},
+				{Value: 30, Level: 1, Self: 3, Name: "func2", Mapping: "file2", Nodes: []*ProfileTree{
+					{Value: 15, Level: 2, Self: 4, Name: "func1:func3", Mapping: "file1"},
+					{Value: 10, Level: 2, Self: 4, Name: "func1", Mapping: "file1"},
 				}},
 			},
 		}
@@ -221,19 +224,20 @@ func Test_treeToNestedDataFrame(t *testing.T) {
 				data.NewField("level", nil, []int64{0, 1, 1, 2, 2}),
 				data.NewField("value", nil, []int64{100, 40, 30, 15, 10}).SetConfig(&data.FieldConfig{Unit: "short"}),
 				data.NewField("self", nil, []int64{1, 2, 3, 4, 4}).SetConfig(&data.FieldConfig{Unit: "short"}),
+				data.NewField("filename", nil, []string{"", "file1", "file2", "file1", "file1"}),
 				data.NewField("label", nil, []data.EnumItemIndex{0, 1, 2, 3, 1}).SetConfig(labelConfig),
 			}, frame.Fields)
 	})
 
 	t.Run("nil profile tree", func(t *testing.T) {
 		frame := treeToNestedSetDataFrame(nil, "short", 15.0, "goroutine:goroutine:count:goroutine:count")
-		require.Equal(t, 4, len(frame.Fields))
+		require.Equal(t, 5, len(frame.Fields))
 		require.Equal(t, 0, frame.Fields[0].Len())
 	})
 
 	t.Run("no rateCalculated metadata for flamegraph", func(t *testing.T) {
 		tree := &ProfileTree{
-			Value: 100, Level: 0, Self: 1, Name: "root",
+			Value: 100, Level: 0, Self: 1, Name: "root", Mapping: "",
 		}
 		frame := treeToNestedSetDataFrame(tree, "short", 15.0, "process_cpu:cpu:nanoseconds:cpu:nanoseconds")
 		require.NotNil(t, frame.Meta)
@@ -242,7 +246,7 @@ func Test_treeToNestedDataFrame(t *testing.T) {
 
 	t.Run("no rateCalculated metadata for instant profile", func(t *testing.T) {
 		tree := &ProfileTree{
-			Value: 100, Level: 0, Self: 1, Name: "root",
+			Value: 100, Level: 0, Self: 1, Name: "root", Mapping: "",
 		}
 		frame := treeToNestedSetDataFrame(tree, "short", 15.0, "goroutine:goroutine:count:goroutine:count")
 		require.NotNil(t, frame.Meta)
@@ -251,7 +255,7 @@ func Test_treeToNestedDataFrame(t *testing.T) {
 
 	t.Run("CPU time keeps original values and units for flamegraph", func(t *testing.T) {
 		tree := &ProfileTree{
-			Value: 3000000000, Level: 0, Self: 1500000000, Name: "root", // 3s total, 1.5s self in nanoseconds
+			Value: 3000000000, Level: 0, Self: 1500000000, Name: "root", Mapping: "", // 3s total, 1.5s self in nanoseconds
 		}
 		// Test CPU profile flamegraph - should keep original cumulative values and units
 		frame := treeToNestedSetDataFrame(tree, "ns", 15.0, "process_cpu:cpu:nanoseconds:cpu:nanoseconds")
@@ -627,6 +631,7 @@ func (f *FakeClient) GetProfile(ctx context.Context, profileTypeID, labelSelecto
 			},
 			Total:   100,
 			MaxSelf: 56,
+			MappingNames: []string{"foo_file", "bar_file", "baz_file"},
 		},
 		Units: "count",
 	}, nil
@@ -643,6 +648,7 @@ func (f *FakeClient) GetSpanProfile(ctx context.Context, profileTypeID, labelSel
 			},
 			Total:   100,
 			MaxSelf: 56,
+			MappingNames: []string{"foo_file", "bar_file", "baz_file"},
 		},
 		Units: "count",
 	}, nil


### PR DESCRIPTION
**What is this feature?**

Adds a new "By kernel/user space" color scheme option to the Flamegraph panel. When using a Pyroscope data source, each frame is colored based on whether it belongs to kernel space (orange), user space (yellow) or is unknown (pink). The classification is derived from the executable/shared library path (e.g. `/usr/bin/app`) exposed by the Pyroscope API - kernel frames are identified by a `[kernel]` prefix in the filename.

<img width="1892" height="912" alt="kernel_user_space_coloring" src="https://github.com/user-attachments/assets/06acd9cf-d4a3-413d-bffd-325a9a51e62d" />


**Why do we need this feature?**

Previously, the Flamegraph panel had no way to visually distinguish between kernel and user space frames. This made it harder to identify at a glance whether CPU time was being spent in application code or in the kernel. The new color scheme makes this visible.

**Who is this feature for?**

Users of the Grafana Flamegraph panel with a Pyroscope data source who want to quickly identify the proportion of time spent in kernel vs. user space.

**Notes**

This PR depends on a corresponding change in grafana/pyroscope ([PR #5201](https://github.com/grafana/pyroscope/pull/5201)) that adds `mapping_names` to the FlameGraph proto response. Without that change, the `filename` 
field will be empty and all frames will fall back to the "unknown" (pink) color.

Note: kernel frame classification currently works only for OTLP-based profiles, where 
the `[kernel]` prefix is added during OTLP -> Google profile conversion. For native 
pprof profiles, all frames will be colored as user space.

The `DataSourceType` prop is optional and defaults to `Unknown`, so existing usages 
of `FlameGraphContainer` are unaffected.

Related PR: [grafana/profiles-drilldown#994](https://github.com/grafana/profiles-drilldown/pull/994)


Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.