### PR TITLE
Dependencies: Vendor get-document github: resolution as workspace

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -544,6 +544,9 @@ i18next.config.ts @grafana/grafana-frontend-platform
 /packages/README.md @grafana/grafana-frontend-platform
 /packages/rollup.config.parts.ts @grafana/frontend-ops
 
+# Vendored
+/packages/get-document/ @grafana/grafana-frontend-platform
+
 # @grafana/alerting
 /packages/grafana-alerting/ @grafana/alerting-frontend
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -34,3 +34,6 @@ test-results
 playwright-report
 
 eslint-suppressions.json
+
+packages/get-document/index.js
+packages/get-document/LICENSE

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -129,6 +129,7 @@ module.exports = [
       'public/build-swagger', // swagger build output
       'apps/plugins/plugin/src/generated/meta/v0alpha1',
       'apps/plugins/plugin/src/generated/plugin/v0alpha1',
+      'packages/get-document/index.js',
     ],
   },
   ...grafanaConfig,

--- a/package.json
+++ b/package.json
@@ -457,7 +457,7 @@
     "socks/ip-address": "10.2.0",
     "refractor/prismjs": "^1.27.0",
     "@mapbox/jsonlint-lines-primitives": "github:mapbox/jsonlint#commit=e31b7289baedf3e1000d7ae7edd42268212c9954",
-    "get-document": "github:webmodules/get-document#commit=a04ccb499d6e0433a368c3bb150b4899b698461f",
+    "get-document": "workspace:*",
     "gitconfiglocal": "2.1.0",
     "tmp@npm:^0.0.33": "~0.2.1",
     "js-yaml@npm:4.1.0": "^4.1.0",

--- a/packages/get-document/LICENSE
+++ b/packages/get-document/LICENSE
@@ -1,0 +1,22 @@
+Copyright (c) 2014 Nathan Rajlich <n@n8.io>
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.

--- a/packages/get-document/README.md
+++ b/packages/get-document/README.md
@@ -1,0 +1,14 @@
+# get-document (vendored)
+
+Vendored copy of `get-document` (`webmodules/get-document` at commit
+`a04ccb49`). See [`VENDORED.md`](./VENDORED.md) for source and sync
+procedure, [`LICENSE`](./LICENSE) for MIT terms.
+
+This package is **private** and resolved only via the root `package.json`
+`resolutions` field — do not import it directly from Grafana code.
+
+---
+
+## Original description
+
+Returns the `document` object from a DOM object.

--- a/packages/get-document/VENDORED.md
+++ b/packages/get-document/VENDORED.md
@@ -1,0 +1,33 @@
+# Vendored package
+
+This package was vendored from an upstream open-source repo to avoid using
+`github:` resolutions in the root `package.json` (a supply-chain risk).
+
+## Source
+
+- Upstream: https://github.com/webmodules/get-document
+- Commit: `a04ccb499d6e0433a368c3bb150b4899b698461f`
+
+## Why vendored
+
+`get-document` is pulled in transitively by `get-window@1.1.2`, which
+declares `npm:1`. The registry tarball ships without a LICENSE file (the
+upstream LICENSE was added in the very commit we vendor from), which
+previously motivated a `github:` resolution. To remove the `github:`
+indirection, we vendor the source here and serve it via a `workspace:*`
+resolution.
+
+Upstream is effectively abandoned (no commits since 2014).
+
+## Syncing from upstream
+
+If/when upstream releases a relevant fix:
+
+1. `git clone https://github.com/webmodules/get-document.git && git checkout <new-sha>`
+2. Diff against this directory; apply matching changes.
+3. Bump `version` in `package.json` (e.g. `1.0.0-grafana.1`).
+4. Update the commit SHA above.
+5. Run `rm -rf node_modules && yarn install`, then `yarn typecheck:tsgo`
+   and `yarn jest --no-watch --testPathPattern='public/app/features/explore'`
+   to confirm the consumer (`get-window` via slate-era editor code)
+   still works.

--- a/packages/get-document/index.js
+++ b/packages/get-document/index.js
@@ -1,0 +1,57 @@
+
+/**
+ * Module exports.
+ */
+
+module.exports = getDocument;
+
+// defined by w3c
+var DOCUMENT_NODE = 9;
+
+/**
+ * Returns `true` if `w` is a Document object, or `false` otherwise.
+ *
+ * @param {?} d - Document object, maybe
+ * @return {Boolean}
+ * @private
+ */
+
+function isDocument (d) {
+  return d && d.nodeType === DOCUMENT_NODE;
+}
+
+/**
+ * Returns the `document` object associated with the given `node`, which may be
+ * a DOM element, the Window object, a Selection, a Range. Basically any DOM
+ * object that references the Document in some way, this function will find it.
+ *
+ * @param {Mixed} node - DOM node, selection, or range in which to find the `document` object
+ * @return {Document} the `document` object associated with `node`
+ * @public
+ */
+
+function getDocument(node) {
+  if (isDocument(node)) {
+    return node;
+
+  } else if (isDocument(node.ownerDocument)) {
+    return node.ownerDocument;
+
+  } else if (isDocument(node.document)) {
+    return node.document;
+
+  } else if (node.parentNode) {
+    return getDocument(node.parentNode);
+
+  // Range support
+  } else if (node.commonAncestorContainer) {
+    return getDocument(node.commonAncestorContainer);
+
+  } else if (node.startContainer) {
+    return getDocument(node.startContainer);
+
+  // Selection support
+  } else if (node.anchorNode) {
+    return getDocument(node.anchorNode);
+  }
+}

--- a/packages/get-document/package.json
+++ b/packages/get-document/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "get-document",
+  "version": "1.0.0-grafana.0",
+  "description": "Vendored fork of get-document — see VENDORED.md",
+  "license": "MIT",
+  "private": true,
+  "main": "index.js",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/webmodules/get-document.git"
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -18253,12 +18253,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"get-document@github:webmodules/get-document#commit=a04ccb499d6e0433a368c3bb150b4899b698461f":
-  version: 1.0.0
-  resolution: "get-document@https://github.com/webmodules/get-document.git#commit=a04ccb499d6e0433a368c3bb150b4899b698461f"
-  checksum: 10/5ec51321f3a5257a08c3ea9ac1984d64302a34c786f5d5691ae1ee00aba189eedac63f401e0cf746b0c77fb84091a4d2a9b66ac23dc0e872cbac860e5e0c5245
-  languageName: node
-  linkType: hard
+"get-document@workspace:*, get-document@workspace:packages/get-document":
+  version: 0.0.0-use.local
+  resolution: "get-document@workspace:packages/get-document"
+  languageName: unknown
+  linkType: soft
 
 "get-east-asian-width@npm:^1.0.0, get-east-asian-width@npm:^1.3.0":
   version: 1.4.0


### PR DESCRIPTION
**What is this feature?**

Vendors `get-document` from `webmodules/get-document` into `packages/get-document/` and replaces the `github:` resolution in `package.json` with `workspace:*`. The upstream is effectively abandoned (last commit 2014), and `.yarnrc.yml` explicitly warns against fetching git tarballs at install time.

The npm package name is preserved so CVE scanners still match, the upstream MIT `LICENSE` ships verbatim, and `VENDORED.md` pins the source commit SHA for future syncs.

**Why do we need this feature?**

So `yarn install` doesn't fetch arbitrary tarballs from `github.com`.

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Verified locally: `yarn install` clean (no `github:` for `get-document` in `yarn.lock`), `yarn typecheck:tsgo` passes, `yarn jest --testPathPattern='public/app/features/explore'` passes (136 suites, 1039 tests). The `yarn patch:` alternative was considered and rejected — vendoring keeps the source reviewable in `git log`/`git blame`.

Please check that:

- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
