### PR TITLE
JestCanvasMockCompare: Remove from scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "codeowners-manifest:generate": "node ./scripts/codeowners-manifest/generate.js",
     "codeowners-manifest:metadata": "node ./scripts/codeowners-manifest/metadata.js",
     "codeowners-manifest:raw": "node ./scripts/codeowners-manifest/raw.js",
-    "canvas-compare": "npx jest-canvas-mock-compare-viewer",
     "dev": "NODE_ENV=dev nx exec -- webpack --config scripts/webpack/webpack.dev.ts",
     "e2e:schema-v2": "KUBERNETES_DASHBOARDS=true yarn playwright test --project dashboards",
     "e2e:playwright": "NODE_OPTIONS='-C @grafana-app/source' yarn playwright test --grep-invert @cloud-plugins",


### PR DESCRIPTION
Remove unneeded script.

The package already prompts the user to run `npx jest-canvas-mock-compare-viewer` on canvas compare test failure and since there's no longer any need to pass in cli arguments we don't need grafana to pass in anything specific at this time.