### PR TITLE
Testinfra: disable grafana.com phone-home services in tests

### DIFF
--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -499,6 +499,15 @@ func createGrafDir(t *testing.T, tmpDir string, opts GrafanaOpts) (string, strin
 	require.NoError(t, err)
 	_, err = analyticsSect.NewKey("intercom_secret", "intercom_secret_at_config")
 	require.NoError(t, err)
+	// Disable phone-home services in tests. Each of these makes outbound
+	// HTTP requests to grafana.com / stats.grafana.org on startup, which is
+	// a source of flakiness on CI runners and adds nothing to the tests.
+	_, err = analyticsSect.NewKey("reporting_enabled", "false")
+	require.NoError(t, err)
+	_, err = analyticsSect.NewKey("check_for_updates", "false")
+	require.NoError(t, err)
+	_, err = analyticsSect.NewKey("check_for_plugin_updates", "false")
+	require.NoError(t, err)
 
 	grpcServerAuth, err := cfg.NewSection("grpc_server_authentication")
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary

Three Grafana background services make outbound HTTP requests on startup that serve no purpose in integration tests but are a recurring source of flakiness on CI runners (DNS hiccups, transient 5xx from grafana.com, captive portals, etc.). Disable all three in the test config:

- `analytics.reporting_enabled = false` — stops [usagestats](pkg/infra/usagestats/service/usage_stats.go#L131) from POSTing to `stats.grafana.org`.
- `analytics.check_for_updates = false` — stops [updatemanager.GrafanaService](pkg/services/updatemanager/grafana.go#L60) from GETting `https://grafana.com/api/grafana/versions/stable` on Run (and every 24h thereafter).
- `analytics.check_for_plugin_updates = false` — stops two services that ping grafana.com:
  - [updatemanager.PluginsService](pkg/services/updatemanager/plugins.go#L101) (immediate + every 10m)
  - [angulardetectorsprovider.Dynamic](pkg/services/pluginsintegration/angulardetectorsprovider/dynamic.go#L71) fetcher

With these flags set, each service reports `IsDisabled() == true` and is never started by dskit at all.

## Test plan

- [ ] CI integration tests still pass
- [ ] Tcpdump on a test run shows no outbound traffic to `grafana.com` / `stats.grafana.org`

🤖 Generated with [Claude Code](https://claude.com/claude-code)