### PR TITLE
Alerting: Fix toast spam when typing silence matcher regex

### DIFF
--- a/public/app/features/alerting/unified/components/silences/SilencedInstancesPreview.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencedInstancesPreview.tsx
@@ -57,7 +57,8 @@ export const SilencedInstancesPreview = ({ amSourceName, matchers: inputMatchers
   useDebouncedDeepCompare(
     () => {
       if (hasValidMatchers) {
-        getAlertmanagerAlerts({ amSourceName, filter: { matchers } });
+        // the inline "Preview not available" Alert below already surfaces the failure to the user.
+        getAlertmanagerAlerts({ amSourceName, filter: { matchers }, showErrorAlert: false });
       }
     },
     500,

--- a/public/app/features/alerting/unified/components/silences/SilencedInstancesPreview.tsx
+++ b/public/app/features/alerting/unified/components/silences/SilencedInstancesPreview.tsx
@@ -9,6 +9,7 @@ import { Alert, Badge, Icon, LoadingPlaceholder, Tooltip, useStyles2 } from '@gr
 import { type MatcherFieldValue } from 'app/features/alerting/unified/types/silence-form';
 import { matcherFieldToMatcher } from 'app/features/alerting/unified/utils/alertmanager';
 import { MATCHER_ALERT_RULE_UID } from 'app/features/alerting/unified/utils/constants';
+import { isValidRE2Regex } from 'app/features/alerting/unified/utils/matchers';
 import { type AlertmanagerAlert, type Matcher, MatcherOperator } from 'app/plugins/datasource/alertmanager/types';
 
 import { alertmanagerApi } from '../../api/alertmanagerApi';
@@ -45,11 +46,19 @@ export const SilencedInstancesPreview = ({ amSourceName, matchers: inputMatchers
   const styles = useStyles2(getStyles);
   const columns = useColumns();
 
-  // By default the form contains an empty matcher - with empty name and value and = operator
-  // We don't want to fetch previews for empty matchers as it results in all alerts returned
-  const hasValidMatchers = ruleUid || inputMatchers.some((matcher) => matcher.value && matcher.name);
+  const regexOperators = new Set([MatcherOperator.regex, MatcherOperator.notRegex]);
+  const hasInvalidRegex = inputMatchers.some(
+    (matcher) => regexOperators.has(matcher.operator) && !isValidRE2Regex(matcher.value)
+  );
 
-  const [getAlertmanagerAlerts, { currentData: alerts = [], isFetching, isError }] = useLazyQuery();
+  // By default the form contains an empty matcher - with empty name and value and = operator
+  // We don't want to fetch previews for empty matchers as it results in all alerts returned,
+  // and we don't want to send invalid regexes to the backend.
+  const hasValidMatchers =
+    !hasInvalidRegex && Boolean(ruleUid || inputMatchers.some((matcher) => matcher.value && matcher.name));
+
+  const [getAlertmanagerAlerts, { currentData: alerts = [], isFetching, isError: isBackendError }] = useLazyQuery();
+  const isError = isBackendError || hasInvalidRegex;
 
   // We need to deep compare the matchers, as otherwise the preview API call is triggered on every render
   // of the component. This is because between react-hook-form's useFieldArray, and our parsing of the matchers,

--- a/public/app/features/alerting/unified/utils/matchers.test.ts
+++ b/public/app/features/alerting/unified/utils/matchers.test.ts
@@ -4,6 +4,7 @@ import {
   encodeMatcher,
   getMatcherQueryParams,
   isPromQLStyleMatcher,
+  isValidRE2Regex,
   labelsToMatchersParam,
   matcherToObjectMatcher,
   normalizeMatchers,
@@ -318,5 +319,28 @@ describe('labelsToMatchersParam', () => {
 
   it('should handle labels with special characters', () => {
     expect(labelsToMatchersParam({ 'job-name': 'my\\job' })).toBe('{job-name="my\\\\job"}');
+  });
+});
+
+describe('isValidRE2Regex', () => {
+  it('accepts valid regex patterns', () => {
+    expect(isValidRE2Regex('foo.*bar')).toBe(true);
+    expect(isValidRE2Regex('frontend|backend')).toBe(true);
+    expect(isValidRE2Regex('[a-z]+')).toBe(true);
+    expect(isValidRE2Regex('')).toBe(true);
+  });
+
+  it('rejects invalid regex patterns', () => {
+    expect(isValidRE2Regex('[')).toBe(false);
+    expect(isValidRE2Regex('(unclosed')).toBe(false);
+    expect(isValidRE2Regex('*invalid')).toBe(false);
+  });
+
+  it('accepts RE2 inline flag groups that would throw in plain JS', () => {
+    expect(isValidRE2Regex('(?i)foo')).toBe(true);
+    expect(isValidRE2Regex('(?s)foo.bar')).toBe(true);
+    expect(isValidRE2Regex('(?im)foo')).toBe(true);
+    expect(isValidRE2Regex('(?-i)foo')).toBe(true);
+    expect(isValidRE2Regex('(?i)(?m)foo')).toBe(true);
   });
 });

--- a/public/app/features/alerting/unified/utils/matchers.ts
+++ b/public/app/features/alerting/unified/utils/matchers.ts
@@ -8,6 +8,7 @@
 import { chain, compact } from 'lodash';
 
 import { type LabelMatcher } from '@grafana/alerting/unstable';
+import { parseFlags } from '@grafana/data';
 import {
   type Matcher,
   MatcherOperator,
@@ -266,6 +267,18 @@ export function convertObjectMatcherToAlertingPackageMatcher(matcher: ObjectMatc
     type,
     value,
   };
+}
+
+export function isValidRE2Regex(value: string): boolean {
+  // parseFlags converts RE2 inline flag groups like (?i), (?im), (?-i) to their JS flag equivalents,
+  // allowing new RegExp() to correctly validate patterns that use RE2-only flag syntax.
+  const { cleaned, flags } = parseFlags(value);
+  try {
+    new RegExp(cleaned, flags);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 export function labelsToMatchersParam(labels: Labels): string | undefined {


### PR DESCRIPTION
This PR supresses redundant error toast notifications on the silence creation form when typing an invalid matcher regex.

When a user types a regex matcher (=~ or !~) on /alerting/silence/new, SilencedInstancesPreview fires a debounced (500ms) request to preview affected alerts on every matcher change. Intermediate values typed by the user are often invalid regexes (e.g. (, (d, (dd|), causing the backend to return 400. With the default showErrorAlert: true on getAlertmanagerAlerts, each failed request raises a toast, so the user ends up with a stack of red error notifications while typing.

The component already renders an inline "Preview not available" alert for the same failure, so the toasts are redundant noise.

Before:
https://github.com/user-attachments/assets/6077e931-aa35-4510-b4c1-d6299e758ecb

After:
<img width="1512" height="902" alt="Kapture 2026-05-28 at 13 48 06" src="https://github.com/user-attachments/assets/e3f30e4f-287e-441e-a3c2-c002c07ded64" />
