### PR TITLE
Testinfra: symlink read-only static dirs instead of copying

### DIFF
--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -309,8 +309,12 @@ func createGrafDir(t *testing.T, tmpDir string, opts GrafanaOpts) (string, strin
 	err = os.MkdirAll(publicDir, 0o750)
 	require.NoError(t, err)
 
+	// Symlink read-only static assets from the source tree instead of copying.
+	// The plugin loader / template renderer only read from these paths, and
+	// CopyRecursive on public/app/plugins (~74 MB, ~66 plugins) is a measurable
+	// chunk of per-test startup time.
 	viewsDir := filepath.Join(publicDir, "views")
-	err = fs.CopyRecursive(filepath.Join(rootDir, "public", "views"), viewsDir)
+	err = os.Symlink(filepath.Join(rootDir, "public", "views"), viewsDir)
 	require.NoError(t, err)
 
 	// add a stub manifest to the build directory
@@ -349,7 +353,7 @@ func createGrafDir(t *testing.T, tmpDir string, opts GrafanaOpts) (string, strin
 	require.NoError(t, err)
 
 	emailsDir := filepath.Join(publicDir, "emails")
-	err = fs.CopyRecursive(filepath.Join(rootDir, "public", "emails"), emailsDir)
+	err = os.Symlink(filepath.Join(rootDir, "public", "emails"), emailsDir)
 	require.NoError(t, err)
 	provDir := filepath.Join(cfgDir, "provisioning")
 	provDSDir := filepath.Join(provDir, "datasources")
@@ -364,8 +368,10 @@ func createGrafDir(t *testing.T, tmpDir string, opts GrafanaOpts) (string, strin
 	provDashboardsDir := filepath.Join(provDir, "dashboards")
 	err = os.MkdirAll(provDashboardsDir, 0o750)
 	require.NoError(t, err)
+	err = os.MkdirAll(filepath.Join(publicDir, "app"), 0o750)
+	require.NoError(t, err)
 	corePluginsDir := filepath.Join(publicDir, "app/plugins")
-	err = fs.CopyRecursive(filepath.Join(rootDir, "public", "app/plugins"), corePluginsDir)
+	err = os.Symlink(filepath.Join(rootDir, "public", "app/plugins"), corePluginsDir)
 	require.NoError(t, err)
 
 	cfg := ini.Empty()


### PR DESCRIPTION
## Summary

[testinfra.go](pkg/tests/testinfra/testinfra.go) currently calls `fs.CopyRecursive` for three static asset trees on every test setup:

| Tree | Size |
| --- | --- |
| `public/views` | 24 KB |
| `public/emails` | 308 KB |
| `public/app/plugins` | ~74 MB (66 core plugins) |

These paths are only read at runtime:
- [pluginsources.go:70-74](pkg/services/pluginsintegration/pluginsources/pluginsources.go#L70-L74) reads `<static>/app/plugins/{datasource,panel}` for core plugin loading
- [http_server.go:694-695](pkg/api/http_server.go#L694-L695) serves `views/` as static
- [home/reader.go](pkg/registry/apis/dashboard/home/reader.go#L33) and friends read `dashboards/home.json`

Nothing writes to these dirs, so replacing the copy with `os.Symlink` to the source tree is equivalent and removes ~74 MB of disk I/O per test setup. Integration tests that spin up a fresh `K8sTestHelper` per subtest (e.g. `TestIntegrationGlobalRole` runs three DualWriter modes) get this saving 3× per test.

`t.TempDir`'s `RemoveAll` removes symlinks, not targets, so cleanup is safe.

## Test plan

- [ ] Existing integration tests still pass on CI
- [ ] Confirm `<tmpdir>/public/{views,emails,app/plugins}` are symlinks in a local test run