### PR TITLE
CI: migrate dashboards-issue-add-label to GATB

### DIFF
--- a/.github/workflows/dashboards-issue-add-label.yml
+++ b/.github/workflows/dashboards-issue-add-label.yml
@@ -21,24 +21,14 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - name: "Get vault secrets"
-        id: vault-secrets
-        uses: grafana/shared-workflows/actions/get-vault-secrets@main # zizmor: ignore[unpinned-uses]
+      - name: Get GitHub App token
+        id: get-github-app-token
+        uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
         with:
-          # Secrets placed in the ci/repo/grafana/grafana/plugins_platform_issue_commands_github_bot path in Vault
-          repo_secrets: |
-            GITHUB_APP_ID=grafana_pr_automation_app:app_id
-            GITHUB_APP_PRIVATE_KEY=grafana_pr_automation_app:app_pem
-
-      - name: Generate token
-        id: generate_token
-        uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
-        with:
-          app-id: ${{ env.GITHUB_APP_ID }}
-          private-key: ${{ env.GITHUB_APP_PRIVATE_KEY }}
+          github_app: grafana-pr-automation
       - name: Check if issue is in target project
         env:
-          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+          GH_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           TARGET_PROJECT: ${{ env.TARGET_PROJECT }}
         run: |
@@ -76,7 +66,7 @@ jobs:
       - name: Add label to issue
         if: env.IN_TARGET_PROJ
         env:
-          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+          GH_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
           LABEL_IDS: ${{ env.LABEL_IDS }}
         run: |
           # shellcheck disable=SC2016 # we don't want the $s to be expanded


### PR DESCRIPTION
Migrate the `dashboards-issue-add-label` workflow from the legacy Vault private-key pattern to the GitHub App Token Broker (GATB).

### Key changes

- Removed the `get-vault-secrets` step that pulled `app_id` and `app_pem` from the [grafana_pr_automation_app` Vault path
- Removed the `actions/create-github-app-token@v2.0.2` step that minted the token locally using the private key
- Added a single `grafana/shared-workflows/actions/create-github-app-token@v0.2.3` step using GATB with `github_app: grafana-pr-automation`
- Updated the two `GH_TOKEN` references to use the new step's output (`steps.get-github-app-token.outputs.token`)