### PR TITLE
Chore: replace os.Exit with returned errors in library code

### DIFF
--- a/pkg/cmd/grafana-cli/commands/secretsconsolidation/secretsconsolidation.go
+++ b/pkg/cmd/grafana-cli/commands/secretsconsolidation/secretsconsolidation.go
@@ -15,7 +15,7 @@ import (
 	"github.com/grafana/grafana/pkg/server"
 )
 
-func ConsolidateSecrets(cmd utils.CommandLine, runner server.Runner) error {
+func ConsolidateSecrets(cmd utils.CommandLine, runner server.Runner) (retErr error) {
 	ctx := context.Background()
 
 	cpuProfilePath := cmd.String("cpuprofile")
@@ -32,8 +32,12 @@ func ConsolidateSecrets(cmd utils.CommandLine, runner server.Runner) error {
 		if err != nil {
 			return fmt.Errorf("create CPU profile file: %w", err)
 		}
+		// Close errors on write files can indicate a failed final flush;
+		// surface them via the named return when no earlier error has occurred.
 		defer func() {
-			_ = f.Close()
+			if cerr := f.Close(); cerr != nil && retErr == nil {
+				retErr = fmt.Errorf("close CPU profile file: %w", cerr)
+			}
 		}()
 		if err := pprof.StartCPUProfile(f); err != nil {
 			return fmt.Errorf("start CPU profile: %w", err)
@@ -73,7 +77,9 @@ func ConsolidateSecrets(cmd utils.CommandLine, runner server.Runner) error {
 			return fmt.Errorf("create memory profile file: %w", err)
 		}
 		defer func() {
-			_ = f.Close()
+			if cerr := f.Close(); cerr != nil && retErr == nil {
+				retErr = fmt.Errorf("close memory profile file: %w", cerr)
+			}
 		}()
 		runtime.GC()
 		if err := pprof.WriteHeapProfile(f); err != nil {

--- a/pkg/infra/log/log.go
+++ b/pkg/infra/log/log.go
@@ -494,7 +494,11 @@ func ReadLoggingConfig(modes []string, logsPath string, cfg *ini.File) error {
 			loggersToReload = append(loggersToReload, fileHandler)
 			handler.val = fileHandler
 		case "syslog":
-			sysLogHandler := NewSyslog(sec, format)
+			sysLogHandler, err := NewSyslog(sec, format)
+			if err != nil {
+				_ = level.Error(root).Log("Failed to initialize syslog handler", "err", err)
+				continue
+			}
 			loggersToClose = append(loggersToClose, sysLogHandler)
 			handler.val = sysLogHandler.logger
 		}

--- a/pkg/infra/log/syslog.go
+++ b/pkg/infra/log/syslog.go
@@ -6,7 +6,6 @@ package log
 import (
 	"fmt"
 	"log/syslog"
-	"os"
 
 	"github.com/go-kit/log"
 	"github.com/go-kit/log/level"
@@ -46,7 +45,7 @@ var selector = func(keyvals ...any) syslog.Priority {
 	return syslog.LOG_INFO
 }
 
-func NewSyslog(sec *ini.Section, format Formatedlogger) *SysLogHandler {
+func NewSyslog(sec *ini.Section, format Formatedlogger) (*SysLogHandler, error) {
 	handler := &SysLogHandler{}
 
 	handler.Format = format
@@ -56,19 +55,16 @@ func NewSyslog(sec *ini.Section, format Formatedlogger) *SysLogHandler {
 	handler.Tag = sec.Key("tag").MustString("")
 
 	if err := handler.Init(); err != nil {
-		fmt.Printf("Failed to init syslog handler. Error: %v\n", err)
-		root.Error("Failed to init syslog log handler", "error", err)
-		os.Exit(1)
+		return nil, fmt.Errorf("init syslog handler: %w", err)
 	}
 	handler.logger = gokitsyslog.NewSyslogLogger(handler.syslog, format, gokitsyslog.PrioritySelectorOption(selector))
 
 	if err := handler.Log("msg", "syslog logger initialized"); err != nil {
-		fmt.Printf("Failed to log to syslog handler. Error: %v\n", err)
-		root.Error("Failed to log to syslog log handler", "error", err)
-		os.Exit(1)
+		_ = handler.Close()
+		return nil, fmt.Errorf("log to syslog handler: %w", err)
 	}
 
-	return handler
+	return handler, nil
 }
 
 func (sw *SysLogHandler) Init() error {

--- a/pkg/infra/log/syslog_windows.go
+++ b/pkg/infra/log/syslog_windows.go
@@ -12,8 +12,8 @@ type SysLogHandler struct {
 	logger log.Logger
 }
 
-func NewSyslog(sec *ini.Section, format Formatedlogger) *SysLogHandler {
-	return &SysLogHandler{}
+func NewSyslog(sec *ini.Section, format Formatedlogger) (*SysLogHandler, error) {
+	return &SysLogHandler{}, nil
 }
 
 func (sw *SysLogHandler) Log(keyvals ...any) error {

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -828,8 +828,7 @@ func (cfg *Cfg) parseAppUrlAndSubUrl(section *ini.Section) (string, string, erro
 	// Check if has app suburl.
 	url, err := url.Parse(appUrl)
 	if err != nil {
-		cfg.Logger.Error("Invalid root_url.", "url", appUrl, "error", err)
-		os.Exit(1)
+		return "", "", fmt.Errorf("invalid root_url %q: %w", appUrl, err)
 	}
 
 	appSubUrl := strings.TrimSuffix(url.Path, "/")
@@ -1199,7 +1198,7 @@ func (cfg *Cfg) applyCommandLineProperties(file *ini.File) {
 	}
 }
 
-func (cfg *Cfg) getCommandLineProperties(args []string) map[string]string {
+func (cfg *Cfg) getCommandLineProperties(args []string) (map[string]string, error) {
 	props := make(map[string]string)
 
 	for _, arg := range args {
@@ -1210,13 +1209,12 @@ func (cfg *Cfg) getCommandLineProperties(args []string) map[string]string {
 		trimmed := strings.TrimPrefix(arg, "cfg:")
 		parts := strings.Split(trimmed, "=")
 		if len(parts) != 2 {
-			cfg.Logger.Error("Invalid command line argument.", "argument", arg)
-			os.Exit(1)
+			return nil, fmt.Errorf("invalid command line argument %q: expected cfg:key=value", arg)
 		}
 
 		props[parts[0]] = parts[1]
 	}
-	return props
+	return props, nil
 }
 
 func makeAbsolute(path string, root string) string {
@@ -1274,20 +1272,20 @@ func (cfg *Cfg) loadConfiguration(args CommandLineArgs) (*ini.File, error) {
 
 	// check if config file exists
 	if _, err := os.Stat(defaultConfigFile); os.IsNotExist(err) {
-		fmt.Println("Grafana-server Init Failed: Could not find config defaults, make sure homepath command line parameter is set or working directory is homepath")
-		os.Exit(1)
+		return nil, fmt.Errorf("could not find config defaults at %q, make sure homepath command line parameter is set or working directory is homepath", defaultConfigFile)
 	}
 
 	// load defaults
 	parsedFile, err := ini.Load(defaultConfigFile)
 	if err != nil {
-		fmt.Printf("Failed to parse defaults.ini, %v\n", err)
-		os.Exit(1)
-		return nil, err
+		return nil, fmt.Errorf("failed to parse defaults.ini: %w", err)
 	}
 
 	// command line props
-	cfg.commandLineProps = cfg.getCommandLineProperties(args.Args)
+	cfg.commandLineProps, err = cfg.getCommandLineProperties(args.Args)
+	if err != nil {
+		return nil, err
+	}
 	// load default overrides
 	cfg.applyCommandLineDefaultProperties(parsedFile)
 
@@ -1298,8 +1296,7 @@ func (cfg *Cfg) loadConfiguration(args CommandLineArgs) (*ini.File, error) {
 		if err2 != nil {
 			return nil, err2
 		}
-		cfg.Logger.Error(err.Error())
-		os.Exit(1)
+		return nil, err
 	}
 
 	// apply environment overrides

--- a/pkg/setting/setting_test.go
+++ b/pkg/setting/setting_test.go
@@ -190,7 +190,8 @@ func TestLoadingSettings(t *testing.T) {
 
 	t.Run("Should get property map from command line args array", func(t *testing.T) {
 		cfg := NewCfg()
-		props := cfg.getCommandLineProperties([]string{"cfg:test=value", "cfg:map.test=1"})
+		props, err := cfg.getCommandLineProperties([]string{"cfg:test=value", "cfg:map.test=1"})
+		require.NoError(t, err)
 
 		require.Equal(t, 2, len(props))
 		require.Equal(t, "value", props["test"])

--- a/pkg/storage/unified/sql/sqltemplate/mocks/test_snapshots.go
+++ b/pkg/storage/unified/sql/sqltemplate/mocks/test_snapshots.go
@@ -153,7 +153,7 @@ func CheckQuerySnapshots(t *testing.T, setup TemplateTestSetup) {
 									}
 								}
 								if update {
-									_ = os.WriteFile(fpath, []byte(clean), 0777)
+									_ = os.WriteFile(fpath, []byte(clean), 0644)
 								}
 							})
 						}


### PR DESCRIPTION
## Summary

Findings from a small audit of `os`/`fs` usage in the backend. Two themes:

**Replace `os.Exit(1)` in library packages with returned errors.** Library code that exits the process prevents reuse and makes failure modes hard to test. Where the surrounding function already returned an error, the fix was mechanical.

- `pkg/infra/log/syslog`: `NewSyslog` now returns `(*SysLogHandler, error)`. The caller in `log.go` logs the failure and continues, matching the pattern already used for the file handler.
- `pkg/setting/setting.go`: `loadConfiguration`, `parseAppUrlAndSubUrl`, and `getCommandLineProperties` propagate errors instead of exiting. The unit test for `getCommandLineProperties` was updated for the new signature.

**Two small unrelated cleanups from the same audit:**

- `secretsconsolidation`: the deferred `f.Close()` on pprof profile files was discarding errors via `_ = f.Close()`. Close errors on write files can indicate truncated output (failed final flush). Switched to a named return so a close error surfaces when no earlier error occurred.
- `test_snapshots.go`: a test helper was writing snapshot files with `0777`. Dropped to `0644`.

**Intentionally skipped:**

- The three `os.Exit(1)` sites in `pkg/services/sqlstore/sqlstore.go` — they live in `SetupTestDB`/`CleanupTestDB`/`initTestDB`, called from ~150 `TestMain` functions. Exit-on-error in `TestMain` is idiomatic, not a library-design problem.
- `ioutil` usage in `pkg/build/wire/` — vendored from `google/wire`, better fixed upstream.

## Test plan

- [x] `go build` passes for all affected packages
- [x] `go build` cross-compiles for `GOOS=windows` (syslog_windows.go signature)
- [x] `go test ./pkg/infra/log/... ./pkg/setting/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)