### PR TITLE
ShortURL: Improve get error handling and delete

### DIFF
--- a/pkg/api/short_url.go
+++ b/pkg/api/short_url.go
@@ -116,6 +116,7 @@ func (hs *HTTPServer) getShortURL(c *contextmodel.ReqContext) response.Response 
 		if shorturls.ErrShortURLNotFound.Is(err) {
 			return response.Err(shorturls.ErrShortURLNotFound.Errorf("shorturl not found: %w", err))
 		}
+		return response.Err(shorturls.ErrShortURLInternal.Errorf("failed to get short URL: %w", err))
 	}
 
 	return response.JSON(http.StatusOK, shortURL)

--- a/pkg/api/short_url_test.go
+++ b/pkg/api/short_url_test.go
@@ -51,6 +51,48 @@ func TestShortURLAPIEndpoint(t *testing.T) {
 				require.Equal(t, fmt.Sprintf("http://localhost:3000/goto/%s?orgId=%d", createResp.Uid, createResp.OrgId), shortUrl.URL)
 			})
 	})
+
+	t.Run("GET /api/short-urls/:uid surfaces non-NotFound errors instead of returning 200 + null", func(t *testing.T) {
+		service := &fakeShortURLService{
+			getShortURLByUIDFunc: func(ctx context.Context, _ identity.Requester, _ string) (*shorturls.ShortUrl, error) {
+				return nil, fmt.Errorf("database unavailable")
+			},
+		}
+
+		getShortURLScenario(t, "When calling GET on", "/api/short-urls/some-uid", "/api/short-urls/:uid", service,
+			func(sc *scenarioContext) {
+				sc.fakeReqWithParams("GET", sc.url, map[string]string{}).exec()
+
+				require.Equal(t, 500, sc.resp.Code)
+				require.NotEqual(t, "null", sc.resp.Body.String())
+			})
+	})
+
+	t.Run("GET /api/short-urls/:uid still returns 404 when the short URL is not found", func(t *testing.T) {
+		service := &fakeShortURLService{
+			getShortURLByUIDFunc: func(ctx context.Context, _ identity.Requester, _ string) (*shorturls.ShortUrl, error) {
+				return nil, shorturls.ErrShortURLNotFound.Errorf("not found")
+			},
+		}
+
+		getShortURLScenario(t, "When calling GET on", "/api/short-urls/some-uid", "/api/short-urls/:uid", service,
+			func(sc *scenarioContext) {
+				sc.fakeReqWithParams("GET", sc.url, map[string]string{}).exec()
+
+				require.Equal(t, 404, sc.resp.Code)
+			})
+	})
+
+	t.Run("GET /api/short-urls/:uid returns 400 on invalid UID format", func(t *testing.T) {
+		service := &fakeShortURLService{}
+
+		getShortURLScenario(t, "When calling GET on", "/api/short-urls/bad%20uid", "/api/short-urls/:uid", service,
+			func(sc *scenarioContext) {
+				sc.fakeReqWithParams("GET", sc.url, map[string]string{}).exec()
+
+				require.Equal(t, 400, sc.resp.Code)
+			})
+	})
 }
 
 func callCreateShortURL(sc *scenarioContext) {
@@ -81,8 +123,31 @@ func createShortURLScenario(t *testing.T, desc string, url string, routePattern 
 	})
 }
 
+func getShortURLScenario(t *testing.T, desc string, url string, routePattern string, shortURLService shorturls.Service, fn scenarioFunc) {
+	t.Run(fmt.Sprintf("%s %s", desc, url), func(t *testing.T) {
+		hs := HTTPServer{
+			Cfg:             setting.NewCfg(),
+			ShortURLService: shortURLService,
+			log:             log.New("test"),
+		}
+
+		sc := setupScenarioContext(t, url)
+		sc.defaultHandler = routing.Wrap(func(c *contextmodel.ReqContext) response.Response {
+			sc.context = c
+			sc.context.SignedInUser = &user.SignedInUser{OrgID: testOrgID, UserID: testUserID}
+
+			return hs.getShortURL(c)
+		})
+
+		sc.m.Get(routePattern, sc.defaultHandler)
+
+		fn(sc)
+	})
+}
+
 type fakeShortURLService struct {
 	createShortURLFunc         func(ctx context.Context, user identity.Requester, cmd *dtos.CreateShortURLCmd) (*shorturls.ShortUrl, error)
+	getShortURLByUIDFunc       func(ctx context.Context, user identity.Requester, uid string) (*shorturls.ShortUrl, error)
 	createConvertShortURLToDTO func(shortURL *shorturls.ShortUrl, appURL string) *dtos.ShortURL
 }
 
@@ -91,6 +156,9 @@ func (s *fakeShortURLService) List(ctx context.Context, orgID int64) ([]*shortur
 }
 
 func (s *fakeShortURLService) GetShortURLByUID(ctx context.Context, user identity.Requester, uid string) (*shorturls.ShortUrl, error) {
+	if s.getShortURLByUIDFunc != nil {
+		return s.getShortURLByUIDFunc(ctx, user, uid)
+	}
 	return nil, nil
 }
 

--- a/pkg/registry/apps/shorturl/legacy_storage.go
+++ b/pkg/registry/apps/shorturl/legacy_storage.go
@@ -163,6 +163,10 @@ func (s *legacyStorage) Update(ctx context.Context,
 
 // GracefulDeleter
 func (s *legacyStorage) Delete(ctx context.Context, name string, deleteValidation rest.ValidateObjectFunc, options *metav1.DeleteOptions) (runtime.Object, bool, error) {
+	requester, err := identity.GetRequester(ctx)
+	if err != nil {
+		return nil, false, err
+	}
 	v, err := s.Get(ctx, name, &metav1.GetOptions{})
 	if err != nil {
 		return v, false, err // includes the not-found error
@@ -171,6 +175,9 @@ func (s *legacyStorage) Delete(ctx context.Context, name string, deleteValidatio
 	if !ok {
 		return v, false, fmt.Errorf("expected a shorturl response from Get")
 	}
-	err = s.service.DeleteStaleShortURLs(ctx, &shorturls.DeleteShortUrlCommand{Uid: name})
+	err = s.service.DeleteStaleShortURLs(ctx, &shorturls.DeleteShortUrlCommand{
+		OrgId: requester.GetOrgID(),
+		Uid:   name,
+	})
 	return p, true, err // true is instant delete
 }

--- a/pkg/services/shorturls/models.go
+++ b/pkg/services/shorturls/models.go
@@ -70,6 +70,7 @@ func ValidateRelativePath(rawPath string) error {
 }
 
 type DeleteShortUrlCommand struct {
+	OrgId     int64
 	Uid       string
 	OlderThan time.Time
 

--- a/pkg/services/shorturls/shorturlimpl/shorturl_test.go
+++ b/pkg/services/shorturls/shorturlimpl/shorturl_test.go
@@ -213,4 +213,53 @@ func TestIntegrationShortURLService(t *testing.T) {
 		require.ErrorIs(t, err, shorturls.ErrShortURLConflict)
 		require.Nil(t, newShortURL2)
 	})
+
+	t.Run("Delete by UID is scoped to the caller's org", func(t *testing.T) {
+		service := ShortURLService{SQLStore: &sqlStore{db: store}}
+
+		ctx := context.Background()
+		inOrg1 := *user
+		inOrg1.UserID = 10
+		inOrg1.OrgID = 100
+		user1 := &inOrg1
+
+		inOrg2 := *user
+		inOrg2.UserID = 20
+		inOrg2.OrgID = 200
+		user2 := &inOrg2
+
+		urlUser2, err := service.CreateShortURL(ctx, user2, &dtos.CreateShortURLCmd{
+			Path: "user2/path",
+			UID:  "shared-uid",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, urlUser2)
+
+		urlUser1, err := service.CreateShortURL(ctx, user1, &dtos.CreateShortURLCmd{
+			Path: "user1/path",
+			UID:  "shared-uid",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, urlUser1)
+
+		delCmd := shorturls.DeleteShortUrlCommand{OrgId: user1.OrgID, Uid: "shared-uid"}
+		err = service.DeleteStaleShortURLs(ctx, &delCmd)
+		require.NoError(t, err)
+		require.Equal(t, int64(1), delCmd.NumDeleted)
+
+		_, err = service.GetShortURLByUID(ctx, user1, "shared-uid")
+		require.ErrorIs(t, err, shorturls.ErrShortURLNotFound)
+
+		survived, err := service.GetShortURLByUID(ctx, user2, "shared-uid")
+		require.NoError(t, err)
+		require.NotNil(t, survived)
+		require.Equal(t, "user2/path", survived.Path)
+	})
+
+	t.Run("Delete by UID without org id is rejected", func(t *testing.T) {
+		service := ShortURLService{SQLStore: &sqlStore{db: store}}
+
+		err := service.DeleteStaleShortURLs(context.Background(), &shorturls.DeleteShortUrlCommand{Uid: "any-uid"})
+		require.ErrorIs(t, err, shorturls.ErrShortURLBadRequest)
+	})
 }

--- a/pkg/services/shorturls/shorturlimpl/store.go
+++ b/pkg/services/shorturls/shorturlimpl/store.go
@@ -59,12 +59,15 @@ func (s sqlStore) Insert(ctx context.Context, shortURL *shorturls.ShortUrl) erro
 }
 
 func (s sqlStore) Delete(ctx context.Context, cmd *shorturls.DeleteShortUrlCommand) error {
-	// If a UID is provided, delete that specific short URL
+	// If a UID is provided, delete that specific short URL scoped to the caller's org
 	if cmd.Uid != "" {
+		if cmd.OrgId == 0 {
+			return shorturls.ErrShortURLBadRequest.Errorf("org id is required to delete a short URL by uid")
+		}
 		return s.db.WithTransactionalDbSession(ctx, func(session *db.Session) error {
-			var rawSql = "DELETE FROM short_url WHERE uid = ?"
+			var rawSql = "DELETE FROM short_url WHERE org_id = ? AND uid = ?"
 
-			if result, err := session.Exec(rawSql, cmd.Uid); err != nil {
+			if result, err := session.Exec(rawSql, cmd.OrgId, cmd.Uid); err != nil {
 				return err
 			} else if cmd.NumDeleted, err = result.RowsAffected(); err != nil {
 				return err


### PR DESCRIPTION
**What is this feature?**

* Fix error handling on get shorturl and error is different than not found
* Scope deletion to org-id in the new k8s delete endpoint

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
