### PR TITLE
ci(backport): pin grafana-github-actions-go to a SHA instead of @dev

### DIFF
--- a/.github/workflows/backport-workflow.yml
+++ b/.github/workflows/backport-workflow.yml
@@ -58,14 +58,7 @@ jobs:
           ref: ${{ github.event.repository.default_branch }}
           fetch-depth: 2
           fetch-tags: false
-          token: ${{ steps.get-github-app-token.outputs.token }}
-          persist-credentials: true
-
-      - name: Configure git user
-        run: |
-          git config --local user.name "github-actions[bot]"
-          git config --local user.email "github-actions[bot]@users.noreply.github.com"
-          git config --local --add --bool push.autoSetupRemote true
+          persist-credentials: false
 
       - name: Run backport
         uses: grafana/grafana-github-actions-go/backport@6782bcaa01680648bdbba76cce1847e1862dbb22

--- a/.github/workflows/backport-workflow.yml
+++ b/.github/workflows/backport-workflow.yml
@@ -68,7 +68,7 @@ jobs:
           git config --local --add --bool push.autoSetupRemote true
 
       - name: Run backport
-        uses: grafana/grafana-github-actions-go/backport@cbf714b93d4ac1da0a09af9f7f487d4b6b3ed060 # main
+        uses: grafana/grafana-github-actions-go/backport@6782bcaa01680648bdbba76cce1847e1862dbb22
         with:
           token: ${{ steps.get-github-app-token.outputs.token }}
           # If triggered by being labelled, only backport that label.


### PR DESCRIPTION
The org is heading toward required signed commits on protected branches. This PR pins \`grafana/grafana-github-actions-go/backport\` to a SHA that publishes via GitHub's GraphQL \`createCommitOnBranch\` mutation, so backport commits are signed on behalf of \`grafana-pr-automation\`.

It also fixes the broken backport on main: the previous SHA (\`cbf714b9…\`, merged in #125612) used \`uses: ./build-go-binary\` internally, which the GitHub Actions runner resolves relative to the consumer's workspace rather than the action's directory — see https://github.com/grafana/grafana/actions/runs/26580883948/job/78313224150. That was fixed upstream in [grafana-github-actions-go#208](https://github.com/grafana/grafana-github-actions-go/pull/208), and this PR pins to that fix.

Changes:
- Pin action from \`@cbf714b9…\` to SHA \`6782bcaa…\` (the merge of upstream fix #208). Fixes broken main; gives signed commits.
- Drop the \`Configure git user\` step — the new action sets a default committer identity itself, and \`push.autoSetupRemote\` is irrelevant now that publishing goes through GraphQL instead of \`git push\`.
- Drop \`persist-credentials: true\` and the explicit \`token:\` on \`actions/checkout\` — both were only needed when the old action used \`git push\`. The new action authenticates against GraphQL with the App token directly.

I've tested the equivalent change end-to-end in \`grafana/mimir\`. I will not test it here — codeowners are responsible for validating it post-merge on a real sentinel PR labeled \`backport <release-branch>\`.