### PR TITLE
Alerting: Support Amazon and Azure Managed Prometheus in rule converter

### DIFF
--- a/pkg/services/ngalert/prom/convert.go
+++ b/pkg/services/ngalert/prom/convert.go
@@ -28,13 +28,26 @@ const (
 var (
 	ErrInvalidDatasourceType = errutil.ValidationFailed(
 		"alerting.invalidDatasourceType",
-		errutil.WithPublicMessage("Datasource type must be Prometheus or Loki to import rules."),
+		errutil.WithPublicMessage("Datasource type must be Prometheus (including Amazon Managed Prometheus and Azure Managed Prometheus) or Loki to import rules."),
 	)
 	ErrInvalidTargetDatasourceType = errutil.ValidationFailed(
 		"alerting.invalidTargetDatasourceType",
-		errutil.WithPublicMessage("Target datasource type must be Prometheus for recording rules."),
+		errutil.WithPublicMessage("Target datasource type must be Prometheus (including Amazon Managed Prometheus and Azure Managed Prometheus) for recording rules."),
 	)
 )
+
+// isPrometheusCompatible reports whether dsType is a Prometheus datasource
+// or one of the managed Prometheus variants (AWS / Azure) that expose the
+// same wire and rule format as native Prometheus.
+func isPrometheusCompatible(dsType string) bool {
+	switch dsType {
+	case datasources.DS_PROMETHEUS,
+		datasources.DS_AMAZON_PROMETHEUS,
+		datasources.DS_AZURE_PROMETHEUS:
+		return true
+	}
+	return false
+}
 
 // Config defines the configuration options for the Prometheus to Grafana rules converter.
 type Config struct {
@@ -118,8 +131,8 @@ func NewConverter(cfg Config) (*Converter, error) {
 	if cfg.KeepOriginalRuleDefinition == nil {
 		cfg.KeepOriginalRuleDefinition = defaultConfig.KeepOriginalRuleDefinition
 	}
-	if cfg.DatasourceType != datasources.DS_PROMETHEUS && cfg.DatasourceType != datasources.DS_LOKI {
-		return nil, ErrInvalidDatasourceType.Errorf("invalid datasource type: %s, must be prometheus or loki", cfg.DatasourceType)
+	if !isPrometheusCompatible(cfg.DatasourceType) && cfg.DatasourceType != datasources.DS_LOKI {
+		return nil, ErrInvalidDatasourceType.Errorf("invalid datasource type: %s, must be prometheus, a Prometheus-compatible type (Amazon/Azure Managed Prometheus), or loki", cfg.DatasourceType)
 	}
 
 	return &Converter{
@@ -218,8 +231,8 @@ func (p *Converter) convertRule(orgID int64, namespaceUID string, promGroup Prom
 	}
 
 	if isRecordingRule {
-		if p.cfg.TargetDatasourceType != datasources.DS_PROMETHEUS {
-			return models.AlertRule{}, ErrInvalidTargetDatasourceType.Errorf("invalid target datasource type: %s, must be prometheus", p.cfg.TargetDatasourceType)
+		if !isPrometheusCompatible(p.cfg.TargetDatasourceType) {
+			return models.AlertRule{}, ErrInvalidTargetDatasourceType.Errorf("invalid target datasource type: %s, must be prometheus or a Prometheus-compatible type (Amazon/Azure Managed Prometheus)", p.cfg.TargetDatasourceType)
 		}
 
 		record = &models.Record{

--- a/pkg/services/ngalert/prom/convert_test.go
+++ b/pkg/services/ngalert/prom/convert_test.go
@@ -424,6 +424,71 @@ func TestPrometheusRulesToGrafanaWithDuplicateRuleNames(t *testing.T) {
 	require.Equal(t, "alert", group.Rules[3].Title)
 }
 
+func TestNewConverter_DatasourceType(t *testing.T) {
+	defaultInterval := 2 * time.Minute
+
+	t.Run("accepts Prometheus and Loki source datasources", func(t *testing.T) {
+		for _, dsType := range []string{
+			datasources.DS_PROMETHEUS,
+			datasources.DS_LOKI,
+			datasources.DS_AMAZON_PROMETHEUS,
+			datasources.DS_AZURE_PROMETHEUS,
+		} {
+			t.Run(dsType, func(t *testing.T) {
+				_, err := NewConverter(Config{
+					DatasourceUID:   "datasource-uid",
+					DatasourceType:  dsType,
+					DefaultInterval: defaultInterval,
+				})
+				require.NoError(t, err)
+			})
+		}
+	})
+
+	t.Run("rejects unknown source datasource type", func(t *testing.T) {
+		_, err := NewConverter(Config{
+			DatasourceUID:   "datasource-uid",
+			DatasourceType:  "graphite",
+			DefaultInterval: defaultInterval,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "invalid datasource type: graphite")
+	})
+
+	t.Run("accepts Prometheus-compatible target datasources for recording rules", func(t *testing.T) {
+		recordingGroup := PrometheusRuleGroup{
+			Name:     "recording-group",
+			Interval: prommodel.Duration(10 * time.Second),
+			Rules: []PrometheusRule{
+				{
+					Record: "some_metric",
+					Expr:   "sum(rate(http_requests_total[5m]))",
+				},
+			},
+		}
+
+		for _, targetType := range []string{
+			datasources.DS_PROMETHEUS,
+			datasources.DS_AMAZON_PROMETHEUS,
+			datasources.DS_AZURE_PROMETHEUS,
+		} {
+			t.Run(targetType, func(t *testing.T) {
+				converter, err := NewConverter(Config{
+					DatasourceUID:        "datasource-uid",
+					DatasourceType:       datasources.DS_PROMETHEUS,
+					TargetDatasourceUID:  "target-datasource-uid",
+					TargetDatasourceType: targetType,
+					DefaultInterval:      defaultInterval,
+				})
+				require.NoError(t, err)
+
+				_, err = converter.PrometheusRulesToGrafana(1, "namespaceUID", recordingGroup)
+				require.NoError(t, err)
+			})
+		}
+	})
+}
+
 func TestCreateMathNode(t *testing.T) {
 	node, err := createMathNode()
 	require.NoError(t, err)


### PR DESCRIPTION
**What is this feature?**

Allow the Prometheus-to-Grafana rule converter (`pkg/services/ngalert/prom`) to accept the `grafana-amazonprometheus-datasource` (Amazon Managed Prometheus) and `grafana-azureprometheus-datasource` (Azure Managed Prometheus) datasource types, both as the *source* datasource for rule import and as the *target* datasource for recording rules.

A new helper `isPrometheusCompatible(dsType string) bool` centralises the check so the two existing call sites cannot drift apart in the future.

**Why do we need this feature?**

The Amazon Managed Prometheus and Azure Managed Prometheus plugins are variants of the core Prometheus datasource and expose the identical wire protocol and rule format. Despite that, the converter hard-codes `datasources.DS_PROMETHEUS` and rejects both variants with `alerting.invalidDatasourceType` / `alerting.invalidTargetDatasourceType`.

Today, users on AWS or Azure who want to import their existing Prometheus rule YAML into Grafana-managed alerting must first reconfigure a stock `prometheus` datasource pointing at the same endpoint, run the import, then switch back — or give up and keep rules in the upstream Prometheus.

**Who is this feature for?**

- Grafana users running on AWS using Amazon Managed Service for Prometheus.
- Grafana users on Azure using Azure Monitor managed service for Prometheus.
- Anyone migrating Prometheus rule files into Grafana-managed alert rules where the query datasource happens to be one of the managed variants.

**Which issue(s) does this PR fix?**

Related to the broader effort to treat managed Prometheus variants as first-class Prometheus-compatible datasources in alerting. Happy to link a specific issue if maintainers can point me to one — I searched but did not find an open issue tracking this gap in the converter specifically.

**How was this tested?**

- New table-driven tests in `convert_test.go`:
  - `NewConverter` accepts `prometheus`, `loki`, `grafana-amazonprometheus-datasource`, and `grafana-azureprometheus-datasource` as source datasource types.
  - `NewConverter` still rejects unrelated types (e.g. `graphite`).
  - Recording-rule conversion succeeds for all three Prometheus-compatible target datasource types.
- `go test ./pkg/services/ngalert/prom/...` passes locally.

**Special notes for your reviewer:**

- The change is intentionally minimal and isolated to the converter package; no alerting evaluation, scheduling, or API surface is modified.
- The downstream alerting query engine resolves datasources by UID and dispatches through the standard datasource plugin interface, so AMP / Azure Managed Prometheus rules execute through their existing plugins exactly as native Prometheus does.
- The public error messages on `ErrInvalidDatasourceType` and `ErrInvalidTargetDatasourceType` were updated so end users get an accurate hint when an unsupported type is supplied.

Please check that:
- [x] It works as expected from a user's perspective.
- [x] No new feature flag is needed — the change relaxes an existing validation; no new surface is added.
- [x] Docs: happy to add a follow-up commit updating `docs/sources/alerting/` rule-import documentation if maintainers can confirm where the canonical "supported source datasources for rule import" list lives.
