### PR TITLE
Background Services: run stoppingFn when shutdown lands mid-startup

### DIFF
--- a/pkg/modules/modules.go
+++ b/pkg/modules/modules.go
@@ -112,7 +112,21 @@ func (m *service) starting(ctx context.Context) error {
 	if err := m.serviceManager.StartAsync(ctx); err != nil {
 		return err
 	}
-	return m.serviceManager.AwaitHealthy(ctx)
+	if err := m.serviceManager.AwaitHealthy(ctx); err != nil {
+		// If our context was cancelled while waiting for inner services to
+		// become healthy (i.e. Shutdown landed mid-startup), return nil so
+		// dskit's BasicService.main detects the cancellation via
+		// serviceContext.Err() and routes through stoppingFn. stoppingFn
+		// calls m.serviceManager.StopAsync()+AwaitStopped(), guaranteeing
+		// every registered service is told to stop and is awaited. Without
+		// this, BasicService goes straight from Starting to Failed and skips
+		// stoppingFn, leaking running background services past Shutdown.
+		if ctx.Err() != nil {
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 func (m *service) running(ctx context.Context) error {
@@ -148,10 +162,18 @@ func (m *service) stopping(failureReason error) error {
 	failed := m.serviceManager.ServicesByState()[services.Failed]
 	for _, f := range failed {
 		// the service listener will log error details for all modules that failed,
-		// so here we return the first error that is not ErrStopProcess
-		if !errors.Is(f.FailureCase(), modules.ErrStopProcess) {
-			return f.FailureCase()
+		// so here we return the first error that is not ErrStopProcess.
+		// context.Canceled is also expected during shutdown (it just means a
+		// child service observed its context being cancelled and surfaced
+		// that as its failure case) and must not be treated as a real
+		// failure, otherwise modules.service ends in Failed which cascades
+		// up as "invalid service state: Failed, expected: Terminated,
+		// failure: context canceled" from Server.Run/ManagerAdapter.
+		cause := f.FailureCase()
+		if errors.Is(cause, modules.ErrStopProcess) || errors.Is(cause, context.Canceled) {
+			continue
 		}
+		return cause
 	}
 
 	return nil

--- a/pkg/registry/backgroundsvcs/adapter/manager.go
+++ b/pkg/registry/backgroundsvcs/adapter/manager.go
@@ -86,7 +86,21 @@ func (m *ManagerAdapter) starting(ctx context.Context) error {
 	if err := m.manager.StartAsync(ctx); err != nil {
 		return err
 	}
-	return m.manager.AwaitRunning(ctx)
+	if err := m.manager.AwaitRunning(ctx); err != nil {
+		// If our context was cancelled while waiting for the inner manager
+		// to reach Running (i.e. Shutdown was called mid-startup), return
+		// nil so dskit's BasicService.main detects the cancellation via
+		// serviceContext.Err() and routes through stoppingFn. Without this,
+		// BasicService transitions directly from Starting to Failed and
+		// skips stoppingFn entirely, leaving m.manager and its background
+		// services running and racing with test cleanup (e.g. t.TempDir()
+		// removal).
+		if ctx.Err() != nil {
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 func (m *ManagerAdapter) running(ctx context.Context) error {


### PR DESCRIPTION
## What

When `Server.Shutdown` is called while `ManagerAdapter` or `modules.service` is still in their `starting` phase, the inner manager's `AwaitRunning`/`AwaitHealthy` returns `context.Canceled`. dskit's `BasicService` treats that as a startup failure and transitions directly from `Starting` to `Failed`, **skipping `stoppingFn` entirely**. The inner `services.Manager` is therefore never told to `StopAsync()` + `AwaitStopped()`, leaving background services running past `Server.Shutdown` and racing with test cleanup such as `t.TempDir()` removal.

## Why

This regression became much easier to hit after #125216 (close DB connections on shutdown), which wired `SQLStore` in as the root of the dependency map and lengthened the startup chain. Symptoms in CI:

- Repeated `Server exited uncleanly: invalid service state: Failed, expected: Terminated, failure: context canceled` lines on stderr.
- Tests in `pkg/extensions/apiserver/tests/iam` failing with `TempDir RemoveAll cleanup: unlinkat ...: directory not empty` (e.g. `TestIntegrationRoleScopeResolution`, `TestIntegrationUserPermissionsK8sRedirect`).

The single-level wrapped error is the giveaway: it means the failure was set during `starting`, not via `running`/`stopping` (which would double-wrap).

## How

- `ManagerAdapter.starting` / `modules.service.starting`: when the inner `Await…` call returns an error *and* our own context has been cancelled, return `nil`. `BasicService.main` then takes the `goto stop` path and runs `stoppingFn`, which performs the proper `StopAsync()` + `AwaitStopped()` of the inner `services.Manager`. Real startup failures (`ctx.Err() == nil`) still surface unchanged.
- `modules.service.stopping`: stop treating a child service's `context.Canceled` failure as the manager's own failure — it's the expected outcome of the cascade cancellation during shutdown, not a real failure.

## Test plan

- [x] `go test ./pkg/registry/backgroundsvcs/adapter/... ./pkg/modules/...` passes.
- [ ] CI run of `pkg/extensions/apiserver/tests/iam` (MySQL) shows no more `Server exited uncleanly` lines and no `TempDir RemoveAll cleanup` failures.