### PR TITLE
Alerting: Block Viewers from Alert Group edit route

### DIFF
--- a/public/app/features/alerting/routes.test.tsx
+++ b/public/app/features/alerting/routes.test.tsx
@@ -1,0 +1,67 @@
+import { contextSrv } from 'app/core/services/context_srv';
+import { AccessControlAction } from 'app/types/accessControl';
+
+import { getAlertingRoutes } from './routes';
+
+describe('alerting route guards', () => {
+  const previousPermissions = contextSrv.user.permissions;
+
+  afterEach(() => {
+    contextSrv.user.permissions = previousPermissions;
+  });
+
+  function getRouteRolesGuard(path: string) {
+    const route = getAlertingRoutes().find((r) => r.path === path);
+    if (!route?.roles) {
+      throw new Error(`Route not found or has no roles guard: ${path}`);
+    }
+    return route.roles;
+  }
+
+  const groupEditPath = '/alerting/:dataSourceUid/namespaces/:namespaceId/groups/:groupName/edit';
+  const groupViewPath = '/alerting/:dataSourceUid/namespaces/:namespaceId/groups/:groupName/view';
+
+  describe('Alert Group edit route', () => {
+    it('rejects users with only read permissions (Viewer)', () => {
+      contextSrv.user.permissions = {
+        [AccessControlAction.AlertingRuleRead]: true,
+        [AccessControlAction.AlertingRuleExternalRead]: true,
+      };
+
+      const guard = getRouteRolesGuard(groupEditPath);
+      expect(guard()).toEqual(['Reject']);
+    });
+
+    it('allows users with Grafana-managed update permission', () => {
+      contextSrv.user.permissions = {
+        [AccessControlAction.AlertingRuleRead]: true,
+        [AccessControlAction.AlertingRuleUpdate]: true,
+      };
+
+      const guard = getRouteRolesGuard(groupEditPath);
+      expect(guard()).toEqual([]);
+    });
+
+    it('allows users with external write permission', () => {
+      contextSrv.user.permissions = {
+        [AccessControlAction.AlertingRuleExternalRead]: true,
+        [AccessControlAction.AlertingRuleExternalWrite]: true,
+      };
+
+      const guard = getRouteRolesGuard(groupEditPath);
+      expect(guard()).toEqual([]);
+    });
+  });
+
+  describe('Alert Group view route', () => {
+    it('allows users with only read permissions (Viewer)', () => {
+      contextSrv.user.permissions = {
+        [AccessControlAction.AlertingRuleRead]: true,
+        [AccessControlAction.AlertingRuleExternalRead]: true,
+      };
+
+      const guard = getRouteRolesGuard(groupViewPath);
+      expect(guard()).toEqual([]);
+    });
+  });
+});

--- a/public/app/features/alerting/routes.tsx
+++ b/public/app/features/alerting/routes.tsx
@@ -396,7 +396,7 @@ export function getAlertingRoutes(cfg = config): RouteDescriptor[] {
     {
       path: '/alerting/:dataSourceUid/namespaces/:namespaceId/groups/:groupName/edit',
       pageClass: 'page-alerting',
-      roles: evaluateAccess([AccessControlAction.AlertingRuleRead, AccessControlAction.AlertingRuleExternalRead]),
+      roles: evaluateAccess([AccessControlAction.AlertingRuleUpdate, AccessControlAction.AlertingRuleExternalWrite]),
       component: importAlertingComponent(
         () =>
           import(


### PR DESCRIPTION
## What is this feature?
Fixes a frontend RBAC gap on the Alert Group edit route. `/alerting/:dataSourceUid/namespaces/:namespaceId/groups/:groupName/edit` was registered with only `AlertingRuleRead`/`AlertingRuleExternalRead`, matching the view route rather than other edit routes. A Viewer could change `/view` to `/edit` in the URL, load the editable group form, and only discover the permission denial when clicking Save (backend returns 403 as expected).

The Alert Rule edit route (`/alerting/:id/edit`) already enforces `AlertingRuleUpdate`/`AlertingRuleExternalWrite` at the route guard. This change aligns the group edit route with the same pattern.

## Why do we need this feature?
- Removes a confusing UX where Viewers see an editable form they cannot save.
- Closes a frontend authorization inconsistency raised by a customer
  (reproducible on v12.0.2 and v13.0.1).
- No backend change needed — backend RBAC was already enforced.

## Who is this feature for?
All users on roles without `AlertingRuleUpdate`/`AlertingRuleExternalWrite`
(notably Viewer).

## Which issue(s) does this PR fix?
https://github.com/grafana/support-escalations/issues/22479