### PR TITLE
Folders: drop duplicate folderTier/resolveTier in validate.go

### DIFF
--- a/pkg/registry/apis/folders/validate.go
+++ b/pkg/registry/apis/folders/validate.go
@@ -242,26 +242,13 @@ func validateOnUpdate(ctx context.Context,
 	return checkSubtreeDepth(ctx, searcher, obj.Namespace, obj.Name, allowedDepth, maxDepth)
 }
 
-// folderTier is the Viewer/Editor/Admin level used by the /access subresource.
-// Comparing tiers across the move catches role-level escalations without
-// firing on per-verb churn.
-//
-// Only the folder tier is compared. Built-in roles bundle dashboard, library
-// panel, alert, and annotation actions with the folder tier, so a folder-tier
-// jump catches them transitively. Custom roles that grant sub-resource
-// actions directly at folder scope without folder access are not caught here.
-type folderTier int
-
-const (
-	tierNone folderTier = iota
-	tierViewer
-	tierEditor
-	tierAdmin
-)
-
-// tierProbes are the verbs we ask Zanzana about to resolve a tier. setperms
-// signals Admin, the Editor verbs (create/update/delete) collectively signal
-// Editor, and get alone signals Viewer.
+// tierProbes are the verbs we ask Zanzana about to resolve a folderTier.
+// setperms signals Admin, the Editor verbs (create/update/delete) collectively
+// signal Editor, and get alone signals Viewer. Only the folder tier is
+// compared on a move: built-in roles bundle dashboard, library panel, alert,
+// and annotation actions with the folder tier, so a folder-tier jump catches
+// them transitively. Custom roles that grant sub-resource actions directly at
+// folder scope without folder access are not caught here.
 var tierProbes = []struct {
 	suffix string
 	verb   string
@@ -271,19 +258,6 @@ var tierProbes = []struct {
 	{"update", utils.VerbUpdate},
 	{"delete", utils.VerbDelete},
 	{"setperms", utils.VerbSetPermissions},
-}
-
-func resolveTier(allowed map[string]bool) folderTier {
-	switch {
-	case allowed["setperms"]:
-		return tierAdmin
-	case allowed["create"] || allowed["update"] || allowed["delete"]:
-		return tierEditor
-	case allowed["get"]:
-		return tierViewer
-	default:
-		return tierNone
-	}
 }
 
 func checkMoveAccess(


### PR DESCRIPTION
## Summary

Fixes a compile error in `pkg/registry/apis/folders` where `folderTier`, the tier constants (`tierNone`/`tierViewer`/`tierEditor`/`tierAdmin`), and `resolveTier` were declared in both `validate.go` and `sub_access.go`.

```
pkg/registry/apis/folders/validate.go:253:6: folderTier redeclared in this block
        pkg/registry/apis/folders/sub_access.go:63:6: other declaration of folderTier
...
```

## Root cause

- #124831 (`e452353940a`) first introduced `folderTier` and `resolveTier` in `sub_access.go`.
- #125124 (`e877b082249`) then added the same identifiers to `validate.go` without noticing the existing declarations. Both files are in the same Go package, so the second copy is a duplicate.

## Changes

- Remove the duplicate `folderTier` type, tier constants, and `resolveTier` from `validate.go`.
- Keep `tierProbes` (only used in `validate.go`) and reuse the shared declarations from `sub_access.go`.
- Fold the original explanatory comment for `folderTier` into the `tierProbes` doc.

## Testing

- `go build ./pkg/registry/apis/folders/...` now succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)