### PR TITLE
Pin backport action to known-good SHA

### DIFF
--- a/.github/workflows/backport-workflow.yml
+++ b/.github/workflows/backport-workflow.yml
@@ -68,7 +68,7 @@ jobs:
           git config --local --add --bool push.autoSetupRemote true
 
       - name: Run backport
-        uses: grafana/grafana-github-actions-go/backport@cbf714b93d4ac1da0a09af9f7f487d4b6b3ed060 # main
+        uses: grafana/grafana-github-actions-go/backport@73932b01c802dd17e7a6218ba625365a4741d814 # known-good inline-build SHA
         with:
           token: ${{ steps.get-github-app-token.outputs.token }}
           # If triggered by being labelled, only backport that label.


### PR DESCRIPTION
https://github.com/grafana/grafana-github-actions-go/commit/3ca50c9

`uses: ./build-go-binary` in a composite action resolves relative to the calling workflow's repository (grafana/grafana), not the action's own repository (grafana/grafana-github-actions-go).

[73932b01](https://github.com/grafana/grafana-github-actions-go/commit/73932b01) predates that refactoring and has the build logic inlined, which works correctly in grafana/mimir.

https://github.com/grafana/mimir/actions/runs/26573441593/workflow?pr=15480#L45

Signed-off-by: Jack Baldry <jack.baldry@grafana.com>
