### PR TITLE
Library Panel: Add auth to /name API call

### DIFF
--- a/pkg/services/libraryelements/api.go
+++ b/pkg/services/libraryelements/api.go
@@ -44,7 +44,7 @@ func (l *LibraryElementService) registerAPIEndpoints() {
 		entities.Get("/", authorize(ac.EvalPermission(ActionLibraryPanelsRead)), routing.Wrap(l.getAllHandler))                    // TODO: add wrapper for k8s - requires search
 		entities.Get("/:uid", authorize(ac.EvalPermission(ActionLibraryPanelsRead)), routing.Wrap(l.getHandler))
 		entities.Get("/:uid/connections/", authorize(ac.EvalPermission(ActionLibraryPanelsRead, uidScope)), routing.Wrap(l.getConnectionsHandler))
-		entities.Get("/name/:name", routing.Wrap(l.getByNameHandler))                                                           // TODO: add wrapper for k8s - requires search
+		entities.Get("/name/:name", authorize(ac.EvalPermission(ActionLibraryPanelsRead)), routing.Wrap(l.getByNameHandler))    // TODO: add wrapper for k8s - requires search
 		entities.Patch("/:uid", authorize(ac.EvalPermission(ActionLibraryPanelsWrite, uidScope)), routing.Wrap(l.patchHandler)) // TODO: add wrapper for k8s
 	})
 }

--- a/pkg/services/libraryelements/libraryelements_permissions_test.go
+++ b/pkg/services/libraryelements/libraryelements_permissions_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -256,6 +257,51 @@ func TestIntegrationLibraryElementGranularPermissions(t *testing.T) {
 	})
 }
 
+// TestIntegrationLibraryElementNameRouteRequiresReadPermission guards the route-level RBAC added
+// to GET /api/library-elements/name/:name. The unscoped library.panels:read check rejects a user
+// who lacks the action entirely (403) while leaving a permitted user unaffected (200). Folder-
+// scoped denial is a different code path (handled by the per-element filter) covered elsewhere.
+func TestIntegrationLibraryElementNameRouteRequiresReadPermission(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	dir, path := testinfra.CreateGrafDir(t, testinfra.GrafanaOpts{})
+	grafanaListedAddr, env := testinfra.StartGrafanaEnv(t, dir, path)
+	cfgProvider, err := configprovider.ProvideService(env.Cfg)
+	require.NoError(t, err)
+	quotaService := quotaimpl.ProvideService(context.Background(), env.SQLStore, cfgProvider)
+	orgService, err := orgimpl.ProvideService(env.SQLStore, env.Cfg, quotaService)
+	require.NoError(t, err)
+
+	sharedOrg, err := orgService.CreateWithMember(context.Background(), &org.CreateOrgCommand{Name: "test org"})
+	require.NoError(t, err)
+
+	createUserInOrg(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
+		DefaultOrgRole: string(org.RoleAdmin),
+		Password:       "admin2",
+		Login:          "admin2",
+		OrgID:          sharedOrg.ID,
+	})
+	// A user with no basic role has none of the fixed roles, so it lacks
+	// library.panels:read entirely — which is what trips the route middleware.
+	createUserInOrg(t, env.SQLStore, env.Cfg, user.CreateUserCommand{
+		DefaultOrgRole: string(org.RoleNone),
+		Password:       "noperms",
+		Login:          "noperms",
+		OrgID:          sharedOrg.ID,
+	})
+
+	createLibraryElement(t, grafanaListedAddr, "admin2", "admin2", "", http.StatusOK)
+	const panelName = "Library Panel Name" // the name createLibraryElement assigns
+
+	t.Run("user with library.panels:read can read by name", func(t *testing.T) {
+		getLibraryElementByName(t, grafanaListedAddr, "admin2", "admin2", panelName, http.StatusOK)
+	})
+
+	t.Run("user without library.panels:read is forbidden", func(t *testing.T) {
+		getLibraryElementByName(t, grafanaListedAddr, "noperms", "noperms", panelName, http.StatusForbidden)
+	})
+}
+
 /*
 	Helper functions
 */
@@ -302,6 +348,10 @@ func deleteLibraryElement(t *testing.T, grafanaListedAddr, user, password, uid s
 
 func getLibraryElement(t *testing.T, grafanaListedAddr, user, password, uid string, expectedStatus int) {
 	makeHTTPRequest(t, "GET", fmt.Sprintf("http://%s:%s@%s/api/library-elements/%s", user, password, grafanaListedAddr, uid), nil, expectedStatus)
+}
+
+func getLibraryElementByName(t *testing.T, grafanaListedAddr, user, password, name string, expectedStatus int) {
+	makeHTTPRequest(t, "GET", fmt.Sprintf("http://%s:%s@%s/api/library-elements/name/%s", user, password, grafanaListedAddr, url.PathEscape(name)), nil, expectedStatus)
 }
 
 func getAllLibraryElements(t *testing.T, grafanaListedAddr, user, password string, expectedStatus int, expectedLength int) {


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Adds the missing authorize(ac.EvalPermission(ActionLibraryPanelsRead)) middleware to the GET /api/library-elements/name/:name route so it matches the five sibling routes in the same group at pkg/services/libraryelements/api.go:42-49. Authentication and the library.panels:read permission are now enforced at the route layer in addition to the per-element post-filter that already existed.

**Why do we need this feature?**

The route was the only one in the group without route-level RBAC. It relied entirely on the per-element filterLibraryPanelsByPermission in the handler. That post-filter is real and works in normal operation, but:

  - The route also had no reqSignedIn, so unauthenticated requests in deployments with anonymous-org access could reach the handler. The basic Viewer role inherits library.panels:read via the fixed library.panels:reader role, so they'd authorize through the per-element filter as well.
  - The post-filter runs after the SQL lookup. Any future refactor that loses the filter (or any fail-open under error in AccessControl.Evaluate) would expose every panel by name across the org.

 The fix matches the existing pattern in the file, keeps the per-element filter as defense-in-depth, and removes the anonymous-reach path.

**Who is this feature for?**
LP users

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
