### PR TITLE
Snapshots: Improve legacy API middleware

### DIFF
--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -233,9 +233,10 @@ func Auth(options *AuthOptions) web.Handler {
 	}
 }
 
-// SnapshotPublicModeOrCreate creates a middleware that allows access
-// if snapshot public mode is enabled or if user has creation permission.
-func SnapshotPublicModeOrCreate(cfg *setting.Cfg, ac2 ac.AccessControl) web.Handler {
+// snapshotPublicModeOrPermission allows access when snapshot public mode is enabled,
+// otherwise requires the user to be signed in and have the given permission.
+func snapshotPublicModeOrPermission(cfg *setting.Cfg, ac2 ac.AccessControl, action string) web.Handler {
+	evaluator := ac.EvalPermission(action)
 	return func(c *contextmodel.ReqContext) {
 		if cfg.SnapshotPublicMode {
 			return
@@ -246,25 +247,28 @@ func SnapshotPublicModeOrCreate(cfg *setting.Cfg, ac2 ac.AccessControl) web.Hand
 			return
 		}
 
-		ac.Middleware(ac2)(ac.EvalPermission(dashboards.ActionSnapshotsCreate))
+		hasAccess, err := ac2.Evaluate(c.Req.Context(), c.SignedInUser, evaluator)
+		if err != nil {
+			c.JsonApiErr(http.StatusInternalServerError, "Internal server error", err)
+			return
+		}
+		if !hasAccess {
+			c.JsonApiErr(http.StatusForbidden, "forbidden", nil)
+			return
+		}
 	}
+}
+
+// SnapshotPublicModeOrCreate creates a middleware that allows access
+// if snapshot public mode is enabled or if user has creation permission.
+func SnapshotPublicModeOrCreate(cfg *setting.Cfg, ac2 ac.AccessControl) web.Handler {
+	return snapshotPublicModeOrPermission(cfg, ac2, dashboards.ActionSnapshotsCreate)
 }
 
 // SnapshotPublicModeOrDelete creates a middleware that allows access
 // if snapshot public mode is enabled or if user has delete permission.
 func SnapshotPublicModeOrDelete(cfg *setting.Cfg, ac2 ac.AccessControl) web.Handler {
-	return func(c *contextmodel.ReqContext) {
-		if cfg.SnapshotPublicMode {
-			return
-		}
-
-		if !c.IsSignedIn {
-			notAuthorized(c)
-			return
-		}
-
-		ac.Middleware(ac2)(ac.EvalPermission(dashboards.ActionSnapshotsDelete))
-	}
+	return snapshotPublicModeOrPermission(cfg, ac2, dashboards.ActionSnapshotsDelete)
 }
 
 func ReqNotSignedIn(c *contextmodel.ReqContext) {

--- a/pkg/middleware/auth_test.go
+++ b/pkg/middleware/auth_test.go
@@ -37,6 +37,8 @@ func setupAuthMiddlewareTest(t *testing.T, identity *authn.Identity, authErr err
 
 func TestAuth_Middleware(t *testing.T) {
 	ac := &actest.FakeAccessControl{}
+	acGrant := &actest.FakeAccessControl{ExpectedEvaluate: true}
+	acErr := &actest.FakeAccessControl{ExpectedErr: errors.New("ac backend down")}
 
 	type testCase struct {
 		desc           string
@@ -104,15 +106,23 @@ func TestAuth_Middleware(t *testing.T) {
 			expectedCode:   http.StatusOK,
 		},
 		{
-			desc:           "snapshot public mode disabled should return 200 for authenticated user",
+			desc:           "SnapshotPublicModeOrCreate public mode disabled should return 200 for authenticated user with snapshots:create",
 			path:           "/api/secure",
-			authMiddleware: SnapshotPublicModeOrCreate(&setting.Cfg{SnapshotPublicMode: false}, ac),
+			authMiddleware: SnapshotPublicModeOrCreate(&setting.Cfg{SnapshotPublicMode: false}, acGrant),
 			identity:       &authn.Identity{ID: "1", Type: authlib.TypeUser},
 			expecedReached: true,
 			expectedCode:   http.StatusOK,
 		},
 		{
-			desc:           "snapshot public mode disabled should return 401 for unauthenticated request",
+			desc:           "SnapshotPublicModeOrCreate public mode disabled should return 403 for authenticated user without snapshots:create",
+			path:           "/api/secure",
+			authMiddleware: SnapshotPublicModeOrCreate(&setting.Cfg{SnapshotPublicMode: false}, ac),
+			identity:       &authn.Identity{ID: "1", Type: authlib.TypeUser},
+			expecedReached: false,
+			expectedCode:   http.StatusForbidden,
+		},
+		{
+			desc:           "SnapshotPublicModeOrCreate public mode disabled should return 401 for unauthenticated request",
 			path:           "/api/secure",
 			authMiddleware: SnapshotPublicModeOrCreate(&setting.Cfg{SnapshotPublicMode: false}, ac),
 			authErr:        errors.New("no auth"),
@@ -120,12 +130,60 @@ func TestAuth_Middleware(t *testing.T) {
 			expectedCode:   http.StatusUnauthorized,
 		},
 		{
-			desc:           "snapshot public mode enabled should return 200 for unauthenticated request",
+			desc:           "SnapshotPublicModeOrCreate public mode enabled should return 200 for unauthenticated request",
 			path:           "/api/secure",
 			authMiddleware: SnapshotPublicModeOrCreate(&setting.Cfg{SnapshotPublicMode: true}, ac),
 			authErr:        errors.New("no auth"),
 			expecedReached: true,
 			expectedCode:   http.StatusOK,
+		},
+		{
+			desc:           "SnapshotPublicModeOrCreate public mode disabled should return 500 when access control engine errors",
+			path:           "/api/secure",
+			authMiddleware: SnapshotPublicModeOrCreate(&setting.Cfg{SnapshotPublicMode: false}, acErr),
+			identity:       &authn.Identity{ID: "1", Type: authlib.TypeUser},
+			expecedReached: false,
+			expectedCode:   http.StatusInternalServerError,
+		},
+		{
+			desc:           "SnapshotPublicModeOrDelete public mode disabled should return 200 for authenticated user with snapshots:delete",
+			path:           "/api/secure",
+			authMiddleware: SnapshotPublicModeOrDelete(&setting.Cfg{SnapshotPublicMode: false}, acGrant),
+			identity:       &authn.Identity{ID: "1", Type: authlib.TypeUser},
+			expecedReached: true,
+			expectedCode:   http.StatusOK,
+		},
+		{
+			desc:           "SnapshotPublicModeOrDelete public mode disabled should return 403 for authenticated user without snapshots:delete",
+			path:           "/api/secure",
+			authMiddleware: SnapshotPublicModeOrDelete(&setting.Cfg{SnapshotPublicMode: false}, ac),
+			identity:       &authn.Identity{ID: "1", Type: authlib.TypeUser},
+			expecedReached: false,
+			expectedCode:   http.StatusForbidden,
+		},
+		{
+			desc:           "SnapshotPublicModeOrDelete public mode disabled should return 401 for unauthenticated request",
+			path:           "/api/secure",
+			authMiddleware: SnapshotPublicModeOrDelete(&setting.Cfg{SnapshotPublicMode: false}, ac),
+			authErr:        errors.New("no auth"),
+			expecedReached: false,
+			expectedCode:   http.StatusUnauthorized,
+		},
+		{
+			desc:           "SnapshotPublicModeOrDelete public mode enabled should return 200 for unauthenticated request",
+			path:           "/api/secure",
+			authMiddleware: SnapshotPublicModeOrDelete(&setting.Cfg{SnapshotPublicMode: true}, ac),
+			authErr:        errors.New("no auth"),
+			expecedReached: true,
+			expectedCode:   http.StatusOK,
+		},
+		{
+			desc:           "SnapshotPublicModeOrDelete public mode disabled should return 500 when access control engine errors",
+			path:           "/api/secure",
+			authMiddleware: SnapshotPublicModeOrDelete(&setting.Cfg{SnapshotPublicMode: false}, acErr),
+			identity:       &authn.Identity{ID: "1", Type: authlib.TypeUser},
+			expecedReached: false,
+			expectedCode:   http.StatusInternalServerError,
 		},
 	}
 


### PR DESCRIPTION
### Summary

  Fix the snapshot RBAC middleware that was silently skipping the permission check.

  SnapshotPublicModeOrCreate / SnapshotPublicModeOrDelete access-control middleware closure was never invoked, it ac.Middleware(ac2)(ac.EvalPermission(...)) returned a handler that was discarded, so the permission check was dead code.
  User-facing impact is narrow since permissions were checked downstream, but the middleware was skipping a validation.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
