### PR TITLE
Alerting Docs: Fix H2

### DIFF
--- a/docs/sources/alerting/configure-notifications/manage-contact-points/_index.md
+++ b/docs/sources/alerting/configure-notifications/manage-contact-points/_index.md
@@ -137,9 +137,9 @@ On the **Contact Points** tab, you can:
 Contact points are assigned to a [specific Alertmanager](ref:configure-alertmanager) and cannot be used by notification policies in other Alertmanagers.
 {{< /admonition >}}
 
-## Grafana Cloud Protected fields
+## Protected fields
 
-For Grafana Cloud users, contact points may contain protected fields that require admin permissions to modify. Protected fields are sensitive configuration settings that affect where notifications are sent, such as:
+For Grafana users, contact points may contain protected fields that require admin permissions to modify. Protected fields are sensitive configuration settings that affect where notifications are sent, such as:
 
 - Target URLs for integrations (webhooks, PagerDuty, Opsgenie, or other integrations.)
 - API endpoints


### PR DESCRIPTION
Remove "Grafana Cloud" from H2.
Content applies to OSS and Enterprise as well.

From: [Slack thread](https://raintank-corp.slack.com/archives/C03E40FGLN5/p1779368625490209)