### PR TITLE
Datasources: Ensure datasource version is updated with title/default changes

### DIFF
--- a/public/app/features/datasources/api.ts
+++ b/public/app/features/datasources/api.ts
@@ -301,23 +301,28 @@ export const updateDataSource = async (dataSource: DataSourceSettings) => {
         }
       }
     }
-    return getBackendSrv().put(
-      `/apis/${dsK8sSettings.apiVersion}/namespaces/${config.namespace}/datasources/${dsK8sSettings.metadata.name}`,
-      dsK8sSettings,
-      {
-        showErrorAlert: false,
-        showSuccessAlert: false,
-        validatePath: true,
-      }
+    return convertK8sDatasourceSettingsToLegacyDatasourceSettings(
+      await getBackendSrv().put<DataSourceSettingsK8s>(
+        `/apis/${dsK8sSettings.apiVersion}/namespaces/${config.namespace}/datasources/${dsK8sSettings.metadata.name}`,
+        dsK8sSettings,
+        {
+          showErrorAlert: false,
+          showSuccessAlert: false,
+          validatePath: true,
+        }
+      )
     );
   }
+
   // we're setting showErrorAlert and showSuccessAlert to false to suppress the popover notifications. Request result will now be
   // handled by the data source config page
-  return getBackendSrv().put(`/api/datasources/uid/${dataSource.uid}`, dataSource, {
-    showErrorAlert: false,
-    showSuccessAlert: false,
-    validatePath: true,
-  });
+  return getBackendSrv()
+    .put<{ datasource: DataSourceSettings }>(`/api/datasources/uid/${dataSource.uid}`, dataSource, {
+      showErrorAlert: false,
+      showSuccessAlert: false,
+      validatePath: true,
+    })
+    .then((response) => response.datasource);
 };
 
 export const deleteDataSource = (uid: string) => {

--- a/public/app/features/datasources/components/DataSourceDefaultButton.tsx
+++ b/public/app/features/datasources/components/DataSourceDefaultButton.tsx
@@ -9,7 +9,7 @@ import { useDispatch } from 'app/types/store';
 
 import * as api from '../api';
 import { useDataSource, useDataSourceRights } from '../state/hooks';
-import { setIsDefault } from '../state/reducers';
+import { setDefaultAndVersion } from '../state/reducers';
 
 export const DataSourceDefaultButton = ({ uid }: { uid: string }) => {
   const [loading, setLoading] = useState(false);
@@ -30,9 +30,17 @@ export const DataSourceDefaultButton = ({ uid }: { uid: string }) => {
 
     try {
       // Make manual API calls to avoid pre-emptively saving other changes from the EditDataSource form
+      // Use the original version from the Redux state to ensure we don't overwrite other default changes
       const ds = await api.getDataSourceByUid(uid);
-      await api.updateDataSource({ ...ds, isDefault: value });
-      dispatch(setIsDefault(value));
+      const up = await api.updateDataSource({ ...ds, isDefault: value, version: dataSource.version });
+
+      // Update the Redux state with the new default and version to allow the EditDataSource form to submit
+      dispatch(
+        setDefaultAndVersion({
+          isDefault: up.isDefault,
+          version: up.version,
+        })
+      );
     } catch (error) {
       dispatch(
         notifyApp(

--- a/public/app/features/datasources/components/DataSourceTabPage.tsx
+++ b/public/app/features/datasources/components/DataSourceTabPage.tsx
@@ -7,8 +7,8 @@ import * as api from '../api';
 import { EditDataSource } from '../components/EditDataSource';
 import { EditDataSourceActions } from '../components/EditDataSourceActions';
 import { useDataSourceInfo } from '../components/useDataSourceInfo';
-import { useDataSourceRights } from '../state/hooks';
-import { setDataSourceName } from '../state/reducers';
+import { useDataSource, useDataSourceRights } from '../state/hooks';
+import { setNameAndVersion } from '../state/reducers';
 
 export interface Props {
   uid: string;
@@ -25,6 +25,7 @@ export function DataSourceTabPage({ uid, pageId }: Props) {
     failure: datasourceFailureByUID.get(uid),
   });
 
+  const dataSource = useDataSource(uid);
   const rights = useDataSourceRights(uid);
   const editable = rights.hasWriteRights && !rights.readOnly;
 
@@ -32,9 +33,17 @@ export function DataSourceTabPage({ uid, pageId }: Props) {
 
   const onEditTitle = async (value: string) => {
     // Make manual API calls to avoid pre-emptively saving other changes from the EditDataSource form
+    // Use the original version from the Redux state to ensure we don't overwrite other name changes
     const ds = await api.getDataSourceByUid(uid);
-    await api.updateDataSource({ ...ds, name: value });
-    dispatch(setDataSourceName(value));
+    const up = await api.updateDataSource({ ...ds, name: value, version: dataSource.version });
+
+    // Update the Redux state with the new name and version to allow the EditDataSource form to submit
+    dispatch(
+      setNameAndVersion({
+        name: up.name,
+        version: up.version,
+      })
+    );
   };
 
   return (

--- a/public/app/features/datasources/components/EditDataSource.test.tsx
+++ b/public/app/features/datasources/components/EditDataSource.test.tsx
@@ -41,8 +41,6 @@ const setup = (props?: Partial<ViewProps>) => {
         dataSourceRights={{ readOnly: false, hasWriteRights: true, hasDeleteRights: true }}
         exploreUrl={'/explore'}
         onDelete={jest.fn()}
-        onDefaultChange={jest.fn()}
-        onNameChange={jest.fn()}
         onOptionsChange={onOptionsChange}
         onTest={jest.fn()}
         onUpdate={jest.fn()}

--- a/public/app/features/datasources/components/EditDataSource.tsx
+++ b/public/app/features/datasources/components/EditDataSource.tsx
@@ -29,7 +29,7 @@ import {
   useTestDataSource,
   useUpdateDatasource,
 } from '../state/hooks';
-import { setIsDefault, setDataSourceName, dataSourceLoaded, testDataSourceFailed } from '../state/reducers';
+import { dataSourceLoaded, testDataSourceFailed } from '../state/reducers';
 import { trackDsConfigClicked, trackDsConfigUpdated } from '../tracking';
 import { type DataSourceRights } from '../types';
 
@@ -63,8 +63,6 @@ export function EditDataSource({ uid, pageId }: Props) {
   const onDelete = useDeleteLoadedDataSource();
   const onTest = useTestDataSource(uid);
   const onUpdate = useUpdateDatasource();
-  const onDefaultChange = (value: boolean) => dispatch(setIsDefault(value));
-  const onNameChange = (name: string) => dispatch(setDataSourceName(name));
   const onOptionsChange = (ds: DataSourceSettingsType) => dispatch(dataSourceLoaded(ds));
 
   return (
@@ -76,8 +74,6 @@ export function EditDataSource({ uid, pageId }: Props) {
       dataSourceRights={dataSourceRights}
       exploreUrl={exploreUrl}
       onDelete={onDelete}
-      onDefaultChange={onDefaultChange}
-      onNameChange={onNameChange}
       onOptionsChange={onOptionsChange}
       onTest={onTest}
       onUpdate={onUpdate}
@@ -93,8 +89,6 @@ export type ViewProps = {
   dataSourceRights: DataSourceRights;
   exploreUrl: string;
   onDelete: () => void;
-  onDefaultChange: (isDefault: boolean) => AnyAction;
-  onNameChange: (name: string) => AnyAction;
   onOptionsChange: (dataSource: DataSourceSettingsType) => AnyAction;
   onTest: () => void;
   onUpdate: (dataSource: DataSourceSettingsType) => Promise<DataSourceSettingsType>;
@@ -108,8 +102,6 @@ export function EditDataSourceView({
   dataSourceRights,
   exploreUrl,
   onDelete,
-  onDefaultChange,
-  onNameChange,
   onOptionsChange,
   onTest,
   onUpdate,

--- a/public/app/features/datasources/state/reducers.test.ts
+++ b/public/app/features/datasources/state/reducers.test.ts
@@ -18,11 +18,11 @@ import {
   initDataSourceSettingsSucceeded,
   initialDataSourceSettingsState,
   initialState,
-  setDataSourceName,
+  setNameAndVersion,
   setDataSourcesLayoutMode,
   setDataSourcesSearchQuery,
   setDataSourceTypeSearchQuery,
-  setIsDefault,
+  setDefaultAndVersion,
 } from './reducers';
 
 const mockPlugin = () =>
@@ -125,21 +125,21 @@ describe('dataSourcesReducer', () => {
     });
   });
 
-  describe('when setDataSourceName is dispatched', () => {
+  describe('when setNameAndVersion is dispatched', () => {
     it('then state should be correct', () => {
       reducerTester<DataSourcesState>()
         .givenReducer(dataSourcesReducer, initialState)
-        .whenActionIsDispatched(setDataSourceName('some name'))
-        .thenStateShouldEqual({ ...initialState, dataSource: { name: 'some name' } } as DataSourcesState);
+        .whenActionIsDispatched(setNameAndVersion({ name: 'some name', version: 2 }))
+        .thenStateShouldEqual({ ...initialState, dataSource: { name: 'some name', version: 2 } } as DataSourcesState);
     });
   });
 
-  describe('when setIsDefault is dispatched', () => {
+  describe('when setDefaultAndVersion is dispatched', () => {
     it('then state should be correct', () => {
       reducerTester<DataSourcesState>()
         .givenReducer(dataSourcesReducer, initialState)
-        .whenActionIsDispatched(setIsDefault(true))
-        .thenStateShouldEqual({ ...initialState, dataSource: { isDefault: true } } as DataSourcesState);
+        .whenActionIsDispatched(setDefaultAndVersion({ isDefault: true, version: 2 }))
+        .thenStateShouldEqual({ ...initialState, dataSource: { isDefault: true, version: 2 } } as DataSourcesState);
     });
   });
 });

--- a/public/app/features/datasources/state/reducers.ts
+++ b/public/app/features/datasources/state/reducers.ts
@@ -35,8 +35,10 @@ export const dataSourcePluginsLoaded = createAction<DataSourceTypesLoadedPayload
 export const setDataSourcesSearchQuery = createAction<string>('dataSources/setDataSourcesSearchQuery');
 export const setDataSourcesLayoutMode = createAction<LayoutMode>('dataSources/setDataSourcesLayoutMode');
 export const setDataSourceTypeSearchQuery = createAction<string>('dataSources/setDataSourceTypeSearchQuery');
-export const setDataSourceName = createAction<string>('dataSources/setDataSourceName');
-export const setIsDefault = createAction<boolean>('dataSources/setIsDefault');
+export const setNameAndVersion = createAction<{ name: string; version?: number }>('dataSources/setNameAndVersion');
+export const setDefaultAndVersion = createAction<{ isDefault: boolean; version?: number }>(
+  'dataSources/setDefaultAndVersion'
+);
 export const setIsSortAscending = createAction<boolean>('dataSources/setIsSortAscending');
 
 // Redux Toolkit uses ImmerJs as part of their solution to ensure that state objects are not mutated.
@@ -91,14 +93,21 @@ export const dataSourcesReducer = (state: DataSourcesState = initialState, actio
     return { ...state, dataSourceMeta: action.payload };
   }
 
-  if (setDataSourceName.match(action)) {
-    return { ...state, dataSource: { ...state.dataSource, name: action.payload } };
-  }
-
-  if (setIsDefault.match(action)) {
+  if (setNameAndVersion.match(action)) {
     return {
       ...state,
-      dataSource: { ...state.dataSource, isDefault: action.payload },
+      dataSource: {
+        ...state.dataSource,
+        name: action.payload.name,
+        version: action.payload.version,
+      },
+    };
+  }
+
+  if (setDefaultAndVersion.match(action)) {
+    return {
+      ...state,
+      dataSource: { ...state.dataSource, isDefault: action.payload.isDefault, version: action.payload.version },
     };
   }
 


### PR DESCRIPTION
**What is this feature?**

When the title of a datasource is edited, or its default status is edited, ensure that we update the version stored in the Redux state to allow the rest of the form to still be submitted with any changes.

**Why do we need this feature?**

Bug exists today where a user edits the title, and then tries to edit other settings and gets an error that the datasource has been edited by someone else.

**Who is this feature for?**

Administrators.

**Which issue(s) does this PR fix?**:

cc #122053 + #122847 

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
