### PR TITLE
Docs: Remove OSS product label from enterprise config docs

### DIFF
--- a/docs/sources/setup-grafana/configure-grafana/enterprise-configuration/index.md
+++ b/docs/sources/setup-grafana/configure-grafana/enterprise-configuration/index.md
@@ -5,7 +5,6 @@ description: Learn about Grafana Enterprise configuration options that you can s
 labels:
   products:
     - enterprise
-    - oss
 title: Configure Grafana Enterprise
 weight: 100
 ---


### PR DESCRIPTION
**What is this feature?**

Removes the OSS product label from the enterprise configuration docs

**Why do we need this feature?**

Having both labels is confusing for something that is explicitly for enterprise only.

**Who is this feature for?**

All users of Grafana documentation
