### PR TITLE
Dependencies: Fix get-document VENDORED.md abandoned-since dates

### DIFF
--- a/packages/get-document/VENDORED.md
+++ b/packages/get-document/VENDORED.md
@@ -17,7 +17,7 @@ previously motivated a `github:` resolution. To remove the `github:`
 indirection, we vendor the source here and serve it via a `workspace:*`
 resolution.
 
-Upstream is effectively abandoned (no commits since 2014).
+Upstream is effectively abandoned, no commits since 2017 (the LICENSE commit we vendor here is the latest on `master`) and no npm publish since `1.0.0` in January 2015.
 
 ## Syncing from upstream
 


### PR DESCRIPTION
**What is this feature?**

Fixes the abandoned-since dates in `packages/get-document/VENDORED.md`. The previous wording said "no commits since 2014" — actually the upstream `master` had test commits through January 2015 and the LICENSE-add commit (the one we vendor at) was 2017-06-14. Last npm publish was `1.0.0` in January 2015.

**Why do we need this feature?**

So the file says something true.

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

Spotted while doing the same audit for the jsonlint vendor PR (#125696) — that one had a similar stale-dates issue and is already fixed there. Pure docs, single-line diff.

Please check that:

- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
