### PR TITLE
Dashboards: Reject duplicate deprecatedInternalID at admission

### DIFF
--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -496,6 +496,32 @@ func (b *DashboardsAPIBuilder) validateCreate(ctx context.Context, a admission.A
 		}
 	}
 
+	// Enforce uniqueness of the deprecated internal ID label. Without this check,
+	// JSON imports carrying spec.id collide with existing dashboards (the
+	// mutation hook stamps spec.id onto the label) and the duplicate only
+	// surfaces later as an HTTP 500 from GetDashboardUIDByID.
+	if !b.isStandalone && !a.IsDryRun() {
+		internalID := accessor.GetDeprecatedInternalID() //nolint:staticcheck
+		if internalID > 0 {
+			ref, err := b.dashboardService.GetDashboardUIDByID(ctx, &dashboards.GetDashboardRefByIDQuery{ID: internalID})
+			var dupErr *dashboards.DeprecatedInternalIDConflictError
+			switch {
+			case err == nil:
+				if ref != nil && ref.UID != accessor.GetName() {
+					return apierrors.NewConflict(dashv1.DashboardResourceInfo.GroupResource(), a.GetName(),
+						fmt.Errorf("dashboard with deprecatedInternalID=%d already exists (uid=%s); choose a different id or omit it from the spec to auto-generate one", internalID, ref.UID))
+				}
+			case errors.Is(err, dashboards.ErrDashboardNotFound):
+				// id is free — fall through
+			case errors.As(err, &dupErr):
+				return apierrors.NewConflict(dashv1.DashboardResourceInfo.GroupResource(), a.GetName(),
+					fmt.Errorf("cannot create dashboard with deprecatedInternalID=%d: id is already used by %d existing dashboards; resolve duplicates before creating a new one", dupErr.ID, dupErr.Count))
+			default:
+				return err
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/registry/apis/dashboard/register_test.go
+++ b/pkg/registry/apis/dashboard/register_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -14,7 +15,10 @@ import (
 
 	dashv1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
 	common "github.com/grafana/grafana/pkg/apimachinery/apis/common/v0alpha1"
+	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/services/dashboards"
+	"github.com/grafana/grafana/pkg/services/quota/quotatest"
 	"github.com/grafana/grafana/pkg/services/user"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
@@ -176,6 +180,135 @@ func TestDashboardAPIBuilder_Validate(t *testing.T) {
 				require.True(t, mockHandler.getCalled, "Get should have been called")
 			} else {
 				require.False(t, mockHandler.getCalled, "Get should not have been called")
+			}
+		})
+	}
+}
+
+func TestDashboardAPIBuilder_ValidateCreate_DeprecatedInternalIDUniqueness(t *testing.T) {
+	const newUID = "new-uid"
+
+	tests := []struct {
+		name              string
+		labelValue        string // value for grafana.app/deprecatedInternalID; "" means no label
+		isStandalone      bool
+		dryRun            bool
+		getUIDRef         *dashboards.DashboardRef
+		getUIDErr         error
+		expectGetUIDCall  bool
+		expectConflict    bool
+		expectGenericFail bool
+	}{
+		{
+			name:             "unused internalID succeeds",
+			labelValue:       "1247",
+			getUIDErr:        dashboards.ErrDashboardNotFound,
+			expectGetUIDCall: true,
+		},
+		{
+			name:             "internalID owned by other dashboard is rejected as conflict",
+			labelValue:       "1247",
+			getUIDRef:        &dashboards.DashboardRef{UID: "other-uid"},
+			expectGetUIDCall: true,
+			expectConflict:   true,
+		},
+		{
+			name:             "internalID already duplicated in store is rejected as conflict",
+			labelValue:       "1247",
+			getUIDErr:        &dashboards.DeprecatedInternalIDConflictError{ID: 1247, Count: 2},
+			expectGetUIDCall: true,
+			expectConflict:   true,
+		},
+		{
+			name:             "same uid is treated as idempotent and allowed",
+			labelValue:       "1247",
+			getUIDRef:        &dashboards.DashboardRef{UID: newUID},
+			expectGetUIDCall: true,
+		},
+		{
+			name:             "missing internalID label skips the check",
+			labelValue:       "",
+			expectGetUIDCall: false,
+		},
+		{
+			name:             "dry-run skips the check",
+			labelValue:       "1247",
+			dryRun:           true,
+			expectGetUIDCall: false,
+		},
+		{
+			name:             "standalone skips the check",
+			labelValue:       "1247",
+			isStandalone:     true,
+			expectGetUIDCall: false,
+		},
+		{
+			name:              "generic service error is surfaced",
+			labelValue:        "1247",
+			getUIDErr:         fmt.Errorf("kaboom"),
+			expectGetUIDCall:  true,
+			expectGenericFail: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			labels := map[string]string{}
+			if tt.labelValue != "" {
+				labels["grafana.app/deprecatedInternalID"] = tt.labelValue
+			}
+			inputObj := &dashv1.Dashboard{
+				Spec:     common.Unstructured{Object: map[string]interface{}{"title": "T"}},
+				TypeMeta: metav1.TypeMeta{Kind: "Dashboard"},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      newUID,
+					Namespace: "stacks-123",
+					Labels:    labels,
+				},
+			}
+
+			svc := dashboards.NewFakeDashboardService(t)
+			svc.On("ValidateBasicDashboardProperties", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+			svc.On("ValidateDashboardRefreshInterval", mock.Anything, mock.Anything).Return(nil)
+			if tt.expectGetUIDCall {
+				svc.On("GetDashboardUIDByID", mock.Anything, mock.Anything).
+					Return(tt.getUIDRef, tt.getUIDErr).Once()
+			}
+
+			b := &DashboardsAPIBuilder{
+				dashboardService: svc,
+				QuotaService:     quotatest.New(false, nil),
+				isStandalone:     tt.isStandalone,
+			}
+
+			ctx := identity.WithRequester(context.Background(), &user.SignedInUser{UserID: 1, OrgID: 1})
+			err := b.Validate(ctx, admission.NewAttributesRecord(
+				inputObj,
+				nil,
+				dashv1.DashboardResourceInfo.GroupVersionKind(),
+				inputObj.Namespace,
+				inputObj.Name,
+				dashv1.DashboardResourceInfo.GroupVersionResource(),
+				"",
+				admission.Create,
+				&metav1.CreateOptions{},
+				tt.dryRun,
+				&user.SignedInUser{UserID: 1, OrgID: 1},
+			), nil)
+
+			switch {
+			case tt.expectConflict:
+				require.Error(t, err)
+				require.True(t, apierrors.IsConflict(err), "expected Conflict, got %T: %v", err, err)
+			case tt.expectGenericFail:
+				require.Error(t, err)
+				require.False(t, apierrors.IsConflict(err), "expected non-Conflict error, got %v", err)
+			default:
+				require.NoError(t, err)
+			}
+
+			if !tt.expectGetUIDCall {
+				svc.AssertNotCalled(t, "GetDashboardUIDByID", mock.Anything, mock.Anything)
 			}
 		})
 	}

--- a/pkg/services/dashboards/errors.go
+++ b/pkg/services/dashboards/errors.go
@@ -2,6 +2,7 @@ package dashboards
 
 import (
 	"errors"
+	"fmt"
 
 	"github.com/grafana/grafana/pkg/services/dashboards/dashboardaccess"
 )
@@ -100,4 +101,16 @@ type UpdatePluginDashboardError struct {
 
 func (d UpdatePluginDashboardError) Error() string {
 	return "Dashboard belongs to plugin"
+}
+
+// DeprecatedInternalIDConflictError is returned when more than one dashboard
+// shares the same grafana.app/deprecatedInternalID label, making lookup-by-id
+// ambiguous.
+type DeprecatedInternalIDConflictError struct {
+	ID    int64
+	Count int
+}
+
+func (e *DeprecatedInternalIDConflictError) Error() string {
+	return fmt.Sprintf("unexpected number of dashboards for id %d. found: %d. desired: 1", e.ID, e.Count)
 }

--- a/pkg/services/dashboards/service/dashboard_service.go
+++ b/pkg/services/dashboards/service/dashboard_service.go
@@ -1332,7 +1332,7 @@ func (dr *DashboardServiceImpl) GetDashboardUIDByID(ctx context.Context, query *
 	if len(result) == 0 {
 		return nil, dashboards.ErrDashboardNotFound
 	} else if len(result) > 1 {
-		return nil, fmt.Errorf("unexpected number of dashboards for id %d. found: %d. desired: 1", query.ID, len(result))
+		return nil, &dashboards.DeprecatedInternalIDConflictError{ID: query.ID, Count: len(result)}
 	}
 
 	return &dashboards.DashboardRef{UID: result[0].UID, Slug: result[0].Slug, FolderUID: result[0].FolderUID}, nil

--- a/pkg/tests/api/dashboards/api_dashboards_test.go
+++ b/pkg/tests/api/dashboards/api_dashboards_test.go
@@ -226,46 +226,20 @@ func TestIntegrationDashboardServiceValidation(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	dashboardWithDuplicatedLegacyAnnotation := "new-uid"
 	t.Run("When saving a dashboard with an already used legacy ID", func(t *testing.T) {
 		resp, err := postDashboard(t, grafanaListedAddr, "admin", "admin", map[string]interface{}{
 			"dashboard": map[string]interface{}{
 				"id":    savedDashInFolder.ID, // nolint:staticcheck
-				"uid":   dashboardWithDuplicatedLegacyAnnotation,
+				"uid":   "new-uid",
 				"title": "Updated title",
 			},
 			"folderUid": savedDashInFolder.FolderUID,
 			"overwrite": true,
 		})
 		require.NoError(t, err)
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, http.StatusConflict, resp.StatusCode)
 		err = resp.Body.Close()
 		require.NoError(t, err)
-	})
-
-	t.Run("When updating a dashboard with legacy ID in multiple dashboards", func(t *testing.T) {
-		resp, err := postDashboard(t, grafanaListedAddr, "admin", "admin", map[string]interface{}{
-			"dashboard": map[string]interface{}{
-				"id":    savedDashInFolder.ID, // nolint:staticcheck
-				"uid":   savedDashInGeneralFolder.UID,
-				"title": "Updated title",
-			},
-			"folderUid": savedDashInFolder.FolderUID,
-			"overwrite": true,
-		})
-		require.NoError(t, err)
-		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
-		err = resp.Body.Close()
-		require.NoError(t, err)
-		// Delete the dashboard with duplicated legacy ID annotation
-		u := fmt.Sprintf("http://admin:admin@%s/api/dashboards/uid/%s", grafanaListedAddr, dashboardWithDuplicatedLegacyAnnotation)
-		req, err := http.NewRequest("DELETE", u, nil)
-		require.NoError(t, err)
-		resp, err = http.DefaultClient.Do(req)
-		require.NoError(t, err)
-		err = resp.Body.Close()
-		require.NoError(t, err)
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
 	})
 
 	t.Run("When updating a dashboard already using that uid", func(t *testing.T) {

--- a/pkg/tests/apis/dashboard/dashboards_test.go
+++ b/pkg/tests/apis/dashboard/dashboards_test.go
@@ -514,6 +514,45 @@ func TestIntegrationLegacySupport(t *testing.T) {
 	}, &dtos.DashboardFullWithMeta{})
 	require.Equal(t, 200, rsp.Response.StatusCode)
 	require.Equal(t, dashboardV0.VERSION, rsp.Result.Meta.APIVersion)
+
+	//---------------------------------------------------------
+	// Reject creating a second dashboard that reuses an existing
+	// grafana.app/deprecatedInternalID. Without admission enforcement, two
+	// dashboards could end up sharing the same legacy id (the symptom was
+	// /api/dashboards/db returning 500 with "unexpected number of dashboards
+	// for id N. found: 2. desired: 1" on any later overwrite).
+	//---------------------------------------------------------
+	t.Run("reject duplicate deprecatedInternalID on create", func(t *testing.T) {
+		const sharedID = int64(99999)
+
+		newDashboardWithID := func(name string) *unstructured.Unstructured {
+			return &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "dashboard.grafana.app/v1",
+					"kind":       "Dashboard",
+					"metadata": map[string]any{
+						"name": name,
+					},
+					"spec": map[string]any{
+						"id":            sharedID,
+						"title":         name,
+						"schemaVersion": int64(36),
+					},
+				},
+			}
+		}
+
+		first, err := clientV1.Resource.Create(ctx, newDashboardWithID("dup-id-a"), metav1.CreateOptions{})
+		require.NoError(t, err, "first create with spec.id should succeed")
+		require.Equal(t, "99999", first.GetLabels()[utils.LabelKeyDeprecatedInternalID], //nolint:staticcheck
+			"mutation hook should lift spec.id onto the label")
+
+		_, err = clientV1.Resource.Create(ctx, newDashboardWithID("dup-id-b"), metav1.CreateOptions{})
+		require.Error(t, err, "second create with same spec.id must be rejected")
+		require.True(t, errors.IsConflict(err),
+			"expected HTTP 409 Conflict, got %T: %v", err, err)
+		require.Contains(t, err.Error(), "deprecatedInternalID=99999")
+	})
 }
 
 func TestIntegrationListPagination(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

Adds an admission-time uniqueness check on `grafana.app/deprecatedInternalID` in `validateCreate`. Imports carrying `spec.id` that collide with an existing dashboard now return HTTP 409 Conflict with a clear message, instead of silently succeeding and surfacing months later as HTTP 500 from `GetDashboardUIDByID` on any id-based lookup. Also introduces a typed `DeprecatedInternalIDConflictError` so the multi-match case is matched via `errors.As` instead of string-comparing error messages.

**Why do we need this feature?**

Customers Terraform `grafana_dashboard` updates were failing with `Dashboard API error: unexpected number of dashboards for id N. found: 2. desired: 1`. Two dashboards in the same stack shared the same `deprecatedInternalID=1247` because a later dashboard-import-UI request carried `"id": 1247` in its JSON body and the mutation hook stamped the same label onto a different uid with no admission check. Once duplicated, any code path resolving by legacy id fails.

**Who is this feature for?**

Anyone importing dashboard JSON via the UI or Terraform — they now get a clear write-time error pointing at the conflicting uid instead of a confusing read-time 500 down the line.

**Which issue(s) does this PR fix?**:

https://github.com/grafana/support-escalations/issues/22469
https://github.com/grafana/support-escalations/issues/22478

**Special notes for your reviewer:**

- The error message text returned by `GetDashboardUIDByID` is preserved verbatim (`unexpected number of dashboards for id N. found: K. desired: 1`) — the typed error's `Error()` produces the same string, so no caller is affected.
- Integration coverage added in `TestIntegrationLegacySupport` under `pkg/tests/apis/dashboard/`; unit coverage in `pkg/registry/apis/dashboard/register_test.go` covers all eight decision branches (unused/conflict/already-duplicated/idempotent/no-label/dry-run/standalone/generic-error).
- Race-condition note: admission is not globally serialized, so two concurrent creates with the same `id` can both pass. In practice the duplicate is introduced minutes-to-months apart (single-actor imports/Terraform applies), which admission catches. The race-free closure is a storage-level unique index on `(namespace, label[deprecatedInternalID])` — flagged as a follow-up rather than gating this PR on it.

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a notable improvement, it's added to our What's New doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)