### PR TITLE
Storage: Reject duplicate deprecatedInternalID at admission

### DIFF
--- a/pkg/apimachinery/utils/meta.go
+++ b/pkg/apimachinery/utils/meta.go
@@ -199,9 +199,7 @@ func (m *grafanaMetaAccessor) SetAnnotation(key string, val string) {
 	if val == "" {
 		if anno != nil {
 			delete(anno, key)
-			if len(anno) == 0 {
-				anno = nil // clear the whole object
-			}
+			anno = nilIfEmpty(anno)
 		}
 	} else {
 		if anno == nil {
@@ -319,10 +317,7 @@ func (m *grafanaMetaAccessor) SetDeprecatedInternalID(id int64) {
 	if id == 0 {
 		if labels != nil {
 			delete(labels, LabelKeyDeprecatedInternalID)
-			if len(labels) == 0 {
-				labels = nil
-			}
-			m.obj.SetLabels(labels)
+			m.obj.SetLabels(nilIfEmpty(labels))
 		}
 		return
 	}
@@ -945,6 +940,15 @@ func (m *grafanaMetaAccessor) SetSecureValues(vals common.InlineSecureValues) (e
 	}
 
 	return fmt.Errorf("unable to set secure values on (%T)", m.raw)
+}
+
+// nilIfEmpty returns nil for an empty map so the field is dropped from the
+// serialized object rather than written as an empty {}.
+func nilIfEmpty(m map[string]string) map[string]string {
+	if len(m) == 0 {
+		return nil
+	}
+	return m
 }
 
 func getJSONFieldName(f reflect.Value, idx int) string {

--- a/pkg/apimachinery/utils/meta.go
+++ b/pkg/apimachinery/utils/meta.go
@@ -199,6 +199,9 @@ func (m *grafanaMetaAccessor) SetAnnotation(key string, val string) {
 	if val == "" {
 		if anno != nil {
 			delete(anno, key)
+			if len(anno) == 0 {
+				anno = nil // clear the whole object
+			}
 		}
 	} else {
 		if anno == nil {
@@ -316,6 +319,9 @@ func (m *grafanaMetaAccessor) SetDeprecatedInternalID(id int64) {
 	if id == 0 {
 		if labels != nil {
 			delete(labels, LabelKeyDeprecatedInternalID)
+			if len(labels) == 0 {
+				labels = nil
+			}
 			m.obj.SetLabels(labels)
 		}
 		return

--- a/pkg/apimachinery/utils/meta_test.go
+++ b/pkg/apimachinery/utils/meta_test.go
@@ -298,6 +298,53 @@ func TestMetaAccessor(t *testing.T) {
 		require.Equal(t, meta.GetDeprecatedInternalID(), int64(1))
 	})
 
+	t.Run("removing the last annotation drops the map (nil, not empty)", func(t *testing.T) {
+		res := &unstructured.Unstructured{Object: map[string]any{}}
+		meta, err := utils.MetaAccessor(res)
+		require.NoError(t, err)
+
+		meta.SetAnnotation("grafana.app/a", "1")
+		meta.SetAnnotation("grafana.app/b", "2")
+
+		// Removing one of several annotations leaves the rest untouched
+		meta.SetAnnotation("grafana.app/a", "")
+		require.Equal(t, map[string]string{"grafana.app/b": "2"}, res.GetAnnotations())
+
+		// Removing the final annotation clears the whole map so it is not
+		// serialized as an empty {}
+		meta.SetAnnotation("grafana.app/b", "")
+		require.Nil(t, res.GetAnnotations())
+	})
+
+	t.Run("clearing the internal ID preserves other labels", func(t *testing.T) {
+		res := &unstructured.Unstructured{Object: map[string]any{}}
+		meta, err := utils.MetaAccessor(res)
+		require.NoError(t, err)
+
+		res.SetLabels(map[string]string{
+			utils.LabelKeyDeprecatedInternalID: "7",
+			"example.com/keep":                 "yes",
+		})
+
+		// Only the internal ID label is removed; unrelated labels survive
+		meta.SetDeprecatedInternalID(0)
+		require.Equal(t, map[string]string{"example.com/keep": "yes"}, res.GetLabels())
+	})
+
+	t.Run("clearing the only label drops the map (nil, not empty)", func(t *testing.T) {
+		res := &unstructured.Unstructured{Object: map[string]any{}}
+		meta, err := utils.MetaAccessor(res)
+		require.NoError(t, err)
+
+		meta.SetDeprecatedInternalID(9)
+		require.Equal(t, map[string]string{
+			utils.LabelKeyDeprecatedInternalID: "9",
+		}, res.GetLabels())
+
+		meta.SetDeprecatedInternalID(0)
+		require.Nil(t, res.GetLabels())
+	})
+
 	t.Run("get and set grafana metadata (unstructured)", func(t *testing.T) {
 		// Error reading spec+status when missing
 		res := &unstructured.Unstructured{

--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -770,9 +770,9 @@ func validateDashboardTags(obj runtime.Object) error {
 
 func (b *DashboardsAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.APIGroupInfo, opts builder.APIGroupOptions) error {
 	storageOpts := apistore.StorageOptions{
-		Scheme:                      opts.Scheme,
-		EnableFolderSupport:         true,
-		RequireDeprecatedInternalID: true,
+		Scheme:               opts.Scheme,
+		EnableFolderSupport:  true,
+		DeprecatedInternalID: apistore.NewDeprecatedIDLookup(b.unified),
 	}
 
 	if b.isStandalone {

--- a/pkg/registry/apis/dashboard/register.go
+++ b/pkg/registry/apis/dashboard/register.go
@@ -771,8 +771,9 @@ func validateDashboardTags(obj runtime.Object) error {
 func (b *DashboardsAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.APIGroupInfo, opts builder.APIGroupOptions) error {
 	storageOpts := apistore.StorageOptions{
 		Scheme:               opts.Scheme,
+		Index:                b.unified,
+		DeprecatedInternalID: apistore.DeprecatedID_Required,
 		EnableFolderSupport:  true,
-		DeprecatedInternalID: apistore.NewDeprecatedIDLookup(b.unified),
 	}
 
 	if b.isStandalone {

--- a/pkg/registry/apis/datasource/register.go
+++ b/pkg/registry/apis/datasource/register.go
@@ -240,7 +240,10 @@ func (b *DataSourceAPIBuilder) AllowedV0Alpha1Resources() []string {
 func (b *DataSourceAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.APIGroupInfo, opts builder.APIGroupOptions) error {
 	if opts.StorageOptsRegister != nil {
 		opts.StorageOptsRegister(b.datasourceResourceInfo.GroupResource(), apistore.StorageOptions{
-			EnableFolderSupport: false,
+			Index: nil, // TODO, required to check that they are unique
+
+			// Keep them for now, but we should get rid of them when possible
+			DeprecatedInternalID: apistore.DeprecatedID_Required,
 
 			// Setting the schema explicitly will force the apistore to explicitly marshal with a matching Group+version
 			// This is required because we map the same go type (DataSourceConfig) across multiple api groups

--- a/pkg/registry/apis/folders/register.go
+++ b/pkg/registry/apis/folders/register.go
@@ -218,10 +218,10 @@ func (b *FolderAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.API
 	opts.StorageOptsRegister(foldersv1.FolderResourceInfo.GroupResource(), apistore.StorageOptions{
 		// Preserve apiVersion/kind from the client on write. Without Scheme, apistore.encode
 		// uses the global LegacyCodec and converts to a single preferred external version.
-		Scheme:                      opts.Scheme,
-		EnableFolderSupport:         true,
-		RequireDeprecatedInternalID: true,
-		Permissions:                 b.setDefaultFolderPermissions,
+		Scheme:               opts.Scheme,
+		EnableFolderSupport:  true,
+		DeprecatedInternalID: apistore.NewDeprecatedIDLookup(b.searcher),
+		Permissions:          b.setDefaultFolderPermissions,
 	})
 
 	// v1

--- a/pkg/registry/apis/folders/register.go
+++ b/pkg/registry/apis/folders/register.go
@@ -219,8 +219,9 @@ func (b *FolderAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *genericapiserver.API
 		// Preserve apiVersion/kind from the client on write. Without Scheme, apistore.encode
 		// uses the global LegacyCodec and converts to a single preferred external version.
 		Scheme:               opts.Scheme,
+		Index:                b.searcher,
 		EnableFolderSupport:  true,
-		DeprecatedInternalID: apistore.NewDeprecatedIDLookup(b.searcher),
+		DeprecatedInternalID: apistore.DeprecatedID_Required,
 		Permissions:          b.setDefaultFolderPermissions,
 	})
 

--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -401,6 +401,14 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *ge
 		Index:                b.unified,
 		DeprecatedInternalID: apistore.DeprecatedID_Required,
 	})
+	opts.StorageOptsRegister(iamv0.ServiceAccountResourceInfo.GroupResource(), apistore.StorageOptions{
+		Index:                b.unified,
+		DeprecatedInternalID: apistore.DeprecatedID_Required,
+	})
+	opts.StorageOptsRegister(iamv0.TeamBindingResourceInfo.GroupResource(), apistore.StorageOptions{
+		Index:                b.unified,
+		DeprecatedInternalID: apistore.DeprecatedID_Optional,
+	})
 
 	if enableTeamsApi {
 		if err := b.UpdateTeamsAPIGroup(opts, storage, enableZanzanaSync); err != nil {

--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -390,16 +390,16 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *ge
 	enableSsoSettingsApi := client.Boolean(ctx, featuremgmt.FlagKubernetesSsoSettingsApi, false, openfeature.TransactionContext(ctx))
 	enableSaResourcePermissions := client.Boolean(ctx, featuremgmt.FlagKubernetesAuthzServiceAccountResourcePermissions, false, openfeature.TransactionContext(ctx))
 
-	internalIDs := apistore.NewDeprecatedIDLookup(b.unified)
-
 	// teams + users must have shorter names because they are often used as part of another name
 	opts.StorageOptsRegister(iamv0.TeamResourceInfo.GroupResource(), apistore.StorageOptions{
 		MaximumNameLength:    80,
-		DeprecatedInternalID: internalIDs,
+		Index:                b.unified,
+		DeprecatedInternalID: apistore.DeprecatedID_Required,
 	})
 	opts.StorageOptsRegister(iamv0.UserResourceInfo.GroupResource(), apistore.StorageOptions{
 		MaximumNameLength:    80,
-		DeprecatedInternalID: internalIDs,
+		Index:                b.unified,
+		DeprecatedInternalID: apistore.DeprecatedID_Required,
 	})
 
 	if enableTeamsApi {

--- a/pkg/registry/apis/iam/register.go
+++ b/pkg/registry/apis/iam/register.go
@@ -390,14 +390,16 @@ func (b *IdentityAccessManagementAPIBuilder) UpdateAPIGroupInfo(apiGroupInfo *ge
 	enableSsoSettingsApi := client.Boolean(ctx, featuremgmt.FlagKubernetesSsoSettingsApi, false, openfeature.TransactionContext(ctx))
 	enableSaResourcePermissions := client.Boolean(ctx, featuremgmt.FlagKubernetesAuthzServiceAccountResourcePermissions, false, openfeature.TransactionContext(ctx))
 
+	internalIDs := apistore.NewDeprecatedIDLookup(b.unified)
+
 	// teams + users must have shorter names because they are often used as part of another name
 	opts.StorageOptsRegister(iamv0.TeamResourceInfo.GroupResource(), apistore.StorageOptions{
-		MaximumNameLength:           80,
-		RequireDeprecatedInternalID: true,
+		MaximumNameLength:    80,
+		DeprecatedInternalID: internalIDs,
 	})
 	opts.StorageOptsRegister(iamv0.UserResourceInfo.GroupResource(), apistore.StorageOptions{
-		MaximumNameLength:           80,
-		RequireDeprecatedInternalID: true,
+		MaximumNameLength:    80,
+		DeprecatedInternalID: internalIDs,
 	})
 
 	if enableTeamsApi {

--- a/pkg/storage/unified/apistore/prepare.go
+++ b/pkg/storage/unified/apistore/prepare.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"strconv"
 	"time"
 
 	"github.com/google/uuid"
@@ -14,6 +15,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/apiserver/pkg/storage"
@@ -147,33 +149,24 @@ func (s *Storage) prepareObjectForStorage(ctx context.Context, newObject runtime
 		return v, err
 	}
 
-	if s.opts.DeprecatedInternalID == nil {
-		obj.SetDeprecatedInternalID(0) // nolint:staticcheck // make sure we do NOT have the label
-	} else {
-		// nolint:staticcheck
-		id := obj.GetDeprecatedInternalID()
-		if id > 0 {
-			// Best-effort guard: the index is eventually consistent, so two
-			// concurrent creates with the same id could still both pass here.
-			found, err := s.opts.DeprecatedInternalID(ctx, &resourcepb.ResourceKey{
-				Group:     s.gr.Group,
-				Resource:  s.gr.Resource,
-				Namespace: obj.GetNamespace(),
-			}, id)
-			if err != nil {
-				return v, err
-			}
-			if found {
-				return v, apierrors.NewConflict(s.gr, obj.GetName(),
-					fmt.Errorf("deprecatedInternalID=%d is already in use", id))
-			}
-		} else {
-			// the ID must be smaller than 9007199254740991, otherwise we will lose precision
-			// on the frontend, which uses the number type to store ids. The largest safe number in
-			// javascript is 9007199254740991, compared to 9223372036854775807 as the max int64
-			// nolint:staticcheck
-			obj.SetDeprecatedInternalID(s.snowflake.Generate().Int64() & ((1 << 52) - 1))
+	// Make sure the deprecated internal ID is valid
+	id := obj.GetDeprecatedInternalID() // nolint:staticcheck
+	// nolint:staticcheck
+	switch {
+	case id > 0:
+		if s.opts.DeprecatedInternalID == DeprecatedID_None {
+			return v, apierrors.NewBadRequest("internal ID is not supported")
 		}
+		if err := s.ensureSingleDeprecatedInternalID(ctx, id, obj); err != nil {
+			return v, err
+		}
+	case s.opts.DeprecatedInternalID == DeprecatedID_Required:
+		// the ID must be smaller than 9007199254740991, otherwise we will lose precision
+		// on the frontend, which uses the number type to store ids. The largest safe number in
+		// javascript is 9007199254740991, compared to 9223372036854775807 as the max int64
+		obj.SetDeprecatedInternalID(s.snowflake.Generate().Int64() & ((1 << 52) - 1))
+	case s.opts.DeprecatedInternalID == DeprecatedID_None:
+		obj.SetDeprecatedInternalID(0) // remove it
 	}
 
 	obj.SetGenerateName("") // Clear the random name field
@@ -196,6 +189,36 @@ func (s *Storage) prepareObjectForStorage(ctx context.Context, newObject runtime
 
 	err = s.encode(newObject, &v.raw)
 	return v, err
+}
+
+func (s *Storage) ensureSingleDeprecatedInternalID(ctx context.Context, id int64, obj utils.GrafanaMetaAccessor) error {
+	if s.opts.Index == nil {
+		// The storage was not configured to verify uniqueness
+		return nil
+	}
+	rsp, err := s.opts.Index.Search(ctx, &resourcepb.ResourceSearchRequest{
+		Limit: 1, // we only need to know if any match exists
+		Options: &resourcepb.ListOptions{
+			Key: &resourcepb.ResourceKey{
+				Group:     s.gr.Group,
+				Resource:  s.gr.Resource,
+				Namespace: obj.GetNamespace(),
+			},
+			Labels: []*resourcepb.Requirement{{
+				Key:      utils.LabelKeyDeprecatedInternalID,
+				Operator: string(selection.Equals),
+				Values:   []string{strconv.FormatInt(id, 10)},
+			}},
+		},
+	})
+	if err != nil {
+		return err
+	}
+	if rsp.Results != nil && len(rsp.Results.Rows) > 0 {
+		return apierrors.NewConflict(s.gr, obj.GetName(),
+			fmt.Errorf("deprecatedInternalID=%d is already in use", id))
+	}
+	return nil
 }
 
 // Called on update

--- a/pkg/storage/unified/apistore/prepare.go
+++ b/pkg/storage/unified/apistore/prepare.go
@@ -148,17 +148,24 @@ func (s *Storage) prepareObjectForStorage(ctx context.Context, newObject runtime
 	}
 
 	if s.opts.DeprecatedInternalID == nil {
-		obj.SetDeprecatedInternalID(0) // nolint:staticcheck make sure we do NOT have the label
+		obj.SetDeprecatedInternalID(0) // nolint:staticcheck // make sure we do NOT have the label
 	} else {
 		// nolint:staticcheck
 		id := obj.GetDeprecatedInternalID()
 		if id > 0 {
-			found, err := s.opts.DeprecatedInternalID(ctx, &resourcepb.ResourceKey{}, id)
+			// Best-effort guard: the index is eventually consistent, so two
+			// concurrent creates with the same id could still both pass here.
+			found, err := s.opts.DeprecatedInternalID(ctx, &resourcepb.ResourceKey{
+				Group:     s.gr.Group,
+				Resource:  s.gr.Resource,
+				Namespace: obj.GetNamespace(),
+			}, id)
 			if err != nil {
 				return v, err
 			}
 			if found {
-				return v, apierrors.NewBadRequest("The same deprecated internal ID already exists")
+				return v, apierrors.NewConflict(s.gr, obj.GetName(),
+					fmt.Errorf("deprecatedInternalID=%d is already in use", id))
 			}
 		} else {
 			// the ID must be smaller than 9007199254740991, otherwise we will lose precision

--- a/pkg/storage/unified/apistore/prepare.go
+++ b/pkg/storage/unified/apistore/prepare.go
@@ -27,6 +27,7 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	secrets "github.com/grafana/grafana/pkg/registry/apis/secret/contracts"
 	"github.com/grafana/grafana/pkg/services/folder"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
 
 type objectForStorage struct {
@@ -146,11 +147,21 @@ func (s *Storage) prepareObjectForStorage(ctx context.Context, newObject runtime
 		return v, err
 	}
 
-	if s.opts.RequireDeprecatedInternalID {
+	if s.opts.DeprecatedInternalID == nil {
+		obj.SetDeprecatedInternalID(0) // nolint:staticcheck make sure we do NOT have the label
+	} else {
 		// nolint:staticcheck
 		id := obj.GetDeprecatedInternalID()
-		if id < 1 {
-			// the ID must be smaller than 9007199254740991, otherwise we will lose prescision
+		if id > 0 {
+			found, err := s.opts.DeprecatedInternalID(ctx, &resourcepb.ResourceKey{}, id)
+			if err != nil {
+				return v, err
+			}
+			if found {
+				return v, apierrors.NewBadRequest("The same deprecated internal ID already exists")
+			}
+		} else {
+			// the ID must be smaller than 9007199254740991, otherwise we will lose precision
 			// on the frontend, which uses the number type to store ids. The largest safe number in
 			// javascript is 9007199254740991, compared to 9223372036854775807 as the max int64
 			// nolint:staticcheck
@@ -224,12 +235,8 @@ func (s *Storage) prepareObjectForUpdate(ctx context.Context, updateObject runti
 	obj.SetResourceVersion("")                           // removed from saved JSON because the RV is not yet calculated
 	obj.SetAnnotation(utils.AnnoKeyGrantPermissions, "") // Grant is ignored for update requests
 
-	// for dashboards, a mutation hook will set it if it didn't exist on the previous obj
-	// avoid setting it back to 0
-	previousInternalID := previous.GetDeprecatedInternalID() // nolint:staticcheck
-	if previousInternalID != 0 {
-		obj.SetDeprecatedInternalID(previousInternalID) // nolint:staticcheck
-	}
+	// Make sure the deprecated internalID does not change
+	obj.SetDeprecatedInternalID(previous.GetDeprecatedInternalID()) // nolint:staticcheck
 
 	err = prepareSecureValues(ctx, s.opts.SecureValues, obj, previous, &v)
 	if err != nil {

--- a/pkg/storage/unified/apistore/prepare.go
+++ b/pkg/storage/unified/apistore/prepare.go
@@ -191,6 +191,12 @@ func (s *Storage) prepareObjectForStorage(ctx context.Context, newObject runtime
 	return v, err
 }
 
+// ensureSingleDeprecatedInternalID rejects a write when the requested internal
+// ID is already in use. This is best effort, not a guarantee: the check queries
+// an eventually-consistent search index and is not atomic with the write, so
+// concurrent (or rapid sequential, before the index catches up) writes with the
+// same ID can both pass. It catches the common accidental-duplicate case, not
+// races.
 func (s *Storage) ensureSingleDeprecatedInternalID(ctx context.Context, id int64, obj utils.GrafanaMetaAccessor) error {
 	if s.opts.Index == nil {
 		// The storage was not configured to verify uniqueness

--- a/pkg/storage/unified/apistore/prepare_test.go
+++ b/pkg/storage/unified/apistore/prepare_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/services/folder"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
 
 var rtscheme = runtime.NewScheme()
@@ -237,7 +238,11 @@ func TestPrepareObjectForStorage(t *testing.T) {
 		require.Equal(t, "2025-12-17T01:01:00Z", tmp.GetAnnotation(utils.AnnoKeyUpdatedTimestamp))
 	})
 
-	s.opts.RequireDeprecatedInternalID = true
+	// Dummy function
+	s.opts.DeprecatedInternalID = func(ctx context.Context, key *resourcepb.ResourceKey, id int64) (bool, error) {
+		return id == 100, nil
+	}
+
 	t.Run("Should generate internal id", func(t *testing.T) {
 		dashboard := dashv1.Dashboard{}
 		dashboard.Name = "test-name"
@@ -268,6 +273,18 @@ func TestPrepareObjectForStorage(t *testing.T) {
 		meta, err = utils.MetaAccessor(newObject)
 		require.NoError(t, err)
 		require.Equal(t, meta.GetDeprecatedInternalID(), int64(1)) // nolint:staticcheck
+	})
+
+	t.Run("Should fail if deprecated ID if already in use", func(t *testing.T) {
+		dashboard := dashv1.Dashboard{}
+		dashboard.Name = "test-name"
+		obj := dashboard.DeepCopyObject()
+		meta, err := utils.MetaAccessor(obj)
+		require.NoError(t, err)
+		meta.SetDeprecatedInternalID(100) // nolint:staticcheck
+
+		_, err = s.prepareObjectForStorage(ctx, obj)
+		require.True(t, apierrors.IsBadRequest(err))
 	})
 
 	t.Run("Should remove grant permissions annotation", func(t *testing.T) {

--- a/pkg/storage/unified/apistore/prepare_test.go
+++ b/pkg/storage/unified/apistore/prepare_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/bwmarrin/snowflake"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
 	"k8s.io/apimachinery/pkg/api/apitesting"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -269,10 +270,8 @@ func TestPrepareObjectForStorage(t *testing.T) {
 		require.Equal(t, "2025-12-17T01:01:00Z", tmp.GetAnnotation(utils.AnnoKeyUpdatedTimestamp))
 	})
 
-	// Dummy function
-	s.opts.DeprecatedInternalID = func(ctx context.Context, key *resourcepb.ResourceKey, id int64) (bool, error) {
-		return id == 100, nil
-	}
+	s.opts.DeprecatedInternalID = DeprecatedID_Required
+	s.opts.Index = &fakeSearchIndex{inUse: map[string]bool{"100": true}}
 
 	t.Run("Should generate internal id", func(t *testing.T) {
 		dashboard := dashv1.Dashboard{}
@@ -824,4 +823,27 @@ func TestPrepareObjectForStorage_FolderSupportDisabled(t *testing.T) {
 		_, err := s.prepareObjectForStorage(ctx, dash)
 		require.NoError(t, err)
 	})
+}
+
+// fakeSearchIndex is a minimal resourcepb.ResourceIndexClient for tests. Search
+// reports a hit when the request filters on a deprecatedInternalID label whose
+// value is listed in inUse, and reports no hits otherwise.
+type fakeSearchIndex struct {
+	resourcepb.ResourceIndexClient
+	inUse map[string]bool // deprecatedInternalID label values that already exist
+}
+
+func (f *fakeSearchIndex) Search(_ context.Context, req *resourcepb.ResourceSearchRequest, _ ...grpc.CallOption) (*resourcepb.ResourceSearchResponse, error) {
+	rsp := &resourcepb.ResourceSearchResponse{Results: &resourcepb.ResourceTable{}}
+	for _, label := range req.GetOptions().GetLabels() {
+		if label.GetKey() != utils.LabelKeyDeprecatedInternalID {
+			continue
+		}
+		for _, v := range label.GetValues() {
+			if f.inUse[v] {
+				rsp.Results.Rows = append(rsp.Results.Rows, &resourcepb.ResourceTableRow{})
+			}
+		}
+	}
+	return rsp, nil
 }

--- a/pkg/storage/unified/apistore/prepare_test.go
+++ b/pkg/storage/unified/apistore/prepare_test.go
@@ -202,6 +202,37 @@ func TestPrepareObjectForStorage(t *testing.T) {
 		require.Equal(t, int64(2), meta2.GetGeneration())
 	})
 
+	t.Run("Update can not change the deprecated internal ID", func(t *testing.T) {
+		// The previously stored object owns internal ID 50
+		previous := &dashv1.Dashboard{ObjectMeta: v1.ObjectMeta{Name: "test-name"}}
+		prevMeta, err := utils.MetaAccessor(previous)
+		require.NoError(t, err)
+		prevMeta.SetDeprecatedInternalID(50) // nolint:staticcheck
+
+		assertStoredID := func(t *testing.T, updated *dashv1.Dashboard) {
+			t.Helper()
+			v, err := s.prepareObjectForUpdate(ctx, updated, previous)
+			require.NoError(t, err)
+			stored, _, err := s.codec.Decode(v.raw.Bytes(), nil, &dashv1.Dashboard{})
+			require.NoError(t, err)
+			storedMeta, err := utils.MetaAccessor(stored)
+			require.NoError(t, err)
+			// The update is ignored: the internal ID stays pinned to the previous value
+			require.Equal(t, int64(50), storedMeta.GetDeprecatedInternalID()) // nolint:staticcheck
+		}
+
+		// Attempting to change it to a different value is ignored
+		changed := &dashv1.Dashboard{ObjectMeta: v1.ObjectMeta{Name: "test-name"}}
+		changedMeta, err := utils.MetaAccessor(changed)
+		require.NoError(t, err)
+		changedMeta.SetDeprecatedInternalID(999) // nolint:staticcheck
+		assertStoredID(t, changed)
+
+		// Attempting to clear it is also ignored
+		cleared := &dashv1.Dashboard{ObjectMeta: v1.ObjectMeta{Name: "test-name"}}
+		assertStoredID(t, cleared)
+	})
+
 	t.Run("Update should skip incrementing generation when content is unchanged", func(t *testing.T) {
 		dashboard := dashv1.Dashboard{
 			ObjectMeta: v1.ObjectMeta{
@@ -284,7 +315,7 @@ func TestPrepareObjectForStorage(t *testing.T) {
 		meta.SetDeprecatedInternalID(100) // nolint:staticcheck
 
 		_, err = s.prepareObjectForStorage(ctx, obj)
-		require.True(t, apierrors.IsBadRequest(err))
+		require.True(t, apierrors.IsConflict(err))
 	})
 
 	t.Run("Should remove grant permissions annotation", func(t *testing.T) {

--- a/pkg/storage/unified/apistore/store.go
+++ b/pkg/storage/unified/apistore/store.go
@@ -25,6 +25,7 @@ import (
 	"k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/storagebackend"
@@ -61,20 +62,20 @@ type DeprecatedIDLookup func(ctx context.Context, key *resourcepb.ResourceKey, i
 func NewDeprecatedIDLookup(index resourcepb.ResourceIndexClient) DeprecatedIDLookup {
 	return func(ctx context.Context, key *resourcepb.ResourceKey, id int64) (bool, error) {
 		rsp, err := index.Search(ctx, &resourcepb.ResourceSearchRequest{
-			Limit: 0, // We don't need the real results
+			Limit: 1, // we only need to know if any match exists
 			Options: &resourcepb.ListOptions{
 				Key: key,
 				Labels: []*resourcepb.Requirement{{
 					Key:      utils.LabelKeyDeprecatedInternalID,
-					Operator: "=",
-					Values:   []string{fmt.Sprintf("%d", id)},
+					Operator: string(selection.Equals),
+					Values:   []string{strconv.FormatInt(id, 10)},
 				}},
 			},
 		})
 		if err != nil {
 			return false, err
 		}
-		return rsp.TotalHits > 0, nil
+		return rsp.Results != nil && len(rsp.Results.Rows) > 0, nil
 	}
 }
 

--- a/pkg/storage/unified/apistore/store.go
+++ b/pkg/storage/unified/apistore/store.go
@@ -55,6 +55,29 @@ var (
 
 type DefaultPermissionSetter = func(ctx context.Context, key *resourcepb.ResourceKey, id authtypes.AuthInfo, obj utils.GrafanaMetaAccessor) error
 
+// Find the previous value by internal ID
+type DeprecatedIDLookup func(ctx context.Context, key *resourcepb.ResourceKey, id int64) (bool, error)
+
+func NewDeprecatedIDLookup(index resourcepb.ResourceIndexClient) DeprecatedIDLookup {
+	return func(ctx context.Context, key *resourcepb.ResourceKey, id int64) (bool, error) {
+		rsp, err := index.Search(ctx, &resourcepb.ResourceSearchRequest{
+			Limit: 0, // We don't need the real results
+			Options: &resourcepb.ListOptions{
+				Key: key,
+				Labels: []*resourcepb.Requirement{{
+					Key:      utils.LabelKeyDeprecatedInternalID,
+					Operator: "=",
+					Values:   []string{fmt.Sprintf("%d", id)},
+				}},
+			},
+		})
+		if err != nil {
+			return false, err
+		}
+		return rsp.TotalHits > 0, nil
+	}
+}
+
 // Optional settings that apply to a single resource
 type StorageOptions struct {
 	Scheme *runtime.Scheme
@@ -66,7 +89,7 @@ type StorageOptions struct {
 	MaximumNameLength int
 
 	// Add internalID label when missing
-	RequireDeprecatedInternalID bool
+	DeprecatedInternalID DeprecatedIDLookup
 
 	// Process inline secure values
 	SecureValues secrets.InlineSecureValueSupport
@@ -170,7 +193,7 @@ func NewStorage(
 			"resource", config.GroupResource.String())
 	}
 
-	if opts.RequireDeprecatedInternalID {
+	if opts.DeprecatedInternalID != nil {
 		node, err := snowflake.NewNode(rand.Int64N(1024))
 		if err != nil {
 			return nil, nil, err
@@ -246,16 +269,19 @@ func (s *Storage) convertToObject(ctx context.Context, data []byte, obj runtime.
 func (s *Storage) Create(ctx context.Context, key string, obj runtime.Object, out runtime.Object, ttl uint64) error {
 	ctx, span := tracer.Start(ctx, "apistore.Storage.Create")
 	defer span.End()
+
+	rkey, err := s.getKey(key)
+	if err != nil {
+		return err
+	}
+
 	v, err := s.prepareObjectForStorage(ctx, obj)
 	if err != nil {
 		return s.handleManagedResourceRouting(ctx, err, resourcepb.WatchEvent_ADDED, key, obj, out)
 	}
 	req := &resourcepb.CreateRequest{
 		Value: v.raw.Bytes(),
-	}
-	req.Key, err = s.getKey(key)
-	if err != nil {
-		return err
+		Key:   rkey,
 	}
 
 	v.permissionCreator, err = afterCreatePermissionCreator(ctx, req.Key, v.grantPermissions, obj, s.opts.Permissions)

--- a/pkg/storage/unified/apistore/store.go
+++ b/pkg/storage/unified/apistore/store.go
@@ -25,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/conversion"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/apiserver/pkg/storage"
 	"k8s.io/apiserver/pkg/storage/storagebackend"
@@ -56,32 +55,23 @@ var (
 
 type DefaultPermissionSetter = func(ctx context.Context, key *resourcepb.ResourceKey, id authtypes.AuthInfo, obj utils.GrafanaMetaAccessor) error
 
-// Find the previous value by internal ID
-type DeprecatedIDLookup func(ctx context.Context, key *resourcepb.ResourceKey, id int64) (bool, error)
+type DeprecatedIDState int
 
-func NewDeprecatedIDLookup(index resourcepb.ResourceIndexClient) DeprecatedIDLookup {
-	return func(ctx context.Context, key *resourcepb.ResourceKey, id int64) (bool, error) {
-		rsp, err := index.Search(ctx, &resourcepb.ResourceSearchRequest{
-			Limit: 1, // we only need to know if any match exists
-			Options: &resourcepb.ListOptions{
-				Key: key,
-				Labels: []*resourcepb.Requirement{{
-					Key:      utils.LabelKeyDeprecatedInternalID,
-					Operator: string(selection.Equals),
-					Values:   []string{strconv.FormatInt(id, 10)},
-				}},
-			},
-		})
-		if err != nil {
-			return false, err
-		}
-		return rsp.Results != nil && len(rsp.Results.Rows) > 0, nil
-	}
-}
+const (
+	// The ID property will always be dropped
+	DeprecatedID_None DeprecatedIDState = iota
+	// The ID will always be added
+	DeprecatedID_Required
+	// OK if the value is sent, but not added automatically
+	DeprecatedID_Optional
+)
 
 // Optional settings that apply to a single resource
 type StorageOptions struct {
 	Scheme *runtime.Scheme
+
+	// Required to force unique constraints
+	Index resourcepb.ResourceIndexClient
 
 	// Allow writing objects with metadata.annotations[grafana.app/folder]
 	EnableFolderSupport bool
@@ -89,8 +79,8 @@ type StorageOptions struct {
 	// Some resources should not allow the absolute maximum (254 characters)
 	MaximumNameLength int
 
-	// Add internalID label when missing
-	DeprecatedInternalID DeprecatedIDLookup
+	// How should we handle deprecated internal IDs
+	DeprecatedInternalID DeprecatedIDState
 
 	// Process inline secure values
 	SecureValues secrets.InlineSecureValueSupport
@@ -194,7 +184,7 @@ func NewStorage(
 			"resource", config.GroupResource.String())
 	}
 
-	if opts.DeprecatedInternalID != nil {
+	if opts.DeprecatedInternalID == DeprecatedID_Required {
 		node, err := snowflake.NewNode(rand.Int64N(1024))
 		if err != nil {
 			return nil, nil, err
@@ -276,6 +266,20 @@ func (s *Storage) Create(ctx context.Context, key string, obj runtime.Object, ou
 		return err
 	}
 
+	meta, err := utils.MetaAccessor(obj)
+	if err != nil {
+		return err
+	}
+
+	// Make sure we are looking at the correct namespace
+	if meta.GetNamespace() != rkey.Namespace {
+		if meta.GetNamespace() == "" {
+			meta.SetNamespace(rkey.Namespace)
+		} else {
+			return apierrors.NewBadRequest("namespace mismatch")
+		}
+	}
+
 	v, err := s.prepareObjectForStorage(ctx, obj)
 	if err != nil {
 		return s.handleManagedResourceRouting(ctx, err, resourcepb.WatchEvent_ADDED, key, obj, out)
@@ -306,7 +310,7 @@ func (s *Storage) Create(ctx context.Context, key string, obj runtime.Object, ou
 		return err
 	}
 
-	meta, err := utils.MetaAccessor(out)
+	meta, err = utils.MetaAccessor(out)
 	if err != nil {
 		return err
 	}

--- a/pkg/tests/api/dashboards/api_dashboards_test.go
+++ b/pkg/tests/api/dashboards/api_dashboards_test.go
@@ -226,46 +226,20 @@ func TestIntegrationDashboardServiceValidation(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	dashboardWithDuplicatedLegacyAnnotation := "new-uid"
 	t.Run("When saving a dashboard with an already used legacy ID", func(t *testing.T) {
 		resp, err := postDashboard(t, grafanaListedAddr, "admin", "admin", map[string]interface{}{
 			"dashboard": map[string]interface{}{
 				"id":    savedDashInFolder.ID, // nolint:staticcheck
-				"uid":   dashboardWithDuplicatedLegacyAnnotation,
+				"uid":   "new-uid",
 				"title": "Updated title",
 			},
 			"folderUid": savedDashInFolder.FolderUID,
 			"overwrite": true,
 		})
 		require.NoError(t, err)
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, http.StatusConflict, resp.StatusCode)
 		err = resp.Body.Close()
 		require.NoError(t, err)
-	})
-
-	t.Run("When updating a dashboard with legacy ID in multiple dashboards", func(t *testing.T) {
-		resp, err := postDashboard(t, grafanaListedAddr, "admin", "admin", map[string]interface{}{
-			"dashboard": map[string]interface{}{
-				"id":    savedDashInFolder.ID, // nolint:staticcheck
-				"uid":   savedDashInGeneralFolder.UID,
-				"title": "Updated title",
-			},
-			"folderUid": savedDashInFolder.FolderUID,
-			"overwrite": true,
-		})
-		require.NoError(t, err)
-		assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
-		err = resp.Body.Close()
-		require.NoError(t, err)
-		// Delete the dashboard with duplicated legacy ID annotation
-		u := fmt.Sprintf("http://admin:admin@%s/api/dashboards/uid/%s", grafanaListedAddr, dashboardWithDuplicatedLegacyAnnotation)
-		req, err := http.NewRequest("DELETE", u, nil)
-		require.NoError(t, err)
-		resp, err = http.DefaultClient.Do(req)
-		require.NoError(t, err)
-		err = resp.Body.Close()
-		require.NoError(t, err)
-		assert.Equal(t, http.StatusOK, resp.StatusCode)
 	})
 
 	t.Run("When updating a dashboard already using that uid", func(t *testing.T) {

--- a/pkg/tests/apis/dashboard/dashboards_test.go
+++ b/pkg/tests/apis/dashboard/dashboards_test.go
@@ -514,6 +514,45 @@ func TestIntegrationLegacySupport(t *testing.T) {
 	}, &dtos.DashboardFullWithMeta{})
 	require.Equal(t, 200, rsp.Response.StatusCode)
 	require.Equal(t, dashboardV0.VERSION, rsp.Result.Meta.APIVersion)
+
+	//---------------------------------------------------------
+	// Reject creating a second dashboard that reuses an existing
+	// grafana.app/deprecatedInternalID. Without admission enforcement, two
+	// dashboards could end up sharing the same legacy id (the symptom was
+	// /api/dashboards/db returning 500 with "unexpected number of dashboards
+	// for id N. found: 2. desired: 1" on any later overwrite).
+	//---------------------------------------------------------
+	t.Run("reject duplicate deprecatedInternalID on create", func(t *testing.T) {
+		const sharedID = int64(99999)
+
+		newDashboardWithID := func(name string) *unstructured.Unstructured {
+			return &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "dashboard.grafana.app/v1",
+					"kind":       "Dashboard",
+					"metadata": map[string]any{
+						"name": name,
+					},
+					"spec": map[string]any{
+						"id":            sharedID,
+						"title":         name,
+						"schemaVersion": int64(36),
+					},
+				},
+			}
+		}
+
+		first, err := clientV1.Resource.Create(ctx, newDashboardWithID("dup-id-a"), metav1.CreateOptions{})
+		require.NoError(t, err, "first create with spec.id should succeed")
+		require.Equal(t, "99999", first.GetLabels()[utils.LabelKeyDeprecatedInternalID], //nolint:staticcheck
+			"mutation hook should lift spec.id onto the label")
+
+		_, err = clientV1.Resource.Create(ctx, newDashboardWithID("dup-id-b"), metav1.CreateOptions{})
+		require.Error(t, err, "second create with same spec.id must be rejected")
+		require.True(t, errors.IsConflict(err),
+			"expected HTTP 409 Conflict, got %T: %v", err, err)
+		require.Contains(t, err.Error(), "deprecatedInternalID=99999")
+	})
 }
 
 func TestIntegrationListPagination(t *testing.T) {


### PR DESCRIPTION
## Enforce unique deprecated internal IDs in unified storage

### What

Two objects in the same group/resource/namespace could end up sharing a legacy `grafana.app/deprecatedInternalID`. For dashboards this caused `/api/dashboards/db` to return `500 "unexpected number of dashboards for id N. found: 2. desired: 1"`. This PR adds a write-time uniqueness check and replaces the `RequireDeprecatedInternalID` bool with a tri-state policy.

### Changes

- **`DeprecatedIDState` policy** replaces `RequireDeprecatedInternalID`:
  - `None` — ID always dropped; sending one is rejected.
  - `Required` — generated when missing.
  - `Optional` — accepted if sent, never auto-added.
- **Uniqueness check** — new `StorageOptions.Index`; on create, a present ID is searched for and rejected with `409 Conflict` if already in use. Best-effort (eventually-consistent index, not atomic with the write).
- **On update**, the internal ID is pinned to the previous value (can't change or clear it).
- **`Storage.Create`** reconciles the object namespace up front so the search runs against the right namespace.
- **`meta.go`** drops annotation/label maps entirely when the last entry is removed instead of serializing `{}`.

Per resource: dashboards/folders/IAM teams, users, service accounts → `Required` + index wired; team bindings → `Optional`; datasources → `Required` but `Index: nil` (uniqueness not yet enforced, TODO).

### Notes

- Uniqueness is **best-effort, not a guarantee** — concurrent/rapid creates with the same ID can both pass.
- Datasource IDs are **not** yet uniqueness-checked yet (`Index: nil`).
