### PR TITLE
Alerting: Open new alert rule drawer from panel menu

### DIFF
--- a/public/app/features/alerting/unified/components/PanelAlertRuleDrawer.tsx
+++ b/public/app/features/alerting/unified/components/PanelAlertRuleDrawer.tsx
@@ -22,7 +22,10 @@ interface Props {
 export function PanelAlertRuleDrawer({ prefill, isOpen = true, onDismiss }: Props) {
   const location = useLocation();
 
-  const { onContinueInAlertingFromDrawer } = createPanelAlertRuleNavigation(() => Promise.resolve(prefill), location);
+  // AlertRuleDrawerForm always passes the live form values to onContinueInAlerting, so the
+  // getFormValues fallback inside createPanelAlertRuleNavigation is never invoked from this caller.
+  // Passing a noop makes the dead branch explicit.
+  const { onContinueInAlertingFromDrawer } = createPanelAlertRuleNavigation(() => Promise.resolve(undefined), location);
 
   return (
     <AlertRuleDrawerForm

--- a/public/app/features/alerting/unified/components/PanelAlertRuleDrawer.tsx
+++ b/public/app/features/alerting/unified/components/PanelAlertRuleDrawer.tsx
@@ -1,0 +1,35 @@
+import { useLocation } from 'react-router-dom-v5-compat';
+
+import { type RuleFormValues } from '../types/rule-form';
+import { createPanelAlertRuleNavigation } from '../utils/navigation';
+
+import { AlertRuleDrawerForm } from './AlertRuleDrawerForm';
+
+interface Props {
+  prefill?: Partial<RuleFormValues>;
+  /**
+   * Defaults to true. Provided automatically by the legacy ModalsContextProvider when
+   * mounted via `ShowModalReactEvent`.
+   */
+  isOpen?: boolean;
+  /**
+   * Provided automatically by the legacy ModalsContextProvider when mounted via
+   * `ShowModalReactEvent`. Scenes callers can pass their own.
+   */
+  onDismiss?: () => void;
+}
+
+export function PanelAlertRuleDrawer({ prefill, isOpen = true, onDismiss }: Props) {
+  const location = useLocation();
+
+  const { onContinueInAlertingFromDrawer } = createPanelAlertRuleNavigation(() => Promise.resolve(prefill), location);
+
+  return (
+    <AlertRuleDrawerForm
+      isOpen={isOpen}
+      onClose={() => onDismiss?.()}
+      onContinueInAlerting={onContinueInAlertingFromDrawer}
+      prefill={prefill}
+    />
+  );
+}

--- a/public/app/features/dashboard-scene/scene/NewAlertRuleDrawer.tsx
+++ b/public/app/features/dashboard-scene/scene/NewAlertRuleDrawer.tsx
@@ -1,0 +1,28 @@
+import {
+  type SceneComponentProps,
+  SceneObjectBase,
+  type SceneObjectRef,
+  type SceneObjectState,
+  type VizPanel,
+} from '@grafana/scenes';
+import { PanelAlertRuleDrawer } from 'app/features/alerting/unified/components/PanelAlertRuleDrawer';
+import { type RuleFormValues } from 'app/features/alerting/unified/types/rule-form';
+
+import { getDashboardSceneFor } from '../utils/utils';
+
+export interface NewAlertRuleDrawerState extends SceneObjectState {
+  panelRef: SceneObjectRef<VizPanel>;
+  prefill?: Partial<RuleFormValues>;
+}
+
+export class NewAlertRuleDrawer extends SceneObjectBase<NewAlertRuleDrawerState> {
+  public onClose = () => {
+    getDashboardSceneFor(this).closeModal();
+  };
+
+  static Component = ({ model }: SceneComponentProps<NewAlertRuleDrawer>) => {
+    const { prefill } = model.useState();
+
+    return <PanelAlertRuleDrawer prefill={prefill} onDismiss={model.onClose} />;
+  };
+}

--- a/public/app/features/dashboard-scene/scene/NewAlertRuleDrawer.tsx
+++ b/public/app/features/dashboard-scene/scene/NewAlertRuleDrawer.tsx
@@ -1,17 +1,10 @@
-import {
-  type SceneComponentProps,
-  SceneObjectBase,
-  type SceneObjectRef,
-  type SceneObjectState,
-  type VizPanel,
-} from '@grafana/scenes';
+import { type SceneComponentProps, SceneObjectBase, type SceneObjectState } from '@grafana/scenes';
 import { PanelAlertRuleDrawer } from 'app/features/alerting/unified/components/PanelAlertRuleDrawer';
 import { type RuleFormValues } from 'app/features/alerting/unified/types/rule-form';
 
 import { getDashboardSceneFor } from '../utils/utils';
 
 export interface NewAlertRuleDrawerState extends SceneObjectState {
-  panelRef: SceneObjectRef<VizPanel>;
   prefill?: Partial<RuleFormValues>;
 }
 

--- a/public/app/features/dashboard-scene/scene/PanelMenuBehavior.test.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelMenuBehavior.test.tsx
@@ -817,7 +817,7 @@ describe('panelMenuBehavior', () => {
       expect((drawer as NewAlertRuleDrawer).state.prefill).toEqual(mockFormValues);
     });
 
-    it('should open the new alert rule drawer with no prefill when no alerting-capable query is found', async () => {
+    it('should show error notification and not open the drawer when no alerting-capable query is found', async () => {
       const { menu, scene } = await buildTestScene({});
 
       config.unifiedAlertingEnabled = true;
@@ -837,10 +837,8 @@ describe('panelMenuBehavior', () => {
       await alertMenuItem?.({} as React.MouseEvent);
       await new Promise((r) => setTimeout(r, 0));
 
-      expect(showModalSpy).toHaveBeenCalledTimes(1);
-      const drawer = showModalSpy.mock.calls[0][0];
-      expect(drawer).toBeInstanceOf(NewAlertRuleDrawer);
-      expect((drawer as NewAlertRuleDrawer).state.prefill).toBeUndefined();
+      expect(showModalSpy).not.toHaveBeenCalled();
+      expect(storeModule.dispatch).toHaveBeenCalled();
     });
 
     it('should show error notification and not open the drawer on failure', async () => {

--- a/public/app/features/dashboard-scene/scene/PanelMenuBehavior.test.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelMenuBehavior.test.tsx
@@ -9,7 +9,6 @@ import {
   getDefaultTimeRange,
   store,
   toDataFrame,
-  urlUtil,
 } from '@grafana/data';
 import { getPanelPlugin } from '@grafana/data/test';
 import { config, locationService } from '@grafana/runtime';
@@ -34,6 +33,7 @@ import { buildPanelEditScene } from '../panel-edit/PanelEditor';
 import { DashboardInteractions } from '../utils/interactions';
 
 import { DashboardScene } from './DashboardScene';
+import { NewAlertRuleDrawer } from './NewAlertRuleDrawer';
 import { VizPanelLinks, VizPanelLinksMenu } from './PanelLinks';
 import { panelMenuBehavior } from './PanelMenuBehavior';
 import { DefaultGridLayoutManager } from './layout-default/DefaultGridLayoutManager';
@@ -785,11 +785,10 @@ describe('panelMenuBehavior', () => {
     beforeEach(() => {
       jest.spyOn(storeModule, 'dispatch').mockImplementation(() => {});
       jest.spyOn(locationService, 'push').mockImplementation(() => {});
-      jest.spyOn(urlUtil, 'renderUrl').mockImplementation((url, params) => `${url}?${JSON.stringify(params)}`);
     });
 
-    it('should navigate to alert creation page on success', async () => {
-      const { menu, panel } = await buildTestScene({});
+    it('should open the new alert rule drawer with prefilled values on success', async () => {
+      const { menu, panel, scene } = await buildTestScene({});
       const mockFormValues = { someKey: 'someValue' };
 
       config.unifiedAlertingEnabled = true;
@@ -798,27 +797,59 @@ describe('panelMenuBehavior', () => {
       jest
         .spyOn(require('app/features/alerting/unified/utils/rule-form'), 'scenesPanelToRuleFormValues')
         .mockResolvedValue(mockFormValues);
+      const showModalSpy = jest.spyOn(scene, 'showModal');
 
-      // activate the menu
       menu.activate();
-      // wait for the menu to be activated
       await new Promise((r) => setTimeout(r, 1));
-      // use userEvent mechanism to click the menu item
+
       const moreMenu = menu.state.items?.find((i) => i.text === 'More...')?.subMenu;
       const alertMenuItem = moreMenu?.find((i) => i.text === 'New alert rule')?.onClick;
       expect(alertMenuItem).toBeDefined();
 
-      alertMenuItem?.({} as React.MouseEvent);
+      await alertMenuItem?.({} as React.MouseEvent);
+      await new Promise((r) => setTimeout(r, 0));
+
       expect(scenesPanelToRuleFormValues).toHaveBeenCalledWith(panel);
+      expect(locationService.push).not.toHaveBeenCalled();
+      expect(showModalSpy).toHaveBeenCalledTimes(1);
+      const drawer = showModalSpy.mock.calls[0][0];
+      expect(drawer).toBeInstanceOf(NewAlertRuleDrawer);
+      expect((drawer as NewAlertRuleDrawer).state.prefill).toEqual(mockFormValues);
     });
 
-    it('should show error notification on failure', async () => {
-      const { menu, panel } = await buildTestScene({});
+    it('should open the new alert rule drawer with no prefill when no alerting-capable query is found', async () => {
+      const { menu, scene } = await buildTestScene({});
+
+      config.unifiedAlertingEnabled = true;
+      grantUserPermissions([AccessControlAction.AlertingRuleRead, AccessControlAction.AlertingRuleUpdate]);
+
+      jest
+        .spyOn(require('app/features/alerting/unified/utils/rule-form'), 'scenesPanelToRuleFormValues')
+        .mockResolvedValue(undefined);
+      const showModalSpy = jest.spyOn(scene, 'showModal');
+
+      menu.activate();
+      await new Promise((r) => setTimeout(r, 1));
+
+      const moreMenu = menu.state.items?.find((i) => i.text === 'More...')?.subMenu;
+      const alertMenuItem = moreMenu?.find((i) => i.text === 'New alert rule')?.onClick;
+
+      await alertMenuItem?.({} as React.MouseEvent);
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(showModalSpy).toHaveBeenCalledTimes(1);
+      const drawer = showModalSpy.mock.calls[0][0];
+      expect(drawer).toBeInstanceOf(NewAlertRuleDrawer);
+      expect((drawer as NewAlertRuleDrawer).state.prefill).toBeUndefined();
+    });
+
+    it('should show error notification and not open the drawer on failure', async () => {
+      const { menu, panel, scene } = await buildTestScene({});
       const mockError = new Error('Test error');
       jest
         .spyOn(require('app/features/alerting/unified/utils/rule-form'), 'scenesPanelToRuleFormValues')
         .mockRejectedValue(mockError);
-      // Don't make notifyApp throw an error, just mock it
+      const showModalSpy = jest.spyOn(scene, 'showModal');
 
       menu.activate();
       await new Promise((r) => setTimeout(r, 1));
@@ -832,6 +863,7 @@ describe('panelMenuBehavior', () => {
       await new Promise((r) => setTimeout(r, 0));
 
       expect(scenesPanelToRuleFormValues).toHaveBeenCalledWith(panel);
+      expect(showModalSpy).not.toHaveBeenCalled();
     });
 
     it('should render "New alert rule" menu item when user has permissions to read and update alerts', async () => {

--- a/public/app/features/dashboard-scene/scene/PanelMenuBehavior.test.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelMenuBehavior.test.tsx
@@ -785,6 +785,11 @@ describe('panelMenuBehavior', () => {
     beforeEach(() => {
       jest.spyOn(storeModule, 'dispatch').mockImplementation(() => {});
       jest.spyOn(locationService, 'push').mockImplementation(() => {});
+      config.featureToggles.createAlertRuleFromPanel = true;
+    });
+
+    afterEach(() => {
+      config.featureToggles.createAlertRuleFromPanel = false;
     });
 
     it('should open the new alert rule drawer with prefilled values on success', async () => {
@@ -862,6 +867,34 @@ describe('panelMenuBehavior', () => {
 
       expect(scenesPanelToRuleFormValues).toHaveBeenCalledWith(panel);
       expect(showModalSpy).not.toHaveBeenCalled();
+    });
+
+    it('should navigate to /alerting/new and not open the drawer when createAlertRuleFromPanel is disabled', async () => {
+      config.featureToggles.createAlertRuleFromPanel = false;
+
+      const { menu, scene } = await buildTestScene({});
+      const mockFormValues = { someKey: 'someValue' };
+
+      config.unifiedAlertingEnabled = true;
+      grantUserPermissions([AccessControlAction.AlertingRuleRead, AccessControlAction.AlertingRuleUpdate]);
+
+      jest
+        .spyOn(require('app/features/alerting/unified/utils/rule-form'), 'scenesPanelToRuleFormValues')
+        .mockResolvedValue(mockFormValues);
+      const showModalSpy = jest.spyOn(scene, 'showModal');
+
+      menu.activate();
+      await new Promise((r) => setTimeout(r, 1));
+
+      const moreMenu = menu.state.items?.find((i) => i.text === 'More...')?.subMenu;
+      const alertMenuItem = moreMenu?.find((i) => i.text === 'New alert rule')?.onClick;
+
+      await alertMenuItem?.({} as React.MouseEvent);
+      await new Promise((r) => setTimeout(r, 0));
+
+      expect(showModalSpy).not.toHaveBeenCalled();
+      expect(locationService.push).toHaveBeenCalledTimes(1);
+      expect(locationService.push).toHaveBeenCalledWith(expect.stringContaining('/alerting/new'));
     });
 
     it('should render "New alert rule" menu item when user has permissions to read and update alerts', async () => {

--- a/public/app/features/dashboard-scene/scene/PanelMenuBehavior.test.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelMenuBehavior.test.tsx
@@ -1,4 +1,5 @@
 import { of } from 'rxjs';
+import { testWithFeatureToggles } from 'test/test-utils';
 
 import {
   FieldType,
@@ -785,116 +786,117 @@ describe('panelMenuBehavior', () => {
     beforeEach(() => {
       jest.spyOn(storeModule, 'dispatch').mockImplementation(() => {});
       jest.spyOn(locationService, 'push').mockImplementation(() => {});
-      config.featureToggles.createAlertRuleFromPanel = true;
     });
 
-    afterEach(() => {
-      config.featureToggles.createAlertRuleFromPanel = false;
+    describe('when createAlertRuleFromPanel is enabled', () => {
+      testWithFeatureToggles({ enable: ['createAlertRuleFromPanel'] });
+
+      it('should open the new alert rule drawer with prefilled values on success', async () => {
+        const { menu, panel, scene } = await buildTestScene({});
+        const mockFormValues = { someKey: 'someValue' };
+
+        config.unifiedAlertingEnabled = true;
+        grantUserPermissions([AccessControlAction.AlertingRuleRead, AccessControlAction.AlertingRuleUpdate]);
+
+        jest
+          .spyOn(require('app/features/alerting/unified/utils/rule-form'), 'scenesPanelToRuleFormValues')
+          .mockResolvedValue(mockFormValues);
+        const showModalSpy = jest.spyOn(scene, 'showModal');
+
+        menu.activate();
+        await new Promise((r) => setTimeout(r, 1));
+
+        const moreMenu = menu.state.items?.find((i) => i.text === 'More...')?.subMenu;
+        const alertMenuItem = moreMenu?.find((i) => i.text === 'New alert rule')?.onClick;
+        expect(alertMenuItem).toBeDefined();
+
+        await alertMenuItem?.({} as React.MouseEvent);
+        await new Promise((r) => setTimeout(r, 0));
+
+        expect(scenesPanelToRuleFormValues).toHaveBeenCalledWith(panel);
+        expect(locationService.push).not.toHaveBeenCalled();
+        expect(showModalSpy).toHaveBeenCalledTimes(1);
+        const drawer = showModalSpy.mock.calls[0][0];
+        expect(drawer).toBeInstanceOf(NewAlertRuleDrawer);
+        expect((drawer as NewAlertRuleDrawer).state.prefill).toEqual(mockFormValues);
+      });
+
+      it('should show error notification and not open the drawer when no alerting-capable query is found', async () => {
+        const { menu, scene } = await buildTestScene({});
+
+        config.unifiedAlertingEnabled = true;
+        grantUserPermissions([AccessControlAction.AlertingRuleRead, AccessControlAction.AlertingRuleUpdate]);
+
+        jest
+          .spyOn(require('app/features/alerting/unified/utils/rule-form'), 'scenesPanelToRuleFormValues')
+          .mockResolvedValue(undefined);
+        const showModalSpy = jest.spyOn(scene, 'showModal');
+
+        menu.activate();
+        await new Promise((r) => setTimeout(r, 1));
+
+        const moreMenu = menu.state.items?.find((i) => i.text === 'More...')?.subMenu;
+        const alertMenuItem = moreMenu?.find((i) => i.text === 'New alert rule')?.onClick;
+
+        await alertMenuItem?.({} as React.MouseEvent);
+        await new Promise((r) => setTimeout(r, 0));
+
+        expect(showModalSpy).not.toHaveBeenCalled();
+        expect(storeModule.dispatch).toHaveBeenCalled();
+      });
+
+      it('should show error notification and not open the drawer on failure', async () => {
+        const { menu, panel, scene } = await buildTestScene({});
+        const mockError = new Error('Test error');
+        jest
+          .spyOn(require('app/features/alerting/unified/utils/rule-form'), 'scenesPanelToRuleFormValues')
+          .mockRejectedValue(mockError);
+        const showModalSpy = jest.spyOn(scene, 'showModal');
+
+        menu.activate();
+        await new Promise((r) => setTimeout(r, 1));
+
+        const moreMenu = menu.state.items?.find((i) => i.text === 'More...')?.subMenu;
+        const alertMenuItem = moreMenu?.find((i) => i.text === 'New alert rule')?.onClick;
+        expect(alertMenuItem).toBeDefined();
+
+        await alertMenuItem?.({} as React.MouseEvent);
+
+        await new Promise((r) => setTimeout(r, 0));
+
+        expect(scenesPanelToRuleFormValues).toHaveBeenCalledWith(panel);
+        expect(showModalSpy).not.toHaveBeenCalled();
+      });
     });
 
-    it('should open the new alert rule drawer with prefilled values on success', async () => {
-      const { menu, panel, scene } = await buildTestScene({});
-      const mockFormValues = { someKey: 'someValue' };
+    describe('when createAlertRuleFromPanel is disabled', () => {
+      testWithFeatureToggles({ disable: ['createAlertRuleFromPanel'] });
 
-      config.unifiedAlertingEnabled = true;
-      grantUserPermissions([AccessControlAction.AlertingRuleRead, AccessControlAction.AlertingRuleUpdate]);
+      it('should navigate to /alerting/new and not open the drawer', async () => {
+        const { menu, scene } = await buildTestScene({});
+        const mockFormValues = { someKey: 'someValue' };
 
-      jest
-        .spyOn(require('app/features/alerting/unified/utils/rule-form'), 'scenesPanelToRuleFormValues')
-        .mockResolvedValue(mockFormValues);
-      const showModalSpy = jest.spyOn(scene, 'showModal');
+        config.unifiedAlertingEnabled = true;
+        grantUserPermissions([AccessControlAction.AlertingRuleRead, AccessControlAction.AlertingRuleUpdate]);
 
-      menu.activate();
-      await new Promise((r) => setTimeout(r, 1));
+        jest
+          .spyOn(require('app/features/alerting/unified/utils/rule-form'), 'scenesPanelToRuleFormValues')
+          .mockResolvedValue(mockFormValues);
+        const showModalSpy = jest.spyOn(scene, 'showModal');
 
-      const moreMenu = menu.state.items?.find((i) => i.text === 'More...')?.subMenu;
-      const alertMenuItem = moreMenu?.find((i) => i.text === 'New alert rule')?.onClick;
-      expect(alertMenuItem).toBeDefined();
+        menu.activate();
+        await new Promise((r) => setTimeout(r, 1));
 
-      await alertMenuItem?.({} as React.MouseEvent);
-      await new Promise((r) => setTimeout(r, 0));
+        const moreMenu = menu.state.items?.find((i) => i.text === 'More...')?.subMenu;
+        const alertMenuItem = moreMenu?.find((i) => i.text === 'New alert rule')?.onClick;
 
-      expect(scenesPanelToRuleFormValues).toHaveBeenCalledWith(panel);
-      expect(locationService.push).not.toHaveBeenCalled();
-      expect(showModalSpy).toHaveBeenCalledTimes(1);
-      const drawer = showModalSpy.mock.calls[0][0];
-      expect(drawer).toBeInstanceOf(NewAlertRuleDrawer);
-      expect((drawer as NewAlertRuleDrawer).state.prefill).toEqual(mockFormValues);
-    });
+        await alertMenuItem?.({} as React.MouseEvent);
+        await new Promise((r) => setTimeout(r, 0));
 
-    it('should show error notification and not open the drawer when no alerting-capable query is found', async () => {
-      const { menu, scene } = await buildTestScene({});
-
-      config.unifiedAlertingEnabled = true;
-      grantUserPermissions([AccessControlAction.AlertingRuleRead, AccessControlAction.AlertingRuleUpdate]);
-
-      jest
-        .spyOn(require('app/features/alerting/unified/utils/rule-form'), 'scenesPanelToRuleFormValues')
-        .mockResolvedValue(undefined);
-      const showModalSpy = jest.spyOn(scene, 'showModal');
-
-      menu.activate();
-      await new Promise((r) => setTimeout(r, 1));
-
-      const moreMenu = menu.state.items?.find((i) => i.text === 'More...')?.subMenu;
-      const alertMenuItem = moreMenu?.find((i) => i.text === 'New alert rule')?.onClick;
-
-      await alertMenuItem?.({} as React.MouseEvent);
-      await new Promise((r) => setTimeout(r, 0));
-
-      expect(showModalSpy).not.toHaveBeenCalled();
-      expect(storeModule.dispatch).toHaveBeenCalled();
-    });
-
-    it('should show error notification and not open the drawer on failure', async () => {
-      const { menu, panel, scene } = await buildTestScene({});
-      const mockError = new Error('Test error');
-      jest
-        .spyOn(require('app/features/alerting/unified/utils/rule-form'), 'scenesPanelToRuleFormValues')
-        .mockRejectedValue(mockError);
-      const showModalSpy = jest.spyOn(scene, 'showModal');
-
-      menu.activate();
-      await new Promise((r) => setTimeout(r, 1));
-
-      const moreMenu = menu.state.items?.find((i) => i.text === 'More...')?.subMenu;
-      const alertMenuItem = moreMenu?.find((i) => i.text === 'New alert rule')?.onClick;
-      expect(alertMenuItem).toBeDefined();
-
-      await alertMenuItem?.({} as React.MouseEvent);
-
-      await new Promise((r) => setTimeout(r, 0));
-
-      expect(scenesPanelToRuleFormValues).toHaveBeenCalledWith(panel);
-      expect(showModalSpy).not.toHaveBeenCalled();
-    });
-
-    it('should navigate to /alerting/new and not open the drawer when createAlertRuleFromPanel is disabled', async () => {
-      config.featureToggles.createAlertRuleFromPanel = false;
-
-      const { menu, scene } = await buildTestScene({});
-      const mockFormValues = { someKey: 'someValue' };
-
-      config.unifiedAlertingEnabled = true;
-      grantUserPermissions([AccessControlAction.AlertingRuleRead, AccessControlAction.AlertingRuleUpdate]);
-
-      jest
-        .spyOn(require('app/features/alerting/unified/utils/rule-form'), 'scenesPanelToRuleFormValues')
-        .mockResolvedValue(mockFormValues);
-      const showModalSpy = jest.spyOn(scene, 'showModal');
-
-      menu.activate();
-      await new Promise((r) => setTimeout(r, 1));
-
-      const moreMenu = menu.state.items?.find((i) => i.text === 'More...')?.subMenu;
-      const alertMenuItem = moreMenu?.find((i) => i.text === 'New alert rule')?.onClick;
-
-      await alertMenuItem?.({} as React.MouseEvent);
-      await new Promise((r) => setTimeout(r, 0));
-
-      expect(showModalSpy).not.toHaveBeenCalled();
-      expect(locationService.push).toHaveBeenCalledTimes(1);
-      expect(locationService.push).toHaveBeenCalledWith(expect.stringContaining('/alerting/new'));
+        expect(showModalSpy).not.toHaveBeenCalled();
+        expect(locationService.push).toHaveBeenCalledTimes(1);
+        expect(locationService.push).toHaveBeenCalledWith(expect.stringContaining('/alerting/new'));
+      });
     });
 
     it('should render "New alert rule" menu item when user has permissions to read and update alerts', async () => {

--- a/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
@@ -239,7 +239,7 @@ export function panelMenuBehavior(menu: VizPanelMenu) {
       moreSubMenu.push({
         text: t('panel.header-menu.new-alert-rule', `New alert rule`),
         iconClassName: 'bell',
-        onClick: (e) => onCreateAlert(panel, dashboard),
+        onClick: () => onCreateAlert(panel, dashboard),
       });
     }
 
@@ -554,10 +554,31 @@ const onCreateAlert = async (panel: VizPanel, dashboard: DashboardScene) => {
     return;
   }
 
+  // The drawer is intentionally narrower than the full rule editor and has no datasource picker,
+  // so a blank drawer would leave the user with no way to recover. Surface the same info as the
+  // edit-panel button's inline Alert and skip opening the drawer.
+  if (!formValues) {
+    dispatch(
+      notifyApp(
+        createErrorNotification(
+          t(
+            'alerting.new-rule-from-panel-button.title-no-alerting-capable-query-found',
+            'No alerting capable query found'
+          ),
+          t(
+            'alerting.new-rule-from-panel-button.body-no-alerting-capable-query-found',
+            'Cannot create alerts from this panel because no query to an alerting capable datasource is found.'
+          )
+        )
+      )
+    );
+    return;
+  }
+
   logInfo(LogMessages.alertRuleFromPanel);
   trackCreateRuleFromPanelDrawerOpened();
 
-  dashboard.showModal(new NewAlertRuleDrawer({ panelRef: panel.getRef(), prefill: formValues }));
+  dashboard.showModal(new NewAlertRuleDrawer({ prefill: formValues }));
 };
 
 export function toggleVizPanelLegend(vizPanel: VizPanel): void {

--- a/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
@@ -9,6 +9,7 @@ import {
   type PanelPlugin,
   type PluginExtensionPanelContext,
   PluginExtensionPoints,
+  urlUtil,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, getObservablePluginLinks, locationService } from '@grafana/runtime';
@@ -551,6 +552,18 @@ const onCreateAlert = async (panel: VizPanel, dashboard: DashboardScene) => {
   } catch (err) {
     const message = `Error getting rule values from the panel: ${getMessageFromError(err)}`;
     dispatch(notifyApp(createErrorNotification(message)));
+    return;
+  }
+
+  // When the drawer flow is disabled, fall back to the legacy full-page rule editor.
+  // This preserves the historical behaviour of navigating with whatever defaults are available
+  // (including undefined, which simply lands the user in a blank form).
+  if (!config.featureToggles.createAlertRuleFromPanel) {
+    const ruleFormUrl = urlUtil.renderUrl('/alerting/new', {
+      defaults: JSON.stringify(formValues),
+      returnTo: window.location.pathname + window.location.search,
+    });
+    locationService.push(ruleFormUrl);
     return;
   }
 

--- a/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
+++ b/public/app/features/dashboard-scene/scene/PanelMenuBehavior.tsx
@@ -9,7 +9,6 @@ import {
   type PanelPlugin,
   type PluginExtensionPanelContext,
   PluginExtensionPoints,
-  urlUtil,
 } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { config, getObservablePluginLinks, locationService } from '@grafana/runtime';
@@ -20,6 +19,8 @@ import { createErrorNotification } from 'app/core/copy/appNotification';
 import { notifyApp } from 'app/core/reducers/appNotification';
 import { contextSrv } from 'app/core/services/context_srv';
 import { getMessageFromError } from 'app/core/utils/errors';
+import { LogMessages, logInfo, trackCreateRuleFromPanelDrawerOpened } from 'app/features/alerting/unified/Analytics';
+import { type RuleFormValues } from 'app/features/alerting/unified/types/rule-form';
 import { getCreateAlertInMenuAvailability } from 'app/features/alerting/unified/utils/access-control';
 import { scenesPanelToRuleFormValues } from 'app/features/alerting/unified/utils/rule-form';
 import { getTrackingSource, shareDashboardType } from 'app/features/dashboard/components/ShareModal/utils';
@@ -39,6 +40,7 @@ import { getEditPanelUrl, tryGetExploreUrlForPanel } from '../utils/urlBuilders'
 import { getDashboardSceneFor, getPanelIdForVizPanel, getQueryRunnerFor, isLibraryPanel } from '../utils/utils';
 
 import { DashboardScene } from './DashboardScene';
+import { NewAlertRuleDrawer } from './NewAlertRuleDrawer';
 import { VizPanelLinks, type VizPanelLinksMenu } from './PanelLinks';
 import { UnlinkLibraryPanelModal } from './UnlinkLibraryPanelModal';
 import { PanelTimeRangeDrawer } from './panel-timerange/PanelTimeRangeDrawer';
@@ -237,7 +239,7 @@ export function panelMenuBehavior(menu: VizPanelMenu) {
       moreSubMenu.push({
         text: t('panel.header-menu.new-alert-rule', `New alert rule`),
         iconClassName: 'bell',
-        onClick: (e) => onCreateAlert(panel),
+        onClick: (e) => onCreateAlert(panel, dashboard),
       });
     }
 
@@ -542,19 +544,20 @@ export function onRemovePanel(dashboard: DashboardScene, panel: VizPanel) {
   );
 }
 
-const onCreateAlert = async (panel: VizPanel) => {
+const onCreateAlert = async (panel: VizPanel, dashboard: DashboardScene) => {
+  let formValues: Partial<RuleFormValues> | undefined;
   try {
-    const formValues = await scenesPanelToRuleFormValues(panel);
-    const ruleFormUrl = urlUtil.renderUrl('/alerting/new', {
-      defaults: JSON.stringify(formValues),
-      returnTo: window.location.pathname + window.location.search,
-    });
-    locationService.push(ruleFormUrl);
+    formValues = await scenesPanelToRuleFormValues(panel);
   } catch (err) {
     const message = `Error getting rule values from the panel: ${getMessageFromError(err)}`;
     dispatch(notifyApp(createErrorNotification(message)));
     return;
   }
+
+  logInfo(LogMessages.alertRuleFromPanel);
+  trackCreateRuleFromPanelDrawerOpened();
+
+  dashboard.showModal(new NewAlertRuleDrawer({ panelRef: panel.getRef(), prefill: formValues }));
 };
 
 export function toggleVizPanelLegend(vizPanel: VizPanel): void {

--- a/public/app/features/dashboard/utils/getPanelMenu.ts
+++ b/public/app/features/dashboard/utils/getPanelMenu.ts
@@ -1,6 +1,6 @@
-import { type PanelMenuItem, type PluginExtensionLink } from '@grafana/data';
+import { type PanelMenuItem, type PluginExtensionLink, urlUtil } from '@grafana/data';
 import { t } from '@grafana/i18n';
-import { locationService } from '@grafana/runtime';
+import { config, locationService } from '@grafana/runtime';
 import { appEvents } from 'app/core/app_events';
 import { createErrorNotification } from 'app/core/copy/appNotification';
 import { notifyApp } from 'app/core/reducers/appNotification';
@@ -184,6 +184,18 @@ export function getPanelMenu(
     } catch (err) {
       const message = `Error getting rule values from the panel: ${getMessageFromError(err)}`;
       dispatch(notifyApp(createErrorNotification(message)));
+      return;
+    }
+
+    // When the drawer flow is disabled, fall back to the legacy full-page rule editor.
+    // This preserves the historical behaviour of navigating with whatever defaults are available
+    // (including undefined, which simply lands the user in a blank form).
+    if (!config.featureToggles.createAlertRuleFromPanel) {
+      const ruleFormUrl = urlUtil.renderUrl('/alerting/new', {
+        defaults: JSON.stringify(formValues),
+        returnTo: window.location.pathname + window.location.search,
+      });
+      locationService.push(ruleFormUrl);
       return;
     }
 

--- a/public/app/features/dashboard/utils/getPanelMenu.ts
+++ b/public/app/features/dashboard/utils/getPanelMenu.ts
@@ -1,11 +1,14 @@
-import { type PanelMenuItem, urlUtil, type PluginExtensionLink } from '@grafana/data';
+import { type PanelMenuItem, type PluginExtensionLink } from '@grafana/data';
 import { t } from '@grafana/i18n';
 import { locationService } from '@grafana/runtime';
+import { appEvents } from 'app/core/app_events';
 import { createErrorNotification } from 'app/core/copy/appNotification';
 import { notifyApp } from 'app/core/reducers/appNotification';
 import { contextSrv } from 'app/core/services/context_srv';
 import { getMessageFromError } from 'app/core/utils/errors';
 import { getExploreUrl } from 'app/core/utils/explore';
+import { LogMessages, logInfo, trackCreateRuleFromPanelDrawerOpened } from 'app/features/alerting/unified/Analytics';
+import { PanelAlertRuleDrawer } from 'app/features/alerting/unified/components/PanelAlertRuleDrawer';
 import { type RuleFormValues } from 'app/features/alerting/unified/types/rule-form';
 import { panelToRuleFormValues } from 'app/features/alerting/unified/utils/rule-form';
 import { type DashboardModel } from 'app/features/dashboard/state/DashboardModel';
@@ -23,6 +26,7 @@ import { InspectTab } from 'app/features/inspector/types';
 import { isPanelModelLibraryPanel } from 'app/features/library-panels/guard';
 import { SHARED_DASHBOARD_QUERY } from 'app/plugins/datasource/dashboard/constants';
 import { dispatch } from 'app/store/store';
+import { ShowModalReactEvent } from 'app/types/events';
 
 import { getCreateAlertInMenuAvailability } from '../../alerting/unified/utils/access-control';
 import { navigateToExplore } from '../../explore/state/main';
@@ -182,12 +186,16 @@ export function getPanelMenu(
       dispatch(notifyApp(createErrorNotification(message)));
       return;
     }
-    const ruleFormUrl = urlUtil.renderUrl('/alerting/new', {
-      defaults: JSON.stringify(formValues),
-      returnTo: window.location.pathname + window.location.search,
-    });
 
-    locationService.push(ruleFormUrl);
+    logInfo(LogMessages.alertRuleFromPanel);
+    trackCreateRuleFromPanelDrawerOpened();
+
+    appEvents.publish(
+      new ShowModalReactEvent({
+        component: PanelAlertRuleDrawer,
+        props: { prefill: formValues },
+      })
+    );
   };
 
   const onCreateAlert = (event: React.MouseEvent) => {

--- a/public/app/features/dashboard/utils/getPanelMenu.ts
+++ b/public/app/features/dashboard/utils/getPanelMenu.ts
@@ -187,6 +187,27 @@ export function getPanelMenu(
       return;
     }
 
+    // The drawer is intentionally narrower than the full rule editor and has no datasource picker,
+    // so a blank drawer would leave the user with no way to recover. Surface the same info as the
+    // edit-panel button's inline Alert and skip opening the drawer.
+    if (!formValues) {
+      dispatch(
+        notifyApp(
+          createErrorNotification(
+            t(
+              'alerting.new-rule-from-panel-button.title-no-alerting-capable-query-found',
+              'No alerting capable query found'
+            ),
+            t(
+              'alerting.new-rule-from-panel-button.body-no-alerting-capable-query-found',
+              'Cannot create alerts from this panel because no query to an alerting capable datasource is found.'
+            )
+          )
+        )
+      );
+      return;
+    }
+
     logInfo(LogMessages.alertRuleFromPanel);
     trackCreateRuleFromPanelDrawerOpened();
 


### PR DESCRIPTION
## What is this feature?

Updates the **New alert rule** action in the dashboard panel menu (More submenu) to open the new alert rule drawer instead of navigating to the full `/alerting/new` page. This matches the existing behaviour of the same action from the edit-panel page, so both entry points are consistent.

https://github.com/user-attachments/assets/1e09fd9f-d7f5-4e20-8951-4b439d3dac5c

The change applies to:

- The scenes dashboard panel menu (`PanelMenuBehavior.tsx`)
- The legacy panel menu (`getPanelMenu.ts`)

## Why do we need this feature?

Today, clicking **More → New alert rule** from a dashboard panel takes the user away from the dashboard to a separate page, while the **New alert rule** button on the edit-panel page opens an inline drawer. This is inconsistent and makes the menu action feel heavier than it needs to be. Keeping the user on the dashboard with a drawer is faster and matches the experience we already ship for the edit-panel button. The drawer's **Continue in Alerting** button still provides a path to the full editor for users who want it.

## Who is this feature for?

Anyone creating alert rules from a dashboard panel.

## Special notes for your reviewer

- Introduces a shared React wrapper `PanelAlertRuleDrawer` so both the scenes and legacy menu paths render the same `AlertRuleDrawerForm` with the same `createPanelAlertRuleNavigation` wiring for the **Continue in Alerting** button.
- The scenes path uses a new `NewAlertRuleDrawer` SceneObject (passed to `dashboard.showModal(...)`); the legacy path mounts the wrapper directly via `ShowModalReactEvent`.
- **No alerting-capable query** (`scenesPanelToRuleFormValues` / `panelToRuleFormValues` returns `undefined`, e.g. text panels): shows an error notification with the same title/body as the edit-panel button's inline Alert, and **does not** open the drawer. The drawer is intentionally narrower than the full editor and has no datasource picker, so a blank drawer would leave the user with no recovery path.
- **Thrown errors** while resolving form values: still dispatch an error notification toast and do not open the drawer.
- Adds the same analytics (`LogMessages.alertRuleFromPanel`, `trackCreateRuleFromPanelDrawerOpened`) that the edit-panel drawer button already emits.
- **Not** gated behind `createAlertRuleFromPanel` 