### PR TITLE
[release-13.0.2] Unified Storage: Pass commit message when routing managed-resource writes

### DIFF
--- a/pkg/storage/unified/apistore/managed.go
+++ b/pkg/storage/unified/apistore/managed.go
@@ -145,6 +145,25 @@ func enforceManagerProperties(auth authtypes.AuthInfo, obj utils.GrafanaMetaAcce
 	return nil
 }
 
+// managedResourceCommitMessage returns the git commit message to use when
+// forwarding a managed-resource write to the provisioning files endpoint. It
+// prefers the caller-supplied grafana.app/message annotation and falls back to
+// an action-specific message so the downstream nanogit commit always has a
+// non-empty subject.
+func managedResourceCommitMessage(obj utils.GrafanaMetaAccessor, action resourcepb.WatchEvent_Type) string {
+	if msg := obj.GetMessage(); msg != "" {
+		return msg
+	}
+	switch action {
+	case resourcepb.WatchEvent_ADDED:
+		return fmt.Sprintf("Create %s", obj.GetName())
+	case resourcepb.WatchEvent_DELETED:
+		return fmt.Sprintf("Delete %s", obj.GetName())
+	default:
+		return fmt.Sprintf("Update %s", obj.GetName())
+	}
+}
+
 func (s *Storage) handleManagedResourceRouting(ctx context.Context,
 	err error,
 	action resourcepb.WatchEvent_Type,
@@ -197,6 +216,7 @@ func (s *Storage) handleManagedResourceRouting(ctx context.Context,
 			Resource("repositories").
 			Name(repo.Identity).
 			Suffix("files", src.Path).
+			Param("message", managedResourceCommitMessage(obj, action)).
 			Do(ctx)
 		return result.Error()
 	}
@@ -211,13 +231,18 @@ func (s *Storage) handleManagedResourceRouting(ctx context.Context,
 		return fmt.Errorf("unsupported provisioning action: %v, %w", action, err)
 	}
 
-	// Execute the change
+	// Execute the change. The provisioning files endpoint reads the commit
+	// message from the `message` query parameter only — it does not inspect
+	// the body's grafana.app/message annotation. Forward the annotation here
+	// (with a sensible fallback) so writes through this fallback path produce
+	// a non-empty git commit message.
 	result := req.Namespace(obj.GetNamespace()).
 		Resource("repositories").
 		Name(repo.Identity).
 		Suffix("files", src.Path).
 		Body(orig).
 		Param("skipDryRun", "true").
+		Param("message", managedResourceCommitMessage(obj, action)).
 		Do(ctx)
 	err = result.Error()
 	if err != nil {

--- a/pkg/storage/unified/apistore/managed_test.go
+++ b/pkg/storage/unified/apistore/managed_test.go
@@ -2,6 +2,9 @@ package apistore
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/go-jose/go-jose/v4/jwt"
@@ -9,6 +12,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	clientrest "k8s.io/client-go/rest"
 
 	authnlib "github.com/grafana/authlib/authn"
 	authtypes "github.com/grafana/authlib/types"
@@ -18,6 +22,7 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	serviceauthn "github.com/grafana/grafana/pkg/services/authn"
+	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
 )
 
 func TestManagedAuthorizer(t *testing.T) {
@@ -303,6 +308,189 @@ func TestManagedAuthorizer(t *testing.T) {
 			} else {
 				require.NoError(t, err)
 			}
+		})
+	}
+}
+
+func TestManagedResourceCommitMessage(t *testing.T) {
+	tests := []struct {
+		name        string
+		objectName  string
+		annotations map[string]string
+		action      resourcepb.WatchEvent_Type
+		want        string
+	}{
+		{
+			name:       "uses grafana.app/message annotation when set (MODIFIED)",
+			objectName: "dash-uid",
+			annotations: map[string]string{
+				utils.AnnoKeyMessage: "Custom commit message",
+			},
+			action: resourcepb.WatchEvent_MODIFIED,
+			want:   "Custom commit message",
+		},
+		{
+			name:       "annotation wins over action-specific fallback (DELETED)",
+			objectName: "dash-uid",
+			annotations: map[string]string{
+				utils.AnnoKeyMessage: "Custom delete message",
+			},
+			action: resourcepb.WatchEvent_DELETED,
+			want:   "Custom delete message",
+		},
+		{
+			name:        "MODIFIED falls back to 'Update <name>' when annotation is absent",
+			objectName:  "dash-uid",
+			annotations: nil,
+			action:      resourcepb.WatchEvent_MODIFIED,
+			want:        "Update dash-uid",
+		},
+		{
+			name:        "ADDED falls back to 'Create <name>' when annotation is absent",
+			objectName:  "dash-uid",
+			annotations: nil,
+			action:      resourcepb.WatchEvent_ADDED,
+			want:        "Create dash-uid",
+		},
+		{
+			name:        "DELETED falls back to 'Delete <name>' when annotation is absent",
+			objectName:  "dash-uid",
+			annotations: nil,
+			action:      resourcepb.WatchEvent_DELETED,
+			want:        "Delete dash-uid",
+		},
+		{
+			name:       "MODIFIED falls back to 'Update <name>' when annotation is an empty string",
+			objectName: "dash-uid",
+			annotations: map[string]string{
+				utils.AnnoKeyMessage: "",
+			},
+			action: resourcepb.WatchEvent_MODIFIED,
+			want:   "Update dash-uid",
+		},
+		{
+			name:       "preserves whitespace-only annotation verbatim",
+			objectName: "dash-uid",
+			annotations: map[string]string{
+				utils.AnnoKeyMessage: "   ",
+			},
+			action: resourcepb.WatchEvent_MODIFIED,
+			want:   "   ",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obj := &dashboard.Dashboard{
+				ObjectMeta: v1.ObjectMeta{
+					Name:        tt.objectName,
+					Annotations: tt.annotations,
+				},
+			}
+			accessor, err := utils.MetaAccessor(obj)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, managedResourceCommitMessage(accessor, tt.action))
+		})
+	}
+}
+
+// fakeRestConfigProvider returns a rest.Config pointing at an arbitrary host,
+// used so tests can capture proxied REST requests with an httptest.Server.
+type fakeRestConfigProvider struct {
+	host string
+}
+
+func (f *fakeRestConfigProvider) GetRestConfig(_ context.Context) (*clientrest.Config, error) {
+	return &clientrest.Config{Host: f.host}, nil
+}
+
+func TestHandleManagedResourceRouting_ForwardsCommitMessage(t *testing.T) {
+	tests := []struct {
+		name        string
+		action      resourcepb.WatchEvent_Type
+		annotations map[string]string
+		wantMethod  string
+		wantMessage string
+	}{
+		{
+			name:   "MODIFIED uses grafana.app/message annotation",
+			action: resourcepb.WatchEvent_MODIFIED,
+			annotations: map[string]string{
+				utils.AnnoKeyManagerKind:     string(utils.ManagerKindRepo),
+				utils.AnnoKeyManagerIdentity: "my-repo",
+				utils.AnnoKeySourcePath:      "dashboards/dash.json",
+				utils.AnnoKeyMessage:         "Custom commit message",
+			},
+			wantMethod:  http.MethodPut,
+			wantMessage: "Custom commit message",
+		},
+		{
+			name:   "MODIFIED falls back to 'Update <name>' when annotation is absent",
+			action: resourcepb.WatchEvent_MODIFIED,
+			annotations: map[string]string{
+				utils.AnnoKeyManagerKind:     string(utils.ManagerKindRepo),
+				utils.AnnoKeyManagerIdentity: "my-repo",
+				utils.AnnoKeySourcePath:      "dashboards/dash.json",
+			},
+			wantMethod:  http.MethodPut,
+			wantMessage: "Update dash-uid",
+		},
+		{
+			name:   "ADDED also forwards the commit message",
+			action: resourcepb.WatchEvent_ADDED,
+			annotations: map[string]string{
+				utils.AnnoKeyManagerKind:     string(utils.ManagerKindRepo),
+				utils.AnnoKeyManagerIdentity: "my-repo",
+				utils.AnnoKeySourcePath:      "dashboards/dash.json",
+				utils.AnnoKeyMessage:         "Create dash.json",
+			},
+			wantMethod:  http.MethodPost,
+			wantMessage: "Create dash.json",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var captured struct {
+				method string
+				path   string
+				query  url.Values
+			}
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				captured.method = r.Method
+				captured.path = r.URL.Path
+				captured.query = r.URL.Query()
+				// Return a 5xx so the caller short-circuits before reaching
+				// the post-write s.Get call (which would need a full store).
+				http.Error(w, "intentional test failure", http.StatusInternalServerError)
+			}))
+			t.Cleanup(server.Close)
+
+			s := &Storage{configProvider: &fakeRestConfigProvider{host: server.URL}}
+			obj := &dashboard.Dashboard{
+				ObjectMeta: v1.ObjectMeta{
+					Name:        "dash-uid",
+					Namespace:   "default",
+					Annotations: tt.annotations,
+				},
+			}
+
+			err := s.handleManagedResourceRouting(
+				context.Background(),
+				errResourceIsManagedInRepository,
+				tt.action,
+				"/default/dashboards/dash-uid",
+				obj,
+				&dashboard.Dashboard{},
+			)
+			// The test server returns 500; surface that as a non-nil error.
+			require.Error(t, err)
+
+			require.Equal(t, tt.wantMethod, captured.method, "HTTP method")
+			require.Contains(t, captured.path, "/namespaces/default/repositories/my-repo/files/dashboards/dash.json",
+				"request path should target the provisioning files endpoint")
+			require.Equal(t, tt.wantMessage, captured.query.Get("message"), "message query parameter")
+			require.Equal(t, "true", captured.query.Get("skipDryRun"), "skipDryRun query parameter should be forwarded")
 		})
 	}
 }

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -40,6 +40,7 @@ import (
 	folder "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
 	provisioning "github.com/grafana/grafana/apps/provisioning/pkg/apis/provisioning/v0alpha1"
 	githubConnection "github.com/grafana/grafana/apps/provisioning/pkg/connection/github"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/infra/db"
 	"github.com/grafana/grafana/pkg/registry/apis/provisioning/jobs"
@@ -1790,6 +1791,24 @@ func RequireDashboardCount(t *testing.T, dashboardClient *apis.K8sResourceClient
 	}, WaitTimeoutDefault, WaitIntervalDefault, "expected %d dashboard(s)", expected)
 }
 
+// RequireRepoManagedDashboard waits until the dashboard with the given uid is
+// available in unified storage and is annotated as managed by the named repo
+// at the given source path. Polls until the assertions hold or the default
+// wait timeout elapses.
+func RequireRepoManagedDashboard(t *testing.T, dashboardClient *apis.K8sResourceClient, ctx context.Context, uid, repoName, sourcePath string) {
+	t.Helper()
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		dash, err := dashboardClient.Resource.Get(ctx, uid, metav1.GetOptions{})
+		if !assert.NoError(c, err) {
+			return
+		}
+		annotations := dash.GetAnnotations()
+		assert.Equal(c, string(utils.ManagerKindRepo), annotations[utils.AnnoKeyManagerKind])
+		assert.Equal(c, repoName, annotations[utils.AnnoKeyManagerIdentity])
+		assert.Equal(c, sourcePath, annotations[utils.AnnoKeySourcePath])
+	}, WaitTimeoutDefault, WaitIntervalDefault, "dashboard %q should be managed by repo %q at %q", uid, repoName, sourcePath)
+}
+
 // RequireDashboardTitle asserts that the dashboard with the given uid (K8s name)
 // has the expected title.
 func RequireDashboardTitle(t *testing.T, dashboardClient *apis.K8sResourceClient, ctx context.Context, uid, expectedTitle string) {
@@ -2187,6 +2206,37 @@ func DashboardJSON(uid, title string, version int) []byte {
 	return data
 }
 
+// NewManagedDashboard builds an unstructured Dashboard with the manager
+// annotations required to route a Dashboard API write through the
+// provisioning files endpoint (handleManagedResourceRouting). If message is
+// empty, the grafana.app/message annotation is omitted so callers can
+// exercise the action-specific fallback ("Create <name>" / "Update <name>"
+// / "Delete <name>").
+func NewManagedDashboard(apiVersion, name, repoName, sourcePath, message string) *unstructured.Unstructured {
+	annotations := map[string]interface{}{
+		utils.AnnoKeyManagerKind:     string(utils.ManagerKindRepo),
+		utils.AnnoKeyManagerIdentity: repoName,
+		utils.AnnoKeySourcePath:      sourcePath,
+	}
+	if message != "" {
+		annotations[utils.AnnoKeyMessage] = message
+	}
+	return &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": apiVersion,
+			"kind":       "Dashboard",
+			"metadata": map[string]interface{}{
+				"name":        name,
+				"annotations": annotations,
+			},
+			"spec": map[string]interface{}{
+				"title":         name,
+				"schemaVersion": 41,
+			},
+		},
+	}
+}
+
 type exportRepoInfo struct {
 	user   *gittest.User
 	remote *gittest.RemoteRepository
@@ -2337,17 +2387,27 @@ func (h *GitTestHelper) CleanupAllResources(t *testing.T, ctx context.Context) {
 // CreateGitRepo creates a git repository with sync target "instance" and registers
 // it with Grafana provisioning. workflows is optional; defaults to ["write"].
 func (h *GitTestHelper) CreateGitRepo(t *testing.T, repoName string, initialFiles map[string][]byte, workflows ...string) (*gittest.RemoteRepository, *gittest.LocalRepo) {
-	return h.createGitRepo(t, repoName, "instance", initialFiles, workflows...)
+	return h.createGitRepo(t, repoName, "instance", false, initialFiles, workflows...)
 }
 
 // CreateFolderTargetGitRepo creates a git repository with sync target "folder" and
 // registers it with Grafana provisioning. Unlike "instance" repos, multiple "folder"
 // repos can coexist on the same Grafana server. workflows is optional; defaults to ["write"].
 func (h *GitTestHelper) CreateFolderTargetGitRepo(t *testing.T, repoName string, initialFiles map[string][]byte, workflows ...string) (*gittest.RemoteRepository, *gittest.LocalRepo) {
-	return h.createGitRepo(t, repoName, "folder", initialFiles, workflows...)
+	return h.createGitRepo(t, repoName, "folder", false, initialFiles, workflows...)
 }
 
-func (h *GitTestHelper) createGitRepo(t *testing.T, repoName string, syncTarget string, initialFiles map[string][]byte, workflows ...string) (*gittest.RemoteRepository, *gittest.LocalRepo) {
+// CreateSyncEnabledGitRepo creates a git repository with sync target "instance"
+// and sync.enabled=true. Sync must be on for the provisioning files endpoint to
+// dual-write into unified storage — without it, callers that write a new
+// repo-managed resource via the Dashboard API would fail at the post-write Get
+// inside handleManagedResourceRouting with KeyNotFound.
+// workflows is optional; defaults to ["write"].
+func (h *GitTestHelper) CreateSyncEnabledGitRepo(t *testing.T, repoName string, initialFiles map[string][]byte, workflows ...string) (*gittest.RemoteRepository, *gittest.LocalRepo) {
+	return h.createGitRepo(t, repoName, "instance", true, initialFiles, workflows...)
+}
+
+func (h *GitTestHelper) createGitRepo(t *testing.T, repoName string, syncTarget string, syncEnabled bool, initialFiles map[string][]byte, workflows ...string) (*gittest.RemoteRepository, *gittest.LocalRepo) {
 	t.Helper()
 
 	ctx := context.Background()
@@ -2405,7 +2465,7 @@ func (h *GitTestHelper) createGitRepo(t *testing.T, repoName string, syncTarget 
 				"tokenUser": user.Username,
 			},
 			"sync": map[string]interface{}{
-				"enabled":         false,
+				"enabled":         syncEnabled,
 				"target":          syncTarget,
 				"intervalSeconds": 60,
 			},

--- a/pkg/tests/apis/provisioning/git/managed_dashboard_commit_message_test.go
+++ b/pkg/tests/apis/provisioning/git/managed_dashboard_commit_message_test.go
@@ -1,0 +1,152 @@
+package git
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	dashboardV1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
+	"github.com/grafana/grafana/pkg/tests/apis/provisioning/common"
+	"github.com/grafana/nanogit/gittest"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// These tests are regression tests for grafana/grafana#124620. Writing a
+// repo-managed dashboard through the Dashboard API used to forward the
+// request to the provisioning files endpoint without a `message` query
+// parameter, which made nanogit's StagedWriter.Commit fail with
+// `commit changes: empty commit message` (HTTP 500).
+//
+// Each test stands up a fresh git-backed repository with sync enabled so the
+// proxied write reflects into unified storage (otherwise the post-write Get
+// inside handleManagedResourceRouting would fail with KeyNotFound on Create).
+// The tests assert two things:
+//   1. The Dashboard API call returns no error (no empty-message failure).
+//   2. The resulting git commit message on origin/main matches either the
+//      caller-supplied grafana.app/message annotation or the action-specific
+//      fallback ("Create <name>" / "Update <name>" / "Delete <name>").
+
+func TestIntegrationGit_ManagedDashboardUpdate_CommitMessage(t *testing.T) {
+	helper := sharedGitHelper(t)
+	ctx := context.Background()
+
+	const (
+		repoName     = "managed-msg-update"
+		dashboardUID = "msg-update-dash"
+		dashboardFn  = "dashboard.json"
+	)
+
+	_, local := helper.CreateSyncEnabledGitRepo(t, repoName, map[string][]byte{
+		dashboardFn: common.DashboardJSON(dashboardUID, "Managed Dashboard", 1),
+	})
+	helper.SyncAndWait(t, repoName)
+	common.RequireRepoManagedDashboard(t, helper.DashboardsV1, ctx, dashboardUID, repoName, dashboardFn)
+
+	t.Run("fallback message", func(t *testing.T) {
+		fresh, err := helper.DashboardsV1.Resource.Get(ctx, dashboardUID, metav1.GetOptions{})
+		require.NoError(t, err)
+
+		annotations := fresh.GetAnnotations()
+		delete(annotations, utils.AnnoKeyMessage)
+		fresh.SetAnnotations(annotations)
+		require.NoError(t, unstructured.SetNestedField(fresh.Object, "Updated (fallback)", "spec", "title"))
+
+		_, err = helper.DashboardsV1.Resource.Update(ctx, fresh, metav1.UpdateOptions{})
+		require.NoError(t, err, "PUT must not fail with empty commit message")
+
+		require.Equal(t, "Update "+dashboardUID, latestCommitSubject(t, local))
+	})
+
+	t.Run("annotation message", func(t *testing.T) {
+		const msg = "Updated dashboard from integration test"
+		fresh, err := helper.DashboardsV1.Resource.Get(ctx, dashboardUID, metav1.GetOptions{})
+		require.NoError(t, err)
+
+		annotations := fresh.GetAnnotations()
+		if annotations == nil {
+			annotations = map[string]string{}
+		}
+		annotations[utils.AnnoKeyMessage] = msg
+		fresh.SetAnnotations(annotations)
+		require.NoError(t, unstructured.SetNestedField(fresh.Object, "Updated (annotated)", "spec", "title"))
+
+		_, err = helper.DashboardsV1.Resource.Update(ctx, fresh, metav1.UpdateOptions{})
+		require.NoError(t, err)
+
+		require.Equal(t, msg, latestCommitSubject(t, local))
+	})
+}
+
+func TestIntegrationGit_ManagedDashboardCreate_CommitMessage(t *testing.T) {
+	helper := sharedGitHelper(t)
+	ctx := context.Background()
+	dashboardAPIVersion := dashboardV1.DashboardResourceInfo.GroupVersion().String()
+
+	const repoName = "managed-msg-create"
+
+	_, local := helper.CreateSyncEnabledGitRepo(t, repoName, nil)
+	helper.SyncAndWait(t, repoName)
+
+	t.Run("annotation message", func(t *testing.T) {
+		const (
+			newUID = "msg-create-annotated"
+			newFn  = "created-annotated.json"
+			msg    = "Create dashboard with custom message"
+		)
+		dash := common.NewManagedDashboard(dashboardAPIVersion, newUID, repoName, newFn, msg)
+
+		_, err := helper.DashboardsV1.Resource.Create(ctx, dash, metav1.CreateOptions{})
+		require.NoError(t, err, "POST must not fail with empty commit message")
+
+		require.Equal(t, msg, latestCommitSubject(t, local))
+	})
+
+	t.Run("fallback message", func(t *testing.T) {
+		const (
+			newUID = "msg-create-fallback"
+			newFn  = "created-fallback.json"
+		)
+		dash := common.NewManagedDashboard(dashboardAPIVersion, newUID, repoName, newFn, "")
+
+		_, err := helper.DashboardsV1.Resource.Create(ctx, dash, metav1.CreateOptions{})
+		require.NoError(t, err, "POST must not fail with empty commit message")
+
+		require.Equal(t, "Create "+newUID, latestCommitSubject(t, local))
+	})
+}
+
+func TestIntegrationGit_ManagedDashboardDelete_CommitMessage(t *testing.T) {
+	helper := sharedGitHelper(t)
+	ctx := context.Background()
+
+	const (
+		repoName     = "managed-msg-delete"
+		dashboardUID = "msg-delete-dash"
+		dashboardFn  = "dashboard.json"
+	)
+
+	_, local := helper.CreateSyncEnabledGitRepo(t, repoName, map[string][]byte{
+		dashboardFn: common.DashboardJSON(dashboardUID, "Managed Dashboard", 1),
+	})
+	helper.SyncAndWait(t, repoName)
+	common.RequireRepoManagedDashboard(t, helper.DashboardsV1, ctx, dashboardUID, repoName, dashboardFn)
+
+	require.NoError(t, helper.DashboardsV1.Resource.Delete(ctx, dashboardUID, metav1.DeleteOptions{}),
+		"DELETE must not fail with empty commit message")
+
+	require.Equal(t, "Delete "+dashboardUID, latestCommitSubject(t, local))
+}
+
+// latestCommitSubject fetches origin/main and returns the subject line of the
+// HEAD commit on that branch.
+func latestCommitSubject(t *testing.T, local *gittest.LocalRepo) string {
+	t.Helper()
+	_, err := local.Git("fetch", "origin", "main")
+	require.NoError(t, err, "git fetch origin main should succeed")
+	out, err := local.Git("log", "-1", "--format=%s", "origin/main")
+	require.NoError(t, err, "git log should succeed")
+	return strings.TrimSpace(out)
+}


### PR DESCRIPTION
Backport of #125556 to `release-13.0.2`.

## Summary

Fixes #124620 on 13.0.x. Writing a repo-managed resource through the Dashboard API used to fail with `commit changes: empty commit message` (HTTP 500) because `handleManagedResourceRouting` proxied the request to the provisioning files endpoint without forwarding a commit message. This change forwards the caller-supplied `grafana.app/message` annotation, with an action-specific fallback (`Create <name>` / `Update <name>` / `Delete <name>`) so every write produces a non-empty git commit.

## Backport notes

Cherry-pick had one conflict in `pkg/tests/apis/provisioning/common/testing.go`:

- `release-13.0.2` predates both the `CreateGithubRepo` helper and the generic `createRepo` extension-point that exist on `main`. To keep the helper API exposed by this fix (`CreateSyncEnabledGitRepo`) functional on the release branch, I adapted the existing private `createGitRepo(t, repoName, syncTarget, initialFiles, workflows...)` to accept an additional `syncEnabled bool` parameter and threaded it through to the inline repo spec's `sync.enabled` field. The two existing public callers (`CreateGitRepo`, `CreateFolderTargetGitRepo`) pass `false` (no behaviour change); `CreateSyncEnabledGitRepo` passes `true`.

- Added the `pkg/apimachinery/utils` import to `common/testing.go` (used by the new `NewManagedDashboard` / `RequireRepoManagedDashboard` helpers).

No changes to the production fix in `pkg/storage/unified/apistore/managed.go` or to the unit tests.

## Test plan

- [x] `go test ./pkg/storage/unified/apistore/...` passes
- [x] Backport branch builds clean
- [ ] CI on this branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)