### PR TITLE
Levitate: Drop unused id-token write perms

### DIFF
--- a/.github/workflows/detect-breaking-changes-levitate.yml
+++ b/.github/workflows/detect-breaking-changes-levitate.yml
@@ -26,7 +26,6 @@ jobs:
         working-directory: './pr'
     permissions:
       contents: read
-      id-token: write
 
     steps:
       - uses: actions/checkout@v5
@@ -64,7 +63,6 @@ jobs:
     runs-on: ubuntu-arm64
     permissions:
       contents: read
-      id-token: write
     defaults:
       run:
         working-directory: './base'


### PR DESCRIPTION
**What is this feature?**

Removes `id-token: write` from the `buildPR` and `buildBase` jobs in `detect-breaking-changes-levitate.yml`. These jobs only build artifacts and never call the OIDC token endpoint.

**Why do we need this feature?**

Least-privilege. These jobs run `yarn install` on PR-controlled code, so we shouldn't hand them a token-minting capability they don't need.

**Who is this feature for?**

Grafana maintainers

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #

**Special notes for your reviewer:**

First step from a wider security review of this workflow

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
