### PR TITLE
CI: Treat decoupled plugins as backend for mt-compat check

### DIFF
--- a/.github/workflows/pr-mt-service-compatibility.yml
+++ b/.github/workflows/pr-mt-service-compatibility.yml
@@ -45,6 +45,21 @@ jobs:
               - '!public/api-enterprise-spec.json'
               - '!public/api-merged.json'
               - '!public/openapi3.json'
+              # decoupled plugins are deployed via backend
+              - '!public/app/plugins/datasource/azuremonitor/**'
+              - '!public/app/plugins/datasource/cloud-monitoring/**'
+              - '!public/app/plugins/datasource/grafana-postgresql-datasource/**'
+              - '!public/app/plugins/datasource/grafana-pyroscope-datasource/**'
+              - '!public/app/plugins/datasource/grafana-testdata-datasource/**'
+              - '!public/app/plugins/datasource/graphite/**'
+              - '!public/app/plugins/datasource/influxdb/**'
+              - '!public/app/plugins/datasource/jaeger/**'
+              - '!public/app/plugins/datasource/loki/**'
+              - '!public/app/plugins/datasource/mssql/**'
+              - '!public/app/plugins/datasource/mysql/**'
+              - '!public/app/plugins/datasource/opentsdb/**'
+              - '!public/app/plugins/datasource/parca/**'
+              - '!public/app/plugins/datasource/tempo/**'
             backend_strict:
               - 'pkg/**'
               - 'go.mod'
@@ -61,6 +76,21 @@ jobs:
               - '!pkg/services/featuremgmt/toggles_gen.csv'
               - '!pkg/services/featuremgmt/toggles_gen.go'
               - '!pkg/services/featuremgmt/toggles_gen.json'
+              # decoupled plugins are deployed via backend
+              - 'public/app/plugins/datasource/azuremonitor/**'
+              - 'public/app/plugins/datasource/cloud-monitoring/**'
+              - 'public/app/plugins/datasource/grafana-postgresql-datasource/**'
+              - 'public/app/plugins/datasource/grafana-pyroscope-datasource/**'
+              - 'public/app/plugins/datasource/grafana-testdata-datasource/**'
+              - 'public/app/plugins/datasource/graphite/**'
+              - 'public/app/plugins/datasource/influxdb/**'
+              - 'public/app/plugins/datasource/jaeger/**'
+              - 'public/app/plugins/datasource/loki/**'
+              - 'public/app/plugins/datasource/mssql/**'
+              - 'public/app/plugins/datasource/mysql/**'
+              - 'public/app/plugins/datasource/opentsdb/**'
+              - 'public/app/plugins/datasource/parca/**'
+              - 'public/app/plugins/datasource/tempo/**'
 
       - name: Check for exception label
         if: steps.changed-files.outputs.frontend_strict_any_changed == 'true' && steps.changed-files.outputs.backend_strict_any_changed == 'true'
@@ -70,11 +100,11 @@ jobs:
             echo "✅ Mixed changes allowed - exception label 'no-check-mt-service-compatibility' is present"
             exit 0
           else
-            echo "❌ This PR contains both frontend and backend changes."
+            echo "❌ This PR contains changes that may not be deployed together."
             echo ""
             echo "Why this check failed:"
-            echo "• Frontend and backend are deployed independently in our SaaS architecture"
-            echo "• Frontend serves all customers with a single deployment"
+            echo "• Frontend, backend, and some data sources are deployed independently in our SaaS architecture"
+            echo "• Frontend changes are deployed on a seperate cadance from backend/RRC"
             echo "• Mixed changes break compatibility between frontend and backend versions"
             echo ""
             echo "How to fix:"


### PR DESCRIPTION
In https://github.com/grafana/grafana/pull/125309 we inadvertently included changes which should not have been deployed together. This is because decoupled plugins are actually deployed via the backend single-tenant pods, instead of via frontend-service.

This PR updates the mt-compat check to treat decoupled plugins as as 'backend' code so they're flagged on future PRs.