### PR TITLE
Alerting: Detect read-only Mimir local ruler storage

### DIFF
--- a/public/app/features/alerting/unified/api/buildInfo.test.ts
+++ b/public/app/features/alerting/unified/api/buildInfo.test.ts
@@ -23,7 +23,7 @@ const mocks = {
   fetchTestRulerRulesGroup: jest.mocked(fetchTestRulerRulesGroup),
 };
 
-beforeEach(() => jest.clearAllMocks());
+beforeEach(() => jest.resetAllMocks());
 
 describe('discoverDataSourceFeatures', () => {
   describe('When buildinfo returns 200 response', () => {
@@ -51,37 +51,96 @@ describe('discoverDataSourceFeatures', () => {
       expect(mocks.fetchTestRulerRulesGroup).not.toHaveBeenCalled();
     });
 
-    it.each([true, false])(
-      `Should return Mimir with rulerApiEnabled set to %p according to the ruler_config_api value`,
-      async (rulerApiEnabled) => {
-        fetch.mockReturnValue(
-          of({
+    it('Should return Mimir with disabled ruler API when buildinfo reports ruler_config_api false', async () => {
+      fetch.mockReturnValue(
+        of({
+          data: {
+            status: 'success',
             data: {
-              status: 'success',
-              data: {
-                version: '2.32.1',
-                features: {
-                  // 'true' and 'false' as strings is intentional
-                  // This is the format returned from the buildinfo endpoint
-                  ruler_config_api: rulerApiEnabled ? 'true' : 'false',
-                },
+              version: '2.32.1',
+              features: {
+                ruler_config_api: 'false',
               },
             },
-          })
-        );
+          },
+        })
+      );
 
-        const response = await discoverDataSourceFeatures({
-          url: '/datasource/proxy',
-          name: 'Prometheus',
-          type: 'prometheus',
-        });
+      const response = await discoverDataSourceFeatures({
+        url: '/datasource/proxy',
+        name: 'Mimir',
+        type: 'prometheus',
+      });
 
-        expect(response.application).toBe(PromApplication.Mimir);
-        expect(response.features.rulerApiEnabled).toBe(rulerApiEnabled);
-        expect(mocks.fetchRules).not.toHaveBeenCalled();
-        expect(mocks.fetchTestRulerRulesGroup).not.toHaveBeenCalled();
-      }
-    );
+      expect(response.application).toBe(PromApplication.Mimir);
+      expect(response.features.rulerApiEnabled).toBe(false);
+      expect(mocks.fetchRules).not.toHaveBeenCalled();
+      expect(mocks.fetchTestRulerRulesGroup).not.toHaveBeenCalled();
+    });
+
+    it('Should return Mimir with enabled ruler API when buildinfo and config API probe both succeed', async () => {
+      fetch.mockReturnValue(
+        of({
+          data: {
+            status: 'success',
+            data: {
+              version: '2.32.1',
+              features: {
+                ruler_config_api: 'true',
+              },
+            },
+          },
+        })
+      );
+      mocks.fetchTestRulerRulesGroup.mockResolvedValue(null);
+
+      const response = await discoverDataSourceFeatures({
+        url: '/datasource/proxy',
+        name: 'Mimir',
+        type: 'prometheus',
+      });
+
+      expect(response.application).toBe(PromApplication.Mimir);
+      expect(response.features.rulerApiEnabled).toBe(true);
+      expect(mocks.fetchRules).not.toHaveBeenCalled();
+      expect(mocks.fetchTestRulerRulesGroup).toHaveBeenCalledTimes(1);
+      expect(mocks.fetchTestRulerRulesGroup).toHaveBeenCalledWith('Mimir', 'mimir');
+    });
+
+    it('Should return Mimir with disabled ruler API when config API probe reports local ruler storage', async () => {
+      fetch.mockReturnValue(
+        of({
+          data: {
+            status: 'success',
+            data: {
+              version: '2.32.1',
+              features: {
+                ruler_config_api: 'true',
+              },
+            },
+          },
+        })
+      );
+      mocks.fetchTestRulerRulesGroup.mockRejectedValue({
+        status: 400,
+        data: {
+          message:
+            'failed to load rule group for user anonymous and namespace test: error parsing /rules/anonymous/test: open /rules/anonymous/test: no such file or directory',
+        },
+      });
+
+      const response = await discoverDataSourceFeatures({
+        url: '/datasource/proxy',
+        name: 'Mimir',
+        type: 'prometheus',
+      });
+
+      expect(response.application).toBe(PromApplication.Mimir);
+      expect(response.features.rulerApiEnabled).toBe(false);
+      expect(mocks.fetchRules).not.toHaveBeenCalled();
+      expect(mocks.fetchTestRulerRulesGroup).toHaveBeenCalledTimes(1);
+      expect(mocks.fetchTestRulerRulesGroup).toHaveBeenCalledWith('Mimir', 'mimir');
+    });
 
     it('When the data source is Loki should not call the buildinfo endpoint', async () => {
       await discoverDataSourceFeatures({ url: '/datasource/proxy', name: 'Loki', type: 'loki' });

--- a/public/app/features/alerting/unified/api/buildInfo.test.ts
+++ b/public/app/features/alerting/unified/api/buildInfo.test.ts
@@ -107,7 +107,7 @@ describe('discoverDataSourceFeatures', () => {
       expect(mocks.fetchTestRulerRulesGroup).toHaveBeenCalledWith('Mimir', 'mimir');
     });
 
-    it('Should return Mimir with disabled ruler API when config API probe reports local ruler storage', async () => {
+    it('Should return Mimir with disabled ruler API when config API probe returns a bad request', async () => {
       fetch.mockReturnValue(
         of({
           data: {
@@ -124,8 +124,7 @@ describe('discoverDataSourceFeatures', () => {
       mocks.fetchTestRulerRulesGroup.mockRejectedValue({
         status: 400,
         data: {
-          message:
-            'failed to load rule group for user anonymous and namespace test: error parsing /rules/anonymous/test: open /rules/anonymous/test: no such file or directory',
+          message: 'bad request',
         },
       });
 
@@ -215,6 +214,37 @@ describe('discoverDataSourceFeatures', () => {
 
       expect(response.application).toBe(PromApplication.Cortex);
       expect(response.features.rulerApiEnabled).toBe(true);
+
+      expect(mocks.fetchTestRulerRulesGroup).toHaveBeenCalledTimes(1);
+      expect(mocks.fetchTestRulerRulesGroup).toHaveBeenCalledWith('Cortex');
+
+      expect(mocks.fetchRules).toHaveBeenCalledTimes(1);
+      expect(mocks.fetchRules).toHaveBeenCalledWith('Cortex');
+    });
+
+    it('Should throw when Cortex ruler probe returns an unexpected bad request', async () => {
+      fetch.mockReturnValue(
+        throwError(() => ({
+          status: 404,
+        }))
+      );
+
+      const error = {
+        status: 400,
+        data: {
+          message: 'bad request',
+        },
+      };
+      mocks.fetchTestRulerRulesGroup.mockRejectedValue(error);
+      mocks.fetchRules.mockResolvedValue([]);
+
+      await expect(
+        discoverDataSourceFeatures({
+          url: '/datasource/proxy',
+          name: 'Cortex',
+          type: 'prometheus',
+        })
+      ).rejects.toBe(error);
 
       expect(mocks.fetchTestRulerRulesGroup).toHaveBeenCalledTimes(1);
       expect(mocks.fetchTestRulerRulesGroup).toHaveBeenCalledWith('Cortex');

--- a/public/app/features/alerting/unified/api/buildInfo.test.ts
+++ b/public/app/features/alerting/unified/api/buildInfo.test.ts
@@ -157,7 +157,7 @@ describe('discoverDataSourceFeatures', () => {
       expect(response.features.rulerApiEnabled).toBe(true);
 
       expect(mocks.fetchTestRulerRulesGroup).toHaveBeenCalledTimes(1);
-      expect(mocks.fetchTestRulerRulesGroup).toHaveBeenCalledWith('Loki');
+      expect(mocks.fetchTestRulerRulesGroup).toHaveBeenCalledWith('Loki', undefined);
 
       expect(mocks.fetchRules).toHaveBeenCalledTimes(1);
       expect(mocks.fetchRules).toHaveBeenCalledWith('Loki');
@@ -190,7 +190,7 @@ describe('discoverDataSourceFeatures', () => {
       expect(response.features.rulerApiEnabled).toBe(false);
 
       expect(mocks.fetchTestRulerRulesGroup).toHaveBeenCalledTimes(1);
-      expect(mocks.fetchTestRulerRulesGroup).toHaveBeenCalledWith('Cortex');
+      expect(mocks.fetchTestRulerRulesGroup).toHaveBeenCalledWith('Cortex', undefined);
 
       expect(mocks.fetchRules).toHaveBeenCalledTimes(1);
       expect(mocks.fetchRules).toHaveBeenCalledWith('Cortex');
@@ -216,7 +216,7 @@ describe('discoverDataSourceFeatures', () => {
       expect(response.features.rulerApiEnabled).toBe(true);
 
       expect(mocks.fetchTestRulerRulesGroup).toHaveBeenCalledTimes(1);
-      expect(mocks.fetchTestRulerRulesGroup).toHaveBeenCalledWith('Cortex');
+      expect(mocks.fetchTestRulerRulesGroup).toHaveBeenCalledWith('Cortex', undefined);
 
       expect(mocks.fetchRules).toHaveBeenCalledTimes(1);
       expect(mocks.fetchRules).toHaveBeenCalledWith('Cortex');
@@ -247,7 +247,7 @@ describe('discoverDataSourceFeatures', () => {
       ).rejects.toBe(error);
 
       expect(mocks.fetchTestRulerRulesGroup).toHaveBeenCalledTimes(1);
-      expect(mocks.fetchTestRulerRulesGroup).toHaveBeenCalledWith('Cortex');
+      expect(mocks.fetchTestRulerRulesGroup).toHaveBeenCalledWith('Cortex', undefined);
 
       expect(mocks.fetchRules).toHaveBeenCalledTimes(1);
       expect(mocks.fetchRules).toHaveBeenCalledWith('Cortex');

--- a/public/app/features/alerting/unified/api/buildInfo.ts
+++ b/public/app/features/alerting/unified/api/buildInfo.ts
@@ -198,7 +198,7 @@ async function hasRulerSupport(dataSourceName: string, subtype?: 'mimir') {
     }
     return true;
   } catch (e) {
-    if (errorIndicatesMissingRulerSupport(e)) {
+    if (errorIndicatesMissingRulerSupport(e, subtype)) {
       return false;
     }
     throw e;
@@ -214,10 +214,12 @@ function getRulerSupportErrorMessage(error: unknown): string {
 }
 
 // these errors indicate that the ruler API might be disabled or not supported
-function errorIndicatesMissingRulerSupport(error: unknown) {
+function errorIndicatesMissingRulerSupport(error: unknown, subtype?: 'mimir') {
   const message = getRulerSupportErrorMessage(error);
+  const mimirConfigApiProbeFailed = subtype === 'mimir' && isFetchError(error) && error.status === 400;
 
   return (
+    mimirConfigApiProbeFailed ||
     message.includes('GetRuleGroup unsupported in rule local store') ||
     (message.includes('failed to load rule group') && message.includes('no such file or directory')) ||
     message.includes('page not found') ||

--- a/public/app/features/alerting/unified/api/buildInfo.ts
+++ b/public/app/features/alerting/unified/api/buildInfo.ts
@@ -21,8 +21,6 @@ import {
 import { fetchRules } from './prometheus';
 import { fetchTestRulerRulesGroup } from './ruler';
 
-const MIMIR_RULER_SUBTYPE = 'mimir';
-
 export async function discoverFeaturesByUid(dataSourceUid: string): Promise<PromApiFeatures> {
   if (dataSourceUid === GRAFANA_RULES_SOURCE_NAME) {
     return {
@@ -108,7 +106,7 @@ export async function discoverDataSourceFeatures(dsSettings: {
 
   // if we have both features and buildinfo reported we're talking to Mimir
   const rulerConfigApiEnabled = features?.ruler_config_api === 'true';
-  const rulerSupported = rulerConfigApiEnabled ? await hasRulerSupport(name, MIMIR_RULER_SUBTYPE) : false;
+  const rulerSupported = rulerConfigApiEnabled ? await hasRulerSupport(name, 'mimir') : false;
 
   return {
     application: PromApplication.Mimir,

--- a/public/app/features/alerting/unified/api/buildInfo.ts
+++ b/public/app/features/alerting/unified/api/buildInfo.ts
@@ -21,6 +21,8 @@ import {
 import { fetchRules } from './prometheus';
 import { fetchTestRulerRulesGroup } from './ruler';
 
+const MIMIR_RULER_SUBTYPE = 'mimir';
+
 export async function discoverFeaturesByUid(dataSourceUid: string): Promise<PromApiFeatures> {
   if (dataSourceUid === GRAFANA_RULES_SOURCE_NAME) {
     return {
@@ -105,10 +107,13 @@ export async function discoverDataSourceFeatures(dsSettings: {
   }
 
   // if we have both features and buildinfo reported we're talking to Mimir
+  const rulerConfigApiEnabled = features?.ruler_config_api === 'true';
+  const rulerSupported = rulerConfigApiEnabled ? await hasRulerSupport(name, MIMIR_RULER_SUBTYPE) : false;
+
   return {
     application: PromApplication.Mimir,
     features: {
-      rulerApiEnabled: features?.ruler_config_api === 'true',
+      rulerApiEnabled: rulerSupported,
     },
   };
 }
@@ -186,9 +191,13 @@ async function hasPromRulesSupport(dataSourceName: string) {
  * Attempt to check if the ruler API is enabled for Cortex, Prometheus does not support it and Mimir
  * reports this via the buildInfo "features"
  */
-async function hasRulerSupport(dataSourceName: string) {
+async function hasRulerSupport(dataSourceName: string, subtype?: 'mimir') {
   try {
-    await fetchTestRulerRulesGroup(dataSourceName);
+    if (subtype) {
+      await fetchTestRulerRulesGroup(dataSourceName, subtype);
+    } else {
+      await fetchTestRulerRulesGroup(dataSourceName);
+    }
     return true;
   } catch (e) {
     if (errorIndicatesMissingRulerSupport(e)) {
@@ -197,11 +206,24 @@ async function hasRulerSupport(dataSourceName: string) {
     throw e;
   }
 }
-// there errors indicate that the ruler API might be disabled or not supported for Cortex
+
+function getRulerSupportErrorMessage(error: unknown): string {
+  if (isFetchError(error)) {
+    return [error.data.message, error.data.error].filter(Boolean).join(' ');
+  }
+
+  return error instanceof Error ? error.message : '';
+}
+
+// these errors indicate that the ruler API might be disabled or not supported
 function errorIndicatesMissingRulerSupport(error: unknown) {
-  return isFetchError(error)
-    ? error.data.message?.includes('GetRuleGroup unsupported in rule local store') || // "local" rule storage
-        error.data.message?.includes('page not found') || // ruler api disabled
-        error.data.message?.includes(RULER_NOT_SUPPORTED_MSG) // ruler api not supported
-    : error instanceof Error && error.message?.includes('404 from rules config endpoint'); // ruler api disabled
+  const message = getRulerSupportErrorMessage(error);
+
+  return (
+    message.includes('GetRuleGroup unsupported in rule local store') ||
+    (message.includes('failed to load rule group') && message.includes('no such file or directory')) ||
+    message.includes('page not found') ||
+    message.includes(RULER_NOT_SUPPORTED_MSG) ||
+    message.includes('404 from rules config endpoint')
+  );
 }

--- a/public/app/features/alerting/unified/api/buildInfo.ts
+++ b/public/app/features/alerting/unified/api/buildInfo.ts
@@ -19,7 +19,7 @@ import {
 } from '../utils/datasource';
 
 import { fetchRules } from './prometheus';
-import { fetchTestRulerRulesGroup, type RulerApiSubtype } from './ruler';
+import { type RulerApiSubtype, fetchTestRulerRulesGroup } from './ruler';
 
 export async function discoverFeaturesByUid(dataSourceUid: string): Promise<PromApiFeatures> {
   if (dataSourceUid === GRAFANA_RULES_SOURCE_NAME) {

--- a/public/app/features/alerting/unified/api/buildInfo.ts
+++ b/public/app/features/alerting/unified/api/buildInfo.ts
@@ -19,7 +19,7 @@ import {
 } from '../utils/datasource';
 
 import { fetchRules } from './prometheus';
-import { fetchTestRulerRulesGroup } from './ruler';
+import { fetchTestRulerRulesGroup, type RulerApiSubtype } from './ruler';
 
 export async function discoverFeaturesByUid(dataSourceUid: string): Promise<PromApiFeatures> {
   if (dataSourceUid === GRAFANA_RULES_SOURCE_NAME) {
@@ -189,13 +189,9 @@ async function hasPromRulesSupport(dataSourceName: string) {
  * Attempt to check if the ruler API is enabled for Cortex, Prometheus does not support it and Mimir
  * reports this via the buildInfo "features"
  */
-async function hasRulerSupport(dataSourceName: string, subtype?: 'mimir') {
+async function hasRulerSupport(dataSourceName: string, subtype?: RulerApiSubtype) {
   try {
-    if (subtype) {
-      await fetchTestRulerRulesGroup(dataSourceName, subtype);
-    } else {
-      await fetchTestRulerRulesGroup(dataSourceName);
-    }
+    await fetchTestRulerRulesGroup(dataSourceName, subtype);
     return true;
   } catch (e) {
     if (errorIndicatesMissingRulerSupport(e, subtype)) {
@@ -207,14 +203,14 @@ async function hasRulerSupport(dataSourceName: string, subtype?: 'mimir') {
 
 function getRulerSupportErrorMessage(error: unknown): string {
   if (isFetchError(error)) {
-    return [error.data.message, error.data.error].filter(Boolean).join(' ');
+    return error.data.message ?? '';
   }
 
   return error instanceof Error ? error.message : '';
 }
 
 // these errors indicate that the ruler API might be disabled or not supported
-function errorIndicatesMissingRulerSupport(error: unknown, subtype?: 'mimir') {
+function errorIndicatesMissingRulerSupport(error: unknown, subtype?: RulerApiSubtype) {
   const message = getRulerSupportErrorMessage(error);
   const mimirConfigApiProbeFailed = subtype === 'mimir' && isFetchError(error) && error.status === 400;
 

--- a/public/app/features/alerting/unified/api/ruler.test.ts
+++ b/public/app/features/alerting/unified/api/ruler.test.ts
@@ -8,7 +8,12 @@ import { setupDataSources } from '../testSetup/datasources';
 import { DataSourceType } from '../utils/datasource';
 
 import { GRAFANA_RULER_CONFIG } from './featureDiscoveryApi';
-import { fetchTestRulerRulesGroup, rulerUrlBuilder } from './ruler';
+import {
+  RULER_CONFIG_API_PROBE_GROUP,
+  RULER_CONFIG_API_PROBE_NAMESPACE,
+  fetchTestRulerRulesGroup,
+  rulerUrlBuilder,
+} from './ruler';
 
 jest.mock('@grafana/runtime', () => ({
   ...jest.requireActual('@grafana/runtime'),
@@ -153,7 +158,7 @@ describe('fetchTestRulerRulesGroup', () => {
     expect(fetch).toHaveBeenCalledTimes(1);
     expect(fetch).toHaveBeenCalledWith(
       expect.objectContaining({
-        url: '/api/ruler/mimir-1/api/v1/rules/test/test',
+        url: `/api/ruler/mimir-1/api/v1/rules/${RULER_CONFIG_API_PROBE_NAMESPACE}/${RULER_CONFIG_API_PROBE_GROUP}`,
         params: { subtype: 'mimir' },
         showErrorAlert: false,
         showSuccessAlert: false,

--- a/public/app/features/alerting/unified/api/ruler.test.ts
+++ b/public/app/features/alerting/unified/api/ruler.test.ts
@@ -1,3 +1,6 @@
+import { of } from 'rxjs';
+
+import { getBackendSrv } from '@grafana/runtime';
 import { type RulerDataSourceConfig } from 'app/types/unified-alerting';
 
 import { mockDataSource } from '../mocks';
@@ -5,7 +8,12 @@ import { setupDataSources } from '../testSetup/datasources';
 import { DataSourceType } from '../utils/datasource';
 
 import { GRAFANA_RULER_CONFIG } from './featureDiscoveryApi';
-import { rulerUrlBuilder } from './ruler';
+import { fetchTestRulerRulesGroup, rulerUrlBuilder } from './ruler';
+
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getBackendSrv: jest.fn(),
+}));
 
 const mimirConfig: RulerDataSourceConfig = {
   dataSourceName: 'Mimir-cloud',
@@ -18,6 +26,10 @@ beforeAll(() => {
     mockDataSource({ type: DataSourceType.Prometheus, name: 'Mimir-cloud', uid: 'mimir-1' }),
     mockDataSource({ type: DataSourceType.Prometheus, name: 'Cortex', uid: 'cortex-1' })
   );
+});
+
+beforeEach(() => {
+  jest.mocked(getBackendSrv).mockReset();
 });
 
 describe('rulerUrlBuilder', () => {
@@ -128,5 +140,24 @@ describe('rulerUrlBuilder', () => {
       expect(group.params).toHaveProperty('group');
       expect(group.params).not.toHaveProperty('namespace');
     });
+  });
+});
+
+describe('fetchTestRulerRulesGroup', () => {
+  it('passes the Mimir subtype parameter when probing a Mimir ruler', async () => {
+    const fetch = jest.fn().mockReturnValue(of({ data: null }));
+    jest.mocked(getBackendSrv).mockReturnValue({ fetch } as unknown as ReturnType<typeof getBackendSrv>);
+
+    await fetchTestRulerRulesGroup('Mimir-cloud', 'mimir');
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledWith(
+      expect.objectContaining({
+        url: '/api/ruler/mimir-1/api/v1/rules/test/test',
+        params: { subtype: 'mimir' },
+        showErrorAlert: false,
+        showSuccessAlert: false,
+      })
+    );
   });
 });

--- a/public/app/features/alerting/unified/api/ruler.ts
+++ b/public/app/features/alerting/unified/api/ruler.ts
@@ -26,13 +26,13 @@ const QUERY_GROUP_TAG = 'QUERY_GROUP';
 export const RULER_CONFIG_API_PROBE_NAMESPACE = '__grafana_alerting_ruler_probe__';
 export const RULER_CONFIG_API_PROBE_GROUP = '__grafana_alerting_ruler_probe__';
 
-type RulerApiSubtype = 'cortex' | 'mimir';
+export type RulerApiSubtype = 'cortex' | 'mimir';
 
 export function rulerUrlBuilder(rulerConfig: RulerDataSourceConfig) {
   const rulerPath = getRulerPath(rulerConfig);
   const queryDetailsProvider = getQueryDetailsProvider(rulerConfig);
 
-  const subtype = rulerConfig.apiVersion === 'legacy' ? 'cortex' : 'mimir';
+  const subtype: RulerApiSubtype = rulerConfig.apiVersion === 'legacy' ? 'cortex' : 'mimir';
 
   return {
     rules: (filter?: FetchRulerRulesFilter): RulerRequestUrl => ({

--- a/public/app/features/alerting/unified/api/ruler.ts
+++ b/public/app/features/alerting/unified/api/ruler.ts
@@ -23,6 +23,8 @@ export interface RulerRequestUrl {
 
 const QUERY_NAMESPACE_TAG = 'QUERY_NAMESPACE';
 const QUERY_GROUP_TAG = 'QUERY_GROUP';
+export const RULER_CONFIG_API_PROBE_NAMESPACE = '__grafana_alerting_ruler_probe__';
+export const RULER_CONFIG_API_PROBE_GROUP = '__grafana_alerting_ruler_probe__';
 
 type RulerApiSubtype = 'cortex' | 'mimir';
 
@@ -151,9 +153,11 @@ export async function fetchTestRulerRulesGroup(
   subtype?: RulerApiSubtype
 ): Promise<RulerRuleGroupDTO | null> {
   const params = subtype ? { subtype } : undefined;
+  const namespace = encodeURIComponent(RULER_CONFIG_API_PROBE_NAMESPACE);
+  const group = encodeURIComponent(RULER_CONFIG_API_PROBE_GROUP);
 
   return rulerGetRequest<RulerRuleGroupDTO | null>(
-    `/api/ruler/${getDatasourceAPIUid(dataSourceName)}/api/v1/rules/test/test`,
+    `/api/ruler/${getDatasourceAPIUid(dataSourceName)}/api/v1/rules/${namespace}/${group}`,
     null,
     params
   );

--- a/public/app/features/alerting/unified/api/ruler.ts
+++ b/public/app/features/alerting/unified/api/ruler.ts
@@ -24,6 +24,8 @@ export interface RulerRequestUrl {
 const QUERY_NAMESPACE_TAG = 'QUERY_NAMESPACE';
 const QUERY_GROUP_TAG = 'QUERY_GROUP';
 
+type RulerApiSubtype = 'cortex' | 'mimir';
+
 export function rulerUrlBuilder(rulerConfig: RulerDataSourceConfig) {
   const rulerPath = getRulerPath(rulerConfig);
   const queryDetailsProvider = getQueryDetailsProvider(rulerConfig);
@@ -144,10 +146,16 @@ export async function fetchRulerRulesNamespace(rulerConfig: RulerDataSourceConfi
 
 // fetch a particular rule group
 // will throw with { status: 404 } if rule group does not exist
-export async function fetchTestRulerRulesGroup(dataSourceName: string): Promise<RulerRuleGroupDTO | null> {
+export async function fetchTestRulerRulesGroup(
+  dataSourceName: string,
+  subtype?: RulerApiSubtype
+): Promise<RulerRuleGroupDTO | null> {
+  const params = subtype ? { subtype } : undefined;
+
   return rulerGetRequest<RulerRuleGroupDTO | null>(
     `/api/ruler/${getDatasourceAPIUid(dataSourceName)}/api/v1/rules/test/test`,
-    null
+    null,
+    params
   );
 }
 

--- a/public/app/features/alerting/unified/group-details/GroupDetailsPage.test.tsx
+++ b/public/app/features/alerting/unified/group-details/GroupDetailsPage.test.tsx
@@ -329,6 +329,9 @@ describe('GroupDetailsPage', () => {
 
       const group = alertingFactory.ruler.group.build({ name: 'test-group-cpu', interval: '11m40s' });
       setRulerRuleGroupResolver((req) => {
+        if (req.params.namespace === 'test' && req.params.groupName === 'test') {
+          return HttpResponse.json({ message: 'group does not exist' }, { status: 404 });
+        }
         if (req.params.namespace === 'test-mimir-namespace' && req.params.groupName === 'test-group-cpu') {
           return HttpResponse.json(group);
         }

--- a/public/app/features/alerting/unified/group-details/GroupDetailsPage.test.tsx
+++ b/public/app/features/alerting/unified/group-details/GroupDetailsPage.test.tsx
@@ -9,6 +9,7 @@ import { setPluginLinksHook } from '@grafana/runtime';
 import { AccessControlAction } from 'app/types/accessControl';
 import { type GrafanaPromRuleGroupDTO, type GrafanaPromRulesResponse } from 'app/types/unified-alerting-dto';
 
+import { RULER_CONFIG_API_PROBE_GROUP, RULER_CONFIG_API_PROBE_NAMESPACE } from '../api/ruler';
 import { setupMswServer } from '../mockApi';
 import { grantUserPermissions, mockGrafanaPromAlertingRule, mockRulerGrafanaRule, mockRulerRuleGroup } from '../mocks';
 import {
@@ -329,7 +330,10 @@ describe('GroupDetailsPage', () => {
 
       const group = alertingFactory.ruler.group.build({ name: 'test-group-cpu', interval: '11m40s' });
       setRulerRuleGroupResolver((req) => {
-        if (req.params.namespace === 'test' && req.params.groupName === 'test') {
+        if (
+          req.params.namespace === RULER_CONFIG_API_PROBE_NAMESPACE &&
+          req.params.groupName === RULER_CONFIG_API_PROBE_GROUP
+        ) {
           return HttpResponse.json({ message: 'group does not exist' }, { status: 404 });
         }
         if (req.params.namespace === 'test-mimir-namespace' && req.params.groupName === 'test-group-cpu') {

--- a/public/app/features/alerting/unified/group-details/GroupEditPage.test.tsx
+++ b/public/app/features/alerting/unified/group-details/GroupEditPage.test.tsx
@@ -8,6 +8,7 @@ import { AppNotificationList } from 'app/core/components/AppNotifications/AppNot
 import { AccessControlAction } from 'app/types/accessControl';
 import { type RulerRuleGroupDTO } from 'app/types/unified-alerting-dto';
 
+import { RULER_CONFIG_API_PROBE_GROUP, RULER_CONFIG_API_PROBE_NAMESPACE } from '../api/ruler';
 import { setupMswServer } from '../mockApi';
 import { grantUserPermissions } from '../mocks';
 import {
@@ -175,7 +176,7 @@ describe('GroupEditPage', () => {
       groupsByName.set(group.name, group);
 
       setRulerRuleGroupResolver(async ({ params: { namespace, groupName } }) => {
-        if (namespace === 'test' && groupName === 'test') {
+        if (namespace === RULER_CONFIG_API_PROBE_NAMESPACE && groupName === RULER_CONFIG_API_PROBE_GROUP) {
           return HttpResponse.json({ message: 'group does not exist' }, { status: 404 });
         }
         if (groupsByName.has(groupName)) {

--- a/public/app/features/alerting/unified/group-details/GroupEditPage.test.tsx
+++ b/public/app/features/alerting/unified/group-details/GroupEditPage.test.tsx
@@ -174,7 +174,10 @@ describe('GroupEditPage', () => {
       groupsByName.clear();
       groupsByName.set(group.name, group);
 
-      setRulerRuleGroupResolver(async ({ params: { groupName } }) => {
+      setRulerRuleGroupResolver(async ({ params: { namespace, groupName } }) => {
+        if (namespace === 'test' && groupName === 'test') {
+          return HttpResponse.json({ message: 'group does not exist' }, { status: 404 });
+        }
         if (groupsByName.has(groupName)) {
           return HttpResponse.json(groupsByName.get(groupName));
         }

--- a/public/app/features/alerting/unified/hooks/ruleGroup/__snapshots__/useUpdateRuleGroup.test.tsx.snap
+++ b/public/app/features/alerting/unified/hooks/ruleGroup/__snapshots__/useUpdateRuleGroup.test.tsx.snap
@@ -22,6 +22,17 @@ exports[`reorder rules for rule group should correctly reorder rules 1`] = `
       ],
     ],
     "method": "GET",
+    "url": "http://localhost/api/ruler/mimir/api/v1/rules/test/test?subtype=mimir",
+  },
+  {
+    "body": "",
+    "headers": [
+      [
+        "accept",
+        "application/json, text/plain, */*",
+      ],
+    ],
+    "method": "GET",
     "url": "http://localhost/api/ruler/mimir/api/v1/rules/namespace-2/group-3?subtype=mimir",
   },
   {
@@ -90,6 +101,17 @@ exports[`useUpdateRuleGroupConfiguration should be able to move a Data Source ma
     ],
     "method": "GET",
     "url": "http://localhost/api/datasources/proxy/uid/mimir/api/v1/status/buildinfo",
+  },
+  {
+    "body": "",
+    "headers": [
+      [
+        "accept",
+        "application/json, text/plain, */*",
+      ],
+    ],
+    "method": "GET",
+    "url": "http://localhost/api/ruler/mimir/api/v1/rules/test/test?subtype=mimir",
   },
   {
     "body": "",

--- a/public/app/features/alerting/unified/hooks/ruleGroup/__snapshots__/useUpdateRuleGroup.test.tsx.snap
+++ b/public/app/features/alerting/unified/hooks/ruleGroup/__snapshots__/useUpdateRuleGroup.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`reorder rules for rule group should correctly reorder rules 1`] = `
       ],
     ],
     "method": "GET",
-    "url": "http://localhost/api/ruler/mimir/api/v1/rules/test/test?subtype=mimir",
+    "url": "http://localhost/api/ruler/mimir/api/v1/rules/__grafana_alerting_ruler_probe__/__grafana_alerting_ruler_probe__?subtype=mimir",
   },
   {
     "body": "",
@@ -111,7 +111,7 @@ exports[`useUpdateRuleGroupConfiguration should be able to move a Data Source ma
       ],
     ],
     "method": "GET",
-    "url": "http://localhost/api/ruler/mimir/api/v1/rules/test/test?subtype=mimir",
+    "url": "http://localhost/api/ruler/mimir/api/v1/rules/__grafana_alerting_ruler_probe__/__grafana_alerting_ruler_probe__?subtype=mimir",
   },
   {
     "body": "",


### PR DESCRIPTION
**What is this feature?**

This updates alerting feature discovery for Mimir data sources so Grafana verifies editable ruler support before showing edit/delete actions for external rules.

When Mimir reports `ruler_config_api: "true"`, Grafana now probes the Mimir config API route with `subtype=mimir`. If the probe indicates local ruler storage, Grafana treats the ruler as read-only for UI edit/delete purposes while still allowing rules to be listed.

**Why do we need this feature?**

Mimir local ruler storage can list rule groups, but write/delete operations are unsupported. Grafana was relying on buildinfo alone, so it showed edit/delete actions that failed at runtime.

This keeps the rules visible but hides actions that cannot succeed.

**Who is this feature for?**

Users viewing externally managed alert rules from Mimir data sources that use local ruler storage.

**Which issue(s) does this PR fix?**:

Fixes #83032

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. Not applicable, bug fix only.
- [x] The docs are updated, and if this is a notable improvement, it's added to What's New. Not applicable, no user-facing docs change.

Test plan:
- [x] `yarn jest --no-watch public/app/features/alerting/unified/api/buildInfo.test.ts public/app/features/alerting/unified/api/ruler.test.ts`
- [x] `yarn jest --no-watch public/app/features/alerting/unified/api/buildInfo.test.ts public/app/features/alerting/unified/api/ruler.test.ts public/app/features/alerting/unified/components/rules/RulesGroup.test.tsx public/app/features/alerting/unified/components/rules/RulesTable.test.tsx`
- [x] `yarn typecheck`
- [x] Manual repro with Mimir local ruler storage: rule group remains visible, edit/delete actions are hidden.

Screenshot:

<img width="1440" height="1413" alt="grafana-mimir-local-ruler-after" src="https://github.com/user-attachments/assets/2c863e63-91d2-455f-8524-843a775bf30d" />

