### PR TITLE
fix(alerting): batch-load alert instances to fix N+1 query in HA single-node eval mode

### DIFF
--- a/pkg/services/ngalert/state/store_state_reader.go
+++ b/pkg/services/ngalert/state/store_state_reader.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"context"
+	"sync"
 
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/services/ngalert/models"
@@ -11,6 +12,7 @@ import (
 type StoreStateReader struct {
 	reader InstanceReader
 	log    log.Logger
+	cache  sync.Map // map[int64]map[string][]*State (orgID -> ruleUID -> states)
 }
 
 func NewStoreStateReader(reader InstanceReader, log log.Logger) *StoreStateReader {
@@ -28,19 +30,44 @@ func (m *StoreStateReader) GetAll(ctx context.Context, orgID int64) []*State {
 		m.log.Error("Failed to list alert instances from DB", "orgID", orgID, "error", err)
 		return nil
 	}
-	return m.convertToStates(instances)
+	states := m.convertToStates(instances)
+	// Populate cache
+	m.cacheStates(orgID, states)
+	return states
 }
 
 func (m *StoreStateReader) GetStatesForRuleUID(ctx context.Context, orgID int64, alertRuleUID string) []*State {
-	instances, err := m.reader.ListAlertInstances(ctx, &models.ListAlertInstancesQuery{
-		RuleOrgID: orgID,
-		RuleUID:   alertRuleUID,
-	})
-	if err != nil {
-		m.log.Error("Failed to list alert instances from DB", "orgID", orgID, "ruleUID", alertRuleUID, "error", err)
-		return nil
+	// Check cache first
+	if states := m.getCachedStates(orgID, alertRuleUID); states != nil {
+		return states
 	}
-	return m.convertToStates(instances)
+
+	// Cache miss - load all for org
+	_ = m.GetAll(ctx, orgID)
+
+	// Try cache again
+	if states := m.getCachedStates(orgID, alertRuleUID); states != nil {
+		return states
+	}
+
+	m.log.Debug("No alert instances found for rule", "orgID", orgID, "ruleUID", alertRuleUID)
+	return nil
+}
+
+func (m *StoreStateReader) cacheStates(orgID int64, states []*State) {
+	orgCache := make(map[string][]*State)
+	for _, s := range states {
+		orgCache[s.AlertRuleUID] = append(orgCache[s.AlertRuleUID], s)
+	}
+	m.cache.Store(orgID, orgCache)
+}
+
+func (m *StoreStateReader) getCachedStates(orgID int64, ruleUID string) []*State {
+	if v, ok := m.cache.Load(orgID); ok {
+		orgCache := v.(map[string][]*State)
+		return orgCache[ruleUID]
+	}
+	return nil
 }
 
 func (m *StoreStateReader) Status(ctx context.Context, key models.AlertRuleKey) (models.RuleStatus, bool) {


### PR DESCRIPTION
Fixes #124004

In HA single-node evaluation mode, listing alert rules caused an N+1 query because StoreStateReader queried the database per-rule for alert instances. With 200+ rules, this meant 200+ separate DB queries instead of 1.

The fix adds a per-org cache to StoreStateReader that loads all alert instances for an org on first access, then serves subsequent requests from the cache. This is safe because the apiStateManager in HA mode is a read-only DB reader, not shared with the scheduler's state manager.