### PR TITLE
Chore: Change owner of generated feature flag files to grafanabot

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1372,6 +1372,8 @@ embed.go @grafana/grafana-as-code
 
 # Generated files not requiring owner approval
 /packages/grafana-data/src/types/featureToggles.gen.ts @grafanabot
+/packages/grafana-runtime/src/internal/openFeature/openfeature-types.gen.d.ts @grafanabot
+/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts @grafanabot
 /docs/sources/setup-grafana/configure-grafana/feature-toggles/index.md @grafanabot
 /pkg/services/featuremgmt/toggles_gen.csv @grafanabot
 /pkg/services/featuremgmt/toggles_gen.go @grafanabot


### PR DESCRIPTION
Updates the owner of the generated OpenFeature frontend files to @grafanabot, to avoid Frontend Platform being tagged for reviews of these generated files.

This matches the behaviour of the old legacy toggle files.