### PR TITLE
fix: surface real failure cause when background service fails during startup

### DIFF
--- a/pkg/registry/backgroundsvcs/adapter/manager.go
+++ b/pkg/registry/backgroundsvcs/adapter/manager.go
@@ -98,6 +98,17 @@ func (m *ManagerAdapter) starting(ctx context.Context) error {
 		if ctx.Err() != nil {
 			return nil
 		}
+		// When a service fails during startup, the inner manager's listener
+		// triggers a self-shutdown, so AwaitRunning can observe the manager
+		// transitioning through Stopping before its failure case is recorded.
+		// That yields a generic state error that hides the real cause. Wait
+		// for the manager to finish terminating and surface its actual failure.
+		termCtx, cancel := context.WithTimeout(context.Background(), stopTimeout)
+		defer cancel()
+		_ = m.manager.AwaitTerminated(termCtx)
+		if failure := m.manager.FailureCase(); failure != nil {
+			return failure
+		}
 		return err
 	}
 	return nil


### PR DESCRIPTION
## Summary

Fixes the flaky `TestServer_Run_Error`. When a background service fails during
startup, the inner module manager's `serviceListener.Failure` triggers a
self-shutdown that cancels the manager's context. The manager then transitions
`Starting → Stopping → Failed`, recording the real failure case only at the
final transition. Meanwhile `managerAdapter.starting`'s `AwaitRunning` could
observe the transient `Stopping` state before the failure case was set,
returning a generic `"invalid service state: Stopping, expected: Running"`
error that hid the real cause (`"boom"` in the test).

```
--- FAIL: TestServer_Run_Error (0.00s)
    server_test.go:126: 
        	Error Trace:	/opt/actions-runner/_work/grafana/grafana/pkg/server/server_test.go:126
        	Error:      	"invalid service state: Failed, expected: Terminated, failure: invalid service state: Stopping, expected: Running" does not contain "boom"
        	Test:       	TestServer_Run_Error
FAIL
```

## Changes

- In `managerAdapter.starting`, when `AwaitRunning` fails and our context
  wasn't cancelled, wait for the inner manager to finish terminating and return
  its actual `FailureCase()` (bounded by `stopTimeout`).

## Testing

- Reproduced the flake reliably before the fix (failed within 200 runs).
- After the fix: `TestServer_Run_Error` passes 300/300 runs.
- Full `pkg/registry/backgroundsvcs/adapter` and `pkg/server` suites pass;
  `go vet` and `gofmt` clean.

## Checklist
- [x] Tests pass (existing test now deterministic)
- [x] No breaking changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


https://github.com/grafana/grafana/actions/runs/26636041227/job/78500428499?pr=125671