### PR TITLE
[release-13.0.2] Provisioning: replay protection for GitHub webhooks

### DIFF
--- a/apps/provisioning/go.mod
+++ b/apps/provisioning/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/grafana/grafana/apps/secret v0.0.0-20260118065639-60cb766a97d6
 	github.com/grafana/grafana/pkg/apimachinery v0.0.0-20260118065639-60cb766a97d6
 	github.com/grafana/nanogit v0.17.0
+	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/migueleliasweb/go-github-mock v1.5.0
 	github.com/prometheus/client_golang v1.23.2
 	github.com/stretchr/testify v1.11.1

--- a/apps/provisioning/go.sum
+++ b/apps/provisioning/go.sum
@@ -108,6 +108,8 @@ github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=

--- a/apps/provisioning/pkg/repository/github/extra.go
+++ b/apps/provisioning/pkg/repository/github/extra.go
@@ -82,7 +82,7 @@ func (e *extra) Build(ctx context.Context, r *provisioning.Repository) (reposito
 		return nil, fmt.Errorf("decrypt webhookSecret: %w", err)
 	}
 
-	return NewGithubWebhookRepository(ghRepo, webhookURL, webhookSecret, e.folderMetadataEnabled), nil
+	return NewGithubWebhookRepository(ghRepo, webhookURL, webhookSecret, e.folderMetadataEnabled, e.factory.replayCache), nil
 }
 
 func (e *extra) Mutate(ctx context.Context, obj runtime.Object) error {

--- a/apps/provisioning/pkg/repository/github/factory.go
+++ b/apps/provisioning/pkg/repository/github/factory.go
@@ -16,10 +16,17 @@ type Factory struct {
 	// Client allows overriding the client to use in the GH client returned. It exists primarily for testing.
 	// FIXME: we should replace in this way. We should add some options pattern for the factory.
 	Client *http.Client
+
+	// replayCache is the process-wide webhook replay cache. It lives on
+	// the factory so a single instance is shared across every per-request
+	// githubWebhookRepository the factory ultimately produces.
+	replayCache *replayCache
 }
 
 func ProvideFactory() *Factory {
-	return &Factory{}
+	return &Factory{
+		replayCache: newReplayCache(defaultReplayCacheTTL),
+	}
 }
 
 func (r *Factory) New(ctx context.Context, ghToken common.RawSecureValue) Client {

--- a/apps/provisioning/pkg/repository/github/webhook.go
+++ b/apps/provisioning/pkg/repository/github/webhook.go
@@ -40,6 +40,7 @@ type githubWebhookRepository struct {
 	gh                    Client
 	webhookURL            string
 	folderMetadataEnabled bool
+	replayCache           *replayCache
 }
 
 func NewGithubWebhookRepository(
@@ -47,7 +48,13 @@ func NewGithubWebhookRepository(
 	webhookURL string,
 	secret common.RawSecureValue,
 	folderMetadataEnabled bool,
+	replay *replayCache,
 ) GithubWebhookRepository {
+	// Defensive: callers should pass the factory-owned cache, but never leave
+	// Webhook with a nil cache to dereference.
+	if replay == nil {
+		replay = newReplayCache(defaultReplayCacheTTL)
+	}
 	return &githubWebhookRepository{
 		GithubRepository:      basic,
 		config:                basic.Config(),
@@ -57,6 +64,7 @@ func NewGithubWebhookRepository(
 		webhookURL:            webhookURL,
 		secret:                secret,
 		folderMetadataEnabled: folderMetadataEnabled,
+		replayCache:           replay,
 	}
 }
 
@@ -73,6 +81,27 @@ func (r *githubWebhookRepository) Webhook(ctx context.Context, req *http.Request
 	payload, err := github.ValidatePayload(req, []byte(r.secret))
 	if err != nil {
 		return nil, apierrors.NewUnauthorized("invalid signature")
+	}
+
+	// Replay protection: key on the validated signature, not the
+	// X-GitHub-Delivery header. GitHub computes the HMAC over the request body
+	// only, so the delivery ID is unauthenticated — an attacker replaying a
+	// captured (body, signature) could simply pick a fresh delivery ID and
+	// slip past a delivery-ID cache. The signature, by contrast, is bound to
+	// both the signed body and the repository's unique secret, so it cannot be
+	// forged or collided across repositories.
+	//
+	// Silently drop a request whose signature we have already processed within
+	// the cache TTL — returning a generic 200 avoids confirming to a replay
+	// attacker that the captured payload was a real previously-processed
+	// delivery.
+	signature := req.Header.Get(github.SHA256SignatureHeader)
+	if signature == "" {
+		signature = req.Header.Get(github.SHA1SignatureHeader)
+	}
+	if r.replayCache.seenOrAdd(signature) {
+		logging.FromContext(ctx).Debug("dropping replayed webhook delivery", "delivery_id", github.DeliveryID(req))
+		return &provisioning.WebhookResponse{Code: http.StatusOK, Message: "ok"}, nil
 	}
 
 	return r.parseWebhook(github.WebHookType(req), payload)

--- a/apps/provisioning/pkg/repository/github/webhook_replay.go
+++ b/apps/provisioning/pkg/repository/github/webhook_replay.go
@@ -1,0 +1,58 @@
+package github
+
+import (
+	"sync"
+	"time"
+
+	"github.com/hashicorp/golang-lru/v2/expirable"
+)
+
+// defaultReplayCacheTTL is the lifetime of a recorded webhook replay key. It
+// must comfortably exceed GitHub's webhook retry window so that a replayed
+// request is still considered a duplicate.
+const defaultReplayCacheTTL = time.Hour
+
+// maxReplayCacheEntries bounds the cache memory footprint. Provisioning webhook
+// volume per instance is low, so an attacker would need an implausible burst to
+// evict a still-live entry within the TTL — and the worst case of an
+// evicted-then-replayed delivery is a single idempotent sync job.
+const maxReplayCacheEntries = 10000
+
+// replayCache tracks recently-seen webhook replay keys so the webhook handler
+// can reject replayed requests. The key is the validated HMAC signature
+// (X-Hub-Signature-256), which binds the entry to the signed request body and
+// the repository's unique secret — see Webhook for why the unauthenticated
+// X-GitHub-Delivery header is not used as the key.
+type replayCache struct {
+	// expirable.LRU is internally locked, but seenOrAdd's Get-then-Add is two
+	// calls; this mutex makes the check-and-set atomic so concurrent identical
+	// requests register exactly one as new.
+	mu  sync.Mutex
+	lru *expirable.LRU[string, struct{}]
+}
+
+func newReplayCache(ttl time.Duration) *replayCache {
+	return &replayCache{
+		lru: expirable.NewLRU[string, struct{}](maxReplayCacheEntries, nil, ttl),
+	}
+}
+
+// seenOrAdd returns true if key has been recorded within the TTL window.
+// Otherwise it records key and returns false. An empty key is never considered
+// a duplicate so callers can decide how to handle missing values.
+func (c *replayCache) seenOrAdd(key string) bool {
+	if key == "" {
+		return false
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	// Get honors per-entry expiry on read; Contains only checks map membership
+	// and would report an expired-but-unswept entry as still present.
+	if _, ok := c.lru.Get(key); ok {
+		return true
+	}
+	c.lru.Add(key, struct{}{})
+	return false
+}

--- a/apps/provisioning/pkg/repository/github/webhook_replay_test.go
+++ b/apps/provisioning/pkg/repository/github/webhook_replay_test.go
@@ -1,0 +1,60 @@
+package github
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestReplayCache(t *testing.T) {
+	t.Run("first add returns false, duplicate returns true", func(t *testing.T) {
+		c := newReplayCache(time.Hour)
+		require.False(t, c.seenOrAdd("abc"))
+		require.True(t, c.seenOrAdd("abc"))
+	})
+
+	t.Run("empty key is never considered seen", func(t *testing.T) {
+		c := newReplayCache(time.Hour)
+		require.False(t, c.seenOrAdd(""))
+		require.False(t, c.seenOrAdd(""))
+	})
+
+	t.Run("entries expire after ttl", func(t *testing.T) {
+		const ttl = 50 * time.Millisecond
+		c := newReplayCache(ttl)
+
+		require.False(t, c.seenOrAdd("abc"))
+		require.True(t, c.seenOrAdd("abc"))
+
+		// Get honors expiry on read, so sleeping past the TTL makes the entry
+		// look absent without depending on the background sweeper.
+		time.Sleep(ttl + 20*time.Millisecond)
+		require.False(t, c.seenOrAdd("abc"))
+	})
+
+	t.Run("concurrent adds of the same key register exactly one as new", func(t *testing.T) {
+		c := newReplayCache(time.Hour)
+
+		const goroutines = 64
+		var wg sync.WaitGroup
+		wg.Add(goroutines)
+
+		var newCount int64
+		var mu sync.Mutex
+		for i := 0; i < goroutines; i++ {
+			go func() {
+				defer wg.Done()
+				if !c.seenOrAdd("same") {
+					mu.Lock()
+					newCount++
+					mu.Unlock()
+				}
+			}()
+		}
+		wg.Wait()
+
+		require.Equal(t, int64(1), newCount)
+	})
+}

--- a/apps/provisioning/pkg/repository/github/webhook_test.go
+++ b/apps/provisioning/pkg/repository/github/webhook_test.go
@@ -13,6 +13,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/mock"
@@ -140,6 +141,183 @@ func TestParseWebhooks(t *testing.T) {
 			require.Equal(t, tt.expected.Job, rsp.Job)
 		})
 	}
+}
+
+func TestGitHubRepository_Webhook_ReplayProtection(t *testing.T) {
+	pushPayload := `{
+		"ref": "refs/heads/main",
+		"repository": {
+			"full_name": "grafana/grafana"
+		}
+	}`
+	// A byte-different but still valid push payload — produces a different
+	// HMAC signature, so it is a distinct (non-replayed) request.
+	otherPayload := `{
+		"ref": "refs/heads/main",
+		"after": "deadbeef",
+		"repository": {
+			"full_name": "grafana/grafana"
+		}
+	}`
+
+	const defaultSecret = "webhook-secret"
+
+	// newSignedRequest signs payload with secret and sets the headers GitHub
+	// sends. deliveryID populates X-GitHub-Delivery; it is intentionally
+	// independent of the signature so tests can vary it freely.
+	newSignedRequest := func(payload, deliveryID, secret string) *http.Request {
+		req, _ := http.NewRequest("POST", "/webhook", strings.NewReader(payload))
+		req.Header.Set("X-GitHub-Event", "push")
+		req.Header.Set("Content-Type", "application/json")
+		if deliveryID != "" {
+			req.Header.Set("X-GitHub-Delivery", deliveryID)
+		}
+
+		mac := hmac.New(sha256.New, []byte(secret))
+		mac.Write([]byte(payload))
+		signature := hex.EncodeToString(mac.Sum(nil))
+		req.Header.Set("X-Hub-Signature-256", "sha256="+signature)
+
+		return req
+	}
+
+	newRepo := func(cache *replayCache, secret string) *githubWebhookRepository {
+		return &githubWebhookRepository{
+			config: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{Name: "test-repo"},
+				Spec: provisioning.RepositorySpec{
+					GitHub: &provisioning.GitHubRepositoryConfig{Branch: "main"},
+					Sync:   provisioning.SyncOptions{Enabled: true},
+				},
+				Status: provisioning.RepositoryStatus{
+					Webhook: &provisioning.WebhookStatus{},
+				},
+			},
+			owner:       "grafana",
+			repo:        "grafana",
+			secret:      common.RawSecureValue(secret),
+			replayCache: cache,
+		}
+	}
+
+	t.Run("first delivery is accepted", func(t *testing.T) {
+		gh := newRepo(newReplayCache(time.Hour), defaultSecret)
+
+		rsp, err := gh.Webhook(context.Background(), newSignedRequest(pushPayload, "delivery-1", defaultSecret))
+		require.NoError(t, err)
+		require.Equal(t, http.StatusAccepted, rsp.Code)
+	})
+
+	t.Run("replayed request is silently dropped", func(t *testing.T) {
+		gh := newRepo(newReplayCache(time.Hour), defaultSecret)
+
+		// First delivery succeeds with the normal accepted-job response.
+		first, err := gh.Webhook(context.Background(), newSignedRequest(pushPayload, "delivery-dup", defaultSecret))
+		require.NoError(t, err)
+		require.Equal(t, http.StatusAccepted, first.Code)
+
+		// Replaying the same signed request returns a generic 200 OK — same
+		// shape as other no-op paths so an attacker can't tell from the
+		// response whether the payload was previously processed.
+		dup, err := gh.Webhook(context.Background(), newSignedRequest(pushPayload, "delivery-dup", defaultSecret))
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, dup.Code)
+		require.Equal(t, "ok", dup.Message)
+		require.Nil(t, dup.Job, "replay must not enqueue a job")
+	})
+
+	t.Run("replay with a fresh delivery id is still dropped", func(t *testing.T) {
+		// Regression: the X-GitHub-Delivery header is not covered by the HMAC,
+		// so an attacker can replay a captured (body, signature) under a new
+		// delivery ID. Keying on the signature must still catch it.
+		gh := newRepo(newReplayCache(time.Hour), defaultSecret)
+
+		_, err := gh.Webhook(context.Background(), newSignedRequest(pushPayload, "delivery-A", defaultSecret))
+		require.NoError(t, err)
+
+		dup, err := gh.Webhook(context.Background(), newSignedRequest(pushPayload, "delivery-B", defaultSecret))
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, dup.Code, "same signed body under a different delivery id is still a replay")
+		require.Nil(t, dup.Job)
+	})
+
+	t.Run("distinct payloads are independent", func(t *testing.T) {
+		gh := newRepo(newReplayCache(time.Hour), defaultSecret)
+
+		_, err := gh.Webhook(context.Background(), newSignedRequest(pushPayload, "delivery-A", defaultSecret))
+		require.NoError(t, err)
+
+		// A different body yields a different signature, so it is processed.
+		rsp, err := gh.Webhook(context.Background(), newSignedRequest(otherPayload, "delivery-B", defaultSecret))
+		require.NoError(t, err)
+		require.Equal(t, http.StatusAccepted, rsp.Code)
+	})
+
+	t.Run("identical body under different secrets does not collide", func(t *testing.T) {
+		// The shared cache is consulted by every repository. Two repos with
+		// distinct webhook secrets produce distinct signatures for the same
+		// body, so one repo's delivery must not shadow another's.
+		cache := newReplayCache(time.Hour)
+		repoA := newRepo(cache, "secret-a")
+		repoB := newRepo(cache, "secret-b")
+
+		_, err := repoA.Webhook(context.Background(), newSignedRequest(pushPayload, "delivery-A", "secret-a"))
+		require.NoError(t, err)
+
+		rsp, err := repoB.Webhook(context.Background(), newSignedRequest(pushPayload, "delivery-B", "secret-b"))
+		require.NoError(t, err)
+		require.Equal(t, http.StatusAccepted, rsp.Code)
+	})
+
+	t.Run("repositories sharing a cache silently drop cross-instance replays", func(t *testing.T) {
+		// Mirrors production: extras.Build rebuilds a repository per request
+		// but threads the factory's single cache through each instance.
+		cache := newReplayCache(time.Hour)
+		first := newRepo(cache, defaultSecret)
+		second := newRepo(cache, defaultSecret)
+
+		_, err := first.Webhook(context.Background(), newSignedRequest(pushPayload, "delivery-1", defaultSecret))
+		require.NoError(t, err)
+
+		dup, err := second.Webhook(context.Background(), newSignedRequest(pushPayload, "delivery-2", defaultSecret))
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, dup.Code)
+		require.Equal(t, "ok", dup.Message)
+		require.Nil(t, dup.Job)
+	})
+
+	t.Run("expired entry is accepted again", func(t *testing.T) {
+		const ttl = 50 * time.Millisecond
+		gh := newRepo(newReplayCache(ttl), defaultSecret)
+
+		_, err := gh.Webhook(context.Background(), newSignedRequest(pushPayload, "delivery-X", defaultSecret))
+		require.NoError(t, err)
+
+		// Once the entry expires, the same signed request is processed again.
+		time.Sleep(ttl + 20*time.Millisecond)
+		rsp, err := gh.Webhook(context.Background(), newSignedRequest(pushPayload, "delivery-X", defaultSecret))
+		require.NoError(t, err)
+		require.Equal(t, http.StatusAccepted, rsp.Code)
+	})
+
+	t.Run("invalid signature is rejected before the replay check", func(t *testing.T) {
+		gh := newRepo(newReplayCache(time.Hour), defaultSecret)
+
+		req, _ := http.NewRequest("POST", "/webhook", strings.NewReader(pushPayload))
+		req.Header.Set("X-GitHub-Event", "push")
+		req.Header.Set("Content-Type", "application/json")
+		req.Header.Set("X-GitHub-Delivery", "delivery-bad-sig")
+		req.Header.Set("X-Hub-Signature-256", "sha256=deadbeef")
+
+		_, err := gh.Webhook(context.Background(), req)
+		require.Error(t, err)
+
+		// A subsequent valid request must still succeed — a failed signature
+		// must not poison the replay cache.
+		rsp, err := gh.Webhook(context.Background(), newSignedRequest(pushPayload, "delivery-good", defaultSecret))
+		require.NoError(t, err)
+		require.Equal(t, http.StatusAccepted, rsp.Code)
+	})
 }
 
 func TestGitHubRepository_Webhook(t *testing.T) {
@@ -898,12 +1076,14 @@ func TestGitHubRepository_Webhook(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Create a GitHub repository with the test config
+			// Create a GitHub repository with the test config. A fresh cache
+			// per subtest keeps replay state from leaking across cases.
 			repo := &githubWebhookRepository{
-				config: tt.config,
-				owner:  "grafana",
-				repo:   "grafana",
-				secret: common.RawSecureValue("webhook-secret"),
+				config:      tt.config,
+				owner:       "grafana",
+				repo:        "grafana",
+				secret:      common.RawSecureValue("webhook-secret"),
+				replayCache: newReplayCache(time.Hour),
 			}
 
 			// Call the Webhook method


### PR DESCRIPTION
Backport of #125550 to `release-13.0.2`.

Cherry-picked from `4627641de37c91581f1656cdfd9d9e7a4c9553c1`.

## What this backports

Adds replay protection to the GitHub provisioning webhook handler. Previously a captured `(body, X-Hub-Signature-256)` tuple could be replayed until the webhook secret rotated, re-enqueuing a sync job each time. A short-lived (1h) cache keyed on the **validated signature** now silently drops a previously-seen signed request with a generic `200 OK`. See the original PR for the full rationale (why key on the signature rather than the unauthenticated `X-GitHub-Delivery`, the silent-200 anti-oracle behavior, and the secret-rotation bound).

## Backport notes — not a clean cherry-pick

`release-13.0.2` predates the `incrementalPolicy` refactor on `main`, so three files conflicted and were resolved by adapting the replay feature onto this branch's structure:

- **`webhook.go` / `extra.go`** — `NewGithubWebhookRepository` here takes `folderMetadataEnabled bool` (not `incrementalPolicy`); kept that signature and appended the `*replayCache` argument. `parseWebhook` on this branch is not context-aware, so the replay block calls `r.parseWebhook(github.WebHookType(req), payload)` accordingly.
- **`webhook_test.go`** — dropped `TestParsePushEvent_LargeDiffForcesFullSync` from the cherry-pick (it depends on `incrementalPolicy`, which doesn't exist on this branch). The new `TestGitHubRepository_Webhook_ReplayProtection` is included unchanged.
- `factory.go`, `webhook_replay.go`, `webhook_replay_test.go`, and the `go.mod`/`go.sum` promotion of `golang-lru/v2` to a direct dependency applied cleanly.

`go build`, `go test`, and `go vet` for `apps/provisioning/pkg/repository/github/...` all pass on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)