### PR TITLE
Provisioning: reject http:// repository URLs when a token is configured

### DIFF
--- a/apps/provisioning/pkg/repository/git/extra.go
+++ b/apps/provisioning/pkg/repository/git/extra.go
@@ -12,11 +12,14 @@ import (
 
 type extra struct {
 	decrypter repository.Decrypter
+	// allowInsecure permits http:// URLs together with a token (cleartext credentials); local/dev only.
+	allowInsecure bool
 }
 
-func Extra(decrypter repository.Decrypter) repository.Extra {
+func Extra(decrypter repository.Decrypter, allowInsecure bool) repository.Extra {
 	return &extra{
-		decrypter: decrypter,
+		decrypter:     decrypter,
+		allowInsecure: allowInsecure,
 	}
 }
 
@@ -51,5 +54,5 @@ func (e *extra) Mutate(ctx context.Context, obj runtime.Object) error {
 }
 
 func (e *extra) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
-	return Validate(ctx, obj)
+	return Validate(ctx, obj, e.allowInsecure)
 }

--- a/apps/provisioning/pkg/repository/git/validator.go
+++ b/apps/provisioning/pkg/repository/git/validator.go
@@ -12,7 +12,9 @@ import (
 )
 
 // Validate validates the git repository configuration without requiring decrypted secrets.
-func Validate(_ context.Context, obj runtime.Object) field.ErrorList {
+// allowInsecure permits http:// URLs together with a token (cleartext credentials); it should
+// only be true for local/dev environments.
+func Validate(_ context.Context, obj runtime.Object, allowInsecure bool) field.ErrorList {
 	repo, ok := obj.(*provisioning.Repository)
 	if !ok {
 		return nil
@@ -29,20 +31,22 @@ func Validate(_ context.Context, obj runtime.Object) field.ErrorList {
 		}
 	}
 
-	return validateGitConfig(repo, cfg)
+	return validateGitConfig(repo, cfg, allowInsecure)
 }
 
 // validateGitConfig validates the git configuration fields.
 // This is extracted to be reusable by other git-based repository types (github, gitlab, bitbucket).
-func validateGitConfig(repo *provisioning.Repository, cfg *provisioning.GitRepositoryConfig) field.ErrorList {
-	return ValidateGitConfigFields(repo, cfg.URL, cfg.Branch, cfg.Path)
+func validateGitConfig(repo *provisioning.Repository, cfg *provisioning.GitRepositoryConfig, allowInsecure bool) field.ErrorList {
+	return ValidateGitConfigFields(repo, cfg.URL, cfg.Branch, cfg.Path, allowInsecure)
 }
 
 // ValidateGitConfigFields validates common git configuration fields (Branch, Path, token/connection).
 // This can be reused by git-based repository types (github, gitlab, bitbucket).
 // The URL parameter is only used for token/connection validation logic, not for URL format validation
 // (providers handle their own URL format validation).
-func ValidateGitConfigFields(repo *provisioning.Repository, url, branch, path string) field.ErrorList {
+// allowInsecure permits http:// URLs together with a token; when false, that combination is rejected
+// because it sends credentials in cleartext.
+func ValidateGitConfigFields(repo *provisioning.Repository, url, branch, path string, allowInsecure bool) field.ErrorList {
 	var list field.ErrorList
 
 	t := string(repo.Spec.Type)
@@ -56,6 +60,13 @@ func ValidateGitConfigFields(repo *provisioning.Repository, url, branch, path st
 				list = append(list, field.Invalid(field.NewPath("spec", t, "url"), url, "invalid git URL format"))
 			}
 		}
+	}
+
+	// Reject http:// together with a token: the token would travel in cleartext on every git
+	// operation. The token is a presence check (IsZero) that works without decryption.
+	if !allowInsecure && strings.HasPrefix(url, "http://") && !repo.Secure.Token.IsZero() {
+		list = append(list, field.Invalid(field.NewPath("spec", t, "url"), url,
+			"http:// is not allowed when a token is configured; use https:// to avoid sending credentials in cleartext"))
 	}
 
 	// Validate branch name format if a branch is provided (applies to all repository types)

--- a/apps/provisioning/pkg/repository/git/validator.go
+++ b/apps/provisioning/pkg/repository/git/validator.go
@@ -64,7 +64,9 @@ func ValidateGitConfigFields(repo *provisioning.Repository, url, branch, path st
 
 	// Reject http:// together with a token: the token would travel in cleartext on every git
 	// operation. The token is a presence check (IsZero) that works without decryption.
-	if !allowInsecure && strings.HasPrefix(url, "http://") && !repo.Secure.Token.IsZero() {
+	// URL schemes are case-insensitive, so normalize before comparing (https:// is unaffected,
+	// since it does not have the http:// prefix).
+	if !allowInsecure && strings.HasPrefix(strings.ToLower(url), "http://") && !repo.Secure.Token.IsZero() {
 		list = append(list, field.Invalid(field.NewPath("spec", t, "url"), url,
 			"http:// is not allowed when a token is configured; use https:// to avoid sending credentials in cleartext"))
 	}

--- a/apps/provisioning/pkg/repository/git/validator_test.go
+++ b/apps/provisioning/pkg/repository/git/validator_test.go
@@ -278,6 +278,29 @@ func TestValidate(t *testing.T) {
 			allowInsecure: true,
 		},
 		{
+			name: "uppercase HTTP scheme with token is rejected",
+			obj: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-repo",
+				},
+				Spec: provisioning.RepositorySpec{
+					Type: provisioning.GitRepositoryType,
+					Git: &provisioning.GitRepositoryConfig{
+						URL:    "HTTP://localhost:3000/grafana/grafana.git",
+						Branch: "main",
+						Path:   "grafana",
+					},
+				},
+				Secure: provisioning.SecureValues{
+					Token: common.InlineSecureValue{
+						Create: common.NewSecretValue("test-token"),
+					},
+				},
+			},
+			expectedError: true,
+			errorContains: []string{"http:// is not allowed when a token is configured"},
+		},
+		{
 			name: "http url without token is allowed",
 			obj: &provisioning.Repository{
 				ObjectMeta: metav1.ObjectMeta{

--- a/apps/provisioning/pkg/repository/git/validator_test.go
+++ b/apps/provisioning/pkg/repository/git/validator_test.go
@@ -16,6 +16,7 @@ func TestValidate(t *testing.T) {
 	tests := []struct {
 		name          string
 		obj           runtime.Object
+		allowInsecure bool
 		expectedError bool
 		errorContains []string
 	}{
@@ -232,6 +233,67 @@ func TestValidate(t *testing.T) {
 			},
 		},
 		{
+			name: "http url with token is rejected",
+			obj: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-repo",
+				},
+				Spec: provisioning.RepositorySpec{
+					Type: provisioning.GitRepositoryType,
+					Git: &provisioning.GitRepositoryConfig{
+						URL:    "http://localhost:3000/grafana/grafana.git",
+						Branch: "main",
+						Path:   "grafana",
+					},
+				},
+				Secure: provisioning.SecureValues{
+					Token: common.InlineSecureValue{
+						Create: common.NewSecretValue("test-token"),
+					},
+				},
+			},
+			expectedError: true,
+			errorContains: []string{"http:// is not allowed when a token is configured"},
+		},
+		{
+			name: "http url with token is allowed when insecure is permitted",
+			obj: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-repo",
+				},
+				Spec: provisioning.RepositorySpec{
+					Type: provisioning.GitRepositoryType,
+					Git: &provisioning.GitRepositoryConfig{
+						URL:    "http://localhost:3000/grafana/grafana.git",
+						Branch: "main",
+						Path:   "grafana",
+					},
+				},
+				Secure: provisioning.SecureValues{
+					Token: common.InlineSecureValue{
+						Create: common.NewSecretValue("test-token"),
+					},
+				},
+			},
+			allowInsecure: true,
+		},
+		{
+			name: "http url without token is allowed",
+			obj: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-repo",
+				},
+				Spec: provisioning.RepositorySpec{
+					Type: provisioning.GitRepositoryType,
+					Git: &provisioning.GitRepositoryConfig{
+						URL:    "http://localhost:3000/grafana/grafana.git",
+						Branch: "main",
+						Path:   "grafana",
+					},
+				},
+			},
+		},
+		{
 			name: "valid git repository with connection",
 			obj: &provisioning.Repository{
 				ObjectMeta: metav1.ObjectMeta{
@@ -255,7 +317,7 @@ func TestValidate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			list := Validate(context.Background(), tt.obj)
+			list := Validate(context.Background(), tt.obj, tt.allowInsecure)
 			if tt.expectedError {
 				assert.NotEmpty(t, list)
 				if len(tt.errorContains) > 0 {

--- a/apps/provisioning/pkg/repository/github/extra.go
+++ b/apps/provisioning/pkg/repository/github/extra.go
@@ -24,14 +24,17 @@ type extra struct {
 	decrypter         repository.Decrypter
 	webhookBuilder    WebhookURLBuilder
 	incrementalPolicy repository.IncrementalSyncPolicy
+	// allowInsecure permits http:// URLs together with a token (cleartext credentials); local/dev only.
+	allowInsecure bool
 }
 
-func Extra(decrypter repository.Decrypter, factory *Factory, webhookBuilder WebhookURLBuilder, incrementalPolicy repository.IncrementalSyncPolicy) repository.Extra {
+func Extra(decrypter repository.Decrypter, factory *Factory, webhookBuilder WebhookURLBuilder, incrementalPolicy repository.IncrementalSyncPolicy, allowInsecure bool) repository.Extra {
 	return &extra{
 		decrypter:         decrypter,
 		factory:           factory,
 		webhookBuilder:    webhookBuilder,
 		incrementalPolicy: incrementalPolicy,
+		allowInsecure:     allowInsecure,
 	}
 }
 
@@ -90,5 +93,5 @@ func (e *extra) Mutate(ctx context.Context, obj runtime.Object) error {
 }
 
 func (e *extra) Validate(ctx context.Context, obj runtime.Object) field.ErrorList {
-	return Validate(ctx, obj)
+	return Validate(ctx, obj, e.allowInsecure)
 }

--- a/apps/provisioning/pkg/repository/github/extra_test.go
+++ b/apps/provisioning/pkg/repository/github/extra_test.go
@@ -32,7 +32,7 @@ func (m *mockSecureValues) WebhookSecret(_ context.Context) (common.RawSecureVal
 }
 
 func TestExtra_Type(t *testing.T) {
-	e := github.Extra(nil, nil, nil, repository.IncrementalSyncPolicy{})
+	e := github.Extra(nil, nil, nil, repository.IncrementalSyncPolicy{}, false)
 	assert.Equal(t, provisioning.GitHubRepositoryType, e.Type())
 }
 
@@ -263,7 +263,7 @@ func TestExtra_Build(t *testing.T) {
 			webhookBuilder := tt.setupWebhook(t, tt.repo)
 			factory := github.ProvideFactory()
 
-			e := github.Extra(decrypter, factory, webhookBuilder, repository.IncrementalSyncPolicy{})
+			e := github.Extra(decrypter, factory, webhookBuilder, repository.IncrementalSyncPolicy{}, false)
 
 			result, err := e.Build(ctx, tt.repo)
 
@@ -393,7 +393,7 @@ func TestExtra_Mutate(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 
-			e := github.Extra(nil, nil, nil, repository.IncrementalSyncPolicy{})
+			e := github.Extra(nil, nil, nil, repository.IncrementalSyncPolicy{}, false)
 
 			err := e.Mutate(ctx, tt.obj)
 

--- a/apps/provisioning/pkg/repository/github/validator.go
+++ b/apps/provisioning/pkg/repository/github/validator.go
@@ -12,7 +12,9 @@ import (
 )
 
 // Validate validates the github repository configuration without requiring decrypted secrets.
-func Validate(_ context.Context, obj runtime.Object) field.ErrorList {
+// allowInsecure permits http:// URLs together with a token (cleartext credentials); it should
+// only be true for local/dev environments.
+func Validate(_ context.Context, obj runtime.Object, allowInsecure bool) field.ErrorList {
 	repo, ok := obj.(*provisioning.Repository)
 	if !ok {
 		return nil
@@ -49,6 +51,6 @@ func Validate(_ context.Context, obj runtime.Object) field.ErrorList {
 	}
 
 	// Validate git-related fields (branch, path, token/connection) using the shared git validator
-	list = append(list, git.ValidateGitConfigFields(repo, gh.URL, gh.Branch, gh.Path)...)
+	list = append(list, git.ValidateGitConfigFields(repo, gh.URL, gh.Branch, gh.Path, allowInsecure)...)
 	return list
 }

--- a/apps/provisioning/pkg/repository/github/validator_test.go
+++ b/apps/provisioning/pkg/repository/github/validator_test.go
@@ -16,6 +16,7 @@ func TestValidate(t *testing.T) {
 	tests := []struct {
 		name          string
 		obj           runtime.Object
+		allowInsecure bool
 		expectedError bool
 		errorContains []string
 	}{
@@ -65,7 +66,7 @@ func TestValidate(t *testing.T) {
 			errorContains: []string{"url"},
 		},
 		{
-			name: "valid HTTP URL for local development",
+			name: "http URL with token is rejected by default",
 			obj: &provisioning.Repository{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "test-repo",
@@ -83,7 +84,44 @@ func TestValidate(t *testing.T) {
 					},
 				},
 			},
-			expectedError: false,
+			expectedError: true,
+			errorContains: []string{"http:// is not allowed when a token is configured"},
+		},
+		{
+			name: "http URL with token is allowed when insecure is permitted (local development)",
+			obj: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-repo",
+				},
+				Spec: provisioning.RepositorySpec{
+					Type: provisioning.GitHubRepositoryType,
+					GitHub: &provisioning.GitHubRepositoryConfig{
+						URL:    "http://github.com/grafana/grafana",
+						Branch: "main",
+					},
+				},
+				Secure: provisioning.SecureValues{
+					Token: common.InlineSecureValue{
+						Create: common.NewSecretValue("test-token"),
+					},
+				},
+			},
+			allowInsecure: true,
+		},
+		{
+			name: "http URL without token is allowed",
+			obj: &provisioning.Repository{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "test-repo",
+				},
+				Spec: provisioning.RepositorySpec{
+					Type: provisioning.GitHubRepositoryType,
+					GitHub: &provisioning.GitHubRepositoryConfig{
+						URL:    "http://github.com/grafana/grafana",
+						Branch: "main",
+					},
+				},
+			},
 		},
 		{
 			name: "valid github.com repository",
@@ -110,7 +148,7 @@ func TestValidate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			list := Validate(context.Background(), tt.obj)
+			list := Validate(context.Background(), tt.obj, tt.allowInsecure)
 			if tt.expectedError {
 				assert.NotEmpty(t, list)
 				if len(tt.errorContains) > 0 {

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2408,7 +2408,7 @@ allow_image_rendering = true
 # Allow http:// repository URLs together with a configured token. This sends the token in
 # cleartext on every git operation, so it is rejected by default. Intended for local/dev only
 # (it is also implicitly allowed when app_mode = development).
-allow_insecure_token = false
+allow_insecure = false
 
 # The minimum sync interval that can be set for a repository. This is how often the controller
 # will check if there has been any changes to the repository not propagated by a webhook.

--- a/conf/defaults.ini
+++ b/conf/defaults.ini
@@ -2405,6 +2405,11 @@ allowed_targets = folder
 # Requires image rendering service to be configured.
 allow_image_rendering = true
 
+# Allow http:// repository URLs together with a configured token. This sends the token in
+# cleartext on every git operation, so it is rejected by default. Intended for local/dev only
+# (it is also implicitly allowed when app_mode = development).
+allow_insecure_token = false
+
 # The minimum sync interval that can be set for a repository. This is how often the controller
 # will check if there has been any changes to the repository not propagated by a webhook.
 # The minimum value is 10 seconds.

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -2823,7 +2823,7 @@ Comma-separated list of targets that a repository can control. `folder` by defau
 
 Whether image rendering is allowed for dashboard previews. Requires the image rendering service to be configured. Default is `true`.
 
-#### `allow_insecure_token`
+#### `allow_insecure`
 
 Whether to allow `http://` repository URLs together with a configured token. Because this sends the token in cleartext on every Git operation, it's rejected by default. Intended for local and development use only. It's also implicitly allowed when `app_mode = development`. Default is `false`.
 

--- a/docs/sources/setup-grafana/configure-grafana/_index.md
+++ b/docs/sources/setup-grafana/configure-grafana/_index.md
@@ -2823,6 +2823,10 @@ Comma-separated list of targets that a repository can control. `folder` by defau
 
 Whether image rendering is allowed for dashboard previews. Requires the image rendering service to be configured. Default is `true`.
 
+#### `allow_insecure_token`
+
+Whether to allow `http://` repository URLs together with a configured token. Because this sends the token in cleartext on every Git operation, it's rejected by default. Intended for local and development use only. It's also implicitly allowed when `app_mode = development`. Default is `false`.
+
 #### `min_sync_interval`
 
 The minimum sync interval that you can set for a repository. Indicates how often the controller will check for changes in the repository that were not propagated by a webhook. The minimum value is `10s`. Default is `10s`.

--- a/pkg/operators/provisioning/config.go
+++ b/pkg/operators/provisioning/config.go
@@ -546,7 +546,7 @@ func (c *ControllerConfig) RepositoryExtras() ([]repository.Extra, error) {
 
 	// http:// URLs with a token are only allowed in development or when explicitly opted in,
 	// since the token would otherwise travel in cleartext.
-	allowInsecure := c.Settings.Env == setting.Dev || provisioningSec.Key("allow_insecure_token").MustBool(false)
+	allowInsecure := c.Settings.Env == setting.Dev || provisioningSec.Key("allow_insecure").MustBool(false)
 
 	extras := make([]repository.Extra, 0)
 	for _, t := range repoTypes {

--- a/pkg/operators/provisioning/config.go
+++ b/pkg/operators/provisioning/config.go
@@ -544,11 +544,15 @@ func (c *ControllerConfig) RepositoryExtras() ([]repository.Extra, error) {
 		repoTypes = []string{"git", "github"}
 	}
 
+	// http:// URLs with a token are only allowed in development or when explicitly opted in,
+	// since the token would otherwise travel in cleartext.
+	allowInsecure := c.Settings.Env == setting.Dev || provisioningSec.Key("allow_insecure_token").MustBool(false)
+
 	extras := make([]repository.Extra, 0)
 	for _, t := range repoTypes {
 		switch provisioning.RepositoryType(t) {
 		case provisioning.GitRepositoryType:
-			extras = append(extras, gitrepo.Extra(decrypter))
+			extras = append(extras, gitrepo.Extra(decrypter, allowInsecure))
 		case provisioning.GitHubRepositoryType:
 			var webhook *webhooks.WebhookExtraBuilder
 			provisioningAppURL := operatorSec.Key("provisioning_server_public_url").String()
@@ -558,7 +562,7 @@ func (c *ControllerConfig) RepositoryExtras() ([]repository.Extra, error) {
 			extras = append(extras, githubrepo.Extra(decrypter, githubrepo.ProvideFactory(), webhook, repository.NewIncrementalSyncPolicy(
 				resources.IsFolderMetadataEnabled(c.Settings),
 				provisioningSec.Key("max_incremental_changes").MustInt(100),
-			)))
+			), allowInsecure))
 		case provisioning.LocalRepositoryType:
 			homePath := operatorSec.Key("home_path").String()
 			if homePath == "" {

--- a/pkg/registry/apis/provisioning/extras/register.go
+++ b/pkg/registry/apis/provisioning/extras/register.go
@@ -38,7 +38,7 @@ func ProvideProvisioningOSSRepositoryExtras(
 	folderMetadataEnabled := resources.IsFolderMetadataEnabled(cfg)
 	// http:// URLs with a token are only allowed in development or when explicitly opted in,
 	// since the token would otherwise travel in cleartext.
-	allowInsecure := cfg.Env == setting.Dev || cfg.ProvisioningAllowInsecureToken
+	allowInsecure := cfg.Env == setting.Dev || cfg.ProvisioningAllowInsecure
 	return []repository.Extra{
 		local.Extra(
 			cfg.HomePath,

--- a/pkg/registry/apis/provisioning/extras/register.go
+++ b/pkg/registry/apis/provisioning/extras/register.go
@@ -36,17 +36,21 @@ func ProvideProvisioningOSSRepositoryExtras(
 ) []repository.Extra {
 	decrypter := repository.ProvideDecrypter(decryptSvc, repository.RegisterDecryptMetrics(reg))
 	folderMetadataEnabled := resources.IsFolderMetadataEnabled(cfg)
+	// http:// URLs with a token are only allowed in development or when explicitly opted in,
+	// since the token would otherwise travel in cleartext.
+	allowInsecure := cfg.Env == setting.Dev || cfg.ProvisioningAllowInsecureToken
 	return []repository.Extra{
 		local.Extra(
 			cfg.HomePath,
 			cfg.PermittedProvisioningPaths,
 		),
-		git.Extra(decrypter),
+		git.Extra(decrypter, allowInsecure),
 		github.Extra(
 			decrypter,
 			ghFactory,
 			webhooksBuilder,
 			repository.NewIncrementalSyncPolicy(folderMetadataEnabled, cfg.ProvisioningMaxIncrementalChanges),
+			allowInsecure,
 		),
 	}
 }

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -158,7 +158,7 @@ type Cfg struct {
 	// Provisioning config
 	ProvisioningAllowedTargets                []string
 	ProvisioningAllowImageRendering           bool
-	ProvisioningAllowInsecureToken            bool // allow http:// repository URLs together with a token (cleartext credentials); local/dev only
+	ProvisioningAllowInsecure                 bool // allow http:// repository URLs together with a token (cleartext credentials); local/dev only
 	ProvisioningMinSyncInterval               time.Duration
 	ProvisioningRepositoryTypes               []string
 	ProvisioningLokiURL                       string
@@ -2486,7 +2486,7 @@ func (cfg *Cfg) readProvisioningSettings(iniFile *ini.File) error {
 		cfg.ProvisioningAllowedTargets = []string{"folder"}
 	}
 	cfg.ProvisioningAllowImageRendering = iniFile.Section("provisioning").Key("allow_image_rendering").MustBool(true)
-	cfg.ProvisioningAllowInsecureToken = iniFile.Section("provisioning").Key("allow_insecure_token").MustBool(false)
+	cfg.ProvisioningAllowInsecure = iniFile.Section("provisioning").Key("allow_insecure").MustBool(false)
 	cfg.ProvisioningMinSyncInterval = iniFile.Section("provisioning").Key("min_sync_interval").MustDuration(10 * time.Second)
 	cfg.ProvisioningMaxResourcesPerRepository = iniFile.Section("provisioning").Key("max_resources_per_repository").MustInt64(0)
 	cfg.ProvisioningMaxRepositories = iniFile.Section("provisioning").Key("max_repositories").MustInt64(10)

--- a/pkg/setting/setting.go
+++ b/pkg/setting/setting.go
@@ -158,6 +158,7 @@ type Cfg struct {
 	// Provisioning config
 	ProvisioningAllowedTargets                []string
 	ProvisioningAllowImageRendering           bool
+	ProvisioningAllowInsecureToken            bool // allow http:// repository URLs together with a token (cleartext credentials); local/dev only
 	ProvisioningMinSyncInterval               time.Duration
 	ProvisioningRepositoryTypes               []string
 	ProvisioningLokiURL                       string
@@ -2485,6 +2486,7 @@ func (cfg *Cfg) readProvisioningSettings(iniFile *ini.File) error {
 		cfg.ProvisioningAllowedTargets = []string{"folder"}
 	}
 	cfg.ProvisioningAllowImageRendering = iniFile.Section("provisioning").Key("allow_image_rendering").MustBool(true)
+	cfg.ProvisioningAllowInsecureToken = iniFile.Section("provisioning").Key("allow_insecure_token").MustBool(false)
 	cfg.ProvisioningMinSyncInterval = iniFile.Section("provisioning").Key("min_sync_interval").MustDuration(10 * time.Second)
 	cfg.ProvisioningMaxResourcesPerRepository = iniFile.Section("provisioning").Key("max_resources_per_repository").MustInt64(0)
 	cfg.ProvisioningMaxRepositories = iniFile.Section("provisioning").Key("max_repositories").MustInt64(10)

--- a/pkg/tests/apis/provisioning/common/testing.go
+++ b/pkg/tests/apis/provisioning/common/testing.go
@@ -1263,6 +1263,9 @@ func defaultGrafanaOpts(provisioningPath string) testinfra.GrafanaOpts {
 		// Allow both folder and instance sync targets for tests
 		// (instance is needed for export jobs, folder for most operations)
 		ProvisioningAllowedTargets: []string{"folder", "instance"},
+		// Tests use a local Gitea server over http:// with a token, so permit the
+		// otherwise-rejected http:// + token combination.
+		ProvisioningAllowInsecure: true,
 	}
 }
 

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -798,6 +798,12 @@ func createGrafDir(t *testing.T, tmpDir string, opts GrafanaOpts) (string, strin
 		_, err = provisioningSect.NewKey("allowed_targets", strings.Join(opts.ProvisioningAllowedTargets, "|"))
 		require.NoError(t, err)
 	}
+	if opts.ProvisioningAllowInsecure {
+		provisioningSect, err := getOrCreateSection("provisioning")
+		require.NoError(t, err)
+		_, err = provisioningSect.NewKey("allow_insecure", "true")
+		require.NoError(t, err)
+	}
 	if len(opts.ProvisioningRepositoryTypes) > 0 {
 		provisioningSect, err := getOrCreateSection("provisioning")
 		require.NoError(t, err)
@@ -997,6 +1003,7 @@ type GrafanaOpts struct {
 	UnifiedStorageResourceVersionBatchTransactionTimeout time.Duration
 	PermittedProvisioningPaths                           string
 	ProvisioningAllowedTargets                           []string
+	ProvisioningAllowInsecure                            bool
 	ProvisioningRepositoryTypes                          []string
 	ProvisioningMaxResourcesPerRepository                int64
 	ProvisioningMaxRepositories                          int64


### PR DESCRIPTION
## Summary

Combining an `http://` repository URL with a token caused the token (PAT) to travel in **cleartext** on every nanogit operation: `git.NewRepository` adds basic auth unconditionally, with no awareness of the URL scheme, and the validators never rejected the combination. This closes that hole (grafana/git-ui-sync-project#1153, `security`).

The rejection lives in the shared `ValidateGitConfigFields`, so it covers the `git` and `github` repository types today and any future git-based types (bitbucket/gitlab) for free. Token presence is checked via `Secure.Token.IsZero()` — no decryption needed at admission time.

**Local/dev escape hatch (per discussion on the issue):** `http://` + token is still allowed when either:
- running in development mode (`app_mode = development`), or
- the new `[provisioning] allow_insecure` flag is set (default `false`).

`http://` without a token (public, read-only local repos) and `https://` (with or without token) remain valid everywhere.

> The GitHub **connection** path is unaffected: it authenticates as a GitHub App against `github.com` over HTTPS (go-github default client, no user-supplied `http://` transport), and the installation token it mints flows through `git.NewRepository` via the github *repository* validator already covered here.

## Changes

- `apps/.../repository/git/validator.go`: add `allowInsecure` param; reject `http://` + token in `ValidateGitConfigFields` with a clear `spec.<type>.url` field error.
- `apps/.../repository/github/validator.go`: thread `allowInsecure` into the shared git validator.
- `apps/.../repository/git/extra.go`, `.../github/extra.go`: plumb `allowInsecure` through the `Extra` constructors (the `Extra` interface is unchanged — no mocks regenerated).
- `pkg/registry/apis/provisioning/extras/register.go` and `pkg/operators/provisioning/config.go`: wire the flag as `cfg.Env == setting.Dev || allow_insecure`.
- `pkg/setting/setting.go` + `conf/defaults.ini`: new `[provisioning] allow_insecure` option (field `ProvisioningAllowInsecure`, default off, documented). The key name mirrors the internal `allowInsecure` naming and Grafana's existing `AllowInsecure` convention.
- `docs/sources/setup-grafana/configure-grafana/_index.md`: document the new option.
- Tests in `git/validator_test.go` and `github/validator_test.go` for reject-by-default / allow-when-insecure / allow-without-token; updated `github/extra_test.go` call sites.

## Testing

- `go build` and `go vet` clean on all affected packages.
- `go test ./apps/provisioning/pkg/repository/git/... ./apps/provisioning/pkg/repository/github/...` — pass.
- `gofmt -l` clean on all edited Go files.

Manual: with `make run` (default `app_mode=development`), a `git` repo with an `http://` URL + token still succeeds. With `app_mode=production` and `allow_insecure=false` the same request fails with a `spec.git.url` admission error; setting `[provisioning] allow_insecure = true` makes it succeed again.

## Acceptance criteria

- [x] `http://` + token rejected with a clear field error on `spec.<type>.url` (prod / flag off)
- [x] `http://` + no token continues to work
- [x] `https://` with or without token continues to work
- [x] Still works locally/in dev (dev mode OR explicit `allow_insecure`)
- [x] Unit tests updated to expect rejection + cover the allow paths

## Notes

- No breaking config change: the new flag defaults to the secure behavior, and development mode keeps working automatically.
- grafana-enterprise, if it wires `git.Extra`/`github.Extra` directly, will need the new `allowInsecure` argument added there (separate repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)