### PR TITLE
Chore: Propose new CODEOWNERS for defunct grafana-as-code team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -297,7 +297,7 @@
 /devenv/docker/blocks/clickhouse/ @grafana/data-sources-plugins
 /devenv/docker/blocks/collectd/ @grafana/observability-metrics
 /devenv/docker/blocks/etcd @grafana/grafana-app-platform-squad
-/devenv/docker/blocks/grafana/ @grafana/grafana-as-code
+/devenv/docker/blocks/grafana/ @grafana/grafana-app-platform-squad
 /devenv/docker/blocks/graphite/ @grafana/data-sources-plugins
 /devenv/docker/blocks/graphite1/ @grafana/data-sources-plugins
 /devenv/docker/blocks/influxdb/ @grafana/data-sources-plugins
@@ -417,7 +417,7 @@
 /pkg/services/datasourceproxy/ @grafana/grafana-catalog
 /pkg/services/datasources/ @grafana/grafana-catalog
 /pkg/services/pluginsintegration/ @grafana/grafana-catalog
-/pkg/plugins/codegen/pfs/ @grafana/grafana-catalog @grafana/grafana-as-code
+/pkg/plugins/codegen/pfs/ @grafana/grafana-catalog
 /pkg/tsdb/grafana-testdata-datasource/ @grafana/grafana-catalog
 /pkg/tsdb/Magefile.go @grafana/grafana-catalog
 /pkg/services/pluginsintegration/pluginsettings/ @grafana/grafana-catalog
@@ -1098,7 +1098,7 @@ scripts/verify-pkg-stig.sh @grafana/grafana-backend-services-squad
 /scripts/validate-npm-packages.sh @grafana/grafana-backend-services-squad @grafana/grafana-frontend-platform
 /scripts/ci-frontend-metrics.sh @grafana/grafana-frontend-platform @grafana/frontend-ops
 /scripts/cli/ @grafana/grafana-frontend-platform
-/scripts/clean-git-or-error.sh @grafana/grafana-as-code
+/scripts/clean-git-or-error.sh @grafana/grafana-app-platform-squad
 /scripts/grafana-server/ @grafana/grafana-frontend-platform
 /scripts/check-frontend-dev.sh @grafana/grafana-frontend-platform
 /scripts/check-codeowner-affected.js @grafana/dataviz-squad
@@ -1109,7 +1109,7 @@ scripts/verify-pkg-stig.sh @grafana/grafana-backend-services-squad
 /scripts/openapi3/ @grafana/grafana-operator-experience-squad
 /scripts/prepare-npm-package.js @grafana/frontend-ops
 /scripts/protobuf-check.sh @grafana/grafana-catalog
-/scripts/stripnulls.sh @grafana/grafana-as-code
+/scripts/stripnulls.sh @grafana/grafana-app-platform-squad
 /scripts/tag_release.sh @grafana/grafana-backend-services-squad
 /scripts/trigger_docker_build.sh @grafana/grafana-backend-services-squad
 /scripts/trigger_grafana_packer.sh @grafana/grafana-backend-services-squad
@@ -1217,12 +1217,13 @@ eslint-suppressions.json @grafanabot
 
 # Kind definitions
 /kinds/dashboard @grafana/dashboards-squad
-/kinds/ @grafana/grafana-as-code
+/kinds/ @grafana/grafana-app-platform-squad
 
 # Kind system and code generation
-embed.go @grafana/grafana-as-code
-/pkg/kinds/ @grafana/grafana-as-code
-/pkg/registry/ @grafana/grafana-as-code
+embed.go @grafana/grafana-app-platform-squad
+/pkg/kinds/ @grafana/grafana-app-platform-squad
+/pkg/registry/ @grafana/grafana-app-platform-squad
+/pkg/registry/backgroundsvcs/ @grafana/grafana-backend-group
 /pkg/registry/apis/ @grafana/grafana-app-platform-squad
 /pkg/registry/apis/iam @grafana/access-squad @grafana/identity-squad
 /pkg/registry/apis/appplugin @grafana/grafana-catalog
@@ -1238,11 +1239,11 @@ embed.go @grafana/grafana-as-code
 /pkg/registry/apps/alerting @grafana/alerting-backend
 /pkg/registry/apps/plugins @grafana/grafana-catalog
 /pkg/registry/apps/dashvalidator @grafana/sharing-squad
-/pkg/codegen/ @grafana/grafana-as-code
-/pkg/codegen/generators @grafana/grafana-as-code
-/pkg/kinds/*/*_gen.go @grafana/grafana-as-code
-/public/app/plugins/*gen.go @grafana/grafana-as-code
-/cue.mod/ @grafana/grafana-as-code
+/pkg/codegen/ @grafana/grafana-app-platform-squad
+/pkg/codegen/generators @grafana/grafana-app-platform-squad
+/pkg/kinds/*/*_gen.go @grafana/grafana-app-platform-squad
+/public/app/plugins/*gen.go @grafana/grafana-app-platform-squad
+/cue.mod/ @grafana/grafana-app-platform-squad
 
 # GitHub Workflows and Templates
 /.github/CODEOWNERS @tolzhabayev


### PR DESCRIPTION
## Summary

The `@grafana/grafana-as-code` team no longer exists, but it is still listed as owner of **13 CODEOWNERS entries**. Those paths are effectively unowned today — reviews can't be auto-requested and there is no accountable team.

This PR proposes successors for every `grafana-as-code` entry. It is a **draft to start the ownership discussion** — proposed teams should confirm (or redirect) before this merges.

## Rationale

Most of these paths are the **kinds / CUE schema / code-generation system** the as-code team originally built. That responsibility has functionally moved to **`@grafana/grafana-app-platform-squad`**, which already owns the adjacent infrastructure: `pkg/apis/`, `apps/`, `pkg/modules/`, `pkg/registry/apis/`, `pkg/apiserver`, `hack/`, and `go.work`.

Two exceptions:
- **`/pkg/registry/backgroundsvcs/`** → `@grafana/grafana-backend-group` — background services are part of server bootstrap, and that group already owns `/pkg/server/`.
- **`/pkg/plugins/codegen/pfs/`** → just drop `grafana-as-code`; `@grafana/grafana-catalog` is already a co-owner.

## Proposed reassignments

| Path | Current owner | Proposed owner | Why |
|------|---------------|----------------|-----|
| `/devenv/docker/blocks/grafana/` | grafana-as-code | `@grafana/grafana-app-platform-squad` | Devenv docker block; app-platform owns the adjacent `etcd` block |
| `/pkg/plugins/codegen/pfs/` | grafana-catalog + grafana-as-code | `@grafana/grafana-catalog` | Plugin schema codegen; catalog is already a co-owner — drop as-code |
| `/scripts/clean-git-or-error.sh` | grafana-as-code | `@grafana/grafana-app-platform-squad` | Codegen pipeline helper script |
| `/scripts/stripnulls.sh` | grafana-as-code | `@grafana/grafana-app-platform-squad` | Codegen pipeline helper script |
| `/kinds/` | grafana-as-code | `@grafana/grafana-app-platform-squad` | Kind definitions (`/kinds/dashboard` stays with dashboards-squad) |
| `embed.go` | grafana-as-code | `@grafana/grafana-app-platform-squad` | Kind embedding |
| `/pkg/kinds/` | grafana-as-code | `@grafana/grafana-app-platform-squad` | Kind system |
| `/pkg/registry/` (catch-all) | grafana-as-code | `@grafana/grafana-app-platform-squad` | Service registry; app-platform owns `pkg/registry/apis/` & `pkg/modules/` |
| `/pkg/registry/backgroundsvcs/` *(new)* | — | `@grafana/grafana-backend-group` | Background services = server bootstrap; owns `/pkg/server/` |
| `/pkg/codegen/` | grafana-as-code | `@grafana/grafana-app-platform-squad` | CUE code generation |
| `/pkg/codegen/generators` | grafana-as-code | `@grafana/grafana-app-platform-squad` | CUE code generation |
| `/pkg/kinds/*/*_gen.go` | grafana-as-code | `@grafana/grafana-app-platform-squad` | Generated kind code |
| `/public/app/plugins/*gen.go` | grafana-as-code | `@grafana/grafana-app-platform-squad` | Generated plugin schema code (kinds pipeline) |
| `/cue.mod/` | grafana-as-code | `@grafana/grafana-app-platform-squad` | CUE module |

## Testing

- N/A — CODEOWNERS-only change. GitHub validates the file on push.

## Checklist

- [ ] `@grafana/grafana-app-platform-squad` confirms ownership of the kinds/codegen paths
- [ ] `@grafana/grafana-backend-group` confirms `/pkg/registry/backgroundsvcs/`
- [ ] `@grafana/grafana-catalog` ok with sole ownership of `/pkg/plugins/codegen/pfs/`
- [ ] No breaking changes

cc @grafana/grafana-app-platform-squad @grafana/grafana-backend-group @grafana/grafana-catalog @tolzhabayev

🤖 Generated with Claude Code