### PR TITLE
fix: handle virtual folders access

### DIFF
--- a/pkg/registry/apis/folders/sub_access.go
+++ b/pkg/registry/apis/folders/sub_access.go
@@ -13,6 +13,7 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/services/apiserver/endpoints/request"
+	"github.com/grafana/grafana/pkg/services/folder"
 )
 
 type subAccessREST struct {
@@ -148,6 +149,19 @@ func (r *subAccessREST) getAccessInfo(ctx context.Context, name string) (*folder
 		return nil, err
 	}
 
+	// sharedwithme is a virtual aggregation view with no RBAC scope and nothing
+	// to act on, so report no access instead of probing for a missing object.
+	if name == folder.SharedWithMeFolderUID {
+		return &foldersV1.FolderAccessInfo{}, nil
+	}
+
+	// The root folder has no stored object to Get and no parent. Normalise the
+	// legacy empty UID to "general" so authz resolves the folders:uid:general
+	// scope, matching legacy /api/folders/general?accesscontrol=true.
+	if folder.IsRootFolderUID(name) {
+		return r.checkAccess(ctx, ns.Value, user, folder.GeneralFolderUID, "")
+	}
+
 	f, err := r.getter.Get(ctx, name, &v1.GetOptions{})
 	if err != nil {
 		return nil, err
@@ -158,6 +172,13 @@ func (r *subAccessREST) getAccessInfo(ctx context.Context, name string) (*folder
 	}
 	parent := obj.GetFolder()
 
+	return r.checkAccess(ctx, ns.Value, user, name, parent)
+}
+
+// checkAccess runs the folder-tier probes for folder `name` (with `parent` as
+// the folder hint) and assembles the FolderAccessInfo, mirroring legacy
+// newToFolderDto in pkg/api/folder.go.
+func (r *subAccessREST) checkAccess(ctx context.Context, namespace string, user identity.Requester, name, parent string) (*foldersV1.FolderAccessInfo, error) {
 	checks := make([]authlib.BatchCheckItem, len(folderTierChecks))
 	for i, c := range folderTierChecks {
 		checks[i] = authlib.BatchCheckItem{
@@ -171,7 +192,7 @@ func (r *subAccessREST) getAccessInfo(ctx context.Context, name string) (*folder
 	}
 
 	batchResp, err := r.accessClient.BatchCheck(ctx, user, authlib.BatchCheckRequest{
-		Namespace: ns.Value,
+		Namespace: namespace,
 		Checks:    checks,
 	})
 	if err != nil {

--- a/pkg/registry/apis/folders/sub_access_test.go
+++ b/pkg/registry/apis/folders/sub_access_test.go
@@ -3,6 +3,7 @@ package folders
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
@@ -15,6 +16,7 @@ import (
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
 	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	grafanarest "github.com/grafana/grafana/pkg/apiserver/rest"
+	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/user"
 )
 
@@ -197,6 +199,78 @@ func TestSubAccessREST_getAccessInfo(t *testing.T) {
 				"AccessControl should match the legacy bundle for tier %d", tc.expectActionsTier)
 		})
 	}
+}
+
+func TestSubAccessREST_getAccessInfo_virtualFolders(t *testing.T) {
+	t.Run("root/general folder runs real access checks against the general scope without a Get", func(t *testing.T) {
+		// "general" and the legacy empty UID must both resolve to the general scope.
+		for _, name := range []string{folder.GeneralFolderUID, folder.LegacyRootFolderUID} {
+			t.Run("name="+strconv.Quote(name), func(t *testing.T) {
+				// Bare mock with no expectations: fails if Get is called.
+				store := grafanarest.NewMockStorage(t)
+
+				var gotChecks []authlib.BatchCheckItem
+				ac := &subAccessMockClient{
+					batchCheckFunc: func(_ context.Context, _ authlib.AuthInfo, req authlib.BatchCheckRequest) (authlib.BatchCheckResponse, error) {
+						gotChecks = req.Checks
+						results := make(map[string]authlib.BatchCheckResult, len(req.Checks))
+						for _, item := range req.Checks {
+							// Editor-like: update allowed, but not setPermissions.
+							results[item.CorrelationID] = authlib.BatchCheckResult{
+								Allowed: item.Verb == utils.VerbGet || item.Verb == utils.VerbUpdate,
+							}
+						}
+						return authlib.BatchCheckResponse{Results: results}, nil
+					},
+				}
+
+				r := &subAccessREST{getter: store, accessClient: ac}
+				ctx := request.WithNamespace(context.Background(), "default")
+				ctx = identity.WithRequester(ctx, &user.SignedInUser{UserID: 1, OrgID: 1})
+
+				got, err := r.getAccessInfo(ctx, name)
+				require.NoError(t, err)
+				require.NotNil(t, got)
+
+				// Legacy empty UID is normalised to "general".
+				require.Len(t, gotChecks, len(folderTierChecks))
+				for _, item := range gotChecks {
+					require.Equal(t, folder.GeneralFolderUID, item.Name, "root checks target the general scope")
+					require.Empty(t, item.Folder, "the root folder has no parent")
+				}
+
+				require.False(t, got.CanAdmin)
+				require.True(t, got.CanEdit)
+				require.True(t, got.CanSave)
+				require.False(t, got.CanDelete)
+				require.Equal(t, actionsForTier(tierEditor), got.AccessControl)
+			})
+		}
+	})
+
+	t.Run("sharedwithme folder reports no access without touching the getter or authz", func(t *testing.T) {
+		// Bare getter mock fails if Get is called; BatchCheck fails the test below.
+		store := grafanarest.NewMockStorage(t)
+		ac := &subAccessMockClient{
+			batchCheckFunc: func(_ context.Context, _ authlib.AuthInfo, _ authlib.BatchCheckRequest) (authlib.BatchCheckResponse, error) {
+				t.Fatal("BatchCheck must not be called for the sharedwithme folder")
+				return authlib.BatchCheckResponse{}, nil
+			},
+		}
+
+		r := &subAccessREST{getter: store, accessClient: ac}
+		ctx := request.WithNamespace(context.Background(), "default")
+		ctx = identity.WithRequester(ctx, &user.SignedInUser{UserID: 1, OrgID: 1})
+
+		got, err := r.getAccessInfo(ctx, folder.SharedWithMeFolderUID)
+		require.NoError(t, err)
+		require.NotNil(t, got)
+		require.False(t, got.CanAdmin)
+		require.False(t, got.CanEdit)
+		require.False(t, got.CanSave)
+		require.False(t, got.CanDelete)
+		require.Nil(t, got.AccessControl)
+	})
 }
 
 // subAccessMockClient is a minimal authlib.AccessClient used by subAccessREST tests.

--- a/pkg/registry/apis/folders/sub_access_test.go
+++ b/pkg/registry/apis/folders/sub_access_test.go
@@ -204,7 +204,7 @@ func TestSubAccessREST_getAccessInfo(t *testing.T) {
 func TestSubAccessREST_getAccessInfo_virtualFolders(t *testing.T) {
 	t.Run("root/general folder runs real access checks against the general scope without a Get", func(t *testing.T) {
 		// "general" and the legacy empty UID must both resolve to the general scope.
-		for _, name := range []string{folder.GeneralFolderUID, folder.LegacyRootFolderUID} {
+		for _, name := range []string{folder.GeneralFolderUID, folder.LegacyRootFolderUID} { //nolint:staticcheck // testing the deprecated legacy empty-string root UID is intentional
 			t.Run("name="+strconv.Quote(name), func(t *testing.T) {
 				// Bare mock with no expectations: fails if Get is called.
 				store := grafanarest.NewMockStorage(t)


### PR DESCRIPTION
Handle 2 virtual folder special cases which have specific access patterns.

1. `sharedwithme` which should return no `AccessControl` as per the legacy behavior.
2. `root` (with name `general` and parent `""` which is handled specifically on the authz side) reproducing the legacy `folders:uid:general` behavior.

Ticket: https://github.com/grafana/search-and-storage-team/issues/794

Related PR: https://github.com/grafana/grafana/pull/125642