### PR TITLE
Alerting: Guard null condition params on rule view

### DIFF
--- a/public/app/features/alerting/unified/GrafanaRuleQueryViewer.tsx
+++ b/public/app/features/alerting/unified/GrafanaRuleQueryViewer.tsx
@@ -345,6 +345,11 @@ function ClassicConditionViewer({ model }: { model: ExpressionQuery }) {
     <div className={styles.container}>
       {model.conditions?.map(({ query, operator, reducer, evaluator }, index) => {
         const isRange = isRangeEvaluator(evaluator);
+        const params = evaluator.params;
+        let thresholdDisplay = '';
+        if (params) {
+          thresholdDisplay = isRange ? `(${params[0]}; ${params[1]})` : String(params[0]);
+        }
 
         return (
           <React.Fragment key={index}>
@@ -357,11 +362,9 @@ function ClassicConditionViewer({ model }: { model: ExpressionQuery }) {
             <div className={styles.blue}>
               <Trans i18nKey="alerting.classic-condition-viewer.of">OF</Trans>
             </div>
-            <div className={styles.bold}>{query.params[0]}</div>
+            <div className={styles.bold}>{query.params?.[0]}</div>
             <div className={styles.blue}>{evalFunctions[evaluator.type].text}</div>
-            <div className={styles.bold}>
-              {isRange ? `(${evaluator.params[0]}; ${evaluator.params[1]})` : evaluator.params[0]}
-            </div>
+            <div className={styles.bold}>{thresholdDisplay}</div>
           </React.Fragment>
         );
       })}
@@ -486,7 +489,7 @@ function ThresholdExpressionViewer({ model }: { model: ExpressionQuery }) {
         </div>
         <div className={styles.value}>{expression}</div>
 
-        {evaluator && (
+        {evaluator?.params && (
           <>
             <div className={styles.blue}>{thresholdFunction?.label}</div>
             <div className={styles.bold}>
@@ -496,7 +499,7 @@ function ThresholdExpressionViewer({ model }: { model: ExpressionQuery }) {
         )}
       </div>
       <div className={styles.container}>
-        {unloadEvaluator && (
+        {unloadEvaluator?.params && (
           <>
             <div className={styles.label}>
               <Trans i18nKey="alerting.threshold-expression-viewer.stop-alerting-when">

--- a/public/app/features/alerting/unified/components/rule-editor/util.ts
+++ b/public/app/features/alerting/unified/components/rule-editor/util.ts
@@ -166,7 +166,7 @@ export function getThresholdsForQueries(queries: AlertQuery[], condition: string
       const threshold = condition.evaluator.params;
 
       // "classic_conditions" use `condition.query.params[]` and "threshold" uses `query.model.expression`
-      const refId = condition.query?.params[0] ?? query.model.expression;
+      const refId = condition.query?.params?.[0] ?? query.model.expression;
 
       // if an expression hasn't been linked to a data query yet, it won't have a refId
       if (!refId) {
@@ -203,8 +203,14 @@ export function getThresholdsForQueries(queries: AlertQuery[], condition: string
           }
 
           if (originRefID && hasValidOrigin && !isRangeThreshold && !hasRangeThreshold) {
+            if (threshold?.[0] === undefined) {
+              return;
+            }
             appendSingleThreshold(originRefID, threshold[0]);
           } else if (originRefID && hasValidOrigin && isRangeThreshold) {
+            if (!threshold) {
+              return;
+            }
             appendRangeThreshold(originRefID, threshold, condition.evaluator.type);
             thresholds[originRefID].mode = GraphThresholdsStyleMode.LineAndArea;
           }


### PR DESCRIPTION
## Summary

Some Grafana-managed alert rules with legacy classic or threshold expressions have `null` `evaluator.params` or `query.params`. Visiting `/alerting/grafana/<uid>/view` crashes with `Cannot read properties of null (reading '0')` because the Query tab dereferences `params[0]` directly.

This is the source of a recent spike in firing alerts on the `Alerting-frontend Errors` rule (page_id `/alerting/grafana/*/view`).

## Changes

- `getThresholdsForQueries` (`util.ts`):
  - Fix optional chaining: `condition.query?.params?.[0]` (was `condition.query?.params[0]`, which still throws when `params` is null)
  - Skip threshold overlay generation when `evaluator.params` is missing instead of pushing `undefined` into the steps array
- `GrafanaRuleQueryViewer.tsx`:
  - `ClassicConditionViewer`: guard `query.params` and `evaluator.params` when rendering
  - `ThresholdExpressionViewer`: only render evaluator/unloadEvaluator blocks when `params` is present

## Related

Crash signature from production:
- Page: `/alerting/grafana/*/view`
- Error: `TypeError: Cannot read properties of null (reading '0')` (Chrome) / `can't access property 0, V.display is null` (Firefox)