### PR TITLE
Provisioning: Add the Migrate to GitOps tab

### DIFF
--- a/public/app/features/provisioning/HomePage.test.tsx
+++ b/public/app/features/provisioning/HomePage.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen } from 'test/test-utils';
+
+import { config } from '@grafana/runtime';
+
+import HomePage from './HomePage';
+
+// Stub the per-tab content so the test stays focused on the tab wiring. The
+// Migrate tab is intentionally NOT mocked — we assert its real placeholder
+// renders when the tab is active.
+jest.mock('./Shared/RepositoryList', () => ({
+  RepositoryList: () => <div>repositories-content</div>,
+}));
+jest.mock('./GettingStarted/GettingStarted', () => ({
+  __esModule: true,
+  default: () => <div>getting-started-content</div>,
+}));
+jest.mock('./Connection/ConnectionsTabContent', () => ({
+  ConnectionsTabContent: () => <div>connections-content</div>,
+}));
+jest.mock('./Shared/ConnectRepositoryButton', () => ({
+  ConnectRepositoryButton: () => <div>connect-repository-button</div>,
+}));
+
+jest.mock('./hooks/useRepositoryList', () => ({
+  useRepositoryList: jest.fn(() => [[], false]),
+}));
+jest.mock('./hooks/useConnectionList', () => ({
+  useConnectionList: jest.fn(() => [[], false, undefined, jest.fn()]),
+}));
+jest.mock('app/api/clients/provisioning/v0alpha1', () => ({
+  useDeletecollectionRepositoryMutation: jest.fn(() => [jest.fn(), {}]),
+}));
+
+// Page resolves navId against the nav index; seed the provisioning node so it
+// renders its children instead of a "page not found" state.
+const preloadedState = {
+  navIndex: {
+    provisioning: { id: 'provisioning', text: 'Provisioning', url: '/admin/provisioning' },
+  },
+};
+
+function renderHomePage(initialEntry = '/admin/provisioning') {
+  return render(<HomePage />, {
+    preloadedState,
+    historyOptions: { initialEntries: [initialEntry] },
+  });
+}
+
+describe('Provisioning HomePage', () => {
+  afterEach(() => {
+    config.featureToggles.provisioningExport = false;
+  });
+
+  it('hides the Migrate to GitOps tab when the feature flag is off', () => {
+    config.featureToggles.provisioningExport = false;
+    renderHomePage();
+
+    expect(screen.queryByRole('tab', { name: /migrate to gitops/i })).not.toBeInTheDocument();
+  });
+
+  it('shows the Migrate to GitOps tab and renders the placeholder when the flag is on', async () => {
+    config.featureToggles.provisioningExport = true;
+    const { user } = renderHomePage();
+
+    const migrateTab = screen.getByRole('tab', { name: /migrate to gitops/i });
+    expect(migrateTab).toBeInTheDocument();
+
+    await user.click(migrateTab);
+
+    expect(screen.getByRole('heading', { name: /migrate to gitops/i })).toBeInTheDocument();
+    expect(screen.getByText(/^experimental$/i)).toBeInTheDocument();
+  });
+
+  it('opens directly on the Migrate placeholder when the URL targets it and the flag is on', () => {
+    config.featureToggles.provisioningExport = true;
+    renderHomePage('/admin/provisioning?tab=migrate');
+
+    expect(screen.getByRole('heading', { name: /migrate to gitops/i })).toBeInTheDocument();
+  });
+
+  it('falls back to the default tab when ?tab=migrate is set but the flag is off', () => {
+    config.featureToggles.provisioningExport = false;
+    renderHomePage('/admin/provisioning?tab=migrate');
+
+    // No repos/connections → default tab is Get started. The Migrate
+    // placeholder heading must not render.
+    expect(screen.getByText('getting-started-content')).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: /migrate to gitops/i })).not.toBeInTheDocument();
+  });
+});

--- a/public/app/features/provisioning/HomePage.tsx
+++ b/public/app/features/provisioning/HomePage.tsx
@@ -2,12 +2,14 @@ import { useMemo, useState } from 'react';
 import { useSearchParams } from 'react-router-dom-v5-compat';
 
 import { t, Trans } from '@grafana/i18n';
+import { config } from '@grafana/runtime';
 import { ConfirmModal, LinkButton, Stack, Tab, TabContent, TabsBar } from '@grafana/ui';
 import { useDeletecollectionRepositoryMutation } from 'app/api/clients/provisioning/v0alpha1';
 import { Page } from 'app/core/components/Page/Page';
 
 import { ConnectionsTabContent } from './Connection/ConnectionsTabContent';
 import GettingStarted from './GettingStarted/GettingStarted';
+import { Migrate } from './Migrate/Migrate';
 import { ConnectRepositoryButton } from './Shared/ConnectRepositoryButton';
 import { RepositoryList } from './Shared/RepositoryList';
 import { CONNECTIONS_URL } from './constants';
@@ -22,6 +24,7 @@ export default function HomePage() {
   const [searchParams, setSearchParams] = useSearchParams();
 
   const isLoading = isLoadingRepos || isLoadingConnections;
+  const isMigrateTabEnabled = !!config.featureToggles.provisioningExport;
 
   const urlTab = searchParams.get('tab');
   const defaultTab = useMemo(() => {
@@ -37,7 +40,10 @@ export default function HomePage() {
     return 'getting-started';
   }, [isLoading, items?.length, connections?.length]);
 
-  const activeTab = urlTab ?? defaultTab;
+  // If the URL points at the Migrate tab but the feature flag is off (e.g. a
+  // stale bookmark), fall back to the default tab so the bar, content, and
+  // action button stay in sync.
+  const activeTab = urlTab === 'migrate' && !isMigrateTabEnabled ? defaultTab : (urlTab ?? defaultTab);
 
   // Handler to update URL when tab changes
   const handleTabChange = (tab: string) => {
@@ -45,8 +51,8 @@ export default function HomePage() {
     setSearchParams(searchParams, { replace: true });
   };
 
-  const tabInfo = useMemo(
-    () => [
+  const tabInfo = useMemo(() => {
+    const tabs = [
       {
         value: 'repositories',
         label: t('provisioning.home-page.tab-repositories', 'Repositories'),
@@ -62,9 +68,18 @@ export default function HomePage() {
         label: t('provisioning.home-page.tab-getting-started', 'Get started'),
         title: t('provisioning.home-page.tab-getting-started-title', 'Get started'),
       },
-    ],
-    []
-  );
+    ];
+
+    if (isMigrateTabEnabled) {
+      tabs.push({
+        value: 'migrate',
+        label: t('provisioning.home-page.tab-migrate', 'Migrate to GitOps'),
+        title: t('provisioning.home-page.tab-migrate-title', 'Migrate to GitOps'),
+      });
+    }
+
+    return tabs;
+  }, [isMigrateTabEnabled]);
 
   const onConfirmDelete = () => {
     deleteAll({});
@@ -77,6 +92,8 @@ export default function HomePage() {
         return <ConnectionsTabContent items={connections ?? []} error={connectionsError} />;
       case 'getting-started':
         return <GettingStarted items={items ?? []} />;
+      case 'migrate':
+        return <Migrate />;
       case 'repositories':
       default:
         return <RepositoryList items={items ?? []} />;
@@ -92,6 +109,7 @@ export default function HomePage() {
           </LinkButton>
         );
       case 'getting-started':
+      case 'migrate':
         return null;
       case 'repositories':
       default:

--- a/public/app/features/provisioning/Migrate/Migrate.test.tsx
+++ b/public/app/features/provisioning/Migrate/Migrate.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from 'test/test-utils';
+
+import { Migrate } from './Migrate';
+
+describe('Migrate', () => {
+  it('renders the Migrate to GitOps heading with an experimental badge', () => {
+    render(<Migrate />);
+
+    expect(screen.getByRole('heading', { name: /migrate to gitops/i })).toBeInTheDocument();
+    expect(screen.getByText(/^experimental$/i)).toBeInTheDocument();
+  });
+
+  it('links to the provisioning documentation', () => {
+    render(<Migrate />);
+
+    const docsLink = screen.getByRole('link', { name: /provisioning documentation/i });
+    expect(docsLink).toHaveAttribute('href', expect.stringContaining('grafana.com/docs'));
+  });
+});

--- a/public/app/features/provisioning/Migrate/Migrate.tsx
+++ b/public/app/features/provisioning/Migrate/Migrate.tsx
@@ -1,0 +1,57 @@
+import { css } from '@emotion/css';
+
+import { FeatureState, type GrafanaTheme2 } from '@grafana/data';
+import { Trans } from '@grafana/i18n';
+import { FeatureBadge, Stack, Text, TextLink, useStyles2 } from '@grafana/ui';
+
+import { CONFIGURE_GRAFANA_DOCS_URL } from '../constants';
+
+/**
+ * Migrate to GitOps tab. This is the entry point for moving existing folders
+ * and dashboards into a Git repository. The interactive migration workflow
+ * (folder leaderboard, quick wins, the migrate drawer) lands in follow-up
+ * changes — for now the tab introduces the feature and links to the guide.
+ */
+export function Migrate() {
+  const styles = useStyles2(getStyles);
+
+  return (
+    <Stack direction="column" gap={2}>
+      <Stack direction="column" gap={1}>
+        <Stack direction="row" gap={1} alignItems="center">
+          <Text element="h2" variant="h2">
+            <Trans i18nKey="provisioning.migrate.header-title">Migrate to GitOps</Trans>
+          </Text>
+          <FeatureBadge featureState={FeatureState.experimental} />
+        </Stack>
+        <Text color="secondary">
+          <Trans i18nKey="provisioning.migrate.header-subtitle">
+            Manage your dashboards and folders like code — every change tracked, every update reviewed, every
+            environment reproducible. Connect a Git repository to get started.
+          </Trans>
+        </Text>
+      </Stack>
+
+      <div className={styles.intro}>
+        <Text color="secondary">
+          <Trans i18nKey="provisioning.migrate.intro">
+            The guided migration workflow is on its way. In the meantime, read the{' '}
+            <TextLink external href={CONFIGURE_GRAFANA_DOCS_URL}>
+              provisioning documentation
+            </TextLink>{' '}
+            to learn how Git Sync keeps Grafana and your repository in step.
+          </Trans>
+        </Text>
+      </div>
+    </Stack>
+  );
+}
+
+const getStyles = (theme: GrafanaTheme2) => ({
+  intro: css({
+    padding: theme.spacing(2),
+    borderRadius: theme.shape.radius.default,
+    border: `1px solid ${theme.colors.border.weak}`,
+    background: theme.colors.background.secondary,
+  }),
+});

--- a/public/app/features/provisioning/constants.ts
+++ b/public/app/features/provisioning/constants.ts
@@ -2,6 +2,7 @@ export const PROVISIONING_URL = '/admin/provisioning';
 export const PROVISIONING_PREVIEW_URL = '/dashboard/provisioning';
 export const CONNECTIONS_URL = `${PROVISIONING_URL}/connections`;
 export const CONNECTIONS_TAB_URL = `${PROVISIONING_URL}?tab=connections`;
+export const MIGRATE_TAB_URL = `${PROVISIONING_URL}?tab=migrate`;
 export const CONNECT_URL = `${PROVISIONING_URL}/connect`;
 export const GETTING_STARTED_URL = `${PROVISIONING_URL}/getting-started`;
 export const UPGRADE_URL = 'https://grafana.com/profile/org/subscription';

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13589,6 +13589,8 @@
       "tab-connections-title": "List of connections",
       "tab-getting-started": "Get started",
       "tab-getting-started-title": "Get started",
+      "tab-migrate": "Migrate to GitOps",
+      "tab-migrate-title": "Migrate to GitOps",
       "tab-repositories": "Repositories",
       "tab-repositories-title": "List of repositories",
       "title-delete-all-configured-repositories": "Delete all configured repositories"
@@ -13646,6 +13648,11 @@
       "show-less": "show less",
       "show-more": "show more",
       "truncated": "Message truncated"
+    },
+    "migrate": {
+      "header-subtitle": "Manage your dashboards and folders like code — every change tracked, every update reviewed, every environment reproducible. Connect a Git repository to get started.",
+      "header-title": "Migrate to GitOps",
+      "intro": "The guided migration workflow is on its way. In the meantime, read the <2>provisioning documentation</2> to learn how Git Sync keeps Grafana and your repository in step."
     },
     "missing-folder-metadata-banner": {
       "error-message": "Could not verify whether this folder has a metadata file. Please try again later.",


### PR DESCRIPTION
## Summary

First slice of the **Migrate to GitOps** work (splitting #123878 into reviewable pieces). This PR adds just the tab scaffolding.

- Adds a **Migrate to GitOps** tab to the provisioning admin page (`/admin/provisioning`), gated behind the experimental `provisioningExport` feature flag.
- When the flag is off the tab is hidden; a stale `?tab=migrate` bookmark falls back to the default tab so the bar, content, and action button stay in sync.
- The tab renders a placeholder that introduces the feature and links to the provisioning docs.

This is intentionally minimal — the interactive migration workflow and the nav-tree / command-palette integration land in follow-up PRs.


<img width="1395" height="603" alt="image" src="https://github.com/user-attachments/assets/c47d3111-d116-45c8-ad79-e5bfbe58e2f4" />


## What's in scope

- `HomePage.tsx` — feature-flag-gated tab wiring + `activeTab` normalization.
- `Migrate/Migrate.tsx` — placeholder page (header, experimental badge, intro + docs link).
- `constants.ts` — `MIGRATE_TAB_URL`.
- `Migrate/Migrate.test.tsx` — renders the heading, the experimental badge, and the docs link.
- i18n keys under `provisioning.migrate.*` and `provisioning.home-page.tab-migrate*`.

## Out of scope (follow-up PRs)

- Backend nav-tree child node for breadcrumbs + command palette (Go change, deployed separately).
- The folder leaderboard hook and KPI survey.
- Quick wins and the foldable "Dashboards to migrate" list.
- The Migrate drawer (migrate / push jobs).

## Test plan

- [ ] `yarn jest --no-watch public/app/features/provisioning/Migrate/` passes.
- [ ] `yarn typecheck`, `yarn run -T eslint public/app/features/provisioning/`, `yarn i18n-extract` clean.
- [ ] With `provisioningExport` enabled, `/admin/provisioning` shows the Migrate to GitOps tab and it renders the placeholder.
- [ ] With the flag disabled, the tab is hidden and `?tab=migrate` falls back to the default tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)