### PR TITLE
Community notifications: onboard frontend-navigation team

### DIFF
--- a/.github/team-notifications-config.json
+++ b/.github/team-notifications-config.json
@@ -45,6 +45,21 @@
         "fr_notify": true,
         "fr_weekly": true
       }
+    },
+    {
+      "name": "frontend-navigation",
+      "kickoff_date": "2026-05-29",
+      "adoption_date": "2025-05-29",
+      "codeowners_teams": [
+        "@grafana/grafana-frontend-navigation"
+      ],
+      "area_labels": ["area/navigation", "area/search", "area/frontend/login", "area/panel/dashboard-list"],
+      "enabled": {
+        "pr_notify": true,
+        "pr_weekly": true,
+        "fr_notify": true,
+        "fr_weekly": true
+      }
     }
   ]
 }


### PR DESCRIPTION
## Summary

Onboards the Frontend Navigation team (`@grafana/grafana-frontend-navigation`) to the community notifications system. All four notification types are enabled (PR real-time + weekly digest, FR real-time + weekly digest).

- Area labels: `area/navigation`, `area/search`, `area/frontend/login`, `area/panel/dashboard-list`
- Adoption date set to 1 year before kickoff so the first weekly digest catches older items.

## Test plan

- [ ] CI passes
- [ ] After merge, vault admin adds the `frontend-navigation` channel mapping (handled in #proj-community-contributions)
- [ ] Bot is invited to the team Slack channel before the first scheduled run