### PR TITLE
ShortURL: Fix unchecked type assertions

### DIFF
--- a/pkg/api/short_url.go
+++ b/pkg/api/short_url.go
@@ -157,7 +157,13 @@ func (sk8s *shortURLK8sHandler) getKubernetesShortURLsHandler(c *contextmodel.Re
 		return
 	}
 
-	c.JSON(http.StatusOK, shorturl.UnstructuredToLegacyShortURL(*out))
+	legacyShortURL, err := shorturl.UnstructuredToLegacyShortURL(*out)
+	if err != nil {
+		sk8s.writeError(c, err)
+		return
+	}
+
+	c.JSON(http.StatusOK, legacyShortURL)
 }
 
 func (sk8s *shortURLK8sHandler) getKubernetesRedirectFromShortURL(c *contextmodel.ReqContext) {

--- a/pkg/registry/apps/shorturl/conversions.go
+++ b/pkg/registry/apps/shorturl/conversions.go
@@ -64,13 +64,30 @@ func UnstructuredToLegacyShortURLDTO(item unstructured.Unstructured, appURL stri
 	}
 }
 
-func UnstructuredToLegacyShortURL(item unstructured.Unstructured) *shorturls.ShortUrl {
-	spec := item.Object["spec"].(map[string]interface{})
-	status := item.Object["status"].(map[string]interface{})
+func UnstructuredToLegacyShortURL(item unstructured.Unstructured) (*shorturls.ShortUrl, error) {
+	path, found, err := unstructured.NestedString(item.Object, "spec", "path")
+	if err != nil {
+		return nil, fmt.Errorf("shorturl %q: invalid spec.path: %w", item.GetName(), err)
+	}
+	if !found {
+		return nil, fmt.Errorf("shorturl %q: missing spec.path", item.GetName())
+	}
+
+	// lastSeenAt is optional. Numbers in an Unstructured may be decoded as either int64
+	// (k8s codec) or float64 (plain JSON unmarshal), so accept both rather than asserting
+	// a single concrete type.
+	lastSeen, found, err := unstructured.NestedNumberAsFloat64(item.Object, "status", "lastSeenAt")
+	if err != nil {
+		return nil, fmt.Errorf("shorturl %q: invalid status.lastSeenAt: %w", item.GetName(), err)
+	}
+	var lastSeenAt int64
+	if found {
+		lastSeenAt = int64(lastSeen)
+	}
 
 	return &shorturls.ShortUrl{
 		Uid:        item.GetName(),
-		Path:       spec["path"].(string),
-		LastSeenAt: status["lastSeenAt"].(int64),
-	}
+		Path:       path,
+		LastSeenAt: lastSeenAt,
+	}, nil
 }

--- a/pkg/registry/apps/shorturl/conversions_test.go
+++ b/pkg/registry/apps/shorturl/conversions_test.go
@@ -1,0 +1,126 @@
+package shorturl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/grafana/grafana/pkg/services/shorturls"
+)
+
+func TestUnstructuredToLegacyShortURL(t *testing.T) {
+	tests := []struct {
+		name        string
+		object      map[string]interface{}
+		expectedUID string
+		expectPath  string
+		expectSeen  int64
+		expectErr   bool
+	}{
+		{
+			name: "lastSeenAt as int64 (k8s codec path)",
+			object: map[string]interface{}{
+				"metadata": map[string]interface{}{"name": "abc123"},
+				"spec":     map[string]interface{}{"path": "d/foo/bar"},
+				"status":   map[string]interface{}{"lastSeenAt": int64(1700000000)},
+			},
+			expectedUID: "abc123",
+			expectPath:  "d/foo/bar",
+			expectSeen:  1700000000,
+		},
+		{
+			name: "lastSeenAt as float64 (JSON unmarshal path)",
+			object: map[string]interface{}{
+				"metadata": map[string]interface{}{"name": "abc123"},
+				"spec":     map[string]interface{}{"path": "d/foo/bar"},
+				"status":   map[string]interface{}{"lastSeenAt": float64(1700000000)},
+			},
+			expectedUID: "abc123",
+			expectPath:  "d/foo/bar",
+			expectSeen:  1700000000,
+		},
+		{
+			name: "missing status defaults lastSeenAt to 0",
+			object: map[string]interface{}{
+				"metadata": map[string]interface{}{"name": "abc123"},
+				"spec":     map[string]interface{}{"path": "d/foo/bar"},
+			},
+			expectedUID: "abc123",
+			expectPath:  "d/foo/bar",
+			expectSeen:  0,
+		},
+		{
+			name: "missing lastSeenAt defaults to 0",
+			object: map[string]interface{}{
+				"metadata": map[string]interface{}{"name": "abc123"},
+				"spec":     map[string]interface{}{"path": "d/foo/bar"},
+				"status":   map[string]interface{}{},
+			},
+			expectedUID: "abc123",
+			expectPath:  "d/foo/bar",
+			expectSeen:  0,
+		},
+		{
+			name: "missing spec returns error",
+			object: map[string]interface{}{
+				"metadata": map[string]interface{}{"name": "abc123"},
+				"status":   map[string]interface{}{"lastSeenAt": int64(1700000000)},
+			},
+			expectErr: true,
+		},
+		{
+			name: "missing spec.path returns error",
+			object: map[string]interface{}{
+				"metadata": map[string]interface{}{"name": "abc123"},
+				"spec":     map[string]interface{}{},
+			},
+			expectErr: true,
+		},
+		{
+			name: "non-string spec.path returns error",
+			object: map[string]interface{}{
+				"metadata": map[string]interface{}{"name": "abc123"},
+				"spec":     map[string]interface{}{"path": 42},
+			},
+			expectErr: true,
+		},
+		{
+			name: "wrong-type lastSeenAt returns error",
+			object: map[string]interface{}{
+				"metadata": map[string]interface{}{"name": "abc123"},
+				"spec":     map[string]interface{}{"path": "d/foo/bar"},
+				"status":   map[string]interface{}{"lastSeenAt": "not-a-number"},
+			},
+			expectErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			item := unstructured.Unstructured{Object: tc.object}
+
+			// require.NotPanics guards the original bug: conversion must never panic,
+			// even when fields are missing or have unexpected types.
+			var (
+				result *shorturls.ShortUrl
+				err    error
+			)
+			require.NotPanics(t, func() {
+				result, err = UnstructuredToLegacyShortURL(item)
+			})
+
+			if tc.expectErr {
+				require.Error(t, err)
+				require.Nil(t, result)
+				return
+			}
+
+			require.NoError(t, err)
+			require.NotNil(t, result)
+			require.Equal(t, tc.expectedUID, result.Uid)
+			require.Equal(t, tc.expectPath, result.Path)
+			require.Equal(t, tc.expectSeen, result.LastSeenAt)
+		})
+	}
+}


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
1. pkg/registry/apps/shorturl/conversions.go — UnstructuredToLegacyShortURL now returns (*shorturls.ShortUrl, error) and uses safe accessors instead of panicking assertions:
  - spec.path via unstructured.NestedString — required, errors if missing or non-string.
  - status.lastSeenAt via unstructured.NestedNumberAsFloat64, which accepts both int64 and float64 (the round-trip mismatch the finding flagged) — then cast to int64. Absent status/lastSeenAt defaults to 0; only a present-but-wrong-type value errors.

  2. pkg/api/short_url.go:160 — the lone caller now checks the error and routes it through writeError (clean 500 via errhttp.Write) instead of feeding a panic-prone call straight into the JSON response.

  3. pkg/registry/apps/shorturl/conversions_test.go — new table-driven test covering int64 success, the float64 regression case, missing/empty status (→0), and the four error paths (missing spec, missing path, non-string path, non-numeric lastSeenAt). Each case is wrapped in require.NotPanics to lock in that the function never panics again.

**Why do we need this feature?**
To avoid backend issues

**Who is this feature for?**
Shorturl users

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
