### PR TITLE
RBAC/Docs: Make it more clear that query permissions implies read

### DIFF
--- a/docs/sources/administration/roles-and-permissions/access-control/rbac-grafana-provisioning/index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/rbac-grafana-provisioning/index.md
@@ -120,6 +120,7 @@ roles:
       - action: 'users:write'
         scope: 'users:*'
       - action: 'users:create'
+      # NOTE: the `datasources:query` action implies `datasources:read`
       # Optional `datasourceType` for scopes `datasources:uid:<DATASOURCE_UID>`.
       # If you omit it, Grafana resolves the plugin type from the data source when this file is provisioned.
       # It is required if there are two datasources with the same uid.

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/datasource_permissions.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/datasource_permissions.md
@@ -178,7 +178,7 @@ Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
 }
 ```
 
-When granting "Query" permission, The subject also has read access to the datasource.
+When granting "Query" permission, The subject also has read access to the data source.
 
 **Example response:**
 

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/datasource_permissions.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/datasource_permissions.md
@@ -178,7 +178,7 @@ Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
 }
 ```
 
-When granting "Query" permission, The subject also has read access to the data source.
+When granting a `Query` permission, the user also has read access to the data source.
 
 **Example response:**
 
@@ -231,7 +231,7 @@ Append `?ds_type=<TYPE>` when you need to disambiguate the UID; refer to [Option
 To add a permission, set the `permission` field to either `Query`, `Edit`, or `Admin`.
 To remove a permission, set the `permission` field to an empty string.
 
-When adding `Query`, `Edit`, or `Admin`, the subject implicitly has `Read` access.
+When adding `Query`, `Edit`, or `Admin` permissions, the user implicitly has `Read` access.
 
 **Required permissions**
 

--- a/docs/sources/developer-resources/api-reference/http-api/api-legacy/datasource_permissions.md
+++ b/docs/sources/developer-resources/api-reference/http-api/api-legacy/datasource_permissions.md
@@ -39,7 +39,7 @@ Permissions can be set for a user, team, service account or a basic role (Admin,
 
 ### Optional `ds_type` query parameter {#ds-type}
 
-Every endpoint in this API accepts an optional query parameter `ds_type`. Set it to the data source **plugin type** (for example `prometheus` or `loki`). Use `ds_type` when more than one data source in the organization shares the same UID so Grafana can resolve the correct instance. If the UID is unique in the organization, you can omit `ds_type`.
+Every endpoint in this API accepts an optional query parameter `ds_type`. Set it to the data source **plugin type** (for example `prometheus` or `loki`). Use `ds_type` when more than one data source in the organization shares the same UID so Grafana can resolve the correct instance.
 
 ## Get permissions for a data source
 
@@ -178,6 +178,8 @@ Authorization: Bearer eyJrIjoiT0tTcG1pUlY2RnVKZTFVaDFsNFZXdE9ZWmNrMkZYbk
 }
 ```
 
+When granting "Query" permission, The subject also has read access to the datasource.
+
 **Example response:**
 
 ```http
@@ -228,6 +230,8 @@ Append `?ds_type=<TYPE>` when you need to disambiguate the UID; refer to [Option
 
 To add a permission, set the `permission` field to either `Query`, `Edit`, or `Admin`.
 To remove a permission, set the `permission` field to an empty string.
+
+When adding `Query`, `Edit`, or `Admin`, the subject implicitly has `Read` access.
 
 **Required permissions**
 


### PR DESCRIPTION
When you grant the `datasources:query` permission, it also allows `datasources:read` -- we should make this more clear in the docs