### PR TITLE
Testinfra: pass live gRPC listener through to avoid port re-bind race

### DIFF
--- a/pkg/services/grpcserver/service.go
+++ b/pkg/services/grpcserver/service.go
@@ -43,19 +43,24 @@ type gPRCServerService struct {
 	enabled          bool
 	startedChan      chan struct{}
 	separateShutdown bool
+	// listener, when non-nil, is served instead of dialing cfg.Address at start
+	// time. Used by tests to pass a pre-bound listener through, avoiding a
+	// close/re-bind race on the reserved port.
+	listener net.Listener
 }
 
 func ProvideService(cfg *setting.Cfg, authenticator interceptors.Authenticator, tracer trace.Tracer, registerer prometheus.Registerer) (Provider, error) {
-	return provideService(cfg, authenticator, tracer, registerer, false)
+	return provideService(cfg, authenticator, tracer, registerer, false, nil)
 }
 
-func provideService(cfg *setting.Cfg, authenticator interceptors.Authenticator, tracer trace.Tracer, registerer prometheus.Registerer, separateShutdown bool) (*gPRCServerService, error) {
+func provideService(cfg *setting.Cfg, authenticator interceptors.Authenticator, tracer trace.Tracer, registerer prometheus.Registerer, separateShutdown bool, listener net.Listener) (*gPRCServerService, error) {
 	s := &gPRCServerService{
 		cfg:              cfg.GRPCServer,
 		logger:           log.New("grpc-server"),
 		enabled:          cfg.GRPCServer.Enabled,
 		startedChan:      make(chan struct{}),
 		separateShutdown: separateShutdown,
+		listener:         listener,
 	}
 
 	// Register the metric here instead of an init() function so that we do
@@ -155,9 +160,13 @@ func (s *gPRCServerService) Run(ctx context.Context) error {
 		"keepalive_timeout", s.cfg.KeepaliveTimeout,
 		"keepalive_min_time", s.cfg.KeepaliveMinTime)
 
-	listener, err := net.Listen(s.cfg.Network, s.cfg.Address)
-	if err != nil {
-		return fmt.Errorf("GRPC server: failed to listen: %w", err)
+	listener := s.listener
+	if listener == nil {
+		var err error
+		listener, err = net.Listen(s.cfg.Network, s.cfg.Address)
+		if err != nil {
+			return fmt.Errorf("GRPC server: failed to listen: %w", err)
+		}
 	}
 
 	s.address = listener.Addr().String()
@@ -231,12 +240,28 @@ func ProvideDSKitService(
 	registerer prometheus.Registerer,
 	serviceName string,
 ) (*DSKitService, error) {
+	return ProvideDSKitServiceWithListener(cfg, tracer, registerer, serviceName, nil)
+}
+
+// ProvideDSKitServiceWithListener is like ProvideDSKitService but serves the
+// gRPC server on a caller-supplied listener instead of dialing cfg.Address at
+// start time. Tests use this to reserve an ephemeral port and pass the live
+// listener straight through, avoiding a close/re-bind race where a parallel
+// process could claim the port in between. A nil listener falls back to the
+// configured address.
+func ProvideDSKitServiceWithListener(
+	cfg *setting.Cfg,
+	tracer trace.Tracer,
+	registerer prometheus.Registerer,
+	serviceName string,
+	listener net.Listener,
+) (*DSKitService, error) {
 	// Use a passthrough authenticator so the grpc_auth interceptor is
 	// registered. This enables per-service auth via ServiceAuthFuncOverride.
 	passthrough := interceptors.AuthenticatorFunc(func(ctx context.Context) (context.Context, error) {
 		return ctx, nil
 	})
-	grpcService, err := provideService(cfg, passthrough, tracer, registerer, true)
+	grpcService, err := provideService(cfg, passthrough, tracer, registerer, true, listener)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/services/grpcserver/service_test.go
+++ b/pkg/services/grpcserver/service_test.go
@@ -2,6 +2,7 @@ package grpcserver
 
 import (
 	"context"
+	"net"
 	"testing"
 	"time"
 
@@ -502,4 +503,49 @@ func BenchmarkGracefulShutdown(b *testing.B) {
 		cancel()
 		<-serverDone
 	}
+}
+
+func TestRunUsesProvidedListener(t *testing.T) {
+	// Reserve a port and hand the live listener to the server, mirroring how the
+	// integration test harness avoids a close/re-bind race on the reserved port.
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	reservedAddr := listener.Addr().String()
+
+	service := &gPRCServerService{
+		cfg: setting.GRPCServerSettings{
+			Network:                 "tcp",
+			Address:                 "127.0.0.1:0",
+			GracefulShutdownTimeout: 5 * time.Second,
+		},
+		logger:      log.NewNopLogger(),
+		enabled:     true,
+		startedChan: make(chan struct{}),
+		server:      grpc.NewServer(),
+		listener:    listener,
+	}
+	grpc_health_v1.RegisterHealthServer(service.server, &testHealthServer{})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	serverDone := make(chan error, 1)
+	go func() {
+		serverDone <- service.Run(ctx)
+	}()
+
+	<-service.startedChan
+
+	// The server must serve on the reserved listener, not dial cfg.Address.
+	assert.Equal(t, reservedAddr, service.GetAddress())
+
+	conn, err := grpc.NewClient(reservedAddr, grpc.WithTransportCredentials(insecure.NewCredentials()))
+	require.NoError(t, err)
+	defer func() { _ = conn.Close() }()
+
+	_, err = grpc_health_v1.NewHealthClient(conn).Check(context.Background(), &grpc_health_v1.HealthCheckRequest{})
+	require.NoError(t, err)
+
+	cancel()
+	require.NoError(t, <-serverDone)
 }

--- a/pkg/tests/testinfra/testinfra.go
+++ b/pkg/tests/testinfra/testinfra.go
@@ -101,22 +101,22 @@ func StartGrafanaEnvWithManualCleanup(t *testing.T, grafDir, cfgPath string) (st
 
 	// Potentially allocate a real gRPC port for unified storage
 	runstore := false
+	var grpcListener net.Listener
 	unistore, _ := cfg.Raw.GetSection("grafana-apiserver")
 	if unistore != nil &&
 		unistore.Key("storage_type").MustString("") == string(options.StorageTypeUnifiedGrpc) &&
 		unistore.Key("address").String() == "" {
-		// Allocate a new address
-		listener2, err := net.Listen("tcp", "127.0.0.1:0")
+		// Reserve an ephemeral port and keep the listener open. We hand it
+		// straight to the gRPC server below instead of closing it and dialing
+		// the address again at startup, which left a window for a parallel
+		// process to claim the port and flake the test.
+		grpcListener, err = net.Listen("tcp", "127.0.0.1:0")
 		require.NoError(t, err)
 
 		cfg.GRPCServer.Network = "tcp"
-		cfg.GRPCServer.Address = listener2.Addr().String()
+		cfg.GRPCServer.Address = grpcListener.Addr().String()
 		cfg.GRPCServer.TLSConfig = nil
 		_, err = unistore.NewKey("address", cfg.GRPCServer.Address)
-		require.NoError(t, err)
-
-		// release the one we just discovered -- it will be used by the services on startup
-		err = listener2.Close()
 		require.NoError(t, err)
 		runstore = true
 	}
@@ -166,7 +166,7 @@ func StartGrafanaEnvWithManualCleanup(t *testing.T, grafDir, cfgPath string) (st
 	var grpcService *grpcserver.DSKitService
 	if runstore {
 		tracer := otel.Tracer("test-grpc-server")
-		grpcService, err = grpcserver.ProvideDSKitService(env.Cfg, tracer, prometheus.NewPedanticRegistry(), "test-grpc-server")
+		grpcService, err = grpcserver.ProvideDSKitServiceWithListener(env.Cfg, tracer, prometheus.NewPedanticRegistry(), "test-grpc-server", grpcListener)
 		require.NoError(t, err)
 
 		registerer := prometheus.NewPedanticRegistry()


### PR DESCRIPTION
🤷🏻  maybe this helps?    I asked the robots what could help with flakeyness at startup

## What

When an integration test uses `unified-grpc` storage, the shared test harness reserved an ephemeral port by opening a listener, recording its address, then **closing it** and re-binding the same address when the gRPC server started later. Under parallel CI load a different process could claim the port in that window, producing an intermittent `failed to listen` failure.

This keeps the reserved listener open and hands it straight to the gRPC server, so the port can never be claimed by anyone else between reservation and serving.

## Why this shape

The address must be known before `InitializeForTest` (the unified-storage client is wired there, before the gRPC server starts), which is why the harness pre-reserved a port in the first place. Closing and re-binding was the original workaround; passing the live listener through removes the race entirely.

## Changes

- `pkg/services/grpcserver/service.go` — `gPRCServerService` gains an optional `listener`; `Run` serves it when set and otherwise falls back to `net.Listen` (production behavior unchanged). Added `ProvideDSKitServiceWithListener` as an **additive** constructor so the production `ProvideDSKitService` signature is untouched.
- `pkg/tests/testinfra/testinfra.go` — keep the reserved listener open and pass it through.
- `pkg/services/grpcserver/service_test.go` — `TestRunUsesProvidedListener` covers the injected-listener path (no harness test currently exercises `unified-grpc`, so it would otherwise be uncovered).

## Testing

- `go test ./pkg/services/grpcserver/...` passes, including the new test
- `go vet` clean on both packages