### PR TITLE
Alerting: Support managed Prometheus data sources in rule conversion

### DIFF
--- a/pkg/services/ngalert/prom/convert.go
+++ b/pkg/services/ngalert/prom/convert.go
@@ -28,13 +28,26 @@ const (
 var (
 	ErrInvalidDatasourceType = errutil.ValidationFailed(
 		"alerting.invalidDatasourceType",
-		errutil.WithPublicMessage("Datasource type must be Prometheus or Loki to import rules."),
+		errutil.WithPublicMessage("Datasource type must be Prometheus-compatible or Loki to import rules."),
 	)
 	ErrInvalidTargetDatasourceType = errutil.ValidationFailed(
 		"alerting.invalidTargetDatasourceType",
-		errutil.WithPublicMessage("Target datasource type must be Prometheus for recording rules."),
+		errutil.WithPublicMessage("Target datasource type must be Prometheus-compatible for recording rules."),
 	)
 )
+
+func isPrometheusCompatibleDatasourceType(datasourceType string) bool {
+	switch datasourceType {
+	case datasources.DS_PROMETHEUS, datasources.DS_AMAZON_PROMETHEUS, datasources.DS_AZURE_PROMETHEUS:
+		return true
+	default:
+		return false
+	}
+}
+
+func isConvertibleDatasourceType(datasourceType string) bool {
+	return datasourceType == datasources.DS_LOKI || isPrometheusCompatibleDatasourceType(datasourceType)
+}
 
 // Config defines the configuration options for the Prometheus to Grafana rules converter.
 type Config struct {
@@ -118,8 +131,8 @@ func NewConverter(cfg Config) (*Converter, error) {
 	if cfg.KeepOriginalRuleDefinition == nil {
 		cfg.KeepOriginalRuleDefinition = defaultConfig.KeepOriginalRuleDefinition
 	}
-	if cfg.DatasourceType != datasources.DS_PROMETHEUS && cfg.DatasourceType != datasources.DS_LOKI {
-		return nil, ErrInvalidDatasourceType.Errorf("invalid datasource type: %s, must be prometheus or loki", cfg.DatasourceType)
+	if !isConvertibleDatasourceType(cfg.DatasourceType) {
+		return nil, ErrInvalidDatasourceType.Errorf("invalid datasource type: %s, must be prometheus-compatible or loki", cfg.DatasourceType)
 	}
 
 	return &Converter{
@@ -218,8 +231,8 @@ func (p *Converter) convertRule(orgID int64, namespaceUID string, promGroup Prom
 	}
 
 	if isRecordingRule {
-		if p.cfg.TargetDatasourceType != datasources.DS_PROMETHEUS {
-			return models.AlertRule{}, ErrInvalidTargetDatasourceType.Errorf("invalid target datasource type: %s, must be prometheus", p.cfg.TargetDatasourceType)
+		if !isPrometheusCompatibleDatasourceType(p.cfg.TargetDatasourceType) {
+			return models.AlertRule{}, ErrInvalidTargetDatasourceType.Errorf("invalid target datasource type: %s, must be prometheus-compatible", p.cfg.TargetDatasourceType)
 		}
 
 		record = &models.Record{

--- a/pkg/services/ngalert/prom/convert_test.go
+++ b/pkg/services/ngalert/prom/convert_test.go
@@ -78,7 +78,7 @@ func TestPrometheusRulesToGrafana(t *testing.T) {
 			expectError: false,
 		},
 		{
-			// If the rule group has recording rules and a non-prometheus target datasource,
+			// If the rule group has recording rules and a non-prometheus-compatible target datasource,
 			// we should return an error
 			name:      "recording rules with non-prometheus target datasource",
 			orgID:     1,
@@ -98,10 +98,10 @@ func TestPrometheusRulesToGrafana(t *testing.T) {
 				TargetDatasourceType: "non-prometheus-datasource",
 			},
 			expectError: true,
-			errorMsg:    "invalid target datasource type: non-prometheus-datasource, must be prometheus",
+			errorMsg:    "invalid target datasource type: non-prometheus-datasource, must be prometheus-compatible",
 		},
 		{
-			// If the rule group has recording rules and a non-prometheus target datasource,
+			// If the rule group has recording rules and a non-prometheus-compatible target datasource,
 			// we should return an error
 			name:      "mixed group with both alert and recording rules requires prometheus target datasource",
 			orgID:     1,
@@ -125,7 +125,7 @@ func TestPrometheusRulesToGrafana(t *testing.T) {
 				TargetDatasourceType: "non-prometheus-datasource",
 			},
 			expectError: true,
-			errorMsg:    "invalid target datasource type: non-prometheus-datasource, must be prometheus",
+			errorMsg:    "invalid target datasource type: non-prometheus-datasource, must be prometheus-compatible",
 		},
 		{
 			name:      "rule group with empty interval",
@@ -377,6 +377,112 @@ func TestPrometheusRulesToGrafana(t *testing.T) {
 				require.NoError(t, err)
 				require.Equal(t, string(originalRuleDefinition), grafanaRule.Metadata.PrometheusStyleRule.OriginalRuleDefinition)
 			}
+		})
+	}
+}
+
+func TestPrometheusRulesToGrafana_PrometheusCompatibleDatasources(t *testing.T) {
+	promGroup := PrometheusRuleGroup{
+		Name: "test-group",
+		Rules: []PrometheusRule{
+			{
+				Alert: "alert-1",
+				Expr:  "up == 0",
+			},
+		},
+	}
+
+	testCases := []struct {
+		name           string
+		datasourceType string
+	}{
+		{
+			name:           "amazon managed prometheus",
+			datasourceType: datasources.DS_AMAZON_PROMETHEUS,
+		},
+		{
+			name:           "azure managed prometheus",
+			datasourceType: datasources.DS_AZURE_PROMETHEUS,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			converter, err := NewConverter(Config{
+				DatasourceUID:   "datasource-uid",
+				DatasourceType:  tc.datasourceType,
+				DefaultInterval: 2 * time.Minute,
+			})
+			require.NoError(t, err)
+
+			grafanaGroup, err := converter.PrometheusRulesToGrafana(1, "namespaceUID", promGroup)
+			require.NoError(t, err)
+			require.Len(t, grafanaGroup.Rules, 1)
+			require.Len(t, grafanaGroup.Rules[0].Data, 3)
+
+			query := grafanaGroup.Rules[0].Data[0]
+			require.Equal(t, "datasource-uid", query.DatasourceUID)
+			require.Equal(t, tc.datasourceType, query.QueryType)
+
+			var model map[string]any
+			require.NoError(t, json.Unmarshal(query.Model, &model))
+
+			ds := model["datasource"].(map[string]any)
+			require.Equal(t, tc.datasourceType, ds["type"])
+			require.Equal(t, "datasource-uid", ds["uid"])
+		})
+	}
+}
+
+func TestPrometheusRulesToGrafana_PrometheusCompatibleTargetDatasources(t *testing.T) {
+	promGroup := PrometheusRuleGroup{
+		Name: "recording-group",
+		Rules: []PrometheusRule{
+			{
+				Record: "some_metric",
+				Expr:   "sum(rate(http_requests_total[5m]))",
+			},
+		},
+	}
+
+	testCases := []struct {
+		name                 string
+		targetDatasourceType string
+	}{
+		{
+			name:                 "prometheus",
+			targetDatasourceType: datasources.DS_PROMETHEUS,
+		},
+		{
+			name:                 "amazon managed prometheus",
+			targetDatasourceType: datasources.DS_AMAZON_PROMETHEUS,
+		},
+		{
+			name:                 "azure managed prometheus",
+			targetDatasourceType: datasources.DS_AZURE_PROMETHEUS,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			converter, err := NewConverter(Config{
+				DatasourceUID:        "datasource-uid",
+				DatasourceType:       datasources.DS_PROMETHEUS,
+				TargetDatasourceUID:  "target-datasource-uid",
+				TargetDatasourceType: tc.targetDatasourceType,
+				DefaultInterval:      2 * time.Minute,
+			})
+			require.NoError(t, err)
+
+			grafanaGroup, err := converter.PrometheusRulesToGrafana(1, "namespaceUID", promGroup)
+			require.NoError(t, err)
+			require.Len(t, grafanaGroup.Rules, 1)
+
+			record := grafanaGroup.Rules[0].Record
+			require.NotNil(t, record)
+			require.Equal(t, queryRefID, record.From)
+			require.Equal(t, "some_metric", record.Metric)
+			require.Equal(t, "target-datasource-uid", record.TargetDatasourceUID)
 		})
 	}
 }


### PR DESCRIPTION
**What is this feature?**

This allows the Prometheus rule converter to accept AWS Managed Prometheus and Azure Managed Prometheus datasource types as Prometheus-compatible datasources. The generated alert query model preserves the managed datasource plugin type and UID instead of rewriting it.

**Why do we need this feature?**

The alert rule import/conversion path already treats AWS and Azure Managed Prometheus as Prometheus-compatible at the API layer, but the converter rejected them because it only allowed native Prometheus and Loki datasource types. That made importing otherwise compatible rule groups fail for managed Prometheus datasources.

**Who is this feature for?**

Users importing or converting Prometheus-compatible alerting rules from AWS Managed Prometheus or Azure Managed Prometheus datasources.

**Which issue(s) does this PR fix?**:

Fixes #123144

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [x] If this is a pre-GA feature, it is behind a feature toggle. Not applicable; this broadens an existing compatibility path.
- [x] The docs are updated, and if this is a notable improvement, it's added to What's New. Not applicable; this is a bug fix for existing rule conversion support.

Tests run:

```bash
go test ./pkg/services/ngalert/prom
go test ./pkg/services/ngalert/api -run "TestRouteConvertPrometheusPostRuleGroup|TestIsPrometheusCompatible|TestIsLotexRulerCompatible"
```
