### PR TITLE
fix: disable mmap for backend bulk parquet reader

### DIFF
--- a/pkg/storage/unified/parquet/reader.go
+++ b/pkg/storage/unified/parquet/reader.go
@@ -107,7 +107,10 @@ func (r *parquetReader) close() {
 }
 
 func newResourceReader(inputPath string, batchSize int64) (*parquetReader, error) {
-	rdr, err := file.OpenParquetFile(inputPath, true)
+	// memoryMap must be false: arrow-go does not implement mmap on Windows
+	// (returns "mmap not implemented on windows"), which would break the
+	// SQLite parquet-buffer migration fallback on Windows on-prem installs.
+	rdr, err := file.OpenParquetFile(inputPath, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/unified/parquet/reader.go
+++ b/pkg/storage/unified/parquet/reader.go
@@ -108,8 +108,7 @@ func (r *parquetReader) close() {
 
 func newResourceReader(inputPath string, batchSize int64) (*parquetReader, error) {
 	// memoryMap must be false: arrow-go does not implement mmap on Windows
-	// (returns "mmap not implemented on windows"), which would break the
-	// SQLite parquet-buffer migration fallback on Windows on-prem installs.
+	// (returns "mmap not implemented on windows")
 	rdr, err := file.OpenParquetFile(inputPath, false)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION

When the first SQLite migration attempt fails, the runner retries through the parquet buffer: it writes records to a temp parquet file, then reads them back via `NewParquetReader` → `OpenParquetFile(path, true)`. The `true` requests memory-mapped I/O, which arrow-go explicitly does not implement on Windows. The read fails, the migration never completes, and the instance can't start.

## The fix

`memoryMap` is purely an I/O optimization — when `false`, arrow-go uses a plain `*os.File` and all parsing/decoding is identical. Switching it off makes the read path cross-platform.

## Regression risk

None expected:
- This reader only runs on the SQLite parquet-buffer fallback (`dialect == "sqlite"`); Postgres/MySQL are unaffected.
- On Linux/macOS the flag only changes the backing reader from mmap to `os.Open`, with no behavioral difference and negligible impact on a one-time sequential migration read.
- Existing `TestParquetWriteThenRead` covers the write→read path and passes.

Fixes the Windows on-prem SQLite startup failure on 13.0.1. ([community escalation](https://community.grafana.com/t/grafana-not-running-after-upgrade-13-0-1-security-01/163087))
