### PR TITLE
[release-13.0.2] Unified Storage: Disable mmap for bulk backend parquet reader

### DIFF
--- a/pkg/storage/unified/parquet/reader.go
+++ b/pkg/storage/unified/parquet/reader.go
@@ -107,7 +107,9 @@ func (r *parquetReader) close() {
 }
 
 func newResourceReader(inputPath string, batchSize int64) (*parquetReader, error) {
-	rdr, err := file.OpenParquetFile(inputPath, true)
+	// memoryMap must be false: arrow-go does not implement mmap on Windows
+	// (returns "mmap not implemented on windows")
+	rdr, err := file.OpenParquetFile(inputPath, false)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Backport https://github.com/grafana/grafana/pull/125753 for https://community.grafana.com/t/grafana-not-running-after-upgrade-13-0-1-security-01/163087.