### PR TITLE
Transformations: Ignore invalid config decimals

### DIFF
--- a/public/app/features/transformers/configFromQuery/configFromQuery.test.ts
+++ b/public/app/features/transformers/configFromQuery/configFromQuery.test.ts
@@ -89,6 +89,35 @@ describe('config from data', () => {
     expect(results[0].fields[1].config.decimals).toBe(5);
   });
 
+  it.each([-3, 2.5, 21])('skips invalid decimals value %s', (decimals) => {
+    const invalidConfig = toDataFrame({
+      fields: [
+        { name: 'Time', type: FieldType.time, values: [1] },
+        { name: 'Decimals', type: FieldType.number, values: [decimals] },
+      ],
+      refId: 'A',
+    });
+    const series = toDataFrame({
+      fields: [
+        { name: 'Time', type: FieldType.time, values: [1] },
+        {
+          name: 'Value',
+          type: FieldType.number,
+          values: [0],
+          config: { decimals: 1 },
+        },
+      ],
+    });
+    const options: ConfigFromQueryTransformOptions = {
+      configRefId: 'A',
+      mappings: [{ fieldName: 'Decimals', handlerKey: 'decimals' }],
+    };
+
+    const results = extractConfigFromQuery(options, [invalidConfig, series]);
+
+    expect(results[0].fields[1].config.decimals).toBe(1);
+  });
+
   it('With custom reducer', () => {
     const options: ConfigFromQueryTransformOptions = {
       configRefId: 'A',

--- a/public/app/features/transformers/configFromQuery/configFromQuery.test.ts
+++ b/public/app/features/transformers/configFromQuery/configFromQuery.test.ts
@@ -89,7 +89,7 @@ describe('config from data', () => {
     expect(results[0].fields[1].config.decimals).toBe(5);
   });
 
-  it.each([-3, 2.5, 21])('skips invalid decimals value %s', (decimals) => {
+  it.each([-3, 2.5, 16])('skips invalid decimals value %s', (decimals) => {
     const invalidConfig = toDataFrame({
       fields: [
         { name: 'Time', type: FieldType.time, values: [1] },

--- a/public/app/features/transformers/fieldToConfigMapping/fieldToConfigMapping.ts
+++ b/public/app/features/transformers/fieldToConfigMapping/fieldToConfigMapping.ts
@@ -275,7 +275,7 @@ function toNumericOrUndefined(value: unknown) {
 function toDecimalsOrUndefined(value: unknown) {
   const numeric = anyToNumber(value);
 
-  if (!Number.isInteger(numeric) || numeric < 0 || numeric > 20) {
+  if (!Number.isInteger(numeric) || numeric < 0 || numeric > 15) {
     return;
   }
 

--- a/public/app/features/transformers/fieldToConfigMapping/fieldToConfigMapping.ts
+++ b/public/app/features/transformers/fieldToConfigMapping/fieldToConfigMapping.ts
@@ -144,7 +144,7 @@ export const configMapHandlers: FieldToConfigMapHandler[] = [
   },
   {
     key: 'decimals',
-    processor: toNumericOrUndefined,
+    processor: toDecimalsOrUndefined,
   },
   {
     key: 'displayName',
@@ -266,6 +266,16 @@ function toNumericOrUndefined(value: unknown) {
   const numeric = anyToNumber(value);
 
   if (isNaN(numeric)) {
+    return;
+  }
+
+  return numeric;
+}
+
+function toDecimalsOrUndefined(value: unknown) {
+  const numeric = anyToNumber(value);
+
+  if (!Number.isInteger(numeric) || numeric < 0 || numeric > 20) {
     return;
   }
 


### PR DESCRIPTION
## Summary

Config from query results accepted any numeric value for the Decimals mapping. Out-of-range values could be written to `field.config.decimals`; a negative value then reached `toFixed` and could blank the panel when the rendered series contained `0`.

This change gives the Decimals mapping its own validator instead of reusing the generic numeric parser. It only applies integer values in the same range as the standard field option editor, `0..15`. Invalid values are skipped, so an existing field-level decimals setting stays unchanged.

## Changes

- Keep `min` and `max` on the existing numeric parser.
- Add a dedicated Decimals parser that accepts only integer values from `0` through `15`.
- Cover negative, fractional, and too-large Decimals values in the config-from-query transformer test.

## Testing

- `corepack yarn jest public/app/features/transformers/configFromQuery/configFromQuery.test.ts --runInBand --no-watch`

## Related

Fixes #125688