### PR TITLE
HistogramPanel: Fix sparse linear bucket bar widths

### DIFF
--- a/devenv/dev-dashboards/panel-histogram/histogram_tests.json
+++ b/devenv/dev-dashboards/panel-histogram/histogram_tests.json
@@ -9,27 +9,24 @@
       {
         "kind": "AnnotationQuery",
         "spec": {
+          "builtIn": true,
+          "enable": true,
+          "hide": true,
+          "iconColor": "rgba(0, 211, 255, 1)",
+          "name": "Annotations & Alerts",
           "query": {
-            "kind": "DataQuery",
-            "group": "datasource",
-            "version": "v0",
             "datasource": {
               "name": "grafana"
             },
+            "group": "grafana",
+            "kind": "DataQuery",
             "spec": {
               "limit": 100,
               "matchAny": false,
               "tags": [],
               "type": "dashboard"
-            }
-          },
-          "enable": true,
-          "hide": true,
-          "iconColor": "rgba(0, 211, 255, 1)",
-          "name": "Annotations \u0026 Alerts",
-          "builtIn": true,
-          "legacyOptions": {
-            "type": "dashboard"
+            },
+            "version": "v0"
           }
         }
       }
@@ -37,13 +34,9 @@
     "cursorSync": "Off",
     "editable": true,
     "elements": {
-      "panel-11": {
+      "panel-10": {
         "kind": "Panel",
         "spec": {
-          "id": 11,
-          "title": "Explicit xMin,xMax",
-          "description": "",
-          "links": [],
           "data": {
             "kind": "QueryGroup",
             "spec": {
@@ -51,53 +44,130 @@
                 {
                   "kind": "PanelQuery",
                   "spec": {
+                    "hidden": false,
                     "query": {
-                      "kind": "DataQuery",
+                      "datasource": {
+                        "name": "PD8C576611E62080A"
+                      },
                       "group": "grafana-testdata-datasource",
-                      "version": "v0",
+                      "kind": "DataQuery",
                       "spec": {
-                        "csvContent": "xMin,xMax,count1,abcd\n1,2,10,123\n2,3,20,265\n3,4,30,73\n4,5,10,24",
-                        "scenarioId": "csv_content"
-                      }
+                        "csvContent": "value\n0\n9",
+                        "scenarioId": "csv_content",
+                        "seriesCount": 1
+                      },
+                      "version": "v0"
                     },
-                    "refId": "A",
-                    "hidden": false
+                    "refId": "A"
                   }
                 }
               ],
-              "transformations": [],
-              "queryOptions": {}
+              "queryOptions": {},
+              "transformations": []
             }
           },
+          "description": "",
+          "id": 16,
+          "links": [],
+          "title": "[0,9] bucket size 1",
           "vizConfig": {
-            "kind": "VizConfig",
             "group": "histogram",
-            "version": "",
+            "kind": "VizConfig",
             "spec": {
-              "options": {
-                "bucketOffset": 0,
-                "legend": {
-                  "calcs": ["sum"],
-                  "displayMode": "list",
-                  "placement": "bottom",
-                  "showLegend": true
-                }
-              },
               "fieldConfig": {
                 "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "fillOpacity": 80,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "lineWidth": 1,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    }
+                  },
                   "thresholds": {
                     "mode": "absolute",
                     "steps": [
                       {
-                        "value": null,
-                        "color": "green"
+                        "color": "green",
+                        "value": 0
                       },
                       {
-                        "value": 80,
-                        "color": "red"
+                        "color": "red",
+                        "value": 80
                       }
                     ]
-                  },
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "bucketSize": 1,
+                "combine": false,
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "overflow": "ellipsis",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "13.2.0-local"
+          }
+        }
+      },
+      "panel-11": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "group": "grafana-testdata-datasource",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "csvContent": "xMin,xMax,count1,abcd\n1,2,10,123\n2,3,20,265\n3,4,30,73\n4,5,10,24",
+                        "scenarioId": "csv_content"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 11,
+          "links": [],
+          "title": "Explicit xMin,xMax",
+          "vizConfig": {
+            "group": "histogram",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
                   "color": {
                     "mode": "palette-classic"
                   },
@@ -109,7 +179,24 @@
                       "tooltip": false,
                       "viz": false
                     },
-                    "lineWidth": 1
+                    "lineWidth": 1,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
                   }
                 },
                 "overrides": [
@@ -129,18 +216,30 @@
                     ]
                   }
                 ]
+              },
+              "options": {
+                "bucketOffset": 0,
+                "legend": {
+                  "calcs": ["sum"],
+                  "displayMode": "list",
+                  "overflow": "ellipsis",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
               }
-            }
+            },
+            "version": "13.2.0-local"
           }
         }
       },
       "panel-12": {
         "kind": "Panel",
         "spec": {
-          "id": 12,
-          "title": "Implict xMax",
-          "description": "",
-          "links": [],
           "data": {
             "kind": "QueryGroup",
             "spec": {
@@ -148,53 +247,34 @@
                 {
                   "kind": "PanelQuery",
                   "spec": {
+                    "hidden": false,
                     "query": {
-                      "kind": "DataQuery",
                       "group": "grafana-testdata-datasource",
-                      "version": "v0",
+                      "kind": "DataQuery",
                       "spec": {
                         "csvContent": "xMin,count1,abcd\n1,10,123\n2,20,265\n3,30,73\n4,10,24",
                         "scenarioId": "csv_content"
-                      }
+                      },
+                      "version": "v0"
                     },
-                    "refId": "A",
-                    "hidden": false
+                    "refId": "A"
                   }
                 }
               ],
-              "transformations": [],
-              "queryOptions": {}
+              "queryOptions": {},
+              "transformations": []
             }
           },
+          "description": "",
+          "id": 12,
+          "links": [],
+          "title": "Implict xMax",
           "vizConfig": {
-            "kind": "VizConfig",
             "group": "histogram",
-            "version": "",
+            "kind": "VizConfig",
             "spec": {
-              "options": {
-                "bucketOffset": 0,
-                "legend": {
-                  "calcs": ["sum"],
-                  "displayMode": "list",
-                  "placement": "bottom",
-                  "showLegend": true
-                }
-              },
               "fieldConfig": {
                 "defaults": {
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "value": null,
-                        "color": "green"
-                      },
-                      {
-                        "value": 80,
-                        "color": "red"
-                      }
-                    ]
-                  },
                   "color": {
                     "mode": "palette-classic"
                   },
@@ -206,7 +286,24 @@
                       "tooltip": false,
                       "viz": false
                     },
-                    "lineWidth": 1
+                    "lineWidth": 1,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
                   }
                 },
                 "overrides": [
@@ -226,18 +323,30 @@
                     ]
                   }
                 ]
+              },
+              "options": {
+                "bucketOffset": 0,
+                "legend": {
+                  "calcs": ["sum"],
+                  "displayMode": "list",
+                  "overflow": "ellipsis",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
               }
-            }
+            },
+            "version": "13.2.0-local"
           }
         }
       },
       "panel-13": {
         "kind": "Panel",
         "spec": {
-          "id": 13,
-          "title": "Implict xMin",
-          "description": "",
-          "links": [],
           "data": {
             "kind": "QueryGroup",
             "spec": {
@@ -245,53 +354,34 @@
                 {
                   "kind": "PanelQuery",
                   "spec": {
+                    "hidden": false,
                     "query": {
-                      "kind": "DataQuery",
                       "group": "grafana-testdata-datasource",
-                      "version": "v0",
+                      "kind": "DataQuery",
                       "spec": {
                         "csvContent": "xMax,count1,abcd\n1,10,123\n2,20,265\n3,30,73\n4,10,24",
                         "scenarioId": "csv_content"
-                      }
+                      },
+                      "version": "v0"
                     },
-                    "refId": "A",
-                    "hidden": false
+                    "refId": "A"
                   }
                 }
               ],
-              "transformations": [],
-              "queryOptions": {}
+              "queryOptions": {},
+              "transformations": []
             }
           },
+          "description": "",
+          "id": 13,
+          "links": [],
+          "title": "Implict xMin",
           "vizConfig": {
-            "kind": "VizConfig",
             "group": "histogram",
-            "version": "",
+            "kind": "VizConfig",
             "spec": {
-              "options": {
-                "bucketOffset": 0,
-                "legend": {
-                  "calcs": ["sum"],
-                  "displayMode": "list",
-                  "placement": "bottom",
-                  "showLegend": true
-                }
-              },
               "fieldConfig": {
                 "defaults": {
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "value": null,
-                        "color": "green"
-                      },
-                      {
-                        "value": 80,
-                        "color": "red"
-                      }
-                    ]
-                  },
                   "color": {
                     "mode": "palette-classic"
                   },
@@ -303,7 +393,24 @@
                       "tooltip": false,
                       "viz": false
                     },
-                    "lineWidth": 1
+                    "lineWidth": 1,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
                   }
                 },
                 "overrides": [
@@ -323,18 +430,30 @@
                     ]
                   }
                 ]
+              },
+              "options": {
+                "bucketOffset": 0,
+                "legend": {
+                  "calcs": ["sum"],
+                  "displayMode": "list",
+                  "overflow": "ellipsis",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
               }
-            }
+            },
+            "version": "13.2.0-local"
           }
         }
       },
       "panel-14": {
         "kind": "Panel",
         "spec": {
-          "id": 14,
-          "title": "heatmap-rows frame",
-          "description": "",
-          "links": [],
           "data": {
             "kind": "QueryGroup",
             "spec": {
@@ -342,53 +461,34 @@
                 {
                   "kind": "PanelQuery",
                   "spec": {
+                    "hidden": false,
                     "query": {
-                      "kind": "DataQuery",
                       "group": "grafana-testdata-datasource",
-                      "version": "v0",
+                      "kind": "DataQuery",
                       "spec": {
                         "rawFrameContent": "[\n  {\n    \"schema\": {\n      \"refId\": \"A\",\n      \"meta\": {\n        \"custom\": {\n          \"resultType\": \"matrix\"\n        },\n        \"type\": \"heatmap-rows\",\n        \"typeVersion\": [\n          0,\n          1\n        ]\n      },\n      \"name\": \"0.005\",\n      \"fields\": [\n        {\n          \"config\": {\n            \"interval\": 1200000\n          },\n          \"name\": \"Time\",\n          \"type\": \"time\",\n          \"typeInfo\": {\n            \"frame\": \"time.Time\"\n          }\n        },\n        {\n          \"config\": {\n            \"displayNameFromDS\": \"0.005\"\n          },\n          \"labels\": {\n            \"le\": \"0.005\"\n          },\n          \"name\": \"0.005\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"float64\"\n          }\n        },\n        {\n          \"config\": {\n            \"displayNameFromDS\": \"0.01\"\n          },\n          \"labels\": {\n            \"le\": \"0.01\"\n          },\n          \"name\": \"0.01\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"float64\"\n          }\n        },\n        {\n          \"config\": {\n            \"displayNameFromDS\": \"0.025\"\n          },\n          \"labels\": {\n            \"le\": \"0.025\"\n          },\n          \"name\": \"0.025\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"float64\"\n          }\n        },\n        {\n          \"config\": {\n            \"displayNameFromDS\": \"0.05\"\n          },\n          \"labels\": {\n            \"le\": \"0.05\"\n          },\n          \"name\": \"0.05\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"float64\"\n          }\n        },\n        {\n          \"config\": {\n            \"displayNameFromDS\": \"0.1\"\n          },\n          \"labels\": {\n            \"le\": \"0.1\"\n          },\n          \"name\": \"0.1\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"float64\"\n          }\n        },\n        {\n          \"config\": {\n            \"displayNameFromDS\": \"0.25\"\n          },\n          \"labels\": {\n            \"le\": \"0.25\"\n          },\n          \"name\": \"0.25\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"float64\"\n          }\n        },\n        {\n          \"config\": {\n            \"displayNameFromDS\": \"0.5\"\n          },\n          \"labels\": {\n            \"le\": \"0.5\"\n          },\n          \"name\": \"0.5\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"float64\"\n          }\n        },\n        {\n          \"config\": {\n            \"displayNameFromDS\": \"1.0\"\n          },\n          \"labels\": {\n            \"le\": \"1.0\"\n          },\n          \"name\": \"1.0\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"float64\"\n          }\n        },\n        {\n          \"config\": {\n            \"displayNameFromDS\": \"2.5\"\n          },\n          \"labels\": {\n            \"le\": \"2.5\"\n          },\n          \"name\": \"2.5\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"float64\"\n          }\n        },\n        {\n          \"config\": {\n            \"displayNameFromDS\": \"5.0\"\n          },\n          \"labels\": {\n            \"le\": \"5.0\"\n          },\n          \"name\": \"5.0\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"float64\"\n          }\n        },\n        {\n          \"config\": {\n            \"displayNameFromDS\": \"10.0\"\n          },\n          \"labels\": {\n            \"le\": \"10.0\"\n          },\n          \"name\": \"10.0\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"float64\"\n          }\n        },\n        {\n          \"config\": {\n            \"displayNameFromDS\": \"25.0\"\n          },\n          \"labels\": {\n            \"le\": \"25.0\"\n          },\n          \"name\": \"25.0\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"float64\"\n          }\n        },\n        {\n          \"config\": {\n            \"displayNameFromDS\": \"50.0\"\n          },\n          \"labels\": {\n            \"le\": \"50.0\"\n          },\n          \"name\": \"50.0\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"float64\"\n          }\n        },\n        {\n          \"config\": {\n            \"displayNameFromDS\": \"100.0\"\n          },\n          \"labels\": {\n            \"le\": \"100.0\"\n          },\n          \"name\": \"100.0\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"float64\"\n          }\n        },\n        {\n          \"config\": {\n            \"displayNameFromDS\": \"+Inf\"\n          },\n          \"labels\": {\n            \"le\": \"+Inf\"\n          },\n          \"name\": \"+Inf\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"float64\"\n          }\n        }\n      ]\n    },\n    \"data\": {\n      \"values\": [\n        [\n          1706456400000,\n          1706457600000,\n          1706458800000,\n          1706460000000,\n          1706461200000,\n          1706462400000,\n          1706463600000,\n          1706464800000,\n          1706466000000,\n          1706467200000,\n          1706468400000,\n          1706469600000,\n          1706470800000,\n          1706472000000,\n          1706473200000,\n          1706474400000,\n          1706475600000,\n          1706476800000,\n          1706478000000\n        ],\n        [\n          0.19357429718875502,\n          0.18072289156626506,\n          0.18313253012048192,\n          0.18955823293172688,\n          0.18634538152610441,\n          0.19518072289156624,\n          0.20080321285140562,\n          0.18313253012048192,\n          0.19678714859437751,\n          0.18795180722891563,\n          0.18473895582329317,\n          0.19357429718875502,\n          0.19116465863453813,\n          0.19196787148594374,\n          0.19437751004016063,\n          0.19759036144578312,\n          0.19839357429718874,\n          0.19357429718875502,\n          0.18634538152610441\n        ],\n        [\n          0.22248995983935738,\n          0.229718875502008,\n          0.22248995983935738,\n          0.22168674698795174,\n          0.2305220883534136,\n          0.21285140562248994,\n          0.2128514056224899,\n          0.22891566265060237,\n          0.22570281124497987,\n          0.22088353413654616,\n          0.22088353413654618,\n          0.21927710843373488,\n          0.21686746987951805,\n          0.22248995983935738,\n          0.21847389558232927,\n          0.21124497991967867,\n          0.216867469879518,\n          0.2200803212851405,\n          0.22329317269076304\n        ],\n        [\n          0.017670682730923704,\n          0.02329317269076303,\n          0.027309236947791138,\n          0.02168674698795181,\n          0.016867469879518093,\n          0.025702811244979917,\n          0.02008032128514059,\n          0.018473895582329314,\n          0.01124497991967871,\n          0.024899598393574307,\n          0.025702811244979862,\n          0.0208835341365462,\n          0.02409638554216864,\n          0.01927710843373498,\n          0.0208835341365462,\n          0.02248995983935742,\n          0.016867469879518093,\n          0.02008032128514059,\n          0.02329317269076303\n        ],\n        [\n          0,\n          0,\n          0.0008032128514056658,\n          0.0008032128514056658,\n          0,\n          0,\n          0,\n          0.0032128514056224966,\n          0,\n          0,\n          0.0024096385542168863,\n          0,\n          0.001606425702811276,\n          0,\n          0,\n          0.0024096385542168863,\n          0.001606425702811276,\n          0,\n          0.0008032128514056103\n        ],\n        [\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0\n        ],\n        [\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0\n        ],\n        [\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0\n        ],\n        [\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0\n        ],\n        [\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0\n        ],\n        [\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0\n        ],\n        [\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0\n        ],\n        [\n          0.06666666666666665,\n          0.06666666666666665,\n          0.06666666666666665,\n          0.06666666666666665,\n          0.06666666666666665,\n          0.06666666666666665,\n          0.06666666666666665,\n          0.06666666666666665,\n          0.06666666666666665,\n          0.06666666666666665,\n          0.06666666666666665,\n          0.06666666666666665,\n          0.06666666666666665,\n          0.06666666666666665,\n          0.06666666666666665,\n          0.06666666666666665,\n          0.06666666666666665,\n          0.06666666666666665,\n          0.06666666666666665\n        ],\n        [\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0\n        ],\n        [\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0\n        ],\n        [\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0\n        ]\n      ]\n    }\n  }\n]",
                         "scenarioId": "raw_frame"
-                      }
+                      },
+                      "version": "v0"
                     },
-                    "refId": "A",
-                    "hidden": false
+                    "refId": "A"
                   }
                 }
               ],
-              "transformations": [],
-              "queryOptions": {}
+              "queryOptions": {},
+              "transformations": []
             }
           },
+          "description": "",
+          "id": 14,
+          "links": [],
+          "title": "heatmap-rows frame",
           "vizConfig": {
-            "kind": "VizConfig",
             "group": "histogram",
-            "version": "",
+            "kind": "VizConfig",
             "spec": {
-              "options": {
-                "bucketOffset": 0,
-                "legend": {
-                  "calcs": [],
-                  "displayMode": "list",
-                  "placement": "bottom",
-                  "showLegend": true
-                }
-              },
               "fieldConfig": {
                 "defaults": {
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "value": null,
-                        "color": "green"
-                      },
-                      {
-                        "value": 80,
-                        "color": "red"
-                      }
-                    ]
-                  },
                   "color": {
                     "mode": "palette-classic"
                   },
@@ -400,22 +500,51 @@
                       "tooltip": false,
                       "viz": false
                     },
-                    "lineWidth": 1
+                    "lineWidth": 1,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
                   }
                 },
                 "overrides": []
+              },
+              "options": {
+                "bucketOffset": 0,
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "overflow": "ellipsis",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
               }
-            }
+            },
+            "version": "13.2.0-local"
           }
         }
       },
       "panel-15": {
         "kind": "Panel",
         "spec": {
-          "id": 15,
-          "title": "heatmap-cells frame",
-          "description": "",
-          "links": [],
           "data": {
             "kind": "QueryGroup",
             "spec": {
@@ -423,53 +552,34 @@
                 {
                   "kind": "PanelQuery",
                   "spec": {
+                    "hidden": false,
                     "query": {
-                      "kind": "DataQuery",
                       "group": "grafana-testdata-datasource",
-                      "version": "v0",
+                      "kind": "DataQuery",
                       "spec": {
                         "rawFrameContent": "[\n  {\n    \"schema\": {\n      \"refId\": \"A\",\n      \"meta\": {\n        \"type\": \"heatmap-cells\",\n        \"typeVersion\": [\n          0,\n          0\n        ],\n        \"executedQueryString\": \"Expr: sum(rate(cortex_request_duration_seconds{container=~\\\"compactor\\\", route=~\\\"(debug_pprof|metrics|ready)\\\"}[4m0s]))\\nStep: 1m0s\",\n        \"preferredVisualisationType\": \"graph\"\n      },\n      \"fields\": [\n        {\n          \"name\": \"xMax\",\n          \"type\": \"time\",\n          \"typeInfo\": {\n            \"frame\": \"time.Time\"\n          },\n          \"config\": {\n            \"interval\": 60000\n          }\n        },\n        {\n          \"name\": \"yMin\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"float64\"\n          },\n          \"labels\": {},\n          \"config\": {\n            \"displayNameFromDS\": \"sum(rate(cortex_request_duration_seconds{container=~\\\"compactor\\\", route=~\\\"(debug_pprof|metrics|ready)\\\"}[4m0s]))\"\n          }\n        },\n        {\n          \"name\": \"yMax\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"float64\"\n          },\n          \"config\": {}\n        },\n        {\n          \"name\": \"count\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"float64\"\n          },\n          \"config\": {}\n        },\n        {\n          \"name\": \"yLayout\",\n          \"type\": \"number\",\n          \"typeInfo\": {\n            \"frame\": \"int8\"\n          },\n          \"config\": {}\n        }\n      ]\n    },\n    \"data\": {\n      \"values\": [\n        [\n          1706483460000,\n          1706483460000,\n          1706483460000,\n          1706483460000,\n          1706483460000,\n          1706483460000,\n          1706483460000,\n          1706483460000,\n          1706483460000,\n          1706483460000,\n          1706483460000,\n          1706483460000,\n          1706483460000,\n          1706483460000,\n          1706483460000,\n          1706483460000,\n          1706483460000,\n          1706483460000,\n          1706483460000,\n          1706483460000,\n          1706483460000,\n          1706483460000,\n          1706483460000,\n          1706483460000,\n          1706483460000,\n          1706483460000,\n          1706483460000,\n          1706483460000,\n          1706483460000,\n          1706483460000,\n          1706483460000,\n          1706483460000,\n          1706483460000,\n          1706483520000,\n          1706483520000,\n          1706483520000,\n          1706483520000,\n          1706483520000,\n          1706483520000,\n          1706483520000,\n          1706483520000,\n          1706483520000,\n          1706483520000,\n          1706483520000,\n          1706483520000,\n          1706483520000,\n          1706483520000,\n          1706483520000,\n          1706483520000,\n          1706483520000,\n          1706483520000,\n          1706483520000,\n          1706483520000,\n          1706483520000,\n          1706483520000,\n          1706483520000,\n          1706483520000,\n          1706483520000,\n          1706483520000,\n          1706483520000,\n          1706483520000,\n          1706483520000,\n          1706483520000,\n          1706483520000,\n          1706483520000,\n          1706483580000,\n          1706483580000,\n          1706483580000,\n          1706483580000,\n          1706483580000,\n          1706483580000,\n          1706483580000,\n          1706483580000,\n          1706483580000,\n          1706483580000,\n          1706483580000,\n          1706483580000,\n          1706483580000,\n          1706483580000,\n          1706483580000,\n          1706483580000,\n          1706483580000,\n          1706483580000,\n          1706483580000,\n          1706483580000,\n          1706483580000,\n          1706483580000,\n          1706483580000,\n          1706483580000,\n          1706483580000,\n          1706483580000,\n          1706483580000,\n          1706483580000,\n          1706483580000,\n          1706483640000,\n          1706483640000,\n          1706483640000,\n          1706483640000,\n          1706483640000,\n          1706483640000,\n          1706483640000,\n          1706483640000,\n          1706483640000,\n          1706483640000,\n          1706483640000,\n          1706483640000,\n          1706483640000,\n          1706483640000,\n          1706483640000,\n          1706483640000,\n          1706483640000,\n          1706483640000,\n          1706483640000,\n          1706483640000,\n          1706483640000,\n          1706483640000,\n          1706483640000,\n          1706483640000,\n          1706483640000,\n          1706483640000,\n          1706483640000,\n          1706483640000,\n          1706483640000,\n          1706483640000,\n          1706483700000,\n          1706483700000,\n          1706483700000,\n          1706483700000,\n          1706483700000,\n          1706483700000,\n          1706483700000,\n          1706483700000,\n          1706483700000,\n          1706483700000,\n          1706483700000,\n          1706483700000,\n          1706483700000,\n          1706483700000,\n          1706483700000,\n          1706483700000,\n          1706483700000,\n          1706483700000,\n          1706483700000,\n          1706483700000,\n          1706483700000,\n          1706483700000,\n          1706483700000,\n          1706483700000,\n          1706483700000,\n          1706483700000,\n          1706483700000,\n          1706483700000,\n          1706483700000,\n          1706483760000,\n          1706483760000,\n          1706483760000,\n          1706483760000,\n          1706483760000,\n          1706483760000,\n          1706483760000,\n          1706483760000,\n          1706483760000,\n          1706483760000,\n          1706483760000,\n          1706483760000,\n          1706483760000,\n          1706483760000,\n          1706483760000,\n          1706483760000,\n          1706483760000,\n          1706483760000,\n          1706483760000,\n          1706483760000,\n          1706483760000,\n          1706483760000,\n          1706483760000,\n          1706483760000,\n          1706483760000,\n          1706483760000,\n          1706483760000,\n          1706483760000,\n          1706483760000,\n          1706483760000,\n          1706483760000\n        ],\n        [\n          0.000012831061023768835,\n          0.000013992371264719713,\n          0.000016639827463764308,\n          0.0000181458605194507,\n          0.000019788201212326197,\n          0.000021579186437577742,\n          0.00002566212204753767,\n          0.000039576402424652394,\n          0.00020529697638030136,\n          0.0002238779402355154,\n          0.00026623723942022893,\n          0.0002903337683112112,\n          0.00031661121939721915,\n          0.00048828125,\n          0.002532889755177753,\n          0.002762135864009951,\n          0.00390625,\n          0.004259795830723663,\n          0.004645340292979379,\n          0.005065779510355506,\n          0.005524271728019902,\n          0.0060242610367497685,\n          0.006569503244169644,\n          0.007164094087536493,\n          0.0078125,\n          0.009290680585958758,\n          0.010131559020711013,\n          0.012048522073499537,\n          0.014328188175072986,\n          0.01703918332289465,\n          0.018581361171917516,\n          0.020263118041422026,\n          13.45434264405943,\n          0.000012831061023768835,\n          0.000013992371264719713,\n          0.000016639827463764308,\n          0.0000181458605194507,\n          0.000019788201212326197,\n          0.000021579186437577742,\n          0.00002566212204753767,\n          0.000039576402424652394,\n          0.0002238779402355154,\n          0.000244140625,\n          0.00026623723942022893,\n          0.0002903337683112112,\n          0.00048828125,\n          0.0021298979153618314,\n          0.002532889755177753,\n          0.002762135864009951,\n          0.00390625,\n          0.004259795830723663,\n          0.004645340292979379,\n          0.005065779510355506,\n          0.005524271728019902,\n          0.0060242610367497685,\n          0.006569503244169644,\n          0.007164094087536493,\n          0.0078125,\n          0.009290680585958758,\n          0.010131559020711013,\n          0.011048543456039804,\n          0.012048522073499537,\n          0.014328188175072986,\n          0.01703918332289465,\n          13.45434264405943,\n          0.000012831061023768835,\n          0.000013992371264719713,\n          0.000016639827463764308,\n          0.0000181458605194507,\n          0.000019788201212326197,\n          0.000021579186437577742,\n          0.00002566212204753767,\n          0.000244140625,\n          0.00026623723942022893,\n          0.0002903337683112112,\n          0.0021298979153618314,\n          0.002532889755177753,\n          0.002762135864009951,\n          0.00390625,\n          0.004259795830723663,\n          0.004645340292979379,\n          0.005065779510355506,\n          0.005524271728019902,\n          0.0060242610367497685,\n          0.006569503244169644,\n          0.007164094087536493,\n          0.0078125,\n          0.009290680585958758,\n          0.010131559020711013,\n          0.011048543456039804,\n          0.012048522073499537,\n          0.014328188175072986,\n          0.01703918332289465,\n          13.45434264405943,\n          0.000012831061023768835,\n          0.000013992371264719713,\n          0.0000152587890625,\n          0.000016639827463764308,\n          0.0000181458605194507,\n          0.000019788201212326197,\n          0.000021579186437577742,\n          0.00002566212204753767,\n          0.000244140625,\n          0.00026623723942022893,\n          0.0002903337683112112,\n          0.0021298979153618314,\n          0.002762135864009951,\n          0.00390625,\n          0.004259795830723663,\n          0.004645340292979379,\n          0.005065779510355506,\n          0.005524271728019902,\n          0.0060242610367497685,\n          0.006569503244169644,\n          0.007164094087536493,\n          0.0078125,\n          0.008519591661447326,\n          0.009290680585958758,\n          0.010131559020711013,\n          0.011048543456039804,\n          0.012048522073499537,\n          0.014328188175072986,\n          0.01703918332289465,\n          13.45434264405943,\n          0.000012831061023768835,\n          0.000013992371264719713,\n          0.0000152587890625,\n          0.000016639827463764308,\n          0.0000181458605194507,\n          0.000019788201212326197,\n          0.000021579186437577742,\n          0.00002566212204753767,\n          0.000244140625,\n          0.00026623723942022893,\n          0.0002903337683112112,\n          0.0005806675366224224,\n          0.0021298979153618314,\n          0.002762135864009951,\n          0.00390625,\n          0.004259795830723663,\n          0.004645340292979379,\n          0.005065779510355506,\n          0.005524271728019902,\n          0.0060242610367497685,\n          0.006569503244169644,\n          0.007164094087536493,\n          0.0078125,\n          0.008519591661447326,\n          0.009290680585958758,\n          0.010131559020711013,\n          0.011048543456039804,\n          0.015625,\n          13.45434264405943,\n          0.000012831061023768835,\n          0.000013992371264719713,\n          0.0000152587890625,\n          0.000016639827463764308,\n          0.0000181458605194507,\n          0.000019788201212326197,\n          0.000021579186437577742,\n          0.00002566212204753767,\n          0.000244140625,\n          0.00026623723942022893,\n          0.0002903337683112112,\n          0.00031661121939721915,\n          0.0003452669830012439,\n          0.0005806675366224224,\n          0.0021298979153618314,\n          0.002762135864009951,\n          0.00390625,\n          0.004259795830723663,\n          0.004645340292979379,\n          0.005065779510355506,\n          0.005524271728019902,\n          0.0060242610367497685,\n          0.006569503244169644,\n          0.007164094087536493,\n          0.0078125,\n          0.008519591661447326,\n          0.009290680585958758,\n          0.010131559020711013,\n          0.011048543456039804,\n          0.015625,\n          13.45434264405943\n        ],\n        [\n          0.000013992371264719713,\n          0.0000152587890625,\n          0.0000181458605194507,\n          0.000019788201212326197,\n          0.000021579186437577742,\n          0.000023532269674803783,\n          0.000027984742529439426,\n          0.000043158372875155485,\n          0.0002238779402355154,\n          0.000244140625,\n          0.0002903337683112112,\n          0.00031661121939721915,\n          0.0003452669830012439,\n          0.0005324744788404579,\n          0.002762135864009951,\n          0.0030121305183748843,\n          0.004259795830723663,\n          0.004645340292979379,\n          0.005065779510355506,\n          0.005524271728019902,\n          0.0060242610367497685,\n          0.006569503244169644,\n          0.007164094087536493,\n          0.0078125,\n          0.008519591661447326,\n          0.010131559020711013,\n          0.011048543456039804,\n          0.013139006488339287,\n          0.015625,\n          0.018581361171917516,\n          0.020263118041422026,\n          0.022097086912079608,\n          14.672064691274738,\n          0.000013992371264719713,\n          0.0000152587890625,\n          0.0000181458605194507,\n          0.000019788201212326197,\n          0.000021579186437577742,\n          0.000023532269674803783,\n          0.000027984742529439426,\n          0.000043158372875155485,\n          0.000244140625,\n          0.00026623723942022893,\n          0.0002903337683112112,\n          0.00031661121939721915,\n          0.0005324744788404579,\n          0.0023226701464896895,\n          0.002762135864009951,\n          0.0030121305183748843,\n          0.004259795830723663,\n          0.004645340292979379,\n          0.005065779510355506,\n          0.005524271728019902,\n          0.0060242610367497685,\n          0.006569503244169644,\n          0.007164094087536493,\n          0.0078125,\n          0.008519591661447326,\n          0.010131559020711013,\n          0.011048543456039804,\n          0.012048522073499537,\n          0.013139006488339287,\n          0.015625,\n          0.018581361171917516,\n          14.672064691274738,\n          0.000013992371264719713,\n          0.0000152587890625,\n          0.0000181458605194507,\n          0.000019788201212326197,\n          0.000021579186437577742,\n          0.000023532269674803783,\n          0.000027984742529439426,\n          0.00026623723942022893,\n          0.0002903337683112112,\n          0.00031661121939721915,\n          0.0023226701464896895,\n          0.002762135864009951,\n          0.0030121305183748843,\n          0.004259795830723663,\n          0.004645340292979379,\n          0.005065779510355506,\n          0.005524271728019902,\n          0.0060242610367497685,\n          0.006569503244169644,\n          0.007164094087536493,\n          0.0078125,\n          0.008519591661447326,\n          0.010131559020711013,\n          0.011048543456039804,\n          0.012048522073499537,\n          0.013139006488339287,\n          0.015625,\n          0.018581361171917516,\n          14.672064691274738,\n          0.000013992371264719713,\n          0.0000152587890625,\n          0.000016639827463764308,\n          0.0000181458605194507,\n          0.000019788201212326197,\n          0.000021579186437577742,\n          0.000023532269674803783,\n          0.000027984742529439426,\n          0.00026623723942022893,\n          0.0002903337683112112,\n          0.00031661121939721915,\n          0.0023226701464896895,\n          0.0030121305183748843,\n          0.004259795830723663,\n          0.004645340292979379,\n          0.005065779510355506,\n          0.005524271728019902,\n          0.0060242610367497685,\n          0.006569503244169644,\n          0.007164094087536493,\n          0.0078125,\n          0.008519591661447326,\n          0.009290680585958758,\n          0.010131559020711013,\n          0.011048543456039804,\n          0.012048522073499537,\n          0.013139006488339287,\n          0.015625,\n          0.018581361171917516,\n          14.672064691274738,\n          0.000013992371264719713,\n          0.0000152587890625,\n          0.000016639827463764308,\n          0.0000181458605194507,\n          0.000019788201212326197,\n          0.000021579186437577742,\n          0.000023532269674803783,\n          0.000027984742529439426,\n          0.00026623723942022893,\n          0.0002903337683112112,\n          0.00031661121939721915,\n          0.0006332224387944383,\n          0.0023226701464896895,\n          0.0030121305183748843,\n          0.004259795830723663,\n          0.004645340292979379,\n          0.005065779510355506,\n          0.005524271728019902,\n          0.0060242610367497685,\n          0.006569503244169644,\n          0.007164094087536493,\n          0.0078125,\n          0.008519591661447326,\n          0.009290680585958758,\n          0.010131559020711013,\n          0.011048543456039804,\n          0.012048522073499537,\n          0.01703918332289465,\n          14.672064691274738,\n          0.000013992371264719713,\n          0.0000152587890625,\n          0.000016639827463764308,\n          0.0000181458605194507,\n          0.000019788201212326197,\n          0.000021579186437577742,\n          0.000023532269674803783,\n          0.000027984742529439426,\n          0.00026623723942022893,\n          0.0002903337683112112,\n          0.00031661121939721915,\n          0.0003452669830012439,\n          0.00037651631479686053,\n          0.0006332224387944383,\n          0.0023226701464896895,\n          0.0030121305183748843,\n          0.004259795830723663,\n          0.004645340292979379,\n          0.005065779510355506,\n          0.005524271728019902,\n          0.0060242610367497685,\n          0.006569503244169644,\n          0.007164094087536493,\n          0.0078125,\n          0.008519591661447326,\n          0.009290680585958758,\n          0.010131559020711013,\n          0.011048543456039804,\n          0.012048522073499537,\n          0.01703918332289465,\n          14.672064691274738\n        ],\n        [\n          0.0044444444444444444,\n          0.017777777777777778,\n          0.0044444444444444444,\n          0.035555555555555556,\n          0.017777777777777778,\n          0.013333333333333332,\n          0.0044444444444444444,\n          0.0044444444444444444,\n          0.0044444444444444444,\n          0.0044444444444444444,\n          0.0044444444444444444,\n          0.008888888888888889,\n          0.0044444444444444444,\n          0.0044444444444444444,\n          0.008888888888888889,\n          0.0044444444444444444,\n          0.017777777777777778,\n          0.03111111111111111,\n          0.013333333333333332,\n          0.05333333333333334,\n          0.035555555555555556,\n          0.022222222222222223,\n          0.022222222222222223,\n          0.022222222222222223,\n          0.017777777777777778,\n          0.013333333333333332,\n          0.013333333333333332,\n          0.008888888888888889,\n          0.0044444444444444444,\n          0.0044444444444444444,\n          0.0044444444444444444,\n          0.0044444444444444444,\n          0.06666666666666667,\n          0.008888888888888889,\n          0.017777777777777778,\n          0.008888888888888889,\n          0.04,\n          0.0044444444444444444,\n          0.013333333333333332,\n          0.0044444444444444444,\n          0.0044444444444444444,\n          0.0044444444444444444,\n          0.0044444444444444444,\n          0.0044444444444444444,\n          0.013333333333333332,\n          0.0044444444444444444,\n          0.0044444444444444444,\n          0.008888888888888889,\n          0.0044444444444444444,\n          0.026666666666666665,\n          0.035555555555555556,\n          0.008888888888888889,\n          0.044444444444444446,\n          0.035555555555555556,\n          0.026666666666666665,\n          0.022222222222222223,\n          0.022222222222222223,\n          0.013333333333333332,\n          0.008888888888888889,\n          0.017777777777777778,\n          0.0044444444444444444,\n          0.008888888888888889,\n          0.0044444444444444444,\n          0.0044444444444444444,\n          0.06666666666666667,\n          0.008888888888888889,\n          0.017777777777777778,\n          0.017777777777777778,\n          0.04,\n          0.0044444444444444444,\n          0.008888888888888889,\n          0.0044444444444444444,\n          0.0044444444444444444,\n          0.008888888888888889,\n          0.017777777777777778,\n          0.0044444444444444444,\n          0.0044444444444444444,\n          0.008888888888888889,\n          0.022222222222222223,\n          0.03111111111111111,\n          0.008888888888888889,\n          0.044444444444444446,\n          0.035555555555555556,\n          0.026666666666666665,\n          0.026666666666666665,\n          0.022222222222222223,\n          0.017777777777777778,\n          0.008888888888888889,\n          0.017777777777777778,\n          0.0044444444444444444,\n          0.008888888888888889,\n          0.0044444444444444444,\n          0.0044444444444444444,\n          0.06666666666666667,\n          0.008888888888888889,\n          0.017777777777777778,\n          0.0044444444444444444,\n          0.017777777777777778,\n          0.03111111111111111,\n          0.008888888888888889,\n          0.008888888888888889,\n          0.0044444444444444444,\n          0.008888888888888889,\n          0.013333333333333332,\n          0.008888888888888889,\n          0.008888888888888889,\n          0.008888888888888889,\n          0.022222222222222223,\n          0.013333333333333332,\n          0.008888888888888889,\n          0.044444444444444446,\n          0.04,\n          0.022222222222222223,\n          0.022222222222222223,\n          0.022222222222222223,\n          0.03111111111111111,\n          0.0044444444444444444,\n          0.013333333333333332,\n          0.017777777777777778,\n          0.008888888888888889,\n          0.0044444444444444444,\n          0.0044444444444444444,\n          0.0044444444444444444,\n          0.06666666666666667,\n          0.008888888888888889,\n          0.026666666666666665,\n          0.0044444444444444444,\n          0.013333333333333332,\n          0.022222222222222223,\n          0.008888888888888889,\n          0.013333333333333332,\n          0.0044444444444444444,\n          0.008888888888888889,\n          0.008888888888888889,\n          0.008888888888888889,\n          0.0044444444444444444,\n          0.008888888888888889,\n          0.008888888888888889,\n          0.026666666666666665,\n          0.0044444444444444444,\n          0.0044444444444444444,\n          0.035555555555555556,\n          0.057777777777777775,\n          0.026666666666666665,\n          0.03111111111111111,\n          0.03111111111111111,\n          0.022222222222222223,\n          0.0044444444444444444,\n          0.013333333333333332,\n          0.013333333333333332,\n          0.008888888888888889,\n          0.0044444444444444444,\n          0.06666666666666667,\n          0.0044444444444444444,\n          0.026666666666666665,\n          0.0044444444444444444,\n          0.022222222222222223,\n          0.022222222222222223,\n          0.0044444444444444444,\n          0.013333333333333332,\n          0.0044444444444444444,\n          0.0044444444444444444,\n          0.0044444444444444444,\n          0.008888888888888889,\n          0.0044444444444444444,\n          0.0044444444444444444,\n          0.0044444444444444444,\n          0.0044444444444444444,\n          0.013333333333333332,\n          0.017777777777777778,\n          0.013333333333333332,\n          0.008888888888888889,\n          0.035555555555555556,\n          0.05333333333333333,\n          0.022222222222222223,\n          0.026666666666666665,\n          0.035555555555555556,\n          0.022222222222222223,\n          0.008888888888888889,\n          0.02222222222222222,\n          0.008888888888888889,\n          0.0044444444444444444,\n          0.0044444444444444444,\n          0.06666666666666667\n        ],\n        [\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0,\n          0\n        ]\n      ]\n    }\n  }\n]",
                         "scenarioId": "raw_frame"
-                      }
+                      },
+                      "version": "v0"
                     },
-                    "refId": "A",
-                    "hidden": false
+                    "refId": "A"
                   }
                 }
               ],
-              "transformations": [],
-              "queryOptions": {}
+              "queryOptions": {},
+              "transformations": []
             }
           },
+          "description": "",
+          "id": 15,
+          "links": [],
+          "title": "heatmap-cells frame",
           "vizConfig": {
-            "kind": "VizConfig",
             "group": "histogram",
-            "version": "",
+            "kind": "VizConfig",
             "spec": {
-              "options": {
-                "bucketOffset": 0,
-                "legend": {
-                  "calcs": [],
-                  "displayMode": "list",
-                  "placement": "bottom",
-                  "showLegend": true
-                }
-              },
               "fieldConfig": {
                 "defaults": {
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "value": null,
-                        "color": "green"
-                      },
-                      {
-                        "value": 80,
-                        "color": "red"
-                      }
-                    ]
-                  },
                   "color": {
                     "mode": "palette-classic"
                   },
@@ -481,7 +591,24 @@
                       "tooltip": false,
                       "viz": false
                     },
-                    "lineWidth": 1
+                    "lineWidth": 1,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
                   }
                 },
                 "overrides": [
@@ -498,18 +625,30 @@
                     ]
                   }
                 ]
+              },
+              "options": {
+                "bucketOffset": 0,
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "overflow": "ellipsis",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
               }
-            }
+            },
+            "version": "13.2.0-local"
           }
         }
       },
-      "panel-3": {
+      "panel-16": {
         "kind": "Panel",
         "spec": {
-          "id": 3,
-          "title": "Time series + bucket size 3",
-          "description": "",
-          "links": [],
           "data": {
             "kind": "QueryGroup",
             "spec": {
@@ -517,31 +656,1210 @@
                 {
                   "kind": "PanelQuery",
                   "spec": {
+                    "hidden": false,
                     "query": {
-                      "kind": "DataQuery",
-                      "group": "datasource",
-                      "version": "v0",
                       "datasource": {
-                        "name": "-- Dashboard --"
+                        "name": "PD8C576611E62080A"
                       },
+                      "group": "grafana-testdata-datasource",
+                      "kind": "DataQuery",
                       "spec": {
-                        "panelId": 4
-                      }
+                        "csvContent": "value\n0\n1\n9",
+                        "scenarioId": "csv_content",
+                        "seriesCount": 1
+                      },
+                      "version": "v0"
                     },
-                    "refId": "A",
-                    "hidden": false
+                    "refId": "A"
                   }
                 }
               ],
-              "transformations": [],
-              "queryOptions": {}
+              "queryOptions": {},
+              "transformations": []
             }
           },
+          "description": "",
+          "id": 17,
+          "links": [],
+          "title": "[0,1,9] bucket size 2",
           "vizConfig": {
-            "kind": "VizConfig",
             "group": "histogram",
-            "version": "",
+            "kind": "VizConfig",
             "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "fillOpacity": 80,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "lineWidth": 1,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "bucketSize": 2,
+                "combine": false,
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "overflow": "ellipsis",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "13.2.0-local"
+          }
+        }
+      },
+      "panel-17": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "PD8C576611E62080A"
+                      },
+                      "group": "grafana-testdata-datasource",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "csvContent": "value\n1\n3\n9",
+                        "scenarioId": "csv_content",
+                        "seriesCount": 1
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 18,
+          "links": [],
+          "title": "[1,3,9] bucket size 1",
+          "vizConfig": {
+            "group": "histogram",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "fillOpacity": 80,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "lineWidth": 1,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "bucketSize": 1,
+                "combine": false,
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "overflow": "ellipsis",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "13.2.0-local"
+          }
+        }
+      },
+      "panel-18": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "PD8C576611E62080A"
+                      },
+                      "group": "grafana-testdata-datasource",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "csvContent": "value\n0\n9",
+                        "scenarioId": "csv_content",
+                        "seriesCount": 1
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 19,
+          "links": [],
+          "title": "[0,9] bucket size auto",
+          "vizConfig": {
+            "group": "histogram",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "fillOpacity": 80,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "lineWidth": 1,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "combine": false,
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "overflow": "ellipsis",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "13.2.0-local"
+          }
+        }
+      },
+      "panel-20": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "PD8C576611E62080A"
+                      },
+                      "group": "grafana-testdata-datasource",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "csvContent": "value\n1\n3\n9",
+                        "scenarioId": "csv_content",
+                        "seriesCount": 1
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 20,
+          "links": [],
+          "title": "[1,3,9] bucket size 2",
+          "vizConfig": {
+            "group": "histogram",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "fillOpacity": 80,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "lineWidth": 1,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "bucketSize": 2,
+                "combine": false,
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "overflow": "ellipsis",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "13.2.0-local"
+          }
+        }
+      },
+      "panel-21": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "PD8C576611E62080A"
+                      },
+                      "group": "grafana-testdata-datasource",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "csvContent": "value\n1\n3\n9",
+                        "scenarioId": "csv_content",
+                        "seriesCount": 1
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 21,
+          "links": [],
+          "title": "[1,3,9] bucket size auto",
+          "vizConfig": {
+            "group": "histogram",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "fillOpacity": 80,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "lineWidth": 1,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "combine": false,
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "overflow": "ellipsis",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "13.2.0-local"
+          }
+        }
+      },
+      "panel-22": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "PD8C576611E62080A"
+                      },
+                      "group": "grafana-testdata-datasource",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "csvContent": "value\n0\n1\n9",
+                        "scenarioId": "csv_content",
+                        "seriesCount": 1
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 22,
+          "links": [],
+          "title": "[0,1,9] bucket size 1",
+          "vizConfig": {
+            "group": "histogram",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "fillOpacity": 80,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "lineWidth": 1,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "bucketSize": 1,
+                "combine": false,
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "overflow": "ellipsis",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "13.2.0-local"
+          }
+        }
+      },
+      "panel-23": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "PD8C576611E62080A"
+                      },
+                      "group": "grafana-testdata-datasource",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "csvContent": "value\n0\n1\n9",
+                        "scenarioId": "csv_content",
+                        "seriesCount": 1
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 23,
+          "links": [],
+          "title": "[0,1,9] bucket size auto",
+          "vizConfig": {
+            "group": "histogram",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "fillOpacity": 80,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "lineWidth": 1,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "combine": false,
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "overflow": "ellipsis",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "13.2.0-local"
+          }
+        }
+      },
+      "panel-24": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "PD8C576611E62080A"
+                      },
+                      "group": "grafana-testdata-datasource",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "csvContent": "value\n0\n9",
+                        "scenarioId": "csv_content",
+                        "seriesCount": 1
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 24,
+          "links": [],
+          "title": "[0,9] bucket size 2",
+          "vizConfig": {
+            "group": "histogram",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "fillOpacity": 80,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "lineWidth": 1,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "bucketSize": 2,
+                "combine": false,
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "overflow": "ellipsis",
+                  "placement": "bottom",
+                  "showLegend": false
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "13.2.0-local"
+          }
+        }
+      },
+      "panel-25": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "PD8C576611E62080A"
+                      },
+                      "group": "grafana-testdata-datasource",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "scenarioId": "csv_metric_values",
+                        "stringInput": "20,30,90"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 25,
+          "links": [],
+          "title": "panel config min = 0",
+          "vizConfig": {
+            "group": "histogram",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "fillOpacity": 80,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "lineWidth": 1,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    }
+                  },
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "overflow": "ellipsis",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "13.2.0-local"
+          }
+        }
+      },
+      "panel-26": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "PD8C576611E62080A"
+                      },
+                      "group": "grafana-testdata-datasource",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "scenarioId": "csv_metric_values",
+                        "stringInput": "20,30,90"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 26,
+          "links": [],
+          "title": "panel config min = 0, max = 110",
+          "vizConfig": {
+            "group": "histogram",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "fillOpacity": 80,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "lineWidth": 1,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    }
+                  },
+                  "max": 110,
+                  "min": 0,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "overflow": "ellipsis",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "13.2.0-local"
+          }
+        }
+      },
+      "panel-27": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "PD8C576611E62080A"
+                      },
+                      "group": "grafana-testdata-datasource",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "scenarioId": "csv_metric_values",
+                        "stringInput": "20,30,90"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 27,
+          "links": [],
+          "title": "panel config max = 110",
+          "vizConfig": {
+            "group": "histogram",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "fillOpacity": 80,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "lineWidth": 1,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    }
+                  },
+                  "max": 110,
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "overflow": "ellipsis",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "13.2.0-local"
+          }
+        }
+      },
+      "panel-28": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "PD8C576611E62080A"
+                      },
+                      "group": "grafana-testdata-datasource",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "scenarioId": "csv_metric_values",
+                        "stringInput": "20,30,90"
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 28,
+          "links": [],
+          "title": "auto x limits",
+          "vizConfig": {
+            "group": "histogram",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "fillOpacity": 80,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "lineWidth": 1,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
+              "options": {
+                "legend": {
+                  "calcs": [],
+                  "displayMode": "list",
+                  "overflow": "ellipsis",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
+              }
+            },
+            "version": "13.2.0-local"
+          }
+        }
+      },
+      "panel-3": {
+        "kind": "Panel",
+        "spec": {
+          "data": {
+            "kind": "QueryGroup",
+            "spec": {
+              "queries": [
+                {
+                  "kind": "PanelQuery",
+                  "spec": {
+                    "hidden": false,
+                    "query": {
+                      "datasource": {
+                        "name": "-- Dashboard --"
+                      },
+                      "group": "datasource",
+                      "kind": "DataQuery",
+                      "spec": {
+                        "panelId": 4
+                      },
+                      "version": "v0"
+                    },
+                    "refId": "A"
+                  }
+                }
+              ],
+              "queryOptions": {},
+              "transformations": []
+            }
+          },
+          "description": "",
+          "id": 3,
+          "links": [],
+          "title": "Time series + bucket size 3",
+          "vizConfig": {
+            "group": "histogram",
+            "kind": "VizConfig",
+            "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "fillOpacity": 80,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "lineWidth": 1,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
               "options": {
                 "bucketOffset": 0,
                 "bucketSize": 3,
@@ -549,52 +1867,24 @@
                 "legend": {
                   "calcs": ["sum"],
                   "displayMode": "list",
+                  "overflow": "ellipsis",
                   "placement": "bottom",
                   "showLegend": true
-                }
-              },
-              "fieldConfig": {
-                "defaults": {
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "value": null,
-                        "color": "green"
-                      },
-                      {
-                        "value": 80,
-                        "color": "red"
-                      }
-                    ]
-                  },
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "custom": {
-                    "fillOpacity": 80,
-                    "gradientMode": "none",
-                    "hideFrom": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": false
-                    },
-                    "lineWidth": 1
-                  }
                 },
-                "overrides": []
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
               }
-            }
+            },
+            "version": "13.2.0-local"
           }
         }
       },
       "panel-4": {
         "kind": "Panel",
         "spec": {
-          "id": 4,
-          "title": "Time series + Auto buckets",
-          "description": "",
-          "links": [],
           "data": {
             "kind": "QueryGroup",
             "spec": {
@@ -602,54 +1892,34 @@
                 {
                   "kind": "PanelQuery",
                   "spec": {
+                    "hidden": false,
                     "query": {
-                      "kind": "DataQuery",
                       "group": "grafana-testdata-datasource",
-                      "version": "v0",
+                      "kind": "DataQuery",
                       "spec": {
                         "scenarioId": "random_walk",
                         "spread": 10
-                      }
+                      },
+                      "version": "v0"
                     },
-                    "refId": "A",
-                    "hidden": false
+                    "refId": "A"
                   }
                 }
               ],
-              "transformations": [],
-              "queryOptions": {}
+              "queryOptions": {},
+              "transformations": []
             }
           },
+          "description": "",
+          "id": 4,
+          "links": [],
+          "title": "Time series + Auto buckets",
           "vizConfig": {
-            "kind": "VizConfig",
             "group": "histogram",
-            "version": "",
+            "kind": "VizConfig",
             "spec": {
-              "options": {
-                "bucketOffset": 0,
-                "combine": false,
-                "legend": {
-                  "calcs": ["sum"],
-                  "displayMode": "list",
-                  "placement": "bottom",
-                  "showLegend": true
-                }
-              },
               "fieldConfig": {
                 "defaults": {
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "value": null,
-                        "color": "green"
-                      },
-                      {
-                        "value": 80,
-                        "color": "red"
-                      }
-                    ]
-                  },
                   "color": {
                     "mode": "palette-classic"
                   },
@@ -661,22 +1931,52 @@
                       "tooltip": false,
                       "viz": false
                     },
-                    "lineWidth": 1
+                    "lineWidth": 1,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
                   }
                 },
                 "overrides": []
+              },
+              "options": {
+                "bucketOffset": 0,
+                "combine": false,
+                "legend": {
+                  "calcs": ["sum"],
+                  "displayMode": "list",
+                  "overflow": "ellipsis",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
               }
-            }
+            },
+            "version": "13.2.0-local"
           }
         }
       },
       "panel-5": {
         "kind": "Panel",
         "spec": {
-          "id": 5,
-          "title": "People height distribution",
-          "description": "",
-          "links": [],
           "data": {
             "kind": "QueryGroup",
             "spec": {
@@ -684,24 +1984,25 @@
                 {
                   "kind": "PanelQuery",
                   "spec": {
+                    "hidden": false,
                     "query": {
-                      "kind": "DataQuery",
                       "group": "grafana-testdata-datasource",
-                      "version": "v0",
+                      "kind": "DataQuery",
                       "spec": {
                         "csvFileName": "weight_height.csv",
                         "scenarioId": "csv_file"
-                      }
+                      },
+                      "version": "v0"
                     },
-                    "refId": "A",
-                    "hidden": false
+                    "refId": "A"
                   }
                 }
               ],
+              "queryOptions": {},
               "transformations": [
                 {
-                  "kind": "Transformation",
                   "group": "filterFieldsByName",
+                  "kind": "Transformation",
                   "spec": {
                     "options": {
                       "include": {
@@ -710,15 +2011,52 @@
                     }
                   }
                 }
-              ],
-              "queryOptions": {}
+              ]
             }
           },
+          "description": "",
+          "id": 5,
+          "links": [],
+          "title": "People height distribution",
           "vizConfig": {
-            "kind": "VizConfig",
             "group": "histogram",
-            "version": "",
+            "kind": "VizConfig",
             "spec": {
+              "fieldConfig": {
+                "defaults": {
+                  "color": {
+                    "mode": "palette-classic"
+                  },
+                  "custom": {
+                    "fillOpacity": 80,
+                    "gradientMode": "none",
+                    "hideFrom": {
+                      "legend": false,
+                      "tooltip": false,
+                      "viz": false
+                    },
+                    "lineWidth": 1,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
+                  }
+                },
+                "overrides": []
+              },
               "options": {
                 "bucketOffset": 0,
                 "bucketSize": 1,
@@ -726,52 +2064,24 @@
                 "legend": {
                   "calcs": ["sum"],
                   "displayMode": "list",
+                  "overflow": "ellipsis",
                   "placement": "bottom",
                   "showLegend": true
-                }
-              },
-              "fieldConfig": {
-                "defaults": {
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "value": null,
-                        "color": "green"
-                      },
-                      {
-                        "value": 80,
-                        "color": "red"
-                      }
-                    ]
-                  },
-                  "color": {
-                    "mode": "palette-classic"
-                  },
-                  "custom": {
-                    "fillOpacity": 80,
-                    "gradientMode": "none",
-                    "hideFrom": {
-                      "legend": false,
-                      "tooltip": false,
-                      "viz": false
-                    },
-                    "lineWidth": 1
-                  }
                 },
-                "overrides": []
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
               }
-            }
+            },
+            "version": "13.2.0-local"
           }
         }
       },
       "panel-6": {
         "kind": "Panel",
         "spec": {
-          "id": 6,
-          "title": "People weight distribution",
-          "description": "",
-          "links": [],
           "data": {
             "kind": "QueryGroup",
             "spec": {
@@ -779,24 +2089,25 @@
                 {
                   "kind": "PanelQuery",
                   "spec": {
+                    "hidden": false,
                     "query": {
-                      "kind": "DataQuery",
                       "group": "grafana-testdata-datasource",
-                      "version": "v0",
+                      "kind": "DataQuery",
                       "spec": {
                         "csvFileName": "weight_height.csv",
                         "scenarioId": "csv_file"
-                      }
+                      },
+                      "version": "v0"
                     },
-                    "refId": "A",
-                    "hidden": false
+                    "refId": "A"
                   }
                 }
               ],
+              "queryOptions": {},
               "transformations": [
                 {
-                  "kind": "Transformation",
                   "group": "filterFieldsByName",
+                  "kind": "Transformation",
                   "spec": {
                     "options": {
                       "include": {
@@ -805,41 +2116,19 @@
                     }
                   }
                 }
-              ],
-              "queryOptions": {}
+              ]
             }
           },
+          "description": "",
+          "id": 6,
+          "links": [],
+          "title": "People weight distribution",
           "vizConfig": {
-            "kind": "VizConfig",
             "group": "histogram",
-            "version": "",
+            "kind": "VizConfig",
             "spec": {
-              "options": {
-                "bucketOffset": 0,
-                "bucketSize": 5,
-                "combine": false,
-                "legend": {
-                  "calcs": ["sum"],
-                  "displayMode": "list",
-                  "placement": "bottom",
-                  "showLegend": true
-                }
-              },
               "fieldConfig": {
                 "defaults": {
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "value": null,
-                        "color": "green"
-                      },
-                      {
-                        "value": 80,
-                        "color": "red"
-                      }
-                    ]
-                  },
                   "color": {
                     "mode": "palette-classic"
                   },
@@ -851,22 +2140,53 @@
                       "tooltip": false,
                       "viz": false
                     },
-                    "lineWidth": 1
+                    "lineWidth": 1,
+                    "stacking": {
+                      "group": "A",
+                      "mode": "none"
+                    }
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
                   }
                 },
                 "overrides": []
+              },
+              "options": {
+                "bucketOffset": 0,
+                "bucketSize": 5,
+                "combine": false,
+                "legend": {
+                  "calcs": ["sum"],
+                  "displayMode": "list",
+                  "overflow": "ellipsis",
+                  "placement": "bottom",
+                  "showLegend": true
+                },
+                "tooltip": {
+                  "hideZeros": false,
+                  "mode": "single",
+                  "sort": "none"
+                }
               }
-            }
+            },
+            "version": "13.2.0-local"
           }
         }
       },
       "panel-8": {
         "kind": "Panel",
         "spec": {
-          "id": 8,
-          "title": "Standalone transform - Height",
-          "description": "",
-          "links": [],
           "data": {
             "kind": "QueryGroup",
             "spec": {
@@ -874,24 +2194,25 @@
                 {
                   "kind": "PanelQuery",
                   "spec": {
+                    "hidden": false,
                     "query": {
-                      "kind": "DataQuery",
                       "group": "grafana-testdata-datasource",
-                      "version": "v0",
+                      "kind": "DataQuery",
                       "spec": {
                         "csvFileName": "weight_height.csv",
                         "scenarioId": "csv_file"
-                      }
+                      },
+                      "version": "v0"
                     },
-                    "refId": "A",
-                    "hidden": false
+                    "refId": "A"
                   }
                 }
               ],
+              "queryOptions": {},
               "transformations": [
                 {
-                  "kind": "Transformation",
                   "group": "filterFieldsByName",
+                  "kind": "Transformation",
                   "spec": {
                     "disabled": true,
                     "options": {
@@ -902,8 +2223,8 @@
                   }
                 },
                 {
-                  "kind": "Transformation",
                   "group": "histogram",
+                  "kind": "Transformation",
                   "spec": {
                     "disabled": true,
                     "options": {
@@ -912,46 +2233,19 @@
                     }
                   }
                 }
-              ],
-              "queryOptions": {}
+              ]
             }
           },
+          "description": "",
+          "id": 8,
+          "links": [],
+          "title": "Standalone transform - Height",
           "vizConfig": {
-            "kind": "VizConfig",
             "group": "table",
-            "version": "10.4.0-pre",
+            "kind": "VizConfig",
             "spec": {
-              "options": {
-                "cellHeight": "sm",
-                "footer": {
-                  "countRows": false,
-                  "fields": [],
-                  "reducer": ["sum"],
-                  "show": false
-                },
-                "showHeader": true,
-                "sortBy": [
-                  {
-                    "desc": true,
-                    "displayName": "Height"
-                  }
-                ]
-              },
               "fieldConfig": {
                 "defaults": {
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "value": null,
-                        "color": "green"
-                      },
-                      {
-                        "value": 80,
-                        "color": "red"
-                      }
-                    ]
-                  },
                   "color": {
                     "mode": "palette-classic"
                   },
@@ -960,22 +2254,45 @@
                     "cellOptions": {
                       "type": "auto"
                     },
+                    "footer": {
+                      "reducers": []
+                    },
                     "inspect": false
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
                   }
                 },
                 "overrides": []
+              },
+              "options": {
+                "cellHeight": "sm",
+                "showHeader": true,
+                "sortBy": [
+                  {
+                    "desc": true,
+                    "displayName": "Height"
+                  }
+                ]
               }
-            }
+            },
+            "version": "13.2.0-local"
           }
         }
       },
       "panel-9": {
         "kind": "Panel",
         "spec": {
-          "id": 9,
-          "title": "Standalone transform - Weight",
-          "description": "",
-          "links": [],
           "data": {
             "kind": "QueryGroup",
             "spec": {
@@ -983,24 +2300,25 @@
                 {
                   "kind": "PanelQuery",
                   "spec": {
+                    "hidden": false,
                     "query": {
-                      "kind": "DataQuery",
                       "group": "grafana-testdata-datasource",
-                      "version": "v0",
+                      "kind": "DataQuery",
                       "spec": {
                         "csvFileName": "weight_height.csv",
                         "scenarioId": "csv_file"
-                      }
+                      },
+                      "version": "v0"
                     },
-                    "refId": "A",
-                    "hidden": false
+                    "refId": "A"
                   }
                 }
               ],
+              "queryOptions": {},
               "transformations": [
                 {
-                  "kind": "Transformation",
                   "group": "filterFieldsByName",
+                  "kind": "Transformation",
                   "spec": {
                     "options": {
                       "include": {
@@ -1010,8 +2328,8 @@
                   }
                 },
                 {
-                  "kind": "Transformation",
                   "group": "histogram",
+                  "kind": "Transformation",
                   "spec": {
                     "options": {
                       "combine": true,
@@ -1019,40 +2337,19 @@
                     }
                   }
                 }
-              ],
-              "queryOptions": {}
+              ]
             }
           },
+          "description": "",
+          "id": 9,
+          "links": [],
+          "title": "Standalone transform - Weight",
           "vizConfig": {
-            "kind": "VizConfig",
             "group": "table",
-            "version": "10.4.0-pre",
+            "kind": "VizConfig",
             "spec": {
-              "options": {
-                "cellHeight": "sm",
-                "footer": {
-                  "countRows": false,
-                  "fields": [],
-                  "reducer": ["sum"],
-                  "show": false
-                },
-                "showHeader": true
-              },
               "fieldConfig": {
                 "defaults": {
-                  "thresholds": {
-                    "mode": "absolute",
-                    "steps": [
-                      {
-                        "value": null,
-                        "color": "green"
-                      },
-                      {
-                        "value": 80,
-                        "color": "red"
-                      }
-                    ]
-                  },
                   "color": {
                     "mode": "palette-classic"
                   },
@@ -1061,12 +2358,33 @@
                     "cellOptions": {
                       "type": "auto"
                     },
+                    "footer": {
+                      "reducers": []
+                    },
                     "inspect": false
+                  },
+                  "thresholds": {
+                    "mode": "absolute",
+                    "steps": [
+                      {
+                        "color": "green",
+                        "value": 0
+                      },
+                      {
+                        "color": "red",
+                        "value": 80
+                      }
+                    ]
                   }
                 },
                 "overrides": []
+              },
+              "options": {
+                "cellHeight": "sm",
+                "showHeader": true
               }
-            }
+            },
+            "version": "13.2.0-local"
           }
         }
       }
@@ -1078,144 +2396,313 @@
           {
             "kind": "GridLayoutItem",
             "spec": {
-              "x": 0,
-              "y": 0,
-              "width": 12,
-              "height": 8,
               "element": {
                 "kind": "ElementReference",
                 "name": "panel-4"
-              }
+              },
+              "height": 8,
+              "width": 12,
+              "x": 0,
+              "y": 0
             }
           },
           {
             "kind": "GridLayoutItem",
             "spec": {
-              "x": 12,
-              "y": 0,
-              "width": 12,
-              "height": 8,
               "element": {
                 "kind": "ElementReference",
                 "name": "panel-3"
-              }
+              },
+              "height": 8,
+              "width": 12,
+              "x": 12,
+              "y": 0
             }
           },
           {
             "kind": "GridLayoutItem",
             "spec": {
-              "x": 0,
-              "y": 8,
-              "width": 12,
-              "height": 8,
               "element": {
                 "kind": "ElementReference",
                 "name": "panel-5"
-              }
+              },
+              "height": 8,
+              "width": 12,
+              "x": 0,
+              "y": 8
             }
           },
           {
             "kind": "GridLayoutItem",
             "spec": {
-              "x": 12,
-              "y": 8,
-              "width": 12,
-              "height": 8,
               "element": {
                 "kind": "ElementReference",
                 "name": "panel-6"
-              }
+              },
+              "height": 8,
+              "width": 12,
+              "x": 12,
+              "y": 8
             }
           },
           {
             "kind": "GridLayoutItem",
             "spec": {
-              "x": 0,
-              "y": 16,
-              "width": 12,
-              "height": 9,
               "element": {
                 "kind": "ElementReference",
                 "name": "panel-8"
-              }
+              },
+              "height": 9,
+              "width": 12,
+              "x": 0,
+              "y": 16
             }
           },
           {
             "kind": "GridLayoutItem",
             "spec": {
-              "x": 12,
-              "y": 16,
-              "width": 12,
-              "height": 9,
               "element": {
                 "kind": "ElementReference",
                 "name": "panel-9"
-              }
+              },
+              "height": 9,
+              "width": 12,
+              "x": 12,
+              "y": 16
             }
           },
           {
             "kind": "GridLayoutItem",
             "spec": {
-              "x": 0,
-              "y": 25,
-              "width": 8,
-              "height": 8,
               "element": {
                 "kind": "ElementReference",
                 "name": "panel-11"
-              }
+              },
+              "height": 8,
+              "width": 8,
+              "x": 0,
+              "y": 25
             }
           },
           {
             "kind": "GridLayoutItem",
             "spec": {
-              "x": 8,
-              "y": 25,
-              "width": 8,
-              "height": 8,
               "element": {
                 "kind": "ElementReference",
                 "name": "panel-12"
-              }
+              },
+              "height": 8,
+              "width": 8,
+              "x": 8,
+              "y": 25
             }
           },
           {
             "kind": "GridLayoutItem",
             "spec": {
-              "x": 16,
-              "y": 25,
-              "width": 8,
-              "height": 8,
               "element": {
                 "kind": "ElementReference",
                 "name": "panel-13"
-              }
+              },
+              "height": 8,
+              "width": 8,
+              "x": 16,
+              "y": 25
             }
           },
           {
             "kind": "GridLayoutItem",
             "spec": {
-              "x": 0,
-              "y": 33,
-              "width": 12,
-              "height": 8,
               "element": {
                 "kind": "ElementReference",
                 "name": "panel-14"
-              }
+              },
+              "height": 8,
+              "width": 12,
+              "x": 0,
+              "y": 33
             }
           },
           {
             "kind": "GridLayoutItem",
             "spec": {
-              "x": 12,
-              "y": 33,
-              "width": 12,
-              "height": 8,
               "element": {
                 "kind": "ElementReference",
                 "name": "panel-15"
-              }
+              },
+              "height": 8,
+              "width": 12,
+              "x": 12,
+              "y": 33
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-10"
+              },
+              "height": 7,
+              "width": 8,
+              "x": 0,
+              "y": 41
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-22"
+              },
+              "height": 7,
+              "width": 8,
+              "x": 8,
+              "y": 41
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-17"
+              },
+              "height": 7,
+              "width": 8,
+              "x": 16,
+              "y": 41
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-18"
+              },
+              "height": 7,
+              "width": 8,
+              "x": 0,
+              "y": 48
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-23"
+              },
+              "height": 7,
+              "width": 8,
+              "x": 8,
+              "y": 48
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-21"
+              },
+              "height": 7,
+              "width": 8,
+              "x": 16,
+              "y": 48
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-24"
+              },
+              "height": 7,
+              "width": 8,
+              "x": 0,
+              "y": 55
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-16"
+              },
+              "height": 7,
+              "width": 8,
+              "x": 8,
+              "y": 55
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-20"
+              },
+              "height": 7,
+              "width": 8,
+              "x": 16,
+              "y": 55
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-28"
+              },
+              "height": 8,
+              "width": 6,
+              "x": 0,
+              "y": 62
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-25"
+              },
+              "height": 8,
+              "width": 6,
+              "x": 6,
+              "y": 62
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-27"
+              },
+              "height": 8,
+              "width": 6,
+              "x": 12,
+              "y": 62
+            }
+          },
+          {
+            "kind": "GridLayoutItem",
+            "spec": {
+              "element": {
+                "kind": "ElementReference",
+                "name": "panel-26"
+              },
+              "height": 8,
+              "width": 6,
+              "x": 18,
+              "y": 62
             }
           }
         ]
@@ -1226,12 +2713,13 @@
     "preload": false,
     "tags": ["gdev", "panel-tests", "graph-ng"],
     "timeSettings": {
-      "from": "now-6h",
-      "to": "now",
       "autoRefresh": "",
       "autoRefreshIntervals": ["5s", "10s", "30s", "1m", "5m", "15m", "30m", "1h", "2h", "1d"],
+      "fiscalYearStartMonth": 0,
+      "from": "now-6h",
       "hideTimepicker": false,
-      "fiscalYearStartMonth": 0
+      "timezone": "browser",
+      "to": "now"
     },
     "title": "Panel Tests - Histogram",
     "variables": []

--- a/public/app/plugins/panel/histogram/Histogram.test.tsx
+++ b/public/app/plugins/panel/histogram/Histogram.test.tsx
@@ -376,7 +376,67 @@ describe('Histogram', () => {
       expect(min).toBe(0);
       expect(max).toBe(4);
     });
+    it('uses configured bucket width for sparse linear histogram bars', () => {
+      const barsMock = jest.requireMock('uplot').paths.bars as jest.Mock;
+      barsMock.mockClear();
 
+      const frame = createLinearHistogramFrame([0, 9], [1, 10], [5, 1]);
+
+      const hist = buildHistogram([frame], { bucketSize: 3 }, theme);
+      const alignedFrame = histogramFieldsToFrame(hist!);
+
+      setUp(
+        {
+          alignedFrame,
+          rawSeries: [frame],
+        },
+        { legend: { ...defaultLegendOptions, showLegend: false } }
+      );
+
+      expect(barsMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          align: 1,
+          disp: expect.objectContaining({
+            x0: expect.objectContaining({ unit: 1 }),
+            size: expect.objectContaining({ unit: 1 }),
+          }),
+        })
+      );
+
+      const barsConfig = barsMock.mock.calls[0][0];
+      expect(barsConfig.disp.size.values()).toEqual([3]);
+    });
+
+    it('uses size as the bucket size when data and bucket size makes one bucket', () => {
+      const barsMock = jest.requireMock('uplot').paths.bars as jest.Mock;
+      barsMock.mockClear();
+
+      const frame = createLinearHistogramFrame([0], [9], [1]);
+
+      const hist = buildHistogram([frame], { bucketSize: 10 }, theme);
+      const alignedFrame = histogramFieldsToFrame(hist!);
+
+      setUp(
+        {
+          alignedFrame,
+          rawSeries: [frame],
+        },
+        { legend: { ...defaultLegendOptions, showLegend: false } }
+      );
+
+      expect(barsMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          align: 1,
+          disp: expect.objectContaining({
+            x0: expect.objectContaining({ unit: 1 }),
+            size: expect.objectContaining({ unit: 1 }),
+          }),
+        })
+      );
+
+      const barsConfig = barsMock.mock.calls[0][0];
+      expect(barsConfig.disp.size.values()).toEqual([10]);
+    });
     /**
      * x scale range: xScaleMin/xScaleMax from count field config override wanted range.
      */

--- a/public/app/plugins/panel/histogram/Histogram.tsx
+++ b/public/app/plugins/panel/histogram/Histogram.tsx
@@ -77,14 +77,17 @@ const prepConfig = (frame: DataFrame, theme: GrafanaTheme2) => {
   let builder = new UPlotConfigBuilder();
 
   let isOrdinalX = frame.fields[0].type === FieldType.string;
+  let isOneValue = frame.fields[0].values.length === 1;
 
   // assumes BucketMin is fields[0] and BucktMax is fields[1]
   let bucketSize = getBucketSize(frame);
-  let bucketSize1 = getBucketSize1(frame);
-
-  let bucketFactor = bucketSize1 / bucketSize;
-
-  let useLogScale = bucketSize1 !== bucketSize; // (imperfect floats)
+  let bucketFactor: number; // only used for log scale
+  let useLogScale = false;
+  if (!isOneValue) {
+    let bucketSize1 = getBucketSize1(frame);
+    bucketFactor = bucketSize1 / bucketSize;
+    useLogScale = bucketSize1 !== bucketSize; // (imperfect floats)
+  }
 
   // splits shifter, to ensure splits always start at first bucket
   let xSplits: uPlot.Axis.Splits = (u, axisIdx, scaleMin, scaleMax, foundIncr, foundSpace) => {
@@ -127,6 +130,8 @@ const prepConfig = (frame: DataFrame, theme: GrafanaTheme2) => {
           }
           if (xScaleMax != null) {
             wantedMax = xScaleMax;
+          } else if (isOneValue) {
+            wantedMax = bucketSize; // if theres only one bucket, the max is the size of that bucket
           }
 
           let fullRangeMax = u.data[0][u.data[0].length - 1];
@@ -221,7 +226,25 @@ const prepConfig = (frame: DataFrame, theme: GrafanaTheme2) => {
   let stackingGroups = getStackingGroups(xMinOnlyFrame(frame));
   builder.setStackingGroups(stackingGroups);
 
-  let pathBuilder = uPlot.paths.bars!({ align: 1, size: [1, Infinity] });
+  // Uniform bucket width only applies to linear numeric histograms.
+  let pathBuilder = uPlot.paths.bars!(
+    isOrdinalX || useLogScale
+      ? { align: 1, size: [1, Infinity] }
+      : {
+          align: 1,
+          disp: {
+            x0: {
+              unit: 1,
+              // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+              values: (u) => u.data[0] as number[],
+            },
+            size: {
+              unit: 1,
+              values: () => [bucketSize],
+            },
+          },
+        }
+  );
 
   let seriesIndex = 0;
 


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**
Fixes histogram bar rendering for sparse linear numeric buckets. Bars now use the configured/computed bucket width instead of uPlot's inferred adjacent x-value spacing.

Panels 1 and 3 below are wrong, panel 2 is correct.  This change ensures all 3 panels render correctly (with single-width bars in all cases) 

<img width="905" height="619" alt="image" src="https://github.com/user-attachments/assets/8b85ad86-991d-4ff5-9697-80e9885ffc53" />

**Example Dashboard**
Here's the JSON I pulled from the original issue - I'm not highly confident if this is a "valid provisioning dashboard" since I don't know the format that well - but the json for each panel should be valid 

```
{
  "annotations": {"list": []},
  "editable": true,
  "fiscalYearStartMonth": 0,
  "graphTooltip": 0,
  "id": null,
  "uid": "hist-debug",
  "title": "Histogram Bug Repro",
  "tags": ["debug"],
  "timezone": "",
  "schemaVersion": 39,
  "version": 0,
  "weekStart": "",
  "time": {"from": "now-1h", "to": "now"},
  "timepicker": {},
  "templating": {"list": []},
  "panels": [
    {
      "id": 1,
      "type": "text",
      "gridPos": {"h": 6, "w": 24, "x": 0, "y": 0},
      "options": {
        "mode": "markdown",
        "content": "All three panels use identical `bucketSize: 1` and the same TestData CSV Content datasource. Only the input values differ."
      }
    },
    {
      "id": 2,
      "type": "histogram",
      "title": "Values [0,0,0,0,0,9]. Bars at 0 and 9 are drawn 9 units wide.",
      "description": "Two populated bucket positions, separated by 9. With bucketSize=1 each bar is 1 unit wide by definition; the panel draws each bar 9 units wide.",
      "gridPos": {"h": 9, "w": 12, "x": 0, "y": 6},
      "datasource": {"type": "grafana-testdata-datasource", "uid": "testdata"},
      "fieldConfig": {"defaults": {}, "overrides": []},
      "options": {"bucketSize": 1, "bucketOffset": 0, "combine": false, "legend": {"showLegend": false}},
      "targets": [{
        "refId": "A",
        "datasource": {"type": "grafana-testdata-datasource", "uid": "testdata"},
        "scenarioId": "csv_content",
        "csvContent": "value\n0\n0\n0\n0\n0\n9"
      }]
    },
    {
      "id": 3,
      "type": "histogram",
      "title": "Values [0, 1, 9]. Bars are drawn 1 unit wide.",
      "description": "Three populated bucket positions. Minimum gap between adjacent populated positions is 1 (from 0 to 1). With bucketSize=1 each bar is 1 unit wide by definition; the panel draws each bar 1 unit wide. X-axis is extended to 11 to show the bar at position 9 with surrounding space.",
      "gridPos": {"h": 9, "w": 12, "x": 12, "y": 6},
      "datasource": {"type": "grafana-testdata-datasource", "uid": "testdata"},
      "fieldConfig": {"defaults": {"min": 0, "max": 11}, "overrides": []},
      "options": {"bucketSize": 1, "bucketOffset": 0, "combine": false, "legend": {"showLegend": false}},
      "targets": [{
        "refId": "A",
        "datasource": {"type": "grafana-testdata-datasource", "uid": "testdata"},
        "scenarioId": "csv_content",
        "csvContent": "value\n0\n1\n9"
      }]
    },
    {
      "id": 5,
      "type": "histogram",
      "title": "Values [1, 3, 9]. Bars are drawn 2 units wide.",
      "description": "Three populated bucket positions. Minimum gap between adjacent populated positions is 2 (from 1 to 3). With bucketSize=1 each bar is 1 unit wide by definition; the panel draws each bar 2 units wide, including the bar at position 9. X-axis is extended to 11 to show the bar at position 9 with surrounding space.",
      "gridPos": {"h": 9, "w": 24, "x": 0, "y": 15},
      "datasource": {"type": "grafana-testdata-datasource", "uid": "testdata"},
      "fieldConfig": {"defaults": {"min": 0, "max": 11}, "overrides": []},
      "options": {"bucketSize": 1, "bucketOffset": 0, "combine": false, "legend": {"showLegend": false}},
      "targets": [{
        "refId": "A",
        "datasource": {"type": "grafana-testdata-datasource", "uid": "testdata"},
        "scenarioId": "csv_content",
        "csvContent": "value\n1\n3\n9"
      }]
    }
  ]
}
```

**Why do we need this feature?**

Sparse histogram data renders bars much wider than their actual bucket size. For example, with bucketSize=1 and populated buckets at 0 and 9, each bar would be drawn 9 units wide, visually smearing counts across empty buckets.

**Who is this feature for?**

Users viewing histogram panels with sparse linear numeric data.

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #125761 

**Special notes for your reviewer:**

Tests run:

- `mise exec node@24.11.0 -- node .yarn/releases/yarn-4.15.0.cjs jest --no-watch public/app/plugins/panel/histogram/Histogram.test.tsx`
- `mise exec node@24.11.0 -- node .yarn/releases/yarn-4.15.0.cjs eslint public/app/plugins/panel/histogram/Histogram.tsx public/app/plugins/panel/histogram/Histogram.test.tsx`
- `mise exec node@24.11.0 -- node .yarn/releases/yarn-4.15.0.cjs prettier --check public/app/plugins/panel/histogram/Histogram.tsx public/app/plugins/panel/histogram/Histogram.test.tsx`

Please check that:
- [X] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
This is a bug fix to existing histogram rendering behavior, so no docs or feature toggle are included.

The change is scoped to linear numeric histograms. Ordinal histograms and log/variable-width histograms don't seem to be affected by the issue so I excluded them from the fix.
