### PR TITLE
Use local open index list on search startup

### DIFF
--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -1093,6 +1093,8 @@ func (s *searchServer) startupIndexStats(ctx context.Context) ([]ResourceStats, 
 	if err != nil {
 		s.log.FromContext(ctx).Warn("failed to load open index stats, falling back to resource stats", "error", err)
 	} else if len(stats) > 0 {
+		// Do not apply initMinSize here: open index stats restore indexes that were recently open on this node,
+		// rather than discovering resources from storage.
 		s.log.FromContext(ctx).Info("using open index stats", "indexes", len(stats))
 		return stats, nil
 	} else {

--- a/pkg/storage/unified/resource/search.go
+++ b/pkg/storage/unified/resource/search.go
@@ -41,6 +41,9 @@ import (
 
 const maxBatchSize = 1000
 
+// openIndexStatsMaxAge is how far back startup accepts the local open index list.
+const openIndexStatsMaxAge = time.Hour
+
 // unknownBuildSize is passed when the caller does not have a cheap size hint.
 // Backends should treat it as unknown, not as an empty resource.
 const unknownBuildSize int64 = -1
@@ -122,8 +125,15 @@ type BuildFn func(index ResourceIndex) (int64, error)
 // UpdateFn is responsible for updating index with changes since given RV. It should return new RV (to be used as next sinceRV), number of updated documents and error, if any.
 type UpdateFn func(context context.Context, index ResourceIndex, sinceRV int64) (newRV int64, updatedDocs int, _ error)
 
-// SearchBackend contains the technology specific logic to support search
+// SearchBackend contains the technology specific logic to support search.
 type SearchBackend interface {
+	// LoadOpenIndexStats returns recently-open indexes from local backend state.
+	// Empty stats means no usable state exists, and callers should fall back to storage stats.
+	LoadOpenIndexStats(now time.Time, maxAge time.Duration) ([]ResourceStats, error)
+
+	// WriteOpenIndexStats persists currently-open indexes to local backend state.
+	WriteOpenIndexStats(now time.Time) error
+
 	// GetIndex returns existing index, or nil.
 	GetIndex(key NamespacedResource) ResourceIndex
 
@@ -156,6 +166,9 @@ type SearchBackend interface {
 
 	// GetOpenIndexes returns the list of indexes that are currently open.
 	GetOpenIndexes() []NamespacedResource
+
+	// Stop closes indexes and stops backend background tasks.
+	Stop()
 }
 
 // searchServer supports indexing+search regardless of implementation.
@@ -1075,12 +1088,26 @@ func (s *searchServer) RebuildIndexes(ctx context.Context, req *resourcepb.Rebui
 	}, nil
 }
 
+func (s *searchServer) startupIndexStats(ctx context.Context) ([]ResourceStats, error) {
+	stats, err := s.search.LoadOpenIndexStats(time.Now(), openIndexStatsMaxAge)
+	if err != nil {
+		s.log.FromContext(ctx).Warn("failed to load open index stats, falling back to resource stats", "error", err)
+	} else if len(stats) > 0 {
+		s.log.FromContext(ctx).Info("using open index stats", "indexes", len(stats))
+		return stats, nil
+	} else {
+		s.log.FromContext(ctx).Debug("open index stats unavailable, falling back to resource stats")
+	}
+
+	return s.storage.GetResourceStats(ctx, NamespacedResource{}, s.initMinSize)
+}
+
 func (s *searchServer) buildIndexes(ctx context.Context) (int, error) {
 	totalBatchesIndexed := 0
 	group := errgroup.Group{}
 	group.SetLimit(s.initWorkers)
 
-	stats, err := s.storage.GetResourceStats(ctx, NamespacedResource{}, s.initMinSize)
+	stats, err := s.startupIndexStats(ctx)
 	if err != nil {
 		return 0, err
 	}
@@ -1145,9 +1172,12 @@ func (s *searchServer) init(ctx context.Context) error {
 }
 
 func (s *searchServer) stop() {
-	// Stop background tasks.
+	// This stops search-server tasks only: rebuild workers, rebuild scans, and rate-limit sweeping.
 	s.bgTaskCancel()
 	s.bgTaskWg.Wait()
+
+	// Stop the backend after search-server workers so no rebuild can race with closing indexes.
+	s.search.Stop()
 }
 
 // Init initializes the search server.

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -143,12 +143,21 @@ type mockSearchBackend struct {
 	mu              sync.Mutex
 	buildIndexCalls []buildIndexCall
 	cache           map[NamespacedResource]ResourceIndex
+	stopCalls       atomic.Int32
 }
 
 type buildIndexCall struct {
 	key    NamespacedResource
 	size   int64
 	fields SearchableDocumentFields
+}
+
+func (m *mockSearchBackend) LoadOpenIndexStats(_ time.Time, _ time.Duration) ([]ResourceStats, error) {
+	return nil, nil
+}
+
+func (m *mockSearchBackend) WriteOpenIndexStats(_ time.Time) error {
+	return nil
 }
 
 func (m *mockSearchBackend) GetIndex(key NamespacedResource) ResourceIndex {
@@ -191,6 +200,133 @@ func (m *mockSearchBackend) TotalDocs() int64 {
 
 func (m *mockSearchBackend) GetOpenIndexes() []NamespacedResource {
 	return m.openIndexes
+}
+
+func (m *mockSearchBackend) Stop() {
+	m.stopCalls.Add(1)
+}
+
+type manifestSearchBackend struct {
+	mockSearchBackend
+
+	stats    []ResourceStats
+	ok       bool
+	loadErr  error
+	loadCall atomic.Int32
+}
+
+func (m *manifestSearchBackend) LoadOpenIndexStats(_ time.Time, _ time.Duration) ([]ResourceStats, error) {
+	m.loadCall.Add(1)
+	if !m.ok {
+		return nil, m.loadErr
+	}
+	return append([]ResourceStats(nil), m.stats...), m.loadErr
+}
+
+func TestBuildIndexesUsesOpenIndexStats(t *testing.T) {
+	key := NamespacedResource{Namespace: "ns", Group: "group", Resource: "resource"}
+	storage := &mockStorageBackend{
+		resourceStats: []ResourceStats{{NamespacedResource: NamespacedResource{Namespace: "fallback", Group: "group", Resource: "resource"}, Count: 50}},
+	}
+	search := &manifestSearchBackend{
+		stats: []ResourceStats{{NamespacedResource: key, Count: 0}},
+		ok:    true,
+	}
+	supplier := &TestDocumentBuilderSupplier{
+		GroupsResources: map[string]string{"group": "resource"},
+	}
+
+	support, err := newSearchServer(SearchOptions{
+		Backend:      search,
+		Resources:    supplier,
+		InitMinCount: 10,
+	}, storage, nil, nil, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	built, err := support.buildIndexes(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, 1, built)
+	require.Equal(t, int32(1), search.loadCall.Load())
+	require.Zero(t, storage.statsCalls.Load())
+	require.Len(t, search.buildIndexCalls, 1)
+	require.Equal(t, key, search.buildIndexCalls[0].key)
+	require.Equal(t, int64(0), search.buildIndexCalls[0].size)
+}
+
+func TestBuildIndexesFallsBackToResourceStats(t *testing.T) {
+	key := NamespacedResource{Namespace: "ns", Group: "group", Resource: "resource"}
+	storage := &mockStorageBackend{
+		resourceStats: []ResourceStats{{NamespacedResource: key, Count: 50}},
+	}
+	search := &manifestSearchBackend{ok: false}
+	supplier := &TestDocumentBuilderSupplier{
+		GroupsResources: map[string]string{"group": "resource"},
+	}
+
+	support, err := newSearchServer(SearchOptions{
+		Backend:      search,
+		Resources:    supplier,
+		InitMinCount: 10,
+	}, storage, nil, nil, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+
+	built, err := support.buildIndexes(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, 1, built)
+	require.Equal(t, int32(1), search.loadCall.Load())
+	require.Equal(t, int32(1), storage.statsCalls.Load())
+	require.Len(t, search.buildIndexCalls, 1)
+	require.Equal(t, key, search.buildIndexCalls[0].key)
+	require.Equal(t, int64(50), search.buildIndexCalls[0].size)
+}
+
+func TestBuildIndexesAppliesOwnershipToOpenIndexStats(t *testing.T) {
+	owned := NamespacedResource{Namespace: "owned", Group: "group", Resource: "resource"}
+	unowned := NamespacedResource{Namespace: "unowned", Group: "group", Resource: "resource"}
+	storage := &mockStorageBackend{}
+	search := &manifestSearchBackend{
+		stats: []ResourceStats{
+			{NamespacedResource: owned, Count: 10},
+			{NamespacedResource: unowned, Count: 10},
+		},
+		ok: true,
+	}
+	supplier := &TestDocumentBuilderSupplier{
+		GroupsResources: map[string]string{"group": "resource"},
+	}
+	ownsIndexFn := func(key NamespacedResource) (bool, error) {
+		return key != unowned, nil
+	}
+
+	support, err := newSearchServer(SearchOptions{
+		Backend:   search,
+		Resources: supplier,
+	}, storage, nil, nil, nil, nil, nil, nil, ownsIndexFn)
+	require.NoError(t, err)
+
+	built, err := support.buildIndexes(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, 1, built)
+	require.Zero(t, storage.statsCalls.Load())
+	require.Len(t, search.buildIndexCalls, 1)
+	require.Equal(t, owned, search.buildIndexCalls[0].key)
+}
+
+func TestSearchServerStopStopsBackend(t *testing.T) {
+	search := &mockSearchBackend{}
+	supplier := &TestDocumentBuilderSupplier{
+		GroupsResources: map[string]string{"group": "resource"},
+	}
+
+	support, err := newSearchServer(SearchOptions{
+		Backend:   search,
+		Resources: supplier,
+	}, &mockStorageBackend{}, nil, nil, nil, nil, nil, nil, nil)
+	require.NoError(t, err)
+	support.bgTaskCancel = func() {}
+
+	support.stop()
+	require.Equal(t, int32(1), search.stopCalls.Load())
 }
 
 func TestSearchGetOrCreateIndex(t *testing.T) {

--- a/pkg/storage/unified/resource/search_test.go
+++ b/pkg/storage/unified/resource/search_test.go
@@ -229,7 +229,7 @@ func TestBuildIndexesUsesOpenIndexStats(t *testing.T) {
 		resourceStats: []ResourceStats{{NamespacedResource: NamespacedResource{Namespace: "fallback", Group: "group", Resource: "resource"}, Count: 50}},
 	}
 	search := &manifestSearchBackend{
-		stats: []ResourceStats{{NamespacedResource: key, Count: 0}},
+		stats: []ResourceStats{{NamespacedResource: key, Count: 5}},
 		ok:    true,
 	}
 	supplier := &TestDocumentBuilderSupplier{
@@ -250,7 +250,7 @@ func TestBuildIndexesUsesOpenIndexStats(t *testing.T) {
 	require.Zero(t, storage.statsCalls.Load())
 	require.Len(t, search.buildIndexCalls, 1)
 	require.Equal(t, key, search.buildIndexCalls[0].key)
-	require.Equal(t, int64(0), search.buildIndexCalls[0].size)
+	require.Equal(t, int64(5), search.buildIndexCalls[0].size)
 }
 
 func TestBuildIndexesFallsBackToResourceStats(t *testing.T) {

--- a/pkg/storage/unified/search/bleve.go
+++ b/pkg/storage/unified/search/bleve.go
@@ -263,6 +263,9 @@ func NewBleveBackend(opts BleveOptions, indexMetrics *resource.BleveIndexMetrics
 	be.bgTasksWg.Add(1)
 	go be.evictExpiredOrUnownedIndexesPeriodically(ctx)
 
+	be.bgTasksWg.Add(1)
+	go be.writeOpenIndexListPeriodically(ctx)
+
 	if opts.Snapshot.Store != nil {
 		// Initialise snapshot metric label series only on instances where the
 		// feature is actually wired up; ProvideIndexMetrics deliberately skips
@@ -1516,10 +1519,15 @@ func (b *bleveBackend) findPreviousFileBasedIndex(resourceDir string) (bleve.Ind
 
 // Stop closes all indexes and stops background tasks.
 func (b *bleveBackend) Stop() {
-	b.closeAllIndexes()
-
 	b.bgTasksCancel()
 	b.bgTasksWg.Wait()
+
+	// Stop the periodic writer before the final write so shutdown writes one stable list.
+	if err := b.WriteOpenIndexStats(time.Now()); err != nil {
+		b.log.Warn("failed to write open index stats during shutdown", "err", err)
+	}
+
+	b.closeAllIndexes()
 }
 
 func (b *bleveBackend) closeAllIndexes() {

--- a/pkg/storage/unified/search/open_index_list.go
+++ b/pkg/storage/unified/search/open_index_list.go
@@ -1,0 +1,233 @@
+package search
+
+import (
+	"cmp"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"path/filepath"
+	"slices"
+	"time"
+
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
+)
+
+const (
+	openIndexListFileName = "open-indexes.json"
+
+	// openIndexListWriteInterval controls how often we refresh the best-effort startup hint between graceful shutdowns.
+	openIndexListWriteInterval = 15 * time.Minute
+)
+
+type openIndexListFile struct {
+	// WrittenAt is formatted as time.RFC3339Nano.
+	WrittenAt string `json:"writtenAt"`
+	// Indexes contains one entry for each open index with at least one document.
+	Indexes []openIndexListEntry `json:"indexes"`
+}
+
+type openIndexListEntry struct {
+	Namespace string `json:"namespace"`
+	Group     string `json:"group"`
+	Resource  string `json:"resource"`
+	DocCount  int64  `json:"docCount"`
+}
+
+func (b *bleveBackend) LoadOpenIndexStats(now time.Time, maxAge time.Duration) ([]resource.ResourceStats, error) {
+	path := filepath.Join(b.opts.Root, openIndexListFileName)
+	file, err := os.Open(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			b.log.Warn("failed to close open index list", "path", path, "err", closeErr)
+		}
+	}()
+
+	return readOpenIndexList(file, now, maxAge)
+}
+
+// readOpenIndexList validates an open index list and returns why it should not be trusted.
+func readOpenIndexList(reader io.Reader, now time.Time, maxAge time.Duration) ([]resource.ResourceStats, error) {
+	var list openIndexListFile
+	if err := json.NewDecoder(reader).Decode(&list); err != nil {
+		return nil, fmt.Errorf("invalid open index list JSON: %w", err)
+	}
+	if err := validateOpenIndexListTimestamp(list.WrittenAt, now, maxAge); err != nil {
+		return nil, err
+	}
+	if len(list.Indexes) == 0 {
+		return nil, fmt.Errorf("open index list has no indexes")
+	}
+
+	stats := make([]resource.ResourceStats, 0, len(list.Indexes))
+	seen := map[resource.NamespacedResource]bool{}
+	for i, entry := range list.Indexes {
+		stat, ok := openIndexListStat(entry)
+		if !ok {
+			return nil, fmt.Errorf("invalid index entry at position %d", i)
+		}
+		if seen[stat.NamespacedResource] {
+			return nil, fmt.Errorf("duplicate index entry for %s", stat.NamespacedResource.String())
+		}
+		seen[stat.NamespacedResource] = true
+		stats = append(stats, stat)
+	}
+	return stats, nil
+}
+
+func validateOpenIndexListTimestamp(writtenAtValue string, now time.Time, maxAge time.Duration) error {
+	if writtenAtValue == "" {
+		return fmt.Errorf("open index list is missing writtenAt")
+	}
+	writtenAt, err := time.Parse(time.RFC3339Nano, writtenAtValue)
+	if err != nil {
+		return fmt.Errorf("invalid open index list writtenAt: %w", err)
+	}
+	if writtenAt.After(now) {
+		return fmt.Errorf("open index list writtenAt is in the future")
+	}
+	if maxAge > 0 && now.Sub(writtenAt) > maxAge {
+		return fmt.Errorf("open index list is stale")
+	}
+	return nil
+}
+
+func openIndexListStat(entry openIndexListEntry) (resource.ResourceStats, bool) {
+	if entry.Namespace == "" || entry.Group == "" || entry.Resource == "" || entry.DocCount <= 0 {
+		return resource.ResourceStats{}, false
+	}
+	return resource.ResourceStats{
+		NamespacedResource: resource.NamespacedResource{
+			Namespace: entry.Namespace,
+			Group:     entry.Group,
+			Resource:  entry.Resource,
+		},
+		Count: entry.DocCount,
+	}, true
+}
+
+func (b *bleveBackend) WriteOpenIndexStats(now time.Time) error {
+	if err := os.MkdirAll(b.opts.Root, 0o750); err != nil {
+		return err
+	}
+
+	keys := b.GetOpenIndexes()
+	slices.SortFunc(keys, compareNamespacedResource)
+
+	indexes := make([]openIndexListEntry, 0, len(keys))
+	for _, key := range keys {
+		idx := b.peekCachedIndex(key)
+		if idx == nil {
+			continue
+		}
+
+		docCount, err := idx.index.DocCount()
+		if err != nil {
+			b.log.Debug("skipping index in open index stats because document count is unavailable", "key", key, "err", err)
+			continue
+		}
+
+		if docCount == 0 {
+			continue
+		}
+		if docCount > math.MaxInt64 {
+			b.log.Debug("skipping index in open index stats because document count is too large", "key", key, "docCount", docCount)
+			continue
+		}
+
+		indexes = append(indexes, openIndexListEntry{
+			Namespace: key.Namespace,
+			Group:     key.Group,
+			Resource:  key.Resource,
+			DocCount:  int64(docCount),
+		})
+	}
+
+	path := filepath.Join(b.opts.Root, openIndexListFileName)
+
+	// If no currently-open index has documents, remove any previous open index list so startup falls back to storage stats.
+	if len(indexes) == 0 {
+		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		return nil
+	}
+
+	contents, err := json.Marshal(openIndexListFile{
+		WrittenAt: now.UTC().Format(time.RFC3339Nano),
+		Indexes:   indexes,
+	})
+	if err != nil {
+		return err
+	}
+	contents = append(contents, '\n')
+
+	// Disk cleanup only removes resource subdirectories, so root-level open index list files are not candidates.
+	tmp, err := os.CreateTemp(b.opts.Root, ".open-indexes-*.tmp")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	closed := false
+	deleteTmpFile := true
+	defer func() {
+		if !closed {
+			_ = tmp.Close()
+		}
+		if deleteTmpFile {
+			_ = os.Remove(tmpName)
+		}
+	}()
+
+	if _, err := tmp.Write(contents); err != nil {
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+	closed = true
+
+	if err := os.Rename(tmpName, path); err != nil {
+		return err
+	}
+	deleteTmpFile = false
+
+	return nil
+}
+
+func compareNamespacedResource(a, b resource.NamespacedResource) int {
+	if c := cmp.Compare(a.Namespace, b.Namespace); c != 0 {
+		return c
+	}
+	if c := cmp.Compare(a.Group, b.Group); c != 0 {
+		return c
+	}
+	return cmp.Compare(a.Resource, b.Resource)
+}
+
+func (b *bleveBackend) writeOpenIndexListPeriodically(ctx context.Context) {
+	defer b.bgTasksWg.Done()
+
+	ticker := time.NewTicker(openIndexListWriteInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now := <-ticker.C:
+			if err := b.WriteOpenIndexStats(now); err != nil {
+				b.log.Warn("failed to write open index stats", "err", err)
+			}
+		}
+	}
+}

--- a/pkg/storage/unified/search/open_index_list.go
+++ b/pkg/storage/unified/search/open_index_list.go
@@ -64,7 +64,7 @@ func (b *bleveBackend) LoadOpenIndexStats(now time.Time, maxAge time.Duration) (
 	return readOpenIndexList(file, now, maxAge)
 }
 
-// readOpenIndexList validates an open index list and returns why it should not be trusted.
+// readOpenIndexList validates an open index list and returns error if invalid.
 func readOpenIndexList(reader io.Reader, now time.Time, maxAge time.Duration) ([]resource.ResourceStats, error) {
 	var list openIndexListFile
 	if err := json.NewDecoder(reader).Decode(&list); err != nil {

--- a/pkg/storage/unified/search/open_index_list.go
+++ b/pkg/storage/unified/search/open_index_list.go
@@ -38,8 +38,17 @@ type openIndexListEntry struct {
 }
 
 func (b *bleveBackend) LoadOpenIndexStats(now time.Time, maxAge time.Duration) ([]resource.ResourceStats, error) {
-	path := filepath.Join(b.opts.Root, openIndexListFileName)
-	file, err := os.Open(path)
+	root, err := os.OpenRoot(b.opts.Root)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if closeErr := root.Close(); closeErr != nil {
+			b.log.Warn("failed to close open index list root", "path", b.opts.Root, "err", closeErr)
+		}
+	}()
+
+	file, err := root.Open(openIndexListFileName)
 	if errors.Is(err, os.ErrNotExist) {
 		return nil, nil
 	}
@@ -48,7 +57,7 @@ func (b *bleveBackend) LoadOpenIndexStats(now time.Time, maxAge time.Duration) (
 	}
 	defer func() {
 		if closeErr := file.Close(); closeErr != nil {
-			b.log.Warn("failed to close open index list", "path", path, "err", closeErr)
+			b.log.Warn("failed to close open index list", "path", filepath.Join(b.opts.Root, openIndexListFileName), "err", closeErr)
 		}
 	}()
 
@@ -76,7 +85,7 @@ func readOpenIndexList(reader io.Reader, now time.Time, maxAge time.Duration) ([
 			return nil, fmt.Errorf("invalid index entry at position %d", i)
 		}
 		if seen[stat.NamespacedResource] {
-			return nil, fmt.Errorf("duplicate index entry for %s", stat.NamespacedResource.String())
+			return nil, fmt.Errorf("duplicate index entry for %s", stat.String())
 		}
 		seen[stat.NamespacedResource] = true
 		stats = append(stats, stat)

--- a/pkg/storage/unified/search/open_index_list_test.go
+++ b/pkg/storage/unified/search/open_index_list_test.go
@@ -1,0 +1,129 @@
+package search
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/storage/unified/resource"
+)
+
+func TestOpenIndexListWriteAndLoad(t *testing.T) {
+	backend, err := NewBleveBackend(BleveOptions{
+		Root:          t.TempDir(),
+		FileThreshold: 10,
+	}, nil)
+	require.NoError(t, err)
+	t.Cleanup(backend.Stop)
+
+	first := resource.NamespacedResource{Namespace: "ns-a", Group: "group-a", Resource: "resource-a"}
+	second := resource.NamespacedResource{Namespace: "ns-b", Group: "group-b", Resource: "resource-b"}
+
+	_, err = backend.BuildIndex(context.Background(), second, 2, nil, "test", indexTestDocs(second, 2, 100), nil, false, time.Time{}, 0)
+	require.NoError(t, err)
+	_, err = backend.BuildIndex(context.Background(), first, 3, nil, "test", indexTestDocs(first, 3, 200), nil, false, time.Time{}, 0)
+	require.NoError(t, err)
+
+	now := time.Now().UTC()
+	require.NoError(t, backend.WriteOpenIndexStats(now))
+
+	stats, err := backend.LoadOpenIndexStats(now.Add(time.Minute), time.Hour)
+	require.NoError(t, err)
+	require.Equal(t, []resource.ResourceStats{
+		{NamespacedResource: first, Count: 3},
+		{NamespacedResource: second, Count: 2},
+	}, stats)
+}
+
+func TestOpenIndexListWriteRemovesOpenIndexListWhenNoIndexes(t *testing.T) {
+	backend, err := NewBleveBackend(BleveOptions{Root: t.TempDir()}, nil)
+	require.NoError(t, err)
+	t.Cleanup(backend.Stop)
+
+	require.NoError(t, writeOpenIndexListFile(backend, "old\n"))
+	require.NoError(t, backend.WriteOpenIndexStats(time.Now()))
+
+	_, err = os.Stat(filepath.Join(backend.opts.Root, openIndexListFileName))
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestOpenIndexListLoadRejectsStaleOpenIndexList(t *testing.T) {
+	backend, err := NewBleveBackend(BleveOptions{Root: t.TempDir()}, nil)
+	require.NoError(t, err)
+	t.Cleanup(backend.Stop)
+
+	now := time.Now().UTC()
+	writeOpenIndexList(t, backend, openIndexListFile{
+		WrittenAt: now.Add(-2 * time.Hour).Format(time.RFC3339Nano),
+		Indexes: []openIndexListEntry{
+			{Namespace: "ns", Group: "group", Resource: "resource", DocCount: 1},
+		},
+	})
+
+	stats, err := backend.LoadOpenIndexStats(now, time.Hour)
+	require.ErrorContains(t, err, "open index list is stale")
+	require.Nil(t, stats)
+}
+
+func TestOpenIndexListLoadRejectsEmptyOpenIndexList(t *testing.T) {
+	backend, err := NewBleveBackend(BleveOptions{Root: t.TempDir()}, nil)
+	require.NoError(t, err)
+	t.Cleanup(backend.Stop)
+
+	now := time.Now().UTC()
+	writeOpenIndexList(t, backend, openIndexListFile{
+		WrittenAt: now.Format(time.RFC3339Nano),
+	})
+
+	stats, err := backend.LoadOpenIndexStats(now, time.Hour)
+	require.ErrorContains(t, err, "open index list has no indexes")
+	require.Nil(t, stats)
+}
+
+func TestOpenIndexListLoadRejectsDuplicateEntry(t *testing.T) {
+	backend, err := NewBleveBackend(BleveOptions{Root: t.TempDir()}, nil)
+	require.NoError(t, err)
+	t.Cleanup(backend.Stop)
+
+	now := time.Now().UTC()
+	writeOpenIndexList(t, backend, openIndexListFile{
+		WrittenAt: now.Format(time.RFC3339Nano),
+		Indexes: []openIndexListEntry{
+			{Namespace: "ns", Group: "group", Resource: "resource", DocCount: 1},
+			{Namespace: "ns", Group: "group", Resource: "resource", DocCount: 1},
+		},
+	})
+
+	stats, err := backend.LoadOpenIndexStats(now, time.Hour)
+	require.ErrorContains(t, err, "duplicate index entry")
+	require.Nil(t, stats)
+}
+
+func TestOpenIndexListLoadRejectsMalformedJSON(t *testing.T) {
+	backend, err := NewBleveBackend(BleveOptions{Root: t.TempDir()}, nil)
+	require.NoError(t, err)
+	t.Cleanup(backend.Stop)
+
+	require.NoError(t, writeOpenIndexListFile(backend, "not-json\n"))
+
+	stats, err := backend.LoadOpenIndexStats(time.Now(), time.Hour)
+	require.ErrorContains(t, err, "invalid open index list JSON")
+	require.Nil(t, stats)
+}
+
+func writeOpenIndexList(t *testing.T, backend *bleveBackend, list openIndexListFile) {
+	t.Helper()
+
+	contents, err := json.Marshal(list)
+	require.NoError(t, err)
+	require.NoError(t, writeOpenIndexListFile(backend, string(contents)))
+}
+
+func writeOpenIndexListFile(backend *bleveBackend, contents string) error {
+	return os.WriteFile(filepath.Join(backend.opts.Root, openIndexListFileName), []byte(contents), 0o640)
+}


### PR DESCRIPTION
This avoids the expensive startup GetResourceStats call when a fresh local open index list exists next to the Bleve indexes. Startup falls back to storage stats if the file is missing, stale, or invalid.

Also wires search backend shutdown through the search server so Bleve backend background tasks are stopped during normal shutdown.