### PR TITLE
publicdashboards: use allowlist to sanitize query targets (fixes rawQuery/InfluxDB leak)

### DIFF
--- a/pkg/services/publicdashboards/internal/service/query.go
+++ b/pkg/services/publicdashboards/internal/service/query.go
@@ -442,14 +442,19 @@ func sanitizeMetadataFromQueryData(res *backend.QueryDataResponse) {
 	}
 }
 
-// targetQueryFieldAllowList contains the set of target fields that are safe to
-// expose to public dashboard viewers. Any field NOT in this list is considered a
-// potential query expression and will be stripped before the dashboard is returned.
+// targetSafeFieldAllowList contains the set of target metadata fields that are safe
+// to expose to public dashboard viewers. Any top-level field NOT in this list is
+// considered a potential raw query expression and will be stripped before the
+// dashboard is returned.
 //
-// Using an allowList (rather than a denylist) ensures that new datasource-specific
+// Note: sanitization is intentionally shallow — only top-level target keys are
+// evaluated. Known nested objects (e.g. "datasource": {"uid":..., "type":...}) are
+// retained verbatim; their subfields are standard Grafana metadata, not query text.
+//
+// Using an allowlist (rather than a denylist) ensures that new datasource-specific
 // query fields (e.g. rawQuery, rawSql, expr, query, flux, etc.) are automatically
 // removed without requiring a code change here each time.
-var targetQueryFieldAllowList = map[string]struct{}{
+var targetSafeFieldAllowList = map[string]struct{}{
 	"refId":          {},
 	"datasource":     {},
 	"exemplar":       {},
@@ -467,12 +472,16 @@ var targetQueryFieldAllowList = map[string]struct{}{
 	"expression": {},
 }
 
-// sanitizeTarget removes any fields from a target object that are not in
-// targetQueryFieldAllowList, protecting against raw query text exposure.
+// sanitizeTarget removes any top-level fields from a target object that are not in
+// targetSafeFieldAllowList, protecting against raw query text exposure.
 func sanitizeTarget(target *simplejson.Json) {
-	for key := range target.MustMap() {
-		if _, safe := targetQueryFieldAllowList[key]; !safe {
-			target.Del(key)
+	m, err := target.Map()
+	if err != nil {
+		return
+	}
+	for key := range m {
+		if _, safe := targetSafeFieldAllowList[key]; !safe {
+			delete(m, key)
 		}
 	}
 }

--- a/pkg/services/publicdashboards/internal/service/query.go
+++ b/pkg/services/publicdashboards/internal/service/query.go
@@ -442,6 +442,41 @@ func sanitizeMetadataFromQueryData(res *backend.QueryDataResponse) {
 	}
 }
 
+// targetQueryFieldAllowList contains the set of target fields that are safe to
+// expose to public dashboard viewers. Any field NOT in this list is considered a
+// potential query expression and will be stripped before the dashboard is returned.
+//
+// Using an allowList (rather than a denylist) ensures that new datasource-specific
+// query fields (e.g. rawQuery, rawSql, expr, query, flux, etc.) are automatically
+// removed without requiring a code change here each time.
+var targetQueryFieldAllowList = map[string]struct{}{
+	"refId":          {},
+	"datasource":     {},
+	"exemplar":       {},
+	"hide":           {},
+	"interval":       {},
+	"intervalMs":     {},
+	"intervalFactor": {},
+	"legendFormat":   {},
+	"maxDataPoints":  {},
+	"format":         {},
+	"instant":        {},
+	"range":          {},
+	"type":           {},
+	// expression is used by server-side __expr__ targets (references other refIds via $A+$B syntax)
+	"expression": {},
+}
+
+// sanitizeTarget removes any fields from a target object that are not in
+// targetQueryFieldAllowList, protecting against raw query text exposure.
+func sanitizeTarget(target *simplejson.Json) {
+	for key := range target.MustMap() {
+		if _, safe := targetQueryFieldAllowList[key]; !safe {
+			target.Del(key)
+		}
+	}
+}
+
 // sanitizeData removes the query expressions from the dashboard data
 func sanitizeData(data *simplejson.Json) {
 	for _, panelObj := range data.Get("panels").MustArray() {
@@ -455,10 +490,7 @@ func sanitizeData(data *simplejson.Json) {
 		}
 
 		for _, targetObj := range panel.Get("targets").MustArray() {
-			target := simplejson.NewFromAny(targetObj)
-			target.Del("expr")
-			target.Del("query")
-			target.Del("rawSql")
+			sanitizeTarget(simplejson.NewFromAny(targetObj))
 		}
 	}
 }
@@ -471,10 +503,7 @@ func sanitizeDataV2(data *simplejson.Json) {
 		queries := elem.Get("spec").Get("data").Get("spec").Get("queries").MustArray()
 		for _, queryObj := range queries {
 			query := simplejson.NewFromAny(queryObj)
-			dataQuerySpec := query.Get("spec").Get("query").Get("spec")
-			dataQuerySpec.Del("expr")
-			dataQuerySpec.Del("query")
-			dataQuerySpec.Del("rawSql")
+			sanitizeTarget(query.Get("spec").Get("query").Get("spec"))
 		}
 	}
 }

--- a/pkg/services/publicdashboards/internal/service/query_test.go
+++ b/pkg/services/publicdashboards/internal/service/query_test.go
@@ -1391,6 +1391,224 @@ func buildJsonDataWithTimeRange(from, to, timezone string) *simplejson.Json {
 	})
 }
 
+func TestSanitizeTarget(t *testing.T) {
+	t.Run("strips all fields not in the allowlist", func(t *testing.T) {
+		target := simplejson.NewFromAny(map[string]interface{}{
+			"refId":         "A",
+			"datasource":    "prometheus",
+			"exemplar":      true,
+			"hide":          false,
+			"interval":      "30s",
+			"intervalMs":    30000,
+			"legendFormat":  "{{job}}",
+			"maxDataPoints": 500,
+			"format":        "time_series",
+			"instant":       true,
+			"range":         false,
+			"type":          "timeseries",
+			// query expression fields — must be stripped
+			"expr":             "up{job=\"grafana\"}",
+			"rawSql":           "SELECT * FROM metrics",
+			"query":            "buckets()",
+			"rawQuery":         "SELECT mean(\"value\") FROM \"measurement\"",
+			"futureQueryField": "very sensitive",
+		})
+
+		sanitizeTarget(target)
+
+		m := target.MustMap()
+		// all allowlisted keys must be retained
+		for _, safeKey := range []string{
+			"refId", "datasource", "exemplar", "hide", "interval", "intervalMs",
+			"legendFormat", "maxDataPoints", "format", "instant", "range", "type",
+		} {
+			_, exists := m[safeKey]
+			assert.True(t, exists, "allowlisted field %q should be retained", safeKey)
+		}
+		// all query fields must be gone
+		for _, queryKey := range []string{"expr", "rawSql", "query", "rawQuery", "futureQueryField"} {
+			_, exists := m[queryKey]
+			assert.False(t, exists, "query field %q should be stripped", queryKey)
+		}
+	})
+
+	t.Run("preserves server-side expression target fields", func(t *testing.T) {
+		// __expr__ targets use 'expression' (referencing other refIds, e.g. $A+$B) and 'type'.
+		// Both are in the allowlist and must survive sanitization.
+		target := simplejson.NewFromAny(map[string]interface{}{
+			"refId": "C",
+			"datasource": map[string]interface{}{
+				"name": "Expression",
+				"type": "__expr__",
+				"uid":  "__expr__",
+			},
+			"expression": "$A + $B",
+			"type":       "math",
+			// should be stripped
+			"hiddenQueryText": "should not appear",
+		})
+
+		sanitizeTarget(target)
+
+		m := target.MustMap()
+		assert.Equal(t, "C", target.Get("refId").MustString())
+		assert.Equal(t, "$A + $B", target.Get("expression").MustString(), "expression should be preserved for __expr__ targets")
+		assert.Equal(t, "math", target.Get("type").MustString(), "type should be preserved for __expr__ targets")
+		_, dsExists := m["datasource"]
+		assert.True(t, dsExists, "datasource should be preserved")
+		_, hidden := m["hiddenQueryText"]
+		assert.False(t, hidden, "unknown fields should still be stripped from __expr__ targets")
+	})
+
+	t.Run("does not panic on an empty target", func(t *testing.T) {
+		require.NotPanics(t, func() {
+			sanitizeTarget(simplejson.NewFromAny(map[string]interface{}{}))
+		})
+	})
+}
+
+func TestSanitizeData(t *testing.T) {
+	t.Run("strips fields not in the allowlist and preserves safe fields", func(t *testing.T) {
+		data := simplejson.NewFromAny(map[string]interface{}{
+			"panels": []interface{}{
+				map[string]interface{}{
+					"type": "graph",
+					"targets": []interface{}{
+						map[string]interface{}{
+							// known query fields — should all be stripped
+							"expr":                        "go_goroutines{job=\"grafana\"}",
+							"rawSql":                      "SELECT * FROM metrics",
+							"query":                       "buckets()",
+							"rawQuery":                    "SELECT mean(\"value\") FROM \"measurement\"",
+							"someNewDatasourceQueryField": "sensitive query text",
+							// safe fields — should all be preserved
+							"refId":         "A",
+							"datasource":    "prometheus",
+							"exemplar":      true,
+							"hide":          false,
+							"interval":      "1m",
+							"legendFormat":  "{{instance}}",
+							"format":        "time_series",
+							"maxDataPoints": 100,
+							"instant":       false,
+							"range":         true,
+						},
+					},
+				},
+			},
+		})
+
+		sanitizeData(data)
+
+		panels := data.Get("panels").MustArray()
+		require.Len(t, panels, 1)
+		targets := simplejson.NewFromAny(panels[0]).Get("targets").MustArray()
+		require.Len(t, targets, 1)
+		target := simplejson.NewFromAny(targets[0])
+
+		// query expression fields must be stripped
+		assert.Empty(t, target.Get("expr").MustString(), "expr should be stripped")
+		assert.Empty(t, target.Get("rawSql").MustString(), "rawSql should be stripped")
+		assert.Empty(t, target.Get("query").MustString(), "query should be stripped")
+		assert.Empty(t, target.Get("rawQuery").MustString(), "rawQuery should be stripped")
+		assert.Empty(t, target.Get("someNewDatasourceQueryField").MustString(), "unknown fields should be stripped")
+
+		// safe metadata fields must be preserved
+		assert.Equal(t, "A", target.Get("refId").MustString(), "refId should be preserved")
+		assert.Equal(t, "prometheus", target.Get("datasource").MustString(), "datasource should be preserved")
+		assert.Equal(t, "1m", target.Get("interval").MustString(), "interval should be preserved")
+		assert.Equal(t, "{{instance}}", target.Get("legendFormat").MustString(), "legendFormat should be preserved")
+		assert.Equal(t, "time_series", target.Get("format").MustString(), "format should be preserved")
+		assert.Equal(t, 100, target.Get("maxDataPoints").MustInt(), "maxDataPoints should be preserved")
+	})
+
+	t.Run("recursively sanitizes targets in collapsed rows", func(t *testing.T) {
+		data := simplejson.NewFromAny(map[string]interface{}{
+			"panels": []interface{}{
+				map[string]interface{}{
+					"type":      "row",
+					"collapsed": true,
+					"panels": []interface{}{
+						map[string]interface{}{
+							"type": "graph",
+							"targets": []interface{}{
+								map[string]interface{}{
+									"rawQuery": "SELECT mean(\"value\") FROM \"measurement\"",
+									"refId":    "A",
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+
+		sanitizeData(data)
+
+		panels := data.Get("panels").MustArray()
+		require.Len(t, panels, 1)
+		innerPanels := simplejson.NewFromAny(panels[0]).Get("panels").MustArray()
+		require.Len(t, innerPanels, 1)
+		targets := simplejson.NewFromAny(innerPanels[0]).Get("targets").MustArray()
+		require.Len(t, targets, 1)
+		t1 := simplejson.NewFromAny(targets[0])
+		assert.Empty(t, t1.Get("rawQuery").MustString(), "rawQuery should be stripped from collapsed row target")
+		assert.Equal(t, "A", t1.Get("refId").MustString(), "refId should be preserved in collapsed row target")
+	})
+
+	t.Run("does not recurse into non-collapsed rows", func(t *testing.T) {
+		// Non-collapsed rows: their child panels are at the top-level panels array,
+		// NOT nested inside the row object. The row itself has no targets, so sanitization
+		// of the row node is a safe no-op.
+		data := simplejson.NewFromAny(map[string]interface{}{
+			"panels": []interface{}{
+				map[string]interface{}{
+					"type":      "row",
+					"collapsed": false,
+					// non-collapsed row has no targets — just a label panel
+				},
+				map[string]interface{}{
+					"type": "timeseries",
+					"targets": []interface{}{
+						map[string]interface{}{
+							"expr":  "rate(http_requests_total[5m])",
+							"refId": "A",
+						},
+					},
+				},
+			},
+		})
+
+		require.NotPanics(t, func() { sanitizeData(data) })
+
+		panels := data.Get("panels").MustArray()
+		// The timeseries panel (index 1) must have its target sanitized
+		topTargets := simplejson.NewFromAny(panels[1]).Get("targets").MustArray()
+		require.Len(t, topTargets, 1)
+		assert.Empty(t, simplejson.NewFromAny(topTargets[0]).Get("expr").MustString(),
+			"expr should be stripped from top-level panel adjacent to a non-collapsed row")
+	})
+
+	t.Run("does not panic when a panel has no targets key", func(t *testing.T) {
+		data := simplejson.NewFromAny(map[string]interface{}{
+			"panels": []interface{}{
+				map[string]interface{}{
+					"type": "text",
+					// no "targets" key at all
+				},
+			},
+		})
+		require.NotPanics(t, func() { sanitizeData(data) })
+	})
+
+	t.Run("does not panic on empty panels", func(t *testing.T) {
+		data := simplejson.NewFromAny(map[string]interface{}{
+			"panels": []interface{}{},
+		})
+		require.NotPanics(t, func() { sanitizeData(data) })
+	})
+}
+
 func TestSanitizeDataV2(t *testing.T) {
 	t.Run("removes expr, query, rawSql from query specs", func(t *testing.T) {
 		data := simplejson.NewFromAny(map[string]interface{}{
@@ -1474,6 +1692,49 @@ func TestSanitizeDataV2(t *testing.T) {
 		q3spec := simplejson.NewFromAny(panel2Queries[0]).Get("spec").Get("query").Get("spec")
 		assert.Empty(t, q3spec.Get("query").MustString())
 		assert.Equal(t, "A", q3spec.Get("refId").MustString())
+	})
+
+	t.Run("strips unknown fields and preserves allowlisted fields in v2 query specs", func(t *testing.T) {
+		data := simplejson.NewFromAny(map[string]interface{}{
+			"elements": map[string]interface{}{
+				"panel-1": map[string]interface{}{
+					"spec": map[string]interface{}{
+						"data": map[string]interface{}{
+							"spec": map[string]interface{}{
+								"queries": []interface{}{
+									map[string]interface{}{
+										"spec": map[string]interface{}{
+											"query": map[string]interface{}{
+												"spec": map[string]interface{}{
+													// query fields — all should be stripped
+													"rawQuery":                    "SELECT mean(\"value\") FROM \"measurement\"",
+													"someNewDatasourceQueryField": "sensitive",
+													// safe fields — should be preserved
+													"refId":  "A",
+													"format": "time_series",
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		})
+
+		sanitizeDataV2(data)
+
+		elements := data.Get("elements").MustMap()
+		panel1Queries := simplejson.NewFromAny(elements["panel-1"]).
+			Get("spec").Get("data").Get("spec").Get("queries").MustArray()
+		require.Len(t, panel1Queries, 1)
+		q1spec := simplejson.NewFromAny(panel1Queries[0]).Get("spec").Get("query").Get("spec")
+		assert.Empty(t, q1spec.Get("rawQuery").MustString(), "rawQuery should be stripped")
+		assert.Empty(t, q1spec.Get("someNewDatasourceQueryField").MustString(), "unknown fields should be stripped")
+		assert.Equal(t, "A", q1spec.Get("refId").MustString(), "refId should be preserved")
+		assert.Equal(t, "time_series", q1spec.Get("format").MustString(), "format should be preserved")
 	})
 
 	t.Run("does not panic when queries key is missing", func(t *testing.T) {

--- a/pkg/services/publicdashboards/internal/service/query_test.go
+++ b/pkg/services/publicdashboards/internal/service/query_test.go
@@ -1504,22 +1504,21 @@ func TestSanitizeData(t *testing.T) {
 		require.Len(t, panels, 1)
 		targets := simplejson.NewFromAny(panels[0]).Get("targets").MustArray()
 		require.Len(t, targets, 1)
-		target := simplejson.NewFromAny(targets[0])
+		targetMap := simplejson.NewFromAny(targets[0]).MustMap()
 
-		// query expression fields must be stripped
-		assert.Empty(t, target.Get("expr").MustString(), "expr should be stripped")
-		assert.Empty(t, target.Get("rawSql").MustString(), "rawSql should be stripped")
-		assert.Empty(t, target.Get("query").MustString(), "query should be stripped")
-		assert.Empty(t, target.Get("rawQuery").MustString(), "rawQuery should be stripped")
-		assert.Empty(t, target.Get("someNewDatasourceQueryField").MustString(), "unknown fields should be stripped")
+		// query expression fields must be absent from the map
+		for _, queryKey := range []string{"expr", "rawSql", "query", "rawQuery", "someNewDatasourceQueryField"} {
+			_, exists := targetMap[queryKey]
+			assert.False(t, exists, "query field %q should be stripped from target", queryKey)
+		}
 
-		// safe metadata fields must be preserved
-		assert.Equal(t, "A", target.Get("refId").MustString(), "refId should be preserved")
-		assert.Equal(t, "prometheus", target.Get("datasource").MustString(), "datasource should be preserved")
-		assert.Equal(t, "1m", target.Get("interval").MustString(), "interval should be preserved")
-		assert.Equal(t, "{{instance}}", target.Get("legendFormat").MustString(), "legendFormat should be preserved")
-		assert.Equal(t, "time_series", target.Get("format").MustString(), "format should be preserved")
-		assert.Equal(t, 100, target.Get("maxDataPoints").MustInt(), "maxDataPoints should be preserved")
+		// safe metadata fields must be retained
+		assert.Equal(t, "A", targetMap["refId"], "refId should be preserved")
+		assert.Equal(t, "prometheus", targetMap["datasource"], "datasource should be preserved")
+		assert.Equal(t, "1m", targetMap["interval"], "interval should be preserved")
+		assert.Equal(t, "{{instance}}", targetMap["legendFormat"], "legendFormat should be preserved")
+		assert.Equal(t, "time_series", targetMap["format"], "format should be preserved")
+		assert.Equal(t, 100, targetMap["maxDataPoints"], "maxDataPoints should be preserved")
 	})
 
 	t.Run("recursively sanitizes targets in collapsed rows", func(t *testing.T) {
@@ -1551,9 +1550,10 @@ func TestSanitizeData(t *testing.T) {
 		require.Len(t, innerPanels, 1)
 		targets := simplejson.NewFromAny(innerPanels[0]).Get("targets").MustArray()
 		require.Len(t, targets, 1)
-		t1 := simplejson.NewFromAny(targets[0])
-		assert.Empty(t, t1.Get("rawQuery").MustString(), "rawQuery should be stripped from collapsed row target")
-		assert.Equal(t, "A", t1.Get("refId").MustString(), "refId should be preserved in collapsed row target")
+		t1Map := simplejson.NewFromAny(targets[0]).MustMap()
+		_, rawQueryExists := t1Map["rawQuery"]
+		assert.False(t, rawQueryExists, "rawQuery should be stripped from collapsed row target")
+		assert.Equal(t, "A", t1Map["refId"], "refId should be preserved in collapsed row target")
 	})
 
 	t.Run("does not recurse into non-collapsed rows", func(t *testing.T) {
@@ -1676,22 +1676,25 @@ func TestSanitizeDataV2(t *testing.T) {
 			Get("spec").Get("data").Get("spec").Get("queries").MustArray()
 		require.Len(t, panel1Queries, 2)
 
-		q1spec := simplejson.NewFromAny(panel1Queries[0]).Get("spec").Get("query").Get("spec")
-		assert.Empty(t, q1spec.Get("expr").MustString())
-		assert.Equal(t, "A", q1spec.Get("refId").MustString())
-		assert.Equal(t, "prometheus", q1spec.Get("datasource").MustString())
+		q1map := simplejson.NewFromAny(panel1Queries[0]).Get("spec").Get("query").Get("spec").MustMap()
+		_, exprExists := q1map["expr"]
+		assert.False(t, exprExists, "expr should be stripped")
+		assert.Equal(t, "A", q1map["refId"], "refId should be preserved")
+		assert.Equal(t, "prometheus", q1map["datasource"], "datasource should be preserved")
 
-		q2spec := simplejson.NewFromAny(panel1Queries[1]).Get("spec").Get("query").Get("spec")
-		assert.Empty(t, q2spec.Get("rawSql").MustString())
-		assert.Equal(t, "B", q2spec.Get("refId").MustString())
-		assert.Equal(t, "time_series", q2spec.Get("format").MustString())
+		q2map := simplejson.NewFromAny(panel1Queries[1]).Get("spec").Get("query").Get("spec").MustMap()
+		_, rawSqlExists := q2map["rawSql"]
+		assert.False(t, rawSqlExists, "rawSql should be stripped")
+		assert.Equal(t, "B", q2map["refId"], "refId should be preserved")
+		assert.Equal(t, "time_series", q2map["format"], "format should be preserved")
 
 		panel2Queries := simplejson.NewFromAny(elements["panel-2"]).
 			Get("spec").Get("data").Get("spec").Get("queries").MustArray()
 		require.Len(t, panel2Queries, 1)
-		q3spec := simplejson.NewFromAny(panel2Queries[0]).Get("spec").Get("query").Get("spec")
-		assert.Empty(t, q3spec.Get("query").MustString())
-		assert.Equal(t, "A", q3spec.Get("refId").MustString())
+		q3map := simplejson.NewFromAny(panel2Queries[0]).Get("spec").Get("query").Get("spec").MustMap()
+		_, queryExists := q3map["query"]
+		assert.False(t, queryExists, "query should be stripped")
+		assert.Equal(t, "A", q3map["refId"], "refId should be preserved")
 	})
 
 	t.Run("strips unknown fields and preserves allowlisted fields in v2 query specs", func(t *testing.T) {
@@ -1730,11 +1733,13 @@ func TestSanitizeDataV2(t *testing.T) {
 		panel1Queries := simplejson.NewFromAny(elements["panel-1"]).
 			Get("spec").Get("data").Get("spec").Get("queries").MustArray()
 		require.Len(t, panel1Queries, 1)
-		q1spec := simplejson.NewFromAny(panel1Queries[0]).Get("spec").Get("query").Get("spec")
-		assert.Empty(t, q1spec.Get("rawQuery").MustString(), "rawQuery should be stripped")
-		assert.Empty(t, q1spec.Get("someNewDatasourceQueryField").MustString(), "unknown fields should be stripped")
-		assert.Equal(t, "A", q1spec.Get("refId").MustString(), "refId should be preserved")
-		assert.Equal(t, "time_series", q1spec.Get("format").MustString(), "format should be preserved")
+		q1map := simplejson.NewFromAny(panel1Queries[0]).Get("spec").Get("query").Get("spec").MustMap()
+		_, rawQueryExists := q1map["rawQuery"]
+		_, unknownExists := q1map["someNewDatasourceQueryField"]
+		assert.False(t, rawQueryExists, "rawQuery should be stripped")
+		assert.False(t, unknownExists, "unknown fields should be stripped")
+		assert.Equal(t, "A", q1map["refId"], "refId should be preserved")
+		assert.Equal(t, "time_series", q1map["format"], "format should be preserved")
 	})
 
 	t.Run("does not panic when queries key is missing", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Replace the per-field denylist in `sanitizeData`/`sanitizeDataV2` with an **allowlist** approach that retains only known-safe metadata fields and strips everything else.

### Problem

The current denylist explicitly removes `expr`, `query`, and `rawSql` from panel targets before returning a public dashboard to the browser. However, InfluxDB datasources store the query expression in `rawQuery` — a fourth field that was never stripped, so raw InfluxQL/Flux query text was visible to any unauthenticated viewer of a public dashboard.

More fundamentally, the denylist approach requires a code change every time a new datasource plugin introduces a new query field. Any field not explicitly listed leaks silently.

Fixes #123673
Fixes #123845

### Approach

An allowlist inverts the safety model: only fields explicitly known to be safe metadata are retained; everything else — including `rawQuery`, `expr`, `rawSql`, `query`, and any future `rawFlux` / `sqlText` / etc. — is stripped by default without requiring further patches.

**Allowlisted fields** (safe to expose to public viewers):
`refId`, `datasource`, `exemplar`, `hide`, `interval`, `intervalMs`, `intervalFactor`, `legendFormat`, `maxDataPoints`, `format`, `instant`, `range`, `type`, `expression`

(`expression` is retained for server-side `__expr__` targets which reference other refIds via e.g. `$A + $B` — no raw datasource query text.)

### Changes

- `query.go`: add `targetQueryFieldAllowList` and shared `sanitizeTarget()` helper; both `sanitizeData` (v1) and `sanitizeDataV2` (v2) now call it
- `query_test.go`:
  - New `TestSanitizeTarget`: direct unit tests for the core helper (unknown future fields, `__expr__` targets, empty target)
  - `TestSanitizeData`: extended with non-collapsed row, missing targets key, and empty panels edge cases
  - `TestSanitizeDataV2`: new subtest asserting unknown fields are stripped

### Note on existing PR

PR #123864 adds `rawQuery` to the denylist in the wrong file (`service/query.go` instead of `internal/service/query.go`) and has no tests. This PR takes the correct file path and a more robust fix.

## Checklist

- [x] I have reviewed the "How to contribute to Grafana" guide
- [x] My changes include tests
- [x] My changes do not break existing tests (`go test ./pkg/services/publicdashboards/...` passes)