### PR TITLE
AccessControl: Resolve built-in grafana datasource type without a store lookup

### DIFF
--- a/pkg/api/datasource/connections.go
+++ b/pkg/api/datasource/connections.go
@@ -99,6 +99,14 @@ type legacyConnectionClientImpl struct {
 
 var _ ConnectionClient = (*legacyConnectionClientImpl)(nil)
 
+// builtinGrafanaDatasourceUID and builtinGrafanaDatasourceType identify the built-in
+// "-- Grafana --" datasource. They mirror grafanads.DatasourceUID / its plugin type, kept
+// local here to avoid importing the tsdb package into this central API package.
+const (
+	builtinGrafanaDatasourceUID  = "grafana"
+	builtinGrafanaDatasourceType = "grafana"
+)
+
 // NewLegacyConnectionClient creates a new ConnectionClient that relies on the legacy datasource service.
 func NewLegacyConnectionClient(datasourceService datasourceservice.DataSourceRetriever) ConnectionClient {
 	return &legacyConnectionClientImpl{
@@ -107,6 +115,23 @@ func NewLegacyConnectionClient(datasourceService datasourceservice.DataSourceRet
 }
 
 func (cl *legacyConnectionClientImpl) GetConnectionByUID(ctx context.Context, orgID int64, uid string) (*dsV0.DataSourceConnectionList, error) {
+	// The built-in "-- Grafana --" datasource has no row in the datasource table, so a store
+	// lookup can never resolve its type and fails outright when no org is set (e.g. global RBAC
+	// roles, which carry a seeded datasources:uid:grafana grant). Its UID and type are fixed and
+	// identical across orgs, so resolve it directly.
+	if uid == builtinGrafanaDatasourceUID {
+		return &dsV0.DataSourceConnectionList{
+			Items: []dsV0.DataSourceConnection{
+				{
+					APIGroup:   builtinGrafanaDatasourceType + ".datasource.grafana.app",
+					APIVersion: "v0alpha1",
+					Name:       uid,
+					Plugin:     builtinGrafanaDatasourceType,
+				},
+			},
+		}, nil
+	}
+
 	query := datasources.GetDataSourceQuery{
 		UID:   uid,
 		OrgID: orgID,

--- a/pkg/api/datasource/connections_test.go
+++ b/pkg/api/datasource/connections_test.go
@@ -189,6 +189,26 @@ func TestGetConnectionByUIDLegacy(t *testing.T) {
 	}
 }
 
+func TestGetConnectionByUIDLegacy_BuiltinGrafana(t *testing.T) {
+	// The built-in "-- Grafana --" datasource has no row in the datasource table, so it must
+	// resolve to its fixed type without a store lookup, even with no org set (global roles).
+	// The mock errors on any store call to prove the lookup is bypassed.
+	client := &legacyConnectionClientImpl{
+		datasourceService: &mockDataSourceService{
+			error: datasources.ErrDataSourceIdentifierNotSet,
+		},
+	}
+
+	conn, err := client.GetConnectionByUID(context.Background(), 0, "grafana")
+
+	require.NoError(t, err)
+	require.NotNil(t, conn)
+	require.Len(t, conn.Items, 1)
+	assert.Equal(t, "grafana", conn.Items[0].Name)
+	assert.Equal(t, "grafana", conn.Items[0].Plugin)
+	assert.Equal(t, "grafana.datasource.grafana.app", conn.Items[0].APIGroup)
+}
+
 // mock the datasource service
 type mockDataSourceService struct {
 	datasources.DataSourceService


### PR DESCRIPTION
## What

Resolve the built-in `-- Grafana --` datasource's plugin type directly in `legacyConnectionClientImpl.GetConnectionByUID`, instead of attempting a datasource store lookup.

## Why

The built-in `grafana` datasource has no row in the datasource table, so `GetConnectionByUID` could never resolve its plugin type from the store. This surfaces through RBAC, where the `fixed:datasources.builtin:reader` fixed role seeds a concrete `datasources:uid:grafana` grant onto the basic Viewer/Editor/Admin roles (stored at the global org).

When that grant is processed for a **global** role (orgID `0`) in a **multi-org** setup, the type-resolution path (`resolveDatasourceTypes` → `GetConnectionByUID`) calls the legacy datasource store with no org, which returns `ErrDataSourceIdentifierNotSet` ("unique identifier and org id are needed to be able to get or delete a datasource"). That error is not swallowed, so the whole role provisioning fails, e.g. when provisioning a global `basic:admin` override via `from: basic:admin`:

```
could not provision role [Global Role:basic:admin]: unique identifier and org id are needed to be able to get or delete a datasource
```

In single-org setups this only "works" because the lookup is retried against the default org and the resulting not-found error is swallowed — leaving the type empty, which is itself a problem for the migration to the per-type k8s datasource APIs (`<type>.datasource.grafana.app`), where the plugin type is required to form the GVR.

The built-in grafana datasource's UID and type are fixed and identical across every org, so it can be resolved directly without a store row.

## What changed

- `pkg/api/datasource/connections.go`: `legacyConnectionClientImpl.GetConnectionByUID` short-circuits the built-in `grafana` UID and returns a synthetic connection with plugin type `grafana` (`grafana.datasource.grafana.app`), regardless of org.

Because all the RBAC datasource-type resolvers (legacy provisioning save and the k8s role/global-role migration resolvers) go through this client, the type now resolves correctly for every caller, for any org including org-less global roles.

## Testing

- New unit test `TestGetConnectionByUIDLegacy_BuiltinGrafana` verifies the built-in resolves to type `grafana` with `orgID=0` and a store mock that errors on any call (proving the lookup is bypassed).
- `go test ./pkg/api/datasource/`, `go vet`, and the provisioner tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
