### PR TITLE
tempo datasource: fix url construction for tempo traces API.

### DIFF
--- a/pkg/tsdb/tempo/trace.go
+++ b/pkg/tsdb/tempo/trace.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"strconv"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
@@ -196,19 +198,31 @@ const (
 
 func (s *Service) createRequest(ctx context.Context, dsInfo *DatasourceInfo, apiVersion TraceRequestApiVersion, traceID string, start int64, end int64) (*http.Request, error) {
 	ctxLogger := s.logger.FromContext(ctx)
-	var baseUrl string
-	var tempoQuery string
 
-	if apiVersion == TraceRequestApiVersionV1 {
-		baseUrl = fmt.Sprintf("%s/api/traces/%s", dsInfo.URL, traceID)
-	} else {
-		baseUrl = fmt.Sprintf("%s/api/v2/traces/%s", dsInfo.URL, traceID)
+	// attach correct path according to the base URL and version.
+	baseURL, err := url.Parse(dsInfo.URL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid base URL: %w", err)
 	}
 
-	if start == 0 || end == 0 {
-		tempoQuery = baseUrl
+	if apiVersion == TraceRequestApiVersionV1 {
+		// <...>/api/traces/<traceID>
+		baseURL = baseURL.JoinPath("api", "traces", traceID)
 	} else {
-		tempoQuery = fmt.Sprintf("%s?start=%d&end=%d", baseUrl, start, end)
+		// <...>/api/v2/traces/<traceID>
+		baseURL = baseURL.JoinPath("api", "v2", "traces", traceID)
+	}
+
+	// append start and end query argument if needed.
+	var tempoQuery string
+	if start == 0 || end == 0 {
+		tempoQuery = baseURL.String()
+	} else {
+		query := baseURL.Query()
+		query.Add("start", strconv.FormatInt(start, 10))
+		query.Add("end", strconv.FormatInt(end, 10))
+		baseURL.RawQuery = query.Encode()
+		tempoQuery = baseURL.String()
 	}
 
 	req, err := http.NewRequestWithContext(ctx, "GET", tempoQuery, nil)

--- a/pkg/tsdb/tempo/trace_test.go
+++ b/pkg/tsdb/tempo/trace_test.go
@@ -17,34 +17,60 @@ import (
 func TestTempo(t *testing.T) {
 	t.Run("createRequest v1 without time range - success", func(t *testing.T) {
 		service := &Service{logger: backend.NewLoggerWith("logger", "tempo-test")}
-		req, err := service.createRequest(context.Background(), &DatasourceInfo{}, TraceRequestApiVersionV1, "traceID", 0, 0)
+		req, err := service.createRequest(context.Background(), &DatasourceInfo{URL: "http://localhost:3200"}, TraceRequestApiVersionV1, "traceID", 0, 0)
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(req.Header))
-		assert.Equal(t, "/api/traces/traceID", req.URL.String())
+		assert.Equal(t, "http://localhost:3200/api/traces/traceID", req.URL.String())
 	})
 
 	t.Run("createRequest v1 with time range - success", func(t *testing.T) {
 		service := &Service{logger: backend.NewLoggerWith("logger", "tempo-test")}
-		req, err := service.createRequest(context.Background(), &DatasourceInfo{}, TraceRequestApiVersionV1, "traceID", 1, 2)
+		req, err := service.createRequest(context.Background(), &DatasourceInfo{URL: "http://localhost:3200"}, TraceRequestApiVersionV1, "traceID", 1, 2)
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(req.Header))
-		assert.Equal(t, "/api/traces/traceID?start=1&end=2", req.URL.String())
+		assert.Equal(t, "/api/traces/traceID", req.URL.Path)
+		assert.Equal(t, "1", req.URL.Query().Get("start"))
+		assert.Equal(t, "2", req.URL.Query().Get("end"))
 	})
 
 	t.Run("createRequest v2 without time range - success", func(t *testing.T) {
 		service := &Service{logger: backend.NewLoggerWith("logger", "tempo-test")}
-		req, err := service.createRequest(context.Background(), &DatasourceInfo{}, TraceRequestApiVersionV2, "traceID", 0, 0)
+		req, err := service.createRequest(context.Background(), &DatasourceInfo{URL: "http://localhost:3200"}, TraceRequestApiVersionV2, "traceID", 0, 0)
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(req.Header))
-		assert.Equal(t, "/api/v2/traces/traceID", req.URL.String())
+		assert.Equal(t, "http://localhost:3200/api/v2/traces/traceID", req.URL.String())
 	})
 
 	t.Run("createRequest v2 with time range - success", func(t *testing.T) {
 		service := &Service{logger: backend.NewLoggerWith("logger", "tempo-test")}
-		req, err := service.createRequest(context.Background(), &DatasourceInfo{}, TraceRequestApiVersionV2, "traceID", 1, 2)
+		req, err := service.createRequest(context.Background(), &DatasourceInfo{URL: "http://localhost:3200"}, TraceRequestApiVersionV2, "traceID", 1, 2)
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(req.Header))
-		assert.Equal(t, "/api/v2/traces/traceID?start=1&end=2", req.URL.String())
+		assert.Equal(t, "/api/v2/traces/traceID", req.URL.Path)
+		assert.Equal(t, "1", req.URL.Query().Get("start"))
+		assert.Equal(t, "2", req.URL.Query().Get("end"))
+	})
+
+	t.Run("createRequest v2 path - with trailing slash", func(t *testing.T) {
+		service := &Service{logger: backend.NewLoggerWith("logger", "tempo-test")}
+		req, err := service.createRequest(context.Background(), &DatasourceInfo{
+			URL: "http://localhost:3200/route/prefix/",
+		}, TraceRequestApiVersionV2, "traceID", 1, 10)
+		require.NoError(t, err)
+		assert.Equal(t, "/route/prefix/api/v2/traces/traceID", req.URL.Path)
+		assert.Equal(t, "1", req.URL.Query().Get("start"))
+		assert.Equal(t, "10", req.URL.Query().Get("end"))
+	})
+
+	t.Run("createRequest v2 path - without trailing slash", func(t *testing.T) {
+		service := &Service{logger: backend.NewLoggerWith("logger", "tempo-test")}
+		req, err := service.createRequest(context.Background(), &DatasourceInfo{
+			URL: "http://localhost:3200/route/prefix",
+		}, TraceRequestApiVersionV2, "traceID", 1, 10)
+		require.NoError(t, err)
+		assert.Equal(t, "/route/prefix/api/v2/traces/traceID", req.URL.Path)
+		assert.Equal(t, "1", req.URL.Query().Get("start"))
+		assert.Equal(t, "10", req.URL.Query().Get("end"))
 	})
 
 	t.Run("getTrace v1 empty ResourceSpans returns downstream error", func(t *testing.T) {


### PR DESCRIPTION
**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/grafana-tempo-datasource/issues/180

Parse the Tempo datasource and append the paths correctly for `/api/traces/*` and `/api/v2/traces/*` APIs.

Previously it could be composed with duplicate `/` like:
```
http://<my-host>/select/tempo//api/v2/traces/595a255d8f984ac7905ace98defae4cd
```

The implementation is referred to https://github.com/grafana/grafana/blob/0b2e7716a4fe772ebc36b7550335137bf91adccc/pkg/tsdb/tempo/search.go#L132, which is more reliable than simple `fmt.Sprintf` for URL composition.

**Special notes for your reviewer:**

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
