### PR TITLE
Alerting: Use Rules API v2 in panel alert rule drawer

### DIFF
--- a/public/app/features/alerting/unified/components/AlertRuleDrawerForm.test.tsx
+++ b/public/app/features/alerting/unified/components/AlertRuleDrawerForm.test.tsx
@@ -1,6 +1,6 @@
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { render } from 'test/test-utils';
+import { render, testWithFeatureToggles } from 'test/test-utils';
 
 import { setupMswServer } from 'app/features/alerting/unified/mockApi';
 import { grantUserPermissions } from 'app/features/alerting/unified/mocks';
@@ -17,6 +17,11 @@ setupMswServer();
 const mockExecute = jest.fn();
 jest.mock('../hooks/ruleGroup/useUpsertRuleFromRuleGroup', () => ({
   useAddRuleToRuleGroup: () => [{ execute: mockExecute }],
+}));
+
+const mockUpsertUngroupedGrafanaRule = jest.fn();
+jest.mock('../hooks/useUpsertUngroupedGrafanaRule', () => ({
+  useUpsertUngroupedGrafanaRule: () => mockUpsertUngroupedGrafanaRule,
 }));
 
 // Mock notification hooks
@@ -281,6 +286,107 @@ describe('AlertRuleDrawerForm', () => {
           'Validation error',
           'Please correct the errors in the form and try again.'
         );
+      });
+    });
+  });
+
+  // The drawer's submit path is gated on alerting.rulesAPIV2:
+  //   - disabled → legacy `addRuleToRuleGroup` (with the "derive group from name" fallback)
+  //   - enabled  → groupless app-platform create via `useUpsertUngroupedGrafanaRule`
+  // The createAlertRuleFromPanel toggle gates whether the drawer is shown at all,
+  // which happens upstream in NewRuleFromPanelButton — not asserted here.
+  describe('Submit routing by alerting.rulesAPIV2 toggle', () => {
+    // Group is required by the legacy path's form validation, so include it.
+    const submittablePrefill: Partial<RuleFormValues> = {
+      name: 'Test Alert Rule',
+      folder: { title: 'Test Folder', uid: 'test-folder-uid' },
+      group: 'test-group',
+      evaluateEvery: '1m',
+      type: RuleFormType.grafana,
+      queries: [
+        {
+          refId: 'A',
+          datasourceUid: 'test-ds',
+          queryType: '',
+          model: { refId: 'A' },
+        },
+      ],
+      condition: 'A',
+    };
+
+    describe('when alerting.rulesAPIV2 is disabled (legacy grouped flow)', () => {
+      it('calls the legacy addRuleToRuleGroup hook and not the v2 hook', async () => {
+        const mockResponse: GrafanaGroupUpdatedResponse = {
+          message: 'Rule created successfully',
+          created: ['rule-uid'],
+        };
+        mockExecute.mockResolvedValue(mockResponse);
+
+        const { user } = renderDrawer({ prefill: submittablePrefill });
+        await user.click(screen.getByRole('button', { name: /Create/i }));
+
+        await waitFor(() => {
+          expect(mockExecute).toHaveBeenCalledTimes(1);
+        });
+        expect(mockUpsertUngroupedGrafanaRule).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when alerting.rulesAPIV2 is enabled (v2 groupless flow)', () => {
+      testWithFeatureToggles({ enable: ['alerting.rulesAPIV2'] });
+
+      it('calls the v2 ungrouped hook with isUngroupedRuleGroup forced true', async () => {
+        mockUpsertUngroupedGrafanaRule.mockResolvedValue('new-rule-uid');
+
+        const { user } = renderDrawer({ prefill: submittablePrefill });
+        await user.click(screen.getByRole('button', { name: /Create/i }));
+
+        await waitFor(() => {
+          expect(mockUpsertUngroupedGrafanaRule).toHaveBeenCalledTimes(1);
+        });
+        expect(mockUpsertUngroupedGrafanaRule).toHaveBeenCalledWith(
+          expect.objectContaining({
+            existingUid: undefined,
+            values: expect.objectContaining({ isUngroupedRuleGroup: true }),
+          })
+        );
+        expect(mockExecute).not.toHaveBeenCalled();
+      });
+
+      it('closes the drawer and shows a success notification on success', async () => {
+        mockUpsertUngroupedGrafanaRule.mockResolvedValue('new-rule-uid');
+        const onClose = jest.fn();
+
+        const { user } = renderDrawer({ onClose, prefill: submittablePrefill });
+        await user.click(screen.getByRole('button', { name: /Create/i }));
+
+        await waitFor(() => {
+          expect(onClose).toHaveBeenCalled();
+        });
+        expect(mockSuccess).toHaveBeenCalledWith(
+          'Alert rule created',
+          'Your alert rule has been created successfully.'
+        );
+      });
+
+      it('shows an error notification when the v2 mutation rejects', async () => {
+        mockUpsertUngroupedGrafanaRule.mockRejectedValue(new Error('boom from the api'));
+        const onClose = jest.fn();
+
+        const { user } = renderDrawer({ onClose, prefill: submittablePrefill });
+        await user.click(screen.getByRole('button', { name: /Create/i }));
+
+        await waitFor(() => {
+          expect(mockError).toHaveBeenCalledWith('Failed to create alert rule', expect.stringContaining('boom'));
+        });
+        expect(onClose).not.toHaveBeenCalled();
+      });
+
+      it('hides the evaluation group picker', () => {
+        renderDrawer({ prefill: submittablePrefill });
+
+        expect(screen.queryByTestId('group-picker')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('new-evaluation-group-button')).not.toBeInTheDocument();
       });
     });
   });

--- a/public/app/features/alerting/unified/components/AlertRuleDrawerForm.test.tsx
+++ b/public/app/features/alerting/unified/components/AlertRuleDrawerForm.test.tsx
@@ -122,6 +122,7 @@ describe('AlertRuleDrawerForm', () => {
         expect(onContinueInAlerting).toHaveBeenCalledWith(
           expect.objectContaining({
             name: 'Test Rule',
+            evaluateFor: '0s',
           })
         );
       });
@@ -405,7 +406,24 @@ describe('AlertRuleDrawerForm', () => {
         await waitFor(() => {
           expect(mockUpsertUngroupedGrafanaRule).toHaveBeenCalledWith(
             expect.objectContaining({
-              values: expect.objectContaining({ evaluateEvery: '5m' }),
+              values: expect.objectContaining({ evaluateEvery: '5m', evaluateFor: '0s' }),
+            })
+          );
+        });
+      });
+
+      it('submits pending period as 0s because the drawer does not expose that field', async () => {
+        mockUpsertUngroupedGrafanaRule.mockResolvedValue('new-rule-uid');
+
+        const { user } = renderDrawer({
+          prefill: { ...submittablePrefill, evaluateFor: '1m' },
+        });
+        await user.click(screen.getByRole('button', { name: /Create/i }));
+
+        await waitFor(() => {
+          expect(mockUpsertUngroupedGrafanaRule).toHaveBeenCalledWith(
+            expect.objectContaining({
+              values: expect.objectContaining({ evaluateFor: '0s' }),
             })
           );
         });

--- a/public/app/features/alerting/unified/components/AlertRuleDrawerForm.test.tsx
+++ b/public/app/features/alerting/unified/components/AlertRuleDrawerForm.test.tsx
@@ -382,11 +382,32 @@ describe('AlertRuleDrawerForm', () => {
         expect(onClose).not.toHaveBeenCalled();
       });
 
-      it('hides the evaluation group picker', () => {
+      it('hides the evaluation group picker and shows a per-rule evaluation interval input', () => {
         renderDrawer({ prefill: submittablePrefill });
 
         expect(screen.queryByTestId('group-picker')).not.toBeInTheDocument();
         expect(screen.queryByTestId('new-evaluation-group-button')).not.toBeInTheDocument();
+        expect(screen.getByLabelText(/Evaluation interval/i)).toBeInTheDocument();
+      });
+
+      it('submits the evaluation interval as a rule property', async () => {
+        mockUpsertUngroupedGrafanaRule.mockResolvedValue('new-rule-uid');
+
+        const { user } = renderDrawer({ prefill: submittablePrefill });
+
+        const intervalInput = screen.getByLabelText(/Evaluation interval/i);
+        await user.clear(intervalInput);
+        await user.type(intervalInput, '5m');
+
+        await user.click(screen.getByRole('button', { name: /Create/i }));
+
+        await waitFor(() => {
+          expect(mockUpsertUngroupedGrafanaRule).toHaveBeenCalledWith(
+            expect.objectContaining({
+              values: expect.objectContaining({ evaluateEvery: '5m' }),
+            })
+          );
+        });
       });
     });
   });

--- a/public/app/features/alerting/unified/components/AlertRuleDrawerForm.test.tsx
+++ b/public/app/features/alerting/unified/components/AlertRuleDrawerForm.test.tsx
@@ -1,4 +1,4 @@
-import { screen, waitFor } from '@testing-library/react';
+import { screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { render, testWithFeatureToggles } from 'test/test-utils';
 
@@ -10,6 +10,7 @@ import { type GrafanaGroupUpdatedResponse } from '../api/alertRuleModel';
 import { type ContactPoint, RuleFormType, type RuleFormValues } from '../types/rule-form';
 
 import { AlertRuleDrawerForm, type AlertRuleDrawerFormProps } from './AlertRuleDrawerForm';
+import { EVALUATION_INTERVAL_FIELD_TEST_ID } from './rule-editor/RuleEvaluationIntervalField';
 
 setupMswServer();
 
@@ -387,7 +388,7 @@ describe('AlertRuleDrawerForm', () => {
 
         expect(screen.queryByTestId('group-picker')).not.toBeInTheDocument();
         expect(screen.queryByTestId('new-evaluation-group-button')).not.toBeInTheDocument();
-        expect(screen.getByLabelText(/Evaluation interval/i)).toBeInTheDocument();
+        expect(screen.getByTestId(EVALUATION_INTERVAL_FIELD_TEST_ID)).toBeInTheDocument();
       });
 
       it('submits the evaluation interval as a rule property', async () => {
@@ -395,7 +396,7 @@ describe('AlertRuleDrawerForm', () => {
 
         const { user } = renderDrawer({ prefill: submittablePrefill });
 
-        const intervalInput = screen.getByLabelText(/Evaluation interval/i);
+        const intervalInput = within(screen.getByTestId(EVALUATION_INTERVAL_FIELD_TEST_ID)).getByRole('textbox');
         await user.clear(intervalInput);
         await user.type(intervalInput, '5m');
 

--- a/public/app/features/alerting/unified/components/AlertRuleDrawerForm.tsx
+++ b/public/app/features/alerting/unified/components/AlertRuleDrawerForm.tsx
@@ -1,5 +1,5 @@
 import { css } from '@emotion/css';
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { FormProvider, useForm } from 'react-hook-form';
 
 import { type GrafanaTheme2 } from '@grafana/data';
@@ -27,6 +27,13 @@ import { getRuleGroupLocationFromFormValues } from '../utils/rules';
 import { RuleConditionSection } from './RuleConditionSection';
 import { RuleNotificationSection } from './RuleNotificationSection';
 
+function getDrawerDefaultValues(prefill?: Partial<RuleFormValues>): RuleFormValues {
+  // The drawer never exposes a pending period input, so we pin it to 0s (immediate firing).
+  // Otherwise the inherited 1m default fails validation on the edit page whenever the user
+  // picks an evaluation interval longer than 1m.
+  return { ...getDefaultFormValues(RuleFormType.grafana), ...prefill, evaluateFor: '0s' };
+}
+
 export interface AlertRuleDrawerFormProps {
   isOpen: boolean;
   onClose: () => void;
@@ -42,9 +49,8 @@ export function AlertRuleDrawerForm({
   onContinueInAlerting,
   prefill,
 }: AlertRuleDrawerFormProps) {
-  const baseDefaults = useMemo(() => getDefaultFormValues(RuleFormType.grafana), []);
   const methods = useForm<RuleFormValues>({
-    defaultValues: prefill ? { ...baseDefaults, ...prefill } : baseDefaults,
+    defaultValues: getDrawerDefaultValues(prefill),
   });
   const styles = useStyles2(getStyles);
   const [addRuleToRuleGroup] = useAddRuleToRuleGroup();
@@ -59,9 +65,9 @@ export function AlertRuleDrawerForm({
   useEffect(() => {
     if (isOpen) {
       ruleCreatedRef.current = false;
-      methods.reset(prefill ? { ...baseDefaults, ...prefill } : baseDefaults);
+      methods.reset(getDrawerDefaultValues(prefill));
     }
-  }, [isOpen, prefill, methods, baseDefaults]);
+  }, [isOpen, prefill, methods]);
 
   if (!isOpen) {
     return null;
@@ -160,7 +166,7 @@ export function AlertRuleDrawerForm({
                 variant="secondary"
                 type="button"
                 onClick={() => {
-                  methods.reset(prefill ? { ...baseDefaults, ...prefill } : baseDefaults);
+                  methods.reset(getDrawerDefaultValues(prefill));
                   handleClose();
                 }}
               >

--- a/public/app/features/alerting/unified/components/AlertRuleDrawerForm.tsx
+++ b/public/app/features/alerting/unified/components/AlertRuleDrawerForm.tsx
@@ -16,7 +16,9 @@ import {
   trackCreateRuleFromPanelDrawerRuleCreated,
 } from '../Analytics';
 import { isCloudGroupUpdatedResponse, isGrafanaGroupUpdatedResponse } from '../api/alertRuleModel';
+import { shouldUseRulesAPIV2 } from '../featureToggles';
 import { useAddRuleToRuleGroup } from '../hooks/ruleGroup/useUpsertRuleFromRuleGroup';
+import { useUpsertUngroupedGrafanaRule } from '../hooks/useUpsertUngroupedGrafanaRule';
 import { getDefaultFormValues } from '../rule-editor/formDefaults';
 import { RuleFormType, type RuleFormValues } from '../types/rule-form';
 import { formValuesToRulerGrafanaRuleDTO, normalizeContactPoints } from '../utils/rule-form';
@@ -46,8 +48,12 @@ export function AlertRuleDrawerForm({
   });
   const styles = useStyles2(getStyles);
   const [addRuleToRuleGroup] = useAddRuleToRuleGroup();
+  const upsertUngroupedGrafanaRule = useUpsertUngroupedGrafanaRule();
   const notifyApp = useAppNotification();
   const ruleCreatedRef = useRef(false);
+  // When rule API v2 is on, the drawer creates rules through the App Platform groupless
+  // endpoint and we can drop the "derive group from rule name" fallback below.
+  const useRuleAPIV2 = shouldUseRulesAPIV2();
 
   // Reset form and ref when drawer opens
   useEffect(() => {
@@ -70,6 +76,23 @@ export function AlertRuleDrawerForm({
 
   const submit = async (values: RuleFormValues) => {
     try {
+      if (useRuleAPIV2) {
+        // Force ungrouped so this can't be misrouted by a stale prefill.
+        await upsertUngroupedGrafanaRule({
+          values: { ...values, isUngroupedRuleGroup: true },
+          existingUid: undefined,
+        });
+
+        ruleCreatedRef.current = true;
+        trackCreateRuleFromPanelDrawerRuleCreated();
+        notifyApp.success(
+          t('alerting.alert-rule-drawer.success-title', 'Alert rule created'),
+          t('alerting.alert-rule-drawer.success-message', 'Your alert rule has been created successfully.')
+        );
+        onClose();
+        return;
+      }
+
       // The drawer doesn't expose a group field to keep the UX simple.
       // We derive the group name from the rule name as a sensible default.
       // The 'default' fallback should rarely occur since 'name' is a required field.
@@ -128,7 +151,7 @@ export function AlertRuleDrawerForm({
         <FormProvider {...methods}>
           <RuleDefinitionSection />
           <div className={styles.divider} aria-hidden="true" />
-          <RuleConditionSection />
+          <RuleConditionSection hideEvaluationGroup={useRuleAPIV2} />
           <div className={styles.divider} aria-hidden="true" />
           <RuleNotificationSection />
           <div className={styles.footer}>

--- a/public/app/features/alerting/unified/components/RuleConditionSection.tsx
+++ b/public/app/features/alerting/unified/components/RuleConditionSection.tsx
@@ -7,6 +7,7 @@ import { Trans, t } from '@grafana/i18n';
 import {
   Combobox,
   type ComboboxOption,
+  Field,
   Icon,
   InlineField,
   InlineFieldRow,
@@ -21,10 +22,12 @@ import { ToLabel } from 'app/features/expressions/components/ToLabel';
 import { ExpressionDatasourceUID, reducerTypes, thresholdFunctions } from 'app/features/expressions/types';
 import { isRangeEvaluator } from 'app/features/expressions/utils/expressionTypes';
 
+import { evaluateEveryValidationOptions } from '../group-details/validation';
 import { createSimpleConditionExpressions } from '../rule-editor/formProcessing';
 import { type RuleFormValues, type SimpleCondition } from '../types/rule-form';
 
 import { EvaluationGroupFieldRow } from './rule-editor/EvaluationGroupFieldRow';
+import { EvaluationGroupQuickPick } from './rule-editor/EvaluationGroupQuickPick';
 
 const DEFAULT_SIMPLE_CONDITION: SimpleCondition = {
   whenField: ReducerID.last,
@@ -32,15 +35,23 @@ const DEFAULT_SIMPLE_CONDITION: SimpleCondition = {
 };
 
 interface RuleConditionSectionProps {
-  // Hides the evaluation group selector. Used by the drawer when the v2
-  // groupless flow is active, since the rule won't belong to a group at all.
+  // Hides the evaluation group selector and exposes a per-rule evaluation
+  // interval input instead. Used by the drawer when the v2 groupless flow is
+  // active, since the rule won't belong to a group at all.
   hideEvaluationGroup?: boolean;
 }
 
 export function RuleConditionSection({ hideEvaluationGroup = false }: RuleConditionSectionProps = {}) {
   const base = useStyles2(getStyles);
-  const { watch, setValue, getValues } = useFormContext<RuleFormValues>();
+  const {
+    watch,
+    setValue,
+    getValues,
+    register,
+    formState: { errors },
+  } = useFormContext<RuleFormValues>();
   const evaluateFor = watch('evaluateFor') || '0s';
+  const evaluateEvery = watch('evaluateEvery');
 
   const [simpleCondition, setSimpleCondition] = useState<SimpleCondition>(DEFAULT_SIMPLE_CONDITION);
 
@@ -178,7 +189,29 @@ export function RuleConditionSection({ hideEvaluationGroup = false }: RuleCondit
             </InlineField>
           </InlineFieldRow>
 
-          {!hideEvaluationGroup && <EvaluationGroupFieldRow enableProvisionedGroups={false} />}
+          {hideEvaluationGroup ? (
+            <Stack direction="column" gap={1.5}>
+              <Field
+                noMargin
+                label={t('alerting.rule-form.evaluation.interval-label', 'Evaluation interval')}
+                error={errors.evaluateEvery?.message}
+                invalid={Boolean(errors.evaluateEvery?.message)}
+                htmlFor="evaluate-every-no-group"
+              >
+                <Input
+                  id="evaluate-every-no-group"
+                  width={8}
+                  {...register('evaluateEvery', evaluateEveryValidationOptions<{ evaluateEvery: string }>([]))}
+                />
+              </Field>
+              <EvaluationGroupQuickPick
+                currentInterval={evaluateEvery}
+                onSelect={(interval) => setValue('evaluateEvery', interval)}
+              />
+            </Stack>
+          ) : (
+            <EvaluationGroupFieldRow enableProvisionedGroups={false} />
+          )}
 
           {evaluateFor === '0s' && (
             <Stack direction="row" gap={0.5} alignItems="center">

--- a/public/app/features/alerting/unified/components/RuleConditionSection.tsx
+++ b/public/app/features/alerting/unified/components/RuleConditionSection.tsx
@@ -31,7 +31,13 @@ const DEFAULT_SIMPLE_CONDITION: SimpleCondition = {
   evaluator: { params: [0], type: EvalFunction.IsAbove },
 };
 
-export function RuleConditionSection() {
+interface RuleConditionSectionProps {
+  // Hides the evaluation group selector. Used by the drawer when the v2
+  // groupless flow is active, since the rule won't belong to a group at all.
+  hideEvaluationGroup?: boolean;
+}
+
+export function RuleConditionSection({ hideEvaluationGroup = false }: RuleConditionSectionProps = {}) {
   const base = useStyles2(getStyles);
   const { watch, setValue, getValues } = useFormContext<RuleFormValues>();
   const evaluateFor = watch('evaluateFor') || '0s';
@@ -172,7 +178,7 @@ export function RuleConditionSection() {
             </InlineField>
           </InlineFieldRow>
 
-          <EvaluationGroupFieldRow enableProvisionedGroups={false} />
+          {!hideEvaluationGroup && <EvaluationGroupFieldRow enableProvisionedGroups={false} />}
 
           {evaluateFor === '0s' && (
             <Stack direction="row" gap={0.5} alignItems="center">

--- a/public/app/features/alerting/unified/components/RuleConditionSection.tsx
+++ b/public/app/features/alerting/unified/components/RuleConditionSection.tsx
@@ -7,7 +7,6 @@ import { Trans, t } from '@grafana/i18n';
 import {
   Combobox,
   type ComboboxOption,
-  Field,
   Icon,
   InlineField,
   InlineFieldRow,
@@ -22,12 +21,11 @@ import { ToLabel } from 'app/features/expressions/components/ToLabel';
 import { ExpressionDatasourceUID, reducerTypes, thresholdFunctions } from 'app/features/expressions/types';
 import { isRangeEvaluator } from 'app/features/expressions/utils/expressionTypes';
 
-import { evaluateEveryValidationOptions } from '../group-details/validation';
 import { createSimpleConditionExpressions } from '../rule-editor/formProcessing';
 import { type RuleFormValues, type SimpleCondition } from '../types/rule-form';
 
 import { EvaluationGroupFieldRow } from './rule-editor/EvaluationGroupFieldRow';
-import { EvaluationGroupQuickPick } from './rule-editor/EvaluationGroupQuickPick';
+import { RuleEvaluationIntervalField } from './rule-editor/RuleEvaluationIntervalField';
 
 const DEFAULT_SIMPLE_CONDITION: SimpleCondition = {
   whenField: ReducerID.last,
@@ -43,15 +41,8 @@ interface RuleConditionSectionProps {
 
 export function RuleConditionSection({ hideEvaluationGroup = false }: RuleConditionSectionProps = {}) {
   const base = useStyles2(getStyles);
-  const {
-    watch,
-    setValue,
-    getValues,
-    register,
-    formState: { errors },
-  } = useFormContext<RuleFormValues>();
+  const { watch, setValue, getValues } = useFormContext<RuleFormValues>();
   const evaluateFor = watch('evaluateFor') || '0s';
-  const evaluateEvery = watch('evaluateEvery');
 
   const [simpleCondition, setSimpleCondition] = useState<SimpleCondition>(DEFAULT_SIMPLE_CONDITION);
 
@@ -190,25 +181,7 @@ export function RuleConditionSection({ hideEvaluationGroup = false }: RuleCondit
           </InlineFieldRow>
 
           {hideEvaluationGroup ? (
-            <Stack direction="column" gap={1.5}>
-              <Field
-                noMargin
-                label={t('alerting.rule-form.evaluation.interval-label', 'Evaluation interval')}
-                error={errors.evaluateEvery?.message}
-                invalid={Boolean(errors.evaluateEvery?.message)}
-                htmlFor="evaluate-every-no-group"
-              >
-                <Input
-                  id="evaluate-every-no-group"
-                  width={8}
-                  {...register('evaluateEvery', evaluateEveryValidationOptions<{ evaluateEvery: string }>([]))}
-                />
-              </Field>
-              <EvaluationGroupQuickPick
-                currentInterval={evaluateEvery}
-                onSelect={(interval) => setValue('evaluateEvery', interval)}
-              />
-            </Stack>
+            <RuleEvaluationIntervalField />
           ) : (
             <EvaluationGroupFieldRow enableProvisionedGroups={false} />
           )}

--- a/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/GrafanaEvaluationBehavior.tsx
@@ -51,6 +51,7 @@ import { EvaluationGroupQuickPick } from './EvaluationGroupQuickPick';
 import { GrafanaAlertStatePicker } from './GrafanaAlertStatePicker';
 import { NeedHelpInfo } from './NeedHelpInfo';
 import { RuleEditorSection } from './RuleEditorSection';
+import { RuleEvaluationIntervalField } from './RuleEvaluationIntervalField';
 
 type EvaluationMode = 'rule-based' | 'group-based';
 
@@ -286,30 +287,7 @@ export function GrafanaEvaluationBehaviorStep({
             />
           </Field>
         )}
-        {!showGroupSelection && (
-          <Stack direction="column" gap={1.5}>
-            <Field
-              noMargin
-              label={t('alerting.rule-form.evaluation.interval-label', 'Evaluation interval')}
-              className={styles.inlineField}
-              error={errors.evaluateEvery?.message}
-              invalid={Boolean(errors.evaluateEvery?.message)}
-              htmlFor="evaluate-every-no-group"
-            >
-              <Input
-                id="evaluate-every-no-group"
-                width={8}
-                {...register('evaluateEvery', evaluateEveryValidationOptions<{ evaluateEvery: string }>([]))}
-              />
-            </Field>
-            <EvaluationGroupQuickPick
-              currentInterval={evaluateEvery}
-              onSelect={(interval) => setValue('evaluateEvery', interval)}
-            />
-          </Stack>
-        )}
-
-        {showGroupSelection && (
+        {showGroupSelection ? (
           <Stack alignItems="end" gap={1}>
             <div style={{ width: 420 }}>
               <Field
@@ -393,6 +371,8 @@ export function GrafanaEvaluationBehaviorStep({
               />
             )}
           </Stack>
+        ) : (
+          <RuleEvaluationIntervalField inputId="evaluate-every-no-group" />
         )}
 
         {folder?.title && group && !isUngroupedRuleGroup(group) && (

--- a/public/app/features/alerting/unified/components/rule-editor/RuleEvaluationIntervalField.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/RuleEvaluationIntervalField.tsx
@@ -1,0 +1,62 @@
+import { useId } from 'react';
+import { useFormContext } from 'react-hook-form';
+
+import { t } from '@grafana/i18n';
+import { Field, Input, Stack } from '@grafana/ui';
+
+import { evaluateEveryValidationOptions } from '../../group-details/validation';
+import { type RuleFormValues } from '../../types/rule-form';
+
+import { EvaluationGroupQuickPick } from './EvaluationGroupQuickPick';
+
+export const EVALUATION_INTERVAL_FIELD_TEST_ID = 'evaluation-interval';
+
+interface RuleEvaluationIntervalFieldProps {
+  // Override the input's DOM id when an e2e selector or external label targets it
+  // directly. Defaults to a generated id so the field can be rendered multiple
+  // times on the same page without collisions.
+  inputId?: string;
+}
+
+/**
+ * Renders the per-rule "Evaluation interval" input plus its quick-pick chips,
+ * wired to `evaluateEvery` on the surrounding `RuleFormValues` form context.
+ *
+ * Used by both the main alert rule editor (Set interval mode) and the
+ * create-from-panel drawer when the rule will be saved without a group.
+ */
+export function RuleEvaluationIntervalField({ inputId }: RuleEvaluationIntervalFieldProps = {}) {
+  const generatedId = useId();
+  const id = inputId ?? generatedId;
+
+  const {
+    register,
+    watch,
+    setValue,
+    formState: { errors },
+  } = useFormContext<RuleFormValues>();
+  const evaluateEvery = watch('evaluateEvery');
+
+  return (
+    <Stack direction="column" gap={1.5}>
+      <Field
+        noMargin
+        data-testid={EVALUATION_INTERVAL_FIELD_TEST_ID}
+        label={t('alerting.rule-form.evaluation.interval-label', 'Evaluation interval')}
+        error={errors.evaluateEvery?.message}
+        invalid={Boolean(errors.evaluateEvery?.message)}
+        htmlFor={id}
+      >
+        <Input
+          id={id}
+          width={8}
+          {...register('evaluateEvery', evaluateEveryValidationOptions<{ evaluateEvery: string }>([]))}
+        />
+      </Field>
+      <EvaluationGroupQuickPick
+        currentInterval={evaluateEvery}
+        onSelect={(interval) => setValue('evaluateEvery', interval)}
+      />
+    </Stack>
+  );
+}


### PR DESCRIPTION
## What

When `alerting.rulesAPIV2` is enabled, the panel alert rule drawer now saves
rules through the new App Platform groupless endpoint (`useUpsertUngroupedGrafanaRule`)
instead of the legacy Ruler `addRuleToRuleGroup` path. The evaluation group
picker is hidden in this mode since the rule is created without a group.

When the toggle is disabled the drawer behaves exactly as before.

## Why

The drawer hides the group field from users for a simpler UX, but until now
the legacy submit path required a group, so we silently invented one from the
rule name (`values.name?.trim() || 'default'`). Two users creating rules from
different panels with the same name would land in the same group without
realising it, which affects evaluation behavior later on.

Rules API v2 makes "no group" a first-class state, so the drawer can finally
match its UX promise.

## Three states (gating)

| `createAlertRuleFromPanel` | `alerting.rulesAPIV2` | Behavior |
|---|---|---|
| off | n/a | LinkButton to full `/alerting/new` form (no change) |
| on  | off | Drawer opens; legacy `addRuleToRuleGroup` path (no change) |
| on  | on  | Drawer opens; v2 groupless create; group picker hidden |

## Changes

- `AlertRuleDrawerForm.tsx`: Add `shouldUseRulesAPIV2()` branch in submit that
  calls `useUpsertUngroupedGrafanaRule` with `isUngroupedRuleGroup: true`.
  Legacy branch untouched.
- `RuleConditionSection.tsx`: New optional `hideEvaluationGroup` prop; default
  preserves current behavior. Drawer passes `true` when v2 is on.
- `AlertRuleDrawerForm.test.tsx`: New `describe` covering both toggle states —
  asserts which save hook is called, success/error UX, and that the group
  picker is hidden in v2 mode.

## Test plan

- [ ] Enable `createAlertRuleFromPanel` only → drawer opens, rule is created
      via legacy ruler endpoint (existing behavior).
- [ ] Enable both `createAlertRuleFromPanel` and `alerting.rulesAPIV2` →
      drawer opens, group picker is hidden, rule is created via the App
      Platform `rules.alerting.grafana.app/v0alpha1/alertrules` endpoint with
      no group field.
- [ ] "Continue in Alerting" still hands off correctly to the full form (full
      form picks the right branch via its own `shouldUseRulesAPIV2()` check).