### PR TITLE
Tempo: prevent case-insensitive header collision when forwarding team headers

### DIFF
--- a/pkg/tsdb/tempo/utils/stream_utils.go
+++ b/pkg/tsdb/tempo/utils/stream_utils.go
@@ -20,7 +20,9 @@ const (
 // returns HTTP header key/value pairs for the outgoing Tempo streaming gRPC call.
 // It always includes datasource HTTP client option headers. When streamingForwardTeamHeadersTempo is enabled, it also merges
 // outgoing gRPC metadata: X-Prom-Label-Policy is set from the x-prom-label-policy metadata values, and every other
-// metadata entry is copied under its existing key.
+// metadata entry is copied under its existing key. Team headers whose key collides case-insensitively with a
+// datasource-configured header are dropped — HTTP/gRPC header names are case-insensitive on the wire, so keeping both
+// would let Go's randomised map iteration deliver the wrong value (e.g. x-scope-orgid).
 func GetHeadersFromIncomingContext(ctx context.Context, logger log.Logger) (map[string]string, error) {
 	plugin := backend.PluginConfigFromContext(ctx)
 	headers, err := getClientOptionsHeaders(ctx, plugin)
@@ -28,9 +30,20 @@ func GetHeadersFromIncomingContext(ctx context.Context, logger log.Logger) (map[
 		return nil, err
 	}
 
+	reserved := make(map[string]struct{}, len(headers))
+	for k := range headers {
+		reserved[strings.ToLower(k)] = struct{}{}
+	}
+
 	// fetch team headers from outgoing context.
 	teamHeaders := getTeamHeaders(ctx, logger, plugin)
 	for k, v := range teamHeaders {
+		if _, conflict := reserved[strings.ToLower(k)]; conflict {
+			if plugin.DataSourceInstanceSettings != nil {
+				logger.Debug("Skipping team header that conflicts with datasource header", "header", k, "datasource_uid", plugin.DataSourceInstanceSettings.UID)
+			}
+			continue
+		}
 		headers[k] = v
 	}
 	return headers, nil

--- a/pkg/tsdb/tempo/utils/stream_utils_test.go
+++ b/pkg/tsdb/tempo/utils/stream_utils_test.go
@@ -172,6 +172,38 @@ func TestGetHeadersFromIncomingContext_MergesIncomingMetadata_WhenToggleOn(t *te
 	assert.Equal(t, "client-value-a,client-value-b", headers["X-Client"])
 }
 
+func TestGetHeadersFromIncomingContext_DatasourceHeaderWinsOverConflictingTeamHeader(t *testing.T) {
+	jsonData := []byte(`{
+		"httpHeaderName1": "X-Scope-Orgid"
+	}`)
+	pluginCtx := backend.PluginContext{
+		DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{
+			JSONData: jsonData,
+			DecryptedSecureJSONData: map[string]string{
+				"httpHeaderValue1": "1",
+			},
+		},
+	}
+	ctx := backend.WithPluginContext(context.Background(), pluginCtx)
+	ctx = config.WithGrafanaConfig(ctx, config.NewGrafanaCfg(map[string]string{
+		featuretoggles.EnabledFeatures: "streamingForwardTeamHeadersTempo",
+	}))
+	ctx = metadata.NewIncomingContext(ctx, metadata.Pairs(
+		"x-scope-orgid", "tenant-from-incoming",
+		"x-custom-forward", "extra",
+	))
+
+	headers, err := GetHeadersFromIncomingContext(ctx, testLogger())
+	require.NoError(t, err)
+
+	// Only the datasource-configured X-Scope-Orgid should be present; the lowercase
+	// incoming variant must be dropped so the gRPC wire only carries one value.
+	assert.Equal(t, "1", headers["X-Scope-Orgid"])
+	_, lowerPresent := headers["x-scope-orgid"]
+	assert.False(t, lowerPresent, "lowercase x-scope-orgid must not coexist with datasource header")
+	assert.Equal(t, "extra", headers["x-custom-forward"])
+}
+
 func TestGetClientOptionsHeaders_ParsesHeaders(t *testing.T) {
 	pluginCtx := backend.PluginContext{
 		DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{


### PR DESCRIPTION
Fixes #123923 

## Summary

- When `streamingForwardTeamHeadersTempo` is on, [GetHeadersFromIncomingContext](pkg/tsdb/tempo/utils/stream_utils.go#L24) forwarded all outgoing gRPC metadata alongside datasource-configured HTTP headers. gRPC lowercases metadata keys, so an incoming `x-scope-orgid` landed in the merged map next to the datasource's canonical `X-Scope-Orgid`. On the wire both serialize to the same case-insensitive name and Go's randomised map iteration could deliver the wrong value, surfacing as Tempo's `no org id` error.
- The fix drops team headers whose key collides case-insensitively with a datasource-configured header, so datasource settings always take precedence.
- Added a regression test that reproduces the `X-Scope-Orgid` vs `x-scope-orgid` collision.

## Notes

The existing function name and toggle description say "team headers", but the implementation forwards *all* outgoing metadata. This PR preserves that broad behavior and only stops the collision. If the intent is to forward a narrower allowlist (e.g. only `X-Prom-Label-Policy`), that's worth a follow-up.