### PR TITLE
Search: chunked snapshot files in KVRemoteIndexStore

### DIFF
--- a/pkg/storage/unified/search/kv_remote_index_store.go
+++ b/pkg/storage/unified/search/kv_remote_index_store.go
@@ -43,6 +43,25 @@ const (
 	// atomic on most backends, but we still chunk to keep individual calls
 	// small.
 	kvDeleteBatchSize = kv.MaxBatchOps
+
+	// defaultKVChunkSize bounds the size of a single value written to the
+	// underlying KV. 10 MiB sits well under the per-value limit on every
+	// supported KV backend.
+	defaultKVChunkSize int64 = 10 * 1024 * 1024
+
+	// minKVChunkSize / maxKVChunkSize bound user-supplied ChunkSize
+	// values. The bounds are sanity guards: anything in this range works
+	// correctly, but values far from typical (a few MiB) are unlikely to
+	// be intentional. The upper bound stays under every backend's
+	// per-value cap with margin.
+	minKVChunkSize int64 = 1024 * 1024
+	maxKVChunkSize int64 = 1024 * 1024 * 1024
+
+	// kvChunkSuffixFormat zero-pads the chunk index so listing returns
+	// chunks in numeric order. Six digits supports up to a million chunks
+	// per file, which is comfortable headroom even at the minimum chunk
+	// size.
+	kvChunkSuffixFormat = "%06d"
 )
 
 // KVRemoteIndexStoreConfig configures NewKVRemoteIndexStore.
@@ -59,6 +78,13 @@ type KVRemoteIndexStoreConfig struct {
 	// build and cleanup locks. Zero values fall back to defaults.
 	BuildLock   LockOptions
 	CleanupLock LockOptions
+
+	// ChunkSize bounds the size (in bytes) of a single KV value used to
+	// store snapshot file data. Files larger than ChunkSize are split into
+	// numbered chunks; readers recover the chunk size from chunk 0's actual
+	// length, so writers can change ChunkSize between deployments without
+	// breaking existing snapshots. Zero falls back to defaultKVChunkSize.
+	ChunkSize int64
 }
 
 // KVRemoteIndexStore implements RemoteIndexStore on top of a kv.KV.
@@ -91,8 +117,13 @@ type KVRemoteIndexStoreConfig struct {
 // Locks live in kv.LeasesSection (managed by lease.Manager), so snapshot
 // keys and lease keys never overlap.
 //
-// Each data file is stored as a single KV value. Transparent chunking for
-// files larger than the backend's per-value limit is not yet implemented.
+// Each snapshot file is split into one or more fixed-size chunks, each
+// stored as a single KV value at key "<...>/<index-key>/<relPath>/<NNNNN>"
+// where NNNNN is the zero-padded chunk index. Even small files get one
+// chunk at index 000000, so read and write paths don't need a separate
+// non-chunked code path. ChunkSize is recoverable at read time from the
+// observed size of chunk 0, so the writer's choice of ChunkSize is not
+// part of the persistent format and can change between deployments.
 //
 // Known limitation: because ListIndexKeys lists only the manifest section,
 // CleanupIncompleteIndexSnapshots cannot detect incomplete uploads (data
@@ -104,6 +135,7 @@ type KVRemoteIndexStore struct {
 	leaseMgr        *lease.Manager
 	buildLockOpts   LockOptions
 	cleanupLockOpts LockOptions
+	chunkSize       int64
 	log             log.Logger
 }
 
@@ -116,11 +148,16 @@ func NewKVRemoteIndexStore(cfg KVRemoteIndexStoreConfig) (*KVRemoteIndexStore, e
 	if cfg.LeaseManager == nil {
 		return nil, fmt.Errorf("lease manager is required")
 	}
+	chunkSize := cmp.Or(cfg.ChunkSize, defaultKVChunkSize)
+	if chunkSize < minKVChunkSize || chunkSize > maxKVChunkSize {
+		return nil, fmt.Errorf("chunk size %d out of range [%d, %d]", chunkSize, minKVChunkSize, maxKVChunkSize)
+	}
 	return &KVRemoteIndexStore{
 		store:           cfg.KV,
 		leaseMgr:        cfg.LeaseManager,
 		buildLockOpts:   cfg.BuildLock,
 		cleanupLockOpts: cfg.CleanupLock,
+		chunkSize:       chunkSize,
 		log:             log.New("kv-remote-index-store"),
 	}, nil
 }
@@ -153,8 +190,16 @@ func kvNamespacePrefix(namespace string) string {
 	return namespace + "/"
 }
 
-func (s *KVRemoteIndexStore) dataKey(ns resource.NamespacedResource, indexKey ulid.ULID, relPath string) string {
-	return kvDataPrefix(ns, indexKey) + relPath
+// dataKeyPrefix returns the per-file prefix under which all chunks of a
+// single snapshot file live. The trailing slash makes prefix-based listing
+// return only this file's chunks.
+func (s *KVRemoteIndexStore) dataKeyPrefix(ns resource.NamespacedResource, indexKey ulid.ULID, relPath string) string {
+	return kvDataPrefix(ns, indexKey) + relPath + "/"
+}
+
+// dataChunkKey returns the KV key for one chunk of a snapshot file.
+func (s *KVRemoteIndexStore) dataChunkKey(ns resource.NamespacedResource, indexKey ulid.ULID, relPath string, chunkIdx int64) string {
+	return s.dataKeyPrefix(ns, indexKey, relPath) + fmt.Sprintf(kvChunkSuffixFormat, chunkIdx)
 }
 
 // manifestKey returns the key for a snapshot's manifest in the manifest
@@ -199,53 +244,132 @@ func validateNsResource(ns resource.NamespacedResource) error {
 	return nil
 }
 
-// WriteSnapshotFile streams src into a single KV value at the per-file key
-// in the data section. Chunking for large files is not yet implemented.
+// WriteSnapshotFile splits src into chunks of at most chunkSize bytes and
+// writes each chunk to a separate KV value under the per-file prefix. Empty
+// files are not supported because all KV backends reject zero-byte values,
+// but snapshot files produced by Bleve are always non-empty in practice.
 func (s *KVRemoteIndexStore) WriteSnapshotFile(ctx context.Context, nsResource resource.NamespacedResource, indexKey ulid.ULID, relPath string, src *os.File) error {
 	if err := validateNsResource(nsResource); err != nil {
 		return err
 	}
-	w, err := s.store.Save(ctx, IndexSnapshotDataSection, s.dataKey(nsResource, indexKey, relPath))
+	stat, err := src.Stat()
 	if err != nil {
-		return fmt.Errorf("opening kv writer for %s: %w", relPath, err)
+		return fmt.Errorf("stat snapshot file %s: %w", relPath, err)
 	}
-	if _, err := io.Copy(w, src); err != nil {
-		_ = w.Close()
-		return fmt.Errorf("writing snapshot file %s: %w", relPath, err)
+	size := stat.Size()
+	if size == 0 {
+		return fmt.Errorf("snapshot file %s is empty", relPath)
 	}
-	if err := w.Close(); err != nil {
-		return fmt.Errorf("closing kv writer for %s: %w", relPath, err)
+	numChunks := (size + s.chunkSize - 1) / s.chunkSize
+
+	for chunkIdx := range numChunks {
+		offset := chunkIdx * s.chunkSize
+		length := s.chunkSize
+		if remaining := size - offset; remaining < length {
+			length = remaining
+		}
+		section := io.NewSectionReader(src, offset, length)
+		if err := s.writeChunk(ctx, nsResource, indexKey, relPath, chunkIdx, section); err != nil {
+			return err
+		}
 	}
 	return nil
 }
 
-// ReadSnapshotFile streams the KV value at the per-file key in the data
-// section into dst, capping the transfer at expectedSize+1 bytes so a
-// misadvertised size cannot transfer unbounded data. Returns
-// ErrSnapshotNotFound if the key is absent.
+// writeChunk uploads a single chunk to its KV key. The reader is fully
+// drained or an error is returned.
+func (s *KVRemoteIndexStore) writeChunk(ctx context.Context, ns resource.NamespacedResource, indexKey ulid.ULID, relPath string, chunkIdx int64, src io.Reader) error {
+	key := s.dataChunkKey(ns, indexKey, relPath, chunkIdx)
+	w, err := s.store.Save(ctx, IndexSnapshotDataSection, key)
+	if err != nil {
+		return fmt.Errorf("opening kv writer for %s chunk %d: %w", relPath, chunkIdx, err)
+	}
+	if _, err := io.Copy(w, src); err != nil {
+		_ = w.Close()
+		return fmt.Errorf("writing %s chunk %d: %w", relPath, chunkIdx, err)
+	}
+	if err := w.Close(); err != nil {
+		return fmt.Errorf("closing kv writer for %s chunk %d: %w", relPath, chunkIdx, err)
+	}
+	return nil
+}
+
+// ReadSnapshotFile reassembles a snapshot file by reading chunks 0..N-1 in
+// order, where N is recovered from chunk 0's actual size and the advertised
+// expectedSize. Returns ErrSnapshotNotFound if chunk 0 is missing, and
+// wraps resource.ErrWriteLimitExceeded if the assembled file would exceed
+// expectedSize.
 func (s *KVRemoteIndexStore) ReadSnapshotFile(ctx context.Context, nsResource resource.NamespacedResource, indexKey ulid.ULID, relPath string, dst *os.File, expectedSize int64) error {
 	if err := validateNsResource(nsResource); err != nil {
 		return err
 	}
-	rc, err := s.store.Get(ctx, IndexSnapshotDataSection, s.dataKey(nsResource, indexKey, relPath))
+
+	// Chunk 0's cap is expectedSize+1: either the whole file fits in one
+	// chunk, or we'll observe the writer's chunk size as len(chunk0) and
+	// fetch the remaining chunks from there.
+	n0, err := s.readChunk(ctx, nsResource, indexKey, relPath, 0, dst, expectedSize+1)
 	if err != nil {
 		if errors.Is(err, kv.ErrNotFound) {
 			return ErrSnapshotNotFound
 		}
-		return fmt.Errorf("reading snapshot file %s: %w", relPath, err)
+		return err
 	}
-	defer func() { _ = rc.Close() }()
-
-	// Read one extra byte so we can detect oversized objects without a
-	// second round trip.
-	n, err := io.Copy(dst, io.LimitReader(rc, expectedSize+1))
-	if err != nil {
-		return fmt.Errorf("copying snapshot file %s: %w", relPath, err)
-	}
-	if n > expectedSize {
+	switch {
+	case n0 > expectedSize:
 		return fmt.Errorf("remote object %s exceeds expected size %d: %w", relPath, expectedSize, resource.ErrWriteLimitExceeded)
+	case n0 == expectedSize:
+		// Single-chunk file fully covered by chunk 0.
+		return nil
+	case n0 == 0:
+		// Multi-chunk file with an empty chunk 0 would never make
+		// progress and we have no chunk size to derive. Treat it as
+		// corruption.
+		return fmt.Errorf("chunk 0 of %s is empty but expected size %d", relPath, expectedSize)
+	}
+
+	// Chunk 0 covered some but not all of the file, so its size IS the
+	// writer's chunk size; fetch the rest accordingly.
+	chunkSize := n0
+	written := n0
+	for chunkIdx := int64(1); written < expectedSize; chunkIdx++ {
+		// Cap each subsequent chunk at chunkSize+1 to detect over-read
+		// without buffering the whole chunk first.
+		n, err := s.readChunk(ctx, nsResource, indexKey, relPath, chunkIdx, dst, chunkSize+1)
+		if err != nil {
+			if errors.Is(err, kv.ErrNotFound) {
+				return fmt.Errorf("chunk %d of %s missing: %w", chunkIdx, relPath, err)
+			}
+			return err
+		}
+		if n == 0 {
+			return fmt.Errorf("chunk %d of %s is empty", chunkIdx, relPath)
+		}
+		written += n
+		if written > expectedSize {
+			return fmt.Errorf("remote object %s exceeds expected size %d: %w", relPath, expectedSize, resource.ErrWriteLimitExceeded)
+		}
 	}
 	return nil
+}
+
+// readChunk fetches one chunk into dst, capped at maxBytes to detect
+// over-sized values. Returns the number of bytes written. Propagates
+// kv.ErrNotFound unwrapped so callers can distinguish a missing chunk.
+func (s *KVRemoteIndexStore) readChunk(ctx context.Context, ns resource.NamespacedResource, indexKey ulid.ULID, relPath string, chunkIdx int64, dst io.Writer, maxBytes int64) (int64, error) {
+	key := s.dataChunkKey(ns, indexKey, relPath, chunkIdx)
+	rc, err := s.store.Get(ctx, IndexSnapshotDataSection, key)
+	if err != nil {
+		if errors.Is(err, kv.ErrNotFound) {
+			return 0, err
+		}
+		return 0, fmt.Errorf("reading %s chunk %d: %w", relPath, chunkIdx, err)
+	}
+	defer func() { _ = rc.Close() }()
+	n, err := io.Copy(dst, io.LimitReader(rc, maxBytes))
+	if err != nil {
+		return n, fmt.Errorf("copying %s chunk %d: %w", relPath, chunkIdx, err)
+	}
+	return n, nil
 }
 
 // WriteSnapshotManifest stores the manifest as a single KV value in the

--- a/pkg/storage/unified/search/kv_remote_index_store_test.go
+++ b/pkg/storage/unified/search/kv_remote_index_store_test.go
@@ -185,7 +185,7 @@ func TestKVRemoteIndexStore_DeleteIndex_LargeFileCount(t *testing.T) {
 	for i := range fileCount {
 		rel := fmt.Sprintf("store/file-%03d", i)
 		files[rel] = 4
-		writeKVValue(t, store.store, IndexSnapshotDataSection, store.dataKey(ns, key, rel), []byte("data"))
+		writeKVValue(t, store.store, IndexSnapshotDataSection, store.dataChunkKey(ns, key, rel, 0), []byte("data"))
 	}
 	metaBytes, err := json.Marshal(IndexMeta{BuildVersion: "11.0.0", Files: files})
 	require.NoError(t, err)
@@ -215,7 +215,7 @@ func TestKVRemoteIndexStore_ReadSnapshotFile_OversizedFails(t *testing.T) {
 
 	// Plant a 100-byte value but advertise it as 10.
 	const advertised = 10
-	writeKVValue(t, store.store, IndexSnapshotDataSection, store.dataKey(ns, key, "store/root.bolt"), bytes.Repeat([]byte("x"), 100))
+	writeKVValue(t, store.store, IndexSnapshotDataSection, store.dataChunkKey(ns, key, "store/root.bolt", 0), bytes.Repeat([]byte("x"), 100))
 
 	err := store.ReadSnapshotFile(t.Context(), ns, key, "store/root.bolt", newTempOSFile(t), advertised)
 	require.Error(t, err)
@@ -239,7 +239,7 @@ func TestKVRemoteIndexStore_DownloadRejectsOversizedFile(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, store.WriteSnapshotManifest(ctx, ns, key, metaBytes))
 
-	writeKVValue(t, store.store, IndexSnapshotDataSection, store.dataKey(ns, key, "store/root.bolt"), bytes.Repeat([]byte("x"), advertised*1000))
+	writeKVValue(t, store.store, IndexSnapshotDataSection, store.dataChunkKey(ns, key, "store/root.bolt", 0), bytes.Repeat([]byte("x"), advertised*1000))
 
 	_, err = DownloadIndexSnapshot(ctx, store, ns, key, filepath.Join(t.TempDir(), "dl"))
 	require.Error(t, err)
@@ -664,6 +664,121 @@ func TestKVRemoteIndexStore_RejectsInvalidNsResource(t *testing.T) {
 	})
 }
 
+func TestKVRemoteIndexStore_New_RejectsInvalidChunkSize(t *testing.T) {
+	store := newTestBadgerKV(t)
+	mgr := newTestLeaseManager(t, store, "owner")
+
+	// Below minimum.
+	_, err := NewKVRemoteIndexStore(KVRemoteIndexStoreConfig{KV: store, LeaseManager: mgr, ChunkSize: 100})
+	require.ErrorContains(t, err, "chunk size")
+
+	// Above maximum.
+	_, err = NewKVRemoteIndexStore(KVRemoteIndexStoreConfig{KV: store, LeaseManager: mgr, ChunkSize: 2 * maxKVChunkSize})
+	require.ErrorContains(t, err, "chunk size")
+
+	// Zero is the documented "use defaults" sentinel.
+	s, err := NewKVRemoteIndexStore(KVRemoteIndexStoreConfig{KV: store, LeaseManager: mgr})
+	require.NoError(t, err)
+	require.Equal(t, defaultKVChunkSize, s.chunkSize)
+}
+
+func TestKVRemoteIndexStore_ChunkedRoundTrip(t *testing.T) {
+	// Round-trips files spanning several chunk-count regimes through the
+	// public Write/Read API and verifies byte-for-byte identity. The small
+	// configured chunk size keeps total bytes per case modest while still
+	// exercising multi-chunk reassembly.
+	const chunkSize int64 = 4096
+	ns := newTestNsResource()
+	ctx := t.Context()
+
+	cases := []struct {
+		name string
+		size int64
+	}{
+		{"smaller than one chunk", 100},
+		{"exactly one chunk", chunkSize},
+		{"one chunk plus a byte", chunkSize + 1},
+		{"exactly two chunks", 2 * chunkSize},
+		{"many chunks with partial last", 7*chunkSize + 123},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			store := newChunkSizedTestStore(t, chunkSize)
+			key := ulid.Make()
+			src, want := newTempFileWithContent(t, tc.size)
+
+			require.NoError(t, store.WriteSnapshotFile(ctx, ns, key, "store/seg.zap", src))
+
+			dst := newTempOSFile(t)
+			require.NoError(t, store.ReadSnapshotFile(ctx, ns, key, "store/seg.zap", dst, tc.size))
+			require.Equal(t, want, readAllFromFile(t, dst))
+		})
+	}
+}
+
+func TestKVRemoteIndexStore_ChunkSizeIndependence(t *testing.T) {
+	// A file written with one ChunkSize must round-trip through a reader
+	// configured with a different ChunkSize. The reader recovers the
+	// writer's chunk size from chunk 0's actual length.
+	ns := newTestNsResource()
+	ctx := t.Context()
+	key := ulid.Make()
+	const size int64 = 9000 // 3 chunks at 4 KiB, 2 chunks at 8 KiB
+
+	backingKV := newTestBadgerKV(t)
+	writer := newChunkSizedTestStoreOn(t, backingKV, 4096)
+	reader := newChunkSizedTestStoreOn(t, backingKV, 8192)
+
+	src, want := newTempFileWithContent(t, size)
+	require.NoError(t, writer.WriteSnapshotFile(ctx, ns, key, "f", src))
+
+	dst := newTempOSFile(t)
+	require.NoError(t, reader.ReadSnapshotFile(ctx, ns, key, "f", dst, size))
+	require.Equal(t, want, readAllFromFile(t, dst))
+}
+
+func TestKVRemoteIndexStore_ChunkedWrite_KeyLayout(t *testing.T) {
+	// Pins the on-disk key shape so layout regressions are caught here
+	// rather than indirectly through DownloadIndexSnapshot.
+	const chunkSize int64 = 1024
+	store := newChunkSizedTestStore(t, chunkSize)
+	ns := newTestNsResource()
+	key := ulid.Make()
+	ctx := t.Context()
+
+	src, _ := newTempFileWithContent(t, 2*chunkSize+10)
+	require.NoError(t, store.WriteSnapshotFile(ctx, ns, key, "store/seg.zap", src))
+
+	got := collectDataKeys(t, store, ns, key)
+	want := []string{
+		store.dataChunkKey(ns, key, "store/seg.zap", 0),
+		store.dataChunkKey(ns, key, "store/seg.zap", 1),
+		store.dataChunkKey(ns, key, "store/seg.zap", 2),
+	}
+	require.ElementsMatch(t, want, got)
+}
+
+func TestKVRemoteIndexStore_ReadSnapshotFile_MissingChunk(t *testing.T) {
+	// If chunk 0 is present but a subsequent chunk is missing, the read
+	// must fail rather than silently truncate.
+	const chunkSize int64 = 1024
+	store := newChunkSizedTestStore(t, chunkSize)
+	ns := newTestNsResource()
+	key := ulid.Make()
+	ctx := t.Context()
+
+	src, _ := newTempFileWithContent(t, 3*chunkSize)
+	require.NoError(t, store.WriteSnapshotFile(ctx, ns, key, "f", src))
+
+	// Drop chunk 1 to simulate a partial upload that was somehow not
+	// caught by the upload-side error handling.
+	require.NoError(t, store.store.Delete(ctx, IndexSnapshotDataSection, store.dataChunkKey(ns, key, "f", 1)))
+
+	err := store.ReadSnapshotFile(ctx, ns, key, "f", newTempOSFile(t), 3*chunkSize)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "chunk 1")
+}
+
 func TestIsRetryableSnapshotStoreError_KVErrRetryable(t *testing.T) {
 	// kv.ErrRetryable wraps a backend's transient error. Confirm
 	// isRetryableSnapshotStoreError treats both the sentinel itself and an
@@ -682,6 +797,49 @@ func TestIsRetryableSnapshotStoreError_KVErrRetryable(t *testing.T) {
 	cancelled, cancel := context.WithCancel(ctx)
 	cancel()
 	assert.False(t, isRetryableSnapshotStoreError(cancelled, kv.ErrRetryable))
+}
+
+// newChunkSizedTestStore builds a KVRemoteIndexStore on a fresh badger KV
+// and forces a small chunk size so chunking tests stay fast. The chunk
+// size is set directly on the internal field so we don't have to lower
+// the production-facing minimum (minKVChunkSize) just to accommodate
+// test fixtures.
+func newChunkSizedTestStore(t *testing.T, chunkSize int64) *KVRemoteIndexStore {
+	t.Helper()
+	return newChunkSizedTestStoreOn(t, newTestBadgerKV(t), chunkSize)
+}
+
+func newChunkSizedTestStoreOn(t *testing.T, store kv.KV, chunkSize int64) *KVRemoteIndexStore {
+	t.Helper()
+	s := newTestKVRemoteIndexStoreOn(t, store, "test-owner")
+	s.chunkSize = chunkSize
+	return s
+}
+
+// newTempFileWithContent writes size bytes of a deterministic pattern to a
+// fresh temp file and returns both the open file (positioned at 0) and the
+// bytes it contains, so callers can use the file as a snapshot source and
+// compare the round-tripped output against the original bytes.
+func newTempFileWithContent(t *testing.T, size int64) (*os.File, []byte) {
+	t.Helper()
+	buf := make([]byte, size)
+	for i := range buf {
+		buf[i] = byte(i)
+	}
+	path := filepath.Join(t.TempDir(), "src")
+	require.NoError(t, os.WriteFile(path, buf, 0o600))
+	f, err := os.Open(path)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = f.Close() })
+	return f, buf
+}
+
+// readAllFromFile reads the entire content of f from offset 0.
+func readAllFromFile(t *testing.T, f *os.File) []byte {
+	t.Helper()
+	b, err := os.ReadFile(f.Name())
+	require.NoError(t, err)
+	return b
 }
 
 // --- helpers ---
@@ -718,7 +876,7 @@ var orphanedSnapshotFiles = []string{"store/root.bolt", "store/00000001.zap"}
 func seedIncompleteSnapshot(t *testing.T, s *KVRemoteIndexStore, ns resource.NamespacedResource, key ulid.ULID) []string {
 	t.Helper()
 	for _, rel := range orphanedSnapshotFiles {
-		writeKVValue(t, s.store, IndexSnapshotDataSection, s.dataKey(ns, key, rel), []byte("orphaned"))
+		writeKVValue(t, s.store, IndexSnapshotDataSection, s.dataChunkKey(ns, key, rel, 0), []byte("orphaned"))
 	}
 	return orphanedSnapshotFiles
 }

--- a/pkg/storage/unified/search/kv_remote_index_store_test.go
+++ b/pkg/storage/unified/search/kv_remote_index_store_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -819,25 +820,36 @@ func newChunkSizedTestStoreOn(t *testing.T, store kv.KV, chunkSize int64) *KVRem
 // newTempFileWithContent writes size bytes of a deterministic pattern to a
 // fresh temp file and returns both the open file (positioned at 0) and the
 // bytes it contains, so callers can use the file as a snapshot source and
-// compare the round-tripped output against the original bytes.
+// compare the round-tripped output against the original bytes. File ops go
+// through an os.Root so gosec recognises them as path-traversal-safe.
 func newTempFileWithContent(t *testing.T, size int64) (*os.File, []byte) {
 	t.Helper()
 	buf := make([]byte, size)
 	for i := range buf {
 		buf[i] = byte(i)
 	}
-	path := filepath.Join(t.TempDir(), "src")
-	require.NoError(t, os.WriteFile(path, buf, 0o600))
-	f, err := os.Open(path)
+	root, err := os.OpenRoot(t.TempDir())
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = root.Close() })
+
+	f, err := root.Create("src")
 	require.NoError(t, err)
 	t.Cleanup(func() { _ = f.Close() })
+	_, err = f.Write(buf)
+	require.NoError(t, err)
+	_, err = f.Seek(0, io.SeekStart)
+	require.NoError(t, err)
 	return f, buf
 }
 
-// readAllFromFile reads the entire content of f from offset 0.
+// readAllFromFile reads the entire content of f. Uses Seek + io.ReadAll on
+// the already-open handle so we don't hand a variable path to os.ReadFile
+// (gosec G304).
 func readAllFromFile(t *testing.T, f *os.File) []byte {
 	t.Helper()
-	b, err := os.ReadFile(f.Name())
+	_, err := f.Seek(0, io.SeekStart)
+	require.NoError(t, err)
+	b, err := io.ReadAll(f)
 	require.NoError(t, err)
 	return b
 }


### PR DESCRIPTION
Makes `KVRemoteIndexStore` round-trip snapshot files larger than the KV backend's per-value limit.

## What changes

Each snapshot file is now split into one or more fixed-size chunks, each stored as its own KV value. The key for chunk N of a file is `<existing-data-prefix>/<relPath>/<NNNNN>` (six-digit zero-padded index). Even small files get one chunk at index `000000`, so the read and write paths don't need a separate non-chunked code path.

`KVRemoteIndexStoreConfig` gains a `ChunkSize` field. Zero falls back to a 10 MiB default; values are validated to a 1 MiB..1 GiB range as a sanity guard.

## Reader is self-describing

Readers don't need to know the writer's `ChunkSize`. The reader fetches chunk 0 capped at `expectedSize+1`; if it covers the file, we're done. Otherwise chunk 0's actual size is the writer's chunk size and the reader fetches chunks 1..N-1 from there. This means `ChunkSize` can change between deployments without breaking previously-written snapshots.

## What's not changing

- Manifest layout (one KV value per snapshot, written last as the completion signal).
- Listing / cleanup paths (prefix scans already catch chunked keys naturally).
- Empty files remain unsupported — KV backends reject zero-byte values — but Bleve snapshot files are always non-empty.

## Out of scope

Parallel chunk I/O for upload/download throughput. Kept serial here to keep the diff small; can be added later as a contained change.
