### PR TITLE
alerting: fix PostgreSQL column migration condition check and expand syntax error

### DIFF
--- a/pkg/services/sqlstore/migrations/ualert/rule_creator_mig.go
+++ b/pkg/services/sqlstore/migrations/ualert/rule_creator_mig.go
@@ -21,12 +21,12 @@ func AddAlertRuleUpdatedByMigration(mg *migrator.Migrator) {
 
 func ExpandAlertRuleUpdatedByMigration(mg *migrator.Migrator) {
 	mg.AddMigration("expand created_by in alert_rule_version table", migrator.NewRawSQLMigration("").
-		SQLite("SELECT 1;"). // do nothing for sqlite because it's a TEXT column
-		Postgres("ALTER TABLE `alert_rule_version` ALTER COLUMN created_by TYPE VARCHAR(190);").
+		SQLite("SELECT 1;").
+		Postgres(`ALTER TABLE "alert_rule_version" ALTER COLUMN created_by TYPE VARCHAR(190);`).
 		Mysql("ALTER TABLE `alert_rule_version` MODIFY created_by VARCHAR(190);"))
 
 	mg.AddMigration("expand updated_by in alert_rule table", migrator.NewRawSQLMigration("").
-		SQLite("SELECT 1;"). // do nothing for sqlite because it's a TEXT column
-		Postgres("ALTER TABLE `alert_rule` ALTER COLUMN updated_by TYPE VARCHAR(190);").
+		SQLite("SELECT 1;").
+		Postgres(`ALTER TABLE "alert_rule" ALTER COLUMN updated_by TYPE VARCHAR(190);`).
 		Mysql("ALTER TABLE `alert_rule` MODIFY updated_by VARCHAR(190);"))
 }

--- a/pkg/services/sqlstore/migrator/dialect_test.go
+++ b/pkg/services/sqlstore/migrator/dialect_test.go
@@ -60,6 +60,31 @@ func TestInsertQuery(t *testing.T) {
 	}
 }
 
+func TestColumnCheckSQL(t *testing.T) {
+	table, col := "alert_rule", "guid"
+
+	t.Run("postgres returns information_schema query scoped to current schema", func(t *testing.T) {
+		db := NewPostgresDialect()
+		sql, args := db.ColumnCheckSQL(table, col)
+		require.Equal(t, "SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name=? AND column_name=?", sql)
+		require.Equal(t, []any{table, col}, args)
+	})
+
+	t.Run("mysql returns INFORMATION_SCHEMA query scoped to DATABASE()", func(t *testing.T) {
+		db := NewMysqlDialect()
+		sql, args := db.ColumnCheckSQL(table, col)
+		require.NotEmpty(t, sql)
+		require.Equal(t, []any{table, col}, args)
+	})
+
+	t.Run("sqlite returns pragma_table_info query", func(t *testing.T) {
+		db := NewSQLite3Dialect()
+		sql, args := db.ColumnCheckSQL(table, col)
+		require.NotEmpty(t, sql)
+		require.Equal(t, []any{col}, args)
+	})
+}
+
 func TestUpdateQuery(t *testing.T) {
 	tests := []struct {
 		name                  string

--- a/pkg/services/sqlstore/migrator/postgres_dialect.go
+++ b/pkg/services/sqlstore/migrator/postgres_dialect.go
@@ -108,6 +108,12 @@ func (db *PostgresDialect) SQLType(c *Column) string {
 	return res
 }
 
+func (db *PostgresDialect) ColumnCheckSQL(tableName, columnName string) (string, []any) {
+	args := []any{tableName, columnName}
+	sql := "SELECT 1 FROM information_schema.columns WHERE table_schema = current_schema() AND table_name=? AND column_name=?"
+	return sql, args
+}
+
 func (db *PostgresDialect) IndexCheckSQL(tableName, indexName string) (string, []any) {
 	args := []any{tableName, indexName}
 	sql := "SELECT 1 FROM " + db.Quote("pg_indexes") + " WHERE" + db.Quote("tablename") + "=? AND " + db.Quote("indexname") + "=?"


### PR DESCRIPTION
Fixes #125731

## Problem

Two bugs affect alerting DB migrations on PostgreSQL when upgrading Grafana (reported: v11.2.0 to v12.4.3).

**1. Missing `ColumnCheckSQL` in `PostgresDialect`**

`BaseDialect.ColumnCheckSQL` returns `("", nil)`. The PostgreSQL dialect did not override it. When the migration runner sees an empty condition SQL, it skips the condition check entirely. This means `IfColumnNotExistsCondition` is silently ignored on PostgreSQL.

The consequence: if a column migration is retried (e.g. after a failed subsequent migration rolled back the log entry), the `ALTER TABLE ... ADD COLUMN` runs again on a column that already exists. PostgreSQL returns `column "X" of relation "Y" already exists`, the migration fails, and Grafana cannot start.

**2. Backtick identifiers in `ExpandAlertRuleUpdatedByMigration` Postgres SQL**

```go
Postgres("ALTER TABLE `alert_rule_version` ALTER COLUMN created_by TYPE VARCHAR(190);")
Postgres("ALTER TABLE `alert_rule` ALTER COLUMN updated_by TYPE VARCHAR(190);")
```

Backtick-quoted identifiers are MySQL syntax. PostgreSQL rejects them with a syntax error. This migration fails on every startup attempt, preventing Grafana from starting after the alerting column migrations run.

## Fix

- Add `ColumnCheckSQL` to `PostgresDialect` using `information_schema.columns` scoped to `current_schema()`, matching the pattern used by MySQL and SQLite dialects.
- Replace backtick identifiers with double-quoted identifiers in the Postgres `ALTER COLUMN` statements.

## Tests

Added unit tests in `dialect_test.go` covering `ColumnCheckSQL` output for all three dialects.