### PR TITLE
Docs: Document the folderless Git Sync target

### DIFF
--- a/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-code.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/git-sync-setup/set-up-code.md
@@ -158,7 +158,7 @@ Replace the placeholders with your values:
 
 {{< admonition type="note" >}}
 
-Only `target: folder` is currently supported for Git Sync.
+Git Sync supports two sync targets: `target: folder` (the default) creates a folder named after the repository and places synced resources inside it, while `target: folderless` places synced resources at the top level without creating a wrapper folder. Refer to [Sync targets](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/as-code/observability-as-code/git-sync/key-concepts/#sync-targets) for details.
 
 {{< /admonition >}}
 
@@ -177,7 +177,7 @@ The following configuration parameters are available:
 | `spec.github.generateDashboardPreviews` | Generate preview images (true/false)                        |
 | `spec.sync.enabled`                     | Enable synchronization (true/false)                         |
 | `spec.sync.intervalSeconds`             | Sync interval in seconds                                    |
-| `spec.sync.target`                      | Where to place synced dashboards (`folder`)                 |
+| `spec.sync.target`                      | Where to place synced dashboards (`folder` or `folderless`) |
 | `spec.workflows`                        | Enabled workflows: `write` (direct commits), `branch` (PRs) |
 | `secure.token.create`                   | GitHub Personal Access Token                                |
 

--- a/docs/sources/as-code/observability-as-code/git-sync/key-concepts.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/key-concepts.md
@@ -113,6 +113,8 @@ With Git Sync you can place synced resources in Grafana in two ways:
 - **Folder sync**: Grafana creates a folder named after the repository and places all synced resources inside it. Subdirectories in the repository become subfolders within that folder. **This is the default behavior**.
 - **Folderless sync**: Grafana places synced resources at the top level, without creating a wrapper folder. Files at the repository path root become top-level resources, and subdirectories become top-level folders.
 
+Use folder sync to keep each repository's resources grouped together under a dedicated folder. Use folderless sync when you want provisioned resources to appear at the top of your Dashboards view instead of nested inside a repository folder.
+
 Both modes can coexist with each other and with resources that aren't managed by Git Sync.
 
 The following examples use the same repository to show how the same files appear with each mode.
@@ -171,8 +173,6 @@ Dashboards
 │   └── Monthly Invoices
 └── Ad-hoc dashboard           ← not managed by Git Sync
 ```
-
-Use folderless sync when you want provisioned resources to appear at the top of your Dashboards view instead of nested inside a repository folder, while still keeping other repositories and manually created resources untouched.
 
 ### Git Sync states
 

--- a/docs/sources/as-code/observability-as-code/git-sync/key-concepts.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/key-concepts.md
@@ -110,8 +110,42 @@ You can find the provisioned dashboards organized in folders under **Dashboards*
 
 The `spec.sync.target` field controls where Git Sync places synced resources in Grafana:
 
-- **`folder`**: Grafana creates a folder named after the repository and places all synced resources inside it. Subdirectories in the repository become subfolders within that folder. Multiple `folder` repositories can coexist with each other and with resources that aren't managed by Git Sync. This is the default behavior described above.
-- **`folderless`**: Grafana places synced resources at the top level, without creating a wrapper folder. Files at the repository path root become top-level resources, and subdirectories become top-level folders. Like `folder`, multiple `folderless` repositories can coexist with each other, with `folder` repositories, and with unprovisioned resources. Because there's no wrapper folder, Git Sync tracks which resources each repository manages individually, so a sync only affects the resources that repository owns.
+- **`folder`**: Grafana creates a folder named after the repository and places all synced resources inside it. Subdirectories in the repository become subfolders within that folder. This is the default behavior described above.
+- **`folderless`**: Grafana places synced resources at the top level, without creating a wrapper folder. Files at the repository path root become top-level resources, and subdirectories become top-level folders.
+
+Both modes can coexist with each other and with resources that aren't managed by Git Sync.
+
+The following examples use the same repository to show how the same files appear with each target.
+
+**In Git (path `grafana/`):**
+
+```
+your-org/grafana-manifests/
+└── grafana/
+    ├── cpu-metrics.json
+    └── team-platform/
+        ├── .folder.json
+        └── memory-usage.json
+```
+
+**With `target: folder`**, a repository folder wraps everything:
+
+```
+Dashboards
+└── 📁 grafana-manifests/
+    ├── CPU Metrics Dashboard
+    └── 📁 team-platform/
+        └── Memory Usage Dashboard
+```
+
+**With `target: folderless`**, the same files map to the top level:
+
+```
+Dashboards
+├── CPU Metrics Dashboard
+└── 📁 team-platform/
+    └── Memory Usage Dashboard
+```
 
 Use `folderless` when you want provisioned resources to appear at the top of your Dashboards view instead of nested inside a repository folder, while still keeping other repositories and manually created resources untouched.
 

--- a/docs/sources/as-code/observability-as-code/git-sync/key-concepts.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/key-concepts.md
@@ -108,16 +108,16 @@ You can find the provisioned dashboards organized in folders under **Dashboards*
 
 ### Sync targets
 
-The `spec.sync.target` field controls where Git Sync places synced resources in Grafana:
+Git Sync can place synced resources in Grafana in two ways:
 
-- **`folder`**: Grafana creates a folder named after the repository and places all synced resources inside it. Subdirectories in the repository become subfolders within that folder. This is the default behavior described above.
-- **`folderless`**: Grafana places synced resources at the top level, without creating a wrapper folder. Files at the repository path root become top-level resources, and subdirectories become top-level folders.
+- **Folder sync**: Grafana creates a folder named after the repository and places all synced resources inside it. Subdirectories in the repository become subfolders within that folder. This is the default behavior described above.
+- **Folderless sync**: Grafana places synced resources at the top level, without creating a wrapper folder. Files at the repository path root become top-level resources, and subdirectories become top-level folders.
 
 Both modes can coexist with each other and with resources that aren't managed by Git Sync.
 
-The following examples use the same repository to show how the same files appear with each target.
+The following examples use the same repository to show how the same files appear with each mode.
 
-**In Git (path `grafana/`):**
+The repository `grafana-manifests` syncs from the path `grafana/`:
 
 ```
 your-org/grafana-manifests/
@@ -128,26 +128,51 @@ your-org/grafana-manifests/
         └── memory-usage.json
 ```
 
-**With `target: folder`**, a repository folder wraps everything:
+The instance also has content that isn't managed by Git Sync: a manually created **Ops** folder and an **Ad-hoc dashboard**.
+
+**With folder sync**, a repository folder wraps the synced resources, alongside the unprovisioned content:
 
 ```
 Dashboards
-└── 📁 grafana-manifests/
-    ├── CPU Metrics Dashboard
-    └── 📁 team-platform/
-        └── Memory Usage Dashboard
+├── 📁 grafana-manifests/      ← managed by Git Sync
+│   ├── CPU Metrics Dashboard
+│   └── 📁 team-platform/
+│       └── Memory Usage Dashboard
+├── 📁 Ops/                    ← not managed by Git Sync
+│   └── Ops dashboard
+└── Ad-hoc dashboard           ← not managed by Git Sync
 ```
 
-**With `target: folderless`**, the same files map to the top level:
+**With folderless sync**, the same files map to the top level, next to the unprovisioned content:
 
 ```
 Dashboards
-├── CPU Metrics Dashboard
-└── 📁 team-platform/
-    └── Memory Usage Dashboard
+├── CPU Metrics Dashboard      ← managed by Git Sync
+├── 📁 team-platform/          ← managed by Git Sync
+│   └── Memory Usage Dashboard
+├── 📁 Ops/                    ← not managed by Git Sync
+│   └── Ops dashboard
+└── Ad-hoc dashboard           ← not managed by Git Sync
 ```
 
-Use `folderless` when you want provisioned resources to appear at the top of your Dashboards view instead of nested inside a repository folder, while still keeping other repositories and manually created resources untouched.
+Folderless sync only manages the resources it provisions. The unprovisioned **Ops** folder and **Ad-hoc dashboard** are left untouched.
+
+#### Multiple folderless repositories
+
+Because folderless sync doesn't create a wrapper folder, several folderless repositories can sync to the top level at the same time. Each repository manages only the resources it provisions:
+
+```
+Dashboards
+├── CPU Metrics Dashboard      ← managed by grafana-manifests
+├── 📁 team-platform/          ← managed by grafana-manifests
+│   └── Memory Usage Dashboard
+├── Billing Overview           ← managed by finance-dashboards
+├── 📁 invoices/               ← managed by finance-dashboards
+│   └── Monthly Invoices
+└── Ad-hoc dashboard           ← not managed by Git Sync
+```
+
+Use folderless sync when you want provisioned resources to appear at the top of your Dashboards view instead of nested inside a repository folder, while still keeping other repositories and manually created resources untouched.
 
 ### Git Sync states
 

--- a/docs/sources/as-code/observability-as-code/git-sync/key-concepts.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/key-concepts.md
@@ -106,6 +106,15 @@ Git Sync is bidirectional, and syncs a repository resource with your Grafana ins
 
 You can find the provisioned dashboards organized in folders under **Dashboards**.
 
+### Sync targets
+
+The `spec.sync.target` field controls where Git Sync places synced resources in Grafana:
+
+- **`folder`**: Grafana creates a folder named after the repository and places all synced resources inside it. Subdirectories in the repository become subfolders within that folder. Multiple `folder` repositories can coexist with each other and with resources that aren't managed by Git Sync. This is the default behavior described above.
+- **`folderless`**: Grafana places synced resources at the top level, without creating a wrapper folder. Files at the repository path root become top-level resources, and subdirectories become top-level folders. Like `folder`, multiple `folderless` repositories can coexist with each other, with `folder` repositories, and with unprovisioned resources. Because there's no wrapper folder, Git Sync tracks which resources each repository manages individually, so a sync only affects the resources that repository owns.
+
+Use `folderless` when you want provisioned resources to appear at the top of your Dashboards view instead of nested inside a repository folder, while still keeping other repositories and manually created resources untouched.
+
 ### Git Sync states
 
 Your Grafana instance can be in one of the following Git Sync states:

--- a/docs/sources/as-code/observability-as-code/git-sync/key-concepts.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/key-concepts.md
@@ -108,7 +108,7 @@ You can find the provisioned dashboards organized in folders under **Dashboards*
 
 ### Sync targets
 
-Git Sync can place synced resources in Grafana in two ways:
+With Git Sync you can place synced resources in Grafana in two ways:
 
 - **Folder sync**: Grafana creates a folder named after the repository and places all synced resources inside it. Subdirectories in the repository become subfolders within that folder. This is the default behavior described above.
 - **Folderless sync**: Grafana places synced resources at the top level, without creating a wrapper folder. Files at the repository path root become top-level resources, and subdirectories become top-level folders.

--- a/docs/sources/as-code/observability-as-code/git-sync/key-concepts.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/key-concepts.md
@@ -110,7 +110,7 @@ You can find the provisioned dashboards organized in folders under **Dashboards*
 
 With Git Sync you can place synced resources in Grafana in two ways:
 
-- **Folder sync**: Grafana creates a folder named after the repository and places all synced resources inside it. Subdirectories in the repository become subfolders within that folder. This is the default behavior described above.
+- **Folder sync**: Grafana creates a folder named after the repository and places all synced resources inside it. Subdirectories in the repository become subfolders within that folder. **This is the default behavior**.
 - **Folderless sync**: Grafana places synced resources at the top level, without creating a wrapper folder. Files at the repository path root become top-level resources, and subdirectories become top-level folders.
 
 Both modes can coexist with each other and with resources that aren't managed by Git Sync.


### PR DESCRIPTION
## What

Documents the new **`folderless`** Git Sync sync target in the user docs:

- **`key-concepts.md`** — new "Sync targets" section explaining `folder` (default, repo-named wrapper folder) vs `folderless` (top-level, no wrapper folder), including coexistence and per-repo ownership.
- **`set-up-code.md`** — updated the note (previously "Only `target: folder` is currently supported") and the `spec.sync.target` config-table row to cover `folderless`.

## Related

User-facing docs for the `folderless` sync target series:
- Type: provisioning `SyncTargetType` enum (#125809)
- Backend behavior + frontend wizard: separate PRs

This PR is independent (off `main`) and should land alongside the feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
