### PR TITLE
Provisioning: Add folderless option to the Git Sync UI

### DIFF
--- a/public/app/features/provisioning/Config/ConfigForm.tsx
+++ b/public/app/features/provisioning/Config/ConfigForm.tsx
@@ -48,7 +48,7 @@ const getTargetOptions = (allowedTargets: string[]) => {
   const allOptions = [
     { value: 'instance', label: t('provisioning.config-form.option-entire-instance', 'Entire instance') },
     { value: 'folder', label: t('provisioning.config-form.option-managed-folder', 'Managed folder') },
-    { value: 'folderless', label: t('provisioning.config-form.option-top-level', 'Top level (no folder)') },
+    { value: 'folderless', label: t('provisioning.config-form.option-folderless', 'Folderless') },
   ];
 
   return allOptions.filter((option) => allowedTargets.includes(option.value));

--- a/public/app/features/provisioning/Config/ConfigForm.tsx
+++ b/public/app/features/provisioning/Config/ConfigForm.tsx
@@ -48,6 +48,7 @@ const getTargetOptions = (allowedTargets: string[]) => {
   const allOptions = [
     { value: 'instance', label: t('provisioning.config-form.option-entire-instance', 'Entire instance') },
     { value: 'folder', label: t('provisioning.config-form.option-managed-folder', 'Managed folder') },
+    { value: 'folderless', label: t('provisioning.config-form.option-top-level', 'Top level (no folder)') },
   ];
 
   return allOptions.filter((option) => allowedTargets.includes(option.value));

--- a/public/app/features/provisioning/Wizard/BootstrapStep.test.tsx
+++ b/public/app/features/provisioning/Wizard/BootstrapStep.test.tsx
@@ -370,6 +370,33 @@ describe('BootstrapStep', () => {
       // Check that the folder option is now selected by looking for the title field
       expect(await screen.findByRole('textbox', { name: /display name/i })).toBeInTheDocument();
     });
+
+    it('should display the folderless option when it is enabled', async () => {
+      mockUseModeOptions.mockReturnValue({
+        enabledOptions: [
+          {
+            target: 'folderless',
+            label: 'Sync to top level (no folder)',
+            description: 'Resources are provisioned at the top level without a wrapper folder',
+            subtitle: 'Use this option to sync external resources to the top level',
+            disabled: false,
+          },
+        ],
+        disabledOptions: [],
+      });
+
+      setup({
+        settingsData: {
+          allowedTargets: ['folder', 'folderless'],
+          allowImageRendering: true,
+          items: [],
+          availableRepositoryTypes: [],
+          maxRepositories: 10,
+        },
+      });
+
+      expect(await screen.findByText('Sync to top level (no folder)')).toBeInTheDocument();
+    });
   });
 
   describe('title field visibility', () => {
@@ -378,6 +405,37 @@ describe('BootstrapStep', () => {
 
       // Default is folder, so title field should be visible
       expect(await screen.findByRole('textbox', { name: /display name/i })).toBeInTheDocument();
+    });
+
+    it('should not show title field for folderless sync target', async () => {
+      // Folderless has no wrapper folder, so the display-name field must not appear.
+      mockUseModeOptions.mockReturnValue({
+        enabledOptions: [
+          {
+            target: 'folderless',
+            label: 'Sync to top level (no folder)',
+            description: 'Resources are provisioned at the top level without a wrapper folder',
+            subtitle: 'Use this option to sync external resources to the top level',
+            disabled: false,
+          },
+        ],
+        disabledOptions: [],
+      });
+
+      const { user } = setup({
+        settingsData: {
+          allowedTargets: ['folder', 'folderless'],
+          allowImageRendering: true,
+          items: [],
+          availableRepositoryTypes: [],
+          maxRepositories: 10,
+        },
+      });
+
+      const folderlessOption = await screen.findByText('Sync to top level (no folder)');
+      await user.click(folderlessOption);
+
+      expect(screen.queryByRole('textbox', { name: /display name/i })).not.toBeInTheDocument();
     });
   });
 

--- a/public/app/features/provisioning/Wizard/BootstrapStep.test.tsx
+++ b/public/app/features/provisioning/Wizard/BootstrapStep.test.tsx
@@ -376,7 +376,7 @@ describe('BootstrapStep', () => {
         enabledOptions: [
           {
             target: 'folderless',
-            label: 'Sync to top level (no folder)',
+            label: 'Sync external storage directly at root level without a containing folder',
             description: 'Resources are provisioned at the top level without a wrapper folder',
             subtitle: 'Use this option to sync external resources to the top level',
             disabled: false,
@@ -395,7 +395,9 @@ describe('BootstrapStep', () => {
         },
       });
 
-      expect(await screen.findByText('Sync to top level (no folder)')).toBeInTheDocument();
+      expect(
+        await screen.findByText('Sync external storage directly at root level without a containing folder')
+      ).toBeInTheDocument();
     });
   });
 
@@ -413,7 +415,7 @@ describe('BootstrapStep', () => {
         enabledOptions: [
           {
             target: 'folderless',
-            label: 'Sync to top level (no folder)',
+            label: 'Sync external storage directly at root level without a containing folder',
             description: 'Resources are provisioned at the top level without a wrapper folder',
             subtitle: 'Use this option to sync external resources to the top level',
             disabled: false,
@@ -432,7 +434,9 @@ describe('BootstrapStep', () => {
         },
       });
 
-      const folderlessOption = await screen.findByText('Sync to top level (no folder)');
+      const folderlessOption = await screen.findByText(
+        'Sync external storage directly at root level without a containing folder'
+      );
       await user.click(folderlessOption);
 
       expect(screen.queryByRole('textbox', { name: /display name/i })).not.toBeInTheDocument();

--- a/public/app/features/provisioning/Wizard/BootstrapStepCardIcons.tsx
+++ b/public/app/features/provisioning/Wizard/BootstrapStepCardIcons.tsx
@@ -25,5 +25,15 @@ export function BootstrapStepCardIcons({ target, repoType }: { target: Target; r
     );
   }
 
+  if (target === 'folderless') {
+    return (
+      <Stack>
+        <Icon name="apps" size="xxl" />
+        <Icon name="arrow-left" size="xxl" />
+        <RepoIcon type={repoType} />
+      </Stack>
+    );
+  }
+
   return null;
 }

--- a/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
+++ b/public/app/features/provisioning/Wizard/SynchronizeStep.tsx
@@ -182,7 +182,7 @@ export const SynchronizeStep = memo(function SynchronizeStep({
                   </Trans>
                 </li>
               )}
-              {syncTarget === 'folder' && (
+              {(syncTarget === 'folder' || syncTarget === 'folderless') && (
                 <>
                   <li>
                     <Trans i18nKey="provisioning.wizard.alert-point-folder-structure">

--- a/public/app/features/provisioning/Wizard/hooks/useModeOptions.test.ts
+++ b/public/app/features/provisioning/Wizard/hooks/useModeOptions.test.ts
@@ -1,0 +1,46 @@
+import { renderHook } from '@testing-library/react';
+
+import { type RepositoryViewList } from 'app/api/clients/provisioning/v0alpha1';
+
+import { useModeOptions } from './useModeOptions';
+
+const settings = (overrides: Partial<RepositoryViewList> = {}): RepositoryViewList => ({
+  kind: 'RepositoryViewList',
+  apiVersion: 'provisioning.grafana.app/v0alpha1',
+  items: [],
+  allowedTargets: ['instance', 'folder', 'folderless'],
+  allowImageRendering: false,
+  maxRepositories: 0,
+  ...overrides,
+});
+
+const targetsOf = (options: Array<{ target: string }>) => options.map((o) => o.target);
+
+describe('useModeOptions', () => {
+  it('includes folderless as an enabled option when it is an allowed target', () => {
+    const { result } = renderHook(() => useModeOptions('repo-a', settings()));
+
+    expect(targetsOf(result.current.enabledOptions)).toContain('folderless');
+    expect(targetsOf(result.current.disabledOptions)).not.toContain('folderless');
+  });
+
+  it('disables folderless when it is not an allowed target', () => {
+    const { result } = renderHook(() => useModeOptions('repo-a', settings({ allowedTargets: ['folder'] })));
+
+    expect(targetsOf(result.current.enabledOptions)).not.toContain('folderless');
+    expect(targetsOf(result.current.disabledOptions)).toContain('folderless');
+  });
+
+  it('keeps folderless enabled even when another folder is already connected', () => {
+    // A connected folder repository only disables the exclusive `instance` target,
+    // not `folderless`, which is allowed to coexist.
+    const list = settings({
+      items: [{ name: 'other-repo', target: 'folder', title: 'Other', type: 'github', workflows: [] }],
+    });
+
+    const { result } = renderHook(() => useModeOptions('repo-a', list));
+
+    expect(targetsOf(result.current.enabledOptions)).toContain('folderless');
+    expect(targetsOf(result.current.disabledOptions)).toContain('instance');
+  });
+});

--- a/public/app/features/provisioning/Wizard/hooks/useModeOptions.ts
+++ b/public/app/features/provisioning/Wizard/hooks/useModeOptions.ts
@@ -52,7 +52,7 @@ function resolveDisabledReason(option: ModeOption, context: DisableContext) {
     );
   }
 
-  if (option.target !== 'instance' && option.target !== 'folder' && option.target !== 'folderless') {
+  if (['instance', 'folder', 'folderless].includes(option.target)) {
     return t('provisioning.mode-options.disabled.not-supported', 'This option is not supported yet.');
   }
 

--- a/public/app/features/provisioning/Wizard/hooks/useModeOptions.ts
+++ b/public/app/features/provisioning/Wizard/hooks/useModeOptions.ts
@@ -52,7 +52,7 @@ function resolveDisabledReason(option: ModeOption, context: DisableContext) {
     );
   }
 
-  if (option.target !== 'instance' && option.target !== 'folder') {
+  if (option.target !== 'instance' && option.target !== 'folder' && option.target !== 'folderless') {
     return t('provisioning.mode-options.disabled.not-supported', 'This option is not supported yet.');
   }
 
@@ -89,6 +89,19 @@ export function useModeOptions(repoName: string, settings?: RepositoryViewList) 
         subtitle: t(
           'provisioning.mode-options.folder.subtitle',
           'Use this option to sync external resources into a new folder without affecting the rest of your instance.'
+        ),
+        disabled: false,
+      },
+      {
+        target: 'folderless',
+        label: t('provisioning.mode-options.folderless.label', 'Sync to top level (no folder)'),
+        description: t(
+          'provisioning.mode-options.folderless.description',
+          'After setup, resources from external storage are provisioned at the top level without creating a wrapper folder. Subdirectories in external storage become top-level folders. Other repositories and resources that are not managed by this repository are left untouched.'
+        ),
+        subtitle: t(
+          'provisioning.mode-options.folderless.subtitle',
+          'Use this option to sync external resources to the top level, with no wrapper folder, while still supporting subfolders and coexisting with other content.'
         ),
         disabled: false,
       },

--- a/public/app/features/provisioning/Wizard/hooks/useModeOptions.ts
+++ b/public/app/features/provisioning/Wizard/hooks/useModeOptions.ts
@@ -94,7 +94,10 @@ export function useModeOptions(repoName: string, settings?: RepositoryViewList) 
       },
       {
         target: 'folderless',
-        label: t('provisioning.mode-options.folderless.label', 'Sync to top level (no folder)'),
+        label: t(
+          'provisioning.mode-options.folderless.label',
+          'Sync external storage directly at root level without a containing folder'
+        ),
         description: t(
           'provisioning.mode-options.folderless.description',
           'After setup, resources from external storage are provisioned at the top level without creating a wrapper folder. Subdirectories in external storage become top-level folders. Other repositories and resources that are not managed by this repository are left untouched.'

--- a/public/app/features/provisioning/Wizard/hooks/useModeOptions.ts
+++ b/public/app/features/provisioning/Wizard/hooks/useModeOptions.ts
@@ -52,7 +52,7 @@ function resolveDisabledReason(option: ModeOption, context: DisableContext) {
     );
   }
 
-  if (['instance', 'folder', 'folderless].includes(option.target)) {
+  if (!['instance', 'folder', 'folderless'].includes(option.target)) {
     return t('provisioning.mode-options.disabled.not-supported', 'This option is not supported yet.');
   }
 

--- a/public/app/features/provisioning/Wizard/hooks/useResourceStats.ts
+++ b/public/app/features/provisioning/Wizard/hooks/useResourceStats.ts
@@ -162,9 +162,10 @@ export function useResourceStats(
 
   // Calculate requiresMigration based on sync target and user selection
   // For instance sync: migrate if there are resources (checkbox is disabled and always true)
-  // For folder sync: only migrate if user explicitly opts in via checkbox
+  // For folder and folderless sync: only migrate if user explicitly opts in via checkbox
   const requiresMigration = syncTarget === 'instance' ? resourceCount > 0 : (migrateResources ?? false);
-  const shouldSkipSync = (resourceCount === 0 || syncTarget === 'folder') && fileCount === 0;
+  const shouldSkipSync =
+    (resourceCount === 0 || syncTarget === 'folder' || syncTarget === 'folderless') && fileCount === 0;
 
   // Format display strings
   const resourceCountDisplay =

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13325,6 +13325,7 @@
       "label-title": "Title",
       "option-entire-instance": "Entire instance",
       "option-managed-folder": "Managed folder",
+      "option-top-level": "Top level (no folder)",
       "placeholder-commit-message-template": "feat(dashboards): {{actionVar}} {{titleVar}}",
       "placeholder-interval-seconds": "60",
       "placeholder-my-config": "My config"
@@ -13690,6 +13691,11 @@
         "description": "After setup, a new Grafana folder will be created and synced with external storage. If any resources are present in external storage, they will be provisioned to this new folder. All new resources created in this folder will be stored and versioned in external storage.",
         "label": "Sync external storage to a new Grafana folder",
         "subtitle": "Use this option to sync external resources into a new folder without affecting the rest of your instance."
+      },
+      "folderless": {
+        "description": "After setup, resources from external storage are provisioned at the top level without creating a wrapper folder. Subdirectories in external storage become top-level folders. Other repositories and resources that are not managed by this repository are left untouched.",
+        "label": "Sync to top level (no folder)",
+        "subtitle": "Use this option to sync external resources to the top level, with no wrapper folder, while still supporting subfolders and coexisting with other content."
       },
       "instance": {
         "description": "Resources will be synced with external storage and provisioned into this instance. Existing Grafana resources will be migrated and merged if needed. After setup, all new resources and changes will be saved to external storage and automatically provisioned back into the instance.",

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -13324,8 +13324,8 @@
       "label-target": "Target",
       "label-title": "Title",
       "option-entire-instance": "Entire instance",
+      "option-folderless": "Folderless",
       "option-managed-folder": "Managed folder",
-      "option-top-level": "Top level (no folder)",
       "placeholder-commit-message-template": "feat(dashboards): {{actionVar}} {{titleVar}}",
       "placeholder-interval-seconds": "60",
       "placeholder-my-config": "My config"
@@ -13694,7 +13694,7 @@
       },
       "folderless": {
         "description": "After setup, resources from external storage are provisioned at the top level without creating a wrapper folder. Subdirectories in external storage become top-level folders. Other repositories and resources that are not managed by this repository are left untouched.",
-        "label": "Sync to top level (no folder)",
+        "label": "Sync external storage directly at root level without a containing folder",
         "subtitle": "Use this option to sync external resources to the top level, with no wrapper folder, while still supporting subfolders and coexisting with other content."
       },
       "instance": {


### PR DESCRIPTION
## What

Surfaces the new **`folderless`** sync target in the provisioning frontend (stacked on the type PR).

- **Setup wizard** (`useModeOptions.ts`): new "Sync to top level (no folder)" mode option, enabled when `folderless` is an allowed target; fixed the catch-all that previously marked any non-folder/instance target as "not supported yet".
- **Bootstrap card icon** (`BootstrapStepCardIcons.tsx`): icon for the folderless option.
- **Synchronize step** (`SynchronizeStep.tsx`): folderless shows the folder-style migration notes, not the instance "alerts will be lost" warning.
- **Resource stats** (`useResourceStats.ts`): folderless behaves like folder for migration/skip-sync (not instance-wide migration).
- **Repository settings** (`ConfigForm.tsx`): "Top level (no folder)" target option.


<img width="1202" height="930" alt="Screenshot 2026-06-08 at 15 33 04" src="https://github.com/user-attachments/assets/81956df9-c16b-4654-9917-fb2f0434136d" />
<img width="809" height="317" alt="Screenshot 2026-06-08 at 15 32 02" src="https://github.com/user-attachments/assets/53d306cb-309f-4aba-bf35-669caf36136f" />


## Notes

- The generated TS client type for `target` (`'folder' | 'folderless' | 'instance'`) comes from the **type PR** — no client change here.
- i18n strings extracted into `en-US/grafana.json` via `yarn i18n-extract`.

## Tests / checks

- New `useModeOptions.test.ts` (folderless enabled when allowed, disabled when not, coexists with a connected folder).
- `yarn jest public/app/features/provisioning/Wizard` — 167 pass.
- `yarn typecheck` and `eslint` on changed files pass.

## Stacked on

- Base: `MissingRoberto/folderless-target-type` (#125809). Retarget to `main` once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
