### PR TITLE
Alerting:  Fix named policy route showing as Default when routing toggle is off

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/NotificationsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/NotificationsStep.tsx
@@ -243,14 +243,11 @@ function AutomaticRooting({ alertUid }: AutomaticRootingProps) {
   const selectedPolicy = watch('selectedPolicy');
 
   const multiplePoliciesEnabled = config.featureToggles.alertingMultiplePolicies ?? false;
-  const policyRoutingSettingsEnabled = config.featureToggles.alertingPolicyRoutingSettings ?? false;
 
-  // When using the new routing settings FF, the policy is stored in selectedPolicy.
-  // In legacy mode (label-based routing), extract it from the __grafana_managed_route__ label so
-  // the notification preview fetches the correct routing tree instead of always defaulting to root.
-  const policyNameForPreview = policyRoutingSettingsEnabled
-    ? selectedPolicy
-    : labels.find((l) => l.key === NAMED_ROOT_LABEL_NAME)?.value;
+  // Prefer the policy field (notification_settings.policy — canonical and honored by the backend
+  // in both toggle states), falling back to the legacy __grafana_managed_route__ label, so the
+  // notification preview fetches the correct routing tree instead of always defaulting to root.
+  const policyNameForPreview = selectedPolicy || labels.find((l) => l.key === NAMED_ROOT_LABEL_NAME)?.value;
 
   return (
     <Stack direction="column" gap={2}>

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/PolicyTreeSelector.integration.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/PolicyTreeSelector.integration.test.tsx
@@ -530,6 +530,77 @@ describe('PolicyTreeSelector - feature toggle ON', () => {
       expect(policyTreeUi.policySelector.query()).not.toBeInTheDocument();
     });
   });
+
+  // Regression: a rule routed via notification_settings.policy (the canonical, backend-honored
+  // storage) was shown as "Default policy" and silently dropped on save when only
+  // alertingMultiplePolicies was enabled (alertingPolicyRoutingSettings OFF), because the
+  // selector/save paths only looked at the legacy __grafana_managed_route__ label.
+  describe('edit existing rule with notification_settings.policy (alertingPolicyRoutingSettings OFF)', () => {
+    const CUSTOM_POLICY_NAME = 'Managed Policy - Empty Provisioned';
+
+    beforeEach(() => {
+      setFolderResponse(
+        mockFolder({
+          uid: grafanaRulerNamespace.uid,
+          title: grafanaRulerNamespace.name,
+          accessControl: {
+            [AccessControlAction.AlertingRuleUpdate]: true,
+          },
+        })
+      );
+
+      const ruleWithPolicy: RulerGrafanaRuleDTO = {
+        ...grafanaRulerRule,
+        labels: {},
+        grafana_alert: {
+          ...grafanaRulerRule.grafana_alert,
+          notification_settings: { policy: CUSTOM_POLICY_NAME },
+        },
+      };
+      const group: RulerRuleGroupDTO<RulerGrafanaRuleDTO> = {
+        ...grafanaRulerGroup,
+        rules: [ruleWithPolicy],
+      };
+      server.use(
+        http.get(`/api/ruler/grafana/api/v1/rules/${grafanaRulerNamespace.uid}/${grafanaRulerGroup.name}`, () =>
+          HttpResponse.json(group)
+        )
+      );
+    });
+
+    it('shows the policy from notification_settings.policy pre-selected, not "Default policy"', async () => {
+      renderRuleEditor(grafanaRulerRule.grafana_alert.uid);
+
+      await waitFor(() => {
+        expect(policyTreeUi.policySelector.get()).toBeEnabled();
+      });
+
+      expect(screen.getByText(CUSTOM_POLICY_NAME)).toBeInTheDocument();
+      expect(policyTreeUi.resetButton.get()).toBeInTheDocument();
+      expect(policyTreeUi.changeButton.query()).not.toBeInTheDocument();
+      expect(policyTreeUi.defaultBadge.query()).not.toBeInTheDocument();
+    });
+
+    it('round-trips notification_settings.policy on save (does not drop it or add a legacy label)', async () => {
+      const capture = captureRequests((r) => r.method === 'POST' && r.url.includes('/api/ruler/'));
+
+      const { user } = renderRuleEditor(grafanaRulerRule.grafana_alert.uid);
+
+      await waitFor(() => {
+        expect(policyTreeUi.policySelector.get()).toBeEnabled();
+      });
+
+      await user.click(ui.buttons.save.get());
+      const requests = await capture;
+      const bodies = await Promise.all(
+        requests.map((r) => r.json() as Promise<RulerRuleGroupDTO<RulerGrafanaRuleDTO>>)
+      );
+      const savedRule = bodies[0].rules.find((r) => r.grafana_alert.title === grafanaRulerRule.grafana_alert.title);
+
+      expect(savedRule?.grafana_alert.notification_settings?.policy).toBe(CUSTOM_POLICY_NAME);
+      expect(savedRule?.labels?.[NAMED_ROOT_LABEL_NAME]).toBeUndefined();
+    });
+  });
 });
 
 describe('PolicyTreeSelector - alertingPolicyRoutingSettings ON', () => {

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/PolicyTreeSelector.integration.test.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/PolicyTreeSelector.integration.test.tsx
@@ -784,5 +784,29 @@ describe('PolicyTreeSelector - alertingPolicyRoutingSettings ON', () => {
       expect(policyTreeUi.resetButton.get()).toBeInTheDocument();
       expect(policyTreeUi.changeButton.query()).not.toBeInTheDocument();
     });
+
+    it('clears the policy on reset (re-opening the selector shows default, not the stale label)', async () => {
+      const { user } = renderRuleEditor(grafanaRulerRule.grafana_alert.uid);
+
+      // Loads expanded with the migrated policy selected.
+      await waitFor(() => {
+        expect(policyTreeUi.policySelector.get()).toBeEnabled();
+      });
+      expect(policyTreeUi.resetButton.get()).toBeInTheDocument();
+
+      // Reset to default, then re-open the selector.
+      await user.click(policyTreeUi.resetButton.get());
+      await waitFor(() => {
+        expect(policyTreeUi.changeButton.get()).toBeInTheDocument();
+      });
+      await user.click(policyTreeUi.changeButton.get());
+      await waitFor(() => {
+        expect(policyTreeUi.policySelector.get()).toBeInTheDocument();
+      });
+
+      // The selector must reflect the default policy, not the stale legacy label.
+      expect(policyTreeUi.resetButton.query()).not.toBeInTheDocument();
+      expect(within(policyTreeUi.policySelector.get()).queryByText(CUSTOM_POLICY_NAME)).not.toBeInTheDocument();
+    });
   });
 });

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/PolicyTreeSelector.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/PolicyTreeSelector.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useController, useFormContext } from 'react-hook-form';
 
 import { type SelectableValue } from '@grafana/data';
@@ -52,10 +52,11 @@ export function PolicyTreeSelector() {
 
   // A rule routed via notification_settings.policy carries a selectedPolicy value but no legacy label.
   // They must keep editing through the policy field even when the toggle is OFF, so the two routing mechanisms never coexist.
-  const isPolicyFieldRule = useRef(
-    usePolicyRoutingSettings ||
+  const [isPolicyFieldRule] = useState(
+    () =>
+      usePolicyRoutingSettings ||
       (Boolean(selectedPolicyField.value) && !labels.some((label) => label.key === NAMED_ROOT_LABEL_NAME))
-  ).current;
+  );
 
   // Resolve the current value from the routing mechanism this rule actually uses. Policy-field rules
   // must read selectedPolicy only: the legacy label can linger in form state (it is stripped at DTO

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/PolicyTreeSelector.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/PolicyTreeSelector.tsx
@@ -57,13 +57,16 @@ export function PolicyTreeSelector() {
       (Boolean(selectedPolicyField.value) && !labels.some((label) => label.key === NAMED_ROOT_LABEL_NAME))
   ).current;
 
-  // Resolve the current value, preferring the policy field (canonical, matches the save path)
-  // and falling back to the legacy label. selectedPolicy defaults to '' (falsy), so an empty
-  // value correctly falls through to the legacy label rather than masking it.
+  // Resolve the current value from the routing mechanism this rule actually uses. Policy-field rules
+  // must read selectedPolicy only: the legacy label can linger in form state (it is stripped at DTO
+  // time, not on edit), so falling back to it would mask a reset-to-default with the stale value.
   const currentPolicyValue = useMemo(() => {
+    if (isPolicyFieldRule) {
+      return selectedPolicyField.value || '';
+    }
     const legacyLabelValue = labels.find((label) => label.key === NAMED_ROOT_LABEL_NAME)?.value;
-    return selectedPolicyField.value || legacyLabelValue || '';
-  }, [selectedPolicyField.value, labels]);
+    return legacyLabelValue || '';
+  }, [isPolicyFieldRule, selectedPolicyField.value, labels]);
 
   const isUsingDefaultPolicy = currentPolicyValue === '';
 
@@ -147,7 +150,9 @@ export function PolicyTreeSelector() {
   const updatePolicyValue = useCallback(
     (newValue: string) => {
       if (isPolicyFieldRule) {
-        selectedPolicyField.onChange(newValue || undefined);
+        // Pass '' (not undefined) on reset: react-hook-form's controller onChange ignores undefined,
+        // leaving the previous policy in place. '' is the field's default and reads as the default policy.
+        selectedPolicyField.onChange(newValue);
         return;
       }
 

--- a/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/PolicyTreeSelector.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/notificaton-preview/PolicyTreeSelector.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useController, useFormContext } from 'react-hook-form';
 
 import { type SelectableValue } from '@grafana/data';
@@ -50,14 +50,20 @@ export function PolicyTreeSelector() {
 
   const { currentData: policies, isLoading, error } = useListNotificationPolicyRoutes();
 
-  // Get current value: from selectedPolicy field (new) or from labels (old)
+  // A rule routed via notification_settings.policy carries a selectedPolicy value but no legacy label.
+  // They must keep editing through the policy field even when the toggle is OFF, so the two routing mechanisms never coexist.
+  const isPolicyFieldRule = useRef(
+    usePolicyRoutingSettings ||
+      (Boolean(selectedPolicyField.value) && !labels.some((label) => label.key === NAMED_ROOT_LABEL_NAME))
+  ).current;
+
+  // Resolve the current value, preferring the policy field (canonical, matches the save path)
+  // and falling back to the legacy label. selectedPolicy defaults to '' (falsy), so an empty
+  // value correctly falls through to the legacy label rather than masking it.
   const currentPolicyValue = useMemo(() => {
-    if (usePolicyRoutingSettings) {
-      return selectedPolicyField.value ?? '';
-    }
-    const existingLabel = labels.find((label) => label.key === NAMED_ROOT_LABEL_NAME);
-    return existingLabel?.value ?? '';
-  }, [usePolicyRoutingSettings, selectedPolicyField.value, labels]);
+    const legacyLabelValue = labels.find((label) => label.key === NAMED_ROOT_LABEL_NAME)?.value;
+    return selectedPolicyField.value || legacyLabelValue || '';
+  }, [selectedPolicyField.value, labels]);
 
   const isUsingDefaultPolicy = currentPolicyValue === '';
 
@@ -110,7 +116,7 @@ export function PolicyTreeSelector() {
 
   // Validate that existing label value is still valid when policies load (legacy label path only)
   useEffect(() => {
-    if (usePolicyRoutingSettings) {
+    if (isPolicyFieldRule) {
       return;
     }
     if (isLoading || !policies || policies.length === 0) {
@@ -136,11 +142,11 @@ export function PolicyTreeSelector() {
       const newLabels = labels.filter((label) => label.key !== NAMED_ROOT_LABEL_NAME);
       setValue('labels', newLabels);
     }
-  }, [usePolicyRoutingSettings, isLoading, policies, labels, setValue]);
+  }, [isPolicyFieldRule, isLoading, policies, labels, setValue]);
 
   const updatePolicyValue = useCallback(
     (newValue: string) => {
-      if (usePolicyRoutingSettings) {
+      if (isPolicyFieldRule) {
         selectedPolicyField.onChange(newValue || undefined);
         return;
       }
@@ -166,7 +172,7 @@ export function PolicyTreeSelector() {
 
       setValue('labels', newLabels);
     },
-    [usePolicyRoutingSettings, selectedPolicyField, getValues, setValue]
+    [isPolicyFieldRule, selectedPolicyField, getValues, setValue]
   );
 
   const handlePolicyChange = (option: SelectableValue<string>) => {

--- a/public/app/features/alerting/unified/utils/rule-form.test.ts
+++ b/public/app/features/alerting/unified/utils/rule-form.test.ts
@@ -413,12 +413,22 @@ describe('getNotificationSettingsForDTO with selectedPolicy', () => {
     jest.restoreAllMocks();
   });
 
-  it('should NOT return policy DTO when alertingPolicyRoutingSettings is OFF', () => {
+  it('should return policy DTO even when alertingPolicyRoutingSettings is OFF', () => {
     jest.replaceProperty(config, 'featureToggles', {
       ...config.featureToggles,
       alertingPolicyRoutingSettings: false,
     });
     const result = getNotificationSettingsForDTO(false, undefined, 'TestPolicy');
+    expect(result).toEqual({ policy: 'TestPolicy' });
+    jest.restoreAllMocks();
+  });
+
+  it('should return undefined when selectedPolicy is not set (legacy label-only rule)', () => {
+    jest.replaceProperty(config, 'featureToggles', {
+      ...config.featureToggles,
+      alertingPolicyRoutingSettings: false,
+    });
+    const result = getNotificationSettingsForDTO(false, undefined, undefined);
     expect(result).toBeUndefined();
     jest.restoreAllMocks();
   });
@@ -531,6 +541,26 @@ describe('formValuesToRulerGrafanaRuleDTO label stripping', () => {
       alertingPolicyRoutingSettings: true,
     });
     const result = formValuesToRulerGrafanaRuleDTO(baseValues());
+    expect(result.labels).not.toHaveProperty('__grafana_managed_route__');
+    expect(result.labels).toHaveProperty('env', 'prod');
+    jest.restoreAllMocks();
+  });
+
+  it('should write notification_settings.policy (and strip the legacy label) for a policy-field rule when FF is OFF', () => {
+    jest.replaceProperty(config, 'featureToggles', {
+      ...config.featureToggles,
+      alertingPolicyRoutingSettings: false,
+    });
+    const values: RuleFormValues = {
+      ...getDefaultFormValues(),
+      condition: 'A',
+      type: RuleFormType.grafana,
+      manualRouting: false,
+      selectedPolicy: 'TestPolicy',
+      labels: [{ key: 'env', value: 'prod' }],
+    };
+    const result = formValuesToRulerGrafanaRuleDTO(values);
+    expect(result.grafana_alert.notification_settings).toEqual({ policy: 'TestPolicy' });
     expect(result.labels).not.toHaveProperty('__grafana_managed_route__');
     expect(result.labels).toHaveProperty('env', 'prod');
     jest.restoreAllMocks();

--- a/public/app/features/alerting/unified/utils/rule-form.ts
+++ b/public/app/features/alerting/unified/utils/rule-form.ts
@@ -120,7 +120,9 @@ export function getNotificationSettingsForDTO(
   contactPoints?: AlertManagerManualRouting,
   selectedPolicy?: string
 ): GrafanaNotificationSettings | undefined {
-  if (config.featureToggles.alertingPolicyRoutingSettings && selectedPolicy && !manualRouting) {
+  // selectedPolicy is only populated for rules routed via notification_settings.policy so emit it in both toggle states.
+  // Legacy label-routed rules leave selectedPolicy unset and keep routing through the label.
+  if (selectedPolicy && !manualRouting) {
     return { policy: selectedPolicy };
   }
   if (contactPoints?.grafana?.selectedContactPoint && manualRouting) {
@@ -182,9 +184,10 @@ export function formValuesToRulerGrafanaRuleDTO(values: RuleFormValues): Postabl
 
   const annotations = arrayToRecord(cleanAnnotations(values.annotations));
   const labels = arrayToRecord(cleanLabels(values.labels));
-  // When the new policy routing is active, the legacy label must not be sent so that both
-  // routing mechanisms never coexist in the same payload.
-  if (config.featureToggles.alertingPolicyRoutingSettings) {
+  // The legacy label must not be sent whenever the policy field is in use, so the two routing
+  // mechanisms never coexist in the same payload: either when the new policy routing is active
+  // (toggle on) or when we are writing a route to notification_settings.policy.
+  if (config.featureToggles.alertingPolicyRoutingSettings || notificationSettings?.policy) {
     delete labels[NAMED_ROOT_LABEL_NAME];
   }
 


### PR DESCRIPTION
**What is this feature?**

This fixes how the rule editor handles a Grafana-managed rule routed via `notification_settings.policy` when the `alertingPolicyRoutingSettings` feature toggle is off.

  - The policy selector now prefers the `notification_settings.policy` field and falls back to the legacy `__grafana_managed_route__` label, so the correct policy is  shown instead of "Default policy".
  - The notification preview reads the policy from the same field, so it fetches the correct routing tree.
  - On save and export, a rule routed through the policy field writes `notification_settings.policy` and strips the legacy label, so the route is no longer dropped and the two routing mechanisms never coexist.

**Why do we need this feature?**

A rule routed via `notification_settings.policy` was shown as "Default policy" in the rule editor notification step and on the modify-export page. The route was also silently dropped on export and save when the `alertingPolicyRoutingSettings` toggle was off, because the selector and save paths only looked at the legacy `__grafana_managed_route__` label.

**Who is this feature for?**

Alerting users

**Which issue(s) does this PR fix?**:

Fixes https://github.com/grafana/alerting-squad/issues/1751

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
