### PR TITLE
Zanzana: Translate user-management RBAC actions to tuples

### DIFF
--- a/pkg/registry/apis/iam/user/search.go
+++ b/pkg/registry/apis/iam/user/search.go
@@ -13,7 +13,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/grafana/authlib/authz"
 	authlib "github.com/grafana/authlib/types"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -42,11 +41,12 @@ import (
 // The RBAC authz server translates Group/Resource/Verb through the mapper
 // to resolve the underlying RBAC action.
 type accessControlCheck struct {
-	action   string // legacy RBAC action name returned to callers
-	group    string
-	resource string
-	verb     string
-	name     string // user UID of the resource being checked
+	action      string // legacy RBAC action name returned to callers
+	group       string
+	resource    string
+	subresource string
+	verb        string
+	name        string // user UID of the resource being checked
 }
 
 var userAccessControlChecks = []accessControlCheck{
@@ -55,7 +55,9 @@ var userAccessControlChecks = []accessControlCheck{
 	{action: "org.users:remove", group: iamv0.GROUP, resource: "users", verb: utils.VerbDelete},
 	{action: "org.users:write", group: iamv0.GROUP, resource: "users", verb: utils.VerbUpdate},
 	{action: "users.permissions:read", group: iamv0.GROUP, resource: "users", verb: utils.VerbGetPermissions},
-	{action: "users.roles:read", group: iamv0.GROUP, resource: "rolebindings", verb: utils.VerbList},
+	// User role-bindings are the "users" subresource of rolebindings so the check
+	// resolves to users.roles:read rather than colliding with team role-bindings.
+	{action: "users.roles:read", group: iamv0.GROUP, resource: "rolebindings", subresource: "users", verb: utils.VerbList},
 }
 
 type SearchHandler struct {
@@ -380,44 +382,63 @@ func (s *SearchHandler) DoSearch(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *SearchHandler) stampAccessControl(ctx context.Context, requester identity.Requester, hits []iamv0.GetSearchUsersUserHit) error {
+	if len(hits) == 0 {
+		return nil
+	}
+
+	ctx, span := s.tracer.Start(ctx, "user.search.stampAccessControl")
+	defer span.End()
+
 	namespace := requester.GetNamespace()
 
-	items := func(yield func(accessControlCheck) bool) {
-		for _, hit := range hits {
-			for _, c := range userAccessControlChecks {
-				c.name = hit.Name
-				if !yield(c) {
-					return
-				}
+	// Build one batch-check item per (hit, access-control check). We call BatchCheck
+	// directly rather than authz.FilterAuthorized because the latter's convenience item
+	// type cannot carry a subresource, which users.roles:read needs to resolve to the
+	// rolebindings "users" subresource. CorrelationID encodes the hit index and action
+	// so results map back to the originating hit.
+	// Folder is omitted: users are not folder-scoped resources.
+	checks := make([]authlib.BatchCheckItem, 0, len(hits)*len(userAccessControlChecks))
+	for i, hit := range hits {
+		for _, c := range userAccessControlChecks {
+			checks = append(checks, authlib.BatchCheckItem{
+				CorrelationID: fmt.Sprintf("%d|%s", i, c.action),
+				Verb:          c.verb,
+				Group:         c.group,
+				Resource:      c.resource,
+				Subresource:   c.subresource,
+				Name:          hit.Name,
+			})
+		}
+	}
+
+	allowed := make(map[string]bool, len(checks))
+	for start := 0; start < len(checks); start += authlib.MaxBatchCheckItems {
+		end := min(start+authlib.MaxBatchCheckItems, len(checks))
+		resp, err := s.accessClient.BatchCheck(ctx, requester, authlib.BatchCheckRequest{
+			Namespace: namespace,
+			Checks:    checks[start:end],
+		})
+		if err != nil {
+			return fmt.Errorf("access control check failed: %w", err)
+		}
+		for id, res := range resp.Results {
+			if res.Allowed {
+				allowed[id] = true
 			}
 		}
 	}
 
-	extractFn := func(c accessControlCheck) authz.BatchCheckItem {
-		return authz.BatchCheckItem{
-			Verb:      c.verb,
-			Group:     c.group,
-			Resource:  c.resource,
-			Namespace: namespace,
-			Name:      c.name,
-			// Folder is omitted: users are not folder-scoped resources.
-			// TODO: set FreshnessTimestamp once we decide whether cached AC is acceptable here.
-		}
-	}
-
-	acMap := make(map[string]map[string]bool, len(hits))
-	for c, err := range authz.FilterAuthorized(ctx, s.accessClient, items, extractFn, authz.WithTracer(s.tracer)) {
-		if err != nil {
-			return fmt.Errorf("access control check failed: %w", err)
-		}
-		if acMap[c.name] == nil {
-			acMap[c.name] = make(map[string]bool, len(userAccessControlChecks))
-		}
-		acMap[c.name][c.action] = true
-	}
-
 	for i := range hits {
-		hits[i].AccessControl = acMap[hits[i].Name]
+		var acMap map[string]bool
+		for _, c := range userAccessControlChecks {
+			if allowed[fmt.Sprintf("%d|%s", i, c.action)] {
+				if acMap == nil {
+					acMap = make(map[string]bool, len(userAccessControlChecks))
+				}
+				acMap[c.action] = true
+			}
+		}
+		hits[i].AccessControl = acMap
 	}
 
 	return nil

--- a/pkg/registry/apis/iam/user/search_test.go
+++ b/pkg/registry/apis/iam/user/search_test.go
@@ -14,6 +14,7 @@ import (
 
 	iamv0 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/infra/tracing"
 	"github.com/grafana/grafana/pkg/services/featuremgmt"
@@ -346,6 +347,48 @@ func TestAccessControl(t *testing.T) {
 			tc.checkHits(t, resp.Hits)
 		})
 	}
+}
+
+// TestAccessControlSubresource verifies that the users.roles:read check is issued
+// against the rolebindings "users" subresource (so it resolves to users.roles:read and
+// stays distinct from team role-bindings), while the core user checks carry no subresource.
+func TestAccessControlSubresource(t *testing.T) {
+	var got []authlib.BatchCheckItem
+	recordingClient := &mockAccessClient{
+		batchCheckFunc: func(_ context.Context, _ authlib.AuthInfo, req authlib.BatchCheckRequest) (authlib.BatchCheckResponse, error) {
+			got = append(got, req.Checks...)
+			return authlib.BatchCheckResponse{}, nil
+		},
+	}
+
+	searchHandler := NewSearchHandler(
+		tracing.NewNoopTracerService(),
+		mockClientWithHits(),
+		featuremgmt.WithFeatures(),
+		&setting.Cfg{},
+		recordingClient,
+	)
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/searchUsers?accesscontrol=true", nil)
+	req.Header.Add("content-type", "application/json")
+	req = req.WithContext(identity.WithRequester(req.Context(), &legacyuser.SignedInUser{Namespace: "default"}))
+
+	searchHandler.DoSearch(rr, req)
+	require.Equal(t, 200, rr.Code)
+
+	var sawUserRoles bool
+	for _, c := range got {
+		if c.Resource == "rolebindings" {
+			sawUserRoles = true
+			assert.Equal(t, "users", c.Subresource, "user role-bindings must be checked via the users subresource")
+			assert.Equal(t, utils.VerbList, c.Verb)
+		} else {
+			assert.Equal(t, "users", c.Resource)
+			assert.Empty(t, c.Subresource, "core user checks must not carry a subresource")
+		}
+	}
+	assert.True(t, sawUserRoles, "expected a users.roles:read check against rolebindings")
 }
 
 type mockAccessClient struct {

--- a/pkg/services/authz/rbac/mapper.go
+++ b/pkg/services/authz/rbac/mapper.go
@@ -355,9 +355,13 @@ func NewMapperRegistry() MapperRegistry {
 				// No need to skip scope on create for roles because we translate `permissions:type:delegate` to `roles:*``
 				skipScopeOnVerb: nil,
 			},
-			"rolebindings": translation{
+			// User role-bindings are the rolebindings resource with a User subject,
+			// addressed as the "users" subresource so they map to users.roles:* and stay
+			// distinct from team role-bindings (rolebindings/teams). Role-binding access
+			// is always subject-scoped; there is no plain rolebindings entry.
+			"rolebindings/users": translation{
 				resource: "rolebindings",
-				// rolebidings should only be modifiable by admins with a wildcard access
+				// rolebindings should only be modifiable by admins with a wildcard access
 				useWildcardScope: true,
 				verbMapping: map[string]string{
 					utils.VerbCreate:           "users.roles:add",

--- a/pkg/services/authz/rbac/mapper_test.go
+++ b/pkg/services/authz/rbac/mapper_test.go
@@ -197,6 +197,39 @@ func TestMapperRegistry_SubresourceLookup(t *testing.T) {
 	})
 }
 
+// TestMapperRegistry_RoleBindingsUsersSubresource verifies the real mapper routes the
+// iam.grafana.app rolebindings "users" subresource to users.roles:* actions, and that
+// there is no plain rolebindings entry (role-binding access is always subject-scoped).
+func TestMapperRegistry_RoleBindingsUsersSubresource(t *testing.T) {
+	reg := NewMapperRegistry()
+
+	cases := []struct {
+		verb   string
+		action string
+	}{
+		{utils.VerbGet, "users.roles:read"},
+		{utils.VerbList, "users.roles:read"},
+		{utils.VerbCreate, "users.roles:add"},
+		{utils.VerbUpdate, "users.roles:add"},
+		{utils.VerbDelete, "users.roles:remove"},
+		{utils.VerbDeleteCollection, "users.roles:remove"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.verb, func(t *testing.T) {
+			mapping, ok := reg.Get("iam.grafana.app", "rolebindings", "users")
+			require.True(t, ok)
+			action, ok := mapping.Action(tc.verb)
+			assert.True(t, ok)
+			assert.Equal(t, tc.action, action)
+		})
+	}
+
+	// No plain rolebindings entry: a check without a subresource does not resolve here.
+	_, ok := reg.Get("iam.grafana.app", "rolebindings", "")
+	assert.False(t, ok, "plain rolebindings must not have a mapper entry")
+}
+
 // TestMapper_ServiceAccountTranslation_ActionSets verifies that service account verbs map to the
 // correct action sets. There is no View level — Edit verbs map to both edit+admin, and admin-only
 // verbs (delete, permissions) map to admin only.

--- a/pkg/services/authz/zanzana/tuple_helpers.go
+++ b/pkg/services/authz/zanzana/tuple_helpers.go
@@ -57,9 +57,15 @@ var (
 	roleBindingsResource = iamv0.RoleBindingInfo.GroupResource().Resource
 )
 
+// roleBindingsUsersSubresource addresses user role-bindings (a RoleBinding with a User
+// subject) as a subresource of the shared rolebindings resource, keeping them distinct
+// from team role-bindings (rolebindings/teams). See pkg/services/authz/rbac/mapper.go.
+const roleBindingsUsersSubresource = "users"
+
 type userActionMapping struct {
-	resource  string
-	relations []string
+	resource    string
+	subresource string
+	relations   []string
 	// skipScope marks actions the mapper authorizes without a scope (create verbs).
 	skipScope bool
 }
@@ -73,7 +79,8 @@ type userActionMapping struct {
 // iam admission validators (pkg/registry/apis/iam/user/validate.go) independently of
 // this grant — so the relation only decides "may you attempt this verb".
 //
-// users.roles:* gate rolebindings, not users. Actions with no iam verb
+// users.roles:* gate user role-bindings, addressed as the rolebindings "users"
+// subresource (distinct from team role-bindings). Actions with no iam verb
 // (users:enable/disable/logout, users.authtoken/password/quotas) gate only legacy HTTP
 // endpoints and are omitted.
 var userManagementMappings = map[string]userActionMapping{
@@ -92,9 +99,9 @@ var userManagementMappings = map[string]userActionMapping{
 	actionUsersPermissionsRead:  {resource: usersResource, relations: []string{RelationGetPermissions}},
 	actionUsersPermissionsWrite: {resource: usersResource, relations: []string{RelationSetPermissions}},
 
-	actionUsersRolesRead:   {resource: roleBindingsResource, relations: []string{RelationGet}},
-	actionUsersRolesAdd:    {resource: roleBindingsResource, relations: []string{RelationCreate, RelationUpdate}},
-	actionUsersRolesRemove: {resource: roleBindingsResource, relations: []string{RelationDelete}},
+	actionUsersRolesRead:   {resource: roleBindingsResource, subresource: roleBindingsUsersSubresource, relations: []string{RelationGet}},
+	actionUsersRolesAdd:    {resource: roleBindingsResource, subresource: roleBindingsUsersSubresource, relations: []string{RelationCreate, RelationUpdate}},
+	actionUsersRolesRemove: {resource: roleBindingsResource, subresource: roleBindingsUsersSubresource, relations: []string{RelationDelete}},
 }
 
 // Scope fragments produced by splitScope for the two "all roles" scopes we
@@ -332,7 +339,7 @@ func UserManagementToTuples(subject string, permission RolePermission) []*openfg
 
 	tuples := make([]*openfgav1.TupleKey, 0, len(m.relations))
 	for _, relation := range m.relations {
-		tuples = append(tuples, NewGroupResourceTuple(subject, relation, iamGroup, m.resource, ""))
+		tuples = append(tuples, NewGroupResourceTuple(subject, relation, iamGroup, m.resource, m.subresource))
 	}
 	return tuples
 }

--- a/pkg/services/authz/zanzana/tuple_helpers.go
+++ b/pkg/services/authz/zanzana/tuple_helpers.go
@@ -28,6 +28,85 @@ const (
 	actionRolesDelete = "roles:delete"
 )
 
+// User-management actions. Hardcoded for the same reason as the role-management
+// actions above: the enterprise-only users.roles:* actions live in pkg/extensions
+// and these shared helpers must not depend on it.
+const (
+	actionUsersCreate = "users:create"
+	actionUsersRead   = "users:read"
+	actionUsersWrite  = "users:write"
+	actionUsersDelete = "users:delete"
+
+	actionUsersPermissionsRead  = "users.permissions:read"
+	actionUsersPermissionsWrite = "users.permissions:write"
+
+	actionUsersRolesRead   = "users.roles:read"
+	actionUsersRolesAdd    = "users.roles:add"
+	actionUsersRolesRemove = "users.roles:remove"
+
+	actionOrgUsersRead   = "org.users:read"
+	actionOrgUsersWrite  = "org.users:write"
+	actionOrgUsersAdd    = "org.users:add"
+	actionOrgUsersRemove = "org.users:remove"
+)
+
+// iam.grafana.app group and the two resources user-management actions gate.
+var (
+	iamGroup             = iamv0.UserResourceInfo.GroupResource().Group
+	usersResource        = iamv0.UserResourceInfo.GroupResource().Resource
+	roleBindingsResource = iamv0.RoleBindingInfo.GroupResource().Resource
+)
+
+// userActionMapping describes the group_resource (within iamGroup) and relation(s)
+// a user-management action grants on the iam K8s API.
+type userActionMapping struct {
+	resource  string
+	relations []string
+	// skipScope marks actions the mapper authorizes without a scope (create verbs);
+	// they translate regardless of the permission's scope.
+	skipScope bool
+}
+
+// userManagementMappings maps user-management RBAC actions to the iam group_resource
+// tuples they grant.
+//
+// On iam.grafana.app/users the global (users:*) and org (org.users:*) action families
+// converge on the same K8s verbs, so both translate to the same relation — a "union"
+// model. This is safe because the iam admission validators
+// (pkg/registry/apis/iam/user/validate.go) enforce field-level escalation guards
+// INDEPENDENTLY of this verb-level grant: only Grafana admins can change the
+// grafanaAdmin or disabled fields, and a non-service, non-admin requester may only
+// change the org role. So the relation only decides "may you attempt this verb"; it
+// can't be used to promote to server admin or edit privileged fields. Those guards
+// run server-side regardless of whether Zanzana or legacy RBAC serves the verb check.
+//
+// users.roles:* gate iam.grafana.app/rolebindings instead (NOT users — role
+// assignments are a distinct resource).
+//
+// Actions with no iam verb at all (users:enable/disable/logout, users.authtoken:*,
+// users.password:*, users.quotas:*) gate only legacy HTTP endpoints and are not
+// listed — there is no iam relation for them to grant.
+var userManagementMappings = map[string]userActionMapping{
+	actionUsersRead:    {resource: usersResource, relations: []string{RelationGet}},
+	actionOrgUsersRead: {resource: usersResource, relations: []string{RelationGet}},
+
+	actionUsersWrite:    {resource: usersResource, relations: []string{RelationUpdate}},
+	actionOrgUsersWrite: {resource: usersResource, relations: []string{RelationUpdate}},
+
+	actionUsersCreate: {resource: usersResource, relations: []string{RelationCreate}, skipScope: true},
+	actionOrgUsersAdd: {resource: usersResource, relations: []string{RelationCreate}},
+
+	actionUsersDelete:    {resource: usersResource, relations: []string{RelationDelete}},
+	actionOrgUsersRemove: {resource: usersResource, relations: []string{RelationDelete}},
+
+	actionUsersPermissionsRead:  {resource: usersResource, relations: []string{RelationGetPermissions}},
+	actionUsersPermissionsWrite: {resource: usersResource, relations: []string{RelationSetPermissions}},
+
+	actionUsersRolesRead:   {resource: roleBindingsResource, relations: []string{RelationGet}},
+	actionUsersRolesAdd:    {resource: roleBindingsResource, relations: []string{RelationCreate, RelationUpdate}},
+	actionUsersRolesRemove: {resource: roleBindingsResource, relations: []string{RelationDelete}},
+}
+
 // Scope fragments produced by splitScope for the two "all roles" scopes we
 // honor when translating role-management permissions:
 //   - permissions:type:delegate → kind="permissions", identifier="delegate"
@@ -89,6 +168,18 @@ func ConvertRolePermissionsToTuples(roleUID string, permissions []RolePermission
 		// actions are intentionally dropped (see RoleManagementToTuples).
 		if isRoleManagementAction(perm.Action) {
 			for _, t := range RoleManagementToTuples(subject, perm) {
+				tupleMap[t.String()] = t
+			}
+			continue
+		}
+
+		// User-management actions (users:*, org.users:*, users.roles:*) take a
+		// dedicated translation path for the same reason as role-management
+		// actions: they map onto iam group_resources rather than via the standard
+		// resource translation table. Non-"all" scopes are intentionally dropped
+		// (see UserManagementToTuples).
+		if isUserManagementAction(perm.Action) {
+			for _, t := range UserManagementToTuples(subject, perm) {
 				tupleMap[t.String()] = t
 			}
 			continue
@@ -236,6 +327,54 @@ func isRolesWildcardScope(kind, identifier string) bool {
 		return true
 	}
 	return false
+}
+
+// UserManagementToTuples returns the Zanzana tuples that grant a role user- and
+// role-binding-management abilities in the namespace, based on its user-management
+// permissions.
+//
+// Only "all" scopes produce tuples. Both iam resources involved are wildcard-only
+// in Zanzana terms: the users resource is uid-based in FGA while the legacy scope
+// is id-based (e.g. users:id:42), so a specific-user scope can't be expressed
+// without an id→uid lookup; and rolebindings is wildcard-scoped by design in the
+// mapper. A permission scoped to a specific instance is therefore dropped — see
+// isAllUsersScope for the accepted "all" shapes. The create verb carries no scope
+// (skipScope) and always translates.
+func UserManagementToTuples(subject string, permission RolePermission) []*openfgav1.TupleKey {
+	m, ok := userManagementMappings[permission.Action]
+	if !ok {
+		return nil
+	}
+
+	if !m.skipScope && !isAllUsersScope(permission.Kind, permission.Identifier) {
+		return nil
+	}
+
+	tuples := make([]*openfgav1.TupleKey, 0, len(m.relations))
+	for _, relation := range m.relations {
+		tuples = append(tuples, NewGroupResourceTuple(subject, relation, iamGroup, m.resource, ""))
+	}
+	return tuples
+}
+
+// isUserManagementAction reports whether the action is one of the user-management
+// actions handled by UserManagementToTuples.
+func isUserManagementAction(action string) bool {
+	_, ok := userManagementMappings[action]
+	return ok
+}
+
+// isAllUsersScope reports whether the (kind, identifier) pair represents an "all"
+// scope for the user-management actions. The legacy shapes that appear are:
+//   - users:* / global.users:*  → identifier="*" (users.permissions:*, users:delete, users.roles:read)
+//   - permissions:type:delegate → kind="permissions", identifier="delegate" (users.roles:add/remove)
+//
+// Specific instance scopes (e.g. users:id:5) match none of these and are dropped.
+func isAllUsersScope(kind, identifier string) bool {
+	if identifier == scopeIdentifierWildcard {
+		return true
+	}
+	return kind == scopeKindPermissions && identifier == scopeIdentifierDelegate
 }
 
 func splitScope(scope string) (string, string, string) {

--- a/pkg/services/authz/zanzana/tuple_helpers.go
+++ b/pkg/services/authz/zanzana/tuple_helpers.go
@@ -57,35 +57,25 @@ var (
 	roleBindingsResource = iamv0.RoleBindingInfo.GroupResource().Resource
 )
 
-// userActionMapping describes the group_resource (within iamGroup) and relation(s)
-// a user-management action grants on the iam K8s API.
 type userActionMapping struct {
 	resource  string
 	relations []string
-	// skipScope marks actions the mapper authorizes without a scope (create verbs);
-	// they translate regardless of the permission's scope.
+	// skipScope marks actions the mapper authorizes without a scope (create verbs).
 	skipScope bool
 }
 
-// userManagementMappings maps user-management RBAC actions to the iam group_resource
-// tuples they grant.
+// userManagementMappings maps each user-management action to the iam group_resource
+// relation(s) it grants.
 //
-// On iam.grafana.app/users the global (users:*) and org (org.users:*) action families
-// converge on the same K8s verbs, so both translate to the same relation — a "union"
-// model. This is safe because the iam admission validators
-// (pkg/registry/apis/iam/user/validate.go) enforce field-level escalation guards
-// INDEPENDENTLY of this verb-level grant: only Grafana admins can change the
-// grafanaAdmin or disabled fields, and a non-service, non-admin requester may only
-// change the org role. So the relation only decides "may you attempt this verb"; it
-// can't be used to promote to server admin or edit privileged fields. Those guards
-// run server-side regardless of whether Zanzana or legacy RBAC serves the verb check.
+// On iam.grafana.app/users the global (users:*) and org (org.users:*) families gate
+// the same verbs, so both map to the same relation. This union is safe because the
+// privileged changes (grafanaAdmin, disabled, profile vs. org role) are gated by the
+// iam admission validators (pkg/registry/apis/iam/user/validate.go) independently of
+// this grant — so the relation only decides "may you attempt this verb".
 //
-// users.roles:* gate iam.grafana.app/rolebindings instead (NOT users — role
-// assignments are a distinct resource).
-//
-// Actions with no iam verb at all (users:enable/disable/logout, users.authtoken:*,
-// users.password:*, users.quotas:*) gate only legacy HTTP endpoints and are not
-// listed — there is no iam relation for them to grant.
+// users.roles:* gate rolebindings, not users. Actions with no iam verb
+// (users:enable/disable/logout, users.authtoken/password/quotas) gate only legacy HTTP
+// endpoints and are omitted.
 var userManagementMappings = map[string]userActionMapping{
 	actionUsersRead:    {resource: usersResource, relations: []string{RelationGet}},
 	actionOrgUsersRead: {resource: usersResource, relations: []string{RelationGet}},
@@ -173,11 +163,8 @@ func ConvertRolePermissionsToTuples(roleUID string, permissions []RolePermission
 			continue
 		}
 
-		// User-management actions (users:*, org.users:*, users.roles:*) take a
-		// dedicated translation path for the same reason as role-management
-		// actions: they map onto iam group_resources rather than via the standard
-		// resource translation table. Non-"all" scopes are intentionally dropped
-		// (see UserManagementToTuples).
+		// User-management actions map onto iam group_resources via a dedicated path,
+		// like the role-management actions above (see UserManagementToTuples).
 		if isUserManagementAction(perm.Action) {
 			for _, t := range UserManagementToTuples(subject, perm) {
 				tupleMap[t.String()] = t
@@ -329,17 +316,10 @@ func isRolesWildcardScope(kind, identifier string) bool {
 	return false
 }
 
-// UserManagementToTuples returns the Zanzana tuples that grant a role user- and
-// role-binding-management abilities in the namespace, based on its user-management
-// permissions.
-//
-// Only "all" scopes produce tuples. Both iam resources involved are wildcard-only
-// in Zanzana terms: the users resource is uid-based in FGA while the legacy scope
-// is id-based (e.g. users:id:42), so a specific-user scope can't be expressed
-// without an id→uid lookup; and rolebindings is wildcard-scoped by design in the
-// mapper. A permission scoped to a specific instance is therefore dropped — see
-// isAllUsersScope for the accepted "all" shapes. The create verb carries no scope
-// (skipScope) and always translates.
+// UserManagementToTuples translates a user-management permission into iam tuples.
+// Only "all" scopes translate (see isAllUsersScope); specific-instance scopes are
+// dropped, since the FGA users type is uid-based while the legacy scope is id-based
+// and rolebindings is wildcard-only. users:create is unscoped and always translates.
 func UserManagementToTuples(subject string, permission RolePermission) []*openfgav1.TupleKey {
 	m, ok := userManagementMappings[permission.Action]
 	if !ok {

--- a/pkg/services/authz/zanzana/tuple_helpers_test.go
+++ b/pkg/services/authz/zanzana/tuple_helpers_test.go
@@ -246,9 +246,10 @@ func TestConvertRolePermissionsToTuples(t *testing.T) {
 		}), tupleKeyStrings(tuples))
 	})
 
-	t.Run("should reconcile role-assignment permissions to rolebindings", func(t *testing.T) {
-		// users.roles:* gate iam.grafana.app/rolebindings, not users. read is
-		// scoped users:*; add/remove are scoped permissions:type:delegate.
+	t.Run("should reconcile role-assignment permissions to the rolebindings users subresource", func(t *testing.T) {
+		// users.roles:* gate user role-bindings, addressed as the rolebindings "users"
+		// subresource (distinct from team role-bindings). read is scoped users:*;
+		// add/remove are scoped permissions:type:delegate.
 		permissions := []RolePermission{
 			{Action: "users.roles:read", Kind: "users", Identifier: "*"},
 			{Action: "users.roles:add", Kind: "permissions", Identifier: "delegate"},
@@ -259,10 +260,10 @@ func TestConvertRolePermissionsToTuples(t *testing.T) {
 		require.NoError(t, err)
 
 		require.ElementsMatch(t, tupleKeyStrings([]*openfgav1.TupleKey{
-			{User: "role:role-assigner#assignee", Relation: "get", Object: "group_resource:iam.grafana.app/rolebindings"},
-			{User: "role:role-assigner#assignee", Relation: "create", Object: "group_resource:iam.grafana.app/rolebindings"},
-			{User: "role:role-assigner#assignee", Relation: "update", Object: "group_resource:iam.grafana.app/rolebindings"},
-			{User: "role:role-assigner#assignee", Relation: "delete", Object: "group_resource:iam.grafana.app/rolebindings"},
+			{User: "role:role-assigner#assignee", Relation: "get", Object: "group_resource:iam.grafana.app/rolebindings/users"},
+			{User: "role:role-assigner#assignee", Relation: "create", Object: "group_resource:iam.grafana.app/rolebindings/users"},
+			{User: "role:role-assigner#assignee", Relation: "update", Object: "group_resource:iam.grafana.app/rolebindings/users"},
+			{User: "role:role-assigner#assignee", Relation: "delete", Object: "group_resource:iam.grafana.app/rolebindings/users"},
 		}), tupleKeyStrings(tuples))
 	})
 
@@ -317,7 +318,7 @@ func TestConvertRolePermissionsToTuples(t *testing.T) {
 func TestUserManagementToTuples(t *testing.T) {
 	const subject = "role:role-1#assignee"
 	const usersObject = "group_resource:iam.grafana.app/users"
-	const roleBindingsObject = "group_resource:iam.grafana.app/rolebindings"
+	const roleBindingsObject = "group_resource:iam.grafana.app/rolebindings/users"
 
 	t.Run("maps each action to its tuples under an all-scope", func(t *testing.T) {
 		cases := []struct {

--- a/pkg/services/authz/zanzana/tuple_helpers_test.go
+++ b/pkg/services/authz/zanzana/tuple_helpers_test.go
@@ -183,9 +183,8 @@ func TestConvertRolePermissionsToTuples(t *testing.T) {
 	})
 
 	t.Run("should reconcile global users-writer permissions", func(t *testing.T) {
-		// A "global users writer" (Grafana Admin) set: the users:* family + the
-		// permissions sub-actions. Under the union model these map to the full
-		// CRUD + permission relations on iam.grafana.app/users.
+		// A "global users writer" (Grafana Admin) set: the users:* family plus the
+		// permissions sub-actions, mapping to full CRUD + permission relations.
 		permissions := []RolePermission{
 			{Action: "users:create", Kind: "", Identifier: ""},
 			{Action: "users:read", Kind: "global.users", Identifier: "*"},
@@ -210,11 +209,8 @@ func TestConvertRolePermissionsToTuples(t *testing.T) {
 
 	t.Run("should reconcile org-admin (org.users) permissions", func(t *testing.T) {
 		// basic_admin (Org Admin) carries only the org.users:* family plus
-		// users.permissions:read, all scoped users:*. Under the union model these
-		// reach the same users relations as the global family — get/update/create/
-		// delete + get_permissions — so the Org Admin is functional for user
-		// management. Field-level escalation (grafanaAdmin/disabled) is still blocked
-		// by iam admission, independent of these grants.
+		// users.permissions:read. Under the union model these reach the same users
+		// relations as the global family, so the Org Admin is functional.
 		permissions := []RolePermission{
 			{Action: "org.users:read", Kind: "users", Identifier: "*"},
 			{Action: "org.users:write", Kind: "users", Identifier: "*"},

--- a/pkg/services/authz/zanzana/tuple_helpers_test.go
+++ b/pkg/services/authz/zanzana/tuple_helpers_test.go
@@ -181,6 +181,227 @@ func TestConvertRolePermissionsToTuples(t *testing.T) {
 		require.NoError(t, err)
 		require.Empty(t, tuples)
 	})
+
+	t.Run("should reconcile global users-writer permissions", func(t *testing.T) {
+		// A "global users writer" (Grafana Admin) set: the users:* family + the
+		// permissions sub-actions. Under the union model these map to the full
+		// CRUD + permission relations on iam.grafana.app/users.
+		permissions := []RolePermission{
+			{Action: "users:create", Kind: "", Identifier: ""},
+			{Action: "users:read", Kind: "global.users", Identifier: "*"},
+			{Action: "users:write", Kind: "global.users", Identifier: "*"},
+			{Action: "users:delete", Kind: "global.users", Identifier: "*"},
+			{Action: "users.permissions:read", Kind: "users", Identifier: "*"},
+			{Action: "users.permissions:write", Kind: "global.users", Identifier: "*"},
+		}
+
+		tuples, err := ConvertRolePermissionsToTuples("role-users-writer", permissions)
+		require.NoError(t, err)
+
+		require.ElementsMatch(t, tupleKeyStrings([]*openfgav1.TupleKey{
+			{User: "role:role-users-writer#assignee", Relation: "get", Object: "group_resource:iam.grafana.app/users"},
+			{User: "role:role-users-writer#assignee", Relation: "update", Object: "group_resource:iam.grafana.app/users"},
+			{User: "role:role-users-writer#assignee", Relation: "create", Object: "group_resource:iam.grafana.app/users"},
+			{User: "role:role-users-writer#assignee", Relation: "delete", Object: "group_resource:iam.grafana.app/users"},
+			{User: "role:role-users-writer#assignee", Relation: "get_permissions", Object: "group_resource:iam.grafana.app/users"},
+			{User: "role:role-users-writer#assignee", Relation: "set_permissions", Object: "group_resource:iam.grafana.app/users"},
+		}), tupleKeyStrings(tuples))
+	})
+
+	t.Run("should reconcile org-admin (org.users) permissions", func(t *testing.T) {
+		// basic_admin (Org Admin) carries only the org.users:* family plus
+		// users.permissions:read, all scoped users:*. Under the union model these
+		// reach the same users relations as the global family — get/update/create/
+		// delete + get_permissions — so the Org Admin is functional for user
+		// management. Field-level escalation (grafanaAdmin/disabled) is still blocked
+		// by iam admission, independent of these grants.
+		permissions := []RolePermission{
+			{Action: "org.users:read", Kind: "users", Identifier: "*"},
+			{Action: "org.users:write", Kind: "users", Identifier: "*"},
+			{Action: "org.users:add", Kind: "users", Identifier: "*"},
+			{Action: "org.users:remove", Kind: "users", Identifier: "*"},
+			{Action: "users.permissions:read", Kind: "users", Identifier: "*"},
+		}
+
+		tuples, err := ConvertRolePermissionsToTuples("role-org-admin", permissions)
+		require.NoError(t, err)
+
+		require.ElementsMatch(t, tupleKeyStrings([]*openfgav1.TupleKey{
+			{User: "role:role-org-admin#assignee", Relation: "get", Object: "group_resource:iam.grafana.app/users"},
+			{User: "role:role-org-admin#assignee", Relation: "update", Object: "group_resource:iam.grafana.app/users"},
+			{User: "role:role-org-admin#assignee", Relation: "create", Object: "group_resource:iam.grafana.app/users"},
+			{User: "role:role-org-admin#assignee", Relation: "delete", Object: "group_resource:iam.grafana.app/users"},
+			{User: "role:role-org-admin#assignee", Relation: "get_permissions", Object: "group_resource:iam.grafana.app/users"},
+		}), tupleKeyStrings(tuples))
+	})
+
+	t.Run("global and org families dedupe to the same tuples", func(t *testing.T) {
+		// users:read and org.users:read both grant `get` on the users resource;
+		// the resulting tuples are identical and collapse to one.
+		permissions := []RolePermission{
+			{Action: "users:read", Kind: "global.users", Identifier: "*"},
+			{Action: "org.users:read", Kind: "users", Identifier: "*"},
+		}
+
+		tuples, err := ConvertRolePermissionsToTuples("role-dedup-users", permissions)
+		require.NoError(t, err)
+		require.ElementsMatch(t, tupleKeyStrings([]*openfgav1.TupleKey{
+			{User: "role:role-dedup-users#assignee", Relation: "get", Object: "group_resource:iam.grafana.app/users"},
+		}), tupleKeyStrings(tuples))
+	})
+
+	t.Run("should reconcile role-assignment permissions to rolebindings", func(t *testing.T) {
+		// users.roles:* gate iam.grafana.app/rolebindings, not users. read is
+		// scoped users:*; add/remove are scoped permissions:type:delegate.
+		permissions := []RolePermission{
+			{Action: "users.roles:read", Kind: "users", Identifier: "*"},
+			{Action: "users.roles:add", Kind: "permissions", Identifier: "delegate"},
+			{Action: "users.roles:remove", Kind: "permissions", Identifier: "delegate"},
+		}
+
+		tuples, err := ConvertRolePermissionsToTuples("role-assigner", permissions)
+		require.NoError(t, err)
+
+		require.ElementsMatch(t, tupleKeyStrings([]*openfgav1.TupleKey{
+			{User: "role:role-assigner#assignee", Relation: "get", Object: "group_resource:iam.grafana.app/rolebindings"},
+			{User: "role:role-assigner#assignee", Relation: "create", Object: "group_resource:iam.grafana.app/rolebindings"},
+			{User: "role:role-assigner#assignee", Relation: "update", Object: "group_resource:iam.grafana.app/rolebindings"},
+			{User: "role:role-assigner#assignee", Relation: "delete", Object: "group_resource:iam.grafana.app/rolebindings"},
+		}), tupleKeyStrings(tuples))
+	})
+
+	t.Run("actions with no iam verb are dropped", func(t *testing.T) {
+		// These gate only legacy HTTP endpoints — no iam verb maps to them, so there
+		// is no relation to grant.
+		permissions := []RolePermission{
+			{Action: "users:enable", Kind: "global.users", Identifier: "*"},
+			{Action: "users:disable", Kind: "global.users", Identifier: "*"},
+			{Action: "users:logout", Kind: "global.users", Identifier: "*"},
+			{Action: "users.authtoken:read", Kind: "global.users", Identifier: "*"},
+			{Action: "users.password:write", Kind: "global.users", Identifier: "*"},
+			{Action: "users.quotas:write", Kind: "global.users", Identifier: "*"},
+		}
+
+		tuples, err := ConvertRolePermissionsToTuples("role-noop", permissions)
+		require.NoError(t, err)
+		require.Empty(t, tuples)
+	})
+
+	t.Run("scoped user-management permissions are dropped", func(t *testing.T) {
+		// Specific-instance scopes can't be expressed (users is uid-based in FGA
+		// while the scope is id-based; rolebindings is wildcard-only). Create is
+		// the exception — it carries no scope and always translates.
+		permissions := []RolePermission{
+			{Action: "users:read", Kind: "users", Identifier: "1"},
+			{Action: "org.users:write", Kind: "users", Identifier: "abc"},
+			{Action: "users.roles:read", Kind: "users", Identifier: "5"},
+		}
+
+		tuples, err := ConvertRolePermissionsToTuples("role-user-scoped", permissions)
+		require.NoError(t, err)
+		require.Empty(t, tuples)
+	})
+
+	t.Run("should combine folder and user permissions", func(t *testing.T) {
+		permissions := []RolePermission{
+			{Action: "folders:read", Kind: "folders", Identifier: "folder1"},
+			{Action: "users.permissions:read", Kind: "users", Identifier: "*"},
+		}
+
+		tuples, err := ConvertRolePermissionsToTuples("role-mixed", permissions)
+		require.NoError(t, err)
+
+		require.ElementsMatch(t, tupleKeyStrings([]*openfgav1.TupleKey{
+			{User: "role:role-mixed#assignee", Relation: "get", Object: "folder:folder1"},
+			{User: "role:role-mixed#assignee", Relation: "get_permissions", Object: "group_resource:iam.grafana.app/users"},
+		}), tupleKeyStrings(tuples))
+	})
+}
+
+func TestUserManagementToTuples(t *testing.T) {
+	const subject = "role:role-1#assignee"
+	const usersObject = "group_resource:iam.grafana.app/users"
+	const roleBindingsObject = "group_resource:iam.grafana.app/rolebindings"
+
+	t.Run("maps each action to its tuples under an all-scope", func(t *testing.T) {
+		cases := []struct {
+			action     string
+			kind       string
+			identifier string
+			expected   []*openfgav1.TupleKey
+		}{
+			// users:create carries no scope (skipScope) and always translates.
+			{"users:create", "", "", []*openfgav1.TupleKey{
+				{User: subject, Relation: "create", Object: usersObject},
+			}},
+			// The global (users:*) and org (org.users:*) families converge on the
+			// same users relations.
+			{"users:read", "global.users", "*", []*openfgav1.TupleKey{
+				{User: subject, Relation: "get", Object: usersObject},
+			}},
+			{"org.users:read", "users", "*", []*openfgav1.TupleKey{
+				{User: subject, Relation: "get", Object: usersObject},
+			}},
+			{"users:write", "global.users", "*", []*openfgav1.TupleKey{
+				{User: subject, Relation: "update", Object: usersObject},
+			}},
+			{"org.users:write", "users", "*", []*openfgav1.TupleKey{
+				{User: subject, Relation: "update", Object: usersObject},
+			}},
+			{"org.users:add", "users", "*", []*openfgav1.TupleKey{
+				{User: subject, Relation: "create", Object: usersObject},
+			}},
+			{"users:delete", "global.users", "*", []*openfgav1.TupleKey{
+				{User: subject, Relation: "delete", Object: usersObject},
+			}},
+			{"org.users:remove", "users", "*", []*openfgav1.TupleKey{
+				{User: subject, Relation: "delete", Object: usersObject},
+			}},
+			{"users.permissions:read", "users", "*", []*openfgav1.TupleKey{
+				{User: subject, Relation: "get_permissions", Object: usersObject},
+			}},
+			{"users.permissions:write", "global.users", "*", []*openfgav1.TupleKey{
+				{User: subject, Relation: "set_permissions", Object: usersObject},
+			}},
+			{"users.roles:read", "users", "*", []*openfgav1.TupleKey{
+				{User: subject, Relation: "get", Object: roleBindingsObject},
+			}},
+			// add maps to both create and update on rolebindings.
+			{"users.roles:add", "permissions", "delegate", []*openfgav1.TupleKey{
+				{User: subject, Relation: "create", Object: roleBindingsObject},
+				{User: subject, Relation: "update", Object: roleBindingsObject},
+			}},
+			{"users.roles:remove", "permissions", "delegate", []*openfgav1.TupleKey{
+				{User: subject, Relation: "delete", Object: roleBindingsObject},
+			}},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.action, func(t *testing.T) {
+				tuples := UserManagementToTuples(subject, RolePermission{
+					Action: tc.action, Kind: tc.kind, Identifier: tc.identifier,
+				})
+				require.ElementsMatch(t, tupleKeyStrings(tc.expected), tupleKeyStrings(tuples))
+			})
+		}
+	})
+
+	t.Run("drops non-all scopes (except create)", func(t *testing.T) {
+		require.Nil(t, UserManagementToTuples(subject, RolePermission{
+			Action: "org.users:write", Kind: "users", Identifier: "1",
+		}))
+		require.Nil(t, UserManagementToTuples(subject, RolePermission{
+			Action: "users.roles:read", Kind: "users", Identifier: "5",
+		}))
+	})
+
+	t.Run("drops actions with no iam verb", func(t *testing.T) {
+		for _, action := range []string{"users:enable", "users:disable", "users:logout", "users.authtoken:read", "users.password:write", "users.quotas:write"} {
+			require.Nil(t, UserManagementToTuples(subject, RolePermission{
+				Action: action, Kind: "global.users", Identifier: "*",
+			}), "action %q should not translate", action)
+		}
+	})
 }
 
 // tupleKeyStrings returns the prototext (`.String()`) form of each tuple.

--- a/pkg/services/authz/zanzana/zanzana.go
+++ b/pkg/services/authz/zanzana/zanzana.go
@@ -34,6 +34,9 @@ const (
 	RelationCreate = common.RelationCreate
 	RelationDelete = common.RelationDelete
 
+	RelationGetPermissions = common.RelationGetPermissions
+	RelationSetPermissions = common.RelationSetPermissions
+
 	RelationSubresourceSetView  = common.RelationSubresourceSetView
 	RelationSubresourceSetEdit  = common.RelationSubresourceSetEdit
 	RelationSubresourceSetAdmin = common.RelationSubresourceSetAdmin


### PR DESCRIPTION
## What

Adds a dedicated translator that converts user-management RBAC actions into Zanzana (OpenFGA) tuples in the RBAC→Zanzana reconciler.

Previously the reconciler (`ConvertRolePermissionsToTuples`) only handled `folders`, `dashboards`, and role-management actions; **every** user-management permission (`users:*`, `org.users:*`, `users.permissions:*`, `users.roles:*`) was silently dropped. As a result, roles granting them — including the built-in **Admin** (`basic_admin`, i.e. Org Admin) — produced no tuples, so once a namespace is routed to Zanzana for `iam.grafana.app/users`, user management would break.

## How

A dedicated `UserManagementToTuples` path, gated alongside the existing role-management bypass.

The Zanzana check is **verb-driven and action-agnostic** (`common.VerbMapping`), so each action maps to the relation(s) the iam K8s mapper (`pkg/services/authz/rbac/mapper.go`) gates it on. On `iam.grafana.app/users`, the **global** (`users:*`) and **org** (`org.users:*`) families converge on the same verbs, so both translate to the **same relation** (a "union"):

| Relation | Granted by |
| --- | --- |
| `get` | `users:read`, `org.users:read` |
| `update` | `users:write`, `org.users:write` |
| `create` | `users:create` (unscoped), `org.users:add` |
| `delete` | `users:delete`, `org.users:remove` |
| `get_permissions` | `users.permissions:read` |
| `set_permissions` | `users.permissions:write` |

### Role-bindings: the `users` subresource

`users.roles:*` gate **user** role-bindings. A `RoleBinding` is the shared `rolebindings` resource regardless of subject kind (the subject is a spec field, not part of the `(group, resource, verb)` authz tuple), and the mapper otherwise maps every `rolebindings` verb to `users.roles:*` — so user and team role-bindings would collapse onto one object. To keep them distinct, user role-bindings are addressed as the **`users` subresource**:

- Mapper: the plain `rolebindings` entry is **replaced** by `rolebindings/users` → `users.roles:*` (`read→get`, `add→create`+`update`, `remove→delete`). There is no plain `rolebindings` entry anymore — role-binding access is always subject-scoped; a subject-agnostic check falls through to the k8s-native mapping fallback (the only such caller, the generic rolebindings authorizer, is access-policy-only).
- Translator: `users.roles:*` tuples target `group_resource:iam.grafana.app/rolebindings/users`.
- `user_search`: the `users.roles:read` access-control check carries `subresource="users"`. `stampAccessControl` now calls `BatchCheck` directly because the `FilterAuthorized` helper cannot carry a subresource.

Team role-bindings get the symmetric `rolebindings/teams` subresource in the companion teams PR (#125820). The `group_resource` FGA type is generic (the subresource lives in the object-id string, like `dashboards/annotations`), so **no `.fga` schema change** is needed.

### Why the union is safe (load-bearing)

Field-level escalation — promoting to `grafanaAdmin`, toggling `disabled`, editing profile vs. only the org `role` — is enforced by the iam **admission validators** (`pkg/registry/apis/iam/user/validate.go`), **independently** of this verb-level grant and regardless of whether Zanzana or legacy RBAC serves the verb check (admission runs in the API server's admission chain, not the authorizer). So the relation only decides "may you attempt this verb"; it cannot be used to escalate.

⚠️ **This admission guard is load-bearing for the safety argument — do not move that field-level logic into the authorizer.**

### Scope handling

Wildcard-only: only "all" scopes translate (`users:*`, `global.users:*`, `permissions:type:delegate`). Specific-instance scopes are dropped — the FGA `user` type is uid-based while the legacy scope is id-based (no id→uid lookup here), and `rolebindings` is wildcard-scoped by design. `users:create` is unscoped and always translates.

### Not translated

`users:enable`, `users:disable`, `users:logout`, `users.authtoken:*`, `users.password:*`, `users.quotas:*` — no iam verb maps to them (legacy HTTP endpoints only), so there's no relation to grant.

## Out of scope / notes

- These actions stay out of `SupportedActions()` / the permission-search API, consistent with role-management.
- No id→uid resolution; no `.fga` schema changes; no rollout-map / feature-flag changes (routing `iam.grafana.app/users` to Zanzana is a separate operational step).
- The symmetric `rolebindings/teams` subresource + the core team actions are in the companion teams PR (#125820). The plain-entry removal lives here, so the two PRs are independent and safe to merge in any order.
- Slight deviation from strict per-endpoint parity (e.g. a `users:delete`-only role can single-delete via iam) — with no field escalation and tenant-scoped deletes, it's a parity nit, not a security issue.

## Tests

Table-driven coverage in `tuple_helpers_test.go`: global users-writer set, org-admin (`org.users:*`) set, global↔org dedup, rolebindings/users, no-iam-verb drops, scoped drops, folder+user combination, and the full per-action mapping. A mapper test asserts `rolebindings/users` → `users.roles:*` and that plain `rolebindings` no longer resolves. A `user_search` test asserts the `users.roles:read` check carries `subresource="users"`.

```
go test ./pkg/services/authz/zanzana/... ./pkg/services/authz/rbac/... ./pkg/registry/apis/iam/...
```

And verified using a manual test that enabled the mt-reconciler:
```
zanzana=# SELECT object_id, relation, _user
zanzana-#   FROM tuple
zanzana-#   WHERE object_id IN ('iam.grafana.app/users', 'iam.grafana.app/rolebindings/users')
zanzana-#   ORDER BY object_id, relation, _user;
            object_id            |    relation     |                      _user
---------------------------------+-----------------+-------------------------------------------------
 iam.grafana.app/rolebindings/users | create       | role:basic_admin#assignee
 iam.grafana.app/rolebindings/users | create       | role:fixed_W5aFaw8isAM27x_eWfElBhZ0iOc#assignee
 iam.grafana.app/rolebindings/users | delete       | role:basic_admin#assignee
 iam.grafana.app/rolebindings/users | delete       | role:fixed_W5aFaw8isAM27x_eWfElBhZ0iOc#assignee
 iam.grafana.app/rolebindings/users | get          | role:basic_admin#assignee
 iam.grafana.app/rolebindings/users | get          | role:fixed_GkfG-1NSwEGb4hpK3-E3qHyNltc#assignee
 iam.grafana.app/rolebindings/users | get          | role:fixed_W5aFaw8isAM27x_eWfElBhZ0iOc#assignee
 iam.grafana.app/rolebindings/users | update       | role:basic_admin#assignee
 iam.grafana.app/rolebindings/users | update       | role:fixed_W5aFaw8isAM27x_eWfElBhZ0iOc#assignee
 iam.grafana.app/users        | create          | role:basic_admin#assignee
 iam.grafana.app/users        | create          | role:fixed_VERj5nayasjgf_Yh0sWqqCkxWlw#assignee
 iam.grafana.app/users        | delete          | role:basic_admin#assignee
 iam.grafana.app/users        | get             | role:basic_admin#assignee
 iam.grafana.app/users        | get_permissions | role:basic_admin#assignee
 iam.grafana.app/users        | set_permissions | role:fixed_wjzgHHo_Ux25DJuELn_oiAdB_yM#assignee
 iam.grafana.app/users        | update          | role:basic_admin#assignee
 ...
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
