### PR TITLE
Zanzana: Translate team-management RBAC actions to tuples

### DIFF
--- a/pkg/registry/apis/iam/team_search.go
+++ b/pkg/registry/apis/iam/team_search.go
@@ -10,7 +10,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/grafana/authlib/authz"
 	authlib "github.com/grafana/authlib/types"
 	"go.opentelemetry.io/otel/trace"
 	"golang.org/x/sync/errgroup"
@@ -44,11 +43,12 @@ const maxIDFilterValues = 100
 // The RBAC authz server translates Group/Resource/Verb through the mapper
 // to resolve the underlying RBAC action.
 type teamAccessControlCheck struct {
-	action   string // legacy RBAC action name returned to callers
-	group    string
-	resource string
-	verb     string
-	name     string // team UID of the resource being checked
+	action      string // legacy RBAC action name returned to callers
+	group       string
+	resource    string
+	subresource string
+	verb        string
+	name        string // team UID of the resource being checked
 }
 
 var teamAccessControlChecks = []teamAccessControlCheck{
@@ -57,7 +57,9 @@ var teamAccessControlChecks = []teamAccessControlCheck{
 	{action: "teams:delete", group: iamv0alpha1.GROUP, resource: "teams", verb: utils.VerbDelete},
 	{action: "teams.permissions:read", group: iamv0alpha1.GROUP, resource: "teams", verb: utils.VerbGetPermissions},
 	{action: "teams.permissions:write", group: iamv0alpha1.GROUP, resource: "teams", verb: utils.VerbSetPermissions},
-	{action: "teams.roles:read", group: iamv0alpha1.GROUP, resource: "rolebindings", verb: utils.VerbList},
+	// Team role-bindings are the "teams" subresource of rolebindings so the check
+	// resolves to teams.roles:read rather than users.roles:read.
+	{action: "teams.roles:read", group: iamv0alpha1.GROUP, resource: "rolebindings", subresource: "teams", verb: utils.VerbList},
 }
 
 type TeamSearchHandler struct {
@@ -428,42 +430,62 @@ func (s *TeamSearchHandler) DoTeamSearch(w http.ResponseWriter, r *http.Request)
 }
 
 func (s *TeamSearchHandler) stampAccessControl(ctx context.Context, requester identity.Requester, hits []iamv0alpha1.GetSearchTeamsTeamHit) error {
+	if len(hits) == 0 {
+		return nil
+	}
+
+	ctx, span := s.tracer.Start(ctx, "team.search.stampAccessControl")
+	defer span.End()
+
 	namespace := requester.GetNamespace()
 
-	items := func(yield func(teamAccessControlCheck) bool) {
-		for _, hit := range hits {
-			for _, c := range teamAccessControlChecks {
-				c.name = hit.Name
-				if !yield(c) {
-					return
-				}
+	// Build one batch-check item per (hit, access-control check). We call BatchCheck
+	// directly rather than authz.FilterAuthorized because the latter's convenience item
+	// type cannot carry a subresource, which teams.roles:read needs to resolve to the
+	// rolebindings "teams" subresource. CorrelationID encodes the hit index and action
+	// so results map back to the originating hit.
+	checks := make([]authlib.BatchCheckItem, 0, len(hits)*len(teamAccessControlChecks))
+	for i, hit := range hits {
+		for _, c := range teamAccessControlChecks {
+			checks = append(checks, authlib.BatchCheckItem{
+				CorrelationID: fmt.Sprintf("%d|%s", i, c.action),
+				Verb:          c.verb,
+				Group:         c.group,
+				Resource:      c.resource,
+				Subresource:   c.subresource,
+				Name:          hit.Name,
+			})
+		}
+	}
+
+	allowed := make(map[string]bool, len(checks))
+	for start := 0; start < len(checks); start += authlib.MaxBatchCheckItems {
+		end := min(start+authlib.MaxBatchCheckItems, len(checks))
+		resp, err := s.accessClient.BatchCheck(ctx, requester, authlib.BatchCheckRequest{
+			Namespace: namespace,
+			Checks:    checks[start:end],
+		})
+		if err != nil {
+			return fmt.Errorf("access control check failed: %w", err)
+		}
+		for id, res := range resp.Results {
+			if res.Allowed {
+				allowed[id] = true
 			}
 		}
 	}
 
-	extractFn := func(c teamAccessControlCheck) authz.BatchCheckItem {
-		return authz.BatchCheckItem{
-			Verb:      c.verb,
-			Group:     c.group,
-			Resource:  c.resource,
-			Namespace: namespace,
-			Name:      c.name,
-		}
-	}
-
-	acMap := make(map[string]map[string]bool, len(hits))
-	for c, err := range authz.FilterAuthorized(ctx, s.accessClient, items, extractFn, authz.WithTracer(s.tracer)) {
-		if err != nil {
-			return fmt.Errorf("access control check failed: %w", err)
-		}
-		if acMap[c.name] == nil {
-			acMap[c.name] = make(map[string]bool, len(teamAccessControlChecks))
-		}
-		acMap[c.name][c.action] = true
-	}
-
 	for i := range hits {
-		hits[i].AccessControl = acMap[hits[i].Name]
+		var acMap map[string]bool
+		for _, c := range teamAccessControlChecks {
+			if allowed[fmt.Sprintf("%d|%s", i, c.action)] {
+				if acMap == nil {
+					acMap = make(map[string]bool, len(teamAccessControlChecks))
+				}
+				acMap[c.action] = true
+			}
+		}
+		hits[i].AccessControl = acMap
 	}
 
 	return nil

--- a/pkg/registry/apis/iam/team_search_test.go
+++ b/pkg/registry/apis/iam/team_search_test.go
@@ -20,6 +20,7 @@ import (
 
 	iamv0alpha1 "github.com/grafana/grafana/apps/iam/pkg/apis/iam/v0alpha1"
 	"github.com/grafana/grafana/pkg/apimachinery/identity"
+	"github.com/grafana/grafana/pkg/apimachinery/utils"
 	"github.com/grafana/grafana/pkg/apiserver/rest"
 	"github.com/grafana/grafana/pkg/infra/log"
 	"github.com/grafana/grafana/pkg/infra/tracing"
@@ -442,6 +443,48 @@ func TestTeamAccessControl(t *testing.T) {
 			tc.checkHits(t, resp.Hits)
 		})
 	}
+}
+
+// TestTeamAccessControlSubresource verifies that the teams.roles:read check is issued
+// against the rolebindings "teams" subresource (so it resolves to teams.roles:read, not
+// users.roles:read), while the core team checks carry no subresource.
+func TestTeamAccessControlSubresource(t *testing.T) {
+	var got []authlib.BatchCheckItem
+	recordingClient := &mockTeamAccessClient{
+		batchCheckFunc: func(_ context.Context, _ authlib.AuthInfo, req authlib.BatchCheckRequest) (authlib.BatchCheckResponse, error) {
+			got = append(got, req.Checks...)
+			return authlib.BatchCheckResponse{}, nil
+		},
+	}
+
+	searchHandler := &TeamSearchHandler{
+		log:          log.New("grafana-apiserver.teams.search"),
+		client:       mockTeamClientWithHits(),
+		tracer:       tracing.NewNoopTracerService(),
+		features:     featuremgmt.WithFeatures(),
+		accessClient: recordingClient,
+	}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/teams/search?accesscontrol=true", nil)
+	req.Header.Add("content-type", "application/json")
+	req = req.WithContext(identity.WithRequester(req.Context(), &user.SignedInUser{Namespace: "default"}))
+
+	searchHandler.DoTeamSearch(rr, req)
+	require.Equal(t, 200, rr.Code)
+
+	var sawTeamRoles bool
+	for _, c := range got {
+		if c.Resource == "rolebindings" {
+			sawTeamRoles = true
+			assert.Equal(t, "teams", c.Subresource, "team role-bindings must be checked via the teams subresource")
+			assert.Equal(t, utils.VerbList, c.Verb)
+		} else {
+			assert.Equal(t, "teams", c.Resource)
+			assert.Empty(t, c.Subresource, "core team checks must not carry a subresource")
+		}
+	}
+	assert.True(t, sawTeamRoles, "expected a teams.roles:read check against rolebindings")
 }
 
 func TestTeamSearchMemberCount(t *testing.T) {

--- a/pkg/services/authz/rbac/mapper.go
+++ b/pkg/services/authz/rbac/mapper.go
@@ -371,6 +371,26 @@ func NewMapperRegistry() MapperRegistry {
 				},
 				folderSupport: false,
 			},
+			// Team role-bindings are the same rolebindings resource with a Team
+			// subject. They are addressed as the "teams" subresource so they map to
+			// the teams.roles:* actions instead of users.roles:*, keeping team and
+			// user role-binding access distinct.
+			"rolebindings/teams": translation{
+				resource: "rolebindings",
+				// rolebindings should only be modifiable by admins with a wildcard access
+				useWildcardScope: true,
+				verbMapping: map[string]string{
+					utils.VerbCreate:           "teams.roles:add",
+					utils.VerbGet:              "teams.roles:read",
+					utils.VerbUpdate:           "teams.roles:add",
+					utils.VerbPatch:            "teams.roles:add",
+					utils.VerbDelete:           "teams.roles:remove",
+					utils.VerbDeleteCollection: "teams.roles:remove",
+					utils.VerbList:             "teams.roles:read",
+					utils.VerbWatch:            "teams.roles:read",
+				},
+				folderSupport: false,
+			},
 		},
 		"provisioning.grafana.app": {
 			"repositories": newResourceTranslation("provisioning.repositories", "uid", false, skipScopeOnAllVerbs),

--- a/pkg/services/authz/rbac/mapper_test.go
+++ b/pkg/services/authz/rbac/mapper_test.go
@@ -197,6 +197,42 @@ func TestMapperRegistry_SubresourceLookup(t *testing.T) {
 	})
 }
 
+// TestMapperRegistry_RoleBindingsTeamsSubresource verifies the real mapper routes the
+// iam.grafana.app rolebindings "teams" subresource to teams.roles:* actions, while the
+// plain rolebindings resource stays on the users.roles:* family.
+func TestMapperRegistry_RoleBindingsTeamsSubresource(t *testing.T) {
+	reg := NewMapperRegistry()
+
+	cases := []struct {
+		verb        string
+		teamsAction string
+		usersAction string
+	}{
+		{utils.VerbGet, "teams.roles:read", "users.roles:read"},
+		{utils.VerbList, "teams.roles:read", "users.roles:read"},
+		{utils.VerbCreate, "teams.roles:add", "users.roles:add"},
+		{utils.VerbUpdate, "teams.roles:add", "users.roles:add"},
+		{utils.VerbDelete, "teams.roles:remove", "users.roles:remove"},
+		{utils.VerbDeleteCollection, "teams.roles:remove", "users.roles:remove"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.verb, func(t *testing.T) {
+			teamsMapping, ok := reg.Get("iam.grafana.app", "rolebindings", "teams")
+			require.True(t, ok)
+			action, ok := teamsMapping.Action(tc.verb)
+			assert.True(t, ok)
+			assert.Equal(t, tc.teamsAction, action)
+
+			usersMapping, ok := reg.Get("iam.grafana.app", "rolebindings", "")
+			require.True(t, ok)
+			action, ok = usersMapping.Action(tc.verb)
+			assert.True(t, ok)
+			assert.Equal(t, tc.usersAction, action)
+		})
+	}
+}
+
 // TestMapper_ServiceAccountTranslation_ActionSets verifies that service account verbs map to the
 // correct action sets. There is no View level — Edit verbs map to both edit+admin, and admin-only
 // verbs (delete, permissions) map to admin only.

--- a/pkg/services/authz/zanzana/tuple_helpers.go
+++ b/pkg/services/authz/zanzana/tuple_helpers.go
@@ -43,6 +43,61 @@ const (
 	scopeIdentifierWildcard = "*"
 )
 
+// Team-management actions. Hardcoded for the same reason as the role-management
+// actions above: the enterprise-only teams.roles:* actions live in pkg/extensions
+// and these shared helpers must not depend on it.
+const (
+	actionTeamsCreate = "teams:create"
+	actionTeamsRead   = "teams:read"
+	actionTeamsWrite  = "teams:write"
+	actionTeamsDelete = "teams:delete"
+
+	actionTeamsPermissionsRead  = "teams.permissions:read"
+	actionTeamsPermissionsWrite = "teams.permissions:write"
+
+	actionTeamsRolesRead   = "teams.roles:read"
+	actionTeamsRolesAdd    = "teams.roles:add"
+	actionTeamsRolesRemove = "teams.roles:remove"
+)
+
+// roleBindingsTeamsSubresource addresses team role-bindings (a RoleBinding with a Team
+// subject) as a subresource of the shared rolebindings resource, keeping them distinct
+// from user role-bindings (plain rolebindings). See pkg/services/authz/rbac/mapper.go.
+const roleBindingsTeamsSubresource = "teams"
+
+// iam.grafana.app group and the resources team-management actions gate.
+var (
+	iamGroup             = iamv0.TeamResourceInfo.GroupResource().Group
+	teamsResource        = iamv0.TeamResourceInfo.GroupResource().Resource
+	roleBindingsResource = iamv0.RoleBindingInfo.GroupResource().Resource
+)
+
+type teamActionMapping struct {
+	resource    string
+	subresource string
+	relations   []string
+	// skipScope marks actions the mapper authorizes without a scope (create verbs).
+	skipScope bool
+}
+
+// teamManagementMappings maps each team-management action to the relation(s) it gates,
+// inverting the iam "teams" and "rolebindings/teams" entries of the K8s mapper. Core
+// team actions target group_resource:iam.grafana.app/teams; team role-assignment actions
+// target the rolebindings "teams" subresource.
+var teamManagementMappings = map[string]teamActionMapping{
+	actionTeamsRead:   {resource: teamsResource, relations: []string{RelationGet}},
+	actionTeamsWrite:  {resource: teamsResource, relations: []string{RelationUpdate}},
+	actionTeamsCreate: {resource: teamsResource, relations: []string{RelationCreate}, skipScope: true},
+	actionTeamsDelete: {resource: teamsResource, relations: []string{RelationDelete}},
+
+	actionTeamsPermissionsRead:  {resource: teamsResource, relations: []string{RelationGetPermissions}},
+	actionTeamsPermissionsWrite: {resource: teamsResource, relations: []string{RelationSetPermissions}},
+
+	actionTeamsRolesRead:   {resource: roleBindingsResource, subresource: roleBindingsTeamsSubresource, relations: []string{RelationGet}},
+	actionTeamsRolesAdd:    {resource: roleBindingsResource, subresource: roleBindingsTeamsSubresource, relations: []string{RelationCreate, RelationUpdate}},
+	actionTeamsRolesRemove: {resource: roleBindingsResource, subresource: roleBindingsTeamsSubresource, relations: []string{RelationDelete}},
+}
+
 // TupleStringWithoutCondition returns the string representation of a tuple without its condition.
 // This is useful for deduplicating tuples that have the same user, relation, and object
 // but different conditions that need to be merged.
@@ -89,6 +144,15 @@ func ConvertRolePermissionsToTuples(roleUID string, permissions []RolePermission
 		// actions are intentionally dropped (see RoleManagementToTuples).
 		if isRoleManagementAction(perm.Action) {
 			for _, t := range RoleManagementToTuples(subject, perm) {
+				tupleMap[t.String()] = t
+			}
+			continue
+		}
+
+		// Team-management actions map onto iam group_resources via a dedicated path,
+		// like the role-management actions above (see TeamManagementToTuples).
+		if isTeamManagementAction(perm.Action) {
+			for _, t := range TeamManagementToTuples(subject, perm) {
 				tupleMap[t.String()] = t
 			}
 			continue
@@ -236,6 +300,50 @@ func isRolesWildcardScope(kind, identifier string) bool {
 		return true
 	}
 	return false
+}
+
+// TeamManagementToTuples translates a team-management permission into iam tuples.
+// Core team actions (teams:*) target group_resource:iam.grafana.app/teams; team
+// role-assignment actions (teams.roles:*) target the rolebindings "teams" subresource so
+// they stay distinct from user role-bindings. Only "all" scopes translate (see
+// isAllTeamsScope); specific-instance scopes are dropped, since the FGA teams type is
+// uid-based while the legacy scope is id-based. teams:create is unscoped and always
+// translates.
+func TeamManagementToTuples(subject string, permission RolePermission) []*openfgav1.TupleKey {
+	m, ok := teamManagementMappings[permission.Action]
+	if !ok {
+		return nil
+	}
+
+	if !m.skipScope && !isAllTeamsScope(permission.Kind, permission.Identifier) {
+		return nil
+	}
+
+	tuples := make([]*openfgav1.TupleKey, 0, len(m.relations))
+	for _, relation := range m.relations {
+		tuples = append(tuples, NewGroupResourceTuple(subject, relation, iamGroup, m.resource, m.subresource))
+	}
+	return tuples
+}
+
+// isTeamManagementAction reports whether the action is one of the team-management
+// actions handled by TeamManagementToTuples.
+func isTeamManagementAction(action string) bool {
+	_, ok := teamManagementMappings[action]
+	return ok
+}
+
+// isAllTeamsScope reports whether the (kind, identifier) pair represents an "all" scope
+// for the team-management actions. The legacy shapes that appear are:
+//   - teams:* / teams:id:*      → identifier="*" (teams:read/write/delete, teams.permissions:*, teams.roles:read)
+//   - permissions:type:delegate → kind="permissions", identifier="delegate" (teams.roles:add/remove)
+//
+// Specific instance scopes (e.g. teams:id:5) match none of these and are dropped.
+func isAllTeamsScope(kind, identifier string) bool {
+	if identifier == scopeIdentifierWildcard {
+		return true
+	}
+	return kind == scopeKindPermissions && identifier == scopeIdentifierDelegate
 }
 
 func splitScope(scope string) (string, string, string) {

--- a/pkg/services/authz/zanzana/tuple_helpers_test.go
+++ b/pkg/services/authz/zanzana/tuple_helpers_test.go
@@ -181,6 +181,138 @@ func TestConvertRolePermissionsToTuples(t *testing.T) {
 		require.NoError(t, err)
 		require.Empty(t, tuples)
 	})
+
+	t.Run("should reconcile team-management permissions", func(t *testing.T) {
+		// A role that can fully manage teams: read/write/create/delete plus team
+		// permissions. Each maps to a single relation on the iam.grafana.app/teams
+		// group_resource.
+		permissions := []RolePermission{
+			{Action: "teams:read", Kind: "teams", Identifier: "*"},
+			{Action: "teams:write", Kind: "teams", Identifier: "*"},
+			{Action: "teams:create", Kind: "", Identifier: ""},
+			{Action: "teams:delete", Kind: "teams", Identifier: "*"},
+			{Action: "teams.permissions:read", Kind: "teams", Identifier: "*"},
+			{Action: "teams.permissions:write", Kind: "teams", Identifier: "*"},
+		}
+
+		tuples, err := ConvertRolePermissionsToTuples("role-team-admin", permissions)
+		require.NoError(t, err)
+
+		require.ElementsMatch(t, tupleKeyStrings([]*openfgav1.TupleKey{
+			{User: "role:role-team-admin#assignee", Relation: "get", Object: "group_resource:iam.grafana.app/teams"},
+			{User: "role:role-team-admin#assignee", Relation: "update", Object: "group_resource:iam.grafana.app/teams"},
+			{User: "role:role-team-admin#assignee", Relation: "create", Object: "group_resource:iam.grafana.app/teams"},
+			{User: "role:role-team-admin#assignee", Relation: "delete", Object: "group_resource:iam.grafana.app/teams"},
+			{User: "role:role-team-admin#assignee", Relation: "get_permissions", Object: "group_resource:iam.grafana.app/teams"},
+			{User: "role:role-team-admin#assignee", Relation: "set_permissions", Object: "group_resource:iam.grafana.app/teams"},
+		}), tupleKeyStrings(tuples))
+	})
+
+	t.Run("should reconcile team role-assignment permissions to the rolebindings teams subresource", func(t *testing.T) {
+		// teams.roles:* gate team role-bindings, which are addressed as the
+		// "teams" subresource of rolebindings so they stay distinct from user
+		// role-bindings (plain rolebindings).
+		permissions := []RolePermission{
+			{Action: "teams.roles:read", Kind: "teams", Identifier: "*"},
+			{Action: "teams.roles:add", Kind: "permissions", Identifier: "delegate"},
+			{Action: "teams.roles:remove", Kind: "permissions", Identifier: "delegate"},
+		}
+
+		tuples, err := ConvertRolePermissionsToTuples("role-team-roles", permissions)
+		require.NoError(t, err)
+
+		require.ElementsMatch(t, tupleKeyStrings([]*openfgav1.TupleKey{
+			{User: "role:role-team-roles#assignee", Relation: "get", Object: "group_resource:iam.grafana.app/rolebindings/teams"},
+			{User: "role:role-team-roles#assignee", Relation: "create", Object: "group_resource:iam.grafana.app/rolebindings/teams"},
+			{User: "role:role-team-roles#assignee", Relation: "update", Object: "group_resource:iam.grafana.app/rolebindings/teams"},
+			{User: "role:role-team-roles#assignee", Relation: "delete", Object: "group_resource:iam.grafana.app/rolebindings/teams"},
+		}), tupleKeyStrings(tuples))
+	})
+
+	t.Run("scoped team-management permissions are dropped", func(t *testing.T) {
+		// Specific-team scopes (teams:id:<n>) cannot be expressed: the FGA teams
+		// type is uid-based while the legacy scope is id-based, so they are dropped.
+		// teams:create is exempt because the mapper authorizes it without a scope.
+		permissions := []RolePermission{
+			{Action: "teams:read", Kind: "teams", Identifier: "5"},
+			{Action: "teams:write", Kind: "teams", Identifier: "5"},
+			{Action: "teams.permissions:write", Kind: "teams", Identifier: "5"},
+			{Action: "teams.roles:read", Kind: "teams", Identifier: "5"},
+		}
+
+		tuples, err := ConvertRolePermissionsToTuples("role-team-scoped", permissions)
+		require.NoError(t, err)
+		require.Empty(t, tuples)
+	})
+}
+
+func TestTeamManagementToTuples(t *testing.T) {
+	const subject = "role:role-1#assignee"
+	const teamsObject = "group_resource:iam.grafana.app/teams"
+	const teamRoleBindingsObject = "group_resource:iam.grafana.app/rolebindings/teams"
+
+	t.Run("maps each action to its tuples under an all-scope", func(t *testing.T) {
+		cases := []struct {
+			action     string
+			kind       string
+			identifier string
+			expected   []*openfgav1.TupleKey
+		}{
+			{"teams:read", "teams", "*", []*openfgav1.TupleKey{
+				{User: subject, Relation: "get", Object: teamsObject},
+			}},
+			{"teams:write", "teams", "*", []*openfgav1.TupleKey{
+				{User: subject, Relation: "update", Object: teamsObject},
+			}},
+			{"teams:create", "", "", []*openfgav1.TupleKey{
+				{User: subject, Relation: "create", Object: teamsObject},
+			}},
+			{"teams:delete", "teams", "*", []*openfgav1.TupleKey{
+				{User: subject, Relation: "delete", Object: teamsObject},
+			}},
+			{"teams.permissions:read", "teams", "*", []*openfgav1.TupleKey{
+				{User: subject, Relation: "get_permissions", Object: teamsObject},
+			}},
+			{"teams.permissions:write", "teams", "*", []*openfgav1.TupleKey{
+				{User: subject, Relation: "set_permissions", Object: teamsObject},
+			}},
+			{"teams.roles:read", "teams", "*", []*openfgav1.TupleKey{
+				{User: subject, Relation: "get", Object: teamRoleBindingsObject},
+			}},
+			{"teams.roles:add", "permissions", "delegate", []*openfgav1.TupleKey{
+				{User: subject, Relation: "create", Object: teamRoleBindingsObject},
+				{User: subject, Relation: "update", Object: teamRoleBindingsObject},
+			}},
+			{"teams.roles:remove", "permissions", "delegate", []*openfgav1.TupleKey{
+				{User: subject, Relation: "delete", Object: teamRoleBindingsObject},
+			}},
+		}
+
+		for _, tc := range cases {
+			t.Run(tc.action, func(t *testing.T) {
+				tuples := TeamManagementToTuples(subject, RolePermission{
+					Action: tc.action, Kind: tc.kind, Identifier: tc.identifier,
+				})
+				require.ElementsMatch(t, tupleKeyStrings(tc.expected), tupleKeyStrings(tuples))
+			})
+		}
+	})
+
+	t.Run("drops specific-instance scopes (except create)", func(t *testing.T) {
+		require.Nil(t, TeamManagementToTuples(subject, RolePermission{Action: "teams:read", Kind: "teams", Identifier: "5"}))
+		require.Nil(t, TeamManagementToTuples(subject, RolePermission{Action: "teams.roles:add", Kind: "teams", Identifier: "5"}))
+
+		// create is unscoped and always translates.
+		require.ElementsMatch(t,
+			tupleKeyStrings([]*openfgav1.TupleKey{{User: subject, Relation: "create", Object: teamsObject}}),
+			tupleKeyStrings(TeamManagementToTuples(subject, RolePermission{Action: "teams:create", Kind: "teams", Identifier: "5"})),
+		)
+	})
+
+	t.Run("returns nil for non-team actions", func(t *testing.T) {
+		require.Nil(t, TeamManagementToTuples(subject, RolePermission{Action: "users:read", Kind: "users", Identifier: "*"}))
+		require.Nil(t, TeamManagementToTuples(subject, RolePermission{Action: "teams:enable", Kind: "teams", Identifier: "*"}))
+	})
 }
 
 // tupleKeyStrings returns the prototext (`.String()`) form of each tuple.

--- a/pkg/services/authz/zanzana/zanzana.go
+++ b/pkg/services/authz/zanzana/zanzana.go
@@ -34,6 +34,9 @@ const (
 	RelationCreate = common.RelationCreate
 	RelationDelete = common.RelationDelete
 
+	RelationGetPermissions = common.RelationGetPermissions
+	RelationSetPermissions = common.RelationSetPermissions
+
 	RelationSubresourceSetView  = common.RelationSubresourceSetView
 	RelationSubresourceSetEdit  = common.RelationSubresourceSetEdit
 	RelationSubresourceSetAdmin = common.RelationSubresourceSetAdmin


### PR DESCRIPTION
## What

Teaches the RBAC→Zanzana reconciler to translate **team-management** permissions, which were previously dropped silently.

### Core team actions → `group_resource:iam.grafana.app/teams`
`teams:read/write/create/delete` and `teams.permissions:read/write` map 1:1 to the `get/update/create/delete/get_permissions/set_permissions` relations, inverting the mapper's `teams` entry. Roles such as Org Admin (`teams:read`), Editor (`teams:create`), Grafana Admin (`teams.permissions:read`), and managed team-admin/member now produce tuples.

### Team role assignments → `rolebindings/teams` subresource
A team role-binding is the **shared** `rolebindings` resource with a `Team` subject, and the mapper otherwise maps every `rolebindings` verb to `users.roles:*`. To avoid `teams.roles:*` aliasing **user** role-bindings, team role-bindings are addressed as the **`teams` subresource**: `group_resource:iam.grafana.app/rolebindings/teams`.

- Mapper: new `iam.grafana.app → rolebindings/teams` entry → `teams.roles:*`.
- `team_search`: the `teams.roles:read` access-control check now carries `subresource="teams"`, so it resolves to `teams.roles:read` (it previously resolved to `users.roles:read` — a latent bug). `stampAccessControl` now calls `BatchCheck` directly because the `FilterAuthorized` helper cannot carry a subresource.
- Translator: `teams.roles:read→get`, `teams.roles:add→create+update`, `teams.roles:remove→delete` on `rolebindings/teams`.

### Notes
- Wildcard-only scope: specific-team scopes (`teams:id:<n>`) are dropped (the FGA `teams` type is uid-based, the legacy scope id-based, no id→uid lookup); `teams:create` is unscoped.
- No `.fga` schema change — `group_resource` is generic and already has the needed relations (same pattern as `dashboards/annotations`).
- Team role-binding **mutations** via Zanzana are future work: the generic k8s rolebindings authorizer is access-policy-only and can't see `subject.kind` at authz time. The `create/update/delete` relations on `rolebindings/teams` are provisioned ahead of that.

## Coordination
- The symmetric `rolebindings/users` subresource lives in #125818 (users), which also owns removing the plain `rolebindings` mapper entry. That removal is intentionally **not** in this PR, so the two are independent and safe to merge in any order.
- Branched from `main`; expect a trivial conflict with #125818 on shared scaffolding (`iamGroup`, the `RelationGetPermissions/SetPermissions` re-exports) — resolved by rebasing whichever merges second.

## Tests
- New translator table tests (`TestTeamManagementToTuples`) + reconciler subtests.
- New mapper test (`TestMapperRegistry_RoleBindingsTeamsSubresource`).
- New `team_search` test asserting the `teams.roles:read` check carries `subresource="teams"`; existing `TestTeamAccessControl` still passes.
- `gofmt`/`go vet` clean. (`TestGetOrCreateStore_FullFlow` fails on clean `main` too — needs an OpenFGA datastore, unrelated.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
