### PR TITLE
CI: fix changelog and release-pr workflows

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -18,18 +18,11 @@ jobs:
   bump-version:
     runs-on: ubuntu-arm64-small
     permissions:
-      id-token: write
-      contents: read
+      contents: write
+      pull-requests: write
     steps:
-      - name: Get GitHub App token
-        id: get-github-app-token
-        uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
-        with:
-          github_app: grafana-delivery-bot
       - name: Checkout Grafana
         uses: actions/checkout@v5
-        with:
-          token: ${{ steps.get-github-app-token.outputs.token }}
       - name: Update package.json versions
         uses: ./pkg/build/actions/bump-version
         with:
@@ -41,13 +34,13 @@ jobs:
           DRY_RUN: ${{ inputs.dry_run }}
           REF_NAME: ${{ github.ref_name }}
           RUN_ID: ${{ github.run_id }}
-          GH_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          git config --local user.name "grafana-delivery-bot[bot]"
-          git config --local user.email "grafana-delivery-bot[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local --add --bool push.autoSetupRemote true
           git checkout -b "bump-version/${RUN_ID}/${VERSION}"
           git add .
           git commit -m "bump version ${VERSION}"
           git push
-          gh pr create --dry-run="$DRY_RUN" -l "type/ci" -l "no-changelog" -B "$REF_NAME" --title "Release: Bump version to ${VERSION}" --body "Updated version to ${VERSION}"
+          gh pr create --dry-run="$DRY_RUN" -l "type/ci" -l "no-changelog" --draft -B "$REF_NAME" --title "Release: Bump version to ${VERSION}" --body "Updated version to ${VERSION}"

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -74,7 +74,7 @@ jobs:
         id: get-github-app-token
         uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
         with:
-          github_app: grafana-delivery-bot
+          github_app: grafana-releases-oss
       - name: "Checkout Grafana repo"
         uses: "actions/checkout@v5"
         with:

--- a/.github/workflows/release-pr.yml
+++ b/.github/workflows/release-pr.yml
@@ -112,14 +112,14 @@ jobs:
       - name: Checkout Grafana
         uses: actions/checkout@v5
         with:
-          token: ${{ steps.get-github-app-token.outputs.token }}
+          token: ${{ github.token }}
           ref: ${{ env.RELEASE_BRANCH }}
           fetch-tags: true
           fetch-depth: 0
       - name: Checkout Grafana (main)
         uses: actions/checkout@v5
         with:
-          token: ${{ steps.get-github-app-token.outputs.token }}
+          token: ${{ github.token }}
           ref: main
           fetch-depth: '0'
           path: .grafana-main
@@ -138,8 +138,8 @@ jobs:
           cache: false
       - name: Configure git user
         run: |
-          git config --local user.name "grafana-releases-oss[bot]"
-          git config --local user.email "grafana-releases-oss[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local --add --bool push.autoSetupRemote true
 
       - name: Create branch
@@ -215,7 +215,7 @@ jobs:
         run: git push
       - name: Create PR
         env:
-          GH_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
+          GH_TOKEN: ${{ github.token }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
           LATEST_FLAG=()
@@ -225,6 +225,7 @@ jobs:
           gh pr create \
             "${LATEST_FLAG[@]}" \
             -l "no-changelog" \
+            --draft \
             --dry-run="$DRY_RUN" \
             -B "${RELEASE_BRANCH}" \
             --title "Release: $VERSION" \


### PR DESCRIPTION
these are using grafana-delivery-bot instead of grafana-releases-oss and the default token.