### PR TITLE
Navigation: Remove Home nav item, make logo a working home link in all menu states

### DIFF
--- a/e2e-playwright/various-suite/bookmarks.spec.ts
+++ b/e2e-playwright/various-suite/bookmarks.spec.ts
@@ -24,7 +24,7 @@ test.describe(
       await expect(navList).toBeVisible();
 
       // Check if the Bookmark section is visible
-      const bookmarksItem = navList.locator('li').nth(1);
+      const bookmarksItem = navList.locator('li').nth(0);
       await expect(bookmarksItem).toBeVisible();
       await expect(bookmarksItem).toContainText('Bookmarks');
 
@@ -70,7 +70,7 @@ test.describe(
       await expect(navList).toBeVisible();
 
       // Check if the Bookmark section is visible
-      const bookmarksItem = navList.locator('li').nth(1);
+      const bookmarksItem = navList.locator('li').nth(0);
       await expect(bookmarksItem).toBeVisible();
       await expect(bookmarksItem).toContainText('Bookmarks');
 

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenu.test.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenu.test.tsx
@@ -111,6 +111,13 @@ describe('MegaMenu', () => {
     expect(screen.queryByLabelText('Profile')).not.toBeInTheDocument();
   });
 
+  it('should filter out home', async () => {
+    renderMegaMenu({ navBarTree: nestedNavTree });
+
+    expect(await screen.findByRole('link', { name: 'Section name' })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Home' })).not.toBeInTheDocument();
+  });
+
   describe('customisation', () => {
     beforeEach(() => {
       setTestFlags({ [CUSTOMISE_FLAG]: true });
@@ -179,12 +186,14 @@ describe('MegaMenu', () => {
         expect(screen.getAllByRole('link', { name: 'Administration' })).toHaveLength(1);
       });
 
-      it('places the pinned block directly below Home and above the other sections', async () => {
+      it('places the pinned block at the top, above the other sections', async () => {
         renderMegaMenu({ bookmarkUrls: ['/admin/settings'] });
 
         await screen.findByRole('list', { name: 'Pinned' });
+        // Home is reached via the logo, not listed, so the pinned block leads the menu
+        expect(screen.queryByRole('link', { name: 'Home' })).not.toBeInTheDocument();
         const names = screen.getAllByRole('link').map((el) => el.textContent);
-        expect(names.indexOf('Home')).toBeLessThan(names.indexOf('Administration'));
+        expect(names.indexOf('Administration')).toBe(0);
         expect(names.indexOf('Administration')).toBeLessThan(names.indexOf('Explore'));
       });
 
@@ -272,14 +281,27 @@ describe('MegaMenu', () => {
       });
 
       it('highlights a pinned item that matches the current page', async () => {
-        // Pin Home; the test renders at "/", so the pinned Home row is the current page
-        renderMegaMenu({ bookmarkUrls: ['/'] });
+        seedBookmarks(['/explore']);
+
+        // Current page is Explore, which is pinned, so the pinned Explore row is the current page
+        const chrome = new AppChromeService();
+        chrome.update({
+          sectionNav: { node: { id: 'explore', text: 'Explore', url: '/explore' }, main: { text: '' } },
+        });
+
+        const wrapper = getWrapper({
+          store: configureStore({ navBarTree: customisableNavTree }),
+          grafanaContext: { chrome },
+          renderWithRouter: true,
+          historyOptions: { initialEntries: ['/explore'] },
+        });
+        render(<MegaMenu onClose={() => {}} />, { wrapper });
 
         const pinned = within(await screen.findByRole('list', { name: 'Pinned' }));
-        expect(pinned.getByRole('link', { name: 'Home' })).toHaveAttribute('aria-current', 'page');
+        expect(pinned.getByRole('link', { name: 'Explore' })).toHaveAttribute('aria-current', 'page');
       });
 
-      it('highlights only the pinned row (not Home) when the active page is under a pinned section', async () => {
+      it('highlights only the matching pinned row when the active page is under a pinned section', async () => {
         seedBookmarks(['/dashboards']);
 
         // Current page is "Playlists", which lives under the (fully pinned) Dashboards section
@@ -311,20 +333,8 @@ describe('MegaMenu', () => {
 
         const pinned = within(await screen.findByRole('list', { name: 'Pinned' }));
         expect(pinned.getByRole('link', { name: 'Playlists' })).toHaveAttribute('aria-current', 'page');
-        // Home must not be highlighted just because the section was moved out of the normal nav
-        expect(screen.getByRole('link', { name: 'Home' })).not.toHaveAttribute('aria-current', 'page');
-      });
-
-      it('does not offer a pin control on Home', async () => {
-        renderMegaMenu();
-
-        await screen.findByRole('link', { name: 'Home' });
-        const labels = screen
-          .getAllByRole('button', { hidden: true })
-          .map((button) => button.getAttribute('aria-label'));
-        expect(labels).not.toContain('Pin Home');
-        // sanity: a regular item still offers it
-        expect(labels).toContain('Pin Explore');
+        // Only the matching pinned row is current — an ancestor section isn't highlighted in its place
+        expect(pinned.getByRole('link', { name: 'Dashboards' })).not.toHaveAttribute('aria-current', 'page');
       });
 
       it('does not offer a pin control on individual starred items, only the Starred section', async () => {
@@ -349,7 +359,7 @@ describe('MegaMenu', () => {
         expect(await screen.findByRole('button', { name: 'Expand section: Bookmarks' })).toBeInTheDocument();
       });
 
-      it('keeps the legacy bookmark control on Home and starred items when the flag is off', async () => {
+      it('keeps the legacy bookmark control on regular and starred items when the flag is off', async () => {
         setTestFlags({ [CUSTOMISE_FLAG]: false });
         const { user } = renderMegaMenu();
 
@@ -361,10 +371,10 @@ describe('MegaMenu', () => {
         const labels = screen
           .getAllByRole('button', { hidden: true })
           .map((button) => button.getAttribute('aria-label'));
-        expect(labels).toContain('Bookmark Home');
+        expect(labels).toContain('Bookmark Explore');
         expect(labels).toContain(`Bookmark ${STARRED_DASHBOARD.name}`);
         // ...and a bookmarked item keeps the legacy "Bookmark" tooltip, not "Unpin"
-        expect(labels).not.toContain('Unpin Home');
+        expect(labels).not.toContain('Unpin Explore');
       });
     });
 
@@ -396,8 +406,6 @@ describe('MegaMenu', () => {
         expect(
           within(screen.getByRole('list', { name: 'Pinned' })).getByRole('link', { name: 'Playlists' })
         ).toBeInTheDocument();
-        // Home stays visible above the pinned block
-        expect(screen.getByRole('link', { name: 'Home' })).toBeInTheDocument();
 
         // Expand again
         await user.click(screen.getByRole('button', { name: 'Show unpinned items' }));

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenu.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenu.tsx
@@ -37,8 +37,6 @@ export const MegaMenu = memo(
       canCustomise,
       isLoading,
       navItems,
-      homeItem,
-      unpinnedItems,
       pinnedNavItems,
       activeItem,
       isPinned,
@@ -71,10 +69,9 @@ export const MegaMenu = memo(
       />
     );
 
-    // Pinned layout: Home, then the pinned block (if any), then the collapsible rest.
+    // Pinned layout: the pinned block (if any), then the collapsible rest.
     const renderPinnedLayout = () => (
       <>
-        {homeItem && renderNavItem(homeItem)}
         {pinnedNavItems.length > 0 && (
           <>
             <li>
@@ -88,7 +85,7 @@ export const MegaMenu = memo(
         {showUnpinnedItems && (
           <li>
             <ul id={UNPINNED_ITEMS_ID} className={styles.pinnedList}>
-              {unpinnedItems.map((link) => renderNavItem(link))}
+              {navItems.map((link) => renderNavItem(link))}
             </ul>
           </li>
         )}

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuHeader.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuHeader.tsx
@@ -30,7 +30,7 @@ export function MegaMenuHeader({ handleDockedMenu, onClose }: Props) {
   return (
     <div className={styles.header}>
       <Stack alignItems="center" minWidth={0} gap={1}>
-        <HomeLink homeNav={homeNav} inMegaMenuOverlay={!state.megaMenuDocked} />
+        <HomeLink homeNav={homeNav} onClick={state.megaMenuDocked ? undefined : onClose} />
         <OrganizationSwitcher />
       </Stack>
       <div className={styles.flexGrow} />

--- a/public/app/core/components/AppChrome/MegaMenu/__mocks__/fixtures.ts
+++ b/public/app/core/components/AppChrome/MegaMenu/__mocks__/fixtures.ts
@@ -2,7 +2,7 @@ import { type NavModelItem } from '@grafana/data';
 
 // Shared nav-tree fixtures for the mega menu tests.
 
-/** A small nested tree (with a profile item to assert filtering) for the non-customisation tests. */
+/** A small nested tree (with profile and home items to assert filtering) for the non-customisation tests. */
 export const nestedNavTree: NavModelItem[] = [
   {
     text: 'Section name',
@@ -23,6 +23,7 @@ export const nestedNavTree: NavModelItem[] = [
     id: 'profile',
     url: 'profile',
   },
+  { text: 'Home', id: 'home', url: '/' },
 ];
 
 /** The full tree the customisation tests render: pinnable sections, Starred, and the Bookmarks section. */

--- a/public/app/core/components/AppChrome/MegaMenu/hooks.ts
+++ b/public/app/core/components/AppChrome/MegaMenu/hooks.ts
@@ -166,8 +166,8 @@ export const useNavCustomization = () => {
 
   // Resolve the active item across the pinned rows and the rest in one search. A pinned section is
   // moved out of `navItems`, so searching `navItems` alone would fail to find it and walk up the
-  // parent chain to wrongly highlight Home; searching the combined list finds the (rendered) pinned
-  // node and stops there. Reference equality then highlights whichever row actually renders.
+  // parent chain to wrongly highlight an ancestor section; searching the combined list finds the
+  // (rendered) pinned node and stops there. Reference equality then highlights whichever row renders.
   const activeItem = getActiveItem([...pinnedNavItems, ...navItems], state.sectionNav.node, location.pathname);
 
   const isPinned = useCallback((url?: string) => Boolean(url && pinnedUrls.includes(url)), [pinnedUrls]);

--- a/public/app/core/components/AppChrome/MegaMenu/hooks.ts
+++ b/public/app/core/components/AppChrome/MegaMenu/hooks.ts
@@ -127,7 +127,7 @@ export const useNavCustomization = () => {
   // Base tree without the items the mega menu never lists directly. When customisation is on, the
   // dedicated Bookmarks section is also dropped — pinned items are re-presented at the top.
   const baseItems = navTree.filter(
-    (item) => !NON_MENU_NAV_IDS.has(item.id ?? '') && !(canCustomise && item.id === 'bookmarks')
+    (item) => !NON_MENU_NAV_IDS[item.id ?? ''] && !(canCustomise && item.id === 'bookmarks')
   );
 
   const pinnedSet = new Set(pinnedUrls);
@@ -159,9 +159,6 @@ export const useNavCustomization = () => {
       }, []);
     }
   }
-
-  const homeItem = navItems.find((item) => item.id === 'home');
-  const unpinnedItems = navItems.filter((item) => item.id !== 'home');
 
   // The non-pinned items become collapsible once something is pinned.
   const unpinnedCollapsible = canCustomise && pinnedNavItems.length > 0;
@@ -214,8 +211,6 @@ export const useNavCustomization = () => {
     canCustomise,
     isLoading,
     navItems,
-    homeItem,
-    unpinnedItems,
     pinnedNavItems,
     activeItem,
     isPinned,

--- a/public/app/core/components/AppChrome/MegaMenu/utils.ts
+++ b/public/app/core/components/AppChrome/MegaMenu/utils.ts
@@ -284,8 +284,9 @@ export function partitionNavForPinning(
   return { pinned: buildPinnedTree(items, pinned), rest: removeMovedItems(items, pinned) };
 }
 
-// Items the mega menu never lists directly (surfaced elsewhere in the chrome).
-export const NON_MENU_NAV_IDS = new Set(['profile', 'help']);
+// Items the mega menu never lists directly (surfaced elsewhere in the chrome). Home is reached via
+// the logo, so it isn't repeated as a menu item.
+export const NON_MENU_NAV_IDS: Record<string, true> = { profile: true, help: true, [HOME_NAV_ID]: true };
 
 export function findByUrl(nodes: NavModelItem[], url: string): NavModelItem | null {
   for (const item of nodes) {

--- a/public/app/core/components/Branding/Branding.tsx
+++ b/public/app/core/components/Branding/Branding.tsx
@@ -54,23 +54,13 @@ const MenuLogo: FC<BrandComponentProps> = ({ className }) => {
   return <img className={className} src={grafanaIconSvg} alt="Grafana" />;
 };
 
-/**
- * inMegaMenuOverlay = true we just render the logo without link (used in mega menu)
- */
-export function HomeLink({ homeNav, inMegaMenuOverlay }: { homeNav?: NavModelItem; inMegaMenuOverlay?: boolean }) {
+export function HomeLink({ homeNav, onClick }: { homeNav?: NavModelItem; onClick?: () => void }) {
   const styles = useStyles2(homeLinkStyles);
 
   const onHomeClicked = () => {
     reportInteraction('grafana_home_clicked');
+    onClick?.();
   };
-
-  if (inMegaMenuOverlay) {
-    return (
-      <div className={styles.homeLink}>
-        <Branding.MenuLogo />
-      </div>
-    );
-  }
 
   return (
     <Tooltip placement="bottom" content={homeNav?.text || 'Home'}>


### PR DESCRIPTION
**What is this feature?**

Removes the "Home" item from the mega menu navigation and makes the Grafana logo a clickable home link in both docked and undocked menu states. Previously, the logo was non-clickable when the mega menu was open in undocked (overlay) mode.

**Why do we need this feature?**

The Home nav item is redundant — the Grafana logo already serves as a home link in most states. In the undocked overlay state, the logo was rendered as a non-clickable `<div>`, making it impossible to navigate home from the open menu. This change simplifies the menu and fixes the dead logo in the overlay.

