### PR TITLE
split-offsite: feat(navigation): hide empty Dashboards items in the mega menu

### DIFF
--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuItem.test.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuItem.test.tsx
@@ -1,0 +1,61 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { render } from 'test/test-utils';
+
+import { type NavModelItem } from '@grafana/data';
+import { configureStore } from 'app/store/configureStore';
+
+import { MegaMenu } from './MegaMenu';
+
+const mockUseEmptyDashboardNavItems = jest.fn();
+jest.mock('./useEmptyDashboardNavItems', () => ({
+  ...jest.requireActual('./useEmptyDashboardNavItems'),
+  useEmptyDashboardNavItems: (...args: unknown[]) => mockUseEmptyDashboardNavItems(...args),
+}));
+
+const setup = () => {
+  const navBarTree: NavModelItem[] = [
+    {
+      text: 'Dashboards',
+      id: 'dashboards',
+      url: '/dashboards',
+      children: [
+        { text: 'Playlists', id: 'dashboards/playlists', url: '/playlists' },
+        { text: 'Snapshots', id: 'dashboards/snapshots', url: '/dashboard/snapshots' },
+        { text: 'Library panels', id: 'dashboards/library-panels', url: '/library-panels' },
+        { text: 'Shared dashboards', id: 'dashboards/public', url: '/dashboard/public' },
+        { text: 'Recently deleted', id: 'dashboards/recently-deleted', url: '/dashboard/recently-deleted' },
+      ],
+    },
+  ];
+  const store = configureStore({ navBarTree });
+  return render(<MegaMenu onClose={() => {}} />, { store });
+};
+
+describe('MegaMenuItem dashboards filtering', () => {
+  afterEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('hides child items whose IDs are returned by useEmptyDashboardNavItems', async () => {
+    mockUseEmptyDashboardNavItems.mockReturnValue(new Set(['dashboards/snapshots', 'dashboards/public']));
+    setup();
+    await userEvent.click(await screen.findByRole('button', { name: 'Expand section: Dashboards' }));
+
+    expect(await screen.findByRole('link', { name: 'Playlists' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Library panels' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Recently deleted' })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Snapshots' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Shared dashboards' })).not.toBeInTheDocument();
+  });
+
+  it('shows every child when the hidden set is empty', async () => {
+    mockUseEmptyDashboardNavItems.mockReturnValue(new Set<string>());
+    setup();
+    await userEvent.click(await screen.findByRole('button', { name: 'Expand section: Dashboards' }));
+
+    for (const name of ['Playlists', 'Snapshots', 'Library panels', 'Shared dashboards', 'Recently deleted']) {
+      expect(await screen.findByRole('link', { name })).toBeInTheDocument();
+    }
+  });
+});

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuItem.test.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuItem.test.tsx
@@ -17,7 +17,7 @@ const setup = () => {
   const navBarTree: NavModelItem[] = [
     {
       text: 'Dashboards',
-      id: 'dashboards',
+      id: 'dashboards/browse',
       url: '/dashboards',
       children: [
         { text: 'Playlists', id: 'dashboards/playlists', url: '/playlists' },

--- a/public/app/core/components/AppChrome/MegaMenu/MegaMenuItem.tsx
+++ b/public/app/core/components/AppChrome/MegaMenu/MegaMenuItem.tsx
@@ -12,6 +12,7 @@ import { useGrafana } from 'app/core/context/GrafanaContext';
 import { Indent } from '../../Indent/Indent';
 
 import { MegaMenuItemText } from './MegaMenuItemText';
+import { useEmptyDashboardNavItems } from './useEmptyDashboardNavItems';
 import { hasChildMatch } from './utils';
 
 interface Props {
@@ -37,6 +38,7 @@ export function MegaMenuItem({ link, activeItem, level = 0, onClick, onPin, isPi
     Boolean(hasActiveChild)
   );
   const showExpandButton = level < MAX_DEPTH && Boolean(linkHasChildren(link) || link.emptyMessage);
+  const hiddenChildIds = useEmptyDashboardNavItems(link, Boolean(sectionExpanded));
   const item = useRef<HTMLLIElement>(null);
 
   const styles = useStyles2(getStyles);
@@ -136,6 +138,7 @@ export function MegaMenuItem({ link, activeItem, level = 0, onClick, onPin, isPi
           {linkHasChildren(link) ? (
             link.children
               .filter((childLink) => !childLink.isCreateAction)
+              .filter((childLink) => !hiddenChildIds.has(childLink.id ?? ''))
               .map((childLink) => (
                 <MegaMenuItem
                   key={`${link.text}-${childLink.text}`}

--- a/public/app/core/components/AppChrome/MegaMenu/useEmptyDashboardNavItems.test.ts
+++ b/public/app/core/components/AppChrome/MegaMenu/useEmptyDashboardNavItems.test.ts
@@ -1,0 +1,122 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { of, throwError } from 'rxjs';
+
+import { type NavModelItem } from '@grafana/data';
+
+import { useEmptyDashboardNavItems, clearDashboardNavItemDataCache } from './useEmptyDashboardNavItems';
+
+const getSnapshots = jest.fn();
+const getLibraryPanels = jest.fn();
+const search = jest.fn();
+const fetch = jest.fn();
+
+jest.mock('app/features/dashboard/services/SnapshotSrv', () => ({
+  getDashboardSnapshotSrv: () => ({ getSnapshots }),
+}));
+jest.mock('app/features/library-panels/state/api', () => ({
+  getLibraryPanels: (...args: unknown[]) => getLibraryPanels(...args),
+}));
+jest.mock('app/features/search/service/searcher', () => ({
+  getGrafanaSearcher: () => ({ search }),
+}));
+jest.mock('@grafana/runtime', () => ({
+  ...jest.requireActual('@grafana/runtime'),
+  getBackendSrv: () => ({ fetch }),
+}));
+
+const DASHBOARDS_LINK: NavModelItem = { text: 'Dashboards', id: 'dashboards', url: '/dashboards' };
+
+const allEmpty = () => {
+  getSnapshots.mockResolvedValue([]);
+  getLibraryPanels.mockResolvedValue({ totalCount: 0 });
+  search.mockResolvedValue({ totalRows: 0 });
+  fetch.mockReturnValue(of({ data: { totalCount: 0 } }));
+};
+
+const allWithData = () => {
+  getSnapshots.mockResolvedValue([{ key: 'a' }]);
+  getLibraryPanels.mockResolvedValue({ totalCount: 3 });
+  search.mockResolvedValue({ totalRows: 2 });
+  fetch.mockReturnValue(of({ data: { totalCount: 5 } }));
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  clearDashboardNavItemDataCache();
+});
+
+describe('useEmptyDashboardNavItems', () => {
+  it('returns an empty set and fetches nothing for a non-dashboards link', () => {
+    allEmpty();
+    const link: NavModelItem = { text: 'Admin', id: 'cfg', url: '/admin' };
+    const { result } = renderHook(() => useEmptyDashboardNavItems(link, true));
+    expect(result.current.size).toBe(0);
+    expect(getSnapshots).not.toHaveBeenCalled();
+    expect(getLibraryPanels).not.toHaveBeenCalled();
+    expect(search).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('fetches nothing while the dashboards section is collapsed', () => {
+    allEmpty();
+    renderHook(() => useEmptyDashboardNavItems(DASHBOARDS_LINK, false));
+    expect(getSnapshots).not.toHaveBeenCalled();
+    expect(getLibraryPanels).not.toHaveBeenCalled();
+    expect(search).not.toHaveBeenCalled();
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('hides all four items when every source is empty', async () => {
+    allEmpty();
+    const { result } = renderHook(() => useEmptyDashboardNavItems(DASHBOARDS_LINK, true));
+    await waitFor(() => expect(result.current.size).toBe(4));
+    expect(result.current.has('dashboards/snapshots')).toBe(true);
+    expect(result.current.has('dashboards/library-panels')).toBe(true);
+    expect(result.current.has('dashboards/public')).toBe(true);
+    expect(result.current.has('dashboards/recently-deleted')).toBe(true);
+  });
+
+  it('hides nothing when every source has data', async () => {
+    allWithData();
+    const { result } = renderHook(() => useEmptyDashboardNavItems(DASHBOARDS_LINK, true));
+    // All four items are hidden during the initial loading state.
+    expect(result.current.size).toBe(4);
+    // Once resolved, nothing is hidden because all sources have data.
+    await waitFor(() => expect(result.current.size).toBe(0));
+  });
+
+  it('shows (does not hide) an item whose check errors', async () => {
+    allEmpty();
+    getSnapshots.mockRejectedValue(new Error('boom'));
+    fetch.mockReturnValue(throwError(() => new Error('boom')));
+    const { result } = renderHook(() => useEmptyDashboardNavItems(DASHBOARDS_LINK, true));
+    await waitFor(() => expect(result.current.size).toBe(2));
+    expect(result.current.has('dashboards/snapshots')).toBe(false);
+    expect(result.current.has('dashboards/public')).toBe(false);
+    expect(result.current.has('dashboards/library-panels')).toBe(true);
+    expect(result.current.has('dashboards/recently-deleted')).toBe(true);
+  });
+
+  it('session cache prevents refetching on remount', async () => {
+    allEmpty();
+    // First mount: let all four sources resolve and populate the resultCache.
+    const { result: result1 } = renderHook(() => useEmptyDashboardNavItems(DASHBOARDS_LINK, true));
+    await waitFor(() => expect(result1.current.size).toBe(4));
+
+    // Each source should have been called exactly once so far.
+    expect(getSnapshots).toHaveBeenCalledTimes(1);
+    expect(getLibraryPanels).toHaveBeenCalledTimes(1);
+    expect(search).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledTimes(1);
+
+    // Second mount WITHOUT clearing the cache — the resultCache should short-circuit all fetches.
+    const { result: result2 } = renderHook(() => useEmptyDashboardNavItems(DASHBOARDS_LINK, true));
+    await waitFor(() => expect(result2.current.size).toBe(4));
+
+    // None of the sources should have been called a second time.
+    expect(getSnapshots).toHaveBeenCalledTimes(1);
+    expect(getLibraryPanels).toHaveBeenCalledTimes(1);
+    expect(search).toHaveBeenCalledTimes(1);
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/public/app/core/components/AppChrome/MegaMenu/useEmptyDashboardNavItems.test.ts
+++ b/public/app/core/components/AppChrome/MegaMenu/useEmptyDashboardNavItems.test.ts
@@ -24,7 +24,7 @@ jest.mock('@grafana/runtime', () => ({
   getBackendSrv: () => ({ fetch }),
 }));
 
-const DASHBOARDS_LINK: NavModelItem = { text: 'Dashboards', id: 'dashboards', url: '/dashboards' };
+const DASHBOARDS_LINK: NavModelItem = { text: 'Dashboards', id: 'dashboards/browse', url: '/dashboards' };
 
 const allEmpty = () => {
   getSnapshots.mockResolvedValue([]);

--- a/public/app/core/components/AppChrome/MegaMenu/useEmptyDashboardNavItems.ts
+++ b/public/app/core/components/AppChrome/MegaMenu/useEmptyDashboardNavItems.ts
@@ -7,7 +7,8 @@ import { getDashboardSnapshotSrv } from 'app/features/dashboard/services/Snapsho
 import { getLibraryPanels } from 'app/features/library-panels/state/api';
 import { getGrafanaSearcher } from 'app/features/search/service/searcher';
 
-export const DASHBOARDS_NAV_ID = 'dashboards';
+// The Dashboards section's nav id is "dashboards/browse" (navtree.NavIDDashboards), not "dashboards".
+export const DASHBOARDS_NAV_ID = 'dashboards/browse';
 export const SNAPSHOTS_NAV_ID = 'dashboards/snapshots';
 export const LIBRARY_PANELS_NAV_ID = 'dashboards/library-panels';
 export const SHARED_DASHBOARDS_NAV_ID = 'dashboards/public';

--- a/public/app/core/components/AppChrome/MegaMenu/useEmptyDashboardNavItems.ts
+++ b/public/app/core/components/AppChrome/MegaMenu/useEmptyDashboardNavItems.ts
@@ -1,0 +1,142 @@
+import { useEffect, useRef, useState } from 'react';
+import { lastValueFrom } from 'rxjs';
+
+import { type NavModelItem } from '@grafana/data';
+import { getBackendSrv } from '@grafana/runtime';
+import { getDashboardSnapshotSrv } from 'app/features/dashboard/services/SnapshotSrv';
+import { getLibraryPanels } from 'app/features/library-panels/state/api';
+import { getGrafanaSearcher } from 'app/features/search/service/searcher';
+
+export const DASHBOARDS_NAV_ID = 'dashboards';
+export const SNAPSHOTS_NAV_ID = 'dashboards/snapshots';
+export const LIBRARY_PANELS_NAV_ID = 'dashboards/library-panels';
+export const SHARED_DASHBOARDS_NAV_ID = 'dashboards/public';
+export const RECENTLY_DELETED_NAV_ID = 'dashboards/recently-deleted';
+
+type DataStatus = 'loading' | 'has-data' | 'empty' | 'error';
+
+// Resolved results persist for the lifetime of the page so re-expanding the Dashboards
+// section does not refetch and re-flicker. Newly-created items therefore appear in the
+// menu on the next page load rather than instantly — an accepted trade-off for navigation.
+const resultCache = new Map<string, boolean>();
+const inflightCache = new Map<string, Promise<boolean>>();
+
+// Test-only: reset the session caches between test cases.
+export function clearDashboardNavItemDataCache() {
+  resultCache.clear();
+  inflightCache.clear();
+}
+
+function useDataStatus(cacheKey: string, fetcher: () => Promise<boolean>, enabled: boolean): DataStatus {
+  const fetcherRef = useRef(fetcher);
+  fetcherRef.current = fetcher;
+
+  const [status, setStatus] = useState<DataStatus>(() =>
+    resultCache.has(cacheKey) ? (resultCache.get(cacheKey) ? 'has-data' : 'empty') : 'loading'
+  );
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    if (resultCache.has(cacheKey)) {
+      setStatus(resultCache.get(cacheKey) ? 'has-data' : 'empty');
+      return;
+    }
+
+    let cancelled = false;
+    let promise = inflightCache.get(cacheKey);
+    if (!promise) {
+      promise = fetcherRef.current();
+      inflightCache.set(cacheKey, promise);
+    }
+    setStatus('loading');
+    promise.then(
+      (hasData) => {
+        resultCache.set(cacheKey, hasData);
+        inflightCache.delete(cacheKey);
+        if (!cancelled) {
+          setStatus(hasData ? 'has-data' : 'empty');
+        }
+      },
+      () => {
+        inflightCache.delete(cacheKey);
+        if (!cancelled) {
+          setStatus('error');
+        }
+      }
+    );
+
+    return () => {
+      cancelled = true;
+    };
+    // fetcherRef is intentionally excluded — it is read via ref to avoid re-running the effect on every render
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cacheKey, enabled]);
+
+  return status;
+}
+
+async function fetchHasSharedDashboards(): Promise<boolean> {
+  const response = await lastValueFrom(
+    getBackendSrv().fetch<{ totalCount: number }>({
+      method: 'GET',
+      url: '/api/dashboards/public-dashboards',
+      params: { page: 1, perpage: 1 },
+      showErrorAlert: false,
+    })
+  );
+  return response.data.totalCount > 0;
+}
+
+/**
+ * Returns the set of child nav IDs under "Dashboards" that should be hidden because they
+ * have no data. Checks run only when `enabled` (the section is expanded) and only for the
+ * Dashboards link. An item is hidden while loading or when confirmed empty, and shown when
+ * it has data or when its check errors.
+ */
+export function useEmptyDashboardNavItems(link: NavModelItem, enabled: boolean): Set<string> {
+  const active = enabled && link.id === DASHBOARDS_NAV_ID;
+
+  const snapshots = useDataStatus(
+    SNAPSHOTS_NAV_ID,
+    () =>
+      getDashboardSnapshotSrv()
+        .getSnapshots()
+        .then((r) => r.length > 0),
+    active
+  );
+  const libraryPanels = useDataStatus(
+    LIBRARY_PANELS_NAV_ID,
+    () => getLibraryPanels({ perPage: 1 }).then((r) => r.totalCount > 0),
+    active
+  );
+  const sharedDashboards = useDataStatus(SHARED_DASHBOARDS_NAV_ID, fetchHasSharedDashboards, active);
+  const recentlyDeleted = useDataStatus(
+    RECENTLY_DELETED_NAV_ID,
+    () =>
+      getGrafanaSearcher()
+        .search({ deleted: true, limit: 1 })
+        .then((r) => r.totalRows > 0),
+    active
+  );
+
+  const hidden = new Set<string>();
+  if (link.id !== DASHBOARDS_NAV_ID) {
+    return hidden;
+  }
+
+  const entries: Array<[string, DataStatus]> = [
+    [SNAPSHOTS_NAV_ID, snapshots],
+    [LIBRARY_PANELS_NAV_ID, libraryPanels],
+    [SHARED_DASHBOARDS_NAV_ID, sharedDashboards],
+    [RECENTLY_DELETED_NAV_ID, recentlyDeleted],
+  ];
+  for (const [id, status] of entries) {
+    if (status === 'loading' || status === 'empty') {
+      hidden.add(id);
+    }
+  }
+
+  return hidden;
+}


### PR DESCRIPTION
**What is this feature?**

In the mega menu, the four data-backed items under **Dashboards** — Snapshots, Library panels, Shared dashboards, and Recently deleted — are now hidden when they have no data. The checks run lazily (only when the Dashboards section is expanded) and results are cached for the session. Playlists and Reporting are unaffected.

This is a menu-only cleanup: it changes *what the mega menu renders*, never *what exists*. Routes, pages, and buttons elsewhere are untouched, and the pages stay reachable by URL. Items are hidden only once confirmed empty; if a count check errors, the item stays visible (fail open).

Implemented as a frontend filter (`useEmptyDashboardNavItems` → `MegaMenuItem`) because the nav tree is built once on the backend at bootstrap and cannot react to a section expanding.

**Screenshots**

with no data:
<img width="3226" height="1816" alt="image" src="https://github.com/user-attachments/assets/e8d25718-6bfe-4d33-90c5-b640783fee1c" />

with data:
<img width="3230" height="1820" alt="image (1)" src="https://github.com/user-attachments/assets/a518b5fd-d4c3-4c4c-90fc-5a6715dfd975" />


**Why do we need this feature?**

For instances that don't use these features, the Dashboards submenu lists pages that only ever show empty states, adding noise to navigation. Hiding empty items keeps the menu focused on what the user actually has.

**Who is this feature for?**

All Grafana users — especially those on instances that don't use snapshots, library panels, shared dashboards, or recently-deleted.

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle. _(N/A — small nav cleanup, intentionally not gated.)_
- [ ] The docs are updated. _(N/A — no user-facing docs affected.)_