### PR TITLE
chore(deps): bump @openfeature/ofrep-web-provider from 0.3.6 to 0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -308,7 +308,7 @@
     "@locker/near-membrane-shared-dom": "0.14.0",
     "@msagl/core": "^1.1.19",
     "@msagl/parser": "^1.1.19",
-    "@openfeature/ofrep-web-provider": "^0.3.3",
+    "@openfeature/ofrep-web-provider": "^0.4.1",
     "@openfeature/react-sdk": "^1.3.0",
     "@openfeature/web-sdk": "^1.8.0",
     "@opentelemetry/api": "1.9.0",

--- a/packages/grafana-runtime/package.json
+++ b/packages/grafana-runtime/package.json
@@ -59,7 +59,7 @@
     "@grafana/schema": "13.1.0-pre",
     "@grafana/ui": "13.1.0-pre",
     "@openfeature/core": "^1.10.0",
-    "@openfeature/ofrep-web-provider": "^0.3.6",
+    "@openfeature/ofrep-web-provider": "^0.4.1",
     "@openfeature/react-sdk": "^1.3.0",
     "@openfeature/web-sdk": "^1.8.0",
     "@types/systemjs": "6.15.3",

--- a/packages/grafana-runtime/src/internal/openFeature/index.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/index.ts
@@ -42,7 +42,8 @@ export async function initOpenFeature() {
 
   const ofProvider = new OFREPWebProvider({
     baseUrl: baseUrl,
-    pollInterval: -1, // disable polling
+    disableVisibilityRefresh: true, // Do not refresh
+    cacheMode: 'disabled', // Do not write to localStorage
     timeoutMs: 5_000,
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2890,7 +2890,7 @@ __metadata:
     "@grafana/schema": "npm:13.1.0-pre"
     "@grafana/ui": "npm:13.1.0-pre"
     "@openfeature/core": "npm:^1.10.0"
-    "@openfeature/ofrep-web-provider": "npm:^0.3.6"
+    "@openfeature/ofrep-web-provider": "npm:^0.4.1"
     "@openfeature/react-sdk": "npm:^1.3.0"
     "@openfeature/web-sdk": "npm:^1.8.0"
     "@rollup/plugin-node-resolve": "npm:16.0.1"
@@ -5715,23 +5715,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openfeature/ofrep-core@npm:^2.1.0":
-  version: 2.1.0
-  resolution: "@openfeature/ofrep-core@npm:2.1.0"
+"@openfeature/ofrep-core@npm:^2.2.0":
+  version: 2.2.0
+  resolution: "@openfeature/ofrep-core@npm:2.2.0"
   peerDependencies:
     "@openfeature/core": ^1.6.0
-  checksum: 10/9a8dbb6def3040aecc3f51110742b9cc5a83faad633273db3425c61b4a6819e26f05aad6cdb02d89d1e8c73ec58f04077c02b613d5f9f106e20bc6eed22c8e73
+  checksum: 10/7fbce29d2eb50fa1cf3d81f7085d48ff4b0c5e95104c78190d23e0b9a018c4ac8370b416bd330499bd0295a9593608eefd5a48cace160d221d3d58862246a09f
   languageName: node
   linkType: hard
 
-"@openfeature/ofrep-web-provider@npm:^0.3.3, @openfeature/ofrep-web-provider@npm:^0.3.6":
-  version: 0.3.6
-  resolution: "@openfeature/ofrep-web-provider@npm:0.3.6"
+"@openfeature/ofrep-web-provider@npm:^0.4.1":
+  version: 0.4.1
+  resolution: "@openfeature/ofrep-web-provider@npm:0.4.1"
   dependencies:
-    "@openfeature/ofrep-core": "npm:^2.1.0"
+    "@openfeature/ofrep-core": "npm:^2.2.0"
   peerDependencies:
     "@openfeature/web-sdk": ^1.4.0
-  checksum: 10/ffe9ef27a8f297f1a416f88b49b25810d19b05e70bea5e94858d077d34bff51c04971174ac74d17b7809e817812d4c66b013d27acd91bc555358a3d38892ff53
+  checksum: 10/8ec4b870a4e4ecea67ab64bfe09d424f7be30327a8c9904faece5af3108a9389396a1851b5218eb59a5f7da2aa69ec4653169c242d16089a768a7e6919db6818
   languageName: node
   linkType: hard
 
@@ -18603,7 +18603,7 @@ __metadata:
     "@msagl/core": "npm:^1.1.19"
     "@msagl/parser": "npm:^1.1.19"
     "@npmcli/package-json": "npm:^6.0.0"
-    "@openfeature/ofrep-web-provider": "npm:^0.3.3"
+    "@openfeature/ofrep-web-provider": "npm:^0.4.1"
     "@openfeature/react-sdk": "npm:^1.3.0"
     "@openfeature/web-sdk": "npm:^1.8.0"
     "@opentelemetry/api": "npm:1.9.0"


### PR DESCRIPTION
**What is this feature?**

Updates the OFREP Web Provider for OpenFeature across a breaking change, disabling the new refresh on window focus functionality, disabling the localStorage caching functionality, and removing the polling disable (as it is now disabled by default).

**Why do we need this feature?**

Latest version, includes a breaking change to behaviour.

**Who is this feature for?**

Developers

**Which issue(s) does this PR fix?**:

cc https://github.com/grafana/grafana-backend-services-squad/pull/16 https://github.com/open-feature/js-sdk-contrib/pull/1535

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
