### PR TITLE
Provisioning: Guard SetFolder by SupportsFolderAnnotation

### DIFF
--- a/pkg/registry/apis/provisioning/resources/parser.go
+++ b/pkg/registry/apis/provisioning/resources/parser.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"path"
+	"slices"
 
 	"go.opentelemetry.io/otel/attribute"
 	"go.yaml.in/yaml/v3"
@@ -211,8 +212,24 @@ func (r *parser) Parse(ctx context.Context, info *repository.FileInfo) (parsed *
 		obj.SetName(obj.GetGenerateName() + util.GenerateShortUID())
 	}
 
-	// Calculate folder identifier from the file path
-	if info.Path != "" {
+	obj.SetUID("")             // clear identifiers
+	obj.SetResourceVersion("") // clear identifiers
+
+	// FIXME: remove this check once we have better unit tests
+	if r.clients == nil {
+		return parsed, fmt.Errorf("no clients configured")
+	}
+
+	// TODO: catch the not found gvk error to return bad request
+	parsed.Client, parsed.GVR, err = r.clients.ForKind(ctx, parsed.GVK)
+	if err != nil {
+		return nil, NewResourceValidationError(fmt.Errorf("get client for kind: %w", err))
+	}
+
+	// Calculate folder identifier from the file path, but only for resources that
+	// are contained in folders. Org-scoped resources (those not in
+	// SupportsFolderAnnotation) must not have a folder annotation stamped onto them.
+	if supportsFolderAnnotation(parsed.GVR.GroupResource()) && info.Path != "" {
 		dirPath := safepath.Dir(info.Path)
 		// _folder.json represents the directory it lives in, so its parent is one level above.
 		if r.folderMetadataEnabled && IsFolderMetadataFile(info.Path) {
@@ -238,21 +255,15 @@ func (r *parser) Parse(ctx context.Context, info *repository.FileInfo) (parsed *
 			parsed.Meta.SetFolder(RootFolder(r.config))
 		}
 	}
-	obj.SetUID("")             // clear identifiers
-	obj.SetResourceVersion("") // clear identifiers
-
-	// FIXME: remove this check once we have better unit tests
-	if r.clients == nil {
-		return parsed, fmt.Errorf("no clients configured")
-	}
-
-	// TODO: catch the not found gvk error to return bad request
-	parsed.Client, parsed.GVR, err = r.clients.ForKind(ctx, parsed.GVK)
-	if err != nil {
-		return nil, NewResourceValidationError(fmt.Errorf("get client for kind: %w", err))
-	}
 
 	return parsed, nil
+}
+
+// supportsFolderAnnotation reports whether resources of the given GroupResource
+// are contained in folders and therefore may carry a folder annotation. Resources
+// not in SupportsFolderAnnotation are org-scoped and must not be stamped with one.
+func supportsFolderAnnotation(gr schema.GroupResource) bool {
+	return slices.Contains(SupportsFolderAnnotation, gr)
 }
 
 // SameIdentity reports whether f and other refer to the same Kubernetes

--- a/pkg/registry/apis/provisioning/resources/parser_test.go
+++ b/pkg/registry/apis/provisioning/resources/parser_test.go
@@ -154,6 +154,82 @@ spec:
 	})
 }
 
+func TestParseFolderAnnotationGuard(t *testing.T) {
+	// A fabricated org-scoped resource that is NOT contained in folders. Only
+	// dashboards and folders exist in SupportsFolderAnnotation today, so we use
+	// a non-folder GVK to exercise the negative path.
+	orgScopedGVK := schema.GroupVersionKind{Group: "example.grafana.app", Version: "v0alpha1", Kind: "Playlist"}
+	orgScopedGVR := schema.GroupVersionResource{Group: "example.grafana.app", Version: "v0alpha1", Resource: "playlists"}
+
+	clients := NewMockResourceClients(t)
+	// Folder-contained resource (dashboard) resolves to the dashboard GVR.
+	clients.On("ForKind", mock.Anything, dashboardV0.DashboardResourceInfo.GroupVersionKind()).
+		Return(nil, dashboardV0.DashboardResourceInfo.GroupVersionResource(), nil).Maybe()
+	// Org-scoped resource resolves to a GVR that is not in SupportsFolderAnnotation.
+	clients.On("ForKind", mock.Anything, orgScopedGVK).
+		Return(nil, orgScopedGVR, nil).Maybe()
+
+	parser := &parser{
+		repo: provisioning.ResourceRepositoryInfo{
+			Type:      provisioning.LocalRepositoryType,
+			Namespace: "xxx",
+			Name:      "repo",
+		},
+		clients: clients,
+		config: &provisioning.Repository{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "xxx", Name: "repo"},
+			Spec: provisioning.RepositorySpec{
+				Type: provisioning.LocalRepositoryType,
+				Sync: provisioning.SyncOptions{Target: provisioning.SyncTargetTypeFolder},
+			},
+		},
+	}
+
+	t.Run("folder-contained resource still gets a folder annotation", func(t *testing.T) {
+		parsed, err := parser.Parse(context.Background(), &repository.FileInfo{
+			Path: "team-a/test-dashboard.json",
+			Data: []byte(`apiVersion: dashboard.grafana.app/v0alpha1
+kind: Dashboard
+metadata:
+  name: test-dashboard
+spec:
+  title: Test dashboard
+`),
+		})
+		require.NoError(t, err)
+		require.Equal(t, ParseFolder("team-a/", "repo").ID, parsed.Meta.GetFolder(),
+			"dashboards must continue to get a folder annotation")
+		require.Equal(t, ParseFolder("team-a/", "repo").ID, parsed.Obj.GetAnnotations()["grafana.app/folder"])
+	})
+
+	t.Run("org-scoped resource gets no folder annotation", func(t *testing.T) {
+		parsed, err := parser.Parse(context.Background(), &repository.FileInfo{
+			Path: "team-a/my-playlist.json",
+			Data: []byte(`apiVersion: example.grafana.app/v0alpha1
+kind: Playlist
+metadata:
+  name: my-playlist
+spec:
+  title: My playlist
+`),
+		})
+		require.NoError(t, err)
+		require.Empty(t, parsed.Meta.GetFolder(),
+			"org-scoped resources must not have a folder annotation stamped on them")
+		_, hasFolder := parsed.Obj.GetAnnotations()["grafana.app/folder"]
+		require.False(t, hasFolder, "org-scoped resources must not carry the folder annotation")
+	})
+}
+
+func TestSupportsFolderAnnotation(t *testing.T) {
+	require.True(t, supportsFolderAnnotation(DashboardResource.GroupResource()),
+		"dashboards are contained in folders")
+	require.True(t, supportsFolderAnnotation(FolderResource.GroupResource()),
+		"folders are contained in folders")
+	require.False(t, supportsFolderAnnotation(schema.GroupResource{Group: "example.grafana.app", Resource: "playlists"}),
+		"org-scoped resources are not contained in folders")
+}
+
 func TestParser_FolderMetadataRefFallback(t *testing.T) {
 	clients := NewMockResourceClients(t)
 	clients.On("ForKind", mock.Anything, mock.Anything).


### PR DESCRIPTION
## What

The provisioning parser (`pkg/registry/apis/provisioning/resources/parser.go`) currently derives a folder ID from the file path and calls `parsed.Meta.SetFolder(...)` for **every** parsed resource, unconditionally.

For org-scoped resources (those not contained in folders, e.g. playlists) this stamps a meaningless, possibly dangling folder annotation onto the object before it is written to the apiserver.

This guards the `SetFolder` block so it only runs when the parsed resource's `GroupResource` is in `SupportsFolderAnnotation` (defined in `resources/client.go`). Resources not in that list get **no** folder annotation.

## Behaviour change

None for existing resources. Dashboards and folders are both in `SupportsFolderAnnotation`, so they continue to receive a folder annotation exactly as before. This is prep work for making new (org-scoped) resources provisionable in Git Sync.

## Implementation notes

- The client/GVR resolution (`ForKind`) is moved ahead of the folder block, since `SupportsFolderAnnotation` keys on `GroupResource`, which is only known after the kind is resolved to a resource. This is a pure reorder of independent operations.
- A small `supportsFolderAnnotation` helper wraps the membership check for testability.

## Tests

- `TestParseFolderAnnotationGuard`: a folder-contained resource (dashboard) still gets the folder annotation (regression); a fabricated org-scoped resource (non-folder GVK) gets no folder annotation.
- `TestSupportsFolderAnnotation`: unit-tests the guard helper directly.
- Existing parser tests pass unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)