### PR TITLE
Provisioning: Make resolveFileGVR kind-aware

### DIFF
--- a/pkg/registry/apis/provisioning/resources/authorizer.go
+++ b/pkg/registry/apis/provisioning/resources/authorizer.go
@@ -238,15 +238,15 @@ func (a *ProvisioningAuthorizer) resolveFileGVR(ctx context.Context, path string
 		return schema.GroupVersionResource{}, fmt.Errorf("parse file %q: %w", path, err)
 	}
 
+	// Resolve by Group AND Kind. Matching by Group alone is incorrect when multiple
+	// kinds share an apiserver group (e.g. dashboards and library panels both live in
+	// dashboard.grafana.app): a Group-only match would resolve every file in the group
+	// to whichever GVR appears first, mis-authorizing files of the other kind.
+	//
 	// Folders are authorized through their own dedicated path (authorizeFolder,
-	// authorizeDeleteFolder, authorizeMoveFolder) — skip them here.
-	for _, gvr := range SupportedProvisioningResources {
-		if gvr == FolderResource {
-			continue
-		}
-		if gvr.Group == gvk.Group {
-			return gvr, nil
-		}
+	// authorizeDeleteFolder, authorizeMoveFolder) and are intentionally not resolvable here.
+	if gvr, ok := gvrForSupportedKind(gvk.Group, gvk.Kind); ok {
+		return gvr, nil
 	}
 
 	return schema.GroupVersionResource{}, fmt.Errorf("unsupported resource type %s/%s at %q", gvk.Group, gvk.Kind, path)

--- a/pkg/registry/apis/provisioning/resources/authorizer_test.go
+++ b/pkg/registry/apis/provisioning/resources/authorizer_test.go
@@ -881,6 +881,64 @@ func TestAuthorizeDeleteByPath(t *testing.T) {
 	})
 }
 
+func TestResolveFileGVR(t *testing.T) {
+	repo := &provisioning.Repository{ObjectMeta: metav1.ObjectMeta{Name: "test-repo"}}
+
+	t.Run("dashboard file resolves to dashboards GVR", func(t *testing.T) {
+		mockReader := repository.NewMockReader(t)
+		mockReader.On("Read", mock.Anything, "team-a/dashboard.json", "").
+			Return(dashboardFileInfo(), nil)
+
+		a := NewAuthorizer(repo, mockReader, auth.NewMockAccessChecker(t), false).(*ProvisioningAuthorizer)
+		gvr, err := a.resolveFileGVR(context.Background(), "team-a/dashboard.json")
+
+		assert.NoError(t, err)
+		assert.Equal(t, DashboardResource, gvr)
+	})
+
+	t.Run("unsupported kind in a supported group returns error", func(t *testing.T) {
+		// A file declaring a different kind in the dashboard group must NOT resolve to
+		// the dashboards GVR. This guards against Group-only matching: resolution is
+		// keyed on Kind, so an unknown kind sharing the group is unsupported.
+		mockReader := repository.NewMockReader(t)
+		mockReader.On("Read", mock.Anything, "team-a/panel.json", "").
+			Return(&repository.FileInfo{
+				Data: []byte(`{"apiVersion":"dashboard.grafana.app/v0alpha1","kind":"LibraryPanel","metadata":{"name":"p"},"spec":{}}`),
+			}, nil)
+
+		a := NewAuthorizer(repo, mockReader, auth.NewMockAccessChecker(t), false).(*ProvisioningAuthorizer)
+		_, err := a.resolveFileGVR(context.Background(), "team-a/panel.json")
+
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "unsupported resource type")
+	})
+}
+
+// TestGVRForSupportedKind verifies that GVR resolution is keyed on Group AND Kind,
+// so that distinct kinds sharing an apiserver group resolve independently.
+func TestGVRForSupportedKind(t *testing.T) {
+	t.Run("dashboard kind resolves to dashboards GVR", func(t *testing.T) {
+		gvr, ok := gvrForSupportedKind(DashboardKind.Group, DashboardKind.Kind)
+		assert.True(t, ok)
+		assert.Equal(t, DashboardResource, gvr)
+	})
+
+	t.Run("matching group but different kind does not resolve", func(t *testing.T) {
+		_, ok := gvrForSupportedKind(DashboardKind.Group, "LibraryPanel")
+		assert.False(t, ok)
+	})
+
+	t.Run("matching kind but different group does not resolve", func(t *testing.T) {
+		_, ok := gvrForSupportedKind("other.grafana.app", DashboardKind.Kind)
+		assert.False(t, ok)
+	})
+
+	t.Run("folder is not resolvable as a file resource", func(t *testing.T) {
+		_, ok := gvrForSupportedKind(FolderKind.Group, FolderKind.Kind)
+		assert.False(t, ok)
+	})
+}
+
 func TestAuthorizeMoveByPath(t *testing.T) {
 	t.Run("file path checks update on source and create on target", func(t *testing.T) {
 		repo := &provisioning.Repository{

--- a/pkg/registry/apis/provisioning/resources/client.go
+++ b/pkg/registry/apis/provisioning/resources/client.go
@@ -33,9 +33,26 @@ var (
 	// SupportedProvisioningResources is the list of resources that can fully managed from the UI
 	SupportedProvisioningResources = []schema.GroupVersionResource{FolderResource, DashboardResource}
 
+	// supportedResourceGVKToGVR maps a supported resource's Group+Kind to its GVR.
+	// Resolution must be keyed on Kind (not Group alone): multiple kinds can share an
+	// apiserver group (e.g. dashboards and library panels in dashboard.grafana.app), so
+	// matching by Group alone would mis-resolve files of the second kind to the wrong GVR.
+	// Folders are intentionally excluded — they are authorized through dedicated paths.
+	supportedResourceGVKToGVR = map[schema.GroupKind]schema.GroupVersionResource{
+		{Group: DashboardKind.Group, Kind: DashboardKind.Kind}: DashboardResource,
+	}
+
 	// SupportsFolderAnnotation is the list of resources that can be saved in a folder
 	SupportsFolderAnnotation = []schema.GroupResource{FolderResource.GroupResource(), DashboardResource.GroupResource()}
 )
+
+// gvrForSupportedKind returns the GVR for a supported resource identified by its
+// Group and Kind. The second return value is false when the Group+Kind pair is not
+// a supported provisioning resource.
+func gvrForSupportedKind(group, kind string) (schema.GroupVersionResource, bool) {
+	gvr, ok := supportedResourceGVKToGVR[schema.GroupKind{Group: group, Kind: kind}]
+	return gvr, ok
+}
 
 // folderGVR builds the GVR for the folder API at the given version.
 func folderGVR(folderAPIVersion string) schema.GroupVersionResource {


### PR DESCRIPTION
## What

`resolveFileGVR` in the provisioning authorizer matched a parsed file to a supported GVR by **Group alone**, returning the first GVR in `SupportedProvisioningResources` for that group. When two kinds share an apiserver group (e.g. dashboards and library panels both live in `dashboard.grafana.app`), every file of the second kind is mis-resolved — and therefore mis-authorized — as the first.

This makes resolution match on **Group AND Kind** via a new `gvrForSupportedKind(group, kind)` helper (backed by a `GroupKind → GVR` map). The "unsupported resource type" error path is unchanged.

## Why

Prep for adding new provisionable resources (playlists, library panels) to Git Sync. Library panels share the dashboard group, so this is a prerequisite. No new resource or feature flag is added; behaviour for the current single-kind-per-group case is identical.

## Tests

Added `TestResolveFileGVR` and `TestGVRForSupportedKind` asserting resolution is keyed on Kind, not just Group. `go test ./pkg/registry/apis/provisioning/resources/...` passes; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)