### PR TITLE
Provisioning: Make strict-validation exemption opt-in

### DIFF
--- a/pkg/registry/apis/provisioning/resources/parser.go
+++ b/pkg/registry/apis/provisioning/resources/parser.go
@@ -34,6 +34,23 @@ type ParserFactory interface {
 	GetParser(ctx context.Context, repo repository.Reader) (Parser, error)
 }
 
+// strictValidationExemptions lists the GroupResources that receive
+// FieldValidation=Ignore on apiserver writes instead of the default Strict.
+//
+// FIXME: the dashboard exemption is temporary while we improve validation.
+// New resources must be added here deliberately rather than relying on a
+// hardcoded equality check.
+var strictValidationExemptions = map[schema.GroupResource]struct{}{
+	DashboardResource.GroupResource(): {},
+}
+
+// skipsStrictValidation reports whether the given GroupResource is exempt from
+// strict field validation and should be written with FieldValidation=Ignore.
+func skipsStrictValidation(gr schema.GroupResource) bool {
+	_, ok := strictValidationExemptions[gr]
+	return ok
+}
+
 // Parser is a parser for a given repository
 //
 //go:generate mockery --name Parser --structname MockParser --inpackage --filename parser_mock.go --with-expecter
@@ -296,8 +313,8 @@ func (f *ParsedResource) DryRun(ctx context.Context) error {
 	}
 
 	fieldValidation := "Strict"
-	if f.SkipStrictValidation || f.GVR == DashboardResource {
-		fieldValidation = "Ignore" // FIXME: dashboard exemption is temporary while we improve validation
+	if f.SkipStrictValidation || skipsStrictValidation(f.GVR.GroupResource()) {
+		fieldValidation = "Ignore"
 	}
 
 	// Handle deletion action separately
@@ -378,8 +395,8 @@ func (f *ParsedResource) Run(ctx context.Context) error {
 	identitySpan.End()
 
 	fieldValidation := "Strict"
-	if f.SkipStrictValidation || f.GVR == DashboardResource {
-		fieldValidation = "Ignore" // FIXME: dashboard exemption is temporary while we improve validation
+	if f.SkipStrictValidation || skipsStrictValidation(f.GVR.GroupResource()) {
+		fieldValidation = "Ignore"
 	}
 
 	// Check for ownership conflicts

--- a/pkg/registry/apis/provisioning/resources/parser_test.go
+++ b/pkg/registry/apis/provisioning/resources/parser_test.go
@@ -503,6 +503,73 @@ func TestDryRunDeletePopulatesExisting(t *testing.T) {
 	})
 }
 
+func TestSkipsStrictValidation(t *testing.T) {
+	// Behaviour must be identical to the previous hardcoded dashboard check:
+	// only the dashboard resource is exempt from strict validation.
+	require.True(t, skipsStrictValidation(DashboardResource.GroupResource()),
+		"dashboard resource must be exempt from strict validation")
+	require.False(t, skipsStrictValidation(FolderResource.GroupResource()),
+		"non-dashboard resources must use strict validation")
+}
+
+func TestParsedResource_DryRun_FieldValidation(t *testing.T) {
+	notFound := apierrors.NewNotFound(schema.GroupResource{Resource: "test"}, "my-resource")
+
+	tests := []struct {
+		name                string
+		gvr                 schema.GroupVersionResource
+		skipStrict          bool
+		wantFieldValidation string
+	}{
+		{
+			name:                "dashboard resource is exempt and uses Ignore",
+			gvr:                 DashboardResource,
+			wantFieldValidation: "Ignore",
+		},
+		{
+			name:                "non-dashboard resource uses Strict",
+			gvr:                 FolderResource,
+			wantFieldValidation: "Strict",
+		},
+		{
+			name:                "SkipStrictValidation forces Ignore regardless of resource",
+			gvr:                 FolderResource,
+			skipStrict:          true,
+			wantFieldValidation: "Ignore",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mockClient := &MockDynamicResourceInterface{}
+			// No existing resource, so DryRun takes the Create path.
+			mockClient.On("Get", mock.Anything, "my-resource", metav1.GetOptions{}, mock.Anything).
+				Return(nil, notFound)
+
+			obj := &unstructured.Unstructured{Object: map[string]any{
+				"metadata": map[string]any{"name": "my-resource", "namespace": "default"},
+			}}
+			mockClient.On("Create", mock.Anything, obj,
+				mock.MatchedBy(func(opts metav1.CreateOptions) bool {
+					return opts.FieldValidation == tt.wantFieldValidation
+				}), mock.Anything).
+				Return(obj, nil)
+
+			parsed := &ParsedResource{
+				Action:               provisioning.ResourceActionCreate,
+				Obj:                  obj,
+				GVR:                  tt.gvr,
+				SkipStrictValidation: tt.skipStrict,
+				Client:               mockClient,
+				Repo:                 testRepoInfo(),
+			}
+
+			require.NoError(t, parsed.DryRun(context.Background()))
+			mockClient.AssertExpectations(t)
+		})
+	}
+}
+
 func newParsedResource(client *MockDynamicResourceInterface, opts ...func(*ParsedResource)) *ParsedResource {
 	obj := &unstructured.Unstructured{Object: map[string]any{
 		"apiVersion": "dashboard.grafana.app/v1",


### PR DESCRIPTION
## What

The provisioning parser forces `FieldValidation=Ignore` (instead of the default `Strict`) only for dashboards, via a hardcoded `f.GVR == DashboardResource` check at two call sites (`DryRun` and `Run`), with a `// FIXME: dashboard exemption is temporary` note.

This replaces the hardcoded check with a small opt-in seam: a package-level `strictValidationExemptions` set (containing only the dashboard `GroupResource` today) and a `skipsStrictValidation(gr)` predicate used at both sites.

## Why

Prep for adding new provisionable resources to Git Sync. New resources default to `Strict`; a resource can later opt into the exemption deliberately (test-driven) rather than editing a conditional. **No behaviour change today** — only dashboards are exempted.

## Tests

Added `TestSkipsStrictValidation` (dashboard → exempt, folder → not) and a table-driven `TestParsedResource_DryRun_FieldValidation` asserting the `FieldValidation` value actually passed to the client. Full `resources` package tests pass; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)