### PR TITLE
alerting: omit org_id from Terraform HCL export of alert rule groups

### DIFF
--- a/pkg/services/ngalert/api/api_provisioning_test.go
+++ b/pkg/services/ngalert/api/api_provisioning_test.go
@@ -955,7 +955,6 @@ func TestIntegrationProvisioningApi(t *testing.T) {
 				insertRule(t, sut, createTestAlertRule("rule2", 1))
 
 				expectedResponse := `resource "grafana_rule_group" "rule_group_cc0954af8a53fa18" {
-  org_id           = 1
   name             = "my-cool-group"
   folder_uid       = "folder-uid"
   interval_seconds = 60

--- a/pkg/services/ngalert/api/test-data/post-rulegroup-101-export.hcl
+++ b/pkg/services/ngalert/api/test-data/post-rulegroup-101-export.hcl
@@ -1,5 +1,4 @@
 resource "grafana_rule_group" "rule_group_d3e8424bfbf66bc3" {
-  org_id           = 1
   name             = "group101"
   folder_uid       = "e4584834-1a87-4dff-8913-8a4748dfca79"
   interval_seconds = 10

--- a/pkg/services/ngalert/api/test-data/post-rulegroup-simplified-routing-export.hcl
+++ b/pkg/services/ngalert/api/test-data/post-rulegroup-simplified-routing-export.hcl
@@ -1,5 +1,4 @@
 resource "grafana_rule_group" "rule_group_2b12784d0e1454cd" {
-  org_id           = 1
   name             = "group_simplified_routing"
   folder_uid       = "e4584834-1a87-4dff-8913-8a4748dfca79"
   interval_seconds = 10

--- a/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
+++ b/pkg/services/ngalert/api/tooling/definitions/provisioning_alert_rules.go
@@ -279,7 +279,7 @@ type AlertRuleGroup struct {
 
 // AlertRuleGroupExport is the provisioned file export of AlertRuleGroupV1.
 type AlertRuleGroupExport struct {
-	OrgID           int64             `json:"orgId" yaml:"orgId" hcl:"org_id"`
+	OrgID           int64             `json:"orgId" yaml:"orgId"`
 	Name            string            `json:"name" yaml:"name" hcl:"name"`
 	Folder          string            `json:"folder" yaml:"folder"`
 	FolderUID       string            `json:"-" yaml:"-" hcl:"folder_uid"`


### PR DESCRIPTION
Fixes #125847

## Problem

Exporting an Alert Rule Group as Terraform HCL always produces:

```hcl
resource "grafana_rule_group" "rule_group_xxx" {
  org_id = 1
  ...
}
```

When `terraform apply` runs with a service account token, the Grafana Terraform Provider rejects this with:

```
Error: org_id is only supported with basic auth. API keys are already org-scoped
```

Service accounts are implicitly scoped to their org, so supplying `org_id` is not supported and breaks every automated deployment using the recommended authentication method.

## Root cause

`AlertRuleGroupExport.OrgID` had the struct tag `hcl:"org_id"`, which causes `gohcl` to always emit the field in HCL output regardless of its value.

## Fix

Remove the `hcl:"org_id"` tag from `OrgID`. The JSON (`orgId`) and YAML (`orgId`) tags are unchanged, so those export formats are not affected.

Users who need `org_id` for basic-auth multi-org setups can add it manually to the exported HCL.

Updated two HCL snapshot test files and one inline assertion to reflect the new output.