### PR TITLE
Alerting: wait for cluster to settle before HA single-node evaluation

### DIFF
--- a/pkg/services/ngalert/cluster/evaluation_coordinator.go
+++ b/pkg/services/ngalert/cluster/evaluation_coordinator.go
@@ -14,6 +14,11 @@ const checkInterval = 5 * time.Second
 
 type ClusterPositionProvider interface {
 	Position() int
+	// WaitReady blocks until the cluster has settled or ctx is done. Until the
+	// cluster settles, every node sees only itself and Position returns 0, so
+	// the first evaluation decision must wait for readiness to avoid every node
+	// electing itself as the primary evaluator.
+	WaitReady(ctx context.Context) error
 }
 
 // EvaluationCoordinator determines whether alert rule evaluation should occur
@@ -40,6 +45,15 @@ func (c *EvaluationCoordinator) Updates(ctx context.Context) <-chan bool {
 	updates := make(chan bool, 1)
 	go func() {
 		defer close(updates)
+
+		// Wait for the cluster to settle before making the first decision.
+		// Before the gossip mesh settles, every node sees only itself and
+		// Position returns 0, which would make every node start evaluating
+		// alert rules and produce duplicate evaluations and state writes.
+		c.log.Info("Waiting for cluster to settle before evaluating alert rules")
+		if err := c.cluster.WaitReady(ctx); err != nil {
+			return
+		}
 
 		current := c.shouldEvaluate()
 		sendLatest(updates, current)

--- a/pkg/services/ngalert/cluster/evaluation_coordinator_test.go
+++ b/pkg/services/ngalert/cluster/evaluation_coordinator_test.go
@@ -14,10 +14,26 @@ import (
 
 type mockPositionProvider struct {
 	position atomic.Int32
+	// ready gates WaitReady. When nil, WaitReady returns immediately (the
+	// cluster is treated as already settled). When set, WaitReady blocks until
+	// the channel is closed, simulating a cluster that has not yet settled.
+	ready chan struct{}
 }
 
 func (m *mockPositionProvider) Position() int {
 	return int(m.position.Load())
+}
+
+func (m *mockPositionProvider) WaitReady(ctx context.Context) error {
+	if m.ready == nil {
+		return nil
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-m.ready:
+		return nil
+	}
 }
 
 func TestNewEvaluationCoordinator(t *testing.T) {
@@ -72,6 +88,65 @@ func TestEvaluationCoordinator_Updates(t *testing.T) {
 				require.True(t, val, "position 0 should emit true")
 			default:
 				t.Fatal("expected initial value immediately")
+			}
+		})
+	})
+
+	t.Run("waits for cluster to settle before first decision", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			provider := &mockPositionProvider{ready: make(chan struct{})}
+			// Before the cluster settles, every node sees only itself and
+			// reports position 0.
+			provider.position.Store(0)
+
+			coordinator, err := NewEvaluationCoordinator(provider, log.NewNopLogger())
+			require.NoError(t, err)
+
+			updates := coordinator.Updates(t.Context())
+			synctest.Wait()
+
+			// No decision must be emitted while the cluster is unsettled,
+			// otherwise this node would start evaluating based on a bogus
+			// position 0.
+			select {
+			case val := <-updates:
+				t.Fatalf("must not emit a decision before the cluster settles, got %v", val)
+			default:
+			}
+
+			// Cluster settles and this node's real position turns out to be 1
+			// (a secondary node).
+			provider.position.Store(1)
+			close(provider.ready)
+			synctest.Wait()
+
+			select {
+			case val := <-updates:
+				require.False(t, val, "settled secondary node should not evaluate")
+			default:
+				t.Fatal("expected a decision once the cluster has settled")
+			}
+		})
+	})
+
+	t.Run("closes channel when context is cancelled before the cluster settles", func(t *testing.T) {
+		synctest.Test(t, func(t *testing.T) {
+			provider := &mockPositionProvider{ready: make(chan struct{})}
+			coordinator, err := NewEvaluationCoordinator(provider, log.NewNopLogger())
+			require.NoError(t, err)
+
+			ctx, cancel := context.WithCancel(t.Context())
+			updates := coordinator.Updates(ctx)
+			synctest.Wait()
+
+			cancel()
+			synctest.Wait()
+
+			select {
+			case _, ok := <-updates:
+				require.False(t, ok, "channel should be closed")
+			default:
+				t.Fatal("channel should close when context is cancelled while waiting for the cluster to settle")
 			}
 		})
 	})


### PR DESCRIPTION
Fixes #125705

## Problem

With `ha_single_node_evaluation = true` in an HA cluster, every node starts the scheduler and reports itself as the primary evaluator. As a result alert rules are evaluated on all nodes, each state transition creates duplicate annotations, and concurrent state persistence produces MySQL deadlocks (`Error 1213: Deadlock found`).

## Root cause

`EvaluationCoordinator.Updates()` reads `peer.Position()` immediately on startup. The evaluation runner is started concurrently with the rest of alerting, before the gossip mesh has settled. Until the cluster settles, each node's member list contains only itself, so `Position()` returns `0` on every node. Every node therefore passes the `position == 0` check, logs "Primary node, alert rule evaluation enabled", and starts evaluating.

The peer position is only correct after the cluster settles, which is why the `alertmanager_peer_position` metric reports the expected `0/1/2` while evaluation has already started everywhere.

## Fix

Block on the cluster peer's `WaitReady(ctx)` before the first evaluation decision so the position is accurate from the start. The `ClusterPeer` interface already exposes `WaitReady`, and both the memberlist and redis peers close their readiness channel when `Settle()` completes. That is bounded by the existing 30s settle timeout, so the wait cannot block startup indefinitely. If the context is cancelled while waiting, the updates channel is closed and the runner shuts down cleanly.

## Tests

Added two unit tests to `evaluation_coordinator_test.go`:
- no evaluation decision is emitted until the cluster signals readiness, and the decision then reflects the settled position
- the updates channel closes if the context is cancelled while waiting for readiness