### PR TITLE
Loki: scope label filter values to the current query in Explore builder

### DIFF
--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.test.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.test.tsx
@@ -56,7 +56,7 @@ describe('LokiQueryBuilder', () => {
     await waitFor(() => expect(screen.getByText('job')).toBeInTheDocument());
   });
 
-  it('uses fetchLabelValues if preselected labels have no equality matcher', async () => {
+  it('scopes fetchLabelValues to a negative matcher in the other label filters', async () => {
     const props = createDefaultProps();
     props.datasource.getDataSamples = jest.fn().mockResolvedValue([]);
     props.datasource.languageProvider.fetchLabelValues = jest.fn().mockReturnValue(['a', 'b']);
@@ -73,11 +73,12 @@ describe('LokiQueryBuilder', () => {
     const selects = getAllByRole(getSelectParent(labels)!, 'combobox');
     await userEvent.click(selects[5]);
     expect(props.datasource.languageProvider.fetchLabelValues).toHaveBeenCalledWith('job', {
+      streamSelector: '{cluster!="cluster1"}',
       timeRange: mockTimeRange,
     });
   });
 
-  it('no streamSelector in fetchLabelValues if preselected label have regex equality matcher with match everything value (.*)', async () => {
+  it('scopes fetchLabelValues to a match-everything regex in the other label filters', async () => {
     const props = createDefaultProps();
     props.datasource.getDataSamples = jest.fn().mockResolvedValue([]);
     props.datasource.languageProvider.fetchLabelValues = jest.fn().mockReturnValue(['a', 'b']);
@@ -94,6 +95,7 @@ describe('LokiQueryBuilder', () => {
     const selects = getAllByRole(getSelectParent(labels)!, 'combobox');
     await userEvent.click(selects[5]);
     expect(props.datasource.languageProvider.fetchLabelValues).toHaveBeenCalledWith('job', {
+      streamSelector: '{cluster=~".*"}',
       timeRange: mockTimeRange,
     });
   });

--- a/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.tsx
+++ b/public/app/plugins/datasource/loki/querybuilder/components/LokiQueryBuilder.tsx
@@ -87,21 +87,16 @@ export const LokiQueryBuilder = memo<Props>(({ datasource, query, onChange, onRu
       return [];
     }
 
-    let values;
+    // Scope the values to the other label filters already in the query so the
+    // dropdown only offers values present in the current result set. The
+    // label/<name>/values endpoint accepts any valid selector (including
+    // negative matchers like != and match-everything regexes), so the only
+    // case we skip scoping is when there are no other filters to scope by.
     const labelsToConsider = query.labels.filter((x) => x !== forLabel);
-    // If we have no equality/regex operation with .*, we can't fetch series as it will throw an error, so we fetch label values
-    const hasEqualityOperation = labelsToConsider.find(
-      (filter) => filter.op === '=' || (filter.op === '=~' && new RegExp(filter.value).test('') === false)
-    );
-    if (labelsToConsider.length === 0 || !hasEqualityOperation) {
-      values = await datasource.languageProvider.fetchLabelValues(forLabel.label, { timeRange });
-    } else {
-      const streamSelector = lokiQueryModeller.renderLabels(labelsToConsider);
-      values = await datasource.languageProvider.fetchLabelValues(forLabel.label, {
-        streamSelector,
-        timeRange,
-      });
-    }
+    const options = labelsToConsider.length
+      ? { streamSelector: lokiQueryModeller.renderLabels(labelsToConsider), timeRange }
+      : { timeRange };
+    const values = await datasource.languageProvider.fetchLabelValues(forLabel.label, options);
 
     return values ? values.map((v) => escapeLabelValueInSelector(v, forLabel.op)) : []; // Escape values in return
   };


### PR DESCRIPTION
Fixes grafana/grafana-loki-datasource#163

## Problem

In the Explore query builder with a Loki datasource, adding a label filter to refine results shows every possible value for the selected label, including values that are not present in the current query results. The expectation, and the behavior in older versions, is that each new label filter offers only values in scope of the current search, like the Label Browser does.

## Root cause

`onGetLabelValues` in `LokiQueryBuilder.tsx` only passed a stream selector to `fetchLabelValues` when at least one of the other label filters used a positive equality matcher:

```ts
const hasEqualityOperation = labelsToConsider.find(
  (filter) => filter.op === '=' || (filter.op === '=~' && new RegExp(filter.value).test('') === false)
);
if (labelsToConsider.length === 0 || !hasEqualityOperation) {
  // unscoped: fetches all values for the label
}
```

When the other filters were only negative matchers (`!=`, `!~`) or a match-everything regex (`=~ ".*"`), the gate was false and the values were fetched without any scope.

That gate was carried over from the previous implementation that used `fetchSeriesLabels` (the `/series` endpoint, which rejects selectors without a positive matcher). The builder now uses `fetchLabelValues`, which hits `/label/<name>/values` and accepts any valid stream selector, so the gate is no longer needed.

## Fix

Render the other label filters into the stream selector whenever there are any, and pass it to `fetchLabelValues`. The language provider already drops an empty `{}` selector, so the case with no other filters stays unscoped as before. Negative matchers and match-everything regexes are now correctly used to scope the values.

## Tests

Updated the two tests in `LokiQueryBuilder.test.tsx` that asserted the old unscoped behavior for negative and match-everything matchers to assert the scoped calls. Full suite passes (17/17).