### PR TITLE
[release-13.0.2] Docs: Updated broken link

### DIFF
--- a/docs/sources/administration/roles-and-permissions/access-control/_index.md
+++ b/docs/sources/administration/roles-and-permissions/access-control/_index.md
@@ -24,6 +24,11 @@ refs:
       destination: /docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/access-control/rbac-fixed-basic-role-definitions/
     - pattern: /docs/grafana-cloud/
       destination: /docs/grafana-cloud/account-management/authentication-and-permissions/access-control/rbac-fixed-basic-role-definitions/
+  rbac-role-definitions-permissions-associated-to-basic-roles:
+    - pattern: /docs/grafana/
+      destination: /docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/access-control/rbac-fixed-basic-role-definitions/#permissions-associated-to-basic-roles
+    - pattern: /docs/grafana-cloud/
+      destination: /docs/grafana-cloud/account-management/authentication-and-permissions/access-control/rbac-fixed-basic-role-definitions/#permissions-associated-to-basic-roles
   rbac-role-definitions-basic-role-assignments:
     - pattern: /docs/grafana/
       destination: /docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/access-control/rbac-fixed-basic-role-definitions/#basic-role-assignments
@@ -155,7 +160,7 @@ Each basic role is comprised of a number of _permissions_. For example, the view
 - `Action: orgs:read`: Enables the viewer to see their organization details
 - `Action: annotations:read, Scope: annotations:*`: Enables the viewer to see annotations that other users have added to a dashboard.
 
-For a comprehensive list of the basic role permissions refer to [Permissions associated to basic roles](https://grafana.com/docs/grafana/<GRAFANA_VERSION>/administration/roles-and-permissions/access-control/rbac-fixed-basic-role-definition#permissions-associated-to-basic-roles).
+For a comprehensive list of the basic role permissions refer to [Permissions associated to basic roles](ref:rbac-role-definitions-permissions-associated-to-basic-roles).
 
 #### Modify basic roles
 


### PR DESCRIPTION
Backport of #125807 to release-13.0.2. Fixes a broken link in the RBAC access-control docs (manual backport; automated backport failed with a 403 branch-creation error). Cherry-pick applied cleanly.

Made with [Cursor](https://cursor.com)