### PR TITLE
Docs: set folder apiVersion to v1 in Git Sync example

### DIFF
--- a/docs/sources/as-code/observability-as-code/git-sync/use-git-sync.md
+++ b/docs/sources/as-code/observability-as-code/git-sync/use-git-sync.md
@@ -128,7 +128,7 @@ Each folder in a synced repository contains a `.folder.json` file at its root:
 
 ```json
 {
-  "apiVersion": "folder.grafana.app/v1beta1",
+  "apiVersion": "folder.grafana.app/v1",
   "kind": "Folder",
   "metadata": {
     "name": "<FOLDER_UID>"


### PR DESCRIPTION
**What is this feature?**

Corrects the `.folder.json` example in the Git Sync documentation to use
`folder.grafana.app/v1` instead of `folder.grafana.app/v1beta1`.

**Why do we need this feature?**

The documented example didn't match what git-sync actually writes. The
`apiVersion` stamped into `.folder.json` comes from the `folders_api_version`
provisioning setting, which defaults to `v1` for on-prem installs
(`pkg/setting/setting.go`). 

**Who is this feature for?**

Users setting up or troubleshooting Git Sync who reference the `.folder.json`
structure in the documentation.

**Which issue(s) does this PR fix?**:

Fixes #

**Special notes for your reviewer:**

Docs-only change, single line, so the example now reflects what a default
repository actually produces.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [x] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.