### PR TITLE
Logs: Fix trace preview for Loki derived fields using TraceQL trace-i…

### DIFF
--- a/public/app/features/logs/components/panel/LogLineDetails.test.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetails.test.tsx
@@ -877,6 +877,78 @@ describe('LogLineDetails', () => {
     expect(await screen.findByText('Trace view')).toBeInTheDocument();
   });
 
+  test('Requests the trace by ID when the derived field uses a TraceQL trace-id lookup', async () => {
+    const entry = 'traceId=1234 msg="some message"';
+    const dataFrame = toDataFrame({
+      fields: [
+        { name: 'timestamp', config: {}, type: FieldType.time, values: [1] },
+        { name: 'entry', values: [entry] },
+        {
+          name: 'traceId',
+          values: ['1234'],
+          config: { links: [{ title: 'link title', url: 'localhost:3210/${__value.text}' }] },
+        },
+        { name: 'userId', values: ['5678'] },
+      ],
+    });
+    const log = createLogLine(
+      { entry, dataFrame, entryFieldIndex: 0, rowIndex: 0, datasourceUid: lokiDS.uid },
+      {
+        escape: false,
+        order: LogsSortOrder.Descending,
+        timeZone: 'browser',
+        virtualization: undefined,
+        wrapLogMessage: true,
+        getFieldLinks: (field: Field, rowIndex: number, dataFrame: DataFrame, vars: ScopedVars) => {
+          if (field.config && field.config.links) {
+            return field.config.links.map((link) => {
+              return {
+                href: '/explore',
+                interpolatedParams: {
+                  query: {
+                    datasource: {
+                      uid: tempoDS.uid,
+                    },
+                    refId: 'A',
+                    query: '{trace:id = "abcd1234"}',
+                    queryType: 'traceql',
+                  },
+                },
+                title: 'tempo',
+                target: '_blank',
+                origin: field,
+              };
+            });
+          }
+          return [];
+        },
+      }
+    );
+
+    const querySpy = jest.spyOn(tempoDS, 'query').mockReturnValueOnce(
+      of({
+        data: [
+          createDataFrame({
+            fields: [
+              { name: 'traceID', values: ['5d5d850e24d89509'], type: FieldType.string },
+              { name: 'spanID', values: ['5d5d850e24d89509'], type: FieldType.string },
+            ],
+          }),
+        ],
+      })
+    );
+
+    await setup({ logs: [log] }, undefined, undefined, { showDetails: [log], currentLog: log });
+
+    await userEvent.click(screen.getByText('Trace'));
+
+    expect(await screen.findByText('Trace view')).toBeInTheDocument();
+    // The TraceQL lookup must be unwrapped to the bare trace ID so Tempo returns full trace spans.
+    expect(querySpy).toHaveBeenCalledWith(
+      expect.objectContaining({ targets: [expect.objectContaining({ query: 'abcd1234' })] })
+    );
+  });
+
   test('Shows a message if the trace cannot be retrieved', async () => {
     const entry = 'traceId=1234 msg="some message"';
     const dataFrame = toDataFrame({

--- a/public/app/features/logs/components/panel/LogLineDetailsTrace.tsx
+++ b/public/app/features/logs/components/panel/LogLineDetailsTrace.tsx
@@ -17,7 +17,7 @@ import { transformDataFrames } from 'app/features/explore/TraceView/utils/transf
 import { SearchTableType, type TempoQuery } from 'app/plugins/datasource/tempo/dataquery.gen';
 
 import { useLogListContext } from './LogListContext';
-import { type EmbeddedInternalLink } from './links';
+import { getTraceIdFromTraceQlQuery, type EmbeddedInternalLink } from './links';
 
 interface Props {
   traceRef: EmbeddedInternalLink;
@@ -49,14 +49,16 @@ export const LogLineDetailsTrace = ({ timeRange, timeZone, traceRef }: Props) =>
       return;
     }
     setDataFrames(undefined);
+    // Tempo only returns renderable trace spans for a bare trace ID, so unwrap `{ trace:id = "..." }` lookups.
+    const traceQuery = getTraceIdFromTraceQlQuery(traceRef.query) ?? traceRef.query;
     const request: DataQueryRequest<TempoQuery> = {
       app,
-      requestId: `log-details-trace-${traceRef.query}`,
+      requestId: `log-details-trace-${traceQuery}`,
       targets: [
         {
-          query: traceRef.query,
+          query: traceQuery,
           queryType: 'traceql',
-          refId: `log-details-trace-${traceRef.query}`,
+          refId: `log-details-trace-${traceQuery}`,
           tableType: SearchTableType.Traces,
           filters: [],
         },

--- a/public/app/features/logs/components/panel/links.test.ts
+++ b/public/app/features/logs/components/panel/links.test.ts
@@ -7,7 +7,7 @@ import { type GetFieldLinksFn } from 'app/plugins/panel/logs/types';
 
 import { createLogLine } from '../mocks/logRow';
 
-import { getTempoTraceFromLinks } from './links';
+import { getTempoTraceFromLinks, getTraceIdFromTraceQlQuery } from './links';
 import { type LogListModel } from './processing';
 
 describe('getTempoTraceFromLinks', () => {
@@ -81,5 +81,30 @@ describe('getTempoTraceFromLinks', () => {
       query: '2203801e0171aa8b',
       queryType: 'traceql',
     });
+  });
+});
+
+describe('getTraceIdFromTraceQlQuery', () => {
+  test.each([
+    ['{trace:id = "2203801e0171aa8b"}', '2203801e0171aa8b'],
+    ['{ trace:id = "2203801e0171aa8b" }', '2203801e0171aa8b'],
+    ['{trace:id="2203801e0171aa8b"}', '2203801e0171aa8b'],
+    ['  {trace:id = "46b539f510ab12113b5011db58d5a334"}  ', '46b539f510ab12113b5011db58d5a334'],
+    ['{trace:id = `2203801e0171aa8b`}', '2203801e0171aa8b'],
+    ['{trace:id = "ABCDEF0123456789"}', 'ABCDEF0123456789'],
+  ])('extracts the trace ID from a TraceQL trace-id lookup: %s', (query, expected) => {
+    expect(getTraceIdFromTraceQlQuery(query)).toBe(expected);
+  });
+
+  test.each([
+    ['2203801e0171aa8b'], // a bare trace ID is not a TraceQL query
+    ['{ span.foo = "bar" }'], // a different TraceQL query
+    ['{trace:id = "not-hex-zz"}'], // non-hex value
+    ['{trace:id =~ "2203801e0171aa8b"}'], // regex operator, not an exact lookup
+    ['{trace:id = "abc" && span.foo = "bar"}'], // compound query
+    ['{trace:id = `2203801e0171aa8b"}'], // mismatched quote characters
+    [''],
+  ])('returns undefined for non trace-id lookups: %s', (query) => {
+    expect(getTraceIdFromTraceQlQuery(query)).toBeUndefined();
   });
 });

--- a/public/app/features/logs/components/panel/links.ts
+++ b/public/app/features/logs/components/panel/links.ts
@@ -36,6 +36,13 @@ export type EmbeddedInternalLink = {
   queryType: string;
 };
 
+// Matches a TraceQL trace-id lookup, e.g. `{ trace:id = "abc" }`. The quote is back-referenced so both ends match.
+const TRACE_ID_QUERY_REGEX = /^\{\s*trace:id\s*=\s*(["`])([0-9A-Fa-f]+)\1\s*\}$/;
+
+export function getTraceIdFromTraceQlQuery(query: string): string | undefined {
+  return query.trim().match(TRACE_ID_QUERY_REGEX)?.[2];
+}
+
 type TempoQuery = {
   query: string;
   queryType: string;


### PR DESCRIPTION
**What is this feature?**

A bug fix for the trace preview in the log line details panel (Explore). When a Loki derived field targets Tempo with a TraceQL trace-id lookup such as `{ trace:id = "<id>" }`, the embedded trace preview now resolves it to the underlying trace ID and renders the trace, instead of leaving the section empty.

**Why do we need this feature?**

The preview sent the derived field's query to Tempo as-is. For a TraceQL trace-id lookup like `{ trace:id = "<id>" }`, Tempo returns a search-results table rather than trace spans, which the preview cannot render — so the trace section stayed empty. A bare trace ID worked only because Tempo routes hex-only queries to a trace-by-id lookup. This PR extracts the trace ID from a `{ trace:id = "<id>" }` query before querying Tempo, so the preview fetches the full trace by ID. Other TraceQL queries are left unchanged.

**Who is this feature for?**

Grafana users who correlate Loki logs with Tempo traces using derived fields configured with a TraceQL query (the recommended `{ trace:id = "$${__value.raw}" }` form) rather than a bare trace ID.

**Which issue(s) does this PR fix?**:

Fixes #125849

**Special notes for your reviewer:**

Frontend-only change. The trace-ID extraction lives in the logs panel's own `links.ts` (next to the existing `isTempoQuery` helper) rather than the Tempo plugin's `utils.ts`, to avoid pulling the Tempo query-editor dependencies into the logs bundle. Covered by unit tests for the new `getTraceIdFromTraceQlQuery` helper and an integration test asserting the preview queries Tempo with the bare trace ID for a `{ trace:id = "..." }` derived field.

Please check that:
- [x] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle. — N/A, bug fix.
- [ ] The docs are updated. — N/A, no user-facing config/behavior change.
