### PR TITLE
[release-12.2.9] Dependencies: Bump Go to v1.26.4

### DIFF
--- a/.citools/src/air/go.mod
+++ b/.citools/src/air/go.mod
@@ -1,6 +1,6 @@
 module air
 
-go 1.26.3
+go 1.26.4
 
 tool github.com/air-verse/air
 

--- a/.citools/src/bra/go.mod
+++ b/.citools/src/bra/go.mod
@@ -1,6 +1,6 @@
 module bra
 
-go 1.26.3
+go 1.26.4
 
 tool github.com/unknwon/bra
 

--- a/.citools/src/cog/go.mod
+++ b/.citools/src/cog/go.mod
@@ -1,6 +1,6 @@
 module cog
 
-go 1.26.3
+go 1.26.4
 
 tool github.com/grafana/cog/cmd/cli
 

--- a/.citools/src/cue/go.mod
+++ b/.citools/src/cue/go.mod
@@ -1,6 +1,6 @@
 module cue
 
-go 1.26.3
+go 1.26.4
 
 tool cuelang.org/go/cmd/cue
 

--- a/.citools/src/golangci-lint/go.mod
+++ b/.citools/src/golangci-lint/go.mod
@@ -1,6 +1,6 @@
 module golangci-lint
 
-go 1.26.3
+go 1.26.4
 
 tool github.com/golangci/golangci-lint/v2/cmd/golangci-lint
 

--- a/.citools/src/jb/go.mod
+++ b/.citools/src/jb/go.mod
@@ -1,6 +1,6 @@
 module jb
 
-go 1.26.3
+go 1.26.4
 
 tool github.com/jsonnet-bundler/jsonnet-bundler/cmd/jb
 

--- a/.citools/src/lefthook/go.mod
+++ b/.citools/src/lefthook/go.mod
@@ -1,6 +1,6 @@
 module lefthook
 
-go 1.26.3
+go 1.26.4
 
 tool github.com/evilmartians/lefthook
 

--- a/.citools/src/swagger/go.mod
+++ b/.citools/src/swagger/go.mod
@@ -1,6 +1,6 @@
 module swagger
 
-go 1.26.3
+go 1.26.4
 
 tool github.com/go-swagger/go-swagger/cmd/swagger
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ARG JS_SRC=js-builder
 # By using FROM instructions we can delegate dependency updates to dependabot
 FROM alpine:3.23.4 AS alpine-base
 FROM ubuntu:22.04 AS ubuntu-base
-FROM golang:1.26.3-alpine AS go-builder-base
+FROM golang:1.26.4-alpine AS go-builder-base
 FROM --platform=${JS_PLATFORM} node:22-alpine AS js-builder-base
 # Javascript build stage
 FROM --platform=${JS_PLATFORM} ${JS_IMAGE} AS js-builder

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ WIRE_TAGS = "oss"
 include .citools/Variables.mk
 
 GO = go
-GO_VERSION = 1.26.3
+GO_VERSION = 1.26.4
 GO_LINT_FILES ?= $(shell ./scripts/go-workspace/golangci-lint-includes.sh)
 GO_TEST_FILES ?= $(shell ./scripts/go-workspace/test-includes.sh)
 SH_FILES ?= $(shell find ./scripts -name *.sh)

--- a/apps/advisor/go.mod
+++ b/apps/advisor/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/advisor
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/Masterminds/semver/v3 v3.4.0

--- a/apps/alerting/alertenrichment/go.mod
+++ b/apps/alerting/alertenrichment/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/alerting/alertenrichment
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/grafana/grafana-app-sdk v0.40.3

--- a/apps/alerting/notifications/go.mod
+++ b/apps/alerting/notifications/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/alerting/notifications
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/grafana/grafana-app-sdk v0.40.3

--- a/apps/dashboard/go.mod
+++ b/apps/dashboard/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/dashboard
 
-go 1.26.3
+go 1.26.4
 
 require (
 	cuelang.org/go v0.11.1

--- a/apps/folder/go.mod
+++ b/apps/folder/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/folder
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/grafana/grafana-app-sdk v0.40.3

--- a/apps/iam/cmd/operator/Dockerfile
+++ b/apps/iam/cmd/operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.3-alpine AS builder
+FROM golang:1.26.4-alpine AS builder
 
 WORKDIR /build
 COPY go.mod go.sum ./

--- a/apps/iam/go.mod
+++ b/apps/iam/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/iam
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/grafana/grafana => ../../
 

--- a/apps/investigations/go.mod
+++ b/apps/investigations/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/investigations
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/grafana/grafana-app-sdk v0.40.3

--- a/apps/playlist/go.mod
+++ b/apps/playlist/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/playlist
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/grafana/grafana-app-sdk v0.40.3

--- a/apps/plugins/go.mod
+++ b/apps/plugins/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/plugins
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/grafana/authlib/types v0.0.0-20250710201142-9542f2f28d43

--- a/apps/preferences/go.mod
+++ b/apps/preferences/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/preferences
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/grafana/grafana-app-sdk v0.40.3

--- a/apps/provisioning/go.mod
+++ b/apps/provisioning/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/provisioning
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/google/go-github/v70 v70.0.0

--- a/apps/secret/go.mod
+++ b/apps/secret/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/secret
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/grafana/grafana-app-sdk v0.40.3

--- a/apps/shorturl/go.mod
+++ b/apps/shorturl/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/apps/shorturl
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/grafana/grafana-app-sdk v0.40.3

--- a/devenv/docker/blocks/prometheus_high_card/go.mod
+++ b/devenv/docker/blocks/prometheus_high_card/go.mod
@@ -1,6 +1,6 @@
 module high-card
 
-go 1.26.3
+go 1.26.4
 
 require github.com/prometheus/client_golang v1.23.2
 

--- a/devenv/docker/blocks/prometheus_utf8/go.mod
+++ b/devenv/docker/blocks/prometheus_utf8/go.mod
@@ -1,6 +1,6 @@
 module utf8-support
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/prometheus/client_golang v1.23.2

--- a/devenv/docker/blocks/stateful_webhook/Dockerfile
+++ b/devenv/docker/blocks/stateful_webhook/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.3
+FROM golang:1.26.4
 
 ADD main.go /go/src/webhook/main.go
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana
 
-go 1.26.3
+go 1.26.4
 
 require (
 	buf.build/gen/go/parca-dev/parca/connectrpc/go v1.18.1-20250703125925-3f0fcf4bff96.1 // @grafana/observability-traces-and-profiling

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.26.3
+go 1.26.4
 
 // The `skip:golangci-lint` comment tag is used to exclude the package from the `golangci-lint` GitHub Action.
 // The module at the root of the repo (`.`) is excluded because ./pkg/... is included manually in the `golangci-lint` configuration.

--- a/hack/go.mod
+++ b/hack/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/hack
 
-go 1.26.3
+go 1.26.4
 
 require k8s.io/code-generator v0.33.1
 

--- a/pkg/aggregator/go.mod
+++ b/pkg/aggregator/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/aggregator
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/emicklei/go-restful/v3 v3.12.2

--- a/pkg/apimachinery/go.mod
+++ b/pkg/apimachinery/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/apimachinery
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/go-jose/go-jose/v3 v3.0.5 // @grafana/identity-access-team

--- a/pkg/apiserver/go.mod
+++ b/pkg/apiserver/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/apiserver
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/pkg/build/go.mod
+++ b/pkg/build/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/build
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/google/uuid v1.6.0 // indirect; @grafana/grafana-backend-group

--- a/pkg/build/wire/go.mod
+++ b/pkg/build/wire/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/build/wire
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/google/go-cmp v0.7.0

--- a/pkg/codegen/go.mod
+++ b/pkg/codegen/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/codegen
 
-go 1.26.3
+go 1.26.4
 
 require (
 	cuelang.org/go v0.11.1

--- a/pkg/plugins/codegen/go.mod
+++ b/pkg/plugins/codegen/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/plugins/codegen
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/grafana/grafana/pkg/codegen => ../../codegen
 

--- a/pkg/promlib/go.mod
+++ b/pkg/promlib/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/promlib
 
-go 1.26.3
+go 1.26.4
 
 require (
 	github.com/grafana/dskit v0.0.0-20260427162712-0457a92dacc3

--- a/pkg/semconv/go.mod
+++ b/pkg/semconv/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana/pkg/semconv
 
-go 1.26.3
+go 1.26.4
 
 require go.opentelemetry.io/otel v1.43.0
 

--- a/scripts/go-workspace/go.mod
+++ b/scripts/go-workspace/go.mod
@@ -1,5 +1,5 @@
 module github.com/grafana/grafana/scripts/go-workspace
 
-go 1.26.3
+go 1.26.4
 
 require golang.org/x/mod v0.30.0

--- a/scripts/modowners/go.mod
+++ b/scripts/modowners/go.mod
@@ -1,5 +1,5 @@
 module github.com/grafana/grafana/scripts/modowners
 
-go 1.26.3
+go 1.26.4
 
 require golang.org/x/mod v0.30.0


### PR DESCRIPTION
Addresses:
- CVE-2026-42504
- CVE-2026-42507
- CVE-2026-27145