### PR TITLE
CI: Update Dependabot PR Updater for GATB

### DIFF
--- a/.github/workflows/pr-dependabot-update-go-workspace.yml
+++ b/.github/workflows/pr-dependabot-update-go-workspace.yml
@@ -22,29 +22,18 @@ jobs:
     if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' && github.event.pull_request.head.repo.full_name == github.repository }}
     continue-on-error: true
     steps:
-    - name: Retrieve GitHub App secrets
-      id: get-secrets
-      uses: grafana/shared-workflows/actions/get-vault-secrets@get-vault-secrets-v1.0.1 # zizmor: ignore[unpinned-uses]
+    - name: Get GitHub App token
+      id: get-github-app-token
+      uses: grafana/shared-workflows/actions/create-github-app-token@259ba21cb3ff07724f331e26d926d655d24b317b # create-github-app-token/v0.2.3
       with:
-        repo_secrets: |
-          APP_ID=grafana-go-workspace-bot:app-id
-          APP_INSTALLATION_ID=grafana-go-workspace-bot:app-installation-id
-          PRIVATE_KEY=grafana-go-workspace-bot:private-key
-
-    - name: Generate GitHub App token
-      id: generate_token
-      uses: actions/create-github-app-token@v1
-      with:
-        app-id: ${{ env.APP_ID }}
-        installation-id: ${{ env.APP_INSTALLATION_ID }}
-        private-key: ${{ env.PRIVATE_KEY }}
+        github_app: grafana-go-workspace-bot
 
     - name: Checkout repository
       uses: actions/checkout@v5
       with:
         repository: ${{ github.event.pull_request.head.repo.full_name }}
         ref: ${{ github.event.pull_request.head.ref }}
-        token: ${{ steps.generate_token.outputs.token }}
+        token: ${{ secrets.GITHUB_TOKEN }}
         persist-credentials: false
 
     - name: Setup Go
@@ -63,7 +52,7 @@ jobs:
     - name: Commit and push workspace changes
       env:
         BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
-        GH_TOKEN: ${{ steps.generate_token.outputs.token }}
+        GH_TOKEN: ${{ steps.get-github-app-token.outputs.token }}
       run: |
         if ! git diff --exit-code --quiet; then
           echo "Committing and pushing workspace changes"


### PR DESCRIPTION
Uses the new GATB workflow to get app tokens to push the commits to Dependabot PRs