### PR TITLE
docs(alerting): clarify alert rule search syntax

### DIFF
--- a/docs/sources/alerting/monitor-status/view-alert-rules.md
+++ b/docs/sources/alerting/monitor-status/view-alert-rules.md
@@ -68,7 +68,7 @@ For example:
 
 You can combine multiple filters in a single search. Any text entered without a `key:` prefix is treated as a query that filters alert rules by name.
 
-Regex matching is supported in search values. However, Go templates used for dynamic labels are not evaluated when searching, so you can't match against the rendered value of a templated label.
+Regex matching is supported in search values. For labels whose values are set by Go templates, search matches against the rendered static value, not the template expression, so you can't use a template query to find a match.
 
 The search input and the **Filter** popup are kept in sync, so changes made in either place are reflected in the other.
 

--- a/docs/sources/alerting/monitor-status/view-alert-rules.md
+++ b/docs/sources/alerting/monitor-status/view-alert-rules.md
@@ -45,6 +45,33 @@ Click the **Saved searches** button to open the list of previously saved searche
 
 {{< figure src="/media/docs/alerting/alerting-saved-searches.png" max-width="750px" alt="Alert rule filter options" >}}
 
+### Search syntax
+
+The search input accepts a structured `key:value` syntax. The key on the left of the colon is the filter type, and the value on the right is what you want to match. Use quotation marks around values that contain spaces, for example `rule:"High CPU usage"`.
+
+The following filter types are supported:
+
+- `datasource`
+- `namespace`
+- `label`
+- `group`
+- `rule`
+- `state`
+- `type`
+- `health`
+
+For example:
+
+- `label:severity` filters rules by the `severity` label.
+- `health:error` filters rules whose health is in an error state.
+- `rule:"High CPU usage"` filters rules by name.
+
+You can combine multiple filters in a single search. Any text entered without a `key:` prefix is treated as a query that filters alert rules by name.
+
+Regex matching is supported in search values. However, Go templates used for dynamic labels are not evaluated when searching, so you can't match against the rendered value of a templated label.
+
+The search input and the **Filter** popup are kept in sync, so changes made in either place are reflected in the other.
+
 ## Change alert rules list view
 
 You can also change how the rule list is displayed using the **View as** option.


### PR DESCRIPTION
## What this PR does

Adds a **Search syntax** subsection to the *View alert rules* page clarifying how searching for alert rules works.

### Changes

- Documents the `key:value` search pattern and quoting rule for values with spaces
- Lists the supported filter types: `datasource`, `namespace`, `label`, `group`, `rule`, `state`, `type`, `health`
- Adds concrete examples (`label:severity`, `health:error`, `rule:"High CPU usage"`)
- Notes that free-form text without a `key:` prefix filters by rule name
- Clarifies that regex matching is supported, but Go templates used for dynamic labels are not evaluated when searching
- Notes the two-way sync between the search input and the Filter popup

Based on the [Grafana Alerting search blog post](https://grafana.com/blog/grafana-alerting-searching-for-grafana-alerts-just-got-faster-easier-and-more-accurate/). This information was not previously documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)