### PR TITLE
Datasources: Remove pagination from getDataSourceInstanceSettingsList

### DIFF
--- a/packages/grafana-runtime/src/internal/index.ts
+++ b/packages/grafana-runtime/src/internal/index.ts
@@ -73,10 +73,6 @@ export { refetchPluginSettings } from '../services/pluginSettings/refetchPluginS
 export { invalidatePluginSettingsCache } from '../services/pluginSettings/invalidatePluginSettingsCache';
 
 export { initDataSourceInstanceSettings, getDataSourceInstanceSettingsList } from '../services/dataSource/settings';
-export {
-  type DataSourceInstanceSettingsPage,
-  type GetDataSourceInstanceSettingsListOptions,
-} from '../services/dataSource/types';
 export { setDataSourcePluginImporter } from '../services/dataSource/dataSource';
 export {
   useDataSourceInstanceSettingsList,

--- a/packages/grafana-runtime/src/services/dataSource/hooks.test.tsx
+++ b/packages/grafana-runtime/src/services/dataSource/hooks.test.tsx
@@ -86,22 +86,11 @@ describe('useDataSourceInstanceSettings', () => {
 });
 
 describe('useDataSourceInstanceSettingsList', () => {
-  it('populates items and reports hasMore=false for the initial page', async () => {
+  it('populates items', async () => {
     const { result } = renderHook(() => useDataSourceInstanceSettingsList());
 
     await waitFor(() => expect(result.current.isLoading).toBe(false));
     expect(result.current.items.length).toBeGreaterThan(0);
-    expect(result.current.hasMore).toBe(false);
-  });
-
-  it('is safe to call fetchMore when there are no more pages', async () => {
-    const { result } = renderHook(() => useDataSourceInstanceSettingsList());
-    await waitFor(() => expect(result.current.isLoading).toBe(false));
-
-    act(() => {
-      result.current.fetchMore();
-    });
-    await waitFor(() => expect(result.current.isLoading).toBe(false));
   });
 
   it('does not re-fetch when the same filter function reference is re-rendered', async () => {

--- a/packages/grafana-runtime/src/services/dataSource/hooks.ts
+++ b/packages/grafana-runtime/src/services/dataSource/hooks.ts
@@ -1,5 +1,5 @@
-import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useAsync, useAsyncFn } from 'react-use';
+import { useMemo } from 'react';
+import { useAsync } from 'react-use';
 
 import { type DataSourceApi, type DataSourceInstanceSettings, type DataSourceRef } from '@grafana/data';
 
@@ -23,11 +23,7 @@ export interface UseDataSourceInstanceSettingsResult {
 export interface UseDataSourceInstanceSettingsListResult {
   isLoading: boolean;
   error?: Error;
-  /** Flattened items across all pages fetched so far. */
   items: DataSourceInstanceSettings[];
-  hasMore: boolean;
-  /** Fetch the next page and append to items. */
-  fetchMore: () => void;
 }
 
 /**
@@ -70,8 +66,7 @@ export function useDataSourceInstanceSettings(
 }
 
 /**
- * React hook wrapping {@link getDataSourceInstanceSettingsList}. Items are flattened
- * across pages; call `fetchMore` to load additional pages. Items reset when
+ * React hook wrapping {@link getDataSourceInstanceSettingsList}. Re-fetches when
  * `filters` changes (compared by value, so inline objects are safe).
  * When `filters.filter` (a callback) is set, the hook re-fetches when the
  * function reference changes. Wrap inline filter callbacks in `useCallback`
@@ -92,42 +87,13 @@ export function useDataSourceInstanceSettingsList(
     return null;
   }, [filterFunc]);
 
-  const [items, setItems] = useState<DataSourceInstanceSettings[]>([]);
-  const [cursor, setCursor] = useState<string | undefined>(undefined);
-  const [hasMore, setHasMore] = useState(true);
-
-  const [fetchState, fetchPage] = useAsyncFn(
-    (nextCursor?: string) => getDataSourceInstanceSettingsList({ filters, cursor: nextCursor }),
+  const { loading, error, value } = useAsync(
+    () => getDataSourceInstanceSettingsList(filters),
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [filterValuesKey, filterFuncKey],
-    { loading: true }
+    [filterValuesKey, filterFuncKey]
   );
 
-  useEffect(() => {
-    if (!fetchState.value) {
-      return;
-    }
-    const page = fetchState.value;
-    setItems((prev) => prev.concat(page.items));
-    setCursor(page.nextCursor);
-    setHasMore(page.hasMore);
-  }, [fetchState.value]);
-
-  useEffect(() => {
-    setItems([]);
-    setCursor(undefined);
-    setHasMore(true);
-    fetchPage();
-  }, [fetchPage]);
-
-  const fetchMore = useCallback(() => {
-    if (!hasMore || fetchState.loading) {
-      return;
-    }
-    fetchPage(cursor);
-  }, [fetchPage, cursor, hasMore, fetchState.loading]);
-
-  return { isLoading: fetchState.loading, error: fetchState.error, items, hasMore, fetchMore };
+  return { isLoading: loading, error, items: value ?? [] };
 }
 
 /**

--- a/packages/grafana-runtime/src/services/dataSource/settings.test.ts
+++ b/packages/grafana-runtime/src/services/dataSource/settings.test.ts
@@ -206,18 +206,16 @@ describe('instanceSettings', () => {
   });
 
   describe('getDataSourceInstanceSettingsList', () => {
-    it('returns a paginated response shape', async () => {
+    it('returns an array of instance settings', async () => {
       initDataSourceInstanceSettings(fixtures, 'Bravo');
-      const page = await getDataSourceInstanceSettingsList();
-      expect(page.hasMore).toBe(false);
-      expect(page.nextCursor).toBeUndefined();
-      expect(Array.isArray(page.items)).toBe(true);
+      const items = await getDataSourceInstanceSettingsList();
+      expect(Array.isArray(items)).toBe(true);
     });
 
     it('filters out built-in grafana / mixed / dashboard by default', async () => {
       initDataSourceInstanceSettings(fixtures, 'Bravo');
-      const page = await getDataSourceInstanceSettingsList();
-      const names = page.items.map((x) => x.name);
+      const items = await getDataSourceInstanceSettingsList();
+      const names = items.map((x) => x.name);
       expect(names).not.toContain('-- Mixed --');
       expect(names).not.toContain('-- Dashboard --');
       expect(names).toContain('Alpha');
@@ -226,21 +224,21 @@ describe('instanceSettings', () => {
 
     it('honours the `mixed` filter', async () => {
       initDataSourceInstanceSettings(fixtures, 'Bravo');
-      const page = await getDataSourceInstanceSettingsList({ filters: { mixed: true } });
-      expect(page.items.some((x) => x.name === '-- Mixed --')).toBe(true);
+      const items = await getDataSourceInstanceSettingsList({ mixed: true });
+      expect(items.some((x) => x.name === '-- Mixed --')).toBe(true);
     });
 
     it('honours the `tracing` filter and excludes metrics-only sources', async () => {
       initDataSourceInstanceSettings(fixtures, 'Bravo');
-      const page = await getDataSourceInstanceSettingsList({ filters: { tracing: true } });
-      const names = page.items.map((x) => x.name);
+      const items = await getDataSourceInstanceSettingsList({ tracing: true });
+      const names = items.map((x) => x.name);
       expect(names).toEqual(['Charlie']);
     });
 
     it('honours the `metrics` filter', async () => {
       initDataSourceInstanceSettings(fixtures, 'Bravo');
-      const page = await getDataSourceInstanceSettingsList({ filters: { metrics: true } });
-      const names = page.items.map((x) => x.name);
+      const items = await getDataSourceInstanceSettingsList({ metrics: true });
+      const names = items.map((x) => x.name);
       expect(names).toContain('Alpha');
       expect(names).not.toContain('Charlie');
     });
@@ -257,8 +255,8 @@ describe('instanceSettings', () => {
         Alpha: fixtures.Alpha,
       };
       initDataSourceInstanceSettings(withLogs, 'Alpha');
-      const page = await getDataSourceInstanceSettingsList({ filters: { logs: true } });
-      const names = page.items.map((x) => x.name);
+      const items = await getDataSourceInstanceSettingsList({ logs: true });
+      const names = items.map((x) => x.name);
       expect(names).toContain('Loki');
       expect(names).not.toContain('Alpha');
     });
@@ -275,8 +273,8 @@ describe('instanceSettings', () => {
         Alpha: fixtures.Alpha,
       };
       initDataSourceInstanceSettings(withAnnotations, 'Alpha');
-      const page = await getDataSourceInstanceSettingsList({ filters: { annotations: true } });
-      const names = page.items.map((x) => x.name);
+      const items = await getDataSourceInstanceSettingsList({ annotations: true });
+      const names = items.map((x) => x.name);
       expect(names).toContain('Annotator');
       expect(names).not.toContain('Alpha');
     });
@@ -293,17 +291,17 @@ describe('instanceSettings', () => {
         Alpha: fixtures.Alpha,
       };
       initDataSourceInstanceSettings(withAlerting, 'Alpha');
-      const page = await getDataSourceInstanceSettingsList({ filters: { alerting: true } });
-      const names = page.items.map((x) => x.name);
+      const items = await getDataSourceInstanceSettingsList({ alerting: true });
+      const names = items.map((x) => x.name);
       expect(names).toContain('Alerter');
       expect(names).not.toContain('Alpha');
     });
 
     it('honours the `type` filter with a string', async () => {
       initDataSourceInstanceSettings(fixtures, 'Bravo');
-      const page = await getDataSourceInstanceSettingsList({ filters: { type: 'test-db' } });
+      const items = await getDataSourceInstanceSettingsList({ type: 'test-db' });
       // Grafana DS is always appended, so filter the base items.
-      const baseItems = page.items.filter((x) => x.meta.id !== 'grafana');
+      const baseItems = items.filter((x) => x.meta.id !== 'grafana');
       expect(baseItems.every((x) => x.type === 'test-db')).toBe(true);
       expect(baseItems.length).toBeGreaterThan(0);
     });
@@ -320,16 +318,14 @@ describe('instanceSettings', () => {
         Alpha: fixtures.Alpha,
       };
       initDataSourceInstanceSettings(mixed, 'Alpha');
-      const page = await getDataSourceInstanceSettingsList({ filters: { type: ['prometheus', 'test-db'] } });
-      expect(page.items.length).toBe(2);
+      const items = await getDataSourceInstanceSettingsList({ type: ['prometheus', 'test-db'] });
+      expect(items.length).toBe(2);
     });
 
     it('honours a custom `filter` function', async () => {
       initDataSourceInstanceSettings(fixtures, 'Bravo');
-      const page = await getDataSourceInstanceSettingsList({
-        filters: { filter: (x) => x.name === 'Alpha' },
-      });
-      const names = page.items.map((x) => x.name);
+      const items = await getDataSourceInstanceSettingsList({ filter: (x) => x.name === 'Alpha' });
+      const names = items.map((x) => x.name);
       expect(names).toEqual(['Alpha']);
     });
 
@@ -355,26 +351,26 @@ describe('instanceSettings', () => {
       initDataSourceInstanceSettings(noCapability, 'Alpha');
 
       const withoutAll = await getDataSourceInstanceSettingsList();
-      expect(withoutAll.items.map((x) => x.name)).not.toContain('NoOp');
+      expect(withoutAll.map((x) => x.name)).not.toContain('NoOp');
 
-      const withAll = await getDataSourceInstanceSettingsList({ filters: { all: true } });
-      expect(withAll.items.map((x) => x.name)).toContain('NoOp');
+      const withAll = await getDataSourceInstanceSettingsList({ all: true });
+      expect(withAll.map((x) => x.name)).toContain('NoOp');
     });
 
     it('honours the `dashboard` filter', async () => {
       initDataSourceInstanceSettings(fixtures, 'Bravo');
-      const page = await getDataSourceInstanceSettingsList({ filters: { dashboard: true } });
-      expect(page.items.some((x) => x.name === '-- Dashboard --')).toBe(true);
+      const items = await getDataSourceInstanceSettingsList({ dashboard: true });
+      expect(items.some((x) => x.name === '-- Dashboard --')).toBe(true);
     });
 
     it('includes Grafana DS by default but excludes it when tracing filter is set', async () => {
       initDataSourceInstanceSettings(fixtures, 'Bravo');
 
-      const defaultPage = await getDataSourceInstanceSettingsList();
-      expect(defaultPage.items.some((x) => x.name === '-- Grafana --')).toBe(true);
+      const defaultItems = await getDataSourceInstanceSettingsList();
+      expect(defaultItems.some((x) => x.name === '-- Grafana --')).toBe(true);
 
-      const tracingPage = await getDataSourceInstanceSettingsList({ filters: { tracing: true } });
-      expect(tracingPage.items.some((x) => x.name === '-- Grafana --')).toBe(false);
+      const tracingItems = await getDataSourceInstanceSettingsList({ tracing: true });
+      expect(tracingItems.some((x) => x.name === '-- Grafana --')).toBe(false);
     });
 
     it('does not add built-in datasources when alerting filter is set', async () => {
@@ -389,17 +385,17 @@ describe('instanceSettings', () => {
         }),
       };
       initDataSourceInstanceSettings(withAlerting, 'Bravo');
-      const page = await getDataSourceInstanceSettingsList({ filters: { alerting: true, mixed: true } });
-      expect(page.items.some((x) => x.name === '-- Mixed --')).toBe(false);
-      expect(page.items.some((x) => x.name === '-- Grafana --')).toBe(false);
+      const items = await getDataSourceInstanceSettingsList({ alerting: true, mixed: true });
+      expect(items.some((x) => x.name === '-- Mixed --')).toBe(false);
+      expect(items.some((x) => x.name === '-- Grafana --')).toBe(false);
     });
 
     it('does not include runtime datasources in list results', async () => {
       initDataSourceInstanceSettings(fixtures, 'Bravo');
       upsertRuntimeDataSourceInstanceSettings(ds({ uid: 'runtime-ds', name: 'Runtime', type: 'runtime' }));
 
-      const page = await getDataSourceInstanceSettingsList({ filters: { all: true } });
-      expect(page.items.some((x) => x.uid === 'runtime-ds')).toBe(false);
+      const items = await getDataSourceInstanceSettingsList({ all: true });
+      expect(items.some((x) => x.uid === 'runtime-ds')).toBe(false);
     });
 
     it('injects datasource variables when `variables` filter is set', async () => {
@@ -409,8 +405,8 @@ describe('instanceSettings', () => {
       } as unknown as TemplateSrv);
 
       initDataSourceInstanceSettings(fixtures, 'Bravo');
-      const page = await getDataSourceInstanceSettingsList({ filters: { variables: true } });
-      const names = page.items.map((x) => x.name);
+      const items = await getDataSourceInstanceSettingsList({ variables: true });
+      const names = items.map((x) => x.name);
       expect(names).toContain('${dsVar}');
 
       // Restore original templateSrv
@@ -419,8 +415,8 @@ describe('instanceSettings', () => {
 
     it('returns items sorted alphabetically by name', async () => {
       initDataSourceInstanceSettings(fixtures, 'Bravo');
-      const page = await getDataSourceInstanceSettingsList();
-      const names = page.items.filter((x) => x.name !== '-- Grafana --').map((x) => x.name);
+      const items = await getDataSourceInstanceSettingsList();
+      const names = items.filter((x) => x.name !== '-- Grafana --').map((x) => x.name);
       const sorted = [...names].sort((a, b) => a.toLowerCase().localeCompare(b.toLowerCase()));
       expect(names).toEqual(sorted);
     });

--- a/packages/grafana-runtime/src/services/dataSource/settings.ts
+++ b/packages/grafana-runtime/src/services/dataSource/settings.ts
@@ -13,9 +13,6 @@ import { type GetDataSourceListFilters } from '../dataSourceSrv';
 import { getTemplateSrv } from '../templateSrv';
 
 import { clearPluginCache } from './pluginCache';
-import { type DataSourceInstanceSettingsPage, type GetDataSourceInstanceSettingsListOptions } from './types';
-
-export type { DataSourceInstanceSettingsPage, GetDataSourceInstanceSettingsListOptions };
 
 let byName: Record<string, DataSourceInstanceSettings> = {};
 let byUid: Record<string, DataSourceInstanceSettings> = {};
@@ -99,16 +96,13 @@ export async function getDataSourceInstanceSettings(
 
 /**
  * Search and filter data source instance settings from the in-memory cache.
- * Returns a paginated response; the initial implementation always returns
- * every matching item in a single page.
  *
  * @internal
  */
 export async function getDataSourceInstanceSettingsList(
-  options?: GetDataSourceInstanceSettingsListOptions
-): Promise<DataSourceInstanceSettingsPage> {
-  const items = applyFilters(options?.filters);
-  return { items, hasMore: false, nextCursor: undefined };
+  filters?: GetDataSourceListFilters
+): Promise<DataSourceInstanceSettings[]> {
+  return applyFilters(filters);
 }
 
 /**

--- a/packages/grafana-runtime/src/services/dataSource/types.ts
+++ b/packages/grafana-runtime/src/services/dataSource/types.ts
@@ -1,37 +1,10 @@
 import {
   type DataSourceApi,
-  type DataSourceInstanceSettings,
   type DataSourceJsonData,
   type DataSourcePlugin,
   type DataSourcePluginMeta,
 } from '@grafana/data';
 import { type DataQuery } from '@grafana/schema';
-
-import { type GetDataSourceListFilters } from '../dataSourceSrv';
-
-/**
- * Paginated response shape. The initial implementation always returns
- * every item in a single page — `hasMore` is false and `nextCursor` undefined.
- * The shape is in place so callers don't need to migrate twice when real
- * pagination lands on the backend.
- *
- * @internal
- */
-export interface DataSourceInstanceSettingsPage {
-  items: DataSourceInstanceSettings[];
-  /** Opaque cursor for fetching the next page. Undefined when no more pages. */
-  nextCursor?: string;
-  hasMore: boolean;
-}
-
-/**
- * @internal
- */
-export interface GetDataSourceInstanceSettingsListOptions {
-  filters?: GetDataSourceListFilters;
-  /** Cursor returned by a previous call; omit to fetch the first page. */
-  cursor?: string;
-}
 
 /** @internal */
 type GenericDataSourcePlugin = DataSourcePlugin<


### PR DESCRIPTION
## What

Removes the pagination scaffolding from the new (internal) `getDataSourceInstanceSettingsList` API and `useDataSourceInstanceSettingsList` hook so they return a plain list of instance settings instead of a paginated page.

## Why

Pagination was added pre-emptively in #123037 to avoid forcing a second migration on external plugin developers once real pagination landed. After further discussion we found we can shrink this endpoint's payload by ~80% instead, so pagination is no longer expected to be needed. The API has not been exposed externally yet, so there are no callers to migrate.