### PR TITLE
RBAC: Chore: add missed fixed roles

### DIFF
--- a/pkg/services/accesscontrol/ossaccesscontrol/dashboard.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/dashboard.go
@@ -93,11 +93,11 @@ func registerDashboardRoles(cfg *setting.Cfg, _ featuremgmt.FeatureToggles, serv
 // Options passed there.
 func DashboardPermissionsRoleRegistrations() []accesscontrol.RoleRegistration {
 	return resourcepermissions.FixedRoleRegistrations(resourcepermissions.Options{
-		Resource:       "dashboards",
+		Resource:       dashboardPermissionsResource,
 		APIGroup:       dashboardv1.APIGroup,
-		ReaderRoleName: "Permission reader",
-		WriterRoleName: "Permission writer",
-		RoleGroup:      "Dashboards",
+		ReaderRoleName: permissionReaderRoleName,
+		WriterRoleName: permissionWriterRoleName,
+		RoleGroup:      dashboardPermissionsRoleGroup,
 	})
 }
 
@@ -121,7 +121,7 @@ func ProvideDashboardPermissions(
 	}
 
 	options := resourcepermissions.Options{
-		Resource:          "dashboards",
+		Resource:          dashboardPermissionsResource,
 		ResourceAttribute: "uid",
 		APIGroup:          dashboardv1.APIGroup,
 		ResourceValidator: func(ctx context.Context, orgID int64, resourceID string) error {
@@ -173,9 +173,9 @@ func ProvideDashboardPermissions(
 			"Edit":  DashboardEditActions,
 			"Admin": DashboardAdminActions,
 		},
-		ReaderRoleName: "Permission reader",
-		WriterRoleName: "Permission writer",
-		RoleGroup:      "Dashboards",
+		ReaderRoleName: permissionReaderRoleName,
+		WriterRoleName: permissionWriterRoleName,
+		RoleGroup:      dashboardPermissionsRoleGroup,
 		GetParentFolder: func(ctx context.Context, namespace string, dashboardUID string, dynamicClient dynamic.Interface) (string, error) {
 			dashboardsGVR := schema.GroupVersionResource{
 				Group:    dashboardv1.APIGroup,

--- a/pkg/services/accesscontrol/ossaccesscontrol/dashboard.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/dashboard.go
@@ -86,6 +86,21 @@ func registerDashboardRoles(cfg *setting.Cfg, _ featuremgmt.FeatureToggles, serv
 	return service.DeclareFixedRoles(DashboardFixedRoleRegistrations(cfg.RBAC.PermissionsWildcardSeed("dashboard"))...)
 }
 
+// DashboardPermissionsRoleRegistrations returns the templated reader/writer fixed
+// roles for dashboard resource permissions (fixed:dashboards.permissions:reader
+// and :writer). These mirror the roles declared by ProvideDashboardPermissions
+// through resourcepermissions.New; the identity fields below must match the
+// Options passed there.
+func DashboardPermissionsRoleRegistrations() []accesscontrol.RoleRegistration {
+	return resourcepermissions.FixedRoleRegistrations(resourcepermissions.Options{
+		Resource:       "dashboards",
+		APIGroup:       dashboardv1.APIGroup,
+		ReaderRoleName: "Permission reader",
+		WriterRoleName: "Permission writer",
+		RoleGroup:      "Dashboards",
+	})
+}
+
 func ProvideDashboardPermissions(
 	cfg *setting.Cfg, features featuremgmt.FeatureToggles, router routing.RouteRegister, sql db.DB, ac accesscontrol.AccessControl,
 	license licensing.Licensing, dashboardService dashboards.DashboardService, folderService folder.Service, service accesscontrol.Service,

--- a/pkg/services/accesscontrol/ossaccesscontrol/folder.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/folder.go
@@ -102,11 +102,11 @@ func registerFolderRoles(cfg *setting.Cfg, _ featuremgmt.FeatureToggles, service
 // passed there.
 func FolderPermissionsRoleRegistrations() []accesscontrol.RoleRegistration {
 	return resourcepermissions.FixedRoleRegistrations(resourcepermissions.Options{
-		Resource:       "folders",
+		Resource:       folderPermissionsResource,
 		APIGroup:       folderv1.APIGroup,
-		ReaderRoleName: "Permission reader",
-		WriterRoleName: "Permission writer",
-		RoleGroup:      "Folders",
+		ReaderRoleName: permissionReaderRoleName,
+		WriterRoleName: permissionWriterRoleName,
+		RoleGroup:      folderPermissionsRoleGroup,
 	})
 }
 
@@ -121,7 +121,7 @@ func ProvideFolderPermissions(
 	}
 
 	options := resourcepermissions.Options{
-		Resource:          "folders",
+		Resource:          folderPermissionsResource,
 		ResourceAttribute: "uid",
 		APIGroup:          folderv1.APIGroup,
 		ResourceValidator: func(ctx context.Context, orgID int64, resourceID string) error {
@@ -165,9 +165,9 @@ func ProvideFolderPermissions(
 			"Edit":  append(DashboardEditActions, FolderEditActions...),
 			"Admin": append(DashboardAdminActions, FolderAdminActions...),
 		},
-		ReaderRoleName:     "Permission reader",
-		WriterRoleName:     "Permission writer",
-		RoleGroup:          "Folders",
+		ReaderRoleName:     permissionReaderRoleName,
+		WriterRoleName:     permissionWriterRoleName,
+		RoleGroup:          folderPermissionsRoleGroup,
 		RestConfigProvider: restConfigProvider,
 	}
 	srv, err := resourcepermissions.New(cfg, options, features, router, license, accesscontrol, service, sql, teamService, userService, actionSetService)

--- a/pkg/services/accesscontrol/ossaccesscontrol/folder.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/folder.go
@@ -95,6 +95,21 @@ func registerFolderRoles(cfg *setting.Cfg, _ featuremgmt.FeatureToggles, service
 	return service.DeclareFixedRoles(FolderFixedRoleRegistrations(cfg.RBAC.PermissionsWildcardSeed("folder"))...)
 }
 
+// FolderPermissionsRoleRegistrations returns the templated reader/writer fixed
+// roles for folder resource permissions (fixed:folders.permissions:reader and
+// :writer). These mirror the roles declared by ProvideFolderPermissions through
+// resourcepermissions.New; the identity fields below must match the Options
+// passed there.
+func FolderPermissionsRoleRegistrations() []accesscontrol.RoleRegistration {
+	return resourcepermissions.FixedRoleRegistrations(resourcepermissions.Options{
+		Resource:       "folders",
+		APIGroup:       folderv1.APIGroup,
+		ReaderRoleName: "Permission reader",
+		WriterRoleName: "Permission writer",
+		RoleGroup:      "Folders",
+	})
+}
+
 func ProvideFolderPermissions(
 	cfg *setting.Cfg, features featuremgmt.FeatureToggles, router routing.RouteRegister, sql db.DB, accesscontrol accesscontrol.AccessControl,
 	license licensing.Licensing, folderService folder.Service, service accesscontrol.Service,

--- a/pkg/services/accesscontrol/ossaccesscontrol/receivers.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/receivers.go
@@ -33,6 +33,20 @@ func defaultPermissions() []accesscontrol.SetResourcePermissionCommand {
 	}
 }
 
+// ReceiverPermissionsRoleRegistrations returns the templated reader/writer fixed
+// roles for alerting receiver resource permissions
+// (fixed:receivers.permissions:reader and :writer). These mirror the roles
+// declared by ProvideReceiverPermissionsService through resourcepermissions.New;
+// the identity fields below must match the Options passed there.
+func ReceiverPermissionsRoleRegistrations() []accesscontrol.RoleRegistration {
+	return resourcepermissions.FixedRoleRegistrations(resourcepermissions.Options{
+		Resource:       "receivers",
+		ReaderRoleName: "Alerting receiver permission reader",
+		WriterRoleName: "Alerting receiver permission writer",
+		RoleGroup:      models.AlertRolesGroup,
+	})
+}
+
 func ProvideReceiverPermissionsService(
 	cfg *setting.Cfg, features featuremgmt.FeatureToggles, router routing.RouteRegister, sql db.DB, ac accesscontrol.AccessControl,
 	license licensing.Licensing, service accesscontrol.Service,

--- a/pkg/services/accesscontrol/ossaccesscontrol/receivers.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/receivers.go
@@ -40,9 +40,9 @@ func defaultPermissions() []accesscontrol.SetResourcePermissionCommand {
 // the identity fields below must match the Options passed there.
 func ReceiverPermissionsRoleRegistrations() []accesscontrol.RoleRegistration {
 	return resourcepermissions.FixedRoleRegistrations(resourcepermissions.Options{
-		Resource:       "receivers",
-		ReaderRoleName: "Alerting receiver permission reader",
-		WriterRoleName: "Alerting receiver permission writer",
+		Resource:       receiverPermissionsResource,
+		ReaderRoleName: receiverPermissionsReaderRoleName,
+		WriterRoleName: receiverPermissionsWriterRoleName,
 		RoleGroup:      models.AlertRolesGroup,
 	})
 }
@@ -53,7 +53,7 @@ func ProvideReceiverPermissionsService(
 	teamService team.Service, userService user.Service, actionSetService resourcepermissions.ActionSetService,
 ) (*ReceiverPermissionsService, error) {
 	options := resourcepermissions.Options{
-		Resource:          "receivers",
+		Resource:          receiverPermissionsResource,
 		ResourceAttribute: "uid",
 		ResourceTranslator: func(ctx context.Context, orgID int64, resourceID string) (string, error) {
 			return models.ScopeReceiversProvider.GetResourceIDFromUID(resourceID), nil
@@ -69,8 +69,8 @@ func ProvideReceiverPermissionsService(
 			string(models.PermissionEdit):  append([]string{}, ReceiversEditActions...),
 			string(models.PermissionAdmin): append([]string{}, ReceiversAdminActions...),
 		},
-		ReaderRoleName: "Alerting receiver permission reader",
-		WriterRoleName: "Alerting receiver permission writer",
+		ReaderRoleName: receiverPermissionsReaderRoleName,
+		WriterRoleName: receiverPermissionsWriterRoleName,
 		RoleGroup:      models.AlertRolesGroup,
 	}
 

--- a/pkg/services/accesscontrol/ossaccesscontrol/resource_permissions.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/resource_permissions.go
@@ -1,0 +1,35 @@
+package ossaccesscontrol
+
+// Display names shared by the generated reader/writer permission-management
+// roles (fixed:{resource}.permissions:reader and :writer) for resources that use
+// the default naming.
+const (
+	permissionReaderRoleName = "Permission reader"
+	permissionWriterRoleName = "Permission writer"
+)
+
+// Resource identity values shared between the resourcepermissions service
+// constructors (Provide*) and the fixed-role reconstruction consumed by the
+// GlobalRole seeder (*PermissionsRoleRegistrations). Both call sites must use
+// these constants so the generated role names cannot drift apart.
+const (
+	folderPermissionsResource  = "folders"
+	folderPermissionsRoleGroup = "Folders"
+
+	dashboardPermissionsResource  = "dashboards"
+	dashboardPermissionsRoleGroup = "Dashboards"
+
+	teamPermissionsResource  = "teams"
+	teamPermissionsRoleGroup = "Teams"
+
+	serviceAccountPermissionsResource  = "serviceaccounts"
+	serviceAccountPermissionsAPIGroup  = "iam.grafana.app"
+	serviceAccountPermissionsRoleGroup = "Service accounts"
+
+	receiverPermissionsResource       = "receivers"
+	receiverPermissionsReaderRoleName = "Alerting receiver permission reader"
+	receiverPermissionsWriterRoleName = "Alerting receiver permission writer"
+
+	routePermissionsReaderRoleName = "Alerting route permission reader"
+	routePermissionsWriterRoleName = "Alerting route permission writer"
+)

--- a/pkg/services/accesscontrol/ossaccesscontrol/resource_permissions_registrations_test.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/resource_permissions_registrations_test.go
@@ -1,0 +1,119 @@
+package ossaccesscontrol
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/services/accesscontrol"
+	"github.com/grafana/grafana/pkg/services/org"
+)
+
+// These tests lock in the templated reader/writer permission-management roles
+// (fixed:{resource}.permissions:reader and :writer) that the GlobalRole seeder
+// aggregates via AllFixedRoleRegistrations. They must stay in sync with the
+// resourcepermissions.Options declared in the corresponding Provide* functions.
+func TestResourcePermissionsRoleRegistrations(t *testing.T) {
+	tests := []struct {
+		name          string
+		got           []accesscontrol.RoleRegistration
+		readerName    string
+		writerName    string
+		group         string
+		readerActions []string
+		writerActions []string
+		scope         string
+	}{
+		{
+			name:          "folders",
+			got:           FolderPermissionsRoleRegistrations(),
+			readerName:    "fixed:folders.permissions:reader",
+			writerName:    "fixed:folders.permissions:writer",
+			group:         "Folders",
+			readerActions: []string{"folders.permissions:read"},
+			writerActions: []string{"folders.permissions:read", "folders.permissions:write"},
+			scope:         "folders:*",
+		},
+		{
+			name:          "dashboards",
+			got:           DashboardPermissionsRoleRegistrations(),
+			readerName:    "fixed:dashboards.permissions:reader",
+			writerName:    "fixed:dashboards.permissions:writer",
+			group:         "Dashboards",
+			readerActions: []string{"dashboards.permissions:read"},
+			writerActions: []string{"dashboards.permissions:read", "dashboards.permissions:write"},
+			scope:         "dashboards:*",
+		},
+		{
+			name:          "teams",
+			got:           TeamPermissionsRoleRegistrations(),
+			readerName:    "fixed:teams.permissions:reader",
+			writerName:    "fixed:teams.permissions:writer",
+			group:         "Teams",
+			readerActions: []string{"teams.permissions:read"},
+			writerActions: []string{"teams.permissions:read", "teams.permissions:write"},
+			scope:         "teams:*",
+		},
+		{
+			name:          "service accounts",
+			got:           ServiceAccountPermissionsRoleRegistrations(),
+			readerName:    "fixed:serviceaccounts.permissions:reader",
+			writerName:    "fixed:serviceaccounts.permissions:writer",
+			group:         "Service accounts",
+			readerActions: []string{"serviceaccounts.permissions:read"},
+			writerActions: []string{"serviceaccounts.permissions:read", "serviceaccounts.permissions:write"},
+			scope:         "serviceaccounts:*",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Len(t, tt.got, 2, "expected a reader and a writer registration")
+
+			reader, writer := tt.got[0], tt.got[1]
+
+			assert.Equal(t, tt.readerName, reader.Role.Name)
+			assert.Equal(t, tt.writerName, writer.Role.Name)
+			assert.Equal(t, tt.group, reader.Role.Group)
+			assert.Equal(t, tt.group, writer.Role.Group)
+			assert.Equal(t, []string{string(org.RoleAdmin)}, reader.Grants)
+			assert.Equal(t, []string{string(org.RoleAdmin)}, writer.Grants)
+
+			assert.Equal(t, tt.readerActions, actionsOf(reader, tt.scope))
+			assert.Equal(t, tt.writerActions, actionsOf(writer, tt.scope))
+		})
+	}
+}
+
+func TestAlertingPermissionsRoleRegistrations(t *testing.T) {
+	t.Run("receivers use the legacy action format", func(t *testing.T) {
+		regs := ReceiverPermissionsRoleRegistrations()
+		require.Len(t, regs, 2)
+		assert.Equal(t, "fixed:receivers.permissions:reader", regs[0].Role.Name)
+		assert.Equal(t, "fixed:receivers.permissions:writer", regs[1].Role.Name)
+		assert.Equal(t, []string{"receivers.permissions:read"}, actionsOf(regs[0], "receivers:*"))
+	})
+
+	t.Run("routes use the k8s action format", func(t *testing.T) {
+		regs := RoutePermissionsRoleRegistrations()
+		require.Len(t, regs, 2)
+		// K8sActionFormat -> fixed:{APIGroup}:{Resource}.permissions:{suffix}
+		assert.Contains(t, regs[0].Role.Name, ".permissions:reader")
+		assert.Contains(t, regs[1].Role.Name, ".permissions:writer")
+		require.Len(t, regs[0].Role.Permissions, 1)
+		assert.Contains(t, regs[0].Role.Permissions[0].Action, ":get_permissions")
+	})
+}
+
+// actionsOf returns the actions in a registration that target the given scope,
+// preserving order.
+func actionsOf(reg accesscontrol.RoleRegistration, scope string) []string {
+	actions := make([]string, 0, len(reg.Role.Permissions))
+	for _, p := range reg.Role.Permissions {
+		if p.Scope == scope {
+			actions = append(actions, p.Action)
+		}
+	}
+	return actions
+}

--- a/pkg/services/accesscontrol/ossaccesscontrol/routes.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/routes.go
@@ -58,8 +58,8 @@ func RoutePermissionsRoleRegistrations() []accesscontrol.RoleRegistration {
 		APIGroup:        accesscontrol.AlertingNotificationsApiGroup,
 		Resource:        accesscontrol.AlertingRoutesResource,
 		K8sActionFormat: true,
-		ReaderRoleName:  "Alerting route permission reader",
-		WriterRoleName:  "Alerting route permission writer",
+		ReaderRoleName:  routePermissionsReaderRoleName,
+		WriterRoleName:  routePermissionsWriterRoleName,
 		RoleGroup:       models.AlertRolesGroup,
 	})
 }
@@ -88,8 +88,8 @@ func ProvideRoutePermissionsService(
 			PermissionEdit:  append([]string{}, RoutesEditActions...),
 			PermissionAdmin: append([]string{}, RoutesAdminActions...),
 		},
-		ReaderRoleName: "Alerting route permission reader",
-		WriterRoleName: "Alerting route permission writer",
+		ReaderRoleName: routePermissionsReaderRoleName,
+		WriterRoleName: routePermissionsWriterRoleName,
 		RoleGroup:      models.AlertRolesGroup,
 	}
 

--- a/pkg/services/accesscontrol/ossaccesscontrol/routes.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/routes.go
@@ -46,6 +46,24 @@ func routeDefaultPermissions() []accesscontrol.SetResourcePermissionCommand {
 	}
 }
 
+// RoutePermissionsRoleRegistrations returns the templated reader/writer fixed
+// roles for alerting route resource permissions. Routes use the K8s action
+// format, so the role names are
+// fixed:{AlertingNotificationsApiGroup}:{AlertingRoutesResource}.permissions:reader
+// and :writer. These mirror the roles declared by ProvideRoutePermissionsService
+// through resourcepermissions.New; the identity fields below must match the
+// Options passed there.
+func RoutePermissionsRoleRegistrations() []accesscontrol.RoleRegistration {
+	return resourcepermissions.FixedRoleRegistrations(resourcepermissions.Options{
+		APIGroup:        accesscontrol.AlertingNotificationsApiGroup,
+		Resource:        accesscontrol.AlertingRoutesResource,
+		K8sActionFormat: true,
+		ReaderRoleName:  "Alerting route permission reader",
+		WriterRoleName:  "Alerting route permission writer",
+		RoleGroup:       models.AlertRolesGroup,
+	})
+}
+
 func ProvideRoutePermissionsService(
 	cfg *setting.Cfg, features featuremgmt.FeatureToggles, router routing.RouteRegister, sql db.DB, ac accesscontrol.AccessControl,
 	license licensing.Licensing, service accesscontrol.Service,

--- a/pkg/services/accesscontrol/ossaccesscontrol/service_account.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/service_account.go
@@ -36,6 +36,21 @@ type ServiceAccountPermissionsService struct {
 	*resourcepermissions.Service
 }
 
+// ServiceAccountPermissionsRoleRegistrations returns the templated reader/writer
+// fixed roles for service account resource permissions
+// (fixed:serviceaccounts.permissions:reader and :writer). These mirror the roles
+// declared by ProvideServiceAccountPermissions through resourcepermissions.New;
+// the identity fields below must match the Options passed there.
+func ServiceAccountPermissionsRoleRegistrations() []accesscontrol.RoleRegistration {
+	return resourcepermissions.FixedRoleRegistrations(resourcepermissions.Options{
+		Resource:       "serviceaccounts",
+		APIGroup:       "iam.grafana.app",
+		ReaderRoleName: "Permission reader",
+		WriterRoleName: "Permission writer",
+		RoleGroup:      "Service accounts",
+	})
+}
+
 func ProvideServiceAccountPermissions(
 	cfg *setting.Cfg, features featuremgmt.FeatureToggles, router routing.RouteRegister, sql db.DB, ac accesscontrol.AccessControl,
 	license licensing.Licensing, serviceAccountRetrieverService *retriever.Service, service accesscontrol.Service,

--- a/pkg/services/accesscontrol/ossaccesscontrol/service_account.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/service_account.go
@@ -43,11 +43,11 @@ type ServiceAccountPermissionsService struct {
 // the identity fields below must match the Options passed there.
 func ServiceAccountPermissionsRoleRegistrations() []accesscontrol.RoleRegistration {
 	return resourcepermissions.FixedRoleRegistrations(resourcepermissions.Options{
-		Resource:       "serviceaccounts",
-		APIGroup:       "iam.grafana.app",
-		ReaderRoleName: "Permission reader",
-		WriterRoleName: "Permission writer",
-		RoleGroup:      "Service accounts",
+		Resource:       serviceAccountPermissionsResource,
+		APIGroup:       serviceAccountPermissionsAPIGroup,
+		ReaderRoleName: permissionReaderRoleName,
+		WriterRoleName: permissionWriterRoleName,
+		RoleGroup:      serviceAccountPermissionsRoleGroup,
 	})
 }
 
@@ -58,9 +58,9 @@ func ProvideServiceAccountPermissions(
 	restConfigProvider apiserver.DirectRestConfigProvider,
 ) (*ServiceAccountPermissionsService, error) {
 	options := resourcepermissions.Options{
-		Resource:           "serviceaccounts",
+		Resource:           serviceAccountPermissionsResource,
 		ResourceAttribute:  "id",
-		APIGroup:           "iam.grafana.app",
+		APIGroup:           serviceAccountPermissionsAPIGroup,
 		ResourceTranslator: serviceaccounts.UIDToIDHandler(serviceAccountRetrieverService),
 		ResourceValidator: func(ctx context.Context, orgID int64, resourceID string) error {
 			ctx, span := tracer.Start(ctx, "accesscontrol.ossaccesscontrol.ProvideServiceAccountPermissions.ResourceValidator")
@@ -85,9 +85,9 @@ func ProvideServiceAccountPermissions(
 			"Edit":  ServiceAccountEditActions,
 			"Admin": ServiceAccountAdminActions,
 		},
-		ReaderRoleName:     "Permission reader",
-		WriterRoleName:     "Permission writer",
-		RoleGroup:          "Service accounts",
+		ReaderRoleName:     permissionReaderRoleName,
+		WriterRoleName:     permissionWriterRoleName,
+		RoleGroup:          serviceAccountPermissionsRoleGroup,
 		RestConfigProvider: restConfigProvider,
 	}
 

--- a/pkg/services/accesscontrol/ossaccesscontrol/team.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/team.go
@@ -43,10 +43,10 @@ var (
 // passed there.
 func TeamPermissionsRoleRegistrations() []accesscontrol.RoleRegistration {
 	return resourcepermissions.FixedRoleRegistrations(resourcepermissions.Options{
-		Resource:       "teams",
-		ReaderRoleName: "Permission reader",
-		WriterRoleName: "Permission writer",
-		RoleGroup:      "Teams",
+		Resource:       teamPermissionsResource,
+		ReaderRoleName: permissionReaderRoleName,
+		WriterRoleName: permissionWriterRoleName,
+		RoleGroup:      teamPermissionsRoleGroup,
 	})
 }
 
@@ -57,7 +57,7 @@ func ProvideTeamPermissions(
 	directRestConfigProvider apiserver.DirectRestConfigProvider,
 ) (*TeamPermissionsService, error) {
 	options := resourcepermissions.Options{
-		Resource:           "teams",
+		Resource:           teamPermissionsResource,
 		ResourceAttribute:  "id",
 		OnlyManaged:        true,
 		ResourceTranslator: team.UIDToIDHandler(teamService),
@@ -89,9 +89,9 @@ func ProvideTeamPermissions(
 			"Member": TeamMemberActions,
 			"Admin":  TeamAdminActions,
 		},
-		ReaderRoleName: "Permission reader",
-		WriterRoleName: "Permission writer",
-		RoleGroup:      "Teams",
+		ReaderRoleName: permissionReaderRoleName,
+		WriterRoleName: permissionWriterRoleName,
+		RoleGroup:      teamPermissionsRoleGroup,
 		OnSetUser: func(session *db.Session, orgID int64, user accesscontrol.User, resourceID, permission string) error {
 			teamId, err := strconv.ParseInt(resourceID, 10, 64)
 			if err != nil {

--- a/pkg/services/accesscontrol/ossaccesscontrol/team.go
+++ b/pkg/services/accesscontrol/ossaccesscontrol/team.go
@@ -36,6 +36,20 @@ var (
 	}
 )
 
+// TeamPermissionsRoleRegistrations returns the templated reader/writer fixed
+// roles for team resource permissions (fixed:teams.permissions:reader and
+// :writer). These mirror the roles declared by ProvideTeamPermissions through
+// resourcepermissions.New; the identity fields below must match the Options
+// passed there.
+func TeamPermissionsRoleRegistrations() []accesscontrol.RoleRegistration {
+	return resourcepermissions.FixedRoleRegistrations(resourcepermissions.Options{
+		Resource:       "teams",
+		ReaderRoleName: "Permission reader",
+		WriterRoleName: "Permission writer",
+		RoleGroup:      "Teams",
+	})
+}
+
 func ProvideTeamPermissions(
 	cfg *setting.Cfg, features featuremgmt.FeatureToggles, router routing.RouteRegister, sql db.DB,
 	ac accesscontrol.AccessControl, license licensing.Licensing, service accesscontrol.Service,

--- a/pkg/services/accesscontrol/resourcepermissions/service.go
+++ b/pkg/services/accesscontrol/resourcepermissions/service.go
@@ -535,15 +535,22 @@ func (s *Service) validateBuiltinRole(ctx context.Context, builtinRole string) e
 	return nil
 }
 
-func (s *Service) declareFixedRoles() error {
-	scopeAll := s.options.GetScope("*")
+// FixedRoleRegistrations returns the templated reader/writer fixed-role
+// registrations derived from the given Options (fixed:{resource}.permissions:reader
+// and :writer). It is the single source of truth for how per-resource permission
+// management roles are generated, shared by the live service ([Service.declareFixedRoles])
+// and the GlobalRole seeder aggregation so the two cannot drift. Only the
+// role-identity fields of Options are read (Resource, APIGroup, K8sActionFormat,
+// ReaderRoleName, WriterRoleName, RoleGroup); the runtime closures are ignored.
+func FixedRoleRegistrations(o Options) []accesscontrol.RoleRegistration {
+	scopeAll := o.GetScope("*")
 	readerRole := accesscontrol.RoleRegistration{
 		Role: accesscontrol.RoleDTO{
-			Name:        s.options.GetRoleName("reader"),
-			DisplayName: s.options.ReaderRoleName,
-			Group:       s.options.RoleGroup,
+			Name:        o.GetRoleName("reader"),
+			DisplayName: o.ReaderRoleName,
+			Group:       o.RoleGroup,
 			Permissions: []accesscontrol.Permission{
-				{Action: s.options.GetAction("read"), Scope: scopeAll},
+				{Action: o.GetAction("read"), Scope: scopeAll},
 			},
 		},
 		Grants: []string{string(org.RoleAdmin)},
@@ -551,17 +558,21 @@ func (s *Service) declareFixedRoles() error {
 
 	writerRole := accesscontrol.RoleRegistration{
 		Role: accesscontrol.RoleDTO{
-			Name:        s.options.GetRoleName("writer"),
-			DisplayName: s.options.WriterRoleName,
-			Group:       s.options.RoleGroup,
+			Name:        o.GetRoleName("writer"),
+			DisplayName: o.WriterRoleName,
+			Group:       o.RoleGroup,
 			Permissions: accesscontrol.ConcatPermissions(readerRole.Role.Permissions, []accesscontrol.Permission{
-				{Action: s.options.GetAction("write"), Scope: scopeAll},
+				{Action: o.GetAction("write"), Scope: scopeAll},
 			}),
 		},
 		Grants: []string{string(org.RoleAdmin)},
 	}
 
-	return s.service.DeclareFixedRoles(readerRole, writerRole)
+	return []accesscontrol.RoleRegistration{readerRole, writerRole}
+}
+
+func (s *Service) declareFixedRoles() error {
+	return s.service.DeclareFixedRoles(FixedRoleRegistrations(s.options)...)
 }
 
 type ActionSetService interface {


### PR DESCRIPTION
ENT: https://github.com/grafana/grafana-enterprise/pull/12256

**What is this feature?**

Adding missed fixed roles to the unified storage via code seeding

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
