### PR TITLE
PanelEditNext: Standardize label casing 

### DIFF
--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Footer/QueryEditorFooter.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Footer/QueryEditorFooter.tsx
@@ -105,10 +105,10 @@ export function QueryEditorFooter() {
           fill="text"
           size="sm"
           onClick={(e) => handleItemClick(e)}
-          aria-label={t('query-editor-next.footer.query-options', 'Query Options')}
+          aria-label={t('query-editor-next.footer.query-options', 'Query options')}
         >
           <Stack direction="row" alignItems="center" gap={0.5}>
-            <Trans i18nKey="query-editor-next.footer.query-options">Query Options</Trans>
+            <Trans i18nKey="query-editor-next.footer.query-options">Query options</Trans>
             <Icon name="angle-down" className={cx(styles.chevron, { [styles.chevronOpen]: isQueryOptionsOpen })} />
           </Stack>
         </Button>

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/ContentHeader.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/ContentHeader.tsx
@@ -148,7 +148,7 @@ export function ContentHeader({
     return (
       <PendingPickerHeader
         editorType={QueryEditorType.Expression}
-        label={<Trans i18nKey="query-editor-next.header.pending-expression">Select an Expression</Trans>}
+        label={<Trans i18nKey="query-editor-next.header.pending-expression">Select an expression</Trans>}
         onCancel={onCancelPendingExpression}
         cancelLabel={<Trans i18nKey="query-editor-next.header.pending-expression-cancel">Cancel</Trans>}
         styles={styles}
@@ -161,7 +161,7 @@ export function ContentHeader({
     return (
       <PendingPickerHeader
         editorType={QueryEditorType.Transformation}
-        label={<Trans i18nKey="query-editor-next.header.pending-transformation">Select a Transformation</Trans>}
+        label={<Trans i18nKey="query-editor-next.header.pending-transformation">Select a transformation</Trans>}
         onCancel={onCancelPendingTransformation}
         cancelLabel={<Trans i18nKey="query-editor-next.header.pending-transformation-cancel">Cancel</Trans>}
         styles={styles}

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/constants.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/constants.ts
@@ -71,25 +71,25 @@ export function getQueryEditorTypeConfig(theme: GrafanaTheme2): Record<QueryEdit
     [QueryEditorType.Query]: {
       icon: 'database',
       color: theme.colors.warning.main,
-      getLabel: () => t('query-editor-next.labels.query', 'Query'),
+      getLabel: () => t('query-editor-next.labels.query', 'query'),
       deleteConfirmation: true,
     },
     [QueryEditorType.Expression]: {
       icon: 'calculator-alt',
       color: theme.colors.tertiary.main,
-      getLabel: () => t('query-editor-next.labels.expression', 'Expression'),
+      getLabel: () => t('query-editor-next.labels.expression', 'expression'),
       deleteConfirmation: true,
     },
     [QueryEditorType.Transformation]: {
       icon: 'process',
       color: theme.colors.success.main,
-      getLabel: () => t('query-editor-next.labels.transformation', 'Transformation'),
+      getLabel: () => t('query-editor-next.labels.transformation', 'transformation'),
       deleteConfirmation: true,
     },
     [QueryEditorType.Alert]: {
       icon: 'bell',
       color: theme.colors.text.secondary, // Alerts use dynamic state-based colors via getAlertStateColor()
-      getLabel: () => t('query-editor-next.labels.alert', 'Alert'),
+      getLabel: () => t('query-editor-next.labels.alert', 'alert'),
       deleteConfirmation: false,
     },
   };

--- a/public/locales/en-US/grafana.json
+++ b/public/locales/en-US/grafana.json
@@ -14306,14 +14306,14 @@
         "no-limit": "No limit"
       },
       "query-inspector": "Query inspector",
-      "query-options": "Query Options"
+      "query-options": "Query options"
     },
     "header": {
       "alert": "Alert",
       "expression": "Expression",
-      "pending-expression": "Select an Expression",
+      "pending-expression": "Select an expression",
       "pending-expression-cancel": "Cancel",
-      "pending-transformation": "Select a Transformation",
+      "pending-transformation": "Select a transformation",
       "pending-transformation-cancel": "Cancel",
       "transformation": "Transformation"
     },
@@ -14322,10 +14322,10 @@
       "close-aria": "Close help panel"
     },
     "labels": {
-      "alert": "Alert",
-      "expression": "Expression",
-      "query": "Query",
-      "transformation": "Transformation"
+      "alert": "alert",
+      "expression": "expression",
+      "query": "query",
+      "transformation": "transformation"
     },
     "sidebar": {
       "add-below": "Add below {{id}}",


### PR DESCRIPTION
## Description
<!--- A high level description of what this PR is doing -->
Resolves DPRO-112

Fixes inconsistent capitalization in Query Editor v2 so user-facing strings follow Grafana's sentence-case convention (e.g. "Hide Query" → "Hide query").

## Changes
<!--- Describe your changes in detail -->
* Lowercased the query type labels (`query`, `expression`, `transformation`, `alert`). 
* "Query Options" → "Query options" in the footer (label + `aria-label`).
* "Select an Expression" → "Select an expression"; "Select a Transformation" → "Select a transformation".

## Risks
N/A - casing-only, no logic changes. Verified the type labels are always interpolated mid-sentence (never standalone).

## Demo
N/A - copy changes only.

## Testing Instructions
<!--- Provide step by step instructions and the dashboard if applicable -->
* Edit a panel with Query Editor v2, hover the card actions, and confirm tooltips read sentence case ("Hide query", "Duplicate expression").
* Confirm the footer reads "Query options" and pending headers read "Select an expression" / "Select a transformation".

## Reviewer Checklist
<!--- The reviewer should make sure the following has been done -->
- [ ] Tests are added where applicable
- [ ] Issue is linked to PR
- [ ] Code pulled and tested
- [ ] Code is meaningfully improved if applicable