### PR TITLE
Alerting: fix MergeTimeIntervals dropping existing mute intervals and wrong collision priority

### DIFF
--- a/pkg/services/ngalert/notifier/merge/merge.go
+++ b/pkg/services/ngalert/notifier/merge/merge.go
@@ -132,7 +132,7 @@ func MergeExtraConfig(_ context.Context, cfg *v1.AMConfigV1) (MergeResult, error
 				Global:            nil, // Grafana does not have global.
 				Route:             route,
 				InhibitRules:      inhibitRules,
-				MuteTimeIntervals: cfg.AlertmanagerConfig.MuteTimeIntervals,
+				MuteTimeIntervals: nil, // folded into TimeIntervals above
 				TimeIntervals:     mergedTimeIntervals,
 				Templates:         nil, // we do not use this.
 			},
@@ -179,12 +179,16 @@ func TimeIntervals(
 ) ([]v1.TimeInterval, map[string]string) {
 	// combine all incoming intervals into a single list
 	incomingAll := make([]v1.TimeInterval, 0, len(incomingTimeIntervals)+len(incomingMuteIntervals))
-	incomingAll = append(incomingAll, incomingTimeIntervals...)
 	for _, interval := range incomingMuteIntervals {
 		incomingAll = append(incomingAll, v1.TimeInterval(interval))
 	}
+	incomingAll = append(incomingAll, incomingTimeIntervals...)
 	usedNames := createIndexTimeIntervals(existingMuteIntervals, existingTimeIntervals, incomingAll)
-	result := make([]v1.TimeInterval, 0, len(existingTimeIntervals)+len(incomingMuteIntervals)+len(incomingTimeIntervals))
+	result := make([]v1.TimeInterval, 0, len(existingMuteIntervals)+len(existingTimeIntervals)+len(incomingMuteIntervals)+len(incomingTimeIntervals))
+	// fold mute time intervals into time intervals. The order is important here because during the applying time intervals with the same name win
+	for _, interval := range existingMuteIntervals {
+		result = append(result, v1.TimeInterval(interval))
+	}
 	result = append(result, existingTimeIntervals...)
 	renames := make(map[string]string)
 	for idx, interval := range incomingAll {

--- a/pkg/services/ngalert/notifier/merge/merge_test.go
+++ b/pkg/services/ngalert/notifier/merge/merge_test.go
@@ -189,9 +189,10 @@ func TestTimeIntervals(t *testing.T) {
 				mti("mti3"),
 			},
 			expected: []v1.TimeInterval{
+				ti("mti1"),
 				ti("ti2"),
-				ti("ti4"),
 				ti("mti3"),
+				ti("ti4"),
 			},
 			expectedRenames: map[string]string{},
 		},
@@ -210,9 +211,10 @@ func TestTimeIntervals(t *testing.T) {
 				mti("ti2"),
 			},
 			expected: []v1.TimeInterval{
+				ti("mti1"),
 				ti("ti2"),
-				ti("mti1" + suffix),
 				ti("ti2" + suffix),
+				ti("mti1" + suffix),
 			},
 			expectedRenames: map[string]string{
 				"ti2":  "ti2" + suffix,
@@ -234,9 +236,10 @@ func TestTimeIntervals(t *testing.T) {
 				mti("ti1"),
 			},
 			expected: []v1.TimeInterval{
+				ti("ti1"),
 				ti("ti1" + suffix),
-				ti("ti1" + suffix + suffix),
 				ti("ti1" + suffix + "_01"),
+				ti("ti1" + suffix + suffix),
 			},
 			expectedRenames: map[string]string{
 				"ti1" + suffix: "ti1" + suffix + suffix,
@@ -279,10 +282,11 @@ func TestTimeIntervals(t *testing.T) {
 				mti("ti1" + suffix + "_01"),
 			},
 			expected: []v1.TimeInterval{
+				ti("ti1"),
 				ti("ti1" + suffix),
+				ti("ti1" + suffix + "_01"),
 				ti("ti1" + suffix + "_02"),
 				ti("ti2"),
-				ti("ti1" + suffix + "_01"),
 			},
 			expectedRenames: map[string]string{
 				"ti1": "ti1" + suffix + "_02",
@@ -486,11 +490,15 @@ func TestMergeExtraConfig(t *testing.T) {
 		assertResult(t, MergeResult{
 			Config: v1.AMConfigV1{AlertmanagerConfig: *load(t, fullMergedConfig, func(p *v1.PostableApiAlertingConfig) {
 				p.Global = nil
-				// remove mti-2 (absent from fullMimirSwappedIntervals) and add the renamed intervals
-				expected := p.TimeIntervals[:len(p.TimeIntervals)-1]
-				expected = append(expected, v1.TimeInterval{Name: "mti-1" + identifier})
-				expected = append(expected, v1.TimeInterval{Name: "ti-1" + identifier})
-				p.TimeIntervals = expected
+				// Keep mti-1 and ti-1 from base; mti-2 is absent in fullMimirSwappedIntervals.
+				// Incoming: mute ti-1 (renamed) → ti-1+id, time ti-2 (no conflict), time mti-1 (renamed) → mti-1+id.
+				p.TimeIntervals = []v1.TimeInterval{
+					p.TimeIntervals[0], // mti-1 (existing mute, folded)
+					p.TimeIntervals[1], // ti-1
+					{Name: "ti-1" + identifier},
+					p.TimeIntervals[3], // ti-2 (incoming time, no conflict)
+					{Name: "mti-1" + identifier},
+				}
 			})},
 			RenameResources: RenameResources{
 				TimeIntervals: map[string]string{

--- a/pkg/services/ngalert/notifier/merge/testdata/merged_config.yaml
+++ b/pkg/services/ngalert/notifier/merge/testdata/merged_config.yaml
@@ -22,18 +22,22 @@ route:
           group_wait: 0s
           group_interval: 1m
           repeat_interval: 1m
-mute_time_intervals:
+time_intervals:
     - name: mti-1
       time_intervals:
         - times:
             - start_time: "00:00"
               end_time: "12:00"
-time_intervals:
     - name: ti-1
       time_intervals:
         - weekdays:
           - saturday
           - sunday
+    - name: mti-2
+      time_intervals:
+        - times:
+            - start_time: "00:00"
+              end_time: "12:00"
     - name: ti-2
       time_intervals:
         - weekdays:
@@ -42,11 +46,6 @@ time_intervals:
           - wednesday
           - thursday
           - friday
-    - name: mti-2
-      time_intervals:
-        - times:
-            - start_time: "00:00"
-              end_time: "12:00"
 receivers:
     - name: grafana-default-email
       grafana_managed_receiver_configs:


### PR DESCRIPTION
## Summary

Follow-up for https://github.com/grafana/alerting/pull/560, applying the same fix to the forked merge logic in Grafana.

Two bugs in `MergeTimeIntervals`:

- **Existing mute intervals were silently dropped.** They were passed to `createIndexTimeIntervals` to build the collision index, but never appended to the result slice. Any `mute_time_intervals` defined in the base Grafana config vanished after a merge.

- **Wrong collision priority for incoming intervals.** Incoming time intervals were appended before mute intervals in `incomingAll`, so time intervals got the lower index and won name collisions. Per alertmanager semantics, mute intervals should win — this is now reflected in the order and in the test comment that was already there.

Also clears `MuteTimeIntervals` from the `MergeExtraConfig` result: since all mute intervals are now folded into `TimeIntervals`, keeping them in both fields would create duplicates.

## Test plan

- [ ] `TestMergeTimeIntervals` — all five sub-cases updated with correct expected slices
- [ ] `TestMergeExtraConfig` — expected yaml and `should_rename_time_intervals_and_refactor_usages` test case updated; all 13 sub-cases pass
- [ ] `go test ./pkg/services/ngalert/notifier/merge/...` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)