### PR TITLE
PanelEditNext: Remove Intercom from feedback logic

### DIFF
--- a/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
+++ b/packages/grafana-runtime/src/internal/openFeature/openfeature.gen.ts
@@ -49,7 +49,7 @@ export const FlagKeys = {
   GrafanaNewPreferencesPage: "grafana.newPreferencesPage",
   /** Enables org-defined dashboard templates for enterprise */
   GrafanaOrgDashboardTemplates: "grafana.orgDashboardTemplates",
-  /** Replaces the Intercom survey for PanelEditNext feedback with an event that triggers an in-house survey */
+  /** Enables firing an event for PanelEditNext feedback that triggers an in-house survey */
   GrafanaPanelEditNextFeedbackEvent: "grafana.panelEditNextFeedbackEvent",
   /** Prevents flickering in dashboards */
   GrafanaScenesFlickeringFix: "grafana.scenesFlickeringFix",
@@ -300,7 +300,7 @@ export const useFlagGrafanaOrgDashboardTemplates = (options?: ReactFlagEvaluatio
 };
 
 /**
- * Replaces the Intercom survey for PanelEditNext feedback with an event that triggers an in-house survey
+ * Enables firing an event for PanelEditNext feedback that triggers an in-house survey
  *
  * **Details:**
  * - flag key: `grafana.panelEditNextFeedbackEvent`

--- a/pkg/services/featuremgmt/registry.go
+++ b/pkg/services/featuremgmt/registry.go
@@ -3181,7 +3181,7 @@ var (
 		},
 		{
 			Name:         "grafana.panelEditNextFeedbackEvent",
-			Description:  "Replaces the Intercom survey for PanelEditNext feedback with an event that triggers an in-house survey",
+			Description:  "Enables firing an event for PanelEditNext feedback that triggers an in-house survey",
 			Stage:        FeatureStageExperimental,
 			Owner:        grafanaDataProSquad,
 			HideFromDocs: true,

--- a/pkg/services/featuremgmt/toggles_gen.json
+++ b/pkg/services/featuremgmt/toggles_gen.json
@@ -2407,11 +2407,14 @@
     {
       "metadata": {
         "name": "grafana.panelEditNextFeedbackEvent",
-        "resourceVersion": "1779903372415",
-        "creationTimestamp": "2026-05-27T17:36:12Z"
+        "resourceVersion": "1780592255785",
+        "creationTimestamp": "2026-05-27T17:36:12Z",
+        "annotations": {
+          "grafana.app/updatedTimestamp": "2026-06-04 16:57:35.785848 +0000 UTC"
+        }
       },
       "spec": {
-        "description": "Replaces the Intercom survey for PanelEditNext feedback with an event that triggers an in-house survey",
+        "description": "Enables firing an event for PanelEditNext feedback that triggers an in-house survey",
         "stage": "experimental",
         "codeowner": "@grafana/datapro",
         "frontend": true,

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/ExperimentalFeedbackButton.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/QueryEditor/Header/ExperimentalFeedbackButton.tsx
@@ -3,6 +3,7 @@ import { useRef } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { useFlagGrafanaPanelEditNextFeedbackEvent } from '@grafana/runtime/internal';
 import { Button, Dropdown, Menu, useStyles2 } from '@grafana/ui';
 
 import { startFeedbackSurvey } from '../../tracking';
@@ -12,6 +13,7 @@ export function ExperimentalFeedbackButton() {
   const { showVersionBanner } = useQueryEditorUIContext();
   const { onSwitchToClassic } = useActionsContext();
   const styles = useStyles2(getStyles);
+  const feedbackEventEnabled = useFlagGrafanaPanelEditNextFeedbackEvent();
 
   // Track whether the banner was visible when this component first mounted.
   // If it was, the user dismissed it - animate the button in.
@@ -25,11 +27,13 @@ export function ExperimentalFeedbackButton() {
 
   const menu = (
     <Menu>
-      <Menu.Item
-        label={t('query-editor-next.experimental-button.give-feedback', 'Give feedback')}
-        icon="comment-alt-message"
-        onClick={() => startFeedbackSurvey()}
-      />
+      {feedbackEventEnabled && (
+        <Menu.Item
+          label={t('query-editor-next.experimental-button.give-feedback', 'Give feedback')}
+          icon="comment-alt-message"
+          onClick={() => startFeedbackSurvey()}
+        />
+      )}
       <Menu.Item
         label={t('query-editor-next.experimental-button.back-to-classic', 'Go back to classic editor')}
         icon="arrow-left"

--- a/public/app/features/dashboard-scene/panel-edit/PanelEditNext/tracking.ts
+++ b/public/app/features/dashboard-scene/panel-edit/PanelEditNext/tracking.ts
@@ -150,62 +150,14 @@ export function trackRenameInitiated() {
   });
 }
 
-const INTERCOM_APP_ID = 'agpb1wfw';
-const INTERCOM_SURVEY_ID = '59003702';
-
-function getIntercom(): ((command: string, ...args: unknown[]) => void) | undefined {
-  if ('Intercom' in window && typeof window.Intercom === 'function') {
-    return window.Intercom;
-  }
-  return undefined;
-}
-
-let intercomLoadPromise: Promise<void> | null = null;
-
-function ensureIntercomLoaded(): Promise<void> {
-  if (typeof getIntercom() === 'function') {
-    return Promise.resolve();
-  }
-
-  if (intercomLoadPromise) {
-    return intercomLoadPromise;
-  }
-
-  intercomLoadPromise = new Promise<void>((resolve, reject) => {
-    const script = document.createElement('script');
-    script.src = `https://widget.intercom.io/widget/${INTERCOM_APP_ID}`;
-    script.async = true;
-    script.onload = () => {
-      getIntercom()?.('boot', { app_id: INTERCOM_APP_ID, hide_default_launcher: true });
-      resolve();
-    };
-    script.onerror = () => {
-      intercomLoadPromise = null;
-      reject(new Error('Failed to load Intercom'));
-    };
-    document.head.appendChild(script);
-  });
-
-  return intercomLoadPromise;
-}
-
 export function startFeedbackSurvey(): void {
   const isPanelEditNextFeedbackEventEnabled = getFeatureFlagClient().getBooleanValue(
     FlagKeys.GrafanaPanelEditNextFeedbackEvent,
     false
   );
   if (isPanelEditNextFeedbackEventEnabled) {
-    // Fire an event for grafana-setupguide-app to detect, which replaces Intercom with an in-house survey.
+    // Fire an event for grafana-setupguide-app to detect, which will show the survey in Cloud.
     getAppEvents().publish(new PanelEditNextFeedbackEvent());
     return;
   }
-
-  ensureIntercomLoaded()
-    .then(() => {
-      getIntercom()?.('startSurvey', INTERCOM_SURVEY_ID);
-    })
-    .catch(() => {
-      // Intercom blocked or unavailable — silently ignore.
-      // The survey is non-critical; the editor remains fully functional.
-    });
 }

--- a/public/app/features/dashboard-scene/panel-edit/QueryEditorBanner.test.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/QueryEditorBanner.test.tsx
@@ -1,3 +1,4 @@
+import { OpenFeatureTestProvider } from '@openfeature/react-sdk';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
@@ -5,6 +6,13 @@ import { QueryEditorBanner } from './QueryEditorBanner';
 
 const onToggle = jest.fn();
 const onDismiss = jest.fn();
+
+const renderComponent = (useQueryExperienceNext: boolean) =>
+  render(
+    <OpenFeatureTestProvider>
+      <QueryEditorBanner useQueryExperienceNext={useQueryExperienceNext} onToggle={onToggle} onDismiss={onDismiss} />
+    </OpenFeatureTestProvider>
+  );
 
 describe('QueryEditorBanner', () => {
   beforeEach(() => {
@@ -14,20 +22,20 @@ describe('QueryEditorBanner', () => {
 
   describe('classic editor (useQueryExperienceNext = false)', () => {
     it('shows the upgrade title and "Try it out" button', () => {
-      render(<QueryEditorBanner useQueryExperienceNext={false} onToggle={onToggle} onDismiss={onDismiss} />);
+      renderComponent(false);
 
       expect(screen.getByText('New editor available')).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /try it out/i })).toBeInTheDocument();
     });
 
     it('does not show new-editor-specific content', () => {
-      render(<QueryEditorBanner useQueryExperienceNext={false} onToggle={onToggle} onDismiss={onDismiss} />);
+      renderComponent(false);
 
       expect(screen.queryByText('Back to classic')).not.toBeInTheDocument();
     });
 
     it('calls onToggle when "Try it out" is clicked', async () => {
-      render(<QueryEditorBanner useQueryExperienceNext={false} onToggle={onToggle} onDismiss={onDismiss} />);
+      renderComponent(false);
 
       await userEvent.click(screen.getByRole('button', { name: /try it out/i }));
 
@@ -37,20 +45,20 @@ describe('QueryEditorBanner', () => {
 
   describe('new editor (useQueryExperienceNext = true)', () => {
     it('shows the new editor title and "Go back to classic" button', () => {
-      render(<QueryEditorBanner useQueryExperienceNext={true} onToggle={onToggle} onDismiss={onDismiss} />);
+      renderComponent(true);
 
       expect(screen.getByText('New query editor')).toBeInTheDocument();
       expect(screen.getByRole('button', { name: /back to classic/i })).toBeInTheDocument();
     });
 
     it('does not show "Try it out" button', () => {
-      render(<QueryEditorBanner useQueryExperienceNext={true} onToggle={onToggle} onDismiss={onDismiss} />);
+      renderComponent(true);
 
       expect(screen.queryByRole('button', { name: /try it out/i })).not.toBeInTheDocument();
     });
 
     it('calls onToggle when "Go back to classic" is clicked', async () => {
-      render(<QueryEditorBanner useQueryExperienceNext={true} onToggle={onToggle} onDismiss={onDismiss} />);
+      renderComponent(true);
 
       await userEvent.click(screen.getByRole('button', { name: /back to classic/i }));
 
@@ -60,7 +68,7 @@ describe('QueryEditorBanner', () => {
 
   describe('dismiss', () => {
     it('calls onDismiss when dismiss button is clicked', async () => {
-      render(<QueryEditorBanner useQueryExperienceNext={false} onToggle={onToggle} onDismiss={onDismiss} />);
+      renderComponent(false);
 
       await userEvent.click(screen.getByRole('button', { name: 'Dismiss' }));
 

--- a/public/app/features/dashboard-scene/panel-edit/QueryEditorBanner.tsx
+++ b/public/app/features/dashboard-scene/panel-edit/QueryEditorBanner.tsx
@@ -2,6 +2,7 @@ import { css, cx } from '@emotion/css';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { t } from '@grafana/i18n';
+import { useFlagGrafanaPanelEditNextFeedbackEvent } from '@grafana/runtime/internal';
 import { Button, Icon, IconButton, useStyles2 } from '@grafana/ui';
 
 import { startFeedbackSurvey, trackBannerDismiss, trackFeedbackClick } from './PanelEditNext/tracking';
@@ -15,6 +16,7 @@ interface Props {
 
 export function QueryEditorBanner({ useQueryExperienceNext, onToggle, onDismiss, className }: Props) {
   const styles = useStyles2(getStyles);
+  const feedbackEventEnabled = useFlagGrafanaPanelEditNextFeedbackEvent();
 
   return (
     <div className={cx(styles.banner, className)}>
@@ -38,7 +40,7 @@ export function QueryEditorBanner({ useQueryExperienceNext, onToggle, onDismiss,
         </span>
       </div>
       <div className={styles.right}>
-        {useQueryExperienceNext && (
+        {useQueryExperienceNext && feedbackEventEnabled && (
           <Button
             variant="primary"
             fill="text"


### PR DESCRIPTION
**What is this feature?**

Removes the Intercom loading logic from the feedback method for PanelEditNext.

Also, this gates showing the dedicated feedback button behind this flag being enabled, so we don't show a button that does nothing when clicked.

**Why do we need this feature?**

The feature flag to enable the in-house survey is at 100%, and we are no longer using Intercom.

**Who is this feature for?**

Developers.

**Which issue(s) does this PR fix?**:

cc #125012

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
