### PR TITLE
Alerting: Reject imported configs with unsupported receiver fields

### DIFF
--- a/pkg/services/ngalert/notifier/legacy_storage/v1/compat_validation.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/v1/compat_validation.go
@@ -1,0 +1,88 @@
+package v1
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/grafana/alerting/definition"
+	"github.com/grafana/alerting/definition/compat"
+	"github.com/prometheus/alertmanager/config"
+)
+
+// findUnsupportedReceiverFields returns the YAML paths of upstream receiver fields
+// that don't survive conversion to Grafana's definition format and would be
+// silently dropped (e.g. the *_file / *_ref fields removed in grafana/alerting#573).
+// It diffs orig against a round-trip of def, so it stays correct as upstream adds
+// fields.
+func findUnsupportedReceiverFields(orig config.Receiver, def definition.Receiver) (fields []string, err error) {
+	roundTripped := compat.DefinitionReceiverToUpstreamReceiver(def)
+
+	var reporter yamlPathReporter
+	// cmp.Diff can panic on inputs it cannot compare; turn that into an error so
+	// it can't crash the import.
+	defer func() {
+		if rec := recover(); rec != nil {
+			err = fmt.Errorf("failed to compare receiver %q: %v", orig.Name, rec)
+		}
+	}()
+
+	// Exporter: upstream config types have unexported fields go-cmp would panic on.
+	// EquateEmpty: don't report nil vs empty as a difference.
+	cmp.Diff(orig, roundTripped,
+		cmp.Exporter(func(reflect.Type) bool { return true }),
+		cmpopts.EquateEmpty(),
+		cmp.Reporter(&reporter),
+	)
+	return reporter.paths, nil
+}
+
+// yamlPathReporter is a go-cmp reporter that records differing values by their
+// YAML path (e.g. email_configs[0].auth_password_file) rather than Go field names.
+type yamlPathReporter struct {
+	path  cmp.Path
+	paths []string
+}
+
+func (r *yamlPathReporter) PushStep(ps cmp.PathStep) { r.path = append(r.path, ps) }
+func (r *yamlPathReporter) PopStep()                 { r.path = r.path[:len(r.path)-1] }
+
+func (r *yamlPathReporter) Report(rs cmp.Result) {
+	if rs.Equal() {
+		return
+	}
+	var b strings.Builder
+	for i, s := range r.path {
+		switch s := s.(type) {
+		case cmp.StructField:
+			if b.Len() > 0 {
+				b.WriteByte('.')
+			}
+			b.WriteString(yamlFieldName(r.path[i-1].Type(), s))
+		case cmp.SliceIndex:
+			if k := s.Key(); k >= 0 {
+				fmt.Fprintf(&b, "[%d]", k)
+			}
+		case cmp.MapIndex:
+			fmt.Fprintf(&b, "[%v]", s.Key())
+		}
+	}
+	r.paths = append(r.paths, b.String())
+}
+
+// yamlFieldName returns the field's YAML tag name, falling back to the Go field
+// name when the parent isn't a struct or the field has no usable yaml tag.
+func yamlFieldName(parent reflect.Type, sf cmp.StructField) string {
+	for parent != nil && parent.Kind() == reflect.Pointer {
+		parent = parent.Elem()
+	}
+	if parent != nil && parent.Kind() == reflect.Struct && sf.Index() < parent.NumField() {
+		tag := parent.Field(sf.Index()).Tag.Get("yaml")
+		if name, _, _ := strings.Cut(tag, ","); name != "" && name != "-" {
+			return name
+		}
+	}
+	return sf.Name()
+}

--- a/pkg/services/ngalert/notifier/legacy_storage/v1/compat_validation_test.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/v1/compat_validation_test.go
@@ -1,0 +1,177 @@
+package v1
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/grafana/alerting/definition/compat"
+	"github.com/grafana/alerting/notify/notifytest"
+	"github.com/prometheus/alertmanager/config"
+	commoncfg "github.com/prometheus/common/config"
+	"github.com/stretchr/testify/require"
+
+	"github.com/grafana/grafana/pkg/apimachinery/errutil"
+)
+
+// unsupportedReceiversFromError reads the receiver list from the error's "extra".
+func unsupportedReceiversFromError(t *testing.T, err error) []unsupportedReceiverFields {
+	t.Helper()
+	var gErr errutil.Error
+	require.ErrorAs(t, err, &gErr)
+	require.Equal(t, "alerting.unsupportedReceiverFields", gErr.MessageID)
+	receivers, ok := gErr.Public().Extra["receivers"].([]unsupportedReceiverFields)
+	require.True(t, ok, "expected Receivers in error extra payload")
+	return receivers
+}
+
+// TestUnsupportedReceiverFieldsError_JSONShape pins the public API response shape.
+func TestUnsupportedReceiverFieldsError_JSONShape(t *testing.T) {
+	err := errUnsupportedReceiverFields([]unsupportedReceiverFields{
+		{Receiver: "a", Fields: []string{"email_configs[0].auth_password_file"}},
+	})
+
+	var gErr errutil.Error
+	require.ErrorAs(t, err, &gErr)
+
+	out, mErr := json.Marshal(gErr.Public())
+	require.NoError(t, mErr)
+	require.JSONEq(t, `{
+		"statusCode": 400,
+		"messageId": "alerting.unsupportedReceiverFields",
+		"message": "Configuration contains receivers that cannot be converted to Grafana receivers",
+		"extra": {"receivers": [{"receiver": "a", "fields": ["email_configs[0].auth_password_file"]}]}
+	}`, string(out))
+}
+
+func TestFindUnsupportedReceiverFields_FlagsRemovedFields(t *testing.T) {
+	testCases := []struct {
+		name     string
+		receiver config.Receiver
+		wantPath string
+	}{
+		{
+			name: "email auth_password_file",
+			receiver: config.Receiver{
+				Name:         "email",
+				EmailConfigs: []*config.EmailConfig{{AuthPasswordFile: "/etc/smtp-password"}},
+			},
+			wantPath: "email_configs[0].auth_password_file",
+		},
+		{
+			name: "slack api_url_file",
+			receiver: config.Receiver{
+				Name:         "slack",
+				SlackConfigs: []*config.SlackConfig{{APIURLFile: "/etc/slack-url"}},
+			},
+			wantPath: "slack_configs[0].api_url_file",
+		},
+		{
+			name: "webhook url_file",
+			receiver: config.Receiver{
+				Name:           "webhook",
+				WebhookConfigs: []*config.WebhookConfig{{URLFile: "/etc/webhook-url"}},
+			},
+			wantPath: "webhook_configs[0].url_file",
+		},
+		{
+			name: "webhook tls cert_file in shared http config",
+			receiver: config.Receiver{
+				Name: "webhook-tls",
+				WebhookConfigs: []*config.WebhookConfig{{
+					HTTPConfig: &commoncfg.HTTPClientConfig{
+						TLSConfig: commoncfg.TLSConfig{CertFile: "/etc/cert.pem"},
+					},
+				}},
+			},
+			wantPath: "webhook_configs[0].http_config.tls_config.cert_file",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			def := compat.UpstreamReceiverToDefinitionReceiver(tc.receiver)
+			fields, err := findUnsupportedReceiverFields(tc.receiver, def)
+			require.NoError(t, err)
+			require.Contains(t, fields, tc.wantPath)
+		})
+	}
+}
+
+// TestFindUnsupportedReceiverFields_NoFalsePositives: every supported field must
+// survive the round-trip, so a fully-populated receiver reports nothing.
+func TestFindUnsupportedReceiverFields_NoFalsePositives(t *testing.T) {
+	def, err := notifytest.GetMimirReceiverWithAllIntegrations()
+	require.NoError(t, err)
+
+	upstream := compat.DefinitionReceiverToUpstreamReceiver(def)
+
+	fields, err := findUnsupportedReceiverFields(upstream, compat.UpstreamReceiverToDefinitionReceiver(upstream))
+	require.NoError(t, err)
+	require.Empty(t, fields, "supported fields must not be reported as unsupported")
+}
+
+func TestExtraConfiguration_Validate_RejectsUnsupportedFields(t *testing.T) {
+	t.Run("rejects unsupported field and names it", func(t *testing.T) {
+		ec := ExtraConfiguration{
+			Identifier: "test",
+			AlertmanagerConfig: `
+global:
+  smtp_smarthost: 'localhost:25'
+  smtp_from: 'alerts@example.com'
+route:
+  receiver: a
+receivers:
+  - name: a
+    email_configs:
+      - to: someone@example.com
+        auth_password_file: /etc/smtp-password
+`,
+		}
+		err := ec.Validate()
+		require.Error(t, err)
+		require.Equal(t, []unsupportedReceiverFields{
+			{Receiver: "a", Fields: []string{"email_configs[0].auth_password_file"}},
+		}, unsupportedReceiversFromError(t, err))
+	})
+
+	t.Run("reports unsupported fields from all receivers", func(t *testing.T) {
+		ec := ExtraConfiguration{
+			Identifier: "test",
+			AlertmanagerConfig: `
+global:
+  smtp_smarthost: 'localhost:25'
+  smtp_from: 'alerts@example.com'
+route:
+  receiver: a
+receivers:
+  - name: a
+    email_configs:
+      - to: someone@example.com
+        auth_password_file: /etc/smtp-password
+  - name: b
+    slack_configs:
+      - channel: '#alerts'
+        api_url_file: /etc/slack-url
+`,
+		}
+		err := ec.Validate()
+		require.Error(t, err)
+		require.Equal(t, []unsupportedReceiverFields{
+			{Receiver: "a", Fields: []string{"email_configs[0].auth_password_file"}},
+			{Receiver: "b", Fields: []string{"slack_configs[0].api_url_file"}},
+		}, unsupportedReceiversFromError(t, err))
+	})
+
+	t.Run("accepts config without unsupported fields", func(t *testing.T) {
+		ec := ExtraConfiguration{
+			Identifier: "test",
+			AlertmanagerConfig: `
+route:
+  receiver: a
+receivers:
+  - name: a
+`,
+		}
+		require.NoError(t, ec.Validate())
+	})
+}

--- a/pkg/services/ngalert/notifier/legacy_storage/v1/compat_validation_test.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/v1/compat_validation_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/grafana/alerting/definition/compat"
+	"github.com/grafana/alerting/http/v0mimir/v0mimirtest"
 	"github.com/grafana/alerting/notify/notifytest"
 	"github.com/prometheus/alertmanager/config"
 	commoncfg "github.com/prometheus/common/config"
@@ -98,16 +99,22 @@ func TestFindUnsupportedReceiverFields_FlagsRemovedFields(t *testing.T) {
 }
 
 // TestFindUnsupportedReceiverFields_NoFalsePositives: every supported field must
-// survive the round-trip, so a fully-populated receiver reports nothing.
+// survive the round-trip. We build a receiver with all integration types for each
+// available HTTP-config variant (basic_auth, oauth2, tls, headers, proxy, ...) so
+// the shared http_config sub-struct is exercised too, and assert nothing is
+// reported.
 func TestFindUnsupportedReceiverFields_NoFalsePositives(t *testing.T) {
-	def, err := notifytest.GetMimirReceiverWithAllIntegrations()
-	require.NoError(t, err)
+	for opt := range v0mimirtest.ValidMimirHTTPConfigs {
+		t.Run(string(opt), func(t *testing.T) {
+			def, err := notifytest.GetMimirReceiverWithAllIntegrations(opt)
+			require.NoError(t, err)
 
-	upstream := compat.DefinitionReceiverToUpstreamReceiver(def)
-
-	fields, err := findUnsupportedReceiverFields(upstream, compat.UpstreamReceiverToDefinitionReceiver(upstream))
-	require.NoError(t, err)
-	require.Empty(t, fields, "supported fields must not be reported as unsupported")
+			upstream := compat.DefinitionReceiverToUpstreamReceiver(def)
+			fields, err := findUnsupportedReceiverFields(upstream, compat.UpstreamReceiverToDefinitionReceiver(upstream))
+			require.NoError(t, err)
+			require.Empty(t, fields, "supported fields must not be reported as unsupported")
+		})
+	}
 }
 
 func TestExtraConfiguration_Validate_RejectsUnsupportedFields(t *testing.T) {

--- a/pkg/services/ngalert/notifier/legacy_storage/v1/errors.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/v1/errors.go
@@ -4,12 +4,27 @@ import "github.com/grafana/grafana/pkg/apimachinery/errutil"
 
 const (
 	errInvalidExtraConfigurationMsg = "Invalid Alertmanager configuration: {{.Public.Error}}"
+	errUnsupportedReceiverFieldsMsg = "Configuration contains receivers that cannot be converted to Grafana receivers"
 )
 
 var (
 	errInvalidExtraConfigurationBase = errutil.ValidationFailed("alerting.invalidExtraConfiguration").MustTemplate(errInvalidExtraConfigurationMsg, errutil.WithPublic(errInvalidExtraConfigurationMsg))
+	errUnsupportedReceiverFieldsBase = errutil.ValidationFailed("alerting.unsupportedReceiverFields").MustTemplate(errUnsupportedReceiverFieldsMsg, errutil.WithPublic(errUnsupportedReceiverFieldsMsg))
 )
+
+// unsupportedReceiverFields is one receiver's unsupported fields, serialized into
+// the error's public "extra" payload.
+type unsupportedReceiverFields struct {
+	Receiver string   `json:"receiver"`
+	Fields   []string `json:"fields"`
+}
 
 func errInvalidExtraConfiguration(err error) error {
 	return errInvalidExtraConfigurationBase.Build(errutil.TemplateData{Public: map[string]any{"Error": err}})
+}
+
+func errUnsupportedReceiverFields(receivers []unsupportedReceiverFields) error {
+	return errUnsupportedReceiverFieldsBase.Build(errutil.TemplateData{Public: map[string]any{
+		"receivers": receivers,
+	}})
 }

--- a/pkg/services/ngalert/notifier/legacy_storage/v1/model.go
+++ b/pkg/services/ngalert/notifier/legacy_storage/v1/model.go
@@ -178,6 +178,14 @@ func (c *ExtraConfiguration) GetAlertmanagerConfig() (PostableApiAlertingConfig,
 	if err != nil {
 		return PostableApiAlertingConfig{}, err
 	}
+	cfg, _, err := alertmanagerConfigFromPrometheus(prometheusConfig)
+	return cfg, err
+}
+
+// alertmanagerConfigFromPrometheus converts a parsed Prometheus/Mimir config to
+// Grafana's PostableApiAlertingConfig. It also returns the intermediate
+// definition-format receivers (index-aligned) so callers can reuse the conversion.
+func alertmanagerConfigFromPrometheus(prometheusConfig config.Config) (PostableApiAlertingConfig, []definition.Receiver, error) {
 	config := PostableApiAlertingConfig{
 		Config: Config{
 			Global:            prometheusConfig.Global,
@@ -189,15 +197,17 @@ func (c *ExtraConfiguration) GetAlertmanagerConfig() (PostableApiAlertingConfig,
 		},
 		Receivers: make([]*PostableApiReceiver, 0, len(prometheusConfig.Receivers)),
 	}
+	defs := make([]definition.Receiver, 0, len(prometheusConfig.Receivers))
 	for _, receiver := range prometheusConfig.Receivers {
-		recv := &PostableApiReceiver{Receiver: compat.UpstreamReceiverToDefinitionReceiver(receiver)}
-		grafana, err := PostableMimirReceiverToPostableGrafanaReceiver(recv)
+		def := compat.UpstreamReceiverToDefinitionReceiver(receiver)
+		defs = append(defs, def)
+		grafana, err := PostableMimirReceiverToPostableGrafanaReceiver(&PostableApiReceiver{Receiver: def})
 		if err != nil {
-			return PostableApiAlertingConfig{}, fmt.Errorf("failed to convert Mimir receiver %s to Grafana receiver: %w", recv.Name, err)
+			return PostableApiAlertingConfig{}, nil, fmt.Errorf("failed to convert Mimir receiver %s to Grafana receiver: %w", def.Name, err)
 		}
 		config.Receivers = append(config.Receivers, grafana)
 	}
-	return config, nil
+	return config, defs, nil
 }
 
 func (c *ExtraConfiguration) parsePrometheusConfig() (config.Config, error) {
@@ -234,15 +244,35 @@ func (c ExtraConfiguration) Validate() error {
 		return errors.New("identifier is required")
 	}
 
-	cfg, err := c.GetAlertmanagerConfig()
+	prometheusConfig, err := c.parsePrometheusConfig()
 	if err != nil {
 		return errInvalidExtraConfiguration(fmt.Errorf("failed to parse alertmanager config: %w", err))
+	}
+
+	cfg, defs, err := alertmanagerConfigFromPrometheus(prometheusConfig)
+	if err != nil {
+		return errInvalidExtraConfiguration(fmt.Errorf("failed to parse alertmanager config: %w", err))
+	}
+
+	// Reject fields Grafana can't represent (e.g. *_file / *_ref) that conversion
+	// would silently drop. Collect across all receivers to report them at once.
+	var unsupported []unsupportedReceiverFields
+	for i, def := range defs {
+		fields, err := findUnsupportedReceiverFields(prometheusConfig.Receivers[i], def)
+		if err != nil {
+			return errInvalidExtraConfiguration(err)
+		}
+		if len(fields) > 0 {
+			unsupported = append(unsupported, unsupportedReceiverFields{Receiver: def.Name, Fields: fields})
+		}
+	}
+	if len(unsupported) > 0 {
+		return errUnsupportedReceiverFields(unsupported)
 	}
 	err = cfg.Validate()
 	if err != nil {
 		return errInvalidExtraConfiguration(fmt.Errorf("invalid alertmanager config: %w", err))
 	}
-
 	return nil
 }
 

--- a/pkg/tests/api/alerting/api_convert_prometheus_alertmanager_test.go
+++ b/pkg/tests/api/alerting/api_convert_prometheus_alertmanager_test.go
@@ -185,6 +185,42 @@ func TestIntegrationConvertPrometheusAlertmanagerEndpoints(t *testing.T) {
 			requireStatusCode(t, http.StatusBadRequest, status, "")
 		})
 
+		t.Run("POST with unsupported receiver fields should fail", func(t *testing.T) {
+			headers := map[string]string{
+				"Content-Type":                         "application/yaml",
+				"X-Grafana-Alerting-Config-Identifier": "test-unsupported-fields",
+			}
+
+			// auth_password_file references the filesystem, which Grafana's
+			// Alertmanager cannot represent; the import must be rejected rather
+			// than silently dropping it.
+			amConfig := apimodels.AlertmanagerUserConfig{
+				AlertmanagerConfig: `
+global:
+  smtp_smarthost: 'localhost:25'
+  smtp_from: 'alerts@example.com'
+route:
+  receiver: a
+receivers:
+  - name: a
+    email_configs:
+      - to: someone@example.com
+        auth_password_file: /etc/smtp-password
+`,
+			}
+
+			_, status, body := apiClient.RawConvertPrometheusPostAlertmanagerConfig(t, amConfig, headers)
+			requireStatusCode(t, http.StatusBadRequest, status, body)
+			require.Contains(t, body, "alerting.unsupportedReceiverFields")
+			require.Contains(t, body, "email_configs[0].auth_password_file")
+
+			// The rejected config must not have been stored.
+			_, status, _ = apiClient.RawConvertPrometheusGetAlertmanagerConfig(t, map[string]string{
+				"X-Grafana-Alerting-Config-Identifier": "test-unsupported-fields",
+			})
+			requireStatusCode(t, http.StatusNotFound, status, "")
+		})
+
 		t.Run("DELETE without config identifier header should use default identifier", func(t *testing.T) {
 			createHeaders := map[string]string{
 				"Content-Type": "application/yaml",


### PR DESCRIPTION
## What

Imported Prometheus/Mimir Alertmanager configs (`POST /convert/api/v1/alerts`) that use receiver fields Grafana cannot represent — the `*_file` / `*_ref` fields removed in [grafana/alerting#573](https://github.com/grafana/alerting/pull/573). They would be  **silently dropped** during conversion to Grafana's receiver format. The import would succeed while quietly discarding config the user wrote (e.g. an SMTP `auth_password_file`).

`ExtraConfiguration.Validate` now rejects such configs, naming the offending receivers and their YAML field paths.

## How

Rather than a hard-coded blocklist, each receiver is round-tripped through the `upstream → definition → upstream` conversion and diffed against the original (go-cmp + a custom reporter that emits YAML-tag paths). Anything that doesn't survive the round trip is unsupported — so this stays correct as upstream adds fields.

The receiver list rides in the error's public `extra` payload:

```json
{
  "messageId": "alerting.unsupportedReceiverFields",
  "message": "Configuration contains receivers that cannot be converted to Grafana receivers",
  "extra": { "receivers": [ { "receiver": "a", "fields": ["email_configs[0].auth_password_file"] } ] }
}
```

A `cmp.Diff` panic is turned into an error rather than crashing the import.

## Tests

- flags representative removed fields (email/slack/webhook + shared HTTP TLS)
- no false positives: a fully-populated supported receiver reports nothing (forward-compat guard)
- `Validate` accept/reject + multi-receiver accumulation
- public JSON error contract