### PR TITLE
docs(alerting): detail regex label matchers in rule search

### DIFF
--- a/docs/sources/alerting/monitor-status/view-alert-rules.md
+++ b/docs/sources/alerting/monitor-status/view-alert-rules.md
@@ -68,7 +68,27 @@ For example:
 
 You can combine multiple filters in a single search. Any text entered without a `key:` prefix is treated as a query that filters alert rules by name.
 
-Regex matching is supported in search values. For labels whose values are set by Go templates, search matches against the rendered static value, not the template expression, so you can't use a template query to find a match.
+#### Match labels with regular expressions
+
+The `label` filter accepts Prometheus-style matchers, so you can match label values with regular expressions instead of exact strings. The other filter types don't support regular expressions.
+
+A label matcher uses the form `label:<KEY><OPERATOR><VALUE>`. The following operators are supported:
+
+- `=`: matches rules whose label value is exactly equal to the value.
+- `!=`: matches rules whose label value isn't equal to the value.
+- `=~`: matches rules whose label value matches the regular expression.
+- `!~`: matches rules whose label value doesn't match the regular expression.
+
+For example:
+
+- `label:severity=~crit.*` matches rules where the `severity` label matches the regular expression, such as `critical` or `crit-high`.
+- `label:team!~fe.*` matches rules where the `team` label doesn't start with `fe`.
+
+Wrap the matcher in quotation marks when the key or value contains spaces or special characters, for example `label:"team=~fe.*devs"`.
+
+Regular expressions use [RE2 syntax](https://github.com/google/re2/wiki/Syntax) and are fully anchored, so the pattern must match the entire label value. Use `.*` or `.+` to match part of a value, for example `label:severity=~.*crit.*`. Matching is case-sensitive by default. To match without case sensitivity, add the `(?i)` inline flag, for example `label:severity=~(?i)critical`.
+
+Label matchers apply to both the alert rule's labels and the labels on its alert instances, so a rule matches when either set of labels satisfies the matcher. For labels whose values are set by Go templates, the matcher runs against the rendered static value, not the template expression, so you can't use a template query to find a match.
 
 The search input and the **Filter** popup are kept in sync, so changes made in either place are reflected in the other.
 


### PR DESCRIPTION
## What this PR does

Expands the alert rule search syntax section in `view-alert-rules.md` to accurately document how regular expression matching works.

The previous wording — "Regex matching is supported in search values" — is imprecise. In the implementation, regex applies **only** to the `label` filter via Prometheus-style matchers, and matching is RE2, fully anchored, and case-sensitive by default. The other filter types don't support regex.

## Changes

Adds a `#### Match labels with regular expressions` subsection covering:

- Supported operators: `=`, `!=`, `=~`, `!~`
- Quoting rules for keys/values with spaces or special characters
- RE2 syntax, full anchoring (use `.*`/`.+` for partial matches), and case-sensitivity (`(?i)` inline flag)
- Matchers apply to both rule labels and alert-instance labels
- Retains the existing Go template rendered-value caveat

## Why

The goal is to make the documentation accurate enough that LLMs answer questions about the search syntax correctly, rather than inferring overly broad regex support from the previous vague phrasing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)