### PR TITLE
UnifiedHomepage: Refresh starred dashboards on recent star change

### DIFF
--- a/public/app/features/home/DashboardTabs/DashboardTabs.tsx
+++ b/public/app/features/home/DashboardTabs/DashboardTabs.tsx
@@ -164,6 +164,7 @@ export function DashboardTabs() {
                 error={recentError}
                 retry={recentRetry}
                 foldersByUid={foldersByUid}
+                onStarChange={starredRetry}
               />
             )}
             {activeTab === STARRED_TAB_ID && (

--- a/public/app/features/home/DashboardTabs/RecentDashboardsTab.tsx
+++ b/public/app/features/home/DashboardTabs/RecentDashboardsTab.tsx
@@ -16,9 +16,10 @@ interface Props {
   error: Error | undefined;
   retry: () => void;
   foldersByUid: Record<string, LocationInfo>;
+  onStarChange?: () => void;
 }
 
-export function RecentDashboardsTab({ dashboards, loading, error, retry, foldersByUid }: Props) {
+export function RecentDashboardsTab({ dashboards, loading, error, retry, foldersByUid, onStarChange }: Props) {
   const styles = useStyles2(getStyles);
 
   if (loading) {
@@ -91,6 +92,7 @@ export function RecentDashboardsTab({ dashboards, loading, error, retry, folders
               locationInfo={foldersByUid[dash.location]}
               layoutMode="list"
               source="homepage_recentTab"
+              onStarChange={onStarChange}
             />
           </li>
         ))}


### PR DESCRIPTION
**What is this feature?**

When a dashboard item is starred in the recent dashboard tab, ensure that the starred dashboards tab data is also refreshed.

**Why do we need this feature?**

You could (un)star a recent dashboard and it would not be reflected if you then switched to the starred dashboards tab.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

Fixes #125898

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
