### PR TITLE
UnifiedHomepage: Avoid tab bar width changing with custom tabs

### DIFF
--- a/public/app/features/home/DashboardTabs/DashboardTabs.tsx
+++ b/public/app/features/home/DashboardTabs/DashboardTabs.tsx
@@ -138,10 +138,13 @@ export function DashboardTabs() {
       <TabsBar>
         {contentTabs.map((tab) => {
           const isActive = activeTab === tab.id;
+          // Keep a consistent tab bar width when on a custom tab by forcing the active label for recent dashboards
+          const forceActiveLabel =
+            activeTab !== RECENT_TAB_ID && activeTab !== STARRED_TAB_ID && tab.id === RECENT_TAB_ID;
           return (
             <Tab
               key={tab.id}
-              label={isActive ? (tab.activeLabel ?? tab.label) : tab.label}
+              label={isActive || forceActiveLabel ? (tab.activeLabel ?? tab.label) : tab.label}
               active={isActive}
               counter={tab.counter}
               onChangeTab={() => setActiveTab(tab.id)}


### PR DESCRIPTION
**What is this feature?**

When a custom tab is active, use the active label for the recent dashboards tab, showing the longer text.

| Before | After |
|-|-|
| <img width="1312" height="311" alt="image" src="https://github.com/user-attachments/assets/ca0a7343-6355-451d-b90f-acbfe4fed763" /> | <img width="1312" height="311" alt="image" src="https://github.com/user-attachments/assets/6b52346c-3e5f-4ecb-b0b2-1f62bb7c3b97" /> |
| <img width="1312" height="311" alt="image" src="https://github.com/user-attachments/assets/d9219acf-5481-4e7a-b6ad-eaf2879c4198" /> | <img width="1312" height="311" alt="image" src="https://github.com/user-attachments/assets/53476ee7-20f2-46aa-9734-0659c8f8db62" /> |
| <img width="1312" height="246" alt="image" src="https://github.com/user-attachments/assets/0d66e719-d06b-4554-aa23-96cfe945d10f" /> | <img width="1312" height="246" alt="image" src="https://github.com/user-attachments/assets/c7f74978-d016-4eb4-8338-79b15a4ce239" /> |

**Why do we need this feature?**

Avoids the position + width of the tab bar changing when the user switches from the two default dashboards tabs to any custom tab being injected.

Matches the existing Cloud-only homepage implementation's behaviour.

**Who is this feature for?**

All users.

**Which issue(s) does this PR fix?**:

cc https://github.com/grafana/grafana/issues/124136

**Special notes for your reviewer:**

Please check that:
- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.
