### PR TITLE
Analytics: expose stackId and stackSlug to frontend boot data

### DIFF
--- a/pkg/api/dtos/models.go
+++ b/pkg/api/dtos/models.go
@@ -54,6 +54,8 @@ type CurrentUser struct {
 type AnalyticsSettings struct {
 	Identifier         string `json:"identifier"`
 	IntercomIdentifier string `json:"intercomIdentifier,omitempty"`
+	StackID            string `json:"stackId,omitempty"`
+	StackSlug          string `json:"stackSlug,omitempty"`
 }
 
 type UserPermissionsMap map[string]bool

--- a/pkg/api/index.go
+++ b/pkg/api/index.go
@@ -224,6 +224,8 @@ func (hs *HTTPServer) buildUserAnalyticsSettings(c *contextmodel.ReqContext) dto
 	return dtos.AnalyticsSettings{
 		Identifier:         identifier,
 		IntercomIdentifier: hashUserIdentifier(identifier, hs.Cfg.IntercomSecret),
+		StackID:            hs.Cfg.StackID,
+		StackSlug:          hs.Cfg.Slug,
 	}
 }
 

--- a/pkg/services/user/model.go
+++ b/pkg/services/user/model.go
@@ -203,6 +203,8 @@ type GetSignedInUserQuery struct {
 type AnalyticsSettings struct {
 	Identifier         string
 	IntercomIdentifier string
+	StackID            string
+	StackSlug          string
 }
 
 func (u *User) NameOrFallback() string {


### PR DESCRIPTION
**What is this feature?**

Adds `stackId` and `stackSlug` to the `AnalyticsSettings` DTO so they are serialized into `window.grafanaBootData.user.analytics` alongside the existing `identifier` and `intercomIdentifier`. Values are sourced from existing `cfg.StackID` / `cfg.Slug` (read from `[environment] stack_id` / `stack_slug` in grafana.ini, populated by Hosted Grafana's deployment).

**Why do we need this feature?**

The frontend RudderStack identify call currently sets `orgId: user.orgId`, which is the Grafana-internal default org — always `1` on Grafana Cloud since each stack only has one org. There's no way today for any plugin's RudderStack events to cleanly attribute usage to a specific Cloud stack.

A follow-up frontend PR will read these fields and pass them in the `identify()` traits dict, so every plugin's RudderStack events automatically gain `context_traits_stack_id` and `context_traits_stack_slug`.

**Who is this feature for?**

Product analytics across plugins on Grafana Cloud — particularly Frontend Observability / Session Replay adoption metrics that need to break down engagement by stack.

**Which issue(s) does this PR fix?**:

Refs grafana/k6-cloud#4296

**Special notes for your reviewer:**

- Additive only. `omitempty` on the JSON tags means self-hosted Grafana (where both fields are empty in `cfg`) emits unchanged bootData.
- Backend half of a two-PR change. The frontend half (separate PR per `AGENTS.md` deploy-cadence guidance) will use these fields in the RudderStack identify call.
- I deliberately did not add a populated-path integration test — `testinfra.GrafanaOpts` has no `StackID` field today, and adding that plumbing felt disproportionate for a one-line population assertion. Happy to add if reviewers want it.

**How to verify locally**

The new `stackId` / `stackSlug` only populate for signed-in users when `cfg.StackID` / `cfg.Slug` are set. HG sets them in prod (e.g. [`cloudmigration.go:207`](https://github.com/grafana/grafana/blob/main/pkg/services/cloudmigration/cloudmigrationimpl/cloudmigration.go#L207) calls gcom with `s.cfg.StackID`).

1. Check out the branch:
   ```bash
   git checkout legander/analytics-add-stack-id-slug
   yarn install --immutable
   ```

2. Add fake values to `conf/custom.ini`:
   ```ini
   [environment]
   stack_id = 999999
   stack_slug = localdev
   ```

3. Build frontend + run backend:
   ```bash
   yarn build && make run
   ```

4. Open http://localhost:3000, sign in (`admin` / `admin`), then in DevTools console:
   ```js
   JSON.stringify(window.grafanaBootData.user.analytics, null, 2)
   ```

5. Expected: `stackId: "999999"` and `stackSlug: "localdev"` alongside `identifier` and `intercomIdentifier`. Without `[environment]` in `custom.ini`, both keys are absent (`omitempty`) — no change for self-hosted.

<img width="540" height="101" alt="Screenshot 2026-06-09 at 12 48 58" src="https://github.com/user-attachments/assets/e0ca809c-a144-4439-bb78-3f55b847624e" />