### PR TITLE
Analytics: pass stackId and stackSlug as RudderStack identify traits

### DIFF
--- a/packages/grafana-data/src/types/config.ts
+++ b/packages/grafana-data/src/types/config.ts
@@ -155,6 +155,8 @@ export type OAuthSettings = Partial<Record<OAuth, { name: string; icon?: IconNam
 export interface AnalyticsSettings {
   identifier: string;
   intercomIdentifier?: string;
+  stackId?: string;
+  stackSlug?: string;
 }
 
 /**

--- a/public/app/core/services/echo/backends/analytics/RudderstackBackend.ts
+++ b/public/app/core/services/echo/backends/analytics/RudderstackBackend.ts
@@ -96,7 +96,7 @@ export class RudderstackBackend implements EchoBackend<PageviewEchoEvent, Rudder
     });
 
     if (options.user) {
-      const { identifier, intercomIdentifier } = options.user.analytics;
+      const { identifier, intercomIdentifier, stackId, stackSlug } = options.user.analytics;
       const apiOptions: RudderstackAPIOptions = {};
 
       if (intercomIdentifier) {
@@ -113,6 +113,8 @@ export class RudderstackBackend implements EchoBackend<PageviewEchoEvent, Rudder
           language: options.user.language,
           version: options.buildInfo.version,
           edition: options.buildInfo.edition,
+          ...(stackId ? { stackId } : {}),
+          ...(stackSlug ? { stackSlug } : {}),
         },
         apiOptions
       );

--- a/public/app/core/services/echo/backends/analytics/RudderstackV3Backend.ts
+++ b/public/app/core/services/echo/backends/analytics/RudderstackV3Backend.ts
@@ -114,7 +114,7 @@ export class RudderstackBackend implements EchoBackend<PageviewEchoEvent, Rudder
     });
 
     if (options.user) {
-      const { identifier, intercomIdentifier } = options.user.analytics;
+      const { identifier, intercomIdentifier, stackId, stackSlug } = options.user.analytics;
       const apiOptions: RudderstackAPIOptions = {};
 
       if (intercomIdentifier) {
@@ -131,6 +131,8 @@ export class RudderstackBackend implements EchoBackend<PageviewEchoEvent, Rudder
           language: options.user.language,
           version: options.buildInfo.version,
           edition: options.buildInfo.edition,
+          ...(stackId ? { stackId } : {}),
+          ...(stackSlug ? { stackSlug } : {}),
         },
         apiOptions
       );


### PR DESCRIPTION
**What is this feature?**

Adds `stackId` and `stackSlug` to the trait dict passed to `window.rudderanalytics.identify(...)` in both `RudderstackBackend` and `RudderstackV3Backend`. Extends the `AnalyticsSettings` TS interface in `@grafana/data` to type the two new optional fields.

**Why do we need this feature?**

The existing identify call sets `orgId: user.orgId`, which is the Grafana-internal default org — always `1` on Grafana Cloud since each stack has only one org. So today's `context_traits_org_id` on every RudderStack event is useless for Cloud customer attribution. The only workaround is parsing `context_page_url` hostname on the BigQuery side.

With this PR, every plugin's `reportInteraction` event automatically carries `context_traits_stack_id` and `context_traits_stack_slug` — cleanly attributable to a Cloud stack without URL parsing.

**Who is this feature for?**

Product analytics across plugins on Grafana Cloud — particularly Frontend Observability / Session Replay adoption metrics that need to break down engagement by stack.

**Which issue(s) does this PR fix?**:

Refs grafana/k6-cloud#4296

**Notes for reviewers:**

- Frontend half of a two-PR change per `AGENTS.md` (separate FE/BE deploy cadences). Depends on grafana/grafana#125922 which exposes the fields on `dtos.AnalyticsSettings`. Until that ships, both fields read `undefined` on the frontend → conditional spread → no traits added → identical behavior to today. Once the backend PR ships, the traits flow through automatically.
- Uses conditional spread (`...(stackId ? { stackId } : {})`) so self-hosted Grafana (where both are empty) gets identical traits to today.
- Both Rudderstack backends touched identically. The V3 backend has the same identify shape as V1, just with different `load()` storage settings.

**How to verify locally**

This PR is a no-op until the backend PR #125922 supplies `stackId` / `stackSlug` in `bootData`, so verifying needs both branches applied. Easiest path is to cherry-pick the backend commit on top of this branch.

1. Apply both PRs together:
   ```bash
   git checkout legander/analytics-pass-stack-id-to-rudderstack
   git cherry-pick legander/analytics-add-stack-id-slug
   yarn install --immutable
   ```

2. Add fake values to `conf/custom.ini` so the backend has something to serialize:
   ```ini
   [environment]
   stack_id = 999999
   stack_slug = localdev
   ```

3. Add a `console.log` of the traits object in the source so the identify call's input is visible without a debugger. In [`public/app/core/services/echo/backends/analytics/RudderstackBackend.ts`](https://github.com/grafana/grafana/blob/legander/analytics-pass-stack-id-to-rudderstack/public/app/core/services/echo/backends/analytics/RudderstackBackend.ts#L118) right before the `window.rudderanalytics?.identify?.(...)` call on line 118 (and equivalently in [`RudderstackV3Backend.ts:126`](https://github.com/grafana/grafana/blob/legander/analytics-pass-stack-id-to-rudderstack/public/app/core/services/echo/backends/analytics/RudderstackV3Backend.ts#L126)):
   ```ts
   console.log('rudderstack identify traits', {
     email: options.user.email,
     orgId: options.user.orgId,
     language: options.user.language,
     version: options.buildInfo.version,
     edition: options.buildInfo.edition,
     stackId,
     stackSlug,
   });
   ```

4. Build the frontend + run the backend:
   ```bash
   yarn build && make run
   ```

5. Open http://localhost:3000, sign in (`admin` / `admin`), open DevTools console.

6. Expected: the `rudderstack identify traits` log line contains `stackId: "999999"` and `stackSlug: "localdev"` alongside `email`, `orgId`, `language`, `version`, `edition`.

<img width="756" height="157" alt="Screenshot 2026-06-09 at 13 14 15" src="https://github.com/user-attachments/assets/eb50dd23-e9e1-4d41-9d6e-4397f361f482" />

7. Negative test — remove `[environment]` from `custom.ini`, restart, repeat. The log line should no longer have `stackId` / `stackSlug` (the conditional spread drops them). Confirms self-hosted Grafana sees no behavior change.