### PR TITLE
Alerting: Make alertmanager syncer validate config

### DIFF
--- a/pkg/services/ngalert/notifier/external_am_syncer.go
+++ b/pkg/services/ngalert/notifier/external_am_syncer.go
@@ -37,6 +37,7 @@ type mimirConfigResponse struct {
 const (
 	syncReasonDatasourceLookup   = "datasource_lookup"
 	syncReasonMimirFetch         = "mimir_fetch"
+	syncReasonValidate           = "validate"
 	syncReasonSave               = "save"
 	syncReasonIdentifierMismatch = "identifier_mismatch"
 )
@@ -143,6 +144,13 @@ func (s *ExternalAMSyncer) FetchExtraConfig(ctx context.Context, orgID int64) (*
 		return nil, 0
 	}
 
+	// Validate post-dedup, so the cost is paid only when the upstream config actually
+	// changed.
+	if err := ec.Validate(); err != nil {
+		s.logger.Warn("Skipping external AM config save: fetched configuration is invalid", "org_id", orgID, "error", err)
+		s.metrics.ExternalAMConfigSyncFailures.WithLabelValues(orgIDStr, syncReasonValidate).Inc()
+		return nil, 0
+	}
 	return &ec, newHash
 }
 

--- a/pkg/services/ngalert/notifier/external_am_syncer_test.go
+++ b/pkg/services/ngalert/notifier/external_am_syncer_test.go
@@ -516,6 +516,42 @@ func TestSyncExternalAMs_RejectedByValidator(t *testing.T) {
 	assert.Equal(t, float64(1), testutil.ToFloat64(moa.metrics.ExternalAMConfigSyncFailures.WithLabelValues("1", "mimir_fetch")))
 }
 
+func TestSyncExternalAMs_InvalidConfigClassifiedOnMetric(t *testing.T) {
+	// Upstream config references a filesystem path (auth_password_file) that Grafana
+	// cannot represent. It fetches and parses fine but fails validation, so the sync
+	// must reject it before saving rather than silently dropping the field.
+	const amConfig = `global:
+  smtp_smarthost: 'localhost:25'
+  smtp_from: 'alerts@example.com'
+route:
+  receiver: a
+receivers:
+  - name: a
+    email_configs:
+      - to: someone@example.com
+        auth_password_file: /etc/smtp-password
+`
+	mimirSrv := startMimirServer(t, amConfig)
+
+	ds := makeMimirDS("mimir-uid", 1, mimirSrv.URL)
+	dsSvc := &dsfakes.FakeDataSourceService{DataSources: []*datasources.DataSource{ds}}
+
+	adminCfg := &mockAdminConfigStore{}
+	adminCfg.On("GetAdminConfiguration", int64(1)).Return(&ngmodels.AdminConfiguration{OrgID: 1, ExternalAlertmanagerUID: ptrTo("mimir-uid")}, nil)
+
+	moa, cs := buildSyncTestMOA(t, adminCfg, dsSvc, true, "", []int64{1})
+
+	moa.SyncAlertmanagersForOrgs(context.Background(), []int64{1})
+
+	// Invalid config must not be persisted.
+	assertNoExtraConfigSaved(t, cs, 1)
+
+	// Failure metric tagged with the dedicated validate reason so operators can alert
+	// on it separately from generic save errors.
+	assert.Equal(t, float64(1), testutil.ToFloat64(moa.metrics.ExternalAMConfigSyncFailures.WithLabelValues("1", "validate")))
+	assert.Equal(t, float64(0), testutil.ToFloat64(moa.metrics.ExternalAMConfigSyncFailures.WithLabelValues("1", "save")))
+}
+
 func TestBuildMimirConfigURL(t *testing.T) {
 	syncer := &ExternalAMSyncer{}
 


### PR DESCRIPTION
**What is this feature?**
Updates External Alertmanager syncer to validate config before returning it to consumer. 

**Why do we need this feature?**
This makes the flow to fail fast on configs that are not valid, instead of getting into save-and-apply flow and fail there.