### PR TITLE
Navigation: Nest Maintenance Windows app under SLO

### DIFF
--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -78,10 +78,6 @@ func (s *ServiceImpl) addAppLinks(treeRoot *navtree.NavTreeRoot, c *contextmodel
 	return nil
 }
 
-// nestMaintenanceWindowsUnderSLO moves the Maintenance Windows app under the SLO
-// app's nav node when both apps are enabled, so it appears as a child page of SLO
-// instead of a standalone app. When the SLO app is not present, Maintenance Windows
-// keeps its own standalone nav entry.
 func (s *ServiceImpl) nestMaintenanceWindowsUnderSLO(treeRoot *navtree.NavTreeRoot) {
 	const sloPluginID = "grafana-slo-app"
 	const mwPluginID = "grafana-maintenancewindows-app"
@@ -92,16 +88,15 @@ func (s *ServiceImpl) nestMaintenanceWindowsUnderSLO(treeRoot *navtree.NavTreeRo
 		return
 	}
 
-	// Remove the standalone Maintenance Windows app node so it only appears nested under SLO.
 	treeRoot.RemoveSectionByID(mwNode.Id)
 
-	sloNode.Children = append(sloNode.Children, &navtree.NavLink{
-		Text:     "Maintenance windows",
-		Id:       mwPluginID,
-		Url:      s.cfg.AppSubURL + "/a/" + mwPluginID + "/maintenance-windows",
-		PluginID: mwPluginID,
-		IsNew:    true,
-	})
+	mwNode.Id = "standalone-plugin-page-" + mwPluginID
+	mwNode.IsNew = true
+	sloNode.Children = append(sloNode.Children, mwNode)
+
+	if appsNode := treeRoot.FindById(navtree.NavIDApps); appsNode != nil && len(appsNode.Children) == 0 {
+		treeRoot.RemoveSectionByID(navtree.NavIDApps)
+	}
 }
 
 // shouldIncludeInvestigations checks if the investigations feature should be included for the assistant app

--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -92,6 +92,9 @@ func (s *ServiceImpl) nestMaintenanceWindowsUnderSLO(treeRoot *navtree.NavTreeRo
 
 	mwNode.Id = "standalone-plugin-page-" + mwPluginID
 	mwNode.IsNew = true
+	// Reset the standalone app's plugin SortWeight so it falls back to its
+	// appended position and sorts last among SLO's child pages.
+	mwNode.SortWeight = 0
 	sloNode.Children = append(sloNode.Children, mwNode)
 
 	if appsNode := treeRoot.FindById(navtree.NavIDApps); appsNode != nil && len(appsNode.Children) == 0 {

--- a/pkg/services/navtree/navtreeimpl/applinks.go
+++ b/pkg/services/navtree/navtreeimpl/applinks.go
@@ -73,7 +73,35 @@ func (s *ServiceImpl) addAppLinks(treeRoot *navtree.NavTreeRoot, c *contextmodel
 		treeRoot.AddSection(appLink)
 	}
 
+	s.nestMaintenanceWindowsUnderSLO(treeRoot)
+
 	return nil
+}
+
+// nestMaintenanceWindowsUnderSLO moves the Maintenance Windows app under the SLO
+// app's nav node when both apps are enabled, so it appears as a child page of SLO
+// instead of a standalone app. When the SLO app is not present, Maintenance Windows
+// keeps its own standalone nav entry.
+func (s *ServiceImpl) nestMaintenanceWindowsUnderSLO(treeRoot *navtree.NavTreeRoot) {
+	const sloPluginID = "grafana-slo-app"
+	const mwPluginID = "grafana-maintenancewindows-app"
+
+	sloNode := treeRoot.FindById("plugin-page-" + sloPluginID)
+	mwNode := treeRoot.FindById("plugin-page-" + mwPluginID)
+	if sloNode == nil || mwNode == nil {
+		return
+	}
+
+	// Remove the standalone Maintenance Windows app node so it only appears nested under SLO.
+	treeRoot.RemoveSectionByID(mwNode.Id)
+
+	sloNode.Children = append(sloNode.Children, &navtree.NavLink{
+		Text:     "Maintenance windows",
+		Id:       mwPluginID,
+		Url:      s.cfg.AppSubURL + "/a/" + mwPluginID + "/maintenance-windows",
+		PluginID: mwPluginID,
+		IsNew:    true,
+	})
 }
 
 // shouldIncludeInvestigations checks if the investigations feature should be included for the assistant app

--- a/pkg/services/navtree/navtreeimpl/applinks_test.go
+++ b/pkg/services/navtree/navtreeimpl/applinks_test.go
@@ -671,6 +671,9 @@ func TestNestMaintenanceWindowsUnderSLO(t *testing.T) {
 			pluginSettings: &pluginsettings.FakePluginSettings{Plugins: ps},
 			features:       featuremgmt.WithFeatures(),
 			pluginStore:    &pluginstore.FakePluginStore{PluginList: list},
+			navigationAppConfig: map[string]NavigationAppConfig{
+				"grafana-slo-app": {SectionID: navtree.NavIDRoot},
+			},
 		}
 	}
 
@@ -680,15 +683,18 @@ func TestNestMaintenanceWindowsUnderSLO(t *testing.T) {
 		err := service.addAppLinks(&treeRoot, reqCtx)
 		require.NoError(t, err)
 
-		// Maintenance Windows should not have its own standalone app node.
 		require.Nil(t, treeRoot.FindById("plugin-page-grafana-maintenancewindows-app"))
 
 		sloNode := treeRoot.FindById("plugin-page-grafana-slo-app")
 		require.NotNil(t, sloNode)
 		mwChild := navtree.FindByURL(sloNode.Children, "/a/grafana-maintenancewindows-app/maintenance-windows")
 		require.NotNil(t, mwChild)
-		require.Equal(t, "Maintenance windows", mwChild.Text)
+		require.Equal(t, "Maintenance Windows", mwChild.Text)
 		require.Equal(t, "grafana-maintenancewindows-app", mwChild.PluginID)
+		require.Equal(t, "standalone-plugin-page-grafana-maintenancewindows-app", mwChild.Id)
+		require.True(t, mwChild.IsNew)
+
+		require.Nil(t, treeRoot.FindById(navtree.NavIDApps))
 	})
 
 	t.Run("Should keep Maintenance Windows as its own app when SLO is not enabled", func(t *testing.T) {

--- a/pkg/services/navtree/navtreeimpl/applinks_test.go
+++ b/pkg/services/navtree/navtreeimpl/applinks_test.go
@@ -631,3 +631,73 @@ func TestAddAppLinksAccessControl(t *testing.T) {
 		require.Equal(t, "/a/test-app1/announcements", appsNode.Children[0].Children[0].Url)
 	})
 }
+
+func TestNestMaintenanceWindowsUnderSLO(t *testing.T) {
+	httpReq, _ := http.NewRequest(http.MethodGet, "", nil)
+	reqCtx := &contextmodel.ReqContext{SignedInUser: &user.SignedInUser{}, Context: &web.Context{Req: httpReq}}
+	permissions := []ac.Permission{
+		{Action: pluginaccesscontrol.ActionAppAccess, Scope: "*"},
+	}
+
+	sloApp := pluginstore.Plugin{
+		JSONData: plugins.JSONData{
+			ID: "grafana-slo-app", Name: "SLO", Type: plugins.TypeApp,
+			Includes: []*plugins.Includes{
+				{Name: "Home", Path: "/a/grafana-slo-app/home", Type: "page", AddToNav: true, DefaultNav: true},
+				{Name: "Manage SLOs", Path: "/a/grafana-slo-app/manage-slos", Type: "page", AddToNav: true},
+			},
+		},
+	}
+	mwApp := pluginstore.Plugin{
+		JSONData: plugins.JSONData{
+			ID: "grafana-maintenancewindows-app", Name: "Maintenance Windows", Type: plugins.TypeApp,
+			Includes: []*plugins.Includes{
+				{Name: "Maintenance windows", Path: "/a/grafana-maintenancewindows-app/maintenance-windows", Type: "page", AddToNav: true, DefaultNav: true},
+			},
+		},
+	}
+
+	newService := func(plugins ...pluginstore.Plugin) ServiceImpl {
+		ps := map[string]*pluginsettings.DTO{}
+		list := make([]pluginstore.Plugin, 0, len(plugins))
+		for _, p := range plugins {
+			ps[p.ID] = &pluginsettings.DTO{OrgID: 1, PluginID: p.ID, PluginVersion: "1.0.0", Enabled: true}
+			list = append(list, p)
+		}
+		return ServiceImpl{
+			log:            log.New("navtree"),
+			cfg:            setting.NewCfg(),
+			accessControl:  accesscontrolmock.New().WithPermissions(permissions),
+			pluginSettings: &pluginsettings.FakePluginSettings{Plugins: ps},
+			features:       featuremgmt.WithFeatures(),
+			pluginStore:    &pluginstore.FakePluginStore{PluginList: list},
+		}
+	}
+
+	t.Run("Should nest Maintenance Windows under SLO when both are enabled", func(t *testing.T) {
+		service := newService(sloApp, mwApp)
+		treeRoot := navtree.NavTreeRoot{}
+		err := service.addAppLinks(&treeRoot, reqCtx)
+		require.NoError(t, err)
+
+		// Maintenance Windows should not have its own standalone app node.
+		require.Nil(t, treeRoot.FindById("plugin-page-grafana-maintenancewindows-app"))
+
+		sloNode := treeRoot.FindById("plugin-page-grafana-slo-app")
+		require.NotNil(t, sloNode)
+		mwChild := navtree.FindByURL(sloNode.Children, "/a/grafana-maintenancewindows-app/maintenance-windows")
+		require.NotNil(t, mwChild)
+		require.Equal(t, "Maintenance windows", mwChild.Text)
+		require.Equal(t, "grafana-maintenancewindows-app", mwChild.PluginID)
+	})
+
+	t.Run("Should keep Maintenance Windows as its own app when SLO is not enabled", func(t *testing.T) {
+		service := newService(mwApp)
+		treeRoot := navtree.NavTreeRoot{}
+		err := service.addAppLinks(&treeRoot, reqCtx)
+		require.NoError(t, err)
+
+		require.Nil(t, treeRoot.FindById("plugin-page-grafana-slo-app"))
+		require.NotNil(t, treeRoot.FindById("plugin-page-grafana-maintenancewindows-app"))
+	})
+}


### PR DESCRIPTION
## Why

The MW app, is a new plugin that will be scaffolded but only impacts the SLO plugin. The goal is to eventually expose this plugin to other grafana plugins.

## Related issues

Closes grafana/slo#4543

## Things to look out for

- Nav-tree mutation: the standalone Maintenance Windows node is removed and re-attached under SLO. Confirm the fallback path (SLO absent) still leaves Maintenance Windows standalone.

## Test plan

- [x] Unit: both apps enabled -> Maintenance Windows nested under SLO, no standalone node.
- [x] Unit: SLO absent -> Maintenance Windows remains standalone.
