### PR TITLE
fix(alerting): hide DS-managed UI when alertingDisableDMAinUI is enabled (#115015)

### DIFF
--- a/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
+++ b/public/app/features/alerting/unified/components/rule-editor/query-and-alert-condition/QueryAndExpressionsStep.tsx
@@ -512,7 +512,7 @@ export const QueryAndExpressionsStep = ({ editingExistingRule, onDataChange, mod
                 }}
               />
             </Field>
-            {mode === 'edit' && hasAlertEnabledDataSources && (
+            {mode === 'edit' && hasAlertEnabledDataSources && !isDisableDMAinUIEnabled && (
               <>
                 <Divider />
                 <SmartAlertTypeDetector


### PR DESCRIPTION
When the  feature toggle is enabled, hides the 'Data source-managed' option in the SmartAlertTypeDetector (rule type radio group) when editing existing rules. The option was already hidden during new rule creation — this extends the same check to the edit-existing-rule path.

Closes #115015