### PR TITLE
Alerting: Fix flaky RuleSequence delete race in integration test

### DIFF
--- a/pkg/tests/apis/alerting/rules/rulesequence/rulesequence_test.go
+++ b/pkg/tests/apis/alerting/rules/rulesequence/rulesequence_test.go
@@ -97,8 +97,13 @@ func TestIntegrationRuleSequenceUnifiedStorageOnly(t *testing.T) {
 		require.NoError(t, err, "RuleSequence should be creatable with unified storage only")
 		require.NotEmpty(t, created.Name)
 
-		got, err := seqClient.Get(ctx, created.Name, v1.GetOptions{})
-		require.NoError(t, err)
+		// The app-sdk OpinionatedWatcher adds a finalizer in the background.
+		// Wait for it to land so Delete doesn't race with the patch.
+		var got *v0alpha1.RuleSequence
+		require.Eventually(t, func() bool {
+			got, err = seqClient.Get(ctx, created.Name, v1.GetOptions{})
+			return err == nil && len(got.Finalizers) > 0
+		}, 2*time.Second, 100*time.Millisecond, "finalizer was not added to RuleSequence")
 		require.Equal(t, created.Name, got.Name)
 		require.Equal(t, seq.Spec.Trigger.Interval, got.Spec.Trigger.Interval)
 		require.Len(t, got.Spec.RecordingRules, 1)


### PR DESCRIPTION
**What is this feature?**

Wait for the OpinionatedWatcher finalizer to land before deleting a RuleSequence in the integration test.

**Why do we need this feature?**

The app-sdk OpinionatedWatcher adds a finalizer to new objects via a background patch. When `TestIntegrationRuleSequenceUnifiedStorageOnly` deletes the RuleSequence immediately after creation, the delete can race with the finalizer patch: `apistore.Storage.Delete` reads the ResourceVersion via Get, but by the time the storage-layer WriteEvent runs, the finalizer patch has bumped the RV, causing "requested RV does not match current RV".

**Who is this feature for?**

CI reliability.

**Which issue(s) does this PR fix?**:

Fixes flaky `TestIntegrationRuleSequenceUnifiedStorageOnly` in Postgres/Sqlite Enterprise CI shards.

**Special notes for your reviewer:**

- [ ] It works as expected from a user's perspective.
- [ ] If this is a pre-GA feature, it is behind a feature toggle.
- [ ] The docs are updated, and if this is a [notable improvement](https://grafana.com/docs/writers-toolkit/contribute/release-notes/#how-to-determine-if-content-belongs-in-whats-new), it's added to our [What's New](https://grafana.com/docs/writers-toolkit/contribute/release-notes/) doc.