### PR TITLE
Zanzana: Fix list query-cache corruption from in-place ident stripping

### DIFF
--- a/pkg/services/authz/zanzana/server/server_list.go
+++ b/pkg/services/authz/zanzana/server/server_list.go
@@ -368,23 +368,26 @@ func getRequestHash(req *openfgav1.ListObjectsRequest) (string, error) {
 
 func typedObjects(typ string, objects []string) []string {
 	prefix := typ + ":"
+	out := make([]string, len(objects))
 	for i := range objects {
-		objects[i] = strings.TrimPrefix(objects[i], prefix)
+		out[i] = strings.TrimPrefix(objects[i], prefix)
 	}
-	return objects
+	return out
 }
 
 func genericObjects(gr string, objects []string) []string {
 	prefix := common.TypeResourcePrefix + gr + "/"
+	out := make([]string, len(objects))
 	for i := range objects {
-		objects[i] = strings.TrimPrefix(objects[i], prefix)
+		out[i] = strings.TrimPrefix(objects[i], prefix)
 	}
-	return objects
+	return out
 }
 
 func folderObject(objects []string) []string {
+	out := make([]string, len(objects))
 	for i := range objects {
-		objects[i] = strings.TrimPrefix(objects[i], common.TypeFolderPrefix)
+		out[i] = strings.TrimPrefix(objects[i], common.TypeFolderPrefix)
 	}
-	return objects
+	return out
 }

--- a/pkg/services/authz/zanzana/server/server_list_test.go
+++ b/pkg/services/authz/zanzana/server/server_list_test.go
@@ -444,3 +444,59 @@ func TestIntegrationServerListStreamDeadline(t *testing.T) {
 		require.Error(t, err)
 	})
 }
+
+// TestStripHelpersDoNotMutateInput guards the root cause of a cache-poisoning bug: the List
+// response strip helpers must return a new slice and never mutate their input, which may be the
+// *openfgav1.ListObjectsResponse.Objects slice owned by the query cache. Mutating it in place
+// corrupted the cached full object idents that BatchCheck relies on.
+func TestStripHelpersDoNotMutateInput(t *testing.T) {
+	t.Run("typedObjects", func(t *testing.T) {
+		in := []string{"folder:abc", "folder:def"}
+		out := typedObjects("folder", in)
+		require.Equal(t, []string{"folder:abc", "folder:def"}, in, "input must not be mutated")
+		require.Equal(t, []string{"abc", "def"}, out)
+	})
+	t.Run("genericObjects", func(t *testing.T) {
+		in := []string{"resource:dashboard.grafana.app/dashboards/x"}
+		out := genericObjects("dashboard.grafana.app/dashboards", in)
+		require.Equal(t, []string{"resource:dashboard.grafana.app/dashboards/x"}, in, "input must not be mutated")
+		require.Equal(t, []string{"x"}, out)
+	})
+	t.Run("folderObject", func(t *testing.T) {
+		in := []string{"folder:abc", "folder:def"}
+		out := folderObject(in)
+		require.Equal(t, []string{"folder:abc", "folder:def"}, in, "input must not be mutated")
+		require.Equal(t, []string{"abc", "def"}, out)
+	})
+}
+
+// TestIntegrationListDoesNotPoisonBatchCheckCache reproduces the end-to-end bug: with the query
+// cache enabled, a List call must not corrupt the cached ListObjects response that a subsequent
+// BatchCheck (identical request) reads, so a directly-granted resource stays authorized.
+func TestIntegrationListDoesNotPoisonBatchCheckCache(t *testing.T) {
+	testutil.SkipIntegrationTestInShortMode(t)
+
+	server := setupOpenFGAServer(t)
+	setup(t, server)
+	server.cfg.CacheSettings.CheckQueryCacheEnabled = true
+
+	ctx := newContextWithNamespace()
+
+	// 1. List populates the ListObjects query cache and strips idents for its own response.
+	_, err := server.List(ctx, &authzv1.ListRequest{
+		Namespace: namespace, Verb: utils.VerbList, Subject: "user:1",
+		Group: dashboardGroup, Resource: dashboardResource,
+	})
+	require.NoError(t, err)
+
+	// 2. BatchCheck issues the identical ListObjects request (cache hit) and must still resolve
+	//    user:1's direct grant on dashboard "1".
+	res, err := server.BatchCheck(ctx, &authzv1.BatchCheckRequest{
+		Namespace: namespace, Subject: "user:1",
+		Checks: []*authzv1.BatchCheckItem{
+			{CorrelationId: "c", Verb: utils.VerbGet, Group: dashboardGroup, Resource: dashboardResource, Name: "1", Folder: ""},
+		},
+	})
+	require.NoError(t, err)
+	assert.True(t, res.GetResults()["c"].GetAllowed(), "directly-granted dashboard must stay authorized after a prior List")
+}


### PR DESCRIPTION
## What & why

When a user lists a resource collection, the unified storage server lists all candidates and filters them through authorization (`FilterAuthorized` → `BatchCheck`). The zanzana `BatchCheck` direct-resource phase enumerates the user's accessible objects with `ListObjects` and resolves each candidate by **set membership**, matching against the full typed ident (`FolderIdent()`/`ResourceIdent()`, e.g. `folder:<uid>`, `resource:<group>/<resource>/<name>`).

`ListObjects` results are cached when `CheckQueryCacheEnabled` is set (**the default**), and `listObjectCached` returns the **shared** `*openfgav1.ListObjectsResponse` pointer.

The bug: the `List` response helpers `typedObjects` / `genericObjects` / `folderObject` strip the object-type prefix **in place**:

```go
objects[i] = strings.TrimPrefix(objects[i], prefix) // mutates the (cached) input slice
```

So the sequence:

1. A zanzana `List` call runs `ListObjects` → the full idents are cached.
2. `List` builds its response via the strip helpers, which **mutate that cached slice in place** → the cache entry is downgraded from full idents (`resource:dashboard.grafana.app/dashboards/x`) to bare ids (`x`).
3. A later `BatchCheck` issues the identical `ListObjects` request → **cache hit** returns the corrupted bare ids.
4. Membership matching against the full `ResourceIdent`/`FolderIdent` misses → the user is denied access to resources they were granted **directly** (e.g. a root dashboard granted to a role, or a folder they can edit).

Direct `Check` (single GET) was unaffected since it doesn't use `ListObjects` + membership, which is why a resource could be opened directly but not show up in lists.

## Fix

Make `typedObjects` / `genericObjects` / `folderObject` return a **new slice** instead of mutating their input, so the cached response is never corrupted.

## Tests

- `TestStripHelpersDoNotMutateInput` — unit test asserting the helpers never mutate their input.
- `TestIntegrationListDoesNotPoisonBatchCheckCache` — enables the query cache, runs `List` then an identical-keyed `BatchCheck`, and asserts a directly-granted resource stays authorized. Fails without the fix, passes with it.