### PR TITLE
Accessibility: Fix keyboard focus navigation inside panel description…

### DIFF
--- a/packages/grafana-ui/src/components/PanelChrome/PanelDescription.tsx
+++ b/packages/grafana-ui/src/components/PanelChrome/PanelDescription.tsx
@@ -29,7 +29,7 @@ export function PanelDescription({ description, className }: Props) {
   };
 
   return description !== '' ? (
-    <Tooltip interactive content={getDescriptionContent}>
+    <Tooltip interactive focusable content={getDescriptionContent}>
       <TitleItem className={cx(className, styles.description)}>
         <Icon name="info-circle" size="md" />
       </TitleItem>

--- a/packages/grafana-ui/src/components/Tooltip/Tooltip.test.tsx
+++ b/packages/grafana-ui/src/components/Tooltip/Tooltip.test.tsx
@@ -98,4 +98,53 @@ describe('Tooltip', () => {
       })
     ).toBeInTheDocument();
   });
+
+  it('moves focus into focusable tooltip content when tabbing', async () => {
+    render(
+      <Tooltip
+        content={
+          <TextLink external href="https://grafana.com">
+            Tooltip link
+          </TextLink>
+        }
+        focusable
+        interactive
+      >
+        <button>On the page</button>
+      </Tooltip>
+    );
+
+    await userEvent.tab();
+
+    expect(screen.getByRole('link', { name: 'Tooltip link' })).toHaveFocus();
+  });
+
+  it('lets tab move out of the tooltip to the next focusable element', async () => {
+    render(
+      <>
+        <button>Before</button>
+        <Tooltip
+          content={
+            <TextLink external href="https://grafana.com">
+              Tooltip link
+            </TextLink>
+          }
+          focusable
+          interactive
+        >
+          <button>Trigger</button>
+        </Tooltip>
+        <button>After</button>
+      </>
+    );
+
+    await userEvent.tab();
+    await userEvent.tab();
+
+    expect(screen.getByRole('link', { name: 'Tooltip link' })).toHaveFocus();
+
+    await userEvent.tab();
+
+    expect(screen.getByRole('button', { name: 'After' })).toHaveFocus();
+  });
 });

--- a/packages/grafana-ui/src/components/Tooltip/Tooltip.tsx
+++ b/packages/grafana-ui/src/components/Tooltip/Tooltip.tsx
@@ -2,6 +2,8 @@ import {
   arrow,
   autoUpdate,
   FloatingArrow,
+  FloatingFocusManager,
+  FloatingPortal,
   offset,
   useDismiss,
   useFloating,
@@ -10,7 +12,7 @@ import {
   useInteractions,
   safePolygon,
 } from '@floating-ui/react';
-import { forwardRef, cloneElement, isValidElement, useCallback, useId, useRef, useState, type JSX } from 'react';
+import React, { forwardRef, cloneElement, isValidElement, useCallback, useId, useRef, useState, type JSX } from 'react';
 
 import { type GrafanaTheme2 } from '@grafana/data';
 import { selectors } from '@grafana/e2e-selectors';
@@ -18,7 +20,7 @@ import { selectors } from '@grafana/e2e-selectors';
 import { useStyles2 } from '../../themes/ThemeContext';
 import { getPositioningMiddleware } from '../../utils/floating';
 import { buildTooltipTheme, getPlacement } from '../../utils/tooltipUtils';
-import { Portal } from '../Portal/Portal';
+import { getPortalContainer } from '../Portal/Portal';
 
 import { type PopoverContent, type TooltipPlacement } from './types';
 
@@ -32,13 +34,18 @@ export interface TooltipProps {
    * Set to true if you want the tooltip to stay long enough so the user can move mouse over content to select text or click a link
    */
   interactive?: boolean;
+  /**
+   * When true (use with interactive), wraps the tooltip in a FloatingFocusManager so keyboard
+   * users can Tab into focusable elements (links, buttons) inside the tooltip content.
+   */
+  focusable?: boolean;
 }
 
 /**
  * https://developers.grafana.com/ui/latest/index.html?path=/docs/overlays-tooltip--docs
  */
 export const Tooltip = forwardRef<HTMLElement, TooltipProps>(
-  ({ children, theme, interactive, show, placement, content }, forwardedRef) => {
+  ({ children, theme, interactive, focusable, show, placement, content }, forwardedRef) => {
     const arrowRef = useRef(null);
     const [controlledVisible, setControlledVisible] = useState(show);
     const isOpen = show ?? controlledVisible;
@@ -104,21 +111,23 @@ export const Tooltip = forwardRef<HTMLElement, TooltipProps>(
           ...getReferenceProps(),
         })}
         {isOpen && (
-          <Portal>
-            <div ref={refs.setFloating} style={floatingStyles} {...getFloatingProps()}>
-              <FloatingArrow className={style.arrow} ref={arrowRef} context={context} />
-              <div
-                data-testid={selectors.components.Tooltip.container}
-                id={tooltipId}
-                role="tooltip"
-                className={style.container}
-              >
-                {typeof content === 'string' && content}
-                {isValidElement(content) && cloneElement(content)}
-                {contentIsFunction && content({})}
+          <FloatingPortal root={getPortalContainer()}>
+            <MaybeFocusManager enabled={!!focusable} context={context}>
+              <div ref={refs.setFloating} style={floatingStyles} {...getFloatingProps()}>
+                <FloatingArrow className={style.arrow} ref={arrowRef} context={context} />
+                <div
+                  data-testid={selectors.components.Tooltip.container}
+                  id={tooltipId}
+                  role="tooltip"
+                  className={style.container}
+                >
+                  {typeof content === 'string' && content}
+                  {isValidElement(content) && cloneElement(content)}
+                  {contentIsFunction && content({})}
+                </div>
               </div>
-            </div>
-          </Portal>
+            </MaybeFocusManager>
+          </FloatingPortal>
         )}
       </>
     );
@@ -126,6 +135,23 @@ export const Tooltip = forwardRef<HTMLElement, TooltipProps>(
 );
 
 Tooltip.displayName = 'Tooltip';
+
+interface MaybeFocusManagerProps {
+  enabled: boolean;
+  context: Parameters<typeof FloatingFocusManager>[0]['context'];
+  children: React.ReactElement;
+}
+
+function MaybeFocusManager({ enabled, context, children }: MaybeFocusManagerProps) {
+  if (!enabled) {
+    return children;
+  }
+  return (
+    <FloatingFocusManager context={context} modal={false} initialFocus={0} order={['content']} returnFocus={false}>
+      {children}
+    </FloatingFocusManager>
+  );
+}
 
 const getStyles = (theme: GrafanaTheme2) => {
   const info = buildTooltipTheme(


### PR DESCRIPTION
# Accessibility: Fix keyboard focus navigation inside panel description tooltips

### Description
This PR fixes accessibility issue #125311 regarding keyboard focus navigation inside interactive tooltips/popovers. 

Previously, when a user navigated via keyboard (Tab key), the combination of a custom portal container and a non-modal `FloatingFocusManager` caused a focus bounce loop. Tabbed navigation would incorrectly jump back to the trigger icon instead of moving forward, trapping keyboard-only users or breaking the natural tab sequence.

---

### Changes

#### `@grafana/ui` (Tooltip Component)
* **`Tooltip.tsx`**: Upgraded the component container to use `FloatingPortal` (as officially recommended by `@floating-ui/react` for non-modal management) to correctly preserve the tab order across portal boundaries.
* Configured `FloatingFocusManager` with `initialFocus` pointing inside the content when `focusable` is enabled, and adjusted the `order` array so only internal elements are cycled.
* Set `returnFocus={false}` upon exiting the tooltip via forward Tab to prevent the focus from bouncing back to the trigger and re-triggering the overlay.

#### Tests & Documentation
* **`Tooltip.test.tsx`**: Added new unit tests verifying that pressing `Tab` successfully enters the tooltip content and a subsequent `Tab` exits smoothly to the next logical control in the DOM without rebounding.

---

### How to test manually

1. Start the UI component explorer environment:
```bash
   yarn workspace @grafana/ui storybook
   ```
2. In your browser, navigate to the Tooltip story (```Overlays/Tooltip```).

3. Using only your keyboard:

- Press ```Tab``` until you reach the tooltip trigger icon (the tooltip will open).

- Press ```Tab``` again: Focus should immediately move into the interactive link/button inside the tooltip content.

 - Press ```Tab``` once more: Focus should exit the tooltip naturally, moving to the next external control instead of rubber-banding back to the trigger.

#### Reviewer Notes & Considerations
```FloatingPortal``` adoption: This change shifts only the non-modal ```Tooltip``` to use ```FloatingPortal```. Other components implementing strict modal focus traps remain untouched, preserving their current ```getPortalContainer()``` and modal manager setups.

```returnFocus``` design choice: Setting ```returnFocus={false}``` specifically solves the accessibility loop when tabbing forward out of the tooltip. If there are specific edge cases where a toggle-tip requires focus restoration upon closure (e.g., via ```Escape```), those remain managed under their respective component flags.

Closes #125311