### PR TITLE
Tempo: Do not escape a single value regex in TraceQL search filters

### DIFF
--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/utils.test.ts
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/utils.test.ts
@@ -156,6 +156,48 @@ describe('filterToQuerySection returns the correct query section for a filter', 
     expect(result).toBe('span.foo=~"bar|baz"');
   });
 
+  it('filter with single value regex is not escaped', () => {
+    const filter: TraceqlFilter = {
+      id: 'abc',
+      tag: 'foo',
+      operator: '=~',
+      value: ['.+'],
+      scope: TraceqlSearchScope.Span,
+      valueType: 'string',
+      isCustomValue: false,
+    };
+    const result = filterToQuerySection(filter, [], lp);
+    expect(result).toBe('span.foo=~".+"');
+  });
+
+  it('filter with single value negative regex is not escaped', () => {
+    const filter: TraceqlFilter = {
+      id: 'abc',
+      tag: 'foo',
+      operator: '!~',
+      value: ['.+'],
+      scope: TraceqlSearchScope.Span,
+      valueType: 'string',
+      isCustomValue: false,
+    };
+    const result = filterToQuerySection(filter, [], lp);
+    expect(result).toBe('span.foo!~".+"');
+  });
+
+  it('filter with multiple values regex still escapes each value for the alternation', () => {
+    const filter: TraceqlFilter = {
+      id: 'abc',
+      tag: 'foo',
+      operator: '=~',
+      value: ['a.b', 'c.d'],
+      scope: TraceqlSearchScope.Span,
+      valueType: 'string',
+      isCustomValue: false,
+    };
+    const result = filterToQuerySection(filter, [], lp);
+    expect(result).toBe('span.foo=~"a\\\\.b|c\\\\.d"');
+  });
+
   it('filter with multiple values and != operator', () => {
     const filter: TraceqlFilter = {
       id: 'abc',

--- a/public/app/plugins/datasource/tempo/SearchTraceQLEditor/utils.ts
+++ b/public/app/plugins/datasource/tempo/SearchTraceQLEditor/utils.ts
@@ -38,7 +38,7 @@ const valueHelper = (f: TraceqlFilter) => {
   if (Array.isArray(value) && !f.isCustomValue) {
     value = getEscapedValues(value);
 
-    if (isRegExpOperator(f.operator!)) {
+    if (isRegExpOperator(f.operator!) && value.length > 1) {
       value = getEscapedRegexValues(value);
     }
   }

--- a/public/app/plugins/datasource/tempo/language_provider.test.ts
+++ b/public/app/plugins/datasource/tempo/language_provider.test.ts
@@ -156,7 +156,9 @@ describe('Language_provider', () => {
             },
           ],
         })
-      ).toBe(`{name${operator}"api/v2/variants/by-upc/\\\\(\\\\?P<upc>\\\\[\\\\s\\\\S\\\\]\\\\*\\\\)/\\\\$"}`);
+        // A single value with a regex operator is treated as a regex pattern, so
+        // its metacharacters are preserved rather than escaped into a literal.
+      ).toBe(`{name${operator}"api/v2/variants/by-upc/(?P<upc>[\\\\s\\\\S]*)/$"}`);
     });
     it('two fields with everything filled in', () => {
       expect(


### PR DESCRIPTION
A trace span filter using a regex operator was escaping the regex metacharacters of a single value, so a broad pattern like .+ became the literal \.\+ and matched nothing while a narrower value matched as expected. Escaping is only needed when several selected values are joined into a regex alternation so each one matches literally, so this limits the escaping to that case and leaves a single value as the regex the user actually entered. The two existing tests that asserted the old behavior were encoding the bug, so I corrected them and added coverage for the single value regex case. Fixes grafana/grafana-tempo-datasource#144