### PR TITLE
fix: make alerting rule sequence informer watch calls cluster scoped

### DIFF
--- a/apps/alerting/rules/pkg/app/app.go
+++ b/apps/alerting/rules/pkg/app/app.go
@@ -30,10 +30,8 @@ func New(cfg app.Config) (app.App, error) {
 				Mutator:   buildKindMutator(kind, runtimeCfg),
 				Watcher:   buildKindWatcher(kind, runtimeCfg),
 			}
-			// Scope the informer's ListWatch to a single namespace when
-			// configured. Only kinds with a watcher run an informer, so this
-			// only affects RuleSequence. An empty namespace watches all
-			// namespaces (the on-prem default).
+			// Only kinds with a watcher run an informer (RuleSequence), so this
+			// scopes that watch to WatchNamespace; empty means all namespaces.
 			if managedKind.Watcher != nil && runtimeCfg.WatchNamespace != "" {
 				managedKind.ReconcileOptions.Namespace = runtimeCfg.WatchNamespace
 			}

--- a/apps/alerting/rules/pkg/app/app.go
+++ b/apps/alerting/rules/pkg/app/app.go
@@ -30,6 +30,13 @@ func New(cfg app.Config) (app.App, error) {
 				Mutator:   buildKindMutator(kind, runtimeCfg),
 				Watcher:   buildKindWatcher(kind, runtimeCfg),
 			}
+			// Scope the informer's ListWatch to a single namespace when
+			// configured. Only kinds with a watcher run an informer, so this
+			// only affects RuleSequence. An empty namespace watches all
+			// namespaces (the on-prem default).
+			if managedKind.Watcher != nil && runtimeCfg.WatchNamespace != "" {
+				managedKind.ReconcileOptions.Namespace = runtimeCfg.WatchNamespace
+			}
 			managedKinds = append(managedKinds, managedKind)
 		}
 	}

--- a/apps/alerting/rules/pkg/app/config/runtime.go
+++ b/apps/alerting/rules/pkg/app/config/runtime.go
@@ -42,10 +42,8 @@ type RuntimeConfig struct {
 	// RuleSequence (if any) owns a rule UID. The default implementation is a
 	// watch-backed in-memory index that provides O(1) lookups.
 	MembershipResolver RuleSequenceMembershipResolver
-	// WatchNamespace scopes the RuleSequence membership-index informer to a
-	// single namespace. In cloud each Grafana instance serves one stack
-	// namespace and its storage identity is scoped to it, so an all-namespace
-	// watch is rejected by unified storage with a namespace mismatch. An empty
-	// value watches all namespaces (the on-prem multi-org default).
+	// WatchNamespace scopes the RuleSequence informer to one namespace. Empty
+	// watches all namespaces (on-prem default); in cloud it must be the stack
+	// namespace, else the all-namespace watch is rejected as a mismatch.
 	WatchNamespace string
 }

--- a/apps/alerting/rules/pkg/app/config/runtime.go
+++ b/apps/alerting/rules/pkg/app/config/runtime.go
@@ -42,4 +42,10 @@ type RuntimeConfig struct {
 	// RuleSequence (if any) owns a rule UID. The default implementation is a
 	// watch-backed in-memory index that provides O(1) lookups.
 	MembershipResolver RuleSequenceMembershipResolver
+	// WatchNamespace scopes the RuleSequence membership-index informer to a
+	// single namespace. In cloud each Grafana instance serves one stack
+	// namespace and its storage identity is scoped to it, so an all-namespace
+	// watch is rejected by unified storage with a namespace mismatch. An empty
+	// value watches all namespaces (the on-prem multi-org default).
+	WatchNamespace string
 }

--- a/pkg/registry/apps/alerting/rules/register.go
+++ b/pkg/registry/apps/alerting/rules/register.go
@@ -90,18 +90,15 @@ func RegisterAppInstaller(
 	return installer, nil
 }
 
-// watchNamespace returns the namespace the RuleSequence membership-index
-// informer should watch. In cloud each Grafana instance serves a single stack
-// namespace and its unified-storage identity is scoped to it, so watching all
-// namespaces is rejected with a namespace mismatch. On-prem (no stack ID) has
-// no such scoping and may serve multiple orgs, so we return an empty string to
-// watch all namespaces.
+// watchNamespace returns the namespace the RuleSequence informer should watch.
+// In cloud each instance serves one stack namespace and its storage identity is
+// scoped to it, so an all-namespace watch is rejected as a mismatch; on-prem
+// (no stack ID) returns "" to watch all namespaces.
 func watchNamespace(cfg *setting.Cfg) string {
 	if cfg == nil || cfg.StackID == "" {
 		return ""
 	}
-	// The cloud namespace mapper ignores the org ID and always returns the
-	// single stack namespace this instance serves.
+	// The cloud mapper ignores the org ID and returns the stack namespace.
 	return reqns.GetNamespaceMapper(cfg)(0)
 }
 

--- a/pkg/registry/apps/alerting/rules/register.go
+++ b/pkg/registry/apps/alerting/rules/register.go
@@ -71,6 +71,7 @@ func RegisterAppInstaller(
 		ResolveRuleRef:                newRuleRefResolver(ng),
 		MembershipResolver:            membershipIndex,
 		NotificationSettingsValidator: newNotificationSettingsValidator(ng),
+		WatchNamespace:                watchNamespace(cfg),
 	}
 
 	provider := simple.NewAppProvider(rulesManifest.LocalManifest(), appSpecificConfig, rulesApp.New)
@@ -87,6 +88,21 @@ func RegisterAppInstaller(
 	}
 	installer.AppInstaller = i
 	return installer, nil
+}
+
+// watchNamespace returns the namespace the RuleSequence membership-index
+// informer should watch. In cloud each Grafana instance serves a single stack
+// namespace and its unified-storage identity is scoped to it, so watching all
+// namespaces is rejected with a namespace mismatch. On-prem (no stack ID) has
+// no such scoping and may serve multiple orgs, so we return an empty string to
+// watch all namespaces.
+func watchNamespace(cfg *setting.Cfg) string {
+	if cfg == nil || cfg.StackID == "" {
+		return ""
+	}
+	// The cloud namespace mapper ignores the org ID and always returns the
+	// single stack namespace this instance serves.
+	return reqns.GetNamespaceMapper(cfg)(0)
 }
 
 func resolveOrgID(ctx context.Context) int64 {

--- a/pkg/registry/apps/alerting/rules/register_test.go
+++ b/pkg/registry/apps/alerting/rules/register_test.go
@@ -9,6 +9,24 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestWatchNamespace(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *setting.Cfg
+		want string
+	}{
+		{name: "nil cfg watches all namespaces", cfg: nil, want: ""},
+		{name: "on-prem (no stack id) watches all namespaces", cfg: &setting.Cfg{}, want: ""},
+		{name: "cloud scopes to the stack namespace", cfg: &setting.Cfg{StackID: "42"}, want: "stacks-42"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, watchNamespace(tt.cfg))
+		})
+	}
+}
+
 func TestRegisterAppInstaller_UnifiedAlertingEnabled(t *testing.T) {
 	tests := []struct {
 		name            string


### PR DESCRIPTION
Populate `ReconcileOptions` with namespace for alerting/rulesequence.