### PR TITLE
Reapply "Dashboards: Skip service for /api/dashboard/db  (#122027)" (#124908)

### DIFF
--- a/pkg/api/apierrors/dashboard.go
+++ b/pkg/api/apierrors/dashboard.go
@@ -6,6 +6,9 @@ import (
 	"fmt"
 	"net/http"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+
+	folderv1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/services/apiserver"
 	"github.com/grafana/grafana/pkg/services/dashboards"
@@ -13,7 +16,6 @@ import (
 	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginstore"
 	"github.com/grafana/grafana/pkg/util"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 // ToDashboardErrorResponse returns a different response status according to the dashboard error type
@@ -53,8 +55,16 @@ func ToDashboardErrorResponse(ctx context.Context, pluginStore pluginstore.Store
 	}
 
 	// --- Kubernetes status errors ---
-	var statusErr *apierrors.StatusError
-	if errors.As(err, &statusErr) {
+	if statusErr, ok := errors.AsType[*apierrors.StatusError](err); ok {
+		// The k8s dashboard apiserver returns NotFound on the folders resource when the
+		// referenced folder UID does not exist. Map that back to the legacy
+		// /api/dashboards/db contract (400 + "folder not found") so existing clients keep
+		// working after the direct-to-client routing change.
+		if apierrors.IsNotFound(err) {
+			if d := statusErr.ErrStatus.Details; d != nil && d.Group == folderv1.APIGroup && d.Kind == folderv1.RESOURCE {
+				return response.Error(http.StatusBadRequest, dashboards.ErrFolderNotFound.Error(), nil)
+			}
+		}
 		return response.Error(int(statusErr.ErrStatus.Code), statusErr.ErrStatus.Message, err)
 	}
 

--- a/pkg/api/apierrors/dashboard_test.go
+++ b/pkg/api/apierrors/dashboard_test.go
@@ -10,12 +10,15 @@ import (
 	"github.com/stretchr/testify/require"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	folderv1 "github.com/grafana/grafana/apps/folder/pkg/apis/folder/v1"
 	"github.com/grafana/grafana/pkg/api/response"
 	"github.com/grafana/grafana/pkg/plugins"
 	"github.com/grafana/grafana/pkg/services/apiserver"
 	"github.com/grafana/grafana/pkg/services/dashboards"
 	"github.com/grafana/grafana/pkg/services/dashboards/dashboardaccess"
+	"github.com/grafana/grafana/pkg/services/folder"
 	"github.com/grafana/grafana/pkg/services/pluginsintegration/pluginstore"
 	"github.com/grafana/grafana/pkg/util"
 )
@@ -53,6 +56,62 @@ func TestToDashboardErrorResponse(t *testing.T) {
 			input:       dashboardaccess.DashboardErr{Reason: "Bad Request", StatusCode: http.StatusBadRequest},
 			want:        response.Error(http.StatusBadRequest, "Bad Request", nil),
 		},
+		// Per-error pins for the typed dashboard errors that the legacy
+		// /api/dashboards/db endpoint used to map explicitly. They all flow
+		// through the generic DashboardErr branch today, but the explicit cases
+		// catch regressions if an error's StatusCode/Status fields change.
+		{
+			name:        "ErrDashboardWithSameUIDExists maps to 400",
+			pluginStore: pluginStoreWithoutPlugin,
+			input:       dashboards.ErrDashboardWithSameUIDExists,
+			want:        response.Error(http.StatusBadRequest, dashboards.ErrDashboardWithSameUIDExists.Error(), nil),
+		},
+		{
+			name:        "ErrDashboardFolderCannotHaveParent maps to 400",
+			pluginStore: pluginStoreWithoutPlugin,
+			input:       dashboards.ErrDashboardFolderCannotHaveParent,
+			want:        response.Error(http.StatusBadRequest, dashboards.ErrDashboardFolderCannotHaveParent.Error(), nil),
+		},
+		{
+			name:        "ErrDashboardTypeMismatch maps to 400",
+			pluginStore: pluginStoreWithoutPlugin,
+			input:       dashboards.ErrDashboardTypeMismatch,
+			want:        response.Error(http.StatusBadRequest, dashboards.ErrDashboardTypeMismatch.Error(), nil),
+		},
+		{
+			name:        "ErrDashboardInvalidUid maps to 400",
+			pluginStore: pluginStoreWithoutPlugin,
+			input:       dashboards.ErrDashboardInvalidUid,
+			want:        response.Error(http.StatusBadRequest, dashboards.ErrDashboardInvalidUid.Error(), nil),
+		},
+		{
+			name:        "ErrDashboardUidTooLong maps to 400",
+			pluginStore: pluginStoreWithoutPlugin,
+			input:       dashboards.ErrDashboardUidTooLong,
+			want:        response.Error(http.StatusBadRequest, dashboards.ErrDashboardUidTooLong.Error(), nil),
+		},
+		{
+			name:        "ErrDashboardCannotSaveProvisionedDashboard maps to 400",
+			pluginStore: pluginStoreWithoutPlugin,
+			input:       dashboards.ErrDashboardCannotSaveProvisionedDashboard,
+			want:        response.Error(http.StatusBadRequest, dashboards.ErrDashboardCannotSaveProvisionedDashboard.Error(), nil),
+		},
+		{
+			// ErrDashboardTitleEmpty carries Status="empty-name", so the response
+			// must be a JSON body, not a bare error string.
+			name:        "ErrDashboardTitleEmpty maps to 400 with status body",
+			pluginStore: pluginStoreWithoutPlugin,
+			input:       dashboards.ErrDashboardTitleEmpty,
+			want:        response.JSON(http.StatusBadRequest, util.DynMap{"status": "empty-name", "message": dashboards.ErrDashboardTitleEmpty.Error()}),
+		},
+		{
+			// folder.ErrNameExists has its own explicit branch in
+			// ToDashboardErrorResponse alongside dashboards.ErrFolderNotFound.
+			name:        "folder.ErrNameExists maps to 400",
+			pluginStore: pluginStoreWithoutPlugin,
+			input:       folder.ErrNameExists.Errorf("%s", "A folder with that name already exists"),
+			want:        response.Error(http.StatusBadRequest, folder.ErrNameExists.Errorf("%s", "A folder with that name already exists").Error(), nil),
+		},
 		// --- 403 Forbidden ---
 		{
 			name:        "dashboard error with a forbidden status",
@@ -60,12 +119,40 @@ func TestToDashboardErrorResponse(t *testing.T) {
 			input:       &k8sErrors.StatusError{ErrStatus: metav1.Status{Code: http.StatusForbidden, Message: "access denied"}},
 			want:        response.Error(http.StatusForbidden, "access denied", &k8sErrors.StatusError{ErrStatus: metav1.Status{Code: http.StatusForbidden, Message: "access denied"}}),
 		},
+		{
+			name:        "ErrDashboardUpdateAccessDenied maps to 403",
+			pluginStore: pluginStoreWithoutPlugin,
+			input:       dashboards.ErrDashboardUpdateAccessDenied,
+			want:        response.Error(http.StatusForbidden, dashboards.ErrDashboardUpdateAccessDenied.Error(), dashboards.ErrDashboardUpdateAccessDenied),
+		},
 		// --- 404 Not Found ---
 		{
 			name:        "folder not found error",
 			pluginStore: pluginStoreWithoutPlugin,
 			input:       dashboards.ErrFolderNotFound,
 			want:        response.Error(http.StatusBadRequest, dashboards.ErrFolderNotFound.Error(), nil),
+		},
+		{
+			// ErrDashboardNotFound carries Status="not-found", so the response
+			// is a JSON body produced by DashboardErr.Body().
+			name:        "ErrDashboardNotFound maps to 404 with status body",
+			pluginStore: pluginStoreWithoutPlugin,
+			input:       dashboards.ErrDashboardNotFound,
+			want:        response.JSON(http.StatusNotFound, util.DynMap{"status": "not-found", "message": dashboards.ErrDashboardNotFound.Error()}),
+		},
+		{
+			// k8s dashboard apiserver surfaces a NotFound on the folders resource when the
+			// referenced folder UID does not exist; legacy /api/dashboards/db must stay 400.
+			name:        "k8s folder not found is mapped to legacy 400",
+			pluginStore: pluginStoreWithoutPlugin,
+			input:       k8sErrors.NewNotFound(folderv1.FolderResourceInfo.GroupResource(), "unknown"),
+			want:        response.Error(http.StatusBadRequest, dashboards.ErrFolderNotFound.Error(), nil),
+		},
+		{
+			name:        "k8s not found for non-folder resource passes through",
+			pluginStore: pluginStoreWithoutPlugin,
+			input:       k8sErrors.NewNotFound(schema.GroupResource{Group: "dashboard.grafana.app", Resource: "dashboards"}, "abc"),
+			want:        response.Error(http.StatusNotFound, `dashboards.dashboard.grafana.app "abc" not found`, k8sErrors.NewNotFound(schema.GroupResource{Group: "dashboard.grafana.app", Resource: "dashboards"}, "abc")),
 		},
 		{
 			name:        "dashboard error with a non-bad-request status",
@@ -85,6 +172,14 @@ func TestToDashboardErrorResponse(t *testing.T) {
 			pluginStore: pluginStoreWithoutPlugin,
 			input:       dashboards.UpdatePluginDashboardError{PluginId: "unknown-plugin"},
 			want:        response.JSON(http.StatusPreconditionFailed, util.DynMap{"status": "plugin-dashboard", "message": "The dashboard belongs to plugin unknown-plugin."}),
+		},
+		{
+			// ErrDashboardVersionMismatch carries Status="version-mismatch", so
+			// the response is the JSON body produced by DashboardErr.Body().
+			name:        "ErrDashboardVersionMismatch maps to 412 with status body",
+			pluginStore: pluginStoreWithoutPlugin,
+			input:       dashboards.ErrDashboardVersionMismatch,
+			want:        response.JSON(http.StatusPreconditionFailed, util.DynMap{"status": "version-mismatch", "message": dashboards.ErrDashboardVersionMismatch.Error()}),
 		},
 		// --- 413 Payload Too Large ---
 		{

--- a/pkg/api/dashboard.go
+++ b/pkg/api/dashboard.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/client-go/dynamic"
 
 	claims "github.com/grafana/authlib/types"
+	dashboardsV0 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v0alpha1"
 	dashboardsV1 "github.com/grafana/grafana/apps/dashboard/pkg/apis/dashboard/v1"
 	"github.com/grafana/grafana/pkg/api/apierrors"
 	"github.com/grafana/grafana/pkg/api/dtos"
@@ -397,9 +398,13 @@ func (hs *HTTPServer) postDashboard(c *contextmodel.ReqContext, cmd dashboards.S
 			" OR it should include a object wrapper with an explicit 'apiVersion' and move the body into a 'spec' element", nil)
 	}
 
+	obj := &unstructured.Unstructured{Object: map[string]interface{}{
+		"spec": spec,
+	}}
+
 	// Items with metadata, spec, etc
 	if dashboards.LooksLikeK8sResource(spec) {
-		obj := &unstructured.Unstructured{Object: spec}
+		obj.Object = spec
 		apiVersion := obj.GetAPIVersion()
 		switch {
 		case strings.HasPrefix(apiVersion, dashboardsV1.GROUP):
@@ -415,83 +420,19 @@ func (hs *HTTPServer) postDashboard(c *contextmodel.ReqContext, cmd dashboards.S
 				obj.SetName(uid) // overwrite the incoming name -- this might happen from TF providers
 			}
 			hs.log.Warn("DEPRECATION WARNING: Accepting k8s style dashboard in legacy /api/dashboards/db.  Please use the /apis/dashboard.grafana.app/ API to manage this resource", "dashboard", obj.GetName())
-			return hs.saveDashboardViaK8s(c, cmd, obj)
 
 		case apiVersion == "":
 			return response.Error(http.StatusBadRequest, "Dashboard appears to be a k8s style resource, but is missing an explicit apiVersion.", nil)
+		default:
+			return response.Error(http.StatusBadRequest, "The dashboard payload references a non dashboard apiVersion.  This should be sent to the requested api directly", nil)
 		}
-		return response.Error(http.StatusBadRequest, "The dashboard payload references a non dashboard apiVersion.  This should be sent to the requested api directly", nil)
+	} else {
+		// Default legacy POSTs to v0alpha1: matches the prior DashboardService.SaveDashboard
+		// behavior. v0 lets the dashboard apiserver mutate hook strip uid/version/id without
+		// running the v1 schema migrations, so legacy callers' panel content is preserved.
+		obj.SetAPIVersion(dashboardsV0.APIVERSION)
 	}
-
-	_, found := spec["title"]
-	if !found {
-		return response.Error(http.StatusBadRequest, "Dashboard is missing required title property", nil)
-	}
-
-	ctx = c.Req.Context()
-
-	var userID int64
-	if id, err := identity.UserIdentifier(c.GetID()); err == nil {
-		userID = id
-	}
-
-	cmd.OrgID = c.GetOrgID()
-	cmd.UserID = userID
-
-	dash := cmd.GetDashboardModel()
-	newDashboard := dash.ID == 0
-	if newDashboard {
-		limitReached, err := hs.QuotaService.QuotaReached(c, dashboards.QuotaTargetSrv)
-		if err != nil {
-			return response.Error(http.StatusInternalServerError, "Failed to get quota", err)
-		}
-		if limitReached {
-			return response.Error(http.StatusForbidden, "Quota reached", nil)
-		}
-	}
-
-	var provisioningData *dashboards.DashboardProvisioning
-	if dash.ID != 0 {
-		data, err := hs.dashboardProvisioningService.GetProvisionedDashboardDataByDashboardID(c.Req.Context(), dash.ID)
-		if err != nil {
-			return response.Error(http.StatusInternalServerError, "Error while checking if dashboard is provisioned using ID", err)
-		}
-		provisioningData = data
-	} else if dash.UID != "" {
-		data, err := hs.dashboardProvisioningService.GetProvisionedDashboardDataByDashboardUID(c.Req.Context(), dash.OrgID, dash.UID)
-		if err != nil && !errors.Is(err, dashboards.ErrProvisionedDashboardNotFound) && !errors.Is(err, dashboards.ErrDashboardNotFound) {
-			return response.Error(http.StatusInternalServerError, "Error while checking if dashboard is provisioned", err)
-		}
-		provisioningData = data
-	}
-
-	allowUiUpdate := true
-	if provisioningData != nil {
-		allowUiUpdate = hs.ProvisioningService.GetAllowUIUpdatesFromConfig(provisioningData.Name)
-	}
-
-	dashItem := &dashboards.SaveDashboardDTO{
-		Dashboard: dash,
-		Message:   cmd.Message,
-		OrgID:     c.GetOrgID(),
-		User:      c.SignedInUser,
-		Overwrite: cmd.Overwrite,
-	}
-
-	dashboard, saveErr := hs.DashboardService.SaveDashboard(ctx, dashItem, allowUiUpdate)
-	if saveErr != nil {
-		return apierrors.ToDashboardErrorResponse(ctx, hs.pluginStore, saveErr)
-	}
-
-	return response.JSON(http.StatusOK, util.DynMap{
-		"status":    "success",
-		"slug":      dashboard.Slug,
-		"version":   dashboard.Version,
-		"id":        dashboard.ID,
-		"uid":       dashboard.UID,
-		"url":       dashboard.GetURL(),
-		"folderUid": dashboard.FolderUID,
-	})
+	return hs.saveDashboardViaK8s(c, cmd, obj)
 }
 
 func (hs *HTTPServer) saveDashboardViaK8s(c *contextmodel.ReqContext, cmd dashboards.SaveDashboardCommand, obj *unstructured.Unstructured) response.Response {
@@ -513,121 +454,174 @@ func (hs *HTTPServer) saveDashboardViaK8s(c *contextmodel.ReqContext, cmd dashbo
 	}
 	client := tmp.Resource(gv.WithResource(dashboardsV1.DASHBOARD_RESOURCE)).Namespace(namespace)
 
-	obj.SetKind("Dashboard") // Writing to the dashboard API
+	// /api/dashboards/db lets clients place identity (uid, id) and version
+	// inside the spec; lift them onto k8s metadata, then strip the originals
+	// so the apistore mutate hooks see a clean spec.
+	specUID, _, _ := unstructured.NestedString(obj.Object, "spec", "uid")
+	internalID, err := nestedInternalID(obj.Object)
+	if err != nil {
+		return response.Error(http.StatusBadRequest, err.Error(), err)
+	}
+	specVersion, hasSpecVersion, err := nestedSpecVersion(obj.Object)
+	if err != nil {
+		return response.Error(http.StatusBadRequest, err.Error(), err)
+	}
+	unstructured.RemoveNestedField(obj.Object, "spec", "uid")
+	unstructured.RemoveNestedField(obj.Object, "spec", "id")
+	unstructured.RemoveNestedField(obj.Object, "spec", "version")
+
+	// Reset the wrapper to a clean state the apistore will accept.
+	obj.SetKind("Dashboard")
 	obj.SetNamespace(namespace)
-	obj.SetAnnotations(map[string]string{}) // clear any annotations
-	obj.SetLabels(map[string]string{})      // clear any labels
+	obj.SetAnnotations(map[string]string{})
+	obj.SetLabels(map[string]string{})
 	delete(obj.Object, "status")
-	delete(obj.Object, "access") // can exist if you copied a /dto object
+	delete(obj.Object, "access") // present if the caller copied a /dto object
 
 	meta, err := utils.MetaAccessor(obj)
 	if err != nil {
 		return response.Error(http.StatusInternalServerError, "Failed to read grafana metadata", err)
 	}
-	meta.SetResourceVersionInt64(0) // remove
-	meta.SetFolder(cmd.FolderUID)
-	meta.SetMessage(cmd.Message)
 	meta.SetUID("")
-	meta.SetResourceVersion("") // remove
+	meta.SetResourceVersion("")
 	meta.SetFinalizers(nil)
 	meta.SetManagedFields(nil)
+	meta.SetFolder(cmd.FolderUID)
+	meta.SetMessage(cmd.Message)
 
 	name := obj.GetName()
-	if name == "" {
-		name, _, _ = unstructured.NestedString(obj.Object, "spec", "uid")
-	}
-
-	// Check (and remove) any legacy internal IDs
-	var old *unstructured.Unstructured
-	internalID, err := nestedInternalID(obj.Object)
-	if err != nil {
-		return response.Error(http.StatusBadRequest, err.Error(), err)
-	}
-	if internalID > 0 && name == "" {
-		found, err := client.List(ctx, metav1.ListOptions{
-			LabelSelector: fmt.Sprintf("%s=%d", utils.LabelKeyDeprecatedInternalID, internalID),
-			Limit:         2,
-		})
-		if err != nil {
-			return response.Error(http.StatusInternalServerError, "unable to lookup previous version", err)
-		}
-		if len(found.Items) == 0 {
-			return response.Error(http.StatusBadRequest,
-				fmt.Sprintf("The payload includes an internal identifier (%d) that is not found", internalID), nil)
-		}
-
-		old = &found.Items[0]
-		name = old.GetName()
+	if name == "" && specUID != "" {
+		name = specUID
 		meta.SetName(name)
-		if !cmd.Overwrite {
-			return response.Error(http.StatusConflict,
-				"Dashboard with the same internal ID already exists. Use overwrite flag to update.", nil)
-		}
 	}
 
-	// Never send internal ID or UID in the body
-	unstructured.RemoveNestedField(obj.Object, "spec", "id")
-	unstructured.RemoveNestedField(obj.Object, "spec", "uid")
+	// Resolve any legacy numeric id onto the k8s name. Errors here pin the
+	// legacy contract: 404 on unknown id, 500 on ambiguous id, 400 when the
+	// supplied uid refers to a different dashboard than the id does.
+	var old *unstructured.Unstructured
+	if internalID > 0 {
+		var rsp response.Response
+		if name, old, rsp = hs.resolveLegacyInternalID(ctx, client, internalID, name); rsp != nil {
+			return rsp
+		}
+		meta.SetName(name)
+		meta.SetDeprecatedInternalID(internalID) // nolint:staticcheck
+	}
 
-	isCreate := name == ""
-	if isCreate {
-		obj.SetGenerateName("a") // prefix
-	} else if old == nil {
-		// Read the old value first
+	// Pull the existing object if we don't already have it; isCreate flips
+	// once we know the name doesn't exist.
+	if name != "" && old == nil {
 		old, err = client.Get(ctx, name, metav1.GetOptions{})
-		if err == nil && old != nil {
-			if !cmd.Overwrite {
+		if k8serrors.IsNotFound(err) {
+			old = nil
+		} else if err != nil {
+			// 403 / etc. must reach the client unchanged.
+			return apierrors.ToDashboardErrorResponse(ctx, hs.pluginStore, err)
+		}
+	}
+	isCreate := old == nil
+	if isCreate && name == "" && obj.GetGenerateName() == "" {
+		obj.SetGenerateName("a")
+	}
+
+	if !isCreate {
+		oldMeta, err := utils.MetaAccessor(old)
+		if err != nil {
+			return response.Error(http.StatusInternalServerError, "Failed to read grafana metadata", err)
+		}
+		// Check if provisioning allows edits.
+		// NOTE this would be handled by the storage layer, however the error is different so
+		// we are checking here to make the existing contracts on /api hold.
+		if m, ok := oldMeta.GetManagerProperties(); ok && !m.AllowsEdits {
+			return response.Error(http.StatusBadRequest, dashboards.ErrDashboardCannotSaveProvisionedDashboard.Error(), nil)
+		}
+
+		// Without overwrite, accept the update only when the caller supplied
+		// the current version (we return meta.GetGeneration() as "version").
+		if !cmd.Overwrite {
+			if !hasSpecVersion || specVersion != oldMeta.GetGeneration() {
 				return response.Error(http.StatusConflict,
 					"Dashboard already exists. Use overwrite flag to update.", nil)
 			}
-		} else if err != nil && k8serrors.IsNotFound(err) {
-			isCreate = true // but name exists
-		} else {
-			return response.Error(http.StatusInternalServerError,
-				"Failed to read existing dashboard", err)
 		}
 	}
 
-	validation := "Warn"
+	validation := metav1.FieldValidationWarn
 	if strings.HasPrefix(gv.Version, "v0") {
-		validation = "Ignore" // v0 can be anything
+		validation = metav1.FieldValidationIgnore // v0 accepts anything
 	}
 	var dash *unstructured.Unstructured
 	if isCreate {
-		dash, err = client.Create(ctx, obj, metav1.CreateOptions{
-			FieldValidation: validation,
-		})
+		// Seed default RBAC permissions for the creator. The apistore strips
+		// this annotation before persisting and invokes its
+		// DefaultPermissionSetter hook after the resource is created.
+		meta.SetAnnotation(utils.AnnoKeyGrantPermissions, utils.AnnoGrantPermissionsDefault)
+		dash, err = client.Create(ctx, obj, metav1.CreateOptions{FieldValidation: validation})
 	} else {
-		dash, err = client.Update(ctx, obj, metav1.UpdateOptions{
-			FieldValidation: validation,
-		})
+		dash, err = client.Update(ctx, obj, metav1.UpdateOptions{FieldValidation: validation})
 	}
 	if err != nil {
 		return apierrors.ToDashboardErrorResponse(ctx, hs.pluginStore, err)
 	}
 
-	meta, err = utils.MetaAccessor(dash)
+	dashMeta, err := utils.MetaAccessor(dash)
 	if err != nil {
 		return response.Error(http.StatusInternalServerError, "Failed get meta accessor", err)
 	}
 
 	title, _, _ = unstructured.NestedString(dash.Object, "spec", "title")
 	slug := slugify.Slugify(title)
-
 	return response.JSON(http.StatusOK, util.DynMap{
 		"status":    "success",
 		"slug":      slug,
-		"version":   meta.GetGeneration(),
-		"id":        meta.GetDeprecatedInternalID(), //nolint:staticcheck
-		"uid":       meta.GetName(),
-		"url":       dashboards.GetDashboardFolderURL(false, meta.GetName(), slug),
-		"folderUid": meta.GetFolder(),
+		"version":   dashMeta.GetGeneration(),
+		"id":        dashMeta.GetDeprecatedInternalID(), //nolint:staticcheck
+		"uid":       dashMeta.GetName(),
+		"url":       dashboards.GetDashboardFolderURL(false, dashMeta.GetName(), slug),
+		"folderUid": dashMeta.GetFolder(),
 	})
+}
+
+// resolveLegacyInternalID maps a legacy numeric id onto the k8s resource name
+// and (when fetched along the way) the existing object. A non-nil
+// response.Response means we couldn't resolve it and the caller should return
+// it directly: 404 if no dashboard has that id and no uid was supplied, 500 if
+// the id is ambiguous, 400 if the supplied uid refers to a different dashboard.
+func (hs *HTTPServer) resolveLegacyInternalID(ctx context.Context, client dynamic.ResourceInterface, internalID int64, name string) (string, *unstructured.Unstructured, response.Response) {
+	ref, err := hs.DashboardService.GetDashboardUIDByID(ctx, &dashboards.GetDashboardRefByIDQuery{ID: internalID})
+	switch {
+	case errors.Is(err, dashboards.ErrDashboardNotFound):
+		if name == "" {
+			return "", nil, response.Error(http.StatusNotFound, dashboards.ErrDashboardNotFound.Error(), nil)
+		}
+		// uid was provided; treat as a regular create with a legacy id label.
+		return name, nil, nil
+	case err != nil:
+		// "unexpected number of dashboards" + any other unexpected error.
+		return "", nil, response.Error(http.StatusInternalServerError, err.Error(), err)
+	}
+	if name == "" {
+		obj, gerr := client.Get(ctx, ref.UID, metav1.GetOptions{})
+		if gerr != nil && !k8serrors.IsNotFound(gerr) {
+			return "", nil, response.Error(http.StatusInternalServerError, "Failed to read existing dashboard", gerr)
+		}
+		return ref.UID, obj, nil
+	}
+	if name == ref.UID {
+		return name, nil, nil
+	}
+	// id and uid disagree; allow the new uid only if it isn't already taken.
+	if _, gerr := client.Get(ctx, name, metav1.GetOptions{}); gerr == nil {
+		return "", nil, response.Error(http.StatusBadRequest, dashboards.ErrDashboardWithSameUIDExists.Error(), nil)
+	} else if !k8serrors.IsNotFound(gerr) {
+		return "", nil, response.Error(http.StatusInternalServerError, "Failed to read existing dashboard", gerr)
+	}
+	return name, nil, nil
 }
 
 func nestedInternalID(obj map[string]interface{}) (int64, error) {
 	val, found, err := unstructured.NestedFieldNoCopy(obj, "spec", "id")
-	if !found || err != nil {
+	if !found || err != nil || val == nil {
 		return 0, nil
 	}
 	i, ok := val.(int64)
@@ -639,6 +633,36 @@ func nestedInternalID(obj map[string]interface{}) (int64, error) {
 		return n.Int64()
 	}
 	return 0, fmt.Errorf("unsupported ID type: %T", val)
+}
+
+// nestedSpecVersion reads spec.version as int64. The legacy /api/dashboards/db
+// payload encodes version as a JSON number; simplejson parses it via UseNumber
+// so we usually see json.Number, but tolerate the common numeric types too.
+// A missing field returns (0, false, nil); a malformed field returns an error
+// so callers can surface a 400 instead of letting it fall through as a 409.
+func nestedSpecVersion(obj map[string]interface{}) (int64, bool, error) {
+	val, found, err := unstructured.NestedFieldNoCopy(obj, "spec", "version")
+	if err != nil {
+		return 0, false, fmt.Errorf("spec.version is invalid: %w", err)
+	}
+	if !found || val == nil {
+		return 0, false, nil
+	}
+	switch v := val.(type) {
+	case int64:
+		return v, true, nil
+	case int:
+		return int64(v), true, nil
+	case float64:
+		return int64(v), true, nil
+	case json.Number:
+		i, err := v.Int64()
+		if err != nil {
+			return 0, false, fmt.Errorf("spec.version is not an integer: %w", err)
+		}
+		return i, true, nil
+	}
+	return 0, false, fmt.Errorf("spec.version has unsupported type %T", val)
 }
 
 // swagger:route GET /dashboards/home dashboards getHomeDashboard

--- a/pkg/api/dashboard_test.go
+++ b/pkg/api/dashboard_test.go
@@ -519,119 +519,9 @@ func TestIntegrationDashboardAPIEndpoint(t *testing.T) {
 		dashTwo.HasACL = false
 	})
 
-	t.Run("Post dashboard response tests", func(t *testing.T) {
-		// This tests that a valid request returns correct response
-		t.Run("Given a correct request for creating a dashboard", func(t *testing.T) {
-			folderUID := "Folder"
-			const dashID int64 = 2
-
-			cmd := dashboards.SaveDashboardCommand{
-				OrgID:  1,
-				UserID: 5,
-				Dashboard: simplejson.NewFromAny(map[string]any{
-					"title": "Dash",
-				}),
-				Overwrite: true,
-				FolderUID: folderUID,
-				IsFolder:  false,
-				Message:   "msg",
-			}
-
-			dashboardService := dashboards.NewFakeDashboardService(t)
-			dashboardService.On("SaveDashboard", mock.Anything, mock.AnythingOfType("*dashboards.SaveDashboardDTO"), mock.AnythingOfType("bool")).
-				Return(&dashboards.Dashboard{ID: dashID, UID: "uid", Title: "Dash", Slug: "dash", Version: 2, FolderUID: folderUID}, nil)
-			mockFolderService := &foldertest.FakeService{
-				ExpectedFolder: &folder.Folder{UID: folderUID, Title: "Folder"},
-			}
-
-			postDashboardScenario(t, "When calling POST on", "/api/dashboards", "/api/dashboards", cmd, dashboardService, mockFolderService, func(sc *scenarioContext) {
-				callPostDashboardShouldReturnSuccess(sc)
-
-				result := sc.ToJSON()
-				assert.Equal(t, "success", result.Get("status").MustString())
-				assert.Equal(t, dashID, result.Get("id").MustInt64())
-				assert.Equal(t, "uid", result.Get("uid").MustString())
-				assert.Equal(t, "dash", result.Get("slug").MustString())
-				assert.Equal(t, "/d/uid/dash", result.Get("url").MustString())
-			})
-		})
-
-		t.Run("Given a correct request for creating a dashboard with folder uid", func(t *testing.T) {
-			const folderUid string = "folderUID"
-			const dashID int64 = 2
-
-			cmd := dashboards.SaveDashboardCommand{
-				OrgID:  1,
-				UserID: 5,
-				Dashboard: simplejson.NewFromAny(map[string]any{
-					"title": "Dash",
-				}),
-				Overwrite: true,
-				FolderUID: folderUid,
-				IsFolder:  false,
-				Message:   "msg",
-			}
-
-			dashboardService := dashboards.NewFakeDashboardService(t)
-			dashboardService.On("SaveDashboard", mock.Anything, mock.AnythingOfType("*dashboards.SaveDashboardDTO"), mock.AnythingOfType("bool")).
-				Return(&dashboards.Dashboard{ID: dashID, UID: "uid", Title: "Dash", Slug: "dash", Version: 2}, nil)
-
-			mockFolder := &foldertest.FakeService{
-				ExpectedFolder: &folder.Folder{UID: "folderUID", Title: "Folder"},
-			}
-
-			postDashboardScenario(t, "When calling POST on", "/api/dashboards", "/api/dashboards", cmd, dashboardService, mockFolder, func(sc *scenarioContext) {
-				callPostDashboardShouldReturnSuccess(sc)
-
-				result := sc.ToJSON()
-				assert.Equal(t, "success", result.Get("status").MustString())
-				assert.Equal(t, dashID, result.Get("id").MustInt64())
-				assert.Equal(t, "uid", result.Get("uid").MustString())
-				assert.Equal(t, "dash", result.Get("slug").MustString())
-				assert.Equal(t, "/d/uid/dash", result.Get("url").MustString())
-			})
-		})
-
-		// This tests that invalid requests returns expected error responses
-		t.Run("Given incorrect requests for creating a dashboard", func(t *testing.T) {
-			testCases := []struct {
-				SaveError          error
-				ExpectedStatusCode int
-			}{
-				{SaveError: dashboards.ErrDashboardNotFound, ExpectedStatusCode: http.StatusNotFound},
-				{SaveError: dashboards.ErrFolderNotFound, ExpectedStatusCode: http.StatusBadRequest},
-				{SaveError: dashboards.ErrDashboardWithSameUIDExists, ExpectedStatusCode: http.StatusBadRequest},
-				{SaveError: dashboards.ErrDashboardVersionMismatch, ExpectedStatusCode: http.StatusPreconditionFailed},
-				{SaveError: dashboards.ErrDashboardTitleEmpty, ExpectedStatusCode: http.StatusBadRequest},
-				{SaveError: dashboards.ErrDashboardFolderCannotHaveParent, ExpectedStatusCode: http.StatusBadRequest},
-				{SaveError: dashboards.ErrDashboardTypeMismatch, ExpectedStatusCode: http.StatusBadRequest},
-				{SaveError: folder.ErrNameExists, ExpectedStatusCode: http.StatusBadRequest},
-				{SaveError: dashboards.ErrDashboardUpdateAccessDenied, ExpectedStatusCode: http.StatusForbidden},
-				{SaveError: dashboards.ErrDashboardInvalidUid, ExpectedStatusCode: http.StatusBadRequest},
-				{SaveError: dashboards.ErrDashboardUidTooLong, ExpectedStatusCode: http.StatusBadRequest},
-				{SaveError: dashboards.ErrDashboardCannotSaveProvisionedDashboard, ExpectedStatusCode: http.StatusBadRequest},
-				{SaveError: dashboards.UpdatePluginDashboardError{PluginId: "plug"}, ExpectedStatusCode: http.StatusPreconditionFailed},
-			}
-
-			cmd := dashboards.SaveDashboardCommand{
-				OrgID: 1,
-				Dashboard: simplejson.NewFromAny(map[string]any{
-					"title": "",
-				}),
-			}
-
-			for _, tc := range testCases {
-				dashboardService := dashboards.NewFakeDashboardService(t)
-				dashboardService.On("SaveDashboard", mock.Anything, mock.AnythingOfType("*dashboards.SaveDashboardDTO"), mock.AnythingOfType("bool")).Return(nil, tc.SaveError)
-
-				postDashboardScenario(t, fmt.Sprintf("Expect '%s' error when calling POST on", tc.SaveError.Error()),
-					"/api/dashboards", "/api/dashboards", cmd, dashboardService, nil, func(sc *scenarioContext) {
-						callPostDashboard(sc)
-						assert.Equal(t, tc.ExpectedStatusCode, sc.resp.Code, sc.resp.Body.String())
-					})
-			}
-		})
-	})
+	// NOTE: Post dashboard response tests were removed because POST /api/dashboards now
+	// goes through the K8s apiserver via saveDashboardViaK8s rather than DashboardService.
+	// The K8s flow is covered by integration tests in pkg/tests/apis/dashboard/.
 
 	t.Run("Given two dashboards being compared", func(t *testing.T) {
 		fakeDashboardVersionService := dashvertest.NewDashboardVersionServiceFake()
@@ -1232,52 +1122,8 @@ func (hs *HTTPServer) callGetDashboardVersionsWithParams(sc *scenarioContext, qu
 	sc.fakeReqWithParams("GET", sc.url, queryParams).exec()
 }
 
-func callPostDashboard(sc *scenarioContext) {
-	sc.fakeReqWithParams("POST", sc.url, map[string]string{}).exec()
-}
-
 func callRestoreDashboardVersion(sc *scenarioContext) {
 	sc.fakeReqWithParams("POST", sc.url, map[string]string{}).exec()
-}
-
-func callPostDashboardShouldReturnSuccess(sc *scenarioContext) {
-	callPostDashboard(sc)
-
-	assert.Equal(sc.t, 200, sc.resp.Code)
-}
-
-func postDashboardScenario(t *testing.T, desc string, url string, routePattern string, cmd dashboards.SaveDashboardCommand, dashboardService dashboards.DashboardService, folderService folder.Service, fn scenarioFunc) {
-	t.Run(fmt.Sprintf("%s %s", desc, url), func(t *testing.T) {
-		cfg := setting.NewCfg()
-		hs := HTTPServer{
-			Cfg:                   cfg,
-			ProvisioningService:   provisioning.NewProvisioningServiceMock(context.Background()),
-			Live:                  newTestLive(t),
-			QuotaService:          quotatest.New(false, nil),
-			pluginStore:           &pluginstore.FakePluginStore{},
-			LibraryElementService: &libraryelementsfake.LibraryElementService{},
-			DashboardService:      dashboardService,
-			folderService:         folderService,
-			Features:              featuremgmt.WithFeatures(),
-			accesscontrolService:  actest.FakeService{},
-			log:                   log.New("test-logger"),
-			tracer:                tracing.InitializeTracerForTest(),
-		}
-
-		sc := setupScenarioContext(t, url)
-		sc.defaultHandler = routing.Wrap(func(c *contextmodel.ReqContext) response.Response {
-			c.Req.Body = mockRequestBody(cmd)
-			c.Req.Header.Add("Content-Type", "application/json")
-			sc.context = c
-			sc.context.SignedInUser = &user.SignedInUser{OrgID: cmd.OrgID, UserID: cmd.UserID}
-
-			return hs.PostDashboard(c)
-		})
-
-		sc.m.Post(routePattern, sc.defaultHandler)
-
-		fn(sc)
-	})
 }
 
 func restoreDashboardVersionScenario(t *testing.T, desc string, url string, routePattern string,

--- a/pkg/tests/apis/dashboard/dashboards_test.go
+++ b/pkg/tests/apis/dashboard/dashboards_test.go
@@ -252,7 +252,7 @@ func TestIntegrationLegacySupport(t *testing.T) {
 			input: map[string]any{
 				"panels": []any{}, // this used to be a panic
 			},
-			expect: "Dashboard is missing required title property",
+			expect: "Dashboard spec is missing required title property",
 		}}
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {

--- a/pkg/tests/apis/dashboard/search_test.go
+++ b/pkg/tests/apis/dashboard/search_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -673,6 +674,11 @@ func setFolderPermissions(t *testing.T, helper *apis.K8sTestHelper, actingUser a
 	require.Equal(t, http.StatusOK, resp.Response.StatusCode, "Failed to set permissions for folder %s", folderUID)
 }
 
+// bleveInternalDocIDRegex matches the 8-byte internal segment doc ID that bleve
+// includes in explain messages (e.g. "in \x00\x00\x00\x00\x00\x00\x00\r)").
+// The value depends on segment layout and is not stable across runs.
+var bleveInternalDocIDRegex = regexp.MustCompile(` in \x00[^)]*\)`)
+
 func roundExplainValues(obj map[string]any, decimals uint32) {
 	for k, val := range obj {
 		switch k {
@@ -680,6 +686,11 @@ func roundExplainValues(obj map[string]any, decimals uint32) {
 			v, ok := val.(float64)
 			if ok {
 				obj[k] = roundTo(v, decimals)
+			}
+		case "message":
+			s, ok := val.(string)
+			if ok {
+				obj[k] = bleveInternalDocIDRegex.ReplaceAllString(s, " in <docID>)")
 			}
 		case "children":
 			children, ok := val.([]any)

--- a/pkg/tests/apis/dashboard/testdata/searchV0/t01-query-single-word.json
+++ b/pkg/tests/apis/dashboard/testdata/searchV0/t01-query-single-word.json
@@ -10,7 +10,7 @@
         "panel-tests",
         "graph-ng"
       ],
-      "score": 0.16
+      "score": 0.131
     },
     {
       "resource": "dashboards",
@@ -21,8 +21,8 @@
         "panel-tests",
         "graph-ng"
       ],
-      "score": 0.155
+      "score": 0.123
     }
   ],
-  "maxScore": 0.16
+  "maxScore": 0.131
 }

--- a/pkg/tests/apis/dashboard/testdata/searchV0/t02-query-multiple-words.json
+++ b/pkg/tests/apis/dashboard/testdata/searchV0/t02-query-multiple-words.json
@@ -10,8 +10,8 @@
         "panel-tests",
         "graph-ng"
       ],
-      "score": 0.226
+      "score": 0.168
     }
   ],
-  "maxScore": 0.226
+  "maxScore": 0.168
 }

--- a/pkg/tests/apis/dashboard/testdata/searchV0/t04-title-ngram-prefix.json
+++ b/pkg/tests/apis/dashboard/testdata/searchV0/t04-title-ngram-prefix.json
@@ -10,8 +10,8 @@
         "panel-tests",
         "graph-ng"
       ],
-      "score": 0.065
+      "score": 0.059
     }
   ],
-  "maxScore": 0.065
+  "maxScore": 0.059
 }

--- a/pkg/tests/apis/dashboard/testdata/searchV0/t05-title-ngram-middle-word.json
+++ b/pkg/tests/apis/dashboard/testdata/searchV0/t05-title-ngram-middle-word.json
@@ -10,8 +10,8 @@
         "panel-tests",
         "graph-ng"
       ],
-      "score": 0.065
+      "score": 0.059
     }
   ],
-  "maxScore": 0.065
+  "maxScore": 0.059
 }

--- a/pkg/tests/apis/dashboard/testdata/searchV0/t06-panel-title-orange.json
+++ b/pkg/tests/apis/dashboard/testdata/searchV0/t06-panel-title-orange.json
@@ -10,7 +10,7 @@
         "panel-tests",
         "graph-ng"
       ],
-      "score": 0.128,
+      "score": 0.115,
       "explain": {
         "children": [
           {
@@ -48,32 +48,32 @@
                               {
                                 "children": [
                                   {
-                                    "message": "fieldNorm(field=fields.panel_title), b=0.750000, fieldLength=38.000002, avgFieldLength=17.000000)",
-                                    "value": 1.926
+                                    "message": "fieldNorm(field=fields.panel_title), b=0.750000, fieldLength=38.000002, avgFieldLength=13.000000)",
+                                    "value": 2.442
                                   }
                                 ],
-                                "message": "saturation(term:), k1=1.200000/(tf=1.732051 + k1*fieldNorm=1.926471))",
-                                "value": 0.297
+                                "message": "saturation(term:), k1=1.200000/(tf=1.732051 + k1*fieldNorm=2.442308))",
+                                "value": 0.257
                               },
                               {
                                 "message": "idf(docFreq=1, maxDocs=17)",
                                 "value": 2.485
                               }
                             ],
-                            "message": "fieldWeight(fields.panel_title:orange in \u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001), as per bm25 model, product of:",
-                            "value": 1.277
+                            "message": "fieldWeight(fields.panel_title:orange in <docID>), as per bm25 model, product of:",
+                            "value": 1.108
                           }
                         ],
-                        "message": "weight(fields.panel_title:orange^5.000000 in \u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0001), product of:",
-                        "value": 0.409
+                        "message": "weight(fields.panel_title:orange^5.000000 in <docID>), product of:",
+                        "value": 0.355
                       }
                     ],
                     "message": "sum of:",
-                    "value": 0.409
+                    "value": 0.355
                   }
                 ],
                 "message": "sum of:",
-                "value": 0.409
+                "value": 0.355
               },
               {
                 "message": "coord(1/4)",
@@ -82,7 +82,7 @@
             ],
             "message": "product of:",
             "partial_match": true,
-            "value": 0.102
+            "value": 0.089
           },
           {
             "children": [
@@ -122,9 +122,9 @@
           }
         ],
         "message": "sum of:",
-        "value": 0.128
+        "value": 0.115
       }
     }
   ],
-  "maxScore": 0.128
+  "maxScore": 0.115
 }


### PR DESCRIPTION
This reverts commit d0a7c775080e944c565e1cd800b8d5f283a21b86.

Brings back #122027 after we merged https://github.com/grafana/grafana/pull/125440
