### PR TITLE
fix: preferences unified migration count validation

### DIFF
--- a/pkg/registry/apis/preferences/legacy/validator.go
+++ b/pkg/registry/apis/preferences/legacy/validator.go
@@ -2,11 +2,13 @@ package legacy
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/grafana/grafana/pkg/infra/log"
+	"github.com/grafana/grafana/pkg/registry/apis/preferences/utils"
 	"github.com/grafana/grafana/pkg/services/sqlstore/migrator"
 	"github.com/grafana/grafana/pkg/storage/unified/migrations"
 	"github.com/grafana/grafana/pkg/storage/unified/resourcepb"
@@ -108,18 +110,55 @@ func (v *preferencesCountValidator) countRejected(response *resourcepb.BulkRespo
 	return n
 }
 
+// ownerRow holds the columns needed to derive a preference's resource name,
+// scanned from the same joined query the read path uses.
+type ownerRow struct {
+	UserUID sql.NullString `xorm:"user_uid"`
+	TeamUID sql.NullString `xorm:"team_uid"`
+}
+
 // countLegacy mirrors the listPreferences read path: include namespace rows
 // (user_id = 0 AND team_id = 0), user rows whose user still exists, and team
 // rows whose team still exists. The LEFT JOINs let us keep namespace rows in
 // the result while still being able to test for user/team existence.
+//
+// It counts *distinct resource names* rather than raw rows. The migrator emits
+// one resource per row, but the resource name is derived solely from the owner
+// (team uid, else user uid, else namespace) — see asPreferencesResource. When
+// the legacy table holds duplicate rows for the same owner (no unique
+// constraint enforces one row per org/user/team), they collapse to a single
+// resource in unified storage, which dedups by name. Counting raw rows here
+// would over-count and false-fail the strict parity check.
 func (v *preferencesCountValidator) countLegacy(sess *xorm.Session, orgID int64) (int64, error) {
-	return sess.Table("preferences").
+	var rows []ownerRow
+	err := sess.Table("preferences").
+		Select("u.uid AS user_uid, t.uid AS team_uid").
 		Join("LEFT", []string{"user", "u"}, "preferences.user_id = u.id").
 		Join("LEFT", []string{"team", "t"}, "preferences.team_id = t.id").
 		Where(`preferences.org_id = ?
 			AND (preferences.user_id = 0 OR u.uid IS NOT NULL)
 			AND (preferences.team_id = 0 OR t.uid IS NOT NULL)`, orgID).
-		Count()
+		Find(&rows)
+	if err != nil {
+		return 0, err
+	}
+
+	names := make(map[string]struct{}, len(rows))
+	for _, r := range rows {
+		// Mirror asPreferencesResource: team takes precedence over user.
+		owner := utils.OwnerReference{}
+		if r.TeamUID.Valid {
+			owner.Owner = utils.TeamResourceOwner
+			owner.Identifier = r.TeamUID.String
+		} else if r.UserUID.Valid {
+			owner.Owner = utils.UserResourceOwner
+			owner.Identifier = r.UserUID.String
+		} else {
+			owner.Owner = utils.NamespaceResourceOwner
+		}
+		names[owner.AsName()] = struct{}{}
+	}
+	return int64(len(names)), nil
 }
 
 func (v *preferencesCountValidator) countUnified(ctx context.Context, sess *xorm.Session, summary *resourcepb.BulkResponse_Summary) (int64, error) {

--- a/pkg/registry/apis/preferences/legacy/validator.go
+++ b/pkg/registry/apis/preferences/legacy/validator.go
@@ -16,12 +16,9 @@ import (
 )
 
 // preferencesCountValidation enforces strict count parity between the legacy
-// preferences table and unified storage. It mirrors migrations.CountValidator
-// but uses a bespoke query that counts exactly what the migrator emits:
-// namespace rows (user_id = 0 AND team_id = 0), user-prefs whose user still
-// exists, and team-prefs whose team still exists. Orphan rows are skipped on
-// the read side (see listPreferences), so they must not be counted here
-// either, or the validator would false-fail.
+// preferences table and unified storage, counting exactly what the migrator
+// emits: distinct owners (namespace, valid user, valid team), excluding
+// orphans. See countLegacy.
 func preferencesCountValidation(resource schema.GroupResource) migrations.ValidatorFactory {
 	return func(client resourcepb.ResourceIndexClient, driverName string) migrations.Validator {
 		return &preferencesCountValidator{
@@ -110,25 +107,18 @@ func (v *preferencesCountValidator) countRejected(response *resourcepb.BulkRespo
 	return n
 }
 
-// ownerRow holds the columns needed to derive a preference's resource name,
-// scanned from the same joined query the read path uses.
+// ownerRow holds the columns needed to derive a preference's resource name.
 type ownerRow struct {
 	UserUID sql.NullString `xorm:"user_uid"`
 	TeamUID sql.NullString `xorm:"team_uid"`
 }
 
-// countLegacy mirrors the listPreferences read path: include namespace rows
-// (user_id = 0 AND team_id = 0), user rows whose user still exists, and team
-// rows whose team still exists. The LEFT JOINs let us keep namespace rows in
-// the result while still being able to test for user/team existence.
-//
-// It counts *distinct resource names* rather than raw rows. The migrator emits
-// one resource per row, but the resource name is derived solely from the owner
-// (team uid, else user uid, else namespace) — see asPreferencesResource. When
-// the legacy table holds duplicate rows for the same owner (no unique
-// constraint enforces one row per org/user/team), they collapse to a single
-// resource in unified storage, which dedups by name. Counting raw rows here
-// would over-count and false-fail the strict parity check.
+// countLegacy counts distinct resource names, mirroring the listPreferences
+// read path (LEFT JOINs exclude orphan user/team rows). Counting distinct
+// names rather than raw rows matters because the name derives solely from the
+// owner (see asPreferencesResource): duplicate legacy rows for the same owner
+// — nothing enforces one row per org/user/team — collapse to a single resource
+// in unified storage, which dedups by name. Raw-row counts would false-fail.
 func (v *preferencesCountValidator) countLegacy(sess *xorm.Session, orgID int64) (int64, error) {
 	var rows []ownerRow
 	err := sess.Table("preferences").

--- a/pkg/registry/apis/preferences/legacy/validator_test.go
+++ b/pkg/registry/apis/preferences/legacy/validator_test.go
@@ -1,0 +1,54 @@
+package legacy
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/grafana/grafana/pkg/util/sqlite"
+	"github.com/grafana/grafana/pkg/util/xorm"
+)
+
+func TestCountLegacy(t *testing.T) {
+	eng, err := xorm.NewEngine("sqlite3", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = eng.Close() })
+
+	for _, ddl := range []string{
+		`CREATE TABLE preferences (id INTEGER PRIMARY KEY, org_id INTEGER, user_id INTEGER, team_id INTEGER)`,
+		`CREATE TABLE user (id INTEGER PRIMARY KEY, uid TEXT)`,
+		`CREATE TABLE team (id INTEGER PRIMARY KEY, uid TEXT)`,
+	} {
+		_, err = eng.Exec(ddl)
+		require.NoError(t, err)
+	}
+
+	// Users 1 & 2 exist; user 99 does not (orphan). Team 1 exists; team 88 does not.
+	_, err = eng.Exec(`INSERT INTO user (id, uid) VALUES (1, 'uA'), (2, 'uB')`)
+	require.NoError(t, err)
+	_, err = eng.Exec(`INSERT INTO team (id, uid) VALUES (1, 'tA')`)
+	require.NoError(t, err)
+
+	_, err = eng.Exec(`INSERT INTO preferences (id, org_id, user_id, team_id) VALUES
+		(1, 1, 0, 0),    -- namespace row
+		(2, 1, 1, 0),    -- user uA
+		(3, 1, 2, 0),    -- user uB
+		(4, 1, 2, 0),    -- DUPLICATE of user uB (collapses in unified storage)
+		(5, 1, 0, 1),    -- team tA
+		(6, 1, 99, 0),   -- orphan user (skipped on read path)
+		(7, 1, 0, 88),   -- orphan team (skipped on read path)
+		(8, 2, 1, 0)     -- different org, excluded
+	`)
+	require.NoError(t, err)
+
+	v := &preferencesCountValidator{}
+	sess := eng.NewSession()
+	t.Cleanup(func() { sess.Close() })
+
+	count, err := v.countLegacy(sess, 1)
+	require.NoError(t, err)
+
+	// Distinct owners in org 1: namespace, user uA, user uB, team tA = 4.
+	// The duplicate uB row and both orphan rows must not inflate the count.
+	require.Equal(t, int64(4), count)
+}


### PR DESCRIPTION
There are duplicate preference configurations out in cloud. I introduce here a more robust count validation logic which handles such corner cases (de-duplication) and enable a smoother migration experience in cloud.

I observed a couple of instances failing due to that in dev: https://ops.grafana-ops.net/goto/s5lss7?orgId=stacks-27821

```sql
MySQL [hg_appo11ydev01]> SELECT org_id, user_id, team_id, COUNT(*)
    -> FROM preferences
    -> WHERE org_id = 1
    -> GROUP BY org_id, user_id, team_id
    -> HAVING COUNT(*) > 1;
+--------+---------+---------+----------+
| org_id | user_id | team_id | COUNT(*) |
+--------+---------+---------+----------+
|      1 |      22 |       0 |        2 |
+--------+---------+---------+----------+
1 row in set (0.003 sec)

```

Ticket: https://github.com/grafana/search-and-storage-team/issues/798